### PR TITLE
docs: Quick Start Guide を最新化

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,9 +23,37 @@ make start-all
 - Keycloak の Realm と Client の自動作成
 - `.env.local` の作成（存在しない場合）
 
-出力された環境変数を `.env.local` に設定してください。
+出力された環境変数を `frontend/control-plane/.env.local` に設定してから、Control Plane UI を起動してください。
 
-### 方法 2: 手動セットアップ
+```bash
+cd frontend/control-plane
+bun run dev
+```
+
+ブラウザで <http://localhost:3000> を開いてログインしてください。
+
+### 方法 2: Docker Compose で起動（本番環境に近い）
+
+Docker イメージをビルドして、Keycloak と連携した環境で起動します。
+
+```bash
+# Docker イメージをビルドして起動
+make docker-run
+
+# アクセス先
+# - Control Plane UI: http://localhost:3000
+# - Keycloak: http://localhost:8080
+```
+
+停止する場合は次を実行します。
+
+```bash
+make docker-stop
+```
+
+この方法では `.env.local` ファイルが必要です。事前に `frontend/control-plane/.env.local` を作成してください。
+
+### 方法 3: 手動セットアップ
 
 #### 1. Docker Desktop を起動
 
@@ -241,7 +269,19 @@ PORT=3001 bun run dev
 
 ## 🧹 環境のクリーンアップ
 
-### Keycloak を停止
+### すべて停止（推奨）
+
+```bash
+make stop-all
+```
+
+### Docker Compose 環境を停止
+
+```bash
+make docker-stop
+```
+
+### Keycloak のみ停止
 
 ```bash
 cd infrastructure/docker/keycloak
@@ -251,12 +291,13 @@ docker compose down
 ### データも削除する場合
 
 ```bash
+cd infrastructure/docker/keycloak
 docker compose down -v
 ```
 
 ### Next.js を停止
 
-ターミナルで `Ctrl + C` を押す。
+開発サーバーを起動しているターミナルで `Ctrl + C` を押す。
 
 ## 📚 次のステップ
 
@@ -266,13 +307,32 @@ docker compose down -v
 
 ## 💡 開発時のヒント
 
+### 環境を再起動
+
+```bash
+# 全体を再起動
+make restart-all
+
+# Docker Compose 環境のみ再起動
+make docker-stop
+make docker-run
+```
+
 ### Keycloak のデータをリセット
 
 ```bash
 cd infrastructure/docker/keycloak
 docker compose down -v
 docker compose up -d
-# 再度 Realm と Client を作成
+# 再度 Realm と Client を作成（または make setup-keycloak を実行）
+```
+
+### Docker イメージを再ビルド
+
+コードを変更した後、Docker イメージを再ビルドする場合は次を実行します。
+
+```bash
+make docker-build
 ```
 
 ### Next.js のキャッシュをクリア
@@ -291,7 +351,13 @@ cd infrastructure/docker/keycloak
 docker compose logs -f keycloak
 ```
 
-**Next.js**:
+**Control Plane UI (Docker Compose)**:
+```bash
+cd frontend/control-plane
+docker compose logs -f control-plane-ui
+```
+
+**Next.js (開発サーバー)**:
 ターミナルに表示される。
 
 ## 🔐 セキュリティ注意事項


### PR DESCRIPTION
## 概要

Quick Start Guide を最新の実装に合わせて更新しました。Docker Compose での起動方法や、新しい Makefile コマンドを反映しています。

## 変更内容

### 起動方法の追加

- **方法 2: Docker Compose で起動（本番環境に近い）** を新規追加
  - `make docker-run` で Docker イメージをビルドして起動
  - `make docker-stop` で停止
  - Keycloak と連携した本番環境に近い構成

### 環境のクリーンアップセクションの更新

- `make stop-all`: すべてのサービスを停止（推奨）
- `make docker-stop`: Docker Compose 環境を停止
- より明確な手順と説明を追加

### 開発時のヒントセクションの拡張

- **環境を再起動**: `make restart-all` と `make docker-run` の使い分け
- **Docker イメージを再ビルド**: `make docker-build` の説明
- **ログを確認**: Docker Compose 環境のログ確認方法を追加

### その他の改善

- 方法 1 の説明を明確化（Control Plane UI の起動手順を明示）
- 各セクションの構成を整理して読みやすくした

## 変更前との差分

### 追加された内容

1. Docker Compose での起動方法（方法 2）
2. `make stop-all` と `make docker-stop` コマンド
3. 環境の再起動手順
4. Docker イメージの再ビルド手順
5. Docker Compose のログ確認方法

### 変更された内容

1. 方法 1 の説明を拡張（Control Plane UI の起動コマンドを追加）
2. 環境のクリーンアップ手順を再構成

## テスト

- [x] textlint チェック通過
- [x] format チェック通過
- [x] Markdown 構文が正しい
- [x] すべてのコマンドが有効

## 参照

- 関連 PR: #40 (Control Plane UI の Docker ビルド CI チェック)
- 関連 PR: #39 (Makefile で一括起動コマンド)
- 関連 PR: #37 (Quick Start Guide と Keycloak 自動セットアップスクリプト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced quickstart guide with clearer environment variable setup paths
  * Added docker-compose setup method with explicit build and run commands
  * Added manual setup method including Docker Desktop startup steps
  * Expanded troubleshooting section with detailed shutdown procedures and reinitialization guidance
  * Improved logs viewing instructions and port-related troubleshooting tips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->