### PR TITLE
feat: add docker-status command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install setup_husky clean lint lint_text format format_check before_commit before-commit start test test_coverage dev build start-all stop-all restart-all setup-keycloak check-docker docker-build docker-run docker-stop
+.PHONY: help install setup_husky clean lint lint_text format format_check before_commit before-commit start test test_coverage dev build start-all stop-all restart-all setup-keycloak check-docker docker-build docker-run docker-stop docker-status
 
 # デフォルトターゲットはhelp
 default: help
@@ -138,6 +138,23 @@ docker-stop:
 	@echo "✅ 停止しました"
 	@echo ""
 
+docker-status: check-docker
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🐳 Docker コンテナの起動状態"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "📦 Keycloak コンテナ:"
+	@cd infrastructure/docker/keycloak && docker compose ps || echo "  ❌ Keycloak コンテナが見つかりません"
+	@echo ""
+	@echo "📦 Control Plane UI コンテナ:"
+	@cd frontend/control-plane && docker compose ps || echo "  ❌ Control Plane UI コンテナが見つかりません"
+	@echo ""
+	@echo "🌐 すべての実行中コンテナ:"
+	@docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" || echo "  ❌ 実行中のコンテナがありません"
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+
 help:
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "📖 TenkaCloud Makefile ヘルプ"
@@ -154,6 +171,7 @@ help:
 	@echo "  make docker-build     Control Plane UI の Docker イメージをビルド"
 	@echo "  make docker-run       Docker Compose で Control Plane UI を起動"
 	@echo "  make docker-stop      Docker Compose を停止"
+	@echo "  make docker-status    Docker コンテナの起動状態を表示"
 	@echo ""
 	@echo "📦 パッケージ管理:"
 	@echo "  make install          bun パッケージをインストール"

--- a/Plan.md
+++ b/Plan.md
@@ -735,6 +735,35 @@ Next.js 16 の仕様変更により、middleware ファイル名が変更され�
 
 ---
 
+### Makefile 改善: Docker ステータス確認コマンドの追加 - 2025-11-20
+
+**目的 (Objective)**:
+- 開発者が Docker コンテナの起動状態を一目で確認できるようにする
+- `make docker-status` コマンドを追加し、Keycloak と Control Plane UI の状態を表示する
+- ドキュメント (`docs/QUICKSTART.md`) を更新し、新しいコマンドの使用方法を記載する
+
+**制約 (Guardrails)**:
+- 既存の `check-docker` ターゲットを活用する
+- 見やすいフォーマットで出力する
+- `CLAUDE.md` のコンテキストを理解し、ドキュメント更新を徹底する
+
+**タスク (TODOs)**:
+- [x] Makefile に `docker-status` ターゲットを追加
+- [x] Makefile の help に `docker-status` を追加
+- [x] `docs/QUICKSTART.md` に `make docker-status` の説明を追加
+- [x] 動作確認
+
+**検証手順 (Validation)**:
+- `make docker-status` を実行し、コンテナの状態が表示されることを確認
+- `make help` に新しいコマンドが表示されることを確認
+
+**進捗ログ (Progress Log)**:
+- [2025-11-20 08:58] Makefile に `docker-status` コマンドを追加完了
+- [2025-11-20 09:00] `docs/QUICKSTART.md` の更新に着手
+- [2025-11-20 09:05] `docs/QUICKSTART.md` に `make docker-status` の説明を追加完了
+
+---
+
 ## 次の実行計画テンプレート
 
 以下のテンプレートを使用して、新しい機能開発の実行計画を作成してください：

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -217,6 +217,16 @@ docker ps
 # エラーが出る場合は Docker Desktop を再起動
 ```
 
+### コンテナの状態を確認する
+
+起動中のコンテナの状態を一括で確認するには、以下のコマンドを使用します。
+
+```bash
+make docker-status
+```
+
+これにより、Keycloak、Control Plane UI、およびその他の実行中のコンテナの状態が表示されます。
+
 ### Keycloak に接続できない
 
 ```bash
@@ -344,6 +354,13 @@ bun run dev
 ```
 
 ### ログを確認
+
+**コンテナの状態確認**:
+```bash
+make docker-status
+```
+
+**Keycloak**:
 
 **Keycloak**:
 ```bash


### PR DESCRIPTION
- Added docker-status target to show container status
- Updated help section in Makefile
- Updated QUICKSTART.md with new command usage
- Recorded execution plan in Plan.md

Refs: Plan.md "Makefile 改善: Docker ステータス確認コマンドの追加"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `make docker-status` command to display the running status of Keycloak, Control Plane UI, and all Docker containers with fallback messaging for missing containers.

* **Documentation**
  * Updated quickstart guide with instructions for checking container health status during troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->