### PR TITLE
feat: Kubernetes環境をコマンド一発で起動できるように改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,19 +291,6 @@ k8s-deploy: check-k8s
 	@kubectl apply -f infrastructure/k8s/application-plane/participant-app.yaml
 	@kubectl apply -f infrastructure/k8s/application-plane/landing-site.yaml
 	@echo "✅ デプロイが完了しました"
-	@echo ""
-	@echo "📋 次のステップ:"
-	@echo "  1. Keycloak のセットアップ:"
-	@echo "     kubectl port-forward svc/keycloak 8080:8080 -n tenkacloud"
-	@echo "     (別のターミナルで) ./infrastructure/docker/keycloak/scripts/setup-keycloak.sh"
-	@echo "  2. /etc/hosts の設定:"
-	@echo "     127.0.0.1 keycloak"
-	@echo "  3. アプリケーションへのアクセス (port-forward):"
-	@echo "     kubectl port-forward svc/control-plane-ui 3000:3000 -n tenkacloud"
-	@echo "     kubectl port-forward svc/tenant-management 3004:3004 -n tenkacloud"
-	@echo "     kubectl port-forward svc/admin-app 3001:3001 -n tenkacloud"
-	@echo "     kubectl port-forward svc/participant-app 3002:3002 -n tenkacloud"
-	@echo "     kubectl port-forward svc/landing-site 3003:3003 -n tenkacloud"
 
 k8s-delete:
 	@echo "🗑️  Kubernetes リソースを削除しています..."
@@ -408,7 +395,7 @@ k8s-start-full: check-k8s k8s-build-all
 	@echo "  - Tenant Management:  http://localhost:3004"
 	@echo "  - Keycloak:           http://localhost:8080"
 	@echo ""
-	@echo "💡 停止するには: make stop-k8s && make k8s-forward-stop"
+	@echo "💡 停止するには: make stop-k8s"
 	@echo ""
 
 stop-k8s: k8s-forward-stop k8s-delete


### PR DESCRIPTION
## 概要

Kubernetes 環境でのデプロイ後、複数の port-forward コマンドを手動で実行する必要があり不便だったため、コマンド一発で全サービスを起動できるように改善しました。

## 変更内容

### 新しいコマンド
- `make k8s-start-full`: ビルド + デプロイ + port-forward + Keycloak 設定を一発で実行
- `make k8s-forward`: 全サービスの port-forward をバックグラウンドで起動
- `make k8s-forward-stop`: port-forward プロセスを停止

### 変更されたコマンド
- `make start` → Kubernetes を選択した場合、自動的に `k8s-start-full` を実行
- `make stop-k8s` → port-forward も含めて停止するように変更

## 使い方

```bash
# 一発で全部起動
make start
# → 2 を選択

# または直接
make k8s-start-full

# 停止
make stop-k8s
```

## テスト

- [x] `make k8s-forward` で全サービスの port-forward が起動することを確認
- [x] `make k8s-forward-stop` でプロセスが停止することを確認
- [x] `make k8s-start-full` で一連のフローが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot Kubernetes startup: new k8s-start-full for deploy, port-forwarding, and Keycloak setup.
  * Port-forward management: k8s-forward to wait for services, start port-forwards and display access URLs; k8s-forward-stop to terminate active port-forwards.
  * stop-k8s now stops port-forwards and cleans up resources in one command.

* **Chores**
  * Help text updated with the new Kubernetes workflow and commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->