### PR TITLE
fix: ランディングサイトのログインリンクを Admin App へリダイレクト

### DIFF
--- a/frontend/landing-site/src/app/dashboard/page.tsx
+++ b/frontend/landing-site/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 import {
   Activity,
   ArrowRight,
@@ -9,9 +9,9 @@ import {
   UserPlus,
   Users,
   Zap,
-} from "lucide-react";
+} from 'lucide-react';
 
-const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL ?? "http://localhost:3001";
+const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL ?? 'http://localhost:3001';
 
 export default function DashboardPage() {
   const container = {
@@ -132,7 +132,7 @@ function StatsCard({
   label,
   value,
   gradient,
-  valueColor = "text-white",
+  valueColor = 'text-white',
 }: {
   icon: React.ReactNode;
   label: string;

--- a/frontend/landing-site/src/app/globals.css
+++ b/frontend/landing-site/src/app/globals.css
@@ -1,7 +1,7 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
-  --font-family-display: "Inter", system-ui, sans-serif;
+  --font-family-display: 'Inter', system-ui, sans-serif;
 
   /* カラーパレット - モダンで洗練されたダークモード対応 */
   --color-primary-50: oklch(0.97 0.01 264);
@@ -59,8 +59,8 @@
     background: oklch(0.02 0.01 264);
     color: oklch(0.98 0.01 264);
     font-feature-settings:
-      "rlig" 1,
-      "calt" 1;
+      'rlig' 1,
+      'calt' 1;
   }
 }
 

--- a/frontend/landing-site/src/app/layout.tsx
+++ b/frontend/landing-site/src/app/layout.tsx
@@ -1,22 +1,22 @@
-import type { Metadata } from "next";
-import "./globals.css";
+import type { Metadata } from 'next';
+import './globals.css';
 
 export const metadata: Metadata = {
-  title: "TenkaCloud - プログラミングバトルプラットフォーム",
+  title: 'TenkaCloud - プログラミングバトルプラットフォーム',
   description:
-    "プログラミングコンテストやハッカソンを5分でデプロイ。マルチテナント対応、自動スケーリング、エンタープライズグレードのセキュリティ。",
+    'プログラミングコンテストやハッカソンを5分でデプロイ。マルチテナント対応、自動スケーリング、エンタープライズグレードのセキュリティ。',
   keywords: [
-    "プログラミングコンテスト",
-    "ハッカソン",
-    "競技プログラミング",
-    "オンラインジャッジ",
-    "マルチテナント",
-    "SaaS",
+    'プログラミングコンテスト',
+    'ハッカソン',
+    '競技プログラミング',
+    'オンラインジャッジ',
+    'マルチテナント',
+    'SaaS',
   ],
   openGraph: {
-    title: "TenkaCloud - プログラミングバトルプラットフォーム",
-    description: "5分でプログラミングコンテストをデプロイ",
-    type: "website",
+    title: 'TenkaCloud - プログラミングバトルプラットフォーム',
+    description: '5分でプログラミングコンテストをデプロイ',
+    type: 'website',
   },
 };
 

--- a/frontend/landing-site/src/app/onboarding/page.tsx
+++ b/frontend/landing-site/src/app/onboarding/page.tsx
@@ -1,20 +1,20 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { Check } from "lucide-react";
-import { EnvironmentStep } from "@/components/onboarding/environment-step";
-import { PlanStep } from "@/components/onboarding/plan-step";
-import { ProfileStep } from "@/components/onboarding/profile-step";
-import { ReviewStep } from "@/components/onboarding/review-step";
-import { TenantStep } from "@/components/onboarding/tenant-step";
-import { type Step, useOnboardingStore } from "@/lib/stores/onboarding-store";
+import { motion } from 'framer-motion';
+import { Check } from 'lucide-react';
+import { EnvironmentStep } from '@/components/onboarding/environment-step';
+import { PlanStep } from '@/components/onboarding/plan-step';
+import { ProfileStep } from '@/components/onboarding/profile-step';
+import { ReviewStep } from '@/components/onboarding/review-step';
+import { TenantStep } from '@/components/onboarding/tenant-step';
+import { type Step, useOnboardingStore } from '@/lib/stores/onboarding-store';
 
 const steps: { id: Step; label: string }[] = [
-  { id: "profile", label: "プロフィール" },
-  { id: "plan", label: "プラン選択" },
-  { id: "tenant", label: "テナント設定" },
-  { id: "environment", label: "環境設定" },
-  { id: "review", label: "確認" },
+  { id: 'profile', label: 'プロフィール' },
+  { id: 'plan', label: 'プラン選択' },
+  { id: 'tenant', label: 'テナント設定' },
+  { id: 'environment', label: '環境設定' },
+  { id: 'review', label: '確認' },
 ];
 
 export default function OnboardingPage() {
@@ -24,15 +24,15 @@ export default function OnboardingPage() {
 
   const renderStep = () => {
     switch (currentStep) {
-      case "profile":
+      case 'profile':
         return <ProfileStep />;
-      case "plan":
+      case 'plan':
         return <PlanStep />;
-      case "tenant":
+      case 'tenant':
         return <TenantStep />;
-      case "environment":
+      case 'environment':
         return <EnvironmentStep />;
-      case "review":
+      case 'review':
         return <ReviewStep />;
       default:
         return null;
@@ -45,11 +45,11 @@ export default function OnboardingPage() {
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div
           className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 264)" }}
+          style={{ background: 'oklch(0.56 0.20 264)' }}
         />
         <div
           className="absolute bottom-1/4 right-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 180)", animationDelay: "-3s" }}
+          style={{ background: 'oklch(0.56 0.20 180)', animationDelay: '-3s' }}
         />
       </div>
 
@@ -69,10 +69,10 @@ export default function OnboardingPage() {
                       animate={{
                         scale: isCurrent ? 1.1 : 1,
                         backgroundColor: isCompleted
-                          ? "oklch(0.56 0.20 264)"
+                          ? 'oklch(0.56 0.20 264)'
                           : isCurrent
-                            ? "oklch(0.56 0.20 180)"
-                            : "oklch(0.15 0.02 264)",
+                            ? 'oklch(0.56 0.20 180)'
+                            : 'oklch(0.15 0.02 264)',
                       }}
                       className="w-10 h-10 rounded-full flex items-center justify-center border-2 border-white/20 transition-all"
                     >
@@ -86,7 +86,7 @@ export default function OnboardingPage() {
                     </motion.div>
                     <span
                       className={`mt-2 text-sm font-medium ${
-                        isCurrent ? "text-white" : "text-white/50"
+                        isCurrent ? 'text-white' : 'text-white/50'
                       }`}
                     >
                       {step.label}
@@ -97,7 +97,7 @@ export default function OnboardingPage() {
                     <div className="flex-1 h-0.5 mx-4 mt-[-2rem]">
                       <div
                         className={`h-full transition-all ${
-                          isCompleted ? "bg-primary-500" : "bg-white/10"
+                          isCompleted ? 'bg-primary-500' : 'bg-white/10'
                         }`}
                       />
                     </div>

--- a/frontend/landing-site/src/app/onboarding/provisioning/page.tsx
+++ b/frontend/landing-site/src/app/onboarding/provisioning/page.tsx
@@ -1,30 +1,30 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { Check, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { motion } from 'framer-motion';
+import { Check, Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 type ProvisioningStep = {
   id: string;
   label: string;
-  status: "pending" | "in_progress" | "completed" | "failed";
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
 };
 
 const INITIAL_STEPS: ProvisioningStep[] = [
-  { id: "realm", label: "Keycloak Realm 作成中", status: "pending" },
-  { id: "database", label: "データベース作成中", status: "pending" },
+  { id: 'realm', label: 'Keycloak Realm 作成中', status: 'pending' },
+  { id: 'database', label: 'データベース作成中', status: 'pending' },
   {
-    id: "namespace",
-    label: "Kubernetes Namespace 作成中",
-    status: "pending",
+    id: 'namespace',
+    label: 'Kubernetes Namespace 作成中',
+    status: 'pending',
   },
   {
-    id: "deployment",
-    label: "アプリケーションデプロイ中",
-    status: "pending",
+    id: 'deployment',
+    label: 'アプリケーションデプロイ中',
+    status: 'pending',
   },
-  { id: "dns", label: "DNS 設定中", status: "pending" },
+  { id: 'dns', label: 'DNS 設定中', status: 'pending' },
 ];
 
 export default function ProvisioningPage() {
@@ -42,7 +42,7 @@ export default function ProvisioningPage() {
       if (currentStep >= INITIAL_STEPS.length) {
         setIsComplete(true);
         timeoutId = setTimeout(() => {
-          router.push("/dashboard");
+          router.push('/dashboard');
         }, 2000);
         return;
       }
@@ -50,8 +50,8 @@ export default function ProvisioningPage() {
       // Set current step to in_progress
       setSteps((prev) =>
         prev.map((step, index) =>
-          index === currentStep ? { ...step, status: "in_progress" } : step,
-        ),
+          index === currentStep ? { ...step, status: 'in_progress' } : step
+        )
       );
 
       // Get duration before incrementing currentStep
@@ -61,8 +61,8 @@ export default function ProvisioningPage() {
       timeoutId = setTimeout(() => {
         setSteps((prev) =>
           prev.map((step, index) =>
-            index === currentStep ? { ...step, status: "completed" } : step,
-          ),
+            index === currentStep ? { ...step, status: 'completed' } : step
+          )
         );
 
         currentStep++;
@@ -86,11 +86,11 @@ export default function ProvisioningPage() {
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div
           className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 264)" }}
+          style={{ background: 'oklch(0.56 0.20 264)' }}
         />
         <div
           className="absolute bottom-1/4 right-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 180)", animationDelay: "-3s" }}
+          style={{ background: 'oklch(0.56 0.20 180)', animationDelay: '-3s' }}
         />
       </div>
 
@@ -110,7 +110,7 @@ export default function ProvisioningPage() {
                     transition={{
                       duration: 2,
                       repeat: Number.POSITIVE_INFINITY,
-                      ease: "linear",
+                      ease: 'linear',
                     }}
                     className="w-20 h-20 border-4 border-primary-500/20 border-t-primary-500 rounded-full"
                   />
@@ -133,7 +133,7 @@ export default function ProvisioningPage() {
                     initial={{ scale: 0 }}
                     animate={{ scale: 1 }}
                     transition={{
-                      type: "spring",
+                      type: 'spring',
                       stiffness: 200,
                       damping: 15,
                     }}
@@ -164,11 +164,11 @@ export default function ProvisioningPage() {
                   className="flex items-center gap-4 p-4 bg-white/5 rounded-xl border border-white/10"
                 >
                   <div className="flex-shrink-0">
-                    {step.status === "completed" ? (
+                    {step.status === 'completed' ? (
                       <div className="w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center">
                         <Check className="w-4 h-4 text-white" />
                       </div>
-                    ) : step.status === "in_progress" ? (
+                    ) : step.status === 'in_progress' ? (
                       <Loader2 className="w-6 h-6 text-primary-400 animate-spin" />
                     ) : (
                       <div className="w-6 h-6 border-2 border-white/20 rounded-full" />
@@ -178,21 +178,21 @@ export default function ProvisioningPage() {
                   <div className="flex-1 text-left">
                     <p
                       className={`font-medium ${
-                        step.status === "completed"
-                          ? "text-white"
-                          : step.status === "in_progress"
-                            ? "text-primary-400"
-                            : "text-white/50"
+                        step.status === 'completed'
+                          ? 'text-white'
+                          : step.status === 'in_progress'
+                            ? 'text-primary-400'
+                            : 'text-white/50'
                       }`}
                     >
                       {step.label}
                     </p>
                   </div>
 
-                  {step.status === "completed" && (
+                  {step.status === 'completed' && (
                     <span className="text-xs text-accent-400">完了</span>
                   )}
-                  {step.status === "in_progress" && (
+                  {step.status === 'in_progress' && (
                     <span className="text-xs text-primary-400">処理中</span>
                   )}
                 </motion.div>

--- a/frontend/landing-site/src/app/page.tsx
+++ b/frontend/landing-site/src/app/page.tsx
@@ -1,6 +1,6 @@
-import { FeaturesSection } from "@/components/landing/features-section";
-import { HeroSection } from "@/components/landing/hero-section";
-import { PricingSection } from "@/components/landing/pricing-section";
+import { FeaturesSection } from '@/components/landing/features-section';
+import { HeroSection } from '@/components/landing/hero-section';
+import { PricingSection } from '@/components/landing/pricing-section';
 
 export default function HomePage() {
   return (

--- a/frontend/landing-site/src/app/signup/page.tsx
+++ b/frontend/landing-site/src/app/signup/page.tsx
@@ -1,35 +1,35 @@
-"use client";
+'use client';
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { motion } from "framer-motion";
-import { ArrowLeft, Github, Mail } from "lucide-react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { zodResolver } from '@hookform/resolvers/zod';
+import { motion } from 'framer-motion';
+import { ArrowLeft, Github, Mail } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3004";
-const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL ?? "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3004';
+const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL ?? 'http://localhost:3001';
 
 const signupSchema = z
   .object({
-    email: z.string().email("有効なメールアドレスを入力してください"),
+    email: z.string().email('有効なメールアドレスを入力してください'),
     password: z
       .string()
-      .min(8, "パスワードは8文字以上必要です")
+      .min(8, 'パスワードは8文字以上必要です')
       .regex(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
-        "パスワードは大文字、小文字、数字を含む必要があります",
+        'パスワードは大文字、小文字、数字を含む必要があります'
       ),
     confirmPassword: z.string(),
     acceptTerms: z.boolean().refine((val) => val === true, {
-      message: "利用規約に同意する必要があります",
+      message: '利用規約に同意する必要があります',
     }),
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: "パスワードが一致しません",
-    path: ["confirmPassword"],
+    message: 'パスワードが一致しません',
+    path: ['confirmPassword'],
   });
 
 type SignupFormData = z.infer<typeof signupSchema>;
@@ -51,9 +51,9 @@ export default function SignupPage() {
     setError(null);
     try {
       const response = await fetch(`${API_URL}/api/signup`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify({
           email: data.email,
@@ -63,15 +63,15 @@ export default function SignupPage() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || "サインアップに失敗しました");
+        throw new Error(errorData.error || 'サインアップに失敗しました');
       }
 
       // Redirect to onboarding
-      router.push("/onboarding");
+      router.push('/onboarding');
     } catch (err) {
-      console.error("Signup failed:", err);
+      console.error('Signup failed:', err);
       setError(
-        err instanceof Error ? err.message : "サインアップに失敗しました",
+        err instanceof Error ? err.message : 'サインアップに失敗しました'
       );
     } finally {
       setIsLoading(false);
@@ -84,11 +84,11 @@ export default function SignupPage() {
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div
           className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 264)" }}
+          style={{ background: 'oklch(0.56 0.20 264)' }}
         />
         <div
           className="absolute bottom-1/4 right-1/4 w-96 h-96 rounded-full opacity-10 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 180)", animationDelay: "-3s" }}
+          style={{ background: 'oklch(0.56 0.20 180)', animationDelay: '-3s' }}
         />
       </div>
 
@@ -169,7 +169,7 @@ export default function SignupPage() {
                 <input
                   id="email"
                   type="email"
-                  {...register("email")}
+                  {...register('email')}
                   className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
                   placeholder="you@example.com"
                 />
@@ -190,7 +190,7 @@ export default function SignupPage() {
                 <input
                   id="password"
                   type="password"
-                  {...register("password")}
+                  {...register('password')}
                   className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
                   placeholder="••••••••"
                 />
@@ -211,7 +211,7 @@ export default function SignupPage() {
                 <input
                   id="confirmPassword"
                   type="password"
-                  {...register("confirmPassword")}
+                  {...register('confirmPassword')}
                   className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
                   placeholder="••••••••"
                 />
@@ -226,7 +226,7 @@ export default function SignupPage() {
                 <input
                   id="acceptTerms"
                   type="checkbox"
-                  {...register("acceptTerms")}
+                  {...register('acceptTerms')}
                   className="mt-1 w-4 h-4 rounded border-white/20 bg-white/5 focus:ring-primary-500"
                 />
                 <label htmlFor="acceptTerms" className="text-sm text-white/70">
@@ -235,14 +235,14 @@ export default function SignupPage() {
                     className="text-primary-400 hover:text-primary-300"
                   >
                     利用規約
-                  </Link>{" "}
-                  と{" "}
+                  </Link>{' '}
+                  と{' '}
                   <Link
                     href="/privacy"
                     className="text-primary-400 hover:text-primary-300"
                   >
                     プライバシーポリシー
-                  </Link>{" "}
+                  </Link>{' '}
                   に同意します
                 </label>
               </div>
@@ -257,13 +257,13 @@ export default function SignupPage() {
                 disabled={isLoading}
                 className="w-full px-6 py-3 bg-gradient-to-r from-primary-500 to-accent-500 rounded-xl font-semibold shadow-lg shadow-primary-500/25 hover:shadow-primary-500/40 transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isLoading ? "作成中..." : "アカウントを作成"}
+                {isLoading ? '作成中...' : 'アカウントを作成'}
               </button>
             </form>
 
             {/* Login link - External link to Admin App */}
             <p className="text-center text-sm text-white/60">
-              すでにアカウントをお持ちですか？{" "}
+              すでにアカウントをお持ちですか？{' '}
               <a
                 href={ADMIN_URL}
                 rel="noopener noreferrer"

--- a/frontend/landing-site/src/components/landing/features-section.tsx
+++ b/frontend/landing-site/src/components/landing/features-section.tsx
@@ -1,44 +1,44 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { Code2, Database, Globe2, Shield, TrendingUp, Zap } from "lucide-react";
+import { motion } from 'framer-motion';
+import { Code2, Database, Globe2, Shield, TrendingUp, Zap } from 'lucide-react';
 
 const features = [
   {
     icon: Zap,
-    title: "5分で本番環境",
+    title: '5分で本番環境',
     description:
-      "クリックだけで Kubernetes、データベース、認証基盤を自動デプロイ。インフラの知識は不要です。",
+      'クリックだけで Kubernetes、データベース、認証基盤を自動デプロイ。インフラの知識は不要です。',
   },
   {
     icon: Shield,
-    title: "エンタープライズグレードのセキュリティ",
+    title: 'エンタープライズグレードのセキュリティ',
     description:
-      "Keycloak による OIDC 認証、テナント間の完全なデータ分離、SOC2 準拠の運用体制。",
+      'Keycloak による OIDC 認証、テナント間の完全なデータ分離、SOC2 準拠の運用体制。',
   },
   {
     icon: TrendingUp,
-    title: "無限のスケーラビリティ",
+    title: '無限のスケーラビリティ',
     description:
-      "10人から10,000人まで。Kubernetes の自動スケーリングで参加者数に合わせてリソースを最適化。",
+      '10人から10,000人まで。Kubernetes の自動スケーリングで参加者数に合わせてリソースを最適化。',
   },
   {
     icon: Code2,
-    title: "マルチ言語対応ジャッジ",
+    title: 'マルチ言語対応ジャッジ',
     description:
-      "Python、JavaScript、Go、Rust など主要言語をサポート。独自の実行環境も追加可能。",
+      'Python、JavaScript、Go、Rust など主要言語をサポート。独自の実行環境も追加可能。',
   },
   {
     icon: Database,
-    title: "Pool & Silo アーキテクチャ",
+    title: 'Pool & Silo アーキテクチャ',
     description:
-      "用途に応じて共有リソース (Pool) と専用リソース (Silo) を選択。コスト効率と分離性のバランスを最適化。",
+      '用途に応じて共有リソース (Pool) と専用リソース (Silo) を選択。コスト効率と分離性のバランスを最適化。',
   },
   {
     icon: Globe2,
-    title: "マルチクラウド対応",
+    title: 'マルチクラウド対応',
     description:
-      "AWS、GCP、Azure、OCI をサポート。ベンダーロックインなしで、最適なクラウドを選択できます。",
+      'AWS、GCP、Azure、OCI をサポート。ベンダーロックインなしで、最適なクラウドを選択できます。',
   },
 ];
 

--- a/frontend/landing-site/src/components/landing/hero-section.tsx
+++ b/frontend/landing-site/src/components/landing/hero-section.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { ArrowRight, Sparkles } from "lucide-react";
-import Link from "next/link";
+import { motion } from 'framer-motion';
+import { ArrowRight, Sparkles } from 'lucide-react';
+import Link from 'next/link';
 
 export function HeroSection() {
   return (
@@ -11,11 +11,11 @@ export function HeroSection() {
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div
           className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full opacity-20 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 264)" }}
+          style={{ background: 'oklch(0.56 0.20 264)' }}
         />
         <div
           className="absolute bottom-1/4 right-1/4 w-96 h-96 rounded-full opacity-20 blur-3xl animate-float"
-          style={{ background: "oklch(0.56 0.20 180)", animationDelay: "-3s" }}
+          style={{ background: 'oklch(0.56 0.20 180)', animationDelay: '-3s' }}
         />
       </div>
 

--- a/frontend/landing-site/src/components/landing/pricing-section.tsx
+++ b/frontend/landing-site/src/components/landing/pricing-section.tsx
@@ -1,55 +1,55 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { Check, Zap } from "lucide-react";
-import Link from "next/link";
+import { motion } from 'framer-motion';
+import { Check, Zap } from 'lucide-react';
+import Link from 'next/link';
 
 const plans = [
   {
-    name: "Free",
-    description: "個人開発者や小規模イベント向け",
-    price: "¥0",
-    period: "/月",
+    name: 'Free',
+    description: '個人開発者や小規模イベント向け',
+    price: '¥0',
+    period: '/月',
     features: [
-      "最大100参加者",
-      "Pool モデル (共有リソース)",
-      "基本的な問題管理",
-      "コミュニティサポート",
-      "1テナント",
+      '最大100参加者',
+      'Pool モデル (共有リソース)',
+      '基本的な問題管理',
+      'コミュニティサポート',
+      '1テナント',
     ],
-    cta: "無料で始める",
+    cta: '無料で始める',
     highlighted: false,
   },
   {
-    name: "Pro",
-    description: "成長企業や定期開催イベント向け",
-    price: "¥9,800",
-    period: "/月",
+    name: 'Pro',
+    description: '成長企業や定期開催イベント向け',
+    price: '¥9,800',
+    period: '/月',
     features: [
-      "最大1,000参加者",
-      "Silo モデル (専用リソース)",
-      "高度な分析・ダッシュボード",
-      "優先サポート (24時間以内)",
-      "カスタムドメイン",
-      "無制限テナント",
+      '最大1,000参加者',
+      'Silo モデル (専用リソース)',
+      '高度な分析・ダッシュボード',
+      '優先サポート (24時間以内)',
+      'カスタムドメイン',
+      '無制限テナント',
     ],
-    cta: "Pro を始める",
+    cta: 'Pro を始める',
     highlighted: true,
   },
   {
-    name: "Enterprise",
-    description: "大規模イベントやエンタープライズ向け",
-    price: "お問い合わせ",
-    period: "",
+    name: 'Enterprise',
+    description: '大規模イベントやエンタープライズ向け',
+    price: 'お問い合わせ',
+    period: '',
     features: [
-      "無制限参加者",
-      "専用インフラ",
-      "SLA 保証 (99.9%)",
-      "専任サポート",
-      "オンプレミス対応",
-      "カスタム統合",
+      '無制限参加者',
+      '専用インフラ',
+      'SLA 保証 (99.9%)',
+      '専任サポート',
+      'オンプレミス対応',
+      'カスタム統合',
     ],
-    cta: "お問い合わせ",
+    cta: 'お問い合わせ',
     highlighted: false,
   },
 ];
@@ -93,8 +93,8 @@ export function PricingSection() {
               <div
                 className={`relative h-full p-8 rounded-3xl ${
                   plan.highlighted
-                    ? "glass border-primary-500/50 glow"
-                    : "glass"
+                    ? 'glass border-primary-500/50 glow'
+                    : 'glass'
                 }`}
               >
                 {plan.highlighted && (
@@ -138,8 +138,8 @@ export function PricingSection() {
                       whileTap={{ scale: 0.98 }}
                       className={`w-full py-3 px-6 rounded-xl font-semibold transition-all ${
                         plan.highlighted
-                          ? "bg-gradient-to-r from-primary-500 to-accent-500 shadow-lg shadow-primary-500/25"
-                          : "bg-white/10 hover:bg-white/15"
+                          ? 'bg-gradient-to-r from-primary-500 to-accent-500 shadow-lg shadow-primary-500/25'
+                          : 'bg-white/10 hover:bg-white/15'
                       }`}
                     >
                       {plan.cta}

--- a/frontend/landing-site/src/components/onboarding/environment-step.tsx
+++ b/frontend/landing-site/src/components/onboarding/environment-step.tsx
@@ -1,34 +1,34 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { ArrowLeft, ArrowRight, Check, Database, Zap } from "lucide-react";
-import { useState } from "react";
+import { motion } from 'framer-motion';
+import { ArrowLeft, ArrowRight, Check, Database, Zap } from 'lucide-react';
+import { useState } from 'react';
 import {
   type ComputeType,
   type TenantModel,
   useOnboardingStore,
-} from "@/lib/stores/onboarding-store";
+} from '@/lib/stores/onboarding-store';
 
 export function EnvironmentStep() {
   const { environmentData, setEnvironmentData, setCurrentStep } =
     useOnboardingStore();
 
   const [model, setModel] = useState<TenantModel | null>(
-    environmentData.model || null,
+    environmentData.model || null
   );
   const [compute, setCompute] = useState<ComputeType | null>(
-    environmentData.compute || null,
+    environmentData.compute || null
   );
 
   const handleNext = () => {
     if (model && compute) {
       setEnvironmentData({ model, compute });
-      setCurrentStep("review");
+      setCurrentStep('review');
     }
   };
 
   const handleBack = () => {
-    setCurrentStep("tenant");
+    setCurrentStep('tenant');
   };
 
   return (
@@ -47,14 +47,14 @@ export function EnvironmentStep() {
         <div className="grid md:grid-cols-2 gap-4">
           <motion.button
             type="button"
-            onClick={() => setModel("pool")}
+            onClick={() => setModel('pool')}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className={`relative p-6 rounded-2xl text-left transition-all ${
-              model === "pool" ? "glass border-primary-500 glow" : "glass"
+              model === 'pool' ? 'glass border-primary-500 glow' : 'glass'
             }`}
           >
-            {model === "pool" && (
+            {model === 'pool' && (
               <div className="absolute top-4 right-4">
                 <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center">
                   <Check className="w-4 h-4 text-white" />
@@ -80,14 +80,14 @@ export function EnvironmentStep() {
 
           <motion.button
             type="button"
-            onClick={() => setModel("silo")}
+            onClick={() => setModel('silo')}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className={`relative p-6 rounded-2xl text-left transition-all ${
-              model === "silo" ? "glass border-primary-500 glow" : "glass"
+              model === 'silo' ? 'glass border-primary-500 glow' : 'glass'
             }`}
           >
-            {model === "silo" && (
+            {model === 'silo' && (
               <div className="absolute top-4 right-4">
                 <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center">
                   <Check className="w-4 h-4 text-white" />
@@ -120,16 +120,16 @@ export function EnvironmentStep() {
         <div className="grid md:grid-cols-2 gap-4">
           <motion.button
             type="button"
-            onClick={() => setCompute("serverless")}
+            onClick={() => setCompute('serverless')}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className={`relative p-6 rounded-2xl text-left transition-all ${
-              compute === "serverless"
-                ? "glass border-primary-500 glow"
-                : "glass"
+              compute === 'serverless'
+                ? 'glass border-primary-500 glow'
+                : 'glass'
             }`}
           >
-            {compute === "serverless" && (
+            {compute === 'serverless' && (
               <div className="absolute top-4 right-4">
                 <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center">
                   <Check className="w-4 h-4 text-white" />
@@ -155,16 +155,16 @@ export function EnvironmentStep() {
 
           <motion.button
             type="button"
-            onClick={() => setCompute("kubernetes")}
+            onClick={() => setCompute('kubernetes')}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className={`relative p-6 rounded-2xl text-left transition-all ${
-              compute === "kubernetes"
-                ? "glass border-primary-500 glow"
-                : "glass"
+              compute === 'kubernetes'
+                ? 'glass border-primary-500 glow'
+                : 'glass'
             }`}
           >
-            {compute === "kubernetes" && (
+            {compute === 'kubernetes' && (
               <div className="absolute top-4 right-4">
                 <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center">
                   <Check className="w-4 h-4 text-white" />

--- a/frontend/landing-site/src/components/onboarding/plan-step.tsx
+++ b/frontend/landing-site/src/components/onboarding/plan-step.tsx
@@ -1,54 +1,54 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { ArrowLeft, ArrowRight, Check } from "lucide-react";
-import { useState } from "react";
+import { motion } from 'framer-motion';
+import { ArrowLeft, ArrowRight, Check } from 'lucide-react';
+import { useState } from 'react';
 import {
   type PlanTier,
   useOnboardingStore,
-} from "@/lib/stores/onboarding-store";
+} from '@/lib/stores/onboarding-store';
 
 const plans = [
   {
-    tier: "free" as PlanTier,
-    name: "Free",
-    price: "¥0",
-    period: "/月",
-    description: "個人開発者や小規模イベント向け",
+    tier: 'free' as PlanTier,
+    name: 'Free',
+    price: '¥0',
+    period: '/月',
+    description: '個人開発者や小規模イベント向け',
     features: [
-      "最大100参加者",
-      "Pool モデル",
-      "基本的な問題管理",
-      "コミュニティサポート",
+      '最大100参加者',
+      'Pool モデル',
+      '基本的な問題管理',
+      'コミュニティサポート',
     ],
   },
   {
-    tier: "pro" as PlanTier,
-    name: "Pro",
-    price: "¥9,800",
-    period: "/月",
-    description: "成長企業や定期開催イベント向け",
+    tier: 'pro' as PlanTier,
+    name: 'Pro',
+    price: '¥9,800',
+    period: '/月',
+    description: '成長企業や定期開催イベント向け',
     features: [
-      "最大1,000参加者",
-      "Silo モデル",
-      "高度な分析",
-      "優先サポート",
-      "カスタムドメイン",
+      '最大1,000参加者',
+      'Silo モデル',
+      '高度な分析',
+      '優先サポート',
+      'カスタムドメイン',
     ],
     popular: true,
   },
   {
-    tier: "enterprise" as PlanTier,
-    name: "Enterprise",
-    price: "お問い合わせ",
-    period: "",
-    description: "大規模イベント向け",
+    tier: 'enterprise' as PlanTier,
+    name: 'Enterprise',
+    price: 'お問い合わせ',
+    period: '',
+    description: '大規模イベント向け',
     features: [
-      "無制限参加者",
-      "専用インフラ",
-      "SLA 保証",
-      "専任サポート",
-      "カスタム統合",
+      '無制限参加者',
+      '専用インフラ',
+      'SLA 保証',
+      '専任サポート',
+      'カスタム統合',
     ],
   },
 ];
@@ -56,18 +56,18 @@ const plans = [
 export function PlanStep() {
   const { planData, setPlanData, setCurrentStep } = useOnboardingStore();
   const [selectedTier, setSelectedTier] = useState<PlanTier | null>(
-    planData.tier || null,
+    planData.tier || null
   );
 
   const handleNext = () => {
     if (selectedTier) {
       setPlanData({ tier: selectedTier });
-      setCurrentStep("tenant");
+      setCurrentStep('tenant');
     }
   };
 
   const handleBack = () => {
-    setCurrentStep("profile");
+    setCurrentStep('profile');
   };
 
   return (
@@ -89,8 +89,8 @@ export function PlanStep() {
             whileTap={{ scale: 0.98 }}
             className={`relative p-6 rounded-2xl text-left transition-all ${
               selectedTier === plan.tier
-                ? "glass border-primary-500 glow"
-                : "glass"
+                ? 'glass border-primary-500 glow'
+                : 'glass'
             }`}
           >
             {plan.popular && (

--- a/frontend/landing-site/src/components/onboarding/profile-step.tsx
+++ b/frontend/landing-site/src/components/onboarding/profile-step.tsx
@@ -1,20 +1,20 @@
-"use client";
+'use client';
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { motion } from "framer-motion";
-import { ArrowRight } from "lucide-react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { zodResolver } from '@hookform/resolvers/zod';
+import { motion } from 'framer-motion';
+import { ArrowRight } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 import {
   type ProfileData,
   useOnboardingStore,
-} from "@/lib/stores/onboarding-store";
+} from '@/lib/stores/onboarding-store';
 
 const profileSchema = z.object({
-  fullName: z.string().min(1, "氏名を入力してください"),
-  email: z.string().email("有効なメールアドレスを入力してください"),
-  organizationName: z.string().min(1, "組織名を入力してください"),
-  purpose: z.string().min(10, "用途を10文字以上で入力してください"),
+  fullName: z.string().min(1, '氏名を入力してください'),
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  organizationName: z.string().min(1, '組織名を入力してください'),
+  purpose: z.string().min(10, '用途を10文字以上で入力してください'),
 });
 
 export function ProfileStep() {
@@ -31,7 +31,7 @@ export function ProfileStep() {
 
   const onSubmit = (data: ProfileData) => {
     setProfileData(data);
-    setCurrentStep("plan");
+    setCurrentStep('plan');
   };
 
   return (
@@ -57,7 +57,7 @@ export function ProfileStep() {
             <input
               id="fullName"
               type="text"
-              {...register("fullName")}
+              {...register('fullName')}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
               placeholder="山田 太郎"
             />
@@ -78,7 +78,7 @@ export function ProfileStep() {
             <input
               id="email"
               type="email"
-              {...register("email")}
+              {...register('email')}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
               placeholder="you@example.com"
             />
@@ -99,7 +99,7 @@ export function ProfileStep() {
             <input
               id="organizationName"
               type="text"
-              {...register("organizationName")}
+              {...register('organizationName')}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
               placeholder="株式会社サンプル"
             />
@@ -119,7 +119,7 @@ export function ProfileStep() {
             </label>
             <textarea
               id="purpose"
-              {...register("purpose")}
+              {...register('purpose')}
               rows={4}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors resize-none"
               placeholder="例: 社内ハッカソンでプログラミングコンテストを開催したい"

--- a/frontend/landing-site/src/components/onboarding/review-step.tsx
+++ b/frontend/landing-site/src/components/onboarding/review-step.tsx
@@ -1,25 +1,25 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { ArrowLeft, Rocket } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useOnboardingStore } from "@/lib/stores/onboarding-store";
+import { motion } from 'framer-motion';
+import { ArrowLeft, Rocket } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useOnboardingStore } from '@/lib/stores/onboarding-store';
 
 const planLabels = {
-  free: "Free",
-  pro: "Pro",
-  enterprise: "Enterprise",
+  free: 'Free',
+  pro: 'Pro',
+  enterprise: 'Enterprise',
 };
 
 const modelLabels = {
-  pool: "Pool (共有リソース)",
-  silo: "Silo (専用リソース)",
+  pool: 'Pool (共有リソース)',
+  silo: 'Silo (専用リソース)',
 };
 
 const computeLabels = {
-  serverless: "Serverless",
-  kubernetes: "Kubernetes",
+  serverless: 'Serverless',
+  kubernetes: 'Kubernetes',
 };
 
 export function ReviewStep() {
@@ -40,38 +40,38 @@ export function ReviewStep() {
         region: tenantData.region,
         isolationModel: environmentData.model?.toUpperCase(),
         computeType: environmentData.compute?.toUpperCase(),
-        status: "ACTIVE",
+        status: 'ACTIVE',
       };
 
-      console.log("Creating tenant:", payload);
+      console.log('Creating tenant:', payload);
 
-      const response = await fetch("http://localhost:3004/api/tenants", {
-        method: "POST",
+      const response = await fetch('http://localhost:3004/api/tenants', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify(payload),
       });
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to create tenant");
+        throw new Error(errorData.error || 'Failed to create tenant');
       }
 
       const result = await response.json();
-      console.log("Tenant created:", result);
+      console.log('Tenant created:', result);
 
       // Redirect to provisioning page
-      router.push("/onboarding/provisioning");
+      router.push('/onboarding/provisioning');
     } catch (error) {
-      console.error("Failed to create tenant:", error);
-      alert(error instanceof Error ? error.message : "Failed to create tenant");
+      console.error('Failed to create tenant:', error);
+      alert(error instanceof Error ? error.message : 'Failed to create tenant');
       setIsSubmitting(false);
     }
   };
 
   const handleBack = () => {
-    setCurrentStep("environment");
+    setCurrentStep('environment');
   };
 
   return (
@@ -188,7 +188,7 @@ export function ReviewStep() {
             className="flex items-center gap-2 px-8 py-3 bg-gradient-to-r from-primary-500 to-accent-500 rounded-xl font-semibold shadow-lg shadow-primary-500/25 hover:shadow-primary-500/40 transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isSubmitting ? (
-              "作成中..."
+              '作成中...'
             ) : (
               <>
                 <Rocket className="w-5 h-5" />

--- a/frontend/landing-site/src/components/onboarding/tenant-step.tsx
+++ b/frontend/landing-site/src/components/onboarding/tenant-step.tsx
@@ -1,29 +1,29 @@
-"use client";
+'use client';
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { motion } from "framer-motion";
-import { ArrowLeft, ArrowRight } from "lucide-react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { zodResolver } from '@hookform/resolvers/zod';
+import { motion } from 'framer-motion';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 import {
   type TenantData,
   useOnboardingStore,
-} from "@/lib/stores/onboarding-store";
+} from '@/lib/stores/onboarding-store';
 
 const tenantSchema = z.object({
-  name: z.string().min(1, "テナント名を入力してください"),
+  name: z.string().min(1, 'テナント名を入力してください'),
   slug: z
     .string()
-    .min(3, "スラッグは3文字以上必要です")
-    .regex(/^[a-z0-9-]+$/, "小文字英数字とハイフンのみ使用できます"),
-  region: z.string().min(1, "リージョンを選択してください"),
+    .min(3, 'スラッグは3文字以上必要です')
+    .regex(/^[a-z0-9-]+$/, '小文字英数字とハイフンのみ使用できます'),
+  region: z.string().min(1, 'リージョンを選択してください'),
 });
 
 const regions = [
-  { value: "ap-northeast-1", label: "東京 (ap-northeast-1)" },
-  { value: "us-west-2", label: "オレゴン (us-west-2)" },
-  { value: "eu-west-1", label: "アイルランド (eu-west-1)" },
-  { value: "ap-southeast-1", label: "シンガポール (ap-southeast-1)" },
+  { value: 'ap-northeast-1', label: '東京 (ap-northeast-1)' },
+  { value: 'us-west-2', label: 'オレゴン (us-west-2)' },
+  { value: 'eu-west-1', label: 'アイルランド (eu-west-1)' },
+  { value: 'ap-southeast-1', label: 'シンガポール (ap-southeast-1)' },
 ];
 
 export function TenantStep() {
@@ -40,21 +40,21 @@ export function TenantStep() {
 
   const onSubmit = (data: TenantData) => {
     setTenantData(data);
-    setCurrentStep("environment");
+    setCurrentStep('environment');
   };
 
   const handleBack = () => {
-    setCurrentStep("plan");
+    setCurrentStep('plan');
   };
 
   // Auto-generate slug from name
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const slug = e.target.value
       .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
 
-    const slugInput = document.getElementById("slug") as HTMLInputElement;
+    const slugInput = document.getElementById('slug') as HTMLInputElement;
     if (slugInput && !slugInput.value) {
       slugInput.value = slug;
     }
@@ -81,9 +81,9 @@ export function TenantStep() {
             <input
               id="name"
               type="text"
-              {...register("name")}
+              {...register('name')}
               onChange={(e) => {
-                register("name").onChange(e);
+                register('name').onChange(e);
                 handleNameChange(e);
               }}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
@@ -106,7 +106,7 @@ export function TenantStep() {
               <input
                 id="slug"
                 type="text"
-                {...register("slug")}
+                {...register('slug')}
                 className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
                 placeholder="my-awesome-contest"
               />
@@ -129,7 +129,7 @@ export function TenantStep() {
             </label>
             <select
               id="region"
-              {...register("region")}
+              {...register('region')}
               className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl focus:outline-none focus:border-primary-500 transition-colors"
             >
               <option value="">選択してください</option>

--- a/frontend/landing-site/src/lib/stores/onboarding-store.ts
+++ b/frontend/landing-site/src/lib/stores/onboarding-store.ts
@@ -1,12 +1,12 @@
-import { create } from "zustand";
+import { create } from 'zustand';
 
-export type Step = "profile" | "plan" | "tenant" | "environment" | "review";
+export type Step = 'profile' | 'plan' | 'tenant' | 'environment' | 'review';
 
-export type PlanTier = "free" | "pro" | "enterprise";
+export type PlanTier = 'free' | 'pro' | 'enterprise';
 
-export type TenantModel = "pool" | "silo";
+export type TenantModel = 'pool' | 'silo';
 
-export type ComputeType = "serverless" | "kubernetes";
+export type ComputeType = 'serverless' | 'kubernetes';
 
 export interface ProfileData {
   fullName: string;
@@ -46,7 +46,7 @@ export interface OnboardingState {
 }
 
 const initialState = {
-  currentStep: "profile" as Step,
+  currentStep: 'profile' as Step,
   profileData: {},
   planData: {},
   tenantData: {},

--- a/frontend/landing-site/src/lib/utils.ts
+++ b/frontend/landing-site/src/lib/utils.ts
@@ -1,5 +1,5 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
## 概要
ランディングサイトの「ログイン」リンクを Admin App へリダイレクトするように修正。

## 変更内容
- signup ページの「ログイン」リンクを `/login` から Admin App (3001) へ変更
- Biome によるコードフォーマットの統一

## 責務の整理
| アプリ | ポート | 対象 |
|--------|--------|------|
| Control Plane | 3000 | サービス提供側（TenkaCloud 運営者） |
| Admin App | 3001 | ユーザー側の管理者（テナント管理者） |
| Participant App | 3002 | 競技者 |
| Landing Site | 3003 | 新規ユーザー獲得 → Admin App へ誘導 |

## テスト
- [x] 型チェック通過
- [x] フォーマット適用済み

Fix #71 
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signup page: localized Japanese messages, inline error display, and environment-driven API/Admin links for smoother onboarding flow
* **Chores**
  * Added backend provisioning infrastructure to automate tenant service setup
  * Included a committed .env.example and adjusted ignore rules for easier local configuration
  * Minor UI/text consistency updates across the landing site (quote/style normalizations)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->