### PR TITLE
feat: Makefile を ni コマンドに移行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ default: help
 NI ?= bunx ni
 NR ?= bunx nr
 NLX ?= bunx nlx
-NCI ?= bunx nci
 BUN ?= bun
 FRONTEND_DIR ?= frontend/control-plane
 CONTROL_PLANE_DIR := frontend/control-plane
@@ -29,11 +28,12 @@ PROBLEM_MANAGEMENT_DIR := $(BACKEND_SERVICES_DIR)/problem-management
 # 📦 パッケージ管理
 # ========================================
 
+# Note: lint_text/format_check は CI で ni インストール前に実行されるため、直接 bun を使用
 lint_text:
-	$(NR) lint_text
+	$(BUN) run lint_text
 
 format_check:
-	$(NR) format_check
+	$(BUN) run format_check
 
 install:
 	$(NI)
@@ -124,7 +124,7 @@ test_quick:
 	@echo "📦 バックエンドサービス:"
 	@echo ""
 	@echo "🔬 $(PROBLEM_MANAGEMENT_DIR) のテスト..."
-	@(cd $(PROBLEM_MANAGEMENT_DIR) && $(NLX) vitest run) || exit 1
+	@(cd $(PROBLEM_MANAGEMENT_DIR) && $(NR) test) || exit 1
 	@echo ""
 	@echo "✅ すべてのテストが成功しました"
 
@@ -141,7 +141,7 @@ test_coverage:
 	@echo "📦 バックエンドサービス:"
 	@echo ""
 	@echo "📈 $(PROBLEM_MANAGEMENT_DIR) のカバレッジテスト..."
-	@(cd $(PROBLEM_MANAGEMENT_DIR) && $(NLX) vitest run --coverage) || exit 1
+	@(cd $(PROBLEM_MANAGEMENT_DIR) && $(NR) test:coverage) || exit 1
 	@echo ""
 	@echo "✅ すべてのカバレッジテストが成功しました"
 


### PR DESCRIPTION
## 概要

Makefile のすべてのパッケージマネージャーコマンドを `@antfu/ni` ベースに移行しました。

## 変更内容

### 変数定義の変更
- `NODE_RUNNER ?= npm` を削除
- 新規追加:
  - `NI ?= bunx ni` (依存関係インストール)
  - `NR ?= bunx nr` (スクリプト実行)
  - `NLX ?= bunx nlx` (パッケージ一時実行)

### 各ターゲットの移行
| ターゲット | 変更前 | 変更後 |
|------------|--------|--------|
| lint_text | `$(NODE_RUNNER) run lint_text` | `$(NR) lint_text` |
| format_check | `$(NODE_RUNNER) run format_check` | `$(NR) format_check` |
| clean | `$(NODE_RUNNER) run clean` | `$(NR) clean` |
| format | `$(NODE_RUNNER) run format` | `$(NR) format` |
| lint | `$(NODE_RUNNER) --prefix $$app run lint` | `cd $$app && $(NR) lint && cd ../..` |
| typecheck | `$(NODE_RUNNER) --prefix` | `cd && $(NR) typecheck && cd` |
| build | `$(NODE_RUNNER) --prefix` | `cd && $(NR) build && cd` |
| dev | `$(NODE_RUNNER) --prefix run dev` | `cd dir && $(NR) dev` |
| test_quick | `$(NODE_RUNNER) --prefix` | `cd && $(NR) test && cd` |
| test_coverage | `$(NODE_RUNNER) --prefix` | `cd && $(NR) test:coverage && cd` |
| start-control-plane | `$(NODE_RUNNER) --prefix run dev` | `cd dir && $(NR) dev` |

### バックエンドサービスのテスト
- `$(NODE_RUNNER) --prefix` を `$(NLX) vitest run` に変更

## テスト計画

- [x] `make -n lint_text` で正しいコマンドが生成される
- [x] `make -n typecheck` で正しいコマンドが生成される
- [ ] CI が正常に動作する

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized package-manager commands across the project using unified wrappers; installation, dev, test and build flows now run consistently per frontend app.
  * Improved multi-app install and test orchestration, and streamlined start/control-plane and CI install flows.
  * No user-facing features changed; behavior and public interfaces remain the same.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->