### PR TITLE
fix(security): Keycloak realm injection 脆弱性を修正

### DIFF
--- a/backend/services/control-plane/user-management/prisma/schema.prisma
+++ b/backend/services/control-plane/user-management/prisma/schema.prisma
@@ -18,6 +18,15 @@ enum UserStatus {
   PENDING
 }
 
+model Tenant {
+  id     String @id @default(uuid())
+  slug   String @unique
+  // 他のフィールドは registration サービスで管理
+  // このモデルは tenantSlug 検証のための読み取り専用参照
+
+  @@map("tenants")
+}
+
 model User {
   id         String     @id @default(uuid())
   tenantId   String


### PR DESCRIPTION
## Summary

- tenantSlug をデータベースで検証し、tenantId との整合性を確認
- クロステナント攻撃（X-Tenant-Slug ヘッダー改ざん）を防止
- Tenant モデルを追加して slug の読み取り専用参照を実現
- 不一致検出時のログ出力を追加

## Security Fix

**HIGH Severity**: Keycloak realm injection 脆弱性

攻撃者が `X-Tenant-Slug` ヘッダーを改ざんすることで、別テナントの Keycloak realm にユーザーを作成したり、パスワードリセットを実行できる脆弱性を修正しました。

### 修正内容

1. `validateAndGetTenantSlug` 関数を追加し、tenantId から正しい slug を取得
2. 提供された slug と実際の slug を比較して不一致を検出
3. `createUser`, `resetPassword`, `deactivateUser` で検証を実施
4. 不一致検出時は警告ログを出力

## Test plan

- [x] 正常ケース: tenantSlug が正しい場合は処理が成功する
- [x] 異常ケース: tenantSlug が不一致の場合は 500 エラーを返す
- [x] 異常ケース: テナントが存在しない場合は 500 エラーを返す
- [x] 全テストが 100% カバレッジで通過

Closes susumutomita/TenkaCloud#102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Implemented cross-tenant slug validation to prevent unauthorized access and data manipulation across tenant boundaries in user management operations including user creation, role updates, password resets, and user deletion.

* **Tests**
  * Expanded test coverage to validate cross-tenant protection enforcement and tenant verification across all user management endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->