### PR TITLE
feat(problem-management): 問題インポート/エクスポート機能を追加

### DIFF
--- a/backend/services/problem-management/src/__tests__/converter.test.ts
+++ b/backend/services/problem-management/src/__tests__/converter.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Converter Tests
+ *
+ * 問題フォーマット変換の単体テスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  exportProblem,
+  exportProblems,
+  importProblem,
+  importProblems,
+  detectFormat,
+} from '../problems/converter';
+import type { Problem } from '../types';
+
+// テスト用の問題データ
+const createTestProblem = (overrides: Partial<Problem> = {}): Problem => ({
+  id: 'test-problem-1',
+  title: 'テスト問題',
+  type: 'gameday',
+  category: 'architecture',
+  difficulty: 'medium',
+  metadata: {
+    author: 'test-author',
+    version: '1.0.0',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-02',
+    tags: ['aws', 'cloudformation'],
+    license: 'MIT',
+  },
+  description: {
+    overview: '# 概要\nこれはテスト問題です。',
+    objectives: ['目標1', '目標2'],
+    hints: ['ヒント1'],
+    prerequisites: ['前提条件1'],
+    estimatedTime: 60,
+  },
+  deployment: {
+    providers: ['aws'],
+    templates: {
+      aws: {
+        type: 'cloudformation',
+        path: '/templates/aws.yaml',
+      },
+    },
+    regions: {
+      aws: ['ap-northeast-1'],
+    },
+    timeout: 30,
+  },
+  scoring: {
+    type: 'lambda',
+    path: '/scoring/index.ts',
+    criteria: [
+      { name: '基準1', weight: 50, maxPoints: 50 },
+      { name: '基準2', weight: 50, maxPoints: 50 },
+    ],
+    timeoutMinutes: 10,
+    intervalMinutes: 5,
+  },
+  resources: {
+    static: [{ path: '/static/file.txt', destination: 's3://bucket/file.txt' }],
+    documentation: [{ path: '/docs/README.md' }],
+  },
+  ...overrides,
+});
+
+describe('exportProblem', () => {
+  it('YAML 形式でエクスポートできるべき', () => {
+    const problem = createTestProblem();
+    const result = exportProblem(problem, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    expect(result.data).toContain('id: test-problem-1');
+    expect(result.data).toContain('title: テスト問題');
+    expect(result.data).toContain('type: gameday');
+  });
+
+  it('JSON 形式でエクスポートできるべき', () => {
+    const problem = createTestProblem();
+    const result = exportProblem(problem, { format: 'tenkacloud-json' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    const parsed = JSON.parse(result.data!);
+    expect(parsed.id).toBe('test-problem-1');
+    expect(parsed.title).toBe('テスト問題');
+  });
+
+  it('prettyPrint オプションで整形された JSON を出力するべき', () => {
+    const problem = createTestProblem();
+    const result = exportProblem(problem, {
+      format: 'tenkacloud-json',
+      prettyPrint: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('\n');
+    expect(result.data).toContain('  ');
+  });
+
+  it('未対応のフォーマットでエラーを返すべき', () => {
+    const problem = createTestProblem();
+    const result = exportProblem(problem, {
+      format: 'unknown-format' as any,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain(
+      'Unsupported export format: unknown-format'
+    );
+  });
+});
+
+describe('exportProblems', () => {
+  it('複数の問題を YAML 形式でエクスポートできるべき', () => {
+    const problems = [
+      createTestProblem({ id: 'problem-1', title: '問題1' }),
+      createTestProblem({ id: 'problem-2', title: '問題2' }),
+    ];
+    const result = exportProblems(problems, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('version: "1.0"');
+    expect(result.data).toContain('problems:');
+    expect(result.data).toContain('id: problem-1');
+    expect(result.data).toContain('id: problem-2');
+  });
+
+  it('複数の問題を JSON 形式でエクスポートできるべき', () => {
+    const problems = [
+      createTestProblem({ id: 'problem-1' }),
+      createTestProblem({ id: 'problem-2' }),
+    ];
+    const result = exportProblems(problems, { format: 'tenkacloud-json' });
+
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(result.data!);
+    expect(parsed.version).toBe('1.0');
+    expect(parsed.problems).toHaveLength(2);
+  });
+});
+
+describe('importProblem', () => {
+  it('YAML 形式からインポートできるべき', () => {
+    const yaml = `
+id: imported-problem
+title: インポートされた問題
+type: gameday
+category: security
+difficulty: hard
+metadata:
+  author: test-author
+  version: "1.0.0"
+  createdAt: "2024-01-01"
+description:
+  overview: 概要テキスト
+  objectives:
+    - 目標1
+deployment:
+  providers:
+    - aws
+  templates:
+    aws:
+      type: cloudformation
+      path: /templates/aws.yaml
+scoring:
+  type: lambda
+  path: /scoring/index.ts
+  criteria:
+    - name: 基準1
+      weight: 100
+      maxPoints: 100
+  timeoutMinutes: 10
+`;
+
+    const result = importProblem(yaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    expect(result.data!.id).toBe('imported-problem');
+    expect(result.data!.title).toBe('インポートされた問題');
+    expect(result.data!.type).toBe('gameday');
+  });
+
+  it('JSON 形式からインポートできるべき', () => {
+    const json = JSON.stringify({
+      id: 'json-problem',
+      title: 'JSON 問題',
+      type: 'jam',
+      category: 'cost',
+      difficulty: 'easy',
+      metadata: {
+        author: 'json-author',
+        version: '2.0.0',
+        createdAt: '2024-02-01',
+      },
+      description: {
+        overview: 'JSON 概要',
+        objectives: ['JSON 目標'],
+      },
+      deployment: {
+        providers: ['gcp'],
+        templates: {
+          gcp: { type: 'terraform', path: '/templates/gcp.tf' },
+        },
+      },
+      scoring: {
+        type: 'container',
+        path: '/scoring/Dockerfile',
+        criteria: [{ name: '基準', weight: 100, maxPoints: 100 }],
+        timeoutMinutes: 15,
+      },
+    });
+
+    const result = importProblem(json, { format: 'tenkacloud-json' });
+
+    expect(result.success).toBe(true);
+    expect(result.data!.id).toBe('json-problem');
+    expect(result.data!.type).toBe('jam');
+    expect(result.data!.deployment?.providers).toContain('gcp');
+  });
+
+  it('必須フィールドがない場合はエラーを返すべき', () => {
+    const yaml = `
+title: タイトルのみ
+`;
+
+    const result = importProblem(yaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('Missing required field: id');
+    expect(result.errors).toContain('Missing required field: type');
+  });
+
+  it('不正な YAML でエラーを返すべき', () => {
+    const invalidYaml = `
+id: test
+  invalid: indentation
+`;
+
+    const result = importProblem(invalidYaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('不正な JSON でエラーを返すべき', () => {
+    const invalidJson = '{ invalid json }';
+
+    const result = importProblem(invalidJson, { format: 'tenkacloud-json' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('importProblems', () => {
+  it('複数の問題を YAML からインポートできるべき', () => {
+    const yaml = `
+version: "1.0"
+problems:
+  - id: problem-1
+    title: 問題1
+    type: gameday
+    category: architecture
+    difficulty: easy
+    metadata:
+      author: author1
+      version: "1.0.0"
+      createdAt: "2024-01-01"
+    description:
+      overview: 概要1
+      objectives:
+        - 目標1
+    deployment:
+      providers:
+        - aws
+      templates:
+        aws:
+          type: cloudformation
+          path: /templates/1.yaml
+    scoring:
+      type: lambda
+      path: /scoring/1.ts
+      criteria:
+        - name: 基準1
+          weight: 100
+          maxPoints: 100
+      timeoutMinutes: 10
+  - id: problem-2
+    title: 問題2
+    type: jam
+    category: security
+    difficulty: hard
+    metadata:
+      author: author2
+      version: "2.0.0"
+      createdAt: "2024-02-01"
+    description:
+      overview: 概要2
+      objectives:
+        - 目標2
+    deployment:
+      providers:
+        - gcp
+      templates:
+        gcp:
+          type: terraform
+          path: /templates/2.tf
+    scoring:
+      type: container
+      path: /scoring/2
+      criteria:
+        - name: 基準2
+          weight: 100
+          maxPoints: 100
+      timeoutMinutes: 15
+`;
+
+    const result = importProblems(yaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(2);
+    expect(result.data![0].id).toBe('problem-1');
+    expect(result.data![1].id).toBe('problem-2');
+  });
+
+  it('problems 配列がない場合はエラーを返すべき', () => {
+    const yaml = `
+version: "1.0"
+`;
+
+    const result = importProblems(yaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain(
+      'Invalid format: expected "problems" array'
+    );
+  });
+});
+
+describe('detectFormat', () => {
+  it('YAML ファイルを検出できるべき', () => {
+    expect(detectFormat('problem.yaml')).toBe('tenkacloud-yaml');
+    expect(detectFormat('problem.yml')).toBe('tenkacloud-yaml');
+    expect(detectFormat('problem.YAML')).toBe('tenkacloud-yaml');
+  });
+
+  it('JSON ファイルを検出できるべき', () => {
+    expect(detectFormat('problem.json')).toBe('tenkacloud-json');
+    expect(detectFormat('problem.JSON')).toBe('tenkacloud-json');
+  });
+
+  it('未対応の拡張子は null を返すべき', () => {
+    expect(detectFormat('problem.txt')).toBeNull();
+    expect(detectFormat('problem.xml')).toBeNull();
+    expect(detectFormat('problem')).toBeNull();
+  });
+});
+
+describe('ラウンドトリップ', () => {
+  it('エクスポートしてインポートしたデータが一致するべき', () => {
+    const original = createTestProblem();
+    const exported = exportProblem(original, { format: 'tenkacloud-yaml' });
+    expect(exported.success).toBe(true);
+
+    const imported = importProblem(exported.data!, {
+      format: 'tenkacloud-yaml',
+    });
+    expect(imported.success).toBe(true);
+
+    // 主要フィールドが一致することを確認
+    expect(imported.data!.id).toBe(original.id);
+    expect(imported.data!.title).toBe(original.title);
+    expect(imported.data!.type).toBe(original.type);
+    expect(imported.data!.category).toBe(original.category);
+    expect(imported.data!.difficulty).toBe(original.difficulty);
+    expect(imported.data!.metadata?.author).toBe(original.metadata.author);
+    expect(imported.data!.metadata?.version).toBe(original.metadata.version);
+    expect(imported.data!.description?.overview).toBe(
+      original.description.overview
+    );
+    expect(imported.data!.description?.objectives).toEqual(
+      original.description.objectives
+    );
+  });
+
+  it('JSON でもラウンドトリップが成功するべき', () => {
+    const original = createTestProblem();
+    const exported = exportProblem(original, { format: 'tenkacloud-json' });
+    expect(exported.success).toBe(true);
+
+    const imported = importProblem(exported.data!, {
+      format: 'tenkacloud-json',
+    });
+    expect(imported.success).toBe(true);
+
+    expect(imported.data!.id).toBe(original.id);
+    expect(imported.data!.title).toBe(original.title);
+  });
+});

--- a/backend/services/problem-management/src/problems/converter.ts
+++ b/backend/services/problem-management/src/problems/converter.ts
@@ -1,0 +1,379 @@
+/**
+ * Problem Format Converter
+ *
+ * TenkaCloud 問題フォーマットと外部フォーマット間の変換
+ */
+
+import { parse, stringify } from 'yaml';
+import type {
+  Problem,
+  ProblemCategory,
+  DifficultyLevel,
+  CloudProvider,
+} from '../types';
+
+/**
+ * サポートする外部フォーマット
+ */
+export type ExternalFormat = 'tenkacloud-yaml' | 'tenkacloud-json';
+
+/**
+ * 変換結果
+ */
+export interface ConversionResult<T> {
+  success: boolean;
+  data?: T;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * エクスポートオプション
+ */
+export interface ExportOptions {
+  format: ExternalFormat;
+  includeMetadata?: boolean;
+  prettyPrint?: boolean;
+}
+
+/**
+ * インポートオプション
+ */
+export interface ImportOptions {
+  format: ExternalFormat;
+  validateSchema?: boolean;
+  overwriteExisting?: boolean;
+}
+
+/**
+ * TenkaCloud YAML 形式のスキーマデータ型
+ */
+interface TenkaCloudYamlProblem {
+  id: string;
+  title: string;
+  type: 'gameday' | 'jam';
+  category: string;
+  difficulty: string;
+  metadata: {
+    author: string;
+    version: string;
+    createdAt: string;
+    updatedAt?: string;
+    tags?: string[];
+    license?: string;
+  };
+  description: {
+    overview: string;
+    objectives: string[];
+    hints?: string[];
+    prerequisites?: string[];
+    estimatedTime?: number;
+  };
+  deployment: {
+    providers: string[];
+    templates: Record<
+      string,
+      { type: string; path: string; parameters?: Record<string, string> }
+    >;
+    regions?: Record<string, string[]>;
+    timeout?: number;
+  };
+  scoring: {
+    type: string;
+    path: string;
+    criteria: Array<{
+      name: string;
+      weight: number;
+      maxPoints: number;
+      description?: string;
+    }>;
+    timeoutMinutes: number;
+    intervalMinutes?: number;
+  };
+  resources?: {
+    static?: Array<{ path: string; destination: string }>;
+    documentation?: Array<{ path: string }>;
+  };
+}
+
+/**
+ * 問題をエクスポート形式に変換
+ */
+export function exportProblem(
+  problem: Problem,
+  options: ExportOptions
+): ConversionResult<string> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  try {
+    const yamlData = convertToYamlSchema(problem);
+
+    let output: string;
+    if (options.format === 'tenkacloud-yaml') {
+      output = stringify(yamlData, {
+        indent: 2,
+        lineWidth: 120,
+      });
+    } else if (options.format === 'tenkacloud-json') {
+      output = options.prettyPrint
+        ? JSON.stringify(yamlData, null, 2)
+        : JSON.stringify(yamlData);
+    } else {
+      errors.push(`Unsupported export format: ${options.format}`);
+      return { success: false, errors, warnings };
+    }
+
+    return { success: true, data: output, errors, warnings };
+  } catch (error) {
+    errors.push(
+      `Export failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { success: false, errors, warnings };
+  }
+}
+
+/**
+ * 問題を一括エクスポート
+ */
+export function exportProblems(
+  problems: Problem[],
+  options: ExportOptions
+): ConversionResult<string> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  try {
+    const yamlData = problems.map((p) => convertToYamlSchema(p));
+
+    let output: string;
+    if (options.format === 'tenkacloud-yaml') {
+      output = stringify(
+        { version: '1.0', problems: yamlData },
+        {
+          indent: 2,
+          lineWidth: 120,
+        }
+      );
+    } else if (options.format === 'tenkacloud-json') {
+      const data = { version: '1.0', problems: yamlData };
+      output = options.prettyPrint
+        ? JSON.stringify(data, null, 2)
+        : JSON.stringify(data);
+    } else {
+      errors.push(`Unsupported export format: ${options.format}`);
+      return { success: false, errors, warnings };
+    }
+
+    return { success: true, data: output, errors, warnings };
+  } catch (error) {
+    errors.push(
+      `Export failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { success: false, errors, warnings };
+  }
+}
+
+/**
+ * エクスポート用の YAML スキーマ形式に変換
+ */
+function convertToYamlSchema(problem: Problem): TenkaCloudYamlProblem {
+  return {
+    id: problem.id,
+    title: problem.title,
+    type: problem.type as 'gameday' | 'jam',
+    category: problem.category,
+    difficulty: problem.difficulty,
+    metadata: {
+      author: problem.metadata.author,
+      version: problem.metadata.version,
+      createdAt: problem.metadata.createdAt,
+      updatedAt: problem.metadata.updatedAt,
+      tags: problem.metadata.tags,
+      license: problem.metadata.license,
+    },
+    description: {
+      overview: problem.description.overview,
+      objectives: problem.description.objectives,
+      hints: problem.description.hints,
+      prerequisites: problem.description.prerequisites,
+      estimatedTime: problem.description.estimatedTime,
+    },
+    deployment: {
+      providers: problem.deployment.providers,
+      templates: problem.deployment.templates as Record<
+        string,
+        { type: string; path: string }
+      >,
+      regions: problem.deployment.regions,
+      timeout: problem.deployment.timeout,
+    },
+    scoring: {
+      type: problem.scoring.type,
+      path: problem.scoring.path,
+      criteria: problem.scoring.criteria,
+      timeoutMinutes: problem.scoring.timeoutMinutes,
+      intervalMinutes: problem.scoring.intervalMinutes,
+    },
+    resources: problem.resources,
+  };
+}
+
+/**
+ * 文字列またはオブジェクトから問題をインポート
+ */
+export function importProblem(
+  input: string,
+  options: ImportOptions
+): ConversionResult<Partial<Problem>> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  try {
+    let parsed: TenkaCloudYamlProblem;
+
+    if (options.format === 'tenkacloud-yaml') {
+      parsed = parse(input) as TenkaCloudYamlProblem;
+    } else if (options.format === 'tenkacloud-json') {
+      parsed = JSON.parse(input) as TenkaCloudYamlProblem;
+    } else {
+      errors.push(`Unsupported import format: ${options.format}`);
+      return { success: false, errors, warnings };
+    }
+
+    // 基本バリデーション
+    if (!parsed.id) {
+      errors.push('Missing required field: id');
+    }
+    if (!parsed.title) {
+      errors.push('Missing required field: title');
+    }
+    if (!parsed.type) {
+      errors.push('Missing required field: type');
+    }
+
+    if (errors.length > 0) {
+      return { success: false, errors, warnings };
+    }
+
+    const problem = convertFromYamlSchema(parsed);
+
+    return { success: true, data: problem, errors, warnings };
+  } catch (error) {
+    errors.push(
+      `Import failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { success: false, errors, warnings };
+  }
+}
+
+/**
+ * 文字列から複数の問題をインポート
+ */
+export function importProblems(
+  input: string,
+  options: ImportOptions
+): ConversionResult<Partial<Problem>[]> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  try {
+    let parsed: { version?: string; problems: TenkaCloudYamlProblem[] };
+
+    if (options.format === 'tenkacloud-yaml') {
+      parsed = parse(input) as {
+        version?: string;
+        problems: TenkaCloudYamlProblem[];
+      };
+    } else if (options.format === 'tenkacloud-json') {
+      parsed = JSON.parse(input) as {
+        version?: string;
+        problems: TenkaCloudYamlProblem[];
+      };
+    } else {
+      errors.push(`Unsupported import format: ${options.format}`);
+      return { success: false, errors, warnings };
+    }
+
+    if (!parsed.problems || !Array.isArray(parsed.problems)) {
+      errors.push('Invalid format: expected "problems" array');
+      return { success: false, errors, warnings };
+    }
+
+    const problems = parsed.problems
+      .map((p, index) => {
+        try {
+          return convertFromYamlSchema(p);
+        } catch (e) {
+          warnings.push(`Problem at index ${index} conversion failed: ${e}`);
+          return null;
+        }
+      })
+      .filter((p): p is Partial<Problem> => p !== null);
+
+    return { success: true, data: problems, errors, warnings };
+  } catch (error) {
+    errors.push(
+      `Import failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { success: false, errors, warnings };
+  }
+}
+
+/**
+ * YAML スキーマ形式から Problem 型に変換
+ */
+function convertFromYamlSchema(yaml: TenkaCloudYamlProblem): Partial<Problem> {
+  return {
+    id: yaml.id,
+    title: yaml.title,
+    type: yaml.type,
+    category: yaml.category as ProblemCategory,
+    difficulty: yaml.difficulty as DifficultyLevel,
+    metadata: {
+      author: yaml.metadata.author,
+      version: yaml.metadata.version,
+      createdAt: yaml.metadata.createdAt,
+      updatedAt: yaml.metadata.updatedAt,
+      tags: yaml.metadata.tags ?? [],
+      license: yaml.metadata.license,
+    },
+    description: {
+      overview: yaml.description.overview,
+      objectives: yaml.description.objectives,
+      hints: yaml.description.hints ?? [],
+      prerequisites: yaml.description.prerequisites,
+      estimatedTime: yaml.description.estimatedTime,
+    },
+    deployment: {
+      providers: yaml.deployment.providers as CloudProvider[],
+      templates: yaml.deployment.templates,
+      regions: yaml.deployment.regions ?? {},
+      timeout: yaml.deployment.timeout,
+    },
+    scoring: {
+      type: yaml.scoring.type as 'lambda' | 'container' | 'api' | 'manual',
+      path: yaml.scoring.path,
+      criteria: yaml.scoring.criteria,
+      timeoutMinutes: yaml.scoring.timeoutMinutes,
+      intervalMinutes: yaml.scoring.intervalMinutes,
+    },
+    resources: yaml.resources,
+  };
+}
+
+/**
+ * ファイル拡張子からフォーマットを推測
+ */
+export function detectFormat(filename: string): ExternalFormat | null {
+  const ext = filename.toLowerCase().split('.').pop();
+  switch (ext) {
+    case 'yaml':
+    case 'yml':
+      return 'tenkacloud-yaml';
+    case 'json':
+      return 'tenkacloud-json';
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- 問題データの YAML/JSON 形式インポート・エクスポート機能を実装
- Admin API にエクスポート・インポートプレビューエンドポイントを追加
- converter モジュールのテストを追加（18件）

## Changes
- `src/problems/converter.ts`: YAML/JSON 変換ロジック
- `src/__tests__/converter.test.ts`: 変換機能のテスト
- `src/routes/admin.ts`: エクスポート・インポートAPI追加

## Test plan
- [x] `bun run test` - 全557テスト通過
- [x] `bun run typecheck` - 型エラーなし
- [x] `make before-commit` - 全チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Problem import and export now available in YAML and JSON formats with automatic format detection
  * Enhanced validation for event business rules and task submission states

* **Tests**
  * Expanded test coverage for problem conversions, validations, and answer verification scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->