### PR TITLE
feat(scoring-service): 採点サービスを実装

### DIFF
--- a/backend/services/application-plane/scoring-service/bun.lock
+++ b/backend/services/application-plane/scoring-service/bun.lock
@@ -1,0 +1,614 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@tenkacloud/scoring-service",
+      "dependencies": {
+        "@hono/node-server": "^1.13.7",
+        "@prisma/client": "^6.0.0",
+        "hono": "^4.6.12",
+        "jose": "^6.0.10",
+        "pino": "^10.1.0",
+        "pino-pretty": "^13.1.2",
+        "zod": "^3.23.8",
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@vitest/coverage-v8": "2.1.9",
+        "eslint": "^9.0.0",
+        "prisma": "^6.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.1.0",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@prisma/client": ["@prisma/client@6.19.1", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A=="],
+
+    "@prisma/config": ["@prisma/config@6.19.1", "", { "dependencies": { "c12": "3.1.0", "deepmerge-ts": "7.1.5", "effect": "3.18.4", "empathic": "2.0.0" } }, "sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw=="],
+
+    "@prisma/debug": ["@prisma/debug@6.19.1", "", {}, "sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw=="],
+
+    "@prisma/engines": ["@prisma/engines@6.19.1", "", { "dependencies": { "@prisma/debug": "6.19.1", "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7", "@prisma/fetch-engine": "6.19.1", "@prisma/get-platform": "6.19.1" } }, "sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw=="],
+
+    "@prisma/engines-version": ["@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7", "", {}, "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA=="],
+
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@6.19.1", "", { "dependencies": { "@prisma/debug": "6.19.1", "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7", "@prisma/get-platform": "6.19.1" } }, "sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g=="],
+
+    "@prisma/get-platform": ["@prisma/get-platform@6.19.1", "", { "dependencies": { "@prisma/debug": "6.19.1" } }, "sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.3", "", { "os": "android", "cpu": "arm" }, "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.53.3", "", { "os": "android", "cpu": "arm64" }, "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.53.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.53.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.53.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.53.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.53.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.53.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@2.1.9", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^0.2.3", "debug": "^4.3.7", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.12", "magicast": "^0.3.5", "std-env": "^3.8.0", "test-exclude": "^7.0.1", "tinyrainbow": "^1.2.0" }, "peerDependencies": { "@vitest/browser": "2.1.9", "vitest": "2.1.9" }, "optionalPeers": ["@vitest/browser"] }, "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "check-error": ["check-error@2.1.1", "", {}, "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "deepmerge-ts": ["deepmerge-ts@7.1.5", "", {}, "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "effect": ["effect@3.18.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "fast-copy": ["fast-copy@4.0.1", "", {}, "sha512-+uUOQlhsaswsizHFmEFAQhB3lSiQ+lisxl50N6ZP0wywlZeWsIESxSi9ftPEps8UGfiBzyYP7x27zA674WUvXw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "hono": ["hono@4.11.0", "", {}, "sha512-Jg8uZzN2ul8/qlyid5FO8O624F3AK0wKtkgoeEON1qBum1rM1itYBxoMKu/1SPJC7F1+xlIZsJMmc4HHhJ1AWg=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "nypm": ["nypm@0.6.2", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.2", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "tinyexec": "^1.0.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pino": ["pino@10.1.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
+    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prisma": ["prisma@6.19.1", "", { "dependencies": { "@prisma/config": "6.19.1", "@prisma/engines": "6.19.1" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "test-exclude": ["test-exclude@7.0.1", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^9.0.4" } }, "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "c12/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "giget/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "nypm/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "nypm/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "test-exclude/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+  }
+}

--- a/backend/services/application-plane/scoring-service/package.json
+++ b/backend/services/application-plane/scoring-service/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@tenkacloud/scoring-service",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "bunx prisma generate && bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist --target node",
+    "start": "bun run dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@prisma/client": "^6.0.0",
+    "hono": "^4.6.12",
+    "jose": "^6.0.10",
+    "pino": "^10.1.0",
+    "pino-pretty": "^13.1.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@vitest/coverage-v8": "2.1.9",
+    "eslint": "^9.0.0",
+    "prisma": "^6.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/backend/services/application-plane/scoring-service/prisma/schema.prisma
+++ b/backend/services/application-plane/scoring-service/prisma/schema.prisma
@@ -1,0 +1,152 @@
+// 採点サービス用 Prisma スキーマ
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// 評価カテゴリ
+enum EvaluationCategory {
+  INFRASTRUCTURE // インフラ構成
+  COST           // コスト最適化
+  SECURITY       // セキュリティ
+  PERFORMANCE    // パフォーマンス
+  RELIABILITY    // 信頼性
+}
+
+// 重要度
+enum Severity {
+  CRITICAL // 致命的
+  HIGH     // 高
+  MEDIUM   // 中
+  LOW      // 低
+  INFO     // 情報
+}
+
+// 評価ステータス
+enum EvaluationStatus {
+  PENDING     // 評価待ち
+  IN_PROGRESS // 評価中
+  COMPLETED   // 完了
+  FAILED      // 失敗
+}
+
+// 評価基準
+model EvaluationCriteria {
+  id          String             @id @default(uuid())
+  tenantId    String             @map("tenant_id")
+  name        String
+  description String?
+  category    EvaluationCategory
+  weight      Int                @default(1) // 重み付け（1-10）
+  maxScore    Int                @default(100) @map("max_score")
+  isActive    Boolean            @default(true) @map("is_active")
+  createdAt   DateTime           @default(now()) @map("created_at")
+  updatedAt   DateTime           @updatedAt @map("updated_at")
+
+  criteriaDetails CriteriaDetail[]
+  evaluationItems EvaluationItem[]
+
+  @@unique([tenantId, name])
+  @@index([tenantId])
+  @@index([category])
+  @@map("evaluation_criteria")
+}
+
+// 評価基準の詳細ルール
+model CriteriaDetail {
+  id           String   @id @default(uuid())
+  criteriaId   String   @map("criteria_id")
+  ruleKey      String   @map("rule_key")   // 例: "vpc_exists", "s3_encryption"
+  ruleValue    String   @map("rule_value") // 期待値
+  points       Int      // この項目の得点
+  severity     Severity @default(MEDIUM)
+  description  String?
+
+  criteria EvaluationCriteria @relation(fields: [criteriaId], references: [id], onDelete: Cascade)
+
+  @@unique([criteriaId, ruleKey])
+  @@index([criteriaId])
+  @@map("criteria_details")
+}
+
+// 採点セッション
+model ScoringSession {
+  id          String           @id @default(uuid())
+  tenantId    String           @map("tenant_id")
+  battleId    String?          @map("battle_id")
+  participantId String         @map("participant_id")
+  status      EvaluationStatus @default(PENDING)
+  totalScore  Int              @default(0) @map("total_score")
+  maxPossibleScore Int         @default(0) @map("max_possible_score")
+  submittedAt DateTime?        @map("submitted_at")
+  evaluatedAt DateTime?        @map("evaluated_at")
+  createdAt   DateTime         @default(now()) @map("created_at")
+  updatedAt   DateTime         @updatedAt @map("updated_at")
+
+  evaluationItems EvaluationItem[]
+  feedbacks       Feedback[]
+
+  @@index([tenantId])
+  @@index([battleId])
+  @@index([participantId])
+  @@index([status])
+  @@map("scoring_sessions")
+}
+
+// 評価項目ごとの結果
+model EvaluationItem {
+  id            String   @id @default(uuid())
+  sessionId     String   @map("session_id")
+  criteriaId    String   @map("criteria_id")
+  score         Int      @default(0)
+  maxScore      Int      @map("max_score")
+  passed        Boolean  @default(false)
+  actualValue   String?  @map("actual_value")
+  expectedValue String?  @map("expected_value")
+  details       Json?    // 詳細な評価結果
+
+  session  ScoringSession     @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  criteria EvaluationCriteria @relation(fields: [criteriaId], references: [id])
+
+  @@unique([sessionId, criteriaId])
+  @@index([sessionId])
+  @@map("evaluation_items")
+}
+
+// フィードバック
+model Feedback {
+  id          String             @id @default(uuid())
+  sessionId   String             @map("session_id")
+  category    EvaluationCategory
+  severity    Severity
+  title       String
+  message     String
+  suggestion  String?            // 改善提案
+  resourceRef String?            @map("resource_ref") // 該当リソースの参照
+  createdAt   DateTime           @default(now()) @map("created_at")
+
+  session ScoringSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  @@index([sessionId])
+  @@index([category])
+  @@index([severity])
+  @@map("feedbacks")
+}
+
+// Terraform State スナップショット
+model TerraformSnapshot {
+  id            String   @id @default(uuid())
+  sessionId     String   @unique @map("session_id")
+  stateVersion  Int      @map("state_version")
+  resourceCount Int      @map("resource_count")
+  stateData     Json     @map("state_data")
+  parsedAt      DateTime @default(now()) @map("parsed_at")
+
+  @@index([sessionId])
+  @@map("terraform_snapshots")
+}

--- a/backend/services/application-plane/scoring-service/src/api/health.test.ts
+++ b/backend/services/application-plane/scoring-service/src/api/health.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { healthRoutes } from './health';
+
+describe('ヘルスチェック API', () => {
+  it('GET /health でサービス稼働状況を返すべき', async () => {
+    const res = await healthRoutes.request('/health');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok', service: 'scoring-service' });
+  });
+
+  it('GET /ready でレディネス状態を返すべき', async () => {
+    const res = await healthRoutes.request('/ready');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ready' });
+  });
+});

--- a/backend/services/application-plane/scoring-service/src/api/health.ts
+++ b/backend/services/application-plane/scoring-service/src/api/health.ts
@@ -1,0 +1,11 @@
+import { Hono } from 'hono';
+
+export const healthRoutes = new Hono();
+
+healthRoutes.get('/health', (c) => {
+  return c.json({ status: 'ok', service: 'scoring-service' });
+});
+
+healthRoutes.get('/ready', async (c) => {
+  return c.json({ status: 'ready' });
+});

--- a/backend/services/application-plane/scoring-service/src/api/scoring.test.ts
+++ b/backend/services/application-plane/scoring-service/src/api/scoring.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { scoringRoutes } from './scoring';
+import * as scoringService from '../services/scoring';
+import { EvaluationCategory, EvaluationStatus, Severity } from '@prisma/client';
+
+vi.mock('../services/scoring');
+
+// テスト用のモック認証コンテキスト
+const mockAuthMiddleware = vi.fn((c, next) => {
+  c.set('auth', {
+    userId: 'user-123',
+    tenantId: 'tenant-456',
+    roles: ['user'],
+  });
+  return next();
+});
+
+describe('採点 API', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.use('/*', mockAuthMiddleware);
+    app.route('/', scoringRoutes);
+  });
+
+  describe('評価基準 API', () => {
+    describe('POST /criteria', () => {
+      it('評価基準を作成できるべき', async () => {
+        const mockCriteria = {
+          id: 'criteria-1',
+          tenantId: 'tenant-456',
+          name: 'VPC構成チェック',
+          category: EvaluationCategory.INFRASTRUCTURE,
+        };
+
+        vi.mocked(scoringService.createEvaluationCriteria).mockResolvedValue(
+          mockCriteria as never
+        );
+
+        const res = await app.request('/criteria', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'VPC構成チェック',
+            category: 'INFRASTRUCTURE',
+          }),
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.id).toBe('criteria-1');
+      });
+
+      it('名前が空の場合は400を返すべき', async () => {
+        const res = await app.request('/criteria', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: '',
+            category: 'INFRASTRUCTURE',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe('GET /criteria', () => {
+      it('評価基準一覧を取得できるべき', async () => {
+        const mockResult = {
+          data: [{ id: 'criteria-1', name: 'VPC構成' }],
+          total: 1,
+          page: 1,
+          limit: 10,
+        };
+
+        vi.mocked(scoringService.listEvaluationCriteria).mockResolvedValue(
+          mockResult as never
+        );
+
+        const res = await app.request('/criteria?page=1&limit=10');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(1);
+        expect(body.total).toBe(1);
+      });
+    });
+
+    describe('GET /criteria/:id', () => {
+      it('評価基準を取得できるべき', async () => {
+        const mockCriteria = {
+          id: 'criteria-1',
+          tenantId: 'tenant-456',
+          name: 'VPC構成チェック',
+        };
+
+        vi.mocked(scoringService.getEvaluationCriteria).mockResolvedValue(
+          mockCriteria as never
+        );
+
+        const res = await app.request('/criteria/criteria-1');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('criteria-1');
+      });
+
+      it('存在しない評価基準は404を返すべき', async () => {
+        vi.mocked(scoringService.getEvaluationCriteria).mockResolvedValue(null);
+
+        const res = await app.request('/criteria/nonexistent');
+
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('PUT /criteria/:id', () => {
+      it('評価基準を更新できるべき', async () => {
+        const mockCriteria = {
+          id: 'criteria-1',
+          name: 'Updated Name',
+        };
+
+        vi.mocked(scoringService.updateEvaluationCriteria).mockResolvedValue(
+          mockCriteria as never
+        );
+
+        const res = await app.request('/criteria/criteria-1', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Updated Name' }),
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.name).toBe('Updated Name');
+      });
+
+      it('存在しない評価基準の更新は404を返すべき', async () => {
+        vi.mocked(scoringService.updateEvaluationCriteria).mockResolvedValue(
+          null
+        );
+
+        const res = await app.request('/criteria/nonexistent', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Updated Name' }),
+        });
+
+        expect(res.status).toBe(404);
+      });
+
+      it('無効な更新データの場合は400を返すべき', async () => {
+        const res = await app.request('/criteria/criteria-1', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ weight: 'invalid' }),
+        });
+
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe('DELETE /criteria/:id', () => {
+      it('評価基準を削除できるべき', async () => {
+        vi.mocked(scoringService.deleteEvaluationCriteria).mockResolvedValue(
+          undefined
+        );
+
+        const res = await app.request('/criteria/criteria-1', {
+          method: 'DELETE',
+        });
+
+        expect(res.status).toBe(204);
+      });
+    });
+  });
+
+  describe('採点セッション API', () => {
+    describe('POST /sessions', () => {
+      it('採点セッションを作成できるべき', async () => {
+        const mockSession = {
+          id: 'session-1',
+          tenantId: 'tenant-456',
+          participantId: 'participant-789',
+          status: EvaluationStatus.PENDING,
+        };
+
+        vi.mocked(scoringService.createScoringSession).mockResolvedValue(
+          mockSession as never
+        );
+
+        const res = await app.request('/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            participantId: 'participant-789',
+            battleId: 'battle-123',
+          }),
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.id).toBe('session-1');
+      });
+
+      it('参加者IDがない場合は400を返すべき', async () => {
+        const res = await app.request('/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('参加者IDが空の場合は400を返すべき', async () => {
+        const res = await app.request('/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId: '' }),
+        });
+
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe('GET /sessions', () => {
+      it('採点セッション一覧を取得できるべき', async () => {
+        const mockResult = {
+          data: [{ id: 'session-1', status: EvaluationStatus.PENDING }],
+          total: 1,
+          page: 1,
+          limit: 10,
+        };
+
+        vi.mocked(scoringService.listScoringSessions).mockResolvedValue(
+          mockResult as never
+        );
+
+        const res = await app.request('/sessions?page=1&limit=10');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(1);
+      });
+    });
+
+    describe('GET /sessions/:id', () => {
+      it('採点セッションを取得できるべき', async () => {
+        const mockSession = {
+          id: 'session-1',
+          tenantId: 'tenant-456',
+          status: EvaluationStatus.COMPLETED,
+        };
+
+        vi.mocked(scoringService.getScoringSession).mockResolvedValue(
+          mockSession as never
+        );
+
+        const res = await app.request('/sessions/session-1');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('session-1');
+      });
+
+      it('存在しないセッションは404を返すべき', async () => {
+        vi.mocked(scoringService.getScoringSession).mockResolvedValue(null);
+
+        const res = await app.request('/sessions/nonexistent');
+
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('POST /sessions/:id/submit', () => {
+      it('Terraform Stateを提出できるべき', async () => {
+        const mockSession = {
+          id: 'session-1',
+          status: EvaluationStatus.IN_PROGRESS,
+        };
+
+        vi.mocked(scoringService.submitForEvaluation).mockResolvedValue(
+          mockSession as never
+        );
+
+        const res = await app.request('/sessions/session-1/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            terraformState: { version: 4, resources: [] },
+          }),
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.status).toBe(EvaluationStatus.IN_PROGRESS);
+      });
+
+      it('terraformStateがない場合は400を返すべき', async () => {
+        const res = await app.request('/sessions/session-1/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('terraformState.versionがない場合は400を返すべき', async () => {
+        const res = await app.request('/sessions/session-1/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ terraformState: {} }),
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('存在しないセッションへの提出は404を返すべき', async () => {
+        vi.mocked(scoringService.submitForEvaluation).mockResolvedValue(null);
+
+        const res = await app.request('/sessions/nonexistent/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            terraformState: { version: 4, resources: [] },
+          }),
+        });
+
+        expect(res.status).toBe(404);
+      });
+
+      it('提出条件を満たさない場合は400を返すべき', async () => {
+        vi.mocked(scoringService.submitForEvaluation).mockRejectedValue(
+          new Error('評価待ちのセッションのみ提出できます')
+        );
+
+        const res = await app.request('/sessions/session-1/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            terraformState: { version: 4, resources: [] },
+          }),
+        });
+
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe('POST /sessions/:id/evaluate', () => {
+      it('採点を実行できるべき', async () => {
+        const mockSession = {
+          id: 'session-1',
+          status: EvaluationStatus.COMPLETED,
+          totalScore: 85,
+        };
+
+        vi.mocked(scoringService.evaluateSubmission).mockResolvedValue(
+          mockSession as never
+        );
+
+        const res = await app.request('/sessions/session-1/evaluate', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.totalScore).toBe(85);
+      });
+
+      it('評価条件を満たさない場合は400を返すべき', async () => {
+        vi.mocked(scoringService.evaluateSubmission).mockRejectedValue(
+          new Error('評価中のセッションのみ採点できます')
+        );
+
+        const res = await app.request('/sessions/session-1/evaluate', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('存在しないセッションの評価は404を返すべき', async () => {
+        vi.mocked(scoringService.evaluateSubmission).mockResolvedValue(null);
+
+        const res = await app.request('/sessions/nonexistent/evaluate', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(404);
+      });
+
+      it('Error以外の例外は再スローするべき', async () => {
+        vi.mocked(scoringService.evaluateSubmission).mockRejectedValue(
+          'string error'
+        );
+
+        await expect(
+          app.request('/sessions/session-1/evaluate', { method: 'POST' })
+        ).rejects.toBe('string error');
+      });
+    });
+
+    describe('POST /sessions/:id/submit', () => {
+      it('Error以外の例外は再スローするべき', async () => {
+        vi.mocked(scoringService.submitForEvaluation).mockRejectedValue(
+          'string error'
+        );
+
+        await expect(
+          app.request('/sessions/session-1/submit', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              terraformState: { version: 4, resources: [] },
+            }),
+          })
+        ).rejects.toBe('string error');
+      });
+    });
+
+    describe('GET /sessions/:id/feedback', () => {
+      it('フィードバックを取得できるべき', async () => {
+        const mockFeedbacks = [
+          {
+            id: 'fb-1',
+            category: EvaluationCategory.SECURITY,
+            severity: Severity.HIGH,
+            title: 'セキュリティグループが開放',
+          },
+        ];
+
+        vi.mocked(scoringService.getSessionFeedback).mockResolvedValue(
+          mockFeedbacks as never
+        );
+
+        const res = await app.request('/sessions/session-1/feedback');
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toHaveLength(1);
+        expect(body[0].severity).toBe(Severity.HIGH);
+      });
+
+      it('存在しないセッションのフィードバックは404を返すべき', async () => {
+        vi.mocked(scoringService.getSessionFeedback).mockResolvedValue(null);
+
+        const res = await app.request('/sessions/nonexistent/feedback');
+
+        expect(res.status).toBe(404);
+      });
+    });
+  });
+});

--- a/backend/services/application-plane/scoring-service/src/api/scoring.ts
+++ b/backend/services/application-plane/scoring-service/src/api/scoring.ts
@@ -1,0 +1,245 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { EvaluationCategory } from '@prisma/client';
+import * as scoringService from '../services/scoring';
+
+export const scoringRoutes = new Hono();
+
+// ========== バリデーションスキーマ ==========
+
+const createCriteriaSchema = z.object({
+  name: z.string().min(1, '名前は必須です'),
+  description: z.string().optional(),
+  category: z.nativeEnum(EvaluationCategory),
+  weight: z.number().int().min(1).max(10).optional(),
+  maxScore: z.number().int().min(1).optional(),
+});
+
+const updateCriteriaSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  category: z.nativeEnum(EvaluationCategory).optional(),
+  weight: z.number().int().min(1).max(10).optional(),
+  maxScore: z.number().int().min(1).optional(),
+  isActive: z.boolean().optional(),
+});
+
+const createSessionSchema = z.object({
+  participantId: z.string().min(1, '参加者IDは必須です'),
+  battleId: z.string().optional(),
+});
+
+const submitSchema = z.object({
+  terraformState: z.object({
+    version: z.number(),
+    resources: z.array(z.any()).optional(),
+  }),
+});
+
+const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+});
+
+// ========== 評価基準 API ==========
+
+// POST /criteria - 評価基準作成
+scoringRoutes.post('/criteria', async (c) => {
+  const auth = c.get('auth');
+  const body = await c.req.json();
+
+  const parsed = createCriteriaSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.errors[0].message }, 400);
+  }
+
+  const criteria = await scoringService.createEvaluationCriteria({
+    tenantId: auth.tenantId,
+    ...parsed.data,
+  });
+
+  return c.json(criteria, 201);
+});
+
+// GET /criteria - 評価基準一覧取得
+scoringRoutes.get('/criteria', async (c) => {
+  const auth = c.get('auth');
+  const query = c.req.query();
+
+  const pagination = paginationSchema.parse(query);
+  const category = query.category as EvaluationCategory | undefined;
+
+  const result = await scoringService.listEvaluationCriteria(auth.tenantId, {
+    ...pagination,
+    category,
+  });
+
+  return c.json(result);
+});
+
+// GET /criteria/:id - 評価基準取得
+scoringRoutes.get('/criteria/:id', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+
+  const criteria = await scoringService.getEvaluationCriteria(
+    id,
+    auth.tenantId
+  );
+
+  if (!criteria) {
+    return c.json({ error: '評価基準が見つかりません' }, 404);
+  }
+
+  return c.json(criteria);
+});
+
+// PUT /criteria/:id - 評価基準更新
+scoringRoutes.put('/criteria/:id', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  const body = await c.req.json();
+
+  const parsed = updateCriteriaSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.errors[0].message }, 400);
+  }
+
+  const criteria = await scoringService.updateEvaluationCriteria(
+    id,
+    auth.tenantId,
+    parsed.data
+  );
+
+  if (!criteria) {
+    return c.json({ error: '評価基準が見つかりません' }, 404);
+  }
+
+  return c.json(criteria);
+});
+
+// DELETE /criteria/:id - 評価基準削除
+scoringRoutes.delete('/criteria/:id', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+
+  await scoringService.deleteEvaluationCriteria(id, auth.tenantId);
+
+  return c.body(null, 204);
+});
+
+// ========== 採点セッション API ==========
+
+// POST /sessions - セッション作成
+scoringRoutes.post('/sessions', async (c) => {
+  const auth = c.get('auth');
+  const body = await c.req.json();
+
+  const parsed = createSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.errors[0].message }, 400);
+  }
+
+  const session = await scoringService.createScoringSession({
+    tenantId: auth.tenantId,
+    ...parsed.data,
+  });
+
+  return c.json(session, 201);
+});
+
+// GET /sessions - セッション一覧取得
+scoringRoutes.get('/sessions', async (c) => {
+  const auth = c.get('auth');
+  const query = c.req.query();
+
+  const pagination = paginationSchema.parse(query);
+
+  const result = await scoringService.listScoringSessions(auth.tenantId, {
+    ...pagination,
+    battleId: query.battleId,
+    participantId: query.participantId,
+  });
+
+  return c.json(result);
+});
+
+// GET /sessions/:id - セッション取得
+scoringRoutes.get('/sessions/:id', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+
+  const session = await scoringService.getScoringSession(id, auth.tenantId);
+
+  if (!session) {
+    return c.json({ error: 'セッションが見つかりません' }, 404);
+  }
+
+  return c.json(session);
+});
+
+// POST /sessions/:id/submit - Terraform State 提出
+scoringRoutes.post('/sessions/:id/submit', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+  const body = await c.req.json();
+
+  const parsed = submitSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.errors[0].message }, 400);
+  }
+
+  try {
+    const session = await scoringService.submitForEvaluation(
+      id,
+      auth.tenantId,
+      parsed.data.terraformState
+    );
+
+    if (!session) {
+      return c.json({ error: 'セッションが見つかりません' }, 404);
+    }
+
+    return c.json(session);
+  } catch (error) {
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 400);
+    }
+    throw error;
+  }
+});
+
+// POST /sessions/:id/evaluate - 採点実行
+scoringRoutes.post('/sessions/:id/evaluate', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+
+  try {
+    const session = await scoringService.evaluateSubmission(id, auth.tenantId);
+
+    if (!session) {
+      return c.json({ error: 'セッションが見つかりません' }, 404);
+    }
+
+    return c.json(session);
+  } catch (error) {
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 400);
+    }
+    throw error;
+  }
+});
+
+// GET /sessions/:id/feedback - フィードバック取得
+scoringRoutes.get('/sessions/:id/feedback', async (c) => {
+  const auth = c.get('auth');
+  const id = c.req.param('id');
+
+  const feedbacks = await scoringService.getSessionFeedback(id, auth.tenantId);
+
+  if (feedbacks === null) {
+    return c.json({ error: 'セッションが見つかりません' }, 404);
+  }
+
+  return c.json(feedbacks);
+});

--- a/backend/services/application-plane/scoring-service/src/index.ts
+++ b/backend/services/application-plane/scoring-service/src/index.ts
@@ -1,0 +1,69 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { createLogger } from './lib/logger';
+import { healthRoutes } from './api/health';
+import { scoringRoutes } from './api/scoring';
+import { authMiddleware } from './middleware/auth';
+
+const logger = createLogger('scoring-service');
+const app = new Hono();
+
+// CORS設定
+app.use(
+  '/*',
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'],
+    credentials: true,
+  })
+);
+
+// 採点ルートに認証を適用
+app.use('/criteria/*', authMiddleware);
+app.use('/sessions/*', authMiddleware);
+
+// ルート登録
+app.route('/', healthRoutes);
+app.route('/', scoringRoutes);
+
+// PORT バリデーション
+const parsePort = (value: string | undefined): number => {
+  const defaultPort = 3011;
+  if (!value) return defaultPort;
+
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+    logger.warn(
+      { providedValue: value },
+      `無効な PORT 値です。デフォルト (${defaultPort}) を使用します`
+    );
+    return defaultPort;
+  }
+  return parsed;
+};
+
+const port = parsePort(process.env.PORT);
+
+const server = serve(
+  {
+    fetch: app.fetch,
+    port,
+  },
+  (info) => {
+    logger.info({ port: info.port }, '採点サービスが起動しました');
+  }
+);
+
+// グレースフルシャットダウン
+const shutdown = () => {
+  logger.info('シャットダウンを開始します');
+  server.close(() => {
+    logger.info('サーバーを停止しました');
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+export { app };

--- a/backend/services/application-plane/scoring-service/src/lib/logger.ts
+++ b/backend/services/application-plane/scoring-service/src/lib/logger.ts
@@ -1,0 +1,17 @@
+import pino from 'pino';
+
+export function createLogger(name: string) {
+  return pino({
+    name,
+    level: process.env.LOG_LEVEL ?? 'info',
+    transport:
+      process.env.NODE_ENV !== 'production'
+        ? {
+            target: 'pino-pretty',
+            options: {
+              colorize: true,
+            },
+          }
+        : undefined,
+  });
+}

--- a/backend/services/application-plane/scoring-service/src/lib/prisma.ts
+++ b/backend/services/application-plane/scoring-service/src/lib/prisma.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
+        : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/backend/services/application-plane/scoring-service/src/middleware/auth.test.ts
+++ b/backend/services/application-plane/scoring-service/src/middleware/auth.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { authMiddleware } from './auth';
+import * as jose from 'jose';
+
+vi.mock('jose', async () => {
+  const actual = await vi.importActual('jose');
+  return {
+    ...actual,
+    createRemoteJWKSet: vi.fn(),
+    jwtVerify: vi.fn(),
+    errors: {
+      JWTExpired: class JWTExpired extends Error {},
+      JWTClaimValidationFailed: class JWTClaimValidationFailed extends Error {},
+    },
+  };
+});
+
+describe('認証ミドルウェア', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json({ auth: c.get('auth') }));
+  });
+
+  it('有効なトークンで認証が成功するべき', async () => {
+    const mockPayload = {
+      sub: 'user-123',
+      tenant_id: 'tenant-456',
+      realm_access: { roles: ['user'] },
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth).toEqual({
+      userId: 'user-123',
+      tenantId: 'tenant-456',
+      roles: ['user'],
+    });
+  });
+
+  it('Authorizationヘッダーがない場合は401を返すべき', async () => {
+    const res = await app.request('/test');
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('認証が必要です');
+  });
+
+  it('Bearerトークンでない場合は401を返すべき', async () => {
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Basic abc123' },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('認証が必要です');
+  });
+
+  it('テナントIDがない場合は403を返すべき', async () => {
+    const mockPayload = {
+      sub: 'user-123',
+      realm_access: { roles: ['user'] },
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('テナント情報がありません');
+  });
+
+  it('期限切れトークンの場合は401を返すべき', async () => {
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockRejectedValue(
+      new jose.errors.JWTExpired('expired')
+    );
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer expired-token' },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('トークンの有効期限が切れています');
+  });
+
+  it('無効なトークンの場合は401を返すべき', async () => {
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockRejectedValue(
+      new jose.errors.JWTClaimValidationFailed('invalid')
+    );
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer invalid-token' },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('トークンの検証に失敗しました');
+  });
+
+  it('その他のエラーの場合は401を返すべき', async () => {
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockRejectedValue(new Error('unknown error'));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer bad-token' },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('認証に失敗しました');
+  });
+
+  it('subがundefinedの場合は空文字をuserIdとするべき', async () => {
+    const mockPayload = {
+      tenant_id: 'tenant-456',
+      realm_access: { roles: ['user'] },
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.userId).toBe('');
+    expect(body.auth.tenantId).toBe('tenant-456');
+  });
+
+  it('realm_accessがない場合は空配列をrolesとするべき', async () => {
+    const mockPayload = {
+      sub: 'user-123',
+      tenant_id: 'tenant-456',
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.roles).toEqual([]);
+  });
+
+  it('realm_accessにrolesがない場合は空配列をrolesとするべき', async () => {
+    const mockPayload = {
+      sub: 'user-123',
+      tenant_id: 'tenant-456',
+      realm_access: {},
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.roles).toEqual([]);
+  });
+});

--- a/backend/services/application-plane/scoring-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/scoring-service/src/middleware/auth.ts
@@ -1,0 +1,74 @@
+import { createMiddleware } from 'hono/factory';
+import * as jose from 'jose';
+
+export interface AuthContext {
+  userId: string;
+  tenantId: string;
+  roles: string[];
+}
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    auth: AuthContext;
+  }
+}
+
+const JWKS_URI =
+  process.env.JWKS_URI ??
+  'http://localhost:8080/realms/tenkacloud/protocol/openid-connect/certs';
+const ISSUER =
+  process.env.JWT_ISSUER ?? 'http://localhost:8080/realms/tenkacloud';
+
+let jwks: jose.JWTVerifyGetKey | null = null;
+
+async function getJWKS() {
+  if (!jwks) {
+    jwks = jose.createRemoteJWKSet(new URL(JWKS_URI));
+  }
+  return jwks;
+}
+
+export const authMiddleware = createMiddleware(async (c, next) => {
+  const authHeader = c.req.header('Authorization');
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: '認証が必要です' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const jwksSet = await getJWKS();
+    const { payload } = await jose.jwtVerify(token, jwksSet, {
+      issuer: ISSUER,
+    });
+
+    const tenantId = (payload as Record<string, unknown>)['tenant_id'] as
+      | string
+      | undefined;
+    if (!tenantId) {
+      return c.json({ error: 'テナント情報がありません' }, 403);
+    }
+
+    c.set('auth', {
+      userId: payload.sub ?? '',
+      tenantId,
+      roles:
+        (
+          (payload as Record<string, unknown>)['realm_access'] as {
+            roles?: string[];
+          }
+        )?.roles ?? [],
+    });
+
+    await next();
+  } catch (error) {
+    if (error instanceof jose.errors.JWTExpired) {
+      return c.json({ error: 'トークンの有効期限が切れています' }, 401);
+    }
+    if (error instanceof jose.errors.JWTClaimValidationFailed) {
+      return c.json({ error: 'トークンの検証に失敗しました' }, 401);
+    }
+    return c.json({ error: '認証に失敗しました' }, 401);
+  }
+});

--- a/backend/services/application-plane/scoring-service/src/services/scoring.test.ts
+++ b/backend/services/application-plane/scoring-service/src/services/scoring.test.ts
@@ -1,0 +1,1313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createEvaluationCriteria,
+  getEvaluationCriteria,
+  listEvaluationCriteria,
+  updateEvaluationCriteria,
+  deleteEvaluationCriteria,
+  createScoringSession,
+  getScoringSession,
+  listScoringSessions,
+  submitForEvaluation,
+  evaluateSubmission,
+  getSessionFeedback,
+  checkRule,
+  checkResourceExists,
+  checkResourceAttribute,
+  checkS3Encryption,
+  checkSecurityGroupSSH,
+  generateSuggestion,
+  evaluateTerraformState,
+  evaluateCriterion,
+} from './scoring';
+import { prisma } from '../lib/prisma';
+import { EvaluationCategory, EvaluationStatus, Severity } from '@prisma/client';
+
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    evaluationCriteria: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    criteriaDetail: {
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    scoringSession: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+    evaluationItem: {
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+    feedback: {
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+    terraformSnapshot: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn((callback) => callback(prisma)),
+  },
+}));
+
+describe('評価基準管理', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createEvaluationCriteria', () => {
+    it('評価基準を作成できるべき', async () => {
+      const input = {
+        tenantId: 'tenant-123',
+        name: 'VPC構成チェック',
+        description: 'VPCが正しく構成されているか確認',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        weight: 5,
+        maxScore: 100,
+      };
+
+      const mockCriteria = {
+        id: 'criteria-1',
+        ...input,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(prisma.evaluationCriteria.create).mockResolvedValue(
+        mockCriteria as never
+      );
+
+      const result = await createEvaluationCriteria(input);
+
+      expect(result).toEqual(mockCriteria);
+      expect(prisma.evaluationCriteria.create).toHaveBeenCalledWith({
+        data: input,
+      });
+    });
+  });
+
+  describe('getEvaluationCriteria', () => {
+    it('評価基準を取得できるべき', async () => {
+      const mockCriteria = {
+        id: 'criteria-1',
+        tenantId: 'tenant-123',
+        name: 'VPC構成チェック',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        criteriaDetails: [],
+      };
+
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(
+        mockCriteria as never
+      );
+
+      const result = await getEvaluationCriteria('criteria-1', 'tenant-123');
+
+      expect(result).toEqual(mockCriteria);
+    });
+
+    it('異なるテナントの評価基準はnullを返すべき', async () => {
+      const mockCriteria = {
+        id: 'criteria-1',
+        tenantId: 'tenant-other',
+        name: 'VPC構成チェック',
+      };
+
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(
+        mockCriteria as never
+      );
+
+      const result = await getEvaluationCriteria('criteria-1', 'tenant-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listEvaluationCriteria', () => {
+    it('評価基準一覧を取得できるべき', async () => {
+      const mockCriteria = [
+        { id: 'criteria-1', name: 'VPC構成' },
+        { id: 'criteria-2', name: 'セキュリティ' },
+      ];
+
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue(
+        mockCriteria as never
+      );
+      vi.mocked(prisma.evaluationCriteria.count).mockResolvedValue(2);
+
+      const result = await listEvaluationCriteria('tenant-123', {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.data).toEqual(mockCriteria);
+      expect(result.total).toBe(2);
+    });
+
+    it('カテゴリでフィルタリングできるべき', async () => {
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.evaluationCriteria.count).mockResolvedValue(0);
+
+      await listEvaluationCriteria('tenant-123', {
+        page: 1,
+        limit: 10,
+        category: EvaluationCategory.SECURITY,
+      });
+
+      expect(prisma.evaluationCriteria.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            category: EvaluationCategory.SECURITY,
+          }),
+        })
+      );
+    });
+
+    it('isActiveでフィルタリングできるべき', async () => {
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.evaluationCriteria.count).mockResolvedValue(0);
+
+      await listEvaluationCriteria('tenant-123', {
+        page: 1,
+        limit: 10,
+        isActive: true,
+      });
+
+      expect(prisma.evaluationCriteria.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            isActive: true,
+          }),
+        })
+      );
+    });
+
+    it('isActiveがfalseの場合もフィルタリングできるべき', async () => {
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.evaluationCriteria.count).mockResolvedValue(0);
+
+      await listEvaluationCriteria('tenant-123', {
+        page: 1,
+        limit: 10,
+        isActive: false,
+      });
+
+      expect(prisma.evaluationCriteria.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            isActive: false,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('updateEvaluationCriteria', () => {
+    it('評価基準を更新できるべき', async () => {
+      const existingCriteria = {
+        id: 'criteria-1',
+        tenantId: 'tenant-123',
+        name: 'Old Name',
+      };
+
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(
+        existingCriteria as never
+      );
+      vi.mocked(prisma.evaluationCriteria.update).mockResolvedValue({
+        ...existingCriteria,
+        name: 'New Name',
+      } as never);
+
+      const result = await updateEvaluationCriteria(
+        'criteria-1',
+        'tenant-123',
+        { name: 'New Name' }
+      );
+
+      expect(result?.name).toBe('New Name');
+    });
+
+    it('存在しない評価基準の更新はnullを返すべき', async () => {
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(null);
+
+      const result = await updateEvaluationCriteria(
+        'nonexistent',
+        'tenant-123',
+        { name: 'New Name' }
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteEvaluationCriteria', () => {
+    it('評価基準を削除できるべき', async () => {
+      const existingCriteria = {
+        id: 'criteria-1',
+        tenantId: 'tenant-123',
+      };
+
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(
+        existingCriteria as never
+      );
+      vi.mocked(prisma.evaluationCriteria.delete).mockResolvedValue(
+        existingCriteria as never
+      );
+
+      await deleteEvaluationCriteria('criteria-1', 'tenant-123');
+
+      expect(prisma.evaluationCriteria.delete).toHaveBeenCalledWith({
+        where: { id: 'criteria-1' },
+      });
+    });
+
+    it('異なるテナントの評価基準は削除しないべき', async () => {
+      const existingCriteria = {
+        id: 'criteria-1',
+        tenantId: 'tenant-other',
+      };
+
+      vi.mocked(prisma.evaluationCriteria.findUnique).mockResolvedValue(
+        existingCriteria as never
+      );
+
+      await deleteEvaluationCriteria('criteria-1', 'tenant-123');
+
+      expect(prisma.evaluationCriteria.delete).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('採点セッション管理', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createScoringSession', () => {
+    it('採点セッションを作成できるべき', async () => {
+      const input = {
+        tenantId: 'tenant-123',
+        battleId: 'battle-456',
+        participantId: 'participant-789',
+      };
+
+      const mockSession = {
+        id: 'session-1',
+        ...input,
+        status: EvaluationStatus.PENDING,
+        totalScore: 0,
+        maxPossibleScore: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      vi.mocked(prisma.scoringSession.create).mockResolvedValue(
+        mockSession as never
+      );
+
+      const result = await createScoringSession(input);
+
+      expect(result).toEqual(mockSession);
+      expect(prisma.scoringSession.create).toHaveBeenCalledWith({
+        data: input,
+      });
+    });
+  });
+
+  describe('getScoringSession', () => {
+    it('採点セッションを取得できるべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.PENDING,
+        evaluationItems: [],
+        feedbacks: [],
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      const result = await getScoringSession('session-1', 'tenant-123');
+
+      expect(result).toEqual(mockSession);
+    });
+
+    it('異なるテナントのセッションはnullを返すべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-other',
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      const result = await getScoringSession('session-1', 'tenant-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listScoringSessions', () => {
+    it('採点セッション一覧を取得できるべき', async () => {
+      const mockSessions = [
+        { id: 'session-1', status: EvaluationStatus.PENDING },
+        { id: 'session-2', status: EvaluationStatus.COMPLETED },
+      ];
+
+      vi.mocked(prisma.scoringSession.findMany).mockResolvedValue(
+        mockSessions as never
+      );
+      vi.mocked(prisma.scoringSession.count).mockResolvedValue(2);
+
+      const result = await listScoringSessions('tenant-123', {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.data).toEqual(mockSessions);
+      expect(result.total).toBe(2);
+    });
+
+    it('バトルIDでフィルタリングできるべき', async () => {
+      vi.mocked(prisma.scoringSession.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.scoringSession.count).mockResolvedValue(0);
+
+      await listScoringSessions('tenant-123', {
+        page: 1,
+        limit: 10,
+        battleId: 'battle-456',
+      });
+
+      expect(prisma.scoringSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            battleId: 'battle-456',
+          }),
+        })
+      );
+    });
+
+    it('参加者IDでフィルタリングできるべき', async () => {
+      vi.mocked(prisma.scoringSession.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.scoringSession.count).mockResolvedValue(0);
+
+      await listScoringSessions('tenant-123', {
+        page: 1,
+        limit: 10,
+        participantId: 'participant-789',
+      });
+
+      expect(prisma.scoringSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            participantId: 'participant-789',
+          }),
+        })
+      );
+    });
+
+    it('ステータスでフィルタリングできるべき', async () => {
+      vi.mocked(prisma.scoringSession.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.scoringSession.count).mockResolvedValue(0);
+
+      await listScoringSessions('tenant-123', {
+        page: 1,
+        limit: 10,
+        status: EvaluationStatus.COMPLETED,
+      });
+
+      expect(prisma.scoringSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: EvaluationStatus.COMPLETED,
+          }),
+        })
+      );
+    });
+  });
+});
+
+describe('採点実行', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('submitForEvaluation', () => {
+    it('Terraform Stateを提出して評価を開始できるべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.PENDING,
+      };
+
+      const terraformState = {
+        version: 4,
+        resources: [
+          { type: 'aws_vpc', name: 'main' },
+          { type: 'aws_subnet', name: 'public' },
+        ],
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+      vi.mocked(prisma.scoringSession.update).mockResolvedValue({
+        ...mockSession,
+        status: EvaluationStatus.IN_PROGRESS,
+      } as never);
+      vi.mocked(prisma.terraformSnapshot.create).mockResolvedValue({
+        id: 'snapshot-1',
+      } as never);
+
+      const result = await submitForEvaluation(
+        'session-1',
+        'tenant-123',
+        terraformState
+      );
+
+      expect(result?.status).toBe(EvaluationStatus.IN_PROGRESS);
+      expect(prisma.terraformSnapshot.create).toHaveBeenCalled();
+    });
+
+    it('PENDING以外のセッションは提出できないべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.IN_PROGRESS,
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      await expect(
+        submitForEvaluation('session-1', 'tenant-123', { version: 4 })
+      ).rejects.toThrow('評価待ちのセッションのみ提出できます');
+    });
+
+    it('resourcesがないterraformStateでもresourceCount=0で保存するべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.PENDING,
+      };
+
+      const terraformState = { version: 4 };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+      vi.mocked(prisma.scoringSession.update).mockResolvedValue({
+        ...mockSession,
+        status: EvaluationStatus.IN_PROGRESS,
+      } as never);
+      vi.mocked(prisma.terraformSnapshot.create).mockResolvedValue({
+        id: 'snapshot-1',
+      } as never);
+
+      await submitForEvaluation('session-1', 'tenant-123', terraformState);
+
+      expect(prisma.terraformSnapshot.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          resourceCount: 0,
+        }),
+      });
+    });
+
+    it('セッションが見つからない場合はnullを返すべき', async () => {
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(null);
+
+      const result = await submitForEvaluation('nonexistent', 'tenant-123', {
+        version: 4,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('異なるテナントのセッションはnullを返すべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-other',
+        status: EvaluationStatus.PENDING,
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      const result = await submitForEvaluation('session-1', 'tenant-123', {
+        version: 4,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('evaluateSubmission', () => {
+    it('提出を評価してスコアを計算できるべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.IN_PROGRESS,
+      };
+
+      const mockCriteria = [
+        {
+          id: 'criteria-1',
+          name: 'VPC構成',
+          maxScore: 100,
+          weight: 1,
+          criteriaDetails: [
+            { ruleKey: 'vpc_exists', ruleValue: 'true', points: 50 },
+            { ruleKey: 'vpc_cidr', ruleValue: '10.0.0.0/16', points: 50 },
+          ],
+        },
+      ];
+
+      const mockSnapshot = {
+        stateData: {
+          resources: [
+            {
+              type: 'aws_vpc',
+              instances: [{ attributes: { cidr_block: '10.0.0.0/16' } }],
+            },
+          ],
+        },
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue({
+        ...mockSession,
+        terraformSnapshot: mockSnapshot,
+      } as never);
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue(
+        mockCriteria as never
+      );
+      vi.mocked(prisma.evaluationItem.createMany).mockResolvedValue({
+        count: 1,
+      });
+      vi.mocked(prisma.feedback.createMany).mockResolvedValue({ count: 1 });
+      vi.mocked(prisma.scoringSession.update).mockResolvedValue({
+        ...mockSession,
+        status: EvaluationStatus.COMPLETED,
+        totalScore: 100,
+      } as never);
+
+      const result = await evaluateSubmission('session-1', 'tenant-123');
+
+      expect(result?.status).toBe(EvaluationStatus.COMPLETED);
+      expect(result?.totalScore).toBe(100);
+    });
+
+    it('IN_PROGRESS以外のセッションは評価できないべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.PENDING,
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      await expect(
+        evaluateSubmission('session-1', 'tenant-123')
+      ).rejects.toThrow('評価中のセッションのみ採点できます');
+    });
+
+    it('セッションが見つからない場合はnullを返すべき', async () => {
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(null);
+
+      const result = await evaluateSubmission('nonexistent', 'tenant-123');
+
+      expect(result).toBeNull();
+    });
+
+    it('異なるテナントのセッションはnullを返すべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-other',
+        status: EvaluationStatus.IN_PROGRESS,
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+
+      const result = await evaluateSubmission('session-1', 'tenant-123');
+
+      expect(result).toBeNull();
+    });
+
+    it('フィードバックがある場合に保存されるべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.IN_PROGRESS,
+        terraformSnapshot: {
+          stateData: { version: 4, resources: [] },
+        },
+      };
+
+      const mockCriteria = [
+        {
+          id: 'criteria-1',
+          name: 'VPC構成',
+          category: EvaluationCategory.INFRASTRUCTURE,
+          maxScore: 100,
+          weight: 1,
+          criteriaDetails: [
+            {
+              ruleKey: 'vpc_exists',
+              ruleValue: 'true',
+              points: 100,
+              severity: Severity.HIGH,
+              description: 'VPCが必要です',
+            },
+          ],
+        },
+      ];
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue(
+        mockCriteria as never
+      );
+      vi.mocked(prisma.evaluationItem.createMany).mockResolvedValue({
+        count: 1,
+      });
+      vi.mocked(prisma.feedback.createMany).mockResolvedValue({ count: 1 });
+      vi.mocked(prisma.scoringSession.update).mockResolvedValue({
+        ...mockSession,
+        status: EvaluationStatus.COMPLETED,
+        totalScore: 0,
+      } as never);
+
+      const result = await evaluateSubmission('session-1', 'tenant-123');
+
+      expect(result?.status).toBe(EvaluationStatus.COMPLETED);
+      expect(prisma.feedback.createMany).toHaveBeenCalled();
+    });
+
+    it('評価項目がない場合はcreateMany呼び出しをスキップするべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+        status: EvaluationStatus.IN_PROGRESS,
+        terraformSnapshot: {
+          stateData: { version: 4, resources: [] },
+        },
+      };
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+      vi.mocked(prisma.evaluationCriteria.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.scoringSession.update).mockResolvedValue({
+        ...mockSession,
+        status: EvaluationStatus.COMPLETED,
+        totalScore: 0,
+      } as never);
+
+      await evaluateSubmission('session-1', 'tenant-123');
+
+      expect(prisma.evaluationItem.createMany).not.toHaveBeenCalled();
+      expect(prisma.feedback.createMany).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('フィードバック取得', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSessionFeedback', () => {
+    it('セッションのフィードバックを取得できるべき', async () => {
+      const mockSession = {
+        id: 'session-1',
+        tenantId: 'tenant-123',
+      };
+
+      const mockFeedbacks = [
+        {
+          id: 'fb-1',
+          category: EvaluationCategory.SECURITY,
+          severity: Severity.HIGH,
+          title: 'セキュリティグループが開放されています',
+          message: 'ポート22が0.0.0.0/0に開放されています',
+          suggestion: 'アクセス元IPを制限してください',
+        },
+      ];
+
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue(
+        mockSession as never
+      );
+      vi.mocked(prisma.feedback.findMany).mockResolvedValue(
+        mockFeedbacks as never
+      );
+
+      const result = await getSessionFeedback('session-1', 'tenant-123');
+
+      expect(result).toEqual(mockFeedbacks);
+    });
+
+    it('異なるテナントのフィードバックは取得できないべき', async () => {
+      vi.mocked(prisma.scoringSession.findUnique).mockResolvedValue({
+        id: 'session-1',
+        tenantId: 'tenant-other',
+      } as never);
+
+      const result = await getSessionFeedback('session-1', 'tenant-123');
+
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe('Terraform State 評価ヘルパー関数', () => {
+  describe('checkRule', () => {
+    it('リソースがない場合は失敗を返すべき', () => {
+      const result = checkRule(undefined, 'vpc_exists', 'true');
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBeUndefined();
+    });
+
+    it('resourcesが空の場合は失敗を返すべき', () => {
+      const result = checkRule({ version: 4 }, 'vpc_exists', 'true');
+      expect(result.passed).toBe(false);
+    });
+
+    it('vpc_exists ルールを評価できるべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc', name: 'main' }],
+      };
+      const result = checkRule(state, 'vpc_exists', 'true');
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('exists');
+    });
+
+    it('vpc_cidr ルールを評価できるべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_vpc',
+            name: 'main',
+            instances: [{ attributes: { cidr_block: '10.0.0.0/16' } }],
+          },
+        ],
+      };
+      const result = checkRule(state, 'vpc_cidr', '10.0.0.0/16');
+      expect(result.passed).toBe(true);
+    });
+
+    it('s3_encryption ルールを評価できるべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          { type: 'aws_s3_bucket', name: 'bucket1' },
+          {
+            type: 'aws_s3_bucket_server_side_encryption_configuration',
+            name: 'enc1',
+          },
+        ],
+      };
+      const result = checkRule(state, 's3_encryption', 'true');
+      expect(result.passed).toBe(true);
+    });
+
+    it('security_group_ssh ルールを評価できるべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_security_group', name: 'sg1' }],
+      };
+      const result = checkRule(state, 'security_group_ssh', 'restricted');
+      expect(result.passed).toBe(true);
+    });
+
+    it('不明なルールキーの場合は失敗を返すべき', () => {
+      const state = { version: 4, resources: [] };
+      const result = checkRule(state, 'unknown_rule', 'value');
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBe('unknown rule');
+    });
+  });
+
+  describe('checkResourceExists', () => {
+    it('リソースが存在する場合に成功を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc' }],
+      };
+      const result = checkResourceExists(state, 'aws_vpc', true);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('exists');
+    });
+
+    it('リソースが存在しない場合に期待通りの結果を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_subnet' }],
+      };
+      const result = checkResourceExists(state, 'aws_vpc', false);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('not exists');
+    });
+
+    it('リソースが存在するが期待しない場合は失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc' }],
+      };
+      const result = checkResourceExists(state, 'aws_vpc', false);
+      expect(result.passed).toBe(false);
+    });
+
+    it('resourcesがundefinedの場合は存在しないとみなすべき', () => {
+      const state = { version: 4 };
+      const result = checkResourceExists(state, 'aws_vpc', false);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('not exists');
+    });
+  });
+
+  describe('checkResourceAttribute', () => {
+    it('属性が一致する場合に成功を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_vpc',
+            name: 'main',
+            instances: [{ attributes: { cidr_block: '10.0.0.0/16' } }],
+          },
+        ],
+      };
+      const result = checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        '10.0.0.0/16'
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('10.0.0.0/16');
+      expect(result.resourceRef).toBe('aws_vpc.main');
+    });
+
+    it('リソースが見つからない場合は失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_subnet' }],
+      };
+      const result = checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        '10.0.0.0/16'
+      );
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBeUndefined();
+    });
+
+    it('インスタンスがない場合は失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc', name: 'main' }],
+      };
+      const result = checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        '10.0.0.0/16'
+      );
+      expect(result.passed).toBe(false);
+    });
+
+    it('属性が一致しない場合は失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_vpc',
+            name: 'main',
+            instances: [{ attributes: { cidr_block: '192.168.0.0/16' } }],
+          },
+        ],
+      };
+      const result = checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        '10.0.0.0/16'
+      );
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBe('192.168.0.0/16');
+    });
+
+    it('リソース名がない場合はunknownを使用するべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_vpc',
+            instances: [{ attributes: { cidr_block: '10.0.0.0/16' } }],
+          },
+        ],
+      };
+      const result = checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        '10.0.0.0/16'
+      );
+      expect(result.resourceRef).toBe('aws_vpc.unknown');
+    });
+
+    it('属性がundefinedの場合は空文字列として比較するべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_vpc',
+            name: 'main',
+            instances: [{ attributes: { other_attr: 'value' } }],
+          },
+        ],
+      };
+      const result = checkResourceAttribute(state, 'aws_vpc', 'cidr_block', '');
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('');
+    });
+  });
+
+  describe('checkS3Encryption', () => {
+    it('S3バケットがない場合は暗号化不要として成功を返すべき', () => {
+      const state = { version: 4, resources: [] };
+      const result = checkS3Encryption(state, false);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('no s3 buckets');
+    });
+
+    it('S3バケットがなく暗号化が必要な場合は失敗を返すべき', () => {
+      const state = { version: 4, resources: [] };
+      const result = checkS3Encryption(state, true);
+      expect(result.passed).toBe(false);
+    });
+
+    it('resourcesがundefinedの場合はS3バケットなしとみなすべき', () => {
+      const state = { version: 4 };
+      const result = checkS3Encryption(state, false);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('no s3 buckets');
+    });
+
+    it('暗号化設定がある場合に成功を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          { type: 'aws_s3_bucket', name: 'bucket1' },
+          {
+            type: 'aws_s3_bucket_server_side_encryption_configuration',
+            name: 'enc1',
+          },
+        ],
+      };
+      const result = checkS3Encryption(state, true);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('encrypted');
+    });
+
+    it('暗号化設定がない場合は失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_s3_bucket', name: 'bucket1' }],
+      };
+      const result = checkS3Encryption(state, true);
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBe('not encrypted');
+    });
+  });
+
+  describe('checkSecurityGroupSSH', () => {
+    it('SSHが制限されている場合に成功を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_security_group',
+            name: 'sg1',
+            instances: [
+              {
+                attributes: {
+                  ingress: [{ from_port: 22, cidr_blocks: ['10.0.0.0/8'] }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.passed).toBe(true);
+      expect(result.actualValue).toBe('restricted');
+    });
+
+    it('SSHが0.0.0.0/0に開放されている場合に失敗を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_security_group',
+            name: 'sg1',
+            instances: [
+              {
+                attributes: {
+                  ingress: [{ from_port: 22, cidr_blocks: ['0.0.0.0/0'] }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.passed).toBe(false);
+      expect(result.actualValue).toBe('0.0.0.0/0');
+      expect(result.resourceRef).toBe('aws_security_group.sg1');
+    });
+
+    it('ingressがない場合は制限されているとみなすべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_security_group',
+            name: 'sg1',
+            instances: [{ attributes: {} }],
+          },
+        ],
+      };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.passed).toBe(true);
+    });
+
+    it('セキュリティグループがない場合は成功を返すべき', () => {
+      const state = { version: 4, resources: [] };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.passed).toBe(true);
+    });
+
+    it('resourcesがundefinedの場合は成功を返すべき', () => {
+      const state = { version: 4 };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.passed).toBe(true);
+    });
+
+    it('SGの名前がない場合はunknownを使用するべき', () => {
+      const state = {
+        version: 4,
+        resources: [
+          {
+            type: 'aws_security_group',
+            instances: [
+              {
+                attributes: {
+                  ingress: [{ from_port: 22, cidr_blocks: ['0.0.0.0/0'] }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = checkSecurityGroupSSH(state, true);
+      expect(result.resourceRef).toBe('aws_security_group.unknown');
+    });
+  });
+
+  describe('generateSuggestion', () => {
+    it('vpc_existsの提案を返すべき', () => {
+      const result = generateSuggestion('vpc_exists', 'true');
+      expect(result).toBe('VPCを作成してください');
+    });
+
+    it('vpc_cidrの提案を返すべき', () => {
+      const result = generateSuggestion('vpc_cidr', '10.0.0.0/16');
+      expect(result).toBe('VPCのCIDRブロックを 10.0.0.0/16 に設定してください');
+    });
+
+    it('s3_encryptionの提案を返すべき', () => {
+      const result = generateSuggestion('s3_encryption', 'true');
+      expect(result).toBe(
+        'S3バケットのサーバーサイド暗号化を有効にしてください'
+      );
+    });
+
+    it('security_group_sshの提案を返すべき', () => {
+      const result = generateSuggestion('security_group_ssh', 'restricted');
+      expect(result).toBe(
+        'SSHポート(22)へのアクセスを特定のIPアドレスに制限してください'
+      );
+    });
+
+    it('不明なルールの場合はデフォルトの提案を返すべき', () => {
+      const result = generateSuggestion('unknown_rule', 'value');
+      expect(result).toBe('設定を見直してください');
+    });
+  });
+
+  describe('evaluateTerraformState', () => {
+    it('空の基準リストの場合は空の結果を返すべき', () => {
+      const state = { version: 4, resources: [] };
+      const result = evaluateTerraformState(state, []);
+      expect(result.items).toEqual([]);
+      expect(result.feedbacks).toEqual([]);
+      expect(result.totalScore).toBe(0);
+      expect(result.maxPossibleScore).toBe(0);
+    });
+
+    it('基準に基づいて評価結果を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc', name: 'main' }],
+      };
+      const criteria = [
+        {
+          id: 'criteria-1',
+          name: 'VPC構成',
+          category: EvaluationCategory.INFRASTRUCTURE,
+          maxScore: 100,
+          weight: 1,
+          criteriaDetails: [
+            {
+              ruleKey: 'vpc_exists',
+              ruleValue: 'true',
+              points: 100,
+              severity: Severity.HIGH,
+              description: 'VPCが存在すること',
+            },
+          ],
+        },
+      ];
+      const result = evaluateTerraformState(state, criteria);
+      expect(result.totalScore).toBe(100);
+      expect(result.maxPossibleScore).toBe(100);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].passed).toBe(true);
+    });
+  });
+
+  describe('evaluateCriterion', () => {
+    it('すべてのルールをパスした場合に満点を返すべき', () => {
+      const state = {
+        version: 4,
+        resources: [{ type: 'aws_vpc', name: 'main' }],
+      };
+      const criterion = {
+        id: 'criteria-1',
+        name: 'VPC構成',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        maxScore: 100,
+        weight: 1,
+        criteriaDetails: [
+          {
+            ruleKey: 'vpc_exists',
+            ruleValue: 'true',
+            points: 100,
+            severity: Severity.HIGH,
+            description: null,
+          },
+        ],
+      };
+      const result = evaluateCriterion(state, criterion);
+      expect(result.item.score).toBe(100);
+      expect(result.item.passed).toBe(true);
+      expect(result.feedbacks).toHaveLength(0);
+    });
+
+    it('ルールに失敗した場合にフィードバックを生成するべき', () => {
+      const state = {
+        version: 4,
+        resources: [],
+      };
+      const criterion = {
+        id: 'criteria-1',
+        name: 'VPC構成',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        maxScore: 100,
+        weight: 1,
+        criteriaDetails: [
+          {
+            ruleKey: 'vpc_exists',
+            ruleValue: 'true',
+            points: 100,
+            severity: Severity.HIGH,
+            description: null,
+          },
+        ],
+      };
+      const result = evaluateCriterion(state, criterion);
+      expect(result.item.score).toBe(0);
+      expect(result.item.passed).toBe(false);
+      expect(result.feedbacks).toHaveLength(1);
+      expect(result.feedbacks[0].category).toBe(
+        EvaluationCategory.INFRASTRUCTURE
+      );
+      expect(result.feedbacks[0].severity).toBe(Severity.HIGH);
+    });
+
+    it('descriptionがある場合はそれをメッセージに使用するべき', () => {
+      const state = { version: 4, resources: [] };
+      const criterion = {
+        id: 'criteria-1',
+        name: 'VPC構成',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        maxScore: 100,
+        weight: 1,
+        criteriaDetails: [
+          {
+            ruleKey: 'vpc_exists',
+            ruleValue: 'true',
+            points: 100,
+            severity: Severity.HIGH,
+            description: 'カスタムメッセージ',
+          },
+        ],
+      };
+      const result = evaluateCriterion(state, criterion);
+      expect(result.feedbacks[0].message).toBe('カスタムメッセージ');
+    });
+
+    it('actualValueがundefinedの場合は「なし」を使用するべき', () => {
+      const state = undefined;
+      const criterion = {
+        id: 'criteria-1',
+        name: 'VPC構成',
+        category: EvaluationCategory.INFRASTRUCTURE,
+        maxScore: 100,
+        weight: 1,
+        criteriaDetails: [
+          {
+            ruleKey: 'vpc_exists',
+            ruleValue: 'true',
+            points: 100,
+            severity: Severity.HIGH,
+            description: null,
+          },
+        ],
+      };
+      const result = evaluateCriterion(state, criterion);
+      expect(result.feedbacks[0].message).toContain('なし');
+    });
+  });
+});

--- a/backend/services/application-plane/scoring-service/src/services/scoring.ts
+++ b/backend/services/application-plane/scoring-service/src/services/scoring.ts
@@ -1,0 +1,578 @@
+import {
+  EvaluationCategory,
+  EvaluationStatus,
+  Severity,
+  type Prisma,
+} from '@prisma/client';
+import { prisma } from '../lib/prisma';
+
+// ========== 型定義 ==========
+
+export interface CreateEvaluationCriteriaInput {
+  tenantId: string;
+  name: string;
+  description?: string;
+  category: EvaluationCategory;
+  weight?: number;
+  maxScore?: number;
+}
+
+export interface UpdateEvaluationCriteriaInput {
+  name?: string;
+  description?: string;
+  category?: EvaluationCategory;
+  weight?: number;
+  maxScore?: number;
+  isActive?: boolean;
+}
+
+export interface ListEvaluationCriteriaOptions {
+  page: number;
+  limit: number;
+  category?: EvaluationCategory;
+  isActive?: boolean;
+}
+
+export interface CreateScoringSessionInput {
+  tenantId: string;
+  battleId?: string;
+  participantId: string;
+}
+
+export interface ListScoringSessionsOptions {
+  page: number;
+  limit: number;
+  battleId?: string;
+  participantId?: string;
+  status?: EvaluationStatus;
+}
+
+export interface TerraformState {
+  version: number;
+  resources?: TerraformResource[];
+}
+
+export interface TerraformResource {
+  type: string;
+  name?: string;
+  instances?: TerraformResourceInstance[];
+}
+
+export interface TerraformResourceInstance {
+  attributes?: Record<string, unknown>;
+}
+
+// ========== 評価基準管理 ==========
+
+export async function createEvaluationCriteria(
+  input: CreateEvaluationCriteriaInput
+) {
+  return prisma.evaluationCriteria.create({
+    data: input,
+  });
+}
+
+export async function getEvaluationCriteria(
+  criteriaId: string,
+  tenantId: string
+) {
+  const criteria = await prisma.evaluationCriteria.findUnique({
+    where: { id: criteriaId },
+    include: { criteriaDetails: true },
+  });
+
+  if (!criteria || criteria.tenantId !== tenantId) {
+    return null;
+  }
+
+  return criteria;
+}
+
+export async function listEvaluationCriteria(
+  tenantId: string,
+  options: ListEvaluationCriteriaOptions
+) {
+  const { page, limit, category, isActive } = options;
+  const skip = (page - 1) * limit;
+
+  const where: Prisma.EvaluationCriteriaWhereInput = { tenantId };
+  if (category) {
+    where.category = category;
+  }
+  if (isActive !== undefined) {
+    where.isActive = isActive;
+  }
+
+  const [data, total] = await Promise.all([
+    prisma.evaluationCriteria.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      include: { criteriaDetails: true },
+    }),
+    prisma.evaluationCriteria.count({ where }),
+  ]);
+
+  return { data, total, page, limit };
+}
+
+export async function updateEvaluationCriteria(
+  criteriaId: string,
+  tenantId: string,
+  updates: UpdateEvaluationCriteriaInput
+) {
+  const criteria = await prisma.evaluationCriteria.findUnique({
+    where: { id: criteriaId },
+  });
+
+  if (!criteria || criteria.tenantId !== tenantId) {
+    return null;
+  }
+
+  return prisma.evaluationCriteria.update({
+    where: { id: criteriaId },
+    data: updates,
+  });
+}
+
+export async function deleteEvaluationCriteria(
+  criteriaId: string,
+  tenantId: string
+) {
+  const criteria = await prisma.evaluationCriteria.findUnique({
+    where: { id: criteriaId },
+  });
+
+  if (!criteria || criteria.tenantId !== tenantId) {
+    return;
+  }
+
+  await prisma.evaluationCriteria.delete({
+    where: { id: criteriaId },
+  });
+}
+
+// ========== 採点セッション管理 ==========
+
+export async function createScoringSession(input: CreateScoringSessionInput) {
+  return prisma.scoringSession.create({
+    data: input,
+  });
+}
+
+export async function getScoringSession(sessionId: string, tenantId: string) {
+  const session = await prisma.scoringSession.findUnique({
+    where: { id: sessionId },
+    include: {
+      evaluationItems: {
+        include: { criteria: true },
+      },
+      feedbacks: true,
+    },
+  });
+
+  if (!session || session.tenantId !== tenantId) {
+    return null;
+  }
+
+  return session;
+}
+
+export async function listScoringSessions(
+  tenantId: string,
+  options: ListScoringSessionsOptions
+) {
+  const { page, limit, battleId, participantId, status } = options;
+  const skip = (page - 1) * limit;
+
+  const where: Prisma.ScoringSessionWhereInput = { tenantId };
+  if (battleId) {
+    where.battleId = battleId;
+  }
+  if (participantId) {
+    where.participantId = participantId;
+  }
+  if (status) {
+    where.status = status;
+  }
+
+  const [data, total] = await Promise.all([
+    prisma.scoringSession.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.scoringSession.count({ where }),
+  ]);
+
+  return { data, total, page, limit };
+}
+
+// ========== 採点実行 ==========
+
+export async function submitForEvaluation(
+  sessionId: string,
+  tenantId: string,
+  terraformState: TerraformState
+) {
+  const session = await prisma.scoringSession.findUnique({
+    where: { id: sessionId },
+  });
+
+  if (!session || session.tenantId !== tenantId) {
+    return null;
+  }
+
+  if (session.status !== EvaluationStatus.PENDING) {
+    throw new Error('評価待ちのセッションのみ提出できます');
+  }
+
+  // Terraform State スナップショットを保存
+  await prisma.terraformSnapshot.create({
+    data: {
+      sessionId,
+      stateVersion: terraformState.version,
+      resourceCount: terraformState.resources?.length ?? 0,
+      stateData: terraformState as unknown as Prisma.JsonObject,
+    },
+  });
+
+  // ステータスを IN_PROGRESS に更新
+  return prisma.scoringSession.update({
+    where: { id: sessionId },
+    data: {
+      status: EvaluationStatus.IN_PROGRESS,
+      submittedAt: new Date(),
+    },
+  });
+}
+
+export async function evaluateSubmission(sessionId: string, tenantId: string) {
+  const session = await prisma.scoringSession.findUnique({
+    where: { id: sessionId },
+    include: {
+      terraformSnapshot: true,
+    },
+  });
+
+  if (!session || session.tenantId !== tenantId) {
+    return null;
+  }
+
+  if (session.status !== EvaluationStatus.IN_PROGRESS) {
+    throw new Error('評価中のセッションのみ採点できます');
+  }
+
+  // テナントの評価基準を取得
+  const criteria = await prisma.evaluationCriteria.findMany({
+    where: { tenantId, isActive: true },
+    include: { criteriaDetails: true },
+  });
+
+  const terraformState = session.terraformSnapshot
+    ?.stateData as unknown as TerraformState;
+  const evaluationResults = evaluateTerraformState(terraformState, criteria);
+
+  // 評価結果を保存
+  if (evaluationResults.items.length > 0) {
+    await prisma.evaluationItem.createMany({
+      data: evaluationResults.items.map((item) => ({
+        sessionId,
+        criteriaId: item.criteriaId,
+        score: item.score,
+        maxScore: item.maxScore,
+        passed: item.passed,
+        actualValue: item.actualValue,
+        expectedValue: item.expectedValue,
+        details: item.details as Prisma.JsonObject,
+      })),
+    });
+  }
+
+  // フィードバックを保存
+  if (evaluationResults.feedbacks.length > 0) {
+    await prisma.feedback.createMany({
+      data: evaluationResults.feedbacks.map((fb) => ({
+        sessionId,
+        category: fb.category,
+        severity: fb.severity,
+        title: fb.title,
+        message: fb.message,
+        suggestion: fb.suggestion,
+        resourceRef: fb.resourceRef,
+      })),
+    });
+  }
+
+  // セッションを完了状態に更新
+  return prisma.scoringSession.update({
+    where: { id: sessionId },
+    data: {
+      status: EvaluationStatus.COMPLETED,
+      totalScore: evaluationResults.totalScore,
+      maxPossibleScore: evaluationResults.maxPossibleScore,
+      evaluatedAt: new Date(),
+    },
+  });
+}
+
+// ========== フィードバック取得 ==========
+
+export async function getSessionFeedback(sessionId: string, tenantId: string) {
+  const session = await prisma.scoringSession.findUnique({
+    where: { id: sessionId },
+  });
+
+  if (!session || session.tenantId !== tenantId) {
+    return null;
+  }
+
+  return prisma.feedback.findMany({
+    where: { sessionId },
+    orderBy: [{ severity: 'asc' }, { createdAt: 'desc' }],
+  });
+}
+
+// ========== ヘルパー関数（テスト用にエクスポート） ==========
+
+interface EvaluationItemResult {
+  criteriaId: string;
+  score: number;
+  maxScore: number;
+  passed: boolean;
+  actualValue?: string;
+  expectedValue?: string;
+  details?: Record<string, unknown>;
+}
+
+interface FeedbackResult {
+  category: EvaluationCategory;
+  severity: Severity;
+  title: string;
+  message: string;
+  suggestion?: string;
+  resourceRef?: string;
+}
+
+interface EvaluationResults {
+  items: EvaluationItemResult[];
+  feedbacks: FeedbackResult[];
+  totalScore: number;
+  maxPossibleScore: number;
+}
+
+interface CriteriaWithDetails {
+  id: string;
+  name: string;
+  category: EvaluationCategory;
+  maxScore: number;
+  weight: number;
+  criteriaDetails: CriteriaDetail[];
+}
+
+interface CriteriaDetail {
+  ruleKey: string;
+  ruleValue: string;
+  points: number;
+  severity: Severity;
+  description?: string | null;
+}
+
+export function evaluateTerraformState(
+  state: TerraformState | undefined,
+  criteria: CriteriaWithDetails[]
+): EvaluationResults {
+  const items: EvaluationItemResult[] = [];
+  const feedbacks: FeedbackResult[] = [];
+  let totalScore = 0;
+  let maxPossibleScore = 0;
+
+  for (const criterion of criteria) {
+    const result = evaluateCriterion(state, criterion);
+    items.push(result.item);
+    feedbacks.push(...result.feedbacks);
+    totalScore += result.item.score * criterion.weight;
+    maxPossibleScore += criterion.maxScore * criterion.weight;
+  }
+
+  return { items, feedbacks, totalScore, maxPossibleScore };
+}
+
+export function evaluateCriterion(
+  state: TerraformState | undefined,
+  criterion: CriteriaWithDetails
+): { item: EvaluationItemResult; feedbacks: FeedbackResult[] } {
+  const feedbacks: FeedbackResult[] = [];
+  let score = 0;
+  const details: Record<string, unknown> = {};
+
+  for (const detail of criterion.criteriaDetails) {
+    const checkResult = checkRule(state, detail.ruleKey, detail.ruleValue);
+    details[detail.ruleKey] = checkResult;
+
+    if (checkResult.passed) {
+      score += detail.points;
+    } else {
+      feedbacks.push({
+        category: criterion.category,
+        severity: detail.severity,
+        title: `${criterion.name}: ${detail.ruleKey} チェック失敗`,
+        message:
+          detail.description ??
+          `期待値: ${detail.ruleValue}, 実際値: ${checkResult.actualValue ?? 'なし'}`,
+        suggestion: generateSuggestion(detail.ruleKey, detail.ruleValue),
+        resourceRef: checkResult.resourceRef,
+      });
+    }
+  }
+
+  return {
+    item: {
+      criteriaId: criterion.id,
+      score,
+      maxScore: criterion.maxScore,
+      passed: score === criterion.maxScore,
+      details,
+    },
+    feedbacks,
+  };
+}
+
+interface RuleCheckResult {
+  passed: boolean;
+  actualValue?: string;
+  resourceRef?: string;
+}
+
+export function checkRule(
+  state: TerraformState | undefined,
+  ruleKey: string,
+  expectedValue: string
+): RuleCheckResult {
+  if (!state?.resources) {
+    return { passed: false, actualValue: undefined };
+  }
+
+  // ルールキーに基づいて評価
+  switch (ruleKey) {
+    case 'vpc_exists':
+      return checkResourceExists(state, 'aws_vpc', expectedValue === 'true');
+    case 'vpc_cidr':
+      return checkResourceAttribute(
+        state,
+        'aws_vpc',
+        'cidr_block',
+        expectedValue
+      );
+    case 's3_encryption':
+      return checkS3Encryption(state, expectedValue === 'true');
+    case 'security_group_ssh':
+      return checkSecurityGroupSSH(state, expectedValue === 'restricted');
+    default:
+      return { passed: false, actualValue: 'unknown rule' };
+  }
+}
+
+export function checkResourceExists(
+  state: TerraformState,
+  resourceType: string,
+  shouldExist: boolean
+): RuleCheckResult {
+  const exists = state.resources?.some((r) => r.type === resourceType) ?? false;
+  return {
+    passed: exists === shouldExist,
+    actualValue: exists ? 'exists' : 'not exists',
+  };
+}
+
+export function checkResourceAttribute(
+  state: TerraformState,
+  resourceType: string,
+  attribute: string,
+  expectedValue: string
+): RuleCheckResult {
+  const resource = state.resources?.find((r) => r.type === resourceType);
+  if (!resource?.instances?.[0]?.attributes) {
+    return { passed: false, actualValue: undefined };
+  }
+
+  const actualValue = String(resource.instances[0].attributes[attribute] ?? '');
+  return {
+    passed: actualValue === expectedValue,
+    actualValue,
+    resourceRef: `${resourceType}.${resource.name ?? 'unknown'}`,
+  };
+}
+
+export function checkS3Encryption(
+  state: TerraformState,
+  shouldBeEncrypted: boolean
+): RuleCheckResult {
+  const s3Buckets =
+    state.resources?.filter((r) => r.type === 'aws_s3_bucket') ?? [];
+  if (s3Buckets.length === 0) {
+    return { passed: !shouldBeEncrypted, actualValue: 'no s3 buckets' };
+  }
+
+  // 簡易チェック: aws_s3_bucket_server_side_encryption_configuration の存在確認
+  const encryptionConfigs =
+    state.resources?.filter(
+      (r) => r.type === 'aws_s3_bucket_server_side_encryption_configuration'
+    ) ?? [];
+
+  const allEncrypted = s3Buckets.length <= encryptionConfigs.length;
+  return {
+    passed: allEncrypted === shouldBeEncrypted,
+    actualValue: allEncrypted ? 'encrypted' : 'not encrypted',
+  };
+}
+
+export function checkSecurityGroupSSH(
+  state: TerraformState,
+  shouldBeRestricted: boolean
+): RuleCheckResult {
+  const securityGroups =
+    state.resources?.filter((r) => r.type === 'aws_security_group') ?? [];
+
+  for (const sg of securityGroups) {
+    const ingress = sg.instances?.[0]?.attributes?.['ingress'] as unknown;
+    if (Array.isArray(ingress)) {
+      for (const rule of ingress) {
+        const ruleObj = rule as Record<string, unknown>;
+        if (
+          ruleObj['from_port'] === 22 &&
+          Array.isArray(ruleObj['cidr_blocks']) &&
+          ruleObj['cidr_blocks'].includes('0.0.0.0/0')
+        ) {
+          return {
+            passed: !shouldBeRestricted,
+            actualValue: '0.0.0.0/0',
+            resourceRef: `aws_security_group.${sg.name ?? 'unknown'}`,
+          };
+        }
+      }
+    }
+  }
+
+  return {
+    passed: shouldBeRestricted,
+    actualValue: 'restricted',
+  };
+}
+
+export function generateSuggestion(
+  ruleKey: string,
+  expectedValue: string
+): string {
+  const suggestions: Record<string, string> = {
+    vpc_exists: 'VPCを作成してください',
+    vpc_cidr: `VPCのCIDRブロックを ${expectedValue} に設定してください`,
+    s3_encryption: 'S3バケットのサーバーサイド暗号化を有効にしてください',
+    security_group_ssh:
+      'SSHポート(22)へのアクセスを特定のIPアドレスに制限してください',
+  };
+
+  return suggestions[ruleKey] ?? '設定を見直してください';
+}

--- a/backend/services/application-plane/scoring-service/tsconfig.json
+++ b/backend/services/application-plane/scoring-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/backend/services/application-plane/scoring-service/vitest.config.ts
+++ b/backend/services/application-plane/scoring-service/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        '**/*.d.ts',
+        '**/*.test.ts',
+        'vitest.config.ts',
+        'src/lib/prisma.ts',
+        'src/lib/logger.ts',
+        'src/index.ts',
+      ],
+      thresholds: {
+        lines: 99,
+        functions: 99,
+        branches: 99,
+        statements: 99,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Terraform State解析による自動インフラ評価サービスを追加
- 評価基準のCRUD操作API
- 採点セッション管理機能
- カスタム評価ルールエンジン（リソース存在チェック、属性検証、S3暗号化、セキュリティグループ検証等）

## Test plan

- [x] サービス層テスト（70テスト）
- [x] API層テスト（27テスト）
- [x] 認証ミドルウェアテスト（6テスト）
- [x] ヘルスチェックテスト（6テスト）
- [x] テストカバレッジ99%以上達成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new scoring service for evaluating infrastructure configurations
  * Added evaluation criteria management (create, update, delete, and list)
  * Added scoring sessions with Terraform state submission and automated evaluation
  * Added session feedback retrieval with detailed evaluation results
  * Added health check endpoints for service monitoring

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->