### PR TITLE
feat(problem-management): 問題テンプレート管理APIを実装

### DIFF
--- a/backend/services/problem-management/prisma/schema.prisma
+++ b/backend/services/problem-management/prisma/schema.prisma
@@ -94,6 +94,65 @@ enum ScoringFunctionType {
   MANUAL
 }
 
+enum ProblemTemplateStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+// =============================================================================
+// Problem Template Models
+// =============================================================================
+
+/// 問題テンプレート（再利用可能な問題のひな形）
+model ProblemTemplate {
+  id            String                @id @default(uuid())
+  name          String
+  description   String                @db.Text
+  type          ProblemType
+  category      ProblemCategory
+  difficulty    DifficultyLevel
+  status        ProblemTemplateStatus @default(DRAFT)
+
+  // テンプレート変数
+  variables     Json                  @default("[]") // ProblemTemplateVariable[]
+
+  // 説明テンプレート
+  overviewTemplate    String          @db.Text
+  objectivesTemplate  String[]
+  hintsTemplate       String[]
+  prerequisites       String[]
+  estimatedTimeMinutes Int?
+
+  // デプロイ設定テンプレート
+  providers           CloudProvider[]
+  templateType        TemplateType
+  templateContent     String          @db.Text
+  regions             Json            @default("{}") // Partial<Record<CloudProvider, string[]>>
+  deploymentTimeout   Int             @default(60)
+
+  // 採点設定テンプレート
+  scoringType         ScoringFunctionType
+  criteriaTemplate    Json            @default("[]") // ScoringCriterion[]（nameを除く）
+  scoringTimeout      Int             @default(30)
+
+  // メタデータ
+  tags          String[]
+  author        String
+  version       String                @default("1.0.0")
+  usageCount    Int                   @default(0)
+
+  // タイムスタンプ
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+
+  @@index([status])
+  @@index([type])
+  @@index([category])
+  @@index([difficulty])
+  @@map("problem_templates")
+}
+
 // =============================================================================
 // Problem Models
 // =============================================================================

--- a/backend/services/problem-management/src/__tests__/converter.test.ts
+++ b/backend/services/problem-management/src/__tests__/converter.test.ts
@@ -12,7 +12,7 @@ import {
   importProblems,
   detectFormat,
 } from '../problems/converter';
-import type { Problem } from '../types';
+import type { Problem, ExternalFormat } from '../types';
 
 // テスト用の問題データ
 const createTestProblem = (overrides: Partial<Problem> = {}): Problem => ({
@@ -141,6 +141,16 @@ describe('exportProblems', () => {
     expect(parsed.version).toBe('1.0');
     expect(parsed.problems).toHaveLength(2);
   });
+
+  it('サポートされていないフォーマットはエラーを返すべき', () => {
+    const problems = [createTestProblem()];
+    const result = exportProblems(problems, {
+      format: 'unknown-format' as ExternalFormat,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Unsupported export format:');
+  });
 });
 
 describe('importProblem', () => {
@@ -255,6 +265,29 @@ id: test
     expect(result.success).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
   });
+
+  it('タイトルがない場合はエラーを返すべき', () => {
+    const yaml = `
+id: test-id
+type: gameday
+`;
+
+    const result = importProblem(yaml, { format: 'tenkacloud-yaml' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('Missing required field: title');
+  });
+
+  it('サポートされていないフォーマットはエラーを返すべき', () => {
+    const yaml = `id: test`;
+
+    const result = importProblem(yaml, {
+      format: 'unknown-format' as ExternalFormat,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Unsupported import format:');
+  });
 });
 
 describe('importProblems', () => {
@@ -340,6 +373,67 @@ version: "1.0"
       'Invalid format: expected "problems" array'
     );
   });
+
+  it('不正な JSON でエラーを返すべき', () => {
+    const result = importProblems('{ invalid json }', {
+      format: 'tenkacloud-json',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain('Import failed:');
+  });
+
+  it('一部の問題が変換失敗しても他の問題はインポートできるべき', () => {
+    const json = JSON.stringify({
+      version: '1.0',
+      problems: [
+        {
+          id: 'valid-problem',
+          title: '有効な問題',
+          type: 'gameday',
+          category: 'architecture',
+          difficulty: 'easy',
+          metadata: {
+            author: 'author1',
+            version: '1.0.0',
+            createdAt: '2024-01-01',
+          },
+          description: { overview: '概要', objectives: ['目標'] },
+          deployment: {
+            providers: ['aws'],
+            templates: { aws: { type: 'cloudformation', path: '/path' } },
+          },
+          scoring: {
+            type: 'lambda',
+            path: '/scoring',
+            criteria: [{ name: '基準', weight: 100, maxPoints: 100 }],
+            timeoutMinutes: 10,
+          },
+        },
+        null, // 不正なデータ
+      ],
+    });
+
+    const result = importProblems(json, { format: 'tenkacloud-json' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(1);
+    expect(result.data![0].id).toBe('valid-problem');
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('サポートされていないフォーマットはエラーを返すべき', () => {
+    const yaml = `version: "1.0"
+problems: []`;
+
+    const result = importProblems(yaml, {
+      format: 'unknown-format' as ExternalFormat,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Unsupported import format:');
+  });
 });
 
 describe('detectFormat', () => {
@@ -400,5 +494,380 @@ describe('ラウンドトリップ', () => {
 
     expect(imported.data!.id).toBe(original.id);
     expect(imported.data!.title).toBe(original.title);
+  });
+});
+
+// Cloud Contest 形式のテストデータ
+const createCloudContestData = () => ({
+  version: '2.0',
+  challenge: {
+    id: 'cc-challenge-1',
+    name: 'Cloud Contest Challenge',
+    description: 'A sample Cloud Contest challenge for testing',
+    difficulty: 'intermediate',
+    category: 'compute',
+    timeLimit: 3600,
+    points: 100,
+  },
+  scenario: {
+    background: 'You need to deploy a scalable web application',
+    objectives: [
+      'Deploy an Auto Scaling Group',
+      'Configure a Load Balancer',
+      'Set up CloudWatch monitoring',
+    ],
+    hints: ['Consider using Launch Templates', 'Think about health checks'],
+  },
+  infrastructure: {
+    provider: 'aws',
+    region: 'us-east-1',
+    template: {
+      type: 'cloudformation',
+      path: 's3://bucket/template.yaml',
+      parameters: {
+        InstanceType: 't3.micro',
+        Environment: 'production',
+      },
+    },
+  },
+  scoring: {
+    endpoint: 'https://scoring.example.com/evaluate',
+    method: 'api',
+    criteria: [
+      {
+        id: 'asg-deployed',
+        name: 'Auto Scaling Group Deployed',
+        points: 30,
+        description: 'ASG is properly configured',
+      },
+      {
+        id: 'lb-configured',
+        name: 'Load Balancer Configured',
+        points: 40,
+        description: 'ALB is attached to ASG',
+      },
+      {
+        id: 'monitoring-setup',
+        name: 'Monitoring Enabled',
+        points: 30,
+        description: 'CloudWatch alarms are configured',
+      },
+    ],
+    timeout: 300,
+  },
+  metadata: {
+    author: 'AWS GameDay Team',
+    version: '1.0.0',
+    createdAt: '2024-01-15T00:00:00Z',
+    tags: ['aws', 'autoscaling', 'load-balancer'],
+  },
+});
+
+describe('Cloud Contest 形式', () => {
+  describe('importProblem (cloud-contest)', () => {
+    it('Cloud Contest JSON からインポートできるべき', () => {
+      const cloudContestData = createCloudContestData();
+      const json = JSON.stringify(cloudContestData);
+
+      const result = importProblem(json, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data!.id).toBe('cc-challenge-1');
+      expect(result.data!.title).toBe('Cloud Contest Challenge');
+      expect(result.data!.type).toBe('gameday');
+      expect(result.data!.category).toBe('compute');
+      expect(result.data!.difficulty).toBe('medium');
+    });
+
+    it('Cloud Contest の scenario を description に変換するべき', () => {
+      const cloudContestData = createCloudContestData();
+      const json = JSON.stringify(cloudContestData);
+
+      const result = importProblem(json, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.description?.overview).toContain(
+        'You need to deploy a scalable web application'
+      );
+      expect(result.data!.description?.objectives).toEqual([
+        'Deploy an Auto Scaling Group',
+        'Configure a Load Balancer',
+        'Set up CloudWatch monitoring',
+      ]);
+      expect(result.data!.description?.hints).toEqual([
+        'Consider using Launch Templates',
+        'Think about health checks',
+      ]);
+    });
+
+    it('Cloud Contest の infrastructure を deployment に変換するべき', () => {
+      const cloudContestData = createCloudContestData();
+      const json = JSON.stringify(cloudContestData);
+
+      const result = importProblem(json, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.deployment?.providers).toContain('aws');
+      expect(result.data!.deployment?.templates?.aws).toBeDefined();
+      expect(result.data!.deployment?.templates?.aws?.type).toBe(
+        'cloudformation'
+      );
+    });
+
+    it('Cloud Contest の scoring を変換するべき', () => {
+      const cloudContestData = createCloudContestData();
+      const json = JSON.stringify(cloudContestData);
+
+      const result = importProblem(json, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.scoring?.type).toBe('api');
+      expect(result.data!.scoring?.path).toBe(
+        'https://scoring.example.com/evaluate'
+      );
+      expect(result.data!.scoring?.criteria).toHaveLength(3);
+      expect(result.data!.scoring?.criteria?.[0].name).toBe(
+        'Auto Scaling Group Deployed'
+      );
+    });
+
+    it('Cloud Contest の difficulty を TenkaCloud の difficulty にマッピングするべき', () => {
+      const testCases = [
+        { input: 'beginner', expected: 'easy' },
+        { input: 'intermediate', expected: 'medium' },
+        { input: 'advanced', expected: 'hard' },
+        { input: 'expert', expected: 'expert' },
+      ];
+
+      for (const { input, expected } of testCases) {
+        const data = createCloudContestData();
+        data.challenge.difficulty = input;
+        const result = importProblem(JSON.stringify(data), {
+          format: 'cloud-contest',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data!.difficulty).toBe(expected);
+      }
+    });
+
+    it('challenge.id がない場合はエラーを返すべき', () => {
+      const invalidData = {
+        version: '2.0',
+        challenge: {
+          name: 'No ID Challenge',
+        },
+      };
+
+      const result = importProblem(JSON.stringify(invalidData), {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain('Missing required field: challenge.id');
+    });
+
+    it('challenge.name がない場合はエラーを返すべき', () => {
+      const invalidData = {
+        version: '2.0',
+        challenge: {
+          id: 'no-name-challenge',
+        },
+      };
+
+      const result = importProblem(JSON.stringify(invalidData), {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain('Missing required field: challenge.name');
+    });
+
+    it('不正な JSON でエラーを返すべき', () => {
+      const result = importProblem('{ invalid }', { format: 'cloud-contest' });
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('exportProblem (cloud-contest)', () => {
+    it('Cloud Contest 形式でエクスポートできるべき', () => {
+      const problem = createTestProblem();
+      const result = exportProblem(problem, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+
+      const parsed = JSON.parse(result.data!);
+      expect(parsed.version).toBe('2.0');
+      expect(parsed.challenge).toBeDefined();
+      expect(parsed.challenge.id).toBe('test-problem-1');
+      expect(parsed.challenge.name).toBe('テスト問題');
+    });
+
+    it('problem の description を scenario に変換するべき', () => {
+      const problem = createTestProblem();
+      const result = exportProblem(problem, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.data!);
+
+      expect(parsed.scenario).toBeDefined();
+      expect(parsed.scenario.background).toContain('これはテスト問題です');
+      expect(parsed.scenario.objectives).toEqual(['目標1', '目標2']);
+      expect(parsed.scenario.hints).toEqual(['ヒント1']);
+    });
+
+    it('problem の deployment を infrastructure に変換するべき', () => {
+      const problem = createTestProblem();
+      const result = exportProblem(problem, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.data!);
+
+      expect(parsed.infrastructure).toBeDefined();
+      expect(parsed.infrastructure.provider).toBe('aws');
+      expect(parsed.infrastructure.template.type).toBe('cloudformation');
+    });
+
+    it('problem の scoring を変換するべき', () => {
+      const problem = createTestProblem();
+      const result = exportProblem(problem, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.data!);
+
+      expect(parsed.scoring).toBeDefined();
+      expect(parsed.scoring.method).toBe('lambda');
+      expect(parsed.scoring.criteria).toHaveLength(2);
+    });
+
+    it('prettyPrint オプションで整形された JSON を出力するべき', () => {
+      const problem = createTestProblem();
+      const result = exportProblem(problem, {
+        format: 'cloud-contest',
+        prettyPrint: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toContain('\n');
+      expect(result.data).toContain('  ');
+    });
+  });
+
+  describe('exportProblems (cloud-contest)', () => {
+    it('複数の問題を Cloud Contest 形式でエクスポートできるべき', () => {
+      const problems = [
+        createTestProblem({ id: 'problem-1', title: '問題1' }),
+        createTestProblem({ id: 'problem-2', title: '問題2' }),
+      ];
+
+      const result = exportProblems(problems, { format: 'cloud-contest' });
+
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.data!);
+
+      expect(parsed.version).toBe('2.0');
+      expect(parsed.challenges).toHaveLength(2);
+      expect(parsed.challenges[0].challenge.id).toBe('problem-1');
+      expect(parsed.challenges[1].challenge.id).toBe('problem-2');
+    });
+  });
+
+  describe('importProblems (cloud-contest)', () => {
+    it('複数の Cloud Contest 問題をインポートできるべき', () => {
+      const data = {
+        version: '2.0',
+        challenges: [
+          createCloudContestData(),
+          {
+            ...createCloudContestData(),
+            challenge: {
+              ...createCloudContestData().challenge,
+              id: 'cc-challenge-2',
+              name: 'Second Challenge',
+            },
+          },
+        ],
+      };
+
+      const result = importProblems(JSON.stringify(data), {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+      expect(result.data![0].id).toBe('cc-challenge-1');
+      expect(result.data![1].id).toBe('cc-challenge-2');
+    });
+
+    it('challenges 配列がない場合はエラーを返すべき', () => {
+      const data = { version: '2.0' };
+
+      const result = importProblems(JSON.stringify(data), {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain(
+        'Invalid format: expected "challenges" array'
+      );
+    });
+
+    it('一部のチャレンジが変換失敗しても他はインポートできるべき', () => {
+      const data = {
+        version: '2.0',
+        challenges: [
+          createCloudContestData(),
+          null, // 不正なデータ
+        ],
+      };
+
+      const result = importProblems(JSON.stringify(data), {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(1);
+      expect(result.data![0].id).toBe('cc-challenge-1');
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('不正な JSON でエラーを返すべき', () => {
+      const result = importProblems('{ invalid }', {
+        format: 'cloud-contest',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('Import failed:');
+    });
+  });
+
+  describe('detectFormat (cloud-contest)', () => {
+    it('Cloud Contest ファイルを検出できるべき', () => {
+      expect(detectFormat('challenge.cloudcontest.json')).toBe('cloud-contest');
+      expect(detectFormat('problem.cc.json')).toBe('cloud-contest');
+    });
+  });
+
+  describe('ラウンドトリップ (cloud-contest)', () => {
+    it('Cloud Contest 形式でエクスポートしてインポートしたデータが一致するべき', () => {
+      const original = createTestProblem();
+      const exported = exportProblem(original, { format: 'cloud-contest' });
+      expect(exported.success).toBe(true);
+
+      const imported = importProblem(exported.data!, {
+        format: 'cloud-contest',
+      });
+      expect(imported.success).toBe(true);
+
+      expect(imported.data!.id).toBe(original.id);
+      expect(imported.data!.title).toBe(original.title);
+      expect(imported.data!.description?.objectives).toEqual(
+        original.description.objectives
+      );
+    });
   });
 });

--- a/backend/services/problem-management/src/__tests__/helpers/prisma-mock.ts
+++ b/backend/services/problem-management/src/__tests__/helpers/prisma-mock.ts
@@ -140,6 +140,15 @@ export function createMockPrisma() {
       create: vi.fn(),
       findMany: vi.fn(),
     },
+    problemTemplate: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
     $transaction: vi.fn((fn) => fn(createMockPrisma())),
     $executeRaw: vi.fn(),
   };

--- a/backend/services/problem-management/src/__tests__/prisma-template-repository.test.ts
+++ b/backend/services/problem-management/src/__tests__/prisma-template-repository.test.ts
@@ -1,0 +1,611 @@
+/**
+ * PrismaProblemTemplateRepository Tests
+ *
+ * Prisma問題テンプレートリポジトリの単体テスト
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockPrisma, type MockPrisma } from './helpers/prisma-mock';
+
+// Prisma をモック
+vi.mock('../repositories/prisma-client', () => ({
+  prisma: createMockPrisma(),
+}));
+
+import { PrismaProblemTemplateRepository } from '../repositories/template-repository';
+import { prisma } from '../repositories/prisma-client';
+
+describe('PrismaProblemTemplateRepository', () => {
+  let mockPrisma: MockPrisma;
+  let repository: PrismaProblemTemplateRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = prisma as unknown as MockPrisma;
+    repository = new PrismaProblemTemplateRepository();
+  });
+
+  describe('create', () => {
+    it('新しいテンプレートを作成できるべき', async () => {
+      const mockTemplate = {
+        id: 'template-1',
+        name: 'Test Template',
+        description: 'Test Description',
+        type: 'GAMEDAY',
+        category: 'ARCHITECTURE',
+        difficulty: 'MEDIUM',
+        status: 'DRAFT',
+        variables: [
+          {
+            name: 'region',
+            type: 'select',
+            description: 'AWS Region',
+            options: ['ap-northeast-1', 'us-east-1'],
+            required: true,
+          },
+        ],
+        overviewTemplate: 'Deploy resources in {{region}}',
+        objectivesTemplate: ['Create VPC', 'Launch EC2'],
+        hintsTemplate: ['Check VPC settings'],
+        prerequisites: ['AWS knowledge'],
+        estimatedTimeMinutes: 60,
+        providers: ['AWS'],
+        templateType: 'CLOUDFORMATION',
+        templateContent: 'AWSTemplateFormatVersion: 2010-09-09',
+        regions: { aws: ['ap-northeast-1'] },
+        deploymentTimeout: 30,
+        scoringType: 'LAMBDA',
+        criteriaTemplate: [{ weight: 1, maxPoints: 100 }],
+        scoringTimeout: 10,
+        tags: ['aws', 'vpc'],
+        author: 'Test Author',
+        version: '1.0.0',
+        usageCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrisma.problemTemplate.create.mockResolvedValue(mockTemplate);
+
+      const result = await repository.create({
+        name: 'Test Template',
+        description: 'Test Description',
+        type: 'gameday',
+        category: 'architecture',
+        difficulty: 'medium',
+        status: 'draft',
+        variables: [
+          {
+            name: 'region',
+            type: 'select',
+            description: 'AWS Region',
+            options: ['ap-northeast-1', 'us-east-1'],
+            required: true,
+          },
+        ],
+        descriptionTemplate: {
+          overviewTemplate: 'Deploy resources in {{region}}',
+          objectivesTemplate: ['Create VPC', 'Launch EC2'],
+          hintsTemplate: ['Check VPC settings'],
+          prerequisites: ['AWS knowledge'],
+          estimatedTime: 60,
+        },
+        deployment: {
+          providers: ['aws'],
+          templateType: 'cloudformation',
+          templateContent: 'AWSTemplateFormatVersion: 2010-09-09',
+          regions: { aws: ['ap-northeast-1'] },
+          timeout: 30,
+        },
+        scoring: {
+          type: 'lambda',
+          criteriaTemplate: [{ weight: 1, maxPoints: 100 }],
+          timeoutMinutes: 10,
+        },
+        tags: ['aws', 'vpc'],
+        author: 'Test Author',
+        version: '1.0.0',
+        usageCount: 0,
+      });
+
+      expect(result.name).toBe('Test Template');
+      expect(result.type).toBe('gameday');
+      expect(result.category).toBe('architecture');
+      expect(result.status).toBe('draft');
+    });
+  });
+
+  describe('update', () => {
+    it('テンプレートを更新できるべき', async () => {
+      const mockTemplate = {
+        id: 'template-1',
+        name: 'Updated Template',
+        description: 'Updated Description',
+        type: 'JAM',
+        category: 'SECURITY',
+        difficulty: 'HARD',
+        status: 'PUBLISHED',
+        variables: [],
+        overviewTemplate: 'Updated overview',
+        objectivesTemplate: ['New Objective'],
+        hintsTemplate: [],
+        prerequisites: [],
+        estimatedTimeMinutes: 120,
+        providers: ['GCP'],
+        templateType: 'TERRAFORM',
+        templateContent: 'resource "google_compute_instance"',
+        regions: { gcp: ['asia-northeast1'] },
+        deploymentTimeout: 60,
+        scoringType: 'API',
+        criteriaTemplate: [],
+        scoringTimeout: 15,
+        tags: ['gcp'],
+        author: 'Test Author',
+        version: '2.0.0',
+        usageCount: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrisma.problemTemplate.update.mockResolvedValue(mockTemplate);
+
+      const result = await repository.update('template-1', {
+        name: 'Updated Template',
+        type: 'jam',
+        category: 'security',
+        difficulty: 'hard',
+        status: 'published',
+        version: '2.0.0',
+      });
+
+      expect(result.name).toBe('Updated Template');
+      expect(result.type).toBe('jam');
+      expect(result.status).toBe('published');
+    });
+
+    it('部分的な更新ができるべき', async () => {
+      const mockTemplate = {
+        id: 'template-1',
+        name: 'Test Template',
+        description: 'Test Description',
+        type: 'GAMEDAY',
+        category: 'ARCHITECTURE',
+        difficulty: 'MEDIUM',
+        status: 'PUBLISHED',
+        variables: [],
+        overviewTemplate: 'Overview',
+        objectivesTemplate: [],
+        hintsTemplate: [],
+        prerequisites: [],
+        estimatedTimeMinutes: null,
+        providers: ['AWS'],
+        templateType: 'CLOUDFORMATION',
+        templateContent: 'content',
+        regions: {},
+        deploymentTimeout: 30,
+        scoringType: 'LAMBDA',
+        criteriaTemplate: [],
+        scoringTimeout: 10,
+        tags: [],
+        author: 'Test Author',
+        version: '1.0.0',
+        usageCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrisma.problemTemplate.update.mockResolvedValue(mockTemplate);
+
+      const result = await repository.update('template-1', {
+        status: 'published',
+      });
+
+      expect(result.status).toBe('published');
+    });
+  });
+
+  describe('delete', () => {
+    it('テンプレートを削除できるべき', async () => {
+      mockPrisma.problemTemplate.delete.mockResolvedValue({});
+
+      await repository.delete('template-1');
+
+      expect(mockPrisma.problemTemplate.delete).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('IDでテンプレートを取得できるべき', async () => {
+      const mockTemplate = {
+        id: 'template-1',
+        name: 'Test Template',
+        description: 'Test Description',
+        type: 'GAMEDAY',
+        category: 'COST',
+        difficulty: 'EASY',
+        status: 'DRAFT',
+        variables: [],
+        overviewTemplate: 'Overview',
+        objectivesTemplate: ['Obj 1'],
+        hintsTemplate: ['Hint 1'],
+        prerequisites: [],
+        estimatedTimeMinutes: 30,
+        providers: ['AWS'],
+        templateType: 'SAM',
+        templateContent: 'Transform: AWS::Serverless-2016-10-31',
+        regions: {},
+        deploymentTimeout: 30,
+        scoringType: 'CONTAINER',
+        criteriaTemplate: [],
+        scoringTimeout: 10,
+        tags: ['serverless'],
+        author: 'Test Author',
+        version: '1.0.0',
+        usageCount: 10,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrisma.problemTemplate.findUnique.mockResolvedValue(mockTemplate);
+
+      const result = await repository.findById('template-1');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('template-1');
+      expect(result?.category).toBe('cost');
+      expect(result?.difficulty).toBe('easy');
+      expect(result?.usageCount).toBe(10);
+    });
+
+    it('見つからない場合は null を返すべき', async () => {
+      mockPrisma.problemTemplate.findUnique.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAll', () => {
+    it('すべてのテンプレートを取得できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      await repository.findAll();
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalled();
+    });
+
+    it('フィルター条件でテンプレートを取得できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      await repository.findAll({
+        type: 'gameday',
+        category: 'reliability',
+        difficulty: 'medium',
+        status: 'published',
+        author: 'Test Author',
+        tags: ['aws'],
+        provider: 'aws',
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            type: 'GAMEDAY',
+            category: 'RELIABILITY',
+            difficulty: 'MEDIUM',
+            status: 'PUBLISHED',
+            author: 'Test Author',
+          }),
+        })
+      );
+    });
+
+    it('ページネーションが動作するべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      await repository.findAll({
+        limit: 20,
+        offset: 40,
+      });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 40,
+          take: 20,
+        })
+      );
+    });
+  });
+
+  describe('search', () => {
+    it('テキスト検索ができるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      const result = await repository.search({
+        query: 'aws vpc',
+      });
+
+      expect(result.templates).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('フィルター条件で検索できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      await repository.search({
+        query: 'aws',
+        type: 'gameday',
+        category: 'architecture',
+        difficulty: 'medium',
+        status: 'published',
+        provider: 'aws',
+        tags: ['vpc'],
+        sortBy: 'usageCount',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalled();
+    });
+
+    it('名前でソートできるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      await repository.search({ sortBy: 'name' });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { name: 'asc' },
+        })
+      );
+    });
+
+    it('使用回数でソートできるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      await repository.search({ sortBy: 'usageCount' });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { usageCount: 'desc' },
+        })
+      );
+    });
+
+    it('作成日時でソートできるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      await repository.search({ sortBy: 'newest' });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        })
+      );
+    });
+
+    it('更新日時でソートできるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      await repository.search({ sortBy: 'updated' });
+
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { updatedAt: 'desc' },
+        })
+      );
+    });
+
+    it('ページネーションが動作するべき', async () => {
+      const mockTemplates = [
+        {
+          id: 'template-1',
+          name: 'Template 1',
+          description: 'Desc',
+          type: 'GAMEDAY',
+          category: 'ARCHITECTURE',
+          difficulty: 'MEDIUM',
+          status: 'PUBLISHED',
+          variables: [],
+          overviewTemplate: 'Overview',
+          objectivesTemplate: [],
+          hintsTemplate: [],
+          prerequisites: [],
+          estimatedTimeMinutes: null,
+          providers: ['AWS'],
+          templateType: 'CLOUDFORMATION',
+          templateContent: '',
+          regions: {},
+          deploymentTimeout: 30,
+          scoringType: 'LAMBDA',
+          criteriaTemplate: [],
+          scoringTimeout: 10,
+          tags: [],
+          author: 'Author',
+          version: '1.0.0',
+          usageCount: 0,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      mockPrisma.problemTemplate.findMany.mockResolvedValue(mockTemplates);
+      mockPrisma.problemTemplate.count.mockResolvedValue(50);
+
+      const result = await repository.search({ page: 2, limit: 10 });
+
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
+      expect(result.hasMore).toBe(true);
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 10,
+        })
+      );
+    });
+  });
+
+  describe('incrementUsageCount', () => {
+    it('使用回数を増やせるべき', async () => {
+      mockPrisma.problemTemplate.update.mockResolvedValue({});
+
+      await repository.incrementUsageCount('template-1');
+
+      expect(mockPrisma.problemTemplate.update).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+        data: {
+          usageCount: { increment: 1 },
+        },
+      });
+    });
+  });
+
+  describe('count', () => {
+    it('テンプレート数をカウントできるべき', async () => {
+      mockPrisma.problemTemplate.count.mockResolvedValue(10);
+
+      const result = await repository.count();
+
+      expect(result).toBe(10);
+    });
+
+    it('フィルター条件でカウントできるべき', async () => {
+      mockPrisma.problemTemplate.count.mockResolvedValue(5);
+
+      const result = await repository.count({
+        type: 'jam',
+        category: 'operations',
+        difficulty: 'hard',
+        status: 'published',
+      });
+
+      expect(result).toBe(5);
+    });
+  });
+
+  describe('exists', () => {
+    it('存在する場合は true を返すべき', async () => {
+      mockPrisma.problemTemplate.count.mockResolvedValue(1);
+
+      const result = await repository.exists('template-1');
+
+      expect(result).toBe(true);
+    });
+
+    it('存在しない場合は false を返すべき', async () => {
+      mockPrisma.problemTemplate.count.mockResolvedValue(0);
+
+      const result = await repository.exists('nonexistent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('型変換', () => {
+    it('すべての難易度レベルを変換できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      // easy
+      await repository.findAll({ difficulty: 'easy' });
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ difficulty: 'EASY' }),
+        })
+      );
+
+      // medium
+      await repository.findAll({ difficulty: 'medium' });
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ difficulty: 'MEDIUM' }),
+        })
+      );
+
+      // hard
+      await repository.findAll({ difficulty: 'hard' });
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ difficulty: 'HARD' }),
+        })
+      );
+
+      // expert
+      await repository.findAll({ difficulty: 'expert' });
+      expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ difficulty: 'EXPERT' }),
+        })
+      );
+    });
+
+    it('すべてのカテゴリを変換できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      const categories = [
+        'architecture',
+        'security',
+        'cost',
+        'performance',
+        'reliability',
+        'operations',
+      ] as const;
+
+      for (const category of categories) {
+        await repository.findAll({ category });
+        expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              category: category.toUpperCase(),
+            }),
+          })
+        );
+      }
+    });
+
+    it('すべてのクラウドプロバイダーを変換できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      const providers = ['aws', 'gcp', 'azure', 'local'] as const;
+
+      for (const provider of providers) {
+        await repository.findAll({ provider });
+        expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              providers: { has: provider.toUpperCase() },
+            }),
+          })
+        );
+      }
+    });
+
+    it('すべてのステータスを変換できるべき', async () => {
+      mockPrisma.problemTemplate.findMany.mockResolvedValue([]);
+
+      const statuses = ['draft', 'published', 'archived'] as const;
+
+      for (const status of statuses) {
+        await repository.findAll({ status });
+        expect(mockPrisma.problemTemplate.findMany).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              status: status.toUpperCase(),
+            }),
+          })
+        );
+      }
+    });
+  });
+});

--- a/backend/services/problem-management/src/repositories/index.ts
+++ b/backend/services/problem-management/src/repositories/index.ts
@@ -15,3 +15,8 @@ export {
   PrismaProblemRepository,
   PrismaMarketplaceRepository,
 } from './problem-repository';
+export {
+  PrismaProblemTemplateRepository,
+  type IProblemTemplateRepository,
+  type ProblemTemplateFilterOptions,
+} from './template-repository';

--- a/backend/services/problem-management/src/repositories/template-repository.ts
+++ b/backend/services/problem-management/src/repositories/template-repository.ts
@@ -1,0 +1,465 @@
+/**
+ * Prisma Problem Template Repository
+ *
+ * PostgreSQL を使用した問題テンプレートリポジトリ実装
+ */
+
+import type {
+  ProblemTemplate as PrismaProblemTemplate,
+  ProblemType as PrismaProblemType,
+  ProblemCategory as PrismaProblemCategory,
+  DifficultyLevel as PrismaDifficultyLevel,
+  CloudProvider as PrismaCloudProvider,
+  TemplateType as PrismaTemplateType,
+  ScoringFunctionType as PrismaScoringFunctionType,
+  ProblemTemplateStatus as PrismaProblemTemplateStatus,
+} from '@prisma/client';
+import { prisma } from './prisma-client';
+import type {
+  ProblemTemplate,
+  ProblemTemplateStatus,
+  ProblemTemplateVariable,
+  ProblemTemplateSearchQuery,
+  ProblemTemplateSearchResult,
+  ProblemType,
+  ProblemCategory,
+  DifficultyLevel,
+  CloudProvider,
+  DeploymentTemplateType,
+  ScoringCriterion,
+} from '../types';
+
+/**
+ * 問題テンプレートリポジトリインターフェース
+ */
+export interface IProblemTemplateRepository {
+  create(
+    template: Omit<ProblemTemplate, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<ProblemTemplate>;
+  update(
+    id: string,
+    updates: Partial<ProblemTemplate>
+  ): Promise<ProblemTemplate>;
+  delete(id: string): Promise<void>;
+  findById(id: string): Promise<ProblemTemplate | null>;
+  findAll(options?: ProblemTemplateFilterOptions): Promise<ProblemTemplate[]>;
+  search(
+    query: ProblemTemplateSearchQuery
+  ): Promise<ProblemTemplateSearchResult>;
+  incrementUsageCount(id: string): Promise<void>;
+  count(options?: ProblemTemplateFilterOptions): Promise<number>;
+  exists(id: string): Promise<boolean>;
+}
+
+export interface ProblemTemplateFilterOptions {
+  type?: ProblemType;
+  category?: ProblemCategory;
+  difficulty?: DifficultyLevel;
+  status?: ProblemTemplateStatus;
+  author?: string;
+  tags?: string[];
+  provider?: CloudProvider;
+  offset?: number;
+  limit?: number;
+}
+
+// =============================================================================
+// 型変換ユーティリティ
+// =============================================================================
+
+function toPrismaType(type: ProblemType): PrismaProblemType {
+  const map: Record<ProblemType, PrismaProblemType> = {
+    gameday: 'GAMEDAY',
+    jam: 'JAM',
+  };
+  return map[type];
+}
+
+function toPrismaCategory(category: ProblemCategory): PrismaProblemCategory {
+  const map: Record<ProblemCategory, PrismaProblemCategory> = {
+    architecture: 'ARCHITECTURE',
+    security: 'SECURITY',
+    cost: 'COST',
+    performance: 'PERFORMANCE',
+    reliability: 'RELIABILITY',
+    operations: 'OPERATIONS',
+  };
+  return map[category];
+}
+
+function toPrismaDifficulty(
+  difficulty: DifficultyLevel
+): PrismaDifficultyLevel {
+  const map: Record<DifficultyLevel, PrismaDifficultyLevel> = {
+    easy: 'EASY',
+    medium: 'MEDIUM',
+    hard: 'HARD',
+    expert: 'EXPERT',
+  };
+  return map[difficulty];
+}
+
+function toPrismaCloudProvider(provider: CloudProvider): PrismaCloudProvider {
+  const map: Record<CloudProvider, PrismaCloudProvider> = {
+    aws: 'AWS',
+    gcp: 'GCP',
+    azure: 'AZURE',
+    local: 'LOCAL',
+  };
+  return map[provider];
+}
+
+function toPrismaTemplateType(
+  type: DeploymentTemplateType
+): PrismaTemplateType {
+  const map: Record<DeploymentTemplateType, PrismaTemplateType> = {
+    cloudformation: 'CLOUDFORMATION',
+    sam: 'SAM',
+    cdk: 'CDK',
+    terraform: 'TERRAFORM',
+    'deployment-manager': 'DEPLOYMENT_MANAGER',
+    arm: 'ARM',
+    'docker-compose': 'DOCKER_COMPOSE',
+  };
+  return map[type];
+}
+
+function toPrismaScoringType(
+  type: 'lambda' | 'container' | 'api' | 'manual'
+): PrismaScoringFunctionType {
+  const map: Record<string, PrismaScoringFunctionType> = {
+    lambda: 'LAMBDA',
+    container: 'CONTAINER',
+    api: 'API',
+    manual: 'MANUAL',
+  };
+  return map[type];
+}
+
+function toPrismaTemplateStatus(
+  status: ProblemTemplateStatus
+): PrismaProblemTemplateStatus {
+  const map: Record<ProblemTemplateStatus, PrismaProblemTemplateStatus> = {
+    draft: 'DRAFT',
+    published: 'PUBLISHED',
+    archived: 'ARCHIVED',
+  };
+  return map[status];
+}
+
+/**
+ * Prisma Problem Template を内部型に変換
+ */
+function toProblemTemplate(
+  prismaTemplate: PrismaProblemTemplate
+): ProblemTemplate {
+  return {
+    id: prismaTemplate.id,
+    name: prismaTemplate.name,
+    description: prismaTemplate.description,
+    type: prismaTemplate.type.toLowerCase() as ProblemType,
+    category: prismaTemplate.category.toLowerCase() as ProblemCategory,
+    difficulty: prismaTemplate.difficulty.toLowerCase() as DifficultyLevel,
+    status: prismaTemplate.status.toLowerCase() as ProblemTemplateStatus,
+    variables: prismaTemplate.variables as ProblemTemplateVariable[],
+    descriptionTemplate: {
+      overviewTemplate: prismaTemplate.overviewTemplate,
+      objectivesTemplate: prismaTemplate.objectivesTemplate,
+      hintsTemplate: prismaTemplate.hintsTemplate,
+      prerequisites: prismaTemplate.prerequisites,
+      estimatedTime: prismaTemplate.estimatedTimeMinutes ?? undefined,
+    },
+    deployment: {
+      providers: prismaTemplate.providers.map(
+        (p) => p.toLowerCase() as CloudProvider
+      ),
+      templateType: prismaTemplate.templateType
+        .toLowerCase()
+        .replace('_', '-') as DeploymentTemplateType,
+      templateContent: prismaTemplate.templateContent,
+      regions: prismaTemplate.regions as Partial<
+        Record<CloudProvider, string[]>
+      >,
+      timeout: prismaTemplate.deploymentTimeout,
+    },
+    scoring: {
+      type: prismaTemplate.scoringType.toLowerCase() as
+        | 'lambda'
+        | 'container'
+        | 'api'
+        | 'manual',
+      criteriaTemplate: prismaTemplate.criteriaTemplate as Omit<
+        ScoringCriterion,
+        'name'
+      >[],
+      timeoutMinutes: prismaTemplate.scoringTimeout,
+    },
+    tags: prismaTemplate.tags,
+    author: prismaTemplate.author,
+    version: prismaTemplate.version,
+    usageCount: prismaTemplate.usageCount,
+    createdAt: prismaTemplate.createdAt,
+    updatedAt: prismaTemplate.updatedAt,
+  };
+}
+
+/**
+ * Prisma Problem Template Repository 実装
+ */
+export class PrismaProblemTemplateRepository implements IProblemTemplateRepository {
+  async create(
+    template: Omit<ProblemTemplate, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<ProblemTemplate> {
+    const created = await prisma.problemTemplate.create({
+      data: {
+        name: template.name,
+        description: template.description,
+        type: toPrismaType(template.type),
+        category: toPrismaCategory(template.category),
+        difficulty: toPrismaDifficulty(template.difficulty),
+        status: toPrismaTemplateStatus(template.status),
+        variables: template.variables as unknown as Record<string, unknown>[],
+        overviewTemplate: template.descriptionTemplate.overviewTemplate,
+        objectivesTemplate: template.descriptionTemplate.objectivesTemplate,
+        hintsTemplate: template.descriptionTemplate.hintsTemplate,
+        prerequisites: template.descriptionTemplate.prerequisites || [],
+        estimatedTimeMinutes: template.descriptionTemplate.estimatedTime,
+        providers: template.deployment.providers.map(toPrismaCloudProvider),
+        templateType: toPrismaTemplateType(template.deployment.templateType),
+        templateContent: template.deployment.templateContent,
+        regions: template.deployment.regions || {},
+        deploymentTimeout: template.deployment.timeout || 60,
+        scoringType: toPrismaScoringType(template.scoring.type),
+        criteriaTemplate: template.scoring
+          .criteriaTemplate as unknown as Record<string, unknown>[],
+        scoringTimeout: template.scoring.timeoutMinutes,
+        tags: template.tags,
+        author: template.author,
+        version: template.version,
+        usageCount: template.usageCount || 0,
+      },
+    });
+
+    return toProblemTemplate(created);
+  }
+
+  async update(
+    id: string,
+    updates: Partial<ProblemTemplate>
+  ): Promise<ProblemTemplate> {
+    const data: Record<string, unknown> = {};
+
+    if (updates.name !== undefined) data.name = updates.name;
+    if (updates.description !== undefined)
+      data.description = updates.description;
+    if (updates.type !== undefined) data.type = toPrismaType(updates.type);
+    if (updates.category !== undefined)
+      data.category = toPrismaCategory(updates.category);
+    if (updates.difficulty !== undefined)
+      data.difficulty = toPrismaDifficulty(updates.difficulty);
+    if (updates.status !== undefined)
+      data.status = toPrismaTemplateStatus(updates.status);
+    if (updates.variables !== undefined) data.variables = updates.variables;
+    if (updates.descriptionTemplate?.overviewTemplate !== undefined) {
+      data.overviewTemplate = updates.descriptionTemplate.overviewTemplate;
+    }
+    if (updates.descriptionTemplate?.objectivesTemplate !== undefined) {
+      data.objectivesTemplate = updates.descriptionTemplate.objectivesTemplate;
+    }
+    if (updates.descriptionTemplate?.hintsTemplate !== undefined) {
+      data.hintsTemplate = updates.descriptionTemplate.hintsTemplate;
+    }
+    if (updates.descriptionTemplate?.prerequisites !== undefined) {
+      data.prerequisites = updates.descriptionTemplate.prerequisites;
+    }
+    if (updates.descriptionTemplate?.estimatedTime !== undefined) {
+      data.estimatedTimeMinutes = updates.descriptionTemplate.estimatedTime;
+    }
+    if (updates.deployment?.providers !== undefined) {
+      data.providers = updates.deployment.providers.map(toPrismaCloudProvider);
+    }
+    if (updates.deployment?.templateType !== undefined) {
+      data.templateType = toPrismaTemplateType(updates.deployment.templateType);
+    }
+    if (updates.deployment?.templateContent !== undefined) {
+      data.templateContent = updates.deployment.templateContent;
+    }
+    if (updates.deployment?.regions !== undefined) {
+      data.regions = updates.deployment.regions;
+    }
+    if (updates.deployment?.timeout !== undefined) {
+      data.deploymentTimeout = updates.deployment.timeout;
+    }
+    if (updates.scoring?.type !== undefined) {
+      data.scoringType = toPrismaScoringType(updates.scoring.type);
+    }
+    if (updates.scoring?.criteriaTemplate !== undefined) {
+      data.criteriaTemplate = updates.scoring.criteriaTemplate;
+    }
+    if (updates.scoring?.timeoutMinutes !== undefined) {
+      data.scoringTimeout = updates.scoring.timeoutMinutes;
+    }
+    if (updates.tags !== undefined) data.tags = updates.tags;
+    if (updates.author !== undefined) data.author = updates.author;
+    if (updates.version !== undefined) data.version = updates.version;
+
+    const updated = await prisma.problemTemplate.update({
+      where: { id },
+      data,
+    });
+
+    return toProblemTemplate(updated);
+  }
+
+  async delete(id: string): Promise<void> {
+    await prisma.problemTemplate.delete({
+      where: { id },
+    });
+  }
+
+  async findById(id: string): Promise<ProblemTemplate | null> {
+    const template = await prisma.problemTemplate.findUnique({
+      where: { id },
+    });
+
+    return template ? toProblemTemplate(template) : null;
+  }
+
+  async findAll(
+    options?: ProblemTemplateFilterOptions
+  ): Promise<ProblemTemplate[]> {
+    const where = this.buildWhereClause(options);
+
+    const templates = await prisma.problemTemplate.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      skip: options?.offset,
+      take: options?.limit,
+    });
+
+    return templates.map(toProblemTemplate);
+  }
+
+  async search(
+    query: ProblemTemplateSearchQuery
+  ): Promise<ProblemTemplateSearchResult> {
+    const where: Record<string, unknown> = {};
+
+    if (query.query) {
+      where.OR = [
+        { name: { contains: query.query, mode: 'insensitive' } },
+        { description: { contains: query.query, mode: 'insensitive' } },
+        { tags: { hasSome: [query.query.toLowerCase()] } },
+      ];
+    }
+    if (query.type) {
+      where.type = toPrismaType(query.type);
+    }
+    if (query.category) {
+      where.category = toPrismaCategory(query.category);
+    }
+    if (query.difficulty) {
+      where.difficulty = toPrismaDifficulty(query.difficulty);
+    }
+    if (query.status) {
+      where.status = toPrismaTemplateStatus(query.status);
+    }
+    if (query.provider) {
+      where.providers = { has: toPrismaCloudProvider(query.provider) };
+    }
+    if (query.tags && query.tags.length > 0) {
+      where.tags = { hasSome: query.tags };
+    }
+
+    let orderBy: Record<string, 'asc' | 'desc'> = { updatedAt: 'desc' };
+    switch (query.sortBy) {
+      case 'name':
+        orderBy = { name: 'asc' };
+        break;
+      case 'usageCount':
+        orderBy = { usageCount: 'desc' };
+        break;
+      case 'newest':
+        orderBy = { createdAt: 'desc' };
+        break;
+      case 'updated':
+        orderBy = { updatedAt: 'desc' };
+        break;
+    }
+
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+    const skip = (page - 1) * limit;
+
+    const [templates, total] = await Promise.all([
+      prisma.problemTemplate.findMany({
+        where,
+        orderBy,
+        skip,
+        take: limit,
+      }),
+      prisma.problemTemplate.count({ where }),
+    ]);
+
+    return {
+      templates: templates.map(toProblemTemplate),
+      total,
+      page,
+      limit,
+      hasMore: skip + limit < total,
+    };
+  }
+
+  async incrementUsageCount(id: string): Promise<void> {
+    await prisma.problemTemplate.update({
+      where: { id },
+      data: {
+        usageCount: { increment: 1 },
+      },
+    });
+  }
+
+  async count(options?: ProblemTemplateFilterOptions): Promise<number> {
+    const where = this.buildWhereClause(options);
+    return prisma.problemTemplate.count({ where });
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const count = await prisma.problemTemplate.count({
+      where: { id },
+    });
+    return count > 0;
+  }
+
+  private buildWhereClause(
+    options?: ProblemTemplateFilterOptions
+  ): Record<string, unknown> {
+    const where: Record<string, unknown> = {};
+
+    if (options?.type) {
+      where.type = toPrismaType(options.type);
+    }
+    if (options?.category) {
+      where.category = toPrismaCategory(options.category);
+    }
+    if (options?.difficulty) {
+      where.difficulty = toPrismaDifficulty(options.difficulty);
+    }
+    if (options?.status) {
+      where.status = toPrismaTemplateStatus(options.status);
+    }
+    if (options?.author) {
+      where.author = options.author;
+    }
+    if (options?.tags && options.tags.length > 0) {
+      where.tags = { hasSome: options.tags };
+    }
+    if (options?.provider) {
+      where.providers = { has: toPrismaCloudProvider(options.provider) };
+    }
+
+    return where;
+  }
+}
+
+export default PrismaProblemTemplateRepository;

--- a/backend/services/problem-management/src/types/index.ts
+++ b/backend/services/problem-management/src/types/index.ts
@@ -386,3 +386,90 @@ export interface MarketplaceSearchResult {
   limit: number;
   hasMore: boolean;
 }
+
+// =============================================================================
+// Problem Template Types
+// =============================================================================
+
+export type ProblemTemplateStatus = 'draft' | 'published' | 'archived';
+
+export interface ProblemTemplateVariable {
+  name: string;
+  type: 'string' | 'number' | 'boolean' | 'select';
+  description: string;
+  defaultValue?: string | number | boolean;
+  options?: string[]; // for select type
+  required: boolean;
+}
+
+export interface ProblemTemplateDeployment {
+  providers: CloudProvider[];
+  templateType: DeploymentTemplateType;
+  templateContent: string; // テンプレートのコンテンツ（変数プレースホルダー含む）
+  regions?: Partial<Record<CloudProvider, string[]>>;
+  timeout?: number;
+}
+
+export interface ProblemTemplateScoring {
+  type: 'lambda' | 'container' | 'api' | 'manual';
+  criteriaTemplate: Omit<ScoringCriterion, 'name'>[];
+  timeoutMinutes: number;
+}
+
+export interface ProblemTemplate {
+  id: string;
+  name: string;
+  description: string;
+  type: ProblemType;
+  category: ProblemCategory;
+  difficulty: DifficultyLevel;
+  status: ProblemTemplateStatus;
+  variables: ProblemTemplateVariable[];
+  descriptionTemplate: {
+    overviewTemplate: string;
+    objectivesTemplate: string[];
+    hintsTemplate: string[];
+    prerequisites?: string[];
+    estimatedTime?: number;
+  };
+  deployment: ProblemTemplateDeployment;
+  scoring: ProblemTemplateScoring;
+  tags: string[];
+  author: string;
+  version: string;
+  usageCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateProblemFromTemplateInput {
+  templateId: string;
+  variables: Record<string, string | number | boolean>;
+  title: string;
+  overrides?: {
+    category?: ProblemCategory;
+    difficulty?: DifficultyLevel;
+    tags?: string[];
+  };
+}
+
+export interface ProblemTemplateSearchQuery {
+  query?: string;
+  type?: ProblemType;
+  category?: ProblemCategory;
+  difficulty?: DifficultyLevel;
+  provider?: CloudProvider;
+  status?: ProblemTemplateStatus;
+  tags?: string[];
+  sortBy?: 'name' | 'usageCount' | 'newest' | 'updated';
+  page?: number;
+  limit?: number;
+}
+
+export interface ProblemTemplateSearchResult {
+  templates: ProblemTemplate[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Summary
- 問題作成を効率化するためのテンプレート機能を追加
- ProblemTemplateモデルとPrismaスキーマを追加
- テンプレートCRUD操作用リポジトリ層を実装
- テンプレート管理用管理者APIエンドポイントを追加
  - GET/POST /admin/templates
  - GET/PUT/DELETE /admin/templates/:templateId
  - POST /admin/templates/:templateId/create-problem
- テンプレート変数のバリデーション機能を追加
- テンプレート↔問題変換機能を実装
- テストカバレッジ92.81%達成

## Test plan
- [x] 全630テストがパス
- [x] カバレッジ閾値（90%）をクリア
- [x] `make before-commit` の全チェックをパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced problem template system for reusable problem definitions with status management (Draft, Published, Archived)
  * Added Cloud Contest format support for seamless import and export of problem definitions
  * Enabled problem generation from templates with variable substitution and override capabilities
  * Implemented comprehensive template search, filtering, and usage tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->