### PR TITLE
fix(scripts): local-setup.sh に provisioning-completion Lambda のビルドを追加

### DIFF
--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -78,6 +78,13 @@ bun install
 bun run deploy
 echo "✅ Tenant Provisioner Lambda built!"
 
+echo ""
+echo "🔨 Building Provisioning Completion Lambda (Control Plane)..."
+cd "$PROJECT_ROOT/backend/services/control-plane/provisioning-completion"
+bun install
+bun run deploy
+echo "✅ Provisioning Completion Lambda built!"
+
 # 3. Terraform でデプロイ
 echo ""
 echo "🏗  Deploying infrastructure to LocalStack..."
@@ -117,7 +124,8 @@ echo "  - S3:          http://localhost:4566"
 echo ""
 echo "Architecture:"
 echo "  Control Plane:     DynamoDB Stream → Provisioning Lambda → EventBridge"
-echo "  Application Plane: EventBridge → Tenant Provisioner → S3"
+echo "                     EventBridge → Provisioning Completion → DynamoDB"
+echo "  Application Plane: EventBridge → Tenant Provisioner → S3 → EventBridge"
 echo ""
 echo "Test commands:"
 echo "  # Create a tenant (triggers full provisioning flow)"
@@ -130,3 +138,6 @@ echo "  aws --endpoint-url=http://localhost:4566 logs tail /aws/lambda/tenkaclou
 echo ""
 echo "  # Check Tenant Provisioner logs (Application Plane)"
 echo "  aws --endpoint-url=http://localhost:4566 logs tail /aws/lambda/tenkacloud-local-tenant-provisioner --follow"
+echo ""
+echo "  # Check Provisioning Completion logs (Control Plane)"
+echo "  aws --endpoint-url=http://localhost:4566 logs tail /aws/lambda/tenkacloud-local-provisioning-completion --follow"


### PR DESCRIPTION
## 変更内容
- provisioning-completion Lambda のビルドステップを追加
- アーキテクチャ図を完全なイベントフローに更新
- provisioning-completion のログ確認コマンドを追加

## 背景
commit 1fae142 で provisioning-completion Lambda を実装したが、
local-setup.sh にビルドステップが含まれていなかった。

## アーキテクチャ（更新後）
```
Control Plane:     DynamoDB Stream → Provisioning Lambda → EventBridge
                   EventBridge → Provisioning Completion → DynamoDB
Application Plane: EventBridge → Tenant Provisioner → S3 → EventBridge
```

## テスト
- `make before-commit` 全チェック通過
- provisioning-completion テスト: 7/7 passed
- カバレッジ: 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local setup process with a new deployment component integration.
  * Refined deployment architecture flow for improved system organization.
  
* **Documentation**
  * Extended verification and testing instructions with additional monitoring commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->