### PR TITLE
feat(control-plane): ダッシュボードを実データに接続

### DIFF
--- a/apps/control-plane/app/dashboard/__tests__/page.test.tsx
+++ b/apps/control-plane/app/dashboard/__tests__/page.test.tsx
@@ -6,9 +6,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { auth } from '@/auth';
 import DashboardPage from '../page';
 
+// API のモック（hoisted で先に定義）
+const mockFetchDashboardStats = vi.hoisted(() => vi.fn());
+const mockFetchActivities = vi.hoisted(() => vi.fn());
+
 // auth のモック
 vi.mock('@/auth', () => ({
   auth: vi.fn(),
+}));
+
+vi.mock('@/lib/api/stats-api', () => ({
+  fetchDashboardStats: mockFetchDashboardStats,
+}));
+
+vi.mock('@/lib/api/activities-api', () => ({
+  fetchActivities: mockFetchActivities,
 }));
 
 // next/navigation のモック
@@ -58,6 +70,16 @@ describe('DashboardPage コンポーネント', () => {
         user: { name: 'Test User', email: 'test@example.com' },
         expires: '',
       });
+      mockFetchDashboardStats.mockResolvedValue({
+        activeTenants: 5,
+        totalTenants: 10,
+        systemStatus: 'healthy',
+        uptimePercentage: 100,
+      });
+      mockFetchActivities.mockResolvedValue({
+        data: [],
+        pagination: { limit: 5, hasNextPage: false },
+      });
     });
 
     it('ダッシュボードタイトルを表示すべき', async () => {
@@ -92,7 +114,7 @@ describe('DashboardPage コンポーネント', () => {
       render(Component);
       expect(screen.getByText('アクティブテナント')).toBeInTheDocument();
       expect(screen.getByText('システムステータス')).toBeInTheDocument();
-      expect(screen.getByText('総ユーザー数')).toBeInTheDocument();
+      expect(screen.getByText('総テナント数')).toBeInTheDocument();
     });
 
     it('システムステータスが正常と表示されるべき', async () => {
@@ -100,6 +122,13 @@ describe('DashboardPage コンポーネント', () => {
       render(Component);
       expect(screen.getByText('正常')).toBeInTheDocument();
       expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+
+    it('実際の統計値を表示すべき', async () => {
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('5')).toBeInTheDocument(); // activeTenants
+      expect(screen.getByText('10')).toBeInTheDocument(); // totalTenants
     });
 
     it('クイックアクションセクションを表示すべき', async () => {
@@ -132,6 +161,180 @@ describe('DashboardPage コンポーネント', () => {
       expect(screen.getByText('直近のシステムイベント')).toBeInTheDocument();
       expect(
         screen.getByText('アクティビティはありません')
+      ).toBeInTheDocument();
+    });
+
+    it('統計取得エラー時はハイフンを表示すべき', async () => {
+      mockFetchDashboardStats.mockRejectedValue(new Error('Network error'));
+      const Component = await DashboardPage();
+      render(Component);
+      // stats が null の場合、各項目はハイフン表示
+      const dashElements = screen.getAllByText('-');
+      expect(dashElements.length).toBeGreaterThan(0);
+    });
+
+    it('システムステータスが異常の場合は異常と表示すべき', async () => {
+      mockFetchDashboardStats.mockResolvedValue({
+        activeTenants: 3,
+        totalTenants: 8,
+        systemStatus: 'degraded',
+        uptimePercentage: 95.5,
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('異常')).toBeInTheDocument();
+      expect(screen.getByText('95.5%')).toBeInTheDocument();
+    });
+
+    it('アクティビティを表示すべき', async () => {
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'CREATE',
+            resourceType: 'TENANT',
+            resourceId: '01J456DEF',
+            details: { name: 'Test Tenant' },
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('テナントを作成しました')).toBeInTheDocument();
+    });
+
+    it('アクティビティ取得エラー時は空リストを表示すべき', async () => {
+      mockFetchActivities.mockRejectedValue(new Error('Network error'));
+      const Component = await DashboardPage();
+      render(Component);
+      expect(
+        screen.getByText('アクティビティはありません')
+      ).toBeInTheDocument();
+    });
+
+    it('複数のアクティビティを表示すべき', async () => {
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'CREATE',
+            resourceType: 'TENANT',
+            timestamp: new Date().toISOString(),
+          },
+          {
+            id: '01J456DEF',
+            action: 'UPDATE',
+            resourceType: 'SETTING',
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('テナントを作成しました')).toBeInTheDocument();
+      expect(screen.getByText('設定を更新しました')).toBeInTheDocument();
+    });
+
+    it('アクティビティの相対時間を「N分前」と表示すべき', async () => {
+      const thirtyMinsAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'CREATE',
+            resourceType: 'TENANT',
+            timestamp: thirtyMinsAgo,
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('30分前')).toBeInTheDocument();
+    });
+
+    it('アクティビティの相対時間を「N時間前」と表示すべき', async () => {
+      const fiveHoursAgo = new Date(
+        Date.now() - 5 * 60 * 60 * 1000
+      ).toISOString();
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'UPDATE',
+            resourceType: 'USER',
+            timestamp: fiveHoursAgo,
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('5時間前')).toBeInTheDocument();
+    });
+
+    it('アクティビティの相対時間を「N日前」と表示すべき', async () => {
+      const threeDaysAgo = new Date(
+        Date.now() - 3 * 24 * 60 * 60 * 1000
+      ).toISOString();
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'DELETE',
+            resourceType: 'BATTLE',
+            timestamp: threeDaysAgo,
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      expect(screen.getByText('3日前')).toBeInTheDocument();
+    });
+
+    it('7日以上前のアクティビティは日付形式で表示すべき', async () => {
+      const tenDaysAgo = new Date(
+        Date.now() - 10 * 24 * 60 * 60 * 1000
+      ).toISOString();
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'ACCESS',
+            resourceType: 'PROBLEM',
+            timestamp: tenDaysAgo,
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      // 日本語の日付形式（例: 2024/12/15）が表示される
+      const expectedDate = new Date(tenDaysAgo).toLocaleDateString('ja-JP');
+      expect(screen.getByText(expectedDate)).toBeInTheDocument();
+    });
+
+    it('未知のアクション/リソースタイプはそのまま表示すべき', async () => {
+      mockFetchActivities.mockResolvedValue({
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'UNKNOWN_ACTION' as unknown as 'CREATE',
+            resourceType: 'UNKNOWN_RESOURCE' as unknown as 'TENANT',
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        pagination: { limit: 5, hasNextPage: false },
+      });
+      const Component = await DashboardPage();
+      render(Component);
+      // フォールバック: 元の値がそのまま使用される
+      expect(
+        screen.getByText('UNKNOWN_RESOURCEをUNKNOWN_ACTIONしました')
       ).toBeInTheDocument();
     });
   });

--- a/apps/control-plane/app/dashboard/page.tsx
+++ b/apps/control-plane/app/dashboard/page.tsx
@@ -10,6 +10,68 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { fetchActivities } from '@/lib/api/activities-api';
+import { fetchDashboardStats, type DashboardStats } from '@/lib/api/stats-api';
+import type { Activity } from '@/types/activity';
+
+async function getStats(): Promise<DashboardStats | null> {
+  try {
+    return await fetchDashboardStats();
+  } catch {
+    return null;
+  }
+}
+
+async function getActivities(): Promise<Activity[]> {
+  try {
+    const result = await fetchActivities(5);
+    return result.data;
+  } catch {
+    return [];
+  }
+}
+
+function formatActivityMessage(activity: Activity): string {
+  const actionLabels: Record<string, string> = {
+    CREATE: '作成',
+    UPDATE: '更新',
+    DELETE: '削除',
+    LOGIN: 'ログイン',
+    LOGOUT: 'ログアウト',
+    ACCESS: 'アクセス',
+  };
+
+  const resourceLabels: Record<string, string> = {
+    TENANT: 'テナント',
+    USER: 'ユーザー',
+    BATTLE: 'バトル',
+    PROBLEM: '問題',
+    SETTING: '設定',
+    SYSTEM: 'システム',
+  };
+
+  const action = actionLabels[activity.action] || activity.action;
+  const resource =
+    resourceLabels[activity.resourceType] || activity.resourceType;
+
+  return `${resource}を${action}しました`;
+}
+
+function formatRelativeTime(timestamp: string): string {
+  const now = new Date();
+  const date = new Date(timestamp);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'たった今';
+  if (diffMins < 60) return `${diffMins}分前`;
+  if (diffHours < 24) return `${diffHours}時間前`;
+  if (diffDays < 7) return `${diffDays}日前`;
+
+  return date.toLocaleDateString('ja-JP');
+}
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -17,6 +79,8 @@ export default async function DashboardPage() {
   if (!session?.user) {
     redirect('/login');
   }
+
+  const [stats, activities] = await Promise.all([getStats(), getActivities()]);
 
   return (
     <div className="space-y-8">
@@ -37,7 +101,9 @@ export default async function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
+            <div className="text-2xl font-bold">
+              {stats?.activeTenants ?? '-'}
+            </div>
             <p className="text-xs text-muted-foreground">
               現在稼働中のテナント数
             </p>
@@ -49,21 +115,31 @@ export default async function DashboardPage() {
             <CardTitle className="text-sm font-medium">
               システムステータス
             </CardTitle>
-            <Badge variant="success">正常</Badge>
+            <Badge
+              variant={
+                stats?.systemStatus === 'healthy' ? 'success' : 'destructive'
+              }
+            >
+              {stats?.systemStatus === 'healthy' ? '正常' : '異常'}
+            </Badge>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">100%</div>
+            <div className="text-2xl font-bold">
+              {stats?.uptimePercentage ?? '-'}%
+            </div>
             <p className="text-xs text-muted-foreground">稼働率</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">総ユーザー数</CardTitle>
+            <CardTitle className="text-sm font-medium">総テナント数</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
-            <p className="text-xs text-muted-foreground">全テナント合計</p>
+            <div className="text-2xl font-bold">
+              {stats?.totalTenants ?? '-'}
+            </div>
+            <p className="text-xs text-muted-foreground">登録済みテナント</p>
           </CardContent>
         </Card>
       </div>
@@ -95,9 +171,27 @@ export default async function DashboardPage() {
           <CardDescription>直近のシステムイベント</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">
-            アクティビティはありません
-          </p>
+          {activities.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              アクティビティはありません
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {activities.map((activity) => (
+                <li
+                  key={activity.id}
+                  className="flex items-center justify-between border-b pb-2 last:border-0 last:pb-0"
+                >
+                  <span className="text-sm">
+                    {formatActivityMessage(activity)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatRelativeTime(activity.timestamp)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/apps/control-plane/lib/api/__tests__/activities-api.test.ts
+++ b/apps/control-plane/lib/api/__tests__/activities-api.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('Activities API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('サーバーサイド（window がない場合）', () => {
+    it('アクティビティを取得できるべき', async () => {
+      vi.stubGlobal('window', undefined);
+
+      const { fetchActivities } = await import('../activities-api');
+
+      const mockActivities = {
+        data: [
+          {
+            id: '01J123ABC',
+            action: 'CREATE',
+            resourceType: 'TENANT',
+            resourceId: '01J456DEF',
+            details: { name: 'Test Tenant' },
+            timestamp: '2025-01-01T00:00:00.000Z',
+          },
+        ],
+        pagination: {
+          limit: 10,
+          hasNextPage: false,
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockActivities),
+      });
+
+      const result = await fetchActivities();
+
+      expect(result).toEqual(mockActivities);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/activities?limit=10'),
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('カスタム limit を指定できるべき', async () => {
+      vi.stubGlobal('window', undefined);
+
+      const { fetchActivities } = await import('../activities-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: { limit: 5, hasNextPage: false },
+          }),
+      });
+
+      await fetchActivities(5);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/activities?limit=5'),
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('APIエラー時に例外をスローすべき', async () => {
+      vi.stubGlobal('window', undefined);
+
+      const { fetchActivities } = await import('../activities-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(fetchActivities()).rejects.toThrow(
+        'Failed to fetch activities: 500'
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('環境変数が設定されている場合はそれを使用すべき', async () => {
+      vi.stubGlobal('window', undefined);
+      vi.stubEnv('TENANT_API_BASE_URL', 'http://custom-api:8080/api');
+
+      const { fetchActivities } = await import('../activities-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: { limit: 10, hasNextPage: false },
+          }),
+      });
+
+      await fetchActivities();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://custom-api:8080/api/activities?limit=10',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe('クライアントサイド（window がある場合）', () => {
+    it('クライアント環境変数を使用すべき', async () => {
+      vi.stubGlobal('window', {});
+      vi.stubEnv(
+        'NEXT_PUBLIC_TENANT_API_BASE_URL',
+        'http://client-api:9000/api'
+      );
+
+      const { fetchActivities } = await import('../activities-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: { limit: 10, hasNextPage: false },
+          }),
+      });
+
+      await fetchActivities();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://client-api:9000/api/activities?limit=10',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+
+    it('クライアント環境変数が未設定の場合はデフォルトを使用すべき', async () => {
+      vi.stubGlobal('window', {});
+
+      const { fetchActivities } = await import('../activities-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [],
+            pagination: { limit: 10, hasNextPage: false },
+          }),
+      });
+
+      await fetchActivities();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:3004/api/activities?limit=10',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/apps/control-plane/lib/api/__tests__/settings-api.test.ts
+++ b/apps/control-plane/lib/api/__tests__/settings-api.test.ts
@@ -1,35 +1,262 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { Settings } from '@/types/settings';
-import { saveSettings } from '../settings-api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '@/types/settings';
 
-describe('saveSettings', () => {
-  it('設定を保存できるべき', async () => {
-    vi.useFakeTimers();
-    const mockSettings: Settings = {
-      platform: {
-        platformName: 'Test Platform',
-        language: 'ja',
-        timezone: 'Asia/Tokyo',
-      },
-      appearance: {
-        theme: 'light',
-      },
-      notifications: {
-        emailNotificationsEnabled: true,
-        systemAlertsEnabled: true,
-        maintenanceNotificationsEnabled: true,
-      },
-      security: {
-        mfaRequired: false,
-        sessionTimeoutMinutes: 30,
-        maxLoginAttempts: 5,
-      },
-    };
+describe('Settings API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
 
-    const savePromise = saveSettings(mockSettings);
-    vi.advanceTimersByTime(500);
-    await expect(savePromise).resolves.toBeUndefined();
+  describe('サーバーサイド（window がない場合）', () => {
+    describe('fetchSettings', () => {
+      it('設定を取得できるべき', async () => {
+        vi.stubGlobal('window', undefined);
 
-    vi.useRealTimers();
+        const { fetchSettings } = await import('../settings-api');
+
+        const mockSettings = {
+          platform: {
+            platformName: 'Test Platform',
+            language: 'en',
+            timezone: 'UTC',
+          },
+          security: {
+            mfaRequired: true,
+            sessionTimeoutMinutes: 30,
+            maxLoginAttempts: 3,
+          },
+          notifications: {
+            emailNotificationsEnabled: false,
+            systemAlertsEnabled: true,
+            maintenanceNotificationsEnabled: false,
+          },
+          appearance: {
+            theme: 'dark',
+          },
+        };
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockSettings),
+        });
+
+        const result = await fetchSettings();
+
+        expect(result).toEqual(mockSettings);
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/settings'),
+          { cache: 'no-store' }
+        );
+
+        vi.unstubAllGlobals();
+      });
+
+      it('APIエラー時に例外をスローすべき', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const { fetchSettings } = await import('../settings-api');
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+        });
+
+        await expect(fetchSettings()).rejects.toThrow(
+          'Failed to fetch settings: 500'
+        );
+
+        vi.unstubAllGlobals();
+      });
+
+      it('環境変数が設定されている場合はそれを使用すべき', async () => {
+        vi.stubGlobal('window', undefined);
+        vi.stubEnv('TENANT_API_BASE_URL', 'http://custom-api:8080/api');
+
+        const { fetchSettings } = await import('../settings-api');
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(DEFAULT_SETTINGS),
+        });
+
+        await fetchSettings();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://custom-api:8080/api/settings',
+          { cache: 'no-store' }
+        );
+
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+      });
+    });
+
+    describe('getSettings', () => {
+      it('設定を取得できるべき', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const { getSettings } = await import('../settings-api');
+
+        const mockSettings = {
+          platform: {
+            platformName: 'Test Platform',
+            language: 'en',
+            timezone: 'UTC',
+          },
+          security: {
+            mfaRequired: true,
+            sessionTimeoutMinutes: 30,
+            maxLoginAttempts: 3,
+          },
+          notifications: {
+            emailNotificationsEnabled: false,
+            systemAlertsEnabled: true,
+            maintenanceNotificationsEnabled: false,
+          },
+          appearance: {
+            theme: 'dark',
+          },
+        };
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockSettings),
+        });
+
+        const result = await getSettings();
+        expect(result).toEqual(mockSettings);
+
+        vi.unstubAllGlobals();
+      });
+
+      it('エラー時にデフォルト設定を返すべき', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const { getSettings } = await import('../settings-api');
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+        });
+
+        const result = await getSettings();
+        expect(result).toEqual(DEFAULT_SETTINGS);
+
+        vi.unstubAllGlobals();
+      });
+    });
+
+    describe('saveSettings', () => {
+      it('設定を保存できるべき', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const { saveSettings } = await import('../settings-api');
+
+        const settings = {
+          platform: {
+            platformName: 'New Platform',
+            language: 'ja' as const,
+            timezone: 'Asia/Tokyo',
+          },
+          security: {
+            mfaRequired: false,
+            sessionTimeoutMinutes: 60,
+            maxLoginAttempts: 5,
+          },
+          notifications: {
+            emailNotificationsEnabled: true,
+            systemAlertsEnabled: true,
+            maintenanceNotificationsEnabled: true,
+          },
+          appearance: {
+            theme: 'system' as const,
+          },
+        };
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        });
+
+        await saveSettings(settings);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/settings'),
+          {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(settings),
+          }
+        );
+
+        vi.unstubAllGlobals();
+      });
+
+      it('保存失敗時に例外をスローすべき', async () => {
+        vi.stubGlobal('window', undefined);
+
+        const { saveSettings } = await import('../settings-api');
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+        });
+
+        await expect(saveSettings(DEFAULT_SETTINGS)).rejects.toThrow(
+          'Failed to save settings: 400'
+        );
+
+        vi.unstubAllGlobals();
+      });
+    });
+  });
+
+  describe('クライアントサイド（window がある場合）', () => {
+    it('クライアント環境変数を使用すべき', async () => {
+      vi.stubGlobal('window', {});
+      vi.stubEnv(
+        'NEXT_PUBLIC_TENANT_API_BASE_URL',
+        'http://client-api:9000/api'
+      );
+
+      const { fetchSettings } = await import('../settings-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(DEFAULT_SETTINGS),
+      });
+
+      await fetchSettings();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://client-api:9000/api/settings',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+
+    it('クライアント環境変数が未設定の場合はデフォルトを使用すべき', async () => {
+      vi.stubGlobal('window', {});
+
+      const { fetchSettings } = await import('../settings-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(DEFAULT_SETTINGS),
+      });
+
+      await fetchSettings();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:3004/api/settings',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
   });
 });

--- a/apps/control-plane/lib/api/__tests__/stats-api.test.ts
+++ b/apps/control-plane/lib/api/__tests__/stats-api.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('Stats API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('サーバーサイド（window がない場合）', () => {
+    it('ダッシュボード統計を取得できるべき', async () => {
+      // Remove window to simulate server-side
+      vi.stubGlobal('window', undefined);
+
+      const { fetchDashboardStats } = await import('../stats-api');
+
+      const mockStats = {
+        activeTenants: 5,
+        totalTenants: 10,
+        systemStatus: 'healthy',
+        uptimePercentage: 99.9,
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockStats),
+      });
+
+      const result = await fetchDashboardStats();
+
+      expect(result).toEqual(mockStats);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/stats'),
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('APIエラー時に例外をスローすべき', async () => {
+      vi.stubGlobal('window', undefined);
+
+      const { fetchDashboardStats } = await import('../stats-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(fetchDashboardStats()).rejects.toThrow(
+        'Failed to fetch stats: 500'
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('環境変数が設定されている場合はそれを使用すべき', async () => {
+      vi.stubGlobal('window', undefined);
+      vi.stubEnv('TENANT_API_BASE_URL', 'http://custom-api:8080/api');
+
+      const { fetchDashboardStats } = await import('../stats-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            activeTenants: 0,
+            totalTenants: 0,
+            systemStatus: 'healthy',
+            uptimePercentage: 100,
+          }),
+      });
+
+      await fetchDashboardStats();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://custom-api:8080/api/stats',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe('クライアントサイド（window がある場合）', () => {
+    it('クライアント環境変数を使用すべき', async () => {
+      vi.stubGlobal('window', {});
+      vi.stubEnv(
+        'NEXT_PUBLIC_TENANT_API_BASE_URL',
+        'http://client-api:9000/api'
+      );
+
+      const { fetchDashboardStats } = await import('../stats-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            activeTenants: 0,
+            totalTenants: 0,
+            systemStatus: 'healthy',
+            uptimePercentage: 100,
+          }),
+      });
+
+      await fetchDashboardStats();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://client-api:9000/api/stats',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+
+    it('クライアント環境変数が未設定の場合はデフォルトを使用すべき', async () => {
+      vi.stubGlobal('window', {});
+
+      const { fetchDashboardStats } = await import('../stats-api');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            activeTenants: 0,
+            totalTenants: 0,
+            systemStatus: 'healthy',
+            uptimePercentage: 100,
+          }),
+      });
+
+      await fetchDashboardStats();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:3004/api/stats',
+        { cache: 'no-store' }
+      );
+
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/apps/control-plane/lib/api/activities-api.ts
+++ b/apps/control-plane/lib/api/activities-api.ts
@@ -1,0 +1,22 @@
+import type { ActivitiesResponse } from '@/types/activity';
+
+// Use NEXT_PUBLIC_TENANT_API_BASE_URL for client components, fall back to server-side env.
+const isServer = typeof window === 'undefined';
+const apiBaseUrl = isServer
+  ? process.env.TENANT_API_BASE_URL || 'http://tenant-management:3004/api'
+  : process.env.NEXT_PUBLIC_TENANT_API_BASE_URL || 'http://localhost:3004/api';
+
+/**
+ * Fetch recent activities from the API
+ */
+export async function fetchActivities(limit = 10): Promise<ActivitiesResponse> {
+  const res = await fetch(`${apiBaseUrl}/activities?limit=${limit}`, {
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch activities: ${res.status}`);
+  }
+
+  return res.json() as Promise<ActivitiesResponse>;
+}

--- a/apps/control-plane/lib/api/settings-api.ts
+++ b/apps/control-plane/lib/api/settings-api.ts
@@ -1,10 +1,49 @@
 import type { Settings } from '@/types/settings';
+import { DEFAULT_SETTINGS } from '@/types/settings';
+
+// Use NEXT_PUBLIC_TENANT_API_BASE_URL for client components, fall back to server-side env.
+const isServer = typeof window === 'undefined';
+const apiBaseUrl = isServer
+  ? process.env.TENANT_API_BASE_URL || 'http://tenant-management:3004/api'
+  : process.env.NEXT_PUBLIC_TENANT_API_BASE_URL || 'http://localhost:3004/api';
+
+/**
+ * 設定を取得する
+ */
+export async function fetchSettings(): Promise<Settings> {
+  const res = await fetch(`${apiBaseUrl}/settings`, { cache: 'no-store' });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch settings: ${res.status}`);
+  }
+
+  return res.json() as Promise<Settings>;
+}
+
+/**
+ * 設定を取得する（エラー時はデフォルト値を返す）
+ */
+export async function getSettings(): Promise<Settings> {
+  try {
+    return await fetchSettings();
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
 
 /**
  * 設定を保存する
- * TODO: 実際の API エンドポイントに接続する
  */
-export async function saveSettings(_settings: Settings): Promise<void> {
-  // モック実装 - 500ms 待機して成功
-  await new Promise((resolve) => setTimeout(resolve, 500));
+export async function saveSettings(settings: Settings): Promise<void> {
+  const res = await fetch(`${apiBaseUrl}/settings`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(settings),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to save settings: ${res.status}`);
+  }
 }

--- a/apps/control-plane/lib/api/stats-api.ts
+++ b/apps/control-plane/lib/api/stats-api.ts
@@ -1,0 +1,22 @@
+// Use NEXT_PUBLIC_TENANT_API_BASE_URL for client components, fall back to server-side env.
+const isServer = typeof window === 'undefined';
+const apiBaseUrl = isServer
+  ? process.env.TENANT_API_BASE_URL || 'http://tenant-management:3004/api'
+  : process.env.NEXT_PUBLIC_TENANT_API_BASE_URL || 'http://localhost:3004/api';
+
+export interface DashboardStats {
+  activeTenants: number;
+  totalTenants: number;
+  systemStatus: 'healthy' | 'degraded' | 'down';
+  uptimePercentage: number;
+}
+
+export async function fetchDashboardStats(): Promise<DashboardStats> {
+  const res = await fetch(`${apiBaseUrl}/stats`, { cache: 'no-store' });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch stats: ${res.status}`);
+  }
+
+  return res.json() as Promise<DashboardStats>;
+}

--- a/apps/control-plane/types/activity.ts
+++ b/apps/control-plane/types/activity.ts
@@ -1,0 +1,36 @@
+/**
+ * Activity types for system event tracking
+ */
+
+export type ActivityAction =
+  | 'CREATE'
+  | 'UPDATE'
+  | 'DELETE'
+  | 'LOGIN'
+  | 'LOGOUT'
+  | 'ACCESS';
+
+export type ActivityResourceType =
+  | 'USER'
+  | 'TENANT'
+  | 'BATTLE'
+  | 'PROBLEM'
+  | 'SETTING'
+  | 'SYSTEM';
+
+export interface Activity {
+  id: string;
+  action: ActivityAction;
+  resourceType: ActivityResourceType;
+  resourceId?: string;
+  details?: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface ActivitiesResponse {
+  data: Activity[];
+  pagination: {
+    limit: number;
+    hasNextPage: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- Dashboard統計をDynamoDB経由の実データに切り替え
- Settings APIをDynamoDB保存に変更
- 最近のアクティビティ機能を実装（AuditLog連携）
- 包括的なテストを追加（100%カバレッジ達成）

## Changes
### Backend (tenant-management)
- `GET /api/activities` エンドポイントを追加
- AuditLogRepository を使用してシステムイベントを取得

### Frontend (control-plane)
- `lib/api/stats-api.ts` - 統計API クライアント
- `lib/api/activities-api.ts` - アクティビティAPI クライアント
- `types/activity.ts` - アクティビティ型定義
- ダッシュボードで実データを表示

## Test plan
- [x] Backend: GET /api/activities の7テストケース追加
- [x] Frontend: アクティビティ表示、相対時間フォーマットのテスト追加
- [x] 全336テストがパス
- [x] 100%カバレッジ達成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays live statistics: active tenants, total tenants, system status, and uptime percentage
  * Added recent activities section showing system activity with translated action labels and relative timestamps
  * Introduced settings management for platform, security, notifications, and appearance configurations
  * Improved error handling with sensible fallbacks for stats and activity data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->