### PR TITLE
fix: ルート package.json の dev スクリプトからポート上書きを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "module": "index.ts",
   "type": "module",
   "scripts": {
-    "dev": "concurrently -n cp,app -c blue,green \"bun run --cwd apps/control-plane dev\" \"bun run --cwd apps/application-plane dev -- -p 3001\"",
+    "dev": "concurrently -n cp,app -c blue,green \"bun run --cwd apps/control-plane dev\" \"bun run --cwd apps/application-plane dev\"",
     "dev:control-plane": "npm run dev --workspace=apps/control-plane",
     "dev:app": "npm run dev --workspace=apps/application-plane",
     "build:apps": "npm run build --workspaces --if-present",


### PR DESCRIPTION
## Summary

- ルート `package.json` の dev スクリプトで `-- -p 3001` が渡されていたため、`apps/application-plane/package.json` で設定した `--port 13001` が上書きされていた問題を修正

## 原因

PR #140 でポート変更を行ったが、ルート `package.json` の dev スクリプトに残っていた `-p 3001` 引数を見落としていた。

```diff
- "dev": "concurrently ... \"bun run --cwd apps/application-plane dev -- -p 3001\"",
+ "dev": "concurrently ... \"bun run --cwd apps/application-plane dev\"",
```

## Test plan

- [x] `make before-commit` で全テスト通過（397 tests）
- [x] `make start` でポート 13000/13001 で起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development script configuration to simplify the application-plane startup process by removing an explicit port parameter. This streamlines the dev environment setup without affecting end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->