### PR TITLE
fix(control-plane): proxy.ts を middleware.ts にリネーム

### DIFF
--- a/apps/control-plane/middleware.ts
+++ b/apps/control-plane/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 
-export const proxy = auth((req) => {
+export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isOnLoginPage = req.nextUrl.pathname.startsWith('/login');
   const isOnApiAuthRoute = req.nextUrl.pathname.startsWith('/api/auth');


### PR DESCRIPTION
## Summary

- `proxy.ts` を `middleware.ts` にリネーム
- Next.js 16 の Proxy 機能と混同され、`The Proxy file must export a function named proxy` エラーが発生していた
- 認証ミドルウェアなので `middleware.ts` として動作させる

## 背景

Next.js 16 では `proxy.ts` という名前のファイルは Proxy 機能として認識され、特定の export 形式が必要。
しかし、このファイルは認証ミドルウェアなので `middleware.ts` にリネームすることで正常に動作する。

## Test plan

- [x] `make before-commit` で全テスト通過（397 tests）
- [x] 両アプリのビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure update with no impact to user-facing functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->