### PR TITLE
fix(control-plane): middleware の export を修正

### DIFF
--- a/apps/control-plane/middleware.ts
+++ b/apps/control-plane/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 
-export default auth((req) => {
+export const middleware = auth((req) => {
   const isLoggedIn = !!req.auth;
   const isOnLoginPage = req.nextUrl.pathname.startsWith('/login');
   const isOnApiAuthRoute = req.nextUrl.pathname.startsWith('/api/auth');


### PR DESCRIPTION
## Summary
- Next.js 16 の middleware 規約に従い、`export const middleware` に修正
- `export default` ではなく名前付きエクスポートが必要

## Changes
- `apps/control-plane/middleware.ts`: `export default auth(...)` → `export const middleware = auth(...)`

## Test plan
- [x] `make before-commit` 通過（397 テスト、ビルド成功）
- [ ] `make start` で開発サーバー起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)