### PR TITLE
feat(localstack): Cognito と初期化スクリプトを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,14 +35,14 @@ services:
       - tenkacloud
 
   # LocalStack - AWS サービスのローカルエミュレーション
-  # DynamoDB, Lambda, EventBridge, S3, IAM をサポート
+  # DynamoDB, Cognito, S3, Lambda, EventBridge, IAM をサポート
   localstack:
     image: localstack/localstack:latest
     ports:
       - "4566:4566"           # LocalStack Gateway
       - "4510-4559:4510-4559" # External services port range
     environment:
-      - SERVICES=dynamodb,lambda,events,s3,iam,logs,sts,sqs
+      - SERVICES=dynamodb,cognito-idp,s3,lambda,events,iam,logs,sts,sqs
       - DEBUG=1
       - LAMBDA_EXECUTOR=docker
       - DOCKER_HOST=unix:///var/run/docker.sock
@@ -50,6 +50,12 @@ services:
     volumes:
       - localstack_data:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts/localstack-init.sh:/etc/localstack/init/ready.d/init.sh:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - tenkacloud
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,6 +58,30 @@ make start
 - **Application Plane**: http://localhost:13001
 - **LocalStack**: http://localhost:4566
 
+## ☁️ LocalStack（AWS ローカルエミュレーション）
+
+LocalStack 起動時に以下の AWS リソースが自動作成されます。
+
+| サービス | リソース | 用途 |
+|----------|----------|------|
+| DynamoDB | `tenants` | テナント情報 |
+| DynamoDB | `battles` | バトルセッション |
+| DynamoDB | `participants` | 参加者情報 |
+| Cognito | `tenkacloud-users` | ユーザープール |
+| S3 | `tenkacloud-assets` | 静的アセット |
+| S3 | `tenkacloud-uploads` | ユーザーアップロード |
+| S3 | `tenkacloud-logs` | ログ保存 |
+| SQS | `battle-events` | バトルイベントキュー |
+| SQS | `scoring-tasks` | 採点タスクキュー |
+
+```bash
+# リソース確認コマンド
+awslocal dynamodb list-tables
+awslocal cognito-idp list-user-pools --max-results 10
+awslocal s3 ls
+awslocal sqs list-queues
+```
+
 ## 📦 主な Makefile コマンド
 
 | コマンド | 説明 |

--- a/scripts/localstack-init.sh
+++ b/scripts/localstack-init.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# LocalStack 初期化スクリプト
+# このスクリプトは LocalStack 起動時に自動実行される
+# /etc/localstack/init/ready.d/ にマウントして使用
+
+set -euo pipefail
+
+echo "🚀 LocalStack 初期化を開始..."
+
+# AWS CLI のエンドポイント設定
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=ap-northeast-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+
+# ============================================
+# DynamoDB テーブル作成
+# ============================================
+echo "📦 DynamoDB テーブルを作成中..."
+
+# テナントテーブル
+awslocal dynamodb create-table \
+  --table-name tenants \
+  --attribute-definitions \
+    AttributeName=id,AttributeType=S \
+  --key-schema \
+    AttributeName=id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  2>/dev/null || echo "  テーブル 'tenants' は既に存在します"
+
+# バトルテーブル
+awslocal dynamodb create-table \
+  --table-name battles \
+  --attribute-definitions \
+    AttributeName=id,AttributeType=S \
+    AttributeName=tenantId,AttributeType=S \
+  --key-schema \
+    AttributeName=id,KeyType=HASH \
+  --global-secondary-indexes \
+    "[{\"IndexName\": \"tenantId-index\", \"KeySchema\": [{\"AttributeName\": \"tenantId\", \"KeyType\": \"HASH\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}}]" \
+  --billing-mode PAY_PER_REQUEST \
+  2>/dev/null || echo "  テーブル 'battles' は既に存在します"
+
+# 参加者テーブル
+awslocal dynamodb create-table \
+  --table-name participants \
+  --attribute-definitions \
+    AttributeName=id,AttributeType=S \
+    AttributeName=battleId,AttributeType=S \
+  --key-schema \
+    AttributeName=id,KeyType=HASH \
+  --global-secondary-indexes \
+    "[{\"IndexName\": \"battleId-index\", \"KeySchema\": [{\"AttributeName\": \"battleId\", \"KeyType\": \"HASH\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}}]" \
+  --billing-mode PAY_PER_REQUEST \
+  2>/dev/null || echo "  テーブル 'participants' は既に存在します"
+
+echo "✅ DynamoDB テーブル作成完了"
+
+# ============================================
+# Cognito ユーザープール作成
+# ============================================
+echo "👤 Cognito ユーザープールを作成中..."
+
+USER_POOL_ID=$(awslocal cognito-idp create-user-pool \
+  --pool-name tenkacloud-users \
+  --policies '{"PasswordPolicy":{"MinimumLength":8,"RequireUppercase":true,"RequireLowercase":true,"RequireNumbers":true,"RequireSymbols":false}}' \
+  --auto-verified-attributes email \
+  --username-attributes email \
+  --query 'UserPool.Id' \
+  --output text \
+  2>/dev/null || echo "")
+
+if [ -n "$USER_POOL_ID" ] && [ "$USER_POOL_ID" != "" ]; then
+  echo "  ユーザープール作成: $USER_POOL_ID"
+
+  # アプリクライアント作成
+  CLIENT_ID=$(awslocal cognito-idp create-user-pool-client \
+    --user-pool-id "$USER_POOL_ID" \
+    --client-name tenkacloud-app \
+    --generate-secret \
+    --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+    --query 'UserPoolClient.ClientId' \
+    --output text \
+    2>/dev/null || echo "")
+
+  if [ -n "$CLIENT_ID" ]; then
+    echo "  アプリクライアント作成: $CLIENT_ID"
+  fi
+else
+  echo "  ユーザープール 'tenkacloud-users' は既に存在するかエラーが発生しました"
+fi
+
+echo "✅ Cognito セットアップ完了"
+
+# ============================================
+# S3 バケット作成
+# ============================================
+echo "🪣 S3 バケットを作成中..."
+
+awslocal s3 mb s3://tenkacloud-assets 2>/dev/null || echo "  バケット 'tenkacloud-assets' は既に存在します"
+awslocal s3 mb s3://tenkacloud-uploads 2>/dev/null || echo "  バケット 'tenkacloud-uploads' は既に存在します"
+awslocal s3 mb s3://tenkacloud-logs 2>/dev/null || echo "  バケット 'tenkacloud-logs' は既に存在します"
+
+echo "✅ S3 バケット作成完了"
+
+# ============================================
+# SQS キュー作成
+# ============================================
+echo "📬 SQS キューを作成中..."
+
+awslocal sqs create-queue --queue-name battle-events 2>/dev/null || echo "  キュー 'battle-events' は既に存在します"
+awslocal sqs create-queue --queue-name scoring-tasks 2>/dev/null || echo "  キュー 'scoring-tasks' は既に存在します"
+
+echo "✅ SQS キュー作成完了"
+
+# ============================================
+# 初期化完了
+# ============================================
+echo ""
+echo "🎉 LocalStack 初期化が完了しました！"
+echo ""
+echo "利用可能なリソース:"
+echo "  - DynamoDB: tenants, battles, participants"
+echo "  - Cognito: tenkacloud-users"
+echo "  - S3: tenkacloud-assets, tenkacloud-uploads, tenkacloud-logs"
+echo "  - SQS: battle-events, scoring-tasks"
+echo ""
+echo "エンドポイント: http://localhost:4566"


### PR DESCRIPTION
## Summary

- LocalStack に cognito-idp サービスを追加
- healthcheck を追加して起動完了を確認
- 初期化スクリプト (`scripts/localstack-init.sh`) で AWS リソースを自動作成
- ドキュメントに LocalStack リソース一覧を追加

## 作成される AWS リソース

| サービス | リソース | 用途 |
|----------|----------|------|
| DynamoDB | `tenants`, `battles`, `participants` | テナント・バトル・参加者データ |
| Cognito | `tenkacloud-users` | ユーザープール |
| S3 | `tenkacloud-assets`, `tenkacloud-uploads`, `tenkacloud-logs` | アセット・アップロード・ログ |
| SQS | `battle-events`, `scoring-tasks` | イベントキュー |

## Test plan

- [ ] `docker compose up localstack` で LocalStack が正常に起動すること
- [ ] `awslocal dynamodb list-tables` でテーブルが作成されていること
- [ ] `awslocal cognito-idp list-user-pools --max-results 10` でユーザープールが作成されていること
- [ ] `awslocal s3 ls` でバケットが作成されていること
- [ ] `awslocal sqs list-queues` でキューが作成されていること

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)