### PR TITLE
feat(control-plane): tenant-management サービスを Docker Compose に追加

### DIFF
--- a/apps/control-plane/components/sidebar.tsx
+++ b/apps/control-plane/components/sidebar.tsx
@@ -17,8 +17,9 @@ export function Sidebar() {
   return (
     <div className="flex h-screen w-64 flex-col bg-gray-900">
       {/* Logo */}
-      <div className="flex h-16 items-center px-6">
+      <div className="flex h-16 flex-col justify-center px-6">
         <h1 className="text-xl font-bold text-white">TenkaCloud</h1>
+        <span className="text-xs text-gray-400">Control Plane</span>
       </div>
 
       {/* Navigation */}

--- a/backend/services/control-plane/tenant-management/Dockerfile
+++ b/backend/services/control-plane/tenant-management/Dockerfile
@@ -1,18 +1,23 @@
-FROM oven/bun:1 as base
+FROM oven/bun:1.2.20-slim AS base
 WORKDIR /app
 
+# Copy workspace configuration
+COPY package.json bun.lock ./
+COPY backend/services/shared/dynamodb/package.json backend/services/shared/dynamodb/
+COPY backend/services/control-plane/tenant-management/package.json backend/services/control-plane/tenant-management/
+
 # Install dependencies
-COPY package.json bun.lock* ./
-RUN bun install
+RUN bun install --frozen-lockfile
 
-# Copy source code and Prisma schema
-COPY . .
+# Copy source code
+COPY backend/services/shared/dynamodb backend/services/shared/dynamodb
+COPY backend/services/control-plane/tenant-management backend/services/control-plane/tenant-management
 
-# Generate Prisma Client
-RUN bunx prisma generate
+WORKDIR /app/backend/services/control-plane/tenant-management
 
 # Build the application
 RUN bun run build
 
-# Start the application
+EXPOSE 3004
+
 CMD ["bun", "run", "start"]

--- a/bun.lock
+++ b/bun.lock
@@ -350,6 +350,10 @@
         "vitest": "^4.0.0",
       },
     },
+    "packages/design-system": {
+      "name": "@tenkacloud/design-system",
+      "version": "1.0.0",
+    },
     "packages/shared": {
       "name": "@tenkacloud/shared",
       "version": "0.1.0",
@@ -1006,6 +1010,8 @@
     "@tenkacloud/core": ["@tenkacloud/core@workspace:packages/core"],
 
     "@tenkacloud/deployment-management": ["@tenkacloud/deployment-management@workspace:backend/services/control-plane/deployment-management"],
+
+    "@tenkacloud/design-system": ["@tenkacloud/design-system@workspace:packages/design-system"],
 
     "@tenkacloud/dynamodb": ["@tenkacloud/dynamodb@workspace:backend/services/shared/dynamodb"],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,27 @@ services:
       - AUTH0_ISSUER=${AUTH0_ISSUER}
       - NEXTAUTH_URL=http://localhost:13000
       - AWS_ENDPOINT_URL=http://localstack:4566
+    depends_on:
+      tenant-management:
+        condition: service_started
+    networks:
+      - tenkacloud
+
+  tenant-management:
+    build:
+      context: .
+      dockerfile: backend/services/control-plane/tenant-management/Dockerfile
+    ports:
+      - "3004:3004"
+    environment:
+      - DYNAMODB_TABLE_NAME=TenkaCloud-dev
+      - DYNAMODB_ENDPOINT=http://localstack:4566
+      - AWS_REGION=ap-northeast-1
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+    depends_on:
+      localstack:
+        condition: service_healthy
     networks:
       - tenkacloud
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -64,9 +64,7 @@ LocalStack 起動時に以下の AWS リソースが自動作成されます。
 
 | サービス | リソース | 用途 |
 |----------|----------|------|
-| DynamoDB | `tenants` | テナント情報 |
-| DynamoDB | `battles` | バトルセッション |
-| DynamoDB | `participants` | 参加者情報 |
+| DynamoDB | `TenkaCloud-dev` | メインテーブル（Single-Table Design） |
 | Cognito | `tenkacloud-users` | ユーザープール |
 | S3 | `tenkacloud-assets` | 静的アセット |
 | S3 | `tenkacloud-uploads` | ユーザーアップロード |
@@ -74,9 +72,12 @@ LocalStack 起動時に以下の AWS リソースが自動作成されます。
 | SQS | `battle-events` | バトルイベントキュー |
 | SQS | `scoring-tasks` | 採点タスクキュー |
 
+DynamoDB は Single-Table Design を採用しています。GSI1（スラッグ検索用）と GSI2（エンティティタイプ検索用）を持ちます。
+
 ```bash
 # リソース確認コマンド
 awslocal dynamodb list-tables
+awslocal dynamodb describe-table --table-name TenkaCloud-dev
 awslocal cognito-idp list-user-pools --max-results 10
 awslocal s3 ls
 awslocal sqs list-queues

--- a/scripts/localstack-init.sh
+++ b/scripts/localstack-init.sh
@@ -14,45 +14,32 @@ export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 
 # ============================================
-# DynamoDB テーブル作成
+# DynamoDB テーブル作成（Single-Table Design）
 # ============================================
 echo "📦 DynamoDB テーブルを作成中..."
 
-# テナントテーブル
+# メインテーブル（Single-Table Design）
+# PK/SK: プライマリキー
+# GSI1PK/GSI1SK: スラッグベースのクエリ用
+# EntityType: エンティティタイプ別クエリ用（GSI2）
 awslocal dynamodb create-table \
-  --table-name tenants \
+  --table-name TenkaCloud-dev \
   --attribute-definitions \
-    AttributeName=id,AttributeType=S \
+    AttributeName=PK,AttributeType=S \
+    AttributeName=SK,AttributeType=S \
+    AttributeName=GSI1PK,AttributeType=S \
+    AttributeName=GSI1SK,AttributeType=S \
+    AttributeName=EntityType,AttributeType=S \
   --key-schema \
-    AttributeName=id,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST \
-  2>/dev/null || echo "  テーブル 'tenants' は既に存在します"
-
-# バトルテーブル
-awslocal dynamodb create-table \
-  --table-name battles \
-  --attribute-definitions \
-    AttributeName=id,AttributeType=S \
-    AttributeName=tenantId,AttributeType=S \
-  --key-schema \
-    AttributeName=id,KeyType=HASH \
+    AttributeName=PK,KeyType=HASH \
+    AttributeName=SK,KeyType=RANGE \
   --global-secondary-indexes \
-    "[{\"IndexName\": \"tenantId-index\", \"KeySchema\": [{\"AttributeName\": \"tenantId\", \"KeyType\": \"HASH\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}}]" \
+    "[
+      {\"IndexName\": \"GSI1\", \"KeySchema\": [{\"AttributeName\": \"GSI1PK\", \"KeyType\": \"HASH\"}, {\"AttributeName\": \"GSI1SK\", \"KeyType\": \"RANGE\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}},
+      {\"IndexName\": \"GSI2\", \"KeySchema\": [{\"AttributeName\": \"EntityType\", \"KeyType\": \"HASH\"}, {\"AttributeName\": \"SK\", \"KeyType\": \"RANGE\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}}
+    ]" \
   --billing-mode PAY_PER_REQUEST \
-  2>/dev/null || echo "  テーブル 'battles' は既に存在します"
-
-# 参加者テーブル
-awslocal dynamodb create-table \
-  --table-name participants \
-  --attribute-definitions \
-    AttributeName=id,AttributeType=S \
-    AttributeName=battleId,AttributeType=S \
-  --key-schema \
-    AttributeName=id,KeyType=HASH \
-  --global-secondary-indexes \
-    "[{\"IndexName\": \"battleId-index\", \"KeySchema\": [{\"AttributeName\": \"battleId\", \"KeyType\": \"HASH\"}], \"Projection\": {\"ProjectionType\": \"ALL\"}}]" \
-  --billing-mode PAY_PER_REQUEST \
-  2>/dev/null || echo "  テーブル 'participants' は既に存在します"
+  2>/dev/null || echo "  テーブル 'TenkaCloud-dev' は既に存在します"
 
 echo "✅ DynamoDB テーブル作成完了"
 
@@ -120,7 +107,7 @@ echo ""
 echo "🎉 LocalStack 初期化が完了しました！"
 echo ""
 echo "利用可能なリソース:"
-echo "  - DynamoDB: tenants, battles, participants"
+echo "  - DynamoDB: TenkaCloud-dev (Single-Table Design with GSI1, GSI2)"
 echo "  - Cognito: tenkacloud-users"
 echo "  - S3: tenkacloud-assets, tenkacloud-uploads, tenkacloud-logs"
 echo "  - SQS: battle-events, scoring-tasks"


### PR DESCRIPTION
## Summary
- Docker Compose に tenant-management バックエンドサービスを追加し、テナント管理 API のフェッチエラーを修正
- Dockerfile をモノレポワークスペース構造に対応（Prisma ベースから DynamoDB ベースへ）
- LocalStack の DynamoDB スキーマを Single-Table Design（TenkaCloud-dev + GSI1/GSI2）に変更
- サイドバーに「Control Plane」サブラベルを追加し、他のプレーンとの区別を明確化

## Test plan
- [ ] `make start` で全サービスが起動することを確認
- [ ] http://localhost:13000/dashboard/tenants でテナント管理ページが表示されることを確認
- [ ] サイドバーに「TenkaCloud」と「Control Plane」が表示されることを確認
- [ ] `awslocal dynamodb describe-table --table-name TenkaCloud-dev` で GSI1/GSI2 が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tenant-management service to the control plane infrastructure.
  * Implemented single-table DynamoDB design with improved indexing for better data organization.

* **Improvements**
  * Enhanced sidebar header layout with "Control Plane" subtitle for improved visual organization.
  * Optimized Docker deployment configuration with streamlined dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->