### PR TITLE
fix(control-plane): テナント管理のエラーハンドリングとローカル開発対応を改善

### DIFF
--- a/apps/control-plane/.env.example
+++ b/apps/control-plane/.env.example
@@ -19,3 +19,7 @@ AUTH0_ISSUER=https://your-tenant.auth0.com
 # Auth0 Custom Claims Namespace (for roles, permissions)
 # Configure in Auth0 Actions or Rules
 AUTH0_NAMESPACE=https://tenkacloud.com
+
+# Application Plane URL (Local Development)
+# Set this to redirect "管理画面を開く" to local Application Plane
+# NEXT_PUBLIC_APPLICATION_PLANE_URL=http://localhost:13001

--- a/apps/control-plane/app/dashboard/tenants/[id]/edit/__tests__/page.test.tsx
+++ b/apps/control-plane/app/dashboard/tenants/[id]/edit/__tests__/page.test.tsx
@@ -23,12 +23,16 @@ vi.mock('next/navigation', () => ({
 }));
 
 // tenantApi をモック（API ベース URL が未設定でも強制的にモックを使用）
-vi.mock('@/lib/api/tenant-api', () => ({
-  tenantApi: {
-    getTenant: vi.fn(),
-    updateTenant: vi.fn(),
-  },
-}));
+vi.mock('@/lib/api/tenant-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api/tenant-api')>();
+  return {
+    ...actual,
+    tenantApi: {
+      getTenant: vi.fn(),
+      updateTenant: vi.fn(),
+    },
+  };
+});
 
 // window.alert をモック
 const mockAlert = vi.fn();

--- a/apps/control-plane/components/tenants/tenant-access-card.tsx
+++ b/apps/control-plane/components/tenants/tenant-access-card.tsx
@@ -9,6 +9,12 @@ interface TenantAccessCardProps {
 }
 
 export function getApplicationPlaneUrl(slug: string): string {
+  // ローカル開発用の環境変数が設定されている場合はそれを使用
+  const localUrl = process.env.NEXT_PUBLIC_APPLICATION_PLANE_URL;
+  if (localUrl) {
+    return localUrl;
+  }
+  // 本番環境: テナントスラッグに基づくサブドメイン
   return `https://${slug}.tenka.cloud`;
 }
 


### PR DESCRIPTION
## Summary
- テナント作成時の重複スラッグエラーをユーザーフレンドリーなメッセージで表示
- `管理画面を開く` ボタンがローカル開発環境で動作するように修正

## Changes
### エラーハンドリングの改善
- `TenantApiError` クラスを追加し、APIエラーをパース
- テナント作成フォームで `alert()` の代わりにstate管理でエラー表示

### ローカル開発対応
- `getApplicationPlaneUrl()` 関数を環境変数 `NEXT_PUBLIC_APPLICATION_PLANE_URL` に対応
- ローカル: `http://localhost:13001`
- 本番: `https://{slug}.tenka.cloud`

## Known Limitations
現在のローカル開発URLはテナント識別を含みません。Application Planeのマルチテナント設計（管理者画面/競技者画面のルーティング含む）は別途設計が必要です。

## Test plan
- [x] `make before-commit` 通過
- [x] 重複スラッグでテナント作成 → エラーメッセージ表示確認
- [x] 管理画面を開く → localhost:13001 へ遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)