### PR TITLE
feat(application-plane): Phase 2 Admin ルート基盤を実装

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
@@ -1,0 +1,372 @@
+/**
+ * Admin Event Detail Page
+ *
+ * イベント詳細・編集画面
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+interface EventDetail {
+  id: string;
+  name: string;
+  description: string;
+  status: 'draft' | 'scheduled' | 'active' | 'ended';
+  type: 'gameday' | 'jam';
+  startTime: string;
+  endTime: string;
+  participantCount: number;
+  maxParticipants: number;
+  cloudProvider: 'aws' | 'gcp' | 'azure';
+  participantType: 'individual' | 'team';
+  problems: {
+    id: string;
+    title: string;
+    points: number;
+    solvedCount: number;
+  }[];
+}
+
+export default function AdminEventDetailPage() {
+  const params = useParams();
+  const eventId = params.eventId as string;
+  const [event, setEvent] = useState<EventDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<
+    'overview' | 'problems' | 'participants'
+  >('overview');
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchEvent = async () => {
+      try {
+        setLoading(true);
+        // Mock data
+        setEvent({
+          id: eventId,
+          name: 'AWS GameDay 2024 Winter',
+          description:
+            'AWS のさまざまなサービスを活用して、実践的な課題に挑戦するイベントです。',
+          status: 'active',
+          type: 'gameday',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 86400000).toISOString(),
+          participantCount: 45,
+          maxParticipants: 100,
+          cloudProvider: 'aws',
+          participantType: 'team',
+          problems: [
+            {
+              id: 'p1',
+              title: 'VPC セットアップ',
+              points: 100,
+              solvedCount: 38,
+            },
+            {
+              id: 'p2',
+              title: 'Lambda 関数のデプロイ',
+              points: 200,
+              solvedCount: 25,
+            },
+            { id: 'p3', title: 'RDS の設定', points: 300, solvedCount: 12 },
+          ],
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEvent();
+  }, [eventId]);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getStatusBadge = (status: EventDetail['status']) => {
+    const styles = {
+      draft: 'bg-gray-100 text-gray-800',
+      scheduled: 'bg-blue-100 text-blue-800',
+      active: 'bg-green-100 text-green-800',
+      ended: 'bg-gray-100 text-gray-500',
+    };
+    const labels = {
+      draft: '下書き',
+      scheduled: '予定',
+      active: '開催中',
+      ended: '終了',
+    };
+    return (
+      <span
+        className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${styles[status]}`}
+      >
+        {labels[status]}
+      </span>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="text-center py-12">
+        <h2 className="text-xl font-semibold text-gray-900">
+          イベントが見つかりません
+        </h2>
+        <Link
+          href="/admin/events"
+          className="text-blue-600 hover:text-blue-700 mt-4 inline-block"
+        >
+          イベント一覧に戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="flex items-center space-x-2 text-sm text-gray-500 mb-2">
+            <Link href="/admin/events" className="hover:text-gray-700">
+              イベント管理
+            </Link>
+            <span>/</span>
+            <span>{event.name}</span>
+          </div>
+          <div className="flex items-center space-x-4">
+            <h1 className="text-2xl font-bold text-gray-900">{event.name}</h1>
+            {getStatusBadge(event.status)}
+          </div>
+        </div>
+        <div className="flex space-x-3">
+          {event.status === 'draft' && (
+            <button
+              type="button"
+              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
+            >
+              公開する
+            </button>
+          )}
+          <button
+            type="button"
+            className="px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            編集
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-gray-200">
+        <nav className="-mb-px flex space-x-8">
+          {[
+            { id: 'overview', label: '概要' },
+            { id: 'problems', label: '問題' },
+            { id: 'participants', label: '参加者' },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id as typeof activeTab)}
+              className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                activeTab === tab.id
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === 'overview' && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-6">
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                イベント情報
+              </h2>
+              <dl className="space-y-4">
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">説明</dt>
+                  <dd className="mt-1 text-sm text-gray-900">
+                    {event.description}
+                  </dd>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">
+                      開始日時
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">
+                      {formatDate(event.startTime)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">
+                      終了日時
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">
+                      {formatDate(event.endTime)}
+                    </dd>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">
+                      クラウドプロバイダー
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900 uppercase">
+                      {event.cloudProvider}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">
+                      参加形式
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">
+                      {event.participantType === 'team'
+                        ? 'チーム参加'
+                        : '個人参加'}
+                    </dd>
+                  </div>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                参加状況
+              </h2>
+              <div className="text-center">
+                <div className="text-4xl font-bold text-gray-900">
+                  {event.participantCount}
+                  <span className="text-lg text-gray-500">
+                    {' '}
+                    / {event.maxParticipants}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-500 mt-1">参加者</p>
+                <div className="mt-4 w-full bg-gray-200 rounded-full h-2">
+                  <div
+                    className="bg-blue-600 h-2 rounded-full"
+                    style={{
+                      width: `${(event.participantCount / event.maxParticipants) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                問題数
+              </h2>
+              <div className="text-center">
+                <div className="text-4xl font-bold text-gray-900">
+                  {event.problems.length}
+                </div>
+                <p className="text-sm text-gray-500 mt-1">問題</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'problems' && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+            <h2 className="text-lg font-semibold text-gray-900">問題一覧</h2>
+            <button
+              type="button"
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
+            >
+              問題を追加
+            </button>
+          </div>
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  タイトル
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  配点
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  解答数
+                </th>
+                <th className="px-6 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {event.problems.map((problem) => (
+                <tr key={problem.id}>
+                  <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                    {problem.title}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {problem.points} pts
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {problem.solvedCount}
+                  </td>
+                  <td className="px-6 py-4 text-right text-sm">
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:text-blue-900"
+                    >
+                      編集
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {activeTab === 'participants' && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-center py-12">
+            <div className="text-4xl mb-4">👥</div>
+            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+              参加者管理
+            </h2>
+            <p className="text-gray-500">
+              {event.participantCount} 人が参加しています
+            </p>
+            <button
+              type="button"
+              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              参加者一覧を見る
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/events/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/page.tsx
@@ -1,0 +1,295 @@
+/**
+ * Admin Events List Page
+ *
+ * イベント管理一覧
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useId, useState } from 'react';
+
+interface AdminEvent {
+  id: string;
+  name: string;
+  status: 'draft' | 'scheduled' | 'active' | 'ended';
+  type: 'gameday' | 'jam';
+  startTime: string;
+  endTime: string;
+  participantCount: number;
+  maxParticipants: number;
+}
+
+export default function AdminEventsPage() {
+  const [events, setEvents] = useState<AdminEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<{ status?: string }>({});
+  const statusFilterId = useId();
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchEvents = async () => {
+      try {
+        setLoading(true);
+        // Mock data for now
+        setEvents([
+          {
+            id: 'evt-1',
+            name: 'AWS GameDay 2024 Winter',
+            status: 'active',
+            type: 'gameday',
+            startTime: new Date().toISOString(),
+            endTime: new Date(Date.now() + 86400000).toISOString(),
+            participantCount: 45,
+            maxParticipants: 100,
+          },
+          {
+            id: 'evt-2',
+            name: 'Security JAM',
+            status: 'scheduled',
+            type: 'jam',
+            startTime: new Date(Date.now() + 172800000).toISOString(),
+            endTime: new Date(Date.now() + 259200000).toISOString(),
+            participantCount: 23,
+            maxParticipants: 50,
+          },
+          {
+            id: 'evt-3',
+            name: 'Cloud Architecture Challenge',
+            status: 'draft',
+            type: 'gameday',
+            startTime: new Date(Date.now() + 604800000).toISOString(),
+            endTime: new Date(Date.now() + 691200000).toISOString(),
+            participantCount: 0,
+            maxParticipants: 100,
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEvents();
+  }, [filter]);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getStatusBadge = (status: AdminEvent['status']) => {
+    const styles = {
+      draft: 'bg-gray-100 text-gray-800',
+      scheduled: 'bg-blue-100 text-blue-800',
+      active: 'bg-green-100 text-green-800',
+      ended: 'bg-gray-100 text-gray-500',
+    };
+    const labels = {
+      draft: '下書き',
+      scheduled: '予定',
+      active: '開催中',
+      ended: '終了',
+    };
+    return (
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[status]}`}
+      >
+        {labels[status]}
+      </span>
+    );
+  };
+
+  const getTypeBadge = (type: AdminEvent['type']) => {
+    const styles = {
+      gameday: 'bg-orange-100 text-orange-800',
+      jam: 'bg-purple-100 text-purple-800',
+    };
+    const labels = {
+      gameday: 'GameDay',
+      jam: 'JAM',
+    };
+    return (
+      <span
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[type]}`}
+      >
+        {labels[type]}
+      </span>
+    );
+  };
+
+  const filteredEvents = filter.status
+    ? events.filter((e) => e.status === filter.status)
+    : events;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">イベント管理</h1>
+        <Link
+          href="/admin/events/new"
+          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          <svg
+            className="w-5 h-5 mr-2"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          新規イベント
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="flex flex-wrap gap-4">
+          <div>
+            <label
+              htmlFor={statusFilterId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              ステータス
+            </label>
+            <select
+              id={statusFilterId}
+              className="border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+              value={filter.status || ''}
+              onChange={(e) =>
+                setFilter({ status: e.target.value || undefined })
+              }
+            >
+              <option value="">すべて</option>
+              <option value="draft">下書き</option>
+              <option value="scheduled">予定</option>
+              <option value="active">開催中</option>
+              <option value="ended">終了</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Events Table */}
+      {loading ? (
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      ) : filteredEvents.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+          <div className="text-4xl mb-4">📭</div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            イベントがありません
+          </h2>
+          <p className="text-gray-500 mb-6">
+            新しいイベントを作成して始めましょう。
+          </p>
+          <Link
+            href="/admin/events/new"
+            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            新規イベント作成
+          </Link>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  イベント名
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  タイプ
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  ステータス
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  期間
+                </th>
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  参加者
+                </th>
+                <th scope="col" className="relative px-6 py-3">
+                  <span className="sr-only">アクション</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredEvents.map((event) => (
+                <tr key={event.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <Link
+                      href={`/admin/events/${event.id}`}
+                      className="text-sm font-medium text-gray-900 hover:text-blue-600"
+                    >
+                      {event.name}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {getTypeBadge(event.type)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {getStatusBadge(event.status)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <div>{formatDate(event.startTime)}</div>
+                    <div className="text-xs text-gray-400">
+                      〜 {formatDate(event.endTime)}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {event.participantCount} / {event.maxParticipants}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <Link
+                      href={`/admin/events/${event.id}`}
+                      className="text-blue-600 hover:text-blue-900 mr-4"
+                    >
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      className="text-red-600 hover:text-red-900"
+                      onClick={() => {
+                        // TODO: Implement delete
+                      }}
+                    >
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/layout.tsx
+++ b/apps/application-plane/app/(admin)/admin/layout.tsx
@@ -1,0 +1,208 @@
+/**
+ * Admin Layout
+ *
+ * 管理者画面用レイアウト（サイドバー付き）
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useTenantOptional } from '@/lib/tenant';
+import type { ReactNode } from 'react';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: ReactNode;
+}
+
+const navItems: NavItem[] = [
+  {
+    href: '/admin',
+    label: 'ダッシュボード',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: '/admin/events',
+    label: 'イベント管理',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: '/admin/participants',
+    label: '参加者管理',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: '/admin/teams',
+    label: 'チーム管理',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: '/admin/settings',
+    label: '設定',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+      </svg>
+    ),
+  },
+];
+
+interface AdminLayoutProps {
+  children: ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  const pathname = usePathname();
+  const { data: session } = useSession();
+  const tenant = useTenantOptional();
+
+  const isActive = (href: string) => {
+    if (href === '/admin') {
+      return pathname === '/admin';
+    }
+    return pathname.startsWith(href);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Top Header */}
+      <header className="bg-white border-b border-gray-200 fixed top-0 left-0 right-0 z-50">
+        <div className="flex items-center justify-between h-16 px-4">
+          <div className="flex items-center space-x-4">
+            <Link href="/admin" className="flex items-center space-x-2">
+              <span className="text-2xl">⚔️</span>
+              <span className="font-bold text-xl text-gray-900">
+                TenkaCloud
+              </span>
+              <span className="text-sm font-medium text-gray-500 border-l border-gray-300 pl-4 ml-2">
+                管理画面
+              </span>
+            </Link>
+          </div>
+
+          <div className="flex items-center space-x-4">
+            {tenant?.slug && (
+              <span className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
+                {tenant.slug}
+              </span>
+            )}
+            <Link
+              href="/dashboard"
+              className="text-sm text-gray-600 hover:text-gray-900"
+            >
+              参加者画面へ
+            </Link>
+            <div className="flex items-center space-x-2">
+              <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-medium">
+                {session?.user?.name?.charAt(0).toUpperCase() || 'A'}
+              </div>
+              <span className="text-sm font-medium text-gray-700">
+                {session?.user?.name || '管理者'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Sidebar */}
+      <aside className="fixed left-0 top-16 bottom-0 w-64 bg-white border-r border-gray-200 overflow-y-auto">
+        <nav className="p-4 space-y-1">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center space-x-3 px-3 py-2 rounded-lg transition-colors ${
+                isActive(item.href)
+                  ? 'bg-blue-50 text-blue-700'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`}
+            >
+              {item.icon}
+              <span className="font-medium">{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main Content */}
+      <main className="ml-64 pt-16">
+        <div className="p-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/page.tsx
@@ -1,0 +1,321 @@
+/**
+ * Admin Dashboard Page
+ *
+ * 管理者ダッシュボード
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTenantOptional } from '@/lib/tenant';
+
+interface DashboardStats {
+  activeEvents: number;
+  totalParticipants: number;
+  totalTeams: number;
+  upcomingEvents: number;
+}
+
+interface RecentActivity {
+  id: string;
+  type:
+    | 'event_created'
+    | 'participant_joined'
+    | 'event_started'
+    | 'event_ended';
+  message: string;
+  timestamp: string;
+}
+
+export default function AdminDashboardPage() {
+  const tenant = useTenantOptional();
+  const [stats, setStats] = useState<DashboardStats>({
+    activeEvents: 0,
+    totalParticipants: 0,
+    totalTeams: 0,
+    upcomingEvents: 0,
+  });
+  const [recentActivities, setRecentActivities] = useState<RecentActivity[]>(
+    []
+  );
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchDashboardData = async () => {
+      try {
+        setLoading(true);
+        // Mock data for now
+        setStats({
+          activeEvents: 2,
+          totalParticipants: 156,
+          totalTeams: 23,
+          upcomingEvents: 5,
+        });
+        setRecentActivities([
+          {
+            id: '1',
+            type: 'event_started',
+            message: 'AWS GameDay 2024 Winter が開始されました',
+            timestamp: new Date().toISOString(),
+          },
+          {
+            id: '2',
+            type: 'participant_joined',
+            message: '新しい参加者が登録しました',
+            timestamp: new Date(Date.now() - 3600000).toISOString(),
+          },
+          {
+            id: '3',
+            type: 'event_created',
+            message: 'Security JAM が作成されました',
+            timestamp: new Date(Date.now() - 7200000).toISOString(),
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDashboardData();
+  }, []);
+
+  const formatTimestamp = (timestamp: string) => {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor(diff / (1000 * 60));
+
+    if (hours > 24) {
+      return date.toLocaleDateString('ja-JP', {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+    if (hours > 0) {
+      return `${hours}時間前`;
+    }
+    if (minutes > 0) {
+      return `${minutes}分前`;
+    }
+    return 'たった今';
+  };
+
+  const getActivityIcon = (type: RecentActivity['type']) => {
+    switch (type) {
+      case 'event_created':
+        return '📝';
+      case 'participant_joined':
+        return '👤';
+      case 'event_started':
+        return '🚀';
+      case 'event_ended':
+        return '🏁';
+      default:
+        return '📌';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">ダッシュボード</h1>
+        {tenant?.slug && (
+          <p className="text-gray-500 mt-1">テナント: {tenant.slug}</p>
+        )}
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-500">
+                開催中のイベント
+              </p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">
+                {stats.activeEvents}
+              </p>
+            </div>
+            <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
+              <span className="text-2xl">🎮</span>
+            </div>
+          </div>
+          <Link
+            href="/admin/events?status=active"
+            className="text-sm text-blue-600 hover:text-blue-700 mt-4 inline-block"
+          >
+            詳細を見る →
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-500">総参加者数</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">
+                {stats.totalParticipants}
+              </p>
+            </div>
+            <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
+              <span className="text-2xl">👥</span>
+            </div>
+          </div>
+          <Link
+            href="/admin/participants"
+            className="text-sm text-blue-600 hover:text-blue-700 mt-4 inline-block"
+          >
+            詳細を見る →
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-500">総チーム数</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">
+                {stats.totalTeams}
+              </p>
+            </div>
+            <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center">
+              <span className="text-2xl">🏆</span>
+            </div>
+          </div>
+          <Link
+            href="/admin/teams"
+            className="text-sm text-blue-600 hover:text-blue-700 mt-4 inline-block"
+          >
+            詳細を見る →
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-500">予定イベント</p>
+              <p className="text-3xl font-bold text-gray-900 mt-1">
+                {stats.upcomingEvents}
+              </p>
+            </div>
+            <div className="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center">
+              <span className="text-2xl">📅</span>
+            </div>
+          </div>
+          <Link
+            href="/admin/events?status=scheduled"
+            className="text-sm text-blue-600 hover:text-blue-700 mt-4 inline-block"
+          >
+            詳細を見る →
+          </Link>
+        </div>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          クイックアクション
+        </h2>
+        <div className="flex flex-wrap gap-4">
+          <Link
+            href="/admin/events/new"
+            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            新規イベント作成
+          </Link>
+          <Link
+            href="/admin/participants/invite"
+            className="inline-flex items-center px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+              />
+            </svg>
+            参加者を招待
+          </Link>
+          <Link
+            href="/admin/settings"
+            className="inline-flex items-center px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            設定
+          </Link>
+        </div>
+      </div>
+
+      {/* Recent Activity */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          最近のアクティビティ
+        </h2>
+        <div className="space-y-4">
+          {recentActivities.map((activity) => (
+            <div
+              key={activity.id}
+              className="flex items-start space-x-3 pb-4 border-b border-gray-100 last:border-0 last:pb-0"
+            >
+              <span className="text-xl">{getActivityIcon(activity.type)}</span>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-gray-900">{activity.message}</p>
+                <p className="text-xs text-gray-500 mt-1">
+                  {formatTimestamp(activity.timestamp)}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/participants/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/participants/page.tsx
@@ -1,0 +1,269 @@
+/**
+ * Admin Participants Page
+ *
+ * 参加者管理
+ */
+
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+
+interface Participant {
+  id: string;
+  name: string;
+  email: string;
+  joinedAt: string;
+  eventsCount: number;
+  totalScore: number;
+  status: 'active' | 'inactive';
+}
+
+export default function AdminParticipantsPage() {
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputId = useId();
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchParticipants = async () => {
+      try {
+        setLoading(true);
+        // Mock data
+        setParticipants([
+          {
+            id: 'user-1',
+            name: '山田太郎',
+            email: 'yamada@example.com',
+            joinedAt: new Date(Date.now() - 2592000000).toISOString(),
+            eventsCount: 5,
+            totalScore: 2500,
+            status: 'active',
+          },
+          {
+            id: 'user-2',
+            name: '佐藤花子',
+            email: 'sato@example.com',
+            joinedAt: new Date(Date.now() - 1296000000).toISOString(),
+            eventsCount: 3,
+            totalScore: 1800,
+            status: 'active',
+          },
+          {
+            id: 'user-3',
+            name: '鈴木一郎',
+            email: 'suzuki@example.com',
+            joinedAt: new Date(Date.now() - 604800000).toISOString(),
+            eventsCount: 1,
+            totalScore: 400,
+            status: 'inactive',
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchParticipants();
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const filteredParticipants = participants.filter(
+    (p) =>
+      p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      p.email.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">参加者管理</h1>
+        <button
+          type="button"
+          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          <svg
+            className="w-5 h-5 mr-2"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+            />
+          </svg>
+          参加者を招待
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="max-w-md">
+          <label htmlFor={searchInputId} className="sr-only">
+            検索
+          </label>
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg
+                className="h-5 w-5 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+            <input
+              id={searchInputId}
+              type="text"
+              placeholder="名前またはメールアドレスで検索..."
+              className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">総参加者数</div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {participants.length}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">
+            アクティブユーザー
+          </div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {participants.filter((p) => p.status === 'active').length}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">平均スコア</div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {participants.length > 0
+              ? Math.round(
+                  participants.reduce((acc, p) => acc + p.totalScore, 0) /
+                    participants.length
+                )
+              : 0}
+          </div>
+        </div>
+      </div>
+
+      {/* Participants Table */}
+      {loading ? (
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      ) : filteredParticipants.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+          <div className="text-4xl mb-4">👥</div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            参加者が見つかりません
+          </h2>
+          <p className="text-gray-500">
+            {searchQuery
+              ? '検索条件を変更してください。'
+              : '参加者を招待して始めましょう。'}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  参加者
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ステータス
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  参加イベント数
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  累計スコア
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  登録日
+                </th>
+                <th className="px-6 py-3" />
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredParticipants.map((participant) => (
+                <tr key={participant.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="flex items-center">
+                      <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center text-white font-medium">
+                        {participant.name.charAt(0)}
+                      </div>
+                      <div className="ml-4">
+                        <div className="text-sm font-medium text-gray-900">
+                          {participant.name}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {participant.email}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        participant.status === 'active'
+                          ? 'bg-green-100 text-green-800'
+                          : 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      {participant.status === 'active'
+                        ? 'アクティブ'
+                        : '非アクティブ'}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {participant.eventsCount}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {participant.totalScore.toLocaleString()} pts
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {formatDate(participant.joinedAt)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:text-blue-900"
+                    >
+                      詳細
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/settings/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/settings/page.tsx
@@ -1,0 +1,291 @@
+/**
+ * Admin Settings Page
+ *
+ * テナント設定
+ */
+
+'use client';
+
+import { useId, useState } from 'react';
+import { useTenantOptional } from '@/lib/tenant';
+
+export default function AdminSettingsPage() {
+  const tenant = useTenantOptional();
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  // Form field IDs
+  const tenantNameId = useId();
+  const contactEmailId = useId();
+  const defaultCloudProviderId = useId();
+  const maxParticipantsId = useId();
+  const maxTeamSizeId = useId();
+
+  // Form state
+  const [settings, setSettings] = useState({
+    tenantName: tenant?.slug || '',
+    contactEmail: 'admin@example.com',
+    defaultCloudProvider: 'aws',
+    maxParticipantsPerEvent: 100,
+    maxTeamSize: 5,
+    enableTeamRegistration: true,
+    enableIndividualRegistration: true,
+    requireEmailVerification: true,
+  });
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      // TODO: Implement actual save logic
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">設定</h1>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {saving ? (
+            <>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+              保存中...
+            </>
+          ) : saved ? (
+            <>
+              <svg
+                className="w-5 h-5 mr-2"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              保存しました
+            </>
+          ) : (
+            '変更を保存'
+          )}
+        </button>
+      </div>
+
+      {/* General Settings */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-6">基本設定</h2>
+        <div className="space-y-6">
+          <div>
+            <label
+              htmlFor={tenantNameId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              テナント名
+            </label>
+            <input
+              id={tenantNameId}
+              type="text"
+              value={settings.tenantName}
+              onChange={(e) =>
+                setSettings({ ...settings, tenantName: e.target.value })
+              }
+              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor={contactEmailId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              連絡先メールアドレス
+            </label>
+            <input
+              id={contactEmailId}
+              type="email"
+              value={settings.contactEmail}
+              onChange={(e) =>
+                setSettings({ ...settings, contactEmail: e.target.value })
+              }
+              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            <p className="mt-1 text-sm text-gray-500">
+              システム通知の送信先として使用されます。
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor={defaultCloudProviderId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              デフォルトクラウドプロバイダー
+            </label>
+            <select
+              id={defaultCloudProviderId}
+              value={settings.defaultCloudProvider}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  defaultCloudProvider: e.target.value,
+                })
+              }
+              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="aws">AWS</option>
+              <option value="gcp">Google Cloud</option>
+              <option value="azure">Microsoft Azure</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Event Settings */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-6">
+          イベント設定
+        </h2>
+        <div className="space-y-6">
+          <div>
+            <label
+              htmlFor={maxParticipantsId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              イベントあたりの最大参加者数
+            </label>
+            <input
+              id={maxParticipantsId}
+              type="number"
+              min={1}
+              max={1000}
+              value={settings.maxParticipantsPerEvent}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  maxParticipantsPerEvent: Number.parseInt(e.target.value, 10),
+                })
+              }
+              className="block w-32 border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor={maxTeamSizeId}
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              最大チームサイズ
+            </label>
+            <input
+              id={maxTeamSizeId}
+              type="number"
+              min={1}
+              max={10}
+              value={settings.maxTeamSize}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  maxTeamSize: Number.parseInt(e.target.value, 10),
+                })
+              }
+              className="block w-32 border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Registration Settings */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-6">登録設定</h2>
+        <div className="space-y-4">
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={settings.enableTeamRegistration}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  enableTeamRegistration: e.target.checked,
+                })
+              }
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <span className="ml-3 text-sm text-gray-700">
+              チーム登録を許可する
+            </span>
+          </label>
+
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={settings.enableIndividualRegistration}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  enableIndividualRegistration: e.target.checked,
+                })
+              }
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <span className="ml-3 text-sm text-gray-700">
+              個人登録を許可する
+            </span>
+          </label>
+
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={settings.requireEmailVerification}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  requireEmailVerification: e.target.checked,
+                })
+              }
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <span className="ml-3 text-sm text-gray-700">
+              メール認証を必須にする
+            </span>
+          </label>
+        </div>
+      </div>
+
+      {/* Danger Zone */}
+      <div className="bg-white rounded-lg shadow-sm border border-red-200 p-6">
+        <h2 className="text-lg font-semibold text-red-600 mb-4">危険な操作</h2>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg">
+            <div>
+              <h3 className="text-sm font-medium text-gray-900">
+                全データを削除
+              </h3>
+              <p className="text-sm text-gray-500">
+                すべてのイベント、参加者、チームデータを削除します。この操作は取り消せません。
+              </p>
+            </div>
+            <button
+              type="button"
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 text-sm font-medium"
+            >
+              削除
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/teams/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/teams/page.tsx
@@ -1,0 +1,244 @@
+/**
+ * Admin Teams Page
+ *
+ * チーム管理
+ */
+
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+
+interface Team {
+  id: string;
+  name: string;
+  memberCount: number;
+  maxMembers: number;
+  createdAt: string;
+  eventsCount: number;
+  totalScore: number;
+  captain: {
+    id: string;
+    name: string;
+  };
+}
+
+export default function AdminTeamsPage() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputId = useId();
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchTeams = async () => {
+      try {
+        setLoading(true);
+        // Mock data
+        setTeams([
+          {
+            id: 'team-1',
+            name: 'Cloud Warriors',
+            memberCount: 4,
+            maxMembers: 5,
+            createdAt: new Date(Date.now() - 2592000000).toISOString(),
+            eventsCount: 3,
+            totalScore: 8500,
+            captain: { id: 'user-1', name: '山田太郎' },
+          },
+          {
+            id: 'team-2',
+            name: 'Lambda Legends',
+            memberCount: 5,
+            maxMembers: 5,
+            createdAt: new Date(Date.now() - 1296000000).toISOString(),
+            eventsCount: 2,
+            totalScore: 6200,
+            captain: { id: 'user-2', name: '佐藤花子' },
+          },
+          {
+            id: 'team-3',
+            name: 'Serverless Samurai',
+            memberCount: 3,
+            maxMembers: 5,
+            createdAt: new Date(Date.now() - 604800000).toISOString(),
+            eventsCount: 1,
+            totalScore: 2100,
+            captain: { id: 'user-3', name: '鈴木一郎' },
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTeams();
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const filteredTeams = teams.filter((t) =>
+    t.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">チーム管理</h1>
+      </div>
+
+      {/* Search */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="max-w-md">
+          <label htmlFor={searchInputId} className="sr-only">
+            検索
+          </label>
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg
+                className="h-5 w-5 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+            <input
+              id={searchInputId}
+              type="text"
+              placeholder="チーム名で検索..."
+              className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">総チーム数</div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {teams.length}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">総メンバー数</div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {teams.reduce((acc, t) => acc + t.memberCount, 0)}
+          </div>
+        </div>
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-sm font-medium text-gray-500">
+            平均チームスコア
+          </div>
+          <div className="text-3xl font-bold text-gray-900 mt-1">
+            {teams.length > 0
+              ? Math.round(
+                  teams.reduce((acc, t) => acc + t.totalScore, 0) / teams.length
+                ).toLocaleString()
+              : 0}
+          </div>
+        </div>
+      </div>
+
+      {/* Teams Grid */}
+      {loading ? (
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      ) : filteredTeams.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+          <div className="text-4xl mb-4">🏆</div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            チームが見つかりません
+          </h2>
+          <p className="text-gray-500">
+            {searchQuery
+              ? '検索条件を変更してください。'
+              : '参加者がチームを作成するとここに表示されます。'}
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredTeams.map((team) => (
+            <div
+              key={team.id}
+              className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {team.name}
+                  </h3>
+                  <p className="text-sm text-gray-500">
+                    キャプテン: {team.captain.name}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <div className="text-2xl font-bold text-blue-600">
+                    {team.totalScore.toLocaleString()}
+                  </div>
+                  <div className="text-xs text-gray-500">pts</div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-gray-500">メンバー</span>
+                  <span className="font-medium text-gray-900">
+                    {team.memberCount} / {team.maxMembers}
+                  </span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div
+                    className="bg-blue-600 h-2 rounded-full"
+                    style={{
+                      width: `${(team.memberCount / team.maxMembers) * 100}%`,
+                    }}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-gray-500">参加イベント</span>
+                  <span className="font-medium text-gray-900">
+                    {team.eventsCount}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-gray-500">作成日</span>
+                  <span className="font-medium text-gray-900">
+                    {formatDate(team.createdAt)}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-4 pt-4 border-t border-gray-100">
+                <button
+                  type="button"
+                  className="w-full text-center text-sm text-blue-600 hover:text-blue-700 font-medium"
+                >
+                  詳細を見る
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Application Plane のマルチテナント対応 Phase 2 として、Admin ルート基盤を実装しました。

### 新規作成ファイル

| ファイル | 説明 |
|---------|------|
| `app/(admin)/admin/layout.tsx` | サイドバー付き Admin レイアウト |
| `app/(admin)/admin/page.tsx` | ダッシュボード（統計、クイックアクション、最近のアクティビティ） |
| `app/(admin)/admin/events/page.tsx` | イベント管理一覧（フィルタ、テーブル表示） |
| `app/(admin)/admin/events/[eventId]/page.tsx` | イベント詳細（タブ: 概要/問題/参加者） |
| `app/(admin)/admin/participants/page.tsx` | 参加者管理（検索、統計、テーブル） |
| `app/(admin)/admin/teams/page.tsx` | チーム管理（カードグリッド、統計） |
| `app/(admin)/admin/settings/page.tsx` | テナント設定（基本/イベント/登録/危険な操作） |

### 技術詳細

- Next.js App Router のルートグループ `(admin)` を使用
- Phase 1 で実装した `useTenantOptional` フックを活用
- NextAuth.js の `useSession` でセッション管理
- Tailwind CSS でレスポンシブ UI
- モックデータは TODO コメント付きで API 統合待ち

### 関連 PR

- Phase 1: PR 156 (マルチテナントルーティング基盤)

## Test plan

- [x] `make before-commit` 通過（lint, format, typecheck, test, build）
- [x] 428 + 85 テスト通過
- [ ] 手動確認: `/admin` 以下の各ページが表示されること
- [ ] 手動確認: サイドバーナビゲーションが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Admin Dashboard with navigation panel for managing events, participants, teams, and settings.
  * Introduced Events management page with filtering, create/edit/delete capabilities, and detailed event view with tabs (overview, problems, participants).
  * Added Participants management page with search and filtering functionality.
  * Added Teams management page with team information display.
  * Introduced Settings page for system configuration including tenant name, cloud provider, registration options, and event constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->