### PR TITLE
feat(ui): フォーム UI コンポーネント (Input, Select, Textarea) を実装

### DIFF
--- a/apps/application-plane/components/ui/__tests__/input.test.tsx
+++ b/apps/application-plane/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Input Component テスト
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Input } from '../input';
+
+describe('Input コンポーネント', () => {
+  describe('基本レンダリング', () => {
+    it('デフォルトの input 要素をレンダリングすべき', () => {
+      render(<Input />);
+      const input = screen.getByRole('textbox');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('placeholder を表示すべき', () => {
+      render(<Input placeholder="メールアドレス" />);
+      const input = screen.getByPlaceholderText('メールアドレス');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('value を正しく設定すべき', () => {
+      render(<Input value="test@example.com" onChange={() => {}} />);
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue('test@example.com');
+    });
+  });
+
+  describe('variants', () => {
+    it('default variant のスタイルを適用すべき', () => {
+      render(<Input variant="default" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('border-gray-300');
+    });
+
+    it('error variant のスタイルを適用すべき', () => {
+      render(<Input variant="error" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('sizes', () => {
+    it('sm サイズのスタイルを適用すべき', () => {
+      render(<Input size="sm" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('text-sm');
+    });
+
+    it('md サイズのスタイルを適用すべき', () => {
+      render(<Input size="md" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('text-base');
+    });
+
+    it('lg サイズのスタイルを適用すべき', () => {
+      render(<Input size="lg" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('text-lg');
+    });
+  });
+
+  describe('状態', () => {
+    it('disabled 状態を適用すべき', () => {
+      render(<Input disabled />);
+      const input = screen.getByRole('textbox');
+      expect(input).toBeDisabled();
+    });
+
+    it('required 属性を適用すべき', () => {
+      render(<Input required />);
+      const input = screen.getByRole('textbox');
+      expect(input).toBeRequired();
+    });
+  });
+
+  describe('label', () => {
+    it('label を表示すべき', () => {
+      render(<Input label="メールアドレス" />);
+      const label = screen.getByText('メールアドレス');
+      expect(label).toBeInTheDocument();
+    });
+
+    it('label が input と関連付けられるべき', () => {
+      render(<Input label="メールアドレス" id="email" />);
+      const input = screen.getByLabelText('メールアドレス');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('required の場合 label にアスタリスクを表示すべき', () => {
+      render(<Input label="メールアドレス" required />);
+      const asterisk = screen.getByText('*');
+      expect(asterisk).toBeInTheDocument();
+    });
+  });
+
+  describe('error message', () => {
+    it('error メッセージを表示すべき', () => {
+      render(<Input error="メールアドレスが無効です" />);
+      const errorMessage = screen.getByText('メールアドレスが無効です');
+      expect(errorMessage).toBeInTheDocument();
+    });
+
+    it('error がある場合 error variant を自動適用すべき', () => {
+      render(<Input error="エラー" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('イベント', () => {
+    it('onChange イベントが発火すべき', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Input onChange={handleChange} />);
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, 'a');
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('onFocus イベントが発火すべき', async () => {
+      const handleFocus = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Input onFocus={handleFocus} />);
+      const input = screen.getByRole('textbox');
+
+      await user.click(input);
+      expect(handleFocus).toHaveBeenCalled();
+    });
+
+    it('onBlur イベントが発火すべき', async () => {
+      const handleBlur = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Input onBlur={handleBlur} />);
+      const input = screen.getByRole('textbox');
+
+      await user.click(input);
+      await user.tab();
+      expect(handleBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('forwardRef', () => {
+    it('ref を正しく転送すべき', () => {
+      const ref = createRef<HTMLInputElement>();
+      render(<Input ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('ref 経由で focus を呼び出せるべき', () => {
+      const ref = createRef<HTMLInputElement>();
+      render(<Input ref={ref} />);
+
+      ref.current?.focus();
+      expect(document.activeElement).toBe(ref.current);
+    });
+  });
+
+  describe('カスタム className', () => {
+    it('追加の className を適用すべき', () => {
+      render(<Input className="custom-class" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('custom-class');
+    });
+  });
+
+  describe('type 属性', () => {
+    it('type="email" を設定すべき', () => {
+      render(<Input type="email" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveAttribute('type', 'email');
+    });
+
+    it('type="password" を設定すべき', () => {
+      render(<Input type="password" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveAttribute('type', 'password');
+    });
+
+    it('type="number" を設定すべき', () => {
+      render(<Input type="number" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveAttribute('type', 'number');
+    });
+  });
+});

--- a/apps/application-plane/components/ui/__tests__/select.test.tsx
+++ b/apps/application-plane/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Select Component テスト
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Select } from '../select';
+
+const options = [
+  { value: 'option1', label: 'オプション1' },
+  { value: 'option2', label: 'オプション2' },
+  { value: 'option3', label: 'オプション3' },
+];
+
+describe('Select コンポーネント', () => {
+  describe('基本レンダリング', () => {
+    it('デフォルトの select 要素をレンダリングすべき', () => {
+      render(<Select options={options} />);
+      const select = screen.getByRole('combobox');
+      expect(select).toBeInTheDocument();
+    });
+
+    it('オプションを正しくレンダリングすべき', () => {
+      render(<Select options={options} />);
+      expect(
+        screen.getByRole('option', { name: 'オプション1' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: 'オプション2' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: 'オプション3' })
+      ).toBeInTheDocument();
+    });
+
+    it('placeholder を表示すべき', () => {
+      render(<Select options={options} placeholder="選択してください" />);
+      const placeholder = screen.getByRole('option', {
+        name: '選択してください',
+      });
+      expect(placeholder).toBeInTheDocument();
+      expect(placeholder).toHaveValue('');
+    });
+
+    it('value を正しく設定すべき', () => {
+      render(<Select options={options} value="option2" onChange={() => {}} />);
+      const select = screen.getByRole('combobox');
+      expect(select).toHaveValue('option2');
+    });
+  });
+
+  describe('variants', () => {
+    it('default variant のスタイルを適用すべき', () => {
+      render(
+        <Select options={options} variant="default" data-testid="select" />
+      );
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('border-gray-300');
+    });
+
+    it('error variant のスタイルを適用すべき', () => {
+      render(<Select options={options} variant="error" data-testid="select" />);
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('sizes', () => {
+    it('sm サイズのスタイルを適用すべき', () => {
+      render(<Select options={options} size="sm" data-testid="select" />);
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('text-sm');
+    });
+
+    it('md サイズのスタイルを適用すべき', () => {
+      render(<Select options={options} size="md" data-testid="select" />);
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('text-base');
+    });
+
+    it('lg サイズのスタイルを適用すべき', () => {
+      render(<Select options={options} size="lg" data-testid="select" />);
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('text-lg');
+    });
+  });
+
+  describe('状態', () => {
+    it('disabled 状態を適用すべき', () => {
+      render(<Select options={options} disabled />);
+      const select = screen.getByRole('combobox');
+      expect(select).toBeDisabled();
+    });
+
+    it('required 属性を適用すべき', () => {
+      render(<Select options={options} required />);
+      const select = screen.getByRole('combobox');
+      expect(select).toBeRequired();
+    });
+  });
+
+  describe('label', () => {
+    it('label を表示すべき', () => {
+      render(<Select options={options} label="カテゴリ" />);
+      const label = screen.getByText('カテゴリ');
+      expect(label).toBeInTheDocument();
+    });
+
+    it('label が select と関連付けられるべき', () => {
+      render(<Select options={options} label="カテゴリ" id="category" />);
+      const select = screen.getByLabelText('カテゴリ');
+      expect(select).toBeInTheDocument();
+    });
+
+    it('required の場合 label にアスタリスクを表示すべき', () => {
+      render(<Select options={options} label="カテゴリ" required />);
+      const asterisk = screen.getByText('*');
+      expect(asterisk).toBeInTheDocument();
+    });
+  });
+
+  describe('error message', () => {
+    it('error メッセージを表示すべき', () => {
+      render(<Select options={options} error="カテゴリを選択してください" />);
+      const errorMessage = screen.getByText('カテゴリを選択してください');
+      expect(errorMessage).toBeInTheDocument();
+    });
+
+    it('error がある場合 error variant を自動適用すべき', () => {
+      render(<Select options={options} error="エラー" data-testid="select" />);
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('イベント', () => {
+    it('onChange イベントが発火すべき', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Select options={options} onChange={handleChange} />);
+      const select = screen.getByRole('combobox');
+
+      await user.selectOptions(select, 'option2');
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('onFocus イベントが発火すべき', async () => {
+      const handleFocus = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Select options={options} onFocus={handleFocus} />);
+      const select = screen.getByRole('combobox');
+
+      await user.click(select);
+      expect(handleFocus).toHaveBeenCalled();
+    });
+
+    it('onBlur イベントが発火すべき', async () => {
+      const handleBlur = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Select options={options} onBlur={handleBlur} />);
+      const select = screen.getByRole('combobox');
+
+      await user.click(select);
+      await user.tab();
+      expect(handleBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('forwardRef', () => {
+    it('ref を正しく転送すべき', () => {
+      const ref = createRef<HTMLSelectElement>();
+      render(<Select options={options} ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLSelectElement);
+    });
+
+    it('ref 経由で focus を呼び出せるべき', () => {
+      const ref = createRef<HTMLSelectElement>();
+      render(<Select options={options} ref={ref} />);
+
+      ref.current?.focus();
+      expect(document.activeElement).toBe(ref.current);
+    });
+  });
+
+  describe('カスタム className', () => {
+    it('追加の className を適用すべき', () => {
+      render(
+        <Select
+          options={options}
+          className="custom-class"
+          data-testid="select"
+        />
+      );
+      const select = screen.getByTestId('select');
+      expect(select).toHaveClass('custom-class');
+    });
+  });
+
+  describe('disabled オプション', () => {
+    it('個別の disabled オプションを設定すべき', () => {
+      const optionsWithDisabled = [
+        { value: 'option1', label: 'オプション1' },
+        { value: 'option2', label: 'オプション2', disabled: true },
+      ];
+      render(<Select options={optionsWithDisabled} />);
+      const disabledOption = screen.getByRole('option', {
+        name: 'オプション2',
+      });
+      expect(disabledOption).toBeDisabled();
+    });
+  });
+});

--- a/apps/application-plane/components/ui/__tests__/textarea.test.tsx
+++ b/apps/application-plane/components/ui/__tests__/textarea.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Textarea Component テスト
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Textarea } from '../textarea';
+
+describe('Textarea コンポーネント', () => {
+  describe('基本レンダリング', () => {
+    it('デフォルトの textarea 要素をレンダリングすべき', () => {
+      render(<Textarea />);
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it('placeholder を表示すべき', () => {
+      render(<Textarea placeholder="説明を入力" />);
+      const textarea = screen.getByPlaceholderText('説明を入力');
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it('value を正しく設定すべき', () => {
+      render(<Textarea value="テスト内容" onChange={() => {}} />);
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toHaveValue('テスト内容');
+    });
+  });
+
+  describe('variants', () => {
+    it('default variant のスタイルを適用すべき', () => {
+      render(<Textarea variant="default" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('border-gray-300');
+    });
+
+    it('error variant のスタイルを適用すべき', () => {
+      render(<Textarea variant="error" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('sizes', () => {
+    it('sm サイズのスタイルを適用すべき', () => {
+      render(<Textarea size="sm" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('text-sm');
+    });
+
+    it('md サイズのスタイルを適用すべき', () => {
+      render(<Textarea size="md" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('text-base');
+    });
+
+    it('lg サイズのスタイルを適用すべき', () => {
+      render(<Textarea size="lg" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('text-lg');
+    });
+  });
+
+  describe('状態', () => {
+    it('disabled 状態を適用すべき', () => {
+      render(<Textarea disabled />);
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeDisabled();
+    });
+
+    it('required 属性を適用すべき', () => {
+      render(<Textarea required />);
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeRequired();
+    });
+  });
+
+  describe('label', () => {
+    it('label を表示すべき', () => {
+      render(<Textarea label="説明" />);
+      const label = screen.getByText('説明');
+      expect(label).toBeInTheDocument();
+    });
+
+    it('label が textarea と関連付けられるべき', () => {
+      render(<Textarea label="説明" id="description" />);
+      const textarea = screen.getByLabelText('説明');
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it('required の場合 label にアスタリスクを表示すべき', () => {
+      render(<Textarea label="説明" required />);
+      const asterisk = screen.getByText('*');
+      expect(asterisk).toBeInTheDocument();
+    });
+  });
+
+  describe('error message', () => {
+    it('error メッセージを表示すべき', () => {
+      render(<Textarea error="説明を入力してください" />);
+      const errorMessage = screen.getByText('説明を入力してください');
+      expect(errorMessage).toBeInTheDocument();
+    });
+
+    it('error がある場合 error variant を自動適用すべき', () => {
+      render(<Textarea error="エラー" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('border-red-500');
+    });
+  });
+
+  describe('イベント', () => {
+    it('onChange イベントが発火すべき', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Textarea onChange={handleChange} />);
+      const textarea = screen.getByRole('textbox');
+
+      await user.type(textarea, 'a');
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('onFocus イベントが発火すべき', async () => {
+      const handleFocus = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Textarea onFocus={handleFocus} />);
+      const textarea = screen.getByRole('textbox');
+
+      await user.click(textarea);
+      expect(handleFocus).toHaveBeenCalled();
+    });
+
+    it('onBlur イベントが発火すべき', async () => {
+      const handleBlur = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Textarea onBlur={handleBlur} />);
+      const textarea = screen.getByRole('textbox');
+
+      await user.click(textarea);
+      await user.tab();
+      expect(handleBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('forwardRef', () => {
+    it('ref を正しく転送すべき', () => {
+      const ref = createRef<HTMLTextAreaElement>();
+      render(<Textarea ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+    });
+
+    it('ref 経由で focus を呼び出せるべき', () => {
+      const ref = createRef<HTMLTextAreaElement>();
+      render(<Textarea ref={ref} />);
+
+      ref.current?.focus();
+      expect(document.activeElement).toBe(ref.current);
+    });
+  });
+
+  describe('カスタム className', () => {
+    it('追加の className を適用すべき', () => {
+      render(<Textarea className="custom-class" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('custom-class');
+    });
+  });
+
+  describe('rows 属性', () => {
+    it('rows を設定すべき', () => {
+      render(<Textarea rows={5} data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveAttribute('rows', '5');
+    });
+
+    it('デフォルトで rows=3 を設定すべき', () => {
+      render(<Textarea data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveAttribute('rows', '3');
+    });
+  });
+
+  describe('resize', () => {
+    it('resize を無効にするスタイルを適用すべき', () => {
+      render(<Textarea resize="none" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('resize-none');
+    });
+
+    it('resize を vertical にするスタイルを適用すべき', () => {
+      render(<Textarea resize="vertical" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('resize-y');
+    });
+
+    it('resize を horizontal にするスタイルを適用すべき', () => {
+      render(<Textarea resize="horizontal" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('resize-x');
+    });
+
+    it('resize を both にするスタイルを適用すべき', () => {
+      render(<Textarea resize="both" data-testid="textarea" />);
+      const textarea = screen.getByTestId('textarea');
+      expect(textarea).toHaveClass('resize');
+    });
+  });
+});

--- a/apps/application-plane/components/ui/index.ts
+++ b/apps/application-plane/components/ui/index.ts
@@ -10,4 +10,7 @@ export {
 } from './badge';
 export { Button } from './button';
 export { Card, CardContent, CardFooter, CardHeader } from './card';
+export { Input } from './input';
 export { Progress, ScoreProgress } from './progress';
+export { Select } from './select';
+export { Textarea } from './textarea';

--- a/apps/application-plane/components/ui/input.tsx
+++ b/apps/application-plane/components/ui/input.tsx
@@ -1,0 +1,82 @@
+/**
+ * Input Component
+ *
+ * フォーム入力用コンポーネント
+ */
+
+import { forwardRef, useId, type InputHTMLAttributes } from 'react';
+
+type InputVariant = 'default' | 'error';
+type InputSize = 'sm' | 'md' | 'lg';
+
+interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size'
+> {
+  variant?: InputVariant;
+  size?: InputSize;
+  label?: string;
+  error?: string;
+}
+
+const variantClasses: Record<InputVariant, string> = {
+  default: 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
+  error: 'border-red-500 focus:border-red-500 focus:ring-red-500',
+};
+
+const sizeClasses: Record<InputSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-base',
+  lg: 'px-4 py-3 text-lg',
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      variant = 'default',
+      size = 'md',
+      label,
+      error,
+      className = '',
+      id,
+      required,
+      disabled,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id || generatedId;
+
+    // error があれば error variant を適用
+    const effectiveVariant = error ? 'error' : variant;
+
+    const baseClasses =
+      'block w-full rounded-lg border bg-white focus:outline-none focus:ring-2 focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
+
+    return (
+      <div className="w-full">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {label}
+            {required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+        )}
+        <input
+          ref={ref}
+          id={inputId}
+          className={`${baseClasses} ${variantClasses[effectiveVariant]} ${sizeClasses[size]} ${className}`}
+          required={required}
+          disabled={disabled}
+          {...props}
+        />
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/apps/application-plane/components/ui/select.tsx
+++ b/apps/application-plane/components/ui/select.tsx
@@ -1,0 +1,115 @@
+/**
+ * Select Component
+ *
+ * フォーム選択用コンポーネント
+ */
+
+import { forwardRef, useId, type SelectHTMLAttributes } from 'react';
+
+type SelectVariant = 'default' | 'error';
+type SelectSize = 'sm' | 'md' | 'lg';
+
+interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface SelectProps extends Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  'size'
+> {
+  options: SelectOption[];
+  variant?: SelectVariant;
+  size?: SelectSize;
+  label?: string;
+  error?: string;
+  placeholder?: string;
+}
+
+const variantClasses: Record<SelectVariant, string> = {
+  default: 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
+  error: 'border-red-500 focus:border-red-500 focus:ring-red-500',
+};
+
+const sizeClasses: Record<SelectSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-base',
+  lg: 'px-4 py-3 text-lg',
+};
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  (
+    {
+      options,
+      variant = 'default',
+      size = 'md',
+      label,
+      error,
+      placeholder,
+      className = '',
+      id,
+      required,
+      disabled,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const selectId = id || generatedId;
+
+    // error があれば error variant を適用
+    const effectiveVariant = error ? 'error' : variant;
+
+    const baseClasses =
+      'block w-full rounded-lg border bg-white focus:outline-none focus:ring-2 focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed transition-colors appearance-none bg-no-repeat bg-right pr-10';
+
+    // Custom dropdown arrow using CSS
+    const arrowStyle = {
+      backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236B7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E")`,
+      backgroundSize: '1.5rem',
+      backgroundPosition: 'right 0.5rem center',
+    };
+
+    return (
+      <div className="w-full">
+        {label && (
+          <label
+            htmlFor={selectId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {label}
+            {required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+        )}
+        <select
+          ref={ref}
+          id={selectId}
+          className={`${baseClasses} ${variantClasses[effectiveVariant]} ${sizeClasses[size]} ${className}`}
+          style={arrowStyle}
+          required={required}
+          disabled={disabled}
+          {...props}
+        >
+          {placeholder && (
+            <option value="" disabled={required}>
+              {placeholder}
+            </option>
+          )}
+          {options.map((option) => (
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+);
+
+Select.displayName = 'Select';

--- a/apps/application-plane/components/ui/textarea.tsx
+++ b/apps/application-plane/components/ui/textarea.tsx
@@ -1,0 +1,94 @@
+/**
+ * Textarea Component
+ *
+ * フォームテキストエリア用コンポーネント
+ */
+
+import { forwardRef, useId, type TextareaHTMLAttributes } from 'react';
+
+type TextareaVariant = 'default' | 'error';
+type TextareaSize = 'sm' | 'md' | 'lg';
+type TextareaResize = 'none' | 'vertical' | 'horizontal' | 'both';
+
+interface TextareaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'size'
+> {
+  variant?: TextareaVariant;
+  size?: TextareaSize;
+  resize?: TextareaResize;
+  label?: string;
+  error?: string;
+}
+
+const variantClasses: Record<TextareaVariant, string> = {
+  default: 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
+  error: 'border-red-500 focus:border-red-500 focus:ring-red-500',
+};
+
+const sizeClasses: Record<TextareaSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-base',
+  lg: 'px-4 py-3 text-lg',
+};
+
+const resizeClasses: Record<TextareaResize, string> = {
+  none: 'resize-none',
+  vertical: 'resize-y',
+  horizontal: 'resize-x',
+  both: 'resize',
+};
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      variant = 'default',
+      size = 'md',
+      resize = 'vertical',
+      label,
+      error,
+      className = '',
+      id,
+      required,
+      disabled,
+      rows = 3,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const textareaId = id || generatedId;
+
+    // error があれば error variant を適用
+    const effectiveVariant = error ? 'error' : variant;
+
+    const baseClasses =
+      'block w-full rounded-lg border bg-white focus:outline-none focus:ring-2 focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
+
+    return (
+      <div className="w-full">
+        {label && (
+          <label
+            htmlFor={textareaId}
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {label}
+            {required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+        )}
+        <textarea
+          ref={ref}
+          id={textareaId}
+          className={`${baseClasses} ${variantClasses[effectiveVariant]} ${sizeClasses[size]} ${resizeClasses[resize]} ${className}`}
+          required={required}
+          disabled={disabled}
+          rows={rows}
+          {...props}
+        />
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';


### PR DESCRIPTION
## Summary

- **Input コンポーネント**: テキスト入力フィールド
  - variants (default, error), sizes (sm, md, lg) をサポート
  - label, error メッセージ, required インジケータをサポート
  - forwardRef で ref 転送に対応
  - 24 テストケースで 100% カバレッジ

- **Select コンポーネント**: ドロップダウン選択
  - options 配列で選択肢を指定
  - placeholder, disabled オプションをサポート
  - カスタム矢印スタイル
  - 23 テストケースで 100% カバレッジ

- **Textarea コンポーネント**: 複数行テキスト入力
  - resize オプション (none, vertical, horizontal, both)
  - rows 属性をサポート
  - 27 テストケースで 100% カバレッジ

既存の Button, Badge コンポーネントのパターンに従い、Tailwind CSS を使用した一貫したスタイリングを実装。

## Test plan

- [x] 全74テストケースがパス
- [x] 100% コードカバレッジ達成
- [x] TypeScript 型チェックパス
- [x] Prettier フォーマットチェックパス
- [x] ビルド成功 (control-plane, application-plane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new reusable form components: Input, Select, and Textarea with support for variants and size customization.
  * Components include built-in error messaging, accessible labels with required indicators, and full keyboard navigation support.

* **Tests**
  * Added comprehensive test coverage for Input, Select, and Textarea components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->