### PR TITLE
feat(application-plane): Admin 型定義を作成

### DIFF
--- a/apps/application-plane/lib/api/__tests__/admin-types.test.ts
+++ b/apps/application-plane/lib/api/__tests__/admin-types.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Admin Types 型互換性テスト
+ *
+ * TypeScript の型チェックでコンパイル時に検証される
+ * ランタイムテストではなく、型の正しさを検証するためのテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  AdminEvent,
+  AdminTeam,
+  AdminParticipant,
+  AdminListResponse,
+  AdminEventFilters,
+  AdminTeamFilters,
+  AdminParticipantFilters,
+  CreateEventRequest,
+  CreateTeamRequest,
+  AddParticipantRequest,
+  UpdateEventRequest,
+  UpdateTeamRequest,
+  UpdateParticipantRequest,
+  ParticipantRole,
+  ParticipantStatus,
+  EventStatus,
+  AdminEventListResponse,
+  AdminTeamListResponse,
+  AdminParticipantListResponse,
+  AdminChallenge,
+  AdminChallengeFilters,
+} from '../admin-types';
+import type { ParticipantEvent, TeamInfo, TeamMember } from '../types';
+
+describe('Admin Types 型互換性テスト', () => {
+  describe('AdminEvent は ParticipantEvent を拡張すべき', () => {
+    it('ParticipantEvent のフィールドを含むべき', () => {
+      // 型チェック: AdminEvent が ParticipantEvent を拡張していることを確認
+      const event: AdminEvent = {
+        // ParticipantEvent のフィールド
+        id: 'evt-1',
+        name: 'Test Event',
+        type: 'gameday',
+        status: 'draft',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-02T00:00:00Z',
+        timezone: 'Asia/Tokyo',
+        participantType: 'team',
+        cloudProvider: 'aws',
+        regions: ['ap-northeast-1'],
+        scoringType: 'realtime',
+        leaderboardVisible: true,
+        problemCount: 5,
+        participantCount: 10,
+        isRegistered: false,
+        // AdminEvent 固有のフィールド
+        maxParticipants: 100,
+        slug: 'test-event',
+        description: 'Test description',
+      };
+
+      // ParticipantEvent として代入可能であることを確認
+      const participantEvent: ParticipantEvent = event;
+      expect(participantEvent.id).toBe('evt-1');
+    });
+
+    it('EventStatus の値が正しく設定できるべき', () => {
+      const statuses: EventStatus[] = [
+        'draft',
+        'scheduled',
+        'active',
+        'paused',
+        'completed',
+        'cancelled',
+      ];
+      expect(statuses).toHaveLength(6);
+    });
+  });
+
+  describe('AdminTeam は TeamInfo を拡張すべき', () => {
+    it('TeamInfo のフィールドを含むべき', () => {
+      const member: TeamMember = {
+        id: 'member-1',
+        name: 'Test Member',
+        email: 'test@example.com',
+        role: 'member',
+        joinedAt: '2024-01-01T00:00:00Z',
+      };
+
+      const team: AdminTeam = {
+        // TeamInfo のフィールド
+        id: 'team-1',
+        name: 'Test Team',
+        members: [member],
+        captainId: 'captain-1',
+        inviteCode: 'ABC123',
+        // AdminTeam 固有のフィールド
+        memberCount: 4,
+        maxMembers: 5,
+        eventsCount: 3,
+        totalScore: 8500,
+        createdAt: '2024-01-01T00:00:00Z',
+      };
+
+      // TeamInfo として代入可能であることを確認
+      const teamInfo: TeamInfo = team;
+      expect(teamInfo.id).toBe('team-1');
+    });
+  });
+
+  describe('AdminParticipant 型の構造が正しいべき', () => {
+    it('必須フィールドとオプショナルフィールドが正しく定義されるべき', () => {
+      // 必須フィールドのみ
+      const minimalParticipant: AdminParticipant = {
+        id: 'participant-1',
+        userId: 'user-1',
+        displayName: 'Test User',
+        email: 'test@example.com',
+        role: 'participant',
+        joinedAt: '2024-01-01T00:00:00Z',
+        status: 'active',
+      };
+      expect(minimalParticipant.id).toBe('participant-1');
+
+      // すべてのフィールド
+      const fullParticipant: AdminParticipant = {
+        id: 'participant-2',
+        userId: 'user-2',
+        displayName: 'Full User',
+        email: 'full@example.com',
+        role: 'admin',
+        teamId: 'team-1',
+        teamName: 'Test Team',
+        joinedAt: '2024-01-01T00:00:00Z',
+        status: 'active',
+        eventsCount: 5,
+        totalScore: 2500,
+      };
+      expect(fullParticipant.teamId).toBe('team-1');
+    });
+
+    it('ParticipantRole の値が正しく設定できるべき', () => {
+      const roles: ParticipantRole[] = ['participant', 'admin', 'spectator'];
+      expect(roles).toHaveLength(3);
+    });
+
+    it('ParticipantStatus の値が正しく設定できるべき', () => {
+      const statuses: ParticipantStatus[] = ['active', 'inactive', 'banned'];
+      expect(statuses).toHaveLength(3);
+    });
+  });
+
+  describe('AdminListResponse ジェネリック型が正しく動作すべき', () => {
+    it('イベント一覧で使用できるべき', () => {
+      const response: AdminListResponse<AdminEvent> = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        hasMore: false,
+      };
+      expect(response.items).toEqual([]);
+    });
+
+    it('チーム一覧で使用できるべき', () => {
+      const response: AdminListResponse<AdminTeam> = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        hasMore: false,
+      };
+      expect(response.items).toEqual([]);
+    });
+
+    it('参加者一覧で使用できるべき', () => {
+      const response: AdminListResponse<AdminParticipant> = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        hasMore: false,
+      };
+      expect(response.items).toEqual([]);
+    });
+  });
+
+  describe('フィルター型が正しく定義されるべき', () => {
+    it('AdminEventFilters はすべてオプショナルであるべき', () => {
+      const emptyFilters: AdminEventFilters = {};
+      const fullFilters: AdminEventFilters = {
+        status: 'active',
+        search: 'test',
+        type: 'gameday',
+      };
+      expect(emptyFilters).toEqual({});
+      expect(fullFilters.status).toBe('active');
+    });
+
+    it('AdminTeamFilters はすべてオプショナルであるべき', () => {
+      const emptyFilters: AdminTeamFilters = {};
+      const fullFilters: AdminTeamFilters = {
+        eventId: 'evt-1',
+        search: 'test',
+      };
+      expect(emptyFilters).toEqual({});
+      expect(fullFilters.eventId).toBe('evt-1');
+    });
+
+    it('AdminParticipantFilters はすべてオプショナルであるべき', () => {
+      const emptyFilters: AdminParticipantFilters = {};
+      const fullFilters: AdminParticipantFilters = {
+        eventId: 'evt-1',
+        teamId: 'team-1',
+        search: 'test',
+        status: 'active',
+        role: 'participant',
+      };
+      expect(emptyFilters).toEqual({});
+      expect(fullFilters.eventId).toBe('evt-1');
+    });
+  });
+
+  describe('リクエスト型が正しく定義されるべき', () => {
+    it('CreateEventRequest の必須フィールドが正しいべき', () => {
+      const request: CreateEventRequest = {
+        name: 'New Event',
+        slug: 'new-event',
+        eventDate: '2024-01-01',
+      };
+      expect(request.name).toBe('New Event');
+    });
+
+    it('CreateTeamRequest の必須フィールドが正しいべき', () => {
+      const request: CreateTeamRequest = {
+        name: 'New Team',
+        eventId: 'evt-1',
+      };
+      expect(request.name).toBe('New Team');
+    });
+
+    it('AddParticipantRequest の必須フィールドが正しいべき', () => {
+      const request: AddParticipantRequest = {
+        email: 'test@example.com',
+      };
+      expect(request.email).toBe('test@example.com');
+    });
+
+    it('UpdateEventRequest は id を必須とすべき', () => {
+      const request: UpdateEventRequest = {
+        id: 'evt-1',
+        name: 'Updated Event',
+      };
+      expect(request.id).toBe('evt-1');
+    });
+
+    it('UpdateTeamRequest は id を必須とすべき', () => {
+      const request: UpdateTeamRequest = {
+        id: 'team-1',
+        name: 'Updated Team',
+      };
+      expect(request.id).toBe('team-1');
+    });
+
+    it('UpdateParticipantRequest は id を必須とすべき', () => {
+      const request: UpdateParticipantRequest = {
+        id: 'participant-1',
+        displayName: 'Updated Name',
+      };
+      expect(request.id).toBe('participant-1');
+    });
+  });
+
+  describe('レガシーレスポンス型が互換性を持つべき', () => {
+    it('AdminEventListResponse が正しい構造を持つべき', () => {
+      const response: AdminEventListResponse = {
+        events: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      };
+      expect(response.events).toEqual([]);
+    });
+
+    it('AdminTeamListResponse が正しい構造を持つべき', () => {
+      const response: AdminTeamListResponse = {
+        teams: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      };
+      expect(response.teams).toEqual([]);
+    });
+
+    it('AdminParticipantListResponse が正しい構造を持つべき', () => {
+      const response: AdminParticipantListResponse = {
+        participants: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      };
+      expect(response.participants).toEqual([]);
+    });
+  });
+
+  describe('AdminChallenge 型が正しく定義されるべき', () => {
+    it('必須フィールドが設定できるべき', () => {
+      const challenge: AdminChallenge = {
+        id: 'challenge-1',
+        eventId: 'evt-1',
+        title: 'Test Challenge',
+        description: 'Test description',
+        difficulty: 'medium',
+        maxScore: 100,
+        order: 1,
+        isPublished: true,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+      expect(challenge.id).toBe('challenge-1');
+    });
+
+    it('difficulty の値が正しいべき', () => {
+      const difficulties: AdminChallenge['difficulty'][] = [
+        'easy',
+        'medium',
+        'hard',
+        'expert',
+      ];
+      expect(difficulties).toHaveLength(4);
+    });
+  });
+
+  describe('AdminChallengeFilters が正しく定義されるべき', () => {
+    it('すべてオプショナルであるべき', () => {
+      const emptyFilters: AdminChallengeFilters = {};
+      const fullFilters: AdminChallengeFilters = {
+        eventId: 'evt-1',
+        difficulty: 'hard',
+        isPublished: true,
+        search: 'test',
+      };
+      expect(emptyFilters).toEqual({});
+      expect(fullFilters.difficulty).toBe('hard');
+    });
+  });
+});

--- a/apps/application-plane/lib/api/admin-types.ts
+++ b/apps/application-plane/lib/api/admin-types.ts
@@ -1,0 +1,289 @@
+/**
+ * Admin API Types
+ *
+ * 管理者向け API の型定義
+ *
+ * 参加者向け types.ts を拡張し、Admin 固有のフィールドを追加
+ */
+
+import type {
+  EventStatus,
+  ParticipantEvent,
+  TeamInfo,
+  TeamMember,
+  ProblemType,
+} from './types';
+
+// Re-export common types for convenience
+export type { EventStatus, ProblemType };
+
+// =============================================================================
+// Admin Event Types
+// =============================================================================
+
+/**
+ * Admin 用イベント型
+ *
+ * ParticipantEvent を拡張し、管理者向けフィールドを追加
+ */
+export interface AdminEvent extends ParticipantEvent {
+  /** イベントの最大参加者数 */
+  maxParticipants: number;
+  /** イベントの説明 */
+  description?: string;
+  /** URL スラッグ */
+  slug: string;
+}
+
+/**
+ * イベント作成リクエスト型
+ */
+export interface CreateEventRequest {
+  name: string;
+  slug: string;
+  description?: string;
+  organizer?: string;
+  eventDate: string;
+  startTime?: string;
+  endTime?: string;
+  status?: EventStatus;
+  imageUrl?: string;
+  maxParticipants?: number;
+  type?: ProblemType;
+}
+
+/**
+ * イベント更新リクエスト型
+ */
+export interface UpdateEventRequest extends Partial<CreateEventRequest> {
+  id: string;
+}
+
+/**
+ * イベントフィルター型
+ */
+export interface AdminEventFilters {
+  status?: EventStatus;
+  search?: string;
+  type?: ProblemType;
+}
+
+// =============================================================================
+// Admin Team Types
+// =============================================================================
+
+/**
+ * Admin 用チーム型
+ *
+ * TeamInfo を拡張し、集計情報を追加
+ */
+export interface AdminTeam extends TeamInfo {
+  /** 現在のメンバー数 */
+  memberCount: number;
+  /** 最大メンバー数 */
+  maxMembers: number;
+  /** 参加イベント数 */
+  eventsCount: number;
+  /** 累計スコア */
+  totalScore: number;
+  /** 作成日時 */
+  createdAt: string;
+}
+
+/**
+ * Admin 用チームメンバー型（TeamMember の alias）
+ */
+export type AdminTeamMember = TeamMember;
+
+/**
+ * チーム作成リクエスト型
+ */
+export interface CreateTeamRequest {
+  name: string;
+  eventId: string;
+  captainId?: string;
+  memberIds?: string[];
+  maxMembers?: number;
+}
+
+/**
+ * チーム更新リクエスト型
+ */
+export interface UpdateTeamRequest extends Partial<
+  Omit<CreateTeamRequest, 'eventId'>
+> {
+  id: string;
+}
+
+/**
+ * チームフィルター型
+ */
+export interface AdminTeamFilters {
+  eventId?: string;
+  search?: string;
+}
+
+// =============================================================================
+// Admin Participant Types
+// =============================================================================
+
+/**
+ * 参加者のロール
+ */
+export type ParticipantRole = 'participant' | 'admin' | 'spectator';
+
+/**
+ * 参加者のステータス
+ */
+export type ParticipantStatus = 'active' | 'inactive' | 'banned';
+
+/**
+ * Admin 用参加者型
+ *
+ * 管理画面で表示する参加者情報
+ */
+export interface AdminParticipant {
+  /** 参加者 ID */
+  id: string;
+  /** ユーザー ID（認証システムでの ID） */
+  userId: string;
+  /** 表示名 */
+  displayName: string;
+  /** メールアドレス */
+  email: string;
+  /** ロール */
+  role: ParticipantRole;
+  /** 所属チーム ID */
+  teamId?: string;
+  /** 所属チーム名 */
+  teamName?: string;
+  /** 参加日時 */
+  joinedAt: string;
+  /** ステータス */
+  status: ParticipantStatus;
+  /** 参加イベント数 */
+  eventsCount?: number;
+  /** 累計スコア */
+  totalScore?: number;
+}
+
+/**
+ * 参加者追加リクエスト型
+ */
+export interface AddParticipantRequest {
+  email: string;
+  name?: string;
+  eventId?: string;
+  teamId?: string;
+  role?: ParticipantRole;
+}
+
+/**
+ * 参加者更新リクエスト型
+ */
+export interface UpdateParticipantRequest {
+  id: string;
+  displayName?: string;
+  role?: ParticipantRole;
+  status?: ParticipantStatus;
+  teamId?: string | null;
+}
+
+/**
+ * 参加者フィルター型
+ */
+export interface AdminParticipantFilters {
+  eventId?: string;
+  teamId?: string;
+  search?: string;
+  status?: ParticipantStatus;
+  role?: ParticipantRole;
+}
+
+// =============================================================================
+// Admin API Response Types
+// =============================================================================
+
+/**
+ * Admin リスト API の汎用レスポンス型
+ *
+ * @template T - リストアイテムの型
+ */
+export interface AdminListResponse<T> {
+  /** アイテムのリスト */
+  items: T[];
+  /** 総件数 */
+  total: number;
+  /** 現在のページ番号 (1-indexed) */
+  page: number;
+  /** 1 ページあたりの件数 */
+  limit: number;
+  /** 次のページが存在するか */
+  hasMore: boolean;
+}
+
+/**
+ * イベント一覧レスポンス型
+ *
+ * @deprecated AdminListResponse<AdminEvent> を使用してください
+ */
+export interface AdminEventListResponse {
+  events: AdminEvent[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * チーム一覧レスポンス型
+ *
+ * @deprecated AdminListResponse<AdminTeam> を使用してください
+ */
+export interface AdminTeamListResponse {
+  teams: AdminTeam[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * 参加者一覧レスポンス型
+ *
+ * @deprecated AdminListResponse<AdminParticipant> を使用してください
+ */
+export interface AdminParticipantListResponse {
+  participants: AdminParticipant[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// =============================================================================
+// Admin Challenge Types (for future use)
+// =============================================================================
+
+/**
+ * Admin 用チャレンジ型（将来の拡張用）
+ */
+export interface AdminChallenge {
+  id: string;
+  eventId: string;
+  title: string;
+  description: string;
+  difficulty: 'easy' | 'medium' | 'hard' | 'expert';
+  maxScore: number;
+  order: number;
+  isPublished: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * チャレンジフィルター型
+ */
+export interface AdminChallengeFilters {
+  eventId?: string;
+  difficulty?: AdminChallenge['difficulty'];
+  isPublished?: boolean;
+  search?: string;
+}


### PR DESCRIPTION
## Summary

- AdminEvent: ParticipantEvent を拡張し maxParticipants, description, slug を追加
- AdminTeam: TeamInfo を拡張し memberCount, maxMembers, eventsCount, totalScore を追加
- AdminParticipant: 管理画面向け参加者型（userId, displayName, role, status など）
- AdminListResponse<T>: ジェネリックなリスト API レスポンス型
- フィルター型: AdminEventFilters, AdminTeamFilters, AdminParticipantFilters
- リクエスト型: Create/Update 系の型を定義
- AdminChallenge: 将来の拡張用チャレンジ型

## 背景

Stream 3 分析で発見されたモックデータと API レスポンスの型不一致を解消するための型定義です。

### 解消された不一致

1. **EventStatus の統一**: 'ended' を 'completed' に統一
2. **AdminEvent 型の拡張**: maxParticipants, description, slug を追加
3. **AdminTeam 型の拡張**: memberCount, maxMembers, eventsCount, totalScore を追加
4. **AdminParticipant 型の作成**: 管理画面専用の参加者情報型

## Test plan

- [x] 型互換性テスト（24 テスト）がパス
- [x] TypeScript コンパイルエラーなし
- [x] Prettier フォーマットチェックパス
- [x] ESLint チェックパス

## Files changed

- `apps/application-plane/lib/api/admin-types.ts` - 新規作成
- `apps/application-plane/lib/api/__tests__/admin-types.test.ts` - 新規作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive type validation tests for admin API, ensuring proper type structure and compatibility for administrative operations across events, teams, participants, and challenges. Tests validate create, update, add, and filter functionality, confirm required fields for request types, and verify list response structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->