### PR TITLE
feat(application-plane): HybridNext ダークテーマへ統一し /rankings ページを追加

### DIFF
--- a/apps/application-plane/app/__tests__/page.test.tsx
+++ b/apps/application-plane/app/__tests__/page.test.tsx
@@ -21,16 +21,20 @@ describe('Participant App ホームページ', () => {
     expect(catchphrase).toBeInTheDocument();
   });
 
-  it('「バトルに参加する」ボタンが表示されるべき', () => {
+  it('「バトルに参加する」ボタンが /events へのリンクを持つべき', () => {
     render(<Home />);
     const joinButton = screen.getByRole('button', { name: 'バトルに参加する' });
     expect(joinButton).toBeInTheDocument();
+    const link = joinButton.closest('a');
+    expect(link).toHaveAttribute('href', '/events');
   });
 
-  it('「観戦モード」ボタンが表示されるべき', () => {
+  it('「観戦モード」ボタンが /events へのリンクを持つべき', () => {
     render(<Home />);
     const spectateButton = screen.getByRole('button', { name: '観戦モード' });
     expect(spectateButton).toBeInTheDocument();
+    const link = spectateButton.closest('a');
+    expect(link).toHaveAttribute('href', '/events');
   });
 
   it('統計情報のプレースホルダーが3つ表示されるべき（API 接続前）', () => {
@@ -40,21 +44,11 @@ describe('Participant App ホームページ', () => {
     expect(placeholders).toHaveLength(3);
   });
 
-  it('ステータスラベル「Status」が表示されるべき', () => {
-    render(<Home />);
-    const statusLabel = screen.getByText('Status');
-    expect(statusLabel).toBeInTheDocument();
-  });
-
-  it('参加者ラベル「Participants」が表示されるべき', () => {
-    render(<Home />);
-    const participantsLabel = screen.getByText('Participants');
-    expect(participantsLabel).toBeInTheDocument();
-  });
-
-  it('問題ラベル「Problems」が表示されるべき', () => {
-    render(<Home />);
-    const problemsLabel = screen.getByText('Problems');
-    expect(problemsLabel).toBeInTheDocument();
-  });
+  it.each(['Status', 'Participants', 'Problems'])(
+    '統計ラベル「%s」が表示されるべき',
+    (label) => {
+      render(<Home />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  );
 });

--- a/apps/application-plane/app/dashboard/page.tsx
+++ b/apps/application-plane/app/dashboard/page.tsx
@@ -14,7 +14,10 @@ import {
   Card,
   CardContent,
   CardHeader,
+  ErrorState,
   EventStatusBadge,
+  getErrorMessage,
+  getErrorType,
   ProblemTypeBadge,
 } from '../../components/ui';
 import { getAvailableEvents, getMyEvents } from '../../lib/api/events';
@@ -24,7 +27,7 @@ export default function DashboardPage() {
   const [myEvents, setMyEvents] = useState<ParticipantEvent[]>([]);
   const [upcomingEvents, setUpcomingEvents] = useState<ParticipantEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     async function fetchData() {
@@ -41,7 +44,9 @@ export default function DashboardPage() {
           )
         );
       } catch (err) {
-        setError(err instanceof Error ? err.message : '読み込みに失敗しました');
+        setError(
+          err instanceof Error ? err : new Error('読み込みに失敗しました')
+        );
       } finally {
         setLoading(false);
       }
@@ -64,34 +69,37 @@ export default function DashboardPage() {
   const scheduledEvents = myEvents.filter((e) => e.status === 'scheduled');
 
   return (
-    <div className="min-h-screen relative overflow-hidden">
+    <div className="min-h-screen bg-surface-0 relative overflow-hidden">
       {/* Background decoration */}
       <div className="absolute top-0 left-0 w-full h-full overflow-hidden -z-10 pointer-events-none">
-        <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-primary-500/20 rounded-full blur-[100px]" />
-        <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-accent-500/20 rounded-full blur-[100px]" />
+        <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-hn-accent/10 rounded-full blur-[100px]" />
+        <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-hn-purple/10 rounded-full blur-[100px]" />
       </div>
 
       <Header />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-2xl font-bold text-white mb-8">ダッシュボード</h1>
+        <h1 className="text-2xl font-bold text-text-primary mb-8">
+          ダッシュボード
+        </h1>
 
         {loading ? (
           <div className="flex justify-center items-center h-64">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
           </div>
         ) : error ? (
-          <Card className="p-8 text-center">
-            <p className="text-red-600 mb-4">{error}</p>
-            <Button onClick={() => window.location.reload()}>再読み込み</Button>
-          </Card>
+          <ErrorState
+            message={getErrorMessage(error)}
+            type={getErrorType(error)}
+            onRetry={() => window.location.reload()}
+          />
         ) : (
           <div className="space-y-8">
             {/* Active Events */}
             {activeEvents.length > 0 && (
               <section>
-                <h2 className="text-xl font-semibold text-white mb-4 flex items-center">
-                  <span className="w-3 h-3 bg-emerald-500 rounded-full mr-2 animate-pulse" />
+                <h2 className="text-xl font-semibold text-text-primary mb-4 flex items-center">
+                  <span className="w-3 h-3 bg-hn-success rounded-full mr-2 animate-pulse" />
                   開催中のイベント
                 </h2>
                 <div className="grid gap-4 md:grid-cols-2">
@@ -101,7 +109,7 @@ export default function DashboardPage() {
                         <CardHeader>
                           <div className="flex items-start justify-between">
                             <div>
-                              <h3 className="font-semibold text-lg text-white">
+                              <h3 className="font-semibold text-lg text-text-primary">
                                 {event.name}
                               </h3>
                               <div className="flex items-center gap-2 mt-1">
@@ -111,10 +119,10 @@ export default function DashboardPage() {
                             </div>
                             {event.myRank && (
                               <div className="text-right">
-                                <div className="text-2xl font-bold text-primary-400">
+                                <div className="text-2xl font-bold text-hn-accent">
                                   #{event.myRank}
                                 </div>
-                                <div className="text-sm text-white/50">
+                                <div className="text-sm text-text-muted">
                                   {event.myScore} pts
                                 </div>
                               </div>
@@ -122,7 +130,7 @@ export default function DashboardPage() {
                           </div>
                         </CardHeader>
                         <CardContent>
-                          <div className="text-sm text-white/60 space-y-1">
+                          <div className="text-sm text-text-secondary space-y-1">
                             <p>終了: {formatDate(event.endTime)}</p>
                             <p>
                               問題数: {event.problemCount} | 参加者:{' '}
@@ -143,7 +151,7 @@ export default function DashboardPage() {
             {/* Scheduled Events */}
             {scheduledEvents.length > 0 && (
               <section>
-                <h2 className="text-xl font-semibold text-white mb-4">
+                <h2 className="text-xl font-semibold text-text-primary mb-4">
                   登録済みのイベント
                 </h2>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -155,10 +163,10 @@ export default function DashboardPage() {
                             <ProblemTypeBadge type={event.type} />
                             <EventStatusBadge status={event.status} />
                           </div>
-                          <h3 className="font-semibold text-white">
+                          <h3 className="font-semibold text-text-primary">
                             {event.name}
                           </h3>
-                          <p className="text-sm text-white/60 mt-2">
+                          <p className="text-sm text-text-secondary mt-2">
                             開始: {formatDate(event.startTime)}
                           </p>
                         </CardContent>
@@ -173,12 +181,12 @@ export default function DashboardPage() {
             {upcomingEvents.length > 0 && (
               <section>
                 <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-xl font-semibold text-white">
+                  <h2 className="text-xl font-semibold text-text-primary">
                     開催予定のイベント
                   </h2>
                   <Link
                     href="/events"
-                    className="text-primary-400 hover:text-primary-300 font-medium"
+                    className="text-hn-accent hover:text-hn-accent-bright font-medium"
                   >
                     すべて見る →
                   </Link>
@@ -190,14 +198,14 @@ export default function DashboardPage() {
                         <CardContent>
                           <div className="flex items-start justify-between mb-2">
                             <ProblemTypeBadge type={event.type} />
-                            <span className="text-sm text-white/50">
+                            <span className="text-sm text-text-muted">
                               {event.participantCount} 人登録
                             </span>
                           </div>
-                          <h3 className="font-semibold text-white">
+                          <h3 className="font-semibold text-text-primary">
                             {event.name}
                           </h3>
-                          <p className="text-sm text-white/60 mt-2">
+                          <p className="text-sm text-text-secondary mt-2">
                             {formatDate(event.startTime)} 開始
                           </p>
                           <Button variant="outline" className="mt-4" fullWidth>
@@ -214,11 +222,11 @@ export default function DashboardPage() {
             {/* Empty State */}
             {myEvents.length === 0 && upcomingEvents.length === 0 && (
               <Card className="text-center py-12">
-                <div className="text-4xl mb-4">⚔️</div>
-                <h2 className="text-xl font-semibold text-white mb-2">
+                <div className="text-4xl mb-4">🏆</div>
+                <h2 className="text-xl font-semibold text-text-primary mb-2">
                   イベントがありません
                 </h2>
-                <p className="text-white/60 mb-6">
+                <p className="text-text-muted mb-6">
                   現在参加可能なイベントはありません。
                   <br />
                   新しいイベントが公開されるまでお待ちください。

--- a/apps/application-plane/app/events/page.tsx
+++ b/apps/application-plane/app/events/page.tsx
@@ -14,7 +14,10 @@ import {
   Button,
   Card,
   CardContent,
+  ErrorState,
   EventStatusBadge,
+  getErrorMessage,
+  getErrorType,
   ProblemTypeBadge,
 } from '../../components/ui';
 import { getAvailableEvents } from '../../lib/api/events';
@@ -27,7 +30,7 @@ import type {
 export default function EventsPage() {
   const [events, setEvents] = useState<ParticipantEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [filter, setFilter] = useState<{
     status?: EventStatus;
     type?: ProblemType;
@@ -49,7 +52,9 @@ export default function EventsPage() {
         });
         setEvents(res.events);
       } catch (err) {
-        setError(err instanceof Error ? err.message : '読み込みに失敗しました');
+        setError(
+          err instanceof Error ? err : new Error('読み込みに失敗しました')
+        );
       } finally {
         setLoading(false);
       }
@@ -90,18 +95,18 @@ export default function EventsPage() {
   };
 
   return (
-    <div className="min-h-screen relative overflow-hidden">
+    <div className="min-h-screen bg-surface-0 relative overflow-hidden">
       {/* Background decoration */}
       <div className="absolute top-0 left-0 w-full h-full overflow-hidden -z-10 pointer-events-none">
-        <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-primary-500/20 rounded-full blur-[100px]" />
-        <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-accent-500/20 rounded-full blur-[100px]" />
+        <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-hn-accent/10 rounded-full blur-[100px]" />
+        <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-hn-purple/10 rounded-full blur-[100px]" />
       </div>
 
       <Header />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold text-white">イベント一覧</h1>
+          <h1 className="text-2xl font-bold text-text-primary">イベント一覧</h1>
         </div>
 
         {/* Filters */}
@@ -109,13 +114,13 @@ export default function EventsPage() {
           <div>
             <label
               htmlFor={statusFilterId}
-              className="block text-sm font-medium text-white/70 mb-1"
+              className="block text-sm font-medium text-text-secondary mb-1"
             >
               ステータス
             </label>
             <select
               id={statusFilterId}
-              className="bg-white/10 border border-white/20 text-white rounded-lg px-3 py-2 focus:ring-primary-500 focus:border-primary-500"
+              className="bg-surface-1 border border-border text-text-primary rounded-lg px-3 py-2 focus:ring-hn-accent focus:border-hn-accent"
               value={filter.status || ''}
               onChange={(e) =>
                 setFilter((f) => ({
@@ -124,13 +129,13 @@ export default function EventsPage() {
                 }))
               }
             >
-              <option value="" className="bg-gray-900">
+              <option value="" className="bg-surface-1">
                 すべて
               </option>
-              <option value="active" className="bg-gray-900">
+              <option value="active" className="bg-surface-1">
                 開催中
               </option>
-              <option value="scheduled" className="bg-gray-900">
+              <option value="scheduled" className="bg-surface-1">
                 開催予定
               </option>
             </select>
@@ -138,13 +143,13 @@ export default function EventsPage() {
           <div>
             <label
               htmlFor={typeFilterId}
-              className="block text-sm font-medium text-white/70 mb-1"
+              className="block text-sm font-medium text-text-secondary mb-1"
             >
               タイプ
             </label>
             <select
               id={typeFilterId}
-              className="bg-white/10 border border-white/20 text-white rounded-lg px-3 py-2 focus:ring-primary-500 focus:border-primary-500"
+              className="bg-surface-1 border border-border text-text-primary rounded-lg px-3 py-2 focus:ring-hn-accent focus:border-hn-accent"
               value={filter.type || ''}
               onChange={(e) =>
                 setFilter((f) => ({
@@ -153,13 +158,13 @@ export default function EventsPage() {
                 }))
               }
             >
-              <option value="" className="bg-gray-900">
+              <option value="" className="bg-surface-1">
                 すべて
               </option>
-              <option value="gameday" className="bg-gray-900">
+              <option value="gameday" className="bg-surface-1">
                 GameDay
               </option>
-              <option value="jam" className="bg-gray-900">
+              <option value="jam" className="bg-surface-1">
                 JAM
               </option>
             </select>
@@ -168,20 +173,21 @@ export default function EventsPage() {
 
         {loading ? (
           <div className="flex justify-center items-center h-64">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-400" />
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
           </div>
         ) : error ? (
-          <Card className="p-8 text-center">
-            <p className="text-red-600 mb-4">{error}</p>
-            <Button onClick={() => window.location.reload()}>再読み込み</Button>
-          </Card>
+          <ErrorState
+            message={getErrorMessage(error)}
+            type={getErrorType(error)}
+            onRetry={() => window.location.reload()}
+          />
         ) : events.length === 0 ? (
           <Card className="text-center py-12">
             <div className="text-4xl mb-4">📭</div>
-            <h2 className="text-xl font-semibold text-white mb-2">
+            <h2 className="text-xl font-semibold text-text-primary mb-2">
               イベントが見つかりません
             </h2>
-            <p className="text-white/60">
+            <p className="text-text-muted">
               条件に一致するイベントがありません。
             </p>
           </Card>
@@ -210,17 +216,17 @@ export default function EventsPage() {
                       </div>
 
                       <div>
-                        <h3 className="font-semibold text-lg text-white">
+                        <h3 className="font-semibold text-lg text-text-primary">
                           {event.name}
                         </h3>
                         {timeUntil && (
-                          <p className="text-primary-400 font-medium text-sm mt-1">
+                          <p className="text-hn-accent font-medium text-sm mt-1">
                             {timeUntil}
                           </p>
                         )}
                       </div>
 
-                      <div className="text-sm text-white/60 space-y-1">
+                      <div className="text-sm text-text-secondary space-y-1">
                         <p>
                           <span className="font-medium">開始:</span>{' '}
                           {formatDate(event.startTime)}
@@ -231,16 +237,16 @@ export default function EventsPage() {
                         </p>
                       </div>
 
-                      <div className="flex items-center justify-between text-sm text-white/50">
+                      <div className="flex items-center justify-between text-sm text-text-muted">
                         <span>問題数: {event.problemCount}</span>
                         <span>参加者: {event.participantCount}</span>
                       </div>
 
                       <div className="flex items-center gap-2 text-sm">
-                        <span className="px-2 py-1 bg-white/10 rounded text-white/80">
+                        <span className="px-2 py-1 bg-surface-2 rounded text-text-secondary">
                           {event.cloudProvider.toUpperCase()}
                         </span>
-                        <span className="text-white/50">
+                        <span className="text-text-muted">
                           {event.participantType === 'team'
                             ? 'チーム参加'
                             : '個人参加'}

--- a/apps/application-plane/app/page.tsx
+++ b/apps/application-plane/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, type Variants } from 'framer-motion';
 import { Eye, Swords, Trophy, Users, Zap } from 'lucide-react';
+import Link from 'next/link';
 
 // 統計情報は API 接続後に動的に取得予定
 const stats = [
@@ -10,22 +11,20 @@ const stats = [
   { label: 'Problems', value: '---', icon: Trophy },
 ];
 
-export default function Home() {
-  const container = {
-    hidden: { opacity: 0 },
-    show: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-      },
-    },
-  };
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1 },
+  },
+};
 
-  const item = {
-    hidden: { opacity: 0, y: 20 },
-    show: { opacity: 1, y: 0 },
-  };
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 },
+};
 
+export default function Home(): React.JSX.Element {
   return (
     <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
       {/* Background decoration */}
@@ -35,12 +34,12 @@ export default function Home() {
       </div>
 
       <motion.main
-        variants={container}
+        variants={containerVariants}
         initial="hidden"
         animate="show"
         className="text-center max-w-2xl w-full glass rounded-3xl p-12"
       >
-        <motion.div variants={item}>
+        <motion.div variants={itemVariants}>
           <h1 className="text-5xl md:text-6xl font-black mb-4 gradient-text">
             TenkaCloud
           </h1>
@@ -52,29 +51,33 @@ export default function Home() {
           </p>
         </motion.div>
 
-        <motion.div variants={item} className="space-y-4">
-          <motion.button
-            type="button"
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="w-full bg-gradient-to-r from-primary-500 to-accent-500 text-white font-bold py-4 px-8 rounded-xl text-lg shadow-lg shadow-primary-500/25 hover:shadow-primary-500/40 transition-shadow flex items-center justify-center gap-3"
-          >
-            <Swords className="w-5 h-5" />
-            バトルに参加する
-          </motion.button>
-          <motion.button
-            type="button"
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="w-full bg-white/5 hover:bg-white/10 text-white font-semibold py-4 px-8 rounded-xl text-lg transition-all border border-white/10 hover:border-white/20 flex items-center justify-center gap-3"
-          >
-            <Eye className="w-5 h-5" />
-            観戦モード
-          </motion.button>
+        <motion.div variants={itemVariants} className="space-y-4">
+          <Link href="/events">
+            <motion.button
+              type="button"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className="w-full bg-gradient-to-r from-primary-500 to-accent-500 text-white font-bold py-4 px-8 rounded-xl text-lg shadow-lg shadow-primary-500/25 hover:shadow-primary-500/40 transition-shadow flex items-center justify-center gap-3"
+            >
+              <Swords className="w-5 h-5" />
+              バトルに参加する
+            </motion.button>
+          </Link>
+          <Link href="/events">
+            <motion.button
+              type="button"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className="w-full bg-white/5 hover:bg-white/10 text-white font-semibold py-4 px-8 rounded-xl text-lg transition-all border border-white/10 hover:border-white/20 flex items-center justify-center gap-3"
+            >
+              <Eye className="w-5 h-5" />
+              観戦モード
+            </motion.button>
+          </Link>
         </motion.div>
 
         <motion.div
-          variants={item}
+          variants={itemVariants}
           className="mt-12 grid grid-cols-3 gap-4 text-center"
         >
           {stats.map((stat) => (

--- a/apps/application-plane/app/rankings/page.tsx
+++ b/apps/application-plane/app/rankings/page.tsx
@@ -1,0 +1,309 @@
+/**
+ * Rankings Page
+ *
+ * グローバルランキングページ
+ * 全期間/月間/週間のランキングを表示
+ */
+
+'use client';
+
+import { Crown, Medal, TrendingUp, Trophy, Users } from 'lucide-react';
+import { useState } from 'react';
+import { Header } from '../../components/layout';
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  Skeleton,
+} from '../../components/ui';
+
+type Period = 'all-time' | 'monthly' | 'weekly';
+
+interface RankingEntry {
+  rank: number;
+  participantId: string;
+  name: string;
+  totalScore: number;
+  eventsParticipated: number;
+  trend?: 'up' | 'down' | 'same';
+}
+
+// TODO: バックエンドAPI接続後に実データに置き換え
+const mockRankings: RankingEntry[] = [
+  {
+    rank: 1,
+    participantId: '1',
+    name: 'クラウドマスター',
+    totalScore: 15000,
+    eventsParticipated: 12,
+    trend: 'same',
+  },
+  {
+    rank: 2,
+    participantId: '2',
+    name: 'インフラ職人',
+    totalScore: 14200,
+    eventsParticipated: 10,
+    trend: 'up',
+  },
+  {
+    rank: 3,
+    participantId: '3',
+    name: 'サーバーレス忍者',
+    totalScore: 13800,
+    eventsParticipated: 11,
+    trend: 'down',
+  },
+  {
+    rank: 4,
+    participantId: '4',
+    name: 'コンテナ使い',
+    totalScore: 12500,
+    eventsParticipated: 9,
+    trend: 'up',
+  },
+  {
+    rank: 5,
+    participantId: '5',
+    name: 'ネットワーク達人',
+    totalScore: 11800,
+    eventsParticipated: 8,
+    trend: 'same',
+  },
+];
+
+export default function RankingsPage() {
+  const [period, setPeriod] = useState<Period>('all-time');
+  const [loading] = useState(false);
+
+  const periodLabels: Record<Period, string> = {
+    'all-time': '全期間',
+    monthly: '月間',
+    weekly: '週間',
+  };
+
+  const getRankStyle = (rank: number) => {
+    switch (rank) {
+      case 1:
+        return 'bg-hn-warning/20 border-hn-warning';
+      case 2:
+        return 'bg-text-muted/20 border-text-muted';
+      case 3:
+        return 'bg-amber-500/20 border-amber-500';
+      default:
+        return 'bg-surface-1 border-border';
+    }
+  };
+
+  const getRankIcon = (rank: number) => {
+    switch (rank) {
+      case 1:
+        return <Crown className="w-6 h-6 text-hn-warning" />;
+      case 2:
+        return <Medal className="w-6 h-6 text-text-secondary" />;
+      case 3:
+        return <Medal className="w-6 h-6 text-amber-400" />;
+      default:
+        return (
+          <span className="text-lg font-bold text-text-primary">#{rank}</span>
+        );
+    }
+  };
+
+  const getTrendIcon = (trend?: 'up' | 'down' | 'same') => {
+    switch (trend) {
+      case 'up':
+        return <span className="text-hn-success">↑</span>;
+      case 'down':
+        return <span className="text-hn-error">↓</span>;
+      default:
+        return <span className="text-text-muted">-</span>;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-surface-0">
+      <Header />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Page Header */}
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-8">
+          <div className="flex items-center gap-3 mb-4 md:mb-0">
+            <div className="w-12 h-12 rounded-xl bg-hn-accent/20 flex items-center justify-center">
+              <Trophy className="w-6 h-6 text-hn-accent" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-text-primary">
+                ランキング
+              </h1>
+              <p className="text-text-secondary">
+                クラウドエンジニアの頂点を目指せ
+              </p>
+            </div>
+          </div>
+
+          {/* Period Filter */}
+          <div className="flex gap-2">
+            {(Object.keys(periodLabels) as Period[]).map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setPeriod(p)}
+                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                  period === p
+                    ? 'bg-hn-accent text-surface-0'
+                    : 'bg-surface-1 text-text-secondary hover:text-text-primary hover:bg-surface-2'
+                }`}
+              >
+                {periodLabels[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+          <Card>
+            <CardContent className="flex items-center gap-4 py-4">
+              <div className="w-12 h-12 rounded-xl bg-hn-success/20 flex items-center justify-center">
+                <Users className="w-6 h-6 text-hn-success" />
+              </div>
+              <div>
+                <div className="text-2xl font-bold text-text-primary">
+                  {loading ? <Skeleton className="h-8 w-16" /> : '128'}
+                </div>
+                <div className="text-sm text-text-muted">総参加者数</div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="flex items-center gap-4 py-4">
+              <div className="w-12 h-12 rounded-xl bg-hn-info/20 flex items-center justify-center">
+                <Trophy className="w-6 h-6 text-hn-info" />
+              </div>
+              <div>
+                <div className="text-2xl font-bold text-text-primary">
+                  {loading ? <Skeleton className="h-8 w-16" /> : '24'}
+                </div>
+                <div className="text-sm text-text-muted">開催イベント数</div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="flex items-center gap-4 py-4">
+              <div className="w-12 h-12 rounded-xl bg-hn-purple/20 flex items-center justify-center">
+                <TrendingUp className="w-6 h-6 text-hn-purple" />
+              </div>
+              <div>
+                <div className="text-2xl font-bold text-text-primary">
+                  {loading ? <Skeleton className="h-8 w-16" /> : '15,000'}
+                </div>
+                <div className="text-sm text-text-muted">最高スコア</div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Rankings Table */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-text-primary">
+                {periodLabels[period]}ランキング
+              </span>
+              <Badge variant="default">Top 50</Badge>
+            </div>
+          </CardHeader>
+
+          {loading ? (
+            <div className="p-6 space-y-4">
+              {[...Array(5)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-surface-2 border-b border-border">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-text-muted uppercase tracking-wider">
+                      順位
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-text-muted uppercase tracking-wider">
+                      名前
+                    </th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-text-muted uppercase tracking-wider">
+                      参加イベント
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-text-muted uppercase tracking-wider">
+                      合計スコア
+                    </th>
+                    <th className="px-6 py-3 text-center text-xs font-medium text-text-muted uppercase tracking-wider">
+                      推移
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {mockRankings.map((entry) => (
+                    <tr
+                      key={entry.participantId}
+                      className={`${getRankStyle(entry.rank)} border-l-4 transition-colors hover:bg-surface-2/50`}
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center justify-center w-10">
+                          {getRankIcon(entry.rank)}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center gap-3">
+                          <div className="w-10 h-10 rounded-full bg-hn-accent/20 flex items-center justify-center">
+                            <span className="text-hn-accent font-bold">
+                              {entry.name.charAt(0)}
+                            </span>
+                          </div>
+                          <span className="font-medium text-text-primary">
+                            {entry.name}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap">
+                        <span className="text-text-secondary">
+                          {entry.eventsParticipated}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 text-right whitespace-nowrap">
+                        <span className="text-lg font-bold text-text-primary">
+                          {entry.totalScore.toLocaleString()}
+                        </span>
+                        <span className="text-text-muted ml-1">pts</span>
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap text-xl">
+                        {getTrendIcon(entry.trend)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+
+        {/* Empty State */}
+        {!loading && mockRankings.length === 0 && (
+          <Card className="text-center py-12">
+            <div className="text-4xl mb-4">🏆</div>
+            <h2 className="text-xl font-semibold text-text-primary mb-2">
+              ランキングデータがありません
+            </h2>
+            <p className="text-text-secondary">
+              イベントに参加してランキングに載ろう！
+            </p>
+          </Card>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/application-plane/components/layout/header.tsx
+++ b/apps/application-plane/components/layout/header.tsx
@@ -20,32 +20,36 @@ export function Header() {
   const isLoading = status === 'loading';
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+    <header className="bg-surface-1 border-b border-border sticky top-0 z-50 backdrop-blur-sm bg-opacity-95">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <Link href="/dashboard" className="flex items-center space-x-2">
-            <span className="text-2xl">⚔️</span>
-            <span className="font-bold text-xl text-gray-900">TenkaCloud</span>
+            <div className="w-8 h-8 bg-hn-accent rounded-lg flex items-center justify-center shadow-brutal-sm">
+              <span className="text-surface-0 font-black text-lg">T</span>
+            </div>
+            <span className="font-bold text-xl text-text-primary">
+              TenkaCloud
+            </span>
           </Link>
 
           {/* Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
             <Link
               href="/dashboard"
-              className="text-gray-600 hover:text-gray-900 font-medium"
+              className="text-text-secondary hover:text-text-primary font-medium transition-colors"
             >
               ダッシュボード
             </Link>
             <Link
               href="/events"
-              className="text-gray-600 hover:text-gray-900 font-medium"
+              className="text-text-secondary hover:text-text-primary font-medium transition-colors"
             >
               イベント
             </Link>
             <Link
               href="/rankings"
-              className="text-gray-600 hover:text-gray-900 font-medium"
+              className="text-text-secondary hover:text-text-primary font-medium transition-colors"
             >
               ランキング
             </Link>
@@ -54,17 +58,17 @@ export function Header() {
           {/* User Menu */}
           <div className="flex items-center space-x-4">
             {isLoading ? (
-              <div className="w-8 h-8 bg-gray-200 rounded-full animate-pulse" />
+              <div className="w-8 h-8 bg-surface-2 rounded-full animate-pulse" />
             ) : session ? (
               <div className="relative">
                 <button
                   type="button"
                   onClick={() => setIsMenuOpen(!isMenuOpen)}
-                  className="flex items-center space-x-2 text-gray-700 hover:text-gray-900"
+                  className="flex items-center space-x-2 text-text-secondary hover:text-text-primary transition-colors"
                   aria-expanded={isMenuOpen}
                   aria-haspopup="true"
                 >
-                  <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-medium">
+                  <div className="w-8 h-8 bg-hn-accent rounded-full flex items-center justify-center text-surface-0 font-medium">
                     {userName ? userName.charAt(0).toUpperCase() : 'U'}
                   </div>
                   <span className="hidden sm:block font-medium">
@@ -87,32 +91,32 @@ export function Header() {
                 </button>
 
                 {isMenuOpen && (
-                  <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5">
+                  <div className="absolute right-0 mt-2 w-48 bg-surface-elevated rounded-lg shadow-lg py-1 border border-border">
                     <Link
                       href="/profile"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
                       onClick={() => setIsMenuOpen(false)}
                     >
                       プロフィール
                     </Link>
                     <Link
                       href="/profile/history"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
                       onClick={() => setIsMenuOpen(false)}
                     >
                       参加履歴
                     </Link>
                     <Link
                       href="/profile/badges"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
                       onClick={() => setIsMenuOpen(false)}
                     >
                       バッジ
                     </Link>
-                    <hr className="my-1" />
+                    <hr className="my-1 border-border" />
                     <button
                       type="button"
-                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block w-full text-left px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
                       onClick={() => {
                         setIsMenuOpen(false);
                         signOut({ callbackUrl: '/login' });
@@ -126,7 +130,7 @@ export function Header() {
             ) : (
               <Link
                 href="/login"
-                className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700"
+                className="bg-hn-accent text-surface-0 px-4 py-2 rounded-lg font-medium hover:bg-hn-accent-bright transition-colors shadow-brutal-sm"
               >
                 ログイン
               </Link>
@@ -135,7 +139,7 @@ export function Header() {
             {/* Mobile Menu Button */}
             <button
               type="button"
-              className="md:hidden p-2 text-gray-600 hover:text-gray-900"
+              className="md:hidden p-2 text-text-secondary hover:text-text-primary transition-colors"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-label="メニューを開く"
             >

--- a/apps/application-plane/components/ui/error-state.tsx
+++ b/apps/application-plane/components/ui/error-state.tsx
@@ -1,0 +1,113 @@
+/**
+ * ErrorState Component
+ *
+ * ユーザーフレンドリーなエラー表示コンポーネント
+ */
+
+import { AlertTriangle, RefreshCw, WifiOff } from 'lucide-react';
+import { Button } from './button';
+import { Card } from './card';
+
+export interface ErrorStateProps {
+  /** エラータイトル */
+  title?: string;
+  /** エラーメッセージ */
+  message: string;
+  /** リトライアクション */
+  onRetry?: () => void;
+  /** リトライボタンのラベル */
+  retryLabel?: string;
+  /** エラータイプ（アイコン選択用） */
+  type?: 'network' | 'general' | 'notFound';
+}
+
+/**
+ * 技術的なエラーメッセージをユーザーフレンドリーなメッセージに変換
+ */
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    const message = err.message.toLowerCase();
+
+    if (message.includes('failed to fetch') || message.includes('network')) {
+      return 'サーバーに接続できません。ネットワーク接続を確認してください。';
+    }
+    if (message.includes('404') || message.includes('not found')) {
+      return 'データが見つかりませんでした。';
+    }
+    if (message.includes('401') || message.includes('unauthorized')) {
+      return '認証が必要です。再ログインしてください。';
+    }
+    if (message.includes('403') || message.includes('forbidden')) {
+      return 'アクセス権限がありません。';
+    }
+    if (message.includes('500') || message.includes('internal server')) {
+      return 'サーバーエラーが発生しました。しばらくしてから再試行してください。';
+    }
+    if (message.includes('timeout')) {
+      return 'リクエストがタイムアウトしました。再試行してください。';
+    }
+  }
+
+  return 'データの読み込みに失敗しました。しばらくしてから再試行してください。';
+}
+
+/**
+ * エラータイプを判定
+ */
+export function getErrorType(err: unknown): 'network' | 'notFound' | 'general' {
+  if (err instanceof Error) {
+    const message = err.message.toLowerCase();
+    if (message.includes('failed to fetch') || message.includes('network')) {
+      return 'network';
+    }
+    if (message.includes('404') || message.includes('not found')) {
+      return 'notFound';
+    }
+  }
+  return 'general';
+}
+
+const icons = {
+  network: WifiOff,
+  general: AlertTriangle,
+  notFound: AlertTriangle,
+};
+
+export function ErrorState({
+  title,
+  message,
+  onRetry,
+  retryLabel = '再試行',
+  type = 'general',
+}: ErrorStateProps) {
+  const Icon = icons[type];
+
+  const defaultTitles = {
+    network: '接続エラー',
+    general: 'エラーが発生しました',
+    notFound: '見つかりません',
+  };
+
+  return (
+    <Card className="text-center py-12 px-6">
+      <div className="flex justify-center mb-4">
+        <div className="w-16 h-16 rounded-full bg-hn-error/10 flex items-center justify-center">
+          <Icon className="w-8 h-8 text-hn-error" />
+        </div>
+      </div>
+
+      <h2 className="text-xl font-semibold text-text-primary mb-2">
+        {title || defaultTitles[type]}
+      </h2>
+
+      <p className="text-text-secondary mb-6 max-w-md mx-auto">{message}</p>
+
+      {onRetry && (
+        <Button onClick={onRetry} variant="outline" className="gap-2">
+          <RefreshCw className="w-4 h-4" />
+          {retryLabel}
+        </Button>
+      )}
+    </Card>
+  );
+}

--- a/apps/application-plane/components/ui/index.ts
+++ b/apps/application-plane/components/ui/index.ts
@@ -21,6 +21,7 @@ export {
 } from './badge';
 export { Button } from './button';
 export { Card, CardContent, CardFooter, CardHeader } from './card';
+export { ErrorState, getErrorMessage, getErrorType } from './error-state';
 export { Input } from './input';
 export { Pagination } from './pagination';
 export { Progress, ScoreProgress } from './progress';


### PR DESCRIPTION
## Summary

- Header をダークテーマ化し、絵文字ロゴをテキストベースに変更
- Leaderboard, Events, Dashboard ページの色を HybridNext デザインシステムに統一
- ErrorState コンポーネントを追加し、エラーメッセージを日本語化
- /rankings ページを新規実装（期間フィルター、ランキングテーブル）
- ホームページのボタンに Link を追加して画面遷移を修正

## Test plan

- [ ] `make start` でローカル起動し、各ページの表示を確認
- [ ] `/dashboard` - ダークテーマが適用されていること
- [ ] `/events` - ダークテーマ + ErrorState 動作確認
- [ ] `/rankings` - 新規ページが表示されること
- [ ] `/events/[id]/leaderboard` - ダークテーマ適用確認
- [ ] エラー発生時に日本語のユーザーフレンドリーなメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Rankings page displaying leaderboards across all-time, monthly, and weekly periods with participant statistics and scores.
  * Added error state displays with retry functionality across pages for better error recovery.

* **Enhancements**
  * Implemented automatic data refresh on the leaderboard page for real-time updates.
  * Redesigned header with new logo and updated styling.
  * Refreshed visual design system across dashboard, events, and leaderboard pages with updated colors and typography.
  * Improved navigation with button links to the events page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->