### PR TITLE
feat(application-plane): Tenant Admin ページを HybridNext テーマに統一

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
@@ -1,6 +1,7 @@
 /**
  * Admin Event Detail Page
  *
+ * HybridNext Design System - Terminal Command Center style
  * イベント詳細・編集画面
  */
 
@@ -9,13 +10,19 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EventStatusBadge, ProblemTypeBadge } from '@/components/ui';
+import type { EventStatus } from '@/lib/api/admin-types';
+import type { ProblemType } from '@/lib/api/types';
 
 interface EventDetail {
   id: string;
   name: string;
   description: string;
-  status: 'draft' | 'scheduled' | 'active' | 'ended';
-  type: 'gameday' | 'jam';
+  status: EventStatus;
+  type: ProblemType;
   startTime: string;
   endTime: string;
   participantCount: number;
@@ -93,49 +100,50 @@ export default function AdminEventDetailPage() {
     });
   };
 
-  const getStatusBadge = (status: EventDetail['status']) => {
-    const styles = {
-      draft: 'bg-gray-100 text-gray-800',
-      scheduled: 'bg-blue-100 text-blue-800',
-      active: 'bg-green-100 text-green-800',
-      ended: 'bg-gray-100 text-gray-500',
-    };
-    const labels = {
-      draft: '下書き',
-      scheduled: '予定',
-      active: '開催中',
-      ended: '終了',
-    };
-    return (
-      <span
-        className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${styles[status]}`}
-      >
-        {labels[status]}
-      </span>
-    );
-  };
-
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-8 w-64" />
+          </div>
+          <Skeleton className="h-10 w-32" />
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2">
+            <Card>
+              <CardContent className="p-6">
+                <Skeleton className="h-6 w-32 mb-4" />
+                <div className="space-y-4">
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+          <Card>
+            <CardContent className="p-6">
+              <Skeleton className="h-6 w-24 mb-4" />
+              <Skeleton className="h-12 w-24 mx-auto" />
+            </CardContent>
+          </Card>
+        </div>
       </div>
     );
   }
 
   if (!event) {
     return (
-      <div className="text-center py-12">
-        <h2 className="text-xl font-semibold text-gray-900">
+      <Card className="text-center py-12">
+        <div className="text-4xl mb-4">📭</div>
+        <h2 className="text-xl font-semibold text-text-primary mb-2">
           イベントが見つかりません
         </h2>
-        <Link
-          href="/admin/events"
-          className="text-blue-600 hover:text-blue-700 mt-4 inline-block"
-        >
-          イベント一覧に戻る
-        </Link>
-      </div>
+        <Button variant="secondary" asChild className="mt-4">
+          <Link href="/admin/events">イベント一覧に戻る</Link>
+        </Button>
+      </Card>
     );
   }
 
@@ -144,38 +152,35 @@ export default function AdminEventDetailPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <div className="flex items-center space-x-2 text-sm text-gray-500 mb-2">
-            <Link href="/admin/events" className="hover:text-gray-700">
+          <div className="flex items-center space-x-2 text-sm text-text-muted mb-2 font-mono">
+            <Link
+              href="/admin/events"
+              className="hover:text-hn-accent transition-colors"
+            >
               イベント管理
             </Link>
-            <span>/</span>
-            <span>{event.name}</span>
+            <span className="text-hn-accent">/</span>
+            <span className="text-text-secondary">{event.name}</span>
           </div>
-          <div className="flex items-center space-x-4">
-            <h1 className="text-2xl font-bold text-gray-900">{event.name}</h1>
-            {getStatusBadge(event.status)}
+          <div className="flex items-center gap-4">
+            <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+              <span className="text-hn-accent font-mono">&gt;_</span>
+              {event.name}
+            </h1>
+            <ProblemTypeBadge type={event.type} />
+            <EventStatusBadge status={event.status} />
           </div>
         </div>
-        <div className="flex space-x-3">
+        <div className="flex gap-3">
           {event.status === 'draft' && (
-            <button
-              type="button"
-              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
-            >
-              公開する
-            </button>
+            <Button variant="success">公開する</Button>
           )}
-          <button
-            type="button"
-            className="px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
-          >
-            編集
-          </button>
+          <Button variant="secondary">編集</Button>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
+      <div className="border-b border-border">
         <nav className="-mb-px flex space-x-8">
           {[
             { id: 'overview', label: '概要' },
@@ -186,10 +191,10 @@ export default function AdminEventDetailPage() {
               key={tab.id}
               type="button"
               onClick={() => setActiveTab(tab.id as typeof activeTab)}
-              className={`py-4 px-1 border-b-2 font-medium text-sm ${
+              className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
                 activeTab === tab.id
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  ? 'border-hn-accent text-hn-accent'
+                  : 'border-transparent text-text-muted hover:text-text-primary hover:border-border'
               }`}
             >
               {tab.label}
@@ -202,171 +207,252 @@ export default function AdminEventDetailPage() {
       {activeTab === 'overview' && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                イベント情報
-              </h2>
-              <dl className="space-y-4">
-                <div>
-                  <dt className="text-sm font-medium text-gray-500">説明</dt>
-                  <dd className="mt-1 text-sm text-gray-900">
-                    {event.description}
-                  </dd>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-hn-accent"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  イベント情報
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="space-y-4">
                   <div>
-                    <dt className="text-sm font-medium text-gray-500">
-                      開始日時
+                    <dt className="text-sm font-medium text-text-muted">
+                      説明
                     </dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {formatDate(event.startTime)}
+                    <dd className="mt-1 text-sm text-text-primary">
+                      {event.description}
                     </dd>
                   </div>
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">
-                      終了日時
-                    </dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {formatDate(event.endTime)}
-                    </dd>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <dt className="text-sm font-medium text-text-muted">
+                        開始日時
+                      </dt>
+                      <dd className="mt-1 text-sm text-text-primary font-mono">
+                        {formatDate(event.startTime)}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-sm font-medium text-text-muted">
+                        終了日時
+                      </dt>
+                      <dd className="mt-1 text-sm text-text-primary font-mono">
+                        {formatDate(event.endTime)}
+                      </dd>
+                    </div>
                   </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">
-                      クラウドプロバイダー
-                    </dt>
-                    <dd className="mt-1 text-sm text-gray-900 uppercase">
-                      {event.cloudProvider}
-                    </dd>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <dt className="text-sm font-medium text-text-muted">
+                        クラウドプロバイダー
+                      </dt>
+                      <dd className="mt-1 text-sm text-text-primary font-mono uppercase">
+                        {event.cloudProvider}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-sm font-medium text-text-muted">
+                        参加形式
+                      </dt>
+                      <dd className="mt-1 text-sm text-text-primary">
+                        {event.participantType === 'team'
+                          ? 'チーム参加'
+                          : '個人参加'}
+                      </dd>
+                    </div>
                   </div>
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">
-                      参加形式
-                    </dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {event.participantType === 'team'
-                        ? 'チーム参加'
-                        : '個人参加'}
-                    </dd>
-                  </div>
-                </div>
-              </dl>
-            </div>
+                </dl>
+              </CardContent>
+            </Card>
           </div>
 
           <div className="space-y-6">
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                参加状況
-              </h2>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-gray-900">
-                  {event.participantCount}
-                  <span className="text-lg text-gray-500">
-                    {' '}
-                    / {event.maxParticipants}
-                  </span>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-hn-success"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                  参加状況
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-center">
+                  <div className="text-4xl font-bold text-text-primary font-mono">
+                    {event.participantCount}
+                    <span className="text-lg text-text-muted">
+                      {' '}
+                      / {event.maxParticipants}
+                    </span>
+                  </div>
+                  <p className="text-sm text-text-muted mt-1">参加者</p>
+                  <div className="mt-4 w-full bg-surface-2 rounded-full h-2">
+                    <div
+                      className="bg-hn-accent h-2 rounded-full transition-all"
+                      style={{
+                        width: `${(event.participantCount / event.maxParticipants) * 100}%`,
+                      }}
+                    />
+                  </div>
                 </div>
-                <p className="text-sm text-gray-500 mt-1">参加者</p>
-                <div className="mt-4 w-full bg-gray-200 rounded-full h-2">
-                  <div
-                    className="bg-blue-600 h-2 rounded-full"
-                    style={{
-                      width: `${(event.participantCount / event.maxParticipants) * 100}%`,
-                    }}
-                  />
-                </div>
-              </div>
-            </div>
+              </CardContent>
+            </Card>
 
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                問題数
-              </h2>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-gray-900">
-                  {event.problems.length}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-hn-purple"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                    />
+                  </svg>
+                  問題数
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-center">
+                  <div className="text-4xl font-bold text-hn-purple font-mono">
+                    {event.problems.length}
+                  </div>
+                  <p className="text-sm text-text-muted mt-1">問題</p>
                 </div>
-                <p className="text-sm text-gray-500 mt-1">問題</p>
-              </div>
-            </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       )}
 
       {activeTab === 'problems' && (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <div className="p-4 border-b border-gray-200 flex justify-between items-center">
-            <h2 className="text-lg font-semibold text-gray-900">問題一覧</h2>
-            <button
-              type="button"
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
-            >
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <svg
+                className="w-5 h-5 text-hn-accent"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
+              </svg>
+              問題一覧
+            </CardTitle>
+            <Button size="sm">
+              <svg
+                className="w-4 h-4 mr-1"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 4v16m8-8H4"
+                />
+              </svg>
               問題を追加
-            </button>
-          </div>
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  タイトル
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  配点
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  解答数
-                </th>
-                <th className="px-6 py-3" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {event.problems.map((problem) => (
-                <tr key={problem.id}>
-                  <td className="px-6 py-4 text-sm font-medium text-gray-900">
-                    {problem.title}
-                  </td>
-                  <td className="px-6 py-4 text-sm text-gray-500">
-                    {problem.points} pts
-                  </td>
-                  <td className="px-6 py-4 text-sm text-gray-500">
-                    {problem.solvedCount}
-                  </td>
-                  <td className="px-6 py-4 text-right text-sm">
-                    <button
-                      type="button"
-                      className="text-blue-600 hover:text-blue-900"
-                    >
-                      編集
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {event.problems.length === 0 ? (
+              <div className="text-center py-8">
+                <div className="text-4xl mb-4">📝</div>
+                <p className="text-text-muted">問題がまだありません</p>
+                <Button className="mt-4">問題を追加</Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {event.problems.map((problem, index) => (
+                  <div
+                    key={problem.id}
+                    className="flex items-center justify-between p-4 bg-surface-1 rounded-[var(--radius)] border border-border hover:border-hn-accent/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="w-8 h-8 bg-hn-accent/20 rounded-[var(--radius)] flex items-center justify-center text-hn-accent font-mono font-bold">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <div className="font-medium text-text-primary">
+                          {problem.title}
+                        </div>
+                        <div className="text-sm text-text-muted font-mono">
+                          {problem.points} pts
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <div className="text-right">
+                        <div className="text-sm text-text-muted">解答数</div>
+                        <div className="font-mono text-hn-success">
+                          {problem.solvedCount}
+                        </div>
+                      </div>
+                      <Button variant="ghost" size="sm">
+                        編集
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       )}
 
       {activeTab === 'participants' && (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-center py-12">
-            <div className="text-4xl mb-4">👥</div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">
-              参加者管理
-            </h2>
-            <p className="text-gray-500">
-              {event.participantCount} 人が参加しています
-            </p>
-            <button
-              type="button"
-              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-            >
-              参加者一覧を見る
-            </button>
-          </div>
-        </div>
+        <Card className="text-center py-12">
+          <div className="text-4xl mb-4">👥</div>
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
+            参加者管理
+          </h2>
+          <p className="text-text-muted">
+            {event.participantCount} 人が参加しています
+          </p>
+          <Button className="mt-4">参加者一覧を見る</Button>
+        </Card>
       )}
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> event --id={eventId}
+        --status={event.status}
+      </div>
     </div>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/events/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/page.tsx
@@ -1,6 +1,7 @@
 /**
  * Admin Events List Page
  *
+ * HybridNext Design System - Terminal Command Center style
  * イベント管理一覧
  */
 
@@ -8,22 +9,17 @@
 
 import Link from 'next/link';
 import { useEffect, useId, useState } from 'react';
-
-interface AdminEvent {
-  id: string;
-  name: string;
-  status: 'draft' | 'scheduled' | 'active' | 'ended';
-  type: 'gameday' | 'jam';
-  startTime: string;
-  endTime: string;
-  participantCount: number;
-  maxParticipants: number;
-}
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EventStatusBadge, ProblemTypeBadge } from '@/components/ui';
+import type { AdminEvent, EventStatus } from '@/lib/api/admin-types';
+import type { ProblemType } from '@/lib/api/types';
 
 export default function AdminEventsPage() {
   const [events, setEvents] = useState<AdminEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<{ status?: string }>({});
+  const [filter, setFilter] = useState<{ status?: EventStatus }>({});
   const statusFilterId = useId();
 
   useEffect(() => {
@@ -37,31 +33,58 @@ export default function AdminEventsPage() {
             id: 'evt-1',
             name: 'AWS GameDay 2024 Winter',
             status: 'active',
-            type: 'gameday',
+            type: 'gameday' as ProblemType,
             startTime: new Date().toISOString(),
             endTime: new Date(Date.now() + 86400000).toISOString(),
             participantCount: 45,
             maxParticipants: 100,
+            timezone: 'Asia/Tokyo',
+            participantType: 'team',
+            cloudProvider: 'aws',
+            regions: ['ap-northeast-1'],
+            scoringType: 'realtime',
+            leaderboardVisible: true,
+            problemCount: 5,
+            isRegistered: false,
+            slug: 'aws-gameday-2024-winter',
           },
           {
             id: 'evt-2',
             name: 'Security JAM',
             status: 'scheduled',
-            type: 'jam',
+            type: 'jam' as ProblemType,
             startTime: new Date(Date.now() + 172800000).toISOString(),
             endTime: new Date(Date.now() + 259200000).toISOString(),
             participantCount: 23,
             maxParticipants: 50,
+            timezone: 'Asia/Tokyo',
+            participantType: 'individual',
+            cloudProvider: 'aws',
+            regions: ['ap-northeast-1'],
+            scoringType: 'realtime',
+            leaderboardVisible: true,
+            problemCount: 8,
+            isRegistered: false,
+            slug: 'security-jam',
           },
           {
             id: 'evt-3',
             name: 'Cloud Architecture Challenge',
             status: 'draft',
-            type: 'gameday',
+            type: 'gameday' as ProblemType,
             startTime: new Date(Date.now() + 604800000).toISOString(),
             endTime: new Date(Date.now() + 691200000).toISOString(),
             participantCount: 0,
             maxParticipants: 100,
+            timezone: 'Asia/Tokyo',
+            participantType: 'team',
+            cloudProvider: 'aws',
+            regions: ['ap-northeast-1'],
+            scoringType: 'realtime',
+            leaderboardVisible: false,
+            problemCount: 0,
+            isRegistered: false,
+            slug: 'cloud-architecture-challenge',
           },
         ]);
       } finally {
@@ -83,213 +106,228 @@ export default function AdminEventsPage() {
     });
   };
 
-  const getStatusBadge = (status: AdminEvent['status']) => {
-    const styles = {
-      draft: 'bg-gray-100 text-gray-800',
-      scheduled: 'bg-blue-100 text-blue-800',
-      active: 'bg-green-100 text-green-800',
-      ended: 'bg-gray-100 text-gray-500',
-    };
-    const labels = {
-      draft: '下書き',
-      scheduled: '予定',
-      active: '開催中',
-      ended: '終了',
-    };
-    return (
-      <span
-        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[status]}`}
-      >
-        {labels[status]}
-      </span>
-    );
-  };
-
-  const getTypeBadge = (type: AdminEvent['type']) => {
-    const styles = {
-      gameday: 'bg-orange-100 text-orange-800',
-      jam: 'bg-purple-100 text-purple-800',
-    };
-    const labels = {
-      gameday: 'GameDay',
-      jam: 'JAM',
-    };
-    return (
-      <span
-        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[type]}`}
-      >
-        {labels[type]}
-      </span>
-    );
-  };
-
   const filteredEvents = filter.status
     ? events.filter((e) => e.status === filter.status)
     : events;
 
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">イベント管理</h1>
-        <Link
-          href="/admin/events/new"
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-        >
-          <svg
-            className="w-5 h-5 mr-2"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 4v16m8-8H4"
-            />
-          </svg>
-          新規イベント
-        </Link>
+        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+          <span className="text-hn-accent font-mono">&gt;_</span>
+          イベント管理
+        </h1>
+        <Button asChild>
+          <Link href="/admin/events/new">
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            新規イベント
+          </Link>
+        </Button>
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-        <div className="flex flex-wrap gap-4">
-          <div>
-            <label
-              htmlFor={statusFilterId}
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              ステータス
-            </label>
-            <select
-              id={statusFilterId}
-              className="border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-              value={filter.status || ''}
-              onChange={(e) =>
-                setFilter({ status: e.target.value || undefined })
-              }
-            >
-              <option value="">すべて</option>
-              <option value="draft">下書き</option>
-              <option value="scheduled">予定</option>
-              <option value="active">開催中</option>
-              <option value="ended">終了</option>
-            </select>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex flex-wrap gap-4 items-end">
+            <div>
+              <label
+                htmlFor={statusFilterId}
+                className="block text-sm font-medium text-text-muted mb-1"
+              >
+                ステータス
+              </label>
+              <select
+                id={statusFilterId}
+                className="bg-surface-1 border border-border rounded-[var(--radius)] px-3 py-2 text-text-primary focus:ring-hn-accent focus:border-hn-accent focus:outline-none"
+                value={filter.status || ''}
+                onChange={(e) =>
+                  setFilter({
+                    status: (e.target.value as EventStatus) || undefined,
+                  })
+                }
+              >
+                <option value="">すべて</option>
+                <option value="draft">下書き</option>
+                <option value="scheduled">予定</option>
+                <option value="active">開催中</option>
+                <option value="completed">終了</option>
+              </select>
+            </div>
+            <div className="text-sm text-text-muted font-mono">
+              {filteredEvents.length} 件のイベント
+            </div>
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
-      {/* Events Table */}
+      {/* Events List */}
       {loading ? (
-        <div className="flex justify-center items-center h-64">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-2">
+                    <Skeleton className="h-6 w-64" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                  <Skeleton className="h-10 w-24" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       ) : filteredEvents.length === 0 ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+        <Card className="text-center py-12">
           <div className="text-4xl mb-4">📭</div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
             イベントがありません
           </h2>
-          <p className="text-gray-500 mb-6">
+          <p className="text-text-muted mb-6">
             新しいイベントを作成して始めましょう。
           </p>
-          <Link
-            href="/admin/events/new"
-            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-          >
-            新規イベント作成
-          </Link>
-        </div>
+          <Button asChild>
+            <Link href="/admin/events/new">新規イベント作成</Link>
+          </Button>
+        </Card>
       ) : (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  イベント名
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  タイプ
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  ステータス
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  期間
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  参加者
-                </th>
-                <th scope="col" className="relative px-6 py-3">
-                  <span className="sr-only">アクション</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {filteredEvents.map((event) => (
-                <tr key={event.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <Link
-                      href={`/admin/events/${event.id}`}
-                      className="text-sm font-medium text-gray-900 hover:text-blue-600"
-                    >
-                      {event.name}
-                    </Link>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {getTypeBadge(event.type)}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {getStatusBadge(event.status)}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    <div>{formatDate(event.startTime)}</div>
-                    <div className="text-xs text-gray-400">
-                      〜 {formatDate(event.endTime)}
+        <div className="space-y-4">
+          {filteredEvents.map((event) => (
+            <Card
+              key={event.id}
+              className="group hover:border-hn-accent/50 transition-all duration-[var(--animation-duration-fast)]"
+            >
+              <CardContent className="p-6">
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 mb-2">
+                      <Link
+                        href={`/admin/events/${event.id}`}
+                        className="text-lg font-semibold text-text-primary hover:text-hn-accent transition-colors"
+                      >
+                        {event.name}
+                      </Link>
+                      <ProblemTypeBadge type={event.type} />
+                      <EventStatusBadge status={event.status} />
                     </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {event.participantCount} / {event.maxParticipants}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <Link
-                      href={`/admin/events/${event.id}`}
-                      className="text-blue-600 hover:text-blue-900 mr-4"
-                    >
-                      編集
-                    </Link>
-                    <button
-                      type="button"
-                      className="text-red-600 hover:text-red-900"
+                    <div className="flex items-center gap-6 text-sm text-text-muted">
+                      <span className="flex items-center gap-1">
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                          />
+                        </svg>
+                        {formatDate(event.startTime)}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+                          />
+                        </svg>
+                        {event.participantCount} / {event.maxParticipants}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                          />
+                        </svg>
+                        {event.problemCount} 問
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button variant="secondary" size="sm" asChild>
+                      <Link href={`/admin/events/${event.id}`}>
+                        <svg
+                          className="w-4 h-4 mr-1"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                          />
+                        </svg>
+                        編集
+                      </Link>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-hn-error hover:text-hn-error hover:bg-hn-error/10"
                       onClick={() => {
                         // TODO: Implement delete
                       }}
                     >
-                      削除
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       )}
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> events --list --count=
+        {filteredEvents.length}
+      </div>
     </div>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/layout.tsx
+++ b/apps/application-plane/app/(admin)/admin/layout.tsx
@@ -59,6 +59,25 @@ const navItems: NavItem[] = [
     ),
   },
   {
+    href: '/admin/marketplace',
+    label: 'マーケットプレイス',
+    icon: (
+      <svg
+        className="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+        />
+      </svg>
+    ),
+  },
+  {
     href: '/admin/participants',
     label: '参加者管理',
     icon: (

--- a/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
@@ -1,0 +1,528 @@
+/**
+ * Admin Marketplace Page
+ *
+ * HybridNext Design System - Terminal Command Center style
+ * 問題マーケットプレイス - 問題の検索と選択
+ */
+
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge, Input, Select } from '@/components/ui';
+import type {
+  CloudProvider,
+  DifficultyLevel,
+  ProblemCategory,
+  ProblemType,
+} from '@/lib/api/types';
+
+interface MarketplaceProblem {
+  id: string;
+  title: string;
+  description: string;
+  type: ProblemType;
+  category: ProblemCategory;
+  difficulty: DifficultyLevel;
+  cloudProvider: CloudProvider;
+  estimatedTimeMinutes: number;
+  authorName: string;
+  rating: number;
+  usageCount: number;
+  tags: string[];
+  createdAt: string;
+}
+
+export default function AdminMarketplacePage() {
+  const [problems, setProblems] = useState<MarketplaceProblem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [selectedDifficulty, setSelectedDifficulty] = useState<string>('');
+  const [selectedCloudProvider, setSelectedCloudProvider] =
+    useState<string>('');
+
+  const searchInputId = useId();
+  const categoryFilterId = useId();
+  const difficultyFilterId = useId();
+  const cloudProviderFilterId = useId();
+
+  useEffect(() => {
+    // TODO: Replace with actual API call
+    const fetchProblems = async () => {
+      try {
+        setLoading(true);
+        // Mock data
+        setProblems([
+          {
+            id: 'prob-1',
+            title: 'VPC ネットワーク設計',
+            description:
+              'マルチ AZ 構成の VPC を設計・構築し、セキュアなネットワーク環境を実現する課題です。',
+            type: 'gameday',
+            category: 'architecture',
+            difficulty: 'medium',
+            cloudProvider: 'aws',
+            estimatedTimeMinutes: 45,
+            authorName: 'AWS Solutions Architect',
+            rating: 4.8,
+            usageCount: 156,
+            tags: ['VPC', 'Networking', 'Security Group'],
+            createdAt: new Date(Date.now() - 2592000000).toISOString(),
+          },
+          {
+            id: 'prob-2',
+            title: 'Lambda コスト最適化',
+            description:
+              'Lambda 関数のメモリ設定とタイムアウトを最適化してコストを削減する課題です。',
+            type: 'jam',
+            category: 'cost',
+            difficulty: 'easy',
+            cloudProvider: 'aws',
+            estimatedTimeMinutes: 30,
+            authorName: 'Cloud Cost Optimizer',
+            rating: 4.5,
+            usageCount: 89,
+            tags: ['Lambda', 'Cost Optimization', 'Serverless'],
+            createdAt: new Date(Date.now() - 1296000000).toISOString(),
+          },
+          {
+            id: 'prob-3',
+            title: 'IAM セキュリティ強化',
+            description:
+              '最小権限の原則に基づいた IAM ポリシーを設計し、セキュリティを強化する課題です。',
+            type: 'gameday',
+            category: 'security',
+            difficulty: 'hard',
+            cloudProvider: 'aws',
+            estimatedTimeMinutes: 60,
+            authorName: 'Security Specialist',
+            rating: 4.9,
+            usageCount: 234,
+            tags: ['IAM', 'Security', 'Policy'],
+            createdAt: new Date(Date.now() - 604800000).toISOString(),
+          },
+          {
+            id: 'prob-4',
+            title: 'Auto Scaling 設計',
+            description:
+              '負荷に応じて自動スケーリングする構成を設計・実装する課題です。',
+            type: 'gameday',
+            category: 'performance',
+            difficulty: 'medium',
+            cloudProvider: 'aws',
+            estimatedTimeMinutes: 50,
+            authorName: 'Performance Engineer',
+            rating: 4.6,
+            usageCount: 178,
+            tags: ['Auto Scaling', 'EC2', 'High Availability'],
+            createdAt: new Date(Date.now() - 172800000).toISOString(),
+          },
+          {
+            id: 'prob-5',
+            title: 'マルチリージョン DR 構成',
+            description:
+              'マルチリージョンの災害復旧（DR）構成を設計・実装する上級課題です。',
+            type: 'gameday',
+            category: 'reliability',
+            difficulty: 'expert',
+            cloudProvider: 'aws',
+            estimatedTimeMinutes: 90,
+            authorName: 'DR Architect',
+            rating: 4.7,
+            usageCount: 67,
+            tags: ['DR', 'Multi-Region', 'RTO/RPO'],
+            createdAt: new Date(Date.now() - 86400000).toISOString(),
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProblems();
+  }, []);
+
+  const getDifficultyBadgeVariant = (
+    difficulty: DifficultyLevel
+  ): 'default' | 'success' | 'warning' | 'danger' | 'purple' => {
+    switch (difficulty) {
+      case 'easy':
+        return 'success';
+      case 'medium':
+        return 'warning';
+      case 'hard':
+        return 'danger';
+      case 'expert':
+        return 'purple';
+      default:
+        return 'default';
+    }
+  };
+
+  const getDifficultyLabel = (difficulty: DifficultyLevel): string => {
+    switch (difficulty) {
+      case 'easy':
+        return '初級';
+      case 'medium':
+        return '中級';
+      case 'hard':
+        return '上級';
+      case 'expert':
+        return 'エキスパート';
+      default:
+        return difficulty;
+    }
+  };
+
+  const getCategoryLabel = (category: ProblemCategory): string => {
+    switch (category) {
+      case 'architecture':
+        return 'アーキテクチャ';
+      case 'security':
+        return 'セキュリティ';
+      case 'cost':
+        return 'コスト最適化';
+      case 'performance':
+        return 'パフォーマンス';
+      case 'reliability':
+        return '信頼性';
+      case 'operations':
+        return '運用';
+      default:
+        return category;
+    }
+  };
+
+  const getCategoryIcon = (category: ProblemCategory): string => {
+    switch (category) {
+      case 'architecture':
+        return '🏗️';
+      case 'security':
+        return '🔒';
+      case 'cost':
+        return '💰';
+      case 'performance':
+        return '⚡';
+      case 'reliability':
+        return '🛡️';
+      case 'operations':
+        return '🔧';
+      default:
+        return '📦';
+    }
+  };
+
+  const filteredProblems = problems.filter((p) => {
+    const matchesSearch =
+      searchQuery === '' ||
+      p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      p.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      p.tags.some((tag) =>
+        tag.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+    const matchesCategory =
+      selectedCategory === '' || p.category === selectedCategory;
+    const matchesDifficulty =
+      selectedDifficulty === '' || p.difficulty === selectedDifficulty;
+    const matchesCloudProvider =
+      selectedCloudProvider === '' || p.cloudProvider === selectedCloudProvider;
+
+    return (
+      matchesSearch &&
+      matchesCategory &&
+      matchesDifficulty &&
+      matchesCloudProvider
+    );
+  });
+
+  const totalProblems = problems.length;
+  const avgRating =
+    problems.length > 0
+      ? (
+          problems.reduce((acc, p) => acc + p.rating, 0) / problems.length
+        ).toFixed(1)
+      : '0.0';
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+          <span className="text-hn-accent font-mono">&gt;_</span>
+          問題マーケットプレイス
+        </h1>
+      </div>
+
+      {/* Search & Filters */}
+      <Card>
+        <CardContent className="p-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+            <div className="lg:col-span-2">
+              <label htmlFor={searchInputId} className="sr-only">
+                検索
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <svg
+                    className="h-5 w-5 text-text-muted"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                </div>
+                <Input
+                  id={searchInputId}
+                  type="text"
+                  placeholder="タイトル、説明、タグで検索..."
+                  className="pl-10"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor={categoryFilterId}
+                className="block text-xs font-medium text-text-muted mb-1"
+              >
+                カテゴリ
+              </label>
+              <Select
+                id={categoryFilterId}
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value)}
+                options={[
+                  { value: '', label: 'すべて' },
+                  { value: 'architecture', label: 'アーキテクチャ' },
+                  { value: 'security', label: 'セキュリティ' },
+                  { value: 'cost', label: 'コスト最適化' },
+                  { value: 'performance', label: 'パフォーマンス' },
+                  { value: 'reliability', label: '信頼性' },
+                  { value: 'operations', label: '運用' },
+                ]}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor={difficultyFilterId}
+                className="block text-xs font-medium text-text-muted mb-1"
+              >
+                難易度
+              </label>
+              <Select
+                id={difficultyFilterId}
+                value={selectedDifficulty}
+                onChange={(e) => setSelectedDifficulty(e.target.value)}
+                options={[
+                  { value: '', label: 'すべて' },
+                  { value: 'easy', label: '初級' },
+                  { value: 'medium', label: '中級' },
+                  { value: 'hard', label: '上級' },
+                  { value: 'expert', label: 'エキスパート' },
+                ]}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor={cloudProviderFilterId}
+                className="block text-xs font-medium text-text-muted mb-1"
+              >
+                クラウド
+              </label>
+              <Select
+                id={cloudProviderFilterId}
+                value={selectedCloudProvider}
+                onChange={(e) => setSelectedCloudProvider(e.target.value)}
+                options={[
+                  { value: '', label: 'すべて' },
+                  { value: 'aws', label: 'AWS' },
+                  { value: 'gcp', label: 'Google Cloud' },
+                  { value: 'azure', label: 'Azure' },
+                  { value: 'local', label: 'LocalStack' },
+                ]}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              公開問題数
+            </div>
+            <div className="text-3xl font-bold text-text-primary mt-1 font-mono">
+              {totalProblems}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">平均評価</div>
+            <div className="text-3xl font-bold text-hn-warning mt-1 font-mono flex items-center gap-2">
+              <span>★</span>
+              {avgRating}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">検索結果</div>
+            <div className="text-3xl font-bold text-hn-accent mt-1 font-mono">
+              {filteredProblems.length}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Problems Grid */}
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6">
+                <Skeleton className="h-6 w-3/4 mb-4" />
+                <div className="space-y-3">
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-2/3" />
+                </div>
+                <div className="flex gap-2 mt-4">
+                  <Skeleton className="h-6 w-16" />
+                  <Skeleton className="h-6 w-16" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : filteredProblems.length === 0 ? (
+        <Card className="text-center py-12">
+          <div className="text-4xl mb-4">🔍</div>
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
+            問題が見つかりません
+          </h2>
+          <p className="text-text-muted">検索条件を変更してください。</p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {filteredProblems.map((problem) => (
+            <Card
+              key={problem.id}
+              className="group hover:border-hn-accent/50 transition-all duration-[var(--animation-duration-fast)]"
+            >
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-2xl">
+                      {getCategoryIcon(problem.category)}
+                    </span>
+                    <div>
+                      <CardTitle className="text-lg group-hover:text-hn-accent transition-colors">
+                        {problem.title}
+                      </CardTitle>
+                      <p className="text-sm text-text-muted font-mono">
+                        {problem.authorName}
+                      </p>
+                    </div>
+                  </div>
+                  <Badge
+                    variant={problem.type === 'gameday' ? 'primary' : 'info'}
+                  >
+                    {problem.type === 'gameday' ? 'GameDay' : 'JAM'}
+                  </Badge>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-text-secondary mb-4 line-clamp-2">
+                  {problem.description}
+                </p>
+
+                <div className="flex flex-wrap gap-2 mb-4">
+                  <Badge
+                    variant={getDifficultyBadgeVariant(problem.difficulty)}
+                  >
+                    {getDifficultyLabel(problem.difficulty)}
+                  </Badge>
+                  <Badge variant="default">
+                    {getCategoryLabel(problem.category)}
+                  </Badge>
+                  <Badge variant="default" className="font-mono uppercase">
+                    {problem.cloudProvider}
+                  </Badge>
+                </div>
+
+                <div className="flex items-center justify-between text-sm text-text-muted mb-4">
+                  <span className="flex items-center gap-1">
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                    {problem.estimatedTimeMinutes} 分
+                  </span>
+                  <span className="flex items-center gap-1 text-hn-warning">
+                    ★ {problem.rating.toFixed(1)}
+                  </span>
+                  <span className="font-mono">{problem.usageCount} 回使用</span>
+                </div>
+
+                <div className="flex flex-wrap gap-1 mb-4">
+                  {problem.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-xs px-2 py-1 bg-surface-2 text-text-muted rounded-[var(--radius)] font-mono"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                  {problem.tags.length > 3 && (
+                    <span className="text-xs px-2 py-1 text-text-muted">
+                      +{problem.tags.length - 3}
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex gap-2">
+                  <Button variant="secondary" size="sm" className="flex-1">
+                    プレビュー
+                  </Button>
+                  <Button size="sm" className="flex-1">
+                    イベントに追加
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> marketplace --search --count=
+        {filteredProblems.length}
+      </div>
+    </div>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/participants/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/participants/page.tsx
@@ -1,25 +1,24 @@
 /**
  * Admin Participants Page
  *
+ * HybridNext Design System - Terminal Command Center style
  * 参加者管理
  */
 
 'use client';
 
 import { useEffect, useId, useState } from 'react';
-
-interface Participant {
-  id: string;
-  name: string;
-  email: string;
-  joinedAt: string;
-  eventsCount: number;
-  totalScore: number;
-  status: 'active' | 'inactive';
-}
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui';
+import type {
+  AdminParticipant,
+  ParticipantStatus,
+} from '@/lib/api/admin-types';
 
 export default function AdminParticipantsPage() {
-  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [participants, setParticipants] = useState<AdminParticipant[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const searchInputId = useId();
@@ -32,31 +31,37 @@ export default function AdminParticipantsPage() {
         // Mock data
         setParticipants([
           {
-            id: 'user-1',
-            name: '山田太郎',
+            id: 'participant-1',
+            userId: 'user-1',
+            displayName: '山田太郎',
             email: 'yamada@example.com',
+            role: 'participant',
             joinedAt: new Date(Date.now() - 2592000000).toISOString(),
+            status: 'active',
             eventsCount: 5,
             totalScore: 2500,
-            status: 'active',
           },
           {
-            id: 'user-2',
-            name: '佐藤花子',
+            id: 'participant-2',
+            userId: 'user-2',
+            displayName: '佐藤花子',
             email: 'sato@example.com',
+            role: 'admin',
             joinedAt: new Date(Date.now() - 1296000000).toISOString(),
+            status: 'active',
             eventsCount: 3,
             totalScore: 1800,
-            status: 'active',
           },
           {
-            id: 'user-3',
-            name: '鈴木一郎',
+            id: 'participant-3',
+            userId: 'user-3',
+            displayName: '鈴木一郎',
             email: 'suzuki@example.com',
+            role: 'participant',
             joinedAt: new Date(Date.now() - 604800000).toISOString(),
+            status: 'inactive',
             eventsCount: 1,
             totalScore: 400,
-            status: 'inactive',
           },
         ]);
       } finally {
@@ -78,18 +83,56 @@ export default function AdminParticipantsPage() {
 
   const filteredParticipants = participants.filter(
     (p) =>
-      p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      p.displayName.toLowerCase().includes(searchQuery.toLowerCase()) ||
       p.email.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  const getStatusBadgeVariant = (
+    status: ParticipantStatus
+  ): 'default' | 'success' | 'warning' | 'danger' => {
+    switch (status) {
+      case 'active':
+        return 'success';
+      case 'inactive':
+        return 'warning';
+      case 'banned':
+        return 'danger';
+      default:
+        return 'default';
+    }
+  };
+
+  const getStatusLabel = (status: ParticipantStatus): string => {
+    switch (status) {
+      case 'active':
+        return 'アクティブ';
+      case 'inactive':
+        return '非アクティブ';
+      case 'banned':
+        return 'BAN';
+      default:
+        return status;
+    }
+  };
+
+  const activeCount = participants.filter((p) => p.status === 'active').length;
+  const avgScore =
+    participants.length > 0
+      ? Math.round(
+          participants.reduce((acc, p) => acc + (p.totalScore || 0), 0) /
+            participants.length
+        )
+      : 0;
+
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">参加者管理</h1>
-        <button
-          type="button"
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-        >
+        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+          <span className="text-hn-accent font-mono">&gt;_</span>
+          参加者管理
+        </h1>
+        <Button>
           <svg
             className="w-5 h-5 mr-2"
             fill="none"
@@ -104,166 +147,176 @@ export default function AdminParticipantsPage() {
             />
           </svg>
           参加者を招待
-        </button>
+        </Button>
       </div>
 
       {/* Search */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-        <div className="max-w-md">
-          <label htmlFor={searchInputId} className="sr-only">
-            検索
-          </label>
-          <div className="relative">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <svg
-                className="h-5 w-5 text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+      <Card>
+        <CardContent className="p-4">
+          <div className="max-w-md">
+            <label htmlFor={searchInputId} className="sr-only">
+              検索
+            </label>
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg
+                  className="h-5 w-5 text-text-muted"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </div>
+              <input
+                id={searchInputId}
+                type="text"
+                placeholder="名前またはメールアドレスで検索..."
+                className="block w-full pl-10 pr-3 py-2 bg-surface-1 border border-border rounded-[var(--radius)] text-text-primary placeholder:text-text-muted focus:ring-hn-accent focus:border-hn-accent focus:outline-none"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
             </div>
-            <input
-              id={searchInputId}
-              type="text"
-              placeholder="名前またはメールアドレスで検索..."
-              className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">総参加者数</div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {participants.length}
-          </div>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">
-            アクティブユーザー
-          </div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {participants.filter((p) => p.status === 'active').length}
-          </div>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">平均スコア</div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {participants.length > 0
-              ? Math.round(
-                  participants.reduce((acc, p) => acc + p.totalScore, 0) /
-                    participants.length
-                )
-              : 0}
-          </div>
-        </div>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              総参加者数
+            </div>
+            <div className="text-3xl font-bold text-text-primary mt-1 font-mono">
+              {participants.length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              アクティブユーザー
+            </div>
+            <div className="text-3xl font-bold text-hn-success mt-1 font-mono">
+              {activeCount}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              平均スコア
+            </div>
+            <div className="text-3xl font-bold text-hn-accent mt-1 font-mono">
+              {avgScore.toLocaleString()}
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
-      {/* Participants Table */}
+      {/* Participants List */}
       {loading ? (
-        <div className="flex justify-center items-center h-64">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-3 w-48" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       ) : filteredParticipants.length === 0 ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+        <Card className="text-center py-12">
           <div className="text-4xl mb-4">👥</div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
             参加者が見つかりません
           </h2>
-          <p className="text-gray-500">
+          <p className="text-text-muted mb-6">
             {searchQuery
               ? '検索条件を変更してください。'
               : '参加者を招待して始めましょう。'}
           </p>
-        </div>
+          <Button>参加者を招待</Button>
+        </Card>
       ) : (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  参加者
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ステータス
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  参加イベント数
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  累計スコア
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  登録日
-                </th>
-                <th className="px-6 py-3" />
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {filteredParticipants.map((participant) => (
-                <tr key={participant.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
-                      <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center text-white font-medium">
-                        {participant.name.charAt(0)}
+        <div className="space-y-3">
+          {filteredParticipants.map((participant) => (
+            <Card
+              key={participant.id}
+              className="group hover:border-hn-accent/50 transition-all duration-[var(--animation-duration-fast)]"
+            >
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className="w-10 h-10 bg-hn-accent rounded-full flex items-center justify-center text-surface-0 font-bold">
+                      {participant.displayName.charAt(0)}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-text-primary">
+                          {participant.displayName}
+                        </span>
+                        <Badge
+                          variant={getStatusBadgeVariant(participant.status)}
+                        >
+                          {getStatusLabel(participant.status)}
+                        </Badge>
+                        {participant.role === 'admin' && (
+                          <Badge variant="default">管理者</Badge>
+                        )}
                       </div>
-                      <div className="ml-4">
-                        <div className="text-sm font-medium text-gray-900">
-                          {participant.name}
-                        </div>
-                        <div className="text-sm text-gray-500">
-                          {participant.email}
-                        </div>
+                      <div className="text-sm text-text-muted">
+                        {participant.email}
                       </div>
                     </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        participant.status === 'active'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-800'
-                      }`}
-                    >
-                      {participant.status === 'active'
-                        ? 'アクティブ'
-                        : '非アクティブ'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {participant.eventsCount}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {participant.totalScore.toLocaleString()} pts
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {formatDate(participant.joinedAt)}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <button
-                      type="button"
-                      className="text-blue-600 hover:text-blue-900"
-                    >
+                  </div>
+                  <div className="flex items-center gap-6">
+                    <div className="text-right">
+                      <div className="text-sm text-text-muted">イベント</div>
+                      <div className="font-mono text-text-primary">
+                        {participant.eventsCount || 0}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm text-text-muted">スコア</div>
+                      <div className="font-mono text-hn-accent">
+                        {(participant.totalScore || 0).toLocaleString()}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm text-text-muted">登録日</div>
+                      <div className="font-mono text-text-secondary text-sm">
+                        {formatDate(participant.joinedAt)}
+                      </div>
+                    </div>
+                    <Button variant="ghost" size="sm">
                       詳細
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       )}
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> participants --list --count=
+        {filteredParticipants.length}
+      </div>
     </div>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/settings/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/settings/page.tsx
@@ -1,12 +1,17 @@
 /**
  * Admin Settings Page
  *
+ * HybridNext Design System - Terminal Command Center style
  * テナント設定
  */
 
 'use client';
 
 import { useId, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
 import { useTenantOptional } from '@/lib/tenant';
 
 export default function AdminSettingsPage() {
@@ -20,6 +25,9 @@ export default function AdminSettingsPage() {
   const defaultCloudProviderId = useId();
   const maxParticipantsId = useId();
   const maxTeamSizeId = useId();
+  const teamRegistrationId = useId();
+  const individualRegistrationId = useId();
+  const emailVerificationId = useId();
 
   // Form state
   const [settings, setSettings] = useState({
@@ -48,17 +56,16 @@ export default function AdminSettingsPage() {
 
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">設定</h1>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={saving}
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-        >
+        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+          <span className="text-hn-accent font-mono">&gt;_</span>
+          設定
+        </h1>
+        <Button onClick={handleSave} disabled={saving}>
           {saving ? (
             <>
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mr-2" />
               保存中...
             </>
           ) : saved ? (
@@ -81,210 +88,307 @@ export default function AdminSettingsPage() {
           ) : (
             '変更を保存'
           )}
-        </button>
+        </Button>
       </div>
 
       {/* General Settings */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">基本設定</h2>
-        <div className="space-y-6">
-          <div>
-            <label
-              htmlFor={tenantNameId}
-              className="block text-sm font-medium text-gray-700 mb-1"
+      <Card>
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold text-text-primary mb-6 flex items-center gap-2">
+            <svg
+              className="w-5 h-5 text-hn-accent"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              テナント名
-            </label>
-            <input
-              id={tenantNameId}
-              type="text"
-              value={settings.tenantName}
-              onChange={(e) =>
-                setSettings({ ...settings, tenantName: e.target.value })
-              }
-              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor={contactEmailId}
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              連絡先メールアドレス
-            </label>
-            <input
-              id={contactEmailId}
-              type="email"
-              value={settings.contactEmail}
-              onChange={(e) =>
-                setSettings({ ...settings, contactEmail: e.target.value })
-              }
-              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-            />
-            <p className="mt-1 text-sm text-gray-500">
-              システム通知の送信先として使用されます。
-            </p>
-          </div>
-
-          <div>
-            <label
-              htmlFor={defaultCloudProviderId}
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              デフォルトクラウドプロバイダー
-            </label>
-            <select
-              id={defaultCloudProviderId}
-              value={settings.defaultCloudProvider}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  defaultCloudProvider: e.target.value,
-                })
-              }
-              className="block w-full max-w-md border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-            >
-              <option value="aws">AWS</option>
-              <option value="gcp">Google Cloud</option>
-              <option value="azure">Microsoft Azure</option>
-            </select>
-          </div>
-        </div>
-      </div>
-
-      {/* Event Settings */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">
-          イベント設定
-        </h2>
-        <div className="space-y-6">
-          <div>
-            <label
-              htmlFor={maxParticipantsId}
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              イベントあたりの最大参加者数
-            </label>
-            <input
-              id={maxParticipantsId}
-              type="number"
-              min={1}
-              max={1000}
-              value={settings.maxParticipantsPerEvent}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  maxParticipantsPerEvent: Number.parseInt(e.target.value, 10),
-                })
-              }
-              className="block w-32 border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor={maxTeamSizeId}
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              最大チームサイズ
-            </label>
-            <input
-              id={maxTeamSizeId}
-              type="number"
-              min={1}
-              max={10}
-              value={settings.maxTeamSize}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  maxTeamSize: Number.parseInt(e.target.value, 10),
-                })
-              }
-              className="block w-32 border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Registration Settings */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">登録設定</h2>
-        <div className="space-y-4">
-          <label className="flex items-center">
-            <input
-              type="checkbox"
-              checked={settings.enableTeamRegistration}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  enableTeamRegistration: e.target.checked,
-                })
-              }
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-            />
-            <span className="ml-3 text-sm text-gray-700">
-              チーム登録を許可する
-            </span>
-          </label>
-
-          <label className="flex items-center">
-            <input
-              type="checkbox"
-              checked={settings.enableIndividualRegistration}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  enableIndividualRegistration: e.target.checked,
-                })
-              }
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-            />
-            <span className="ml-3 text-sm text-gray-700">
-              個人登録を許可する
-            </span>
-          </label>
-
-          <label className="flex items-center">
-            <input
-              type="checkbox"
-              checked={settings.requireEmailVerification}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  requireEmailVerification: e.target.checked,
-                })
-              }
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-            />
-            <span className="ml-3 text-sm text-gray-700">
-              メール認証を必須にする
-            </span>
-          </label>
-        </div>
-      </div>
-
-      {/* Danger Zone */}
-      <div className="bg-white rounded-lg shadow-sm border border-red-200 p-6">
-        <h2 className="text-lg font-semibold text-red-600 mb-4">危険な操作</h2>
-        <div className="space-y-4">
-          <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            基本設定
+          </h2>
+          <div className="space-y-6">
             <div>
-              <h3 className="text-sm font-medium text-gray-900">
-                全データを削除
-              </h3>
-              <p className="text-sm text-gray-500">
-                すべてのイベント、参加者、チームデータを削除します。この操作は取り消せません。
+              <label
+                htmlFor={tenantNameId}
+                className="block text-sm font-medium text-text-secondary mb-1"
+              >
+                テナント名
+              </label>
+              <Input
+                id={tenantNameId}
+                type="text"
+                value={settings.tenantName}
+                onChange={(e) =>
+                  setSettings({ ...settings, tenantName: e.target.value })
+                }
+                className="max-w-md"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor={contactEmailId}
+                className="block text-sm font-medium text-text-secondary mb-1"
+              >
+                連絡先メールアドレス
+              </label>
+              <Input
+                id={contactEmailId}
+                type="email"
+                value={settings.contactEmail}
+                onChange={(e) =>
+                  setSettings({ ...settings, contactEmail: e.target.value })
+                }
+                className="max-w-md"
+              />
+              <p className="mt-1 text-sm text-text-muted">
+                システム通知の送信先として使用されます。
               </p>
             </div>
-            <button
-              type="button"
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 text-sm font-medium"
-            >
-              削除
-            </button>
+
+            <div>
+              <label
+                htmlFor={defaultCloudProviderId}
+                className="block text-sm font-medium text-text-secondary mb-1"
+              >
+                デフォルトクラウドプロバイダー
+              </label>
+              <Select
+                id={defaultCloudProviderId}
+                value={settings.defaultCloudProvider}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    defaultCloudProvider: e.target.value,
+                  })
+                }
+                options={[
+                  { value: 'aws', label: 'AWS' },
+                  { value: 'gcp', label: 'Google Cloud' },
+                  { value: 'azure', label: 'Microsoft Azure' },
+                ]}
+                className="max-w-md"
+              />
+            </div>
           </div>
-        </div>
+        </CardContent>
+      </Card>
+
+      {/* Event Settings */}
+      <Card>
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold text-text-primary mb-6 flex items-center gap-2">
+            <svg
+              className="w-5 h-5 text-hn-purple"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            イベント設定
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <label
+                htmlFor={maxParticipantsId}
+                className="block text-sm font-medium text-text-secondary mb-1"
+              >
+                イベントあたりの最大参加者数
+              </label>
+              <Input
+                id={maxParticipantsId}
+                type="number"
+                min={1}
+                max={1000}
+                value={settings.maxParticipantsPerEvent}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    maxParticipantsPerEvent: Number.parseInt(
+                      e.target.value,
+                      10
+                    ),
+                  })
+                }
+                className="w-32"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor={maxTeamSizeId}
+                className="block text-sm font-medium text-text-secondary mb-1"
+              >
+                最大チームサイズ
+              </label>
+              <Input
+                id={maxTeamSizeId}
+                type="number"
+                min={1}
+                max={10}
+                value={settings.maxTeamSize}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    maxTeamSize: Number.parseInt(e.target.value, 10),
+                  })
+                }
+                className="w-32"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Registration Settings */}
+      <Card>
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold text-text-primary mb-6 flex items-center gap-2">
+            <svg
+              className="w-5 h-5 text-hn-success"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+              />
+            </svg>
+            登録設定
+          </h2>
+          <div className="space-y-4">
+            <label
+              htmlFor={teamRegistrationId}
+              className="flex items-center cursor-pointer group"
+            >
+              <input
+                id={teamRegistrationId}
+                type="checkbox"
+                checked={settings.enableTeamRegistration}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    enableTeamRegistration: e.target.checked,
+                  })
+                }
+                className="h-4 w-4 text-hn-accent bg-surface-1 border-border rounded focus:ring-hn-accent focus:ring-offset-surface-0"
+              />
+              <span className="ml-3 text-sm text-text-secondary group-hover:text-text-primary transition-colors">
+                チーム登録を許可する
+              </span>
+            </label>
+
+            <label
+              htmlFor={individualRegistrationId}
+              className="flex items-center cursor-pointer group"
+            >
+              <input
+                id={individualRegistrationId}
+                type="checkbox"
+                checked={settings.enableIndividualRegistration}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    enableIndividualRegistration: e.target.checked,
+                  })
+                }
+                className="h-4 w-4 text-hn-accent bg-surface-1 border-border rounded focus:ring-hn-accent focus:ring-offset-surface-0"
+              />
+              <span className="ml-3 text-sm text-text-secondary group-hover:text-text-primary transition-colors">
+                個人登録を許可する
+              </span>
+            </label>
+
+            <label
+              htmlFor={emailVerificationId}
+              className="flex items-center cursor-pointer group"
+            >
+              <input
+                id={emailVerificationId}
+                type="checkbox"
+                checked={settings.requireEmailVerification}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    requireEmailVerification: e.target.checked,
+                  })
+                }
+                className="h-4 w-4 text-hn-accent bg-surface-1 border-border rounded focus:ring-hn-accent focus:ring-offset-surface-0"
+              />
+              <span className="ml-3 text-sm text-text-secondary group-hover:text-text-primary transition-colors">
+                メール認証を必須にする
+              </span>
+            </label>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Danger Zone */}
+      <Card className="border-hn-error/30">
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold text-hn-error mb-4 flex items-center gap-2">
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            危険な操作
+          </h2>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between p-4 bg-hn-error/10 rounded-lg border border-hn-error/20">
+              <div>
+                <h3 className="text-sm font-medium text-text-primary">
+                  全データを削除
+                </h3>
+                <p className="text-sm text-text-muted">
+                  すべてのイベント、参加者、チームデータを削除します。この操作は取り消せません。
+                </p>
+              </div>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => {
+                  // TODO: Implement delete confirmation
+                }}
+              >
+                削除
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> config --tenant=
+        {settings.tenantName || 'default'}
       </div>
     </div>
   );

--- a/apps/application-plane/app/(admin)/admin/teams/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/teams/page.tsx
@@ -1,29 +1,20 @@
 /**
  * Admin Teams Page
  *
+ * HybridNext Design System - Terminal Command Center style
  * チーム管理
  */
 
 'use client';
 
 import { useEffect, useId, useState } from 'react';
-
-interface Team {
-  id: string;
-  name: string;
-  memberCount: number;
-  maxMembers: number;
-  createdAt: string;
-  eventsCount: number;
-  totalScore: number;
-  captain: {
-    id: string;
-    name: string;
-  };
-}
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { AdminTeam } from '@/lib/api/admin-types';
 
 export default function AdminTeamsPage() {
-  const [teams, setTeams] = useState<Team[]>([]);
+  const [teams, setTeams] = useState<AdminTeam[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const searchInputId = useId();
@@ -38,32 +29,38 @@ export default function AdminTeamsPage() {
           {
             id: 'team-1',
             name: 'Cloud Warriors',
+            members: [],
+            captainId: 'user-1',
+            inviteCode: 'CW2024',
             memberCount: 4,
             maxMembers: 5,
-            createdAt: new Date(Date.now() - 2592000000).toISOString(),
             eventsCount: 3,
             totalScore: 8500,
-            captain: { id: 'user-1', name: '山田太郎' },
+            createdAt: new Date(Date.now() - 2592000000).toISOString(),
           },
           {
             id: 'team-2',
             name: 'Lambda Legends',
+            members: [],
+            captainId: 'user-2',
+            inviteCode: 'LL2024',
             memberCount: 5,
             maxMembers: 5,
-            createdAt: new Date(Date.now() - 1296000000).toISOString(),
             eventsCount: 2,
             totalScore: 6200,
-            captain: { id: 'user-2', name: '佐藤花子' },
+            createdAt: new Date(Date.now() - 1296000000).toISOString(),
           },
           {
             id: 'team-3',
             name: 'Serverless Samurai',
+            members: [],
+            captainId: 'user-3',
+            inviteCode: 'SS2024',
             memberCount: 3,
             maxMembers: 5,
-            createdAt: new Date(Date.now() - 604800000).toISOString(),
             eventsCount: 1,
             totalScore: 2100,
-            captain: { id: 'user-3', name: '鈴木一郎' },
+            createdAt: new Date(Date.now() - 604800000).toISOString(),
           },
         ]);
       } finally {
@@ -87,158 +84,193 @@ export default function AdminTeamsPage() {
     t.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  const totalMembers = teams.reduce((acc, t) => acc + t.memberCount, 0);
+  const avgScore =
+    teams.length > 0
+      ? Math.round(
+          teams.reduce((acc, t) => acc + t.totalScore, 0) / teams.length
+        )
+      : 0;
+
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">チーム管理</h1>
+        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
+          <span className="text-hn-accent font-mono">&gt;_</span>
+          チーム管理
+        </h1>
       </div>
 
       {/* Search */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-        <div className="max-w-md">
-          <label htmlFor={searchInputId} className="sr-only">
-            検索
-          </label>
-          <div className="relative">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <svg
-                className="h-5 w-5 text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+      <Card>
+        <CardContent className="p-4">
+          <div className="max-w-md">
+            <label htmlFor={searchInputId} className="sr-only">
+              検索
+            </label>
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg
+                  className="h-5 w-5 text-text-muted"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </div>
+              <input
+                id={searchInputId}
+                type="text"
+                placeholder="チーム名で検索..."
+                className="block w-full pl-10 pr-3 py-2 bg-surface-1 border border-border rounded-[var(--radius)] text-text-primary placeholder:text-text-muted focus:ring-hn-accent focus:border-hn-accent focus:outline-none"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
             </div>
-            <input
-              id={searchInputId}
-              type="text"
-              placeholder="チーム名で検索..."
-              className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
           </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">総チーム数</div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {teams.length}
-          </div>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">総メンバー数</div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {teams.reduce((acc, t) => acc + t.memberCount, 0)}
-          </div>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="text-sm font-medium text-gray-500">
-            平均チームスコア
-          </div>
-          <div className="text-3xl font-bold text-gray-900 mt-1">
-            {teams.length > 0
-              ? Math.round(
-                  teams.reduce((acc, t) => acc + t.totalScore, 0) / teams.length
-                ).toLocaleString()
-              : 0}
-          </div>
-        </div>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              総チーム数
+            </div>
+            <div className="text-3xl font-bold text-text-primary mt-1 font-mono">
+              {teams.length}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              総メンバー数
+            </div>
+            <div className="text-3xl font-bold text-hn-purple mt-1 font-mono">
+              {totalMembers}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="text-sm font-medium text-text-muted">
+              平均チームスコア
+            </div>
+            <div className="text-3xl font-bold text-hn-accent mt-1 font-mono">
+              {avgScore.toLocaleString()}
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Teams Grid */}
       {loading ? (
-        <div className="flex justify-center items-center h-64">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6">
+                <Skeleton className="h-6 w-40 mb-4" />
+                <div className="space-y-3">
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       ) : filteredTeams.length === 0 ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+        <Card className="text-center py-12">
           <div className="text-4xl mb-4">🏆</div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
             チームが見つかりません
           </h2>
-          <p className="text-gray-500">
+          <p className="text-text-muted">
             {searchQuery
               ? '検索条件を変更してください。'
               : '参加者がチームを作成するとここに表示されます。'}
           </p>
-        </div>
+        </Card>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredTeams.map((team) => (
-            <div
+            <Card
               key={team.id}
-              className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow"
+              className="group hover:border-hn-accent/50 transition-all duration-[var(--animation-duration-fast)]"
             >
-              <div className="flex items-start justify-between mb-4">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    {team.name}
-                  </h3>
-                  <p className="text-sm text-gray-500">
-                    キャプテン: {team.captain.name}
-                  </p>
-                </div>
-                <div className="text-right">
-                  <div className="text-2xl font-bold text-blue-600">
-                    {team.totalScore.toLocaleString()}
+              <CardContent className="p-6">
+                <div className="flex items-start justify-between mb-4">
+                  <div>
+                    <h3 className="text-lg font-semibold text-text-primary group-hover:text-hn-accent transition-colors">
+                      {team.name}
+                    </h3>
+                    <p className="text-sm text-text-muted font-mono">
+                      #{team.inviteCode}
+                    </p>
                   </div>
-                  <div className="text-xs text-gray-500">pts</div>
-                </div>
-              </div>
-
-              <div className="space-y-3">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-500">メンバー</span>
-                  <span className="font-medium text-gray-900">
-                    {team.memberCount} / {team.maxMembers}
-                  </span>
-                </div>
-                <div className="w-full bg-gray-200 rounded-full h-2">
-                  <div
-                    className="bg-blue-600 h-2 rounded-full"
-                    style={{
-                      width: `${(team.memberCount / team.maxMembers) * 100}%`,
-                    }}
-                  />
+                  <div className="text-right">
+                    <div className="text-2xl font-bold text-hn-accent font-mono">
+                      {team.totalScore.toLocaleString()}
+                    </div>
+                    <div className="text-xs text-text-muted">pts</div>
+                  </div>
                 </div>
 
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-500">参加イベント</span>
-                  <span className="font-medium text-gray-900">
-                    {team.eventsCount}
-                  </span>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-text-muted">メンバー</span>
+                    <span className="font-mono text-text-primary">
+                      {team.memberCount} / {team.maxMembers}
+                    </span>
+                  </div>
+                  <div className="w-full bg-surface-2 rounded-full h-2">
+                    <div
+                      className="bg-hn-accent h-2 rounded-full transition-all"
+                      style={{
+                        width: `${(team.memberCount / team.maxMembers) * 100}%`,
+                      }}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-text-muted">参加イベント</span>
+                    <span className="font-mono text-text-primary">
+                      {team.eventsCount}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-text-muted">作成日</span>
+                    <span className="font-mono text-text-secondary text-xs">
+                      {formatDate(team.createdAt)}
+                    </span>
+                  </div>
                 </div>
 
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-500">作成日</span>
-                  <span className="font-medium text-gray-900">
-                    {formatDate(team.createdAt)}
-                  </span>
+                <div className="mt-4 pt-4 border-t border-border">
+                  <Button variant="ghost" size="sm" className="w-full">
+                    詳細を見る
+                  </Button>
                 </div>
-              </div>
-
-              <div className="mt-4 pt-4 border-t border-gray-100">
-                <button
-                  type="button"
-                  className="w-full text-center text-sm text-blue-600 hover:text-blue-700 font-medium"
-                >
-                  詳細を見る
-                </button>
-              </div>
-            </div>
+              </CardContent>
+            </Card>
           ))}
         </div>
       )}
+
+      {/* Terminal-style footer */}
+      <div className="text-center text-text-muted text-xs font-mono py-4">
+        <span className="text-hn-accent">$</span> teams --list --count=
+        {filteredTeams.length}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- /admin/events/[eventId] を HybridNext ダークテーマに移行
- /admin/marketplace ページを新規作成（問題マーケットプレイス）
- admin/layout.tsx にマーケットプレイスのナビゲーションを追加
- 全管理画面のテーマ・スタイルを統一

## Test plan
- [ ] `/admin` ダッシュボードが HybridNext ダークテーマで表示される
- [ ] `/admin/events` イベント一覧が HybridNext ダークテーマで表示される
- [ ] `/admin/events/[id]` イベント詳細が HybridNext ダークテーマで表示される
- [ ] `/admin/marketplace` 問題マーケットプレイスが正しく表示される
- [ ] `/admin/participants` 参加者管理が HybridNext ダークテーマで表示される
- [ ] `/admin/teams` チーム管理が HybridNext ダークテーマで表示される
- [ ] `/admin/settings` 設定ページが HybridNext ダークテーマで表示される
- [ ] `make before-commit` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)