### PR TITLE
fix(dev): tenant-management API を dev スクリプトに追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ start-dev-servers:
 	@echo "📋 アクセス先:"
 	@echo "  - Control Plane:      http://localhost:13000"
 	@echo "  - Application Plane:  http://localhost:13001"
+	@echo "  - Tenant API:         http://localhost:13004"
 	@echo "  - LocalStack:         http://localhost:4566"
 	@echo ""
 	@echo "💡 終了するには Ctrl+C を押してください"

--- a/backend/services/control-plane/tenant-management/.env.example
+++ b/backend/services/control-plane/tenant-management/.env.example
@@ -1,0 +1,17 @@
+# DynamoDB Configuration
+DYNAMODB_TABLE_NAME=TenkaCloud-dev
+DYNAMODB_ENDPOINT=http://localhost:4566
+
+# AWS Configuration (for LocalStack)
+AWS_REGION=ap-northeast-1
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+
+# Provisioning (disabled for local development)
+PROVISIONING_ENABLED=false
+
+# CORS Configuration
+ALLOWED_ORIGIN=http://localhost:13000
+
+# Environment
+NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "module": "index.ts",
   "type": "module",
   "scripts": {
-    "dev": "concurrently -n cp,app -c blue,green \"bun run --cwd apps/control-plane dev\" \"bun run --cwd apps/application-plane dev\"",
+    "dev": "concurrently -n cp,app,api -c blue,green,yellow \"bun run --cwd apps/control-plane dev\" \"bun run --cwd apps/application-plane dev\" \"bun run --cwd backend/services/control-plane/tenant-management dev\"",
     "dev:control-plane": "npm run dev --workspace=apps/control-plane",
     "dev:app": "npm run dev --workspace=apps/application-plane",
     "build:apps": "npm run build --workspaces --if-present",


### PR DESCRIPTION
## Summary
- `package.json` の `dev` スクリプトに tenant-management バックエンドを追加
- `Makefile` の起動メッセージに Tenant API エンドポイント（port 13004）を追加
- tenant-management 用の `.env.example` を作成（LocalStack 設定）

## Problem
`http://localhost:13000/dashboard/tenants` にアクセスすると `ECONNREFUSED` エラーが発生していた。
これは `make start` / `bun run dev` で tenant-management API（port 13004）が起動していなかったため。

## Solution
`dev` スクリプトに tenant-management サービスを追加し、フロントエンドと同時に起動するようにした。

## Test plan
- [x] `make before-commit` が成功することを確認
- [ ] `make start` で 3 つのサービス（control-plane, application-plane, tenant-management）が起動することを確認
- [ ] `http://localhost:13000/dashboard/tenants` が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tenant API service now available in local development environment on port 13004.

* **Development**
  * Updated development startup to run Tenant API alongside other services with improved service visibility.
  * Added local development configuration support for the new Tenant API service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->