### PR TITLE
refactor(application-plane): Admin 問題ページのバッジコンポーネントを統合

### DIFF
--- a/apps/application-plane/app/(admin)/admin/problems/[id]/deploy/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/problems/[id]/deploy/page.tsx
@@ -13,13 +13,13 @@ import { useEffect, useId, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Badge, Input, Select } from '@/components/ui';
+import { Badge, Input, ProblemTypeBadge, Select } from '@/components/ui';
 import {
-  getProblem,
-  getAWSRegions,
-  deployProblem,
-  getDeploymentStatus,
   deleteDeployment,
+  deployProblem,
+  getAWSRegions,
+  getDeploymentStatus,
+  getProblem,
 } from '@/lib/api/admin-problems';
 import type {
   AdminProblem,
@@ -559,9 +559,7 @@ export default function AdminProblemDeployPage() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
             <div>
               <p className="text-text-muted">タイプ</p>
-              <Badge variant={problem.type === 'gameday' ? 'primary' : 'info'}>
-                {problem.type === 'gameday' ? 'GameDay' : 'JAM'}
-              </Badge>
+              <ProblemTypeBadge type={problem.type} />
             </div>
             <div>
               <p className="text-text-muted">難易度</p>

--- a/apps/application-plane/app/(admin)/admin/problems/[id]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/problems/[id]/page.tsx
@@ -13,14 +13,15 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui';
-import { getProblem, deleteProblem } from '@/lib/api/admin-problems';
+import {
+  CategoryBadge,
+  DifficultyBadge,
+  getCategoryIcon,
+  ProblemTypeBadge,
+  ProviderBadge,
+} from '@/components/ui';
+import { deleteProblem, getProblem } from '@/lib/api/admin-problems';
 import type { AdminProblem } from '@/lib/api/admin-types';
-import type {
-  CloudProvider,
-  DifficultyLevel,
-  ProblemCategory,
-} from '@/lib/api/types';
 
 export default function AdminProblemDetailPage() {
   const params = useParams();
@@ -63,91 +64,6 @@ export default function AdminProblemDetailPage() {
     } catch (err) {
       console.error('Failed to delete problem:', err);
       alert('問題の削除に失敗しました');
-    }
-  };
-
-  const getDifficultyBadgeVariant = (
-    difficulty: DifficultyLevel
-  ): 'default' | 'success' | 'warning' | 'danger' | 'purple' => {
-    switch (difficulty) {
-      case 'easy':
-        return 'success';
-      case 'medium':
-        return 'warning';
-      case 'hard':
-        return 'danger';
-      case 'expert':
-        return 'purple';
-      default:
-        return 'default';
-    }
-  };
-
-  const getDifficultyLabel = (difficulty: DifficultyLevel): string => {
-    switch (difficulty) {
-      case 'easy':
-        return '初級';
-      case 'medium':
-        return '中級';
-      case 'hard':
-        return '上級';
-      case 'expert':
-        return 'エキスパート';
-      default:
-        return difficulty;
-    }
-  };
-
-  const getCategoryLabel = (category: ProblemCategory): string => {
-    switch (category) {
-      case 'architecture':
-        return 'アーキテクチャ';
-      case 'security':
-        return 'セキュリティ';
-      case 'cost':
-        return 'コスト最適化';
-      case 'performance':
-        return 'パフォーマンス';
-      case 'reliability':
-        return '信頼性';
-      case 'operations':
-        return '運用';
-      default:
-        return category;
-    }
-  };
-
-  const getCategoryIcon = (category: ProblemCategory): string => {
-    switch (category) {
-      case 'architecture':
-        return '🏗️';
-      case 'security':
-        return '🔒';
-      case 'cost':
-        return '💰';
-      case 'performance':
-        return '⚡';
-      case 'reliability':
-        return '🛡️';
-      case 'operations':
-        return '🔧';
-      default:
-        return '📦';
-    }
-  };
-
-  const getProviderLabel = (provider: CloudProvider): string => {
-    switch (provider) {
-      case 'aws':
-        return 'AWS';
-      case 'gcp':
-        return 'Google Cloud';
-      case 'azure':
-        return 'Azure';
-      case 'local':
-        return 'LocalStack';
-      default:
-        return provider;
     }
   };
 
@@ -433,17 +349,9 @@ export default function AdminProblemDetailPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex flex-wrap gap-2">
-                <Badge
-                  variant={problem.type === 'gameday' ? 'primary' : 'info'}
-                >
-                  {problem.type === 'gameday' ? 'GameDay' : 'JAM'}
-                </Badge>
-                <Badge variant={getDifficultyBadgeVariant(problem.difficulty)}>
-                  {getDifficultyLabel(problem.difficulty)}
-                </Badge>
-                <Badge variant="default">
-                  {getCategoryLabel(problem.category)}
-                </Badge>
+                <ProblemTypeBadge type={problem.type} />
+                <DifficultyBadge difficulty={problem.difficulty} />
+                <CategoryBadge category={problem.category} />
               </div>
 
               <div className="space-y-2 text-sm">
@@ -487,13 +395,7 @@ export default function AdminProblemDetailPage() {
                 <p className="text-sm text-text-muted mb-2">対応プロバイダー</p>
                 <div className="flex flex-wrap gap-2">
                   {problem.deployment.providers.map((provider) => (
-                    <Badge
-                      key={provider}
-                      variant="default"
-                      className="font-mono uppercase"
-                    >
-                      {getProviderLabel(provider)}
-                    </Badge>
+                    <ProviderBadge key={provider} provider={provider} />
                   ))}
                 </div>
               </div>

--- a/apps/application-plane/app/(admin)/admin/problems/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/problems/page.tsx
@@ -12,11 +12,18 @@ import { useEffect, useId, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Badge, Input, Select } from '@/components/ui';
-import { getProblems, deleteProblem } from '@/lib/api/admin-problems';
+import {
+  CategoryBadge,
+  DifficultyBadge,
+  getCategoryIcon,
+  Input,
+  ProblemTypeBadge,
+  ProviderBadge,
+  Select,
+} from '@/components/ui';
+import { deleteProblem, getProblems } from '@/lib/api/admin-problems';
 import type { AdminProblem, AdminProblemFilters } from '@/lib/api/admin-types';
 import type {
-  CloudProvider,
   DifficultyLevel,
   ProblemCategory,
   ProblemType,
@@ -74,91 +81,6 @@ export default function AdminProblemsPage() {
     } catch (err) {
       console.error('Failed to delete problem:', err);
       alert('問題の削除に失敗しました');
-    }
-  };
-
-  const getDifficultyBadgeVariant = (
-    difficulty: DifficultyLevel
-  ): 'default' | 'success' | 'warning' | 'danger' | 'purple' => {
-    switch (difficulty) {
-      case 'easy':
-        return 'success';
-      case 'medium':
-        return 'warning';
-      case 'hard':
-        return 'danger';
-      case 'expert':
-        return 'purple';
-      default:
-        return 'default';
-    }
-  };
-
-  const getDifficultyLabel = (difficulty: DifficultyLevel): string => {
-    switch (difficulty) {
-      case 'easy':
-        return '初級';
-      case 'medium':
-        return '中級';
-      case 'hard':
-        return '上級';
-      case 'expert':
-        return 'エキスパート';
-      default:
-        return difficulty;
-    }
-  };
-
-  const getCategoryLabel = (category: ProblemCategory): string => {
-    switch (category) {
-      case 'architecture':
-        return 'アーキテクチャ';
-      case 'security':
-        return 'セキュリティ';
-      case 'cost':
-        return 'コスト最適化';
-      case 'performance':
-        return 'パフォーマンス';
-      case 'reliability':
-        return '信頼性';
-      case 'operations':
-        return '運用';
-      default:
-        return category;
-    }
-  };
-
-  const getCategoryIcon = (category: ProblemCategory): string => {
-    switch (category) {
-      case 'architecture':
-        return '🏗️';
-      case 'security':
-        return '🔒';
-      case 'cost':
-        return '💰';
-      case 'performance':
-        return '⚡';
-      case 'reliability':
-        return '🛡️';
-      case 'operations':
-        return '🔧';
-      default:
-        return '📦';
-    }
-  };
-
-  const getProviderLabel = (provider: CloudProvider): string => {
-    switch (provider) {
-      case 'aws':
-        return 'AWS';
-      case 'gcp':
-        return 'Google Cloud';
-      case 'azure':
-        return 'Azure';
-      case 'local':
-        return 'LocalStack';
-      default:
-        return provider;
     }
   };
 
@@ -411,29 +333,11 @@ export default function AdminProblemsPage() {
                     </p>
 
                     <div className="flex flex-wrap gap-2 mb-4">
-                      <Badge
-                        variant={
-                          problem.type === 'gameday' ? 'primary' : 'info'
-                        }
-                      >
-                        {problem.type === 'gameday' ? 'GameDay' : 'JAM'}
-                      </Badge>
-                      <Badge
-                        variant={getDifficultyBadgeVariant(problem.difficulty)}
-                      >
-                        {getDifficultyLabel(problem.difficulty)}
-                      </Badge>
-                      <Badge variant="default">
-                        {getCategoryLabel(problem.category)}
-                      </Badge>
+                      <ProblemTypeBadge type={problem.type} />
+                      <DifficultyBadge difficulty={problem.difficulty} />
+                      <CategoryBadge category={problem.category} />
                       {problem.deployment.providers.map((provider) => (
-                        <Badge
-                          key={provider}
-                          variant="default"
-                          className="font-mono uppercase"
-                        >
-                          {getProviderLabel(provider)}
-                        </Badge>
+                        <ProviderBadge key={provider} provider={provider} />
                       ))}
                     </div>
 

--- a/apps/application-plane/components/ui/badge.tsx
+++ b/apps/application-plane/components/ui/badge.tsx
@@ -195,3 +195,82 @@ export function ProblemTypeBadge({ type }: { type: string }) {
     </Badge>
   );
 }
+
+// Problem Category Badge
+export function CategoryBadge({ category }: { category: string }) {
+  const categoryConfig: Record<string, { label: string; icon: string }> = {
+    architecture: { label: 'アーキテクチャ', icon: '🏗️' },
+    security: { label: 'セキュリティ', icon: '🔒' },
+    cost: { label: 'コスト最適化', icon: '💰' },
+    performance: { label: 'パフォーマンス', icon: '⚡' },
+    reliability: { label: '信頼性', icon: '🛡️' },
+    operations: { label: '運用', icon: '🔧' },
+  };
+
+  const config = categoryConfig[category] || { label: category, icon: '📦' };
+
+  return (
+    <Badge variant="default" badgeStyle="subtle">
+      {config.label}
+    </Badge>
+  );
+}
+
+// Category Icon (for standalone use)
+export function getCategoryIcon(category: string): string {
+  const icons: Record<string, string> = {
+    architecture: '🏗️',
+    security: '🔒',
+    cost: '💰',
+    performance: '⚡',
+    reliability: '🛡️',
+    operations: '🔧',
+  };
+  return icons[category] || '📦';
+}
+
+// Category Label (for standalone use)
+export function getCategoryLabel(category: string): string {
+  const labels: Record<string, string> = {
+    architecture: 'アーキテクチャ',
+    security: 'セキュリティ',
+    cost: 'コスト最適化',
+    performance: 'パフォーマンス',
+    reliability: '信頼性',
+    operations: '運用',
+  };
+  return labels[category] || category;
+}
+
+// Cloud Provider Badge
+export function ProviderBadge({ provider }: { provider: string }) {
+  const providerConfig: Record<string, string> = {
+    aws: 'AWS',
+    gcp: 'Google Cloud',
+    azure: 'Azure',
+    local: 'LocalStack',
+  };
+
+  const label = providerConfig[provider] || provider;
+
+  return (
+    <Badge
+      variant="default"
+      badgeStyle="subtle"
+      className="font-mono uppercase"
+    >
+      {label}
+    </Badge>
+  );
+}
+
+// Provider Label (for standalone use)
+export function getProviderLabel(provider: string): string {
+  const labels: Record<string, string> = {
+    aws: 'AWS',
+    gcp: 'Google Cloud',
+    azure: 'Azure',
+    local: 'LocalStack',
+  };
+  return labels[provider] || provider;
+}

--- a/apps/application-plane/components/ui/index.ts
+++ b/apps/application-plane/components/ui/index.ts
@@ -15,9 +15,14 @@ export {
 } from './alert-dialog';
 export {
   Badge,
+  CategoryBadge,
   DifficultyBadge,
   EventStatusBadge,
+  getCategoryIcon,
+  getCategoryLabel,
+  getProviderLabel,
   ProblemTypeBadge,
+  ProviderBadge,
 } from './badge';
 export { Button } from './button';
 export { Card, CardContent, CardFooter, CardHeader } from './card';


### PR DESCRIPTION
## Summary
- 3つの Admin 問題ページ (一覧、詳細、デプロイ) に重複していたヘルパー関数を共通の Badge コンポーネントに統合
- 約 112 行の重複コードを削減し、保守性を向上

### 追加された共通コンポーネント
- `CategoryBadge` - カテゴリ表示バッジ
- `ProviderBadge` - クラウドプロバイダーバッジ
- `getCategoryIcon()` - カテゴリアイコン取得
- `getCategoryLabel()` - カテゴリラベル取得
- `getProviderLabel()` - プロバイダーラベル取得

## Test plan
- [x] `make before-commit` がすべてパス (lint, format, typecheck, test, build)
- [x] テストカバレッジ 100% 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency for problem metadata displays across admin pages with unified badge components for problem types, difficulty levels, categories, and providers.

* **Refactor**
  * Consolidated badge rendering logic to use dedicated, reusable UI components for cleaner and more maintainable code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->