### PR TITLE
refactor(application-plane): Admin ページのアイコンとバッジを統合

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/page.tsx
@@ -7,6 +7,14 @@
 
 'use client';
 
+import {
+  Calendar,
+  ClipboardList,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useId, useState } from 'react';
 import {
@@ -73,7 +81,7 @@ export default function AdminEventsPage() {
         actions={
           <Button asChild>
             <Link href="/admin/events/new">
-              <PlusIcon className="w-5 h-5 mr-2" />
+              <Plus className="w-5 h-5 mr-2" />
               新規イベント
             </Link>
           </Button>
@@ -203,15 +211,15 @@ function EventCard({ event }: EventCardProps) {
             </div>
             <div className="flex items-center gap-6 text-sm text-text-muted">
               <span className="flex items-center gap-1">
-                <CalendarIcon className="w-4 h-4" />
+                <Calendar className="w-4 h-4" />
                 {formatDateTime(event.startTime)}
               </span>
               <span className="flex items-center gap-1">
-                <UsersIcon className="w-4 h-4" />
+                <Users className="w-4 h-4" />
                 {event.participantCount} / {event.maxParticipants}
               </span>
               <span className="flex items-center gap-1">
-                <ClipboardIcon className="w-4 h-4" />
+                <ClipboardList className="w-4 h-4" />
                 {event.problemCount} 問
               </span>
             </div>
@@ -219,7 +227,7 @@ function EventCard({ event }: EventCardProps) {
           <div className="flex items-center gap-2">
             <Button variant="secondary" size="sm" asChild>
               <Link href={`/admin/events/${event.id}`}>
-                <EditIcon className="w-4 h-4 mr-1" />
+                <Pencil className="w-4 h-4 mr-1" />
                 編集
               </Link>
             </Button>
@@ -231,126 +239,11 @@ function EventCard({ event }: EventCardProps) {
                 // TODO: Implement delete
               }}
             >
-              <TrashIcon className="w-4 h-4" />
+              <Trash2 className="w-4 h-4" />
             </Button>
           </div>
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-// Icon components (decorative, hidden from screen readers)
-function PlusIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M12 4v16m8-8H4"
-      />
-    </svg>
-  );
-}
-
-function CalendarIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-      />
-    </svg>
-  );
-}
-
-function UsersIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-      />
-    </svg>
-  );
-}
-
-function ClipboardIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-      />
-    </svg>
-  );
-}
-
-function EditIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-      />
-    </svg>
-  );
-}
-
-function TrashIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-      />
-    </svg>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/page.tsx
@@ -7,12 +7,21 @@
 
 'use client';
 
+import {
+  ChevronRight,
+  Clock,
+  Inbox,
+  Plus,
+  Settings,
+  UserPlus,
+  Zap,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { useTenantOptional } from '@/lib/tenant';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useTenantOptional } from '@/lib/tenant';
 
 interface DashboardStats {
   activeEvents: number;
@@ -71,19 +80,7 @@ function StatCard({ title, value, icon, href, accentColor }: StatCardProps) {
           className="text-sm text-hn-accent hover:text-hn-accent-bright mt-4 inline-flex items-center gap-1 group-hover:gap-2 transition-all"
         >
           詳細を見る
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
+          <ChevronRight className="w-4 h-4" />
         </Link>
       </CardContent>
     </Card>
@@ -268,19 +265,7 @@ export default function AdminDashboardPage() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-hn-accent"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 10V3L4 14h7v7l9-11h-7z"
-              />
-            </svg>
+            <Zap className="w-5 h-5 text-hn-accent" />
             クイックアクション
           </CardTitle>
         </CardHeader>
@@ -288,61 +273,19 @@ export default function AdminDashboardPage() {
           <div className="flex flex-wrap gap-4">
             <Button asChild>
               <Link href="/admin/events/new">
-                <svg
-                  className="w-5 h-5 mr-2"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
+                <Plus className="w-5 h-5 mr-2" />
                 新規イベント作成
               </Link>
             </Button>
             <Button variant="secondary" asChild>
               <Link href="/admin/participants/invite">
-                <svg
-                  className="w-5 h-5 mr-2"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
-                  />
-                </svg>
+                <UserPlus className="w-5 h-5 mr-2" />
                 参加者を招待
               </Link>
             </Button>
             <Button variant="ghost" asChild>
               <Link href="/admin/settings">
-                <svg
-                  className="w-5 h-5 mr-2"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
+                <Settings className="w-5 h-5 mr-2" />
                 設定
               </Link>
             </Button>
@@ -354,19 +297,7 @@ export default function AdminDashboardPage() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-hn-accent"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <Clock className="w-5 h-5 text-hn-accent" />
             最近のアクティビティ
           </CardTitle>
         </CardHeader>
@@ -385,19 +316,7 @@ export default function AdminDashboardPage() {
             </div>
           ) : recentActivities.length === 0 ? (
             <div className="text-center py-8 text-text-muted">
-              <svg
-                className="w-12 h-12 mx-auto mb-4 text-text-muted/50"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
-                />
-              </svg>
+              <Inbox className="w-12 h-12 mx-auto mb-4 text-text-muted/50" />
               <p className="font-mono">アクティビティはありません</p>
             </div>
           ) : (

--- a/apps/application-plane/app/(admin)/admin/participants/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/participants/page.tsx
@@ -7,6 +7,7 @@
 
 'use client';
 
+import { UserPlus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import {
   AdminPageFooter,
@@ -15,13 +16,10 @@ import {
   SearchInput,
   StatCard,
 } from '@/components/admin';
-import { Badge, Skeleton } from '@/components/ui';
+import { Badge, ParticipantStatusBadge, Skeleton } from '@/components/ui';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import type {
-  AdminParticipant,
-  ParticipantStatus,
-} from '@/lib/api/admin-types';
+import type { AdminParticipant } from '@/lib/api/admin-types';
 import { formatDate } from '@/lib/utils';
 
 export default function AdminParticipantsPage() {
@@ -85,7 +83,7 @@ export default function AdminParticipantsPage() {
         title="参加者管理"
         actions={
           <Button>
-            <UserPlusIcon className="w-5 h-5 mr-2" />
+            <UserPlus className="w-5 h-5 mr-2" />
             参加者を招待
           </Button>
         }
@@ -196,7 +194,11 @@ function ParticipantCard({ participant }: ParticipantCardProps) {
                 <span className="font-medium text-text-primary">
                   {participant.displayName}
                 </span>
-                <ParticipantStatusBadge status={participant.status} />
+                <ParticipantStatusBadge
+                  status={
+                    participant.status as 'active' | 'inactive' | 'banned'
+                  }
+                />
                 {participant.role === 'admin' && (
                   <Badge variant="default">管理者</Badge>
                 )}
@@ -245,46 +247,5 @@ function ParticipantStat({
       <div className="text-sm text-text-muted">{label}</div>
       <div className={`font-mono ${valueClassName}`}>{value}</div>
     </div>
-  );
-}
-
-interface ParticipantStatusBadgeProps {
-  status: ParticipantStatus;
-}
-
-function ParticipantStatusBadge({ status }: ParticipantStatusBadgeProps) {
-  const config: Record<
-    ParticipantStatus,
-    { variant: 'success' | 'warning' | 'danger'; label: string }
-  > = {
-    active: { variant: 'success', label: 'アクティブ' },
-    inactive: { variant: 'warning', label: '非アクティブ' },
-    banned: { variant: 'danger', label: 'BAN' },
-  };
-
-  const { variant, label } = config[status] || {
-    variant: 'default' as const,
-    label: status,
-  };
-
-  return <Badge variant={variant}>{label}</Badge>;
-}
-
-function UserPlusIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
-      />
-    </svg>
   );
 }

--- a/apps/application-plane/components/ui/badge.tsx
+++ b/apps/application-plane/components/ui/badge.tsx
@@ -274,3 +274,37 @@ export function getProviderLabel(provider: string): string {
   };
   return labels[provider] || provider;
 }
+
+// Participant Status Badge
+export type ParticipantStatus = 'active' | 'inactive' | 'banned';
+
+export function ParticipantStatusBadge({
+  status,
+}: {
+  status: ParticipantStatus;
+}) {
+  const config: Record<
+    ParticipantStatus,
+    { variant: BadgeVariant; badgeStyle: BadgeStyle; label: string }
+  > = {
+    active: { variant: 'success', badgeStyle: 'subtle', label: 'アクティブ' },
+    inactive: {
+      variant: 'warning',
+      badgeStyle: 'subtle',
+      label: '非アクティブ',
+    },
+    banned: { variant: 'danger', badgeStyle: 'subtle', label: 'BAN' },
+  };
+
+  const { variant, badgeStyle, label } = config[status] || {
+    variant: 'default' as BadgeVariant,
+    badgeStyle: 'subtle' as BadgeStyle,
+    label: status,
+  };
+
+  return (
+    <Badge variant={variant} badgeStyle={badgeStyle}>
+      {label}
+    </Badge>
+  );
+}

--- a/apps/application-plane/components/ui/index.ts
+++ b/apps/application-plane/components/ui/index.ts
@@ -21,9 +21,11 @@ export {
   getCategoryIcon,
   getCategoryLabel,
   getProviderLabel,
+  ParticipantStatusBadge,
   ProblemTypeBadge,
   ProviderBadge,
 } from './badge';
+export type { ParticipantStatus } from './badge';
 export { Button } from './button';
 export { Card, CardContent, CardFooter, CardHeader } from './card';
 export { ErrorState, getErrorMessage, getErrorType } from './error-state';


### PR DESCRIPTION
## Summary
- `ParticipantStatusBadge` を共通コンポーネントとして追加
- 3つの Admin ページ (events, participants, dashboard) でインライン SVG アイコンを lucide-react に置き換え
- 約 191 行の重複コードを削減

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `components/ui/badge.tsx` | `ParticipantStatusBadge` 追加 (+34行) |
| `components/ui/index.ts` | 新規エクスポート追加 (+2行) |
| `admin/events/page.tsx` | インライン SVG を lucide-react に置き換え |
| `admin/participants/page.tsx` | 共通バッジコンポーネント使用 |
| `admin/page.tsx` | インライン SVG を lucide-react に置き換え |

## Test plan
- [x] `make before-commit` がすべてパス (lint, format, typecheck, test, build)
- [x] テストカバレッジ 100% 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized icons across admin dashboard and events pages for improved visual consistency.
  * Consolidated participant status badge component into shared UI library for better code reusability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->