### PR TITLE
fix(infrastructure): LocalStack で DynamoDB Stream trigger を無効化

### DIFF
--- a/infrastructure/terraform/environments/local/main.tf
+++ b/infrastructure/terraform/environments/local/main.tf
@@ -80,6 +80,10 @@ module "provisioning_lambda" {
   event_bus_name      = module.eventbridge.event_bus_name
   lambda_zip_path     = "${path.module}/../../../../backend/services/control-plane/provisioning/lambda.zip"
 
+  # Disable DynamoDB Stream trigger for LocalStack (unstable)
+  # Provisioning is triggered via API instead
+  enable_stream_trigger = false
+
   tags = {
     Environment = "local"
   }


### PR DESCRIPTION
## Summary
- LocalStack 環境で DynamoDB Stream Event Source Mapping の作成時に "Stream not found" エラーが発生する問題を修正
- LocalStack では Stream ARN が Terraform state と不整合になる既知の問題があるため、`enable_stream_trigger = false` を設定

## Test plan
- [ ] `make start` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local environment provisioning configuration to use API-triggered activation instead of stream-based activation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->