### PR TITLE
feat(gameday): チーム登録・Dashboard API を実装

### DIFF
--- a/backend/services/application-plane/gameday-service/src/api/admin.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.test.ts
@@ -30,7 +30,21 @@ const mockGameController = vi.hoisted(() => {
   };
 });
 
+const mockDashboardService = vi.hoisted(() => {
+  class TeamAlreadyExistsError extends Error {
+    constructor(teamId: string) {
+      super(`チームは既に登録済みです: ${teamId}`);
+      this.name = 'TeamAlreadyExistsError';
+    }
+  }
+  return {
+    registerTeam: vi.fn(),
+    TeamAlreadyExistsError,
+  };
+});
+
 vi.mock('../services/game-controller', () => mockGameController);
+vi.mock('../services/dashboard-service', () => mockDashboardService);
 
 import { adminRoutes } from './admin';
 
@@ -616,6 +630,107 @@ describe('管理者 API', () => {
         expect(res.status).toBe(StatusCodes.BAD_REQUEST);
         const body = await res.json();
         expect(body.error).toBe('JSON の解析に失敗しました');
+      });
+    });
+  });
+
+  // === チーム登録 ===
+  describe('POST /teams/register', () => {
+    describe('有効なリクエストの場合', () => {
+      it('CREATED を返しチーム情報を含むべき', async () => {
+        const team = {
+          eventId: 'event-1',
+          teamId: 'team-1',
+          teamName: 'チームA',
+          score: 0,
+          isHealthy: true,
+          websiteUrl: 'https://example.com',
+          apiUrl: 'https://api.example.com',
+        };
+        mockDashboardService.registerTeam.mockResolvedValue(team);
+
+        const res = await app.request('/teams/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            eventId: 'event-1',
+            teamId: 'team-1',
+            teamName: 'チームA',
+            websiteUrl: 'https://example.com',
+            apiUrl: 'https://api.example.com',
+          }),
+        });
+
+        expect(res.status).toBe(StatusCodes.CREATED);
+        const body = await res.json();
+        expect(body.teamId).toBe('team-1');
+        expect(body.teamName).toBe('チームA');
+      });
+    });
+
+    describe('重複チーム登録の場合', () => {
+      it('CONFLICT を返すべき', async () => {
+        mockDashboardService.registerTeam.mockRejectedValue(
+          new mockDashboardService.TeamAlreadyExistsError('team-1')
+        );
+
+        const res = await app.request('/teams/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            eventId: 'event-1',
+            teamId: 'team-1',
+            teamName: 'チームA',
+          }),
+        });
+
+        expect(res.status).toBe(StatusCodes.CONFLICT);
+        const body = await res.json();
+        expect(body.error).toContain('既に登録済み');
+      });
+    });
+
+    describe('必須フィールドが不足している場合', () => {
+      it('BAD_REQUEST を返すべき', async () => {
+        const res = await app.request('/teams/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ eventId: 'event-1' }),
+        });
+        expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      });
+    });
+
+    describe('不正な JSON の場合', () => {
+      it('BAD_REQUEST を返しエラーメッセージを含むべき', async () => {
+        const res = await app.request('/teams/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: 'invalid-json',
+        });
+        expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+        const body = await res.json();
+        expect(body.error).toBe('JSON の解析に失敗しました');
+      });
+    });
+
+    describe('予期しないエラーが発生した場合', () => {
+      it('INTERNAL_SERVER_ERROR を返すべき', async () => {
+        mockDashboardService.registerTeam.mockRejectedValue(
+          new Error('DB接続エラー')
+        );
+
+        const res = await app.request('/teams/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            eventId: 'event-1',
+            teamId: 'team-1',
+            teamName: 'チームA',
+          }),
+        });
+
+        expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
       });
     });
   });

--- a/backend/services/application-plane/gameday-service/src/api/admin.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.ts
@@ -5,6 +5,7 @@ import {
   startGameSchema,
   faultInjectionSchema,
   seedAttacksSchema,
+  registerTeamSchema,
 } from '../schemas';
 import {
   startGame,
@@ -19,6 +20,10 @@ import {
   GameNotFoundError,
   ConcurrentModificationError,
 } from '../services/game-controller';
+import {
+  registerTeam,
+  TeamAlreadyExistsError,
+} from '../services/dashboard-service';
 
 export const adminRoutes = new Hono();
 
@@ -189,6 +194,33 @@ adminRoutes.get('/attack-logs', async (c) => {
   }
   const logs = await listAttackLogs(eventId);
   return c.json({ logs }, StatusCodes.OK);
+});
+
+// チーム登録
+adminRoutes.post('/teams/register', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (body === null) {
+    return c.json(
+      { error: 'JSON の解析に失敗しました' },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  const parsed = registerTeamSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: '無効なリクエスト', details: parsed.error.issues },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  try {
+    const result = await registerTeam(parsed.data);
+    return c.json(result, StatusCodes.CREATED);
+  } catch (error) {
+    if (error instanceof TeamAlreadyExistsError) {
+      return c.json({ error: error.message }, StatusCodes.CONFLICT);
+    }
+    throw error;
+  }
 });
 
 // 攻撃カタログシード

--- a/backend/services/application-plane/gameday-service/src/api/participant.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.test.ts
@@ -108,7 +108,31 @@ const mockParticipantService = vi.hoisted(() => {
   };
 });
 
+const mockDashboardService = vi.hoisted(() => {
+  class BlackoutActiveError extends Error {
+    constructor() {
+      super('ブラックアウト中はリーダーボードを閲覧できません');
+      this.name = 'BlackoutActiveError';
+    }
+  }
+  class TeamNotFoundError extends Error {
+    constructor(teamId: string) {
+      super(`チームが見つかりません: ${teamId}`);
+      this.name = 'TeamNotFoundError';
+    }
+  }
+  return {
+    updateTeamUrl: vi.fn(),
+    getLeaderboard: vi.fn(),
+    getAttackStatistics: vi.fn(),
+    getTeamDashboard: vi.fn(),
+    BlackoutActiveError,
+    TeamNotFoundError,
+  };
+});
+
 vi.mock('../services/participant-service', () => mockParticipantService);
+vi.mock('../services/dashboard-service', () => mockDashboardService);
 
 import { participantRoutes } from './participant';
 
@@ -943,6 +967,165 @@ describe('プレーヤー API', () => {
     it('eventId なしで BAD_REQUEST を返すべき', async () => {
       const res = await app.request('/voting/results');
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === ダッシュボード: リーダーボード ===
+  describe('GET /dashboard/leaderboard', () => {
+    it('正常系でスコア降順の一覧を返すべき', async () => {
+      mockDashboardService.getLeaderboard.mockResolvedValue([
+        { teamId: 'team-2', score: 5000 },
+        { teamId: 'team-1', score: 3000 },
+      ]);
+      const res = await app.request('/dashboard/leaderboard?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.leaderboard).toHaveLength(2);
+      expect(body.leaderboard[0].teamId).toBe('team-2');
+    });
+
+    it('eventId なしで BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/dashboard/leaderboard');
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('ブラックアウト中で FORBIDDEN を返すべき', async () => {
+      mockDashboardService.getLeaderboard.mockRejectedValue(
+        new mockDashboardService.BlackoutActiveError()
+      );
+      const res = await app.request('/dashboard/leaderboard?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      const body = await res.json();
+      expect(body.error).toContain('ブラックアウト');
+    });
+
+    it('予期しないエラーで INTERNAL_SERVER_ERROR を返すべき', async () => {
+      mockDashboardService.getLeaderboard.mockRejectedValue(
+        new Error('DB接続エラー')
+      );
+      const res = await app.request('/dashboard/leaderboard?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  // === ダッシュボード: 攻撃統計 ===
+  describe('GET /dashboard/attack-stats', () => {
+    it('正常系で OK を返すべき', async () => {
+      mockDashboardService.getAttackStatistics.mockResolvedValue([
+        {
+          teamId: 'team-1',
+          attacksSent: 2,
+          attacksReceived: 1,
+          successRate: 0.5,
+        },
+      ]);
+      const res = await app.request('/dashboard/attack-stats?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.stats).toHaveLength(1);
+    });
+
+    it('eventId なしで BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/dashboard/attack-stats');
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === ダッシュボード: チーム詳細 ===
+  describe('GET /dashboard/team', () => {
+    it('正常系で OK を返すべき', async () => {
+      mockDashboardService.getTeamDashboard.mockResolvedValue({
+        team: { teamId: 'team-1', score: 5000 },
+        recentHealthChecks: [],
+        attackHistory: [],
+      });
+      const res = await app.request(
+        '/dashboard/team?eventId=event-1&teamId=team-1'
+      );
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.team.teamId).toBe('team-1');
+    });
+
+    it('チームが存在しない場合 NOT_FOUND を返すべき', async () => {
+      mockDashboardService.getTeamDashboard.mockResolvedValue(null);
+      const res = await app.request(
+        '/dashboard/team?eventId=event-1&teamId=nonexistent'
+      );
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
+    });
+
+    it('パラメータ不足で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/dashboard/team');
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === チーム URL 更新 ===
+  describe('POST /teams/update-url', () => {
+    it('正常系で OK を返すべき', async () => {
+      mockDashboardService.updateTeamUrl.mockResolvedValue(undefined);
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          websiteUrl: 'https://new.example.com',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('バリデーション失敗で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('不正な JSON で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      const body = await res.json();
+      expect(body.error).toBe('JSON の解析に失敗しました');
+    });
+
+    it('不正な URL で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          websiteUrl: 'not-a-url',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('チームが存在しない場合 NOT_FOUND を返すべき', async () => {
+      mockDashboardService.updateTeamUrl.mockRejectedValue(
+        new mockDashboardService.TeamNotFoundError('team-1')
+      );
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          websiteUrl: 'https://example.com',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
     });
   });
 });

--- a/backend/services/application-plane/gameday-service/src/api/participant.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.ts
@@ -9,6 +9,7 @@ import {
   requestAllianceSchema,
   allianceActionSchema,
   voteSchema,
+  updateTeamUrlSchema,
 } from '../schemas';
 import {
   getAttackCatalog,
@@ -38,6 +39,14 @@ import {
   AttackAlreadyPurchasedError,
   VoteAlreadyExistsError,
 } from '../services/participant-service';
+import {
+  updateTeamUrl,
+  getLeaderboard,
+  getAttackStatistics,
+  getTeamDashboard,
+  BlackoutActiveError,
+  TeamNotFoundError as DashboardTeamNotFoundError,
+} from '../services/dashboard-service';
 
 export const participantRoutes = new Hono();
 
@@ -432,4 +441,79 @@ participantRoutes.get('/voting/results', async (c) => {
   }
   const results = await getVotingResults(eventId);
   return c.json({ results }, StatusCodes.OK);
+});
+
+// === ダッシュボード ===
+
+// リーダーボード
+participantRoutes.get('/dashboard/leaderboard', async (c) => {
+  const eventId = c.req.query('eventId');
+  if (!eventId) {
+    return c.json({ error: 'eventId は必須です' }, StatusCodes.BAD_REQUEST);
+  }
+  try {
+    const leaderboard = await getLeaderboard(eventId);
+    return c.json({ leaderboard }, StatusCodes.OK);
+  } catch (error) {
+    if (error instanceof BlackoutActiveError) {
+      return c.json({ error: error.message }, StatusCodes.FORBIDDEN);
+    }
+    throw error;
+  }
+});
+
+// 攻撃統計
+participantRoutes.get('/dashboard/attack-stats', async (c) => {
+  const eventId = c.req.query('eventId');
+  if (!eventId) {
+    return c.json({ error: 'eventId は必須です' }, StatusCodes.BAD_REQUEST);
+  }
+  const stats = await getAttackStatistics(eventId);
+  return c.json({ stats }, StatusCodes.OK);
+});
+
+// チーム詳細ダッシュボード
+participantRoutes.get('/dashboard/team', async (c) => {
+  const eventId = c.req.query('eventId');
+  const teamId = c.req.query('teamId');
+  if (!eventId || !teamId) {
+    return c.json(
+      { error: 'eventId と teamId は必須です' },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  const dashboard = await getTeamDashboard(eventId, teamId);
+  if (!dashboard) {
+    return c.json({ error: 'チームが見つかりません' }, StatusCodes.NOT_FOUND);
+  }
+  return c.json(dashboard, StatusCodes.OK);
+});
+
+// === チーム URL 更新 ===
+
+participantRoutes.post('/teams/update-url', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (body === null) {
+    return c.json(
+      { error: 'JSON の解析に失敗しました' },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  const parsed = updateTeamUrlSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: '無効なリクエスト', details: parsed.error.issues },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  const { eventId, teamId, websiteUrl, apiUrl } = parsed.data;
+  try {
+    await updateTeamUrl(eventId, teamId, { websiteUrl, apiUrl });
+    return c.json({ success: true }, StatusCodes.OK);
+  } catch (error) {
+    if (error instanceof DashboardTeamNotFoundError) {
+      return c.json({ error: error.message }, StatusCodes.NOT_FOUND);
+    }
+    throw error;
+  }
 });

--- a/backend/services/application-plane/gameday-service/src/repositories/gameday-repository.ts
+++ b/backend/services/application-plane/gameday-service/src/repositories/gameday-repository.ts
@@ -84,6 +84,8 @@ interface TeamStateItem {
   teamName: string;
   score: number;
   isHealthy: boolean;
+  websiteUrl: string | null;
+  apiUrl: string | null;
   CreatedAt: string;
   UpdatedAt: string;
 }
@@ -123,6 +125,8 @@ export interface TeamState {
   teamName: string;
   score: number;
   isHealthy: boolean;
+  websiteUrl: string | null;
+  apiUrl: string | null;
 }
 
 function toTeamState(item: TeamStateItem): TeamState {
@@ -132,6 +136,8 @@ function toTeamState(item: TeamStateItem): TeamState {
     teamName: item.teamName,
     score: item.score,
     isHealthy: item.isHealthy,
+    websiteUrl: item.websiteUrl ?? null,
+    apiUrl: item.apiUrl ?? null,
   };
 }
 
@@ -160,6 +166,13 @@ export class VoteAlreadyExistsError extends Error {
   constructor() {
     super('既に投票済みです');
     this.name = 'VoteAlreadyExistsError';
+  }
+}
+
+export class TeamAlreadyExistsError extends Error {
+  constructor(teamId: string) {
+    super(`チームは既に登録済みです: ${teamId}`);
+    this.name = 'TeamAlreadyExistsError';
   }
 }
 
@@ -353,6 +366,120 @@ export class GamedayRepository {
       }
       throw error;
     }
+  }
+
+  // === チーム登録 ===
+
+  async createTeam(input: {
+    eventId: string;
+    teamId: string;
+    teamName: string;
+    websiteUrl?: string;
+    apiUrl?: string;
+  }): Promise<TeamState> {
+    const client = getDocClient();
+    const tableName = getTableName();
+    const now = new Date().toISOString();
+
+    const item: TeamStateItem = {
+      PK: buildGamedayPK(input.eventId),
+      SK: buildTeamSK(input.teamId),
+      EntityType: 'TEAM',
+      eventId: input.eventId,
+      teamId: input.teamId,
+      teamName: input.teamName,
+      score: 0,
+      isHealthy: true,
+      websiteUrl: input.websiteUrl ?? null,
+      apiUrl: input.apiUrl ?? null,
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    try {
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: item,
+          ConditionExpression:
+            'attribute_not_exists(PK) AND attribute_not_exists(SK)',
+        })
+      );
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        throw new TeamAlreadyExistsError(input.teamId);
+      }
+      throw error;
+    }
+
+    return toTeamState(item);
+  }
+
+  async updateTeamUrls(
+    eventId: string,
+    teamId: string,
+    urls: { websiteUrl?: string; apiUrl?: string }
+  ): Promise<void> {
+    const client = getDocClient();
+    const tableName = getTableName();
+    const now = new Date().toISOString();
+
+    const expressionParts: string[] = ['UpdatedAt = :now'];
+    const expressionValues: Record<string, unknown> = { ':now': now };
+
+    if (urls.websiteUrl !== undefined) {
+      expressionParts.push('websiteUrl = :wUrl');
+      expressionValues[':wUrl'] = urls.websiteUrl;
+    }
+    if (urls.apiUrl !== undefined) {
+      expressionParts.push('apiUrl = :aUrl');
+      expressionValues[':aUrl'] = urls.apiUrl;
+    }
+
+    try {
+      await client.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: {
+            PK: buildGamedayPK(eventId),
+            SK: buildTeamSK(teamId),
+          },
+          UpdateExpression: `SET ${expressionParts.join(', ')}`,
+          ExpressionAttributeValues: expressionValues,
+          ConditionExpression: 'attribute_exists(PK) AND attribute_exists(SK)',
+        })
+      );
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async updateTeamHealthy(
+    eventId: string,
+    teamId: string,
+    isHealthy: boolean
+  ): Promise<void> {
+    const client = getDocClient();
+    const tableName = getTableName();
+    const now = new Date().toISOString();
+
+    await client.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: {
+          PK: buildGamedayPK(eventId),
+          SK: buildTeamSK(teamId),
+        },
+        UpdateExpression: 'SET isHealthy = :h, UpdatedAt = :now',
+        ExpressionAttributeValues: {
+          ':h': isHealthy,
+          ':now': now,
+        },
+      })
+    );
   }
 
   // === 攻撃ログ ===
@@ -986,6 +1113,43 @@ export class GamedayRepository {
     } while (exclusiveStartKey);
 
     return allItems;
+  }
+
+  async createHealthCheck(input: {
+    eventId: string;
+    teamId: string;
+    checkType: 'website' | 'api';
+    isHealthy: boolean;
+    statusCode: number | null;
+    responseTimeMs: number | null;
+  }): Promise<HealthCheckResult> {
+    const client = getDocClient();
+    const tableName = getTableName();
+    const id = ulid();
+    const now = new Date().toISOString();
+
+    const item = {
+      PK: buildGamedayPK(input.eventId),
+      SK: buildHealthCheckSK(input.teamId, now),
+      EntityType: 'HEALTHCHECK',
+      id,
+      eventId: input.eventId,
+      teamId: input.teamId,
+      checkType: input.checkType,
+      isHealthy: input.isHealthy,
+      statusCode: input.statusCode,
+      responseTimeMs: input.responseTimeMs,
+      createdAt: now,
+    };
+
+    await client.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: item,
+      })
+    );
+
+    return item as unknown as HealthCheckResult;
   }
 
   // === 投票 ===

--- a/backend/services/application-plane/gameday-service/src/schemas/index.ts
+++ b/backend/services/application-plane/gameday-service/src/schemas/index.ts
@@ -23,6 +23,23 @@ export const seedAttacksSchema = z.object({
   eventId: z.string().min(1),
 });
 
+// 管理者: チーム登録
+export const registerTeamSchema = z.object({
+  eventId: z.string().min(1),
+  teamId: z.string().min(1),
+  teamName: z.string().min(1),
+  websiteUrl: z.string().url().optional(),
+  apiUrl: z.string().url().optional(),
+});
+
+// プレーヤー: チーム URL 更新
+export const updateTeamUrlSchema = z.object({
+  eventId: z.string().min(1),
+  teamId: z.string().min(1),
+  websiteUrl: z.string().url().optional(),
+  apiUrl: z.string().url().optional(),
+});
+
 // プレーヤー: 攻撃購入
 export const purchaseAttackSchema = z.object({
   eventId: z.string().min(1),

--- a/backend/services/application-plane/gameday-service/src/services/dashboard-service.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/dashboard-service.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRepository = vi.hoisted(() => ({
+  createTeam: vi.fn(),
+  updateTeamUrls: vi.fn(),
+  getGameState: vi.fn(),
+  listTeams: vi.fn(),
+  listAttackLogs: vi.fn(),
+  getTeamState: vi.fn(),
+  listHealthChecks: vi.fn(),
+}));
+
+vi.mock('../lib/dynamodb', () => ({
+  gamedayRepository: mockRepository,
+}));
+
+// TeamAlreadyExistsError は実際のクラスを使うためモック不要
+const mockTeamAlreadyExistsError = vi.hoisted(() => {
+  class TeamAlreadyExistsError extends Error {
+    constructor(teamId: string) {
+      super(`チームは既に登録済みです: ${teamId}`);
+      this.name = 'TeamAlreadyExistsError';
+    }
+  }
+  return { TeamAlreadyExistsError };
+});
+
+vi.mock('../repositories/gameday-repository', () => mockTeamAlreadyExistsError);
+
+import {
+  registerTeam,
+  updateTeamUrl,
+  getLeaderboard,
+  getAttackStatistics,
+  getTeamDashboard,
+  BlackoutActiveError,
+  TeamAlreadyExistsError,
+} from './dashboard-service';
+
+describe('ダッシュボードサービス', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // === チーム登録 ===
+  describe('registerTeam', () => {
+    it('チームを登録できるべき', async () => {
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'チームA',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      };
+      mockRepository.createTeam.mockResolvedValue(team);
+
+      const result = await registerTeam({
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'チームA',
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      });
+
+      expect(result).toEqual(team);
+      expect(mockRepository.createTeam).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'チームA',
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      });
+    });
+
+    it('重複チーム登録で TeamAlreadyExistsError を投げるべき', async () => {
+      mockRepository.createTeam.mockRejectedValue(
+        new TeamAlreadyExistsError('team-1')
+      );
+
+      await expect(
+        registerTeam({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          teamName: 'チームA',
+        })
+      ).rejects.toThrow(TeamAlreadyExistsError);
+    });
+  });
+
+  // === チーム URL 更新 ===
+  describe('updateTeamUrl', () => {
+    it('チーム URL を更新できるべき', async () => {
+      mockRepository.getTeamState.mockResolvedValue({
+        teamId: 'team-1',
+        teamName: 'A',
+      });
+      mockRepository.updateTeamUrls.mockResolvedValue(undefined);
+
+      await updateTeamUrl('event-1', 'team-1', {
+        websiteUrl: 'https://new.example.com',
+      });
+
+      expect(mockRepository.updateTeamUrls).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        { websiteUrl: 'https://new.example.com' }
+      );
+    });
+
+    it('チームが存在しない場合 TeamNotFoundError を投げるべき', async () => {
+      mockRepository.getTeamState.mockResolvedValue(null);
+
+      await expect(
+        updateTeamUrl('event-1', 'nonexistent', {
+          websiteUrl: 'https://example.com',
+        })
+      ).rejects.toThrow('チームが見つかりません');
+    });
+  });
+
+  // === リーダーボード ===
+  describe('getLeaderboard', () => {
+    it('スコア降順でチーム一覧を返すべき', async () => {
+      mockRepository.getGameState.mockResolvedValue({
+        eventId: 'event-1',
+        blackout: false,
+      });
+      mockRepository.listTeams.mockResolvedValue([
+        {
+          teamId: 'team-1',
+          teamName: 'A',
+          score: 1000,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+        {
+          teamId: 'team-2',
+          teamName: 'B',
+          score: 5000,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+        {
+          teamId: 'team-3',
+          teamName: 'C',
+          score: 3000,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+      ]);
+
+      const result = await getLeaderboard('event-1');
+
+      expect(result[0].teamId).toBe('team-2');
+      expect(result[1].teamId).toBe('team-3');
+      expect(result[2].teamId).toBe('team-1');
+    });
+
+    it('ブラックアウト中は BlackoutActiveError を投げるべき', async () => {
+      mockRepository.getGameState.mockResolvedValue({
+        eventId: 'event-1',
+        blackout: true,
+      });
+
+      await expect(getLeaderboard('event-1')).rejects.toThrow(
+        BlackoutActiveError
+      );
+    });
+
+    it('ゲーム未作成時は空配列を返すべき', async () => {
+      mockRepository.getGameState.mockResolvedValue(null);
+      mockRepository.listTeams.mockResolvedValue([]);
+
+      const result = await getLeaderboard('event-1');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // === 攻撃統計 ===
+  describe('getAttackStatistics', () => {
+    it('チームごとの攻撃統計を集計するべき', async () => {
+      mockRepository.listTeams.mockResolvedValue([
+        {
+          teamId: 'team-1',
+          teamName: 'A',
+          score: 0,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+        {
+          teamId: 'team-2',
+          teamName: 'B',
+          score: 0,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+      ]);
+      mockRepository.listAttackLogs.mockResolvedValue([
+        { attackerTeamId: 'team-1', defenderTeamId: 'team-2', success: true },
+        { attackerTeamId: 'team-1', defenderTeamId: 'team-2', success: false },
+        { attackerTeamId: 'team-2', defenderTeamId: 'team-1', success: true },
+      ]);
+
+      const result = await getAttackStatistics('event-1');
+
+      const team1Stats = result.find((s) => s.teamId === 'team-1')!;
+      expect(team1Stats.attacksSent).toBe(2);
+      expect(team1Stats.attacksReceived).toBe(1);
+      expect(team1Stats.successRate).toBe(0.5);
+
+      const team2Stats = result.find((s) => s.teamId === 'team-2')!;
+      expect(team2Stats.attacksSent).toBe(1);
+      expect(team2Stats.attacksReceived).toBe(2);
+      expect(team2Stats.successRate).toBe(1);
+    });
+
+    it('ADMIN 攻撃は統計に含まれないべき', async () => {
+      mockRepository.listTeams.mockResolvedValue([
+        {
+          teamId: 'team-1',
+          teamName: 'A',
+          score: 0,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+      ]);
+      mockRepository.listAttackLogs.mockResolvedValue([
+        { attackerTeamId: 'ADMIN', defenderTeamId: 'team-1', success: true },
+      ]);
+
+      const result = await getAttackStatistics('event-1');
+
+      const team1Stats = result.find((s) => s.teamId === 'team-1')!;
+      expect(team1Stats.attacksSent).toBe(0);
+      expect(team1Stats.attacksReceived).toBe(0);
+      expect(team1Stats.successRate).toBe(0);
+    });
+
+    it('攻撃がないチームの成功率は 0 であるべき', async () => {
+      mockRepository.listTeams.mockResolvedValue([
+        {
+          teamId: 'team-1',
+          teamName: 'A',
+          score: 0,
+          isHealthy: true,
+          websiteUrl: null,
+          apiUrl: null,
+        },
+      ]);
+      mockRepository.listAttackLogs.mockResolvedValue([]);
+
+      const result = await getAttackStatistics('event-1');
+      expect(result[0].successRate).toBe(0);
+    });
+  });
+
+  // === チームダッシュボード ===
+  describe('getTeamDashboard', () => {
+    it('チーム詳細ダッシュボードを返すべき', async () => {
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 5000,
+        isHealthy: true,
+        websiteUrl: null,
+        apiUrl: null,
+      };
+      mockRepository.getTeamState.mockResolvedValue(team);
+      mockRepository.listHealthChecks.mockResolvedValue([
+        { id: 'hc-1', checkType: 'website', isHealthy: true },
+      ]);
+      mockRepository.listAttackLogs.mockResolvedValue([
+        { attackerTeamId: 'team-1', defenderTeamId: 'team-2', success: true },
+        { attackerTeamId: 'team-3', defenderTeamId: 'team-1', success: false },
+        { attackerTeamId: 'team-2', defenderTeamId: 'team-3', success: true },
+      ]);
+
+      const result = await getTeamDashboard('event-1', 'team-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.team).toEqual(team);
+      expect(result!.recentHealthChecks).toHaveLength(1);
+      expect(result!.attackHistory).toHaveLength(2);
+    });
+
+    it('チームが存在しない場合は null を返すべき', async () => {
+      mockRepository.getTeamState.mockResolvedValue(null);
+
+      const result = await getTeamDashboard('event-1', 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/services/application-plane/gameday-service/src/services/dashboard-service.ts
+++ b/backend/services/application-plane/gameday-service/src/services/dashboard-service.ts
@@ -1,0 +1,147 @@
+import { gamedayRepository } from '../lib/dynamodb';
+import { TeamAlreadyExistsError } from '../repositories/gameday-repository';
+import type { TeamState } from '../repositories/gameday-repository';
+import type { AttackLog, HealthCheckResult } from '../types';
+
+export { TeamAlreadyExistsError };
+
+export class BlackoutActiveError extends Error {
+  constructor() {
+    super('ブラックアウト中はリーダーボードを閲覧できません');
+    this.name = 'BlackoutActiveError';
+  }
+}
+
+// === チーム登録 ===
+
+export async function registerTeam(input: {
+  eventId: string;
+  teamId: string;
+  teamName: string;
+  websiteUrl?: string;
+  apiUrl?: string;
+}): Promise<TeamState> {
+  return gamedayRepository.createTeam(input);
+}
+
+// === チーム URL 更新 ===
+
+export async function updateTeamUrl(
+  eventId: string,
+  teamId: string,
+  urls: { websiteUrl?: string; apiUrl?: string }
+): Promise<void> {
+  const team = await gamedayRepository.getTeamState(eventId, teamId);
+  if (!team) {
+    throw new TeamNotFoundError(teamId);
+  }
+  await gamedayRepository.updateTeamUrls(eventId, teamId, urls);
+}
+
+export class TeamNotFoundError extends Error {
+  constructor(teamId: string) {
+    super(`チームが見つかりません: ${teamId}`);
+    this.name = 'TeamNotFoundError';
+  }
+}
+
+// === リーダーボード ===
+
+export async function getLeaderboard(eventId: string): Promise<TeamState[]> {
+  const game = await gamedayRepository.getGameState(eventId);
+  if (game?.blackout) {
+    throw new BlackoutActiveError();
+  }
+
+  const teams = await gamedayRepository.listTeams(eventId);
+  return teams.sort((a, b) => b.score - a.score);
+}
+
+// === 攻撃統計 ===
+
+export interface AttackStatistics {
+  teamId: string;
+  teamName: string;
+  attacksSent: number;
+  attacksReceived: number;
+  successRate: number;
+}
+
+export async function getAttackStatistics(
+  eventId: string
+): Promise<AttackStatistics[]> {
+  const [teams, logs] = await Promise.all([
+    gamedayRepository.listTeams(eventId),
+    gamedayRepository.listAttackLogs(eventId),
+  ]);
+
+  const statsMap = new Map<
+    string,
+    { sent: number; received: number; successSent: number }
+  >();
+
+  for (const team of teams) {
+    statsMap.set(team.teamId, { sent: 0, received: 0, successSent: 0 });
+  }
+
+  for (const log of logs) {
+    if (log.attackerTeamId === 'ADMIN') continue;
+
+    const attackerStats = statsMap.get(log.attackerTeamId);
+    if (attackerStats) {
+      attackerStats.sent++;
+      if (log.success) {
+        attackerStats.successSent++;
+      }
+    }
+
+    const defenderStats = statsMap.get(log.defenderTeamId);
+    if (defenderStats) {
+      defenderStats.received++;
+    }
+  }
+
+  return teams.map((team) => {
+    const stats = statsMap.get(team.teamId)!;
+    return {
+      teamId: team.teamId,
+      teamName: team.teamName,
+      attacksSent: stats.sent,
+      attacksReceived: stats.received,
+      successRate: stats.sent > 0 ? stats.successSent / stats.sent : 0,
+    };
+  });
+}
+
+// === チームダッシュボード ===
+
+export interface TeamDashboard {
+  team: TeamState;
+  recentHealthChecks: HealthCheckResult[];
+  attackHistory: AttackLog[];
+}
+
+export async function getTeamDashboard(
+  eventId: string,
+  teamId: string
+): Promise<TeamDashboard | null> {
+  const team = await gamedayRepository.getTeamState(eventId, teamId);
+  if (!team) {
+    return null;
+  }
+
+  const [recentHealthChecks, allLogs] = await Promise.all([
+    gamedayRepository.listHealthChecks(eventId, teamId),
+    gamedayRepository.listAttackLogs(eventId),
+  ]);
+
+  const attackHistory = allLogs.filter(
+    (log) => log.attackerTeamId === teamId || log.defenderTeamId === teamId
+  );
+
+  return {
+    team,
+    recentHealthChecks,
+    attackHistory,
+  };
+}


### PR DESCRIPTION
## Summary
- チーム登録エンドポイント (`POST /admin/teams/register`) を追加
- Dashboard API（リーダーボード、攻撃統計、チーム詳細）を `participant` ルートに実装
- チーム URL 更新 (`POST /teams/update-url`) を追加
- `TeamState` に `websiteUrl` / `apiUrl` フィールドを拡張
- ブラックアウト中のリーダーボードアクセス制限（403）を実装
- 存在しないチームへの URL 更新で 404 を返す安全なエラーハンドリング

## Changes
| ファイル | 操作 | 概要 |
|---|---|---|
| `src/repositories/gameday-repository.ts` | 変更 | TeamState 拡張、createTeam、updateTeamUrls、updateTeamHealthy 追加 |
| `src/schemas/index.ts` | 変更 | registerTeamSchema、updateTeamUrlSchema 追加 |
| `src/services/dashboard-service.ts` | **新規** | リーダーボード、統計集計、チーム登録/URL更新 |
| `src/services/dashboard-service.test.ts` | **新規** | Dashboard テスト (13 tests) |
| `src/api/admin.ts` | 変更 | チーム登録エンドポイント追加 |
| `src/api/admin.test.ts` | 変更 | チーム登録テスト追加 (5 tests) |
| `src/api/participant.ts` | 変更 | Dashboard + URL更新エンドポイント追加 |
| `src/api/participant.test.ts` | 変更 | Dashboard + URL更新テスト追加 (13 tests) |

## Test plan
- [x] 全196テストが通過
- [x] TypeScript 型チェック通過
- [x] Prettier フォーマット通過
- [ ] CI パイプラインが通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin team registration endpoint for event setup
  * Dashboard endpoints displaying leaderboards and attack statistics
  * Team URL management for website and API endpoints
  * Team health check monitoring and tracking
  * Enhanced team dashboard with recent health checks and attack history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->