### PR TITLE
feat(gameday): Auditor（ヘルスチェッカー）を実装

### DIFF
--- a/backend/services/application-plane/gameday-service/src/api/admin.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.test.ts
@@ -43,8 +43,17 @@ const mockDashboardService = vi.hoisted(() => {
   };
 });
 
+const mockAuditorService = vi.hoisted(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  isRunning: vi.fn().mockReturnValue(false),
+}));
+
 vi.mock('../services/game-controller', () => mockGameController);
 vi.mock('../services/dashboard-service', () => mockDashboardService);
+vi.mock('../services/auditor-service', () => ({
+  auditorService: mockAuditorService,
+}));
 
 import { adminRoutes } from './admin';
 
@@ -731,6 +740,98 @@ describe('管理者 API', () => {
         });
 
         expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+      });
+    });
+  });
+
+  // === Auditor ===
+  describe('POST /auditor/start', () => {
+    describe('正常な開始の場合', () => {
+      it('OK を返し started ステータスを含むべき', async () => {
+        mockAuditorService.isRunning.mockReturnValue(false);
+
+        const res = await app.request('/auditor/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ eventId: 'event-1' }),
+        });
+
+        expect(res.status).toBe(StatusCodes.OK);
+        const body = await res.json();
+        expect(body.status).toBe('started');
+        expect(body.eventId).toBe('event-1');
+        expect(mockAuditorService.start).toHaveBeenCalledWith('event-1');
+      });
+    });
+
+    describe('既に起動中の場合', () => {
+      it('CONFLICT を返すべき', async () => {
+        mockAuditorService.isRunning.mockReturnValue(true);
+
+        const res = await app.request('/auditor/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ eventId: 'event-1' }),
+        });
+
+        expect(res.status).toBe(StatusCodes.CONFLICT);
+        const body = await res.json();
+        expect(body.error).toContain('既に起動');
+      });
+    });
+
+    describe('eventId が空の場合', () => {
+      it('BAD_REQUEST を返すべき', async () => {
+        const res = await app.request('/auditor/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ eventId: '' }),
+        });
+        expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      });
+    });
+
+    describe('不正な JSON の場合', () => {
+      it('BAD_REQUEST を返しエラーメッセージを含むべき', async () => {
+        const res = await app.request('/auditor/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: 'invalid-json',
+        });
+        expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+        const body = await res.json();
+        expect(body.error).toBe('JSON の解析に失敗しました');
+      });
+    });
+  });
+
+  describe('POST /auditor/stop', () => {
+    describe('起動中の場合', () => {
+      it('OK を返し stopped ステータスを含むべき', async () => {
+        mockAuditorService.isRunning.mockReturnValue(true);
+
+        const res = await app.request('/auditor/stop', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(StatusCodes.OK);
+        const body = await res.json();
+        expect(body.status).toBe('stopped');
+        expect(mockAuditorService.stop).toHaveBeenCalled();
+      });
+    });
+
+    describe('起動していない場合', () => {
+      it('CONFLICT を返すべき', async () => {
+        mockAuditorService.isRunning.mockReturnValue(false);
+
+        const res = await app.request('/auditor/stop', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(StatusCodes.CONFLICT);
+        const body = await res.json();
+        expect(body.error).toContain('起動していません');
       });
     });
   });

--- a/backend/services/application-plane/gameday-service/src/api/admin.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.ts
@@ -24,6 +24,7 @@ import {
   registerTeam,
   TeamAlreadyExistsError,
 } from '../services/dashboard-service';
+import { auditorService } from '../services/auditor-service';
 
 export const adminRoutes = new Hono();
 
@@ -241,4 +242,47 @@ adminRoutes.post('/attacks/seed', async (c) => {
   }
   const count = await seedAttackCatalog(parsed.data.eventId);
   return c.json({ seeded: count }, StatusCodes.CREATED);
+});
+
+// === Auditor ===
+
+// Auditor 開始
+adminRoutes.post('/auditor/start', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (body === null) {
+    return c.json(
+      { error: 'JSON の解析に失敗しました' },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  const parsed = eventIdSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: '無効なリクエスト', details: parsed.error.issues },
+      StatusCodes.BAD_REQUEST
+    );
+  }
+  if (auditorService.isRunning()) {
+    return c.json(
+      { error: 'Auditor は既に起動しています' },
+      StatusCodes.CONFLICT
+    );
+  }
+  auditorService.start(parsed.data.eventId);
+  return c.json(
+    { status: 'started', eventId: parsed.data.eventId },
+    StatusCodes.OK
+  );
+});
+
+// Auditor 停止
+adminRoutes.post('/auditor/stop', async (c) => {
+  if (!auditorService.isRunning()) {
+    return c.json(
+      { error: 'Auditor は起動していません' },
+      StatusCodes.CONFLICT
+    );
+  }
+  auditorService.stop();
+  return c.json({ status: 'stopped' }, StatusCodes.OK);
 });

--- a/backend/services/application-plane/gameday-service/src/index.ts
+++ b/backend/services/application-plane/gameday-service/src/index.ts
@@ -6,6 +6,7 @@ import { healthRoutes } from './api/health';
 import { adminRoutes } from './api/admin';
 import { participantRoutes } from './api/participant';
 import { authMiddleware, requireAdmin } from './middleware/auth';
+import { auditorService } from './services/auditor-service';
 
 const logger = createLogger('gameday-service');
 const app = new Hono();
@@ -59,6 +60,7 @@ const server = serve(
 // グレースフルシャットダウン
 const shutdown = () => {
   logger.info('シャットダウンを開始します');
+  auditorService.stop();
   server.close(() => {
     logger.info('サーバーを停止しました');
     process.exit(0);

--- a/backend/services/application-plane/gameday-service/src/services/auditor-service.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/auditor-service.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockRepository = vi.hoisted(() => ({
+  getGameState: vi.fn(),
+  listTeams: vi.fn(),
+  createHealthCheck: vi.fn(),
+  updateTeamScore: vi.fn(),
+  updateTeamHealthy: vi.fn(),
+}));
+
+vi.mock('../lib/dynamodb', () => ({
+  gamedayRepository: mockRepository,
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { AuditorService } from './auditor-service';
+
+describe('Auditor サービス', () => {
+  let auditor: AuditorService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    auditor = new AuditorService();
+  });
+
+  afterEach(() => {
+    auditor.stop();
+    vi.useRealTimers();
+  });
+
+  // === httpCheck ===
+  describe('httpCheck', () => {
+    it('正常レスポンスで isHealthy: true を返すべき', async () => {
+      vi.useRealTimers();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 200,
+        })
+      );
+
+      const result = await auditor.httpCheck('https://example.com');
+
+      expect(result.isHealthy).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('5xx レスポンスで isHealthy: false を返すべき', async () => {
+      vi.useRealTimers();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 500,
+        })
+      );
+
+      const result = await auditor.httpCheck('https://example.com');
+
+      expect(result.isHealthy).toBe(false);
+      expect(result.statusCode).toBe(500);
+    });
+
+    it('接続エラーで isHealthy: false, statusCode: null を返すべき', async () => {
+      vi.useRealTimers();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new Error('Connection refused'))
+      );
+
+      const result = await auditor.httpCheck('https://example.com');
+
+      expect(result.isHealthy).toBe(false);
+      expect(result.statusCode).toBeNull();
+    });
+  });
+
+  // === checkTeam ===
+  describe('checkTeam', () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 }));
+      mockRepository.createHealthCheck.mockResolvedValue({});
+      mockRepository.updateTeamScore.mockResolvedValue(undefined);
+      mockRepository.updateTeamHealthy.mockResolvedValue(undefined);
+    });
+
+    it('両方 UP で +100pt を付与するべき', async () => {
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      };
+
+      await auditor.checkTeam('event-1', team, 'normal');
+
+      expect(mockRepository.createHealthCheck).toHaveBeenCalledTimes(2);
+      expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        100
+      );
+      expect(mockRepository.updateTeamHealthy).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        true
+      );
+    });
+
+    it('片方 DOWN で -100pt（通常）を適用するべき', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({ status: 200 })
+          .mockResolvedValueOnce({ status: 503 })
+      );
+
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      };
+
+      await auditor.checkTeam('event-1', team, 'normal');
+
+      expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        -100
+      );
+      expect(mockRepository.updateTeamHealthy).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        false
+      );
+    });
+
+    it('片方 DOWN + scoreWeight high で -1000pt を適用するべき', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({ status: 200 })
+          .mockRejectedValueOnce(new Error('timeout'))
+      );
+
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      };
+
+      await auditor.checkTeam('event-1', team, 'high');
+
+      expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        -1000
+      );
+    });
+
+    it('両方 DOWN で -100pt（通常）を適用するべき', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new Error('Connection refused'))
+      );
+
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: 'https://api.example.com',
+      };
+
+      await auditor.checkTeam('event-1', team, 'normal');
+
+      expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        -100
+      );
+      expect(mockRepository.updateTeamHealthy).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        false
+      );
+    });
+
+    it('URL 未設定のチームはスキップするべき', async () => {
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: null,
+        apiUrl: null,
+      };
+
+      await auditor.checkTeam('event-1', team, 'normal');
+
+      expect(mockRepository.createHealthCheck).not.toHaveBeenCalled();
+      expect(mockRepository.updateTeamScore).not.toHaveBeenCalled();
+    });
+
+    it('websiteUrl のみ設定時、website だけチェックするべき', async () => {
+      const team = {
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'A',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: 'https://example.com',
+        apiUrl: null,
+      };
+
+      await auditor.checkTeam('event-1', team, 'normal');
+
+      expect(mockRepository.createHealthCheck).toHaveBeenCalledTimes(1);
+      expect(mockRepository.createHealthCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ checkType: 'website' })
+      );
+      expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        100
+      );
+    });
+  });
+
+  // === runCheck ===
+  describe('runCheck', () => {
+    it('ゲーム未開始時はチェックをスキップするべき', async () => {
+      vi.useRealTimers();
+      (auditor as unknown as { eventId: string }).eventId = 'event-1';
+      mockRepository.getGameState.mockResolvedValue({ isRunning: false });
+
+      await auditor.runCheck();
+
+      expect(mockRepository.listTeams).not.toHaveBeenCalled();
+    });
+
+    it('ゲームが存在しない場合はチェックをスキップするべき', async () => {
+      vi.useRealTimers();
+      (auditor as unknown as { eventId: string }).eventId = 'event-1';
+      mockRepository.getGameState.mockResolvedValue(null);
+
+      await auditor.runCheck();
+
+      expect(mockRepository.listTeams).not.toHaveBeenCalled();
+    });
+
+    it('eventId が null の場合は早期リターンするべき', async () => {
+      vi.useRealTimers();
+      await auditor.runCheck();
+
+      expect(mockRepository.getGameState).not.toHaveBeenCalled();
+    });
+  });
+
+  // === start / stop ===
+  describe('ライフサイクル', () => {
+    it('start で isRunning が true になるべき', () => {
+      mockRepository.getGameState.mockResolvedValue({ isRunning: true });
+      mockRepository.listTeams.mockResolvedValue([]);
+
+      auditor.start('event-1');
+
+      expect(auditor.isRunning()).toBe(true);
+    });
+
+    it('stop で isRunning が false になるべき', () => {
+      mockRepository.getGameState.mockResolvedValue({ isRunning: true });
+      mockRepository.listTeams.mockResolvedValue([]);
+
+      auditor.start('event-1');
+      auditor.stop();
+
+      expect(auditor.isRunning()).toBe(false);
+    });
+
+    it('二重起動しないべき', () => {
+      mockRepository.getGameState.mockResolvedValue({ isRunning: true });
+      mockRepository.listTeams.mockResolvedValue([]);
+
+      auditor.start('event-1');
+      auditor.start('event-1');
+
+      expect(auditor.isRunning()).toBe(true);
+    });
+  });
+});

--- a/backend/services/application-plane/gameday-service/src/services/auditor-service.ts
+++ b/backend/services/application-plane/gameday-service/src/services/auditor-service.ts
@@ -1,0 +1,177 @@
+import { gamedayRepository } from '../lib/dynamodb';
+import { createLogger } from '../lib/logger';
+import type { TeamState } from '../repositories/gameday-repository';
+
+const logger = createLogger('auditor');
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+const HEALTH_CHECK_INTERVAL_MS = 60_000;
+const UPTIME_BONUS = 100;
+const DOWNTIME_PENALTY_NORMAL = -100;
+const DOWNTIME_PENALTY_HIGH = -1000;
+
+export interface HttpCheckResult {
+  isHealthy: boolean;
+  statusCode: number | null;
+  responseTimeMs: number;
+}
+
+export class AuditorService {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private eventId: string | null = null;
+
+  start(eventId: string): void {
+    if (this.intervalId) {
+      logger.warn('Auditor は既に起動しています');
+      return;
+    }
+
+    this.eventId = eventId;
+    logger.info({ eventId }, 'Auditor を開始します');
+
+    this.intervalId = setInterval(() => {
+      this.runCheck().catch((err) => {
+        logger.error({ err }, 'ヘルスチェック実行中にエラーが発生しました');
+      });
+    }, HEALTH_CHECK_INTERVAL_MS);
+
+    // 即座に最初のチェックを実行
+    this.runCheck().catch((err) => {
+      logger.error({ err }, '初回ヘルスチェック実行中にエラーが発生しました');
+    });
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.eventId = null;
+      logger.info('Auditor を停止しました');
+    }
+  }
+
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
+
+  async runCheck(): Promise<void> {
+    if (!this.eventId) return;
+
+    const game = await gamedayRepository.getGameState(this.eventId);
+    if (!game || !game.isRunning) {
+      logger.info('ゲームが開始されていないためチェックをスキップします');
+      return;
+    }
+
+    const teams = await gamedayRepository.listTeams(this.eventId);
+
+    const results = await Promise.allSettled(
+      teams.map((team) => this.checkTeam(this.eventId!, team, game.scoreWeight))
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger.error(
+          { err: result.reason },
+          'チームチェック中にエラーが発生しました'
+        );
+      }
+    }
+  }
+
+  async checkTeam(
+    eventId: string,
+    team: TeamState,
+    scoreWeight: string
+  ): Promise<void> {
+    let websiteResult: HttpCheckResult | null = null;
+    let apiResult: HttpCheckResult | null = null;
+
+    if (team.websiteUrl) {
+      websiteResult = await this.httpCheck(team.websiteUrl);
+      await gamedayRepository.createHealthCheck({
+        eventId,
+        teamId: team.teamId,
+        checkType: 'website',
+        isHealthy: websiteResult.isHealthy,
+        statusCode: websiteResult.statusCode,
+        responseTimeMs: websiteResult.responseTimeMs,
+      });
+    }
+
+    if (team.apiUrl) {
+      apiResult = await this.httpCheck(team.apiUrl);
+      await gamedayRepository.createHealthCheck({
+        eventId,
+        teamId: team.teamId,
+        checkType: 'api',
+        isHealthy: apiResult.isHealthy,
+        statusCode: apiResult.statusCode,
+        responseTimeMs: apiResult.responseTimeMs,
+      });
+    }
+
+    // URL が未設定の場合はチェックをスキップ（ペナルティなし）
+    if (!team.websiteUrl && !team.apiUrl) {
+      return;
+    }
+
+    const websiteUp = websiteResult ? websiteResult.isHealthy : true;
+    const apiUp = apiResult ? apiResult.isHealthy : true;
+    const allUp = websiteUp && apiUp;
+
+    // スコア反映
+    let delta: number;
+    if (allUp) {
+      delta = UPTIME_BONUS;
+    } else {
+      delta =
+        scoreWeight === 'high'
+          ? DOWNTIME_PENALTY_HIGH
+          : DOWNTIME_PENALTY_NORMAL;
+    }
+
+    await gamedayRepository.updateTeamScore(eventId, team.teamId, delta);
+    await gamedayRepository.updateTeamHealthy(eventId, team.teamId, allUp);
+
+    logger.info(
+      {
+        teamId: team.teamId,
+        websiteUp,
+        apiUp,
+        delta,
+      },
+      'ヘルスチェック完了'
+    );
+  }
+
+  async httpCheck(url: string): Promise<HttpCheckResult> {
+    const start = Date.now();
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+      });
+
+      const responseTimeMs = Date.now() - start;
+      const isHealthy = response.status >= 200 && response.status < 300;
+
+      return {
+        isHealthy,
+        statusCode: response.status,
+        responseTimeMs,
+      };
+    } catch {
+      const responseTimeMs = Date.now() - start;
+      return {
+        isHealthy: false,
+        statusCode: null,
+        responseTimeMs,
+      };
+    }
+  }
+}
+
+// シングルトンインスタンス
+export const auditorService = new AuditorService();


### PR DESCRIPTION
## Summary
- 60秒間隔でチームの Website/API を死活監視する `AuditorService` を実装
- ヘルスチェック結果に応じて即座にスコア反映（両方 UP: +100pt、どちらか DOWN: -100pt）
- `scoreWeight: 'high'` 時のダウンタイムペナルティ -1,000pt に対応
- 管理者 API に `POST /auditor/start` / `POST /auditor/stop` エンドポイントを追加
- グレースフルシャットダウンで Auditor を安全に停止

## Changes
| ファイル | 操作 | 概要 |
|---|---|---|
| `src/services/auditor-service.ts` | **新規** | ヘルスチェッカー（60s interval, Promise.allSettled, AbortSignal.timeout） |
| `src/services/auditor-service.test.ts` | **新規** | Auditor テスト (15 tests) |
| `src/api/admin.ts` | 変更 | Auditor start/stop エンドポイント追加 |
| `src/api/admin.test.ts` | 変更 | Auditor テスト追加 (6 tests) |
| `src/index.ts` | 変更 | グレースフルシャットダウンで Auditor 停止 |

## Dependencies
- Depends on #191 (`feat/gameday-team-dashboard`)

## Test plan
- [x] 全202テストが通過（gameday-service）
- [x] TypeScript 型チェック通過
- [x] Prettier フォーマット通過
- [ ] CI パイプラインが通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added auditor service to monitor and perform health checks on teams during active games.
  * New admin endpoints to start and stop auditor monitoring with automatic score adjustments based on team uptime and downtime.
  * Enhanced server shutdown to gracefully stop monitoring services.

* **Tests**
  * Added comprehensive test coverage for auditor functionality and endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->