### PR TITLE
fix(problem-service): AUTH_SKIP モードを追加

### DIFF
--- a/backend/services/application-plane/problem-service/src/auth/index.ts
+++ b/backend/services/application-plane/problem-service/src/auth/index.ts
@@ -1,12 +1,36 @@
 /**
  * 認証・認可システム
  *
- * control-plane の Keycloak 認証を再利用
+ * control-plane の Keycloak 認証を再利用。
+ *
+ * AUTH_SKIP モードでは JWT 検証をバイパスし、
+ * モックユーザーを返す（ローカル開発用）。
  */
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-// Keycloak configuration
+// ── AUTH_SKIP ガード ─────────────────────────────────
+/* v8 ignore start -- Production safety guard */
+if (process.env.AUTH_SKIP === '1' && process.env.NODE_ENV === 'production') {
+  throw new Error('AUTH_SKIP cannot be enabled in production');
+}
+/* v8 ignore stop */
+
+const authSkipEnabled =
+  process.env.AUTH_SKIP === '1' && process.env.NODE_ENV !== 'production';
+
+/* v8 ignore start -- Development-only warning */
+if (authSkipEnabled && typeof console !== 'undefined') {
+  console.warn(
+    '\x1b[33m⚠️  AUTH_SKIP mode is enabled in problem-service. JWT verification is bypassed.\x1b[0m'
+  );
+  console.warn(
+    '\x1b[33m   This should only be used for local development.\x1b[0m'
+  );
+}
+/* v8 ignore stop */
+
+// ── Keycloak 設定 ────────────────────────────────────
 const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM || 'tenkacloud';
 const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'http://localhost:8080';
 const JWKS_URL = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`;
@@ -131,14 +155,35 @@ export interface AuthContext {
   error?: string;
 }
 
+/** AUTH_SKIP モードで使用するモックユーザー */
+const mockUser: AuthenticatedUser = {
+  id: 'dev-user',
+  email: 'dev@localhost',
+  username: 'dev-user',
+  roles: [UserRole.PLATFORM_ADMIN, UserRole.COMPETITOR],
+  tenantId: 'dev-tenant',
+};
+
 /**
  * ヘッダーからトークンを抽出して認証
+ *
+ * AUTH_SKIP モード: モックユーザーを即座に返す（JWT 検証なし）
+ * 通常モード: Keycloak の JWKS でトークンを検証
  */
 export async function authenticateRequest(headers: {
   authorization?: string;
   authorizationtoken?: string;
   [key: string]: string | undefined;
 }): Promise<AuthContext> {
+  // AUTH_SKIP=1: 開発用にJWT検証をバイパス
+  if (authSkipEnabled) {
+    return {
+      user: mockUser,
+      token: 'mock-access-token',
+      isValid: true,
+    };
+  }
+
   const authHeader = headers.authorization || headers.authorizationtoken;
 
   if (!authHeader) {

--- a/backend/services/application-plane/problem-service/src/routes/index.ts
+++ b/backend/services/application-plane/problem-service/src/routes/index.ts
@@ -19,6 +19,7 @@ app.use(
   '*',
   cors({
     origin: [
+      'http://localhost:3000', // Nginx proxy (dev)
       'http://localhost:13000', // Admin App
       'http://localhost:13001', // Participant App
       'http://localhost:13002', // Landing Page


### PR DESCRIPTION
## Summary
- problem-service の認証モジュールに AUTH_SKIP モードを追加し、ローカル開発時に Keycloak なしで動作可能にした
- CORS 許可オリジンに `http://localhost:3000`（Nginx proxy）を追加

## Background
`AUTH_SKIP=1` でローカル開発している場合、フロントエンドは `mock-access-token` を送信するが、problem-service は Keycloak の JWKS エンドポイントに接続しようとして失敗していた。gameday-service には既に AUTH_SKIP サポートがあったが、problem-service には未実装だった。

## Changes
- `auth/index.ts`: production safety guard、AUTH_SKIP バイパス、モックユーザーを追加（gameday-service と同じパターン）
- `routes/index.ts`: CORS に `localhost:3000` を追加

## Test plan
- [x] `make before-commit` 通過（lint, format, typecheck, test coverage, build）
- [ ] `AUTH_SKIP=1` でローカル起動し、「イベントを探す」画面でイベント一覧が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added development-only authentication bypass with safety guards to prevent accidental usage in production environments.
  * Enabled local development server support via CORS configuration for `localhost:3000`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->