### PR TITLE
fix(docker): AUTH_SKIP 環境変数の統一と KEYCLOAK 設定の除去

### DIFF
--- a/backend/services/application-plane/problem-service/.env.example
+++ b/backend/services/application-plane/problem-service/.env.example
@@ -1,0 +1,8 @@
+PORT=3100
+DYNAMODB_TABLE=TenkaCloud-dev
+DYNAMODB_ENDPOINT=http://localhost:4566
+AWS_REGION=ap-northeast-1
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+CORS_ORIGIN=http://localhost:13001,http://localhost:13000,http://localhost:3000
+AUTH_SKIP=1

--- a/backend/services/application-plane/problem-service/src/server.ts
+++ b/backend/services/application-plane/problem-service/src/server.ts
@@ -16,14 +16,14 @@ console.log(`
 ║  Server starting...                                          ║
 ║                                                              ║
 ║  Endpoints:                                                  ║
-║    - Admin API:  http://localhost:${port}/api/admin             ║
-║    - Player API: http://localhost:${port}/api/player            ║
-║    - Health:     http://localhost:${port}/health                ║
+║    - Admin API:       http://localhost:${port}/api/admin        ║
+║    - Player API:      http://localhost:${port}/api/player       ║
+║    - Participant API: http://localhost:${port}/api/participant  ║
+║    - Health:          http://localhost:${port}/health           ║
 ║                                                              ║
 ║  Environment:                                                ║
 ║    - NODE_ENV: ${process.env.NODE_ENV || 'development'}                             ║
-║    - KEYCLOAK_URL: ${process.env.KEYCLOAK_URL || 'http://localhost:8080'}        ║
-║    - KEYCLOAK_REALM: ${process.env.KEYCLOAK_REALM || 'tenkacloud'}                    ║
+║    - AUTH_SKIP: ${process.env.AUTH_SKIP || '0'}                                      ║
 ╚══════════════════════════════════════════════════════════════╝
 `);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,8 +156,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
       - CORS_ORIGIN=http://localhost:3000,http://localhost:13001
-      - KEYCLOAK_URL=http://keycloak:8080
-      - KEYCLOAK_REALM=tenkacloud
+      - AUTH_SKIP=1
     depends_on:
       localstack:
         condition: service_healthy
@@ -208,6 +207,8 @@ services:
       - AWS_ENDPOINT_URL=http://localstack:4566
       - AWS_REGION=${AWS_REGION:-ap-northeast-1}
       - NEXT_PUBLIC_API_URL=http://localhost:3000/api
+      - AUTH_SKIP=1
+      - NEXT_PUBLIC_AUTH_SKIP=1
     networks:
       - tenkacloud
 


### PR DESCRIPTION
docker-compose.yml から KEYCLOAK_URL/KEYCLOAK_REALM を除去し AUTH_SKIP=1 に統一。 フロントエンドにも AUTH_SKIP/NEXT_PUBLIC_AUTH_SKIP を追加。
server.ts のログ表示を Participant API 追加・AUTH_SKIP 表示に更新。

https://claude.ai/code/session_01JSX8Z2Up5hvaraTD4h97Mm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service environment configuration with new parameters for database connectivity, AWS integration, and CORS origin settings
  * Revised authentication configuration approach across services
  * Updated Docker Compose configuration to align with refreshed service environment requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->