### PR TITLE
feat(dev): make dev コマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,9 @@ start-dev-servers:
 	NEXT_PUBLIC_APPLICATION_PLANE_URL=http://localhost:13001 \
 	$(NR) dev
 
+# make dev: 開発サーバーのみ起動（インフラは既に起動済みの前提）
+dev: start-dev-servers
+
 # make stop: エミュレータを停止
 stop: stop-local
 


### PR DESCRIPTION
## Summary
- `make dev` でインフラ起動済みの場合に dev サーバーのみ起動するショートカットを追加
- `make start`（インフラ + dev サーバー）との使い分けを明確化

## Test plan
- [ ] `make dev` で dev サーバーが起動すること
- [ ] `make start` は従来通りインフラ + dev サーバーが起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `dev` Make target for independently starting development servers, streamlining workflows when infrastructure is already operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->