### PR TITLE
fix(dev): ローカル環境のセットアップから Terraform を除去

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ vite.config.ts.timestamp-*
 !.claude/skills/
 
 .playwright-mcp
+apps/*/test-results/
+apps/*/playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ start: start-infrastructure-bg start-dev-servers
 start-infrastructure: start-local
 
 # バックグラウンドでエミュレータを起動し、準備完了を待つ
-start-infrastructure-bg: check-docker check-aws-cli check-terraform
+start-infrastructure-bg: check-docker check-aws-cli
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "🚀 TenkaCloud を起動します"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -531,7 +531,7 @@ check-terraform:
 	@command -v terraform >/dev/null 2>&1 || { echo "❌ Terraform がインストールされていません。"; echo "   brew install terraform でインストールしてください。"; exit 1; }
 	@echo "✅ Terraform がインストールされています"
 
-start-local: check-docker check-aws-cli check-terraform
+start-local: check-docker check-aws-cli
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "🚀 $(CLOUD_EMULATOR) でローカル環境を起動します"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/infrastructure/terraform/modules/eventbridge/main.tf
+++ b/infrastructure/terraform/modules/eventbridge/main.tf
@@ -8,6 +8,10 @@
 resource "aws_cloudwatch_event_bus" "tenant_events" {
   name = "${var.name_prefix}-tenant-events"
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # Rule: Tenant Onboarding
@@ -22,6 +26,10 @@ resource "aws_cloudwatch_event_rule" "tenant_onboarding" {
   })
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # Rule: Tenant Offboarding
@@ -36,6 +44,10 @@ resource "aws_cloudwatch_event_rule" "tenant_offboarding" {
   })
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # Rule: Tenant Updated
@@ -50,4 +62,8 @@ resource "aws_cloudwatch_event_rule" "tenant_updated" {
   })
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }

--- a/infrastructure/terraform/modules/provisioning-completion/main.tf
+++ b/infrastructure/terraform/modules/provisioning-completion/main.tf
@@ -31,10 +31,23 @@ resource "aws_iam_role" "lambda_role" {
   tags = var.tags
 }
 
-# Lambda Basic Execution Policy
-resource "aws_iam_role_policy_attachment" "lambda_basic" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+# Lambda Basic Execution Policy (inline: エミュレータは AWS managed policy 未対応)
+resource "aws_iam_role_policy" "lambda_basic" {
+  name = "${var.name_prefix}-provisioning-completion-basic-execution"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      Resource = "*"
+    }]
+  })
 }
 
 # DynamoDB Policy for updating tenant status
@@ -60,6 +73,10 @@ resource "aws_sqs_queue" "dlq" {
   message_retention_seconds = 1209600 # 14 days
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # SQS Policy for Lambda DLQ

--- a/infrastructure/terraform/modules/provisioning-lambda/main.tf
+++ b/infrastructure/terraform/modules/provisioning-lambda/main.tf
@@ -30,10 +30,23 @@ resource "aws_iam_role" "lambda_role" {
   tags = var.tags
 }
 
-# Lambda Basic Execution Policy
-resource "aws_iam_role_policy_attachment" "lambda_basic" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+# Lambda Basic Execution Policy (inline: エミュレータは AWS managed policy 未対応)
+resource "aws_iam_role_policy" "lambda_basic" {
+  name = "${var.name_prefix}-provisioning-basic-execution"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      Resource = "*"
+    }]
+  })
 }
 
 # DynamoDB Stream Read Policy (only if stream is enabled)
@@ -106,6 +119,10 @@ resource "aws_sqs_queue" "dlq" {
   message_retention_seconds = 1209600 # 14 days
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # SQS Policy for Lambda DLQ

--- a/infrastructure/terraform/modules/tenant-provisioner/main.tf
+++ b/infrastructure/terraform/modules/tenant-provisioner/main.tf
@@ -32,10 +32,23 @@ resource "aws_iam_role" "lambda_role" {
   tags = var.tags
 }
 
-# Lambda Basic Execution Policy
-resource "aws_iam_role_policy_attachment" "lambda_basic" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+# Lambda Basic Execution Policy (inline: エミュレータは AWS managed policy 未対応)
+resource "aws_iam_role_policy" "lambda_basic" {
+  name = "${var.name_prefix}-tenant-provisioner-basic-execution"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+      Resource = "*"
+    }]
+  })
 }
 
 # EventBridge PutEvents Policy
@@ -94,6 +107,10 @@ resource "aws_sqs_queue" "dlq" {
   message_retention_seconds = 1209600 # 14 days
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # SQS Policy for Lambda DLQ

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -2,7 +2,7 @@
 # TenkaCloud Local Environment Setup
 #
 # クラウドエミュレータ（Kumo / LocalStack / Floci）を起動し、
-# Terraform でインフラをデプロイする
+# AWS CLI でインフラをセットアップする（Terraform 不使用）
 # 冪等性: 既に起動・デプロイ済みの場合はスキップ
 #
 # 使い方:
@@ -24,6 +24,13 @@ export AWS_SECRET_ACCESS_KEY=test
 export AWS_DEFAULT_REGION=ap-northeast-1
 
 EMULATOR_ENDPOINT=http://localhost:4566
+NAME_PREFIX=tenkacloud-local
+TABLE_NAME=TenkaCloud-local
+EVENT_BUS_NAME=${NAME_PREFIX}-tenant-events
+
+aws_cmd() {
+  aws --endpoint-url="$EMULATOR_ENDPOINT" "$@"
+}
 
 # エミュレータの準備状態をチェック
 check_emulator_ready() {
@@ -32,7 +39,7 @@ check_emulator_ready() {
       curl -s "$EMULATOR_ENDPOINT/_localstack/health" 2>/dev/null | grep -qE '"dynamodb": "(available|running)"'
       ;;
     kumo|floci)
-      aws --endpoint-url="$EMULATOR_ENDPOINT" dynamodb list-tables >/dev/null 2>&1
+      aws_cmd dynamodb list-tables >/dev/null 2>&1
       ;;
     *)
       echo "❌ 不明なエミュレータ: $CLOUD_EMULATOR"
@@ -42,7 +49,7 @@ check_emulator_ready() {
 }
 
 check_infrastructure_deployed() {
-  aws --endpoint-url="$EMULATOR_ENDPOINT" dynamodb describe-table --table-name TenkaCloud-local >/dev/null 2>&1
+  aws_cmd dynamodb describe-table --table-name "$TABLE_NAME" >/dev/null 2>&1
 }
 
 echo "🚀 TenkaCloud Local Environment Setup"
@@ -85,14 +92,6 @@ until check_emulator_ready; do
 done
 echo "✅ $CLOUD_EMULATOR is ready!"
 
-# LocalStack 以外はリソース初期化スクリプトを実行
-# （LocalStack は init.sh をマウントして自動実行される）
-if [ "$CLOUD_EMULATOR" != "localstack" ]; then
-  echo ""
-  echo "📦 リソースを初期化中..."
-  "$SCRIPT_DIR/cloud-emulator-init.sh"
-fi
-
 # 2. Lambda をビルド
 echo ""
 echo "🔨 Building Provisioning Lambda (Control Plane)..."
@@ -115,33 +114,179 @@ bun install
 bun run deploy
 echo "✅ Provisioning Completion Lambda built!"
 
-# 3. Terraform でデプロイ
+# 3. AWS CLI でリソースを作成（Terraform 不使用）
 echo ""
-echo "🏗  Deploying infrastructure to $CLOUD_EMULATOR..."
-cd "$PROJECT_ROOT/infrastructure/terraform/environments/local"
-terraform init -upgrade
-terraform apply -auto-approve
-echo "✅ Infrastructure deployed!"
+echo "🏗  Setting up infrastructure via AWS CLI..."
+
+# --- DynamoDB ---
+echo "📦 DynamoDB テーブルを作成中..."
+aws_cmd dynamodb create-table \
+  --table-name "$TABLE_NAME" \
+  --attribute-definitions \
+    AttributeName=PK,AttributeType=S \
+    AttributeName=SK,AttributeType=S \
+    AttributeName=GSI1PK,AttributeType=S \
+    AttributeName=GSI1SK,AttributeType=S \
+    AttributeName=EntityType,AttributeType=S \
+    AttributeName=CreatedAt,AttributeType=S \
+  --key-schema \
+    AttributeName=PK,KeyType=HASH \
+    AttributeName=SK,KeyType=RANGE \
+  --global-secondary-indexes \
+    '[
+      {"IndexName":"GSI1","KeySchema":[{"AttributeName":"GSI1PK","KeyType":"HASH"},{"AttributeName":"GSI1SK","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}},
+      {"IndexName":"GSI2","KeySchema":[{"AttributeName":"EntityType","KeyType":"HASH"},{"AttributeName":"CreatedAt","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}
+    ]' \
+  --billing-mode PAY_PER_REQUEST \
+  --stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES \
+  --region ap-northeast-1 \
+  2>/dev/null || echo "  テーブル '$TABLE_NAME' は既に存在します"
+echo "✅ DynamoDB 完了"
+
+# --- S3 ---
+echo "🪣 S3 バケットを作成中..."
+aws_cmd s3 mb s3://${NAME_PREFIX}-data 2>/dev/null || echo "  バケット '${NAME_PREFIX}-data' は既に存在します"
+echo "✅ S3 完了"
+
+# --- SQS DLQ ---
+echo "📬 SQS Dead Letter Queue を作成中..."
+aws_cmd sqs create-queue --queue-name ${NAME_PREFIX}-provisioning-dlq 2>/dev/null || echo "  既存"
+aws_cmd sqs create-queue --queue-name ${NAME_PREFIX}-tenant-provisioner-dlq 2>/dev/null || echo "  既存"
+aws_cmd sqs create-queue --queue-name ${NAME_PREFIX}-provisioning-completion-dlq 2>/dev/null || echo "  既存"
+echo "✅ SQS 完了"
+
+# --- EventBridge ---
+echo "🚌 EventBridge イベントバスを作成中..."
+aws_cmd events create-event-bus --name "$EVENT_BUS_NAME" 2>/dev/null || echo "  バス '$EVENT_BUS_NAME' は既に存在します"
+echo "✅ EventBridge バス完了"
+
+# --- Lambda ---
+echo "⚡ Lambda 関数を登録中..."
+DUMMY_ROLE="arn:aws:iam::000000000000:role/dummy-lambda-role"
+
+# Provisioning Lambda (Control Plane)
+aws_cmd lambda create-function \
+  --function-name ${NAME_PREFIX}-provisioning \
+  --runtime nodejs20.x \
+  --role "$DUMMY_ROLE" \
+  --handler index.handler \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning/lambda.zip" \
+  --timeout 60 \
+  --memory-size 256 \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DYNAMODB_TABLE=$TABLE_NAME}" \
+  2>/dev/null || \
+aws_cmd lambda update-function-code \
+  --function-name ${NAME_PREFIX}-provisioning \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning/lambda.zip" \
+  2>/dev/null || echo "  Provisioning Lambda 登録スキップ（エミュレータ未対応）"
+
+# Tenant Provisioner Lambda (Application Plane)
+aws_cmd lambda create-function \
+  --function-name ${NAME_PREFIX}-tenant-provisioner \
+  --runtime nodejs20.x \
+  --role "$DUMMY_ROLE" \
+  --handler handler.handler \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/application-plane/tenant-provisioner/lambda.zip" \
+  --timeout 120 \
+  --memory-size 256 \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DATA_BUCKET_NAME=${NAME_PREFIX}-data}" \
+  2>/dev/null || \
+aws_cmd lambda update-function-code \
+  --function-name ${NAME_PREFIX}-tenant-provisioner \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/application-plane/tenant-provisioner/lambda.zip" \
+  2>/dev/null || echo "  Tenant Provisioner Lambda 登録スキップ（エミュレータ未対応）"
+
+# Provisioning Completion Lambda (Control Plane)
+aws_cmd lambda create-function \
+  --function-name ${NAME_PREFIX}-provisioning-completion \
+  --runtime nodejs20.x \
+  --role "$DUMMY_ROLE" \
+  --handler handler.handler \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning-completion/lambda.zip" \
+  --timeout 30 \
+  --memory-size 128 \
+  --environment "Variables={DYNAMODB_TABLE=$TABLE_NAME}" \
+  2>/dev/null || \
+aws_cmd lambda update-function-code \
+  --function-name ${NAME_PREFIX}-provisioning-completion \
+  --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning-completion/lambda.zip" \
+  2>/dev/null || echo "  Provisioning Completion Lambda 登録スキップ（エミュレータ未対応）"
+
+echo "✅ Lambda 完了"
+
+# --- EventBridge ルールと Lambda ターゲット ---
+echo "🔗 EventBridge ルールと Lambda ターゲットを設定中..."
+
+ACCOUNT_ID=000000000000
+REGION=ap-northeast-1
+LAMBDA_BASE="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function"
+
+# TenantOnboarding → tenant-provisioner
+aws_cmd events put-rule \
+  --name ${NAME_PREFIX}-tenant-onboarding \
+  --event-bus-name "$EVENT_BUS_NAME" \
+  --event-pattern '{"source":["tenkacloud.control-plane"],"detail-type":["TenantOnboarding"]}' \
+  2>/dev/null || echo "  ルール tenant-onboarding は既に存在します"
+
+aws_cmd events put-targets \
+  --rule ${NAME_PREFIX}-tenant-onboarding \
+  --event-bus-name "$EVENT_BUS_NAME" \
+  --targets "Id=tenant-provisioner,Arn=${LAMBDA_BASE}/${NAME_PREFIX}-tenant-provisioner" \
+  2>/dev/null || echo "  ターゲット tenant-provisioner は既に存在します"
+
+# TenantProvisioned → provisioning-completion
+aws_cmd events put-rule \
+  --name ${NAME_PREFIX}-tenant-provisioned \
+  --event-bus-name "$EVENT_BUS_NAME" \
+  --event-pattern '{"source":["tenkacloud.application-plane"],"detail-type":["TenantProvisioned"]}' \
+  2>/dev/null || echo "  ルール tenant-provisioned は既に存在します"
+
+aws_cmd events put-targets \
+  --rule ${NAME_PREFIX}-tenant-provisioned \
+  --event-bus-name "$EVENT_BUS_NAME" \
+  --targets "Id=provisioning-completion,Arn=${LAMBDA_BASE}/${NAME_PREFIX}-provisioning-completion" \
+  2>/dev/null || echo "  ターゲット provisioning-completion は既に存在します"
+
+echo "✅ EventBridge ルール完了"
+
+# --- DynamoDB Stream → Provisioning Lambda ---
+echo "🔁 DynamoDB Stream トリガーを設定中..."
+STREAM_ARN=$(aws_cmd dynamodb describe-table \
+  --table-name "$TABLE_NAME" \
+  --query 'Table.LatestStreamArn' \
+  --output text 2>/dev/null || echo "")
+
+if [ -n "$STREAM_ARN" ] && [ "$STREAM_ARN" != "None" ] && [ "$STREAM_ARN" != "null" ]; then
+  aws_cmd lambda create-event-source-mapping \
+    --event-source-arn "$STREAM_ARN" \
+    --function-name ${NAME_PREFIX}-provisioning \
+    --starting-position LATEST \
+    --batch-size 10 \
+    2>/dev/null || echo "  Stream トリガーは既に存在するかエミュレータ未対応"
+  echo "✅ DynamoDB Stream トリガー完了"
+else
+  echo "  ⚠️  DynamoDB Stream ARN が取得できません（エミュレータ未対応の可能性）"
+fi
 
 # 4. 確認
 echo ""
-echo "🔍 Verifying deployment..."
+echo "🔍 デプロイ確認..."
 
 echo ""
 echo "DynamoDB Tables:"
-aws --endpoint-url="$EMULATOR_ENDPOINT" dynamodb list-tables
+aws_cmd dynamodb list-tables
 
 echo ""
 echo "Lambda Functions:"
-aws --endpoint-url="$EMULATOR_ENDPOINT" lambda list-functions --query 'Functions[].FunctionName' 2>/dev/null || echo "  (Lambda 未対応)"
+aws_cmd lambda list-functions --query 'Functions[].FunctionName' 2>/dev/null || echo "  (Lambda 未対応)"
 
 echo ""
 echo "EventBridge Event Buses:"
-aws --endpoint-url="$EMULATOR_ENDPOINT" events list-event-buses --query 'EventBuses[].Name' 2>/dev/null || echo "  (EventBridge 未対応)"
+aws_cmd events list-event-buses --query 'EventBuses[].Name' 2>/dev/null || echo "  (EventBridge 未対応)"
 
 echo ""
 echo "S3 Buckets:"
-aws --endpoint-url="$EMULATOR_ENDPOINT" s3 ls 2>/dev/null || echo "  (S3 未対応)"
+aws_cmd s3 ls 2>/dev/null || echo "  (S3 未対応)"
 
 echo ""
 echo "======================================"
@@ -159,11 +304,9 @@ echo "                     EventBridge → Provisioning Completion → DynamoDB"
 echo "  Application Plane: EventBridge → Tenant Provisioner → S3 → EventBridge"
 echo ""
 echo "Test commands:"
-echo "  # Create a tenant (triggers full provisioning flow)"
-echo "  aws --endpoint-url=$EMULATOR_ENDPOINT dynamodb put-item \\"
-echo "    --table-name TenkaCloud-local \\"
-echo "    --item '{\"PK\":{\"S\":\"TENANT#test-tenant\"},\"SK\":{\"S\":\"METADATA\"},\"id\":{\"S\":\"test-tenant\"},\"name\":{\"S\":\"Test Tenant\"},\"slug\":{\"S\":\"test-tenant\"},\"tier\":{\"S\":\"FREE\"},\"status\":{\"S\":\"ACTIVE\"},\"provisioningStatus\":{\"S\":\"PENDING\"},\"EntityType\":{\"S\":\"TENANT\"},\"CreatedAt\":{\"S\":\"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'\"}}'"
+echo "  # テナント作成（プロビジョニングフロー全体を起動）"
+echo "  make test-tenant"
 echo ""
-echo "  # Check Provisioning Lambda logs (Control Plane)"
-echo "  aws --endpoint-url=$EMULATOR_ENDPOINT logs tail /aws/lambda/tenkacloud-local-provisioning --follow"
+echo "  # Provisioning Lambda のログ確認"
+echo "  make logs-local"
 echo ""


### PR DESCRIPTION
## Summary

- ローカルエミュレータ（Kumo/Floci）は IAM・EventBridge タグ API・DynamoDB GSI など未対応 API が多く Terraform が動作しないため除去
- `scripts/local-setup.sh` を AWS CLI ベースに置き換え（DynamoDB/S3/SQS/EventBridge/Lambda 登録）
- Terraform は本番 AWS 環境のみで使用する方針に変更

## Changes

- **scripts/local-setup.sh**: Terraform apply を削除し AWS CLI でリソース作成・Lambda 登録に変更
- **Makefile**: `start-local` / `start-infrastructure-bg` から `check-terraform` 依存を削除
- **.gitignore**: Playwright `test-results/` / `playwright-report/` を追加
- **terraform modules**: エミュレータ互換性改善
  - `AWSLambdaBasicExecutionRole` managed policy を inline policy に置換（Floci 対応）
  - EventBridge / SQS リソースに `lifecycle { ignore_changes = [tags, tags_all] }` 追加（Kumo/Floci 対応）

## Test plan

- [x] `make start-kumo` でローカル環境が起動することを確認
- [x] `make before-commit` (lint/typecheck/test/build) が全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified local development setup: Terraform is no longer required to start the local environment.
  * Updated local infrastructure provisioning script to use AWS CLI for improved setup experience.
  * Enhanced .gitignore to properly exclude Playwright test result artifacts.
  * Infrastructure configuration optimizations to improve resource management consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->