### PR TITLE
fix(dev): 開発サーバーを Kumo 自動起動後に立ち上げ、ポート解放コマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help install install_ci setup_husky clean lint lint_text format format_check before_commit before-commit start test test_quick test_coverage test_e2e test_e2e_ui test_e2e_headed dev build
-.PHONY: start-compose stop-compose stop restart status
+.PHONY: start-compose stop-compose stop stop-dev-servers restart status
 .PHONY: start-infrastructure start-infrastructure-bg start-dev-servers start-control-plane stop-infrastructure stop-control-plane restart-all
 .PHONY: check-docker check-docker-hub docker-build docker-run docker-stop docker-status
 .PHONY: start-local stop-local start-kumo start-localstack start-floci logs-local test-lambda test-tenant
@@ -227,8 +227,8 @@ start-infrastructure-bg: check-docker check-aws-cli
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@./scripts/local-setup.sh
 
-# フロントエンド開発サーバーを起動
-start-dev-servers:
+# フロントエンド開発サーバーを起動（Kumo が未起動なら先に起動する）
+start-dev-servers: start-local
 	@echo ""
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "🖥️  開発サーバーを起動します"
@@ -246,6 +246,7 @@ start-dev-servers:
 	@echo ""
 	DYNAMODB_ENDPOINT=$(EMULATOR_ENDPOINT) \
 	DYNAMODB_TABLE=$(LOCAL_TABLE) \
+	DYNAMODB_TABLE_NAME=$(LOCAL_TABLE) \
 	AWS_REGION=ap-northeast-1 \
 	AWS_ACCESS_KEY_ID=test \
 	AWS_SECRET_ACCESS_KEY=test \
@@ -258,6 +259,12 @@ start-dev-servers:
 
 # make stop: エミュレータを停止
 stop: stop-local
+
+# 開発サーバーのポートを解放（13000/13001/13004）
+stop-dev-servers:
+	@echo "🛑 開発サーバーを停止しています..."
+	@lsof -ti:13000,13001,13004 2>/dev/null | xargs kill -9 2>/dev/null || true
+	@echo "✅ ポート 13000/13001/13004 を解放しました"
 
 restart:
 	@echo "♻️  TenkaCloud を再起動します..."

--- a/apps/application-plane/app/(admin)/admin/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/__tests__/page.test.tsx
@@ -223,7 +223,7 @@ describe('Admin ダッシュボードページ', () => {
         {
           id: 'act-1',
           type: 'event_started',
-          message: '最近のアクティビティ',
+          message: 'テストイベント開始',
           timestamp: fiveMinAgo,
         },
       ],
@@ -231,9 +231,9 @@ describe('Admin ダッシュボードページ', () => {
     render(<AdminDashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('最近のアクティビティ')).toBeInTheDocument();
+      expect(screen.getByText('テストイベント開始')).toBeInTheDocument();
+      expect(screen.getByText('5分前')).toBeInTheDocument();
     });
-    expect(screen.getByText('5分前')).toBeInTheDocument();
     globalThis.Date = originalDate;
   });
 


### PR DESCRIPTION
## Summary
- `start-dev-servers` の前提条件に `start-local` を追加し、Kumo が未起動でも `make start-dev-servers` で自動起動するようにした
- `DYNAMODB_TABLE_NAME` 環境変数を追加（テナント管理サービスが参照する変数名と一致）
- `stop-dev-servers` ターゲットを追加（ポート 13000/13001/13004 を解放）
- タイムスタンプテストのアクティビティメッセージをセクションタイトルと重複しない値に修正し、`waitFor` 内でアサーションを実施

## Test plan
- [ ] `make start-dev-servers` でエミュレータが起動してから開発サーバーが起動することを確認
- [ ] `make stop-dev-servers` でポートが解放されることを確認
- [ ] `make before-commit` がすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development server startup process by ensuring cloud emulator dependencies are initialized before servers start.
  * Added ability to clean up local development ports as part of the shutdown process.
  * Enhanced environment configuration for local development database setup.

* **Tests**
  * Updated test assertions to verify proper timestamp display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->