### PR TITLE
fix(kumo): Kumo エミュレータの GSI/filter バグを回避しイベント一覧を正常表示

### DIFF
--- a/apps/application-plane/app/api/participant/events/[eventId]/route.ts
+++ b/apps/application-plane/app/api/participant/events/[eventId]/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Participant Event Detail API Proxy
+ *
+ * 参加者向けイベント詳細エンドポイント
+ */
+
+import { serverApiRequest } from '@/lib/api/server';
+import type { EventDetails } from '@/lib/api/types';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  const { eventId } = await params;
+
+  try {
+    const data = await serverApiRequest<EventDetails>(
+      `/participant/events/${eventId}`
+    );
+    return Response.json(data);
+  } catch (error) {
+    const status =
+      error instanceof Error && error.message.includes('404') ? 404 : 500;
+    return Response.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to fetch event',
+      },
+      { status }
+    );
+  }
+}

--- a/backend/services/application-plane/problem-service/src/auth/index.ts
+++ b/backend/services/application-plane/problem-service/src/auth/index.ts
@@ -17,8 +17,7 @@ if (process.env.AUTH_SKIP === '1' && process.env.NODE_ENV === 'production') {
 /* v8 ignore stop */
 
 const authSkipEnabled =
-  process.env.AUTH_SKIP === '1' &&
-  (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test');
+  process.env.AUTH_SKIP === '1' && process.env.NODE_ENV !== 'production';
 
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== 'undefined') {

--- a/backend/services/shared/dynamodb/src/event-repository.ts
+++ b/backend/services/shared/dynamodb/src/event-repository.ts
@@ -186,71 +186,56 @@ export class EventRepository {
     const client = getDocClient();
     const tableName = getTableName();
 
-    const filterParts: string[] = [];
-    const expressionValues: Record<string, unknown> = {
-      ':gsi1pk': buildTenantGSI(tenantId),
-    };
-    const expressionNames: Record<string, string> = {};
+    // NOTE: Kumo (local AWS emulator) has bugs with combined filter expressions
+    // and GSI hash key prefix matching. To work around these limitations,
+    // we query without DynamoDB-level filters and apply all filtering in application code.
+    const result = await client.send(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: 'GSI1',
+        KeyConditionExpression: 'GSI1PK = :gsi1pk',
+        ExpressionAttributeValues: { ':gsi1pk': buildTenantGSI(tenantId) },
+        Limit: 200,
+        ScanIndexForward: false,
+      })
+    );
+
+    // Filter in application code (handles Kumo emulator limitations)
+    const allItems = result.Items ?? [];
+    let events = allItems
+      .filter((item) => item.EntityType === EntityType.EVENT)
+      .map((item) => toDomain(item as EventItem));
 
     if (options?.type) {
-      filterParts.push('#type = :type');
-      expressionNames['#type'] = 'type';
-      expressionValues[':type'] = options.type;
+      events = events.filter((e) => e.type === options.type);
     }
 
     if (options?.status) {
       const statuses = Array.isArray(options.status)
         ? options.status
         : [options.status];
-      if (statuses.length === 1) {
-        filterParts.push('#status = :status');
-        expressionNames['#status'] = 'status';
-        expressionValues[':status'] = statuses[0];
-      } else {
-        const statusPlaceholders = statuses.map((_, i) => `:status${i}`);
-        filterParts.push(`#status IN (${statusPlaceholders.join(', ')})`);
-        expressionNames['#status'] = 'status';
-        statuses.forEach((s, i) => {
-          expressionValues[`:status${i}`] = s;
-        });
-      }
+      events = events.filter((e) => statuses.includes(e.status as EventStatus));
     }
 
     if (options?.startAfter) {
-      filterParts.push('startTime >= :startAfter');
-      expressionValues[':startAfter'] = options.startAfter.toISOString();
+      events = events.filter(
+        (e) => new Date(e.startTime) >= options.startAfter!
+      );
     }
 
     if (options?.startBefore) {
-      filterParts.push('startTime <= :startBefore');
-      expressionValues[':startBefore'] = options.startBefore.toISOString();
+      events = events.filter(
+        (e) => new Date(e.startTime) <= options.startBefore!
+      );
     }
 
-    const result = await client.send(
-      new QueryCommand({
-        TableName: tableName,
-        IndexName: 'GSI1',
-        KeyConditionExpression: 'GSI1PK = :gsi1pk',
-        FilterExpression:
-          filterParts.length > 0 ? filterParts.join(' AND ') : undefined,
-        ExpressionAttributeValues: expressionValues,
-        ExpressionAttributeNames:
-          Object.keys(expressionNames).length > 0 ? expressionNames : undefined,
-        Limit: options?.limit ?? 50,
-        ScanIndexForward: false,
-      })
-    );
+    const limit = options?.limit ?? 50;
 
-    let events = (result.Items ?? []).map((item) =>
-      toDomain(item as EventItem)
-    );
-
-    // Apply offset if provided
     if (options?.offset) {
       events = events.slice(options.offset);
     }
 
-    return events;
+    return events.slice(0, limit);
   }
 
   async list(options?: EventFilterOptions): Promise<{
@@ -668,9 +653,13 @@ export class EventRepository {
       })
     );
 
-    const problems = (result.Items ?? []).map((item) =>
-      toEventProblemDomain(item as EventProblemItem)
-    );
+    // Filter in application code to handle emulators (e.g. Kumo) that don't
+    // correctly implement begins_with and may return extra items
+    const problems = (result.Items ?? [])
+      .filter(
+        (item) => typeof item.SK === 'string' && item.SK.startsWith('PROBLEM#')
+      )
+      .map((item) => toEventProblemDomain(item as EventProblemItem));
 
     // Sort by order
     return problems.sort((a, b) => a.order - b.order);


### PR DESCRIPTION
## Summary
Kumo（ローカル AWS エミュレータ）の以下のバグにより、`/events` ページでイベントが表示されなかった問題を修正。

### Kumo のバグ（回避済み）
- GSI ハッシュキーで前方一致検索になり、プレフィックス一致するキーも返す
  → `TENANT#dev-tenant` クエリで `TENANT#dev-tenant#GAMEDAY` も返る
- `FilterExpression` の AND 条件が正しく評価されない
- `begins_with` がすべての SK を返す（正しく動作しない）

### 変更内容
1. **`event-repository.ts`（shared）**: `findByTenant` の DynamoDB FilterExpression を廃止し、アプリコードで EntityType/status/type/startTime をフィルタリング
2. **`event-repository.ts`（shared）**: `getEventProblems` で SK が `PROBLEM#` で始まるアイテムのみをフィルタリング
3. **`auth/index.ts`（problem-service）**: `AUTH_SKIP` 有効条件を `NODE_ENV !== 'production'` に緩和（bun は NODE_ENV を自動設定しないため）
4. **`route.ts`（application-plane）**: `/api/participant/events/[eventId]` の Next.js プロキシルートを追加（欠落していた）

## Test plan
- [ ] `make stop && make start-local && make start-dev-servers`
- [ ] `http://localhost:13001/events` でイベントが表示される
- [ ] イベントカード → `/events/[eventId]` に遷移する
- [ ] 「バトルに参加」→ `/gameday/[eventId]` に遷移する
- [ ] `make before-commit` がパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to retrieve individual participant event details.

* **Chores**
  * Optimized event data retrieval performance.
  * Updated authentication configuration for non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->