### PR TITLE
fix: ランキング API プロキシルートを追加

### DIFF
--- a/apps/application-plane/app/api/participant/rankings/route.ts
+++ b/apps/application-plane/app/api/participant/rankings/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Rankings API Proxy
+ *
+ * グローバルランキングエンドポイント
+ */
+
+import { NextRequest } from 'next/server';
+import { serverApiRequest, successResponse } from '@/lib/api/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const params = new URLSearchParams();
+  const limit = searchParams.get('limit');
+  const offset = searchParams.get('offset');
+  if (limit) params.set('limit', limit);
+  if (offset) params.set('offset', offset);
+
+  const qs = params.toString();
+  const data = await serverApiRequest(
+    `/participant/rankings${qs ? `?${qs}` : ''}`
+  );
+  return successResponse(data);
+}


### PR DESCRIPTION
## Summary
- `/api/participant/rankings` プロキシルートが存在せず 404 エラーになっていた
- problem-service の `/participant/rankings` に転送するルートを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)