### PR TITLE
feat: GameDay Battle ページ Cloudscape 統一 + ダークモード修正

### DIFF
--- a/apps/application-plane/app/(participant)/gameday/[eventId]/alliance/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/alliance/page.tsx
@@ -1,23 +1,25 @@
 /**
  * Alliance Page (同盟)
  *
- * ACTIVE同盟、受信PENDING、送信PENDING、新規リクエストフォーム
+ * Cloudscape Design System — 同盟リクエスト送信、ACTIVE同盟、受信/送信PENDING
  */
 
 'use client';
 
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Select from '@cloudscape-design/components/select';
+import type { SelectProps } from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useState } from 'react';
-import { AllianceCard } from '@/components/gameday';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  ErrorState,
-  getErrorMessage,
-  getErrorType,
-  Select,
-} from '@/components/ui';
 import {
   acceptAlliance,
   breakAlliance,
@@ -35,8 +37,10 @@ export default function AlliancePage() {
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>(
     {},
   );
-  const [teams, setTeams] = useState<{ value: string; label: string }[]>([]);
-  const [selectedTeam, setSelectedTeam] = useState('');
+  const [teamOptions, setTeamOptions] = useState<SelectProps.Option[]>([]);
+  const [selectedTeam, setSelectedTeam] = useState<SelectProps.Option | null>(
+    null,
+  );
   const [requesting, setRequesting] = useState(false);
 
   const fetchData = useCallback(async () => {
@@ -54,7 +58,6 @@ export default function AlliancePage() {
     }
   }, [eventId, teamId]);
 
-  // Fetch teams
   useEffect(() => {
     if (!eventId) return;
     const GAMEDAY_API_URL =
@@ -71,7 +74,7 @@ export default function AlliancePage() {
             value: t.teamId,
             label: t.teamName,
           }));
-        setTeams(opts);
+        setTeamOptions(opts);
       })
       .catch(() => {});
   }, [eventId, teamId]);
@@ -107,11 +110,11 @@ export default function AlliancePage() {
   };
 
   const handleRequest = async () => {
-    if (!eventId || !teamId || !selectedTeam) return;
+    if (!eventId || !teamId || !selectedTeam?.value) return;
     setRequesting(true);
     try {
-      await requestAlliance(eventId, teamId, selectedTeam);
-      setSelectedTeam('');
+      await requestAlliance(eventId, teamId, selectedTeam.value);
+      setSelectedTeam(null);
       await fetchData();
     } catch {
       // ignore
@@ -122,19 +125,22 @@ export default function AlliancePage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
-      </div>
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
     );
   }
 
   if (error) {
     return (
-      <ErrorState
-        message={getErrorMessage(error)}
-        type={getErrorType(error)}
-        onRetry={fetchData}
-      />
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator type="error">{error.message}</StatusIndicator>
+            <Button onClick={fetchData}>再試行</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
     );
   }
 
@@ -146,97 +152,165 @@ export default function AlliancePage() {
     (a) => a.status === 'PENDING' && a.requesterTeamId === teamId,
   );
 
+  const getPartnerTeamId = (a: Alliance) =>
+    a.requesterTeamId === teamId ? a.targetTeamId : a.requesterTeamId;
+
+  const formatDate = (ts: string) =>
+    new Date(ts).toLocaleDateString('ja-JP', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-        <span className="text-hn-accent font-mono">&gt;_</span>
-        同盟
-      </h1>
+    <SpaceBetween size="l">
+      <Header variant="h1">同盟</Header>
 
       {/* New Alliance Request */}
-      <Card>
-        <CardHeader>
-          <span className="font-semibold text-text-primary">
-            同盟リクエスト送信
-          </span>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-end gap-4">
+      <Container header={<Header variant="h2">同盟リクエスト送信</Header>}>
+        <SpaceBetween direction="horizontal" size="l" alignItems="end">
+          <FormField label="対象チーム" stretch>
             <Select
-              options={teams}
+              selectedOption={selectedTeam}
+              onChange={({ detail }) => setSelectedTeam(detail.selectedOption)}
+              options={teamOptions}
               placeholder="チームを選択"
-              value={selectedTeam}
-              onChange={(e) => setSelectedTeam(e.target.value)}
-              label="対象チーム"
+              filteringType="auto"
             />
-            <Button
-              variant="primary"
-              size="md"
-              onClick={handleRequest}
-              loading={requesting}
-              disabled={!selectedTeam || requesting}
-            >
-              送信
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+          </FormField>
+          <Button
+            variant="primary"
+            onClick={handleRequest}
+            loading={requesting}
+            disabled={!selectedTeam || requesting}
+          >
+            送信
+          </Button>
+        </SpaceBetween>
+      </Container>
 
       {/* Active Alliances */}
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold text-text-primary">
-          アクティブ ({active.length})
-        </h2>
-        {active.length === 0 ? (
-          <p className="text-text-muted text-sm">同盟なし</p>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {active.map((a) => (
-              <AllianceCard
-                key={a.id}
-                alliance={a}
-                myTeamId={teamId}
-                loading={actionLoading[a.id]}
-                onBreak={() => handleBreak(a.id)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <Cards
+        header={<Header counter={`(${active.length})`}>アクティブ</Header>}
+        items={active}
+        cardsPerRow={[
+          { cards: 1 },
+          { minWidth: 400, cards: 2 },
+          { minWidth: 700, cards: 3 },
+        ]}
+        cardDefinition={{
+          header: (a) => getPartnerTeamId(a),
+          sections: [
+            {
+              id: 'status',
+              content: () => (
+                <StatusIndicator type="success">ACTIVE</StatusIndicator>
+              ),
+            },
+            {
+              id: 'date',
+              header: '締結日',
+              content: (a) => formatDate(a.updatedAt),
+            },
+            {
+              id: 'action',
+              content: (a) => (
+                <Button
+                  variant="link"
+                  loading={actionLoading[a.id]}
+                  onClick={() => handleBreak(a.id)}
+                >
+                  同盟を破棄
+                </Button>
+              ),
+            },
+          ],
+        }}
+        empty={
+          <Box textAlign="center" padding="l" color="text-body-secondary">
+            同盟なし
+          </Box>
+        }
+      />
 
       {/* Pending Incoming */}
       {pendingIncoming.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold text-hn-warning">
-            受信リクエスト ({pendingIncoming.length})
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {pendingIncoming.map((a) => (
-              <AllianceCard
-                key={a.id}
-                alliance={a}
-                myTeamId={teamId}
-                loading={actionLoading[a.id]}
-                onAccept={() => handleAccept(a.id)}
-              />
-            ))}
-          </div>
-        </div>
+        <Cards
+          header={
+            <Header counter={`(${pendingIncoming.length})`}>
+              <StatusIndicator type="warning">受信リクエスト</StatusIndicator>
+            </Header>
+          }
+          items={pendingIncoming}
+          cardsPerRow={[
+            { cards: 1 },
+            { minWidth: 400, cards: 2 },
+            { minWidth: 700, cards: 3 },
+          ]}
+          cardDefinition={{
+            header: (a) => a.requesterTeamId,
+            sections: [
+              {
+                id: 'status',
+                content: () => (
+                  <StatusIndicator type="pending">PENDING</StatusIndicator>
+                ),
+              },
+              {
+                id: 'date',
+                header: '受信日',
+                content: (a) => formatDate(a.createdAt),
+              },
+              {
+                id: 'action',
+                content: (a) => (
+                  <Button
+                    variant="primary"
+                    loading={actionLoading[a.id]}
+                    onClick={() => handleAccept(a.id)}
+                  >
+                    承認
+                  </Button>
+                ),
+              },
+            ],
+          }}
+        />
       )}
 
       {/* Pending Outgoing */}
       {pendingOutgoing.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold text-text-secondary">
-            送信済みリクエスト ({pendingOutgoing.length})
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {pendingOutgoing.map((a) => (
-              <AllianceCard key={a.id} alliance={a} myTeamId={teamId} />
-            ))}
-          </div>
-        </div>
+        <Cards
+          header={
+            <Header counter={`(${pendingOutgoing.length})`}>
+              送信済みリクエスト
+            </Header>
+          }
+          items={pendingOutgoing}
+          cardsPerRow={[
+            { cards: 1 },
+            { minWidth: 400, cards: 2 },
+            { minWidth: 700, cards: 3 },
+          ]}
+          cardDefinition={{
+            header: (a) => a.targetTeamId,
+            sections: [
+              {
+                id: 'status',
+                content: () => (
+                  <StatusIndicator type="in-progress">送信済み</StatusIndicator>
+                ),
+              },
+              {
+                id: 'date',
+                header: '送信日',
+                content: (a) => formatDate(a.createdAt),
+              },
+            ],
+          }}
+        />
       )}
-    </div>
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/attack/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/attack/page.tsx
@@ -1,23 +1,26 @@
 /**
  * Attack Station (攻撃ステーション)
  *
- * 攻撃カタロググリッド、購入、ターゲット選択 + 実行、攻撃履歴テーブル
+ * Cloudscape Design System — 攻撃カタログ、ターゲット選択、攻撃履歴テーブル
  */
 
 'use client';
 
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Select from '@cloudscape-design/components/select';
+import type { SelectProps } from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useState } from 'react';
-import { AttackCard } from '@/components/gameday';
-import {
-  Badge,
-  Card,
-  CardContent,
-  CardHeader,
-  ErrorState,
-  getErrorMessage,
-  getErrorType,
-  Select,
-} from '@/components/ui';
 import {
   executeAttack,
   getAttackCatalog,
@@ -38,8 +41,9 @@ export default function AttackPage() {
   const [cooldowns, setCooldowns] = useState<Record<string, number>>({});
   const [purchasing, setPurchasing] = useState<Record<string, boolean>>({});
   const [executing, setExecuting] = useState<Record<string, boolean>>({});
-  const [selectedTarget, setSelectedTarget] = useState('');
-  const [teams, setTeams] = useState<{ value: string; label: string }[]>([]);
+  const [selectedTarget, setSelectedTarget] =
+    useState<SelectProps.Option | null>(null);
+  const [teamOptions, setTeamOptions] = useState<SelectProps.Option[]>([]);
 
   const fetchData = useCallback(async () => {
     if (!eventId || !teamId) return;
@@ -60,7 +64,6 @@ export default function AttackPage() {
     }
   }, [eventId, teamId]);
 
-  // Fetch team list for target selection
   useEffect(() => {
     if (!eventId) return;
     getParticipantTeams(eventId)
@@ -71,7 +74,7 @@ export default function AttackPage() {
             value: team.teamId,
             label: team.teamName,
           }));
-        setTeams(opts);
+        setTeamOptions(opts);
       })
       .catch(() => {});
   }, [eventId, teamId]);
@@ -94,10 +97,10 @@ export default function AttackPage() {
   };
 
   const handleExecute = async (attackId: string) => {
-    if (!eventId || !teamId || !selectedTarget) return;
+    if (!eventId || !teamId || !selectedTarget?.value) return;
     setExecuting((prev) => ({ ...prev, [attackId]: true }));
     try {
-      await executeAttack(eventId, teamId, attackId, selectedTarget);
+      await executeAttack(eventId, teamId, attackId, selectedTarget.value);
       await fetchData();
     } catch (err) {
       const e = err as Error & { status?: number; body?: CooldownError };
@@ -114,19 +117,22 @@ export default function AttackPage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
-      </div>
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
     );
   }
 
   if (error) {
     return (
-      <ErrorState
-        message={getErrorMessage(error)}
-        type={getErrorType(error)}
-        onRetry={fetchData}
-      />
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator type="error">{error.message}</StatusIndicator>
+            <Button onClick={fetchData}>再試行</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
     );
   }
 
@@ -137,111 +143,145 @@ export default function AttackPage() {
     });
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-          <span className="text-hn-accent font-mono">&gt;_</span>
-          攻撃ステーション
-        </h1>
-      </div>
+    <SpaceBetween size="l">
+      <Header variant="h1">攻撃ステーション</Header>
 
       {/* Target Selection */}
-      <Card>
-        <CardContent>
-          <div className="flex items-center gap-4">
-            <Select
-              options={teams}
-              placeholder="ターゲットチームを選択"
-              value={selectedTarget}
-              onChange={(e) => setSelectedTarget(e.target.value)}
-              label="ターゲット"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Attack Catalog Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {catalog.map((attack) => (
-          <AttackCard
-            key={attack.id}
-            attack={attack}
-            purchased={purchasedIds.has(attack.id)}
-            cooldownUntil={cooldowns[attack.id]}
-            purchasing={purchasing[attack.id]}
-            executing={executing[attack.id]}
-            onPurchase={() => handlePurchase(attack.id)}
-            onExecute={() => handleExecute(attack.id)}
+      <Container>
+        <FormField label="ターゲットチーム">
+          <Select
+            selectedOption={selectedTarget}
+            onChange={({ detail }) => setSelectedTarget(detail.selectedOption)}
+            options={teamOptions}
+            placeholder="ターゲットチームを選択"
+            filteringType="auto"
           />
-        ))}
-      </div>
+        </FormField>
+      </Container>
+
+      {/* Attack Catalog */}
+      <Cards
+        header={<Header counter={`(${catalog.length})`}>攻撃カタログ</Header>}
+        items={catalog}
+        cardsPerRow={[
+          { cards: 1 },
+          { minWidth: 400, cards: 2 },
+          { minWidth: 700, cards: 3 },
+        ]}
+        cardDefinition={{
+          header: (attack) => attack.name,
+          sections: [
+            {
+              id: 'type',
+              content: (attack) => (
+                <Badge
+                  color={attack.attackType === 'vulnerability' ? 'red' : 'blue'}
+                >
+                  {attack.attackType}
+                </Badge>
+              ),
+            },
+            {
+              id: 'desc',
+              header: '説明',
+              content: (attack) => (
+                <Box color="text-body-secondary">{attack.description}</Box>
+              ),
+            },
+            {
+              id: 'stats',
+              content: (attack) => (
+                <SpaceBetween direction="horizontal" size="l">
+                  <Box variant="small">
+                    コスト: <b>{attack.purchaseCost}</b>
+                  </Box>
+                  <Box variant="small">
+                    ダメージ: <b>{attack.damage}</b>
+                  </Box>
+                  <Box variant="small">
+                    報酬: <b>{attack.reward}</b>
+                  </Box>
+                </SpaceBetween>
+              ),
+            },
+            {
+              id: 'action',
+              content: (attack) => {
+                const purchased = purchasedIds.has(attack.id);
+                const onCooldown =
+                  cooldowns[attack.id] && Date.now() < cooldowns[attack.id];
+                return purchased ? (
+                  <Button
+                    variant="primary"
+                    fullWidth
+                    onClick={() => handleExecute(attack.id)}
+                    loading={executing[attack.id]}
+                    disabled={!selectedTarget?.value || onCooldown || false}
+                  >
+                    {onCooldown ? 'クールダウン中...' : '攻撃実行'}
+                  </Button>
+                ) : (
+                  <Button
+                    fullWidth
+                    onClick={() => handlePurchase(attack.id)}
+                    loading={purchasing[attack.id]}
+                  >
+                    購入 ({attack.purchaseCost} pts)
+                  </Button>
+                );
+              },
+            },
+          ],
+        }}
+        empty="攻撃カタログが空です"
+      />
 
       {/* Attack History */}
-      <Card>
-        <CardHeader>
-          <span className="font-semibold text-text-primary">攻撃履歴</span>
-        </CardHeader>
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="bg-surface-2 border-b border-border">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">
-                  時間
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">
-                  攻撃
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">
-                  対象
-                </th>
-                <th className="px-4 py-3 text-center text-xs font-medium text-text-muted uppercase">
-                  結果
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-text-muted uppercase">
-                  報酬
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {history.map((log) => (
-                <tr key={log.id}>
-                  <td className="px-4 py-3 text-sm font-mono text-text-muted">
-                    {formatTime(log.createdAt)}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-text-primary">
-                    {log.attackSlug}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-text-secondary">
-                    {log.defenderTeamId}
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <Badge
-                      variant={log.success ? 'success' : 'danger'}
-                      badgeStyle="subtle"
-                      size="sm"
-                    >
-                      {log.success ? '成功' : '失敗'}
-                    </Badge>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-right font-mono text-hn-success">
-                    {log.success ? `+${log.reward}` : '0'}
-                  </td>
-                </tr>
-              ))}
-              {history.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={5}
-                    className="px-4 py-8 text-center text-text-muted text-sm"
-                  >
-                    攻撃履歴なし
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </Card>
-    </div>
+      <Table
+        header={<Header counter={`(${history.length})`}>攻撃履歴</Header>}
+        items={history}
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: '時間',
+            cell: (log) => formatTime(log.createdAt),
+            width: 100,
+          },
+          {
+            id: 'attack',
+            header: '攻撃',
+            cell: (log) => <Box variant="code">{log.attackSlug}</Box>,
+          },
+          {
+            id: 'target',
+            header: '対象',
+            cell: (log) => log.defenderTeamId,
+          },
+          {
+            id: 'result',
+            header: '結果',
+            cell: (log) => (
+              <StatusIndicator type={log.success ? 'success' : 'error'}>
+                {log.success ? '成功' : '失敗'}
+              </StatusIndicator>
+            ),
+            width: 120,
+          },
+          {
+            id: 'reward',
+            header: '報酬',
+            cell: (log) =>
+              log.success ? (
+                <Box color="text-status-success">+{log.reward}</Box>
+              ) : (
+                '0'
+              ),
+            width: 100,
+          },
+        ]}
+        empty="攻撃履歴なし"
+        sortingDisabled
+      />
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/defense/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/defense/page.tsx
@@ -1,14 +1,22 @@
 /**
  * Defense Trench (防衛塹壕)
  *
- * 受けている攻撃一覧、ヒント購入、脆弱性修正報告
+ * Cloudscape Design System — 受けている攻撃一覧、ヒント購入、脆弱性修正報告
  */
 
 'use client';
 
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useState } from 'react';
-import { DefenseItem } from '@/components/gameday';
-import { ErrorState, getErrorMessage, getErrorType } from '@/components/ui';
 import { getActiveDefense, purchaseHint, reportFix } from '@/lib/api/gameday';
 import type { AttackLog } from '@/lib/api/gameday-types';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
@@ -71,67 +79,149 @@ export default function DefensePage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
-      </div>
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
     );
   }
 
   if (error) {
     return (
-      <ErrorState
-        message={getErrorMessage(error)}
-        type={getErrorType(error)}
-        onRetry={fetchData}
-      />
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator type="error">{error.message}</StatusIndicator>
+            <Button onClick={fetchData}>再試行</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
     );
   }
 
   const active = attacks.filter((a) => !a.neutralized);
   const neutralized = attacks.filter((a) => a.neutralized);
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-        <span className="text-hn-accent font-mono">&gt;_</span>
-        防衛塹壕
-      </h1>
+  const formatTime = (ts: string) =>
+    new Date(ts).toLocaleTimeString('ja-JP', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
 
-      {/* Active attacks */}
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold text-text-primary">
-          攻撃を受けている ({active.length})
-        </h2>
-        {active.length === 0 ? (
-          <p className="text-text-muted text-sm py-4">
-            現在攻撃を受けていません
-          </p>
-        ) : (
-          active.map((atk) => (
-            <DefenseItem
-              key={atk.id}
-              attack={atk}
-              hint={hints[atk.attackId]}
-              hintLoading={hintLoading[atk.attackId]}
-              fixLoading={fixLoading[atk.attackSlug]}
-              onPurchaseHint={() => handlePurchaseHint(atk.attackId)}
-              onReportFix={() => handleReportFix(atk.attackSlug)}
-            />
-          ))
-        )}
-      </div>
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1">防衛塹壕</Header>
+
+      {/* Active Attacks */}
+      <Table
+        header={
+          <Header
+            counter={`(${active.length})`}
+            description="現在受けている攻撃"
+          >
+            攻撃を受けている
+          </Header>
+        }
+        items={active}
+        columnDefinitions={[
+          {
+            id: 'attack',
+            header: '攻撃',
+            cell: (atk) => <Box variant="code">{atk.attackSlug}</Box>,
+          },
+          {
+            id: 'attacker',
+            header: '攻撃元',
+            cell: (atk) => atk.attackerTeamId,
+          },
+          {
+            id: 'damage',
+            header: 'ダメージ',
+            cell: (atk) => <Box color="text-status-error">{atk.damage}</Box>,
+            width: 100,
+          },
+          {
+            id: 'time',
+            header: '時間',
+            cell: (atk) => formatTime(atk.createdAt),
+            width: 120,
+          },
+          {
+            id: 'hint',
+            header: 'ヒント',
+            cell: (atk) =>
+              hints[atk.attackId] ? (
+                <StatusIndicator type="info">
+                  {hints[atk.attackId]}
+                </StatusIndicator>
+              ) : (
+                <Button
+                  variant="link"
+                  loading={hintLoading[atk.attackId]}
+                  onClick={() => handlePurchaseHint(atk.attackId)}
+                >
+                  ヒント購入
+                </Button>
+              ),
+          },
+          {
+            id: 'fix',
+            header: '修正',
+            cell: (atk) => (
+              <Button
+                variant="primary"
+                loading={fixLoading[atk.attackSlug]}
+                onClick={() => handleReportFix(atk.attackSlug)}
+              >
+                修正報告
+              </Button>
+            ),
+            width: 130,
+          },
+        ]}
+        empty="現在攻撃を受けていません"
+        sortingDisabled
+        footer={
+          <Box textAlign="center" color="text-body-secondary" fontSize="body-s">
+            <em>10秒ごとに自動更新</em>
+          </Box>
+        }
+      />
 
       {/* Neutralized */}
       {neutralized.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold text-text-secondary">
-            修正済み ({neutralized.length})
-          </h2>
-          {neutralized.map((atk) => (
-            <DefenseItem key={atk.id} attack={atk} />
-          ))}
-        </div>
+        <Table
+          header={<Header counter={`(${neutralized.length})`}>修正済み</Header>}
+          items={neutralized}
+          columnDefinitions={[
+            {
+              id: 'attack',
+              header: '攻撃',
+              cell: (atk) => <Box variant="code">{atk.attackSlug}</Box>,
+            },
+            {
+              id: 'attacker',
+              header: '攻撃元',
+              cell: (atk) => atk.attackerTeamId,
+            },
+            {
+              id: 'status',
+              header: 'ステータス',
+              cell: () => (
+                <StatusIndicator type="success">修正済み</StatusIndicator>
+              ),
+            },
+            {
+              id: 'time',
+              header: '時間',
+              cell: (atk) => formatTime(atk.createdAt),
+              width: 120,
+            },
+          ]}
+          empty=""
+          sortingDisabled
+        />
       )}
-    </div>
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -61,18 +61,12 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
       text: 'Event',
       items: [
         { type: 'link', text: 'Home', href: basePath },
-        { type: 'link', text: 'Score events', href: `${basePath}/scoreboard` },
-        {
-          type: 'link',
-          text: 'Scoreboard',
-          href: `${basePath}/scoreboard`,
-          external: true,
-        },
+        { type: 'link', text: 'Scoreboard', href: `${basePath}/scoreboard` },
       ],
     },
     {
       type: 'section',
-      text: 'Quests',
+      text: 'Battle',
       items: [
         { type: 'link', text: '防衛', href: `${basePath}/defense` },
         { type: 'link', text: '攻撃', href: `${basePath}/attack` },

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -1,21 +1,22 @@
 /**
  * Vote Page (投票)
  *
- * チームカードグリッド、投票ボタン、結果表示
+ * Cloudscape Design System — チームカードグリッド、投票ボタン、結果表示
  */
 
 'use client';
 
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useState } from 'react';
-import {
-  Badge,
-  Button,
-  Card,
-  CardContent,
-  ErrorState,
-  getErrorMessage,
-  getErrorType,
-} from '@/components/ui';
 import { getVotingResults, submitVote } from '@/lib/api/gameday';
 import type { Team, Vote } from '@/lib/api/gameday-types';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
@@ -43,7 +44,6 @@ export default function VotePage() {
       ]);
       setTeams(teamsRes.teams || []);
       setVotes(votesData.results);
-      // Check if already voted
       if (votesData.results.some((v: Vote) => v.voterTeamId === teamId)) {
         setVoted(true);
       }
@@ -77,23 +77,25 @@ export default function VotePage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
-      </div>
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
     );
   }
 
   if (error) {
     return (
-      <ErrorState
-        message={getErrorMessage(error)}
-        type={getErrorType(error)}
-        onRetry={fetchData}
-      />
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator type="error">{error.message}</StatusIndicator>
+            <Button onClick={fetchData}>再試行</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
     );
   }
 
-  // Tally votes per team
   const voteCounts: Record<string, number> = {};
   for (const v of votes) {
     voteCounts[v.votedForTeamId] = (voteCounts[v.votedForTeamId] || 0) + 1;
@@ -102,59 +104,58 @@ export default function VotePage() {
   const otherTeams = teams.filter((t) => t.teamId !== teamId);
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-        <span className="text-hn-accent font-mono">&gt;_</span>
-        投票
-      </h1>
+    <SpaceBetween size="l">
+      <Header variant="h1">投票</Header>
 
       {voted && (
-        <div className="bg-hn-success/10 border border-hn-success/30 rounded-[var(--radius)] p-4 text-hn-success text-sm">
+        <StatusIndicator type="success">
           投票済みです。ありがとうございます!
-        </div>
+        </StatusIndicator>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {otherTeams.map((team) => (
-          <Card key={team.teamId}>
-            <CardContent className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="font-semibold text-text-primary text-lg">
-                  {team.teamName}
-                </span>
-                {voteCounts[team.teamId] && (
-                  <Badge variant="info" badgeStyle="subtle" size="sm">
-                    {voteCounts[team.teamId]} 票
-                  </Badge>
-                )}
-              </div>
-
-              {!voted ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  fullWidth
-                  onClick={() => handleVote(team.teamId)}
-                  loading={voting}
-                  disabled={voting}
-                >
-                  投票する
-                </Button>
-              ) : (
-                <div className="text-center text-xs text-text-muted py-1">
-                  {voteCounts[team.teamId] || 0} 票獲得
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {otherTeams.length === 0 && (
-        <Card className="text-center py-12">
-          <p className="text-text-muted">他のチームがまだ登録されていません</p>
-        </Card>
-      )}
-    </div>
+      <Cards
+        items={otherTeams}
+        cardsPerRow={[
+          { cards: 1 },
+          { minWidth: 400, cards: 2 },
+          { minWidth: 700, cards: 3 },
+        ]}
+        cardDefinition={{
+          header: (team) => (
+            <SpaceBetween direction="horizontal" size="xs">
+              <span>{team.teamName}</span>
+              {voteCounts[team.teamId] ? (
+                <Badge color="blue">{voteCounts[team.teamId]} 票</Badge>
+              ) : null}
+            </SpaceBetween>
+          ),
+          sections: [
+            {
+              id: 'action',
+              content: (team) =>
+                !voted ? (
+                  <Button
+                    fullWidth
+                    onClick={() => handleVote(team.teamId)}
+                    loading={voting}
+                    disabled={voting}
+                  >
+                    投票する
+                  </Button>
+                ) : (
+                  <Box textAlign="center" color="text-body-secondary">
+                    {voteCounts[team.teamId] || 0} 票獲得
+                  </Box>
+                ),
+            },
+          ],
+        }}
+        empty={
+          <Box textAlign="center" padding="l" color="text-body-secondary">
+            他のチームがまだ登録されていません
+          </Box>
+        }
+      />
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/layout.tsx
+++ b/apps/application-plane/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { auth, authSkipEnabled } from '@/auth';
 import { Providers } from '@/components/providers';
+import '@cloudscape-design/global-styles/index.css';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -16,8 +17,8 @@ export default async function RootLayout({
   const session = await auth();
 
   return (
-    <html lang="ja">
-      <body>
+    <html lang="ja" className="awsui-dark-mode">
+      <body className="awsui-dark-mode">
         <Providers session={session} authSkip={authSkipEnabled}>
           {children}
         </Providers>


### PR DESCRIPTION
## Summary

- サイドナビ: Quests → Battle 名称変更、Score events/Scoreboard 重複解消
- 同盟・攻撃・防衛・投票の4ページを Cloudscape コンポーネントに変換
- ダークモード: html/body に awsui-dark-mode クラス + global styles ルートインポート

## Test plan

- [x] typecheck パス
- [x] 全 493 テストパス
- [x] format_check パス (biome + prettier)

https://claude.ai/code/session_01ByKPNvTphgWTMSMqSWD8er

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Applied dark mode theme globally across the application.

* **Style**
  * Redesigned alliance, attack, defense, and voting pages with improved layouts and visual components.
  * Enhanced data tables with better formatting and status indicators.
  * Improved form controls and interactive elements for better usability.

* **Chores**
  * Updated navigation: renamed "Quests" section to "Battle" and simplified scoreboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->