### PR TITLE
feat: イベント新規作成・編集ページの実装

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/edit/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/edit/page.tsx
@@ -1,0 +1,247 @@
+/**
+ * Admin Event Edit Page
+ *
+ * Cloudscape Design System — イベント編集
+ */
+
+'use client';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import DatePicker from '@cloudscape-design/components/date-picker';
+import Form from '@cloudscape-design/components/form';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import Select from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import type { AdminEvent } from '@/lib/api/admin-types';
+import { get, put } from '@/lib/api/client';
+
+import {
+  buildPayload,
+  CLOUD_PROVIDER_OPTIONS,
+  findOption,
+  PARTICIPANT_TYPE_OPTIONS,
+  SCORING_TYPE_OPTIONS,
+  STATUS_OPTIONS,
+  TIMEZONE_OPTIONS,
+  TYPE_OPTIONS,
+  useEventFormState,
+} from '../../use-event-form-state';
+
+export default function AdminEventEditPage() {
+  const router = useRouter();
+  const params = useParams();
+  const eventId = params.eventId as string;
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const { form, errors, submitting, serverError, setField, submit } =
+    useEventFormState();
+
+  useEffect(() => {
+    async function fetchEvent() {
+      try {
+        setLoading(true);
+        setFetchError(null);
+        const data = await get<AdminEvent>(`/admin/events/${eventId}`);
+        const startDate = data.startTime ? data.startTime.slice(0, 10) : '';
+        const endDate = data.endTime ? data.endTime.slice(0, 10) : '';
+        setField('name', data.name || '');
+        setField('type', findOption(TYPE_OPTIONS, data.type));
+        setField('status', findOption(STATUS_OPTIONS, data.status));
+        setField('startTime', startDate);
+        setField('endTime', endDate);
+        setField(
+          'timezone',
+          findOption(TIMEZONE_OPTIONS, data.timezone) ?? TIMEZONE_OPTIONS[0],
+        );
+        setField(
+          'participantType',
+          findOption(PARTICIPANT_TYPE_OPTIONS, data.participantType),
+        );
+        setField(
+          'cloudProvider',
+          findOption(CLOUD_PROVIDER_OPTIONS, data.cloudProvider),
+        );
+        setField('maxParticipants', String(data.maxParticipants ?? 100));
+        setField(
+          'scoringType',
+          findOption(SCORING_TYPE_OPTIONS, data.scoringType),
+        );
+      } catch (err) {
+        setFetchError(
+          err instanceof Error ? err.message : 'イベントの取得に失敗しました',
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchEvent();
+  }, [eventId, setField]);
+
+  const handleSubmit = async () => {
+    const ok = await submit(() =>
+      put(`/admin/events/${eventId}`, buildPayload(form)),
+    );
+    if (ok) router.push('/admin/events');
+  };
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <SpaceBetween size="m">
+          <StatusIndicator type="error">{fetchError}</StatusIndicator>
+          <Button onClick={() => router.push('/admin/events')}>
+            イベント一覧に戻る
+          </Button>
+        </SpaceBetween>
+      </Box>
+    );
+  }
+
+  return (
+    <Form
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button variant="link" onClick={() => router.push('/admin/events')}>
+            キャンセル
+          </Button>
+          <Button variant="primary" loading={submitting} onClick={handleSubmit}>
+            更新
+          </Button>
+        </SpaceBetween>
+      }
+      header={<Header variant="h1">イベント編集</Header>}
+      errorText={serverError ?? undefined}
+    >
+      <Container header={<Header variant="h2">基本情報</Header>}>
+        <SpaceBetween size="l">
+          <FormField
+            label="イベント名"
+            errorText={errors.name}
+            constraintText="必須"
+          >
+            <Input
+              value={form.name}
+              onChange={({ detail }) => setField('name', detail.value)}
+              placeholder="例: クラウドチャレンジ 2026 春"
+            />
+          </FormField>
+          <SpaceBetween direction="horizontal" size="l">
+            <FormField label="タイプ">
+              <Select
+                selectedOption={form.type}
+                onChange={({ detail }) =>
+                  setField('type', detail.selectedOption)
+                }
+                options={TYPE_OPTIONS}
+              />
+            </FormField>
+            <FormField label="ステータス">
+              <Select
+                selectedOption={form.status}
+                onChange={({ detail }) =>
+                  setField('status', detail.selectedOption)
+                }
+                options={STATUS_OPTIONS}
+              />
+            </FormField>
+          </SpaceBetween>
+          <SpaceBetween direction="horizontal" size="l">
+            <FormField label="開始日">
+              <DatePicker
+                value={form.startTime}
+                onChange={({ detail }) => setField('startTime', detail.value)}
+                placeholder="YYYY/MM/DD"
+                openCalendarAriaLabel={(s) =>
+                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
+                }
+              />
+            </FormField>
+            <FormField label="終了日" errorText={errors.endTime}>
+              <DatePicker
+                value={form.endTime}
+                onChange={({ detail }) => setField('endTime', detail.value)}
+                placeholder="YYYY/MM/DD"
+                openCalendarAriaLabel={(s) =>
+                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
+                }
+              />
+            </FormField>
+          </SpaceBetween>
+          <FormField label="タイムゾーン">
+            <Select
+              selectedOption={form.timezone}
+              onChange={({ detail }) =>
+                setField('timezone', detail.selectedOption)
+              }
+              options={TIMEZONE_OPTIONS}
+            />
+          </FormField>
+        </SpaceBetween>
+      </Container>
+      <Box margin={{ top: 'l' }}>
+        <Container header={<Header variant="h2">参加設定</Header>}>
+          <SpaceBetween size="l">
+            <SpaceBetween direction="horizontal" size="l">
+              <FormField label="参加形式">
+                <Select
+                  selectedOption={form.participantType}
+                  onChange={({ detail }) =>
+                    setField('participantType', detail.selectedOption)
+                  }
+                  options={PARTICIPANT_TYPE_OPTIONS}
+                />
+              </FormField>
+              <FormField label="クラウドプロバイダー">
+                <Select
+                  selectedOption={form.cloudProvider}
+                  onChange={({ detail }) =>
+                    setField('cloudProvider', detail.selectedOption)
+                  }
+                  options={CLOUD_PROVIDER_OPTIONS}
+                />
+              </FormField>
+            </SpaceBetween>
+            <SpaceBetween direction="horizontal" size="l">
+              <FormField label="最大参加者数">
+                <Input
+                  type="number"
+                  value={form.maxParticipants}
+                  onChange={({ detail }) =>
+                    setField('maxParticipants', detail.value)
+                  }
+                  inputMode="numeric"
+                />
+              </FormField>
+              <FormField label="採点方式">
+                <Select
+                  selectedOption={form.scoringType}
+                  onChange={({ detail }) =>
+                    setField('scoringType', detail.selectedOption)
+                  }
+                  options={SCORING_TYPE_OPTIONS}
+                />
+              </FormField>
+            </SpaceBetween>
+          </SpaceBetween>
+        </Container>
+      </Box>
+    </Form>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
+++ b/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
@@ -1,0 +1,297 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildPayload,
+  CLOUD_PROVIDER_OPTIONS,
+  DEFAULT_FORM_STATE,
+  findOption,
+  PARTICIPANT_TYPE_OPTIONS,
+  SCORING_TYPE_OPTIONS,
+  STATUS_OPTIONS,
+  TIMEZONE_OPTIONS,
+  TYPE_OPTIONS,
+  useEventFormState,
+  validateEventForm,
+} from '../use-event-form-state';
+
+describe('useEventFormState フック', () => {
+  it('デフォルト値で初期化されるべき', () => {
+    const { result } = renderHook(() => useEventFormState());
+    expect(result.current.form.name).toBe('');
+    expect(result.current.form.type).toEqual(TYPE_OPTIONS[0]);
+    expect(result.current.form.status).toEqual(STATUS_OPTIONS[0]);
+    expect(result.current.form.maxParticipants).toBe('100');
+    expect(result.current.errors).toEqual({});
+    expect(result.current.submitting).toBe(false);
+    expect(result.current.serverError).toBeNull();
+  });
+
+  it('カスタム初期値で初期化されるべき', () => {
+    const custom = {
+      ...DEFAULT_FORM_STATE,
+      name: 'テスト',
+      maxParticipants: '50',
+    };
+    const { result } = renderHook(() => useEventFormState(custom));
+    expect(result.current.form.name).toBe('テスト');
+    expect(result.current.form.maxParticipants).toBe('50');
+  });
+
+  it('setField でフォーム値を更新できるべき', () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', '新しいイベント');
+    });
+    expect(result.current.form.name).toBe('新しいイベント');
+  });
+
+  it('setField で Select オプションを更新できるべき', () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('type', TYPE_OPTIONS[1]);
+    });
+    expect(result.current.form.type).toEqual(TYPE_OPTIONS[1]);
+  });
+
+  it('setField で全フィールドを個別に更新できるべき', () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('startTime', '2026-05-01');
+      result.current.setField('endTime', '2026-05-02');
+      result.current.setField('timezone', TIMEZONE_OPTIONS[1]);
+      result.current.setField('participantType', PARTICIPANT_TYPE_OPTIONS[1]);
+      result.current.setField('cloudProvider', CLOUD_PROVIDER_OPTIONS[1]);
+      result.current.setField('maxParticipants', '500');
+      result.current.setField('scoringType', SCORING_TYPE_OPTIONS[1]);
+      result.current.setField('status', STATUS_OPTIONS[1]);
+    });
+    expect(result.current.form.startTime).toBe('2026-05-01');
+    expect(result.current.form.endTime).toBe('2026-05-02');
+    expect(result.current.form.timezone).toEqual(TIMEZONE_OPTIONS[1]);
+    expect(result.current.form.participantType).toEqual(
+      PARTICIPANT_TYPE_OPTIONS[1],
+    );
+    expect(result.current.form.cloudProvider).toEqual(
+      CLOUD_PROVIDER_OPTIONS[1],
+    );
+    expect(result.current.form.maxParticipants).toBe('500');
+    expect(result.current.form.scoringType).toEqual(SCORING_TYPE_OPTIONS[1]);
+    expect(result.current.form.status).toEqual(STATUS_OPTIONS[1]);
+  });
+
+  it('名前が空の場合にバリデーションエラーを返すべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit(async () => ({}));
+    });
+    expect(ok).toBe(false);
+    expect(result.current.errors.name).toBe('イベント名は必須です');
+  });
+
+  it('終了日が開始日より前の場合にバリデーションエラーを返すべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', 'テスト');
+      result.current.setField('startTime', '2026-05-10');
+      result.current.setField('endTime', '2026-05-01');
+    });
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit(async () => ({}));
+    });
+    expect(ok).toBe(false);
+    expect(result.current.errors.endTime).toBe(
+      '終了日は開始日より後に設定してください',
+    );
+  });
+
+  it('バリデーション成功時に API を呼び出して true を返すべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', 'テストイベント');
+    });
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit(async () => ({ id: 'evt-1' }));
+    });
+    expect(ok).toBe(true);
+    expect(result.current.errors).toEqual({});
+    expect(result.current.serverError).toBeNull();
+  });
+
+  it('API エラー時に serverError をセットして false を返すべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', 'テスト');
+    });
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit(async () => {
+        throw new Error('サーバーエラー');
+      });
+    });
+    expect(ok).toBe(false);
+    expect(result.current.serverError).toBe('サーバーエラー');
+  });
+
+  it('Error 以外の例外時にデフォルトエラーメッセージを返すべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', 'テスト');
+    });
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit(async () => {
+        throw 'string error';
+      });
+    });
+    expect(ok).toBe(false);
+    expect(result.current.serverError).toBe('エラーが発生しました');
+  });
+
+  it('submit 完了後に submitting が false になるべき', async () => {
+    const { result } = renderHook(() => useEventFormState());
+    act(() => {
+      result.current.setField('name', 'テスト');
+    });
+    await act(async () => {
+      await result.current.submit(async () => ({ id: 'evt-1' }));
+    });
+    expect(result.current.submitting).toBe(false);
+  });
+});
+
+describe('validateEventForm', () => {
+  it('名前が空の場合にエラーを返すべき', () => {
+    expect(validateEventForm({ ...DEFAULT_FORM_STATE, name: '' }).name).toBe(
+      'イベント名は必須です',
+    );
+  });
+
+  it('空白のみの名前にエラーを返すべき', () => {
+    expect(validateEventForm({ ...DEFAULT_FORM_STATE, name: '   ' }).name).toBe(
+      'イベント名は必須です',
+    );
+  });
+
+  it('正常な名前にはエラーを返さないべき', () => {
+    expect(
+      validateEventForm({ ...DEFAULT_FORM_STATE, name: 'テスト' }).name,
+    ).toBeUndefined();
+  });
+
+  it('終了日が開始日以前の場合にエラーを返すべき', () => {
+    expect(
+      validateEventForm({
+        ...DEFAULT_FORM_STATE,
+        name: 'テスト',
+        startTime: '2026-05-10',
+        endTime: '2026-05-01',
+      }).endTime,
+    ).toBe('終了日は開始日より後に設定してください');
+  });
+
+  it('終了日が開始日と同じ場合にエラーを返すべき', () => {
+    expect(
+      validateEventForm({
+        ...DEFAULT_FORM_STATE,
+        name: 'テスト',
+        startTime: '2026-05-10',
+        endTime: '2026-05-10',
+      }).endTime,
+    ).toBe('終了日は開始日より後に設定してください');
+  });
+
+  it('開始日が空の場合に終了日エラーを返さないべき', () => {
+    expect(
+      validateEventForm({
+        ...DEFAULT_FORM_STATE,
+        name: 'テスト',
+        startTime: '',
+        endTime: '2026-05-01',
+      }).endTime,
+    ).toBeUndefined();
+  });
+
+  it('終了日が空の場合にエラーを返さないべき', () => {
+    expect(
+      validateEventForm({
+        ...DEFAULT_FORM_STATE,
+        name: 'テスト',
+        startTime: '2026-05-01',
+        endTime: '',
+      }).endTime,
+    ).toBeUndefined();
+  });
+});
+
+describe('findOption', () => {
+  it('値にマッチするオプションを返すべき', () => {
+    expect(findOption(TYPE_OPTIONS, 'jam')).toEqual({
+      label: 'Jam',
+      value: 'jam',
+    });
+  });
+
+  it('マッチしない場合に null を返すべき', () => {
+    expect(findOption(TYPE_OPTIONS, 'unknown')).toBeNull();
+  });
+
+  it('value が undefined の場合に null を返すべき', () => {
+    expect(findOption(TYPE_OPTIONS, undefined)).toBeNull();
+  });
+
+  it('value が空文字の場合に null を返すべき', () => {
+    expect(findOption(TYPE_OPTIONS, '')).toBeNull();
+  });
+});
+
+describe('buildPayload', () => {
+  it('フォーム状態からペイロードを正しく構築すべき', () => {
+    expect(buildPayload(DEFAULT_FORM_STATE)).toEqual({
+      name: '',
+      type: 'gameday',
+      status: 'draft',
+      startTime: '',
+      endTime: '',
+      timezone: 'Asia/Tokyo',
+      participantType: 'individual',
+      cloudProvider: 'aws',
+      maxParticipants: 100,
+      scoringType: 'realtime',
+    });
+  });
+
+  it('null オプションの場合に undefined を返すべき', () => {
+    const payload = buildPayload({
+      ...DEFAULT_FORM_STATE,
+      type: null,
+      status: null,
+    });
+    expect(payload.type).toBeUndefined();
+    expect(payload.status).toBeUndefined();
+  });
+});
+
+describe('定数オプション', () => {
+  it('TYPE_OPTIONS に gameday と jam が含まれるべき', () => {
+    expect(TYPE_OPTIONS).toHaveLength(2);
+  });
+  it('STATUS_OPTIONS に draft と scheduled が含まれるべき', () => {
+    expect(STATUS_OPTIONS).toHaveLength(2);
+  });
+  it('PARTICIPANT_TYPE_OPTIONS に individual と team が含まれるべき', () => {
+    expect(PARTICIPANT_TYPE_OPTIONS).toHaveLength(2);
+  });
+  it('CLOUD_PROVIDER_OPTIONS に 4 つのプロバイダーが含まれるべき', () => {
+    expect(CLOUD_PROVIDER_OPTIONS).toHaveLength(4);
+  });
+  it('SCORING_TYPE_OPTIONS に realtime と batch が含まれるべき', () => {
+    expect(SCORING_TYPE_OPTIONS).toHaveLength(2);
+  });
+  it('TIMEZONE_OPTIONS に 4 つのタイムゾーンが含まれるべき', () => {
+    expect(TIMEZONE_OPTIONS).toHaveLength(4);
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/events/new/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/new/page.tsx
@@ -1,0 +1,174 @@
+/**
+ * Admin Event Create Page
+ *
+ * Cloudscape Design System — イベント新規作成
+ */
+
+'use client';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import DatePicker from '@cloudscape-design/components/date-picker';
+import Form from '@cloudscape-design/components/form';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import Select from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { useRouter } from 'next/navigation';
+
+import { post } from '@/lib/api/client';
+
+import {
+  buildPayload,
+  CLOUD_PROVIDER_OPTIONS,
+  PARTICIPANT_TYPE_OPTIONS,
+  SCORING_TYPE_OPTIONS,
+  STATUS_OPTIONS,
+  TIMEZONE_OPTIONS,
+  TYPE_OPTIONS,
+  useEventFormState,
+} from '../use-event-form-state';
+
+export default function AdminEventCreatePage() {
+  const router = useRouter();
+  const { form, errors, submitting, serverError, setField, submit } =
+    useEventFormState();
+
+  const handleSubmit = async () => {
+    const ok = await submit(() => post('/admin/events', buildPayload(form)));
+    if (ok) router.push('/admin/events');
+  };
+
+  return (
+    <Form
+      actions={
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button variant="link" onClick={() => router.push('/admin/events')}>
+            キャンセル
+          </Button>
+          <Button variant="primary" loading={submitting} onClick={handleSubmit}>
+            作成
+          </Button>
+        </SpaceBetween>
+      }
+      header={<Header variant="h1">イベント作成</Header>}
+      errorText={serverError ?? undefined}
+    >
+      <Container header={<Header variant="h2">基本情報</Header>}>
+        <SpaceBetween size="l">
+          <FormField
+            label="イベント名"
+            errorText={errors.name}
+            constraintText="必須"
+          >
+            <Input
+              value={form.name}
+              onChange={({ detail }) => setField('name', detail.value)}
+              placeholder="例: クラウドチャレンジ 2026 春"
+            />
+          </FormField>
+          <SpaceBetween direction="horizontal" size="l">
+            <FormField label="タイプ">
+              <Select
+                selectedOption={form.type}
+                onChange={({ detail }) =>
+                  setField('type', detail.selectedOption)
+                }
+                options={TYPE_OPTIONS}
+              />
+            </FormField>
+            <FormField label="ステータス">
+              <Select
+                selectedOption={form.status}
+                onChange={({ detail }) =>
+                  setField('status', detail.selectedOption)
+                }
+                options={STATUS_OPTIONS}
+              />
+            </FormField>
+          </SpaceBetween>
+          <SpaceBetween direction="horizontal" size="l">
+            <FormField label="開始日">
+              <DatePicker
+                value={form.startTime}
+                onChange={({ detail }) => setField('startTime', detail.value)}
+                placeholder="YYYY/MM/DD"
+                openCalendarAriaLabel={(s) =>
+                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
+                }
+              />
+            </FormField>
+            <FormField label="終了日" errorText={errors.endTime}>
+              <DatePicker
+                value={form.endTime}
+                onChange={({ detail }) => setField('endTime', detail.value)}
+                placeholder="YYYY/MM/DD"
+                openCalendarAriaLabel={(s) =>
+                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
+                }
+              />
+            </FormField>
+          </SpaceBetween>
+          <FormField label="タイムゾーン">
+            <Select
+              selectedOption={form.timezone}
+              onChange={({ detail }) =>
+                setField('timezone', detail.selectedOption)
+              }
+              options={TIMEZONE_OPTIONS}
+            />
+          </FormField>
+        </SpaceBetween>
+      </Container>
+      <Box margin={{ top: 'l' }}>
+        <Container header={<Header variant="h2">参加設定</Header>}>
+          <SpaceBetween size="l">
+            <SpaceBetween direction="horizontal" size="l">
+              <FormField label="参加形式">
+                <Select
+                  selectedOption={form.participantType}
+                  onChange={({ detail }) =>
+                    setField('participantType', detail.selectedOption)
+                  }
+                  options={PARTICIPANT_TYPE_OPTIONS}
+                />
+              </FormField>
+              <FormField label="クラウドプロバイダー">
+                <Select
+                  selectedOption={form.cloudProvider}
+                  onChange={({ detail }) =>
+                    setField('cloudProvider', detail.selectedOption)
+                  }
+                  options={CLOUD_PROVIDER_OPTIONS}
+                />
+              </FormField>
+            </SpaceBetween>
+            <SpaceBetween direction="horizontal" size="l">
+              <FormField label="最大参加者数">
+                <Input
+                  type="number"
+                  value={form.maxParticipants}
+                  onChange={({ detail }) =>
+                    setField('maxParticipants', detail.value)
+                  }
+                  inputMode="numeric"
+                />
+              </FormField>
+              <FormField label="採点方式">
+                <Select
+                  selectedOption={form.scoringType}
+                  onChange={({ detail }) =>
+                    setField('scoringType', detail.selectedOption)
+                  }
+                  options={SCORING_TYPE_OPTIONS}
+                />
+              </FormField>
+            </SpaceBetween>
+          </SpaceBetween>
+        </Container>
+      </Box>
+    </Form>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
+++ b/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
@@ -1,0 +1,174 @@
+/**
+ * useEventFormState Hook
+ *
+ * イベント作成・編集フォームの状態管理
+ */
+
+import type { SelectProps } from '@cloudscape-design/components/select';
+import { useCallback, useState } from 'react';
+
+// =============================================================================
+// Options
+// =============================================================================
+
+export const TYPE_OPTIONS: SelectProps.Options = [
+  { label: 'GameDay', value: 'gameday' },
+  { label: 'Jam', value: 'jam' },
+];
+
+export const STATUS_OPTIONS: SelectProps.Options = [
+  { label: '下書き', value: 'draft' },
+  { label: '予定', value: 'scheduled' },
+];
+
+export const PARTICIPANT_TYPE_OPTIONS: SelectProps.Options = [
+  { label: '個人', value: 'individual' },
+  { label: 'チーム', value: 'team' },
+];
+
+export const CLOUD_PROVIDER_OPTIONS: SelectProps.Options = [
+  { label: 'AWS', value: 'aws' },
+  { label: 'GCP', value: 'gcp' },
+  { label: 'Azure', value: 'azure' },
+  { label: 'ローカル', value: 'local' },
+];
+
+export const SCORING_TYPE_OPTIONS: SelectProps.Options = [
+  { label: 'リアルタイム', value: 'realtime' },
+  { label: 'バッチ', value: 'batch' },
+];
+
+export const TIMEZONE_OPTIONS: SelectProps.Options = [
+  { label: 'Asia/Tokyo (JST)', value: 'Asia/Tokyo' },
+  { label: 'UTC', value: 'UTC' },
+  { label: 'America/New_York (EST)', value: 'America/New_York' },
+  { label: 'Europe/London (GMT)', value: 'Europe/London' },
+];
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface EventFormState {
+  name: string;
+  type: SelectProps.Option | null;
+  status: SelectProps.Option | null;
+  startTime: string;
+  endTime: string;
+  timezone: SelectProps.Option | null;
+  participantType: SelectProps.Option | null;
+  cloudProvider: SelectProps.Option | null;
+  maxParticipants: string;
+  scoringType: SelectProps.Option | null;
+}
+
+export interface EventFormErrors {
+  name?: string;
+  endTime?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+export function findOption(
+  options: SelectProps.Options,
+  value: string | undefined,
+): SelectProps.Option | null {
+  if (!value) return null;
+  return (
+    (options as SelectProps.Option[]).find((o) => o.value === value) ?? null
+  );
+}
+
+export function buildPayload(form: EventFormState) {
+  return {
+    name: form.name,
+    type: form.type?.value,
+    status: form.status?.value,
+    startTime: form.startTime,
+    endTime: form.endTime,
+    timezone: form.timezone?.value,
+    participantType: form.participantType?.value,
+    cloudProvider: form.cloudProvider?.value,
+    maxParticipants: Number(form.maxParticipants),
+    scoringType: form.scoringType?.value,
+  };
+}
+
+export function validateEventForm(form: EventFormState): EventFormErrors {
+  const errs: EventFormErrors = {};
+  if (!form.name.trim()) {
+    errs.name = 'イベント名は必須です';
+  }
+  if (form.startTime && form.endTime && form.endTime <= form.startTime) {
+    errs.endTime = '終了日は開始日より後に設定してください';
+  }
+  return errs;
+}
+
+export const DEFAULT_FORM_STATE: EventFormState = {
+  name: '',
+  type: TYPE_OPTIONS[0],
+  status: STATUS_OPTIONS[0],
+  startTime: '',
+  endTime: '',
+  timezone: TIMEZONE_OPTIONS[0],
+  participantType: PARTICIPANT_TYPE_OPTIONS[0],
+  cloudProvider: CLOUD_PROVIDER_OPTIONS[0],
+  maxParticipants: '100',
+  scoringType: SCORING_TYPE_OPTIONS[0],
+};
+
+export interface UseEventFormStateReturn {
+  form: EventFormState;
+  errors: EventFormErrors;
+  submitting: boolean;
+  serverError: string | null;
+  setField: <K extends keyof EventFormState>(
+    key: K,
+    value: EventFormState[K],
+  ) => void;
+  submit: (apiCall: () => Promise<unknown>) => Promise<boolean>;
+}
+
+export function useEventFormState(
+  initialState: EventFormState = DEFAULT_FORM_STATE,
+): UseEventFormStateReturn {
+  const [form, setForm] = useState<EventFormState>(initialState);
+  const [errors, setErrors] = useState<EventFormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const setField = useCallback(
+    <K extends keyof EventFormState>(key: K, value: EventFormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const submit = useCallback(
+    async (apiCall: () => Promise<unknown>): Promise<boolean> => {
+      const validationErrors = validateEventForm(form);
+      setErrors(validationErrors);
+      if (Object.keys(validationErrors).length > 0) return false;
+
+      try {
+        setSubmitting(true);
+        setServerError(null);
+        await apiCall();
+        return true;
+      } catch (err) {
+        setServerError(
+          err instanceof Error ? err.message : 'エラーが発生しました',
+        );
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [form],
+  );
+
+  return { form, errors, submitting, serverError, setField, submit };
+}


### PR DESCRIPTION
## Summary

- イベント新規作成ページ (`/admin/events/new`) を Cloudscape Form で実装
- イベント編集ページ (`/admin/events/[eventId]/edit`) を Cloudscape Form で実装
- `useEventFormState` フックに共通フォームロジックを抽出
- 30 テスト、100% カバレッジ

## Test plan

- [x] typecheck パス
- [x] 30 テストパス (100% coverage)
- [x] lint/format パス

https://claude.ai/code/session_01ByKPNvTphgWTMSMqSWD8er