### PR TITLE
feat: 管理者向け分析ダッシュボードを追加

### DIFF
--- a/apps/application-plane/app/(admin)/admin/analytics/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/analytics/__tests__/page.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminAnalyticsPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useParams: () => ({}),
+}));
+
+vi.mock('next-auth/react', () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+const mockGetAnalyticsData = vi.fn();
+vi.mock('@/lib/api/admin-analytics', () => ({
+  getAnalyticsData: (...args: unknown[]) => mockGetAnalyticsData(...args),
+}));
+
+const analyticsData = {
+  overview: {
+    totalEvents: 12,
+    totalParticipants: 245,
+    avgScore: 72,
+    completionRate: 85,
+  },
+  eventTimeline: [
+    { month: '2026-01', eventCount: 3, participantCount: 50 },
+    { month: '2026-02', eventCount: 5, participantCount: 80 },
+    { month: '2026-03', eventCount: 4, participantCount: 115 },
+  ],
+  scoreDistribution: [
+    { category: '0-20', value: 1 },
+    { category: '21-40', value: 3 },
+    { category: '41-60', value: 5 },
+    { category: '61-80', value: 7 },
+    { category: '81-100', value: 2 },
+  ],
+  teamComparison: [
+    { teamName: 'チームA', score: 85, memberCount: 4, completionRate: 90 },
+    { teamName: 'チームB', score: 72, memberCount: 3, completionRate: 80 },
+    { teamName: 'チームC', score: 60, memberCount: 5, completionRate: 70 },
+  ],
+};
+
+describe('Admin 分析ページ', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ページタイトル「分析ダッシュボード」が表示されるべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('分析ダッシュボード')).toBeInTheDocument();
+    });
+  });
+
+  it('概要メトリクスを表示すべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('総イベント数')).toBeInTheDocument();
+    });
+    expect(screen.getByText('総参加者数')).toBeInTheDocument();
+    expect(screen.getByText('平均スコア')).toBeInTheDocument();
+    expect(screen.getByText('完了率')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('245')).toBeInTheDocument();
+    expect(screen.getByText('72')).toBeInTheDocument();
+    expect(screen.getByText('85%')).toBeInTheDocument();
+  });
+
+  it('タブが表示されるべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('概要')).toBeInTheDocument();
+    });
+    expect(screen.getByText('イベント分析')).toBeInTheDocument();
+    expect(screen.getByText('スコア分布')).toBeInTheDocument();
+    expect(screen.getByText('チーム比較')).toBeInTheDocument();
+  });
+
+  it('ローディング中はスピナーを表示すべき', () => {
+    mockGetAnalyticsData.mockReturnValue(new Promise(() => {}));
+    render(<AdminAnalyticsPage />);
+
+    const spinners = document.querySelectorAll('[class*="awsui_root"]');
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  it('API エラー時はエラーメッセージを表示すべき', async () => {
+    mockGetAnalyticsData.mockRejectedValue(new Error('Network error'));
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('再試行')).toBeInTheDocument();
+  });
+
+  it('Error 以外の例外が投げられた場合もエラーを表示すべき', async () => {
+    mockGetAnalyticsData.mockRejectedValue('string error');
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('分析データの読み込みに失敗しました'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('CSV エクスポートボタンが表示されるべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CSV エクスポート')).toBeInTheDocument();
+    });
+  });
+
+  it('CSV エクスポートボタンをクリックするとダウンロードが開始されるべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    const mockClick = vi.fn();
+    const mockCreateObjectURL = vi.fn().mockReturnValue('blob:test');
+    const mockRevokeObjectURL = vi.fn();
+
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(mockCreateObjectURL);
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(mockRevokeObjectURL);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        return {
+          href: '',
+          download: '',
+          click: mockClick,
+          set setAttribute(_val: string) {
+            /* noop */
+          },
+        } as unknown as HTMLAnchorElement;
+      }
+      return document.createElementNS(
+        'http://www.w3.org/1999/xhtml',
+        tag,
+      ) as HTMLElement;
+    });
+
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CSV エクスポート')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('CSV エクスポート'));
+
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:test');
+
+    vi.restoreAllMocks();
+  });
+
+  it('チーム比較タブでチームデータを表示すべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('チーム比較')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('チーム比較'));
+
+    await waitFor(() => {
+      expect(screen.getByText('チームA')).toBeInTheDocument();
+    });
+    expect(screen.getByText('チームB')).toBeInTheDocument();
+    expect(screen.getByText('チームC')).toBeInTheDocument();
+  });
+
+  it('期間選択フィルタが表示されるべき', async () => {
+    mockGetAnalyticsData.mockResolvedValue(analyticsData);
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('全期間')).toBeInTheDocument();
+    });
+  });
+
+  it('再試行ボタンをクリックするとデータを再取得すべき', async () => {
+    mockGetAnalyticsData.mockRejectedValueOnce(new Error('Network error'));
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('再試行')).toBeInTheDocument();
+    });
+
+    mockGetAnalyticsData.mockResolvedValueOnce(analyticsData);
+    fireEvent.click(screen.getByText('再試行'));
+
+    await waitFor(() => {
+      expect(screen.getByText('分析ダッシュボード')).toBeInTheDocument();
+    });
+    expect(mockGetAnalyticsData).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/analytics/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/analytics/page.tsx
@@ -1,0 +1,345 @@
+/**
+ * Admin Analytics Page
+ *
+ * Cloudscape Design System — 分析ダッシュボード
+ */
+
+'use client';
+
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+import PieChart from '@cloudscape-design/components/pie-chart';
+import Select from '@cloudscape-design/components/select';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import Tabs from '@cloudscape-design/components/tabs';
+import type { SelectProps } from '@cloudscape-design/components/select';
+import { useCallback, useEffect, useState } from 'react';
+import { getAnalyticsData } from '@/lib/api/admin-analytics';
+import type { AnalyticsData } from '@/lib/api/admin-analytics';
+
+/**
+ * 期間フィルタオプション
+ */
+const periodOptions: SelectProps.Option[] = [
+  { label: '全期間', value: 'all' },
+  { label: '過去30日', value: '30d' },
+  { label: '過去90日', value: '90d' },
+  { label: '過去1年', value: '1y' },
+];
+
+/**
+ * CSV エクスポート関数
+ */
+function exportAnalyticsCsv(data: AnalyticsData): void {
+  const lines: string[] = [];
+
+  // 概要セクション
+  lines.push('セクション,項目,値');
+  lines.push(`概要,総イベント数,${data.overview.totalEvents}`);
+  lines.push(`概要,総参加者数,${data.overview.totalParticipants}`);
+  lines.push(`概要,平均スコア,${data.overview.avgScore}`);
+  lines.push(`概要,完了率,${data.overview.completionRate}%`);
+  lines.push('');
+
+  // イベントタイムライン
+  lines.push('月,イベント数,参加者数');
+  for (const entry of data.eventTimeline) {
+    lines.push(`${entry.month},${entry.eventCount},${entry.participantCount}`);
+  }
+  lines.push('');
+
+  // スコア分布
+  lines.push('カテゴリ,チーム数');
+  for (const entry of data.scoreDistribution) {
+    lines.push(`${entry.category},${entry.value}`);
+  }
+  lines.push('');
+
+  // チーム比較
+  lines.push('チーム名,スコア,メンバー数,完了率');
+  for (const team of data.teamComparison) {
+    lines.push(
+      `${team.teamName},${team.score},${team.memberCount},${team.completionRate}%`,
+    );
+  }
+
+  const csvContent = lines.join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'analytics.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function AdminAnalyticsPage() {
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [selectedPeriod, setSelectedPeriod] =
+    useState<SelectProps.Option | null>(periodOptions[0]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const analyticsData = await getAnalyticsData();
+      setData(analyticsData);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err
+          : new Error('分析データの読み込みに失敗しました'),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <Container>
+        <Box textAlign="center" padding="l">
+          <Spinner size="large" />
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <SpaceBetween size="s" direction="vertical" alignItems="center">
+          <StatusIndicator type="error">{error.message}</StatusIndicator>
+          <Button onClick={fetchData}>再試行</Button>
+        </SpaceBetween>
+      </Container>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={
+          <SpaceBetween size="s" direction="horizontal">
+            <Select
+              selectedOption={selectedPeriod}
+              onChange={({ detail }) =>
+                setSelectedPeriod(detail.selectedOption)
+              }
+              options={periodOptions}
+              placeholder="期間を選択"
+            />
+            <Button
+              iconName="download"
+              onClick={() => exportAnalyticsCsv(data)}
+            >
+              CSV エクスポート
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        分析ダッシュボード
+      </Header>
+
+      <Tabs
+        tabs={[
+          {
+            label: '概要',
+            id: 'overview',
+            content: (
+              <SpaceBetween size="l">
+                <ColumnLayout columns={4} variant="text-grid">
+                  <Container>
+                    <SpaceBetween size="xs">
+                      <Box variant="awsui-key-label">総イベント数</Box>
+                      <Box variant="awsui-value-large">
+                        {data.overview.totalEvents.toLocaleString()}
+                      </Box>
+                    </SpaceBetween>
+                  </Container>
+                  <Container>
+                    <SpaceBetween size="xs">
+                      <Box variant="awsui-key-label">総参加者数</Box>
+                      <Box variant="awsui-value-large">
+                        {data.overview.totalParticipants.toLocaleString()}
+                      </Box>
+                    </SpaceBetween>
+                  </Container>
+                  <Container>
+                    <SpaceBetween size="xs">
+                      <Box variant="awsui-key-label">平均スコア</Box>
+                      <Box variant="awsui-value-large">
+                        {data.overview.avgScore}
+                      </Box>
+                    </SpaceBetween>
+                  </Container>
+                  <Container>
+                    <SpaceBetween size="xs">
+                      <Box variant="awsui-key-label">完了率</Box>
+                      <Box variant="awsui-value-large">
+                        {data.overview.completionRate}%
+                      </Box>
+                    </SpaceBetween>
+                  </Container>
+                </ColumnLayout>
+              </SpaceBetween>
+            ),
+          },
+          {
+            label: 'イベント分析',
+            id: 'events',
+            content: (
+              <SpaceBetween size="l">
+                <Container
+                  header={<Header variant="h2">月別イベント数</Header>}
+                >
+                  <BarChart
+                    series={[
+                      {
+                        title: 'イベント数',
+                        type: 'bar',
+                        data: data.eventTimeline.map((entry) => ({
+                          x: entry.month,
+                          y: entry.eventCount,
+                        })),
+                      },
+                    ]}
+                    xDomain={data.eventTimeline.map((e) => e.month)}
+                    yDomain={[
+                      0,
+                      Math.max(
+                        ...data.eventTimeline.map((e) => e.eventCount),
+                        1,
+                      ),
+                    ]}
+                    xTitle="月"
+                    yTitle="イベント数"
+                    xScaleType="categorical"
+                    empty={<Box textAlign="center">データがありません</Box>}
+                    noMatch={
+                      <Box textAlign="center">一致するデータがありません</Box>
+                    }
+                  />
+                </Container>
+                <Container
+                  header={<Header variant="h2">月別参加者数推移</Header>}
+                >
+                  <LineChart
+                    series={[
+                      {
+                        title: '参加者数',
+                        type: 'line',
+                        data: data.eventTimeline.map((entry) => ({
+                          x: entry.month,
+                          y: entry.participantCount,
+                        })),
+                      },
+                    ]}
+                    xDomain={data.eventTimeline.map((e) => e.month)}
+                    yDomain={[
+                      0,
+                      Math.max(
+                        ...data.eventTimeline.map((e) => e.participantCount),
+                        1,
+                      ),
+                    ]}
+                    xTitle="月"
+                    yTitle="参加者数"
+                    xScaleType="categorical"
+                    empty={<Box textAlign="center">データがありません</Box>}
+                    noMatch={
+                      <Box textAlign="center">一致するデータがありません</Box>
+                    }
+                  />
+                </Container>
+              </SpaceBetween>
+            ),
+          },
+          {
+            label: 'スコア分布',
+            id: 'scores',
+            content: (
+              <Container header={<Header variant="h2">スコア分布</Header>}>
+                <PieChart
+                  data={data.scoreDistribution.map((entry) => ({
+                    title: entry.category,
+                    value: entry.value,
+                  }))}
+                  detailPopoverContent={(datum) => [
+                    { key: 'チーム数', value: datum.value },
+                  ]}
+                  segmentDescription={(datum) => `${datum.value} チーム`}
+                  empty={<Box textAlign="center">データがありません</Box>}
+                  noMatch={
+                    <Box textAlign="center">一致するデータがありません</Box>
+                  }
+                />
+              </Container>
+            ),
+          },
+          {
+            label: 'チーム比較',
+            id: 'teams',
+            content: (
+              <Container
+                header={<Header variant="h2">チームパフォーマンス</Header>}
+              >
+                <Table
+                  columnDefinitions={[
+                    {
+                      id: 'teamName',
+                      header: 'チーム名',
+                      cell: (item) => item.teamName,
+                      sortingField: 'teamName',
+                    },
+                    {
+                      id: 'score',
+                      header: 'スコア',
+                      cell: (item) => item.score,
+                      sortingField: 'score',
+                    },
+                    {
+                      id: 'memberCount',
+                      header: 'メンバー数',
+                      cell: (item) => item.memberCount,
+                      sortingField: 'memberCount',
+                    },
+                    {
+                      id: 'completionRate',
+                      header: '完了率',
+                      cell: (item) => `${item.completionRate}%`,
+                      sortingField: 'completionRate',
+                    },
+                  ]}
+                  items={data.teamComparison}
+                  sortingDisabled
+                  variant="embedded"
+                  empty={<Box textAlign="center">チームデータがありません</Box>}
+                />
+              </Container>
+            ),
+          },
+        ]}
+      />
+    </SpaceBetween>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/layout.tsx
+++ b/apps/application-plane/app/(admin)/admin/layout.tsx
@@ -22,6 +22,7 @@ const navItems: SideNavigationProps.Item[] = [
   { type: 'link', text: 'マーケットプレイス', href: '/admin/marketplace' },
   { type: 'link', text: '参加者管理', href: '/admin/participants' },
   { type: 'link', text: 'チーム管理', href: '/admin/teams' },
+  { type: 'link', text: '分析', href: '/admin/analytics' },
   { type: 'divider' },
   { type: 'link', text: 'GameDay管理', href: '/admin/gameday' },
   { type: 'link', text: '設定', href: '/admin/settings' },

--- a/apps/application-plane/app/api/admin/analytics/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/analytics/__tests__/route.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Session } from 'next-auth';
+
+const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
+const mockServerApiRequest = vi.fn();
+
+vi.mock('@/lib/api/server', () => ({
+  getAdminSession: () => mockGetAdminSession(),
+  serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
+  unauthorizedResponse: (msg = 'Unauthorized') =>
+    new Response(JSON.stringify({ error: msg }), { status: 401 }),
+  forbiddenResponse: (msg = 'Forbidden') =>
+    new Response(JSON.stringify({ error: msg }), { status: 403 }),
+  badRequestResponse: (msg = 'Bad Request') =>
+    new Response(JSON.stringify({ error: msg }), { status: 400 }),
+  successResponse: <T>(data: T, status = 200) =>
+    new Response(JSON.stringify(data), { status }),
+}));
+
+const session: Session = {
+  user: { name: 'Admin', email: 'admin@example.com' },
+  expires: new Date().toISOString(),
+  roles: ['admin'],
+};
+
+const eventsData = {
+  events: [
+    {
+      id: 'evt-1',
+      name: 'イベント1',
+      status: 'completed',
+      eventDate: '2026-01-15',
+      participantCount: 30,
+    },
+    {
+      id: 'evt-2',
+      name: 'イベント2',
+      status: 'active',
+      eventDate: '2026-02-10',
+      participantCount: 50,
+    },
+    {
+      id: 'evt-3',
+      name: 'イベント3',
+      status: 'completed',
+      eventDate: '2026-01-20',
+      participantCount: 20,
+    },
+  ],
+  total: 3,
+};
+
+const statsData = {
+  activeEvents: 1,
+  totalParticipants: 100,
+  totalTeams: 5,
+  upcomingEvents: 2,
+};
+
+const teamsData = {
+  teams: [
+    {
+      id: 'team-1',
+      name: 'チームA',
+      memberCount: 4,
+      score: 85,
+      completionRate: 90,
+    },
+    {
+      id: 'team-2',
+      name: 'チームB',
+      memberCount: 3,
+      score: 45,
+      completionRate: 60,
+    },
+  ],
+  total: 2,
+};
+
+describe('Admin Analytics API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/analytics', () => {
+    it('未認証の場合は 401 を返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(null);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe('Authentication required');
+    });
+
+    it('分析データを正しく集計して返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce(eventsData)
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce(teamsData);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      expect(data.overview.totalEvents).toBe(3);
+      expect(data.overview.totalParticipants).toBe(100);
+      expect(data.overview.avgScore).toBe(65);
+      expect(data.overview.completionRate).toBe(67);
+    });
+
+    it('月別イベントタイムラインを生成すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce(eventsData)
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce(teamsData);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.eventTimeline).toHaveLength(2);
+      expect(data.eventTimeline[0].month).toBe('2026-01');
+      expect(data.eventTimeline[0].eventCount).toBe(2);
+      expect(data.eventTimeline[0].participantCount).toBe(50);
+      expect(data.eventTimeline[1].month).toBe('2026-02');
+      expect(data.eventTimeline[1].eventCount).toBe(1);
+    });
+
+    it('スコア分布を計算すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce(eventsData)
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce(teamsData);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.scoreDistribution).toHaveLength(5);
+      const range41to60 = data.scoreDistribution.find(
+        (d: { category: string }) => d.category === '41-60',
+      );
+      expect(range41to60.value).toBe(1);
+      const range81to100 = data.scoreDistribution.find(
+        (d: { category: string }) => d.category === '81-100',
+      );
+      expect(range81to100.value).toBe(1);
+    });
+
+    it('チーム比較データを返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce(eventsData)
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce(teamsData);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.teamComparison).toHaveLength(2);
+      expect(data.teamComparison[0].teamName).toBe('チームA');
+      expect(data.teamComparison[0].score).toBe(85);
+      expect(data.teamComparison[0].memberCount).toBe(4);
+    });
+
+    it('バックエンド API エラー時は 400 を返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new Error('Backend error'));
+
+      const { GET } = await import('../route');
+      const response = await GET();
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe('Backend error');
+    });
+
+    it('Error 以外の例外でも 400 を返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue('string error');
+
+      const { GET } = await import('../route');
+      const response = await GET();
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe('Failed to fetch analytics');
+    });
+
+    it('イベントが空の場合は完了率 0 を返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce({ events: [], total: 0 })
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce({ teams: [], total: 0 });
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.overview.completionRate).toBe(0);
+      expect(data.overview.avgScore).toBe(0);
+      expect(data.eventTimeline).toHaveLength(0);
+    });
+
+    it('チームにスコアがない場合はデフォルト値を使うべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce(eventsData)
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce({
+          teams: [{ id: 'team-1', name: 'チームX', memberCount: 3 }],
+          total: 1,
+        });
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.teamComparison[0].score).toBe(0);
+      expect(data.teamComparison[0].completionRate).toBe(0);
+    });
+
+    it('イベントに参加者数がない場合はデフォルト値を使うべき', async () => {
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest
+        .mockResolvedValueOnce({
+          events: [
+            {
+              id: 'evt-1',
+              name: 'テスト',
+              status: 'active',
+              eventDate: '2026-03-01',
+            },
+          ],
+          total: 1,
+        })
+        .mockResolvedValueOnce(statsData)
+        .mockResolvedValueOnce(teamsData);
+
+      const { GET } = await import('../route');
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.eventTimeline[0].participantCount).toBe(0);
+    });
+  });
+});

--- a/apps/application-plane/app/api/admin/analytics/route.ts
+++ b/apps/application-plane/app/api/admin/analytics/route.ts
@@ -1,0 +1,175 @@
+/**
+ * Admin Analytics API
+ *
+ * 管理者向け分析データエンドポイント
+ * - GET: 分析データ取得
+ */
+
+import {
+  getAdminSession,
+  unauthorizedResponse,
+  forbiddenResponse,
+  badRequestResponse,
+  successResponse,
+  serverApiRequest,
+} from '@/lib/api/server';
+import type { AnalyticsData } from '@/lib/api/admin-analytics';
+
+/**
+ * バックエンドイベントレスポンス型
+ */
+interface BackendEventsResponse {
+  events: Array<{
+    id: string;
+    name: string;
+    status: string;
+    eventDate: string;
+    participantCount?: number;
+  }>;
+  total: number;
+}
+
+/**
+ * バックエンドダッシュボード統計型
+ */
+interface BackendDashboardStats {
+  activeEvents: number;
+  totalParticipants: number;
+  totalTeams: number;
+  upcomingEvents: number;
+}
+
+/**
+ * バックエンドチームレスポンス型
+ */
+interface BackendTeamsResponse {
+  teams: Array<{
+    id: string;
+    name: string;
+    memberCount: number;
+    score?: number;
+    completionRate?: number;
+  }>;
+  total: number;
+}
+
+/**
+ * 月ごとにイベントを集計する
+ */
+function aggregateEventsByMonth(
+  events: BackendEventsResponse['events'],
+): Array<{ month: string; eventCount: number; participantCount: number }> {
+  const monthMap = new Map<
+    string,
+    { eventCount: number; participantCount: number }
+  >();
+
+  for (const event of events) {
+    const date = new Date(event.eventDate);
+    const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+    const existing = monthMap.get(monthKey) ?? {
+      eventCount: 0,
+      participantCount: 0,
+    };
+    existing.eventCount += 1;
+    existing.participantCount += event.participantCount ?? 0;
+    monthMap.set(monthKey, existing);
+  }
+
+  return Array.from(monthMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, data]) => ({
+      month,
+      eventCount: data.eventCount,
+      participantCount: data.participantCount,
+    }));
+}
+
+/**
+ * スコア分布を計算する
+ */
+function calculateScoreDistribution(
+  teams: BackendTeamsResponse['teams'],
+): Array<{ category: string; value: number }> {
+  const ranges = [
+    { category: '0-20', min: 0, max: 20 },
+    { category: '21-40', min: 21, max: 40 },
+    { category: '41-60', min: 41, max: 60 },
+    { category: '61-80', min: 61, max: 80 },
+    { category: '81-100', min: 81, max: 100 },
+  ];
+
+  return ranges.map(({ category, min, max }) => ({
+    category,
+    value: teams.filter((t) => {
+      const score = t.score ?? 0;
+      return score >= min && score <= max;
+    }).length,
+  }));
+}
+
+/**
+ * GET /api/admin/analytics
+ *
+ * 分析データを取得（管理者のみ）
+ */
+export async function GET() {
+  const session = await getAdminSession();
+  if (!session) {
+    return session === null
+      ? unauthorizedResponse('Authentication required')
+      : forbiddenResponse('Admin role required');
+  }
+
+  try {
+    const [eventsData, statsData, teamsData] = await Promise.all([
+      serverApiRequest<BackendEventsResponse>(
+        '/admin/events?page=1&pageSize=1000',
+      ),
+      serverApiRequest<BackendDashboardStats>('/admin/dashboard/stats'),
+      serverApiRequest<BackendTeamsResponse>(
+        '/admin/teams?page=1&pageSize=1000',
+      ),
+    ]);
+
+    const events = eventsData.events ?? [];
+    const teams = teamsData.teams ?? [];
+
+    const totalScores = teams.reduce((sum, t) => sum + (t.score ?? 0), 0);
+    const avgScore =
+      teams.length > 0 ? Math.round(totalScores / teams.length) : 0;
+
+    const completedEvents = events.filter(
+      (e) => e.status === 'completed',
+    ).length;
+    const completionRate =
+      events.length > 0
+        ? Math.round((completedEvents / events.length) * 100)
+        : 0;
+
+    const analyticsData: AnalyticsData = {
+      overview: {
+        totalEvents: eventsData.total ?? events.length,
+        totalParticipants: statsData.totalParticipants ?? 0,
+        avgScore,
+        completionRate,
+      },
+      eventTimeline: aggregateEventsByMonth(events),
+      scoreDistribution: calculateScoreDistribution(teams),
+      teamComparison: teams.map((t) => ({
+        teamName: t.name,
+        score: t.score ?? 0,
+        memberCount: t.memberCount,
+        completionRate: t.completionRate ?? 0,
+      })),
+    };
+
+    return successResponse(analyticsData);
+  } catch (error) {
+    console.error('Failed to fetch analytics:', error);
+    return badRequestResponse(
+      error instanceof Error ? error.message : 'Failed to fetch analytics',
+    );
+  }
+}

--- a/apps/application-plane/lib/api/admin-analytics.ts
+++ b/apps/application-plane/lib/api/admin-analytics.ts
@@ -1,0 +1,61 @@
+/**
+ * Admin Analytics API Client
+ *
+ * 管理画面分析ダッシュボード用の API クライアント
+ */
+
+import { get } from './client';
+
+/**
+ * 分析データ
+ */
+export interface AnalyticsData {
+  overview: OverviewMetrics;
+  eventTimeline: EventTimelineEntry[];
+  scoreDistribution: ScoreDistributionEntry[];
+  teamComparison: TeamComparisonEntry[];
+}
+
+/**
+ * 概要メトリクス
+ */
+export interface OverviewMetrics {
+  totalEvents: number;
+  totalParticipants: number;
+  avgScore: number;
+  completionRate: number;
+}
+
+/**
+ * イベントタイムラインエントリ
+ */
+export interface EventTimelineEntry {
+  month: string;
+  eventCount: number;
+  participantCount: number;
+}
+
+/**
+ * スコア分布エントリ
+ */
+export interface ScoreDistributionEntry {
+  category: string;
+  value: number;
+}
+
+/**
+ * チーム比較エントリ
+ */
+export interface TeamComparisonEntry {
+  teamName: string;
+  score: number;
+  memberCount: number;
+  completionRate: number;
+}
+
+/**
+ * 分析データを取得
+ */
+export async function getAnalyticsData(): Promise<AnalyticsData> {
+  return get<AnalyticsData>('/admin/analytics');
+}


### PR DESCRIPTION
## Summary
- 管理者向け分析ダッシュボード（/admin/analytics）を新規作成
- Cloudscape BarChart/LineChart/PieChart/Table を使った4タブ構成（概要・イベント分析・スコア分布・チーム比較）
- CSV エクスポート機能（クライアントサイド Blob ダウンロード）
- API エンドポイント /api/admin/analytics で既存バックエンドデータを集計
- サイドバーに「分析」リンクを追加

## Test plan
- [ ] 分析ページが正しくレンダリングされること
- [ ] 各タブの切り替えが動作すること
- [ ] CSV エクスポートが動作すること
- [ ] API エラー時にエラー表示と再試行が動作すること
- [ ] 21 件のユニットテスト（ページ 11 件、API 10 件）が全てパス

https://claude.ai/code/session_01ByKPNvTphgWTMSMqSWD8er

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin analytics dashboard featuring overview metrics, event analysis, score distribution, and team comparison tabs
  * CSV export capability for analytics data
  * Period selection filter and error recovery with retry option
  * Navigation link to analytics section

* **Tests**
  * Added comprehensive test coverage for dashboard and API functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->