### PR TITLE
feat: CP モックAPI + AWS Console STS フェデレーション

### DIFF
--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -33,6 +33,7 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [score, setScore] = useState<number | undefined>();
   const [rank, setRank] = useState<number | undefined>();
+  const [awsConsoleLoading, setAwsConsoleLoading] = useState(false);
 
   const basePath = `/gameday/${eventId}`;
 
@@ -93,13 +94,35 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
         { type: 'link', text: t('gameday.voteNav'), href: `${basePath}/vote` },
         {
           type: 'link',
-          text: t('gameday.awsConsole'),
-          href: 'https://console.aws.amazon.com',
-          external: true,
+          text: awsConsoleLoading
+            ? `${t('gameday.awsConsole')}...`
+            : t('gameday.awsConsole'),
+          href: `${basePath}/aws-console`,
         },
       ],
     },
   ];
+
+  const openAwsConsole = useCallback(async () => {
+    if (!eventId || awsConsoleLoading) return;
+    setAwsConsoleLoading(true);
+    try {
+      const response = await fetch(
+        `/api/participant/events/${encodeURIComponent(eventId)}/aws-console`,
+      );
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string };
+        console.error('AWS Console error:', data.error);
+        return;
+      }
+      const data = (await response.json()) as { url: string };
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      console.error('AWS Console fetch error:', err);
+    } finally {
+      setAwsConsoleLoading(false);
+    }
+  }, [eventId, awsConsoleLoading]);
 
   const activeHref = (() => {
     if (pathname === basePath || pathname === `${basePath}/`) return basePath;
@@ -217,8 +240,10 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
             activeHref={activeHref}
             items={navItems}
             onFollow={(event) => {
-              if (!event.detail.external) {
-                event.preventDefault();
+              event.preventDefault();
+              if (event.detail.href === `${basePath}/aws-console`) {
+                openAwsConsole();
+              } else if (!event.detail.external) {
                 router.push(event.detail.href);
               }
             }}

--- a/apps/application-plane/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Session } from 'next-auth';
+
+// Mock auth
+const mockAuth = vi.fn<() => Promise<Session | null>>();
+vi.mock('@/auth', () => ({
+  auth: () => mockAuth(),
+}));
+
+// Mock stsFederation
+const mockGenerateParticipantConsoleUrl = vi.fn();
+vi.mock('@/lib/aws', () => ({
+  stsFederation: {
+    generateParticipantConsoleUrl: (
+      ...args: [string, string, string, string, number?]
+    ) => mockGenerateParticipantConsoleUrl(...args),
+  },
+}));
+
+describe('AWS Console Federation API', () => {
+  const makeParams = (eventId: string) => ({
+    params: Promise.resolve({ eventId }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 環境変数をクリア
+    delete process.env.AWS_PARTICIPANT_ROLE_ARN;
+  });
+
+  it('未認証の場合は 401 を返すべき', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    const response = await GET(request, await makeParams('evt-1'));
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toBe('Authentication required');
+  });
+
+  it('Role ARN が設定されていない場合は 404 を返すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    const response = await GET(request, await makeParams('evt-1'));
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toBe(
+      'AWS Console access is not configured for this event',
+    );
+  });
+
+  it('Federation URL を正常に返すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+    process.env.AWS_PARTICIPANT_ROLE_ARN =
+      'arn:aws:iam::123456789012:role/ParticipantRole';
+
+    const expiresAt = new Date(Date.now() + 3600000);
+    mockGenerateParticipantConsoleUrl.mockResolvedValue({
+      url: 'https://signin.aws.amazon.com/federation?Action=login&SigninToken=test-token',
+      expiresAt,
+    });
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    const response = await GET(request, await makeParams('evt-1'));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.url).toContain('https://signin.aws.amazon.com/federation');
+    expect(data.expiresAt).toBe(expiresAt.toISOString());
+  });
+
+  it('正しいパラメータで generateParticipantConsoleUrl を呼び出すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+    process.env.AWS_PARTICIPANT_ROLE_ARN =
+      'arn:aws:iam::123456789012:role/ParticipantRole';
+
+    mockGenerateParticipantConsoleUrl.mockResolvedValue({
+      url: 'https://signin.aws.amazon.com/federation?Action=login',
+      expiresAt: new Date(),
+    });
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    await GET(request, await makeParams('evt-1'));
+
+    expect(mockGenerateParticipantConsoleUrl).toHaveBeenCalledWith(
+      'tenant-1',
+      'test@example.com',
+      'evt-1-team-1',
+      'arn:aws:iam::123456789012:role/ParticipantRole',
+    );
+  });
+
+  it('イベント固有の Role ARN を使用すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+    process.env.AWS_ROLE_ARN_evt_special =
+      'arn:aws:iam::999999999999:role/SpecialRole';
+
+    mockGenerateParticipantConsoleUrl.mockResolvedValue({
+      url: 'https://signin.aws.amazon.com/federation?Action=login',
+      expiresAt: new Date(),
+    });
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt_special/aws-console',
+    );
+    await GET(request, await makeParams('evt_special'));
+
+    expect(mockGenerateParticipantConsoleUrl).toHaveBeenCalledWith(
+      'tenant-1',
+      'test@example.com',
+      'evt_special-team-1',
+      'arn:aws:iam::999999999999:role/SpecialRole',
+    );
+
+    delete process.env.AWS_ROLE_ARN_evt_special;
+  });
+
+  it('STS エラーの場合は 500 を返すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+    process.env.AWS_PARTICIPANT_ROLE_ARN =
+      'arn:aws:iam::123456789012:role/ParticipantRole';
+
+    mockGenerateParticipantConsoleUrl.mockRejectedValue(
+      new Error('STS AssumeRole failed: Access denied'),
+    );
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    const response = await GET(request, await makeParams('evt-1'));
+
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe('STS AssumeRole failed: Access denied');
+  });
+
+  it('tenantId がない場合はデフォルト値を使用すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+    };
+    mockAuth.mockResolvedValue(session);
+    process.env.AWS_PARTICIPANT_ROLE_ARN =
+      'arn:aws:iam::123456789012:role/ParticipantRole';
+
+    mockGenerateParticipantConsoleUrl.mockResolvedValue({
+      url: 'https://signin.aws.amazon.com/federation?Action=login',
+      expiresAt: new Date(),
+    });
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    await GET(request, await makeParams('evt-1'));
+
+    expect(mockGenerateParticipantConsoleUrl).toHaveBeenCalledWith(
+      'default',
+      'test@example.com',
+      'evt-1-no-team',
+      'arn:aws:iam::123456789012:role/ParticipantRole',
+    );
+  });
+});

--- a/apps/application-plane/app/api/participant/events/[eventId]/aws-console/route.ts
+++ b/apps/application-plane/app/api/participant/events/[eventId]/aws-console/route.ts
@@ -1,0 +1,62 @@
+/**
+ * AWS Console Federation API
+ *
+ * STS Federation を使用して参加者用 AWS Console ログイン URL を生成するエンドポイント
+ */
+
+import { auth } from '@/auth';
+import { stsFederation } from '@/lib/aws';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ eventId: string }> },
+) {
+  const { eventId } = await params;
+
+  // 認証チェック
+  const session = await auth();
+  if (!session) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  // Role ARN の取得（環境変数またはイベント設定から）
+  const roleArn =
+    process.env.AWS_PARTICIPANT_ROLE_ARN ||
+    process.env[`AWS_ROLE_ARN_${eventId}`];
+
+  if (!roleArn) {
+    return Response.json(
+      { error: 'AWS Console access is not configured for this event' },
+      { status: 404 },
+    );
+  }
+
+  const tenantId = session.tenantId || 'default';
+  const participantId = session.user?.email || 'unknown';
+  const teamId = session.teamId || 'no-team';
+
+  try {
+    const result = await stsFederation.generateParticipantConsoleUrl(
+      tenantId,
+      participantId,
+      `${eventId}-${teamId}`,
+      roleArn,
+    );
+
+    return Response.json({
+      url: result.url,
+      expiresAt: result.expiresAt.toISOString(),
+    });
+  } catch (error) {
+    console.error('STS Federation error:', error);
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to generate AWS Console URL',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/application-plane/components/gameday/__tests__/aws-console-button.test.tsx
+++ b/apps/application-plane/components/gameday/__tests__/aws-console-button.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AwsConsoleButton } from '../aws-console-button';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock window.open
+const mockWindowOpen = vi.fn();
+Object.defineProperty(window, 'open', {
+  value: mockWindowOpen,
+  writable: true,
+});
+
+describe('AwsConsoleButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ボタンが表示されるべき', () => {
+    render(<AwsConsoleButton eventId="evt-1" />);
+    expect(
+      screen.getByRole('button', { name: /AWS Console を開く/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('カスタムラベルを表示すべき', () => {
+    render(<AwsConsoleButton eventId="evt-1" label="カスタムラベル" />);
+    expect(
+      screen.getByRole('button', { name: /カスタムラベル/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('クリック時に Federation URL を取得して新しいタブで開くべき', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          url: 'https://signin.aws.amazon.com/federation?Action=login&SigninToken=test',
+          expiresAt: new Date().toISOString(),
+        }),
+    });
+
+    render(<AwsConsoleButton eventId="evt-1" />);
+    const button = screen.getByRole('button', { name: /AWS Console を開く/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/participant/events/evt-1/aws-console',
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://signin.aws.amazon.com/federation?Action=login&SigninToken=test',
+        '_blank',
+        'noopener,noreferrer',
+      );
+    });
+  });
+
+  it('API エラー時にエラーメッセージを表示すべき', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () =>
+        Promise.resolve({
+          error: 'AWS Console access is not configured for this event',
+        }),
+    });
+
+    render(<AwsConsoleButton eventId="evt-1" />);
+    const button = screen.getByRole('button', { name: /AWS Console を開く/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('AWS Console access is not configured for this event'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('ネットワークエラー時にフォールバックメッセージを表示すべき', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    render(<AwsConsoleButton eventId="evt-1" />);
+    const button = screen.getByRole('button', { name: /AWS Console を開く/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('eventId を URL エンコードすべき', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          url: 'https://signin.aws.amazon.com/federation?Action=login',
+          expiresAt: new Date().toISOString(),
+        }),
+    });
+
+    render(<AwsConsoleButton eventId="event with spaces" />);
+    const button = screen.getByRole('button', { name: /AWS Console を開く/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/participant/events/event%20with%20spaces/aws-console',
+      );
+    });
+  });
+});

--- a/apps/application-plane/components/gameday/aws-console-button.tsx
+++ b/apps/application-plane/components/gameday/aws-console-button.tsx
@@ -1,0 +1,81 @@
+/**
+ * AWS Console Federation Button
+ *
+ * STS Federation を使用して AWS Console にログインするためのボタン
+ * クリック時に API から Federation URL を取得し、新しいタブで開く
+ */
+
+'use client';
+
+import Button from '@cloudscape-design/components/button';
+import { useCallback, useState } from 'react';
+
+interface AwsConsoleButtonProps {
+  eventId: string;
+  label?: string;
+  variant?: 'primary' | 'normal' | 'link';
+  fullWidth?: boolean;
+}
+
+export function AwsConsoleButton({
+  eventId,
+  label = 'AWS Console を開く',
+  variant = 'primary',
+  fullWidth = false,
+}: AwsConsoleButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClick = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/participant/events/${encodeURIComponent(eventId)}/aws-console`,
+      );
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string };
+        throw new Error(data.error || `HTTP ${response.status}`);
+      }
+
+      const data = (await response.json()) as {
+        url: string;
+        expiresAt: string;
+      };
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to open AWS Console';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  return (
+    <div style={fullWidth ? { width: '100%' } : undefined}>
+      <Button
+        variant={variant}
+        loading={loading}
+        onClick={handleClick}
+        iconName="external"
+        fullWidth={fullWidth}
+      >
+        {label}
+      </Button>
+      {error && (
+        <div
+          style={{
+            color: '#d91515',
+            fontSize: '12px',
+            marginTop: '4px',
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/application-plane/components/gameday/index.ts
+++ b/apps/application-plane/components/gameday/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { AllianceCard } from './alliance-card';
+export { AwsConsoleButton } from './aws-console-button';
 export { AllianceStatusBadge } from './alliance-status-badge';
 export { AttackCard } from './attack-card';
 export { AttackTypeBadge } from './attack-type-badge';


### PR DESCRIPTION
## Summary

- CP モック API に triggerProvisioning/getProvisioningStatus メソッド追加
- AWS Console STS フェデレーション API エンドポイント実装
- GameDay サイドナビの AWS Console リンクを動的フェデレーション URL に変更
- AwsConsoleButton コンポーネント追加

## Test plan

- [x] CP 461テストパス
- [x] AP 668テストパス
- [x] typecheck パス
- [x] format_check パス

https://claude.ai/code/session_01ByKPNvTphgWTMSMqSWD8er