### PR TITLE
feat: PageLayout テンプレートを導入し全参加者ページに統一適用

### DIFF
--- a/apps/application-plane/app/dashboard/page.tsx
+++ b/apps/application-plane/app/dashboard/page.tsx
@@ -20,7 +20,7 @@ import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import '@cloudscape-design/global-styles/index.css';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Header as AppHeader } from '../../components/layout';
+import { PageLayout } from '../../components/layout';
 import { useI18n } from '../../lib/i18n';
 import { getMyEvents } from '../../lib/api/events';
 import type { ParticipantEvent } from '../../lib/api/types';
@@ -168,140 +168,124 @@ export default function DashboardPage() {
   };
 
   return (
-    <div className="min-h-screen">
-      <AppHeader />
+    <PageLayout>
+      <SpaceBetween size="xl">
+        <Header variant="h1" description={t('dashboard.description')}>
+          {t('dashboard.title')}
+        </Header>
 
-      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <SpaceBetween size="xl">
-          <Header variant="h1" description={t('dashboard.description')}>
-            {t('dashboard.title')}
-          </Header>
-
-          {loading ? (
-            <Box textAlign="center" padding="xxl">
-              <Spinner size="large" />
-            </Box>
-          ) : error ? (
-            <Box textAlign="center" padding="xl">
-              <SpaceBetween size="m">
-                <StatusIndicator type="error">{error.message}</StatusIndicator>
-                <Button onClick={() => window.location.reload()}>
-                  {t('common.retry')}
-                </Button>
-              </SpaceBetween>
-            </Box>
-          ) : (
-            <SpaceBetween size="xl">
-              {/* Stats summary */}
-              <ColumnLayout columns={3} variant="text-grid">
-                <Container>
-                  <Box
-                    fontSize="display-l"
-                    fontWeight="bold"
-                    textAlign="center"
-                  >
-                    {activeEvents.length}
-                  </Box>
-                  <Box
-                    color="text-body-secondary"
-                    textAlign="center"
-                    variant="small"
-                  >
-                    {t('dashboard.active')}
-                  </Box>
-                </Container>
-                <Container>
-                  <Box
-                    fontSize="display-l"
-                    fontWeight="bold"
-                    textAlign="center"
-                  >
-                    {scheduledEvents.length}
-                  </Box>
-                  <Box
-                    color="text-body-secondary"
-                    textAlign="center"
-                    variant="small"
-                  >
-                    {t('dashboard.scheduled')}
-                  </Box>
-                </Container>
-                <Container>
-                  <Box
-                    fontSize="display-l"
-                    fontWeight="bold"
-                    textAlign="center"
-                  >
-                    {myEvents.length}
-                  </Box>
-                  <Box
-                    color="text-body-secondary"
-                    textAlign="center"
-                    variant="small"
-                  >
-                    合計
-                  </Box>
-                </Container>
-              </ColumnLayout>
-
-              {/* Active events */}
-              {activeEvents.length > 0 && (
-                <Container
-                  header={<Header variant="h2">{t('dashboard.active')}</Header>}
-                >
-                  <Cards
-                    cardDefinition={cardDefinitionActive}
-                    cardsPerRow={[{ cards: 1 }, { minWidth: 480, cards: 2 }]}
-                    items={activeEvents}
-                    loadingText={t('common.loading')}
-                  />
-                </Container>
-              )}
-
-              {/* Scheduled (registered) events */}
-              {scheduledEvents.length > 0 && (
-                <Container
-                  header={
-                    <Header variant="h2">{t('dashboard.scheduled')}</Header>
-                  }
-                >
-                  <Cards
-                    cardDefinition={cardDefinitionScheduled}
-                    cardsPerRow={[
-                      { cards: 1 },
-                      { minWidth: 320, cards: 2 },
-                      { minWidth: 960, cards: 3 },
-                    ]}
-                    items={scheduledEvents}
-                    loadingText={t('common.loading')}
-                  />
-                </Container>
-              )}
-
-              {/* No events CTA */}
-              {myEvents.length === 0 && (
-                <Container>
-                  <Box textAlign="center" padding="xxl">
-                    <SpaceBetween size="m">
-                      <Box fontSize="display-l">🏆</Box>
-                      <Header variant="h2">{t('dashboard.noMyEvents')}</Header>
-                      <Box color="text-body-secondary">
-                        {t('dashboard.noEventsDescription')}
-                      </Box>
-                      <Button
-                        variant="primary"
-                        onClick={() => router.push('/events')}
-                      >
-                        {t('dashboard.browseEvents')}
-                      </Button>
-                    </SpaceBetween>
-                  </Box>
-                </Container>
-              )}
+        {loading ? (
+          <Box textAlign="center" padding="xxl">
+            <Spinner size="large" />
+          </Box>
+        ) : error ? (
+          <Box textAlign="center" padding="xl">
+            <SpaceBetween size="m">
+              <StatusIndicator type="error">{error.message}</StatusIndicator>
+              <Button onClick={() => window.location.reload()}>
+                {t('common.retry')}
+              </Button>
             </SpaceBetween>
-          )}
-        </SpaceBetween>
-      </main>
-    </div>
+          </Box>
+        ) : (
+          <SpaceBetween size="xl">
+            {/* Stats summary */}
+            <ColumnLayout columns={3} variant="text-grid">
+              <Container>
+                <Box fontSize="display-l" fontWeight="bold" textAlign="center">
+                  {activeEvents.length}
+                </Box>
+                <Box
+                  color="text-body-secondary"
+                  textAlign="center"
+                  variant="small"
+                >
+                  {t('dashboard.active')}
+                </Box>
+              </Container>
+              <Container>
+                <Box fontSize="display-l" fontWeight="bold" textAlign="center">
+                  {scheduledEvents.length}
+                </Box>
+                <Box
+                  color="text-body-secondary"
+                  textAlign="center"
+                  variant="small"
+                >
+                  {t('dashboard.scheduled')}
+                </Box>
+              </Container>
+              <Container>
+                <Box fontSize="display-l" fontWeight="bold" textAlign="center">
+                  {myEvents.length}
+                </Box>
+                <Box
+                  color="text-body-secondary"
+                  textAlign="center"
+                  variant="small"
+                >
+                  合計
+                </Box>
+              </Container>
+            </ColumnLayout>
+
+            {/* Active events */}
+            {activeEvents.length > 0 && (
+              <Container
+                header={<Header variant="h2">{t('dashboard.active')}</Header>}
+              >
+                <Cards
+                  cardDefinition={cardDefinitionActive}
+                  cardsPerRow={[{ cards: 1 }, { minWidth: 480, cards: 2 }]}
+                  items={activeEvents}
+                  loadingText={t('common.loading')}
+                />
+              </Container>
+            )}
+
+            {/* Scheduled (registered) events */}
+            {scheduledEvents.length > 0 && (
+              <Container
+                header={
+                  <Header variant="h2">{t('dashboard.scheduled')}</Header>
+                }
+              >
+                <Cards
+                  cardDefinition={cardDefinitionScheduled}
+                  cardsPerRow={[
+                    { cards: 1 },
+                    { minWidth: 320, cards: 2 },
+                    { minWidth: 960, cards: 3 },
+                  ]}
+                  items={scheduledEvents}
+                  loadingText={t('common.loading')}
+                />
+              </Container>
+            )}
+
+            {/* No events CTA */}
+            {myEvents.length === 0 && (
+              <Container>
+                <Box textAlign="center" padding="xxl">
+                  <SpaceBetween size="m">
+                    <Box fontSize="display-l">🏆</Box>
+                    <Header variant="h2">{t('dashboard.noMyEvents')}</Header>
+                    <Box color="text-body-secondary">
+                      {t('dashboard.noEventsDescription')}
+                    </Box>
+                    <Button
+                      variant="primary"
+                      onClick={() => router.push('/events')}
+                    >
+                      {t('dashboard.browseEvents')}
+                    </Button>
+                  </SpaceBetween>
+                </Box>
+              </Container>
+            )}
+          </SpaceBetween>
+        )}
+      </SpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/events/page.tsx
+++ b/apps/application-plane/app/events/page.tsx
@@ -22,7 +22,7 @@ import Table from '@cloudscape-design/components/table';
 import '@cloudscape-design/global-styles/index.css';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Header as AppHeader } from '../../components/layout';
+import { PageLayout } from '../../components/layout';
 import { useI18n } from '../../lib/i18n';
 import { getAvailableEvents } from '../../lib/api/events';
 import type {
@@ -375,225 +375,210 @@ export default function EventsPage() {
   );
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <AppHeader />
+    <PageLayout>
+      <SpaceBetween size="l">
+        <Header
+          counter={!loading && !error ? `(${events.length})` : undefined}
+          description={t('events.description')}
+          actions={viewToggle}
+        >
+          {t('events.title')}
+        </Header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
-          <SpaceBetween size="l">
-            <Header
-              counter={!loading && !error ? `(${events.length})` : undefined}
-              description={t('events.description')}
-              actions={viewToggle}
-            >
-              {t('events.title')}
-            </Header>
+        {filterBar}
 
-            {filterBar}
-
-            {loading ? (
-              <Box textAlign="center" padding="xl">
-                <Spinner size="large" />
-              </Box>
-            ) : viewMode === 'cards' ? (
-              <Cards
-                cardDefinition={{
-                  header: (event) => (
-                    <Link
-                      href={`/events/${event.id}`}
-                      fontSize="heading-m"
-                      onFollow={(e) => {
-                        e.preventDefault();
-                        router.push(`/events/${event.id}`);
-                      }}
-                    >
-                      {event.name}
-                    </Link>
+        {loading ? (
+          <Box textAlign="center" padding="xl">
+            <Spinner size="large" />
+          </Box>
+        ) : viewMode === 'cards' ? (
+          <Cards
+            cardDefinition={{
+              header: (event) => (
+                <Link
+                  href={`/events/${event.id}`}
+                  fontSize="heading-m"
+                  onFollow={(e) => {
+                    e.preventDefault();
+                    router.push(`/events/${event.id}`);
+                  }}
+                >
+                  {event.name}
+                </Link>
+              ),
+              sections: [
+                {
+                  id: 'status',
+                  header: t('events.statusLabel'),
+                  content: (event) => (
+                    <SpaceBetween direction="horizontal" size="xs">
+                      {getEventStatusIndicator(event.status, t)}
+                      <Badge
+                        color={event.type === 'gameday' ? 'blue' : 'green'}
+                      >
+                        {event.type === 'gameday'
+                          ? t('events.gameday')
+                          : t('events.jam')}
+                      </Badge>
+                      {event.isRegistered && (
+                        <Badge color="green">{t('events.registered')}</Badge>
+                      )}
+                    </SpaceBetween>
                   ),
-                  sections: [
-                    {
-                      id: 'status',
-                      header: t('events.statusLabel'),
-                      content: (event) => (
-                        <SpaceBetween direction="horizontal" size="xs">
-                          {getEventStatusIndicator(event.status, t)}
-                          <Badge
-                            color={event.type === 'gameday' ? 'blue' : 'green'}
-                          >
-                            {event.type === 'gameday'
-                              ? t('events.gameday')
-                              : t('events.jam')}
-                          </Badge>
-                          {event.isRegistered && (
-                            <Badge color="green">
-                              {t('events.registered')}
-                            </Badge>
-                          )}
-                        </SpaceBetween>
-                      ),
-                    },
-                    {
-                      id: 'schedule',
-                      header: t('events.schedule'),
-                      content: (event) => {
-                        const timeUntil =
-                          event.status === 'scheduled'
-                            ? getTimeUntilStart(event.startTime)
-                            : null;
-                        return (
-                          <SpaceBetween size="xxs">
-                            <Box variant="small">
-                              {t('events.startTime')}:{' '}
-                              {formatDate(event.startTime)}
-                            </Box>
-                            <Box variant="small">
-                              {t('events.endTime')}: {formatDate(event.endTime)}
-                            </Box>
-                            {timeUntil && (
-                              <Box color="text-status-info" fontWeight="bold">
-                                {timeUntil}
-                              </Box>
-                            )}
-                          </SpaceBetween>
-                        );
-                      },
-                    },
-                    {
-                      id: 'details',
-                      header: t('events.details'),
-                      content: (event) => (
-                        <SpaceBetween direction="horizontal" size="l">
-                          <Box variant="small">
-                            {t('events.problems')}:{' '}
-                            <Box variant="span" fontWeight="bold">
-                              {event.problemCount}
-                            </Box>
+                },
+                {
+                  id: 'schedule',
+                  header: t('events.schedule'),
+                  content: (event) => {
+                    const timeUntil =
+                      event.status === 'scheduled'
+                        ? getTimeUntilStart(event.startTime)
+                        : null;
+                    return (
+                      <SpaceBetween size="xxs">
+                        <Box variant="small">
+                          {t('events.startTime')}: {formatDate(event.startTime)}
+                        </Box>
+                        <Box variant="small">
+                          {t('events.endTime')}: {formatDate(event.endTime)}
+                        </Box>
+                        {timeUntil && (
+                          <Box color="text-status-info" fontWeight="bold">
+                            {timeUntil}
                           </Box>
-                          <Box variant="small">
-                            {t('events.participants')}:{' '}
-                            <Box variant="span" fontWeight="bold">
-                              {event.participantCount}
-                            </Box>
-                          </Box>
-                          <Box variant="small">
-                            {event.cloudProvider.toUpperCase()}
-                          </Box>
-                          <Box variant="small">
-                            {event.participantType === 'team'
-                              ? t('events.team')
-                              : t('events.solo')}
-                          </Box>
-                        </SpaceBetween>
-                      ),
-                    },
-                    {
-                      id: 'action',
-                      content: (event) => (
-                        <Button
-                          variant={
-                            event.status === 'active' ? 'primary' : 'normal'
-                          }
-                          fullWidth
-                          onClick={() => router.push(`/events/${event.id}`)}
-                        >
-                          {getActionLabel(event, t)}
-                        </Button>
-                      ),
-                    },
-                  ],
-                }}
-                cardsPerRow={[
-                  { cards: 1 },
-                  { minWidth: 600, cards: 2 },
-                  { minWidth: 1000, cards: 3 },
-                ]}
-                items={events}
-                empty={emptyNode}
-              />
-            ) : viewMode === 'list' ? (
-              <Table
-                columnDefinitions={[
-                  {
-                    id: 'name',
-                    header: t('events.name'),
-                    cell: (event) => (
-                      <Link
-                        href={`/events/${event.id}`}
-                        onFollow={(e) => {
-                          e.preventDefault();
-                          router.push(`/events/${event.id}`);
-                        }}
-                      >
-                        {event.name}
-                      </Link>
-                    ),
-                    minWidth: 200,
-                  },
-                  {
-                    id: 'status',
-                    header: t('events.statusLabel'),
-                    cell: (event) => (
-                      <SpaceBetween direction="horizontal" size="xs">
-                        {getEventStatusIndicator(event.status, t)}
-                        <Badge
-                          color={event.type === 'gameday' ? 'blue' : 'green'}
-                        >
-                          {event.type === 'gameday'
-                            ? t('events.gameday')
-                            : t('events.jam')}
-                        </Badge>
+                        )}
                       </SpaceBetween>
-                    ),
-                    width: 220,
+                    );
                   },
-                  {
-                    id: 'start',
-                    header: t('events.startTime'),
-                    cell: (event) => formatDate(event.startTime),
-                    width: 160,
-                  },
-                  {
-                    id: 'end',
-                    header: t('events.endTime'),
-                    cell: (event) => formatDate(event.endTime),
-                    width: 160,
-                  },
-                  {
-                    id: 'participants',
-                    header: t('events.participants'),
-                    cell: (event) => event.participantCount,
-                    width: 110,
-                  },
-                  {
-                    id: 'action',
-                    header: '',
-                    cell: (event) => (
-                      <Button
-                        variant={
-                          event.status === 'active' ? 'primary' : 'normal'
-                        }
-                        onClick={() => router.push(`/events/${event.id}`)}
-                      >
-                        {getActionLabel(event, t)}
-                      </Button>
-                    ),
-                    width: 140,
-                  },
-                ]}
-                items={events}
-                empty={emptyNode}
-              />
-            ) : (
-              <CalendarView
-                events={events}
-                t={t}
-                locale={locale}
-                onNavigate={(path) => router.push(path)}
-              />
-            )}
-          </SpaceBetween>
-        </div>
-      </main>
-    </div>
+                },
+                {
+                  id: 'details',
+                  header: t('events.details'),
+                  content: (event) => (
+                    <SpaceBetween direction="horizontal" size="l">
+                      <Box variant="small">
+                        {t('events.problems')}:{' '}
+                        <Box variant="span" fontWeight="bold">
+                          {event.problemCount}
+                        </Box>
+                      </Box>
+                      <Box variant="small">
+                        {t('events.participants')}:{' '}
+                        <Box variant="span" fontWeight="bold">
+                          {event.participantCount}
+                        </Box>
+                      </Box>
+                      <Box variant="small">
+                        {event.cloudProvider.toUpperCase()}
+                      </Box>
+                      <Box variant="small">
+                        {event.participantType === 'team'
+                          ? t('events.team')
+                          : t('events.solo')}
+                      </Box>
+                    </SpaceBetween>
+                  ),
+                },
+                {
+                  id: 'action',
+                  content: (event) => (
+                    <Button
+                      variant={event.status === 'active' ? 'primary' : 'normal'}
+                      fullWidth
+                      onClick={() => router.push(`/events/${event.id}`)}
+                    >
+                      {getActionLabel(event, t)}
+                    </Button>
+                  ),
+                },
+              ],
+            }}
+            cardsPerRow={[
+              { cards: 1 },
+              { minWidth: 600, cards: 2 },
+              { minWidth: 1000, cards: 3 },
+            ]}
+            items={events}
+            empty={emptyNode}
+          />
+        ) : viewMode === 'list' ? (
+          <Table
+            columnDefinitions={[
+              {
+                id: 'name',
+                header: t('events.name'),
+                cell: (event) => (
+                  <Link
+                    href={`/events/${event.id}`}
+                    onFollow={(e) => {
+                      e.preventDefault();
+                      router.push(`/events/${event.id}`);
+                    }}
+                  >
+                    {event.name}
+                  </Link>
+                ),
+                minWidth: 200,
+              },
+              {
+                id: 'status',
+                header: t('events.statusLabel'),
+                cell: (event) => (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    {getEventStatusIndicator(event.status, t)}
+                    <Badge color={event.type === 'gameday' ? 'blue' : 'green'}>
+                      {event.type === 'gameday'
+                        ? t('events.gameday')
+                        : t('events.jam')}
+                    </Badge>
+                  </SpaceBetween>
+                ),
+                width: 220,
+              },
+              {
+                id: 'start',
+                header: t('events.startTime'),
+                cell: (event) => formatDate(event.startTime),
+                width: 160,
+              },
+              {
+                id: 'end',
+                header: t('events.endTime'),
+                cell: (event) => formatDate(event.endTime),
+                width: 160,
+              },
+              {
+                id: 'participants',
+                header: t('events.participants'),
+                cell: (event) => event.participantCount,
+                width: 110,
+              },
+              {
+                id: 'action',
+                header: '',
+                cell: (event) => (
+                  <Button
+                    variant={event.status === 'active' ? 'primary' : 'normal'}
+                    onClick={() => router.push(`/events/${event.id}`)}
+                  >
+                    {getActionLabel(event, t)}
+                  </Button>
+                ),
+                width: 140,
+              },
+            ]}
+            items={events}
+            empty={emptyNode}
+          />
+        ) : (
+          <CalendarView
+            events={events}
+            t={t}
+            locale={locale}
+            onNavigate={(path) => router.push(path)}
+          />
+        )}
+      </SpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/profile/badges/page.tsx
+++ b/apps/application-plane/app/profile/badges/page.tsx
@@ -15,7 +15,7 @@ import CloudscapeLink from '@cloudscape-design/components/link';
 import CloudscapeSpaceBetween from '@cloudscape-design/components/space-between';
 import CloudscapeSpinner from '@cloudscape-design/components/spinner';
 import { useEffect, useState } from 'react';
-import { Header } from '../../../components/layout';
+import { PageLayout } from '../../../components/layout';
 import { useI18n } from '../../../lib/i18n';
 import { getMyBadges } from '../../../lib/api/profile';
 import type { Badge } from '../../../lib/api/types';
@@ -33,65 +33,53 @@ export default function BadgesPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <Header />
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
-          <CloudscapeSpaceBetween size="l">
-            <CloudscapeBox>
-              <CloudscapeLink href="/profile">
-                {t('profile.backToProfile')}
-              </CloudscapeLink>
-            </CloudscapeBox>
+    <PageLayout maxWidth="3xl">
+      <CloudscapeSpaceBetween size="l">
+        <CloudscapeBox>
+          <CloudscapeLink href="/profile">
+            {t('profile.backToProfile')}
+          </CloudscapeLink>
+        </CloudscapeBox>
 
-            <CloudscapeHeader variant="h1">
-              {t('profile.badges')}
-            </CloudscapeHeader>
+        <CloudscapeHeader variant="h1">{t('profile.badges')}</CloudscapeHeader>
 
-            {loading ? (
-              <CloudscapeBox textAlign="center" padding="xl">
-                <CloudscapeSpinner size="large" />
-              </CloudscapeBox>
-            ) : (
-              <CloudscapeContainer>
-                <CloudscapeCards
-                  cardDefinition={{
-                    header: (b) => b.name,
-                    sections: [
-                      {
-                        id: 'description',
-                        content: (b) => b.description,
-                      },
-                      {
-                        id: 'date',
-                        header: t('profile.acquiredDate'),
-                        content: (b) =>
-                          new Date(b.earnedAt).toLocaleDateString(),
-                      },
-                    ],
-                  }}
-                  cardsPerRow={[{ cards: 1 }, { minWidth: 400, cards: 2 }]}
-                  items={badges}
-                  empty={
-                    <CloudscapeBox
-                      textAlign="center"
-                      color="inherit"
-                      padding="m"
-                    >
-                      {t('profile.noBadges')}
-                    </CloudscapeBox>
-                  }
-                  header={
-                    <CloudscapeHeader>
-                      {t('profile.badges')} ({badges.length})
-                    </CloudscapeHeader>
-                  }
-                />
-              </CloudscapeContainer>
-            )}
-          </CloudscapeSpaceBetween>
-        </div>
-      </main>
-    </div>
+        {loading ? (
+          <CloudscapeBox textAlign="center" padding="xl">
+            <CloudscapeSpinner size="large" />
+          </CloudscapeBox>
+        ) : (
+          <CloudscapeContainer>
+            <CloudscapeCards
+              cardDefinition={{
+                header: (b) => b.name,
+                sections: [
+                  {
+                    id: 'description',
+                    content: (b) => b.description,
+                  },
+                  {
+                    id: 'date',
+                    header: t('profile.acquiredDate'),
+                    content: (b) => new Date(b.earnedAt).toLocaleDateString(),
+                  },
+                ],
+              }}
+              cardsPerRow={[{ cards: 1 }, { minWidth: 400, cards: 2 }]}
+              items={badges}
+              empty={
+                <CloudscapeBox textAlign="center" color="inherit" padding="m">
+                  {t('profile.noBadges')}
+                </CloudscapeBox>
+              }
+              header={
+                <CloudscapeHeader>
+                  {t('profile.badges')} ({badges.length})
+                </CloudscapeHeader>
+              }
+            />
+          </CloudscapeContainer>
+        )}
+      </CloudscapeSpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/profile/history/page.tsx
+++ b/apps/application-plane/app/profile/history/page.tsx
@@ -15,7 +15,7 @@ import CloudscapeSpaceBetween from '@cloudscape-design/components/space-between'
 import CloudscapeSpinner from '@cloudscape-design/components/spinner';
 import CloudscapeTable from '@cloudscape-design/components/table';
 import { useEffect, useState } from 'react';
-import { Header } from '../../../components/layout';
+import { PageLayout } from '../../../components/layout';
 import { useI18n } from '../../../lib/i18n';
 import { getEventHistory } from '../../../lib/api/profile';
 import type { ParticipantEventSummary } from '../../../lib/api/types';
@@ -33,75 +33,63 @@ export default function HistoryPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <Header />
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
-          <CloudscapeSpaceBetween size="l">
-            <CloudscapeBox>
-              <CloudscapeLink href="/profile">
-                {t('profile.backToProfile')}
-              </CloudscapeLink>
-            </CloudscapeBox>
+    <PageLayout maxWidth="3xl">
+      <CloudscapeSpaceBetween size="l">
+        <CloudscapeBox>
+          <CloudscapeLink href="/profile">
+            {t('profile.backToProfile')}
+          </CloudscapeLink>
+        </CloudscapeBox>
 
-            <CloudscapeHeader variant="h1">
-              {t('profile.history')}
-            </CloudscapeHeader>
+        <CloudscapeHeader variant="h1">{t('profile.history')}</CloudscapeHeader>
 
-            {loading ? (
-              <CloudscapeBox textAlign="center" padding="xl">
-                <CloudscapeSpinner size="large" />
-              </CloudscapeBox>
-            ) : (
-              <CloudscapeContainer>
-                <CloudscapeTable
-                  columnDefinitions={[
-                    {
-                      id: 'event',
-                      header: t('profile.event'),
-                      cell: (e) => e.eventName,
-                    },
-                    {
-                      id: 'date',
-                      header: t('profile.date'),
-                      cell: (e) =>
-                        new Date(e.participatedAt).toLocaleDateString(),
-                    },
-                    {
-                      id: 'rank',
-                      header: t('leaderboard.rank'),
-                      cell: (e) =>
-                        e.finalRank
-                          ? `${e.finalRank} / ${e.totalParticipants}`
-                          : '-',
-                    },
-                    {
-                      id: 'score',
-                      header: t('profile.score'),
-                      cell: (e) => `${e.score.toLocaleString()} pts`,
-                    },
-                  ]}
-                  items={events}
-                  empty={
-                    <CloudscapeBox
-                      textAlign="center"
-                      color="inherit"
-                      padding="m"
-                    >
-                      {t('profile.historyEmpty')}
-                    </CloudscapeBox>
-                  }
-                  header={
-                    <CloudscapeHeader>
-                      {t('profile.history')} ({events.length})
-                    </CloudscapeHeader>
-                  }
-                />
-              </CloudscapeContainer>
-            )}
-          </CloudscapeSpaceBetween>
-        </div>
-      </main>
-    </div>
+        {loading ? (
+          <CloudscapeBox textAlign="center" padding="xl">
+            <CloudscapeSpinner size="large" />
+          </CloudscapeBox>
+        ) : (
+          <CloudscapeContainer>
+            <CloudscapeTable
+              columnDefinitions={[
+                {
+                  id: 'event',
+                  header: t('profile.event'),
+                  cell: (e) => e.eventName,
+                },
+                {
+                  id: 'date',
+                  header: t('profile.date'),
+                  cell: (e) => new Date(e.participatedAt).toLocaleDateString(),
+                },
+                {
+                  id: 'rank',
+                  header: t('leaderboard.rank'),
+                  cell: (e) =>
+                    e.finalRank
+                      ? `${e.finalRank} / ${e.totalParticipants}`
+                      : '-',
+                },
+                {
+                  id: 'score',
+                  header: t('profile.score'),
+                  cell: (e) => `${e.score.toLocaleString()} pts`,
+                },
+              ]}
+              items={events}
+              empty={
+                <CloudscapeBox textAlign="center" color="inherit" padding="m">
+                  {t('profile.historyEmpty')}
+                </CloudscapeBox>
+              }
+              header={
+                <CloudscapeHeader>
+                  {t('profile.history')} ({events.length})
+                </CloudscapeHeader>
+              }
+            />
+          </CloudscapeContainer>
+        )}
+      </CloudscapeSpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/profile/page.tsx
+++ b/apps/application-plane/app/profile/page.tsx
@@ -16,7 +16,7 @@ import CloudscapeLink from '@cloudscape-design/components/link';
 import CloudscapeSpaceBetween from '@cloudscape-design/components/space-between';
 import CloudscapeSpinner from '@cloudscape-design/components/spinner';
 import { useEffect, useState } from 'react';
-import { Header } from '../../components/layout';
+import { PageLayout } from '../../components/layout';
 import { useI18n } from '../../lib/i18n';
 import { getMyProfile } from '../../lib/api/profile';
 import type { ParticipantProfile } from '../../lib/api/types';
@@ -37,85 +37,75 @@ export default function ProfilePage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <Header />
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
+    <PageLayout maxWidth="3xl">
+      <CloudscapeSpaceBetween size="l">
+        <CloudscapeHeader variant="h1">{t('profile.title')}</CloudscapeHeader>
+
+        {loading && (
+          <CloudscapeBox textAlign="center" padding="xl">
+            <CloudscapeSpinner size="large" />
+          </CloudscapeBox>
+        )}
+
+        {error && (
+          <CloudscapeContainer>
+            <CloudscapeBox color="text-status-error">{error}</CloudscapeBox>
+          </CloudscapeContainer>
+        )}
+
+        {!loading && !error && (
           <CloudscapeSpaceBetween size="l">
-            <CloudscapeHeader variant="h1">
-              {t('profile.title')}
-            </CloudscapeHeader>
+            <CloudscapeContainer
+              header={
+                <CloudscapeHeader variant="h2">
+                  {profile?.name ?? 'ユーザー'}
+                </CloudscapeHeader>
+              }
+            >
+              <CloudscapeKeyValuePairs
+                columns={2}
+                items={[
+                  {
+                    label: t('profile.email'),
+                    value: profile?.email ?? '-',
+                  },
+                  {
+                    label: t('profile.rank'),
+                    value: profile?.rank
+                      ? `${profile.rank}${t('profile.rankSuffix')}`
+                      : '-',
+                  },
+                  {
+                    label: t('profile.eventsParticipated'),
+                    value: String(profile?.totalEventsParticipated ?? 0),
+                  },
+                  {
+                    label: t('profile.totalScore'),
+                    value: `${(profile?.totalScore ?? 0).toLocaleString()} pts`,
+                  },
+                ]}
+              />
+            </CloudscapeContainer>
 
-            {loading && (
-              <CloudscapeBox textAlign="center" padding="xl">
-                <CloudscapeSpinner size="large" />
-              </CloudscapeBox>
-            )}
-
-            {error && (
-              <CloudscapeContainer>
-                <CloudscapeBox color="text-status-error">{error}</CloudscapeBox>
-              </CloudscapeContainer>
-            )}
-
-            {!loading && !error && (
-              <CloudscapeSpaceBetween size="l">
-                <CloudscapeContainer
-                  header={
-                    <CloudscapeHeader variant="h2">
-                      {profile?.name ?? 'ユーザー'}
-                    </CloudscapeHeader>
-                  }
-                >
-                  <CloudscapeKeyValuePairs
-                    columns={2}
-                    items={[
-                      {
-                        label: t('profile.email'),
-                        value: profile?.email ?? '-',
-                      },
-                      {
-                        label: t('profile.rank'),
-                        value: profile?.rank
-                          ? `${profile.rank}${t('profile.rankSuffix')}`
-                          : '-',
-                      },
-                      {
-                        label: t('profile.eventsParticipated'),
-                        value: String(profile?.totalEventsParticipated ?? 0),
-                      },
-                      {
-                        label: t('profile.totalScore'),
-                        value: `${(profile?.totalScore ?? 0).toLocaleString()} pts`,
-                      },
-                    ]}
-                  />
-                </CloudscapeContainer>
-
-                <CloudscapeContainer
-                  header={
-                    <CloudscapeHeader variant="h2">
-                      {t('profile.menu')}
-                    </CloudscapeHeader>
-                  }
-                >
-                  <CloudscapeColumnLayout columns={2}>
-                    <CloudscapeLink
-                      href="/profile/history"
-                      fontSize="heading-s"
-                    >
-                      {t('profile.history')}
-                    </CloudscapeLink>
-                    <CloudscapeLink href="/profile/badges" fontSize="heading-s">
-                      {t('profile.badges')}
-                    </CloudscapeLink>
-                  </CloudscapeColumnLayout>
-                </CloudscapeContainer>
-              </CloudscapeSpaceBetween>
-            )}
+            <CloudscapeContainer
+              header={
+                <CloudscapeHeader variant="h2">
+                  {t('profile.menu')}
+                </CloudscapeHeader>
+              }
+            >
+              <CloudscapeColumnLayout columns={2}>
+                <CloudscapeLink href="/profile/history" fontSize="heading-s">
+                  {t('profile.history')}
+                </CloudscapeLink>
+                <CloudscapeLink href="/profile/badges" fontSize="heading-s">
+                  {t('profile.badges')}
+                </CloudscapeLink>
+              </CloudscapeColumnLayout>
+            </CloudscapeContainer>
           </CloudscapeSpaceBetween>
-        </div>
-      </main>
-    </div>
+        )}
+      </CloudscapeSpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/rankings/page.tsx
+++ b/apps/application-plane/app/rankings/page.tsx
@@ -19,7 +19,7 @@ import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Table from '@cloudscape-design/components/table';
 import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useState } from 'react';
-import { Header } from '../../components/layout';
+import { PageLayout } from '../../components/layout';
 import { getErrorMessage } from '../../components/ui';
 import { getGlobalRanking } from '../../lib/api/profile';
 
@@ -115,205 +115,197 @@ export default function RankingsPage() {
   const topScore = rankings[0]?.totalScore;
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <Header />
+    <PageLayout>
+      <SpaceBetween size="l">
+        {/* My Rank Banner */}
+        {data?.myRank && (
+          <Container>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '16px',
+              }}
+            >
+              <Box fontSize="display-l" fontWeight="heavy">
+                {data.myRank}位
+              </Box>
+              <div>
+                <Box variant="p" color="text-body-secondary">
+                  あなたの現在の順位
+                </Box>
+                <Box variant="p" color="text-body-secondary">
+                  / {data.total}人中
+                </Box>
+              </div>
+            </div>
+          </Container>
+        )}
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
-          <SpaceBetween size="l">
-            {/* My Rank Banner */}
-            {data?.myRank && (
-              <Container>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '16px',
-                  }}
-                >
-                  <Box fontSize="display-l" fontWeight="heavy">
-                    {data.myRank}位
+        {/* Stats Cards */}
+        {!error && (
+          <ColumnLayout columns={2}>
+            <Container
+              header={
+                <CloudscapeHeader variant="h3">総参加者数</CloudscapeHeader>
+              }
+            >
+              {loading ? (
+                <Spinner size="large" />
+              ) : (
+                <Box variant="p" fontSize="display-l" fontWeight="heavy">
+                  {totalParticipants.toLocaleString()}
+                </Box>
+              )}
+            </Container>
+
+            <Container
+              header={
+                <CloudscapeHeader variant="h3">最高スコア</CloudscapeHeader>
+              }
+            >
+              {loading ? (
+                <Spinner size="large" />
+              ) : (
+                <Box variant="p" fontSize="display-l" fontWeight="heavy">
+                  {topScore !== undefined ? topScore.toLocaleString() : '-'}
+                </Box>
+              )}
+            </Container>
+          </ColumnLayout>
+        )}
+
+        {/* Error State */}
+        {error && (
+          <Container>
+            <SpaceBetween size="m" direction="vertical" alignItems="center">
+              <StatusIndicator type="error">
+                {getErrorMessage(error)}
+              </StatusIndicator>
+              <Button onClick={fetchRankings}>再試行</Button>
+            </SpaceBetween>
+          </Container>
+        )}
+
+        {/* Rankings Table */}
+        {!error && (
+          <Table
+            header={
+              <CloudscapeHeader
+                variant="h1"
+                description="クラウドエンジニアの頂点を目指せ"
+                counter={`(${rankings.length})`}
+                actions={<Badge color="blue">Top 50</Badge>}
+              >
+                ランキング
+              </CloudscapeHeader>
+            }
+            loading={loading}
+            loadingText="ランキングを読み込み中..."
+            items={rankings}
+            empty={
+              <Box textAlign="center" padding="xl">
+                <SpaceBetween size="s">
+                  <Box variant="p" fontSize="heading-xl" fontWeight="bold">
+                    {'\u{1F3C6}'}
                   </Box>
-                  <div>
-                    <Box variant="p" color="text-body-secondary">
-                      あなたの現在の順位
-                    </Box>
-                    <Box variant="p" color="text-body-secondary">
-                      / {data.total}人中
-                    </Box>
-                  </div>
-                </div>
-              </Container>
-            )}
-
-            {/* Stats Cards */}
-            {!error && (
-              <ColumnLayout columns={2}>
-                <Container
-                  header={
-                    <CloudscapeHeader variant="h3">総参加者数</CloudscapeHeader>
-                  }
-                >
-                  {loading ? (
-                    <Spinner size="large" />
-                  ) : (
-                    <Box variant="p" fontSize="display-l" fontWeight="heavy">
-                      {totalParticipants.toLocaleString()}
-                    </Box>
-                  )}
-                </Container>
-
-                <Container
-                  header={
-                    <CloudscapeHeader variant="h3">最高スコア</CloudscapeHeader>
-                  }
-                >
-                  {loading ? (
-                    <Spinner size="large" />
-                  ) : (
-                    <Box variant="p" fontSize="display-l" fontWeight="heavy">
-                      {topScore !== undefined ? topScore.toLocaleString() : '-'}
-                    </Box>
-                  )}
-                </Container>
-              </ColumnLayout>
-            )}
-
-            {/* Error State */}
-            {error && (
-              <Container>
-                <SpaceBetween size="m" direction="vertical" alignItems="center">
-                  <StatusIndicator type="error">
-                    {getErrorMessage(error)}
-                  </StatusIndicator>
-                  <Button onClick={fetchRankings}>再試行</Button>
+                  <Box variant="h2" fontWeight="bold">
+                    ランキングデータがありません
+                  </Box>
+                  <Box variant="p" color="text-body-secondary">
+                    イベントに参加してランキングに載ろう！
+                  </Box>
+                  <Button variant="primary" href="/events">
+                    イベントを探す
+                  </Button>
                 </SpaceBetween>
-              </Container>
-            )}
-
-            {/* Rankings Table */}
-            {!error && (
-              <Table
-                header={
-                  <CloudscapeHeader
-                    variant="h1"
-                    description="クラウドエンジニアの頂点を目指せ"
-                    counter={`(${rankings.length})`}
-                    actions={<Badge color="blue">Top 50</Badge>}
-                  >
-                    ランキング
-                  </CloudscapeHeader>
-                }
-                loading={loading}
-                loadingText="ランキングを読み込み中..."
-                items={rankings}
-                empty={
-                  <Box textAlign="center" padding="xl">
-                    <SpaceBetween size="s">
-                      <Box variant="p" fontSize="heading-xl" fontWeight="bold">
-                        {'\u{1F3C6}'}
-                      </Box>
-                      <Box variant="h2" fontWeight="bold">
-                        ランキングデータがありません
-                      </Box>
-                      <Box variant="p" color="text-body-secondary">
-                        イベントに参加してランキングに載ろう！
-                      </Box>
-                      <Button variant="primary" href="/events">
-                        イベントを探す
-                      </Button>
-                    </SpaceBetween>
-                  </Box>
-                }
-                columnDefinitions={[
-                  {
-                    id: 'rank',
-                    header: '順位',
-                    width: 100,
-                    cell: (item) => {
-                      const bgColor = getRankBoxColor(item.rank);
-                      return (
-                        <Box
-                          fontSize={item.rank <= 3 ? 'heading-m' : 'body-m'}
-                          fontWeight="bold"
-                        >
-                          {bgColor ? (
-                            <span
-                              style={{
-                                background: bgColor,
-                                padding: '4px 12px',
-                                borderRadius: '8px',
-                                display: 'inline-block',
-                              }}
-                            >
-                              {getRankIcon(item.rank)}
-                            </span>
-                          ) : (
-                            getRankIcon(item.rank)
-                          )}
-                        </Box>
-                      );
-                    },
-                  },
-                  {
-                    id: 'name',
-                    header: '名前',
-                    cell: (item) => (
-                      <SpaceBetween
-                        size="xs"
-                        direction="horizontal"
-                        alignItems="center"
-                      >
-                        <div
+              </Box>
+            }
+            columnDefinitions={[
+              {
+                id: 'rank',
+                header: '順位',
+                width: 100,
+                cell: (item) => {
+                  const bgColor = getRankBoxColor(item.rank);
+                  return (
+                    <Box
+                      fontSize={item.rank <= 3 ? 'heading-m' : 'body-m'}
+                      fontWeight="bold"
+                    >
+                      {bgColor ? (
+                        <span
                           style={{
-                            width: 36,
-                            height: 36,
-                            borderRadius: '50%',
-                            background: getRankColor(item.rank),
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            fontWeight: 700,
-                            fontSize: '0.875rem',
-                            color: '#FFFFFF',
+                            background: bgColor,
+                            padding: '4px 12px',
+                            borderRadius: '8px',
+                            display: 'inline-block',
                           }}
                         >
-                          {item.name.charAt(0)}
-                        </div>
-                        <Box fontWeight="bold">{item.name}</Box>
-                      </SpaceBetween>
-                    ),
-                  },
-                  {
-                    id: 'eventsParticipated',
-                    header: '参加イベント',
-                    width: 150,
-                    cell: (item) => (
-                      <Badge color="blue">
-                        {`${item.eventsParticipated}回`}
-                      </Badge>
-                    ),
-                  },
-                  {
-                    id: 'totalScore',
-                    header: '合計スコア',
-                    width: 180,
-                    cell: (item) => (
-                      <Box fontWeight="bold" fontSize="heading-s">
-                        {item.totalScore.toLocaleString()}
-                        <Box variant="span" color="text-body-secondary">
-                          {' '}
-                          pts
-                        </Box>
-                      </Box>
-                    ),
-                  },
-                ]}
-              />
-            )}
-          </SpaceBetween>
-        </div>
-      </main>
-    </div>
+                          {getRankIcon(item.rank)}
+                        </span>
+                      ) : (
+                        getRankIcon(item.rank)
+                      )}
+                    </Box>
+                  );
+                },
+              },
+              {
+                id: 'name',
+                header: '名前',
+                cell: (item) => (
+                  <SpaceBetween
+                    size="xs"
+                    direction="horizontal"
+                    alignItems="center"
+                  >
+                    <div
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: '50%',
+                        background: getRankColor(item.rank),
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontWeight: 700,
+                        fontSize: '0.875rem',
+                        color: '#FFFFFF',
+                      }}
+                    >
+                      {item.name.charAt(0)}
+                    </div>
+                    <Box fontWeight="bold">{item.name}</Box>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'eventsParticipated',
+                header: '参加イベント',
+                width: 150,
+                cell: (item) => (
+                  <Badge color="blue">{`${item.eventsParticipated}回`}</Badge>
+                ),
+              },
+              {
+                id: 'totalScore',
+                header: '合計スコア',
+                width: 180,
+                cell: (item) => (
+                  <Box fontWeight="bold" fontSize="heading-s">
+                    {item.totalScore.toLocaleString()}
+                    <Box variant="span" color="text-body-secondary">
+                      {' '}
+                      pts
+                    </Box>
+                  </Box>
+                ),
+              },
+            ]}
+          />
+        )}
+      </SpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/components/layout/__tests__/page-layout.test.tsx
+++ b/apps/application-plane/components/layout/__tests__/page-layout.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PageLayout } from '../page-layout';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => null,
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+  signOut: vi.fn(),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  useTenantOptional: () => null,
+}));
+
+describe('PageLayout', () => {
+  it('ヘッダーが表示されるべき', () => {
+    render(<PageLayout>content</PageLayout>);
+    expect(screen.getByText('TenkaCloud')).toBeInTheDocument();
+  });
+
+  it('子コンテンツが表示されるべき', () => {
+    render(<PageLayout>test content</PageLayout>);
+    expect(screen.getByText('test content')).toBeInTheDocument();
+  });
+
+  it('デフォルトで max-w-7xl が適用されるべき', () => {
+    render(<PageLayout>content</PageLayout>);
+    const main = document.querySelector('main');
+    expect(main?.className).toContain('max-w-7xl');
+  });
+
+  it('maxWidth prop で幅を変更できるべき', () => {
+    render(<PageLayout maxWidth="3xl">content</PageLayout>);
+    const main = document.querySelector('main');
+    expect(main?.className).toContain('max-w-3xl');
+  });
+
+  it('awsui-dark-mode ラッパーを含むべき', () => {
+    render(<PageLayout>content</PageLayout>);
+    expect(document.querySelector('.awsui-dark-mode')).toBeInTheDocument();
+  });
+});

--- a/apps/application-plane/components/layout/index.ts
+++ b/apps/application-plane/components/layout/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { Header } from './header';
+export { PageLayout } from './page-layout';

--- a/apps/application-plane/components/layout/page-layout.tsx
+++ b/apps/application-plane/components/layout/page-layout.tsx
@@ -1,0 +1,54 @@
+/**
+ * PageLayout
+ *
+ * 全参加者ページ共通テンプレート:
+ *   AppHeader → <main> (max-w-7xl, パディング統一) → awsui-dark-mode ラッパー
+ *
+ * 使用例:
+ *   <PageLayout>
+ *     <Header variant="h1">ページタイトル</Header>
+ *     ...Cloudscape コンテンツ...
+ *   </PageLayout>
+ *
+ *   <PageLayout maxWidth="3xl">  // 幅を変える場合
+ *     ...
+ *   </PageLayout>
+ */
+
+'use client';
+
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import '@cloudscape-design/global-styles/index.css';
+import type { ReactNode } from 'react';
+import { Header } from './header';
+
+type MaxWidth = '3xl' | '4xl' | '5xl' | '6xl' | '7xl';
+
+interface PageLayoutProps {
+  children: ReactNode;
+  /** コンテンツ最大幅（デフォルト: 7xl） */
+  maxWidth?: MaxWidth;
+}
+
+const maxWidthClass: Record<MaxWidth, string> = {
+  '3xl': 'max-w-3xl',
+  '4xl': 'max-w-4xl',
+  '5xl': 'max-w-5xl',
+  '6xl': 'max-w-6xl',
+  '7xl': 'max-w-7xl',
+};
+
+export function PageLayout({ children, maxWidth = '7xl' }: PageLayoutProps) {
+  return (
+    <div className="min-h-screen bg-surface-0">
+      <Header />
+      <main
+        className={`${maxWidthClass[maxWidth]} mx-auto px-4 sm:px-6 lg:px-8 py-8`}
+      >
+        <div className="awsui-dark-mode">
+          <SpaceBetween size="l">{children}</SpaceBetween>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `components/layout/page-layout.tsx` に `PageLayout` コンポーネントを新設
- `AppHeader + <main max-w-7xl> + awsui-dark-mode` のボイラープレートを1コンポーネントに集約
- `maxWidth` prop で幅を変更可能（デフォルト `7xl`、profile は `3xl`）

## 新規ページの書き方
```tsx
import { PageLayout } from '@/components/layout';

export default function MyPage() {
  return (
    <PageLayout>
      <Header variant="h1">タイトル</Header>
      {/* Cloudscape コンテンツ */}
    </PageLayout>
  );
}
```

## 適用済みページ
- `app/events/page.tsx`
- `app/dashboard/page.tsx`
- `app/rankings/page.tsx`
- `app/profile/page.tsx`
- `app/profile/badges/page.tsx`
- `app/profile/history/page.tsx`

## Test plan
- [x] `make before-commit` 全通過 (770 tests)
- [x] PageLayout 単体テスト 5件追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)