### PR TITLE
fix: ヘッダーのコントラストを強化して視認性を改善

### DIFF
--- a/apps/application-plane/components/layout/header.tsx
+++ b/apps/application-plane/components/layout/header.tsx
@@ -22,7 +22,7 @@ export function Header() {
   const isLoading = status === 'loading';
 
   return (
-    <header className="bg-surface-1 border-b border-border sticky top-0 z-50 backdrop-blur-sm bg-opacity-95">
+    <header className="bg-surface-3 border-b-2 border-hn-accent/40 sticky top-0 z-50 shadow-md">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}


### PR DESCRIPTION
## Summary
- `bg-surface-1`（#242e33）→ `bg-surface-3`（#313d43）でページ背景（#1d2528）との差を拡大
- `border-b-2 border-hn-accent/40` でアクセントカラーのボーダーラインを追加
- `shadow-md` で浮き上がり感を演出

## Test plan
- [x] `make before-commit` 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)