### PR TITLE
feat: Cloudscape product-detail-page パターンをランディング・イベントページに適用

### DIFF
--- a/apps/application-plane/app/dashboard/page.tsx
+++ b/apps/application-plane/app/dashboard/page.tsx
@@ -168,12 +168,14 @@ export default function DashboardPage() {
   };
 
   return (
-    <PageLayout>
-      <SpaceBetween size="xl">
+    <PageLayout
+      header={
         <Header variant="h1" description={t('dashboard.description')}>
           {t('dashboard.title')}
         </Header>
-
+      }
+    >
+      <SpaceBetween size="xl">
         {loading ? (
           <Box textAlign="center" padding="xxl">
             <Spinner size="large" />

--- a/apps/application-plane/app/events/[eventId]/page.tsx
+++ b/apps/application-plane/app/events/[eventId]/page.tsx
@@ -27,7 +27,7 @@ import '@cloudscape-design/global-styles/index.css';
 import NextLink from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Header as AppHeader } from '../../../components/layout';
+import { PageLayout } from '../../../components/layout';
 import {
   getEventDetails,
   getLeaderboard,
@@ -264,36 +264,42 @@ export default function EventDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-surface-0">
-        <AppHeader />
-        <div className="flex justify-center items-center h-64">
+      <PageLayout
+        breadcrumbs={[
+          { text: 'ホーム', href: '/' },
+          { text: 'イベント', href: '/events' },
+          { text: '読み込み中...' },
+        ]}
+      >
+        <Box textAlign="center" padding="xxl">
           <Spinner size="large" />
-        </div>
-      </div>
+        </Box>
+      </PageLayout>
     );
   }
 
   if (error || !event) {
     return (
-      <div className="min-h-screen bg-surface-0">
-        <AppHeader />
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="awsui-dark-mode">
-            <Container>
-              <Box textAlign="center" padding="xl">
-                <SpaceBetween size="m">
-                  <StatusIndicator type="error">
-                    {error || 'イベントが見つかりません'}
-                  </StatusIndicator>
-                  <Button onClick={() => router.push('/events')}>
-                    イベント一覧に戻る
-                  </Button>
-                </SpaceBetween>
-              </Box>
-            </Container>
-          </div>
-        </main>
-      </div>
+      <PageLayout
+        breadcrumbs={[
+          { text: 'ホーム', href: '/' },
+          { text: 'イベント', href: '/events' },
+          { text: 'エラー' },
+        ]}
+      >
+        <Container>
+          <Box textAlign="center" padding="xl">
+            <SpaceBetween size="m">
+              <StatusIndicator type="error">
+                {error || 'イベントが見つかりません'}
+              </StatusIndicator>
+              <Button onClick={() => router.push('/events')}>
+                イベント一覧に戻る
+              </Button>
+            </SpaceBetween>
+          </Box>
+        </Container>
+      </PageLayout>
     );
   }
 
@@ -301,425 +307,389 @@ export default function EventDetailPage() {
   const canParticipate = event.isRegistered && isActive;
 
   return (
-    <div className="min-h-screen bg-surface-0">
-      <AppHeader />
-
-      {/* Registration Modal */}
-      <div className="awsui-dark-mode">
-        <Modal
-          visible={showModal}
-          onDismiss={() => setShowModal(false)}
-          closeAriaLabel="閉じる"
-          header="参加登録"
-          size="medium"
-          footer={
-            <Box float="right">
-              <Button variant="link" onClick={() => setShowModal(false)}>
-                キャンセル
-              </Button>
-            </Box>
+    <PageLayout
+      breadcrumbs={[
+        { text: 'ホーム', href: '/' },
+        { text: 'イベント', href: '/events' },
+        { text: event.name },
+      ]}
+      header={
+        <Header
+          variant="h1"
+          description={
+            <SpaceBetween direction="horizontal" size="xs">
+              {getEventStatusIndicator(event.status)}
+              <Badge color={event.type === 'gameday' ? 'blue' : 'green'}>
+                {event.type === 'gameday' ? 'GameDay' : 'JAM'}
+              </Badge>
+              {event.isRegistered && <Badge color="green">登録済み</Badge>}
+            </SpaceBetween>
+          }
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              {!event.isRegistered && event.status !== 'completed' && (
+                <Button
+                  variant="primary"
+                  onClick={handleRegisterClick}
+                  loading={registering}
+                >
+                  {event.participantType === 'team'
+                    ? 'チームで登録'
+                    : '参加登録'}
+                </Button>
+              )}
+              {canParticipate && (
+                <NextLink href={`/gameday/${eventId}`}>
+                  <Button variant="primary">バトルに参加</Button>
+                </NextLink>
+              )}
+            </SpaceBetween>
           }
         >
-          <SpaceBetween size="l">
-            <Box variant="p" color="text-body-secondary">
-              参加方法を選択してください
-            </Box>
+          {event.name}
+        </Header>
+      }
+    >
+      {/* Registration Modal */}
+      <Modal
+        visible={showModal}
+        onDismiss={() => setShowModal(false)}
+        closeAriaLabel="閉じる"
+        header="参加登録フォーム"
+        size="medium"
+        footer={
+          <Box float="right">
+            <Button variant="link" onClick={() => setShowModal(false)}>
+              キャンセル
+            </Button>
+          </Box>
+        }
+      >
+        <SpaceBetween size="l">
+          <Box variant="p" color="text-body-secondary">
+            参加方法を選択してください
+          </Box>
 
-            <Tabs
-              activeTabId={activeTab}
-              onChange={({ detail }) => {
-                setActiveTab(detail.activeTabId);
-                setModalError(null);
-              }}
-              tabs={[
-                {
-                  id: 'solo',
-                  label: '一人で参加',
-                  content: (
-                    <SpaceBetween size="m">
-                      <Box variant="p">個人として参加します。</Box>
-                      <Button
-                        variant="primary"
-                        fullWidth
-                        onClick={() => void handleSoloRegister()}
-                        loading={registering}
-                      >
-                        一人で参加する
-                      </Button>
-                    </SpaceBetween>
-                  ),
-                },
-                {
-                  id: 'create',
-                  label: 'チームを作成',
-                  content: (
-                    <SpaceBetween size="m">
-                      <FormField label="チーム名">
-                        <Input
-                          value={teamName}
-                          onChange={({ detail }) => setTeamName(detail.value)}
-                          placeholder="チーム名を入力"
-                        />
-                      </FormField>
-                      <Button
-                        variant="primary"
-                        fullWidth
-                        onClick={() => void handleCreateTeam()}
-                        loading={registering}
-                      >
-                        チームを作成して参加
-                      </Button>
-                    </SpaceBetween>
-                  ),
-                },
-                {
-                  id: 'join',
-                  label: '招待コードで参加',
-                  content: (
-                    <SpaceBetween size="m">
-                      <FormField label="招待コード">
-                        <Input
-                          value={inviteCode}
-                          onChange={({ detail }) =>
-                            setInviteCode(detail.value.toUpperCase())
-                          }
-                          placeholder="6文字のコードを入力"
-                        />
-                      </FormField>
-                      <Button
-                        variant="primary"
-                        fullWidth
-                        onClick={() => void handleJoinTeam()}
-                        loading={registering}
-                      >
-                        チームに参加
-                      </Button>
-                    </SpaceBetween>
-                  ),
-                },
-              ]}
-            />
-
-            {modalError && (
-              <StatusIndicator type="error">{modalError}</StatusIndicator>
-            )}
-          </SpaceBetween>
-        </Modal>
-      </div>
-
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="awsui-dark-mode">
-          <SpaceBetween size="l">
-            {/* Breadcrumb */}
-            <CloudscapeLink
-              href="/events"
-              onFollow={(e) => {
-                e.preventDefault();
-                router.push('/events');
-              }}
-            >
-              &larr; イベント一覧
-            </CloudscapeLink>
-
-            {/* Event Header Container */}
-            <Container
-              header={
-                <Header
-                  variant="h1"
-                  description={
-                    <span
-                      style={{
-                        display: 'inline-flex',
-                        gap: '6px',
-                        alignItems: 'center',
-                      }}
+          <Tabs
+            activeTabId={activeTab}
+            onChange={({ detail }) => {
+              setActiveTab(detail.activeTabId);
+              setModalError(null);
+            }}
+            tabs={[
+              {
+                id: 'solo',
+                label: '一人で参加',
+                content: (
+                  <SpaceBetween size="m">
+                    <Box variant="p">個人として参加します。</Box>
+                    <Button
+                      variant="primary"
+                      fullWidth
+                      onClick={() => void handleSoloRegister()}
+                      loading={registering}
                     >
-                      {getEventStatusIndicator(event.status)}
-                      <Badge
-                        color={event.type === 'gameday' ? 'blue' : 'green'}
-                      >
-                        {event.type === 'gameday' ? 'GameDay' : 'JAM'}
-                      </Badge>
-                      {event.isRegistered && (
-                        <Badge color="green">登録済み</Badge>
-                      )}
-                    </span>
-                  }
-                  actions={
-                    <SpaceBetween direction="horizontal" size="xs">
-                      {!event.isRegistered && event.status !== 'completed' && (
-                        <Button
-                          variant="primary"
-                          onClick={handleRegisterClick}
-                          loading={registering}
-                        >
-                          {event.participantType === 'team'
-                            ? 'チームで登録'
-                            : '参加登録'}
-                        </Button>
-                      )}
-                      {canParticipate && (
-                        <NextLink href={`/gameday/${eventId}`}>
-                          <Button variant="primary">バトルに参加</Button>
-                        </NextLink>
-                      )}
-                    </SpaceBetween>
-                  }
-                >
-                  {event.name}
-                </Header>
-              }
-            >
-              <KeyValuePairs
-                columns={4}
-                items={[
-                  {
-                    label: '開始',
-                    value: formatDate(event.startTime),
-                  },
-                  {
-                    label: '終了',
-                    value: formatDate(event.endTime),
-                  },
-                  {
-                    label: '期間',
-                    value: getEventDuration(event.startTime, event.endTime),
-                  },
-                  {
-                    label: '参加者数',
-                    value: `${event.participantCount}人`,
-                  },
-                  {
-                    label: '参加形式',
-                    value: event.participantType === 'team' ? 'チーム' : '個人',
-                  },
-                  {
-                    label: 'クラウド',
-                    value: event.cloudProvider.toUpperCase(),
-                  },
-                  {
-                    label: '採点方式',
-                    value:
-                      event.scoringType === 'realtime'
-                        ? 'リアルタイム'
-                        : 'バッチ',
-                  },
-                  ...(event.myRank
-                    ? [
-                        {
-                          label: 'あなたの順位',
-                          value: (
-                            <Box fontSize="heading-l" fontWeight="bold">
-                              #{event.myRank}
-                              <Box
-                                variant="span"
-                                fontSize="body-s"
-                                color="text-body-secondary"
-                              >
-                                {' '}
-                                ({event.myScore} pts)
-                              </Box>
-                            </Box>
-                          ),
-                        },
-                      ]
-                    : []),
-                ]}
-              />
-            </Container>
-
-            <ColumnLayout
-              columns={
-                event.participantType === 'team' && event.teamInfo ? 2 : 1
-              }
-            >
-              {/* Problems List */}
-              <Cards
-                ariaLabels={{
-                  itemSelectionLabel: (_e, n) => `選択: ${n.title}`,
-                  selectionGroupLabel: '問題選択',
-                }}
-                cardDefinition={{
-                  header: (problem) => (
-                    <SpaceBetween direction="horizontal" size="xs">
-                      <CloudscapeLink
-                        href={
-                          canParticipate && problem.isUnlocked
-                            ? `/events/${eventId}/challenges/${problem.id}`
-                            : undefined
+                      一人で参加する
+                    </Button>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'create',
+                label: 'チームを作成',
+                content: (
+                  <SpaceBetween size="m">
+                    <FormField label="チーム名">
+                      <Input
+                        value={teamName}
+                        onChange={({ detail }) => setTeamName(detail.value)}
+                        placeholder="チーム名を入力"
+                      />
+                    </FormField>
+                    <Button
+                      variant="primary"
+                      fullWidth
+                      onClick={() => void handleCreateTeam()}
+                      loading={registering}
+                    >
+                      チームを作成して参加
+                    </Button>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'join',
+                label: '招待コードで参加',
+                content: (
+                  <SpaceBetween size="m">
+                    <FormField label="招待コード">
+                      <Input
+                        value={inviteCode}
+                        onChange={({ detail }) =>
+                          setInviteCode(detail.value.toUpperCase())
                         }
-                        onFollow={(e) => {
-                          if (canParticipate && problem.isUnlocked) {
-                            e.preventDefault();
-                            router.push(
-                              `/events/${eventId}/challenges/${problem.id}`,
-                            );
-                          }
-                        }}
-                        fontSize="heading-m"
-                      >
-                        {problem.title}
-                      </CloudscapeLink>
+                        placeholder="6文字のコードを入力"
+                      />
+                    </FormField>
+                    <Button
+                      variant="primary"
+                      fullWidth
+                      onClick={() => void handleJoinTeam()}
+                      loading={registering}
+                    >
+                      チームに参加
+                    </Button>
+                  </SpaceBetween>
+                ),
+              },
+            ]}
+          />
+
+          {modalError && (
+            <StatusIndicator type="error">{modalError}</StatusIndicator>
+          )}
+        </SpaceBetween>
+      </Modal>
+
+      <SpaceBetween size="l">
+        {/* Event Metadata */}
+        <Container>
+          <KeyValuePairs
+            columns={4}
+            items={[
+              {
+                label: '開始',
+                value: formatDate(event.startTime),
+              },
+              {
+                label: '終了',
+                value: formatDate(event.endTime),
+              },
+              {
+                label: '期間',
+                value: getEventDuration(event.startTime, event.endTime),
+              },
+              {
+                label: '参加者数',
+                value: `${event.participantCount}人`,
+              },
+              {
+                label: '参加形式',
+                value: event.participantType === 'team' ? 'チーム' : '個人',
+              },
+              {
+                label: 'クラウド',
+                value: event.cloudProvider.toUpperCase(),
+              },
+              {
+                label: '採点方式',
+                value:
+                  event.scoringType === 'realtime' ? 'リアルタイム' : 'バッチ',
+              },
+              ...(event.myRank
+                ? [
+                    {
+                      label: 'あなたの順位',
+                      value: (
+                        <Box fontSize="heading-l" fontWeight="bold">
+                          #{event.myRank}
+                          <Box
+                            variant="span"
+                            fontSize="body-s"
+                            color="text-body-secondary"
+                          >
+                            {' '}
+                            ({event.myScore} pts)
+                          </Box>
+                        </Box>
+                      ),
+                    },
+                  ]
+                : []),
+            ]}
+          />
+        </Container>
+
+        <ColumnLayout
+          columns={event.participantType === 'team' && event.teamInfo ? 2 : 1}
+        >
+          {/* Problems List */}
+          <Cards
+            ariaLabels={{
+              itemSelectionLabel: (_e, n) => `選択: ${n.title}`,
+              selectionGroupLabel: '問題選択',
+            }}
+            cardDefinition={{
+              header: (problem) => (
+                <SpaceBetween direction="horizontal" size="xs">
+                  <CloudscapeLink
+                    href={
+                      canParticipate && problem.isUnlocked
+                        ? `/events/${eventId}/challenges/${problem.id}`
+                        : undefined
+                    }
+                    onFollow={(e) => {
+                      if (canParticipate && problem.isUnlocked) {
+                        e.preventDefault();
+                        router.push(
+                          `/events/${eventId}/challenges/${problem.id}`,
+                        );
+                      }
+                    }}
+                    fontSize="heading-m"
+                  >
+                    {problem.title}
+                  </CloudscapeLink>
+                </SpaceBetween>
+              ),
+              sections: [
+                {
+                  id: 'meta',
+                  content: (problem) => (
+                    <SpaceBetween direction="horizontal" size="xs">
+                      {getDifficultyBadge(problem.difficulty)}
+                      {getProblemStatusIndicator(problem)}
+                      <Box variant="small">
+                        {problem.maxScore * problem.pointMultiplier} pts
+                      </Box>
                     </SpaceBetween>
                   ),
-                  sections: [
+                },
+                {
+                  id: 'overview',
+                  header: '概要',
+                  content: (problem) => (
+                    <Box variant="p" color="text-body-secondary">
+                      {problem.overview}
+                    </Box>
+                  ),
+                },
+              ],
+            }}
+            cardsPerRow={[{ cards: 1 }, { minWidth: 500, cards: 2 }]}
+            items={event.problems}
+            loadingText="問題を読み込み中"
+            header={
+              <Header counter={`(${event.problemCount})`}>問題一覧</Header>
+            }
+            empty={
+              <Box textAlign="center" padding="l">
+                {isActive
+                  ? 'まだ問題が登録されていません'
+                  : '問題はイベント開始時に公開されます'}
+              </Box>
+            }
+          />
+
+          {/* Team Info (if team event) */}
+          {event.participantType === 'team' && event.teamInfo && (
+            <Container header={<Header variant="h2">チーム情報</Header>}>
+              <SpaceBetween size="l">
+                <KeyValuePairs
+                  columns={2}
+                  items={[
                     {
-                      id: 'meta',
-                      content: (problem) => (
-                        <SpaceBetween direction="horizontal" size="xs">
-                          {getDifficultyBadge(problem.difficulty)}
-                          {getProblemStatusIndicator(problem)}
-                          <Box variant="small">
-                            {problem.maxScore * problem.pointMultiplier} pts
-                          </Box>
-                        </SpaceBetween>
-                      ),
+                      label: 'チーム名',
+                      value: <Box fontWeight="bold">{event.teamInfo.name}</Box>,
                     },
                     {
-                      id: 'overview',
-                      header: '概要',
-                      content: (problem) => (
-                        <Box variant="p" color="text-body-secondary">
-                          {problem.overview}
-                        </Box>
-                      ),
+                      label: 'メンバー数',
+                      value: `${event.teamInfo.members.length}人`,
                     },
-                  ],
-                }}
-                cardsPerRow={[{ cards: 1 }, { minWidth: 500, cards: 2 }]}
-                items={event.problems}
-                loadingText="問題を読み込み中"
-                header={
-                  <Header counter={`(${event.problemCount})`}>問題一覧</Header>
-                }
-                empty={
-                  <Box textAlign="center" padding="l">
-                    {isActive
-                      ? 'まだ問題が登録されていません'
-                      : '問題はイベント開始時に公開されます'}
+                  ]}
+                />
+
+                <Box variant="h3">メンバー</Box>
+                <SpaceBetween direction="horizontal" size="xs">
+                  {event.teamInfo.members.map((member) => (
+                    <Badge
+                      key={member.id}
+                      color={member.role === 'captain' ? 'blue' : 'grey'}
+                    >
+                      {member.name}
+                      {member.role === 'captain' && ' (キャプテン)'}
+                    </Badge>
+                  ))}
+                </SpaceBetween>
+
+                {event.teamInfo.inviteCode && (
+                  <Container header={<Header variant="h3">招待コード</Header>}>
+                    <Box fontSize="heading-l" fontWeight="bold" variant="code">
+                      {event.teamInfo.inviteCode}
+                    </Box>
+                  </Container>
+                )}
+              </SpaceBetween>
+            </Container>
+          )}
+        </ColumnLayout>
+
+        {/* Leaderboard Preview */}
+        {leaderboard && event.leaderboardVisible && (
+          <Table
+            columnDefinitions={[
+              {
+                id: 'rank',
+                header: '順位',
+                cell: (entry) => (
+                  <Box fontWeight={entry.rank <= 3 ? 'bold' : 'normal'}>
+                    #{entry.rank}
                   </Box>
-                }
-              />
-
-              {/* Team Info (if team event) */}
-              {event.participantType === 'team' && event.teamInfo && (
-                <Container header={<Header variant="h2">チーム情報</Header>}>
-                  <SpaceBetween size="l">
-                    <KeyValuePairs
-                      columns={2}
-                      items={[
-                        {
-                          label: 'チーム名',
-                          value: (
-                            <Box fontWeight="bold">{event.teamInfo.name}</Box>
-                          ),
-                        },
-                        {
-                          label: 'メンバー数',
-                          value: `${event.teamInfo.members.length}人`,
-                        },
-                      ]}
-                    />
-
-                    <Box variant="h3">メンバー</Box>
-                    <SpaceBetween direction="horizontal" size="xs">
-                      {event.teamInfo.members.map((member) => (
-                        <Badge
-                          key={member.id}
-                          color={member.role === 'captain' ? 'blue' : 'grey'}
-                        >
-                          {member.name}
-                          {member.role === 'captain' && ' (キャプテン)'}
-                        </Badge>
-                      ))}
-                    </SpaceBetween>
-
-                    {event.teamInfo.inviteCode && (
-                      <Container
-                        header={<Header variant="h3">招待コード</Header>}
-                      >
-                        <Box
-                          fontSize="heading-l"
-                          fontWeight="bold"
-                          variant="code"
-                        >
-                          {event.teamInfo.inviteCode}
-                        </Box>
-                      </Container>
-                    )}
+                ),
+                width: 80,
+              },
+              {
+                id: 'name',
+                header: '名前',
+                cell: (entry) => (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <span>{entry.name}</span>
+                    {entry.isMe && <Badge color="blue">自分</Badge>}
                   </SpaceBetween>
-                </Container>
-              )}
-            </ColumnLayout>
-
-            {/* Leaderboard Preview */}
-            {leaderboard && event.leaderboardVisible && (
-              <Table
-                columnDefinitions={[
-                  {
-                    id: 'rank',
-                    header: '順位',
-                    cell: (entry) => (
-                      <Box fontWeight={entry.rank <= 3 ? 'bold' : 'normal'}>
-                        #{entry.rank}
-                      </Box>
-                    ),
-                    width: 80,
-                  },
-                  {
-                    id: 'name',
-                    header: '名前',
-                    cell: (entry) => (
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <span>{entry.name}</span>
-                        {entry.isMe && <Badge color="blue">自分</Badge>}
-                      </SpaceBetween>
-                    ),
-                  },
-                  {
-                    id: 'score',
-                    header: 'スコア',
-                    cell: (entry) => (
-                      <Box fontWeight="bold">{entry.totalScore}</Box>
-                    ),
-                    width: 120,
-                  },
-                ]}
-                items={leaderboard.entries.slice(0, 5)}
-                loadingText="読み込み中"
-                header={
-                  <Header
-                    actions={
-                      <NextLink href={`/events/${eventId}/leaderboard`}>
-                        <Button variant="link">全ランキングを見る</Button>
-                      </NextLink>
-                    }
-                    description={
-                      leaderboard.isFrozen ? (
-                        <StatusIndicator type="warning">凍結中</StatusIndicator>
-                      ) : undefined
-                    }
-                  >
-                    リーダーボード
-                  </Header>
+                ),
+              },
+              {
+                id: 'score',
+                header: 'スコア',
+                cell: (entry) => (
+                  <Box fontWeight="bold">{entry.totalScore}</Box>
+                ),
+                width: 120,
+              },
+            ]}
+            items={leaderboard.entries.slice(0, 5)}
+            loadingText="読み込み中"
+            header={
+              <Header
+                actions={
+                  <NextLink href={`/events/${eventId}/leaderboard`}>
+                    <Button variant="link">全ランキングを見る</Button>
+                  </NextLink>
                 }
-                empty="リーダーボードデータはありません"
-              />
-            )}
+                description={
+                  leaderboard.isFrozen ? (
+                    <StatusIndicator type="warning">凍結中</StatusIndicator>
+                  ) : undefined
+                }
+              >
+                リーダーボード
+              </Header>
+            }
+            empty="リーダーボードデータはありません"
+          />
+        )}
 
-            {/* Waiting message for registered but not active */}
-            {event.isRegistered && !isActive && (
-              <Container>
-                <Box textAlign="center" padding="l">
-                  <StatusIndicator type="pending">
-                    イベント開始をお待ちください
-                  </StatusIndicator>
-                </Box>
-              </Container>
-            )}
-          </SpaceBetween>
-        </div>
-      </main>
-    </div>
+        {/* Waiting message for registered but not active */}
+        {event.isRegistered && !isActive && (
+          <Container>
+            <Box textAlign="center" padding="l">
+              <StatusIndicator type="pending">
+                イベント開始をお待ちください
+              </StatusIndicator>
+            </Box>
+          </Container>
+        )}
+      </SpaceBetween>
+    </PageLayout>
   );
 }

--- a/apps/application-plane/app/events/page.tsx
+++ b/apps/application-plane/app/events/page.tsx
@@ -375,8 +375,8 @@ export default function EventsPage() {
   );
 
   return (
-    <PageLayout>
-      <SpaceBetween size="l">
+    <PageLayout
+      header={
         <Header
           counter={!loading && !error ? `(${events.length})` : undefined}
           description={t('events.description')}
@@ -384,7 +384,9 @@ export default function EventsPage() {
         >
           {t('events.title')}
         </Header>
-
+      }
+    >
+      <SpaceBetween size="l">
         {filterBar}
 
         {loading ? (

--- a/apps/application-plane/app/page.tsx
+++ b/apps/application-plane/app/page.tsx
@@ -1,17 +1,16 @@
 'use client';
 
-import {
-  Award,
-  Cloud,
-  Code2,
-  Rocket,
-  Shield,
-  Target,
-  Trophy,
-  Users,
-  Zap,
-} from 'lucide-react';
-import Link from 'next/link';
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import '@cloudscape-design/global-styles/index.css';
+import { Header as AppHeader } from '@/components/layout';
 
 const stats = [
   { value: '3+', label: 'Cloud Providers' },
@@ -22,229 +21,223 @@ const stats = [
 
 const features = [
   {
-    icon: Cloud,
     title: 'マルチクラウド対応',
     description: 'AWS / GCP / Azure の実環境で腕試し',
+    status: 'info' as const,
   },
   {
-    icon: Code2,
     title: '実践的な課題',
     description: 'インフラ構築・セキュリティ・コスト最適化',
+    status: 'success' as const,
   },
   {
-    icon: Users,
     title: 'チーム or 個人',
     description: '仲間と協力、またはソロで挑戦',
+    status: 'pending' as const,
   },
   {
-    icon: Trophy,
     title: 'リアルタイム採点',
     description: '自動採点で即座にフィードバック',
+    status: 'success' as const,
   },
 ];
 
 const eventTypes = [
   {
-    icon: Zap,
     name: 'GameDay',
     description:
       '障害対応シミュレーション。本番さながらのインシデント対応を体験',
     tags: ['Incident Response', 'Troubleshooting'],
+    color: 'blue' as const,
   },
   {
-    icon: Shield,
     name: 'Jam',
     description:
       'セキュリティ・最適化課題。制限時間内に課題を解いてスコアを競う',
     tags: ['Security', 'Optimization'],
+    color: 'green' as const,
   },
 ];
 
 export default function Home(): React.JSX.Element {
   return (
-    <div className="min-h-screen">
-      {/* Hero Section */}
-      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-28">
-        <div className="space-y-6">
-          <p className="text-hn-accent font-medium tracking-wide uppercase text-sm">
-            Cloud Competition Platform
-          </p>
-          <h1 className="font-display text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-text-primary">
-            クラウドスキルを競い
-            <br />
-            <span className="text-hn-accent">高め合う場所</span>
-          </h1>
-          <p className="text-xl md:text-2xl text-text-muted max-w-3xl">
-            AWS・GCP・Azure
-            の実環境で、インフラ構築・障害対応・セキュリティの腕を競う。
-            最強のクラウドエンジニアを目指せ。
-          </p>
-          <div className="flex flex-wrap gap-4 pt-4">
-            <Link
-              href="/events"
-              className="inline-flex items-center px-6 py-3 bg-hn-accent hover:bg-hn-accent-muted text-surface-0 font-medium rounded-lg transition-colors"
-            >
-              イベントを探す
-              <Rocket className="w-4 h-4 ml-2" />
-            </Link>
-            <Link
-              href="/rankings"
-              className="inline-flex items-center px-6 py-3 border border-border hover:border-hn-accent font-medium rounded-lg transition-colors"
-            >
-              <Award className="w-4 h-4 mr-2" />
-              ランキングを見る
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Stats Section */}
-      <section className="bg-surface-1 border-y border-border">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-            {stats.map((stat) => (
-              <div key={stat.label} className="text-center">
-                <div className="font-mono text-3xl md:text-4xl font-bold text-hn-accent">
-                  {stat.value}
-                </div>
-                <div className="text-sm text-text-muted mt-1">{stat.label}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* What is TenkaCloud Section */}
-      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h2 className="font-display text-2xl md:text-3xl font-bold text-text-primary">
-              TenkaCloud とは
-            </h2>
-            <p className="text-text-muted mt-2">
-              クラウドエンジニアのための競技プラットフォーム
-            </p>
-          </div>
-        </div>
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="p-6 rounded-lg border border-border hover:border-hn-accent transition-colors"
-            >
-              <div className="w-12 h-12 rounded-lg bg-hn-accent/10 flex items-center justify-center mb-4">
-                <feature.icon className="w-6 h-6 text-hn-accent" />
-              </div>
-              <h3 className="font-display font-semibold text-lg mb-2 text-text-primary">
-                {feature.title}
-              </h3>
-              <p className="text-sm text-text-muted">{feature.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Event Types Section */}
-      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 border-t border-border">
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h2 className="font-display text-2xl md:text-3xl font-bold text-text-primary">
-              イベントタイプ
-            </h2>
-            <p className="text-text-muted mt-2">
-              目的に合わせて、2種類のイベント形式から選択
-            </p>
-          </div>
-          <Link
-            href="/events"
-            className="text-sm font-medium text-hn-accent hover:text-hn-accent-muted transition-colors hidden md:block"
-          >
-            すべてのイベント →
-          </Link>
-        </div>
-        <div className="grid gap-6 md:grid-cols-2">
-          {eventTypes.map((type) => (
-            <Link
-              key={type.name}
-              href="/events"
-              className="group block p-6 rounded-lg border-2 border-border hover:border-hn-accent transition-all hover:shadow-lg"
-            >
-              <div className="flex flex-wrap gap-2 mb-3">
-                {type.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="px-2 py-0.5 text-xs font-medium bg-hn-accent/10 text-hn-accent rounded-full"
+    <div className="min-h-screen bg-surface-0">
+      <AppHeader />
+      <div className="awsui-dark-mode">
+        <ContentLayout
+          header={
+            <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              <SpaceBetween size="l">
+                <Box variant="small" color="text-status-info">
+                  Cloud Competition Platform
+                </Box>
+                <SpaceBetween size="xs">
+                  <Box variant="h1" fontSize="display-l" fontWeight="bold">
+                    クラウドスキルを競い
+                  </Box>
+                  <Box
+                    variant="h1"
+                    fontSize="display-l"
+                    fontWeight="bold"
+                    color="text-status-info"
                   >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              <div className="flex items-center gap-3 mb-3">
-                <div className="w-10 h-10 rounded-lg bg-hn-accent/10 flex items-center justify-center group-hover:bg-hn-accent/20 transition-colors">
-                  <type.icon className="w-5 h-5 text-hn-accent" />
-                </div>
-                <h3 className="font-display text-xl font-bold text-text-primary group-hover:text-hn-accent transition-colors">
-                  {type.name}
-                </h3>
-              </div>
-              <p className="text-text-muted text-sm">{type.description}</p>
-              <div className="flex items-center gap-2 mt-4 text-hn-accent text-sm font-medium">
-                <span>イベントを見る</span>
-                <svg
-                  className="w-4 h-4 group-hover:translate-x-1 transition-transform"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                    高め合う場所
+                  </Box>
+                </SpaceBetween>
+                <Box
+                  variant="p"
+                  color="text-body-secondary"
+                  fontSize="heading-s"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 8l4 4m0 0l-4 4m4-4H3"
-                  />
-                </svg>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </section>
+                  AWS・GCP・Azure
+                  の実環境で、インフラ構築・障害対応・セキュリティの腕を競う。
+                  最強のクラウドエンジニアを目指せ。
+                </Box>
+                <SpaceBetween direction="horizontal" size="s">
+                  <Button
+                    variant="primary"
+                    iconName="angle-right-double"
+                    iconAlign="right"
+                    href="/events"
+                  >
+                    イベントを探す
+                  </Button>
+                  <Button href="/rankings">ランキングを見る</Button>
+                </SpaceBetween>
+              </SpaceBetween>
+            </div>
+          }
+        >
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+            <SpaceBetween size="xxl">
+              {/* Stats */}
+              <Container
+                header={<Header variant="h2">プラットフォーム実績</Header>}
+              >
+                <ColumnLayout columns={4} variant="text-grid">
+                  {stats.map((stat) => (
+                    <div key={stat.label}>
+                      <Box
+                        fontSize="display-l"
+                        fontWeight="bold"
+                        textAlign="center"
+                        color="text-status-info"
+                      >
+                        {stat.value}
+                      </Box>
+                      <Box
+                        color="text-body-secondary"
+                        textAlign="center"
+                        variant="small"
+                      >
+                        {stat.label}
+                      </Box>
+                    </div>
+                  ))}
+                </ColumnLayout>
+              </Container>
 
-      {/* CTA Section */}
-      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="p-8 md:p-12 rounded-2xl bg-surface-1 border border-border text-center">
-          <div className="w-12 h-12 mx-auto mb-6 rounded-full bg-hn-accent/10 flex items-center justify-center">
-            <Target className="w-6 h-6 text-hn-accent" />
-          </div>
-          <h2 className="font-display text-2xl md:text-3xl font-bold text-text-primary mb-4">
-            まずは観戦してみよう
-          </h2>
-          <p className="text-text-muted mb-6 max-w-xl mx-auto">
-            アカウント不要で、開催中のイベントやランキングを閲覧できます。
-            どんな課題があるのか、どんな人が参加しているのか、まずはチェック。
-          </p>
-          <div className="flex flex-wrap justify-center gap-4">
-            <Link
-              href="/events"
-              className="inline-flex items-center px-6 py-3 bg-hn-accent hover:bg-hn-accent-muted text-surface-0 font-medium rounded-lg transition-colors"
-            >
-              イベント一覧を見る
-            </Link>
-            <Link
-              href="/rankings"
-              className="inline-flex items-center px-6 py-3 border border-border hover:border-hn-accent font-medium rounded-lg transition-colors"
-            >
-              ランキングを見る
-            </Link>
-          </div>
-        </div>
-      </section>
+              {/* Features */}
+              <Container
+                header={
+                  <Header
+                    variant="h2"
+                    description="クラウドエンジニアのための競技プラットフォーム"
+                  >
+                    TenkaCloud とは
+                  </Header>
+                }
+              >
+                <ColumnLayout columns={4} variant="text-grid">
+                  {features.map((feature) => (
+                    <SpaceBetween key={feature.title} size="xs">
+                      <StatusIndicator type={feature.status}>
+                        {feature.title}
+                      </StatusIndicator>
+                      <Box color="text-body-secondary" variant="small">
+                        {feature.description}
+                      </Box>
+                    </SpaceBetween>
+                  ))}
+                </ColumnLayout>
+              </Container>
 
-      {/* Footer */}
-      <footer className="py-8 px-4 border-t border-border">
-        <div className="max-w-5xl mx-auto text-center text-text-muted text-sm">
-          <p>TenkaCloud - The Open Cloud Battle Arena</p>
-        </div>
-      </footer>
+              {/* Event Types */}
+              <Container
+                header={
+                  <Header
+                    variant="h2"
+                    description="目的に合わせて、2種類のイベント形式から選択"
+                    actions={
+                      <Button variant="link" href="/events">
+                        すべてのイベント →
+                      </Button>
+                    }
+                  >
+                    イベントタイプ
+                  </Header>
+                }
+              >
+                <ColumnLayout columns={2}>
+                  {eventTypes.map((type) => (
+                    <Container key={type.name}>
+                      <SpaceBetween size="s">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          {type.tags.map((tag) => (
+                            <Badge key={tag} color={type.color}>
+                              {tag}
+                            </Badge>
+                          ))}
+                        </SpaceBetween>
+                        <Box
+                          variant="h3"
+                          fontSize="heading-l"
+                          fontWeight="bold"
+                        >
+                          {type.name}
+                        </Box>
+                        <Box color="text-body-secondary" variant="small">
+                          {type.description}
+                        </Box>
+                        <Button variant="link" href="/events">
+                          イベントを見る →
+                        </Button>
+                      </SpaceBetween>
+                    </Container>
+                  ))}
+                </ColumnLayout>
+              </Container>
+
+              {/* CTA */}
+              <Container>
+                <Box textAlign="center" padding="l">
+                  <SpaceBetween size="m">
+                    <Box variant="h2" fontSize="heading-xl" fontWeight="bold">
+                      まずは観戦してみよう
+                    </Box>
+                    <Box color="text-body-secondary" variant="p">
+                      アカウント不要で、開催中のイベントやランキングを閲覧できます。
+                      どんな課題があるのか、どんな人が参加しているのか、まずはチェック。
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="s">
+                      <Button variant="primary" href="/events">
+                        イベント一覧を見る
+                      </Button>
+                      <Button href="/rankings">ランキングを見る</Button>
+                    </SpaceBetween>
+                  </SpaceBetween>
+                </Box>
+              </Container>
+            </SpaceBetween>
+          </div>
+        </ContentLayout>
+
+        <footer className="py-8 border-t border-border">
+          <Box textAlign="center" color="text-body-secondary" variant="small">
+            TenkaCloud - The Open Cloud Battle Arena
+          </Box>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/apps/application-plane/components/layout/__tests__/page-layout.test.tsx
+++ b/apps/application-plane/components/layout/__tests__/page-layout.test.tsx
@@ -1,3 +1,4 @@
+import Header from '@cloudscape-design/components/header';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PageLayout } from '../page-layout';
@@ -18,7 +19,7 @@ vi.mock('@/lib/tenant', () => ({
 }));
 
 describe('PageLayout', () => {
-  it('ヘッダーが表示されるべき', () => {
+  it('アプリヘッダー（TenkaCloud）が表示されるべき', () => {
     render(<PageLayout>content</PageLayout>);
     expect(screen.getByText('TenkaCloud')).toBeInTheDocument();
   });
@@ -28,20 +29,52 @@ describe('PageLayout', () => {
     expect(screen.getByText('test content')).toBeInTheDocument();
   });
 
-  it('デフォルトで max-w-7xl が適用されるべき', () => {
-    render(<PageLayout>content</PageLayout>);
-    const main = document.querySelector('main');
-    expect(main?.className).toContain('max-w-7xl');
-  });
-
-  it('maxWidth prop で幅を変更できるべき', () => {
-    render(<PageLayout maxWidth="3xl">content</PageLayout>);
-    const main = document.querySelector('main');
-    expect(main?.className).toContain('max-w-3xl');
-  });
-
   it('awsui-dark-mode ラッパーを含むべき', () => {
     render(<PageLayout>content</PageLayout>);
     expect(document.querySelector('.awsui-dark-mode')).toBeInTheDocument();
+  });
+
+  it('header を渡すと ContentLayout でラップされるべき', () => {
+    render(
+      <PageLayout header={<Header variant="h1">ページタイトル</Header>}>
+        content
+      </PageLayout>,
+    );
+    expect(screen.getByText('ページタイトル')).toBeInTheDocument();
+  });
+
+  it('breadcrumbs を渡すとパンくずリストが表示されるべき', () => {
+    render(
+      <PageLayout
+        breadcrumbs={[
+          { text: 'トップ', href: '/' },
+          { text: 'イベント一覧', href: '/events' },
+          { text: 'イベント詳細' },
+        ]}
+      >
+        content
+      </PageLayout>,
+    );
+    expect(screen.getAllByText('トップ').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('イベント一覧').length).toBeGreaterThanOrEqual(
+      1,
+    );
+    expect(screen.getAllByText('イベント詳細').length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it('breadcrumbs なしの場合はパンくずリストが表示されないべき', () => {
+    render(<PageLayout>content</PageLayout>);
+    expect(
+      screen.queryByRole('navigation', { name: 'パンくずリスト' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('maxWidth prop でコンテンツ幅を変更できるべき', () => {
+    const { container } = render(
+      <PageLayout maxWidth="3xl">content</PageLayout>,
+    );
+    expect(container.querySelector('.max-w-3xl')).toBeInTheDocument();
   });
 });

--- a/apps/application-plane/components/layout/index.ts
+++ b/apps/application-plane/components/layout/index.ts
@@ -4,3 +4,4 @@
 
 export { Header } from './header';
 export { PageLayout } from './page-layout';
+export type { BreadcrumbItem } from './page-layout';

--- a/apps/application-plane/components/layout/page-layout.tsx
+++ b/apps/application-plane/components/layout/page-layout.tsx
@@ -1,34 +1,42 @@
 /**
  * PageLayout
  *
- * 全参加者ページ共通テンプレート:
- *   AppHeader → <main> (max-w-7xl, パディング統一) → awsui-dark-mode ラッパー
+ * 全参加者ページ共通テンプレート — Cloudscape product-detail パターン
  *
- * 使用例:
+ * header を渡すと ContentLayout でラップされ、AWS コンソール風の
+ * ヘッダー背景（product-detail-page パターン）が有効になります。
+ *
+ * 使用例（シンプル）:
  *   <PageLayout>
- *     <Header variant="h1">ページタイトル</Header>
- *     ...Cloudscape コンテンツ...
+ *     <Header variant="h1">タイトル</Header>
+ *     ...コンテンツ...
  *   </PageLayout>
  *
- *   <PageLayout maxWidth="3xl">  // 幅を変える場合
- *     ...
+ * 使用例（product-detail パターン）:
+ *   <PageLayout
+ *     header={<Header variant="h1" actions={<Button>操作</Button>}>タイトル</Header>}
+ *     breadcrumbs={[{ text: 'ホーム', href: '/' }, { text: 'イベント', href: '/events' }, { text: 'イベント名' }]}
+ *   >
+ *     ...コンテンツ...
  *   </PageLayout>
  */
 
 'use client';
 
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import ContentLayout from '@cloudscape-design/components/content-layout';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import '@cloudscape-design/global-styles/index.css';
+import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Header } from './header';
 
-type MaxWidth = '3xl' | '4xl' | '5xl' | '6xl' | '7xl';
-
-interface PageLayoutProps {
-  children: ReactNode;
-  /** コンテンツ最大幅（デフォルト: 7xl） */
-  maxWidth?: MaxWidth;
+export interface BreadcrumbItem {
+  text: string;
+  href?: string;
 }
+
+type MaxWidth = '3xl' | '4xl' | '5xl' | '6xl' | '7xl';
 
 const maxWidthClass: Record<MaxWidth, string> = {
   '3xl': 'max-w-3xl',
@@ -38,17 +46,61 @@ const maxWidthClass: Record<MaxWidth, string> = {
   '7xl': 'max-w-7xl',
 };
 
-export function PageLayout({ children, maxWidth = '7xl' }: PageLayoutProps) {
+interface PageLayoutProps {
+  children: ReactNode;
+  /**
+   * ContentLayout のヘッダーセクション（product-detail パターン）。
+   * 渡すと AWS コンソール風のヘッダー背景が表示される。
+   */
+  header?: ReactNode;
+  /** パンくずリスト（header と合わせて使用） */
+  breadcrumbs?: BreadcrumbItem[];
+  /** コンテンツ最大幅（デフォルト: 7xl）。header なしの場合のみ有効 */
+  maxWidth?: MaxWidth;
+}
+
+export function PageLayout({
+  children,
+  header,
+  breadcrumbs,
+  maxWidth = '7xl',
+}: PageLayoutProps) {
+  const router = useRouter();
+  const widthClass = maxWidthClass[maxWidth];
+
   return (
     <div className="min-h-screen bg-surface-0">
       <Header />
-      <main
-        className={`${maxWidthClass[maxWidth]} mx-auto px-4 sm:px-6 lg:px-8 py-8`}
-      >
-        <div className="awsui-dark-mode">
-          <SpaceBetween size="l">{children}</SpaceBetween>
-        </div>
-      </main>
+      <div className="awsui-dark-mode">
+        {breadcrumbs && breadcrumbs.length > 0 && (
+          <div className={`${widthClass} mx-auto px-4 sm:px-6 lg:px-8 pt-4`}>
+            <BreadcrumbGroup
+              items={breadcrumbs.map((item) => ({
+                text: item.text,
+                href: item.href ?? '#',
+              }))}
+              onFollow={(e) => {
+                e.preventDefault();
+                if (e.detail.href && e.detail.href !== '#') {
+                  router.push(e.detail.href);
+                }
+              }}
+              ariaLabel="パンくずリスト"
+            />
+          </div>
+        )}
+        {header ? (
+          <ContentLayout header={header}>
+            <div className={`${widthClass} mx-auto px-4 sm:px-6 lg:px-8 pb-8`}>
+              <SpaceBetween size="l">{children}</SpaceBetween>
+            </div>
+          </ContentLayout>
+        ) : (
+          <div className={`${widthClass} mx-auto px-4 sm:px-6 lg:px-8 py-8`}>
+            <SpaceBetween size="l">{children}</SpaceBetween>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `PageLayout` コンポーネントに `ContentLayout` + `BreadcrumbGroup` 対応を追加（`header`/`breadcrumbs` props）
- ランディングページ（`app/page.tsx`）を Cloudscape `ContentLayout` でラップし、ヒーローヘッダーを product-detail パターンに統一
- イベント一覧ページ（`events/page.tsx`）のページタイトルを `ContentLayout` ヘッダーに移動
- イベント詳細ページ（`events/[eventId]/page.tsx`）に `BreadcrumbGroup` を追加し `PageLayout` で統一
- ダッシュボードページ（`dashboard/page.tsx`）の `Header` を `PageLayout.header` prop に移動

## Test plan

- [ ] ランディングページが `ContentLayout` のグラデーションヘッダーで表示される
- [ ] イベント一覧・詳細ページでパンくずリストが表示される
- [ ] 既存テスト 830 件すべてパス
- [ ] カバレッジ 99%+ 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)