### PR TITLE
feat: JAM問題エディタ・攻撃カタログ管理UI・統一スコアリングスキーマ

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/attacks/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/attacks/page.tsx
@@ -1,0 +1,228 @@
+/**
+ * Admin Attack Catalog Page
+ *
+ * Cloudscape Design System - GameDay イベントの攻撃カタログ管理
+ */
+
+'use client';
+
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+import { getAttackCatalog } from '@/lib/api/gameday';
+import { seedAttacks } from '@/lib/api/gameday-admin';
+import type { Attack } from '@/lib/api/gameday-types';
+
+export default function AdminAttackCatalogPage() {
+  const router = useRouter();
+  const params = useParams();
+  const eventId = params.eventId as string;
+
+  const [attacks, setAttacks] = useState<Attack[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [seeding, setSeeding] = useState(false);
+
+  const fetchAttacks = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getAttackCatalog(eventId);
+      setAttacks(data.attacks);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : '\u653b\u6483\u30ab\u30bf\u30ed\u30b0\u306e\u53d6\u5f97\u306b\u5931\u6557\u3057\u307e\u3057\u305f',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchAttacks();
+  }, [fetchAttacks]);
+
+  const handleSeed = async () => {
+    setSeeding(true);
+    try {
+      await seedAttacks(eventId);
+      await fetchAttacks();
+    } catch {
+      // Error handled by re-fetch
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={`\u30a4\u30d9\u30f3\u30c8 ID: ${eventId}`}
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button variant="primary" loading={seeding} onClick={handleSeed}>
+              {attacks.length > 0
+                ? '\u30ab\u30bf\u30ed\u30b0\u3092\u518d\u751f\u6210'
+                : '\u30c7\u30d5\u30a9\u30eb\u30c8\u653b\u6483\u3092\u30b7\u30fc\u30c9'}
+            </Button>
+            <Button onClick={() => router.push(`/admin/events/${eventId}`)}>
+              {'\u30a4\u30d9\u30f3\u30c8\u306b\u623b\u308b'}
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        {'\u653b\u6483\u30ab\u30bf\u30ed\u30b0\u7ba1\u7406'}
+      </Header>
+
+      {/* Stats */}
+      <Container>
+        <SpaceBetween direction="horizontal" size="xl">
+          <div>
+            <Box variant="awsui-key-label">{'\u7dcf\u653b\u6483\u6570'}</Box>
+            <Box variant="awsui-value-large">{attacks.length}</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">
+              {'\u5e73\u5747\u30b3\u30b9\u30c8'}
+            </Box>
+            <Box variant="awsui-value-large">
+              {attacks.length > 0
+                ? Math.round(
+                    attacks.reduce((sum, a) => sum + a.purchaseCost, 0) /
+                      attacks.length,
+                  ).toLocaleString()
+                : 0}
+            </Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">
+              {'\u5e73\u5747\u30c0\u30e1\u30fc\u30b8'}
+            </Box>
+            <Box variant="awsui-value-large">
+              {attacks.length > 0
+                ? Math.round(
+                    attacks.reduce((sum, a) => sum + a.damage, 0) /
+                      attacks.length,
+                  ).toLocaleString()
+                : 0}
+            </Box>
+          </div>
+        </SpaceBetween>
+      </Container>
+
+      {error && (
+        <Container>
+          <SpaceBetween size="m" direction="vertical" alignItems="center">
+            <StatusIndicator type="error">{error}</StatusIndicator>
+            <Button onClick={fetchAttacks}>
+              {'\u518d\u8aad\u307f\u8fbc\u307f'}
+            </Button>
+          </SpaceBetween>
+        </Container>
+      )}
+
+      {!error && (
+        <Table
+          items={attacks}
+          header={
+            <Header counter={`(${attacks.length})`}>
+              {'\u653b\u6483\u4e00\u89a7'}
+            </Header>
+          }
+          empty={
+            <Box textAlign="center" padding="l">
+              <SpaceBetween size="m">
+                <Box variant="h3">
+                  {
+                    '\u653b\u6483\u30ab\u30bf\u30ed\u30b0\u304c\u7a7a\u3067\u3059'
+                  }
+                </Box>
+                <Box color="text-body-secondary">
+                  {
+                    '\u30c7\u30d5\u30a9\u30eb\u30c8\u653b\u6483\u3092\u30b7\u30fc\u30c9\u3057\u3066\u30ab\u30bf\u30ed\u30b0\u3092\u521d\u671f\u5316\u3057\u307e\u3057\u3087\u3046\u3002'
+                  }
+                </Box>
+                <Button
+                  variant="primary"
+                  loading={seeding}
+                  onClick={handleSeed}
+                >
+                  {
+                    '\u30c7\u30d5\u30a9\u30eb\u30c8\u653b\u6483\u3092\u30b7\u30fc\u30c9'
+                  }
+                </Button>
+              </SpaceBetween>
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: 'name',
+              header: '\u653b\u6483\u540d',
+              cell: (item) => <Box fontWeight="bold">{item.name}</Box>,
+              sortingField: 'name',
+            },
+            {
+              id: 'type',
+              header: '\u30bf\u30a4\u30d7',
+              cell: (item) =>
+                item.attackType === 'vulnerability' ? (
+                  <Badge color="red">{'\u8106\u5f31\u6027'}</Badge>
+                ) : (
+                  <Badge color="blue">{'\u30ab\u30aa\u30b9'}</Badge>
+                ),
+            },
+            {
+              id: 'cost',
+              header: '\u30b3\u30b9\u30c8',
+              cell: (item) => `${item.purchaseCost.toLocaleString()} pts`,
+              sortingField: 'purchaseCost',
+            },
+            {
+              id: 'damage',
+              header: '\u30c0\u30e1\u30fc\u30b8',
+              cell: (item) => `${item.damage.toLocaleString()} pts`,
+              sortingField: 'damage',
+            },
+            {
+              id: 'reward',
+              header: '\u5831\u916c',
+              cell: (item) => `${item.reward.toLocaleString()} pts`,
+              sortingField: 'reward',
+            },
+            {
+              id: 'cooldown',
+              header: '\u30af\u30fc\u30eb\u30c0\u30a6\u30f3',
+              cell: (item) => `${item.cooldownSeconds}s`,
+            },
+            {
+              id: 'hintCost',
+              header: '\u30d2\u30f3\u30c8\u30b3\u30b9\u30c8',
+              cell: (item) => `${item.hintCost.toLocaleString()} pts`,
+            },
+          ]}
+        />
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
@@ -1,0 +1,308 @@
+/**
+ * Admin Event Problems Page
+ *
+ * Cloudscape Design System - イベントに紐づく問題の管理
+ */
+
+'use client';
+
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Modal from '@cloudscape-design/components/modal';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+import type { AdminProblem } from '@/lib/api/admin-types';
+import {
+  addProblemToEvent,
+  getEventProblems,
+  getProblems,
+  removeProblemFromEvent,
+} from '@/lib/api/admin-problems';
+
+function getDifficultyBadge(difficulty: string) {
+  switch (difficulty) {
+    case 'easy':
+      return <Badge color="green">Easy</Badge>;
+    case 'medium':
+      return <Badge color="blue">Medium</Badge>;
+    case 'hard':
+      return <Badge color="red">Hard</Badge>;
+    default:
+      return <Badge>{difficulty}</Badge>;
+  }
+}
+
+export default function AdminEventProblemsPage() {
+  const router = useRouter();
+  const params = useParams();
+  const eventId = params.eventId as string;
+
+  const [problems, setProblems] = useState<AdminProblem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removingIds, setRemovingIds] = useState<Set<string>>(new Set());
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [allProblems, setAllProblems] = useState<AdminProblem[]>([]);
+  const [addModalLoading, setAddModalLoading] = useState(false);
+  const [addingId, setAddingId] = useState<string | null>(null);
+
+  const fetchProblems = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getEventProblems(eventId);
+      setProblems(data.problems);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : '\u554f\u984c\u306e\u53d6\u5f97\u306b\u5931\u6557\u3057\u307e\u3057\u305f',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchProblems();
+  }, [fetchProblems]);
+
+  const handleRemove = async (problemId: string) => {
+    setRemovingIds((prev) => new Set(prev).add(problemId));
+    try {
+      await removeProblemFromEvent(eventId, problemId);
+      await fetchProblems();
+    } catch {
+      // Error handling
+    } finally {
+      setRemovingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(problemId);
+        return next;
+      });
+    }
+  };
+
+  const handleOpenAddModal = async () => {
+    setShowAddModal(true);
+    setAddModalLoading(true);
+    try {
+      const data = await getProblems({ limit: 100 });
+      const existingIds = new Set(problems.map((p) => p.id));
+      setAllProblems(data.problems.filter((p) => !existingIds.has(p.id)));
+    } catch {
+      setAllProblems([]);
+    } finally {
+      setAddModalLoading(false);
+    }
+  };
+
+  const handleAddProblem = async (problemId: string) => {
+    setAddingId(problemId);
+    try {
+      await addProblemToEvent(eventId, problemId);
+      setShowAddModal(false);
+      await fetchProblems();
+    } catch {
+      // Error handling
+    } finally {
+      setAddingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button variant="primary" onClick={handleOpenAddModal}>
+              {'\u554f\u984c\u3092\u8ffd\u52a0'}
+            </Button>
+            <Button onClick={() => router.push('/admin/problems/new')}>
+              {'\u65b0\u898f\u554f\u984c\u4f5c\u6210'}
+            </Button>
+            <Button onClick={() => router.push(`/admin/events/${eventId}`)}>
+              {'\u30a4\u30d9\u30f3\u30c8\u306b\u623b\u308b'}
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        {'\u554f\u984c\u7ba1\u7406'}
+      </Header>
+
+      {error && (
+        <Container>
+          <SpaceBetween size="m" direction="vertical" alignItems="center">
+            <StatusIndicator type="error">{error}</StatusIndicator>
+            <Button onClick={fetchProblems}>
+              {'\u518d\u8aad\u307f\u8fbc\u307f'}
+            </Button>
+          </SpaceBetween>
+        </Container>
+      )}
+
+      {!error && (
+        <Table
+          loading={loading}
+          loadingText={'\u554f\u984c\u3092\u8aad\u307f\u8fbc\u307f\u4e2d...'}
+          items={problems}
+          header={
+            <Header counter={`(${problems.length})`}>
+              {'\u30a4\u30d9\u30f3\u30c8\u306e\u554f\u984c\u4e00\u89a7'}
+            </Header>
+          }
+          empty={
+            <Box textAlign="center" padding="l">
+              <SpaceBetween size="m">
+                <Box variant="h3">
+                  {
+                    '\u554f\u984c\u304c\u307e\u3060\u3042\u308a\u307e\u305b\u3093'
+                  }
+                </Box>
+                <Box color="text-body-secondary">
+                  {
+                    '\u554f\u984c\u3092\u8ffd\u52a0\u3057\u3066\u30a4\u30d9\u30f3\u30c8\u3092\u69cb\u6210\u3057\u307e\u3057\u3087\u3046\u3002'
+                  }
+                </Box>
+                <Button variant="primary" onClick={handleOpenAddModal}>
+                  {'\u554f\u984c\u3092\u8ffd\u52a0'}
+                </Button>
+              </SpaceBetween>
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: 'title',
+              header: '\u30bf\u30a4\u30c8\u30eb',
+              cell: (item) => <Box fontWeight="bold">{item.title}</Box>,
+            },
+            {
+              id: 'category',
+              header: '\u30ab\u30c6\u30b4\u30ea',
+              cell: (item) => item.category,
+            },
+            {
+              id: 'difficulty',
+              header: '\u96e3\u6613\u5ea6',
+              cell: (item) => getDifficultyBadge(item.difficulty),
+            },
+            {
+              id: 'scoring',
+              header: '\u914d\u70b9',
+              cell: (item) => {
+                const total = item.scoring.criteria.reduce(
+                  (sum, c) => sum + c.maxPoints,
+                  0,
+                );
+                return `${total} pts`;
+              },
+            },
+            {
+              id: 'actions',
+              header: '\u30a2\u30af\u30b7\u30e7\u30f3',
+              cell: (item) => (
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button
+                    variant="link"
+                    onClick={() =>
+                      router.push(`/admin/problems/${item.id}/edit`)
+                    }
+                  >
+                    {'\u7de8\u96c6'}
+                  </Button>
+                  <Button
+                    variant="link"
+                    loading={removingIds.has(item.id)}
+                    onClick={() => handleRemove(item.id)}
+                  >
+                    {'\u524a\u9664'}
+                  </Button>
+                </SpaceBetween>
+              ),
+            },
+          ]}
+        />
+      )}
+
+      {/* Add Problem Modal */}
+      <Modal
+        visible={showAddModal}
+        onDismiss={() => setShowAddModal(false)}
+        header={'\u554f\u984c\u3092\u9078\u629e'}
+        size="large"
+      >
+        {addModalLoading ? (
+          <Box textAlign="center" padding="l">
+            <Spinner size="large" />
+          </Box>
+        ) : allProblems.length === 0 ? (
+          <Box textAlign="center" padding="l">
+            <SpaceBetween size="m">
+              <Box>
+                {
+                  '\u8ffd\u52a0\u53ef\u80fd\u306a\u554f\u984c\u304c\u3042\u308a\u307e\u305b\u3093'
+                }
+              </Box>
+              <Button onClick={() => router.push('/admin/problems/new')}>
+                {'\u65b0\u898f\u554f\u984c\u4f5c\u6210'}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        ) : (
+          <Table
+            items={allProblems}
+            columnDefinitions={[
+              {
+                id: 'title',
+                header: '\u30bf\u30a4\u30c8\u30eb',
+                cell: (item) => item.title,
+              },
+              {
+                id: 'category',
+                header: '\u30ab\u30c6\u30b4\u30ea',
+                cell: (item) => item.category,
+              },
+              {
+                id: 'difficulty',
+                header: '\u96e3\u6613\u5ea6',
+                cell: (item) => getDifficultyBadge(item.difficulty),
+              },
+              {
+                id: 'add',
+                header: '',
+                cell: (item) => (
+                  <Button
+                    variant="primary"
+                    loading={addingId === item.id}
+                    onClick={() => handleAddProblem(item.id)}
+                  >
+                    {'\u8ffd\u52a0'}
+                  </Button>
+                ),
+              },
+            ]}
+          />
+        )}
+      </Modal>
+    </SpaceBetween>
+  );
+}

--- a/apps/application-plane/app/api/admin/events/[eventId]/problems/[problemId]/route.ts
+++ b/apps/application-plane/app/api/admin/events/[eventId]/problems/[problemId]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Admin Event Problem Delete API
+ *
+ * - DELETE: イベントから問題を削除
+ */
+
+import { NextRequest } from 'next/server';
+import {
+  getAdminSession,
+  unauthorizedResponse,
+  forbiddenResponse,
+  badRequestResponse,
+  successResponse,
+  serverApiRequest,
+} from '@/lib/api/server';
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ eventId: string; problemId: string }> },
+) {
+  const session = await getAdminSession();
+  if (!session) {
+    return session === null
+      ? unauthorizedResponse('Authentication required')
+      : forbiddenResponse('Admin role required');
+  }
+
+  const { eventId, problemId } = await params;
+
+  try {
+    await serverApiRequest(`/admin/events/${eventId}/problems/${problemId}`, {
+      method: 'DELETE',
+    });
+    return successResponse({ success: true });
+  } catch (error) {
+    console.error('Failed to remove problem from event:', error);
+    return badRequestResponse(
+      error instanceof Error
+        ? error.message
+        : 'Failed to remove problem from event',
+    );
+  }
+}

--- a/apps/application-plane/app/api/admin/events/[eventId]/problems/route.ts
+++ b/apps/application-plane/app/api/admin/events/[eventId]/problems/route.ts
@@ -1,7 +1,8 @@
 /**
  * Admin Event Problems API
  *
- * イベントへの問題追加エンドポイント
+ * イベントの問題管理エンドポイント
+ * - GET: イベントの問題一覧取得
  * - POST: イベントに問題を追加
  */
 
@@ -14,6 +15,35 @@ import {
   successResponse,
   serverApiRequest,
 } from '@/lib/api/server';
+
+/**
+ * GET /api/admin/events/[eventId]/problems
+ *
+ * イベントの問題一覧を取得（管理者のみ）
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ eventId: string }> },
+) {
+  const session = await getAdminSession();
+  if (!session) {
+    return session === null
+      ? unauthorizedResponse('Authentication required')
+      : forbiddenResponse('Admin role required');
+  }
+
+  const { eventId } = await params;
+
+  try {
+    const data = await serverApiRequest(`/admin/events/${eventId}/problems`);
+    return successResponse(data);
+  } catch (error) {
+    console.error('Failed to fetch event problems:', error);
+    return badRequestResponse(
+      error instanceof Error ? error.message : 'Failed to fetch event problems',
+    );
+  }
+}
 
 /**
  * イベント問題追加リクエスト型

--- a/apps/application-plane/lib/api/admin-problems.ts
+++ b/apps/application-plane/lib/api/admin-problems.ts
@@ -113,3 +113,38 @@ export async function deleteDeployment(
 export async function getAWSRegions(): Promise<{ regions: AWSRegion[] }> {
   return get<{ regions: AWSRegion[] }>('/admin/aws/regions');
 }
+
+// =============================================================================
+// Event-Problem Association
+// =============================================================================
+
+/**
+ * イベントの問題一覧を取得
+ */
+export async function getEventProblems(
+  eventId: string,
+): Promise<{ problems: AdminProblem[]; total: number }> {
+  return get<{ problems: AdminProblem[]; total: number }>(
+    `/admin/events/${eventId}/problems`,
+  );
+}
+
+/**
+ * イベントに問題を追加
+ */
+export async function addProblemToEvent(
+  eventId: string,
+  problemId: string,
+): Promise<{ eventId: string; problemId: string; addedAt: string }> {
+  return post(`/admin/events/${eventId}/problems`, { problemId });
+}
+
+/**
+ * イベントから問題を削除
+ */
+export async function removeProblemFromEvent(
+  eventId: string,
+  problemId: string,
+): Promise<{ success: boolean }> {
+  return del(`/admin/events/${eventId}/problems/${problemId}`);
+}

--- a/packages/shared/src/types/__tests__/scoring.test.ts
+++ b/packages/shared/src/types/__tests__/scoring.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateTotalScore,
+  createScoreEvent,
+  GAMEDAY_POINTS,
+  JAM_POINTS,
+} from '../scoring';
+import type { ScoreEvent } from '../scoring';
+
+describe('\u7d71\u4e00\u30b9\u30b3\u30a2\u30ea\u30f3\u30b0\u30b9\u30ad\u30fc\u30de', () => {
+  describe('GAMEDAY_POINTS', () => {
+    it('\u521d\u671f\u30dd\u30a4\u30f3\u30c8\u304c 10,000 \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(GAMEDAY_POINTS.INITIAL).toBe(10_000);
+    });
+
+    it('\u653b\u6483\u8cfc\u5165\u30b3\u30b9\u30c8\u304c -3,000 \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(GAMEDAY_POINTS.ATTACK_PURCHASE).toBe(-3_000);
+    });
+
+    it('\u653b\u6483\u6210\u529f\u5831\u916c\u304c 1,000 \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(GAMEDAY_POINTS.ATTACK_SUCCESS).toBe(1_000);
+    });
+
+    it('\u9632\u5fa1\u6210\u529f\u5831\u916c\u304c 1,500 \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(GAMEDAY_POINTS.DEFENSE_FIX).toBe(1_500);
+    });
+
+    it('\u30d8\u30eb\u30b9\u30c1\u30a7\u30c3\u30af\u5408\u683c\u5831\u916c\u304c 200 \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(GAMEDAY_POINTS.HEALTH_CHECK_PASS).toBe(200);
+    });
+  });
+
+  describe('JAM_POINTS', () => {
+    it('\u30d2\u30f3\u30c8\u30da\u30ca\u30eb\u30c6\u30a3\u7387\u304c 20% \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(JAM_POINTS.HINT_PENALTY_RATE).toBe(0.2);
+    });
+
+    it('\u65e9\u89e3\u304d\u30dc\u30fc\u30ca\u30b9\u7387\u304c 10% \u3067\u3042\u308b\u3079\u304d', () => {
+      expect(JAM_POINTS.EARLY_SOLVE_BONUS_RATE).toBe(0.1);
+    });
+  });
+
+  describe('createScoreEvent', () => {
+    it('\u30bf\u30a4\u30e0\u30b9\u30bf\u30f3\u30d7\u4ed8\u304d\u306e ScoreEvent \u3092\u4f5c\u6210\u3059\u3079\u304d', () => {
+      const event = createScoreEvent({
+        eventId: 'evt-1',
+        teamId: 'team-1',
+        userId: 'user-1',
+        category: 'attack_success',
+        points: 1000,
+        metadata: { attackSlug: 'sql-injection' },
+      });
+
+      expect(event.eventId).toBe('evt-1');
+      expect(event.teamId).toBe('team-1');
+      expect(event.points).toBe(1000);
+      expect(event.category).toBe('attack_success');
+      expect(event.timestamp).toBeDefined();
+    });
+  });
+
+  describe('calculateTotalScore', () => {
+    it('\u30b9\u30b3\u30a2\u30a4\u30d9\u30f3\u30c8\u306e\u5408\u8a08\u3092\u8a08\u7b97\u3059\u3079\u304d', () => {
+      const events: ScoreEvent[] = [
+        createScoreEvent({
+          eventId: 'evt-1',
+          teamId: 'team-1',
+          userId: 'user-1',
+          category: 'initial_points',
+          points: GAMEDAY_POINTS.INITIAL,
+          metadata: {},
+        }),
+        createScoreEvent({
+          eventId: 'evt-1',
+          teamId: 'team-1',
+          userId: 'user-1',
+          category: 'attack_purchase',
+          points: GAMEDAY_POINTS.ATTACK_PURCHASE,
+          metadata: {},
+        }),
+        createScoreEvent({
+          eventId: 'evt-1',
+          teamId: 'team-1',
+          userId: 'user-1',
+          category: 'attack_success',
+          points: GAMEDAY_POINTS.ATTACK_SUCCESS,
+          metadata: {},
+        }),
+      ];
+
+      // 10,000 - 3,000 + 1,000 = 8,000
+      expect(calculateTotalScore(events)).toBe(8_000);
+    });
+
+    it('\u7a7a\u306e\u30a4\u30d9\u30f3\u30c8\u914d\u5217\u3067 0 \u3092\u8fd4\u3059\u3079\u304d', () => {
+      expect(calculateTotalScore([])).toBe(0);
+    });
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,2 +1,9 @@
 // Export all shared types
 export type { Tenant, TenantStatus, TenantTier } from './tenant';
+export type { ScoreEvent, ScoreEventCategory } from './scoring';
+export {
+  GAMEDAY_POINTS,
+  JAM_POINTS,
+  createScoreEvent,
+  calculateTotalScore,
+} from './scoring';

--- a/packages/shared/src/types/scoring.ts
+++ b/packages/shared/src/types/scoring.ts
@@ -1,0 +1,111 @@
+/**
+ * Unified Scoring Schema
+ *
+ * ADR-003: 統一スコアリングスキーマとポイント経済
+ * GameDay と JAM で共通のスコアイベント型と定数を定義
+ */
+
+// =============================================================================
+// Score Event Types
+// =============================================================================
+
+/**
+ * スコアイベントカテゴリ
+ */
+export type ScoreEventCategory =
+  | 'attack_success'
+  | 'attack_blocked'
+  | 'defense_fix'
+  | 'hint_purchase'
+  | 'attack_purchase'
+  | 'challenge_solve'
+  | 'clue_reveal'
+  | 'health_check_pass'
+  | 'initial_points';
+
+/**
+ * 統一スコアイベント型
+ *
+ * GameDay / JAM 共通のスコア変動イベント
+ */
+export interface ScoreEvent {
+  /** イベントID */
+  eventId: string;
+  /** チームID */
+  teamId: string;
+  /** ユーザーID */
+  userId: string;
+  /** スコアカテゴリ */
+  category: ScoreEventCategory;
+  /** ポイント（正 = 獲得、負 = 消費） */
+  points: number;
+  /** メタデータ */
+  metadata: Record<string, unknown>;
+  /** タイムスタンプ */
+  timestamp: string;
+}
+
+// =============================================================================
+// GameDay Point Economy
+// =============================================================================
+
+/**
+ * GameDay ポイント経済定数
+ */
+export const GAMEDAY_POINTS = {
+  /** ゲーム開始時の初期ポイント */
+  INITIAL: 10_000,
+  /** 攻撃購入コスト */
+  ATTACK_PURCHASE: -3_000,
+  /** 攻撃成功報酬 */
+  ATTACK_SUCCESS: 1_000,
+  /** 攻撃被弾ダメージ */
+  ATTACK_HIT: -1_000,
+  /** 防御成功（脆弱性修正）報酬 */
+  DEFENSE_FIX: 1_500,
+  /** ヒント購入コスト範囲 */
+  HINT_COST_MIN: -500,
+  HINT_COST_MAX: -3_000,
+  /** ヘルスチェック合格報酬 */
+  HEALTH_CHECK_PASS: 200,
+} as const;
+
+// =============================================================================
+// JAM Point Economy
+// =============================================================================
+
+/**
+ * JAM ポイント経済定数
+ */
+export const JAM_POINTS = {
+  /** 問題正解ポイント範囲 */
+  SOLVE_MIN: 100,
+  SOLVE_MAX: 1_000,
+  /** ヒント使用時のペナルティ（正解ポイントからの減額率） */
+  HINT_PENALTY_RATE: 0.2,
+  /** 早解きボーナス率 */
+  EARLY_SOLVE_BONUS_RATE: 0.1,
+} as const;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * ScoreEvent を作成するヘルパー
+ */
+export function createScoreEvent(
+  params: Omit<ScoreEvent, 'timestamp'>,
+): ScoreEvent {
+  return {
+    ...params,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * スコアイベントのポイント合計を計算
+ */
+export function calculateTotalScore(events: ScoreEvent[]): number {
+  return events.reduce((total, event) => total + event.points, 0);
+}


### PR DESCRIPTION
## Summary

- Issue 282: JAM問題エディタUI — イベント問題管理ページ（追加モーダル・削除・編集導線）+ API
- Issue 284: GameDay攻撃カタログ管理UI — 攻撃一覧表示・ワンクリックシード・統計
- Issue 279: 統一スコアリングスキーマ — ScoreEvent型・GAMEDAY/JAM ポイント経済定数・ヘルパー関数

### 追加ファイル
- `/admin/events/[id]/problems/page.tsx` — 問題管理ページ
- `/admin/events/[id]/attacks/page.tsx` — 攻撃カタログ管理ページ
- `packages/shared/src/types/scoring.ts` — 統一スコアリング型
- API: GET/DELETE for event-problem association
- テスト 10件追加

## Test plan

- [x] `make before-commit` 全パス
- [x] スコアリングスキーマテスト 10件通過
- [x] 全テスト通過・カバレッジ99%+維持
- [x] TypeScript型チェック通過

https://claude.ai/code/session_01Fov5H8YVRozKAoBxmNNJaZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attack catalog management for event admins with summary statistics (total count, average cost, and damage) and ability to regenerate default attacks.
  * Problem management interface allowing admins to add existing problems to events, edit details, and remove as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->