### PR TITLE
test: GameDay・管理者ページの全テストを追加

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/attacks/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/attacks/__tests__/page.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminAttackCatalogPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetAttackCatalog = vi.fn();
+const mockSeedAttacks = vi.fn();
+
+vi.mock('@/lib/api/gameday', () => ({
+  getAttackCatalog: (...args: unknown[]) => mockGetAttackCatalog(...args),
+}));
+
+vi.mock('@/lib/api/gameday-admin', () => ({
+  seedAttacks: (...args: unknown[]) => mockSeedAttacks(...args),
+}));
+
+const baseAttack = {
+  id: 'atk-1',
+  slug: 'sql-injection',
+  name: 'SQL Injection',
+  description: 'Inject SQL',
+  attackType: 'vulnerability' as const,
+  purchaseCost: 100,
+  damage: 50,
+  reward: 150,
+  cooldownSeconds: 60,
+  hintCost: 50,
+};
+
+describe('AdminAttackCatalogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAttackCatalog.mockResolvedValue({ attacks: [baseAttack] });
+  });
+
+  it('ローディング中は攻撃データを表示しないべき', () => {
+    mockGetAttackCatalog.mockReturnValue(new Promise(() => {}));
+    render(<AdminAttackCatalogPage />);
+    expect(screen.queryByText('SQL Injection')).not.toBeInTheDocument();
+  });
+
+  it('攻撃カタログ管理ページのタイトルを表示すべき', async () => {
+    render(<AdminAttackCatalogPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('攻撃カタログ管理')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃一覧を表示すべき', async () => {
+    render(<AdminAttackCatalogPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQL Injection')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃カタログが空の場合は空状態メッセージを表示すべき', async () => {
+    mockGetAttackCatalog.mockResolvedValue({ attacks: [] });
+    render(<AdminAttackCatalogPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('攻撃カタログが空です')).toBeInTheDocument();
+    });
+  });
+
+  it('イベントIDをヘッダーに表示すべき', async () => {
+    render(<AdminAttackCatalogPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/イベント ID: ev-1/)).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetAttackCatalog.mockRejectedValue(
+      new Error('攻撃カタログの取得に失敗しました'),
+    );
+    render(<AdminAttackCatalogPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('攻撃カタログの取得に失敗しました'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminEventProblemsPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetEventProblems = vi.fn();
+const mockGetProblems = vi.fn();
+const mockAddProblemToEvent = vi.fn();
+const mockRemoveProblemFromEvent = vi.fn();
+
+vi.mock('@/lib/api/admin-problems', () => ({
+  getEventProblems: (...args: unknown[]) => mockGetEventProblems(...args),
+  getProblems: (...args: unknown[]) => mockGetProblems(...args),
+  addProblemToEvent: (...args: unknown[]) => mockAddProblemToEvent(...args),
+  removeProblemFromEvent: (...args: unknown[]) =>
+    mockRemoveProblemFromEvent(...args),
+}));
+
+const baseProblem = {
+  id: 'prob-1',
+  title: 'SQLインジェクション基礎',
+  type: 'gameday' as const,
+  category: 'web' as const,
+  difficulty: 'medium' as const,
+  description: {
+    overview: 'SQLインジェクションの基礎',
+    objectives: [],
+    hints: [],
+    prerequisites: [],
+  },
+  metadata: { author: 'admin', version: '1.0', tags: [] },
+  deployment: { providers: ['aws' as const], templates: {}, regions: {} },
+  scoring: {
+    type: 'lambda' as const,
+    path: 'handler',
+    timeoutMinutes: 5,
+    criteria: [{ name: '正解', weight: 1, maxPoints: 100 }],
+  },
+};
+
+describe('AdminEventProblemsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEventProblems.mockResolvedValue({ problems: [] });
+    mockGetProblems.mockResolvedValue({ problems: [], total: 0 });
+  });
+
+  it('ローディング中は問題データを表示しないべき', () => {
+    mockGetEventProblems.mockReturnValue(new Promise(() => {}));
+    render(<AdminEventProblemsPage />);
+    expect(
+      screen.queryByText('SQLインジェクション基礎'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('問題管理ページのタイトルを表示すべき', async () => {
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('問題管理')).toBeInTheDocument();
+    });
+  });
+
+  it('問題リストを表示すべき', async () => {
+    mockGetEventProblems.mockResolvedValue({ problems: [baseProblem] });
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQLインジェクション基礎')).toBeInTheDocument();
+    });
+  });
+
+  it('問題が空の場合は空状態メッセージを表示すべき', async () => {
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('問題がまだありません')).toBeInTheDocument();
+    });
+  });
+
+  it('問題追加ボタンを表示すべき', async () => {
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      const addButtons = screen.getAllByRole('button', {
+        name: /問題を追加/i,
+      });
+      expect(addButtons.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/gameday/[eventId]/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/[eventId]/__tests__/page.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminGamedayControlPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetGameStatus = vi.fn();
+const mockGetTeams = vi.fn();
+const mockGetAttackLogs = vi.fn();
+const mockStartGame = vi.fn();
+const mockStopGame = vi.fn();
+const mockToggleBlackout = vi.fn();
+const mockToggleScoreWeight = vi.fn();
+const mockRegisterTeam = vi.fn();
+const mockSeedAttacks = vi.fn();
+const mockStartAuditor = vi.fn();
+const mockStopAuditor = vi.fn();
+const mockExecuteFaultInjection = vi.fn();
+
+vi.mock('@/lib/api/gameday-admin', () => ({
+  getGameStatus: (...args: unknown[]) => mockGetGameStatus(...args),
+  getTeams: (...args: unknown[]) => mockGetTeams(...args),
+  getAttackLogs: (...args: unknown[]) => mockGetAttackLogs(...args),
+  startGame: (...args: unknown[]) => mockStartGame(...args),
+  stopGame: (...args: unknown[]) => mockStopGame(...args),
+  toggleBlackout: (...args: unknown[]) => mockToggleBlackout(...args),
+  toggleScoreWeight: (...args: unknown[]) => mockToggleScoreWeight(...args),
+  registerTeam: (...args: unknown[]) => mockRegisterTeam(...args),
+  seedAttacks: (...args: unknown[]) => mockSeedAttacks(...args),
+  startAuditor: (...args: unknown[]) => mockStartAuditor(...args),
+  stopAuditor: (...args: unknown[]) => mockStopAuditor(...args),
+  executeFaultInjection: (...args: unknown[]) =>
+    mockExecuteFaultInjection(...args),
+}));
+
+const mockGetAttackCatalog = vi.fn();
+vi.mock('@/lib/api/gameday', () => ({
+  getAttackCatalog: (...args: unknown[]) => mockGetAttackCatalog(...args),
+}));
+
+const baseGameState = {
+  eventId: 'ev-1',
+  isRunning: false,
+  blackout: false,
+  scoreWeight: 'normal' as const,
+  durationMinutes: 60,
+  startedAt: null,
+};
+
+describe('AdminGamedayControlPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGameStatus.mockResolvedValue(baseGameState);
+    mockGetTeams.mockResolvedValue({ teams: [] });
+    mockGetAttackLogs.mockResolvedValue({ logs: [] });
+    mockGetAttackCatalog.mockResolvedValue({ attacks: [] });
+  });
+
+  it('ローディング中はコントロールパネルを表示しないべき', () => {
+    mockGetGameStatus.mockReturnValue(new Promise(() => {}));
+    render(<AdminGamedayControlPage />);
+    expect(
+      screen.queryByText('GameDay コントロールパネル'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('コントロールパネルのヘッダーを表示すべき', async () => {
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('GameDay コントロールパネル'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('ゲーム制御タブを表示すべき', async () => {
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      const elements = screen.getAllByText('ゲーム制御');
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('停止状態のゲームにゲーム開始ボタンを表示すべき', async () => {
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ゲーム開始')).toBeInTheDocument();
+    });
+  });
+
+  it('稼働中ゲームにゲーム停止ボタンを表示すべき', async () => {
+    mockGetGameStatus.mockResolvedValue({
+      ...baseGameState,
+      isRunning: true,
+      startedAt: new Date().toISOString(),
+    });
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ゲーム停止')).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetGameStatus.mockRejectedValue(new Error('読み込みに失敗しました'));
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('チームタブにチーム登録フォームを表示すべき', async () => {
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('チーム管理')).toBeInTheDocument();
+    });
+  });
+
+  it('イベントIDをヘッダーに表示すべき', async () => {
+    render(<AdminGamedayControlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/イベント ID: ev-1/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/gameday/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/__tests__/page.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminGamedayPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGet = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  get: (...args: unknown[]) => mockGet(...args),
+}));
+
+const mockGetGameStatus = vi.fn();
+vi.mock('@/lib/api/gameday-admin', () => ({
+  getGameStatus: (...args: unknown[]) => mockGetGameStatus(...args),
+}));
+
+const baseGameState = {
+  eventId: 'ev-1',
+  isRunning: false,
+  blackout: false,
+  scoreWeight: 'normal' as const,
+  durationMinutes: 60,
+  startedAt: null,
+};
+
+const baseEvent = {
+  id: 'ev-1',
+  name: 'GameDay Test Event',
+  type: 'gameday',
+  status: 'active',
+  startTime: '2024-06-01T10:00:00Z',
+  participantCount: 20,
+};
+
+describe('AdminGamedayPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ events: [baseEvent] });
+    mockGetGameStatus.mockResolvedValue(baseGameState);
+  });
+
+  it('ローディング中はイベントデータを表示しないべき', () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    render(<AdminGamedayPage />);
+    expect(screen.queryByText('GameDay Test Event')).not.toBeInTheDocument();
+  });
+
+  it('GameDay管理ページのタイトルを表示すべき', async () => {
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('GameDay 管理')).toBeInTheDocument();
+    });
+  });
+
+  it('GameDayイベントを表示すべき', async () => {
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('GameDay Test Event')).toBeInTheDocument();
+    });
+  });
+
+  it('GameDayタイプ以外のイベントをフィルタリングすべき', async () => {
+    mockGet.mockResolvedValue({
+      events: [
+        baseEvent,
+        { ...baseEvent, id: 'ev-2', name: 'JAM Event', type: 'jam' },
+      ],
+    });
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('GameDay Test Event')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('JAM Event')).not.toBeInTheDocument();
+  });
+
+  it('イベントがない場合は空状態メッセージを表示すべき', async () => {
+    mockGet.mockResolvedValue({ events: [] });
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('GameDay イベントがありません'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラー状態を表示すべき', async () => {
+    mockGet.mockRejectedValue(new Error('API Error'));
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    });
+  });
+
+  it('手動イベントID検索フォームを表示すべき', async () => {
+    render(<AdminGamedayPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/イベント ID を直接入力して検索/),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/participants/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/participants/__tests__/page.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminParticipantsPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: (_: string) => null }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const baseParticipant = {
+  id: 'user-1',
+  userId: 'uid-1',
+  displayName: 'Alice',
+  email: 'alice@example.com',
+  role: 'participant' as const,
+  joinedAt: '2024-06-01T10:00:00Z',
+  status: 'active' as const,
+  eventsCount: 3,
+  totalScore: 1500,
+};
+
+describe('AdminParticipantsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ participants: [baseParticipant], total: 1 }),
+      }),
+    );
+  });
+
+  it('ローディング中は参加者データを表示しないべき', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<AdminParticipantsPage />);
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('参加者管理ページのタイトルを表示すべき', async () => {
+    render(<AdminParticipantsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('参加者管理')).toBeInTheDocument();
+    });
+  });
+
+  it('参加者リストを表示すべき', async () => {
+    render(<AdminParticipantsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('参加者統計を表示すべき', async () => {
+    render(<AdminParticipantsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('総参加者数')).toBeInTheDocument();
+    });
+    expect(screen.getByText('アクティブユーザー')).toBeInTheDocument();
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: '参加者の取得に失敗しました' }),
+      }),
+    );
+    render(<AdminParticipantsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    });
+  });
+
+  it('参加者が空の場合は空状態メッセージを表示すべき', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ participants: [], total: 0 }),
+      }),
+    );
+    render(<AdminParticipantsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('参加者が見つかりません')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/problems/[id]/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/problems/[id]/__tests__/page.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminProblemDetailPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ id: 'prob-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetProblem = vi.fn();
+const mockDeleteProblem = vi.fn();
+
+vi.mock('@/lib/api/admin-problems', () => ({
+  getProblem: (...args: unknown[]) => mockGetProblem(...args),
+  deleteProblem: (...args: unknown[]) => mockDeleteProblem(...args),
+}));
+
+const baseProblem = {
+  id: 'prob-1',
+  title: 'SQLインジェクション基礎',
+  type: 'gameday' as const,
+  category: 'web' as const,
+  difficulty: 'medium' as const,
+  description: {
+    overview: 'SQLインジェクションの基礎を学ぶ問題です',
+    objectives: ['SQLインジェクションを理解する'],
+    hints: ['ヒント1'],
+    prerequisites: [],
+  },
+  metadata: {
+    author: 'admin',
+    version: '1.0',
+    tags: ['sql', 'web'],
+  },
+  deployment: {
+    providers: ['aws' as const],
+    templates: {},
+    regions: {},
+  },
+  scoring: {
+    type: 'lambda' as const,
+    path: 'handler.lambda',
+    timeoutMinutes: 5,
+    criteria: [
+      { name: '正解', description: '正解', weight: 1, maxPoints: 100 },
+    ],
+  },
+};
+
+describe('AdminProblemDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProblem.mockResolvedValue(baseProblem);
+  });
+
+  it('ローディング中は問題データを表示しないべき', () => {
+    mockGetProblem.mockReturnValue(new Promise(() => {}));
+    render(<AdminProblemDetailPage />);
+    expect(
+      screen.queryByText('SQLインジェクション基礎'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('問題タイトルを表示すべき', async () => {
+    render(<AdminProblemDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQLインジェクション基礎')).toBeInTheDocument();
+    });
+  });
+
+  it('問題概要を表示すべき', async () => {
+    render(<AdminProblemDetailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('SQLインジェクションの基礎を学ぶ問題です'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetProblem.mockRejectedValue(new Error('API Error'));
+    render(<AdminProblemDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('問題の取得に失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('問題一覧へ戻るリンクを表示すべき', async () => {
+    render(<AdminProblemDetailPage />);
+
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      const backLink = links.find(
+        (l) =>
+          l.getAttribute('href') === '/admin/problems' ||
+          l.textContent?.includes('問題一覧'),
+      );
+      expect(backLink).toBeTruthy();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/problems/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/problems/__tests__/page.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminProblemsPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetProblems = vi.fn();
+const mockDeleteProblem = vi.fn();
+
+vi.mock('@/lib/api/admin-problems', () => ({
+  getProblems: (...args: unknown[]) => mockGetProblems(...args),
+  deleteProblem: (...args: unknown[]) => mockDeleteProblem(...args),
+}));
+
+const baseProblem = {
+  id: 'prob-1',
+  title: 'SQLインジェクション基礎',
+  type: 'gameday' as const,
+  category: 'web' as const,
+  difficulty: 'medium' as const,
+  description: {
+    overview: 'SQLインジェクションの基礎を学ぶ問題です',
+    objectives: ['SQLインジェクションを理解する'],
+    hints: ['ヒント1'],
+    prerequisites: [],
+  },
+  metadata: {
+    author: 'admin',
+    version: '1.0',
+    tags: ['sql', 'web'],
+  },
+  deployment: {
+    providers: ['aws' as const],
+    templates: {},
+    regions: {},
+  },
+  scoring: {
+    type: 'lambda' as const,
+    path: 'handler.lambda',
+    timeoutMinutes: 5,
+    criteria: [
+      { name: '正解', description: '正解', weight: 1, maxPoints: 100 },
+    ],
+  },
+};
+
+describe('AdminProblemsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProblems.mockResolvedValue({ problems: [baseProblem], total: 1 });
+  });
+
+  it('ローディング中は問題データを表示しないべき', () => {
+    mockGetProblems.mockReturnValue(new Promise(() => {}));
+    render(<AdminProblemsPage />);
+    expect(
+      screen.queryByText('SQLインジェクション基礎'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('問題一覧を表示すべき', async () => {
+    render(<AdminProblemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQLインジェクション基礎')).toBeInTheDocument();
+    });
+  });
+
+  it('新規問題作成リンクを表示すべき', async () => {
+    render(<AdminProblemsPage />);
+
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      const newLink = links.find((l) => l.textContent?.includes('新規問題'));
+      expect(newLink).toBeTruthy();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetProblems.mockRejectedValue(new Error('API Error'));
+    render(<AdminProblemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('問題の取得に失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('問題が空の場合は空状態を表示すべき', async () => {
+    mockGetProblems.mockResolvedValue({ problems: [], total: 0 });
+    render(<AdminProblemsPage />);
+
+    await waitFor(() => {
+      // No problem cards shown
+      expect(
+        screen.queryByText('SQLインジェクション基礎'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/teams/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/teams/__tests__/page.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminTeamsPage from '../page';
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const baseTeam = {
+  id: 'team-1',
+  name: 'TeamAlpha',
+  members: [],
+  captainId: 'user-1',
+  inviteCode: 'ALPHA123',
+  memberCount: 3,
+  maxMembers: 5,
+  eventsCount: 2,
+  totalScore: 2500,
+  createdAt: '2024-06-01T10:00:00Z',
+};
+
+describe('AdminTeamsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ teams: [baseTeam], total: 1 }),
+      }),
+    );
+  });
+
+  it('ローディング中はチームデータを表示しないべき', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<AdminTeamsPage />);
+    expect(screen.queryByText('TeamAlpha')).not.toBeInTheDocument();
+  });
+
+  it('チーム管理ページのタイトルを表示すべき', async () => {
+    render(<AdminTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('チーム管理')).toBeInTheDocument();
+    });
+  });
+
+  it('チームカードを表示すべき', async () => {
+    render(<AdminTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TeamAlpha')).toBeInTheDocument();
+    });
+  });
+
+  it('チーム統計を表示すべき', async () => {
+    render(<AdminTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('総チーム数')).toBeInTheDocument();
+    });
+    expect(screen.getByText('総メンバー数')).toBeInTheDocument();
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'チームの取得に失敗しました' }),
+      }),
+    );
+    render(<AdminTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    });
+  });
+
+  it('チームが空の場合は空状態メッセージを表示すべき', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ teams: [], total: 0 }),
+      }),
+    );
+    render(<AdminTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('チームが見つかりません')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/alliance/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/alliance/__tests__/page.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AlliancePage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+const mockGetAlliances = vi.fn();
+const mockAcceptAlliance = vi.fn();
+const mockBreakAlliance = vi.fn();
+const mockRequestAlliance = vi.fn();
+
+vi.mock('@/lib/api/gameday', () => ({
+  getAlliances: (...args: unknown[]) => mockGetAlliances(...args),
+  acceptAlliance: (...args: unknown[]) => mockAcceptAlliance(...args),
+  breakAlliance: (...args: unknown[]) => mockBreakAlliance(...args),
+  requestAlliance: (...args: unknown[]) => mockRequestAlliance(...args),
+}));
+
+const mockAddNotification = vi.fn();
+vi.mock('@/lib/notifications', () => ({
+  useNotifications: () => ({ addNotification: mockAddNotification }),
+}));
+
+const baseAlliance = {
+  id: 'ally-1',
+  requesterTeamId: 'team-1',
+  targetTeamId: 'team-2',
+  status: 'ACTIVE' as const,
+  createdAt: '2024-06-01T10:00:00Z',
+  updatedAt: '2024-06-01T10:30:00Z',
+};
+
+describe('AlliancePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            teams: [
+              { teamId: 'team-1', teamName: 'TeamAlpha' },
+              { teamId: 'team-2', teamName: 'TeamBeta' },
+            ],
+          }),
+      }),
+    );
+    mockGetAlliances.mockResolvedValue({ alliances: [] });
+  });
+
+  it('ローディング中は同盟データを表示しないべき', () => {
+    mockGetAlliances.mockReturnValue(new Promise(() => {}));
+    render(<AlliancePage />);
+    expect(screen.queryByText('team-2')).not.toBeInTheDocument();
+  });
+
+  it('同盟ページのヘッダーを表示すべき', async () => {
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alliance')).toBeInTheDocument();
+    });
+  });
+
+  it('同盟リクエスト送信フォームを表示すべき', async () => {
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Send alliance request')).toBeInTheDocument();
+    });
+  });
+
+  it('アクティブ同盟を表示すべき', async () => {
+    mockGetAlliances.mockResolvedValue({ alliances: [baseAlliance] });
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('team-2')).toBeInTheDocument();
+    });
+    // Active badge
+    const activeElements = screen.getAllByText('Active');
+    expect(activeElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('同盟がない場合は空状態メッセージを表示すべき', async () => {
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No alliances.')).toBeInTheDocument();
+    });
+  });
+
+  it('受信した同盟リクエストを表示すべき', async () => {
+    const pendingAlliance = {
+      ...baseAlliance,
+      id: 'ally-2',
+      requesterTeamId: 'team-2',
+      targetTeamId: 'team-1',
+      status: 'PENDING' as const,
+    };
+    mockGetAlliances.mockResolvedValue({ alliances: [pendingAlliance] });
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Incoming requests')).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetAlliances.mockRejectedValue(new Error('読み込みに失敗しました'));
+    render(<AlliancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/attack/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/attack/__tests__/page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AttackPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+const mockGetAttackCatalog = vi.fn();
+const mockGetAttackHistory = vi.fn();
+const mockGetParticipantTeams = vi.fn();
+const mockPurchaseAttack = vi.fn();
+const mockExecuteAttack = vi.fn();
+
+vi.mock('@/lib/api/gameday', () => ({
+  getAttackCatalog: (...args: unknown[]) => mockGetAttackCatalog(...args),
+  getAttackHistory: (...args: unknown[]) => mockGetAttackHistory(...args),
+  getParticipantTeams: (...args: unknown[]) => mockGetParticipantTeams(...args),
+  purchaseAttack: (...args: unknown[]) => mockPurchaseAttack(...args),
+  executeAttack: (...args: unknown[]) => mockExecuteAttack(...args),
+}));
+
+const baseAttack = {
+  id: 'atk-1',
+  slug: 'sql-injection',
+  name: 'SQL Injection',
+  description: 'Inject SQL into the database',
+  attackType: 'vulnerability' as const,
+  purchaseCost: 100,
+  damage: 50,
+  reward: 150,
+  cooldownSeconds: 60,
+};
+
+const baseLog = {
+  attackId: 'log-1',
+  attackSlug: 'sql-injection',
+  attackerTeamId: 'team-1',
+  defenderTeamId: 'team-2',
+  success: true,
+  damage: 50,
+  reward: 150,
+  createdAt: '2024-06-01T10:00:00Z',
+  neutralized: false,
+};
+
+describe('AttackPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAttackCatalog.mockResolvedValue({ attacks: [baseAttack] });
+    mockGetAttackHistory.mockResolvedValue({ history: [] });
+    mockGetParticipantTeams.mockResolvedValue({
+      teams: [
+        { teamId: 'team-1', teamName: 'TeamAlpha' },
+        { teamId: 'team-2', teamName: 'TeamBeta' },
+      ],
+    });
+  });
+
+  it('ローディング中は攻撃カタログを表示しないべき', () => {
+    mockGetAttackCatalog.mockReturnValue(new Promise(() => {}));
+    mockGetAttackHistory.mockReturnValue(new Promise(() => {}));
+    render(<AttackPage />);
+    expect(screen.queryByText('SQL Injection')).not.toBeInTheDocument();
+  });
+
+  it('攻撃カタログを表示すべき', async () => {
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQL Injection')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃ページのヘッダーを表示すべき', async () => {
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Attack Station')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃履歴テーブルを表示すべき', async () => {
+    mockGetAttackHistory.mockResolvedValue({ history: [baseLog] });
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('sql-injection')).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetAttackCatalog.mockRejectedValue(new Error('読み込みに失敗しました'));
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃カタログが空の場合は空状態を表示すべき', async () => {
+    mockGetAttackCatalog.mockResolvedValue({ attacks: [] });
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      // Cards empty text comes from t('common.noData') which is 'No data'
+      expect(screen.queryByText('SQL Injection')).not.toBeInTheDocument();
+    });
+  });
+
+  it('購入ボタンを表示すべき', async () => {
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQL Injection')).toBeInTheDocument();
+    });
+
+    // Purchase button shows cost
+    expect(screen.getByText(/Purchase.*100 pts/)).toBeInTheDocument();
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/defense/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/defense/__tests__/page.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import DefensePage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+const mockGetActiveDefense = vi.fn();
+const mockPurchaseHint = vi.fn();
+const mockReportFix = vi.fn();
+
+vi.mock('@/lib/api/gameday', () => ({
+  getActiveDefense: (...args: unknown[]) => mockGetActiveDefense(...args),
+  purchaseHint: (...args: unknown[]) => mockPurchaseHint(...args),
+  reportFix: (...args: unknown[]) => mockReportFix(...args),
+}));
+
+const mockAddNotification = vi.fn();
+vi.mock('@/lib/notifications', () => ({
+  useNotifications: () => ({ addNotification: mockAddNotification }),
+}));
+
+const baseAttack = {
+  attackId: 'atk-log-1',
+  attackSlug: 'sql-injection',
+  attackerTeamId: 'team-2',
+  defenderTeamId: 'team-1',
+  success: true,
+  damage: 50,
+  reward: 0,
+  createdAt: '2024-06-01T10:00:00Z',
+  neutralized: false,
+};
+
+describe('DefensePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActiveDefense.mockResolvedValue({ attacks: [] });
+  });
+
+  it('ローディング中は攻撃データを表示しないべき', () => {
+    mockGetActiveDefense.mockReturnValue(new Promise(() => {}));
+    render(<DefensePage />);
+    expect(screen.queryByText('sql-injection')).not.toBeInTheDocument();
+  });
+
+  it('防衛ページのヘッダーを表示すべき', async () => {
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Defense Trench')).toBeInTheDocument();
+    });
+  });
+
+  it('アクティブな攻撃を表示すべき', async () => {
+    mockGetActiveDefense.mockResolvedValue({ attacks: [baseAttack] });
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('sql-injection')).toBeInTheDocument();
+    });
+    expect(screen.getByText('team-2')).toBeInTheDocument();
+  });
+
+  it('攻撃がない場合は空状態メッセージを表示すべき', async () => {
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No active attacks right now.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetActiveDefense.mockRejectedValue(new Error('読み込みに失敗しました'));
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('修正済み攻撃を別テーブルに表示すべき', async () => {
+    const neutralizedAttack = { ...baseAttack, neutralized: true };
+    mockGetActiveDefense.mockResolvedValue({
+      attacks: [baseAttack, neutralizedAttack],
+    });
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      // Mitigated table header (appears multiple times - header + cell content)
+      const mitigated = screen.getAllByText('Mitigated');
+      expect(mitigated.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('10秒ごとに自動更新する旨を表示すべき', async () => {
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Refreshes every 10 seconds'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/scoreboard/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/scoreboard/__tests__/page.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ScoreboardPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+const mockGetLeaderboard = vi.fn();
+const mockGetAttackStats = vi.fn();
+
+vi.mock('@/lib/api/gameday', () => ({
+  getLeaderboard: (...args: unknown[]) => mockGetLeaderboard(...args),
+  getAttackStats: (...args: unknown[]) => mockGetAttackStats(...args),
+}));
+
+const baseLeaderboard = [
+  {
+    rank: 1,
+    teamId: 'team-2',
+    teamName: 'TeamBeta',
+    score: 1500,
+    attacksLaunched: 5,
+    attacksReceived: 2,
+    vulnerabilitiesFixed: 3,
+  },
+  {
+    rank: 2,
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+    score: 1200,
+    attacksLaunched: 3,
+    attacksReceived: 4,
+    vulnerabilitiesFixed: 2,
+  },
+];
+
+const baseAttackStats = [
+  {
+    attackSlug: 'sql-injection',
+    attackName: 'SQL Injection',
+    totalExecutions: 10,
+    successRate: 0.7,
+  },
+];
+
+describe('ScoreboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetLeaderboard.mockResolvedValue({ leaderboard: baseLeaderboard });
+    mockGetAttackStats.mockResolvedValue({ stats: baseAttackStats });
+  });
+
+  it('ローディング中はリーダーボードデータを表示しないべき', () => {
+    mockGetLeaderboard.mockReturnValue(new Promise(() => {}));
+    mockGetAttackStats.mockReturnValue(new Promise(() => {}));
+    render(<ScoreboardPage />);
+    expect(screen.queryByText('TeamBeta')).not.toBeInTheDocument();
+  });
+
+  it('リーダーボードのデータを表示すべき', async () => {
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TeamBeta')).toBeInTheDocument();
+    });
+    expect(screen.getByText('TeamAlpha')).toBeInTheDocument();
+  });
+
+  it('スコアボードタイトルを表示すべき', async () => {
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('スコアボード')).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃統計を表示すべき', async () => {
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SQL Injection')).toBeInTheDocument();
+    });
+  });
+
+  it('APIエラー時にエラー状態を表示すべき', async () => {
+    mockGetLeaderboard.mockRejectedValue(new Error('Server error'));
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      // ErrorState renders a title
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    });
+  });
+
+  it('403エラー時にブラックアウト画面を表示すべき', async () => {
+    const forbiddenError = Object.assign(new Error('Forbidden'), {
+      status: 403,
+    });
+    mockGetLeaderboard.mockRejectedValue(forbiddenError);
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('BLACKOUT')).toBeInTheDocument();
+    });
+  });
+
+  it('自チームのバッジを表示すべき', async () => {
+    render(<ScoreboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('自チーム')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import VotePage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+const mockGetVotingResults = vi.fn();
+const mockSubmitVote = vi.fn();
+vi.mock('@/lib/api/gameday', () => ({
+  getVotingResults: (...args: unknown[]) => mockGetVotingResults(...args),
+  submitVote: (...args: unknown[]) => mockSubmitVote(...args),
+}));
+
+const baseTeamsResponse = {
+  teams: [
+    { teamId: 'team-1', teamName: 'TeamAlpha' },
+    { teamId: 'team-2', teamName: 'TeamBeta' },
+    { teamId: 'team-3', teamName: 'TeamGamma' },
+  ],
+};
+
+const baseVotingResults = {
+  results: [],
+};
+
+describe('VotePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(baseTeamsResponse),
+      }),
+    );
+    mockGetVotingResults.mockResolvedValue(baseVotingResults);
+  });
+
+  it('ローディング中はチームデータを表示しないべき', () => {
+    mockGetVotingResults.mockReturnValue(new Promise(() => {}));
+    render(<VotePage />);
+    expect(screen.queryByText('TeamBeta')).not.toBeInTheDocument();
+  });
+
+  it('他チームのカードを表示すべき', async () => {
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TeamBeta')).toBeInTheDocument();
+    });
+    // 自チームは表示しない
+    expect(screen.queryByText('TeamAlpha')).not.toBeInTheDocument();
+  });
+
+  it('他チームへの投票ボタンを表示すべき', async () => {
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TeamBeta')).toBeInTheDocument();
+    });
+
+    const voteButtons = screen.getAllByRole('button', { name: /Vote/i });
+    expect(voteButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetVotingResults.mockRejectedValue(new Error('読み込みに失敗しました'));
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('投票済みの場合は投票完了メッセージを表示すべき', async () => {
+    mockGetVotingResults.mockResolvedValue({
+      results: [{ voterTeamId: 'team-1', votedForTeamId: 'team-2' }],
+    });
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your vote has been submitted. Thank you.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('チームがない場合は空状態メッセージを表示すべき', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            teams: [{ teamId: 'team-1', teamName: 'TeamAlpha' }],
+          }),
+      }),
+    );
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No other teams are registered yet.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('投票するボタンクリックで submitVote を呼ぶべき', async () => {
+    mockSubmitVote.mockResolvedValue({});
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TeamBeta')).toBeInTheDocument();
+    });
+
+    const voteButtons = screen.getAllByRole('button', { name: /Vote/i });
+    fireEvent.click(voteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockSubmitVote).toHaveBeenCalledWith('ev-1', 'team-1', 'team-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- GameDay参加者ページ (vote, attack, alliance, scoreboard, defense) のテストを追加
- 管理者ページ (participants, teams, problems, problems/[id], events/problems, events/attacks, gameday, gameday/[eventId]) のテストを追加
- 各ページでローディング・データ表示・エラー状態・空状態をカバー
- 全444テスト通過、カバレッジ99%+維持

## Test plan

- [x] `make before-commit` 通過（lint, format, typecheck, test, build）
- [x] 全 44 テストファイル、444 テストが通過
- [x] カバレッジ: statements 100%, branches 99.38%, functions 100%, lines 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage across admin and participant features with comprehensive test suites for event management, problem management, gameday controls, participant administration, team management, and interactive gameplay pages.

**Note:** These changes are internal improvements with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->