### PR TITLE
feat: GameDay フロー強化 — Leaderboard接続・管理UI導線・自動初期化

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
@@ -250,6 +250,44 @@ export default function AdminEventDetailPage() {
         )}
       </Container>
 
+      {/* GameDay Quick Actions (only for gameday events) */}
+      {event.type === 'gameday' && (
+        <Container header={<Header variant="h2">GameDay 管理</Header>}>
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="primary"
+              onClick={() => router.push(`/admin/gameday/${eventId}`)}
+            >
+              ゲーム制御パネル
+            </Button>
+            <Button
+              onClick={() => router.push(`/admin/events/${eventId}/attacks`)}
+            >
+              攻撃カタログ
+            </Button>
+            <Button
+              onClick={() => router.push(`/admin/events/${eventId}/problems`)}
+            >
+              問題管理
+            </Button>
+          </SpaceBetween>
+        </Container>
+      )}
+
+      {/* JAM Quick Actions (only for jam events) */}
+      {event.type === 'jam' && (
+        <Container header={<Header variant="h2">JAM 管理</Header>}>
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="primary"
+              onClick={() => router.push(`/admin/events/${eventId}/problems`)}
+            >
+              問題管理
+            </Button>
+          </SpaceBetween>
+        </Container>
+      )}
+
       {/* Problems table */}
       <Table
         header={

--- a/backend/services/application-plane/leaderboard-service/src/api/gameday-leaderboard.ts
+++ b/backend/services/application-plane/leaderboard-service/src/api/gameday-leaderboard.ts
@@ -1,0 +1,87 @@
+/**
+ * GameDay Leaderboard API
+ *
+ * GameDay イベントのリーダーボードエンドポイント
+ * - GET /api/leaderboards/gameday/:eventId — リーダーボード取得
+ * - GET /api/leaderboards/gameday/:eventId/stream — SSE ストリーム
+ */
+
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import { getGameDayLeaderboard } from '../services/gameday-leaderboard';
+
+export const gamedayLeaderboardRoutes = new Hono();
+
+const SSE_INTERVAL_MS = 3000;
+
+gamedayLeaderboardRoutes.get(
+  '/api/leaderboards/gameday/:eventId',
+  async (c) => {
+    const eventId = c.req.param('eventId');
+    const auth = c.get('auth');
+
+    try {
+      const result = await getGameDayLeaderboard(
+        eventId,
+        auth?.token,
+      );
+
+      if (!result) {
+        return c.json(
+          { error: 'GameDay イベントが見つかりません' },
+          404,
+        );
+      }
+
+      return c.json(result);
+    } catch (error) {
+      if (error instanceof Error) {
+        return c.json({ error: error.message }, 500);
+      }
+      return c.json(
+        { error: 'GameDay リーダーボードの取得に失敗しました' },
+        500,
+      );
+    }
+  },
+);
+
+gamedayLeaderboardRoutes.get(
+  '/api/leaderboards/gameday/:eventId/stream',
+  async (c) => {
+    const eventId = c.req.param('eventId');
+    const auth = c.get('auth');
+
+    return streamSSE(c, async (stream) => {
+      let running = true;
+
+      stream.onAbort(() => {
+        running = false;
+      });
+
+      while (running) {
+        const result = await getGameDayLeaderboard(
+          eventId,
+          auth?.token,
+        );
+
+        if (!result) {
+          await stream.writeSSE({
+            event: 'error',
+            data: JSON.stringify({
+              error: 'GameDay イベントが見つかりません',
+            }),
+          });
+          break;
+        }
+
+        await stream.writeSSE({
+          event: 'leaderboard',
+          data: JSON.stringify(result),
+        });
+
+        await stream.sleep(SSE_INTERVAL_MS);
+      }
+    });
+  },
+);

--- a/backend/services/application-plane/leaderboard-service/src/index.ts
+++ b/backend/services/application-plane/leaderboard-service/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors';
 import { createLogger } from './lib/logger';
 import { healthRoutes } from './api/health';
 import { leaderboardRoutes } from './api/leaderboard';
+import { gamedayLeaderboardRoutes } from './api/gameday-leaderboard';
 import { authMiddleware } from './middleware/auth';
 
 const logger = createLogger('leaderboard-service');
@@ -24,6 +25,7 @@ app.use('/api/leaderboards/*', authMiddleware);
 // ルート登録
 app.route('/', healthRoutes);
 app.route('/', leaderboardRoutes);
+app.route('/', gamedayLeaderboardRoutes);
 
 // PORT バリデーション
 const parsePort = (value: string | undefined): number => {

--- a/backend/services/application-plane/leaderboard-service/src/services/gameday-leaderboard.test.ts
+++ b/backend/services/application-plane/leaderboard-service/src/services/gameday-leaderboard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getGameDayLeaderboard } from './gameday-leaderboard';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('GameDay Leaderboard Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GameDay リーダーボードを取得すべき', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          leaderboard: [
+            {
+              teamId: 'team-1',
+              teamName: 'Alpha',
+              score: 8000,
+              rank: 1,
+              attacksLaunched: 3,
+              attacksReceived: 1,
+              vulnerabilitiesFixed: 2,
+            },
+            {
+              teamId: 'team-2',
+              teamName: 'Beta',
+              score: 6000,
+              rank: 2,
+              attacksLaunched: 1,
+              attacksReceived: 2,
+              vulnerabilitiesFixed: 1,
+            },
+          ],
+        }),
+    });
+
+    const result = await getGameDayLeaderboard('event-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.eventId).toBe('event-1');
+    expect(result!.entries).toHaveLength(2);
+    expect(result!.entries[0].teamName).toBe('Alpha');
+    expect(result!.entries[0].score).toBe(8000);
+    expect(result!.entries[1].teamName).toBe('Beta');
+  });
+
+  it('イベントが見つからない場合は null を返すべき', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const result = await getGameDayLeaderboard('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('API エラーの場合は null を返すべき', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const result = await getGameDayLeaderboard('event-1');
+    expect(result).toBeNull();
+  });
+
+  it('認証トークンをヘッダーに含めるべき', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ leaderboard: [] }),
+    });
+
+    await getGameDayLeaderboard('event-1', 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+  });
+
+  it('空のリーダーボードを正しく処理すべき', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ leaderboard: [] }),
+    });
+
+    const result = await getGameDayLeaderboard('event-1');
+    expect(result!.entries).toHaveLength(0);
+  });
+});

--- a/backend/services/application-plane/leaderboard-service/src/services/gameday-leaderboard.ts
+++ b/backend/services/application-plane/leaderboard-service/src/services/gameday-leaderboard.ts
@@ -1,0 +1,89 @@
+/**
+ * GameDay Leaderboard Service
+ *
+ * gameday-service の /dashboard/leaderboard からスコアを取得してリーダーボード形式に変換
+ * ADR-003: Option A — GameDay のスコアを直接読み取る
+ */
+
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('gameday-leaderboard');
+
+export interface GameDayLeaderboardEntry {
+  rank: number;
+  teamId: string;
+  teamName: string;
+  score: number;
+  attacksLaunched: number;
+  attacksReceived: number;
+  vulnerabilitiesFixed: number;
+}
+
+export interface GameDayLeaderboardResult {
+  eventId: string;
+  frozen: boolean;
+  entries: GameDayLeaderboardEntry[];
+  updatedAt: Date;
+}
+
+const GAMEDAY_API_URL =
+  process.env.GAMEDAY_API_URL || 'http://localhost:3020/api/gameday';
+
+/**
+ * GameDay サービスからリーダーボードを取得
+ */
+export async function getGameDayLeaderboard(
+  eventId: string,
+  token?: string,
+): Promise<GameDayLeaderboardResult | null> {
+  try {
+    const url = `${GAMEDAY_API_URL}/dashboard/leaderboard?eventId=${encodeURIComponent(eventId)}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, { headers });
+
+    if (!response.ok) {
+      if (response.status === 404) return null;
+      throw new Error(`GameDay API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const leaderboard = data.leaderboard ?? [];
+
+    return {
+      eventId,
+      frozen: false,
+      entries: leaderboard.map(
+        (
+          entry: {
+            teamId: string;
+            teamName: string;
+            score: number;
+            rank: number;
+            attacksLaunched?: number;
+            attacksReceived?: number;
+            vulnerabilitiesFixed?: number;
+          },
+          index: number,
+        ) => ({
+          rank: entry.rank ?? index + 1,
+          teamId: entry.teamId,
+          teamName: entry.teamName,
+          score: entry.score,
+          attacksLaunched: entry.attacksLaunched ?? 0,
+          attacksReceived: entry.attacksReceived ?? 0,
+          vulnerabilitiesFixed: entry.vulnerabilitiesFixed ?? 0,
+        }),
+      ),
+      updatedAt: new Date(),
+    };
+  } catch (error) {
+    logger.error({ error, eventId }, 'GameDay リーダーボードの取得に失敗');
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Issue 281: Leaderboard を GameDay スコアに接続 — leaderboard-service に GameDay リーダーボード取得 + SSE ストリーム追加
- Issue 278: GameDay 自動初期化 — backend の initializeGamedayService() が既に実装済みであることを確認・フロントエンドUIの導線整備
- GameDay/JAM 管理フロー改善 — イベント詳細ページにタイプ別管理セクション追加

### 技術詳細
- `GET /api/leaderboards/gameday/:eventId` — gameday-service から直接スコア取得（ADR-003 Option A）
- `GET /api/leaderboards/gameday/:eventId/stream` — SSE リアルタイム配信（3秒間隔）
- イベント詳細に GameDay: ゲーム制御パネル・攻撃カタログ・問題管理ボタン
- イベント詳細に JAM: 問題管理ボタン
- テスト 5件追加

## Test plan

- [x] `make before-commit` 全パス
- [x] GameDay leaderboard テスト 5件通過
- [x] 全テスト通過・カバレッジ99%+維持

https://claude.ai/code/session_01Fov5H8YVRozKAoBxmNNJaZ