### PR TITLE
test(gameday-service): カバレッジを 91% から 99% 以上に改善

### DIFF
--- a/backend/services/application-plane/gameday-service/src/api/admin.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.test.ts
@@ -276,6 +276,22 @@ describe("管理者 API", () => {
 			});
 		});
 
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.stopGame.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/game/stop", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
 		describe("eventId が空の場合", () => {
 			it("BAD_REQUEST を返すべき", async () => {
 				const res = await app.request("/game/stop", {
@@ -339,6 +355,30 @@ describe("管理者 API", () => {
 			it("BAD_REQUEST を返すべき", async () => {
 				const res = await app.request("/game/status");
 				expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+			});
+		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.getGameStatus.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/game/status?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.getGameStatus.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/game/status?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
 			});
 		});
 	});
@@ -446,6 +486,22 @@ describe("管理者 API", () => {
 				expect(body.error).toBe("JSON の解析に失敗しました");
 			});
 		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.toggleScoreWeight.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/score-weight/toggle", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
 	});
 
 	describe("POST /blackout/toggle", () => {
@@ -551,6 +607,22 @@ describe("管理者 API", () => {
 				expect(body.error).toBe("JSON の解析に失敗しました");
 			});
 		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.toggleBlackout.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/blackout/toggle", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
 	});
 
 	describe("POST /fault-injection/execute", () => {
@@ -611,6 +683,66 @@ describe("管理者 API", () => {
 				expect(body.error).toBe("JSON の解析に失敗しました");
 			});
 		});
+
+		describe("ゲームが存在しない場合", () => {
+			it("NOT_FOUND を返すべき", async () => {
+				mockGameController.executeFaultInjection.mockRejectedValue(
+					new mockGameController.GameNotFoundError(),
+				);
+
+				const res = await app.request("/fault-injection/execute", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						eventId: "event-1",
+						teamId: "team-1",
+						attackSlug: "sql-injection",
+					}),
+				});
+
+				expect(res.status).toBe(StatusCodes.NOT_FOUND);
+			});
+		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.executeFaultInjection.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/fault-injection/execute", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						eventId: "event-1",
+						teamId: "team-1",
+						attackSlug: "sql-injection",
+					}),
+				});
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.executeFaultInjection.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/fault-injection/execute", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						eventId: "event-1",
+						teamId: "team-1",
+						attackSlug: "sql-injection",
+					}),
+				});
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+			});
+		});
 	});
 
 	describe("GET /teams", () => {
@@ -640,6 +772,42 @@ describe("管理者 API", () => {
 			it("BAD_REQUEST を返すべき", async () => {
 				const res = await app.request("/teams");
 				expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+			});
+		});
+
+		describe("ゲームが存在しない場合", () => {
+			it("NOT_FOUND を返すべき", async () => {
+				mockGameController.listTeams.mockRejectedValue(
+					new mockGameController.GameNotFoundError(),
+				);
+
+				const res = await app.request("/teams?eventId=nonexistent");
+
+				expect(res.status).toBe(StatusCodes.NOT_FOUND);
+			});
+		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.listTeams.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/teams?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.listTeams.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/teams?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
 			});
 		});
 	});
@@ -677,6 +845,42 @@ describe("管理者 API", () => {
 			it("BAD_REQUEST を返すべき", async () => {
 				const res = await app.request("/attack-logs");
 				expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+			});
+		});
+
+		describe("ゲームが存在しない場合", () => {
+			it("NOT_FOUND を返すべき", async () => {
+				mockGameController.listAttackLogs.mockRejectedValue(
+					new mockGameController.GameNotFoundError(),
+				);
+
+				const res = await app.request("/attack-logs?eventId=nonexistent");
+
+				expect(res.status).toBe(StatusCodes.NOT_FOUND);
+			});
+		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.listAttackLogs.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/attack-logs?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.listAttackLogs.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/attack-logs?eventId=event-1");
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
 			});
 		});
 	});
@@ -723,6 +927,54 @@ describe("管理者 API", () => {
 				expect(res.status).toBe(StatusCodes.BAD_REQUEST);
 				const body = await res.json();
 				expect(body.error).toBe("JSON の解析に失敗しました");
+			});
+		});
+
+		describe("ゲームが存在しない場合", () => {
+			it("NOT_FOUND を返すべき", async () => {
+				mockGameController.seedAttackCatalog.mockRejectedValue(
+					new mockGameController.GameNotFoundError(),
+				);
+
+				const res = await app.request("/attacks/seed", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "nonexistent" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.NOT_FOUND);
+			});
+		});
+
+		describe("別テナントのゲームにアクセスした場合", () => {
+			it("FORBIDDEN を返すべき", async () => {
+				mockGameController.seedAttackCatalog.mockRejectedValue(
+					new mockGameController.CrossTenantAccessError("tenant-1", "tenant-2"),
+				);
+
+				const res = await app.request("/attacks/seed", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.FORBIDDEN);
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.seedAttackCatalog.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/attacks/seed", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1" }),
+				});
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
 			});
 		});
 	});

--- a/backend/services/application-plane/gameday-service/src/api/participant.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.test.ts
@@ -142,22 +142,38 @@ const mockDashboardService = vi.hoisted(() => {
   };
 });
 
-const mockGameController = vi.hoisted(() => ({
-  getGameStatus: vi.fn(),
-}));
-
-vi.mock('../services/participant-service', () => mockParticipantService);
-vi.mock('../services/dashboard-service', () => mockDashboardService);
-vi.mock('../services/game-controller', () => ({
-  getGameStatus: mockGameController.getGameStatus,
-  CrossTenantAccessError: class CrossTenantAccessError extends Error {
+const mockGameController = vi.hoisted(() => {
+  class CrossTenantAccessError extends Error {
     constructor(requestTenantId: string, resourceTenantId: string) {
       super(
         `クロステナントアクセスが拒否されました: リクエストテナント=${requestTenantId}, リソーステナント=${resourceTenantId}`
       );
       this.name = 'CrossTenantAccessError';
     }
+  }
+  return {
+    getGameStatus: vi.fn(),
+    CrossTenantAccessError,
+  };
+});
+
+const mockGamedayRepository = vi.hoisted(() => ({
+  addMember: vi.fn(),
+  getMembership: vi.fn(),
+}));
+
+vi.mock('../repositories/gameday-repository', () => ({
+  GamedayRepository: class {
+    addMember = mockGamedayRepository.addMember;
+    getMembership = mockGamedayRepository.getMembership;
   },
+}));
+
+vi.mock('../services/participant-service', () => mockParticipantService);
+vi.mock('../services/dashboard-service', () => mockDashboardService);
+vi.mock('../services/game-controller', () => ({
+  getGameStatus: mockGameController.getGameStatus,
+  CrossTenantAccessError: mockGameController.CrossTenantAccessError,
 }));
 
 import { participantRoutes } from './participant';
@@ -169,6 +185,8 @@ describe('プレーヤー API', () => {
     vi.clearAllMocks();
     // デフォルトの getAllAttackLogs は空配列を返す
     mockParticipantService.getAllAttackLogs.mockResolvedValue([]);
+    mockGamedayRepository.addMember.mockResolvedValue(undefined);
+    mockGamedayRepository.getMembership.mockResolvedValue(null);
     app = new Hono();
     app.use('/*', async (c, next) => {
       c.set('auth' as never, {
@@ -1354,6 +1372,269 @@ describe('プレーヤー API', () => {
       expect(body.team.teamId).toBe('unknown');
       expect(body.score).toBe(0);
       expect(body.recentAttacks).toEqual([]);
+    });
+  });
+
+  // === teams/create 不正な JSON ===
+  describe('POST /teams/create (不正な JSON)', () => {
+    it('不正な JSON で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('予期しないエラーで INTERNAL_SERVER_ERROR を返すべき', async () => {
+      mockDashboardService.registerTeam.mockRejectedValue(new Error('DB error'));
+      const res = await app.request('/teams/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          teamName: 'テストチーム',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  // === teams/join 不正な JSON ===
+  describe('POST /teams/join (不正な JSON)', () => {
+    it('不正な JSON で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === teams/update-url 予期しないエラー ===
+  describe('POST /teams/update-url (予期しないエラー)', () => {
+    it('予期しないエラーで INTERNAL_SERVER_ERROR を返すべき', async () => {
+      mockDashboardService.updateTeamUrl.mockRejectedValue(new Error('DB error'));
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          websiteUrl: 'https://example.com',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  // === リーダーボード getAllAttackLogs が失敗する場合 ===
+  describe('GET /dashboard/leaderboard (getAllAttackLogs 失敗)', () => {
+    it('getAllAttackLogs が失敗しても空ログでリーダーボードを返すべき', async () => {
+      mockDashboardService.getLeaderboard.mockResolvedValue([
+        { teamId: 'team-1', teamName: 'チームA', score: 5000 },
+      ]);
+      mockParticipantService.getAllAttackLogs.mockRejectedValue(
+        new Error('DynamoDB error')
+      );
+      const res = await app.request('/dashboard/leaderboard?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.leaderboard).toHaveLength(1);
+    });
+  });
+
+  // === 攻撃統計 getAllAttackLogs が失敗する場合 ===
+  describe('GET /dashboard/attack-stats (getAllAttackLogs 失敗)', () => {
+    it('getAllAttackLogs が失敗しても空の統計を返すべき', async () => {
+      mockParticipantService.getAllAttackLogs.mockRejectedValue(
+        new Error('DynamoDB error')
+      );
+      const res = await app.request('/dashboard/attack-stats?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.stats).toHaveLength(0);
+    });
+  });
+
+  // === userId ありのチーム作成 ===
+  describe('POST /teams/create (userId あり)', () => {
+    it('userId あり でメンバー登録も行うべき', async () => {
+      mockDashboardService.registerTeam.mockResolvedValue({
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'テストチーム',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: null,
+        apiUrl: null,
+        inviteCode: 'ABC123',
+      });
+      const res = await app.request('/teams/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-1',
+          teamName: 'テストチーム',
+          userId: 'user-1',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.CREATED);
+      expect(mockGamedayRepository.addMember).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        userId: 'user-1',
+        teamId: 'team-1',
+        teamName: 'テストチーム',
+        mode: 'team',
+      });
+    });
+  });
+
+  // === userId ありのチーム参加 ===
+  describe('POST /teams/join (userId あり)', () => {
+    it('userId あり でメンバー登録も行うべき', async () => {
+      mockDashboardService.joinTeamByInviteCode.mockResolvedValue({
+        eventId: 'event-1',
+        teamId: 'team-1',
+        teamName: 'テストチーム',
+        score: 0,
+        isHealthy: true,
+        websiteUrl: null,
+        apiUrl: null,
+        inviteCode: 'ABC123',
+      });
+      const res = await app.request('/teams/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          inviteCode: 'ABC123',
+          userId: 'user-1',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(mockGamedayRepository.addMember).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        userId: 'user-1',
+        teamId: 'team-1',
+        teamName: 'テストチーム',
+        mode: 'team',
+      });
+    });
+  });
+
+  // === ソロ参加登録 ===
+  describe('POST /teams/solo', () => {
+    it('正常系で CREATED を返すべき', async () => {
+      const res = await app.request('/teams/solo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventId: 'event-1', userId: 'user-1' }),
+      });
+      expect(res.status).toBe(StatusCodes.CREATED);
+      const body = await res.json();
+      expect(body.mode).toBe('solo');
+      expect(mockGamedayRepository.addMember).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        userId: 'user-1',
+        teamId: 'solo-user-1',
+        teamName: 'ソロ参加',
+        mode: 'solo',
+      });
+    });
+
+    it('必須フィールドが欠けている場合 BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/solo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventId: 'event-1' }),
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('不正な JSON で BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/solo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      });
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === メンバーシップ取得 ===
+  describe('GET /teams/my-membership', () => {
+    it('メンバーシップが存在する場合 OK を返すべき', async () => {
+      mockGamedayRepository.getMembership.mockResolvedValue({
+        userId: 'user-1',
+        teamId: 'team-1',
+        teamName: 'テストチーム',
+        mode: 'team',
+      });
+      const res = await app.request(
+        '/teams/my-membership?eventId=event-1&userId=user-1'
+      );
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.membership.teamId).toBe('team-1');
+    });
+
+    it('メンバーシップが存在しない場合 OK で null を返すべき', async () => {
+      const res = await app.request(
+        '/teams/my-membership?eventId=event-1&userId=nonexistent'
+      );
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.membership).toBeNull();
+    });
+
+    it('必須パラメータが欠けている場合 BAD_REQUEST を返すべき', async () => {
+      const res = await app.request('/teams/my-membership?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // === リーダーボード（攻撃ログあり）===
+  describe('GET /dashboard/leaderboard (攻撃ログあり)', () => {
+    it('攻撃ログを集計してリーダーボードに反映すべき', async () => {
+      mockDashboardService.getLeaderboard.mockResolvedValue([
+        { teamId: 'team-1', teamName: 'チームA', score: 5000 },
+        { teamId: 'team-2', teamName: 'チームB', score: 3000 },
+      ]);
+      mockParticipantService.getAllAttackLogs.mockResolvedValue([
+        {
+          attackerTeamId: 'team-1',
+          defenderTeamId: 'team-2',
+          attackSlug: 'sql-injection',
+          success: true,
+        },
+      ]);
+      const res = await app.request('/dashboard/leaderboard?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.OK);
+      const body = await res.json();
+      expect(body.leaderboard).toHaveLength(2);
+      expect(body.leaderboard[0].attacksLaunched).toBe(1);
+      expect(body.leaderboard[1].attacksReceived).toBe(1);
+    });
+  });
+
+  // === ゲームステータス CrossTenantAccessError ===
+  describe('GET /game/status (CrossTenantAccess)', () => {
+    it('別テナントアクセスで FORBIDDEN を返すべき', async () => {
+      mockGameController.getGameStatus.mockRejectedValue(
+        new mockGameController.CrossTenantAccessError('tenant-1', 'tenant-2')
+      );
+      const res = await app.request('/game/status?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('予期しないエラーで INTERNAL_SERVER_ERROR を返すべき', async () => {
+      mockGameController.getGameStatus.mockRejectedValue(new Error('DB error'));
+      const res = await app.request('/game/status?eventId=event-1');
+      expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
     });
   });
 });

--- a/backend/services/application-plane/gameday-service/src/services/auditor-service.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/auditor-service.test.ts
@@ -212,6 +212,30 @@ describe("Auditor サービス", () => {
 			);
 		});
 
+		it("apiUrl のみ設定時、api だけチェックするべき", async () => {
+			const team = {
+				eventId: "event-1",
+				teamId: "team-1",
+				teamName: "A",
+				score: 0,
+				isHealthy: true,
+				websiteUrl: null,
+				apiUrl: "https://api.example.com",
+			};
+
+			await auditor.checkTeam("event-1", team, "normal");
+
+			expect(mockRepository.createHealthCheck).toHaveBeenCalledTimes(1);
+			expect(mockRepository.createHealthCheck).toHaveBeenCalledWith(
+				expect.objectContaining({ checkType: "api" }),
+			);
+			expect(mockRepository.updateTeamScore).toHaveBeenCalledWith(
+				"event-1",
+				"team-1",
+				100,
+			);
+		});
+
 		it("URL 未設定のチームはスキップするべき", async () => {
 			const team = {
 				eventId: "event-1",
@@ -281,6 +305,75 @@ describe("Auditor サービス", () => {
 			await auditor.runCheck();
 
 			expect(mockRepository.getGameState).not.toHaveBeenCalled();
+		});
+
+		it("チームのチェックが成功する場合 runCheck を正常に完了すべき", async () => {
+			vi.useRealTimers();
+			vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 200 }));
+			(auditor as unknown as { eventId: string }).eventId = "event-1";
+			mockRepository.getGameState.mockResolvedValue({
+				eventId: "event-1",
+				tenantId: "tenant-1",
+				isRunning: true,
+				scoreWeight: "normal",
+				blackout: false,
+				durationMinutes: 240,
+				startedAt: new Date().toISOString(),
+			});
+			mockRepository.listTeams.mockResolvedValue([
+				{
+					eventId: "event-1",
+					teamId: "team-1",
+					teamName: "テストチーム",
+					score: 0,
+					isHealthy: true,
+					websiteUrl: "https://example.com",
+					apiUrl: null,
+				},
+			]);
+			mockRepository.createHealthCheck.mockResolvedValue({});
+			mockRepository.updateTeamScore.mockResolvedValue(undefined);
+			mockRepository.updateTeamHealthy.mockResolvedValue(undefined);
+
+			await auditor.runCheck();
+
+			expect(mockRepository.createHealthCheck).toHaveBeenCalled();
+		});
+
+		it("チームのチェック中にエラーが発生しても runCheck を続行すべき", async () => {
+			vi.useRealTimers();
+			vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 200 }));
+			(auditor as unknown as { eventId: string }).eventId = "event-1";
+			mockRepository.getGameState.mockResolvedValue({
+				eventId: "event-1",
+				tenantId: "tenant-1",
+				isRunning: true,
+				scoreWeight: "normal",
+				blackout: false,
+				durationMinutes: 240,
+				startedAt: new Date().toISOString(),
+			});
+			mockRepository.listTeams.mockResolvedValue([
+				{
+					eventId: "event-1",
+					teamId: "team-1",
+					teamName: "テストチーム",
+					score: 0,
+					isHealthy: true,
+					websiteUrl: "https://example.com",
+					apiUrl: null,
+				},
+			]);
+			// createHealthCheck を失敗させて checkTeam を reject させる
+			mockRepository.createHealthCheck.mockRejectedValue(
+				new Error("DynamoDB write error"),
+			);
+			mockRepository.updateTeamScore.mockResolvedValue(undefined);
+			mockRepository.updateTeamHealthy.mockResolvedValue(undefined);
+
+			await auditor.runCheck();
+
+			expect(mockRepository.listTeams).toHaveBeenCalled();
 		});
 	});
 
@@ -486,6 +579,29 @@ describe("Auditor サービス", () => {
 
 			auditor.start("event-1");
 			auditor.start("event-1");
+
+			expect(auditor.isRunning()).toBe(true);
+		});
+
+		it("start 後の即時 runCheck がエラーでもクラッシュしないべき", async () => {
+			vi.useRealTimers();
+			mockRepository.getGameState.mockRejectedValue(new Error("DB error"));
+
+			auditor.start("event-1");
+
+			// 即時呼び出しの .catch が実行されることを確認（エラーが伝播しない）
+			await new Promise((resolve) => {
+				process.nextTick(resolve);
+			});
+			expect(auditor.isRunning()).toBe(true);
+		});
+
+		it("インターバル内の runCheck がエラーでもクラッシュしないべき", async () => {
+			mockRepository.getGameState.mockRejectedValue(new Error("DB error"));
+
+			auditor.start("event-1");
+			// インターバルを1回だけ進める
+			await vi.advanceTimersByTimeAsync(60_000);
 
 			expect(auditor.isRunning()).toBe(true);
 		});

--- a/backend/services/application-plane/gameday-service/src/services/dashboard-service.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/dashboard-service.test.ts
@@ -37,6 +37,7 @@ import {
 	getAttackStatistics,
 	getTeamDashboard,
 	joinTeamByInviteCode,
+	listTeams,
 	BlackoutActiveError,
 	TeamAlreadyExistsError,
 } from "./dashboard-service";
@@ -324,6 +325,32 @@ describe("ダッシュボードサービス", () => {
 			const result = await getAttackStatistics("event-1");
 			expect(result[0].successRate).toBe(0);
 		});
+
+		it("ログに含まれるチームが teams リストに存在しない場合は無視するべき", async () => {
+			mockRepository.listTeams.mockResolvedValue([
+				{
+					teamId: "team-1",
+					teamName: "A",
+					score: 0,
+					isHealthy: true,
+					websiteUrl: null,
+					apiUrl: null,
+				},
+			]);
+			// team-unknown は teams リストに存在しない
+			mockRepository.listAttackLogs.mockResolvedValue([
+				{
+					attackerTeamId: "team-unknown",
+					defenderTeamId: "team-unknown",
+					success: true,
+				},
+			]);
+
+			const result = await getAttackStatistics("event-1");
+			// team-1 の統計には影響なし
+			expect(result[0].attacksSent).toBe(0);
+			expect(result[0].attacksReceived).toBe(0);
+		});
 	});
 
 	// === チームダッシュボード ===
@@ -361,6 +388,29 @@ describe("ダッシュボードサービス", () => {
 
 			const result = await getTeamDashboard("event-1", "nonexistent");
 			expect(result).toBeNull();
+		});
+	});
+
+	// === チーム一覧取得 ===
+	describe("listTeams", () => {
+		it("チーム一覧を返すべき", async () => {
+			const teams = [
+				{
+					eventId: "event-1",
+					teamId: "team-1",
+					teamName: "チームA",
+					score: 5000,
+					isHealthy: true,
+					websiteUrl: null,
+					apiUrl: null,
+				},
+			];
+			mockRepository.listTeams.mockResolvedValue(teams);
+
+			const result = await listTeams("event-1");
+
+			expect(result).toEqual(teams);
+			expect(mockRepository.listTeams).toHaveBeenCalledWith("event-1");
 		});
 	});
 

--- a/backend/services/application-plane/gameday-service/src/services/game-controller.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/game-controller.test.ts
@@ -176,6 +176,17 @@ describe("ゲームコントローラーサービス", () => {
 			});
 		});
 
+		describe("リポジトリが null を返す場合", () => {
+			it("GameNotFoundError を投げるべき", async () => {
+				mockGamedayRepository.getGameState.mockResolvedValue(baseGameState);
+				mockGamedayRepository.stopGame.mockResolvedValue(null);
+
+				await expect(stopGame("event-1", TENANT_ID)).rejects.toThrow(
+					GameNotFoundError,
+				);
+			});
+		});
+
 		describe("別テナントのゲームにアクセスした場合", () => {
 			it("CrossTenantAccessError を投げるべき", async () => {
 				mockGamedayRepository.getGameState.mockResolvedValue(baseGameState);
@@ -245,6 +256,17 @@ describe("ゲームコントローラーサービス", () => {
 			});
 		});
 
+		describe("リポジトリが null を返す場合", () => {
+			it("GameNotFoundError を投げるべき", async () => {
+				mockGamedayRepository.getGameState.mockResolvedValue(baseGameState);
+				mockGamedayRepository.toggleScoreWeight.mockResolvedValue(null);
+
+				await expect(
+					toggleScoreWeight("event-1", TENANT_ID),
+				).rejects.toThrow(GameNotFoundError);
+			});
+		});
+
 		describe("別テナントのゲームにアクセスした場合", () => {
 			it("CrossTenantAccessError を投げるべき", async () => {
 				mockGamedayRepository.getGameState.mockResolvedValue(baseGameState);
@@ -279,6 +301,17 @@ describe("ゲームコントローラーサービス", () => {
 				await expect(toggleBlackout("nonexistent", TENANT_ID)).rejects.toThrow(
 					GameNotFoundError,
 				);
+			});
+		});
+
+		describe("リポジトリが null を返す場合", () => {
+			it("GameNotFoundError を投げるべき", async () => {
+				mockGamedayRepository.getGameState.mockResolvedValue(baseGameState);
+				mockGamedayRepository.toggleBlackout.mockResolvedValue(null);
+
+				await expect(
+					toggleBlackout("event-1", TENANT_ID),
+				).rejects.toThrow(GameNotFoundError);
 			});
 		});
 

--- a/backend/services/application-plane/gameday-service/src/services/participant-service.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/participant-service.test.ts
@@ -62,6 +62,7 @@ import {
 	executeAttack,
 	getAttackHistory,
 	getActiveAttacks,
+	getAllAttackLogs,
 	purchaseHint,
 	reportFix,
 	listTeamAlliances,
@@ -498,6 +499,71 @@ describe("プレーヤーサービス", () => {
 			});
 		});
 
+		describe("クールダウン後の場合", () => {
+			it("クールダウン済みであれば攻撃を実行すべき", async () => {
+				mockGamedayRepository.getGameState.mockResolvedValue(runningGame);
+				mockGamedayRepository.getAttack.mockResolvedValue(sampleAttack);
+				// lastUsedAt を十分過去の時刻に設定（cooldownSeconds=300 を超えている）
+				const oldTime = new Date(Date.now() - 600_000).toISOString();
+				mockGamedayRepository.getAttackPurchase.mockResolvedValue({
+					id: "p-1",
+					lastUsedAt: oldTime,
+				});
+				mockGamedayRepository.getTeamState.mockResolvedValue({
+					...sampleTeam,
+					teamId: "team-2",
+				});
+				mockGamedayRepository.getTeamVulnerability.mockResolvedValue(null);
+				mockGamedayRepository.updatePurchaseLastUsedAt.mockResolvedValue(undefined);
+				mockGamedayRepository.updateMultipleTeamScores.mockResolvedValue(undefined);
+				mockGamedayRepository.listTeamActiveAlliances.mockResolvedValue([]);
+				mockGamedayRepository.addAttackLog.mockResolvedValue({ id: "log-1" });
+
+				const result = await executeAttack(
+					"event-1",
+					"team-1",
+					"team-2",
+					"sql-injection",
+				);
+
+				expect(result).toBeDefined();
+			});
+		});
+
+		describe("非 vulnerability 攻撃の場合", () => {
+			it("脆弱性チェックなしで攻撃を実行すべき", async () => {
+				const chaosAttack = {
+					...sampleAttack,
+					attackType: "chaos" as const,
+					targetVulnerability: undefined,
+				};
+				mockGamedayRepository.getGameState.mockResolvedValue(runningGame);
+				mockGamedayRepository.getAttack.mockResolvedValue(chaosAttack);
+				mockGamedayRepository.getAttackPurchase.mockResolvedValue({
+					id: "p-1",
+					lastUsedAt: null,
+				});
+				mockGamedayRepository.getTeamState.mockResolvedValue({
+					...sampleTeam,
+					teamId: "team-2",
+				});
+				mockGamedayRepository.updatePurchaseLastUsedAt.mockResolvedValue(undefined);
+				mockGamedayRepository.updateMultipleTeamScores.mockResolvedValue(undefined);
+				mockGamedayRepository.listTeamActiveAlliances.mockResolvedValue([]);
+				mockGamedayRepository.addAttackLog.mockResolvedValue({ id: "log-1" });
+
+				const result = await executeAttack(
+					"event-1",
+					"team-1",
+					"team-2",
+					"chaos-attack",
+				);
+
+				expect(result).toBeDefined();
+				expect(mockGamedayRepository.getTeamVulnerability).not.toHaveBeenCalled();
+			});
+		});
+
 		describe("ターゲットチームが見つからない場合", () => {
 			it("TeamNotFoundError を投げるべき", async () => {
 				mockGamedayRepository.getGameState.mockResolvedValue(runningGame);
@@ -858,6 +924,28 @@ describe("プレーヤーサービス", () => {
 			mockGamedayRepository.listVotes.mockResolvedValue([]);
 			const result = await getVotingResults("event-1");
 			expect(result).toEqual([]);
+		});
+	});
+
+	// === 全攻撃ログ取得 ===
+	describe("getAllAttackLogs", () => {
+		it("全攻撃ログを返すべき", async () => {
+			const logs = [
+				{
+					id: "log-1",
+					eventId: "event-1",
+					attackerTeamId: "team-1",
+					defenderTeamId: "team-2",
+					attackSlug: "sql-injection",
+					success: true,
+				},
+			];
+			mockGamedayRepository.listAttackLogs.mockResolvedValue(logs);
+
+			const result = await getAllAttackLogs("event-1");
+
+			expect(result).toEqual(logs);
+			expect(mockGamedayRepository.listAttackLogs).toHaveBeenCalledWith("event-1");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- admin.test.ts: CrossTenantAccessError / GameNotFoundError / 予期しないエラーの分岐カバレッジを追加
- participant.test.ts: 不正 JSON・addMember 分岐・solo/my-membership エンドポイント・攻撃ログ統計の分岐を追加
- auditor-service.test.ts: setInterval エラーハンドラ・apiUrl 単独設定・runCheck 継続動作のテストを追加
- dashboard-service.test.ts: listTeams・unknown チームのログ無視のテストを追加
- game-controller.test.ts: stopGame/toggleScoreWeight/toggleBlackout の null 返却時テストを追加
- participant-service.test.ts: クールダウン後攻撃・非 vulnerability 攻撃・getAllAttackLogs のテストを追加

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| Statements | 91.58% | 99.87% |
| Branches | 85.45% | 99.48% |
| Functions | 90.44% | 100% |
| Lines | 91.86% | 100% |

## Test plan

- [x] `npx vitest run --coverage` がすべて通過 (99%+ 閾値をクリア)
- [x] `make before-commit` がすべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for admin API endpoints including cross-tenant access control, game-not-found scenarios, and error handling across multiple endpoints.
  * Expanded participant API test coverage for invalid input handling, membership operations, and error resilience.
  * Added test cases for auditor service team-check execution and lifecycle stability.
  * Improved dashboard service test coverage for team listing and attack statistics edge cases.
  * Added unit tests for game-controller state-change operations and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->