### PR TITLE
feat: イベントライフサイクル管理 UI を実装

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/__tests__/page.test.tsx
@@ -197,32 +197,54 @@ describe('イベント詳細ページ', () => {
     });
   });
 
-  it('予定ステータスで「開始する」ボタンが表示されるべき', async () => {
+  it('予定ステータスで「開始する」と「キャンセル」ボタンが表示されるべき', async () => {
     mockGet.mockResolvedValue({ ...mockEvent, status: 'scheduled' });
     render(<AdminEventDetailPage />);
     await waitFor(() => {
       expect(
         screen.getByRole('button', { name: '開始する' }),
       ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'キャンセル' }),
+      ).toBeInTheDocument();
     });
   });
 
-  it('開催中ステータスで「終了する」ボタンが表示されるべき', async () => {
+  it('開催中ステータスで「一時停止」と「終了する」ボタンが表示されるべき', async () => {
     mockGet.mockResolvedValue({ ...mockEvent, status: 'active' });
     render(<AdminEventDetailPage />);
     await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: '一時停止' }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: '終了する' }),
       ).toBeInTheDocument();
     });
   });
 
-  it('完了ステータスではステータス遷移ボタンが表示されないべき', async () => {
+  it('一時停止ステータスで「再開する」と「キャンセル」ボタンが表示されるべき', async () => {
+    mockGet.mockResolvedValue({ ...mockEvent, status: 'paused' });
+    render(<AdminEventDetailPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: '再開する' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'キャンセル' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('完了ステータスで「キャンセル」ボタンのみ表示されるべき', async () => {
     mockGet.mockResolvedValue({ ...mockEvent, status: 'completed' });
     render(<AdminEventDetailPage />);
     await waitFor(() => {
       expect(screen.getByText('テストイベント 2026')).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole('button', { name: 'キャンセル' }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: '公開する' }),
     ).not.toBeInTheDocument();
@@ -231,6 +253,20 @@ describe('イベント詳細ページ', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: '終了する' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('キャンセル済みステータスでは遷移ボタンが表示されないべき', async () => {
+    mockGet.mockResolvedValue({ ...mockEvent, status: 'cancelled' });
+    render(<AdminEventDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText('テストイベント 2026')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('button', { name: '公開する' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'キャンセル' }),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/page.tsx
@@ -46,6 +46,10 @@ function getStatusIndicator(status: EventStatus) {
       return <StatusIndicator type="pending">予定</StatusIndicator>;
     case 'completed':
       return <StatusIndicator type="stopped">終了</StatusIndicator>;
+    case 'paused':
+      return <StatusIndicator type="warning">一時停止</StatusIndicator>;
+    case 'cancelled':
+      return <StatusIndicator type="error">キャンセル</StatusIndicator>;
     case 'draft':
       return <StatusIndicator type="info">下書き</StatusIndicator>;
     default:
@@ -64,21 +68,38 @@ function getTypeBadge(type: string) {
   }
 }
 
+interface StatusAction {
+  label: string;
+  status: EventStatus;
+  variant: 'primary' | 'normal';
+}
+
 /**
- * 次のステータスを取得
+ * 現在のステータスから有効な遷移アクションを返す
  */
-function getNextStatus(
-  current: EventStatus,
-): { label: string; status: EventStatus } | null {
+function getStatusActions(current: EventStatus): StatusAction[] {
   switch (current) {
     case 'draft':
-      return { label: '公開する', status: 'scheduled' };
+      return [{ label: '公開する', status: 'scheduled', variant: 'primary' }];
     case 'scheduled':
-      return { label: '開始する', status: 'active' };
+      return [
+        { label: '開始する', status: 'active', variant: 'primary' },
+        { label: 'キャンセル', status: 'cancelled', variant: 'normal' },
+      ];
     case 'active':
-      return { label: '終了する', status: 'completed' };
+      return [
+        { label: '一時停止', status: 'paused', variant: 'normal' },
+        { label: '終了する', status: 'completed', variant: 'primary' },
+      ];
+    case 'paused':
+      return [
+        { label: '再開する', status: 'active', variant: 'primary' },
+        { label: 'キャンセル', status: 'cancelled', variant: 'normal' },
+      ];
+    case 'completed':
+      return [{ label: 'キャンセル', status: 'cancelled', variant: 'normal' }];
     default:
-      return null;
+      return [];
   }
 }
 
@@ -168,7 +189,7 @@ export default function AdminEventDetailPage() {
     );
   }
 
-  const nextAction = getNextStatus(event.status);
+  const actions = getStatusActions(event.status);
 
   return (
     <SpaceBetween size="l">
@@ -177,15 +198,16 @@ export default function AdminEventDetailPage() {
         variant="h1"
         actions={
           <SpaceBetween direction="horizontal" size="xs">
-            {nextAction && (
+            {actions.map((action) => (
               <Button
-                variant="primary"
+                key={action.status}
+                variant={action.variant}
                 loading={transitioning}
-                onClick={() => handleStatusTransition(nextAction.status)}
+                onClick={() => handleStatusTransition(action.status)}
               >
-                {nextAction.label}
+                {action.label}
               </Button>
-            )}
+            ))}
             <Button
               onClick={() => router.push(`/admin/events/${eventId}/edit`)}
             >

--- a/apps/application-plane/app/(admin)/admin/events/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/page.tsx
@@ -31,11 +31,13 @@ function getNextStatusAction(
 ): { label: string; nextStatus: EventStatus } | null {
   switch (status) {
     case 'draft':
-      return { label: '\u516c\u958b', nextStatus: 'scheduled' as EventStatus };
+      return { label: '公開', nextStatus: 'scheduled' };
     case 'scheduled':
-      return { label: '\u958b\u59cb', nextStatus: 'active' as EventStatus };
+      return { label: '開始', nextStatus: 'active' };
     case 'active':
-      return { label: '\u7d42\u4e86', nextStatus: 'completed' as EventStatus };
+      return { label: '終了', nextStatus: 'completed' };
+    case 'paused':
+      return { label: '再開', nextStatus: 'active' };
     default:
       return null;
   }
@@ -46,7 +48,9 @@ const STATUS_OPTIONS: SelectProps.Option[] = [
   { label: '下書き', value: 'draft' },
   { label: '予定', value: 'scheduled' },
   { label: '開催中', value: 'active' },
+  { label: '一時停止', value: 'paused' },
   { label: '終了', value: 'completed' },
+  { label: 'キャンセル', value: 'cancelled' },
 ];
 
 function getStatusIndicator(status: EventStatus) {
@@ -57,6 +61,10 @@ function getStatusIndicator(status: EventStatus) {
       return <StatusIndicator type="pending">予定</StatusIndicator>;
     case 'completed':
       return <StatusIndicator type="stopped">終了</StatusIndicator>;
+    case 'paused':
+      return <StatusIndicator type="warning">一時停止</StatusIndicator>;
+    case 'cancelled':
+      return <StatusIndicator type="error">キャンセル</StatusIndicator>;
     case 'draft':
       return <StatusIndicator type="info">下書き</StatusIndicator>;
     default:


### PR DESCRIPTION
## Summary

- イベント詳細ページで全ステータス遷移をサポート（draft/scheduled/active/paused/completed/cancelled）
- イベント一覧ページのステータスフィルターと遷移ボタンを拡張
- StatusIndicator に paused（一時停止）と cancelled（キャンセル）の表示を追���

### ステータス遷移マップ
```
draft → scheduled（公開する）
scheduled → active（開始する）/ cancelled（キャンセル）
active → paused（一時停止）/ completed（終了する）
paused → active（再開する）/ cancelled（キャンセル）
completed → cancelled（キャンセル）
cancelled → (遷移不可)
```

バックエンドの event-lifecycle.ts は既に全遷移をバリデーション済み。このPRはフロントエンドUIの対応。

## Test plan

- [x] 全ステータスの遷移ボタン表示テスト
- [x] `make before-commit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)