### PR TITLE
fix: gameday-seed スクリプトの修正

### DIFF
--- a/backend/services/application-plane/gameday-service/src/api/admin.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.test.ts
@@ -23,6 +23,12 @@ const mockGameController = vi.hoisted(() => {
 			this.name = "CrossTenantAccessError";
 		}
 	}
+	class GameAlreadyExistsError extends Error {
+		constructor(eventId: string) {
+			super(`ゲームは既に存在します: ${eventId}`);
+			this.name = "GameAlreadyExistsError";
+		}
+	}
 	return {
 		initGame: vi.fn(),
 		startGame: vi.fn(),
@@ -35,6 +41,7 @@ const mockGameController = vi.hoisted(() => {
 		listAttackLogs: vi.fn(),
 		seedAttackCatalog: vi.fn(),
 		GameNotFoundError,
+		GameAlreadyExistsError,
 		ConcurrentModificationError,
 		CrossTenantAccessError,
 	};
@@ -141,6 +148,40 @@ describe("管理者 API", () => {
 				expect(body.error).toBe("JSON の解析に失敗しました");
 			});
 		});
+
+		describe("ゲームが既に存在する場合", () => {
+			it("CONFLICT を返すべき", async () => {
+				mockGameController.startGame.mockRejectedValue(
+					new mockGameController.GameAlreadyExistsError("event-1"),
+				);
+
+				const res = await app.request("/game/start", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1", durationMinutes: 240 }),
+				});
+
+				expect(res.status).toBe(StatusCodes.CONFLICT);
+				const body = await res.json();
+				expect(body.error).toContain("既に存在します");
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.startGame.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/game/start", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ eventId: "event-1", durationMinutes: 240 }),
+				});
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+			});
+		});
 	});
 
 	describe("POST /game/init", () => {
@@ -212,6 +253,48 @@ describe("管理者 API", () => {
 				expect(res.status).toBe(StatusCodes.BAD_REQUEST);
 				const body = await res.json();
 				expect(body.error).toBe("JSON の解析に失敗しました");
+			});
+		});
+
+		describe("ゲームが既に存在する場合", () => {
+			it("CONFLICT を返すべき", async () => {
+				mockGameController.initGame.mockRejectedValue(
+					new mockGameController.GameAlreadyExistsError("event-1"),
+				);
+
+				const res = await app.request("/game/init", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						eventId: "event-1",
+						tenantId: "tenant-1",
+						durationMinutes: 240,
+					}),
+				});
+
+				expect(res.status).toBe(StatusCodes.CONFLICT);
+				const body = await res.json();
+				expect(body.error).toContain("既に存在します");
+			});
+		});
+
+		describe("予期しないエラーが発生した場合", () => {
+			it("INTERNAL_SERVER_ERROR を返すべき", async () => {
+				mockGameController.initGame.mockRejectedValue(
+					new Error("DB接続エラー"),
+				);
+
+				const res = await app.request("/game/init", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						eventId: "event-1",
+						tenantId: "tenant-1",
+						durationMinutes: 240,
+					}),
+				});
+
+				expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
 			});
 		});
 	});

--- a/backend/services/application-plane/gameday-service/src/api/admin.ts
+++ b/backend/services/application-plane/gameday-service/src/api/admin.ts
@@ -20,6 +20,7 @@ import {
 	listAttackLogs,
 	seedAttackCatalog,
 	GameNotFoundError,
+	GameAlreadyExistsError,
 	ConcurrentModificationError,
 	CrossTenantAccessError,
 } from "../services/game-controller";
@@ -47,13 +48,20 @@ adminRoutes.post("/game/start", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const tenantId = c.get("auth").tenantId;
-	const result = await startGame(
-		parsed.data.eventId,
-		tenantId,
-		parsed.data.durationMinutes,
-	);
-	return c.json(result, StatusCodes.CREATED);
+	try {
+		const tenantId = c.get("auth").tenantId;
+		const result = await startGame(
+			parsed.data.eventId,
+			tenantId,
+			parsed.data.durationMinutes,
+		);
+		return c.json(result, StatusCodes.CREATED);
+	} catch (error) {
+		if (error instanceof GameAlreadyExistsError) {
+			return c.json({ error: error.message }, StatusCodes.CONFLICT);
+		}
+		throw error;
+	}
 });
 
 // ゲーム初期化（isRunning: false で作成、イベント作成時に自動呼び出し）
@@ -72,12 +80,19 @@ adminRoutes.post("/game/init", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const result = await initGame(
-		parsed.data.eventId,
-		parsed.data.tenantId,
-		parsed.data.durationMinutes,
-	);
-	return c.json(result, StatusCodes.CREATED);
+	try {
+		const result = await initGame(
+			parsed.data.eventId,
+			parsed.data.tenantId,
+			parsed.data.durationMinutes,
+		);
+		return c.json(result, StatusCodes.CREATED);
+	} catch (error) {
+		if (error instanceof GameAlreadyExistsError) {
+			return c.json({ error: error.message }, StatusCodes.CONFLICT);
+		}
+		throw error;
+	}
 });
 
 // ゲーム停止

--- a/backend/services/application-plane/gameday-service/src/services/game-controller.ts
+++ b/backend/services/application-plane/gameday-service/src/services/game-controller.ts
@@ -1,5 +1,8 @@
 import { gamedayRepository } from "../lib/dynamodb";
-import { ConcurrentModificationError } from "../repositories/gameday-repository";
+import {
+	ConcurrentModificationError,
+	GameAlreadyExistsError,
+} from "../repositories/gameday-repository";
 import {
 	validateTenantAccess,
 	CrossTenantAccessError,
@@ -11,6 +14,7 @@ import { DEFAULT_ATTACKS } from "../data/default-attacks";
 import { ulid } from "ulid";
 
 export { ConcurrentModificationError };
+export { GameAlreadyExistsError };
 export { CrossTenantAccessError };
 
 export class GameNotFoundError extends Error {

--- a/scripts/gameday-seed.sh
+++ b/scripts/gameday-seed.sh
@@ -36,8 +36,23 @@ fi
 echo "✅ GameDay サービスに接続しました"
 echo ""
 
-# 1. 攻撃カタログをシード
-echo "📦 ステップ 1/4: 攻撃カタログをシード中..."
+# 1. ゲーム初期化（isRunning: false でゲーム状態を作成）
+echo "📦 ステップ 1/5: ゲームを初期化中..."
+TENANT_ID="${TENANT_ID:-dev-tenant}"
+INIT_RESULT=$(curl -sf -X POST "$GAMEDAY_API/admin/game/init" \
+  -H "Content-Type: application/json" \
+  -d "{\"eventId\": \"$EVENT_ID\", \"tenantId\": \"$TENANT_ID\", \"durationMinutes\": $DURATION}" 2>&1) || {
+  # 既に初期化済みの場合は続行
+  echo "  ⏭️  ゲームは既に初期化されています"
+  INIT_RESULT=""
+}
+if [ -n "$INIT_RESULT" ]; then
+  echo "✅ ゲームを初期化しました (tenantId: $TENANT_ID)"
+fi
+
+# 2. 攻撃カタログをシード
+echo ""
+echo "📦 ステップ 2/5: 攻撃カタログをシード中..."
 SEED_RESULT=$(curl -sf -X POST "$GAMEDAY_API/admin/attacks/seed" \
   -H "Content-Type: application/json" \
   -d "{\"eventId\": \"$EVENT_ID\"}" 2>&1) || {
@@ -48,9 +63,9 @@ SEED_RESULT=$(curl -sf -X POST "$GAMEDAY_API/admin/attacks/seed" \
 SEEDED=$(echo "$SEED_RESULT" | grep -o '"seeded":[0-9]*' | grep -o '[0-9]*')
 echo "✅ ${SEEDED:-?} 個の攻撃をシードしました"
 
-# 2. チーム登録
+# 3. チーム登録
 echo ""
-echo "📦 ステップ 2/4: デモチームを登録中..."
+echo "📦 ステップ 3/5: デモチームを登録中..."
 
 register_team() {
   local team_id="$1"
@@ -78,9 +93,9 @@ register_team "team-charlie" "Team Charlie"
 register_team "team-9" "Team 9"
 register_team "red-xiii" "レッドXIII"
 
-# 3. ゲーム開始
+# 4. ゲーム開始
 echo ""
-echo "📦 ステップ 3/4: ゲームを開始中 (${DURATION}分)..."
+echo "📦 ステップ 4/5: ゲームを開始中 (${DURATION}分)..."
 START_RESULT=$(curl -sf -X POST "$GAMEDAY_API/admin/game/start" \
   -H "Content-Type: application/json" \
   -d "{\"eventId\": \"$EVENT_ID\", \"durationMinutes\": $DURATION}" 2>&1) || {
@@ -92,9 +107,9 @@ if [ -n "$START_RESULT" ]; then
   echo "✅ ゲームを開始しました"
 fi
 
-# 4. 状態確認
+# 5. 状態確認
 echo ""
-echo "📦 ステップ 4/4: 状態を確認中..."
+echo "📦 ステップ 5/5: 状態を確認中..."
 STATUS=$(curl -sf "$GAMEDAY_API/admin/game/status?eventId=$EVENT_ID" 2>&1)
 IS_RUNNING=$(echo "$STATUS" | grep -o '"isRunning":true' || echo "")
 if [ -n "$IS_RUNNING" ]; then


### PR DESCRIPTION
## Summary

- ゲーム初期化欠落と GameAlreadyExistsError 未処理を修正
- `make gameday-seed` が正常に完了するようになる

Closes: fix: gameday-seed スクリプトの修正

## Test plan

- [x] `make before-commit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for game operations: HTTP 409 Conflict is now returned when attempting to initialize or start an already-existing game.
  * Fixed generic error handling to properly return HTTP 500 Internal Server Error.

* **Tests**
  * Extended test coverage for conflict scenarios and error handling in game operations.

* **Chores**
  * Updated seeding script to initialize the game before seeding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->