### PR TITLE
feat: GameDay チュートリアル・レポート・チェックリスト

### DIFF
--- a/apps/application-plane/app/(admin)/admin/gameday/[eventId]/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/[eventId]/__tests__/page.test.tsx
@@ -141,4 +141,142 @@ describe('AdminGamedayControlPage', () => {
       expect(screen.getByText(/イベント ID: ev-1/)).toBeInTheDocument();
     });
   });
+
+  describe('開始前チェックリスト', () => {
+    it('チェックリスト項目を表示すべき', async () => {
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('開始前チェックリスト')).toBeInTheDocument();
+      });
+    });
+
+    it('チェック項目がすべて失敗の場合ゲーム開始ボタンを無効にすべき', async () => {
+      mockGetGameStatus.mockResolvedValue(baseGameState);
+      mockGetTeams.mockResolvedValue({ teams: [] });
+      mockGetAttackCatalog.mockResolvedValue({ attacks: [] });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('ゲーム開始')).toBeInTheDocument();
+      });
+
+      const startButton = screen.getByText('ゲーム開始').closest('button');
+      expect(startButton).toBeDisabled();
+    });
+
+    it('チーム不足の場合エラー表示すべき', async () => {
+      mockGetTeams.mockResolvedValue({
+        teams: [{ teamId: 't1', teamName: 'Team 1', eventId: 'ev-1' }],
+      });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'チームが2チーム以上必要です（チーム管理タブで登録）',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('攻撃カタログ未登録の場合エラー表示すべき', async () => {
+      mockGetAttackCatalog.mockResolvedValue({ attacks: [] });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('攻撃カタログが未登録です（攻撃管理タブで生成）'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('すべてのチェックが通った場合ゲーム開始ボタンを有効にすべき', async () => {
+      mockGetGameStatus.mockResolvedValue(baseGameState);
+      mockGetTeams.mockResolvedValue({
+        teams: [
+          { teamId: 't1', teamName: 'Team 1', eventId: 'ev-1' },
+          { teamId: 't2', teamName: 'Team 2', eventId: 'ev-1' },
+        ],
+      });
+      mockGetAttackCatalog.mockResolvedValue({
+        attacks: [
+          {
+            id: 'a1',
+            name: 'Attack 1',
+            slug: 'attack-1',
+            attackType: 'vulnerability',
+            targetVulnerability: null,
+            description: 'desc',
+            purchaseCost: 10,
+            damage: 5,
+            reward: 3,
+            cooldownSeconds: 60,
+            defenseHint: 'hint',
+            hintCost: 5,
+          },
+        ],
+      });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('ゲーム開始')).toBeInTheDocument();
+      });
+
+      const startButton = screen.getByText('ゲーム開始').closest('button');
+      expect(startButton).not.toBeDisabled();
+    });
+
+    it('チェック未達の場合警告アラートを表示すべき', async () => {
+      mockGetTeams.mockResolvedValue({ teams: [] });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'すべてのチェック項目を満たすまでゲームを開始できません',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('すべてのチェックが通った場合警告アラートを非表示にすべき', async () => {
+      mockGetGameStatus.mockResolvedValue(baseGameState);
+      mockGetTeams.mockResolvedValue({
+        teams: [
+          { teamId: 't1', teamName: 'Team 1', eventId: 'ev-1' },
+          { teamId: 't2', teamName: 'Team 2', eventId: 'ev-1' },
+        ],
+      });
+      mockGetAttackCatalog.mockResolvedValue({
+        attacks: [
+          {
+            id: 'a1',
+            name: 'Attack 1',
+            slug: 'attack-1',
+            attackType: 'vulnerability',
+            targetVulnerability: null,
+            description: 'desc',
+            purchaseCost: 10,
+            damage: 5,
+            reward: 3,
+            cooldownSeconds: 60,
+            defenseHint: 'hint',
+            hintCost: 5,
+          },
+        ],
+      });
+      render(<AdminGamedayControlPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('開始前チェックリスト')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(
+          'すべてのチェック項目を満たすまでゲームを開始できません',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/application-plane/app/(admin)/admin/gameday/[eventId]/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/[eventId]/page.tsx
@@ -6,6 +6,7 @@
 
 'use client';
 
+import Alert from '@cloudscape-design/components/alert';
 import Badge from '@cloudscape-design/components/badge';
 import Box from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
@@ -229,6 +230,11 @@ export default function AdminGamedayControlPage() {
     return Math.max(0, totalSeconds - elapsedSeconds);
   };
 
+  const hasEnoughTeams = teams.length >= 2;
+  const hasAttacks = attacks.length > 0;
+  const hasGameState = gameState !== null;
+  const allChecksPassed = hasEnoughTeams && hasAttacks && hasGameState;
+
   if (loading) {
     return (
       <Box textAlign="center" padding="l">
@@ -260,6 +266,34 @@ export default function AdminGamedayControlPage() {
             id: 'control',
             content: (
               <SpaceBetween size="l">
+                <Container
+                  header={<Header variant="h2">開始前チェックリスト</Header>}
+                >
+                  <SpaceBetween size="s">
+                    <StatusIndicator
+                      type={hasEnoughTeams ? 'success' : 'error'}
+                    >
+                      {hasEnoughTeams
+                        ? `チーム登録済み（${teams.length}チーム）`
+                        : 'チームが2チーム以上必要です（チーム管理タブで登録）'}
+                    </StatusIndicator>
+                    <StatusIndicator type={hasAttacks ? 'success' : 'error'}>
+                      {hasAttacks
+                        ? `攻撃カタログ登録済み（${attacks.length}件）`
+                        : '攻撃カタログが未登録です（攻撃管理タブで生成）'}
+                    </StatusIndicator>
+                    <StatusIndicator type={hasGameState ? 'success' : 'error'}>
+                      {hasGameState
+                        ? 'ゲーム状態初期化済み'
+                        : 'ゲーム状態が未初期化です'}
+                    </StatusIndicator>
+                    {!allChecksPassed && (
+                      <Alert type="warning">
+                        すべてのチェック項目を満たすまでゲームを開始できません
+                      </Alert>
+                    )}
+                  </SpaceBetween>
+                </Container>
                 <Container
                   header={
                     <Header
@@ -325,6 +359,7 @@ export default function AdminGamedayControlPage() {
                             <Button
                               variant="primary"
                               loading={actionLoading}
+                              disabled={!allChecksPassed}
                               onClick={() =>
                                 handleAction(() =>
                                   startGame(

--- a/apps/application-plane/app/(admin)/admin/gameday/[eventId]/report/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/[eventId]/report/__tests__/page.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import GameDayReportPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantId: vi.fn().mockReturnValue('test-tenant'),
+  useTenantOptional: () => null,
+}));
+
+const mockGetGameStatus = vi.fn();
+const mockGetTeams = vi.fn();
+
+vi.mock('@/lib/api/gameday-admin', () => ({
+  getGameStatus: (...args: unknown[]) => mockGetGameStatus(...args),
+  getTeams: (...args: unknown[]) => mockGetTeams(...args),
+}));
+
+const mockGamedayRequest = vi.fn();
+vi.mock('@/lib/api/gameday', () => ({
+  gamedayRequest: (...args: unknown[]) => mockGamedayRequest(...args),
+}));
+
+const baseGameState = {
+  eventId: 'ev-1',
+  tenantId: 'test-tenant',
+  isRunning: false,
+  blackout: false,
+  scoreWeight: 'normal' as const,
+  durationMinutes: 60,
+  startedAt: '2026-04-06T10:00:00Z',
+};
+
+const sampleLeaderboard = [
+  {
+    teamId: 'team-1',
+    teamName: 'Alpha',
+    score: 500,
+    rank: 1,
+    attacksLaunched: 10,
+    attacksReceived: 3,
+    vulnerabilitiesFixed: 5,
+  },
+  {
+    teamId: 'team-2',
+    teamName: 'Bravo',
+    score: 300,
+    rank: 2,
+    attacksLaunched: 7,
+    attacksReceived: 5,
+    vulnerabilitiesFixed: 2,
+  },
+];
+
+const sampleAttackStats = [
+  {
+    attackSlug: 'sql-injection',
+    attackName: 'SQL Injection',
+    totalExecutions: 15,
+    successRate: 0.8,
+  },
+  {
+    attackSlug: 'xss',
+    attackName: 'Cross-Site Scripting',
+    totalExecutions: 10,
+    successRate: 0.6,
+  },
+];
+
+describe('GameDayReportPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGameStatus.mockResolvedValue(baseGameState);
+    mockGetTeams.mockResolvedValue({
+      teams: [
+        { eventId: 'ev-1', teamId: 'team-1', teamName: 'Alpha' },
+        { eventId: 'ev-1', teamId: 'team-2', teamName: 'Bravo' },
+      ],
+    });
+    mockGamedayRequest.mockImplementation((endpoint: string) => {
+      if (endpoint === '/dashboard/leaderboard') {
+        return Promise.resolve({ leaderboard: sampleLeaderboard });
+      }
+      if (endpoint === '/dashboard/attack-stats') {
+        return Promise.resolve({ stats: sampleAttackStats });
+      }
+      return Promise.reject(new Error('Unknown endpoint'));
+    });
+  });
+
+  it('レポートタイトルを表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('GameDay レポート')).toBeInTheDocument();
+    });
+  });
+
+  it('イベントIDを表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/イベント ID: ev-1/)).toBeInTheDocument();
+    });
+  });
+
+  it('ランキングテーブルを表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('最終ランキング')).toBeInTheDocument();
+      expect(screen.getByText(/\(2\)/)).toBeInTheDocument();
+    });
+  });
+
+  it('攻撃統計を表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('攻撃使用回数ランキング')).toBeInTheDocument();
+      expect(screen.getByText('攻撃成功率ランキング')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('SQL Injection').length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getAllByText('Cross-Site Scripting').length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('CSVダウンロードボタンが存在すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      const buttons = screen.getAllByText('CSV ダウンロード');
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('ローディング中はスピナーを表示すべき', () => {
+    mockGetGameStatus.mockReturnValue(new Promise(() => {}));
+    render(<GameDayReportPage />);
+    expect(screen.queryByText('GameDay レポート')).not.toBeInTheDocument();
+  });
+
+  it('APIエラー時にエラーメッセージを表示すべき', async () => {
+    mockGetGameStatus.mockRejectedValue(
+      new Error('レポートの取得に失敗しました'),
+    );
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('レポートの取得に失敗しました'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('イベント概要セクションを表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('イベント概要')).toBeInTheDocument();
+    });
+  });
+
+  it('チームパフォーマンスサマリーを表示すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('チームパフォーマンスサマリー'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('コントロールパネルに戻るボタンが存在すべき', async () => {
+    render(<GameDayReportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('コントロールパネルに戻る')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/application-plane/app/(admin)/admin/gameday/[eventId]/report/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/[eventId]/report/page.tsx
@@ -1,0 +1,476 @@
+/**
+ * Post-Game Report Page
+ *
+ * Cloudscape Design System - GameDay 終了後レポート
+ * 経営層向けに結果を共有するためのレポートページ
+ */
+
+'use client';
+
+import Badge from '@cloudscape-design/components/badge';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+import { gamedayRequest } from '@/lib/api/gameday';
+import type {
+  AttackStats,
+  GameState,
+  LeaderboardEntry,
+} from '@/lib/api/gameday-types';
+import { getGameStatus, getTeams } from '@/lib/api/gameday-admin';
+import type { Team } from '@/lib/api/gameday-types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ReportData {
+  gameState: GameState;
+  teams: Team[];
+  leaderboard: LeaderboardEntry[];
+  attackStats: AttackStats[];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function generateCsv(leaderboard: LeaderboardEntry[]): string {
+  const header = [
+    '順位',
+    'チーム名',
+    '最終スコア',
+    '攻撃実行数',
+    '被攻撃数',
+    '脆弱性修正数',
+  ].join(',');
+
+  const rows = leaderboard.map((entry) =>
+    [
+      entry.rank,
+      `"${entry.teamName.replace(/"/g, '""')}"`,
+      entry.score,
+      entry.attacksLaunched,
+      entry.attacksReceived,
+      entry.vulnerabilitiesFixed,
+    ].join(','),
+  );
+
+  return [header, ...rows].join('\n');
+}
+
+function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function getTeamPerformanceSummary(entry: LeaderboardEntry): string {
+  const parts: string[] = [];
+
+  if (entry.rank === 1) {
+    parts.push('総合優勝');
+  } else if (entry.rank <= 3) {
+    parts.push(`総合${entry.rank}位入賞`);
+  }
+
+  if (entry.attacksLaunched > 0) {
+    parts.push(`${entry.attacksLaunched}回の攻撃を実行`);
+  }
+
+  if (entry.vulnerabilitiesFixed > 0) {
+    parts.push(`${entry.vulnerabilitiesFixed}件の脆弱性を修正`);
+  }
+
+  if (entry.attacksReceived > 0) {
+    parts.push(`${entry.attacksReceived}回の攻撃を受けた`);
+  }
+
+  if (parts.length === 0) {
+    parts.push('活動なし');
+  }
+
+  return parts.join(' / ');
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export default function GameDayReportPage() {
+  const params = useParams();
+  const router = useRouter();
+  const eventId = params.eventId as string;
+
+  const [data, setData] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchReport = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const [gameState, teamsData, leaderboardData, attackStatsData] =
+        await Promise.all([
+          getGameStatus(eventId),
+          getTeams(eventId),
+          gamedayRequest<{ leaderboard: LeaderboardEntry[] }>(
+            '/dashboard/leaderboard',
+            { params: { eventId } },
+          ),
+          gamedayRequest<{ stats: AttackStats[] }>('/dashboard/attack-stats', {
+            params: { eventId },
+          }),
+        ]);
+
+      setData({
+        gameState,
+        teams: teamsData.teams,
+        leaderboard: leaderboardData.leaderboard,
+        attackStats: attackStatsData.stats,
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'レポートの取得に失敗しました',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchReport();
+  }, [fetchReport]);
+
+  const handleCsvDownload = () => {
+    if (!data) return;
+    const csv = generateCsv(data.leaderboard);
+    downloadCsv(csv, `gameday-report-${eventId}.csv`);
+  };
+
+  if (loading) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" padding="xl">
+        <SpaceBetween size="m">
+          <StatusIndicator type="error">{error}</StatusIndicator>
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={() => router.push(`/admin/gameday/${eventId}`)}>
+              コントロールパネルに戻る
+            </Button>
+            <Button onClick={fetchReport}>再読み込み</Button>
+          </SpaceBetween>
+        </SpaceBetween>
+      </Box>
+    );
+  }
+
+  if (!data) return null;
+
+  const { gameState, teams, leaderboard, attackStats } = data;
+
+  const sortedByCount = [...attackStats].sort(
+    (a, b) => b.totalExecutions - a.totalExecutions,
+  );
+  const sortedBySuccess = [...attackStats].sort(
+    (a, b) => b.successRate - a.successRate,
+  );
+
+  const durationText = `${gameState.durationMinutes}分`;
+
+  return (
+    <SpaceBetween size="l">
+      {/* Header */}
+      <Header
+        variant="h1"
+        description={`イベント ID: ${eventId}`}
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button iconName="download" onClick={handleCsvDownload}>
+              CSV ダウンロード
+            </Button>
+            <Button onClick={() => router.push(`/admin/gameday/${eventId}`)}>
+              コントロールパネルに戻る
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        GameDay レポート
+      </Header>
+
+      {/* Event Summary */}
+      <Container header={<Header variant="h2">イベント概要</Header>}>
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValuePairs
+            items={[
+              { label: 'イベント ID', value: eventId },
+              { label: '設定時間', value: durationText },
+              {
+                label: '参加チーム数',
+                value: `${teams.length} チーム`,
+              },
+            ]}
+          />
+          <KeyValuePairs
+            items={[
+              {
+                label: '開始時刻',
+                value: gameState.startedAt
+                  ? formatDateTime(gameState.startedAt)
+                  : '-',
+              },
+              {
+                label: 'ゲーム状態',
+                value: gameState.isRunning ? (
+                  <StatusIndicator type="success">稼働中</StatusIndicator>
+                ) : (
+                  <StatusIndicator type="stopped">終了</StatusIndicator>
+                ),
+              },
+              {
+                label: 'スコア重み',
+                value:
+                  gameState.scoreWeight === 'high' ? (
+                    <Badge color="blue">2x</Badge>
+                  ) : (
+                    '通常'
+                  ),
+              },
+            ]}
+          />
+        </ColumnLayout>
+      </Container>
+
+      {/* Final Rankings Table */}
+      <Table
+        header={
+          <Header
+            variant="h2"
+            counter={`(${leaderboard.length})`}
+            actions={
+              <Button iconName="download" onClick={handleCsvDownload}>
+                CSV ダウンロード
+              </Button>
+            }
+          >
+            最終ランキング
+          </Header>
+        }
+        items={leaderboard}
+        empty={
+          <Box textAlign="center" padding="l">
+            <Box variant="p" color="text-body-secondary">
+              ランキングデータがありません
+            </Box>
+          </Box>
+        }
+        columnDefinitions={[
+          {
+            id: 'rank',
+            header: '順位',
+            cell: (item) => item.rank,
+            sortingField: 'rank',
+          },
+          {
+            id: 'teamName',
+            header: 'チーム名',
+            cell: (item) => (
+              <Box fontWeight={item.rank <= 3 ? 'bold' : 'normal'}>
+                {item.teamName}
+              </Box>
+            ),
+            sortingField: 'teamName',
+          },
+          {
+            id: 'score',
+            header: '最終スコア',
+            cell: (item) => `${item.score} pts`,
+            sortingField: 'score',
+          },
+          {
+            id: 'attacksLaunched',
+            header: '攻撃実行数',
+            cell: (item) => item.attacksLaunched,
+            sortingField: 'attacksLaunched',
+          },
+          {
+            id: 'attacksReceived',
+            header: '被攻撃数',
+            cell: (item) => item.attacksReceived,
+            sortingField: 'attacksReceived',
+          },
+          {
+            id: 'vulnerabilitiesFixed',
+            header: '脆弱性修正数',
+            cell: (item) => item.vulnerabilitiesFixed,
+            sortingField: 'vulnerabilitiesFixed',
+          },
+        ]}
+      />
+
+      {/* Attack Statistics */}
+      <ColumnLayout columns={2}>
+        <Container
+          header={<Header variant="h2">攻撃使用回数ランキング</Header>}
+        >
+          <Table
+            items={sortedByCount}
+            empty={
+              <Box textAlign="center" padding="l">
+                <Box variant="p" color="text-body-secondary">
+                  攻撃統計がありません
+                </Box>
+              </Box>
+            }
+            columnDefinitions={[
+              {
+                id: 'attackName',
+                header: '攻撃名',
+                cell: (item) => item.attackName,
+              },
+              {
+                id: 'totalExecutions',
+                header: '実行回数',
+                cell: (item) => item.totalExecutions,
+              },
+              {
+                id: 'successRate',
+                header: '成功率',
+                cell: (item) => `${Math.round(item.successRate * 100)}%`,
+              },
+            ]}
+          />
+        </Container>
+
+        <Container header={<Header variant="h2">攻撃成功率ランキング</Header>}>
+          <Table
+            items={sortedBySuccess}
+            empty={
+              <Box textAlign="center" padding="l">
+                <Box variant="p" color="text-body-secondary">
+                  攻撃統計がありません
+                </Box>
+              </Box>
+            }
+            columnDefinitions={[
+              {
+                id: 'attackName',
+                header: '攻撃名',
+                cell: (item) => item.attackName,
+              },
+              {
+                id: 'successRate',
+                header: '成功率',
+                cell: (item) => `${Math.round(item.successRate * 100)}%`,
+              },
+              {
+                id: 'totalExecutions',
+                header: '実行回数',
+                cell: (item) => item.totalExecutions,
+              },
+            ]}
+          />
+        </Container>
+      </ColumnLayout>
+
+      {/* Team Performance Summary */}
+      <Container
+        header={<Header variant="h2">チームパフォーマンスサマリー</Header>}
+      >
+        <SpaceBetween size="m">
+          {leaderboard.map((entry) => (
+            <Container
+              key={entry.teamId}
+              header={
+                <Header
+                  variant="h3"
+                  info={
+                    <Badge
+                      color={
+                        entry.rank === 1
+                          ? 'blue'
+                          : entry.rank <= 3
+                            ? 'green'
+                            : 'grey'
+                      }
+                    >
+                      {entry.rank}位
+                    </Badge>
+                  }
+                >
+                  {entry.teamName}
+                </Header>
+              }
+            >
+              <ColumnLayout columns={4} variant="text-grid">
+                <div>
+                  <Box variant="awsui-key-label">最終スコア</Box>
+                  <Box fontSize="heading-l" fontWeight="bold">
+                    {entry.score} pts
+                  </Box>
+                </div>
+                <div>
+                  <Box variant="awsui-key-label">攻撃実行</Box>
+                  <Box>{entry.attacksLaunched}回</Box>
+                </div>
+                <div>
+                  <Box variant="awsui-key-label">被攻撃</Box>
+                  <Box>{entry.attacksReceived}回</Box>
+                </div>
+                <div>
+                  <Box variant="awsui-key-label">脆弱性修正</Box>
+                  <Box>{entry.vulnerabilitiesFixed}件</Box>
+                </div>
+              </ColumnLayout>
+              <Box margin={{ top: 's' }}>
+                <Box variant="awsui-key-label">パフォーマンス概要</Box>
+                <Box>{getTeamPerformanceSummary(entry)}</Box>
+              </Box>
+            </Container>
+          ))}
+          {leaderboard.length === 0 && (
+            <Box textAlign="center" padding="l">
+              <Box variant="p" color="text-body-secondary">
+                チームデータがありません
+              </Box>
+            </Box>
+          )}
+        </SpaceBetween>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -69,6 +69,11 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
           text: t('gameday.scoreboard'),
           href: `${basePath}/scoreboard`,
         },
+        {
+          type: 'link',
+          text: t('gameday.tutorial'),
+          href: `${basePath}/tutorial`,
+        },
       ],
     },
     {
@@ -133,6 +138,7 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
       '/attack',
       '/alliance',
       '/vote',
+      '/tutorial',
     ];
     for (const suffix of suffixes) {
       if (pathname.startsWith(`${basePath}${suffix}`))

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/tutorial/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/tutorial/__tests__/page.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TutorialPage from '../page';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/lib/hooks/use-gameday-session', () => ({
+  useGamedaySession: () => ({
+    eventId: 'ev-1',
+    teamId: 'team-1',
+    teamName: 'TeamAlpha',
+  }),
+}));
+
+describe('TutorialPage', () => {
+  it('ページタイトルを表示すべき', () => {
+    render(<TutorialPage />);
+    expect(screen.getByText('ルール & チュートリアル')).toBeInTheDocument();
+  });
+
+  it('スコアリングテーブルを表示すべき', () => {
+    render(<TutorialPage />);
+    expect(screen.getByText('10,000')).toBeInTheDocument();
+    expect(screen.getByText('+1,000')).toBeInTheDocument();
+    expect(screen.getByText('-3,000')).toBeInTheDocument();
+    expect(screen.getByText('+1,500')).toBeInTheDocument();
+    expect(screen.getByText('+200')).toBeInTheDocument();
+  });
+
+  it('ステップバイステップガイドを表示すべき', () => {
+    render(<TutorialPage />);
+    expect(screen.getByText('Step 1')).toBeInTheDocument();
+    expect(screen.getByText('Step 2')).toBeInTheDocument();
+    expect(screen.getByText('Step 3')).toBeInTheDocument();
+    expect(screen.getByText('Step 4')).toBeInTheDocument();
+    expect(screen.getByText('Step 5')).toBeInTheDocument();
+    expect(screen.getByText('Step 6')).toBeInTheDocument();
+  });
+
+  it('キーコンセプトを表示すべき', () => {
+    render(<TutorialPage />);
+    expect(screen.getByText('Cooldown')).toBeInTheDocument();
+    expect(screen.getByText('Blackout')).toBeInTheDocument();
+    expect(screen.getByText('Score Weight')).toBeInTheDocument();
+    expect(screen.getByText('Alliance')).toBeInTheDocument();
+  });
+
+  it('ゲーム概要セクションを表示すべき', () => {
+    render(<TutorialPage />);
+    expect(screen.getByText('GameDay とは？')).toBeInTheDocument();
+  });
+});

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/tutorial/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/tutorial/page.tsx
@@ -1,0 +1,248 @@
+/**
+ * Tutorial / Rules Page (ルール & チュートリアル)
+ *
+ * Cloudscape Design System — GameDay のルール、スコアリング、遊び方を解説する静的ページ
+ */
+
+'use client';
+
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Icon from '@cloudscape-design/components/icon';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
+
+interface ScoreRow {
+  action: string;
+  points: string;
+  description: string;
+  type: 'positive' | 'negative' | 'neutral';
+}
+
+const SCORING_TABLE: ScoreRow[] = [
+  {
+    action: '初期ポイント',
+    points: '10,000',
+    description: 'ゲーム開始時にすべてのチームに付与されます',
+    type: 'neutral',
+  },
+  {
+    action: '攻撃成功',
+    points: '+1,000',
+    description: '他チームへの攻撃が成功した時の報酬（同盟チームと分配）',
+    type: 'positive',
+  },
+  {
+    action: '攻撃被弾',
+    points: '-1,000',
+    description: '他チームから攻撃を受けた時のダメージ',
+    type: 'negative',
+  },
+  {
+    action: '防御修正',
+    points: '+1,500',
+    description: '脆弱性を修正して防御に成功した時の報酬',
+    type: 'positive',
+  },
+  {
+    action: '攻撃購入',
+    points: '-3,000',
+    description: '攻撃カタログからアイテムを購入するコスト',
+    type: 'negative',
+  },
+  {
+    action: 'ヘルスチェック通過',
+    points: '+200',
+    description: 'サービスが稼働している場合、定期チェックごとに加算',
+    type: 'positive',
+  },
+  {
+    action: 'ヘルスチェック失敗（通常）',
+    points: '-100',
+    description: 'サービスがダウンしている場合のペナルティ',
+    type: 'negative',
+  },
+  {
+    action: 'ヘルスチェック失敗（2x モード）',
+    points: '-1,000',
+    description: '管理者が 2x ペナルティモードを有効にしている場合',
+    type: 'negative',
+  },
+];
+
+interface Step {
+  number: string;
+  title: string;
+  description: string;
+}
+
+const STEPS: Step[] = [
+  {
+    number: 'Step 1',
+    title: 'URL を設定する',
+    description:
+      'チームの Website URL と API URL を司令部ページで登録してください。ヘルスチェックの対象になります。',
+  },
+  {
+    number: 'Step 2',
+    title: '攻撃カタログを見る',
+    description:
+      '攻撃ページで利用可能な攻撃アイテムを確認し、ポイントを使って購入してください。',
+  },
+  {
+    number: 'Step 3',
+    title: '攻撃を実行する',
+    description:
+      '購入した攻撃を選び、ターゲットチームを指定して実行します。成功すればポイント獲得。',
+  },
+  {
+    number: 'Step 4',
+    title: '防御と修正',
+    description:
+      '防衛ページで受けている攻撃を確認し、ヒントを活用して脆弱性を修正しましょう。',
+  },
+  {
+    number: 'Step 5',
+    title: '同盟を結ぶ',
+    description:
+      '他チームと同盟を組むと、攻撃成功時の報酬を共有できます。戦略的に活用しましょう。',
+  },
+  {
+    number: 'Step 6',
+    title: '投票する',
+    description: 'イベント終了前に、最も優れたチームに投票してください。',
+  },
+];
+
+interface Concept {
+  name: string;
+  description: string;
+}
+
+const KEY_CONCEPTS: Concept[] = [
+  {
+    name: 'Cooldown',
+    description:
+      '攻撃にはクールダウン期間があります。同じ攻撃を連続して実行することはできません。',
+  },
+  {
+    name: 'Blackout',
+    description:
+      '管理者がスコアボードを非表示にする期間です。順位が見えない中で戦略を立てる必要があります。',
+  },
+  {
+    name: 'Score Weight',
+    description:
+      '管理者が 2x ペナルティモードを有効にすると、ヘルスチェック失敗時のペナルティが 10 倍に増加します。',
+  },
+  {
+    name: 'Alliance',
+    description:
+      '同盟チームがいると、攻撃成功報酬が分配されます。強力なチームと同盟を結ぶことで安定した収入を得られます。',
+  },
+];
+
+export default function TutorialPage() {
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="GameDay の遊び方とルールを確認しましょう"
+      >
+        ルール &amp; チュートリアル
+      </Header>
+
+      {/* Game Overview */}
+      <Container header={<Header variant="h2">GameDay とは？</Header>}>
+        <SpaceBetween size="s">
+          <Box variant="p">
+            GameDay
+            はチーム対抗のセキュリティ競技です。各チームは自分たちのインフラを守りながら、
+            他チームのインフラに攻撃を仕掛けます。攻撃と防御のバランスを取りながら、
+            最も高いスコアを獲得したチームが勝利します。
+          </Box>
+          <Alert type="info">
+            攻撃の購入にはポイントが必要です。むやみに攻撃を購入するとポイントが不足するので、
+            戦略的に行動しましょう。
+          </Alert>
+        </SpaceBetween>
+      </Container>
+
+      {/* Scoring System */}
+      <Container header={<Header variant="h2">スコアリングシステム</Header>}>
+        <Table
+          columnDefinitions={[
+            {
+              id: 'action',
+              header: 'アクション',
+              cell: (item: ScoreRow) => item.action,
+              width: 200,
+            },
+            {
+              id: 'points',
+              header: 'ポイント',
+              cell: (item: ScoreRow) => (
+                <StatusIndicator
+                  type={
+                    item.type === 'positive'
+                      ? 'success'
+                      : item.type === 'negative'
+                        ? 'error'
+                        : 'info'
+                  }
+                >
+                  {item.points}
+                </StatusIndicator>
+              ),
+              width: 150,
+            },
+            {
+              id: 'description',
+              header: '説明',
+              cell: (item: ScoreRow) => item.description,
+            },
+          ]}
+          items={SCORING_TABLE}
+          variant="embedded"
+        />
+      </Container>
+
+      {/* How to Play */}
+      <Container header={<Header variant="h2">遊び方</Header>}>
+        <SpaceBetween size="m">
+          {STEPS.map((step) => (
+            <ColumnLayout key={step.number} columns={2} variant="text-grid">
+              <Box>
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Icon name="status-positive" />
+                  <Box variant="h3">{step.number}</Box>
+                </SpaceBetween>
+                <Box fontWeight="bold">{step.title}</Box>
+              </Box>
+              <Box variant="p">{step.description}</Box>
+            </ColumnLayout>
+          ))}
+        </SpaceBetween>
+      </Container>
+
+      {/* Key Concepts */}
+      <Container header={<Header variant="h2">キーコンセプト</Header>}>
+        <ColumnLayout columns={2} variant="text-grid">
+          {KEY_CONCEPTS.map((concept) => (
+            <SpaceBetween key={concept.name} size="xxs">
+              <Box fontWeight="bold">{concept.name}</Box>
+              <Box variant="p" color="text-body-secondary">
+                {concept.description}
+              </Box>
+            </SpaceBetween>
+          ))}
+        </ColumnLayout>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/apps/application-plane/lib/i18n.tsx
+++ b/apps/application-plane/lib/i18n.tsx
@@ -166,6 +166,7 @@ const messages = {
       attackHistoryAggregate: 'Attack History',
       refreshesEvery30Seconds: '30秒ごとに自動更新',
       teams: 'teams',
+      tutorial: 'ルール',
     },
     events: {
       title: 'イベント一覧',
@@ -437,6 +438,7 @@ const messages = {
       attackHistoryAggregate: 'Attack History',
       refreshesEvery30Seconds: 'Refreshes every 30 seconds',
       teams: 'teams',
+      tutorial: 'Rules',
     },
     events: {
       title: 'Events',

--- a/docs/decisions/003-mvp-release-architecture.md
+++ b/docs/decisions/003-mvp-release-architecture.md
@@ -33,11 +33,11 @@ MVP では以下の 2 つのイベントタイプをサポートする。
 1. イベント作成（名前・タイプ・日時・チーム設定）
 2. GameDay → 攻撃カタログ設定
    JAM → 問題追加・配点設定
-3. イベント公開（draft → published）
+3. イベント公開（draft → scheduled）
 4. 参加者の登録を確認
-5. ゲーム開始（published → running）
+5. ゲーム開始（scheduled → active）
 6. リアルタイム監視（スコアボード・攻撃ログ）
-7. ゲーム終了（running → finished）
+7. ゲーム終了（active → completed）
 8. 結果確認・表彰
 
 [参加者フロー]
@@ -100,23 +100,36 @@ interface ScoreEvent {
 ### イベントライフサイクル
 
 ```text
-draft → published → running → finished → archived
-  ↓        ↓          ↓         ↓
+draft → scheduled → active → completed → cancelled
+  ↓        ↓          ↓ ↑        ↓
  編集可   参加受付   プレイ中   結果確認
+                      ↓ ↑
+                     paused
 ```
 
-### 必要な UI ページ（不足分）
+実装: `problem-service/src/services/event-lifecycle.ts`
+
+### UI ページ実装状態
 
 **管理者側:**
-- `/admin/events/new` — イベント作成フォーム（不足）
-- `/admin/events/[id]/edit` — イベント編集（不足）
-- `/admin/events/[id]/problems` — 問題管理（JAM 用、不足）
-- `/admin/events/[id]/attacks` — 攻撃カタログ管理（GameDay 用、不足）
+- `/admin/events/new` — イベント作成フォーム（実装済み）
+- `/admin/events/[id]/edit` — イベント編集（実装済み）
+- `/admin/events/[id]/problems` — 問題管理+デプロイ（実装済み）
+- `/admin/events/[id]/attacks` — 攻撃カタログ管理（実装済み）
+- `/admin/gameday/[id]` — ゲーム制御パネル（実装済み）
+- `/admin/gameday/[id]/dashboard` — リアルタイムダッシュボード（実装中）
+- `/admin/gameday/[id]/report` — ポストゲームレポート（実装中）
 
 **参加者側:**
-- `/events` — イベント一覧（既存だが登録状態がスタブ）
-- `/events/[id]` — イベント詳細+参加登録（既存だが接続不完全）
-- `/events/[id]/register` — 参加登録+チーム編成フロー（不足）
+- `/events` — イベント一覧（実装済み）
+- `/events/[id]` — イベント詳細+参加登録（実装済み）
+- `/gameday/[id]` — 司令部（実装済み）
+- `/gameday/[id]/attack` — 攻撃ステーション（実装済み）
+- `/gameday/[id]/defense` — 防御トレンチ（実装済み）
+- `/gameday/[id]/alliance` — 同盟（実装済み）
+- `/gameday/[id]/vote` — 投票（実装済み）
+- `/gameday/[id]/scoreboard` — スコアボード（実装済み、SSE）
+- `/gameday/[id]/tutorial` — チュートリアル（実装中）
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

### 参加者向け
- `/gameday/[eventId]/tutorial` チュートリアルページ追加（スコアリング表、プレイ手順、重要コンセプト）
- サイドナビに「ルール」リンク追加

### 管理者向け
- `/admin/gameday/[eventId]/report` ポストゲームレポートページ（最終ランキング、攻撃統計、CSVダウンロード）
- プレゲームチェックリスト（チーム登録・攻撃カタログ・ゲーム初期化の検証、未準備時はStartボタン無効化）

### ドキュメント
- ADR-003 のイベントライフサイクルを実装に合わせて更新（published→scheduled, running→active 等）
- UI ページ実装状態を反映

## Test plan

- [x] チュートリアルページテスト追加
- [x] レポートページテスト追加  
- [x] チェックリストテスト追加
- [x] `make before-commit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-game validation checklist to admin control panel verifying team count and attack catalog prerequisites before starting events
  * Added post-game "GameDay レポート" page displaying final leaderboards, attack statistics rankings, and CSV export functionality
  * Added "ルール & チュートリアル" page with game rules, scoring table, step-by-step guide, and key concepts reference
  * Added tutorial navigation link to event menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->