### PR TITLE
feat: 問題定義をプラットフォームから分離可能にする

### DIFF
--- a/backend/services/application-plane/problem-service/prisma/schema.prisma
+++ b/backend/services/application-plane/problem-service/prisma/schema.prisma
@@ -220,7 +220,8 @@ model DeploymentTemplate {
   problem     Problem       @relation(fields: [problemId], references: [id], onDelete: Cascade)
   provider    CloudProvider
   type        TemplateType
-  path        String
+  path        String?
+  content     String?       @db.Text
   parameters  Json          @default("{}")
 
   createdAt   DateTime      @default(now())

--- a/backend/services/application-plane/problem-service/src/providers/aws/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/aws/index.ts
@@ -108,7 +108,7 @@ export class AWSCloudProvider implements ICloudProvider {
 			// CloudFormation CreateStack を呼び出し
 			const createStackParams = {
 				StackName: options.stackName,
-				TemplateBody: await this.loadTemplate(template.path),
+				TemplateBody: template.content ?? await this.loadTemplate(template.path ?? ""),
 				Parameters: parameters,
 				Tags: tags,
 				Capabilities: [

--- a/backend/services/application-plane/problem-service/src/repositories/problem-repository.ts
+++ b/backend/services/application-plane/problem-service/src/repositories/problem-repository.ts
@@ -49,7 +49,8 @@ function toProblem(
 		templates?: {
 			provider: string;
 			type: string;
-			path: string;
+			path: string | null;
+			content: string | null;
 			parameters: unknown;
 		}[];
 		regions?: { provider: string; regions: string[] }[];
@@ -67,7 +68,8 @@ function toProblem(
 		const provider = t.provider.toLowerCase() as CloudProvider;
 		templatesMap[provider] = {
 			type: t.type as DeploymentTemplateType,
-			path: t.path,
+			path: t.path ?? undefined,
+			content: t.content ?? undefined,
 			parameters: t.parameters as Record<string, string> | undefined,
 		};
 	});
@@ -204,6 +206,34 @@ export class PrismaProblemRepository implements IProblemRepository {
 				scoringPath: problem.scoring.path,
 				scoringTimeoutMinutes: problem.scoring.timeoutMinutes || 5,
 				scoringIntervalMinutes: problem.scoring.intervalMinutes,
+				templates: {
+					create: Object.entries(problem.deployment.templates || {}).map(
+						([provider, t]) => ({
+							provider: toPrismaCloudProvider(provider as CloudProvider),
+							type: (t.type?.toUpperCase() ?? "CLOUDFORMATION") as "CLOUDFORMATION" | "SAM" | "CDK" | "TERRAFORM" | "DEPLOYMENT_MANAGER" | "ARM" | "DOCKER_COMPOSE",
+							path: t.path ?? null,
+							content: t.content ?? null,
+							parameters: t.parameters ?? {},
+						}),
+					),
+				},
+				regions: {
+					create: Object.entries(problem.deployment.regions || {}).map(
+						([provider, regions]) => ({
+							provider: toPrismaCloudProvider(provider as CloudProvider),
+							regions: regions ?? [],
+						}),
+					),
+				},
+				criteria: {
+					create: (problem.scoring.criteria || []).map((c, i) => ({
+						name: c.name,
+						description: c.description ?? null,
+						weight: c.weight,
+						maxPoints: c.maxPoints,
+						order: i,
+					})),
+				},
 			},
 			include: {
 				templates: true,

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -822,6 +822,97 @@ adminRouter.post(
 	},
 );
 
+// 問題インポート（テンプレート内容を含む）
+const importProblemSchema = z.object({
+	title: z.string().min(1),
+	type: z.enum(["gameday", "jam"]),
+	category: z.string().min(1),
+	difficulty: z.enum(["easy", "medium", "hard", "expert"]),
+	description: z.object({
+		overview: z.string(),
+		objectives: z.array(z.string()),
+		hints: z.array(z.string()),
+		prerequisites: z.array(z.string()).optional(),
+	}),
+	metadata: z.object({
+		author: z.string(),
+		version: z.string(),
+		tags: z.array(z.string()),
+	}),
+	deployment: z.object({
+		providers: z.array(z.string()),
+		timeout: z.number().optional(),
+		regions: z.record(z.array(z.string())).optional(),
+	}),
+	scoring: z.object({
+		type: z.enum(["lambda", "container", "api", "manual"]),
+		path: z.string().optional(),
+		timeoutMinutes: z.number(),
+		criteria: z.array(
+			z.object({
+				name: z.string(),
+				weight: z.number(),
+				maxPoints: z.number(),
+			}),
+		),
+	}),
+	templates: z.record(z.string()).default({}),
+});
+
+adminRouter.post(
+	"/problems/import",
+	zValidator("json", importProblemSchema),
+	async (c) => {
+		const data = c.req.valid("json");
+
+		try {
+			const templateEntries: Record<string, { type: string; content: string }> = {};
+			for (const [provider, content] of Object.entries(data.templates)) {
+				templateEntries[provider] = {
+					type: "cloudformation",
+					content,
+				};
+			}
+
+			const problem = await problemRepository.create({
+				id: crypto.randomUUID(),
+				title: data.title,
+				type: data.type,
+				category: data.category,
+				difficulty: data.difficulty,
+				description: {
+					...data.description,
+					prerequisites: data.description.prerequisites ?? [],
+				},
+				metadata: {
+					author: data.metadata.author,
+					version: data.metadata.version,
+					tags: data.metadata.tags,
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				},
+				deployment: {
+					providers: data.deployment.providers as Array<"aws" | "gcp" | "azure" | "local">,
+					timeout: data.deployment.timeout,
+					templates: Object.fromEntries(
+						Object.entries(templateEntries).map(([provider, t]) => [
+							provider,
+							{ type: t.type as "cloudformation", content: t.content },
+						]),
+					),
+					regions: (data.deployment.regions ?? {}) as Record<string, string[]>,
+				},
+				scoring: data.scoring,
+			});
+
+			return c.json(problem, 201);
+		} catch (error) {
+			console.error("Failed to import problem:", error);
+			return c.json({ error: "Failed to import problem" }, 500);
+		}
+	},
+);
+
 // 問題更新
 adminRouter.put(
 	"/problems/:problemId",

--- a/backend/services/application-plane/problem-service/src/types/index.ts
+++ b/backend/services/application-plane/problem-service/src/types/index.ts
@@ -106,7 +106,8 @@ export interface ProblemDescription {
 
 export interface DeploymentTemplate {
 	type: DeploymentTemplateType;
-	path: string;
+	path?: string;
+	content?: string;
 	parameters?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

- `DeploymentTemplate` に `content` フィールドを追加（Prisma スキーマ + TypeScript 型）
- `POST /admin/problems/import` エンドポイント追加（テンプレート内容をJSON で一括インポート）
- `loadTemplate()` を `content` 優先に変更（DB内容があればファイルシステム不要）
- `create()` でテンプレート・リージョン・採点基準をネスト作成

これにより `problems/` ディレクトリなしでプラットフォームが動作可能になり、OSS公開時に問題の答えが露出しない。

## Test plan

- [x] `make before-commit` 通過
- [x] 既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployment templates now support inline content definition alongside file path references
  * New admin endpoint enables importing problems with comprehensive deployment configurations, including templates, regions, and evaluation criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->