### PR TITLE
feat: 問題定義の分離 + インポートAPI品質改善

### DIFF
--- a/backend/services/application-plane/problem-service/src/providers/aws/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/aws/index.ts
@@ -108,7 +108,7 @@ export class AWSCloudProvider implements ICloudProvider {
 			// CloudFormation CreateStack を呼び出し
 			const createStackParams = {
 				StackName: options.stackName,
-				TemplateBody: template.content ?? await this.loadTemplate(template.path ?? ""),
+				TemplateBody: await this.resolveTemplateBody(template),
 				Parameters: parameters,
 				Tags: tags,
 				Capabilities: [
@@ -469,10 +469,23 @@ export class AWSCloudProvider implements ICloudProvider {
 		}));
 	}
 
+	private async resolveTemplateBody(
+		template: { content?: string; path?: string },
+	): Promise<string> {
+		if (template.content) {
+			return template.content;
+		}
+		if (template.path) {
+			return this.loadTemplate(template.path);
+		}
+		throw new Error(
+			"デプロイテンプレートに content も path も設定されていません",
+		);
+	}
+
 	private async loadTemplate(path: string): Promise<string> {
-		// 実際の実装ではファイルシステムまたは S3 からテンプレートを読み込む
-		console.log(`[AWS] Loading template from ${path}`);
-		return "{}";
+		const fs = await import("node:fs/promises");
+		return fs.readFile(path, "utf-8");
 	}
 
 	private async validateTemplate(

--- a/backend/services/application-plane/problem-service/src/repositories/problem-repository.ts
+++ b/backend/services/application-plane/problem-service/src/repositories/problem-repository.ts
@@ -10,6 +10,7 @@ import type {
 	ProblemCategory as PrismaProblemCategory,
 	DifficultyLevel as PrismaDifficultyLevel,
 	CloudProvider as PrismaCloudProvider,
+	TemplateType as PrismaTemplateType,
 	MarketplaceListing,
 } from "@prisma/client";
 import { prisma as _prisma } from "./prisma-client";
@@ -175,6 +176,21 @@ function toPrismaCloudProvider(provider: CloudProvider): PrismaCloudProvider {
 	return map[provider];
 }
 
+function toPrismaTemplateType(
+	type: DeploymentTemplateType | undefined,
+): PrismaTemplateType {
+	const map: Record<DeploymentTemplateType, PrismaTemplateType> = {
+		cloudformation: "CLOUDFORMATION",
+		sam: "SAM",
+		cdk: "CDK",
+		terraform: "TERRAFORM",
+		"deployment-manager": "DEPLOYMENT_MANAGER",
+		arm: "ARM",
+		"docker-compose": "DOCKER_COMPOSE",
+	};
+	return map[type ?? "cloudformation"] ?? "CLOUDFORMATION";
+}
+
 /**
  * Prisma Problem Repository 実装
  */
@@ -210,7 +226,7 @@ export class PrismaProblemRepository implements IProblemRepository {
 					create: Object.entries(problem.deployment.templates || {}).map(
 						([provider, t]) => ({
 							provider: toPrismaCloudProvider(provider as CloudProvider),
-							type: (t.type?.toUpperCase() ?? "CLOUDFORMATION") as "CLOUDFORMATION" | "SAM" | "CDK" | "TERRAFORM" | "DEPLOYMENT_MANAGER" | "ARM" | "DOCKER_COMPOSE",
+							type: toPrismaTemplateType(t.type),
 							path: t.path ?? null,
 							content: t.content ?? null,
 							parameters: t.parameters ?? {},

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -823,40 +823,30 @@ adminRouter.post(
 );
 
 // 問題インポート（テンプレート内容を含む）
-const importProblemSchema = z.object({
-	title: z.string().min(1),
-	type: z.enum(["gameday", "jam"]),
-	category: z.string().min(1),
-	difficulty: z.enum(["easy", "medium", "hard", "expert"]),
-	description: z.object({
-		overview: z.string(),
-		objectives: z.array(z.string()),
-		hints: z.array(z.string()),
-		prerequisites: z.array(z.string()).optional(),
-	}),
-	metadata: z.object({
-		author: z.string(),
-		version: z.string(),
-		tags: z.array(z.string()),
-	}),
+const templateTypeEnum = z.enum([
+	"cloudformation",
+	"sam",
+	"cdk",
+	"terraform",
+	"deployment-manager",
+	"arm",
+	"docker-compose",
+]);
+
+const importProblemSchema = createProblemSchema.extend({
 	deployment: z.object({
-		providers: z.array(z.string()),
+		providers: z.array(z.enum(["aws", "gcp", "azure", "local"])).min(1),
 		timeout: z.number().optional(),
 		regions: z.record(z.array(z.string())).optional(),
 	}),
-	scoring: z.object({
-		type: z.enum(["lambda", "container", "api", "manual"]),
-		path: z.string().optional(),
-		timeoutMinutes: z.number(),
-		criteria: z.array(
+	templates: z
+		.record(
 			z.object({
-				name: z.string(),
-				weight: z.number(),
-				maxPoints: z.number(),
+				type: templateTypeEnum,
+				content: z.string().min(1),
 			}),
-		),
-	}),
-	templates: z.record(z.string()).default({}),
+		)
+		.default({}),
 });
 
 adminRouter.post(
@@ -866,41 +856,31 @@ adminRouter.post(
 		const data = c.req.valid("json");
 
 		try {
-			const templateEntries: Record<string, { type: string; content: string }> = {};
-			for (const [provider, content] of Object.entries(data.templates)) {
-				templateEntries[provider] = {
-					type: "cloudformation",
-					content,
-				};
-			}
-
 			const problem = await problemRepository.create({
 				id: crypto.randomUUID(),
 				title: data.title,
 				type: data.type,
 				category: data.category,
 				difficulty: data.difficulty,
-				description: {
-					...data.description,
-					prerequisites: data.description.prerequisites ?? [],
-				},
+				description: data.description,
 				metadata: {
 					author: data.metadata.author,
 					version: data.metadata.version,
 					tags: data.metadata.tags,
+					license: data.metadata.license,
 					createdAt: new Date().toISOString(),
 					updatedAt: new Date().toISOString(),
 				},
 				deployment: {
-					providers: data.deployment.providers as Array<"aws" | "gcp" | "azure" | "local">,
+					providers: data.deployment.providers,
 					timeout: data.deployment.timeout,
 					templates: Object.fromEntries(
-						Object.entries(templateEntries).map(([provider, t]) => [
+						Object.entries(data.templates).map(([provider, t]) => [
 							provider,
-							{ type: t.type as "cloudformation", content: t.content },
+							{ type: t.type, content: t.content },
 						]),
 					),
-					regions: (data.deployment.regions ?? {}) as Record<string, string[]>,
+					regions: data.deployment.regions ?? {},
 				},
 				scoring: data.scoring,
 			});


### PR DESCRIPTION
## Summary

- DeploymentTemplate に content フィールド追加（テンプレート内容をDB格納）
- POST /admin/problems/import エンドポイント追加
- importProblemSchema を createProblemSchema.extend() で定義（重複排除）
- resolveTemplateBody() で content/path 存在チェック（サイレント障害防止）
- toPrismaTemplateType() で型安全な変換（as キャスト排除）
- loadTemplate() をスタブから実装に変更

## Test plan
- [x] `make before-commit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)