### PR TITLE
Harden local deploy provider and asset resolution

### DIFF
--- a/backend/services/application-plane/problem-service/src/__tests__/local-provider.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/local-provider.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileMock } = vi.hoisted(() => ({
+	execFileMock: vi.fn((_file, _args, _options, callback) => callback(null, "")),
+}));
+
+vi.mock("node:child_process", () => ({
+	execFile: execFileMock,
+}));
+
+vi.mock("../providers/problem-assets", () => ({
+	resolveProblemAssetPath: vi.fn(async () => "/tmp/problem/local/docker-compose.yaml"),
+}));
+
+import {
+	getLocalProvider,
+	LocalCloudProvider,
+} from "../providers/local";
+
+describe("LocalCloudProvider", () => {
+	beforeEach(() => {
+		execFileMock.mockClear();
+	});
+
+	it("getLocalProvider は同じインスタンスを返すべき", () => {
+		expect(getLocalProvider()).toBe(getLocalProvider());
+	});
+
+	it("スタックを削除したあとでも新しいデプロイでポートを再利用しないべき", async () => {
+		const provider = new LocalCloudProvider();
+		const credentials = {
+			provider: "local" as const,
+			accountId: "local-dev",
+		};
+		const problem = {
+			id: "problem-1",
+			deployment: {
+				templates: {
+					local: {
+						path: "gameday/local/docker-compose.yaml",
+					},
+				},
+			},
+		} as never;
+
+		const first = await provider.deployStack(problem, credentials, {
+			stackName: "team-a",
+			region: "local",
+			dryRun: false,
+		});
+		await provider.deleteStack("team-a", credentials);
+		const second = await provider.deployStack(problem, credentials, {
+			stackName: "team-b",
+			region: "local",
+			dryRun: false,
+		});
+
+		expect(first.success).toBe(true);
+		expect(second.success).toBe(true);
+		expect(first.outputs?.ApiUrl).toBe("http://localhost:18080");
+		expect(second.outputs?.ApiUrl).toBe("http://localhost:18090");
+		expect(execFileMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/backend/services/application-plane/problem-service/src/__tests__/problem-assets.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/problem-assets.test.ts
@@ -1,0 +1,39 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import * as nodePath from "node:path";
+import { tmpdir } from "node:os";
+import { vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+const originalProblemsDir = process.env.PROBLEMS_DIR;
+
+afterEach(() => {
+	process.env.PROBLEMS_DIR = originalProblemsDir;
+	vi.resetModules();
+});
+
+describe("problem-assets", () => {
+	it("存在しないアセットは明確な not found エラーを返すべき", async () => {
+		const baseDir = await mkdtemp(nodePath.join(tmpdir(), "problem-assets-"));
+		process.env.PROBLEMS_DIR = baseDir;
+		const { resolveProblemAssetPath } = await import("../providers/problem-assets");
+
+		await expect(
+			resolveProblemAssetPath("gameday/missing/template.yaml"),
+		).rejects.toThrow("Problem asset not found: gameday/missing/template.yaml");
+	});
+
+	it("ベースディレクトリ配下のテキストアセットを読み込めるべき", async () => {
+		const baseDir = await mkdtemp(nodePath.join(tmpdir(), "problem-assets-"));
+		const assetDir = nodePath.join(baseDir, "gameday");
+		const assetPath = nodePath.join(assetDir, "template.yaml");
+		process.env.PROBLEMS_DIR = baseDir;
+		const { loadProblemTextAsset } = await import("../providers/problem-assets");
+
+		await mkdir(assetDir, { recursive: true });
+		await writeFile(assetPath, "Resources: {}\n", "utf-8");
+
+		await expect(loadProblemTextAsset("gameday/template.yaml")).resolves.toBe(
+			"Resources: {}\n",
+		);
+	});
+});

--- a/backend/services/application-plane/problem-service/src/providers/local/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/local/index.ts
@@ -44,6 +44,7 @@ export class LocalCloudProvider implements ICloudProvider {
 	readonly displayName = "Local Development";
 
 	private deployedStacks: Map<string, LocalStack> = new Map();
+	private nextPortOffset = 0;
 
 	/**
 	 * 認証情報の検証（ローカルでは常に成功）
@@ -281,21 +282,27 @@ export class LocalCloudProvider implements ICloudProvider {
 		problemRoot: string,
 		region: string,
 		stackName: string,
-		ports: { apiPort: number; frontendPort: number },
+		ports: LocalPorts,
 	): Record<string, string> {
 		return {
 			...Object.fromEntries(
-				Object.entries(templateParameters).map(([key, value]) => [key, String(value)]),
+				Object.entries(templateParameters).map(([key, value]) => [
+					key,
+					this.sanitizeEnvironmentValue(String(value)),
+				]),
 			),
 			...Object.fromEntries(
-				Object.entries(overrideParameters).map(([key, value]) => [key, String(value)]),
+				Object.entries(overrideParameters).map(([key, value]) => [
+					key,
+					this.sanitizeEnvironmentValue(String(value)),
+				]),
 			),
-			PROBLEM_ROOT: problemRoot,
-			REGION: region,
-			STACK_NAME: stackName,
+			PROBLEM_ROOT: this.sanitizeEnvironmentValue(problemRoot),
+			REGION: this.sanitizeEnvironmentValue(region),
+			STACK_NAME: this.sanitizeEnvironmentValue(stackName),
 			API_PORT: String(ports.apiPort),
 			FRONTEND_PORT: String(ports.frontendPort),
-			DB_EXPOSE_PORT: String(this.allocateHostPort(3306)),
+			DB_EXPOSE_PORT: String(ports.dbPort),
 		};
 	}
 
@@ -346,16 +353,22 @@ export class LocalCloudProvider implements ICloudProvider {
 		}
 	}
 
-	private allocatePorts(): { apiPort: number; frontendPort: number } {
-		const offset = this.deployedStacks.size * 10;
+	private sanitizeEnvironmentValue(value: string): string {
+		return value.replace(/[\r\n\x00-\x1F\x7F]/g, "");
+	}
+
+	private allocatePorts(): LocalPorts {
+		const offset = this.nextPortOffset;
+		this.nextPortOffset += 1;
 		return {
-			apiPort: this.allocateHostPort(18080 + offset),
-			frontendPort: this.allocateHostPort(13080 + offset),
+			apiPort: this.allocateHostPort(18080, offset),
+			frontendPort: this.allocateHostPort(13080, offset),
+			dbPort: this.allocateHostPort(3306, offset),
 		};
 	}
 
-	private allocateHostPort(basePort: number): number {
-		return basePort + this.deployedStacks.size;
+	private allocateHostPort(basePort: number, offset: number): number {
+		return basePort + offset * 10;
 	}
 
 	private getProjectName(stackName: string): string {
@@ -378,9 +391,20 @@ interface LocalStack {
 	environment: Record<string, string>;
 }
 
+interface LocalPorts {
+	apiPort: number;
+	frontendPort: number;
+	dbPort: number;
+}
+
+let localProviderInstance: LocalCloudProvider | null = null;
+
 /**
  * ローカルプロバイダーのシングルトンインスタンスを取得
  */
 export function getLocalProvider(): LocalCloudProvider {
-	return new LocalCloudProvider();
+	if (!localProviderInstance) {
+		localProviderInstance = new LocalCloudProvider();
+	}
+	return localProviderInstance;
 }

--- a/backend/services/application-plane/problem-service/src/providers/problem-assets.ts
+++ b/backend/services/application-plane/problem-service/src/providers/problem-assets.ts
@@ -40,7 +40,21 @@ export async function resolveProblemAssetPath(assetPath: string): Promise<string
 	const baseDir = await getProblemsBaseDir();
 	const candidate = nodePath.resolve(baseDir, assetPath);
 	const realBase = await realpath(baseDir);
-	const realCandidate = await realpath(candidate);
+	let realCandidate: string;
+
+	try {
+		realCandidate = await realpath(candidate);
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			throw new Error(`Problem asset not found: ${assetPath}`);
+		}
+		throw error;
+	}
 
 	if (
 		realCandidate !== realBase &&


### PR DESCRIPTION
## Summary
- return a clear not-found error when a problem asset path does not exist
- make the local deploy provider a singleton and stop reusing host ports after stack deletion
- add problem-service regression tests for asset resolution and local provider port allocation

## Verification
- /Users/susumu/product/TenkaCloud/node_modules/.bin/vitest run backend/services/application-plane/problem-service/src/__tests__/problem-assets.test.ts backend/services/application-plane/problem-service/src/__tests__/local-provider.test.ts backend/services/application-plane/problem-service/src/__tests__/routes-admin.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for deploying problems to multiple providers: AWS CloudFormation and Local Docker Compose.
  * Introduced provider and region selection in the admin deployment interface.
  * Enhanced deployment tracking to manage multiple active deployments across different providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->