### PR TITLE
[codex] Avoid forwarding AUTH_SKIP mock tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ vite.config.ts.timestamp-*
 apps/*/test-results/
 apps/*/playwright-report/
 package-lock.json
+
+tmp
+.DS_Store

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/edit/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/edit/page.tsx
@@ -9,7 +9,6 @@
 import Box from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
-import DatePicker from '@cloudscape-design/components/date-picker';
 import Form from '@cloudscape-design/components/form';
 import FormField from '@cloudscape-design/components/form-field';
 import Header from '@cloudscape-design/components/header';
@@ -51,13 +50,13 @@ export default function AdminEventEditPage() {
         setLoading(true);
         setFetchError(null);
         const data = await get<AdminEvent>(`/admin/events/${eventId}`);
-        const startDate = data.startTime ? data.startTime.slice(0, 10) : '';
-        const endDate = data.endTime ? data.endTime.slice(0, 10) : '';
+        const startDateTime = data.startTime ? data.startTime.slice(0, 16) : '';
+        const endDateTime = data.endTime ? data.endTime.slice(0, 16) : '';
         setField('name', data.name || '');
         setField('type', findOption(TYPE_OPTIONS, data.type));
         setField('status', findOption(STATUS_OPTIONS, data.status));
-        setField('startTime', startDate);
-        setField('endTime', endDate);
+        setField('startTime', startDateTime);
+        setField('endTime', endDateTime);
         setField(
           'timezone',
           findOption(TIMEZONE_OPTIONS, data.timezone) ?? TIMEZONE_OPTIONS[0],
@@ -163,24 +162,22 @@ export default function AdminEventEditPage() {
             </FormField>
           </SpaceBetween>
           <SpaceBetween direction="horizontal" size="l">
-            <FormField label="開始日">
-              <DatePicker
+            <FormField label="開始日時">
+              <input
+                type="datetime-local"
                 value={form.startTime}
-                onChange={({ detail }) => setField('startTime', detail.value)}
-                placeholder="YYYY/MM/DD"
-                openCalendarAriaLabel={(s) =>
-                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
-                }
+                onChange={(event) => setField('startTime', event.target.value)}
+                placeholder="YYYY-MM-DDTHH:mm"
+                className="awsui-input-type-text"
               />
             </FormField>
-            <FormField label="終了日" errorText={errors.endTime}>
-              <DatePicker
+            <FormField label="終了日時" errorText={errors.endTime}>
+              <input
+                type="datetime-local"
                 value={form.endTime}
-                onChange={({ detail }) => setField('endTime', detail.value)}
-                placeholder="YYYY/MM/DD"
-                openCalendarAriaLabel={(s) =>
-                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
-                }
+                onChange={(event) => setField('endTime', event.target.value)}
+                placeholder="YYYY-MM-DDTHH:mm"
+                className="awsui-input-type-text"
               />
             </FormField>
           </SpaceBetween>

--- a/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
+++ b/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
@@ -252,15 +252,20 @@ describe('buildPayload', () => {
   it('フォーム状態からペイロードを正しく構築すべき', () => {
     expect(buildPayload(DEFAULT_FORM_STATE)).toEqual({
       name: '',
+      slug: 'event',
       type: 'gameday',
       status: 'draft',
-      startTime: '',
-      endTime: '',
+      eventDate: '',
+      startTime: undefined,
+      endTime: undefined,
       timezone: 'Asia/Tokyo',
       participantType: 'individual',
       cloudProvider: 'aws',
+      regions: ['ap-northeast-1'],
       maxParticipants: 100,
       scoringType: 'realtime',
+      scoringIntervalMinutes: 5,
+      leaderboardVisible: true,
     });
   });
 
@@ -272,6 +277,22 @@ describe('buildPayload', () => {
     });
     expect(payload.type).toBeUndefined();
     expect(payload.status).toBeUndefined();
+  });
+
+  it('local provider と日付入力を backend 契約に正規化すべき', () => {
+    const payload = buildPayload({
+      ...DEFAULT_FORM_STATE,
+      name: 'Spring GameDay 2026',
+      startTime: '2026-05-01',
+      endTime: '2026-05-02',
+      cloudProvider: { label: 'ローカル', value: 'local' },
+    });
+
+    expect(payload.slug).toBe('spring-gameday-2026');
+    expect(payload.eventDate).toBe('2026-05-01');
+    expect(payload.startTime).toBe('2026-05-01T00:00:00.000Z');
+    expect(payload.endTime).toBe('2026-05-02T23:59:59.000Z');
+    expect(payload.regions).toEqual(['local']);
   });
 });
 

--- a/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
+++ b/apps/application-plane/app/(admin)/admin/events/__tests__/use-event-form-state.test.ts
@@ -57,8 +57,8 @@ describe('useEventFormState フック', () => {
   it('setField で全フィールドを個別に更新できるべき', () => {
     const { result } = renderHook(() => useEventFormState());
     act(() => {
-      result.current.setField('startTime', '2026-05-01');
-      result.current.setField('endTime', '2026-05-02');
+      result.current.setField('startTime', '2026-05-01T09:00');
+      result.current.setField('endTime', '2026-05-02T18:00');
       result.current.setField('timezone', TIMEZONE_OPTIONS[1]);
       result.current.setField('participantType', PARTICIPANT_TYPE_OPTIONS[1]);
       result.current.setField('cloudProvider', CLOUD_PROVIDER_OPTIONS[1]);
@@ -66,8 +66,8 @@ describe('useEventFormState フック', () => {
       result.current.setField('scoringType', SCORING_TYPE_OPTIONS[1]);
       result.current.setField('status', STATUS_OPTIONS[1]);
     });
-    expect(result.current.form.startTime).toBe('2026-05-01');
-    expect(result.current.form.endTime).toBe('2026-05-02');
+    expect(result.current.form.startTime).toBe('2026-05-01T09:00');
+    expect(result.current.form.endTime).toBe('2026-05-02T18:00');
     expect(result.current.form.timezone).toEqual(TIMEZONE_OPTIONS[1]);
     expect(result.current.form.participantType).toEqual(
       PARTICIPANT_TYPE_OPTIONS[1],
@@ -90,12 +90,12 @@ describe('useEventFormState フック', () => {
     expect(result.current.errors.name).toBe('イベント名は必須です');
   });
 
-  it('終了日が開始日より前の場合にバリデーションエラーを返すべき', async () => {
+  it('終了日時が開始日時より前の場合にバリデーションエラーを返すべき', async () => {
     const { result } = renderHook(() => useEventFormState());
     act(() => {
       result.current.setField('name', 'テスト');
-      result.current.setField('startTime', '2026-05-10');
-      result.current.setField('endTime', '2026-05-01');
+      result.current.setField('startTime', '2026-05-10T10:00');
+      result.current.setField('endTime', '2026-05-10T09:00');
     });
     let ok: boolean | undefined;
     await act(async () => {
@@ -103,7 +103,7 @@ describe('useEventFormState フック', () => {
     });
     expect(ok).toBe(false);
     expect(result.current.errors.endTime).toBe(
-      '終了日は開始日より後に設定してください',
+      '終了日時は開始日時より後に設定してください',
     );
   });
 
@@ -182,45 +182,45 @@ describe('validateEventForm', () => {
     ).toBeUndefined();
   });
 
-  it('終了日が開始日以前の場合にエラーを返すべき', () => {
+  it('終了日時が開始日時以前の場合にエラーを返すべき', () => {
     expect(
       validateEventForm({
         ...DEFAULT_FORM_STATE,
         name: 'テスト',
-        startTime: '2026-05-10',
-        endTime: '2026-05-01',
+        startTime: '2026-05-10T10:00',
+        endTime: '2026-05-10T09:00',
       }).endTime,
-    ).toBe('終了日は開始日より後に設定してください');
+    ).toBe('終了日時は開始日時より後に設定してください');
   });
 
-  it('終了日が開始日と同じ場合にエラーを返すべき', () => {
+  it('終了日時が開始日時と同じ場合にエラーを返すべき', () => {
     expect(
       validateEventForm({
         ...DEFAULT_FORM_STATE,
         name: 'テスト',
-        startTime: '2026-05-10',
-        endTime: '2026-05-10',
+        startTime: '2026-05-10T10:00',
+        endTime: '2026-05-10T10:00',
       }).endTime,
-    ).toBe('終了日は開始日より後に設定してください');
+    ).toBe('終了日時は開始日時より後に設定してください');
   });
 
-  it('開始日が空の場合に終了日エラーを返さないべき', () => {
+  it('開始日時が空の場合に終了日時エラーを返さないべき', () => {
     expect(
       validateEventForm({
         ...DEFAULT_FORM_STATE,
         name: 'テスト',
         startTime: '',
-        endTime: '2026-05-01',
+        endTime: '2026-05-01T12:00',
       }).endTime,
     ).toBeUndefined();
   });
 
-  it('終了日が空の場合にエラーを返さないべき', () => {
+  it('終了日時が空の場合にエラーを返さないべき', () => {
     expect(
       validateEventForm({
         ...DEFAULT_FORM_STATE,
         name: 'テスト',
-        startTime: '2026-05-01',
+        startTime: '2026-05-01T12:00',
         endTime: '',
       }).endTime,
     ).toBeUndefined();
@@ -279,19 +279,19 @@ describe('buildPayload', () => {
     expect(payload.status).toBeUndefined();
   });
 
-  it('local provider と日付入力を backend 契約に正規化すべき', () => {
+  it('local provider と日時入力を backend 契約に正規化すべき', () => {
     const payload = buildPayload({
       ...DEFAULT_FORM_STATE,
       name: 'Spring GameDay 2026',
-      startTime: '2026-05-01',
-      endTime: '2026-05-02',
+      startTime: '2026-05-01T09:30',
+      endTime: '2026-05-02T18:45',
       cloudProvider: { label: 'ローカル', value: 'local' },
     });
 
     expect(payload.slug).toBe('spring-gameday-2026');
     expect(payload.eventDate).toBe('2026-05-01');
-    expect(payload.startTime).toBe('2026-05-01T00:00:00.000Z');
-    expect(payload.endTime).toBe('2026-05-02T23:59:59.000Z');
+    expect(payload.startTime).toBe('2026-05-01T09:30:00.000Z');
+    expect(payload.endTime).toBe('2026-05-02T18:45:00.000Z');
     expect(payload.regions).toEqual(['local']);
   });
 });

--- a/apps/application-plane/app/(admin)/admin/events/new/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/new/__tests__/page.test.tsx
@@ -33,8 +33,8 @@ describe('イベント作成ページ', () => {
 
   it('日時設定フィールドが表示されるべき', () => {
     render(<AdminEventCreatePage />);
-    expect(screen.getByText('開始日')).toBeInTheDocument();
-    expect(screen.getByText('終了日')).toBeInTheDocument();
+    expect(screen.getByText('開始日時')).toBeInTheDocument();
+    expect(screen.getByText('終了日時')).toBeInTheDocument();
     expect(screen.getByText('タイムゾーン')).toBeInTheDocument();
   });
 

--- a/apps/application-plane/app/(admin)/admin/events/new/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/new/__tests__/page.test.tsx
@@ -85,7 +85,13 @@ describe('イベント作成ページ', () => {
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(
         '/admin/events',
-        expect.objectContaining({ name: 'テストイベント' }),
+        expect.objectContaining({
+          name: 'テストイベント',
+          slug: 'event',
+          regions: ['ap-northeast-1'],
+          scoringIntervalMinutes: 5,
+          leaderboardVisible: true,
+        }),
       );
     });
     expect(mockPush).toHaveBeenCalledWith('/admin/events');

--- a/apps/application-plane/app/(admin)/admin/events/new/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/new/page.tsx
@@ -9,7 +9,6 @@
 import Box from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
-import DatePicker from '@cloudscape-design/components/date-picker';
 import Form from '@cloudscape-design/components/form';
 import FormField from '@cloudscape-design/components/form-field';
 import Header from '@cloudscape-design/components/header';
@@ -90,24 +89,22 @@ export default function AdminEventCreatePage() {
             </FormField>
           </SpaceBetween>
           <SpaceBetween direction="horizontal" size="l">
-            <FormField label="開始日">
-              <DatePicker
+            <FormField label="開始日時">
+              <input
+                type="datetime-local"
                 value={form.startTime}
-                onChange={({ detail }) => setField('startTime', detail.value)}
-                placeholder="YYYY/MM/DD"
-                openCalendarAriaLabel={(s) =>
-                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
-                }
+                onChange={(event) => setField('startTime', event.target.value)}
+                placeholder="YYYY-MM-DDTHH:mm"
+                className="awsui-input-type-text"
               />
             </FormField>
-            <FormField label="終了日" errorText={errors.endTime}>
-              <DatePicker
+            <FormField label="終了日時" errorText={errors.endTime}>
+              <input
+                type="datetime-local"
                 value={form.endTime}
-                onChange={({ detail }) => setField('endTime', detail.value)}
-                placeholder="YYYY/MM/DD"
-                openCalendarAriaLabel={(s) =>
-                  s ? `日付を選択、選択済み ${s}` : '日付を選択'
-                }
+                onChange={(event) => setField('endTime', event.target.value)}
+                placeholder="YYYY-MM-DDTHH:mm"
+                className="awsui-input-type-text"
               />
             </FormField>
           </SpaceBetween>

--- a/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
+++ b/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
@@ -111,11 +111,12 @@ export function buildPayload(form: EventFormState) {
     name: form.name,
     type: form.type?.value,
     status: form.status?.value,
-    slug: form.name
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '') || 'event',
+    slug:
+      form.name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'event',
     eventDate: form.startTime.split('T')[0] || form.startTime,
     startTime: toIsoDateTime(form.startTime),
     endTime: toIsoDateTime(form.endTime),

--- a/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
+++ b/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
@@ -82,17 +82,41 @@ export function findOption(
 }
 
 export function buildPayload(form: EventFormState) {
+  const provider = form.cloudProvider?.value ?? 'aws';
+  const defaultRegions =
+    provider === 'local'
+      ? ['local']
+      : provider === 'gcp'
+        ? ['asia-northeast1']
+        : provider === 'azure'
+          ? ['japaneast']
+          : ['ap-northeast-1'];
+
+  const toIsoDateTime = (value: string, endOfDay = false) => {
+    if (!value) return undefined;
+    return `${value}T${endOfDay ? '23:59:59' : '00:00:00'}.000Z`;
+  };
+
   return {
     name: form.name,
     type: form.type?.value,
     status: form.status?.value,
-    startTime: form.startTime,
-    endTime: form.endTime,
+    slug: form.name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'event',
+    eventDate: form.startTime,
+    startTime: toIsoDateTime(form.startTime),
+    endTime: toIsoDateTime(form.endTime, true),
     timezone: form.timezone?.value,
     participantType: form.participantType?.value,
-    cloudProvider: form.cloudProvider?.value,
+    cloudProvider: provider,
+    regions: defaultRegions,
     maxParticipants: Number(form.maxParticipants),
     scoringType: form.scoringType?.value,
+    scoringIntervalMinutes: 5,
+    leaderboardVisible: true,
   };
 }
 

--- a/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
+++ b/apps/application-plane/app/(admin)/admin/events/use-event-form-state.ts
@@ -92,9 +92,19 @@ export function buildPayload(form: EventFormState) {
           ? ['japaneast']
           : ['ap-northeast-1'];
 
-  const toIsoDateTime = (value: string, endOfDay = false) => {
+  const toIsoDateTime = (value: string) => {
     if (!value) return undefined;
-    return `${value}T${endOfDay ? '23:59:59' : '00:00:00'}.000Z`;
+    if (value.endsWith('Z')) return value;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return `${value}T00:00:00.000Z`;
+    }
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+      return `${value}:00.000Z`;
+    }
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+      return `${value}.000Z`;
+    }
+    return value;
   };
 
   return {
@@ -106,9 +116,9 @@ export function buildPayload(form: EventFormState) {
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '') || 'event',
-    eventDate: form.startTime,
+    eventDate: form.startTime.split('T')[0] || form.startTime,
     startTime: toIsoDateTime(form.startTime),
-    endTime: toIsoDateTime(form.endTime, true),
+    endTime: toIsoDateTime(form.endTime),
     timezone: form.timezone?.value,
     participantType: form.participantType?.value,
     cloudProvider: provider,
@@ -126,7 +136,7 @@ export function validateEventForm(form: EventFormState): EventFormErrors {
     errs.name = 'イベント名は必須です';
   }
   if (form.startTime && form.endTime && form.endTime <= form.startTime) {
-    errs.endTime = '終了日は開始日より後に設定してください';
+    errs.endTime = '終了日時は開始日時より後に設定してください';
   }
   return errs;
 }

--- a/apps/application-plane/app/(admin)/admin/gameday/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/__tests__/page.test.tsx
@@ -103,7 +103,7 @@ describe('AdminGamedayPage', () => {
     render(<AdminGamedayPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+      expect(screen.getByText('API Error')).toBeInTheDocument();
     });
   });
 
@@ -112,7 +112,7 @@ describe('AdminGamedayPage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/イベント ID を直接入力して検索/),
+        screen.getByText(/イベント ID を直接指定して GameDay 状態を確認します/),
       ).toBeInTheDocument();
     });
   });

--- a/apps/application-plane/app/(admin)/admin/gameday/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/page.tsx
@@ -6,18 +6,20 @@
 
 'use client';
 
-import Link from 'next/link';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import '@cloudscape-design/global-styles/index.css';
+import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
-import {
-  Button,
-  Card,
-  CardContent,
-  ErrorState,
-  getErrorMessage,
-  getErrorType,
-  Input,
-  Skeleton,
-} from '@/components/ui';
 import { get } from '@/lib/api/client';
 import { getGameStatus } from '@/lib/api/gameday-admin';
 import type { GameState } from '@/lib/api/gameday-types';
@@ -31,7 +33,26 @@ interface AdminEvent {
   participantCount: number;
 }
 
+function getGameStateSummary(gameState: GameState | null) {
+  if (!gameState) {
+    return {
+      indicator: <StatusIndicator type="info">ゲーム未初期化</StatusIndicator>,
+      details: 'ゲーム状態はまだ作成されていません',
+    };
+  }
+
+  return {
+    indicator: gameState.isRunning ? (
+      <StatusIndicator type="success">進行中</StatusIndicator>
+    ) : (
+      <StatusIndicator type="stopped">停止中</StatusIndicator>
+    ),
+    details: `スコア重み: ${gameState.scoreWeight === 'high' ? '2x' : '通常'} / ブラックアウト: ${gameState.blackout ? 'ON' : 'OFF'} / ${gameState.durationMinutes}分`,
+  };
+}
+
 export default function AdminGamedayPage() {
+  const router = useRouter();
   const [events, setEvents] = useState<AdminEvent[]>([]);
   const [gameStates, setGameStates] = useState<
     Record<string, GameState | null>
@@ -48,11 +69,10 @@ export default function AdminGamedayPage() {
     try {
       const data = await get<{ events: AdminEvent[] }>('/admin/events');
       const gamedayEvents = (data.events ?? []).filter(
-        (e) => e.type === 'gameday',
+        (event) => event.type === 'gameday',
       );
       setEvents(gamedayEvents);
 
-      // Fetch game status for each event
       const states: Record<string, GameState | null> = {};
       await Promise.all(
         gamedayEvents.map(async (event) => {
@@ -79,6 +99,7 @@ export default function AdminGamedayPage() {
 
   const handleLookup = useCallback(async () => {
     if (!manualEventId.trim()) return;
+
     setLookupLoading(true);
     setLookupError(null);
     try {
@@ -87,9 +108,10 @@ export default function AdminGamedayPage() {
         ...prev,
         [state.eventId]: state,
       }));
-      // Add to events list if not present
       setEvents((prev) => {
-        if (prev.find((e) => e.id === state.eventId)) return prev;
+        if (prev.find((event) => event.id === state.eventId)) {
+          return prev;
+        }
         return [
           ...prev,
           {
@@ -113,119 +135,132 @@ export default function AdminGamedayPage() {
   }, [manualEventId]);
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-          <span className="text-hn-accent font-mono">&gt;_</span>
-          GameDay 管理
-        </h1>
-        <p className="text-text-secondary mt-1">
-          GameDayイベントを選択してゲームを管理します
-        </p>
-      </div>
+    <SpaceBetween size="l">
+      <Header variant="h1" description="GameDayイベントを選択してゲームを管理します">
+        GameDay 管理
+      </Header>
 
-      {/* Event List */}
-      {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {[1, 2].map((i) => (
-            <Card key={i}>
-              <CardContent className="space-y-3">
-                <Skeleton className="h-5 w-32" />
-                <Skeleton className="h-4 w-48" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : error ? (
-        <ErrorState
-          message={getErrorMessage(error)}
-          type={getErrorType(error)}
-          onRetry={fetchEvents}
-        />
-      ) : events.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {events.map((event) => {
-            const gs = gameStates[event.id];
-            return (
-              <Card key={event.id} hoverable>
-                <Link href={`/admin/gameday/${event.id}`}>
-                  <CardContent className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <span className="font-bold text-text-primary">
-                        {event.name}
-                      </span>
-                      <span
-                        className={`w-3 h-3 rounded-full ${
-                          gs?.isRunning
-                            ? 'bg-hn-success animate-pulse'
-                            : 'bg-text-muted'
-                        }`}
-                      />
-                    </div>
-                    <div className="text-sm font-mono text-text-muted">
+      <Container>
+        {loading ? (
+          <Box textAlign="center" padding="xxl">
+            <Spinner size="large" />
+          </Box>
+        ) : error ? (
+          <Box textAlign="center" padding="xxl">
+            <SpaceBetween size="m" alignItems="center">
+              <StatusIndicator type="error">{error.message}</StatusIndicator>
+              <Button onClick={fetchEvents}>再読み込み</Button>
+            </SpaceBetween>
+          </Box>
+        ) : events.length > 0 ? (
+          <Cards
+            cardsPerRow={[
+              { cards: 1 },
+              { minWidth: 520, cards: 2 },
+            ]}
+            items={events}
+            cardDefinition={{
+              header: (event) => (
+                <NextLink
+                  href={`/admin/gameday/${event.id}`}
+                  className="text-[#539fe5] hover:underline"
+                >
+                  {event.name}
+                </NextLink>
+              ),
+              sections: [
+                {
+                  id: 'event-id',
+                  header: 'イベント ID',
+                  content: (event) => (
+                    <Box variant="code" color="text-body-secondary">
                       {event.id}
-                    </div>
-                    <div className="flex items-center gap-3 text-sm text-text-muted">
-                      {gs ? (
-                        <>
-                          <span>
-                            スコア重み:{' '}
-                            {gs.scoreWeight === 'high' ? '2x' : '通常'}
-                          </span>
-                          <span>
-                            ブラックアウト: {gs.blackout ? 'ON' : 'OFF'}
-                          </span>
-                          <span>{gs.durationMinutes}分</span>
-                        </>
-                      ) : (
-                        <span>ゲーム未初期化</span>
-                      )}
-                    </div>
-                  </CardContent>
-                </Link>
-              </Card>
-            );
-          })}
-        </div>
-      ) : (
-        <Card className="text-center py-8">
-          <p className="text-text-muted">GameDay イベントがありません</p>
-          <Button variant="primary" asChild className="mt-4">
-            <Link href="/admin/events/new">新規イベント作成</Link>
-          </Button>
-        </Card>
-      )}
+                    </Box>
+                  ),
+                },
+                {
+                  id: 'participants',
+                  header: '参加者数',
+                  content: (event) => `${event.participantCount ?? 0} 人`,
+                },
+                {
+                  id: 'status',
+                  header: 'ゲーム状態',
+                  content: (event) => getGameStateSummary(gameStates[event.id]).indicator,
+                },
+                {
+                  id: 'details',
+                  header: '詳細',
+                  content: (event) => (
+                    <Box color="text-body-secondary">
+                      {getGameStateSummary(gameStates[event.id]).details}
+                    </Box>
+                  ),
+                },
+              ],
+            }}
+            empty={<></>}
+          />
+        ) : (
+          <Box textAlign="center" padding="xxl">
+            <SpaceBetween size="m" alignItems="center">
+              <Box variant="h2">GameDay イベントがありません</Box>
+              <Box color="text-body-secondary">
+                まずイベント管理から GameDay イベントを作成してください。
+              </Box>
+              <SpaceBetween direction="horizontal" size="s">
+                <Button
+                  variant="primary"
+                  onClick={() => router.push('/admin/events/new')}
+                >
+                  新規イベント作成
+                </Button>
+                <Button onClick={() => router.push('/admin/events')}>
+                  イベント管理へ
+                </Button>
+              </SpaceBetween>
+            </SpaceBetween>
+          </Box>
+        )}
+      </Container>
 
-      {/* Manual Lookup */}
-      <Card>
-        <CardContent>
-          <p className="text-sm text-text-muted mb-3">
-            イベント ID を直接入力して検索することもできます
-          </p>
-          <div className="flex items-end gap-4">
-            <Input
-              label="イベント ID"
-              value={manualEventId}
-              onChange={(e) => setManualEventId(e.target.value)}
-              placeholder="event-id-here"
-              onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
-            />
+      <Container
+        header={
+          <Header variant="h2" description="イベント ID を直接指定して GameDay 状態を確認します">
+            直接検索
+          </Header>
+        }
+      >
+        <SpaceBetween size="m">
+          <SpaceBetween direction="horizontal" size="s">
+            <FormField label="イベント ID" stretch>
+              <Input
+                value={manualEventId}
+                onChange={({ detail }) => setManualEventId(detail.value)}
+                placeholder="event-id-here"
+                onKeyDown={({ detail }) => {
+                  if (detail.key === 'Enter') {
+                    void handleLookup();
+                  }
+                }}
+              />
+            </FormField>
             <Button
-              variant="secondary"
-              onClick={handleLookup}
+              variant="primary"
               loading={lookupLoading}
               disabled={!manualEventId.trim() || lookupLoading}
+              onClick={() => {
+                void handleLookup();
+              }}
             >
               検索
             </Button>
-          </div>
+          </SpaceBetween>
           {lookupError && (
-            <p className="text-sm text-hn-error mt-2">
-              {getErrorMessage(lookupError)}
-            </p>
+            <StatusIndicator type="error">{lookupError.message}</StatusIndicator>
           )}
-        </CardContent>
-      </Card>
-    </div>
+        </SpaceBetween>
+      </Container>
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/gameday/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/gameday/page.tsx
@@ -136,7 +136,10 @@ export default function AdminGamedayPage() {
 
   return (
     <SpaceBetween size="l">
-      <Header variant="h1" description="GameDayイベントを選択してゲームを管理します">
+      <Header
+        variant="h1"
+        description="GameDayイベントを選択してゲームを管理します"
+      >
         GameDay 管理
       </Header>
 
@@ -154,10 +157,7 @@ export default function AdminGamedayPage() {
           </Box>
         ) : events.length > 0 ? (
           <Cards
-            cardsPerRow={[
-              { cards: 1 },
-              { minWidth: 520, cards: 2 },
-            ]}
+            cardsPerRow={[{ cards: 1 }, { minWidth: 520, cards: 2 }]}
             items={events}
             cardDefinition={{
               header: (event) => (
@@ -186,7 +186,8 @@ export default function AdminGamedayPage() {
                 {
                   id: 'status',
                   header: 'ゲーム状態',
-                  content: (event) => getGameStateSummary(gameStates[event.id]).indicator,
+                  content: (event) =>
+                    getGameStateSummary(gameStates[event.id]).indicator,
                 },
                 {
                   id: 'details',
@@ -226,7 +227,10 @@ export default function AdminGamedayPage() {
 
       <Container
         header={
-          <Header variant="h2" description="イベント ID を直接指定して GameDay 状態を確認します">
+          <Header
+            variant="h2"
+            description="イベント ID を直接指定して GameDay 状態を確認します"
+          >
             直接検索
           </Header>
         }
@@ -257,7 +261,9 @@ export default function AdminGamedayPage() {
             </Button>
           </SpaceBetween>
           {lookupError && (
-            <StatusIndicator type="error">{lookupError.message}</StatusIndicator>
+            <StatusIndicator type="error">
+              {lookupError.message}
+            </StatusIndicator>
           )}
         </SpaceBetween>
       </Container>

--- a/apps/application-plane/app/(admin)/admin/layout.tsx
+++ b/apps/application-plane/app/(admin)/admin/layout.tsx
@@ -15,6 +15,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { NotificationPanel } from '@/components/notifications/notification-panel';
 import { useTenantOptional } from '@/lib/tenant';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 const navItems: SideNavigationProps.Item[] = [
@@ -38,6 +39,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   const router = useRouter();
   const { data: session } = useSession();
   const tenant = useTenantOptional();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const activeHref = navItems
     .filter((item): item is SideNavigationProps.Link => item.type === 'link')
@@ -48,58 +54,62 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <div className="awsui-dark-mode">
-      <div id="admin-top-nav" style={{ position: 'relative' }}>
-        <TopNavigation
-          identity={{
-            href: '/admin',
-            title: 'TenkaCloud',
-            onFollow: (e) => {
-              e.preventDefault();
-              router.push('/admin');
-            },
-          }}
-          utilities={[
-            ...(tenant?.slug
-              ? [
-                  {
-                    type: 'button' as const,
-                    text: tenant.slug,
-                    disableUtilityCollapse: true,
-                  },
-                ]
-              : []),
-            {
-              type: 'button' as const,
-              text: '参加者画面へ',
-              href: '/dashboard',
-              variant: 'link' as const,
-            },
-            {
-              type: 'menu-dropdown' as const,
-              text: session?.user?.name || '管理者',
-              iconName: 'user-profile' as const,
-              items: [
-                { id: 'settings', text: '設定' },
-                { id: 'signout', text: 'サインアウト' },
-              ],
-            },
-          ]}
-          i18nStrings={{
-            overflowMenuTriggerText: 'その他',
-            overflowMenuTitleText: 'すべて',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            right: '200px',
-            top: '50%',
-            transform: 'translateY(-50%)',
-            zIndex: 1000,
-          }}
-        >
-          <NotificationPanel />
-        </div>
+      <div id="admin-top-nav" style={{ position: 'relative', minHeight: 72 }}>
+        {mounted ? (
+          <>
+            <TopNavigation
+              identity={{
+                href: '/admin',
+                title: 'TenkaCloud',
+                onFollow: (e) => {
+                  e.preventDefault();
+                  router.push('/admin');
+                },
+              }}
+              utilities={[
+                ...(tenant?.slug
+                  ? [
+                      {
+                        type: 'button' as const,
+                        text: tenant.slug,
+                        disableUtilityCollapse: true,
+                      },
+                    ]
+                  : []),
+                {
+                  type: 'button' as const,
+                  text: '参加者画面へ',
+                  href: '/dashboard',
+                  variant: 'link' as const,
+                },
+                {
+                  type: 'menu-dropdown' as const,
+                  text: session?.user?.name || '管理者',
+                  iconName: 'user-profile' as const,
+                  items: [
+                    { id: 'settings', text: '設定' },
+                    { id: 'signout', text: 'サインアウト' },
+                  ],
+                },
+              ]}
+              i18nStrings={{
+                overflowMenuTriggerText: 'その他',
+                overflowMenuTitleText: 'すべて',
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                right: '200px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                zIndex: 1000,
+              }}
+            >
+              <NotificationPanel />
+            </div>
+          </>
+        ) : null}
       </div>
       <AppLayout
         navigation={

--- a/apps/application-plane/app/(admin)/admin/marketplace/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/marketplace/__tests__/page.test.tsx
@@ -80,19 +80,21 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
     vi.clearAllMocks();
   });
 
+  async function waitForProblemCards() {
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
+      ).toBeInTheDocument();
+    });
+  }
+
   describe('\u30d7\u30ec\u30d3\u30e5\u30fc\u30e2\u30fc\u30c0\u30eb', () => {
     it('\u30d7\u30ec\u30d3\u30e5\u30fc\u30dc\u30bf\u30f3\u3092\u30af\u30ea\u30c3\u30af\u3059\u308b\u3068\u554f\u984c\u8a73\u7d30\u30e2\u30fc\u30c0\u30eb\u3092\u8868\u793a\u3059\u3079\u304d', async () => {
       const user = userEvent.setup();
       mockGetProblems.mockResolvedValue(problemsResponse);
       mockGetProblem.mockResolvedValue(baseProblem);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       );
@@ -106,13 +108,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
       mockGetProblems.mockResolvedValue(problemsResponse);
       mockGetProblem.mockResolvedValue(baseProblem);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       );
@@ -133,13 +129,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
       mockGetProblems.mockResolvedValue(problemsResponse);
       mockGetProblem.mockResolvedValue(baseProblem);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       );
@@ -153,13 +143,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
       mockGetProblems.mockResolvedValue(problemsResponse);
       mockGetProblem.mockRejectedValue(new Error('Not found'));
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       );
@@ -177,13 +161,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
       mockGetProblems.mockResolvedValue(problemsResponse);
       mockGetProblem.mockResolvedValue(baseProblem);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       );
@@ -207,13 +185,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
       });
       vi.stubGlobal('fetch', mockFetch);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       await user.click(
         screen.getByRole('button', {
           name: '\u30a4\u30d9\u30f3\u30c8\u306b\u8ffd\u52a0',
@@ -233,13 +205,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
     it('\u30d7\u30ec\u30d3\u30e5\u30fc\u30dc\u30bf\u30f3\u304c\u6709\u52b9\u3067\u3042\u308b\u3079\u304d', async () => {
       mockGetProblems.mockResolvedValue(problemsResponse);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       expect(
         screen.getByRole('button', { name: '\u30d7\u30ec\u30d3\u30e5\u30fc' }),
       ).not.toBeDisabled();
@@ -248,13 +214,7 @@ describe('Admin \u30de\u30fc\u30b1\u30c3\u30c8\u30d7\u30ec\u30a4\u30b9\u30da\u30
     it('\u30a4\u30d9\u30f3\u30c8\u306b\u8ffd\u52a0\u30dc\u30bf\u30f3\u304c\u6709\u52b9\u3067\u3042\u308b\u3079\u304d', async () => {
       mockGetProblems.mockResolvedValue(problemsResponse);
       render(<AdminMarketplacePage />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'S3 \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u5b9a',
-          ),
-        ).toBeInTheDocument();
-      });
+      await waitForProblemCards();
       expect(
         screen.getByRole('button', {
           name: '\u30a4\u30d9\u30f3\u30c8\u306b\u8ffd\u52a0',

--- a/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
@@ -7,30 +7,29 @@
 
 'use client';
 
-import { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import CloudscapeBadge from '@cloudscape-design/components/badge';
 import Box from '@cloudscape-design/components/box';
 import CloudscapeButton from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Container from '@cloudscape-design/components/container';
 import Flashbar from '@cloudscape-design/components/flashbar';
+import FormField from '@cloudscape-design/components/form-field';
 import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
 import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Modal from '@cloudscape-design/components/modal';
 import CloudscapeSelect from '@cloudscape-design/components/select';
+import type { SelectProps } from '@cloudscape-design/components/select';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import '@cloudscape-design/global-styles/index.css';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import {
-  Badge,
   ErrorState,
   getErrorMessage,
   getErrorType,
-  Input,
-  Select,
   Skeleton,
 } from '@/components/ui';
 import { getProblem, getProblems } from '@/lib/api/admin-problems';
@@ -112,11 +111,6 @@ export default function AdminMarketplacePage() {
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [addingToEvent, setAddingToEvent] = useState(false);
   const [flashMessages, setFlashMessages] = useState<FlashMessage[]>([]);
-
-  const searchInputId = useId();
-  const categoryFilterId = useId();
-  const difficultyFilterId = useId();
-  const cloudProviderFilterId = useId();
 
   const fetchProblems = useCallback(async () => {
     try {
@@ -237,23 +231,6 @@ export default function AdminMarketplacePage() {
     }
   }, [selectedEventId, addToEventProblemId, handleCloseAddToEvent]);
 
-  const getDifficultyBadgeVariant = (
-    difficulty: DifficultyLevel,
-  ): 'default' | 'success' | 'warning' | 'danger' | 'purple' => {
-    switch (difficulty) {
-      case 'easy':
-        return 'success';
-      case 'medium':
-        return 'warning';
-      case 'hard':
-        return 'danger';
-      case 'expert':
-        return 'purple';
-      default:
-        return 'default';
-    }
-  };
-
   const getDifficultyLabel = (difficulty: DifficultyLevel): string => {
     switch (difficulty) {
       case 'easy':
@@ -353,8 +330,34 @@ export default function AdminMarketplacePage() {
         ).toFixed(1)
       : '0.0';
 
+  const categoryOptions: SelectProps.Option[] = [
+    { label: 'すべて', value: '' },
+    { label: 'アーキテクチャ', value: 'architecture' },
+    { label: 'セキュリティ', value: 'security' },
+    { label: 'コスト最適化', value: 'cost' },
+    { label: 'パフォーマンス', value: 'performance' },
+    { label: '信頼性', value: 'reliability' },
+    { label: '運用', value: 'operations' },
+  ];
+
+  const difficultyOptions: SelectProps.Option[] = [
+    { label: 'すべて', value: '' },
+    { label: '初級', value: 'easy' },
+    { label: '中級', value: 'medium' },
+    { label: '上級', value: 'hard' },
+    { label: 'エキスパート', value: 'expert' },
+  ];
+
+  const providerOptions: SelectProps.Option[] = [
+    { label: 'すべて', value: '' },
+    { label: 'AWS', value: 'aws' },
+    { label: 'Google Cloud', value: 'gcp' },
+    { label: 'Azure', value: 'azure' },
+    { label: 'LocalStack', value: 'local' },
+  ];
+
   return (
-    <div className="space-y-6">
+    <SpaceBetween size="l">
       {flashMessages.length > 0 && (
         <Flashbar
           items={flashMessages.map((msg) => ({
@@ -368,118 +371,66 @@ export default function AdminMarketplacePage() {
         />
       )}
 
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-text-primary flex items-center gap-3">
-          <span className="text-hn-accent font-mono">&gt;_</span>
-          問題マーケットプレイス
-        </h1>
-      </div>
+      <Header
+        variant="h1"
+        description="公開済みの問題を検索し、イベントへ追加できます"
+      >
+        問題マーケットプレイス
+      </Header>
 
-      {/* Search & Filters */}
-      <Card>
-        <CardContent className="p-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            <div className="lg:col-span-2">
-              <label htmlFor={searchInputId} className="sr-only">
-                検索
-              </label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <svg
-                    className="h-5 w-5 text-text-muted"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                    />
-                  </svg>
-                </div>
-                <Input
-                  id={searchInputId}
-                  type="text"
-                  placeholder="タイトル、説明、タグで検索..."
-                  className="pl-10"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                />
-              </div>
-            </div>
+      <Container header={<Header variant="h2">検索と絞り込み</Header>}>
+        <ColumnLayout columns={4} variant="text-grid">
+          <FormField label="検索">
+            <Input
+              value={searchQuery}
+              onChange={({ detail }) => setSearchQuery(detail.value)}
+              placeholder="タイトル、説明、タグで検索..."
+              type="search"
+              inputMode="search"
+            />
+          </FormField>
+          <FormField label="カテゴリ">
+            <CloudscapeSelect
+              selectedOption={
+                categoryOptions.find(
+                  (option) => option.value === selectedCategory,
+                ) ?? null
+              }
+              onChange={({ detail }) =>
+                setSelectedCategory(detail.selectedOption.value ?? '')
+              }
+              options={categoryOptions}
+            />
+          </FormField>
+          <FormField label="難易度">
+            <CloudscapeSelect
+              selectedOption={
+                difficultyOptions.find(
+                  (option) => option.value === selectedDifficulty,
+                ) ?? null
+              }
+              onChange={({ detail }) =>
+                setSelectedDifficulty(detail.selectedOption.value ?? '')
+              }
+              options={difficultyOptions}
+            />
+          </FormField>
+          <FormField label="クラウド">
+            <CloudscapeSelect
+              selectedOption={
+                providerOptions.find(
+                  (option) => option.value === selectedCloudProvider,
+                ) ?? null
+              }
+              onChange={({ detail }) =>
+                setSelectedCloudProvider(detail.selectedOption.value ?? '')
+              }
+              options={providerOptions}
+            />
+          </FormField>
+        </ColumnLayout>
+      </Container>
 
-            <div>
-              <label
-                htmlFor={categoryFilterId}
-                className="block text-xs font-medium text-text-muted mb-1"
-              >
-                カテゴリ
-              </label>
-              <Select
-                id={categoryFilterId}
-                value={selectedCategory}
-                onChange={(e) => setSelectedCategory(e.target.value)}
-                options={[
-                  { value: '', label: 'すべて' },
-                  { value: 'architecture', label: 'アーキテクチャ' },
-                  { value: 'security', label: 'セキュリティ' },
-                  { value: 'cost', label: 'コスト最適化' },
-                  { value: 'performance', label: 'パフォーマンス' },
-                  { value: 'reliability', label: '信頼性' },
-                  { value: 'operations', label: '運用' },
-                ]}
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor={difficultyFilterId}
-                className="block text-xs font-medium text-text-muted mb-1"
-              >
-                難易度
-              </label>
-              <Select
-                id={difficultyFilterId}
-                value={selectedDifficulty}
-                onChange={(e) => setSelectedDifficulty(e.target.value)}
-                options={[
-                  { value: '', label: 'すべて' },
-                  { value: 'easy', label: '初級' },
-                  { value: 'medium', label: '中級' },
-                  { value: 'hard', label: '上級' },
-                  { value: 'expert', label: 'エキスパート' },
-                ]}
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor={cloudProviderFilterId}
-                className="block text-xs font-medium text-text-muted mb-1"
-              >
-                クラウド
-              </label>
-              <Select
-                id={cloudProviderFilterId}
-                value={selectedCloudProvider}
-                onChange={(e) => setSelectedCloudProvider(e.target.value)}
-                options={[
-                  { value: '', label: 'すべて' },
-                  { value: 'aws', label: 'AWS' },
-                  { value: 'gcp', label: 'Google Cloud' },
-                  { value: 'azure', label: 'Azure' },
-                  { value: 'local', label: 'LocalStack' },
-                ]}
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Error State */}
       {error && (
         <ErrorState
           message={getErrorMessage(error)}
@@ -488,53 +439,34 @@ export default function AdminMarketplacePage() {
         />
       )}
 
-      {/* Stats - hidden when error */}
       {!error && (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <Card>
-            <CardContent className="p-6">
-              <div className="text-sm font-medium text-text-muted">
-                公開問題数
-              </div>
-              <div className="text-3xl font-bold text-text-primary mt-1 font-mono">
-                {loading ? <Skeleton className="h-9 w-12" /> : totalProblems}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-6">
-              <div className="text-sm font-medium text-text-muted">
-                平均評価
-              </div>
-              <div className="text-3xl font-bold text-hn-warning mt-1 font-mono flex items-center gap-2">
-                <span>★</span>
-                {loading ? <Skeleton className="h-9 w-12" /> : avgRating}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-6">
-              <div className="text-sm font-medium text-text-muted">
-                検索結果
-              </div>
-              <div className="text-3xl font-bold text-hn-accent mt-1 font-mono">
-                {loading ? (
-                  <Skeleton className="h-9 w-12" />
-                ) : (
-                  filteredProblems.length
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+        <ColumnLayout columns={3} variant="text-grid">
+          <Container>
+            <Box variant="awsui-key-label">公開問題数</Box>
+            <Box variant="awsui-value-large">
+              {loading ? <Skeleton className="h-9 w-12" /> : totalProblems}
+            </Box>
+          </Container>
+          <Container>
+            <Box variant="awsui-key-label">平均評価</Box>
+            <Box variant="awsui-value-large">
+              {loading ? <Skeleton className="h-9 w-12" /> : `★ ${avgRating}`}
+            </Box>
+          </Container>
+          <Container>
+            <Box variant="awsui-key-label">検索結果</Box>
+            <Box variant="awsui-value-large">
+              {loading ? <Skeleton className="h-9 w-12" /> : filteredProblems.length}
+            </Box>
+          </Container>
+        </ColumnLayout>
       )}
 
-      {/* Problems Grid - hidden when error */}
       {!error && loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {Array.from({ length: 4 }).map((_, i) => (
-            <Card key={i}>
-              <CardContent className="p-6">
+            <Container key={i}>
+              <SpaceBetween size="m">
                 <Skeleton className="h-6 w-3/4 mb-4" />
                 <div className="space-y-3">
                   <Skeleton className="h-4 w-full" />
@@ -544,135 +476,117 @@ export default function AdminMarketplacePage() {
                   <Skeleton className="h-6 w-16" />
                   <Skeleton className="h-6 w-16" />
                 </div>
-              </CardContent>
-            </Card>
+              </SpaceBetween>
+            </Container>
           ))}
         </div>
       ) : !error && filteredProblems.length === 0 ? (
-        <Card className="text-center py-12">
-          <div className="text-4xl mb-4">🔍</div>
-          <h2 className="text-xl font-semibold text-text-primary mb-2">
-            問題が見つかりません
-          </h2>
-          <p className="text-text-muted">検索条件を変更してください。</p>
-        </Card>
+        <Container>
+          <Box textAlign="center" padding="xxl">
+            <SpaceBetween size="m">
+              <Box variant="h2">問題が見つかりません</Box>
+              <Box color="text-body-secondary">
+                検索条件または絞り込み条件を変更してください。
+              </Box>
+            </SpaceBetween>
+          </Box>
+        </Container>
       ) : !error ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {filteredProblems.map((problem) => (
-            <Card
-              key={problem.id}
-              className="group hover:border-hn-accent/50 transition-all duration-[var(--animation-duration-fast)]"
-            >
-              <CardHeader className="pb-2">
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <span className="text-2xl">
-                      {getCategoryIcon(problem.category)}
-                    </span>
-                    <div>
-                      <CardTitle className="text-lg group-hover:text-hn-accent transition-colors">
-                        {problem.title}
-                      </CardTitle>
-                      <p className="text-sm text-text-muted font-mono">
-                        {problem.authorName}
-                      </p>
-                    </div>
-                  </div>
-                  <Badge
-                    variant={problem.type === 'gameday' ? 'primary' : 'info'}
-                  >
-                    {problem.type === 'gameday'
-                      ? 'Incident Drill'
-                      : 'Challenge'}
-                  </Badge>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-text-secondary mb-4 line-clamp-2">
-                  {problem.description}
-                </p>
-
-                <div className="flex flex-wrap gap-2 mb-4">
-                  <Badge
-                    variant={getDifficultyBadgeVariant(problem.difficulty)}
-                  >
-                    {getDifficultyLabel(problem.difficulty)}
-                  </Badge>
-                  <Badge variant="default">
-                    {getCategoryLabel(problem.category)}
-                  </Badge>
-                  <Badge variant="default" className="font-mono uppercase">
-                    {problem.cloudProvider}
-                  </Badge>
-                </div>
-
-                <div className="flex items-center justify-between text-sm text-text-muted mb-4">
-                  <span className="flex items-center gap-1">
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
+        <Cards
+          cardsPerRow={[
+            { cards: 1 },
+            { minWidth: 700, cards: 2 },
+          ]}
+          items={filteredProblems}
+          cardDefinition={{
+            header: (problem) => (
+              <SpaceBetween direction="horizontal" size="s">
+                <Box fontSize="heading-m" fontWeight="bold">
+                  {getCategoryIcon(problem.category)} {problem.title}
+                </Box>
+                <CloudscapeBadge color={problem.type === 'gameday' ? 'blue' : 'green'}>
+                  {problem.type === 'gameday' ? 'Incident Drill' : 'Challenge'}
+                </CloudscapeBadge>
+              </SpaceBetween>
+            ),
+            sections: [
+              {
+                id: 'author',
+                header: '作成者',
+                content: (problem) => problem.authorName,
+              },
+              {
+                id: 'description',
+                header: '説明',
+                content: (problem) => (
+                  <Box color="text-body-secondary">{problem.description}</Box>
+                ),
+              },
+              {
+                id: 'meta',
+                header: '属性',
+                content: (problem) => (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <CloudscapeBadge color="grey">
+                      {getDifficultyLabel(problem.difficulty)}
+                    </CloudscapeBadge>
+                    <CloudscapeBadge color="grey">
+                      {getCategoryLabel(problem.category)}
+                    </CloudscapeBadge>
+                    <CloudscapeBadge color="grey">
+                      {problem.cloudProvider.toUpperCase()}
+                    </CloudscapeBadge>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'summary',
+                header: '概要',
+                content: (problem) => (
+                  <Box color="text-body-secondary">
+                    推定 {problem.estimatedTimeMinutes} 分 / ★{' '}
+                    {problem.rating.toFixed(1)} / {problem.usageCount} 回使用
+                  </Box>
+                ),
+              },
+              {
+                id: 'tags',
+                header: 'タグ',
+                content: (problem) => (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    {problem.tags.slice(0, 3).map((tag) => (
+                      <CloudscapeBadge key={tag}>{tag}</CloudscapeBadge>
+                    ))}
+                    {problem.tags.length > 3 ? (
+                      <Box color="text-body-secondary">
+                        +{problem.tags.length - 3}
+                      </Box>
+                    ) : null}
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'actions',
+                header: '操作',
+                content: (problem) => (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <CloudscapeButton onClick={() => handlePreview(problem.id)}>
+                      プレビュー
+                    </CloudscapeButton>
+                    <CloudscapeButton
+                      variant="primary"
+                      onClick={() => handleAddToEvent(problem.id)}
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    {problem.estimatedTimeMinutes} 分
-                  </span>
-                  <span className="flex items-center gap-1 text-hn-warning">
-                    ★ {problem.rating.toFixed(1)}
-                  </span>
-                  <span className="font-mono">{problem.usageCount} 回使用</span>
-                </div>
-
-                <div className="flex flex-wrap gap-1 mb-4">
-                  {problem.tags.slice(0, 3).map((tag) => (
-                    <span
-                      key={tag}
-                      className="text-xs px-2 py-1 bg-surface-2 text-text-muted rounded-[var(--radius)] font-mono"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                  {problem.tags.length > 3 && (
-                    <span className="text-xs px-2 py-1 text-text-muted">
-                      +{problem.tags.length - 3}
-                    </span>
-                  )}
-                </div>
-
-                <div className="flex gap-2">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="flex-1"
-                    onClick={() => handlePreview(problem.id)}
-                  >
-                    プレビュー
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="flex-1"
-                    onClick={() => handleAddToEvent(problem.id)}
-                  >
-                    イベントに追加
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+                      イベントに追加
+                    </CloudscapeButton>
+                  </SpaceBetween>
+                ),
+              },
+            ],
+          }}
+        />
       ) : null}
-
-      {/* Terminal-style footer */}
-      <div className="text-center text-text-muted text-xs font-mono py-4">
-        <span className="text-hn-accent">$</span> marketplace --search --count=
-        {filteredProblems.length}
-      </div>
+      
       {/* Preview Modal */}
       <Modal
         visible={previewVisible}
@@ -900,6 +814,6 @@ export default function AdminMarketplacePage() {
           )}
         </SpaceBetween>
       </Modal>
-    </div>
+    </SpaceBetween>
   );
 }

--- a/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/marketplace/page.tsx
@@ -456,7 +456,11 @@ export default function AdminMarketplacePage() {
           <Container>
             <Box variant="awsui-key-label">検索結果</Box>
             <Box variant="awsui-value-large">
-              {loading ? <Skeleton className="h-9 w-12" /> : filteredProblems.length}
+              {loading ? (
+                <Skeleton className="h-9 w-12" />
+              ) : (
+                filteredProblems.length
+              )}
             </Box>
           </Container>
         </ColumnLayout>
@@ -493,10 +497,7 @@ export default function AdminMarketplacePage() {
         </Container>
       ) : !error ? (
         <Cards
-          cardsPerRow={[
-            { cards: 1 },
-            { minWidth: 700, cards: 2 },
-          ]}
+          cardsPerRow={[{ cards: 1 }, { minWidth: 700, cards: 2 }]}
           items={filteredProblems}
           cardDefinition={{
             header: (problem) => (
@@ -504,7 +505,9 @@ export default function AdminMarketplacePage() {
                 <Box fontSize="heading-m" fontWeight="bold">
                   {getCategoryIcon(problem.category)} {problem.title}
                 </Box>
-                <CloudscapeBadge color={problem.type === 'gameday' ? 'blue' : 'green'}>
+                <CloudscapeBadge
+                  color={problem.type === 'gameday' ? 'blue' : 'green'}
+                >
                   {problem.type === 'gameday' ? 'Incident Drill' : 'Challenge'}
                 </CloudscapeBadge>
               </SpaceBetween>
@@ -586,7 +589,7 @@ export default function AdminMarketplacePage() {
           }}
         />
       ) : null}
-      
+
       {/* Preview Modal */}
       <Modal
         visible={previewVisible}

--- a/apps/application-plane/app/api/admin/events/[eventId]/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/events/[eventId]/__tests__/route.test.ts
@@ -6,6 +6,10 @@ import type { Session } from 'next-auth';
 const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
 const mockServerApiRequest = vi.fn();
 
+vi.mock('@/auth', () => ({
+  authSkipEnabled: true,
+}));
+
 vi.mock('@/lib/api/server', () => ({
   getAdminSession: () => mockGetAdminSession(),
   serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
@@ -22,6 +26,11 @@ vi.mock('@/lib/api/server', () => ({
 describe('Admin Event Detail API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete (
+      globalThis as typeof globalThis & {
+        __TENKACLOUD_DEV_EVENTS__?: unknown[];
+      }
+    ).__TENKACLOUD_DEV_EVENTS__;
   });
 
   const createParams = (eventId: string) => Promise.resolve({ eventId });
@@ -141,6 +150,70 @@ describe('Admin Event Detail API', () => {
         '/admin/events/event-1',
         expect.objectContaining({
           method: 'PUT',
+        }),
+      );
+    });
+
+    it('network error 時は local dev store のイベントを更新すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      (
+        globalThis as typeof globalThis & {
+          __TENKACLOUD_DEV_EVENTS__?: unknown[];
+        }
+      ).__TENKACLOUD_DEV_EVENTS__ = [
+        {
+          id: 'event-1',
+          slug: 'test-event',
+          name: 'Test Event',
+          type: 'gameday',
+          status: 'draft',
+          startTime: '2026-04-09T00:00:00.000Z',
+          endTime: '2026-04-10T23:59:59.000Z',
+          timezone: 'Asia/Tokyo',
+          participantType: 'individual',
+          cloudProvider: 'local',
+          regions: ['local'],
+          scoringType: 'realtime',
+          leaderboardVisible: true,
+          problemCount: 0,
+          participantCount: 0,
+          isRegistered: false,
+          createdAt: '2026-04-09T00:00:00.000Z',
+        },
+      ];
+
+      const { PATCH, GET } = await import('../route');
+      const response = await PATCH(
+        new NextRequest('http://localhost/api/admin/events/event-1', {
+          method: 'PATCH',
+          body: JSON.stringify({ status: 'scheduled' }),
+        }),
+        { params: createParams('event-1') },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: 'event-1',
+          status: 'scheduled',
+        }),
+      );
+
+      const detailResponse = await GET(
+        new NextRequest('http://localhost/api/admin/events/event-1'),
+        { params: createParams('event-1') },
+      );
+      await expect(detailResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: 'event-1',
+          status: 'scheduled',
         }),
       );
     });

--- a/apps/application-plane/app/api/admin/events/[eventId]/route.ts
+++ b/apps/application-plane/app/api/admin/events/[eventId]/route.ts
@@ -18,11 +18,7 @@ import {
   serverApiRequest,
 } from '@/lib/api/server';
 import type { EventDetails, EventStatus } from '@/lib/api/types';
-import {
-  deleteDevEvent,
-  findDevEvent,
-  updateDevEvent,
-} from '../dev-store';
+import { deleteDevEvent, findDevEvent, updateDevEvent } from '../dev-store';
 
 /**
  * イベント更新リクエスト型

--- a/apps/application-plane/app/api/admin/events/[eventId]/route.ts
+++ b/apps/application-plane/app/api/admin/events/[eventId]/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
   unauthorizedResponse,
@@ -17,6 +18,11 @@ import {
   serverApiRequest,
 } from '@/lib/api/server';
 import type { EventDetails, EventStatus } from '@/lib/api/types';
+import {
+  deleteDevEvent,
+  findDevEvent,
+  updateDevEvent,
+} from '../dev-store';
 
 /**
  * イベント更新リクエスト型
@@ -31,6 +37,16 @@ interface UpdateEventRequest {
   endTime?: string;
   status?: EventStatus;
   imageUrl?: string;
+}
+
+function isLocalDevFallbackError(error: unknown): boolean {
+  const isAuthSkipUnauthorized =
+    authSkipEnabled &&
+    error instanceof Error &&
+    /^Unauthorized$/i.test(error.message);
+  const isNetworkError =
+    error instanceof TypeError && /fetch failed/i.test(String(error));
+  return isAuthSkipUnauthorized || isNetworkError;
 }
 
 /**
@@ -58,6 +74,14 @@ export async function GET(
     );
     return successResponse(data);
   } catch (error) {
+    if (isLocalDevFallbackError(error)) {
+      console.warn('Admin event detail fallback to local dev store:', error);
+      const event = findDevEvent(eventId);
+      if (event) {
+        return successResponse(event);
+      }
+    }
+
     console.error('Failed to fetch event:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to fetch event',
@@ -83,10 +107,9 @@ export async function PUT(
   }
 
   const { eventId } = await params;
+  const body = (await request.json()) as UpdateEventRequest;
 
   try {
-    const body = (await request.json()) as UpdateEventRequest;
-
     const data = await serverApiRequest<EventDetails>(
       `/admin/events/${eventId}`,
       {
@@ -97,11 +120,26 @@ export async function PUT(
 
     return successResponse(data);
   } catch (error) {
+    if (isLocalDevFallbackError(error)) {
+      console.warn('Admin event update fallback to local dev store:', error);
+      const event = updateDevEvent(eventId, body);
+      if (event) {
+        return successResponse(event);
+      }
+    }
+
     console.error('Failed to update event:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to update event',
     );
   }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ eventId: string }> },
+) {
+  return PUT(request, context);
 }
 
 /**
@@ -130,6 +168,11 @@ export async function DELETE(
 
     return successResponse({ success: true, message: 'Event deleted' });
   } catch (error) {
+    if (isLocalDevFallbackError(error) && deleteDevEvent(eventId)) {
+      console.warn('Admin event delete fallback to local dev store:', error);
+      return successResponse({ success: true, message: 'Event deleted' });
+    }
+
     console.error('Failed to delete event:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to delete event',

--- a/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
@@ -27,6 +27,11 @@ vi.mock('@/lib/api/server', () => ({
 describe('Admin Events API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete (
+      globalThis as typeof globalThis & {
+        __TENKACLOUD_DEV_EVENTS__?: unknown[];
+      }
+    ).__TENKACLOUD_DEV_EVENTS__;
   });
 
   describe('GET /api/admin/events', () => {
@@ -298,6 +303,57 @@ describe('Admin Events API', () => {
       expect(response.status).toBe(201);
       const data = await response.json();
       expect(data).toEqual(createdEvent);
+    });
+
+    it('network error 時は local dev store に作成して 201 を返すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { POST, GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/events', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Local Event',
+          slug: 'local-event',
+          type: 'gameday',
+          status: 'draft',
+          startTime: '2026-04-09T00:00:00.000Z',
+          endTime: '2026-04-10T23:59:59.000Z',
+          timezone: 'Asia/Tokyo',
+          participantType: 'individual',
+          cloudProvider: 'local',
+          regions: ['local'],
+          scoringType: 'realtime',
+          leaderboardVisible: true,
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data).toEqual(
+        expect.objectContaining({
+          name: 'Local Event',
+          type: 'gameday',
+          cloudProvider: 'local',
+          regions: ['local'],
+        }),
+      );
+
+      const listResponse = await GET(
+        new NextRequest('http://localhost/api/admin/events'),
+      );
+      await expect(listResponse.json()).resolves.toEqual({
+        events: [expect.objectContaining({ name: 'Local Event' })],
+        total: 1,
+        page: 1,
+        pageSize: 10,
+      });
     });
   });
 });

--- a/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
@@ -212,8 +212,8 @@ describe('Admin Events API', () => {
         method: 'POST',
         body: JSON.stringify({
           name: '',
-          slug: 'test',
-          eventDate: '2024-01-01',
+          startTime: '2024-01-01T00:00:00.000Z',
+          endTime: '2024-01-02T23:59:59.000Z',
         }),
       });
       const response = await POST(request);
@@ -223,7 +223,7 @@ describe('Admin Events API', () => {
       expect(data.error).toBe('Event name is required');
     });
 
-    it('slug が空の場合は 400 を返すべき', async () => {
+    it('startTime がない場合は 400 を返すべき', async () => {
       const session: Session = {
         user: { name: 'Admin', email: 'admin@example.com' },
         expires: new Date().toISOString(),
@@ -236,18 +236,17 @@ describe('Admin Events API', () => {
         method: 'POST',
         body: JSON.stringify({
           name: 'Test Event',
-          slug: '',
-          eventDate: '2024-01-01',
+          endTime: '2024-01-02T23:59:59.000Z',
         }),
       });
       const response = await POST(request);
 
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.error).toBe('Event slug is required');
+      expect(data.error).toBe('Event start time is required');
     });
 
-    it('eventDate がない場合は 400 を返すべき', async () => {
+    it('endTime がない場合は 400 を返すべき', async () => {
       const session: Session = {
         user: { name: 'Admin', email: 'admin@example.com' },
         expires: new Date().toISOString(),
@@ -258,13 +257,16 @@ describe('Admin Events API', () => {
       const { POST } = await import('../route');
       const request = new NextRequest('http://localhost/api/admin/events', {
         method: 'POST',
-        body: JSON.stringify({ name: 'Test Event', slug: 'test' }),
+        body: JSON.stringify({
+          name: 'Test Event',
+          startTime: '2024-01-01T00:00:00.000Z',
+        }),
       });
       const response = await POST(request);
 
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.error).toBe('Event date is required');
+      expect(data.error).toBe('Event end time is required');
     });
 
     it('イベントを作成し 201 を返すべき', async () => {
@@ -278,8 +280,6 @@ describe('Admin Events API', () => {
       const createdEvent = {
         id: 'event-1',
         name: 'Test Event',
-        slug: 'test-event',
-        eventDate: '2024-01-01',
         status: 'draft',
       };
       mockServerApiRequest.mockResolvedValue(createdEvent);
@@ -289,8 +289,8 @@ describe('Admin Events API', () => {
         method: 'POST',
         body: JSON.stringify({
           name: 'Test Event',
-          slug: 'test-event',
-          eventDate: '2024-01-01',
+          startTime: '2024-01-01T00:00:00.000Z',
+          endTime: '2024-01-02T23:59:59.000Z',
         }),
       });
       const response = await POST(request);

--- a/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
@@ -5,6 +5,11 @@ import type { Session } from 'next-auth';
 // Mock server utilities
 const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
 const mockServerApiRequest = vi.fn();
+const mockAuthSkipEnabled = true;
+
+vi.mock('@/auth', () => ({
+  authSkipEnabled: mockAuthSkipEnabled,
+}));
 
 vi.mock('@/lib/api/server', () => ({
   getAdminSession: () => mockGetAdminSession(),
@@ -129,6 +134,54 @@ describe('Admin Events API', () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error).toBe('API Error');
+    });
+
+    it('AUTH_SKIP の Unauthorized は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new Error('Unauthorized'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest(
+        'http://localhost/api/admin/events?page=3&pageSize=25',
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        events: [],
+        total: 0,
+        page: 3,
+        pageSize: 25,
+      });
+    });
+
+    it('network error は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/events');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        events: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      });
     });
   });
 

--- a/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/events/__tests__/route.test.ts
@@ -274,6 +274,52 @@ describe('Admin Events API', () => {
       expect(data.error).toBe('Event end time is required');
     });
 
+    it('不正な JSON の場合は 400 を返すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+
+      const { POST } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/events', {
+        method: 'POST',
+        body: '{',
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Invalid request',
+      });
+    });
+
+    it('name が文字列でない場合は 400 を返すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+
+      const { POST } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/events', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: 123,
+          startTime: '2024-01-01T00:00:00.000Z',
+          endTime: '2024-01-02T23:59:59.000Z',
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Event name is required',
+      });
+    });
+
     it('イベントを作成し 201 を返すべき', async () => {
       const session: Session = {
         user: { name: 'Admin', email: 'admin@example.com' },

--- a/apps/application-plane/app/api/admin/events/dev-store.ts
+++ b/apps/application-plane/app/api/admin/events/dev-store.ts
@@ -81,8 +81,7 @@ export function createDevEvent(body: DevEventPayload): DevEventRecord {
     status: body.status || 'draft',
     startTime: body.startTime || now,
     endTime:
-      body.endTime ||
-      new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      body.endTime || new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     timezone: body.timezone || 'Asia/Tokyo',
     participantType:
       (body.participantType as ParticipantEvent['participantType']) ||

--- a/apps/application-plane/app/api/admin/events/dev-store.ts
+++ b/apps/application-plane/app/api/admin/events/dev-store.ts
@@ -1,0 +1,139 @@
+import type { ParticipantEvent, EventStatus } from '@/lib/api/types';
+
+export interface DevEventRecord extends ParticipantEvent {
+  slug: string;
+  createdAt: string;
+  description?: string;
+  organizer?: string;
+  eventDate?: string;
+  imageUrl?: string;
+}
+
+interface DevEventPayload {
+  name: string;
+  slug?: string;
+  description?: string;
+  organizer?: string;
+  eventDate?: string;
+  startTime?: string;
+  endTime?: string;
+  status?: EventStatus;
+  imageUrl?: string;
+  type?: string;
+  timezone?: string;
+  participantType?: string;
+  cloudProvider?: string;
+  regions?: string[];
+  scoringType?: string;
+  leaderboardVisible?: boolean;
+}
+
+interface DevEventUpdate {
+  name?: string;
+  slug?: string;
+  description?: string;
+  organizer?: string;
+  eventDate?: string;
+  startTime?: string;
+  endTime?: string;
+  status?: EventStatus;
+  imageUrl?: string;
+}
+
+export function getDevEventStore(): DevEventRecord[] {
+  const globalStore = globalThis as typeof globalThis & {
+    __TENKACLOUD_DEV_EVENTS__?: DevEventRecord[];
+  };
+  if (!globalStore.__TENKACLOUD_DEV_EVENTS__) {
+    globalStore.__TENKACLOUD_DEV_EVENTS__ = [];
+  }
+  return globalStore.__TENKACLOUD_DEV_EVENTS__;
+}
+
+export function listDevEvents(
+  page: number,
+  pageSize: number,
+  status?: EventStatus | null,
+): { events: DevEventRecord[]; total: number; page: number; pageSize: number } {
+  const store = getDevEventStore();
+  const filtered = status
+    ? store.filter((event) => event.status === status)
+    : store;
+  const offset = Math.max(page - 1, 0) * pageSize;
+  return {
+    events: filtered.slice(offset, offset + pageSize),
+    total: filtered.length,
+    page,
+    pageSize,
+  };
+}
+
+export function createDevEvent(body: DevEventPayload): DevEventRecord {
+  const now = new Date().toISOString();
+  const event: DevEventRecord = {
+    id: `dev-event-${Date.now()}`,
+    slug: body.slug?.trim() || `event-${Date.now()}`,
+    name: body.name,
+    description: body.description,
+    organizer: body.organizer,
+    eventDate: body.eventDate || body.startTime,
+    type: (body.type as ParticipantEvent['type']) || 'gameday',
+    status: body.status || 'draft',
+    startTime: body.startTime || now,
+    endTime:
+      body.endTime ||
+      new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    timezone: body.timezone || 'Asia/Tokyo',
+    participantType:
+      (body.participantType as ParticipantEvent['participantType']) ||
+      'individual',
+    cloudProvider:
+      (body.cloudProvider as ParticipantEvent['cloudProvider']) || 'aws',
+    regions: body.regions?.length ? body.regions : ['ap-northeast-1'],
+    scoringType:
+      (body.scoringType as ParticipantEvent['scoringType']) || 'realtime',
+    leaderboardVisible: body.leaderboardVisible ?? true,
+    problemCount: 0,
+    participantCount: 0,
+    isRegistered: false,
+    createdAt: now,
+    imageUrl: body.imageUrl,
+  };
+  getDevEventStore().unshift(event);
+  return event;
+}
+
+export function findDevEvent(eventId: string): DevEventRecord | undefined {
+  return getDevEventStore().find((event) => event.id === eventId);
+}
+
+export function updateDevEvent(
+  eventId: string,
+  input: DevEventUpdate,
+): DevEventRecord | null {
+  const store = getDevEventStore();
+  const index = store.findIndex((event) => event.id === eventId);
+  if (index === -1) {
+    return null;
+  }
+
+  const current = store[index];
+  const updated: DevEventRecord = {
+    ...current,
+    ...input,
+    slug: input.slug?.trim() || current.slug,
+    eventDate: input.eventDate || input.startTime || current.eventDate,
+  };
+  store[index] = updated;
+  return updated;
+}
+
+export function deleteDevEvent(eventId: string): boolean {
+  const store = getDevEventStore();
+  const index = store.findIndex((event) => event.id === eventId);
+  if (index === -1) {
+    return false;
+  }
+  store.splice(index, 1);
+  return true;
+}

--- a/apps/application-plane/app/api/admin/events/dev-store.ts
+++ b/apps/application-plane/app/api/admin/events/dev-store.ts
@@ -137,3 +137,7 @@ export function deleteDevEvent(eventId: string): boolean {
   store.splice(index, 1);
   return true;
 }
+
+export function clearDevEvents() {
+  getDevEventStore().length = 0;
+}

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -18,6 +18,21 @@ import {
 } from '@/lib/api/server';
 import type { ParticipantEvent, EventStatus } from '@/lib/api/types';
 
+interface DevEventRecord extends ParticipantEvent {
+  slug: string;
+  createdAt: string;
+}
+
+function getDevEventStore(): DevEventRecord[] {
+  const globalStore = globalThis as typeof globalThis & {
+    __TENKACLOUD_DEV_EVENTS__?: DevEventRecord[];
+  };
+  if (!globalStore.__TENKACLOUD_DEV_EVENTS__) {
+    globalStore.__TENKACLOUD_DEV_EVENTS__ = [];
+  }
+  return globalStore.__TENKACLOUD_DEV_EVENTS__;
+}
+
 /**
  * Admin イベント一覧レスポンス型
  */
@@ -37,6 +52,55 @@ function emptyEventList(page: number, pageSize: number): AdminEventListResponse 
   };
 }
 
+function buildDevEventList(
+  page: number,
+  pageSize: number,
+  status?: EventStatus | null,
+): AdminEventListResponse {
+  const store = getDevEventStore();
+  const filtered = status
+    ? store.filter((event) => event.status === status)
+    : store;
+  const offset = Math.max(page - 1, 0) * pageSize;
+  return {
+    events: filtered.slice(offset, offset + pageSize),
+    total: filtered.length,
+    page,
+    pageSize,
+  };
+}
+
+function createDevEvent(body: CreateEventRequest): DevEventRecord {
+  const now = new Date().toISOString();
+  const event: DevEventRecord = {
+    id: `dev-event-${Date.now()}`,
+    slug: body.slug?.trim() || `event-${Date.now()}`,
+    name: body.name,
+    type: (body.type as ParticipantEvent['type']) || 'gameday',
+    status: body.status || 'draft',
+    startTime: body.startTime || new Date().toISOString(),
+    endTime:
+      body.endTime ||
+      new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    timezone: body.timezone || 'Asia/Tokyo',
+    participantType:
+      (body.participantType as ParticipantEvent['participantType']) ||
+      'individual',
+    cloudProvider:
+      (body.cloudProvider as ParticipantEvent['cloudProvider']) || 'aws',
+    regions: body.regions?.length ? body.regions : ['ap-northeast-1'],
+    scoringType:
+      (body.scoringType as ParticipantEvent['scoringType']) || 'realtime',
+    leaderboardVisible: body.leaderboardVisible ?? true,
+    problemCount: 0,
+    participantCount: 0,
+    isRegistered: false,
+    createdAt: now,
+  };
+  getDevEventStore().unshift(event);
+  return event;
+}
+
 /**
  * イベント作成リクエスト型
  */
@@ -50,6 +114,13 @@ interface CreateEventRequest {
   endTime?: string;
   status?: EventStatus;
   imageUrl?: string;
+  type?: string;
+  timezone?: string;
+  participantType?: string;
+  cloudProvider?: string;
+  regions?: string[];
+  scoringType?: string;
+  leaderboardVisible?: boolean;
 }
 
 /**
@@ -96,7 +167,7 @@ export async function GET(request: NextRequest) {
 
     if (isAuthSkipUnauthorized || isNetworkError) {
       console.warn('Admin events fallback to empty dataset:', error);
-      return successResponse(emptyEventList(page, pageSize));
+      return successResponse(buildDevEventList(page, pageSize, status));
     }
 
     console.error('Failed to fetch events:', error);
@@ -120,9 +191,9 @@ export async function POST(request: NextRequest) {
       : forbiddenResponse('Admin role required');
   }
 
-  try {
-    const body = (await request.json()) as CreateEventRequest;
+  const body = (await request.json()) as CreateEventRequest;
 
+  try {
     // 必須フィールドのバリデーション
     if (!body.name?.trim()) {
       return badRequestResponse('Event name is required');
@@ -142,6 +213,18 @@ export async function POST(request: NextRequest) {
 
     return successResponse(data, 201);
   } catch (error) {
+    const isAuthSkipUnauthorized =
+      authSkipEnabled &&
+      error instanceof Error &&
+      /^Unauthorized$/i.test(error.message);
+    const isNetworkError =
+      error instanceof TypeError && /fetch failed/i.test(String(error));
+
+    if (isAuthSkipUnauthorized || isNetworkError) {
+      console.warn('Admin events create fallback to local dev store:', error);
+      return successResponse(createDevEvent(body), 201);
+    }
+
     console.error('Failed to create event:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to create event',

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -42,10 +42,10 @@ function emptyEventList(page: number, pageSize: number): AdminEventListResponse 
  */
 interface CreateEventRequest {
   name: string;
-  slug: string;
+  slug?: string;
   description?: string;
   organizer?: string;
-  eventDate: string;
+  eventDate?: string;
   startTime?: string;
   endTime?: string;
   status?: EventStatus;
@@ -127,11 +127,11 @@ export async function POST(request: NextRequest) {
     if (!body.name?.trim()) {
       return badRequestResponse('Event name is required');
     }
-    if (!body.slug?.trim()) {
-      return badRequestResponse('Event slug is required');
+    if (!body.startTime?.trim()) {
+      return badRequestResponse('Event start time is required');
     }
-    if (!body.eventDate) {
-      return badRequestResponse('Event date is required');
+    if (!body.endTime?.trim()) {
+      return badRequestResponse('Event end time is required');
     }
 
     // バックエンド API を呼び出し

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { z } from 'zod';
 import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
@@ -44,24 +45,44 @@ function emptyEventList(
 /**
  * イベント作成リクエスト型
  */
-interface CreateEventRequest {
-  name: string;
-  slug?: string;
-  description?: string;
-  organizer?: string;
-  eventDate?: string;
-  startTime?: string;
-  endTime?: string;
-  status?: EventStatus;
-  imageUrl?: string;
-  type?: string;
-  timezone?: string;
-  participantType?: string;
-  cloudProvider?: string;
-  regions?: string[];
-  scoringType?: string;
-  leaderboardVisible?: boolean;
-}
+const createEventRequestSchema = z.object({
+  name: z
+    .string({
+      required_error: 'Event name is required',
+      invalid_type_error: 'Event name is required',
+    })
+    .trim()
+    .min(1, 'Event name is required'),
+  slug: z.string().trim().min(1).optional(),
+  description: z.string().optional(),
+  organizer: z.string().optional(),
+  eventDate: z.string().optional(),
+  startTime: z
+    .string({
+      required_error: 'Event start time is required',
+      invalid_type_error: 'Event start time is required',
+    })
+    .trim()
+    .min(1, 'Event start time is required'),
+  endTime: z
+    .string({
+      required_error: 'Event end time is required',
+      invalid_type_error: 'Event end time is required',
+    })
+    .trim()
+    .min(1, 'Event end time is required'),
+  status: z.custom<EventStatus>().optional(),
+  imageUrl: z.string().optional(),
+  type: z.string().optional(),
+  timezone: z.string().optional(),
+  participantType: z.string().optional(),
+  cloudProvider: z.string().optional(),
+  regions: z.array(z.string()).optional(),
+  scoringType: z.string().optional(),
+  leaderboardVisible: z.boolean().optional(),
+});
+
+type CreateEventRequest = z.infer<typeof createEventRequestSchema>;
 
 /**
  * GET /api/admin/events
@@ -131,20 +152,24 @@ export async function POST(request: NextRequest) {
       : forbiddenResponse('Admin role required');
   }
 
-  const body = (await request.json()) as CreateEventRequest;
+  const json = await request
+    .json()
+    .catch(() => null satisfies null | Record<string, unknown>);
+  if (json === null) {
+    return badRequestResponse('Invalid request');
+  }
+
+  const parsedBody = createEventRequestSchema.safeParse(json);
+
+  if (!parsedBody.success) {
+    return badRequestResponse(
+      parsedBody.error.issues[0]?.message ?? 'Invalid request',
+    );
+  }
+
+  const body = parsedBody.data;
 
   try {
-    // 必須フィールドのバリデーション
-    if (!body.name?.trim()) {
-      return badRequestResponse('Event name is required');
-    }
-    if (!body.startTime?.trim()) {
-      return badRequestResponse('Event start time is required');
-    }
-    if (!body.endTime?.trim()) {
-      return badRequestResponse('Event end time is required');
-    }
-
     // バックエンド API を呼び出し
     const data = await serverApiRequest<ParticipantEvent>('/admin/events', {
       method: 'POST',

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -17,21 +17,7 @@ import {
   serverApiRequest,
 } from '@/lib/api/server';
 import type { ParticipantEvent, EventStatus } from '@/lib/api/types';
-
-interface DevEventRecord extends ParticipantEvent {
-  slug: string;
-  createdAt: string;
-}
-
-function getDevEventStore(): DevEventRecord[] {
-  const globalStore = globalThis as typeof globalThis & {
-    __TENKACLOUD_DEV_EVENTS__?: DevEventRecord[];
-  };
-  if (!globalStore.__TENKACLOUD_DEV_EVENTS__) {
-    globalStore.__TENKACLOUD_DEV_EVENTS__ = [];
-  }
-  return globalStore.__TENKACLOUD_DEV_EVENTS__;
-}
+import { createDevEvent, listDevEvents } from './dev-store';
 
 /**
  * Admin イベント一覧レスポンス型
@@ -50,55 +36,6 @@ function emptyEventList(page: number, pageSize: number): AdminEventListResponse 
     page,
     pageSize,
   };
-}
-
-function buildDevEventList(
-  page: number,
-  pageSize: number,
-  status?: EventStatus | null,
-): AdminEventListResponse {
-  const store = getDevEventStore();
-  const filtered = status
-    ? store.filter((event) => event.status === status)
-    : store;
-  const offset = Math.max(page - 1, 0) * pageSize;
-  return {
-    events: filtered.slice(offset, offset + pageSize),
-    total: filtered.length,
-    page,
-    pageSize,
-  };
-}
-
-function createDevEvent(body: CreateEventRequest): DevEventRecord {
-  const now = new Date().toISOString();
-  const event: DevEventRecord = {
-    id: `dev-event-${Date.now()}`,
-    slug: body.slug?.trim() || `event-${Date.now()}`,
-    name: body.name,
-    type: (body.type as ParticipantEvent['type']) || 'gameday',
-    status: body.status || 'draft',
-    startTime: body.startTime || new Date().toISOString(),
-    endTime:
-      body.endTime ||
-      new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-    timezone: body.timezone || 'Asia/Tokyo',
-    participantType:
-      (body.participantType as ParticipantEvent['participantType']) ||
-      'individual',
-    cloudProvider:
-      (body.cloudProvider as ParticipantEvent['cloudProvider']) || 'aws',
-    regions: body.regions?.length ? body.regions : ['ap-northeast-1'],
-    scoringType:
-      (body.scoringType as ParticipantEvent['scoringType']) || 'realtime',
-    leaderboardVisible: body.leaderboardVisible ?? true,
-    problemCount: 0,
-    participantCount: 0,
-    isRegistered: false,
-    createdAt: now,
-  };
-  getDevEventStore().unshift(event);
-  return event;
 }
 
 /**
@@ -167,7 +104,7 @@ export async function GET(request: NextRequest) {
 
     if (isAuthSkipUnauthorized || isNetworkError) {
       console.warn('Admin events fallback to empty dataset:', error);
-      return successResponse(buildDevEventList(page, pageSize, status));
+      return successResponse(listDevEvents(page, pageSize, status));
     }
 
     console.error('Failed to fetch events:', error);

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -29,7 +29,10 @@ interface AdminEventListResponse {
   pageSize: number;
 }
 
-function emptyEventList(page: number, pageSize: number): AdminEventListResponse {
+function emptyEventList(
+  page: number,
+  pageSize: number,
+): AdminEventListResponse {
   return {
     events: [],
     total: 0,

--- a/apps/application-plane/app/api/admin/events/route.ts
+++ b/apps/application-plane/app/api/admin/events/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
   unauthorizedResponse,
@@ -25,6 +26,15 @@ interface AdminEventListResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+function emptyEventList(page: number, pageSize: number): AdminEventListResponse {
+  return {
+    events: [],
+    total: 0,
+    page,
+    pageSize,
+  };
 }
 
 /**
@@ -77,6 +87,18 @@ export async function GET(request: NextRequest) {
 
     return successResponse(data);
   } catch (error) {
+    const isAuthSkipUnauthorized =
+      authSkipEnabled &&
+      error instanceof Error &&
+      /^Unauthorized$/i.test(error.message);
+    const isNetworkError =
+      error instanceof TypeError && /fetch failed/i.test(String(error));
+
+    if (isAuthSkipUnauthorized || isNetworkError) {
+      console.warn('Admin events fallback to empty dataset:', error);
+      return successResponse(emptyEventList(page, pageSize));
+    }
+
     console.error('Failed to fetch events:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to fetch events',

--- a/apps/application-plane/app/api/admin/participants/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/participants/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
+
+const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
+const mockServerApiRequest = vi.fn();
+const mockAuthSkipEnabled = true;
+
+vi.mock('@/auth', () => ({
+  authSkipEnabled: mockAuthSkipEnabled,
+}));
+
+vi.mock('@/lib/api/server', () => ({
+  getAdminSession: () => mockGetAdminSession(),
+  serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
+  unauthorizedResponse: (msg = 'Unauthorized') =>
+    new Response(JSON.stringify({ error: msg }), { status: 401 }),
+  forbiddenResponse: (msg = 'Forbidden') =>
+    new Response(JSON.stringify({ error: msg }), { status: 403 }),
+  badRequestResponse: (msg = 'Bad Request') =>
+    new Response(JSON.stringify({ error: msg }), { status: 400 }),
+  successResponse: <T>(data: T, status = 200) =>
+    new Response(JSON.stringify(data), { status }),
+}));
+
+describe('Admin Participants API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/participants', () => {
+    it('参加者一覧を取得すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+
+      const mockParticipants = {
+        participants: [
+          {
+            id: 'participant-1',
+            displayName: 'Dev User',
+            email: 'dev@example.com',
+            status: 'active',
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 10,
+      };
+      mockServerApiRequest.mockResolvedValue(mockParticipants);
+
+      const { GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/participants');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(mockParticipants);
+    });
+
+    it('AUTH_SKIP の Unauthorized は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new Error('Unauthorized'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest(
+        'http://localhost/api/admin/participants?page=2&pageSize=25',
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        participants: [],
+        total: 0,
+        page: 2,
+        pageSize: 25,
+      });
+    });
+
+    it('network error は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/participants');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        participants: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      });
+    });
+  });
+});

--- a/apps/application-plane/app/api/admin/participants/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/participants/__tests__/route.test.ts
@@ -53,7 +53,9 @@ describe('Admin Participants API', () => {
       mockServerApiRequest.mockResolvedValue(mockParticipants);
 
       const { GET } = await import('../route');
-      const request = new NextRequest('http://localhost/api/admin/participants');
+      const request = new NextRequest(
+        'http://localhost/api/admin/participants',
+      );
       const response = await GET(request);
 
       expect(response.status).toBe(200);
@@ -94,7 +96,9 @@ describe('Admin Participants API', () => {
       mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
 
       const { GET } = await import('../route');
-      const request = new NextRequest('http://localhost/api/admin/participants');
+      const request = new NextRequest(
+        'http://localhost/api/admin/participants',
+      );
       const response = await GET(request);
 
       expect(response.status).toBe(200);

--- a/apps/application-plane/app/api/admin/participants/route.ts
+++ b/apps/application-plane/app/api/admin/participants/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
   unauthorizedResponse,
@@ -25,6 +26,18 @@ interface AdminParticipantListResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+function emptyParticipantList(
+  page: number,
+  pageSize: number,
+): AdminParticipantListResponse {
+  return {
+    participants: [],
+    total: 0,
+    page,
+    pageSize,
+  };
 }
 
 /**
@@ -74,6 +87,18 @@ export async function GET(request: NextRequest) {
 
     return successResponse(data);
   } catch (error) {
+    const isAuthSkipUnauthorized =
+      authSkipEnabled &&
+      error instanceof Error &&
+      /^Unauthorized$/i.test(error.message);
+    const isNetworkError =
+      error instanceof TypeError && /fetch failed/i.test(String(error));
+
+    if (isAuthSkipUnauthorized || isNetworkError) {
+      console.warn('Admin participants fallback to empty dataset:', error);
+      return successResponse(emptyParticipantList(page, pageSize));
+    }
+
     console.error('Failed to fetch participants:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to fetch participants',

--- a/apps/application-plane/app/api/admin/settings/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/settings/__tests__/route.test.ts
@@ -5,6 +5,10 @@ import type { Session } from 'next-auth';
 const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
 const mockServerApiRequest = vi.fn();
 
+vi.mock('@/auth', () => ({
+  authSkipEnabled: true,
+}));
+
 vi.mock('@/lib/api/server', () => ({
   getAdminSession: () => mockGetAdminSession(),
   serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
@@ -27,6 +31,11 @@ const adminSession: Session = {
 describe('Admin Settings API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete (
+      globalThis as typeof globalThis & {
+        __TENKACLOUD_DEV_SETTINGS__?: unknown;
+      }
+    ).__TENKACLOUD_DEV_SETTINGS__;
   });
 
   describe('GET /api/admin/settings', () => {
@@ -81,6 +90,23 @@ describe('Admin Settings API', () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error).toBe('Failed to fetch settings');
+    });
+
+    it('network error 時は local dev settings を返すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(adminSession);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { GET } = await import('../route');
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          tenantName: 'Dev Tenant',
+          slug: 'dev-tenant',
+          apiKey: expect.stringMatching(/^sk-dev-/),
+        }),
+      );
     });
   });
 
@@ -190,6 +216,28 @@ describe('Admin Settings API', () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error).toBe('Failed to update settings');
+    });
+
+    it('network error 時は local dev settings を更新すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(adminSession);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { PUT } = await import('../route');
+      const response = await PUT(
+        new NextRequest('http://localhost/api/admin/settings', {
+          method: 'PUT',
+          body: JSON.stringify({ tenantName: 'Local Tenant', slug: 'local' }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          tenantName: 'Local Tenant',
+          slug: 'local',
+          apiKey: expect.stringMatching(/^sk-dev-/),
+        }),
+      );
     });
   });
 
@@ -346,6 +394,80 @@ describe('Admin Settings API', () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error).toBe('Failed to execute action');
+    });
+
+    it('network error 時は local dev API キーを再生成すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(adminSession);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { GET, POST } = await import('../route');
+
+      const before = await GET();
+      const beforeData = await before.json();
+
+      const response = await POST(
+        new NextRequest('http://localhost/api/admin/settings', {
+          method: 'POST',
+          body: JSON.stringify({ action: 'regenerate-api-key' }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const afterData = await response.json();
+      expect(afterData.apiKey).toMatch(/^sk-dev-/);
+      expect(afterData.apiKey).not.toBe(beforeData.apiKey);
+    });
+
+    it('network error 時の delete-all-data は local dev events を削除すべき', async () => {
+      mockGetAdminSession.mockResolvedValue(adminSession);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      (
+        globalThis as typeof globalThis & {
+          __TENKACLOUD_DEV_EVENTS__?: unknown[];
+        }
+      ).__TENKACLOUD_DEV_EVENTS__ = [
+        {
+          id: 'event-1',
+          slug: 'test-event',
+          name: 'Test Event',
+          type: 'gameday',
+          status: 'draft',
+          startTime: '2026-04-09T00:00:00.000Z',
+          endTime: '2026-04-10T23:59:59.000Z',
+          timezone: 'Asia/Tokyo',
+          participantType: 'individual',
+          cloudProvider: 'local',
+          regions: ['local'],
+          scoringType: 'realtime',
+          leaderboardVisible: true,
+          problemCount: 0,
+          participantCount: 0,
+          isRegistered: false,
+          createdAt: '2026-04-09T00:00:00.000Z',
+        },
+      ];
+
+      const { POST } = await import('../route');
+      const response = await POST(
+        new NextRequest('http://localhost/api/admin/settings', {
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'delete-all-data',
+            confirmationToken: 'DELETE',
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ success: true });
+      expect(
+        (
+          globalThis as typeof globalThis & {
+            __TENKACLOUD_DEV_EVENTS__?: unknown[];
+          }
+        ).__TENKACLOUD_DEV_EVENTS__,
+      ).toEqual([]);
     });
   });
 });

--- a/apps/application-plane/app/api/admin/settings/route.ts
+++ b/apps/application-plane/app/api/admin/settings/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
   unauthorizedResponse,
@@ -15,6 +16,7 @@ import {
   successResponse,
   serverApiRequest,
 } from '@/lib/api/server';
+import { clearDevEvents } from '../events/dev-store';
 
 /**
  * 設定レスポンス型
@@ -23,6 +25,42 @@ interface SettingsResponse {
   tenantName: string;
   slug: string;
   apiKey: string;
+}
+
+function buildDevApiKey() {
+  return `sk-dev-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getDevSettingsStore(): SettingsResponse {
+  const globalStore = globalThis as typeof globalThis & {
+    __TENKACLOUD_DEV_SETTINGS__?: SettingsResponse;
+  };
+  if (!globalStore.__TENKACLOUD_DEV_SETTINGS__) {
+    globalStore.__TENKACLOUD_DEV_SETTINGS__ = {
+      tenantName: 'Dev Tenant',
+      slug: 'dev-tenant',
+      apiKey: buildDevApiKey(),
+    };
+  }
+  return globalStore.__TENKACLOUD_DEV_SETTINGS__;
+}
+
+function setDevSettingsStore(next: SettingsResponse) {
+  const globalStore = globalThis as typeof globalThis & {
+    __TENKACLOUD_DEV_SETTINGS__?: SettingsResponse;
+  };
+  globalStore.__TENKACLOUD_DEV_SETTINGS__ = next;
+  return next;
+}
+
+function isLocalDevFallbackError(error: unknown): boolean {
+  const isAuthSkipUnauthorized =
+    authSkipEnabled &&
+    error instanceof Error &&
+    /^Unauthorized$/i.test(error.message);
+  const isNetworkError =
+    error instanceof TypeError && /fetch failed/i.test(String(error));
+  return isAuthSkipUnauthorized || isNetworkError;
 }
 
 /**
@@ -56,6 +94,11 @@ export async function GET() {
     const data = await serverApiRequest<SettingsResponse>('/admin/settings');
     return successResponse(data);
   } catch (error) {
+    if (isLocalDevFallbackError(error)) {
+      console.warn('Admin settings fallback to local dev store:', error);
+      return successResponse(getDevSettingsStore());
+    }
+
     console.error('Failed to fetch settings:', error);
     return badRequestResponse('Failed to fetch settings');
   }
@@ -72,9 +115,9 @@ export async function PUT(request: NextRequest) {
     return unauthorizedResponse('Authentication required');
   }
 
-  try {
-    const body = (await request.json()) as UpdateSettingsRequest;
+  const body = (await request.json()) as UpdateSettingsRequest;
 
+  try {
     if (body.tenantName !== undefined && !body.tenantName.trim()) {
       return badRequestResponse('Tenant name cannot be empty');
     }
@@ -89,6 +132,18 @@ export async function PUT(request: NextRequest) {
 
     return successResponse(data);
   } catch (error) {
+    if (isLocalDevFallbackError(error)) {
+      console.warn('Admin settings update fallback to local dev store:', error);
+      const current = getDevSettingsStore();
+      return successResponse(
+        setDevSettingsStore({
+          ...current,
+          tenantName: body.tenantName ?? current.tenantName,
+          slug: body.slug ?? current.slug,
+        }),
+      );
+    }
+
     console.error('Failed to update settings:', error);
     return badRequestResponse('Failed to update settings');
   }
@@ -107,9 +162,9 @@ export async function POST(request: NextRequest) {
     return unauthorizedResponse('Authentication required');
   }
 
-  try {
-    const body = (await request.json()) as ActionRequest;
+  const body = (await request.json()) as ActionRequest;
 
+  try {
     if (!body.action) {
       return badRequestResponse('Action is required');
     }
@@ -145,6 +200,23 @@ export async function POST(request: NextRequest) {
 
     return badRequestResponse(`Unknown action: ${body.action}`);
   } catch (error) {
+    if (isLocalDevFallbackError(error)) {
+      console.warn('Admin settings action fallback to local dev store:', error);
+      if (body.action === 'regenerate-api-key') {
+        const current = getDevSettingsStore();
+        return successResponse(
+          setDevSettingsStore({
+            ...current,
+            apiKey: buildDevApiKey(),
+          }),
+        );
+      }
+      if (body.action === 'delete-all-data') {
+        clearDevEvents();
+        return successResponse({ success: true });
+      }
+    }
+
     console.error('Failed to execute action:', error);
     return badRequestResponse('Failed to execute action');
   }

--- a/apps/application-plane/app/api/admin/settings/route.ts
+++ b/apps/application-plane/app/api/admin/settings/route.ts
@@ -7,6 +7,7 @@
  * - POST: アクション実行（API キー再生成、全データ削除）
  */
 
+import { randomBytes } from 'node:crypto';
 import { NextRequest } from 'next/server';
 import { authSkipEnabled } from '@/auth';
 import {
@@ -28,7 +29,7 @@ interface SettingsResponse {
 }
 
 function buildDevApiKey() {
-  return `sk-dev-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+  return `sk-dev-${Date.now().toString(36)}${randomBytes(6).toString('hex')}`;
 }
 
 function getDevSettingsStore(): SettingsResponse {

--- a/apps/application-plane/app/api/admin/teams/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/admin/teams/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
+
+const mockGetAdminSession = vi.fn<() => Promise<Session | null>>();
+const mockServerApiRequest = vi.fn();
+const mockAuthSkipEnabled = true;
+
+vi.mock('@/auth', () => ({
+  authSkipEnabled: mockAuthSkipEnabled,
+}));
+
+vi.mock('@/lib/api/server', () => ({
+  getAdminSession: () => mockGetAdminSession(),
+  serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
+  unauthorizedResponse: (msg = 'Unauthorized') =>
+    new Response(JSON.stringify({ error: msg }), { status: 401 }),
+  forbiddenResponse: (msg = 'Forbidden') =>
+    new Response(JSON.stringify({ error: msg }), { status: 403 }),
+  badRequestResponse: (msg = 'Bad Request') =>
+    new Response(JSON.stringify({ error: msg }), { status: 400 }),
+  successResponse: <T>(data: T, status = 200) =>
+    new Response(JSON.stringify(data), { status }),
+}));
+
+describe('Admin Teams API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/teams', () => {
+    it('チーム一覧を取得すべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+
+      const mockTeams = {
+        teams: [
+          {
+            id: 'team-1',
+            name: 'Blue Team',
+            totalScore: 1200,
+            memberCount: 3,
+            maxMembers: 5,
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 10,
+      };
+      mockServerApiRequest.mockResolvedValue(mockTeams);
+
+      const { GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/teams');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(mockTeams);
+    });
+
+    it('AUTH_SKIP の Unauthorized は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new Error('Unauthorized'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest(
+        'http://localhost/api/admin/teams?page=2&pageSize=25',
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        teams: [],
+        total: 0,
+        page: 2,
+        pageSize: 25,
+      });
+    });
+
+    it('network error は空一覧にフォールバックすべき', async () => {
+      const session: Session = {
+        user: { name: 'Admin', email: 'admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['admin'],
+      };
+      mockGetAdminSession.mockResolvedValue(session);
+      mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+      const { GET } = await import('../route');
+      const request = new NextRequest('http://localhost/api/admin/teams');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        teams: [],
+        total: 0,
+        page: 1,
+        pageSize: 10,
+      });
+    });
+  });
+});

--- a/apps/application-plane/app/api/admin/teams/route.ts
+++ b/apps/application-plane/app/api/admin/teams/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import { authSkipEnabled } from '@/auth';
 import {
   getAdminSession,
   unauthorizedResponse,
@@ -25,6 +26,15 @@ interface AdminTeamListResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+function emptyTeamList(page: number, pageSize: number): AdminTeamListResponse {
+  return {
+    teams: [],
+    total: 0,
+    page,
+    pageSize,
+  };
 }
 
 /**
@@ -72,6 +82,18 @@ export async function GET(request: NextRequest) {
 
     return successResponse(data);
   } catch (error) {
+    const isAuthSkipUnauthorized =
+      authSkipEnabled &&
+      error instanceof Error &&
+      /^Unauthorized$/i.test(error.message);
+    const isNetworkError =
+      error instanceof TypeError && /fetch failed/i.test(String(error));
+
+    if (isAuthSkipUnauthorized || isNetworkError) {
+      console.warn('Admin teams fallback to empty dataset:', error);
+      return successResponse(emptyTeamList(page, pageSize));
+    }
+
     console.error('Failed to fetch teams:', error);
     return badRequestResponse(
       error instanceof Error ? error.message : 'Failed to fetch teams',

--- a/apps/application-plane/lib/api/__tests__/server.test.ts
+++ b/apps/application-plane/lib/api/__tests__/server.test.ts
@@ -7,6 +7,7 @@ const mockAuth = vi.fn<() => Promise<Session | null>>();
 
 vi.mock('@/auth', () => ({
   auth: () => mockAuth(),
+  authSkipEnabled: false,
 }));
 
 vi.mock('@/lib/api/backend-urls', () => ({
@@ -179,6 +180,36 @@ describe('Server API Utilities', () => {
 
     it('未認証の場合は Authorization ヘッダーなしでリクエストを送信すべき', async () => {
       mockAuth.mockResolvedValue(null);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const { serverApiRequest } = await import('../server');
+      await serverApiRequest<{ data: string }>('/test-endpoint');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/test-endpoint'),
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    it('AUTH_SKIP のモックトークンはバックエンドへ転送しないべき', async () => {
+      mockAuth.mockResolvedValue({
+        user: { name: 'Dev User', email: 'dev@example.com' },
+        expires: new Date().toISOString(),
+        accessToken: 'mock-access-token',
+      } as Session);
+
+      vi.doMock('@/auth', () => ({
+        auth: () => mockAuth(),
+        authSkipEnabled: true,
+      }));
 
       mockFetch.mockResolvedValue({
         ok: true,

--- a/apps/application-plane/lib/api/gameday-admin.ts
+++ b/apps/application-plane/lib/api/gameday-admin.ts
@@ -5,6 +5,21 @@
 import { getAuthToken } from '@/lib/auth/get-auth-token';
 import { getGamedayApiUrl } from '@/lib/api/backend-urls';
 import type { AttackLog, GameState, Team } from './gameday-types';
+import {
+  executeLocalFaultInjection,
+  getLocalAttackLogs,
+  getLocalAuditorRunning,
+  getLocalGameState,
+  getLocalTeams,
+  isLocalGameDayEvent,
+  registerLocalTeam,
+  seedLocalAttacks,
+  setLocalAuditorRunning,
+  startLocalGame,
+  stopLocalGame,
+  toggleLocalBlackout,
+  toggleLocalScoreWeight,
+} from './gameday-local';
 
 const ADMIN_URL = `${getGamedayApiUrl()}/admin`;
 
@@ -55,42 +70,83 @@ async function adminRequest<T>(
   return response.json();
 }
 
+async function withLocalFallback<T>(
+  eventId: string,
+  remote: () => Promise<T>,
+  fallback: () => T,
+): Promise<T> {
+  try {
+    return await remote();
+  } catch (error) {
+    if (isLocalGameDayEvent(eventId)) {
+      console.warn('GameDay admin fallback to local store:', error);
+      return fallback();
+    }
+    throw error;
+  }
+}
+
 // --- Game Management ---
 
 export function startGame(eventId: string, durationMinutes?: number) {
-  return adminRequest<GameState>('/game/start', {
-    method: 'POST',
-    body: JSON.stringify({ eventId, durationMinutes }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/game/start', {
+        method: 'POST',
+        body: JSON.stringify({ eventId, durationMinutes }),
+      }),
+    () => startLocalGame(eventId, durationMinutes),
+  );
 }
 
 export function stopGame(eventId: string) {
-  return adminRequest<GameState>('/game/stop', {
-    method: 'POST',
-    body: JSON.stringify({ eventId }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/game/stop', {
+        method: 'POST',
+        body: JSON.stringify({ eventId }),
+      }),
+    () => stopLocalGame(eventId),
+  );
 }
 
 export function getGameStatus(eventId: string) {
-  return adminRequest<GameState>('/game/status', {
-    params: { eventId },
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/game/status', {
+        params: { eventId },
+      }),
+    () => getLocalGameState(eventId),
+  );
 }
 
 // --- Score & Features ---
 
 export function toggleScoreWeight(eventId: string) {
-  return adminRequest<GameState>('/score-weight/toggle', {
-    method: 'POST',
-    body: JSON.stringify({ eventId }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/score-weight/toggle', {
+        method: 'POST',
+        body: JSON.stringify({ eventId }),
+      }),
+    () => toggleLocalScoreWeight(eventId),
+  );
 }
 
 export function toggleBlackout(eventId: string) {
-  return adminRequest<GameState>('/blackout/toggle', {
-    method: 'POST',
-    body: JSON.stringify({ eventId }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/blackout/toggle', {
+        method: 'POST',
+        body: JSON.stringify({ eventId }),
+      }),
+    () => toggleLocalBlackout(eventId),
+  );
 }
 
 // --- Team Management ---
@@ -101,31 +157,51 @@ export function registerTeam(
   teamName: string,
   urls?: { websiteUrl?: string; apiUrl?: string },
 ) {
-  return adminRequest<Team>('/teams/register', {
-    method: 'POST',
-    body: JSON.stringify({ eventId, teamId, teamName, ...urls }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<Team>('/teams/register', {
+        method: 'POST',
+        body: JSON.stringify({ eventId, teamId, teamName, ...urls }),
+      }),
+    () => registerLocalTeam(eventId, teamId, teamName, urls),
+  );
 }
 
 export function getTeams(eventId: string) {
-  return adminRequest<{ teams: Team[] }>('/teams', {
-    params: { eventId },
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<{ teams: Team[] }>('/teams', {
+        params: { eventId },
+      }),
+    () => ({ teams: getLocalTeams(eventId) }),
+  );
 }
 
 // --- Attack Catalog ---
 
 export function seedAttacks(eventId: string) {
-  return adminRequest<{ seeded: number }>('/attacks/seed', {
-    method: 'POST',
-    body: JSON.stringify({ eventId }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<{ seeded: number }>('/attacks/seed', {
+        method: 'POST',
+        body: JSON.stringify({ eventId }),
+      }),
+    () => ({ seeded: seedLocalAttacks(eventId).length }),
+  );
 }
 
 export function getAttackLogs(eventId: string) {
-  return adminRequest<{ logs: AttackLog[] }>('/attack-logs', {
-    params: { eventId },
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<{ logs: AttackLog[] }>('/attack-logs', {
+        params: { eventId },
+      }),
+    () => ({ logs: getLocalAttackLogs(eventId) }),
+  );
 }
 
 // --- Fault Injection ---
@@ -135,23 +211,43 @@ export function executeFaultInjection(
   teamId: string,
   attackSlug: string,
 ) {
-  return adminRequest<AttackLog>('/fault-injection/execute', {
-    method: 'POST',
-    body: JSON.stringify({ eventId, teamId, attackSlug }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<AttackLog>('/fault-injection/execute', {
+        method: 'POST',
+        body: JSON.stringify({ eventId, teamId, attackSlug }),
+      }),
+    () => executeLocalFaultInjection(eventId, teamId, attackSlug),
+  );
 }
 
 // --- Auditor ---
 
 export function startAuditor(eventId: string) {
-  return adminRequest<{ status: string; eventId: string }>('/auditor/start', {
-    method: 'POST',
-    body: JSON.stringify({ eventId }),
-  });
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<{ status: string; eventId: string }>('/auditor/start', {
+        method: 'POST',
+        body: JSON.stringify({ eventId }),
+      }),
+    () => {
+      setLocalAuditorRunning(true);
+      return { status: 'running', eventId };
+    },
+  );
 }
 
 export function stopAuditor() {
   return adminRequest<{ status: string }>('/auditor/stop', {
     method: 'POST',
+  }).catch((error) => {
+    if (getLocalAuditorRunning()) {
+      console.warn('GameDay admin fallback to local auditor stop:', error);
+      setLocalAuditorRunning(false);
+      return { status: 'stopped' };
+    }
+    throw error;
   });
 }

--- a/apps/application-plane/lib/api/gameday-local.ts
+++ b/apps/application-plane/lib/api/gameday-local.ts
@@ -151,7 +151,8 @@ export function startLocalGame(eventId: string, durationMinutes?: number) {
     ...getLocalGameState(eventId),
     isRunning: true,
     startedAt: new Date().toISOString(),
-    durationMinutes: durationMinutes || getLocalGameState(eventId).durationMinutes,
+    durationMinutes:
+      durationMinutes || getLocalGameState(eventId).durationMinutes,
   });
 }
 
@@ -183,8 +184,12 @@ export function executeLocalFaultInjection(
   teamId: string,
   attackSlug: string,
 ) {
-  const defender = getLocalTeams(eventId).find((team) => team.teamId === teamId);
-  const attack = getLocalAttacks(eventId).find((item) => item.slug === attackSlug);
+  const defender = getLocalTeams(eventId).find(
+    (team) => team.teamId === teamId,
+  );
+  const attack = getLocalAttacks(eventId).find(
+    (item) => item.slug === attackSlug,
+  );
   const log: AttackLog = {
     id: `log-${Date.now()}`,
     eventId,

--- a/apps/application-plane/lib/api/gameday-local.ts
+++ b/apps/application-plane/lib/api/gameday-local.ts
@@ -1,0 +1,211 @@
+import type { Attack, AttackLog, GameState, Team } from './gameday-types';
+
+interface LocalGameDayState {
+  games: Record<string, GameState>;
+  teams: Record<string, Team[]>;
+  logs: Record<string, AttackLog[]>;
+  attacks: Record<string, Attack[]>;
+  auditorRunning: boolean;
+}
+
+const DEFAULT_ATTACKS: Attack[] = [
+  {
+    id: 'atk-sqli',
+    name: 'SQL Injection',
+    slug: 'sql-injection',
+    attackType: 'vulnerability',
+    targetVulnerability: 'sql-injection',
+    description: 'Database query injection attack',
+    purchaseCost: 100,
+    damage: 250,
+    reward: 50,
+    cooldownSeconds: 120,
+    defenseHint: 'Use parameterized queries',
+    hintCost: 25,
+  },
+  {
+    id: 'atk-xss',
+    name: 'Stored XSS',
+    slug: 'stored-xss',
+    attackType: 'vulnerability',
+    targetVulnerability: 'stored-xss',
+    description: 'Persistent client-side script injection',
+    purchaseCost: 120,
+    damage: 300,
+    reward: 60,
+    cooldownSeconds: 180,
+    defenseHint: 'Escape untrusted output',
+    hintCost: 30,
+  },
+];
+
+function defaultGameState(eventId: string): GameState {
+  return {
+    eventId,
+    tenantId: 'dev-tenant',
+    isRunning: false,
+    startedAt: null,
+    scoreWeight: 'normal',
+    blackout: false,
+    durationMinutes: 60,
+  };
+}
+
+function getStore(): LocalGameDayState {
+  const root = globalThis as typeof globalThis & {
+    __TENKACLOUD_LOCAL_GAMEDAY__?: LocalGameDayState;
+  };
+  if (!root.__TENKACLOUD_LOCAL_GAMEDAY__) {
+    root.__TENKACLOUD_LOCAL_GAMEDAY__ = {
+      games: {},
+      teams: {},
+      logs: {},
+      attacks: {},
+      auditorRunning: false,
+    };
+  }
+  return root.__TENKACLOUD_LOCAL_GAMEDAY__;
+}
+
+export function isLocalGameDayEvent(eventId: string) {
+  return eventId.startsWith('dev-event-');
+}
+
+export function getLocalGameState(eventId: string): GameState {
+  const store = getStore();
+  store.games[eventId] ??= defaultGameState(eventId);
+  return store.games[eventId];
+}
+
+export function setLocalGameState(eventId: string, next: GameState) {
+  getStore().games[eventId] = next;
+  return next;
+}
+
+export function getLocalTeams(eventId: string): Team[] {
+  const store = getStore();
+  store.teams[eventId] ??= [];
+  return store.teams[eventId];
+}
+
+export function setLocalTeams(eventId: string, teams: Team[]) {
+  getStore().teams[eventId] = teams;
+  return teams;
+}
+
+export function getLocalAttackLogs(eventId: string): AttackLog[] {
+  const store = getStore();
+  store.logs[eventId] ??= [];
+  return store.logs[eventId];
+}
+
+export function pushLocalAttackLog(eventId: string, log: AttackLog) {
+  getLocalAttackLogs(eventId).unshift(log);
+  return log;
+}
+
+export function getLocalAttacks(eventId: string): Attack[] {
+  const store = getStore();
+  store.attacks[eventId] ??= [];
+  return store.attacks[eventId];
+}
+
+export function seedLocalAttacks(eventId: string) {
+  const seeded = DEFAULT_ATTACKS.map((attack) => ({
+    ...attack,
+    id: `${eventId}-${attack.id}`,
+  }));
+  getStore().attacks[eventId] = seeded;
+  return seeded;
+}
+
+export function registerLocalTeam(
+  eventId: string,
+  teamId: string,
+  teamName: string,
+  urls?: { websiteUrl?: string; apiUrl?: string },
+) {
+  const teams = getLocalTeams(eventId);
+  const existing = teams.find((team) => team.teamId === teamId);
+  if (existing) {
+    existing.teamName = teamName;
+    existing.websiteUrl = urls?.websiteUrl;
+    existing.apiUrl = urls?.apiUrl;
+    return existing;
+  }
+
+  const created: Team = {
+    eventId,
+    teamId,
+    teamName,
+    websiteUrl: urls?.websiteUrl,
+    apiUrl: urls?.apiUrl,
+    score: 0,
+  };
+  teams.push(created);
+  return created;
+}
+
+export function startLocalGame(eventId: string, durationMinutes?: number) {
+  return setLocalGameState(eventId, {
+    ...getLocalGameState(eventId),
+    isRunning: true,
+    startedAt: new Date().toISOString(),
+    durationMinutes: durationMinutes || getLocalGameState(eventId).durationMinutes,
+  });
+}
+
+export function stopLocalGame(eventId: string) {
+  return setLocalGameState(eventId, {
+    ...getLocalGameState(eventId),
+    isRunning: false,
+  });
+}
+
+export function toggleLocalScoreWeight(eventId: string) {
+  const current = getLocalGameState(eventId);
+  return setLocalGameState(eventId, {
+    ...current,
+    scoreWeight: current.scoreWeight === 'high' ? 'normal' : 'high',
+  });
+}
+
+export function toggleLocalBlackout(eventId: string) {
+  const current = getLocalGameState(eventId);
+  return setLocalGameState(eventId, {
+    ...current,
+    blackout: !current.blackout,
+  });
+}
+
+export function executeLocalFaultInjection(
+  eventId: string,
+  teamId: string,
+  attackSlug: string,
+) {
+  const defender = getLocalTeams(eventId).find((team) => team.teamId === teamId);
+  const attack = getLocalAttacks(eventId).find((item) => item.slug === attackSlug);
+  const log: AttackLog = {
+    id: `log-${Date.now()}`,
+    eventId,
+    attackerTeamId: 'admin',
+    defenderTeamId: teamId,
+    attackId: attack?.id || attackSlug,
+    attackSlug,
+    success: true,
+    neutralized: false,
+    damage: attack?.damage || 100,
+    reward: attack?.reward || 0,
+    details: `Admin fault injection against ${defender?.teamName || teamId}`,
+    createdAt: new Date().toISOString(),
+  };
+  return pushLocalAttackLog(eventId, log);
+}
+
+export function setLocalAuditorRunning(running: boolean) {
+  getStore().auditorRunning = running;
+}
+
+export function getLocalAuditorRunning() {
+  return getStore().auditorRunning;
+}

--- a/apps/application-plane/lib/api/gameday.ts
+++ b/apps/application-plane/lib/api/gameday.ts
@@ -4,6 +4,7 @@
 
 import { getAuthToken } from '@/lib/auth/get-auth-token';
 import { getGamedayApiUrl } from '@/lib/api/backend-urls';
+import { getLocalAttacks, isLocalGameDayEvent } from './gameday-local';
 import type {
   Alliance,
   Attack,
@@ -73,6 +74,12 @@ export async function gamedayRequest<T>(
 export function getAttackCatalog(eventId: string) {
   return gamedayRequest<{ attacks: Attack[] }>('/attacks/catalog', {
     params: { eventId },
+  }).catch((error) => {
+    if (isLocalGameDayEvent(eventId)) {
+      console.warn('GameDay catalog fallback to local store:', error);
+      return { attacks: getLocalAttacks(eventId) };
+    }
+    throw error;
   });
 }
 

--- a/apps/application-plane/lib/api/server.ts
+++ b/apps/application-plane/lib/api/server.ts
@@ -5,8 +5,10 @@
  */
 
 import { NextResponse } from 'next/server';
-import { auth } from '@/auth';
+import { auth, authSkipEnabled } from '@/auth';
 import { getProblemServiceUrl } from '@/lib/api/backend-urls';
+
+const MOCK_ACCESS_TOKEN = 'mock-access-token';
 
 /**
  * 統一エラーレスポンス
@@ -88,6 +90,8 @@ export async function serverApiRequest<T>(
 ): Promise<T> {
   const session = await auth();
   const token = session?.accessToken;
+  const shouldForwardToken =
+    token && !(authSkipEnabled && token === MOCK_ACCESS_TOKEN);
 
   const url = `${API_BASE_URL}${endpoint}`;
 
@@ -95,7 +99,7 @@ export async function serverApiRequest<T>(
     ...options,
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(shouldForwardToken ? { Authorization: `Bearer ${token}` } : {}),
       ...options.headers,
     },
   });

--- a/apps/control-plane/app/dashboard/__tests__/layout.test.tsx
+++ b/apps/control-plane/app/dashboard/__tests__/layout.test.tsx
@@ -39,16 +39,18 @@ vi.mock('@cloudscape-design/components/side-navigation', () => ({
   default: ({
     items,
     header,
+    activeHref,
     onFollow,
   }: {
     items: Array<{ text: string; href: string; type: string }>;
     header: { text: string };
+    activeHref?: string;
     onFollow?: (e: {
       preventDefault: () => void;
       detail: { href: string };
     }) => void;
   }) => (
-    <div data-testid="side-navigation">
+    <div data-testid="side-navigation" data-active-href={activeHref}>
       <span>{header.text}</span>
       {items.map((item: { text: string; href: string; type: string }) => (
         <a
@@ -99,8 +101,8 @@ vi.mock('@cloudscape-design/components/top-navigation', () => ({
       >
         {identity.title}
       </button>
-      {utilities?.map((util) =>
-        util.items?.map((item) => (
+      {utilities?.map((util) => [
+        ...(util.items?.map((item) => (
           <button
             key={item.id}
             type="button"
@@ -112,8 +114,19 @@ vi.mock('@cloudscape-design/components/top-navigation', () => ({
           >
             {item.text}
           </button>
-        )),
-      )}
+        )) ?? []),
+        <button
+          key={`${util.text}-unknown`}
+          type="button"
+          onClick={() => {
+            if (util.onItemClick) {
+              util.onItemClick({ detail: { id: 'unknown' } });
+            }
+          }}
+        >
+          不明なメニュー
+        </button>,
+      ])}
     </div>
   ),
 }));
@@ -215,6 +228,20 @@ describe('DashboardLayout コンポーネント', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
+  it('未対応メニューをクリックしても遷移もログアウトも行わないべき', async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardLayout>
+        <div>テスト</div>
+      </DashboardLayout>,
+    );
+
+    await user.click(screen.getByRole('button', { name: '不明なメニュー' }));
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
   it('テナント管理パスではテナント管理リンクがアクティブになるべき', () => {
     vi.mocked(usePathname).mockReturnValue('/dashboard/tenants');
     render(
@@ -222,8 +249,10 @@ describe('DashboardLayout コンポーネント', () => {
         <div>テスト</div>
       </DashboardLayout>,
     );
-    // SideNavigation にアクティブ状態が渡されることを確認
-    expect(screen.getByText('テナント管理')).toBeInTheDocument();
+    expect(screen.getByTestId('side-navigation')).toHaveAttribute(
+      'data-active-href',
+      '/control/dashboard/tenants',
+    );
   });
 
   it('ダッシュボードパスではダッシュボードリンクがアクティブになるべき', () => {
@@ -233,6 +262,22 @@ describe('DashboardLayout コンポーネント', () => {
         <div>テスト</div>
       </DashboardLayout>,
     );
-    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.getByTestId('side-navigation')).toHaveAttribute(
+      'data-active-href',
+      '/control/dashboard',
+    );
+  });
+
+  it('類似パスでは前方一致で誤ってアクティブにしないべき', () => {
+    vi.mocked(usePathname).mockReturnValue('/dashboard/tenants-legacy');
+    render(
+      <DashboardLayout>
+        <div>テスト</div>
+      </DashboardLayout>,
+    );
+    expect(screen.getByTestId('side-navigation')).not.toHaveAttribute(
+      'data-active-href',
+      '/control/dashboard/tenants',
+    );
   });
 });

--- a/apps/control-plane/app/dashboard/layout.tsx
+++ b/apps/control-plane/app/dashboard/layout.tsx
@@ -14,44 +14,62 @@ import '@cloudscape-design/global-styles/index.css';
 import { usePathname, useRouter } from 'next/navigation';
 import { signOut } from 'next-auth/react';
 import { type ReactNode, useEffect, useState } from 'react';
+import { stripControlBasePath, withControlBasePath } from '@/lib/base-path';
 
-const navItems: SideNavigationProps.Item[] = [
-  { type: 'link', text: 'ダッシュボード', href: '/dashboard' },
-  { type: 'link', text: 'テナント管理', href: '/dashboard/tenants' },
-  { type: 'link', text: '設定', href: '/dashboard/settings' },
+const navItems: Array<SideNavigationProps.Link & { appPath: string }> = [
+  {
+    type: 'link',
+    text: 'ダッシュボード',
+    href: withControlBasePath('/dashboard'),
+    appPath: '/dashboard',
+  },
+  {
+    type: 'link',
+    text: 'テナント管理',
+    href: withControlBasePath('/dashboard/tenants'),
+    appPath: '/dashboard/tenants',
+  },
+  {
+    type: 'link',
+    text: '設定',
+    href: withControlBasePath('/dashboard/settings'),
+    appPath: '/dashboard/settings',
+  },
 ];
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
+  const normalizedPath = stripControlBasePath(pathname);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const activeHref = navItems
-    .filter((item): item is SideNavigationProps.Link => item.type === 'link')
-    .find((item) => {
-      if (item.href === '/dashboard') return pathname === '/dashboard';
-      return pathname.startsWith(item.href);
-    })?.href;
+  const activeHref = navItems.find((item) => {
+    if (item.appPath === '/dashboard') {
+      return normalizedPath === '/dashboard';
+    }
+
+    return normalizedPath.startsWith(item.appPath);
+  })?.href;
 
   // Cloudscape は SSR で異なる内部 ID を生成するため、CSR のみでレンダリング
   if (!mounted) {
     return (
-      <div className="awsui-dark-mode" style={{ minHeight: '100vh' }}>
+      <div style={{ minHeight: '100vh' }}>
         {children}
       </div>
     );
   }
 
   return (
-    <div className="awsui-dark-mode">
+    <div>
       <div id="cp-top-nav">
         <TopNavigation
           identity={{
-            href: '/dashboard',
+            href: withControlBasePath('/dashboard'),
             title: 'TenkaCloud',
             onFollow: (e) => {
               e.preventDefault();
@@ -71,6 +89,10 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
                 },
               ],
               onItemClick: ({ detail }) => {
+                if (detail.id === 'settings') {
+                  router.push('/dashboard/settings');
+                  return;
+                }
                 if (detail.id === 'signout') {
                   signOut({ callbackUrl: '/login' });
                 }
@@ -86,12 +108,15 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
       <AppLayout
         navigation={
           <SideNavigation
-            header={{ text: 'Control Plane', href: '/dashboard' }}
+            header={{
+              text: 'Control Plane',
+              href: withControlBasePath('/dashboard'),
+            }}
             activeHref={activeHref}
             items={navItems}
             onFollow={(e) => {
               e.preventDefault();
-              router.push(e.detail.href);
+              router.push(stripControlBasePath(e.detail.href));
             }}
           />
         }

--- a/apps/control-plane/app/dashboard/layout.tsx
+++ b/apps/control-plane/app/dashboard/layout.tsx
@@ -52,16 +52,15 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
       return normalizedPath === '/dashboard';
     }
 
-    return normalizedPath.startsWith(item.appPath);
+    return (
+      normalizedPath === item.appPath ||
+      normalizedPath.startsWith(`${item.appPath}/`)
+    );
   })?.href;
 
   // Cloudscape は SSR で異なる内部 ID を生成するため、CSR のみでレンダリング
   if (!mounted) {
-    return (
-      <div style={{ minHeight: '100vh' }}>
-        {children}
-      </div>
-    );
+    return <div style={{ minHeight: '100vh' }}>{children}</div>;
   }
 
   return (

--- a/apps/control-plane/app/dashboard/settings/page.tsx
+++ b/apps/control-plane/app/dashboard/settings/page.tsx
@@ -2,10 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { saveSettings } from '@/lib/api/settings-api';
-import {
-  getStoredThemePreference,
-  persistThemePreference,
-} from '@/lib/theme';
+import { getStoredThemePreference, persistThemePreference } from '@/lib/theme';
 import {
   DEFAULT_SETTINGS,
   LANGUAGES,

--- a/apps/control-plane/app/dashboard/settings/page.tsx
+++ b/apps/control-plane/app/dashboard/settings/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { saveSettings } from '@/lib/api/settings-api';
+import {
+  getStoredThemePreference,
+  persistThemePreference,
+} from '@/lib/theme';
 import {
   DEFAULT_SETTINGS,
   LANGUAGES,
@@ -24,6 +28,17 @@ export default function SettingsPage({
     text: string;
   } | null>(null);
 
+  useEffect(() => {
+    const storedTheme = getStoredThemePreference();
+    setSettings((current) => ({
+      ...current,
+      appearance: {
+        ...current.appearance,
+        theme: storedTheme,
+      },
+    }));
+  }, []);
+
   const handleSave = async () => {
     setIsSaving(true);
     setMessage(null);
@@ -42,23 +57,27 @@ export default function SettingsPage({
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">設定</h1>
-        <p className="mt-2 text-sm text-muted-foreground text-gray-500">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          設定
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
           プラットフォームの設定を管理します
         </p>
       </div>
 
       {message && (
         <div
-          className={`rounded-md p-4 ${
+          className={`rounded-md border p-4 ${
             message.type === 'success'
-              ? 'bg-green-50 border border-green-200'
-              : 'bg-red-50 border border-red-200'
+              ? 'border-emerald-500/20 bg-emerald-500/10'
+              : 'border-rose-500/20 bg-rose-500/10'
           }`}
         >
           <p
             className={`text-sm ${
-              message.type === 'success' ? 'text-green-800' : 'text-red-800'
+              message.type === 'success'
+                ? 'text-emerald-800 dark:text-emerald-300'
+                : 'text-rose-800 dark:text-rose-300'
             }`}
           >
             {message.text}
@@ -68,12 +87,12 @@ export default function SettingsPage({
 
       <div className="space-y-6">
         {/* プラットフォーム設定 */}
-        <section className="rounded-xl border bg-card text-card-foreground shadow">
-          <div className="flex flex-col space-y-1.5 p-6 border-b">
+        <section className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+          <div className="flex flex-col space-y-1.5 border-b border-border p-6">
             <h2 className="text-lg font-semibold leading-none tracking-tight">
               プラットフォーム設定
             </h2>
-            <p className="text-sm text-muted-foreground text-gray-500">
+            <p className="text-sm text-muted-foreground">
               基本的なプラットフォームの設定を行います
             </p>
           </div>
@@ -88,7 +107,7 @@ export default function SettingsPage({
                 </label>
                 <input
                   id="platformName"
-                  className="flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   value={settings.platform.platformName}
                   onChange={(e) =>
                     setSettings({
@@ -110,7 +129,7 @@ export default function SettingsPage({
                 </label>
                 <select
                   id="language"
-                  className="flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   value={settings.platform.language}
                   onChange={(e) =>
                     setSettings({
@@ -138,7 +157,7 @@ export default function SettingsPage({
                 </label>
                 <select
                   id="timezone"
-                  className="flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   value={settings.platform.timezone}
                   onChange={(e) =>
                     setSettings({
@@ -162,12 +181,12 @@ export default function SettingsPage({
         </section>
 
         {/* 外観設定 */}
-        <section className="rounded-xl border bg-card text-card-foreground shadow">
-          <div className="flex flex-col space-y-1.5 p-6 border-b">
+        <section className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+          <div className="flex flex-col space-y-1.5 border-b border-border p-6">
             <h2 className="text-lg font-semibold leading-none tracking-tight">
               外観設定
             </h2>
-            <p className="text-sm text-muted-foreground text-gray-500">
+            <p className="text-sm text-muted-foreground">
               アプリケーションの表示設定を行います
             </p>
           </div>
@@ -181,17 +200,19 @@ export default function SettingsPage({
               </label>
               <select
                 id="theme"
-                className="flex h-10 w-full max-w-xs rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="flex h-10 w-full max-w-xs rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 value={settings.appearance.theme}
-                onChange={(e) =>
+                onChange={(e) => {
+                  const theme = e.target.value as 'light' | 'dark' | 'system';
+                  persistThemePreference(theme);
                   setSettings({
                     ...settings,
                     appearance: {
                       ...settings.appearance,
-                      theme: e.target.value as 'light' | 'dark' | 'system',
+                      theme,
                     },
-                  })
-                }
+                  });
+                }}
               >
                 {THEMES.map((theme) => (
                   <option key={theme.value} value={theme.value}>
@@ -204,12 +225,12 @@ export default function SettingsPage({
         </section>
 
         {/* 通知設定 */}
-        <section className="rounded-xl border bg-card text-card-foreground shadow">
-          <div className="flex flex-col space-y-1.5 p-6 border-b">
+        <section className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+          <div className="flex flex-col space-y-1.5 border-b border-border p-6">
             <h2 className="text-lg font-semibold leading-none tracking-tight">
               通知設定
             </h2>
-            <p className="text-sm text-muted-foreground text-gray-500">
+            <p className="text-sm text-muted-foreground">
               通知の受信設定を行います
             </p>
           </div>
@@ -218,7 +239,7 @@ export default function SettingsPage({
               <label className="flex items-center space-x-3 cursor-pointer">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                   checked={settings.notifications.emailNotificationsEnabled}
                   onChange={(e) =>
                     setSettings({
@@ -232,7 +253,7 @@ export default function SettingsPage({
                 />
                 <div>
                   <span className="text-sm font-medium">メール通知</span>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-muted-foreground">
                     重要なイベントをメールで通知します
                   </p>
                 </div>
@@ -240,7 +261,7 @@ export default function SettingsPage({
               <label className="flex items-center space-x-3 cursor-pointer">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                   checked={settings.notifications.systemAlertsEnabled}
                   onChange={(e) =>
                     setSettings({
@@ -254,7 +275,7 @@ export default function SettingsPage({
                 />
                 <div>
                   <span className="text-sm font-medium">システムアラート</span>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-muted-foreground">
                     システムの警告やエラーを通知します
                   </p>
                 </div>
@@ -262,7 +283,7 @@ export default function SettingsPage({
               <label className="flex items-center space-x-3 cursor-pointer">
                 <input
                   type="checkbox"
-                  className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                  className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                   checked={
                     settings.notifications.maintenanceNotificationsEnabled
                   }
@@ -278,7 +299,7 @@ export default function SettingsPage({
                 />
                 <div>
                   <span className="text-sm font-medium">メンテナンス通知</span>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-muted-foreground">
                     予定されているメンテナンスを通知します
                   </p>
                 </div>
@@ -288,25 +309,27 @@ export default function SettingsPage({
         </section>
 
         {/* セキュリティ設定（読み取り専用） */}
-        <section className="rounded-xl border bg-card text-card-foreground shadow">
-          <div className="flex flex-col space-y-1.5 p-6 border-b">
+        <section className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+          <div className="flex flex-col space-y-1.5 border-b border-border p-6">
             <h2 className="text-lg font-semibold leading-none tracking-tight">
               セキュリティ設定
             </h2>
-            <p className="text-sm text-muted-foreground text-gray-500">
+            <p className="text-sm text-muted-foreground">
               セキュリティに関する設定を確認できます
             </p>
           </div>
           <div className="p-6">
             <dl className="grid gap-4 md:grid-cols-3">
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-gray-500">MFA 必須</dt>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  MFA 必須
+                </dt>
                 <dd className="text-sm">
                   {settings.security.mfaRequired ? '有効' : '無効'}
                 </dd>
               </div>
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-gray-500">
+                <dt className="text-sm font-medium text-muted-foreground">
                   セッションタイムアウト
                 </dt>
                 <dd className="text-sm">
@@ -314,7 +337,7 @@ export default function SettingsPage({
                 </dd>
               </div>
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-gray-500">
+                <dt className="text-sm font-medium text-muted-foreground">
                   最大ログイン試行回数
                 </dt>
                 <dd className="text-sm">
@@ -332,7 +355,7 @@ export default function SettingsPage({
           type="button"
           onClick={handleSave}
           disabled={isSaving}
-          className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-black text-white"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
         >
           {isSaving ? '保存中...' : '設定を保存'}
         </button>

--- a/apps/control-plane/app/dashboard/tenants/[id]/page.tsx
+++ b/apps/control-plane/app/dashboard/tenants/[id]/page.tsx
@@ -23,22 +23,24 @@ export default async function TenantDetailPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="space-y-1">
-          <h1 className="text-3xl font-bold tracking-tight">{tenant.name}</h1>
-          <p className="text-muted-foreground text-gray-500">ID: {tenant.id}</p>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            {tenant.name}
+          </h1>
+          <p className="text-sm text-muted-foreground">ID: {tenant.id}</p>
         </div>
-        <div className="flex space-x-2">
+        <div className="flex flex-wrap gap-2">
           <Link
             href="/dashboard/tenants"
-            className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
           >
             戻る
           </Link>
           <TenantActions tenantId={tenant.id} />
           <Link
             href={`/dashboard/tenants/${tenant.id}/edit`}
-            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-black text-white"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
           >
             編集
           </Link>
@@ -46,7 +48,7 @@ export default async function TenantDetailPage({
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
-        <div className="rounded-xl border bg-card text-card-foreground shadow">
+        <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
           <div className="flex flex-col space-y-1.5 p-6">
             <h3 className="font-semibold leading-none tracking-tight">
               基本情報
@@ -55,7 +57,7 @@ export default async function TenantDetailPage({
           <div className="p-6 pt-0">
             <dl className="grid gap-4">
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">
+                <dt className="text-sm font-medium text-muted-foreground">
                   ステータス
                 </dt>
                 <dd className="col-span-2">
@@ -73,27 +75,35 @@ export default async function TenantDetailPage({
                 </dd>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">Tier</dt>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Tier
+                </dt>
                 <dd className="col-span-2 capitalize">{tenant.tier}</dd>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">Slug</dt>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Slug
+                </dt>
                 <dd className="col-span-2 font-mono text-sm">{tenant.slug}</dd>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">
+                <dt className="text-sm font-medium text-muted-foreground">
                   管理者 Email
                 </dt>
                 <dd className="col-span-2">{tenant.adminEmail}</dd>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">作成日時</dt>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  作成日時
+                </dt>
                 <dd className="col-span-2">
                   {new Date(tenant.createdAt).toLocaleString('ja-JP')}
                 </dd>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                <dt className="font-medium text-sm text-gray-500">更新日時</dt>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  更新日時
+                </dt>
                 <dd className="col-span-2">
                   {new Date(tenant.updatedAt).toLocaleString('ja-JP')}
                 </dd>

--- a/apps/control-plane/app/dashboard/tenants/new/page.tsx
+++ b/apps/control-plane/app/dashboard/tenants/new/page.tsx
@@ -54,14 +54,16 @@ export default function NewTenantPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold tracking-tight">新規テナント作成</h1>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          新規テナント作成
+        </h1>
       </div>
 
       {error && (
-        <div className="max-w-2xl rounded-md bg-red-50 border border-red-200 p-4">
+        <div className="max-w-2xl rounded-md border border-rose-500/20 bg-rose-500/10 p-4">
           <div className="flex">
             <svg
-              className="h-5 w-5 text-red-400"
+              className="h-5 w-5 text-rose-500"
               viewBox="0 0 20 20"
               fill="currentColor"
             >
@@ -72,19 +74,21 @@ export default function NewTenantPage() {
               />
             </svg>
             <div className="ml-3">
-              <p className="text-sm font-medium text-red-800">{error}</p>
+              <p className="text-sm font-medium text-rose-800 dark:text-rose-300">
+                {error}
+              </p>
             </div>
           </div>
         </div>
       )}
 
-      <div className="rounded-xl border bg-card text-card-foreground shadow max-w-2xl">
+      <div className="max-w-2xl rounded-xl border border-border bg-card text-card-foreground shadow-sm">
         <form onSubmit={handleSubmit}>
           <div className="flex flex-col space-y-1.5 p-6">
             <h3 className="font-semibold leading-none tracking-tight">
               テナント情報
             </h3>
-            <p className="text-sm text-muted-foreground text-gray-500">
+            <p className="text-sm text-muted-foreground">
               新しいテナントを作成します。
             </p>
           </div>
@@ -99,7 +103,7 @@ export default function NewTenantPage() {
               <input
                 id="name"
                 required
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 border-gray-300"
+                className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground ring-offset-background shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                 placeholder="例: 株式会社Acme"
                 value={formData.name}
                 onChange={(e) => {
@@ -128,7 +132,7 @@ export default function NewTenantPage() {
                 pattern="^[a-z0-9-]+$"
                 minLength={3}
                 maxLength={63}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 border-gray-300"
+                className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground ring-offset-background shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                 placeholder="例: acme-corp"
                 value={formData.slug}
                 onChange={(e) => {
@@ -136,7 +140,7 @@ export default function NewTenantPage() {
                   setFormData({ ...formData, slug: e.target.value });
                 }}
               />
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-muted-foreground">
                 小文字英数字とハイフンのみ（3〜63文字）
               </p>
             </div>
@@ -151,7 +155,7 @@ export default function NewTenantPage() {
                 id="email"
                 type="email"
                 required
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 border-gray-300"
+                className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground ring-offset-background shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                 placeholder="admin@example.com"
                 value={formData.adminEmail}
                 onChange={(e) =>
@@ -168,7 +172,7 @@ export default function NewTenantPage() {
               </label>
               <select
                 id="tier"
-                className="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 border-gray-300"
+                className="flex h-10 w-full items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground ring-offset-background shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                 value={formData.tier}
                 onChange={(e) =>
                   setFormData({
@@ -189,7 +193,7 @@ export default function NewTenantPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-black text-white"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
             >
               {isLoading ? '作成中...' : '作成'}
             </button>

--- a/apps/control-plane/app/layout.tsx
+++ b/apps/control-plane/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import { ThemeSync } from '@/components/theme-sync';
+import { getThemeBootstrapScript } from '@/lib/theme';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -12,8 +14,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja">
-      <body>{children}</body>
+    <html lang="ja" suppressHydrationWarning>
+      <body
+        className="min-h-screen bg-background text-foreground"
+        suppressHydrationWarning
+      >
+        <script
+          dangerouslySetInnerHTML={{ __html: getThemeBootstrapScript() }}
+        />
+        <ThemeSync />
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/control-plane/components/__tests__/theme-sync.test.tsx
+++ b/apps/control-plane/components/__tests__/theme-sync.test.tsx
@@ -1,0 +1,104 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ThemeSync } from '@/components/theme-sync';
+import { CONTROL_PLANE_THEME_STORAGE_KEY } from '@/lib/theme';
+
+type MediaChangeListener = (() => void) | undefined;
+
+function mockMatchMedia(initialMatches = false) {
+  let matches = initialMatches;
+  let changeListener: MediaChangeListener;
+
+  const mediaQueryList = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn((event: string, listener: () => void) => {
+      if (event === 'change') {
+        changeListener = listener;
+      }
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockReturnValue(mediaQueryList),
+  });
+
+  return {
+    mediaQueryList,
+    setMatches(next: boolean) {
+      matches = next;
+    },
+    triggerChange() {
+      changeListener?.();
+    },
+  };
+}
+
+describe('ThemeSync', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+    document.body.className = '';
+    vi.restoreAllMocks();
+  });
+
+  it('初期表示時に保存済み theme を反映し、購読解除できるべき', () => {
+    const { mediaQueryList } = mockMatchMedia(true);
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, 'dark');
+
+    const { unmount } = render(<ThemeSync />);
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.body).toHaveClass('awsui-dark-mode');
+    expect(mediaQueryList.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+
+    unmount();
+
+    expect(mediaQueryList.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+  });
+
+  it('system theme のとき media change で再同期すべき', () => {
+    const matchMedia = mockMatchMedia(false);
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, 'system');
+
+    render(<ThemeSync />);
+
+    expect(document.body).not.toHaveClass('awsui-dark-mode');
+
+    matchMedia.setMatches(true);
+    matchMedia.triggerChange();
+
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.body).toHaveClass('awsui-dark-mode');
+  });
+
+  it('system 以外の theme のとき media change では再同期しないべき', () => {
+    const matchMedia = mockMatchMedia(true);
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, 'dark');
+
+    render(<ThemeSync />);
+
+    matchMedia.setMatches(false);
+    matchMedia.triggerChange();
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.body).toHaveClass('awsui-dark-mode');
+  });
+});

--- a/apps/control-plane/components/tenants/plan-card.tsx
+++ b/apps/control-plane/components/tenants/plan-card.tsx
@@ -75,7 +75,7 @@ export function PlanCard({ tenant }: PlanCardProps) {
       TIER_FEATURES[targetTier].isolationModel;
 
   return (
-    <div className="rounded-xl border bg-card text-card-foreground shadow">
+    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
       <div className="flex flex-col space-y-1.5 p-6">
         <h3 className="font-semibold leading-none tracking-tight">プラン</h3>
         <p className="text-sm text-muted-foreground">
@@ -97,22 +97,22 @@ export function PlanCard({ tenant }: PlanCardProps) {
               <div
                 key={tier}
                 data-testid={`plan-card-${tier}`}
-                className={`rounded-lg border p-4 ${
+                className={`rounded-lg border p-4 transition-colors ${
                   isCurrent
-                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500'
-                    : 'border-gray-200'
+                    ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+                    : 'border-border bg-background'
                 }`}
               >
                 <div className="mb-4 flex items-center justify-between">
                   <h4 className="font-semibold">{TENANT_TIER_LABELS[tier]}</h4>
                   {isCurrent && (
-                    <span className="rounded-full bg-blue-500 px-2 py-1 text-xs text-white">
+                    <span className="rounded-full bg-primary px-2 py-1 text-xs text-primary-foreground">
                       現在のプラン
                     </span>
                   )}
                 </div>
 
-                <ul className="mb-4 space-y-2 text-sm text-gray-600">
+                <ul className="mb-4 space-y-2 text-sm text-muted-foreground">
                   <li>{formatLimit(features.maxParticipants)}</li>
                   <li>{formatBattleLimit(features.maxBattles)}</li>
                   {features.apiAccess && <li>API アクセス</li>}
@@ -131,8 +131,8 @@ export function PlanCard({ tenant }: PlanCardProps) {
                     onClick={() => handleTierClick(tier)}
                     className={`w-full rounded-md px-3 py-2 text-sm font-medium ${
                       targetOrder > currentTierOrder
-                        ? 'bg-blue-600 text-white hover:bg-blue-700'
-                        : 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                        ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                        : 'border border-border bg-background text-foreground hover:bg-accent hover:text-accent-foreground'
                     }`}
                   >
                     {actionLabel}
@@ -151,20 +151,20 @@ export function PlanCard({ tenant }: PlanCardProps) {
       </div>
 
       {showDialog && targetTier && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 text-card-foreground shadow-xl">
             <h3 className="mb-4 text-lg font-semibold">
               プランを変更しますか？
             </h3>
 
-            <p className="mb-4 text-sm text-gray-600">
+            <p className="mb-4 text-sm text-muted-foreground">
               {TENANT_TIER_LABELS[tenant.tier]} →{' '}
               {TENANT_TIER_LABELS[targetTier]} に
               {isUpgrade ? 'アップグレード' : 'ダウングレード'}
             </p>
 
             {requiresReprovisioning && (
-              <div className="mb-4 rounded-md bg-amber-50 p-3 text-sm text-amber-700">
+              <div className="mb-4 rounded-md border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-300">
                 <strong>注意:</strong>{' '}
                 分離モデルが変更されるため、再プロビジョニングが必要です。一時的にサービスが停止します。
               </div>
@@ -175,7 +175,7 @@ export function PlanCard({ tenant }: PlanCardProps) {
                 type="button"
                 onClick={handleCancel}
                 disabled={isLoading}
-                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                className="rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
               >
                 キャンセル
               </button>
@@ -183,7 +183,7 @@ export function PlanCard({ tenant }: PlanCardProps) {
                 type="button"
                 onClick={handleConfirm}
                 disabled={isLoading}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
               >
                 {isLoading ? '処理中...' : '変更を確定'}
               </button>

--- a/apps/control-plane/components/tenants/provisioning-card.tsx
+++ b/apps/control-plane/components/tenants/provisioning-card.tsx
@@ -15,10 +15,13 @@ const statusLabels: Record<ProvisioningStatus, string> = {
 };
 
 const statusColors: Record<ProvisioningStatus, string> = {
-  PENDING: 'bg-gray-100 text-gray-800',
-  IN_PROGRESS: 'bg-blue-100 text-blue-800',
-  COMPLETED: 'bg-green-100 text-green-800',
-  FAILED: 'bg-red-100 text-red-800',
+  PENDING: 'border border-border bg-muted text-muted-foreground',
+  IN_PROGRESS:
+    'border border-sky-500/20 bg-sky-500/10 text-sky-800 dark:text-sky-300',
+  COMPLETED:
+    'border border-emerald-500/20 bg-emerald-500/10 text-emerald-800 dark:text-emerald-300',
+  FAILED:
+    'border border-rose-500/20 bg-rose-500/10 text-rose-800 dark:text-rose-300',
 };
 
 interface ProvisioningCardProps {
@@ -51,7 +54,7 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
   };
 
   return (
-    <div className="rounded-xl border bg-card text-card-foreground shadow">
+    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
       <div className="flex flex-col space-y-1.5 p-6">
         <h3 className="font-semibold leading-none tracking-tight">
           プロビジョニング
@@ -60,7 +63,9 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
       <div className="p-6 pt-0">
         <dl className="grid gap-4">
           <div className="grid grid-cols-3 items-center gap-4">
-            <dt className="font-medium text-sm text-gray-500">ステータス</dt>
+            <dt className="text-sm font-medium text-muted-foreground">
+              ステータス
+            </dt>
             <dd className="col-span-2">
               <span
                 className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[tenant.provisioningStatus]}`}
@@ -70,15 +75,19 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
             </dd>
           </div>
           <div className="grid grid-cols-3 items-center gap-4">
-            <dt className="font-medium text-sm text-gray-500">リージョン</dt>
+            <dt className="text-sm font-medium text-muted-foreground">
+              リージョン
+            </dt>
             <dd className="col-span-2">{tenant.region}</dd>
           </div>
           <div className="grid grid-cols-3 items-center gap-4">
-            <dt className="font-medium text-sm text-gray-500">分離モデル</dt>
+            <dt className="text-sm font-medium text-muted-foreground">
+              分離モデル
+            </dt>
             <dd className="col-span-2">{tenant.isolationModel}</dd>
           </div>
           <div className="grid grid-cols-3 items-center gap-4">
-            <dt className="font-medium text-sm text-gray-500">
+            <dt className="text-sm font-medium text-muted-foreground">
               コンピュートタイプ
             </dt>
             <dd className="col-span-2">{tenant.computeType}</dd>
@@ -86,7 +95,7 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
         </dl>
 
         {error && (
-          <div className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div className="mt-4 rounded-md border border-rose-500/20 bg-rose-500/10 p-3 text-sm text-rose-800 dark:text-rose-300">
             {error}
           </div>
         )}
@@ -97,7 +106,7 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
               type="button"
               onClick={handleProvision}
               disabled={isLoading}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-blue-600 text-white hover:bg-blue-700"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
             >
               {isLoading
                 ? 'プロビジョニング中...'

--- a/apps/control-plane/components/tenants/tenant-access-card.tsx
+++ b/apps/control-plane/components/tenants/tenant-access-card.tsx
@@ -49,7 +49,7 @@ export function TenantAccessCard({
   };
 
   return (
-    <div className="rounded-xl border bg-card text-card-foreground shadow">
+    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
       <div className="flex flex-col space-y-1.5 p-6">
         <h3 className="font-semibold leading-none tracking-tight">
           テナント管理画面
@@ -59,20 +59,22 @@ export function TenantAccessCard({
         </p>
       </div>
       <div className="p-6 pt-0">
-        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
           <div className="mb-3">
-            <span className="text-sm text-gray-500">URL:</span>
-            <p className="font-mono text-sm">{applicationPlaneUrl}</p>
+            <span className="text-sm text-muted-foreground">URL:</span>
+            <p className="break-all font-mono text-sm text-foreground">
+              {applicationPlaneUrl}
+            </p>
           </div>
 
           {isProvisioningInProgress && (
-            <div className="mb-3 rounded-md bg-amber-50 p-2 text-sm text-amber-700">
+            <div className="mb-3 rounded-md border border-amber-500/20 bg-amber-500/10 p-2 text-sm text-amber-800 dark:text-amber-300">
               プロビジョニング中です。完了までお待ちください。
             </div>
           )}
 
           {isProvisioningFailed && (
-            <div className="mb-3 rounded-md bg-red-50 p-2 text-sm text-red-700">
+            <div className="mb-3 rounded-md border border-rose-500/20 bg-rose-500/10 p-2 text-sm text-rose-800 dark:text-rose-300">
               プロビジョニング失敗。管理者にお問い合わせください。
             </div>
           )}
@@ -85,8 +87,8 @@ export function TenantAccessCard({
               aria-disabled={!isProvisioningComplete}
               className={`inline-flex items-center rounded-md px-4 py-2 text-sm font-medium ${
                 isProvisioningComplete
-                  ? 'bg-blue-600 text-white hover:bg-blue-700'
-                  : 'pointer-events-none cursor-not-allowed bg-gray-300 text-gray-500'
+                  ? 'border border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'pointer-events-none cursor-not-allowed border border-border bg-muted text-muted-foreground'
               }`}
             >
               管理画面を開く
@@ -108,7 +110,7 @@ export function TenantAccessCard({
             <button
               type="button"
               onClick={handleCopyUrl}
-              className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="inline-flex items-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-accent hover:text-accent-foreground"
             >
               {copyStatus === 'success' ? (
                 <>

--- a/apps/control-plane/components/tenants/tenant-list.tsx
+++ b/apps/control-plane/components/tenants/tenant-list.tsx
@@ -78,13 +78,13 @@ export function TenantList({ tenants }: TenantListProps) {
       {/* Search and Filters */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
             type="text"
             placeholder="テナント名、メール、IDで検索..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="flex h-10 w-full rounded-md border border-gray-300 bg-background pl-10 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex h-10 w-full rounded-md border border-border bg-background py-2 pl-10 pr-3 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         </div>
         <div className="flex gap-2">
@@ -93,7 +93,7 @@ export function TenantList({ tenants }: TenantListProps) {
             onChange={(e) =>
               setStatusFilter(e.target.value as TenantStatus | 'ALL')
             }
-            className="flex h-10 rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex h-10 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="ALL">すべてのステータス</option>
             {Object.entries(TENANT_STATUS_LABELS).map(([value, label]) => (
@@ -107,7 +107,7 @@ export function TenantList({ tenants }: TenantListProps) {
             onChange={(e) =>
               setTierFilter(e.target.value as TenantTier | 'ALL')
             }
-            className="flex h-10 rounded-md border border-gray-300 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex h-10 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="ALL">すべてのTier</option>
             {Object.entries(TENANT_TIER_LABELS).map(([value, label]) => (
@@ -228,7 +228,10 @@ export function TenantList({ tenants }: TenantListProps) {
       )}
 
       {deleteError && (
-        <div className="text-sm text-red-600" role="alert">
+        <div
+          className="rounded-md border border-rose-500/20 bg-rose-500/10 p-3 text-sm text-rose-800 dark:text-rose-300"
+          role="alert"
+        >
           {deleteError}
         </div>
       )}

--- a/apps/control-plane/components/theme-sync.tsx
+++ b/apps/control-plane/components/theme-sync.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import {
+  applyThemePreference,
+  CONTROL_PLANE_THEME_CHANGE_EVENT,
+  getStoredThemePreference,
+} from '@/lib/theme';
+
+export function ThemeSync() {
+  useEffect(() => {
+    const syncTheme = () => {
+      applyThemePreference(getStoredThemePreference());
+    };
+
+    syncTheme();
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleMediaChange = () => {
+      if (getStoredThemePreference() === 'system') {
+        syncTheme();
+      }
+    };
+
+    window.addEventListener(CONTROL_PLANE_THEME_CHANGE_EVENT, syncTheme);
+    window.addEventListener('storage', syncTheme);
+    mediaQuery.addEventListener('change', handleMediaChange);
+
+    return () => {
+      window.removeEventListener(CONTROL_PLANE_THEME_CHANGE_EVENT, syncTheme);
+      window.removeEventListener('storage', syncTheme);
+      mediaQuery.removeEventListener('change', handleMediaChange);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/control-plane/lib/base-path.test.ts
+++ b/apps/control-plane/lib/base-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { stripControlBasePath, withControlBasePath } from './base-path';
+
+describe('base-path ヘルパー', () => {
+  it('先頭スラッシュのないパスには control prefix を付与すべき', () => {
+    expect(withControlBasePath('dashboard/settings')).toBe(
+      '/control/dashboard/settings',
+    );
+  });
+
+  it('クエリ文字列付きの control パスは二重に prefix しないべき', () => {
+    expect(withControlBasePath('/control?tab=settings')).toBe(
+      '/control?tab=settings',
+    );
+  });
+
+  it('ハッシュ付きの control パスは二重に prefix しないべき', () => {
+    expect(withControlBasePath('/control#top')).toBe('/control#top');
+  });
+
+  it('クエリ文字列付きの control パスを正しく strip すべき', () => {
+    expect(stripControlBasePath('/control?tab=settings')).toBe(
+      '/?tab=settings',
+    );
+  });
+
+  it('control ルートパスはルートに strip すべき', () => {
+    expect(stripControlBasePath('/control')).toBe('/');
+  });
+
+  it('ハッシュ付きの control パスを正しく strip すべき', () => {
+    expect(stripControlBasePath('/control#top')).toBe('/#top');
+  });
+
+  it('ネストした control パスを正しく strip すべき', () => {
+    expect(stripControlBasePath('/control/dashboard/settings')).toBe(
+      '/dashboard/settings',
+    );
+  });
+
+  it('control 配下ではないパスはそのまま返すべき', () => {
+    expect(stripControlBasePath('/dashboard')).toBe('/dashboard');
+  });
+});

--- a/apps/control-plane/lib/base-path.ts
+++ b/apps/control-plane/lib/base-path.ts
@@ -1,14 +1,20 @@
 export const CONTROL_PLANE_BASE_PATH = '/control';
 
+function isControlBasePath(path: string): boolean {
+  return (
+    path === CONTROL_PLANE_BASE_PATH ||
+    path.startsWith(`${CONTROL_PLANE_BASE_PATH}/`) ||
+    path.startsWith(`${CONTROL_PLANE_BASE_PATH}?`) ||
+    path.startsWith(`${CONTROL_PLANE_BASE_PATH}#`)
+  );
+}
+
 export function withControlBasePath(path: string): string {
   if (!path.startsWith('/')) {
     return `${CONTROL_PLANE_BASE_PATH}/${path}`;
   }
 
-  if (
-    path === CONTROL_PLANE_BASE_PATH ||
-    path.startsWith(`${CONTROL_PLANE_BASE_PATH}/`)
-  ) {
+  if (isControlBasePath(path)) {
     return path;
   }
 
@@ -20,8 +26,9 @@ export function stripControlBasePath(path: string): string {
     return '/';
   }
 
-  if (path.startsWith(`${CONTROL_PLANE_BASE_PATH}/`)) {
-    return path.slice(CONTROL_PLANE_BASE_PATH.length);
+  if (isControlBasePath(path)) {
+    const stripped = path.slice(CONTROL_PLANE_BASE_PATH.length);
+    return stripped.startsWith('/') ? stripped : `/${stripped}`;
   }
 
   return path;

--- a/apps/control-plane/lib/base-path.ts
+++ b/apps/control-plane/lib/base-path.ts
@@ -1,0 +1,28 @@
+export const CONTROL_PLANE_BASE_PATH = '/control';
+
+export function withControlBasePath(path: string): string {
+  if (!path.startsWith('/')) {
+    return `${CONTROL_PLANE_BASE_PATH}/${path}`;
+  }
+
+  if (
+    path === CONTROL_PLANE_BASE_PATH ||
+    path.startsWith(`${CONTROL_PLANE_BASE_PATH}/`)
+  ) {
+    return path;
+  }
+
+  return `${CONTROL_PLANE_BASE_PATH}${path}`;
+}
+
+export function stripControlBasePath(path: string): string {
+  if (path === CONTROL_PLANE_BASE_PATH) {
+    return '/';
+  }
+
+  if (path.startsWith(`${CONTROL_PLANE_BASE_PATH}/`)) {
+    return path.slice(CONTROL_PLANE_BASE_PATH.length);
+  }
+
+  return path;
+}

--- a/apps/control-plane/lib/theme.test.ts
+++ b/apps/control-plane/lib/theme.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyThemePreference,
+  CONTROL_PLANE_THEME_CHANGE_EVENT,
+  CONTROL_PLANE_THEME_STORAGE_KEY,
+  getStoredThemePreference,
+  getThemeBootstrapScript,
+  isTheme,
+  persistThemePreference,
+  resolveThemePreference,
+} from './theme';
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+const originalLocalStorage = window.localStorage;
+const originalMatchMedia = window.matchMedia;
+
+describe('theme ヘルパー', () => {
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    window.localStorage.clear();
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+    document.body.className = '';
+    vi.restoreAllMocks();
+  });
+
+  it('theme 文字列だけを受け入れるべき', () => {
+    expect(isTheme('light')).toBe(true);
+    expect(isTheme('dark')).toBe(true);
+    expect(isTheme('system')).toBe(true);
+    expect(isTheme('blue')).toBe(false);
+    expect(isTheme(null)).toBe(false);
+  });
+
+  it('window がない場合は system を返すべき', () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(getStoredThemePreference()).toBe('system');
+  });
+
+  it('localStorage が利用できない場合は system を返すべき', () => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(getStoredThemePreference()).toBe('system');
+  });
+
+  it('保存済み theme が不正値なら system を返すべき', () => {
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, 'invalid');
+
+    expect(getStoredThemePreference()).toBe('system');
+  });
+
+  it('保存済み theme が有効値ならその値を返すべき', () => {
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, 'dark');
+
+    expect(getStoredThemePreference()).toBe('dark');
+  });
+
+  it('system theme はダークモード検知時に dark を解決すべき', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: true }),
+    });
+
+    expect(resolveThemePreference('system')).toBe('dark');
+  });
+
+  it('system theme はライトモード検知時に light を解決すべき', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+
+    expect(resolveThemePreference('system')).toBe('light');
+  });
+
+  it('window がない system theme は dark を解決すべき', () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(resolveThemePreference('system')).toBe('dark');
+  });
+
+  it('system 以外の theme はそのまま返すべき', () => {
+    expect(resolveThemePreference('light')).toBe('light');
+    expect(resolveThemePreference('dark')).toBe('dark');
+  });
+
+  it('theme を DOM に反映すべき', () => {
+    const resolved = applyThemePreference('dark');
+
+    expect(resolved).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.body).toHaveClass('awsui-dark-mode');
+  });
+
+  it('document がない場合も解決済み theme を返すべき', () => {
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(applyThemePreference('light')).toBe('light');
+  });
+
+  it('theme を保存して変更イベントを発火すべき', () => {
+    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+    expect(persistThemePreference('dark')).toBe('dark');
+    expect(window.localStorage.getItem(CONTROL_PLANE_THEME_STORAGE_KEY)).toBe(
+      'dark',
+    );
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: CONTROL_PLANE_THEME_CHANGE_EVENT,
+      }),
+    );
+  });
+
+  it('setItem がなくても theme を反映できるべき', () => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: vi.fn().mockReturnValue('light'),
+      },
+    });
+    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+    expect(persistThemePreference('light')).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: CONTROL_PLANE_THEME_CHANGE_EVENT,
+      }),
+    );
+  });
+
+  it('window がない場合はイベントを発火しないべき', () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(persistThemePreference('light')).toBe('light');
+  });
+
+  it('bootstrap script に theme 初期化ロジックを含むべき', () => {
+    const script = getThemeBootstrapScript();
+
+    expect(script).toContain(CONTROL_PLANE_THEME_STORAGE_KEY);
+    expect(script).toContain('matchMedia');
+    expect(script).toContain('document.documentElement.dataset.theme = theme');
+  });
+});

--- a/apps/control-plane/lib/theme.ts
+++ b/apps/control-plane/lib/theme.ts
@@ -1,7 +1,6 @@
 import type { Theme } from '@/types/settings';
 
-export const CONTROL_PLANE_THEME_STORAGE_KEY =
-  'tenkacloud-control-plane-theme';
+export const CONTROL_PLANE_THEME_STORAGE_KEY = 'tenkacloud-control-plane-theme';
 
 export const CONTROL_PLANE_THEME_CHANGE_EVENT =
   'tenkacloud:control-plane-theme-change';

--- a/apps/control-plane/lib/theme.ts
+++ b/apps/control-plane/lib/theme.ts
@@ -1,0 +1,98 @@
+import type { Theme } from '@/types/settings';
+
+export const CONTROL_PLANE_THEME_STORAGE_KEY =
+  'tenkacloud-control-plane-theme';
+
+export const CONTROL_PLANE_THEME_CHANGE_EVENT =
+  'tenkacloud:control-plane-theme-change';
+
+export function isTheme(value: string | null): value is Theme {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+export function getStoredThemePreference(): Theme {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+
+  if (
+    typeof window.localStorage === 'undefined' ||
+    typeof window.localStorage.getItem !== 'function'
+  ) {
+    return 'system';
+  }
+
+  const stored = window.localStorage.getItem(CONTROL_PLANE_THEME_STORAGE_KEY);
+  return isTheme(stored) ? stored : 'system';
+}
+
+export function resolveThemePreference(theme: Theme): 'light' | 'dark' {
+  if (theme === 'system') {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+    }
+    return 'dark';
+  }
+
+  return theme;
+}
+
+export function applyThemePreference(theme: Theme): 'light' | 'dark' {
+  const resolved = resolveThemePreference(theme);
+
+  if (typeof document === 'undefined') {
+    return resolved;
+  }
+
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
+  document.documentElement.dataset.theme = theme;
+  document.body.classList.toggle('awsui-dark-mode', resolved === 'dark');
+
+  return resolved;
+}
+
+export function persistThemePreference(theme: Theme): 'light' | 'dark' {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.localStorage !== 'undefined' &&
+    typeof window.localStorage.setItem === 'function'
+  ) {
+    window.localStorage.setItem(CONTROL_PLANE_THEME_STORAGE_KEY, theme);
+  }
+
+  const resolved = applyThemePreference(theme);
+
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent(CONTROL_PLANE_THEME_CHANGE_EVENT, {
+        detail: { theme, resolved },
+      }),
+    );
+  }
+
+  return resolved;
+}
+
+export function getThemeBootstrapScript(): string {
+  return `
+    (function() {
+      try {
+        var key = '${CONTROL_PLANE_THEME_STORAGE_KEY}';
+        var stored = window.localStorage.getItem(key);
+        var theme =
+          stored === 'light' || stored === 'dark' || stored === 'system'
+            ? stored
+            : 'system';
+        var resolved =
+          theme === 'system'
+            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : theme;
+        document.documentElement.classList.toggle('dark', resolved === 'dark');
+        document.documentElement.dataset.theme = theme;
+        document.body.classList.toggle('awsui-dark-mode', resolved === 'dark');
+      } catch (_) {}
+    })();
+  `;
+}

--- a/apps/control-plane/vitest.setup.ts
+++ b/apps/control-plane/vitest.setup.ts
@@ -1,9 +1,63 @@
 import '@testing-library/jest-dom';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
-import { afterEach, expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 
 expect.extend(matchers);
+
+function createStorageMock(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+if (
+  typeof window !== 'undefined' &&
+  (typeof window.localStorage === 'undefined' ||
+    typeof window.localStorage.getItem !== 'function' ||
+    typeof window.localStorage.setItem !== 'function' ||
+    typeof window.localStorage.clear !== 'function')
+) {
+  Object.defineProperty(window, 'localStorage', {
+    writable: true,
+    value: createStorageMock(),
+  });
+}
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 afterEach(() => {
   cleanup();

--- a/backend/services/shared/dynamodb/src/tenant-repository.test.ts
+++ b/backend/services/shared/dynamodb/src/tenant-repository.test.ts
@@ -120,6 +120,43 @@ describe('TenantRepository', () => {
 
       expect(result.tenants).toHaveLength(0);
     });
+
+    it('limit に達するまで query を継続し、有効な lastKey を返すべき', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Items: [
+            {
+              ...validTenantItem,
+              PK: 'EVENT#01ARZ3NDEKTSV4RRFFQ69G5FAV',
+              EntityType: 'EVENT',
+            },
+          ],
+          LastEvaluatedKey: { PK: 'cursor-1' },
+        })
+        .mockResolvedValueOnce({
+          Items: [
+            validTenantItem,
+            {
+              ...validTenantItem,
+              PK: 'TENANT#01ARZ3NDEKTSV4RRFFQ69G5FAA',
+              id: '01ARZ3NDEKTSV4RRFFQ69G5FAA',
+              slug: 'test-tenant-2',
+            },
+          ],
+          LastEvaluatedKey: { PK: 'cursor-2' },
+        });
+
+      const result = await repo.list({ limit: 2 });
+
+      expect(result.tenants).toHaveLength(2);
+      expect(result.tenants.map((tenant) => tenant.id)).toEqual([
+        '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        '01ARZ3NDEKTSV4RRFFQ69G5FAA',
+      ]);
+      expect(result.lastKey).toEqual({ PK: 'cursor-2' });
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockSend.mock.calls[0][0].input.IndexName).toBe('GSI2');
+    });
   });
 
   describe('findBySlug', () => {
@@ -185,6 +222,7 @@ describe('TenantRepository', () => {
 
       expect(result).toBe(2);
       expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockSend.mock.calls[0][0].input.IndexName).toBe('GSI2');
     });
   });
 });

--- a/backend/services/shared/dynamodb/src/tenant-repository.test.ts
+++ b/backend/services/shared/dynamodb/src/tenant-repository.test.ts
@@ -80,11 +80,27 @@ describe('TenantRepository', () => {
 
       const result = await repo.list();
 
+      expect(result.tenants).toHaveLength(2);
+      expect(result.tenants[0].id).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+    });
+
+    it('legacy item は PK から tenant id を復元して返すべき', async () => {
+      const legacyItem = {
+        ...validTenantItem,
+        id: undefined,
+      };
+      mockSend.mockResolvedValue({
+        Items: [legacyItem],
+        LastEvaluatedKey: undefined,
+      });
+
+      const result = await repo.list();
+
       expect(result.tenants).toHaveLength(1);
       expect(result.tenants[0].id).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
     });
 
-    it('idが空文字のアイテムをフィルタリングすべき', async () => {
+    it('idが空文字でも PK から tenant id を復元すべき', async () => {
       const emptyIdItem = { ...validTenantItem, id: '' };
       mockSend.mockResolvedValue({
         Items: [emptyIdItem, validTenantItem],
@@ -93,7 +109,8 @@ describe('TenantRepository', () => {
 
       const result = await repo.list();
 
-      expect(result.tenants).toHaveLength(1);
+      expect(result.tenants).toHaveLength(2);
+      expect(result.tenants[0].id).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
     });
 
     it('アイテムが空の場合は空配列を返すべき', async () => {
@@ -130,6 +147,44 @@ describe('TenantRepository', () => {
       const result = await repo.findBySlug('no-such-slug');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('count', () => {
+    it('tenant metadata の件数だけ合計すべき', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Items: [
+            validTenantItem,
+            {
+              ...validTenantItem,
+              PK: 'EVENT#01ARZ3NDEKTSV4RRFFQ69G5FAV',
+              EntityType: 'EVENT',
+            },
+          ],
+          LastEvaluatedKey: { PK: 'x' },
+        })
+        .mockResolvedValueOnce({
+          Items: [
+            {
+              ...validTenantItem,
+              PK: 'TENANT#01ARZ3NDEKTSV4RRFFQ69G5FAA',
+              id: '01ARZ3NDEKTSV4RRFFQ69G5FAA',
+            },
+            {
+              ...validTenantItem,
+              PK: 'SYSTEM#SETTING',
+              SK: 'KEY#platform',
+              EntityType: 'SYSTEM_SETTING',
+            },
+          ],
+          LastEvaluatedKey: undefined,
+        });
+
+      const result = await repo.count();
+
+      expect(result).toBe(2);
+      expect(mockSend).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/backend/services/shared/dynamodb/src/tenant-repository.ts
+++ b/backend/services/shared/dynamodb/src/tenant-repository.ts
@@ -4,6 +4,7 @@ import {
   UpdateCommand,
   QueryCommand,
   DeleteCommand,
+  ScanCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import { getDocClient, getTableName } from './client';
@@ -20,11 +21,48 @@ import { EntityType, IsolationModel, ComputeType } from './types';
 // Key builders
 const buildTenantPK = (id: string) => `TENANT#${id}`;
 const buildMetadataSK = () => 'METADATA';
+const TENANT_PK_PREFIX = 'TENANT#';
+
+function parseTenantIdFromPk(pk: string): string | null {
+  if (!pk.startsWith(TENANT_PK_PREFIX)) {
+    return null;
+  }
+
+  const id = pk.slice(TENANT_PK_PREFIX.length);
+  return id.length > 0 ? id : null;
+}
+
+function resolveTenantId(item: Pick<TenantItem, 'PK'> & { id?: string }): string {
+  if (typeof item.id === 'string' && item.id.length > 0) {
+    return item.id;
+  }
+
+  return parseTenantIdFromPk(item.PK) ?? '';
+}
+
+function isTenantMetadataItem(
+  item: Partial<TenantItem>,
+  status?: TenantStatus
+): item is TenantItem {
+  if (
+    typeof item.PK !== 'string' ||
+    typeof item.SK !== 'string' ||
+    item.EntityType !== EntityType.TENANT
+  ) {
+    return false;
+  }
+
+  if (parseTenantIdFromPk(item.PK) === null || item.SK !== buildMetadataSK()) {
+    return false;
+  }
+
+  return status ? item.status === status : true;
+}
 
 // Convert DynamoDB item to domain object
 function toDomain(item: TenantItem): Tenant {
   return {
-    id: item.id,
+    id: resolveTenantId(item),
     name: item.name,
     slug: item.slug,
     status: item.status,
@@ -138,45 +176,33 @@ export class TenantRepository {
   }): Promise<{ tenants: Tenant[]; lastKey?: Record<string, unknown> }> {
     const client = getDocClient();
     const tableName = getTableName();
+    const limit = options?.limit ?? 50;
+    const tenants: Tenant[] = [];
+    let lastKey = options?.lastKey;
 
-    let filterExpression: string | undefined;
-    const expressionValues: Record<string, unknown> = {
-      ':entityType': EntityType.TENANT,
-    };
+    while (tenants.length < limit) {
+      const result = await client.send(
+        new ScanCommand({
+          TableName: tableName,
+          ExclusiveStartKey: lastKey,
+        })
+      );
 
-    if (options?.status) {
-      filterExpression = '#status = :status';
-      expressionValues[':status'] = options.status;
+      tenants.push(
+        ...(result.Items ?? [])
+          .filter((item) => isTenantMetadataItem(item as Partial<TenantItem>, options?.status))
+          .map((item) => toDomain(item as TenantItem))
+      );
+
+      lastKey = result.LastEvaluatedKey;
+      if (!lastKey) {
+        break;
+      }
     }
 
-    const result = await client.send(
-      new QueryCommand({
-        TableName: tableName,
-        IndexName: 'GSI2',
-        KeyConditionExpression: 'EntityType = :entityType',
-        FilterExpression: filterExpression,
-        ExpressionAttributeValues: expressionValues,
-        ExpressionAttributeNames: filterExpression
-          ? { '#status': 'status' }
-          : undefined,
-        Limit: options?.limit ?? 50,
-        ExclusiveStartKey: options?.lastKey,
-        ScanIndexForward: false, // Newest first
-      })
-    );
-
-    const tenants = (result.Items ?? [])
-      .filter(
-        (item) =>
-          item.EntityType === EntityType.TENANT &&
-          typeof item.id === 'string' &&
-          item.id.length > 0
-      )
-      .map((item) => toDomain(item as TenantItem));
-
     return {
-      tenants,
-      lastKey: result.LastEvaluatedKey,
+      tenants: tenants.slice(0, limit),
+      lastKey,
     };
   }
 
@@ -276,19 +302,23 @@ export class TenantRepository {
   async count(): Promise<number> {
     const client = getDocClient();
     const tableName = getTableName();
+    let total = 0;
+    let lastKey: Record<string, unknown> | undefined;
 
-    const result = await client.send(
-      new QueryCommand({
-        TableName: tableName,
-        IndexName: 'GSI2',
-        KeyConditionExpression: 'EntityType = :entityType',
-        ExpressionAttributeValues: {
-          ':entityType': EntityType.TENANT,
-        },
-        Select: 'COUNT',
-      })
-    );
+    do {
+      const result = await client.send(
+        new ScanCommand({
+          TableName: tableName,
+          ExclusiveStartKey: lastKey,
+        })
+      );
 
-    return result.Count ?? 0;
+      total += (result.Items ?? []).filter((item) =>
+        isTenantMetadataItem(item as Partial<TenantItem>)
+      ).length;
+      lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+
+    return total;
   }
 }

--- a/backend/services/shared/dynamodb/src/tenant-repository.ts
+++ b/backend/services/shared/dynamodb/src/tenant-repository.ts
@@ -4,7 +4,6 @@ import {
   UpdateCommand,
   QueryCommand,
   DeleteCommand,
-  ScanCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import { getDocClient, getTableName } from './client';
@@ -57,6 +56,22 @@ function isTenantMetadataItem(
   }
 
   return status ? item.status === status : true;
+}
+
+function buildTenantEntityQueryInput(options?: {
+  limit?: number;
+  lastKey?: Record<string, unknown>;
+}) {
+  return {
+    TableName: getTableName(),
+    IndexName: 'GSI2',
+    KeyConditionExpression: 'EntityType = :entityType',
+    ExpressionAttributeValues: {
+      ':entityType': EntityType.TENANT,
+    },
+    ExclusiveStartKey: options?.lastKey,
+    Limit: options?.limit,
+  };
 }
 
 // Convert DynamoDB item to domain object
@@ -175,22 +190,26 @@ export class TenantRepository {
     lastKey?: Record<string, unknown>;
   }): Promise<{ tenants: Tenant[]; lastKey?: Record<string, unknown> }> {
     const client = getDocClient();
-    const tableName = getTableName();
     const limit = options?.limit ?? 50;
     const tenants: Tenant[] = [];
     let lastKey = options?.lastKey;
 
     while (tenants.length < limit) {
+      const remaining = limit - tenants.length;
       const result = await client.send(
-        new ScanCommand({
-          TableName: tableName,
-          ExclusiveStartKey: lastKey,
-        })
+        new QueryCommand(
+          buildTenantEntityQueryInput({ lastKey, limit: remaining }),
+        ),
       );
 
       tenants.push(
         ...(result.Items ?? [])
-          .filter((item) => isTenantMetadataItem(item as Partial<TenantItem>, options?.status))
+          .filter((item) =>
+            isTenantMetadataItem(
+              item as Partial<TenantItem>,
+              options?.status,
+            ),
+          )
           .map((item) => toDomain(item as TenantItem))
       );
 
@@ -301,16 +320,12 @@ export class TenantRepository {
 
   async count(): Promise<number> {
     const client = getDocClient();
-    const tableName = getTableName();
     let total = 0;
     let lastKey: Record<string, unknown> | undefined;
 
     do {
       const result = await client.send(
-        new ScanCommand({
-          TableName: tableName,
-          ExclusiveStartKey: lastKey,
-        })
+        new QueryCommand(buildTenantEntityQueryInput({ lastKey }))
       );
 
       total += (result.Items ?? []).filter((item) =>


### PR DESCRIPTION
## Summary
- skip forwarding the `mock-access-token` Authorization header from Next server routes when `AUTH_SKIP` is enabled
- keep the existing local fallback path by letting downstream admin APIs return `Unauthorized` naturally instead of triggering JWT parsing noise
- add a regression test for `serverApiRequest()` so AUTH_SKIP mock tokens are never sent to the backend

## Why
The application-plane mock session uses `mock-access-token` during local development. That token is not a JWT, so forwarding it to problem-service caused `JWSInvalid: Invalid Compact JWS` logs before the route fell back.

## Impact
- local admin routes such as `/api/admin/events` stop emitting JWT verification errors in AUTH_SKIP mode
- backend behavior is unchanged for real access tokens

## Verification
- `./apps/application-plane/node_modules/.bin/vitest run apps/application-plane/lib/api/__tests__/server.test.ts`
- `./apps/application-plane/node_modules/.bin/vitest run apps/application-plane/app/api/admin/events/__tests__/route.test.ts`
- `make before-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme system with dark mode support and persistent user preferences.
  * Introduced local fallback functionality for offline development and testing scenarios.

* **Bug Fixes**
  * Improved pagination and filtering logic for data retrieval operations.

* **Style**
  * Updated admin UI pages with improved design components and layout.
  * Migrated styling system to theme-aware design tokens.
  * Replaced date picker with native datetime input controls.

* **Tests**
  * Extended test coverage for new API behaviors and theme functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->