### PR TITLE
[codex] Avoid forwarding AUTH_SKIP mock tokens

### DIFF
--- a/apps/application-plane/lib/api/__tests__/server.test.ts
+++ b/apps/application-plane/lib/api/__tests__/server.test.ts
@@ -7,6 +7,7 @@ const mockAuth = vi.fn<() => Promise<Session | null>>();
 
 vi.mock('@/auth', () => ({
   auth: () => mockAuth(),
+  authSkipEnabled: false,
 }));
 
 vi.mock('@/lib/api/backend-urls', () => ({
@@ -179,6 +180,36 @@ describe('Server API Utilities', () => {
 
     it('未認証の場合は Authorization ヘッダーなしでリクエストを送信すべき', async () => {
       mockAuth.mockResolvedValue(null);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const { serverApiRequest } = await import('../server');
+      await serverApiRequest<{ data: string }>('/test-endpoint');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/test-endpoint'),
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    it('AUTH_SKIP のモックトークンはバックエンドへ転送しないべき', async () => {
+      mockAuth.mockResolvedValue({
+        user: { name: 'Dev User', email: 'dev@example.com' },
+        expires: new Date().toISOString(),
+        accessToken: 'mock-access-token',
+      } as Session);
+
+      vi.doMock('@/auth', () => ({
+        auth: () => mockAuth(),
+        authSkipEnabled: true,
+      }));
 
       mockFetch.mockResolvedValue({
         ok: true,

--- a/apps/application-plane/lib/api/server.ts
+++ b/apps/application-plane/lib/api/server.ts
@@ -5,8 +5,10 @@
  */
 
 import { NextResponse } from 'next/server';
-import { auth } from '@/auth';
+import { auth, authSkipEnabled } from '@/auth';
 import { getProblemServiceUrl } from '@/lib/api/backend-urls';
+
+const MOCK_ACCESS_TOKEN = 'mock-access-token';
 
 /**
  * 統一エラーレスポンス
@@ -88,6 +90,8 @@ export async function serverApiRequest<T>(
 ): Promise<T> {
   const session = await auth();
   const token = session?.accessToken;
+  const shouldForwardToken =
+    token && !(authSkipEnabled && token === MOCK_ACCESS_TOKEN);
 
   const url = `${API_BASE_URL}${endpoint}`;
 
@@ -95,7 +99,7 @@ export async function serverApiRequest<T>(
     ...options,
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(shouldForwardToken ? { Authorization: `Bearer ${token}` } : {}),
       ...options.headers,
     },
   });


### PR DESCRIPTION
## Summary
- skip forwarding the `mock-access-token` Authorization header from Next server routes when `AUTH_SKIP` is enabled
- keep the existing local fallback path by letting downstream admin APIs return `Unauthorized` naturally instead of triggering JWT parsing noise
- add a regression test for `serverApiRequest()` so AUTH_SKIP mock tokens are never sent to the backend

## Why
The application-plane mock session uses `mock-access-token` during local development. That token is not a JWT, so forwarding it to problem-service caused `JWSInvalid: Invalid Compact JWS` logs before the route fell back.

## Impact
- local admin routes such as `/api/admin/events` stop emitting JWT verification errors in AUTH_SKIP mode
- backend behavior is unchanged for real access tokens

## Verification
- `./apps/application-plane/node_modules/.bin/vitest run apps/application-plane/lib/api/__tests__/server.test.ts`
- `./apps/application-plane/node_modules/.bin/vitest run apps/application-plane/app/api/admin/events/__tests__/route.test.ts`
- `make before-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage with new case verifying authorization header behavior when authentication bypass conditions are active.

* **Bug Fixes**
  * Authorization header forwarding in API requests is now conditional, allowing selective omission while maintaining token handling based on configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->