### PR TITLE
[codex] Fix dashboard header hydration mismatch

### DIFF
--- a/apps/application-plane/app/dashboard/__tests__/page.test.tsx
+++ b/apps/application-plane/app/dashboard/__tests__/page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import DashboardPage from '../page';
 
@@ -56,6 +57,15 @@ describe('ダッシュボードページ', () => {
       // Navigation link + h1 heading both show "Dashboard"
       expect(screen.getAllByText('Dashboard').length).toBeGreaterThanOrEqual(1);
     });
+  });
+
+  it('サーバー描画時は静的な見出しを返すべき', () => {
+    const html = renderToStaticMarkup(<DashboardPage />);
+
+    expect(html).toContain('<h1');
+    expect(html).toContain('Dashboard');
+    expect(html).toContain('Browse joined events and upcoming competitions.');
+    expect(html).not.toContain('awsui_heading');
   });
 
   it('参加中のイベントが表示されるべき', async () => {

--- a/apps/application-plane/app/dashboard/page.tsx
+++ b/apps/application-plane/app/dashboard/page.tsx
@@ -44,9 +44,14 @@ function getStatusIndicator(status: string, t: (k: string) => string) {
 export default function DashboardPage() {
   const { t, locale } = useI18n();
   const router = useRouter();
+  const [mounted, setMounted] = useState(false);
   const [myEvents, setMyEvents] = useState<ParticipantEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     getMyEvents()
@@ -166,9 +171,18 @@ export default function DashboardPage() {
   return (
     <PageLayout
       header={
-        <Header variant="h1" description={t('dashboard.description')}>
-          {t('dashboard.title')}
-        </Header>
+        mounted ? (
+          <Header variant="h1" description={t('dashboard.description')}>
+            {t('dashboard.title')}
+          </Header>
+        ) : (
+          <div>
+            <h1 className="text-3xl font-bold">{t('dashboard.title')}</h1>
+            <p className="mt-2 text-sm text-gray-500">
+              {t('dashboard.description')}
+            </p>
+          </div>
+        )
       }
     >
       <SpaceBetween size="xl">


### PR DESCRIPTION
## Summary
- avoid rendering the Cloudscape `Header` for the dashboard page during SSR so generated heading ids stay stable across hydration
- swap to the Cloudscape header after mount on the client
- add an SSR regression test that verifies the server-rendered dashboard header stays static

## Why
The participant dashboard was rendering a Cloudscape `Header` during SSR. That component generates internal heading ids, so the server markup and first client render could diverge and trigger a hydration mismatch on `/dashboard`.

## Verification
- `./apps/application-plane/node_modules/.bin/vitest run app/dashboard/__tests__/page.test.tsx`
- `./apps/application-plane/node_modules/.bin/vitest run components/layout/__tests__/page-layout.test.tsx`
- `make before-commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Dashboard page server-side rendering, verifying the correct title and description are displayed.

* **Bug Fixes**
  * Improved Dashboard page server-side rendering with fallback content during initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->