### PR TITLE
[codex] Show dashboard service connection statuses

### DIFF
--- a/apps/control-plane/app/dashboard/__tests__/page.test.tsx
+++ b/apps/control-plane/app/dashboard/__tests__/page.test.tsx
@@ -9,6 +9,7 @@ import DashboardPage from '../page';
 // API のモック（hoisted で先に定義）
 const mockFetchDashboardStats = vi.hoisted(() => vi.fn());
 const mockFetchActivities = vi.hoisted(() => vi.fn());
+const mockFetchServiceConnections = vi.hoisted(() => vi.fn());
 
 // getSession のモック
 vi.mock('@/auth', () => ({
@@ -17,6 +18,27 @@ vi.mock('@/auth', () => ({
 
 vi.mock('@/lib/api/stats-api', () => ({
   fetchDashboardStats: mockFetchDashboardStats,
+}));
+
+vi.mock('@/lib/api/service-health', () => ({
+  fetchServiceConnections: mockFetchServiceConnections,
+  summarizeServiceConnections: (
+    services: Array<{ status: 'connected' | 'unreachable' }>,
+  ) => {
+    const connectedCount = services.filter(
+      (service) => service.status === 'connected',
+    ).length;
+
+    if (connectedCount === services.length && services.length > 0) {
+      return 'healthy';
+    }
+
+    if (connectedCount === 0) {
+      return 'down';
+    }
+
+    return 'degraded';
+  },
 }));
 
 vi.mock('@/lib/api/activities-api', () => ({
@@ -161,6 +183,20 @@ describe('DashboardPage コンポーネント', () => {
         systemStatus: 'healthy',
         uptimePercentage: 100,
       });
+      mockFetchServiceConnections.mockResolvedValue([
+        {
+          id: 'tenant-management',
+          name: 'Tenant Management',
+          status: 'connected',
+          checkedUrl: 'http://tenant-management:13004/health',
+        },
+        {
+          id: 'problem-service',
+          name: 'Problem Service',
+          status: 'connected',
+          checkedUrl: 'http://problem-service:3100/health',
+        },
+      ]);
       mockFetchActivities.mockResolvedValue({
         data: [],
         pagination: { limit: 5, hasNextPage: false },
@@ -198,15 +234,17 @@ describe('DashboardPage コンポーネント', () => {
       const Component = await DashboardPage();
       render(Component);
       expect(screen.getByText('アクティブテナント')).toBeInTheDocument();
-      expect(screen.getByText('システムステータス')).toBeInTheDocument();
+      expect(screen.getByText('サービス接続')).toBeInTheDocument();
       expect(screen.getByText('総テナント数')).toBeInTheDocument();
     });
 
-    it('システムステータスが正常と表示されるべき', async () => {
+    it('サービス接続が正常と表示されるべき', async () => {
       const Component = await DashboardPage();
       render(Component);
       expect(screen.getByText('正常')).toBeInTheDocument();
-      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByText('Tenant Management')).toBeInTheDocument();
+      expect(screen.getByText('Problem Service')).toBeInTheDocument();
+      expect(screen.getAllByText('接続中')).toHaveLength(2);
     });
 
     it('実際の統計値を表示すべき', async () => {
@@ -258,17 +296,34 @@ describe('DashboardPage コンポーネント', () => {
       expect(dashElements.length).toBeGreaterThan(0);
     });
 
-    it('システムステータスが異常の場合は異常と表示すべき', async () => {
-      mockFetchDashboardStats.mockResolvedValue({
-        activeTenants: 3,
-        totalTenants: 8,
-        systemStatus: 'degraded',
-        uptimePercentage: 95.5,
-      });
+    it('サービス接続に失敗がある場合は一部異常と表示すべき', async () => {
+      mockFetchServiceConnections.mockResolvedValue([
+        {
+          id: 'tenant-management',
+          name: 'Tenant Management',
+          status: 'connected',
+          checkedUrl: 'http://tenant-management:13004/health',
+        },
+        {
+          id: 'problem-service',
+          name: 'Problem Service',
+          status: 'unreachable',
+          checkedUrl: 'http://problem-service:3100/health',
+        },
+      ]);
       const Component = await DashboardPage();
       render(Component);
-      expect(screen.getByText('異常')).toBeInTheDocument();
-      expect(screen.getByText('95.5%')).toBeInTheDocument();
+      expect(screen.getByText('一部異常')).toBeInTheDocument();
+      expect(screen.getByText('未接続')).toBeInTheDocument();
+    });
+
+    it('サービス接続一覧が取得できない場合は案内文を表示すべき', async () => {
+      mockFetchServiceConnections.mockRejectedValue(new Error('Network error'));
+      const Component = await DashboardPage();
+      render(Component);
+      expect(
+        screen.getByText('接続先を確認できませんでした'),
+      ).toBeInTheDocument();
     });
 
     it('アクティビティを表示すべき', async () => {

--- a/apps/control-plane/app/dashboard/page.tsx
+++ b/apps/control-plane/app/dashboard/page.tsx
@@ -9,7 +9,6 @@ import Button from '@cloudscape-design/components/button';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
-import Link from '@cloudscape-design/components/link';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import '@cloudscape-design/global-styles/index.css';
@@ -17,6 +16,11 @@ import NextLink from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/auth';
 import { fetchActivities } from '@/lib/api/activities-api';
+import {
+  fetchServiceConnections,
+  summarizeServiceConnections,
+  type ServiceConnection,
+} from '@/lib/api/service-health';
 import { fetchDashboardStats, type DashboardStats } from '@/lib/api/stats-api';
 import type { Activity } from '@/types/activity';
 
@@ -32,6 +36,14 @@ async function getActivities(): Promise<Activity[]> {
   try {
     const result = await fetchActivities(5);
     return result.data;
+  } catch {
+    return [];
+  }
+}
+
+async function getServiceConnections(): Promise<ServiceConnection[]> {
+  try {
+    return await fetchServiceConnections();
   } catch {
     return [];
   }
@@ -86,7 +98,12 @@ export default async function DashboardPage() {
     redirect('/login');
   }
 
-  const [stats, activities] = await Promise.all([getStats(), getActivities()]);
+  const [stats, activities, serviceConnections] = await Promise.all([
+    getStats(),
+    getActivities(),
+    getServiceConnections(),
+  ]);
+  const serviceStatus = summarizeServiceConnections(serviceConnections);
 
   return (
     <SpaceBetween size="l">
@@ -108,21 +125,48 @@ export default async function DashboardPage() {
             <Header
               variant="h3"
               info={
-                stats?.systemStatus === 'healthy' ? (
+                serviceStatus === 'healthy' ? (
                   <StatusIndicator type="success">正常</StatusIndicator>
+                ) : serviceStatus === 'degraded' ? (
+                  <StatusIndicator type="warning">一部異常</StatusIndicator>
                 ) : (
-                  <StatusIndicator type="error">異常</StatusIndicator>
+                  <StatusIndicator type="error">未接続</StatusIndicator>
                 )
               }
             >
-              システムステータス
+              サービス接続
             </Header>
           }
         >
-          <Box variant="awsui-key-label">稼働率</Box>
-          <Box variant="awsui-value-large">
-            {stats?.uptimePercentage ?? '-'}%
-          </Box>
+          {serviceConnections.length === 0 ? (
+            <Box color="text-body-secondary">接続先を確認できませんでした</Box>
+          ) : (
+            <SpaceBetween size="xs">
+              {serviceConnections.map((service) => (
+                <div
+                  key={service.id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: '12px',
+                  }}
+                >
+                  <div>
+                    <Box variant="awsui-key-label">{service.name}</Box>
+                    <Box color="text-body-secondary" fontSize="body-s">
+                      {service.id}
+                    </Box>
+                  </div>
+                  <StatusIndicator
+                    type={service.status === 'connected' ? 'success' : 'error'}
+                  >
+                    {service.status === 'connected' ? '接続中' : '未接続'}
+                  </StatusIndicator>
+                </div>
+              ))}
+            </SpaceBetween>
+          )}
         </Container>
 
         <Container header={<Header variant="h3">総テナント数</Header>}>

--- a/apps/control-plane/lib/api/__tests__/service-health.test.ts
+++ b/apps/control-plane/lib/api/__tests__/service-health.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('service-health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it('TENANT_API_BASE_URL が localhost の場合は localhost のヘルス URL を優先すべき', async () => {
+    vi.stubEnv('TENANT_API_BASE_URL', 'http://localhost:13004/api');
+
+    const { resolveServiceHealthUrls } = await import('../service-health');
+
+    expect(resolveServiceHealthUrls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'tenant-management',
+          checkedUrl: 'http://localhost:13004/health',
+        }),
+        expect.objectContaining({
+          id: 'problem-service',
+          checkedUrl: 'http://localhost:3100/health',
+        }),
+      ]),
+    );
+  });
+
+  it('環境変数が未設定の場合は Docker 向け URL を優先すべき', async () => {
+    const { resolveServiceHealthUrls } = await import('../service-health');
+
+    expect(resolveServiceHealthUrls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'tenant-management',
+          checkedUrl: 'http://tenant-management:13004/health',
+        }),
+        expect.objectContaining({
+          id: 'leaderboard-service',
+          checkedUrl: 'http://leaderboard-service:3012/health',
+        }),
+      ]),
+    );
+  });
+
+  it('個別のヘルス URL 環境変数がある場合はその URL を使用すべき', async () => {
+    vi.stubEnv(
+      'PROBLEM_SERVICE_HEALTH_URL',
+      'http://custom-problem-service.internal/health',
+    );
+
+    const { resolveServiceHealthUrls } = await import('../service-health');
+
+    expect(resolveServiceHealthUrls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'problem-service',
+          checkedUrl: 'http://custom-problem-service.internal/health',
+        }),
+      ]),
+    );
+  });
+
+  it('127.0.0.1 の場合も localhost 扱いで優先すべき', async () => {
+    vi.stubEnv('TENANT_API_BASE_URL', 'http://127.0.0.1:13004/api');
+
+    const { resolveServiceHealthUrls } = await import('../service-health');
+
+    expect(resolveServiceHealthUrls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'gameday-service',
+          checkedUrl: 'http://localhost:3020/health',
+        }),
+      ]),
+    );
+  });
+
+  it('最初の候補に失敗しても代替 URL で接続できれば接続中と判定すべき', async () => {
+    vi.stubEnv('TENANT_API_BASE_URL', 'http://localhost:13004/api');
+    global.fetch = vi.fn().mockImplementation((input: string | URL) => {
+      const url = String(input);
+
+      if (url.includes('localhost')) {
+        return Promise.reject(new Error('connect ECONNREFUSED'));
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: 'ok', service: 'tenant-management' }),
+      });
+    }) as unknown as typeof fetch;
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+    const tenantService = services.find(
+      (service) => service.id === 'tenant-management',
+    );
+
+    expect(tenantService).toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        checkedUrl: 'http://tenant-management:13004/health',
+        detail: 'tenant-management',
+      }),
+    );
+  });
+
+  it('HTTP エラーを返したサービスは未接続と判定すべき', async () => {
+    global.fetch = vi.fn().mockImplementation((input: string | URL) => {
+      const url = String(input);
+
+      if (url.includes('problem-service') || url.includes('localhost:3100')) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: 'ok', service: 'healthy-service' }),
+      });
+    }) as unknown as typeof fetch;
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+    const problemService = services.find(
+      (service) => service.id === 'problem-service',
+    );
+
+    expect(problemService).toEqual(
+      expect.objectContaining({
+        status: 'unreachable',
+        detail: 'HTTP 503',
+      }),
+    );
+  });
+
+  it('unhealthy な payload を返した場合は代替 URL を試すべき', async () => {
+    vi.stubEnv('TENANT_API_BASE_URL', 'http://localhost:13004/api');
+    global.fetch = vi.fn().mockImplementation((input: string | URL) => {
+      const url = String(input);
+
+      if (url === 'http://localhost:3100/health') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: 'degraded' }),
+        });
+      }
+
+      if (url === 'http://problem-service:3100/health') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ status: 'healthy', service: 'problem-service' }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: 'ok', service: 'healthy-service' }),
+      });
+    }) as unknown as typeof fetch;
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+    const problemService = services.find(
+      (service) => service.id === 'problem-service',
+    );
+
+    expect(problemService).toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        checkedUrl: 'http://problem-service:3100/health',
+        detail: 'problem-service',
+      }),
+    );
+  });
+
+  it('個別のヘルス URL 環境変数がある場合はその URL だけを使うべき', async () => {
+    vi.stubEnv(
+      'PROBLEM_SERVICE_HEALTH_URL',
+      'http://custom-problem-service.internal/health',
+    );
+    global.fetch = vi.fn().mockImplementation((input: string | URL) => {
+      const url = String(input);
+
+      if (url === 'http://custom-problem-service.internal/health') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.reject(new Error('invalid json')),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: 'ok', service: 'healthy-service' }),
+      });
+    }) as unknown as typeof fetch;
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+    const problemService = services.find(
+      (service) => service.id === 'problem-service',
+    );
+
+    expect(problemService).toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        checkedUrl: 'http://custom-problem-service.internal/health',
+        detail: undefined,
+      }),
+    );
+  });
+
+  it('全候補に失敗した場合は未接続と判定すべき', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('fetch failed'));
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+
+    expect(services).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'problem-service',
+          status: 'unreachable',
+          detail: 'fetch failed',
+        }),
+      ]),
+    );
+  });
+
+  it('接続状況から全体ステータスを集計すべき', async () => {
+    const { summarizeServiceConnections } = await import('../service-health');
+
+    expect(
+      summarizeServiceConnections([
+        {
+          id: 'tenant-management',
+          name: 'Tenant Management',
+          status: 'connected',
+          checkedUrl: 'http://tenant-management:13004/health',
+        },
+      ]),
+    ).toBe('healthy');
+
+    expect(
+      summarizeServiceConnections([
+        {
+          id: 'tenant-management',
+          name: 'Tenant Management',
+          status: 'connected',
+          checkedUrl: 'http://tenant-management:13004/health',
+        },
+        {
+          id: 'problem-service',
+          name: 'Problem Service',
+          status: 'unreachable',
+          checkedUrl: 'http://problem-service:3100/health',
+        },
+      ]),
+    ).toBe('degraded');
+
+    expect(
+      summarizeServiceConnections([
+        {
+          id: 'tenant-management',
+          name: 'Tenant Management',
+          status: 'unreachable',
+          checkedUrl: 'http://tenant-management:13004/health',
+        },
+      ]),
+    ).toBe('down');
+  });
+
+  it('Error 以外で失敗した場合は Unknown error として扱うべき', async () => {
+    global.fetch = vi.fn().mockRejectedValue('boom');
+
+    const { fetchServiceConnections } = await import('../service-health');
+    const services = await fetchServiceConnections();
+
+    expect(services).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'tenant-management',
+          status: 'unreachable',
+          detail: 'Unknown error',
+        }),
+      ]),
+    );
+  });
+
+  it('AbortSignal.timeout が使えない場合でもヘルスチェックできるべき', async () => {
+    vi.stubGlobal('AbortSignal', undefined);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ status: 'ok', service: 'tenant-management' }),
+    }) as unknown as typeof fetch;
+    global.fetch = mockFetch;
+
+    const { fetchServiceConnections } = await import('../service-health');
+    await fetchServiceConnections();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://tenant-management:13004/health',
+      { cache: 'no-store' },
+    );
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/control-plane/lib/api/service-health.ts
+++ b/apps/control-plane/lib/api/service-health.ts
@@ -1,0 +1,188 @@
+export type ServiceConnectionState = 'connected' | 'unreachable';
+
+export interface ServiceConnection {
+  id: string;
+  name: string;
+  status: ServiceConnectionState;
+  checkedUrl: string;
+  detail?: string;
+}
+
+interface ServiceHealthTarget {
+  id: string;
+  name: string;
+  envKey: string;
+  localUrl: string;
+  dockerUrl: string;
+}
+
+const SERVICE_HEALTH_TARGETS: ServiceHealthTarget[] = [
+  {
+    id: 'tenant-management',
+    name: 'Tenant Management',
+    envKey: 'TENANT_MANAGEMENT_HEALTH_URL',
+    localUrl: 'http://localhost:13004/health',
+    dockerUrl: 'http://tenant-management:13004/health',
+  },
+  {
+    id: 'problem-service',
+    name: 'Problem Service',
+    envKey: 'PROBLEM_SERVICE_HEALTH_URL',
+    localUrl: 'http://localhost:3100/health',
+    dockerUrl: 'http://problem-service:3100/health',
+  },
+  {
+    id: 'gameday-service',
+    name: 'GameDay Service',
+    envKey: 'GAMEDAY_SERVICE_HEALTH_URL',
+    localUrl: 'http://localhost:3020/health',
+    dockerUrl: 'http://gameday-service:3020/health',
+  },
+  {
+    id: 'battle-service',
+    name: 'Battle Service',
+    envKey: 'BATTLE_SERVICE_HEALTH_URL',
+    localUrl: 'http://localhost:3010/health',
+    dockerUrl: 'http://battle-service:3010/health',
+  },
+  {
+    id: 'scoring-service',
+    name: 'Scoring Service',
+    envKey: 'SCORING_SERVICE_HEALTH_URL',
+    localUrl: 'http://localhost:3011/health',
+    dockerUrl: 'http://scoring-service:3011/health',
+  },
+  {
+    id: 'leaderboard-service',
+    name: 'Leaderboard Service',
+    envKey: 'LEADERBOARD_SERVICE_HEALTH_URL',
+    localUrl: 'http://localhost:3012/health',
+    dockerUrl: 'http://leaderboard-service:3012/health',
+  },
+];
+
+function preferLocalUrls(): boolean {
+  const tenantApiBaseUrl =
+    process.env.TENANT_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_TENANT_API_BASE_URL;
+
+  return (
+    tenantApiBaseUrl?.includes('localhost') === true ||
+    tenantApiBaseUrl?.includes('127.0.0.1') === true
+  );
+}
+
+function getFetchOptions(): RequestInit {
+  if (
+    typeof AbortSignal !== 'undefined' &&
+    typeof AbortSignal.timeout === 'function'
+  ) {
+    return {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(2000),
+    };
+  }
+
+  return { cache: 'no-store' };
+}
+
+export function resolveServiceHealthUrls(): ServiceConnection[] {
+  const localFirst = preferLocalUrls();
+
+  return SERVICE_HEALTH_TARGETS.map((target) => {
+    const configuredUrl = process.env[target.envKey];
+    const checkedUrl =
+      configuredUrl || (localFirst ? target.localUrl : target.dockerUrl);
+
+    return {
+      id: target.id,
+      name: target.name,
+      status: 'unreachable',
+      checkedUrl,
+    };
+  });
+}
+
+function getCandidateUrls(target: ServiceHealthTarget): string[] {
+  const configuredUrl = process.env[target.envKey];
+  if (configuredUrl) {
+    return [configuredUrl];
+  }
+
+  return preferLocalUrls()
+    ? [target.localUrl, target.dockerUrl]
+    : [target.dockerUrl, target.localUrl];
+}
+
+async function checkServiceConnection(
+  target: ServiceHealthTarget,
+): Promise<ServiceConnection> {
+  let lastDetail = 'ヘルスチェックに失敗しました';
+
+  for (const url of getCandidateUrls(target)) {
+    try {
+      const response = await fetch(url, getFetchOptions());
+      if (!response.ok) {
+        lastDetail = `HTTP ${response.status}`;
+        continue;
+      }
+
+      const payload = (await response.json().catch(() => null)) as {
+        status?: string;
+        service?: string;
+      } | null;
+
+      const reportedStatus = payload?.status;
+      const reportedService = payload?.service;
+      const isHealthy =
+        reportedStatus === undefined ||
+        reportedStatus === 'ok' ||
+        reportedStatus === 'healthy';
+
+      if (!isHealthy) {
+        lastDetail = reportedStatus ?? 'unhealthy';
+        continue;
+      }
+
+      return {
+        id: target.id,
+        name: target.name,
+        status: 'connected',
+        checkedUrl: url,
+        detail: reportedService || reportedStatus,
+      };
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : 'Unknown error';
+    }
+  }
+
+  return {
+    id: target.id,
+    name: target.name,
+    status: 'unreachable',
+    checkedUrl: getCandidateUrls(target)[0],
+    detail: lastDetail,
+  };
+}
+
+export async function fetchServiceConnections(): Promise<ServiceConnection[]> {
+  return Promise.all(SERVICE_HEALTH_TARGETS.map(checkServiceConnection));
+}
+
+export function summarizeServiceConnections(
+  services: ServiceConnection[],
+): 'healthy' | 'degraded' | 'down' {
+  const connectedCount = services.filter(
+    (service) => service.status === 'connected',
+  ).length;
+
+  if (connectedCount === services.length && services.length > 0) {
+    return 'healthy';
+  }
+
+  if (connectedCount === 0) {
+    return 'down';
+  }
+
+  return 'degraded';
+}


### PR DESCRIPTION
## Summary
- replace the ambiguous dashboard uptime card with a microservice connection status list
- add a dedicated service-health helper that checks related backend `/health` endpoints with localhost and Docker fallbacks
- cover the new dashboard UI and health-check fallback behavior with tests

## Why
`100%` on the control-plane dashboard was derived from tenant provisioning state, not actual backend connectivity. That made the card misleading. Showing each related service's connection state is more actionable for operators.

## Verification
- `./apps/control-plane/node_modules/.bin/vitest run app/dashboard/__tests__/page.test.tsx`
- `./apps/control-plane/node_modules/.bin/vitest run lib/api/__tests__/service-health.test.ts`
- `make before-commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service connection monitoring now available on the dashboard, displaying individual service connectivity status.
  * Updated status indicators to show overall health: "正常" (healthy), "一部異常" (partially degraded), or "未接続" (disconnected).
  * Dashboard now displays service-specific connection details instead of system uptime percentage.
  * Added error messaging when service connections cannot be verified.

* **Tests**
  * Added comprehensive test coverage for service health checking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->