### PR TITLE
[codex] guard gameday team deployments

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -23,6 +23,9 @@ import Table from '@cloudscape-design/components/table';
 import '@cloudscape-design/global-styles/index.css';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AdminProblem } from '@/lib/api/admin-types';
+import { getProblem } from '@/lib/api/admin-problems';
+import { getGameDayTeamDeploymentIssue } from '../../../../../../../../lib/api/gameday-team-deploy';
 
 // ============================================================
 // Types
@@ -206,6 +209,8 @@ export default function GameDayDeploymentsPage() {
   const eventId = params.eventId as string;
   const problemId = params.problemId as string;
 
+  const [problem, setProblem] = useState<AdminProblem | null>(null);
+  const [problemLoading, setProblemLoading] = useState(true);
   const [accounts, setAccounts] = useState<CompetitorAccount[]>([]);
   const [jobs, setJobs] = useState<DeploymentJob[]>([]);
   const [accountsLoading, setAccountsLoading] = useState(true);
@@ -228,6 +233,14 @@ export default function GameDayDeploymentsPage() {
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const sseRef = useRef<EventSource | null>(null);
+  const teamDeployIssue = problem
+    ? getGameDayTeamDeploymentIssue(problem)
+    : null;
+  const deployDisabled =
+    deployLoading ||
+    problemLoading ||
+    teamDeployIssue !== null ||
+    accounts.length === 0;
 
   // ---- Data fetching ----
 
@@ -239,6 +252,18 @@ export default function GameDayDeploymentsPage() {
       console.error('Failed to refresh jobs', e);
     }
   }, [eventId, problemId]);
+
+  const refreshProblem = useCallback(async () => {
+    try {
+      setProblemLoading(true);
+      const data = await getProblem(problemId);
+      setProblem(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '問題取得失敗');
+    } finally {
+      setProblemLoading(false);
+    }
+  }, [problemId]);
 
   const refreshAccounts = useCallback(async () => {
     try {
@@ -305,6 +330,7 @@ export default function GameDayDeploymentsPage() {
   // ---- Initial load ----
 
   useEffect(() => {
+    refreshProblem();
     refreshAccounts();
     // SSE が失敗する前の初期データ取得
     fetchJobs(eventId, problemId)
@@ -313,7 +339,7 @@ export default function GameDayDeploymentsPage() {
         setJobsLoading(false);
       })
       .catch(() => setJobsLoading(false));
-  }, [eventId, problemId, refreshAccounts]);
+  }, [eventId, problemId, refreshAccounts, refreshProblem]);
 
   // アクティブジョブがなければポーリングを止める
   useEffect(() => {
@@ -324,6 +350,10 @@ export default function GameDayDeploymentsPage() {
   // ---- Actions ----
 
   const handleDeploy = async () => {
+    if (problemLoading || teamDeployIssue || accounts.length === 0) {
+      return;
+    }
+
     setDeployLoading(true);
     setError(null);
     try {
@@ -406,13 +436,18 @@ export default function GameDayDeploymentsPage() {
     <SpaceBetween size="l">
       <Header
         variant="h1"
+        description={
+          problem?.title
+            ? `${problem.title} をイベント参加チームの AWS アカウントへ配布します。`
+            : undefined
+        }
         actions={
           <SpaceBetween direction="horizontal" size="xs">
             <Button
               variant="primary"
               onClick={handleDeploy}
               loading={deployLoading}
-              disabled={accounts.length === 0}
+              disabled={deployDisabled}
             >
               全チームへデプロイ
             </Button>
@@ -430,6 +465,15 @@ export default function GameDayDeploymentsPage() {
       {error && (
         <Alert type="error" dismissible onDismiss={() => setError(null)}>
           {error}
+        </Alert>
+      )}
+
+      {teamDeployIssue && <Alert type="warning">{teamDeployIssue}</Alert>}
+
+      {!teamDeployIssue && !problemLoading && accounts.length === 0 && (
+        <Alert type="info">
+          先に競技アカウントを追加してください。アカウントが 1 件もない場合は
+          チーム配布を開始できません。
         </Alert>
       )}
 

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
@@ -52,7 +52,12 @@ const baseProblem = {
   metadata: { author: 'admin', version: '1.0', tags: [] },
   deployment: {
     providers: ['aws' as const],
-    templates: {},
+    templates: {
+      aws: {
+        type: 'cloudformation' as const,
+        path: 's3://templates/problem.yaml',
+      },
+    },
     regions: { aws: ['ap-northeast-1'] },
   },
   scoring: {
@@ -61,6 +66,13 @@ const baseProblem = {
     timeoutMinutes: 5,
     criteria: [{ name: '正解', weight: 1, maxPoints: 100 }],
   },
+};
+
+const unsupportedTeamDeployProblem = {
+  ...baseProblem,
+  id: 'prob-unsupported',
+  title: 'JAM 問題',
+  type: 'jam' as const,
 };
 
 describe('AdminEventProblemsPage', () => {
@@ -215,5 +227,41 @@ describe('AdminEventProblemsPage', () => {
     await waitFor(() => {
       expect(screen.getAllByText('デプロイ').length).toBeGreaterThanOrEqual(1);
     });
+  });
+
+  it('対応している問題ではチームデプロイ画面へ遷移できるべき', async () => {
+    mockGetEventProblems.mockResolvedValue({ problems: [baseProblem] });
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'チームへデプロイ' }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'チームへデプロイ' }),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/events/ev-1/problems/prob-1/deployments',
+    );
+  });
+
+  it('未対応の問題ではチームデプロイ理由を表示すべき', async () => {
+    mockGetEventProblems.mockResolvedValue({
+      problems: [unsupportedTeamDeployProblem],
+    });
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('GameDay 問題のみチーム配布に対応しています。'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'チームへデプロイ' }),
+    ).toBeDisabled();
   });
 });

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
@@ -34,6 +34,7 @@ import {
   getProblems,
   removeProblemFromEvent,
 } from '@/lib/api/admin-problems';
+import { getGameDayTeamDeploymentIssue } from '../../../../../../lib/api/gameday-team-deploy';
 
 // =============================================================================
 // Types
@@ -418,35 +419,47 @@ export default function AdminEventProblemsPage() {
             {
               id: 'actions',
               header: 'アクション',
-              cell: (item) => (
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() =>
-                      router.push(`/admin/problems/${item.id}/edit`)
-                    }
-                  >
-                    編集
-                  </Button>
-                  <Button
-                    variant="link"
-                    onClick={() =>
-                      router.push(
-                        `/admin/events/${eventId}/problems/${item.id}/deployments`,
-                      )
-                    }
-                  >
-                    チームへデプロイ
-                  </Button>
-                  <Button
-                    variant="link"
-                    loading={removingIds.has(item.id)}
-                    onClick={() => handleRemove(item.id)}
-                  >
-                    削除
-                  </Button>
-                </SpaceBetween>
-              ),
+              cell: (item) => {
+                const teamDeployIssue = getGameDayTeamDeploymentIssue(item);
+
+                return (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button
+                      variant="link"
+                      onClick={() =>
+                        router.push(`/admin/problems/${item.id}/edit`)
+                      }
+                    >
+                      編集
+                    </Button>
+                    <SpaceBetween size="xxs">
+                      <Button
+                        variant="link"
+                        disabled={teamDeployIssue !== null}
+                        onClick={() =>
+                          router.push(
+                            `/admin/events/${eventId}/problems/${item.id}/deployments`,
+                          )
+                        }
+                      >
+                        チームへデプロイ
+                      </Button>
+                      {teamDeployIssue && (
+                        <Box color="text-body-secondary" fontSize="body-s">
+                          {teamDeployIssue}
+                        </Box>
+                      )}
+                    </SpaceBetween>
+                    <Button
+                      variant="link"
+                      loading={removingIds.has(item.id)}
+                      onClick={() => handleRemove(item.id)}
+                    >
+                      削除
+                    </Button>
+                  </SpaceBetween>
+                );
+              },
             },
           ]}
         />

--- a/apps/application-plane/lib/__tests__/gameday-team-deploy.test.ts
+++ b/apps/application-plane/lib/__tests__/gameday-team-deploy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGameDayTeamDeploymentIssue } from '../api/gameday-team-deploy';
+
+const baseProblem = {
+  type: 'gameday' as const,
+  deployment: {
+    providers: ['aws' as const],
+    timeout: 60,
+    templates: {
+      aws: {
+        type: 'cloudformation' as const,
+        path: 's3://templates/problem.yaml',
+      },
+    },
+    regions: {
+      aws: ['ap-northeast-1'],
+    },
+  },
+};
+
+describe('getGameDayTeamDeploymentIssue', () => {
+  it('GameDay の AWS 問題はチーム配布可能と判定すべき', () => {
+    expect(getGameDayTeamDeploymentIssue(baseProblem)).toBeNull();
+  });
+
+  it('GameDay 以外の問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        type: 'jam',
+      }),
+    ).toBe('GameDay 問題のみチーム配布に対応しています。');
+  });
+
+  it('AWS provider がない問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        deployment: {
+          ...baseProblem.deployment,
+          providers: ['local'],
+          templates: {},
+        },
+      }),
+    ).toBe('チーム配布には AWS デプロイ設定が必要です。');
+  });
+
+  it('AWS テンプレートがない問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        deployment: {
+          ...baseProblem.deployment,
+          templates: {},
+        },
+      }),
+    ).toBe('チーム配布には AWS テンプレートの設定が必要です。');
+  });
+});

--- a/apps/application-plane/lib/api/gameday-team-deploy.ts
+++ b/apps/application-plane/lib/api/gameday-team-deploy.ts
@@ -1,0 +1,27 @@
+import type { AdminProblem } from '@/lib/api/admin-types';
+
+type TeamDeployableProblem = Pick<AdminProblem, 'type' | 'deployment'>;
+
+export function getGameDayTeamDeploymentIssue(
+  problem: TeamDeployableProblem,
+): string | null {
+  if (problem.type !== 'gameday') {
+    return 'GameDay 問題のみチーム配布に対応しています。';
+  }
+
+  if (!problem.deployment.providers.includes('aws')) {
+    return 'チーム配布には AWS デプロイ設定が必要です。';
+  }
+
+  if (!problem.deployment.templates.aws) {
+    return 'チーム配布には AWS テンプレートの設定が必要です。';
+  }
+
+  return null;
+}
+
+export function canDeployGameDayProblemToTeams(
+  problem: TeamDeployableProblem,
+): boolean {
+  return getGameDayTeamDeploymentIssue(problem) === null;
+}

--- a/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
@@ -134,6 +134,45 @@ describe("gameday-deployer", () => {
 		vi.clearAllMocks();
 	});
 
+	describe("getGameDayDeploymentValidationError", () => {
+		it("GameDay の AWS 問題はデプロイ可能と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(getGameDayDeploymentValidationError(makeProblem())).toBeNull();
+		});
+
+		it("GameDay 以外の問題は未対応と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(
+				getGameDayDeploymentValidationError({
+					...makeProblem(),
+					type: "jam",
+				}),
+			).toBe("Team deployment is only supported for GameDay problems");
+		});
+
+		it("AWS テンプレートがない問題は未対応と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(
+				getGameDayDeploymentValidationError({
+					...makeProblem(),
+					deployment: {
+						...makeProblem().deployment,
+						templates: {},
+					},
+				}),
+			).toBe("Team deployment requires an AWS deployment template");
+		});
+	});
+
 	describe("reconcile", () => {
 		it("アクティブジョブがない場合は何もしないべき", async () => {
 			mockFindActive.mockResolvedValueOnce([]);

--- a/backend/services/application-plane/problem-service/src/__tests__/routes-admin.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/routes-admin.test.ts
@@ -15,6 +15,19 @@ const {
 	mockTemplateRepository,
 	mockAWSProvider,
 	mockLocalProvider,
+	mockCompetitorAccountCreate,
+	mockCompetitorAccountFindByEventId,
+	mockCompetitorAccountFindById,
+	mockCompetitorAccountUpdateStatus,
+	mockCompetitorAccountDelete,
+	mockGameDayJobCreate,
+	mockGameDayJobFindByEventAndProblem,
+	mockGameDayJobFindById,
+	mockGameDayJobFindActive,
+	mockGameDayJobUpdateStatus,
+	mockDeployProblemToTeams,
+	mockRetryJob,
+	mockSubscribeToJob,
 } = vi.hoisted(() => ({
 	mockEventRepository: {
 		findByTenant: vi.fn().mockResolvedValue([]),
@@ -117,6 +130,23 @@ const {
 			completedAt: new Date(),
 		}),
 	},
+	mockCompetitorAccountCreate: vi
+		.fn()
+		.mockResolvedValue({ id: "account-1", name: "team01" }),
+	mockCompetitorAccountFindByEventId: vi.fn().mockResolvedValue([]),
+	mockCompetitorAccountFindById: vi.fn().mockResolvedValue(null),
+	mockCompetitorAccountUpdateStatus: vi.fn().mockResolvedValue(undefined),
+	mockCompetitorAccountDelete: vi.fn().mockResolvedValue(undefined),
+	mockGameDayJobCreate: vi
+		.fn()
+		.mockResolvedValue({ id: "job-1", status: "pending" }),
+	mockGameDayJobFindByEventAndProblem: vi.fn().mockResolvedValue([]),
+	mockGameDayJobFindById: vi.fn().mockResolvedValue(null),
+	mockGameDayJobFindActive: vi.fn().mockResolvedValue([]),
+	mockGameDayJobUpdateStatus: vi.fn().mockResolvedValue(undefined),
+	mockDeployProblemToTeams: vi.fn().mockResolvedValue([]),
+	mockRetryJob: vi.fn().mockResolvedValue(null),
+	mockSubscribeToJob: vi.fn().mockReturnValue(() => {}),
 }));
 
 // 依存関係をモック
@@ -208,28 +238,48 @@ vi.mock("../providers/local", () => ({
 
 vi.mock("../repositories/competitor-account-repository", () => ({
 	CompetitorAccountRepository: class {
-		create = vi.fn().mockResolvedValue({ id: "account-1", name: "team01" });
-		findByEventId = vi.fn().mockResolvedValue([]);
-		findById = vi.fn().mockResolvedValue(null);
-		updateStatus = vi.fn().mockResolvedValue(undefined);
-		delete = vi.fn().mockResolvedValue(undefined);
+		create = mockCompetitorAccountCreate;
+		findByEventId = mockCompetitorAccountFindByEventId;
+		findById = mockCompetitorAccountFindById;
+		updateStatus = mockCompetitorAccountUpdateStatus;
+		delete = mockCompetitorAccountDelete;
 	},
 }));
 
 vi.mock("../repositories/gameday-deployment-job-repository", () => ({
 	GameDayDeploymentJobRepository: class {
-		create = vi.fn().mockResolvedValue({ id: "job-1", status: "pending" });
-		findByEventAndProblem = vi.fn().mockResolvedValue([]);
-		findById = vi.fn().mockResolvedValue(null);
-		findActive = vi.fn().mockResolvedValue([]);
-		updateStatus = vi.fn().mockResolvedValue(undefined);
+		create = mockGameDayJobCreate;
+		findByEventAndProblem = mockGameDayJobFindByEventAndProblem;
+		findById = mockGameDayJobFindById;
+		findActive = mockGameDayJobFindActive;
+		updateStatus = mockGameDayJobUpdateStatus;
 	},
 }));
 
 vi.mock("../problems/gameday-deployer", () => ({
-	deployProblemToTeams: vi.fn().mockResolvedValue([]),
-	retryJob: vi.fn().mockResolvedValue(null),
-	subscribeToJob: vi.fn().mockReturnValue(() => {}),
+	deployProblemToTeams: mockDeployProblemToTeams,
+	getGameDayDeploymentValidationError: vi.fn(
+		(problem: {
+			type: string;
+			deployment?: {
+				providers?: string[];
+				templates?: { aws?: unknown };
+			};
+		}) => {
+			if (problem.type !== "gameday") {
+				return "Team deployment is only supported for GameDay problems";
+			}
+			if (!problem.deployment?.providers?.includes("aws")) {
+				return "Team deployment requires AWS deployment support";
+			}
+			if (!problem.deployment?.templates?.aws) {
+				return "Team deployment requires an AWS deployment template";
+			}
+			return null;
+		},
+	),
+	retryJob: mockRetryJob,
+	subscribeToJob: mockSubscribeToJob,
 	reconcile: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -245,6 +295,7 @@ import {
 	removeChallengeFromContest,
 	registerTeamToContest,
 } from "../jam/contest";
+import { deployProblemToTeams } from "../problems/gameday-deployer";
 
 // テスト用の管理者ユーザー
 const mockAdminUser = {
@@ -315,6 +366,122 @@ describe("Admin Routes", () => {
 			const body = await res.json();
 			expect(body).toHaveProperty("events");
 			expect(body).toHaveProperty("total");
+		});
+	});
+
+	describe("POST /events/:eventId/problems/:problemId/deploy", () => {
+		beforeEach(() => {
+			setupAdminAuth();
+		});
+
+		it("GameDay 問題のチームデプロイを開始できるべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {
+						aws: { type: "cloudformation", path: "s3://template.yaml" },
+					},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+			mockCompetitorAccountFindByEventId.mockResolvedValueOnce([
+				{ id: "account-1", name: "team01" },
+			]);
+			mockDeployProblemToTeams.mockResolvedValueOnce([
+				{ id: "job-1", status: "pending" },
+			]);
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(202);
+			expect(deployProblemToTeams).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "problem-1" }),
+				"event-1",
+			);
+		});
+
+		it("GameDay 以外のイベントは拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "jam",
+			});
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "Team deployment is only supported for GameDay events",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
+		});
+
+		it("AWS テンプレートがない問題は拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "Team deployment requires an AWS deployment template",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
+		});
+
+		it("競技アカウントがない場合は拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {
+						aws: { type: "cloudformation", path: "s3://template.yaml" },
+					},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+			mockCompetitorAccountFindByEventId.mockResolvedValueOnce([]);
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "No competitor accounts configured for this event",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
+++ b/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
@@ -59,6 +59,24 @@ export function subscribeToJob(
 const jobRepo = new GameDayDeploymentJobRepository();
 const accountRepo = new CompetitorAccountRepository();
 
+export function getGameDayDeploymentValidationError(
+	problem: Pick<Problem, "type" | "deployment">,
+): string | null {
+	if (problem.type !== "gameday") {
+		return "Team deployment is only supported for GameDay problems";
+	}
+
+	if (!problem.deployment.providers.includes("aws")) {
+		return "Team deployment requires AWS deployment support";
+	}
+
+	if (!problem.deployment.templates.aws) {
+		return "Team deployment requires an AWS deployment template";
+	}
+
+	return null;
+}
+
 /**
  * 1 問題 × 全チームへのデプロイを開始する
  *
@@ -69,6 +87,11 @@ export async function deployProblemToTeams(
 	eventId: string,
 	concurrency = 10,
 ): Promise<DeploymentJob[]> {
+	const validationError = getGameDayDeploymentValidationError(problem);
+	if (validationError) {
+		throw new Error(validationError);
+	}
+
 	const accounts = await accountRepo.findByEventId(eventId);
 	if (accounts.length === 0) {
 		return [];

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -74,6 +74,7 @@ import {
 } from "../repositories/gameday-deployment-job-repository";
 import {
 	deployProblemToTeams,
+	getGameDayDeploymentValidationError,
 	retryJob,
 	subscribeToJob,
 } from "../problems/gameday-deployer";
@@ -3088,9 +3089,33 @@ adminRouter.post(
 		const eventId = c.req.param("eventId");
 		const problemId = c.req.param("problemId");
 
+		const event = await eventRepository.findById(eventId);
+		if (!event) {
+			return c.json({ error: "Event not found" }, 404);
+		}
+		if (event.type !== "gameday") {
+			return c.json(
+				{ error: "Team deployment is only supported for GameDay events" },
+				400,
+			);
+		}
+
 		const problem = await problemRepository.findById(problemId);
 		if (!problem) {
 			return c.json({ error: "Problem not found" }, 404);
+		}
+
+		const validationError = getGameDayDeploymentValidationError(problem);
+		if (validationError) {
+			return c.json({ error: validationError }, 400);
+		}
+
+		const accounts = await competitorAccountRepo.findByEventId(eventId);
+		if (accounts.length === 0) {
+			return c.json(
+				{ error: "No competitor accounts configured for this event" },
+				400,
+			);
 		}
 
 		try {


### PR DESCRIPTION
## What changed
- added shared GameDay team-deployment validation for admin UI and problem-service
- blocked team deployment unless the target is a GameDay problem with AWS provider support and an AWS template
- added backend route checks for event type and competitor-account presence before starting deployment jobs
- updated the admin event problems screen and team deployment screen to show why deployment is unavailable instead of allowing a broken action
- added frontend and backend regression tests for the new validation paths

## Why
GameDay team deployment existed as a route and screen, but unsupported problems could still expose the action. That let users click into flows that would only fail later, or return ambiguous empty results when the event was not actually deployable to teams.

## Impact
- admins now see clear preconditions for team deployment
- unsupported GameDay deployment attempts fail fast with explicit 400 responses
- supported GameDay problems keep the existing deployment flow

## Root cause
The GameDay deployment path assumed AWS-backed GameDay problems and configured competitor accounts, but those assumptions were not enforced consistently in either the UI or the backend route.

## Validation
- `make before-commit`
- targeted Vitest runs for the new GameDay deployment helpers and route coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented validation for GameDay team deployments: problems now require proper AWS configuration and registered competitor accounts. Users see helpful warnings and disabled deployment buttons when conditions aren't met.

* **Tests**
  * Added comprehensive test coverage for deployment validation logic across frontend and backend systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->