### PR TITLE
[codex] show local dev events on participant routes

### DIFF
--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -23,6 +23,9 @@ import Table from '@cloudscape-design/components/table';
 import '@cloudscape-design/global-styles/index.css';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AdminProblem } from '@/lib/api/admin-types';
+import { getProblem } from '@/lib/api/admin-problems';
+import { getGameDayTeamDeploymentIssue } from '../../../../../../../../lib/api/gameday-team-deploy';
 
 // ============================================================
 // Types
@@ -206,6 +209,8 @@ export default function GameDayDeploymentsPage() {
   const eventId = params.eventId as string;
   const problemId = params.problemId as string;
 
+  const [problem, setProblem] = useState<AdminProblem | null>(null);
+  const [problemLoading, setProblemLoading] = useState(true);
   const [accounts, setAccounts] = useState<CompetitorAccount[]>([]);
   const [jobs, setJobs] = useState<DeploymentJob[]>([]);
   const [accountsLoading, setAccountsLoading] = useState(true);
@@ -228,6 +233,14 @@ export default function GameDayDeploymentsPage() {
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const sseRef = useRef<EventSource | null>(null);
+  const teamDeployIssue = problem
+    ? getGameDayTeamDeploymentIssue(problem)
+    : null;
+  const deployDisabled =
+    deployLoading ||
+    problemLoading ||
+    teamDeployIssue !== null ||
+    accounts.length === 0;
 
   // ---- Data fetching ----
 
@@ -239,6 +252,18 @@ export default function GameDayDeploymentsPage() {
       console.error('Failed to refresh jobs', e);
     }
   }, [eventId, problemId]);
+
+  const refreshProblem = useCallback(async () => {
+    try {
+      setProblemLoading(true);
+      const data = await getProblem(problemId);
+      setProblem(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '問題取得失敗');
+    } finally {
+      setProblemLoading(false);
+    }
+  }, [problemId]);
 
   const refreshAccounts = useCallback(async () => {
     try {
@@ -305,6 +330,7 @@ export default function GameDayDeploymentsPage() {
   // ---- Initial load ----
 
   useEffect(() => {
+    refreshProblem();
     refreshAccounts();
     // SSE が失敗する前の初期データ取得
     fetchJobs(eventId, problemId)
@@ -313,7 +339,7 @@ export default function GameDayDeploymentsPage() {
         setJobsLoading(false);
       })
       .catch(() => setJobsLoading(false));
-  }, [eventId, problemId, refreshAccounts]);
+  }, [eventId, problemId, refreshAccounts, refreshProblem]);
 
   // アクティブジョブがなければポーリングを止める
   useEffect(() => {
@@ -324,6 +350,10 @@ export default function GameDayDeploymentsPage() {
   // ---- Actions ----
 
   const handleDeploy = async () => {
+    if (problemLoading || teamDeployIssue || accounts.length === 0) {
+      return;
+    }
+
     setDeployLoading(true);
     setError(null);
     try {
@@ -406,13 +436,18 @@ export default function GameDayDeploymentsPage() {
     <SpaceBetween size="l">
       <Header
         variant="h1"
+        description={
+          problem?.title
+            ? `${problem.title} をイベント参加チームの AWS アカウントへ配布します。`
+            : undefined
+        }
         actions={
           <SpaceBetween direction="horizontal" size="xs">
             <Button
               variant="primary"
               onClick={handleDeploy}
               loading={deployLoading}
-              disabled={accounts.length === 0}
+              disabled={deployDisabled}
             >
               全チームへデプロイ
             </Button>
@@ -430,6 +465,15 @@ export default function GameDayDeploymentsPage() {
       {error && (
         <Alert type="error" dismissible onDismiss={() => setError(null)}>
           {error}
+        </Alert>
+      )}
+
+      {teamDeployIssue && <Alert type="warning">{teamDeployIssue}</Alert>}
+
+      {!teamDeployIssue && !problemLoading && accounts.length === 0 && (
+        <Alert type="info">
+          先に競技アカウントを追加してください。アカウントが 1 件もない場合は
+          チーム配布を開始できません。
         </Alert>
       )}
 

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/__tests__/page.test.tsx
@@ -52,7 +52,12 @@ const baseProblem = {
   metadata: { author: 'admin', version: '1.0', tags: [] },
   deployment: {
     providers: ['aws' as const],
-    templates: {},
+    templates: {
+      aws: {
+        type: 'cloudformation' as const,
+        path: 's3://templates/problem.yaml',
+      },
+    },
     regions: { aws: ['ap-northeast-1'] },
   },
   scoring: {
@@ -61,6 +66,13 @@ const baseProblem = {
     timeoutMinutes: 5,
     criteria: [{ name: '正解', weight: 1, maxPoints: 100 }],
   },
+};
+
+const unsupportedTeamDeployProblem = {
+  ...baseProblem,
+  id: 'prob-unsupported',
+  title: 'JAM 問題',
+  type: 'jam' as const,
 };
 
 describe('AdminEventProblemsPage', () => {
@@ -215,5 +227,41 @@ describe('AdminEventProblemsPage', () => {
     await waitFor(() => {
       expect(screen.getAllByText('デプロイ').length).toBeGreaterThanOrEqual(1);
     });
+  });
+
+  it('対応している問題ではチームデプロイ画面へ遷移できるべき', async () => {
+    mockGetEventProblems.mockResolvedValue({ problems: [baseProblem] });
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'チームへデプロイ' }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'チームへデプロイ' }),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/events/ev-1/problems/prob-1/deployments',
+    );
+  });
+
+  it('未対応の問題ではチームデプロイ理由を表示すべき', async () => {
+    mockGetEventProblems.mockResolvedValue({
+      problems: [unsupportedTeamDeployProblem],
+    });
+    render(<AdminEventProblemsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('GameDay 問題のみチーム配布に対応しています。'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'チームへデプロイ' }),
+    ).toBeDisabled();
   });
 });

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/page.tsx
@@ -34,6 +34,7 @@ import {
   getProblems,
   removeProblemFromEvent,
 } from '@/lib/api/admin-problems';
+import { getGameDayTeamDeploymentIssue } from '../../../../../../lib/api/gameday-team-deploy';
 
 // =============================================================================
 // Types
@@ -418,35 +419,47 @@ export default function AdminEventProblemsPage() {
             {
               id: 'actions',
               header: 'アクション',
-              cell: (item) => (
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() =>
-                      router.push(`/admin/problems/${item.id}/edit`)
-                    }
-                  >
-                    編集
-                  </Button>
-                  <Button
-                    variant="link"
-                    onClick={() =>
-                      router.push(
-                        `/admin/events/${eventId}/problems/${item.id}/deployments`,
-                      )
-                    }
-                  >
-                    チームへデプロイ
-                  </Button>
-                  <Button
-                    variant="link"
-                    loading={removingIds.has(item.id)}
-                    onClick={() => handleRemove(item.id)}
-                  >
-                    削除
-                  </Button>
-                </SpaceBetween>
-              ),
+              cell: (item) => {
+                const teamDeployIssue = getGameDayTeamDeploymentIssue(item);
+
+                return (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button
+                      variant="link"
+                      onClick={() =>
+                        router.push(`/admin/problems/${item.id}/edit`)
+                      }
+                    >
+                      編集
+                    </Button>
+                    <SpaceBetween size="xxs">
+                      <Button
+                        variant="link"
+                        disabled={teamDeployIssue !== null}
+                        onClick={() =>
+                          router.push(
+                            `/admin/events/${eventId}/problems/${item.id}/deployments`,
+                          )
+                        }
+                      >
+                        チームへデプロイ
+                      </Button>
+                      {teamDeployIssue && (
+                        <Box color="text-body-secondary" fontSize="body-s">
+                          {teamDeployIssue}
+                        </Box>
+                      )}
+                    </SpaceBetween>
+                    <Button
+                      variant="link"
+                      loading={removingIds.has(item.id)}
+                      onClick={() => handleRemove(item.id)}
+                    >
+                      削除
+                    </Button>
+                  </SpaceBetween>
+                );
+              },
             },
           ]}
         />

--- a/apps/application-plane/app/api/admin/events/dev-store.ts
+++ b/apps/application-plane/app/api/admin/events/dev-store.ts
@@ -1,4 +1,9 @@
-import type { ParticipantEvent, EventStatus } from '@/lib/api/types';
+import type {
+  EventDetails,
+  ParticipantEvent,
+  EventStatus,
+  ProblemType,
+} from '@/lib/api/types';
 
 export interface DevEventRecord extends ParticipantEvent {
   slug: string;
@@ -53,12 +58,24 @@ export function getDevEventStore(): DevEventRecord[] {
 export function listDevEvents(
   page: number,
   pageSize: number,
-  status?: EventStatus | null,
+  status?: EventStatus | EventStatus[] | null,
+  type?: ProblemType | null,
 ): { events: DevEventRecord[]; total: number; page: number; pageSize: number } {
   const store = getDevEventStore();
-  const filtered = status
-    ? store.filter((event) => event.status === status)
-    : store;
+  const statuses = Array.isArray(status)
+    ? status.filter(Boolean)
+    : status
+      ? [status]
+      : [];
+  const filtered = store.filter((event) => {
+    if (statuses.length > 0 && !statuses.includes(event.status)) {
+      return false;
+    }
+    if (type && event.type !== type) {
+      return false;
+    }
+    return true;
+  });
   const offset = Math.max(page - 1, 0) * pageSize;
   return {
     events: filtered.slice(offset, offset + pageSize),
@@ -104,6 +121,18 @@ export function createDevEvent(body: DevEventPayload): DevEventRecord {
 
 export function findDevEvent(eventId: string): DevEventRecord | undefined {
   return getDevEventStore().find((event) => event.id === eventId);
+}
+
+export function getDevEventDetails(eventId: string): EventDetails | null {
+  const event = findDevEvent(eventId);
+  if (!event) {
+    return null;
+  }
+
+  return {
+    ...event,
+    problems: [],
+  };
 }
 
 export function updateDevEvent(

--- a/apps/application-plane/app/api/participant/events/[eventId]/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/participant/events/[eventId]/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearDevEvents,
+  createDevEvent,
+} from '@/app/api/admin/events/dev-store';
+
+const mockServerApiRequest = vi.fn();
+let mockAuthSkipEnabled = false;
+
+vi.mock('@/auth', () => ({
+  get authSkipEnabled() {
+    return mockAuthSkipEnabled;
+  },
+}));
+
+vi.mock('@/lib/api/server', () => ({
+  serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
+}));
+
+describe('Participant Event Detail API Proxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSkipEnabled = false;
+    clearDevEvents();
+  });
+
+  it('イベント詳細を取得できるべき', async () => {
+    mockServerApiRequest.mockResolvedValue({ id: 'event-1', name: 'Event 1' });
+
+    const { GET } = await import('../route');
+    const response = await GET(new Request('http://localhost'), {
+      params: Promise.resolve({ eventId: 'event-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockServerApiRequest).toHaveBeenCalledWith(
+      '/participant/events/event-1',
+    );
+    await expect(response.json()).resolves.toEqual({
+      id: 'event-1',
+      name: 'Event 1',
+    });
+  });
+
+  it('AUTH_SKIP 中の Unauthorized は local dev store を返すべき', async () => {
+    mockAuthSkipEnabled = true;
+    const event = createDevEvent({
+      name: 'Local Event',
+      status: 'draft',
+      type: 'gameday',
+    });
+    mockServerApiRequest.mockRejectedValue(new Error('Unauthorized'));
+
+    const { GET } = await import('../route');
+    const response = await GET(new Request('http://localhost'), {
+      params: Promise.resolve({ eventId: event.id }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        id: event.id,
+        name: 'Local Event',
+        problems: [],
+      }),
+    );
+  });
+
+  it('network error 時も local dev store を返すべき', async () => {
+    const event = createDevEvent({
+      name: 'Offline Event',
+      status: 'draft',
+      type: 'jam',
+    });
+    mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+    const { GET } = await import('../route');
+    const response = await GET(new Request('http://localhost'), {
+      params: Promise.resolve({ eventId: event.id }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        id: event.id,
+        name: 'Offline Event',
+        problems: [],
+      }),
+    );
+  });
+});

--- a/apps/application-plane/app/api/participant/events/[eventId]/route.ts
+++ b/apps/application-plane/app/api/participant/events/[eventId]/route.ts
@@ -4,6 +4,8 @@
  * 参加者向けイベント詳細エンドポイント
  */
 
+import { authSkipEnabled } from '@/auth';
+import { getDevEventDetails } from '@/app/api/admin/events/dev-store';
 import { serverApiRequest } from '@/lib/api/server';
 import type { EventDetails } from '@/lib/api/types';
 
@@ -19,6 +21,20 @@ export async function GET(
     );
     return Response.json(data);
   } catch (error) {
+    const isAuthSkipUnauthorized =
+      authSkipEnabled &&
+      error instanceof Error &&
+      /^Unauthorized$/i.test(error.message);
+    const isNetworkError =
+      error instanceof TypeError && /fetch failed/i.test(String(error));
+
+    if (isAuthSkipUnauthorized || isNetworkError) {
+      const data = getDevEventDetails(eventId);
+      if (data) {
+        return Response.json(data);
+      }
+    }
+
     const status =
       error instanceof Error && error.message.includes('404') ? 404 : 500;
     return Response.json(

--- a/apps/application-plane/app/api/participant/events/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/participant/events/__tests__/route.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import {
+  clearDevEvents,
+  createDevEvent,
+} from '@/app/api/admin/events/dev-store';
 
 const mockServerApiRequest = vi.fn();
 let mockAuthSkipEnabled = false;
@@ -22,6 +26,7 @@ describe('Participant Events API Proxy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuthSkipEnabled = false;
+    clearDevEvents();
   });
 
   it('イベント一覧を取得できるべき', async () => {
@@ -46,7 +51,12 @@ describe('Participant Events API Proxy', () => {
     });
   });
 
-  it('network fetch failure の場合は空一覧を返すべき', async () => {
+  it('network fetch failure の場合は local dev events を返すべき', async () => {
+    createDevEvent({
+      name: 'Local Draft Event',
+      status: 'draft',
+      type: 'gameday',
+    });
     mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
 
     const { GET } = await import('../route');
@@ -54,11 +64,24 @@ describe('Participant Events API Proxy', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ events: [], total: 0 });
+    await expect(response.json()).resolves.toEqual({
+      events: [
+        expect.objectContaining({
+          name: 'Local Draft Event',
+          status: 'draft',
+        }),
+      ],
+      total: 1,
+    });
   });
 
-  it('AUTH_SKIP 中に Unauthorized の場合は空一覧を返すべき', async () => {
+  it('AUTH_SKIP 中に Unauthorized の場合は local dev events を返すべき', async () => {
     mockAuthSkipEnabled = true;
+    createDevEvent({
+      name: 'Unauthorized Fallback Event',
+      status: 'draft',
+      type: 'jam',
+    });
     mockServerApiRequest.mockRejectedValue(new Error('Unauthorized'));
 
     const { GET } = await import('../route');
@@ -66,7 +89,46 @@ describe('Participant Events API Proxy', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ events: [], total: 0 });
+    await expect(response.json()).resolves.toEqual({
+      events: [
+        expect.objectContaining({
+          name: 'Unauthorized Fallback Event',
+          status: 'draft',
+        }),
+      ],
+      total: 1,
+    });
+  });
+
+  it('fallback 時も type フィルタを適用すべき', async () => {
+    createDevEvent({
+      name: 'GameDay Event',
+      type: 'gameday',
+      status: 'draft',
+    });
+    createDevEvent({
+      name: 'Jam Event',
+      type: 'jam',
+      status: 'draft',
+    });
+    mockServerApiRequest.mockRejectedValue(new TypeError('fetch failed'));
+
+    const { GET } = await import('../route');
+    const request = new NextRequest(
+      'http://localhost/api/participant/events?type=gameday&limit=10',
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      events: [
+        expect.objectContaining({
+          name: 'GameDay Event',
+          type: 'gameday',
+        }),
+      ],
+      total: 1,
+    });
   });
 
   it('通常の API エラーは 400 を返すべき', async () => {

--- a/apps/application-plane/app/api/participant/events/route.ts
+++ b/apps/application-plane/app/api/participant/events/route.ts
@@ -13,7 +13,8 @@ import {
   badRequestResponse,
   serverApiRequest,
 } from '@/lib/api/server';
-import type { ParticipantEvent } from '@/lib/api/types';
+import type { ParticipantEvent, ProblemType } from '@/lib/api/types';
+import { listDevEvents } from '@/app/api/admin/events/dev-store';
 
 interface ParticipantEventListResponse {
   events: ParticipantEvent[];
@@ -41,6 +42,8 @@ export async function GET(request: NextRequest) {
 
   const queryString = queryParams.toString();
   const endpoint = `/participant/events${queryString ? `?${queryString}` : ''}`;
+  const pageSize = limit ? Number.parseInt(limit, 10) || 50 : 50;
+  const requestedType = (type as ProblemType | null) ?? null;
 
   try {
     const data = await serverApiRequest<ParticipantEventListResponse>(endpoint);
@@ -55,15 +58,20 @@ export async function GET(request: NextRequest) {
 
     if (isAuthSkipUnauthorized) {
       console.warn(
-        'Participant events backend rejected AUTH_SKIP token. Returning empty list.',
+        'Participant events backend rejected AUTH_SKIP token. Returning local dev events.',
         error,
       );
-      return successResponse({ events: [], total: 0 });
+      const data = listDevEvents(1, pageSize, null, requestedType);
+      return successResponse({ events: data.events, total: data.total });
     }
 
     if (isNetworkError) {
-      console.warn('Participant events backend unreachable:', error);
-      return successResponse({ events: [], total: 0 });
+      console.warn(
+        'Participant events backend unreachable. Returning local dev events.',
+        error,
+      );
+      const data = listDevEvents(1, pageSize, null, requestedType);
+      return successResponse({ events: data.events, total: data.total });
     }
 
     console.error('Failed to fetch participant events:', error);

--- a/apps/application-plane/lib/__tests__/gameday-team-deploy.test.ts
+++ b/apps/application-plane/lib/__tests__/gameday-team-deploy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGameDayTeamDeploymentIssue } from '../api/gameday-team-deploy';
+
+const baseProblem = {
+  type: 'gameday' as const,
+  deployment: {
+    providers: ['aws' as const],
+    timeout: 60,
+    templates: {
+      aws: {
+        type: 'cloudformation' as const,
+        path: 's3://templates/problem.yaml',
+      },
+    },
+    regions: {
+      aws: ['ap-northeast-1'],
+    },
+  },
+};
+
+describe('getGameDayTeamDeploymentIssue', () => {
+  it('GameDay の AWS 問題はチーム配布可能と判定すべき', () => {
+    expect(getGameDayTeamDeploymentIssue(baseProblem)).toBeNull();
+  });
+
+  it('GameDay 以外の問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        type: 'jam',
+      }),
+    ).toBe('GameDay 問題のみチーム配布に対応しています。');
+  });
+
+  it('AWS provider がない問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        deployment: {
+          ...baseProblem.deployment,
+          providers: ['local'],
+          templates: {},
+        },
+      }),
+    ).toBe('チーム配布には AWS デプロイ設定が必要です。');
+  });
+
+  it('AWS テンプレートがない問題は未対応と判定すべき', () => {
+    expect(
+      getGameDayTeamDeploymentIssue({
+        ...baseProblem,
+        deployment: {
+          ...baseProblem.deployment,
+          templates: {},
+        },
+      }),
+    ).toBe('チーム配布には AWS テンプレートの設定が必要です。');
+  });
+});

--- a/apps/application-plane/lib/api/gameday-team-deploy.ts
+++ b/apps/application-plane/lib/api/gameday-team-deploy.ts
@@ -1,0 +1,27 @@
+import type { AdminProblem } from '@/lib/api/admin-types';
+
+type TeamDeployableProblem = Pick<AdminProblem, 'type' | 'deployment'>;
+
+export function getGameDayTeamDeploymentIssue(
+  problem: TeamDeployableProblem,
+): string | null {
+  if (problem.type !== 'gameday') {
+    return 'GameDay 問題のみチーム配布に対応しています。';
+  }
+
+  if (!problem.deployment.providers.includes('aws')) {
+    return 'チーム配布には AWS デプロイ設定が必要です。';
+  }
+
+  if (!problem.deployment.templates.aws) {
+    return 'チーム配布には AWS テンプレートの設定が必要です。';
+  }
+
+  return null;
+}
+
+export function canDeployGameDayProblemToTeams(
+  problem: TeamDeployableProblem,
+): boolean {
+  return getGameDayTeamDeploymentIssue(problem) === null;
+}

--- a/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
@@ -134,6 +134,45 @@ describe("gameday-deployer", () => {
 		vi.clearAllMocks();
 	});
 
+	describe("getGameDayDeploymentValidationError", () => {
+		it("GameDay の AWS 問題はデプロイ可能と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(getGameDayDeploymentValidationError(makeProblem())).toBeNull();
+		});
+
+		it("GameDay 以外の問題は未対応と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(
+				getGameDayDeploymentValidationError({
+					...makeProblem(),
+					type: "jam",
+				}),
+			).toBe("Team deployment is only supported for GameDay problems");
+		});
+
+		it("AWS テンプレートがない問題は未対応と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(
+				getGameDayDeploymentValidationError({
+					...makeProblem(),
+					deployment: {
+						...makeProblem().deployment,
+						templates: {},
+					},
+				}),
+			).toBe("Team deployment requires an AWS deployment template");
+		});
+	});
+
 	describe("reconcile", () => {
 		it("アクティブジョブがない場合は何もしないべき", async () => {
 			mockFindActive.mockResolvedValueOnce([]);

--- a/backend/services/application-plane/problem-service/src/__tests__/routes-admin.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/routes-admin.test.ts
@@ -15,6 +15,19 @@ const {
 	mockTemplateRepository,
 	mockAWSProvider,
 	mockLocalProvider,
+	mockCompetitorAccountCreate,
+	mockCompetitorAccountFindByEventId,
+	mockCompetitorAccountFindById,
+	mockCompetitorAccountUpdateStatus,
+	mockCompetitorAccountDelete,
+	mockGameDayJobCreate,
+	mockGameDayJobFindByEventAndProblem,
+	mockGameDayJobFindById,
+	mockGameDayJobFindActive,
+	mockGameDayJobUpdateStatus,
+	mockDeployProblemToTeams,
+	mockRetryJob,
+	mockSubscribeToJob,
 } = vi.hoisted(() => ({
 	mockEventRepository: {
 		findByTenant: vi.fn().mockResolvedValue([]),
@@ -117,6 +130,23 @@ const {
 			completedAt: new Date(),
 		}),
 	},
+	mockCompetitorAccountCreate: vi
+		.fn()
+		.mockResolvedValue({ id: "account-1", name: "team01" }),
+	mockCompetitorAccountFindByEventId: vi.fn().mockResolvedValue([]),
+	mockCompetitorAccountFindById: vi.fn().mockResolvedValue(null),
+	mockCompetitorAccountUpdateStatus: vi.fn().mockResolvedValue(undefined),
+	mockCompetitorAccountDelete: vi.fn().mockResolvedValue(undefined),
+	mockGameDayJobCreate: vi
+		.fn()
+		.mockResolvedValue({ id: "job-1", status: "pending" }),
+	mockGameDayJobFindByEventAndProblem: vi.fn().mockResolvedValue([]),
+	mockGameDayJobFindById: vi.fn().mockResolvedValue(null),
+	mockGameDayJobFindActive: vi.fn().mockResolvedValue([]),
+	mockGameDayJobUpdateStatus: vi.fn().mockResolvedValue(undefined),
+	mockDeployProblemToTeams: vi.fn().mockResolvedValue([]),
+	mockRetryJob: vi.fn().mockResolvedValue(null),
+	mockSubscribeToJob: vi.fn().mockReturnValue(() => {}),
 }));
 
 // 依存関係をモック
@@ -208,28 +238,48 @@ vi.mock("../providers/local", () => ({
 
 vi.mock("../repositories/competitor-account-repository", () => ({
 	CompetitorAccountRepository: class {
-		create = vi.fn().mockResolvedValue({ id: "account-1", name: "team01" });
-		findByEventId = vi.fn().mockResolvedValue([]);
-		findById = vi.fn().mockResolvedValue(null);
-		updateStatus = vi.fn().mockResolvedValue(undefined);
-		delete = vi.fn().mockResolvedValue(undefined);
+		create = mockCompetitorAccountCreate;
+		findByEventId = mockCompetitorAccountFindByEventId;
+		findById = mockCompetitorAccountFindById;
+		updateStatus = mockCompetitorAccountUpdateStatus;
+		delete = mockCompetitorAccountDelete;
 	},
 }));
 
 vi.mock("../repositories/gameday-deployment-job-repository", () => ({
 	GameDayDeploymentJobRepository: class {
-		create = vi.fn().mockResolvedValue({ id: "job-1", status: "pending" });
-		findByEventAndProblem = vi.fn().mockResolvedValue([]);
-		findById = vi.fn().mockResolvedValue(null);
-		findActive = vi.fn().mockResolvedValue([]);
-		updateStatus = vi.fn().mockResolvedValue(undefined);
+		create = mockGameDayJobCreate;
+		findByEventAndProblem = mockGameDayJobFindByEventAndProblem;
+		findById = mockGameDayJobFindById;
+		findActive = mockGameDayJobFindActive;
+		updateStatus = mockGameDayJobUpdateStatus;
 	},
 }));
 
 vi.mock("../problems/gameday-deployer", () => ({
-	deployProblemToTeams: vi.fn().mockResolvedValue([]),
-	retryJob: vi.fn().mockResolvedValue(null),
-	subscribeToJob: vi.fn().mockReturnValue(() => {}),
+	deployProblemToTeams: mockDeployProblemToTeams,
+	getGameDayDeploymentValidationError: vi.fn(
+		(problem: {
+			type: string;
+			deployment?: {
+				providers?: string[];
+				templates?: { aws?: unknown };
+			};
+		}) => {
+			if (problem.type !== "gameday") {
+				return "Team deployment is only supported for GameDay problems";
+			}
+			if (!problem.deployment?.providers?.includes("aws")) {
+				return "Team deployment requires AWS deployment support";
+			}
+			if (!problem.deployment?.templates?.aws) {
+				return "Team deployment requires an AWS deployment template";
+			}
+			return null;
+		},
+	),
+	retryJob: mockRetryJob,
+	subscribeToJob: mockSubscribeToJob,
 	reconcile: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -245,6 +295,7 @@ import {
 	removeChallengeFromContest,
 	registerTeamToContest,
 } from "../jam/contest";
+import { deployProblemToTeams } from "../problems/gameday-deployer";
 
 // テスト用の管理者ユーザー
 const mockAdminUser = {
@@ -315,6 +366,122 @@ describe("Admin Routes", () => {
 			const body = await res.json();
 			expect(body).toHaveProperty("events");
 			expect(body).toHaveProperty("total");
+		});
+	});
+
+	describe("POST /events/:eventId/problems/:problemId/deploy", () => {
+		beforeEach(() => {
+			setupAdminAuth();
+		});
+
+		it("GameDay 問題のチームデプロイを開始できるべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {
+						aws: { type: "cloudformation", path: "s3://template.yaml" },
+					},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+			mockCompetitorAccountFindByEventId.mockResolvedValueOnce([
+				{ id: "account-1", name: "team01" },
+			]);
+			mockDeployProblemToTeams.mockResolvedValueOnce([
+				{ id: "job-1", status: "pending" },
+			]);
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(202);
+			expect(deployProblemToTeams).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "problem-1" }),
+				"event-1",
+			);
+		});
+
+		it("GameDay 以外のイベントは拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "jam",
+			});
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "Team deployment is only supported for GameDay events",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
+		});
+
+		it("AWS テンプレートがない問題は拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "Team deployment requires an AWS deployment template",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
+		});
+
+		it("競技アカウントがない場合は拒否すべき", async () => {
+			mockEventRepository.findById.mockResolvedValueOnce({
+				id: "event-1",
+				type: "gameday",
+			});
+			mockProblemRepository.findById.mockResolvedValueOnce({
+				id: "problem-1",
+				type: "gameday",
+				deployment: {
+					providers: ["aws"],
+					templates: {
+						aws: { type: "cloudformation", path: "s3://template.yaml" },
+					},
+					regions: { aws: ["ap-northeast-1"] },
+				},
+			});
+			mockCompetitorAccountFindByEventId.mockResolvedValueOnce([]);
+
+			const res = await app.request(
+				"/api/admin/events/event-1/problems/problem-1/deploy",
+				{ method: "POST" },
+			);
+
+			expect(res.status).toBe(400);
+			await expect(res.json()).resolves.toEqual({
+				error: "No competitor accounts configured for this event",
+			});
+			expect(deployProblemToTeams).not.toHaveBeenCalled();
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
+++ b/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
@@ -59,6 +59,24 @@ export function subscribeToJob(
 const jobRepo = new GameDayDeploymentJobRepository();
 const accountRepo = new CompetitorAccountRepository();
 
+export function getGameDayDeploymentValidationError(
+	problem: Pick<Problem, "type" | "deployment">,
+): string | null {
+	if (problem.type !== "gameday") {
+		return "Team deployment is only supported for GameDay problems";
+	}
+
+	if (!problem.deployment.providers.includes("aws")) {
+		return "Team deployment requires AWS deployment support";
+	}
+
+	if (!problem.deployment.templates.aws) {
+		return "Team deployment requires an AWS deployment template";
+	}
+
+	return null;
+}
+
 /**
  * 1 問題 × 全チームへのデプロイを開始する
  *
@@ -69,6 +87,11 @@ export async function deployProblemToTeams(
 	eventId: string,
 	concurrency = 10,
 ): Promise<DeploymentJob[]> {
+	const validationError = getGameDayDeploymentValidationError(problem);
+	if (validationError) {
+		throw new Error(validationError);
+	}
+
 	const accounts = await accountRepo.findByEventId(eventId);
 	if (accounts.length === 0) {
 		return [];

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -74,6 +74,7 @@ import {
 } from "../repositories/gameday-deployment-job-repository";
 import {
 	deployProblemToTeams,
+	getGameDayDeploymentValidationError,
 	retryJob,
 	subscribeToJob,
 } from "../problems/gameday-deployer";
@@ -3088,9 +3089,33 @@ adminRouter.post(
 		const eventId = c.req.param("eventId");
 		const problemId = c.req.param("problemId");
 
+		const event = await eventRepository.findById(eventId);
+		if (!event) {
+			return c.json({ error: "Event not found" }, 404);
+		}
+		if (event.type !== "gameday") {
+			return c.json(
+				{ error: "Team deployment is only supported for GameDay events" },
+				400,
+			);
+		}
+
 		const problem = await problemRepository.findById(problemId);
 		if (!problem) {
 			return c.json({ error: "Problem not found" }, 404);
+		}
+
+		const validationError = getGameDayDeploymentValidationError(problem);
+		if (validationError) {
+			return c.json({ error: validationError }, 400);
+		}
+
+		const accounts = await competitorAccountRepo.findByEventId(eventId);
+		if (accounts.length === 0) {
+			return c.json(
+				{ error: "No competitor accounts configured for this event" },
+				400,
+			);
 		}
 
 		try {


### PR DESCRIPTION
## What changed
- made the participant events list route fall back to the local admin dev event store during `AUTH_SKIP` unauthorized responses and backend network failures
- added participant event detail fallback so locally created events can also open their detail page
- expanded the shared dev event store helpers to support type filtering and event detail lookup
- added regression tests for participant list and detail fallback behavior

## Why
Locally created events were saved by the admin event route, but the participant event routes returned an empty dataset when the backend was unavailable in local development. That made newly created events disappear from `/events` even though they existed in the local dev store.

## Impact
- local event creation is now visible on `/events`
- clicking a locally created event can load its detail view without the backend
- fallback behavior still only applies to `AUTH_SKIP` unauthorized responses and backend network failures

## Validation
- `make before-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for team deployments with enhanced requirement checks.
  * Implemented offline fallback support for event details when API connectivity is unavailable.
  * Enhanced deployment UI with conditional alerts displaying configuration requirements.

* **Bug Fixes**
  * Improved error handling for deployment requests with insufficient account or configuration setup.

* **Tests**
  * Extended test coverage for team deployment validation and API fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->