### PR TITLE
Harden GameDay participant authorization

### DIFF
--- a/apps/application-plane/app/api/gameday/teams/__tests__/routes.test.ts
+++ b/apps/application-plane/app/api/gameday/teams/__tests__/routes.test.ts
@@ -226,4 +226,115 @@ describe('GameDay Team Route Fallbacks', () => {
       }),
     });
   });
+
+  it('create route は backend に userId を転送しないべき', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ teamId: 'TEAM001' }), { status: 201 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../create/route');
+    await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+          teamId: 'TEAM001',
+          teamName: 'Blue Team',
+        }),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://gameday.local/teams/create',
+      expect.objectContaining({
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+          teamId: 'TEAM001',
+          teamName: 'Blue Team',
+        }),
+      }),
+    );
+  });
+
+  it('join route は backend に userId を転送しないべき', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ teamId: 'TEAM001' }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../join/route');
+    await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+          inviteCode: 'ABC123',
+        }),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://gameday.local/teams/join',
+      expect.objectContaining({
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+          inviteCode: 'ABC123',
+        }),
+      }),
+    );
+  });
+
+  it('solo route は backend に userId を転送しないべき', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ mode: 'solo' }), { status: 201 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../solo/route');
+    await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+        }),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://gameday.local/teams/solo',
+      expect.objectContaining({
+        body: JSON.stringify({
+          eventId: 'dev-event-1',
+        }),
+      }),
+    );
+  });
+
+  it('my-membership route は backend query から userId を排除すべき', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ membership: null }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { GET } = await import('../my-membership/route');
+    await GET(
+      new Request(
+        'http://localhost/api/gameday/teams/my-membership?eventId=dev-event-2',
+      ) as never,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://gameday.local/teams/my-membership?eventId=dev-event-2',
+      expect.any(Object),
+    );
+  });
 });

--- a/apps/application-plane/app/api/gameday/teams/create/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/create/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: Request) {
     const response = await fetch(`${gamedayUrl}/teams/create`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, userId }),
+      body: JSON.stringify(body),
     });
     const data = await response.json();
     return Response.json(data, { status: response.status });

--- a/apps/application-plane/app/api/gameday/teams/join/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/join/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     const response = await fetch(`${gamedayUrl}/teams/join`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, userId }),
+      body: JSON.stringify(body),
     });
     const data = await response.json();
     return Response.json(data, { status: response.status });

--- a/apps/application-plane/app/api/gameday/teams/my-membership/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/my-membership/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
   try {
     const gamedayUrl = getGamedayApiUrl();
     const response = await fetch(
-      `${gamedayUrl}/teams/my-membership?eventId=${encodeURIComponent(eventId)}&userId=${encodeURIComponent(userId)}`,
+      `${gamedayUrl}/teams/my-membership?eventId=${encodeURIComponent(eventId)}`,
       { headers: { 'Content-Type': 'application/json' } },
     );
     const data = await response.json();

--- a/apps/application-plane/app/api/gameday/teams/solo/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/solo/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
     const response = await fetch(`${gamedayUrl}/teams/solo`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, userId }),
+      body: JSON.stringify(body),
     });
     const data = await response.json();
     return Response.json(data, { status: response.status });

--- a/backend/services/application-plane/gameday-service/src/api/participant.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.test.ts
@@ -2,6 +2,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import { Hono } from 'hono';
 
+function createMembership(
+  overrides: Partial<{
+    eventId: string;
+    userId: string;
+    teamId: string;
+    teamName: string;
+    mode: 'solo' | 'team';
+  }> = {},
+) {
+  return {
+    eventId: 'event-1',
+    userId: 'user-1',
+    teamId: 'team-1',
+    teamName: 'テストチーム',
+    mode: 'team' as const,
+    ...overrides,
+  };
+}
+
 const mockParticipantService = vi.hoisted(() => {
   class GameNotRunningError extends Error {
     constructor() {
@@ -186,7 +205,7 @@ describe('プレーヤー API', () => {
     // デフォルトの getAllAttackLogs は空配列を返す
     mockParticipantService.getAllAttackLogs.mockResolvedValue([]);
     mockGamedayRepository.addMember.mockResolvedValue(undefined);
-    mockGamedayRepository.getMembership.mockResolvedValue(null);
+    mockGamedayRepository.getMembership.mockResolvedValue(createMembership());
     app = new Hono();
     app.use('/*', async (c, next) => {
       c.set('auth' as never, {
@@ -386,6 +405,41 @@ describe('プレーヤー API', () => {
       });
       expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
     });
+
+    it('偽装した teamId では FORBIDDEN を返すべき', async () => {
+      const res = await app.request('/attacks/purchase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-999',
+          attackId: 'atk-1',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(mockParticipantService.purchaseAttack).not.toHaveBeenCalled();
+    });
+
+    it('teamId 省略時は認証済みメンバーシップの teamId を使うべき', async () => {
+      mockParticipantService.purchaseAttack.mockResolvedValue({
+        id: 'p-1',
+        attackId: 'atk-1',
+      });
+      const res = await app.request('/attacks/purchase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          attackId: 'atk-1',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.CREATED);
+      expect(mockParticipantService.purchaseAttack).toHaveBeenCalledWith(
+        'event-1',
+        'team-1',
+        'atk-1',
+      );
+    });
   });
 
   // === 攻撃実行 ===
@@ -565,6 +619,14 @@ describe('プレーヤー API', () => {
     it('パラメータ不足で BAD_REQUEST を返すべき', async () => {
       const res = await app.request('/attacks/history');
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('他チームの履歴を要求した場合 FORBIDDEN を返すべき', async () => {
+      const res = await app.request(
+        '/attacks/history?eventId=event-1&teamId=team-999'
+      );
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(mockParticipantService.getAttackHistory).not.toHaveBeenCalled();
     });
   });
 
@@ -830,7 +892,7 @@ describe('プレーヤー API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           eventId: 'event-1',
-          teamId: 'team-2',
+          teamId: 'team-1',
         }),
       });
       expect(res.status).toBe(StatusCodes.OK);
@@ -854,7 +916,7 @@ describe('プレーヤー API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           eventId: 'event-1',
-          teamId: 'team-2',
+          teamId: 'team-1',
         }),
       });
       expect(res.status).toBe(StatusCodes.NOT_FOUND);
@@ -869,7 +931,7 @@ describe('プレーヤー API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           eventId: 'event-1',
-          teamId: 'team-2',
+          teamId: 'team-1',
         }),
       });
       expect(res.status).toBe(StatusCodes.FORBIDDEN);
@@ -884,7 +946,7 @@ describe('プレーヤー API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           eventId: 'event-1',
-          teamId: 'team-2',
+          teamId: 'team-1',
         }),
       });
       expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
@@ -1169,9 +1231,7 @@ describe('プレーヤー API', () => {
         recentHealthChecks: [],
         attackHistory: [],
       });
-      const res = await app.request(
-        '/dashboard/team?eventId=event-1&teamId=team-1'
-      );
+      const res = await app.request('/dashboard/team?eventId=event-1&teamId=team-1');
       expect(res.status).toBe(StatusCodes.OK);
       const body = await res.json();
       expect(body.team.teamId).toBe('team-1');
@@ -1179,17 +1239,23 @@ describe('プレーヤー API', () => {
 
     it('チームが存在しない場合はデフォルト値で OK を返すべき', async () => {
       mockDashboardService.getTeamDashboard.mockResolvedValue(null);
-      const res = await app.request(
-        '/dashboard/team?eventId=event-1&teamId=nonexistent'
-      );
+      const res = await app.request('/dashboard/team?eventId=event-1');
       expect(res.status).toBe(StatusCodes.OK);
       const body = await res.json();
-      expect(body.team.teamId).toBe('nonexistent');
+      expect(body.team.teamId).toBe('team-1');
     });
 
     it('パラメータ不足で BAD_REQUEST を返すべき', async () => {
       const res = await app.request('/dashboard/team');
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('他チームのダッシュボードを要求した場合 FORBIDDEN を返すべき', async () => {
+      const res = await app.request(
+        '/dashboard/team?eventId=event-1&teamId=team-999'
+      );
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(mockDashboardService.getTeamDashboard).not.toHaveBeenCalled();
     });
   });
 
@@ -1258,6 +1324,20 @@ describe('プレーヤー API', () => {
         }),
       });
       expect(res.status).toBe(StatusCodes.NOT_FOUND);
+    });
+
+    it('他チームの URL 更新を拒否すべき', async () => {
+      const res = await app.request('/teams/update-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId: 'event-1',
+          teamId: 'team-999',
+          websiteUrl: 'https://example.com',
+        }),
+      });
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(mockDashboardService.updateTeamUrl).not.toHaveBeenCalled();
     });
   });
 
@@ -1364,12 +1444,10 @@ describe('プレーヤー API', () => {
   describe('GET /dashboard/team チームなし時', () => {
     it('チームが存在しない場合は空のダッシュボードを返すべき', async () => {
       mockDashboardService.getTeamDashboard.mockResolvedValue(null);
-      const res = await app.request(
-        '/dashboard/team?eventId=event-1&teamId=unknown'
-      );
+      const res = await app.request('/dashboard/team?eventId=event-1');
       expect(res.status).toBe(StatusCodes.OK);
       const body = await res.json();
-      expect(body.team.teamId).toBe('unknown');
+      expect(body.team.teamId).toBe('team-1');
       expect(body.score).toBe(0);
       expect(body.recentAttacks).toEqual([]);
     });
@@ -1459,9 +1537,9 @@ describe('プレーヤー API', () => {
     });
   });
 
-  // === userId ありのチーム作成 ===
-  describe('POST /teams/create (userId あり)', () => {
-    it('userId あり でメンバー登録も行うべき', async () => {
+  // === userId 偽装つきのチーム作成 ===
+  describe('POST /teams/create (userId 偽装あり)', () => {
+    it('body の userId ではなく認証ユーザーでメンバー登録すべき', async () => {
       mockDashboardService.registerTeam.mockResolvedValue({
         eventId: 'event-1',
         teamId: 'team-1',
@@ -1479,7 +1557,7 @@ describe('プレーヤー API', () => {
           eventId: 'event-1',
           teamId: 'team-1',
           teamName: 'テストチーム',
-          userId: 'user-1',
+          userId: 'attacker-user',
         }),
       });
       expect(res.status).toBe(StatusCodes.CREATED);
@@ -1493,9 +1571,9 @@ describe('プレーヤー API', () => {
     });
   });
 
-  // === userId ありのチーム参加 ===
-  describe('POST /teams/join (userId あり)', () => {
-    it('userId あり でメンバー登録も行うべき', async () => {
+  // === userId 偽装つきのチーム参加 ===
+  describe('POST /teams/join (userId 偽装あり)', () => {
+    it('body の userId ではなく認証ユーザーでメンバー登録すべき', async () => {
       mockDashboardService.joinTeamByInviteCode.mockResolvedValue({
         eventId: 'event-1',
         teamId: 'team-1',
@@ -1512,7 +1590,7 @@ describe('プレーヤー API', () => {
         body: JSON.stringify({
           eventId: 'event-1',
           inviteCode: 'ABC123',
-          userId: 'user-1',
+          userId: 'attacker-user',
         }),
       });
       expect(res.status).toBe(StatusCodes.OK);
@@ -1532,7 +1610,7 @@ describe('プレーヤー API', () => {
       const res = await app.request('/teams/solo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ eventId: 'event-1', userId: 'user-1' }),
+        body: JSON.stringify({ eventId: 'event-1', userId: 'attacker-user' }),
       });
       expect(res.status).toBe(StatusCodes.CREATED);
       const body = await res.json();
@@ -1550,7 +1628,7 @@ describe('プレーヤー API', () => {
       const res = await app.request('/teams/solo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ eventId: 'event-1' }),
+        body: JSON.stringify({}),
       });
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
     });
@@ -1568,31 +1646,27 @@ describe('プレーヤー API', () => {
   // === メンバーシップ取得 ===
   describe('GET /teams/my-membership', () => {
     it('メンバーシップが存在する場合 OK を返すべき', async () => {
-      mockGamedayRepository.getMembership.mockResolvedValue({
-        userId: 'user-1',
-        teamId: 'team-1',
-        teamName: 'テストチーム',
-        mode: 'team',
-      });
-      const res = await app.request(
-        '/teams/my-membership?eventId=event-1&userId=user-1'
-      );
+      mockGamedayRepository.getMembership.mockResolvedValue(createMembership());
+      const res = await app.request('/teams/my-membership?eventId=event-1&userId=admin');
       expect(res.status).toBe(StatusCodes.OK);
       const body = await res.json();
       expect(body.membership.teamId).toBe('team-1');
+      expect(mockGamedayRepository.getMembership).toHaveBeenCalledWith(
+        'event-1',
+        'user-1',
+      );
     });
 
     it('メンバーシップが存在しない場合 OK で null を返すべき', async () => {
-      const res = await app.request(
-        '/teams/my-membership?eventId=event-1&userId=nonexistent'
-      );
+      mockGamedayRepository.getMembership.mockResolvedValueOnce(null);
+      const res = await app.request('/teams/my-membership?eventId=event-1');
       expect(res.status).toBe(StatusCodes.OK);
       const body = await res.json();
       expect(body.membership).toBeNull();
     });
 
     it('必須パラメータが欠けている場合 BAD_REQUEST を返すべき', async () => {
-      const res = await app.request('/teams/my-membership?eventId=event-1');
+      const res = await app.request('/teams/my-membership');
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
     });
   });

--- a/backend/services/application-plane/gameday-service/src/api/participant.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { StatusCodes } from "http-status-codes";
 import {
@@ -10,6 +11,9 @@ import {
 	allianceActionSchema,
 	voteSchema,
 	updateTeamUrlSchema,
+	createTeamSchema,
+	joinTeamSchema,
+	soloParticipationSchema,
 } from "../schemas";
 import {
 	getGameStatus,
@@ -46,7 +50,6 @@ import {
 import {
 	updateTeamUrl,
 	getLeaderboard,
-	getAttackStatistics,
 	getTeamDashboard,
 	listTeams,
 	registerTeam,
@@ -55,15 +58,27 @@ import {
 	TeamNotFoundError as DashboardTeamNotFoundError,
 	TeamAlreadyExistsError,
 } from "../services/dashboard-service";
-import {
-	getAllAttackLogs,
-	getAttackHistory,
-} from "../services/participant-service";
+import { getAllAttackLogs } from "../services/participant-service";
+import type { MemberRecord } from "../repositories/gameday-repository";
 import { GamedayRepository } from "../repositories/gameday-repository";
 
 const gamedayRepo = new GamedayRepository();
 
 export const participantRoutes = new Hono();
+
+class MembershipRequiredError extends Error {
+	constructor() {
+		super("このイベントへの参加登録が必要です");
+		this.name = "MembershipRequiredError";
+	}
+}
+
+class TeamAccessDeniedError extends Error {
+	constructor() {
+		super("自分のチーム以外を操作することはできません");
+		this.name = "TeamAccessDeniedError";
+	}
+}
 
 function mapErrorToResponse(error: unknown): {
 	error: string;
@@ -110,7 +125,31 @@ function mapErrorToResponse(error: unknown): {
 	if (error instanceof TeamNotFoundError) {
 		return { error: error.message, status: 404 };
 	}
+	if (
+		error instanceof MembershipRequiredError ||
+		error instanceof TeamAccessDeniedError
+	) {
+		return { error: error.message, status: 403 };
+	}
 	return null;
+}
+
+async function getAuthorizedMembership(
+	c: Context,
+	eventId: string,
+	requestedTeamId?: string,
+): Promise<MemberRecord> {
+	const membership = await gamedayRepo.getMembership(
+		eventId,
+		c.get("auth").userId,
+	);
+	if (!membership) {
+		throw new MembershipRequiredError();
+	}
+	if (requestedTeamId && requestedTeamId !== membership.teamId) {
+		throw new TeamAccessDeniedError();
+	}
+	return membership;
 }
 
 // === 攻撃 ===
@@ -178,9 +217,14 @@ participantRoutes.post("/attacks/purchase", async (c) => {
 		);
 	}
 	try {
-		const result = await purchaseAttack(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await purchaseAttack(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.attackId,
 		);
 		return c.json(result, StatusCodes.CREATED);
@@ -210,9 +254,14 @@ participantRoutes.post("/attacks/execute", async (c) => {
 		);
 	}
 	try {
-		const result = await executeAttack(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await executeAttack(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.targetTeamId,
 			parsed.data.attackId,
 		);
@@ -234,14 +283,20 @@ participantRoutes.post("/attacks/execute", async (c) => {
 participantRoutes.get("/attacks/history", async (c) => {
 	const eventId = c.req.query("eventId");
 	const teamId = c.req.query("teamId");
-	if (!eventId || !teamId) {
-		return c.json(
-			{ error: "eventId と teamId は必須です" },
-			StatusCodes.BAD_REQUEST,
-		);
+	if (!eventId) {
+		return c.json({ error: "eventId は必須です" }, StatusCodes.BAD_REQUEST);
 	}
-	const history = await getAttackHistory(eventId, teamId);
-	return c.json({ history }, StatusCodes.OK);
+	try {
+		const membership = await getAuthorizedMembership(c, eventId, teamId);
+		const history = await getAttackHistory(eventId, membership.teamId);
+		return c.json({ history }, StatusCodes.OK);
+	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
+		throw error;
+	}
 });
 
 // === 防御 ===
@@ -250,14 +305,20 @@ participantRoutes.get("/attacks/history", async (c) => {
 participantRoutes.get("/defense/active", async (c) => {
 	const eventId = c.req.query("eventId");
 	const teamId = c.req.query("teamId");
-	if (!eventId || !teamId) {
-		return c.json(
-			{ error: "eventId と teamId は必須です" },
-			StatusCodes.BAD_REQUEST,
-		);
+	if (!eventId) {
+		return c.json({ error: "eventId は必須です" }, StatusCodes.BAD_REQUEST);
 	}
-	const attacks = await getActiveAttacks(eventId, teamId);
-	return c.json({ attacks }, StatusCodes.OK);
+	try {
+		const membership = await getAuthorizedMembership(c, eventId, teamId);
+		const attacks = await getActiveAttacks(eventId, membership.teamId);
+		return c.json({ attacks }, StatusCodes.OK);
+	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
+		throw error;
+	}
 });
 
 // ヒント購入
@@ -277,9 +338,14 @@ participantRoutes.post("/defense/hint", async (c) => {
 		);
 	}
 	try {
-		const result = await purchaseHint(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await purchaseHint(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.attackId,
 		);
 		return c.json(result, StatusCodes.OK);
@@ -309,9 +375,14 @@ participantRoutes.post("/defense/report-fix", async (c) => {
 		);
 	}
 	try {
-		const result = await reportFix(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await reportFix(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.vulnerabilitySlug,
 		);
 		return c.json(result, StatusCodes.OK);
@@ -330,14 +401,20 @@ participantRoutes.post("/defense/report-fix", async (c) => {
 participantRoutes.get("/alliances", async (c) => {
 	const eventId = c.req.query("eventId");
 	const teamId = c.req.query("teamId");
-	if (!eventId || !teamId) {
-		return c.json(
-			{ error: "eventId と teamId は必須です" },
-			StatusCodes.BAD_REQUEST,
-		);
+	if (!eventId) {
+		return c.json({ error: "eventId は必須です" }, StatusCodes.BAD_REQUEST);
 	}
-	const alliances = await listTeamAlliances(eventId, teamId);
-	return c.json({ alliances }, StatusCodes.OK);
+	try {
+		const membership = await getAuthorizedMembership(c, eventId, teamId);
+		const alliances = await listTeamAlliances(eventId, membership.teamId);
+		return c.json({ alliances }, StatusCodes.OK);
+	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
+		throw error;
+	}
 });
 
 // 同盟申請
@@ -357,9 +434,14 @@ participantRoutes.post("/alliances/request", async (c) => {
 		);
 	}
 	try {
-		const result = await requestAlliance(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await requestAlliance(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.targetTeamId,
 		);
 		return c.json(result, StatusCodes.CREATED);
@@ -390,10 +472,15 @@ participantRoutes.post("/alliances/:id/accept", async (c) => {
 		);
 	}
 	try {
+		const membership = await getAuthorizedMembership(
+			c,
+			parsed.data.eventId,
+			parsed.data.teamId,
+		);
 		const result = await acceptAlliance(
 			parsed.data.eventId,
 			id,
-			parsed.data.teamId,
+			membership.teamId,
 		);
 		return c.json(result, StatusCodes.OK);
 	} catch (error) {
@@ -423,7 +510,12 @@ participantRoutes.post("/alliances/:id/break", async (c) => {
 		);
 	}
 	try {
-		await breakAlliance(parsed.data.eventId, id, parsed.data.teamId);
+		const membership = await getAuthorizedMembership(
+			c,
+			parsed.data.eventId,
+			parsed.data.teamId,
+		);
+		await breakAlliance(parsed.data.eventId, id, membership.teamId);
 		return c.json({ success: true }, StatusCodes.OK);
 	} catch (error) {
 		const mapped = mapErrorToResponse(error);
@@ -440,14 +532,20 @@ participantRoutes.post("/alliances/:id/break", async (c) => {
 participantRoutes.get("/monitoring/status", async (c) => {
 	const eventId = c.req.query("eventId");
 	const teamId = c.req.query("teamId");
-	if (!eventId || !teamId) {
-		return c.json(
-			{ error: "eventId と teamId は必須です" },
-			StatusCodes.BAD_REQUEST,
-		);
+	if (!eventId) {
+		return c.json({ error: "eventId は必須です" }, StatusCodes.BAD_REQUEST);
 	}
-	const checks = await getMonitoringStatus(eventId, teamId);
-	return c.json({ checks }, StatusCodes.OK);
+	try {
+		const membership = await getAuthorizedMembership(c, eventId, teamId);
+		const checks = await getMonitoringStatus(eventId, membership.teamId);
+		return c.json({ checks }, StatusCodes.OK);
+	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
+		throw error;
+	}
 });
 
 // === 投票 ===
@@ -469,9 +567,14 @@ participantRoutes.post("/voting/vote", async (c) => {
 		);
 	}
 	try {
-		const result = await castVote(
+		const membership = await getAuthorizedMembership(
+			c,
 			parsed.data.eventId,
 			parsed.data.teamId,
+		);
+		const result = await castVote(
+			parsed.data.eventId,
+			membership.teamId,
 			parsed.data.votedForTeamId,
 		);
 		return c.json(result, StatusCodes.CREATED);
@@ -575,33 +678,39 @@ participantRoutes.get("/dashboard/attack-stats", async (c) => {
 participantRoutes.get("/dashboard/team", async (c) => {
 	const eventId = c.req.query("eventId");
 	const teamId = c.req.query("teamId");
-	if (!eventId || !teamId) {
-		return c.json(
-			{ error: "eventId と teamId は必須です" },
-			StatusCodes.BAD_REQUEST,
-		);
+	if (!eventId) {
+		return c.json({ error: "eventId は必須です" }, StatusCodes.BAD_REQUEST);
 	}
-	const dashboard = await getTeamDashboard(eventId, teamId);
-	if (!dashboard) {
-		return c.json(
-			{
-				team: {
-					teamId,
-					teamName: "",
+	try {
+		const membership = await getAuthorizedMembership(c, eventId, teamId);
+		const dashboard = await getTeamDashboard(eventId, membership.teamId);
+		if (!dashboard) {
+			return c.json(
+				{
+					team: {
+						teamId: membership.teamId,
+						teamName: "",
+						score: 0,
+						isHealthy: true,
+						websiteUrl: null,
+						apiUrl: null,
+					},
 					score: 0,
-					isHealthy: true,
-					websiteUrl: null,
-					apiUrl: null,
+					recentAttacks: [],
+					recentHealthChecks: [],
+					attackHistory: [],
 				},
-				score: 0,
-				recentAttacks: [],
-				recentHealthChecks: [],
-				attackHistory: [],
-			},
-			StatusCodes.OK,
-		);
+				StatusCodes.OK,
+			);
+		}
+		return c.json(dashboard, StatusCodes.OK);
+	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
+		throw error;
 	}
-	return c.json(dashboard, StatusCodes.OK);
 });
 
 // === チーム URL 更新 ===
@@ -621,11 +730,22 @@ participantRoutes.post("/teams/update-url", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const { eventId, teamId, websiteUrl, apiUrl } = parsed.data;
 	try {
-		await updateTeamUrl(eventId, teamId, { websiteUrl, apiUrl });
+		const membership = await getAuthorizedMembership(
+			c,
+			parsed.data.eventId,
+			parsed.data.teamId,
+		);
+		await updateTeamUrl(parsed.data.eventId, membership.teamId, {
+			websiteUrl: parsed.data.websiteUrl,
+			apiUrl: parsed.data.apiUrl,
+		});
 		return c.json({ success: true }, StatusCodes.OK);
 	} catch (error) {
+		const mapped = mapErrorToResponse(error);
+		if (mapped) {
+			return c.json({ error: mapped.error }, mapped.status);
+		}
 		if (error instanceof DashboardTeamNotFoundError) {
 			return c.json({ error: error.message }, StatusCodes.NOT_FOUND);
 		}
@@ -643,29 +763,22 @@ participantRoutes.post("/teams/create", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const { eventId, teamId, teamName, userId } = body as {
-		eventId?: string;
-		teamId?: string;
-		teamName?: string;
-		userId?: string;
-	};
-	if (!eventId || !teamId || !teamName) {
+	const parsed = createTeamSchema.safeParse(body);
+	if (!parsed.success) {
 		return c.json(
-			{ error: "eventId, teamId, teamName は必須です" },
+			{ error: "無効なリクエスト", details: parsed.error.issues },
 			StatusCodes.BAD_REQUEST,
 		);
 	}
 	try {
-		const team = await registerTeam({ eventId, teamId, teamName });
-		if (userId) {
-			await gamedayRepo.addMember({
-				eventId,
-				userId,
-				teamId: team.teamId,
-				teamName: team.teamName,
-				mode: "team",
-			});
-		}
+		const team = await registerTeam(parsed.data);
+		await gamedayRepo.addMember({
+			eventId: parsed.data.eventId,
+			userId: c.get("auth").userId,
+			teamId: team.teamId,
+			teamName: team.teamName,
+			mode: "team",
+		});
 		return c.json(
 			{
 				teamId: team.teamId,
@@ -692,30 +805,27 @@ participantRoutes.post("/teams/join", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const { eventId, inviteCode, userId } = body as {
-		eventId?: string;
-		inviteCode?: string;
-		userId?: string;
-	};
-	if (!eventId || !inviteCode) {
+	const parsed = joinTeamSchema.safeParse(body);
+	if (!parsed.success) {
 		return c.json(
-			{ error: "eventId, inviteCode は必須です" },
+			{ error: "無効なリクエスト", details: parsed.error.issues },
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const team = await joinTeamByInviteCode(eventId, inviteCode);
+	const team = await joinTeamByInviteCode(
+		parsed.data.eventId,
+		parsed.data.inviteCode,
+	);
 	if (!team) {
 		return c.json({ error: "招待コードが無効です" }, StatusCodes.NOT_FOUND);
 	}
-	if (userId) {
-		await gamedayRepo.addMember({
-			eventId,
-			userId,
-			teamId: team.teamId,
-			teamName: team.teamName,
-			mode: "team",
-		});
-	}
+	await gamedayRepo.addMember({
+		eventId: parsed.data.eventId,
+		userId: c.get("auth").userId,
+		teamId: team.teamId,
+		teamName: team.teamName,
+		mode: "team",
+	});
 	return c.json(
 		{ teamId: team.teamId, teamName: team.teamName },
 		StatusCodes.OK,
@@ -732,15 +842,16 @@ participantRoutes.post("/teams/solo", async (c) => {
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const { eventId, userId } = body as { eventId?: string; userId?: string };
-	if (!eventId || !userId) {
+	const parsed = soloParticipationSchema.safeParse(body);
+	if (!parsed.success) {
 		return c.json(
-			{ error: "eventId, userId は必須です" },
+			{ error: "無効なリクエスト", details: parsed.error.issues },
 			StatusCodes.BAD_REQUEST,
 		);
 	}
+	const userId = c.get("auth").userId;
 	await gamedayRepo.addMember({
-		eventId,
+		eventId: parsed.data.eventId,
 		userId,
 		teamId: `solo-${userId}`,
 		teamName: "ソロ参加",
@@ -753,14 +864,13 @@ participantRoutes.post("/teams/solo", async (c) => {
 
 participantRoutes.get("/teams/my-membership", async (c) => {
 	const eventId = c.req.query("eventId");
-	const userId = c.req.query("userId");
-	if (!eventId || !userId) {
+	if (!eventId) {
 		return c.json(
-			{ error: "eventId, userId は必須です" },
+			{ error: "eventId は必須です" },
 			StatusCodes.BAD_REQUEST,
 		);
 	}
-	const membership = await gamedayRepo.getMembership(eventId, userId);
+	const membership = await gamedayRepo.getMembership(eventId, c.get("auth").userId);
 	if (!membership) {
 		return c.json({ membership: null }, StatusCodes.OK);
 	}

--- a/backend/services/application-plane/gameday-service/src/schemas/index.ts
+++ b/backend/services/application-plane/gameday-service/src/schemas/index.ts
@@ -101,7 +101,7 @@ export const registerTeamSchema = z.object({
 // プレーヤー: チーム URL 更新
 export const updateTeamUrlSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	websiteUrl: safeUrl.optional(),
 	apiUrl: safeUrl.optional(),
 });
@@ -109,14 +109,14 @@ export const updateTeamUrlSchema = z.object({
 // プレーヤー: 攻撃購入
 export const purchaseAttackSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	attackId: z.string().min(1),
 });
 
 // プレーヤー: 攻撃実行
 export const executeAttackSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	attackId: z.string().min(1),
 	targetTeamId: z.string().min(1),
 });
@@ -124,33 +124,51 @@ export const executeAttackSchema = z.object({
 // プレーヤー: ヒント購入
 export const purchaseHintSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	attackId: z.string().min(1),
 });
 
 // プレーヤー: 脆弱性修正報告
 export const reportFixSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	vulnerabilitySlug: z.string().min(1),
 });
 
 // プレーヤー: 同盟申請
 export const requestAllianceSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	targetTeamId: z.string().min(1),
 });
 
 // プレーヤー: 同盟承認/破棄
 export const allianceActionSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 });
 
 // プレーヤー: 投票
 export const voteSchema = z.object({
 	eventId: z.string().min(1),
-	teamId: z.string().min(1),
+	teamId: z.string().min(1).optional(),
 	votedForTeamId: z.string().min(1),
+});
+
+// プレーヤー: チーム作成
+export const createTeamSchema = z.object({
+	eventId: z.string().min(1),
+	teamId: z.string().min(1),
+	teamName: z.string().min(1),
+});
+
+// プレーヤー: 招待コードでチーム参加
+export const joinTeamSchema = z.object({
+	eventId: z.string().min(1),
+	inviteCode: z.string().min(1),
+});
+
+// プレーヤー: ソロ参加
+export const soloParticipationSchema = z.object({
+	eventId: z.string().min(1),
 });


### PR DESCRIPTION
## Summary
- resolve GameDay participant actions from authenticated membership instead of trusting client-supplied team IDs
- stop forwarding userId from Next.js GameDay team proxy routes to the backend
- add regression tests for forged teamId and userId attempts

## Verification
- make before-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened team authorization to prevent unauthorized data access
  * Improved error responses with clearer permission denial messages
  * Simplified API requests by removing redundant user parameters from payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->