### PR TITLE
simplify: fix double-log, O(n) stats, pre-compute vote lookup, leadingCandidate guard

### DIFF
--- a/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -103,7 +103,11 @@ export default function VotePage() {
   );
 
   const totalVotes = votes.length;
-  const leadingCandidate = voteCandidates[0] ?? null;
+  const leadingCandidate =
+    voteCandidates[0]?.votes > 0 ? voteCandidates[0] : null;
+  const votedForTeam = votedTeamId
+    ? (voteCandidates.find((team) => team.teamId === votedTeamId) ?? null)
+    : null;
 
   if (loading) {
     return (
@@ -217,8 +221,8 @@ export default function VotePage() {
               </div>
               <div className="text-emerald-200/80">
                 {locale === 'ja'
-                  ? `投票先: ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`
-                  : `Voted for ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`}
+                  ? `投票先: ${votedForTeam?.teamName ?? votedTeamId}`
+                  : `Voted for ${votedForTeam?.teamName ?? votedTeamId}`}
               </div>
             </div>
           </div>

--- a/backend/services/control-plane/tenant-management/src/index.ts
+++ b/backend/services/control-plane/tenant-management/src/index.ts
@@ -94,31 +94,24 @@ app.get(
         tenantRepository.list({ limit: 100 }),
       ]);
 
-    // Count active tenants
-    const activeTenants = listResult.tenants.filter(
-      (t) => t.status === 'ACTIVE'
-    ).length;
+    let activeTenants = 0;
+    let failedCount = 0;
+    let inProgressCount = 0;
+    let completedCount = 0;
+    let pendingCount = 0;
+    for (const t of listResult.tenants) {
+      if (t.status === 'ACTIVE') activeTenants++;
+      if (t.provisioningStatus === 'FAILED') failedCount++;
+      else if (t.provisioningStatus === 'IN_PROGRESS') inProgressCount++;
+      else if (t.provisioningStatus === 'COMPLETED') completedCount++;
+      else if (t.provisioningStatus === 'PENDING') pendingCount++;
+    }
 
-    // Determine system status based on provisioning state
-    const failedCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'FAILED'
-    ).length;
-    const inProgressCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'IN_PROGRESS'
-    ).length;
-
-    // Calculate system health:
-    // - degraded: any tenant has failed provisioning
-    // - healthy: all tenants completed or pending/in-progress
     const systemStatus: 'healthy' | 'degraded' | 'down' =
       failedCount > 0 ? 'degraded' : 'healthy';
-
-    // Calculate uptime percentage based on successful provisioning
-    // (tenants not in FAILED state / total tenants) * 100
-    const successfulTenants = totalTenants - failedCount;
     const uptimePercentage =
       totalTenants > 0
-        ? Math.round((successfulTenants / totalTenants) * 100)
+        ? Math.round(((totalTenants - failedCount) / totalTenants) * 100)
         : 100;
 
       return c.json({
@@ -126,16 +119,11 @@ app.get(
         totalTenants,
         systemStatus,
         uptimePercentage,
-        // Additional context for debugging
         provisioningStats: {
-          completed: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'COMPLETED'
-          ).length,
+          completed: completedCount,
           inProgress: inProgressCount,
           failed: failedCount,
-          pending: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'PENDING'
-          ).length,
+          pending: pendingCount,
         },
       });
     } catch (error) {

--- a/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
+++ b/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
@@ -107,7 +107,7 @@ provisioningRoutes.post(
         applicationDeploymentStatus: 'FAILED',
         provisioningError: errorMessage,
       });
-      throw error;
+      return c.json(errorResponse('Failed to start provisioning', 500), 500);
     }
 
     await tenantRepository.update(tenant.id, {


### PR DESCRIPTION
## Summary

Follow-up simplification pass on susumutomita/TenkaCloud#367.

- **Double logging eliminated** (`routes/provisioning.ts`): inner EventBridge catch block now returns the 500 response directly instead of re-throwing, so the outer catch no longer logs the same error a second time with a less-specific message
- **Stats route O(n)** (`index.ts`): replaced four sequential `Array.filter()` passes over the tenant list with a single `for-of` loop accumulating all five counters in one pass — 4× fewer iterations on each dashboard load
- **Pre-computed vote lookup** (`vote/page.tsx`): added `votedForTeam` alongside `leadingCandidate` so the confirmation banner no longer calls `Array.find()` twice (once for each locale branch) on every render
- **`leadingCandidate` 0-vote guard** (`vote/page.tsx`): `voteCandidates[0]` was returned as the leader even when all teams had 0 votes, showing "Current leader: TeamA (0 votes)" on an empty board — now returns `null` when top vote count is 0

## Test plan
- [x] `make before-commit` passes (1111 tests, lint, typecheck, build)
- [x] AI quality loop: **0 critical, 0 high, 0 medium** findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vote display logic to correctly identify the leading candidate based on vote count.
  * Improved error handling in provisioning workflow to provide immediate feedback on failures.

* **Performance**
  * Optimized stats calculation for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->