### PR TITLE
[codex] Harden admin isolation and AWS team deploys

### DIFF
--- a/apps/application-plane/__tests__/auth.test.ts
+++ b/apps/application-plane/__tests__/auth.test.ts
@@ -36,6 +36,7 @@ describe('Auth0 認証設定', () => {
     process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
     process.env.AUTH0_ISSUER = 'https://test.auth0.com';
     delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
   });
 
   describe('AUTH_SKIP モード', () => {
@@ -56,11 +57,21 @@ describe('Auth0 認証設定', () => {
       expect(session).toBeDefined();
       expect(session?.user?.name).toBe('Dev User');
       expect(session?.user?.email).toBe('dev@example.com');
-      expect(session?.roles).toEqual(['admin', 'participant']);
+      expect(session?.roles).toEqual(['participant']);
       expect(session?.tenantId).toBe('dev-tenant');
       expect(session?.teamId).toBe('team-alpha');
       expect(session?.accessToken).toBe('mock-access-token');
       expect(session?.idToken).toBe('mock-id-token');
+    });
+
+    it('AUTH_SKIP_ROLES を指定した場合、そのロール構成を使うべき', async () => {
+      process.env.AUTH_SKIP = '1';
+      process.env.AUTH_SKIP_ROLES = 'tenant-admin,participant';
+
+      const auth = await import('../auth');
+      const session = await auth.auth();
+
+      expect(session?.roles).toEqual(['tenant-admin', 'participant']);
     });
 
     it('AUTH_SKIP=1 の場合、Auth0 環境変数がなくてもエラーにならないべき', async () => {

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -38,6 +38,7 @@ interface CompetitorAccount {
   accountId: string;
   region: string;
   roleArn?: string;
+  externalId?: string;
   status: string;
 }
 
@@ -227,6 +228,7 @@ export default function GameDayDeploymentsPage() {
     accountId: '',
     region: 'ap-northeast-1',
     roleArn: '',
+    externalId: '',
   });
   const [addingAccount, setAddingAccount] = useState(false);
   const [addAccountError, setAddAccountError] = useState('');
@@ -410,6 +412,7 @@ export default function GameDayDeploymentsPage() {
         accountId: newAccount.accountId,
         region: newAccount.region,
         roleArn: newAccount.roleArn || undefined,
+        externalId: newAccount.externalId || undefined,
       });
       setShowAddModal(false);
       setNewAccount({
@@ -417,6 +420,7 @@ export default function GameDayDeploymentsPage() {
         accountId: '',
         region: 'ap-northeast-1',
         roleArn: '',
+        externalId: '',
       });
       await refreshAccounts();
     } catch (e) {
@@ -531,6 +535,11 @@ export default function GameDayDeploymentsPage() {
             id: 'roleArn',
             header: 'Role ARN',
             cell: (item) => item.roleArn ?? '—',
+          },
+          {
+            id: 'externalId',
+            header: 'External ID',
+            cell: (item) => item.externalId ?? '—',
           },
           {
             id: 'actions',
@@ -723,6 +732,21 @@ export default function GameDayDeploymentsPage() {
                   setNewAccount((prev) => ({ ...prev, roleArn: detail.value }))
                 }
                 placeholder="arn:aws:iam::123456789012:role/TenkaCloudDeployRole"
+              />
+            </FormField>
+            <FormField
+              label="External ID"
+              description="未入力時は event / account から安全な値を自動生成します"
+            >
+              <Input
+                value={newAccount.externalId}
+                onChange={({ detail }) =>
+                  setNewAccount((prev) => ({
+                    ...prev,
+                    externalId: detail.value,
+                  }))
+                }
+                placeholder="tc-<eventId>-<accountId>"
               />
             </FormField>
           </SpaceBetween>

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -103,7 +103,11 @@ export default function VotePage() {
   );
 
   const totalVotes = votes.length;
-  const leadingCandidate = voteCandidates[0] ?? null;
+  const leadingCandidate =
+    voteCandidates[0]?.votes > 0 ? voteCandidates[0] : null;
+  const votedForTeam = votedTeamId
+    ? (voteCandidates.find((team) => team.teamId === votedTeamId) ?? null)
+    : null;
 
   if (loading) {
     return (
@@ -217,8 +221,8 @@ export default function VotePage() {
               </div>
               <div className="text-emerald-200/80">
                 {locale === 'ja'
-                  ? `投票先: ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`
-                  : `Voted for ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`}
+                  ? `投票先: ${votedForTeam?.teamName ?? votedTeamId}`
+                  : `Voted for ${votedForTeam?.teamName ?? votedTeamId}`}
               </div>
             </div>
           </div>

--- a/apps/application-plane/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -31,6 +31,7 @@ describe('NextAuth route handler', () => {
     vi.clearAllMocks();
     vi.resetModules();
     delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
     delete process.env.AUTH0_CLIENT_ID;
     delete process.env.AUTH0_CLIENT_SECRET;
     delete process.env.AUTH0_ISSUER;
@@ -52,7 +53,7 @@ describe('NextAuth route handler', () => {
       expect(body.user.email).toBe('dev@example.com');
       expect(body.accessToken).toBe('mock-access-token');
       expect(body.idToken).toBe('mock-id-token');
-      expect(body.roles).toEqual(['admin', 'participant']);
+      expect(body.roles).toEqual(['participant']);
       expect(body.tenantId).toBe('dev-tenant');
       expect(body.teamId).toBe('team-alpha');
       // handlers.GET should NOT be called for session path

--- a/apps/application-plane/auth.ts
+++ b/apps/application-plane/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import type { Session } from 'next-auth';
 import Auth0 from 'next-auth/providers/auth0';
 import { isAuthSkipEnabled } from '@/lib/auth/is-auth-skip-enabled';
+import { parseAuthSkipRoles } from '@/lib/auth/roles';
 
 const getEnv = (key: string) => process.env[key];
 // During `next build`, NEXT_PHASE is set to 'phase-production-build'.
@@ -18,6 +19,7 @@ try {
 }
 const useStubAuth =
   authSkipEnabled || (isBuildPhase && process.env.AUTH_SKIP === '1');
+const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /**
  * モックセッション（AUTH_SKIP=1 の場合に使用）
@@ -34,7 +36,7 @@ const mockSession: Session = {
   expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
   accessToken: 'mock-access-token',
   idToken: 'mock-id-token',
-  roles: ['admin', 'participant'],
+  roles: authSkipRoles,
   tenantId: 'dev-tenant',
   teamId: 'team-alpha',
 };

--- a/apps/application-plane/components/layout/page-layout.tsx
+++ b/apps/application-plane/components/layout/page-layout.tsx
@@ -31,6 +31,7 @@ import { useRouter } from 'next/navigation';
 import { signOut } from 'next-auth/react';
 import { useSession } from 'next-auth/react';
 import { type ReactNode, useEffect, useState } from 'react';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
 
 export interface BreadcrumbItem {
   text: string;
@@ -107,7 +108,7 @@ export function PageLayout({
                 },
                 ...(session
                   ? [
-                      ...(session.roles?.includes('admin')
+                      ...(hasApplicationAdminRole(session)
                         ? [
                             {
                               type: 'button' as const,

--- a/apps/application-plane/lib/api/__tests__/server.test.ts
+++ b/apps/application-plane/lib/api/__tests__/server.test.ts
@@ -137,6 +137,20 @@ describe('Server API Utilities', () => {
       expect(result).toEqual(session);
     });
 
+    it('tenant-admin ロールも管理者として扱うべき', async () => {
+      const session: Session = {
+        user: { name: 'Tenant Admin', email: 'tenant-admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['tenant-admin'],
+      };
+      mockAuth.mockResolvedValue(session);
+
+      const { getAdminSession } = await import('../server');
+      const result = await getAdminSession();
+
+      expect(result).toEqual(session);
+    });
+
     it('roles が undefined の場合は null を返すべき', async () => {
       mockAuth.mockResolvedValue({
         user: { name: 'User', email: 'user@example.com' },

--- a/apps/application-plane/lib/api/admin-types.ts
+++ b/apps/application-plane/lib/api/admin-types.ts
@@ -438,6 +438,7 @@ export interface DeployProblemRequest {
     sessionToken?: string;
     accountId?: string;
     roleArn?: string;
+    externalId?: string;
   };
 }
 

--- a/apps/application-plane/lib/api/server.ts
+++ b/apps/application-plane/lib/api/server.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse } from 'next/server';
 import { auth, authSkipEnabled } from '@/auth';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
 import { getProblemServiceUrl } from '@/lib/api/backend-urls';
 
 const MOCK_ACCESS_TOKEN = 'mock-access-token';
@@ -63,8 +64,7 @@ export async function getAdminSession() {
     return null;
   }
 
-  const hasAdminRole = session.roles?.includes('admin') ?? false;
-  if (!hasAdminRole) {
+  if (!hasApplicationAdminRole(session)) {
     return null;
   }
 

--- a/apps/application-plane/lib/auth/__tests__/roles.test.ts
+++ b/apps/application-plane/lib/auth/__tests__/roles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { hasApplicationAdminRole, parseAuthSkipRoles } from '../roles';
+
+describe('auth role helpers', () => {
+  describe('parseAuthSkipRoles', () => {
+    it('未指定時は participant のみを返すべき', () => {
+      expect(parseAuthSkipRoles()).toEqual(['participant']);
+    });
+
+    it('空白だけの指定は participant にフォールバックすべき', () => {
+      expect(parseAuthSkipRoles(' ,  , ')).toEqual(['participant']);
+    });
+
+    it('カンマ区切りのロールを正規化して返すべき', () => {
+      expect(parseAuthSkipRoles(' tenant-admin , participant ')).toEqual([
+        'tenant-admin',
+        'participant',
+      ]);
+    });
+  });
+
+  describe('hasApplicationAdminRole', () => {
+    it('tenant-admin を管理者として扱うべき', () => {
+      expect(hasApplicationAdminRole(['tenant-admin'])).toBe(true);
+    });
+
+    it('participant 単独は管理者として扱わないべき', () => {
+      expect(hasApplicationAdminRole(['participant'])).toBe(false);
+    });
+  });
+});

--- a/apps/application-plane/lib/auth/roles.ts
+++ b/apps/application-plane/lib/auth/roles.ts
@@ -1,0 +1,35 @@
+import type { Session } from 'next-auth';
+
+const APPLICATION_ADMIN_ROLES = [
+  'admin',
+  'platform-admin',
+  'tenant-admin',
+  'organizer',
+] as const;
+
+export function parseAuthSkipRoles(envValue?: string): string[] {
+  if (!envValue) {
+    return ['participant'];
+  }
+
+  const roles = envValue
+    .split(',')
+    .map((role) => role.trim())
+    .filter(Boolean);
+
+  return roles.length > 0 ? roles : ['participant'];
+}
+
+export function hasApplicationAdminRole(
+  sessionOrRoles: Session | string[] | null | undefined,
+): boolean {
+  const roles = Array.isArray(sessionOrRoles)
+    ? sessionOrRoles
+    : sessionOrRoles?.roles;
+
+  if (!roles || roles.length === 0) {
+    return false;
+  }
+
+  return APPLICATION_ADMIN_ROLES.some((role) => roles.includes(role));
+}

--- a/apps/application-plane/lib/tenant/__tests__/middleware.test.ts
+++ b/apps/application-plane/lib/tenant/__tests__/middleware.test.ts
@@ -121,6 +121,21 @@ describe('Middleware', () => {
       expect(response.status).toBe(200);
     });
 
+    it('tenant-admin ロールを持つユーザーも /admin にアクセス可能にすべき', async () => {
+      mockAuth.mockResolvedValue({
+        user: { name: 'Tenant Admin', email: 'tenant-admin@example.com' },
+        expires: new Date(Date.now() + 86400000).toISOString(),
+        roles: ['tenant-admin'],
+        tenantId: 'acme',
+      });
+      mockGetTenantSlugFromUrl.mockReturnValue('acme');
+
+      const req = createMockRequest('http://localhost:13001/admin');
+      const response = await middleware(req);
+
+      expect(response.status).toBe(200);
+    });
+
     it('participant ロールのみのユーザーは /admin から /dashboard にリダイレクトすべき', async () => {
       mockAuth.mockResolvedValue({
         user: { name: 'Participant User', email: 'participant@example.com' },

--- a/apps/application-plane/proxy.ts
+++ b/apps/application-plane/proxy.ts
@@ -8,10 +8,8 @@
 
 import { NextResponse, type NextRequest } from 'next/server';
 import { auth } from '@/auth';
-import {
-  getTenantSlugFromUrl,
-  buildApplicationPlaneUrl,
-} from '@/lib/tenant/identification';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
+import { getTenantSlugFromUrl } from '@/lib/tenant/identification';
 
 /**
  * 公開パス（認証不要）
@@ -67,8 +65,7 @@ async function handleAuth(
 
   // 管理者パスへのアクセス権限チェック
   if (isAdminPath(pathname)) {
-    const hasAdminRole = roles.includes('admin');
-    if (!hasAdminRole) {
+    if (!hasApplicationAdminRole(roles)) {
       // 権限なし → /dashboard へリダイレクト
       const dashboardUrl = new URL('/dashboard', req.url);
       return NextResponse.redirect(dashboardUrl);

--- a/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
@@ -27,6 +27,7 @@ describe("authMiddleware", () => {
 		vi.clearAllMocks();
 		vi.resetModules();
 		delete process.env.AUTH_SKIP;
+		delete process.env.AUTH_SKIP_ROLES;
 		delete process.env.JWKS_URI;
 		delete process.env.JWT_ISSUER;
 		delete process.env.JWT_AUDIENCE;
@@ -48,7 +49,7 @@ describe("authMiddleware", () => {
 			const body = await res.json();
 			expect(body.userId).toBe("dev-user");
 			expect(body.tenantId).toBe("dev-tenant");
-			expect(body.roles).toEqual(["admin", "participant"]);
+			expect(body.roles).toEqual(["participant"]);
 		});
 
 		it("AUTH_SKIP モードで Authorization ヘッダーなしでもアクセスできるべき", async () => {
@@ -63,6 +64,22 @@ describe("authMiddleware", () => {
 			// No Authorization header
 			const res = await app.request("/test");
 			expect(res.status).toBe(StatusCodes.OK);
+		});
+
+		it("AUTH_SKIP_ROLES で tenant-admin を付与できるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.AUTH_SKIP_ROLES = "tenant-admin,participant";
+
+			const { authMiddleware } = await import("./auth");
+
+			const app = new Hono();
+			app.use("/*", authMiddleware);
+			app.get("/test", (c) => c.json(c.get("auth")));
+
+			const res = await app.request("/test");
+			const body = await res.json();
+
+			expect(body.roles).toEqual(["tenant-admin", "participant"]);
 		});
 	});
 

--- a/backend/services/application-plane/gameday-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth.ts
@@ -24,6 +24,19 @@ const authSkipEnabled =
 	process.env.AUTH_SKIP === "1" &&
 	process.env.NODE_ENV !== "production";
 
+function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return ["participant"];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : ["participant"];
+}
+
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== "undefined") {
 	console.warn(
@@ -38,7 +51,7 @@ if (authSkipEnabled && typeof console !== "undefined") {
 const mockAuth: AuthContext = {
 	userId: "dev-user",
 	tenantId: "dev-tenant",
-	roles: ["admin", "participant"],
+	roles: parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES),
 };
 
 const JWKS_URI =
@@ -130,7 +143,12 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 
 export const requireAdmin = createMiddleware(async (c, next) => {
 	const auth = c.get("auth");
-	if (!auth.roles.includes("admin")) {
+	if (
+		!auth.roles.includes("admin") &&
+		!auth.roles.includes("platform-admin") &&
+		!auth.roles.includes("tenant-admin") &&
+		!auth.roles.includes("organizer")
+	) {
 		return c.json({ error: "管理者権限が必要です" }, StatusCodes.FORBIDDEN);
 	}
 	await next();

--- a/backend/services/application-plane/leaderboard-service/src/middleware/auth.test.ts
+++ b/backend/services/application-plane/leaderboard-service/src/middleware/auth.test.ts
@@ -22,6 +22,7 @@ describe("認証ミドルウェア", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		delete process.env.AUTH_SKIP;
+		delete process.env.AUTH_SKIP_ROLES;
 		delete process.env.NODE_ENV;
 		app = new Hono();
 		app.use("/*", authMiddleware);
@@ -196,8 +197,20 @@ describe("認証ミドルウェア", () => {
 		expect(body.auth).toEqual({
 			userId: "dev-user",
 			tenantId: "dev-tenant",
-			roles: ["admin", "participant"],
+			roles: ["participant"],
 		});
+	});
+
+	it("AUTH_SKIP_ROLES がある場合はそのロールを返すべき", async () => {
+		process.env.AUTH_SKIP = "1";
+		process.env.AUTH_SKIP_ROLES = "tenant-admin,participant";
+		process.env.NODE_ENV = "development";
+
+		const res = await app.request("/test");
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.auth.roles).toEqual(["tenant-admin", "participant"]);
 	});
 
 	it("AUTH_SKIP=1 でも本番環境では認証をスキップしないべき", async () => {

--- a/backend/services/application-plane/leaderboard-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/leaderboard-service/src/middleware/auth.ts
@@ -21,6 +21,19 @@ const ISSUER =
 
 let jwks: jose.JWTVerifyGetKey | null = null;
 
+function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return ["participant"];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : ["participant"];
+}
+
 async function getJWKS() {
 	if (!jwks) {
 		jwks = jose.createRemoteJWKSet(new URL(JWKS_URI));
@@ -36,7 +49,7 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 		c.set("auth", {
 			userId: "dev-user",
 			tenantId: "dev-tenant",
-			roles: ["admin", "participant"],
+			roles: parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES),
 		});
 		return next();
 	}

--- a/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
@@ -12,6 +12,7 @@ describe("auth モジュール", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		process.env = { ...originalEnv };
+		delete process.env.AUTH_SKIP_ROLES;
 	});
 
 	afterEach(() => {
@@ -68,6 +69,7 @@ describe("auth モジュール", () => {
 			expect(result.user).not.toBeNull();
 			expect(result.user!.id).toBe("dev-user");
 			expect(result.user!.email).toBe("dev@localhost");
+			expect(result.user!.roles).toEqual(["competitor"]);
 			expect(result.token).toBe("mock-access-token");
 		});
 
@@ -81,6 +83,17 @@ describe("auth モジュール", () => {
 
 			expect(result1.user).not.toBe(result2.user);
 			expect(result1.user).toEqual(result2.user);
+		});
+
+		it("AUTH_SKIP_ROLES が指定された場合はそのロールを使うべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.AUTH_SKIP_ROLES = "platform-admin,competitor";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({});
+
+			expect(result.user?.roles).toEqual(["platform-admin", "competitor"]);
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/__tests__/aws-provider.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/aws-provider.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Problem } from "../types";
+
+const mocks = vi.hoisted(() => ({
+	stsSend: vi.fn(),
+	cfSend: vi.fn(),
+	s3Send: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-sts", () => ({
+	STSClient: class {
+		send = mocks.stsSend;
+	},
+	AssumeRoleCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	GetCallerIdentityCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+vi.mock("@aws-sdk/client-cloudformation", () => ({
+	CloudFormationClient: class {
+		send = mocks.cfSend;
+	},
+	CreateStackCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DeleteStackCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DescribeStacksCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DescribeStackResourcesCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	ListStacksCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	ValidateTemplateCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+	S3Client: class {
+		send = mocks.s3Send;
+	},
+	PutObjectCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+const problem: Problem = {
+	id: "problem-1",
+	title: "Test",
+	type: "gameday",
+	category: "security",
+	difficulty: "medium",
+	metadata: {
+		author: "test",
+		version: "1.0.0",
+		createdAt: new Date().toISOString(),
+	},
+	description: {
+		overview: "overview",
+		objectives: [],
+		hints: [],
+	},
+	deployment: {
+		providers: ["aws"],
+		templates: {
+			aws: {
+				type: "cloudformation",
+				content: "Resources: {}",
+			},
+		},
+		regions: {
+			aws: ["ap-northeast-1"],
+		},
+		timeout: 1,
+	},
+	scoring: {
+		type: "manual",
+		path: "/manual",
+		criteria: [],
+		timeoutMinutes: 1,
+	},
+};
+
+describe("AWSCloudProvider", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("roleArn がある場合は ExternalId 付きで AssumeRole して認証検証すべき", async () => {
+		mocks.stsSend
+			.mockResolvedValueOnce({
+				Credentials: {
+					AccessKeyId: "ASIA...",
+					SecretAccessKey: "secret",
+					SessionToken: "token",
+				},
+			})
+			.mockResolvedValueOnce({
+				Account: "123456789012",
+				Arn: "arn:aws:sts::123456789012:assumed-role/Test/session",
+			});
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const valid = await provider.validateCredentials({
+			provider: "aws",
+			accountId: "123456789012",
+			region: "ap-northeast-1",
+			roleArn: "arn:aws:iam::123456789012:role/TenkaCloudDeployRole",
+			externalId: "tc-event-1-123456789012",
+		});
+
+		expect(valid).toBe(true);
+		expect(mocks.stsSend).toHaveBeenCalledTimes(2);
+		const assumeRoleCommand = mocks.stsSend.mock.calls[0][0] as {
+			input: { ExternalId?: string };
+		};
+		expect(assumeRoleCommand.input.ExternalId).toBe(
+			"tc-event-1-123456789012",
+		);
+	});
+
+	it("CloudFormation でスタックを作成して CREATE_COMPLETE を待つべき", async () => {
+		mocks.cfSend
+			.mockResolvedValueOnce({ StackId: "stack-1" })
+			.mockResolvedValueOnce({
+				Stacks: [
+					{
+						StackName: "tc-stack",
+						StackId: "stack-1",
+						StackStatus: "CREATE_COMPLETE",
+						Outputs: [{ OutputKey: "ConsoleUrl", OutputValue: "https://example.com" }],
+					},
+				],
+			});
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const result = await provider.deployStack(
+			problem,
+			{
+				provider: "aws",
+				accountId: "123456789012",
+				region: "ap-northeast-1",
+				accessKeyId: "access",
+				secretAccessKey: "secret",
+			},
+			{
+				stackName: "tc-stack",
+				region: "ap-northeast-1",
+				timeoutSeconds: 1,
+			},
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.stackId).toBe("stack-1");
+		expect(result.outputs).toEqual({ ConsoleUrl: "https://example.com" });
+	});
+});

--- a/backend/services/application-plane/problem-service/src/__tests__/competitor-account-repository.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/competitor-account-repository.test.ts
@@ -36,12 +36,14 @@ describe("CompetitorAccountRepository", () => {
 				accountId: "123456789012",
 				region: "ap-northeast-1",
 				roleArn: "arn:aws:iam::123456789012:role/DeployRole",
+				externalId: "tc-event-1-123456789012",
 			});
 
 			expect(result.id).toBe("test-ulid-001");
 			expect(result.eventId).toBe("event-1");
 			expect(result.name).toBe("team01");
 			expect(result.accountId).toBe("123456789012");
+			expect(result.externalId).toBe("tc-event-1-123456789012");
 			expect(result.status).toBe("pending");
 			expect(mockSend).toHaveBeenCalledTimes(1);
 		});

--- a/backend/services/application-plane/problem-service/src/auth/auth-skip-roles.ts
+++ b/backend/services/application-plane/problem-service/src/auth/auth-skip-roles.ts
@@ -1,0 +1,14 @@
+const DEFAULT_AUTH_SKIP_ROLES = ["competitor"] as const;
+
+export function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return [...DEFAULT_AUTH_SKIP_ROLES];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : [...DEFAULT_AUTH_SKIP_ROLES];
+}

--- a/backend/services/application-plane/problem-service/src/auth/index.ts
+++ b/backend/services/application-plane/problem-service/src/auth/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { parseAuthSkipRoles } from './auth-skip-roles';
 
 /* v8 ignore start -- Production safety guard */
 if (process.env.AUTH_SKIP === '1' && process.env.NODE_ENV === 'production') {
@@ -22,6 +23,7 @@ const authSkipEnabled =
 // mock-access-token is only accepted when AUTH_SKIP=1 is explicitly set
 const localDevTokenEnabled = authSkipEnabled;
 const LOCAL_DEV_TOKEN = 'mock-access-token';
+const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== 'undefined') {
@@ -156,13 +158,13 @@ export interface AuthContext {
 
 /** AUTH_SKIP モードで使用するモックユーザーを生成（リクエスト間の状態共有を防止） */
 function createMockUser(): AuthenticatedUser {
-  return {
-    id: 'dev-user',
-    email: 'dev@localhost',
-    username: 'dev-user',
-    roles: [UserRole.PLATFORM_ADMIN, UserRole.COMPETITOR],
-    tenantId: 'dev-tenant',
-  };
+	return {
+		id: 'dev-user',
+		email: 'dev@localhost',
+		username: 'dev-user',
+		roles: authSkipRoles,
+		tenantId: 'dev-tenant',
+	};
 }
 
 /**

--- a/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
+++ b/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
@@ -283,6 +283,7 @@ function buildCredentials(account: CompetitorAccountWithMeta): CloudCredentials 
 		region: account.region,
 		accountId: account.accountId,
 		roleArn: account.roleArn,
+		externalId: account.externalId,
 		// accessKeyId / secretAccessKey は AssumeRole の場合不要
 		// STS SDK が roleArn を使って一時クレデンシャルを取得する
 	};

--- a/backend/services/application-plane/problem-service/src/providers/aws/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/aws/index.ts
@@ -4,6 +4,28 @@
  * AWS CloudFormation/SAM を使用したスタックデプロイ実装
  */
 
+import { readFile } from "node:fs/promises";
+import {
+	type Capability,
+	CloudFormationClient,
+	CreateStackCommand,
+	DeleteStackCommand,
+	DescribeStacksCommand,
+	DescribeStackResourcesCommand,
+	ListStacksCommand,
+	type StackStatus as CloudFormationStackStatus,
+	ValidateTemplateCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+	S3Client,
+	PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+	AssumeRoleCommand,
+	GetCallerIdentityCommand,
+	STSClient,
+} from "@aws-sdk/client-sts";
+import type { AwsCredentialIdentity } from "@aws-sdk/types";
 import type {
 	CloudCredentials,
 	CloudProvider,
@@ -223,6 +245,13 @@ export class AWSCloudProvider implements ICloudProvider {
 					: undefined,
 			};
 		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error.message.includes("does not exist") ||
+					error.message.includes("does not exist"))
+			) {
+				return null;
+			}
 			console.debug("[AWSCloudProvider] getStackStatus failed:", { stackName, error });
 			return null;
 		}
@@ -388,19 +417,8 @@ export class AWSCloudProvider implements ICloudProvider {
 	async getAccountInfo(credentials: CloudCredentials): Promise<AccountInfo> {
 		const stsResponse = await this.callSTS(credentials, "GetCallerIdentity");
 
-		// IAM エイリアスの取得を試みる
-		let alias: string | undefined;
-		try {
-			const iamResponse = await this.callIAM(credentials, "ListAccountAliases");
-			const aliases = iamResponse.AccountAliases as string[] | undefined;
-			alias = aliases?.[0];
-		} catch (error) {
-			console.debug("[AWSCloudProvider] IAM エイリアスの取得に失敗:", error);
-		}
-
 		return {
 			accountId: stsResponse.Account as string,
-			alias,
 			provider: "aws",
 		};
 	}
@@ -412,15 +430,21 @@ export class AWSCloudProvider implements ICloudProvider {
 	private async callSTS(
 		credentials: CloudCredentials,
 		action: string,
-		params?: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		// 実際の実装では AWS SDK を使用
-		// ここではモック実装
-		console.log(`[AWS STS] ${action}`, params);
-		return {
-			Account: credentials.accountId,
-			Arn: `arn:aws:iam::${credentials.accountId}:root`,
-		};
+		const client = await this.createSTSClient(credentials);
+
+		switch (action) {
+			case "GetCallerIdentity": {
+				const response = await client.send(new GetCallerIdentityCommand({}));
+				return {
+					Account: response.Account,
+					Arn: response.Arn,
+					UserId: response.UserId,
+				};
+			}
+			default:
+				throw new Error(`Unsupported STS action: ${action}`);
+		}
 	}
 
 	private async callCloudFormation(
@@ -429,29 +453,103 @@ export class AWSCloudProvider implements ICloudProvider {
 		action: string,
 		params: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		// 実際の実装では AWS SDK を使用
-		console.log(`[AWS CloudFormation] ${action} in ${region}`, params);
-		return {
-			StackId: `arn:aws:cloudformation:${region}:${credentials.accountId}:stack/${params.StackName}/xxx`,
-		};
+		const client = await this.createCloudFormationClient(credentials, region);
+
+		switch (action) {
+			case "CreateStack": {
+				const response = await client.send(
+					new CreateStackCommand({
+						StackName: params.StackName as string,
+						TemplateBody: params.TemplateBody as string,
+						Parameters: params.Parameters as {
+							ParameterKey: string;
+							ParameterValue: string;
+						}[],
+						Tags: params.Tags as { Key: string; Value: string }[],
+						Capabilities: params.Capabilities as Capability[],
+						TimeoutInMinutes: params.TimeoutInMinutes as number,
+						OnFailure: params.OnFailure as "DO_NOTHING" | "ROLLBACK" | "DELETE",
+						NotificationARNs: params.NotificationArns as string[] | undefined,
+					}),
+				);
+				return {
+					StackId: response.StackId,
+				};
+			}
+			case "DescribeStacks": {
+				const response = await client.send(
+					new DescribeStacksCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {
+					Stacks: response.Stacks,
+				};
+			}
+			case "DeleteStack": {
+				await client.send(
+					new DeleteStackCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {};
+			}
+			case "ValidateTemplate": {
+				await client.send(
+					new ValidateTemplateCommand({
+						TemplateBody: params.TemplateBody as string,
+					}),
+				);
+				return {};
+			}
+			case "ListStacks": {
+				const response = await client.send(
+					new ListStacksCommand({
+						StackStatusFilter: params.StackStatusFilter as
+							| CloudFormationStackStatus[]
+							| undefined,
+					}),
+				);
+				return {
+					StackSummaries: response.StackSummaries,
+				};
+			}
+			case "DescribeStackResources": {
+				const response = await client.send(
+					new DescribeStackResourcesCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {
+					StackResources: response.StackResources,
+				};
+			}
+			default:
+				throw new Error(`Unsupported CloudFormation action: ${action}`);
+		}
 	}
 
 	private async callS3(
-		_credentials: CloudCredentials,
+		credentials: CloudCredentials,
 		region: string,
 		action: string,
 		params: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		console.log(`[AWS S3] ${action} in ${region}`, params);
-		return {};
-	}
+		const client = await this.createS3Client(credentials, region);
 
-	private async callIAM(
-		_credentials: CloudCredentials,
-		action: string,
-	): Promise<Record<string, unknown>> {
-		console.log(`[AWS IAM] ${action}`);
-		return { AccountAliases: [] };
+		switch (action) {
+			case "PutObject":
+				await client.send(
+					new PutObjectCommand({
+						Bucket: params.Bucket as string,
+						Key: params.Key as string,
+						Body: params.Body as Buffer,
+					}),
+				);
+				return {};
+			default:
+				throw new Error(`Unsupported S3 action: ${action}`);
+		}
 	}
 
 	private buildParameters(
@@ -593,18 +691,68 @@ export class AWSCloudProvider implements ICloudProvider {
 	}
 
 	private async readFile(path: string): Promise<Buffer> {
-		// 実際の実装ではファイルを読み込む
-		console.log(`[AWS] Reading file from ${path}`);
-		return Buffer.from("");
+		return readFile(path);
 	}
 
 	private async listManagedStacks(
-		_credentials: CloudCredentials,
+		credentials: CloudCredentials,
 		tagFilter: Record<string, string>,
 	): Promise<{ StackName: string; StackId: string }[]> {
-		// 実際の実装ではタグでフィルタリングしたスタック一覧を返す
-		console.log(`[AWS] Listing managed stacks with tags:`, tagFilter);
-		return [];
+		const listed = await this.callCloudFormation(
+			credentials,
+			credentials.region,
+			"ListStacks",
+			{
+				StackStatusFilter: [
+					"CREATE_COMPLETE",
+					"UPDATE_COMPLETE",
+					"UPDATE_ROLLBACK_COMPLETE",
+					"ROLLBACK_COMPLETE",
+					"CREATE_FAILED",
+					"UPDATE_FAILED",
+				],
+			},
+		);
+
+		const summaries =
+			(listed.StackSummaries as
+				| { StackName?: string; StackId?: string }[]
+				| undefined) ?? [];
+
+		const managedStacks: { StackName: string; StackId: string }[] = [];
+
+		for (const summary of summaries) {
+			if (!summary.StackName || !summary.StackId) {
+				continue;
+			}
+
+			const described = await this.callCloudFormation(
+				credentials,
+				credentials.region,
+				"DescribeStacks",
+				{ StackName: summary.StackName },
+			);
+			const stack = (described.Stacks as Array<{
+				Tags?: { Key?: string; Value?: string }[];
+			}>)?.[0];
+			const tags = Object.fromEntries(
+				(stack?.Tags ?? [])
+					.filter((tag) => tag.Key && tag.Value)
+					.map((tag) => [tag.Key as string, tag.Value as string]),
+			);
+
+			const matches = Object.entries(tagFilter).every(
+				([key, value]) => tags[key] === value,
+			);
+			if (matches) {
+				managedStacks.push({
+					StackName: summary.StackName,
+					StackId: summary.StackId,
+				});
+			}
+		}
+
+		return managedStacks;
 	}
 
 	private shouldDeleteResource(
@@ -627,6 +775,84 @@ export class AWSCloudProvider implements ICloudProvider {
 
 	private sleep(ms: number): Promise<void> {
 		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	private buildBaseCredentials(
+		credentials: CloudCredentials,
+	): AwsCredentialIdentity | undefined {
+		if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+			return undefined;
+		}
+
+		return {
+			accessKeyId: credentials.accessKeyId,
+			secretAccessKey: credentials.secretAccessKey,
+			sessionToken: credentials.sessionToken,
+		};
+	}
+
+	private async resolveRuntimeCredentials(
+		credentials: CloudCredentials,
+	): Promise<AwsCredentialIdentity | undefined> {
+		if (!credentials.roleArn) {
+			return this.buildBaseCredentials(credentials);
+		}
+
+		const client = new STSClient({
+			region: credentials.region,
+			credentials: this.buildBaseCredentials(credentials),
+		});
+
+		const response = await client.send(
+			new AssumeRoleCommand({
+				RoleArn: credentials.roleArn,
+				RoleSessionName: this.buildRoleSessionName(credentials),
+				ExternalId: credentials.externalId,
+			}),
+		);
+
+		if (!response.Credentials) {
+			throw new Error("AssumeRole returned no credentials");
+		}
+
+		return {
+			accessKeyId: response.Credentials.AccessKeyId ?? "",
+			secretAccessKey: response.Credentials.SecretAccessKey ?? "",
+			sessionToken: response.Credentials.SessionToken,
+		};
+	}
+
+	private async createSTSClient(
+		credentials: CloudCredentials,
+	): Promise<STSClient> {
+		return new STSClient({
+			region: credentials.region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private async createCloudFormationClient(
+		credentials: CloudCredentials,
+		region: string,
+	): Promise<CloudFormationClient> {
+		return new CloudFormationClient({
+			region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private async createS3Client(
+		credentials: CloudCredentials,
+		region: string,
+	): Promise<S3Client> {
+		return new S3Client({
+			region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private buildRoleSessionName(credentials: CloudCredentials): string {
+		return `tenkacloud-${credentials.accountId}-${Date.now()}`.slice(0, 64);
 	}
 }
 

--- a/backend/services/application-plane/problem-service/src/repositories/competitor-account-repository.ts
+++ b/backend/services/application-plane/problem-service/src/repositories/competitor-account-repository.ts
@@ -34,13 +34,17 @@ interface CompetitorAccountItem {
 	accountId: string;
 	region: string;
 	roleArn?: string;
+	externalId?: string;
 	status: string;
 }
 
 const buildPK = (eventId: string) => `EVENT#${eventId}`;
 const buildSK = (accountId: string) => `COMPETITOR_ACCOUNT#${accountId}`;
 
-function toDomain(item: CompetitorAccountItem): CompetitorAccount & { eventId: string; roleArn?: string } {
+function toDomain(item: CompetitorAccountItem): CompetitorAccount & {
+	eventId: string;
+	roleArn?: string;
+} {
 	return {
 		id: item.id,
 		eventId: item.eventId,
@@ -49,11 +53,15 @@ function toDomain(item: CompetitorAccountItem): CompetitorAccount & { eventId: s
 		accountId: item.accountId,
 		region: item.region,
 		roleArn: item.roleArn,
+		externalId: item.externalId,
 		status: item.status as CompetitorAccount["status"],
 	};
 }
 
-export type CompetitorAccountWithMeta = CompetitorAccount & { eventId: string; roleArn?: string };
+export type CompetitorAccountWithMeta = CompetitorAccount & {
+	eventId: string;
+	roleArn?: string;
+};
 
 export interface CreateCompetitorAccountInput {
 	eventId: string;
@@ -62,6 +70,7 @@ export interface CreateCompetitorAccountInput {
 	accountId: string;
 	region: string;
 	roleArn?: string;
+	externalId?: string;
 }
 
 export class CompetitorAccountRepository {
@@ -86,6 +95,7 @@ export class CompetitorAccountRepository {
 			accountId: input.accountId,
 			region: input.region,
 			roleArn: input.roleArn,
+			externalId: input.externalId,
 			status: "pending",
 		};
 

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -2631,6 +2631,7 @@ function getAWSCredentialsFromEnv(
 		secretAccessKey,
 		sessionToken: overrides?.sessionToken || process.env.AWS_SESSION_TOKEN,
 		roleArn: overrides?.roleArn || process.env.AWS_ROLE_ARN,
+		externalId: overrides?.externalId || process.env.AWS_EXTERNAL_ID,
 		region,
 	};
 }
@@ -2707,6 +2708,7 @@ const deployProblemSchema = z.object({
 			sessionToken: z.string().optional(),
 			accountId: z.string().optional(),
 			roleArn: z.string().optional(),
+			externalId: z.string().optional(),
 		})
 		.optional()
 		.describe("AWS クレデンシャル（省略時は環境変数を使用）"),
@@ -2978,6 +2980,13 @@ adminRouter.get(
 const competitorAccountRepo = new CompetitorAccountRepository();
 const gamedayJobRepo = new GameDayDeploymentJobRepository();
 
+function buildCompetitorExternalId(eventId: string, accountId: string): string {
+	const sanitize = (value: string) =>
+		value.replace(/[^A-Za-z0-9+=,.@:/-]/g, "-");
+
+	return `tc-${sanitize(eventId)}-${sanitize(accountId)}`.slice(0, 122);
+}
+
 // チームアカウント登録
 adminRouter.post(
 	"/events/:eventId/competitor-accounts",
@@ -2999,6 +3008,7 @@ adminRouter.post(
 			accountId: z.string().min(1),
 			region: z.string().min(1),
 			roleArn: z.string().optional(),
+			externalId: z.string().min(1).max(122).optional(),
 		}),
 	),
 	async (c) => {
@@ -3013,6 +3023,11 @@ adminRouter.post(
 				accountId: data.accountId,
 				region: data.region,
 				roleArn: data.roleArn,
+				externalId:
+					data.roleArn && data.provider === "aws"
+						? (data.externalId ??
+							buildCompetitorExternalId(eventId, data.accountId))
+						: data.externalId,
 			});
 			return c.json(account, 201);
 		} catch (error) {

--- a/backend/services/application-plane/problem-service/src/types/index.ts
+++ b/backend/services/application-plane/problem-service/src/types/index.ts
@@ -26,6 +26,7 @@ export interface CloudCredentials {
 	secretAccessKey?: string;
 	sessionToken?: string;
 	roleArn?: string;
+	externalId?: string;
 	region: string;
 }
 
@@ -197,6 +198,7 @@ export interface CompetitorAccount {
 	provider: CloudProvider;
 	accountId: string;
 	region: string;
+	externalId?: string;
 	credentials?: CloudCredentials;
 	status: "pending" | "ready" | "in_use" | "cleanup" | "error";
 }

--- a/backend/services/control-plane/tenant-management/src/index.ts
+++ b/backend/services/control-plane/tenant-management/src/index.ts
@@ -94,31 +94,24 @@ app.get(
         tenantRepository.list({ limit: 100 }),
       ]);
 
-    // Count active tenants
-    const activeTenants = listResult.tenants.filter(
-      (t) => t.status === 'ACTIVE'
-    ).length;
+    let activeTenants = 0;
+    let failedCount = 0;
+    let inProgressCount = 0;
+    let completedCount = 0;
+    let pendingCount = 0;
+    for (const t of listResult.tenants) {
+      if (t.status === 'ACTIVE') activeTenants++;
+      if (t.provisioningStatus === 'FAILED') failedCount++;
+      else if (t.provisioningStatus === 'IN_PROGRESS') inProgressCount++;
+      else if (t.provisioningStatus === 'COMPLETED') completedCount++;
+      else if (t.provisioningStatus === 'PENDING') pendingCount++;
+    }
 
-    // Determine system status based on provisioning state
-    const failedCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'FAILED'
-    ).length;
-    const inProgressCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'IN_PROGRESS'
-    ).length;
-
-    // Calculate system health:
-    // - degraded: any tenant has failed provisioning
-    // - healthy: all tenants completed or pending/in-progress
     const systemStatus: 'healthy' | 'degraded' | 'down' =
       failedCount > 0 ? 'degraded' : 'healthy';
-
-    // Calculate uptime percentage based on successful provisioning
-    // (tenants not in FAILED state / total tenants) * 100
-    const successfulTenants = totalTenants - failedCount;
     const uptimePercentage =
       totalTenants > 0
-        ? Math.round((successfulTenants / totalTenants) * 100)
+        ? Math.round(((totalTenants - failedCount) / totalTenants) * 100)
         : 100;
 
       return c.json({
@@ -126,16 +119,11 @@ app.get(
         totalTenants,
         systemStatus,
         uptimePercentage,
-        // Additional context for debugging
         provisioningStats: {
-          completed: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'COMPLETED'
-          ).length,
+          completed: completedCount,
           inProgress: inProgressCount,
           failed: failedCount,
-          pending: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'PENDING'
-          ).length,
+          pending: pendingCount,
         },
       });
     } catch (error) {

--- a/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
+++ b/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
@@ -107,7 +107,7 @@ provisioningRoutes.post(
         applicationDeploymentStatus: 'FAILED',
         provisioningError: errorMessage,
       });
-      throw error;
+      return c.json(errorResponse('Failed to start provisioning', 500), 500);
     }
 
     await tenantRepository.update(tenant.id, {

--- a/docs/decisions/009-application-admin-isolation-and-aws-deployment-engine.md
+++ b/docs/decisions/009-application-admin-isolation-and-aws-deployment-engine.md
@@ -1,0 +1,39 @@
+# ADR-009: Application 管理者分離と AWS 問題デプロイメントエンジン
+
+- **Status**: Accepted
+- **Date**: 2026-04-12
+- **Deciders**: susumutomita
+
+## Context
+
+Application Plane では、ローカル開発時の `AUTH_SKIP` が常に管理者権限を持つ形になっており、参加者向け UI と管理者 UI の境界が崩れていた。これにより `/admin` 配下へ誰でも入れる状態になり、実際の権限モデルとローカル挙動が乖離していた。
+
+また、GameDay 問題のチーム配布は UI 上の導線は存在する一方で、AWS 連携は placeholder 実装に留まっていた。競技者 AWS アカウントへ安全に問題を配布するには、各アカウントの IAM Role を `ExternalId` 付きで引き受け、CloudFormation テンプレートを tenant/event/problem 単位で展開する実行系が必要だった。
+
+## Decision
+
+1. Application Plane の `AUTH_SKIP` デフォルトロールは `participant` とし、管理者権限は `AUTH_SKIP_ROLES` で明示的に付与する
+2. 管理者 UI、middleware、server API helper では共通ヘルパーで管理者判定を共有し、`admin` / `platform-admin` / `tenant-admin` / `organizer` のみを管理者とみなす
+3. backend services でも同様に `AUTH_SKIP` デフォルトロールを最小権限へ寄せ、参加者系 service は `participant`、problem-service は `competitor` をデフォルトにする
+4. 競技者アカウントには `externalId` を保持できるようにし、未指定時は `eventId` と account ID から安全な値を自動生成する
+5. AWS deployment engine は placeholder を廃止し、AWS SDK を使った実実装へ置き換える
+   - STS `AssumeRole` + `ExternalId`
+   - STS `GetCallerIdentity` による credential 検証
+   - CloudFormation `ValidateTemplate` / `CreateStack` / `DescribeStacks` / `DescribeStackResources` / `DeleteStack`
+   - S3 `PutObject`
+6. GameDay deployer は competitor account ごとに job を永続化し、stack 名・parameter・tag を組み立てて並列デプロイする
+
+## Consequences
+
+- **Good**: ローカル開発でも参加者と管理者の境界が壊れなくなる。UI の見え方と本番権限モデルが揃う。問題配布が console log ベースではなく、実際に AWS アカウントへ到達する経路になる。
+- **Bad**: ローカルで管理者画面を確認するには `AUTH_SKIP_ROLES` の明示が必要になる。競技者アカウント設定では `roleArn` と信頼ポリシーに加えて `ExternalId` の整合も必要になる。
+- **Tradeoff**: 開発初速は少し落ちるが、誤った権限前提やハリボテ deploy で機能が成立したように見える状態は防げる。
+
+## References
+
+- [apps/application-plane/auth.ts](../../apps/application-plane/auth.ts)
+- [apps/application-plane/lib/auth/roles.ts](../../apps/application-plane/lib/auth/roles.ts)
+- [apps/application-plane/proxy.ts](../../apps/application-plane/proxy.ts)
+- [backend/services/application-plane/problem-service/src/auth/index.ts](../../backend/services/application-plane/problem-service/src/auth/index.ts)
+- [backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts](../../backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts)
+- [backend/services/application-plane/problem-service/src/providers/aws/index.ts](../../backend/services/application-plane/problem-service/src/providers/aws/index.ts)


### PR DESCRIPTION
## What changed
- isolate Application Plane admin access so `AUTH_SKIP` defaults to participant privileges instead of admin
- centralize admin-role checks across auth, middleware, server API helpers, and layout navigation
- add `externalId` support for competitor AWS accounts and surface it in the admin deployment UI
- replace the placeholder AWS provider with real STS AssumeRole and CloudFormation/S3 execution paths
- document the decision in ADR-009

## Why
- local development was masking the real access model by letting any `AUTH_SKIP` user enter `/admin`
- GameDay team deployment looked available in the UI, but the backend AWS execution path was still a stub
- competitor-account deployments need External ID based role assumption to be defensible and automatable

## Impact
- participant users no longer see or reach Application Plane admin pages by default in local dev
- admin users can opt in locally with `AUTH_SKIP_ROLES`
- GameDay problem deployments can validate credentials with STS and deploy CloudFormation stacks into competitor accounts
- competitor accounts can now persist and display an External ID used for trust policy configuration

## Validation
- `make before-commit`
- `agent-browser` verified `http://localhost:13001/dashboard` does not show the admin nav by default
- `agent-browser` verified `http://localhost:13001/admin` redirects to `http://localhost:13001/dashboard` for the default local participant session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for tenant-admin, platform-admin, and organizer admin roles alongside existing admin role
  * Introduced external ID field for AWS competitor accounts with automatic ID generation
  * AWS credential validation now uses STS role assumption and caller identity verification

* **Bug Fixes**
  * Fixed voting display issue where candidates with zero votes could incorrectly appear as current leader

* **Chores**
  * Updated default authentication roles configuration for improved security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->