### PR TITLE
docs: add architecture harness and one-pass invariants

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+bun scripts/architecture-harness.ts --staged --fail-on=error
 bun scripts/ai-improvement-loop.ts --staged --fail-on=high
 make before-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,18 @@ make start      # 全サービス起動（Docker + UI + Backend 11 サービス�
 ## 品質ゲート
 
 ```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error
 make before-commit   # lint, format, typecheck, test (99％+ coverage), build
 ```
 
 **これが通らない限りタスクは未完了。** 失敗したらコードを修正する（設定ファイルを変えない）。
 
+アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) です。`Codex` と `Claude Code` のどちらでも、この script を通らない変更は未完了です。
+
 大きい変更や新機能の前後では、次も実行する。
 
 ```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error
 bun scripts/ai-improvement-loop.ts --write --fail-on=high
 ```
 
@@ -123,6 +127,8 @@ vi.mock("@tenkacloud/dynamodb", () => ({
 ### ハーネス優先
 
 - 先に壊れるテストや検出ルールを書く
+- 先に [`docs/architecture/harness.md`](./docs/architecture/harness.md) の invariant を確認する
+- `tenant 作成 -> provisioning -> app endpoint -> event -> competitor account -> problem deploy -> participant join -> attack / defense / vote / aws-console` の one-pass を完了条件にする
 - 1 テストケースに `expect` を詰め込みすぎない（アサーションルーレット禁止）
 - route handler で fallback を重複実装しない
 - UI から直接 `fetch` や `process.env.*API_URL` を読まない

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@
 
 タスク完了前に必ず `make before-commit` を実行。lint・format・typecheck・test（カバレッジ 99％+）・build がすべて通るまで未完了。失敗したら原因を特定してコードを修正する（設定ファイルを変更しない）。
 
+その前に `bun scripts/architecture-harness.ts --staged --fail-on=error` を通す。アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) で、これは `Codex` と `Claude Code` の両方に共通です。
+
 ## コマンド体系
 
 ```bash
@@ -41,6 +43,12 @@ make help             # 全コマンド一覧
 ### PR
 
 小さい意味のある単位。PR 作成まで含めてタスク完了。`make before-commit` 通過が前提。
+
+### ハーネス優先
+
+- 仕様より先に [`docs/architecture/harness.md`](./docs/architecture/harness.md) の invariant を確認する
+- `tenant 作成 -> provisioning -> tenant app endpoint -> event 作成 -> competitor account 登録 -> problem deploy -> participant join -> attack / defense / vote / aws-console` の one-pass を完了条件にする
+- `local` と `AWS` の両方の受け入れ条件がない変更は未完了として扱う
 
 ## 禁止事項
 
@@ -84,5 +92,6 @@ DynamoDB シングルテーブル設計。PK/SK にテナント ID を含めて�
 - デザインシステム: [Cloudscape](https://cloudscape.design/components/)（全 UI コンポーネントはここから選択）
 - フロントエンドデザイン: `/skill frontend-design`
 - スペック・仕様書: `/skill spec`
+- アーキテクチャハーネス: `docs/architecture/harness.md`
 - アーキテクチャ決定記録: `docs/decisions/`
 - エージェント設定: @AGENTS.md

--- a/apps/application-plane/__tests__/auth.test.ts
+++ b/apps/application-plane/__tests__/auth.test.ts
@@ -36,6 +36,7 @@ describe('Auth0 認証設定', () => {
     process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
     process.env.AUTH0_ISSUER = 'https://test.auth0.com';
     delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
   });
 
   describe('AUTH_SKIP モード', () => {
@@ -56,11 +57,21 @@ describe('Auth0 認証設定', () => {
       expect(session).toBeDefined();
       expect(session?.user?.name).toBe('Dev User');
       expect(session?.user?.email).toBe('dev@example.com');
-      expect(session?.roles).toEqual(['admin', 'participant']);
+      expect(session?.roles).toEqual(['participant']);
       expect(session?.tenantId).toBe('dev-tenant');
       expect(session?.teamId).toBe('team-alpha');
       expect(session?.accessToken).toBe('mock-access-token');
       expect(session?.idToken).toBe('mock-id-token');
+    });
+
+    it('AUTH_SKIP_ROLES を指定した場合、そのロール構成を使うべき', async () => {
+      process.env.AUTH_SKIP = '1';
+      process.env.AUTH_SKIP_ROLES = 'tenant-admin,participant';
+
+      const auth = await import('../auth');
+      const session = await auth.auth();
+
+      expect(session?.roles).toEqual(['tenant-admin', 'participant']);
     });
 
     it('AUTH_SKIP=1 の場合、Auth0 環境変数がなくてもエラーにならないべき', async () => {

--- a/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/apps/application-plane/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -38,6 +38,7 @@ interface CompetitorAccount {
   accountId: string;
   region: string;
   roleArn?: string;
+  externalId?: string;
   status: string;
 }
 
@@ -227,6 +228,7 @@ export default function GameDayDeploymentsPage() {
     accountId: '',
     region: 'ap-northeast-1',
     roleArn: '',
+    externalId: '',
   });
   const [addingAccount, setAddingAccount] = useState(false);
   const [addAccountError, setAddAccountError] = useState('');
@@ -410,6 +412,7 @@ export default function GameDayDeploymentsPage() {
         accountId: newAccount.accountId,
         region: newAccount.region,
         roleArn: newAccount.roleArn || undefined,
+        externalId: newAccount.externalId || undefined,
       });
       setShowAddModal(false);
       setNewAccount({
@@ -417,6 +420,7 @@ export default function GameDayDeploymentsPage() {
         accountId: '',
         region: 'ap-northeast-1',
         roleArn: '',
+        externalId: '',
       });
       await refreshAccounts();
     } catch (e) {
@@ -531,6 +535,11 @@ export default function GameDayDeploymentsPage() {
             id: 'roleArn',
             header: 'Role ARN',
             cell: (item) => item.roleArn ?? '—',
+          },
+          {
+            id: 'externalId',
+            header: 'External ID',
+            cell: (item) => item.externalId ?? '—',
           },
           {
             id: 'actions',
@@ -723,6 +732,21 @@ export default function GameDayDeploymentsPage() {
                   setNewAccount((prev) => ({ ...prev, roleArn: detail.value }))
                 }
                 placeholder="arn:aws:iam::123456789012:role/TenkaCloudDeployRole"
+              />
+            </FormField>
+            <FormField
+              label="External ID"
+              description="未入力時は event / account から安全な値を自動生成します"
+            >
+              <Input
+                value={newAccount.externalId}
+                onChange={({ detail }) =>
+                  setNewAccount((prev) => ({
+                    ...prev,
+                    externalId: detail.value,
+                  }))
+                }
+                placeholder="tc-<eventId>-<accountId>"
               />
             </FormField>
           </SpaceBetween>

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/__tests__/layout.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/__tests__/layout.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import GamedayLayout from '../layout';
 
@@ -25,6 +24,7 @@ vi.mock('@/lib/hooks/use-gameday-session', () => ({
 vi.mock('@/lib/api/gameday', () => ({
   getParticipantGameStatus: vi.fn().mockResolvedValue(null),
   getTeamDashboard: vi.fn().mockResolvedValue(null),
+  getLeaderboard: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/components/notifications/notification-panel', () => ({
@@ -45,35 +45,34 @@ describe('GamedayLayout', () => {
     });
   });
 
-  it('ヘッダーが通常ページと同じスタイルを持つべき', async () => {
+  it('トップナビゲーションコンテナが表示されるべき', async () => {
     render(<GamedayLayout>content</GamedayLayout>);
     await waitFor(() => {
-      const header = document.querySelector('#gameday-top-nav header');
-      expect(header).toBeInTheDocument();
-      expect(header).toHaveClass('border-hn-accent/40');
+      expect(document.querySelector('#gameday-top-nav')).toBeInTheDocument();
     });
   });
 
   it('スコアとランクが表示されるべき', async () => {
     render(<GamedayLayout>content</GamedayLayout>);
     await waitFor(() => {
-      expect(screen.getByText('Score')).toBeInTheDocument();
-      expect(screen.getByText('Rank')).toBeInTheDocument();
+      expect(screen.getAllByText(/Score: /).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(/Rank: /).length).toBeGreaterThanOrEqual(1);
     });
   });
 
   it('チーム名が表示されるべき', async () => {
     render(<GamedayLayout>content</GamedayLayout>);
     await waitFor(() => {
-      expect(screen.getByText('TeamAlpha')).toBeInTheDocument();
+      expect(screen.getAllByText('TeamAlpha').length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  it('JA/EN 言語切り替えが表示されるべき', async () => {
+  it('現在の言語が表示されるべき', async () => {
     render(<GamedayLayout>content</GamedayLayout>);
     await waitFor(() => {
-      expect(screen.getByText('JA')).toBeInTheDocument();
-      expect(screen.getByText('EN')).toBeInTheDocument();
+      // locale.toUpperCase() is shown as the dropdown trigger (JA or EN)
+      const localeItems = screen.getAllByText(/^(JA|EN)$/);
+      expect(localeItems.length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -1,8 +1,7 @@
 /**
  * GameDay Layout
  *
- * Cloudscape Design System — AWS GameDay 風 AppLayout + SideNavigation
- * カスタムヘッダーに Score/Rank/Team 表示
+ * Cloudscape Design System — TopNavigation + AppLayout + SideNavigation
  */
 
 'use client';
@@ -10,8 +9,8 @@
 import AppLayout from '@cloudscape-design/components/app-layout';
 import SideNavigation from '@cloudscape-design/components/side-navigation';
 import type { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
 import '@cloudscape-design/global-styles/index.css';
-import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useState } from 'react';
@@ -38,9 +37,13 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
   const [score, setScore] = useState<number | undefined>();
   const [rank, setRank] = useState<number | undefined>();
   const [awsConsoleLoading, setAwsConsoleLoading] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   const basePath = `/gameday/${eventId}`;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const fetchStatus = useCallback(async () => {
     if (!eventId || !teamId) return;
@@ -168,172 +171,111 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
       : `${t('gameday.rank')}: --`;
 
   return (
-    <>
-      <div id="gameday-top-nav">
-        <header className="sticky top-0 z-50 border-b-2 border-hn-accent/40 bg-surface-3/95 shadow-md backdrop-blur-sm">
-          <div className="mx-auto max-w-[1600px] px-4 sm:px-6 lg:px-8">
-            <div className="flex min-h-16 items-center gap-4 py-3">
-              <Link
-                href={basePath}
-                className="flex shrink-0 items-center space-x-3"
-                onClick={(e) => {
+    <div className="awsui-dark-mode">
+      <div id="gameday-top-nav" style={{ position: 'relative', minHeight: 72 }}>
+        {mounted ? (
+          <>
+            <TopNavigation
+              identity={{
+                href: basePath,
+                title: 'TenkaCloud',
+                onFollow: (e) => {
                   e.preventDefault();
                   router.push(basePath);
-                }}
-              >
-                <div className="w-8 h-8 bg-hn-accent rounded-lg flex items-center justify-center shadow-brutal-sm">
-                  <span className="text-surface-0 font-black text-lg">T</span>
-                </div>
-                <span className="font-bold text-xl text-text-primary">
-                  TenkaCloud
-                </span>
-                <span className="hidden text-sm font-medium text-text-secondary md:block">
-                  {t('gameday.title')}
-                </span>
-              </Link>
-
-              <div className="hidden min-w-0 flex-1 items-center gap-2 lg:flex">
-                <span className="rounded-full border border-border bg-surface-2 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-text-secondary">
-                  Incident Drill
-                </span>
-                {gameState && (
-                  <span
-                    className={`rounded-full px-3 py-1 text-xs font-bold ${gameState.isRunning ? 'bg-emerald-500 text-white' : 'bg-surface-2 text-text-secondary'}`}
-                  >
-                    {gameState.isRunning
-                      ? t('gameday.live')
-                      : t('gameday.stopped')}
-                  </span>
-                )}
-                {gameState?.scoreWeight === 'high' && (
-                  <span className="rounded-full bg-hn-accent px-3 py-1 text-xs font-bold text-white">
-                    2x SCORE
-                  </span>
-                )}
-                <div className="grid min-w-[220px] grid-cols-2 gap-2">
-                  <div className="rounded-2xl border border-border bg-surface-2 px-3 py-2">
-                    <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted">
-                      {t('gameday.score')}
-                    </div>
-                    <div className="text-sm font-semibold text-text-primary">
-                      {scoreDisplay.replace(`${t('gameday.score')}: `, '')}
-                    </div>
-                  </div>
-                  <div className="rounded-2xl border border-border bg-surface-2 px-3 py-2">
-                    <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted">
-                      {t('gameday.rank')}
-                    </div>
-                    <div className="text-sm font-semibold text-text-primary">
-                      {rankDisplay.replace(`${t('gameday.rank')}: `, '')}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="ml-auto flex items-center gap-3">
-                <NotificationPanel />
-
-                <div className="hidden items-center gap-2 rounded-full border border-border bg-surface-2 px-3 py-1 sm:flex">
-                  <button
-                    type="button"
-                    className={`text-sm ${locale === 'ja' ? 'text-text-primary' : 'text-text-muted'}`}
-                    onClick={() => setLocale('ja')}
-                  >
-                    JA
-                  </button>
-                  <span className="text-text-muted">/</span>
-                  <button
-                    type="button"
-                    className={`text-sm ${locale === 'en' ? 'text-text-primary' : 'text-text-muted'}`}
-                    onClick={() => setLocale('en')}
-                  >
-                    EN
-                  </button>
-                </div>
-
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setIsMenuOpen(!isMenuOpen)}
-                    className="flex items-center space-x-2 rounded-full border border-border bg-surface-2 px-2 py-1.5 text-text-secondary transition-colors hover:text-text-primary"
-                    aria-expanded={isMenuOpen}
-                    aria-haspopup="true"
-                  >
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-hn-accent text-surface-0 font-medium">
-                      {(teamName || teamId || 'T').charAt(0).toUpperCase()}
-                    </div>
-                    <span className="hidden text-sm font-medium sm:block">
-                      {teamName || teamId || 'Team'}
-                    </span>
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </button>
-
-                  {isMenuOpen && (
-                    <div className="absolute right-0 z-50 mt-2 w-48 rounded-lg border border-border bg-surface-elevated py-1 shadow-lg">
-                      <Link
-                        href="/events"
-                        className="block px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
-                        onClick={() => setIsMenuOpen(false)}
-                      >
-                        {t('gameday.events')}
-                      </Link>
-                      <Link
-                        href={`/events/${eventId}`}
-                        className="block px-4 py-2 text-sm text-text-secondary hover:bg-surface-2 hover:text-text-primary transition-colors"
-                        onClick={() => setIsMenuOpen(false)}
-                      >
-                        {t('gameday.eventDetail')}
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        </header>
-      </div>
-      <div className="awsui-dark-mode">
-        <AppLayout
-          navigation={
-            <SideNavigation
-              header={{ text: t('gameday.title'), href: basePath }}
-              activeHref={activeHref}
-              items={navItems}
-              onFollow={(event) => {
-                event.preventDefault();
-                if (event.detail.href === `${basePath}/aws-console`) {
-                  openAwsConsole();
-                } else if (!event.detail.external) {
-                  router.push(event.detail.href);
-                }
+                },
+              }}
+              utilities={[
+                {
+                  type: 'button' as const,
+                  text: scoreDisplay,
+                  disableUtilityCollapse: true,
+                },
+                {
+                  type: 'button' as const,
+                  text: rankDisplay,
+                  disableUtilityCollapse: true,
+                },
+                ...(gameState?.isRunning
+                  ? [
+                      {
+                        type: 'button' as const,
+                        text: t('gameday.live'),
+                        disableUtilityCollapse: true,
+                      },
+                    ]
+                  : []),
+                {
+                  type: 'menu-dropdown' as const,
+                  text: locale.toUpperCase(),
+                  ariaLabel:
+                    locale === 'ja' ? '言語切り替え' : 'Switch language',
+                  items: [
+                    { id: 'ja', text: 'JA' },
+                    { id: 'en', text: 'EN' },
+                  ],
+                  onItemClick: (e) => setLocale(e.detail.id as 'ja' | 'en'),
+                },
+                {
+                  type: 'menu-dropdown' as const,
+                  text: teamName || teamId || 'Team',
+                  iconName: 'user-profile' as const,
+                  items: [
+                    { id: 'events', text: t('gameday.events') },
+                    { id: 'event-detail', text: t('gameday.eventDetail') },
+                  ],
+                  onItemClick: (e) => {
+                    if (e.detail.id === 'events') router.push('/events');
+                    if (e.detail.id === 'event-detail')
+                      router.push(`/events/${eventId}`);
+                  },
+                },
+              ]}
+              i18nStrings={{
+                overflowMenuTriggerText: 'その他',
+                overflowMenuTitleText: 'すべて',
               }}
             />
-          }
-          toolsHide
-          content={children}
-          headerSelector="#gameday-top-nav"
-          ariaLabels={{
-            navigation: t('gameday.menu'),
-            navigationClose:
-              locale === 'ja' ? 'ナビゲーションを閉じる' : 'Close navigation',
-            navigationToggle:
-              locale === 'ja' ? 'ナビゲーションを開く' : 'Open navigation',
-          }}
-        />
+            <div
+              style={{
+                position: 'absolute',
+                right: '200px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                zIndex: 1000,
+              }}
+            >
+              <NotificationPanel />
+            </div>
+          </>
+        ) : null}
       </div>
-    </>
+      <AppLayout
+        navigation={
+          <SideNavigation
+            header={{ text: t('gameday.title'), href: basePath }}
+            activeHref={activeHref}
+            items={navItems}
+            onFollow={(event) => {
+              event.preventDefault();
+              if (event.detail.href === `${basePath}/aws-console`) {
+                openAwsConsole();
+              } else if (!event.detail.external) {
+                router.push(event.detail.href);
+              }
+            }}
+          />
+        }
+        toolsHide
+        content={children}
+        headerSelector="#gameday-top-nav"
+        ariaLabels={{
+          navigation: t('gameday.menu'),
+          navigationClose:
+            locale === 'ja' ? 'ナビゲーションを閉じる' : 'Close navigation',
+          navigationToggle:
+            locale === 'ja' ? 'ナビゲーションを開く' : 'Open navigation',
+        }}
+      />
+    </div>
   );
 }

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -103,7 +103,11 @@ export default function VotePage() {
   );
 
   const totalVotes = votes.length;
-  const leadingCandidate = voteCandidates[0] ?? null;
+  const leadingCandidate =
+    voteCandidates[0]?.votes > 0 ? voteCandidates[0] : null;
+  const votedForTeam = votedTeamId
+    ? (voteCandidates.find((team) => team.teamId === votedTeamId) ?? null)
+    : null;
 
   if (loading) {
     return (
@@ -217,8 +221,8 @@ export default function VotePage() {
               </div>
               <div className="text-emerald-200/80">
                 {locale === 'ja'
-                  ? `投票先: ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`
-                  : `Voted for ${voteCandidates.find((team) => team.teamId === votedTeamId)?.teamName ?? votedTeamId}`}
+                  ? `投票先: ${votedForTeam?.teamName ?? votedTeamId}`
+                  : `Voted for ${votedForTeam?.teamName ?? votedTeamId}`}
               </div>
             </div>
           </div>

--- a/apps/application-plane/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/apps/application-plane/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -31,6 +31,7 @@ describe('NextAuth route handler', () => {
     vi.clearAllMocks();
     vi.resetModules();
     delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
     delete process.env.AUTH0_CLIENT_ID;
     delete process.env.AUTH0_CLIENT_SECRET;
     delete process.env.AUTH0_ISSUER;
@@ -52,7 +53,7 @@ describe('NextAuth route handler', () => {
       expect(body.user.email).toBe('dev@example.com');
       expect(body.accessToken).toBe('mock-access-token');
       expect(body.idToken).toBe('mock-id-token');
-      expect(body.roles).toEqual(['admin', 'participant']);
+      expect(body.roles).toEqual(['participant']);
       expect(body.tenantId).toBe('dev-tenant');
       expect(body.teamId).toBe('team-alpha');
       // handlers.GET should NOT be called for session path

--- a/apps/application-plane/auth.ts
+++ b/apps/application-plane/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import type { Session } from 'next-auth';
 import Auth0 from 'next-auth/providers/auth0';
 import { isAuthSkipEnabled } from '@/lib/auth/is-auth-skip-enabled';
+import { parseAuthSkipRoles } from '@/lib/auth/roles';
 
 const getEnv = (key: string) => process.env[key];
 // During `next build`, NEXT_PHASE is set to 'phase-production-build'.
@@ -18,6 +19,7 @@ try {
 }
 const useStubAuth =
   authSkipEnabled || (isBuildPhase && process.env.AUTH_SKIP === '1');
+const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /**
  * モックセッション（AUTH_SKIP=1 の場合に使用）
@@ -34,7 +36,7 @@ const mockSession: Session = {
   expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
   accessToken: 'mock-access-token',
   idToken: 'mock-id-token',
-  roles: ['admin', 'participant'],
+  roles: authSkipRoles,
   tenantId: 'dev-tenant',
   teamId: 'team-alpha',
 };

--- a/apps/application-plane/components/layout/page-layout.tsx
+++ b/apps/application-plane/components/layout/page-layout.tsx
@@ -31,6 +31,7 @@ import { useRouter } from 'next/navigation';
 import { signOut } from 'next-auth/react';
 import { useSession } from 'next-auth/react';
 import { type ReactNode, useEffect, useState } from 'react';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
 
 export interface BreadcrumbItem {
   text: string;
@@ -107,7 +108,7 @@ export function PageLayout({
                 },
                 ...(session
                   ? [
-                      ...(session.roles?.includes('admin')
+                      ...(hasApplicationAdminRole(session)
                         ? [
                             {
                               type: 'button' as const,

--- a/apps/application-plane/lib/api/__tests__/server.test.ts
+++ b/apps/application-plane/lib/api/__tests__/server.test.ts
@@ -137,6 +137,20 @@ describe('Server API Utilities', () => {
       expect(result).toEqual(session);
     });
 
+    it('tenant-admin ロールも管理者として扱うべき', async () => {
+      const session: Session = {
+        user: { name: 'Tenant Admin', email: 'tenant-admin@example.com' },
+        expires: new Date().toISOString(),
+        roles: ['tenant-admin'],
+      };
+      mockAuth.mockResolvedValue(session);
+
+      const { getAdminSession } = await import('../server');
+      const result = await getAdminSession();
+
+      expect(result).toEqual(session);
+    });
+
     it('roles が undefined の場合は null を返すべき', async () => {
       mockAuth.mockResolvedValue({
         user: { name: 'User', email: 'user@example.com' },

--- a/apps/application-plane/lib/api/admin-types.ts
+++ b/apps/application-plane/lib/api/admin-types.ts
@@ -438,6 +438,7 @@ export interface DeployProblemRequest {
     sessionToken?: string;
     accountId?: string;
     roleArn?: string;
+    externalId?: string;
   };
 }
 

--- a/apps/application-plane/lib/api/server.ts
+++ b/apps/application-plane/lib/api/server.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse } from 'next/server';
 import { auth, authSkipEnabled } from '@/auth';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
 import { getProblemServiceUrl } from '@/lib/api/backend-urls';
 
 const MOCK_ACCESS_TOKEN = 'mock-access-token';
@@ -63,8 +64,7 @@ export async function getAdminSession() {
     return null;
   }
 
-  const hasAdminRole = session.roles?.includes('admin') ?? false;
-  if (!hasAdminRole) {
+  if (!hasApplicationAdminRole(session)) {
     return null;
   }
 

--- a/apps/application-plane/lib/auth/__tests__/roles.test.ts
+++ b/apps/application-plane/lib/auth/__tests__/roles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { hasApplicationAdminRole, parseAuthSkipRoles } from '../roles';
+
+describe('auth role helpers', () => {
+  describe('parseAuthSkipRoles', () => {
+    it('未指定時は participant のみを返すべき', () => {
+      expect(parseAuthSkipRoles()).toEqual(['participant']);
+    });
+
+    it('空白だけの指定は participant にフォールバックすべき', () => {
+      expect(parseAuthSkipRoles(' ,  , ')).toEqual(['participant']);
+    });
+
+    it('カンマ区切りのロールを正規化して返すべき', () => {
+      expect(parseAuthSkipRoles(' tenant-admin , participant ')).toEqual([
+        'tenant-admin',
+        'participant',
+      ]);
+    });
+  });
+
+  describe('hasApplicationAdminRole', () => {
+    it('tenant-admin を管理者として扱うべき', () => {
+      expect(hasApplicationAdminRole(['tenant-admin'])).toBe(true);
+    });
+
+    it('participant 単独は管理者として扱わないべき', () => {
+      expect(hasApplicationAdminRole(['participant'])).toBe(false);
+    });
+  });
+});

--- a/apps/application-plane/lib/auth/roles.ts
+++ b/apps/application-plane/lib/auth/roles.ts
@@ -1,0 +1,35 @@
+import type { Session } from 'next-auth';
+
+const APPLICATION_ADMIN_ROLES = [
+  'admin',
+  'platform-admin',
+  'tenant-admin',
+  'organizer',
+] as const;
+
+export function parseAuthSkipRoles(envValue?: string): string[] {
+  if (!envValue) {
+    return ['participant'];
+  }
+
+  const roles = envValue
+    .split(',')
+    .map((role) => role.trim())
+    .filter(Boolean);
+
+  return roles.length > 0 ? roles : ['participant'];
+}
+
+export function hasApplicationAdminRole(
+  sessionOrRoles: Session | string[] | null | undefined,
+): boolean {
+  const roles = Array.isArray(sessionOrRoles)
+    ? sessionOrRoles
+    : sessionOrRoles?.roles;
+
+  if (!roles || roles.length === 0) {
+    return false;
+  }
+
+  return APPLICATION_ADMIN_ROLES.some((role) => roles.includes(role));
+}

--- a/apps/application-plane/lib/tenant/__tests__/middleware.test.ts
+++ b/apps/application-plane/lib/tenant/__tests__/middleware.test.ts
@@ -121,6 +121,21 @@ describe('Middleware', () => {
       expect(response.status).toBe(200);
     });
 
+    it('tenant-admin ロールを持つユーザーも /admin にアクセス可能にすべき', async () => {
+      mockAuth.mockResolvedValue({
+        user: { name: 'Tenant Admin', email: 'tenant-admin@example.com' },
+        expires: new Date(Date.now() + 86400000).toISOString(),
+        roles: ['tenant-admin'],
+        tenantId: 'acme',
+      });
+      mockGetTenantSlugFromUrl.mockReturnValue('acme');
+
+      const req = createMockRequest('http://localhost:13001/admin');
+      const response = await middleware(req);
+
+      expect(response.status).toBe(200);
+    });
+
     it('participant ロールのみのユーザーは /admin から /dashboard にリダイレクトすべき', async () => {
       mockAuth.mockResolvedValue({
         user: { name: 'Participant User', email: 'participant@example.com' },

--- a/apps/application-plane/proxy.ts
+++ b/apps/application-plane/proxy.ts
@@ -8,10 +8,8 @@
 
 import { NextResponse, type NextRequest } from 'next/server';
 import { auth } from '@/auth';
-import {
-  getTenantSlugFromUrl,
-  buildApplicationPlaneUrl,
-} from '@/lib/tenant/identification';
+import { hasApplicationAdminRole } from '@/lib/auth/roles';
+import { getTenantSlugFromUrl } from '@/lib/tenant/identification';
 
 /**
  * 公開パス（認証不要）
@@ -67,8 +65,7 @@ async function handleAuth(
 
   // 管理者パスへのアクセス権限チェック
   if (isAdminPath(pathname)) {
-    const hasAdminRole = roles.includes('admin');
-    if (!hasAdminRole) {
+    if (!hasApplicationAdminRole(roles)) {
       // 権限なし → /dashboard へリダイレクト
       const dashboardUrl = new URL('/dashboard', req.url);
       return NextResponse.redirect(dashboardUrl);

--- a/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
@@ -27,6 +27,7 @@ describe("authMiddleware", () => {
 		vi.clearAllMocks();
 		vi.resetModules();
 		delete process.env.AUTH_SKIP;
+		delete process.env.AUTH_SKIP_ROLES;
 		delete process.env.JWKS_URI;
 		delete process.env.JWT_ISSUER;
 		delete process.env.JWT_AUDIENCE;
@@ -48,7 +49,7 @@ describe("authMiddleware", () => {
 			const body = await res.json();
 			expect(body.userId).toBe("dev-user");
 			expect(body.tenantId).toBe("dev-tenant");
-			expect(body.roles).toEqual(["admin", "participant"]);
+			expect(body.roles).toEqual(["participant"]);
 		});
 
 		it("AUTH_SKIP モードで Authorization ヘッダーなしでもアクセスできるべき", async () => {
@@ -63,6 +64,22 @@ describe("authMiddleware", () => {
 			// No Authorization header
 			const res = await app.request("/test");
 			expect(res.status).toBe(StatusCodes.OK);
+		});
+
+		it("AUTH_SKIP_ROLES で tenant-admin を付与できるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.AUTH_SKIP_ROLES = "tenant-admin,participant";
+
+			const { authMiddleware } = await import("./auth");
+
+			const app = new Hono();
+			app.use("/*", authMiddleware);
+			app.get("/test", (c) => c.json(c.get("auth")));
+
+			const res = await app.request("/test");
+			const body = await res.json();
+
+			expect(body.roles).toEqual(["tenant-admin", "participant"]);
 		});
 	});
 

--- a/backend/services/application-plane/gameday-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth.ts
@@ -24,6 +24,19 @@ const authSkipEnabled =
 	process.env.AUTH_SKIP === "1" &&
 	process.env.NODE_ENV !== "production";
 
+function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return ["participant"];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : ["participant"];
+}
+
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== "undefined") {
 	console.warn(
@@ -38,7 +51,7 @@ if (authSkipEnabled && typeof console !== "undefined") {
 const mockAuth: AuthContext = {
 	userId: "dev-user",
 	tenantId: "dev-tenant",
-	roles: ["admin", "participant"],
+	roles: parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES),
 };
 
 const JWKS_URI =
@@ -130,7 +143,12 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 
 export const requireAdmin = createMiddleware(async (c, next) => {
 	const auth = c.get("auth");
-	if (!auth.roles.includes("admin")) {
+	if (
+		!auth.roles.includes("admin") &&
+		!auth.roles.includes("platform-admin") &&
+		!auth.roles.includes("tenant-admin") &&
+		!auth.roles.includes("organizer")
+	) {
 		return c.json({ error: "管理者権限が必要です" }, StatusCodes.FORBIDDEN);
 	}
 	await next();

--- a/backend/services/application-plane/leaderboard-service/src/middleware/auth.test.ts
+++ b/backend/services/application-plane/leaderboard-service/src/middleware/auth.test.ts
@@ -22,6 +22,7 @@ describe("認証ミドルウェア", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		delete process.env.AUTH_SKIP;
+		delete process.env.AUTH_SKIP_ROLES;
 		delete process.env.NODE_ENV;
 		app = new Hono();
 		app.use("/*", authMiddleware);
@@ -196,8 +197,20 @@ describe("認証ミドルウェア", () => {
 		expect(body.auth).toEqual({
 			userId: "dev-user",
 			tenantId: "dev-tenant",
-			roles: ["admin", "participant"],
+			roles: ["participant"],
 		});
+	});
+
+	it("AUTH_SKIP_ROLES がある場合はそのロールを返すべき", async () => {
+		process.env.AUTH_SKIP = "1";
+		process.env.AUTH_SKIP_ROLES = "tenant-admin,participant";
+		process.env.NODE_ENV = "development";
+
+		const res = await app.request("/test");
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.auth.roles).toEqual(["tenant-admin", "participant"]);
 	});
 
 	it("AUTH_SKIP=1 でも本番環境では認証をスキップしないべき", async () => {

--- a/backend/services/application-plane/leaderboard-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/leaderboard-service/src/middleware/auth.ts
@@ -21,6 +21,19 @@ const ISSUER =
 
 let jwks: jose.JWTVerifyGetKey | null = null;
 
+function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return ["participant"];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : ["participant"];
+}
+
 async function getJWKS() {
 	if (!jwks) {
 		jwks = jose.createRemoteJWKSet(new URL(JWKS_URI));
@@ -36,7 +49,7 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 		c.set("auth", {
 			userId: "dev-user",
 			tenantId: "dev-tenant",
-			roles: ["admin", "participant"],
+			roles: parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES),
 		});
 		return next();
 	}

--- a/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
@@ -12,6 +12,7 @@ describe("auth モジュール", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		process.env = { ...originalEnv };
+		delete process.env.AUTH_SKIP_ROLES;
 	});
 
 	afterEach(() => {
@@ -68,6 +69,7 @@ describe("auth モジュール", () => {
 			expect(result.user).not.toBeNull();
 			expect(result.user!.id).toBe("dev-user");
 			expect(result.user!.email).toBe("dev@localhost");
+			expect(result.user!.roles).toEqual(["competitor"]);
 			expect(result.token).toBe("mock-access-token");
 		});
 
@@ -81,6 +83,17 @@ describe("auth モジュール", () => {
 
 			expect(result1.user).not.toBe(result2.user);
 			expect(result1.user).toEqual(result2.user);
+		});
+
+		it("AUTH_SKIP_ROLES が指定された場合はそのロールを使うべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.AUTH_SKIP_ROLES = "platform-admin,competitor";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({});
+
+			expect(result.user?.roles).toEqual(["platform-admin", "competitor"]);
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/__tests__/aws-provider.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/aws-provider.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Problem } from "../types";
+
+const mocks = vi.hoisted(() => ({
+	stsSend: vi.fn(),
+	cfSend: vi.fn(),
+	s3Send: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-sts", () => ({
+	STSClient: class {
+		send = mocks.stsSend;
+	},
+	AssumeRoleCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	GetCallerIdentityCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+vi.mock("@aws-sdk/client-cloudformation", () => ({
+	CloudFormationClient: class {
+		send = mocks.cfSend;
+	},
+	CreateStackCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DeleteStackCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DescribeStacksCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	DescribeStackResourcesCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	ListStacksCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+	ValidateTemplateCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+	S3Client: class {
+		send = mocks.s3Send;
+	},
+	PutObjectCommand: class {
+		constructor(public readonly input: unknown) {}
+	},
+}));
+
+const problem: Problem = {
+	id: "problem-1",
+	title: "Test",
+	type: "gameday",
+	category: "security",
+	difficulty: "medium",
+	metadata: {
+		author: "test",
+		version: "1.0.0",
+		createdAt: new Date().toISOString(),
+	},
+	description: {
+		overview: "overview",
+		objectives: [],
+		hints: [],
+	},
+	deployment: {
+		providers: ["aws"],
+		templates: {
+			aws: {
+				type: "cloudformation",
+				content: "Resources: {}",
+			},
+		},
+		regions: {
+			aws: ["ap-northeast-1"],
+		},
+		timeout: 1,
+	},
+	scoring: {
+		type: "manual",
+		path: "/manual",
+		criteria: [],
+		timeoutMinutes: 1,
+	},
+};
+
+describe("AWSCloudProvider", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("roleArn がある場合は ExternalId 付きで AssumeRole して認証検証すべき", async () => {
+		mocks.stsSend
+			.mockResolvedValueOnce({
+				Credentials: {
+					AccessKeyId: "ASIA...",
+					SecretAccessKey: "secret",
+					SessionToken: "token",
+				},
+			})
+			.mockResolvedValueOnce({
+				Account: "123456789012",
+				Arn: "arn:aws:sts::123456789012:assumed-role/Test/session",
+			});
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const valid = await provider.validateCredentials({
+			provider: "aws",
+			accountId: "123456789012",
+			region: "ap-northeast-1",
+			roleArn: "arn:aws:iam::123456789012:role/TenkaCloudDeployRole",
+			externalId: "tc-event-1-123456789012",
+		});
+
+		expect(valid).toBe(true);
+		expect(mocks.stsSend).toHaveBeenCalledTimes(2);
+		const assumeRoleCommand = mocks.stsSend.mock.calls[0][0] as {
+			input: { ExternalId?: string };
+		};
+		expect(assumeRoleCommand.input.ExternalId).toBe(
+			"tc-event-1-123456789012",
+		);
+	});
+
+	it("CloudFormation でスタックを作成して CREATE_COMPLETE を待つべき", async () => {
+		mocks.cfSend
+			.mockResolvedValueOnce({ StackId: "stack-1" })
+			.mockResolvedValueOnce({
+				Stacks: [
+					{
+						StackName: "tc-stack",
+						StackId: "stack-1",
+						StackStatus: "CREATE_COMPLETE",
+						Outputs: [{ OutputKey: "ConsoleUrl", OutputValue: "https://example.com" }],
+					},
+				],
+			});
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const result = await provider.deployStack(
+			problem,
+			{
+				provider: "aws",
+				accountId: "123456789012",
+				region: "ap-northeast-1",
+				accessKeyId: "access",
+				secretAccessKey: "secret",
+			},
+			{
+				stackName: "tc-stack",
+				region: "ap-northeast-1",
+				timeoutSeconds: 1,
+			},
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.stackId).toBe("stack-1");
+		expect(result.outputs).toEqual({ ConsoleUrl: "https://example.com" });
+	});
+});

--- a/backend/services/application-plane/problem-service/src/__tests__/competitor-account-repository.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/competitor-account-repository.test.ts
@@ -36,12 +36,14 @@ describe("CompetitorAccountRepository", () => {
 				accountId: "123456789012",
 				region: "ap-northeast-1",
 				roleArn: "arn:aws:iam::123456789012:role/DeployRole",
+				externalId: "tc-event-1-123456789012",
 			});
 
 			expect(result.id).toBe("test-ulid-001");
 			expect(result.eventId).toBe("event-1");
 			expect(result.name).toBe("team01");
 			expect(result.accountId).toBe("123456789012");
+			expect(result.externalId).toBe("tc-event-1-123456789012");
 			expect(result.status).toBe("pending");
 			expect(mockSend).toHaveBeenCalledTimes(1);
 		});

--- a/backend/services/application-plane/problem-service/src/auth/auth-skip-roles.ts
+++ b/backend/services/application-plane/problem-service/src/auth/auth-skip-roles.ts
@@ -1,0 +1,14 @@
+const DEFAULT_AUTH_SKIP_ROLES = ["competitor"] as const;
+
+export function parseAuthSkipRoles(envValue?: string): string[] {
+	if (!envValue) {
+		return [...DEFAULT_AUTH_SKIP_ROLES];
+	}
+
+	const roles = envValue
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+
+	return roles.length > 0 ? roles : [...DEFAULT_AUTH_SKIP_ROLES];
+}

--- a/backend/services/application-plane/problem-service/src/auth/index.ts
+++ b/backend/services/application-plane/problem-service/src/auth/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { parseAuthSkipRoles } from './auth-skip-roles';
 
 /* v8 ignore start -- Production safety guard */
 if (process.env.AUTH_SKIP === '1' && process.env.NODE_ENV === 'production') {
@@ -22,6 +23,7 @@ const authSkipEnabled =
 // mock-access-token is only accepted when AUTH_SKIP=1 is explicitly set
 const localDevTokenEnabled = authSkipEnabled;
 const LOCAL_DEV_TOKEN = 'mock-access-token';
+const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== 'undefined') {
@@ -156,13 +158,13 @@ export interface AuthContext {
 
 /** AUTH_SKIP モードで使用するモックユーザーを生成（リクエスト間の状態共有を防止） */
 function createMockUser(): AuthenticatedUser {
-  return {
-    id: 'dev-user',
-    email: 'dev@localhost',
-    username: 'dev-user',
-    roles: [UserRole.PLATFORM_ADMIN, UserRole.COMPETITOR],
-    tenantId: 'dev-tenant',
-  };
+	return {
+		id: 'dev-user',
+		email: 'dev@localhost',
+		username: 'dev-user',
+		roles: authSkipRoles,
+		tenantId: 'dev-tenant',
+	};
 }
 
 /**

--- a/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
+++ b/backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts
@@ -283,6 +283,7 @@ function buildCredentials(account: CompetitorAccountWithMeta): CloudCredentials 
 		region: account.region,
 		accountId: account.accountId,
 		roleArn: account.roleArn,
+		externalId: account.externalId,
 		// accessKeyId / secretAccessKey は AssumeRole の場合不要
 		// STS SDK が roleArn を使って一時クレデンシャルを取得する
 	};

--- a/backend/services/application-plane/problem-service/src/providers/aws/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/aws/index.ts
@@ -4,6 +4,28 @@
  * AWS CloudFormation/SAM を使用したスタックデプロイ実装
  */
 
+import { readFile } from "node:fs/promises";
+import {
+	type Capability,
+	CloudFormationClient,
+	CreateStackCommand,
+	DeleteStackCommand,
+	DescribeStacksCommand,
+	DescribeStackResourcesCommand,
+	ListStacksCommand,
+	type StackStatus as CloudFormationStackStatus,
+	ValidateTemplateCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+	S3Client,
+	PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+	AssumeRoleCommand,
+	GetCallerIdentityCommand,
+	STSClient,
+} from "@aws-sdk/client-sts";
+import type { AwsCredentialIdentity } from "@aws-sdk/types";
 import type {
 	CloudCredentials,
 	CloudProvider,
@@ -223,6 +245,13 @@ export class AWSCloudProvider implements ICloudProvider {
 					: undefined,
 			};
 		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error.message.includes("does not exist") ||
+					error.message.includes("does not exist"))
+			) {
+				return null;
+			}
 			console.debug("[AWSCloudProvider] getStackStatus failed:", { stackName, error });
 			return null;
 		}
@@ -388,19 +417,8 @@ export class AWSCloudProvider implements ICloudProvider {
 	async getAccountInfo(credentials: CloudCredentials): Promise<AccountInfo> {
 		const stsResponse = await this.callSTS(credentials, "GetCallerIdentity");
 
-		// IAM エイリアスの取得を試みる
-		let alias: string | undefined;
-		try {
-			const iamResponse = await this.callIAM(credentials, "ListAccountAliases");
-			const aliases = iamResponse.AccountAliases as string[] | undefined;
-			alias = aliases?.[0];
-		} catch (error) {
-			console.debug("[AWSCloudProvider] IAM エイリアスの取得に失敗:", error);
-		}
-
 		return {
 			accountId: stsResponse.Account as string,
-			alias,
 			provider: "aws",
 		};
 	}
@@ -412,15 +430,21 @@ export class AWSCloudProvider implements ICloudProvider {
 	private async callSTS(
 		credentials: CloudCredentials,
 		action: string,
-		params?: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		// 実際の実装では AWS SDK を使用
-		// ここではモック実装
-		console.log(`[AWS STS] ${action}`, params);
-		return {
-			Account: credentials.accountId,
-			Arn: `arn:aws:iam::${credentials.accountId}:root`,
-		};
+		const client = await this.createSTSClient(credentials);
+
+		switch (action) {
+			case "GetCallerIdentity": {
+				const response = await client.send(new GetCallerIdentityCommand({}));
+				return {
+					Account: response.Account,
+					Arn: response.Arn,
+					UserId: response.UserId,
+				};
+			}
+			default:
+				throw new Error(`Unsupported STS action: ${action}`);
+		}
 	}
 
 	private async callCloudFormation(
@@ -429,29 +453,103 @@ export class AWSCloudProvider implements ICloudProvider {
 		action: string,
 		params: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		// 実際の実装では AWS SDK を使用
-		console.log(`[AWS CloudFormation] ${action} in ${region}`, params);
-		return {
-			StackId: `arn:aws:cloudformation:${region}:${credentials.accountId}:stack/${params.StackName}/xxx`,
-		};
+		const client = await this.createCloudFormationClient(credentials, region);
+
+		switch (action) {
+			case "CreateStack": {
+				const response = await client.send(
+					new CreateStackCommand({
+						StackName: params.StackName as string,
+						TemplateBody: params.TemplateBody as string,
+						Parameters: params.Parameters as {
+							ParameterKey: string;
+							ParameterValue: string;
+						}[],
+						Tags: params.Tags as { Key: string; Value: string }[],
+						Capabilities: params.Capabilities as Capability[],
+						TimeoutInMinutes: params.TimeoutInMinutes as number,
+						OnFailure: params.OnFailure as "DO_NOTHING" | "ROLLBACK" | "DELETE",
+						NotificationARNs: params.NotificationArns as string[] | undefined,
+					}),
+				);
+				return {
+					StackId: response.StackId,
+				};
+			}
+			case "DescribeStacks": {
+				const response = await client.send(
+					new DescribeStacksCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {
+					Stacks: response.Stacks,
+				};
+			}
+			case "DeleteStack": {
+				await client.send(
+					new DeleteStackCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {};
+			}
+			case "ValidateTemplate": {
+				await client.send(
+					new ValidateTemplateCommand({
+						TemplateBody: params.TemplateBody as string,
+					}),
+				);
+				return {};
+			}
+			case "ListStacks": {
+				const response = await client.send(
+					new ListStacksCommand({
+						StackStatusFilter: params.StackStatusFilter as
+							| CloudFormationStackStatus[]
+							| undefined,
+					}),
+				);
+				return {
+					StackSummaries: response.StackSummaries,
+				};
+			}
+			case "DescribeStackResources": {
+				const response = await client.send(
+					new DescribeStackResourcesCommand({
+						StackName: params.StackName as string,
+					}),
+				);
+				return {
+					StackResources: response.StackResources,
+				};
+			}
+			default:
+				throw new Error(`Unsupported CloudFormation action: ${action}`);
+		}
 	}
 
 	private async callS3(
-		_credentials: CloudCredentials,
+		credentials: CloudCredentials,
 		region: string,
 		action: string,
 		params: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		console.log(`[AWS S3] ${action} in ${region}`, params);
-		return {};
-	}
+		const client = await this.createS3Client(credentials, region);
 
-	private async callIAM(
-		_credentials: CloudCredentials,
-		action: string,
-	): Promise<Record<string, unknown>> {
-		console.log(`[AWS IAM] ${action}`);
-		return { AccountAliases: [] };
+		switch (action) {
+			case "PutObject":
+				await client.send(
+					new PutObjectCommand({
+						Bucket: params.Bucket as string,
+						Key: params.Key as string,
+						Body: params.Body as Buffer,
+					}),
+				);
+				return {};
+			default:
+				throw new Error(`Unsupported S3 action: ${action}`);
+		}
 	}
 
 	private buildParameters(
@@ -593,18 +691,68 @@ export class AWSCloudProvider implements ICloudProvider {
 	}
 
 	private async readFile(path: string): Promise<Buffer> {
-		// 実際の実装ではファイルを読み込む
-		console.log(`[AWS] Reading file from ${path}`);
-		return Buffer.from("");
+		return readFile(path);
 	}
 
 	private async listManagedStacks(
-		_credentials: CloudCredentials,
+		credentials: CloudCredentials,
 		tagFilter: Record<string, string>,
 	): Promise<{ StackName: string; StackId: string }[]> {
-		// 実際の実装ではタグでフィルタリングしたスタック一覧を返す
-		console.log(`[AWS] Listing managed stacks with tags:`, tagFilter);
-		return [];
+		const listed = await this.callCloudFormation(
+			credentials,
+			credentials.region,
+			"ListStacks",
+			{
+				StackStatusFilter: [
+					"CREATE_COMPLETE",
+					"UPDATE_COMPLETE",
+					"UPDATE_ROLLBACK_COMPLETE",
+					"ROLLBACK_COMPLETE",
+					"CREATE_FAILED",
+					"UPDATE_FAILED",
+				],
+			},
+		);
+
+		const summaries =
+			(listed.StackSummaries as
+				| { StackName?: string; StackId?: string }[]
+				| undefined) ?? [];
+
+		const managedStacks: { StackName: string; StackId: string }[] = [];
+
+		for (const summary of summaries) {
+			if (!summary.StackName || !summary.StackId) {
+				continue;
+			}
+
+			const described = await this.callCloudFormation(
+				credentials,
+				credentials.region,
+				"DescribeStacks",
+				{ StackName: summary.StackName },
+			);
+			const stack = (described.Stacks as Array<{
+				Tags?: { Key?: string; Value?: string }[];
+			}>)?.[0];
+			const tags = Object.fromEntries(
+				(stack?.Tags ?? [])
+					.filter((tag) => tag.Key && tag.Value)
+					.map((tag) => [tag.Key as string, tag.Value as string]),
+			);
+
+			const matches = Object.entries(tagFilter).every(
+				([key, value]) => tags[key] === value,
+			);
+			if (matches) {
+				managedStacks.push({
+					StackName: summary.StackName,
+					StackId: summary.StackId,
+				});
+			}
+		}
+
+		return managedStacks;
 	}
 
 	private shouldDeleteResource(
@@ -627,6 +775,84 @@ export class AWSCloudProvider implements ICloudProvider {
 
 	private sleep(ms: number): Promise<void> {
 		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	private buildBaseCredentials(
+		credentials: CloudCredentials,
+	): AwsCredentialIdentity | undefined {
+		if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+			return undefined;
+		}
+
+		return {
+			accessKeyId: credentials.accessKeyId,
+			secretAccessKey: credentials.secretAccessKey,
+			sessionToken: credentials.sessionToken,
+		};
+	}
+
+	private async resolveRuntimeCredentials(
+		credentials: CloudCredentials,
+	): Promise<AwsCredentialIdentity | undefined> {
+		if (!credentials.roleArn) {
+			return this.buildBaseCredentials(credentials);
+		}
+
+		const client = new STSClient({
+			region: credentials.region,
+			credentials: this.buildBaseCredentials(credentials),
+		});
+
+		const response = await client.send(
+			new AssumeRoleCommand({
+				RoleArn: credentials.roleArn,
+				RoleSessionName: this.buildRoleSessionName(credentials),
+				ExternalId: credentials.externalId,
+			}),
+		);
+
+		if (!response.Credentials) {
+			throw new Error("AssumeRole returned no credentials");
+		}
+
+		return {
+			accessKeyId: response.Credentials.AccessKeyId ?? "",
+			secretAccessKey: response.Credentials.SecretAccessKey ?? "",
+			sessionToken: response.Credentials.SessionToken,
+		};
+	}
+
+	private async createSTSClient(
+		credentials: CloudCredentials,
+	): Promise<STSClient> {
+		return new STSClient({
+			region: credentials.region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private async createCloudFormationClient(
+		credentials: CloudCredentials,
+		region: string,
+	): Promise<CloudFormationClient> {
+		return new CloudFormationClient({
+			region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private async createS3Client(
+		credentials: CloudCredentials,
+		region: string,
+	): Promise<S3Client> {
+		return new S3Client({
+			region,
+			credentials: await this.resolveRuntimeCredentials(credentials),
+		});
+	}
+
+	private buildRoleSessionName(credentials: CloudCredentials): string {
+		return `tenkacloud-${credentials.accountId}-${Date.now()}`.slice(0, 64);
 	}
 }
 

--- a/backend/services/application-plane/problem-service/src/repositories/competitor-account-repository.ts
+++ b/backend/services/application-plane/problem-service/src/repositories/competitor-account-repository.ts
@@ -34,13 +34,17 @@ interface CompetitorAccountItem {
 	accountId: string;
 	region: string;
 	roleArn?: string;
+	externalId?: string;
 	status: string;
 }
 
 const buildPK = (eventId: string) => `EVENT#${eventId}`;
 const buildSK = (accountId: string) => `COMPETITOR_ACCOUNT#${accountId}`;
 
-function toDomain(item: CompetitorAccountItem): CompetitorAccount & { eventId: string; roleArn?: string } {
+function toDomain(item: CompetitorAccountItem): CompetitorAccount & {
+	eventId: string;
+	roleArn?: string;
+} {
 	return {
 		id: item.id,
 		eventId: item.eventId,
@@ -49,11 +53,15 @@ function toDomain(item: CompetitorAccountItem): CompetitorAccount & { eventId: s
 		accountId: item.accountId,
 		region: item.region,
 		roleArn: item.roleArn,
+		externalId: item.externalId,
 		status: item.status as CompetitorAccount["status"],
 	};
 }
 
-export type CompetitorAccountWithMeta = CompetitorAccount & { eventId: string; roleArn?: string };
+export type CompetitorAccountWithMeta = CompetitorAccount & {
+	eventId: string;
+	roleArn?: string;
+};
 
 export interface CreateCompetitorAccountInput {
 	eventId: string;
@@ -62,6 +70,7 @@ export interface CreateCompetitorAccountInput {
 	accountId: string;
 	region: string;
 	roleArn?: string;
+	externalId?: string;
 }
 
 export class CompetitorAccountRepository {
@@ -86,6 +95,7 @@ export class CompetitorAccountRepository {
 			accountId: input.accountId,
 			region: input.region,
 			roleArn: input.roleArn,
+			externalId: input.externalId,
 			status: "pending",
 		};
 

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -2631,6 +2631,7 @@ function getAWSCredentialsFromEnv(
 		secretAccessKey,
 		sessionToken: overrides?.sessionToken || process.env.AWS_SESSION_TOKEN,
 		roleArn: overrides?.roleArn || process.env.AWS_ROLE_ARN,
+		externalId: overrides?.externalId || process.env.AWS_EXTERNAL_ID,
 		region,
 	};
 }
@@ -2707,6 +2708,7 @@ const deployProblemSchema = z.object({
 			sessionToken: z.string().optional(),
 			accountId: z.string().optional(),
 			roleArn: z.string().optional(),
+			externalId: z.string().optional(),
 		})
 		.optional()
 		.describe("AWS クレデンシャル（省略時は環境変数を使用）"),
@@ -2978,6 +2980,13 @@ adminRouter.get(
 const competitorAccountRepo = new CompetitorAccountRepository();
 const gamedayJobRepo = new GameDayDeploymentJobRepository();
 
+function buildCompetitorExternalId(eventId: string, accountId: string): string {
+	const sanitize = (value: string) =>
+		value.replace(/[^A-Za-z0-9+=,.@:/-]/g, "-");
+
+	return `tc-${sanitize(eventId)}-${sanitize(accountId)}`.slice(0, 122);
+}
+
 // チームアカウント登録
 adminRouter.post(
 	"/events/:eventId/competitor-accounts",
@@ -2999,6 +3008,7 @@ adminRouter.post(
 			accountId: z.string().min(1),
 			region: z.string().min(1),
 			roleArn: z.string().optional(),
+			externalId: z.string().min(1).max(122).optional(),
 		}),
 	),
 	async (c) => {
@@ -3013,6 +3023,11 @@ adminRouter.post(
 				accountId: data.accountId,
 				region: data.region,
 				roleArn: data.roleArn,
+				externalId:
+					data.roleArn && data.provider === "aws"
+						? (data.externalId ??
+							buildCompetitorExternalId(eventId, data.accountId))
+						: data.externalId,
 			});
 			return c.json(account, 201);
 		} catch (error) {

--- a/backend/services/application-plane/problem-service/src/types/index.ts
+++ b/backend/services/application-plane/problem-service/src/types/index.ts
@@ -26,6 +26,7 @@ export interface CloudCredentials {
 	secretAccessKey?: string;
 	sessionToken?: string;
 	roleArn?: string;
+	externalId?: string;
 	region: string;
 }
 
@@ -197,6 +198,7 @@ export interface CompetitorAccount {
 	provider: CloudProvider;
 	accountId: string;
 	region: string;
+	externalId?: string;
 	credentials?: CloudCredentials;
 	status: "pending" | "ready" | "in_use" | "cleanup" | "error";
 }

--- a/backend/services/control-plane/tenant-management/src/index.ts
+++ b/backend/services/control-plane/tenant-management/src/index.ts
@@ -94,31 +94,24 @@ app.get(
         tenantRepository.list({ limit: 100 }),
       ]);
 
-    // Count active tenants
-    const activeTenants = listResult.tenants.filter(
-      (t) => t.status === 'ACTIVE'
-    ).length;
+    let activeTenants = 0;
+    let failedCount = 0;
+    let inProgressCount = 0;
+    let completedCount = 0;
+    let pendingCount = 0;
+    for (const t of listResult.tenants) {
+      if (t.status === 'ACTIVE') activeTenants++;
+      if (t.provisioningStatus === 'FAILED') failedCount++;
+      else if (t.provisioningStatus === 'IN_PROGRESS') inProgressCount++;
+      else if (t.provisioningStatus === 'COMPLETED') completedCount++;
+      else if (t.provisioningStatus === 'PENDING') pendingCount++;
+    }
 
-    // Determine system status based on provisioning state
-    const failedCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'FAILED'
-    ).length;
-    const inProgressCount = listResult.tenants.filter(
-      (t) => t.provisioningStatus === 'IN_PROGRESS'
-    ).length;
-
-    // Calculate system health:
-    // - degraded: any tenant has failed provisioning
-    // - healthy: all tenants completed or pending/in-progress
     const systemStatus: 'healthy' | 'degraded' | 'down' =
       failedCount > 0 ? 'degraded' : 'healthy';
-
-    // Calculate uptime percentage based on successful provisioning
-    // (tenants not in FAILED state / total tenants) * 100
-    const successfulTenants = totalTenants - failedCount;
     const uptimePercentage =
       totalTenants > 0
-        ? Math.round((successfulTenants / totalTenants) * 100)
+        ? Math.round(((totalTenants - failedCount) / totalTenants) * 100)
         : 100;
 
       return c.json({
@@ -126,16 +119,11 @@ app.get(
         totalTenants,
         systemStatus,
         uptimePercentage,
-        // Additional context for debugging
         provisioningStats: {
-          completed: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'COMPLETED'
-          ).length,
+          completed: completedCount,
           inProgress: inProgressCount,
           failed: failedCount,
-          pending: listResult.tenants.filter(
-            (t) => t.provisioningStatus === 'PENDING'
-          ).length,
+          pending: pendingCount,
         },
       });
     } catch (error) {

--- a/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
+++ b/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
@@ -107,7 +107,7 @@ provisioningRoutes.post(
         applicationDeploymentStatus: 'FAILED',
         provisioningError: errorMessage,
       });
-      throw error;
+      return c.json(errorResponse('Failed to start provisioning', 500), 500);
     }
 
     await tenantRepository.update(tenant.id, {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,16 +26,20 @@ make start     # 全サービス起動
 1. Issue を確認し、ブランチを作成する
 2. **テストを先に書く**（TDD）
 3. 実装する
+4. `bun scripts/architecture-harness.ts --staged --fail-on=error` を通す
 4. `make before-commit` を通す
 5. PR を作成する
 
 ```bash
 git checkout -b feat/your-feature
 # テストを書く → 実装する → 繰り返す
+bun scripts/architecture-harness.ts --staged --fail-on=error
 make before-commit   # 必須。通らなければ PR を出さない
 git push -u origin HEAD
 gh pr create
 ```
+
+アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./architecture/harness.md) です。`Codex` と `Claude Code` のどちらを使っても、repo 内のこのハーネスを優先します。
 
 ## 品質基準
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,6 +1,6 @@
 # TenkaCloud 概要
 
-この文書は、TenkaCloud の責務分割と文書の入口を短く把握するための概要です。詳細な手順は [QUICKSTART.md](./QUICKSTART.md)、設計判断は [architecture/architecture.md](./architecture/architecture.md) を参照してください。
+この文書は、TenkaCloud の責務分割と文書の入口を短く把握するための概要です。詳細な手順は [QUICKSTART.md](./QUICKSTART.md)、設計判断は [architecture/architecture.md](./architecture/architecture.md)、不変条件は [architecture/harness.md](./architecture/harness.md) を参照してください。
 
 ## 何を作っているか
 
@@ -15,7 +15,9 @@ TenkaCloud は、クラウド競技イベントを常設化するための OSS �
 - テナント管理
 - 設定管理
 - 共有 API への導線
-- 今後の監査、プロビジョニング、全体運用
+- 監査、プロビジョニング要求、全体運用
+
+Control Plane は tenant manager です。tenant runtime や problem runtime を直接ホストしません。
 
 実体は以下のとおりです。
 
@@ -30,6 +32,10 @@ TenkaCloud は、クラウド競技イベントを常設化するための OSS �
 - Battle セッション
 - 問題閲覧と挑戦
 - ランキング、プロフィール
+- tenant admin UI
+- competitor AWS account への問題デプロイ
+
+Application Plane は tenant ごとに 1 つです。tenant は company 単位であり、department 単位では分けません。
 
 実体は以下のとおりです。
 
@@ -83,6 +89,7 @@ TenkaCloud/
 
 - UI の仕様は `apps/*/app` とそのテストを優先して確認する
 - API の仕様は `backend/services/**/src` を優先して確認する
+- アーキテクチャ境界と one-pass 完了条件は `docs/architecture/harness.md` を優先する
 - 歴史的な計画や草案は `Plan.md` や `docs/plans/` に残るが、仕様の正本ではない
 
 ## 次に読む文書

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 # TenkaCloud Quick Start
 
-この手順は、ローカル開発を最短で始めるための正本です。
+この手順は、ローカル開発を最短で始めるための正本です。アーキテクチャ不変条件は [architecture/harness.md](./architecture/harness.md) を参照してください。
 
 ## 前提
 
@@ -79,6 +79,21 @@ bun run dev
 ```
 
 ## 動作確認
+
+### one-pass の最小確認
+
+ローカルで「一部ページが開く」だけでは完了扱いにしません。最低限、次の one-pass を確認します。
+
+1. Control Plane で tenant を作成する
+2. provisioning を開始し、tenant status が進むことを確認する
+3. tenant の Application Plane に到達する
+4. event を作成する
+5. competitor account を登録する
+6. problem を deploy する
+7. participant として event に参加する
+8. `attack / defense / vote / aws-console` が実リソース前提で動くことを確認する
+
+この one-pass は `docs/architecture/harness.md` の `ONE_PASS_LOCAL` と同じです。
 
 ### tenant-management
 

--- a/docs/architecture/actors.md
+++ b/docs/architecture/actors.md
@@ -4,6 +4,8 @@
 
 TenkaCloud は Control Plane と Application Plane の 2 層構造を持つマルチテナント SaaS です。問題はマーケットプレイス型で提供され、問題作成者が公開した問題をテナントが利用します。
 
+責務境界の正本は [`docs/architecture/harness.md`](./harness.md) です。特に `INVARIANT_TENANT_IS_COMPANY`, `INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT`, `INVARIANT_PROBLEM_RUNTIME_IN_COMPETITOR_AWS_ACCOUNTS` を破る運用は採りません。
+
 ## アクター一覧
 
 | 層 | アクター | 説明 |
@@ -19,12 +21,7 @@ TenkaCloud は Control Plane と Application Plane の 2 層構造を持つマ�
 
 Control Plane は TenkaCloud プラットフォーム全体を管理する共有層です。テナント管理、問題マーケットプレイス、課金などのプラットフォーム機能を提供します。
 
-### テナントの種類
-
-| 種類 | 説明 | ユースケース |
-|------|------|-------------|
-| マルチテナント | 共有インフラ上で複数テナントが稼働 | 小〜中規模、コスト重視 |
-| 専用環境 | テナント専用のインフラを割り当て | 大規模、セキュリティ要件が高い |
+tenant は「各社」を表します。部署単位で tenant を増やしません。Control Plane は tenant manager であり、tenant runtime host ではありません。
 
 ### Platform Admin (プラットフォーム管理者)
 
@@ -33,7 +30,7 @@ TenkaCloud プラットフォーム全体を管理するスーパーユーザー
 **できること**
 
 - マルチテナント環境でテナントを作成する
-- 専用環境でテナントをプロビジョニングする
+- event-driven で tenant Application Plane のプロビジョニング要求を出す
 - テナントを停止・再開する
 - テナントを削除する
 - 全テナントの利用状況を確認する
@@ -64,6 +61,8 @@ TenkaCloud プラットフォーム全体を管理するスーパーユーザー
 
 Application Plane は各テナント固有のビジネスロジックを実行する層です。イベント管理、競技参加、スコアリングなどの機能を提供します。テナントごとに独立したデータを持ちます。
 
+Application Plane は tenant ごとに 1 つで、各社に対して 1 Plane を持ちます。問題 runtime は Application Plane ではなく competitor AWS account に作成します。
+
 ### Tenant Admin (テナント管理者)
 
 特定テナント内でイベント・参加者を管理する管理者です。
@@ -76,6 +75,7 @@ Application Plane は各テナント固有のビジネスロジックを実行�
 - マーケットプレイスから問題を検索・追加する
 - イベント内の問題順序を設定する
 - 問題をクラウド環境にデプロイする
+- competitor AWS account に `AssumeRole + ExternalId + CloudFormation` で問題を配備する
 - 問題環境を削除・リセットする
 - 参加者を招待・削除する
 - 参加者のロールを変更する

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -6,6 +6,8 @@
 
 TenkaCloud は、Control Plane と Application Plane を分離したマルチテナント構成を採用しています。
 
+この文書だけで原則を持たず、アーキテクチャ不変条件の正本は [`docs/architecture/harness.md`](./harness.md) とします。`Codex` と `Claude Code` のどちらが触っても、`bun scripts/architecture-harness.ts --staged --fail-on=error` を通らない変更は受け入れません。
+
 ```text
 ┌─────────────────────────────────────────────────────────────┐
 │                        TenkaCloud                           │
@@ -27,6 +29,17 @@ TenkaCloud は、Control Plane と Application Plane を分離したマルチテ
 
 ## 2. プレーンごとの責務
 
+## Architecture Invariants
+
+- `INVARIANT_SERVERLESS_ONLY`
+- `INVARIANT_TENANT_IS_COMPANY`
+- `INVARIANT_DEPARTMENT_IS_NOT_TENANT`
+- `INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT`
+- `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`
+- `INVARIANT_PROBLEM_RUNTIME_IN_COMPETITOR_AWS_ACCOUNTS`
+- `ONE_PASS_LOCAL`
+- `ONE_PASS_AWS`
+
 ### Control Plane
 
 共有運用面を担います。
@@ -35,6 +48,9 @@ TenkaCloud は、Control Plane と Application Plane を分離したマルチテ
 - 運用設定
 - 共通管理 UI
 - 登録、プロビジョニング、ユーザー管理の導線
+- tenant provisioning request と監査
+
+Control Plane は tenant manager であり、tenant runtime host ではありません。tenant ごとの実行系 endpoint を直接抱え込まず、event-driven provisioning で tenant Application Plane を起動・追跡します。
 
 主要実体は以下のとおりです。
 
@@ -57,6 +73,10 @@ TenkaCloud は、Control Plane と Application Plane を分離したマルチテ
 - 問題管理
 - スコアリング
 - リーダーボード
+- tenant admin UI と participant UI
+- competitor AWS account への問題デプロイ
+
+Application Plane は tenant ごとに 1 つです。各社ごとに 1 Plane を持ち、部署ごとには分けません。
 
 主要実体は以下のとおりです。
 
@@ -114,6 +134,8 @@ Hono ベースのサービスが多く、ルートの `package.json` の `dev` �
 
 現行のローカル開発では DynamoDB 互換のローカルエミュレータを使用します。problem-service は Prisma を含みますが、リポジトリ全体の唯一のデータ前提としては固定していません。各サービスの実装を優先してください。
 
+Control Plane と Application Plane の正本アーキテクチャは serverless only です。tenant runtime や platform runtime に `ECS`, `EKS`, `RDS`, `NAT Gateway` を持ち込まない方針を採ります。
+
 ## 6. 認証
 
 - 本番相当: Auth0
@@ -154,3 +176,5 @@ Hono ベースのサービスが多く、ルートの `package.json` の `dev` �
 5. `Plan.md` と `docs/plans/*`
 
 `Plan.md` と `docs/plans/*` は履歴や構想が混ざるため、現在仕様の正本には使いません。
+
+アーキテクチャの境界やワンパス完了条件を判断するときは、必ず [`docs/architecture/harness.md`](./harness.md) を参照します。

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -1,0 +1,40 @@
+# TenkaCloud Architecture Harness
+
+この文書は、セッションが変わっても壊してはいけない原則を機械可読な ID つきで固定する正本です。
+
+## Invariants
+
+- `INVARIANT_SERVERLESS_ONLY`
+  Control Plane と tenant ごとの Application Plane は serverless-only で構成する。常駐 compute を前提にしない。
+- `INVARIANT_TENANT_IS_COMPANY`
+  tenant は company 単位である。
+- `INVARIANT_DEPARTMENT_IS_NOT_TENANT`
+  department は tenant にしない。部署分割は tenant 境界ではない。
+- `INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT`
+  1 tenant につき 1 Application Plane を配備する。
+- `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`
+  Control Plane は tenant manager であり、tenant runtime host ではない。
+- `INVARIANT_PROBLEM_RUNTIME_IN_COMPETITOR_AWS_ACCOUNTS`
+  問題の runtime と課金対象リソースは competitor AWS accounts にのみ作る。
+
+## One-Pass Acceptance
+
+- `ONE_PASS_LOCAL`
+  `make start` 後に、tenant 作成、provisioning、tenant Application Plane 到達、event 作成、competitor account 登録、problem deploy、participant join、attack/defense/vote/aws-console までローカルで一気通貫する。
+- `ONE_PASS_AWS`
+  AWS 上でも同じ順序で、tenant 作成から participant 競技開始まで local fallback なしで一気通貫する。
+
+## Banned Assumptions
+
+- platform account が tenant runtime を直接 host する前提
+- Control Plane が competitor account へ直接 CloudFormation を流す前提
+- tenant runtime を `ECS`, `EKS`, `Fargate`, `RDS`, `NAT Gateway` に依存させる前提
+- 「見た目が出る」「一部 API が通る」を one-pass completion と見なす運用
+
+## Enforcement
+
+- `bun scripts/architecture-harness.ts --staged --fail-on=error`
+- `bun scripts/ai-improvement-loop.ts --staged --fail-on=high`
+- `make before-commit`
+
+Git hook と AI エージェント向けガイドは、この文書を参照して同じ判定に従う。

--- a/docs/decisions/009-application-admin-isolation-and-aws-deployment-engine.md
+++ b/docs/decisions/009-application-admin-isolation-and-aws-deployment-engine.md
@@ -1,0 +1,39 @@
+# ADR-009: Application 管理者分離と AWS 問題デプロイメントエンジン
+
+- **Status**: Accepted
+- **Date**: 2026-04-12
+- **Deciders**: susumutomita
+
+## Context
+
+Application Plane では、ローカル開発時の `AUTH_SKIP` が常に管理者権限を持つ形になっており、参加者向け UI と管理者 UI の境界が崩れていた。これにより `/admin` 配下へ誰でも入れる状態になり、実際の権限モデルとローカル挙動が乖離していた。
+
+また、GameDay 問題のチーム配布は UI 上の導線は存在する一方で、AWS 連携は placeholder 実装に留まっていた。競技者 AWS アカウントへ安全に問題を配布するには、各アカウントの IAM Role を `ExternalId` 付きで引き受け、CloudFormation テンプレートを tenant/event/problem 単位で展開する実行系が必要だった。
+
+## Decision
+
+1. Application Plane の `AUTH_SKIP` デフォルトロールは `participant` とし、管理者権限は `AUTH_SKIP_ROLES` で明示的に付与する
+2. 管理者 UI、middleware、server API helper では共通ヘルパーで管理者判定を共有し、`admin` / `platform-admin` / `tenant-admin` / `organizer` のみを管理者とみなす
+3. backend services でも同様に `AUTH_SKIP` デフォルトロールを最小権限へ寄せ、参加者系 service は `participant`、problem-service は `competitor` をデフォルトにする
+4. 競技者アカウントには `externalId` を保持できるようにし、未指定時は `eventId` と account ID から安全な値を自動生成する
+5. AWS deployment engine は placeholder を廃止し、AWS SDK を使った実実装へ置き換える
+   - STS `AssumeRole` + `ExternalId`
+   - STS `GetCallerIdentity` による credential 検証
+   - CloudFormation `ValidateTemplate` / `CreateStack` / `DescribeStacks` / `DescribeStackResources` / `DeleteStack`
+   - S3 `PutObject`
+6. GameDay deployer は competitor account ごとに job を永続化し、stack 名・parameter・tag を組み立てて並列デプロイする
+
+## Consequences
+
+- **Good**: ローカル開発でも参加者と管理者の境界が壊れなくなる。UI の見え方と本番権限モデルが揃う。問題配布が console log ベースではなく、実際に AWS アカウントへ到達する経路になる。
+- **Bad**: ローカルで管理者画面を確認するには `AUTH_SKIP_ROLES` の明示が必要になる。競技者アカウント設定では `roleArn` と信頼ポリシーに加えて `ExternalId` の整合も必要になる。
+- **Tradeoff**: 開発初速は少し落ちるが、誤った権限前提やハリボテ deploy で機能が成立したように見える状態は防げる。
+
+## References
+
+- [apps/application-plane/auth.ts](../../apps/application-plane/auth.ts)
+- [apps/application-plane/lib/auth/roles.ts](../../apps/application-plane/lib/auth/roles.ts)
+- [apps/application-plane/proxy.ts](../../apps/application-plane/proxy.ts)
+- [backend/services/application-plane/problem-service/src/auth/index.ts](../../backend/services/application-plane/problem-service/src/auth/index.ts)
+- [backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts](../../backend/services/application-plane/problem-service/src/problems/gameday-deployer.ts)
+- [backend/services/application-plane/problem-service/src/providers/aws/index.ts](../../backend/services/application-plane/problem-service/src/providers/aws/index.ts)

--- a/docs/decisions/010-architecture-harness-and-one-pass-invariants.md
+++ b/docs/decisions/010-architecture-harness-and-one-pass-invariants.md
@@ -1,0 +1,43 @@
+# ADR-010: アーキテクチャ原則をハーネス化し one-pass を完了条件にする
+
+- **Status**: Accepted
+- **Date**: 2026-04-12
+- **Deciders**: susumutomita
+
+## Context
+
+TenkaCloud は Control Plane / Application Plane / competitor AWS account の責務分離が仕様上は決まっている一方で、セッションごとの認識ずれや一時しのぎ実装により、完了条件が「画面が出る」「一部 API が通る」に崩れやすかった。
+
+この状態では、`tenant 作成 -> provisioning -> tenant runtime 到達 -> problem deploy -> participant 競技開始` の一気通貫が最後まで閉じず、ローカルと AWS の双方でワンパスが成立しない。
+
+また、`Codex` と `Claude Code` を併用する以上、口頭ルールだけでは維持できない。repo 内の正本と Git hook で強制する必要がある。
+
+## Decision
+
+1. 原則の正本を [`docs/architecture/harness.md`](../architecture/harness.md) に置く
+2. 次を invariant として ID 付きで固定する
+   - `INVARIANT_SERVERLESS_ONLY`
+   - `INVARIANT_TENANT_IS_COMPANY`
+   - `INVARIANT_DEPARTMENT_IS_NOT_TENANT`
+   - `INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT`
+   - `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`
+   - `INVARIANT_PROBLEM_RUNTIME_IN_COMPETITOR_AWS_ACCOUNTS`
+   - `ONE_PASS_LOCAL`
+   - `ONE_PASS_AWS`
+3. `scripts/architecture-harness.ts` を追加し、正本ドキュメントと staged 変更を検査する
+4. `packages/shared/src/quality/architecture-harness.ts` に検出ロジックを置き、テストで固定する
+5. `.husky/pre-commit` で `bun scripts/architecture-harness.ts --staged --fail-on=error` を必須化する
+6. `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` はこのハーネスを参照し、agent 固有ルールではなく repo ルールを優先する
+
+## Consequences
+
+- **Good**: セッションが変わっても原則の所在が揺れない。Control Plane への problem deploy 持ち込みや serverful runtime 逆戻りをコミット前に落とせる。
+- **Bad**: 文書更新や設計変更のたびにハーネスの更新が必要になる。
+- **Tradeoff**: 開発の自由度は少し下がるが、完成条件と責務境界は大きく安定する。
+
+## References
+
+- [docs/architecture/harness.md](../architecture/harness.md)
+- [docs/architecture/architecture.md](../architecture/architecture.md)
+- [AGENTS.md](../../AGENTS.md)
+- [CLAUDE.md](../../CLAUDE.md)

--- a/docs/design/application-plane-multi-tenant-routing.md
+++ b/docs/design/application-plane-multi-tenant-routing.md
@@ -1,5 +1,9 @@
 # Application Plane マルチテナントルーティング設計書
 
+> Historical Design Note
+> この文書は管理者 UI と tenant 識別の初期設計メモです。現行仕様の正本ではありません。tenant 境界、problem runtime 境界、one-pass 完了条件は [`docs/architecture/harness.md`](../architecture/harness.md) を優先してください。
+> 特に「Challenge AWS デプロイ」は Application Plane から competitor AWS account へ `AssumeRole + ExternalId + CloudFormation` で行う前提で読み替えます。
+
 ## Overview
 
 Application Plane にマルチテナントルーティングと管理者機能を実装する。

--- a/docs/design/tenant-plan-and-navigation.md
+++ b/docs/design/tenant-plan-and-navigation.md
@@ -1,5 +1,9 @@
 # テナントプラン切り替え機能 & 管理画面導線設計
 
+> Historical Design Note
+> この文書は tenant detail UI と plan 表示の設計メモです。現行仕様の正本ではありません。`専用環境` や `POOL → SILO 再プロビジョニング` の記述は、現在の `INVARIANT_SERVERLESS_ONLY` と `INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT` を優先して再評価してください。
+> 現行の正本は [`docs/architecture/harness.md`](../architecture/harness.md) と [`docs/architecture/architecture.md`](../architecture/architecture.md) です。
+
 ## 概要
 
 テナントのプラン（Tier）切り替え機能と、各テナント専用の Application Plane への導線を設計する。

--- a/docs/plans/2026-02-09-full-platform-completion-design.md
+++ b/docs/plans/2026-02-09-full-platform-completion-design.md
@@ -1,5 +1,9 @@
 # TenkaCloud フルプラットフォーム完成 設計書
 
+> Historical Plan
+> この文書は 2026-02-09 時点の設計計画です。現行仕様の正本ではありません。現在のアーキテクチャ境界は [`docs/architecture/harness.md`](../architecture/harness.md) と [`docs/architecture/architecture.md`](../architecture/architecture.md) を参照してください。
+> 特に `EKS`, `ECS`, `RDS`, `NAT Gateway` を Control Plane / tenant Application Plane の前提にする記述は、現行の `INVARIANT_SERVERLESS_ONLY` では採用しません。
+
 ## 概要
 
 TenkaCloud のメインパス（テナント作成→ Application Plane 自動プロビジョニング→問題デプロイ→バトル→自動採点→リーダーボード）を完成させ、100 問の構築型問題を登録する。

--- a/packages/shared/src/quality/__tests__/architecture-harness.test.ts
+++ b/packages/shared/src/quality/__tests__/architecture-harness.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeArchitecture,
+  formatArchitectureReportAsMarkdown,
+  getArchitectureHarnessAuthoritativePaths,
+  shouldAnalyzeArchitectureFile,
+} from '../architecture-harness';
+
+describe('architecture harness', () => {
+  it('docs とコードの対象ファイルだけを分析対象にするべき', () => {
+    expect(shouldAnalyzeArchitectureFile('docs/architecture/harness.md')).toBe(
+      true,
+    );
+    expect(
+      shouldAnalyzeArchitectureFile(
+        'backend/services/control-plane/provisioning/src/handler.ts',
+      ),
+    ).toBe(true);
+    expect(shouldAnalyzeArchitectureFile('docs/image.png')).toBe(false);
+  });
+
+  it('authoritative docs に invariant ID が揃っていることを要求するべき', () => {
+    const report = analyzeArchitecture([
+      {
+        path: 'docs/architecture/harness.md',
+        content: '# Harness\n\n## Invariants\n\n- `INVARIANT_SERVERLESS_ONLY`',
+      },
+    ]);
+
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'authoritative-docs-present',
+          severity: 'error',
+        }),
+        expect.objectContaining({
+          ruleId: 'required-invariant-missing',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('Control Plane への CloudFormation 実装持ち込みを検出するべき', () => {
+    const report = analyzeArchitecture([
+      {
+        path: 'backend/services/control-plane/deployment-management/src/index.ts',
+        content:
+          "import { CloudFormationClient, CreateStackCommand } from '@aws-sdk/client-cloudformation';",
+      },
+    ]);
+
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        ruleId: 'control-plane-deploys-problem-runtime',
+        severity: 'error',
+      }),
+    );
+  });
+
+  it('serverful runtime 前提を検出するべき', () => {
+    const report = analyzeArchitecture([
+      {
+        path: 'docs/architecture/architecture.md',
+        content: 'tenant runtime は ECS と RDS で動かす。',
+      },
+    ]);
+
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        ruleId: 'serverful-platform-runtime',
+        severity: 'error',
+      }),
+    );
+  });
+
+  it('Markdown レポートを出力するべき', () => {
+    const report = analyzeArchitecture([
+      {
+        path: 'AGENTS.md',
+        content: '# AGENTS\n\nmake before-commit',
+      },
+    ]);
+
+    const markdown = formatArchitectureReportAsMarkdown(report);
+    expect(markdown).toContain('# Architecture Harness Report');
+    expect(markdown).toContain('## Findings');
+  });
+
+  it('authoritative paths 一覧を返すべき', () => {
+    expect(getArchitectureHarnessAuthoritativePaths()).toEqual(
+      expect.arrayContaining([
+        'docs/architecture/harness.md',
+        'docs/architecture/architecture.md',
+        'AGENTS.md',
+        'CLAUDE.md',
+      ]),
+    );
+  });
+});

--- a/packages/shared/src/quality/__tests__/tech-debt-loop.test.ts
+++ b/packages/shared/src/quality/__tests__/tech-debt-loop.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   analyzeRepository,
   formatImprovementReportAsMarkdown,

--- a/packages/shared/src/quality/architecture-harness.ts
+++ b/packages/shared/src/quality/architecture-harness.ts
@@ -1,0 +1,377 @@
+import path from 'node:path';
+
+export type ArchitectureSeverity = 'error' | 'warning';
+
+export interface ArchitectureFile {
+  path: string;
+  content: string;
+}
+
+export interface ArchitectureFinding {
+  ruleId: string;
+  severity: ArchitectureSeverity;
+  filePath: string;
+  line: number;
+  summary: string;
+  recommendation: string;
+}
+
+export interface ArchitectureReport {
+  findings: ArchitectureFinding[];
+  summary: {
+    error: number;
+    warning: number;
+    total: number;
+  };
+  nextActions: string[];
+}
+
+interface RuleContext {
+  file: ArchitectureFile;
+  normalizedPath: string;
+  lines: string[];
+  filesByPath: Map<string, ArchitectureFile>;
+}
+
+interface ArchitectureRule {
+  id: string;
+  evaluate(context: RuleContext): ArchitectureFinding[];
+}
+
+const ARCHITECTURE_FILE_PATTERN = /\.(md|ts|tsx|js|jsx|mjs|cjs|tf|hcl)$/;
+const REQUIRED_INVARIANTS = [
+  'INVARIANT_SERVERLESS_ONLY',
+  'INVARIANT_TENANT_IS_COMPANY',
+  'INVARIANT_DEPARTMENT_IS_NOT_TENANT',
+  'INVARIANT_ONE_APPLICATION_PLANE_PER_TENANT',
+  'INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME',
+  'INVARIANT_PROBLEM_RUNTIME_IN_COMPETITOR_AWS_ACCOUNTS',
+  'ONE_PASS_LOCAL',
+  'ONE_PASS_AWS',
+] as const;
+
+const AUTHORITATIVE_DOCS = [
+  'docs/architecture/harness.md',
+  'docs/architecture/architecture.md',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'docs/CONTRIBUTING.md',
+] as const;
+
+const SERVERFUL_DOC_PATHS = [
+  'docs/architecture/architecture.md',
+  'docs/architecture/actors.md',
+] as const;
+
+export function getArchitectureHarnessAuthoritativePaths(): string[] {
+  return [...AUTHORITATIVE_DOCS];
+}
+
+function normalizeFilePath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function firstMatchLine(lines: string[], pattern: RegExp): number {
+  return (
+    lines.findIndex((line) => {
+      pattern.lastIndex = 0;
+      return pattern.test(line);
+    }) + 1 || 1
+  );
+}
+
+export function shouldAnalyzeArchitectureFile(filePath: string): boolean {
+  const normalized = normalizeFilePath(filePath);
+  if (!ARCHITECTURE_FILE_PATTERN.test(normalized)) {
+    return false;
+  }
+
+  return ![
+    '/node_modules/',
+    '/.next/',
+    '/coverage/',
+    '/dist/',
+    '/build/',
+    '/out/',
+    '/.git/',
+  ].some((segment) => normalized.includes(segment));
+}
+
+const rules: ArchitectureRule[] = [
+  {
+    id: 'authoritative-docs-present',
+    evaluate({ normalizedPath, file, filesByPath }) {
+      if (normalizedPath !== 'docs/architecture/harness.md') {
+        return [];
+      }
+
+      const findings: ArchitectureFinding[] = [];
+      for (const docPath of AUTHORITATIVE_DOCS) {
+        if (!filesByPath.has(docPath)) {
+          findings.push({
+            ruleId: 'authoritative-docs-present',
+            severity: 'error',
+            filePath: normalizedPath,
+            line: 1,
+            summary: `正本ドキュメント ${docPath} が harness の検査対象に含まれていない。`,
+            recommendation:
+              'architecture-harness 実行時は正本ドキュメントを必ず読み込み、原則の欠落を検出できるようにする。',
+          });
+        }
+      }
+
+      if (file.content.includes('## Invariants')) {
+        for (const invariant of REQUIRED_INVARIANTS) {
+          if (!file.content.includes(invariant)) {
+            findings.push({
+              ruleId: 'required-invariant-missing',
+              severity: 'error',
+              filePath: normalizedPath,
+              line: 1,
+              summary: `architecture harness から ${invariant} が欠落している。`,
+              recommendation:
+                '原則 ID を docs/architecture/harness.md に明示し、他文書と hook から参照できるようにする。',
+            });
+          }
+        }
+      }
+
+      return findings;
+    },
+  },
+  {
+    id: 'architecture-doc-links-harness',
+    evaluate({ normalizedPath, file, lines }) {
+      if (normalizedPath !== 'docs/architecture/architecture.md') {
+        return [];
+      }
+
+      if (file.content.includes('docs/architecture/harness.md')) {
+        return [];
+      }
+
+      return [
+        {
+          ruleId: 'architecture-doc-links-harness',
+          severity: 'error',
+          filePath: normalizedPath,
+          line: 1,
+          summary:
+            'アーキテクチャ正本が architecture harness を参照しておらず、不変条件の所在が分散する。',
+          recommendation:
+            'docs/architecture/architecture.md から docs/architecture/harness.md を明示的に参照する。',
+        },
+      ];
+    },
+  },
+  {
+    id: 'agent-guides-run-harness',
+    evaluate({ normalizedPath, file, lines }) {
+      if (
+        normalizedPath !== 'AGENTS.md' &&
+        normalizedPath !== 'CLAUDE.md' &&
+        normalizedPath !== 'docs/CONTRIBUTING.md'
+      ) {
+        return [];
+      }
+
+      if (
+        file.content.includes('bun scripts/architecture-harness.ts --staged')
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          ruleId: 'agent-guides-run-harness',
+          severity: 'error',
+          filePath: normalizedPath,
+          line: firstMatchLine(lines, /make before-commit/),
+          summary:
+            'エージェント/コントリビューター向け正本に architecture harness 実行が書かれていない。',
+          recommendation:
+            'Codex と Claude Code のどちらも同じ pre-commit と手動チェックを辿るよう、bun scripts/architecture-harness.ts --staged を明記する。',
+        },
+      ];
+    },
+  },
+  {
+    id: 'serverful-platform-runtime',
+    evaluate({ normalizedPath, file, lines }) {
+      if (
+        !normalizedPath.startsWith('backend/services/control-plane/') &&
+        !normalizedPath.startsWith(
+          'backend/services/application-plane/tenant-provisioner/',
+        ) &&
+        !normalizedPath.startsWith('infrastructure/') &&
+        !SERVERFUL_DOC_PATHS.includes(
+          normalizedPath as (typeof SERVERFUL_DOC_PATHS)[number],
+        )
+      ) {
+        return [];
+      }
+
+      if (
+        normalizedPath.startsWith('infrastructure/reference/') ||
+        normalizedPath.startsWith('reference/')
+      ) {
+        return [];
+      }
+
+      const pattern =
+        /\b(ECS|EKS|Fargate|RDS|NatGateway|NAT Gateway|aws_ecs|aws_eks|aws_db_instance)\b/;
+      if (!pattern.test(file.content)) {
+        return [];
+      }
+
+      const matchingLine = lines.find((line) => {
+        pattern.lastIndex = 0;
+        if (!pattern.test(line)) {
+          return false;
+        }
+
+        return !/(禁止|持ち込まない|使わない|ではない|ではなく|not use|must not|do not)/i.test(
+          line,
+        );
+      });
+      if (!matchingLine) {
+        return [];
+      }
+
+      return [
+        {
+          ruleId: 'serverful-platform-runtime',
+          severity: 'error',
+          filePath: normalizedPath,
+          line: firstMatchLine(
+            lines,
+            new RegExp(matchingLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+          ),
+          summary:
+            'platform / tenant runtime の正本に serverful 前提が入り込んでいる。',
+          recommendation:
+            'Control Plane と tenant Application Plane は serverless-only とし、ECS/EKS/RDS/NAT 前提を正本から排除する。',
+        },
+      ];
+    },
+  },
+  {
+    id: 'control-plane-deploys-problem-runtime',
+    evaluate({ normalizedPath, file, lines }) {
+      if (!normalizedPath.startsWith('backend/services/control-plane/')) {
+        return [];
+      }
+
+      const pattern =
+        /\b(CloudFormationClient|CreateStackCommand|DeleteStackCommand|DescribeStacksCommand|ValidateTemplateCommand|AssumeRoleCommand)\b/;
+      if (!pattern.test(file.content)) {
+        return [];
+      }
+
+      return [
+        {
+          ruleId: 'control-plane-deploys-problem-runtime',
+          severity: 'error',
+          filePath: normalizedPath,
+          line: firstMatchLine(lines, pattern),
+          summary:
+            'Control Plane が problem runtime deployment の実行系を持ち込んでいる。',
+          recommendation:
+            '競技者 AWS アカウントへの AssumeRole + CloudFormation は tenant Application Plane 側へ閉じ込める。',
+        },
+      ];
+    },
+  },
+];
+
+export function analyzeArchitecture(
+  files: ArchitectureFile[],
+): ArchitectureReport {
+  const filteredFiles = files.filter((file) =>
+    shouldAnalyzeArchitectureFile(file.path),
+  );
+  const filesByPath = new Map(
+    filteredFiles.map((file) => [normalizeFilePath(file.path), file]),
+  );
+
+  const findings = filteredFiles
+    .flatMap((file) => {
+      const normalizedPath = normalizeFilePath(file.path);
+      const lines = file.content.split(/\r?\n/);
+      return rules.flatMap((rule) =>
+        rule.evaluate({
+          file,
+          normalizedPath,
+          lines,
+          filesByPath,
+        }),
+      );
+    })
+    .sort((left, right) => left.filePath.localeCompare(right.filePath));
+
+  const summary = findings.reduce(
+    (accumulator, finding) => {
+      accumulator[finding.severity] += 1;
+      accumulator.total += 1;
+      return accumulator;
+    },
+    { error: 0, warning: 0, total: 0 },
+  );
+
+  return {
+    findings,
+    summary,
+    nextActions: findings
+      .slice(0, 5)
+      .map(
+        (finding) =>
+          `${finding.filePath}: ${finding.summary} ${finding.recommendation}`,
+      ),
+  };
+}
+
+export function formatArchitectureReportAsMarkdown(
+  report: ArchitectureReport,
+): string {
+  const lines = [
+    '# Architecture Harness Report',
+    '',
+    '## Summary',
+    '',
+    `- Error: ${report.summary.error}`,
+    `- Warning: ${report.summary.warning}`,
+    `- Total: ${report.summary.total}`,
+    '',
+    '## Next Actions',
+    '',
+    ...report.nextActions.map((action, index) => `${index + 1}. ${action}`),
+    '',
+    '## Findings',
+    '',
+  ];
+
+  for (const finding of report.findings) {
+    lines.push(`### ${finding.ruleId}`);
+    lines.push('');
+    lines.push(`- File: \`${finding.filePath}:${finding.line}\``);
+    lines.push(`- Severity: ${finding.severity}`);
+    lines.push(`- Summary: ${finding.summary}`);
+    lines.push(`- Recommendation: ${finding.recommendation}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function hasArchitectureFindingsAtOrAboveSeverity(
+  report: ArchitectureReport,
+  threshold: ArchitectureSeverity,
+): boolean {
+  const rank = { warning: 1, error: 2 } satisfies Record<
+    ArchitectureSeverity,
+    number
+  >;
+  return report.findings.some(
+    (finding) => rank[finding.severity] >= rank[threshold],
+  );
+}

--- a/packages/shared/src/quality/index.ts
+++ b/packages/shared/src/quality/index.ts
@@ -4,6 +4,13 @@ export {
   hasFindingsAtOrAboveSeverity,
   shouldAnalyzeFile,
 } from './tech-debt-loop';
+export {
+  analyzeArchitecture,
+  formatArchitectureReportAsMarkdown,
+  getArchitectureHarnessAuthoritativePaths,
+  hasArchitectureFindingsAtOrAboveSeverity,
+  shouldAnalyzeArchitectureFile,
+} from './architecture-harness';
 export type {
   DebtFinding,
   DebtHotspot,
@@ -11,3 +18,9 @@ export type {
   ImprovementReport,
   RepositoryFile,
 } from './tech-debt-loop';
+export type {
+  ArchitectureFile,
+  ArchitectureFinding,
+  ArchitectureReport,
+  ArchitectureSeverity,
+} from './architecture-harness';

--- a/scripts/architecture-harness.ts
+++ b/scripts/architecture-harness.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+
+import { execFileSync } from 'node:child_process';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  analyzeArchitecture,
+  formatArchitectureReportAsMarkdown,
+  getArchitectureHarnessAuthoritativePaths,
+  hasArchitectureFindingsAtOrAboveSeverity,
+  shouldAnalyzeArchitectureFile,
+  type ArchitectureFile,
+  type ArchitectureSeverity,
+} from '../packages/shared/src/quality';
+
+interface CliOptions {
+  root: string;
+  staged: boolean;
+  failOn?: ArchitectureSeverity;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    root: process.cwd(),
+    staged: false,
+    failOn: undefined,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--staged') {
+      options.staged = true;
+      continue;
+    }
+    if (arg.startsWith('--root=')) {
+      options.root = path.resolve(arg.slice('--root='.length));
+      continue;
+    }
+    if (arg.startsWith('--fail-on=')) {
+      const severity = arg.slice('--fail-on='.length) as ArchitectureSeverity;
+      if (severity === 'error' || severity === 'warning') {
+        options.failOn = severity;
+      }
+    }
+  }
+
+  return options;
+}
+
+async function collectRepositoryFiles(root: string): Promise<ArchitectureFile[]> {
+  const files: ArchitectureFile[] = [];
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDir, entry.name);
+      const relativePath = path.relative(root, absolutePath);
+
+      if (entry.isDirectory()) {
+        if (
+          ['node_modules', '.git', '.next', 'coverage', 'dist', 'build', 'out']
+            .includes(entry.name)
+        ) {
+          continue;
+        }
+        await walk(absolutePath);
+        continue;
+      }
+
+      if (!shouldAnalyzeArchitectureFile(relativePath)) {
+        continue;
+      }
+
+      files.push({
+        path: relativePath,
+        content: await readFile(absolutePath, 'utf8'),
+      });
+    }
+  }
+
+  await walk(root);
+  return files;
+}
+
+async function collectStagedFiles(root: string): Promise<ArchitectureFile[]> {
+  const output = execFileSync(
+    'git',
+    ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+    {
+      cwd: root,
+      encoding: 'utf8',
+    }
+  );
+
+  const paths = new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((filePath) => shouldAnalyzeArchitectureFile(filePath))
+  );
+
+  for (const filePath of getArchitectureHarnessAuthoritativePaths()) {
+    paths.add(filePath);
+  }
+
+  const files = await Promise.all(
+    [...paths].map(async (filePath) => ({
+      path: filePath,
+      content: await readFile(path.join(root, filePath), 'utf8'),
+    }))
+  );
+
+  return files;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const files = options.staged
+    ? await collectStagedFiles(options.root)
+    : await collectRepositoryFiles(options.root);
+
+  const report = analyzeArchitecture(files);
+  console.log(formatArchitectureReportAsMarkdown(report));
+
+  if (
+    options.failOn &&
+    hasArchitectureFindingsAtOrAboveSeverity(report, options.failOn)
+  ) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('[architecture-harness] failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a repo-local architecture harness that enforces serverless-only and one-pass invariants for both Codex and Claude Code
- make the harness part of pre-commit and document it in the authoritative docs
- mark older design and plan docs as historical and point them back to the current architecture source of truth

## Verification
- bun scripts/architecture-harness.ts --fail-on=error
- make before-commit

## Follow-up issues
- https://github.com/susumutomita/TenkaCloud/issues/371
- https://github.com/susumutomita/TenkaCloud/issues/372
- https://github.com/susumutomita/TenkaCloud/issues/373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Architecture harness system for enforcing platform invariants with automated pre-commit validation.
  * Support for multiple admin role types (admin, platform-admin, tenant-admin, organizer) with configurable role assignment.
  * AWS deployment engine with External ID support for competitor account access.
  * External ID field for competitor account management with auto-generation capability.
  * Gameday interface redesigned with improved navigation and controls.

* **Bug Fixes**
  * Vote page now correctly handles candidate ranking with zero votes.
  * Improved error handling for CloudFormation stack operations.

* **Documentation**
  * Architecture invariants and one-pass completion guidelines documented.
  * Contributor workflow updated with quality gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->