### PR TITLE
Fix GameDay header: Cloudscape TopNavigation + notification bell

### DIFF
--- a/apps/application-plane/app/(participant)/gameday/[eventId]/__tests__/layout.test.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/__tests__/layout.test.tsx
@@ -27,6 +27,16 @@ vi.mock('@/lib/api/gameday', () => ({
   getLeaderboard: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock('@/lib/notifications', () => ({
+  useNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    markAsRead: vi.fn(),
+    markAllRead: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
 vi.mock('@/components/notifications/notification-panel', () => ({
   NotificationPanel: () => <div data-testid="notification-panel" />,
 }));

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -22,6 +22,7 @@ import {
 import type { GameState } from '@/lib/api/gameday-types';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { NotificationPanel } from '@/components/notifications/notification-panel';
+import { useNotifications } from '@/lib/notifications';
 import { useI18n } from '@/lib/i18n';
 
 interface GamedayLayoutProps {
@@ -33,11 +34,13 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { eventId, teamId, teamName } = useGamedaySession();
+  const { unreadCount } = useNotifications();
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [score, setScore] = useState<number | undefined>();
   const [rank, setRank] = useState<number | undefined>();
   const [awsConsoleLoading, setAwsConsoleLoading] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [notifOpen, setNotifOpen] = useState(false);
 
   const basePath = `/gameday/${eventId}`;
 
@@ -210,6 +213,29 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
                     ]
                   : []),
                 {
+                  type: 'button' as const,
+                  iconSvg: (
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+                      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+                    </svg>
+                  ),
+                  badge: unreadCount > 0,
+                  ariaLabel: `通知${unreadCount > 0 ? ` (${unreadCount}件の未読)` : ''}`,
+                  disableUtilityCollapse: true,
+                  onClick: () => setNotifOpen((prev) => !prev),
+                },
+                {
                   type: 'menu-dropdown' as const,
                   text: locale.toUpperCase(),
                   ariaLabel:
@@ -240,17 +266,21 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
                 overflowMenuTitleText: 'すべて',
               }}
             />
-            <div
-              style={{
-                position: 'absolute',
-                right: '320px',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                zIndex: 1000,
-              }}
-            >
-              <NotificationPanel />
-            </div>
+            {notifOpen && (
+              <div
+                style={{
+                  position: 'fixed',
+                  top: '56px',
+                  right: '8px',
+                  zIndex: 2000,
+                }}
+              >
+                <NotificationPanel
+                  isOpen={notifOpen}
+                  onClose={() => setNotifOpen(false)}
+                />
+              </div>
+            )}
           </>
         ) : null}
       </div>

--- a/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
+++ b/apps/application-plane/app/(participant)/gameday/[eventId]/layout.tsx
@@ -171,7 +171,12 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
       : `${t('gameday.rank')}: --`;
 
   return (
-    <div className="awsui-dark-mode">
+    <div
+      className="awsui-dark-mode"
+      style={{
+        background: 'var(--color-background-container-content-6u8rvp, #161d26)',
+      }}
+    >
       <div id="gameday-top-nav" style={{ position: 'relative', minHeight: 72 }}>
         {mounted ? (
           <>
@@ -238,7 +243,7 @@ export default function GamedayLayout({ children }: GamedayLayoutProps) {
             <div
               style={{
                 position: 'absolute',
-                right: '200px',
+                right: '320px',
                 top: '50%',
                 transform: 'translateY(-50%)',
                 zIndex: 1000,

--- a/apps/application-plane/components/notifications/notification-panel.tsx
+++ b/apps/application-plane/components/notifications/notification-panel.tsx
@@ -2,6 +2,13 @@
  * Notification Panel
  *
  * Cloudscape Flashbar による通知表示、ベルアイコン + ドロップダウンパネル
+ *
+ * Usage A (self-contained): <NotificationPanel />
+ *   Renders its own bell trigger and manages open/close state internally.
+ *
+ * Usage B (controlled): <NotificationPanel isOpen={open} onClose={handleClose} />
+ *   Renders only the dropdown panel; caller owns the trigger and open state.
+ *   Use this when the bell lives inside a Cloudscape TopNavigation utility.
  */
 
 'use client';
@@ -16,6 +23,13 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNotifications } from '@/lib/notifications';
 import type { Notification, NotificationSeverity } from '@/lib/notifications';
+
+interface NotificationPanelProps {
+  /** Controlled mode: panel open state managed by the caller. */
+  isOpen?: boolean;
+  /** Controlled mode: called when the panel should close (outside click). */
+  onClose?: () => void;
+}
 
 function mapSeverityToFlashType(
   severity: NotificationSeverity,
@@ -40,32 +54,39 @@ function formatTimestamp(timestamp: string): string {
   });
 }
 
-export function NotificationPanel() {
+export function NotificationPanel({ isOpen, onClose }: NotificationPanelProps) {
   const { notifications, unreadCount, markAsRead, markAllRead, clearAll } =
     useNotifications();
 
-  const [isOpen, setIsOpen] = useState(false);
+  const controlled = isOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const panelOpen = controlled ? isOpen : internalOpen;
+
   const panelRef = useRef<HTMLDivElement>(null);
 
   const handleToggle = useCallback(() => {
-    setIsOpen((prev) => !prev);
+    setInternalOpen((prev) => !prev);
   }, []);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!panelOpen) return;
 
     const handleClickOutside = (event: MouseEvent) => {
       if (
         panelRef.current &&
         !panelRef.current.contains(event.target as Node)
       ) {
-        setIsOpen(false);
+        if (controlled) {
+          onClose?.();
+        } else {
+          setInternalOpen(false);
+        }
       }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
+  }, [panelOpen, controlled, onClose]);
 
   const flashItems: FlashbarProps.MessageDefinition[] = useMemo(
     () =>
@@ -88,6 +109,71 @@ export function NotificationPanel() {
     [notifications, markAsRead],
   );
 
+  const dropdown = panelOpen ? (
+    <div
+      data-testid="notification-dropdown"
+      style={{
+        width: '420px',
+        maxHeight: '500px',
+        overflowY: 'auto',
+        background: 'var(--color-background-container-content)',
+        border: '1px solid var(--color-border-divider-default)',
+        borderRadius: '8px',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--color-border-divider-default)',
+        }}
+      >
+        <Header
+          variant="h3"
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                variant="link"
+                onClick={markAllRead}
+                disabled={unreadCount === 0}
+              >
+                すべて既読
+              </Button>
+              <Button
+                variant="link"
+                onClick={clearAll}
+                disabled={notifications.length === 0}
+              >
+                すべて削除
+              </Button>
+            </SpaceBetween>
+          }
+        >
+          通知
+        </Header>
+      </div>
+      <div style={{ padding: '8px' }}>
+        {notifications.length === 0 ? (
+          <Box textAlign="center" padding="l" color="text-body-secondary">
+            通知はありません
+          </Box>
+        ) : (
+          <Flashbar items={flashItems} />
+        )}
+      </div>
+    </div>
+  ) : null;
+
+  /* Controlled mode: only render the dropdown (no trigger button). */
+  if (controlled) {
+    return (
+      <div ref={panelRef} data-testid="notification-panel">
+        {dropdown}
+      </div>
+    );
+  }
+
+  /* Self-contained mode: render bell trigger + dropdown. */
   return (
     <div
       ref={panelRef}
@@ -126,62 +212,9 @@ export function NotificationPanel() {
         {unreadCount > 0 && <Badge color="red">{`${unreadCount}`}</Badge>}
       </button>
 
-      {isOpen && (
-        <div
-          data-testid="notification-dropdown"
-          style={{
-            position: 'absolute',
-            right: 0,
-            top: '100%',
-            width: '420px',
-            maxHeight: '500px',
-            overflowY: 'auto',
-            zIndex: 1000,
-            background: 'var(--color-background-container-content)',
-            border: '1px solid var(--color-border-divider-default)',
-            borderRadius: '8px',
-            boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
-          }}
-        >
-          <div
-            style={{
-              padding: '12px 16px',
-              borderBottom: '1px solid var(--color-border-divider-default)',
-            }}
-          >
-            <Header
-              variant="h3"
-              actions={
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={markAllRead}
-                    disabled={unreadCount === 0}
-                  >
-                    すべて既読
-                  </Button>
-                  <Button
-                    variant="link"
-                    onClick={clearAll}
-                    disabled={notifications.length === 0}
-                  >
-                    すべて削除
-                  </Button>
-                </SpaceBetween>
-              }
-            >
-              通知
-            </Header>
-          </div>
-          <div style={{ padding: '8px' }}>
-            {notifications.length === 0 ? (
-              <Box textAlign="center" padding="l" color="text-body-secondary">
-                通知はありません
-              </Box>
-            ) : (
-              <Flashbar items={flashItems} />
-            )}
-          </div>
+      {dropdown && (
+        <div style={{ position: 'absolute', right: 0, top: '100%' }}>
+          {dropdown}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Replace custom Tailwind header with Cloudscape `TopNavigation` + `AppLayout` + `SideNavigation` to match the design system
- Add score, rank, locale switcher, and team dropdown as proper Cloudscape utility items
- Move notification bell out of fragile absolute-position overlay and into the `TopNavigation` utilities using `iconSvg` + `badge` — Cloudscape handles placement correctly
- Notification dropdown now renders as `position: fixed` (top: 56px, right: 8px) via controlled `isOpen`/`onClose` props on `NotificationPanel`
- Add Cloudscape dark background (`#161d26`) to the layout wrapper so any gap between nav and AppLayout matches the theme

## Test plan

- [x] All 1119 tests pass
- [x] `make before-commit` passes (lint, format, typecheck, coverage, build)
- [x] Bell icon appears correctly in the TopNavigation between Rank and locale dropdown
- [x] Clicking bell opens notification dropdown below nav bar
- [x] No color strip at top of page

🤖 Generated with [Claude Code](https://claude.com/claude-code)