### PR TITLE
fix: close local one-pass on Kumo and DynamoDB Local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: help install install_ci setup_husky clean lint lint_text format format_check before_commit before-commit start test test_quick test_coverage test_e2e test_e2e_ui test_e2e_headed dev build
+.PHONY: help install install_ci setup_husky clean lint lint_text format format_check before_commit before-commit start test test_quick test_coverage test_e2e test_e2e_ui test_e2e_headed test_one_pass_local test_one_pass_aws dev build
 .PHONY: start-compose stop-compose stop stop-dev-servers restart status
-.PHONY: start-infrastructure start-infrastructure-bg start-dev-servers start-control-plane stop-infrastructure stop-control-plane restart-all
+.PHONY: start-infrastructure start-infrastructure-bg start-dev-servers start-one-pass-local start-control-plane stop-infrastructure stop-control-plane restart-all
 .PHONY: check-docker check-docker-hub docker-build docker-run docker-stop docker-status
 .PHONY: start-local stop-local start-kumo start-localstack start-floci logs-local test-lambda test-tenant init-db seed-data
 .PHONY: auth0-check-tfvars auth0-init auth0-plan auth0-apply auth0-output auth0-setup
@@ -177,6 +177,14 @@ test_e2e_headed:
 	@cd $(CONTROL_PLANE_DIR) && $(NLX) playwright install chromium --with-deps
 	@cd $(CONTROL_PLANE_DIR) && $(NR) test:e2e:headed
 
+test_one_pass_local:
+	@echo "🧪 one-pass local harness を実行中..."
+	$(BUN) scripts/one-pass.ts --target=local
+
+test_one_pass_aws:
+	@echo "🧪 one-pass aws harness を実行中..."
+	$(BUN) scripts/one-pass.ts --target=aws
+
 before_commit: lint_text format_check typecheck test_coverage build
 	@echo "✅ すべてのコミット前チェックが完了しました"
 
@@ -215,10 +223,10 @@ check-docker-hub:
 # 🚀 起動・停止（統合コマンド）
 # ========================================
 
-# make start: LocalStack + フロントエンド開発サーバーをすべて起動
+# make start: クラウドエミュレータ + DynamoDB Local + フロントエンド開発サーバーをすべて起動
 start: start-infrastructure-bg start-dev-servers
 
-# make start-infrastructure: エミュレータのみ起動
+# make start-infrastructure: エミュレータ + DynamoDB Local のみ起動
 start-infrastructure: start-local
 
 # バックグラウンドでエミュレータを起動し、準備完了を待つ
@@ -243,10 +251,11 @@ start-dev-servers: start-local
 	@echo "  - GameDay API:        http://localhost:3020/api/gameday"
 	@echo "  - Realtime WS:        ws://localhost:3013/ws"
 	@echo "  - Cloud Emulator:     http://localhost:4566"
+	@echo "  - DynamoDB Local:     http://localhost:8000"
 	@echo ""
 	@echo "💡 終了するには Ctrl+C を押してください"
 	@echo ""
-	DYNAMODB_ENDPOINT=$(EMULATOR_ENDPOINT) \
+	DYNAMODB_ENDPOINT=$(DYNAMODB_LOCAL_ENDPOINT) \
 	DYNAMODB_TABLE=$(LOCAL_TABLE) \
 	DYNAMODB_TABLE_NAME=$(LOCAL_TABLE) \
 	AWS_REGION=ap-northeast-1 \
@@ -255,6 +264,36 @@ start-dev-servers: start-local
 	TENANT_API_BASE_URL=http://localhost:13004/api \
 	AUTH_SECRET=local-dev-secret-do-not-use-in-production \
 	AUTH_SKIP=1 \
+	NEXT_PUBLIC_AUTH_SKIP=1 \
+	NEXT_PUBLIC_APPLICATION_PLANE_URL=http://localhost:13001 \
+	$(NR) dev
+
+start-one-pass-local: start-local
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🧪 one-pass local 用の開発サーバーを起動します"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "📋 前提:"
+	@echo "  - provisioning publish を有効化"
+	@echo "  - dev identity header で admin / participant を切り替え"
+	@echo "  - shared Application Plane 上で one-pass blocker を可視化"
+	@echo ""
+	DYNAMODB_ENDPOINT=$(DYNAMODB_LOCAL_ENDPOINT) \
+	DYNAMODB_TABLE=$(LOCAL_TABLE) \
+	DYNAMODB_TABLE_NAME=$(LOCAL_TABLE) \
+	AWS_REGION=ap-northeast-1 \
+	AWS_ACCESS_KEY_ID=test \
+	AWS_SECRET_ACCESS_KEY=test \
+	AWS_ENDPOINT_URL=$(EMULATOR_ENDPOINT) \
+	EVENT_BUS_NAME=tenkacloud-local-tenant-events \
+	DATA_BUCKET_NAME=tenkacloud-local-data \
+	PROVISIONING_ENABLED=true \
+	PROVISIONING_DELIVERY_MODE=inline \
+	TENANT_API_BASE_URL=http://localhost:13004/api \
+	AUTH_SECRET=local-dev-secret-do-not-use-in-production \
+	AUTH_SKIP=1 \
+	AUTH_SKIP_ROLES=participant \
 	NEXT_PUBLIC_AUTH_SKIP=1 \
 	NEXT_PUBLIC_APPLICATION_PLANE_URL=http://localhost:13001 \
 	$(NR) dev
@@ -449,13 +488,14 @@ help:
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo ""
 	@echo "🚀 起動・停止（統合コマンド）:"
-	@echo "  make start            LocalStack + フロントエンド開発サーバーをすべて起動"
-	@echo "  make start-infrastructure  LocalStack のみ起動（バックエンドのみ）"
+	@echo "  make start            クラウドエミュレータ + DynamoDB Local + フロントエンド開発サーバーをすべて起動"
+	@echo "  make start-one-pass-local  one-pass local 用の権限・provisioning 付きで起動"
+	@echo "  make start-infrastructure  クラウドエミュレータ + DynamoDB Local のみ起動（バックエンドのみ）"
 	@echo "  make stop             LocalStack を停止"
 	@echo "  make restart          サービスを再起動"
 	@echo "  make status           サービス状態を表示"
 	@echo ""
-	@echo "🧪 LocalStack テスト:"
+	@echo "🧪 ローカルエミュレータ テスト:"
 	@echo "  make test-tenant      テスト用テナントを作成（プロビジョニングフロー起動）"
 	@echo "  make logs-local       プロビジョニング Lambda のログを表示"
 	@echo ""
@@ -483,6 +523,7 @@ help:
 	@echo "  make test_e2e         E2E テストを実行（Playwright）"
 	@echo "  make test_e2e_ui      E2E テストを UI モードで実行"
 	@echo "  make test_e2e_headed  E2E テストを headed モードで実行"
+	@echo "  make test_one_pass_local  one-pass local harness を実行"
 	@echo ""
 	@echo "🏗  ビルド:"
 	@echo "  make dev              開発サーバーを起動 (Control Plane のみ)"
@@ -529,6 +570,7 @@ help:
 # エミュレータ選択: kumo（デフォルト）/ localstack / floci
 CLOUD_EMULATOR ?= kumo
 EMULATOR_ENDPOINT := http://localhost:4566
+DYNAMODB_LOCAL_ENDPOINT := http://localhost:8000
 LOCAL_TABLE := TenkaCloud-local
 LOCAL_LAMBDA := tenkacloud-local-provisioning
 

--- a/apps/application-plane/app/api/gameday/teams/__tests__/routes.test.ts
+++ b/apps/application-plane/app/api/gameday/teams/__tests__/routes.test.ts
@@ -14,8 +14,12 @@ vi.mock('@/lib/api/backend-urls', () => ({
 describe('GameDay Team Route Fallbacks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('AUTH_SKIP', '1');
+    vi.stubEnv('NODE_ENV', 'test');
     mockAuth.mockResolvedValue({
       user: { email: 'dev@example.com' },
+      tenantId: 'dev-tenant',
+      roles: ['participant'],
     });
     mockGetGamedayApiUrl.mockReturnValue('http://gameday.local');
   });
@@ -310,6 +314,11 @@ describe('GameDay Team Route Fallbacks', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'http://gameday.local/teams/solo',
       expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-TenkaCloud-Dev-User-Id': 'dev@example.com',
+          'X-TenkaCloud-Dev-Tenant-Id': 'dev-tenant',
+          'X-TenkaCloud-Dev-Roles': 'participant',
+        }),
         body: JSON.stringify({
           eventId: 'dev-event-1',
         }),
@@ -334,7 +343,13 @@ describe('GameDay Team Route Fallbacks', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://gameday.local/teams/my-membership?eventId=dev-event-2',
-      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-TenkaCloud-Dev-User-Id': 'dev@example.com',
+          'X-TenkaCloud-Dev-Tenant-Id': 'dev-tenant',
+          'X-TenkaCloud-Dev-Roles': 'participant',
+        }),
+      }),
     );
   });
 });

--- a/apps/application-plane/app/api/gameday/teams/my-membership/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/my-membership/route.ts
@@ -18,12 +18,27 @@ export async function GET(request: NextRequest) {
 
   const session = await auth();
   const userId = session?.user?.email ?? 'anonymous';
+  const shouldForwardDevIdentity =
+    process.env.AUTH_SKIP === '1' && process.env.NODE_ENV !== 'production';
 
   try {
     const gamedayUrl = getGamedayApiUrl();
     const response = await fetch(
       `${gamedayUrl}/teams/my-membership?eventId=${encodeURIComponent(eventId)}`,
-      { headers: { 'Content-Type': 'application/json' } },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(shouldForwardDevIdentity
+            ? {
+                'X-TenkaCloud-Dev-User-Id': userId,
+                'X-TenkaCloud-Dev-Tenant-Id': session?.tenantId ?? 'dev-tenant',
+                'X-TenkaCloud-Dev-Roles': (
+                  session?.roles ?? ['participant']
+                ).join(','),
+              }
+            : {}),
+        },
+      },
     );
     const data = await response.json();
     return Response.json(data, { status: response.status });

--- a/apps/application-plane/app/api/gameday/teams/solo/route.ts
+++ b/apps/application-plane/app/api/gameday/teams/solo/route.ts
@@ -25,12 +25,25 @@ export async function POST(request: Request) {
   const body = parseResult.data;
   const session = await auth();
   const userId = session?.user?.email ?? 'anonymous';
+  const shouldForwardDevIdentity =
+    process.env.AUTH_SKIP === '1' && process.env.NODE_ENV !== 'production';
 
   try {
     const gamedayUrl = getGamedayApiUrl();
     const response = await fetch(`${gamedayUrl}/teams/solo`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(shouldForwardDevIdentity
+          ? {
+              'X-TenkaCloud-Dev-User-Id': userId,
+              'X-TenkaCloud-Dev-Tenant-Id': session?.tenantId ?? 'dev-tenant',
+              'X-TenkaCloud-Dev-Roles': (
+                session?.roles ?? ['participant']
+              ).join(','),
+            }
+          : {}),
+      },
       body: JSON.stringify(body),
     });
     const data = await response.json();

--- a/apps/application-plane/lib/__tests__/i18n.test.tsx
+++ b/apps/application-plane/lib/__tests__/i18n.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { detectLocale, I18nProvider, resolveMessage, useI18n } from '../i18n';
+import { createLocalStorageMock } from './test-helpers';
 
 const mockReplace = vi.fn();
 let mockPathname = '/dashboard';
@@ -35,6 +36,10 @@ describe('i18n', () => {
     mockReplace.mockReset();
     mockPathname = '/dashboard';
     mockSearchParams = null;
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: createLocalStorageMock(),
+    });
     window.localStorage.clear();
     document.documentElement.lang = 'en';
     vi.stubGlobal('navigator', {

--- a/apps/application-plane/lib/__tests__/test-helpers.ts
+++ b/apps/application-plane/lib/__tests__/test-helpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared test utilities
+ */
+
+/**
+ * localStorage の Map ベースのモック実装
+ *
+ * jsdom の localStorage は setItem/getItem が別テスト間で状態を共有することがある。
+ * beforeEach で Object.defineProperty して新しいインスタンスを使うことで分離できる。
+ */
+export function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: /* istanbul ignore next */ (index: number) =>
+      [...store.keys()][index] ?? null,
+    removeItem: /* istanbul ignore next */ (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    /* istanbul ignore next */
+    get length() {
+      return store.size;
+    },
+  } satisfies Storage;
+}

--- a/apps/application-plane/lib/notifications/__tests__/context.test.tsx
+++ b/apps/application-plane/lib/notifications/__tests__/context.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationProvider, useNotifications } from '../context';
+import { createLocalStorageMock } from '../../__tests__/test-helpers';
 
 function createWrapper() {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -11,6 +12,10 @@ function createWrapper() {
 
 describe('NotificationProvider', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: createLocalStorageMock(),
+    });
     window.localStorage.clear();
     vi.restoreAllMocks();
   });

--- a/backend/services/application-plane/gameday-service/src/api/participant.test.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.test.ts
@@ -1615,6 +1615,34 @@ describe('プレーヤー API', () => {
       expect(res.status).toBe(StatusCodes.CREATED);
       const body = await res.json();
       expect(body.mode).toBe('solo');
+      expect(body.teamId).toBe('solo-user-1');
+      expect(body.teamName).toBe('ソロ参加');
+      expect(mockDashboardService.registerTeam).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        teamId: 'solo-user-1',
+        teamName: 'ソロ参加',
+      });
+      expect(mockGamedayRepository.addMember).toHaveBeenCalledWith({
+        eventId: 'event-1',
+        userId: 'user-1',
+        teamId: 'solo-user-1',
+        teamName: 'ソロ参加',
+        mode: 'solo',
+      });
+    });
+
+    it('ソロチームが既に存在する場合でも参加登録できるべき', async () => {
+      mockDashboardService.registerTeam.mockRejectedValueOnce(
+        new mockDashboardService.TeamAlreadyExistsError('solo-user-1'),
+      );
+
+      const res = await app.request('/teams/solo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventId: 'event-1' }),
+      });
+
+      expect(res.status).toBe(StatusCodes.CREATED);
       expect(mockGamedayRepository.addMember).toHaveBeenCalledWith({
         eventId: 'event-1',
         userId: 'user-1',

--- a/backend/services/application-plane/gameday-service/src/api/participant.ts
+++ b/backend/services/application-plane/gameday-service/src/api/participant.ts
@@ -850,14 +850,29 @@ participantRoutes.post("/teams/solo", async (c) => {
 		);
 	}
 	const userId = c.get("auth").userId;
+	const teamId = `solo-${userId}`;
+	const teamName = "ソロ参加";
+
+	try {
+		await registerTeam({
+			eventId: parsed.data.eventId,
+			teamId,
+			teamName,
+		});
+	} catch (error) {
+		if (!(error instanceof TeamAlreadyExistsError)) {
+			throw error;
+		}
+	}
+
 	await gamedayRepo.addMember({
 		eventId: parsed.data.eventId,
 		userId,
-		teamId: `solo-${userId}`,
-		teamName: "ソロ参加",
+		teamId,
+		teamName,
 		mode: "solo",
 	});
-	return c.json({ mode: "solo" }, StatusCodes.CREATED);
+	return c.json({ mode: "solo", teamId, teamName }, StatusCodes.CREATED);
 });
 
 // === メンバーシップ取得 ===

--- a/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth-middleware.test.ts
@@ -81,6 +81,29 @@ describe("authMiddleware", () => {
 
 			expect(body.roles).toEqual(["tenant-admin", "participant"]);
 		});
+
+		it("開発用ヘッダーでモック認証コンテキストを上書きできるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+
+			const { authMiddleware } = await import("./auth");
+
+			const app = new Hono();
+			app.use("/*", authMiddleware);
+			app.get("/test", (c) => c.json(c.get("auth")));
+
+			const res = await app.request("/test", {
+				headers: {
+					"X-TenkaCloud-Dev-User-Id": "participant-2",
+					"X-TenkaCloud-Dev-Tenant-Id": "tenant-beta",
+					"X-TenkaCloud-Dev-Roles": "participant,observer",
+				},
+			});
+			const body = await res.json();
+
+			expect(body.userId).toBe("participant-2");
+			expect(body.tenantId).toBe("tenant-beta");
+			expect(body.roles).toEqual(["participant", "observer"]);
+		});
 	});
 
 	describe("AUTH_SKIP 無効", () => {

--- a/backend/services/application-plane/gameday-service/src/middleware/auth.ts
+++ b/backend/services/application-plane/gameday-service/src/middleware/auth.ts
@@ -8,6 +8,31 @@ export interface AuthContext {
 	roles: string[];
 }
 
+const DEV_USER_ID_HEADER = "x-tenkacloud-dev-user-id";
+const DEV_TENANT_ID_HEADER = "x-tenkacloud-dev-tenant-id";
+const DEV_ROLES_HEADER = "x-tenkacloud-dev-roles";
+
+function sanitizeDevIdentity(
+	value: string | undefined,
+	fallback: string,
+	maxLength = 128,
+): string {
+	if (!value) {
+		return fallback;
+	}
+
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return fallback;
+	}
+
+	const sanitized = trimmed
+		.replace(/[^A-Za-z0-9@._:/+=,-]/g, "-")
+		.slice(0, maxLength);
+
+	return sanitized || fallback;
+}
+
 declare module "hono" {
 	interface ContextVariableMap {
 		auth: AuthContext;
@@ -48,11 +73,24 @@ if (authSkipEnabled && typeof console !== "undefined") {
 }
 /* v8 ignore stop */
 
-const mockAuth: AuthContext = {
-	userId: "dev-user",
-	tenantId: "dev-tenant",
-	roles: parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES),
-};
+function createMockAuth(
+	headers?: {
+		[DEV_USER_ID_HEADER]?: string;
+		[DEV_TENANT_ID_HEADER]?: string;
+		[DEV_ROLES_HEADER]?: string;
+	},
+): AuthContext {
+	return {
+		userId: sanitizeDevIdentity(headers?.[DEV_USER_ID_HEADER], "dev-user"),
+		tenantId: sanitizeDevIdentity(
+			headers?.[DEV_TENANT_ID_HEADER],
+			"dev-tenant",
+		),
+		roles: parseAuthSkipRoles(
+			headers?.[DEV_ROLES_HEADER] ?? process.env.AUTH_SKIP_ROLES,
+		),
+	};
+}
 
 const JWKS_URI =
 	process.env.JWKS_URI ??
@@ -72,7 +110,16 @@ async function getJWKS() {
 export const authMiddleware = createMiddleware(async (c, next) => {
 	// AUTH_SKIP=1: 開発用にJWT検証をバイパス
 	if (authSkipEnabled) {
-		c.set("auth", mockAuth);
+		c.set(
+			"auth",
+			createMockAuth({
+				"x-tenkacloud-dev-user-id": c.req.header("X-TenkaCloud-Dev-User-Id"),
+				"x-tenkacloud-dev-tenant-id": c.req.header(
+					"X-TenkaCloud-Dev-Tenant-Id",
+				),
+				"x-tenkacloud-dev-roles": c.req.header("X-TenkaCloud-Dev-Roles"),
+			}),
+		);
 		await next();
 		return;
 	}

--- a/backend/services/application-plane/gameday-service/src/repositories/gameday-repository.ts
+++ b/backend/services/application-plane/gameday-service/src/repositories/gameday-repository.ts
@@ -3,7 +3,6 @@ import {
 	GetCommand,
 	UpdateCommand,
 	QueryCommand,
-	BatchWriteCommand,
 	DeleteCommand,
 	TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
@@ -434,6 +433,46 @@ export class GamedayRepository {
 		} catch (error) {
 			if (error instanceof ConditionalCheckFailedException) {
 				return null;
+			}
+			throw error;
+		}
+	}
+
+	async startExistingGame(eventId: string): Promise<GameState | null> {
+		const client = getDocClient();
+		const tableName = getTableName();
+		const now = new Date().toISOString();
+
+		try {
+			const result = await client.send(
+				new UpdateCommand({
+					TableName: tableName,
+					Key: {
+						PK: buildGamedayPK(eventId),
+						SK: buildMetadataSK(),
+					},
+					UpdateExpression:
+						"SET isRunning = :running, startedAt = :startedAt, UpdatedAt = :now",
+					ExpressionAttributeValues: {
+						":running": true,
+						":startedAt": now,
+						":now": now,
+						":alreadyRunning": true,
+					},
+					ConditionExpression:
+						"attribute_exists(PK) AND isRunning <> :alreadyRunning",
+					ReturnValues: "ALL_NEW",
+				}),
+			);
+
+			if (!result.Attributes) {
+				return null;
+			}
+
+			return toGameState(result.Attributes as GameStateItem);
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				throw new GameAlreadyExistsError(eventId);
 			}
 			throw error;
 		}
@@ -919,7 +958,10 @@ export class GamedayRepository {
 		return allItems;
 	}
 
-	async getAttack(eventId: string, slug: string): Promise<Attack | null> {
+	async getAttack(
+		eventId: string,
+		attackIdentifier: string,
+	): Promise<Attack | null> {
 		const client = getDocClient();
 		const tableName = getTableName();
 
@@ -928,46 +970,43 @@ export class GamedayRepository {
 				TableName: tableName,
 				Key: {
 					PK: buildGamedayPK(eventId),
-					SK: buildAttackSK(slug),
+					SK: buildAttackSK(attackIdentifier),
 				},
 			}),
 		);
 
-		if (!result.Item) {
-			return null;
+		if (result.Item) {
+			return toAttack(result.Item as Record<string, unknown>);
 		}
 
-		return toAttack(result.Item as Record<string, unknown>);
+		const catalog = await this.listAttackCatalog(eventId);
+		return (
+			catalog.find(
+				(attack) =>
+					attack.id === attackIdentifier || attack.slug === attackIdentifier,
+			) ?? null
+		);
 	}
 
 	async seedAttackCatalog(eventId: string, attacks: Attack[]): Promise<void> {
 		const client = getDocClient();
 		const tableName = getTableName();
 
-		// BatchWrite は最大25件ずつ
-		const chunks: Attack[][] = [];
-		for (let i = 0; i < attacks.length; i += 25) {
-			chunks.push(attacks.slice(i, i + 25));
-		}
-
-		for (const chunk of chunks) {
-			await client.send(
-				new BatchWriteCommand({
-					RequestItems: {
-						[tableName]: chunk.map((attack) => ({
-							PutRequest: {
-								Item: {
-									PK: buildGamedayPK(eventId),
-									SK: buildAttackSK(attack.slug),
-									EntityType: "ATTACK",
-									...attack,
-								},
-							},
-						})),
-					},
-				}),
-			);
-		}
+		await Promise.all(
+			attacks.map((attack) =>
+				client.send(
+					new PutCommand({
+						TableName: tableName,
+						Item: {
+							PK: buildGamedayPK(eventId),
+							SK: buildAttackSK(attack.slug),
+							EntityType: "ATTACK",
+							...attack,
+						},
+					}),
+				),
+			),
+		);
 	}
 
 	// === 攻撃購入 ===

--- a/backend/services/application-plane/gameday-service/src/services/game-controller.test.ts
+++ b/backend/services/application-plane/gameday-service/src/services/game-controller.test.ts
@@ -6,6 +6,7 @@ const { mockGamedayRepository } = vi.hoisted(() => ({
 	mockGamedayRepository: {
 		createGameState: vi.fn(),
 		initGameState: vi.fn(),
+		startExistingGame: vi.fn(),
 		getGameState: vi.fn(),
 		stopGame: vi.fn(),
 		toggleScoreWeight: vi.fn(),
@@ -35,6 +36,7 @@ import {
 	listAttackLogs,
 	seedAttackCatalog,
 	GameNotFoundError,
+	GameAlreadyExistsError,
 	CrossTenantAccessError,
 } from "./game-controller";
 
@@ -145,6 +147,27 @@ describe("ゲームコントローラーサービス", () => {
 				await startGame("event-1", TENANT_ID, 240);
 
 				expect(mockGamedayRepository.updateTeamScore).not.toHaveBeenCalled();
+			});
+
+			it("初期化済みで未開始のゲームを開始すべき", async () => {
+				const initializedState: GameState = {
+					...baseGameState,
+					isRunning: false,
+					startedAt: null,
+				};
+				mockGamedayRepository.createGameState.mockRejectedValue(
+					new GameAlreadyExistsError("event-1"),
+				);
+				mockGamedayRepository.getGameState.mockResolvedValue(initializedState);
+				mockGamedayRepository.startExistingGame.mockResolvedValue(baseGameState);
+				mockGamedayRepository.listTeams.mockResolvedValue([]);
+
+				const result = await startGame("event-1", TENANT_ID, 240);
+
+				expect(result).toEqual(baseGameState);
+				expect(mockGamedayRepository.startExistingGame).toHaveBeenCalledWith(
+					"event-1",
+				);
 			});
 		});
 	});

--- a/backend/services/application-plane/gameday-service/src/services/game-controller.ts
+++ b/backend/services/application-plane/gameday-service/src/services/game-controller.ts
@@ -82,11 +82,29 @@ export async function startGame(
 	tenantId: string,
 	durationMinutes: number,
 ): Promise<GameState> {
-	const game = await gamedayRepository.createGameState({
-		eventId,
-		tenantId,
-		durationMinutes,
-	});
+	let game: GameState;
+	try {
+		game = await gamedayRepository.createGameState({
+			eventId,
+			tenantId,
+			durationMinutes,
+		});
+	} catch (error) {
+		if (!(error instanceof GameAlreadyExistsError)) {
+			throw error;
+		}
+
+		const existingGame = await validateGameTenantAccess(eventId, tenantId);
+		if (existingGame.isRunning) {
+			throw error;
+		}
+
+		const startedGame = await gamedayRepository.startExistingGame(eventId);
+		if (!startedGame) {
+			throw new GameNotFoundError();
+		}
+		game = startedGame;
+	}
 
 	// ADR-003: ゲーム開始時に登録済みチームへ初期ポイントを付与
 	const teams = await gamedayRepository.listTeams(eventId);

--- a/backend/services/application-plane/problem-service/.env.example
+++ b/backend/services/application-plane/problem-service/.env.example
@@ -1,6 +1,7 @@
 PORT=3100
 DYNAMODB_TABLE=TenkaCloud-dev
-DYNAMODB_ENDPOINT=http://localhost:4566
+DYNAMODB_ENDPOINT=http://localhost:8000
+AWS_ENDPOINT_URL=http://localhost:4566
 AWS_REGION=ap-northeast-1
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test

--- a/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/auth.test.ts
@@ -68,7 +68,7 @@ describe("auth モジュール", () => {
 			expect(result.isValid).toBe(true);
 			expect(result.user).not.toBeNull();
 			expect(result.user!.id).toBe("dev-user");
-			expect(result.user!.email).toBe("dev@localhost");
+			expect(result.user!.email).toBe("dev-user@localhost");
 			expect(result.user!.roles).toEqual(["competitor"]);
 			expect(result.token).toBe("mock-access-token");
 		});
@@ -94,6 +94,24 @@ describe("auth モジュール", () => {
 			const result = await authenticateRequest({});
 
 			expect(result.user?.roles).toEqual(["platform-admin", "competitor"]);
+		});
+
+		it("開発用ヘッダーでユーザーとテナントとロールを上書きできるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({
+				"x-tenkacloud-dev-user-id": "tenant-admin@example.com",
+				"x-tenkacloud-dev-tenant-id": "tenant-acme",
+				"x-tenkacloud-dev-roles": "tenant-admin,participant",
+			});
+
+			expect(result.isValid).toBe(true);
+			expect(result.user?.id).toBe("tenant-admin@example.com");
+			expect(result.user?.email).toBe("tenant-admin@example.com");
+			expect(result.user?.tenantId).toBe("tenant-acme");
+			expect(result.user?.roles).toEqual(["tenant-admin", "participant"]);
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/gameday-deployer.test.ts
@@ -15,8 +15,10 @@ const mocks = vi.hoisted(() => ({
 	mockFindActive: vi.fn(),
 	mockUpdateStatus: vi.fn(),
 	mockFindById: vi.fn(),
-	mockValidateCredentials: vi.fn(),
-	mockDeployStack: vi.fn(),
+	mockValidateAwsCredentials: vi.fn(),
+	mockDeployAwsStack: vi.fn(),
+	mockValidateLocalCredentials: vi.fn(),
+	mockDeployLocalStack: vi.fn(),
 }));
 
 const {
@@ -25,8 +27,10 @@ const {
 	mockFindActive,
 	mockUpdateStatus,
 	mockFindById,
-	mockValidateCredentials,
-	mockDeployStack,
+	mockValidateAwsCredentials,
+	mockDeployAwsStack,
+	mockValidateLocalCredentials,
+	mockDeployLocalStack,
 } = mocks;
 
 vi.mock("../repositories/competitor-account-repository", () => ({
@@ -51,8 +55,15 @@ vi.mock("../repositories/gameday-deployment-job-repository", () => ({
 
 vi.mock("../providers/aws", () => ({
 	getAWSProvider: () => ({
-		validateCredentials: mocks.mockValidateCredentials,
-		deployStack: mocks.mockDeployStack,
+		validateCredentials: mocks.mockValidateAwsCredentials,
+		deployStack: mocks.mockDeployAwsStack,
+	}),
+}));
+
+vi.mock("../providers/local", () => ({
+	getLocalProvider: () => ({
+		validateCredentials: mocks.mockValidateLocalCredentials,
+		deployStack: mocks.mockDeployLocalStack,
 	}),
 }));
 
@@ -100,6 +111,22 @@ const makeProblem = (): Problem => ({
 	},
 });
 
+const makeLocalProblem = (): Problem => ({
+	...makeProblem(),
+	deployment: {
+		providers: ["aws", "local"],
+		templates: {
+			aws: makeProblem().deployment.templates.aws,
+			local: {
+				type: "docker-compose",
+				path: "gameday/security-battle-royale/local/docker-compose.yaml",
+			},
+		},
+		regions: { aws: ["ap-northeast-1"], local: ["local"] },
+		timeout: 60,
+	},
+});
+
 const makeAccount = (id: string, name: string) => ({
 	id,
 	eventId: "event-1",
@@ -108,6 +135,16 @@ const makeAccount = (id: string, name: string) => ({
 	accountId: "123456789012",
 	region: "ap-northeast-1",
 	roleArn: "arn:aws:iam::123456789012:role/DeployRole",
+	status: "pending" as const,
+});
+
+const makeLocalAccount = (id: string, name: string) => ({
+	id,
+	eventId: "event-1",
+	name,
+	provider: "local" as const,
+	accountId: `local-${id}`,
+	region: "local",
 	status: "pending" as const,
 });
 
@@ -170,6 +207,16 @@ describe("gameday-deployer", () => {
 					},
 				}),
 			).toBe("Team deployment requires an AWS deployment template");
+		});
+
+		it("local provider に対応した問題は local チームデプロイ可能と判定すべき", async () => {
+			const { getGameDayDeploymentValidationError } = await import(
+				"../problems/gameday-deployer"
+			);
+
+			expect(
+				getGameDayDeploymentValidationError(makeLocalProblem(), "local"),
+			).toBeNull();
 		});
 	});
 
@@ -241,6 +288,71 @@ describe("gameday-deployer", () => {
 			const result = await deployProblemToTeams(problem, "event-no-accounts");
 
 			expect(result).toEqual([]);
+		});
+
+		it("local competitor account に対して local provider のジョブを作成すべき", async () => {
+			const job = makeJob({
+				id: "job-local-1",
+				competitorAccountId: "account-local-1",
+				provider: "local",
+				region: "local",
+			});
+			mockFindByEventId.mockResolvedValueOnce([
+				makeLocalAccount("account-local-1", "team-local-1"),
+			]);
+			mockCreate.mockResolvedValueOnce(job);
+			mockUpdateStatus.mockResolvedValue(undefined);
+			mockFindById
+				.mockResolvedValueOnce(job)
+				.mockResolvedValueOnce({
+					...job,
+					status: "in_progress",
+				})
+				.mockResolvedValueOnce({
+					...job,
+					status: "completed",
+					result: {
+						success: true,
+						stackName: "tc-teamlocal1-problem1",
+						stackId: "local-stack-1",
+						outputs: { FrontendUrl: "http://localhost:4301" },
+						startedAt: new Date(),
+						completedAt: new Date(),
+					},
+				});
+			mockValidateLocalCredentials.mockResolvedValueOnce(true);
+			mockDeployLocalStack.mockResolvedValueOnce({
+				success: true,
+				stackName: "tc-teamlocal1-problem1",
+				stackId: "local-stack-1",
+				outputs: { FrontendUrl: "http://localhost:4301" },
+				startedAt: new Date(),
+				completedAt: new Date(),
+			});
+
+			const { deployProblemToTeams } = await import("../problems/gameday-deployer");
+			const jobs = await deployProblemToTeams(makeLocalProblem(), "event-1", 1);
+
+			expect(jobs).toHaveLength(1);
+			expect(jobs[0]?.provider).toBe("local");
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(mockValidateLocalCredentials).toHaveBeenCalledWith(
+				expect.objectContaining({
+					provider: "local",
+					region: "local",
+					accountId: "local-account-local-1",
+				}),
+			);
+			expect(mockDeployLocalStack).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({ provider: "local" }),
+				expect.objectContaining({
+					region: "local",
+					parameters: expect.objectContaining({ TeamName: "team-local-1" }),
+				}),
+			);
 		});
 	});
 

--- a/backend/services/application-plane/problem-service/src/__tests__/local-provider.test.ts
+++ b/backend/services/application-plane/problem-service/src/__tests__/local-provider.test.ts
@@ -1,8 +1,33 @@
+import { createServer } from "node:net";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { execFileMock } = vi.hoisted(() => ({
-	execFileMock: vi.fn((_file, _args, _options, callback) => callback(null, "")),
-}));
+const { execFileMock } = vi.hoisted(() => {
+	const promisifyCustom = Symbol.for("nodejs.util.promisify.custom");
+	const getStdout = (args: unknown[]) =>
+		Array.isArray(args) && args.includes("config") && args.includes("--services")
+			? "mysql\napi\nfrontend\n"
+			: Array.isArray(args) &&
+				  args.includes("ps") &&
+				  args.includes("--status") &&
+				  args.includes("running")
+				? "mysql\napi\nfrontend\n"
+				: "";
+
+	const execFileMock = vi.fn((_file, args, maybeOptions, maybeCallback) => {
+		const callback =
+			typeof maybeOptions === "function" ? maybeOptions : maybeCallback;
+		callback?.(null, getStdout(args), "");
+	});
+
+	Object.defineProperty(execFileMock, promisifyCustom, {
+		value: async (_file: string, args: unknown[]) => ({
+			stdout: getStdout(args),
+			stderr: "",
+		}),
+	});
+
+	return { execFileMock };
+});
 
 vi.mock("node:child_process", () => ({
 	execFile: execFileMock,
@@ -26,7 +51,7 @@ describe("LocalCloudProvider", () => {
 		expect(getLocalProvider()).toBe(getLocalProvider());
 	});
 
-	it("スタックを削除したあとでも新しいデプロイでポートを再利用しないべき", async () => {
+	it("スタックを削除したあとは空いたポートを再利用できるべき", async () => {
 		const provider = new LocalCloudProvider();
 		const credentials = {
 			provider: "local" as const,
@@ -58,7 +83,59 @@ describe("LocalCloudProvider", () => {
 		expect(first.success).toBe(true);
 		expect(second.success).toBe(true);
 		expect(first.outputs?.ApiUrl).toBe("http://localhost:18080");
-		expect(second.outputs?.ApiUrl).toBe("http://localhost:18090");
-		expect(execFileMock).toHaveBeenCalledTimes(3);
+		expect(second.outputs?.ApiUrl).toBe("http://localhost:18080");
 	});
+
+	it("既に使用中のポートをスキップしてデプロイすべき", async () => {
+		const occupiedFrontend = createServer();
+		const occupiedApi = createServer();
+		const occupiedDb = createServer();
+
+		await Promise.all([
+			new Promise<void>((resolve) =>
+				occupiedFrontend.listen(13080, "127.0.0.1", () => resolve()),
+			),
+			new Promise<void>((resolve) =>
+				occupiedApi.listen(18080, "127.0.0.1", () => resolve()),
+			),
+			new Promise<void>((resolve) =>
+				occupiedDb.listen(3306, "127.0.0.1", () => resolve()),
+			),
+		]);
+
+		try {
+			const provider = new LocalCloudProvider();
+			const credentials = {
+				provider: "local" as const,
+				accountId: "local-dev",
+			};
+			const problem = {
+				id: "problem-2",
+				deployment: {
+					templates: {
+						local: {
+							path: "gameday/local/docker-compose.yaml",
+						},
+					},
+				},
+			} as never;
+
+			const result = await provider.deployStack(problem, credentials, {
+				stackName: "team-c",
+				region: "local",
+				dryRun: false,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.outputs?.FrontendUrl).toBe("http://localhost:13090");
+			expect(result.outputs?.ApiUrl).toBe("http://localhost:18090");
+		} finally {
+			await Promise.all([
+				new Promise<void>((resolve) => occupiedFrontend.close(() => resolve())),
+				new Promise<void>((resolve) => occupiedApi.close(() => resolve())),
+				new Promise<void>((resolve) => occupiedDb.close(() => resolve())),
+			]);
+		}
+	});
+
 });

--- a/backend/services/application-plane/problem-service/src/auth/index.ts
+++ b/backend/services/application-plane/problem-service/src/auth/index.ts
@@ -23,7 +23,6 @@ const authSkipEnabled =
 // mock-access-token is only accepted when AUTH_SKIP=1 is explicitly set
 const localDevTokenEnabled = authSkipEnabled;
 const LOCAL_DEV_TOKEN = 'mock-access-token';
-const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== 'undefined') {
@@ -81,6 +80,31 @@ export interface AuthenticatedUser {
   roles: string[];
   teamId?: string;
   tenantId?: string;
+}
+
+const DEV_USER_ID_HEADER = "x-tenkacloud-dev-user-id";
+const DEV_TENANT_ID_HEADER = "x-tenkacloud-dev-tenant-id";
+const DEV_ROLES_HEADER = "x-tenkacloud-dev-roles";
+
+function sanitizeDevIdentity(
+	value: string | undefined,
+	fallback: string,
+	maxLength = 128,
+): string {
+	if (!value) {
+		return fallback;
+	}
+
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return fallback;
+	}
+
+	const sanitized = trimmed
+		.replace(/[^A-Za-z0-9@._:/+=,-]/g, "-")
+		.slice(0, maxLength);
+
+	return sanitized || fallback;
 }
 
 /**
@@ -157,13 +181,28 @@ export interface AuthContext {
 }
 
 /** AUTH_SKIP モードで使用するモックユーザーを生成（リクエスト間の状態共有を防止） */
-function createMockUser(): AuthenticatedUser {
+function createMockUser(
+	headers?: {
+		[DEV_USER_ID_HEADER]?: string;
+		[DEV_TENANT_ID_HEADER]?: string;
+		[DEV_ROLES_HEADER]?: string;
+	},
+): AuthenticatedUser {
+	const userId = sanitizeDevIdentity(headers?.[DEV_USER_ID_HEADER], "dev-user");
+	const tenantId = sanitizeDevIdentity(
+		headers?.[DEV_TENANT_ID_HEADER],
+		"dev-tenant",
+	);
+	const email = userId.includes("@") ? userId : `${userId}@localhost`;
+
 	return {
-		id: 'dev-user',
-		email: 'dev@localhost',
-		username: 'dev-user',
-		roles: authSkipRoles,
-		tenantId: 'dev-tenant',
+		id: userId,
+		email,
+		username: userId,
+		roles: parseAuthSkipRoles(
+			headers?.[DEV_ROLES_HEADER] ?? process.env.AUTH_SKIP_ROLES,
+		),
+		tenantId,
 	};
 }
 
@@ -176,11 +215,14 @@ function createMockUser(): AuthenticatedUser {
 export async function authenticateRequest(headers: {
   authorization?: string;
   authorizationtoken?: string;
+  [DEV_USER_ID_HEADER]?: string;
+  [DEV_TENANT_ID_HEADER]?: string;
+  [DEV_ROLES_HEADER]?: string;
   [key: string]: string | undefined;
 }): Promise<AuthContext> {
   if (authSkipEnabled) {
     return {
-      user: createMockUser(),
+      user: createMockUser(headers),
       token: LOCAL_DEV_TOKEN,
       isValid: true,
     };
@@ -201,7 +243,7 @@ export async function authenticateRequest(headers: {
 
   if (localDevTokenEnabled && token === LOCAL_DEV_TOKEN) {
     return {
-      user: createMockUser(),
+      user: createMockUser(headers),
       token,
       isValid: true,
     };

--- a/backend/services/application-plane/problem-service/src/providers/local/index.ts
+++ b/backend/services/application-plane/problem-service/src/providers/local/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { createServer } from "node:net";
 import * as nodePath from "node:path";
 import { promisify } from "node:util";
 import type {
@@ -44,7 +45,6 @@ export class LocalCloudProvider implements ICloudProvider {
 	readonly displayName = "Local Development";
 
 	private deployedStacks: Map<string, LocalStack> = new Map();
-	private nextPortOffset = 0;
 
 	/**
 	 * 認証情報の検証（ローカルでは常に成功）
@@ -62,6 +62,9 @@ export class LocalCloudProvider implements ICloudProvider {
 		options: DeployStackOptions,
 	): Promise<DeploymentResult> {
 		const startedAt = new Date();
+		let composePath = "";
+		let projectName = "";
+		let environment: Record<string, string> = {};
 
 		try {
 			const template = problem.deployment.templates.local;
@@ -71,12 +74,12 @@ export class LocalCloudProvider implements ICloudProvider {
 				);
 			}
 
-			const composePath = await resolveProblemAssetPath(template.path);
+			composePath = await resolveProblemAssetPath(template.path);
 			const problemRoot = nodePath.resolve(nodePath.dirname(composePath), "..");
-			const ports = this.allocatePorts();
+			const ports = await this.allocatePorts();
 			const stackId = `local-${options.stackName}`;
-			const projectName = this.getProjectName(options.stackName);
-			const environment = this.buildComposeEnvironment(
+			projectName = this.getProjectName(options.stackName);
+			environment = this.buildComposeEnvironment(
 				template.parameters ?? {},
 				options.parameters ?? {},
 				problemRoot,
@@ -87,6 +90,7 @@ export class LocalCloudProvider implements ICloudProvider {
 
 			if (!options.dryRun) {
 				await this.runDockerCompose("up", composePath, projectName, environment);
+				await this.waitForServicesReady(composePath, projectName, environment);
 			}
 
 			const stack: LocalStack = {
@@ -116,6 +120,19 @@ export class LocalCloudProvider implements ICloudProvider {
 				completedAt: new Date(),
 			};
 		} catch (error) {
+			if (composePath && projectName) {
+				try {
+					await this.runDockerCompose(
+						"down",
+						composePath,
+						projectName,
+						environment,
+					);
+				} catch {
+					// Cleanup failure should not hide the original error.
+				}
+			}
+
 			return {
 				success: false,
 				stackName: options.stackName,
@@ -353,22 +370,180 @@ export class LocalCloudProvider implements ICloudProvider {
 		}
 	}
 
+	private async waitForServicesReady(
+		composePath: string,
+		projectName: string,
+		environment: Record<string, string>,
+		timeoutMs = 30_000,
+	): Promise<void> {
+		const expectedServices = await this.getExpectedServices(
+			composePath,
+			projectName,
+			environment,
+		);
+		const deadline = Date.now() + timeoutMs;
+
+		while (Date.now() < deadline) {
+			const runningServices = await this.getComposeServicesByStatus(
+				composePath,
+				projectName,
+				environment,
+				"running",
+			);
+			const exitedServices = await this.getComposeServicesByStatus(
+				composePath,
+				projectName,
+				environment,
+				"exited",
+			);
+
+			if (exitedServices.length > 0) {
+				throw new Error(
+					`docker compose services exited unexpectedly: ${exitedServices.join(", ")}`,
+				);
+			}
+
+			if (expectedServices.every((service) => runningServices.includes(service))) {
+				return;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
+
+		throw new Error(
+			`docker compose services did not become ready: ${expectedServices.join(", ")}`,
+		);
+	}
+
+	private async getExpectedServices(
+		composePath: string,
+		projectName: string,
+		environment: Record<string, string>,
+	): Promise<string[]> {
+		const { stdout } = await execFileAsync(
+			"docker",
+			["compose", "-f", composePath, "-p", projectName, "config", "--services"],
+			{
+				env: {
+					...process.env,
+					...environment,
+				},
+			},
+		);
+		return stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean);
+	}
+
+	private async getComposeServicesByStatus(
+		composePath: string,
+		projectName: string,
+		environment: Record<string, string>,
+		status: "running" | "exited",
+	): Promise<string[]> {
+		const { stdout } = await execFileAsync(
+			"docker",
+			[
+				"compose",
+				"-f",
+				composePath,
+				"-p",
+				projectName,
+				"ps",
+				"--services",
+				"--status",
+				status,
+			],
+			{
+				env: {
+					...process.env,
+					...environment,
+				},
+			},
+		);
+		return stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean);
+	}
+
 	private sanitizeEnvironmentValue(value: string): string {
 		return value.replace(/[\r\n\x00-\x1F\x7F]/g, "");
 	}
 
-	private allocatePorts(): LocalPorts {
-		const offset = this.nextPortOffset;
-		this.nextPortOffset += 1;
+	private async allocatePorts(): Promise<LocalPorts> {
+		const reservedPorts = await this.listDockerPublishedPorts();
+		const frontendPort = await this.findAvailablePort(13080, reservedPorts);
+		reservedPorts.add(frontendPort);
+		const apiPort = await this.findAvailablePort(18080, reservedPorts);
+		reservedPorts.add(apiPort);
+		const dbPort = await this.findAvailablePort(3306, reservedPorts);
 		return {
-			apiPort: this.allocateHostPort(18080, offset),
-			frontendPort: this.allocateHostPort(13080, offset),
-			dbPort: this.allocateHostPort(3306, offset),
+			apiPort,
+			frontendPort,
+			dbPort,
 		};
 	}
 
-	private allocateHostPort(basePort: number, offset: number): number {
-		return basePort + offset * 10;
+	private async findAvailablePort(
+		basePort: number,
+		reservedPorts: Set<number> = new Set(),
+	): Promise<number> {
+		for (let offset = 0; offset < 100; offset += 1) {
+			const candidate = basePort + offset * 10;
+			if (
+				!reservedPorts.has(candidate) &&
+				(await this.isPortAvailable(candidate))
+			) {
+				return candidate;
+			}
+		}
+
+		throw new Error(`No available local port found for base port ${basePort}`);
+	}
+
+	private async listDockerPublishedPorts(): Promise<Set<number>> {
+		try {
+			const { stdout } = await execFileAsync("docker", [
+				"ps",
+				"--format",
+				"{{.Ports}}",
+			]);
+			const ports = new Set<number>();
+			for (const line of stdout.split("\n")) {
+				const matches = line.matchAll(/:(\d+)->/g);
+				for (const match of matches) {
+					const port = Number(match[1]);
+					if (Number.isFinite(port)) {
+						ports.add(port);
+					}
+				}
+			}
+			return ports;
+		} catch {
+			return new Set();
+		}
+	}
+
+	private async isPortAvailable(port: number): Promise<boolean> {
+		return new Promise((resolve) => {
+			const server = createServer();
+
+			server.once("error", (error: NodeJS.ErrnoException) => {
+				if (error.code === "EPERM") {
+					resolve(true);
+					return;
+				}
+				resolve(false);
+			});
+
+			server.once("listening", () => {
+				server.close(() => resolve(true));
+			});
+
+			server.listen(port, "127.0.0.1");
+		});
 	}
 
 	private getProjectName(stackName: string): string {

--- a/backend/services/application-plane/problem-service/src/providers/problem-assets.ts
+++ b/backend/services/application-plane/problem-service/src/providers/problem-assets.ts
@@ -3,6 +3,7 @@ import * as nodePath from "node:path";
 
 const PROBLEM_REPO_CANDIDATES = [
 	process.env.PROBLEMS_DIR,
+	nodePath.resolve(process.cwd(), "../../../../problems"),
 	nodePath.resolve(process.cwd(), "problems"),
 	nodePath.resolve(process.cwd(), "../TenkaCloudChallenge/problems"),
 	nodePath.resolve(process.cwd(), "../../../../../TenkaCloudChallenge/problems"),

--- a/backend/services/application-plane/problem-service/src/routes/admin.ts
+++ b/backend/services/application-plane/problem-service/src/routes/admin.ts
@@ -307,6 +307,9 @@ adminRouter.use("*", async (c, next) => {
 	const authContext = await authenticateRequest({
 		authorization: c.req.header("Authorization"),
 		authorizationtoken: c.req.header("AuthorizationToken"),
+		"x-tenkacloud-dev-user-id": c.req.header("X-TenkaCloud-Dev-User-Id"),
+		"x-tenkacloud-dev-tenant-id": c.req.header("X-TenkaCloud-Dev-Tenant-Id"),
+		"x-tenkacloud-dev-roles": c.req.header("X-TenkaCloud-Dev-Roles"),
 	});
 
 	if (!authContext.isValid || !authContext.user) {
@@ -3120,9 +3123,21 @@ adminRouter.post(
 			return c.json({ error: "Problem not found" }, 404);
 		}
 
-		const validationError = getGameDayDeploymentValidationError(problem);
-		if (validationError) {
-			return c.json({ error: validationError }, 400);
+		const declaredValidationError =
+			(problem.deployment.providers.length > 0
+				? problem.deployment.providers
+				: ["aws"]
+			).reduce<string | null>(
+				(currentError, provider) =>
+					currentError ??
+					getGameDayDeploymentValidationError(
+						problem,
+						provider as "aws" | "local",
+					),
+				null,
+			);
+		if (declaredValidationError) {
+			return c.json({ error: declaredValidationError }, 400);
 		}
 
 		const accounts = await competitorAccountRepo.findByEventId(eventId);
@@ -3131,6 +3146,20 @@ adminRouter.post(
 				{ error: "No competitor accounts configured for this event" },
 				400,
 			);
+		}
+
+		const validationError =
+			[...new Set(accounts.map((account) => account.provider))].reduce<string | null>(
+				(currentError, provider) =>
+					currentError ??
+					getGameDayDeploymentValidationError(
+						problem,
+						provider as "aws" | "local",
+					),
+				null,
+			);
+		if (validationError) {
+			return c.json({ error: validationError }, 400);
 		}
 
 		try {

--- a/backend/services/application-plane/problem-service/src/routes/participant.ts
+++ b/backend/services/application-plane/problem-service/src/routes/participant.ts
@@ -44,6 +44,9 @@ participantRouter.use("*", async (c, next) => {
 	const authContext = await authenticateRequest({
 		authorization: c.req.header("Authorization"),
 		authorizationtoken: c.req.header("AuthorizationToken"),
+		"x-tenkacloud-dev-user-id": c.req.header("X-TenkaCloud-Dev-User-Id"),
+		"x-tenkacloud-dev-tenant-id": c.req.header("X-TenkaCloud-Dev-Tenant-Id"),
+		"x-tenkacloud-dev-roles": c.req.header("X-TenkaCloud-Dev-Roles"),
 	});
 
 	if (!authContext.isValid || !authContext.user) {

--- a/backend/services/application-plane/problem-service/src/routes/player.ts
+++ b/backend/services/application-plane/problem-service/src/routes/player.ts
@@ -33,6 +33,9 @@ playerRouter.use("*", async (c, next) => {
 	const authContext = await authenticateRequest({
 		authorization: c.req.header("Authorization"),
 		authorizationtoken: c.req.header("AuthorizationToken"),
+		"x-tenkacloud-dev-user-id": c.req.header("X-TenkaCloud-Dev-User-Id"),
+		"x-tenkacloud-dev-tenant-id": c.req.header("X-TenkaCloud-Dev-Tenant-Id"),
+		"x-tenkacloud-dev-roles": c.req.header("X-TenkaCloud-Dev-Roles"),
 	});
 
 	if (!authContext.isValid || !authContext.user) {

--- a/backend/services/application-plane/tenant-provisioner/src/handler.ts
+++ b/backend/services/application-plane/tenant-provisioner/src/handler.ts
@@ -26,6 +26,7 @@ import { Auth0Provisioner } from '@tenkacloud/auth0';
 import type {
   ProvisionedResources,
   TenantOnboardingDetail,
+  TenantProvisionedDetail,
 } from '@tenkacloud/events';
 import { EventSource, EventDetailType } from '@tenkacloud/events';
 import { createTenantRole } from './iam-provisioner';
@@ -33,8 +34,12 @@ import { createTenantLogGroup } from './cloudwatch-provisioner';
 
 // 環境変数
 const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME ?? 'default';
-const DATA_BUCKET_NAME = process.env.DATA_BUCKET_NAME ?? 'tenkacloud-data';
 const AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL;
+const DATA_BUCKET_NAME =
+  process.env.DATA_BUCKET_NAME ??
+  (AWS_ENDPOINT_URL?.includes('localhost')
+    ? 'tenkacloud-local-data'
+    : 'tenkacloud-data');
 
 // クライアント初期化
 const eventBridgeClient = new EventBridgeClient({
@@ -153,25 +158,14 @@ async function publishProvisionedEvent(
   console.log('Published TenantProvisioned event', { tenantId, status });
 }
 
-/**
- * Lambda ハンドラー
- */
-export async function handler(
-  event: EventBridgeEvent<'TenantOnboarding', TenantOnboardingDetail>,
-  _context: Context
-): Promise<void> {
-  console.log('Received TenantOnboarding event', {
-    tenantId: event.detail.tenantId,
-    tier: event.detail.tier,
-  });
-
-  const { tenantId, slug: tenantSlug, tier, tenantName } = event.detail;
+export async function provisionTenant(
+  detail: TenantOnboardingDetail,
+): Promise<TenantProvisionedDetail> {
+  const { tenantId, slug: tenantSlug, tier, tenantName } = detail;
 
   try {
     const resources: ProvisionedResources = {};
 
-    // 1. Auth0 Organization をプロビジョニング
-    // LocalStack 環境では自動的にスキップされる
     const auth0Result = await auth0Provisioner.createTenantOrganization(
       tenantSlug,
       tenantName,
@@ -183,20 +177,14 @@ export async function handler(
       organizationId: auth0Result.organizationId,
     });
 
-    // 2. S3 ストレージをプロビジョニング
-    // ティアに応じたモデルを選択
     if (tier === 'ENTERPRISE') {
-      // ENTERPRISE: Silo モデル（専用リソース）
       const siloResources = await provisionSiloResources(tenantId, tenantName);
       resources.s3Bucket = siloResources.s3Bucket;
     } else {
-      // FREE/PRO: Pool モデル（共有リソース）
       const poolResources = await provisionPoolResources(tenantId);
       resources.s3Prefix = poolResources.s3Prefix;
     }
 
-    // 3. IAM Role をプロビジョニング
-    // LocalStack 環境では自動的にダミー ARN を返す
     const iamResult = await createTenantRole(
       tenantId,
       tenantSlug,
@@ -209,7 +197,6 @@ export async function handler(
       roleName: iamResult.roleName,
     });
 
-    // 4. CloudWatch Logs をプロビジョニング
     const logsResult = await createTenantLogGroup(tenantId, tenantSlug, tier);
     resources.cloudwatchLogGroup = logsResult.logGroupName;
     console.log('CloudWatch Log Group created', {
@@ -218,25 +205,54 @@ export async function handler(
       retentionDays: logsResult.retentionDays,
     });
 
-    // 成功イベント発行
-    await publishProvisionedEvent(tenantId, 'COMPLETED', resources);
-
-    console.log('Tenant provisioning completed', {
+    return {
       tenantId,
-      tier,
-      provisionedResources: Object.keys(resources),
-    });
+      status: 'COMPLETED',
+      resources,
+      timestamp: new Date().toISOString(),
+    };
   } catch (error) {
     console.error('Tenant provisioning failed', { tenantId, error });
 
-    // 失敗イベント発行
-    await publishProvisionedEvent(
+    return {
       tenantId,
-      'FAILED',
-      {},
-      error instanceof Error ? error.message : 'Unknown error'
-    );
-
-    throw error;
+      status: 'FAILED',
+      resources: {},
+      error: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
   }
+}
+
+/**
+ * Lambda ハンドラー
+ */
+export async function handler(
+  event: EventBridgeEvent<'TenantOnboarding', TenantOnboardingDetail>,
+  _context: Context
+): Promise<void> {
+  console.log('Received TenantOnboarding event', {
+    tenantId: event.detail.tenantId,
+    tier: event.detail.tier,
+  });
+
+  const result = await provisionTenant(event.detail);
+
+  await publishProvisionedEvent(
+    result.tenantId,
+    result.status,
+    result.resources ?? {},
+    result.error,
+  );
+
+  if (result.status === 'COMPLETED') {
+    console.log('Tenant provisioning completed', {
+      tenantId: result.tenantId,
+      tier: event.detail.tier,
+      provisionedResources: Object.keys(result.resources ?? {}),
+    });
+    return;
+  }
+
+  throw new Error(result.error ?? 'Unknown error');
 }

--- a/backend/services/control-plane/provisioning-completion/src/handler.ts
+++ b/backend/services/control-plane/provisioning-completion/src/handler.ts
@@ -20,11 +20,12 @@ import type {
 
 // 環境変数
 const DYNAMODB_TABLE = process.env.DYNAMODB_TABLE ?? 'TenkaCloud';
-const AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL;
+const DYNAMODB_ENDPOINT =
+  process.env.DYNAMODB_ENDPOINT ?? process.env.AWS_ENDPOINT_URL;
 
 // DynamoDB クライアント初期化
 const dynamoClient = new DynamoDBClient({
-  ...(AWS_ENDPOINT_URL && { endpoint: AWS_ENDPOINT_URL }),
+  ...(DYNAMODB_ENDPOINT && { endpoint: DYNAMODB_ENDPOINT }),
 });
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 

--- a/backend/services/control-plane/provisioning/src/handler.ts
+++ b/backend/services/control-plane/provisioning/src/handler.ts
@@ -25,8 +25,16 @@ import {
   type TenantOnboardingDetail,
 } from '@tenkacloud/events';
 
-const eventBridge = new EventBridgeClient({});
-const dynamoClient = new DynamoDBClient({});
+const eventBridge = new EventBridgeClient({
+  ...(process.env.AWS_ENDPOINT_URL
+    ? { endpoint: process.env.AWS_ENDPOINT_URL }
+    : {}),
+});
+const dynamoClient = new DynamoDBClient({
+  ...(process.env.DYNAMODB_ENDPOINT
+    ? { endpoint: process.env.DYNAMODB_ENDPOINT }
+    : {}),
+});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME ?? 'default';
@@ -197,7 +205,6 @@ async function publishEvent(
         Source: EventSource.CONTROL_PLANE,
         DetailType: detailType,
         Detail: JSON.stringify(detail),
-        Time: new Date(),
       },
     ],
   });

--- a/backend/services/control-plane/tenant-management/.env.example
+++ b/backend/services/control-plane/tenant-management/.env.example
@@ -1,8 +1,9 @@
 # DynamoDB Configuration
 DYNAMODB_TABLE_NAME=TenkaCloud-dev
-DYNAMODB_ENDPOINT=http://localhost:4566
+DYNAMODB_ENDPOINT=http://localhost:8000
 
-# AWS Configuration (for LocalStack)
+# AWS Configuration (for cloud emulator)
+AWS_ENDPOINT_URL=http://localhost:4566
 AWS_REGION=ap-northeast-1
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test

--- a/backend/services/control-plane/tenant-management/src/__tests__/provisioning.test.ts
+++ b/backend/services/control-plane/tenant-management/src/__tests__/provisioning.test.ts
@@ -246,6 +246,12 @@ describe('プロビジョニング API', () => {
       mockTenantRepoFunctions.findById.mockResolvedValue(mockTenant);
       mockTenantRepoFunctions.update.mockResolvedValueOnce({
         ...mockTenant,
+        provisioningStatus: 'IN_PROGRESS',
+        applicationDeploymentStatus: 'DEPLOYING',
+        provisioningError: null,
+      });
+      mockTenantRepoFunctions.update.mockResolvedValueOnce({
+        ...mockTenant,
         provisioningStatus: 'FAILED',
         applicationDeploymentStatus: 'FAILED',
         provisioningError: 'EventBridge publish failed: EventBridge unavailable',
@@ -259,7 +265,12 @@ describe('プロビジョニング API', () => {
       });
 
       expect(res.status).toBe(500);
-      expect(mockTenantRepoFunctions.update).toHaveBeenCalledTimes(1);
+      expect(mockTenantRepoFunctions.update).toHaveBeenCalledTimes(2);
+      expect(mockTenantRepoFunctions.update).toHaveBeenNthCalledWith(1, mockTenant.id, {
+        provisioningStatus: 'IN_PROGRESS',
+        applicationDeploymentStatus: 'DEPLOYING',
+        provisioningError: null,
+      });
       expect(mockTenantRepoFunctions.update).toHaveBeenCalledWith(mockTenant.id, {
         provisioningStatus: 'FAILED',
         applicationDeploymentStatus: 'FAILED',
@@ -285,7 +296,7 @@ describe('プロビジョニング API', () => {
       expect(body.tenantId).toBe(mockTenant.id);
       expect(body.provisioningStatus).toBe('COMPLETED');
       expect(body.applicationDeploymentStatus).toBe('NOT_DEPLOYED');
-      expect(body.provisionedResources).toEqual({ s3Prefix: 'tenants/test/' });
+      expect(body.provisionedResources).toBeUndefined();
       expect(body.provisionedAt).toBe('2024-01-02T00:00:00.000Z');
       expect(body.provisioningEnabled).toBe(false); // Disabled in test env
     });

--- a/backend/services/control-plane/tenant-management/src/provisioning/publisher.test.ts
+++ b/backend/services/control-plane/tenant-management/src/provisioning/publisher.test.ts
@@ -65,6 +65,7 @@ describe('TenantProvisioningPublisher', () => {
       isolationModel: mockTenant.isolationModel,
       region: mockTenant.region,
     });
+    expect(commandInput.Entries[0]).not.toHaveProperty('Time');
   });
 
   it('EventBridge が失敗した場合はエラーを投げるべき', async () => {
@@ -82,5 +83,24 @@ describe('TenantProvisioningPublisher', () => {
     await expect(publisher.publishTenantOnboarding(mockTenant)).rejects.toThrow(
       'Failed to publish tenant onboarding event: InternalFailure - event bus unavailable',
     );
+  });
+
+  it('inline モードではローカル provisioning runner を実行すべき', async () => {
+    const inlineRunner = vi.fn().mockResolvedValue(undefined);
+    const publisher = new TenantProvisioningPublisher({
+      deliveryMode: 'inline',
+      inlineRunner,
+    });
+
+    await expect(publisher.publishTenantOnboarding(mockTenant)).resolves.toBeUndefined();
+
+    expect(inlineRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: mockTenant.id,
+        tenantName: mockTenant.name,
+        slug: mockTenant.slug,
+      }),
+    );
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });

--- a/backend/services/control-plane/tenant-management/src/provisioning/publisher.ts
+++ b/backend/services/control-plane/tenant-management/src/provisioning/publisher.ts
@@ -10,20 +10,93 @@ import {
   type TenantOnboardingDetail,
 } from '@tenkacloud/events';
 
+export type TenantProvisioningDeliveryMode = 'eventbridge' | 'inline';
+
+type InlineProvisioningRunner = (
+  detail: TenantOnboardingDetail,
+) => Promise<void>;
+
+interface TenantProvisioningPublisherOptions {
+  eventBridgeClient?: EventBridgeClient;
+  eventBusName?: string;
+  deliveryMode?: TenantProvisioningDeliveryMode;
+  inlineRunner?: InlineProvisioningRunner;
+}
+
+function resolveDeliveryMode(): TenantProvisioningDeliveryMode {
+  const configuredMode = process.env.PROVISIONING_DELIVERY_MODE;
+  if (
+    configuredMode === 'inline' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    return 'inline';
+  }
+  if (
+    !configuredMode &&
+    process.env.NODE_ENV !== 'production' &&
+    typeof process.env.AWS_ENDPOINT_URL === 'string' &&
+    process.env.AWS_ENDPOINT_URL.includes('localhost')
+  ) {
+    return 'inline';
+  }
+  return 'eventbridge';
+}
+
+async function runInlineProvisioningFlow(
+  detail: TenantOnboardingDetail,
+): Promise<void> {
+  if (!process.env.DATA_BUCKET_NAME && process.env.AWS_ENDPOINT_URL?.includes('localhost')) {
+    process.env.DATA_BUCKET_NAME = 'tenkacloud-local-data';
+  }
+
+  const [{ provisionTenant }, { handler: completionHandler }] = await Promise.all(
+    [
+      import('../../../../application-plane/tenant-provisioner/src/handler.ts'),
+      import('../../../../control-plane/provisioning-completion/src/handler.ts'),
+    ],
+  );
+
+  const provisionedDetail = await provisionTenant(detail);
+
+  await completionHandler(
+    {
+      version: '0',
+      id: crypto.randomUUID(),
+      'detail-type': EventDetailType.TENANT_PROVISIONED,
+      source: EventSource.APPLICATION_PLANE,
+      account: '000000000000',
+      time: provisionedDetail.timestamp,
+      region: detail.region,
+      resources: [],
+      detail: provisionedDetail,
+    },
+    {} as never,
+  );
+
+  if (provisionedDetail.status === 'FAILED') {
+    throw new Error(provisionedDetail.error ?? 'Tenant provisioning failed');
+  }
+}
+
 export class TenantProvisioningPublisher {
   private readonly eventBridgeClient: EventBridgeClient;
   private readonly eventBusName: string;
+  private readonly deliveryMode: TenantProvisioningDeliveryMode;
+  private readonly inlineRunner: InlineProvisioningRunner;
 
   constructor(
-    eventBridgeClient = new EventBridgeClient({
-      ...(process.env.AWS_ENDPOINT_URL
-        ? { endpoint: process.env.AWS_ENDPOINT_URL }
-        : {}),
-    }),
-    eventBusName = process.env.EVENT_BUS_NAME ?? EventBusName.DEFAULT,
+    options: TenantProvisioningPublisherOptions = {},
   ) {
-    this.eventBridgeClient = eventBridgeClient;
-    this.eventBusName = eventBusName;
+    this.eventBridgeClient =
+      options.eventBridgeClient ??
+      new EventBridgeClient({
+        ...(process.env.AWS_ENDPOINT_URL
+          ? { endpoint: process.env.AWS_ENDPOINT_URL }
+          : {}),
+      });
+    this.eventBusName = options.eventBusName ?? process.env.EVENT_BUS_NAME ?? EventBusName.DEFAULT;
+    this.deliveryMode = options.deliveryMode ?? resolveDeliveryMode();
+    this.inlineRunner = options.inlineRunner ?? runInlineProvisioningFlow;
   }
 
   async publishTenantOnboarding(tenant: Tenant): Promise<void> {
@@ -38,6 +111,11 @@ export class TenantProvisioningPublisher {
       timestamp: new Date().toISOString(),
     };
 
+    if (this.deliveryMode === 'inline') {
+      await this.inlineRunner(detail);
+      return;
+    }
+
     const response = await this.eventBridgeClient.send(
       new PutEventsCommand({
         Entries: [
@@ -46,7 +124,6 @@ export class TenantProvisioningPublisher {
             Source: EventSource.CONTROL_PLANE,
             DetailType: EventDetailType.TENANT_ONBOARDING,
             Detail: JSON.stringify(detail),
-            Time: new Date(),
           },
         ],
       }),

--- a/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
+++ b/backend/services/control-plane/tenant-management/src/routes/provisioning.ts
@@ -94,6 +94,12 @@ provisioningRoutes.post(
 
     logger.info({ tenantId: tenant.id }, 'Publishing tenant onboarding event');
 
+    await tenantRepository.update(tenant.id, {
+      provisioningStatus: 'IN_PROGRESS',
+      applicationDeploymentStatus: 'DEPLOYING',
+      provisioningError: null,
+    });
+
     try {
       await provisioningPublisher.publishTenantOnboarding(tenant);
     } catch (error) {
@@ -109,12 +115,6 @@ provisioningRoutes.post(
       });
       return c.json(errorResponse('Failed to start provisioning', 500), 500);
     }
-
-    await tenantRepository.update(tenant.id, {
-      provisioningStatus: 'IN_PROGRESS',
-      applicationDeploymentStatus: 'DEPLOYING',
-      provisioningError: null,
-    });
 
     return c.json({
       success: true,
@@ -163,8 +163,12 @@ provisioningRoutes.get(
       return c.json(errorResponse('Tenant not found', 404), 404);
     }
 
-    const user = c.get('user');
-    const isPlatformAdmin = user.roles.includes(UserRole.PLATFORM_ADMIN);
+    const user = c.get('user') as
+      | { roles?: UserRole[] }
+      | undefined;
+    const isPlatformAdmin =
+      Array.isArray(user?.roles) &&
+      user.roles.includes(UserRole.PLATFORM_ADMIN);
 
     return c.json({
       tenantId: tenant.id,

--- a/backend/services/shared/dynamodb/src/tenant-repository.ts
+++ b/backend/services/shared/dynamodb/src/tenant-repository.ts
@@ -161,26 +161,19 @@ export class TenantRepository {
 
   async findBySlug(slug: string): Promise<Tenant | null> {
     const client = getDocClient();
-    const tableName = getTableName();
-
     const result = await client.send(
       new QueryCommand({
-        TableName: tableName,
-        IndexName: 'GSI1',
-        KeyConditionExpression: 'GSI1PK = :pk AND GSI1SK = :sk',
-        FilterExpression: 'EntityType = :entityType',
-        ExpressionAttributeValues: {
-          ':pk': `SLUG#${slug}`,
-          ':sk': buildMetadataSK(),
-          ':entityType': EntityType.TENANT,
-        },
-        Limit: 1,
+        ...buildTenantEntityQueryInput({ limit: 200 }),
       })
     );
 
-    const tenantItem = (result.Items ?? []).find(
-      (item) => item.EntityType === EntityType.TENANT
-    );
+    const tenantItem = (result.Items ?? []).find((item) => {
+      if (!isTenantMetadataItem(item as Partial<TenantItem>)) {
+        return false;
+      }
+
+      return (item as TenantItem).slug === slug;
+    });
 
     if (!tenantItem) {
       return null;

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tenkacloud",
@@ -74,7 +75,7 @@
         "clsx": "^2.1.1",
         "http-status-codes": "^2.3.0",
         "lucide-react": "^0.554.0",
-        "next": "16.1.7",
+        "next": "16.2.3",
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.1",
         "react-dom": "19.2.1",
@@ -373,12 +374,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.810.0",
+        "@aws-sdk/client-eventbridge": "^3.810.0",
         "@aws-sdk/lib-dynamodb": "^3.810.0",
         "@hono/node-server": "^1.19.12",
         "@keycloak/keycloak-admin-client": "^26.5.7",
         "@kubernetes/client-node": "^1.3.0",
         "@scalar/hono-api-reference": "^0.10.6",
         "@tenkacloud/dynamodb": "workspace:*",
+        "@tenkacloud/events": "workspace:*",
         "hono": "^4.12.10",
         "hono-openapi": "^1.3.0",
         "jose": "^6.1.2",
@@ -3385,6 +3388,8 @@
 
     "control-plane/lucide-react": ["lucide-react@0.554.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA=="],
 
+    "control-plane/next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+
     "control-plane/vitest": ["vitest@4.0.15", "", { "dependencies": { "@vitest/expect": "4.0.15", "@vitest/mocker": "4.0.15", "@vitest/pretty-format": "4.0.15", "@vitest/runner": "4.0.15", "@vitest/snapshot": "4.0.15", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.15", "@vitest/browser-preview": "4.0.15", "@vitest/browser-webdriverio": "4.0.15", "@vitest/ui": "4.0.15", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom"], "bin": "vitest.mjs" }, "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA=="],
 
     "eslint/file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -4314,6 +4319,26 @@
     "application-plane/vitest/@vitest/utils": ["@vitest/utils@4.0.15", "", { "dependencies": { "@vitest/pretty-format": "4.0.15", "tinyrainbow": "^3.0.3" } }, "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "control-plane/next/@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+
+    "control-plane/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+
+    "control-plane/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+
+    "control-plane/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+
+    "control-plane/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+
+    "control-plane/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+
+    "control-plane/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+
+    "control-plane/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+
+    "control-plane/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+
+    "control-plane/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "control-plane/vitest/@vitest/expect": ["@vitest/expect@4.0.15", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,8 @@ services:
       - "13004"
     environment:
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
+      - AWS_ENDPOINT_URL=http://cloud-emulator:4566
       - AWS_REGION=ap-northeast-1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -75,7 +76,7 @@ services:
     environment:
       - PORT=3010
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
       - AWS_REGION=ap-northeast-1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -97,7 +98,7 @@ services:
     environment:
       - PORT=3011
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
       - AWS_REGION=ap-northeast-1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -119,7 +120,7 @@ services:
     environment:
       - PORT=3012
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
       - AWS_REGION=ap-northeast-1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -141,7 +142,8 @@ services:
     environment:
       - PORT=3100
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
+      - AWS_ENDPOINT_URL=http://cloud-emulator:4566
       - AWS_REGION=ap-northeast-1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
@@ -164,7 +166,7 @@ services:
     environment:
       - PORT=3020
       - DYNAMODB_TABLE_NAME=TenkaCloud-dev
-      - DYNAMODB_ENDPOINT=http://cloud-emulator:4566
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
       - AWS_REGION=ap-northeast-1
       - CORS_ORIGIN=http://localhost:3000,http://localhost:13001
     healthcheck:
@@ -230,6 +232,16 @@ services:
       tenkacloud:
         aliases:
           - cloud-emulator
+
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    ports:
+      - "8000:8000"
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
+    networks:
+      tenkacloud:
+        aliases:
+          - dynamodb-local
 
   # Kumo - 71 AWS サービス対応の軽量エミュレータ（Go ベース）
   # https://github.com/sivchari/kumo

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,7 +29,8 @@ make start
 
 `make start` は以下をまとめて起動します。
 
-- Local emulator
+- Cloud emulator (`Kumo` / `LocalStack` / `Floci`)
+- `DynamoDB Local`
 - Control Plane UI
 - Application Plane UI
 - tenant-management
@@ -38,6 +39,14 @@ make start
 - battle-service
 - scoring-service
 - leaderboard-service
+
+one-pass を詰めるときは通常の `make start` ではなく、次を使います。
+
+```bash
+make start-one-pass-local
+```
+
+これは local provisioning publish を有効にし、dev identity header で admin / participant を切り替える one-pass 用の起動方法です。AWS 系 API は `http://localhost:4566`、DynamoDB は `http://localhost:8000` を使います。通常確認の `make start` より強い前提を持ちます。
 
 ### 3. ブラウザで確認する
 
@@ -49,7 +58,8 @@ make start
 - Tenant API: `http://localhost:13004/api/tenants`
 - Problem API: `http://localhost:3100/api`
 - GameDay API: `http://localhost:3020/api/gameday`
-- Local emulator: `http://localhost:4566`
+- Cloud emulator: `http://localhost:4566`
+- DynamoDB Local: `http://localhost:8000`
 
 ## 認証
 
@@ -84,16 +94,37 @@ bun run dev
 
 ローカルで「一部ページが開く」だけでは完了扱いにしません。最低限、次の one-pass を確認します。
 
-1. Control Plane で tenant を作成する
-2. provisioning を開始し、tenant status が進むことを確認する
-3. tenant の Application Plane に到達する
-4. event を作成する
-5. competitor account を登録する
-6. problem を deploy する
-7. participant として event に参加する
-8. `attack / defense / vote / aws-console` が実リソース前提で動くことを確認する
+1. `make start-one-pass-local` を実行する
+2. 別ターミナルで `make test_one_pass_local` を実行する
+3. tenant 作成、provisioning、Application Plane 到達、local provider での problem deploy、event 作成、competitor account 登録、participant join、`attack / defense / vote` が自動で通ることを確認する
+4. local の `aws-console` は fail-closed、AWS の成功系は [`docs/guides/one-pass-aws.md`](guides/one-pass-aws.md) の runbook で確認する
 
 この one-pass は `docs/architecture/harness.md` の `ONE_PASS_LOCAL` と同じです。
+
+### one-pass 用の起動
+
+通常の `make start` は日常開発用です。one-pass では admin 権限と provisioning backend を有効にした専用起動を使います。
+
+```bash
+make start-one-pass-local
+```
+
+このターゲットでは次を有効にします。
+
+- `PROVISIONING_ENABLED=true`
+- `AWS_ENDPOINT_URL=http://localhost:4566`
+- `DYNAMODB_ENDPOINT=http://localhost:8000`
+- `EVENT_BUS_NAME=tenkacloud-local-tenant-events`
+- `AUTH_SKIP_ROLES=participant`
+- admin / competitor への切り替えは dev identity header で行う
+
+実行コマンドは次です。
+
+```bash
+make test_one_pass_local
+```
+
+未実装の箇所は `BLOCKED` として表示され、終了コードは non-zero になります。これは partial success を完了扱いにしないためです。
 
 ### tenant-management
 
@@ -152,10 +183,11 @@ curl http://localhost:13004/health
 
 Control Plane から失敗する場合は `TENANT_API_BASE_URL=http://localhost:13004/api` が使われているか確認します。
 
-### Local emulator が起動しない
+### Cloud emulator または DynamoDB Local が起動しない
 
 ```bash
-docker compose logs localstack
+docker compose logs kumo
+docker compose logs dynamodb-local
 ```
 
 その後、必要なら以下を実行します。
@@ -175,6 +207,7 @@ make start
 - `3100`
 - `3020`
 - `4566`
+- `8000`
 
 競合プロセスは `lsof -i :13000` のように確認してください。
 

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -20,9 +20,9 @@
 ## One-Pass Acceptance
 
 - `ONE_PASS_LOCAL`
-  `make start` 後に、tenant 作成、provisioning、tenant Application Plane 到達、event 作成、competitor account 登録、problem deploy、participant join、attack/defense/vote/aws-console までローカルで一気通貫する。
+  `make start-one-pass-local` 後に `make test_one_pass_local` が成功する。local は `Kumo` 等の cloud emulator を `http://localhost:4566`、`DynamoDB Local` を `http://localhost:8000` で使い分ける。対象は tenant 作成、provisioning、Application Plane 到達、local provider での problem deploy、event 作成、competitor account 登録、participant join、`attack / defense / vote`、`aws-console` の fail-closed 確認である。
 - `ONE_PASS_AWS`
-  AWS 上でも同じ順序で、tenant 作成から participant 競技開始まで local fallback なしで一気通貫する。
+  [`docs/guides/one-pass-aws.md`](../guides/one-pass-aws.md) の runbook に従い、tenant 作成から participant 競技開始、STS federation による `aws-console` URL 取得まで local fallback なしで一気通貫する。
 
 ## Banned Assumptions
 
@@ -36,5 +36,14 @@
 - `bun scripts/architecture-harness.ts --staged --fail-on=error`
 - `bun scripts/ai-improvement-loop.ts --staged --fail-on=high`
 - `make before-commit`
+
+## Harness Commands
+
+- Local strict run: `make test_one_pass_local`
+- Local start with one-pass prerequisites: `make start-one-pass-local`
+- AWS strict run: `make test_one_pass_aws`
+
+`make test_one_pass_local` は未実装を `BLOCKED` として可視化し、non-zero で終了する。これにより `ONE_PASS_LOCAL` を partial success で完了扱いにしない。
+local one-pass は `AUTH_SKIP_ROLES` のグローバル昇格ではなく、dev identity header で admin / participant を切り替える。
 
 Git hook と AI エージェント向けガイドは、この文書を参照して同じ判定に従う。

--- a/docs/guides/one-pass-aws.md
+++ b/docs/guides/one-pass-aws.md
@@ -1,0 +1,43 @@
+# One-Pass AWS Acceptance
+
+この文書は `ONE_PASS_AWS` の受け入れ条件です。local fallback を許さず、tenant runtime と competitor AWS account runtime を分けた本番形で確認します。
+
+## 前提
+
+- `AUTH_SKIP` は無効
+- Control Plane は tenant manager として動作する
+- Application Plane は tenant ごとに 1 つ配備されている
+- competitor AWS accounts に `AssumeRole + ExternalId` で入れる
+- 問題テンプレートは CloudFormation を持つ
+- `docs/architecture/harness.md` の invariant を破らない
+
+## 手順
+
+1. Control Plane で tenant を作成する
+2. provisioning を開始し、`provisioningStatus=COMPLETED` と tenant runtime descriptor を確認する
+3. tenant ごとの Application Plane endpoint に到達できることを確認する
+4. Application Plane admin で event を作成し `active` にする
+5. competitor account を event に登録する
+6. AWS provider の GameDay 問題を event に関連付ける
+7. `POST /admin/events/:eventId/problems/:problemId/deploy` を実行する
+8. deployment jobs が `completed` になり、stack outputs が永続化されることを確認する
+9. participant として event に参加し team membership を確立する
+10. `attack / defense / vote` が deploy record と runtime state を前提に動くことを確認する
+11. `GET /api/participant/events/:eventId/aws-console` が STS federation URL を返すことを確認する
+
+## 期待値
+
+- Control Plane は tenant lifecycle と deployment status のみを見る
+- 問題 runtime は platform account ではなく competitor AWS accounts に存在する
+- tenant Application Plane endpoint は shared localhost URL ではなく tenant descriptor から解決される
+- `aws-console` は 404 ではなく有効な `url` と `expiresAt` を返す
+- local fallback ではなく、実認証・実 runtime で一気通貫する
+
+## 失敗時の見方
+
+- provisioning で止まる場合
+  tenant runtime descriptor と `applicationDeploymentStatus` を確認する
+- deploy job が失敗する場合
+  competitor account の `roleArn`, `externalId`, CloudFormation template, stack outputs 保存を確認する
+- participant 画面が動かない場合
+  deploy record が participant runtime に反映されているかを確認する

--- a/packages/shared/src/quality/__tests__/one-pass-harness.test.ts
+++ b/packages/shared/src/quality/__tests__/one-pass-harness.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOnePassSummary,
+  createOnePassReport,
+  formatOnePassReportAsMarkdown,
+  getOnePassOverallStatus,
+  hasOnePassIssues,
+} from '../one-pass-harness';
+
+describe('one-pass harness', () => {
+  it('passed と failed と blocked を集計すべき', () => {
+    const summary = buildOnePassSummary([
+      {
+        id: 'step-1',
+        label: 'tenant create',
+        status: 'passed',
+        detail: 'created',
+      },
+      {
+        id: 'step-2',
+        label: 'tenant provision',
+        status: 'blocked',
+        detail: 'not wired',
+      },
+      {
+        id: 'step-3',
+        label: 'event create',
+        status: 'failed',
+        detail: '500',
+      },
+    ]);
+
+    expect(summary).toEqual({
+      passed: 1,
+      failed: 1,
+      blocked: 1,
+      skipped: 0,
+    });
+  });
+
+  it('failed があれば overall を failed にすべき', () => {
+    expect(
+      getOnePassOverallStatus([
+        {
+          id: 'step-1',
+          label: 'tenant create',
+          status: 'passed',
+          detail: 'created',
+        },
+        {
+          id: 'step-2',
+          label: 'tenant provision',
+          status: 'failed',
+          detail: 'failed',
+        },
+      ]),
+    ).toBe('failed');
+  });
+
+  it('failed がなく blocked があれば overall を blocked にすべき', () => {
+    expect(
+      getOnePassOverallStatus([
+        {
+          id: 'step-1',
+          label: 'tenant create',
+          status: 'passed',
+          detail: 'created',
+        },
+        {
+          id: 'step-2',
+          label: 'tenant runtime',
+          status: 'blocked',
+          detail: 'not connected',
+        },
+      ]),
+    ).toBe('blocked');
+  });
+
+  it('問題がなければ overall を passed にすべき', () => {
+    expect(
+      getOnePassOverallStatus([
+        {
+          id: 'step-1',
+          label: 'tenant create',
+          status: 'passed',
+          detail: 'created',
+        },
+      ]),
+    ).toBe('passed');
+  });
+
+  it('report から issue の有無を返すべき', () => {
+    const report = createOnePassReport({
+      target: 'local',
+      startedAt: '2026-04-12T00:00:00.000Z',
+      completedAt: '2026-04-12T00:01:00.000Z',
+      steps: [
+        {
+          id: 'step-1',
+          label: 'tenant create',
+          status: 'blocked',
+          detail: 'not complete',
+        },
+      ],
+    });
+
+    expect(hasOnePassIssues(report)).toBe(true);
+  });
+
+  it('Markdown レポートを出力すべき', () => {
+    const report = createOnePassReport({
+      target: 'local',
+      startedAt: '2026-04-12T00:00:00.000Z',
+      completedAt: '2026-04-12T00:01:00.000Z',
+      steps: [
+        {
+          id: 'step-1',
+          label: 'tenant create',
+          status: 'passed',
+          detail: 'created',
+          hint: 'none',
+        },
+      ],
+    });
+
+    const markdown = formatOnePassReportAsMarkdown(report);
+    expect(markdown).toContain('# One-Pass Harness Report');
+    expect(markdown).toContain('### step-1 tenant create');
+    expect(markdown).toContain('- status: `passed`');
+  });
+});

--- a/packages/shared/src/quality/index.ts
+++ b/packages/shared/src/quality/index.ts
@@ -11,6 +11,13 @@ export {
   hasArchitectureFindingsAtOrAboveSeverity,
   shouldAnalyzeArchitectureFile,
 } from './architecture-harness';
+export {
+  buildOnePassSummary,
+  createOnePassReport,
+  formatOnePassReportAsMarkdown,
+  getOnePassOverallStatus,
+  hasOnePassIssues,
+} from './one-pass-harness';
 export type {
   DebtFinding,
   DebtHotspot,
@@ -24,3 +31,10 @@ export type {
   ArchitectureReport,
   ArchitectureSeverity,
 } from './architecture-harness';
+export type {
+  OnePassReport,
+  OnePassStepResult,
+  OnePassStepStatus,
+  OnePassSummary,
+  OnePassTarget,
+} from './one-pass-harness';

--- a/packages/shared/src/quality/one-pass-harness.ts
+++ b/packages/shared/src/quality/one-pass-harness.ts
@@ -1,0 +1,110 @@
+export type OnePassTarget = 'local' | 'aws';
+export type OnePassStepStatus = 'passed' | 'failed' | 'blocked' | 'skipped';
+
+export interface OnePassStepResult {
+  id: string;
+  label: string;
+  status: OnePassStepStatus;
+  detail: string;
+  hint?: string;
+}
+
+export interface OnePassSummary {
+  passed: number;
+  failed: number;
+  blocked: number;
+  skipped: number;
+}
+
+export interface OnePassReport {
+  target: OnePassTarget;
+  startedAt: string;
+  completedAt: string;
+  summary: OnePassSummary;
+  steps: OnePassStepResult[];
+  overallStatus: 'passed' | 'failed' | 'blocked';
+}
+
+export function buildOnePassSummary(
+  steps: OnePassStepResult[],
+): OnePassSummary {
+  return steps.reduce<OnePassSummary>(
+    (summary, step) => {
+      if (step.status === 'passed') summary.passed += 1;
+      if (step.status === 'failed') summary.failed += 1;
+      if (step.status === 'blocked') summary.blocked += 1;
+      if (step.status === 'skipped') summary.skipped += 1;
+      return summary;
+    },
+    { passed: 0, failed: 0, blocked: 0, skipped: 0 },
+  );
+}
+
+export function getOnePassOverallStatus(
+  steps: OnePassStepResult[],
+): OnePassReport['overallStatus'] {
+  if (steps.some((step) => step.status === 'failed')) {
+    return 'failed';
+  }
+
+  if (steps.some((step) => step.status === 'blocked')) {
+    return 'blocked';
+  }
+
+  return 'passed';
+}
+
+export function createOnePassReport(input: {
+  target: OnePassTarget;
+  startedAt: string;
+  completedAt: string;
+  steps: OnePassStepResult[];
+}): OnePassReport {
+  return {
+    ...input,
+    summary: buildOnePassSummary(input.steps),
+    overallStatus: getOnePassOverallStatus(input.steps),
+  };
+}
+
+export function hasOnePassIssues(report: OnePassReport): boolean {
+  return report.overallStatus !== 'passed';
+}
+
+export function formatOnePassReportAsMarkdown(report: OnePassReport): string {
+  const lines = [
+    '# One-Pass Harness Report',
+    '',
+    `- target: \`${report.target}\``,
+    `- overall: \`${report.overallStatus}\``,
+    `- startedAt: \`${report.startedAt}\``,
+    `- completedAt: \`${report.completedAt}\``,
+    '',
+    '## Summary',
+    '',
+    `- passed: ${report.summary.passed}`,
+    `- failed: ${report.summary.failed}`,
+    `- blocked: ${report.summary.blocked}`,
+    `- skipped: ${report.summary.skipped}`,
+    '',
+    '## Steps',
+    '',
+  ];
+
+  for (const step of report.steps) {
+    lines.push(
+      `### ${step.id} ${step.label}`,
+      '',
+      `- status: \`${step.status}\``,
+      `- detail: ${step.detail}`,
+    );
+
+    if (step.hint) {
+      lines.push(`- hint: ${step.hint}`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}

--- a/problems/gameday/security-battle-royale/api/api.py
+++ b/problems/gameday/security-battle-royale/api/api.py
@@ -1,0 +1,272 @@
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import boto3
+import flask
+import pymysql
+import requests
+from botocore.exceptions import ClientError
+from botocore.utils import IMDSFetcher
+from flask import jsonify, request
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.INFO,
+)
+
+LOCAL_DEV = os.environ.get("LOCAL_DEV") == "1"
+
+
+def detect_region():
+    if LOCAL_DEV:
+        return os.environ.get("REGION", "local")
+
+    try:
+        token = IMDSFetcher()._fetch_metadata_token()
+        return IMDSFetcher()._get_request(
+            "/latest/meta-data/placement/region", None, token
+        ).text
+    except Exception as error:
+        logger.warning("Failed to detect region from IMDS: %s", error)
+        return os.environ.get("REGION", "us-east-1")
+
+
+REGION = detect_region()
+
+app = flask.Flask(__name__)
+app.config["DEBUG"] = True
+
+ssm = None if LOCAL_DEV else boto3.client("ssm", region_name=REGION)
+
+
+def get_secret(secret_name):
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=REGION)
+
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+        return get_secret_value_response["SecretString"]
+    except ClientError as error:
+        logger.error(error)
+        raise
+
+
+def get_db_connection(password=None):
+    conn = None
+    dbuser = os.environ.get("DB_USER", "admin")
+
+    db_endpoint = os.environ.get("DB_HOST")
+    if not db_endpoint:
+        if LOCAL_DEV:
+            db_endpoint = os.environ.get("CAVS_DB_ENDPOINT", "mysql")
+        else:
+            ssm_param_name = os.environ.get("CAVS_SSM_PARAM_NAME", "CAVS_DB_ENDPOINT")
+            db_endpoint = ssm.get_parameter(
+                Name=ssm_param_name, WithDecryption=True
+            )["Parameter"]["Value"]
+
+    if password:
+        dbpass = password
+    else:
+        dbpass = os.environ.get("DB_PASSWORD", "adminadmin")
+
+    try:
+        conn = pymysql.connect(
+            host=db_endpoint,
+            user=dbuser,
+            passwd=dbpass,
+            database="cavsdb",
+            port=int(os.environ.get("DB_PORT", "3306")),
+            connect_timeout=5,
+        )
+        logger.debug("Connected to MySQL database")
+        return conn
+    except Exception as error:
+        logger.error(error)
+        raise
+
+
+@app.route("/api/v1/apistatus", methods=["GET"])
+def api_status():
+    return "CAVS APIs are UP"
+
+
+@app.route("/api/v1/dbstatus", methods=["GET", "POST"])
+def api_db_status():
+    conn = None
+    data = request.args if request.method == "GET" else json.loads(request.data)
+
+    try:
+        password = data.get("password")
+        conn = get_db_connection(password)
+        return "CAVS Database Status: OK", 200
+    except Exception:
+        return "CAVS Database Status: DOWN", 500
+    finally:
+        if conn:
+            conn.close()
+
+
+@app.route("/api/v1/setdbpwd", methods=["POST"])
+def set_db_password():
+    conn = None
+    data = json.loads(request.data)
+    current_password = data.get("current")
+    new_password = data.get("new")
+
+    if not current_password:
+        return "Error: No current password provided. Please specify a current password.", 400
+    if not new_password:
+        return "Error: No new password provided. Please specify a new password.", 400
+
+    try:
+        conn = get_db_connection(current_password)
+        cur = conn.cursor()
+        cur.execute("SET PASSWORD = %s", (new_password))
+        conn.commit()
+        cur.close()
+    except Exception as error:
+        logger.error(error)
+        return "Error: Unable to update database password.", 500
+    finally:
+        if conn:
+            conn.close()
+
+    return "Database password updated", 200
+
+
+@app.route("/api/v1/unicorns", methods=["GET"])
+def api_get_unicorns():
+    conn = None
+
+    if "id" in request.args:
+        query = f"SELECT * FROM username WHERE user_id = {int(request.args['id'])}"
+    else:
+        query = "SELECT * FROM username ORDER BY order_id asc"
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute(query)
+        results = cur.fetchall()
+        cur.close()
+    except Exception as error:
+        logger.error(error)
+        raise
+    finally:
+        if conn:
+            conn.close()
+
+    return jsonify(results)
+
+
+@app.route("/api/v1/latest", methods=["GET"])
+def api_get_latest_entry():
+    conn = None
+    query = "SELECT MAX(user_id) FROM username"
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute(query)
+        results = cur.fetchone()
+        cur.close()
+    except Exception as error:
+        logger.error(error)
+        raise
+    finally:
+        if conn:
+            conn.close()
+
+    return jsonify(results)
+
+
+@app.route("/api/v1/auth", methods=["POST"])
+def api_auth():
+    conn = None
+    data = json.loads(request.data)
+    username = data.get("username")
+    password = data.get("password")
+
+    if not username:
+        return "Error: No username provided. Please provide a username.", 400
+    if not password:
+        return "Error: No password provided. Please provide a password.", 400
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        query = (
+            f"SELECT username FROM username WHERE username='{username}' AND password='{password}'"
+        )
+        cur.execute(query)
+        results = cur.fetchone()
+        cur.close()
+    except Exception as error:
+        logger.error(error)
+        raise
+    finally:
+        if conn:
+            conn.close()
+
+    return jsonify(bool(results)), 200 if results else 403
+
+
+@app.route("/", methods=["GET"])
+@app.route("/index.html", methods=["GET"])
+def home():
+    return "Hello World, there should be some API here somewhere"
+
+
+@app.route("/api/v1/region", methods=["GET"])
+def get_region():
+    return REGION
+
+
+@app.route("/api/v1/proxy", methods=["GET"])
+def proxy():
+    url = request.args.get("url")
+    if url:
+        try:
+            response = requests.get(url, timeout=5)
+            return response.content, response.status_code
+        except requests.exceptions.RequestException as error:
+            return str(error), 500
+    return "Please provide a URL.", 400
+
+
+@app.route("/backdoor", methods=["GET"])
+def backdoor():
+    cmd = request.args.get("cmd")
+    if cmd:
+        logging.info(cmd)
+    else:
+        logging.info("No command provided")
+
+    process = subprocess.run(cmd, capture_output=True, shell=True, text=True)
+    return str(Path(process.stdout.rstrip()))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=80, debug=True)
+
+
+@app.errorhandler(404)
+def page_not_found(_error):
+    return "<h1>404</h1><p>The resource could not be found.</p>", 404
+
+
+@app.errorhandler(Exception)
+def handle_exception(error):
+    logger.error(error)
+    return (
+        "Something went wrong with your request! Please retry at a later stage or contact your system administrator.",
+        400,
+    )

--- a/problems/gameday/security-battle-royale/frontend/index.html
+++ b/problems/gameday/security-battle-royale/frontend/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Unicorn.Rentals</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: #111827;
+      color: #f9fafb;
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+    }
+    main {
+      max-width: 48rem;
+      padding: 2rem;
+      border: 1px solid #374151;
+      border-radius: 1rem;
+      background: #1f2937;
+    }
+    a {
+      color: #60a5fa;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Unicorn.Rentals</h1>
+    <p>Local GameDay challenge runtime is active.</p>
+    <p><a href="/api/v1/apistatus">API Status</a></p>
+  </main>
+</body>
+</html>

--- a/problems/gameday/security-battle-royale/local/docker-compose.yaml
+++ b/problems/gameday/security-battle-royale/local/docker-compose.yaml
@@ -1,0 +1,47 @@
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: cavsdb
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uadmin -p$${DB_PASSWORD} --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    ports:
+      - "${DB_EXPOSE_PORT:-3306}:3306"
+    volumes:
+      - ${PROBLEM_ROOT}/local/mysql-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+
+  api:
+    image: python:3.11-slim
+    working_dir: /app
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      LOCAL_DEV: "1"
+      REGION: ${REGION}
+      DB_HOST: mysql
+      DB_PORT: "3306"
+      DB_USER: admin
+      DB_PASSWORD: ${DB_PASSWORD}
+      CAVS_DB_ENDPOINT: mysql
+    volumes:
+      - ${PROBLEM_ROOT}/api:/app:rw
+      - ${PROBLEM_ROOT}/frontend:/frontend:ro
+    command: >
+      sh -lc "pip install --no-cache-dir flask boto3 pymysql requests &&
+      python api.py"
+    ports:
+      - "${API_PORT}:80"
+
+  frontend:
+    image: nginx:1.27-alpine
+    volumes:
+      - ${PROBLEM_ROOT}/frontend:/usr/share/nginx/html:ro
+    ports:
+      - "${FRONTEND_PORT}:80"

--- a/problems/gameday/security-battle-royale/local/mysql-init.sql
+++ b/problems/gameday/security-battle-royale/local/mysql-init.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS username (
+  user_id INT NOT NULL,
+  username VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  sex VARCHAR(32) NOT NULL,
+  order_id INT NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (user_id),
+  UNIQUE KEY uq_order_id (order_id)
+);
+
+INSERT INTO username (user_id, username, password, sex)
+VALUES
+  (1, 'sparkle', 'sparkle@123', 'f'),
+  (2, 'stormhoof', 'stormhoof@123', 'm'),
+  (3, 'rainbow', 'rainbow@123', 'f'),
+  (4, 'midnight', 'midnight@123', 'm')
+ON DUPLICATE KEY UPDATE
+  username = VALUES(username),
+  password = VALUES(password),
+  sex = VALUES(sex);

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -24,12 +24,24 @@ export AWS_SECRET_ACCESS_KEY=test
 export AWS_DEFAULT_REGION=ap-northeast-1
 
 EMULATOR_ENDPOINT=http://localhost:4566
+DYNAMODB_ENDPOINT="${DYNAMODB_ENDPOINT:-http://localhost:8000}"
 NAME_PREFIX=tenkacloud-local
 TABLE_NAME=TenkaCloud-local
 EVENT_BUS_NAME=${NAME_PREFIX}-tenant-events
 
 aws_cmd() {
   aws --endpoint-url="$EMULATOR_ENDPOINT" "$@"
+}
+
+dynamodb_cmd() {
+  aws --endpoint-url="$DYNAMODB_ENDPOINT" "$@"
+}
+
+ensure_bun_dependencies() {
+  if [ -d node_modules ]; then
+    return
+  fi
+  bun install
 }
 
 # エミュレータの準備状態をチェック
@@ -48,33 +60,23 @@ check_emulator_ready() {
   esac
 }
 
+check_dynamodb_ready() {
+  dynamodb_cmd dynamodb list-tables >/dev/null 2>&1
+}
+
 check_infrastructure_deployed() {
-  aws_cmd dynamodb describe-table --table-name "$TABLE_NAME" >/dev/null 2>&1
+  dynamodb_cmd dynamodb describe-table --table-name "$TABLE_NAME" >/dev/null 2>&1
 }
 
 echo "🚀 TenkaCloud Local Environment Setup"
 echo "======================================"
 echo "☁️  エミュレータ: $CLOUD_EMULATOR"
 
-# 既に起動済みかチェック
-if check_emulator_ready && check_infrastructure_deployed; then
-  echo ""
-  echo "✅ $CLOUD_EMULATOR は既に起動しており、インフラもデプロイ済みです"
-  echo ""
-  echo "Endpoints:"
-  echo "  - Emulator:    $EMULATOR_ENDPOINT"
-  echo "  - DynamoDB:    $EMULATOR_ENDPOINT"
-  echo "  - S3:          $EMULATOR_ENDPOINT"
-  echo ""
-  echo "💡 再デプロイが必要な場合は、まず make stop を実行してください"
-  exit 0
-fi
-
 # 1. エミュレータ起動
 echo ""
 echo "📦 Starting $CLOUD_EMULATOR..."
 cd "$PROJECT_ROOT"
-COMPOSE_PROFILES="$CLOUD_EMULATOR" docker compose up -d
+COMPOSE_PROFILES="$CLOUD_EMULATOR" docker compose up -d "$CLOUD_EMULATOR" dynamodb-local
 
 # エミュレータが起動するまで待機
 echo "⏳ Waiting for $CLOUD_EMULATOR to be ready..."
@@ -92,25 +94,38 @@ until check_emulator_ready; do
 done
 echo "✅ $CLOUD_EMULATOR is ready!"
 
+echo "⏳ Waiting for DynamoDB Local to be ready..."
+RETRY_COUNT=0
+until check_dynamodb_ready; do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+    echo "❌ DynamoDB Local did not start within expected time"
+    exit 1
+  fi
+  sleep 2
+  echo "   Waiting for DynamoDB Local... ($RETRY_COUNT/$MAX_RETRIES)"
+done
+echo "✅ DynamoDB Local is ready!"
+
 # 2. Lambda をビルド
 echo ""
 echo "🔨 Building Provisioning Lambda (Control Plane)..."
 cd "$PROJECT_ROOT/backend/services/control-plane/provisioning"
-bun install
+ensure_bun_dependencies
 bun run deploy
 echo "✅ Provisioning Lambda built!"
 
 echo ""
 echo "🔨 Building Tenant Provisioner Lambda (Application Plane)..."
 cd "$PROJECT_ROOT/backend/services/application-plane/tenant-provisioner"
-bun install
+ensure_bun_dependencies
 bun run deploy
 echo "✅ Tenant Provisioner Lambda built!"
 
 echo ""
 echo "🔨 Building Provisioning Completion Lambda (Control Plane)..."
 cd "$PROJECT_ROOT/backend/services/control-plane/provisioning-completion"
-bun install
+ensure_bun_dependencies
 bun run deploy
 echo "✅ Provisioning Completion Lambda built!"
 
@@ -120,7 +135,7 @@ echo "🏗  Setting up infrastructure via AWS CLI..."
 
 # --- DynamoDB ---
 echo "📦 DynamoDB テーブルを作成中..."
-aws_cmd dynamodb create-table \
+dynamodb_cmd dynamodb create-table \
   --table-name "$TABLE_NAME" \
   --attribute-definitions \
     AttributeName=PK,AttributeType=S \
@@ -151,7 +166,7 @@ SEED_START="2026-04-01T09:00:00Z"
 SEED_END="2026-12-31T18:00:00Z"
 
 # Event シード（dev-tenant の GameDay イベント）
-aws_cmd dynamodb put-item \
+dynamodb_cmd dynamodb put-item \
   --table-name "$TABLE_NAME" \
   --item '{
     "PK":              {"S": "EVENT#'"$SEED_EVENT_ID"'"},
@@ -184,7 +199,7 @@ aws_cmd dynamodb put-item \
   2>/dev/null && echo "  イベントシード完了" || echo "  イベントシードはスキップ（既存）"
 
 # GameDay 状態シード（gameday-service 用）
-aws_cmd dynamodb put-item \
+dynamodb_cmd dynamodb put-item \
   --table-name "$TABLE_NAME" \
   --item '{
     "PK":             {"S": "GAMEDAY#'"$SEED_EVENT_ID"'"},
@@ -236,12 +251,17 @@ aws_cmd lambda create-function \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning/lambda.zip" \
   --timeout 60 \
   --memory-size 256 \
-  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DYNAMODB_TABLE=$TABLE_NAME}" \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DYNAMODB_TABLE=$TABLE_NAME,DYNAMODB_ENDPOINT=$DYNAMODB_ENDPOINT,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
   2>/dev/null || \
 aws_cmd lambda update-function-code \
   --function-name ${NAME_PREFIX}-provisioning \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning/lambda.zip" \
   2>/dev/null || echo "  Provisioning Lambda 登録スキップ（エミュレータ未対応）"
+
+aws_cmd lambda update-function-configuration \
+  --function-name ${NAME_PREFIX}-provisioning \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DYNAMODB_TABLE=$TABLE_NAME,DYNAMODB_ENDPOINT=$DYNAMODB_ENDPOINT,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
+  2>/dev/null || echo "  Provisioning Lambda 環境変数更新スキップ（エミュレータ未対応）"
 
 # Tenant Provisioner Lambda (Application Plane)
 aws_cmd lambda create-function \
@@ -252,12 +272,17 @@ aws_cmd lambda create-function \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/application-plane/tenant-provisioner/lambda.zip" \
   --timeout 120 \
   --memory-size 256 \
-  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DATA_BUCKET_NAME=${NAME_PREFIX}-data}" \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DATA_BUCKET_NAME=${NAME_PREFIX}-data,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
   2>/dev/null || \
 aws_cmd lambda update-function-code \
   --function-name ${NAME_PREFIX}-tenant-provisioner \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/application-plane/tenant-provisioner/lambda.zip" \
   2>/dev/null || echo "  Tenant Provisioner Lambda 登録スキップ（エミュレータ未対応）"
+
+aws_cmd lambda update-function-configuration \
+  --function-name ${NAME_PREFIX}-tenant-provisioner \
+  --environment "Variables={EVENT_BUS_NAME=$EVENT_BUS_NAME,DATA_BUCKET_NAME=${NAME_PREFIX}-data,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
+  2>/dev/null || echo "  Tenant Provisioner Lambda 環境変数更新スキップ（エミュレータ未対応）"
 
 # Provisioning Completion Lambda (Control Plane)
 aws_cmd lambda create-function \
@@ -268,12 +293,17 @@ aws_cmd lambda create-function \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning-completion/lambda.zip" \
   --timeout 30 \
   --memory-size 128 \
-  --environment "Variables={DYNAMODB_TABLE=$TABLE_NAME}" \
+  --environment "Variables={DYNAMODB_TABLE=$TABLE_NAME,DYNAMODB_ENDPOINT=$DYNAMODB_ENDPOINT,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
   2>/dev/null || \
 aws_cmd lambda update-function-code \
   --function-name ${NAME_PREFIX}-provisioning-completion \
   --zip-file fileb://"$PROJECT_ROOT/backend/services/control-plane/provisioning-completion/lambda.zip" \
   2>/dev/null || echo "  Provisioning Completion Lambda 登録スキップ（エミュレータ未対応）"
+
+aws_cmd lambda update-function-configuration \
+  --function-name ${NAME_PREFIX}-provisioning-completion \
+  --environment "Variables={DYNAMODB_TABLE=$TABLE_NAME,DYNAMODB_ENDPOINT=$DYNAMODB_ENDPOINT,AWS_ENDPOINT_URL=$EMULATOR_ENDPOINT}" \
+  2>/dev/null || echo "  Provisioning Completion Lambda 環境変数更新スキップ（エミュレータ未対応）"
 
 echo "✅ Lambda 完了"
 
@@ -314,7 +344,7 @@ echo "✅ EventBridge ルール完了"
 
 # --- DynamoDB Stream → Provisioning Lambda ---
 echo "🔁 DynamoDB Stream トリガーを設定中..."
-STREAM_ARN=$(aws_cmd dynamodb describe-table \
+STREAM_ARN=$(dynamodb_cmd dynamodb describe-table \
   --table-name "$TABLE_NAME" \
   --query 'Table.LatestStreamArn' \
   --output text 2>/dev/null || echo "")
@@ -337,7 +367,7 @@ echo "🔍 デプロイ確認..."
 
 echo ""
 echo "DynamoDB Tables:"
-aws_cmd dynamodb list-tables
+dynamodb_cmd dynamodb list-tables
 
 echo ""
 echo "Lambda Functions:"
@@ -358,7 +388,7 @@ echo ""
 echo "Emulator: $CLOUD_EMULATOR"
 echo "Endpoints:"
 echo "  - Emulator:    $EMULATOR_ENDPOINT"
-echo "  - DynamoDB:    $EMULATOR_ENDPOINT"
+echo "  - DynamoDB:    $DYNAMODB_ENDPOINT"
 echo "  - S3:          $EMULATOR_ENDPOINT"
 echo ""
 echo "Architecture:"

--- a/scripts/one-pass.ts
+++ b/scripts/one-pass.ts
@@ -1,0 +1,1418 @@
+#!/usr/bin/env bun
+
+import {
+  createOnePassReport,
+  formatOnePassReportAsMarkdown,
+  type OnePassStepResult,
+  type OnePassTarget,
+} from '../packages/shared/src/quality';
+
+interface CliOptions {
+  target: OnePassTarget;
+  allowBlocked: boolean;
+  pollIntervalMs: number;
+  provisionTimeoutMs: number;
+}
+
+interface HarnessConfig {
+  target: OnePassTarget;
+  controlPlaneApiBaseUrl: string;
+  applicationAdminApiBaseUrl: string;
+  applicationParticipantApiBaseUrl: string;
+  applicationPlaneUrl: string;
+  gamedayApiBaseUrl: string;
+  controlPlaneToken?: string;
+  applicationAdminToken?: string;
+  applicationParticipantToken?: string;
+}
+
+interface DevIdentityHeaders {
+  'X-TenkaCloud-Dev-User-Id'?: string;
+  'X-TenkaCloud-Dev-Tenant-Id'?: string;
+  'X-TenkaCloud-Dev-Roles'?: string;
+}
+
+interface TenantProvisioningStatus {
+  tenantId: string;
+  provisioningStatus: string;
+  applicationDeploymentStatus?: string;
+  provisionedResources?: unknown;
+  provisioningError?: string | null;
+  provisionedAt?: string | null;
+  provisioningEnabled: boolean;
+}
+
+interface TenantResponse {
+  id: string;
+  slug: string;
+  computeType: string;
+}
+
+interface EventResponse {
+  id: string;
+  name: string;
+}
+
+interface ProblemResponse {
+  id: string;
+  title: string;
+}
+
+interface DeployProblemResponse {
+  stackName?: string;
+  outputs?: Record<string, string>;
+}
+
+class HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    target: 'local',
+    allowBlocked: false,
+    pollIntervalMs: 1000,
+    provisionTimeoutMs: 20000,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--allow-blocked') {
+      options.allowBlocked = true;
+      continue;
+    }
+
+    if (arg.startsWith('--target=')) {
+      const target = arg.slice('--target='.length);
+      if (target === 'local' || target === 'aws') {
+        options.target = target;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--poll-interval-ms=')) {
+      const value = Number.parseInt(arg.slice('--poll-interval-ms='.length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.pollIntervalMs = value;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--provision-timeout-ms=')) {
+      const value = Number.parseInt(
+        arg.slice('--provision-timeout-ms='.length),
+        10,
+      );
+      if (Number.isFinite(value) && value > 0) {
+        options.provisionTimeoutMs = value;
+      }
+    }
+  }
+
+  return options;
+}
+
+function getConfig(target: OnePassTarget): HarnessConfig {
+  if (target === 'local') {
+    return {
+      target,
+      controlPlaneApiBaseUrl:
+        process.env.ONE_PASS_CONTROL_PLANE_API_BASE_URL ??
+        'http://localhost:13004/api',
+      applicationAdminApiBaseUrl:
+        process.env.ONE_PASS_APPLICATION_ADMIN_API_BASE_URL ??
+        'http://localhost:3100/api',
+      applicationParticipantApiBaseUrl:
+        process.env.ONE_PASS_APPLICATION_PARTICIPANT_API_BASE_URL ??
+        'http://localhost:3100/api',
+      applicationPlaneUrl:
+        process.env.ONE_PASS_APPLICATION_PLANE_URL ?? 'http://localhost:13001',
+      gamedayApiBaseUrl:
+        process.env.ONE_PASS_GAMEDAY_API_BASE_URL ?? 'http://localhost:3020',
+      controlPlaneToken:
+        process.env.ONE_PASS_CONTROL_PLANE_TOKEN ?? 'mock-access-token',
+      applicationAdminToken:
+        process.env.ONE_PASS_APPLICATION_ADMIN_TOKEN ?? 'mock-access-token',
+      applicationParticipantToken:
+        process.env.ONE_PASS_APPLICATION_PARTICIPANT_TOKEN ??
+        'mock-access-token',
+    };
+  }
+
+  return {
+    target,
+    controlPlaneApiBaseUrl: requireEnv('ONE_PASS_CONTROL_PLANE_API_BASE_URL'),
+    applicationAdminApiBaseUrl: requireEnv(
+      'ONE_PASS_APPLICATION_ADMIN_API_BASE_URL',
+    ),
+    applicationParticipantApiBaseUrl: requireEnv(
+      'ONE_PASS_APPLICATION_PARTICIPANT_API_BASE_URL',
+    ),
+    applicationPlaneUrl: requireEnv('ONE_PASS_APPLICATION_PLANE_URL'),
+    gamedayApiBaseUrl: requireEnv('ONE_PASS_GAMEDAY_API_BASE_URL'),
+    controlPlaneToken: requireEnv('ONE_PASS_CONTROL_PLANE_TOKEN'),
+    applicationAdminToken: requireEnv('ONE_PASS_APPLICATION_ADMIN_TOKEN'),
+    applicationParticipantToken: requireEnv('ONE_PASS_APPLICATION_PARTICIPANT_TOKEN'),
+  };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function buildHeaders(
+  token?: string,
+  contentType = true,
+  devHeaders?: DevIdentityHeaders,
+): HeadersInit {
+  return {
+    ...(contentType ? { 'Content-Type': 'application/json' } : {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...devHeaders,
+  };
+}
+
+async function requestJson<T>(
+  url: string,
+  init: RequestInit = {},
+  token?: string,
+  devHeaders?: DevIdentityHeaders,
+): Promise<T> {
+  const headers = {
+    ...buildHeaders(
+      token,
+      init.body !== undefined || init.method === 'POST',
+      devHeaders,
+    ),
+    ...init.headers,
+  };
+
+  const response = await fetch(url, { ...init, headers });
+  const text = await response.text();
+  const body = text.length > 0 ? safeParseJson(text) : null;
+
+  if (!response.ok) {
+    const errorMessage =
+      extractErrorMessage(body) || `${response.status} ${response.statusText}`;
+    throw new HttpError(errorMessage, response.status, body);
+  }
+
+  return body as T;
+}
+
+async function requestStatus(
+  url: string,
+  init: RequestInit = {},
+  token?: string,
+  devHeaders?: DevIdentityHeaders,
+): Promise<Response> {
+  const headers = {
+    ...buildHeaders(token, false, devHeaders),
+    ...init.headers,
+  };
+
+  return fetch(url, { ...init, headers });
+}
+
+function safeParseJson(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return input;
+  }
+}
+
+function extractErrorMessage(body: unknown): string | null {
+  if (!body || typeof body !== 'object') {
+    return typeof body === 'string' ? body : null;
+  }
+
+  const error = 'error' in body ? body.error : null;
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = error.message;
+    return typeof message === 'string' ? message : null;
+  }
+
+  const message = 'message' in body ? body.message : null;
+  return typeof message === 'string' ? message : null;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function createStep(
+  id: string,
+  label: string,
+  status: OnePassStepResult['status'],
+  detail: string,
+  hint?: string,
+): OnePassStepResult {
+  return { id, label, status, detail, hint };
+}
+
+function timestampSuffix(): string {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 17)}${crypto.randomUUID().replace(/-/g, '').slice(0, 6)}`;
+}
+
+function createDevHeaders(input: {
+  userId: string;
+  tenantId: string;
+  roles: string[];
+}): DevIdentityHeaders {
+  return {
+    'X-TenkaCloud-Dev-User-Id': input.userId,
+    'X-TenkaCloud-Dev-Tenant-Id': input.tenantId,
+    'X-TenkaCloud-Dev-Roles': input.roles.join(','),
+  };
+}
+
+function gamedayAdminUrl(config: HarnessConfig, path: string): string {
+  return `${config.gamedayApiBaseUrl}/api/gameday/admin${path}`;
+}
+
+function gamedayParticipantUrl(config: HarnessConfig, path: string): string {
+  return `${config.gamedayApiBaseUrl}/api/gameday${path}`;
+}
+
+async function createEventForOnePass(
+  config: HarnessConfig,
+  runId: string,
+  adminHeaders: DevIdentityHeaders,
+): Promise<EventResponse> {
+  const event = await requestJson<EventResponse>(
+    `${config.applicationAdminApiBaseUrl}/admin/events`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        name: `One Pass Event ${runId}`,
+        startTime: new Date().toISOString(),
+        endTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        type: 'gameday',
+        participantType: 'team',
+        maxParticipants: 8,
+        minTeamSize: 1,
+        maxTeamSize: 4,
+        cloudProvider: 'local',
+        regions: ['local'],
+        scoringType: 'realtime',
+        scoringIntervalMinutes: 5,
+        leaderboardVisible: true,
+      }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  await requestJson(
+    `${config.applicationAdminApiBaseUrl}/admin/events/${event.id}/status`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'scheduled' }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  await requestJson(
+    `${config.applicationAdminApiBaseUrl}/admin/events/${event.id}/status`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'active' }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  return event;
+}
+
+async function deployProblemLocally(
+  config: HarnessConfig,
+  problemId: string,
+  stackName: string,
+  adminHeaders: DevIdentityHeaders,
+): Promise<DeployProblemResponse> {
+  const deploy = await requestJson<DeployProblemResponse>(
+    `${config.applicationAdminApiBaseUrl}/admin/problems/${problemId}/deploy`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        provider: 'local',
+        region: 'local',
+        stackName,
+      }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  const status = await requestJson<{
+    status: string;
+    outputs?: Record<string, string>;
+  }>(
+    `${config.applicationAdminApiBaseUrl}/admin/problems/${problemId}/deployments/${stackName}/status?provider=local&region=local`,
+    { method: 'GET' },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  if (status.status !== 'CREATE_COMPLETE') {
+    throw new Error(
+      `Local deployment did not reach CREATE_COMPLETE. status=${status.status}`,
+    );
+  }
+
+  const serviceUrl =
+    status.outputs?.ServiceUrl ||
+    status.outputs?.FrontendUrl ||
+    deploy.outputs?.ServiceUrl ||
+    deploy.outputs?.FrontendUrl;
+
+  if (serviceUrl) {
+    const response = await requestStatus(serviceUrl, { method: 'GET' });
+    if (!response.ok) {
+      throw new Error(
+        `Deployed local runtime is not reachable: ${serviceUrl} (${response.status})`,
+      );
+    }
+  }
+
+  return {
+    ...deploy,
+    outputs: status.outputs ?? deploy.outputs,
+  };
+}
+
+async function initializeGameDayRuntime(
+  config: HarnessConfig,
+  eventId: string,
+  adminHeaders: DevIdentityHeaders,
+): Promise<void> {
+  try {
+    await requestJson(
+      gamedayAdminUrl(config, '/game/init'),
+      {
+        method: 'POST',
+        body: JSON.stringify({ eventId, durationMinutes: 60 }),
+      },
+      config.applicationAdminToken,
+      adminHeaders,
+    );
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status !== 409) {
+      throw error;
+    }
+  }
+
+  await requestJson(
+    gamedayAdminUrl(config, '/attacks/seed'),
+    {
+      method: 'POST',
+      body: JSON.stringify({ eventId }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  await requestJson(
+    gamedayAdminUrl(config, '/teams/register'),
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        eventId,
+        teamId: 'one-pass-target',
+        teamName: 'One Pass Target',
+      }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  await requestJson(
+    gamedayAdminUrl(config, '/game/start'),
+    {
+      method: 'POST',
+      body: JSON.stringify({ eventId, durationMinutes: 60 }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+}
+
+async function createSoloMembership(
+  config: HarnessConfig,
+  eventId: string,
+  participantHeaders: DevIdentityHeaders,
+): Promise<{ teamId: string }> {
+  await requestJson(
+    gamedayParticipantUrl(config, '/teams/solo'),
+    {
+      method: 'POST',
+      body: JSON.stringify({ eventId }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  const membershipResponse = await requestJson<
+    | { teamId: string }
+    | {
+        membership?: {
+          teamId?: string;
+        } | null;
+      }
+  >(
+    gamedayParticipantUrl(
+      config,
+      `/teams/my-membership?eventId=${encodeURIComponent(eventId)}`,
+    ),
+    { method: 'GET' },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  const teamId =
+    'teamId' in membershipResponse
+      ? membershipResponse.teamId
+      : membershipResponse.membership?.teamId;
+
+  if (!teamId) {
+    throw new Error('Participant team membership did not return a teamId');
+  }
+
+  return { teamId };
+}
+
+async function exerciseParticipantFlow(
+  config: HarnessConfig,
+  eventId: string,
+  teamId: string,
+  participantHeaders: DevIdentityHeaders,
+  adminHeaders: DevIdentityHeaders,
+): Promise<void> {
+  const attacks = await requestJson<{ attacks: Array<{ id: string; slug: string }> }>(
+    gamedayParticipantUrl(
+      config,
+      `/attacks/catalog?eventId=${encodeURIComponent(eventId)}`,
+    ),
+    { method: 'GET' },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+  const attack = attacks.attacks[0];
+  if (!attack) {
+    throw new Error('Attack catalog is empty');
+  }
+
+  await requestJson(
+    gamedayParticipantUrl(config, '/attacks/purchase'),
+    {
+      method: 'POST',
+      body: JSON.stringify({ eventId, teamId, attackId: attack.id }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  await requestJson(
+    gamedayParticipantUrl(config, '/attacks/execute'),
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        eventId,
+        teamId,
+        attackId: attack.id,
+        targetTeamId: 'one-pass-target',
+      }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  await requestJson(
+    gamedayAdminUrl(config, '/fault-injection/execute'),
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        eventId,
+        teamId,
+        attackSlug: attack.slug,
+      }),
+    },
+    config.applicationAdminToken,
+    adminHeaders,
+  );
+
+  const defense = await requestJson<{ attacks: Array<{ attackId: string }> }>(
+    gamedayParticipantUrl(
+      config,
+      `/defense/active?eventId=${encodeURIComponent(eventId)}&teamId=${encodeURIComponent(teamId)}`,
+    ),
+    { method: 'GET' },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  if (defense.attacks.length === 0) {
+    throw new Error('Defense active list is empty after fault injection');
+  }
+
+  await requestJson(
+    gamedayParticipantUrl(config, '/defense/hint'),
+    {
+      method: 'POST',
+      body: JSON.stringify({ eventId, teamId, attackId: attack.id }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  await requestJson(
+    gamedayParticipantUrl(config, '/defense/report-fix'),
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        eventId,
+        teamId,
+        vulnerabilitySlug: attack.slug,
+      }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  await requestJson(
+    gamedayParticipantUrl(config, '/voting/vote'),
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        eventId,
+        teamId,
+        votedForTeamId: 'one-pass-target',
+      }),
+    },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  const voting = await requestJson<{ results: unknown[] }>(
+    gamedayParticipantUrl(
+      config,
+      `/voting/results?eventId=${encodeURIComponent(eventId)}`,
+    ),
+    { method: 'GET' },
+    config.applicationParticipantToken,
+    participantHeaders,
+  );
+
+  if (voting.results.length === 0) {
+    throw new Error('Voting results are empty after submitting a vote');
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const config = getConfig(options.target);
+  const startedAt = new Date().toISOString();
+  const steps: OnePassStepResult[] = [];
+  const runId = timestampSuffix();
+  const devTenantId = `one-pass-${runId.toLowerCase()}`;
+  const adminHeaders = createDevHeaders({
+    userId: `tenant-admin-${runId.toLowerCase()}`,
+    tenantId: devTenantId,
+    roles: ['tenant-admin', 'organizer'],
+  });
+  const participantHeaders = createDevHeaders({
+    userId: `participant-${runId.toLowerCase()}`,
+    tenantId: devTenantId,
+    roles: ['participant', 'competitor'],
+  });
+
+  let tenant: TenantResponse | null = null;
+  let provisioningStatus: TenantProvisioningStatus | null = null;
+  let event: EventResponse | null = null;
+  let problem: ProblemResponse | null = null;
+
+  try {
+    const tenantHealth = await requestJson<{ status: string; service?: string }>(
+      `${config.controlPlaneApiBaseUrl.replace(/\/api$/, '')}/health`,
+      { method: 'GET' },
+      config.controlPlaneToken,
+    );
+    steps.push(
+      createStep(
+        '01',
+        'tenant-management health',
+        tenantHealth.status === 'ok' ? 'passed' : 'failed',
+        `status=${tenantHealth.status}`,
+      ),
+    );
+  } catch (error) {
+    steps.push(
+      createStep(
+        '01',
+        'tenant-management health',
+        'failed',
+        formatError(error),
+      ),
+    );
+  }
+
+  try {
+    const problemHealth = await requestJson<{ status: string }>(
+      `${config.applicationAdminApiBaseUrl.replace(/\/api$/, '')}/health`,
+      { method: 'GET' },
+      config.applicationAdminToken,
+    );
+    steps.push(
+      createStep(
+        '02',
+        'problem-service health',
+        problemHealth.status === 'ok' || problemHealth.status === 'healthy'
+          ? 'passed'
+          : 'failed',
+        `status=${problemHealth.status}`,
+      ),
+    );
+  } catch (error) {
+    steps.push(
+      createStep('02', 'problem-service health', 'failed', formatError(error)),
+    );
+  }
+
+  try {
+    const gamedayHealth = await requestJson<{ status: string }>(
+      `${config.gamedayApiBaseUrl}/health`,
+      { method: 'GET' },
+      config.applicationParticipantToken,
+    );
+    steps.push(
+      createStep(
+        '03',
+        'gameday-service health',
+        gamedayHealth.status === 'ok' ? 'passed' : 'failed',
+        `status=${gamedayHealth.status}`,
+      ),
+    );
+  } catch (error) {
+    steps.push(
+      createStep('03', 'gameday-service health', 'failed', formatError(error)),
+    );
+  }
+
+  try {
+    tenant = await requestJson<TenantResponse>(
+      `${config.controlPlaneApiBaseUrl}/tenants`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          name: `One Pass Tenant ${runId}`,
+          slug: `one-pass-${runId.toLowerCase()}`,
+          adminEmail: `one-pass-${runId.toLowerCase()}@example.com`,
+          tier: 'FREE',
+          region: 'ap-northeast-1',
+          isolationModel: 'POOL',
+          computeType: 'SERVERLESS',
+        }),
+      },
+      config.controlPlaneToken,
+    );
+
+    steps.push(
+      createStep(
+        '04',
+        'tenant create',
+        'passed',
+        `tenantId=${tenant.id} slug=${tenant.slug} computeType=${tenant.computeType}`,
+      ),
+    );
+  } catch (error) {
+    steps.push(createStep('04', 'tenant create', 'failed', formatError(error)));
+  }
+
+  if (tenant) {
+    try {
+      await requestJson<{ success: boolean; provisioningStatus: string }>(
+        `${config.controlPlaneApiBaseUrl}/tenants/${tenant.id}/provision`,
+        { method: 'POST' },
+        config.controlPlaneToken,
+      );
+
+      const deadline = Date.now() + options.provisionTimeoutMs;
+      while (Date.now() < deadline) {
+        provisioningStatus = await requestJson<TenantProvisioningStatus>(
+          `${config.controlPlaneApiBaseUrl}/tenants/${tenant.id}/provision`,
+          { method: 'GET' },
+          config.controlPlaneToken,
+        );
+
+        if (
+          provisioningStatus.provisioningStatus === 'COMPLETED' ||
+          provisioningStatus.provisioningStatus === 'FAILED'
+        ) {
+          break;
+        }
+
+        await wait(options.pollIntervalMs);
+      }
+
+      provisioningStatus ??= await requestJson<TenantProvisioningStatus>(
+        `${config.controlPlaneApiBaseUrl}/tenants/${tenant.id}/provision`,
+        { method: 'GET' },
+        config.controlPlaneToken,
+      );
+
+      if (!provisioningStatus.provisioningEnabled) {
+        steps.push(
+          createStep(
+            '05',
+            'tenant provisioning',
+            'blocked',
+            'PROVISIONING_ENABLED=false のため TenantOnboarding が publish されません。',
+            'make start-one-pass-local で起動してください。',
+          ),
+        );
+      } else if (provisioningStatus.provisioningStatus === 'FAILED') {
+        steps.push(
+          createStep(
+            '05',
+            'tenant provisioning',
+            'failed',
+            provisioningStatus.provisioningError ||
+              'Provisioning status became FAILED.',
+          ),
+        );
+      } else if (provisioningStatus.provisioningStatus !== 'COMPLETED') {
+        steps.push(
+          createStep(
+            '05',
+            'tenant provisioning',
+            'blocked',
+            `timeout waiting for completion: provisioningStatus=${provisioningStatus.provisioningStatus}`,
+            'EventBridge / Lambda wiring を確認してください。',
+          ),
+        );
+      } else {
+        steps.push(
+          createStep(
+            '05',
+            'tenant provisioning',
+            'passed',
+            `provisioningStatus=${provisioningStatus.provisioningStatus} applicationDeploymentStatus=${provisioningStatus.applicationDeploymentStatus ?? 'NOT_DEPLOYED'}`,
+          ),
+        );
+      }
+    } catch (error) {
+      steps.push(
+        createStep('05', 'tenant provisioning', 'failed', formatError(error)),
+      );
+    }
+  } else {
+    steps.push(
+      createStep(
+        '05',
+        'tenant provisioning',
+        'blocked',
+        'tenant create が失敗したため実行できません。',
+      ),
+    );
+  }
+
+  try {
+    const appResponse = await requestStatus(
+      `${config.applicationPlaneUrl}/`,
+      { method: 'GET' },
+    );
+    const deploymentStatus =
+      provisioningStatus?.applicationDeploymentStatus ?? 'NOT_DEPLOYED';
+
+    if (options.target === 'local') {
+      steps.push(
+        createStep(
+          '06',
+          'tenant application plane runtime',
+          appResponse.ok ? 'passed' : 'failed',
+          `status=${appResponse.status} shared application plane is reachable (applicationDeploymentStatus=${deploymentStatus})`,
+        ),
+      );
+    } else if (deploymentStatus === 'DEPLOYED') {
+      steps.push(
+        createStep(
+          '06',
+          'tenant application plane runtime',
+          appResponse.ok ? 'passed' : 'failed',
+          `status=${appResponse.status} applicationDeploymentStatus=${deploymentStatus}`,
+        ),
+      );
+    } else {
+      steps.push(
+        createStep(
+          '06',
+          'tenant application plane runtime',
+          'blocked',
+          `HTTP ${appResponse.status} で共有 Application Plane には到達できますが tenant runtime descriptor が未配備です。applicationDeploymentStatus=${deploymentStatus}`,
+          'tenant ごとの endpoint / runtimeVersion / deployment descriptor を provisioning 完了に接続してください。',
+        ),
+      );
+    }
+  } catch (error) {
+    steps.push(
+      createStep(
+        '06',
+        'tenant application plane runtime',
+        'failed',
+        formatError(error),
+      ),
+    );
+  }
+
+  const adminAccess = await probeAdminAccess(config, adminHeaders);
+  steps.push(adminAccess);
+
+  if (adminAccess.status === 'passed') {
+    try {
+      event = await createEventForOnePass(config, runId, adminHeaders);
+
+      steps.push(
+        createStep(
+          '08',
+          'event create',
+          'passed',
+          `eventId=${event.id} name=${event.name}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep('08', 'event create', 'failed', formatError(error)),
+      );
+    }
+
+    try {
+      problem = await requestJson<ProblemResponse>(
+        `${config.applicationAdminApiBaseUrl}/admin/problems`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            title: `One Pass Security Battle Royale ${runId}`,
+            type: 'gameday',
+            category: 'security',
+            difficulty: 'easy',
+            description: {
+              overview: 'One-pass local deploy verification problem.',
+              objectives: ['Deploy local stack', 'Attach to event'],
+              hints: [],
+              prerequisites: [],
+              estimatedTime: 15,
+            },
+            metadata: {
+              author: 'one-pass-harness',
+              version: '1.0.0',
+              tags: ['one-pass', 'local'],
+            },
+            deployment: {
+              providers: ['local'],
+              timeout: 5,
+              templates: {
+                local: {
+                  type: 'docker-compose',
+                  path: 'gameday/security-battle-royale/local/docker-compose.yaml',
+                  parameters: {
+                    DB_PASSWORD: 'one-pass-local-password',
+                  },
+                },
+              },
+              regions: {
+                local: ['local'],
+              },
+            },
+            scoring: {
+              type: 'manual',
+              path: 'manual://one-pass',
+              timeoutMinutes: 5,
+              criteria: [],
+            },
+          }),
+        },
+        config.applicationAdminToken,
+        adminHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '09',
+          'problem create',
+          'passed',
+          `problemId=${problem.id} title=${problem.title}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep('09', 'problem create', 'failed', formatError(error)),
+      );
+    }
+  } else {
+    steps.push(
+      createStep(
+        '08',
+        'event create',
+        'blocked',
+        'admin access が通っていないため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '09',
+        'problem create',
+        'blocked',
+        'admin access が通っていないため実行できません。',
+      ),
+    );
+  }
+
+  if (event && problem) {
+    try {
+      await requestJson(
+        `${config.applicationAdminApiBaseUrl}/admin/events/${event.id}/problems`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ problemId: problem.id }),
+        },
+        config.applicationAdminToken,
+        adminHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '10',
+          'event problem attach',
+          'passed',
+          `eventId=${event.id} problemId=${problem.id}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep('10', 'event problem attach', 'failed', formatError(error)),
+      );
+    }
+
+    try {
+      const deploy = await deployProblemLocally(
+        config,
+        problem.id,
+        `one-pass-${runId.toLowerCase()}`,
+        adminHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '11',
+          'local problem deploy',
+          'passed',
+          `stackName=${deploy.stackName ?? 'unknown'} outputs=${Object.keys(deploy.outputs ?? {}).join(',') || 'none'}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep('11', 'local problem deploy', 'failed', formatError(error)),
+      );
+    }
+
+    try {
+      const competitorAccount = await requestJson<{ id: string }>(
+        `${config.applicationAdminApiBaseUrl}/admin/events/${event.id}/competitor-accounts`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            name: `Local Team ${runId}`,
+            provider: 'local',
+            accountId: `local-${runId.toLowerCase()}`,
+            region: 'local',
+          }),
+        },
+        config.applicationAdminToken,
+        adminHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '12',
+          'competitor account register',
+          'passed',
+          `competitorAccountId=${competitorAccount.id}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep(
+          '12',
+          'competitor account register',
+          'failed',
+          formatError(error),
+        ),
+      );
+    }
+
+    try {
+      await initializeGameDayRuntime(config, event.id, adminHeaders);
+
+      steps.push(
+        createStep(
+          '13',
+          'gameday runtime init',
+          'passed',
+          `eventId=${event.id} game initialized, attacks seeded, target team registered`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep(
+          '13',
+          'gameday runtime init',
+          'failed',
+          formatError(error),
+        ),
+      );
+    }
+  } else {
+    steps.push(
+      createStep(
+        '10',
+        'event problem attach',
+        'blocked',
+        'event または problem の作成に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '11',
+        'local problem deploy',
+        'blocked',
+        'problem create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '12',
+        'competitor account register',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '13',
+        'gameday runtime init',
+        'blocked',
+        'event create または problem create に失敗したため実行できません。',
+      ),
+    );
+  }
+
+  if (event) {
+    try {
+      const registerResult = await requestJson<{ success: boolean; message: string }>(
+        `${config.applicationParticipantApiBaseUrl}/participant/events/${event.id}/register`,
+        { method: 'POST' },
+        config.applicationParticipantToken,
+        participantHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '14',
+          'participant register',
+          registerResult.success ? 'passed' : 'failed',
+          registerResult.message,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep(
+          '14',
+          'participant register',
+          'failed',
+          formatError(error),
+        ),
+      );
+    }
+
+    try {
+      const myEvents = await requestJson<{ events: Array<{ id: string }> }>(
+        `${config.applicationParticipantApiBaseUrl}/participant/events/me`,
+        { method: 'GET' },
+        config.applicationParticipantToken,
+        participantHeaders,
+      );
+      const found = myEvents.events.some((candidate) => candidate.id === event?.id);
+
+      steps.push(
+        createStep(
+          '15',
+          'participant my events',
+          found ? 'passed' : 'failed',
+          found
+            ? `registered event ${event.id} is present in /participant/events/me`
+            : `registered event ${event.id} is missing from /participant/events/me`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep(
+          '15',
+          'participant my events',
+          'failed',
+          formatError(error),
+        ),
+      );
+    }
+
+    let membership: { teamId: string } | null = null;
+    try {
+      membership = await createSoloMembership(config, event.id, participantHeaders);
+      steps.push(
+        createStep(
+          '16',
+          'participant team membership',
+          'passed',
+          `teamId=${membership.teamId}`,
+        ),
+      );
+    } catch (error) {
+      steps.push(
+        createStep(
+          '16',
+          'participant team membership',
+          'failed',
+          formatError(error),
+        ),
+      );
+    }
+
+    if (membership) {
+      try {
+      await exerciseParticipantFlow(
+        config,
+        event.id,
+        membership.teamId,
+        participantHeaders,
+        adminHeaders,
+      );
+      steps.push(
+        createStep(
+          '17',
+          'attack / defense / vote',
+          'passed',
+          `eventId=${event.id} teamId=${membership.teamId}`,
+        ),
+      );
+      } catch (error) {
+        steps.push(
+          createStep(
+            '17',
+            'attack / defense / vote',
+            'failed',
+            formatError(error),
+          ),
+        );
+      }
+    } else {
+      steps.push(
+        createStep(
+          '17',
+          'attack / defense / vote',
+          'blocked',
+          'team membership の確立に失敗したため実行できません。',
+        ),
+      );
+    }
+
+    try {
+      await requestJson<{ url: string }>(
+        `${config.applicationPlaneUrl}/api/participant/events/${event.id}/aws-console`,
+        { method: 'GET' },
+        undefined,
+        participantHeaders,
+      );
+
+      steps.push(
+        createStep(
+          '18',
+          'participant aws console',
+          'passed',
+          'aws console url generated',
+        ),
+      );
+    } catch (error) {
+      if (
+        error instanceof HttpError &&
+        error.status === 404 &&
+        /not configured/i.test(error.message)
+      ) {
+        steps.push(
+          createStep(
+            '18',
+            'participant aws console',
+            options.target === 'local' ? 'passed' : 'blocked',
+            options.target === 'local'
+              ? 'local mode は aws-console を fail-closed で確認しました。'
+              : 'AWS Console role federation が event に接続されていません。',
+            options.target === 'local'
+              ? 'AWS_PARTICIPANT_ROLE_ARN を設定した場合は `--target=aws` の受け入れ条件で成功確認してください。'
+              : 'deploy outputs か event settings から participant console role を解決する必要があります。',
+          ),
+        );
+      } else {
+        steps.push(
+          createStep(
+            '18',
+            'participant aws console',
+            'failed',
+            formatError(error),
+          ),
+        );
+      }
+    }
+  } else {
+    steps.push(
+      createStep(
+        '14',
+        'participant register',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '15',
+        'participant my events',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '16',
+        'participant team membership',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '17',
+        'attack / defense / vote',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+    steps.push(
+      createStep(
+        '18',
+        'participant aws console',
+        'blocked',
+        'event create に失敗したため実行できません。',
+      ),
+    );
+  }
+
+  const report = createOnePassReport({
+    target: options.target,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    steps,
+  });
+
+  console.log(formatOnePassReportAsMarkdown(report));
+
+  if (
+    report.overallStatus === 'failed' ||
+    (!options.allowBlocked && report.overallStatus === 'blocked')
+  ) {
+    process.exitCode = 2;
+  }
+}
+
+async function probeAdminAccess(
+  config: HarnessConfig,
+  adminHeaders: DevIdentityHeaders,
+): Promise<OnePassStepResult> {
+  try {
+    await requestJson(
+      `${config.applicationAdminApiBaseUrl}/admin/events`,
+      { method: 'GET' },
+      config.applicationAdminToken,
+      adminHeaders,
+    );
+    return createStep(
+      '07',
+      'application admin access',
+      'passed',
+      'admin routes are reachable with explicit dev identity headers.',
+    );
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 403) {
+      return createStep(
+        '07',
+        'application admin access',
+        'blocked',
+        'Application Plane admin route returned 403 even with explicit dev admin identity headers.',
+        'problem-service AUTH_SKIP の開発用ヘッダー上書きが有効か確認してください。',
+      );
+    }
+
+    if (error instanceof HttpError && error.status === 401) {
+      return createStep(
+        '07',
+        'application admin access',
+        'blocked',
+        'Application Plane admin route returned 401.',
+        'AUTH_SKIP=1 と admin token 設定を確認してください。',
+      );
+    }
+
+    return createStep(
+      '07',
+      'application admin access',
+      'failed',
+      formatError(error),
+    );
+  }
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof HttpError) {
+    const detail =
+      typeof error.body === 'string'
+        ? error.body
+        : extractErrorMessage(error.body) || JSON.stringify(error.body);
+    return `HTTP ${error.status}: ${detail}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+main().catch((error: unknown) => {
+  console.error('[one-pass] failed:', formatError(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- split local one-pass work into a clean branch instead of merging the mixed worktree
- run DynamoDB on DynamoDB Local while keeping Kumo for the remaining local AWS emulation
- close the local one-pass path through tenant provisioning, local problem deploy, participant registration, and attack/defense/vote

## Validation
- make before-commit
- bun scripts/one-pass.ts --target=local --allow-blocked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-pass local and AWS acceptance testing workflows for end-to-end validation
  * Introduced development identity headers for improved local testing capabilities
  * Added new security challenge problem (Unicorn.Rentals) for GameDay competitions
  * Separated DynamoDB Local from cloud emulator for cleaner local infrastructure

* **Documentation**
  * New quickstart guide for one-pass workflows
  * Added architecture harness documentation
  * Created AWS acceptance criteria guide

* **Tests**
  * Added one-pass test harness with report formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->