### PR TITLE
fix: add cdk-nag suppressions and individual destroy targets

### DIFF
--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install deploy deploy-control-plane deploy-application-plane deploy-problem destroy synth diff bootstrap build test lint format format-check static-analysis before-commit clean help
+.PHONY: install deploy deploy-control-plane deploy-application-plane deploy-problem destroy destroy-control-plane destroy-application-plane destroy-problem synth diff bootstrap build test lint format format-check static-analysis before-commit clean help
 
 ENV ?= development
 CDK := bun run cdk
@@ -49,6 +49,18 @@ deploy-problem: build
 #? destroy: Destroy all stacks
 destroy: build
 	$(CDK) destroy --all $(CDK_CONTEXT)
+
+#? destroy-control-plane: Destroy ControlPlane stack only
+destroy-control-plane: build
+	$(CDK) destroy ControlPlaneStack $(CDK_CONTEXT)
+
+#? destroy-application-plane: Destroy AppPlane stack only
+destroy-application-plane: build
+	$(CDK) destroy AppPlaneStack $(CDK_CONTEXT)
+
+#? destroy-problem: Destroy ProblemDeployPlane stack only
+destroy-problem: build
+	$(CDK) destroy ProblemDeployPlaneStack $(CDK_CONTEXT)
 
 #? synth: Synthesize CloudFormation templates
 synth: build

--- a/infrastructure/lib/app-plane.ts
+++ b/infrastructure/lib/app-plane.ts
@@ -6,6 +6,7 @@ import {
   type TenantLifecycleScriptJobProps,
 } from "@cdklabs/sbt-aws";
 import * as cdk from "aws-cdk-lib";
+import { NagSuppressions } from "cdk-nag";
 import type { Construct } from "constructs";
 import { buildProvisionScript } from "./handlers/provision";
 import { buildDeprovisionScript } from "./handlers/deprovision";
@@ -79,5 +80,12 @@ export class AppPlaneStack extends cdk.Stack {
       eventManager: props.eventManager,
       scriptJobs: [provisioningJob, deprovisioningJob],
     });
+
+    NagSuppressions.addStackSuppressions(this, [
+      {
+        id: "AwsSolutions-IAM5",
+        reason: `DynamoDB permissions scoped to table prefix '${props.dynamoDbTablePrefix}-*', CloudFormation permissions scoped to stack prefix '${props.cfnStackPrefix}-*'`,
+      },
+    ]);
   }
 }

--- a/infrastructure/lib/control-plane.ts
+++ b/infrastructure/lib/control-plane.ts
@@ -1,5 +1,6 @@
 import { CognitoAuth, ControlPlane, type IEventManager } from "@cdklabs/sbt-aws";
 import { Stack, type StackProps } from "aws-cdk-lib";
+import { NagSuppressions } from "cdk-nag";
 import type { Construct } from "constructs";
 
 export interface ControlPlaneStackProps extends StackProps {
@@ -34,5 +35,16 @@ export class ControlPlaneStack extends Stack {
 
     this.eventManager = controlPlane.eventManager;
     this.regApiGatewayUrl = controlPlane.controlPlaneAPIGatewayUrl;
+
+    NagSuppressions.addStackSuppressions(this, [
+      {
+        id: "AwsSolutions-L1",
+        reason: "Lambda runtimes are managed by @cdklabs/sbt-aws and cannot be overridden",
+      },
+      {
+        id: "AwsSolutions-IAM5",
+        reason: "Wildcard permissions in SBT ControlPlane are scoped to specific API paths (DELETE/PUT /tenants/*)",
+      },
+    ]);
   }
 }

--- a/infrastructure/lib/problem-deploy-plane.ts
+++ b/infrastructure/lib/problem-deploy-plane.ts
@@ -1,5 +1,6 @@
 import { CoreApplicationPlane, type IEventManager, ScriptJob } from "@cdklabs/sbt-aws";
 import * as cdk from "aws-cdk-lib";
+import { NagSuppressions } from "cdk-nag";
 import type { Construct } from "constructs";
 import { EVENTS, EVENT_SOURCES } from "./constants/events";
 import { buildDeployProblemScript } from "./handlers/deploy-problem";
@@ -67,5 +68,12 @@ export class ProblemDeployPlaneStack extends cdk.Stack {
       eventManager: props.eventManager,
       scriptJobs: [problemDeployJob],
     });
+
+    NagSuppressions.addStackSuppressions(this, [
+      {
+        id: "AwsSolutions-IAM5",
+        reason: `Cross-account AssumeRole scoped to role name '${props.targetRoleName}' with account wildcard — required for multi-account problem deployment`,
+      },
+    ]);
   }
 }


### PR DESCRIPTION
## Summary

- Add `NagSuppressions` to all 3 stacks so `cdk deploy` passes with cdk-nag enabled
- Add `make destroy-control-plane`, `destroy-application-plane`, `destroy-problem` for individual stack deletion

## cdk-nag Suppressions

| Stack | Rule | Reason |
|---|---|---|
| ControlPlaneStack | AwsSolutions-L1 | Lambda runtimes managed by SBT, cannot override |
| ControlPlaneStack | AwsSolutions-IAM5 | SBT API path wildcards (DELETE/PUT /tenants/*) |
| AppPlaneStack | AwsSolutions-IAM5 | DynamoDB/CloudFormation scoped to configurable prefixes |
| ProblemDeployPlaneStack | AwsSolutions-IAM5 | Cross-account AssumeRole scoped to role name |

## Test Plan

- [x] `make build` passes
- [x] `make test` — 17/17 pass
- [ ] `make deploy` — no cdk-nag errors
- [ ] `make destroy-application-plane` — individual destroy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new Make targets added for selective infrastructure teardown: `destroy-control-plane`, `destroy-application-plane`, and `destroy-problem`. These complement the existing `destroy` command.

* **Chores**
  * Infrastructure stacks updated with security rule suppressions for IAM and runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->