### PR TITLE
fix: restore nginx.conf, add provisioning env, fix stop/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,16 @@ start:
 
 #? stop: Stop all services
 stop:
-	@docker compose --profile localstack --profile kumo --profile floci stop 2>/dev/null || true
-	@lsof -ti:13000,13001,13004 2>/dev/null | xargs kill -9 2>/dev/null || true
+	@if docker info > /dev/null 2>&1; then \
+		docker compose --profile localstack --profile kumo --profile floci down; \
+	else \
+		echo "Docker is not running, skipping container shutdown"; \
+	fi
+	@PIDS=$$(lsof -ti:13000,13001,13004,3010,3011,3012,3020,3100 2>/dev/null); \
+	if [ -n "$$PIDS" ]; then \
+		echo "Killing dev server processes: $$PIDS"; \
+		echo "$$PIDS" | xargs kill -9; \
+	fi
 	@echo "Stopped."
 
 #? restart: Restart all services
@@ -104,8 +112,9 @@ typecheck:
 
 #? test: Run tests with coverage
 test:
-test_coverage: test
 	@for app in $(FRONTEND_APPS); do (cd $$app && $(NR) test:coverage) || exit 1; done
+
+test_coverage: test
 
 #? test_quick: Run tests without coverage (fast)
 test_quick:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,9 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
       - AUTH_SKIP=${AUTH_SKIP:-1}
+      - PROVISIONING_ENABLED=true
+      - PROVISIONING_DELIVERY_MODE=inline
+      - EVENT_BUS_NAME=tenkacloud-local-tenant-events
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:13004/health"]
       interval: 10s

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -1,0 +1,181 @@
+upstream control-plane {
+    server control-plane:13000;
+}
+
+upstream application-plane {
+    server application-plane:13001;
+}
+
+upstream tenant-api {
+    server tenant-management:13004;
+}
+
+upstream battle-api {
+    server battle-service:3010;
+}
+
+upstream scoring-api {
+    server scoring-service:3011;
+}
+
+upstream leaderboard-api {
+    server leaderboard-service:3012;
+}
+
+upstream problem-api {
+    server problem-service:3100;
+}
+
+upstream gameday-api {
+    server gameday-service:3020;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    # Logging
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log warn;
+
+    # Control Plane: /control/*
+    # Note: control-plane has basePath: '/control', so we proxy directly without URL rewrite
+    location /control {
+        proxy_pass http://control-plane;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Tenant API: /api/tenants/*
+    # Rewrite to remove /api prefix since tenant-management serves on /api/tenants
+    location /api/tenants {
+        proxy_pass http://tenant-api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Battle API: /api/battles/* → battle-service /battles/*
+    location /api/battles {
+        proxy_pass http://battle-api/battles;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Scoring API: /api/scores/* → scoring-service /api/scores/*
+    location /api/scores {
+        proxy_pass http://scoring-api/api/scores;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Scoring API: /api/criteria/* → scoring-service /criteria/*
+    location /api/criteria {
+        proxy_pass http://scoring-api/criteria;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Scoring API: /api/sessions/* → scoring-service /sessions/*
+    location /api/sessions {
+        proxy_pass http://scoring-api/sessions;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Leaderboard API (with SSE support): /api/leaderboards/* → leaderboard-service /api/leaderboards/*
+    location /api/leaderboards {
+        proxy_pass http://leaderboard-api/api/leaderboards;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE support
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+    }
+
+    # Problem Service: /api/admin/* → problem-service /api/admin/*
+    location /api/admin {
+        proxy_pass http://problem-api/api/admin;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Problem Service: /api/player/* → problem-service /api/player/*
+    location /api/player {
+        proxy_pass http://problem-api/api/player;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Problem Service: /api/participant/* → problem-service /api/participant/*
+    location /api/participant {
+        proxy_pass http://problem-api/api/participant;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # GameDay API: /api/gameday/* → gameday-service /api/gameday/*
+    location /api/gameday {
+        proxy_pass http://gameday-api/api/gameday;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Application Plane: /* (default)
+    location / {
+        proxy_pass http://application-plane;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary

- Restore `infrastructure/nginx/nginx.conf` (deleted in PR 385, breaks `docker compose up`)
- Add `PROVISIONING_ENABLED`, `PROVISIONING_DELIVERY_MODE`, `EVENT_BUS_NAME` to tenant-management in `docker-compose.yml`
- Fix `make stop`: use `docker compose down` instead of `stop`, kill all service ports
- Fix `make test`: recipe was attached to wrong target line

## Test Plan

- [x] `make before-commit` passes
- [x] `make start` starts all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the robustness and reliability of the deployment shutdown process to gracefully handle scenarios when Docker is not running
  * Configured environment variables for tenant management provisioning behavior settings and event bus connectivity requirements
  * Established a reverse proxy gateway layer to enable intelligent API request routing and streamlined microservice communication integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->