### PR TITLE
feat: integrate Application Plane with Cognito auth

### DIFF
--- a/client/Application/__tests__/auth.test.ts
+++ b/client/Application/__tests__/auth.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { NextAuthConfig } from 'next-auth';
 
-// Mock next-auth
 vi.mock('next-auth', () => ({
   default: vi.fn((config) => ({
     handlers: { GET: vi.fn(), POST: vi.fn() },
@@ -11,11 +10,11 @@ vi.mock('next-auth', () => ({
   })),
 }));
 
-vi.mock('next-auth/providers/auth0', () => ({
+vi.mock('next-auth/providers/cognito', () => ({
   default: vi.fn((options) => ({
-    id: 'auth0',
-    name: 'Auth0',
-    type: 'oauth',
+    id: 'cognito',
+    name: 'Cognito',
+    type: 'oidc',
     ...options,
   })),
 }));
@@ -28,21 +27,30 @@ vi.mock('@/lib/auth/is-auth-skip-enabled', () => ({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRecord = Record<string, any>;
 
-describe('Auth0 認証設定', () => {
+describe('Cognito 認証設定', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    process.env.AUTH0_CLIENT_ID = 'test-client-id';
-    process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
-    process.env.AUTH0_ISSUER = 'https://test.auth0.com';
+    process.env.COGNITO_CLIENT_ID = 'test-client-id';
+    process.env.COGNITO_CLIENT_SECRET = 'test-client-secret';
+    process.env.COGNITO_ISSUER =
+      'https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_test';
+    delete process.env.AUTH0_CLIENT_ID;
+    delete process.env.AUTH0_CLIENT_SECRET;
+    delete process.env.AUTH0_ISSUER;
     delete process.env.AUTH_SKIP;
     delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.SKIP_PROVIDER_VALIDATION;
+    delete process.env.SKIP_AUTH0_VALIDATION;
   });
 
   describe('AUTH_SKIP モード', () => {
     beforeEach(() => {
       vi.clearAllMocks();
       vi.resetModules();
+      delete process.env.COGNITO_CLIENT_ID;
+      delete process.env.COGNITO_CLIENT_SECRET;
+      delete process.env.COGNITO_ISSUER;
       delete process.env.AUTH0_CLIENT_ID;
       delete process.env.AUTH0_CLIENT_SECRET;
       delete process.env.AUTH0_ISSUER;
@@ -90,21 +98,30 @@ describe('Auth0 認証設定', () => {
       expect(session?.roles).toEqual(['tenant-admin', 'participant']);
     });
 
-    it('AUTH_SKIP=1 の場合、Auth0 環境変数がなくてもエラーにならないべき', async () => {
+    it('AUTH_SKIP=1 の場合、Cognito 環境変数がなくてもエラーにならないべき', async () => {
       process.env.AUTH_SKIP = '1';
 
       await expect(import('../auth')).resolves.toBeDefined();
     });
 
-    it('AUTH_SKIP=1 の場合、モックセッションに tenantId/teamId が含まれないべき（Control Plane は全テナント管理者向け）', async () => {
+    it('AUTH_SKIP=1 の場合、モックセッションに tenantId/teamId が含まれるべき', async () => {
       process.env.AUTH_SKIP = '1';
 
       const auth = await import('../auth');
       const session = await auth.auth();
 
-      // Application Plane ではテナント/チーム情報をセッションに含む
-      expect(session?.tenantId).toBeDefined();
-      expect(session?.teamId).toBeDefined();
+      expect(session?.tenantId).toBe('dev-tenant');
+      expect(session?.teamId).toBe('team-alpha');
+    });
+
+    it('getSession() でもモックセッションを返すべき', async () => {
+      process.env.AUTH_SKIP = '1';
+
+      const auth = await import('../auth');
+      const session = await auth.getSession();
+
+      expect(session?.user?.name).toBe('Dev User');
+      expect(session?.tenantId).toBe('dev-tenant');
     });
   });
 
@@ -117,25 +134,55 @@ describe('Auth0 認証設定', () => {
         },
       }));
 
-      process.env.AUTH0_CLIENT_ID = 'test-client-id';
-      process.env.AUTH0_CLIENT_SECRET = 'test-client-secret';
-      process.env.AUTH0_ISSUER = 'https://test.auth0.com';
+      process.env.COGNITO_CLIENT_ID = 'test-client-id';
+      process.env.COGNITO_CLIENT_SECRET = 'test-client-secret';
+      process.env.COGNITO_ISSUER =
+        'https://cognito-idp.ap-northeast-1.amazonaws.com/test';
 
       const auth = await import('../auth');
-      // auth モジュールが正常にロードされ、Auth0 プロバイダが使用される
       expect(auth.handlers).toBeDefined();
       expect(auth.auth).toBeDefined();
     });
   });
 
   it('必須の環境変数が欠けている場合はエラーを投げるべき', async () => {
-    process.env.AUTH0_CLIENT_ID = '';
-    process.env.AUTH0_CLIENT_SECRET = '';
-    process.env.AUTH0_ISSUER = '';
+    process.env.COGNITO_CLIENT_ID = '';
+    process.env.COGNITO_CLIENT_SECRET = '';
+    process.env.COGNITO_ISSUER = '';
 
     await expect(import('../auth')).rejects.toThrow(
-      'Missing required Auth0 environment variables',
+      'Missing required auth environment variables',
     );
+  });
+
+  it('Auth0 環境変数へのフォールバックが動作すべき', async () => {
+    delete process.env.COGNITO_CLIENT_ID;
+    delete process.env.COGNITO_CLIENT_SECRET;
+    delete process.env.COGNITO_ISSUER;
+    process.env.AUTH0_CLIENT_ID = 'auth0-client-id';
+    process.env.AUTH0_CLIENT_SECRET = 'auth0-client-secret';
+    process.env.AUTH0_ISSUER = 'https://test.auth0.com';
+
+    const Cognito = (await import('next-auth/providers/cognito')).default;
+    await import('../auth');
+
+    expect(Cognito).toHaveBeenCalledWith({
+      clientId: 'auth0-client-id',
+      clientSecret: 'auth0-client-secret',
+      issuer: 'https://test.auth0.com',
+    });
+  });
+
+  it('SKIP_PROVIDER_VALIDATION=1 の場合、環境変数なしでもエラーにならないべき', async () => {
+    delete process.env.COGNITO_CLIENT_ID;
+    delete process.env.COGNITO_CLIENT_SECRET;
+    delete process.env.COGNITO_ISSUER;
+    delete process.env.AUTH0_CLIENT_ID;
+    delete process.env.AUTH0_CLIENT_SECRET;
+    delete process.env.AUTH0_ISSUER;
+    process.env.SKIP_PROVIDER_VALIDATION = '1';
+
+    await expect(import('../auth')).resolves.toBeDefined();
   });
 
   it('handlers と auth がエクスポートされるべき', async () => {
@@ -150,14 +197,22 @@ describe('Auth0 認証設定', () => {
     expect(auth.signOut).toBeDefined();
   });
 
-  it('Auth0 プロバイダが環境変数から設定されるべき', async () => {
-    const Auth0 = (await import('next-auth/providers/auth0')).default;
+  it('getSession() は AUTH_SKIP 無効時に nextAuth.auth() を呼ぶべき', async () => {
+    const auth = await import('../auth');
+    const session = await auth.getSession();
+    // nextAuth.auth is mocked to return undefined, so session should be falsy
+    expect(session).toBeUndefined();
+  });
+
+  it('Cognito プロバイダが環境変数から設定されるべき', async () => {
+    const Cognito = (await import('next-auth/providers/cognito')).default;
     await import('../auth');
 
-    expect(Auth0).toHaveBeenCalledWith({
+    expect(Cognito).toHaveBeenCalledWith({
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
-      issuer: 'https://test.auth0.com',
+      issuer:
+        'https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_test',
     });
   });
 
@@ -190,7 +245,38 @@ describe('Auth0 認証設定', () => {
       expect(result.idToken).toBe('test-id-token');
     });
 
-    it('Auth0 カスタムクレームからロールとテナント情報を取得すべき', async () => {
+    it('Cognito の cognito:groups からロールを取得すべき', async () => {
+      const NextAuth = (await import('next-auth')).default;
+
+      await import('../auth');
+      const mockCall = vi.mocked(NextAuth).mock.calls[0][0] as NextAuthConfig;
+      const jwtCallback = mockCall.callbacks?.jwt;
+
+      if (!jwtCallback) throw new Error('JWT callback not defined');
+
+      const token = {};
+      const profile = {
+        'cognito:groups': ['participant', 'team_lead'],
+        'custom:tenant_id': 'tenant-cognito-123',
+        'custom:team_id': 'team-cognito-456',
+        email: 'test@example.com',
+        name: 'Test User',
+        picture: 'https://example.com/avatar.png',
+      };
+
+      const result = (await jwtCallback({
+        token,
+        profile,
+        user: { id: '1', name: 'Test', email: 'test@example.com' },
+        trigger: 'signIn',
+      } as Parameters<typeof jwtCallback>[0])) as AnyRecord;
+
+      expect(result.roles).toEqual(['participant', 'team_lead']);
+      expect(result.tenantId).toBe('tenant-cognito-123');
+      expect(result.teamId).toBe('team-cognito-456');
+    });
+
+    it('Auth0 カスタムクレームにフォールバックすべき', async () => {
       const NextAuth = (await import('next-auth')).default;
 
       await import('../auth');
@@ -219,9 +305,6 @@ describe('Auth0 認証設定', () => {
       expect(result.roles).toEqual(['participant', 'team_lead']);
       expect(result.tenantId).toBe('tenant-123');
       expect(result.teamId).toBe('team-456');
-      expect(result.email).toBe('test@example.com');
-      expect(result.name).toBe('Test User');
-      expect(result.picture).toBe('https://example.com/avatar.png');
     });
 
     it('カスタムクレームがない場合、フォールバックすべき', async () => {
@@ -252,6 +335,31 @@ describe('Auth0 認証設定', () => {
       expect(result.teamId).toBeNull();
     });
 
+    it('profile に email/name がない場合、token の既存値を維持すべき', async () => {
+      const NextAuth = (await import('next-auth')).default;
+
+      await import('../auth');
+      const mockCall = vi.mocked(NextAuth).mock.calls[0][0] as NextAuthConfig;
+      const jwtCallback = mockCall.callbacks?.jwt;
+
+      if (!jwtCallback) throw new Error('JWT callback not defined');
+
+      const token = { email: 'existing@example.com', name: 'Existing User' };
+      const profile = {
+        'cognito:groups': ['participant'],
+      };
+
+      const result = (await jwtCallback({
+        token,
+        profile,
+        user: { id: '1', name: 'Test', email: 'test@example.com' },
+        trigger: 'signIn',
+      } as Parameters<typeof jwtCallback>[0])) as AnyRecord;
+
+      expect(result.email).toBe('existing@example.com');
+      expect(result.name).toBe('Existing User');
+    });
+
     it('ロールが存在しない場合、空配列にフォールバックすべき', async () => {
       const NextAuth = (await import('next-auth')).default;
 
@@ -279,7 +387,6 @@ describe('Auth0 認証設定', () => {
   });
 
   describe('Session コールバック', () => {
-    // セッションコールバック用のヘルパー
     async function callSessionCallback() {
       const NextAuth = (await import('next-auth')).default;
 

--- a/client/Application/__tests__/auth.test.ts
+++ b/client/Application/__tests__/auth.test.ts
@@ -24,6 +24,17 @@ vi.mock('@/lib/auth/is-auth-skip-enabled', () => ({
     process.env.AUTH_SKIP === '1' && process.env.NODE_ENV !== 'production',
 }));
 
+vi.mock('@/lib/auth/roles', () => ({
+  parseAuthSkipRoles: (envValue?: string) => {
+    if (!envValue) return ['participant'];
+    const roles = envValue
+      .split(',')
+      .map((role: string) => role.trim())
+      .filter(Boolean);
+    return roles.length > 0 ? roles : ['participant'];
+  },
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyRecord = Record<string, any>;
 
@@ -198,10 +209,16 @@ describe('Cognito 認証設定', () => {
   });
 
   it('getSession() は AUTH_SKIP 無効時に nextAuth.auth() を呼ぶべき', async () => {
+    const NextAuth = (await import('next-auth')).default;
     const auth = await import('../auth');
+
     const session = await auth.getSession();
     // nextAuth.auth is mocked to return undefined, so session should be falsy
     expect(session).toBeUndefined();
+
+    // Verify that nextAuth.auth was actually called
+    const nextAuthInstance = vi.mocked(NextAuth).mock.results[0]?.value;
+    expect(nextAuthInstance.auth).toHaveBeenCalled();
   });
 
   it('Cognito プロバイダが環境変数から設定されるべき', async () => {

--- a/client/Application/auth.ts
+++ b/client/Application/auth.ts
@@ -5,14 +5,18 @@ import { isAuthSkipEnabled } from '@/lib/auth/is-auth-skip-enabled';
 import { parseAuthSkipRoles } from '@/lib/auth/roles';
 
 const getEnv = (key: string) => process.env[key];
+/* istanbul ignore next -- production guard branches not testable in unit tests */
 const skipProviderValidation =
-  getEnv('SKIP_AUTH0_VALIDATION') === '1' ||
-  getEnv('SKIP_PROVIDER_VALIDATION') === '1';
+  process.env.NODE_ENV !== 'production' &&
+  (getEnv('SKIP_AUTH0_VALIDATION') === '1' ||
+    getEnv('SKIP_PROVIDER_VALIDATION') === '1');
+/* istanbul ignore next -- build phase only triggers during `next build` */
 const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
 let authSkipEnabled: boolean;
 try {
   authSkipEnabled = isAuthSkipEnabled();
 } catch {
+  // Caught only when AUTH_SKIP=1 && NODE_ENV=production (e.g. local build).
   authSkipEnabled = false;
 }
 /* istanbul ignore next -- build phase only triggers during `next build` */

--- a/client/Application/auth.ts
+++ b/client/Application/auth.ts
@@ -1,31 +1,28 @@
 import NextAuth from 'next-auth';
 import type { Session } from 'next-auth';
-import Auth0 from 'next-auth/providers/auth0';
+import Cognito from 'next-auth/providers/cognito';
 import { isAuthSkipEnabled } from '@/lib/auth/is-auth-skip-enabled';
 import { parseAuthSkipRoles } from '@/lib/auth/roles';
 
 const getEnv = (key: string) => process.env[key];
-// During `next build`, NEXT_PHASE is set to 'phase-production-build'.
-// If AUTH_SKIP=1 is present in a local .env.local, isAuthSkipEnabled() will
-// throw because NODE_ENV=production, but it is harmless at build time.
+const skipProviderValidation =
+  getEnv('SKIP_AUTH0_VALIDATION') === '1' ||
+  getEnv('SKIP_PROVIDER_VALIDATION') === '1';
 const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
 let authSkipEnabled: boolean;
 try {
   authSkipEnabled = isAuthSkipEnabled();
 } catch {
-  // Caught only when AUTH_SKIP=1 && NODE_ENV=production (e.g. local build).
-  // Treat as disabled but allow stubs so the build can succeed.
   authSkipEnabled = false;
 }
+/* istanbul ignore next -- build phase only triggers during `next build` */
 const useStubAuth =
   authSkipEnabled || (isBuildPhase && process.env.AUTH_SKIP === '1');
 const authSkipRoles = parseAuthSkipRoles(process.env.AUTH_SKIP_ROLES);
 
 /**
- * モックセッション（AUTH_SKIP=1 の場合に使用）
- *
- * Application Plane は特定テナントのビジネスロジックを実行するため、
- * tenantId と teamId を含む。開発時はデフォルト値を使用。
+ * Mock session for AUTH_SKIP=1 (local development only).
+ * Application Plane includes tenantId and teamId.
  */
 const mockSession: Session = {
   user: {
@@ -41,7 +38,6 @@ const mockSession: Session = {
   teamId: 'team-alpha',
 };
 
-// AUTH_SKIP モードの警告
 /* v8 ignore start -- Development-only warning */
 if (authSkipEnabled && typeof console !== 'undefined') {
   console.warn(
@@ -53,64 +49,81 @@ if (authSkipEnabled && typeof console !== 'undefined') {
 }
 /* v8 ignore stop */
 
-// Auth0 設定のバリデーション
-/* v8 ignore start -- Stub config only used when AUTH_SKIP=1 */
-const stubConfig = useStubAuth
+// Cognito configuration (falls back to Auth0 env vars for backward compatibility)
+const stubFallback = skipProviderValidation || useStubAuth;
+/* istanbul ignore next -- stub only used when AUTH_SKIP=1 or SKIP_PROVIDER_VALIDATION=1 */
+const stub = stubFallback
   ? {
-      clientId: 'stub-client-id',
-      clientSecret: 'stub-client-secret',
-      issuer: 'https://example.com',
+      id: 'stub-client-id',
+      secret: 'stub-client-secret',
+      iss: 'https://example.com',
     }
-  : { clientId: undefined, clientSecret: undefined, issuer: undefined };
-/* v8 ignore stop */
-
-const auth0Config = {
-  clientId: getEnv('AUTH0_CLIENT_ID') ?? stubConfig.clientId,
-  clientSecret: getEnv('AUTH0_CLIENT_SECRET') ?? stubConfig.clientSecret,
-  issuer: getEnv('AUTH0_ISSUER') ?? stubConfig.issuer,
+  : { id: undefined, secret: undefined, iss: undefined };
+const cognitoConfig = {
+  clientId: getEnv('COGNITO_CLIENT_ID') ?? getEnv('AUTH0_CLIENT_ID') ?? stub.id,
+  clientSecret:
+    getEnv('COGNITO_CLIENT_SECRET') ??
+    getEnv('AUTH0_CLIENT_SECRET') ??
+    stub.secret,
+  issuer: getEnv('COGNITO_ISSUER') ?? getEnv('AUTH0_ISSUER') ?? stub.iss,
 };
 
-/* v8 ignore start -- Module-level validation tested in auth.test.ts */
 if (
+  !skipProviderValidation &&
   !useStubAuth &&
-  (!auth0Config.clientId || !auth0Config.clientSecret || !auth0Config.issuer)
+  (!cognitoConfig.clientId ||
+    !cognitoConfig.clientSecret ||
+    !cognitoConfig.issuer)
 ) {
   throw new Error(
-    'Missing required Auth0 environment variables: AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_ISSUER',
+    'Missing required auth environment variables. Set COGNITO_CLIENT_ID, COGNITO_CLIENT_SECRET, COGNITO_ISSUER ' +
+      '(or legacy AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_ISSUER)',
   );
 }
-/* v8 ignore stop */
 
 const nextAuth = NextAuth({
-  providers: [Auth0(auth0Config)],
+  providers: [Cognito(cognitoConfig)],
   callbacks: {
     async jwt({ token, account, profile }) {
-      // アクセストークンとリフレッシュトークンを JWT に保存
       if (account) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token;
         token.idToken = account.id_token;
       }
 
-      // Auth0 のユーザー情報を JWT に保存
       if (profile) {
-        // Auth0 のカスタムクレームからロールとテナント情報を取得
+        // Cognito: cognito:groups, custom:tenant_id, custom:team_id
+        // Auth0 fallback: namespace claims
         const namespace = 'https://tenkacloud.com';
+        const cognitoGroups = profile['cognito:groups'] as string[] | undefined;
+        const auth0Roles = profile[`${namespace}/roles`] as
+          | string[]
+          | undefined;
         token.roles =
-          (profile[`${namespace}/roles`] as string[]) ||
-          (profile.roles as string[]) ||
-          [];
-        token.tenantId = (profile[`${namespace}/tenant_id`] as string) || null;
-        token.teamId = (profile[`${namespace}/team_id`] as string) || null;
-        token.email = profile.email as string;
-        token.name = profile.name as string;
-        token.picture = profile.picture as string;
+          cognitoGroups ?? auth0Roles ?? (profile.roles as string[]) ?? [];
+
+        const cognitoTenantId = profile['custom:tenant_id'] as
+          | string
+          | undefined;
+        const auth0TenantId = profile[`${namespace}/tenant_id`] as
+          | string
+          | undefined;
+        token.tenantId = cognitoTenantId ?? auth0TenantId ?? null;
+
+        const cognitoTeamId = profile['custom:team_id'] as string | undefined;
+        const auth0TeamId = profile[`${namespace}/team_id`] as
+          | string
+          | undefined;
+        token.teamId = cognitoTeamId ?? auth0TeamId ?? null;
+
+        token.email = (profile.email as string) ?? token.email;
+        token.name = (profile.name as string) ?? token.name;
+        token.picture = (profile.picture as string) ?? token.picture;
       }
 
       return token;
     },
     async session({ session, token }) {
-      // JWT のトークン情報をセッションに含める
       session.accessToken = token.accessToken as string;
       session.idToken = token.idToken as string;
       session.roles = token.roles as string[];
@@ -136,8 +149,14 @@ const nextAuth = NextAuth({
 
 export const { handlers, signIn, signOut } = nextAuth;
 
-// AUTH_SKIP=1 の場合はモックセッションを返す
+// AUTH_SKIP=1 returns mock session
 export const auth = authSkipEnabled ? async () => mockSession : nextAuth.auth;
 
-/** AUTH_SKIP モードのフラグとモックセッション（route handler で使用） */
 export { authSkipEnabled, mockSession };
+
+export async function getSession(): Promise<Session | null> {
+  if (authSkipEnabled) {
+    return mockSession;
+  }
+  return nextAuth.auth();
+}

--- a/client/Application/types/next-auth.d.ts
+++ b/client/Application/types/next-auth.d.ts
@@ -2,8 +2,8 @@ import type { DefaultSession } from 'next-auth';
 
 declare module 'next-auth' {
   /**
-   * セッション型の拡張
-   * Auth0 からのトークン情報、ロール、テナント情報を含める
+   * Session type extension.
+   * Includes token info, roles, and tenant context from Cognito/Auth0.
    */
   interface Session {
     accessToken?: string;
@@ -18,9 +18,6 @@ declare module 'next-auth' {
     } & DefaultSession['user'];
   }
 
-  /**
-   * JWT トークン型の拡張
-   */
   interface JWT {
     accessToken?: string;
     refreshToken?: string;
@@ -34,13 +31,18 @@ declare module 'next-auth' {
   }
 
   /**
-   * Auth0 プロファイル型の拡張
+   * Profile type extension for Cognito and Auth0 claims.
    */
   interface Profile {
     roles?: string[];
     email?: string;
     name?: string;
     picture?: string;
+    // Cognito claims
+    'cognito:groups'?: string[];
+    'custom:tenant_id'?: string;
+    'custom:team_id'?: string;
+    // Auth0 legacy claims
     'https://tenkacloud.com/roles'?: string[];
     'https://tenkacloud.com/tenant_id'?: string;
     'https://tenkacloud.com/team_id'?: string;

--- a/server/application/microservices/battle-service/src/middleware/auth.test.ts
+++ b/server/application/microservices/battle-service/src/middleware/auth.test.ts
@@ -198,4 +198,48 @@ describe('認証ミドルウェア', () => {
     const body = await res.json();
     expect(body.auth.roles).toEqual([]);
   });
+
+  it('Cognito の custom:tenant_id からテナント ID を抽出すべき', async () => {
+    const mockPayload = {
+      sub: 'user-cognito',
+      'custom:tenant_id': 'cognito-tenant-789',
+      'cognito:groups': ['admin'],
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.tenantId).toBe('cognito-tenant-789');
+  });
+
+  it('Cognito の cognito:groups からロールを取得すべき', async () => {
+    const mockPayload = {
+      sub: 'user-cognito',
+      'custom:tenant_id': 'cognito-tenant-789',
+      'cognito:groups': ['tenant-admin', 'participant'],
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.roles).toEqual(['tenant-admin', 'participant']);
+  });
 });

--- a/server/application/microservices/battle-service/src/middleware/auth.ts
+++ b/server/application/microservices/battle-service/src/middleware/auth.ts
@@ -56,20 +56,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
     const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
     const tenantId =
-      (claims['custom:tenant_id'] as string | undefined) ??
+      (claims['custom:tenant_id'] as string | undefined) ||
       (claims['tenant_id'] as string | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
     const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
-    const realmAccess = claims['realm_access'] as { roles?: string[] } | undefined;
-    const keycloakRoles = realmAccess?.roles;
+    const keycloakRoles = (claims['realm_access'] as { roles?: string[] } | undefined)?.roles;
 
     c.set('auth', {
       userId: (payload.sub as string) ?? '',
       tenantId,
-      roles: cognitoGroups ?? keycloakRoles ?? [],
+      roles:
+        (cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??
+        (keycloakRoles && keycloakRoles.length > 0 ? keycloakRoles : undefined) ??
+        [],
     });
 
     await next();

--- a/server/application/microservices/battle-service/src/middleware/auth.ts
+++ b/server/application/microservices/battle-service/src/middleware/auth.ts
@@ -62,11 +62,15 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
+    if (!payload.sub) {
+      return c.json({ error: 'トークンに sub がありません' }, 401);
+    }
+
     const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
     const keycloakRoles = (claims['realm_access'] as { roles?: string[] } | undefined)?.roles;
 
     c.set('auth', {
-      userId: (payload.sub as string) ?? '',
+      userId: payload.sub,
       tenantId,
       roles:
         (cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??

--- a/server/application/microservices/battle-service/src/middleware/auth.ts
+++ b/server/application/microservices/battle-service/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory';
 import * as jose from 'jose';
+import { z } from 'zod';
 
 export interface AuthContext {
   userId: string;
@@ -18,6 +19,14 @@ const JWKS_URI =
   'http://localhost:8080/realms/tenkacloud/protocol/openid-connect/certs';
 const ISSUER =
   process.env.JWT_ISSUER ?? 'http://localhost:8080/realms/tenkacloud';
+
+const JwtClaimsSchema = z.object({
+  sub: z.string().optional(),
+  'custom:tenant_id': z.string().min(1).optional(),
+  tenant_id: z.string().min(1).optional(),
+  'cognito:groups': z.array(z.string()).min(1).optional(),
+  realm_access: z.object({ roles: z.array(z.string()) }).optional(),
+}).passthrough();
 
 let jwks: jose.JWTVerifyGetKey | null = null;
 
@@ -43,28 +52,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       issuer: ISSUER,
     });
 
+    const parsed = JwtClaimsSchema.safeParse(payload);
+    const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
+
     const tenantId =
-      ((payload as Record<string, unknown>)['custom:tenant_id'] as
-        | string
-        | undefined) ??
-      ((payload as Record<string, unknown>)['tenant_id'] as
-        | string
-        | undefined);
+      (claims['custom:tenant_id'] as string | undefined) ??
+      (claims['tenant_id'] as string | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
-    const cognitoGroups = (payload as Record<string, unknown>)[
-      'cognito:groups'
-    ] as string[] | undefined;
-    const keycloakRoles = (
-      (payload as Record<string, unknown>)['realm_access'] as {
-        roles?: string[];
-      }
-    )?.roles;
+    const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
+    const realmAccess = claims['realm_access'] as { roles?: string[] } | undefined;
+    const keycloakRoles = realmAccess?.roles;
 
     c.set('auth', {
-      userId: payload.sub ?? '',
+      userId: (payload.sub as string) ?? '',
       tenantId,
       roles: cognitoGroups ?? keycloakRoles ?? [],
     });

--- a/server/application/microservices/battle-service/src/middleware/auth.ts
+++ b/server/application/microservices/battle-service/src/middleware/auth.ts
@@ -43,22 +43,30 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       issuer: ISSUER,
     });
 
-    const tenantId = (payload as Record<string, unknown>)['tenant_id'] as
-      | string
-      | undefined;
+    const tenantId =
+      ((payload as Record<string, unknown>)['custom:tenant_id'] as
+        | string
+        | undefined) ??
+      ((payload as Record<string, unknown>)['tenant_id'] as
+        | string
+        | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
+    const cognitoGroups = (payload as Record<string, unknown>)[
+      'cognito:groups'
+    ] as string[] | undefined;
+    const keycloakRoles = (
+      (payload as Record<string, unknown>)['realm_access'] as {
+        roles?: string[];
+      }
+    )?.roles;
+
     c.set('auth', {
       userId: payload.sub ?? '',
       tenantId,
-      roles:
-        (
-          (payload as Record<string, unknown>)['realm_access'] as {
-            roles?: string[];
-          }
-        )?.roles ?? [],
+      roles: cognitoGroups ?? keycloakRoles ?? [],
     });
 
     await next();

--- a/server/application/microservices/gameday-service/src/middleware/auth-middleware.test.ts
+++ b/server/application/microservices/gameday-service/src/middleware/auth-middleware.test.ts
@@ -326,6 +326,69 @@ describe("authMiddleware", () => {
 			);
 		});
 
+		it("Cognito の custom:tenant_id からテナント ID を抽出すべき", async () => {
+			const jose = await import("jose");
+			vi.mocked(jose.jwtVerify).mockResolvedValue({
+				payload: {
+					sub: "cognito-user-1",
+					"custom:tenant_id": "cognito-tenant-abc",
+					"cognito:groups": ["participant"],
+					iss: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id",
+					aud: "",
+					iat: 0,
+					exp: 0,
+				},
+				protectedHeader: { alg: "RS256" },
+				key: {} as CryptoKey,
+			});
+
+			const { authMiddleware } = await import("./auth");
+
+			const app = new Hono();
+			app.use("/*", authMiddleware);
+			app.get("/test", (c) => c.json(c.get("auth")));
+
+			const res = await app.request("/test", {
+				headers: { Authorization: "Bearer cognito-token" },
+			});
+			expect(res.status).toBe(StatusCodes.OK);
+
+			const body = await res.json();
+			expect(body.userId).toBe("cognito-user-1");
+			expect(body.tenantId).toBe("cognito-tenant-abc");
+		});
+
+		it("Cognito の cognito:groups からロールを取得すべき", async () => {
+			const jose = await import("jose");
+			vi.mocked(jose.jwtVerify).mockResolvedValue({
+				payload: {
+					sub: "cognito-user-2",
+					"custom:tenant_id": "cognito-tenant-xyz",
+					"cognito:groups": ["admin", "organizer"],
+					iss: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id",
+					aud: "",
+					iat: 0,
+					exp: 0,
+				},
+				protectedHeader: { alg: "RS256" },
+				key: {} as CryptoKey,
+			});
+
+			const { authMiddleware } = await import("./auth");
+
+			const app = new Hono();
+			app.use("/*", authMiddleware);
+			app.get("/test", (c) => c.json(c.get("auth")));
+
+			const res = await app.request("/test", {
+				headers: { Authorization: "Bearer cognito-token" },
+			});
+			expect(res.status).toBe(StatusCodes.OK);
+
+			const body = await res.json();
+			expect(body.roles).toEqual(["admin", "organizer"]);
+		});
+
 		it("realm_access がない場合は空のロール配列を設定すべき", async () => {
 			const jose = await import("jose");
 			vi.mocked(jose.jwtVerify).mockResolvedValue({

--- a/server/application/microservices/gameday-service/src/middleware/auth.ts
+++ b/server/application/microservices/gameday-service/src/middleware/auth.ts
@@ -149,9 +149,10 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			);
 		}
 
-		const tenantId = (payload as Record<string, unknown>)["tenant_id"] as
-			| string
-			| undefined;
+		const typedPayload = payload as Record<string, unknown>;
+		const tenantId =
+			(typedPayload["custom:tenant_id"] as string | undefined) ??
+			(typedPayload["tenant_id"] as string | undefined);
 		if (!tenantId) {
 			return c.json(
 				{ error: "テナント情報がありません" },
@@ -159,15 +160,17 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			);
 		}
 
+		const cognitoGroups = typedPayload["cognito:groups"] as
+			| string[]
+			| undefined;
+		const keycloakRoles = (
+			typedPayload["realm_access"] as { roles?: string[] } | undefined
+		)?.roles;
+
 		c.set("auth", {
 			userId: payload.sub,
 			tenantId,
-			roles:
-				(
-					(payload as Record<string, unknown>)["realm_access"] as {
-						roles?: string[];
-					}
-				)?.roles ?? [],
+			roles: cognitoGroups ?? keycloakRoles ?? [],
 		});
 
 		await next();

--- a/server/application/microservices/gameday-service/src/middleware/auth.ts
+++ b/server/application/microservices/gameday-service/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 import { StatusCodes } from "http-status-codes";
 import * as jose from "jose";
+import { z } from "zod";
 
 export interface AuthContext {
 	userId: string;
@@ -98,6 +99,14 @@ const JWKS_URI =
 const ISSUER =
 	process.env.JWT_ISSUER ?? "http://localhost:8080/realms/tenkacloud";
 
+const JwtClaimsSchema = z.object({
+	sub: z.string().optional(),
+	"custom:tenant_id": z.string().min(1).optional(),
+	tenant_id: z.string().min(1).optional(),
+	"cognito:groups": z.array(z.string()).min(1).optional(),
+	realm_access: z.object({ roles: z.array(z.string()) }).optional(),
+}).passthrough();
+
 let jwks: jose.JWTVerifyGetKey | null = null;
 
 async function getJWKS() {
@@ -149,10 +158,12 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			);
 		}
 
-		const typedPayload = payload as Record<string, unknown>;
+		const parsed = JwtClaimsSchema.safeParse(payload);
+		const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
+
 		const tenantId =
-			(typedPayload["custom:tenant_id"] as string | undefined) ??
-			(typedPayload["tenant_id"] as string | undefined);
+			(claims["custom:tenant_id"] as string | undefined) ??
+			(claims["tenant_id"] as string | undefined);
 		if (!tenantId) {
 			return c.json(
 				{ error: "テナント情報がありません" },
@@ -160,15 +171,14 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			);
 		}
 
-		const cognitoGroups = typedPayload["cognito:groups"] as
+		const cognitoGroups = claims["cognito:groups"] as
 			| string[]
 			| undefined;
-		const keycloakRoles = (
-			typedPayload["realm_access"] as { roles?: string[] } | undefined
-		)?.roles;
+		const realmAccess = claims["realm_access"] as { roles?: string[] } | undefined;
+		const keycloakRoles = realmAccess?.roles;
 
 		c.set("auth", {
-			userId: payload.sub,
+			userId: payload.sub as string,
 			tenantId,
 			roles: cognitoGroups ?? keycloakRoles ?? [],
 		});

--- a/server/application/microservices/gameday-service/src/middleware/auth.ts
+++ b/server/application/microservices/gameday-service/src/middleware/auth.ts
@@ -162,7 +162,7 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 		const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
 		const tenantId =
-			(claims["custom:tenant_id"] as string | undefined) ??
+			(claims["custom:tenant_id"] as string | undefined) ||
 			(claims["tenant_id"] as string | undefined);
 		if (!tenantId) {
 			return c.json(
@@ -171,16 +171,16 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			);
 		}
 
-		const cognitoGroups = claims["cognito:groups"] as
-			| string[]
-			| undefined;
-		const realmAccess = claims["realm_access"] as { roles?: string[] } | undefined;
-		const keycloakRoles = realmAccess?.roles;
+		const cognitoGroups = claims["cognito:groups"] as string[] | undefined;
+		const keycloakRoles = (claims["realm_access"] as { roles?: string[] } | undefined)?.roles;
 
 		c.set("auth", {
 			userId: payload.sub as string,
 			tenantId,
-			roles: cognitoGroups ?? keycloakRoles ?? [],
+			roles:
+				(cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??
+				(keycloakRoles && keycloakRoles.length > 0 ? keycloakRoles : undefined) ??
+				[],
 		});
 
 		await next();

--- a/server/application/microservices/leaderboard-service/src/middleware/auth.test.ts
+++ b/server/application/microservices/leaderboard-service/src/middleware/auth.test.ts
@@ -243,4 +243,48 @@ describe("認証ミドルウェア", () => {
 		const body = await res.json();
 		expect(body.auth.roles).toEqual([]);
 	});
+
+	it("Cognito の custom:tenant_id からテナント ID を抽出すべき", async () => {
+		const mockPayload = {
+			sub: "user-cognito",
+			"custom:tenant_id": "cognito-tenant-789",
+			"cognito:groups": ["admin"],
+		};
+
+		vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+		vi.mocked(jose.jwtVerify).mockResolvedValue({
+			payload: mockPayload,
+			protectedHeader: { alg: "RS256" },
+		} as never);
+
+		const res = await app.request("/test", {
+			headers: { Authorization: "Bearer cognito-token" },
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.auth.tenantId).toBe("cognito-tenant-789");
+	});
+
+	it("Cognito の cognito:groups からロールを取得すべき", async () => {
+		const mockPayload = {
+			sub: "user-cognito",
+			"custom:tenant_id": "cognito-tenant-789",
+			"cognito:groups": ["tenant-admin", "participant"],
+		};
+
+		vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+		vi.mocked(jose.jwtVerify).mockResolvedValue({
+			payload: mockPayload,
+			protectedHeader: { alg: "RS256" },
+		} as never);
+
+		const res = await app.request("/test", {
+			headers: { Authorization: "Bearer cognito-token" },
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.auth.roles).toEqual(["tenant-admin", "participant"]);
+	});
 });

--- a/server/application/microservices/leaderboard-service/src/middleware/auth.ts
+++ b/server/application/microservices/leaderboard-service/src/middleware/auth.ts
@@ -87,20 +87,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 		const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
 		const tenantId =
-			(claims["custom:tenant_id"] as string | undefined) ??
+			(claims["custom:tenant_id"] as string | undefined) ||
 			(claims["tenant_id"] as string | undefined);
 		if (!tenantId) {
 			return c.json({ error: "テナント情報がありません" }, 403);
 		}
 
 		const cognitoGroups = claims["cognito:groups"] as string[] | undefined;
-		const realmAccess = claims["realm_access"] as { roles?: string[] } | undefined;
-		const keycloakRoles = realmAccess?.roles;
+		const keycloakRoles = (claims["realm_access"] as { roles?: string[] } | undefined)?.roles;
 
 		c.set("auth", {
 			userId: (payload.sub as string) ?? "",
 			tenantId,
-			roles: cognitoGroups ?? keycloakRoles ?? [],
+			roles:
+				(cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??
+				(keycloakRoles && keycloakRoles.length > 0 ? keycloakRoles : undefined) ??
+				[],
 		});
 
 		await next();

--- a/server/application/microservices/leaderboard-service/src/middleware/auth.ts
+++ b/server/application/microservices/leaderboard-service/src/middleware/auth.ts
@@ -74,22 +74,30 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			issuer: ISSUER,
 		});
 
-		const tenantId = (payload as Record<string, unknown>)["tenant_id"] as
-			| string
-			| undefined;
+		const tenantId =
+			((payload as Record<string, unknown>)["custom:tenant_id"] as
+				| string
+				| undefined) ??
+			((payload as Record<string, unknown>)["tenant_id"] as
+				| string
+				| undefined);
 		if (!tenantId) {
 			return c.json({ error: "テナント情報がありません" }, 403);
 		}
 
+		const cognitoGroups = (payload as Record<string, unknown>)[
+			"cognito:groups"
+		] as string[] | undefined;
+		const keycloakRoles = (
+			(payload as Record<string, unknown>)["realm_access"] as {
+				roles?: string[];
+			}
+		)?.roles;
+
 		c.set("auth", {
 			userId: payload.sub ?? "",
 			tenantId,
-			roles:
-				(
-					(payload as Record<string, unknown>)["realm_access"] as {
-						roles?: string[];
-					}
-				)?.roles ?? [],
+			roles: cognitoGroups ?? keycloakRoles ?? [],
 		});
 
 		await next();

--- a/server/application/microservices/leaderboard-service/src/middleware/auth.ts
+++ b/server/application/microservices/leaderboard-service/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from "hono/factory";
 import * as jose from "jose";
+import { z } from "zod";
 
 export interface AuthContext {
 	userId: string;
@@ -18,6 +19,14 @@ const JWKS_URI =
 	"http://localhost:8080/realms/tenkacloud/protocol/openid-connect/certs";
 const ISSUER =
 	process.env.JWT_ISSUER ?? "http://localhost:8080/realms/tenkacloud";
+
+const JwtClaimsSchema = z.object({
+	sub: z.string().optional(),
+	"custom:tenant_id": z.string().min(1).optional(),
+	tenant_id: z.string().min(1).optional(),
+	"cognito:groups": z.array(z.string()).min(1).optional(),
+	realm_access: z.object({ roles: z.array(z.string()) }).optional(),
+}).passthrough();
 
 let jwks: jose.JWTVerifyGetKey | null = null;
 
@@ -74,28 +83,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			issuer: ISSUER,
 		});
 
+		const parsed = JwtClaimsSchema.safeParse(payload);
+		const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
+
 		const tenantId =
-			((payload as Record<string, unknown>)["custom:tenant_id"] as
-				| string
-				| undefined) ??
-			((payload as Record<string, unknown>)["tenant_id"] as
-				| string
-				| undefined);
+			(claims["custom:tenant_id"] as string | undefined) ??
+			(claims["tenant_id"] as string | undefined);
 		if (!tenantId) {
 			return c.json({ error: "テナント情報がありません" }, 403);
 		}
 
-		const cognitoGroups = (payload as Record<string, unknown>)[
-			"cognito:groups"
-		] as string[] | undefined;
-		const keycloakRoles = (
-			(payload as Record<string, unknown>)["realm_access"] as {
-				roles?: string[];
-			}
-		)?.roles;
+		const cognitoGroups = claims["cognito:groups"] as string[] | undefined;
+		const realmAccess = claims["realm_access"] as { roles?: string[] } | undefined;
+		const keycloakRoles = realmAccess?.roles;
 
 		c.set("auth", {
-			userId: payload.sub ?? "",
+			userId: (payload.sub as string) ?? "",
 			tenantId,
 			roles: cognitoGroups ?? keycloakRoles ?? [],
 		});

--- a/server/application/microservices/leaderboard-service/src/middleware/auth.ts
+++ b/server/application/microservices/leaderboard-service/src/middleware/auth.ts
@@ -93,11 +93,15 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 			return c.json({ error: "テナント情報がありません" }, 403);
 		}
 
+		if (!payload.sub) {
+			return c.json({ error: "トークンに sub がありません" }, 401);
+		}
+
 		const cognitoGroups = claims["cognito:groups"] as string[] | undefined;
 		const keycloakRoles = (claims["realm_access"] as { roles?: string[] } | undefined)?.roles;
 
 		c.set("auth", {
-			userId: (payload.sub as string) ?? "",
+			userId: payload.sub,
 			tenantId,
 			roles:
 				(cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??

--- a/server/application/microservices/problem-service/src/__tests__/auth.test.ts
+++ b/server/application/microservices/problem-service/src/__tests__/auth.test.ts
@@ -58,7 +58,7 @@ describe("auth モジュール", () => {
 	});
 
 	describe("authenticateRequest - AUTH_SKIP モード", () => {
-		it("AUTH_SKIP=1 かつ development ではモックユーザーを返すべき", async () => {
+		it("AUTH_SKIP=1 かつ development では認証成功とモックユーザーを返すべき", async () => {
 			process.env.AUTH_SKIP = "1";
 			process.env.NODE_ENV = "development";
 
@@ -67,8 +67,26 @@ describe("auth モジュール", () => {
 
 			expect(result.isValid).toBe(true);
 			expect(result.user).not.toBeNull();
+		});
+
+		it("AUTH_SKIP=1 かつ development ではモックユーザーの id と email が既定値であるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({});
+
 			expect(result.user!.id).toBe("dev-user");
 			expect(result.user!.email).toBe("dev-user@localhost");
+		});
+
+		it("AUTH_SKIP=1 かつ development ではモックユーザーのロールとトークンが既定値であるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({});
+
 			expect(result.user!.roles).toEqual(["competitor"]);
 			expect(result.token).toBe("mock-access-token");
 		});
@@ -96,7 +114,7 @@ describe("auth モジュール", () => {
 			expect(result.user?.roles).toEqual(["platform-admin", "competitor"]);
 		});
 
-		it("開発用ヘッダーでユーザーとテナントとロールを上書きできるべき", async () => {
+		it("開発用ヘッダーでユーザー ID とメールを上書きできるべき", async () => {
 			process.env.AUTH_SKIP = "1";
 			process.env.NODE_ENV = "development";
 
@@ -110,6 +128,19 @@ describe("auth モジュール", () => {
 			expect(result.isValid).toBe(true);
 			expect(result.user?.id).toBe("tenant-admin@example.com");
 			expect(result.user?.email).toBe("tenant-admin@example.com");
+		});
+
+		it("開発用ヘッダーでテナント ID とロールを上書きできるべき", async () => {
+			process.env.AUTH_SKIP = "1";
+			process.env.NODE_ENV = "development";
+
+			const { authenticateRequest } = await import("../auth");
+			const result = await authenticateRequest({
+				"x-tenkacloud-dev-user-id": "tenant-admin@example.com",
+				"x-tenkacloud-dev-tenant-id": "tenant-acme",
+				"x-tenkacloud-dev-roles": "tenant-admin,participant",
+			});
+
 			expect(result.user?.tenantId).toBe("tenant-acme");
 			expect(result.user?.roles).toEqual(["tenant-admin", "participant"]);
 		});
@@ -213,6 +244,264 @@ describe("auth モジュール", () => {
 			expect(
 				hasAnyRole(user, [UserRole.PLATFORM_ADMIN, UserRole.ORGANIZER]),
 			).toBe(false);
+		});
+	});
+
+	describe("verifyToken - Cognito クレーム抽出", () => {
+		it("Cognito の custom:tenant_id からテナントIDを抽出すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "cognito-user-123",
+						email: "user@example.com",
+						preferred_username: "cognitouser",
+						"custom:tenant_id": "tenant-from-cognito",
+						"cognito:groups": ["organizer", "competitor"],
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-cognito-token");
+
+			expect(user).not.toBeNull();
+			expect(user!.tenantId).toBe("tenant-from-cognito");
+		});
+
+		it("Cognito の cognito:groups からロールを抽出すべき（複数グループ）", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "cognito-user-123",
+						email: "user@example.com",
+						preferred_username: "cognitouser",
+						"custom:tenant_id": "tenant-from-cognito",
+						"cognito:groups": ["organizer", "competitor"],
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-cognito-token");
+
+			expect(user!.roles).toEqual(["organizer", "competitor"]);
+		});
+
+		it("Cognito クレームから sub, email, preferred_username を抽出すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "cognito-user-123",
+						email: "user@example.com",
+						preferred_username: "cognitouser",
+						"custom:tenant_id": "tenant-from-cognito",
+						"cognito:groups": ["organizer", "competitor"],
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-cognito-token");
+
+			expect(user!.id).toBe("cognito-user-123");
+			expect(user!.email).toBe("user@example.com");
+			expect(user!.username).toBe("cognitouser");
+		});
+
+		it("Cognito の cognito:groups からロールを抽出すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "cognito-user-456",
+						"cognito:groups": ["platform-admin"],
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-cognito-token");
+
+			expect(user).not.toBeNull();
+			expect(user!.roles).toEqual(["platform-admin"]);
+		});
+
+		it("Cognito クレームが Keycloak クレームより優先されるべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "dual-user",
+						"custom:tenant_id": "cognito-tenant",
+						tenantId: "keycloak-tenant",
+						"cognito:groups": ["competitor"],
+						realm_access: { roles: ["organizer"] },
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-token");
+
+			expect(user).not.toBeNull();
+			expect(user!.tenantId).toBe("cognito-tenant");
+			expect(user!.roles).toEqual(["competitor"]);
+		});
+
+		it("Cognito クレームがない場合は Keycloak クレームにフォールバックすべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "keycloak-user",
+						tenantId: "keycloak-tenant",
+						realm_access: { roles: ["organizer", "tenant-admin"] },
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-keycloak-token");
+
+			expect(user).not.toBeNull();
+			expect(user!.tenantId).toBe("keycloak-tenant");
+			expect(user!.roles).toEqual(["organizer", "tenant-admin"]);
+		});
+
+		it("両方のクレームがない場合は空ロールと undefined テナントを返すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: {
+						sub: "minimal-user",
+					},
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			const user = await verifyToken("fake-token");
+
+			expect(user).not.toBeNull();
+			expect(user!.tenantId).toBeUndefined();
+			expect(user!.roles).toEqual([]);
+		});
+	});
+
+	describe("JWKS_URI / JWT_ISSUER 環境変数", () => {
+		it("JWKS_URI が設定されている場合はその URL を使用すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+			process.env.JWKS_URI = "https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id/.well-known/jwks.json";
+
+			const mockCreateRemoteJWKSet = vi.fn(() => vi.fn());
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: mockCreateRemoteJWKSet,
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: { sub: "test-user" },
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			await verifyToken("fake-token");
+
+			expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(
+				new URL("https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id/.well-known/jwks.json"),
+			);
+		});
+
+		it("JWT_ISSUER が設定されている場合はその issuer を使用すべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+			process.env.JWT_ISSUER = "https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id";
+
+			const mockJwtVerify = vi.fn().mockResolvedValue({
+				payload: { sub: "test-user" },
+			});
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: mockJwtVerify,
+			}));
+
+			const { verifyToken } = await import("../auth");
+			await verifyToken("fake-token");
+
+			expect(mockJwtVerify).toHaveBeenCalledWith(
+				"fake-token",
+				expect.any(Function),
+				{ issuer: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id" },
+			);
+		});
+
+		it("JWKS_URI が未設定の場合は Keycloak パターンにフォールバックすべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+			delete process.env.JWKS_URI;
+			process.env.KEYCLOAK_URL = "http://keycloak.local:8080";
+			process.env.KEYCLOAK_REALM = "myrealm";
+
+			const mockCreateRemoteJWKSet = vi.fn(() => vi.fn());
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: mockCreateRemoteJWKSet,
+				jwtVerify: vi.fn().mockResolvedValue({
+					payload: { sub: "test-user" },
+				}),
+			}));
+
+			const { verifyToken } = await import("../auth");
+			await verifyToken("fake-token");
+
+			expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(
+				new URL("http://keycloak.local:8080/realms/myrealm/protocol/openid-connect/certs"),
+			);
+		});
+
+		it("JWT_ISSUER が未設定の場合は Keycloak パターンにフォールバックすべき", async () => {
+			process.env.AUTH_SKIP = "0";
+			process.env.NODE_ENV = "test";
+			delete process.env.JWT_ISSUER;
+			process.env.KEYCLOAK_URL = "http://keycloak.local:8080";
+			process.env.KEYCLOAK_REALM = "myrealm";
+
+			const mockJwtVerify = vi.fn().mockResolvedValue({
+				payload: { sub: "test-user" },
+			});
+			vi.doMock("jose", () => ({
+				createRemoteJWKSet: vi.fn(() => vi.fn()),
+				jwtVerify: mockJwtVerify,
+			}));
+
+			const { verifyToken } = await import("../auth");
+			await verifyToken("fake-token");
+
+			expect(mockJwtVerify).toHaveBeenCalledWith(
+				"fake-token",
+				expect.any(Function),
+				{ issuer: "http://keycloak.local:8080/realms/myrealm" },
+			);
 		});
 	});
 

--- a/server/application/microservices/problem-service/src/auth/index.ts
+++ b/server/application/microservices/problem-service/src/auth/index.ts
@@ -1,7 +1,9 @@
 /**
  * 認証・認可システム
  *
- * control-plane の Keycloak 認証を再利用。
+ * Cognito JWT と Keycloak JWT の両方をサポート。
+ * JWKS_URI / JWT_ISSUER 環境変数で設定可能。
+ * 未設定の場合は Keycloak パターンにフォールバック。
  *
  * AUTH_SKIP モードでは JWT 検証をバイパスし、
  * モックユーザーを返す（ローカル開発用）。
@@ -37,7 +39,11 @@ if (authSkipEnabled && typeof console !== 'undefined') {
 
 const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM || 'tenkacloud';
 const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'http://localhost:8080';
-const JWKS_URL = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`;
+const KEYCLOAK_JWKS_URL = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`;
+const KEYCLOAK_ISSUER = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`;
+
+const JWKS_URL = process.env.JWKS_URI || KEYCLOAK_JWKS_URL;
+const JWT_ISSUER = process.env.JWT_ISSUER || KEYCLOAK_ISSUER;
 
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
 
@@ -60,6 +66,7 @@ export interface JWTPayload {
   sub: string;
   email?: string;
   preferred_username?: string;
+  // Keycloak claims
   realm_access?: {
     roles: string[];
   };
@@ -68,7 +75,10 @@ export interface JWTPayload {
       roles: string[];
     };
   };
-  // TenkaCloud 拡張
+  // Cognito claims
+  'custom:tenant_id'?: string;
+  'cognito:groups'?: string[];
+  // TenkaCloud 拡張 (Keycloak)
   teamId?: string;
   tenantId?: string;
 }
@@ -109,24 +119,33 @@ function sanitizeDevIdentity(
 
 /**
  * JWT トークンを検証してユーザー情報を取得
+ *
+ * Cognito と Keycloak 両方のクレーム形式をサポート。
+ * - tenant_id: `custom:tenant_id` (Cognito) -> `tenantId` (Keycloak)
+ * - roles: `cognito:groups` (Cognito) -> `realm_access.roles` (Keycloak)
  */
 export async function verifyToken(
   token: string
 ): Promise<AuthenticatedUser | null> {
   try {
     const { payload } = await jwtVerify(token, getJWKS(), {
-      issuer: `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`,
+      issuer: JWT_ISSUER,
     });
 
     const jwtPayload = payload as unknown as JWTPayload;
+
+    const tenantId =
+      jwtPayload['custom:tenant_id'] ?? jwtPayload.tenantId;
+    const roles =
+      jwtPayload['cognito:groups'] ?? jwtPayload.realm_access?.roles ?? [];
 
     return {
       id: jwtPayload.sub,
       email: jwtPayload.email || '',
       username: jwtPayload.preferred_username || '',
-      roles: jwtPayload.realm_access?.roles || [],
+      roles,
       teamId: jwtPayload.teamId,
-      tenantId: jwtPayload.tenantId,
+      tenantId,
     };
   } catch (error) {
     console.error('JWT verification failed:', error);
@@ -210,7 +229,7 @@ function createMockUser(
  * ヘッダーからトークンを抽出して認証
  *
  * AUTH_SKIP モード: モックユーザーを即座に返す（JWT 検証なし）
- * 通常モード: Keycloak の JWKS でトークンを検証
+ * 通常モード: JWKS_URI (Cognito/Keycloak) でトークンを検証
  */
 export async function authenticateRequest(headers: {
   authorization?: string;

--- a/server/application/microservices/problem-service/src/auth/index.ts
+++ b/server/application/microservices/problem-service/src/auth/index.ts
@@ -49,6 +49,7 @@ const JWT_ISSUER = process.env.JWT_ISSUER || KEYCLOAK_ISSUER;
 const JwtClaimsSchema = z.object({
   sub: z.string().optional(),
   'custom:tenant_id': z.string().min(1).optional(),
+  tenant_id: z.string().min(1).optional(),
   tenantId: z.string().min(1).optional(),
   'cognito:groups': z.array(z.string()).min(1).optional(),
   realm_access: z.object({ roles: z.array(z.string()) }).optional(),
@@ -127,11 +128,8 @@ function sanitizeDevIdentity(
 }
 
 /**
- * JWT トークンを検証してユーザー情報を取得
- *
- * Cognito と Keycloak 両方のクレーム形式をサポート。
- * - tenant_id: `custom:tenant_id` (Cognito) -> `tenantId` (Keycloak)
- * - roles: `cognito:groups` (Cognito) -> `realm_access.roles` (Keycloak)
+ * Cognito: custom:tenant_id -> cognito:groups
+ * Keycloak: tenantId / tenant_id -> realm_access.roles
  */
 export async function verifyToken(
   token: string
@@ -143,14 +141,16 @@ export async function verifyToken(
 
     const jwtPayload = payload as unknown as JWTPayload;
     const parsed = JwtClaimsSchema.safeParse(payload);
-    const claims = parsed.success ? parsed.data : {};
+    const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
     const tenantId =
-      (claims['custom:tenant_id'] ?? claims.tenantId) ??
-      (jwtPayload['custom:tenant_id'] ?? jwtPayload.tenantId);
+      (claims['custom:tenant_id'] as string | undefined) ??
+      (claims['tenant_id'] as string | undefined) ??
+      (claims['tenantId'] as string | undefined);
     const roles =
-      (claims['cognito:groups'] ?? claims.realm_access?.roles) ??
-      (jwtPayload['cognito:groups'] ?? jwtPayload.realm_access?.roles ?? []);
+      (claims['cognito:groups'] as string[] | undefined) ??
+      (claims['realm_access'] as { roles?: string[] } | undefined)?.roles ??
+      [];
 
     return {
       id: jwtPayload.sub,

--- a/server/application/microservices/problem-service/src/auth/index.ts
+++ b/server/application/microservices/problem-service/src/auth/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { z } from 'zod';
 import { parseAuthSkipRoles } from './auth-skip-roles';
 
 /* v8 ignore start -- Production safety guard */
@@ -44,6 +45,14 @@ const KEYCLOAK_ISSUER = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`;
 
 const JWKS_URL = process.env.JWKS_URI || KEYCLOAK_JWKS_URL;
 const JWT_ISSUER = process.env.JWT_ISSUER || KEYCLOAK_ISSUER;
+
+const JwtClaimsSchema = z.object({
+  sub: z.string().optional(),
+  'custom:tenant_id': z.string().min(1).optional(),
+  tenantId: z.string().min(1).optional(),
+  'cognito:groups': z.array(z.string()).min(1).optional(),
+  realm_access: z.object({ roles: z.array(z.string()) }).optional(),
+}).passthrough();
 
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
 
@@ -133,11 +142,15 @@ export async function verifyToken(
     });
 
     const jwtPayload = payload as unknown as JWTPayload;
+    const parsed = JwtClaimsSchema.safeParse(payload);
+    const claims = parsed.success ? parsed.data : {};
 
     const tenantId =
-      jwtPayload['custom:tenant_id'] ?? jwtPayload.tenantId;
+      (claims['custom:tenant_id'] ?? claims.tenantId) ??
+      (jwtPayload['custom:tenant_id'] ?? jwtPayload.tenantId);
     const roles =
-      jwtPayload['cognito:groups'] ?? jwtPayload.realm_access?.roles ?? [];
+      (claims['cognito:groups'] ?? claims.realm_access?.roles) ??
+      (jwtPayload['cognito:groups'] ?? jwtPayload.realm_access?.roles ?? []);
 
     return {
       id: jwtPayload.sub,

--- a/server/application/microservices/problem-service/src/auth/index.ts
+++ b/server/application/microservices/problem-service/src/auth/index.ts
@@ -143,13 +143,16 @@ export async function verifyToken(
     const parsed = JwtClaimsSchema.safeParse(payload);
     const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
-    const tenantId =
-      (claims['custom:tenant_id'] as string | undefined) ??
-      (claims['tenant_id'] as string | undefined) ??
+    const rawTenantId =
+      (claims['custom:tenant_id'] as string | undefined) ||
+      (claims['tenant_id'] as string | undefined) ||
       (claims['tenantId'] as string | undefined);
+    const tenantId = rawTenantId?.trim() || undefined;
+    const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
+    const keycloakRoles = (claims['realm_access'] as { roles?: string[] } | undefined)?.roles;
     const roles =
-      (claims['cognito:groups'] as string[] | undefined) ??
-      (claims['realm_access'] as { roles?: string[] } | undefined)?.roles ??
+      (cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??
+      (keycloakRoles && keycloakRoles.length > 0 ? keycloakRoles : undefined) ??
       [];
 
     return {

--- a/server/application/microservices/scoring-service/src/middleware/auth.test.ts
+++ b/server/application/microservices/scoring-service/src/middleware/auth.test.ts
@@ -222,4 +222,48 @@ describe('認証ミドルウェア', () => {
     const body = await res.json();
     expect(body.auth.roles).toEqual([]);
   });
+
+  it('Cognito の custom:tenant_id からテナント ID を抽出すべき', async () => {
+    const mockPayload = {
+      sub: 'user-cognito',
+      'custom:tenant_id': 'cognito-tenant-789',
+      'cognito:groups': ['admin'],
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.tenantId).toBe('cognito-tenant-789');
+  });
+
+  it('Cognito の cognito:groups からロールを取得すべき', async () => {
+    const mockPayload = {
+      sub: 'user-cognito',
+      'custom:tenant_id': 'cognito-tenant-789',
+      'cognito:groups': ['tenant-admin', 'participant'],
+    };
+
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(vi.fn() as never);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: mockPayload,
+      protectedHeader: { alg: 'RS256' },
+    } as never);
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.auth.roles).toEqual(['tenant-admin', 'participant']);
+  });
 });

--- a/server/application/microservices/scoring-service/src/middleware/auth.ts
+++ b/server/application/microservices/scoring-service/src/middleware/auth.ts
@@ -56,20 +56,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
     const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
 
     const tenantId =
-      (claims['custom:tenant_id'] as string | undefined) ??
+      (claims['custom:tenant_id'] as string | undefined) ||
       (claims['tenant_id'] as string | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
     const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
-    const realmAccess = claims['realm_access'] as { roles?: string[] } | undefined;
-    const keycloakRoles = realmAccess?.roles;
+    const keycloakRoles = (claims['realm_access'] as { roles?: string[] } | undefined)?.roles;
 
     c.set('auth', {
       userId: (payload.sub as string) ?? '',
       tenantId,
-      roles: cognitoGroups ?? keycloakRoles ?? [],
+      roles:
+        (cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??
+        (keycloakRoles && keycloakRoles.length > 0 ? keycloakRoles : undefined) ??
+        [],
     });
 
     await next();

--- a/server/application/microservices/scoring-service/src/middleware/auth.ts
+++ b/server/application/microservices/scoring-service/src/middleware/auth.ts
@@ -62,11 +62,15 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
+    if (!payload.sub) {
+      return c.json({ error: 'トークンに sub がありません' }, 401);
+    }
+
     const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
     const keycloakRoles = (claims['realm_access'] as { roles?: string[] } | undefined)?.roles;
 
     c.set('auth', {
-      userId: (payload.sub as string) ?? '',
+      userId: payload.sub,
       tenantId,
       roles:
         (cognitoGroups && cognitoGroups.length > 0 ? cognitoGroups : undefined) ??

--- a/server/application/microservices/scoring-service/src/middleware/auth.ts
+++ b/server/application/microservices/scoring-service/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory';
 import * as jose from 'jose';
+import { z } from 'zod';
 
 export interface AuthContext {
   userId: string;
@@ -18,6 +19,14 @@ const JWKS_URI =
   'http://localhost:8080/realms/tenkacloud/protocol/openid-connect/certs';
 const ISSUER =
   process.env.JWT_ISSUER ?? 'http://localhost:8080/realms/tenkacloud';
+
+const JwtClaimsSchema = z.object({
+  sub: z.string().optional(),
+  'custom:tenant_id': z.string().min(1).optional(),
+  tenant_id: z.string().min(1).optional(),
+  'cognito:groups': z.array(z.string()).min(1).optional(),
+  realm_access: z.object({ roles: z.array(z.string()) }).optional(),
+}).passthrough();
 
 let jwks: jose.JWTVerifyGetKey | null = null;
 
@@ -43,28 +52,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       issuer: ISSUER,
     });
 
+    const parsed = JwtClaimsSchema.safeParse(payload);
+    const claims = parsed.success ? parsed.data : (payload as Record<string, unknown>);
+
     const tenantId =
-      ((payload as Record<string, unknown>)['custom:tenant_id'] as
-        | string
-        | undefined) ??
-      ((payload as Record<string, unknown>)['tenant_id'] as
-        | string
-        | undefined);
+      (claims['custom:tenant_id'] as string | undefined) ??
+      (claims['tenant_id'] as string | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
-    const cognitoGroups = (payload as Record<string, unknown>)[
-      'cognito:groups'
-    ] as string[] | undefined;
-    const keycloakRoles = (
-      (payload as Record<string, unknown>)['realm_access'] as {
-        roles?: string[];
-      }
-    )?.roles;
+    const cognitoGroups = claims['cognito:groups'] as string[] | undefined;
+    const realmAccess = claims['realm_access'] as { roles?: string[] } | undefined;
+    const keycloakRoles = realmAccess?.roles;
 
     c.set('auth', {
-      userId: payload.sub ?? '',
+      userId: (payload.sub as string) ?? '',
       tenantId,
       roles: cognitoGroups ?? keycloakRoles ?? [],
     });

--- a/server/application/microservices/scoring-service/src/middleware/auth.ts
+++ b/server/application/microservices/scoring-service/src/middleware/auth.ts
@@ -43,22 +43,30 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       issuer: ISSUER,
     });
 
-    const tenantId = (payload as Record<string, unknown>)['tenant_id'] as
-      | string
-      | undefined;
+    const tenantId =
+      ((payload as Record<string, unknown>)['custom:tenant_id'] as
+        | string
+        | undefined) ??
+      ((payload as Record<string, unknown>)['tenant_id'] as
+        | string
+        | undefined);
     if (!tenantId) {
       return c.json({ error: 'テナント情報がありません' }, 403);
     }
 
+    const cognitoGroups = (payload as Record<string, unknown>)[
+      'cognito:groups'
+    ] as string[] | undefined;
+    const keycloakRoles = (
+      (payload as Record<string, unknown>)['realm_access'] as {
+        roles?: string[];
+      }
+    )?.roles;
+
     c.set('auth', {
       userId: payload.sub ?? '',
       tenantId,
-      roles:
-        (
-          (payload as Record<string, unknown>)['realm_access'] as {
-            roles?: string[];
-          }
-        )?.roles ?? [],
+      roles: cognitoGroups ?? keycloakRoles ?? [],
     });
 
     await next();

--- a/server/application/microservices/tenant-management/src/middleware/auth-cognito.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth-cognito.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Logger mock
+const mockLoggerFunctions = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFunctions),
+}));
+
+// jose mock — JWT 検証を制御
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+describe('認証ミドルウェア — Cognito クレーム抽出', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.JWKS_URI;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
+
+  it('Cognito の custom:tenant_id からテナント ID を抽出すべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {
+        sub: 'cognito-user-1',
+        email: 'cognito@example.com',
+        name: 'Cognito User',
+        'custom:tenant_id': 'cognito-tenant-abc',
+        'cognito:groups': ['tenant-admin'],
+        iss: 'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id',
+        aud: '',
+        iat: 0,
+        exp: 0,
+      },
+      protectedHeader: { alg: 'RS256' },
+      key: {} as CryptoKey,
+    });
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBe('cognito-user-1');
+    expect(body.tenantId).toBe('cognito-tenant-abc');
+  });
+
+  it('Cognito の cognito:groups からロールを取得すべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {
+        sub: 'cognito-user-2',
+        email: 'admin@example.com',
+        'custom:tenant_id': 'cognito-tenant-xyz',
+        'cognito:groups': ['platform-admin', 'tenant-admin'],
+        iss: 'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id',
+        aud: '',
+        iat: 0,
+        exp: 0,
+      },
+      protectedHeader: { alg: 'RS256' },
+      key: {} as CryptoKey,
+    });
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer cognito-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.roles).toEqual(['platform-admin', 'tenant-admin']);
+  });
+
+  it('Cognito クレームが Auth0 クレームより優先されるべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {
+        sub: 'hybrid-user',
+        'custom:tenant_id': 'cognito-tenant',
+        'https://tenkacloud.com/tenant_id': 'auth0-tenant',
+        'cognito:groups': ['cognito-role'],
+        'https://tenkacloud.com/roles': ['auth0-role'],
+        iss: '',
+        aud: '',
+        iat: 0,
+        exp: 0,
+      },
+      protectedHeader: { alg: 'RS256' },
+      key: {} as CryptoKey,
+    });
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer hybrid-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.tenantId).toBe('cognito-tenant');
+    expect(body.roles).toEqual(['cognito-role']);
+  });
+
+  it('cognito:groups が空配列の場合 Auth0 ロールにフォールバックすべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {
+        sub: 'fallback-user',
+        'https://tenkacloud.com/tenant_id': 'auth0-tenant',
+        'cognito:groups': [],
+        'https://tenkacloud.com/roles': ['auth0-role'],
+        iss: '',
+        aud: '',
+        iat: 0,
+        exp: 0,
+      },
+      protectedHeader: { alg: 'RS256' },
+      key: {} as CryptoKey,
+    });
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer fallback-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.roles).toEqual(['auth0-role']);
+  });
+});

--- a/server/application/microservices/tenant-management/src/middleware/auth-optional.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth-optional.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Logger mock
+const mockLoggerFunctions = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFunctions),
+}));
+
+// jose mock — JWT 検証を制御
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+describe('認証ミドルウェア — optionalAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.JWKS_URI;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
+
+  it('トークンがない場合はユーザーコンテキストなしで通過すべき', async () => {
+    const { optionalAuth } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', optionalAuth);
+    app.get('/test', (c) => {
+      const user = c.get('user');
+      return c.json({ hasUser: !!user });
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.hasUser).toBe(false);
+  });
+
+  it('不正なフォーマットの場合はユーザーコンテキストなしで通過すべき', async () => {
+    const { optionalAuth } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', optionalAuth);
+    app.get('/test', (c) => {
+      const user = c.get('user');
+      return c.json({ hasUser: !!user });
+    });
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Basic something' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.hasUser).toBe(false);
+  });
+
+  it('有効なトークンがある場合はユーザーコンテキストを設定すべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: {
+        sub: 'optional-user',
+        email: 'optional@example.com',
+        name: 'Optional User',
+        'custom:tenant_id': 'optional-tenant',
+        'cognito:groups': ['user'],
+        iss: '',
+        aud: '',
+        iat: 0,
+        exp: 0,
+      },
+      protectedHeader: { alg: 'RS256' },
+      key: {} as CryptoKey,
+    });
+
+    const { optionalAuth } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', optionalAuth);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer valid-optional-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBe('optional-user');
+    expect(body.tenantId).toBe('optional-tenant');
+    expect(body.roles).toEqual(['user']);
+  });
+
+  it('無効なトークンの場合はユーザーコンテキストなしで通過すべき', async () => {
+    const jose = await import('jose');
+    vi.mocked(jose.jwtVerify).mockRejectedValue(
+      new Error('Invalid token'),
+    );
+
+    const { optionalAuth } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', optionalAuth);
+    app.get('/test', (c) => {
+      const user = c.get('user');
+      return c.json({ hasUser: !!user });
+    });
+
+    const res = await app.request('/test', {
+      headers: { Authorization: 'Bearer invalid-token' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.hasUser).toBe(false);
+  });
+});

--- a/server/application/microservices/tenant-management/src/middleware/auth-roles.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth-roles.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Logger mock
+const mockLoggerFunctions = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFunctions),
+}));
+
+// jose mock — JWT 検証を制御
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+describe('認証ミドルウェア — requireRoles / requireTenantAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.JWKS_URI;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
+
+  // ─── requireRoles ────────────────────────────────────
+  describe('requireRoles ミドルウェア', () => {
+    it('必要なロールを持つユーザーにアクセスを許可すべき', async () => {
+      process.env.AUTH_SKIP = '1';
+
+      const { authMiddleware, requireRoles, UserRole } = await import(
+        './auth'
+      );
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get(
+        '/admin',
+        requireRoles(UserRole.PLATFORM_ADMIN),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/admin');
+      expect(res.status).toBe(200);
+    });
+
+    it('必要なロールを持たないユーザーに 403 を返すべき', async () => {
+      process.env.AUTH_SKIP = '1';
+      process.env.AUTH_SKIP_ROLES = 'user';
+
+      const { authMiddleware, requireRoles, UserRole } = await import(
+        './auth'
+      );
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get(
+        '/admin',
+        requireRoles(UserRole.PLATFORM_ADMIN),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/admin');
+      expect(res.status).toBe(403);
+
+      const body = await res.json();
+      expect(body.error).toBe('Forbidden: Insufficient permissions');
+    });
+
+    it('ユーザーコンテキストがない場合は 401 を返すべき', async () => {
+      const { requireRoles, UserRole } = await import('./auth');
+
+      const app = new Hono();
+      // authMiddleware を適用せずに requireRoles のみ
+      app.get(
+        '/admin',
+        requireRoles(UserRole.PLATFORM_ADMIN),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/admin');
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized: No user context');
+    });
+  });
+
+  // ─── requireTenantAccess ────────────────────────────
+  describe('requireTenantAccess ミドルウェア', () => {
+    it('プラットフォーム管理者はすべてのテナントにアクセスできるべき', async () => {
+      process.env.AUTH_SKIP = '1';
+
+      const { authMiddleware, requireTenantAccess } = await import(
+        './auth'
+      );
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get(
+        '/tenants/:tenantId',
+        requireTenantAccess(),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/tenants/any-tenant-id');
+      expect(res.status).toBe(200);
+    });
+
+    it('異なるテナントへのアクセスは 403 を返すべき', async () => {
+      process.env.AUTH_SKIP = '1';
+
+      const { authMiddleware, requireTenantAccess } = await import(
+        './auth'
+      );
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get(
+        '/tenants/:tenantId',
+        requireTenantAccess(),
+        (c) => c.json({ ok: true }),
+      );
+
+      // Dev user has tenantId = 'dev-tenant', requesting different tenant
+      const res = await app.request('/tenants/other-tenant', {
+        headers: {
+          'X-TenkaCloud-Dev-Roles': 'tenant-admin',
+          'X-TenkaCloud-Dev-Tenant-Id': 'my-tenant',
+        },
+      });
+      expect(res.status).toBe(403);
+
+      const body = await res.json();
+      expect(body.error).toBe('Forbidden: Cannot access this tenant');
+    });
+
+    it('自分のテナントへのアクセスは許可すべき', async () => {
+      process.env.AUTH_SKIP = '1';
+
+      const { authMiddleware, requireTenantAccess } = await import(
+        './auth'
+      );
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get(
+        '/tenants/:tenantId',
+        requireTenantAccess(),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/tenants/my-tenant', {
+        headers: {
+          'X-TenkaCloud-Dev-Roles': 'tenant-admin',
+          'X-TenkaCloud-Dev-Tenant-Id': 'my-tenant',
+        },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('ユーザーコンテキストがない場合は 401 を返すべき', async () => {
+      const { requireTenantAccess } = await import('./auth');
+
+      const app = new Hono();
+      app.get(
+        '/tenants/:tenantId',
+        requireTenantAccess(),
+        (c) => c.json({ ok: true }),
+      );
+
+      const res = await app.request('/tenants/any-tenant');
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/server/application/microservices/tenant-management/src/middleware/auth-skip.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth-skip.test.ts
@@ -23,6 +23,7 @@ describe('認証ミドルウェア — AUTH_SKIP モード', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    process.env.NODE_ENV = 'development';
     delete process.env.AUTH_SKIP;
     delete process.env.AUTH_SKIP_ROLES;
     delete process.env.AUTH0_DOMAIN;

--- a/server/application/microservices/tenant-management/src/middleware/auth-skip.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth-skip.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Logger mock
+const mockLoggerFunctions = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFunctions),
+}));
+
+// jose mock — JWT 検証を制御
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+describe('認証ミドルウェア — AUTH_SKIP モード', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.JWKS_URI;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
+
+  it('AUTH_SKIP 有効時にステータス 200 を返すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('AUTH_SKIP 有効時にデフォルトのユーザー ID を設定すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.id).toBe('dev-user');
+  });
+
+  it('AUTH_SKIP 有効時にデフォルトのメールアドレスを設定すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.email).toBe('dev@tenkacloud.local');
+  });
+
+  it('AUTH_SKIP 有効時にデフォルトのユーザー名を設定すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.username).toBe('Dev Admin');
+  });
+
+  it('AUTH_SKIP 有効時にデフォルトのロールを設定すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.roles).toEqual(['platform-admin']);
+  });
+
+  it('AUTH_SKIP 有効時にデフォルトのテナント ID を設定すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.tenantId).toBe('dev-tenant');
+  });
+
+  it('開発用ヘッダーでユーザー ID を上書きできるべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'custom-user',
+        'X-TenkaCloud-Dev-Email': 'custom@example.com',
+        'X-TenkaCloud-Dev-Username': 'Custom User',
+        'X-TenkaCloud-Dev-Tenant-Id': 'custom-tenant',
+        'X-TenkaCloud-Dev-Roles': 'tenant-admin,user',
+      },
+    });
+    const body = await res.json();
+    expect(body.id).toBe('custom-user');
+  });
+
+  it('開発用ヘッダーでメールアドレスを上書きできるべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'custom-user',
+        'X-TenkaCloud-Dev-Email': 'custom@example.com',
+        'X-TenkaCloud-Dev-Username': 'Custom User',
+        'X-TenkaCloud-Dev-Tenant-Id': 'custom-tenant',
+        'X-TenkaCloud-Dev-Roles': 'tenant-admin,user',
+      },
+    });
+    const body = await res.json();
+    expect(body.email).toBe('custom@example.com');
+  });
+
+  it('開発用ヘッダーでユーザー名を上書きできるべき（スペースはハイフンに置換）', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'custom-user',
+        'X-TenkaCloud-Dev-Email': 'custom@example.com',
+        'X-TenkaCloud-Dev-Username': 'Custom User',
+        'X-TenkaCloud-Dev-Tenant-Id': 'custom-tenant',
+        'X-TenkaCloud-Dev-Roles': 'tenant-admin,user',
+      },
+    });
+    const body = await res.json();
+    // Spaces are replaced with hyphens by sanitizeDevHeader
+    expect(body.username).toBe('Custom-User');
+  });
+
+  it('開発用ヘッダーでテナント ID を上書きできるべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'custom-user',
+        'X-TenkaCloud-Dev-Email': 'custom@example.com',
+        'X-TenkaCloud-Dev-Username': 'Custom User',
+        'X-TenkaCloud-Dev-Tenant-Id': 'custom-tenant',
+        'X-TenkaCloud-Dev-Roles': 'tenant-admin,user',
+      },
+    });
+    const body = await res.json();
+    expect(body.tenantId).toBe('custom-tenant');
+  });
+
+  it('開発用ヘッダーでロールを上書きできるべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'custom-user',
+        'X-TenkaCloud-Dev-Email': 'custom@example.com',
+        'X-TenkaCloud-Dev-Username': 'Custom User',
+        'X-TenkaCloud-Dev-Tenant-Id': 'custom-tenant',
+        'X-TenkaCloud-Dev-Roles': 'tenant-admin,user',
+      },
+    });
+    const body = await res.json();
+    expect(body.roles).toEqual(['tenant-admin', 'user']);
+  });
+
+  it('AUTH_SKIP_ROLES 環境変数でロールを設定できるべき', async () => {
+    process.env.AUTH_SKIP = '1';
+    process.env.AUTH_SKIP_ROLES = 'tenant-admin,user';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test');
+    const body = await res.json();
+    expect(body.roles).toEqual(['tenant-admin', 'user']);
+  });
+
+  it('開発用ヘッダーの値をサニタイズすべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': 'user<script>alert(1)</script>',
+        'X-TenkaCloud-Dev-Tenant-Id': 'tenant; DROP TABLE users',
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // Dangerous characters should be replaced with hyphens
+    expect(body.id).not.toContain('<');
+    expect(body.id).not.toContain('>');
+    expect(body.tenantId).not.toContain(';');
+  });
+
+  it('空の開発用ヘッダーはフォールバック値を使用すべき', async () => {
+    process.env.AUTH_SKIP = '1';
+
+    const { authMiddleware } = await import('./auth');
+
+    const app = new Hono();
+    app.use('/*', authMiddleware);
+    app.get('/test', (c) => c.json(c.get('user')));
+
+    const res = await app.request('/test', {
+      headers: {
+        'X-TenkaCloud-Dev-User-Id': '   ',
+        'X-TenkaCloud-Dev-Tenant-Id': '',
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBe('dev-user');
+    expect(body.tenantId).toBe('dev-tenant');
+  });
+});

--- a/server/application/microservices/tenant-management/src/middleware/auth.test.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Logger mock
+const mockLoggerFunctions = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFunctions),
+}));
+
+// jose mock — JWT 検証を制御
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+describe('認証ミドルウェア — JWT 検証・JWKS 設定・エラーケース', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.AUTH_SKIP;
+    delete process.env.AUTH_SKIP_ROLES;
+    delete process.env.AUTH0_DOMAIN;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.JWKS_URI;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+  });
+
+  // ─── JWT 検証（Auth0 クレーム） ──────────────────────
+  describe('JWT 検証（Auth0 クレーム）', () => {
+    it('Auth0 トークンからユーザー情報を抽出すべき', async () => {
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockResolvedValue({
+        payload: {
+          sub: 'auth0|user-123',
+          email: 'user@example.com',
+          name: 'Test User',
+          org_id: 'org-abc',
+          'https://tenkacloud.com/roles': ['tenant-admin'],
+          'https://tenkacloud.com/tenant_id': 'tenant-xyz',
+          iss: 'https://dev-tenkacloud.auth0.com/',
+          aud: 'https://api.tenkacloud.com',
+          iat: 0,
+          exp: 0,
+        },
+        protectedHeader: { alg: 'RS256' },
+        key: {} as CryptoKey,
+      });
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json(c.get('user')));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer valid-auth0-token' },
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBe('auth0|user-123');
+      expect(body.email).toBe('user@example.com');
+      expect(body.username).toBe('Test User');
+      expect(body.roles).toEqual(['tenant-admin']);
+      expect(body.tenantId).toBe('tenant-xyz');
+      expect(body.organizationId).toBe('org-abc');
+    });
+
+    it('email がないトークンでも空文字として処理すべき', async () => {
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockResolvedValue({
+        payload: {
+          sub: 'auth0|m2m-client',
+          nickname: 'api-client',
+          'https://tenkacloud.com/roles': [],
+          'https://tenkacloud.com/tenant_id': 'tenant-m2m',
+          iss: '',
+          aud: '',
+          iat: 0,
+          exp: 0,
+        },
+        protectedHeader: { alg: 'RS256' },
+        key: {} as CryptoKey,
+      });
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json(c.get('user')));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer m2m-token' },
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.email).toBe('');
+      expect(body.username).toBe('api-client');
+    });
+
+    it('Auth0 namespace にロールがない場合は空配列を返すべき', async () => {
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockResolvedValue({
+        payload: {
+          sub: 'auth0|user-no-roles',
+          email: 'noroles@example.com',
+          'https://tenkacloud.com/tenant_id': 'tenant-abc',
+          iss: '',
+          aud: '',
+          iat: 0,
+          exp: 0,
+        },
+        protectedHeader: { alg: 'RS256' },
+        key: {} as CryptoKey,
+      });
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json(c.get('user')));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer token-no-roles' },
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.roles).toEqual([]);
+    });
+  });
+
+  // ─── JWKS_URI / JWT_ISSUER 環境変数 ───────────────────
+  describe('JWKS_URI / JWT_ISSUER 設定', () => {
+    it('JWKS_URI 環境変数が設定されている場合はそれを使用すべき', async () => {
+      process.env.JWKS_URI =
+        'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id/.well-known/jwks.json';
+      process.env.JWT_ISSUER =
+        'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id';
+
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockResolvedValue({
+        payload: {
+          sub: 'cognito-user',
+          'custom:tenant_id': 'tenant-via-env',
+          'cognito:groups': ['user'],
+          iss: 'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id',
+          aud: '',
+          iat: 0,
+          exp: 0,
+        },
+        protectedHeader: { alg: 'RS256' },
+        key: {} as CryptoKey,
+      });
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json(c.get('user')));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(res.status).toBe(200);
+
+      // createRemoteJWKSet should have been called with the custom JWKS_URI
+      expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+        new URL(
+          'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id/.well-known/jwks.json',
+        ),
+      );
+
+      // jwtVerify should have been called with the custom issuer
+      expect(jose.jwtVerify).toHaveBeenCalledWith(
+        'token',
+        expect.any(Function),
+        expect.objectContaining({
+          issuer:
+            'https://cognito-idp.ap-northeast-1.amazonaws.com/pool-id',
+        }),
+      );
+    });
+
+    it('JWT_AUDIENCE が設定されている場合は audience を検証すべき', async () => {
+      process.env.JWT_AUDIENCE = 'my-custom-api';
+
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockResolvedValue({
+        payload: {
+          sub: 'user-aud',
+          'https://tenkacloud.com/tenant_id': 'tenant-aud',
+          'https://tenkacloud.com/roles': ['user'],
+          iss: '',
+          aud: 'my-custom-api',
+          iat: 0,
+          exp: 0,
+        },
+        protectedHeader: { alg: 'RS256' },
+        key: {} as CryptoKey,
+      });
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json(c.get('user')));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer aud-token' },
+      });
+      expect(res.status).toBe(200);
+
+      expect(jose.jwtVerify).toHaveBeenCalledWith(
+        'aud-token',
+        expect.any(Function),
+        expect.objectContaining({ audience: 'my-custom-api' }),
+      );
+    });
+  });
+
+  // ─── 認証エラーケース ─────────────────────────────────
+  describe('認証エラーケース', () => {
+    it('Authorization ヘッダーがない場合は 401 を返すべき', async () => {
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json({ ok: true }));
+
+      const res = await app.request('/test');
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized: Missing Authorization header');
+    });
+
+    it('Bearer プレフィックスがない場合は 401 を返すべき', async () => {
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json({ ok: true }));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Basic invalid-format' },
+      });
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized: Invalid Authorization format');
+    });
+
+    it('JWT 検証失敗時に 401 を返すべき', async () => {
+      const jose = await import('jose');
+      vi.mocked(jose.jwtVerify).mockRejectedValue(
+        new Error('Invalid signature'),
+      );
+
+      const { authMiddleware } = await import('./auth');
+
+      const app = new Hono();
+      app.use('/*', authMiddleware);
+      app.get('/test', (c) => c.json({ ok: true }));
+
+      const res = await app.request('/test', {
+        headers: { Authorization: 'Bearer bad-token' },
+      });
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized: Invalid token');
+    });
+  });
+});

--- a/server/application/microservices/tenant-management/src/middleware/auth.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from 'hono';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import type { JWTVerifyOptions } from 'jose';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger('auth-middleware');
@@ -21,12 +22,18 @@ if (authSkipEnabled && typeof console !== 'undefined') {
   );
 }
 
-// Auth0 configuration
+// ── JWT / JWKS configuration ─────────────────────────
+// Primary: generic JWKS_URI / JWT_ISSUER (works with Cognito, Keycloak, etc.)
+// Fallback: Auth0-specific AUTH0_DOMAIN derivation
 const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN || 'dev-tenkacloud.auth0.com';
 const AUTH0_AUDIENCE =
   process.env.AUTH0_AUDIENCE || 'https://api.tenkacloud.com';
-const JWKS_URL = `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
 const AUTH0_NAMESPACE = 'https://tenkacloud.com';
+
+const JWKS_URL =
+  process.env.JWKS_URI ?? `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
+const JWT_ISSUER =
+  process.env.JWT_ISSUER ?? `https://${AUTH0_DOMAIN}/`;
 
 // Lazy initialization of JWKS to avoid startup failures
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
@@ -38,6 +45,28 @@ function getJWKS() {
   return jwksCache;
 }
 
+/**
+ * Sanitize dev header values to prevent header injection.
+ * Only allows alphanumeric, @, ., _, :, /, +, =, comma, hyphen.
+ */
+function sanitizeDevHeader(
+  value: string | undefined,
+  fallback: string,
+  maxLength = 128,
+): string {
+  if (!value) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  const sanitized = trimmed
+    .replace(/[^A-Za-z0-9@._:/+=,-]/g, '-')
+    .slice(0, maxLength);
+  return sanitized || fallback;
+}
+
 // User roles enum
 export enum UserRole {
   PLATFORM_ADMIN = 'platform-admin',
@@ -45,7 +74,7 @@ export enum UserRole {
   USER = 'user',
 }
 
-// Auth0 JWT payload interface
+// JWT payload interface — supports both Auth0 and Cognito claims
 export interface JWTPayload {
   sub: string;
   email?: string;
@@ -53,7 +82,11 @@ export interface JWTPayload {
   nickname?: string;
   picture?: string;
   org_id?: string;
+  // Cognito claims
+  'cognito:groups'?: string[];
+  'custom:tenant_id'?: string;
   [key: `${typeof AUTH0_NAMESPACE}/${string}`]: unknown;
+  [key: string]: unknown;
 }
 
 // Authenticated user context
@@ -74,36 +107,74 @@ declare module 'hono' {
 }
 
 function extractRoles(payload: JWTPayload): string[] {
+  // 1. Cognito: cognito:groups
+  const cognitoGroups = payload['cognito:groups'];
+  if (Array.isArray(cognitoGroups) && cognitoGroups.length > 0) {
+    return cognitoGroups as string[];
+  }
+
+  // 2. Auth0: namespace/roles
   const rolesKey = `${AUTH0_NAMESPACE}/roles` as const;
   const roles = payload[rolesKey];
   if (Array.isArray(roles)) {
     return roles as string[];
   }
+
   return [];
 }
 
 function extractTenantId(payload: JWTPayload): string | undefined {
+  // 1. Cognito: custom:tenant_id
+  const cognitoTenantId = payload['custom:tenant_id'];
+  if (typeof cognitoTenantId === 'string' && cognitoTenantId) {
+    return cognitoTenantId;
+  }
+
+  // 2. Auth0: namespace/tenant_id
   const tenantKey = `${AUTH0_NAMESPACE}/tenant_id` as const;
   const tenantId = payload[tenantKey];
   if (typeof tenantId === 'string') {
     return tenantId;
   }
+
   return undefined;
 }
 
 /**
- * JWT authentication middleware for Auth0
- * Validates JWT token from Authorization header and attaches user info to context
+ * JWT authentication middleware supporting Auth0 and Cognito.
+ * Validates JWT token from Authorization header and attaches user info to context.
  */
 export async function authMiddleware(c: Context, next: Next) {
-  // AUTH_SKIP=1: 開発用に JWT 検証をバイパス
+  // AUTH_SKIP=1: 開発用に JWT 検証をバイパス（dev ヘッダーで上書き可能）
   if (authSkipEnabled) {
+    const devRolesRaw =
+      c.req.header('X-TenkaCloud-Dev-Roles') ??
+      process.env.AUTH_SKIP_ROLES;
+    const devRoles = devRolesRaw
+      ? devRolesRaw
+          .split(',')
+          .map((r) => r.trim())
+          .filter(Boolean)
+      : [UserRole.PLATFORM_ADMIN];
+
     const mockUser: AuthenticatedUser = {
-      id: 'dev-user',
-      email: 'dev@tenkacloud.local',
-      username: 'Dev Admin',
-      roles: [UserRole.PLATFORM_ADMIN],
-      tenantId: 'dev-tenant',
+      id: sanitizeDevHeader(
+        c.req.header('X-TenkaCloud-Dev-User-Id'),
+        'dev-user',
+      ),
+      email: sanitizeDevHeader(
+        c.req.header('X-TenkaCloud-Dev-Email'),
+        'dev@tenkacloud.local',
+      ),
+      username: sanitizeDevHeader(
+        c.req.header('X-TenkaCloud-Dev-Username'),
+        'Dev Admin',
+      ),
+      roles: devRoles,
+      tenantId: sanitizeDevHeader(
+        c.req.header('X-TenkaCloud-Dev-Tenant-Id'),
+        'dev-tenant',
+      ),
     };
     c.set('user', mockUser);
     await next();
@@ -125,10 +196,20 @@ export async function authMiddleware(c: Context, next: Next) {
   }
 
   try {
-    const { payload } = await jwtVerify(token, getJWKS(), {
-      issuer: `https://${AUTH0_DOMAIN}/`,
-      audience: AUTH0_AUDIENCE,
-    });
+    const verifyOptions: JWTVerifyOptions = {
+      issuer: JWT_ISSUER,
+    };
+    // Only enforce audience when explicitly configured
+    if (process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE) {
+      verifyOptions.audience =
+        process.env.JWT_AUDIENCE ?? AUTH0_AUDIENCE;
+    }
+
+    const { payload } = await jwtVerify(
+      token,
+      getJWKS(),
+      verifyOptions,
+    );
 
     const jwtPayload = payload as unknown as JWTPayload;
 
@@ -254,10 +335,19 @@ export async function optionalAuth(c: Context, next: Next) {
   }
 
   try {
-    const { payload } = await jwtVerify(token, getJWKS(), {
-      issuer: `https://${AUTH0_DOMAIN}/`,
-      audience: AUTH0_AUDIENCE,
-    });
+    const verifyOptions: JWTVerifyOptions = {
+      issuer: JWT_ISSUER,
+    };
+    if (process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE) {
+      verifyOptions.audience =
+        process.env.JWT_AUDIENCE ?? AUTH0_AUDIENCE;
+    }
+
+    const { payload } = await jwtVerify(
+      token,
+      getJWKS(),
+      verifyOptions,
+    );
 
     const jwtPayload = payload as unknown as JWTPayload;
 

--- a/server/application/microservices/tenant-management/src/middleware/auth.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth.ts
@@ -34,6 +34,8 @@ const JWKS_URL =
   process.env.JWKS_URI ?? `https://${AUTH0_DOMAIN}/.well-known/jwks.json`;
 const JWT_ISSUER =
   process.env.JWT_ISSUER ?? `https://${AUTH0_DOMAIN}/`;
+const JWT_AUDIENCE =
+  process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE ?? AUTH0_AUDIENCE;
 
 // Lazy initialization of JWKS to avoid startup failures
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
@@ -199,9 +201,8 @@ export async function authMiddleware(c: Context, next: Next) {
     const verifyOptions: JWTVerifyOptions = {
       issuer: JWT_ISSUER,
     };
-    const audience = process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE ?? AUTH0_AUDIENCE;
-    if (audience) {
-      verifyOptions.audience = audience;
+    if (JWT_AUDIENCE) {
+      verifyOptions.audience = JWT_AUDIENCE;
     }
 
     const { payload } = await jwtVerify(
@@ -337,9 +338,8 @@ export async function optionalAuth(c: Context, next: Next) {
     const verifyOptions: JWTVerifyOptions = {
       issuer: JWT_ISSUER,
     };
-    const optAudience = process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE ?? AUTH0_AUDIENCE;
-    if (optAudience) {
-      verifyOptions.audience = optAudience;
+    if (JWT_AUDIENCE) {
+      verifyOptions.audience = JWT_AUDIENCE;
     }
 
     const { payload } = await jwtVerify(

--- a/server/application/microservices/tenant-management/src/middleware/auth.ts
+++ b/server/application/microservices/tenant-management/src/middleware/auth.ts
@@ -199,10 +199,9 @@ export async function authMiddleware(c: Context, next: Next) {
     const verifyOptions: JWTVerifyOptions = {
       issuer: JWT_ISSUER,
     };
-    // Only enforce audience when explicitly configured
-    if (process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE) {
-      verifyOptions.audience =
-        process.env.JWT_AUDIENCE ?? AUTH0_AUDIENCE;
+    const audience = process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE ?? AUTH0_AUDIENCE;
+    if (audience) {
+      verifyOptions.audience = audience;
     }
 
     const { payload } = await jwtVerify(
@@ -338,9 +337,9 @@ export async function optionalAuth(c: Context, next: Next) {
     const verifyOptions: JWTVerifyOptions = {
       issuer: JWT_ISSUER,
     };
-    if (process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE) {
-      verifyOptions.audience =
-        process.env.JWT_AUDIENCE ?? AUTH0_AUDIENCE;
+    const optAudience = process.env.JWT_AUDIENCE ?? process.env.AUTH0_AUDIENCE ?? AUTH0_AUDIENCE;
+    if (optAudience) {
+      verifyOptions.audience = optAudience;
     }
 
     const { payload } = await jwtVerify(


### PR DESCRIPTION
## Summary

- Replace Auth0 provider with Cognito in Application Plane `auth.ts`
  - `cognito:groups` for roles, `custom:tenant_id` / `custom:team_id` for tenant context
  - Auth0 namespace claims kept as fallback for backward compatibility
  - Add `SKIP_PROVIDER_VALIDATION`, `getSession()` helper
- Update all 6 backend microservice auth middlewares for Cognito JWT claims
  - gameday, battle, scoring, leaderboard: `cognito:groups` + `custom:tenant_id` with Keycloak fallback
  - problem-service: add `JWKS_URI` / `JWT_ISSUER` env vars (Keycloak URL fallback)
  - tenant-management: add `JWKS_URI` / `JWT_ISSUER`, Cognito claims, dev header support
- Split tenant-management auth tests into 5 focused files (was 780 lines)
- Fix assertion roulette in problem-service and tenant-management tests

## Test plan

- [ ] `make before-commit` passes (lint, format, typecheck, test 99%+, build)
- [ ] AUTH_SKIP mode works locally with `make start`
- [ ] Cognito JWT claims extracted correctly (tested via unit tests)
- [ ] Auth0/Keycloak fallback claims still work (backward compat tests)
- [ ] Dev headers forwarded in AUTH_SKIP mode for all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable JWT verification via JWKS_URI/JWT_ISSUER (optional audience) and a session helper honoring dev skip mode.
  * Dev-mode header overrides for user identity and roles with input sanitization.
  * Added Cognito claim support (groups/tenant) while keeping fallbacks.

* **Bug Fixes**
  * Clearer claim precedence across Cognito/Keycloak/Auth0 and explicit 401 when token subject is missing.

* **Tests**
  * Significantly expanded auth tests: providers, skip-mode, dev overrides, JWT claim extraction, and multi-service coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->