### PR TITLE
feat: implement problem deployment trigger via EventBridge

### DIFF
--- a/infrastructure/templates/sample-s3-security.yaml
+++ b/infrastructure/templates/sample-s3-security.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  GameDay Challenge - S3 Security Misconfiguration.
+  Creates an S3 bucket with intentionally weak security settings.
+  Participants must identify and fix the vulnerabilities.
+
+Parameters:
+  ProblemId:
+    Type: String
+    Description: Problem identifier
+  TeamId:
+    Type: String
+    Description: Team identifier
+  TenantId:
+    Type: String
+    Description: Tenant identifier
+
+Resources:
+  VulnerableBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "tc-challenge-${TeamId}-${ProblemId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      Tags:
+        - Key: TenantId
+          Value: !Ref TenantId
+        - Key: ProblemId
+          Value: !Ref ProblemId
+        - Key: TeamId
+          Value: !Ref TeamId
+        - Key: ManagedBy
+          Value: tenkacloud
+
+Outputs:
+  BucketName:
+    Description: Name of the vulnerable S3 bucket
+    Value: !Ref VulnerableBucket
+  BucketArn:
+    Description: ARN of the vulnerable S3 bucket
+    Value: !GetAtt VulnerableBucket.Arn

--- a/server/application/libs/events/src/types.ts
+++ b/server/application/libs/events/src/types.ts
@@ -116,6 +116,31 @@ export interface TenantOffboardingDetail {
 }
 
 // =============================================================================
+// Problem Deployment Event Types
+// =============================================================================
+
+/**
+ * ProblemDeployRequested イベントの詳細
+ * GameDay 問題デプロイ時に problem-service が発火 → ProblemDeployPlane が処理
+ */
+export interface ProblemDeployRequestedDetail {
+  /** 問題 ID */
+  problemId: string;
+  /** チーム ID */
+  teamId: string;
+  /** テナント ID */
+  tenantId: string;
+  /** デプロイ先 IAM Role ARN（cross-account AssumeRole） */
+  targetRoleArn: string;
+  /** Confused Deputy 防止用 ExternalId */
+  externalId: string;
+  /** CloudFormation テンプレート URL */
+  templateUrl: string;
+  /** イベント発生時刻 (ISO 8601) */
+  timestamp: string;
+}
+
+// =============================================================================
 // Event Type Constants
 // =============================================================================
 
@@ -127,6 +152,7 @@ export const EventDetailType = {
   TENANT_PROVISIONED: 'TenantProvisioned',
   TENANT_UPDATED: 'TenantUpdated',
   TENANT_OFFBOARDING: 'TenantOffboarding',
+  PROBLEM_DEPLOY_REQUESTED: 'ProblemDeployRequested',
 } as const;
 
 export type EventDetailType =
@@ -138,6 +164,7 @@ export type EventDetailType =
 export const EventSource = {
   CONTROL_PLANE: 'tenkacloud.control-plane',
   APPLICATION_PLANE: 'tenkacloud.application-plane',
+  PROBLEM_SERVICE: 'tenkacloud.problem-service',
 } as const;
 
 export type EventSource = (typeof EventSource)[keyof typeof EventSource];
@@ -193,4 +220,5 @@ export type EventDetailMap = {
   TenantProvisioned: TenantProvisionedDetail;
   TenantUpdated: TenantUpdatedDetail;
   TenantOffboarding: TenantOffboardingDetail;
+  ProblemDeployRequested: ProblemDeployRequestedDetail;
 };

--- a/server/application/microservices/problem-service/package.json
+++ b/server/application/microservices/problem-service/package.json
@@ -32,6 +32,7 @@
     "@prisma/client": "^5.22.0",
     "@scalar/hono-api-reference": "^0.10.6",
     "@tenkacloud/dynamodb": "workspace:*",
+    "@tenkacloud/events": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "hono": "^4.12.10",
@@ -54,12 +55,16 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-cloudformation": "^3.0.0",
+    "@aws-sdk/client-eventbridge": "^3.0.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@aws-sdk/client-lambda": "^3.0.0",
     "@aws-sdk/client-sts": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-cloudformation": {
+      "optional": true
+    },
+    "@aws-sdk/client-eventbridge": {
       "optional": true
     },
     "@aws-sdk/client-s3": {

--- a/server/application/microservices/problem-service/src/problems/__tests__/deploy-publisher.test.ts
+++ b/server/application/microservices/problem-service/src/problems/__tests__/deploy-publisher.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ProblemDeployPublisher Tests
+ *
+ * EventBridge を使った問題デプロイイベントの publish をテストする。
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ProblemDeployRequestedDetail } from "@tenkacloud/events";
+
+// ============================================================
+// モック
+// ============================================================
+
+const mocks = vi.hoisted(() => ({
+	mockSend: vi.fn(),
+	mockDeployProblem: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-eventbridge", () => {
+	return {
+		EventBridgeClient: class {
+			send = mocks.mockSend;
+		},
+		PutEventsCommand: class {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+		},
+	};
+});
+
+vi.mock("../../../../../../lib/handlers/deploy-problem.ts", () => ({
+	deployProblem: mocks.mockDeployProblem,
+}));
+
+// ============================================================
+// テストデータ
+// ============================================================
+
+const makeDetail = (
+	overrides: Partial<ProblemDeployRequestedDetail> = {},
+): ProblemDeployRequestedDetail => ({
+	problemId: "problem-1",
+	teamId: "team-1",
+	tenantId: "tenant-1",
+	targetRoleArn: "arn:aws:iam::123456789012:role/DeployRole",
+	externalId: "ext-id-123",
+	templateUrl: "https://s3.amazonaws.com/bucket/template.yaml",
+	timestamp: "2026-01-01T00:00:00.000Z",
+	...overrides,
+});
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("ProblemDeployPublisher", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("EventBridge モード", () => {
+		it("EventBridge モードでイベントを publish すべき", async () => {
+			const { ProblemDeployPublisher } = await import("../deploy-publisher");
+
+			mocks.mockSend.mockResolvedValueOnce({
+				FailedEntryCount: 0,
+				Entries: [{ EventId: "evt-1" }],
+			});
+
+			const publisher = new ProblemDeployPublisher({
+				deliveryMode: "eventbridge",
+				eventBusName: "test-bus",
+			});
+
+			const detail = makeDetail();
+			await publisher.publishDeployRequested(detail);
+
+			expect(mocks.mockSend).toHaveBeenCalledOnce();
+
+			const command = mocks.mockSend.mock.calls[0][0];
+			const entry = command.input.Entries[0];
+
+			expect(entry.EventBusName).toBe("test-bus");
+			expect(entry.Source).toBe("tenkacloud.problem-service");
+			expect(entry.DetailType).toBe("ProblemDeployRequested");
+
+			const parsed = JSON.parse(entry.Detail);
+			expect(parsed.problemId).toBe("problem-1");
+			expect(parsed.teamId).toBe("team-1");
+			expect(parsed.tenantId).toBe("tenant-1");
+			expect(parsed.targetRoleArn).toBe(
+				"arn:aws:iam::123456789012:role/DeployRole",
+			);
+		});
+
+		it("EventBridge 送信失敗時にエラーを投げるべき", async () => {
+			const { ProblemDeployPublisher } = await import("../deploy-publisher");
+
+			mocks.mockSend.mockResolvedValueOnce({
+				FailedEntryCount: 1,
+				Entries: [
+					{
+						ErrorCode: "InternalFailure",
+						ErrorMessage: "Service unavailable",
+					},
+				],
+			});
+
+			const publisher = new ProblemDeployPublisher({
+				deliveryMode: "eventbridge",
+				eventBusName: "test-bus",
+			});
+
+			await expect(
+				publisher.publishDeployRequested(makeDetail()),
+			).rejects.toThrow(
+				"Failed to publish problem deploy event: InternalFailure - Service unavailable",
+			);
+		});
+	});
+
+	describe("inline モード", () => {
+		it("inline モードでは deployProblem を直接呼ぶべき", async () => {
+			const { ProblemDeployPublisher } = await import("../deploy-publisher");
+
+			mocks.mockDeployProblem.mockResolvedValueOnce({
+				deployStatus: "completed",
+			});
+
+			const publisher = new ProblemDeployPublisher({
+				deliveryMode: "inline",
+			});
+
+			const detail = makeDetail();
+			await publisher.publishDeployRequested(detail);
+
+			expect(mocks.mockSend).not.toHaveBeenCalled();
+			expect(mocks.mockDeployProblem).toHaveBeenCalledOnce();
+			expect(mocks.mockDeployProblem).toHaveBeenCalledWith({
+				problemId: "problem-1",
+				teamId: "team-1",
+				tenantId: "tenant-1",
+				targetRoleArn: "arn:aws:iam::123456789012:role/DeployRole",
+				externalId: "ext-id-123",
+				templateUrl: "https://s3.amazonaws.com/bucket/template.yaml",
+				appName: "tenkacloud",
+			});
+		});
+
+		it("inline モードでデプロイ失敗時にエラーを投げるべき", async () => {
+			const { ProblemDeployPublisher } = await import("../deploy-publisher");
+
+			mocks.mockDeployProblem.mockResolvedValueOnce({
+				deployStatus: "failed",
+			});
+
+			const publisher = new ProblemDeployPublisher({
+				deliveryMode: "inline",
+			});
+
+			await expect(
+				publisher.publishDeployRequested(makeDetail()),
+			).rejects.toThrow(
+				"Problem deployment failed for problem problem-1 team team-1",
+			);
+		});
+
+		it("カスタム inlineRunner を使用できるべき", async () => {
+			const { ProblemDeployPublisher } = await import("../deploy-publisher");
+
+			const customRunner = vi.fn().mockResolvedValue(undefined);
+			const publisher = new ProblemDeployPublisher({
+				deliveryMode: "inline",
+				inlineRunner: customRunner,
+			});
+
+			const detail = makeDetail();
+			await publisher.publishDeployRequested(detail);
+
+			expect(customRunner).toHaveBeenCalledOnce();
+			expect(customRunner).toHaveBeenCalledWith(detail);
+			expect(mocks.mockSend).not.toHaveBeenCalled();
+			expect(mocks.mockDeployProblem).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/server/application/microservices/problem-service/src/problems/deploy-publisher.ts
+++ b/server/application/microservices/problem-service/src/problems/deploy-publisher.ts
@@ -1,0 +1,126 @@
+/**
+ * Problem Deploy Publisher
+ *
+ * GameDay 問題デプロイイベントを EventBridge に publish する。
+ * ローカル開発では inline モードで直接 deployProblem を呼び出す。
+ */
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from '@aws-sdk/client-eventbridge';
+import {
+  EventBusName,
+  EventDetailType,
+  EventSource,
+  type ProblemDeployRequestedDetail,
+} from '@tenkacloud/events';
+
+export type ProblemDeployDeliveryMode = 'eventbridge' | 'inline';
+
+type InlineDeployRunner = (
+  detail: ProblemDeployRequestedDetail,
+) => Promise<void>;
+
+interface ProblemDeployPublisherOptions {
+  eventBridgeClient?: EventBridgeClient;
+  eventBusName?: string;
+  deliveryMode?: ProblemDeployDeliveryMode;
+  inlineRunner?: InlineDeployRunner;
+}
+
+function resolveDeliveryMode(): ProblemDeployDeliveryMode {
+  const configuredMode = process.env.PROBLEM_DEPLOY_DELIVERY_MODE;
+  if (
+    configuredMode === 'inline' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    return 'inline';
+  }
+  if (
+    !configuredMode &&
+    process.env.NODE_ENV !== 'production' &&
+    typeof process.env.AWS_ENDPOINT_URL === 'string' &&
+    process.env.AWS_ENDPOINT_URL.includes('localhost')
+  ) {
+    return 'inline';
+  }
+  return 'eventbridge';
+}
+
+async function runInlineDeployFlow(
+  detail: ProblemDeployRequestedDetail,
+): Promise<void> {
+  const { deployProblem } = await import(
+    '../../../../../lib/handlers/deploy-problem.ts'
+  );
+
+  const result = await deployProblem({
+    problemId: detail.problemId,
+    teamId: detail.teamId,
+    tenantId: detail.tenantId,
+    targetRoleArn: detail.targetRoleArn,
+    externalId: detail.externalId,
+    templateUrl: detail.templateUrl,
+    appName: 'tenkacloud',
+  });
+
+  if (result.deployStatus !== 'completed') {
+    throw new Error(
+      `Problem deployment failed for problem ${detail.problemId} team ${detail.teamId}`,
+    );
+  }
+}
+
+export class ProblemDeployPublisher {
+  private readonly eventBridgeClient: EventBridgeClient;
+  private readonly eventBusName: string;
+  private readonly deliveryMode: ProblemDeployDeliveryMode;
+  private readonly inlineRunner: InlineDeployRunner;
+
+  constructor(options: ProblemDeployPublisherOptions = {}) {
+    this.eventBridgeClient =
+      options.eventBridgeClient ??
+      new EventBridgeClient({
+        ...(process.env.AWS_ENDPOINT_URL
+          ? { endpoint: process.env.AWS_ENDPOINT_URL }
+          : {}),
+      });
+    this.eventBusName =
+      options.eventBusName ??
+      process.env.PROBLEM_DEPLOY_EVENT_BUS_NAME ??
+      process.env.EVENT_BUS_NAME ??
+      EventBusName.DEFAULT;
+    this.deliveryMode = options.deliveryMode ?? resolveDeliveryMode();
+    this.inlineRunner = options.inlineRunner ?? runInlineDeployFlow;
+  }
+
+  async publishDeployRequested(
+    detail: ProblemDeployRequestedDetail,
+  ): Promise<void> {
+    if (this.deliveryMode === 'inline') {
+      await this.inlineRunner(detail);
+      return;
+    }
+
+    const response = await this.eventBridgeClient.send(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: this.eventBusName,
+            Source: EventSource.PROBLEM_SERVICE,
+            DetailType: EventDetailType.PROBLEM_DEPLOY_REQUESTED,
+            Detail: JSON.stringify(detail),
+          },
+        ],
+      }),
+    );
+
+    if ((response.FailedEntryCount ?? 0) > 0) {
+      const failedEntry = response.Entries?.find((entry) => entry.ErrorCode);
+      throw new Error(
+        `Failed to publish problem deploy event: ${failedEntry?.ErrorCode ?? 'UnknownError'} - ${failedEntry?.ErrorMessage ?? 'Unknown error'}`,
+      );
+    }
+  }
+}

--- a/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
+++ b/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
@@ -94,6 +94,7 @@ export function getGameDayDeploymentValidationError(
 export async function deployProblemToTeams(
 	problem: Problem,
 	eventId: string,
+	tenantId?: string,
 	concurrency = 10,
 ): Promise<DeploymentJob[]> {
 	const accounts = await accountRepo.findByEventId(eventId);
@@ -146,7 +147,7 @@ export async function deployProblemToTeams(
 			const detail: ProblemDeployRequestedDetail = {
 				problemId: problem.id,
 				teamId: account.id,
-				tenantId: eventId,
+				tenantId: tenantId ?? eventId,
 				targetRoleArn: account.roleArn,
 				externalId: account.externalId,
 				templateUrl,
@@ -154,6 +155,7 @@ export async function deployProblemToTeams(
 			};
 			try {
 				await deployPublisher.publishDeployRequested(detail);
+				await jobRepo.updateStatus(eventId, problem.id, job.id, "in_progress");
 			} catch (error) {
 				await jobRepo.updateStatus(eventId, problem.id, job.id, "failed", {
 					error: error instanceof Error ? error.message : "EventBridge publish failed",

--- a/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
+++ b/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
@@ -5,6 +5,7 @@
  * ジョブ状態は DynamoDB で永続化する。
  */
 
+import type { ProblemDeployRequestedDetail } from "@tenkacloud/events";
 import { getAWSProvider } from "../providers/aws";
 import { getLocalProvider } from "../providers/local";
 import {
@@ -21,6 +22,7 @@ import type {
 	Problem,
 } from "../types";
 import type { DeployStackOptions } from "../providers/interface";
+import { ProblemDeployPublisher } from "./deploy-publisher";
 
 /** SSE サブスクライバー管理 (in-memory) */
 const subscribers = new Map<
@@ -59,6 +61,7 @@ export function subscribeToJob(
 
 const jobRepo = new GameDayDeploymentJobRepository();
 const accountRepo = new CompetitorAccountRepository();
+const deployPublisher = new ProblemDeployPublisher();
 
 export function getGameDayDeploymentValidationError(
 	problem: Pick<Problem, "type" | "deployment">,
@@ -125,7 +128,29 @@ export async function deployProblemToTeams(
 		jobs.push(job);
 	}
 
-	// 非同期で並列デプロイ開始（レスポンスを待たない）
+	// EventBridge モードの場合はイベントを publish（CDK ProblemDeployPlane が処理）
+	if (process.env.PROBLEM_DEPLOY_DELIVERY_MODE === "eventbridge") {
+		const templateUrl =
+			problem.deployment.templates.aws?.path ?? "";
+		for (const job of jobs) {
+			const account = accounts.find((a) => a.id === job.competitorAccountId);
+			if (!account) continue;
+
+			const detail: ProblemDeployRequestedDetail = {
+				problemId: problem.id,
+				teamId: account.id,
+				tenantId: eventId,
+				targetRoleArn: account.roleArn ?? "",
+				externalId: account.externalId ?? "",
+				templateUrl,
+				timestamp: new Date().toISOString(),
+			};
+			void deployPublisher.publishDeployRequested(detail);
+		}
+		return jobs;
+	}
+
+	// ローカル開発: 非同期で並列デプロイ開始（レスポンスを待たない）
 	void runDeployments(jobs, problem, accounts, concurrency);
 
 	return jobs;

--- a/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
+++ b/server/application/microservices/problem-service/src/problems/gameday-deployer.ts
@@ -136,16 +136,29 @@ export async function deployProblemToTeams(
 			const account = accounts.find((a) => a.id === job.competitorAccountId);
 			if (!account) continue;
 
+			if (!account.roleArn || !account.externalId) {
+				await jobRepo.updateStatus(eventId, problem.id, job.id, "failed", {
+					error: `Missing roleArn or externalId for account ${account.id}`,
+				});
+				continue;
+			}
+
 			const detail: ProblemDeployRequestedDetail = {
 				problemId: problem.id,
 				teamId: account.id,
 				tenantId: eventId,
-				targetRoleArn: account.roleArn ?? "",
-				externalId: account.externalId ?? "",
+				targetRoleArn: account.roleArn,
+				externalId: account.externalId,
 				templateUrl,
 				timestamp: new Date().toISOString(),
 			};
-			void deployPublisher.publishDeployRequested(detail);
+			try {
+				await deployPublisher.publishDeployRequested(detail);
+			} catch (error) {
+				await jobRepo.updateStatus(eventId, problem.id, job.id, "failed", {
+					error: error instanceof Error ? error.message : "EventBridge publish failed",
+				});
+			}
 		}
 		return jobs;
 	}

--- a/server/application/microservices/problem-service/src/routes/admin.ts
+++ b/server/application/microservices/problem-service/src/routes/admin.ts
@@ -3163,7 +3163,7 @@ adminRouter.post(
 		}
 
 		try {
-			const jobs = await deployProblemToTeams(problem, eventId);
+			const jobs = await deployProblemToTeams(problem, eventId, event.tenantId);
 			return c.json({ jobs }, 202);
 		} catch (error) {
 			logger.error({ error }, "Failed to deploy problem to teams");


### PR DESCRIPTION
## Summary

- Add `ProblemDeployRequestedDetail` event type to `@tenkacloud/events`
- Create `ProblemDeployPublisher` in problem-service following tenant-management pattern
  - EventBridge mode: publishes `problem.deploy.requested` events for CDK ProblemDeployPlane
  - Inline mode: calls `deployProblem` handler directly for local dev
- Integrate into `gameday-deployer.ts`: event-driven deploy when `PROBLEM_DEPLOY_DELIVERY_MODE=eventbridge`
- Add sample S3 security challenge CloudFormation template

## Event flow

```
Admin triggers deploy → problem-service creates jobs
  → publishes ProblemDeployRequested per team
    → EventBridge → ProblemDeployPlane (CodeBuild)
      → STS AssumeRole → CloudFormation in team account
```

## Test plan

- [ ] 5 new publisher tests pass (eventbridge, inline, error cases)
- [ ] Existing 790 problem-service tests still pass
- [ ] Local dev: `PROBLEM_DEPLOY_DELIVERY_MODE=inline` uses direct handler
- [ ] AWS: `PROBLEM_DEPLOY_DELIVERY_MODE=eventbridge` publishes to EventBridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for asynchronous problem deployment with configurable event delivery (EventBridge or inline mode).

* **Tests**
  * Added test coverage for deployment event publishing across delivery modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->