### PR TITLE
feat: add make test_one_pass_local target for E2E harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,16 @@ build:
 		$(NR) build) || exit 1; \
 	done
 
+######## One-Pass E2E ########
+
+#? test_one_pass_local: Run one-pass E2E harness (requires make start)
+test_one_pass_local:
+	@$(BUN) scripts/one-pass.ts --target local --allow-blocked
+
+#? test_one_pass_local_strict: Run one-pass E2E harness (fails on blocked steps)
+test_one_pass_local_strict:
+	@$(BUN) scripts/one-pass.ts --target local
+
 ######## Data ########
 
 #? seed: Initialize DB tables and seed demo data


### PR DESCRIPTION
## Summary

Add Makefile targets to run the one-pass E2E harness:

```bash
make start                    # Start all services
make test_one_pass_local      # Run E2E (shows blocked steps)
make test_one_pass_local_strict  # Fails on any blocked step
```

The 18-step one-pass script (`scripts/one-pass.ts`) is already implemented:

| Step | Description |
|------|-------------|
| 01-03 | Service health checks |
| 04-05 | Tenant create + provisioning |
| 06 | Application Plane runtime |
| 07 | Admin access probe |
| 08-10 | Event + problem create + attach |
| 11 | Local problem deploy |
| 12 | Competitor account register |
| 13-16 | Participant flow (register, join, team) |
| 17 | Attack / defense / vote |
| 18 | AWS Console federation |

## Test plan

- [ ] `make start` then `make test_one_pass_local` produces report
- [ ] Passed steps match running services

🤖 Generated with [Claude Code](https://claude.com/claude-code)