### PR TITLE
feat: connect tenant runtime and deploy records to participant flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,23 @@ make start      # 全サービス起動（Docker + UI + Backend 11 サービス�
 
 ## 品質ゲート
 
+PR 作成前に以下を **この順序で** 実行する。
+
 ```bash
 bun scripts/architecture-harness.ts --staged --fail-on=error
 make before-commit   # lint, format, typecheck, test (99％+ coverage), build
+/review              # コードレビュー
+/security-review     # セキュリティレビュー
+/simplify            # コード重複・品質・効率チェック
 ```
 
-**これが通らない限りタスクは未完了。** 失敗したらコードを修正する（設定ファイルを変えない）。
+**すべて通らない限りタスクは未完了。** 失敗したらコードを修正する（設定ファイルを変えない）。
+
+### 作業順序（厳守）
+
+新規機能を追加する前に以下を実施する。
+1. **ドキュメント更新** — 関連する docs/, ADR, CLAUDE.md を先に更新する。
+2. **リファクタリング** — 技術的負債を先に解消する（`bun scripts/ai-improvement-loop.ts --staged --fail-on=high`）。
 
 アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) です。`Codex` と `Claude Code` のどちらでも、この script を通らない変更は未完了です。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,23 @@
 
 ## ゲート
 
-タスク完了前に必ず `make before-commit` を実行。lint・format・typecheck・test（カバレッジ 99％+）・build がすべて通るまで未完了。失敗したら原因を特定してコードを修正する（設定ファイルを変更しない）。
+### PR 作成前の必須チェック（この順序で実行）
 
-その前に `bun scripts/architecture-harness.ts --staged --fail-on=error` を通す。アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) で、これは `Codex` と `Claude Code` の両方に共通です。
+1. `bun scripts/architecture-harness.ts --staged --fail-on=error`
+2. `make before-commit` — lint・format・typecheck・test（カバレッジ 99％+）・build
+3. `/review` — コードレビュー（品質・慣習・リスク）
+4. `/security-review` — セキュリティレビュー（認証・認可・インジェクション）
+5. `/simplify` — コード重複・品質・効率の最終チェック
+
+すべて通るまで未完了。失敗したら原因を特定してコードを修正する（設定ファイルを変更しない）。
+
+アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) で、これは `Codex` と `Claude Code` の両方に共通です。
+
+### 作業順序
+
+新規機能を追加する前に、以下を先に実施する。
+1. **ドキュメント更新** — 変更に関連する docs/, ADR, CLAUDE.md を先に更新する。
+2. **リファクタリング** — 技術的負債（`bun scripts/ai-improvement-loop.ts --staged --fail-on=high` で検出）を先に解消する。
 
 ## コマンド体系
 

--- a/client/AdminWeb/components/tenants/__tests__/provisioning-card.test.tsx
+++ b/client/AdminWeb/components/tenants/__tests__/provisioning-card.test.tsx
@@ -113,6 +113,45 @@ describe('ProvisioningCard コンポーネント', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('デプロイ済みで applicationPlaneEndpoint がある場合はリンクを表示すべき', () => {
+      render(
+        <ProvisioningCard
+          tenant={createMockTenant({
+            applicationDeploymentStatus: 'DEPLOYED',
+            applicationPlaneEndpoint:
+              'http://localhost:13001?tenant=test-tenant',
+          })}
+        />,
+      );
+      const link = screen.getByRole('link', {
+        name: 'http://localhost:13001?tenant=test-tenant',
+      });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute(
+        'href',
+        'http://localhost:13001?tenant=test-tenant',
+      );
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('未デプロイ状態では applicationPlaneEndpoint リンクを表示しないべき', () => {
+      render(
+        <ProvisioningCard
+          tenant={createMockTenant({
+            applicationDeploymentStatus: 'NOT_DEPLOYED',
+            applicationPlaneEndpoint:
+              'http://localhost:13001?tenant=test-tenant',
+          })}
+        />,
+      );
+      expect(
+        screen.queryByRole('link', {
+          name: 'http://localhost:13001?tenant=test-tenant',
+        }),
+      ).not.toBeInTheDocument();
+    });
+
     it('その他の作成済みリソースとエラーを表示すべき', () => {
       render(
         <ProvisioningCard

--- a/client/AdminWeb/components/tenants/__tests__/provisioning-card.test.tsx
+++ b/client/AdminWeb/components/tenants/__tests__/provisioning-card.test.tsx
@@ -135,6 +135,21 @@ describe('ProvisioningCard コンポーネント', () => {
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
+    it('安全でない URL スキームの applicationPlaneEndpoint はリンクではなくテキストで表示すべき', () => {
+      render(
+        <ProvisioningCard
+          tenant={createMockTenant({
+            applicationDeploymentStatus: 'DEPLOYED',
+            applicationPlaneEndpoint: 'javascript:alert(1)',
+          })}
+        />,
+      );
+      expect(
+        screen.queryByRole('link', { name: 'javascript:alert(1)' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+    });
+
     it('未デプロイ状態では applicationPlaneEndpoint リンクを表示しないべき', () => {
       render(
         <ProvisioningCard

--- a/client/AdminWeb/components/tenants/provisioning-card.tsx
+++ b/client/AdminWeb/components/tenants/provisioning-card.tsx
@@ -42,6 +42,14 @@ const applicationStatusColors: Record<ApplicationDeploymentStatus, string> = {
     'border border-rose-500/20 bg-rose-500/10 text-rose-800 dark:text-rose-300',
 };
 
+function isSafeUrl(url: string): boolean {
+  try {
+    return ['http:', 'https:'].includes(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
 interface ProvisioningCardProps {
   tenant: Tenant;
 }
@@ -106,14 +114,20 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
               </span>
               {applicationDeploymentStatus === 'DEPLOYED' &&
               tenant.applicationPlaneEndpoint ? (
-                <a
-                  href={tenant.applicationPlaneEndpoint}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-sky-600 underline hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-200"
-                >
-                  {tenant.applicationPlaneEndpoint}
-                </a>
+                isSafeUrl(tenant.applicationPlaneEndpoint) ? (
+                  <a
+                    href={tenant.applicationPlaneEndpoint}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-sky-600 underline hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-200"
+                  >
+                    {tenant.applicationPlaneEndpoint}
+                  </a>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    {tenant.applicationPlaneEndpoint}
+                  </span>
+                )
               ) : null}
             </dd>
           </div>

--- a/client/AdminWeb/components/tenants/provisioning-card.tsx
+++ b/client/AdminWeb/components/tenants/provisioning-card.tsx
@@ -98,12 +98,23 @@ export function ProvisioningCard({ tenant }: ProvisioningCardProps) {
             <dt className="text-sm font-medium text-muted-foreground">
               Application Plane
             </dt>
-            <dd className="col-span-2">
+            <dd className="col-span-2 flex items-center gap-2">
               <span
                 className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${applicationStatusColors[applicationDeploymentStatus]}`}
               >
                 {applicationStatusLabels[applicationDeploymentStatus]}
               </span>
+              {applicationDeploymentStatus === 'DEPLOYED' &&
+              tenant.applicationPlaneEndpoint ? (
+                <a
+                  href={tenant.applicationPlaneEndpoint}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-sky-600 underline hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-200"
+                >
+                  {tenant.applicationPlaneEndpoint}
+                </a>
+              ) : null}
             </dd>
           </div>
           <div className="grid grid-cols-3 items-center gap-4">

--- a/client/AdminWeb/lib/api/mock-tenant-api.ts
+++ b/client/AdminWeb/lib/api/mock-tenant-api.ts
@@ -151,6 +151,7 @@ export const mockTenantApi = {
     tenantId: string;
     provisioningStatus: string;
     applicationDeploymentStatus?: string;
+    applicationPlaneEndpoint?: string;
     provisioningEnabled: boolean;
   } | null> {
     await delay(300);
@@ -161,6 +162,7 @@ export const mockTenantApi = {
       provisioningStatus: tenant.provisioningStatus,
       applicationDeploymentStatus:
         tenant.applicationDeploymentStatus ?? 'NOT_DEPLOYED',
+      applicationPlaneEndpoint: tenant.applicationPlaneEndpoint,
       provisioningEnabled: true,
     };
   },

--- a/client/AdminWeb/lib/api/sbt-api-adapter.ts
+++ b/client/AdminWeb/lib/api/sbt-api-adapter.ts
@@ -210,6 +210,7 @@ export function createSbtTenantApi(
     async getProvisioningStatus(id: string): Promise<{
       tenantId: string;
       provisioningStatus: string;
+      applicationPlaneEndpoint?: string;
       provisioningEnabled: boolean;
     } | null> {
       try {

--- a/client/AdminWeb/lib/api/tenant-api.ts
+++ b/client/AdminWeb/lib/api/tenant-api.ts
@@ -129,6 +129,7 @@ const localTenantApi = {
     tenantId: string;
     provisioningStatus: string;
     applicationDeploymentStatus?: string;
+    applicationPlaneEndpoint?: string;
     provisionedResources?: unknown;
     provisioningError?: string | null;
     provisionedAt?: string | null;
@@ -142,6 +143,7 @@ const localTenantApi = {
       tenantId: string;
       provisioningStatus: string;
       applicationDeploymentStatus?: string;
+      applicationPlaneEndpoint?: string;
       provisionedResources?: unknown;
       provisioningError?: string | null;
       provisionedAt?: string | null;

--- a/client/AdminWeb/types/tenant.ts
+++ b/client/AdminWeb/types/tenant.ts
@@ -157,6 +157,7 @@ export interface Tenant {
   computeType: ComputeType;
   provisioningStatus: ProvisioningStatus;
   applicationDeploymentStatus?: ApplicationDeploymentStatus;
+  applicationPlaneEndpoint?: string;
   provisionedResources?: TenantProvisionedResources;
   provisioningError?: string;
   provisionedAt?: string;

--- a/client/Application/app/(participant)/gameday/[eventId]/attack/__tests__/page.test.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/attack/__tests__/page.test.tsx
@@ -18,6 +18,17 @@ vi.mock('@/lib/hooks/use-gameday-session', () => ({
   }),
 }));
 
+const mockDeploymentResult = {
+  isReady: true,
+  isChecking: false,
+  status: { deployed: true, status: 'completed' },
+  checkError: null,
+};
+
+vi.mock('@/lib/hooks/use-deployment-status', () => ({
+  useDeploymentStatus: () => mockDeploymentResult,
+}));
+
 const mockGetAttackCatalog = vi.fn();
 const mockGetAttackHistory = vi.fn();
 const mockGetParticipantTeams = vi.fn();
@@ -67,6 +78,10 @@ describe('AttackPage', () => {
         { teamId: 'team-2', teamName: 'TeamBeta' },
       ],
     });
+    mockDeploymentResult.isReady = true;
+    mockDeploymentResult.isChecking = false;
+    mockDeploymentResult.status = { deployed: true, status: 'completed' };
+    mockDeploymentResult.checkError = null;
   });
 
   it('ローディング中は攻撃カタログを表示しないべき', () => {
@@ -129,5 +144,39 @@ describe('AttackPage', () => {
 
     // Purchase button shows cost
     expect(screen.getByText(/Purchase.*100 pts/)).toBeInTheDocument();
+  });
+
+  it('デプロイ未完了時に警告メッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'pending',
+    };
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment deployment has not been completed yet. Please contact your administrator.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('デプロイ中に進捗メッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'in_progress',
+    };
+    render(<AttackPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment is being deployed. Please wait a moment.',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/client/Application/app/(participant)/gameday/[eventId]/attack/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/attack/page.tsx
@@ -29,18 +29,13 @@ import {
   purchaseAttack,
 } from '@/lib/api/gameday';
 import type { Attack, AttackLog, CooldownError } from '@/lib/api/gameday-types';
-import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
+import { DeploymentGate } from '@/components/gameday/deployment-gate';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 
 export default function AttackPage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
-  const {
-    isReady,
-    isChecking,
-    status: deploymentStatus,
-  } = useDeploymentStatus(eventId);
   const [catalog, setCatalog] = useState<Attack[]>([]);
   const [history, setHistory] = useState<AttackLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -127,7 +122,7 @@ export default function AttackPage() {
     }
   };
 
-  if (loading || isChecking) {
+  if (loading) {
     return (
       <Box textAlign="center" padding="xxl">
         <Spinner size="large" />
@@ -148,32 +143,6 @@ export default function AttackPage() {
     );
   }
 
-  if (!isReady && deploymentStatus) {
-    const message =
-      deploymentStatus.status === 'in_progress'
-        ? t('gameday.deploymentInProgress')
-        : deploymentStatus.status === 'failed'
-          ? t('gameday.deploymentFailed')
-          : t('gameday.deploymentNotReady');
-    return (
-      <Container>
-        <Box textAlign="center" padding="xl">
-          <SpaceBetween size="m">
-            <StatusIndicator
-              type={
-                deploymentStatus.status === 'in_progress'
-                  ? 'in-progress'
-                  : 'warning'
-              }
-            >
-              {message}
-            </StatusIndicator>
-          </SpaceBetween>
-        </Box>
-      </Container>
-    );
-  }
-
   const formatTime = (timestamp: string) =>
     new Date(timestamp).toLocaleTimeString(
       locale === 'ja' ? 'ja-JP' : 'en-US',
@@ -184,159 +153,165 @@ export default function AttackPage() {
     );
 
   return (
-    <SpaceBetween size="l">
-      <Header variant="h1" description={t('gameday.attackDescription')}>
-        {t('gameday.attackStation')}
-      </Header>
+    <DeploymentGate eventId={eventId}>
+      <SpaceBetween size="l">
+        <Header variant="h1" description={t('gameday.attackDescription')}>
+          {t('gameday.attackStation')}
+        </Header>
 
-      <Container
-        header={<Header variant="h2">{t('gameday.targetSelection')}</Header>}
-      >
-        <FormField label={t('common.targetTeam')}>
-          <Select
-            selectedOption={selectedTarget}
-            onChange={({ detail }) => setSelectedTarget(detail.selectedOption)}
-            options={teamOptions}
-            placeholder={t('common.selectTeam')}
-            filteringType="auto"
-          />
-        </FormField>
-      </Container>
+        <Container
+          header={<Header variant="h2">{t('gameday.targetSelection')}</Header>}
+        >
+          <FormField label={t('common.targetTeam')}>
+            <Select
+              selectedOption={selectedTarget}
+              onChange={({ detail }) =>
+                setSelectedTarget(detail.selectedOption)
+              }
+              options={teamOptions}
+              placeholder={t('common.selectTeam')}
+              filteringType="auto"
+            />
+          </FormField>
+        </Container>
 
-      <Cards
-        header={
-          <Header counter={`(${catalog.length})`}>
-            {t('gameday.attackName')}
-          </Header>
-        }
-        items={catalog}
-        cardsPerRow={[
-          { cards: 1 },
-          { minWidth: 400, cards: 2 },
-          { minWidth: 700, cards: 3 },
-        ]}
-        cardDefinition={{
-          header: (attack) => attack.name,
-          sections: [
-            {
-              id: 'type',
-              content: (attack) => (
-                <Badge
-                  color={attack.attackType === 'vulnerability' ? 'red' : 'blue'}
-                >
-                  {attack.attackType === 'vulnerability'
-                    ? t('gameday.vulnerability')
-                    : t('gameday.chaos')}
-                </Badge>
-              ),
-            },
-            {
-              id: 'desc',
-              header: locale === 'ja' ? '説明' : 'Description',
-              content: (attack) => (
-                <Box color="text-body-secondary">{attack.description}</Box>
-              ),
-            },
-            {
-              id: 'stats',
-              content: (attack) => (
-                <SpaceBetween direction="horizontal" size="l">
-                  <Box variant="small">
-                    {t('gameday.cost')}: <b>{attack.purchaseCost}</b>
-                  </Box>
-                  <Box variant="small">
-                    {t('gameday.damage')}: <b>{attack.damage}</b>
-                  </Box>
-                  <Box variant="small">
-                    {t('gameday.reward')}: <b>{attack.reward}</b>
-                  </Box>
-                </SpaceBetween>
-              ),
-            },
-            {
-              id: 'action',
-              content: (attack) => {
-                const purchased = purchasedIds.has(attack.id);
-                const onCooldown =
-                  cooldowns[attack.id] && Date.now() < cooldowns[attack.id];
-
-                return purchased ? (
-                  <Button
-                    variant="primary"
-                    fullWidth
-                    onClick={() => handleExecute(attack.id)}
-                    loading={executing[attack.id]}
-                    disabled={!selectedTarget?.value || Boolean(onCooldown)}
+        <Cards
+          header={
+            <Header counter={`(${catalog.length})`}>
+              {t('gameday.attackName')}
+            </Header>
+          }
+          items={catalog}
+          cardsPerRow={[
+            { cards: 1 },
+            { minWidth: 400, cards: 2 },
+            { minWidth: 700, cards: 3 },
+          ]}
+          cardDefinition={{
+            header: (attack) => attack.name,
+            sections: [
+              {
+                id: 'type',
+                content: (attack) => (
+                  <Badge
+                    color={
+                      attack.attackType === 'vulnerability' ? 'red' : 'blue'
+                    }
                   >
-                    {onCooldown
-                      ? `${t('gameday.cooldown')}...`
-                      : t('gameday.execute')}
-                  </Button>
-                ) : (
-                  <Button
-                    fullWidth
-                    onClick={() => handlePurchase(attack.id)}
-                    loading={purchasing[attack.id]}
-                  >
-                    {t('gameday.purchase')} ({attack.purchaseCost} pts)
-                  </Button>
-                );
+                    {attack.attackType === 'vulnerability'
+                      ? t('gameday.vulnerability')
+                      : t('gameday.chaos')}
+                  </Badge>
+                ),
               },
-            },
-          ],
-        }}
-        empty={t('common.noData')}
-      />
+              {
+                id: 'desc',
+                header: locale === 'ja' ? '説明' : 'Description',
+                content: (attack) => (
+                  <Box color="text-body-secondary">{attack.description}</Box>
+                ),
+              },
+              {
+                id: 'stats',
+                content: (attack) => (
+                  <SpaceBetween direction="horizontal" size="l">
+                    <Box variant="small">
+                      {t('gameday.cost')}: <b>{attack.purchaseCost}</b>
+                    </Box>
+                    <Box variant="small">
+                      {t('gameday.damage')}: <b>{attack.damage}</b>
+                    </Box>
+                    <Box variant="small">
+                      {t('gameday.reward')}: <b>{attack.reward}</b>
+                    </Box>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'action',
+                content: (attack) => {
+                  const purchased = purchasedIds.has(attack.id);
+                  const onCooldown =
+                    cooldowns[attack.id] && Date.now() < cooldowns[attack.id];
 
-      <Table
-        header={
-          <Header counter={`(${history.length})`}>
-            {t('gameday.attackHistory')}
-          </Header>
-        }
-        items={history}
-        columnDefinitions={[
-          {
-            id: 'time',
-            header: t('gameday.time'),
-            cell: (log) => formatTime(log.createdAt),
-            width: 100,
-          },
-          {
-            id: 'attack',
-            header: t('gameday.attackName'),
-            cell: (log) => <Box variant="code">{log.attackSlug}</Box>,
-          },
-          {
-            id: 'target',
-            header: t('gameday.target'),
-            cell: (log) => log.defenderTeamId,
-          },
-          {
-            id: 'result',
-            header: t('gameday.result'),
-            cell: (log) => (
-              <StatusIndicator type={log.success ? 'success' : 'error'}>
-                {log.success ? t('gameday.success') : t('gameday.failed')}
-              </StatusIndicator>
-            ),
-            width: 120,
-          },
-          {
-            id: 'reward',
-            header: t('gameday.reward'),
-            cell: (log) =>
-              log.success ? (
-                <Box color="text-status-success">+{log.reward}</Box>
-              ) : (
-                '0'
+                  return purchased ? (
+                    <Button
+                      variant="primary"
+                      fullWidth
+                      onClick={() => handleExecute(attack.id)}
+                      loading={executing[attack.id]}
+                      disabled={!selectedTarget?.value || Boolean(onCooldown)}
+                    >
+                      {onCooldown
+                        ? `${t('gameday.cooldown')}...`
+                        : t('gameday.execute')}
+                    </Button>
+                  ) : (
+                    <Button
+                      fullWidth
+                      onClick={() => handlePurchase(attack.id)}
+                      loading={purchasing[attack.id]}
+                    >
+                      {t('gameday.purchase')} ({attack.purchaseCost} pts)
+                    </Button>
+                  );
+                },
+              },
+            ],
+          }}
+          empty={t('common.noData')}
+        />
+
+        <Table
+          header={
+            <Header counter={`(${history.length})`}>
+              {t('gameday.attackHistory')}
+            </Header>
+          }
+          items={history}
+          columnDefinitions={[
+            {
+              id: 'time',
+              header: t('gameday.time'),
+              cell: (log) => formatTime(log.createdAt),
+              width: 100,
+            },
+            {
+              id: 'attack',
+              header: t('gameday.attackName'),
+              cell: (log) => <Box variant="code">{log.attackSlug}</Box>,
+            },
+            {
+              id: 'target',
+              header: t('gameday.target'),
+              cell: (log) => log.defenderTeamId,
+            },
+            {
+              id: 'result',
+              header: t('gameday.result'),
+              cell: (log) => (
+                <StatusIndicator type={log.success ? 'success' : 'error'}>
+                  {log.success ? t('gameday.success') : t('gameday.failed')}
+                </StatusIndicator>
               ),
-            width: 100,
-          },
-        ]}
-        empty={t('gameday.noAttackHistory')}
-        sortingDisabled
-      />
-    </SpaceBetween>
+              width: 120,
+            },
+            {
+              id: 'reward',
+              header: t('gameday.reward'),
+              cell: (log) =>
+                log.success ? (
+                  <Box color="text-status-success">+{log.reward}</Box>
+                ) : (
+                  '0'
+                ),
+              width: 100,
+            },
+          ]}
+          empty={t('gameday.noAttackHistory')}
+          sortingDisabled
+        />
+      </SpaceBetween>
+    </DeploymentGate>
   );
 }

--- a/client/Application/app/(participant)/gameday/[eventId]/attack/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/attack/page.tsx
@@ -29,12 +29,18 @@ import {
   purchaseAttack,
 } from '@/lib/api/gameday';
 import type { Attack, AttackLog, CooldownError } from '@/lib/api/gameday-types';
+import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 
 export default function AttackPage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
+  const {
+    isReady,
+    isChecking,
+    status: deploymentStatus,
+  } = useDeploymentStatus(eventId);
   const [catalog, setCatalog] = useState<Attack[]>([]);
   const [history, setHistory] = useState<AttackLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -121,7 +127,7 @@ export default function AttackPage() {
     }
   };
 
-  if (loading) {
+  if (loading || isChecking) {
     return (
       <Box textAlign="center" padding="xxl">
         <Spinner size="large" />
@@ -136,6 +142,32 @@ export default function AttackPage() {
           <SpaceBetween size="m">
             <StatusIndicator type="error">{error.message}</StatusIndicator>
             <Button onClick={fetchData}>{t('common.retry')}</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!isReady && deploymentStatus) {
+    const message =
+      deploymentStatus.status === 'in_progress'
+        ? t('gameday.deploymentInProgress')
+        : deploymentStatus.status === 'failed'
+          ? t('gameday.deploymentFailed')
+          : t('gameday.deploymentNotReady');
+    return (
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator
+              type={
+                deploymentStatus.status === 'in_progress'
+                  ? 'in-progress'
+                  : 'warning'
+              }
+            >
+              {message}
+            </StatusIndicator>
           </SpaceBetween>
         </Box>
       </Container>

--- a/client/Application/app/(participant)/gameday/[eventId]/defense/__tests__/page.test.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/defense/__tests__/page.test.tsx
@@ -18,6 +18,17 @@ vi.mock('@/lib/hooks/use-gameday-session', () => ({
   }),
 }));
 
+const mockDeploymentResult = {
+  isReady: true,
+  isChecking: false,
+  status: { deployed: true, status: 'completed' },
+  checkError: null,
+};
+
+vi.mock('@/lib/hooks/use-deployment-status', () => ({
+  useDeploymentStatus: () => mockDeploymentResult,
+}));
+
 const mockGetActiveDefense = vi.fn();
 const mockPurchaseHint = vi.fn();
 const mockReportFix = vi.fn();
@@ -49,6 +60,10 @@ describe('DefensePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetActiveDefense.mockResolvedValue({ attacks: [] });
+    mockDeploymentResult.isReady = true;
+    mockDeploymentResult.isChecking = false;
+    mockDeploymentResult.status = { deployed: true, status: 'completed' };
+    mockDeploymentResult.checkError = null;
   });
 
   it('ローディング中は攻撃データを表示しないべき', () => {
@@ -114,6 +129,40 @@ describe('DefensePage', () => {
     await waitFor(() => {
       expect(
         screen.getByText('Refreshes every 10 seconds'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('デプロイ未完了時に警告メッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'pending',
+    };
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment deployment has not been completed yet. Please contact your administrator.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('デプロイ失敗時にエラーメッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'failed',
+    };
+    render(<DefensePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment deployment has failed. Please contact your administrator.',
+        ),
       ).toBeInTheDocument();
     });
   });

--- a/client/Application/app/(participant)/gameday/[eventId]/defense/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/defense/page.tsx
@@ -18,6 +18,7 @@ import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getActiveDefense, purchaseHint, reportFix } from '@/lib/api/gameday';
 import type { AttackLog } from '@/lib/api/gameday-types';
+import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 import { useNotifications } from '@/lib/notifications';
@@ -25,6 +26,11 @@ import { useNotifications } from '@/lib/notifications';
 export default function DefensePage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
+  const {
+    isReady,
+    isChecking,
+    status: deploymentStatus,
+  } = useDeploymentStatus(eventId);
   const { addNotification } = useNotifications();
   const [attacks, setAttacks] = useState<AttackLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -98,7 +104,7 @@ export default function DefensePage() {
     }
   };
 
-  if (loading) {
+  if (loading || isChecking) {
     return (
       <Box textAlign="center" padding="xxl">
         <Spinner size="large" />
@@ -113,6 +119,32 @@ export default function DefensePage() {
           <SpaceBetween size="m">
             <StatusIndicator type="error">{error.message}</StatusIndicator>
             <Button onClick={fetchData}>{t('common.retry')}</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!isReady && deploymentStatus) {
+    const message =
+      deploymentStatus.status === 'in_progress'
+        ? t('gameday.deploymentInProgress')
+        : deploymentStatus.status === 'failed'
+          ? t('gameday.deploymentFailed')
+          : t('gameday.deploymentNotReady');
+    return (
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator
+              type={
+                deploymentStatus.status === 'in_progress'
+                  ? 'in-progress'
+                  : 'warning'
+              }
+            >
+              {message}
+            </StatusIndicator>
           </SpaceBetween>
         </Box>
       </Container>

--- a/client/Application/app/(participant)/gameday/[eventId]/defense/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/defense/page.tsx
@@ -18,7 +18,7 @@ import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getActiveDefense, purchaseHint, reportFix } from '@/lib/api/gameday';
 import type { AttackLog } from '@/lib/api/gameday-types';
-import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
+import { DeploymentGate } from '@/components/gameday/deployment-gate';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 import { useNotifications } from '@/lib/notifications';
@@ -26,11 +26,6 @@ import { useNotifications } from '@/lib/notifications';
 export default function DefensePage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
-  const {
-    isReady,
-    isChecking,
-    status: deploymentStatus,
-  } = useDeploymentStatus(eventId);
   const { addNotification } = useNotifications();
   const [attacks, setAttacks] = useState<AttackLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -104,7 +99,7 @@ export default function DefensePage() {
     }
   };
 
-  if (loading || isChecking) {
+  if (loading) {
     return (
       <Box textAlign="center" padding="xxl">
         <Spinner size="large" />
@@ -125,32 +120,6 @@ export default function DefensePage() {
     );
   }
 
-  if (!isReady && deploymentStatus) {
-    const message =
-      deploymentStatus.status === 'in_progress'
-        ? t('gameday.deploymentInProgress')
-        : deploymentStatus.status === 'failed'
-          ? t('gameday.deploymentFailed')
-          : t('gameday.deploymentNotReady');
-    return (
-      <Container>
-        <Box textAlign="center" padding="xl">
-          <SpaceBetween size="m">
-            <StatusIndicator
-              type={
-                deploymentStatus.status === 'in_progress'
-                  ? 'in-progress'
-                  : 'warning'
-              }
-            >
-              {message}
-            </StatusIndicator>
-          </SpaceBetween>
-        </Box>
-      </Container>
-    );
-  }
-
   const active = attacks.filter((attack) => !attack.neutralized);
   const neutralized = attacks.filter((attack) => attack.neutralized);
 
@@ -165,100 +134,22 @@ export default function DefensePage() {
     );
 
   return (
-    <SpaceBetween size="l">
-      <Header variant="h1" description={t('gameday.defenseDescription')}>
-        {t('gameday.defenseTrench')}
-      </Header>
+    <DeploymentGate eventId={eventId}>
+      <SpaceBetween size="l">
+        <Header variant="h1" description={t('gameday.defenseDescription')}>
+          {t('gameday.defenseTrench')}
+        </Header>
 
-      <Table
-        header={
-          <Header
-            counter={`(${active.length})`}
-            description={t('gameday.defenseDescription')}
-          >
-            {t('gameday.underAttack')}
-          </Header>
-        }
-        items={active}
-        columnDefinitions={[
-          {
-            id: 'attack',
-            header: t('gameday.attackName'),
-            cell: (attack) => <Box variant="code">{attack.attackSlug}</Box>,
-          },
-          {
-            id: 'attacker',
-            header: t('gameday.attacker'),
-            cell: (attack) => attack.attackerTeamId,
-          },
-          {
-            id: 'damage',
-            header: t('gameday.damage'),
-            cell: (attack) => (
-              <Box color="text-status-error">{attack.damage}</Box>
-            ),
-            width: 100,
-          },
-          {
-            id: 'time',
-            header: t('gameday.time'),
-            cell: (attack) => formatTime(attack.createdAt),
-            width: 120,
-          },
-          {
-            id: 'hint',
-            header: t('gameday.hint'),
-            cell: (attack) =>
-              hints[attack.attackId] ? (
-                <StatusIndicator type="info">
-                  {hints[attack.attackId]}
-                </StatusIndicator>
-              ) : (
-                <Button
-                  variant="link"
-                  loading={hintLoading[attack.attackId]}
-                  onClick={() => handlePurchaseHint(attack.attackId)}
-                >
-                  {t('gameday.hint')}
-                </Button>
-              ),
-          },
-          {
-            id: 'fix',
-            header: t('gameday.reportFix'),
-            cell: (attack) => (
-              <Button
-                variant="primary"
-                loading={fixLoading[attack.attackSlug]}
-                onClick={() => handleReportFix(attack.attackSlug)}
-              >
-                {t('gameday.reportFix')}
-              </Button>
-            ),
-            width: 160,
-          },
-        ]}
-        empty={t('gameday.noActiveAttacks')}
-        sortingDisabled
-        footer={
-          <Box textAlign="center" color="text-body-secondary" fontSize="body-s">
-            <em>
-              {locale === 'ja'
-                ? '10秒ごとに自動更新'
-                : 'Refreshes every 10 seconds'}
-            </em>
-          </Box>
-        }
-      />
-
-      {neutralized.length > 0 ? (
         <Table
           header={
-            <Header counter={`(${neutralized.length})`}>
-              {t('gameday.fixed')}
+            <Header
+              counter={`(${active.length})`}
+              description={t('gameday.defenseDescription')}
+            >
+              {t('gameday.underAttack')}
             </Header>
           }
-          items={neutralized}
+          items={active}
           columnDefinitions={[
             {
               id: 'attack',
@@ -271,13 +162,12 @@ export default function DefensePage() {
               cell: (attack) => attack.attackerTeamId,
             },
             {
-              id: 'status',
-              header: t('gameday.result'),
-              cell: () => (
-                <StatusIndicator type="success">
-                  {t('gameday.mitigated')}
-                </StatusIndicator>
+              id: 'damage',
+              header: t('gameday.damage'),
+              cell: (attack) => (
+                <Box color="text-status-error">{attack.damage}</Box>
               ),
+              width: 100,
             },
             {
               id: 'time',
@@ -285,11 +175,96 @@ export default function DefensePage() {
               cell: (attack) => formatTime(attack.createdAt),
               width: 120,
             },
+            {
+              id: 'hint',
+              header: t('gameday.hint'),
+              cell: (attack) =>
+                hints[attack.attackId] ? (
+                  <StatusIndicator type="info">
+                    {hints[attack.attackId]}
+                  </StatusIndicator>
+                ) : (
+                  <Button
+                    variant="link"
+                    loading={hintLoading[attack.attackId]}
+                    onClick={() => handlePurchaseHint(attack.attackId)}
+                  >
+                    {t('gameday.hint')}
+                  </Button>
+                ),
+            },
+            {
+              id: 'fix',
+              header: t('gameday.reportFix'),
+              cell: (attack) => (
+                <Button
+                  variant="primary"
+                  loading={fixLoading[attack.attackSlug]}
+                  onClick={() => handleReportFix(attack.attackSlug)}
+                >
+                  {t('gameday.reportFix')}
+                </Button>
+              ),
+              width: 160,
+            },
           ]}
-          empty=""
+          empty={t('gameday.noActiveAttacks')}
           sortingDisabled
+          footer={
+            <Box
+              textAlign="center"
+              color="text-body-secondary"
+              fontSize="body-s"
+            >
+              <em>
+                {locale === 'ja'
+                  ? '10秒ごとに自動更新'
+                  : 'Refreshes every 10 seconds'}
+              </em>
+            </Box>
+          }
         />
-      ) : null}
-    </SpaceBetween>
+
+        {neutralized.length > 0 ? (
+          <Table
+            header={
+              <Header counter={`(${neutralized.length})`}>
+                {t('gameday.fixed')}
+              </Header>
+            }
+            items={neutralized}
+            columnDefinitions={[
+              {
+                id: 'attack',
+                header: t('gameday.attackName'),
+                cell: (attack) => <Box variant="code">{attack.attackSlug}</Box>,
+              },
+              {
+                id: 'attacker',
+                header: t('gameday.attacker'),
+                cell: (attack) => attack.attackerTeamId,
+              },
+              {
+                id: 'status',
+                header: t('gameday.result'),
+                cell: () => (
+                  <StatusIndicator type="success">
+                    {t('gameday.mitigated')}
+                  </StatusIndicator>
+                ),
+              },
+              {
+                id: 'time',
+                header: t('gameday.time'),
+                cell: (attack) => formatTime(attack.createdAt),
+                width: 120,
+              },
+            ]}
+            empty=""
+            sortingDisabled
+          />
+        ) : null}
+      </SpaceBetween>
+    </DeploymentGate>
   );
 }

--- a/client/Application/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
@@ -18,6 +18,17 @@ vi.mock('@/lib/hooks/use-gameday-session', () => ({
   }),
 }));
 
+const mockDeploymentResult = {
+  isReady: true,
+  isChecking: false,
+  status: { deployed: true, status: 'completed' },
+  checkError: null,
+};
+
+vi.mock('@/lib/hooks/use-deployment-status', () => ({
+  useDeploymentStatus: () => mockDeploymentResult,
+}));
+
 const mockGetVotingResults = vi.fn();
 const mockSubmitVote = vi.fn();
 const mockGetParticipantTeams = vi.fn();
@@ -44,6 +55,11 @@ describe('VotePage', () => {
     vi.clearAllMocks();
     mockGetParticipantTeams.mockResolvedValue(baseTeamsResponse);
     mockGetVotingResults.mockResolvedValue(baseVotingResults);
+    // デプロイ済みをデフォルトにする
+    mockDeploymentResult.isReady = true;
+    mockDeploymentResult.isChecking = false;
+    mockDeploymentResult.status = { deployed: true, status: 'completed' };
+    mockDeploymentResult.checkError = null;
   });
 
   it('ローディング中はチームデータを表示しないべき', () => {
@@ -125,6 +141,57 @@ describe('VotePage', () => {
 
     await waitFor(() => {
       expect(mockSubmitVote).toHaveBeenCalledWith('ev-1', 'team-1', 'team-2');
+    });
+  });
+
+  it('デプロイ未完了時に警告メッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'pending',
+    };
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment deployment has not been completed yet. Please contact your administrator.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('デプロイ中に進捗メッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'in_progress',
+    };
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment is being deployed. Please wait a moment.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('デプロイ失敗時にエラーメッセージを表示すべき', async () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = {
+      deployed: false,
+      status: 'failed',
+    };
+    render(<VotePage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The environment deployment has failed. Please contact your administrator.',
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/client/Application/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/vote/__tests__/page.test.tsx
@@ -73,7 +73,7 @@ describe('VotePage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: 'Vote targets' }),
+        screen.getByRole('heading', { name: /Vote targets/ }),
       ).toBeInTheDocument();
     });
     expect(screen.getAllByText('TeamBeta').length).toBeGreaterThanOrEqual(1);
@@ -110,7 +110,7 @@ describe('VotePage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Your vote has been submitted. Thank you.'),
+        screen.getByText(/Your vote has been submitted/),
       ).toBeInTheDocument();
     });
   });
@@ -123,8 +123,8 @@ describe('VotePage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByText('No other teams are registered yet.'),
-      ).toHaveLength(2);
+        screen.getAllByText('No other teams are registered yet.').length,
+      ).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/client/Application/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -13,6 +13,7 @@ import {
   submitVote,
 } from '@/lib/api/gameday';
 import type { Team, Vote } from '@/lib/api/gameday-types';
+import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 
@@ -23,6 +24,11 @@ interface VoteCandidate extends Team {
 export default function VotePage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
+  const {
+    isReady,
+    isChecking,
+    status: deploymentStatus,
+  } = useDeploymentStatus(eventId);
   const [teams, setTeams] = useState<Team[]>([]);
   const [votes, setVotes] = useState<Vote[]>([]);
   const [loading, setLoading] = useState(true);
@@ -109,7 +115,7 @@ export default function VotePage() {
     ? (voteCandidates.find((team) => team.teamId === votedTeamId) ?? null)
     : null;
 
-  if (loading) {
+  if (loading || isChecking) {
     return (
       <div className="flex justify-center items-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
@@ -129,6 +135,29 @@ export default function VotePage() {
           >
             {t('common.retry')}
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isReady && deploymentStatus) {
+    const message =
+      deploymentStatus.status === 'in_progress'
+        ? t('gameday.deploymentInProgress')
+        : deploymentStatus.status === 'failed'
+          ? t('gameday.deploymentFailed')
+          : t('gameday.deploymentNotReady');
+    return (
+      <div className="rounded-[28px] border border-amber-500/30 bg-amber-500/10 p-8">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="text-amber-400">
+            {deploymentStatus.status === 'in_progress' ? (
+              <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              <span className="text-2xl">!</span>
+            )}
+          </div>
+          <p className="text-sm text-amber-200">{message}</p>
         </div>
       </div>
     );

--- a/client/Application/app/(participant)/gameday/[eventId]/vote/page.tsx
+++ b/client/Application/app/(participant)/gameday/[eventId]/vote/page.tsx
@@ -6,6 +6,17 @@
 
 'use client';
 
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Cards from '@cloudscape-design/components/cards';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+import '@cloudscape-design/global-styles/index.css';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   getParticipantTeams,
@@ -13,7 +24,7 @@ import {
   submitVote,
 } from '@/lib/api/gameday';
 import type { Team, Vote } from '@/lib/api/gameday-types';
-import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
+import { DeploymentGate } from '@/components/gameday/deployment-gate';
 import { useGamedaySession } from '@/lib/hooks/use-gameday-session';
 import { useI18n } from '@/lib/i18n';
 
@@ -24,11 +35,6 @@ interface VoteCandidate extends Team {
 export default function VotePage() {
   const { t, locale } = useI18n();
   const { eventId, teamId } = useGamedaySession();
-  const {
-    isReady,
-    isChecking,
-    status: deploymentStatus,
-  } = useDeploymentStatus(eventId);
   const [teams, setTeams] = useState<Team[]>([]);
   const [votes, setVotes] = useState<Vote[]>([]);
   const [loading, setLoading] = useState(true);
@@ -115,355 +121,213 @@ export default function VotePage() {
     ? (voteCandidates.find((team) => team.teamId === votedTeamId) ?? null)
     : null;
 
-  if (loading || isChecking) {
+  if (loading) {
     return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hn-accent" />
-      </div>
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
     );
   }
 
   if (error) {
     return (
-      <div className="rounded-[28px] border border-hn-error/30 bg-hn-error/10 p-8">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <p className="text-sm text-hn-error">{error.message}</p>
-          <button
-            type="button"
-            onClick={fetchData}
-            className="rounded-full border border-border bg-surface-3 px-4 py-2 text-sm font-semibold text-text-primary hover:bg-surface-2 transition-colors"
-          >
-            {t('common.retry')}
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (!isReady && deploymentStatus) {
-    const message =
-      deploymentStatus.status === 'in_progress'
-        ? t('gameday.deploymentInProgress')
-        : deploymentStatus.status === 'failed'
-          ? t('gameday.deploymentFailed')
-          : t('gameday.deploymentNotReady');
-    return (
-      <div className="rounded-[28px] border border-amber-500/30 bg-amber-500/10 p-8">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <div className="text-amber-400">
-            {deploymentStatus.status === 'in_progress' ? (
-              <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            ) : (
-              <span className="text-2xl">!</span>
-            )}
-          </div>
-          <p className="text-sm text-amber-200">{message}</p>
-        </div>
-      </div>
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator type="error">{error.message}</StatusIndicator>
+            <Button onClick={fetchData}>{t('common.retry')}</Button>
+          </SpaceBetween>
+        </Box>
+      </Container>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <section className="rounded-[32px] border border-border bg-surface-2/90 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.18)] backdrop-blur-sm">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(340px,0.9fr)]">
-          <div className="space-y-4">
-            <div className="inline-flex items-center rounded-full border border-hn-accent/35 bg-hn-accent/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-hn-accent">
-              {t('gameday.voteNav')}
-            </div>
-            <div className="space-y-2">
-              <h1 className="text-4xl font-black tracking-tight text-text-primary">
-                {t('gameday.voting')}
-              </h1>
-              <p className="max-w-2xl text-sm leading-7 text-text-secondary">
-                {t('gameday.votingDescription')}
-              </p>
-            </div>
-            <div className="grid gap-3 md:grid-cols-3">
-              <VoteStatCard
-                label={locale === 'ja' ? '投票対象' : 'Candidates'}
-                value={String(voteCandidates.length)}
-                tone="neutral"
-              />
-              <VoteStatCard
-                label={locale === 'ja' ? '総投票数' : 'Total votes'}
-                value={String(totalVotes)}
-                tone="accent"
-              />
-              <VoteStatCard
-                label={locale === 'ja' ? '投票状況' : 'Your status'}
-                value={
-                  votedTeamId
-                    ? locale === 'ja'
-                      ? '投票済み'
-                      : 'Submitted'
-                    : locale === 'ja'
-                      ? '未投票'
-                      : 'Pending'
-                }
-                tone={votedTeamId ? 'success' : 'neutral'}
-              />
-            </div>
-          </div>
+    <DeploymentGate eventId={eventId}>
+      <SpaceBetween size="l">
+        <Header variant="h1" description={t('gameday.votingDescription')}>
+          {t('gameday.voting')}
+        </Header>
 
-          <aside className="rounded-[28px] border border-border bg-surface-3 p-5">
-            <div className="space-y-4">
-              <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-                  {locale === 'ja' ? '現在のトップ' : 'Current leader'}
-                </div>
-                <div className="mt-2 text-2xl font-bold text-text-primary">
-                  {leadingCandidate?.teamName ??
-                    (locale === 'ja' ? 'まだなし' : 'No votes yet')}
-                </div>
-                <div className="mt-1 text-sm text-text-secondary">
-                  {leadingCandidate
-                    ? `${leadingCandidate.votes} ${t('gameday.voteCount')}`
-                    : locale === 'ja'
-                      ? '最初の一票を待っています。'
-                      : 'Waiting for the first vote.'}
-                </div>
-              </div>
-              <div className="rounded-2xl border border-border bg-surface-2 px-4 py-3 text-sm text-text-secondary">
-                {votedTeamId
-                  ? locale === 'ja'
-                    ? '投票後はリアルタイムで得票状況だけを確認できます。'
-                    : 'After voting, you can keep tracking the live tally.'
-                  : locale === 'ja'
-                    ? '他チームを 1 つ選んで投票してください。自チームへの投票はできません。'
-                    : 'Pick one other team to cast your vote. Self-voting is not allowed.'}
-              </div>
-            </div>
-          </aside>
-        </div>
-      </section>
+        <ColumnLayout columns={3}>
+          <Container>
+            <Box variant="awsui-key-label">
+              {locale === 'ja' ? '投票対象' : 'Candidates'}
+            </Box>
+            <Box variant="awsui-value-large">{voteCandidates.length}</Box>
+          </Container>
+          <Container>
+            <Box variant="awsui-key-label">
+              {locale === 'ja' ? '総投票数' : 'Total votes'}
+            </Box>
+            <Box variant="awsui-value-large">{totalVotes}</Box>
+          </Container>
+          <Container>
+            <Box variant="awsui-key-label">
+              {locale === 'ja' ? '投票状況' : 'Your status'}
+            </Box>
+            <Box variant="awsui-value-large">
+              {votedTeamId ? (
+                <StatusIndicator type="success">
+                  {locale === 'ja' ? '投票済み' : 'Submitted'}
+                </StatusIndicator>
+              ) : (
+                <StatusIndicator type="pending">
+                  {locale === 'ja' ? '未投票' : 'Pending'}
+                </StatusIndicator>
+              )}
+            </Box>
+          </Container>
+        </ColumnLayout>
 
-      {votedTeamId ? (
-        <section className="rounded-[28px] border border-emerald-500/35 bg-emerald-500/10 px-5 py-4 text-sm text-emerald-200">
-          <div className="flex items-center gap-3">
-            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/20 text-base">
-              ✓
-            </span>
-            <div>
-              <div className="font-semibold text-emerald-100">
-                {t('gameday.votedMessage')}
-              </div>
-              <div className="text-emerald-200/80">
-                {locale === 'ja'
-                  ? `投票先: ${votedForTeam?.teamName ?? votedTeamId}`
-                  : `Voted for ${votedForTeam?.teamName ?? votedTeamId}`}
-              </div>
-            </div>
-          </div>
-        </section>
-      ) : null}
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,0.85fr)]">
-        <section className="rounded-[32px] border border-border bg-surface-2/90 p-6">
-          <div className="mb-5 flex items-end justify-between gap-4">
-            <div>
-              <h2 className="text-2xl font-bold text-text-primary">
-                {locale === 'ja' ? '投票対象チーム' : 'Vote targets'}
-              </h2>
-              <p className="mt-1 text-sm text-text-secondary">
-                {locale === 'ja'
-                  ? '各チームの得票状況を見ながら 1 チームに投票できます。'
-                  : 'Review each team and cast one vote for the strongest performance.'}
-              </p>
-            </div>
-            <div className="rounded-full border border-border bg-surface-3 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-text-secondary">
-              {voteCandidates.length} {locale === 'ja' ? 'チーム' : 'teams'}
-            </div>
-          </div>
-
-          {voteCandidates.length === 0 ? (
-            <div className="rounded-[24px] border border-dashed border-border bg-surface-3 px-6 py-16 text-center text-text-secondary">
-              <div className="text-lg font-semibold text-text-primary">
-                {t('gameday.noOtherTeams')}
-              </div>
-              <p className="mt-2 text-sm">
-                {locale === 'ja'
-                  ? '投票を始めるには、別の参加チームが登録される必要があります。'
-                  : 'Another registered team is required before voting becomes available.'}
-              </p>
-            </div>
-          ) : (
-            <div className="grid gap-4 md:grid-cols-2">
-              {voteCandidates.map((team, index) => {
-                const isLeading = index === 0 && team.votes > 0;
-                const isSelected = votedTeamId === team.teamId;
-
-                return (
-                  <article
-                    key={team.teamId}
-                    className={`rounded-[26px] border p-5 transition-colors ${
-                      isSelected
-                        ? 'border-emerald-400/60 bg-emerald-500/10'
-                        : isLeading
-                          ? 'border-hn-accent/50 bg-hn-accent/10'
-                          : 'border-border bg-surface-3'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-text-muted">
-                          {locale === 'ja'
-                            ? `候補 ${index + 1}`
-                            : `Candidate ${index + 1}`}
-                        </div>
-                        <h3 className="mt-2 text-xl font-bold text-text-primary">
-                          {team.teamName}
-                        </h3>
-                      </div>
-                      <div className="rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-semibold text-text-primary">
-                        {team.votes} {t('gameday.voteCount')}
-                      </div>
-                    </div>
-
-                    <div className="mt-5 grid grid-cols-2 gap-3">
-                      <VoteMiniStat
-                        label={locale === 'ja' ? '現在順位' : 'Standing'}
-                        value={`#${index + 1}`}
-                      />
-                      <VoteMiniStat
-                        label={locale === 'ja' ? '得票' : 'Votes'}
-                        value={String(team.votes)}
-                      />
-                    </div>
-
-                    <div className="mt-5">
-                      {votedTeamId ? (
-                        <div className="rounded-2xl border border-border bg-surface-2 px-4 py-3 text-center text-sm text-text-secondary">
-                          {isSelected
-                            ? locale === 'ja'
-                              ? 'このチームに投票しました'
-                              : 'You voted for this team'
-                            : `${team.votes} ${t('gameday.votesReceived')}`}
-                        </div>
-                      ) : (
-                        <button
-                          type="button"
-                          className={`w-full rounded-2xl px-4 py-3 text-sm font-semibold transition-colors disabled:opacity-50 ${
-                            isLeading
-                              ? 'bg-hn-accent text-white hover:bg-hn-accent/90'
-                              : 'border border-border bg-surface-3 text-text-primary hover:bg-surface-2'
-                          }`}
-                          onClick={() => handleVote(team.teamId)}
-                          disabled={votingTeamId !== null}
-                        >
-                          {votingTeamId === team.teamId ? (
-                            <span className="flex items-center justify-center gap-2">
-                              <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                              {t('gameday.voteAction')}
-                            </span>
-                          ) : (
-                            t('gameday.voteAction')
-                          )}
-                        </button>
-                      )}
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-          )}
-        </section>
-
-        <aside className="rounded-[32px] border border-border bg-surface-2/90 p-6">
-          <div className="mb-5">
-            <h2 className="text-2xl font-bold text-text-primary">
-              {locale === 'ja' ? '得票ボード' : 'Vote board'}
-            </h2>
-            <p className="mt-1 text-sm text-text-secondary">
+        {votedTeamId ? (
+          <Container>
+            <StatusIndicator type="success">
+              {t('gameday.votedMessage')}
+              {' — '}
               {locale === 'ja'
-                ? '現在の得票順にチームを並べています。'
-                : 'Teams are ordered by current vote count.'}
-            </p>
-          </div>
+                ? `投票先: ${votedForTeam?.teamName ?? votedTeamId}`
+                : `Voted for ${votedForTeam?.teamName ?? votedTeamId}`}
+            </StatusIndicator>
+          </Container>
+        ) : null}
 
-          {voteCandidates.length === 0 ? (
-            <div className="rounded-[24px] border border-dashed border-border bg-surface-3 px-5 py-10 text-center text-sm text-text-secondary">
-              {t('gameday.noOtherTeams')}
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {voteCandidates.map((team, index) => (
-                <div
-                  key={team.teamId}
-                  className="flex items-center justify-between rounded-2xl border border-border bg-surface-3 px-4 py-3"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-surface-2 text-sm font-black text-text-primary">
-                      {index + 1}
-                    </div>
-                    <div>
-                      <div className="font-semibold text-text-primary">
-                        {team.teamName}
-                      </div>
-                      <div className="text-xs text-text-muted">
+        <Container
+          header={
+            <Header
+              counter={`(${leadingCandidate ? leadingCandidate.votes : 0})`}
+            >
+              {locale === 'ja' ? '現在のトップ' : 'Current leader'}
+            </Header>
+          }
+        >
+          <Box fontSize="heading-l" fontWeight="bold">
+            {leadingCandidate?.teamName ??
+              (locale === 'ja' ? 'まだなし' : 'No votes yet')}
+          </Box>
+          <Box color="text-body-secondary">
+            {leadingCandidate
+              ? `${leadingCandidate.votes} ${t('gameday.voteCount')}`
+              : locale === 'ja'
+                ? '最初の一票を待っています。'
+                : 'Waiting for the first vote.'}
+          </Box>
+        </Container>
+
+        <Cards
+          header={
+            <Header
+              counter={`(${voteCandidates.length})`}
+              description={
+                locale === 'ja'
+                  ? '各チームの得票状況を見ながら 1 チームに投票できます。'
+                  : 'Review each team and cast one vote for the strongest performance.'
+              }
+            >
+              {locale === 'ja' ? '投票対象チーム' : 'Vote targets'}
+            </Header>
+          }
+          items={voteCandidates}
+          cardsPerRow={[{ cards: 1 }, { minWidth: 400, cards: 2 }]}
+          cardDefinition={{
+            header: (team) => team.teamName,
+            sections: [
+              {
+                id: 'stats',
+                content: (team) => (
+                  <SpaceBetween direction="horizontal" size="l">
+                    <Box variant="small">
+                      {locale === 'ja' ? '順位' : 'Standing'}:{' '}
+                      <b>#{voteCandidates.indexOf(team) + 1}</b>
+                    </Box>
+                    <Box variant="small">
+                      {locale === 'ja' ? '得票' : 'Votes'}: <b>{team.votes}</b>
+                    </Box>
+                  </SpaceBetween>
+                ),
+              },
+              {
+                id: 'action',
+                content: (team) => {
+                  if (votedTeamId) {
+                    return (
+                      <Box textAlign="center" color="text-body-secondary">
                         {votedTeamId === team.teamId
                           ? locale === 'ja'
-                            ? 'あなたの投票先'
-                            : 'Your vote'
-                          : locale === 'ja'
-                            ? '投票対象'
-                            : 'Eligible target'}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-lg font-bold text-text-primary">
-                      {team.votes}
-                    </div>
-                    <div className="text-xs uppercase tracking-[0.18em] text-text-muted">
-                      {t('gameday.voteCount')}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </aside>
-      </div>
-    </div>
-  );
-}
+                            ? 'このチームに投票しました'
+                            : 'You voted for this team'
+                          : `${team.votes} ${t('gameday.votesReceived')}`}
+                      </Box>
+                    );
+                  }
+                  return (
+                    <Button
+                      fullWidth
+                      variant="primary"
+                      onClick={() => handleVote(team.teamId)}
+                      loading={votingTeamId === team.teamId}
+                      disabled={votingTeamId !== null}
+                    >
+                      {t('gameday.voteAction')}
+                    </Button>
+                  );
+                },
+              },
+            ],
+          }}
+          empty={t('gameday.noOtherTeams')}
+        />
 
-function VoteStatCard({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: string;
-  tone: 'neutral' | 'accent' | 'success';
-}) {
-  const toneClass =
-    tone === 'accent'
-      ? 'border-hn-accent/35 bg-hn-accent/10'
-      : tone === 'success'
-        ? 'border-emerald-500/35 bg-emerald-500/10'
-        : 'border-border bg-surface-3';
-
-  return (
-    <div className={`rounded-[24px] border px-4 py-4 ${toneClass}`}>
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-        {label}
-      </div>
-      <div className="mt-2 text-2xl font-black text-text-primary">{value}</div>
-    </div>
-  );
-}
-
-function VoteMiniStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-border bg-surface-2 px-3 py-3">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-semibold text-text-primary">
-        {value}
-      </div>
-    </div>
+        <Table
+          header={
+            <Header
+              description={
+                locale === 'ja'
+                  ? '現在の得票順にチームを並べています。'
+                  : 'Teams are ordered by current vote count.'
+              }
+            >
+              {locale === 'ja' ? '得票ボード' : 'Vote board'}
+            </Header>
+          }
+          items={voteCandidates}
+          columnDefinitions={[
+            {
+              id: 'rank',
+              header: '#',
+              cell: (_team) => voteCandidates.indexOf(_team) + 1,
+              width: 60,
+            },
+            {
+              id: 'team',
+              header: locale === 'ja' ? 'チーム' : 'Team',
+              cell: (team) => <Box fontWeight="bold">{team.teamName}</Box>,
+            },
+            {
+              id: 'status',
+              header: locale === 'ja' ? '状態' : 'Status',
+              cell: (team) =>
+                votedTeamId === team.teamId ? (
+                  <StatusIndicator type="success">
+                    {locale === 'ja' ? 'あなたの投票先' : 'Your vote'}
+                  </StatusIndicator>
+                ) : (
+                  <Box color="text-body-secondary">
+                    {locale === 'ja' ? '投票対象' : 'Eligible target'}
+                  </Box>
+                ),
+            },
+            {
+              id: 'votes',
+              header: t('gameday.voteCount'),
+              cell: (team) => <Box fontWeight="bold">{team.votes}</Box>,
+              width: 100,
+            },
+          ]}
+          empty={t('gameday.noOtherTeams')}
+          sortingDisabled
+        />
+      </SpaceBetween>
+    </DeploymentGate>
   );
 }

--- a/client/Application/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
+++ b/client/Application/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Session } from 'next-auth';
 
 // Mock auth
@@ -17,19 +17,11 @@ vi.mock('@/lib/aws', () => ({
   },
 }));
 
-// Mock backend-urls
-vi.mock('@/lib/api/backend-urls', () => ({
-  getProblemServiceUrl: () => 'http://localhost:3100/api',
+// Mock serverApiRequest
+const mockServerApiRequest = vi.fn();
+vi.mock('@/lib/api/server', () => ({
+  serverApiRequest: (...args: unknown[]) => mockServerApiRequest(...args),
 }));
-
-// Mock getAuthToken
-vi.mock('@/lib/auth/get-auth-token', () => ({
-  getAuthToken: vi.fn().mockResolvedValue('mock-token'),
-}));
-
-// Mock global fetch for deployment status requests
-const originalFetch = globalThis.fetch;
-const mockFetch = vi.fn();
 
 describe('AWS Console Federation API', () => {
   const makeParams = (eventId: string) => ({
@@ -40,18 +32,8 @@ describe('AWS Console Federation API', () => {
     vi.clearAllMocks();
     // 環境変数をクリア
     delete process.env.AWS_PARTICIPANT_ROLE_ARN;
-    // fetchRoleArnFromDeployment uses fetch internally
-    globalThis.fetch = mockFetch;
     // Default: deployment fetch fails (so it falls back to env vars)
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({ error: 'Not found' }),
-    });
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
+    mockServerApiRequest.mockRejectedValue(new Error('Not found'));
   });
 
   it('未認証の場合は 401 を返すべき', async () => {
@@ -252,25 +234,10 @@ describe('AWS Console Federation API', () => {
     process.env.AWS_PARTICIPANT_ROLE_ARN =
       'arn:aws:iam::123456789012:role/FallbackRole';
 
-    // deployment status fetch succeeds with roleArn
-    let callCount = 0;
-    mockFetch.mockImplementation(async (url: string) => {
-      callCount++;
-      if (callCount === 1) {
-        // event detail
-        return {
-          ok: true,
-          json: async () => ({ problems: [{ problemId: 'prob-1' }] }),
-        };
-      }
-      // deployment status
-      return {
-        ok: true,
-        json: async () => ({
-          deployed: true,
-          roleArn: 'arn:aws:iam::999999999999:role/DeploymentRole',
-        }),
-      };
+    // serverApiRequest returns deployment status with roleArn
+    mockServerApiRequest.mockResolvedValue({
+      deployed: true,
+      roleArn: 'arn:aws:iam::999999999999:role/DeploymentRole',
     });
 
     const expiresAt = new Date(Date.now() + 3600000);
@@ -284,6 +251,11 @@ describe('AWS Console Federation API', () => {
       'http://localhost/api/participant/events/evt-1/aws-console',
     );
     await GET(request, await makeParams('evt-1'));
+
+    // serverApiRequest がイベント全体のデプロイメントステータスを呼ぶ
+    expect(mockServerApiRequest).toHaveBeenCalledWith(
+      '/participant/events/evt-1/deployments/status',
+    );
 
     // デプロイメントレコードの roleArn が使われる
     expect(mockGenerateParticipantConsoleUrl).toHaveBeenCalledWith(

--- a/client/Application/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
+++ b/client/Application/app/api/participant/events/[eventId]/aws-console/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Session } from 'next-auth';
 
 // Mock auth
@@ -17,6 +17,20 @@ vi.mock('@/lib/aws', () => ({
   },
 }));
 
+// Mock backend-urls
+vi.mock('@/lib/api/backend-urls', () => ({
+  getProblemServiceUrl: () => 'http://localhost:3100/api',
+}));
+
+// Mock getAuthToken
+vi.mock('@/lib/auth/get-auth-token', () => ({
+  getAuthToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+// Mock global fetch for deployment status requests
+const originalFetch = globalThis.fetch;
+const mockFetch = vi.fn();
+
 describe('AWS Console Federation API', () => {
   const makeParams = (eventId: string) => ({
     params: Promise.resolve({ eventId }),
@@ -26,6 +40,18 @@ describe('AWS Console Federation API', () => {
     vi.clearAllMocks();
     // 環境変数をクリア
     delete process.env.AWS_PARTICIPANT_ROLE_ARN;
+    // fetchRoleArnFromDeployment uses fetch internally
+    globalThis.fetch = mockFetch;
+    // Default: deployment fetch fails (so it falls back to env vars)
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Not found' }),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it('未認証の場合は 401 を返すべき', async () => {
@@ -60,9 +86,7 @@ describe('AWS Console Federation API', () => {
 
     expect(response.status).toBe(404);
     const data = await response.json();
-    expect(data.error).toBe(
-      'AWS Console access is not configured for this event',
-    );
+    expect(data.error).toContain('not configured');
   });
 
   it('Federation URL を正常に返すべき', async () => {
@@ -212,6 +236,61 @@ describe('AWS Console Federation API', () => {
       'test@example.com',
       'evt-1-no-team',
       'arn:aws:iam::123456789012:role/ParticipantRole',
+    );
+  });
+
+  it('デプロイメントレコードから roleArn を優先的に使用すべき', async () => {
+    const session: Session = {
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      roles: ['participant'],
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+    };
+    mockAuth.mockResolvedValue(session);
+    // 環境変数にもセット（フォールバック）
+    process.env.AWS_PARTICIPANT_ROLE_ARN =
+      'arn:aws:iam::123456789012:role/FallbackRole';
+
+    // deployment status fetch succeeds with roleArn
+    let callCount = 0;
+    mockFetch.mockImplementation(async (url: string) => {
+      callCount++;
+      if (callCount === 1) {
+        // event detail
+        return {
+          ok: true,
+          json: async () => ({ problems: [{ problemId: 'prob-1' }] }),
+        };
+      }
+      // deployment status
+      return {
+        ok: true,
+        json: async () => ({
+          deployed: true,
+          roleArn: 'arn:aws:iam::999999999999:role/DeploymentRole',
+        }),
+      };
+    });
+
+    const expiresAt = new Date(Date.now() + 3600000);
+    mockGenerateParticipantConsoleUrl.mockResolvedValue({
+      url: 'https://signin.aws.amazon.com/federation?Action=login',
+      expiresAt,
+    });
+
+    const { GET } = await import('../route');
+    const request = new Request(
+      'http://localhost/api/participant/events/evt-1/aws-console',
+    );
+    await GET(request, await makeParams('evt-1'));
+
+    // デプロイメントレコードの roleArn が使われる
+    expect(mockGenerateParticipantConsoleUrl).toHaveBeenCalledWith(
+      'tenant-1',
+      'test@example.com',
+      'evt-1-team-1',
+      'arn:aws:iam::999999999999:role/DeploymentRole',
     );
   });
 });

--- a/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
+++ b/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
@@ -8,60 +8,23 @@
 
 import { auth } from '@/auth';
 import { stsFederation } from '@/lib/aws';
-import { getProblemServiceUrl } from '@/lib/api/backend-urls';
-import { getAuthToken } from '@/lib/auth/get-auth-token';
-
-interface DeploymentStatusResponse {
-  deployed: boolean;
-  status: string;
-  outputs: Record<string, string> | null;
-  roleArn: string | null;
-  externalId: string | null;
-  competitorAccountId: string | null;
-  region: string | null;
-  error: string | null;
-}
+import { serverApiRequest } from '@/lib/api/server';
+import type { DeploymentStatus } from '@/lib/api/gameday-types';
 
 /**
  * デプロイメントレコードから roleArn を取得する
+ *
+ * イベント全体のデプロイメント状態を 1 回の API 呼び出しで取得する。
  */
 async function fetchRoleArnFromDeployment(
   eventId: string,
 ): Promise<string | null> {
   try {
-    const baseUrl = getProblemServiceUrl();
-    const token = await getAuthToken();
-
-    // イベントの全 problem のデプロイ状態を確認
-    // まずイベント情報を取得して problemId を特定する
-    const eventRes = await fetch(`${baseUrl}/participant/events/${eventId}`, {
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    });
-    if (!eventRes.ok) return null;
-
-    const eventData = (await eventRes.json()) as {
-      problems?: { problemId: string }[];
-    };
-    if (!eventData.problems?.length) return null;
-
-    // 最初の problem のデプロイ状態を取得
-    for (const problem of eventData.problems) {
-      const statusRes = await fetch(
-        `${baseUrl}/participant/events/${eventId}/problems/${problem.problemId}/deployments/status`,
-        {
-          headers: {
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-        },
-      );
-      if (!statusRes.ok) continue;
-
-      const status = (await statusRes.json()) as DeploymentStatusResponse;
-      if (status.deployed && status.roleArn) {
-        return status.roleArn;
-      }
+    const result = await serverApiRequest<DeploymentStatus>(
+      `/participant/events/${eventId}/deployments/status`,
+    );
+    if (result.deployed && result.roleArn) {
+      return result.roleArn;
     }
   } catch {
     // デプロイメントレコードからの取得失敗は無視してフォールバック

--- a/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
+++ b/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
@@ -26,8 +26,9 @@ async function fetchRoleArnFromDeployment(
     if (result.deployed && result.roleArn) {
       return result.roleArn;
     }
-  } catch {
+  } catch (error) {
     // デプロイメントレコードからの取得失敗は無視してフォールバック
+    console.warn('Failed to fetch deployment roleArn:', error);
   }
   return null;
 }

--- a/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
+++ b/client/Application/app/api/participant/events/[eventId]/aws-console/route.ts
@@ -1,11 +1,73 @@
 /**
  * AWS Console Federation API
  *
- * STS Federation を使用して参加者用 AWS Console ログイン URL を生成するエンドポイント
+ * STS Federation を使用して参加者用 AWS Console ログイン URL を生成するエンドポイント。
+ * デプロイメントレコードから competitor account の roleArn を取得する。
+ * フォールバックとして環境変数を使用する。
  */
 
 import { auth } from '@/auth';
 import { stsFederation } from '@/lib/aws';
+import { getProblemServiceUrl } from '@/lib/api/backend-urls';
+import { getAuthToken } from '@/lib/auth/get-auth-token';
+
+interface DeploymentStatusResponse {
+  deployed: boolean;
+  status: string;
+  outputs: Record<string, string> | null;
+  roleArn: string | null;
+  externalId: string | null;
+  competitorAccountId: string | null;
+  region: string | null;
+  error: string | null;
+}
+
+/**
+ * デプロイメントレコードから roleArn を取得する
+ */
+async function fetchRoleArnFromDeployment(
+  eventId: string,
+): Promise<string | null> {
+  try {
+    const baseUrl = getProblemServiceUrl();
+    const token = await getAuthToken();
+
+    // イベントの全 problem のデプロイ状態を確認
+    // まずイベント情報を取得して problemId を特定する
+    const eventRes = await fetch(`${baseUrl}/participant/events/${eventId}`, {
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    if (!eventRes.ok) return null;
+
+    const eventData = (await eventRes.json()) as {
+      problems?: { problemId: string }[];
+    };
+    if (!eventData.problems?.length) return null;
+
+    // 最初の problem のデプロイ状態を取得
+    for (const problem of eventData.problems) {
+      const statusRes = await fetch(
+        `${baseUrl}/participant/events/${eventId}/problems/${problem.problemId}/deployments/status`,
+        {
+          headers: {
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+        },
+      );
+      if (!statusRes.ok) continue;
+
+      const status = (await statusRes.json()) as DeploymentStatusResponse;
+      if (status.deployed && status.roleArn) {
+        return status.roleArn;
+      }
+    }
+  } catch {
+    // デプロイメントレコードからの取得失敗は無視してフォールバック
+  }
+  return null;
+}
 
 export async function GET(
   _request: Request,
@@ -19,14 +81,19 @@ export async function GET(
     return Response.json({ error: 'Authentication required' }, { status: 401 });
   }
 
-  // Role ARN の取得（環境変数またはイベント設定から）
+  // Role ARN の取得: デプロイメントレコード → 環境変数の順にフォールバック
+  const deploymentRoleArn = await fetchRoleArnFromDeployment(eventId);
   const roleArn =
+    deploymentRoleArn ||
     process.env.AWS_PARTICIPANT_ROLE_ARN ||
     process.env[`AWS_ROLE_ARN_${eventId}`];
 
   if (!roleArn) {
     return Response.json(
-      { error: 'AWS Console access is not configured for this event' },
+      {
+        error:
+          'AWS Console access is not configured for this event. No deployment record or environment configuration found.',
+      },
       { status: 404 },
     );
   }

--- a/client/Application/components/gameday/__tests__/deployment-gate.test.tsx
+++ b/client/Application/components/gameday/__tests__/deployment-gate.test.tsx
@@ -9,7 +9,7 @@ const mockDeploymentResult = {
     deployed: boolean;
     status: string;
   } | null,
-  checkError: null,
+  checkError: null as Error | null,
 };
 
 vi.mock('@/lib/hooks/use-deployment-status', () => ({
@@ -101,15 +101,16 @@ describe('DeploymentGate', () => {
     ).toBeInTheDocument();
   });
 
-  it('ステータスが null の場合は子要素を表示すべき', () => {
+  it('エラー時はブロックメッセージを表示すべき (fail-closed)', () => {
     mockDeploymentResult.isReady = false;
     mockDeploymentResult.status = null;
+    mockDeploymentResult.checkError = new Error('Network error');
     render(
       <DeploymentGate eventId="ev-1">
         <div>テストコンテンツ</div>
       </DeploymentGate>,
     );
 
-    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+    expect(screen.queryByText('テストコンテンツ')).not.toBeInTheDocument();
   });
 });

--- a/client/Application/components/gameday/__tests__/deployment-gate.test.tsx
+++ b/client/Application/components/gameday/__tests__/deployment-gate.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DeploymentGate } from '../deployment-gate';
+
+const mockDeploymentResult = {
+  isReady: true,
+  isChecking: false,
+  status: { deployed: true, status: 'completed' } as {
+    deployed: boolean;
+    status: string;
+  } | null,
+  checkError: null,
+};
+
+vi.mock('@/lib/hooks/use-deployment-status', () => ({
+  useDeploymentStatus: () => mockDeploymentResult,
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ eventId: 'ev-1' }),
+}));
+
+describe('DeploymentGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeploymentResult.isReady = true;
+    mockDeploymentResult.isChecking = false;
+    mockDeploymentResult.status = { deployed: true, status: 'completed' };
+    mockDeploymentResult.checkError = null;
+  });
+
+  it('デプロイ済みの場合は子要素を表示すべき', () => {
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+  });
+
+  it('チェック中はスピナーを表示すべき', () => {
+    mockDeploymentResult.isChecking = true;
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.queryByText('テストコンテンツ')).not.toBeInTheDocument();
+  });
+
+  it('デプロイ未完了時に警告メッセージを表示すべき', () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = { deployed: false, status: 'pending' };
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.queryByText('テストコンテンツ')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The environment deployment has not been completed yet. Please contact your administrator.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('デプロイ中に進捗メッセージを表示すべき', () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = { deployed: false, status: 'in_progress' };
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.queryByText('テストコンテンツ')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The environment is being deployed. Please wait a moment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('デプロイ失敗時にエラーメッセージを表示すべき', () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = { deployed: false, status: 'failed' };
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.queryByText('テストコンテンツ')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The environment deployment has failed. Please contact your administrator.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('ステータスが null の場合は子要素を表示すべき', () => {
+    mockDeploymentResult.isReady = false;
+    mockDeploymentResult.status = null;
+    render(
+      <DeploymentGate eventId="ev-1">
+        <div>テストコンテンツ</div>
+      </DeploymentGate>,
+    );
+
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+  });
+});

--- a/client/Application/components/gameday/deployment-gate.tsx
+++ b/client/Application/components/gameday/deployment-gate.tsx
@@ -1,0 +1,58 @@
+/**
+ * DeploymentGate
+ *
+ * デプロイメント状態を確認し、未完了の場合はブロックメッセージを表示する。
+ * 攻撃/防御/投票ページで共通利用する。
+ */
+
+'use client';
+
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import { useDeploymentStatus } from '@/lib/hooks/use-deployment-status';
+import { useI18n } from '@/lib/i18n';
+
+interface DeploymentGateProps {
+  eventId: string | undefined;
+  children: React.ReactNode;
+}
+
+export function DeploymentGate({ eventId, children }: DeploymentGateProps) {
+  const { t } = useI18n();
+  const { isReady, isChecking, status } = useDeploymentStatus(eventId);
+
+  if (isChecking) {
+    return (
+      <Box textAlign="center" padding="xxl">
+        <Spinner size="large" />
+      </Box>
+    );
+  }
+
+  if (!isReady && status) {
+    const message =
+      status.status === 'in_progress'
+        ? t('gameday.deploymentInProgress')
+        : status.status === 'failed'
+          ? t('gameday.deploymentFailed')
+          : t('gameday.deploymentNotReady');
+    return (
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <SpaceBetween size="m">
+            <StatusIndicator
+              type={status.status === 'in_progress' ? 'in-progress' : 'warning'}
+            >
+              {message}
+            </StatusIndicator>
+          </SpaceBetween>
+        </Box>
+      </Container>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/client/Application/components/gameday/deployment-gate.tsx
+++ b/client/Application/components/gameday/deployment-gate.tsx
@@ -22,13 +22,27 @@ interface DeploymentGateProps {
 
 export function DeploymentGate({ eventId, children }: DeploymentGateProps) {
   const { t } = useI18n();
-  const { isReady, isChecking, status } = useDeploymentStatus(eventId);
+  const { isReady, isChecking, status, checkError } =
+    useDeploymentStatus(eventId);
 
   if (isChecking) {
     return (
       <Box textAlign="center" padding="xxl">
         <Spinner size="large" />
       </Box>
+    );
+  }
+
+  // fail-closed: エラー時もブロック
+  if (checkError && !status) {
+    return (
+      <Container>
+        <Box textAlign="center" padding="xl">
+          <StatusIndicator type="error">
+            {t('gameday.deploymentNotReady')}
+          </StatusIndicator>
+        </Box>
+      </Container>
     );
   }
 

--- a/client/Application/components/gameday/index.ts
+++ b/client/Application/components/gameday/index.ts
@@ -8,6 +8,7 @@ export { AllianceStatusBadge } from './alliance-status-badge';
 export { AttackCard } from './attack-card';
 export { AttackTypeBadge } from './attack-type-badge';
 export { DefenseItem } from './defense-item';
+export { DeploymentGate } from './deployment-gate';
 export { GameStatusBar } from './game-status-bar';
 export { GameTimer } from './game-timer';
 export { HealthIndicator } from './health-indicator';

--- a/client/Application/lib/api/gameday-types.ts
+++ b/client/Application/lib/api/gameday-types.ts
@@ -123,3 +123,14 @@ export interface CooldownError {
   error: string;
   remainingSeconds: number;
 }
+
+export interface DeploymentStatus {
+  deployed: boolean;
+  status: string;
+  outputs: Record<string, string> | null;
+  roleArn: string | null;
+  externalId: string | null;
+  competitorAccountId: string | null;
+  region: string | null;
+  error: string | null;
+}

--- a/client/Application/lib/api/gameday.ts
+++ b/client/Application/lib/api/gameday.ts
@@ -3,7 +3,7 @@
  */
 
 import { getAuthToken } from '@/lib/auth/get-auth-token';
-import { getGamedayApiUrl } from '@/lib/api/backend-urls';
+import { getGamedayApiUrl, getProblemServiceUrl } from '@/lib/api/backend-urls';
 import { getLocalAttacks, isLocalGameDayEvent } from './gameday-local';
 import type {
   Alliance,
@@ -11,6 +11,7 @@ import type {
   AttackLog,
   AttackPurchase,
   AttackStats,
+  DeploymentStatus,
   GameState,
   HealthCheckResult,
   LeaderboardEntry,
@@ -260,4 +261,86 @@ export function updateTeamUrl(
     method: 'POST',
     body: JSON.stringify({ eventId, teamId, ...urls }),
   });
+}
+
+// --- Deployment Status ---
+
+const PROBLEM_SERVICE_URL = getProblemServiceUrl();
+
+const NOT_DEPLOYED_RESPONSE: DeploymentStatus = {
+  deployed: false,
+  status: 'not_found',
+  outputs: null,
+  roleArn: null,
+  externalId: null,
+  competitorAccountId: null,
+  region: null,
+  error: 'No deployment found',
+};
+
+/**
+ * 参加者向けデプロイメント状態取得（問題単位）
+ *
+ * problem-service の participant API を直接呼び出す
+ */
+export async function getDeploymentStatus(
+  eventId: string,
+  problemId: string,
+): Promise<DeploymentStatus> {
+  const token = await getAuthToken();
+  const url = `${PROBLEM_SERVICE_URL}/participant/events/${eventId}/problems/${problemId}/deployments/status`;
+
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return NOT_DEPLOYED_RESPONSE;
+    }
+    const body = await response
+      .json()
+      .catch(() => ({ error: 'Unknown error' }));
+    throw new Error(
+      (body as { error?: string }).error || `HTTP ${response.status}`,
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * 参加者向けデプロイメント状態取得（イベント全体）
+ *
+ * problem-service の participant API を直接呼び出す
+ */
+export async function getEventDeploymentStatus(
+  eventId: string,
+): Promise<DeploymentStatus> {
+  const token = await getAuthToken();
+  const url = `${PROBLEM_SERVICE_URL}/participant/events/${eventId}/deployments/status`;
+
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return NOT_DEPLOYED_RESPONSE;
+    }
+    const body = await response
+      .json()
+      .catch(() => ({ error: 'Unknown error' }));
+    throw new Error(
+      (body as { error?: string }).error || `HTTP ${response.status}`,
+    );
+  }
+
+  return response.json();
 }

--- a/client/Application/lib/hooks/use-deployment-status.ts
+++ b/client/Application/lib/hooks/use-deployment-status.ts
@@ -56,9 +56,8 @@ export function useDeploymentStatus(
         setCheckError(
           err instanceof Error ? err : new Error('Failed to check deployment'),
         );
-        // エラー時は fail-open: ネットワークエラー等でデプロイチェックが失敗しても
-        // ページ表示は許可する（gameday-service 側で実際の操作を制御する）
-        setIsReady(true);
+        // エラー時は fail-closed: デプロイチェックが失敗した場合は安全側に倒す
+        setIsReady(false);
       } finally {
         if (!cancelled) setIsChecking(false);
       }

--- a/client/Application/lib/hooks/use-deployment-status.ts
+++ b/client/Application/lib/hooks/use-deployment-status.ts
@@ -1,0 +1,75 @@
+/**
+ * Deployment Status Hook
+ *
+ * 参加者のデプロイメント状態を取得するカスタムフック。
+ * 攻撃/防御/投票ページで、環境がデプロイされていない場合に
+ * fail-closed エラーを表示するために使用する。
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getEventDeploymentStatus } from '@/lib/api/gameday';
+import type { DeploymentStatus } from '@/lib/api/gameday-types';
+
+interface UseDeploymentStatusResult {
+  /** デプロイが完了しているか */
+  isReady: boolean;
+  /** チェック中か */
+  isChecking: boolean;
+  /** デプロイメント状態の詳細 */
+  status: DeploymentStatus | null;
+  /** 取得エラー（ネットワークエラー等） */
+  checkError: Error | null;
+}
+
+/**
+ * イベントのデプロイメント状態を取得するフック
+ *
+ * @param eventId イベント ID
+ */
+export function useDeploymentStatus(
+  eventId: string | undefined,
+): UseDeploymentStatusResult {
+  const [isReady, setIsReady] = useState(false);
+  const [isChecking, setIsChecking] = useState(true);
+  const [status, setStatus] = useState<DeploymentStatus | null>(null);
+  const [checkError, setCheckError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!eventId) {
+      setIsChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function check() {
+      try {
+        const result = await getEventDeploymentStatus(eventId!);
+        if (cancelled) return;
+        setStatus(result);
+        setIsReady(result.deployed);
+        setCheckError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setCheckError(
+          err instanceof Error ? err : new Error('Failed to check deployment'),
+        );
+        // エラー時は fail-open: ネットワークエラー等でデプロイチェックが失敗しても
+        // ページ表示は許可する（gameday-service 側で実際の操作を制御する）
+        setIsReady(true);
+      } finally {
+        if (!cancelled) setIsChecking(false);
+      }
+    }
+
+    check();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId]);
+
+  return { isReady, isChecking, status, checkError };
+}

--- a/client/Application/lib/i18n.tsx
+++ b/client/Application/lib/i18n.tsx
@@ -168,6 +168,11 @@ const messages = {
       refreshesEvery30Seconds: '30秒ごとに自動更新',
       teams: 'teams',
       tutorial: 'ルール',
+      deploymentNotReady:
+        '環境のデプロイがまだ完了していません。管理者にお問い合わせください。',
+      deploymentInProgress: '環境をデプロイ中です。しばらくお待ちください。',
+      deploymentFailed:
+        '環境のデプロイに失敗しました。管理者にお問い合わせください。',
     },
     events: {
       title: 'イベント一覧',
@@ -442,6 +447,12 @@ const messages = {
       refreshesEvery30Seconds: 'Refreshes every 30 seconds',
       teams: 'teams',
       tutorial: 'Rules',
+      deploymentNotReady:
+        'The environment deployment has not been completed yet. Please contact your administrator.',
+      deploymentInProgress:
+        'The environment is being deployed. Please wait a moment.',
+      deploymentFailed:
+        'The environment deployment has failed. Please contact your administrator.',
     },
     events: {
       title: 'Events',

--- a/server/application/libs/dynamodb/src/tenant-repository.ts
+++ b/server/application/libs/dynamodb/src/tenant-repository.ts
@@ -89,6 +89,7 @@ function toDomain(item: TenantItem): Tenant {
     computeType: item.computeType,
     provisioningStatus: item.provisioningStatus,
     applicationDeploymentStatus: item.applicationDeploymentStatus,
+    applicationPlaneEndpoint: item.applicationPlaneEndpoint,
     provisionedResources: item.provisionedResources,
     provisioningError: item.provisioningError,
     provisionedAt: item.provisionedAt ? new Date(item.provisionedAt) : undefined,
@@ -274,6 +275,16 @@ export class TenantRepository {
         'applicationDeploymentStatus';
       expressionValues[':applicationDeploymentStatus'] =
         input.applicationDeploymentStatus;
+    }
+
+    if (input.applicationPlaneEndpoint !== undefined) {
+      updateExpressions.push(
+        '#applicationPlaneEndpoint = :applicationPlaneEndpoint',
+      );
+      expressionNames['#applicationPlaneEndpoint'] =
+        'applicationPlaneEndpoint';
+      expressionValues[':applicationPlaneEndpoint'] =
+        input.applicationPlaneEndpoint;
     }
 
     if (input.provisionedResources !== undefined) {

--- a/server/application/libs/dynamodb/src/tenant-types.ts
+++ b/server/application/libs/dynamodb/src/tenant-types.ts
@@ -92,6 +92,7 @@ export interface TenantItem extends DynamoDBItem {
   computeType: ComputeType;
   provisioningStatus: ProvisioningStatus;
   applicationDeploymentStatus?: ApplicationDeploymentStatus;
+  applicationPlaneEndpoint?: string;
   provisionedResources?: TenantProvisionedResources;
   provisioningError?: string | null;
   provisionedAt?: string;
@@ -135,6 +136,7 @@ export interface Tenant {
   computeType: ComputeType;
   provisioningStatus: ProvisioningStatus;
   applicationDeploymentStatus?: ApplicationDeploymentStatus;
+  applicationPlaneEndpoint?: string;
   provisionedResources?: TenantProvisionedResources;
   provisioningError?: string | null;
   provisionedAt?: Date;
@@ -196,6 +198,7 @@ export interface UpdateTenantInput {
   isolationModel?: IsolationModel;
   provisioningStatus?: ProvisioningStatus;
   applicationDeploymentStatus?: ApplicationDeploymentStatus;
+  applicationPlaneEndpoint?: string;
   provisionedResources?: TenantProvisionedResources;
   provisioningError?: string | null;
   provisionedAt?: Date;

--- a/server/application/microservices/problem-service/src/__tests__/routes-participant.test.ts
+++ b/server/application/microservices/problem-service/src/__tests__/routes-participant.test.ts
@@ -14,6 +14,8 @@ const {
   mockOpenClue,
   mockValidateAnswer,
   mockGetChallengeDetail,
+  mockGameDayJobFindByEventAndProblem,
+  mockCompetitorAccountFindByEventId,
 } = vi.hoisted(() => ({
   mockEventRepository: {
     findByTenant: vi.fn().mockResolvedValue([]),
@@ -49,6 +51,8 @@ const {
     success: false,
     error: 'Not found',
   }),
+  mockGameDayJobFindByEventAndProblem: vi.fn().mockResolvedValue([]),
+  mockCompetitorAccountFindByEventId: vi.fn().mockResolvedValue([]),
 }));
 
 // 依存関係をモック
@@ -93,6 +97,27 @@ vi.mock('../jam/scoring', () => ({
   openClue: (...args: unknown[]) => mockOpenClue(...args),
   validateAnswer: (...args: unknown[]) => mockValidateAnswer(...args),
 }));
+
+vi.mock('../repositories/gameday-deployment-job-repository', () => ({
+  GameDayDeploymentJobRepository: class {
+    findByEventAndProblem = mockGameDayJobFindByEventAndProblem;
+    findById = vi.fn().mockResolvedValue(null);
+    findActive = vi.fn().mockResolvedValue([]);
+    create = vi.fn();
+    updateStatus = vi.fn();
+  },
+}));
+
+vi.mock('../repositories/competitor-account-repository', () => {
+  class MockCompetitorAccountRepository {
+    findByEventId = mockCompetitorAccountFindByEventId;
+    findById = vi.fn().mockResolvedValue(null);
+    create = vi.fn();
+    updateStatus = vi.fn();
+    delete = vi.fn();
+  }
+  return { CompetitorAccountRepository: MockCompetitorAccountRepository };
+});
 
 import { authenticateRequest, hasRole } from '../auth';
 import { participantRouter } from '../routes/participant';
@@ -1611,6 +1636,190 @@ describe('Participant Routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.events).toEqual([]);
+    });
+  });
+
+  describe('GET /events/:eventId/deployments/status', () => {
+    beforeEach(() => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        isValid: true,
+        user: { id: 'user-1', tenantId: 'tenant-1', teamId: 'team-1', roles: ['competitor'] },
+      });
+      vi.mocked(hasRole).mockReturnValue(true);
+    });
+
+    it('イベントが見つからない場合は 404 を返すべき', async () => {
+      vi.mocked(getEventWithProblems).mockResolvedValue(null);
+
+      const res = await app.request('/api/participant/events/event-1/deployments/status');
+      expect(res.status).toBe(404);
+    });
+
+    it('デプロイジョブが完了している場合は deployed: true を返すべき', async () => {
+      vi.mocked(getEventWithProblems).mockResolvedValue({
+        event: { id: 'event-1', tenantId: 'tenant-1', type: 'GAMEDAY' } as never,
+        problems: [{ problemId: 'prob-1', order: 1 }] as never,
+      });
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([
+        {
+          id: 'job-1',
+          eventId: 'event-1',
+          problemId: 'prob-1',
+          competitorAccountId: 'acct-1',
+          status: 'completed',
+          result: {
+            success: true,
+            outputs: { WebsiteUrl: 'https://example.com' },
+          },
+        },
+      ]);
+      mockCompetitorAccountFindByEventId.mockResolvedValue([
+        {
+          id: 'acct-1',
+          name: 'team-1',
+          accountId: '123456789012',
+          roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+          externalId: 'ext-id-1',
+          region: 'ap-northeast-1',
+        },
+      ]);
+
+      const res = await app.request('/api/participant/events/event-1/deployments/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(true);
+      expect(body.outputs).toEqual({ WebsiteUrl: 'https://example.com' });
+      expect(body.roleArn).toBe('arn:aws:iam::123456789012:role/TestRole');
+    });
+
+    it('ジョブが未完了の場合は deployed: false を返すべき', async () => {
+      vi.mocked(getEventWithProblems).mockResolvedValue({
+        event: { id: 'event-1', tenantId: 'tenant-1', type: 'GAMEDAY' } as never,
+        problems: [{ problemId: 'prob-1', order: 1 }] as never,
+      });
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([
+        {
+          id: 'job-1',
+          eventId: 'event-1',
+          problemId: 'prob-1',
+          competitorAccountId: 'acct-1',
+          status: 'in_progress',
+          error: null,
+        },
+      ]);
+      mockCompetitorAccountFindByEventId.mockResolvedValue([
+        {
+          id: 'acct-1',
+          name: 'team-1',
+          accountId: '123456789012',
+          region: 'ap-northeast-1',
+        },
+      ]);
+
+      const res = await app.request('/api/participant/events/event-1/deployments/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(false);
+      expect(body.status).toBe('in_progress');
+    });
+
+    it('問題がない場合は deployed: false を返すべき', async () => {
+      vi.mocked(getEventWithProblems).mockResolvedValue({
+        event: { id: 'event-1', tenantId: 'tenant-1', type: 'GAMEDAY' } as never,
+        problems: [] as never,
+      });
+
+      const res = await app.request('/api/participant/events/event-1/deployments/status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(false);
+      expect(body.status).toBe('no_problems');
+    });
+  });
+
+  describe('GET /events/:eventId/problems/:problemId/deployments/status', () => {
+    beforeEach(() => {
+      vi.mocked(authenticateRequest).mockResolvedValue({
+        isValid: true,
+        user: { id: 'user-1', tenantId: 'tenant-1', teamId: 'team-1', roles: ['competitor'] },
+      });
+      vi.mocked(hasRole).mockReturnValue(true);
+    });
+
+    it('デプロイジョブがない場合は 404 を返すべき', async () => {
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([]);
+
+      const res = await app.request(
+        '/api/participant/events/event-1/problems/prob-1/deployments/status',
+      );
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.deployed).toBe(false);
+    });
+
+    it('チームのデプロイが完了している場合は deployed: true を返すべき', async () => {
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([
+        {
+          id: 'job-1',
+          eventId: 'event-1',
+          problemId: 'prob-1',
+          competitorAccountId: 'acct-1',
+          status: 'completed',
+          result: {
+            success: true,
+            outputs: { ApiUrl: 'https://api.example.com' },
+          },
+        },
+      ]);
+      mockCompetitorAccountFindByEventId.mockResolvedValue([
+        {
+          id: 'acct-1',
+          name: 'team-1',
+          accountId: '123456789012',
+          roleArn: 'arn:aws:iam::123456789012:role/TeamRole',
+          externalId: 'ext-1',
+          region: 'ap-northeast-1',
+        },
+      ]);
+
+      const res = await app.request(
+        '/api/participant/events/event-1/problems/prob-1/deployments/status',
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(true);
+      expect(body.outputs).toEqual({ ApiUrl: 'https://api.example.com' });
+      expect(body.roleArn).toBe('arn:aws:iam::123456789012:role/TeamRole');
+    });
+
+    it('デプロイが失敗している場合はエラー情報を返すべき', async () => {
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([
+        {
+          id: 'job-1',
+          eventId: 'event-1',
+          problemId: 'prob-1',
+          competitorAccountId: 'acct-1',
+          status: 'failed',
+          error: 'Stack creation failed',
+        },
+      ]);
+      mockCompetitorAccountFindByEventId.mockResolvedValue([
+        {
+          id: 'acct-1',
+          name: 'other-team',
+          accountId: '123456789012',
+          region: 'ap-northeast-1',
+        },
+      ]);
+
+      const res = await app.request(
+        '/api/participant/events/event-1/problems/prob-1/deployments/status',
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(false);
+      expect(body.status).toBe('failed');
+      expect(body.error).toBe('Stack creation failed');
     });
   });
 });

--- a/server/application/microservices/problem-service/src/__tests__/routes-participant.test.ts
+++ b/server/application/microservices/problem-service/src/__tests__/routes-participant.test.ts
@@ -1806,7 +1806,7 @@ describe('Participant Routes', () => {
       mockCompetitorAccountFindByEventId.mockResolvedValue([
         {
           id: 'acct-1',
-          name: 'other-team',
+          name: 'team-1',
           accountId: '123456789012',
           region: 'ap-northeast-1',
         },
@@ -1820,6 +1820,39 @@ describe('Participant Routes', () => {
       expect(body.deployed).toBe(false);
       expect(body.status).toBe('failed');
       expect(body.error).toBe('Stack creation failed');
+    });
+
+    it('他チームのデプロイデータにアクセスできないべき', async () => {
+      mockGameDayJobFindByEventAndProblem.mockResolvedValue([
+        {
+          id: 'job-1',
+          eventId: 'event-1',
+          problemId: 'prob-1',
+          competitorAccountId: 'acct-other',
+          status: 'completed',
+          result: { outputs: { Secret: 'should-not-see' } },
+        },
+      ]);
+      mockCompetitorAccountFindByEventId.mockResolvedValue([
+        {
+          id: 'acct-other',
+          name: 'other-team',
+          accountId: '999999999999',
+          roleArn: 'arn:aws:iam::999999999999:role/OtherRole',
+          externalId: 'secret-ext-id',
+          region: 'us-east-1',
+        },
+      ]);
+
+      const res = await app.request(
+        '/api/participant/events/event-1/problems/prob-1/deployments/status',
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deployed).toBe(false);
+      expect(body.status).toBe('pending');
+      expect(body.roleArn).toBeUndefined();
+      expect(body.externalId).toBeUndefined();
     });
   });
 });

--- a/server/application/microservices/problem-service/src/routes/participant/gameday.ts
+++ b/server/application/microservices/problem-service/src/routes/participant/gameday.ts
@@ -371,7 +371,10 @@ gamedayRoutes.get(
 		const { eventId } = c.req.param();
 
 		try {
-			const result = await getEventWithProblems(eventId);
+			const [result, accounts] = await Promise.all([
+				getEventWithProblems(eventId),
+				competitorAccountRepo.findByEventId(eventId),
+			]);
 			if (!result || result.event.tenantId !== user.tenantId) {
 				return c.json({ error: "Event not found", deployed: false }, 404);
 			}
@@ -380,8 +383,6 @@ gamedayRoutes.get(
 			if (eventProblems.length === 0) {
 				return c.json({ deployed: false, status: "no_problems", error: null });
 			}
-
-			const accounts = await competitorAccountRepo.findByEventId(eventId);
 			const teamId = user.teamId;
 
 			// 各 problem のジョブ状態を集約
@@ -395,9 +396,10 @@ gamedayRoutes.get(
 					if (teamAccount) {
 						const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
 						if (teamJob) {
+							const normalizedStatus = teamJob.status.toLowerCase();
 							return c.json({
-								deployed: teamJob.status === "completed",
-								status: teamJob.status,
+								deployed: normalizedStatus === "completed",
+								status: normalizedStatus,
 								outputs: teamJob.result?.outputs ?? null,
 								roleArn: teamAccount.roleArn ?? null,
 								externalId: teamAccount.externalId ?? null,
@@ -410,12 +412,12 @@ gamedayRoutes.get(
 				}
 
 				// completed なジョブを探す
-				const completedJob = jobs.find((j) => j.status === "completed");
+				const completedJob = jobs.find((j) => j.status.toLowerCase() === "completed");
 				if (completedJob) {
 					const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
 					return c.json({
 						deployed: true,
-						status: completedJob.status,
+						status: completedJob.status.toLowerCase(),
 						outputs: completedJob.result?.outputs ?? null,
 						roleArn: account?.roleArn ?? null,
 						externalId: account?.externalId ?? null,
@@ -452,7 +454,10 @@ gamedayRoutes.get(
 		const { eventId, problemId } = c.req.param();
 
 		try {
-			const jobs = await gamedayJobRepo.findByEventAndProblem(eventId, problemId);
+			const [jobs, accounts] = await Promise.all([
+				gamedayJobRepo.findByEventAndProblem(eventId, problemId),
+				competitorAccountRepo.findByEventId(eventId),
+			]);
 			if (jobs.length === 0) {
 				return c.json({
 					error: "No deployment found for this event and problem",
@@ -461,7 +466,6 @@ gamedayRoutes.get(
 			}
 
 			// ユーザーのチーム ID で紐づく competitor account を探す
-			const accounts = await competitorAccountRepo.findByEventId(eventId);
 			const teamId = user.teamId;
 
 			// チーム ID がある場合、そのチームの competitor account に紐づくジョブを返す
@@ -470,9 +474,10 @@ gamedayRoutes.get(
 				if (teamAccount) {
 					const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
 					if (teamJob) {
+						const normalizedStatus = teamJob.status.toLowerCase();
 						return c.json({
-							deployed: teamJob.status === "completed",
-							status: teamJob.status,
+							deployed: normalizedStatus === "completed",
+							status: normalizedStatus,
 							outputs: teamJob.result?.outputs ?? null,
 							roleArn: teamAccount.roleArn ?? null,
 							externalId: teamAccount.externalId ?? null,
@@ -485,12 +490,12 @@ gamedayRoutes.get(
 			}
 
 			// チーム ID がないか見つからない場合は、最初の completed ジョブを返す
-			const completedJob = jobs.find((j) => j.status === "completed");
+			const completedJob = jobs.find((j) => j.status.toLowerCase() === "completed");
 			if (completedJob) {
 				const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
 				return c.json({
 					deployed: true,
-					status: completedJob.status,
+					status: completedJob.status.toLowerCase(),
 					outputs: completedJob.result?.outputs ?? null,
 					roleArn: account?.roleArn ?? null,
 					externalId: account?.externalId ?? null,
@@ -505,7 +510,7 @@ gamedayRoutes.get(
 			const latestAccount = accounts.find((a) => a.id === latestJob.competitorAccountId);
 			return c.json({
 				deployed: false,
-				status: latestJob.status,
+				status: latestJob.status.toLowerCase(),
 				outputs: null,
 				roleArn: latestAccount?.roleArn ?? null,
 				externalId: latestAccount?.externalId ?? null,

--- a/server/application/microservices/problem-service/src/routes/participant/gameday.ts
+++ b/server/application/microservices/problem-service/src/routes/participant/gameday.ts
@@ -385,45 +385,31 @@ gamedayRoutes.get(
 			}
 			const teamId = user.teamId;
 
-			// 各 problem のジョブ状態を集約
+			// チーム ID がない場合はデータを返さない（cross-team leak 防止）
+			if (!teamId) {
+				return c.json({ deployed: false, status: "pending", error: null });
+			}
+
+			const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
+			if (!teamAccount) {
+				return c.json({ deployed: false, status: "pending", error: null });
+			}
+
+			// 自チームのジョブのみ検索
 			for (const ep of eventProblems) {
 				const jobs = await gamedayJobRepo.findByEventAndProblem(eventId, ep.problemId);
-				if (jobs.length === 0) continue;
-
-				// チーム ID がある場合、対応する competitor account のジョブを探す
-				if (teamId) {
-					const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
-					if (teamAccount) {
-						const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
-						if (teamJob) {
-							const normalizedStatus = teamJob.status.toLowerCase();
-							return c.json({
-								deployed: normalizedStatus === "completed",
-								status: normalizedStatus,
-								outputs: teamJob.result?.outputs ?? null,
-								roleArn: teamAccount.roleArn ?? null,
-								externalId: teamAccount.externalId ?? null,
-								competitorAccountId: teamAccount.accountId,
-								region: teamAccount.region,
-								error: teamJob.error ?? null,
-							});
-						}
-					}
-				}
-
-				// completed なジョブを探す
-				const completedJob = jobs.find((j) => j.status.toLowerCase() === "completed");
-				if (completedJob) {
-					const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
+				const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
+				if (teamJob) {
+					const normalizedStatus = teamJob.status.toLowerCase();
 					return c.json({
-						deployed: true,
-						status: completedJob.status.toLowerCase(),
-						outputs: completedJob.result?.outputs ?? null,
-						roleArn: account?.roleArn ?? null,
-						externalId: account?.externalId ?? null,
-						competitorAccountId: account?.accountId ?? null,
-						region: account?.region ?? null,
-						error: null,
+						deployed: normalizedStatus === "completed",
+						status: normalizedStatus,
+						outputs: teamJob.result?.outputs ?? null,
+						roleArn: teamAccount.roleArn ?? null,
+						externalId: teamAccount.externalId ?? null,
+						competitorAccountId: teamAccount.accountId,
+						region: teamAccount.region,
+						error: teamJob.error ?? null,
 					});
 				}
 			}
@@ -454,10 +440,16 @@ gamedayRoutes.get(
 		const { eventId, problemId } = c.req.param();
 
 		try {
-			const [jobs, accounts] = await Promise.all([
+			// テナント分離: イベントが自テナントに属するか確認
+			const [eventResult, jobs, accounts] = await Promise.all([
+				getEventWithProblems(eventId),
 				gamedayJobRepo.findByEventAndProblem(eventId, problemId),
 				competitorAccountRepo.findByEventId(eventId),
 			]);
+			if (!eventResult || eventResult.event.tenantId !== user.tenantId) {
+				return c.json({ error: "Event not found", deployed: false }, 404);
+			}
+
 			if (jobs.length === 0) {
 				return c.json({
 					error: "No deployment found for this event and problem",
@@ -465,58 +457,33 @@ gamedayRoutes.get(
 				}, 404);
 			}
 
-			// ユーザーのチーム ID で紐づく competitor account を探す
+			// チーム ID がない場合はデータを返さない（cross-team leak 防止）
 			const teamId = user.teamId;
-
-			// チーム ID がある場合、そのチームの competitor account に紐づくジョブを返す
-			if (teamId) {
-				const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
-				if (teamAccount) {
-					const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
-					if (teamJob) {
-						const normalizedStatus = teamJob.status.toLowerCase();
-						return c.json({
-							deployed: normalizedStatus === "completed",
-							status: normalizedStatus,
-							outputs: teamJob.result?.outputs ?? null,
-							roleArn: teamAccount.roleArn ?? null,
-							externalId: teamAccount.externalId ?? null,
-							competitorAccountId: teamAccount.accountId,
-							region: teamAccount.region,
-							error: teamJob.error ?? null,
-						});
-					}
-				}
+			if (!teamId) {
+				return c.json({ deployed: false, status: "pending", error: null });
 			}
 
-			// チーム ID がないか見つからない場合は、最初の completed ジョブを返す
-			const completedJob = jobs.find((j) => j.status.toLowerCase() === "completed");
-			if (completedJob) {
-				const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
-				return c.json({
-					deployed: true,
-					status: completedJob.status.toLowerCase(),
-					outputs: completedJob.result?.outputs ?? null,
-					roleArn: account?.roleArn ?? null,
-					externalId: account?.externalId ?? null,
-					competitorAccountId: account?.accountId ?? null,
-					region: account?.region ?? null,
-					error: null,
-				});
+			const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
+			if (!teamAccount) {
+				return c.json({ deployed: false, status: "pending", error: null });
 			}
 
-			// 全ジョブが未完了の場合
-			const latestJob = jobs[0];
-			const latestAccount = accounts.find((a) => a.id === latestJob.competitorAccountId);
+			// 自チームのジョブのみ返す
+			const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
+			if (!teamJob) {
+				return c.json({ deployed: false, status: "pending", error: null });
+			}
+
+			const normalizedStatus = teamJob.status.toLowerCase();
 			return c.json({
-				deployed: false,
-				status: latestJob.status.toLowerCase(),
-				outputs: null,
-				roleArn: latestAccount?.roleArn ?? null,
-				externalId: latestAccount?.externalId ?? null,
-				competitorAccountId: latestAccount?.accountId ?? null,
-				region: latestAccount?.region ?? null,
-				error: latestJob.error ?? null,
+				deployed: normalizedStatus === "completed",
+				status: normalizedStatus,
+				outputs: teamJob.result?.outputs ?? null,
+				roleArn: teamAccount.roleArn ?? null,
+				externalId: teamAccount.externalId ?? null,
+				competitorAccountId: teamAccount.accountId,
+				region: teamAccount.region,
+				error: teamJob.error ?? null,
 			});
 		} catch (error) {
 			logger.error({ error }, "Failed to fetch deployment status");

--- a/server/application/microservices/problem-service/src/routes/participant/gameday.ts
+++ b/server/application/microservices/problem-service/src/routes/participant/gameday.ts
@@ -18,10 +18,18 @@ import {
 import { getChallengeDetail } from "../../jam/challenge";
 import { openClue, validateAnswer } from "../../jam/scoring";
 import type { ScoringCriterion } from "../../types";
+import {
+	GameDayDeploymentJobRepository,
+} from "../../repositories/gameday-deployment-job-repository";
+import {
+	CompetitorAccountRepository,
+} from "../../repositories/competitor-account-repository";
 
 const logger = createLogger("participant-gameday");
 const gamedayRoutes = new Hono();
 const problemRepository = new PrismaProblemRepository();
+const gamedayJobRepo = new GameDayDeploymentJobRepository();
+const competitorAccountRepo = new CompetitorAccountRepository();
 
 /** JAMチャレンジ詳細を取得（クルー付き） */
 gamedayRoutes.get(
@@ -340,5 +348,176 @@ gamedayRoutes.post(
 		return c.json({ error: "Failed to leave team" }, 500);
 	}
 });
+
+// ====================
+// デプロイメント状態取得
+// ====================
+
+/** イベント全体のデプロイメント状態取得（参加者向け） */
+gamedayRoutes.get(
+	"/events/:eventId/deployments/status",
+	describeRoute({
+		tags: ["Participant / Challenges"],
+		summary: "イベント全体のデプロイメント状態取得",
+		responses: {
+			200: { description: "成功" },
+			401: { description: "認証エラー" },
+			403: { description: "権限エラー" },
+			404: { description: "デプロイレコードが見つかりません" },
+		},
+	}),
+	async (c) => {
+		const user = c.get("user") as AuthenticatedUser;
+		const { eventId } = c.req.param();
+
+		try {
+			const result = await getEventWithProblems(eventId);
+			if (!result || result.event.tenantId !== user.tenantId) {
+				return c.json({ error: "Event not found", deployed: false }, 404);
+			}
+
+			const { problems: eventProblems } = result;
+			if (eventProblems.length === 0) {
+				return c.json({ deployed: false, status: "no_problems", error: null });
+			}
+
+			const accounts = await competitorAccountRepo.findByEventId(eventId);
+			const teamId = user.teamId;
+
+			// 各 problem のジョブ状態を集約
+			for (const ep of eventProblems) {
+				const jobs = await gamedayJobRepo.findByEventAndProblem(eventId, ep.problemId);
+				if (jobs.length === 0) continue;
+
+				// チーム ID がある場合、対応する competitor account のジョブを探す
+				if (teamId) {
+					const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
+					if (teamAccount) {
+						const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
+						if (teamJob) {
+							return c.json({
+								deployed: teamJob.status === "completed",
+								status: teamJob.status,
+								outputs: teamJob.result?.outputs ?? null,
+								roleArn: teamAccount.roleArn ?? null,
+								externalId: teamAccount.externalId ?? null,
+								competitorAccountId: teamAccount.accountId,
+								region: teamAccount.region,
+								error: teamJob.error ?? null,
+							});
+						}
+					}
+				}
+
+				// completed なジョブを探す
+				const completedJob = jobs.find((j) => j.status === "completed");
+				if (completedJob) {
+					const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
+					return c.json({
+						deployed: true,
+						status: completedJob.status,
+						outputs: completedJob.result?.outputs ?? null,
+						roleArn: account?.roleArn ?? null,
+						externalId: account?.externalId ?? null,
+						competitorAccountId: account?.accountId ?? null,
+						region: account?.region ?? null,
+						error: null,
+					});
+				}
+			}
+
+			return c.json({ deployed: false, status: "pending", error: null });
+		} catch (error) {
+			logger.error({ error }, "Failed to fetch event deployment status");
+			return c.json({ error: "Failed to fetch deployment status" }, 500);
+		}
+	},
+);
+
+/** 参加者向けデプロイメント状態取得 */
+gamedayRoutes.get(
+	"/events/:eventId/problems/:problemId/deployments/status",
+	describeRoute({
+		tags: ["Participant / Challenges"],
+		summary: "参加者向けデプロイメント状態取得",
+		responses: {
+			200: { description: "成功" },
+			401: { description: "認証エラー" },
+			403: { description: "権限エラー" },
+			404: { description: "デプロイレコードが見つかりません" },
+		},
+	}),
+	async (c) => {
+		const user = c.get("user") as AuthenticatedUser;
+		const { eventId, problemId } = c.req.param();
+
+		try {
+			const jobs = await gamedayJobRepo.findByEventAndProblem(eventId, problemId);
+			if (jobs.length === 0) {
+				return c.json({
+					error: "No deployment found for this event and problem",
+					deployed: false,
+				}, 404);
+			}
+
+			// ユーザーのチーム ID で紐づく competitor account を探す
+			const accounts = await competitorAccountRepo.findByEventId(eventId);
+			const teamId = user.teamId;
+
+			// チーム ID がある場合、そのチームの competitor account に紐づくジョブを返す
+			if (teamId) {
+				const teamAccount = accounts.find((a) => a.name === teamId || a.id === teamId);
+				if (teamAccount) {
+					const teamJob = jobs.find((j) => j.competitorAccountId === teamAccount.id);
+					if (teamJob) {
+						return c.json({
+							deployed: teamJob.status === "completed",
+							status: teamJob.status,
+							outputs: teamJob.result?.outputs ?? null,
+							roleArn: teamAccount.roleArn ?? null,
+							externalId: teamAccount.externalId ?? null,
+							competitorAccountId: teamAccount.accountId,
+							region: teamAccount.region,
+							error: teamJob.error ?? null,
+						});
+					}
+				}
+			}
+
+			// チーム ID がないか見つからない場合は、最初の completed ジョブを返す
+			const completedJob = jobs.find((j) => j.status === "completed");
+			if (completedJob) {
+				const account = accounts.find((a) => a.id === completedJob.competitorAccountId);
+				return c.json({
+					deployed: true,
+					status: completedJob.status,
+					outputs: completedJob.result?.outputs ?? null,
+					roleArn: account?.roleArn ?? null,
+					externalId: account?.externalId ?? null,
+					competitorAccountId: account?.accountId ?? null,
+					region: account?.region ?? null,
+					error: null,
+				});
+			}
+
+			// 全ジョブが未完了の場合
+			const latestJob = jobs[0];
+			const latestAccount = accounts.find((a) => a.id === latestJob.competitorAccountId);
+			return c.json({
+				deployed: false,
+				status: latestJob.status,
+				outputs: null,
+				roleArn: latestAccount?.roleArn ?? null,
+				externalId: latestAccount?.externalId ?? null,
+				competitorAccountId: latestAccount?.accountId ?? null,
+				region: latestAccount?.region ?? null,
+				error: latestJob.error ?? null,
+			});
+		} catch (error) {
+			logger.error({ error }, "Failed to fetch deployment status");
+			return c.json({ error: "Failed to fetch deployment status" }, 500);
+		}
+	},
+);
 
 export { gamedayRoutes };

--- a/server/application/microservices/tenant-management/src/__tests__/provisioning.test.ts
+++ b/server/application/microservices/tenant-management/src/__tests__/provisioning.test.ts
@@ -301,6 +301,36 @@ describe('プロビジョニング API', () => {
       expect(body.provisioningEnabled).toBe(false); // Disabled in test env
     });
 
+    it('applicationPlaneEndpoint をレスポンスに含めるべき', async () => {
+      const mockTenant = createMockTenant({
+        provisioningStatus: 'COMPLETED',
+        applicationDeploymentStatus: 'DEPLOYED',
+        applicationPlaneEndpoint: 'http://localhost:13001?tenant=test-organization',
+      });
+      mockTenantRepoFunctions.findById.mockResolvedValue(mockTenant);
+
+      const res = await app.request(`/api/tenants/${mockTenant.id}/provision`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.applicationPlaneEndpoint).toBe(
+        'http://localhost:13001?tenant=test-organization'
+      );
+    });
+
+    it('applicationPlaneEndpoint が未設定の場合は undefined を返すべき', async () => {
+      const mockTenant = createMockTenant({
+        provisioningStatus: 'PENDING',
+      });
+      mockTenantRepoFunctions.findById.mockResolvedValue(mockTenant);
+
+      const res = await app.request(`/api/tenants/${mockTenant.id}/provision`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.applicationPlaneEndpoint).toBeUndefined();
+    });
+
     it('存在しないテナントで 404 エラーになるべき', async () => {
       mockTenantRepoFunctions.findById.mockResolvedValue(null);
 

--- a/server/application/microservices/tenant-management/src/provisioning/manager.test.ts
+++ b/server/application/microservices/tenant-management/src/provisioning/manager.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockUpdateProvisioningStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/dynamodb', () => ({
+  tenantRepository: {
+    update: mockUpdate,
+    updateProvisioningStatus: mockUpdateProvisioningStatus,
+  },
+}));
+
+vi.mock('./keycloak', () => ({
+  KeycloakProvisioner: vi.fn().mockImplementation(() => ({
+    createRealm: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('./kubernetes', () => ({
+  KubernetesProvisioner: vi.fn().mockImplementation(() => ({
+    createNamespace: vi.fn().mockResolvedValue('test-tenant'),
+    deployParticipantApp: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import type { Tenant } from '@tenkacloud/dynamodb';
+import {
+  ProvisioningManager,
+  resolveApplicationPlaneEndpoint,
+} from './manager';
+
+const mockTenant: Tenant = {
+  id: '01HJXK5K3VDXK5YPNZBKRT5ABC',
+  name: 'Test Tenant',
+  slug: 'test-tenant',
+  adminEmail: 'admin@example.com',
+  tier: 'FREE',
+  status: 'ACTIVE',
+  region: 'ap-northeast-1',
+  isolationModel: 'POOL',
+  computeType: 'SERVERLESS',
+  provisioningStatus: 'PENDING',
+  createdAt: new Date('2026-04-11T00:00:00.000Z'),
+  updatedAt: new Date('2026-04-11T00:00:00.000Z'),
+};
+
+describe('resolveApplicationPlaneEndpoint', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('APPLICATION_PLANE_BASE_URL が設定されている場合はそれを使用すべき', () => {
+    vi.stubEnv('APPLICATION_PLANE_BASE_URL', 'https://app.example.com');
+    const result = resolveApplicationPlaneEndpoint('my-tenant');
+    expect(result).toBe('https://app.example.com?tenant=my-tenant');
+  });
+
+  it('本番環境ではサブドメイン形式の URL を返すべき', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const result = resolveApplicationPlaneEndpoint('my-tenant');
+    expect(result).toBe('https://my-tenant.tenka.cloud');
+  });
+
+  it('ローカル開発環境では localhost URL を返すべき', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const result = resolveApplicationPlaneEndpoint('my-tenant');
+    expect(result).toBe('http://localhost:13001?tenant=my-tenant');
+  });
+
+  it('APPLICATION_PLANE_BASE_URL が NODE_ENV=production より優先されるべき', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('APPLICATION_PLANE_BASE_URL', 'https://custom.example.com');
+    const result = resolveApplicationPlaneEndpoint('my-tenant');
+    expect(result).toBe('https://custom.example.com?tenant=my-tenant');
+  });
+
+  it('slug に特殊文字がある場合はエンコードすべき', () => {
+    const result = resolveApplicationPlaneEndpoint('my tenant&co');
+    expect(result).toBe(
+      'http://localhost:13001?tenant=my%20tenant%26co',
+    );
+  });
+});
+
+describe('ProvisioningManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockUpdate.mockResolvedValue(mockTenant);
+    mockUpdateProvisioningStatus.mockResolvedValue(mockTenant);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('プロビジョニング完了時に applicationPlaneEndpoint を設定すべき', async () => {
+    const manager = new ProvisioningManager();
+
+    await manager.provisionTenant(mockTenant);
+
+    expect(mockUpdate).toHaveBeenCalledWith(mockTenant.id, {
+      provisioningStatus: 'COMPLETED',
+      applicationDeploymentStatus: 'DEPLOYED',
+      applicationPlaneEndpoint: 'http://localhost:13001?tenant=test-tenant',
+      status: 'ACTIVE',
+    });
+  });
+
+  it('プロビジョニング完了時に APPLICATION_PLANE_BASE_URL からエンドポイントを解決すべき', async () => {
+    vi.stubEnv('APPLICATION_PLANE_BASE_URL', 'https://app.tenka.cloud');
+    const manager = new ProvisioningManager();
+
+    await manager.provisionTenant(mockTenant);
+
+    expect(mockUpdate).toHaveBeenCalledWith(mockTenant.id, {
+      provisioningStatus: 'COMPLETED',
+      applicationDeploymentStatus: 'DEPLOYED',
+      applicationPlaneEndpoint: 'https://app.tenka.cloud?tenant=test-tenant',
+      status: 'ACTIVE',
+    });
+  });
+
+  it('プロビジョニング失敗時は FAILED ステータスに更新すべき', async () => {
+    mockUpdateProvisioningStatus.mockRejectedValueOnce(undefined);
+    mockUpdateProvisioningStatus
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    // Make createRealm throw to trigger failure path
+    const { KeycloakProvisioner } = await import('./keycloak');
+    const mockCreateRealm = vi
+      .fn()
+      .mockRejectedValue(new Error('Keycloak unavailable'));
+    vi.mocked(KeycloakProvisioner).mockImplementation(
+      () =>
+        ({
+          createRealm: mockCreateRealm,
+        }) as unknown as InstanceType<typeof KeycloakProvisioner>,
+    );
+
+    const manager = new ProvisioningManager();
+    await manager.provisionTenant(mockTenant);
+
+    expect(mockUpdateProvisioningStatus).toHaveBeenCalledWith(
+      mockTenant.id,
+      'FAILED',
+    );
+  });
+});

--- a/server/application/microservices/tenant-management/src/provisioning/manager.test.ts
+++ b/server/application/microservices/tenant-management/src/provisioning/manager.test.ts
@@ -135,10 +135,10 @@ describe('ProvisioningManager', () => {
   });
 
   it('プロビジョニング失敗時は FAILED ステータスに更新すべき', async () => {
-    mockUpdateProvisioningStatus.mockRejectedValueOnce(undefined);
-    mockUpdateProvisioningStatus
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined);
+    // 1st call: IN_PROGRESS update succeeds
+    mockUpdateProvisioningStatus.mockResolvedValueOnce(undefined);
+    // 2nd call: FAILED update succeeds
+    mockUpdateProvisioningStatus.mockResolvedValueOnce(undefined);
 
     // Make createRealm throw to trigger failure path
     const { KeycloakProvisioner } = await import('./keycloak');
@@ -155,6 +155,12 @@ describe('ProvisioningManager', () => {
     const manager = new ProvisioningManager();
     await manager.provisionTenant(mockTenant);
 
+    // First call sets IN_PROGRESS
+    expect(mockUpdateProvisioningStatus).toHaveBeenCalledWith(
+      mockTenant.id,
+      'IN_PROGRESS',
+    );
+    // Second call sets FAILED after createRealm throws
     expect(mockUpdateProvisioningStatus).toHaveBeenCalledWith(
       mockTenant.id,
       'FAILED',

--- a/server/application/microservices/tenant-management/src/provisioning/manager.ts
+++ b/server/application/microservices/tenant-management/src/provisioning/manager.ts
@@ -17,7 +17,7 @@ export function resolveApplicationPlaneEndpoint(slug: string): string {
     return `${baseUrl}?tenant=${encodeURIComponent(slug)}`;
   }
   if (process.env.NODE_ENV === 'production') {
-    return `https://${encodeURIComponent(slug)}.tenka.cloud`;
+    return `https://${slug}.tenka.cloud`;
   }
   return `http://localhost:13001?tenant=${encodeURIComponent(slug)}`;
 }

--- a/server/application/microservices/tenant-management/src/provisioning/manager.ts
+++ b/server/application/microservices/tenant-management/src/provisioning/manager.ts
@@ -6,6 +6,22 @@ import type { Tenant } from '@tenkacloud/dynamodb';
 
 const logger = createLogger('provisioning-manager');
 
+/**
+ * Resolve the Application Plane URL for a tenant.
+ * - Local dev: http://localhost:13001?tenant={slug}
+ * - Production: https://{slug}.tenka.cloud (or APPLICATION_PLANE_BASE_URL)
+ */
+export function resolveApplicationPlaneEndpoint(slug: string): string {
+  const baseUrl = process.env.APPLICATION_PLANE_BASE_URL;
+  if (baseUrl) {
+    return `${baseUrl}?tenant=${encodeURIComponent(slug)}`;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return `https://${encodeURIComponent(slug)}.tenka.cloud`;
+  }
+  return `http://localhost:13001?tenant=${encodeURIComponent(slug)}`;
+}
+
 export class ProvisioningManager {
   private keycloakProvisioner: KeycloakProvisioner;
   private k8sProvisioner: KubernetesProvisioner;
@@ -37,9 +53,16 @@ export class ProvisioningManager {
       // Deploy Participant App (Base)
       await this.k8sProvisioner.deployParticipantApp(tenant.slug, namespace);
 
-      // 3. Update status to COMPLETED
+      // 3. Resolve Application Plane endpoint
+      const applicationPlaneEndpoint = resolveApplicationPlaneEndpoint(
+        tenant.slug,
+      );
+
+      // 4. Update status to COMPLETED
       await tenantRepository.update(tenant.id, {
         provisioningStatus: 'COMPLETED',
+        applicationDeploymentStatus: 'DEPLOYED',
+        applicationPlaneEndpoint,
         status: 'ACTIVE',
       });
 

--- a/server/application/microservices/tenant-management/src/routes/provisioning.ts
+++ b/server/application/microservices/tenant-management/src/routes/provisioning.ts
@@ -175,6 +175,7 @@ provisioningRoutes.get(
       provisioningStatus: tenant.provisioningStatus,
       applicationDeploymentStatus:
         tenant.applicationDeploymentStatus ?? 'NOT_DEPLOYED',
+      applicationPlaneEndpoint: tenant.applicationPlaneEndpoint,
       provisionedResources: isPlatformAdmin
         ? tenant.provisionedResources
         : undefined,


### PR DESCRIPTION
## Summary

Closes the last two gaps in the one-pass E2E flow + security hardening.

### Issue 372 — Tenant Application Plane runtime descriptor
- Add `applicationPlaneEndpoint` to tenant types (DynamoDB, domain, API)
- Set endpoint on provisioning completion (local: `localhost:13001?tenant={slug}`, prod: `{slug}.tenka.cloud`)
- Show clickable endpoint link in AdminWeb provisioning card
- 12 new tests

### Issue 373 — Problem deploy record → participant runtime
- Add participant deployment status endpoints (event-level + problem-level)
- Update `aws-console` route to fetch `roleArn` from deployment record
- Add `useDeploymentStatus` hook for fail-closed behavior
- Attack/defense/vote pages show explicit error when deployment not ready
- 16 new tests

### Simplify fixes
- Extract `DeploymentGate` shared component (removed 3-way copy-paste)
- Replace N+1 HTTP fetch in aws-console route with single call
- Parallelize independent DynamoDB queries with `Promise.all`
- Normalize deployment job status to lowercase
- Rewrite vote page from Tailwind to Cloudscape

### Security fixes
- **Vuln 1 (HIGH)**: Add tenant isolation to per-problem deployment endpoint (was missing `tenantId` check, allowing cross-tenant IDOR)
- **Vuln 2 (MEDIUM)**: Remove cross-team data fallback that leaked other teams' `roleArn`/`externalId`/`outputs`
- Added regression test: 他チームのデプロイデータにアクセスできないべき

### Quality gate updates (CLAUDE.md / AGENTS.md)
- PR requires: harness → before-commit → /review → /security-review → /simplify
- Work order: docs update and refactoring before new features

## Test plan
- [ ] 28+ new tests pass
- [ ] Security regression test confirms cross-team isolation
- [ ] `make test_one_pass_local` shows fewer blocked steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application Plane endpoint is now displayed in the tenant provisioning interface when deployment is complete.
  * Attack, defense, and voting pages are now protected by deployment status checks to ensure the environment is ready before participant access.
  * AWS console role configuration now resolves from deployment records as a primary source.

* **Improvements**
  * Added safe URL validation for external link rendering to prevent malicious schemes.
  * Enhanced user interface for gameday pages with improved design components.

* **Tests**
  * Added comprehensive test coverage for deployment status checking and provisioning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->