### PR TITLE
fix: show game init button for uninitialized GameDay events

### DIFF
--- a/client/Application/app/(admin)/admin/gameday/[eventId]/page.tsx
+++ b/client/Application/app/(admin)/admin/gameday/[eventId]/page.tsx
@@ -33,6 +33,7 @@ import {
   getAttackLogs,
   getGameStatus,
   getTeams,
+  initGame,
   registerTeam,
   seedAttacks,
   startAuditor,
@@ -244,11 +245,43 @@ export default function AdminGamedayControlPage() {
   }
 
   if (error) {
+    const isGameNotFound =
+      error.includes('ゲームが見つかりません') ||
+      error.includes('Game not found');
     return (
       <Box textAlign="center" padding="l">
         <SpaceBetween size="m">
-          <StatusIndicator type="error">{error}</StatusIndicator>
-          <Button onClick={fetchData}>再読み込み</Button>
+          <StatusIndicator type={isGameNotFound ? 'info' : 'error'}>
+            {isGameNotFound
+              ? 'このイベントのゲームはまだ初期化されていません'
+              : error}
+          </StatusIndicator>
+          {isGameNotFound ? (
+            <Button
+              variant="primary"
+              loading={actionLoading}
+              onClick={async () => {
+                setActionLoading(true);
+                try {
+                  await initGame(eventId);
+                  setError(null);
+                  await fetchData();
+                } catch (e) {
+                  setError(
+                    e instanceof Error
+                      ? e.message
+                      : 'ゲーム初期化に失敗しました',
+                  );
+                } finally {
+                  setActionLoading(false);
+                }
+              }}
+            >
+              ゲームを初期化
+            </Button>
+          ) : (
+            <Button onClick={fetchData}>再読み込み</Button>
+          )}
         </SpaceBetween>
       </Box>
     );

--- a/client/Application/lib/api/gameday-admin.ts
+++ b/client/Application/lib/api/gameday-admin.ts
@@ -123,6 +123,18 @@ export function getGameStatus(eventId: string) {
   );
 }
 
+export function initGame(eventId: string, durationMinutes = 120) {
+  return withLocalFallback(
+    eventId,
+    () =>
+      adminRequest<GameState>('/game/init', {
+        method: 'POST',
+        body: JSON.stringify({ eventId, durationMinutes }),
+      }),
+    () => getLocalGameState(eventId),
+  );
+}
+
 // --- Score & Features ---
 
 export function toggleScoreWeight(eventId: string) {


### PR DESCRIPTION
## Summary

When navigating to a GameDay event that hasn't been initialized in gameday-service, the page showed a cryptic error "ゲームが見つかりません" with only a reload button.

Now shows:
- Info indicator: "このイベントのゲームはまだ初期化されていません"
- Primary button: "ゲームを初期化" → calls `POST /game/init`
- After init, automatically reloads the game state

Also adds `initGame()` to the gameday-admin API client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)