### PR TITLE
fix: add make format target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ start-aws:
 lint_text:
 	@$(BUN) run lint_text
 
+#? format: Auto-format all code
+format:
+	@$(BUN) run format
+
 #? format_check: Check code formatting
 format_check:
 	@$(BUN) run format_check


### PR DESCRIPTION
make format_check existed but make format was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build system with a new formatting command to support code formatting operations during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->