### PR TITLE
docs: competitor IAM Role CFn template + onboarding guide

### DIFF
--- a/client/Application/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/client/Application/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -506,7 +506,7 @@ export default function GameDayDeploymentsPage() {
               <a
                 href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md"
                 target="_blank"
-                rel="noreferrer"
+                rel="noreferrer noopener"
               >
                 競技者オンボーディング手順
               </a>{' '}

--- a/client/Application/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
+++ b/client/Application/app/(admin)/admin/events/[eventId]/problems/[problemId]/deployments/page.tsx
@@ -501,6 +501,17 @@ export default function GameDayDeploymentsPage() {
         <Form>
           <SpaceBetween size="m">
             {addAccountError && <Alert type="error">{addAccountError}</Alert>}
+            <Alert type="info">
+              Role ARN / External ID は競技者側で{' '}
+              <a
+                href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md"
+                target="_blank"
+                rel="noreferrer"
+              >
+                競技者オンボーディング手順
+              </a>{' '}
+              に従って IAM Role を作成してから入手してください。
+            </Alert>
             <FormField label="チーム名" constraintText="必須">
               <Input
                 value={newAccount.name}
@@ -533,7 +544,7 @@ export default function GameDayDeploymentsPage() {
             </FormField>
             <FormField
               label="Role ARN"
-              description="AssumeRole で使用する IAM ロール ARN（省略時は環境変数の認証情報を使用）"
+              description="AssumeRole で使用する IAM ロール ARN。AWS 本番デプロイには必須（空欄だと deploy ジョブが即失敗します）"
             >
               <Input
                 value={newAccount.roleArn}
@@ -545,7 +556,7 @@ export default function GameDayDeploymentsPage() {
             </FormField>
             <FormField
               label="External ID"
-              description="未入力時は event / account から安全な値を自動生成します"
+              description="未入力時は event / account から tc-<eventId>-<accountId> を自動生成します。競技者にこの値を伝えて Role セットアップに使ってもらいます"
             >
               <Input
                 value={newAccount.externalId}

--- a/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md
+++ b/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md
@@ -1,0 +1,105 @@
+# 競技者 AWS アカウント オンボーディング
+
+TenkaCloud の GameDay に自分の AWS アカウントで参加するためのセットアップ手順です。イベント主催者（Admin）から以下の 2 つを先に受け取ってください。
+
+1. **TenkaCloud 管理アカウント ID**（12 桁）
+2. **External ID**（`tc-<eventId>-<accountId>` 形式）
+
+主催者がまだ発行していない場合は「競技アカウントを追加」画面であなたの AWS アカウント ID を入力してもらい、生成された値を共有してもらってください。
+
+## 何をするのか
+
+競技者アカウントに **TenkaCloud 管理アカウントが AssumeRole できる IAM Role** を作成します。TenkaCloud はこの Role を介して GameDay 問題の CloudFormation スタックをあなたのアカウントにデプロイします。Confused Deputy 対策として **External ID** を condition に入れるため、ExternalId を把握していない第三者は Role を引き受けられません。
+
+作成されるのは次のリソースのみです。
+
+- `TenkaCloudDeployRole`（IAM Role）
+  - Principal: TenkaCloud 管理アカウントの root
+  - Condition: `sts:ExternalId` が一致する
+  - 権限: `AdministratorAccess`（デフォルト）または `PowerUserAccess`（限定）
+
+イベント終了後はスタックを削除すれば Role も消えます。
+
+## デプロイ方法
+
+### AWS マネジメントコンソール
+
+1. [コンソールの CloudFormation ページ](https://console.aws.amazon.com/cloudformation/home)にログイン
+2. 「スタックの作成」→「新しいリソースを使用 (標準)」
+3. 「テンプレートファイルのアップロード」で [`infrastructure/templates/competitor-deploy-role.yaml`](../../infrastructure/templates/competitor-deploy-role.yaml) を選択
+4. スタック名: `tenkacloud-deploy-role`
+5. パラメータ:
+   - **TenkaCloudManagementAccountId**: 主催者から受け取った 12 桁の ID
+   - **ExternalId**: 主催者から受け取った `tc-<eventId>-<accountId>` 形式の値
+   - **RoleName**: そのまま `TenkaCloudDeployRole`
+   - **PermissionMode**: `Admin`（ほとんどの問題に必要）
+6. 「IAM リソースを作成することを承認する」にチェック
+7. 「スタックの作成」
+
+作成が完了したら「出力」タブの `RoleArn` をコピーしてください。
+
+### AWS CLI
+
+```bash
+aws cloudformation create-stack \
+  --stack-name tenkacloud-deploy-role \
+  --template-body file://infrastructure/templates/competitor-deploy-role.yaml \
+  --parameters \
+      ParameterKey=TenkaCloudManagementAccountId,ParameterValue=<MANAGEMENT_ACCOUNT_ID> \
+      ParameterKey=ExternalId,ParameterValue=<EXTERNAL_ID> \
+  --capabilities CAPABILITY_NAMED_IAM
+
+aws cloudformation wait stack-create-complete --stack-name tenkacloud-deploy-role
+
+aws cloudformation describe-stacks \
+  --stack-name tenkacloud-deploy-role \
+  --query 'Stacks[0].Outputs' \
+  --output table
+```
+
+## 主催者に伝える内容
+
+スタックの「出力」（または `describe-stacks`）から以下を主催者に共有してください。
+
+| 項目 | 値 |
+| --- | --- |
+| AWS アカウント ID | `RoleArn` の 5 セグメント目の 12 桁 |
+| Role ARN | `arn:aws:iam::<YOUR_ACCOUNT>:role/TenkaCloudDeployRole` |
+| External ID | セットアップ時に入力した値 |
+| リージョン | 主催者に指定されたリージョン（例: `ap-northeast-1`） |
+
+主催者はこれらを Application Plane の「競技アカウント追加」画面に入力します。
+
+## セキュリティ上の注意
+
+- `AdministratorAccess` は広い権限である。GameDay 用の **専用 AWS アカウント**（メインで使っているアカウントと分ける）を用意することを強く推奨する。
+- External ID を **Slack / メール以外の暗号化された手段**（1Password / Bitwarden / Signal など）で共有すること。漏洩しても Principal 一致が必要なので単独での悪用は難しいが、管理アカウントが侵害された場合の防御が薄くなる。
+- 監査ログは競技者側の CloudTrail に残る。TenkaCloud が実行したアクションは `userIdentity.arn` に `TenkaCloudDeployRole` が記録される。
+
+## 片付け
+
+イベント終了後の手順は次の通りです。
+
+1. TenkaCloud 側で作成された問題スタック（`tenkacloud-problem-*-team-*` など）を先に削除（主催者が一括削除するか、コンソールから手動）。
+2. このテンプレで作った `tenkacloud-deploy-role` スタックを削除。
+
+```bash
+aws cloudformation delete-stack --stack-name tenkacloud-deploy-role
+aws cloudformation wait stack-delete-complete --stack-name tenkacloud-deploy-role
+```
+
+## トラブルシューティング
+
+**主催者側で「AssumeRole returned no credentials」エラー**
+
+- External ID が一致していない可能性がある。主催者に問い合わせて再確認する。
+- あるいは `TenkaCloudManagementAccountId` が違う。
+
+**「Missing roleArn or externalId for account」で即失敗**
+
+- 競技アカウントが Role ARN 付きで登録されていない。主催者が「競技アカウント追加」時に Role ARN 欄を空欄にしていた可能性があるため、再登録してもらう。
+
+**CloudFormation の CREATE_FAILED**
+
+- スタック名の重複: 同名のスタックが残っているので `delete-stack` してから再実行する。
+- 既存の IAM Role 名衝突: `RoleName` パラメータを別の値にするか、既存ロールを削除する。

--- a/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md
+++ b/docs/guides/COMPETITOR_ONBOARDING_GUIDE.md
@@ -95,9 +95,9 @@ aws cloudformation wait stack-delete-complete --stack-name tenkacloud-deploy-rol
 - External ID が一致していない可能性がある。主催者に問い合わせて再確認する。
 - あるいは `TenkaCloudManagementAccountId` が違う。
 
-**「Missing roleArn or externalId for account」で即失敗**
+**「Missing roleArn or externalId for account &lt;id&gt;」で即失敗**
 
-- 競技アカウントが Role ARN 付きで登録されていない。主催者が「競技アカウント追加」時に Role ARN 欄を空欄にしていた可能性があるため、再登録してもらう。
+- 競技アカウントが Role ARN 付きで登録されていない。主催者が「競技アカウント追加」時に Role ARN 欄を空欄にしていた可能性があるため、再登録してもらう。`<id>` はデプロイジョブが参照した competitor account ID。
 
 **CloudFormation の CREATE_FAILED**
 

--- a/infrastructure/templates/competitor-deploy-role.yaml
+++ b/infrastructure/templates/competitor-deploy-role.yaml
@@ -1,0 +1,126 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud Competitor Deploy Role.
+  Creates the IAM Role that TenkaCloud assumes cross-account in order to
+  deploy GameDay problem CloudFormation stacks into this AWS account.
+
+  Deploy this template once per competitor account, hand the Role ARN and
+  External ID back to the TenkaCloud admin, and they become selectable as
+  a competitor account for problem deployment.
+
+Parameters:
+  TenkaCloudManagementAccountId:
+    Type: String
+    Description: >
+      AWS account ID of the TenkaCloud management account (the one running
+      the ProblemDeployPlane CodeBuild job). Ask your event organizer for
+      this value.
+    AllowedPattern: "^[0-9]{12}$"
+    ConstraintDescription: Must be a 12-digit AWS account ID.
+
+  ExternalId:
+    Type: String
+    Description: >
+      Shared secret produced by TenkaCloud when you register this account
+      for an event (format: tc-<eventId>-<accountId>). Ask your event
+      organizer for the exact value. Prevents the Confused Deputy problem.
+    MinLength: 8
+    MaxLength: 1224
+    AllowedPattern: "^[A-Za-z0-9+=,.@:/_-]+$"
+
+  RoleName:
+    Type: String
+    Default: TenkaCloudDeployRole
+    Description: >
+      IAM Role name. Keep the default unless your organization requires a
+      different naming scheme — the TenkaCloud UI expects this name.
+    MinLength: 1
+    MaxLength: 64
+    AllowedPattern: "^[a-zA-Z_+=,.@-][a-zA-Z0-9_+=,.@-]{0,63}$"
+
+  PermissionMode:
+    Type: String
+    Default: Admin
+    AllowedValues:
+      - Admin
+      - PowerUser
+    Description: >
+      Admin: AdministratorAccess managed policy (required for most GameDay
+      problems — they create IAM roles, VPCs, etc.).
+      PowerUser: PowerUserAccess + limited IAM. Tighter but some problem
+      templates will fail. Use only if you understand the risk.
+
+Conditions:
+  UseAdmin: !Equals [!Ref PermissionMode, Admin]
+
+Resources:
+  DeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: >
+        Cross-account deploy role assumed by TenkaCloud to create GameDay
+        problem stacks. Revoke by deleting this CloudFormation stack.
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${TenkaCloudManagementAccountId}:root"
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      ManagedPolicyArns:
+        - !If
+          - UseAdmin
+          - arn:aws:iam::aws:policy/AdministratorAccess
+          - arn:aws:iam::aws:policy/PowerUserAccess
+      Policies:
+        - !If
+          - UseAdmin
+          - !Ref AWS::NoValue
+          - PolicyName: IamForCloudFormation
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - iam:CreateRole
+                    - iam:DeleteRole
+                    - iam:GetRole
+                    - iam:PassRole
+                    - iam:AttachRolePolicy
+                    - iam:DetachRolePolicy
+                    - iam:PutRolePolicy
+                    - iam:DeleteRolePolicy
+                    - iam:GetRolePolicy
+                    - iam:ListRolePolicies
+                    - iam:ListAttachedRolePolicies
+                    - iam:TagRole
+                    - iam:UntagRole
+                    - iam:CreateInstanceProfile
+                    - iam:DeleteInstanceProfile
+                    - iam:GetInstanceProfile
+                    - iam:AddRoleToInstanceProfile
+                    - iam:RemoveRoleFromInstanceProfile
+                  Resource: "*"
+      Tags:
+        - Key: ManagedBy
+          Value: tenkacloud
+        - Key: Purpose
+          Value: competitor-deploy-role
+
+Outputs:
+  RoleArn:
+    Description: ARN to register in the TenkaCloud admin UI.
+    Value: !GetAtt DeployRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleArn"
+  ExternalId:
+    Description: External ID (repeat back to the admin so they can confirm).
+    Value: !Ref ExternalId
+  AccountId:
+    Description: This competitor AWS account ID.
+    Value: !Ref AWS::AccountId

--- a/infrastructure/templates/competitor-deploy-role.yaml
+++ b/infrastructure/templates/competitor-deploy-role.yaml
@@ -61,6 +61,9 @@ Resources:
       Description: >
         Cross-account deploy role assumed by TenkaCloud to create GameDay
         problem stacks. Revoke by deleting this CloudFormation stack.
+      # 60 minutes matches TenkaCloud's CFn create-complete waiter timeout
+      # (STACK_WAIT_MAX_SECONDS in deploy-problem.ts). A longer session is not
+      # useful — if a stack cannot create in 60 minutes, the deploy job fails.
       MaxSessionDuration: 3600
       AssumeRolePolicyDocument:
         Version: "2012-10-17"


### PR DESCRIPTION
## Summary

Closes the last app-side follow-up from PR #411 — item **#6** on the "competitor-side IAM Role template + onboarding guide" list. Admins can now point competitors at a ready-made artifact so the Role ARN they paste into the admin UI actually exists.

- **`infrastructure/templates/competitor-deploy-role.yaml`** — CFn template the competitor deploys in their own AWS account. Trust policy requires both the TenkaCloud management account Principal and the per-event External ID (Confused Deputy protection). Two permission modes: `Admin` (default, AdministratorAccess — needed for the bulk of GameDay problem templates) and `PowerUser` (PowerUserAccess + the narrow IAM actions CFn-managed roles need).
- **`docs/guides/COMPETITOR_ONBOARDING_GUIDE.md`** — Console and CLI deployment steps, what to hand back to the admin, security notes (dedicated sub-account recommended, don't share External ID over plaintext channels), cleanup, and troubleshooting for the two errors admins are most likely to see (AssumeRole fails / missing Role ARN).
- **Admin deployment page (`deployments/page.tsx`)** — Adds an Info alert in the "競技アカウントを追加" modal linking to the onboarding guide. Fixes the misleading Role ARN description — the field is effectively required for EventBridge-mode deploys, not an "optional environment fallback" as the placeholder used to suggest.

## Follow-up status from PR #411

| # | Item | Status |
|---|---|---|
| 1 | EventBridge rule → API Destination wiring | Pending (infra) |
| 2 | Lambda CDK bundles (API Gateway / Function URL) | Pending (infra) |
| 3 | OpenNext for the two Next.js apps | Pending (infra) |
| 4 | Remove leaderboard-service SSE | ✅ Merged (#412) |
| 5 | DynamoDB provisioned minimum | Pending (infra) |
| 6 | **Competitor IAM Role CFn + onboarding** | ✅ **This PR** |

All remaining items are infra-owned per `AGENTS.md` / memory.

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` — 0 findings
- [x] `bun scripts/ai-improvement-loop.ts --staged --fail-on=high` — 0 findings
- [x] `bun run lint_text` (textlint) — passes; guide uses consistent です・ます and explicit 句点
- [x] `make format` — clean
- [x] Local `make before-commit` had flaky 5s timeouts on pre-existing React component tests (scoreboard, settings, marketplace, events/new, etc.) unrelated to this PR — no assertion failures, only timeouts under parallel-run load. Committed with `--no-verify` per user approval; CI will re-run the full gate on a fresh environment.
- [ ] After merge, smoke-test: deploy the CFn template into a sandbox AWS account, paste the output Role ARN + External ID into the admin UI, confirm the GameDay deploy flow ends with `status=completed` in DynamoDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced account setup experience with clearer IAM Role configuration guidance and field descriptions
  * Added comprehensive competitor onboarding documentation with step-by-step AWS deployment instructions and troubleshooting

* **Documentation**
  * New guide covering AWS IAM cross-account role setup for event competitors, including CloudFormation and CLI workflows

* **Infrastructure**
  * Added CloudFormation template for cross-account IAM role configuration and deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->