### PR TITLE
docs: align AGENTS/README/QUICKSTART path references with current layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,17 +73,32 @@ bun scripts/ai-improvement-loop.ts --write --fail-on=high
 
 ```
 TenkaCloud/
-├── apps/
-│   ├── control-plane/         # テナント管理 UI (Next.js, :13000)
-│   └── application-plane/     # GameDay/Battle UI (Next.js, :13001)
-├── backend/services/
-│   ├── shared/                # DynamoDB クライアント, イベント型, 認証
-│   ├── control-plane/         # テナント管理, プロビジョニング
-│   └── application-plane/     # problem, gameday, battle, scoring, leaderboard
-├── packages/                  # 共有ライブラリ
-├── docs/decisions/            # ADR（アーキテクチャ決定記録）
-└── infrastructure/            # IaC
+├── client/
+│   ├── AdminWeb/              # Control Plane UI (Next.js 16, :13000, basePath=/control)
+│   └── Application/           # Application Plane UI (Next.js 16, :13001)
+├── server/
+│   ├── application/
+│   │   ├── microservices/     # Hono backend services
+│   │   │   ├── problem-service       :3100  # イベント・問題管理
+│   │   │   ├── gameday-service       :3020  # GameDay ゲーム状態
+│   │   │   ├── leaderboard-service   :3012  # スコア集計・SSE 配信
+│   │   │   ├── battle-service        :3010  # バトル管理
+│   │   │   ├── scoring-service       :3011  # 採点パイプライン
+│   │   │   └── tenant-management     :13004 # テナント CRUD
+│   │   ├── libs/              # DynamoDB クライアント, イベント型, 認証共有
+│   │   └── reverseproxy/      # ローカル開発用リバースプロキシ
+│   ├── lib/                   # CDK スタック (ADR-013: SBT 0.3.9 ベース)
+│   ├── bin/cdk.ts             # CDK エントリ
+│   └── test/                  # CDK スモークテスト
+├── packages/                  # 共有ライブラリ (quality harness 検出ロジック等)
+├── docs/architecture/harness.md  # アーキテクチャ invariant 正本
+├── docs/decisions/            # ADR (000-template.md, 001..013)
+├── infrastructure/templates/  # 補助 IaC (CFn テンプレート, competitor IAM Role 等)
+├── scripts/                   # CDK orchestration (install/cleanup/provision-tenant.sh) + harness 等
+└── problems/                  # GameDay/JAM 問題セット
 ```
+
+> 旧 `apps/` および `backend/services/` パスは廃止 (PR #414 / restructure #398 で `client/`, `server/application/microservices/` に移行済み)。`backend/services/` 配下に残る `node_modules` / `dist` / `lambda.zip` は build artifact のみで、ソースは `server/application/microservices/` を見ること。
 
 ### サービス間通信
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ TenkaCloud は、クラウド技術者向けの OSS 競技プラットフォー�
 
 ## システム構成
 
-- `apps/control-plane`: プラットフォーム管理 UI。テナント管理、設定、運用導線を担当
-- `apps/application-plane`: テナント向け UI。GameDay / Battle / ランキング / プロフィールを担当
-- `backend/services/control-plane/*`: テナント管理、登録、プロビジョニングなどの共有サービス
-- `backend/services/application-plane/*`: problem / gameday / battle / scoring / leaderboard などの競技サービス
+- `client/AdminWeb`: Control Plane UI (Next.js 16, basePath=/control)。テナント管理、設定、運用導線を担当
+- `client/Application`: Application Plane UI (Next.js 16)。GameDay / Battle / ランキング / プロフィールを担当
+- `server/application/microservices/*`: Hono ベースのバックエンドサービス群 (problem / gameday / battle / scoring / leaderboard / tenant-management)
+- `server/application/libs/`: DynamoDB クライアント、イベント型、認証など共通実装
+- `server/lib/` + `server/bin/cdk.ts`: SBT (`@cdklabs/sbt-aws` 0.3.9) ベースの CDK スタック群 (詳細は [ADR-013](docs/decisions/013-sbt-control-plane-onboarding-wire-format.md))
 - `problems/`: 問題データとドキュメント
 
 ローカル開発は `Auth0` と `AUTH_SKIP=1` の両方を前提にできます。`Keycloak` / `Cognito` / `frontend/` 構成を前提にした記述は正本から外します。

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -79,12 +79,12 @@ make dev-app   # Application Plane のみ
 バックエンドを個別に触る場合の例は以下のとおりです。
 
 ```bash
-cd backend/services/control-plane/tenant-management
+cd server/application/microservices/tenant-management
 bun run dev
 ```
 
 ```bash
-cd backend/services/application-plane/problem-service
+cd server/application/microservices/problem-service
 bun run dev
 ```
 


### PR DESCRIPTION
## Summary

オンボーディング時に最初に読まれる 3 つの docs (AGENTS.md / README.md / docs/QUICKSTART.md) のパス参照が、リポジトリ再構成 (PR #398) で消えた `apps/*` と `backend/services/*` のままだったので、現状に合わせる。

- `apps/control-plane` → `client/AdminWeb` (Next.js 16, basePath=/control)
- `apps/application-plane` → `client/Application`
- `backend/services/control-plane/*` / `backend/services/application-plane/*` → `server/application/microservices/*`
- `backend/services/shared/*` → `server/application/libs/`
- AGENTS.md ディレクトリツリーに `server/lib/` (CDK スタック) と `server/bin/cdk.ts` も明示

`backend/services/*` 配下には `node_modules` / `dist` / `lambda.zip` の build artifact だけ残っていて、ソースは全部 `server/application/microservices/` に移行済み。AGENTS.md に注記を入れた。

## Known follow-ups (別 PR)

- `docs/architecture/architecture.md` も全面的に旧パス前提なので大規模書き換えが必要。本 PR のスコープから外して別 PR に切る。
- 旧 `backend/services/*` の node_modules / dist 残骸自体の削除も別 PR (CI / ビルド設定への影響を切り分けたい)。

## Test plan

- [x] `bun scripts/architecture-harness.ts --staged --fail-on=error` 0 件
- [x] `make before-commit` 全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect the reorganized repository structure, including changes to component organization.
  * Revised system configuration documentation with updated component layout information.
  * Corrected development quickstart guide paths to match the new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->