### PR TITLE
docs: align architecture.md with post-ADR-014 layout, mark phase2 design as superseded

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -13,15 +13,17 @@ TenkaCloud は、Control Plane と Application Plane を分離したマルチテ
 │                        TenkaCloud                           │
 ├─────────────────────────────────────────────────────────────┤
 │ Control Plane                                               │
-│ - apps/control-plane                                        │
-│ - backend/services/control-plane/*                          │
+│ - client/AdminWeb (Next.js, basePath=/control)              │
+│ - server/microservices/tenant-management                    │
+│ - infrastructure/cdk (SBT 0.3.9 ベース)                     │
 │                                                             │
 │ Application Plane                                           │
-│ - apps/application-plane                                    │
-│ - backend/services/application-plane/*                      │
+│ - client/Application (Next.js)                              │
+│ - server/microservices/{problem,gameday,battle,             │
+│                         scoring,leaderboard}-service        │
 ├─────────────────────────────────────────────────────────────┤
 │ Shared                                                      │
-│ - backend/services/shared/*                                 │
+│ - server/libs/*                                             │
 │ - packages/*                                                │
 │ - problems/*                                                │
 └─────────────────────────────────────────────────────────────┘
@@ -54,15 +56,11 @@ Control Plane は tenant manager であり、tenant runtime host ではありま
 
 主要実体は以下のとおりです。
 
-- UI: `apps/control-plane`
-- Services:
-  - `backend/services/control-plane/tenant-management`
-  - `backend/services/control-plane/registration`
-  - `backend/services/control-plane/provisioning`
-  - `backend/services/control-plane/provisioning-completion`
-  - `backend/services/control-plane/user-management`
-  - `backend/services/control-plane/system-management`
-  - `backend/services/control-plane/deployment-management`
+- UI: `client/AdminWeb` (Next.js, `basePath=/control`)
+- Services: `server/microservices/tenant-management`
+- Infra: `infrastructure/cdk` (SBT 0.3.9 ベースの Cognito + EventBridge + tenant CRUD Lambda)
+
+> 旧構造で `backend/services/control-plane/{registration, provisioning, provisioning-completion, user-management, system-management, deployment-management}` として独立 Lambda に分かれていた責務は、SBT 移行 (ADR-013) と再構成 (ADR-014) を経て、SBT が提供する Cognito UserPool と EventBridge ルール、および `tenant-management` 内の provisioning publisher (`server/microservices/tenant-management/src/provisioning/publisher.ts`) に集約された。Lambda 単位での分割は廃止。
 
 ### Application Plane
 
@@ -80,25 +78,27 @@ Application Plane は tenant ごとに 1 つです。各社ごとに 1 Plane を
 
 主要実体は以下のとおりです。
 
-- UI: `apps/application-plane`
+- UI: `client/Application` (Next.js)
 - Services:
-  - `backend/services/application-plane/problem-service`
-  - `backend/services/application-plane/gameday-service`
-  - `backend/services/application-plane/battle-service`
-  - `backend/services/application-plane/scoring-service`
-  - `backend/services/application-plane/leaderboard-service`
-  - `backend/services/application-plane/tenant-provisioner`
+  - `server/microservices/problem-service`
+  - `server/microservices/gameday-service`
+  - `server/microservices/battle-service`
+  - `server/microservices/scoring-service`
+  - `server/microservices/leaderboard-service`
+- tenant プロビジョニング実行: `infrastructure/cdk/lib/{bootstrap-template,tenant-template,tenant-pipeline}/` 配下の SBT スタック (旧 `backend/services/application-plane/tenant-provisioner` の Lambda は廃止)
+- realtime 系 (旧 `realtime-service` Lambda) は polling ベースに切り替え済み (PR #412 / `INVARIANT_POLLING_OVER_SSE` メモリ参照)
 
 ## 3. UI 構成
 
-### `apps/control-plane`
+### `client/AdminWeb`
 
-- Next.js 16
+- Next.js 16 (`output: 'standalone'`, `basePath=/control`)
 - ポート `13000`
-- 主に `/control` 配下でプラットフォーム管理を提供
-- ローカルでは `AUTH_SKIP=1` で確認可能
+- 主に `/control/dashboard/*` 配下でプラットフォーム管理を提供
+- 認証は NextAuth v5 + Cognito (本番) / `AUTH_SKIP=1` (ローカル)
+- SBT API は `lib/api/sbt-api-adapter.ts` 経由 (詳細は [ADR-013](../decisions/013-sbt-control-plane-onboarding-wire-format.md))
 
-### `apps/application-plane`
+### `client/Application`
 
 - Next.js 16
 - ポート `13001`
@@ -124,11 +124,11 @@ Hono ベースのサービスが多く、ルートの `package.json` の `dev` �
 
 ### 共有コード
 
-- `backend/services/shared/dynamodb`
-- `backend/services/shared/events`
-- `backend/services/shared/auth0`
-- `packages/shared`
-- `packages/design-system`
+- `server/libs/dynamodb` — DynamoDB クライアント、リポジトリ層、tenant context / isolation middleware
+- `server/libs/events` — EventBridge 型定義 (TenantOnboarding / Provisioned / Updated / Offboarding)
+- `server/libs/auth` — JWT 検証、JWKS、role 抽出 (NextAuth v5 / Cognito / Auth0 互換)
+- `packages/shared` — quality harness 検出ロジックなどのプラットフォーム共有
+- `packages/design-system` — UI コンポーネント (Cloudscape ラッパー)
 
 ### データストア
 
@@ -169,10 +169,10 @@ Control Plane と Application Plane の正本アーキテクチャは serverless
 
 仕様を把握するときの優先順位は以下のとおりです。
 
-1. `apps/*` と `backend/services/*` の実装
+1. `client/{AdminWeb,Application}/` と `server/microservices/*/src/` の実装
 2. この文書
 3. `docs/QUICKSTART.md`
-4. `docs/decisions/*`
+4. `docs/decisions/*` (特に最新の ADR-013 / ADR-014)
 5. `Plan.md` と `docs/plans/*`
 
 `Plan.md` と `docs/plans/*` は履歴や構想が混ざるため、現在仕様の正本には使いません。

--- a/docs/design/phase2-sbt-tenant-isolation.md
+++ b/docs/design/phase2-sbt-tenant-isolation.md
@@ -1,5 +1,21 @@
 # Phase 2: SBT パターンによるテナント分離設計
 
+> **Status: Superseded (履歴文書)**
+>
+> 本文書は SBT 採用前の Phase 2 検討メモで、以下の点で現状と乖離している:
+>
+> - Terraform 前提 (`infrastructure/terraform/modules/*`) — ADR-011 で **CDK + SBT に一本化** され、Terraform は廃止。CDK は `infrastructure/cdk/` 配下 (ADR-014 で `server/` から移動)。
+> - 個別 Lambda 前提 (`backend/services/{control-plane,application-plane}/{provisioning,provisioning-completion,tenant-provisioner}`) — SBT が提供する EventBridge と `server/microservices/tenant-management/src/provisioning/publisher.ts` への集約で代替済み。
+> - SBT wire format (エンドポイントとペイロード形状) は [ADR-013](../decisions/013-sbt-control-plane-onboarding-wire-format.md) を正本とする。
+>
+> 現在の正本:
+>
+> - アーキテクチャ: [`docs/architecture/architecture.md`](../architecture/architecture.md)
+> - SBT 構成: [ADR-011](../decisions/011-sbt-control-plane-and-two-layer-application-plane.md), [ADR-013](../decisions/013-sbt-control-plane-onboarding-wire-format.md)
+> - リポジトリ構造: [ADR-014](../decisions/014-repository-layout-cdk-out-of-server.md)
+>
+> 以下は当時の検討記録として残す (鵜呑みにしないこと)。
+
 ## 概要
 
 AWS SaaS Builder Toolkit (SBT) のパターンを TenkaCloud に適用し、マルチテナント分離を実現する。


### PR DESCRIPTION
## Summary

`docs/architecture/architecture.md` が PR #398 / #414 / #416 後も旧構造 (`apps/`, `backend/services/`) を指したままだったので、現在の `client/` + `server/microservices/` + `infrastructure/cdk/` レイアウトに合わせて書き換える。`docs/design/phase2-sbt-tenant-isolation.md` は当時の検討記録なので supersede 通告ヘッダで現状 ADR への誘導に留める。

## Changes

### `docs/architecture/architecture.md`

- 全体図 (§1): 旧 `apps/control-plane` / `backend/services/control-plane/*` → `client/AdminWeb` / `server/microservices/tenant-management` / `infrastructure/cdk` 表記
- Control Plane Services (§2): 旧 7 Lambda 分割は SBT + tenant-management 内の publisher に集約された旨を明記 (歴史的経緯は blockquote で残す)
- Application Plane Services (§2): 現存する 5 microservice を列挙、tenant provisioner は SBT スタックに移行、realtime は polling 化 (PR #412) を注記
- UI 構成 (§3): basePath=/control や NextAuth v5 + Cognito, sbt-api-adapter といった現状仕様に更新
- 共有層 (§5): `server/libs/{dynamodb,events,auth}` と `packages/{shared,design-system}` の役割を明示
- ドキュメントの読み方 (§8): 優先順位に最新 ADR-013/014 を追加

### `docs/design/phase2-sbt-tenant-isolation.md`

- 冒頭に **Superseded (履歴文書)** バナーを追加
- Terraform モジュール / 個別 Lambda 前提が現状と乖離している旨を明示
- ADR-011 / ADR-013 / ADR-014 と architecture.md への誘導
- 本文は鵜呑み禁止の注意付きで履歴として残置

## Test plan

- [x] \`bun scripts/architecture-harness.ts --staged --fail-on=error\` 0 件
- [x] \`make before-commit\` 全 pass

## Known follow-ups (本 PR 対象外)

- AdminWeb を 3 コンソール (tenant / application / event admin) に分割する計画 (#11) → ADR ドラフトから別 PR
- AdminConsoleHostingStack を OpenNext (Lambda) に移行 → 別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)