### PR TITLE
fix: cloud で 5 microservice Lambda が DynamoDB に届かないバグを修正

### DIFF
--- a/docs/e2e-tests/E2E_TEST_PLAN.md
+++ b/docs/e2e-tests/E2E_TEST_PLAN.md
@@ -80,7 +80,7 @@ services:
   # Control Plane UI
   control-plane:
     build:
-      context: ./apps/control-plane
+      context: ./client/AdminWeb
     ports:
       - "13000:13000"
     environment:
@@ -92,7 +92,7 @@ services:
   # Application Plane UI
   application-plane:
     build:
-      context: ./apps/application-plane
+      context: ./client/Application
     ports:
       - "13001:13001"
     environment:
@@ -503,13 +503,13 @@ jobs:
           DYNAMODB_ENDPOINT: http://localhost:4566
 
       - name: Run E2E tests (Control Plane)
-        run: bun run --cwd apps/control-plane test:e2e
+        run: bun run --cwd client/AdminWeb test:e2e
         env:
           AUTH_SKIP: '1'
           DYNAMODB_ENDPOINT: http://localhost:4566
 
       - name: Run E2E tests (Application Plane)
-        run: bun run --cwd apps/application-plane test:e2e
+        run: bun run --cwd client/Application test:e2e
         env:
           AUTH_SKIP: '1'
           DYNAMODB_ENDPOINT: http://localhost:4566
@@ -561,10 +561,10 @@ bun run e2e:seed
 
 # 3. E2E テスト実行
 # Control Plane
-cd apps/control-plane && bun run test:e2e
+cd client/AdminWeb && bun run test:e2e
 
 # Application Plane
-cd apps/application-plane && bun run test:e2e
+cd client/Application && bun run test:e2e
 
 # UI モードで実行（デバッグ用）
 bun run test:e2e:ui

--- a/server/microservices/battle-service/src/lib/dynamodb.ts
+++ b/server/microservices/battle-service/src/lib/dynamodb.ts
@@ -2,7 +2,9 @@ import { initDynamoDB, BattleRepository } from '@tenkacloud/dynamodb';
 
 // DynamoDB初期化
 initDynamoDB({
-  tableName: process.env.DYNAMODB_TABLE ?? 'TenkaCloud',
+  // AdminApiStack injects DYNAMODB_TABLE_NAME on Lambda; docker-compose / Makefile set both
+  // for back-compat with services that historically read DYNAMODB_TABLE.
+  tableName: process.env.DYNAMODB_TABLE_NAME ?? process.env.DYNAMODB_TABLE ?? 'TenkaCloud-dev',
   region: process.env.AWS_REGION ?? 'ap-northeast-1',
   endpoint: process.env.DYNAMODB_ENDPOINT,
 });

--- a/server/microservices/gameday-service/src/lib/dynamodb.ts
+++ b/server/microservices/gameday-service/src/lib/dynamodb.ts
@@ -1,9 +1,14 @@
 import { initDynamoDB } from "@tenkacloud/dynamodb";
 import { GamedayRepository } from "../repositories/gameday-repository";
 
-const tableName = process.env.DYNAMODB_TABLE;
+// AdminApiStack injects DYNAMODB_TABLE_NAME on Lambda; docker-compose / Makefile set both
+// for back-compat with services that historically read DYNAMODB_TABLE.
+const tableName =
+	process.env.DYNAMODB_TABLE_NAME ?? process.env.DYNAMODB_TABLE;
 if (!tableName) {
-	throw new Error("DYNAMODB_TABLE 環境変数が設定されていません");
+	throw new Error(
+		"DYNAMODB_TABLE_NAME (or DYNAMODB_TABLE) 環境変数が設定されていません",
+	);
 }
 
 const region = process.env.AWS_REGION;

--- a/server/microservices/leaderboard-service/src/lib/dynamodb.ts
+++ b/server/microservices/leaderboard-service/src/lib/dynamodb.ts
@@ -2,7 +2,9 @@ import { initDynamoDB, BattleRepository } from "@tenkacloud/dynamodb";
 
 // DynamoDB初期化
 initDynamoDB({
-	tableName: process.env.DYNAMODB_TABLE ?? "TenkaCloud",
+	// AdminApiStack injects DYNAMODB_TABLE_NAME on Lambda; docker-compose / Makefile set both
+	// for back-compat with services that historically read DYNAMODB_TABLE.
+	tableName: process.env.DYNAMODB_TABLE_NAME ?? process.env.DYNAMODB_TABLE ?? "TenkaCloud-dev",
 	region: process.env.AWS_REGION ?? "ap-northeast-1",
 	endpoint: process.env.DYNAMODB_ENDPOINT,
 });

--- a/server/microservices/problem-service/src/lib/dynamodb.ts
+++ b/server/microservices/problem-service/src/lib/dynamodb.ts
@@ -5,7 +5,9 @@ import {
 } from "@tenkacloud/dynamodb";
 
 initDynamoDB({
-	tableName: process.env.DYNAMODB_TABLE ?? "TenkaCloud",
+	// AdminApiStack injects DYNAMODB_TABLE_NAME on Lambda; docker-compose / Makefile set both
+	// for back-compat with services that historically read DYNAMODB_TABLE.
+	tableName: process.env.DYNAMODB_TABLE_NAME ?? process.env.DYNAMODB_TABLE ?? "TenkaCloud-dev",
 	region: process.env.AWS_REGION ?? "ap-northeast-1",
 	endpoint: process.env.DYNAMODB_ENDPOINT,
 });

--- a/server/microservices/scoring-service/src/lib/dynamodb.ts
+++ b/server/microservices/scoring-service/src/lib/dynamodb.ts
@@ -5,7 +5,9 @@ import {
 } from '@tenkacloud/dynamodb';
 
 initDynamoDB({
-  tableName: process.env.DYNAMODB_TABLE ?? 'TenkaCloud',
+  // AdminApiStack injects DYNAMODB_TABLE_NAME on Lambda; docker-compose / Makefile set both
+  // for back-compat with services that historically read DYNAMODB_TABLE.
+  tableName: process.env.DYNAMODB_TABLE_NAME ?? process.env.DYNAMODB_TABLE ?? 'TenkaCloud-dev',
   region: process.env.AWS_REGION ?? 'ap-northeast-1',
   endpoint: process.env.DYNAMODB_ENDPOINT,
 });


### PR DESCRIPTION
## Summary

レポジトリ全体監査で見つけた **production-blocking bug**:

`AdminApiStack` (PR #422) は各 Lambda の env に `DYNAMODB_TABLE_NAME` を注入していたが、`tenant-management` 以外の 5 service (battle / gameday / leaderboard / problem / scoring) は **`process.env.DYNAMODB_TABLE` のみを読んでいた**。命名のズレで cloud deploy 後にこれらの Lambda はすべて DynamoDB に届かず、`AdminApiStack` 越しの request が失敗する。

| Service | 修正前 | Cloud deploy 時の挙動 |
|---|---|---|
| tenant-management | `DYNAMODB_TABLE_NAME ?? 'TenkaCloud-dev'` | ✅ 正常 |
| battle-service | `DYNAMODB_TABLE ?? 'TenkaCloud'` | ❌ default の `'TenkaCloud'` table を見にいく (存在しない) |
| gameday-service | `DYNAMODB_TABLE` 必須・無いと throw | ❌ Lambda cold start で throw |
| leaderboard-service | `DYNAMODB_TABLE ?? 'TenkaCloud'` | ❌ 同上 |
| problem-service | `DYNAMODB_TABLE ?? 'TenkaCloud'` | ❌ 同上 |
| scoring-service | `DYNAMODB_TABLE ?? 'TenkaCloud'` | ❌ 同上 |

## Fix

- 5 service の `src/lib/dynamodb.ts` を `DYNAMODB_TABLE_NAME ?? DYNAMODB_TABLE ?? 'TenkaCloud-dev'` に統一。`AdminApiStack` の env 命名と一致させつつ、docker-compose / Makefile の旧 `DYNAMODB_TABLE` も後方互換で読む。
- gameday-service の throw メッセージも `_NAME` 優先に。

## ローカル開発への影響

なし。`docker-compose.yml` は元々 `DYNAMODB_TABLE_NAME=TenkaCloud-dev` を全 service に注入していたので動作は不変。ただし default 値が `'TenkaCloud'` から `'TenkaCloud-dev'` に変わり、`scripts/init-dynamodb-tables.sh` が実際に作る table 名と一致するようになった (env 注入忘れた場合のフォールバックも正しい table を見るように)。

## 副次修正 (audit で見つけた小さな staleness)

- `docs/e2e-tests/E2E_TEST_PLAN.md`: 古い `apps/control-plane` / `apps/application-plane` パスを `client/AdminWeb` / `client/Application` に置換 (PR #424 で抜けていた docker-compose / CI workflow 部分)。

## レポジトリ全体監査の結論

ProtoShip と並行して docs / 責務 / dead code の監査を済ませました。

**今 PR で fix したのは**:
- 上記 production bug (この PR)
- (別 PR #425) `make destroy` の AdminApiStack 対応 + 並列 CFN delete
- (別 PR #424) docs staleness sync (Auth0 / NextAuth / `apps/` パス等)
- (merged PR #423) dead code (`server/libs/auth0`, `mock-tenant-api`, `next-auth.d.ts`)

**残った tech debt** (本 PR 範囲外、別 issue 化候補):
- 5 microservice の `src/middleware/auth.ts` がほぼ同じ JWT 検証ロジックを重複実装している (security 的にもクリティカル、`server/libs/auth-middleware/` 切り出し必要)
- logger 実装ドリフト (pino vs custom; `server/libs/logger/` 切り出し)
- `client/Application/lib/aws/sts-federation.ts` が `@aws-sdk/client-sts` を直接 import (UI からの AWS SDK 直叩きは責務違反、サーバ経由に分離必要)
- 6 microservice の EventBridge publisher コードが個別実装

## Test plan

- [x] 5 service の bun build (Lambda bundle) が clean に通る
- [x] 5 service の test suite (auth.test.ts / schemas/index.test.ts の pre-existing 失敗を除き) 全て pass
- [x] textlint clean
- [ ] **AWS deploy で実検証**: `make deploy` 後、AdminApiStack 越しに problem-service / gameday-service にリクエストが届く (現状は default table 名で 5xx で落ちる想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)