### PR TITLE
feat: Application Plane から local AWS profile / SSO で問題 deploy できるように

### DIFF
--- a/client/Application/app/api/admin/events/route.ts
+++ b/client/Application/app/api/admin/events/route.ts
@@ -19,7 +19,6 @@ import {
   serverApiRequest,
 } from '@/lib/api/server';
 import type { ParticipantEvent, EventStatus } from '@/lib/api/types';
-import { createDevEvent, listDevEvents } from './dev-store';
 
 /**
  * Admin イベント一覧レスポンス型

--- a/server/microservices/problem-service/src/__tests__/aws-provider.test.ts
+++ b/server/microservices/problem-service/src/__tests__/aws-provider.test.ts
@@ -94,6 +94,45 @@ describe("AWSCloudProvider", () => {
 		vi.clearAllMocks();
 	});
 
+	it("accessKeyId / roleArn が無い場合でも SDK default chain で STS が成功すれば valid とすべき", async () => {
+		// SDK default chain (profile / SSO / instance role) を使うパス。AWS provider 内部
+		// では credentials = undefined のまま STS Client を作るため、SDK が自動で chain を
+		// 走る。ここでは STS GetCallerIdentity が成功する想定 = chain で creds が見つかった。
+		mocks.stsSend.mockResolvedValueOnce({
+			Account: "111122223333",
+			Arn: "arn:aws:iam::111122223333:user/dev",
+		});
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const credentials = {
+			provider: "aws" as const,
+			accountId: "",
+			region: "ap-northeast-1",
+		};
+		const valid = await provider.validateCredentials(credentials);
+
+		expect(valid).toBe(true);
+		// 副作用: 空だった accountId が STS の応答で in-place に補完される。
+		expect(credentials.accountId).toBe("111122223333");
+	});
+
+	it("STS GetCallerIdentity が失敗した場合は invalid を返すべき", async () => {
+		mocks.stsSend.mockRejectedValueOnce(new Error("CredentialsProviderError"));
+
+		const { AWSCloudProvider } = await import("../providers/aws");
+		const provider = new AWSCloudProvider();
+
+		const valid = await provider.validateCredentials({
+			provider: "aws",
+			accountId: "",
+			region: "ap-northeast-1",
+		});
+
+		expect(valid).toBe(false);
+	});
+
 	it("roleArn がある場合は ExternalId 付きで AssumeRole して認証検証すべき", async () => {
 		mocks.stsSend
 			.mockResolvedValueOnce({

--- a/server/microservices/problem-service/src/__tests__/routes-admin.test.ts
+++ b/server/microservices/problem-service/src/__tests__/routes-admin.test.ts
@@ -2001,7 +2001,10 @@ describe("Admin Routes", () => {
 				expect(body.error).toContain("AWS deployment template");
 			});
 
-			it("AWS クレデンシャルがない場合は 400 を返すべき", async () => {
+			it("env が無くても provider に委譲し、SDK chain で credentials が取れなければ 401 を返すべき", async () => {
+				// 旧仕様: env keys 必須 → 400 で reject
+				// 新仕様: SDK default chain (profile / SSO / instance role) も許可。
+				//        最終的な可否は validateCredentials の STS GetCallerIdentity で判定。
 				delete process.env.AWS_ACCESS_KEY_ID;
 				delete process.env.AWS_SECRET_ACCESS_KEY;
 				delete process.env.AWS_ACCOUNT_ID;
@@ -2009,6 +2012,7 @@ describe("Admin Routes", () => {
 				mockProblemRepository.findById.mockResolvedValueOnce(
 					mockProblemWithAWS,
 				);
+				mockAWSProvider.validateCredentials.mockResolvedValueOnce(false);
 
 				const res = await app.request("/api/admin/problems/problem-1/deploy", {
 					method: "POST",
@@ -2018,7 +2022,7 @@ describe("Admin Routes", () => {
 					}),
 				});
 
-				expect(res.status).toBe(400);
+				expect(res.status).toBe(401);
 				const body = await res.json();
 				expect(body.error).toContain("AWS credentials");
 			});

--- a/server/microservices/problem-service/src/providers/aws/index.ts
+++ b/server/microservices/problem-service/src/providers/aws/index.ts
@@ -76,25 +76,30 @@ export class AWSCloudProvider implements ICloudProvider {
 	readonly displayName = "Amazon Web Services";
 
 	/**
-	 * 認証情報の検証
+	 * 認証情報の検証。
+	 *
+	 * accessKeyId / secretAccessKey / roleArn のいずれかが渡された場合はそれを使う。
+	 * 何も渡されていない場合は AWS SDK の default credential chain
+	 * (env / `~/.aws/credentials` / SSO / container metadata 等) に委譲する。
+	 * いずれの経路でも最終的な可否は STS GetCallerIdentity の成功で判定する。
+	 *
+	 * 副作用: 渡された credentials.accountId が空のとき、STS が返した値で
+	 * in-place に補完する (CFn stack tag や role session name に使うため)。
 	 */
 	async validateCredentials(credentials: CloudCredentials): Promise<boolean> {
 		if (credentials.provider !== "aws") {
 			return false;
 		}
 
-		// AssumeRole または直接認証情報のいずれかが必要
-		if (
-			!credentials.roleArn &&
-			(!credentials.accessKeyId || !credentials.secretAccessKey)
-		) {
-			return false;
-		}
-
 		try {
-			// STS GetCallerIdentity で認証を検証
 			const stsResponse = await this.callSTS(credentials, "GetCallerIdentity");
-			return !!stsResponse.Account;
+			if (!stsResponse.Account) {
+				return false;
+			}
+			if (!credentials.accountId) {
+				credentials.accountId = stsResponse.Account;
+			}
+			return true;
 		} catch (error) {
 			console.debug("[AWSCloudProvider] validateCredentials failed:", error);
 			return false;

--- a/server/microservices/problem-service/src/routes/admin-deploy.ts
+++ b/server/microservices/problem-service/src/routes/admin-deploy.ts
@@ -19,26 +19,30 @@ const deployRoutes = new Hono();
 // AWS デプロイメント
 // ====================
 
-// AWS クレデンシャルを環境変数から取得するヘルパー
-function getAWSCredentialsFromEnv(
+/**
+ * AWS クレデンシャルを呼び出し元の override → 環境変数 → SDK default chain の順で解決する。
+ *
+ * accountId / accessKeyId / secretAccessKey が未指定でも CloudCredentials を返す。
+ * undefined のフィールドは AWS SDK 側に渡らないので、SDK は default credential chain
+ * (`~/.aws/config` / `~/.aws/credentials`、SSO、container metadata、instance role 等)
+ * に fall back する。これによりローカル開発時に developer の AWS profile / SSO が
+ * そのまま使える。accountId は省略時 STS GetCallerIdentity から自動補完される
+ * (provider 内部でも参照は session name 用途のみなので best-effort)。
+ */
+function resolveAWSCredentials(
 	region: string,
 	overrides?: Partial<CloudCredentials>,
-): CloudCredentials | null {
-	const accessKeyId =
-		overrides?.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+): CloudCredentials {
+	const accessKeyId = overrides?.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 	const secretAccessKey =
-		overrides?.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+		overrides?.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
 	const accountId = overrides?.accountId || process.env.AWS_ACCOUNT_ID || "";
-
-	if (!accessKeyId || !secretAccessKey || !accountId) {
-		return null;
-	}
 
 	return {
 		provider: "aws",
 		accountId,
-		accessKeyId,
-		secretAccessKey,
+		...(accessKeyId ? { accessKeyId } : {}),
+		...(secretAccessKey ? { secretAccessKey } : {}),
 		sessionToken: overrides?.sessionToken || process.env.AWS_SESSION_TOKEN,
 		roleArn: overrides?.roleArn || process.env.AWS_ROLE_ARN,
 		externalId: overrides?.externalId || process.env.AWS_EXTERNAL_ID,
@@ -82,16 +86,11 @@ async function validateDeploymentRequest(
 		};
 	}
 
-	const credentials = getAWSCredentialsFromEnv(region);
-	if (!credentials) {
-		return {
-			valid: false,
-			error: "AWS credentials not configured",
-			status: 400,
-		};
-	}
-
-	return { valid: true, credentials };
+	// 旧ロジックは AWS_ACCESS_KEY_ID 等の env が無いと早期 fail していたが、
+	// 現在は SDK default chain を信頼するので resolveAWSCredentials は常に
+	// non-null を返す。実際の認証可否は provider.validateCredentials が STS
+	// GetCallerIdentity で確認する。
+	return { valid: true, credentials: resolveAWSCredentials(region) };
 }
 
 // デプロイリクエストスキーマ
@@ -173,16 +172,7 @@ deployRoutes.post(
 		const credentials =
 			input.provider === "local"
 				? getLocalCredentials(input.region)
-				: getAWSCredentialsFromEnv(input.region, input.credentials);
-		if (!credentials) {
-			return c.json(
-				{
-					error:
-						"AWS credentials not configured. Set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_ACCOUNT_ID environment variables or provide them in the request.",
-				},
-				400,
-			);
-		}
+				: resolveAWSCredentials(input.region, input.credentials);
 
 		// スタック名の生成（UUID で一意性を保証）
 		const stackName =


### PR DESCRIPTION
## Summary

ユーザー要望:
1. Application Plane の admin UI からイベント作成 / 問題 deploy を実行可能にする
2. Control Plane を経由せず developer の **local AWS 認証情報** (`~/.aws/credentials`, SSO, instance role 等) で任意の AWS account に問題を deploy できるようにする

## 監査結果

UI と backend の event 作成パスは既に wired (PR #422 で `DYNAMODB_TABLE_NAME` を統一しているのが前提)。実際に欠けていたのは **「local AWS 認証で deploy する経路」** だった。

### 修正前の挙動 (壊れていた)

```ts
// admin-deploy.ts:33-35
if (!accessKeyId || !secretAccessKey || !accountId) {
  return null;  // → 400 で reject
}
```

`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ACCOUNT_ID` の **3 つの env が揃っていないと早期 fail**。`aws sso login` 後の developer shell や IAM role を assume している環境では env keys が無いので deploy できなかった。

### 修正後

env が無くても `CloudCredentials` を返し、AWS SDK の **default credential chain** に委譲する。SDK は env / `~/.aws/credentials` / `~/.aws/config` / SSO / container metadata / instance role の順で探索する。最終的な可否は STS GetCallerIdentity の成否で判定 (`provider.validateCredentials`)。

`accountId` が空のときは STS の応答で in-place 補完。

## 変更内容

| File | 変更 |
|---|---|
| `server/microservices/problem-service/src/routes/admin-deploy.ts` | `getAWSCredentialsFromEnv` → `resolveAWSCredentials`。env keys 必須を撤去。失敗時 400 → SDK chain にフォール。 |
| `server/microservices/problem-service/src/providers/aws/index.ts` | `validateCredentials` の precondition (roleArn or accessKeyId 必須) を撤去。STS GetCallerIdentity の成否のみで判定。accountId in-place 補完。 |
| `server/microservices/problem-service/src/__tests__/aws-provider.test.ts` | SDK chain での valid 判定 + accountId 補完 + STS 失敗 invalid の 3 ケース追加。 |
| `server/microservices/problem-service/src/__tests__/routes-admin.test.ts` | 旧「env 無し → 400」テストを「env 無し + STS 失敗 → 401」に書き直し。 |
| `client/Application/app/api/admin/events/route.ts` | 過去 PR の名残で未使用の `dev-store` import を削除。 |

## 効果

```bash
# Developer shell (AWS profile / SSO 設定済み)
aws sso login
bun run --cwd server/microservices/problem-service dev

# Application Plane の admin UI から:
# /admin/problems/[id]/deploy → Control Plane / SBT 不在でも自分の AWS account に CFn deploy が通る
```

GameDay の team account 一括 deploy (`admin-gameday-deploy.ts`) も同じ `resolveAWSCredentials` を共有するので、developer が role を assume する pattern (env `AWS_ROLE_ARN` or req body の `credentials.roleArn`) もそのまま動く。

## Test plan

- [x] `bun run test` (problem-service): 813/813 pass (新テスト 2 件含む)
- [x] `bun run test` (Application): 1156/1156 pass
- [x] `bun run typecheck` (Application): clean
- [x] `bun run lint_text`: clean
- [ ] **AWS 実環境**: `aws sso login` 済み shell で problem-service を起動し、Application Plane UI から問題 deploy が通る (user 検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)