### PR TITLE
feat: 問題 deploy パイプライン (CodeBuild + EventBridge) 基盤を追加

### DIFF
--- a/infrastructure/cdk/bin/cdk.ts
+++ b/infrastructure/cdk/bin/cdk.ts
@@ -9,6 +9,7 @@ import { AdminConsoleHostingStack } from "../lib/admin-console-hosting";
 import { BootstrapTemplateStack } from "../lib/bootstrap-template/bootstrap-template-stack";
 import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
+import { ProblemDeployPipelineStack } from "../lib/problem-deploy-pipeline";
 import { getEnv } from "../lib/helper-functions";
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
@@ -175,6 +176,17 @@ if (missingBundles.length === 0) {
     `Skipping AdminApiStack: dist/lambda missing for [${missingBundles.join(", ")}]. Run 'bash scripts/build-microservices-lambda.sh' first.`,
   );
 }
+
+// ProblemDeployPipelineStack: GameDay の admin が UI から「全チームに problem を deploy」
+// 「失敗した team を retry (redeploy)」「event 終了で全 stack を teardown」を起動すると、
+// problem-service が SBT EventBus に ProblemDeployRequested を publish する。
+// 本 stack はそれを受けて CodeBuild project を起動し、各 team account に
+// AssumeRole + CFn deploy/delete する。SBT の BashJobRunner と同じ event-driven パターン。
+const problemDeployPipeline = new ProblemDeployPipelineStack(app, "ProblemDeployPipelineStack", {
+  eventBusArn: controlPlaneStack.eventBusArn,
+});
+problemDeployPipeline.addDependency(controlPlaneStack);
+cdk.Aspects.of(problemDeployPipeline).add(new DestroyPolicySetter());
 
 // AdminConsoleHostingStack: client/AdminWeb (Next.js) を CloudFront+S3 で配信する想定。
 // ⚠️ TenkaCloud の AdminWeb は `output: 'standalone'` + API routes (NextAuth 等) を持つため

--- a/infrastructure/cdk/bin/cdk.ts
+++ b/infrastructure/cdk/bin/cdk.ts
@@ -171,22 +171,24 @@ if (missingBundles.length === 0) {
   });
   adminApiStack.addDependency(controlPlaneStack);
   cdk.Aspects.of(adminApiStack).add(new DestroyPolicySetter());
+
+  // ProblemDeployPipelineStack: admin UI からの「全チームに problem を deploy」
+  // 「retry (redeploy)」「event 終了で teardown」を SBT EventBus 経由で受けて
+  // CodeBuild + 完了 handler Lambda で処理する。AdminApiStack の DDB table を
+  // 完了 handler が UpdateItem するので AdminApiStack 必須 (= microservice
+  // bundle 必須)。
+  const problemDeployPipeline = new ProblemDeployPipelineStack(app, "ProblemDeployPipelineStack", {
+    eventBusArn: controlPlaneStack.eventBusArn,
+    controlPlaneTable: adminApiStack.controlPlaneTable,
+  });
+  problemDeployPipeline.addDependency(controlPlaneStack);
+  problemDeployPipeline.addDependency(adminApiStack);
+  cdk.Aspects.of(problemDeployPipeline).add(new DestroyPolicySetter());
 } else {
   logger.warn(
-    `Skipping AdminApiStack: dist/lambda missing for [${missingBundles.join(", ")}]. Run 'bash scripts/build-microservices-lambda.sh' first.`,
+    `Skipping AdminApiStack & ProblemDeployPipelineStack: dist/lambda missing for [${missingBundles.join(", ")}]. Run 'bash scripts/build-microservices-lambda.sh' first.`,
   );
 }
-
-// ProblemDeployPipelineStack: GameDay の admin が UI から「全チームに problem を deploy」
-// 「失敗した team を retry (redeploy)」「event 終了で全 stack を teardown」を起動すると、
-// problem-service が SBT EventBus に ProblemDeployRequested を publish する。
-// 本 stack はそれを受けて CodeBuild project を起動し、各 team account に
-// AssumeRole + CFn deploy/delete する。SBT の BashJobRunner と同じ event-driven パターン。
-const problemDeployPipeline = new ProblemDeployPipelineStack(app, "ProblemDeployPipelineStack", {
-  eventBusArn: controlPlaneStack.eventBusArn,
-});
-problemDeployPipeline.addDependency(controlPlaneStack);
-cdk.Aspects.of(problemDeployPipeline).add(new DestroyPolicySetter());
 
 // AdminConsoleHostingStack: client/AdminWeb (Next.js) を CloudFront+S3 で配信する想定。
 // ⚠️ TenkaCloud の AdminWeb は `output: 'standalone'` + API routes (NextAuth 等) を持つため

--- a/infrastructure/cdk/lib/admin-api-stack.ts
+++ b/infrastructure/cdk/lib/admin-api-stack.ts
@@ -38,6 +38,9 @@ export interface AdminApiStackProps extends cdk.StackProps {
  * install.sh が phase 0 で build する。
  */
 export class AdminApiStack extends cdk.Stack {
+  /** Shared DynamoDB table — exposed for cross-stack ref (ProblemDeployPipelineStack 等). */
+  public readonly controlPlaneTable: Table;
+
   constructor(scope: Construct, id: string, props: AdminApiStackProps) {
     super(scope, id, props);
 
@@ -54,6 +57,7 @@ export class AdminApiStack extends cdk.Stack {
       pointInTimeRecovery: true,
     });
     // GSI1: テナント別クエリ (AGENTS.md の DB 設計参照)
+    this.controlPlaneTable = table;
     table.addGlobalSecondaryIndex({
       indexName: "GSI1",
       partitionKey: { name: "GSI1PK", type: AttributeType.STRING },

--- a/infrastructure/cdk/lib/problem-deploy-pipeline.ts
+++ b/infrastructure/cdk/lib/problem-deploy-pipeline.ts
@@ -2,9 +2,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as cdk from "aws-cdk-lib";
 import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus, Rule, RuleTargetInput } from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
 import * as iam from "aws-cdk-lib/aws-iam";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { Construct } from "constructs";
 
@@ -15,6 +17,12 @@ export interface ProblemDeployPipelineProps {
    * を listen する rule + 完了 event を publish する権限の grant に使う。
    */
   readonly eventBusArn: string;
+  /**
+   * GameDayDeploymentJob 行を持つ shared DynamoDB table。
+   * 完了 handler Lambda が UpdateItem する。AdminApiStack の controlPlaneTable
+   * を渡す想定 (cross-stack reference)。
+   */
+  readonly controlPlaneTable: ITable;
 }
 
 /**
@@ -165,6 +173,43 @@ export class ProblemDeployPipelineStack extends cdk.Stack {
     new cdk.CfnOutput(this, "ProblemDeployCodeBuildProject", {
       value: project.projectName,
       description: "Name of the CodeBuild project that runs ProblemDeployRequested jobs.",
+    });
+
+    // ── Completion handler Lambda ──────────────────────────────
+    // CodeBuild script の emit_outcome が SBT EventBus に
+    // problem.deploy.completed / problem.deploy.failed を publish するので、
+    // それを subscribe して GameDayDeploymentJob 行を更新する。
+    // UI が job 一覧を polling しているので、これが届かないと永久に "in_progress"
+    // のまま残る。
+    const completionHandlerCodePath = path.resolve(__dirname, "..", "src");
+    const completionHandler = new LambdaFunction(this, "CompletionHandler", {
+      functionName: `tenkacloud-problem-deploy-completion-${this.region}`,
+      runtime: Runtime.NODEJS_20_X,
+      handler: "deploy-completion-handler.handler",
+      code: Code.fromAsset(completionHandlerCodePath, {
+        // path には他の Python lambda 等も入るので exclude で絞る。
+        exclude: ["*.py", "*.test.*", "**/*.test.*"],
+      }),
+      timeout: cdk.Duration.seconds(15),
+      logRetention: RetentionDays.ONE_WEEK,
+      environment: {
+        DYNAMODB_TABLE_NAME: props.controlPlaneTable.tableName,
+      },
+    });
+    props.controlPlaneTable.grantReadWriteData(completionHandler);
+
+    new Rule(this, "ProblemDeployCompletionRule", {
+      ruleName: `tenkacloud-problem-deploy-completion-${this.region}`,
+      eventBus,
+      eventPattern: {
+        source: ["tenkacloud.problem-service"],
+        detailType: ["problem.deploy.completed", "problem.deploy.failed"],
+      },
+      targets: [new targets.LambdaFunction(completionHandler)],
+    });
+
+    new cdk.CfnOutput(this, "ProblemDeployCompletionHandlerName", {
+      value: completionHandler.functionName,
     });
   }
 }

--- a/infrastructure/cdk/lib/problem-deploy-pipeline.ts
+++ b/infrastructure/cdk/lib/problem-deploy-pipeline.ts
@@ -1,0 +1,170 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as cdk from "aws-cdk-lib";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import { EventBus, Rule, RuleTargetInput } from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import type { Construct } from "constructs";
+
+export interface ProblemDeployPipelineProps {
+  /**
+   * SBT EventManager の eventBus ARN。ControlPlaneStack の `eventBusArn` を渡す。
+   * 本 stack 内で `EventBus.fromEventBusArn` で import し、`ProblemDeployRequested`
+   * を listen する rule + 完了 event を publish する権限の grant に使う。
+   */
+  readonly eventBusArn: string;
+}
+
+/**
+ * 問題デプロイパイプライン (CodeBuild ベース)。
+ *
+ * **役割**: GameDay の admin が UI 上で「全チームに problem を deploy」「失敗した
+ * team を retry (redeploy)」「event 終了で全 stack を teardown」のいずれかを起動
+ * すると、problem-service が `ProblemDeployRequested` を SBT EventBus に publish
+ * する。本構造はそれを受けて CodeBuild project を起動し、bash buildspec が:
+ *   1. team account の cross-account role を AssumeRole (externalId 付き)
+ *   2. ACTION に応じて CFn create/delete を実行
+ *   3. 完了時に `problem.deploy.completed` / `problem.deploy.failed` を publish
+ * する。
+ *
+ * **なぜ SBT BashJobRunner を直接使わないか**:
+ * `@cdklabs/sbt-aws` の `BashJobRunner` は `incomingEvent` 型が SBT 内部の
+ * `DetailType` enum 固定 (ONBOARDING_REQUEST 等)。本イベント
+ * (`ProblemDeployRequested`) は TenkaCloud 独自なので、EventBridge rule と
+ * CodeBuild project を直接組み立てる。実装パターン (CodeBuild + IAM + Rule)
+ * は SBT 内部と同等で、同じ EventBus を共有するので Control Plane / Application
+ * Plane の event 経路はそのまま使える。
+ *
+ * **target account 側の前提**:
+ * - `infrastructure/templates/competitor-deploy-role.yaml` を deploy 済みで、
+ *   `tenkacloud-competitor-deploy-role` (cross-account role) が存在する。
+ * - その role の trust policy で本 stack の CodeBuild role と externalId を許可。
+ */
+export class ProblemDeployPipelineStack extends cdk.Stack {
+  public readonly codeBuildProjectName: string;
+
+  constructor(scope: Construct, id: string, props: ProblemDeployPipelineProps & cdk.StackProps) {
+    super(scope, id, props);
+
+    const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
+    const buildspecScriptPath = path.resolve(__dirname, "..", "..", "..", "scripts", "codebuild", "deploy-problem.sh");
+    const buildspecScript = fs.readFileSync(buildspecScriptPath, "utf8");
+
+    const logGroup = new LogGroup(this, "DeployJobLogs", {
+      logGroupName: `/aws/codebuild/tenkacloud-problem-deploy-${this.node.addr}`,
+      retention: RetentionDays.TWO_WEEKS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // CodeBuild project は AssumeRole を呼ぶだけなので最小限の IAM。
+    // 実際の CFn 操作は AssumeRole 後の一時 credentials で行うので、当 role
+    // 自体には CFn 権限は持たせない (least privilege)。
+    const project = new codebuild.Project(this, "DeployJob", {
+      projectName: `tenkacloud-problem-deploy-${this.region}`,
+      description: "Deploys problem CFn templates to competitor accounts via cross-account AssumeRole.",
+      timeout: cdk.Duration.minutes(60),
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
+        computeType: codebuild.ComputeType.SMALL,
+      },
+      logging: { cloudWatch: { logGroup } },
+      buildSpec: codebuild.BuildSpec.fromObject({
+        version: "0.2",
+        phases: {
+          install: { commands: ["yum install -y jq || dnf install -y jq"] },
+          build: {
+            commands: [
+              // 起動側で env が全て揃ってる前提。スクリプト本体は heredoc 経由で
+              // build env に埋め込む (S3 から fetch しなくていいよう asset 化)。
+              `cat <<'__TENKACLOUD_DEPLOY_PROBLEM_EOF__' >/tmp/deploy-problem.sh\n${buildspecScript}\n__TENKACLOUD_DEPLOY_PROBLEM_EOF__`,
+              "chmod +x /tmp/deploy-problem.sh",
+              "bash /tmp/deploy-problem.sh",
+            ],
+          },
+        },
+      }),
+    });
+
+    // 自身のアカウント内 STS 経由で **任意の external account** の role を AssumeRole
+    // できるようにする。target は incoming event の TARGET_ROLE_ARN で決まり、
+    // 信頼関係は target 側の role 設定に依存するので、ここでは sts:AssumeRole を
+    // wildcard resource で許可する (実質 target の trust policy が gate)。
+    project.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["sts:AssumeRole"],
+        resources: ["*"],
+      }),
+    );
+    // 完了 event を EventBus に publish する権限。
+    project.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["events:PutEvents"],
+        resources: [eventBus.eventBusArn],
+      }),
+    );
+
+    this.codeBuildProjectName = project.projectName;
+
+    // ── EventBridge rule: ProblemDeployRequested → CodeBuild StartBuild ──
+    // input transformer で event payload を CodeBuild env vars (PROBLEM_ID 等) に
+    // マップする。bash 側はこの env を読んで動く。
+    new Rule(this, "ProblemDeployRequestedRule", {
+      ruleName: `tenkacloud-problem-deploy-requested-${this.region}`,
+      eventBus,
+      eventPattern: {
+        source: ["tenkacloud.problem-service"],
+        detailType: ["ProblemDeployRequested"],
+      },
+      targets: [
+        new targets.CodeBuildProject(project, {
+          event: RuleTargetInput.fromObject({
+            environmentVariablesOverride: [
+              { name: "ACTION", value: cdk.aws_events.EventField.fromPath("$.detail.action"), type: "PLAINTEXT" },
+              {
+                name: "PROBLEM_ID",
+                value: cdk.aws_events.EventField.fromPath("$.detail.problemId"),
+                type: "PLAINTEXT",
+              },
+              { name: "TEAM_ID", value: cdk.aws_events.EventField.fromPath("$.detail.teamId"), type: "PLAINTEXT" },
+              { name: "EVENT_ID", value: cdk.aws_events.EventField.fromPath("$.detail.eventId"), type: "PLAINTEXT" },
+              { name: "JOB_ID", value: cdk.aws_events.EventField.fromPath("$.detail.jobId"), type: "PLAINTEXT" },
+              {
+                name: "TARGET_ROLE_ARN",
+                value: cdk.aws_events.EventField.fromPath("$.detail.targetRoleArn"),
+                type: "PLAINTEXT",
+              },
+              {
+                name: "EXTERNAL_ID",
+                value: cdk.aws_events.EventField.fromPath("$.detail.externalId"),
+                type: "PLAINTEXT",
+              },
+              {
+                name: "TEMPLATE_URL",
+                value: cdk.aws_events.EventField.fromPath("$.detail.templateUrl"),
+                type: "PLAINTEXT",
+              },
+              {
+                name: "STACK_NAME",
+                value: cdk.aws_events.EventField.fromPath("$.detail.stackName"),
+                type: "PLAINTEXT",
+              },
+              {
+                name: "STACK_REGION",
+                value: cdk.aws_events.EventField.fromPath("$.detail.region"),
+                type: "PLAINTEXT",
+              },
+              { name: "EVENT_BUS_NAME", value: eventBus.eventBusName, type: "PLAINTEXT" },
+            ],
+          }),
+        }),
+      ],
+    });
+
+    new cdk.CfnOutput(this, "ProblemDeployCodeBuildProject", {
+      value: project.projectName,
+      description: "Name of the CodeBuild project that runs ProblemDeployRequested jobs.",
+    });
+  }
+}

--- a/infrastructure/cdk/src/deploy-completion-handler.mjs
+++ b/infrastructure/cdk/src/deploy-completion-handler.mjs
@@ -1,0 +1,100 @@
+// Deploy completion handler — subscribes to problem.deploy.completed /
+// problem.deploy.failed events emitted by the CodeBuild deploy pipeline and
+// updates the corresponding GameDayDeploymentJob row in the shared DynamoDB
+// table.
+//
+// Event detail shape (from scripts/codebuild/deploy-problem.sh emit_outcome):
+//   {
+//     deploymentKey: "<eventId>:<problemId>:<jobId>",
+//     jobOutput: {
+//       tenantData: {
+//         deployStatus: "completed" | "failed",
+//         stackName?: string,
+//         stackId?: string,
+//         errorReason?: string
+//       }
+//     }
+//   }
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+
+const TABLE = process.env.DYNAMODB_TABLE_NAME;
+if (!TABLE) {
+  throw new Error("DYNAMODB_TABLE_NAME env var is required");
+}
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function parseKey(deploymentKey) {
+  if (typeof deploymentKey !== "string") {
+    throw new Error(`deploymentKey is not a string: ${deploymentKey}`);
+  }
+  const [eventId, problemId, jobId] = deploymentKey.split(":");
+  if (!eventId || !problemId || !jobId) {
+    throw new Error(`deploymentKey must be "<eventId>:<problemId>:<jobId>", got ${deploymentKey}`);
+  }
+  return { eventId, problemId, jobId };
+}
+
+export const handler = async (event) => {
+  // EventBridge rule with multiple detail-types delivers a single event per
+  // invocation. Detail-type tells us success vs failure; the payload tells the rest.
+  const detailType = event["detail-type"];
+  const detail = event.detail ?? {};
+  const tenantData = detail.jobOutput?.tenantData ?? {};
+
+  const { eventId, problemId, jobId } = parseKey(detail.deploymentKey);
+
+  const status =
+    detailType === "problem.deploy.completed" || tenantData.deployStatus === "completed" ? "completed" : "failed";
+
+  const now = new Date().toISOString();
+  const updateExpr = ["SET #status = :status", "#updatedAt = :updatedAt", "#completedAt = :completedAt"];
+  const exprAttrNames = {
+    "#status": "status",
+    "#updatedAt": "UpdatedAt",
+    "#completedAt": "completedAt",
+  };
+  const exprAttrValues = {
+    ":status": status,
+    ":updatedAt": now,
+    ":completedAt": now,
+  };
+
+  if (tenantData.stackName) {
+    updateExpr.push("#stackName = :stackName");
+    exprAttrNames["#stackName"] = "stackName";
+    exprAttrValues[":stackName"] = tenantData.stackName;
+  }
+  if (tenantData.stackId) {
+    updateExpr.push("#stackId = :stackId");
+    exprAttrNames["#stackId"] = "stackId";
+    exprAttrValues[":stackId"] = tenantData.stackId;
+  }
+  if (status === "failed" && tenantData.errorReason) {
+    updateExpr.push("#error = :error");
+    exprAttrNames["#error"] = "error";
+    exprAttrValues[":error"] = tenantData.errorReason;
+  }
+  // Active GSI partition は active job だけが入る。完了 / 失敗 → 削除。
+  const removeExpr = ["GSI1PK", "GSI1SK"];
+
+  const params = {
+    TableName: TABLE,
+    Key: {
+      PK: `GAMEDAY_DEPLOY#EVENT#${eventId}#PROBLEM#${problemId}`,
+      SK: `JOB#${jobId}`,
+    },
+    UpdateExpression: `${updateExpr.join(", ")} REMOVE ${removeExpr.join(", ")}`,
+    ExpressionAttributeNames: exprAttrNames,
+    ExpressionAttributeValues: exprAttrValues,
+    // Job が存在しない invalid event は no-op で良いので ConditionExpression は付けない。
+    // (重複配信や順序違反でレース condition があり得るため、idempotent な UpdateItem に留める)
+    ReturnValues: "NONE",
+  };
+
+  await ddb.send(new UpdateCommand(params));
+  console.log(`[deploy-completion] eventId=${eventId} problemId=${problemId} jobId=${jobId} status=${status}`);
+  return { statusCode: 200, body: "ok" };
+};

--- a/scripts/codebuild/deploy-problem.sh
+++ b/scripts/codebuild/deploy-problem.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Problem deploy CodeBuild script — runs inside CodeBuild after EventBridge
+# routes a ProblemDeployRequested event here. Dispatches based on $ACTION:
+#   deploy   : 新規 stack (CreateStack)
+#   redeploy : 既存 failed/rollback stack を消してから create
+#   teardown : delete-stack (event 終了後の resource 解放)
+#
+# 必須 env (EventBridge input transformer から流し込む):
+#   ACTION              "deploy"|"redeploy"|"teardown"
+#   PROBLEM_ID          DynamoDB / log 用
+#   TEAM_ID             competitor account の id (= DynamoDB SK)
+#   EVENT_ID            イベント ID
+#   JOB_ID              GameDayDeploymentJob の ID
+#   TARGET_ROLE_ARN     team account の cross-account role
+#   EXTERNAL_ID         Confused Deputy 防止用
+#   TEMPLATE_URL        CFn テンプレートの S3 URL (deploy/redeploy のみ)
+#   STACK_NAME          target account 内での stack 名
+#   STACK_REGION        deploy 先 region
+#   EVENT_BUS_NAME      完了イベントを返す bus
+#   ACCOUNT_ID          target account ID (CFn validation 等で使う)
+#
+# 終了時に PROBLEM_DEPLOY_COMPLETED または PROBLEM_DEPLOY_FAILED を
+# EventBus に publish する。dispatch 側は SBT と同じ pattern。
+
+set -euo pipefail
+
+ACTION="${ACTION:-deploy}"
+DEPLOYMENT_KEY="${EVENT_ID}:${PROBLEM_ID}:${JOB_ID}"
+
+log() { echo "[deploy-problem] [$(date +%H:%M:%S)] $*"; }
+fail() { log "FAIL: $*"; emit_outcome "failed" "$*"; exit 1; }
+
+emit_outcome() {
+  local status="$1"
+  local reason="${2:-}"
+  local detail_type
+  if [[ "$status" == "completed" ]]; then
+    detail_type="problem.deploy.completed"
+  else
+    detail_type="problem.deploy.failed"
+  fi
+  local payload
+  payload=$(jq -n \
+    --arg key "$DEPLOYMENT_KEY" \
+    --arg status "$status" \
+    --arg stackName "${STACK_NAME:-}" \
+    --arg stackId "${STACK_ID:-}" \
+    --arg reason "$reason" \
+    '{ deploymentKey: $key, jobOutput: { tenantData: { deployStatus: $status, stackName: $stackName, stackId: $stackId, errorReason: $reason } } }')
+  aws events put-events --entries "[{
+    \"Source\": \"tenkacloud.problem-service\",
+    \"DetailType\": \"${detail_type}\",
+    \"EventBusName\": \"${EVENT_BUS_NAME}\",
+    \"Detail\": $(echo "$payload" | jq -Rs .)
+  }]" >/dev/null || log "WARN: put-events failed (continuing)"
+}
+
+assume_target_role() {
+  log "AssumeRole into ${TARGET_ROLE_ARN} (externalId=${EXTERNAL_ID})"
+  local creds
+  creds=$(aws sts assume-role \
+    --role-arn "${TARGET_ROLE_ARN}" \
+    --role-session-name "tenkacloud-${EVENT_ID:0:32}" \
+    --external-id "${EXTERNAL_ID}" \
+    --duration-seconds 3600 \
+    --output json) || fail "AssumeRole failed"
+  export AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY
+  export AWS_SESSION_TOKEN
+  AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<<"$creds")
+  AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<<"$creds")
+  AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<<"$creds")
+}
+
+stack_exists() {
+  aws cloudformation describe-stacks \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" \
+    >/dev/null 2>&1
+}
+
+stack_status() {
+  aws cloudformation describe-stacks \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" \
+    --query 'Stacks[0].StackStatus' \
+    --output text 2>/dev/null
+}
+
+wait_for_create() {
+  log "wait stack-create-complete: ${STACK_NAME}"
+  aws cloudformation wait stack-create-complete \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" \
+    || fail "stack-create wait failed (status=$(stack_status || echo unknown))"
+}
+
+wait_for_delete() {
+  log "wait stack-delete-complete: ${STACK_NAME}"
+  aws cloudformation wait stack-delete-complete \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" \
+    || fail "stack-delete wait failed"
+}
+
+do_create() {
+  log "create-stack ${STACK_NAME} from ${TEMPLATE_URL}"
+  local result
+  result=$(aws cloudformation create-stack \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" \
+    --template-url "${TEMPLATE_URL}" \
+    --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+    --on-failure ROLLBACK \
+    --tags \
+      Key=tenkacloud:problem-id,Value="${PROBLEM_ID}" \
+      Key=tenkacloud:team-id,Value="${TEAM_ID}" \
+      Key=tenkacloud:event-id,Value="${EVENT_ID}" \
+      Key=tenkacloud:managed-by,Value=tenkacloud-deploy-pipeline \
+    --output json) || fail "create-stack failed"
+  STACK_ID=$(jq -r '.StackId' <<<"$result")
+  export STACK_ID
+  wait_for_create
+}
+
+do_delete() {
+  log "delete-stack ${STACK_NAME}"
+  aws cloudformation delete-stack \
+    --stack-name "${STACK_NAME}" \
+    --region "${STACK_REGION}" || fail "delete-stack failed"
+  wait_for_delete
+}
+
+main() {
+  log "ACTION=${ACTION} PROBLEM_ID=${PROBLEM_ID} TEAM_ID=${TEAM_ID} STACK=${STACK_NAME}"
+  assume_target_role
+
+  case "$ACTION" in
+    deploy)
+      if stack_exists; then
+        fail "stack already exists; use ACTION=redeploy to recreate"
+      fi
+      do_create
+      ;;
+    redeploy)
+      if stack_exists; then
+        log "existing stack status: $(stack_status)"
+        do_delete
+      fi
+      do_create
+      ;;
+    teardown)
+      if stack_exists; then
+        do_delete
+      else
+        log "stack not found; nothing to teardown"
+      fi
+      ;;
+    *)
+      fail "unknown ACTION: ${ACTION}"
+      ;;
+  esac
+
+  emit_outcome "completed"
+  log "OK"
+}
+
+main "$@"

--- a/server/libs/events/src/types.ts
+++ b/server/libs/events/src/types.ts
@@ -123,6 +123,14 @@ export interface TenantOffboardingDetail {
  * ProblemDeployRequested イベントの詳細
  * GameDay 問題デプロイ時に problem-service が発火 → ProblemDeployPlane が処理
  */
+/**
+ * 問題デプロイのアクション種別。
+ * - deploy: 新規 CFn create-stack
+ * - redeploy: 失敗 stack を delete してから create (rollback / failed 状態の復旧)
+ * - teardown: イベント終了後に delete-stack (リソース解放)
+ */
+export type ProblemDeployAction = "deploy" | "redeploy" | "teardown";
+
 export interface ProblemDeployRequestedDetail {
   /** 問題 ID */
   problemId: string;
@@ -140,6 +148,11 @@ export interface ProblemDeployRequestedDetail {
   externalId: string;
   /** CloudFormation テンプレート URL */
   templateUrl: string;
+  /**
+   * 実行アクション。省略時は "deploy" 互換。
+   * CodeBuild の buildspec が $ACTION で分岐する。
+   */
+  action?: ProblemDeployAction;
   /**
    * Complete/Failed イベントを DynamoDB の Job にマップし直すための複合キー
    * `${eventId}:${problemId}:${jobId}` 形式


### PR DESCRIPTION
## ユーザー要望

> アプリの管理プレーンから問題を選んでデプロイしたら、問題の CFn テンプレートが問題アカウントにデプロイされる体験を作りたい。失敗したアカウントに対する修正デプロイ、イベント終了後のリソース削除も基本機能として必要。Control Plane / Application Plane の SBT EventBridge 経路はまさに使える。

## 本 PR の内容 (基盤レイヤ)

新 stack `ProblemDeployPipelineStack` + buildspec script + event 型拡張。**SBT EventBus を共有** して `ProblemDeployRequested` を CodeBuild にルーティングする pipeline を立てる。

### 構造

```
problem-service Lambda
    │ 「全チームへ deploy」/「retry」/「teardown」UI 操作
    ▼
ProblemDeployRequestedDetail { action: 'deploy'|'redeploy'|'teardown', ... }
    │ SBT EventBus に PutEvents
    ▼
EventBridge rule (本 stack で定義)
    │ source=tenkacloud.problem-service / detail-type=ProblemDeployRequested
    │ input transformer → CodeBuild env vars (ACTION / TARGET_ROLE_ARN / ...)
    ▼
CodeBuild project `tenkacloud-problem-deploy-${region}`
    │ buildspec が `bash scripts/codebuild/deploy-problem.sh` を実行
    │   1. AssumeRole into team account (externalId 付き)
    │   2. ACTION で分岐:
    │      - deploy:   create-stack (既存ありなら fail)
    │      - redeploy: 既存 delete → create-stack
    │      - teardown: 既存 delete-stack (無ければ no-op)
    │   3. 完了時に problem.deploy.completed / failed を publish
    ▼
SBT EventBus に completion event
    (本 PR ではここまで。subscribe して DDB 更新する Lambda は別 PR)
```

### なぜ SBT BashJobRunner を直接使わない

`@cdklabs/sbt-aws` の `BashJobRunner` は `incomingEvent` 型が SBT 内部の `DetailType` enum (ONBOARDING_REQUEST 等) 固定。本 event は独自 detail-type なので直接渡せない。実装パターン (CodeBuild + EventBridge rule + Step Function) は同等で、**SBT EventBus を共有する** のは変わらないので Control Plane / Application Plane の event 経路はそのまま機能する。

### IAM 最小権限

CodeBuild role に持たせるのは:
- `sts:AssumeRole` (target は target 側の trust policy が gate するので resource は `*`)
- `events:PutEvents` (本 EventBus に completion event を返す用)

CFn 操作権限は **持たない**。実際の create-stack / delete-stack は AssumeRole 後の一時 credentials で行うので、TenkaCloud 自身の AWS account に対する権限漏れは無い。

## このあとの追加 PR

- [ ] **完了 handler Lambda**: completion event → `GameDayDeploymentJob` の status 更新
- [ ] **gameday-deployer.ts rewire**: 現状 in-process (Lambda 15 分制限) → eventbridge mode に切り替え
- [ ] **UI**: 「全 stack 削除」ボタン (event.status=completed で有効化)、retry → redeploy action 送出
- [ ] **target account setup docs**: `infrastructure/templates/competitor-deploy-role.yaml` の trust policy に CodeBuild role ARN + externalId を入れる手順

## Test plan

- [x] `cdk list` に `ProblemDeployPipelineStack` が出る
- [x] `cdk synth ProblemDeployPipelineStack` が clean (CodeBuild Project + Events Rule + LogGroup)
- [x] `bash -n scripts/codebuild/deploy-problem.sh` syntax OK
- [x] `make before-commit` pass
- [ ] **AWS 実環境**: 本 stack を deploy → problem-service から `ProblemDeployRequested` を publish → CodeBuild が起動 → target account に CFn stack が作られる (要: target side cross-account role + completion handler 別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new problem deployment pipeline with EventBridge-driven automation
  * Support for multiple deployment actions: deploy, redeploy, and teardown
  * Automatic tracking of deployment completion and failure events
  * Cross-account CloudFormation deployment capability with STS role assumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->