### PR TITLE
feat(application-console): 問題カタログ + 詳細ページを追加し Home を TenkaCloud dashboard 化

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -6,6 +6,8 @@ import type { AppConfig } from "./config";
 import { CallbackPage } from "./pages/Callback";
 import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
+import { ProblemDetailPage } from "./pages/ProblemDetail";
+import { ProblemsPage } from "./pages/Problems";
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
@@ -29,6 +31,8 @@ export function App({ config }: { config: AppConfig }) {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/callback" element={<CallbackPage config={config} />} />
         <Route path="/" element={guarded(config, <HomePage />)} />
+        <Route path="/problems" element={guarded(config, <ProblemsPage />)} />
+        <Route path="/problems/:problemId" element={guarded(config, <ProblemDetailPage />)} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </AuthProvider>

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -8,7 +8,7 @@ import type { AppConfig } from "../config";
 
 /**
  * application-admin-console の shell。TopNavigation はサインアウトのみ、
- * SideNavigation は今は「ホーム」だけ。今後の PR で「問題」「イベント」等が増える。
+ * SideNavigation は ホーム / 問題 (catalog)。今後の PR で「競技イベント」「参加者」等が増える。
  *
  * テナント名は build 時 config.tenantName が pooled stack だと "Shared Pooled Tenant"
  * placeholder のまま漏れるので、ここでは表示しない。Home ページ側で JWT custom 属性
@@ -49,7 +49,10 @@ export function ShellLayout({
           <SideNavigation
             activeHref={location.pathname}
             header={{ href: "/", text: "メニュー" }}
-            items={[{ type: "link", href: "/", text: "ホーム" }]}
+            items={[
+              { type: "link", href: "/", text: "ホーム" },
+              { type: "link", href: "/problems", text: "問題カタログ" },
+            ]}
             onFollow={(e) => {
               if (!e.detail.external) {
                 e.preventDefault();

--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -1,0 +1,88 @@
+/**
+ * 問題カタログ。現状は静的 (frontend-baked) だが、将来は backend API から取得する。
+ * 1 問題 = 1 CFn テンプレート + メタデータ。
+ *
+ * カテゴリ:
+ *   - "Battle"    リアルタイム対戦競技 (旧 GameDay 形式相当)
+ *   - "Challenge" 個別演習・常設チャレンジ (旧 JAM 形式相当)
+ *
+ * status:
+ *   - "ready"      参加者向けデプロイ可能
+ *   - "draft"      問題本体は揃っているが UI / backend 連携が未完
+ *   - "deprecated" 停止予定
+ */
+
+export type ProblemCategory = "Battle" | "Challenge";
+export type ProblemStatus = "ready" | "draft" | "deprecated";
+
+export interface ProblemSummary {
+  id: string;
+  name: string;
+  category: ProblemCategory;
+  status: ProblemStatus;
+  /** カード表示用の 1 行サマリ */
+  shortDescription: string;
+  /** 想定難易度 (1=入門 / 5=エキスパート) */
+  difficulty: 1 | 2 | 3 | 4 | 5;
+  /** 想定プレイ時間 */
+  estimatedDuration: string;
+  tags: readonly string[];
+}
+
+export interface ProblemDetail extends ProblemSummary {
+  /** Markdown 風の長文 (改行 OK)。詳細ページに丸ごと表示する */
+  description: string;
+  /** 参加者がアクセスする想定ポート */
+  exposedPorts: readonly { port: number; name: string }[];
+  /** 学習目的 (シナリオ作者からのねらい) */
+  learningGoals: readonly string[];
+}
+
+const SECURITY_BATTLE_ROYALE: ProblemDetail = {
+  id: "security-battle-royale",
+  name: "Security Battle Royale",
+  category: "Battle",
+  status: "draft",
+  shortDescription:
+    "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",
+  difficulty: 3,
+  estimatedDuration: "60〜90 分",
+  tags: ["security", "web", "sql-injection", "rce", "ssrf"],
+  exposedPorts: [
+    { port: 80, name: "frontend (nginx)" },
+    { port: 8080, name: "api (Flask)" },
+  ],
+  learningGoals: [
+    "意図的な SQL injection / RCE / SSRF を発見・修正する一連の手順を体験する",
+    "EC2 IMDS / IAM Role の露出経路と、それを塞ぐベストプラクティスを理解する",
+    "競技中に同居する攻撃者と防御者のトレードオフ (可用性を保ちつつ守る) を体験する",
+  ],
+  description: [
+    "ECサイト風の Web アプリ「Unicorn.Rentals」を題材に、SQL injection / リモートコード実行 / SSRF / IMDS 露出を含む複数の脆弱性が仕込まれた状態でデプロイされる。",
+    "",
+    "競技参加者は次のいずれかのロールでプレイする。",
+    "  - **攻撃側**: 他チームの公開エンドポイントを巡回し、得点リソースを奪取する。",
+    "  - **防御側**: 自チームのアプリを継続稼働させたまま、脆弱性を順次塞いでいく。",
+    "",
+    "デプロイ単位は EC2 1 台 + Docker 構成 (mysql / Flask api / nginx frontend)。デプロイ完了後、参加者には Frontend URL と API URL が払い出される。",
+  ].join("\n"),
+};
+
+export const PROBLEM_CATALOG: readonly ProblemDetail[] = [SECURITY_BATTLE_ROYALE];
+
+export function findProblem(id: string): ProblemDetail | undefined {
+  return PROBLEM_CATALOG.find((p) => p.id === id);
+}
+
+export function listProblemSummaries(): readonly ProblemSummary[] {
+  return PROBLEM_CATALOG.map((p) => ({
+    id: p.id,
+    name: p.name,
+    category: p.category,
+    status: p.status,
+    shortDescription: p.shortDescription,
+    difficulty: p.difficulty,
+    estimatedDuration: p.estimatedDuration,
+    tags: p.tags,
+  }));
+}

--- a/apps/application-admin-console/src/pages/Home.tsx
+++ b/apps/application-admin-console/src/pages/Home.tsx
@@ -1,20 +1,28 @@
+import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import { decodeIdToken } from "../auth/claims";
+import { listProblemSummaries } from "../data/problems";
 
 /**
- * 認証済み TenantAdmin が最初に見るページ。
+ * TenantAdmin のホーム画面。
  *
- * JWT (id_token) から `custom:tenantName` (将来) と `custom:tenantId` (現状) を読んで
- * 「どのテナントとしてログインしているか」を明示する。pooled stack 経由でも
- * 自分のテナント名が出る (config.tenantName の "Shared Pooled Tenant" placeholder ではない)。
+ *  - hero: ようこそ + テナント識別
+ *  - クイックアクション: 「問題をデプロイする」「テナント設定」(後者は stub)
+ *  - 問題カタログのプレビュー (件数 + ready 件数)
+ *  - テナント情報 (JWT claims)
  *
- * 機能ボタン (問題管理 / イベント管理 / 参加者管理) は今後の PR で追加する。
+ * テナント名は JWT (custom:tenantName / custom:tenantId) から取り出す。
+ * config.tenantName は pooled stack で "Shared Pooled Tenant" placeholder のため使わない。
  */
 export function HomePage() {
+  const navigate = useNavigate();
   const auth = useAuth();
   const claims = auth.tokens ? decodeIdToken(auth.tokens.idToken) : null;
   const tenantName = claims?.["custom:tenantName"];
@@ -23,36 +31,93 @@ export function HomePage() {
   const userEmail = claims?.email;
   const displayName = tenantName ?? tenantId ?? "(unknown tenant)";
 
+  const problems = listProblemSummaries();
+  const totalCount = problems.length;
+  const readyCount = problems.filter((p) => p.status === "ready").length;
+  const draftCount = problems.filter((p) => p.status === "draft").length;
+  const battleCount = problems.filter((p) => p.category === "Battle").length;
+
   return (
     <SpaceBetween size="l">
-      <Header variant="h1" description="TenkaCloud Battle / Challenge — テナント管理コンソール">
+      <Header
+        variant="h1"
+        description="TenkaCloud Battle / Challenge — テナント管理コンソール"
+        actions={
+          <Button variant="primary" onClick={() => navigate("/problems")}>
+            問題カタログを開く
+          </Button>
+        }
+      >
         ようこそ、{displayName} さん
       </Header>
 
-      <Container header={<Header variant="h2">テナント情報</Header>}>
-        <SpaceBetween size="s">
-          <KeyValue label="テナント名" value={tenantName ?? "(未設定)"} />
-          <KeyValue label="テナント ID" value={tenantId ?? "(unknown)"} />
-          <KeyValue label="プラン" value={tenantTier ?? "(unknown)"} />
-          <KeyValue label="サインインユーザー" value={userEmail ?? "(unknown)"} />
-        </SpaceBetween>
+      <Container header={<Header variant="h2">問題カタログ</Header>}>
+        <ColumnLayout columns={4} variant="text-grid">
+          <Stat label="登録数" value={String(totalCount)} />
+          <Stat label="公開中 (ready)" value={String(readyCount)} />
+          <Stat label="下書き (draft)" value={String(draftCount)} />
+          <Stat label="Battle" value={String(battleCount)} />
+        </ColumnLayout>
       </Container>
 
-      <Container header={<Header variant="h2">次のステップ</Header>}>
+      <Container
+        header={
+          <Header
+            variant="h2"
+            actions={<Button onClick={() => navigate("/problems")}>すべての問題を見る</Button>}
+          >
+            次のアクション
+          </Header>
+        }
+      >
         <Box variant="p">
-          このコンソールから問題を競技アカウントへデプロイし、参加者にプレイ環境を配布します。
-          管理機能 (問題一覧 / デプロイ / 参加者管理) は順次追加予定です。
+          競技アカウントへ問題をデプロイすると、参加者向けの URL (frontend / api) と、
+          <strong>チーム単位のログインキー</strong>{" "}
+          が払い出されます。参加者個別のアカウントは作成せず、各チームに 1
+          つ配布する短命なキーでアクセス制御するため、運営側で個人情報の管理義務を抱え込みません。
+          まずは <strong>問題カタログ</strong> から問題を 1 つ選んでください。
         </Box>
+      </Container>
+
+      <Container header={<Header variant="h2">テナント情報</Header>}>
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValue label="テナント名" value={tenantName ?? "(未設定)"} />
+          <KeyValue label="テナント ID" value={tenantId ?? "(unknown)"} />
+          <KeyValue
+            label="プラン"
+            valueNode={tenantTier ? <Badge>{tenantTier}</Badge> : <span>(unknown)</span>}
+          />
+          <KeyValue label="サインインユーザー" value={userEmail ?? "(unknown)"} />
+        </ColumnLayout>
       </Container>
     </SpaceBetween>
   );
 }
 
-function KeyValue({ label, value }: { label: string; value: string }) {
+function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <Box variant="awsui-key-label">{label}</Box>
-      <Box variant="p">{value}</Box>
+      <Box fontSize="display-l" fontWeight="bold">
+        {value}
+      </Box>
+    </div>
+  );
+}
+
+function KeyValue({
+  label,
+  value,
+  valueNode,
+}: {
+  label: string;
+  value?: string;
+  valueNode?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Box variant="awsui-key-label">{label}</Box>
+      {valueNode ?? <Box variant="p">{value ?? ""}</Box>}
     </div>
   );
 }

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -1,0 +1,150 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router";
+import { findProblem } from "../data/problems";
+
+const DIFFICULTY_LABEL = {
+  1: "入門",
+  2: "初級",
+  3: "中級",
+  4: "上級",
+  5: "エキスパート",
+} as const;
+
+/**
+ * 問題詳細ページ。manifest 由来のメタデータを表示し「競技アカウントへデプロイ」CTA を出す。
+ *
+ * MVP では Deploy ボタンは Modal で「未実装 (backend 待ち)」を案内する stub。
+ * 後段 PR で /problems/:id/deploy backend を繋ぎ、ジョブ ID を払い出して
+ * /deployments/:id へ遷移する流れに置き換える。
+ */
+export function ProblemDetailPage() {
+  const { problemId } = useParams<{ problemId: string }>();
+  const navigate = useNavigate();
+  const [confirmingDeploy, setConfirmingDeploy] = useState(false);
+
+  if (!problemId) return <Navigate to="/problems" replace />;
+  const problem = findProblem(problemId);
+  if (!problem) {
+    return (
+      <SpaceBetween size="l">
+        <Header variant="h1">問題が見つかりません</Header>
+        <Alert type="error">指定された問題 ID ({problemId}) はカタログに存在しません。</Alert>
+        <Button onClick={() => navigate("/problems")}>問題一覧へ戻る</Button>
+      </SpaceBetween>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={problem.shortDescription}
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={() => navigate("/problems")}>一覧へ戻る</Button>
+            <Button
+              variant="primary"
+              disabled={problem.status !== "ready" && problem.status !== "draft"}
+              onClick={() => setConfirmingDeploy(true)}
+            >
+              競技アカウントへデプロイ
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        {problem.name}
+      </Header>
+
+      <Container header={<Header variant="h2">概要</Header>}>
+        <ColumnLayout columns={4} variant="text-grid">
+          <Meta label="カテゴリ">
+            <Badge color={problem.category === "Battle" ? "red" : "blue"}>{problem.category}</Badge>
+          </Meta>
+          <Meta label="難易度">{DIFFICULTY_LABEL[problem.difficulty]}</Meta>
+          <Meta label="想定プレイ時間">{problem.estimatedDuration}</Meta>
+          <Meta label="ステータス">
+            <Badge color={problem.status === "ready" ? "green" : "blue"}>{problem.status}</Badge>
+          </Meta>
+        </ColumnLayout>
+      </Container>
+
+      <Container header={<Header variant="h2">問題説明</Header>}>
+        <Box variant="p">
+          <span style={{ whiteSpace: "pre-wrap" }}>{problem.description}</span>
+        </Box>
+      </Container>
+
+      <Container header={<Header variant="h2">学習目的</Header>}>
+        <ul>
+          {problem.learningGoals.map((g) => (
+            <li key={g}>{g}</li>
+          ))}
+        </ul>
+      </Container>
+
+      <Container header={<Header variant="h2">参加者に払い出されるエンドポイント</Header>}>
+        <SpaceBetween size="s">
+          <Box variant="p">
+            デプロイ完了時、競技アカウント上で立ち上がった以下のポートが、参加者に共有可能な URL
+            として表示されます。
+          </Box>
+          <ul>
+            {problem.exposedPorts.map((p) => (
+              <li key={`${p.name}-${p.port}`}>
+                {p.name} (port {p.port})
+              </li>
+            ))}
+          </ul>
+          <Alert type="info" header="アクセス制御は per-team ログインキー">
+            各エンドポイントは <strong>チーム単位で発行されるログインキー</strong> で gating
+            されます。参加者ごとのユーザーアカウントは作成されないため、運営側で個別アカウントの管理義務
+            (招待 / リセット / 削除) を負わない構成です。
+          </Alert>
+        </SpaceBetween>
+      </Container>
+
+      <Container header={<Header variant="h2">タグ</Header>}>
+        <SpaceBetween direction="horizontal" size="xs">
+          {problem.tags.map((t) => (
+            <Badge key={t}>{t}</Badge>
+          ))}
+        </SpaceBetween>
+      </Container>
+
+      <Modal
+        visible={confirmingDeploy}
+        onDismiss={() => setConfirmingDeploy(false)}
+        header="競技アカウントへデプロイ"
+        footer={
+          <Box float="right">
+            <Button onClick={() => setConfirmingDeploy(false)}>閉じる</Button>
+          </Box>
+        }
+      >
+        <Alert type="info" header="まだ実装されていません">
+          現在 Deploy backend (CloudFormation 起動 + ステータス追跡 + チームログインキー発行)
+          は実装中です。 完成すると、このボタンから問題を競技アカウントへ deploy し、参加者向けの
+          URL と チーム単位のログインキーが払い出される予定です。
+        </Alert>
+      </Modal>
+    </SpaceBetween>
+  );
+}
+
+function Meta({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <Box variant="awsui-key-label">{label}</Box>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/apps/application-admin-console/src/pages/Problems.tsx
+++ b/apps/application-admin-console/src/pages/Problems.tsx
@@ -1,0 +1,100 @@
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Cards from "@cloudscape-design/components/cards";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useNavigate } from "react-router";
+import { listProblemSummaries, type ProblemSummary } from "../data/problems";
+
+const DIFFICULTY_LABEL: Record<ProblemSummary["difficulty"], string> = {
+  1: "入門",
+  2: "初級",
+  3: "中級",
+  4: "上級",
+  5: "エキスパート",
+};
+
+const STATUS_BADGE_COLOR: Record<ProblemSummary["status"], "green" | "blue" | "grey"> = {
+  ready: "green",
+  draft: "blue",
+  deprecated: "grey",
+};
+
+const STATUS_LABEL: Record<ProblemSummary["status"], string> = {
+  ready: "公開中",
+  draft: "下書き",
+  deprecated: "停止予定",
+};
+
+/**
+ * 問題一覧ページ。Cloudscape Cards で 1 件ずつカード表示する。
+ * クリックすると /problems/:id へ遷移して詳細 + Deploy ボタン。
+ */
+export function ProblemsPage() {
+  const navigate = useNavigate();
+  const problems = listProblemSummaries();
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="競技アカウントへデプロイ可能な問題の一覧。デプロイすると参加者にプレイ環境が払い出されます。"
+      >
+        問題カタログ
+      </Header>
+
+      <Cards
+        items={[...problems]}
+        cardDefinition={{
+          header: (item) => (
+            <Link
+              fontSize="heading-m"
+              onFollow={(e) => {
+                e.preventDefault();
+                navigate(`/problems/${encodeURIComponent(item.id)}`);
+              }}
+              href={`/problems/${encodeURIComponent(item.id)}`}
+            >
+              {item.name}
+            </Link>
+          ),
+          sections: [
+            {
+              id: "badges",
+              content: (item) => (
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Badge color={item.category === "Battle" ? "red" : "blue"}>{item.category}</Badge>
+                  <Badge color={STATUS_BADGE_COLOR[item.status]}>{STATUS_LABEL[item.status]}</Badge>
+                  <Badge color="grey">難易度: {DIFFICULTY_LABEL[item.difficulty]}</Badge>
+                  <Badge color="grey">想定時間: {item.estimatedDuration}</Badge>
+                </SpaceBetween>
+              ),
+            },
+            {
+              id: "description",
+              content: (item) => <Box variant="p">{item.shortDescription}</Box>,
+            },
+            {
+              id: "tags",
+              header: "タグ",
+              content: (item) => (
+                <SpaceBetween direction="horizontal" size="xxs">
+                  {item.tags.map((t) => (
+                    <Badge key={t}>{t}</Badge>
+                  ))}
+                </SpaceBetween>
+              ),
+            },
+          ],
+        }}
+        cardsPerRow={[{ cards: 1 }, { minWidth: 700, cards: 2 }]}
+        empty={
+          <Box textAlign="center" color="inherit" padding="xxl">
+            問題がまだ登録されていません。
+          </Box>
+        }
+      />
+    </SpaceBetween>
+  );
+}


### PR DESCRIPTION
## Summary

- application-admin-console を「Apps を消した直後の空 landing」から「TenkaCloud Battle / Challenge プラットフォームの実物 dashboard」に作り変える
- 問題カタログ (frontend-baked / 1 問: security-battle-royale) + 一覧ページ + 詳細ページを追加
- Home を 統計サマリ + クイックアクション + テナント情報 の 3 セクション dashboard に再設計
- 「参加者は per-team ログインキーで gating、個別ユーザー作成は行わない」運用モデルを画面コピーに明文化

## 背景

PR #434 でガラ空きにした application-admin-console は「ホーム 1 ページ + テナント情報カード」だけで TenkaCloud らしさが画面に出ていなかった。本 PR で Battle / Challenge を運営する画面の骨格を入れる。

## 主な変更

### 問題カタログ (frontend-baked)
- src/data/problems.ts: ProblemCategory (\"Battle\" / \"Challenge\") / ProblemStatus (\"ready\" / \"draft\" / \"deprecated\")
- 現状 1 問: security-battle-royale (Battle / SQLi / RCE / SSRF / IMDS 露出)
- 後で backend API (\`GET /problems\`) に置き換える前提で findProblem / listProblemSummaries の I/F を分離

### Problems list (/problems)
- Cloudscape Cards でカテゴリ / ステータス / 難易度 / 想定時間 / タグの badge 表示
- カードクリックで詳細遷移

### Problem detail (/problems/:problemId)
- 概要 / 問題説明 / 学習目的 / 払い出されるエンドポイント / タグを Container ごと
- 「競技アカウントへデプロイ」CTA は Modal で「未実装 (backend 待ち)」案内する stub
- 参加者エンドポイントは「per-team ログインキーで gating」を Alert で明示

### Home page 再設計
- Hero: 「ようこそ、<tenantName | tenantId> さん」+ 「問題カタログを開く」primary CTA
- 問題カタログの統計 (登録数 / ready / draft / Battle) を ColumnLayout で表示
- 「次のアクション」コピーで per-team キー方式の運用モデルを明文化
- テナント情報 (JWT claims) は維持

### Sidebar
- 「ホーム」+ 「問題カタログ」を SideNavigation に追加

## 参加者アクセスモデル (画面コピーに反映)

参加者ごとの Cognito ユーザー作成は行わない。代わりに、デプロイ時に各チームへ 1 つの短命ログインキーを発行し、deploy された問題環境はそのキーで gating する。これにより運営側で個人情報・アカウント lifecycle (招待 / リセット / 削除) を抱え込まない。backend は次の PR で実装する。

## 既知の follow-up

- 問題 deploy backend (Lambda + DDB + CFn 起動 + チームキー発行) は未実装
- 問題 CFn template (\`problems/gameday/security-battle-royale/template.yaml\`) は未作成 — 並行作業候補
- problems.ts の static catalog は backend 完成後 \`GET /problems\` API 経由に置換予定

## Test plan
- [x] make before-commit 通過 (lint / format / test 全 38 件)
- [ ] 手動: ログイン後 Home → 「問題カタログを開く」→ /problems で 1 件カード表示 → 詳細遷移 → 「競技アカウントへデプロイ」で Modal 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)