### PR TITLE
feat(application-console): 問題 deploy form を実 form 化 + multi-tenant 命名規約

### DIFF
--- a/apps/application-admin-console/src/components/DeployForm.tsx
+++ b/apps/application-admin-console/src/components/DeployForm.tsx
@@ -1,0 +1,200 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
+import { buildStackPrefix } from "../lib/resource-naming";
+
+const AWS_ACCOUNT_ID_RE = /^\d{12}$/;
+const TEAM_NAME_RE = /^[A-Za-z0-9 _-]{1,40}$/;
+
+export interface DeployFormValues {
+  region: string;
+  awsAccountId: string;
+  teamName: string;
+}
+
+interface Props {
+  problemId: string;
+  problemName: string;
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
+  value: r.code,
+  label: r.label,
+}));
+
+/**
+ * 問題を競技アカウントへデプロイする際の Form Modal。
+ *
+ * 入力:
+ *   - region: AWS Region (deploy 先)
+ *   - awsAccountId: 12 桁の AWS アカウント ID (deploy 先)
+ *   - teamName: チーム名 (stack 名 + ログインキーラベルに使う)
+ *
+ * 送信:
+ *   現状は backend 未実装なので、入力値を確認 Alert に表示して止める。
+ *   backend 実装時には POST /problems/:id/deploy を呼び、ジョブ ID を返して
+ *   /deployments/:jobId に遷移する。
+ *
+ * 認証モデル:
+ *   参加者個別アカウントは作らず、各チームに 1 つの短命ログインキーを発行する。
+ *   teamName が同じデプロイは別 stack として扱う (= 別チーム = 別キー)。
+ */
+export function DeployFormModal({ problemId, problemName, visible, onDismiss }: Props) {
+  const [region, setRegion] = useState<SelectProps.Option>({
+    value: DEFAULT_AWS_REGION.code,
+    label: DEFAULT_AWS_REGION.label,
+  });
+  const [awsAccountId, setAwsAccountId] = useState("");
+  const [teamName, setTeamName] = useState("");
+  const [submitted, setSubmitted] = useState<DeployFormValues | null>(null);
+
+  const accountIdInvalid = awsAccountId.length > 0 && !AWS_ACCOUNT_ID_RE.test(awsAccountId);
+  const teamNameInvalid = teamName.length > 0 && !TEAM_NAME_RE.test(teamName);
+  const canSubmit =
+    !!region.value && AWS_ACCOUNT_ID_RE.test(awsAccountId) && TEAM_NAME_RE.test(teamName);
+
+  const handleSubmit = () => {
+    if (!canSubmit || !region.value) return;
+    setSubmitted({
+      region: region.value,
+      awsAccountId,
+      teamName,
+    });
+    // backend 実装後は: POST /problems/:problemId/deploy ボディに上記を送り、
+    // ジョブ ID を受け取って navigate(`/deployments/${jobId}`)
+  };
+
+  const reset = () => {
+    setSubmitted(null);
+    setAwsAccountId("");
+    setTeamName("");
+    setRegion({ value: DEFAULT_AWS_REGION.code, label: DEFAULT_AWS_REGION.label });
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={() => {
+        reset();
+        onDismiss();
+      }}
+      header={`「${problemName}」を競技アカウントへデプロイ`}
+      size="medium"
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              onClick={() => {
+                reset();
+                onDismiss();
+              }}
+            >
+              閉じる
+            </Button>
+            <Button
+              variant="primary"
+              disabled={!canSubmit || submitted !== null}
+              onClick={handleSubmit}
+            >
+              デプロイを開始
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <Form>
+        <SpaceBetween size="l">
+          {submitted ? (
+            <Alert type="warning" header="backend 未実装 — デプロイは送信されていません">
+              入力された値は次の通りです (実装完了後、これらが POST /problems/{problemId}
+              /deploy に送られ、CloudFormation 起動 + チームログインキー発行が走ります)。
+              <ul>
+                <li>Region: {submitted.region}</li>
+                <li>AWS Account ID: {submitted.awsAccountId}</li>
+                <li>Team Name: {submitted.teamName}</li>
+                <li>
+                  Stack 名 prefix: <code>{buildStackPrefix(problemId, submitted.teamName)}</code>
+                </li>
+              </ul>
+            </Alert>
+          ) : (
+            <Alert type="info" header="デプロイ contract">
+              入力された AWS アカウント / リージョンに問題スタックを CFn で展開し、Team Name
+              ごとに短命ログインキーを 1 つ発行します。参加者個別の Cognito ユーザは作成しません。
+              <br />
+              同一 (Account, Region)
+              に複数のチームのスタックを並べる運用を許容するため、各リソース名には
+              <code>
+                {" "}
+                tc-{"{problemId}"}-{"{teamName}"}{" "}
+              </code>
+              を共通 prefix として付与し、衝突を回避します。
+            </Alert>
+          )}
+
+          <FormField
+            label="AWS Region"
+            description="問題スタックを deploy するリージョン"
+            constraintText="リージョン跨ぎは未対応 (近接プレイヤーのレイテンシ最適化を優先)"
+          >
+            <Select
+              selectedOption={region}
+              options={REGION_OPTIONS}
+              onChange={({ detail }) => detail.selectedOption && setRegion(detail.selectedOption)}
+            />
+          </FormField>
+
+          <FormField
+            label="AWS Account ID"
+            description="deploy 先の競技アカウント (12 桁の数字)"
+            errorText={accountIdInvalid ? "12 桁の数字で入力してください" : undefined}
+          >
+            <Input
+              value={awsAccountId}
+              type="text"
+              inputMode="numeric"
+              placeholder="123456789012"
+              onChange={({ detail }) =>
+                setAwsAccountId(detail.value.replace(/\D/g, "").slice(0, 12))
+              }
+              invalid={accountIdInvalid}
+            />
+          </FormField>
+
+          <FormField
+            label="Team Name"
+            description="チーム識別子。スタック名・ログインキーラベル・各リソース prefix に使う"
+            constraintText="英数字 / スペース / _ / - のみ、40 文字以内"
+            errorText={teamNameInvalid ? "英数字 / スペース / _ / - のみ、40 文字以内" : undefined}
+          >
+            <Input
+              value={teamName}
+              placeholder="例: alpha-team"
+              onChange={({ detail }) => setTeamName(detail.value)}
+              invalid={teamNameInvalid}
+            />
+          </FormField>
+
+          {teamName.length > 0 && !teamNameInvalid && (
+            <FormField
+              label="生成される Stack 名 prefix (preview)"
+              description="同一 (Account, Region) に複数チームのスタックが共存できるよう、リソース名はこの prefix で衝突回避します"
+            >
+              <Box variant="code">{buildStackPrefix(problemId, teamName)}</Box>
+            </FormField>
+          )}
+        </SpaceBetween>
+      </Form>
+    </Modal>
+  );
+}

--- a/apps/application-admin-console/src/data/aws-regions.ts
+++ b/apps/application-admin-console/src/data/aws-regions.ts
@@ -1,0 +1,18 @@
+/**
+ * AWS リージョンのカタログ。問題 deploy 先の Select に出す。
+ * 日本国内向けに東京・大阪・米国系を優先表示。必要に応じて追加する。
+ */
+export interface AwsRegion {
+  readonly code: string;
+  readonly label: string;
+}
+
+export const AWS_REGIONS: readonly AwsRegion[] = [
+  { code: "ap-northeast-1", label: "ap-northeast-1 (東京)" },
+  { code: "ap-northeast-3", label: "ap-northeast-3 (大阪)" },
+  { code: "us-east-1", label: "us-east-1 (バージニア北部)" },
+  { code: "us-west-2", label: "us-west-2 (オレゴン)" },
+  { code: "eu-west-1", label: "eu-west-1 (アイルランド)" },
+];
+
+export const DEFAULT_AWS_REGION: AwsRegion = AWS_REGIONS[0];

--- a/apps/application-admin-console/src/lib/resource-naming.ts
+++ b/apps/application-admin-console/src/lib/resource-naming.ts
@@ -1,0 +1,36 @@
+/**
+ * 問題 deploy 時の resource 命名規約。
+ *
+ * 同一 (account, region) に複数チームの問題スタックが同居する運用パターンを許容する
+ * (「1 チーム = 1 AWS アカウント」が王道だが、規模を圧縮するためにアカウント
+ * 共有でリージョン別 / チーム別に並べることもある)。
+ *
+ * よって衝突を避けるため、stack 名 + リソース名にチームと問題を埋め込む共通 prefix
+ * を導入する。CFn template 側ではこの prefix を `Parameters.NamePrefix` で受け取り、
+ * `!Sub '${NamePrefix}-...'` で各リソース名に展開する想定。
+ *
+ * 規約:
+ *   `tc-{problemId-slug}-{teamName-slug}` を base prefix として、
+ *   stack 名は `${prefix}` (e.g. `tc-security-battle-royale-alpha-team`)、
+ *   個別リソース名は `${prefix}-${role}` (e.g. `${prefix}-vpc`, `${prefix}-ec2`).
+ *
+ *   Stack 名は CFn 側 128 文字制限。slug + tc + 区切りで余裕を持って ≤ 100 を確保する。
+ *   問題 id は 32, team name は 40 までに制限する (form 側 validation)。
+ */
+
+const SLUG_NON_ALPHANUM = /[^A-Za-z0-9]+/g;
+const SLUG_TRIM_DASH = /^-+|-+$/g;
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(SLUG_NON_ALPHANUM, "-")
+    .replace(SLUG_TRIM_DASH, "")
+    .slice(0, 40);
+}
+
+export function buildStackPrefix(problemId: string, teamName: string): string {
+  const probSlug = slugify(problemId);
+  const teamSlug = slugify(teamName);
+  return `tc-${probSlug}-${teamSlug}`;
+}

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -5,10 +5,10 @@ import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
+import { DeployFormModal } from "../components/DeployForm";
 import { findProblem } from "../data/problems";
 
 const DIFFICULTY_LABEL = {
@@ -120,22 +120,12 @@ export function ProblemDetailPage() {
         </SpaceBetween>
       </Container>
 
-      <Modal
+      <DeployFormModal
+        problemId={problem.id}
+        problemName={problem.name}
         visible={confirmingDeploy}
         onDismiss={() => setConfirmingDeploy(false)}
-        header="競技アカウントへデプロイ"
-        footer={
-          <Box float="right">
-            <Button onClick={() => setConfirmingDeploy(false)}>閉じる</Button>
-          </Box>
-        }
-      >
-        <Alert type="info" header="まだ実装されていません">
-          現在 Deploy backend (CloudFormation 起動 + ステータス追跡 + チームログインキー発行)
-          は実装中です。 完成すると、このボタンから問題を競技アカウントへ deploy し、参加者向けの
-          URL と チーム単位のログインキーが払い出される予定です。
-        </Alert>
-      </Modal>
+      />
     </SpaceBetween>
   );
 }

--- a/apps/application-admin-console/test/lib/resource-naming.test.ts
+++ b/apps/application-admin-console/test/lib/resource-naming.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildStackPrefix, slugify } from "../../src/lib/resource-naming";
+
+describe("slugify", () => {
+  it("英数字以外をハイフンに置換するべき", () => {
+    expect(slugify("Alpha Team")).toBe("alpha-team");
+    expect(slugify("Team_42!")).toBe("team-42");
+  });
+
+  it("先頭末尾の連続ハイフンを刈るべき", () => {
+    expect(slugify("---hello---")).toBe("hello");
+    expect(slugify("___under___")).toBe("under");
+  });
+
+  it("大文字を全部小文字化するべき", () => {
+    expect(slugify("ALPHA")).toBe("alpha");
+  });
+
+  it("40 文字を超えたら truncate するべき", () => {
+    const long = "a".repeat(60);
+    expect(slugify(long)).toHaveLength(40);
+  });
+
+  it("空文字でも例外を出さず空を返すべき", () => {
+    expect(slugify("")).toBe("");
+  });
+});
+
+describe("buildStackPrefix", () => {
+  it("`tc-{problemSlug}-{teamSlug}` を組み立てるべき", () => {
+    expect(buildStackPrefix("security-battle-royale", "Alpha Team")).toBe(
+      "tc-security-battle-royale-alpha-team",
+    );
+  });
+
+  it("同一 problem でも team が違えば異なる prefix を返すべき (collision 回避の根拠)", () => {
+    const a = buildStackPrefix("p", "team-a");
+    const b = buildStackPrefix("p", "team-b");
+    expect(a).not.toBe(b);
+  });
+
+  it("空 team でも prefix としては成立するべき (validation は呼び出し側責務)", () => {
+    expect(buildStackPrefix("p1", "")).toBe("tc-p1-");
+  });
+});


### PR DESCRIPTION
## Summary

- 問題詳細ページの deploy Modal を **stub から実 form** に拡張: AWS Region / AWS Account ID / Team Name の 3 入力 + validation
- 同一 (Account, Region) に複数チームのスタックを並べる運用 (王道は「1 チーム = 1 アカウント」だが、規模圧縮で account 共有もある) を許容するため、リソース名衝突を避ける共通 prefix \`tc-{problemSlug}-{teamSlug}\` を contract として導入
- form 上で生成される Stack 名 prefix を preview 表示
- backend 未実装のため、送信は入力値を Alert に echo する stub

## 背景

PR #435 で deploy Modal を「未実装」のお知らせ Alert として置いていたが、運用方針が固まったので form 入力を実装する。

運用方針:
- 1 問題 = 1 CFn テンプレート (problems/<id>/template.yaml) のペライチ構成
- form の入力 (Region / Account / Team) を CFn パラメータに流す
- 同じアカウント / リージョンに別チームの stack を並べることを許容する

## 主な変更

### Form
- \`src/components/DeployForm.tsx\`: Cloudscape Form Modal で region/account/team を入力
- \`src/data/aws-regions.ts\`: ap-northeast-1/3, us-east-1, us-west-2, eu-west-1
- 入力 validation: account id は 12 桁、team name は \`[A-Za-z0-9 _-]{1,40}\`

### Resource naming helper
- \`src/lib/resource-naming.ts\`: \`slugify()\` と \`buildStackPrefix(problemId, teamName) = \"tc-{slug}-{slug}\"\`
- \`test/lib/resource-naming.test.ts\`: 7 ケース (slugify / buildStackPrefix の各分岐)

### Form での視覚化
- info Alert で「同一 (Account, Region) に複数チームを並べる運用、prefix で衝突回避」を明示
- Team Name 入力後、有効なら Stack 名 prefix preview を Box variant=code で表示

## 期待する CFn template の対応 (次の PR)

\`problems/gameday/security-battle-royale/template.yaml\` を新規作成し、\`Parameters.NamePrefix\` を受け取り、\`!Sub '${NamePrefix}-vpc'\` のように各リソース名へ展開する。本 PR の form が出す prefix と一致させる。

## Test plan

- [x] make before-commit 通過 (lint / format / test 全 46 件)
- [ ] 手動: 問題詳細から deploy Modal → 入力 / validation / preview 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)