### PR TITLE
feat(problems): 問題カタログ規約 — metadata.json + template.yaml + JSON Schema + validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ tmp
 # Vestige of pre-PR-#398 layout. ソースは server/microservices/ に移行済み。
 # working tree に残る node_modules/dist/lambda.zip は git 管理外 (本ディレクトリ自体を ignore)。
 backend/
+sampleimages/

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ install_ci:    ; bun install --frozen-lockfile --ignore-scripts
 build:         ; bun run build
 typecheck:     ; bun run typecheck
 test:          ; bun run test
-check:         install lint test
-before-commit: lint test
+validate-problems: ; bun run validate:problems
+check:         install lint test validate-problems
+before-commit: lint test validate-problems
 
 # ===== Lint / Fix =====
 lint:   lint-md lint-text lint-format

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
     "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test",
+    "validate:problems": "bun run scripts/validate-problems.ts",
     "lint:md": "markdownlint-cli2 '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist'",
     "lint:text": "textlint '**/*.md'",
     "lint:format": "biome check",

--- a/problems/README.md
+++ b/problems/README.md
@@ -1,0 +1,116 @@
+# TenkaCloud 問題カタログ
+
+TenkaCloud で配信する問題 (Battle / Challenge) は 1 ディレクトリ 1 問題の規約で管理する。
+リポジトリの `problems/` 配下を見れば、現在カタログに載っている全問題が分かるのが正本。
+
+## ディレクトリ構造
+
+```
+problems/
+  <category>/                     # gameday / jam / ...
+    <problem-id>/                 # kebab-case の問題 ID (= ディレクトリ名)
+      metadata.json               # 問題メタデータ (UI / カタログ正本)
+      template.yaml               # CFn ペライチ (deploy 本体)
+      api/, frontend/, local/     # 任意の問題実装ファイル
+      ...
+  SCHEMA.json                     # metadata.json の JSON Schema (draft-07)
+  README.md                       # このファイル
+```
+
+1 つの問題ディレクトリは **`metadata.json` と `template.yaml`** の 2 つだけあれば成立する。
+追加の `api/` や `frontend/` 等は問題実装の都合で置く。
+
+## 必須ファイル
+
+### `metadata.json`
+
+[`SCHEMA.json`](./SCHEMA.json) で形式を定義する。frontend のカタログ表示と backend の deploy
+パイプラインの両方が参照する正本。記述例は
+[`gameday/security-battle-royale/metadata.json`](./gameday/security-battle-royale/metadata.json)
+を参照。
+
+主なキーは次の通りです。
+
+| キー                | 用途                                                                      |
+| ------------------- | ------------------------------------------------------------------------- |
+| `id`                | kebab-case 英小文字 ID。ディレクトリ名と一致させる。CFn stack 名にも入る。 |
+| `name`              | UI 表示名 (人間可読、日本語可)。                                          |
+| `category`          | `Battle` (リアルタイム対戦) または `Challenge` (個別演習)。               |
+| `status`            | `ready` / `draft` / `deprecated`。                                        |
+| `difficulty`        | 1 (入門) 〜 5 (エキスパート)。                                            |
+| `estimatedDuration` | 想定プレイ時間 (例: `60〜90 分`)。                                        |
+| `shortDescription`  | カード表示用の 1 行サマリ。                                               |
+| `description`       | 詳細ページの長文 (改行 OK)。                                              |
+| `tags`              | 検索 / フィルタリング用 kebab-case タグ。                                 |
+| `exposedPorts`      | deploy 後に参加者へ払い出されるポート (`{port, name}` の配列)。           |
+| `learningGoals`     | 想定学習目的の箇条書き。                                                  |
+| `cfnTemplate`       | 同ディレクトリ内 CFn テンプレートへの相対パス。                           |
+
+### `template.yaml`
+
+CloudFormation テンプレート。「ペライチ」とし、deploy 時には**このファイル単独**を競技アカウントの
+CFn にアップロードして展開する。
+
+#### 必須パラメータ
+
+deploy パイプラインがすべての問題テンプレートに対して同じ引数で起動できるよう、
+次のパラメータをサポートします。
+
+| パラメータ        | 必須 | 用途                                                                            |
+| ----------------- | ---- | ------------------------------------------------------------------------------- |
+| `NamePrefix`      | ○    | `tc-{problemSlug}-{teamSlug}` 形式の共通リソース prefix。全リソース名に冠する。 |
+| `AllowedCidr`     | -    | 公開ポートを許可する CIDR (default `0.0.0.0/0`)。                               |
+| 問題固有パラメータ | -    | `DbPassword` 等。問題ごとに自由に追加してよい。                                 |
+
+#### 命名規約 (衝突回避)
+
+同一 (Account, Region) に複数チームの問題スタックが共存する運用を想定する。
+すべてのリソース名 / タグ / グループ名等は `${NamePrefix}` を冠する。
+
+例えば次のように記述します。
+
+```yaml
+Resources:
+  MyVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+```
+
+#### 出力 (Outputs)
+
+UI / 運営側で扱いやすいよう、最低でも次の Output を含めます。
+
+- `FrontendUrl` / `ApiUrl` 等、参加者向けエンドポイント URL
+- `InstanceId` 等、運営側のデバッグ用識別子
+- `NamePrefix` (deploy 時の引数 echo)
+
+## 新しい問題を追加する手順
+
+1. `problems/<category>/<id>/` ディレクトリを作る (kebab-case)。
+2. [`SCHEMA.json`](./SCHEMA.json) に従って `metadata.json` を書く。
+3. `template.yaml` を書く (上記 NamePrefix 規約に沿う)。
+4. docker-compose や言語ランタイム等を伴う問題では `api/` / `frontend/` / `local/` 配下に実装ファイルを置く。
+5. `bun run validate:problems` (※今後追加) でメタデータの形式チェックを通す。
+6. 動作確認: `aws cloudformation deploy --template-file template.yaml --stack-name tc-<id>-test --parameter-overrides NamePrefix=tc-<id>-test ...`
+
+## frontend カタログとの連携 (今後)
+
+現状 frontend (`apps/application-admin-console/src/data/problems.ts`) は問題カタログを静的リテラルで
+持っている。今後 build 時に `problems/**/metadata.json` をスキャンして frontend に注入する仕組みを
+入れ、`metadata.json` を正本とする (TODO)。
+
+## ロードマップ (本 PR の範囲外)
+
+以下は metadata.json 規約の上に積む後続の仕事。現状は枠組みだけ提示。
+
+- **participant ポータル**: チームログインキーで認証し、自チームに deploy された問題への
+  click-through 一覧 + 競技状況を見せる別アプリ。
+- **scoreboard**: Battle / Challenge 両モード共通の得点 backend (DDB + 集計 Lambda)。
+- **Challenge ダッシュボード**: 線グラフ + 得点ヒストリー + リアルタイム得点。
+- **Battle 演出 / disruption イベント**: 競技中に妨害やシチュエーションチェンジを差し込む
+  仕組み + ペナルティ / 得点の可視化。
+- **deploy backend**: form 入力を受け取り、CFn テンプレートを competitor account の
+  CloudFormation に展開する Lambda + cross-account AssumeRole + ステータス追跡。

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tenkacloud.example/schemas/problem-metadata.json",
+  "title": "TenkaCloud Problem Metadata",
+  "description": "1 つの問題ディレクトリ (problems/<category>/<id>/) に置く metadata.json の構造を定義する。frontend カタログ表示と backend deploy パイプラインの両方が参照する正本。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "category",
+    "status",
+    "difficulty",
+    "estimatedDuration",
+    "shortDescription",
+    "description",
+    "tags",
+    "exposedPorts",
+    "learningGoals",
+    "cfnTemplate"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "IDE 補完のための JSON Schema 参照 (任意、validator は無視する)。"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$",
+      "description": "kebab-case の英小文字 ID。ディレクトリ名と一致させる。CFn stack 名の prefix に組み込まれる。"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "description": "UI 表示用の問題名 (人間可読、日本語可)。"
+    },
+    "category": {
+      "type": "string",
+      "enum": ["Battle", "Challenge"],
+      "description": "問題カテゴリ。Battle = リアルタイム対戦、Challenge = 個別演習・常設チャレンジ。"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ready", "draft", "deprecated"],
+      "description": "公開ステータス。ready = 参加者向けデプロイ可能 / draft = 開発中 / deprecated = 廃止予定。"
+    },
+    "difficulty": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 5,
+      "description": "1=入門 / 2=初級 / 3=中級 / 4=上級 / 5=エキスパート。"
+    },
+    "estimatedDuration": {
+      "type": "string",
+      "description": "想定プレイ時間。UI 表示用の自由文字列 (例: '60〜90 分')。"
+    },
+    "shortDescription": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "カード表示用の 1 行サマリ (200 文字以内目安)。"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "詳細ページに表示する長文。改行を含む生テキスト。"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "description": "検索 / フィルタリング用の kebab-case タグ。"
+    },
+    "exposedPorts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["port", "name"],
+        "properties": {
+          "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "name": { "type": "string", "minLength": 1 }
+        }
+      },
+      "description": "deploy 後に参加者へ払い出されるエンドポイントのポート / 用途名。"
+    },
+    "learningGoals": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "問題作者が想定する学習目的の箇条書き。"
+    },
+    "cfnTemplate": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._/-]+\\.(yaml|yml|json)$",
+      "description": "同一ディレクトリからの相対パスで指す CFn テンプレートファイル (ペライチ)。デプロイ時にこのテンプレートが competitor account の CFn にアップロードされる。"
+    }
+  }
+}

--- a/problems/gameday/security-battle-royale/metadata.json
+++ b/problems/gameday/security-battle-royale/metadata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "security-battle-royale",
+  "name": "Security Battle Royale",
+  "category": "Battle",
+  "status": "draft",
+  "difficulty": 3,
+  "estimatedDuration": "60〜90 分",
+  "shortDescription": "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",
+  "description": "ECサイト風の Web アプリ「Unicorn.Rentals」を題材に、SQL injection / リモートコード実行 / SSRF / IMDS 露出を含む複数の脆弱性が仕込まれた状態でデプロイされる。\n\n競技参加者は次のいずれかのロールでプレイする。\n  - **攻撃側**: 他チームの公開エンドポイントを巡回し、得点リソースを奪取する。\n  - **防御側**: 自チームのアプリを継続稼働させたまま、脆弱性を順次塞いでいく。\n\nデプロイ単位は EC2 1 台 + Docker 構成 (mysql / Flask api / nginx frontend)。デプロイ完了後、参加者には Frontend URL と API URL が払い出される。",
+  "tags": ["security", "web", "sql-injection", "rce", "ssrf"],
+  "exposedPorts": [
+    { "port": 80, "name": "frontend (nginx)" },
+    { "port": 8080, "name": "api (Flask)" }
+  ],
+  "learningGoals": [
+    "意図的な SQL injection / RCE / SSRF を発見・修正する一連の手順を体験する",
+    "EC2 IMDS / IAM Role の露出経路と、それを塞ぐベストプラクティスを理解する",
+    "競技中に同居する攻撃者と防御者のトレードオフ (可用性を保ちつつ守る) を体験する"
+  ],
+  "cfnTemplate": "template.yaml"
+}

--- a/problems/gameday/security-battle-royale/template.yaml
+++ b/problems/gameday/security-battle-royale/template.yaml
@@ -1,0 +1,228 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud problem — security-battle-royale.
+  Single-EC2 docker-compose deploy (mysql + flask api + nginx frontend) with
+  intentional SQLi / RCE / SSRF / IMDS-exposure vulnerabilities for participants
+  to attack and defend.
+
+# 同一 (Account, Region) に複数チームの問題スタックが共存できるよう、すべての
+# リソース名は ${NamePrefix} (= "tc-{problemSlug}-{teamSlug}", UI 側 buildStackPrefix
+# と一致) を冠する。
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    ConstraintDescription: >
+      `tc-{problemSlug}-{teamSlug}` 形式 (英小文字 / 数字 / ハイフン)。
+      application-admin-console の DeployForm が生成する prefix を渡す。
+    Description: >
+      すべてのリソース名に冠する共通 prefix。同一 Account / Region に複数チームの
+      スタックが共存しても衝突しないようにする。
+  DbPassword:
+    Type: String
+    NoEcho: true
+    MinLength: 8
+    MaxLength: 64
+    AllowedPattern: "^[A-Za-z0-9!@#$%^&*()_+\\-=]+$"
+    ConstraintDescription: 8〜64 文字の英数字 + 限定記号。
+    Description: 埋め込み MySQL の root / admin パスワード。
+  AllowedCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+    Description: frontend (80) / api (8080) を許可する CIDR。
+  InstanceType:
+    Type: String
+    Default: t3.small
+    AllowedValues:
+      - t3.micro
+      - t3.small
+      - t3.medium
+    Description: EC2 インスタンスタイプ。
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
+    Description: SSM-backed Amazon Linux 2023 AMI (auto-resolved)。
+  RepoUrl:
+    Type: String
+    Default: https://github.com/susumutomita/TenkaCloud.git
+    Description: 問題ソース取得元 (公開 GitHub リポジトリ前提)。
+  RepoRef:
+    Type: String
+    Default: trunk/protoship-migration
+    Description: チェックアウトする branch / tag / commit。
+
+Resources:
+  # ----- VPC + Networking -----
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.99.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.99.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet"
+
+  Igw:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-igw"
+
+  IgwAttach:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref Igw
+
+  Rt:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rt"
+
+  RtRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IgwAttach
+    Properties:
+      RouteTableId: !Ref Rt
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref Igw
+
+  RtAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref Rt
+      SubnetId: !Ref PublicSubnet
+
+  # ----- Security Group -----
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: !Sub "${NamePrefix} problem instance access"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref AllowedCidr
+          Description: frontend (nginx)
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          CidrIp: !Ref AllowedCidr
+          Description: api (Flask)
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-sg"
+
+  # ----- IAM (SSM Session Manager only) -----
+  # api.py が IMDS を叩く設計 (= 意図的な exposure)。なのでロールには Session Manager だけ。
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-instance-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub "${NamePrefix}-instance-profile"
+      Roles:
+        - !Ref InstanceRole
+
+  # ----- EC2 -----
+  Ec2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref Sg
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2"
+        - Key: TenkaCloud:Problem
+          Value: security-battle-royale
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+          dnf update -y
+          dnf install -y docker git
+          systemctl enable --now docker
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64" \
+            -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+          mkdir -p /opt/tenkacloud
+          cd /opt/tenkacloud
+          # branch / tag / commit いずれも指せるよう、shallow fetch + checkout 形式
+          git clone "${RepoUrl}" repo
+          cd repo
+          git fetch origin "${RepoRef}" || git fetch --all
+          git checkout "${RepoRef}" || git checkout FETCH_HEAD
+
+          PROBLEM_ROOT=/opt/tenkacloud/repo/problems/gameday/security-battle-royale
+          cd "$PROBLEM_ROOT/local"
+
+          cat > .env <<ENVEOF
+          PROBLEM_ROOT=$PROBLEM_ROOT
+          DB_PASSWORD=${DbPassword}
+          DB_EXPOSE_PORT=3306
+          API_PORT=8080
+          FRONTEND_PORT=80
+          REGION=${AWS::Region}
+          ENVEOF
+
+          docker compose up -d
+
+Outputs:
+  FrontendUrl:
+    Description: 参加者向け frontend (nginx) URL。
+    Value: !Sub "http://${Ec2.PublicDnsName}"
+  ApiUrl:
+    Description: 参加者向け api (Flask) URL。
+    Value: !Sub "http://${Ec2.PublicDnsName}:8080"
+  InstanceId:
+    Description: EC2 インスタンス ID (運営者が SSM Session Manager から接続する際に使う)。
+    Value: !Ref Ec2
+  SsmStartSessionCommand:
+    Description: 運営者がインスタンスへ Session Manager で接続するコマンド。
+    Value: !Sub "aws ssm start-session --target ${Ec2}"
+  NamePrefix:
+    Description: 本スタックが利用した共通リソース prefix。
+    Value: !Ref NamePrefix

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+/**
+ * problems/ 配下のすべての metadata.json を problems/SCHEMA.json で validate する。
+ *
+ * Usage:
+ *   bun run scripts/validate-problems.ts
+ *
+ * 失敗時は exit code 1 + エラー内容を stderr に出す。CI / pre-commit で実行する想定。
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import Ajv2020 from "ajv";
+import addFormats from "ajv-formats";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+const SCHEMA_PATH = join(PROBLEMS_DIR, "SCHEMA.json");
+
+function findMetadataFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) {
+      found.push(...findMetadataFiles(full));
+    } else if (entry === "metadata.json") {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function main(): void {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  const metadataFiles = findMetadataFiles(PROBLEMS_DIR);
+  if (metadataFiles.length === 0) {
+    console.error("No metadata.json found under problems/. At least one problem is expected.");
+    process.exit(1);
+  }
+
+  let failed = 0;
+  for (const file of metadataFiles) {
+    const rel = relative(REPO_ROOT, file);
+    const data = JSON.parse(readFileSync(file, "utf8"));
+    if (validate(data)) {
+      console.log(`OK  ${rel}`);
+      continue;
+    }
+    failed += 1;
+    console.error(`NG  ${rel}`);
+    for (const err of validate.errors ?? []) {
+      console.error(`     ${err.instancePath || "(root)"} ${err.message ?? ""}`);
+    }
+
+    // id とディレクトリ名の一致もチェック (schema では強制できないので別途)
+    const expectedId = file.split("/").slice(-2, -1)[0];
+    if (data.id && data.id !== expectedId) {
+      console.error(`     id (${data.id}) はディレクトリ名 (${expectedId}) と一致させてください`);
+    }
+  }
+
+  if (failed > 0) {
+    console.error(
+      `\n${failed} / ${metadataFiles.length} 件の metadata.json が schema に違反しています`,
+    );
+    process.exit(1);
+  }
+  console.log(`\n${metadataFiles.length} 件の metadata.json はすべて有効です`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- 「同じディレクトリに CloudFormation (\`template.yaml\`) + メタデータ (\`metadata.json\`)」 の規約を導入
- 1 ディレクトリ = 1 問題で managed する形を確定し、frontend カタログ表示と backend deploy パイプラインの両方が \`problems/**/metadata.json\` を正本として参照できる土台を作る
- 現状唯一の問題 \`security-battle-royale\` を新規約に乗せる (metadata.json + CFn ペライチ)

## 背景

「問題カタログをどうやって管理するか」のレビュー回で、CFn + metadata.json を同じディレクトリに置けば成立する、という設計判断に合意。本 PR はその規約と最初の問題を land する。

## 主な変更

### Schema + 規約
- \`problems/SCHEMA.json\`: metadata.json の JSON Schema (draft-07)
- \`problems/README.md\`: 1 dir = 1 問題、必須ファイル、命名規約、ロードマップを記述

### 最初の問題 \`security-battle-royale\`
- \`problems/gameday/security-battle-royale/metadata.json\`: frontend カタログと 1:1 のメタデータ
- \`problems/gameday/security-battle-royale/template.yaml\`: ペライチ CFn
  - EC2 + 最小 VPC + SG + IAM (SSM only) + UserData で \`git clone\` + \`docker compose up\`
  - すべてのリソース名は \`\${NamePrefix}\` で衝突回避 (UI 側 \`buildStackPrefix\` と整合)
  - \`aws cloudformation validate-template\` で構文確認済

### Validation tooling
- \`scripts/validate-problems.ts\`: ajv で全 metadata.json を schema validate + id ↔ ディレクトリ名一致を確認
- \`package.json\`: \`bun run validate:problems\` 追加
- \`Makefile\`: \`make validate-problems\` 追加 + \`make before-commit\` に組み込み

## ロードマップ (本 PR の範囲外)

問題ごとの個別実装 (CFn 中身) や、その上に積む系統 (frontend カタログ自動化 / participant ポータル / scoreboard / Challenge ダッシュボード / Battle 演出 / deploy backend) は順次別 PR で。

## Test plan
- [x] make before-commit 通過 (lint / format / test / validate-problems)
- [x] aws cloudformation validate-template でテンプレート構文確認
- [ ] 手動: \`aws cloudformation deploy\` で security-battle-royale を実 deploy → docker compose 起動 → Frontend URL / API URL アクセス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)