### PR TITLE
feat(deploy): 競技者アカウント向け bootstrap CFn — Deploy backend PR-A

### DIFF
--- a/infrastructure/templates/README.md
+++ b/infrastructure/templates/README.md
@@ -1,0 +1,80 @@
+# TenkaCloud — 競技者向け事前セットアップ
+
+このディレクトリは、TenkaCloud から問題を deploy される側 (= 競技者) の AWS アカウントで
+事前に 1 回だけ流す CloudFormation テンプレートを置く。
+
+## `competitor-bootstrap.yaml`
+
+### これは何か
+
+TenkaCloud の Deploy Lambda が、競技者 AWS アカウントへ問題 CFn (`problems/<id>/template.yaml`) を
+deploy するために使う **IAM Role** を作るテンプレート。
+trust policy は TenkaCloud control-plane アカウント ID + ExternalId に限定し、
+それ以外の主体からの AssumeRole を拒否する。
+
+### セットアップ手順
+
+#### 1. TenkaCloud 運営者から以下を受け取る
+
+- **TenkaCloudAccountId**: TenkaCloud の control-plane が動く AWS アカウント ID (12 桁)
+- **ExternalId**: テナント固有の External ID (16 文字以上の secret)
+
+#### 2. 競技者 AWS アカウントでテンプレートを deploy
+
+CLI で実行する場合は次の通りです。
+
+```bash
+aws cloudformation deploy \
+  --template-file infrastructure/templates/competitor-bootstrap.yaml \
+  --stack-name tenkacloud-competitor-bootstrap \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+      TenkaCloudAccountId=123456789012 \
+      ExternalId=share-this-secret-with-tenkacloud
+```
+
+Console から流す場合は CFn →「スタックの作成」→ テンプレート yaml を upload →
+パラメータ入力 →「IAM 権限変更を承認」にチェックして実行します。
+
+#### 3. 出力された RoleArn を TenkaCloud 運営者に共有
+
+deploy 完了後、CFn Outputs に表示される `RoleArn` を TenkaCloud 運営者に伝える。
+TenkaCloud 側はこの ARN と ExternalId を用いて AssumeRole し、問題 CFn を本アカウントへ
+展開できるようになる。
+
+### 付与される権限
+
+作成される Role に対し、問題 CFn が必要とする次の権限を付与します。
+
+| サービス       | スコープ                                         | 用途                                   |
+| -------------- | ------------------------------------------------ | -------------------------------------- |
+| CloudFormation | `*`                                              | 問題スタックの create / update / delete |
+| EC2 / VPC      | `*`                                              | 問題 CFn が VPC + EC2 を立てる         |
+| SSM            | `GetParameter*` / `DescribeParameters`           | AMI ID 解決 / セッションマネージャ     |
+| IAM            | `tc-*` の Role / Instance Profile のみ           | 問題 CFn が EC2 instance profile を作る |
+| S3             | `tc-*` バケット / オブジェクト                   | 将来の S3 利用問題向け                 |
+| CloudWatch Logs| `*`                                              | 診断ログ                               |
+
+権限スコープは問題 CFn が実際に必要とするものに合わせて広めに付与している (`ec2:*` など)。
+最小権限化は問題テンプレートが固まった後に絞る方針。
+
+### 撤回 / クリーンアップ
+
+このスタックを削除すると Role も消える ⇒ TenkaCloud からの AssumeRole が即時に拒否される。
+
+```bash
+aws cloudformation delete-stack --stack-name tenkacloud-competitor-bootstrap
+```
+
+### セキュリティ上の前提
+
+- **External ID は secret として扱う**。Confused Deputy 攻撃を防ぐため、TenkaCloud 運営者と
+  競技者だけが知っている値である必要がある。
+- TenkaCloud の Deploy Lambda は CloudTrail に AssumeRole 履歴を残す。競技者は自身の
+  CloudTrail でその AssumeRole / 後続の CFn / EC2 操作を監査できる。
+- スタック削除で権限を即時撤回できるので、競技終了後はスタックを消すと安全。
+
+## 関連
+
+- [`/problems/README.md`](../../problems/README.md) — 問題カタログ規約
+- [`/problems/gameday/security-battle-royale/template.yaml`](../../problems/gameday/security-battle-royale/template.yaml) — 実際に deploy される問題 CFn の例

--- a/infrastructure/templates/competitor-bootstrap.yaml
+++ b/infrastructure/templates/competitor-bootstrap.yaml
@@ -1,0 +1,162 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud Competitor Bootstrap. 競技者 (= 問題 deploy 先) AWS アカウントが
+  事前に 1 回だけ deploy する。TenkaCloud control-plane の Deploy Lambda が
+  AssumeRole するための IAM Role を作る。trust は TenkaCloud アカウント ID +
+  ExternalId に限定し、Confused Deputy を防ぐ。
+
+# このスタックを deploy した後、出力された RoleArn を TenkaCloud の TenantAdmin に
+# 伝えると、TenkaCloud から問題 CFn を本アカウントへ deploy できるようになる。
+# スタック削除すると Role も消えるので、TenkaCloud からのアクセス権を一括撤回できる。
+
+Parameters:
+  TenkaCloudAccountId:
+    Type: String
+    AllowedPattern: "^[0-9]{12}$"
+    ConstraintDescription: 12 桁の AWS アカウント ID。
+    Description: >
+      AssumeRole を許可する TenkaCloud control-plane の AWS アカウント ID。
+      TenkaCloud 運営者から事前に共有される。
+  ExternalId:
+    Type: String
+    NoEcho: true
+    MinLength: 16
+    MaxLength: 128
+    AllowedPattern: "^[A-Za-z0-9_=,.@:/-]+$"
+    Description: >
+      AssumeRole 時に TenkaCloud から渡される External ID。Confused Deputy 攻撃を
+      防ぐためのテナント固有 secret。TenkaCloud 運営者から事前に共有される。
+  RoleName:
+    Type: String
+    Default: TenkaCloud-CompetitorDeploy-Role
+    AllowedPattern: "^[A-Za-z0-9_+=,.@-]{1,64}$"
+    Description: >
+      作成する IAM Role 名。TenkaCloud 側の deploy 設定とずれないよう default を使う想定。
+
+Resources:
+  # 問題 CFn が触るリソース全方位の権限を持つ Role。
+  # 各問題は VPC + EC2 + IAM (instance profile / role) + CFn 自身を作るため、
+  # この程度の広さがないと Create / Update / Delete どれかでこける。
+  # 最小権限化は問題テンプレが固まってから別途。
+  CompetitorDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: >-
+        TenkaCloud が問題 CFn (security-battle-royale 等) を本アカウントへ deploy するときに
+        AssumeRole される。trust = TenkaCloud account + ExternalId。
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowTenkaCloudControlPlaneToAssume
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${TenkaCloudAccountId}:root"
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      MaxSessionDuration: 3600
+      Policies:
+        - PolicyName: ProblemDeployPermissions
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # CloudFormation 全般 (deploy / update / delete / describe)
+              - Sid: CloudFormationFull
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                Resource: "*"
+
+              # 問題 CFn が作る EC2 / VPC リソース
+              - Sid: Ec2Vpc
+                Effect: Allow
+                Action:
+                  - ec2:*
+                Resource: "*"
+
+              # SSM (AMI 解決 + Session Manager) + ParameterStore
+              - Sid: Ssm
+                Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                  - ssm:GetParameter
+                  - ssm:GetParametersByPath
+                  - ssm:DescribeParameters
+                Resource: "*"
+
+              # IAM (問題 CFn が instance profile / role を作る)
+              # 問題 CFn が作る role / policy のみ触れるよう Path / Name で絞る。
+              - Sid: IamForProblemRoles
+                Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:PassRole
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:GetInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:TagRole
+                  - iam:UntagRole
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/tc-*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/tc-*"
+
+              # 問題 CFn が S3 を使う場合の余地 (今は使ってないが将来用)
+              - Sid: S3ForProblemBuckets
+                Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                  - s3:DeleteBucket
+                  - s3:GetBucket*
+                  - s3:PutBucket*
+                  - s3:ListBucket
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - "arn:aws:s3:::tc-*"
+                  - "arn:aws:s3:::tc-*/*"
+
+              # CloudWatch Logs (UserData / 問題アプリの diag 用)
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DeleteLogGroup
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: "*"
+      Tags:
+        - Key: TenkaCloud:Purpose
+          Value: competitor-deploy
+        - Key: TenkaCloud:ManagedBy
+          Value: competitor-bootstrap.yaml
+
+Outputs:
+  RoleArn:
+    Description: >-
+      作成された Role の ARN。TenkaCloud 運営者にこの値を共有すると、TenkaCloud から
+      問題を本アカウントへ deploy できるようになる。
+    Value: !GetAtt CompetitorDeployRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleArn"
+  AccountId:
+    Description: 競技者 AWS アカウント ID (UI に入力する値)。
+    Value: !Ref AWS::AccountId
+  RoleName:
+    Description: Role 名 (TenkaCloud 側 default と一致するか確認用)。
+    Value: !Ref RoleName


### PR DESCRIPTION
## Summary

Deploy backend の最初の PR。TenkaCloud から問題 CFn を競技者 AWS アカウントへ deploy するための **cross-account IAM Role** を作る CFn テンプレートを追加する。Lambda / DDB / API 実装は後続 PR-B 以降で。

## なぜ最初にこれか

\`POST /deployments\` を実装しても、deploy 先アカウントに AssumeRole 可能な Role が無いと CFn 起動できない。先に **競技者側のセットアップ** を確立し、それを前提に backend を組み立てる。

## 追加ファイル

### \`infrastructure/templates/competitor-bootstrap.yaml\`
- IAM Role \`TenkaCloud-CompetitorDeploy-Role\` を作成
- **trust policy**: TenkaCloud control-plane account ID + ExternalId (Confused Deputy 対策)
- **permissions**:
  - \`cloudformation:*\` (問題スタック CRUD)
  - \`ec2:*\` (security-battle-royale が EC2 + VPC を立てる)
  - SSM read (AMI 解決 / Session Manager)
  - IAM \`tc-*\` Role / Instance Profile only (NamePrefix で他を触らせない)
  - S3 \`tc-*\` only (将来用)
  - CloudWatch Logs
- **Outputs**: RoleArn (TenkaCloud 運営者に共有する値)

### \`infrastructure/templates/README.md\`
- 競技者向けセットアップ手順 (CLI / Console)
- 権限の根拠と スコープ表
- セキュリティ前提 (ExternalId secret 扱い、CloudTrail 監査、stack 削除で即時撤回)

## 設計判断

- **EC2 系のみ**: security-battle-royale が EC2 + IMDS 前提のため、本 Role は EC2 系問題に最適化。Lambda / RDS 系問題が来たら拡張。
- **競技者画面 (participant portal) は別系統**: portal 自体は TenkaCloud account で Lambda + S3 で動かす (cost 最適化)。本 PR の Role とは無関係。
- **\`tc-*\` prefix で IAM / S3 を絞る**: 問題 CFn が NamePrefix で名前を付ける規約 (PR #437) と整合し、Role が TenkaCloud 管理外リソースを触れないようにする。

## 検証

- [x] \`aws cloudformation validate-template\` 通過
- [x] make before-commit (lint / format / test / validate-problems)

## ロードマップ

| PR  | 内容                                                       |
| --- | ---------------------------------------------------------- |
| **A (本 PR)** | 競技者向け bootstrap CFn                          |
| B   | Deploy Lambda 雛形 + DDB Deployments table                 |
| C   | POST /deployments                                          |
| D   | Status Updater Lambda + EventBridge schedule (auto-teardown TTL) |
| E   | GET /deployments + UI 結線                                  |
| F   | DELETE /deployments                                        |

🤖 Generated with [Claude Code](https://claude.com/claude-code)