### PR TITLE
feat(deploy): Deploy backend 基盤 (DDB Deployments + Worker IAM Role) — PR-B

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -10,6 +10,7 @@ import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
 import { getEnv } from "../lib/helper-functions";
+import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
 import { loadConfig } from "../lib/utils/config-loader";
@@ -130,6 +131,16 @@ const controlPlaneStack = new ControlPlaneStack(app, "ControlPlaneStack", {
 // 既定値) なので Free Tier 枠 (25 RCU/WCU) を圧迫する。Aspect で全 CfnTable を
 // dynamoReadCapacity / dynamoWriteCapacity (default 1/1) に揃えて Free Tier に収める。
 cdk.Aspects.of(controlPlaneStack).add(
+  new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
+);
+
+// Problem deploy backend (PR-B): Deployments DDB + Worker IAM Role の土台のみ。
+// EventBridge Rule + Lambda は後段 PR で本 stack に追加する。
+const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
+  ...stackEnv,
+  eventBusArn: controlPlaneStack.eventBusArn,
+});
+cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
 );
 

--- a/infrastructure/lib/problem-deploy/deploy-worker-role.ts
+++ b/infrastructure/lib/problem-deploy/deploy-worker-role.ts
@@ -1,0 +1,84 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+
+export interface DeployWorkerRoleProps {
+  /** 後段 PR で作成される Lambda 群が CRUD する Deployments テーブルの ARN。 */
+  readonly deploymentsTableArn: string;
+  /**
+   * SBT control-plane の EventBus ARN。Lambda が deploy 系イベントを put する。
+   */
+  readonly eventBusArn: string;
+}
+
+/**
+ * 問題 deploy 系 Lambda が引き受ける IAM Role。
+ *
+ * 用途:
+ *   - 競技者アカウントの `TenkaCloud-CompetitorDeploy-Role` を AssumeRole する
+ *     (cross-account)
+ *   - Deployments table を CRUD する
+ *   - SBT EventBus に deploy 系イベントを put する
+ *   - CloudWatch Logs に書く (managed policy)
+ *
+ * AssumeRole の許可は `*` (どの account の role でも引ける) にしている。理由:
+ *   - 競技者アカウントは UI 入力で動的に決まり、deploy ごとに異なる
+ *   - Resource を絞ると無限に拡張するか、deploy のたびに Role を更新する運用になる
+ *   - 引かれる側 (競技者の Bootstrap Role) で trust + ExternalId で絞り、
+ *     Confused Deputy はそちら側で防ぐ
+ *
+ * 後段 PR (PR-C / D / E) で Lambda 関数が増えるたびに、本 Role を assume させる
+ * 形で再利用する。
+ */
+export class DeployWorkerRole extends Construct {
+  public readonly role: iam.Role;
+
+  constructor(scope: Construct, id: string, props: DeployWorkerRoleProps) {
+    super(scope, id);
+
+    this.role = new iam.Role(this, "Role", {
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      description: "TenkaCloud problem deploy worker (cross-account AssumeRole + DDB + EventBus)",
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+      ],
+      inlinePolicies: {
+        AssumeCompetitorRoles: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ["sts:AssumeRole"],
+              resources: ["arn:aws:iam::*:role/TenkaCloud-CompetitorDeploy-Role"],
+            }),
+          ],
+        }),
+        DeploymentsTableAccess: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:BatchWriteItem",
+              ],
+              resources: [props.deploymentsTableArn, `${props.deploymentsTableArn}/index/*`],
+            }),
+          ],
+        }),
+        EventBusPublish: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ["events:PutEvents"],
+              resources: [props.eventBusArn],
+            }),
+          ],
+        }),
+      },
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/deployments-table.ts
+++ b/infrastructure/lib/problem-deploy/deployments-table.ts
@@ -1,0 +1,51 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * 問題 deploy ジョブを 1 行 1 件で記録する DynamoDB テーブル。
+ *
+ * Schema:
+ *   PK: DEPLOYMENT#<jobId>          (jobId = ULID)
+ *   SK: META
+ *
+ * 主な属性:
+ *   jobId / problemId / tenantId / awsAccountId / region / teamName /
+ *   namePrefix / teamLoginKey / status / stackId / stackOutputs /
+ *   failureReason / createdAt / updatedAt / expiresAt
+ *
+ * GSI1 (テナント別の deployment 一覧):
+ *   PK: TENANT#<tenantId>
+ *   SK: createdAt (ISO8601)
+ *
+ * memory: provisioned 1/1 (DynamoDbLowCapacity Aspect で更に均す)。training / 競技
+ * イベント中の用途で QPS 極小、コスト 0 原則を優先する。
+ *
+ * 削除方針: RETAIN。stack delete でユーザの deployment 履歴を意図せず消さない。
+ * 必要なら手動で破棄する。
+ */
+export class DeploymentsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+      timeToLiveAttribute: "expiresAt",
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI1",
+      partitionKey: { name: "GSI1PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -1,0 +1,53 @@
+import * as cdk from "aws-cdk-lib";
+import { CfnOutput } from "aws-cdk-lib";
+import type { Construct } from "constructs";
+import { DeployWorkerRole } from "./deploy-worker-role";
+import { DeploymentsTable } from "./deployments-table";
+
+export interface ProblemDeployBackendStackProps extends cdk.StackProps {
+  /**
+   * SBT ControlPlane の EventBus ARN。Deploy 系イベント (DeployRequested /
+   * DeployStarted / DeployCompleted / DeployFailed) を流す。後段 PR で
+   * EventBridge Rule を本 stack に追加する。
+   */
+  readonly eventBusArn: string;
+}
+
+/**
+ * 問題 deploy backend のスタック。
+ *
+ * 本 PR (PR-B) ではまだ Lambda は無く、後続 PR (C-G) が必要とする土台:
+ *   - Deployments テーブル (DDB)
+ *   - Deploy Worker IAM Role (cross-account AssumeRole + DDB + EventBus)
+ * のみを置く。EventBridge Rule + Lambda は target が同時に landing する形で
+ * 後段 PR が追加する。
+ */
+export class ProblemDeployBackendStack extends cdk.Stack {
+  public readonly deploymentsTableName: string;
+  public readonly deploymentsTableArn: string;
+  public readonly deployWorkerRoleArn: string;
+
+  constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
+    super(scope, id, props);
+
+    const deployments = new DeploymentsTable(this, "Deployments");
+    const workerRole = new DeployWorkerRole(this, "WorkerRole", {
+      deploymentsTableArn: deployments.table.tableArn,
+      eventBusArn: props.eventBusArn,
+    });
+
+    this.deploymentsTableName = deployments.table.tableName;
+    this.deploymentsTableArn = deployments.table.tableArn;
+    this.deployWorkerRoleArn = workerRole.role.roleArn;
+
+    new CfnOutput(this, "DeploymentsTableName", {
+      value: deployments.table.tableName,
+      description:
+        "Deploy ジョブを記録する DynamoDB テーブル名。後段 PR の Lambda が読み書きする。",
+    });
+    new CfnOutput(this, "DeployWorkerRoleArn", {
+      value: workerRole.role.roleArn,
+      description: "後段 PR で作成する Lambda が引き受ける IAM Role の ARN。",
+    });
+  }
+}

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -1,0 +1,188 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
+
+const FAKE_BUS_ARN = "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus";
+
+function synth(): Template {
+  const app = new cdk.App();
+  const stack = new ProblemDeployBackendStack(app, "TestStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+    eventBusArn: FAKE_BUS_ARN,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("ProblemDeployBackendStack", () => {
+  describe("instantiate したとき", () => {
+    it("Deployments テーブルを 1 つ作るべき", () => {
+      const tpl = synth();
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 1);
+    });
+
+    it("Deployments テーブルは PROVISIONED 1/1 で PK/SK を持つべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::DynamoDB::Table",
+        Match.objectLike({
+          BillingMode: Match.absent(),
+          ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+          KeySchema: Match.arrayWith([
+            Match.objectLike({ AttributeName: "PK", KeyType: "HASH" }),
+            Match.objectLike({ AttributeName: "SK", KeyType: "RANGE" }),
+          ]),
+        }),
+      );
+    });
+
+    it("Deployments テーブルは GSI1 を持ち、PROVISIONED 1/1 であるべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::DynamoDB::Table",
+        Match.objectLike({
+          GlobalSecondaryIndexes: Match.arrayWith([
+            Match.objectLike({
+              IndexName: "GSI1",
+              KeySchema: Match.arrayWith([
+                Match.objectLike({ AttributeName: "GSI1PK", KeyType: "HASH" }),
+                Match.objectLike({ AttributeName: "GSI1SK", KeyType: "RANGE" }),
+              ]),
+              ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it("Deployments テーブルは expiresAt の TTL を持つべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::DynamoDB::Table",
+        Match.objectLike({
+          TimeToLiveSpecification: { AttributeName: "expiresAt", Enabled: true },
+        }),
+      );
+    });
+
+    it("Deployments テーブルは Retain で削除耐性を持つべき", () => {
+      const tpl = synth();
+      tpl.hasResource("AWS::DynamoDB::Table", { DeletionPolicy: "Retain" });
+    });
+
+    it("DeployWorkerRole を 1 つ作り、lambda.amazonaws.com に assume させるべき", () => {
+      const tpl = synth();
+      tpl.resourceCountIs("AWS::IAM::Role", 1);
+      tpl.hasResourceProperties(
+        "AWS::IAM::Role",
+        Match.objectLike({
+          AssumeRolePolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("DeployWorkerRole は競技者 Role を AssumeRole できる inline policy を持つべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::IAM::Role",
+        Match.objectLike({
+          Policies: Match.arrayWith([
+            Match.objectLike({
+              PolicyName: "AssumeCompetitorRoles",
+              PolicyDocument: Match.objectLike({
+                Statement: Match.arrayWith([
+                  Match.objectLike({
+                    Effect: "Allow",
+                    Action: "sts:AssumeRole",
+                    Resource: "arn:aws:iam::*:role/TenkaCloud-CompetitorDeploy-Role",
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it("DeployWorkerRole は Deployments への CRUD inline policy を持つべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::IAM::Role",
+        Match.objectLike({
+          Policies: Match.arrayWith([
+            Match.objectLike({
+              PolicyName: "DeploymentsTableAccess",
+              PolicyDocument: Match.objectLike({
+                Statement: Match.arrayWith([
+                  Match.objectLike({
+                    Effect: "Allow",
+                    Action: Match.arrayWith([
+                      "dynamodb:GetItem",
+                      "dynamodb:PutItem",
+                      "dynamodb:UpdateItem",
+                      "dynamodb:DeleteItem",
+                      "dynamodb:Query",
+                    ]),
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it("DeployWorkerRole は EventBus PutEvents inline policy を持ち、Resource は与えた arn 限定であるべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::IAM::Role",
+        Match.objectLike({
+          Policies: Match.arrayWith([
+            Match.objectLike({
+              PolicyName: "EventBusPublish",
+              PolicyDocument: Match.objectLike({
+                Statement: Match.arrayWith([
+                  Match.objectLike({
+                    Effect: "Allow",
+                    Action: "events:PutEvents",
+                    Resource: FAKE_BUS_ARN,
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it("Outputs に DeploymentsTableName と DeployWorkerRoleArn を含むべき", () => {
+      const tpl = synth();
+      tpl.hasOutput("DeploymentsTableName", {});
+      tpl.hasOutput("DeployWorkerRoleArn", {});
+    });
+  });
+
+  describe("複数 stack を同居しても", () => {
+    it("synth が衝突なく通るべき (ResourceName 自動生成)", () => {
+      const app = new cdk.App();
+      const a = new ProblemDeployBackendStack(app, "A", {
+        env: { account: "123456789012", region: "ap-northeast-1" },
+        eventBusArn: FAKE_BUS_ARN,
+      });
+      const b = new ProblemDeployBackendStack(app, "B", {
+        env: { account: "123456789012", region: "ap-northeast-1" },
+        eventBusArn: FAKE_BUS_ARN,
+      });
+      expect(() => Template.fromStack(a)).not.toThrow();
+      expect(() => Template.fromStack(b)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Deploy backend ロードマップの **PR-B**。問題 deploy ジョブを記録する DynamoDB テーブルと、後段 PR の Lambda 群が引き受ける IAM Role の土台を立てる。

EventBridge Rule + Lambda 関数本体は target が同時に landing する形で **PR-C 以降** が追加する (rules without targets はデバッグ困難になるため意図的に分割)。

## 主な変更

### \`infrastructure/lib/problem-deploy/\`

- \`deployments-table.ts\`: DDB Deployments テーブル
  - PROVISIONED 1/1 (memory: コスト 0、on-demand 禁止)
  - PK: \`DEPLOYMENT#<jobId>\` / SK: \`META\`
  - GSI1: テナント別一覧用 (\`TENANT#<tenantId>\` / \`createdAt\`)
  - \`expiresAt\` を TTL 属性に指定 (auto-teardown 用 / PR-E)
  - RemovalPolicy.RETAIN (競技履歴を意図せず破棄しない)
- \`deploy-worker-role.ts\`: 後段 Lambda 群が引き受ける IAM Role
  - inline policies:
    - \`AssumeCompetitorRoles\`: \`arn:aws:iam::*:role/TenkaCloud-CompetitorDeploy-Role\` を AssumeRole
    - \`DeploymentsTableAccess\`: Deployments DDB に CRUD
    - \`EventBusPublish\`: 与えられた eventBusArn にのみ PutEvents
- \`problem-deploy-backend-stack.ts\`: 上記 2 construct を持つ新 stack

### \`infrastructure/bin/infrastructure.ts\`
- ProblemDeployBackendStack を ControlPlaneStack の直後に instantiate
- DynamoDbLowCapacity Aspect で provisioned 1/1 を強制

### \`infrastructure/test/problem-deploy-backend-stack.test.ts\`
- 11 ケース (DDB schema / GSI1 / TTL / Retain / Role 各 inline policy / Outputs / multi-stack 同居)

## 設計判断

- **\`sts:AssumeRole\` の Resource を \`*::role/TenkaCloud-CompetitorDeploy-Role\` (account ワイルドカード) にした理由**: 競技者アカウントは UI 入力で動的に決まる。Resource を絞ると無限拡張になる。Confused Deputy は引かれる側 (PR-A の Bootstrap CFn の trust + ExternalId) で防ぐ。
- **DDB は provisioned 1/1**: memory 方針 (on-demand 禁止 / コスト 0)。DynamoDbLowCapacity Aspect でも保証。
- **TTL \`expiresAt\`**: PR-E StatusUpdater が auto-teardown のキーに使う。
- **RemovalPolicy.RETAIN**: stack delete 時もテーブル保持。

## ロードマップ

| PR | 内容 |
|----|------|
| A (#438 merged) | 競技者向け bootstrap CFn |
| **B (本 PR)** | DDB + Worker IAM Role |
| C | Deploy API Lambda (POST /deployments) |
| D | DeployWorker Lambda |
| E | StatusUpdater Lambda + auto-teardown TTL |
| F | GET /deployments + UI 結線 |
| G | DELETE /deployments |
| H | participant portal hosting + PortalUpdater |

## Test plan

- [x] make before-commit (lint / format / test 全 36 件)
- [x] CDK Template assertions 11 ケース通過
- [ ] make synth で実 stack の synth が成功することを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced backend infrastructure for managing deployment operations, including a dedicated database for tracking job metadata
  * Configured secure worker roles with appropriate permissions for cross-account deployments and event messaging

* **Tests**
  * Added integration tests validating the deployment infrastructure configuration and security controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->