### PR TITLE
feat(deploy): DeployWorker Lambda — DeployRequested → AssumeRole + CFn CreateStack (PR-D)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
         "@aws-sdk/client-sts": "^3.1030.0",
         "@aws-sdk/lib-dynamodb": "^3.1040.0",
         "@biomejs/biome": "^2.4.12",
+        "@types/aws-lambda": "^8.10.150",
         "@types/node": "^24.10.1",
         "aws-cdk": "2.1118.0",
         "cdk-nag": "^2.37.55",
@@ -652,6 +653,8 @@
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/aws-lambda": ["@types/aws-lambda@8.10.161", "", {}, "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -134,11 +134,14 @@ cdk.Aspects.of(controlPlaneStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
 );
 
-// Problem deploy backend (PR-B): Deployments DDB + Worker IAM Role の土台のみ。
-// EventBridge Rule + Lambda は後段 PR で本 stack に追加する。
+// Problem deploy backend: Deployments DDB + IAM Role + Deploy API Lambda + Worker Lambda。
+// `DEPLOY_EXTERNAL_ID` は競技者 Bootstrap CFn (templates/competitor-bootstrap.yaml) で
+// 設定された ExternalId と一致させる必要がある。.env から渡す。
+const deployExternalId = process.env.CDK_PARAM_DEPLOY_EXTERNAL_ID || "tenkacloud-dev-external-id";
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,
   eventBusArn: controlPlaneStack.eventBusArn,
+  deployExternalId,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),

--- a/infrastructure/lib/problem-deploy/deploy-worker-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-worker-lambda.ts
@@ -7,6 +7,11 @@ import type { IRole } from "aws-cdk-lib/aws-iam";
 import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
+import {
+  COMPETITOR_ROLE_NAME_DEFAULT,
+  EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
+  EVENT_SOURCE,
+} from "./handlers/shared/events";
 
 export interface DeployWorkerLambdaProps {
   readonly deploymentsTableName: string;
@@ -47,7 +52,7 @@ export class DeployWorkerLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTableName,
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         DEPLOY_EXTERNAL_ID: props.externalId,
-        COMPETITOR_ROLE_NAME: props.competitorRoleName ?? "TenkaCloud-CompetitorDeploy-Role",
+        COMPETITOR_ROLE_NAME: props.competitorRoleName ?? COMPETITOR_ROLE_NAME_DEFAULT,
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -71,8 +76,8 @@ export class DeployWorkerLambda extends Construct {
       eventBus: props.eventBus,
       description: "Route tenkacloud.problem DeployRequested events to the worker Lambda.",
       eventPattern: {
-        source: ["tenkacloud.problem"],
-        detailType: ["DeployRequested"],
+        source: [EVENT_SOURCE],
+        detailType: [EVENT_DETAIL_TYPE_DEPLOY_REQUESTED],
       },
       targets: [new LambdaTarget(this.fn)],
     });

--- a/infrastructure/lib/problem-deploy/deploy-worker-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-worker-lambda.ts
@@ -1,0 +1,80 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { IEventBus } from "aws-cdk-lib/aws-events";
+import { Rule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction as LambdaTarget } from "aws-cdk-lib/aws-events-targets";
+import type { IRole } from "aws-cdk-lib/aws-iam";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface DeployWorkerLambdaProps {
+  readonly deploymentsTableName: string;
+  readonly eventBus: IEventBus;
+  readonly executionRole: IRole;
+  /** Bootstrap CFn (PR-A) で発行された ExternalId を SSM 等から渡す。 */
+  readonly externalId: string;
+  /** 競技者側の AssumeRole 名 (PR-A bootstrap CFn の default と一致)。 */
+  readonly competitorRoleName?: string;
+}
+
+/**
+ * `tenkacloud.problem` / `DeployRequested` イベントを受けて、競技者アカウントへ
+ * AssumeRole + CFn CreateStack を実行する Lambda。
+ *
+ * Lambda asset には `problems/` ディレクトリ全体を同梱する (commandHooks.afterBundling)。
+ * ランタイムは `__dirname/problems/<category>/<problemId>/template.yaml` を読む。
+ */
+export class DeployWorkerLambda extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly rule: Rule;
+
+  constructor(scope: Construct, id: string, props: DeployWorkerLambdaProps) {
+    super(scope, id);
+
+    const repoRoot = path.resolve(__dirname, "..", "..", "..");
+    const problemsDir = path.join(repoRoot, "problems");
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/deploy-worker/index.ts"),
+      handler: "handler",
+      timeout: Duration.minutes(5),
+      memorySize: 512,
+      role: props.executionRole,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTableName,
+        DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
+        DEPLOY_EXTERNAL_ID: props.externalId,
+        COMPETITOR_ROLE_NAME: props.competitorRoleName ?? "TenkaCloud-CompetitorDeploy-Role",
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+        commandHooks: {
+          beforeBundling: () => [],
+          beforeInstall: () => [],
+          afterBundling: (_inputDir, outputDir) => [
+            // Lambda asset に problems/ をそのまま同梱。Worker handler は
+            // path.resolve(__dirname, "problems") から template.yaml を読む。
+            `cp -R "${problemsDir}" "${outputDir}/problems"`,
+          ],
+        },
+      },
+    });
+
+    this.rule = new Rule(this, "DeployRequestedRule", {
+      eventBus: props.eventBus,
+      description: "Route tenkacloud.problem DeployRequested events to the worker Lambda.",
+      eventPattern: {
+        source: ["tenkacloud.problem"],
+        detailType: ["DeployRequested"],
+      },
+      targets: [new LambdaTarget(this.fn)],
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -1,18 +1,16 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
+import {
+  type DeployRequestedDetail,
+  EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
+  publishProblemEvent,
+} from "../shared/events.js";
 import { buildStackPrefix } from "./naming.js";
 import { generateTeamLoginKey } from "./team-key.js";
-import {
-  type DeploymentItem,
-  type DeployRequest,
-  type DeployRequestedDetail,
-  type DeployResponse,
-  EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
-  EVENT_SOURCE,
-} from "./types.js";
+import type { DeploymentItem, DeployRequest, DeployResponse } from "./types.js";
 
 export interface DeployContext {
   readonly tableName: string;
@@ -92,19 +90,13 @@ export async function startDeployment(
     teamName: item.teamName,
     namePrefix: item.namePrefix,
   };
-  await ctx.events.send(
-    new PutEventsCommand({
-      Entries: [
-        {
-          EventBusName: ctx.eventBusName,
-          Source: EVENT_SOURCE,
-          DetailType: EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
-          Detail: JSON.stringify(detail),
-          Resources: [`tenkacloud:deployment:${jobId}`],
-        },
-      ],
-    }),
-  );
+  await publishProblemEvent({
+    client: ctx.events,
+    busName: ctx.eventBusName,
+    detailType: EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
+    jobId,
+    detail,
+  });
 
   return {
     jobId,

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
-/**
- * EventBridge constants. Producer (Deploy API Lambda) と Consumer (DeployWorker
- * Lambda) で同じシンボルを参照させ、文字列 drift を防ぐ。
- */
-export const EVENT_SOURCE = "tenkacloud.problem" as const;
-export const EVENT_DETAIL_TYPE_DEPLOY_REQUESTED = "DeployRequested" as const;
+export {
+  type DeployRequestedDetail,
+  DeployRequestedDetailSchema,
+  EVENT_DETAIL_TYPE_DEPLOY_REQUESTED,
+  EVENT_SOURCE,
+} from "../shared/events.js";
 
 export const DeploymentStatusSchema = z.enum([
   "PENDING",
@@ -82,13 +82,3 @@ export const DeployResponseSchema = z.object({
   expiresAt: z.number(),
 });
 export type DeployResponse = z.infer<typeof DeployResponseSchema>;
-
-export interface DeployRequestedDetail {
-  jobId: string;
-  problemId: string;
-  tenantId: string;
-  awsAccountId: string;
-  region: string;
-  teamName: string;
-  namePrefix: string;
-}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/index.ts
@@ -1,0 +1,18 @@
+import type { EventBridgeEvent } from "aws-lambda";
+import { DeployRequestedDetailSchema } from "./types.js";
+import { buildWorkerShared, handleDeployRequested } from "./worker.js";
+
+const shared = buildWorkerShared();
+
+export const handler = async (
+  event: EventBridgeEvent<"DeployRequested", unknown>,
+): Promise<void> => {
+  const parsed = DeployRequestedDetailSchema.safeParse(event.detail);
+  if (!parsed.success) {
+    console.error("[worker] invalid DeployRequested detail", {
+      issues: parsed.error.issues,
+    });
+    throw new Error("invalid event detail");
+  }
+  await handleDeployRequested(shared, parsed.data);
+};

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
@@ -1,0 +1,16 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * 問題 CFn の `DbPassword` パラメータに渡すランダム値を生成する (mysql 仕様の制約に
+ * 合わせて記号は使わず、英数字のみで 24 文字)。worker は deploy 起動の都度 1 回だけ
+ * 生成し、CFn のパラメータと DDB の `dbPassword` フィールドに同じ値を保存する。
+ */
+export function generateProblemSecret(): string {
+  const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const bytes = randomBytes(24);
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return out;
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
@@ -1,16 +1,12 @@
 import { randomBytes } from "node:crypto";
 
 /**
- * 問題 CFn の `DbPassword` パラメータに渡すランダム値を生成する。
+ * 問題 CFn の `DbPassword` パラメータに渡す 144 bit のランダム値。
+ * base64url の 24 文字 (alphabet `A-Za-z0-9-_`) を返す。CFn の AllowedPattern
+ * (`^[A-Za-z0-9!@#$%^&*()_+\-=]+$`) のサブセットになるよう base64url を選ぶ。
  *
- * 18 byte (= 144 bits) の crypto-strong random を base64url で 24 文字に符号化する。
- * 出力アルファベットは `A-Za-z0-9-_` で、CFn 側 `DbPassword` の AllowedPattern
- * (`^[A-Za-z0-9!@#$%^&*()_+\-=]+$`) のサブセットになる。
- *
- * 旧実装は 62 文字アルファベットに `byte % 62` で写していたが、256 が 62 で割り切れない
- * ため modulo bias で前半 8 文字の出現確率が約 1.6% 高くなっていた (CodeQL
- * `js/biased-cryptographic-random` 指摘)。base64url は 6 bit ずつ取り出すので
- * 完全一様。
+ * `byte % alphabet.length` 方式は modulo bias が乗るため使わない。base64url は
+ * 6 bit ずつ取り出すので完全一様。
  */
 export function generateProblemSecret(): string {
   return randomBytes(18).toString("base64url");

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/team-secret.ts
@@ -1,16 +1,17 @@
 import { randomBytes } from "node:crypto";
 
 /**
- * 問題 CFn の `DbPassword` パラメータに渡すランダム値を生成する (mysql 仕様の制約に
- * 合わせて記号は使わず、英数字のみで 24 文字)。worker は deploy 起動の都度 1 回だけ
- * 生成し、CFn のパラメータと DDB の `dbPassword` フィールドに同じ値を保存する。
+ * 問題 CFn の `DbPassword` パラメータに渡すランダム値を生成する。
+ *
+ * 18 byte (= 144 bits) の crypto-strong random を base64url で 24 文字に符号化する。
+ * 出力アルファベットは `A-Za-z0-9-_` で、CFn 側 `DbPassword` の AllowedPattern
+ * (`^[A-Za-z0-9!@#$%^&*()_+\-=]+$`) のサブセットになる。
+ *
+ * 旧実装は 62 文字アルファベットに `byte % 62` で写していたが、256 が 62 で割り切れない
+ * ため modulo bias で前半 8 文字の出現確率が約 1.6% 高くなっていた (CodeQL
+ * `js/biased-cryptographic-random` 指摘)。base64url は 6 bit ずつ取り出すので
+ * 完全一様。
  */
 export function generateProblemSecret(): string {
-  const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  const bytes = randomBytes(24);
-  let out = "";
-  for (let i = 0; i < bytes.length; i += 1) {
-    out += ALPHABET[bytes[i] % ALPHABET.length];
-  }
-  return out;
+  return randomBytes(18).toString("base64url");
 }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/templates.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/templates.ts
@@ -1,19 +1,24 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-/**
- * Lambda 実行環境で `problems/` ディレクトリ (CDK の bundling.commandHooks で同梱) から
- * 問題 CFn テンプレートを読む。problemId からどの category 配下にあるかを検索して
- * `template.yaml` の中身を返す。
- *
- * テスト時は `rootDir` を渡して repository root を指定する。
- */
-
 const DEFAULT_ROOT = path.resolve(__dirname, "problems");
 
+const cache = new Map<string, string>();
+
+/**
+ * Lambda asset の `problems/` から問題 CFn テンプレートを読む。Lambda コンテナの
+ * 寿命中は内容不変なので一度読んだら module-scope cache に保持する。
+ *
+ * テストで `rootDir` を渡すと cache を bypass して新しい root を見にいく
+ * (試験ごとに別 fixture を読みたいケース用)。
+ */
 export function loadProblemTemplate(problemId: string, rootDir: string = DEFAULT_ROOT): string {
   if (!/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(problemId)) {
     throw new Error(`invalid problemId: ${problemId}`);
+  }
+  if (rootDir === DEFAULT_ROOT) {
+    const cached = cache.get(problemId);
+    if (cached) return cached;
   }
   const categories = fs
     .readdirSync(rootDir, { withFileTypes: true })
@@ -22,7 +27,9 @@ export function loadProblemTemplate(problemId: string, rootDir: string = DEFAULT
   for (const category of categories) {
     const candidate = path.join(rootDir, category, problemId, "template.yaml");
     if (fs.existsSync(candidate)) {
-      return fs.readFileSync(candidate, "utf8");
+      const body = fs.readFileSync(candidate, "utf8");
+      if (rootDir === DEFAULT_ROOT) cache.set(problemId, body);
+      return body;
     }
   }
   throw new Error(`template not found for problemId=${problemId} under ${rootDir}`);

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/templates.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/templates.ts
@@ -1,0 +1,29 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Lambda 実行環境で `problems/` ディレクトリ (CDK の bundling.commandHooks で同梱) から
+ * 問題 CFn テンプレートを読む。problemId からどの category 配下にあるかを検索して
+ * `template.yaml` の中身を返す。
+ *
+ * テスト時は `rootDir` を渡して repository root を指定する。
+ */
+
+const DEFAULT_ROOT = path.resolve(__dirname, "problems");
+
+export function loadProblemTemplate(problemId: string, rootDir: string = DEFAULT_ROOT): string {
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(problemId)) {
+    throw new Error(`invalid problemId: ${problemId}`);
+  }
+  const categories = fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  for (const category of categories) {
+    const candidate = path.join(rootDir, category, problemId, "template.yaml");
+    if (fs.existsSync(candidate)) {
+      return fs.readFileSync(candidate, "utf8");
+    }
+  }
+  throw new Error(`template not found for problemId=${problemId} under ${rootDir}`);
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/types.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * EventBridge から渡される detail。Producer (Deploy API Lambda) と shape を一致させる。
+ * 防御的に Zod で validate する。
+ */
+export const DeployRequestedDetailSchema = z.object({
+  jobId: z.string().min(1),
+  problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
+  tenantId: z.string().min(1),
+  awsAccountId: z.string().regex(/^\d{12}$/),
+  region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
+  teamName: z.string().min(1),
+  namePrefix: z.string().regex(/^tc-[a-z0-9-]+$/),
+});
+export type DeployRequestedDetail = z.infer<typeof DeployRequestedDetailSchema>;
+
+export const EVENT_SOURCE = "tenkacloud.problem" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_STARTED = "DeployStarted" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_FAILED = "DeployFailed" as const;

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/types.ts
@@ -1,20 +1,7 @@
-import { z } from "zod";
-
-/**
- * EventBridge から渡される detail。Producer (Deploy API Lambda) と shape を一致させる。
- * 防御的に Zod で validate する。
- */
-export const DeployRequestedDetailSchema = z.object({
-  jobId: z.string().min(1),
-  problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
-  tenantId: z.string().min(1),
-  awsAccountId: z.string().regex(/^\d{12}$/),
-  region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
-  teamName: z.string().min(1),
-  namePrefix: z.string().regex(/^tc-[a-z0-9-]+$/),
-});
-export type DeployRequestedDetail = z.infer<typeof DeployRequestedDetailSchema>;
-
-export const EVENT_SOURCE = "tenkacloud.problem" as const;
-export const EVENT_DETAIL_TYPE_DEPLOY_STARTED = "DeployStarted" as const;
-export const EVENT_DETAIL_TYPE_DEPLOY_FAILED = "DeployFailed" as const;
+export {
+  type DeployRequestedDetail,
+  DeployRequestedDetailSchema,
+  EVENT_DETAIL_TYPE_DEPLOY_FAILED,
+  EVENT_DETAIL_TYPE_DEPLOY_STARTED,
+  EVENT_SOURCE,
+} from "../shared/events.js";

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/worker.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/worker.ts
@@ -4,7 +4,7 @@ import {
   type CreateStackInput,
 } from "@aws-sdk/client-cloudformation";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import {
   DynamoDBDocumentClient,
@@ -12,14 +12,15 @@ import {
   type UpdateCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
-import { generateProblemSecret } from "./team-secret.js";
-import { loadProblemTemplate } from "./templates.js";
 import {
+  COMPETITOR_ROLE_NAME_DEFAULT,
   type DeployRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_FAILED,
   EVENT_DETAIL_TYPE_DEPLOY_STARTED,
-  EVENT_SOURCE,
-} from "./types.js";
+  publishProblemEvent,
+} from "../shared/events.js";
+import { generateProblemSecret } from "./team-secret.js";
+import { loadProblemTemplate } from "./templates.js";
 
 export interface WorkerSharedResources {
   readonly tableName: string;
@@ -44,7 +45,7 @@ export interface AssumedCredentials {
 export function buildWorkerShared(): WorkerSharedResources {
   const tableName = getEnv("DEPLOYMENTS_TABLE_NAME");
   const eventBusName = getEnv("DEPLOY_EVENT_BUS_NAME");
-  const competitorRoleName = process.env.COMPETITOR_ROLE_NAME ?? "TenkaCloud-CompetitorDeploy-Role";
+  const competitorRoleName = process.env.COMPETITOR_ROLE_NAME ?? COMPETITOR_ROLE_NAME_DEFAULT;
   const externalId = getEnv("DEPLOY_EXTERNAL_ID");
   const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
   const events = new EventBridgeClient({});
@@ -76,9 +77,11 @@ const ALLOWED_CIDR_DEFAULT = "0.0.0.0/0";
 /**
  * DeployRequested イベントを受けて、競技者アカウントへ問題 CFn を deploy する。
  *
- * 失敗 (AssumeRole / CreateStack / DDB) は throw して Lambda 全体を失敗扱いにする
- * (DLQ / EventBridge retry が拾える)。同時にベストエフォートで DDB を FAILED 更新 +
- * DeployFailed event を publish する。
+ * AssumeRole / CreateStack / DDB Update のいずれかが失敗したら throw して Lambda 全体を
+ * 失敗扱いにし (EventBridge retry / DLQ が拾える)、ベストエフォートで DDB FAILED 更新
+ * + DeployFailed event publish (markFailed)。
+ *
+ * 重複 deploy 防止 (同一 namePrefix の同時起動拒否) は別途 conditional put で追加する想定。
  */
 export async function handleDeployRequested(
   shared: WorkerSharedResources,
@@ -123,9 +126,42 @@ export async function handleDeployRequested(
     throw err;
   }
 
-  const updatedAt = new Date().toISOString();
-  const update: UpdateCommandInput = {
-    TableName: shared.tableName,
+  try {
+    await Promise.all([
+      shared.ddb.send(
+        new UpdateCommand(buildSuccessUpdate(shared.tableName, detail, stackId, dbPassword)),
+      ),
+      publishProblemEvent({
+        client: shared.events,
+        busName: shared.eventBusName,
+        detailType: EVENT_DETAIL_TYPE_DEPLOY_STARTED,
+        jobId: detail.jobId,
+        detail: {
+          jobId: detail.jobId,
+          tenantId: detail.tenantId,
+          stackId,
+          namePrefix: detail.namePrefix,
+          awsAccountId: detail.awsAccountId,
+          region: detail.region,
+        },
+      }),
+    ]);
+  } catch (err) {
+    // CFn は既に走り出している。DDB / EventBus の post-success 同期に失敗しても
+    // 状態が PENDING のままだと UI と乖離するので、failed 扱いに倒す + DLQ retry を効かせる。
+    await markFailed(shared, detail, "post_create_sync_failed", err);
+    throw err;
+  }
+}
+
+function buildSuccessUpdate(
+  tableName: string,
+  detail: DeployRequestedDetail,
+  stackId: string,
+  dbPassword: string,
+): UpdateCommandInput {
+  return {
+    TableName: tableName,
     Key: { PK: `DEPLOYMENT#${detail.jobId}`, SK: "META" },
     UpdateExpression:
       "SET #s = :status, stackId = :stackId, dbPassword = :dbPassword, updatedAt = :updatedAt",
@@ -134,31 +170,9 @@ export async function handleDeployRequested(
       ":status": "IN_PROGRESS",
       ":stackId": stackId,
       ":dbPassword": dbPassword,
-      ":updatedAt": updatedAt,
+      ":updatedAt": new Date().toISOString(),
     },
   };
-  await shared.ddb.send(new UpdateCommand(update));
-
-  await shared.events.send(
-    new PutEventsCommand({
-      Entries: [
-        {
-          EventBusName: shared.eventBusName,
-          Source: EVENT_SOURCE,
-          DetailType: EVENT_DETAIL_TYPE_DEPLOY_STARTED,
-          Detail: JSON.stringify({
-            jobId: detail.jobId,
-            tenantId: detail.tenantId,
-            stackId,
-            namePrefix: detail.namePrefix,
-            awsAccountId: detail.awsAccountId,
-            region: detail.region,
-          }),
-          Resources: [`tenkacloud:deployment:${detail.jobId}`],
-        },
-      ],
-    }),
-  );
 }
 
 async function assumeCompetitorRole(
@@ -192,9 +206,9 @@ async function markFailed(
   err: unknown,
 ): Promise<void> {
   const message = err instanceof Error ? err.message : String(err);
-  const updatedAt = new Date().toISOString();
-  try {
-    await shared.ddb.send(
+  // DDB / EventBridge の更新は独立。片方が失敗しても他方は走らせる。
+  const results = await Promise.allSettled([
+    shared.ddb.send(
       new UpdateCommand({
         TableName: shared.tableName,
         Key: { PK: `DEPLOYMENT#${detail.jobId}`, SK: "META" },
@@ -203,33 +217,29 @@ async function markFailed(
         ExpressionAttributeValues: {
           ":status": "FAILED",
           ":reason": `${reasonKey}: ${message}`.slice(0, 1024),
-          ":updatedAt": updatedAt,
+          ":updatedAt": new Date().toISOString(),
         },
       }),
-    );
-    await shared.events.send(
-      new PutEventsCommand({
-        Entries: [
-          {
-            EventBusName: shared.eventBusName,
-            Source: EVENT_SOURCE,
-            DetailType: EVENT_DETAIL_TYPE_DEPLOY_FAILED,
-            Detail: JSON.stringify({
-              jobId: detail.jobId,
-              tenantId: detail.tenantId,
-              reason: reasonKey,
-            }),
-            Resources: [`tenkacloud:deployment:${detail.jobId}`],
-          },
-        ],
-      }),
-    );
-  } catch (publishErr) {
-    console.error("[worker] markFailed publish failed", {
+    ),
+    publishProblemEvent({
+      client: shared.events,
+      busName: shared.eventBusName,
+      detailType: EVENT_DETAIL_TYPE_DEPLOY_FAILED,
       jobId: detail.jobId,
-      reasonKey,
-      message,
-      publishErr: publishErr instanceof Error ? publishErr.message : String(publishErr),
-    });
+      detail: {
+        jobId: detail.jobId,
+        tenantId: detail.tenantId,
+        reason: reasonKey,
+      },
+    }),
+  ]);
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.error("[worker] markFailed downstream failed", {
+        jobId: detail.jobId,
+        reasonKey,
+        err: r.reason instanceof Error ? r.reason.message : String(r.reason),
+      });
+    }
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-worker/worker.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-worker/worker.ts
@@ -1,0 +1,235 @@
+import {
+  CloudFormationClient,
+  CreateStackCommand,
+  type CreateStackInput,
+} from "@aws-sdk/client-cloudformation";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+  type UpdateCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import { generateProblemSecret } from "./team-secret.js";
+import { loadProblemTemplate } from "./templates.js";
+import {
+  type DeployRequestedDetail,
+  EVENT_DETAIL_TYPE_DEPLOY_FAILED,
+  EVENT_DETAIL_TYPE_DEPLOY_STARTED,
+  EVENT_SOURCE,
+} from "./types.js";
+
+export interface WorkerSharedResources {
+  readonly tableName: string;
+  readonly eventBusName: string;
+  readonly competitorRoleName: string;
+  readonly externalId: string;
+  readonly ddb: DynamoDBDocumentClient;
+  readonly events: EventBridgeClient;
+  readonly sts: STSClient;
+  /** target アカウントの一時 credentials で CFn client を作る factory。テストで DI 可能。 */
+  readonly cfnFactory: (creds: AssumedCredentials, region: string) => CloudFormationClient;
+  readonly readTemplate: (problemId: string) => string;
+  readonly secretFactory: () => string;
+}
+
+export interface AssumedCredentials {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+}
+
+export function buildWorkerShared(): WorkerSharedResources {
+  const tableName = getEnv("DEPLOYMENTS_TABLE_NAME");
+  const eventBusName = getEnv("DEPLOY_EVENT_BUS_NAME");
+  const competitorRoleName = process.env.COMPETITOR_ROLE_NAME ?? "TenkaCloud-CompetitorDeploy-Role";
+  const externalId = getEnv("DEPLOY_EXTERNAL_ID");
+  const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  const events = new EventBridgeClient({});
+  const sts = new STSClient({});
+  return {
+    tableName,
+    eventBusName,
+    competitorRoleName,
+    externalId,
+    ddb,
+    events,
+    sts,
+    cfnFactory: (creds, region) =>
+      new CloudFormationClient({
+        region,
+        credentials: {
+          accessKeyId: creds.accessKeyId,
+          secretAccessKey: creds.secretAccessKey,
+          sessionToken: creds.sessionToken,
+        },
+      }),
+    readTemplate: (problemId) => loadProblemTemplate(problemId),
+    secretFactory: () => generateProblemSecret(),
+  };
+}
+
+const ALLOWED_CIDR_DEFAULT = "0.0.0.0/0";
+
+/**
+ * DeployRequested イベントを受けて、競技者アカウントへ問題 CFn を deploy する。
+ *
+ * 失敗 (AssumeRole / CreateStack / DDB) は throw して Lambda 全体を失敗扱いにする
+ * (DLQ / EventBridge retry が拾える)。同時にベストエフォートで DDB を FAILED 更新 +
+ * DeployFailed event を publish する。
+ */
+export async function handleDeployRequested(
+  shared: WorkerSharedResources,
+  detail: DeployRequestedDetail,
+): Promise<void> {
+  let assumed: AssumedCredentials;
+  try {
+    assumed = await assumeCompetitorRole(shared, detail);
+  } catch (err) {
+    await markFailed(shared, detail, "assume_role_failed", err);
+    throw err;
+  }
+
+  const dbPassword = shared.secretFactory();
+  const templateBody = shared.readTemplate(detail.problemId);
+
+  let stackId: string;
+  try {
+    const cfn = shared.cfnFactory(assumed, detail.region);
+    const input: CreateStackInput = {
+      StackName: detail.namePrefix,
+      TemplateBody: templateBody,
+      Capabilities: ["CAPABILITY_NAMED_IAM"],
+      Parameters: [
+        { ParameterKey: "NamePrefix", ParameterValue: detail.namePrefix },
+        { ParameterKey: "DbPassword", ParameterValue: dbPassword },
+        { ParameterKey: "AllowedCidr", ParameterValue: ALLOWED_CIDR_DEFAULT },
+      ],
+      Tags: [
+        { Key: "TenkaCloud:JobId", Value: detail.jobId },
+        { Key: "TenkaCloud:TenantId", Value: detail.tenantId },
+        { Key: "TenkaCloud:ProblemId", Value: detail.problemId },
+        { Key: "TenkaCloud:TeamName", Value: detail.teamName },
+      ],
+      OnFailure: "DELETE",
+    };
+    const out = await cfn.send(new CreateStackCommand(input));
+    if (!out.StackId) throw new Error("CreateStack returned without StackId");
+    stackId = out.StackId;
+  } catch (err) {
+    await markFailed(shared, detail, "create_stack_failed", err);
+    throw err;
+  }
+
+  const updatedAt = new Date().toISOString();
+  const update: UpdateCommandInput = {
+    TableName: shared.tableName,
+    Key: { PK: `DEPLOYMENT#${detail.jobId}`, SK: "META" },
+    UpdateExpression:
+      "SET #s = :status, stackId = :stackId, dbPassword = :dbPassword, updatedAt = :updatedAt",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: {
+      ":status": "IN_PROGRESS",
+      ":stackId": stackId,
+      ":dbPassword": dbPassword,
+      ":updatedAt": updatedAt,
+    },
+  };
+  await shared.ddb.send(new UpdateCommand(update));
+
+  await shared.events.send(
+    new PutEventsCommand({
+      Entries: [
+        {
+          EventBusName: shared.eventBusName,
+          Source: EVENT_SOURCE,
+          DetailType: EVENT_DETAIL_TYPE_DEPLOY_STARTED,
+          Detail: JSON.stringify({
+            jobId: detail.jobId,
+            tenantId: detail.tenantId,
+            stackId,
+            namePrefix: detail.namePrefix,
+            awsAccountId: detail.awsAccountId,
+            region: detail.region,
+          }),
+          Resources: [`tenkacloud:deployment:${detail.jobId}`],
+        },
+      ],
+    }),
+  );
+}
+
+async function assumeCompetitorRole(
+  shared: WorkerSharedResources,
+  detail: DeployRequestedDetail,
+): Promise<AssumedCredentials> {
+  const roleArn = `arn:aws:iam::${detail.awsAccountId}:role/${shared.competitorRoleName}`;
+  const out = await shared.sts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: `tenkacloud-${detail.jobId}`,
+      ExternalId: shared.externalId,
+      DurationSeconds: 3600,
+    }),
+  );
+  const creds = out.Credentials;
+  if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+    throw new Error("AssumeRole returned without credentials");
+  }
+  return {
+    accessKeyId: creds.AccessKeyId,
+    secretAccessKey: creds.SecretAccessKey,
+    sessionToken: creds.SessionToken,
+  };
+}
+
+async function markFailed(
+  shared: WorkerSharedResources,
+  detail: DeployRequestedDetail,
+  reasonKey: string,
+  err: unknown,
+): Promise<void> {
+  const message = err instanceof Error ? err.message : String(err);
+  const updatedAt = new Date().toISOString();
+  try {
+    await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: `DEPLOYMENT#${detail.jobId}`, SK: "META" },
+        UpdateExpression: "SET #s = :status, failureReason = :reason, updatedAt = :updatedAt",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":status": "FAILED",
+          ":reason": `${reasonKey}: ${message}`.slice(0, 1024),
+          ":updatedAt": updatedAt,
+        },
+      }),
+    );
+    await shared.events.send(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: shared.eventBusName,
+            Source: EVENT_SOURCE,
+            DetailType: EVENT_DETAIL_TYPE_DEPLOY_FAILED,
+            Detail: JSON.stringify({
+              jobId: detail.jobId,
+              tenantId: detail.tenantId,
+              reason: reasonKey,
+            }),
+            Resources: [`tenkacloud:deployment:${detail.jobId}`],
+          },
+        ],
+      }),
+    );
+  } catch (publishErr) {
+    console.error("[worker] markFailed publish failed", {
+      jobId: detail.jobId,
+      reasonKey,
+      message,
+      publishErr: publishErr instanceof Error ? publishErr.message : String(publishErr),
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -1,0 +1,62 @@
+import type { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { z } from "zod";
+
+/**
+ * Deploy Backend で流れる EventBridge イベントの定義。
+ *
+ * Producer (Deploy API Lambda / Deploy Worker Lambda) と Consumer (Deploy Worker /
+ * StatusUpdater) で同じシンボルを参照させ、文字列 drift を防ぐ。
+ */
+
+export const EVENT_SOURCE = "tenkacloud.problem" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_REQUESTED = "DeployRequested" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_STARTED = "DeployStarted" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_FAILED = "DeployFailed" as const;
+
+export const COMPETITOR_ROLE_NAME_DEFAULT = "TenkaCloud-CompetitorDeploy-Role" as const;
+
+/**
+ * `DeployRequested` event の `detail`。Producer (Deploy API) と Consumer (Deploy Worker)
+ * の両方で参照する単一の正本。Producer は出力時、Consumer は入力時に validate する。
+ *
+ * `namePrefix` は `slugify` の出力 (`tc-{problemSlug}-{teamSlug}`) と一致させる。
+ * 各 slug は非空かつ末尾ハイフンを許さない (UI / API の slugify と一致)。
+ */
+export const DeployRequestedDetailSchema = z.object({
+  jobId: z.string().min(1),
+  problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
+  tenantId: z.string().min(1),
+  awsAccountId: z.string().regex(/^\d{12}$/),
+  region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
+  teamName: z.string().min(1),
+  namePrefix: z.string().regex(/^tc-[a-z0-9]+(?:-[a-z0-9]+)+$/),
+});
+export type DeployRequestedDetail = z.infer<typeof DeployRequestedDetailSchema>;
+
+/**
+ * `tenkacloud.problem` event を 1 件 publish する shared helper。
+ * Resources は `tenkacloud:deployment:<jobId>` で統一し、subscriber が job 単位で
+ * filter / 検索しやすいようにする。
+ */
+export async function publishProblemEvent(args: {
+  client: EventBridgeClient;
+  busName: string;
+  detailType: string;
+  jobId: string;
+  detail: Record<string, unknown>;
+}): Promise<void> {
+  await args.client.send(
+    new PutEventsCommand({
+      Entries: [
+        {
+          EventBusName: args.busName,
+          Source: EVENT_SOURCE,
+          DetailType: args.detailType,
+          Detail: JSON.stringify(args.detail),
+          Resources: [`tenkacloud:deployment:${args.jobId}`],
+        },
+      ],
+    }),
+  );
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -3,6 +3,7 @@ import { CfnOutput } from "aws-cdk-lib";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { Construct } from "constructs";
 import { DeployApiLambda } from "./deploy-api-lambda";
+import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
 import { DeploymentsTable } from "./deployments-table";
 
@@ -16,6 +17,15 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * Cognito JWT authorizer 結線時に削除する。
    */
   readonly defaultTenantId?: string;
+  /**
+   * 競技者 Bootstrap CFn (PR-A) で運営者と共有された ExternalId。
+   * Worker Lambda が AssumeRole 時の sts:ExternalId として渡す。Confused Deputy 対策。
+   */
+  readonly deployExternalId: string;
+  /**
+   * 競技者側 IAM Role 名 (PR-A の default と一致させる)。省略時は規約通り。
+   */
+  readonly competitorRoleName?: string;
 }
 
 /**
@@ -24,8 +34,7 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
  * - Deployments テーブル (DDB)
  * - Deploy Worker IAM Role (cross-account AssumeRole + DDB + EventBus)
  * - Deploy API Lambda + Function URL (POST /problems/:id/deploy)
- *
- * EventBridge Rule + DeployWorker Lambda は別途追加する。
+ * - Deploy Worker Lambda + EventBridge Rule (DeployRequested → AssumeRole + CFn)
  */
 export class ProblemDeployBackendStack extends cdk.Stack {
   public readonly deploymentsTableName: string;
@@ -49,6 +58,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       eventBusName: eventBus.eventBusName,
       executionRole: workerRole.role,
       defaultTenantId: props.defaultTenantId,
+    });
+
+    new DeployWorkerLambda(this, "DeployWorker", {
+      deploymentsTableName: deployments.table.tableName,
+      eventBus,
+      executionRole: workerRole.role,
+      externalId: props.deployExternalId,
+      competitorRoleName: props.competitorRoleName,
     });
 
     this.deploymentsTableName = deployments.table.tableName;

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/client-sts": "^3.1030.0",
     "@aws-sdk/lib-dynamodb": "^3.1040.0",
     "@biomejs/biome": "^2.4.12",
+    "@types/aws-lambda": "^8.10.150",
     "@types/node": "^24.10.1",
     "aws-cdk": "2.1118.0",
     "cdk-nag": "^2.37.55",

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -10,6 +10,7 @@ function synth(): Template {
   const stack = new ProblemDeployBackendStack(app, "TestStack", {
     env: { account: "123456789012", region: "ap-northeast-1" },
     eventBusArn: FAKE_BUS_ARN,
+    deployExternalId: "ext-test",
   });
   return Template.fromStack(stack);
 }
@@ -223,16 +224,53 @@ describe("ProblemDeployBackendStack", () => {
     });
   });
 
+  describe("DeployWorkerLambda + EventBridge Rule", () => {
+    it("Lambda 関数を 2 つ作るべき (API + Worker)", () => {
+      const tpl = synth();
+      tpl.resourceCountIs("AWS::Lambda::Function", 2);
+    });
+
+    it("Worker Lambda は DEPLOY_EXTERNAL_ID を env として持つべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              DEPLOY_EXTERNAL_ID: "ext-test",
+              COMPETITOR_ROLE_NAME: "TenkaCloud-CompetitorDeploy-Role",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("EventBridge Rule で tenkacloud.problem / DeployRequested を target にすべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          EventPattern: Match.objectLike({
+            source: ["tenkacloud.problem"],
+            "detail-type": ["DeployRequested"],
+          }),
+        }),
+      );
+    });
+  });
+
   describe("複数 stack を同居しても", () => {
     it("synth が衝突なく通るべき (ResourceName 自動生成)", () => {
       const app = new cdk.App();
       const a = new ProblemDeployBackendStack(app, "A", {
         env: { account: "123456789012", region: "ap-northeast-1" },
         eventBusArn: FAKE_BUS_ARN,
+        deployExternalId: "ext-a",
       });
       const b = new ProblemDeployBackendStack(app, "B", {
         env: { account: "123456789012", region: "ap-northeast-1" },
         eventBusArn: FAKE_BUS_ARN,
+        deployExternalId: "ext-b",
       });
       expect(() => Template.fromStack(a)).not.toThrow();
       expect(() => Template.fromStack(b)).not.toThrow();

--- a/infrastructure/test/problem-deploy/deploy-worker.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-worker.test.ts
@@ -1,0 +1,135 @@
+import type { CreateStackCommand } from "@aws-sdk/client-cloudformation";
+import type { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import type { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import type { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AssumedCredentials,
+  handleDeployRequested,
+  type WorkerSharedResources,
+} from "../../lib/problem-deploy/handlers/deploy-worker/worker";
+
+const FIXED_CREDS: AssumedCredentials = {
+  accessKeyId: "AKIA-TEST",
+  secretAccessKey: "secret",
+  sessionToken: "token",
+};
+
+function buildShared(overrides: Partial<WorkerSharedResources> = {}): {
+  shared: WorkerSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  eventsSend: ReturnType<typeof vi.fn>;
+  stsSend: ReturnType<typeof vi.fn>;
+  cfnSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn().mockResolvedValue({});
+  const eventsSend = vi.fn().mockResolvedValue({});
+  const stsSend = vi.fn().mockResolvedValue({
+    Credentials: {
+      AccessKeyId: FIXED_CREDS.accessKeyId,
+      SecretAccessKey: FIXED_CREDS.secretAccessKey,
+      SessionToken: FIXED_CREDS.sessionToken,
+    },
+  });
+  const cfnSend = vi.fn().mockResolvedValue({ StackId: "arn:aws:cloudformation:.../stk-1/uuid" });
+  const shared: WorkerSharedResources = {
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+    externalId: "ext-id-test",
+    ddb: { send: ddbSend } as unknown as WorkerSharedResources["ddb"],
+    events: { send: eventsSend } as unknown as WorkerSharedResources["events"],
+    sts: { send: stsSend } as unknown as WorkerSharedResources["sts"],
+    cfnFactory: () =>
+      ({ send: cfnSend }) as unknown as ReturnType<WorkerSharedResources["cfnFactory"]>,
+    readTemplate: () => "AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n",
+    secretFactory: () => "fixed-secret-1234567890ab",
+    ...overrides,
+  };
+  return { shared, ddbSend, eventsSend, stsSend, cfnSend };
+}
+
+const sampleDetail = () => ({
+  jobId: "01HABCXYZ",
+  problemId: "security-battle-royale",
+  tenantId: "tenant-acme",
+  awsAccountId: "999999999999",
+  region: "ap-northeast-1",
+  teamName: "Alpha Team",
+  namePrefix: "tc-security-battle-royale-alpha-team",
+});
+
+describe("handleDeployRequested", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("AssumeRole / CreateStack / DDB Update / DeployStarted の順で処理するべき", async () => {
+    const { shared, stsSend, cfnSend, ddbSend, eventsSend } = buildShared();
+    await handleDeployRequested(shared, sampleDetail());
+
+    expect(stsSend).toHaveBeenCalledOnce();
+    const stsCmd = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    expect(stsCmd.input.RoleArn).toBe(
+      "arn:aws:iam::999999999999:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(stsCmd.input.ExternalId).toBe("ext-id-test");
+
+    expect(cfnSend).toHaveBeenCalledOnce();
+    const cfnCmd = cfnSend.mock.calls[0]?.[0] as CreateStackCommand;
+    expect(cfnCmd.input.StackName).toBe("tc-security-battle-royale-alpha-team");
+    expect(cfnCmd.input.Parameters).toEqual(
+      expect.arrayContaining([
+        { ParameterKey: "NamePrefix", ParameterValue: "tc-security-battle-royale-alpha-team" },
+        { ParameterKey: "DbPassword", ParameterValue: "fixed-secret-1234567890ab" },
+        { ParameterKey: "AllowedCidr", ParameterValue: "0.0.0.0/0" },
+      ]),
+    );
+
+    expect(ddbSend).toHaveBeenCalledOnce();
+    const updateCmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(updateCmd.input.ExpressionAttributeValues?.[":status"]).toBe("IN_PROGRESS");
+    expect(updateCmd.input.ExpressionAttributeValues?.[":stackId"]).toBe(
+      "arn:aws:cloudformation:.../stk-1/uuid",
+    );
+
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const evtCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(evtCmd.input.Entries?.[0].DetailType).toBe("DeployStarted");
+  });
+
+  it("AssumeRole 失敗時は FAILED に更新して throw するべき", async () => {
+    const { shared, stsSend, cfnSend, ddbSend, eventsSend } = buildShared();
+    stsSend.mockRejectedValueOnce(new Error("AccessDenied"));
+    await expect(handleDeployRequested(shared, sampleDetail())).rejects.toThrow("AccessDenied");
+    expect(cfnSend).not.toHaveBeenCalled();
+    // markFailed が DDB と EventBridge を呼ぶ
+    expect(ddbSend).toHaveBeenCalledOnce();
+    const updateCmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(updateCmd.input.ExpressionAttributeValues?.[":status"]).toBe("FAILED");
+    expect(eventsSend).toHaveBeenCalledOnce();
+    expect((eventsSend.mock.calls[0]?.[0] as PutEventsCommand).input.Entries?.[0].DetailType).toBe(
+      "DeployFailed",
+    );
+  });
+
+  it("CreateStack 失敗時も FAILED に更新して throw するべき", async () => {
+    const { shared, cfnSend, ddbSend, eventsSend } = buildShared();
+    cfnSend.mockRejectedValueOnce(new Error("ValidationError"));
+    await expect(handleDeployRequested(shared, sampleDetail())).rejects.toThrow("ValidationError");
+    expect(ddbSend).toHaveBeenCalledOnce();
+    const updateCmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(updateCmd.input.ExpressionAttributeValues?.[":status"]).toBe("FAILED");
+    expect(eventsSend).toHaveBeenCalledOnce();
+  });
+
+  it("CreateStack が StackId を返さなかったら失敗扱いにすべき", async () => {
+    const { shared, cfnSend } = buildShared();
+    cfnSend.mockResolvedValueOnce({});
+    await expect(handleDeployRequested(shared, sampleDetail())).rejects.toThrow();
+  });
+
+  it("AssumeRole が Credentials を返さなかったら失敗扱いにすべき", async () => {
+    const { shared, stsSend } = buildShared();
+    stsSend.mockResolvedValueOnce({ Credentials: null });
+    await expect(handleDeployRequested(shared, sampleDetail())).rejects.toThrow();
+  });
+});

--- a/infrastructure/test/problem-deploy/team-secret.test.ts
+++ b/infrastructure/test/problem-deploy/team-secret.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { generateProblemSecret } from "../../lib/problem-deploy/handlers/deploy-worker/team-secret";
+
+describe("generateProblemSecret", () => {
+  it("base64url 24 文字 (18 byte = 144 bits) を返すべき", () => {
+    const secret = generateProblemSecret();
+    expect(secret).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secret.length).toBe(24);
+  });
+
+  it("呼び出しごとに異なる値を返すべき", () => {
+    const a = generateProblemSecret();
+    const b = generateProblemSecret();
+    expect(a).not.toBe(b);
+  });
+
+  it("CFn DbPassword の AllowedPattern (英数字 + 限定記号) のサブセットに含まれるべき", () => {
+    const cfnAllowed = /^[A-Za-z0-9!@#$%^&*()_+\-=]+$/;
+    for (let i = 0; i < 50; i += 1) {
+      expect(generateProblemSecret()).toMatch(cfnAllowed);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Deploy backend ロードマップの **PR-D**。EventBridge \`tenkacloud.problem\` / \`DeployRequested\` を受けて、競技者アカウントへ \`sts:AssumeRole\` (ExternalId 付き) + \`cloudformation:CreateStack\` を実行する Lambda を追加する。

これで縦串が貫通する:
\`\`\`
UI form → Deploy API Lambda (DDB Put + EventBridge Publish)
       → Deploy Worker Lambda (AssumeRole + CFn CreateStack)
       → 競技者アカウントで problem stack 起動
       → DDB IN_PROGRESS update + DeployStarted publish
\`\`\`

## 主な変更

### Lambda handler (\`handlers/deploy-worker/\`)
- \`index.ts\` — EventBridge entrypoint + Zod 検証 + worker 委譲
- \`worker.ts\` — \`handleDeployRequested\` core (AssumeRole + CreateStack + DDB Update + DeployStarted)。失敗時は \`markFailed\` (DDB FAILED + DeployFailed publish) + Lambda throw (retry 可能)
- \`templates.ts\` — Lambda asset の \`problems/\` から \`template.yaml\` を読む
- \`team-secret.ts\` — \`DbPassword\` 用ランダム 24 文字英数字
- \`types.ts\` — DeployRequestedDetailSchema + イベント定数

### CDK
- \`deploy-worker-lambda.ts\` — NodejsFunction (Node.js 20 / arm64 / 512MB / 5min) + EventBridge Rule
- \`bundling.commandHooks.afterBundling\` で \`problems/\` ディレクトリを Lambda asset に \`cp -R\` で同梱
- \`problem-deploy-backend-stack.ts\` に DeployWorkerLambda 追加、\`deployExternalId\` prop 必須化
- bin で \`CDK_PARAM_DEPLOY_EXTERNAL_ID\` env から渡す

### Tests (53 → 61, +8)
- \`deploy-worker.test.ts\` 5 ケース: 正常 / AssumeRole 失敗 / CreateStack 失敗 / StackId 不在 / Credentials 不在
- \`problem-deploy-backend-stack.test.ts\` 3 ケース追加: Lambda 数 / Worker env / EventBridge Rule pattern

## 設計判断

- **失敗時 throw + markFailed の二重書き**: EventBridge retry を効かせつつ UI が DDB から状態を即読みできる
- **DbPassword は worker 側で生成**: API Lambda に secret 生成責務を持たせない
- **\`commandHooks afterBundling cp -R problems/\`**: NodejsFunction は静的ファイルを自動同梱しないため shell hook で copy
- **\`OnFailure: \"DELETE\"\`**: CreateStack 失敗時は ROLLBACK_FAILED の壊れた stack を残さない
- **既存 DeployWorkerRole を流用**: cross-account AssumeRole + DDB CRUD + EventBus PutEvents が既に揃っている

## 制限 / 暫定実装

- \`DEPLOY_EXTERNAL_ID\` は env vars 経由 (\`CDK_PARAM_DEPLOY_EXTERNAL_ID\`)。本番では SSM SecureString に置く改修を後段で
- 重複 deploy 防止 (同一 namePrefix の同時起動拒否) は未実装

## ロードマップ

| PR | 内容 |
|----|------|
| A (#438) | 競技者 bootstrap CFn |
| B (#441) | DDB + Worker IAM Role |
| C (#442) | Deploy API Lambda |
| **D (本 PR)** | DeployWorker Lambda — 縦串貫通 |
| E | StatusUpdater Lambda + auto-teardown TTL |
| F | API Gateway + Cognito + GET + UI 結線 |
| G | DELETE |
| H | participant portal hosting + PortalUpdater |

## Test plan

- [x] make before-commit (lint / format / test 全 61 件)
- [ ] 手動: 競技者アカウントで bootstrap CFn deploy → Deploy API SigV4 invoke →
      Worker が CFn CreateStack を呼んで stack 起動 → DDB IN_PROGRESS 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)