### PR TITLE
feat(deploy): StatusUpdater Lambda + auto-teardown TTL — PR-E

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
@@ -1,0 +1,112 @@
+import type { Output, Stack } from "@aws-sdk/client-cloudformation";
+
+export type DeploymentStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "COMPLETE"
+  | "FAILED"
+  | "DELETING"
+  | "DELETED";
+
+export type ResolvedStatus =
+  | { kind: "transition"; status: Exclude<DeploymentStatus, "PENDING">; failureReason?: string }
+  | { kind: "stable" };
+
+const COMPLETE_STATUSES = new Set(["CREATE_COMPLETE", "UPDATE_COMPLETE"]);
+const FAILED_STATUSES = new Set([
+  "CREATE_FAILED",
+  "ROLLBACK_COMPLETE",
+  "ROLLBACK_FAILED",
+  "UPDATE_FAILED",
+  "UPDATE_ROLLBACK_COMPLETE",
+  "UPDATE_ROLLBACK_FAILED",
+  "DELETE_FAILED",
+]);
+const DELETED_STATUSES = new Set(["DELETE_COMPLETE"]);
+const IN_PROGRESS_STATUSES = new Set([
+  "CREATE_IN_PROGRESS",
+  "UPDATE_IN_PROGRESS",
+  "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+  "ROLLBACK_IN_PROGRESS",
+  "UPDATE_ROLLBACK_IN_PROGRESS",
+  "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+  "DELETE_IN_PROGRESS",
+  "REVIEW_IN_PROGRESS",
+  "IMPORT_IN_PROGRESS",
+  "IMPORT_COMPLETE",
+  "IMPORT_ROLLBACK_IN_PROGRESS",
+  "IMPORT_ROLLBACK_FAILED",
+  "IMPORT_ROLLBACK_COMPLETE",
+]);
+
+/**
+ * CFn StackStatus → 内部 DeploymentStatus の遷移を計算する。
+ *
+ * 入力:
+ *   - currentStatus: DDB に保存された現在の DeploymentStatus
+ *   - cfnStack: DescribeStacks の結果 (StackStatus / StackStatusReason / Outputs)
+ *
+ * 出力:
+ *   - kind="transition": 状態遷移すべき (DDB Update + Event publish)
+ *   - kind="stable": 遷移なし (無視)
+ *
+ * StackStatus が認識できない場合は stable を返して既存状態を維持する (CFn が新しい
+ * status を追加した時に worker が誤判定で FAILED に倒さないように)。
+ */
+export function resolveDeploymentStatus(
+  currentStatus: DeploymentStatus,
+  cfnStatus: string | undefined,
+  stackStatusReason: string | undefined,
+): ResolvedStatus {
+  if (!cfnStatus) return { kind: "stable" };
+
+  if (DELETED_STATUSES.has(cfnStatus)) {
+    if (currentStatus === "DELETED") return { kind: "stable" };
+    return { kind: "transition", status: "DELETED" };
+  }
+  if (COMPLETE_STATUSES.has(cfnStatus)) {
+    if (currentStatus === "COMPLETE") return { kind: "stable" };
+    return { kind: "transition", status: "COMPLETE" };
+  }
+  if (FAILED_STATUSES.has(cfnStatus)) {
+    if (currentStatus === "FAILED") return { kind: "stable" };
+    return {
+      kind: "transition",
+      status: "FAILED",
+      failureReason: stackStatusReason ? `${cfnStatus}: ${stackStatusReason}` : cfnStatus,
+    };
+  }
+  if (IN_PROGRESS_STATUSES.has(cfnStatus)) {
+    // CFn 側でまだ進行中 (CREATE_IN_PROGRESS など) は in-flight 扱い、内部状態は維持
+    return { kind: "stable" };
+  }
+  return { kind: "stable" };
+}
+
+/**
+ * CFn の Outputs (Array<Output>) を `OutputKey -> OutputValue` の JSON 文字列に直す。
+ * UI / participant portal が parse して `FrontendUrl` などを取り出す想定。
+ */
+export function serializeStackOutputs(outputs: Output[] | undefined): string {
+  if (!outputs?.length) return "{}";
+  const obj: Record<string, string> = {};
+  for (const o of outputs) {
+    if (o.OutputKey && o.OutputValue !== undefined) {
+      obj[o.OutputKey] = o.OutputValue;
+    }
+  }
+  return JSON.stringify(obj);
+}
+
+export function extractStackContext(stack: Stack | undefined): {
+  cfnStatus: string | undefined;
+  stackStatusReason: string | undefined;
+  outputs: Output[] | undefined;
+} {
+  if (!stack) return { cfnStatus: undefined, stackStatusReason: undefined, outputs: undefined };
+  return {
+    cfnStatus: stack.StackStatus,
+    stackStatusReason: stack.StackStatusReason,
+    outputs: stack.Outputs,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
@@ -40,18 +40,8 @@ const IN_PROGRESS_STATUSES = new Set([
 ]);
 
 /**
- * CFn StackStatus → 内部 DeploymentStatus の遷移を計算する。
- *
- * 入力:
- *   - currentStatus: DDB に保存された現在の DeploymentStatus
- *   - cfnStack: DescribeStacks の結果 (StackStatus / StackStatusReason / Outputs)
- *
- * 出力:
- *   - kind="transition": 状態遷移すべき (DDB Update + Event publish)
- *   - kind="stable": 遷移なし (無視)
- *
- * StackStatus が認識できない場合は stable を返して既存状態を維持する (CFn が新しい
- * status を追加した時に worker が誤判定で FAILED に倒さないように)。
+ * 認識できない StackStatus は `stable` を返す (CFn が将来的に追加する新規 status を
+ * 既存ロジックが誤判定で FAILED に倒すのを防ぐ)。
  */
 export function resolveDeploymentStatus(
   currentStatus: DeploymentStatus,
@@ -76,17 +66,10 @@ export function resolveDeploymentStatus(
       failureReason: stackStatusReason ? `${cfnStatus}: ${stackStatusReason}` : cfnStatus,
     };
   }
-  if (IN_PROGRESS_STATUSES.has(cfnStatus)) {
-    // CFn 側でまだ進行中 (CREATE_IN_PROGRESS など) は in-flight 扱い、内部状態は維持
-    return { kind: "stable" };
-  }
+  if (IN_PROGRESS_STATUSES.has(cfnStatus)) return { kind: "stable" };
   return { kind: "stable" };
 }
 
-/**
- * CFn の Outputs (Array<Output>) を `OutputKey -> OutputValue` の JSON 文字列に直す。
- * UI / participant portal が parse して `FrontendUrl` などを取り出す想定。
- */
 export function serializeStackOutputs(outputs: Output[] | undefined): string {
   if (!outputs?.length) return "{}";
   const obj: Record<string, string> = {};

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -13,6 +13,8 @@ export const EVENT_SOURCE = "tenkacloud.problem" as const;
 export const EVENT_DETAIL_TYPE_DEPLOY_REQUESTED = "DeployRequested" as const;
 export const EVENT_DETAIL_TYPE_DEPLOY_STARTED = "DeployStarted" as const;
 export const EVENT_DETAIL_TYPE_DEPLOY_FAILED = "DeployFailed" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_COMPLETED = "DeployCompleted" as const;
+export const EVENT_DETAIL_TYPE_DEPLOY_DELETED = "DeployDeleted" as const;
 
 export const COMPETITOR_ROLE_NAME_DEFAULT = "TenkaCloud-CompetitorDeploy-Role" as const;
 

--- a/infrastructure/lib/problem-deploy/handlers/status-updater/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/status-updater/index.ts
@@ -1,0 +1,7 @@
+import { buildUpdaterShared, runStatusUpdate } from "./updater.js";
+
+const shared = buildUpdaterShared();
+
+export const handler = async (): Promise<void> => {
+  await runStatusUpdate(shared);
+};

--- a/infrastructure/lib/problem-deploy/handlers/status-updater/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/status-updater/types.ts
@@ -1,0 +1,16 @@
+import type { DeploymentStatus } from "../shared/cfn-status.js";
+
+/**
+ * StatusUpdater が DDB から拾う行の必要フィールド。`DeploymentItem` のサブセット。
+ */
+export interface TrackedDeployment {
+  jobId: string;
+  tenantId: string;
+  problemId: string;
+  awsAccountId: string;
+  region: string;
+  namePrefix: string;
+  stackId?: string;
+  status: DeploymentStatus;
+  expiresAt: number;
+}

--- a/infrastructure/lib/problem-deploy/handlers/status-updater/updater.ts
+++ b/infrastructure/lib/problem-deploy/handlers/status-updater/updater.ts
@@ -1,0 +1,320 @@
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  type Stack,
+} from "@aws-sdk/client-cloudformation";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  UpdateCommand,
+  type UpdateCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import {
+  type DeploymentStatus,
+  extractStackContext,
+  resolveDeploymentStatus,
+  serializeStackOutputs,
+} from "../shared/cfn-status.js";
+import {
+  COMPETITOR_ROLE_NAME_DEFAULT,
+  EVENT_DETAIL_TYPE_DEPLOY_COMPLETED,
+  EVENT_DETAIL_TYPE_DEPLOY_DELETED,
+  EVENT_DETAIL_TYPE_DEPLOY_FAILED,
+  publishProblemEvent,
+} from "../shared/events.js";
+import type { TrackedDeployment } from "./types.js";
+
+interface AssumedCredentials {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+}
+
+const NON_TERMINAL_STATUSES = new Set<DeploymentStatus>(["PENDING", "IN_PROGRESS", "DELETING"]);
+
+export interface UpdaterSharedResources {
+  readonly tableName: string;
+  readonly eventBusName: string;
+  readonly competitorRoleName: string;
+  readonly externalId: string;
+  readonly ddb: DynamoDBDocumentClient;
+  readonly events: EventBridgeClient;
+  readonly sts: STSClient;
+  readonly cfnFactory: (creds: AssumedCredentials, region: string) => CloudFormationClient;
+  readonly now: () => number;
+}
+
+export function buildUpdaterShared(): UpdaterSharedResources {
+  return {
+    tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
+    eventBusName: getEnv("DEPLOY_EVENT_BUS_NAME"),
+    competitorRoleName: process.env.COMPETITOR_ROLE_NAME ?? COMPETITOR_ROLE_NAME_DEFAULT,
+    externalId: getEnv("DEPLOY_EXTERNAL_ID"),
+    ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+    events: new EventBridgeClient({}),
+    sts: new STSClient({}),
+    cfnFactory: (creds, region) =>
+      new CloudFormationClient({
+        region,
+        credentials: {
+          accessKeyId: creds.accessKeyId,
+          secretAccessKey: creds.secretAccessKey,
+          sessionToken: creds.sessionToken,
+        },
+      }),
+    now: () => Date.now(),
+  };
+}
+
+/**
+ * 30 秒に 1 回起動する scheduled Lambda 本体。
+ *
+ * 1. DDB scan で non-terminal (PENDING/IN_PROGRESS/DELETING) 行を集める
+ * 2. 各 row について並列で processOne を実行 (失敗は他に伝播させない)
+ * 3. processOne:
+ *    - expiresAt < now() && stackId あり && terminal でない → DeleteStack 起動 + DELETING に遷移
+ *    - stackId なし (PENDING のまま CFn 未起動) → スキップ (Worker が拾う / 失敗時は markFailed 済)
+ *    - その他 → DescribeStacks + status 解決 + 必要なら DDB Update + Event publish
+ */
+export async function runStatusUpdate(shared: UpdaterSharedResources): Promise<void> {
+  const items = await scanTracked(shared);
+  await Promise.allSettled(items.map((item) => processOne(shared, item)));
+}
+
+async function scanTracked(shared: UpdaterSharedResources): Promise<TrackedDeployment[]> {
+  const out: TrackedDeployment[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const res = await shared.ddb.send(
+      new ScanCommand({
+        TableName: shared.tableName,
+        FilterExpression: "#s IN (:pending, :inProgress, :deleting)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":pending": "PENDING",
+          ":inProgress": "IN_PROGRESS",
+          ":deleting": "DELETING",
+        },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    for (const raw of res.Items ?? []) {
+      out.push(toTracked(raw));
+    }
+    exclusiveStartKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+  return out;
+}
+
+function toTracked(raw: Record<string, unknown>): TrackedDeployment {
+  return {
+    jobId: String(raw.jobId ?? ""),
+    tenantId: String(raw.tenantId ?? ""),
+    problemId: String(raw.problemId ?? ""),
+    awsAccountId: String(raw.awsAccountId ?? ""),
+    region: String(raw.region ?? ""),
+    namePrefix: String(raw.namePrefix ?? ""),
+    stackId: typeof raw.stackId === "string" ? raw.stackId : undefined,
+    status: String(raw.status ?? "PENDING") as DeploymentStatus,
+    expiresAt: Number(raw.expiresAt ?? 0),
+  };
+}
+
+async function processOne(shared: UpdaterSharedResources, item: TrackedDeployment): Promise<void> {
+  if (!NON_TERMINAL_STATUSES.has(item.status)) return;
+  if (!item.stackId) return; // Worker がまだ CFn を作っていない / markFailed 済
+
+  const expired = expiredFor(shared.now(), item.expiresAt);
+
+  let assumed: AssumedCredentials;
+  try {
+    assumed = await assumeRole(shared, item);
+  } catch (err) {
+    console.error("[status-updater] AssumeRole failed", {
+      jobId: item.jobId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+  const cfn = shared.cfnFactory(assumed, item.region);
+
+  if (expired && item.status !== "DELETING") {
+    await tearDown(shared, cfn, item);
+    return;
+  }
+
+  let stack: Stack | undefined;
+  try {
+    const out = await cfn.send(new DescribeStacksCommand({ StackName: item.stackId }));
+    stack = out.Stacks?.[0];
+  } catch (err) {
+    console.error("[status-updater] DescribeStacks failed", {
+      jobId: item.jobId,
+      stackId: item.stackId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  const { cfnStatus, stackStatusReason, outputs } = extractStackContext(stack);
+  const resolved = resolveDeploymentStatus(item.status, cfnStatus, stackStatusReason);
+  if (resolved.kind !== "transition") return;
+
+  const stackOutputs = resolved.status === "COMPLETE" ? serializeStackOutputs(outputs) : undefined;
+  await applyTransition(shared, item, resolved.status, resolved.failureReason, stackOutputs);
+}
+
+function expiredFor(nowMs: number, expiresAtSeconds: number): boolean {
+  if (!expiresAtSeconds) return false;
+  return nowMs / 1000 > expiresAtSeconds;
+}
+
+async function assumeRole(
+  shared: UpdaterSharedResources,
+  item: TrackedDeployment,
+): Promise<AssumedCredentials> {
+  const roleArn = `arn:aws:iam::${item.awsAccountId}:role/${shared.competitorRoleName}`;
+  const out = await shared.sts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: `tenkacloud-su-${item.jobId}`,
+      ExternalId: shared.externalId,
+      DurationSeconds: 900,
+    }),
+  );
+  const creds = out.Credentials;
+  if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+    throw new Error("AssumeRole returned without credentials");
+  }
+  return {
+    accessKeyId: creds.AccessKeyId,
+    secretAccessKey: creds.SecretAccessKey,
+    sessionToken: creds.SessionToken,
+  };
+}
+
+async function tearDown(
+  shared: UpdaterSharedResources,
+  cfn: CloudFormationClient,
+  item: TrackedDeployment,
+): Promise<void> {
+  try {
+    await cfn.send(new DeleteStackCommand({ StackName: item.stackId }));
+  } catch (err) {
+    console.error("[status-updater] DeleteStack failed", {
+      jobId: item.jobId,
+      stackId: item.stackId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+  await applyTransition(shared, item, "DELETING", "auto_teardown_ttl", undefined);
+}
+
+async function applyTransition(
+  shared: UpdaterSharedResources,
+  item: TrackedDeployment,
+  next: Exclude<DeploymentStatus, "PENDING">,
+  failureReason: string | undefined,
+  stackOutputs: string | undefined,
+): Promise<void> {
+  const updatedAt = new Date().toISOString();
+  const update = buildTransitionUpdate(
+    shared.tableName,
+    item,
+    next,
+    failureReason,
+    stackOutputs,
+    updatedAt,
+  );
+  try {
+    await shared.ddb.send(new UpdateCommand(update));
+  } catch (err) {
+    // ConditionalCheckFailed は他 Lambda が先に同じ遷移を書いた場合に起きる。
+    // race の早い方を let-win としてここで silently 終了する。
+    const code = (err as { name?: string })?.name ?? "";
+    if (code === "ConditionalCheckFailedException") return;
+    console.error("[status-updater] DDB Update failed", {
+      jobId: item.jobId,
+      next,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  await publishForTransition(shared, item, next, failureReason, stackOutputs);
+}
+
+function buildTransitionUpdate(
+  tableName: string,
+  item: TrackedDeployment,
+  next: Exclude<DeploymentStatus, "PENDING">,
+  failureReason: string | undefined,
+  stackOutputs: string | undefined,
+  updatedAt: string,
+): UpdateCommandInput {
+  const sets: string[] = ["#s = :next", "updatedAt = :updatedAt"];
+  const values: Record<string, unknown> = {
+    ":next": next,
+    ":updatedAt": updatedAt,
+    ":current": item.status,
+  };
+  if (failureReason !== undefined) {
+    sets.push("failureReason = :reason");
+    values[":reason"] = failureReason.slice(0, 1024);
+  }
+  if (stackOutputs !== undefined) {
+    sets.push("stackOutputs = :outputs");
+    values[":outputs"] = stackOutputs;
+  }
+  return {
+    TableName: tableName,
+    Key: { PK: `DEPLOYMENT#${item.jobId}`, SK: "META" },
+    UpdateExpression: `SET ${sets.join(", ")}`,
+    ConditionExpression: "#s = :current",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: values,
+  };
+}
+
+async function publishForTransition(
+  shared: UpdaterSharedResources,
+  item: TrackedDeployment,
+  next: Exclude<DeploymentStatus, "PENDING">,
+  failureReason: string | undefined,
+  stackOutputs: string | undefined,
+): Promise<void> {
+  if (next === "IN_PROGRESS" || next === "DELETING") return;
+  const detailType =
+    next === "COMPLETE"
+      ? EVENT_DETAIL_TYPE_DEPLOY_COMPLETED
+      : next === "DELETED"
+        ? EVENT_DETAIL_TYPE_DEPLOY_DELETED
+        : EVENT_DETAIL_TYPE_DEPLOY_FAILED;
+  try {
+    await publishProblemEvent({
+      client: shared.events,
+      busName: shared.eventBusName,
+      detailType,
+      jobId: item.jobId,
+      detail: {
+        jobId: item.jobId,
+        tenantId: item.tenantId,
+        status: next,
+        failureReason,
+        stackOutputs,
+      },
+    });
+  } catch (err) {
+    console.error("[status-updater] publish event failed", {
+      jobId: item.jobId,
+      detailType,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/status-updater/updater.ts
+++ b/infrastructure/lib/problem-deploy/handlers/status-updater/updater.ts
@@ -37,6 +37,12 @@ interface AssumedCredentials {
 
 const NON_TERMINAL_STATUSES = new Set<DeploymentStatus>(["PENDING", "IN_PROGRESS", "DELETING"]);
 
+const DETAIL_TYPE_BY_STATUS = {
+  COMPLETE: EVENT_DETAIL_TYPE_DEPLOY_COMPLETED,
+  DELETED: EVENT_DETAIL_TYPE_DEPLOY_DELETED,
+  FAILED: EVENT_DETAIL_TYPE_DEPLOY_FAILED,
+} as const satisfies Partial<Record<DeploymentStatus, string>>;
+
 export interface UpdaterSharedResources {
   readonly tableName: string;
   readonly eventBusName: string;
@@ -71,16 +77,6 @@ export function buildUpdaterShared(): UpdaterSharedResources {
   };
 }
 
-/**
- * 30 秒に 1 回起動する scheduled Lambda 本体。
- *
- * 1. DDB scan で non-terminal (PENDING/IN_PROGRESS/DELETING) 行を集める
- * 2. 各 row について並列で processOne を実行 (失敗は他に伝播させない)
- * 3. processOne:
- *    - expiresAt < now() && stackId あり && terminal でない → DeleteStack 起動 + DELETING に遷移
- *    - stackId なし (PENDING のまま CFn 未起動) → スキップ (Worker が拾う / 失敗時は markFailed 済)
- *    - その他 → DescribeStacks + status 解決 + 必要なら DDB Update + Event publish
- */
 export async function runStatusUpdate(shared: UpdaterSharedResources): Promise<void> {
   const items = await scanTracked(shared);
   await Promise.allSettled(items.map((item) => processOne(shared, item)));
@@ -289,13 +285,8 @@ async function publishForTransition(
   failureReason: string | undefined,
   stackOutputs: string | undefined,
 ): Promise<void> {
-  if (next === "IN_PROGRESS" || next === "DELETING") return;
-  const detailType =
-    next === "COMPLETE"
-      ? EVENT_DETAIL_TYPE_DEPLOY_COMPLETED
-      : next === "DELETED"
-        ? EVENT_DETAIL_TYPE_DEPLOY_DELETED
-        : EVENT_DETAIL_TYPE_DEPLOY_FAILED;
+  const detailType = DETAIL_TYPE_BY_STATUS[next as keyof typeof DETAIL_TYPE_BY_STATUS];
+  if (!detailType) return;
   try {
     await publishProblemEvent({
       client: shared.events,

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -6,6 +6,7 @@ import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
 import { DeploymentsTable } from "./deployments-table";
+import { StatusUpdaterLambda } from "./status-updater-lambda";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
   /**
@@ -61,6 +62,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     });
 
     new DeployWorkerLambda(this, "DeployWorker", {
+      deploymentsTableName: deployments.table.tableName,
+      eventBus,
+      executionRole: workerRole.role,
+      externalId: props.deployExternalId,
+      competitorRoleName: props.competitorRoleName,
+    });
+
+    new StatusUpdaterLambda(this, "StatusUpdater", {
       deploymentsTableName: deployments.table.tableName,
       eventBus,
       executionRole: workerRole.role,

--- a/infrastructure/lib/problem-deploy/status-updater-lambda.ts
+++ b/infrastructure/lib/problem-deploy/status-updater-lambda.ts
@@ -23,8 +23,8 @@ export interface StatusUpdaterLambdaProps {
 }
 
 /**
- * 30 秒ごとに走り、IN_PROGRESS な deployment の CFn StackStatus を polling して DDB と
- * EventBus に反映する Lambda。expiresAt を超えた non-terminal deployment は DeleteStack
+ * EventBridge schedule rule で起動し、non-terminal deployment の CFn StackStatus を
+ * polling して DDB と EventBus に反映する Lambda。expiresAt を超えた行は DeleteStack
  * で auto teardown する。
  */
 export class StatusUpdaterLambda extends Construct {

--- a/infrastructure/lib/problem-deploy/status-updater-lambda.ts
+++ b/infrastructure/lib/problem-deploy/status-updater-lambda.ts
@@ -1,0 +1,66 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { IEventBus } from "aws-cdk-lib/aws-events";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction as LambdaTarget } from "aws-cdk-lib/aws-events-targets";
+import type { IRole } from "aws-cdk-lib/aws-iam";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import { COMPETITOR_ROLE_NAME_DEFAULT } from "./handlers/shared/events";
+
+export interface StatusUpdaterLambdaProps {
+  readonly deploymentsTableName: string;
+  readonly eventBus: IEventBus;
+  readonly executionRole: IRole;
+  readonly externalId: string;
+  readonly competitorRoleName?: string;
+  /**
+   * 起動間隔。EventBridge classic Rule は分単位までしか扱えないため default は 1 分。
+   * (秒単位 polling が要るなら EventBridge Scheduler に置き換える)
+   */
+  readonly schedulePeriod?: Duration;
+}
+
+/**
+ * 30 秒ごとに走り、IN_PROGRESS な deployment の CFn StackStatus を polling して DDB と
+ * EventBus に反映する Lambda。expiresAt を超えた non-terminal deployment は DeleteStack
+ * で auto teardown する。
+ */
+export class StatusUpdaterLambda extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly rule: Rule;
+
+  constructor(scope: Construct, id: string, props: StatusUpdaterLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/status-updater/index.ts"),
+      handler: "handler",
+      timeout: Duration.minutes(5),
+      memorySize: 512,
+      role: props.executionRole,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTableName,
+        DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
+        DEPLOY_EXTERNAL_ID: props.externalId,
+        COMPETITOR_ROLE_NAME: props.competitorRoleName ?? COMPETITOR_ROLE_NAME_DEFAULT,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    this.rule = new Rule(this, "ScheduleRule", {
+      description: "Periodic CFn status polling for non-terminal deployments.",
+      schedule: Schedule.rate(props.schedulePeriod ?? Duration.minutes(1)),
+      targets: [new LambdaTarget(this.fn)],
+    });
+  }
+}

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -225,9 +225,9 @@ describe("ProblemDeployBackendStack", () => {
   });
 
   describe("DeployWorkerLambda + EventBridge Rule", () => {
-    it("Lambda 関数を 2 つ作るべき (API + Worker)", () => {
+    it("Lambda 関数を 3 つ作るべき (API + Worker + StatusUpdater)", () => {
       const tpl = synth();
-      tpl.resourceCountIs("AWS::Lambda::Function", 2);
+      tpl.resourceCountIs("AWS::Lambda::Function", 3);
     });
 
     it("Worker Lambda は DEPLOY_EXTERNAL_ID を env として持つべき", () => {
@@ -254,6 +254,16 @@ describe("ProblemDeployBackendStack", () => {
             source: ["tenkacloud.problem"],
             "detail-type": ["DeployRequested"],
           }),
+        }),
+      );
+    });
+
+    it("StatusUpdater には rate(1 minute) の schedule rule を立てるべき", () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          ScheduleExpression: "rate(1 minute)",
         }),
       );
     });

--- a/infrastructure/test/problem-deploy/cfn-status.test.ts
+++ b/infrastructure/test/problem-deploy/cfn-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDeploymentStatus,
+  serializeStackOutputs,
+} from "../../lib/problem-deploy/handlers/shared/cfn-status";
+
+describe("resolveDeploymentStatus", () => {
+  it("CREATE_COMPLETE → COMPLETE 遷移を返すべき", () => {
+    expect(resolveDeploymentStatus("IN_PROGRESS", "CREATE_COMPLETE", undefined)).toEqual({
+      kind: "transition",
+      status: "COMPLETE",
+    });
+  });
+
+  it("UPDATE_COMPLETE も COMPLETE 扱いするべき", () => {
+    expect(resolveDeploymentStatus("IN_PROGRESS", "UPDATE_COMPLETE", undefined)).toEqual({
+      kind: "transition",
+      status: "COMPLETE",
+    });
+  });
+
+  it("CREATE_FAILED → FAILED + reason を埋め込むべき", () => {
+    const r = resolveDeploymentStatus("IN_PROGRESS", "CREATE_FAILED", "VPC limit exceeded");
+    expect(r).toEqual({
+      kind: "transition",
+      status: "FAILED",
+      failureReason: "CREATE_FAILED: VPC limit exceeded",
+    });
+  });
+
+  it("ROLLBACK_COMPLETE → FAILED に倒すべき", () => {
+    const r = resolveDeploymentStatus("IN_PROGRESS", "ROLLBACK_COMPLETE", undefined);
+    expect(r).toEqual({ kind: "transition", status: "FAILED", failureReason: "ROLLBACK_COMPLETE" });
+  });
+
+  it("DELETE_COMPLETE → DELETED 遷移を返すべき", () => {
+    expect(resolveDeploymentStatus("DELETING", "DELETE_COMPLETE", undefined)).toEqual({
+      kind: "transition",
+      status: "DELETED",
+    });
+  });
+
+  it("既に COMPLETE なら CREATE_COMPLETE で再遷移しないべき (二重発火防止)", () => {
+    expect(resolveDeploymentStatus("COMPLETE", "CREATE_COMPLETE", undefined)).toEqual({
+      kind: "stable",
+    });
+  });
+
+  it("CREATE_IN_PROGRESS は stable (内部 IN_PROGRESS を維持)", () => {
+    expect(resolveDeploymentStatus("IN_PROGRESS", "CREATE_IN_PROGRESS", undefined)).toEqual({
+      kind: "stable",
+    });
+  });
+
+  it("未知の StackStatus は stable で安全側に倒すべき", () => {
+    expect(resolveDeploymentStatus("IN_PROGRESS", "FUTURE_NEW_STATUS", undefined)).toEqual({
+      kind: "stable",
+    });
+  });
+
+  it("cfnStatus 不明 (undefined) なら stable", () => {
+    expect(resolveDeploymentStatus("IN_PROGRESS", undefined, undefined)).toEqual({
+      kind: "stable",
+    });
+  });
+});
+
+describe("serializeStackOutputs", () => {
+  it("Outputs を OutputKey -> OutputValue の JSON にすべき", () => {
+    const json = serializeStackOutputs([
+      { OutputKey: "FrontendUrl", OutputValue: "http://example.com" },
+      { OutputKey: "ApiUrl", OutputValue: "http://example.com:8080" },
+    ]);
+    expect(JSON.parse(json)).toEqual({
+      FrontendUrl: "http://example.com",
+      ApiUrl: "http://example.com:8080",
+    });
+  });
+
+  it("空配列は空オブジェクトの JSON を返すべき", () => {
+    expect(serializeStackOutputs([])).toBe("{}");
+  });
+
+  it("undefined は空オブジェクトの JSON を返すべき", () => {
+    expect(serializeStackOutputs(undefined)).toBe("{}");
+  });
+
+  it("OutputKey か OutputValue が欠けたエントリはスキップするべき", () => {
+    const json = serializeStackOutputs([
+      { OutputKey: "FrontendUrl", OutputValue: "http://example.com" },
+      { OutputKey: undefined, OutputValue: "x" },
+      { OutputKey: "OnlyKey" },
+    ]);
+    expect(JSON.parse(json)).toEqual({ FrontendUrl: "http://example.com" });
+  });
+});

--- a/infrastructure/test/problem-deploy/status-updater.test.ts
+++ b/infrastructure/test/problem-deploy/status-updater.test.ts
@@ -1,0 +1,215 @@
+import { DeleteStackCommand, DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+import type { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  runStatusUpdate,
+  type UpdaterSharedResources,
+} from "../../lib/problem-deploy/handlers/status-updater/updater";
+
+const FIXED_NOW_MS = 1_700_000_000_000;
+
+function buildShared(rows: Record<string, unknown>[]): {
+  shared: UpdaterSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  eventsSend: ReturnType<typeof vi.fn>;
+  stsSend: ReturnType<typeof vi.fn>;
+  cfnSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn().mockImplementation(async (cmd) => {
+    if (cmd instanceof ScanCommand) return { Items: rows, LastEvaluatedKey: undefined };
+    return {};
+  });
+  const eventsSend = vi.fn().mockResolvedValue({});
+  const stsSend = vi.fn().mockResolvedValue({
+    Credentials: { AccessKeyId: "AKIA", SecretAccessKey: "S", SessionToken: "T" },
+  });
+  const cfnSend = vi.fn();
+  const shared: UpdaterSharedResources = {
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+    externalId: "ext",
+    ddb: { send: ddbSend } as unknown as UpdaterSharedResources["ddb"],
+    events: { send: eventsSend } as unknown as UpdaterSharedResources["events"],
+    sts: { send: stsSend } as unknown as UpdaterSharedResources["sts"],
+    cfnFactory: () =>
+      ({ send: cfnSend }) as unknown as ReturnType<UpdaterSharedResources["cfnFactory"]>,
+    now: () => FIXED_NOW_MS,
+  };
+  return { shared, ddbSend, eventsSend, stsSend, cfnSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#JOB1",
+  SK: "META",
+  jobId: "JOB1",
+  tenantId: "tenant-acme",
+  problemId: "security-battle-royale",
+  awsAccountId: "999999999999",
+  region: "ap-northeast-1",
+  namePrefix: "tc-security-battle-royale-alpha-team",
+  stackId: "arn:aws:cloudformation:ap-northeast-1:999999999999:stack/tc-/uuid",
+  status: "IN_PROGRESS",
+  expiresAt: Math.floor(FIXED_NOW_MS / 1000) + 3600,
+  ...over,
+});
+
+describe("runStatusUpdate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("CFn が CREATE_COMPLETE になったら DDB を COMPLETE に更新し DeployCompleted を publish するべき", async () => {
+    const row = sampleRow();
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([row]);
+    cfnSend.mockResolvedValueOnce({
+      Stacks: [
+        {
+          StackStatus: "CREATE_COMPLETE",
+          Outputs: [{ OutputKey: "FrontendUrl", OutputValue: "http://x" }],
+        },
+      ],
+    });
+
+    await runStatusUpdate(shared);
+
+    // DescribeStacks 呼ばれた
+    expect(cfnSend).toHaveBeenCalledOnce();
+    expect(cfnSend.mock.calls[0]?.[0]).toBeInstanceOf(DescribeStacksCommand);
+
+    // DDB Update (transition)
+    const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updateCalls).toHaveLength(1);
+    const updateCmd = updateCalls[0][0] as UpdateCommand;
+    expect(updateCmd.input.ExpressionAttributeValues?.[":next"]).toBe("COMPLETE");
+    expect(updateCmd.input.ExpressionAttributeValues?.[":outputs"]).toContain("FrontendUrl");
+    // ConditionExpression で current = ":current" を要求
+    expect(updateCmd.input.ConditionExpression).toContain(":current");
+
+    // Event publish
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const evt = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(evt.input.Entries?.[0].DetailType).toBe("DeployCompleted");
+  });
+
+  it("CFn が ROLLBACK_COMPLETE なら FAILED + DeployFailed publish", async () => {
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([sampleRow()]);
+    cfnSend.mockResolvedValueOnce({
+      Stacks: [{ StackStatus: "ROLLBACK_COMPLETE", StackStatusReason: "VPC limit" }],
+    });
+
+    await runStatusUpdate(shared);
+
+    const updateCmd = ddbSend.mock.calls.find((c) => c[0] instanceof UpdateCommand)?.[0] as
+      | UpdateCommand
+      | undefined;
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":next"]).toBe("FAILED");
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":reason"]).toContain("ROLLBACK_COMPLETE");
+
+    expect((eventsSend.mock.calls[0]?.[0] as PutEventsCommand).input.Entries?.[0].DetailType).toBe(
+      "DeployFailed",
+    );
+  });
+
+  it("CFn が CREATE_IN_PROGRESS なら DDB Update も Event publish もしないべき", async () => {
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([sampleRow()]);
+    cfnSend.mockResolvedValueOnce({
+      Stacks: [{ StackStatus: "CREATE_IN_PROGRESS" }],
+    });
+
+    await runStatusUpdate(shared);
+
+    const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updateCalls).toHaveLength(0);
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("expiresAt < now() で stackId 持ち IN_PROGRESS なら DeleteStack + DELETING に遷移するべき", async () => {
+    const row = sampleRow({ expiresAt: Math.floor(FIXED_NOW_MS / 1000) - 60 });
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([row]);
+    cfnSend.mockResolvedValueOnce({}); // DeleteStack
+
+    await runStatusUpdate(shared);
+
+    expect(cfnSend).toHaveBeenCalledOnce();
+    expect(cfnSend.mock.calls[0]?.[0]).toBeInstanceOf(DeleteStackCommand);
+
+    const updateCmd = ddbSend.mock.calls.find((c) => c[0] instanceof UpdateCommand)?.[0] as
+      | UpdateCommand
+      | undefined;
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":next"]).toBe("DELETING");
+    // teardown 直後は publish しない (DELETING は intermediate state)
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("stackId が無い行はスキップする (Worker がまだ CFn を作っていない)", async () => {
+    const row = sampleRow({ stackId: undefined });
+    const { shared, cfnSend, ddbSend, eventsSend } = buildShared([row]);
+
+    await runStatusUpdate(shared);
+
+    expect(cfnSend).not.toHaveBeenCalled();
+    const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updateCalls).toHaveLength(0);
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("DELETING 中の行が DELETE_COMPLETE になったら DELETED + DeployDeleted publish", async () => {
+    const row = sampleRow({ status: "DELETING" });
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([row]);
+    cfnSend.mockResolvedValueOnce({ Stacks: [{ StackStatus: "DELETE_COMPLETE" }] });
+
+    await runStatusUpdate(shared);
+
+    const updateCmd = ddbSend.mock.calls.find((c) => c[0] instanceof UpdateCommand)?.[0] as
+      | UpdateCommand
+      | undefined;
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":next"]).toBe("DELETED");
+    expect((eventsSend.mock.calls[0]?.[0] as PutEventsCommand).input.Entries?.[0].DetailType).toBe(
+      "DeployDeleted",
+    );
+  });
+
+  it("AssumeRole 失敗時は他の row 処理を continue する", async () => {
+    const row = sampleRow();
+    const { shared, ddbSend, stsSend } = buildShared([row]);
+    stsSend.mockRejectedValueOnce(new Error("AccessDenied"));
+
+    await expect(runStatusUpdate(shared)).resolves.toBeUndefined();
+    const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updateCalls).toHaveLength(0); // 状態変えない
+  });
+
+  it("ConditionalCheckFailedException は silently swallow すべき (race の let-win)", async () => {
+    const row = sampleRow();
+    const { shared, ddbSend, eventsSend, cfnSend } = buildShared([row]);
+    cfnSend.mockResolvedValueOnce({ Stacks: [{ StackStatus: "CREATE_COMPLETE", Outputs: [] }] });
+    // Update が ConditionalCheckFailed を投げる
+    ddbSend.mockImplementationOnce(async (cmd) => {
+      if (cmd instanceof ScanCommand) return { Items: [row], LastEvaluatedKey: undefined };
+      return {};
+    });
+    ddbSend.mockImplementationOnce(async (cmd) => {
+      if (cmd instanceof UpdateCommand) {
+        const err: Error & { name?: string } = new Error("conditional check failed");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      }
+      return {};
+    });
+
+    await runStatusUpdate(shared);
+
+    // race で先に書かれたので publish しない
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("ScanCommand の filter は PENDING / IN_PROGRESS / DELETING に絞るべき", async () => {
+    const { shared, ddbSend } = buildShared([]);
+    await runStatusUpdate(shared);
+    const scanCmd = ddbSend.mock.calls[0]?.[0] as ScanCommand;
+    expect(scanCmd).toBeInstanceOf(ScanCommand);
+    expect(scanCmd.input.FilterExpression).toContain(":pending");
+    expect(scanCmd.input.FilterExpression).toContain(":inProgress");
+    expect(scanCmd.input.FilterExpression).toContain(":deleting");
+  });
+});


### PR DESCRIPTION
## 概要

EventBridge schedule rule (rate(1 minute)) で起動する scheduled Lambda を追加し、CFn StackStatus と DDB Deployments を同期する。これで deploy backend の縦串が完全に閉じる。

```
UI form → Deploy API → Worker → CFn 起動
                                    ↓
                            StatusUpdater (1 min)
                                    ↓
                  COMPLETE / FAILED / DELETED へ駆動
                                    ↓
              DeployCompleted / DeployFailed / DeployDeleted
```

## 追加

### Lambda handler (`handlers/status-updater/`)

- `index.ts` EventBridge schedule entrypoint
- `updater.ts` Scan + AssumeRole + DescribeStacks + 状態遷移 + Event publish (`runStatusUpdate` 関数で testable)
- `types.ts` `TrackedDeployment` 型

### Shared (`handlers/shared/`)

- `cfn-status.ts` CFn StackStatus → DeploymentStatus 純粋マッパー
  - `resolveDeploymentStatus(current, cfnStatus, reason)` → `{kind:"transition", status, failureReason?}` or `{kind:"stable"}`
  - `serializeStackOutputs(outputs)` で `Outputs` を `{OutputKey: OutputValue}` JSON 化
  - 未知の StackStatus は `stable` に倒す (AWS 側の新規 StackStatus 追加に対し fail-closed)
- `events.ts` に `EVENT_DETAIL_TYPE_DEPLOY_COMPLETED` / `_DEPLOY_DELETED` を追加

### CDK

- `status-updater-lambda.ts` NodejsFunction (Node.js 20 / arm64 / 5min / 512MB) + Schedule.rate(1 minute)
  - `DeployWorkerRole` を `executionRole` として再利用 (Worker と同じ DDB / EventBridge / cross-account AssumeRole 権限が必要)
  - **EventBridge classic Rule は分単位までしか扱えない** ため default 1 分。秒単位 polling が要るなら EventBridge Scheduler に置き換え可能 (defer)
- `problem-deploy-backend-stack.ts` に `StatusUpdaterLambda` 追加 → Lambda 数 2 → 3

## Tests (64 → 87, +23)

- `cfn-status.test.ts` 13 ケース: `CREATE_COMPLETE` / `UPDATE_COMPLETE` / `CREATE_FAILED` (with reason) / `ROLLBACK_COMPLETE` / `DELETE_COMPLETE` / 既に `COMPLETE` (二重発火防止) / `CREATE_IN_PROGRESS` (stable) / 未知 StackStatus / undefined / Outputs 直列化 4 ケース
- `status-updater.test.ts` 9 ケース: `CREATE_COMPLETE` → COMPLETE + DeployCompleted / `ROLLBACK_COMPLETE` → FAILED / `CREATE_IN_PROGRESS` no-op / TTL teardown (DeleteStack + DELETING) / no stackId skip / DELETING → DELETED / AssumeRole 失敗 continue / `ConditionalCheckFailedException` silent swallow / Scan filter 検証
- `problem-deploy-backend-stack.test.ts` Lambda 数 3 + `rate(1 minute)` Rule

## 設計判断

### Let-win idempotency
全 DDB Update に `ConditionExpression #s = :current`。並行で別 invocation が先に同遷移を書いた場合 `ConditionalCheckFailedException` を silently swallow し、Event の二重 publish を防ぐ。

### AssumeRole 失敗 continue
1 行の AssumeRole 失敗が他 row の処理を止めない (`Promise.allSettled` + per-row try/catch)。

### DELETING は intermediate
`DeleteStack` 直後の DDB Update は publish しない (`DELETE_COMPLETE` で初めて `DeployDeleted` publish)。

### EventBridge sub-minute 不可
`Schedule.rate(Duration.seconds(30))` は `CannotConvertedIntoWhole` で synth が失敗する (classic Rule は分単位)。秒単位 polling が必要なら EventBridge Scheduler への移行検討。

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A (#438) | 競技者 bootstrap CFn | merged |
| B (#441) | DDB + Worker IAM Role | merged |
| C (#442) | Deploy API Lambda | merged |
| D (#443) | DeployWorker Lambda | merged |
| **E (本 PR)** | StatusUpdater Lambda + auto-teardown TTL | review |
| F | API Gateway + Cognito + GET + UI 結線 | TODO |
| G | DELETE | TODO |
| H | participant portal hosting + PortalUpdater | TODO |

## Test plan

- [x] `bun --filter @TenkaCloud/infrastructure test` (87 pass)
- [x] CDK synth (3 Lambda 含む)
- [ ] dev 環境で deploy → 1 minute schedule で polling されることを確認
- [ ] expiresAt 短縮 (例: 60 秒) で auto-teardown 経路を end-to-end 検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring of deployment status changes from infrastructure providers.
  * Enabled automatic cleanup of expired deployments.
  * Implemented event-based notifications for deployment completion, deletion, and failure transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->