### PR TITLE
feat(deploy): Deploy API GET endpoints (list / detail) — PR-F1

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -2,11 +2,14 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { buildContext, buildSharedResources, startDeployment } from "./deploy.js";
+import { getDeployment, listDeployments } from "./list.js";
 import { DeployRequestSchema } from "./types.js";
 
 /**
- * Deploy API Lambda の Hono app。route:
+ * Deploy API Lambda の Hono app。routes:
  *   POST /problems/:problemId/deploy
+ *   GET  /problems/:problemId/deployments
+ *   GET  /deployments/:jobId
  *
  * Auth: Lambda Function URL AWS_IAM が一次 gate。tenantId は `DEFAULT_TENANT_ID`
  * env から取り出す (Cognito JWT authorizer 結線時に JWT claim から差し替え予定)。
@@ -14,6 +17,10 @@ import { DeployRequestSchema } from "./types.js";
 
 // problemId は metadata.json と整合する RFC 1035-ish の slug。両端は英数字、内側のみハイフン許容。
 const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID
+const LIST_LIMIT_MAX = 200;
+
+const resolveTenantId = (): string => process.env.DEFAULT_TENANT_ID ?? "unknown-tenant";
 
 // SDK clients / env を module scope で 1 度だけ build。warm invoke で connection pool 再利用。
 const shared = buildSharedResources();
@@ -40,8 +47,7 @@ app.post("/problems/:problemId/deploy", async (c) => {
     return c.json({ error: "validation failed", issues: parsed.error.issues }, 400);
   }
 
-  const tenantId = process.env.DEFAULT_TENANT_ID ?? "unknown-tenant";
-  const ctx = buildContext(shared, tenantId);
+  const ctx = buildContext(shared, resolveTenantId());
 
   try {
     const response = await startDeployment(ctx, { ...parsed.data, problemId });
@@ -49,6 +55,47 @@ app.post("/problems/:problemId/deploy", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[deploy] startDeployment failed", { problemId, message });
+    return c.json({ error: "internal_error" }, 500);
+  }
+});
+
+app.get("/problems/:problemId/deployments", async (c) => {
+  const problemId = c.req.param("problemId");
+  if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+    return c.json({ error: "invalid problemId" }, 400);
+  }
+  const limitParam = c.req.query("limit");
+  const limit = limitParam !== undefined ? Number.parseInt(limitParam, 10) : undefined;
+  if (limit !== undefined && (!Number.isFinite(limit) || limit < 1 || limit > LIST_LIMIT_MAX)) {
+    return c.json({ error: "invalid limit" }, 400);
+  }
+  try {
+    const response = await listDeployments(shared, {
+      tenantId: resolveTenantId(),
+      problemId,
+      limit,
+      cursor: c.req.query("cursor"),
+    });
+    return c.json(response, 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[deploy] listDeployments failed", { problemId, message });
+    return c.json({ error: "internal_error" }, 500);
+  }
+});
+
+app.get("/deployments/:jobId", async (c) => {
+  const jobId = c.req.param("jobId");
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
+    return c.json({ error: "invalid jobId" }, 400);
+  }
+  try {
+    const item = await getDeployment(shared, resolveTenantId(), jobId);
+    if (!item) return c.json({ error: "not_found" }, 404);
+    return c.json(item, 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[deploy] getDeployment failed", { jobId, message });
     return c.json({ error: "internal_error" }, 500);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/list.ts
@@ -1,0 +1,129 @@
+import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploySharedResources } from "./deploy.js";
+import type { DeploymentItem, DeploymentStatus } from "./types.js";
+
+export interface DeploymentSummary {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly region: string;
+  readonly teamName: string;
+  readonly namePrefix: string;
+  readonly status: DeploymentStatus;
+  readonly stackId?: string;
+  readonly stackOutputs?: string;
+  readonly failureReason?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+}
+
+export interface ListDeploymentsRequest {
+  readonly tenantId: string;
+  readonly problemId?: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export interface ListDeploymentsResponse {
+  readonly items: readonly DeploymentSummary[];
+  readonly nextCursor?: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * `teamLoginKey` (短命 bearer) や `dbPassword` (CFn Parameter) など、リスト/詳細
+ * 表示で出してはいけないフィールドを落とす。新しい sensitive フィールドが増えたら
+ * ここに追加する。
+ */
+export function toSummary(item: Partial<DeploymentItem>): DeploymentSummary {
+  return {
+    jobId: String(item.jobId ?? ""),
+    problemId: String(item.problemId ?? ""),
+    tenantId: String(item.tenantId ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
+    region: String(item.region ?? ""),
+    teamName: String(item.teamName ?? ""),
+    namePrefix: String(item.namePrefix ?? ""),
+    status: (item.status ?? "PENDING") as DeploymentStatus,
+    stackId: item.stackId,
+    stackOutputs: item.stackOutputs,
+    failureReason: item.failureReason,
+    createdAt: String(item.createdAt ?? ""),
+    updatedAt: String(item.updatedAt ?? ""),
+    expiresAt: Number(item.expiresAt ?? 0),
+  };
+}
+
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), "utf8").toString("base64url");
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> | undefined {
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // 不正な cursor は undefined として最初から開始
+  }
+  return undefined;
+}
+
+/**
+ * 指定 tenant の Deployment 一覧を新しい順に返す。`problemId` が指定されたら
+ * GSI1 query 後に in-memory で絞り込む (テナント当たりの行数が小さい前提)。
+ */
+export async function listDeployments(
+  shared: DeploySharedResources,
+  request: ListDeploymentsRequest,
+): Promise<ListDeploymentsResponse> {
+  const limit = Math.min(Math.max(request.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const exclusiveStartKey = request.cursor ? decodeCursor(request.cursor) : undefined;
+
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TENANT#${request.tenantId}` },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  const raw = (out.Items ?? []) as Partial<DeploymentItem>[];
+  const filtered = request.problemId ? raw.filter((i) => i.problemId === request.problemId) : raw;
+  const items = filtered.map(toSummary);
+  const nextCursor = out.LastEvaluatedKey
+    ? encodeCursor(out.LastEvaluatedKey as Record<string, unknown>)
+    : undefined;
+  return { items, nextCursor };
+}
+
+/**
+ * 指定 jobId の Deployment 1 件を返す。`tenantId` が caller と一致しない行は
+ * クロステナント漏洩防止のため `undefined` を返す (404 相当)。
+ */
+export async function getDeployment(
+  shared: DeploySharedResources,
+  tenantId: string,
+  jobId: string,
+): Promise<DeploymentSummary | undefined> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = out.Item as Partial<DeploymentItem> | undefined;
+  if (!item) return undefined;
+  if (item.tenantId !== tenantId) return undefined;
+  return toSummary(item);
+}

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  startDeployment: vi.fn(),
+  listDeployments: vi.fn(),
+  getDeployment: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", () => ({
+  buildSharedResources: () => ({
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: vi.fn() },
+    events: { send: vi.fn() },
+  }),
+  buildContext: (shared: unknown, tenantId: string) => ({ ...(shared as object), tenantId }),
+  startDeployment: mocks.startDeployment,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/list", () => ({
+  listDeployments: mocks.listDeployments,
+  getDeployment: mocks.getDeployment,
+}));
+
+const { app } = await import("../../lib/problem-deploy/handlers/deploy-handler/index");
+
+const ULID = "01H8XGJWBWBAQ4N6RZHM4S2KMV";
+
+describe("GET /problems/:problemId/deployments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 200 と items を返すべき", async () => {
+    mocks.listDeployments.mockResolvedValueOnce({
+      items: [{ jobId: "JOB1", status: "IN_PROGRESS" }],
+      nextCursor: "abc",
+    });
+    const res = await app.request("/problems/security-battle-royale/deployments");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items[0].jobId).toBe("JOB1");
+    expect(body.nextCursor).toBe("abc");
+  });
+
+  it("不正な problemId は 400", async () => {
+    const res = await app.request("/problems/Invalid_ID!/deployments");
+    expect(res.status).toBe(400);
+    expect(mocks.listDeployments).not.toHaveBeenCalled();
+  });
+
+  it("limit が範囲外なら 400", async () => {
+    const res = await app.request("/problems/security-battle-royale/deployments?limit=500");
+    expect(res.status).toBe(400);
+  });
+
+  it("limit / cursor を listDeployments に渡すべき", async () => {
+    mocks.listDeployments.mockResolvedValueOnce({ items: [], nextCursor: undefined });
+    await app.request("/problems/security-battle-royale/deployments?limit=10&cursor=xyz");
+    expect(mocks.listDeployments).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 10, cursor: "xyz", problemId: "security-battle-royale" }),
+    );
+  });
+
+  it("内部エラーは 500", async () => {
+    mocks.listDeployments.mockRejectedValueOnce(new Error("ddb down"));
+    const res = await app.request("/problems/security-battle-royale/deployments");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("internal_error");
+  });
+});
+
+describe("GET /deployments/:jobId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 200 と item を返すべき", async () => {
+    mocks.getDeployment.mockResolvedValueOnce({ jobId: ULID, status: "COMPLETE" });
+    const res = await app.request(`/deployments/${ULID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe(ULID);
+  });
+
+  it("不正な jobId (ULID 形式でない) は 400", async () => {
+    const res = await app.request("/deployments/not-a-ulid");
+    expect(res.status).toBe(400);
+    expect(mocks.getDeployment).not.toHaveBeenCalled();
+  });
+
+  it("見つからなければ 404", async () => {
+    mocks.getDeployment.mockResolvedValueOnce(undefined);
+    const res = await app.request(`/deployments/${ULID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("内部エラーは 500", async () => {
+    mocks.getDeployment.mockRejectedValueOnce(new Error("boom"));
+    const res = await app.request(`/deployments/${ULID}`);
+    expect(res.status).toBe(500);
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-list.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-list.test.ts
@@ -1,0 +1,190 @@
+import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
+import {
+  getDeployment,
+  listDeployments,
+  toSummary,
+} from "../../lib/problem-deploy/handlers/deploy-handler/list";
+
+function buildShared(): {
+  shared: DeploySharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: DeploySharedResources = {
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    events: {} as unknown as DeploySharedResources["events"],
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#01HABC",
+  SK: "META",
+  GSI1PK: "TENANT#tenant-acme",
+  GSI1SK: "2026-05-04T15:00:00.000Z",
+  jobId: "01HABC",
+  problemId: "security-battle-royale",
+  tenantId: "tenant-acme",
+  awsAccountId: "999999999999",
+  region: "ap-northeast-1",
+  teamName: "Alpha",
+  namePrefix: "tc-security-battle-royale-alpha",
+  teamLoginKey: "SECRET_LOGIN_KEY_DO_NOT_LEAK",
+  status: "IN_PROGRESS",
+  createdAt: "2026-05-04T15:00:00.000Z",
+  updatedAt: "2026-05-04T15:00:01.000Z",
+  expiresAt: 1_700_000_000,
+  stackId: "arn:aws:cloudformation:ap-northeast-1:999999999999:stack/x/uuid",
+  ...over,
+});
+
+describe("toSummary", () => {
+  it("teamLoginKey を含めてはいけない", () => {
+    const s = toSummary(sampleRow()) as Record<string, unknown>;
+    expect(s.teamLoginKey).toBeUndefined();
+    expect(JSON.stringify(s)).not.toContain("SECRET_LOGIN_KEY_DO_NOT_LEAK");
+  });
+
+  it("公開フィールドはそのまま入るべき", () => {
+    const s = toSummary(sampleRow());
+    expect(s.jobId).toBe("01HABC");
+    expect(s.problemId).toBe("security-battle-royale");
+    expect(s.tenantId).toBe("tenant-acme");
+    expect(s.status).toBe("IN_PROGRESS");
+    expect(s.stackId).toContain("cloudformation");
+  });
+});
+
+describe("listDeployments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GSI1 に対して TENANT#<id> で Query を投げるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()], LastEvaluatedKey: undefined });
+
+    await listDeployments(shared, { tenantId: "tenant-acme" });
+
+    expect(ddbSend).toHaveBeenCalledOnce();
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd).toBeInstanceOf(QueryCommand);
+    expect(cmd.input.IndexName).toBe("GSI1");
+    expect(cmd.input.KeyConditionExpression).toContain("GSI1PK = :pk");
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+    expect(cmd.input.ScanIndexForward).toBe(false);
+  });
+
+  it("teamLoginKey を返り値に出さないべき (DDB の row には含まれていても)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()], LastEvaluatedKey: undefined });
+
+    const out = await listDeployments(shared, { tenantId: "tenant-acme" });
+    expect(out.items).toHaveLength(1);
+    expect(JSON.stringify(out.items[0])).not.toContain("SECRET_LOGIN_KEY_DO_NOT_LEAK");
+  });
+
+  it("problemId が指定されたら filter するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({ problemId: "security-battle-royale", jobId: "JOB1" }),
+        sampleRow({ problemId: "other-problem", jobId: "JOB2" }),
+      ],
+      LastEvaluatedKey: undefined,
+    });
+
+    const out = await listDeployments(shared, {
+      tenantId: "tenant-acme",
+      problemId: "security-battle-royale",
+    });
+    expect(out.items.map((i) => i.jobId)).toEqual(["JOB1"]);
+  });
+
+  it("LastEvaluatedKey を base64url cursor で返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    const lastKey = { PK: "DEPLOYMENT#X", SK: "META" };
+    ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: lastKey });
+
+    const out = await listDeployments(shared, { tenantId: "tenant-acme" });
+    expect(out.nextCursor).toBeDefined();
+    const decoded = JSON.parse(Buffer.from(out.nextCursor ?? "", "base64url").toString("utf8"));
+    expect(decoded).toEqual(lastKey);
+  });
+
+  it("cursor を渡すと ExclusiveStartKey として渡されるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    const startKey = { PK: "DEPLOYMENT#Y", SK: "META" };
+    const cursor = Buffer.from(JSON.stringify(startKey), "utf8").toString("base64url");
+
+    await listDeployments(shared, { tenantId: "tenant-acme", cursor });
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ExclusiveStartKey).toEqual(startKey);
+  });
+
+  it("不正な cursor は無視して最初から開始するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+    await listDeployments(shared, { tenantId: "tenant-acme", cursor: "!!!not-valid!!!" });
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ExclusiveStartKey).toBeUndefined();
+  });
+
+  it("limit は 1〜200 にクランプされるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+
+    await listDeployments(shared, { tenantId: "tenant-acme", limit: 500 });
+    expect((ddbSend.mock.calls[0]?.[0] as QueryCommand).input.Limit).toBe(200);
+
+    ddbSend.mockClear();
+    await listDeployments(shared, { tenantId: "tenant-acme", limit: 0 });
+    expect((ddbSend.mock.calls[0]?.[0] as QueryCommand).input.Limit).toBe(1);
+  });
+});
+
+describe("getDeployment", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PK=DEPLOYMENT#<jobId> SK=META で GetItem を投げるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    await getDeployment(shared, "tenant-acme", "01HABC");
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as GetCommand;
+    expect(cmd).toBeInstanceOf(GetCommand);
+    expect(cmd.input.Key).toEqual({ PK: "DEPLOYMENT#01HABC", SK: "META" });
+  });
+
+  it("行が無ければ undefined を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await getDeployment(shared, "tenant-acme", "01HABC");
+    expect(out).toBeUndefined();
+  });
+
+  it("tenantId が一致しない行はクロステナント漏洩防止で undefined を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-other" }) });
+
+    const out = await getDeployment(shared, "tenant-acme", "01HABC");
+    expect(out).toBeUndefined();
+  });
+
+  it("teamLoginKey を返り値に含めないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    const out = await getDeployment(shared, "tenant-acme", "01HABC");
+    expect(out).toBeDefined();
+    expect(JSON.stringify(out)).not.toContain("SECRET_LOGIN_KEY_DO_NOT_LEAK");
+  });
+});


### PR DESCRIPTION
## 概要

Deploy API Lambda に GET 系を追加。Cognito 結線 (PR-F2) と UI 結線 (PR-F3) の前段。

```
GET /problems/:problemId/deployments?limit=&cursor=  →  list (tenant-scoped)
GET /deployments/:jobId                              →  detail
```

## 追加

### \`handlers/deploy-handler/list.ts\` (新規)

- \`listDeployments(shared, {tenantId, problemId?, limit?, cursor?})\`
  - GSI1 (\`TENANT#<tenantId>\` / \`createdAt\` desc) を Query
  - \`problemId\` 指定時は in-memory 絞り込み
  - \`limit\` は [1, 200] にクランプ、default 50
  - \`cursor\` は LastEvaluatedKey の base64url、不正値は黙って先頭から
- \`getDeployment(shared, tenantId, jobId)\`
  - PK=\`DEPLOYMENT#<jobId>\` SK=\`META\` GetItem
  - **\`tenantId\` 不一致行はクロステナント漏洩防止で \`undefined\`**
- \`toSummary()\` で \`teamLoginKey\` などの sensitive フィールドを drop

### \`handlers/deploy-handler/index.ts\` route 追加

- \`GET /problems/:problemId/deployments?limit=&cursor=\` (200 / 400 / 500)
- \`GET /deployments/:jobId\` (200 / 400 invalid ULID / 404 / 500)
- 既存 POST と同じく Function URL AWS_IAM が一次 gate、tenant は env

## Tests (87 → 109, +22)

- \`deploy-list.test.ts\` 13 ケース: \`toSummary\` の sensitive drop / GSI1 Query
  形式 / problemId filter / cursor 双方向 / 不正 cursor / limit クランプ /
  クロステナント GetItem 拒否
- \`deploy-handler-routes.test.ts\` 9 ケース: 200 / 400 (invalid problemId, invalid
  jobId, limit out of range) / 404 / 500 / limit & cursor 透過

## 設計判断

### \`teamLoginKey\` は GET レスポンスから完全除外
POST 時の 1 度きり露出に統一し、以降は DDB 内に閉じる (types.ts のコメント通り)。\`toSummary\` に明示的なホワイトリスト方式で、新フィールド追加時の漏洩を防ぐ。

### クロステナント GetItem はサイレント 404
存在を漏らさない。テナント A が他テナントの jobId を総当たりしても確認できない。

### bare Scan ではなく GSI1 Query
テナント別ソート + ページネーション可能。問題別分布が偏ったら問題別 GSI を切る (defer)。

### \`problemId\` filter は in-memory
GSI1SK が createdAt のため。catalog が膨れたら検討。

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜E | 競技者 bootstrap 〜 StatusUpdater | merged |
| **F1 (本 PR)** | Deploy API GET endpoints | review |
| F2 | API Gateway HTTP API + Cognito JWT authorizer | TODO |
| F3 | UI 結線 (DeployForm 実 POST、deployments list/detail、polling) | TODO |
| G | DELETE | TODO |
| H | participant portal hosting + PortalUpdater | TODO |

## Test plan

- [x] \`bun --filter @TenkaCloud/infrastructure test\` (109 pass)
- [x] CDK synth (Lambda 数変わらず 3)
- [ ] dev 環境で \`aws lambda invoke\` 経由で GET 動作確認 (PR-F2 で Cognito 経由に置換)

🤖 Generated with [Claude Code](https://claude.com/claude-code)