### PR TITLE
feat(deploy): API Gateway HTTP API + Cognito JWT authorizer — PR-F2

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -139,8 +139,8 @@ cdk.Aspects.of(controlPlaneStack).add(
 // 設定された ExternalId と一致させる必要がある。.env から渡す。
 //
 // `DEPLOY_USER_POOL_ID` / `DEPLOY_USER_POOL_CLIENT_ID` を両方渡すと UI 用の
-// HTTP API + Cognito JWT authorizer が立ち上がる (PR-F2)。tenant-template-stack
-// が払い出した値を `provision-tenant.sh` 経由で .env に転記する想定。
+// HTTP API + Cognito JWT authorizer が立ち上がる。tenant-template-stack が払い出した
+// 値を `provision-tenant.sh` 経由で .env に転記する想定。
 const deployExternalId = process.env.CDK_PARAM_DEPLOY_EXTERNAL_ID || "tenkacloud-dev-external-id";
 const deployUserPoolId = process.env.CDK_PARAM_DEPLOY_USER_POOL_ID;
 const deployUserPoolClientId = process.env.CDK_PARAM_DEPLOY_USER_POOL_CLIENT_ID;

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -137,11 +137,30 @@ cdk.Aspects.of(controlPlaneStack).add(
 // Problem deploy backend: Deployments DDB + IAM Role + Deploy API Lambda + Worker Lambda。
 // `DEPLOY_EXTERNAL_ID` は競技者 Bootstrap CFn (templates/competitor-bootstrap.yaml) で
 // 設定された ExternalId と一致させる必要がある。.env から渡す。
+//
+// `DEPLOY_USER_POOL_ID` / `DEPLOY_USER_POOL_CLIENT_ID` を両方渡すと UI 用の
+// HTTP API + Cognito JWT authorizer が立ち上がる (PR-F2)。tenant-template-stack
+// が払い出した値を `provision-tenant.sh` 経由で .env に転記する想定。
 const deployExternalId = process.env.CDK_PARAM_DEPLOY_EXTERNAL_ID || "tenkacloud-dev-external-id";
+const deployUserPoolId = process.env.CDK_PARAM_DEPLOY_USER_POOL_ID;
+const deployUserPoolClientId = process.env.CDK_PARAM_DEPLOY_USER_POOL_CLIENT_ID;
+const deployApiCognito =
+  deployUserPoolId && deployUserPoolClientId
+    ? { userPoolId: deployUserPoolId, clientId: deployUserPoolClientId }
+    : undefined;
+const deployApiCorsOriginsRaw = process.env.CDK_PARAM_DEPLOY_API_CORS_ORIGINS;
+const deployApiCorsOrigins = deployApiCorsOriginsRaw
+  ? deployApiCorsOriginsRaw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  : undefined;
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,
   eventBusArn: controlPlaneStack.eventBusArn,
   deployExternalId,
+  deployApiCognito,
+  deployApiCorsOrigins,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),

--- a/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
@@ -5,28 +5,24 @@ import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 
+export interface DeployApiCognito {
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
 export interface DeployApiGatewayProps {
-  /** Cognito User Pool ID (e.g. ap-northeast-1_AbCdEfGhI) */
-  readonly cognitoUserPoolId: string;
-  /** Cognito User Pool client ID — JWT audience として要求する */
-  readonly cognitoClientId: string;
-  /** 既存 Deploy API Lambda */
+  readonly cognito: DeployApiCognito;
   readonly deployHandler: IFunction;
-  /** CORS 許可 origins (UI が CloudFront / localhost から fetch してくる) */
+  /** UI が CloudFront / localhost dev から fetch するため必須。 */
   readonly corsAllowOrigins: readonly string[];
 }
 
 /**
  * Deploy API の認証付き公開エンドポイント。HTTP API + Cognito JWT authorizer で
- * `custom:tenantId` 付きの id_token を持っている caller のみ Lambda に到達する。
+ * `custom:tenantId` 付き id_token を持つ caller のみ Lambda に到達する。
  *
- * Function URL (AWS_IAM) は ops 用にそのまま残し、本 API Gateway は UI / 外部
- * 呼び出し用の主経路。tenantId は authorizer.jwt.claims["custom:tenantId"] から
- * Lambda 側で取り出す (`handlers/deploy-handler/auth.ts`)。
- *
- * **multi-tenant 化 defer**: 現在は単一 User Pool を信頼する。テナントごとに
- * Pool が分かれる本番形態では custom Lambda authorizer + tenant pool registry
- * (DDB) に置き換える。後続 PR で対応。
+ * 単一 User Pool を信頼する単純化。複数テナントが各自の Pool を使う構成では
+ * custom Lambda authorizer + tenant→pool registry に置き換える。
  */
 export class DeployApiGateway extends Construct {
   public readonly httpApi: HttpApi;
@@ -36,22 +32,20 @@ export class DeployApiGateway extends Construct {
     super(scope, id);
 
     const { region } = Stack.of(this);
-    const issuerUrl = `https://cognito-idp.${region}.amazonaws.com/${props.cognitoUserPoolId}`;
+    const issuerUrl = `https://cognito-idp.${region}.amazonaws.com/${props.cognito.userPoolId}`;
 
     this.authorizer = new HttpJwtAuthorizer("DeployJwtAuthorizer", issuerUrl, {
-      jwtAudience: [props.cognitoClientId],
+      jwtAudience: [props.cognito.clientId],
       identitySource: ["$request.header.Authorization"],
     });
 
     this.httpApi = new HttpApi(this, "HttpApi", {
       apiName: "TenkaCloud-DeployApi",
-      description: "Deploy API for problem deployment (POST/GET).",
+      description: "Deploy API for problem deployment.",
       corsPreflight: {
         allowOrigins: [...props.corsAllowOrigins],
         allowHeaders: ["authorization", "content-type"],
         allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.POST, CorsHttpMethod.OPTIONS],
-        allowCredentials: false,
-        maxAge: undefined,
       },
     });
 

--- a/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
@@ -1,0 +1,80 @@
+import { CfnOutput, Stack } from "aws-cdk-lib";
+import { CorsHttpMethod, HttpApi, HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpJwtAuthorizer } from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+export interface DeployApiGatewayProps {
+  /** Cognito User Pool ID (e.g. ap-northeast-1_AbCdEfGhI) */
+  readonly cognitoUserPoolId: string;
+  /** Cognito User Pool client ID — JWT audience として要求する */
+  readonly cognitoClientId: string;
+  /** 既存 Deploy API Lambda */
+  readonly deployHandler: IFunction;
+  /** CORS 許可 origins (UI が CloudFront / localhost から fetch してくる) */
+  readonly corsAllowOrigins: readonly string[];
+}
+
+/**
+ * Deploy API の認証付き公開エンドポイント。HTTP API + Cognito JWT authorizer で
+ * `custom:tenantId` 付きの id_token を持っている caller のみ Lambda に到達する。
+ *
+ * Function URL (AWS_IAM) は ops 用にそのまま残し、本 API Gateway は UI / 外部
+ * 呼び出し用の主経路。tenantId は authorizer.jwt.claims["custom:tenantId"] から
+ * Lambda 側で取り出す (`handlers/deploy-handler/auth.ts`)。
+ *
+ * **multi-tenant 化 defer**: 現在は単一 User Pool を信頼する。テナントごとに
+ * Pool が分かれる本番形態では custom Lambda authorizer + tenant pool registry
+ * (DDB) に置き換える。後続 PR で対応。
+ */
+export class DeployApiGateway extends Construct {
+  public readonly httpApi: HttpApi;
+  public readonly authorizer: HttpJwtAuthorizer;
+
+  constructor(scope: Construct, id: string, props: DeployApiGatewayProps) {
+    super(scope, id);
+
+    const { region } = Stack.of(this);
+    const issuerUrl = `https://cognito-idp.${region}.amazonaws.com/${props.cognitoUserPoolId}`;
+
+    this.authorizer = new HttpJwtAuthorizer("DeployJwtAuthorizer", issuerUrl, {
+      jwtAudience: [props.cognitoClientId],
+      identitySource: ["$request.header.Authorization"],
+    });
+
+    this.httpApi = new HttpApi(this, "HttpApi", {
+      apiName: "TenkaCloud-DeployApi",
+      description: "Deploy API for problem deployment (POST/GET).",
+      corsPreflight: {
+        allowOrigins: [...props.corsAllowOrigins],
+        allowHeaders: ["authorization", "content-type"],
+        allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.POST, CorsHttpMethod.OPTIONS],
+        allowCredentials: false,
+        maxAge: undefined,
+      },
+    });
+
+    const integration = new HttpLambdaIntegration("DeployLambdaIntegration", props.deployHandler);
+
+    const routes: Array<{ path: string; methods: HttpMethod[] }> = [
+      { path: "/problems/{problemId}/deploy", methods: [HttpMethod.POST] },
+      { path: "/problems/{problemId}/deployments", methods: [HttpMethod.GET] },
+      { path: "/deployments/{jobId}", methods: [HttpMethod.GET] },
+    ];
+
+    for (const route of routes) {
+      this.httpApi.addRoutes({
+        path: route.path,
+        methods: route.methods,
+        integration,
+        authorizer: this.authorizer,
+      });
+    }
+
+    new CfnOutput(this, "DeployApiGatewayUrl", {
+      value: this.httpApi.apiEndpoint,
+      description: "Deploy API HTTP API endpoint (Cognito JWT required).",
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -1,0 +1,41 @@
+import type { Context } from "hono";
+
+/**
+ * API Gateway HTTP API + Cognito JWT authorizer 経由の payload v2 形式から
+ * `custom:tenantId` claim を取り出す。
+ *
+ * Function URL (AWS_IAM) 直叩き経路 (ops / 開発時) では JWT claim が無いので
+ * `DEFAULT_TENANT_ID` env にフォールバックする。本番運用では UI 経由 = HTTP API
+ * 経由のみが想定されるので JWT claim 経路が常用。
+ */
+const FALLBACK_TENANT_ID = "unknown-tenant";
+
+export interface JwtAuthorizerContext {
+  readonly jwt?: {
+    readonly claims?: Record<string, string | number | boolean | undefined>;
+  };
+}
+
+export interface AuthorizerEvent {
+  readonly requestContext?: {
+    readonly authorizer?: JwtAuthorizerContext;
+  };
+}
+
+export function extractTenantIdFromClaims(
+  claims: Record<string, string | number | boolean | undefined> | undefined,
+): string | undefined {
+  if (!claims) return undefined;
+  const raw = claims["custom:tenantId"];
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function resolveTenantId(c: Context): string {
+  const event = c.env?.event as AuthorizerEvent | undefined;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims;
+  const fromJwt = extractTenantIdFromClaims(claims);
+  if (fromJwt) return fromJwt;
+  return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -1,30 +1,12 @@
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
 import type { Context } from "hono";
 
-/**
- * API Gateway HTTP API + Cognito JWT authorizer 経由の payload v2 形式から
- * `custom:tenantId` claim を取り出す。
- *
- * Function URL (AWS_IAM) 直叩き経路 (ops / 開発時) では JWT claim が無いので
- * `DEFAULT_TENANT_ID` env にフォールバックする。本番運用では UI 経由 = HTTP API
- * 経由のみが想定されるので JWT claim 経路が常用。
- */
 const FALLBACK_TENANT_ID = "unknown-tenant";
 
-export interface JwtAuthorizerContext {
-  readonly jwt?: {
-    readonly claims?: Record<string, string | number | boolean | undefined>;
-  };
-}
+type JwtClaimValue = string | number | boolean | string[];
+type JwtClaims = { readonly [name: string]: JwtClaimValue };
 
-export interface AuthorizerEvent {
-  readonly requestContext?: {
-    readonly authorizer?: JwtAuthorizerContext;
-  };
-}
-
-export function extractTenantIdFromClaims(
-  claims: Record<string, string | number | boolean | undefined> | undefined,
-): string | undefined {
+export function extractTenantIdFromClaims(claims: JwtClaims | undefined): string | undefined {
   if (!claims) return undefined;
   const raw = claims["custom:tenantId"];
   if (typeof raw !== "string") return undefined;
@@ -33,8 +15,8 @@ export function extractTenantIdFromClaims(
 }
 
 export function resolveTenantId(c: Context): string {
-  const event = c.env?.event as AuthorizerEvent | undefined;
-  const claims = event?.requestContext?.authorizer?.jwt?.claims;
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
   const fromJwt = extractTenantIdFromClaims(claims);
   if (fromJwt) return fromJwt;
   return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
+import { resolveTenantId } from "./auth.js";
 import { buildContext, buildSharedResources, startDeployment } from "./deploy.js";
 import { getDeployment, listDeployments } from "./list.js";
 import { DeployRequestSchema } from "./types.js";
@@ -11,16 +12,15 @@ import { DeployRequestSchema } from "./types.js";
  *   GET  /problems/:problemId/deployments
  *   GET  /deployments/:jobId
  *
- * Auth: Lambda Function URL AWS_IAM が一次 gate。tenantId は `DEFAULT_TENANT_ID`
- * env から取り出す (Cognito JWT authorizer 結線時に JWT claim から差し替え予定)。
+ * Auth: 本番経路は API Gateway HTTP API + Cognito JWT authorizer で、tenantId は
+ * JWT の `custom:tenantId` claim から取り出す。Function URL (AWS_IAM) は ops 用に
+ * 残しており、その経路では `DEFAULT_TENANT_ID` env にフォールバック。
  */
 
 // problemId は metadata.json と整合する RFC 1035-ish の slug。両端は英数字、内側のみハイフン許容。
 const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID
 const LIST_LIMIT_MAX = 200;
-
-const resolveTenantId = (): string => process.env.DEFAULT_TENANT_ID ?? "unknown-tenant";
 
 // SDK clients / env を module scope で 1 度だけ build。warm invoke で connection pool 再利用。
 const shared = buildSharedResources();
@@ -47,7 +47,7 @@ app.post("/problems/:problemId/deploy", async (c) => {
     return c.json({ error: "validation failed", issues: parsed.error.issues }, 400);
   }
 
-  const ctx = buildContext(shared, resolveTenantId());
+  const ctx = buildContext(shared, resolveTenantId(c));
 
   try {
     const response = await startDeployment(ctx, { ...parsed.data, problemId });
@@ -71,7 +71,7 @@ app.get("/problems/:problemId/deployments", async (c) => {
   }
   try {
     const response = await listDeployments(shared, {
-      tenantId: resolveTenantId(),
+      tenantId: resolveTenantId(c),
       problemId,
       limit,
       cursor: c.req.query("cursor"),
@@ -90,7 +90,7 @@ app.get("/deployments/:jobId", async (c) => {
     return c.json({ error: "invalid jobId" }, 400);
   }
   try {
-    const item = await getDeployment(shared, resolveTenantId(), jobId);
+    const item = await getDeployment(shared, resolveTenantId(c), jobId);
     if (!item) return c.json({ error: "not_found" }, 404);
     return c.json(item, 200);
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { CfnOutput } from "aws-cdk-lib";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { Construct } from "constructs";
-import { DeployApiGateway } from "./deploy-api-gateway";
+import { type DeployApiCognito, DeployApiGateway } from "./deploy-api-gateway";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
@@ -31,13 +31,9 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
   readonly competitorRoleName?: string;
   /**
    * Deploy API HTTP API の手前に置く Cognito JWT authorizer 設定。
-   * `userPoolId` / `clientId` の両方が指定された場合のみ HTTP API を作成する。
-   * 単一テナント設定 (現状)。多テナントの custom authorizer 化は後続 PR。
+   * 指定された場合のみ HTTP API を作成する。単一 User Pool 信頼。
    */
-  readonly deployApiCognito?: {
-    readonly userPoolId: string;
-    readonly clientId: string;
-  };
+  readonly deployApiCognito?: DeployApiCognito;
   /**
    * HTTP API CORS で許可する origins。UI が CloudFront / localhost dev から
    * fetch するため必須。
@@ -96,8 +92,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
 
     if (props.deployApiCognito) {
       const apiGw = new DeployApiGateway(this, "DeployApiGateway", {
-        cognitoUserPoolId: props.deployApiCognito.userPoolId,
-        cognitoClientId: props.deployApiCognito.clientId,
+        cognito: props.deployApiCognito,
         deployHandler: deployApi.fn,
         corsAllowOrigins: props.deployApiCorsOrigins ?? ["*"],
       });

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { CfnOutput } from "aws-cdk-lib";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { Construct } from "constructs";
+import { DeployApiGateway } from "./deploy-api-gateway";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
@@ -15,7 +16,8 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
   readonly eventBusArn: string;
   /**
    * Deploy API Lambda が `DEFAULT_TENANT_ID` env として受け取るテナント ID。
-   * Cognito JWT authorizer 結線時に削除する。
+   * 本番経路 (HTTP API + Cognito) では JWT claim を使うので、ここは Function URL
+   * 直叩き経路 (ops / 開発) のフォールバック値。
    */
   readonly defaultTenantId?: string;
   /**
@@ -27,6 +29,20 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * 競技者側 IAM Role 名 (PR-A の default と一致させる)。省略時は規約通り。
    */
   readonly competitorRoleName?: string;
+  /**
+   * Deploy API HTTP API の手前に置く Cognito JWT authorizer 設定。
+   * `userPoolId` / `clientId` の両方が指定された場合のみ HTTP API を作成する。
+   * 単一テナント設定 (現状)。多テナントの custom authorizer 化は後続 PR。
+   */
+  readonly deployApiCognito?: {
+    readonly userPoolId: string;
+    readonly clientId: string;
+  };
+  /**
+   * HTTP API CORS で許可する origins。UI が CloudFront / localhost dev から
+   * fetch するため必須。
+   */
+  readonly deployApiCorsOrigins?: readonly string[];
 }
 
 /**
@@ -42,6 +58,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
   public readonly deploymentsTableArn: string;
   public readonly deployWorkerRoleArn: string;
   public readonly deployApiUrl: string;
+  public readonly deployApiGatewayUrl?: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -76,6 +93,16 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       externalId: props.deployExternalId,
       competitorRoleName: props.competitorRoleName,
     });
+
+    if (props.deployApiCognito) {
+      const apiGw = new DeployApiGateway(this, "DeployApiGateway", {
+        cognitoUserPoolId: props.deployApiCognito.userPoolId,
+        cognitoClientId: props.deployApiCognito.clientId,
+        deployHandler: deployApi.fn,
+        corsAllowOrigins: props.deployApiCorsOrigins ?? ["*"],
+      });
+      this.deployApiGatewayUrl = apiGw.httpApi.apiEndpoint;
+    }
 
     this.deploymentsTableName = deployments.table.tableName;
     this.deploymentsTableArn = deployments.table.tableArn;

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -5,12 +5,15 @@ import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-
 
 const FAKE_BUS_ARN = "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus";
 
-function synth(): Template {
+function synth(
+  overrides?: Partial<ConstructorParameters<typeof ProblemDeployBackendStack>[2]>,
+): Template {
   const app = new cdk.App();
   const stack = new ProblemDeployBackendStack(app, "TestStack", {
     env: { account: "123456789012", region: "ap-northeast-1" },
     eventBusArn: FAKE_BUS_ARN,
     deployExternalId: "ext-test",
+    ...overrides,
   });
   return Template.fromStack(stack);
 }
@@ -264,6 +267,68 @@ describe("ProblemDeployBackendStack", () => {
         "AWS::Events::Rule",
         Match.objectLike({
           ScheduleExpression: "rate(1 minute)",
+        }),
+      );
+    });
+  });
+
+  describe("HTTP API + Cognito JWT authorizer", () => {
+    it("deployApiCognito 未指定なら HTTP API は作らないべき", () => {
+      const tpl = synth();
+      tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 0);
+      tpl.resourceCountIs("AWS::ApiGatewayV2::Authorizer", 0);
+    });
+
+    it("deployApiCognito 指定で HTTP API + JWT authorizer を作るべき", () => {
+      const tpl = synth({
+        deployApiCognito: {
+          userPoolId: "ap-northeast-1_TESTPOOL",
+          clientId: "test-client-id",
+        },
+        deployApiCorsOrigins: ["http://localhost:5173"],
+      });
+      tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 1);
+      tpl.hasResourceProperties(
+        "AWS::ApiGatewayV2::Authorizer",
+        Match.objectLike({
+          AuthorizerType: "JWT",
+          IdentitySource: ["$request.header.Authorization"],
+          JwtConfiguration: Match.objectLike({
+            Audience: ["test-client-id"],
+            Issuer: "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_TESTPOOL",
+          }),
+        }),
+      );
+    });
+
+    it("HTTP API は POST /deploy / GET /deployments / GET /deployments/:jobId のルートを持つべき", () => {
+      const tpl = synth({
+        deployApiCognito: { userPoolId: "ap-northeast-1_X", clientId: "c-1" },
+      });
+      const expectedRoutes = [
+        "POST /problems/{problemId}/deploy",
+        "GET /problems/{problemId}/deployments",
+        "GET /deployments/{jobId}",
+      ];
+      for (const routeKey of expectedRoutes) {
+        tpl.hasResourceProperties(
+          "AWS::ApiGatewayV2::Route",
+          Match.objectLike({ RouteKey: routeKey, AuthorizationType: "JWT" }),
+        );
+      }
+    });
+
+    it("CORS allowOrigins は指定値を反映するべき", () => {
+      const tpl = synth({
+        deployApiCognito: { userPoolId: "ap-northeast-1_X", clientId: "c-1" },
+        deployApiCorsOrigins: ["http://localhost:5173", "https://example.com"],
+      });
+      tpl.hasResourceProperties(
+        "AWS::ApiGatewayV2::Api",
+        Match.objectLike({
+          CorsConfiguration: Match.objectLike({
+            AllowOrigins: ["http://localhost:5173", "https://example.com"],
+          }),
         }),
       );
     });

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -1,0 +1,80 @@
+import type { Context } from "hono";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractTenantIdFromClaims,
+  resolveTenantId,
+} from "../../lib/problem-deploy/handlers/deploy-handler/auth";
+
+describe("extractTenantIdFromClaims", () => {
+  it("custom:tenantId が文字列なら返すべき", () => {
+    expect(extractTenantIdFromClaims({ "custom:tenantId": "tenant-acme" })).toBe("tenant-acme");
+  });
+
+  it("空文字 / 空白のみは undefined", () => {
+    expect(extractTenantIdFromClaims({ "custom:tenantId": "" })).toBeUndefined();
+    expect(extractTenantIdFromClaims({ "custom:tenantId": "   " })).toBeUndefined();
+  });
+
+  it("数値 / boolean は (Cognito 仕様外なので) 拒否", () => {
+    expect(
+      extractTenantIdFromClaims({ "custom:tenantId": 42 as unknown as string }),
+    ).toBeUndefined();
+    expect(
+      extractTenantIdFromClaims({ "custom:tenantId": true as unknown as string }),
+    ).toBeUndefined();
+  });
+
+  it("claims 自体が undefined なら undefined", () => {
+    expect(extractTenantIdFromClaims(undefined)).toBeUndefined();
+  });
+
+  it("custom:tenantId キーが無ければ undefined", () => {
+    expect(extractTenantIdFromClaims({ sub: "u-1" })).toBeUndefined();
+  });
+
+  it("trim して返すべき (Cognito の trailing space 揺れ対策)", () => {
+    expect(extractTenantIdFromClaims({ "custom:tenantId": "  tenant-acme  " })).toBe("tenant-acme");
+  });
+});
+
+function buildCtx(claims?: Record<string, string>): Context {
+  return {
+    env: {
+      event: {
+        requestContext: claims ? { authorizer: { jwt: { claims } } } : {},
+      },
+    },
+  } as unknown as Context;
+}
+
+describe("resolveTenantId", () => {
+  const original = process.env.DEFAULT_TENANT_ID;
+  afterEach(() => {
+    if (original === undefined) delete process.env.DEFAULT_TENANT_ID;
+    else process.env.DEFAULT_TENANT_ID = original;
+  });
+
+  it("JWT claim が居れば優先するべき", () => {
+    process.env.DEFAULT_TENANT_ID = "tenant-from-env";
+    const c = buildCtx({ "custom:tenantId": "tenant-from-jwt" });
+    expect(resolveTenantId(c)).toBe("tenant-from-jwt");
+  });
+
+  it("JWT claim が無ければ DEFAULT_TENANT_ID env を返すべき", () => {
+    process.env.DEFAULT_TENANT_ID = "tenant-from-env";
+    const c = buildCtx();
+    expect(resolveTenantId(c)).toBe("tenant-from-env");
+  });
+
+  it("env も無ければ unknown-tenant に倒すべき", () => {
+    delete process.env.DEFAULT_TENANT_ID;
+    const c = buildCtx();
+    expect(resolveTenantId(c)).toBe("unknown-tenant");
+  });
+
+  it("requestContext が存在しない (Function URL ops 経路) なら env にフォールバック", () => {
+    process.env.DEFAULT_TENANT_ID = "tenant-from-env";
+    const c = { env: {} } as unknown as Context;
+    expect(resolveTenantId(c)).toBe("tenant-from-env");
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -15,13 +15,10 @@ describe("extractTenantIdFromClaims", () => {
     expect(extractTenantIdFromClaims({ "custom:tenantId": "   " })).toBeUndefined();
   });
 
-  it("数値 / boolean は (Cognito 仕様外なので) 拒否", () => {
-    expect(
-      extractTenantIdFromClaims({ "custom:tenantId": 42 as unknown as string }),
-    ).toBeUndefined();
-    expect(
-      extractTenantIdFromClaims({ "custom:tenantId": true as unknown as string }),
-    ).toBeUndefined();
+  it("数値 / boolean / 配列は (string でないので) 拒否", () => {
+    expect(extractTenantIdFromClaims({ "custom:tenantId": 42 })).toBeUndefined();
+    expect(extractTenantIdFromClaims({ "custom:tenantId": true })).toBeUndefined();
+    expect(extractTenantIdFromClaims({ "custom:tenantId": ["tenant-acme"] })).toBeUndefined();
   });
 
   it("claims 自体が undefined なら undefined", () => {


### PR DESCRIPTION
**Stacked on #445 (PR-F1)**. F1 のコミット (Deploy API GET endpoints) も diff に含まれる — F1 が main にマージされたら自動で本 PR の diff から消える。

## 概要

UI から呼べる Deploy API の認証付き経路を作る。HTTP API + Cognito JWT authorizer + 既存 Deploy API Lambda 統合。tenantId は JWT の `custom:tenantId` claim から取り出す。

## 追加 (F1 を除いた本 PR 固有分)

- **`handlers/deploy-handler/auth.ts`** (新規): `extractTenantIdFromClaims` / `resolveTenantId(c)` — JWT claim 優先、Function URL 経路は env フォールバック
- **`lib/problem-deploy/deploy-api-gateway.ts`** (新規): HttpApi + HttpJwtAuthorizer (issuer=`cognito-idp.<region>.amazonaws.com/<userPoolId>`, audience=clientId) + 3 routes (POST deploy, GET list, GET detail) + CORS preflight
- **`ProblemDeployBackendStack`**: optional `deployApiCognito` / `deployApiCorsOrigins` props (両方揃ったときだけ HTTP API を起動、未指定なら従来の Function URL のみ)
- **`bin`**: `CDK_PARAM_DEPLOY_USER_POOL_ID` / `CDK_PARAM_DEPLOY_USER_POOL_CLIENT_ID` / `CDK_PARAM_DEPLOY_API_CORS_ORIGINS` env を読む

## Tests (PR-F1 → PR-F2 で 109 → 123, +14)

- `deploy-auth.test.ts` 10 ケース: claims 抽出 (string / 空文字 / 空白 / 非 string / undefined / キー無し / trim) + resolveTenantId (JWT 優先 / env fallback / unknown-tenant 最終 fallback / requestContext 無し)
- `problem-deploy-backend-stack.test.ts` 4 ケース追加: HTTP API 作らない (default) / 作る / 3 routes すべて JWT 認可付き / CORS allowOrigins 反映

## 設計判断

### 単一 User Pool 信頼 (multi-tenant 化 defer)
現状は 1 つの User Pool しか trust しない。`provision-tenant.sh` は per-tenant Pool を作るので、複数テナント運用時は custom Lambda authorizer + tenant pool registry (DDB) に置き換える。後続 PR で対応。本 PR scope は単一テナント MVP。

### Function URL は残す
ops / 開発 / curl debug 用。本番 UI 経路は HTTP API、内部運用は Function URL の二系統並走。

### CORS は env 駆動
deploy backend は CloudFront URL を直接知らないので `CDK_PARAM_DEPLOY_API_CORS_ORIGINS` CSV を `provision-tenant.sh` から渡す想定。

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜E | 競技者 bootstrap 〜 StatusUpdater | merged |
| F1 (#445) | Deploy API GET endpoints | review |
| **F2 (本 PR)** | API Gateway + Cognito JWT authorizer | review |
| F3 | UI 結線 (DeployForm 実 POST、deployments list/detail、polling) | TODO |
| G | DELETE | TODO |
| H | participant portal hosting + PortalUpdater | TODO |

## Test plan

- [x] `bun --filter @TenkaCloud/infrastructure test` (123 pass)
- [x] CDK synth (HTTP API + JWT authorizer 含む)
- [ ] dev 環境で deploy → curl で 401 (no token) / 200 (valid token) 確認
- [ ] PR-F3 で UI から fetch、tenantId が JWT 由来になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)