### PR TITLE
feat(deploy): UI 結線 — DeployForm 実 POST + 詳細ページ polling — PR-F3

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
 import { CallbackPage } from "./pages/Callback";
+import { DeploymentDetailPage } from "./pages/DeploymentDetail";
 import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { ProblemDetailPage } from "./pages/ProblemDetail";
@@ -32,7 +33,14 @@ export function App({ config }: { config: AppConfig }) {
         <Route path="/callback" element={<CallbackPage config={config} />} />
         <Route path="/" element={guarded(config, <HomePage />)} />
         <Route path="/problems" element={guarded(config, <ProblemsPage />)} />
-        <Route path="/problems/:problemId" element={guarded(config, <ProblemDetailPage />)} />
+        <Route
+          path="/problems/:problemId"
+          element={guarded(config, <ProblemDetailPage config={config} />)}
+        />
+        <Route
+          path="/deployments/:jobId"
+          element={guarded(config, <DeploymentDetailPage config={config} />)}
+        />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </AuthProvider>

--- a/apps/application-admin-console/src/api/client.ts
+++ b/apps/application-admin-console/src/api/client.ts
@@ -13,8 +13,8 @@ export interface ApiClient {
   del(path: string): Promise<void>;
 }
 
-export function createApiClient(config: AppConfig, idToken: string): ApiClient {
-  const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+export function createApiClient(baseUrl: string, idToken: string): ApiClient {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 
   const request = async (path: string, init: RequestInit = {}): Promise<Response> => {
     const url = new URL(path.replace(/^\//, ""), base);
@@ -51,8 +51,16 @@ export function createApiClient(config: AppConfig, idToken: string): ApiClient {
 export function useApiClient(config: AppConfig): ApiClient | null {
   const auth = useAuth();
   return useMemo(
-    () => (auth.tokens ? createApiClient(config, auth.tokens.idToken) : null),
-    [auth.tokens, config],
+    () => (auth.tokens ? createApiClient(config.apiBaseUrl, auth.tokens.idToken) : null),
+    [auth.tokens, config.apiBaseUrl],
+  );
+}
+
+export function useDeployApiClient(config: AppConfig): ApiClient | null {
+  const auth = useAuth();
+  return useMemo(
+    () => (auth.tokens ? createApiClient(config.deployApiBaseUrl, auth.tokens.idToken) : null),
+    [auth.tokens, config.deployApiBaseUrl],
   );
 }
 

--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -1,0 +1,83 @@
+import type { ApiClient } from "./client";
+
+export type DeploymentStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "COMPLETE"
+  | "FAILED"
+  | "DELETING"
+  | "DELETED";
+
+export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+  "COMPLETE",
+  "FAILED",
+  "DELETED",
+]);
+
+export interface DeployRequestBody {
+  readonly region: string;
+  readonly awsAccountId: string;
+  readonly teamName: string;
+}
+
+export interface DeployResponse {
+  readonly jobId: string;
+  readonly status: DeploymentStatus;
+  readonly namePrefix: string;
+  /** チーム共有ログインキー。レスポンスで 1 度だけ露出するので、UI 側で表示し別途控える。 */
+  readonly teamLoginKey: string;
+  readonly expiresAt: number;
+}
+
+export interface DeploymentSummary {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly region: string;
+  readonly teamName: string;
+  readonly namePrefix: string;
+  readonly status: DeploymentStatus;
+  readonly stackId?: string;
+  readonly stackOutputs?: string;
+  readonly failureReason?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+}
+
+export interface ListDeploymentsResponse {
+  readonly items: readonly DeploymentSummary[];
+  readonly nextCursor?: string;
+}
+
+export function startDeployment(
+  client: ApiClient,
+  problemId: string,
+  body: DeployRequestBody,
+): Promise<DeployResponse> {
+  return client.post<DeployResponse>(`/problems/${encodeURIComponent(problemId)}/deploy`, body);
+}
+
+export function getDeployment(client: ApiClient, jobId: string): Promise<DeploymentSummary> {
+  return client.get<DeploymentSummary>(`/deployments/${encodeURIComponent(jobId)}`);
+}
+
+export interface ListDeploymentsParams {
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export function listDeployments(
+  client: ApiClient,
+  problemId: string,
+  params: ListDeploymentsParams = {},
+): Promise<ListDeploymentsResponse> {
+  const qs = new URLSearchParams();
+  if (params.limit !== undefined) qs.set("limit", String(params.limit));
+  if (params.cursor) qs.set("cursor", params.cursor);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return client.get<ListDeploymentsResponse>(
+    `/problems/${encodeURIComponent(problemId)}/deployments${suffix}`,
+  );
+}

--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -1,5 +1,24 @@
 import type { ApiClient } from "./client";
 
+export const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+export function parseStackOutputs(json: string | undefined): Record<string, string> {
+  if (!json) return {};
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === "string") out[k] = v;
+      }
+      return out;
+    }
+  } catch {
+    // stackOutputs は best-effort 表示。壊れた JSON でページを落とさない。
+  }
+  return {};
+}
+
 export type DeploymentStatus =
   | "PENDING"
   | "IN_PROGRESS"

--- a/apps/application-admin-console/src/components/DeployForm.tsx
+++ b/apps/application-admin-console/src/components/DeployForm.tsx
@@ -8,19 +8,18 @@ import Modal from "@cloudscape-design/components/modal";
 import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
+import { useNavigate } from "react-router";
+import { useDeployApiClient } from "../api/client";
+import { type DeployResponse, startDeployment } from "../api/deploy-client";
+import type { AppConfig } from "../config";
 import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
 import { buildStackPrefix } from "../lib/resource-naming";
 
 const AWS_ACCOUNT_ID_RE = /^\d{12}$/;
 const TEAM_NAME_RE = /^[A-Za-z0-9 _-]{1,40}$/;
 
-export interface DeployFormValues {
-  region: string;
-  awsAccountId: string;
-  teamName: string;
-}
-
 interface Props {
+  config: AppConfig;
   problemId: string;
   problemName: string;
   visible: boolean;
@@ -33,113 +32,142 @@ const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
 }));
 
 /**
- * 問題を競技アカウントへデプロイする際の Form Modal。
- *
- * 入力:
- *   - region: AWS Region (deploy 先)
- *   - awsAccountId: 12 桁の AWS アカウント ID (deploy 先)
- *   - teamName: チーム名 (stack 名 + ログインキーラベルに使う)
- *
- * 送信:
- *   現状は backend 未実装なので、入力値を確認 Alert に表示して止める。
- *   backend 実装時には POST /problems/:id/deploy を呼び、ジョブ ID を返して
- *   /deployments/:jobId に遷移する。
- *
- * 認証モデル:
- *   参加者個別アカウントは作らず、各チームに 1 つの短命ログインキーを発行する。
- *   teamName が同じデプロイは別 stack として扱う (= 別チーム = 別キー)。
+ * `teamLoginKey` はレスポンスで 1 度だけ露出する短命キー。Modal 上で表示し
+ * 利用者が控えるまで閉じない (navigate も明示クリック後)。
  */
-export function DeployFormModal({ problemId, problemName, visible, onDismiss }: Props) {
+export function DeployFormModal({ config, problemId, problemName, visible, onDismiss }: Props) {
+  const apiClient = useDeployApiClient(config);
+  const navigate = useNavigate();
   const [region, setRegion] = useState<SelectProps.Option>({
     value: DEFAULT_AWS_REGION.code,
     label: DEFAULT_AWS_REGION.label,
   });
   const [awsAccountId, setAwsAccountId] = useState("");
   const [teamName, setTeamName] = useState("");
-  const [submitted, setSubmitted] = useState<DeployFormValues | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [response, setResponse] = useState<DeployResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const accountIdInvalid = awsAccountId.length > 0 && !AWS_ACCOUNT_ID_RE.test(awsAccountId);
   const teamNameInvalid = teamName.length > 0 && !TEAM_NAME_RE.test(teamName);
   const canSubmit =
-    !!region.value && AWS_ACCOUNT_ID_RE.test(awsAccountId) && TEAM_NAME_RE.test(teamName);
+    !!apiClient &&
+    !!region.value &&
+    AWS_ACCOUNT_ID_RE.test(awsAccountId) &&
+    TEAM_NAME_RE.test(teamName) &&
+    !submitting &&
+    response === null;
 
-  const handleSubmit = () => {
-    if (!canSubmit || !region.value) return;
-    setSubmitted({
-      region: region.value,
-      awsAccountId,
-      teamName,
-    });
-    // backend 実装後は: POST /problems/:problemId/deploy ボディに上記を送り、
-    // ジョブ ID を受け取って navigate(`/deployments/${jobId}`)
+  const handleSubmit = async () => {
+    if (!canSubmit || !region.value || !apiClient) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await startDeployment(apiClient, problemId, {
+        region: region.value,
+        awsAccountId,
+        teamName,
+      });
+      setResponse(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const reset = () => {
-    setSubmitted(null);
+    setResponse(null);
+    setError(null);
+    setSubmitting(false);
     setAwsAccountId("");
     setTeamName("");
     setRegion({ value: DEFAULT_AWS_REGION.code, label: DEFAULT_AWS_REGION.label });
   };
 
+  const close = () => {
+    reset();
+    onDismiss();
+  };
+
+  const goToDetail = () => {
+    if (!response) return;
+    const jobId = response.jobId;
+    reset();
+    onDismiss();
+    navigate(`/deployments/${jobId}`);
+  };
+
   return (
     <Modal
       visible={visible}
-      onDismiss={() => {
-        reset();
-        onDismiss();
-      }}
+      onDismiss={close}
       header={`「${problemName}」を競技アカウントへデプロイ`}
       size="medium"
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
-            <Button
-              onClick={() => {
-                reset();
-                onDismiss();
-              }}
-            >
-              閉じる
-            </Button>
-            <Button
-              variant="primary"
-              disabled={!canSubmit || submitted !== null}
-              onClick={handleSubmit}
-            >
-              デプロイを開始
-            </Button>
+            <Button onClick={close}>閉じる</Button>
+            {response ? (
+              <Button variant="primary" onClick={goToDetail}>
+                ジョブ詳細を見る
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                loading={submitting}
+                disabled={!canSubmit}
+                onClick={handleSubmit}
+              >
+                デプロイを開始
+              </Button>
+            )}
           </SpaceBetween>
         </Box>
       }
     >
       <Form>
         <SpaceBetween size="l">
-          {submitted ? (
-            <Alert type="warning" header="backend 未実装 — デプロイは送信されていません">
-              入力された値は次の通りです (実装完了後、これらが POST /problems/{problemId}
-              /deploy に送られ、CloudFormation 起動 + チームログインキー発行が走ります)。
-              <ul>
-                <li>Region: {submitted.region}</li>
-                <li>AWS Account ID: {submitted.awsAccountId}</li>
-                <li>Team Name: {submitted.teamName}</li>
-                <li>
-                  Stack 名 prefix: <code>{buildStackPrefix(problemId, submitted.teamName)}</code>
-                </li>
-              </ul>
+          {response ? (
+            <Alert type="success" header="デプロイ受付完了 — チームログインキーを控えてください">
+              <SpaceBetween size="s">
+                <Box>
+                  Job ID: <code>{response.jobId}</code>
+                </Box>
+                <Box>
+                  Stack 名 prefix: <code>{response.namePrefix}</code>
+                </Box>
+                <Box>
+                  チームログインキー (この画面でしか表示されません): <br />
+                  <Box variant="code" fontSize="heading-s">
+                    {response.teamLoginKey}
+                  </Box>
+                </Box>
+                <Box variant="small" color="text-status-warning">
+                  このキーは一度だけ表示されます。安全な場所に控えてからジョブ詳細に進んでください。
+                </Box>
+              </SpaceBetween>
             </Alert>
           ) : (
-            <Alert type="info" header="デプロイ contract">
-              入力された AWS アカウント / リージョンに問題スタックを CFn で展開し、Team Name
-              ごとに短命ログインキーを 1 つ発行します。参加者個別の Cognito ユーザは作成しません。
-              <br />
-              同一 (Account, Region)
-              に複数のチームのスタックを並べる運用を許容するため、各リソース名には
-              <code>
-                {" "}
-                tc-{"{problemId}"}-{"{teamName}"}{" "}
-              </code>
-              を共通 prefix として付与し、衝突を回避します。
-            </Alert>
+            <>
+              {error && (
+                <Alert type="error" header="デプロイ送信に失敗しました">
+                  {error}
+                </Alert>
+              )}
+              <Alert type="info" header="デプロイ contract">
+                入力された AWS アカウント / リージョンに問題スタックを CFn で展開し、Team Name
+                ごとに短命ログインキーを 1 つ発行します。参加者個別の Cognito ユーザは作成しません。
+                <br />
+                同一 (Account, Region)
+                に複数のチームのスタックを並べる運用を許容するため、各リソース名には
+                <code>
+                  {" "}
+                  tc-{"{problemId}"}-{"{teamName}"}{" "}
+                </code>
+                を共通 prefix として付与し、衝突を回避します。
+              </Alert>
+            </>
           )}
 
           <FormField
@@ -150,6 +178,7 @@ export function DeployFormModal({ problemId, problemName, visible, onDismiss }: 
             <Select
               selectedOption={region}
               options={REGION_OPTIONS}
+              disabled={response !== null || submitting}
               onChange={({ detail }) => detail.selectedOption && setRegion(detail.selectedOption)}
             />
           </FormField>
@@ -164,6 +193,7 @@ export function DeployFormModal({ problemId, problemName, visible, onDismiss }: 
               type="text"
               inputMode="numeric"
               placeholder="123456789012"
+              disabled={response !== null || submitting}
               onChange={({ detail }) =>
                 setAwsAccountId(detail.value.replace(/\D/g, "").slice(0, 12))
               }
@@ -180,12 +210,13 @@ export function DeployFormModal({ problemId, problemName, visible, onDismiss }: 
             <Input
               value={teamName}
               placeholder="例: alpha-team"
+              disabled={response !== null || submitting}
               onChange={({ detail }) => setTeamName(detail.value)}
               invalid={teamNameInvalid}
             />
           </FormField>
 
-          {teamName.length > 0 && !teamNameInvalid && (
+          {teamName.length > 0 && !teamNameInvalid && response === null && (
             <FormField
               label="生成される Stack 名 prefix (preview)"
               description="同一 (Account, Region) に複数チームのスタックが共存できるよう、リソース名はこの prefix で衝突回避します"

--- a/apps/application-admin-console/src/components/DeployForm.tsx
+++ b/apps/application-admin-console/src/components/DeployForm.tsx
@@ -50,13 +50,13 @@ export function DeployFormModal({ config, problemId, problemName, visible, onDis
 
   const accountIdInvalid = awsAccountId.length > 0 && !AWS_ACCOUNT_ID_RE.test(awsAccountId);
   const teamNameInvalid = teamName.length > 0 && !TEAM_NAME_RE.test(teamName);
+  const inputsLocked = response !== null || submitting;
   const canSubmit =
     !!apiClient &&
     !!region.value &&
     AWS_ACCOUNT_ID_RE.test(awsAccountId) &&
     TEAM_NAME_RE.test(teamName) &&
-    !submitting &&
-    response === null;
+    !inputsLocked;
 
   const handleSubmit = async () => {
     if (!canSubmit || !region.value || !apiClient) return;
@@ -178,7 +178,7 @@ export function DeployFormModal({ config, problemId, problemName, visible, onDis
             <Select
               selectedOption={region}
               options={REGION_OPTIONS}
-              disabled={response !== null || submitting}
+              disabled={inputsLocked}
               onChange={({ detail }) => detail.selectedOption && setRegion(detail.selectedOption)}
             />
           </FormField>
@@ -193,7 +193,7 @@ export function DeployFormModal({ config, problemId, problemName, visible, onDis
               type="text"
               inputMode="numeric"
               placeholder="123456789012"
-              disabled={response !== null || submitting}
+              disabled={inputsLocked}
               onChange={({ detail }) =>
                 setAwsAccountId(detail.value.replace(/\D/g, "").slice(0, 12))
               }
@@ -210,7 +210,7 @@ export function DeployFormModal({ config, problemId, problemName, visible, onDis
             <Input
               value={teamName}
               placeholder="例: alpha-team"
-              disabled={response !== null || submitting}
+              disabled={inputsLocked}
               onChange={({ detail }) => setTeamName(detail.value)}
               invalid={teamNameInvalid}
             />

--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -8,11 +8,16 @@ export interface AppConfig {
   /** 画面表示用のテナント名 (admin-console での tenant 作成時に入力された名前)。 */
   readonly tenantName: string;
   /**
-   * テナント API の base URL (末尾スラッシュなし)。#40-d で追加。
+   * テナント API の base URL (末尾スラッシュなし)。
    * application-admin-console は /apps 等の操作を JWT 認証付きでここに送る。
    * dev fallback ではダミー URL になるので実 API 呼び出しは成立しない。
    */
   readonly apiBaseUrl: string;
+  /**
+   * Deploy API (HTTP API + Cognito JWT authorizer) の base URL。
+   * 問題 deploy / 状態取得用 (POST /problems/:id/deploy など)。
+   */
+  readonly deployApiBaseUrl: string;
 }
 
 /**
@@ -26,6 +31,7 @@ interface RuntimeConfig {
   readonly tenantId: string;
   readonly tenantName: string;
   readonly apiUrl: string;
+  readonly deployApiUrl: string;
 }
 
 async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
@@ -38,7 +44,8 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       !data.userClientId ||
       !data.tenantId ||
       !data.tenantName ||
-      !data.apiUrl
+      !data.apiUrl ||
+      !data.deployApiUrl
     )
       return null;
     return {
@@ -47,6 +54,7 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       tenantId: data.tenantId,
       tenantName: data.tenantName,
       apiUrl: data.apiUrl,
+      deployApiUrl: data.deployApiUrl,
     };
   } catch {
     return null;
@@ -57,6 +65,7 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
 const DEV_FALLBACK_TENANT_ID = "dev-local";
 const DEV_FALLBACK_TENANT_NAME = "Local Dev Tenant";
 const DEV_FALLBACK_API_BASE_URL = "http://localhost:3999";
+const DEV_FALLBACK_DEPLOY_API_BASE_URL = "http://localhost:3998";
 
 /**
  * 設定を解決する。URL は以下のいずれかから来る:
@@ -83,13 +92,14 @@ export async function loadConfig(
       tenantId: runtime.tenantId,
       tenantName: runtime.tenantName,
       apiBaseUrl: runtime.apiUrl,
+      deployApiBaseUrl: runtime.deployApiUrl,
       redirectUri,
       scope,
     };
   }
 
   // dev fallback: 認証用 URL は .env.local / import.meta.env から、テナント情報は
-  // ハードコード placeholder (dev-local / Local Dev Tenant / http://localhost:3999)。
+  // ハードコード placeholder (dev-local / Local Dev Tenant / http://localhost:399x)。
   const required = (key: string): string => {
     const value = env[key];
     if (!value) throw new Error(`Missing required env var: ${key}`);
@@ -100,7 +110,8 @@ export async function loadConfig(
     cognitoClientId: required("VITE_COGNITO_CLIENT_ID"),
     tenantId: DEV_FALLBACK_TENANT_ID,
     tenantName: DEV_FALLBACK_TENANT_NAME,
-    apiBaseUrl: DEV_FALLBACK_API_BASE_URL,
+    apiBaseUrl: env.VITE_API_BASE_URL ?? DEV_FALLBACK_API_BASE_URL,
+    deployApiBaseUrl: env.VITE_DEPLOY_API_BASE_URL ?? DEV_FALLBACK_DEPLOY_API_BASE_URL,
     redirectUri,
     scope,
   };

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -17,12 +17,13 @@ import {
   type DeploymentStatus,
   type DeploymentSummary,
   getDeployment,
+  JOB_ID_RE,
+  parseStackOutputs,
   TERMINAL_STATUSES,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
 
 const POLL_INTERVAL_MS = 5_000;
-const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
 const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   PENDING: "pending",
@@ -33,57 +34,50 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   DELETED: "stopped",
 };
 
-function parseStackOutputs(json: string | undefined): Record<string, string> {
-  if (!json) return {};
-  try {
-    const parsed = JSON.parse(json);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const out: Record<string, string> = {};
-      for (const [k, v] of Object.entries(parsed)) {
-        if (typeof v === "string") out[k] = v;
-      }
-      return out;
-    }
-  } catch {
-    // 壊れた JSON は表示しない
-  }
-  return {};
-}
-
 export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const { jobId } = useParams<{ jobId: string }>();
   const apiClient = useDeployApiClient(config);
   const [item, setItem] = useState<DeploymentSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
+  const [manualRefreshing, setManualRefreshing] = useState(false);
   const stopPollingRef = useRef(false);
 
-  const fetchOnce = useCallback(async () => {
-    if (!apiClient || !jobId || !ULID_RE.test(jobId)) return;
-    setRefreshing(true);
-    try {
-      const fetched = await getDeployment(apiClient, jobId);
-      setItem(fetched);
-      setError(null);
-      if (TERMINAL_STATUSES.has(fetched.status)) stopPollingRef.current = true;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setRefreshing(false);
-    }
-  }, [apiClient, jobId]);
+  // showSpinner=true は手動再読み込みボタンからの呼び出し時のみ。auto polling は
+  // 5 秒ごとに spinner を点滅させずバックグラウンド更新する。
+  const fetchOnce = useCallback(
+    async ({ showSpinner }: { showSpinner: boolean } = { showSpinner: false }) => {
+      if (!apiClient || !jobId || !JOB_ID_RE.test(jobId)) return;
+      if (showSpinner) setManualRefreshing(true);
+      try {
+        const fetched = await getDeployment(apiClient, jobId);
+        setItem(fetched);
+        setError(null);
+        if (TERMINAL_STATUSES.has(fetched.status)) stopPollingRef.current = true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (showSpinner) setManualRefreshing(false);
+      }
+    },
+    [apiClient, jobId],
+  );
 
   useEffect(() => {
+    let cancelled = false;
     stopPollingRef.current = false;
-    void fetchOnce();
-    const interval = setInterval(() => {
-      if (stopPollingRef.current) return;
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
+    const tick = async () => {
+      if (cancelled || stopPollingRef.current) return;
+      await fetchOnce();
+    };
+    void tick();
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [fetchOnce]);
 
-  if (!jobId || !ULID_RE.test(jobId)) {
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
     return <Alert type="error">不正な Job ID です。</Alert>;
   }
 
@@ -112,7 +106,7 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
       <Header
         variant="h1"
         actions={
-          <Button onClick={fetchOnce} loading={refreshing}>
+          <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
             再読み込み
           </Button>
         }

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -1,0 +1,176 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import StatusIndicator, {
+  type StatusIndicatorProps,
+} from "@cloudscape-design/components/status-indicator";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams } from "react-router";
+import { useDeployApiClient } from "../api/client";
+import {
+  type DeploymentStatus,
+  type DeploymentSummary,
+  getDeployment,
+  TERMINAL_STATUSES,
+} from "../api/deploy-client";
+import type { AppConfig } from "../config";
+
+const POLL_INTERVAL_MS = 5_000;
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "success",
+  FAILED: "error",
+  DELETING: "in-progress",
+  DELETED: "stopped",
+};
+
+function parseStackOutputs(json: string | undefined): Record<string, string> {
+  if (!json) return {};
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === "string") out[k] = v;
+      }
+      return out;
+    }
+  } catch {
+    // 壊れた JSON は表示しない
+  }
+  return {};
+}
+
+export function DeploymentDetailPage({ config }: { config: AppConfig }) {
+  const { jobId } = useParams<{ jobId: string }>();
+  const apiClient = useDeployApiClient(config);
+  const [item, setItem] = useState<DeploymentSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const stopPollingRef = useRef(false);
+
+  const fetchOnce = useCallback(async () => {
+    if (!apiClient || !jobId || !ULID_RE.test(jobId)) return;
+    setRefreshing(true);
+    try {
+      const fetched = await getDeployment(apiClient, jobId);
+      setItem(fetched);
+      setError(null);
+      if (TERMINAL_STATUSES.has(fetched.status)) stopPollingRef.current = true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRefreshing(false);
+    }
+  }, [apiClient, jobId]);
+
+  useEffect(() => {
+    stopPollingRef.current = false;
+    void fetchOnce();
+    const interval = setInterval(() => {
+      if (stopPollingRef.current) return;
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchOnce]);
+
+  if (!jobId || !ULID_RE.test(jobId)) {
+    return <Alert type="error">不正な Job ID です。</Alert>;
+  }
+
+  if (!item && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 状態を取得中...
+      </Box>
+    );
+  }
+
+  if (error && !item) {
+    return (
+      <Alert type="error" header="ジョブの取得に失敗しました">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!item) return null;
+
+  const outputs = parseStackOutputs(item.stackOutputs);
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={
+          <Button onClick={fetchOnce} loading={refreshing}>
+            再読み込み
+          </Button>
+        }
+        description={`Job ID: ${item.jobId}`}
+      >
+        デプロイジョブ「{item.teamName}」
+      </Header>
+
+      <Container header={<Header variant="h2">ステータス</Header>}>
+        <SpaceBetween size="m">
+          <StatusIndicator type={STATUS_TYPE[item.status]}>{item.status}</StatusIndicator>
+          {item.status === "FAILED" && item.failureReason && (
+            <Alert type="error" header="失敗理由">
+              {item.failureReason}
+            </Alert>
+          )}
+          {!TERMINAL_STATUSES.has(item.status) && (
+            <Box variant="small" color="text-status-info">
+              {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+            </Box>
+          )}
+        </SpaceBetween>
+      </Container>
+
+      <Container header={<Header variant="h2">基本情報</Header>}>
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValuePairs
+            items={[
+              { label: "Problem ID", value: <code>{item.problemId}</code> },
+              { label: "Team", value: item.teamName },
+              { label: "AWS Account", value: <code>{item.awsAccountId}</code> },
+              { label: "Region", value: item.region },
+            ]}
+          />
+          <KeyValuePairs
+            items={[
+              { label: "Stack 名 prefix", value: <code>{item.namePrefix}</code> },
+              {
+                label: "Stack ID",
+                value: item.stackId ? <code>{item.stackId}</code> : "(未割当)",
+              },
+              { label: "作成", value: item.createdAt },
+              { label: "更新", value: item.updatedAt },
+            ]}
+          />
+        </ColumnLayout>
+      </Container>
+
+      {Object.keys(outputs).length > 0 && (
+        <Container header={<Header variant="h2">CloudFormation Outputs</Header>}>
+          <KeyValuePairs
+            items={Object.entries(outputs).map(([label, value]) => ({
+              label,
+              value: <code>{value}</code>,
+            }))}
+          />
+        </Container>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -9,6 +9,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { DeployFormModal } from "../components/DeployForm";
+import type { AppConfig } from "../config";
 import { findProblem } from "../data/problems";
 
 const DIFFICULTY_LABEL = {
@@ -21,12 +22,9 @@ const DIFFICULTY_LABEL = {
 
 /**
  * 問題詳細ページ。manifest 由来のメタデータを表示し「競技アカウントへデプロイ」CTA を出す。
- *
- * MVP では Deploy ボタンは Modal で「未実装 (backend 待ち)」を案内する stub。
- * 後段 PR で /problems/:id/deploy backend を繋ぎ、ジョブ ID を払い出して
- * /deployments/:id へ遷移する流れに置き換える。
+ * Deploy ボタンは Modal を開き、HTTP API 経由で deploy job を起動する。
  */
-export function ProblemDetailPage() {
+export function ProblemDetailPage({ config }: { config: AppConfig }) {
   const { problemId } = useParams<{ problemId: string }>();
   const navigate = useNavigate();
   const [confirmingDeploy, setConfirmingDeploy] = useState(false);
@@ -121,6 +119,7 @@ export function ProblemDetailPage() {
       </Container>
 
       <DeployFormModal
+        config={config}
         problemId={problem.id}
         problemName={problem.name}
         visible={confirmingDeploy}

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -12,6 +12,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Shared Pooled Tenant", // ← intentionally placeholder; runtime should not display this
   apiBaseUrl: "https://api.example.com/prod",
+  deployApiBaseUrl: "https://deploy.example.com",
 };
 
 function makeIdToken(claims: Record<string, string>): string {

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -10,6 +10,7 @@ const config: AppConfig = {
   tenantId: "t-1",
   tenantName: "T1",
   apiBaseUrl: "https://api.example.com/prod",
+  deployApiBaseUrl: "https://deploy.example.com",
 };
 
 describe("createApiClient", () => {
@@ -22,7 +23,7 @@ describe("createApiClient", () => {
         .mockResolvedValue(new Response(JSON.stringify({ apps: [] }), { status: 200 }));
       vi.stubGlobal("fetch", fetchMock);
 
-      const api = createApiClient(config, "TOKEN");
+      const api = createApiClient(config.apiBaseUrl, "TOKEN");
       await api.get("apps");
 
       const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
@@ -38,7 +39,7 @@ describe("createApiClient", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 201 }));
       vi.stubGlobal("fetch", fetchMock);
 
-      const api = createApiClient(config, "TOKEN");
+      const api = createApiClient(config.apiBaseUrl, "TOKEN");
       await api.post("apps", { name: "x", upstreamUrl: "https://x.example.com" });
 
       const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
@@ -57,7 +58,7 @@ describe("createApiClient", () => {
           .fn()
           .mockImplementation(() => Promise.resolve(new Response("forbidden", { status: 403 }))),
       );
-      const api = createApiClient(config, "TOKEN");
+      const api = createApiClient(config.apiBaseUrl, "TOKEN");
 
       await expect(api.get("apps")).rejects.toBeInstanceOf(ApiError);
       await expect(api.get("apps")).rejects.toThrow(/403.*forbidden/);
@@ -71,8 +72,8 @@ describe("createApiClient", () => {
         .mockImplementation(() => Promise.resolve(new Response("{}", { status: 200 })));
       vi.stubGlobal("fetch", fetchMock);
 
-      const a = createApiClient({ ...config, apiBaseUrl: "https://api.example.com/prod" }, "T");
-      const b = createApiClient({ ...config, apiBaseUrl: "https://api.example.com/prod/" }, "T");
+      const a = createApiClient("https://api.example.com/prod", "T");
+      const b = createApiClient("https://api.example.com/prod/", "T");
       await a.get("apps");
       await b.get("apps");
 

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../src/api/client";
+import {
+  type DeployRequestBody,
+  getDeployment,
+  listDeployments,
+  startDeployment,
+  TERMINAL_STATUSES,
+} from "../../src/api/deploy-client";
+
+interface CapturedCall {
+  path: string;
+  method: "GET" | "POST" | "DELETE";
+  body?: unknown;
+}
+
+function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const client: ApiClient = {
+    get: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "GET" });
+      return Promise.resolve(response);
+    }),
+    post: vi.fn().mockImplementation((path: string, body: unknown) => {
+      calls.push({ path, method: "POST", body });
+      return Promise.resolve(response);
+    }),
+    del: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve();
+    }),
+  };
+  return { client, calls };
+}
+
+describe("startDeployment", () => {
+  it("POST /problems/:problemId/deploy にボディを送るべき", async () => {
+    const { client, calls } = fakeClient({
+      jobId: "01H",
+      status: "PENDING",
+      namePrefix: "tc-x-y",
+      teamLoginKey: "K",
+      expiresAt: 0,
+    });
+    const body: DeployRequestBody = {
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+      teamName: "Alpha",
+    };
+    const res = await startDeployment(client, "security-battle-royale", body);
+    expect(res.jobId).toBe("01H");
+    expect(calls[0]).toEqual({
+      path: "/problems/security-battle-royale/deploy",
+      method: "POST",
+      body,
+    });
+  });
+
+  it("problemId に特殊文字が来ても URL encode するべき", async () => {
+    const { client, calls } = fakeClient({
+      jobId: "01H",
+      status: "PENDING",
+      namePrefix: "x",
+      teamLoginKey: "K",
+      expiresAt: 0,
+    });
+    await startDeployment(client, "a/b", {
+      region: "r",
+      awsAccountId: "0".repeat(12),
+      teamName: "t",
+    });
+    expect(calls[0]?.path).toBe("/problems/a%2Fb/deploy");
+  });
+});
+
+describe("getDeployment", () => {
+  it("GET /deployments/:jobId を呼ぶべき", async () => {
+    const { client, calls } = fakeClient({
+      jobId: "01H",
+      problemId: "p",
+      tenantId: "t",
+      awsAccountId: "0".repeat(12),
+      region: "ap-northeast-1",
+      teamName: "T",
+      namePrefix: "x",
+      status: "IN_PROGRESS",
+      createdAt: "2026-05-04T15:00:00Z",
+      updatedAt: "2026-05-04T15:00:00Z",
+      expiresAt: 0,
+    });
+    await getDeployment(client, "01H");
+    expect(calls[0]).toEqual({ path: "/deployments/01H", method: "GET" });
+  });
+});
+
+describe("listDeployments", () => {
+  it("GET /problems/:problemId/deployments を呼ぶべき (params 無し)", async () => {
+    const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
+    await listDeployments(client, "p");
+    expect(calls[0]?.path).toBe("/problems/p/deployments");
+  });
+
+  it("limit / cursor を query string に乗せるべき", async () => {
+    const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
+    await listDeployments(client, "p", { limit: 10, cursor: "abc" });
+    expect(calls[0]?.path).toBe("/problems/p/deployments?limit=10&cursor=abc");
+  });
+});
+
+describe("TERMINAL_STATUSES", () => {
+  it("COMPLETE / FAILED / DELETED を含むべき (poll 停止条件)", () => {
+    expect(TERMINAL_STATUSES.has("COMPLETE")).toBe(true);
+    expect(TERMINAL_STATUSES.has("FAILED")).toBe(true);
+    expect(TERMINAL_STATUSES.has("DELETED")).toBe(true);
+  });
+
+  it("PENDING / IN_PROGRESS / DELETING は含まないべき", () => {
+    expect(TERMINAL_STATUSES.has("PENDING")).toBe(false);
+    expect(TERMINAL_STATUSES.has("IN_PROGRESS")).toBe(false);
+    expect(TERMINAL_STATUSES.has("DELETING")).toBe(false);
+  });
+});

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -15,6 +15,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "テスト事業部",
   apiBaseUrl: "https://api.example.com/prod",
+  deployApiBaseUrl: "https://deploy.example.com",
 };
 
 describe("loadStoredTokens", () => {

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -9,7 +9,7 @@ const env = {
 };
 
 describe("loadConfig", () => {
-  describe("/runtime-config.json が cognitoDomain / userClientId / tenantId / tenantName / apiUrl を全部返したとき", () => {
+  describe("/runtime-config.json が必須フィールドを全部返したとき", () => {
     async function loadWithFullRuntime() {
       vi.stubGlobal(
         "fetch",
@@ -22,6 +22,7 @@ describe("loadConfig", () => {
                 tenantId: "tenant-prod-1",
                 tenantName: "DENSO 第一事業部",
                 apiUrl: "https://prod-api.example.com/prod",
+                deployApiUrl: "https://prod-deploy.example.com",
               }),
               { status: 200 },
             ),
@@ -50,6 +51,12 @@ describe("loadConfig", () => {
     it("apiBaseUrl を runtime-config.apiUrl から取るべき (key が異なる)", async () => {
       expect((await loadWithFullRuntime()).apiBaseUrl).toBe("https://prod-api.example.com/prod");
     });
+
+    it("deployApiBaseUrl を runtime-config.deployApiUrl から取るべき", async () => {
+      expect((await loadWithFullRuntime()).deployApiBaseUrl).toBe(
+        "https://prod-deploy.example.com",
+      );
+    });
   });
 
   describe("/runtime-config.json が 404 を返したとき (dev fallback)", () => {
@@ -62,6 +69,7 @@ describe("loadConfig", () => {
       expect(config.tenantId).toBe("dev-local");
       expect(config.tenantName).toBe("Local Dev Tenant");
       expect(config.apiBaseUrl).toBe("http://localhost:3999");
+      expect(config.deployApiBaseUrl).toBe("http://localhost:3998");
     });
   });
 
@@ -99,6 +107,7 @@ describe("loadConfig", () => {
               userClientId: "prod-client-id",
               tenantId: "tenant-prod-1",
               tenantName: "T",
+              deployApiUrl: "https://x",
             }),
             { status: 200 },
           ),
@@ -107,6 +116,27 @@ describe("loadConfig", () => {
 
       const config = await loadConfig(env);
       expect(config.apiBaseUrl).toBe("http://localhost:3999");
+    });
+
+    it("deployApiUrl 欠け → env fallback に進むべき", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-cognito.example.com",
+              userClientId: "prod-client-id",
+              tenantId: "tenant-prod-1",
+              tenantName: "T",
+              apiUrl: "https://a",
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+
+      const config = await loadConfig(env);
+      expect(config.deployApiBaseUrl).toBe("http://localhost:3998");
     });
   });
 

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -38,9 +38,15 @@ interface RuntimeConfigProps {
   readonly tenantName: string;
   /**
    * application-admin-console が叩くテナント API (POST /apps 等) の base URL。
-   * ApiGateway.restApi.url (末尾スラッシュ有) から渡す。#40-d / #64 で追加。
+   * ApiGateway.restApi.url (末尾スラッシュ有) から渡す。
    */
   readonly apiUrl: string;
+  /**
+   * Deploy API (HTTP API + Cognito JWT authorizer) の base URL。
+   * ProblemDeployBackendStack の DeployApiGateway から渡す。未指定なら空文字 →
+   * frontend の dev fallback ("http://localhost:3998") に倒れる。
+   */
+  readonly deployApiUrl?: string;
 }
 
 /**
@@ -143,6 +149,7 @@ export class ApplicationAdminConsoleHosting extends Construct {
           tenantId: props.tenantId,
           tenantName: props.tenantName,
           apiUrl: props.apiUrl.replace(/\/$/, ""),
+          deployApiUrl: (props.deployApiUrl ?? "").replace(/\/$/, ""),
         }),
       ],
       destinationBucket: this.bucket,


### PR DESCRIPTION
## 概要

application-admin-console を Deploy API (HTTP API + Cognito) に結線し、"backend 未実装" placeholder を実 fetch に置き換える。**これで UI から問題が deploy できる縦串が完全に貫通**。

## Frontend 変更

- **`config.ts`**: `deployApiBaseUrl` 追加 (runtime-config.deployApiUrl / VITE_DEPLOY_API_BASE_URL env / dev fallback `http://localhost:3998`)
- **`api/client.ts`**: `createApiClient(baseUrl, idToken)` に signature 変更、`useDeployApiClient(config)` hook 追加
- **`api/deploy-client.ts`** (新規): `startDeployment` / `getDeployment` / `listDeployments` typed wrapper + `TERMINAL_STATUSES` set
- **`DeployForm.tsx`**: placeholder Alert 削除、try/catch で実 POST、成功時 `teamLoginKey` 一度だけ表示、`/deployments/:jobId` 遷移
- **`DeploymentDetail.tsx`** (新規): 5 秒 polling、終端 status で停止、CFn Outputs 表示、失敗理由表示、手動再読み込み
- **`App.tsx`**: `/deployments/:jobId` ルート追加

## Infrastructure 変更

- **`application-admin-console-hosting.ts`**: `RuntimeConfigProps.deployApiUrl?` 追加、runtime-config.json に `deployApiUrl` を書き出す

## Tests (46 → 55, +9)

- `api/deploy-client.test.ts` 7 ケース
- `config.test.ts` 2 ケース追加 (`deployApiBaseUrl` runtime-config + dev fallback)
- 既存 fixture に `deployApiBaseUrl` 追加、`client.test` は新 signature 追従

## 設計判断

- **`teamLoginKey`**: POST レスポンスでのみ露出、Modal で 1 度表示後 navigate
- **5 秒 polling** (memory: polling over SSE)、終端で `stopPollingRef` 経由で no-op
- **Function URL** (AWS_IAM) は ops 用に touch せず

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜E | 競技者 bootstrap 〜 StatusUpdater | merged |
| F1 (#445) | Deploy API GET endpoints | merged |
| F2 (#446) | API Gateway + Cognito JWT authorizer | merged |
| **F3 (本 PR)** | UI 結線 | review |
| G | DELETE | TODO |
| H | participant portal hosting + PortalUpdater | TODO |

## Test plan

- [x] `bun run test` (55 + 109 + 37 + 30 全 pass)
- [x] `tsc --noEmit` clean
- [ ] dev 環境で Cognito ログイン → DeployForm 送信 → polling 動作確認
- [ ] tenant-template-stack の cross-stack 紐付け (deployApiUrl を ProblemDeployBackendStack から渡す) は別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deploy form now submits deployments to backend with success confirmation and job ID display
  * New deployment detail page displays deployment status, metadata, and CloudFormation outputs
  * Automatic status polling every 5 seconds until completion; includes manual refresh option
  * Shows deployment failure reasons when applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->