### PR TITLE
feat(deploy): tenant-template が deployApiUrl を runtime-config に流す配線

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -205,9 +205,6 @@ const tenantTemplateStack = new TenantTemplateStack(
 );
 
 tenantTemplateStack.addDependency(bootstrapTemplateStack);
-if (problemDeployBackendStack.deployApiGatewayUrl) {
-  tenantTemplateStack.addDependency(problemDeployBackendStack);
-}
 cdk.Tags.of(tenantTemplateStack).add("TenantId", tenantId);
 cdk.Tags.of(tenantTemplateStack).add("IsPooledDeploy", String(isPooledDeploy));
 cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -200,10 +200,14 @@ const tenantTemplateStack = new TenantTemplateStack(
     ApiKeySSMParameterNames: apiKeySSMParameterNames,
     tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
     commitId,
+    deployApiUrl: problemDeployBackendStack.deployApiGatewayUrl,
   },
 );
 
 tenantTemplateStack.addDependency(bootstrapTemplateStack);
+if (problemDeployBackendStack.deployApiGatewayUrl) {
+  tenantTemplateStack.addDependency(problemDeployBackendStack);
+}
 cdk.Tags.of(tenantTemplateStack).add("TenantId", tenantId);
 cdk.Tags.of(tenantTemplateStack).add("IsPooledDeploy", String(isPooledDeploy));
 cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -33,6 +33,12 @@ interface TenantTemplateStackProps extends StackProps {
   tenantMappingTable: Table;
   commitId: string;
   waveNumber?: string;
+  /**
+   * ProblemDeployBackendStack の HTTP API URL (Cognito 認証付き)。
+   * runtime-config.json に書き出して application-admin-console が deploy API を
+   * 呼べるようにする。未指定なら空文字 → 既存の dev fallback で動作。
+   */
+  deployApiUrl?: string;
 }
 
 export class TenantTemplateStack extends Stack {
@@ -97,6 +103,7 @@ export class TenantTemplateStack extends Stack {
       tenantId: props.tenantId,
       tenantName: props.tenantName,
       apiUrl: apiGateway.restApi.url,
+      deployApiUrl: props.deployApiUrl,
     });
 
     new AwsCustomResource(this, "CreateTenantMapping", {

--- a/infrastructure/test/application-admin-console-hosting.test.ts
+++ b/infrastructure/test/application-admin-console-hosting.test.ts
@@ -100,7 +100,7 @@ describe("ApplicationAdminConsoleHosting", () => {
   });
 
   describe("deployRuntimeConfig() を呼び出したとき", () => {
-    function synthWithRuntimeConfig() {
+    function synthWithRuntimeConfig(deployApiUrl?: string) {
       const app = new cdk.App();
       const stack = new cdk.Stack(app, "TestStack");
       const hosting = new ApplicationAdminConsoleHosting(stack, "Hosting", {
@@ -112,19 +112,48 @@ describe("ApplicationAdminConsoleHosting", () => {
         tenantId: "tenant-1",
         tenantName: "DENSO 第一事業部",
         apiUrl: "https://abc.execute-api.ap-northeast-1.amazonaws.com/prod/",
+        deployApiUrl,
       });
-      return Template.fromStack(stack);
+      return { template: Template.fromStack(stack), stack };
+    }
+
+    function readRuntimeConfigJson(stack: cdk.Stack): Record<string, unknown> {
+      const synth = cdk.App.of(stack)?.synth();
+      if (!synth) throw new Error("synth output unavailable");
+      const assemblyDir = synth.directory;
+      const assets = fs
+        .readdirSync(assemblyDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && d.name.startsWith("asset."));
+      for (const asset of assets) {
+        const candidate = path.join(assemblyDir, asset.name, "runtime-config.json");
+        if (fs.existsSync(candidate)) {
+          return JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
+        }
+      }
+      throw new Error("runtime-config.json asset not found");
     }
 
     it("BucketDeployment Custom Resource が 2 個に増えるべき (dist と runtime-config)", () => {
-      const template = synthWithRuntimeConfig();
+      const { template } = synthWithRuntimeConfig();
       template.resourceCountIs("Custom::CDKBucketDeployment", 2);
     });
 
     it("CloudFront 既存 distribution が同じ Bucket に対して使われ続けるべき (新 Bucket を作らない)", () => {
-      const template = synthWithRuntimeConfig();
+      const { template } = synthWithRuntimeConfig();
       template.resourceCountIs("AWS::S3::Bucket", 1);
       template.resourceCountIs("AWS::CloudFront::Distribution", 1);
+    });
+
+    it("deployApiUrl 指定時は runtime-config.json に書き込むべき", () => {
+      const { stack } = synthWithRuntimeConfig("https://deploy.example.com/");
+      const json = readRuntimeConfigJson(stack);
+      expect(json.deployApiUrl).toBe("https://deploy.example.com");
+    });
+
+    it("deployApiUrl 未指定なら deployApiUrl は空文字 (frontend が dev fallback に倒れる)", () => {
+      const { stack } = synthWithRuntimeConfig();
+      const json = readRuntimeConfigJson(stack);
+      expect(json.deployApiUrl).toBe("");
     });
   });
 });


### PR DESCRIPTION
## 概要

PR-F3 で残した production blocker (CloudFront 配信の `runtime-config.json` の `deployApiUrl` が空文字) を解消。`tenantTemplateStack` が `problemDeployBackendStack.deployApiGatewayUrl` を cross-stack reference 経由で受け取り、`deployRuntimeConfig` に渡す。

これで production 経路が閉じる: `ProblemDeployBackendStack` で HTTP API を作ると CloudFront 配信の `runtime-config.json` に `deployApiUrl` が乗り、UI が dev fallback ではなく実 URL を fetch する。

## 変更

- **`TenantTemplateStackProps.deployApiUrl?: string`** 追加 → `deployRuntimeConfig` に透過
- **`bin/infrastructure.ts`**: `problemDeployBackendStack.deployApiGatewayUrl` を prop で渡す。non-undefined のときだけ `addDependency` で stack 順序保証 (HTTP API なし運用時は依存無し)

## Tests (123 → 125, +2)

- `application-admin-console-hosting.test.ts`:
  - `synthWithRuntimeConfig` が `deployApiUrl` を受け取れるようリファクタ
  - `runtime-config.json` asset を synth 出力から読み出す helper 追加
  - `deployApiUrl` 指定時に JSON に書き込まれる / 未指定で空文字

## 設計判断

### CDK_PARAM 経由ではなく cross-stack reference
operator が手で URL をコピーする 2 段階 deploy を回避。両 stack が同じ App に属するので CDK が自動で CFn export/import を貼る。

### `deployApiGatewayUrl` undefined 時は依存追加しない
`deployApiCognito` が未設定の運用 (Function URL のみ) でも synth が通る。`runtime-config.json` の `deployApiUrl` は空文字のまま → frontend dev fallback に倒れる。

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜E | 競技者 bootstrap 〜 StatusUpdater | merged |
| F1 (#445) | Deploy API GET endpoints | merged |
| F2 (#446) | API Gateway + Cognito JWT authorizer | merged |
| F3 (#447) | UI 結線 | merged |
| **F3.5 (本 PR)** | tenant-template ↔ deploy backend cross-stack 配線 | review |
| G | DELETE | TODO |
| H | participant portal hosting + PortalUpdater | TODO |

## Test plan

- [x] `bun --filter @TenkaCloud/infrastructure test` (125 pass)
- [x] CDK synth (cross-stack reference 解決確認)
- [ ] dev 環境で 1) ProblemDeployBackendStack deploy → HTTP API 起動 2) TenantTemplateStack deploy → `runtime-config.json` に `deployApiUrl` が乗ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)