### PR TITLE
fix(security): Cognito tenant attributes を Client writeAttributes から除外

### DIFF
--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -99,9 +99,14 @@ export class IdentityProvider extends Construct {
     });
     this.cognitoDomainUrl = `https://${domainPrefix}.auth.${stack.region}.amazoncognito.com`;
 
-    const writeAttributes = new aws_cognito.ClientAttributes()
-      .withStandardAttributes({ email: true })
-      .withCustomAttributes("tenantId", "userRole", "apiKey", "tenantTier");
+    // `custom:tenantId` / `userRole` / `apiKey` / `tenantTier` は admin (provision-tenant.sh
+    // が `admin-create-user` で初期化、必要なら `admin-update-user-attributes` で更新) のみ
+    // 書き換える。Client の `writeAttributes` から外すことで、ユーザの access_token から
+    // `UpdateUserAttributes` で `custom:tenantId` を別テナントに書き換えてクロステナント
+    // 操作する経路を塞ぐ (Deploy API の JWT authorizer が claim を信頼するため)。
+    const writeAttributes = new aws_cognito.ClientAttributes().withStandardAttributes({
+      email: true,
+    });
 
     this.tenantUserPoolClient = new aws_cognito.UserPoolClient(this, "tenantUserPoolClient", {
       userPool: this.tenantUserPool,

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -79,5 +79,22 @@ describe("IdentityProvider", () => {
         "https://tenkacloud-development-tenant-1-123456789012.auth.ap-northeast-1.amazoncognito.com",
       );
     });
+
+    it("UserPoolClient の writeAttributes は custom:tenantId を含まないべき (cross-tenant rewrite 防止)", () => {
+      const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
+      const clients = template.findResources("AWS::Cognito::UserPoolClient");
+      const writeAttrs = Object.values(clients)[0]?.Properties?.WriteAttributes ?? [];
+      const blocked = ["custom:tenantId", "custom:userRole", "custom:apiKey", "custom:tenantTier"];
+      for (const attr of blocked) {
+        expect(writeAttrs).not.toContain(attr);
+      }
+    });
+
+    it("UserPoolClient の writeAttributes は email を含むべき (ユーザは自分の email を更新できる)", () => {
+      const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
+      const clients = template.findResources("AWS::Cognito::UserPoolClient");
+      const writeAttrs = Object.values(clients)[0]?.Properties?.WriteAttributes ?? [];
+      expect(writeAttrs).toContain("email");
+    });
   });
 });


### PR DESCRIPTION
## 概要

PR-F2 security review (#446) で flagged されていた cross-tenant rewrite 経路を塞ぐ。

## 攻撃シナリオ (修正前)

1. テナント A の認証ユーザが access_token を取得
2. \`cognito-idp UpdateUserAttributes(AccessToken, {"custom:tenantId": "B"})\` を呼ぶ — Client の \`writeAttributes\` に \`custom:tenantId\` が含まれていたため成功
3. 再ログイン後の id_token は \`custom:tenantId=B\`
4. Deploy API (HTTP API + Cognito JWT authorizer) が claim を信頼し、テナント B の Deployments を読み書き / 競技アカウントへ deploy → **クロステナント侵害**

## 修正

`identity-provider.ts`: `writeAttributes` から `tenantId` / `userRole` / `apiKey` / `tenantTier` を除外。`email` のみ残す (ユーザが自分のメールを更新できる必要があるため)。

これらの custom 属性は admin (`provision-tenant.sh` の `admin-create-user`、必要なら `admin-update-user-attributes`) でのみ書き換わる。`UpdateUserAttributes` API は writeAttributes に含まれない属性に対して `NotAuthorizedException` を返す。

## なぜ schema-level `Mutable: false` を使わないか

Cognito の custom attribute は作成後 `Mutable` flag を変更不可 (CFn が update-replace を試みるが pool 再作成が必要 = 既存ユーザ全消失)。本修正は Client-level の `writeAttributes` 制御のみで攻撃経路を塞ぐ非破壊的な fix。

将来的な防御の重ね掛け:
- `apps/admin-console` 等、複数 OAuth Client がある場合は全 Client の writeAttributes を確認する
- IaC で writeAttributes を assert するテストで drift を防ぐ (本 PR で追加)

## Tests (125 → 127, +2)

- `identity-provider.test.ts`: writeAttributes は `custom:tenantId` / `userRole` / `apiKey` / `tenantTier` を含まない
- `identity-provider.test.ts`: writeAttributes は `email` を含む

## Test plan

- [x] `bun --filter @TenkaCloud/infrastructure test` (127 pass)
- [ ] dev 環境: 既存 tenant Pool に対して \`aws cognito-idp update-user-attributes\` で \`custom:tenantId\` 書き換えを試行 → \`NotAuthorizedException\` が返ることを確認
- [ ] \`aws cognito-idp admin-update-user-attributes\` (操作者 IAM) は引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)