### PR TITLE
feat(deploy): DELETE /deployments/:jobId 経路 + UI 削除ボタン — PR-G

### DIFF
--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -82,6 +82,10 @@ export function getDeployment(client: ApiClient, jobId: string): Promise<Deploym
   return client.get<DeploymentSummary>(`/deployments/${encodeURIComponent(jobId)}`);
 }
 
+export function deleteDeployment(client: ApiClient, jobId: string): Promise<void> {
+  return client.del(`/deployments/${encodeURIComponent(jobId)}`);
+}
+
 export interface ListDeploymentsParams {
   readonly limit?: number;
   readonly cursor?: string;

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -25,8 +25,6 @@ import {
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
 
-const DELETED_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
-
 const POLL_INTERVAL_MS = 5_000;
 
 const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
@@ -125,7 +123,7 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   if (!item) return null;
 
   const outputs = parseStackOutputs(item.stackOutputs);
-  const canDelete = !DELETED_STATUSES.has(item.status);
+  const canDelete = item.status !== "DELETING" && item.status !== "DELETED";
 
   return (
     <SpaceBetween size="l">
@@ -138,7 +136,7 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
             </Button>
             <Button
               variant="normal"
-              iconName="remove"
+              iconName="delete-marker"
               disabled={!canDelete}
               onClick={() => {
                 setDeleteError(null);

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -5,6 +5,7 @@ import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import StatusIndicator, {
@@ -16,12 +17,15 @@ import { useDeployApiClient } from "../api/client";
 import {
   type DeploymentStatus,
   type DeploymentSummary,
+  deleteDeployment,
   getDeployment,
   JOB_ID_RE,
   parseStackOutputs,
   TERMINAL_STATUSES,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
+
+const DELETED_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -40,6 +44,9 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const [item, setItem] = useState<DeploymentSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [manualRefreshing, setManualRefreshing] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const stopPollingRef = useRef(false);
 
   // showSpinner=true は手動再読み込みボタンからの呼び出し時のみ。auto polling は
@@ -77,6 +84,24 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
     };
   }, [fetchOnce]);
 
+  const handleDelete = useCallback(async () => {
+    if (!apiClient || !jobId) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteDeployment(apiClient, jobId);
+      setDeleteModalOpen(false);
+      // DELETING / DELETE_COMPLETE 遷移は StatusUpdater (1 min) が反映する。
+      // 既存の polling が拾うので追加フェッチ不要、stop flag も解除して継続。
+      stopPollingRef.current = false;
+      await fetchOnce({ showSpinner: false });
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleting(false);
+    }
+  }, [apiClient, jobId, fetchOnce]);
+
   if (!jobId || !JOB_ID_RE.test(jobId)) {
     return <Alert type="error">不正な Job ID です。</Alert>;
   }
@@ -100,15 +125,29 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   if (!item) return null;
 
   const outputs = parseStackOutputs(item.stackOutputs);
+  const canDelete = !DELETED_STATUSES.has(item.status);
 
   return (
     <SpaceBetween size="l">
       <Header
         variant="h1"
         actions={
-          <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
-            再読み込み
-          </Button>
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
+              再読み込み
+            </Button>
+            <Button
+              variant="normal"
+              iconName="remove"
+              disabled={!canDelete}
+              onClick={() => {
+                setDeleteError(null);
+                setDeleteModalOpen(true);
+              }}
+            >
+              削除
+            </Button>
+          </SpaceBetween>
         }
         description={`Job ID: ${item.jobId}`}
       >
@@ -165,6 +204,37 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
           />
         </Container>
       )}
+
+      <Modal
+        visible={deleteModalOpen}
+        onDismiss={() => setDeleteModalOpen(false)}
+        header={`「${item.teamName}」のデプロイを削除`}
+        size="medium"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setDeleteModalOpen(false)} disabled={deleting}>
+                キャンセル
+              </Button>
+              <Button variant="primary" loading={deleting} onClick={handleDelete}>
+                削除する
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            競技アカウント (<code>{item.awsAccountId}</code> / {item.region}) で起動中の
+            CloudFormation Stack <code>{item.namePrefix}</code> を削除します。
+          </Box>
+          <Box variant="small" color="text-status-warning">
+            この操作は取り消せません。実際の削除は次の StatusUpdater 周期 (最大 1 分)
+            で実行されます。
+          </Box>
+          {deleteError && <Alert type="error">{deleteError}</Alert>}
+        </SpaceBetween>
+      </Modal>
     </SpaceBetween>
   );
 }

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "../../src/api/client";
 import {
   type DeployRequestBody,
+  deleteDeployment,
   getDeployment,
   listDeployments,
   startDeployment,
@@ -70,6 +71,20 @@ describe("startDeployment", () => {
       teamName: "t",
     });
     expect(calls[0]?.path).toBe("/problems/a%2Fb/deploy");
+  });
+});
+
+describe("deleteDeployment", () => {
+  it("DELETE /deployments/:jobId を呼ぶべき", async () => {
+    const { client, calls } = fakeClient(undefined);
+    await deleteDeployment(client, "01H");
+    expect(calls[0]).toEqual({ path: "/deployments/01H", method: "DELETE" });
+  });
+
+  it("jobId に特殊文字が来ても URL encode するべき", async () => {
+    const { client, calls } = fakeClient(undefined);
+    await deleteDeployment(client, "a/b");
+    expect(calls[0]?.path).toBe("/deployments/a%2Fb");
   });
 });
 

--- a/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-gateway.ts
@@ -45,7 +45,12 @@ export class DeployApiGateway extends Construct {
       corsPreflight: {
         allowOrigins: [...props.corsAllowOrigins],
         allowHeaders: ["authorization", "content-type"],
-        allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.POST, CorsHttpMethod.OPTIONS],
+        allowMethods: [
+          CorsHttpMethod.GET,
+          CorsHttpMethod.POST,
+          CorsHttpMethod.DELETE,
+          CorsHttpMethod.OPTIONS,
+        ],
       },
     });
 
@@ -54,7 +59,7 @@ export class DeployApiGateway extends Construct {
     const routes: Array<{ path: string; methods: HttpMethod[] }> = [
       { path: "/problems/{problemId}/deploy", methods: [HttpMethod.POST] },
       { path: "/problems/{problemId}/deployments", methods: [HttpMethod.GET] },
-      { path: "/deployments/{jobId}", methods: [HttpMethod.GET] },
+      { path: "/deployments/{jobId}", methods: [HttpMethod.GET, HttpMethod.DELETE] },
     ];
 
     for (const route of routes) {

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -1,0 +1,76 @@
+import { GetCommand, UpdateCommand, type UpdateCommandInput } from "@aws-sdk/lib-dynamodb";
+import type { DeploySharedResources } from "./deploy.js";
+import type { DeploymentItem, DeploymentStatus } from "./types.js";
+
+export type TeardownOutcome =
+  | { kind: "accepted"; previousStatus: DeploymentStatus }
+  | { kind: "not_found" }
+  | { kind: "already_deleted" }
+  | { kind: "race"; reason: "tenant_or_status_mismatch" };
+
+const TEARDOWNABLE_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "FAILED",
+]);
+
+/**
+ * 手動 teardown を要求する。新しく CFn DeleteStack を呼ぶ Lambda は作らず、
+ * `expiresAt` を現在時刻に書き換えて既存の StatusUpdater (1 min) に拾わせる。
+ *
+ * これで:
+ *   - Deploy API Lambda に新しい STS / CFn 権限を足さない
+ *   - auto-teardown TTL の経路と同じ機械で動く (idempotent / let-win 込み)
+ *   - 0〜60 秒の遅延は許容
+ *
+ * 既に `DELETING` / `DELETED` の行は no-op で返す。
+ * クロステナント漏洩防止のため `tenantId` mismatch は `not_found` 扱い (存在を漏らさない)。
+ */
+export async function requestTeardown(
+  shared: DeploySharedResources,
+  tenantId: string,
+  jobId: string,
+  nowMs: number,
+): Promise<TeardownOutcome> {
+  const got = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = got.Item as Partial<DeploymentItem> | undefined;
+  if (!item) return { kind: "not_found" };
+  if (item.tenantId !== tenantId) return { kind: "not_found" };
+  const status = (item.status ?? "PENDING") as DeploymentStatus;
+  if (status === "DELETING" || status === "DELETED") return { kind: "already_deleted" };
+
+  const update: UpdateCommandInput = {
+    TableName: shared.tableName,
+    Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    UpdateExpression: "SET expiresAt = :expiresAt, updatedAt = :updatedAt",
+    ConditionExpression: "tenantId = :tenantId AND #s IN (:p, :i, :c, :f)",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: {
+      ":expiresAt": Math.floor(nowMs / 1000),
+      ":updatedAt": new Date(nowMs).toISOString(),
+      ":tenantId": tenantId,
+      ":p": "PENDING",
+      ":i": "IN_PROGRESS",
+      ":c": "COMPLETE",
+      ":f": "FAILED",
+    },
+  };
+  try {
+    await shared.ddb.send(new UpdateCommand(update));
+  } catch (err) {
+    const code = (err as { name?: string })?.name ?? "";
+    if (code === "ConditionalCheckFailedException") {
+      return { kind: "race", reason: "tenant_or_status_mismatch" };
+    }
+    throw err;
+  }
+  return { kind: "accepted", previousStatus: status };
+}
+
+export { TEARDOWNABLE_STATUSES };

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -8,13 +8,6 @@ export type TeardownOutcome =
   | { kind: "already_deleted" }
   | { kind: "race"; reason: "tenant_or_status_mismatch" };
 
-const TEARDOWNABLE_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
-  "PENDING",
-  "IN_PROGRESS",
-  "COMPLETE",
-  "FAILED",
-]);
-
 /**
  * 手動 teardown を要求する。新しく CFn DeleteStack を呼ぶ Lambda は作らず、
  * `expiresAt` を現在時刻に書き換えて既存の StatusUpdater (1 min) に拾わせる。
@@ -72,5 +65,3 @@ export async function requestTeardown(
   }
   return { kind: "accepted", previousStatus: status };
 }
-
-export { TEARDOWNABLE_STATUSES };

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -2,15 +2,17 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { resolveTenantId } from "./auth.js";
+import { requestTeardown } from "./delete.js";
 import { buildContext, buildSharedResources, startDeployment } from "./deploy.js";
 import { getDeployment, listDeployments } from "./list.js";
 import { DeployRequestSchema } from "./types.js";
 
 /**
  * Deploy API Lambda の Hono app。routes:
- *   POST /problems/:problemId/deploy
- *   GET  /problems/:problemId/deployments
- *   GET  /deployments/:jobId
+ *   POST   /problems/:problemId/deploy
+ *   GET    /problems/:problemId/deployments
+ *   GET    /deployments/:jobId
+ *   DELETE /deployments/:jobId
  *
  * Auth: 本番経路は API Gateway HTTP API + Cognito JWT authorizer で、tenantId は
  * JWT の `custom:tenantId` claim から取り出す。Function URL (AWS_IAM) は ops 用に
@@ -96,6 +98,24 @@ app.get("/deployments/:jobId", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[deploy] getDeployment failed", { jobId, message });
+    return c.json({ error: "internal_error" }, 500);
+  }
+});
+
+app.delete("/deployments/:jobId", async (c) => {
+  const jobId = c.req.param("jobId");
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
+    return c.json({ error: "invalid jobId" }, 400);
+  }
+  try {
+    const outcome = await requestTeardown(shared, resolveTenantId(c), jobId, Date.now());
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, 404);
+    if (outcome.kind === "already_deleted") return c.json({ status: "already_deleted" }, 200);
+    if (outcome.kind === "race") return c.json({ error: "conflict" }, 409);
+    return c.json({ status: "accepted", previousStatus: outcome.previousStatus }, 202);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[deploy] requestTeardown failed", { jobId, message });
     return c.json({ error: "internal_error" }, 500);
   }
 });

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -301,7 +301,7 @@ describe("ProblemDeployBackendStack", () => {
       );
     });
 
-    it("HTTP API は POST /deploy / GET /deployments / GET /deployments/:jobId のルートを持つべき", () => {
+    it("HTTP API は POST deploy / GET list / GET detail / DELETE detail の全ルートを JWT 認可で持つべき", () => {
       const tpl = synth({
         deployApiCognito: { userPoolId: "ap-northeast-1_X", clientId: "c-1" },
       });
@@ -309,6 +309,7 @@ describe("ProblemDeployBackendStack", () => {
         "POST /problems/{problemId}/deploy",
         "GET /problems/{problemId}/deployments",
         "GET /deployments/{jobId}",
+        "DELETE /deployments/{jobId}",
       ];
       for (const routeKey of expectedRoutes) {
         tpl.hasResourceProperties(

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -1,0 +1,126 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestTeardown } from "../../lib/problem-deploy/handlers/deploy-handler/delete";
+import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
+
+const NOW_MS = 1_700_000_000_000;
+
+function buildShared(): {
+  shared: DeploySharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: DeploySharedResources = {
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    events: {} as unknown as DeploySharedResources["events"],
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#JOB1",
+  SK: "META",
+  jobId: "JOB1",
+  tenantId: "tenant-acme",
+  problemId: "p",
+  awsAccountId: "999999999999",
+  region: "ap-northeast-1",
+  teamName: "T",
+  namePrefix: "tc-p-t",
+  status: "IN_PROGRESS",
+  expiresAt: 9_999_999_999,
+  ...over,
+});
+
+describe("requestTeardown", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: expiresAt を now() に書き換えて accepted を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out).toEqual({ kind: "accepted", previousStatus: "IN_PROGRESS" });
+
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    expect(updateCmd).toBeInstanceOf(UpdateCommand);
+    expect(updateCmd.input.ExpressionAttributeValues?.[":expiresAt"]).toBe(
+      Math.floor(NOW_MS / 1000),
+    );
+    expect(updateCmd.input.ConditionExpression).toContain("tenantId = :tenantId");
+    expect(updateCmd.input.ConditionExpression).toContain(":p");
+    expect(updateCmd.input.ConditionExpression).toContain(":i");
+    expect(updateCmd.input.ConditionExpression).toContain(":c");
+    expect(updateCmd.input.ConditionExpression).toContain(":f");
+  });
+
+  it("行が無ければ not_found を返し Update を呼ばないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+    const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("tenantId 不一致は not_found 扱いで存在を漏らさないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-other" }) });
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("既に DELETING / DELETED なら already_deleted を返すべき (no-op)", async () => {
+    for (const status of ["DELETING", "DELETED"]) {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Item: sampleRow({ status }) });
+
+      const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+      expect(out).toEqual({ kind: "already_deleted" });
+      const updateCalls = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+      expect(updateCalls).toHaveLength(0);
+    }
+  });
+
+  it("ConditionalCheckFailed は race として返すべき (StatusUpdater が先に状態を変えたケース)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+    ddbSend.mockImplementationOnce(async (cmd) => {
+      if (cmd instanceof UpdateCommand) {
+        const err: Error & { name?: string } = new Error("conditional check failed");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      }
+      return {};
+    });
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out).toEqual({ kind: "race", reason: "tenant_or_status_mismatch" });
+  });
+
+  it("Update が他のエラーを投げたら例外を伝播するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+    ddbSend.mockRejectedValueOnce(new Error("ProvisionedThroughputExceeded"));
+
+    await expect(requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS)).rejects.toThrow(
+      /ProvisionedThroughputExceeded/,
+    );
+  });
+
+  it("最初の GetItem は PK=DEPLOYMENT#<jobId> SK=META を引くべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+    ddbSend.mockResolvedValueOnce({});
+
+    await requestTeardown(shared, "tenant-acme", "JOB42", NOW_MS);
+    const getCmd = ddbSend.mock.calls[0]?.[0] as GetCommand;
+    expect(getCmd).toBeInstanceOf(GetCommand);
+    expect(getCmd.input.Key).toEqual({ PK: "DEPLOYMENT#JOB42", SK: "META" });
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   startDeployment: vi.fn(),
   listDeployments: vi.fn(),
   getDeployment: vi.fn(),
+  requestTeardown: vi.fn(),
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", () => ({
@@ -20,6 +21,10 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", () => ({
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/list", () => ({
   listDeployments: mocks.listDeployments,
   getDeployment: mocks.getDeployment,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
+  requestTeardown: mocks.requestTeardown,
 }));
 
 const { app } = await import("../../lib/problem-deploy/handlers/deploy-handler/index");
@@ -96,6 +101,57 @@ describe("GET /deployments/:jobId", () => {
   it("内部エラーは 500", async () => {
     mocks.getDeployment.mockRejectedValueOnce(new Error("boom"));
     const res = await app.request(`/deployments/${ULID}`);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("DELETE /deployments/:jobId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 202 と previousStatus を返すべき", async () => {
+    mocks.requestTeardown.mockResolvedValueOnce({
+      kind: "accepted",
+      previousStatus: "IN_PROGRESS",
+    });
+    const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+    expect(body.previousStatus).toBe("IN_PROGRESS");
+  });
+
+  it("既に DELETING/DELETED なら 200 with already_deleted", async () => {
+    mocks.requestTeardown.mockResolvedValueOnce({ kind: "already_deleted" });
+    const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("already_deleted");
+  });
+
+  it("not_found は 404", async () => {
+    mocks.requestTeardown.mockResolvedValueOnce({ kind: "not_found" });
+    const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+
+  it("race は 409", async () => {
+    mocks.requestTeardown.mockResolvedValueOnce({
+      kind: "race",
+      reason: "tenant_or_status_mismatch",
+    });
+    const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
+    expect(res.status).toBe(409);
+  });
+
+  it("不正な jobId は 400 (requestTeardown を呼ばない)", async () => {
+    const res = await app.request("/deployments/not-a-ulid", { method: "DELETE" });
+    expect(res.status).toBe(400);
+    expect(mocks.requestTeardown).not.toHaveBeenCalled();
+  });
+
+  it("内部エラーは 500", async () => {
+    mocks.requestTeardown.mockRejectedValueOnce(new Error("boom"));
+    const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
     expect(res.status).toBe(500);
   });
 });


### PR DESCRIPTION
## 概要

手動 teardown を実装。新たな Lambda / IAM 権限を追加せず、`expiresAt` を現在時刻に書き換えて既存の StatusUpdater (1 min) に拾わせる方式 — auto-teardown TTL と同じ機械を流用する。

```
DELETE /deployments/:jobId
   ↓
Deploy API Lambda: DDB Update (expiresAt = now)
   ↓ (0〜60 秒)
StatusUpdater が expired を検出 → DeleteStack → DELETING
   ↓
DELETE_COMPLETE → DELETED + DeployDeleted publish
   ↓
UI 5 秒 polling が反映
```

## 追加

### Backend `handlers/deploy-handler/`
- `delete.ts` 新規: `requestTeardown(shared, tenantId, jobId, nowMs)` — GetItem で tenantId 一致を確認 → `expiresAt = floor(nowMs/1000)` で Update
- `index.ts`: `DELETE /deployments/:jobId` route。202 / 200 (already_deleted) / 404 / 409 (race) / 400 / 500

### CDK
- `deploy-api-gateway.ts`: route methods に DELETE 追加、CORS allowMethods に DELETE 追加

### Frontend `apps/application-admin-console`
- `deploy-client.ts`: `deleteDeployment(client, jobId)`
- `DeploymentDetail.tsx`: Header に「削除」ボタン + 確認 Modal (Stack 名 prefix 表示で誤削除防止) + DELETING / DELETED 中は disable + 送信後 polling 続行

## 設計判断

### 新しい CFn 権限を Deploy API Lambda に渡さない
StatusUpdater が既に `cloudformation:DeleteStack` を持っている (PR-E)。Deploy API は DDB Update のみで完結 → 攻撃面の最小化。

### tenantId 不一致は 404
存在を漏らさない。total enumeration による cross-tenant inference を防ぐ。

### already_deleted は 200 (no-op) で冪等
連打や clock skew で複数回 DELETE が来ても race にせず success として返す。

## Tests (127 → 140 backend, 55 → 57 frontend)

- `deploy-delete.test.ts` 7 ケース
- `deploy-handler-routes.test.ts` 6 ケース追加
- `problem-deploy-backend-stack.test.ts`: HTTP API DELETE route 検証
- `deploy-client.test.ts` 2 ケース追加

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜F3.5 | deploy backend / UI / cross-stack 配線 | merged |
| #449 | Cognito tenant attr writeAttributes 制限 (security) | review |
| **G (本 PR)** | DELETE | review |
| H1 | participant portal hosting | parallel WIP |
| H2 | PortalUpdater Lambda | TODO |

## Test plan

- [x] `bun run test` (backend 140 + frontend 57 + 他 113 全 pass)
- [x] CDK synth (DELETE route 含む)
- [ ] dev 環境: 削除ボタン → 確認モーダル → DELETE 送信 → 1 分後に DELETING → DELETED へ自動遷移を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)