### PR TITLE
feat(deploy): Participant Portal hosting (S3 + CloudFront) — PR-H1

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -155,12 +155,24 @@ const deployApiCorsOrigins = deployApiCorsOriginsRaw
       .map((s) => s.trim())
       .filter((s) => s.length > 0)
   : undefined;
+const enableParticipantPortal = process.env.CDK_PARAM_ENABLE_PARTICIPANT_PORTAL === "true";
+const participantPortalEventTitle =
+  process.env.CDK_PARAM_PARTICIPANT_PORTAL_EVENT_TITLE || "TenkaCloud Battle";
+const participantPortalRuntimeConfig = enableParticipantPortal
+  ? {
+      eventTitle: participantPortalEventTitle,
+      eventRegion: awsRegion ?? "ap-northeast-1",
+      mode: "dev-mock" as const,
+    }
+  : undefined;
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,
   eventBusArn: controlPlaneStack.eventBusArn,
   deployExternalId,
   deployApiCognito,
   deployApiCorsOrigins,
+  enableParticipantPortal,
+  participantPortalRuntimeConfig,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -10,6 +10,7 @@ import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
 import { getEnv } from "../lib/helper-functions";
+import type { ParticipantPortalMode } from "../lib/problem-deploy/participant-portal-hosting";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
@@ -156,13 +157,16 @@ const deployApiCorsOrigins = deployApiCorsOriginsRaw
       .filter((s) => s.length > 0)
   : undefined;
 const enableParticipantPortal = process.env.CDK_PARAM_ENABLE_PARTICIPANT_PORTAL === "true";
-const participantPortalEventTitle =
-  process.env.CDK_PARAM_PARTICIPANT_PORTAL_EVENT_TITLE || "TenkaCloud Battle";
-const participantPortalRuntimeConfig = enableParticipantPortal
+const participantPortalEventTitle = process.env.CDK_PARAM_PARTICIPANT_PORTAL_EVENT_TITLE;
+const participantPortal = enableParticipantPortal
   ? {
-      eventTitle: participantPortalEventTitle,
-      eventRegion: awsRegion ?? "ap-northeast-1",
-      mode: "dev-mock" as const,
+      runtimeConfig: participantPortalEventTitle
+        ? {
+            eventTitle: participantPortalEventTitle,
+            eventRegion: awsRegion ?? "ap-northeast-1",
+            mode: "dev-mock" satisfies ParticipantPortalMode,
+          }
+        : ("default-dev-mock" as const),
     }
   : undefined;
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
@@ -171,8 +175,7 @@ const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDep
   deployExternalId,
   deployApiCognito,
   deployApiCorsOrigins,
-  enableParticipantPortal,
-  participantPortalRuntimeConfig,
+  participantPortal,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -10,7 +10,7 @@ import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
 import { getEnv } from "../lib/helper-functions";
-import type { ParticipantPortalMode } from "../lib/problem-deploy/participant-portal-hosting";
+import type { ParticipantPortalRuntimeConfig } from "../lib/problem-deploy/participant-portal-hosting";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
@@ -158,16 +158,16 @@ const deployApiCorsOrigins = deployApiCorsOriginsRaw
   : undefined;
 const enableParticipantPortal = process.env.CDK_PARAM_ENABLE_PARTICIPANT_PORTAL === "true";
 const participantPortalEventTitle = process.env.CDK_PARAM_PARTICIPANT_PORTAL_EVENT_TITLE;
+const participantPortalRuntimeConfig: ParticipantPortalRuntimeConfig | "default-dev-mock" =
+  participantPortalEventTitle
+    ? {
+        eventTitle: participantPortalEventTitle,
+        eventRegion: awsRegion || "ap-northeast-1",
+        mode: "dev-mock",
+      }
+    : "default-dev-mock";
 const participantPortal = enableParticipantPortal
-  ? {
-      runtimeConfig: participantPortalEventTitle
-        ? {
-            eventTitle: participantPortalEventTitle,
-            eventRegion: awsRegion ?? "ap-northeast-1",
-            mode: "dev-mock" satisfies ParticipantPortalMode,
-          }
-        : ("default-dev-mock" as const),
-    }
+  ? { runtimeConfig: participantPortalRuntimeConfig }
   : undefined;
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -16,7 +16,7 @@ export type ParticipantPortalMode = "dev-mock" | "backend";
 
 export interface ParticipantPortalRuntimeConfig {
   /**
-   * Portal backend (PR-H2 で立てる Lambda Function URL) の base URL。
+   * Portal backend (Lambda Function URL) の base URL。
    * mode="dev-mock" のときは frontend が呼ばないので空文字 OK。
    */
   readonly apiBaseUrl?: string;
@@ -24,10 +24,15 @@ export interface ParticipantPortalRuntimeConfig {
   readonly eventRegion: string;
   /**
    * "dev-mock": frontend 単体動作 (auth 偽装)。"backend": 実 backend を呼ぶ。
-   * Portal backend が無い段階では "dev-mock" に倒す。
    */
   readonly mode: ParticipantPortalMode;
 }
+
+const DEFAULT_DEV_MOCK_RUNTIME_CONFIG = (region: string): ParticipantPortalRuntimeConfig => ({
+  eventTitle: "TenkaCloud Battle",
+  eventRegion: region,
+  mode: "dev-mock",
+});
 
 /**
  * 競技者向け Participant Portal を S3 + CloudFront で配信する Construct。
@@ -35,9 +40,6 @@ export interface ParticipantPortalRuntimeConfig {
  * 構造は ApplicationAdminConsoleHosting と同等 (S3 private + OAI + CloudFront +
  * SPA fallback)。dist 供給は build pipeline (`bun run --cwd apps/participant-portal
  * build` が `apps/participant-portal/dist` に出力) が担当。
- *
- * runtime-config.json は portal backend (PR-H2) が確定してから
- * `deployRuntimeConfig()` で配置する。
  */
 export class ParticipantPortalHosting extends Construct {
   public readonly distributionDomainName: string;
@@ -86,14 +88,14 @@ export class ParticipantPortalHosting extends Construct {
     });
   }
 
-  deployRuntimeConfig(props: ParticipantPortalRuntimeConfig): void {
+  deployRuntimeConfig(config: ParticipantPortalRuntimeConfig): void {
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [
         Source.jsonData("runtime-config.json", {
-          apiBaseUrl: (props.apiBaseUrl ?? "").replace(/\/$/, ""),
-          eventTitle: props.eventTitle,
-          eventRegion: props.eventRegion,
-          mode: props.mode,
+          apiBaseUrl: (config.apiBaseUrl ?? "").replace(/\/$/, ""),
+          eventTitle: config.eventTitle,
+          eventRegion: config.eventRegion,
+          mode: config.mode,
         }),
       ],
       destinationBucket: this.bucket,
@@ -103,3 +105,5 @@ export class ParticipantPortalHosting extends Construct {
     });
   }
 }
+
+export { DEFAULT_DEV_MOCK_RUNTIME_CONFIG };

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -1,0 +1,105 @@
+import * as path from "node:path";
+import { RemovalPolicy } from "aws-cdk-lib";
+import {
+  Distribution,
+  HttpVersion,
+  OriginAccessIdentity,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+
+export type ParticipantPortalMode = "dev-mock" | "backend";
+
+export interface ParticipantPortalRuntimeConfig {
+  /**
+   * Portal backend (PR-H2 で立てる Lambda Function URL) の base URL。
+   * mode="dev-mock" のときは frontend が呼ばないので空文字 OK。
+   */
+  readonly apiBaseUrl?: string;
+  readonly eventTitle: string;
+  readonly eventRegion: string;
+  /**
+   * "dev-mock": frontend 単体動作 (auth 偽装)。"backend": 実 backend を呼ぶ。
+   * Portal backend が無い段階では "dev-mock" に倒す。
+   */
+  readonly mode: ParticipantPortalMode;
+}
+
+/**
+ * 競技者向け Participant Portal を S3 + CloudFront で配信する Construct。
+ *
+ * 構造は ApplicationAdminConsoleHosting と同等 (S3 private + OAI + CloudFront +
+ * SPA fallback)。dist 供給は build pipeline (`bun run --cwd apps/participant-portal
+ * build` が `apps/participant-portal/dist` に出力) が担当。
+ *
+ * runtime-config.json は portal backend (PR-H2) が確定してから
+ * `deployRuntimeConfig()` で配置する。
+ */
+export class ParticipantPortalHosting extends Construct {
+  public readonly distributionDomainName: string;
+  public readonly distributionUrl: string;
+  private readonly bucket: Bucket;
+  private readonly distribution: Distribution;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.bucket = new Bucket(this, "SiteBucket", {
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    const oai = new OriginAccessIdentity(this, "OAI");
+    this.bucket.grantRead(oai);
+
+    this.distribution = new Distribution(this, "Distribution", {
+      defaultBehavior: {
+        origin: new S3Origin(this.bucket, { originAccessIdentity: oai }),
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      },
+      defaultRootObject: "index.html",
+      httpVersion: HttpVersion.HTTP2,
+      priceClass: PriceClass.PRICE_CLASS_100,
+      errorResponses: [
+        { httpStatus: 403, responseHttpStatus: 200, responsePagePath: "/index.html" },
+        { httpStatus: 404, responseHttpStatus: 200, responsePagePath: "/index.html" },
+      ],
+    });
+
+    this.distributionDomainName = this.distribution.distributionDomainName;
+    this.distributionUrl = `https://${this.distribution.distributionDomainName}`;
+
+    const distDir = path.join(__dirname, "..", "..", "..", "apps", "participant-portal", "dist");
+    new BucketDeployment(this, "SiteDeployment", {
+      sources: [Source.asset(distDir)],
+      destinationBucket: this.bucket,
+      distribution: this.distribution,
+      distributionPaths: ["/*"],
+      prune: false,
+    });
+  }
+
+  deployRuntimeConfig(props: ParticipantPortalRuntimeConfig): void {
+    new BucketDeployment(this, "RuntimeConfigDeployment", {
+      sources: [
+        Source.jsonData("runtime-config.json", {
+          apiBaseUrl: (props.apiBaseUrl ?? "").replace(/\/$/, ""),
+          eventTitle: props.eventTitle,
+          eventRegion: props.eventRegion,
+          mode: props.mode,
+        }),
+      ],
+      destinationBucket: this.bucket,
+      distribution: this.distribution,
+      distributionPaths: ["/runtime-config.json"],
+      prune: false,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -7,6 +7,10 @@ import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
 import { DeploymentsTable } from "./deployments-table";
+import {
+  ParticipantPortalHosting,
+  type ParticipantPortalRuntimeConfig,
+} from "./participant-portal-hosting";
 import { StatusUpdaterLambda } from "./status-updater-lambda";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
@@ -39,6 +43,18 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * fetch するため必須。
    */
   readonly deployApiCorsOrigins?: readonly string[];
+  /**
+   * 競技者向け Participant Portal を S3 + CloudFront で配信するかのフラグ。
+   * `true` のとき `ParticipantPortalHosting` を作成、`runtimeConfig` で
+   * runtime-config.json を初期配置する。
+   */
+  readonly enableParticipantPortal?: boolean;
+  /**
+   * Participant Portal の runtime-config.json に書き出す値。
+   * `enableParticipantPortal` が `true` のときのみ参照される。
+   * 未指定時は `mode="dev-mock"` のサンプル値が入る (Portal backend が無い段階用)。
+   */
+  readonly participantPortalRuntimeConfig?: ParticipantPortalRuntimeConfig;
 }
 
 /**
@@ -55,6 +71,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
   public readonly deployWorkerRoleArn: string;
   public readonly deployApiUrl: string;
   public readonly deployApiGatewayUrl?: string;
+  public readonly participantPortalUrl?: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -97,6 +114,22 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         corsAllowOrigins: props.deployApiCorsOrigins ?? ["*"],
       });
       this.deployApiGatewayUrl = apiGw.httpApi.apiEndpoint;
+    }
+
+    if (props.enableParticipantPortal) {
+      const portal = new ParticipantPortalHosting(this, "ParticipantPortal");
+      portal.deployRuntimeConfig(
+        props.participantPortalRuntimeConfig ?? {
+          eventTitle: "TenkaCloud Battle",
+          eventRegion: this.region,
+          mode: "dev-mock",
+        },
+      );
+      this.participantPortalUrl = portal.distributionUrl;
+      new CfnOutput(this, "ParticipantPortalUrl", {
+        value: portal.distributionUrl,
+        description: "Participant Portal CloudFront URL.",
+      });
     }
 
     this.deploymentsTableName = deployments.table.tableName;

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -8,6 +8,7 @@ import { DeployWorkerLambda } from "./deploy-worker-lambda";
 import { DeployWorkerRole } from "./deploy-worker-role";
 import { DeploymentsTable } from "./deployments-table";
 import {
+  DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
   ParticipantPortalHosting,
   type ParticipantPortalRuntimeConfig,
 } from "./participant-portal-hosting";
@@ -44,17 +45,15 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    */
   readonly deployApiCorsOrigins?: readonly string[];
   /**
-   * 競技者向け Participant Portal を S3 + CloudFront で配信するかのフラグ。
-   * `true` のとき `ParticipantPortalHosting` を作成、`runtimeConfig` で
-   * runtime-config.json を初期配置する。
+   * 競技者向け Participant Portal を S3 + CloudFront で配信する。指定された
+   * `runtimeConfig` が runtime-config.json として配置される。Portal backend が
+   * 無い段階では `runtimeConfig: "default-dev-mock"` を渡せば mode="dev-mock"
+   * のサンプル値で起動する (frontend 単体動作)。
+   * 未指定なら Portal Hosting を作らない。
    */
-  readonly enableParticipantPortal?: boolean;
-  /**
-   * Participant Portal の runtime-config.json に書き出す値。
-   * `enableParticipantPortal` が `true` のときのみ参照される。
-   * 未指定時は `mode="dev-mock"` のサンプル値が入る (Portal backend が無い段階用)。
-   */
-  readonly participantPortalRuntimeConfig?: ParticipantPortalRuntimeConfig;
+  readonly participantPortal?: {
+    readonly runtimeConfig: ParticipantPortalRuntimeConfig | "default-dev-mock";
+  };
 }
 
 /**
@@ -116,15 +115,13 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       this.deployApiGatewayUrl = apiGw.httpApi.apiEndpoint;
     }
 
-    if (props.enableParticipantPortal) {
+    if (props.participantPortal) {
       const portal = new ParticipantPortalHosting(this, "ParticipantPortal");
-      portal.deployRuntimeConfig(
-        props.participantPortalRuntimeConfig ?? {
-          eventTitle: "TenkaCloud Battle",
-          eventRegion: this.region,
-          mode: "dev-mock",
-        },
-      );
+      const runtimeConfig =
+        props.participantPortal.runtimeConfig === "default-dev-mock"
+          ? DEFAULT_DEV_MOCK_RUNTIME_CONFIG(this.region)
+          : props.participantPortal.runtimeConfig;
+      portal.deployRuntimeConfig(runtimeConfig);
       this.participantPortalUrl = portal.distributionUrl;
       new CfnOutput(this, "ParticipantPortalUrl", {
         value: portal.distributionUrl,

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -1,9 +1,29 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 
 const FAKE_BUS_ARN = "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus";
+
+const portalDistDir = path.join(__dirname, "..", "..", "apps", "participant-portal", "dist");
+
+/**
+ * ParticipantPortalHosting は Source.asset で apps/participant-portal/dist を
+ * 参照する。CI / クリーンクローン時に未 build のことがあるので、最小 placeholder
+ * を作って synth が通るようにする (実 build は install.sh / `bun run build` 経由で
+ * 上書きされる)。
+ */
+function ensurePortalPlaceholderDist() {
+  if (!fs.existsSync(portalDistDir)) {
+    fs.mkdirSync(portalDistDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(portalDistDir, "index.html"),
+      "<!doctype html><html><body>placeholder</body></html>",
+    );
+  }
+}
 
 function synth(
   overrides?: Partial<ConstructorParameters<typeof ProblemDeployBackendStack>[2]>,
@@ -328,6 +348,68 @@ describe("ProblemDeployBackendStack", () => {
         Match.objectLike({
           CorsConfiguration: Match.objectLike({
             AllowOrigins: ["http://localhost:5173", "https://example.com"],
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("Participant Portal hosting", () => {
+    beforeAll(() => ensurePortalPlaceholderDist());
+
+    it("enableParticipantPortal=false (default) なら CloudFront / S3 Bucket を 1 個も増やさないべき", () => {
+      const tpl = synth();
+      tpl.resourceCountIs("AWS::CloudFront::Distribution", 0);
+      tpl.resourceCountIs("AWS::S3::Bucket", 0);
+    });
+
+    it("enableParticipantPortal=true で S3 Bucket / CloudFront Distribution / OAI を 1 セット作るべき", () => {
+      const tpl = synth({ enableParticipantPortal: true });
+      tpl.resourceCountIs("AWS::S3::Bucket", 1);
+      tpl.resourceCountIs("AWS::CloudFront::Distribution", 1);
+      tpl.resourceCountIs("AWS::CloudFront::CloudFrontOriginAccessIdentity", 1);
+    });
+
+    it("enableParticipantPortal=true なら ParticipantPortalUrl Output を持つべき", () => {
+      const tpl = synth({ enableParticipantPortal: true });
+      tpl.hasOutput("ParticipantPortalUrl", {});
+    });
+
+    it("S3 Bucket は public access を完全に block すべき (Portal も同様)", () => {
+      const tpl = synth({ enableParticipantPortal: true });
+      tpl.hasResourceProperties(
+        "AWS::S3::Bucket",
+        Match.objectLike({
+          PublicAccessBlockConfiguration: {
+            BlockPublicAcls: true,
+            BlockPublicPolicy: true,
+            IgnorePublicAcls: true,
+            RestrictPublicBuckets: true,
+          },
+        }),
+      );
+    });
+
+    it("CloudFront Distribution は HTTPS リダイレクトと SPA fallback (403/404 → /index.html 200) を持つべき", () => {
+      const tpl = synth({ enableParticipantPortal: true });
+      tpl.hasResourceProperties(
+        "AWS::CloudFront::Distribution",
+        Match.objectLike({
+          DistributionConfig: Match.objectLike({
+            DefaultCacheBehavior: Match.objectLike({ ViewerProtocolPolicy: "redirect-to-https" }),
+            DefaultRootObject: "index.html",
+            CustomErrorResponses: Match.arrayWith([
+              Match.objectLike({
+                ErrorCode: 403,
+                ResponseCode: 200,
+                ResponsePagePath: "/index.html",
+              }),
+              Match.objectLike({
+                ErrorCode: 404,
+                ResponseCode: 200,
+                ResponsePagePath: "/index.html",
+              }),
+            ]),
           }),
         }),
       );

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -357,26 +357,26 @@ describe("ProblemDeployBackendStack", () => {
   describe("Participant Portal hosting", () => {
     beforeAll(() => ensurePortalPlaceholderDist());
 
-    it("enableParticipantPortal=false (default) なら CloudFront / S3 Bucket を 1 個も増やさないべき", () => {
+    it("participantPortal 未指定 (default) なら CloudFront / S3 Bucket を 1 個も増やさないべき", () => {
       const tpl = synth();
       tpl.resourceCountIs("AWS::CloudFront::Distribution", 0);
       tpl.resourceCountIs("AWS::S3::Bucket", 0);
     });
 
-    it("enableParticipantPortal=true で S3 Bucket / CloudFront Distribution / OAI を 1 セット作るべき", () => {
-      const tpl = synth({ enableParticipantPortal: true });
+    it("participantPortal 指定で S3 Bucket / CloudFront Distribution / OAI を 1 セット作るべき", () => {
+      const tpl = synth({ participantPortal: { runtimeConfig: "default-dev-mock" } });
       tpl.resourceCountIs("AWS::S3::Bucket", 1);
       tpl.resourceCountIs("AWS::CloudFront::Distribution", 1);
       tpl.resourceCountIs("AWS::CloudFront::CloudFrontOriginAccessIdentity", 1);
     });
 
-    it("enableParticipantPortal=true なら ParticipantPortalUrl Output を持つべき", () => {
-      const tpl = synth({ enableParticipantPortal: true });
+    it("participantPortal 指定なら ParticipantPortalUrl Output を持つべき", () => {
+      const tpl = synth({ participantPortal: { runtimeConfig: "default-dev-mock" } });
       tpl.hasOutput("ParticipantPortalUrl", {});
     });
 
     it("S3 Bucket は public access を完全に block すべき (Portal も同様)", () => {
-      const tpl = synth({ enableParticipantPortal: true });
+      const tpl = synth({ participantPortal: { runtimeConfig: "default-dev-mock" } });
       tpl.hasResourceProperties(
         "AWS::S3::Bucket",
         Match.objectLike({
@@ -391,7 +391,7 @@ describe("ProblemDeployBackendStack", () => {
     });
 
     it("CloudFront Distribution は HTTPS リダイレクトと SPA fallback (403/404 → /index.html 200) を持つべき", () => {
-      const tpl = synth({ enableParticipantPortal: true });
+      const tpl = synth({ participantPortal: { runtimeConfig: "default-dev-mock" } });
       tpl.hasResourceProperties(
         "AWS::CloudFront::Distribution",
         Match.objectLike({


### PR DESCRIPTION
## 概要

競技者向け Participant Portal の静的ホスティングを追加。既に存在する `apps/participant-portal` (Vite + React + Cloudscape) を S3 + CloudFront で配信し、`runtime-config.json` で event タイトル / mode を注入する。

Portal backend (PR-H2 の予定) は未実装なので mode は `dev-mock` 既定。frontend は backend を呼ばず、参加者の遷移と画面のみ確認できる状態で MVP デモが取れる。

```
apps/participant-portal/dist
   ↓
S3 (private + OAI) + CloudFront (HTTPS / SPA fallback / HTTP2)
   ↓
runtime-config.json (eventTitle, eventRegion, mode="dev-mock")
   ↓
CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true で opt-in
```

## 追加

### CDK
- **`participant-portal-hosting.ts`** 新規: `ApplicationAdminConsoleHosting` と同等の S3 (private) + OAI + CloudFront (HTTPS redirect / SPA fallback) を立てる Construct。`deployRuntimeConfig({apiBaseUrl?, eventTitle, eventRegion, mode})` で runtime-config.json を配置
- **`problem-deploy-backend-stack.ts`**: optional props `enableParticipantPortal` / `participantPortalRuntimeConfig` 追加。flag が true のときのみ Hosting + runtime-config を作成し `CfnOutput ParticipantPortalUrl` を公開

### bin
- `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` env / `CDK_PARAM_PARTICIPANT_PORTAL_EVENT_TITLE` env

## 設計判断

### 既定 OFF
`enableParticipantPortal` は default false。既存スタックを deploy しても新リソースは増えない (CloudFront / S3 が 0 個のままを test で assert)。導入はオプトイン。

### 単一スタックに同居
既存の `ProblemDeployBackendStack` に Hosting を相乗りさせる。Deploy / Status / Portal は同じ deploy ライフサイクルで配ることが多いため、Stack 分割を避けて依存解決をシンプルに保つ。Portal backend (PR-H2) で Lambda / DDB が増えても同 Stack に収まる規模の想定。

### Portal backend 未接続
mode 既定 `dev-mock` で frontend が backend を呼ばない。PR-H2 で Lambda Function URL を立てたら mode を `backend` に切り替え、`apiBaseUrl` を runtime-config に注入する想定。

## Tests (127 → 132, +5)

- `enableParticipantPortal=false` (default) で CloudFront / S3 を増やさない
- `=true` で Bucket / Distribution / OAI を 1 セット作る
- `ParticipantPortalUrl` Output を持つ
- S3 Bucket は public access 完全 block
- CloudFront は HTTPS redirect + SPA fallback (403/404 → /index.html 200)

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜F3.5 | deploy backend / UI / cross-stack 配線 | merged |
| #449 | Cognito tenant attr writeAttributes 制限 (security) | review |
| #450 (PR-G) | DELETE | review |
| **PR-H1 (本 PR)** | Participant Portal hosting | review |
| PR-H2 | Portal backend Lambda + auth + apiBaseUrl 配線 | TODO |

## Test plan

- [x] `bun --filter @TenkaCloud/infrastructure test` (132 pass)
- [x] CDK synth (Hosting opt-in / opt-out 両方)
- [ ] dev 環境: \`CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true\` で deploy → CloudFront URL に access して participant-portal が `dev-mock` モードで表示されることを目視
- [ ] runtime-config.json が CloudFront 経由で fetch されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional participant portal feature that can be deployed alongside backend infrastructure with configurable event title and region settings, including secure HTTPS hosting and single-page application routing.

* **Tests**
  * Added test coverage for participant portal deployment, security configurations, and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->