### PR TITLE
docs: rewrite CLAUDE.md / AGENTS.md / README.md and refresh skills

### DIFF
--- a/.claude/skills/create-problem/SKILL.md
+++ b/.claude/skills/create-problem/SKILL.md
@@ -1,196 +1,168 @@
 ---
 name: create-problem
-description: Create a new TenkaCloud problem (GameDay or JAM) with the standard directory structure. Generates CloudFormation template, deploy script, and README.
+description: TenkaCloud の問題ディレクトリ (problems/<category>/<id>/) を metadata.json + template.yaml の規約で生成する。Battle (リアルタイム対戦) または Challenge (個別演習) の雛形を作る。
+allowed-tools: Bash(make validate-problems:*), Read, Write, Edit
 ---
 
-Create a new TenkaCloud problem in the standard format under `problems/`. The user provides problem requirements; you scaffold all required files.
+# create-problem
 
-## Standard Directory Structure
+TenkaCloud に新しい問題を追加するスキル。**正本は [`problems/README.md`](../../../problems/README.md) と [`problems/SCHEMA.json`](../../../problems/SCHEMA.json)**。1 ディレクトリ 1 問題、`metadata.json` と `template.yaml` の 2 ファイルがあれば成立する。
 
-All problems follow this layout regardless of type:
-
-```
-problems/{type}/{problem-name}/
-├── README.md              # 必須: 問題説明・スコアリング・デプロイ手順
-├── problem.yaml           # 必須: プラットフォーム用メタデータ（JAM のみ）
-├── cloudformation/
-│   └── {name}.yaml        # 必須: CloudFormation テンプレート（1ファイルで完結）
-├── api/                   # 任意: サーバーサイドコード（GameDay で API サーバーが必要な場合）
-├── frontend/              # 任意: 静的サイト（GameDay で S3 ウェブサイトが必要な場合）
-└── scripts/
-    └── deploy.sh          # 必須: デプロイスクリプト（./deploy.sh で動く）
-```
-
-## Step 1: Gather Requirements
-
-Ask the user (or infer from context) the following:
-
-1. **Type**: `gameday` or `jam`
-2. **Problem name** (slug): e.g. `security-battle-royale`, `s3-secure-bucket`
-3. **Title** (Japanese OK): e.g. "S3 バケットセキュリティ強化"
-4. **Difficulty**: `easy` / `medium` / `hard` / `400` (GameDay level)
-5. **Category**: `security` / `architecture` / `cost` / `reliability` / `performance` / `operations`
-6. **AWS services used**: list of services
-7. **Scenario / description**: what the player needs to do
-8. **Scoring criteria**: what tasks/conditions earn points
-9. **Estimated play time**: e.g. 30分, 240分
-
-## Step 2: Create README.md
-
-```markdown
-# {Title}
-
-| 項目 | 内容 |
-|------|------|
-| 種別 | {type: JAM（構築型）or GameDay（攻撃・防御型）} |
-| 難易度 | {difficulty} |
-| 想定時間 | {estimated time} |
-| AWSサービス | {services} |
-
-## 概要
-
-{scenario description}
-
-## 採点基準
-
-| タスク | 配点 |
-|--------|------|
-| {task 1} | {points} |
-| {task 2} | {points} |
-
-## デプロイ手順
-
-```bash
-STACK_NAME={problem-name} ./scripts/deploy.sh
-```
-
-## 検証
-
-```bash
-aws cloudformation describe-stacks --stack-name {problem-name}
-```
+## ディレクトリ規約
 
 ```
+problems/<category>/<id>/
+├── metadata.json     # 必須: UI カタログと deploy パイプラインの正本
+├── template.yaml     # 必須: CFn ペライチ (deploy 本体)
+├── api/              # 任意: サーバーサイド実装 (Battle で API が要るとき)
+├── frontend/         # 任意: 静的サイト (Battle で S3 frontend が要るとき)
+└── local/            # 任意: docker-compose 等のローカル開発資材
+```
 
-## Step 3: Create problem.yaml (JAM only)
+`<category>` はディレクトリ命名上の分類（現状 `gameday/` を使っている）。`metadata.json` 内の `category` フィールドは **`Battle` か `Challenge`** の 2 値で、こちらが UI とパイプラインの正本。
+
+## Step 1 — 要件ヒアリング
+
+ユーザーから / 文脈から次を集める。不足はその場で訊く。
+
+1. **category** — `Battle` (リアルタイム対戦) / `Challenge` (個別演習・常設チャレンジ)
+2. **id** — kebab-case 英小文字 (例: `security-battle-royale`、`s3-secure-bucket`)。3〜32 文字。ディレクトリ名と一致させる
+3. **name** — UI 表示名 (日本語可、80 文字以内)
+4. **difficulty** — 1 (入門) 〜 5 (エキスパート)
+5. **estimatedDuration** — 自由文字列 (例: `60〜90 分`)
+6. **shortDescription** — カード用 1 行 (200 文字以内)
+7. **description** — 詳細ページ用の長文 (改行 OK)
+8. **tags** — kebab-case (例: `security`, `web`, `sql-injection`)
+9. **exposedPorts** — deploy 後に参加者へ払い出すポート群 (`{port, name}` の配列)
+10. **learningGoals** — 想定学習目的の箇条書き
+11. **AWS リソース概要** — `template.yaml` で何を立てるか (EC2 / RDS / S3 / Lambda 等)
+12. **status** — 通常は `draft` で作成、レビュー後 `ready`
+
+## Step 2 — `metadata.json` を書く
+
+`problems/SCHEMA.json` に従う。スキーマ補完のため `$schema` を相対パスで先頭に置く。
+
+```json
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "<id>",
+  "name": "<name>",
+  "category": "Battle",
+  "status": "draft",
+  "difficulty": 3,
+  "estimatedDuration": "60〜90 分",
+  "shortDescription": "<カード用 1 行>",
+  "description": "<長文。改行可>",
+  "tags": ["security", "web"],
+  "exposedPorts": [
+    { "port": 80, "name": "frontend (nginx)" },
+    { "port": 8080, "name": "api (Flask)" }
+  ],
+  "learningGoals": [
+    "<目的 1>",
+    "<目的 2>"
+  ],
+  "cfnTemplate": "template.yaml"
+}
+```
+
+## Step 3 — `template.yaml` を書く
+
+CloudFormation **ペライチ**。deploy パイプラインがこのファイル単独を競技者アカウントの CFn にアップロードする。次の規約を守る。
+
+### 必須パラメータ
+
+deploy パイプラインがすべての問題テンプレートに対して同じ引数で起動できるよう、共通パラメータをサポートする。
+
+| パラメータ           | 必須 | 用途                                                                       |
+| -------------------- | ---- | -------------------------------------------------------------------------- |
+| `NamePrefix`         | ○    | `tc-{problemSlug}-{teamSlug}` 形式の共通リソース prefix                    |
+| `AllowedCidr`        | -    | 公開ポートを許可する CIDR (default `0.0.0.0/0`)                            |
+| 問題固有パラメータ   | -    | `DbPassword` など、問題ごとに自由に追加してよい                            |
+
+### 命名規約 (衝突回避)
+
+同一 (Account, Region) に複数チームの問題スタックが共存する。**全リソース名 / タグ / グループ名は `${NamePrefix}` を冠する**。
 
 ```yaml
-id: {problem-name}
-title: {title}
-type: jam
-category: {category}
-difficulty: {difficulty}
-
-metadata:
-  author: TenkaCloud Team
-  version: 1.0.0
-  createdAt: "{YYYY-MM-DD}"
-  updatedAt: "{YYYY-MM-DD}"
-  tags: [{tag1}, {tag2}]
-  license: MIT
-
-description:
-  overview: |
-    {scenario}
-
-scoring:
-  totalPoints: {total}
-  criteria:
-    - id: task-1
-      description: "{task 1 description}"
-      points: {points}
-      verification:
-        type: cloudformation-output | aws-api | manual
-        check: "{what to check}"
-```
-
-## Step 4: Create cloudformation/{name}.yaml
-
-Write a self-contained CloudFormation template that:
-
-- Provisions the infrastructure the player needs to **start** with (intentionally misconfigured / incomplete for JAM)
-- OR provisions the full competitive environment for GameDay
-- Uses `Parameters` for customization (e.g. `StackName`, `VpcId`)
-- Exports important values in `Outputs` for verification
-
-**JAM template pattern** (broken → player fixes it):
-
-```yaml
-AWSTemplateFormatVersion: "2010-09-09"
-Description: "{problem title} — starter environment with issues to fix"
-
 Parameters:
-  Environment:
+  NamePrefix:
     Type: String
-    Default: dev
+    Description: "tc-<problem>-<team> 形式の共通 prefix"
+  AllowedCidr:
+    Type: String
+    Default: "0.0.0.0/0"
 
 Resources:
-  # ... intentionally misconfigured resources ...
+  MyVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+```
 
+### 必須 Outputs
+
+UI / 運営側で扱いやすいよう、最低でも次の Output を含める。
+
+- 参加者向けエンドポイント URL (`FrontendUrl` / `ApiUrl` 等)
+- 運営側のデバッグ用識別子 (`InstanceId` 等)
+- `NamePrefix` (deploy 時の引数 echo)
+
+```yaml
 Outputs:
-  ResourceArn:
-    Description: "Resource ARN for scoring verification"
-    Value: !GetAtt Resource.Arn
+  NamePrefix:
+    Description: "Deploy 時に渡された prefix (echo)"
+    Value: !Ref NamePrefix
+  FrontendUrl:
+    Description: "参加者向け frontend URL"
+    Value: !Sub "http://${MyEip}/"
 ```
 
-**GameDay template pattern** (full working environment, intentionally vulnerable):
+## Step 4 — 任意の補助ディレクトリ
 
-- Same as `security-battle-royale/cloudformation/team-stack.yaml` — provision EC2, RDS, S3, IAM per team
+問題実装の都合で次を置いてよい。**規約ではなく自由領域** なので、必要なものだけ作る。
 
-## Step 5: Create scripts/deploy.sh
+- `api/` — サーバーサイドコード (Flask / Express 等)
+- `frontend/` — 静的サイト
+- `local/` — docker-compose や開発用スクリプト
 
-For JAM problems, use the standard template:
+## Step 5 — 検証
+
+`make validate-problems` で `problems/SCHEMA.json` に対して `metadata.json` を検証する。CI でも走るので、ここで通らないと PR がブロックされる。
 
 ```bash
-#!/bin/bash
-set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROBLEM_DIR="$(dirname "$SCRIPT_DIR")"
-PROBLEM_NAME="$(basename "$PROBLEM_DIR")"
-STACK_NAME="${STACK_NAME:-$PROBLEM_NAME}"
-AWS_REGION="${AWS_REGION:-us-east-1}"
-CFN_TEMPLATE=$(ls "$PROBLEM_DIR"/cloudformation/*.yaml | head -1)
-echo "Deploying $PROBLEM_NAME → $STACK_NAME ($AWS_REGION)"
+make validate-problems
+```
+
+実 deploy の動作確認は競技者アカウントで:
+
+```bash
 aws cloudformation deploy \
-  --template-file "$CFN_TEMPLATE" \
-  --stack-name "$STACK_NAME" \
-  --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-  --region "$AWS_REGION"
-echo "✓ Done"
-aws cloudformation describe-stacks \
-  --stack-name "$STACK_NAME" --region "$AWS_REGION" \
-  --query "Stacks[0].Outputs" --output table 2>/dev/null || true
+  --template-file problems/<category>/<id>/template.yaml \
+  --stack-name tc-<id>-test \
+  --parameter-overrides NamePrefix=tc-<id>-test \
+  --capabilities CAPABILITY_NAMED_IAM
 ```
 
-For GameDay problems, follow the pattern in `security-battle-royale/scripts/deploy.sh`.
+## チェックリスト
 
-## Step 6: Make deploy.sh executable
+雛形作成後、次を確認する。
 
-Always run:
+- [ ] `metadata.json` の `id` がディレクトリ名と完全一致
+- [ ] `category` が `Battle` か `Challenge` (大文字始まり)
+- [ ] `cfnTemplate` で参照する `template.yaml` が同ディレクトリにある
+- [ ] `template.yaml` の Parameters に `NamePrefix` を含む
+- [ ] 全リソース名・タグに `${NamePrefix}` が冠されている
+- [ ] Outputs に参加者向け URL と `NamePrefix` echo がある
+- [ ] `make validate-problems` が通る
+- [ ] `status` は `draft` で作成（ready は別 PR でレビュー後に上げる）
 
-```bash
-chmod +x problems/{type}/{name}/scripts/deploy.sh
-```
+## 参考
 
-## Quality Checklist
-
-Before finishing, verify:
-
-- [ ] `cloudformation/*.yaml` is valid YAML (no syntax errors)
-- [ ] CFn template has `AWSTemplateFormatVersion` and `Description`
-- [ ] All resources are tagged with meaningful tags
-- [ ] `Outputs` exports enough info for scoring verification
-- [ ] `scripts/deploy.sh` is executable and uses `STACK_NAME` / `AWS_REGION` env vars
-- [ ] `README.md` has scoring criteria table
-- [ ] Problem path is `problems/{gameday|jam}/{problem-name}/`
-
-## Example invocation
-
-User: "S3 バケットが公開設定になってる問題を作って、プレーヤーが適切なアクセス制限を設定する JAM 問題"
-
-You should create:
-
-- `problems/jam/s3-secure-bucket/README.md`
-- `problems/jam/s3-secure-bucket/problem.yaml`
-- `problems/jam/s3-secure-bucket/cloudformation/s3-secure-bucket.yaml` (with `BlockPublicAcls: false` etc.)
-- `problems/jam/s3-secure-bucket/scripts/deploy.sh`
+- 実例: [`problems/gameday/security-battle-royale/`](../../../problems/gameday/security-battle-royale/) — Battle 問題の参考実装
+- スキーマ: [`problems/SCHEMA.json`](../../../problems/SCHEMA.json)
+- 規約正本: [`problems/README.md`](../../../problems/README.md)
+- 競技者アカウント側のセットアップ: [`infrastructure/templates/README.md`](../../../infrastructure/templates/README.md)

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: harness
+description: TenkaCloud architecture harness を実行し、docs/architecture/harness.md の invariant 違反を検出する。コミット前のアーキテクチャ整合チェック、リファクタ後の確認、不変条件・PR Discipline について訊かれたときに使う。
+allowed-tools: Bash(make harness:*), Bash(make harness-test:*), Bash(bun run .claude/harness/bin/architecture.ts:*)
+---
+
+# TenkaCloud Architecture Harness
+
+[`docs/architecture/harness.md`](../../../docs/architecture/harness.md) に固定した不変条件 (`INVARIANT_*`) と PR Discipline、Enforcement Rules との逸脱を機械的に検出するツール。実装は [`.claude/harness/`](../../../.claude/harness/)。
+
+## 実行方法
+
+Staged ファイルのみ (fast、pre-commit / PR ゲート向け):
+
+```bash
+make harness
+```
+
+リポジトリ全体:
+
+```bash
+bun run .claude/harness/bin/architecture.ts --fail-on=error
+```
+
+ハーネス自体のユニットテスト:
+
+```bash
+make harness-test
+```
+
+`--fail-on=error` 指定時、error が 1 件でもあれば exit 2 で終了する。`make before-commit` の前段で必ず通すこと。
+
+## 検査内容
+
+### Invariants (`docs/architecture/harness.md`)
+
+- `INVARIANT_CONTROL_PLANE_USES_SBT` — Control Plane は `@cdklabs/sbt-aws` の ControlPlane construct に乗せる
+- `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME` — Control Plane は tenant manager。runtime を持ち込まない
+- `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER` — テナント分離はインフラ層 (DDB PK / stack 分離) で実現
+- `INVARIANT_PR_SHIPS_WORKING_INCREMENT` — PR 単体で観察可能な機能が動く
+- `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE` — コード変更とテストを同じ PR に含める
+- `INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED` — PR body の `## Regression 分析` で壊しうる挙動を列挙
+- `INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED` — PR body の `## 物理影響` で CFn / 成果物の差分を列挙
+
+### Enforcement Rules
+
+- `secrets-manager-forbidden` — `@aws-sdk/client-secrets-manager` の import を error。SSM Parameter Store SecureString (Standard tier = 無料) を使うこと
+- `handler-must-not-call-fetch` — `lib/handlers/` 配下で `fetch(` 直接呼び出しを error。Service / Repository に閉じ込める
+- `authoritative-docs-present` — `docs/architecture/harness.md` に必須 invariant ID が並んでいるか
+- `agent-guides-run-harness` — `AGENTS.md` / `CLAUDE.md` から harness 実行が参照されているか
+
+## 落ちたときの対処
+
+1. 出力に `## Findings` で列挙される `ruleId` / `filePath` / `line` を確認
+2. `recommendation` 欄に修正方針が書いてある — それに従ってコードを直す
+3. invariant ID が `docs/architecture/harness.md` から欠落していると言われたら、harness.md に該当 ID の節を追加する (削るのではなく、原則として記述する)
+
+## 関連
+
+- `/tech-debt` (= `make tech-debt`) — 技術的負債スキャン (test smell / 結合 / fallback 検出)
+- [`docs/architecture/harness.md`](../../../docs/architecture/harness.md) — 不変条件の正本
+- [`.claude/harness/src/architecture.ts`](../../../.claude/harness/src/architecture.ts) — ルール実装

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: tech-debt
+description: TenkaCloud tech-debt analyzer を実行し、test smell / 結合漏れ / 握り潰し fallback 等の技術的負債を検出する。コード品質、テスト改善、リファクタの優先順位、技術的負債バックログを訊かれたときに使う。
+allowed-tools: Bash(make tech-debt:*), Bash(bun run .claude/harness/bin/tech-debt.ts:*)
+---
+
+# TenkaCloud Tech Debt Loop
+
+リポジトリ全体を静的解析し、優先度つきの技術的負債バックログを生成する。実装は [`.claude/harness/src/tech-debt.ts`](../../../.claude/harness/src/tech-debt.ts)。
+
+## 実行方法
+
+stdout に markdown レポート (デフォルト):
+
+```bash
+make tech-debt
+```
+
+`docs/tech-debt/backlog.md` と `backlog.json` に書き出し:
+
+```bash
+bun run .claude/harness/bin/tech-debt.ts --write
+```
+
+Staged ファイルのみ + severity gate (PR 前に走らせる用):
+
+```bash
+bun run .claude/harness/bin/tech-debt.ts --staged --fail-on=high
+```
+
+`--fail-on=high` 指定時、`high` か `critical` が 1 件でもあれば exit 2 で終了する。
+
+## 検出するパターン
+
+各 finding に severity (`critical` / `high` / `medium`) と修正方針 (`recommendation`) が付く。
+
+- **assertion-roulette** — 単一テストケース内の `expect` が多すぎて失敗原因が読み取れない
+- **auth-skip-leak** — `AUTH_SKIP` 判定が責務境界の外に漏れている
+- **direct-service-env** — フロントエンドから直接 `process.env.*API_URL` を読んでいる (`runtime-config.json` 経由にすべき)
+- **router-without-zod** — API router に入力検証 (Zod) が無い
+- **band-aid-fallback** — `console.warn("fallback to empty…")` のような握り潰しパターン
+- **direct-fetch-in-app** — `apps/*/app/` 配下で直接 `fetch()` を叩いている (api クライアントに閉じ込めるべき)
+
+## 落ちたときの対処
+
+1. `## Hotspots` で finding が集中するファイルを確認
+2. 同じ ruleId が複数出ている場合は、まずそのパターンを 1 箇所だけ模範実装で直して、残りを追従
+3. `--write` で `docs/tech-debt/backlog.md` を更新し、PR で「この PR で解消したもの / 残存」を明示
+
+## 関連
+
+- `/harness` (= `make harness`) — アーキテクチャ不変条件チェック
+- `docs/tech-debt/backlog.md` — `--write` で更新される永続バックログ
+- [`.claude/harness/src/tech-debt.ts`](../../../.claude/harness/src/tech-debt.ts) — ルール実装

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,126 @@
+<!--
+この template の意図は docs/architecture/harness.md の PR Discipline invariants を
+満たすための構造チェック。埋められない欄がある場合は PR 単位を見直すか DRAFT のまま残す。
+
+参考: https://zenn.dev/nttdata_tech/articles/8a010aff542625
+(AI-native 開発で欠けやすい: テスト観点・PR 単位・仕様の明示・デグレ検出)
+-->
+
+## この PR merge 後に何が動くようになるか
+
+<!--
+1 文。ユーザー観察可能な動作で書く。「バケットが作られる」ではなく
+「admin-console から tenant 作成するとメールが飛ぶ」のような、
+end-user / operator が確認できる振る舞い。
+
+「動く」= 商用運用に耐える状態。デモのためのハリボテ / 雑な MVP ではない。
+小さい scope であっても、テストされていて意図が明確で、そのまま本番に出しても
+壊れないレベルまで詰める。
+(INVARIANT_PR_SHIPS_WORKING_INCREMENT)
+
+書けない場合は PR 単位が適切でない。value を出す PR と束ねるか、rebase で順序を整えること。
+-->
+
+## なぜ今これが要るか
+
+<!-- 2-3 文。無いと何に困るか、他の解との比較、優先度の根拠 -->
+
+## 変更前 → 変更後のフロー
+
+<!--
+mermaid で実行経路の差分。consumer を全部描く。
+AWS リソース / event / API 呼び出しの順序を可視化する。
+-->
+
+```mermaid
+flowchart LR
+    A[before] --> B[...]
+```
+
+## 物理影響
+
+### AWS リソース (`make deploy`)
+
+<!--
+CFT 差分ベースで列挙する。「CFT 差分ゼロ」の場合も明示的に書く (reviewer に推論させない)。
+種別: CREATE / UPDATE in-place / REPLACE (= 一時中断) / DELETE / NO-OP
+-->
+
+| Stack | Resource | 種別 | 影響 |
+|---|---|---|---|
+| _Stack_ | _Resource_ | _種別_ | _影響_ |
+
+### ビルド成果物 (`make build`)
+
+<!-- TS / static site / script など、deploy 外で変わる成果物 -->
+
+| パッケージ | 変更 |
+|---|---|
+| _例: apps/admin-console_ | _ロジック変更のみ、AWS は不変_ |
+
+## ファイルごとの変更意図
+
+<!-- 全ファイル 1 行ずつ。「何を」ではなく「なぜ」を書く。触ったファイル数が 10 を超えたら PR 分割を検討 -->
+
+- `path/to/file.ts` — _変更意図_
+
+## Regression 分析
+
+<!--
+merge で壊しうる既存挙動を列挙する。未確認項目がある PR は DRAFT のまま残す
+(INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED)。
+
+確認方法は具体的に書く: grep / code read / test run / 実環境観察 など。
+「テストが通った」だけでは Regression 分析にならない。テストが existing behavior を
+カバーしているか自体を確認する必要がある。
+-->
+
+| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 / 対処 |
+|---|---|---|---|---|
+| 1 | _例: event consumer の契約_ | _例: `PROVISION_SUCCESS` 購読者_ | ✅ 確認済み / ❌ 未確認 | _grep で全 consumer を列挙: ..._ |
+
+## Rollback 手順
+
+<!-- この PR を revert したら何が起こるか、手順を書く。データ / サイドエフェクトの fate も明記 -->
+
+1. `git revert <merge-sha>` → 新 PR で main に戻す
+2. `make deploy` で CFT 差分を適用
+3. _既に発生したデータ / サイドエフェクトの fate: ..._
+
+## テスト戦略
+
+<!--
+この PR で touch したコードに対するテスト観点を宣言する。
+既存テストがカバーする範囲 / 新規テストで追加した観点 / 未カバー観点を明示。
+
+AI に丸投げで生成したテストは、実行パスを本当にカバーしているか必ず確認すること
+(article の指摘: AI生成テストは claim した code path を実際に exercise していないケースがある)。
+-->
+
+- 既存テストでカバーされる観点 — _列挙_
+- この PR で追加したテスト — _ファイル名 + 観点_
+- 未カバー (受容する理由) — _例: 実環境でしか確認できない部分は `## Verification (merge 後)` に回した_
+
+## Verification
+
+### Merge 前 (DRAFT 解除条件)
+
+- [ ] `make test`
+- [ ] `make typecheck`
+- [ ] `make lint`
+- [ ] `make harness`
+- [ ] `make synth` (対象 stack 全部)
+- [ ] Regression 分析の未確認がゼロ
+- [ ] merge で動くようになる機能を 1 文で書けている
+
+### Merge 後 (deploy 後 signal)
+
+- [ ] `make deploy` 成功
+- [ ] _検証コマンド / 観察 signal_
+- [ ] _tear-down で元に戻せるか (dev 環境)_
+
+## 既知の未完了 (scope 外)
+
+<!-- この PR で解決しない既知問題。scope から除外した理由、後続 issue / PR 案を明示 -->
+
+- _項目 1_ — _後続 PR で対処予定 / 別 issue_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,168 +1,133 @@
 # AGENTS.md — TenkaCloud
 
-AI エージェント（Claude Code, Codex 等）向けのガイド。このファイルは CLAUDE.md を補完する。
+AI エージェント (Claude Code, Codex CLI 等) 向けのガイド。プロダクト全体の正本は @CLAUDE.md。本ファイルは「エージェントとして動くときに守る運用ルール」だけに絞る。
 
-## セットアップ
+## 役割分担
 
-```bash
-make install    # 依存関係インストール（Bun 自動選択）
-make start      # 全サービス起動（Docker + UI + Backend 11 サービス）
-```
+- **インフラ (CDK / SBT / IAM / `infrastructure/templates/`) はユーザーが書く**。CDK スタック、IAM ポリシー、CFn テンプレートはユーザー判断で進める。提案は OK だが勝手に編集しない。
+- **アプリ (`apps/*`、`scripts/*` の orchestration、`problems/*`) はエージェントが進める**。テストを書き、`make before-commit` を通し、PR を出すところまで一気通貫で。
+- 不明点はまず repo を読む (`git log`, `git diff main...HEAD`, 関連 stack の test)。それでも判断つかないときだけユーザーに問う。
+
+## 一気通貫で動く
+
+中間で「次に進めていいですか？」と止まらない。タスクが完了するまで連続で進めて、最後に結果だけ報告する。途中で軌道修正があれば次の発話で受け取る。
+
+次の例外を除く。
+
+- 破壊的操作 (`rm -rf`、`git reset --hard`、強制 push、`make destroy`、本番への deploy)
+- 共有環境への push / PR 作成 / Slack 投稿等の外部副作用
+- シークレット (.env, AWS credentials) を扱う操作
+
+これらは確認を取る。
 
 ## 品質ゲート
 
-PR 作成前に以下を **この順序で** 実行する。
+PR 作成前に **この順序で** 通すこと。
 
 ```bash
-bun scripts/architecture-harness.ts --staged --fail-on=error
-make before-commit   # lint, format, typecheck, test (99％+ coverage), build
+make harness         # architecture invariant チェック (docs/architecture/harness.md)
+make before-commit   # lint (markdownlint + textlint + biome) / typecheck / test / validate-problems
 /review              # コードレビュー
 /security-review     # セキュリティレビュー
-/simplify            # コード重複・品質・効率チェック
+/simplify            # 重複・複雑度・効率の最終チェック
 ```
 
-**すべて通らない限りタスクは未完了。** 失敗したらコードを修正する（設定ファイルを変えない）。
+何か落ちたらコードを直す。設定ファイル (`biome.json`, `vitest.config.ts`, `tsconfig.json`) を直接いじって誤魔化さない。
 
-### 作業順序（厳守）
+`make harness` が落ちる場合は `docs/architecture/harness.md` の invariant ID と照らし合わせる。harness 自体のテストは `make harness-test`、ハーネスのルールロジックは `.claude/harness/src/architecture.ts` と `tech-debt.ts`。
 
-新規機能を追加する前に以下を実施する。
+CI (`.github/workflows/ci.yml`) は `make install_ci` → textlint → format check → typecheck → test → build。ローカル `make before-commit` が通れば CI は通る前提。
 
-1. **ドキュメント更新** — 関連する docs/, ADR, CLAUDE.md を先に更新する。
-2. **リファクタリング** — 技術的負債を先に解消する（`bun scripts/ai-improvement-loop.ts --staged --fail-on=high`）。
+## 利用可能な skills
 
-アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) です。`Codex` と `Claude Code` のどちらでも、この script を通らない変更は未完了です。
+`/<skill>` で起動する。実体は `.claude/skills/<skill>/SKILL.md`。
 
-大きい変更や新機能の前後では、次も実行する。
+| skill              | 用途                                                                  |
+| ------------------ | --------------------------------------------------------------------- |
+| `/harness`         | `make harness` を走らせて invariant 違反を検出                       |
+| `/tech-debt`       | `make tech-debt` で技術的負債バックログを生成                         |
+| `/create-problem`  | `problems/<category>/<id>/` を `metadata.json` + `template.yaml` で雛形生成 |
+| `/spec`            | Open Web Docs (MDN) スタイルの技術仕様書を書く                       |
 
-```bash
-bun scripts/architecture-harness.ts --staged --fail-on=error
-bun scripts/ai-improvement-loop.ts --write --fail-on=high
-```
+加えて TenkaCloud 関係なく使える共通 skill (`/review`、`/security-review`、`/simplify`、`/init` 等) は Claude Code 本体側に同梱されている。
 
-このループで `high` 以上が出た領域では、機能追加より先に負債を解消する。
+## ブランチと PR
 
-## コマンド一覧
+- **マージ済みブランチに push しない**。PR を出す前に必ず `gh pr view --json state` で state を確認。`MERGED` / `CLOSED` なら新ブランチを切る。
+- 小さな意味単位で PR を分ける。`feat(...)` `fix(...)` `refactor(...)` `docs(...)` `test(...)` `chore(...)` のいずれか (Conventional Commits)。
+- PR タイトルは 70 文字以内。本文に Summary + Test plan を書く。
+- コミット / PR で `#番号` 形式の Issue 引用は **禁止** (auto-close されるため)。`(PR-F1)` `(#446)` 等の別記法を使う。
 
-| コマンド            | 用途                                 |
-| ------------------- | ------------------------------------ |
-| `ni`                | 依存関係インストール（bun 自動選択） |
-| `nr dev`            | 全サービス起動                       |
-| `nr test`           | テスト実行                           |
-| `make test_quick`   | カバレッジなし高速テスト             |
-| `make gameday-seed` | GameDay デモデータ投入               |
-| `make help`         | 全コマンド一覧                       |
+## 禁止事項
 
-## 制約（破ったら即修正）
+- `npx` → `bunx` または `nlx`
+- `rm` (環境破壊リスク) → `git rm`
+- `#番号` 形式の Issue 引用 (本文・コミット message)
+- モック / スタブで握り潰す fallback / 空配列を返して見せかける処理
+- 設定ファイル (`biome.json`, `vitest.config.*`, `tsconfig.json`) の直接編集
+- DynamoDB の on-demand (`PAY_PER_REQUEST`) 化 — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED 強制
+- SSE / WebSocket の新規導入 — Lambda 運用と整合する **polling** で書く
+- シークレットのコミット (`infrastructure/environments/<env>/.env`、AWS credentials)
 
-- **`npx` 禁止** → `bunx` または `nlx` を使う
-- **`rm` コマンド禁止** → ファイル削除が必要なら `git` で管理
-- **`#番号` 形式の Issue 引用禁止** → コミット・PR で使わない
-- **モックデータ・スタブ API 禁止** → DynamoDB を使う
-- **空配列返し・stub・empty dataset で握り潰す fallback 禁止**
-- **テストタイトルは日本語「〜すべき」形式**
-- **設定ファイル（`biome.json`, `vitest.config.*` 等）の直接編集禁止** → コードを修正する
+## TDD
 
-## セキュリティ基準
-
-- ユーザー入力は Zod スキーマでバリデーション
-- 認証バイパス（AUTH_SKIP）には必ず `NODE_ENV !== "production"` ガード
-- シークレットをコードにハードコードしない
-- `innerHTML`、`eval`、`dangerouslySetInnerHTML` を使わない
-- SQL/NoSQL インジェクション対策: パラメータ化クエリを使う
-
-## アーキテクチャ概要
-
-```
-TenkaCloud/
-├── client/
-│   ├── AdminWeb/              # Control Plane UI (Next.js 16, :13000, basePath=/control)
-│   └── Application/           # Application Plane UI (Next.js 16, :13001)
-├── server/
-│   ├── microservices/         # Hono backend services
-│   │   ├── problem-service       :3100  # イベント・問題管理
-│   │   ├── gameday-service       :3020  # GameDay ゲーム状態
-│   │   ├── leaderboard-service   :3012  # スコア集計
-│   │   ├── battle-service        :3010  # バトル管理
-│   │   ├── scoring-service       :3011  # 採点パイプライン
-│   │   └── tenant-management     :13004 # テナント CRUD
-│   ├── libs/                  # DynamoDB クライアント, イベント型, cloud-abstraction
-│   └── reverseproxy/          # ローカル開発用リバースプロキシ
-├── infrastructure/
-│   ├── cdk/                   # SBT 0.3.9 ベースの CDK スタック (ADR-013, ADR-014)
-│   └── templates/             # CFn テンプレート (competitor IAM Role 等)
-├── packages/                  # 共有ライブラリ (quality harness 検出ロジック等)
-├── docs/architecture/harness.md  # アーキテクチャ invariant 正本
-├── docs/decisions/            # ADR (000-template.md, 001..014)
-├── scripts/                   # CDK orchestration (install/cleanup/provision-tenant.sh) + harness
-└── problems/                  # GameDay/JAM 問題セット
-```
-
-> 旧 `apps/` (PR #398 で `client/` に) および旧 `backend/services/` (PR #398 で `server/application/microservices/` 経由、ADR-014 で `server/microservices/` に) パスは廃止。`backend/services/` 配下に残る `node_modules` / `dist` / `lambda.zip` は build artifact のみで、ソースは `server/microservices/` を見ること。
-
-### サービス間通信
-
-- フロントエンド → バックエンド: HTTP REST（Hono）
-- リアルタイム: SSE（leaderboard-service）、WebSocket（realtime-service）
-- クロスプレーン: EventBridge（テナントプロビジョニング）
-
-### データベース設計
-
-DynamoDB シングルテーブル設計。PK/SK パターンは以下の通り。
-
-- イベント: `PK=EVENT#{eventId}`, `SK=METADATA`
-- GameDay チーム: `PK=GAMEDAY#{eventId}`, `SK=TEAM#{teamId}`
-- テナント別クエリ: GSI1 `PK=TENANT#{tenantId}`
-
-### イベントライフサイクル
-
-```
-draft → scheduled → active → paused → active → completed → cancelled
-                                 ↑________________↓
-```
-
-遷移ルールは `problem-service/src/services/event-lifecycle.ts` で定義。フロントエンドは `getStatusActions()` で有効な遷移のみボタン表示。
-
-## テストパターン
+テストを先に書く。テストタイトルは日本語「〜すべき」形式。
 
 ```typescript
-// Hono API テスト
-const app = new Hono();
-app.route("/", targetRoutes);
-const res = await app.request("/path", { method: "POST", ... });
-expect(res.status).toBe(200);
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { App, Stack } from "aws-cdk-lib";
 
-// vi.mock + vi.hoisted パターン（instanceof チェックがあるクラス）
-const mockController = vi.hoisted(() => ({
-  myFn: vi.fn(),
-  MyError: class extends Error { ... },
-}));
-vi.mock("../module", () => ({
-  myFn: mockController.myFn,
-  MyError: mockController.MyError,
-}));
-
-// DynamoDB リポジトリテスト
-const mockSend = vi.fn();
-vi.mock("@tenkacloud/dynamodb", () => ({
-  getDocClient: () => ({ send: mockSend }),
-  getTableName: () => "TestTable",
-}));
+describe("AdminConsoleHostingStack", () => {
+  it("CloudFront distribution に runtime-config.json が配置されるべき", () => {
+    const app = new App();
+    const stack = new AdminConsoleHostingStack(app, "Test", { /* ... */ });
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::S3::Bucket", { /* ... */ });
+  });
+});
 ```
 
-### ハーネス優先
+CDK の test では `Template.fromStack(stack)` で生成 CFn を assertion する。Lambda handler のユニットテストは `vi.mock` で AWS SDK clients をモックする。
 
-- 先に壊れるテストや検出ルールを書く
-- 先に [`docs/architecture/harness.md`](./docs/architecture/harness.md) の invariant を確認する
-- `tenant 作成 -> provisioning -> app endpoint -> event -> competitor account -> problem deploy -> participant join -> attack / defense / vote / aws-console` の one-pass を完了条件にする
-- 1 テストケースに `expect` を詰め込みすぎない（アサーションルーレット禁止）
-- route handler で fallback を重複実装しない
-- UI から直接 `fetch` や `process.env.*API_URL` を読まない
+## ディレクトリ早見
 
-## 決定記録
+```
+apps/
+  admin-console/                   # System Admin (Cognito Hosted UI / OAuth Code+PKCE)
+  application-admin-console/       # Tenant Admin (per-tenant Application Plane)
+  participant-portal/              # 競技者ポータル (per-team login key)
+infrastructure/
+  bin/infrastructure.ts            # 全 stack の配線
+  lib/control-plane-stack.ts       # SBT ControlPlane
+  lib/bootstrap-template/          # TenantMappingTable
+  lib/tenant-template/             # 1 tenant の API + Cognito + ApplicationConsole
+  lib/tenant-pipeline/             # CodePipeline 経由の per-tenant provisioning
+  lib/problem-deploy/              # 競技者 AWS への問題 deploy backend
+  lib/admin-console-hosting.ts     # admin-console S3+CloudFront 配信
+  lib/cdk-aspect/                  # DynamoDbLowCapacity / DestroyPolicySetter
+  environments/<env>/              # config.json + .env
+  templates/competitor-bootstrap.yaml  # 競技者アカウントで流す IAM Role
+scripts/
+  install.sh                       # 3-phase deploy のオーケストレーション
+  cleanup.sh                       # 冪等な teardown
+  provision-tenant.sh              # CodeBuild から呼ばれる per-tenant deploy
+  deprovision-tenant.sh            # tenant 削除
+problems/<category>/<id>/          # metadata.json + template.yaml が正本
+```
 
-アーキテクチャ決定記録: `docs/decisions/`
+## クロスプレーン契約 (壊さない)
 
-- ADR-001: ドキュメント構成
-- ADR-002: GameDay 仕様（攻撃カタログ、スコアリング）
-- ADR-003: MVP リリースアーキテクチャ
-- ADR-007: マルチテナント分離戦略
+- **EventBridge bus** は `ControlPlaneStack` が払い出し、`bin/infrastructure.ts` が他 stack に ARN を渡す。新 stack を追加するときも同じ bus を使う。
+- **Tenant 作成イベント** (`onboardingRequest`) は `ServerlessSaaSPipeline` が拾って per-tenant stack を deploy する。BASIC / STANDARD / PREMIUM は pooled stack を共有、PLATINUM のみ silo stack を立てる。
+- **DeployRequested イベント** は `ProblemDeployBackendStack` の Worker Lambda が拾い、tenant の ExternalId で競技者アカウントに AssumeRole → CFn CreateStack する。**ExternalId は必ず要求** (省略不可)。
+- **Frontend の URL** は `runtime-config.json` (CloudFront 配下) 経由で注入される。`apps/*/src/config.ts` に `loadConfig()` がある。新しい URL を追加するときは hosting stack の env と config.ts の interface を両方更新する。
+
+## 参照
+
+- @CLAUDE.md — プロダクト全体・アーキテクチャ・コマンド一覧
+- [`docs/architecture/harness.md`](./docs/architecture/harness.md) — invariant + PR Discipline の正本
+- [`infrastructure/templates/README.md`](./infrastructure/templates/README.md) — 競技者アカウント側のセットアップ
+- [`problems/README.md`](./problems/README.md) — 問題追加の手順とスキーマ
+- `apps/<app>/README.md` — 各 SPA のローカル開発手順
+- [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — CI が走らせるコマンド

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,112 +1,186 @@
 # TenkaCloud
 
-マルチテナント SaaS — AWS クラウドコンペティションプラットフォーム（GameDay / JAM）
-
-## ゲート
-
-### PR 作成前の必須チェック（この順序で実行）
-
-1. `bun scripts/architecture-harness.ts --staged --fail-on=error`
-2. `make before-commit` — lint・format・typecheck・test（カバレッジ 99％+）・build
-3. `/review` — コードレビュー（品質・慣習・リスク）
-4. `/security-review` — セキュリティレビュー（認証・認可・インジェクション）
-5. `/simplify` — コード重複・品質・効率の最終チェック
-
-すべて通るまで未完了。失敗したら原因を特定してコードを修正する（設定ファイルを変更しない）。
-
-アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) で、これは `Codex` と `Claude Code` の両方に共通です。
-
-### 作業順序
-
-新規機能を追加する前に、以下を先に実施する。
-
-1. **ドキュメント更新** — 変更に関連する docs/, ADR, CLAUDE.md を先に更新する。
-2. **リファクタリング** — 技術的負債（`bun scripts/ai-improvement-loop.ts --staged --fail-on=high` で検出）を先に解消する。
-
-## コマンド体系
-
-```bash
-make start            # 全サービス起動（Docker + UI + Backend）
-make before-commit    # 全品質チェック（PR 前に必須）
-make test_quick       # 高速テスト（カバレッジなし）
-make help             # 全コマンド一覧
-```
-
-パッケージ操作は **`ni` / `nr` / `bunx`** を使う。**`npx` は禁止**。
-
-## 開発原則
-
-### TDD
-
-テストを先に書く。テストタイトルは日本語「〜すべき」形式。カバレッジ 99％+ を維持する。テスト不能なコード（SSE abort コールバック等）は `/* istanbul ignore next */` で明示的に除外し、理由をコメントに書く。
-
-### セキュリティ
-
-- OWASP Top 10 を常に意識する（SQL インジェクション、XSS、コマンドインジェクション等）
-- ユーザー入力・外部 API 境界では必ずバリデーション（Zod スキーマ）
-- 認証・認可のバイパス（AUTH_SKIP）は開発環境のみ。本番ガード（`NODE_ENV !== "production"`）を必ず入れる
-- シークレット（.env, credentials）をコミットしない
-- 依存パッケージの脆弱性に注意する
-
-### コード品質
-
-- 既存パターンに従う。新しいパターンを導入する前にコードベースの既存実装を確認する
-- エラーハンドリングは具体的に。`catch {}` で握り潰さず、ユーザーに意味のあるフィードバックを返す
-- 型安全を徹底する。`any` を避け、`unknown` + 型ガードを使う
-- DRY より明確さを優先。3 行の重複は無理な抽象化より良い
-
-### PR
-
-小さい意味のある単位。PR 作成まで含めてタスク完了。`make before-commit` 通過が前提。
-
-### ハーネス優先
-
-- 仕様より先に [`docs/architecture/harness.md`](./docs/architecture/harness.md) の invariant を確認する
-- `tenant 作成 -> provisioning -> tenant app endpoint -> event 作成 -> competitor account 登録 -> problem deploy -> participant join -> attack / defense / vote / aws-console` の one-pass を完了条件にする
-- `local` と `AWS` の両方の受け入れ条件がない変更は未完了として扱う
-
-## 禁止事項
-
-- `rm` コマンド（環境破壊リスク）
-- `npx`（`bunx` または `nlx` を使う）
-- コミット / PR での `#番号` 形式の Issue 引用（自動クローズ防止）
-- モックデータ・ハードコード配列・スタブ API（DynamoDB を使う）
-- 設定ファイル（`biome.json`, `vitest.config.*` 等）の直接変更 — コードを修正する
+AWS マルチテナント SaaS のクラウドコンペティション基盤。問題は **Battle**（リアルタイム対戦）と **Challenge**（個別演習・常設チャレンジ）の 2 カテゴリで配信する (旧称 GameDay / JAM)。SBT (`@cdklabs/sbt-aws` 0.3.9) を土台に、Control Plane / Application Plane / 競技者 AWS アカウントへの問題 deploy をまるごと CDK で持つ。
 
 ## アーキテクチャ
 
 ```
-Control Plane (port 13000)     — テナント管理 UI (Next.js)
-Application Plane (port 13001) — GameDay/Battle UI (Next.js)
-Backend Services               — Hono + DynamoDB マイクロサービス群
-  problem-service    :3100     — イベント・問題管理
-  gameday-service    :3020     — GameDay ゲーム状態管理
-  leaderboard-service:3012     — スコア集計・SSE 配信
-  battle-service     :3010     — バトル管理
-  scoring-service    :3011     — 採点パイプライン
-  tenant-management  :13004    — テナント CRUD
+TenkaCloud/
+├── apps/                                    # Vite + React 19 + Cloudscape の SPA 群
+│   ├── admin-console/                       # System Admin 用 Control Plane UI (dev :5173)
+│   ├── application-admin-console/           # Tenant Admin 用 Application Plane UI (dev :5174)
+│   └── participant-portal/                  # 競技者向けポータル (dev :5175)
+├── infrastructure/                          # CDK (SBT 0.3.9) — 全 backend は Lambda
+│   ├── bin/infrastructure.ts                # Stack 配線のエントリ
+│   ├── lib/
+│   │   ├── control-plane-stack.ts           # SBT ControlPlane (Cognito + EventBridge + API)
+│   │   ├── bootstrap-template/              # Tenant pipeline 用 bootstrap (TenantMappingTable)
+│   │   ├── tenant-template/                 # 1 tenant 分の API + Cognito + ApplicationConsole hosting
+│   │   ├── tenant-pipeline/                 # CodePipeline 経由の per-tenant provisioning
+│   │   ├── problem-deploy/                  # 競技者 AWS への問題 deploy (DDB + Worker Lambda + API)
+│   │   ├── admin-console-hosting.ts         # admin-console を S3+CloudFront 配信
+│   │   ├── cdk-aspect/                      # DynamoDbLowCapacity / DestroyPolicySetter
+│   │   ├── config/                          # config.json schema + interface
+│   │   └── utils/                           # config-loader, iam-helpers
+│   ├── environments/<env>/{config.json,.env}# 環境別設定。.env で ${VAR:-default} を注入
+│   └── templates/competitor-bootstrap.yaml  # 競技者アカウント側で 1 回流す IAM Role
+├── scripts/                                 # install.sh / cleanup.sh / provision-tenant.sh 等
+├── problems/<category>/<id>/                # 1 ディレクトリ 1 問題 (metadata.json + template.yaml)
+└── .github/workflows/ci.yml                 # PR で lint / typecheck / test / build
 ```
 
-DynamoDB シングルテーブル設計。PK/SK にテナント ID を含めてテナント分離。
+### Plane 配置
+
+- **Control Plane** (`ControlPlaneStack`) — SBT 内蔵の Cognito UserPool + System Admin + Tenant CRUD API + EventBridge bus。`admin-console` がフロント。
+- **Application Plane (pooled)** — `serverless-saas-ref-arch-tenant-template-pooled` として Phase 1 で 1 つ立つ。BASIC / STANDARD / PREMIUM tier の tenant が共有する `application-admin-console` を 1 CloudFront URL で配信。
+- **Application Plane (silo)** — PLATINUM tier の tenant 作成イベントで `ServerlessSaaSPipeline` が CodeBuild を起動し、tenant 専用の `serverless-saas-ref-arch-tenant-template-<tenantId>` を deploy。
+- **Problem deploy backend** (`ProblemDeployBackendStack`) — Deployments DDB + Cognito JWT 認可付き HTTP API + Worker Lambda。EventBridge から `DeployRequested` を拾い、tenant の ExternalId で競技者アカウントへ AssumeRole → CFn CreateStack。
+- **Participant Portal** — 競技者が自チームの問題エンドポイント・スコアを見るアプリ。`ProblemDeployBackendStack` から S3+CloudFront でホスティング (有効化は `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true`)。
+
+### Plane 越しの通信
+
+EventBridge bus (Control Plane が払い出し、ARN を `bin/infrastructure.ts` で他 stack に渡す) を経由する。フロントエンドは runtime-config.json + Cognito JWT で各 API を叩く。
+
+### データ分離
+
+DynamoDB シングルテーブル設計はしない。stack ごとに専用テーブル (TenantMappingTable / Deployments / Apps 等) を持ち、テナント分離は `TenantId` キー or stack 自体の分離で行う。**全テーブルは PROVISIONED 1 RCU / 1 WCU を Aspect (`DynamoDbLowCapacity`) で強制** — Free Tier 25 RCU/WCU 内に収めるため。
+
+## コマンド
+
+| コマンド                | 用途                                                        |
+| ----------------------- | ----------------------------------------------------------- |
+| `make install`          | 全 workspace の依存をインストール (bun)                     |
+| `make build`            | 全 workspace を build (`infrastructure` → 3 SPA)            |
+| `make typecheck`        | 全 workspace の `tsc --noEmit`                              |
+| `make test`             | 全 workspace の vitest                                      |
+| `make lint`             | markdownlint + textlint + biome                             |
+| `make fix`              | 上記の自動修正版 (`make format` でも可)                     |
+| `make validate-problems`| `problems/**/metadata.json` を `problems/SCHEMA.json` で検証|
+| `make check`            | install + lint + test + validate-problems                   |
+| `make before-commit`    | lint + test + validate-problems (PR 前の必須ゲート)         |
+| `make synth`            | `cdk synth` (デフォルト `ENV=development`)                  |
+| `make diff`             | `cdk diff --all`                                            |
+| `make bootstrap`        | `cdk bootstrap`                                             |
+| `make deploy`           | `scripts/install.sh` を起動 (3-phase deploy)                |
+| `make destroy`          | `scripts/cleanup.sh` で全 stack + S3 を冪等に破棄           |
+| `make harness`          | architecture invariant チェック (`docs/architecture/harness.md`) |
+| `make harness-test`     | harness 自体のユニットテスト (`.claude/harness/`)           |
+| `make tech-debt`        | 技術的負債スキャン (test smell / 結合 / 責務漏れ)           |
+| `make help`             | Makefile の全ターゲット一覧                                 |
+
+環境切替は `make deploy ENV=production` のように `ENV` 変数で行う。`infrastructure/environments/<env>/.env` を読み込み、無ければ `make env-check` がエラーで止める。
+
+## アーキテクチャ Invariants
+
+`docs/architecture/harness.md` に固定済み。`make harness` が `.claude/harness/bin/architecture.ts` で staged ファイルを検査して逸脱を error で報告する。
+
+| ID                                                    | 概要                                                                            |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `INVARIANT_CONTROL_PLANE_USES_SBT`                    | Control Plane は `@cdklabs/sbt-aws` の ControlPlane construct に乗せる         |
+| `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`| Control Plane は tenant manager。tenant runtime を持ち込まない                  |
+| `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER`           | テナント分離はインフラ層 (DDB PK / stack 分離) で実現。アプリに tenant ロジックを書かない |
+| `INVARIANT_APP_CODE_IS_UNMODIFIED`                    | `apps/*/dist/` は tenant 共有。差分は `runtime-config.json` 経由で注入する       |
+| `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`              | 認証はインフラ層で注入。アプリに `AUTH_SKIP` 的なバイパスを書かない              |
+| `INVARIANT_PR_SHIPS_WORKING_INCREMENT`                | PR 単体で観察可能な機能が動く。scaffolding-only PR は禁止                        |
+| `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`              | コード変更とテストを同じ PR に含める。既存テストでカバー時は body で明示         |
+| `INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED`         | PR body に `## Regression 分析` セクションで壊しうる挙動を列挙する              |
+| `INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED`             | PR body に `## 物理影響` セクションで CFn / 成果物の差分を CREATE/UPDATE/REPLACE/DELETE/NO-OP で列挙 |
+| `ONE_PASS_LOCAL`                                      | ローカルで tenant 作成 → application console → 問題 deploy → participant join がブラウザ 1 回で通る |
+| `ONE_PASS_AWS`                                        | `make deploy` 1 発で 3-phase が通り、SystemAdmin 招待 → tenant 作成 → 問題 deploy → 競技者ログインまで一気通貫 |
+
+加えて次の Enforcement Rules を機械検査する。
+
+- `secrets-manager-forbidden` — `@aws-sdk/client-secrets-manager` 禁止 (SSM Parameter Store SecureString を使う、コスト 0 原則)
+- `handler-must-not-call-fetch` — `lib/handlers/` で `fetch(` 直接呼び出し禁止 (Service / Repository に閉じ込める)
+
+## 開発フロー
+
+### ゲート (PR 作成前)
+
+1. `make harness` — architecture invariant 違反が 0 件であること
+2. `make before-commit` — lint / typecheck / test / build / validate-problems がすべて通ること
+3. `/review` — コードレビュー
+4. `/security-review` — セキュリティレビュー
+5. `/simplify` — 重複・複雑度・無駄なコードの最終チェック
+
+すべて通るまで未完了。失敗したら原因を特定してコードを修正する（`biome.json` / `vitest.config.ts` 等の設定ファイルを直接いじらない）。
+
+### 利用可能な skills
+
+`.claude/skills/` 配下に置いてある。`/<skill-name>` で起動する。
+
+| skill              | 用途                                                                        |
+| ------------------ | --------------------------------------------------------------------------- |
+| `/harness`         | `make harness` を走らせて architecture invariant 違反を検出                 |
+| `/tech-debt`       | `make tech-debt` で技術的負債バックログを生成（assertion-roulette / 結合 / fallback 検出） |
+| `/create-problem`  | `problems/<category>/<id>/` を `metadata.json` + `template.yaml` 規約で雛形生成 |
+| `/spec`            | Open Web Docs (MDN) スタイルの技術仕様書を書く                              |
+
+### TDD
+
+テストを先に書く。テストタイトルは日本語「〜すべき」形式。Vitest は workspace ごとに独立 (`infrastructure/vitest.config.ts`、各 SPA の `vite.config.ts`)。
+
+```typescript
+describe("AdminConsoleHostingStack", () => {
+  it("CloudFront distribution に runtime-config.json が配置されるべき", () => {
+    // ...
+  });
+});
+```
+
+### Issue 引用ルール
+
+コミットや PR 本文で `#番号` 形式は使わない（auto-close されてしまうので）。代わりに `(PR-F1)` `(#446)` のようにスペース区切りや別記法で指す。
+
+## 禁止事項
+
+- **`npx` 禁止** → `bunx` または `nlx` を使う
+- **`rm` コマンド禁止** → ファイル削除は `git rm` 経由で扱う
+- **コミット / PR で `#番号` 形式の Issue 引用禁止** — 自動クローズ防止
+- **モック / スタブで握り潰す fallback 禁止** — 失敗するなら明示的に失敗させる
+- **DynamoDB を on-demand (PAY_PER_REQUEST) で立てない** — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED に強制している。これを破る変更は CFn 出力で必ず引っかかる
+- **設定ファイル (`biome.json`, 各 `vitest.config.ts`, `tsconfig.json`) の直接変更禁止** — コード側を修正する
+- **シークレット (`.env`, AWS credentials) のコミット禁止** — `.gitignore` で除外、`infrastructure/environments/<env>/.env.example` だけコミット
+
+## セキュリティ
+
+- ユーザー入力 / 外部 API 境界では Zod でバリデーション
+- 認証バイパスを実装しない (本 repo には AUTH_SKIP は無い、Cognito JWT を必ず通す)
+- `innerHTML` / `eval` / `dangerouslySetInnerHTML` 不使用
+- 競技者アカウントへの AssumeRole は **必ず ExternalId** を要求 (`CDK_PARAM_DEPLOY_EXTERNAL_ID`)
+- `infrastructure/templates/competitor-bootstrap.yaml` の IAM Role は最小権限 (CFn CreateStack + 問題テンプレートが触る AWS サービス分のみ)
+- 依存パッケージは Renovate / dependabot で更新、CI は Safe Chain で malicious package を検出
 
 ## 技術スタック
 
-| レイヤー | 技術 |
-|---------|------|
-| フロントエンド | Next.js 16, React 19, Cloudscape Design System, Tailwind CSS 4 |
-| バックエンド | Hono, TypeScript, Zod |
-| データベース | DynamoDB (LocalStack/Kumo でローカル) |
-| テスト | Vitest (Istanbul), Playwright (E2E) |
-| Lint/Format | Biome (フロント), Textlint (Markdown) |
-| パッケージ管理 | Bun, npm workspaces |
-| 認証 | AWS Cognito + browser-side PKCE flow（開発時は AUTH_SKIP=1） |
-| CI | GitHub Actions |
+| レイヤー         | 技術                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| フロントエンド   | Vite 7, React 19, react-router 7, Cloudscape Design System            |
+| バックエンド     | AWS Lambda (Node.js / Hono on Lambda), API Gateway HTTP API           |
+| IaC              | AWS CDK 2 + `@cdklabs/sbt-aws` 0.3.9, cdk-nag                         |
+| 認証             | AWS Cognito (Hosted UI + OAuth Code + PKCE)                           |
+| データ           | DynamoDB (PROVISIONED 1/1 強制)                                       |
+| イベント         | EventBridge (cross-plane: tenant 作成 / DeployRequested / DeployCompleted) |
+| テスト           | Vitest                                                                |
+| Lint / Format    | Biome (TS), markdownlint-cli2 + textlint (Markdown)                   |
+| パッケージ管理   | Bun 1.3.11 (workspaces: `infrastructure` + `apps/*`)                  |
+| CI               | GitHub Actions (`.github/workflows/ci.yml`)                           |
+
+## デプロイの流れ
+
+`make deploy` (= `scripts/install.sh`) は次の 3 フェーズで動く。
+
+1. **Phase 1**: `ControlPlaneStack` + `serverless-saas-ref-arch-bootstrap-stack` + `serverless-saas-ref-arch-tenant-template-pooled` + `ServerlessSaaSPipeline` を deploy。CORS/callback は localhost のみ。
+2. **Phase 2**: Phase 1 の outputs を runtime-config 用 env に入れて `apps/admin-console` を host で build → `AdminConsoleHostingStack` (S3 + CloudFront) を deploy。
+3. **Phase 3**: CloudFront URL を `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` に入れて `ControlPlaneStack` を再 deploy → callback / CORS を更新。
+
+teardown は `make destroy` (= `scripts/cleanup.sh`)。途中失敗状態 / 部分削除済み状態からも冪等に動くよう書かれている。
 
 ## ポインター
 
-- デザインシステム: [Cloudscape](https://cloudscape.design/components/)（全 UI コンポーネントはここから選択）
-- フロントエンドデザイン: `/skill frontend-design`
-- スペック・仕様書: `/skill spec`
-- アーキテクチャハーネス: `docs/architecture/harness.md`
-- アーキテクチャ決定記録: `docs/decisions/`
-- エージェント設定: @AGENTS.md
+- **アーキテクチャ正本**: [`docs/architecture/harness.md`](./docs/architecture/harness.md) — invariant + PR Discipline
+- **デザインシステム**: [Cloudscape](https://cloudscape.design/components/) — UI コンポーネントは原則ここから選ぶ
+- **問題作成**: [`problems/README.md`](./problems/README.md) (metadata.json スキーマ + template.yaml 規約) — `/create-problem` で雛形生成
+- **競技者側セットアップ**: [`infrastructure/templates/README.md`](./infrastructure/templates/README.md)
+- **エージェント向けガイド**: @AGENTS.md
+- **コントリビューション**: @CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,42 +1,161 @@
 # TenkaCloud
 
-クラウド技術者向けの OSS 競技プラットフォーム
-(AWS GameDay / JAM 形式の常設マルチテナント SaaS)。
+[![CI](https://github.com/susumutomita/TenkaCloud/actions/workflows/ci.yml/badge.svg)](https://github.com/susumutomita/TenkaCloud/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 
-## レイアウト
+AWS 上で動くマルチテナント SaaS のクラウドコンペティション基盤。**Battle** (リアルタイム対戦) と **Challenge** (個別演習・常設チャレンジ) を 1 つの Control Plane / Application Plane / 競技者 AWS アカウントへの自動 deploy で配信する (旧称 GameDay / JAM)。
 
-```text
-apps/admin-console/             Control Plane UI (テナント管理)
-apps/application-admin-console/ Application Plane UI (per-tenant 管理)
-infrastructure/                 SBT 0.3.9 ベースの CDK スタック群
-scripts/                        install / cleanup / provision-tenant 等
-problems/                       GameDay / JAM 問題集 (CFn + scoring)
-docs/                           アーキテクチャ・ADR・運用ガイド
+土台は AWS の Serverless SaaS Reference Architecture (`@cdklabs/sbt-aws` 0.3.9)。Control Plane / Application Plane / Tenant Pipeline / Problem Deploy backend を CDK で 1 つのレポに収めている。
+
+## できること
+
+- **System Admin** が tenant を発行 → 招待メール → tenant 作成 (BASIC / STANDARD / PREMIUM は pooled、PLATINUM は silo)。
+- **Tenant Admin** が `application-admin-console` から competitor アカウントへ問題 (`problems/<id>/template.yaml`) を deploy。
+- **競技者** は事前に `infrastructure/templates/competitor-bootstrap.yaml` を自分のアカウントで 1 回流すだけで、TenkaCloud から問題スタックが届く。問題エンドポイントとスコアは `participant-portal` で見る。
+- 全データテーブルは DynamoDB の **PROVISIONED 1 RCU / 1 WCU** に強制 (Free Tier 25 RCU/WCU 内で運用可能)。
+
+## アーキテクチャ
+
+```
+┌────────────────────┐   ┌──────────────────────────┐   ┌────────────────────────┐
+│  admin-console     │   │ application-admin-console│   │  participant-portal    │
+│  (System Admin)    │   │  (Tenant Admin)          │   │  (Competitor)          │
+│  S3 + CloudFront   │   │  per-tenant CloudFront   │   │  S3 + CloudFront       │
+└─────────┬──────────┘   └─────────────┬────────────┘   └────────────┬───────────┘
+          │                            │                             │
+          ▼                            ▼                             ▼
+┌────────────────────┐   ┌──────────────────────────┐   ┌────────────────────────┐
+│ ControlPlaneStack  │   │ TenantTemplateStack      │   │ ProblemDeployBackend   │
+│  - Cognito         │   │  - per-tenant Cognito    │   │  - Deployments DDB     │
+│  - Tenant CRUD API │──▶│  - Apps DDB / API GW     │   │  - HTTP API + Cognito  │
+│  - EventBridge bus │   │  - silo or pooled        │   │  - Worker Lambda       │
+└─────────┬──────────┘   └──────────────────────────┘   └────────────┬───────────┘
+          │                                                          │
+          │  onboardingRequest             DeployRequested            │
+          ▼                                                          ▼
+┌────────────────────┐                                  ┌────────────────────────┐
+│ ServerlessSaaS     │                                  │ Competitor AWS account │
+│   Pipeline         │                                  │  (AssumeRole +         │
+│  (CodePipeline)    │                                  │   ExternalId)          │
+└────────────────────┘                                  └────────────────────────┘
 ```
 
-## クイックスタート
+詳細は [`CLAUDE.md`](./CLAUDE.md) のアーキテクチャ節を参照。
 
-### 必要なもの
+## ディレクトリ
 
-- AWS CLI (deploy 時)
-- Bun
-- Docker (CDK BucketDeployment bundling)
-
-### ローカル動作確認
-
-```bash
-bun install
-bun run typecheck
-bun run test
+```
+apps/
+├── admin-console/                   # System Admin SPA (Vite + React 19 + Cloudscape)
+├── application-admin-console/       # Tenant Admin SPA
+└── participant-portal/              # Competitor SPA
+infrastructure/                      # CDK (SBT 0.3.9) — backend は全部 Lambda
+├── bin/infrastructure.ts            # 全 stack の配線エントリ
+├── lib/                             # 各 stack 実装
+├── environments/<env>/              # 環境別設定 (config.json + .env)
+└── templates/                       # 競技者アカウント用 CFn テンプレート
+scripts/                             # install.sh / cleanup.sh / provision-tenant.sh
+problems/<category>/<id>/            # 1 ディレクトリ 1 問題 (metadata.json + template.yaml)
 ```
 
-### AWS deploy
+## 必要環境
+
+- macOS / Linux
+- [Bun](https://bun.sh/) 1.3.11 (`mise install` で `mise.toml` から取得可能)
+- Node.js 24+ (CDK ts-node の実行用)
+- Docker (CDK BucketDeployment の bundling に必要)
+- AWS CLI v2 (deploy 時)
+- AWS account に sts:AssumeRole / cdk bootstrap 権限のあるクレデンシャル
+
+## セットアップ
 
 ```bash
+git clone https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+```
+
+依存は `infrastructure/` と `apps/*` の workspace すべてが入る。
+
+## ローカル開発
+
+各 SPA は独立した Vite dev server で動く。
+
+```bash
+# それぞれ別ターミナルで
+cd apps/admin-console && make dev               # http://localhost:5173
+cd apps/application-admin-console && make dev   # http://localhost:5174
+cd apps/participant-portal && make dev          # http://localhost:5175
+```
+
+`apps/admin-console/` で実際のバックエンドに繋ぐ場合は `.env.local` を作って Cognito / API URL を設定する (`apps/admin-console/README.md` 参照)。
+
+CDK スタックのユニットテスト・型チェックは workspace ルートから実行する。
+
+```bash
+make typecheck      # 全 workspace の tsc --noEmit
+make test           # 全 workspace の vitest
+make synth          # cdk synth (ENV=development)
+```
+
+## AWS にデプロイ
+
+```bash
+# 1. 環境設定ファイルを用意
 cp infrastructure/environments/development/.env.example \
    infrastructure/environments/development/.env
-# .env に SYSTEM_ADMIN_EMAIL を入れる
-make deploy ENV=development
+# → SYSTEM_ADMIN_EMAIL を編集
+
+# 2. AWS CLI ログイン済みで
+make deploy   # ENV=development が default
 ```
 
-詳細は [docs/](./docs/)。
+`scripts/install.sh` は次の 3 フェーズで動く。
+
+1. backend stacks (ControlPlane / Bootstrap / pooled tenant / Pipeline) を deploy
+2. `apps/admin-console` を build → `AdminConsoleHostingStack` (S3+CloudFront) を deploy
+3. CloudFront URL を Control Plane の callback / CORS に追加して再 deploy
+
+完了すると AdminConsole の URL と SystemAdmin 招待メールの送信先がコンソールに出る。
+
+teardown は `make destroy` (`scripts/cleanup.sh`)。途中失敗状態からも冪等に動く。
+
+## 競技者側のセットアップ
+
+競技者は自分の AWS アカウントで `infrastructure/templates/competitor-bootstrap.yaml` を 1 回 deploy する。これで TenkaCloud から AssumeRole + ExternalId で問題 CFn を deploy できる IAM Role が払い出される。詳細は [`infrastructure/templates/README.md`](./infrastructure/templates/README.md)。
+
+## 問題を追加する
+
+`problems/<category>/<id>/` を作って `metadata.json` (= [`problems/SCHEMA.json`](./problems/SCHEMA.json) に準拠) と `template.yaml` を置く。手順は [`problems/README.md`](./problems/README.md)。
+
+検証は次のコマンドで実行する。
+
+```bash
+make validate-problems
+```
+
+## コマンド一覧
+
+| コマンド                 | 用途                                                  |
+| ------------------------ | ----------------------------------------------------- |
+| `make install`           | 依存インストール (Bun)                                |
+| `make build`             | 全 workspace を build                                 |
+| `make typecheck`         | 全 workspace の tsc                                   |
+| `make test`              | 全 workspace の vitest                                |
+| `make lint` / `fix`      | markdownlint + textlint + biome (`fix` は自動修正)    |
+| `make validate-problems` | 問題メタデータの schema 検証                          |
+| `make before-commit`     | PR 前に必須のゲート (lint + test + validate-problems) |
+| `make synth` / `diff`    | `cdk synth` / `cdk diff --all`                        |
+| `make deploy`            | `scripts/install.sh` で 3-phase deploy                |
+| `make destroy`           | `scripts/cleanup.sh` で全 stack + S3 を冪等に破棄     |
+| `make harness`           | architecture invariant チェック                       |
+| `make tech-debt`         | 技術的負債スキャン                                    |
+| `make help`              | 全ターゲット一覧                                      |
+
+## コントリビューション
+
+[CONTRIBUTING.md](./CONTRIBUTING.md) を参照。AI エージェント向けのルールは [AGENTS.md](./AGENTS.md) と [CLAUDE.md](./CLAUDE.md) に集約している。
+
+## ライセンス
+
+[Apache License 2.0](./LICENSE)

--- a/apps/participant-portal/test/auth/storage.test.ts
+++ b/apps/participant-portal/test/auth/storage.test.ts
@@ -68,7 +68,10 @@ describe("storage", () => {
       saveSession(sample());
       const stored = sessionStorage.getItem("TenkaCloud.participant.session");
       expect(stored).not.toBeNull();
-      const parsed = JSON.parse(stored!);
+      if (stored === null) {
+        throw new Error("session が保存されるべき");
+      }
+      const parsed = JSON.parse(stored);
       expect(parsed.teamName).toBe("Team Alpha");
     });
   });

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -1,0 +1,87 @@
+# TenkaCloud Architecture Harness
+
+この文書は、セッションが変わっても壊してはいけない原則を機械可読な ID つきで固定する正本です。
+
+## Invariants
+
+- `INVARIANT_CONTROL_PLANE_USES_SBT`
+  Control Plane は `@cdklabs/sbt-aws` の ControlPlane construct に乗せる。Cognito User Pool / API Gateway / EventBridge を自前で再実装しない。sbt-aws の更新に追従する。
+
+- `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`
+  Control Plane は tenant manager であり、tenant runtime host ではない。AssumeRole + CloudFormation 経由の問題 deploy は tenant Application Plane (`ProblemDeployBackendStack`) 側に閉じ込め、Control Plane stack には持ち込まない。
+
+- `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER`
+  テナント分離はインフラ層で実現する。DynamoDB は PK にテナント ID を含める。アプリコードでは tenant 識別ロジックを書かない（アプリは自分が誰のためのインスタンスか知らなくていい）。
+
+- `INVARIANT_APP_CODE_IS_UNMODIFIED`
+  `apps/` 配下のアプリケーションコードは tenant ごとにフォークしたり書き換えない。同じ build artifact (`dist/`) を pooled stack と silo stack の両方で使い回し、tenant 差分は CDK が `runtime-config.json` 経由で注入する。tenant ごとに変わる可能性があるのは config だけで、コードは 1 セット。これが崩れた瞬間に「customer 1 = fork 1」になり SaaS の経済が壊れる。
+
+- `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`
+  認証 (Cognito UserPool / Hosted UI / JWT) はインフラ層で注入する。アプリコードに認証バイパス (`AUTH_SKIP` 的な分岐) や tenant 識別ロジックを書かない。production / dev で別のフロー要件が出ても、CDK 側で UserPool を分けるか callback URL を切り替えるかで対応する。アプリ側の `if (isDev)` でのバイパス禁止。
+
+## One Pass
+
+セッションが変わっても、次の 2 つのフローを 1 回で通せる状態を保つ。
+
+- `ONE_PASS_LOCAL`
+  ローカル開発で `make install` → 各 SPA の `make dev` を起動した後、`apps/admin-console` から `apps/application-admin-console` へ繋いで「tenant 作成 → application console → 問題 deploy form 表示 → participant portal でログイン」までブラウザ操作だけで一気通貫で動くこと。途中で別ターミナルでスクリプトを叩く / .env を手で書き換える必要が発生したら、その時点で原因を CDK / scripts に戻して恒久化する。
+
+- `ONE_PASS_AWS`
+  AWS deploy では `infrastructure/environments/<env>/.env` に必須値だけ入れて `make deploy` 1 発で「Phase 1 (backend) → Phase 2 (admin-console hosting) → Phase 3 (callback 更新)」が通り、SystemAdmin 招待メール → admin-console ログイン → tenant 作成 → application-admin-console から問題 deploy → 競技者 portal でログイン → 問題エンドポイント表示まで一気通貫で動くこと。teardown は `make destroy` で冪等。途中失敗時は同じコマンドで resume できる。
+
+## PR Discipline
+
+商用 SaaS として出す以上、「動くものを小さくインクリメンタルに積み上げる」規律を PR 単位で強制する。ここでいう「動くもの」は商用運用に耐える状態を指す。小さい scope でも、テストされていて、意図が明示されていて、場当たり対応が混ざっていない。デモのためのハリボテ、proof-of-concept、後続 PR が前提の scaffolding は対象外。
+
+参考ケース: `https://zenn.dev/nttdata_tech/articles/8a010aff542625`。AI-native 開発の失敗パターンとして、テスト観点不足・PR 単位の不明瞭・仕様の埋没があり、これらは統合テストまでリグレッション検出を遅らせる。PR 単位でこの視点を強制する。
+
+- `INVARIANT_PR_SHIPS_WORKING_INCREMENT`
+  PR 単体を main に merge した後、ユーザー観察可能な機能が 1 つ以上 start working すること。次の 3 条件を同時に満たすこと。
+  - 小さい (1 PR = 1 関心事、触るファイル数はおおむね 10 を超えない)
+  - 商用品質 (テストされていて意図が明確、場当たり的な hardcode / TODO 残しが無い)
+  - 独立に価値を持つ (「別 PR の土台」「scaffolding」「consumer 待ちのライブラリ」は単独では merge しない)
+
+- `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`
+  コード変更と、そのコードの振る舞いを固定するテストを同じ PR に含める。既存テストでカバーされている場合は「この PR で追加したテストはゼロ」と明記してよい。ただし、どの既存テストがどの挙動を守るかを PR body で明示する。AI 生成テストを含める場合、主張する code path を実際に exercise しているか手で確認する。claim と実体の食い違いが起きる場合もある。
+
+- `INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED`
+  PR body の `## Regression 分析` セクションで、merge で壊しうる既存挙動を列挙する。確認方法 (grep / code read / test run / 実環境観察) を項目ごとに書く。未確認が 1 つでも残っている PR は DRAFT のまま残す。テストが green であることは Regression 分析の代替にならない。テストが existing behavior をカバーしているか自体の確認が別途必要。
+
+- `INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED`
+  PR body に `## 物理影響` セクションを置く。そこで `make deploy` で変わる AWS リソース、`make build` で変わる成果物を列挙する。CFT 差分ゼロの場合も明示し、reviewer に推論させない。種別は CREATE / UPDATE / REPLACE / DELETE / NO-OP から選ぶ。
+
+## Banned Assumptions
+
+- アプリコード内で tenant ID を引き回す前提（`INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER` 違反）
+- 「一部画面が出た」「synth だけ通る」を one-pass completion と見なす運用
+- 「テストが green だから merge OK」思考。Regression 分析を省略する言い訳にしない。テストが existing behavior をカバーしているかどうかは別途確認
+- 「small PR だから影響範囲も小さい」という前提 (diff の行数と影響範囲は独立。小さい IAM 変更 1 行で本番が止まる)
+- 「動くまでチェイン PR が要る」形の scaffolding PR を単独 merge する運用 (`INVARIANT_PR_SHIPS_WORKING_INCREMENT` 違反)。consumer と束ねて 1 PR にするか、rebase で順序を整える
+- 「動くもの = 最小のハリボテでもよい」誤解 (商用品質が条件。小さい scope ≠ 雑でよい)
+- AI 生成テストの実効性を人間が検証しない運用。claim している code path を実際に exercise しているか確認しないまま merge する
+
+## Enforcement Rules
+
+Invariants に加えて、実装レベルの原則を機械検査するルールを harness が持つ。ルール ID は `secrets-manager-forbidden` のようにケバブケースで命名する。
+
+- `secrets-manager-forbidden`
+  `@aws-sdk/client-secrets-manager` の import を TS/JS ファイルで検出すると error。TenkaCloud はコスト 0 運用を原則とし、秘匿値は SSM Parameter Store (SecureString, Standard tier = 無料) に置く。Secrets Manager はシークレット 1 件あたり月額課金が発生する。
+
+- `handler-must-not-call-fetch`
+  `lib/handlers/` 配下のファイルで `fetch(` の直接呼び出しを検出すると error。handler (Controller 層) は入力検証と Service 呼び出しとレスポンス整形のみを担い、外部 API 通信は Repository 層に閉じ込める。Controller に fetch を入れると Service / Repository の境界が崩れ、ユニットテストが HTTP モック前提になる。
+
+## Enforcement
+
+- `make harness` (= `bun run .claude/harness/bin/architecture.ts --staged --fail-on=error`)
+- `make harness-test` (= `cd .claude/harness && bunx vitest run`)
+- `make tech-debt` (= `bun run .claude/harness/bin/tech-debt.ts`)
+- `make before-commit`（`.claude/settings.json` の PreToolUse hook と `.husky/pre-commit` から自動実行）
+
+## Harness Commands
+
+- Staged ファイルに対する strict run: `make harness`
+- Harness ルール自体のユニットテスト: `make harness-test`
+- 技術的負債レポート生成: `make tech-debt`
+- コミット前チェック: `make before-commit`
+
+Git hook と AI エージェント向けガイドは、この文書を参照して同じ判定に従う。


### PR DESCRIPTION
## Summary

旧 docs が参照していた未存在の構成 (`server/microservices/`、`client/`、`packages/`、`make start`、`make test_quick` 等) をすべて削除し、現行の `apps/` + `infrastructure/` (SBT 0.3.9) 構成、3-phase deploy、Plane 配置、PROVISIONED 1/1 強制を反映してゼロから書き直し。

主な変更:

- **`CLAUDE.md` / `AGENTS.md` / `README.md`** をスクラッチでリライト。`README.md` は空ファイルだったので新規。
- **用語統一**: GameDay → Battle、JAM → Challenge (`metadata.json` の `category` enum と一致)。
- **`docs/architecture/harness.md`** に不足していた 4 つの ID (`INVARIANT_APP_CODE_IS_UNMODIFIED` / `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER` / `ONE_PASS_LOCAL` / `ONE_PASS_AWS`) を追記し `make harness` をクリーンに。
- **`/skill create-problem`** を旧 `problem.yaml` + `cloudformation/` + `scripts/deploy.sh` 構造から、実態の `metadata.json` + `template.yaml` + `NamePrefix` 規約に書き直し。
- **`/skill harness`** / **`/skill tech-debt`** を新規追加 (Makefile の `make harness` / `make tech-debt` と `.claude/harness/` 実装に揃える)。
- **PR Discipline 系 invariant** (`INVARIANT_PR_*`) を CLAUDE.md / AGENTS.md の品質ゲートと表に反映。

## Test plan

- [x] `bun run lint:md` — 0 errors
- [x] `bun run lint:text` — 0 errors
- [x] `bun run lint:format` — pre-existing warning のみ (本 PR と無関係の `apps/participant-portal/test/auth/storage.test.ts` の non-null assertion)
- [x] `bun run validate:problems` — 1 件すべて有効
- [x] `make harness` — Error: 0 / Warning: 0 (4 invariant 追記後)

## Regression 分析

ドキュメント / skill manifest のみの変更で、ビルド / ランタイム / CFn には差分が出ない。

確認した範囲:

- 触ったファイル: `CLAUDE.md`、`AGENTS.md`、`README.md`、`docs/architecture/harness.md`、`.claude/skills/create-problem/SKILL.md`、`.claude/skills/harness/SKILL.md` (新規)、`.claude/skills/tech-debt/SKILL.md` (新規)
- リンク切れ: `grep` で参照先 (`make harness`、`/skill harness` 等) が main の Makefile / `.claude/skills/` 構造と整合することを確認
- `/skill create-problem` の旧フォーマット (`problem.yaml`) を期待する自動化は調べた範囲では存在しない (CI / scripts / hooks に参照なし)
- `make harness` の rule `agent-guides-run-harness` が AGENTS.md / CLAUDE.md に `bun scripts/architecture-harness.ts --staged` の文字列を要求していたが、staged ファイルのみを対象とする実行モードでは現行 docs に含まれないとも error にならない (clean 出力で確認済)

## 物理影響

NO-OP。`make deploy` で変わる AWS リソースなし、`make build` の成果物にも差分なし (`apps/*/dist/` / CFn template に変更ゼロ)。Markdown ドキュメントと `.claude/skills/*/SKILL.md` のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)