### PR TITLE
feat(deploy): Participant Portal frontend を実 backend に結線 — PR-H3

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -1,0 +1,66 @@
+export type DeploymentStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "COMPLETE"
+  | "FAILED"
+  | "DELETING"
+  | "DELETED";
+
+export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+  "COMPLETE",
+  "FAILED",
+  "DELETED",
+]);
+
+export interface ParticipantView {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly teamName: string;
+  readonly region: string;
+  readonly status: DeploymentStatus;
+  readonly stackOutputs: Record<string, string>;
+  readonly failureReason?: string;
+  readonly expiresAt: number;
+}
+
+export class PortalAuthError extends Error {
+  constructor() {
+    super("チームログインキーが無効か、デプロイが既に削除されています。");
+    this.name = "PortalAuthError";
+  }
+}
+
+export class PortalNetworkError extends Error {
+  constructor(
+    public readonly status: number,
+    body: string,
+  ) {
+    super(`Portal API ${status}: ${body || "unknown"}`);
+    this.name = "PortalNetworkError";
+  }
+}
+
+/**
+ * `GET /portal/me` を `Authorization: Bearer <teamLoginKey>` で呼び、
+ * `ParticipantView` を返す。401 は `PortalAuthError`、それ以外の HTTP error は
+ * `PortalNetworkError`。Lambda 側 (PR-H2) と shape を一致させる。
+ */
+export async function getPortalMe(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  signal?: AbortSignal,
+): Promise<ParticipantView> {
+  const base = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
+  const url = new URL("portal/me", base);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { authorization: `Bearer ${teamLoginKey}` },
+    signal,
+  });
+  if (res.status === 401) throw new PortalAuthError();
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+  return (await res.json()) as ParticipantView;
+}

--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -1,11 +1,11 @@
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { getPortalMe, PortalAuthError } from "../api/portal-client";
 import type { AppConfig } from "../config";
 import { toAsciiSlug } from "../lib/slug";
 import { clearSession, loadSession, type ParticipantSession, saveSession } from "./storage";
 
-/**
- * Mock auth for `mode === "dev-mock"`. Real backend swaps in here behind the same I/F.
- */
+const DEFAULT_DEV_TTL_MS = 4 * 60 * 60 * 1000;
+
 async function exchangeKeyForSession(
   config: AppConfig,
   teamLoginKey: string,
@@ -15,9 +15,27 @@ async function exchangeKeyForSession(
     throw new Error("チームログインキーを入力してください");
   }
 
-  if (config.mode !== "dev-mock") {
-    // TODO: backend 実装時にここで fetch(`${config.apiBaseUrl}/login`, ...) する
-    throw new Error("backend が未実装のため、現状は dev モードでのみ login できます");
+  if (config.mode === "backend") {
+    // teamLoginKey 自体が bearer。backend が view を返したらそれを session 化する。
+    // sessionToken には teamLoginKey そのものを保管 (sessionStorage は same-origin
+    // 隔離されている前提) し、以降の polling でも同じキーを Authorization に乗せる。
+    let view: Awaited<ReturnType<typeof getPortalMe>>;
+    try {
+      view = await getPortalMe(config.apiBaseUrl, trimmed);
+    } catch (err) {
+      if (err instanceof PortalAuthError) throw err;
+      throw new Error(err instanceof Error ? err.message : "backend に接続できませんでした");
+    }
+    const now = Date.now();
+    return {
+      sessionToken: trimmed,
+      teamId: view.jobId,
+      teamName: view.teamName,
+      eventId: view.problemId,
+      issuedAt: now,
+      // backend の expiresAt は epoch seconds、storage は ms に揃える。
+      expiresAt: view.expiresAt > 0 ? view.expiresAt * 1000 : now + DEFAULT_DEV_TTL_MS,
+    };
   }
 
   const slug = toAsciiSlug(trimmed);
@@ -28,7 +46,7 @@ async function exchangeKeyForSession(
     teamName: `Team ${trimmed.slice(0, 8)}`,
     eventId: "mock-event-1",
     issuedAt: now,
-    expiresAt: now + 4 * 60 * 60 * 1000,
+    expiresAt: now + DEFAULT_DEV_TTL_MS,
   };
 }
 

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -1,18 +1,77 @@
-import Badge from "@cloudscape-design/components/badge";
+import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator, {
+  type StatusIndicatorProps,
+} from "@cloudscape-design/components/status-indicator";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type DeploymentStatus,
+  getPortalMe,
+  type ParticipantView,
+  PortalAuthError,
+  TERMINAL_STATUSES,
+} from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 
-/**
- * 認証済みの参加者が最初に見るページ。AWS GameDay 参考画面の Home に対応。
- */
+const POLL_INTERVAL_MS = 5_000;
+
+const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "success",
+  FAILED: "error",
+  DELETING: "in-progress",
+  DELETED: "stopped",
+};
+
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const teamName = auth.session?.teamName ?? "(unknown)";
+  const sessionToken = auth.session?.sessionToken ?? null;
+  const isBackend = config.mode === "backend";
+
+  const [view, setView] = useState<ParticipantView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const stopPollingRef = useRef(false);
+
+  const tick = useCallback(async () => {
+    if (!isBackend || !sessionToken) return;
+    try {
+      const next = await getPortalMe(config.apiBaseUrl, sessionToken);
+      setView(next);
+      setError(null);
+      if (TERMINAL_STATUSES.has(next.status)) stopPollingRef.current = true;
+    } catch (err) {
+      if (err instanceof PortalAuthError) {
+        // セッションが backend で無効化された (削除等)。logout して login へ戻す。
+        auth.logout();
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
+
+  useEffect(() => {
+    if (!isBackend || !sessionToken) return;
+    let cancelled = false;
+    stopPollingRef.current = false;
+    const run = async () => {
+      if (cancelled || stopPollingRef.current) return;
+      await tick();
+    };
+    void run();
+    const interval = setInterval(run, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isBackend, sessionToken, tick]);
 
   return (
     <SpaceBetween size="l">
@@ -20,33 +79,73 @@ export function HomePage({ config }: { config: AppConfig }) {
         Welcome, {teamName}
       </Header>
 
-      <Container header={<Header variant="h2">Event Information</Header>}>
-        <ColumnLayout columns={2} variant="text-grid">
-          <Stat label="Status">
-            <Badge color="green">In Progress</Badge>
-          </Stat>
-          <Stat label="Event region">{config.eventRegion}</Stat>
-        </ColumnLayout>
+      <Container header={<Header variant="h2">問題のデプロイ状況</Header>}>
+        <SpaceBetween size="m">
+          {!isBackend && (
+            <Alert type="info">
+              dev-mock モードで動作中です。実 backend と接続するには runtime-config の{" "}
+              <code>mode</code> を <code>backend</code> に設定してください。
+            </Alert>
+          )}
+          {error && (
+            <Alert type="error" header="状態の取得に失敗しました">
+              {error}
+            </Alert>
+          )}
+          {isBackend && !view && !error && <Box>状態を取得中...</Box>}
+          {view && (
+            <>
+              <StatusIndicator type={STATUS_TYPE[view.status]}>{view.status}</StatusIndicator>
+              {view.status === "FAILED" && view.failureReason && (
+                <Alert type="error" header="失敗理由">
+                  {view.failureReason}
+                </Alert>
+              )}
+              <ColumnLayout columns={2} variant="text-grid">
+                <KeyValuePairs
+                  items={[
+                    { label: "Problem", value: <code>{view.problemId}</code> },
+                    { label: "Region", value: view.region },
+                  ]}
+                />
+                <KeyValuePairs
+                  items={[
+                    { label: "Job ID", value: <code>{view.jobId}</code> },
+                    { label: "Team", value: view.teamName },
+                  ]}
+                />
+              </ColumnLayout>
+              {Object.keys(view.stackOutputs).length > 0 && (
+                <Container header={<Header variant="h3">アクセス先 URL</Header>}>
+                  <KeyValuePairs
+                    items={Object.entries(view.stackOutputs).map(([label, value]) => ({
+                      label,
+                      value: (
+                        <a href={value} target="_blank" rel="noreferrer noopener">
+                          <code>{value}</code>
+                        </a>
+                      ),
+                    }))}
+                  />
+                </Container>
+              )}
+              {!TERMINAL_STATUSES.has(view.status) && (
+                <Box variant="small" color="text-status-info">
+                  {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+                </Box>
+              )}
+            </>
+          )}
+        </SpaceBetween>
       </Container>
 
       <Container header={<Header variant="h2">これからやること</Header>}>
         <Box variant="p">
-          左メニューの <strong>Quests</strong> から、自チームに deploy された問題に
-          アクセスできます。スコア状況は <strong>Scoreboard</strong>、得点履歴は{" "}
-          <strong>Score events</strong>
-          で確認します。運営からの連絡は <strong>Notifications</strong> に届きます。 AWS Console
-          へのサインイン情報は <strong>Tools → SSO Credentials</strong> から取得します。
+          上のステータスが <strong>COMPLETE</strong> になると、CloudFormation Outputs に 表示される
+          URL から問題に取り組めます。スコア状況は <strong>Scoreboard</strong>
+          、得点履歴は <strong>Score events</strong> から確認してください。
         </Box>
       </Container>
     </SpaceBetween>
-  );
-}
-
-function Stat({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <Box variant="awsui-key-label">{label}</Box>
-      <div>{children}</div>
-    </div>
   );
 }

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getPortalMe,
+  PortalAuthError,
+  PortalNetworkError,
+  TERMINAL_STATUSES,
+} from "../../src/api/portal-client";
+
+const KEY = "AbCdEfGhIjKlMnOpQrStUvWx";
+const VIEW = {
+  jobId: "JOB1",
+  problemId: "p",
+  teamName: "Alpha",
+  region: "ap-northeast-1",
+  status: "COMPLETE",
+  stackOutputs: { FrontendUrl: "https://x" },
+  expiresAt: 1_700_000_000,
+};
+
+describe("getPortalMe", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("apiBaseUrl + /portal/me を Bearer 付きで GET し view を返すべき", async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(VIEW), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const view = await getPortalMe("https://api.example.com", KEY);
+    expect(view.jobId).toBe("JOB1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("https://api.example.com/portal/me");
+    expect(init.method).toBe("GET");
+    expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${KEY}`);
+  });
+
+  it("末尾スラッシュの有無で URL は同じになるべき", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify(VIEW), { status: 200 })),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getPortalMe("https://api.example.com/", KEY);
+    await getPortalMe("https://api.example.com", KEY);
+
+    const url1 = (fetchMock.mock.calls[0] as [URL])[0].toString();
+    const url2 = (fetchMock.mock.calls[1] as [URL])[0].toString();
+    expect(url1).toBe(url2);
+  });
+
+  it("401 は PortalAuthError を投げるべき", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+    await expect(getPortalMe("https://x", KEY)).rejects.toBeInstanceOf(PortalAuthError);
+  });
+
+  it("500 は PortalNetworkError (status と body 含む)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.resolve(new Response("ddb down", { status: 500 }))),
+    );
+    await expect(getPortalMe("https://x", KEY)).rejects.toBeInstanceOf(PortalNetworkError);
+    await expect(getPortalMe("https://x", KEY)).rejects.toThrow(/500.*ddb down/);
+  });
+
+  it("AbortSignal を fetch に伝播するべき", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify(VIEW), { status: 200 })),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctrl = new AbortController();
+    await getPortalMe("https://x", KEY, ctrl.signal);
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(init.signal).toBe(ctrl.signal);
+  });
+});
+
+describe("TERMINAL_STATUSES", () => {
+  it("COMPLETE / FAILED / DELETED を含むべき (poll 停止判定用)", () => {
+    expect(TERMINAL_STATUSES.has("COMPLETE")).toBe(true);
+    expect(TERMINAL_STATUSES.has("FAILED")).toBe(true);
+    expect(TERMINAL_STATUSES.has("DELETED")).toBe(true);
+  });
+
+  it("PENDING / IN_PROGRESS / DELETING は含まないべき", () => {
+    expect(TERMINAL_STATUSES.has("PENDING")).toBe(false);
+    expect(TERMINAL_STATUSES.has("IN_PROGRESS")).toBe(false);
+    expect(TERMINAL_STATUSES.has("DELETING")).toBe(false);
+  });
+});

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider, useAuth } from "../../src/auth/AuthProvider";
 import type { AppConfig } from "../../src/config";
 
@@ -23,7 +23,10 @@ const renderAuth = (config: AppConfig) =>
   });
 
 describe("AuthProvider", () => {
-  afterEach(() => sessionStorage.clear());
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
 
   it("初期状態は ready=true / session なしであるべき", () => {
     const { result } = renderAuth(devConfig);
@@ -69,10 +72,43 @@ describe("AuthProvider", () => {
     expect(result.current.session).toBeNull();
   });
 
-  it("prod config (= 本物 backend が必要) で login すると 'backend が未実装' で throw するべき", async () => {
+  it("backend mode: /portal/me を Bearer 付きで叩き session を構築するべき", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            jobId: "JOB1",
+            problemId: "p",
+            teamName: "Alpha",
+            region: "ap-northeast-1",
+            status: "COMPLETE",
+            stackOutputs: {},
+            expiresAt: 1_700_000_000,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
     const { result } = renderAuth(prodConfig);
     await act(async () => {
-      await expect(result.current.login("anything")).rejects.toThrow(/backend が未実装/);
+      await result.current.login("AbCdEfGhIjKlMnOpQrStUvWx");
+    });
+    expect(result.current.session).not.toBeNull();
+    expect(result.current.session?.teamId).toBe("JOB1");
+    expect(result.current.session?.teamName).toBe("Alpha");
+    expect(result.current.session?.eventId).toBe("p");
+    expect(result.current.session?.sessionToken).toBe("AbCdEfGhIjKlMnOpQrStUvWx");
+    expect(result.current.session?.expiresAt).toBe(1_700_000_000_000);
+  });
+
+  it("backend mode: 401 で PortalAuthError を throw、session は変わらないべき", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+    const { result } = renderAuth(prodConfig);
+    await act(async () => {
+      await expect(result.current.login("AbCdEfGhIjKlMnOpQrStUvWx")).rejects.toThrow(
+        /チームログインキーが無効/,
+      );
     });
     expect(result.current.session).toBeNull();
   });


### PR DESCRIPTION
## 概要

PR-H2 (#453) で立てた `/portal/me` Lambda に participant-portal frontend を結線し、`mode="backend"` で teamLoginKey 入力 → 実 backend 認証 → ライブステータス表示までの縦串を完成させる。

```
Competitor → CloudFront (PR-H1)
   ↓ teamLoginKey 入力
Portal frontend (mode=backend)
   ↓ Authorization: Bearer <teamLoginKey>
Lambda Function URL → DDB GSI2 Query (PR-H2)
   ↓
ParticipantView (status, stackOutputs, failureReason, ...)
   ↓ 5 秒 polling
Home page で live 表示 + 401 → auto-logout
```

## 追加 / 変更

### `api/portal-client.ts` (新規)
- `getPortalMe(apiBaseUrl, teamLoginKey, signal?)`: `GET /portal/me` を Bearer 付きで呼び `ParticipantView` を返す
- 401 は `PortalAuthError` (auth 系の UI 分岐用)、その他 HTTP error は `PortalNetworkError`
- `DeploymentStatus` / `ParticipantView` / `TERMINAL_STATUSES` を export

### `auth/AuthProvider.tsx`
- `mode === "backend"` 経路を実装: teamLoginKey で `getPortalMe` 検証 → `ParticipantSession` 構築 (`sessionToken = teamLoginKey` 自体、`teamId = jobId`、`teamName = view.teamName`、`eventId = view.problemId`、`expiresAt = view.expiresAt * 1000`)
- 401 はそのまま `PortalAuthError` で伝播 → Login Page で「キーが無効」表示
- 既存 dev-mock 経路は触らず後方互換

### `pages/Home.tsx`
- `mode === "backend"` のとき Home で `/portal/me` を 5 秒 polling
- ステータス (Cloudscape `StatusIndicator`)、CFn Outputs URL、失敗時の `failureReason` を live 表示
- polling 中の 401 は `auth.logout()` で login 画面へ自動誘導 (削除や expire への自然なフォールバック)
- terminal status (COMPLETE / FAILED / DELETED) で polling 停止

## Tests (30 → 38, +8)

- `api/portal-client.test.ts` 7 ケース: 200 / 末尾スラッシュ / 401 / 500 / AbortSignal 透過 / TERMINAL_STATUSES 包含
- `auth/AuthProvider.test.tsx` 既存 "backend が未実装で throw" を削除し、代わりに「backend mode で /portal/me を叩き session を構築する」「401 で PortalAuthError」を追加。dev-mock 既存 5 ケースは保持

## 設計判断

### sessionToken に teamLoginKey 自体を保管
backend はステートレス bearer を期待 (PR-H2)。session token を別途発行する代わりに、ユーザ入力の teamLoginKey を sessionStorage に置いて以降の polling で再利用する。sessionStorage は same-origin 隔離 + ブラウザを閉じれば消えるので運用想定 (1 試合の間しかセッションが要らない) と整合。

### 401 の auto-logout
backend が「行が削除された」「key が無効化された」と判定 (PR-H2 の DELETING/DELETED guard) すると 401 が返る。Home の polling が 401 を観測したら `auth.logout()` で session を破棄し、login へリダイレクト。Stale な session を放置しない。

### `cancelled` flag + clearInterval cleanup
polling は再 mount / sessionToken 変化で stale interval が残らないよう、useEffect cleanup で `cancelled = true` + `clearInterval`。in-flight の fetch resolve が unmount 後に setState を起こさない。

### 外部リンクは `rel="noreferrer noopener"`
`stackOutputs` の URL を新しい tab で開く (`target="_blank"`) ときに、競技者スタック側 (CFn 起動先) に opener / referrer を渡さない。tabnabbing 防止の defense-in-depth。

## ロードマップ

| PR | 内容 | 状態 |
|----|------|------|
| A〜F3.5 / 449-451 | deploy backend / UI / portal hosting | merged |
| #453 (PR-H2) | Portal backend Lambda + GSI2 + auth | merged |
| **PR-H3 (本 PR)** | Portal frontend `mode=backend` + live polling | review |

## Test plan

- [x] `bun --filter @TenkaCloud/participant-portal test` (38 pass)
- [x] `tsc --noEmit` clean
- [ ] dev 環境: `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` で deploy → POST `/problems/:id/deploy` で生成した teamLoginKey で Portal にログイン → Home が IN_PROGRESS / COMPLETE 遷移を表示することを目視
- [ ] 不正キーで 401 → Login 画面に戻ることを確認
- [ ] DELETE `/deployments/:jobId` 後に Home の polling が auto-logout することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)