### PR TITLE
fix(application-admin): runtime-config の deployApiUrl 空文字で全体が起動不能になる production バグを修正

### DIFF
--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -39,13 +39,17 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
     const res = await fetch("/runtime-config.json", { cache: "no-store" });
     if (!res.ok) return null;
     const data = (await res.json()) as Partial<RuntimeConfig>;
+    // 認証 + tenant + apiUrl がそろっていれば runtime-config を採用する。
+    // `deployApiUrl` は ProblemDeployBackendStack で HTTP API がまだ立っていない構成
+    // (CDK_PARAM_DEPLOY_USER_POOL_ID 未設定) では空文字で書き出されるため、ここで
+    // 必須にすると 「Cognito 設定はあるのに env fallback (= VITE_COGNITO_DOMAIN 要求)」
+    // に倒れて全体が起動不能になる。空のときは下流で dev fallback URL に倒す。
     if (
       !data.cognitoDomain ||
       !data.userClientId ||
       !data.tenantId ||
       !data.tenantName ||
-      !data.apiUrl ||
-      !data.deployApiUrl
+      !data.apiUrl
     )
       return null;
     return {
@@ -54,7 +58,7 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       tenantId: data.tenantId,
       tenantName: data.tenantName,
       apiUrl: data.apiUrl,
-      deployApiUrl: data.deployApiUrl,
+      deployApiUrl: data.deployApiUrl ?? "",
     };
   } catch {
     return null;
@@ -92,7 +96,10 @@ export async function loadConfig(
       tenantId: runtime.tenantId,
       tenantName: runtime.tenantName,
       apiBaseUrl: runtime.apiUrl,
-      deployApiBaseUrl: runtime.deployApiUrl,
+      // `deployApiUrl` は HTTP API 未配置時に空文字で来る。env / dev fallback に倒す
+      // ことで「全体は動くが deploy 機能だけ呼べない」状態 (= 部分 degrade) で起動する。
+      deployApiBaseUrl:
+        runtime.deployApiUrl || env.VITE_DEPLOY_API_BASE_URL || DEV_FALLBACK_DEPLOY_API_BASE_URL,
       redirectUri,
       scope,
     };

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -118,7 +118,31 @@ describe("loadConfig", () => {
       expect(config.apiBaseUrl).toBe("http://localhost:3999");
     });
 
-    it("deployApiUrl 欠け → env fallback に進むべき", async () => {
+    it("deployApiUrl 欠け / 空文字 → 他フィールドの runtime-config は採用し、deployApiBaseUrl のみ dev fallback に倒すべき (HTTP API 未配置運用の degrade)", async () => {
+      for (const deployApiUrl of [undefined, ""]) {
+        const body: Record<string, unknown> = {
+          cognitoDomain: "https://prod-cognito.example.com",
+          userClientId: "prod-client-id",
+          tenantId: "tenant-prod-1",
+          tenantName: "T",
+          apiUrl: "https://a",
+        };
+        if (deployApiUrl !== undefined) body.deployApiUrl = deployApiUrl;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status: 200 })),
+        );
+
+        const config = await loadConfig(env);
+        // runtime-config の他フィールドは採用される (env fallback に倒れない)
+        expect(config.cognitoDomain).toBe("https://prod-cognito.example.com");
+        expect(config.tenantId).toBe("tenant-prod-1");
+        // deployApiBaseUrl だけ env / dev fallback に
+        expect(config.deployApiBaseUrl).toBe("http://localhost:3998");
+      }
+    });
+
+    it("deployApiUrl 空 + VITE_DEPLOY_API_BASE_URL があれば env を使うべき", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(
@@ -129,14 +153,17 @@ describe("loadConfig", () => {
               tenantId: "tenant-prod-1",
               tenantName: "T",
               apiUrl: "https://a",
+              deployApiUrl: "",
             }),
             { status: 200 },
           ),
         ),
       );
-
-      const config = await loadConfig(env);
-      expect(config.deployApiBaseUrl).toBe("http://localhost:3998");
+      const config = await loadConfig({
+        ...env,
+        VITE_DEPLOY_API_BASE_URL: "https://override.example.com",
+      });
+      expect(config.deployApiBaseUrl).toBe("https://override.example.com");
     });
   });
 


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

\`CDK_PARAM_DEPLOY_USER_POOL_ID\` を設定していない production 環境で Application Plane の Cognito ログインが通るようになる (現状: 「Config load failed: Missing required env var: VITE_COGNITO_DOMAIN」で UI が一切出ない)。

## なぜ今これが要るか

ユーザの dev 環境で再現済みの blocker。\`runtime-config.json\` は Cognito 設定を正しく持っているのに、frontend が「\`deployApiUrl\` が空文字 = 欠損」と誤判定して runtime-config 全体を捨て、env fallback path に進んで \`VITE_COGNITO_DOMAIN\` を要求して落ちる。CDK redeploy では時間がかかるため frontend 側の degrade で即修正。

## 変更前 → 変更後のフロー

```mermaid
flowchart LR
    subgraph Before
      RC1[runtime-config.json: deployApiUrl=""] --> F1{!data.deployApiUrl?}
      F1 -- "true (空文字)" --> N1[null 返却]
      N1 --> E1[env fallback]
      E1 --> X1[VITE_COGNITO_DOMAIN throw]
    end
    subgraph After
      RC2[runtime-config.json: deployApiUrl=""] --> F2{cognitoDomain etc?}
      F2 -- ok --> RT2[runtime-config 採用]
      RT2 --> D2{deployApiUrl 空?}
      D2 -- yes --> DV2[deployApiBaseUrl = env or DEV_FALLBACK]
      D2 -- no --> RT2use[deployApiBaseUrl = runtime.deployApiUrl]
      DV2 --> OK2[Cognito ログインまで動く]
      RT2use --> OK2
    end
```

## 物理影響

### AWS リソース (\`make deploy\`)

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| (none) | (none) | NO-OP | frontend 修正のみ。CFT 差分ゼロ |

### ビルド成果物 (\`make build\`)

| パッケージ | 変更 |
|---|---|
| apps/application-admin-console | \`src/config.ts\` のロジック修正のみ。再 build + S3 upload で配信される |

## ファイルごとの変更意図

- \`apps/application-admin-console/src/config.ts\` — \`fetchRuntimeConfig\` から \`deployApiUrl\` 必須チェックを除外、\`loadConfig\` で空ならフォールバックに倒す
- \`apps/application-admin-console/test/config.test.ts\` — 新仕様 (空 deployApiUrl で他フィールドは runtime-config を採用) を反映、env override の追加ケース

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 / 対処 |
|---|---|---|---|---|
| 1 | \`deployApiUrl\` が runtime-config に正しく入っているケース | HTTP API 配置済み環境 | ✅ 確認済み | \`runtime.deployApiUrl ||\` の左辺が truthy なら従来通り採用 (test の「runtime-config が必須フィールドを全部返したとき」分岐) |
| 2 | runtime-config 完全 404 のケース (純 dev) | 開発者ローカル | ✅ 確認済み | env fallback path は不変 (test 「404 (dev fallback)」分岐) |
| 3 | \`apiUrl\` 欠けで env fallback に倒すべき挙動 | 古い runtime-config | ✅ 確認済み | 必須リストに残しているので不変 (test 「apiUrl 欠け → env fallback」) |
| 4 | env fallback path で \`VITE_COGNITO_DOMAIN\` 要求 | 純 dev mode | ✅ 確認済み | path 自体は同じ。\`required()\` は触らず |
| 5 | participant-portal の同様問題 | 別 app | ✅ 確認済み | participant-portal の \`config.ts\` は別実装で \`deployApiUrl\` を扱わないため無関係 (grep) |

## Rollback 手順

1. \`git revert <merge-sha>\` → 新 PR で main に戻す
2. \`make build\` + S3 upload で frontend を前バージョンに戻す
3. revert すると同じ \`Missing required env var\` で再発するため、revert する場合は \`CDK_PARAM_DEPLOY_USER_POOL_ID\` を運用側で確実にセットする必要がある

## テスト戦略

- 既存テストでカバーされる観点 — runtime-config 全フィールドあり / 完全 404 / apiUrl 欠け / cognitoDomain 欠け
- この PR で追加 / 変更したテスト
  - \`deployApiUrl 欠け / 空文字 → 他フィールドの runtime-config は採用、deployApiBaseUrl のみ dev fallback\` (undefined / "" の 2 ケース)
  - \`deployApiUrl 空 + VITE_DEPLOY_API_BASE_URL\` で env override
- 未カバー (受容する理由)
  - production runtime-config の実際の上書き挙動は manual 検証 (\`## Verification (merge 後)\`)

## Verification

### Merge 前 (DRAFT 解除条件)

- [x] \`make test\` (application-admin-console 58 / 全 app 全 pass)
- [x] \`make typecheck\`
- [x] \`make lint\`
- [x] \`make harness\`
- [x] \`make synth\` (frontend のみの変更だが念のため)
- [x] Regression 分析の未確認がゼロ
- [x] merge で動くようになる機能を 1 文で書けている

### Merge 後 (deploy 後 signal)

- [ ] \`bun run --cwd apps/application-admin-console build\` で dist 生成
- [ ] CloudFront 配信先の S3 に upload
- [ ] CloudFront cache invalidation (\`/index.html\` + \`/assets/*\`)
- [ ] dev 環境でログインページにアクセスし、\"Missing required env var\" が出ず Cognito Hosted UI に遷移することを目視

## 既知の未完了 (scope 外)

- **Infrastructure 側でも修正**: \`application-admin-console-hosting.ts\` で \`deployApiUrl\` を「undefined なら属性ごと省略」する形に変えれば runtime-config.json から空フィールド自体が消え、frontend 側のフォールバックも要らなくなる。両側で防御するのが理想だが、redeploy が要るので別 PR で対応
- **競技者向け portal の \`PATCH /portal/me\`** (PR-I-1 #455 で別途進行中) — このバグとは独立

🤖 Generated with [Claude Code](https://claude.com/claude-code)