### PR TITLE
docs(requirements + adr-001): Problem Deploy 機能の要件定義 + 実装案 (Draft)

### DIFF
--- a/docs/architecture/adr-001-problem-deploy-crud.md
+++ b/docs/architecture/adr-001-problem-deploy-crud.md
@@ -1,0 +1,157 @@
+# ADR-001: 問題 Deploy を CRUD × Step Functions で再設計する
+
+- **Status**: Proposed (2026-05-05)
+- **Supersedes**: 既存 `ProblemDeployBackendStack` の `DeployApiGateway` (専用 HTTP API + 単一 Cognito JWT authorizer) と `DeployWorkerLambda` (1 event = 1 CFn deploy) 構成
+- **Related issues**: #458 (publish 経路統一)、#459 (cross-account federation)
+
+## Context
+
+`ProblemDeployBackendStack` は **(a) 専用 HTTP API + 別 Cognito JWT authorizer** + **(b) 1 event = 1 Lambda invocation = 1 CFn deploy** という単発前提で書かれている。本構造は現状次の問題を抱える。
+
+- 単一 User Pool 信頼で multi-tenant SaaS (pooled / silo) と整合しない (#458)
+- `install.sh` が `ProblemDeployBackendStack` を deploy していない (operator が手動で env を export する設計になっている)
+- 1 deploy = 1 イベント = 1 Lambda 起動なので bulk operation が不可能 (operator は GameDay で N 問 × M チームを捌く)
+- Lambda 15 分 timeout の壁がある。CFn deploy は 5〜30 分かかるので Lambda 起動中に CFn が終わらないと「成功したのに Lambda 落ちた」状態になる。
+
+## Decision
+
+問題 Deploy を **CRUD 4 操作 × Step Functions の batch 処理** として再設計する。
+
+### 1. publish 経路は tenant API + tenant Cognito に統合
+
+```
+[application-admin-console (ログイン済)]
+        ↓ POST /deployments/{operation}  with tenant Cognito JWT
+[TenantTemplateStack の REST API]
+        ↓ Lambda が StepFunctions.StartExecution を呼ぶ
+[Step Functions]
+        ↓ 各 (problem × account) を Map iterator で処理
+[CFn API (cross-account AssumeRole 経由)]
+```
+
+専用 HTTP API + 別 Cognito の構成は廃止。tenant 自身の Cognito で認可する (= SBT の Control Plane → Application Plane と同型)。
+
+EventBridge 中継は **入れない** (subscriber が他に居ない時点で経路を増やす意味なし)。tenant API Lambda が `StepFunctions:StartExecution` を直接呼ぶ。
+
+### 2. CRUD 4 操作を 4 つの Step Functions state machine として表現する
+
+| 操作 | 用途 | API | State Machine | 内部 |
+|---|---|---|---|---|
+| **Create** | 新規 deploy (複数問題 × 複数アカウント) | POST /deployments/bulk-create | `BulkCreateStateMachine` | Map → AssumeRole → CFn CreateStack → .sync |
+| **Read** | 状況確認 (cross-account fan-out aggregation) | GET /deployments | `BulkReadStateMachine` (option) または同期 Lambda | Map → AssumeRole → CFn DescribeStacks |
+| **Update** | template の更新を既 deploy に push | POST /deployments/bulk-update | `BulkUpdateStateMachine` | Map → AssumeRole → CFn UpdateStack → .sync |
+| **Delete** | cleanup | POST /deployments/bulk-delete | `BulkDeleteStateMachine` | Map → AssumeRole → CFn DeleteStack → .sync |
+
+各 state machine は同じ shape の Map iterator を持つ。違いは inner step の CFn API だけ。
+
+### 3. Spec cap で size 問題を回避する
+
+API request 時に Zod で次のように cap する。
+
+- 1 リクエスト最大 500 entries (= problems × accounts)
+- 個別軸: max 10 problems × max 50 accounts (操作上の現実的上限)
+
+これを超える運用は複数バッチに分割する。実装側は size を考慮しない。
+
+### 4. 失敗時は continue + summary
+
+state machine の Map state に `Catch` で per-item 失敗を吸収。最後に `{ ok: N, failed: M, errors: [...] }` を返す。1 アカウントの IAM 不備で全 batch が止まる挙動は避ける (GameDay 想定)。
+
+### 5. 並列度は MaxConcurrency: 10 を default
+
+完全 sequential (1 並列) は 500 entry × 5 min = 41 時間で非現実的。`MaxConcurrency: 10` で 4 時間程度。Step Functions の同時実行 quota (1,000) には遠く及ばない。
+
+### 6. State の所在: CFn が source of truth、DDB は participant 体験用のみ
+
+- **deploy 状態** (PENDING / IN_PROGRESS / CREATE_COMPLETE / FAILED) → **CFn 自身が持つ**。`describe-stacks` で取得。
+- **deploy 履歴** (誰がいつ batch を投げたか) → **Step Functions execution history** (Standard で 1 年保持)。
+- **stack の所在カタログ** (operator UI の「自テナントの deploy 一覧」) → **CFn stack の Tag** (`TenkaCloud:TenantId`, `BatchId`, `ProblemId`)。Tag filter で逆引き。
+- **participant 体験用 state** (teamLoginKey、displayTeamName、将来のスコア) → **DDB `ParticipantSessions` テーブル** (現 `Deployments` テーブルから deploy 状態列を全部削除して縮小・改称)。
+
+つまり **既存 `Deployments` DDB の deploy 状態列 (status / failureReason / stackOutputs) は全廃止**。CFn が持っているものを DDB に複製しない。
+
+### 7. 既存 stack / Lambda の整理
+
+| Construct | 扱い |
+|---|---|
+| `ProblemDeployBackendStack.DeployApiGateway` | **削除** (専用 HTTP API 廃止) |
+| `ProblemDeployBackendStack.DeployApiLambda` | tenant API から呼び出される **「StartExecution + 入力 validation」薄 Lambda** にダイエット |
+| `ProblemDeployBackendStack.DeployWorkerLambda` | **廃止** (Step Functions が直接 CFn を呼ぶ) |
+| `ProblemDeployBackendStack.StatusUpdaterLambda` | **廃止** (CFn 自身が状態保持、polling は不要) |
+| `ProblemDeployBackendStack.DeploymentsTable` | **`ParticipantSessions` に改称 + 縮小** (deploy 状態列を全部削除、teamLoginKey / displayTeamName 等のみ残す) |
+| `ProblemDeployBackendStack.ParticipantPortalLambda` / `ParticipantPortalHosting` | **継続** (本 ADR と独立) |
+| `bin/infrastructure.ts` の `CDK_PARAM_DEPLOY_USER_POOL_ID` 周り | **削除** |
+| `application-admin-console` の `deployApiBaseUrl` / `useDeployApiClient` / `isDeployApiConfigured` | **削除** (`apiBaseUrl` に統合) |
+| `runtime-config.json.deployApiUrl` | **削除** (`apiUrl` のみ) |
+| `install.sh` の `cdk deploy` リスト | `ProblemDeployBackendStack` を **追加** |
+
+## Consequences
+
+### 良くなること
+
+- multi-tenant SaaS と整合する認可 (pooled / silo どちらの tenant も自身の Cognito で deploy 操作)
+- bulk operation が UI 1 click で N 問 × M アカウントに飛ばせる
+- Lambda 15 分 timeout の壁が消える (Step Functions `.sync` で CFn 完了を待つ)
+- DDB schema が participant state だけになって責務が明確
+- Step Functions Console から「ある batch が今どこまで進んでるか」「どの item で失敗したか」が GUI で見える
+- `make deploy` 1 発で Deploy 機能まで通る (`ONE_PASS_AWS` invariant 達成)
+
+### コスト・トレードオフ
+
+- Step Functions Standard の課金 (state transition 単価。500 entry × 4 transition ≈ 2,000 transitions ≈ $0.05 / batch)。GameDay 規模では無視できる
+- 既存 `Deployments` DDB に蓄積された deploy 履歴データは migration 不可 (CFn が持ってるから捨てる、もしくは read-only で保持して新規はそちらに書かない)
+- 4 つの state machine + 関連 IAM Role が CFn template を太らせる (resource 数 +20 くらい)
+
+## Alternatives considered
+
+### Alt-A: Lambda fan-out (SQS) で順次起動
+
+- ❌ Lambda 15 分 timeout で CFn 完了待ちが詰まる
+- ❌「Lambda 起動中に CFn が終わらないと別途 polling Lambda が要る」の罠
+
+### Alt-B: CodeBuild で実行
+
+- ❌ コンテナ起動 30 秒 × N の overhead
+- ❌ 状態機械を bash で書くことになり、retry / 並列度の制御が貧弱
+- △ 任意 script を実行できるのは利点だが、現スコープでは不要 (CFn API を呼ぶだけ)
+
+### Alt-C: ECS Task / Fargate
+
+- ❌ Container infra が増える (network / cluster / task definition の運用負荷)
+- ❌ 起動 latency が deploy あたり 30〜60 秒上乗せ
+
+### Alt-D: AWS Service Catalog
+
+- △ multi-account portfolio 共有が AWS native でできる
+- ❌ 学習コストと運用ノウハウが増える (Service Catalog 自体の権限 / ポートフォリオ管理)
+- ❌ tenant 拡張可能な問題カタログ (DDB) と Service Catalog 製品の二重管理になる
+
+→ Step Functions Standard が決定打。CodeBuild は将来「問題テンプレを動的生成してから deploy」が必要になったときの escape hatch として残す (現時点では使わない)。
+
+## Migration plan
+
+PR 単位で以下を分割実装する。各 PR が `INVARIANT_PR_SHIPS_WORKING_INCREMENT` を満たすこと。
+
+1. **PR-1: ADR commit** (本 PR)
+2. **PR-2: tenant API に Cognito authorizer + 空 routes 追加**。実 Lambda 配線はまだ。Single deploy だけ動く形で旧 DeployApiGateway と並存
+3. **PR-3: BulkCreateStateMachine 実装** + `POST /deployments/bulk-create` 配線。旧 single-deploy と並存
+4. **PR-4: BulkDeleteStateMachine + bulk-delete API**。旧 DELETE と並存
+5. **PR-5: BulkReadStateMachine (or sync Lambda) + GET /deployments fan-out**
+6. **PR-6: BulkUpdateStateMachine + bulk-update API**
+7. **PR-7: 旧 DeployApiGateway / DeployWorkerLambda / StatusUpdaterLambda 廃止 + DDB 縮小 (Deployments → ParticipantSessions 改称)**
+8. **PR-8: install.sh に ProblemDeployBackendStack を追加 + frontend cleanup (`deployApiBaseUrl` 撤去等)**
+
+PR-2 から PR-6 までは旧経路と並存し、PR-7 で旧経路を一気に廃止する。これで途中の各 PR が main に merge されても production が壊れない。
+
+## Open questions (本 ADR の scope 外)
+
+- **Cross-account federation の保存場所** (#459) — 競技者アカウントごとの ExternalId / RoleName / region をどこに持つか。Step Functions の入力に含めるための前提なので、本 ADR の実装着手前に #459 を ADR-002 として別途決定する必要がある。
+- **Problem catalog の DDB schema** (built-in repo + 拡張 DDB ハイブリッド、可視範囲モデル) — 本 ADR は「problem には S3 上の CFn template URL がある」を所与としている。問題カタログ自体の data model は別 ADR (ADR-003 予定)。
+- **Read state machine vs sync Lambda の選択** — Read は同期で済むので Lambda でも可だが、cross-account fan-out で 50 アカウントを叩くと数十秒かかる。Step Functions に揃えると一貫するが、逆に「単一ジョブの状態確認」の latency が悪化する。実装時に reassess する。
+
+## References
+
+- Issue #458 — Deploy 操作の publish 経路を SBT 同型 (tenant API + tenant Cognito) に統一する (本 ADR がスコープを拡張して supersede)
+- Issue #459 — Cross-account federation の保存・管理 (ADR-002 で決める)
+- CLAUDE.md — `ONE_PASS_AWS` invariant、`INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`
+- `docs/architecture/harness.md` — 既存 invariant 群

--- a/docs/architecture/adr-001-problem-deploy-crud.md
+++ b/docs/architecture/adr-001-problem-deploy-crud.md
@@ -17,32 +17,41 @@
 
 問題 Deploy を **CRUD 4 操作 × Step Functions の batch 処理** として再設計する。
 
-### 1. publish 経路は tenant API + tenant Cognito に統合
+### 1. publish 経路は tenant API + tenant Cognito + EventBridge → Step Functions
 
 ```
 [application-admin-console (ログイン済)]
         ↓ POST /deployments/{operation}  with tenant Cognito JWT
 [TenantTemplateStack の REST API]
-        ↓ Lambda が StepFunctions.StartExecution を呼ぶ
-[Step Functions]
+        ↓ Lambda が events:PutEvents を呼ぶ
+[EventBridge bus (= ControlPlaneStack.eventBusArn)]
+        ↓ EventBridge Rule (detail-type で分岐)
+[Step Functions State Machine (operation ごとに 1 つ)]
         ↓ 各 (problem × account) を Map iterator で処理
 [CFn API (cross-account AssumeRole 経由)]
 ```
 
 専用 HTTP API + 別 Cognito の構成は廃止。tenant 自身の Cognito で認可する (= SBT の Control Plane → Application Plane と同型)。
 
-EventBridge 中継は **入れない** (subscriber が他に居ない時点で経路を増やす意味なし)。tenant API Lambda が `StepFunctions:StartExecution` を直接呼ぶ。
+**Lambda は EventBridge に publish し、Step Functions は EventBridge Rule で event-driven に起動する**。Step Functions は EventBridge Rule の Target として直接設定可能 ([ドキュメント](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-eventbridge.html))。tenant API Lambda が StartExecution を直叩きせず EventBridge を中継する理由は次の 4 点。
 
-### 2. CRUD 4 操作を 4 つの Step Functions state machine として表現する
+1. **疎結合の seam を残す**: 将来の audit log / Slack 通知 / 監視 subscriber が同じ event を listen できる
+2. **SBT の既存パターンとの整合**: ControlPlane → ApplicationPlane の `onboardingRequest` event 中継と同じ形を維持
+3. **Replay / archive**: EventBridge archive で event を後から replay できる
+4. **権限境界の整理**: tenant API Lambda は `events:PutEvents` だけ持てば良く、`states:StartExecution` 権限を渡す必要がない
 
-| 操作 | 用途 | API | State Machine | 内部 |
+EventBridge detail-type は operation ごとに分ける (`DeployCreateRequested` / `DeployUpdateRequested` / `DeployDeleteRequested`)。Read は同期応答が必要なので EventBridge を経由せず、tenant API Lambda が直接 cross-account `cloudformation:DescribeStacks` を fan-out する。
+
+### 2. CRUD 4 操作を 3 つの event-driven state machine + 1 つの sync Lambda で表現する
+
+| 操作 | 用途 | API | 経路 | 内部 |
 |---|---|---|---|---|
-| **Create** | 新規 deploy (複数問題 × 複数アカウント) | POST /deployments/bulk-create | `BulkCreateStateMachine` | Map → AssumeRole → CFn CreateStack → .sync |
-| **Read** | 状況確認 (cross-account fan-out aggregation) | GET /deployments | `BulkReadStateMachine` (option) または同期 Lambda | Map → AssumeRole → CFn DescribeStacks |
-| **Update** | template の更新を既 deploy に push | POST /deployments/bulk-update | `BulkUpdateStateMachine` | Map → AssumeRole → CFn UpdateStack → .sync |
-| **Delete** | cleanup | POST /deployments/bulk-delete | `BulkDeleteStateMachine` | Map → AssumeRole → CFn DeleteStack → .sync |
+| **Create** | 新規 deploy (複数問題 × 複数アカウント) | POST /deployments/bulk-create | EventBridge (`DeployCreateRequested`) → `BulkCreateStateMachine` | Map → AssumeRole → CFn CreateStack → .sync |
+| **Read** | 状況確認 (cross-account fan-out aggregation) | GET /deployments | sync Lambda (cross-account `cloudformation:DescribeStacks` fan-out) | EventBridge 経由しない (同期応答が必要) |
+| **Update** | template の更新を既 deploy に push | POST /deployments/bulk-update | EventBridge (`DeployUpdateRequested`) → `BulkUpdateStateMachine` | Map → AssumeRole → CFn UpdateStack → .sync |
+| **Delete** | cleanup | POST /deployments/bulk-delete | EventBridge (`DeployDeleteRequested`) → `BulkDeleteStateMachine` | Map → AssumeRole → CFn DeleteStack → .sync |
 
-各 state machine は同じ shape の Map iterator を持つ。違いは inner step の CFn API だけ。
+3 つの state machine は同じ shape の Map iterator を持つ。違いは inner step の CFn API (CreateStack / UpdateStack / DeleteStack) だけ。各 state machine 専用の EventBridge Rule を 1 つ立て、Target を該当 state machine に設定する。
 
 ### 3. Spec cap で size 問題を回避する
 
@@ -134,10 +143,10 @@ PR 単位で以下を分割実装する。各 PR が `INVARIANT_PR_SHIPS_WORKING
 
 1. **PR-1: ADR commit** (本 PR)
 2. **PR-2: tenant API に Cognito authorizer + 空 routes 追加**。実 Lambda 配線はまだ。Single deploy だけ動く形で旧 DeployApiGateway と並存
-3. **PR-3: BulkCreateStateMachine 実装** + `POST /deployments/bulk-create` 配線。旧 single-deploy と並存
-4. **PR-4: BulkDeleteStateMachine + bulk-delete API**。旧 DELETE と並存
-5. **PR-5: BulkReadStateMachine (or sync Lambda) + GET /deployments fan-out**
-6. **PR-6: BulkUpdateStateMachine + bulk-update API**
+3. **PR-3: BulkCreateStateMachine + EventBridge Rule (`DeployCreateRequested`) + tenant API Lambda が `events:PutEvents`** 配線。`POST /deployments/bulk-create` で起動。旧 single-deploy と並存
+4. **PR-4: BulkDeleteStateMachine + EventBridge Rule (`DeployDeleteRequested`) + bulk-delete API**。旧 DELETE と並存
+5. **PR-5: GET /deployments の sync Lambda (cross-account DescribeStacks fan-out)**
+6. **PR-6: BulkUpdateStateMachine + EventBridge Rule (`DeployUpdateRequested`) + bulk-update API**
 7. **PR-7: 旧 DeployApiGateway / DeployWorkerLambda / StatusUpdaterLambda 廃止 + DDB 縮小 (Deployments → ParticipantSessions 改称)**
 8. **PR-8: install.sh に ProblemDeployBackendStack を追加 + frontend cleanup (`deployApiBaseUrl` 撤去等)**
 

--- a/docs/architecture/adr-001-problem-deploy-crud.md
+++ b/docs/architecture/adr-001-problem-deploy-crud.md
@@ -188,16 +188,20 @@ Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn
 
 ### Phase 1: MVP (Walking Skeleton) — 1 PR で end-to-end 1 経路を通す
 
-**PR-2 (MVP)**: 既存 UI の「Deploy 開始」ボタンを押すと、(問題 1 × アカウント 1) で Step Functions が起動して CFn deploy が成功するところまでを 1 PR で繋げる。
+**PR-2 (MVP)**: 既存 UI の「Deploy 開始」ボタンを押すと、(問題 1 × **同一 TenkaCloud AWS account 内**) で Step Functions が起動して CFn deploy が成功するところまでを 1 PR で繋げる。**MVP では cross-account を持ち込まない** — TenkaCloud 自社 AWS account 内に CFn stack を立てるだけ。これで「publish 経路 → Step Functions → CFn」のパス自体が動くことを証明する。cross-account / AssumeRole / ExternalId は Phase 2 (PR-3 以降) で重ねる。
 
 含める要素は次のとおり。
 
+- `ProblemTemplatesBucket` (S3 bucket) を `ProblemDeployBackendStack` 配下に新規作成 (versioning + lifecycle で旧版 30 日保持)
+- `install.sh` (= `make deploy`) に **repo の `problems/` ディレクトリ全体を `ProblemTemplatesBucket` へ sync する step** を追加 (`aws s3 sync problems/ s3://.../problems/`)。State Machine は `s3://.../problems/<id>/template.yaml` を CFn `TemplateURL` で参照する
+- 既存問題 (`security-battle-royale`) は CFn UserData が GitHub から Git clone して app コード (Flask api / MySQL-init / frontend) を取得する作りなので、**MVP では `template.yaml` を S3 に置くだけで動く**。`RepoUrl` / `RepoRef` はデフォルト値 (public TenkaCloud repo) を使う。private repo / S3 直配信が必要な問題種別への対応は Phase 2 で検討 (Open question 5 として後述)
 - `TenantTemplateStack` の REST API に Cognito authorizer + `POST /problems/{problemId}/deploy` route を追加 (要件 FR-2 Create の単発経路)
-- 同 route が tenant API Lambda を呼ぶ。Lambda は Zod validate → `events:PutEvents` で `DeployCreateRequested` を発行
+- 同 route が tenant API Lambda を呼ぶ。Lambda は Zod validate → S3 上の template URL を解決 → `events:PutEvents` で `DeployCreateRequested` を発行 (event detail に `templateUrl` を載せる)
 - EventBridge Rule (`source: tenkacloud.deploy`、`detail-type: DeployCreateRequested`) を作り、Target に `DeployCreateStateMachine` を設定
-- `DeployCreateStateMachine` は Distributed Map (要件 FR-1 を満たすが MVP では `deployments` 配列の長さ 1 しか入らない)。Map iterator は `AssumeRole` → `CloudFormation:CreateStack` (`.sync`) → 完了レポート
-- 競技者 IAM Role / ExternalId は `bin/infrastructure.ts` の env から渡す既存方式を流用 (#459 の解決前なのでハードコード気味、Phase 2 で改善)
+- `DeployCreateStateMachine` は Distributed Map (要件 FR-1 を満たすが MVP では `deployments` 配列の長さ 1 しか入らない)。Map iterator は **同一 account 内で** `CloudFormation:CreateStack` (`TemplateURL` で S3 上の template を指す) を `.sync` で完了待ち → 完了レポート (AssumeRole なし)
+- State Machine の execution role は CFn CreateStack / DescribeStacks を **同一 account 内のみ** に許可する単純な policy (cross-account は Phase 2 で追加)
 - `application-admin-console` の `useDeployApiClient` を `useApiClient` に切り替え、既存 `DeployFormModal` から新経路を叩く
+- DeployForm の `awsAccountId` 入力は MVP では使わない (= TenkaCloud 自社 account に固定)。input 自体は残しておくが値を Step Functions に渡さない、ような UI 上の degrade で十分
 - 旧 `DeployApiGateway` (専用 HTTP API + 別 Cognito) は **同 PR で削除する** (旧経路と並存させない、=「動く 1 本」だけが残る状態にする)
 - 旧 `DeployWorkerLambda` / `StatusUpdaterLambda` も同 PR で削除 (Step Functions が肩代わりするため)
 - `install.sh` の `cdk deploy` リストに `ProblemDeployBackendStack` を追加
@@ -238,6 +242,7 @@ PR-2 の MVP が main に入ったら、要件の残りを順に実装する。�
 - **`org-shared` の "組織" の定義** (要件 Open Question 1) — tenant のグループか、tenant 内の team か、ACL 列か。問題カタログ実装 (PR-3) 前に ADR-003 で確定する
 - **batch SLO の具体値** (要件 Open Question 4) — 並列度 50 で `~2h` という見積もりが要件として許容されるか、operator にフィードバックを取る
 - **失敗 item 再実行 API の冪等性** — CFn `CreateStack` の `AlreadyExists` をどう扱うか (成功扱い / 別エラー扱い)、再実行で stackName が衝突する場合の解決方針
+- **問題テンプレ依存ファイルの bundle 方式** (Phase 2) — 現在の問題 (`security-battle-royale`) は EC2 UserData の `git clone` で public TenkaCloud repo から app コード (Flask API / MySQL-init / frontend) を取ってくる作り。MVP では `template.yaml` だけ S3 に置けば動くが、private repo / 機密 / Lambda code zip 同梱が必要な問題が将来増えたとき、依存ファイル全体を S3 に bundle して UserData が `aws s3 cp` で取りに行く方式への切替が必要。問題種別ごとのテンプレ規約を整理する別 ADR で扱う
 
 ## References
 

--- a/docs/architecture/adr-001-problem-deploy-crud.md
+++ b/docs/architecture/adr-001-problem-deploy-crud.md
@@ -1,25 +1,29 @@
-# ADR-001: 問題 Deploy を CRUD × Step Functions で再設計する
+# ADR-001: 問題 Deploy を CRUD x Step Functions Distributed Map で実装する
 
 - **Status**: Proposed (2026-05-05)
+- **Requirements**: [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) の確定後に書き直し
 - **Supersedes**: 既存 `ProblemDeployBackendStack` の `DeployApiGateway` (専用 HTTP API + 単一 Cognito JWT authorizer) と `DeployWorkerLambda` (1 event = 1 CFn deploy) 構成
 - **Related issues**: #458 (publish 経路統一)、#459 (cross-account federation)
 
 ## Context
 
-`ProblemDeployBackendStack` は **(a) 専用 HTTP API + 別 Cognito JWT authorizer** + **(b) 1 event = 1 Lambda invocation = 1 CFn deploy** という単発前提で書かれている。本構造は現状次の問題を抱える。
+要件文書 [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) で確定した要件と、現状実装の `ProblemDeployBackendStack` のギャップを埋めるための設計判断を本 ADR で記録する。
 
-- 単一 User Pool 信頼で multi-tenant SaaS (pooled / silo) と整合しない (#458)
-- `install.sh` が `ProblemDeployBackendStack` を deploy していない (operator が手動で env を export する設計になっている)
-- 1 deploy = 1 イベント = 1 Lambda 起動なので bulk operation が不可能 (operator は GameDay で N 問 × M チームを捌く)
-- Lambda 15 分 timeout の壁がある。CFn deploy は 5〜30 分かかるので Lambda 起動中に CFn が終わらないと「成功したのに Lambda 落ちた」状態になる。
+要件側の主要な制約 (本 ADR の Decision を駆動するもの) は次のとおり。
+
+- **FR-1**: 1 batch あたり 750 stacks (= Challenge: 25 チーム × 30 問) を扱える bulk operation 必須
+- **FR-2**: CRUD 4 操作すべて要る (Update は問題作成 iteration 用途)
+- **FR-3**: 失敗時は部分 retry のみ。operator はデバッグできない
+- **FR-5**: 問題カタログ (S3 template + DDB metadata + 可視範囲)
+- **NFR-1**: operator は AWS 専門知識を持たない
+- **NFR-2**: operator は TenkaCloud 自社 AWS account を一切触らない
+- **NFR-3**: 競技者アカウントは野良 AWS account の可能性あり (= AWS Organizations 単位の共有が使えない)
 
 ## Decision
 
-問題 Deploy を **CRUD 4 操作 × Step Functions の batch 処理** として再設計する。
-
 ### 1. publish 経路は tenant API + tenant Cognito + EventBridge → Step Functions
 
-```
+```text
 [application-admin-console (ログイン済)]
         ↓ POST /deployments/{operation}  with tenant Cognito JWT
 [TenantTemplateStack の REST API]
@@ -27,11 +31,11 @@
 [EventBridge bus (= ControlPlaneStack.eventBusArn)]
         ↓ EventBridge Rule (detail-type で分岐)
 [Step Functions State Machine (operation ごとに 1 つ)]
-        ↓ 各 (problem × account) を Map iterator で処理
+        ↓ Distributed Map で各 (problem × account) を並列処理
 [CFn API (cross-account AssumeRole 経由)]
 ```
 
-専用 HTTP API + 別 Cognito の構成は廃止。tenant 自身の Cognito で認可する (= SBT の Control Plane → Application Plane と同型)。
+専用 HTTP API + 別 Cognito の構成は廃止 (NFR-2 と整合)。tenant 自身の Cognito で認可する (= SBT の Control Plane → Application Plane と同型)。
 
 **Lambda は EventBridge に publish し、Step Functions は EventBridge Rule で event-driven に起動する**。Step Functions は EventBridge Rule の Target として直接設定可能 ([ドキュメント](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-eventbridge.html))。tenant API Lambda が StartExecution を直叩きせず EventBridge を中継する理由は次の 4 点。
 
@@ -42,74 +46,106 @@
 
 EventBridge detail-type は operation ごとに分ける (`DeployCreateRequested` / `DeployUpdateRequested` / `DeployDeleteRequested`)。Read は同期応答が必要なので EventBridge を経由せず、tenant API Lambda が直接 cross-account `cloudformation:DescribeStacks` を fan-out する。
 
-### 2. CRUD 4 操作を 3 つの event-driven state machine + 1 つの sync Lambda で表現する
+### 2. CRUD 4 操作の API と State Machine 配置
 
-| 操作 | 用途 | API | 経路 | 内部 |
+要件 FR-2 で確定した 4 操作それぞれの実装方針。
+
+| 操作 | API | 経路 | 内部 | 駆動要件 |
 |---|---|---|---|---|
-| **Create** | 新規 deploy (複数問題 × 複数アカウント) | POST /deployments/bulk-create | EventBridge (`DeployCreateRequested`) → `BulkCreateStateMachine` | Map → AssumeRole → CFn CreateStack → .sync |
-| **Read** | 状況確認 (cross-account fan-out aggregation) | GET /deployments | sync Lambda (cross-account `cloudformation:DescribeStacks` fan-out) | EventBridge 経由しない (同期応答が必要) |
-| **Update** | template の更新を既 deploy に push | POST /deployments/bulk-update | EventBridge (`DeployUpdateRequested`) → `BulkUpdateStateMachine` | Map → AssumeRole → CFn UpdateStack → .sync |
-| **Delete** | cleanup | POST /deployments/bulk-delete | EventBridge (`DeployDeleteRequested`) → `BulkDeleteStateMachine` | Map → AssumeRole → CFn DeleteStack → .sync |
+| **Create** | `POST /deployments` | EventBridge (`DeployCreateRequested`) → `DeployCreateStateMachine` (Distributed Map) | AssumeRole → CFn CreateStack → `.sync` で完了待ち | FR-1 (bulk 750)、FR-5 (authoring iteration では 1 件) |
+| **Read** | `GET /deployments` | sync Lambda (cross-account `cloudformation:DescribeStacks` fan-out) | EventBridge を経由しない (同期応答が必要) | FR-3 (operator が UI で状況把握) |
+| **Update** | `POST /deployments/update` | EventBridge (`DeployUpdateRequested`) → `DeployUpdateStateMachine` (Distributed Map) | AssumeRole → CFn UpdateStack → `.sync` | FR-5 (authoring iteration、通常 1 件) |
+| **Delete** | `POST /deployments/delete` | EventBridge (`DeployDeleteRequested`) → `DeployDeleteStateMachine` (Distributed Map) | AssumeRole → CFn DeleteStack → `.sync` | FR-1 (event 終了時 bulk teardown)、FR-4 |
 
-3 つの state machine は同じ shape の Map iterator を持つ。違いは inner step の CFn API (CreateStack / UpdateStack / DeleteStack) だけ。各 state machine 専用の EventBridge Rule を 1 つ立て、Target を該当 state machine に設定する。
+3 つの state machine (Create / Update / Delete) は同じ shape の Distributed Map iterator を持つ。違いは inner step の CFn API (`CreateStack` / `UpdateStack` / `DeleteStack`) だけ。各 state machine 専用の EventBridge Rule を 1 つ立て、Target を該当 state machine に設定する。
 
-### 3. Spec cap で size 問題を回避する
+API は **bulk と単発を区別しない**。bulk request body は `{deployments: [{problemId, accountId, region, ...}]}`、単発は `deployments` 配列の長さが 1 のもの。authoring iteration (FR-5) では length=1、event preparation (FR-1) では length=750。state machine は同じものを iterator 1 件で回す。
 
-API request 時に Zod で次のように cap する。
+### 3. Distributed Map で 750 件の bulk を扱う
 
-- 1 リクエスト最大 500 entries (= problems × accounts)
-- 個別軸: max 10 problems × max 50 accounts (操作上の現実的上限)
+要件 FR-1 が「1 batch = 750 stacks」を要求するので、Step Functions の **Standard Map** ではなく **Distributed Map** を使う。
 
-これを超える運用は複数バッチに分割する。実装側は size を考慮しない。
+| 観点 | Standard Map | Distributed Map | 750 件で必要か |
+|---|---|---|---|
+| 入力サイズ上限 | state input 256 KB | S3 経由なら無制限、in-memory でも 100K entries まで | ✅ Distributed Map 必須 (750 × 500 bytes = 375 KB は 256 KB 超過) |
+| 並列度 | 40 | 10,000 | ✅ Distributed Map で並列化 |
+| 子実行の分離 | 親 execution の history 内 | 各 item が独立 child execution | ✅ 失敗 item の再実行が容易 (FR-3) |
+| 課金 | state transition のみ | child execution × state transition | △ コスト増だが許容 (後述) |
 
-### 4. 失敗時は continue + summary
+Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn `.sync` は Standard が要るので **Standard child execution** を選ぶ。
 
-state machine の Map state に `Catch` で per-item 失敗を吸収。最後に `{ ok: N, failed: M, errors: [...] }` を返す。1 アカウントの IAM 不備で全 batch が止まる挙動は避ける (GameDay 想定)。
+並列度 (`MaxConcurrency`) は **default 50** とする。750 件を並列 50 で回すと、CFn 1 件 5〜10 分と仮定して `750 / 50 × 7.5 min ≈ 113 min ≈ 2 時間`。Acceptance Criteria の「1 hour 以内」目標とは届かないので、CFn template の最適化 (リソース数削減 / VPC 持ち込み) と併せて改善する。並列度を上げるとカウンターパート側 AWS account の API rate limit に当たる懸念があるため、operator が「並列度を上げる/下げる」設定はしない (`MaxConcurrency: 50` 固定)。
 
-### 5. 並列度は MaxConcurrency: 10 を default
+### 4. 失敗時は continue + summary、再実行 API で部分 retry
 
-完全 sequential (1 並列) は 500 entry × 5 min = 41 時間で非現実的。`MaxConcurrency: 10` で 4 時間程度。Step Functions の同時実行 quota (1,000) には遠く及ばない。
+要件 FR-3 を満たすための具体実装。
 
-### 6. State の所在: CFn が source of truth、DDB は participant 体験用のみ
+- **Distributed Map の `ToleratedFailureCount` / `ToleratedFailurePercentage` を未設定** にする (= 失敗してもエラー扱いにせず、全 item を最後まで試す)
+- 各 child execution の Catch で per-item 失敗を吸収。最後に親が `{ ok: N, failed: M, failedItems: [...] }` を返す
+- 失敗 item の jobId を返り値に含めて、operator が同 batch を「失敗分だけ再実行」できるようにする
+  - UI 上のボタンは「失敗した N 件を再実行」と表示
+  - 内部的には `POST /deployments` で `{deployments: [失敗 item の subset]}` を再投げ
+  - 新しい batchId が振られるが、stack は同じ namePrefix で CFn 側が冪等に扱う (CreateStack の `AlreadyExists` を成功扱いにする等)
 
-- **deploy 状態** (PENDING / IN_PROGRESS / CREATE_COMPLETE / FAILED) → **CFn 自身が持つ**。`describe-stacks` で取得。
-- **deploy 履歴** (誰がいつ batch を投げたか) → **Step Functions execution history** (Standard で 1 年保持)。
-- **stack の所在カタログ** (operator UI の「自テナントの deploy 一覧」) → **CFn stack の Tag** (`TenkaCloud:TenantId`, `BatchId`, `ProblemId`)。Tag filter で逆引き。
-- **participant 体験用 state** (teamLoginKey、displayTeamName、将来のスコア) → **DDB `ParticipantSessions` テーブル** (現 `Deployments` テーブルから deploy 状態列を全部削除して縮小・改称)。
+### 5. 問題カタログ: S3 template + DDB metadata + 可視範囲
 
-つまり **既存 `Deployments` DDB の deploy 状態列 (status / failureReason / stackOutputs) は全廃止**。CFn が持っているものを DDB に複製しない。
+要件 FR-5 を実装するための data model。
+
+- **CFn テンプレ実体**: S3 bucket に置く。バージョンごとに別 key (例: `tenants/{tenantId}/problems/{problemId}/v{N}.yaml`) もしくは S3 versioning 利用
+- **問題メタデータ DDB** (新規 `Problems` テーブル):
+  - `PK = TENANT#{ownerTenantId}`, `SK = PROBLEM#{problemId}`
+  - 列: `title`, `description`, `templateS3Url`, `currentVersion`, `visibility` (`public` / `org-shared` / `private`), `createdAt`, `updatedAt`
+  - GSI1: `PK = VISIBILITY#public`, `SK = PROBLEM#{problemId}` で全 tenant への横断 list
+  - GSI2: `PK = ORG#{orgId}` (org-shared のための index、組織エンティティが確定後に活性化)
+- **CFn deploy 時の template 取得**: state machine が `templateS3Url` を CFn `CreateStack` の `TemplateURL` parameter に渡す。CFn が S3 から fetch する経路を使う (Lambda が pre-fetch しない)
+
+`org-shared` の "組織" 定義は Open Questions に残す (本 ADR では「将来 org-shared を扱うための GSI を予約」までしか書かない)。
+
+### 6. State の所在: CFn が source of truth、DDB は participant 体験用 + 問題カタログのみ
+
+要件 FR-4 (cleanup の保証範囲) との整合。
+
+- **deploy 状態** (PENDING / IN_PROGRESS / CREATE_COMPLETE / FAILED) → **CFn 自身が持つ**。`describe-stacks` で取得する。
+- **deploy 履歴** (誰がいつ batch を投げたか) → **Step Functions execution history** (Standard で 1 年保持)
+- **stack の所在カタログ** (operator UI の「自テナントの deploy 一覧」) → **CFn stack の Tag** (`TenkaCloud:TenantId`, `BatchId`, `ProblemId`, `JobId`) を参照する。Tag filter で逆引きする
+- **participant 体験用 state** (teamLoginKey、displayTeamName、将来のスコア) → **DDB `ParticipantSessions` テーブル** (現 `Deployments` テーブルを縮小・改称)
+- **問題カタログ** → 上述 (5) の `Problems` DDB
+
+つまり **既存 `Deployments` DDB の deploy 状態列 (status / failureReason / stackOutputs) は全廃止する**。CFn が持っているものを DDB に複製しない。
 
 ### 7. 既存 stack / Lambda の整理
 
-| Construct | 扱い |
-|---|---|
-| `ProblemDeployBackendStack.DeployApiGateway` | **削除** (専用 HTTP API 廃止) |
-| `ProblemDeployBackendStack.DeployApiLambda` | tenant API から呼び出される **「StartExecution + 入力 validation」薄 Lambda** にダイエット |
-| `ProblemDeployBackendStack.DeployWorkerLambda` | **廃止** (Step Functions が直接 CFn を呼ぶ) |
-| `ProblemDeployBackendStack.StatusUpdaterLambda` | **廃止** (CFn 自身が状態保持、polling は不要) |
-| `ProblemDeployBackendStack.DeploymentsTable` | **`ParticipantSessions` に改称 + 縮小** (deploy 状態列を全部削除、teamLoginKey / displayTeamName 等のみ残す) |
-| `ProblemDeployBackendStack.ParticipantPortalLambda` / `ParticipantPortalHosting` | **継続** (本 ADR と独立) |
-| `bin/infrastructure.ts` の `CDK_PARAM_DEPLOY_USER_POOL_ID` 周り | **削除** |
-| `application-admin-console` の `deployApiBaseUrl` / `useDeployApiClient` / `isDeployApiConfigured` | **削除** (`apiBaseUrl` に統合) |
-| `runtime-config.json.deployApiUrl` | **削除** (`apiUrl` のみ) |
-| `install.sh` の `cdk deploy` リスト | `ProblemDeployBackendStack` を **追加** |
+| Construct | 扱い | 駆動要件 |
+|---|---|---|
+| `ProblemDeployBackendStack.DeployApiGateway` | **削除** (専用 HTTP API 廃止) | NFR-2 |
+| `ProblemDeployBackendStack.DeployApiLambda` | **「StartExecution + 入力 validation」薄 Lambda** にダイエット (tenant API から呼ばれる) | FR-2 |
+| `ProblemDeployBackendStack.DeployWorkerLambda` | **廃止** (Step Functions が直接 CFn を呼ぶ) | FR-1 (15min timeout の壁を消す) |
+| `ProblemDeployBackendStack.StatusUpdaterLambda` | **廃止** (CFn 自身が状態保持、polling は不要) | FR-4 |
+| `ProblemDeployBackendStack.DeploymentsTable` | **`ParticipantSessions` に改称 + 縮小** (deploy 状態列を全部削除、teamLoginKey / displayTeamName 等のみ残す) | FR-4 |
+| `ProblemDeployBackendStack.ParticipantPortalLambda` / `ParticipantPortalHosting` | **継続** (本 ADR と独立) | - |
+| `bin/infrastructure.ts` の `CDK_PARAM_DEPLOY_USER_POOL_ID` 周り | **削除** | NFR-2 |
+| `application-admin-console` の `deployApiBaseUrl` / `useDeployApiClient` / `isDeployApiConfigured` | **削除** (`apiBaseUrl` に統合) | NFR-2 |
+| `runtime-config.json.deployApiUrl` | **削除** (`apiUrl` のみ) | NFR-2 |
+| `install.sh` の `cdk deploy` リスト | `ProblemDeployBackendStack` を **追加** | `ONE_PASS_AWS` invariant |
+| `ProblemDeployBackendStack` 配下の **新規 construct**: `ProblemsTable` (DDB)、`ProblemTemplatesBucket` (S3)、3 つの State Machine (Create / Update / Delete) | **追加** | FR-1 / FR-2 / FR-5 |
 
 ## Consequences
 
-### 良くなること
+### 良くなること (要件との対応)
 
-- multi-tenant SaaS と整合する認可 (pooled / silo どちらの tenant も自身の Cognito で deploy 操作)
-- bulk operation が UI 1 click で N 問 × M アカウントに飛ばせる
-- Lambda 15 分 timeout の壁が消える (Step Functions `.sync` で CFn 完了を待つ)
-- DDB schema が participant state だけになって責務が明確
-- Step Functions Console から「ある batch が今どこまで進んでるか」「どの item で失敗したか」が GUI で見える
-- `make deploy` 1 発で Deploy 機能まで通る (`ONE_PASS_AWS` invariant 達成)
+- ✅ NFR-2 (operator が AWS account を触らない) — 認可は tenant 自身の Cognito で完結
+- ✅ FR-1 (bulk 750 stacks) — Distributed Map で並列処理
+- ✅ FR-3 (部分 retry) — 失敗 item を返す API で operator が単純に「再実行」できる
+- ✅ FR-4 (cleanup の保証範囲) — CFn DeleteStack 成功までを responsibility に閉じ込め
+- ✅ FR-5 (authoring iteration) — 単発 (length=1) も bulk と同じ API で扱える
+- ✅ `ONE_PASS_AWS` invariant — `make deploy` 1 発で全動線が通る
 
 ### コスト・トレードオフ
 
-- Step Functions Standard の課金 (state transition 単価。500 entry × 4 transition ≈ 2,000 transitions ≈ $0.05 / batch)。GameDay 規模では無視できる
+- Step Functions Distributed Map の課金: child execution 単価。750 件 × 4 transitions × $0.025/1000 ≈ $0.075/batch。GameDay 規模 (月 10 イベント) で月 $1 未満
 - 既存 `Deployments` DDB に蓄積された deploy 履歴データは migration 不可 (CFn が持ってるから捨てる、もしくは read-only で保持して新規はそちらに書かない)
-- 4 つの state machine + 関連 IAM Role が CFn template を太らせる (resource 数 +20 くらい)
+- 新規 `Problems` DDB + S3 bucket + 3 つの state machine + EventBridge Rule で CFn template が +30 リソース程度太る
+- 並列度 50 では Acceptance Criteria の「1 hour 以内」は未達 (~2h)。CFn template 最適化と組合せでカバー、達成できなければ SLO 緩和または並列度上げの検討
 
 ## Alternatives considered
 
@@ -131,36 +167,84 @@ state machine の Map state に `Catch` で per-item 失敗を吸収。最後に
 
 ### Alt-D: AWS Service Catalog
 
-- △ multi-account portfolio 共有が AWS native でできる
-- ❌ 学習コストと運用ノウハウが増える (Service Catalog 自体の権限 / ポートフォリオ管理)
-- ❌ tenant 拡張可能な問題カタログ (DDB) と Service Catalog 製品の二重管理になる
+要件文書 (`docs/requirements/problem-deploy.md`) の「Service Catalog 採否の判断基準」セクションで詳細評価済み。
 
-→ Step Functions Standard が決定打。CodeBuild は将来「問題テンプレを動的生成してから deploy」が必要になったときの escape hatch として残す (現時点では使わない)。
+- ❌ NFR-3 (野良 AWS account 許容) で Service Catalog の AWS Organizations 単位 portfolio 共有が使えない
+- ❌ NFR-2 (operator が AWS Console を見ない) で Service Catalog の主 UI が直接使えない
+- △ provisioning engine 専用利用は技術的に可能だが、UI を SaaS 側で作る以上 Service Catalog のメリット (admin UI / portfolio 管理) が消える
+
+→ Step Functions Distributed Map が決定打。
+
+### Alt-E: Standard Map で並列起動 (本 ADR の前案)
+
+- ❌ 256 KB 入力上限で 750 件が入らない (FR-1 違反)
+- ❌ MaxConcurrency が最大 40
+
+→ Distributed Map に切り替えた。
 
 ## Migration plan
 
-PR 単位で以下を分割実装する。各 PR が `INVARIANT_PR_SHIPS_WORKING_INCREMENT` を満たすこと。
+実装の優先順位は **「まず MVP (Walking Skeleton) を 1 本通す → 動くことを確認してから多機能化」** とする。これは「実装はまず既存の Application 画面から Deploy 開始ボタンを押したら Step Functions が起動して問題が deploy される、を目指す」という運用方針。
 
-1. **PR-1: ADR commit** (本 PR)
-2. **PR-2: tenant API に Cognito authorizer + 空 routes 追加**。実 Lambda 配線はまだ。Single deploy だけ動く形で旧 DeployApiGateway と並存
-3. **PR-3: BulkCreateStateMachine + EventBridge Rule (`DeployCreateRequested`) + tenant API Lambda が `events:PutEvents`** 配線。`POST /deployments/bulk-create` で起動。旧 single-deploy と並存
-4. **PR-4: BulkDeleteStateMachine + EventBridge Rule (`DeployDeleteRequested`) + bulk-delete API**。旧 DELETE と並存
-5. **PR-5: GET /deployments の sync Lambda (cross-account DescribeStacks fan-out)**
-6. **PR-6: BulkUpdateStateMachine + EventBridge Rule (`DeployUpdateRequested`) + bulk-update API**
-7. **PR-7: 旧 DeployApiGateway / DeployWorkerLambda / StatusUpdaterLambda 廃止 + DDB 縮小 (Deployments → ParticipantSessions 改称)**
-8. **PR-8: install.sh に ProblemDeployBackendStack を追加 + frontend cleanup (`deployApiBaseUrl` 撤去等)**
+### Phase 1: MVP (Walking Skeleton) — 1 PR で end-to-end 1 経路を通す
 
-PR-2 から PR-6 までは旧経路と並存し、PR-7 で旧経路を一気に廃止する。これで途中の各 PR が main に merge されても production が壊れない。
+**PR-2 (MVP)**: 既存 UI の「Deploy 開始」ボタンを押すと、(問題 1 × アカウント 1) で Step Functions が起動して CFn deploy が成功するところまでを 1 PR で繋げる。
 
-## Open questions (本 ADR の scope 外)
+含める要素は次のとおり。
 
-- **Cross-account federation の保存場所** (#459) — 競技者アカウントごとの ExternalId / RoleName / region をどこに持つか。Step Functions の入力に含めるための前提なので、本 ADR の実装着手前に #459 を ADR-002 として別途決定する必要がある。
-- **Problem catalog の DDB schema** (built-in repo + 拡張 DDB ハイブリッド、可視範囲モデル) — 本 ADR は「problem には S3 上の CFn template URL がある」を所与としている。問題カタログ自体の data model は別 ADR (ADR-003 予定)。
-- **Read state machine vs sync Lambda の選択** — Read は同期で済むので Lambda でも可だが、cross-account fan-out で 50 アカウントを叩くと数十秒かかる。Step Functions に揃えると一貫するが、逆に「単一ジョブの状態確認」の latency が悪化する。実装時に reassess する。
+- `TenantTemplateStack` の REST API に Cognito authorizer + `POST /problems/{problemId}/deploy` route を追加 (要件 FR-2 Create の単発経路)
+- 同 route が tenant API Lambda を呼ぶ。Lambda は Zod validate → `events:PutEvents` で `DeployCreateRequested` を発行
+- EventBridge Rule (`source: tenkacloud.deploy`、`detail-type: DeployCreateRequested`) を作り、Target に `DeployCreateStateMachine` を設定
+- `DeployCreateStateMachine` は Distributed Map (要件 FR-1 を満たすが MVP では `deployments` 配列の長さ 1 しか入らない)。Map iterator は `AssumeRole` → `CloudFormation:CreateStack` (`.sync`) → 完了レポート
+- 競技者 IAM Role / ExternalId は `bin/infrastructure.ts` の env から渡す既存方式を流用 (#459 の解決前なのでハードコード気味、Phase 2 で改善)
+- `application-admin-console` の `useDeployApiClient` を `useApiClient` に切り替え、既存 `DeployFormModal` から新経路を叩く
+- 旧 `DeployApiGateway` (専用 HTTP API + 別 Cognito) は **同 PR で削除する** (旧経路と並存させない、=「動く 1 本」だけが残る状態にする)
+- 旧 `DeployWorkerLambda` / `StatusUpdaterLambda` も同 PR で削除 (Step Functions が肩代わりするため)
+- `install.sh` の `cdk deploy` リストに `ProblemDeployBackendStack` を追加
+- frontend の `deployApiBaseUrl` / `isDeployApiConfigured` / `runtime-config.deployApiUrl` を削除
+
+含めない要素 (Phase 2 に倒す)。
+
+- 問題カタログ DDB / S3 (= 既存の repo `problems/<id>/template.yaml` をそのまま使う、`templateS3Url` は CFn template 直アップロードで代用)
+- bulk operation (deployments 配列は length=1 固定)
+- Update / Delete / Read fan-out
+- 失敗時の部分 retry UX (失敗したら再投げのみ、UI は単純なエラー表示)
+- ParticipantSessions DDB 改称 (現 `Deployments` テーブル名のまま、ただし deploy 状態列は使わない)
+
+完了条件 (PR-2 の DoD) は次のとおり。
+
+- `make deploy` 1 発で AWS 上の経路が立ち上がる
+- application-admin-console から「Deploy」ボタン → 競技者アカウントに CFn stack が作られる
+- operator は AWS Console / CLI を一切触らない
+
+### Phase 2: 多機能化 (MVP が動いてから着手)
+
+PR-2 の MVP が main に入ったら、要件の残りを順に実装する。順序は要件側の依存と Open questions 解決順に従う。
+
+1. **PR-3: ADR-002 (Cross-account federation)** + 競技者アカウント登録 UI / DDB / SSM SecureString。Issue #459 の決着
+2. **PR-4: ADR-003 (問題カタログ + 可視範囲) + `ProblemsTable` (DDB) + `ProblemTemplatesBucket` (S3) + 問題管理 API + UI**。FR-5 の authoring 基盤
+3. **PR-5: bulk Create**。`POST /deployments` で `deployments[]` を 750 件まで受け取れるようにし、UI で「複数選択 → 一括 Deploy」を生やす。内部実装は PR-2 の Distributed Map をそのまま使う (entry 数だけ増える)
+4. **PR-6: `DeployDeleteStateMachine` + Delete API + UI 「batch を Delete」**。FR-1 (event 終了時 bulk teardown) の経路
+5. **PR-7: `DeployUpdateStateMachine` + Update API + UI**。FR-5 (authoring iteration) の単発 Update
+6. **PR-8: `GET /deployments` の sync Lambda (cross-account DescribeStacks fan-out)**。FR-3 (operator が状況を画面で見る)
+7. **PR-9: 失敗 item 再実行 UX**。FR-3 の「失敗した分だけ再実行」ボタン
+8. **PR-10: `Deployments` → `ParticipantSessions` 改称 + deploy 状態列削除**。data model 整理
+
+各 PR は依然 `INVARIANT_PR_SHIPS_WORKING_INCREMENT` を満たす。Phase 2 の各 PR は MVP の上に機能を「積み増す」形なので、merge ごとに operator から見える機能が 1 つ増える。
+
+## Open questions (本 ADR の scope 外、後続で確定する)
+
+- **Cross-account federation の保存場所** (#459) — 競技者アカウントごとの ExternalId / RoleName / region をどこに持つか。Step Functions の入力に含めるための前提なので、本 ADR の実装着手 (PR-4 以降) 前に #459 を ADR-002 として別途確定する必要がある
+- **`org-shared` の "組織" の定義** (要件 Open Question 1) — tenant のグループか、tenant 内の team か、ACL 列か。問題カタログ実装 (PR-3) 前に ADR-003 で確定する
+- **batch SLO の具体値** (要件 Open Question 4) — 並列度 50 で `~2h` という見積もりが要件として許容されるか、operator にフィードバックを取る
+- **失敗 item 再実行 API の冪等性** — CFn `CreateStack` の `AlreadyExists` をどう扱うか (成功扱い / 別エラー扱い)、再実行で stackName が衝突する場合の解決方針
 
 ## References
 
+- [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) — 本 ADR が満たすべき要件 (FR-1〜6 / NFR-1〜4 / Acceptance Criteria)
 - Issue #458 — Deploy 操作の publish 経路を SBT 同型 (tenant API + tenant Cognito) に統一する (本 ADR がスコープを拡張して supersede)
 - Issue #459 — Cross-account federation の保存・管理 (ADR-002 で決める)
 - CLAUDE.md — `ONE_PASS_AWS` invariant、`INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`
 - `docs/architecture/harness.md` — 既存 invariant 群
+- AWS docs: [Step Functions Distributed Map](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-distributed.html)
+- AWS docs: [EventBridge → Step Functions Rule](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-eventbridge.html)

--- a/docs/architecture/adr-001-problem-deploy-crud.md
+++ b/docs/architecture/adr-001-problem-deploy-crud.md
@@ -1,9 +1,9 @@
 # ADR-001: 問題 Deploy を CRUD x Step Functions Distributed Map で実装する
 
 - **Status**: Proposed (2026-05-05)
-- **Requirements**: [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) の確定後に書き直し
+- **Requirements**: [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) (Approved)
 - **Supersedes**: 既存 `ProblemDeployBackendStack` の `DeployApiGateway` (専用 HTTP API + 単一 Cognito JWT authorizer) と `DeployWorkerLambda` (1 event = 1 CFn deploy) 構成
-- **Related issues**: #458 (publish 経路統一)、#459 (cross-account federation)
+- **Related issues**: Issue 458 (publish 経路統一)、Issue 459 (cross-account federation)
 
 ## Context
 
@@ -37,7 +37,7 @@
 
 専用 HTTP API + 別 Cognito の構成は廃止 (NFR-2 と整合)。tenant 自身の Cognito で認可する (= SBT の Control Plane → Application Plane と同型)。
 
-**Lambda は EventBridge に publish し、Step Functions は EventBridge Rule で event-driven に起動する**。Step Functions は EventBridge Rule の Target として直接設定可能 ([ドキュメント](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-eventbridge.html))。tenant API Lambda が StartExecution を直叩きせず EventBridge を中継する理由は次の 4 点。
+**Lambda は EventBridge に publish し、Step Functions は EventBridge Rule で event-driven に起動する**。Step Functions State Machine は EventBridge Rule の **native target** として設定可能 ([AWS docs: EventBridge Targets](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html#eb-console-targets))。仕組みは EventBridge Rule に専用 IAM Role (`states:StartExecution` 権限) を持たせ、event 受信時に EventBridge がその Role を assume して `StartExecution` を呼ぶ。Lambda 中継は不要 (CDK では `aws-events-targets.SfnStateMachine` で 1 行)。tenant API Lambda が StartExecution を直叩きせず EventBridge を中継する理由は次の 4 点。
 
 1. **疎結合の seam を残す**: 将来の audit log / Slack 通知 / 監視 subscriber が同じ event を listen できる
 2. **SBT の既存パターンとの整合**: ControlPlane → ApplicationPlane の `onboardingRequest` event 中継と同じ形を維持
@@ -107,7 +107,7 @@ Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn
 
 - **deploy 状態** (PENDING / IN_PROGRESS / CREATE_COMPLETE / FAILED) → **CFn 自身が持つ**。`describe-stacks` で取得する。
 - **deploy 履歴** (誰がいつ batch を投げたか) → **Step Functions execution history** (Standard で 1 年保持)
-- **stack の所在カタログ** (operator UI の「自テナントの deploy 一覧」) → **CFn stack の Tag** (`TenkaCloud:TenantId`, `BatchId`, `ProblemId`, `JobId`) を参照する。Tag filter で逆引きする
+- **stack の所在カタログ** (operator UI の「自テナントの deploy 一覧」) → **CFn stack の Tag** (`TenkaCloud:TenantId`, `BatchId`, `ProblemId`, `JobId`) を打つ。逆引きの実装は次の 2 通りで実装する。`cloudformation:DescribeStacks` 自体は tag filter をサポートしないため、(a) `resource-groups:GetResources` (Resource Groups Tagging API、tag filter ネイティブ対応) を使うか、(b) `cloudformation:ListStacks` で取得後 client-side filter する。MVP では同一 account なので 1 回の `ListStacks` 結果を tenantId tag で絞る (b) が単純。Phase 2 で cross-account になったら各 account で `GetResources` を fan-out (a) に切替検討
 - **participant 体験用 state** (teamLoginKey、displayTeamName、将来のスコア) → **DDB `ParticipantSessions` テーブル** (現 `Deployments` テーブルを縮小・改称)
 - **問題カタログ** → 上述 (5) の `Problems` DDB
 
@@ -142,7 +142,7 @@ Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn
 
 ### コスト・トレードオフ
 
-- Step Functions Distributed Map の課金: child execution 単価。750 件 × 4 transitions × $0.025/1000 ≈ $0.075/batch。GameDay 規模 (月 10 イベント) で月 $1 未満
+- Step Functions Distributed Map の課金: child execution × state transition 単価。CFn `.sync` の wait loop で transition 数が膨らむため、1 child execution あたり ~8 transitions と見積もり。750 × 8 × $0.025/1000 ≈ $0.15/batch + 親の Distributed Map 自体の transition。月 10 イベントでも $2 未満なので許容
 - 既存 `Deployments` DDB に蓄積された deploy 履歴データは migration 不可 (CFn が持ってるから捨てる、もしくは read-only で保持して新規はそちらに書かない)
 - 新規 `Problems` DDB + S3 bucket + 3 つの state machine + EventBridge Rule で CFn template が +30 リソース程度太る
 - 並列度 50 では Acceptance Criteria の「1 hour 以内」は未達 (~2h)。CFn template 最適化と組合せでカバー、達成できなければ SLO 緩和または並列度上げの検討
@@ -186,9 +186,36 @@ Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn
 
 実装の優先順位は **「まず MVP (Walking Skeleton) を 1 本通す → 動くことを確認してから多機能化」** とする。これは「実装はまず既存の Application 画面から Deploy 開始ボタンを押したら Step Functions が起動して問題が deploy される、を目指す」という運用方針。
 
-### Phase 1: MVP (Walking Skeleton) — 1 PR で end-to-end 1 経路を通す
+### Phase 1a: MVP-0 — シェルで CFn deploy が通ることを確認する
 
-**PR-2 (MVP)**: 既存 UI の「Deploy 開始」ボタンを押すと、(問題 1 × **同一 TenkaCloud AWS account 内**) で Step Functions が起動して CFn deploy が成功するところまでを 1 PR で繋げる。**MVP では cross-account を持ち込まない** — TenkaCloud 自社 AWS account 内に CFn stack を立てるだけ。これで「publish 経路 → Step Functions → CFn」のパス自体が動くことを証明する。cross-account / AssumeRole / ExternalId は Phase 2 (PR-3 以降) で重ねる。
+**PR-1.5 (MVP-0)**: `scripts/deploy-battles.sh` (= 引数に問題フォルダを取り、順次 CFn deploy する shell script) と `make deploy-battles` ターゲットを追加し、AWS CLI セッションから「`problems/<id>/template.yaml` を CFn deploy → smoke 動作確認 → `make destroy-battles` で teardown」までできる状態を作る。
+
+**狙い**: SaaS 配線 (Step Functions / EventBridge / tenant API / Cognito) を一切持ち込まず、**まず CFn template 自体と AWS 権限の正しさを smoke test する**。スクリプトとして deploy ロジックが固まれば、Phase 1b の orchestration はそのスクリプトをそのまま実行する形に乗せ替えるだけで済む。これは SBT の `BashJobRunner` (CodeBuild が provision-tenant.sh を実行する) と同じパターン。
+
+含める要素は次のとおり。
+
+- `scripts/deploy-battles.sh` (新規): 引数 1 個以上で問題ディレクトリ (`problems/gameday/security-battle-royale` 等) を受け取り、各々を順次 `aws cloudformation deploy` で同一 account に deploy する。teamSlug は env か引数で受ける
+- `scripts/destroy-battles.sh` (新規): 同じ引数で `aws cloudformation delete-stack` を順次呼ぶ
+- `Makefile` に `deploy-battles` / `destroy-battles` ターゲットを追加 (内部で上のシェルを呼ぶ。default 引数は `problems/gameday/security-battle-royale demo-team`)
+- これは「開発者が deploy 機構を smoke test するためのツール」であり、operator UX には繋がらない (operator は引き続き旧 UI 経路を使う)
+
+含めない要素 (Phase 1b 以降に倒す)。
+
+- Step Functions / EventBridge / CodeBuild / tenant API / Cognito 関連の変更
+- 既存 `ProblemDeployBackendStack` の構成変更 (= 旧経路はそのまま放置)
+- frontend の変更
+- bulk operation の並列化 (sequential ループのみ。並列化は Phase 2 の Distributed Map で扱う)
+
+完了条件 (PR-1.5 の DoD) は次のとおり。
+
+- `make deploy-battles` を流すと CFn stack が立ち、`security-battle-royale` の EC2 + nginx + Flask api + MySQL が動く (frontend URL が 200 を返す)
+- `make destroy-battles` で stack が消える (`DeleteStack` が成功)
+- 引数で複数問題を渡したときに順次 deploy される
+- 両 target が developer の AWS CLI セッションで実行できる (operator は使わない)
+
+### Phase 1b: MVP-1 — 既存 UI の Deploy ボタンを Step Functions 経路に切り替える
+
+**PR-2 (MVP-1)**: 既存 UI の「Deploy 開始」ボタンを押すと、(問題 1 × **同一 TenkaCloud AWS account 内**) で Step Functions が起動して CFn deploy が成功するところまでを 1 PR で繋げる。**MVP-1 でも cross-account を持ち込まない** — TenkaCloud 自社 AWS account 内に CFn stack を立てるだけ。これで「publish 経路 → Step Functions → CFn」のパス自体が動くことを証明する。cross-account / AssumeRole / ExternalId は Phase 2 (PR-3 以降) で重ねる。
 
 含める要素は次のとおり。
 
@@ -225,7 +252,7 @@ Distributed Map の child execution は `EXPRESS` workflow にできるが、CFn
 
 PR-2 の MVP が main に入ったら、要件の残りを順に実装する。順序は要件側の依存と Open questions 解決順に従う。
 
-1. **PR-3: ADR-002 (Cross-account federation)** + 競技者アカウント登録 UI / DDB / SSM SecureString。Issue #459 の決着
+1. **PR-3: ADR-002 (Cross-account federation)** + 競技者アカウント登録 UI / DDB / SSM SecureString。Issue (#459) の決着
 2. **PR-4: ADR-003 (問題カタログ + 可視範囲) + `ProblemsTable` (DDB) + `ProblemTemplatesBucket` (S3) + 問題管理 API + UI**。FR-5 の authoring 基盤
 3. **PR-5: bulk Create**。`POST /deployments` で `deployments[]` を 750 件まで受け取れるようにし、UI で「複数選択 → 一括 Deploy」を生やす。内部実装は PR-2 の Distributed Map をそのまま使う (entry 数だけ増える)
 4. **PR-6: `DeployDeleteStateMachine` + Delete API + UI 「batch を Delete」**。FR-1 (event 終了時 bulk teardown) の経路
@@ -238,17 +265,18 @@ PR-2 の MVP が main に入ったら、要件の残りを順に実装する。�
 
 ## Open questions (本 ADR の scope 外、後続で確定する)
 
-- **Cross-account federation の保存場所** (#459) — 競技者アカウントごとの ExternalId / RoleName / region をどこに持つか。Step Functions の入力に含めるための前提なので、本 ADR の実装着手 (PR-4 以降) 前に #459 を ADR-002 として別途確定する必要がある
+- **Cross-account federation の保存場所** (Issue (#459)) — 競技者アカウントごとの ExternalId / RoleName / region をどこに持つか。Step Functions の入力に含めるための前提なので、本 ADR の実装着手 (PR-4 以降) 前に Issue (#459) を ADR-002 として別途確定する必要がある
 - **`org-shared` の "組織" の定義** (要件 Open Question 1) — tenant のグループか、tenant 内の team か、ACL 列か。問題カタログ実装 (PR-3) 前に ADR-003 で確定する
 - **batch SLO の具体値** (要件 Open Question 4) — 並列度 50 で `~2h` という見積もりが要件として許容されるか、operator にフィードバックを取る
 - **失敗 item 再実行 API の冪等性** — CFn `CreateStack` の `AlreadyExists` をどう扱うか (成功扱い / 別エラー扱い)、再実行で stackName が衝突する場合の解決方針
+- **`ParticipantSessions` DDB の cleanup policy** — CFn `DeleteStack` 成功後、`teamLoginKey` / `displayTeamName` 等の participant 体験用 row はいつ削除するか。「競技履歴として保持」と「DeleteStack 成功イベントで cascade 削除」の 2 案を PR-10 で確定する
 - **問題テンプレ依存ファイルの bundle 方式** (Phase 2) — 現在の問題 (`security-battle-royale`) は EC2 UserData の `git clone` で public TenkaCloud repo から app コード (Flask API / MySQL-init / frontend) を取ってくる作り。MVP では `template.yaml` だけ S3 に置けば動くが、private repo / 機密 / Lambda code zip 同梱が必要な問題が将来増えたとき、依存ファイル全体を S3 に bundle して UserData が `aws s3 cp` で取りに行く方式への切替が必要。問題種別ごとのテンプレ規約を整理する別 ADR で扱う
 
 ## References
 
 - [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) — 本 ADR が満たすべき要件 (FR-1〜6 / NFR-1〜4 / Acceptance Criteria)
-- Issue #458 — Deploy 操作の publish 経路を SBT 同型 (tenant API + tenant Cognito) に統一する (本 ADR がスコープを拡張して supersede)
-- Issue #459 — Cross-account federation の保存・管理 (ADR-002 で決める)
+- Issue (#458) — Deploy 操作の publish 経路を SBT 同型 (tenant API + tenant Cognito) に統一する (本 ADR がスコープを拡張して supersede)
+- Issue (#459) — Cross-account federation の保存・管理 (ADR-002 で決める)
 - CLAUDE.md — `ONE_PASS_AWS` invariant、`INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`
 - `docs/architecture/harness.md` — 既存 invariant 群
 - AWS docs: [Step Functions Distributed Map](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-distributed.html)

--- a/docs/requirements/problem-deploy.md
+++ b/docs/requirements/problem-deploy.md
@@ -1,8 +1,8 @@
 # Problem Deploy 機能 要件定義
 
-- **Status**: Draft (2026-05-05)
+- **Status**: Approved (2026-05-05)
 - **Scope**: TenkaCloud の operator が SaaS UI から「問題スタック」を競技者の AWS アカウントへ deploy する機能。本ドキュメントは要件 (= 何を満たせば成功か) を定義する。実装方針 (= どう作るか) は別途 ADR で決める。
-- **Related**: ADR-001 (実装案、本要件確定後に書き直す)
+- **Related**: ADR-001 (本要件に基づく実装案)
 
 ## ゴール
 
@@ -187,13 +187,13 @@ Service Catalog を採用するためには下記すべてを満たす必要が�
 ## Open questions (要件レベルで未確定、ADR 着手前に確定が必要)
 
 1. **`org-shared` の "組織" の定義** — tenant のグループか、tenant 内の team か、ACL 列か (ADR-003 候補)
-2. **競技者アカウント登録 UI と ExternalId 管理** — Issue #459 で別途
+2. **競技者アカウント登録 UI と ExternalId 管理** — Issue (#459) で別途
 3. **問題作成者と operator の権限関係** — 同一テナント内で role 分離するか、operator なら誰でも問題を作れるか
 4. **batch SLO の具体値** — Acceptance Criteria 記載の「1 hour 以内」は仮置き
 
 ## References
 
-- Issue #458 — Deploy 操作の publish 経路 (本要件文書で再整理、現実装案は ADR-001 で書き直し)
-- Issue #459 — Cross-account federation (ExternalId 管理) — 本要件の前提
+- Issue (#458) — Deploy 操作の publish 経路 (本要件文書で再整理、現実装案は ADR-001 で書き直し)
+- Issue (#459) — Cross-account federation (ExternalId 管理) — 本要件の前提
 - `infrastructure/templates/competitor-bootstrap.yaml` — 競技者側 IAM Role 定義
 - ADR-001 (Draft) — 本要件確定後に Decision を書き直す対象

--- a/docs/requirements/problem-deploy.md
+++ b/docs/requirements/problem-deploy.md
@@ -1,0 +1,199 @@
+# Problem Deploy 機能 要件定義
+
+- **Status**: Draft (2026-05-05)
+- **Scope**: TenkaCloud の operator が SaaS UI から「問題スタック」を競技者の AWS アカウントへ deploy する機能。本ドキュメントは要件 (= 何を満たせば成功か) を定義する。実装方針 (= どう作るか) は別途 ADR で決める。
+- **Related**: ADR-001 (実装案、本要件確定後に書き直す)
+
+## ゴール
+
+operator (TenkaCloud 顧客企業の運営担当) が、自社競技イベント (Battle / Challenge) を **TenkaCloud SaaS の画面操作だけで** 開催 → 運営 → 撤収まで通せる。AWS Console は触らない、コマンドラインは叩かない。
+
+operator が達成したい仕事は次のとおり。
+
+1. **Pre-event**: イベント当日に向けて、参加者全員分の問題環境を「ボタン 1 つで」競技者アカウント側に展開する
+2. **During-event**: 各参加者の deploy 状況を画面で把握する。失敗していたら再実行ボタンで取り戻す (operator はデバッグできないので、それ以上の操作は要求しない)
+3. **Post-event**: 全環境を「ボタン 1 つで」撤収する
+
+## アクター
+
+| アクター | TenkaCloud から見た位置 | 操作する場所 |
+|---|---|---|
+| **operator** (運営担当者) | TenkaCloud のテナント (顧客企業) の admin | TenkaCloud SaaS (`application-admin-console`) のみ。AWS Console / CLI は触らない、触れない前提 |
+| **participant** (競技者) | 1 チームに 1 名以上 | TenkaCloud SaaS (`participant-portal`) のみ |
+| **問題作者** | operator と同一人物のことが多い | TenkaCloud SaaS の問題管理画面 (要 設計) |
+
+## システム境界
+
+| AWS account | 誰の管理下 | 何が動く |
+|---|---|---|
+| **TenkaCloud 自社 AWS account** | TenkaCloud (= SaaS 提供側) | Control Plane / Application Plane 全部、Step Functions / Lambda / DDB / S3 / Cognito |
+| **競技者 AWS account** | competitor (= 競技参加者 or 主催者が用意した使い捨てアカウント) | 問題スタックの CFn 配下のリソースのみ。`competitor-bootstrap.yaml` で IAM Role + ExternalId が事前設定済 |
+
+operator の AWS account は **登場しない**。operator は TenkaCloud SaaS の顧客であり、TenkaCloud の sub-account を持たない。
+
+competitor account は **TenkaCloud の AWS Organizations 配下にあるとは限らない** (野良 AWS account を許す前提)。これは Service Catalog の Org 単位 portfolio 共有が**使えない**という設計制約に直結する。
+
+## Functional Requirements
+
+### FR-1. 規模 (Scale)
+
+| 競技形式 | 1 イベントの典型値 | 1 batch の最大 deploy 数 |
+|---|---|---|
+| **Battle** | 25 チーム × 1 問 | 25 stacks |
+| **Challenge** | 25 チーム × 30 問 | **750 stacks** |
+
+設計はこの規模を **1 batch で起動できる** ことを前提とする。Challenge 規模 (750 stacks) を operator が手作業で 1 つずつ起動することは要件として認めない (= bulk operation が必須)。
+
+### FR-2. CRUD 4 操作すべて要る
+
+| 操作 | 必要 | 主な利用シーン |
+|---|---|---|
+| **Create** | ✅ 必須 | 新規 deploy。FR-1 規模 (= 25 × 30 = 750 stacks/batch) |
+| **Read** | ✅ 必須 | operator が UI で deploy の状況を見られる |
+| **Update** | ✅ 必須 | **問題作成 iteration**: test deploy → CFn テンプレを直す → Update で同 stack を新版に切り替える → 動作確認 …のループを問題作者が回す |
+| **Delete** | ✅ 必須 | イベント終了時の bulk teardown、または iteration 中の不要 stack 撤去 |
+
+Update のスコープは **問題作成 (authoring) の iteration** が主用途。1 件単位の Update を機敏に回せることが重要 (= bulk 1 batch 内の更新ではなく、1 問題 × 1 test account の小回り Update)。
+
+イベント本番中に既 deploy へ hot-fix を流す運用は想定しないが、Update 機能自体は authoring iteration のために必要なので CRUD は 4 操作すべて持つ。
+
+### FR-3. 失敗時の operator UX
+
+operator はデバッグできない前提。
+
+- 失敗 item は UI に「N 件失敗」とだけ表示
+- operator は **「失敗した分だけ再実行」ボタン 1 つで部分 retry** できる
+- 再実行は前回の input で再起動するだけ (内部的な詳細を operator に問わない)
+- 連続失敗時の代替手段 (チケット起票、サポート問い合わせ) は SaaS の operational support に委ねる (本機能の責務外)
+
+### FR-4. cleanup の保証範囲
+
+operator が「Delete」を押せば、CFn `DeleteStack` が成功するところまでを TenkaCloud が保証する。
+
+それ以外は次のとおり扱う。
+
+- CFn 配下に閉じ込められていない実リソース (CFn 外で API 直叩きで作ったもの等) の漏れは **問題作者の責任**
+- 問題テンプレ規約として「`DeletionPolicy: Delete` を全 resource に明示」「CFn の外でリソースを作らない」ことをガイドラインに明記
+- TenkaCloud は実リソース漏れ検知・強制削除の機能を持たない
+
+### FR-5. 問題カタログ + authoring iteration
+
+operator (= 問題作者) は **TenkaCloud SaaS UI から問題を作成・更新・削除できる**。
+
+- 問題には CFn テンプレートが紐付く (バージョン管理あり)
+- 可視範囲を選べる: `public` / `org-shared` / `private`
+- public は全 tenant が deploy 対象として選べる
+- org-shared / private のセマンティクスは ADR で詳細化 (`組織` というエンティティの定義含む)
+
+問題のメタデータ (タイトル、説明、可視範囲、template URL 等) は SaaS の DDB で管理。CFn テンプレ実体は S3 上に置く (バージョンごとに別 key、または S3 versioning)。
+
+**Authoring iteration**: 問題作者は次のループを TenkaCloud SaaS UI 上で回せる。
+
+1. 新規問題を作る (テンプレートを upload)
+2. 自分の test 用 competitor account に **1 件だけ deploy** (= 単発 Create)
+3. 動作確認 (participant-portal や AWS Console から確認)
+4. 不具合があればテンプレートを upload し直し (新バージョン)
+5. 同じ test stack に **Update** を流す (= 単発 Update)
+6. CFn Update が drift / `UPDATE_ROLLBACK_FAILED` 等で詰まったときは **Delete** で test stack を捨てて、ステップ 2 に戻って再作成する
+7. OK になったら可視範囲を `public` 等に切り替えて公開
+
+このループを「単発 (1 問題 × 1 account) の小回り CRUD」として扱う。FR-1 の bulk 規模 (750 stacks) とは別経路だが、API・state machine は共通でよい (Map iterator が 1 件回るだけ)。
+
+### FR-6. operator UI workflow
+
+最低限の操作フローは次のとおり。
+
+1. 問題カタログ画面で問題を複数選択
+2. 競技者アカウント情報 (account ID + ExternalId + region) を複数選択 (登録済 account から)
+3. 「Deploy」ボタン → batch 実行開始
+4. batch 進捗画面で N/M 件成功・失敗を見られる
+5. 失敗があれば「失敗分を再実行」ボタンが出る
+6. イベント終了時、batch 一覧画面から「Delete」ボタンで teardown
+
+competitor account の登録 (account ID + ExternalId + competitor が立てた IAM Role 名) は別 UI が要る。これは別 Issue (#459) で扱う。
+
+## Non-functional Requirements
+
+### NFR-1. operator の AWS 習熟度を期待しない
+
+operator は IAM, CFn, Step Functions, EventBridge を 1 つも触ったことがない人を想定する。SaaS UI の用語も「AssumeRole」「ExternalId」のような AWS 専門語を画面に出さず、「競技者アカウントの接続情報」のような業務用語に翻訳する。
+
+competitor account 側の `competitor-bootstrap.yaml` を participant に流してもらう手順だけは AWS 知識を要するため、これは participant (or その所属組織の AWS 担当) 向けの手順書として別途用意する。
+
+### NFR-2. operator は TenkaCloud の AWS account を一切触らない
+
+これは SaaS の本質。operator が TenkaCloud のリソース (Step Functions の Console 等) を直接見る運用は一切想定しない。失敗時の状態は SaaS UI に翻訳して提示する。
+
+### NFR-3. 競技者アカウントの組織関係を仮定しない
+
+競技者 AWS account は TenkaCloud の AWS Organizations 配下にあるとは限らない (野良 account ありえる)。
+
+これは AWS Service Catalog の **AWS Organizations 単位の portfolio 共有が使えない** ことを意味する。cross-account access は全て **IAM AssumeRole + ExternalId** (`competitor-bootstrap.yaml` で立てた Role) で行う。
+
+### NFR-4. 問題テンプレ規約
+
+問題作成者向けの規約として次の事項を明文化する。
+
+- すべての AWS リソースを CFn 配下に作る (API 直叩きでリソースを作らない)
+- `DeletionPolicy` は明示的に `Delete` (デフォルトの場合は省略可、`Retain` を使うときは合理的な理由を README に書く)
+- `competitor-bootstrap.yaml` の IAM Role が持つ権限の範囲内で作れるリソースだけを使う
+
+詳細は別ドキュメント (`problems/CONVENTIONS.md` 想定) で展開。
+
+## 暗黙の前提として禁止する事項
+
+要件外として、次の事項は本機能の scope に**含めない**。
+
+- ❌ operator が AWS Console / CLI を直接触ること
+- ❌ operator が TenkaCloud の AWS account にアクセスすること
+- ❌ AWS Service Catalog の UI を operator に直接見せる構成
+- ❌ AWS Organizations 単位での competitor account 共有を前提にする構成
+- ❌ 問題テンプレ実体を SaaS DDB に直書き (= S3 に置く前提)
+- ❌ イベント本番中に operator が既 deploy へ hot-fix を流す運用 (Update 機能自体は authoring iteration 用に持つが、live-event hot-fix の UX は提供しない)
+
+## Service Catalog 採否の判断基準
+
+ADR で実装案を比較するときの基準を要件側から固定する。
+
+Service Catalog を採用するためには下記すべてを満たす必要がある。
+
+| 条件 | Service Catalog で満たせるか | 結論 |
+|---|---|---|
+| operator が SaaS UI から問題を upload して即 deploy 可能にできる | △ Service Catalog はもともと admin が portfolio を組む前提。SaaS Lambda が Service Catalog API を叩いて product version を登録する仕組みは作れる | 仕組み次第 |
+| 野良 (TenkaCloud Org 外) AWS account へ deploy できる | ❌ Service Catalog の portfolio 共有は AWS Organizations 単位 | **不可** |
+| operator に AWS Console を見せない | ❌ Service Catalog の主 UI は AWS Console | **不可** (provisioning engine 専用利用ならいけるが、その場合 UI は SaaS 側で作るので Service Catalog のメリットが薄れる) |
+
+**判断**: NFR-3 (野良 account 許容) の時点で Service Catalog の cross-account 機構が使えない。ADR では Step Functions による自前実装を採用する。Service Catalog は採用しない。
+
+## 受け入れ基準 (Acceptance Criteria)
+
+要件が満たされた状態を operationally に判定するチェックリストを次に示す。
+
+- [ ] `make deploy` を 1 回流して、operator が次のフローを SaaS UI だけで完走できる
+  - 詳細手順:
+  1. operator がログイン
+  2. 25 チーム × 30 問の Challenge セットを選択して Deploy
+  3. 進捗画面で全 750 件の状況が見える
+  4. 失敗があれば「失敗分を再実行」で部分 retry できる
+  5. イベント終了で「Delete」を押せば全 750 stack が CFn DeleteStack 成功する
+- [ ] operator は AWS Console / CLI を一度も触らずに完走できる
+- [ ] operator は IAM / CFn / Step Functions / Lambda の語を SaaS 画面上で目にしない
+- [ ] competitor account を野良 AWS account にしてもフローが通る
+- [ ] 750 件 batch が現実的時間内に完了する (上限は ADR で詳細化、SLO 候補: 1 hour 以内)
+- [ ] 1 batch 内の 1 件失敗が他 749 件の成功を妨げない
+- [ ] CFn DeleteStack が成功するところまでを cleanup 完了とみなす (実リソース漏れは問題作者責任)
+- [ ] 問題作者が TenkaCloud SaaS UI 上で次のループを回せる: 新規作成 → 1 件 deploy → テンプレ修正 → Update → 動作確認 → 公開
+
+## Open questions (要件レベルで未確定、ADR 着手前に確定が必要)
+
+1. **`org-shared` の "組織" の定義** — tenant のグループか、tenant 内の team か、ACL 列か (ADR-003 候補)
+2. **競技者アカウント登録 UI と ExternalId 管理** — Issue #459 で別途
+3. **問題作成者と operator の権限関係** — 同一テナント内で role 分離するか、operator なら誰でも問題を作れるか
+4. **batch SLO の具体値** — Acceptance Criteria 記載の「1 hour 以内」は仮置き
+
+## References
+
+- Issue #458 — Deploy 操作の publish 経路 (本要件文書で再整理、現実装案は ADR-001 で書き直し)
+- Issue #459 — Cross-account federation (ExternalId 管理) — 本要件の前提
+- `infrastructure/templates/competitor-bootstrap.yaml` — 競技者側 IAM Role 定義
+- ADR-001 (Draft) — 本要件確定後に Decision を書き直す対象


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

Problem Deploy 機能の再設計方針 (ADR-001) が repo に commit され、後続の実装 PR (PR-2 〜 PR-8) が参照できる状態になる。コード差分はゼロ、ドキュメントのみ。

## なぜ今これが要るか

Issue #458 (publish 経路統一) を実装し始めたところ、現状の ProblemDeployBackendStack の構造 (専用 HTTP API + 別 Cognito + 1-event-1-deploy) が multi-tenant SaaS と整合しない設計上の不整合が複数浮上した。実装ブランチ `feat/deploy-via-tenant-api` (stash 済み) を一度破棄し、CRUD 4 操作を Step Functions の batch 処理として再設計する方針を ADR としてまとめる。

## 変更前 → 変更後のフロー

```mermaid
flowchart TB
    subgraph 変更前
      F1[application-admin-console] -->|専用 HTTP API| G1[DeployApiGateway 単一 Cognito]
      G1 -->|1 event| W1[Worker Lambda]
      W1 -->|1 CFn deploy| C1[CFn StackA]
    end
    subgraph 変更後
      F2[application-admin-console] -->|tenant API + tenant Cognito| G2[TenantTemplateStack RestApi]
      G2 -->|StartExecution| S2[Step Functions Map]
      S2 -->|sync CFn| C2A[CFn StackA]
      S2 -->|sync CFn| C2B[CFn StackB]
      S2 -->|sync CFn| C2C[CFn ...]
    end
```

## 物理影響

### AWS リソース (`make deploy`)

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| (なし) | (なし) | NO-OP | ADR ドキュメントのみ。CFn 差分ゼロ |

### ビルド成果物 (`make build`)

| パッケージ | 変更 |
|---|---|
| (なし) | コード差分なし |

新ファイル: `docs/architecture/adr-001-problem-deploy-crud.md` (1 file, +157 lines)

## ファイルごとの変更意図

- `docs/architecture/adr-001-problem-deploy-crud.md` — 新規 ADR。Context (なぜ再設計必要か)、Decision (publish 経路 / state machine / spec cap / state 所在 / 既存 stack の整理)、Consequences、Alternatives (Lambda fan-out / CodeBuild / ECS / Service Catalog の却下理由)、Migration plan (PR 8 本に分割)、Open questions (#459 / 問題カタログ / Read の同期 vs 非同期)。

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 / 対処 |
|---|---|---|---|---|
| 1 | 既存コードへの影響 | (なし) | ✅ 確認済み | コード差分ゼロのため。`git diff main...HEAD --stat` で `docs/...md` 1 ファイルのみ |
| 2 | textlint / markdownlint との整合 | docs ビルド | ✅ 確認済み | `make lint` 通過 |
| 3 | 既存 ADR 命名規約との衝突 | 命名 | ✅ 確認済み | 既存 ADR は無し (`docs/architecture/` には harness.md のみ)。`adr-001-` 番号開始は妥当 |

## Rollback 手順

`git revert <merge-sha>` → 新 PR で main に戻すだけ。コード差分なしのため副作用なし。

## テスト戦略

- 既存テストでカバーされる観点 — なし (ADR はドキュメントのみ、振る舞いを変えない)
- この PR で追加 / 変更したテスト — なし
- 未カバー (受容する理由) — N/A (ADR は決定の記録であり、テスト対象は後続 PR-2〜8 で実装される実体側で固める)

## Verification

### Merge 前 (DRAFT 解除条件)

- [x] `make lint` (markdownlint + textlint + biome 全 pass)
- [x] `make test` を不要 (コード差分ゼロ)
- [x] ADR 本文が Context / Decision / Consequences / Alternatives / Migration / Open questions の構造を持つ
- [x] 関連 Issue #458 #459 を ADR References に記載

### Merge 後 (運用 signal)

- [ ] 後続 PR-2 が本 ADR を Reference に挙げて開かれること
- [ ] Issue #458 を「ADR-001 で扱う」コメントで更新する
- [ ] Issue #459 を ADR-002 を立てる予定として更新する

## 既知の未完了 (scope 外)

- ADR-002 (Cross-account federation): Issue #459 を追って別 ADR で扱う
- ADR-003 (Problem catalog DDB schema + 可視範囲モデル): 別途。本 ADR は「problem には CFn template URL がある」を所与とした

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record detailing the deployment system design strategy
  * Added requirements documentation for problem stack deployment operations, including batch support, cross-account functionality, and partial retry capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->