### PR TITLE
feat(deploy-battles): MVP-0 - 引数に問題フォルダを取り順次 CFn deploy する shell + make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ export JSII_DEPRECATED := quiet
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
         env-check synth diff bootstrap \
-        deploy deploy-control-plane deploy-bootstrap destroy
+        deploy deploy-control-plane deploy-bootstrap destroy \
+        deploy-battles destroy-battles
 
 help:
 	@awk '/^# =====/ {gsub(/^# ===== | =====$$/, ""); printf "\n%s\n", $$0} \
@@ -95,3 +96,23 @@ deploy:               env-check
 deploy-control-plane: env-check build ; $(CDK) deploy ControlPlaneStack $(APPROVAL)
 deploy-bootstrap:     env-check build ; $(CDK) deploy serverless-saas-ref-arch-bootstrap-stack $(APPROVAL)
 destroy:              env-check       ; bash scripts/cleanup.sh
+
+# ===== Problem deploy smoke test (MVP-0, ADR-001 PR-1.5) =====
+# 引数に問題フォルダを取り、順次 CFn deploy する開発者向け smoke test ツール。
+# SaaS 配線 (Step Functions / EventBridge / tenant API / Cognito) を持ち込まず、
+# CFn template と AWS 権限の正しさだけを確認する。
+#
+# 使い方 (default 1 件):
+#   make deploy-battles
+#   make destroy-battles
+#
+# 使い方 (引数指定):
+#   make deploy-battles BATTLES="problems/gameday/security-battle-royale problems/gameday/another"
+#   make deploy-battles BATTLES="problems/gameday/security-battle-royale" TEAM_SLUG=alpha
+BATTLES   ?= problems/gameday/security-battle-royale
+TEAM_SLUG ?= demo-team
+
+deploy-battles:
+	@TEAM_SLUG="$(TEAM_SLUG)" bash scripts/deploy-battles.sh $(BATTLES)
+destroy-battles:
+	@TEAM_SLUG="$(TEAM_SLUG)" bash scripts/destroy-battles.sh $(BATTLES)

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# deploy-battles.sh — 引数に問題ディレクトリを受け取り、順次 CFn deploy する smoke test ツール。
+#
+# Usage:
+#   bash scripts/deploy-battles.sh <problem-dir> [<problem-dir> ...]
+#
+# 環境変数:
+#   TEAM_SLUG     チーム識別子。リソース名 prefix `tc-{problemSlug}-{teamSlug}` に使う。
+#                 default: "demo-team"
+#   AWS_REGION    deploy 先 region。default: aws cli config から取得
+#   DB_PASSWORD   問題テンプレ (security-battle-royale 等) の DbPassword Parameter に渡す。
+#                 未指定なら deploy ごとにランダム生成 (32 桁英数字)。secret を repo に残さない
+#                 ため、固定値が必要なときは呼び出し側で `DB_PASSWORD=xxx make deploy-battles` を使う
+#
+# 例:
+#   bash scripts/deploy-battles.sh problems/gameday/security-battle-royale
+#   bash scripts/deploy-battles.sh problems/gameday/security-battle-royale problems/gameday/another
+#   TEAM_SLUG=alpha bash scripts/deploy-battles.sh problems/gameday/security-battle-royale
+#
+# 設計意図:
+#   ADR-001 の MVP-0 (PR-1.5) として、SaaS 配線 (Step Functions / EventBridge / tenant API /
+#   Cognito) を一切持ち込まずに「CFn template と AWS 権限の正しさ」だけを smoke test する。
+#   このスクリプトが安定すれば、MVP-1 では SBT ScriptJob パターン (Step Functions →
+#   CodeBuild StartBuild .sync → 同 script 実行) で wrap するだけで済む。
+
+set -euo pipefail
+
+# shellcheck source=lib/battles-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/battles-common.sh"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <problem-dir> [<problem-dir> ...]" >&2
+  echo "  e.g.: $0 problems/gameday/security-battle-royale" >&2
+  exit 1
+fi
+
+TEAM_SLUG="${TEAM_SLUG:-demo-team}"
+AWS_REGION="$(resolve_aws_region)"
+
+deploy_one() {
+  local problem_dir="$1"
+  local template="${problem_dir}/template.yaml"
+  if [[ ! -f "${template}" ]]; then
+    echo "error: ${template} が見つかりません" >&2
+    return 1
+  fi
+
+  local problem_slug
+  problem_slug="$(basename "${problem_dir}")"
+  local name_prefix
+  name_prefix="$(build_name_prefix "${problem_dir}" "${TEAM_SLUG}")"
+
+  echo ""
+  echo "=========================================="
+  echo "Deploying: ${problem_dir}"
+  echo "  StackName : ${name_prefix}"
+  echo "  Region    : ${AWS_REGION}"
+  echo "  TeamSlug  : ${TEAM_SLUG}"
+  echo "=========================================="
+
+  # DbPassword は env DB_PASSWORD で渡す。未指定なら毎回ランダム生成 (smoke test なので
+  # 永続性は不要)。secrets-in-source の commit を防ぐためハードコードしない。
+  local db_password="${DB_PASSWORD:-}"
+  if [[ -z "${db_password}" ]]; then
+    # /dev/urandom を `tr` で英数字に絞って 32 桁切り出す。`head -c 32` が早期 close した
+    # 際の `tr` への SIGPIPE で `set -o pipefail` が pipeline 全体を 141 で fail させる
+    # ことがあるため、subshell で pipefail を局所的に無効化する (template の AllowedPattern
+    # `^[A-Za-z0-9!@#$%^&*()_+\-=]+$` に収まる字種を選んでいる)。
+    db_password="$(set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+  fi
+
+  # `aws cloudformation deploy` は CreateStack / UpdateStack を冪等に扱う:
+  #   - stack が無ければ Create
+  #   - stack があれば Update (差分が無ければ "No changes" で 0 終了)
+  #   - --no-fail-on-empty-changeset で「差分無し」を成功扱いにする (rerun 時の運用上の都合)
+  aws cloudformation deploy \
+    --region "${AWS_REGION}" \
+    --stack-name "${name_prefix}" \
+    --template-file "${template}" \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides \
+        "NamePrefix=${name_prefix}" \
+        "DbPassword=${db_password}" \
+    --tags \
+        "TenkaCloud:NamePrefix=${name_prefix}" \
+        "TenkaCloud:Problem=${problem_slug}" \
+        "TenkaCloud:TeamSlug=${TEAM_SLUG}" \
+        "TenkaCloud:DeployedBy=deploy-battles.sh"
+
+  # outputs を表示 (FrontendUrl 等が見える)
+  echo ""
+  echo "Outputs for ${name_prefix}:"
+  aws cloudformation describe-stacks \
+    --region "${AWS_REGION}" \
+    --stack-name "${name_prefix}" \
+    --query "Stacks[0].Outputs" \
+    --output table
+}
+
+failures=()
+for problem_dir in "$@"; do
+  # 末尾のスラッシュを正規化
+  problem_dir="${problem_dir%/}"
+  if ! deploy_one "${problem_dir}"; then
+    failures+=("${problem_dir}")
+  fi
+done
+
+echo ""
+echo "=========================================="
+if [[ ${#failures[@]} -eq 0 ]]; then
+  echo "All $# deploy(s) succeeded."
+  exit 0
+else
+  echo "Failed deploys (${#failures[@]} of $#):"
+  for f in "${failures[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi

--- a/scripts/destroy-battles.sh
+++ b/scripts/destroy-battles.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# destroy-battles.sh — deploy-battles.sh で立てた CFn stack を順次 delete する。
+#
+# Usage:
+#   bash scripts/destroy-battles.sh <problem-dir> [<problem-dir> ...]
+#
+# 環境変数:
+#   TEAM_SLUG     deploy-battles.sh と同じ値を指定する。default: "demo-team"
+#   AWS_REGION    deploy 先 region。default: aws cli config から取得
+#   WAIT_FOR_DELETE  "true" にすると DELETE_COMPLETE まで待機。default: "false" (非同期)
+#
+# 例:
+#   bash scripts/destroy-battles.sh problems/gameday/security-battle-royale
+#   WAIT_FOR_DELETE=true bash scripts/destroy-battles.sh problems/gameday/security-battle-royale
+
+set -euo pipefail
+
+# shellcheck source=lib/battles-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/battles-common.sh"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <problem-dir> [<problem-dir> ...]" >&2
+  exit 1
+fi
+
+TEAM_SLUG="${TEAM_SLUG:-demo-team}"
+AWS_REGION="$(resolve_aws_region)"
+WAIT_FOR_DELETE="${WAIT_FOR_DELETE:-false}"
+
+destroy_one() {
+  local problem_dir="$1"
+  local name_prefix
+  name_prefix="$(build_name_prefix "${problem_dir}" "${TEAM_SLUG}")"
+
+  echo ""
+  echo "=========================================="
+  echo "Deleting: ${name_prefix} (region: ${AWS_REGION})"
+  echo "=========================================="
+
+  # delete-stack は stack が無くてもエラーにならない (CFn の挙動)。
+  aws cloudformation delete-stack \
+    --region "${AWS_REGION}" \
+    --stack-name "${name_prefix}"
+
+  if [[ "${WAIT_FOR_DELETE}" == "true" ]]; then
+    echo "Waiting for DELETE_COMPLETE..."
+    aws cloudformation wait stack-delete-complete \
+      --region "${AWS_REGION}" \
+      --stack-name "${name_prefix}"
+    echo "  → DELETE_COMPLETE"
+  else
+    echo "  → DELETE 要求送信済 (非同期)。完了確認は AWS Console か WAIT_FOR_DELETE=true で再実行"
+  fi
+}
+
+failures=()
+for problem_dir in "$@"; do
+  problem_dir="${problem_dir%/}"
+  if ! destroy_one "${problem_dir}"; then
+    failures+=("${problem_dir}")
+  fi
+done
+
+echo ""
+echo "=========================================="
+if [[ ${#failures[@]} -eq 0 ]]; then
+  echo "All $# delete request(s) issued."
+  exit 0
+else
+  echo "Failed delete requests (${#failures[@]} of $#):"
+  for f in "${failures[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi

--- a/scripts/lib/battles-common.sh
+++ b/scripts/lib/battles-common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# battles-common.sh — deploy-battles.sh / destroy-battles.sh の共通ヘルパー。
+#
+# 使い方 (sibling script から source する):
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/battles-common.sh"
+
+# stack 名 prefix の規約: `tc-{problemSlug}-{teamSlug}` (template.yaml の AllowedPattern
+# `^tc-[a-z0-9]+(-[a-z0-9]+)+$` と一致)。同一 (Account, Region) に複数チームの問題スタックを
+# 並べるための衝突回避 prefix。frontend (`apps/application-admin-console/src/lib/resource-naming.ts`)
+# と backend (`infrastructure/lib/problem-deploy/handlers/deploy-handler/naming.ts`) でも
+# 同じ規約を実装している (cross-language contract)。
+build_name_prefix() {
+  local problem_dir="$1"
+  local team_slug="$2"
+  local problem_slug
+  problem_slug="$(basename "${problem_dir}")"
+  echo "tc-${problem_slug}-${team_slug}"
+}
+
+# AWS region を解決。AWS_REGION env か aws cli config から取り、どちらも空ならエラー終了。
+resolve_aws_region() {
+  local region="${AWS_REGION:-$(aws configure get region 2>/dev/null || echo "")}"
+  if [[ -z "${region}" ]]; then
+    echo "error: AWS_REGION 未設定。aws configure or 環境変数で指定してください" >&2
+    return 1
+  fi
+  echo "${region}"
+}


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

開発者が AWS CLI セッションから `make deploy-battles` で CFn deploy / `make destroy-battles` で teardown を smoke test できるようになる。SaaS 配線 (Step Functions / EventBridge / tenant API / Cognito) は一切持ち込まず、CFn template と AWS 権限の正しさだけを検証する段階。

```bash
# default 1 件 (security-battle-royale を demo-team で立てる):
make deploy-battles
make destroy-battles

# 引数指定:
make deploy-battles BATTLES="problems/gameday/security-battle-royale problems/gameday/another"
make deploy-battles BATTLES="problems/gameday/security-battle-royale" TEAM_SLUG=alpha
```

## なぜ今これが要るか

ADR-001 (PR #460) の Migration plan で MVP-0 (PR-1.5) として位置付けた smoke test ツール。Walking Skeleton 戦略として「まず CFn template と AWS 権限が正しいことを確認 → MVP-1 で SBT ScriptJob パターンで wrap」と分割する。スクリプトは MVP-0 と MVP-1 で共通になるので、無駄にならない。

## 変更前 → 変更後のフロー

```mermaid
flowchart LR
    subgraph 変更前
      D1[開発者] --> AWS1[AWS Console / 手作業 aws cli] --> CF1[CFn Stack]
    end
    subgraph 変更後
      D2[開発者] --> M2[make deploy-battles] --> S2[scripts/deploy-battles.sh] --> CF2[CFn Stack]
    end
```

## 物理影響

### AWS リソース (`make deploy`)

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| (なし) | (なし) | NO-OP | 本 PR は CDK 構成を変更しない |

### ビルド成果物 (`make build`)

なし (shell + Makefile のみ)。

### 開発者環境

`make deploy-battles` を流すと開発者の AWS account に CFn stack が立つが、これはローカル smoke test の運用であり、merge / production に影響しない。

## ファイルごとの変更意図

- `scripts/deploy-battles.sh` (新規) — 引数に問題ディレクトリを取り、各々を `aws cloudformation deploy` で同一 account に順次 deploy。stack 名 prefix は `tc-{problemSlug}-{teamSlug}` (template.yaml の AllowedPattern と一致)。`--no-fail-on-empty-changeset` で rerun 時の差分無しを成功扱いに
- `scripts/destroy-battles.sh` (新規) — 同じ引数で `aws cloudformation delete-stack` を順次呼ぶ。`WAIT_FOR_DELETE=true` で完了待機可能
- `Makefile` — `deploy-battles` / `destroy-battles` ターゲット追加。`BATTLES` / `TEAM_SLUG` 変数で引数を上書き可能

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 |
|---|---|---|---|---|
| 1 | 既存 Makefile target との衝突 | make 操作 | ✅ | `make help` で新 target が独立 section に出る、既存 target 不変 |
| 2 | 既存 `scripts/` 下のスクリプト (install.sh / cleanup.sh) との干渉 | `make deploy` / `make destroy` | ✅ | 新 scripts は他から source されていない、独立 |
| 3 | lint / typecheck / test / validate-problems への影響 | CI gate | ✅ | shell は textlint / biome / vitest 対象外。`make before-commit` exit 0 |
| 4 | `make deploy-battles` の冪等性 | 開発者の AWS account | ✅ | `--no-fail-on-empty-changeset` で rerun OK |

## Rollback 手順

1. `make deploy-battles` で立てた stack があれば `make destroy-battles` で消す
2. `git revert <merge-sha>` を新 PR で main に戻す

## テスト戦略

- 既存テストでカバーされる観点 — なし (shell + Makefile はテスト対象外)
- この PR で追加したテスト — なし
- 未カバー (受容する理由)
  - bash script の unit test は scope 外
  - 引数バリデーションは手動確認 (`scripts/deploy-battles.sh` を引数なし / 不正引数で実行して error path を確認済み)
  - 実 deploy 動作確認は AWS account を持つ開発者が `make deploy-battles` を流して目視 (Acceptance Criteria 参照)

## Verification

### Merge 前 (DRAFT 解除条件)

- [x] `make before-commit` (lint / typecheck / test / validate-problems pass)
- [x] `bash -n scripts/deploy-battles.sh` (syntax OK)
- [x] `bash -n scripts/destroy-battles.sh` (syntax OK)
- [x] `make help` で `deploy-battles` / `destroy-battles` が新規 section に表示
- [x] 引数なしで実行 → usage 表示
- [x] 不正引数で実行 → error 表示

### Merge 後 (運用 signal)

- [ ] 開発者が `make deploy-battles` で CFn stack が立ち、`security-battle-royale` の EC2 + nginx + Flask api + MySQL が動く (frontend URL が 200 を返す)
- [ ] `make destroy-battles` で stack が消える (`DeleteStack` が成功)
- [ ] 引数で複数問題を渡したときに順次 deploy される

## 既知の未完了 (scope 外)

- **MVP-1 (PR-2)**: 既存 UI から Step Functions 経路で本 script を実行する SaaS 配線。SBT ScriptJob パターン (Step Functions → CodeBuild StartBuild `.sync` → 本 script を実行) を採用する予定
- **ADR-001 の Alt-B (CodeBuild) 評価更新**: PR #460 の現状は「却下」だが、SBT ScriptJob を MVP-1 で採用する関係で「採用 (orchestration 層)」に書き換える必要がある (MVP-0 が安定したら別 PR で更新)
- **Lambda code zip / private repo 同梱**: Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
