### PR TITLE
fix(deploy-battles): BATTLES 必須化 + 安全な hello-world sample + cfnParameters 動的化 + UTF-8 強制

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,17 +102,24 @@ destroy:              env-check       ; bash scripts/cleanup.sh
 # SaaS 配線 (Step Functions / EventBridge / tenant API / Cognito) を持ち込まず、
 # CFn template と AWS 権限の正しさだけを確認する。
 #
-# 使い方 (default 1 件):
-#   make deploy-battles
-#   make destroy-battles
+# `BATTLES` は **必須** (= default を持たない)。引数なしで `make deploy-battles` を叩いた
+# ときに silently deploy が始まる事故を防ぐため、明示指定を要求する。
 #
-# 使い方 (引数指定):
+# 使い方:
+#   make deploy-battles BATTLES="problems/gameday/security-battle-royale"
 #   make deploy-battles BATTLES="problems/gameday/security-battle-royale problems/gameday/another"
 #   make deploy-battles BATTLES="problems/gameday/security-battle-royale" TEAM_SLUG=alpha
-BATTLES   ?= problems/gameday/security-battle-royale
 TEAM_SLUG ?= demo-team
 
 deploy-battles:
+	@if [ -z "$(BATTLES)" ]; then \
+	  echo "error: BATTLES が未指定。例: make deploy-battles BATTLES=\"problems/gameday/security-battle-royale\"" >&2; \
+	  exit 1; \
+	fi
 	@TEAM_SLUG="$(TEAM_SLUG)" bash scripts/deploy-battles.sh $(BATTLES)
 destroy-battles:
+	@if [ -z "$(BATTLES)" ]; then \
+	  echo "error: BATTLES が未指定。例: make destroy-battles BATTLES=\"problems/gameday/security-battle-royale\"" >&2; \
+	  exit 1; \
+	fi
 	@TEAM_SLUG="$(TEAM_SLUG)" bash scripts/destroy-battles.sh $(BATTLES)

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -98,6 +98,11 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9._/-]+\\.(yaml|yml|json)$",
       "description": "同一ディレクトリからの相対パスで指す CFn テンプレートファイル (ペライチ)。デプロイ時にこのテンプレートが competitor account の CFn にアップロードされる。"
+    },
+    "cfnParameters": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "CFn template の Parameters に渡す値を {ParameterName: value} で宣言する。`NamePrefix` は script が自動注入するので含めない。`__RANDOM_PASSWORD__` を value にすると、deploy ごとに 32 桁ランダム英数字を生成して渡す (DbPassword 等の secret 用途)。省略可 (Parameters 全部に default が付いているテンプレートでは不要)。"
     }
   }
 }

--- a/problems/gameday/security-battle-royale/metadata.json
+++ b/problems/gameday/security-battle-royale/metadata.json
@@ -18,5 +18,8 @@
     "EC2 IMDS / IAM Role の露出経路と、それを塞ぐベストプラクティスを理解する",
     "競技中に同居する攻撃者と防御者のトレードオフ (可用性を保ちつつ守る) を体験する"
   ],
-  "cfnTemplate": "template.yaml"
+  "cfnTemplate": "template.yaml",
+  "cfnParameters": {
+    "DbPassword": "__RANDOM_PASSWORD__"
+  }
 }

--- a/problems/sample/hello-world/metadata.json
+++ b/problems/sample/hello-world/metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "hello-world",
+  "name": "Hello World (Sample)",
+  "category": "Challenge",
+  "status": "ready",
+  "difficulty": 1,
+  "estimatedDuration": "1 分",
+  "shortDescription": "TenkaCloud デプロイ機構の smoke test 用サンプル問題。SSM Parameter を 1 つだけ作る無害なスタック。",
+  "description": "deploy-battles.sh / Step Functions などのデプロイ経路を smoke test するためのサンプル。本問題は SSM Parameter (`/{NamePrefix}/hello`) を 1 つ作るだけで、EC2 / VPC / 公開エンドポイント / 脆弱性のあるソフトウェアは一切含まない。コストはゼロ。\n\n通常の競技には使わず、開発者が `make deploy-battles BATTLES=problems/sample/hello-world` で deploy 機構の正しさを確かめるためだけに用意している。",
+  "tags": ["sample", "smoke-test", "ssm"],
+  "exposedPorts": [{ "port": 1, "name": "(no public endpoint — SSM Parameter only, port unused)" }],
+  "learningGoals": ["TenkaCloud のデプロイ機構が end-to-end で動くことを smoke test で確認する"],
+  "cfnTemplate": "template.yaml",
+  "cfnParameters": {}
+}

--- a/problems/sample/hello-world/template.yaml
+++ b/problems/sample/hello-world/template.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud sample problem (hello-world). Minimal smoke test stack that creates
+  a single SSM Parameter and nothing else. Use this for verifying that
+  `make deploy-battles` end-to-end works without exposing any vulnerable software
+  or public-facing resources. Free of charge under standard SSM tier.
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    ConstraintDescription: >
+      `tc-{problemSlug}-{teamSlug}` format. The deploy-battles.sh script auto-injects
+      this value, you do not need to set it manually.
+    Description: >
+      Common prefix attached to all resource names. Used to prevent collisions
+      when multiple teams' stacks coexist in the same account / region.
+
+Resources:
+  HelloParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${NamePrefix}/hello"
+      Type: String
+      Value: !Sub "Hello from ${NamePrefix}"
+      Description: !Sub "TenkaCloud smoke test parameter created by hello-world (${NamePrefix})."
+      Tier: Standard
+
+Outputs:
+  ParameterName:
+    Description: SSM Parameter name created by this stack.
+    Value: !Ref HelloParameter
+  ParameterValue:
+    Description: SSM Parameter value (echoed in Outputs for smoke test verification).
+    Value: !Sub "Hello from ${NamePrefix}"
+  NamePrefix:
+    Description: Common resource prefix that this stack used.
+    Value: !Ref NamePrefix

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -99,8 +99,12 @@ deploy_one() {
   local name_prefix
   name_prefix="$(build_name_prefix "${problem_dir}" "${TEAM_SLUG}")"
 
-  local -a parameter_overrides
-  mapfile -t parameter_overrides < <(build_parameter_overrides "${problem_dir}" "${name_prefix}")
+  # macOS 標準 bash 3.2 は `mapfile` (bash 4+) 未対応なので、while read で配列を埋める。
+  local -a parameter_overrides=()
+  local line
+  while IFS= read -r line; do
+    parameter_overrides+=("${line}")
+  done < <(build_parameter_overrides "${problem_dir}" "${name_prefix}")
 
   echo ""
   echo "=========================================="

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -13,9 +13,13 @@
 #                 ため、固定値が必要なときは呼び出し側で `DB_PASSWORD=xxx make deploy-battles` を使う
 #
 # 例:
-#   bash scripts/deploy-battles.sh problems/gameday/security-battle-royale
-#   bash scripts/deploy-battles.sh problems/gameday/security-battle-royale problems/gameday/another
-#   TEAM_SLUG=alpha bash scripts/deploy-battles.sh problems/gameday/security-battle-royale
+#   bash scripts/deploy-battles.sh problems/sample/hello-world
+#   bash scripts/deploy-battles.sh problems/sample/hello-world problems/gameday/security-battle-royale
+#   TEAM_SLUG=alpha bash scripts/deploy-battles.sh problems/sample/hello-world
+#
+# CFn template の Parameter は metadata.json の `cfnParameters` で宣言する (= 問題作者が
+# 必要な値を渡す)。`NamePrefix` だけは script が自動注入する。`__RANDOM_PASSWORD__` を
+# value に置くと deploy ごとにランダム生成 (DbPassword 等の secret 用途)。
 #
 # 設計意図:
 #   ADR-001 の MVP-0 (PR-1.5) として、SaaS 配線 (Step Functions / EventBridge / tenant API /
@@ -28,14 +32,59 @@ set -euo pipefail
 # shellcheck source=lib/battles-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/battles-common.sh"
 
+# CFn template の Description などに含まれる multibyte 文字 (日本語等) が aws CLI 経由で
+# 「?」に化ける現象がある。LC_ALL/LANG が C / POSIX / 空 のとき、aws CLI 内部の Python が
+# template file を ASCII codec で open し、UTF-8 chars を replace してしまうため。
+# 値が ASCII-only locale なら UTF-8 に倒す。
+case "${LC_ALL:-${LANG:-}}" in
+  C|POSIX|"")
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+    ;;
+esac
+
 if [[ $# -lt 1 ]]; then
   echo "usage: $0 <problem-dir> [<problem-dir> ...]" >&2
-  echo "  e.g.: $0 problems/gameday/security-battle-royale" >&2
+  echo "  e.g.: $0 problems/sample/hello-world" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq が必要です (brew install jq / apt install jq)" >&2
   exit 1
 fi
 
 TEAM_SLUG="${TEAM_SLUG:-demo-team}"
 AWS_REGION="$(resolve_aws_region)"
+
+# metadata.json の cfnParameters を `Key=Value` 形式の配列に展開する。`__RANDOM_PASSWORD__`
+# トークンは 32 桁ランダム英数字に置換 (DbPassword 等の secret 用途)。`NamePrefix` は
+# script が常に自動注入するので、ここでは扱わない。
+build_parameter_overrides() {
+  local problem_dir="$1"
+  local name_prefix="$2"
+  local metadata="${problem_dir}/metadata.json"
+  local -a overrides=("NamePrefix=${name_prefix}")
+
+  if [[ ! -f "${metadata}" ]]; then
+    printf '%s\n' "${overrides[@]}"
+    return 0
+  fi
+
+  local key value
+  while IFS=$'\t' read -r key value; do
+    [[ -z "${key}" ]] && continue
+    if [[ "${value}" == "__RANDOM_PASSWORD__" ]]; then
+      # /dev/urandom を `tr` で英数字に絞って 32 桁切り出す。`head -c 32` が早期 close した
+      # 際の SIGPIPE で `set -o pipefail` が pipeline を 141 で fail させることがあるため、
+      # subshell で pipefail を局所的に無効化する。
+      value="$(set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+    fi
+    overrides+=("${key}=${value}")
+  done < <(jq -r '.cfnParameters // {} | to_entries[] | "\(.key)\t\(.value)"' "${metadata}")
+
+  printf '%s\n' "${overrides[@]}"
+}
 
 deploy_one() {
   local problem_dir="$1"
@@ -50,24 +99,17 @@ deploy_one() {
   local name_prefix
   name_prefix="$(build_name_prefix "${problem_dir}" "${TEAM_SLUG}")"
 
+  local -a parameter_overrides
+  mapfile -t parameter_overrides < <(build_parameter_overrides "${problem_dir}" "${name_prefix}")
+
   echo ""
   echo "=========================================="
   echo "Deploying: ${problem_dir}"
   echo "  StackName : ${name_prefix}"
   echo "  Region    : ${AWS_REGION}"
   echo "  TeamSlug  : ${TEAM_SLUG}"
+  echo "  Parameters: ${#parameter_overrides[@]} item(s) (NamePrefix + cfnParameters)"
   echo "=========================================="
-
-  # DbPassword は env DB_PASSWORD で渡す。未指定なら毎回ランダム生成 (smoke test なので
-  # 永続性は不要)。secrets-in-source の commit を防ぐためハードコードしない。
-  local db_password="${DB_PASSWORD:-}"
-  if [[ -z "${db_password}" ]]; then
-    # /dev/urandom を `tr` で英数字に絞って 32 桁切り出す。`head -c 32` が早期 close した
-    # 際の `tr` への SIGPIPE で `set -o pipefail` が pipeline 全体を 141 で fail させる
-    # ことがあるため、subshell で pipefail を局所的に無効化する (template の AllowedPattern
-    # `^[A-Za-z0-9!@#$%^&*()_+\-=]+$` に収まる字種を選んでいる)。
-    db_password="$(set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
-  fi
 
   # `aws cloudformation deploy` は CreateStack / UpdateStack を冪等に扱う:
   #   - stack が無ければ Create
@@ -79,9 +121,7 @@ deploy_one() {
     --template-file "${template}" \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset \
-    --parameter-overrides \
-        "NamePrefix=${name_prefix}" \
-        "DbPassword=${db_password}" \
+    --parameter-overrides "${parameter_overrides[@]}" \
     --tags \
         "TenkaCloud:NamePrefix=${name_prefix}" \
         "TenkaCloud:Problem=${problem_slug}" \

--- a/scripts/destroy-battles.sh
+++ b/scripts/destroy-battles.sh
@@ -18,6 +18,14 @@ set -euo pipefail
 # shellcheck source=lib/battles-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/battles-common.sh"
 
+# UTF-8 強制 (deploy-battles.sh と同じ理由、対称性のため)。
+case "${LC_ALL:-${LANG:-}}" in
+  C|POSIX|"")
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+    ;;
+esac
+
 if [[ $# -lt 1 ]]; then
   echo "usage: $0 <problem-dir> [<problem-dir> ...]" >&2
   exit 1


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

PR #461 (MVP-0) で起きた 4 つの問題を 1 PR で解消する。

1. **`make deploy-battles` 引数なしで sudden に security-battle-royale が deploy された** → `BATTLES` を必須化、未指定なら error で止まる
2. **`DbPassword` ハードコードで他問題が deploy できない** (/review Blocker) → `metadata.json` の `cfnParameters` で問題ごとに宣言する仕組みに置換
3. **CFn Description の日本語が `?` に化ける** → aws CLI subprocess に UTF-8 locale 強制
4. **smoke test に security-battle-royale (脆弱性入り) を default で使うのは危険** → 無害な `problems/sample/hello-world` (SSM Parameter 1 個、$0、公開エンドポイント無し) を新設

## 使い方

```bash
# 引数なしは error:
$ make deploy-battles
error: BATTLES が未指定。例: make deploy-battles BATTLES="problems/gameday/security-battle-royale"

# 安全な sample で smoke test:
make deploy-battles BATTLES=problems/sample/hello-world
make destroy-battles BATTLES=problems/sample/hello-world

# 既存の battle 系 (cfnParameters は metadata.json から自動展開):
make deploy-battles BATTLES=problems/gameday/security-battle-royale
```

## 変更前 → 変更後のフロー

```mermaid
flowchart TB
    subgraph 変更前
      A1[make deploy-battles] -->|引数なし=default で sudden| B1[CFn deploy of security-battle-royale]
      A2[script] -->|hardcoded| C2["DbPassword=demo"]
    end
    subgraph 変更後
      A3[make deploy-battles BATTLES=...] -->|明示指定必須| S3[script]
      S3 --> M3[metadata.json cfnParameters]
      M3 -->|__RANDOM_PASSWORD__ → 32桁ランダム| O3[--parameter-overrides 動的構築]
      O3 --> D3[CFn deploy]
    end
```

## 物理影響

### AWS リソース (`make deploy`)
| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| (なし) | (なし) | NO-OP | CDK 構成不変 |

新しい sample 問題は repo にファイルが追加されるだけ。CFn deploy は `make deploy-battles BATTLES=...` を明示実行したときだけ走る。

### ビルド成果物 (`make build`)
なし。

## ファイルごとの変更意図

- `Makefile` — `BATTLES ?=` default を削除、未指定なら `error: BATTLES が未指定` で exit 1
- `scripts/deploy-battles.sh` — `build_parameter_overrides()` 関数を追加。`metadata.json` の `cfnParameters` を `jq` で読み、`__RANDOM_PASSWORD__` トークンは 32 桁ランダムに置換、`NamePrefix` は script が自動注入。UTF-8 locale 強制を top-level に追加
- `scripts/destroy-battles.sh` — UTF-8 locale 強制 (対称性)
- `problems/SCHEMA.json` — `cfnParameters` field 追加 (optional、`object of strings`)
- `problems/gameday/security-battle-royale/metadata.json` — `cfnParameters: {"DbPassword": "__RANDOM_PASSWORD__"}` を宣言
- `problems/sample/hello-world/template.yaml` (新規) — SSM Parameter 1 個だけ
- `problems/sample/hello-world/metadata.json` (新規) — sample メタデータ、`cfnParameters: {}` (NamePrefix のみ)

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 |
|---|---|---|---|---|
| 1 | 既存の `make deploy-battles` (引数なし) | smoke test 操作 | ✅ 仕様変更として明示 | error メッセージで指示 |
| 2 | `--parameter-overrides "DbPassword=..."` を期待していた経路 | smoke test | ✅ 引き続き動く | metadata.json から自動展開 |
| 3 | `make validate-problems` (SCHEMA 検証) | CI gate | ✅ 通過 | `cfnParameters` は optional、新 sample / 既存問題ともに valid |
| 4 | `jq` 依存の追加 | 開発者環境 | ✅ 確認済み | macOS / Linux 標準、未インストール時は明示 error |

## Rollback 手順

`git revert <merge-sha>` のみ。`make deploy-battles BATTLES=...` で立てた stack があれば `make destroy-battles BATTLES=...` で消してから revert。

## テスト戦略

- 既存テストでカバー: `make validate-problems` で SCHEMA 検証
- 追加テスト: なし (shell + Makefile はテスト対象外)
- 手動確認:
  - `make deploy-battles` (引数なし) → exit 1 + error message ✅
  - `build_parameter_overrides` を bash inline で展開 → hello-world (空 cfnParameters) と security-battle-royale (DbPassword randomized) で期待通り動く ✅
  - `make before-commit` exit 0 ✅

## Verification

### Merge 前

- [x] `make before-commit` (lint / typecheck / test / validate-problems pass)
- [x] `bash -n` × 3 scripts (syntax OK)
- [x] `make deploy-battles` (no args) → error 1
- [x] `build_parameter_overrides` 動作確認
- [x] `validate-problems` で hello-world / security-battle-royale 両方 OK

### Merge 後 (手動 smoke test)

- [ ] `make deploy-battles BATTLES=problems/sample/hello-world` → CFn stack `tc-hello-world-demo-team` が立ち、SSM Parameter `/tc-hello-world-demo-team/hello` が created
- [ ] `make destroy-battles BATTLES=problems/sample/hello-world` で stack 消える
- [ ] (UTF-8 fix の確認) CFn console の Description 表示が `?` ではなく日本語で表示される

## 既知の未完了 (scope 外)

- **security-battle-royale の `RepoRef` default が削除済 branch を指していて frontend が起動しない問題** — 本 PR で観測したが、scope 外 (security-battle-royale 単体の修正、別 PR で `RepoRef: main` に更新)
- MVP-1 (Step Functions / CodeBuild / EventBridge で本 script を wrap) — 別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
