### PR TITLE
refactor(catalog): 問題カタログを problems/ ディレクトリから自動 discovery + CORS fix

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -1,15 +1,10 @@
 /**
- * 問題カタログ。現状は静的 (frontend-baked) だが、将来は backend API から取得する。
- * 1 問題 = 1 CFn テンプレート + メタデータ。
+ * 問題カタログ。`problems/` ディレクトリの metadata.json を Vite の `import.meta.glob`
+ * で build 時に取り込む。問題を追加するときは `problems/<category>/<id>/{template.yaml,
+ * metadata.json}` を置くだけで、本ファイルへの手作業は不要。
  *
- * カテゴリ:
- *   - "Battle"    リアルタイム対戦競技 (旧 GameDay 形式相当)
- *   - "Challenge" 個別演習・常設チャレンジ (旧 JAM 形式相当)
- *
- * status:
- *   - "ready"      参加者向けデプロイ可能
- *   - "draft"      問題本体は揃っているが UI / backend 連携が未完
- *   - "deprecated" 停止予定
+ * Phase 2 (ADR-003) で問題カタログを DDB-backed の API に置き換える予定。それまでは
+ * 静的 build-time discovery で 1 元化を保つ。
  */
 
 export type ProblemCategory = "Battle" | "Challenge";
@@ -38,58 +33,56 @@ export interface ProblemDetail extends ProblemSummary {
   learningGoals: readonly string[];
 }
 
-const HELLO_WORLD: ProblemDetail = {
-  id: "hello-world",
-  name: "Hello World (Sample)",
-  category: "Challenge",
-  status: "ready",
-  shortDescription:
-    "TenkaCloud デプロイ機構の smoke test 用サンプル問題。SSM Parameter を 1 つだけ作る無害なスタック。",
-  difficulty: 1,
-  estimatedDuration: "1 分",
-  tags: ["sample", "smoke-test", "ssm"],
-  exposedPorts: [{ port: 1, name: "(no public endpoint — SSM Parameter only)" }],
-  learningGoals: ["TenkaCloud のデプロイ機構が end-to-end で動くことを smoke test で確認する"],
-  description: [
-    "deploy-battles.sh / Step Functions などのデプロイ経路を smoke test するためのサンプル問題。",
-    "",
-    "本問題は SSM Parameter (`/{NamePrefix}/hello`) を 1 つ作るだけで、EC2 / VPC / 公開エンドポイント / 脆弱性のあるソフトウェアは一切含まない。コストはゼロ。",
-    "",
-    "通常の競技には使わず、開発者が `make deploy-battles BATTLES=problems/challenges/hello-world` で deploy 機構の正しさを確かめるためだけに用意している。UI からも同様の smoke test として deploy できる。",
-  ].join("\n"),
-};
+/**
+ * `problems/<category>/<id>/metadata.json` の生 shape。`problems/SCHEMA.json` と一致。
+ * UI で使わない field (`cfnTemplate` / `cfnParameters`) も型として定義しておくが
+ * `ProblemDetail` には map しない。
+ */
+interface ProblemMetadata {
+  $schema?: string;
+  id: string;
+  name: string;
+  category: ProblemCategory;
+  status: ProblemStatus;
+  difficulty: 1 | 2 | 3 | 4 | 5;
+  estimatedDuration: string;
+  shortDescription: string;
+  description: string;
+  tags: string[];
+  exposedPorts: { port: number; name: string }[];
+  learningGoals: string[];
+  cfnTemplate: string;
+  cfnParameters?: Record<string, string>;
+}
 
-const SECURITY_BATTLE_ROYALE: ProblemDetail = {
-  id: "security-battle-royale",
-  name: "Security Battle Royale",
-  category: "Battle",
-  status: "draft",
-  shortDescription:
-    "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",
-  difficulty: 3,
-  estimatedDuration: "60〜90 分",
-  tags: ["security", "web", "sql-injection", "rce", "ssrf"],
-  exposedPorts: [
-    { port: 80, name: "frontend (nginx)" },
-    { port: 8080, name: "api (Flask)" },
-  ],
-  learningGoals: [
-    "意図的な SQL injection / RCE / SSRF を発見・修正する一連の手順を体験する",
-    "EC2 IMDS / IAM Role の露出経路と、それを塞ぐベストプラクティスを理解する",
-    "競技中に同居する攻撃者と防御者のトレードオフ (可用性を保ちつつ守る) を体験する",
-  ],
-  description: [
-    "ECサイト風の Web アプリ「Unicorn.Rentals」を題材に、SQL injection / リモートコード実行 / SSRF / IMDS 露出を含む複数の脆弱性が仕込まれた状態でデプロイされる。",
-    "",
-    "競技参加者は次のいずれかのロールでプレイする。",
-    "  - **攻撃側**: 他チームの公開エンドポイントを巡回し、得点リソースを奪取する。",
-    "  - **防御側**: 自チームのアプリを継続稼働させたまま、脆弱性を順次塞いでいく。",
-    "",
-    "デプロイ単位は EC2 1 台 + Docker 構成 (mysql / Flask api / nginx frontend)。デプロイ完了後、参加者には Frontend URL と API URL が払い出される。",
-  ].join("\n"),
-};
+// `import.meta.glob` で repo root の `problems/*/*/metadata.json` を build 時 / HMR 時に
+// 全件取り込む。`eager: true` で同期 import (lazy chunk なし)。`{ default: ... }` 構造で
+// 返るのでアダプタで剥がす。
+const metadataModules = import.meta.glob<{ default: ProblemMetadata }>(
+  "../../../../problems/*/*/metadata.json",
+  { eager: true },
+);
 
-export const PROBLEM_CATALOG: readonly ProblemDetail[] = [HELLO_WORLD, SECURITY_BATTLE_ROYALE];
+function metadataToDetail(metadata: ProblemMetadata): ProblemDetail {
+  return {
+    id: metadata.id,
+    name: metadata.name,
+    category: metadata.category,
+    status: metadata.status,
+    shortDescription: metadata.shortDescription,
+    difficulty: metadata.difficulty,
+    estimatedDuration: metadata.estimatedDuration,
+    tags: metadata.tags,
+    description: metadata.description,
+    exposedPorts: metadata.exposedPorts,
+    learningGoals: metadata.learningGoals,
+  };
+}
+
+// 表示順の安定化のため id で sort。category > id の 2 段 sort は Phase 2 で必要に応じて。
+export const PROBLEM_CATALOG: readonly ProblemDetail[] = Object.values(metadataModules)
+  .map((mod) => metadataToDetail(mod.default))
+  .sort((a, b) => a.id.localeCompare(b.id));
 
 export function findProblem(id: string): ProblemDetail | undefined {
   return PROBLEM_CATALOG.find((p) => p.id === id);

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -37,7 +37,13 @@ if (fs.existsSync(envFilePath)) {
  *   一致しない場合は metadata 側を信用する)
  */
 function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
-  if (!fs.existsSync(problemsRoot)) return {};
+  if (!fs.existsSync(problemsRoot)) {
+    console.warn(
+      `[discoverProblemsCatalog] ${problemsRoot} not found — assuming pre-install or wrong cwd. ` +
+        `Catalog will be empty; tenant API will reject all problemId.`,
+    );
+    return {};
+  }
   const catalog: Record<string, string> = {};
   for (const category of fs.readdirSync(problemsRoot, { withFileTypes: true })) {
     if (!category.isDirectory()) continue;
@@ -48,10 +54,16 @@ function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
       if (!fs.existsSync(metadataPath)) continue;
       try {
         const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { id?: unknown };
-        if (typeof meta.id !== "string" || meta.id.length === 0) continue;
+        if (typeof meta.id !== "string" || meta.id.length === 0) {
+          console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
+          continue;
+        }
         catalog[meta.id] = `problems/${category.name}/${problem.name}`;
-      } catch {
-        // 壊れた metadata.json は make validate-problems が CI で弾くので、ここは silent skip。
+      } catch (err) {
+        console.warn(
+          `[discoverProblemsCatalog] ${metadataPath}: parse failed (${(err as Error).message}). ` +
+            `Run 'make validate-problems' to see schema errors.`,
+        );
       }
     }
   }

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -26,6 +26,38 @@ if (fs.existsSync(envFilePath)) {
   console.log(`[bin] Loaded env from ${envFilePath}`);
 }
 
+/**
+ * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
+ * `{ [problemId]: "problems/<category>/<id>" }` の map を返す。frontend の Vite glob と
+ * 同じ正本 (filesystem) から問題カタログを引くための関数。
+ *
+ * - `problemsRoot` が存在しない / metadata.json が無い場合は空 map を返す (synth 時に
+ *   problems/ を埋める前に typecheck が走るケースの防御)
+ * - id は metadata.json の `id` field を採用 (ディレクトリ名と一致するのは規約だが、
+ *   一致しない場合は metadata 側を信用する)
+ */
+function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
+  if (!fs.existsSync(problemsRoot)) return {};
+  const catalog: Record<string, string> = {};
+  for (const category of fs.readdirSync(problemsRoot, { withFileTypes: true })) {
+    if (!category.isDirectory()) continue;
+    const categoryDir = path.join(problemsRoot, category.name);
+    for (const problem of fs.readdirSync(categoryDir, { withFileTypes: true })) {
+      if (!problem.isDirectory()) continue;
+      const metadataPath = path.join(categoryDir, problem.name, "metadata.json");
+      if (!fs.existsSync(metadataPath)) continue;
+      try {
+        const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { id?: unknown };
+        if (typeof meta.id !== "string" || meta.id.length === 0) continue;
+        catalog[meta.id] = `problems/${category.name}/${problem.name}`;
+      } catch {
+        // 壊れた metadata.json は make validate-problems が CI で弾くので、ここは silent skip。
+      }
+    }
+  }
+  return catalog;
+}
+
 const app = new cdk.App();
 
 // required input parameters
@@ -155,12 +187,11 @@ const participantPortal = enableParticipantPortal
   ? { runtimeConfig: participantPortalRuntimeConfig }
   : undefined;
 
-// MVP-1 hard-coded 問題カタログ。Phase 2 (ADR-003) で DDB ベース問題管理に置換予定。
-// problemId → problemDir (= scripts/deploy-battles.sh の引数 path)。
-const problemsCatalog: Record<string, string> = {
-  "hello-world": "problems/challenges/hello-world",
-  "security-battle-royale": "problems/battles/security-battle-royale",
-};
+// 問題カタログを `problems/<category>/<id>/metadata.json` から自動生成。問題追加時に
+// 本ファイルを書き換える必要はない (frontend `data/problems.ts` も同 metadata を Vite glob
+// で読むので、3 重管理を避ける)。
+// Phase 2 (ADR-003) で DDB ベース問題管理に置換するまでの自動 discovery 経路。
+const problemsCatalog = discoverProblemsCatalog(path.resolve(__dirname, "..", "..", "problems"));
 
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
+import { cors } from "hono/cors";
 import {
   HTTP_ACCEPTED,
   HTTP_BAD_REQUEST,
@@ -41,6 +42,20 @@ const LIST_LIMIT_MAX = 200;
 const shared = buildSharedResources();
 
 const app = new Hono();
+
+// CORS は本 Lambda 側で打つ (= API Gateway の defaultCorsPreflightOptions は OPTIONS のみ
+// 対応で、実 POST/GET レスポンスには Access-Control-Allow-Origin が付かないため)。
+// Cognito JWT は Authorization header で送られるので credentials cookie は使わず、`*`
+// で許可する。Phase 2 で tenant の CloudFront URL に絞る。
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    maxAge: 600,
+  }),
+);
 
 app.get("/healthz", (c) => c.json({ ok: true }));
 


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

1. **問題追加が `problems/<category>/<id>/` 1 ディレクトリだけで完結**する。frontend カタログ (Vite glob) と backend (CDK fs scan) が build 時 / synth 時に自動取り込み
2. **UI Deploy ボタンが CORS error なしで成功レスポンスを受け取れる** (Hono cors middleware を tenant API Lambda に追加)

実 AWS で MVP-1 経路 (UI → tenant API → EventBridge → Step Functions → CodeBuild → CFn → SSM Parameter) が end-to-end で動くことを `tc-hello-world-test` stack で確認済 (Outputs に `Hello from tc-hello-world-test`)。

## なぜ今これが要るか

PR #463 / #464 で発覚した 2 つの問題:

- **3 重管理問題**: 問題リストが filesystem (`problems/`) / frontend (`data/problems.ts`) / backend (`bin/infrastructure.ts:problemsCatalog`) の 3 箇所にバラバラ。1 個追加すると 3 ファイル更新が必要、忘れると不具合 (PR #463 で hello-world を frontend カタログに入れ忘れて不具合発生 → #464 で hot-fix)
- **CORS error**: UI Deploy ボタン押下時、deploy 自体は 202 で受理されたが browser が JS から response を読めず「Failed to fetch」表示 → operator が失敗したと誤認

## 変更点

### Frontend (`apps/application-admin-console/src/data/problems.ts`)

Vite の `import.meta.glob<{ default: ProblemMetadata }>("../../../../problems/*/*/metadata.json", { eager: true })` で repo root の全 metadata.json を build 時に取り込み、`ProblemDetail` 配列に変換。手書き定数 (`HELLO_WORLD` / `SECURITY_BATTLE_ROYALE`) は撤廃。

### Backend (`infrastructure/bin/infrastructure.ts`)

`discoverProblemsCatalog(problemsRoot)` ヘルパー追加。`fs.readdirSync` で `problems/<category>/<id>/` を 2 階層辿り、`metadata.json` を持つディレクトリを採集。id は metadata の `id` field を採用。旧 hard-coded map 撤廃。

### Lambda CORS (`infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts`)

Hono `cors()` middleware を `app.use("*", ...)` で挿入。API Gateway REST API の `defaultCorsPreflightOptions` は OPTIONS のみ対応で、実 POST/GET レスポンスには CORS ヘッダが付かないため Lambda 側で打つ必要がある。Cognito JWT は Authorization header で送られるので credentials cookie 不要、`origin: "*"` で許可 (Phase 2 で tenant CloudFront URL に絞る)。

## 物理影響

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| ProblemDeployBackendStack | Deploy API Lambda code | UPDATE in-place | Lambda zip が再 build (CORS middleware 追加分) |
| (その他) | (なし) | NO-OP | CDK 構成不変、CFn 出力同じ |

build 成果物: frontend の `dist/assets/index-*.js` に両問題が含まれることを `bun run build` + grep で確認済 (`Hello World` / `Security Battle Royale` 両方 hit)。

## ファイルごとの変更意図

- `apps/application-admin-console/src/data/problems.ts` — `import.meta.glob` で metadata.json 全件取り込み + `metadataToDetail` adapter。公開 API (`PROBLEM_CATALOG` / `findProblem` / `listProblemSummaries`) は不変
- `infrastructure/bin/infrastructure.ts` — `discoverProblemsCatalog()` 関数追加、旧 hard-coded map 撤廃
- `infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts` — `app.use("*", cors())` を route 定義の前に挿入

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | `data/problems.ts` を直接 import している箇所 | frontend | ✅ 公開 API 不変 (`PROBLEM_CATALOG` / `findProblem` / `listProblemSummaries`) |
| 2 | `bin/infrastructure.ts:problemsCatalog` 利用側 | ProblemDeployBackendStack | ✅ 型 (`Record<string, string>`) と内容 (PR #463 と同) 不変 |
| 3 | Vite が repo root の `problems/` にアクセスする fs 制限 | dev / build | ✅ `bun run build` 成功、`Hello World` / `Security Battle Royale` が bundle に含まれる |
| 4 | `tsc --noEmit` で metadata.json を type 解決 | typecheck | ✅ `resolveJsonModule: true` 既設、exit 0 |
| 5 | API Gateway `defaultCorsPreflightOptions` と Hono `cors()` の競合 | OPTIONS preflight | ✅ 両者は別レイヤーで動く (Gateway = OPTIONS / Lambda = POST/GET レスポンス)、競合なし |
| 6 | 既存 deploy 機能 (UI Deploy ボタン) | application-admin-console | ✅ **実 AWS で確認済** — `tc-hello-world-test` stack が CREATE_COMPLETE、SSM Parameter `Hello from tc-hello-world-test` が出力 |

## Rollback 手順

`git revert <merge-sha>` のみ。filesystem の `problems/` 構造は不変、CDK 構成も不変。

## テスト戦略

- 既存テストでカバー: `make validate-problems` (SCHEMA 検証)、infra tests (146 件)、frontend tests (60 件)
- 新規テスト: なし (build-time / synth-time の自動 discovery は静的解析でしか壊せない、e2e は実 AWS で確認)
- 未カバー: Hono cors middleware の unit test は scope 外 (Hono 側で十分テストされている)

## Verification

### Merge 前

- [x] `make before-commit` exit 0 (lint / typecheck / test / validate-problems)
- [x] `bun run build` (frontend) で両問題が bundle に含まれる
- [x] backend `discoverProblemsCatalog` dry-run で正しい map が返る

### Merge 後 (実 AWS で確認済)

- [x] **MVP-1 経路 end-to-end**: UI Deploy ボタン → tenant API → EventBridge → Step Functions → CodeBuild → CFn → `tc-hello-world-test` stack CREATE_COMPLETE
- [x] SSM Parameter `/tc-hello-world-test/hello = "Hello from tc-hello-world-test"` 作成確認
- [ ] (本 PR merge 後) UI 上で CORS error なく 202 レスポンスが見えること

## 既知の deferred (本 PR で解消しない)

- **問題作者が SaaS UI から問題を upload する経路** (Phase 2 / ADR-003 の DDB-backed catalog)。本 PR は filesystem 経由の build-time discovery で 3 重管理を解消するだけ
- **CORS origin の絞り込み** — 現状 `origin: "*"`。Phase 2 で tenant の CloudFront URL に絞る (per-tenant 値が必要、Lambda env で受ける形か authorizer pattern)
- **問題の可視範囲** (`public` / `org-shared` / `private`) — metadata.json の status は読むが filtering UI は未実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS middleware to the deployment API, enabling cross-origin requests with support for Authorization and Content-Type headers.

* **Refactor**
  * Refactored the problem catalog system to dynamically load problem metadata at build and runtime, replacing hardcoded definitions with a scalable metadata-driven approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->