### PR TITLE
refactor: MVP-1 後の dead code / silent failure 整理 + Phase 2 ADR-002/003 起草

### DIFF
--- a/docs/architecture/adr-002-cross-account-federation.md
+++ b/docs/architecture/adr-002-cross-account-federation.md
@@ -1,0 +1,177 @@
+# ADR-002: 競技者 AWS アカウント への federation を tenant 単位 ExternalId + 専用 DDB + SSM SecureString で管理する
+
+- **Status**: Proposed (2026-05-05)
+- **Related issues**: Issue 459 (cross-account federation 設計)、Issue 458 (publish 経路統一 ✅ 完了)
+- **Related ADR**: [ADR-001](./adr-001-problem-deploy-crud.md) (本 ADR は ADR-001 の Decision 6「cross-account 越境」をさらに具体化する)
+
+## Context
+
+ADR-001 で「問題 deploy 系の publish 経路は tenant API + EventBridge + Step Functions」「CFn API は cross-account AssumeRole 経由」を確定した。本 ADR は **AssumeRole する先を「どの ExternalId で / どこに保存された」値で決めるか** を確定する。
+
+要件文書 [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) の制約のうち、本 ADR を駆動するものは次のとおり。
+
+- **NFR-2**: operator は TenkaCloud 自社 AWS account を触らない (operator は tenant 内のみ)
+- **NFR-3**: 競技者アカウントは AWS Organizations 共有が使えない野良 account を含む (= per-account の federation が必要)
+- **CLAUDE.md `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER`**: テナント分離はインフラ層で実現
+- **CLAUDE.md `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`**: 認証はインフラ層で注入
+- **CLAUDE.md `secrets-manager-forbidden`**: SSM Parameter Store SecureString を使う (Secrets Manager 禁止)
+- **`DynamoDbLowCapacity` Aspect**: 全テーブル 1 RCU / 1 WCU 強制
+
+### 現状 (Phase 1) の federation 仕組み
+
+| 項目 | 現状 | 問題点 |
+|---|---|---|
+| ExternalId | TenkaCloud 全体で 1 個の env (`CDK_PARAM_DEPLOY_EXTERNAL_ID`、default `tenkacloud-dev-external-id`) | 1 個漏れたら全 competitor account に影響。Confused Deputy 対策として実質不足 |
+| Competitor Role 名 | 単一 default `TenkaCloud-CompetitorDeploy-Role` | 競技者側で名前を変えると即崩壊。tenant ごとに違う名前を許す余地なし |
+| Tenant ↔ 競技者アカウントの紐付け | **存在しない**。DeployForm で operator が `awsAccountId` を毎回手入力 | typo した別 account を入れれば 401/403 で落ちるだけで誤 deploy 防御弱い |
+| 競技者 Bootstrap | `infrastructure/templates/competitor-bootstrap.yaml` を 1 回 deploy | 全 tenant 共通の ExternalId を競技者が知る必要がある |
+| 鍵ローテーション | 仕組み無し | ExternalId 変えるなら全 competitor / 全 worker に手作業伝搬 |
+
+## Decision
+
+### 1. ExternalId は tenant 単位で発行する (= A2)
+
+- 1 tenant 配下の複数 competitor account は **同じ ExternalId** を共有する
+- 別 tenant とは ExternalId が必ず異なる
+- 漏洩時の blast RADIUS は当該 tenant の全 competitor account で打ち止め
+
+(tenant, account) ペアごと (= A3) は管理が複雑化する割に Confused Deputy 防御は A2 でも十分強い (= AWS 推奨もコンテキスト単位、すべての顧客単位の弱者運用は推奨されていない)。Phase 3 以降に必要性が出たら edge 単位に縮められる構造を残す (= A2 → A3 への移行は新 ExternalId を発行して per-edge に migrate するだけで、A1 → A2 のような全 reset は要らない)。
+
+### 2. メタデータは新 DDB `CompetitorAccounts`、ExternalId は SSM SecureString (= B2 + B3)
+
+#### 2.1 `CompetitorAccounts` DDB schema
+
+| 属性 | 型 | 説明 |
+|---|---|---|
+| `PK` | String | `TENANT#{tenantId}` |
+| `SK` | String | `ACCOUNT#{awsAccountId}` |
+| `tenantId` | String | tenant 内表示用 |
+| `awsAccountId` | String | 12 桁の AWS Account ID |
+| `region` | String | 主たる deploy region (デフォルト `ap-northeast-1`) |
+| `competitorRoleName` | String | 競技者 bootstrap で deploy された IAM Role 名 |
+| `alias` | String? | operator 表示用ラベル (例 "Team Acme prod") |
+| `verified` | Boolean | STS AssumeRole sanity check が通ったか |
+| `verifiedAt` | String? | ISO 8601、verified=true 化したときの時刻 |
+| `createdAt` | String | ISO 8601 |
+| `updatedAt` | String | ISO 8601 |
+
+- `BillingMode = PROVISIONED 1/1` (`DynamoDbLowCapacity` Aspect で強制)
+- ExternalId は **本テーブルに保存しない** (= 2.2 SSM 側に置く)
+- GSI: 不要 (PK 単一で tenant 内一覧、Get で SK 直接 lookup)
+
+#### 2.2 SSM Parameter Store SecureString path 規約
+
+```
+/{env}/tenants/{tenantId}/external-id
+```
+
+- 1 tenant 1 値 (Decision 1 = A2 と整合)
+- KMS は AWS managed (`alias/aws/ssm`、コスト 0)
+- Worker Lambda の IAM policy は `ssm:GetParameter` を path prefix で許可:
+  - resource: `arn:aws:ssm:{region}:{account}:parameter/{env}/tenants/${aws:PrincipalTag/tenantId}/external-id` ← セッション tag が無いケース用に **fallback で `parameter/{env}/tenants/*/external-id` も書く** (Phase 1.5 暫定。Phase 2 でセッション tag injection を Cognito identity propagation で実装済んだら絞る)
+- Lambda は cold start で読み込まず、deployment 行の `tenantId` から都度 GetParameter (warm cache 5 分 TTL は SDK の middleware で十分)
+
+#### 2.3 なぜ DDB と SSM の二段か
+
+- DDB は人間が見る tenant 管理メタデータ (alias / verified / region)
+- SSM は machine-only な秘密 (ExternalId)
+- 同じ DDB 行に ExternalId を入れると、誤って `Scan` 結果や CloudWatch log に流出する経路が生える (`secrets-manager-forbidden` 原則)
+- `secrets-manager-forbidden` は Secrets Manager の高コスト (= $0.40/secret/月 + API call) を避けるためで、SSM SecureString は無料
+
+### 3. Onboarding は 5-step で完結する (= C)
+
+```text
+[1] operator が application-admin-console / Competitor Accounts 画面で「Add account」
+[2] frontend → tenant API → 新 endpoint POST /tenants/{me}/accounts
+       backend が下記を 1 transaction で実行:
+         - SSM SecureString に random 32 文字 ExternalId を Put (`/{env}/tenants/{tenantId}/external-id` 既存なら no-op)
+         - DDB CompetitorAccounts に row 追加 (verified=false)
+         - 戻り値: { externalId, tenkaCloudAccountId, bootstrapTemplateUrl }
+[3] operator が画面に表示された 3 値を競技者にコピペ送信
+       (or "Open in CloudFormation 1-click" link を競技者に送る)
+[4] 競技者が `competitor-bootstrap.yaml` を自分のアカウントで deploy
+       Parameter: ExternalId, TrustedAccountId (= TenkaCloud account ID)
+[5] operator が画面で「Verify」ボタン
+       backend が STS AssumeRole で sanity check → DDB.verified = true
+```
+
+#### 3.1 「Add account」が冪等
+
+- 同じ tenant で 2 度目の Add は ExternalId を **回さない** (SSM Put で `Overwrite=false` 相当のロジック)
+- DDB row は account ごとに 1 つなので、同じ awsAccountId を再 Add すると 409 Conflict
+
+#### 3.2 「Verify」失敗時の表示
+
+- 失敗理由は STS の `ErrorCode` (AccessDenied / ExternalIdMismatch / AssumeRoleFailed) を operator に表示
+- 失敗 row は DDB に残し `verified=false` のまま (削除はしない、operator が原因解決後に再 Verify できる)
+
+### 4. DeployForm は drop-down で verified account から選ぶ (自由入力廃止)
+
+- frontend `DeployForm.tsx` の `awsAccountId` 自由入力 input を **撤廃**
+- 代わりに `useCompetitorAccounts()` hook で `verified=true` の row を引き、`<Select>` で表示
+- verified=false の row は選択肢に出ない (UI 側 + backend 側両方で防御)
+- alias 列があれば `${alias} (${awsAccountId})`、無ければ `${awsAccountId}` を表示
+
+### 5. legacy `CDK_PARAM_DEPLOY_EXTERNAL_ID` env は dev fallback として残す (= D)
+
+- env 名を `CDK_PARAM_DEPLOY_EXTERNAL_ID_DEV_FALLBACK` に rename
+- 本番経路 (Worker Lambda の AssumeRole) は **必ず SSM から読む**
+- dev fallback env は CDK synth 時の bootstrap-stack 作成で 1 度だけ使う (ローカル開発で SSM が無い状態でも synth が通るように)
+- `bin/infrastructure.ts` から「単一 env を全 worker に注入する」ロジックを削除
+
+## Migration
+
+### Phase 2.1 (本 ADR を実装する PR)
+
+1. `CompetitorAccountsTable` (新 DDB) construct を追加 (`infrastructure/lib/competitor-accounts/`)
+2. SSM SecureString helper (`infrastructure/lib/utils/external-id-store.ts`) を追加
+3. tenant API に `POST /tenants/{me}/accounts` / `GET /tenants/{me}/accounts` / `POST /tenants/{me}/accounts/{accountId}/verify` / `DELETE /tenants/{me}/accounts/{accountId}` を追加
+4. application-admin-console に「Competitor Accounts」画面を追加
+5. DeployForm の `awsAccountId` 自由入力を Select に置き換え
+6. Worker Lambda が deployment 行の `awsAccountId` から `(externalId, competitorRoleName)` を解決するよう書き換え
+
+### Phase 2.2 (legacy env 撤去)
+
+1. 旧 deployment 行 (env-based ExternalId) を migration script で `externalId` フィールドを既存 env 値で埋める (現行運用が `tenkacloud-dev-external-id` の 1 値なので一括 update)
+2. `CDK_PARAM_DEPLOY_EXTERNAL_ID` を `CDK_PARAM_DEPLOY_EXTERNAL_ID_DEV_FALLBACK` に rename + 旧名のコード参照を撤去
+3. `infrastructure/templates/competitor-bootstrap.yaml` の Parameter 説明文を「tenant 個別の ExternalId を使うこと」に更新
+4. `infrastructure/templates/README.md` に新 onboarding フローを記載
+
+### Phase 3 (rotation)
+
+- ExternalId rotation API (`POST /tenants/{me}/accounts/{accountId}/rotate-external-id`) を追加
+- rotation 時は新値を SSM に Put (旧値は version として 7 日残す = SSM Parameter version 機能)
+- 競技者には新 ExternalId と CFn update 手順を画面で案内
+
+## Consequences
+
+### Positive
+
+- ExternalId 漏洩 blast RADIUS が 1 tenant に閉じる (Decision 1)
+- operator の「typo した別 account を入れて 401」事故が消える (Decision 4 = 自由入力廃止)
+- 「verified」概念で onboarding 進捗が可視化される (operator が「この account は使えるんだっけ」を画面で判別可能)
+- SSM SecureString は KMS managed key + IAM 制御で監査可能、Secrets Manager より安い (`secrets-manager-forbidden` と整合)
+- legacy env を escape hatch として残すことで dev / single-tenant ローカル開発が壊れない
+
+### Negative
+
+- 競技者は tenant 切替時に新しい ExternalId で `competitor-bootstrap.yaml` を再 deploy する必要がある
+- DDB と SSM の二段管理で「片方だけ存在する」不整合が起きうる (=「Add account」を 1 transaction 化 +「Delete account」で SSM 側も同時削除する責務を backend が持つ必要)
+
+### Unknown
+
+- AWS Organizations を使う tenant ([NFR-3](../requirements/problem-deploy.md) で「野良も許容」となっているため非必須) に対して、Org wide の `aws:PrincipalOrgID` condition で更に絞り込めるかは Phase 3 で検討
+
+## 関連 invariant
+
+- `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER` — tenant 単位 ExternalId + tenant scoped DDB query
+- `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER` — Worker の AssumeRole は infra (Worker Role) 層が注入、Lambda コードに ExternalId を hard-code しない
+- CLAUDE.md `secrets-manager-forbidden` — SSM SecureString を使う
+- `DynamoDbLowCapacity` Aspect — `CompetitorAccountsTable` も 1/1 PROVISIONED に強制
+
+## 関連リソース
+
+- Issue 459 — 本 ADR の前提となる設計判断ペーパー (現状調査含む)
+- [`infrastructure/templates/competitor-bootstrap.yaml`](../../infrastructure/templates/competitor-bootstrap.yaml) — Phase 2.2 で説明文を改訂
+- [`infrastructure/lib/problem-deploy/`](../../infrastructure/lib/problem-deploy/) — Worker Lambda の AssumeRole 経路、Phase 2.1 で書き換え
+- [ADR-001](./adr-001-problem-deploy-crud.md) — Decision 6 で本 ADR をフォロー

--- a/docs/architecture/adr-003-problem-catalog-ddb.md
+++ b/docs/architecture/adr-003-problem-catalog-ddb.md
@@ -1,0 +1,159 @@
+# ADR-003: 問題カタログを filesystem 自動 discovery から DDB-backed catalog API に移行する
+
+- **Status**: Proposed (2026-05-05)
+- **Related ADR**: [ADR-001](./adr-001-problem-deploy-crud.md) (FR-5「問題カタログ」を本 ADR で具体化)
+- **Related PR**: PR 465 (filesystem 自動 discovery を導入、本 ADR の前段)
+- **Related issues**:「SaaS UI から問題を upload する経路」(本 ADR の deferred 項目で開く新 issue)
+
+## Context
+
+PR 465 で「frontend / backend / filesystem の 3 重管理」問題を解消するため、`problems/<category>/<id>/metadata.json` を **filesystem 正本** にし、frontend (Vite `import.meta.glob`) と backend CDK (`fs.readdirSync`) が build 時 / synth 時に自動取り込みする方式を採用した。
+
+これは MVP-1 の暫定解で、次の 3 つの制約があり SaaS としては不完全。
+
+1. **問題追加に repo merge が必要**: 競技作者が UI から自分の問題を upload できない (= operator が GitHub PR を出して merge → CDK redeploy するまで反映されない)
+2. **可視範囲 (`public` / `org-shared` / `private`) が表現できない**: filesystem に置かれた problem は全 tenant で見える (実際は frontend で `import.meta.glob` するため build 時に全部 bundle される)
+3. **多 tenant 用に「うちの tenant だけが使える private 問題」を持てない**: 1 zip / 1 source.zip しか走らないので tenant 別に問題セットを分けられない
+
+要件文書 [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) の `FR-5: 問題カタログ` は次の 3 項目をひとつのまとまりで要求していた。
+
+- S3 に CFn template
+- DDB に metadata
+- 可視範囲フィールド (`public` / `org-shared` / `private`)
+
+PR 465 はこの 3 項目のうち「DDB metadata」と「可視範囲」を実装していない。本 ADR で完成形を確定する。
+
+## Decision
+
+### 1. データレイアウトは S3 (template) + DDB (metadata) + 可視範囲 (DDB attribute)
+
+```
+[S3 bucket] tenkacloud-problem-templates-{account}-{region}/
+  ├ tpl/{problemId}/{version}/template.yaml      ← 不変 (version で履歴)
+  └ tpl/{problemId}/{version}/checksum.sha256
+
+[DDB table] Problems
+  PK: PROBLEM#{problemId}
+  SK: VERSION#{version}                          ← latest = MAX(version)
+  attributes: {
+    problemId, version,
+    name, category, status, difficulty,
+    estimatedDuration, shortDescription, description,
+    tags, exposedPorts, learningGoals,
+    cfnTemplateS3Uri, cfnTemplateChecksum,
+    cfnParameters,                               ← 既存 schema の cfnParameters と互換
+    visibility: "public" | "org-shared" | "private",
+    ownerTenantId,                               ← visibility ≠ public のとき必須
+    sharedWithTenantIds: string[],               ← visibility = org-shared のとき
+    createdAt, updatedAt
+  }
+
+[DDB GSI] OwnerTenantIndex
+  GSI1PK: TENANT#{ownerTenantId}
+  GSI1SK: VERSION#{problemId}#{version}
+  → owner tenant の private 問題を一覧する
+```
+
+### 2. visibility による fan-out 規則
+
+問題リスト取得 API (`GET /problems`) は呼び出し元 tenant の JWT (`custom:tenantId`) を見て、次の union を返す。
+
+- `visibility = "public"` の全件
+- `visibility = "org-shared"` かつ `sharedWithTenantIds` に caller tenant が含まれる件
+- `visibility = "private"` かつ `ownerTenantId = caller tenant` の件
+
+3 query の結果を merge して dedupe (同 problemId が public / shared 両方に出るのは仕様上ない、念のため)。
+
+### 3. CRUD API は tenant API + Cognito JWT 認可で統一する (= ADR-001 と同型)
+
+Operations:
+
+| 操作 | endpoint | 認可 |
+|---|---|---|
+| Create | `POST /problems` | 自 tenant TenantAdmin role |
+| Read (1 件) | `GET /problems/{problemId}` | visibility filter (上記 §2) |
+| Read (一覧) | `GET /problems` | visibility filter |
+| Update (新 version) | `POST /problems/{problemId}/versions` | owner tenant のみ |
+| Delete (deprecate) | `PATCH /problems/{problemId}` `{ status: "deprecated" }` | owner tenant のみ |
+| Hard delete | (なし) | DDB 行は不変、status だけ deprecated に倒す |
+
+Update は **新 version を作る** だけで、既存 version は保つ。deploy 中の job への影響を避ける (= deploy job は jobId に紐づく version を使い続ける)。
+
+### 4. CFn template upload フロー
+
+```text
+[1] operator/作者が「Add problem」画面で metadata + template.yaml を選ぶ
+[2] frontend → POST /problems
+       backend が S3 に template Put (server-side hash 計算)、
+       DDB Problems に row insert (version="v1")
+[3] 画面に Created の確認、deploy 可能になる
+```
+
+template.yaml の syntax 検証 (cfn-lint) は backend Lambda で **行う**。MVP-1 の `make validate-problems` は Phase 2 で本 endpoint に置き換える (filesystem 経路は撤去するため)。
+
+### 5. filesystem 経路の撤去戦略
+
+PR 465 で導入した `import.meta.glob` (frontend) と `discoverProblemsCatalog` (backend) は **本 ADR 実装後に削除する**。
+
+具体的な変更箇所は次のとおり。
+
+- `apps/application-admin-console/src/data/problems.ts` を「DDB API client から fetch する hook」に書き換え (`PROBLEM_CATALOG` const → `useProblemCatalog()` hook)
+- `infrastructure/bin/infrastructure.ts` の `discoverProblemsCatalog()` 呼び出しを撤去 (= DeployApiLambda の env `BATTLE_PROBLEMS_CATALOG` も廃止、Lambda が DDB を都度 query する形に)
+- `problems/` ディレクトリ自体は **削除しない**: seed data として残し、初回 deploy 時に `make seed-problems` で DDB に流し込む one-shot script を用意する
+
+## Migration
+
+### Phase 2.1 (本 ADR を実装する PR-A)
+
+1. `ProblemCatalogTable` (新 DDB) construct を追加
+2. `ProblemTemplateBucket` (新 S3) construct を追加 (versioned bucket)
+3. tenant API に CRUD endpoint 5 個を追加
+4. cfn-lint Lambda layer (or container function) を追加
+5. visibility filter 付き query helper
+
+### Phase 2.2 (frontend / backend の filesystem 経路撤去 PR-B)
+
+1. `apps/application-admin-console` で `useProblemCatalog()` hook + Cloudscape `<Cards>` で表示
+2. `bin/infrastructure.ts` から `discoverProblemsCatalog()` 削除、`DeployApiLambda` の `BATTLE_PROBLEMS_CATALOG` env 削除
+3. `DeployApiLambda` の `startDeployment` を `ProblemCatalogTable` query に書き換え (`UnknownProblemError` の発火経路は不変)
+4. `make seed-problems` script を追加 (`problems/<category>/<id>/{metadata.json,template.yaml}` を読んで DDB + S3 に流し込む one-shot)
+5. CI gate `make validate-problems` を `make seed-problems --dry-run` に置き換え
+6. `apps/application-admin-console/src/data/problems.ts` を削除
+
+### Phase 3 (作者 UI)
+
+1. application-admin-console に「Problem Authoring」画面を追加 (template.yaml editor + metadata form + cfn-lint preview)
+2. `POST /problems` の auth role を「TenantAdmin」から「ProblemAuthor」に絞る (custom Cognito group 追加)
+
+## Consequences
+
+### Positive
+
+- 問題追加に repo merge が不要になる (SaaS の本来の姿)
+- visibility (`public` / `org-shared` / `private`) が表現できる、tenant 別の問題セットが持てる
+- version 履歴で「deploy 中の job が古い template を使い続ける」運用が安全
+- 3 重管理が完全消滅 (filesystem 経路撤去)
+
+### Negative
+
+- DDB read/write が deploy 経路に追加される (Lambda cold start で +50ms 程度)
+- S3 / DDB の Free Tier 枠を 1 RCU/WCU でやりくりするため、scan が増えると throttle 可能性 (`ProblemCatalogTable` は GSI で query 化、scan は禁止)
+- 既存 PR 465 の filesystem 経路を **同じ PR で削除する** ことで legacy fallback を残さない (CLAUDE.md「fallback 禁止」原則)。代わりに `make seed-problems` で初回 migration を扱う
+
+### Risk
+
+- visibility filter 実装の不備で別 tenant の private 問題が漏れるバグは critical。実装時に **権限境界の unit test を必ず書く** (PK 漏洩 / GSI 漏洩 / cross-tenant 同 problemId の混線を網羅)
+
+## 関連 invariant
+
+- `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER` — visibility filter は backend 層、frontend で見えなくしない
+- `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE` — visibility 周りは権限 unit test を必須
+- `DynamoDbLowCapacity` Aspect — `ProblemCatalogTable` も 1/1 PROVISIONED
+
+## 関連リソース
+
+- [`problems/SCHEMA.json`](../../problems/SCHEMA.json) — 既存 metadata.json schema、本 ADR で DDB attribute と互換に保つ
+- [`apps/application-admin-console/src/data/problems.ts`](../../apps/application-admin-console/src/data/problems.ts) — Phase 2.2 で削除
+- [`infrastructure/bin/infrastructure.ts`](../../infrastructure/bin/infrastructure.ts) — Phase 2.2 で `discoverProblemsCatalog` 撤去
+- [ADR-001](./adr-001-problem-deploy-crud.md) — FR-5 を本 ADR で具体化
+- PR 465 — 本 ADR の前段 (filesystem 自動 discovery 導入)

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -15,6 +15,7 @@ import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
 import { loadConfig } from "../lib/utils/config-loader";
+import { discoverProblemsCatalog } from "../lib/utils/discover-problems-catalog";
 
 // TenkaCloud の env 読み込み。`infrastructure/environments/<env>/.env` がある場合だけ load。
 // ref の bin は CDK_PARAM_* を全部 process.env から直読みするので、ここで先に注入しておく。
@@ -24,50 +25,6 @@ const envFilePath = path.resolve(__dirname, `../environments/${environment}/.env
 if (fs.existsSync(envFilePath)) {
   dotenv.config({ path: envFilePath });
   console.log(`[bin] Loaded env from ${envFilePath}`);
-}
-
-/**
- * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
- * `{ [problemId]: "problems/<category>/<id>" }` の map を返す。frontend の Vite glob と
- * 同じ正本 (filesystem) から問題カタログを引くための関数。
- *
- * - `problemsRoot` が存在しない / metadata.json が無い場合は空 map を返す (synth 時に
- *   problems/ を埋める前に typecheck が走るケースの防御)
- * - id は metadata.json の `id` field を採用 (ディレクトリ名と一致するのは規約だが、
- *   一致しない場合は metadata 側を信用する)
- */
-function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
-  if (!fs.existsSync(problemsRoot)) {
-    console.warn(
-      `[discoverProblemsCatalog] ${problemsRoot} not found — assuming pre-install or wrong cwd. ` +
-        `Catalog will be empty; tenant API will reject all problemId.`,
-    );
-    return {};
-  }
-  const catalog: Record<string, string> = {};
-  for (const category of fs.readdirSync(problemsRoot, { withFileTypes: true })) {
-    if (!category.isDirectory()) continue;
-    const categoryDir = path.join(problemsRoot, category.name);
-    for (const problem of fs.readdirSync(categoryDir, { withFileTypes: true })) {
-      if (!problem.isDirectory()) continue;
-      const metadataPath = path.join(categoryDir, problem.name, "metadata.json");
-      if (!fs.existsSync(metadataPath)) continue;
-      try {
-        const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { id?: unknown };
-        if (typeof meta.id !== "string" || meta.id.length === 0) {
-          console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
-          continue;
-        }
-        catalog[meta.id] = `problems/${category.name}/${problem.name}`;
-      } catch (err) {
-        console.warn(
-          `[discoverProblemsCatalog] ${metadataPath}: parse failed (${(err as Error).message}). ` +
-            `Run 'make validate-problems' to see schema errors.`,
-        );
-      }
-    }
-  }
-  return catalog;
 }
 
 const app = new cdk.App();

--- a/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
+++ b/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
@@ -56,27 +56,22 @@ export class DeployCodeBuildProject extends Construct {
         // aws CLI と jq は Amazon Linux 2023 image に標準で含まれる。
       },
       environmentVariables: {
-        // Step Functions が environmentVariablesOverride で実行時に上書きする変数。
-        // ここでは default value を設定して、ローカルテストや手動起動でも壊れないようにする。
+        // Step Functions が environmentVariablesOverride で実行時に毎回上書きする。
+        // CodeBuild 側で必須宣言するため placeholder default を入れる。
         BATTLE_PROBLEM_DIR: {
           type: BuildEnvironmentVariableType.PLAINTEXT,
-          value: "problems/challenges/hello-world",
+          value: "<unset-overridden-by-step-functions>",
         },
         TEAM_SLUG: {
           type: BuildEnvironmentVariableType.PLAINTEXT,
-          value: "demo-team",
+          value: "<unset-overridden-by-step-functions>",
         },
       },
       buildSpec: BuildSpec.fromObject({
         version: "0.2",
         phases: {
-          install: {
-            commands: ["echo 'TenkaCloud deploy CodeBuild — running deploy-battles.sh'"],
-          },
           build: {
             commands: [
-              // source.zip は cdk/ scripts/ apps/ ... 構造で展開される (`install.sh`)。
-              // problems/ は本 PR で install.sh が同梱するように変更する。
               'echo "BATTLE_PROBLEM_DIR=$BATTLE_PROBLEM_DIR  TEAM_SLUG=$TEAM_SLUG  AWS_REGION=$AWS_REGION"',
               'bash scripts/deploy-battles.sh "$BATTLE_PROBLEM_DIR"',
             ],

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -138,26 +138,38 @@ export interface DeploySharedResources {
 }
 
 export function buildSharedResources(): DeploySharedResources {
-  const catalogRaw = process.env.BATTLE_PROBLEMS_CATALOG ?? "{}";
-  let problemsCatalog: Record<string, string> = {};
-  try {
-    const parsed = JSON.parse(catalogRaw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      for (const [k, v] of Object.entries(parsed)) {
-        if (typeof v === "string") problemsCatalog[k] = v;
-      }
-    }
-  } catch {
-    problemsCatalog = {};
-  }
-
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
     eventBusName: getEnv("DEPLOY_EVENT_BUS_NAME"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     events: new EventBridgeClient({}),
-    problemsCatalog,
+    problemsCatalog: parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG),
   };
+}
+
+/**
+ * `BATTLE_PROBLEMS_CATALOG` env (JSON `{problemId: problemDir}`) を decode する。
+ * 不正な JSON / 不正な shape / 非 string value は drop し warn (operator が気づける)。
+ * Lambda cold start で 1 回だけ評価されるので overhead は無視できる。
+ */
+function parseProblemsCatalog(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      `[buildSharedResources] BATTLE_PROBLEMS_CATALOG parse failed (${(err as Error).message}). ` +
+        `tenant API will reject all problemId.`,
+    );
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const catalog: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === "string") catalog[k] = v;
+  }
+  return catalog;
 }
 
 export function buildContext(shared: DeploySharedResources, tenantId: string): DeployContext {

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -3,7 +3,6 @@ import { CfnOutput } from "aws-cdk-lib";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import type { IStateMachine } from "aws-cdk-lib/aws-stepfunctions";
 import type { Construct } from "constructs";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project";
@@ -62,13 +61,8 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
  * `deployApiLambda` を `LambdaIntegration` で invoke する形に組む。
  */
 export class ProblemDeployBackendStack extends cdk.Stack {
-  public readonly deploymentsTableName: string;
-  public readonly deploymentsTableArn: string;
   /** tenant API から `LambdaIntegration` で invoke される Lambda。 */
   public readonly deployApiLambda: IFunction;
-  public readonly deployCreateStateMachine: IStateMachine;
-  public readonly participantPortalUrl?: string;
-  public readonly participantPortalApiUrl?: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -96,7 +90,6 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     const stateMachine = new DeployCreateStateMachine(this, "DeployCreate", {
       codeBuildProject: codeBuild.project,
     });
-    this.deployCreateStateMachine = stateMachine.stateMachine;
 
     // EventBridge Rule: `DeployCreateRequested` event を State Machine に流す。
     new DeployEventRule(this, "DeployCreateRule", {
@@ -108,7 +101,6 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       const portalLambda = new ParticipantPortalLambda(this, "ParticipantPortalLambda", {
         deploymentsTable: deployments.table,
       });
-      this.participantPortalApiUrl = portalLambda.url.url;
       new CfnOutput(this, "ParticipantPortalApiUrl", {
         value: portalLambda.url.url,
         description: "Participant Portal Lambda Function URL (auth via teamLoginKey bearer).",
@@ -119,21 +111,16 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         props.participantPortal.runtimeConfig === "default-dev-mock"
           ? DEFAULT_DEV_MOCK_RUNTIME_CONFIG(this.region)
           : props.participantPortal.runtimeConfig;
-      const runtimeConfig: ParticipantPortalRuntimeConfig = {
+      portal.deployRuntimeConfig({
         ...baseConfig,
         apiBaseUrl: portalLambda.url.url,
         mode: "backend",
-      };
-      portal.deployRuntimeConfig(runtimeConfig);
-      this.participantPortalUrl = portal.distributionUrl;
+      });
       new CfnOutput(this, "ParticipantPortalUrl", {
         value: portal.distributionUrl,
         description: "Participant Portal CloudFront URL.",
       });
     }
-
-    this.deploymentsTableName = deployments.table.tableName;
-    this.deploymentsTableArn = deployments.table.tableArn;
 
     new CfnOutput(this, "DeploymentsTableName", {
       value: deployments.table.tableName,

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
+ * `{ [problemId]: "problems/<category>/<id>" }` の map を返す。frontend の Vite glob と
+ * 同じ正本 (filesystem) から問題カタログを引くためのヘルパー。
+ *
+ * - `problemsRoot` が存在しない / metadata.json が無い場合は空 map を返す (synth 時に
+ *   problems/ を埋める前に typecheck が走るケースの防御)
+ * - id は metadata.json の `id` field を採用 (ディレクトリ名と一致するのは規約だが、
+ *   一致しない場合は metadata 側を信用する)
+ *
+ * Phase 2 (ADR-003) で DDB ベースの問題カタログに置換されるまでの自動 discovery 経路。
+ */
+export function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
+  if (!fs.existsSync(problemsRoot)) {
+    console.warn(
+      `[discoverProblemsCatalog] ${problemsRoot} not found — assuming pre-install or wrong cwd. ` +
+        `Catalog will be empty; tenant API will reject all problemId.`,
+    );
+    return {};
+  }
+  const catalog: Record<string, string> = {};
+  for (const category of fs.readdirSync(problemsRoot, { withFileTypes: true })) {
+    if (!category.isDirectory()) continue;
+    const categoryDir = path.join(problemsRoot, category.name);
+    for (const problem of fs.readdirSync(categoryDir, { withFileTypes: true })) {
+      if (!problem.isDirectory()) continue;
+      const metadataPath = path.join(categoryDir, problem.name, "metadata.json");
+      if (!fs.existsSync(metadataPath)) continue;
+      try {
+        const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { id?: unknown };
+        if (typeof meta.id !== "string" || meta.id.length === 0) {
+          console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
+          continue;
+        }
+        catalog[meta.id] = `problems/${category.name}/${problem.name}`;
+      } catch (err) {
+        console.warn(
+          `[discoverProblemsCatalog] ${metadataPath}: parse failed (${(err as Error).message}). ` +
+            `Run 'make validate-problems' to see schema errors.`,
+        );
+      }
+    }
+  }
+  return catalog;
+}

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -1,0 +1,115 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { discoverProblemsCatalog } from "../lib/utils/discover-problems-catalog";
+
+/**
+ * discoverProblemsCatalog: `problems/<category>/<id>/metadata.json` を 2 階層 scan して
+ * `{ [problemId]: problemDir }` map を返す。CDK synth 時に bin/infrastructure.ts から呼ぶ。
+ *
+ * 設計意図:
+ *   - 不正な metadata は silent skip ではなく console.warn に出す (operator が気づける)
+ *   - problemsRoot 自体が無い場合も throw せず空 map を返す (synth 時に problems/ を埋める前
+ *     に typecheck が走るケースの防御)
+ *   - id は metadata.json の `id` field から (ディレクトリ名と乖離した場合 metadata 優先)
+ */
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = fs.mkdtempSync(path.join(os.tmpdir(), "discover-catalog-"));
+});
+
+afterEach(() => {
+  fs.rmSync(workspace, { recursive: true, force: true });
+});
+
+function writeProblem(category: string, dir: string, body: object): void {
+  const target = path.join(workspace, category, dir);
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, "metadata.json"), JSON.stringify(body));
+}
+
+describe("discoverProblemsCatalog", () => {
+  it("metadata.json を持つ全 problem を id → problemDir map で返すべき", () => {
+    writeProblem("challenges", "hello-world", { id: "hello-world" });
+    writeProblem("battles", "security-battle-royale", { id: "security-battle-royale" });
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({
+      "hello-world": "problems/challenges/hello-world",
+      "security-battle-royale": "problems/battles/security-battle-royale",
+    });
+  });
+
+  it("ディレクトリ名と異なる id を metadata 側で名乗っているときは metadata の id を採用すべき", () => {
+    writeProblem("challenges", "physical-dir-name", { id: "logical-id" });
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({ "logical-id": "problems/challenges/physical-dir-name" });
+  });
+
+  it("problemsRoot 自体が存在しないときは空 map を返し warn すべき", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const missing = path.join(workspace, "missing-root");
+
+    const catalog = discoverProblemsCatalog(missing);
+
+    expect(catalog).toEqual({});
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("not found");
+    warn.mockRestore();
+  });
+
+  it("metadata.json が無いディレクトリは silent skip するべき (warn しない)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fs.mkdirSync(path.join(workspace, "challenges", "no-metadata"), { recursive: true });
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({});
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("壊れた JSON を持つ metadata は warn して skip し他の problem は採集すべき", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fs.mkdirSync(path.join(workspace, "challenges", "broken"), { recursive: true });
+    fs.writeFileSync(path.join(workspace, "challenges", "broken", "metadata.json"), "{not-json");
+    writeProblem("challenges", "good", { id: "good" });
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({ good: "problems/challenges/good" });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("parse failed");
+    warn.mockRestore();
+  });
+
+  it("id field が無い / 空文字の metadata は warn して skip するべき", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeProblem("challenges", "no-id", { name: "no id field" });
+    writeProblem("challenges", "empty-id", { id: "" });
+    writeProblem("challenges", "good", { id: "good" });
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({ good: "problems/challenges/good" });
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0]?.[0]).toContain("missing or invalid 'id' field");
+    warn.mockRestore();
+  });
+
+  it("ファイル (= ディレクトリでない) が category 直下に紛れていても無視するべき", () => {
+    writeProblem("challenges", "hello-world", { id: "hello-world" });
+    fs.writeFileSync(path.join(workspace, "README.md"), "not a category");
+    fs.writeFileSync(path.join(workspace, "challenges", "stray.txt"), "not a problem dir");
+
+    const catalog = discoverProblemsCatalog(workspace);
+
+    expect(catalog).toEqual({ "hello-world": "problems/challenges/hello-world" });
+  });
+});


### PR DESCRIPTION
## この PR が解決すること

PR #460〜#465 の MVP-1 連続 PR で書き散らかした「dead code / 重複 / silent failure」を 1 PR で整理し、Phase 2 の cross-account federation (Issue #459) と problem catalog DDB (ADR-001 FR-5) の設計を ADR として確定する。

## 変更点

### Code refactor (commit 1)

- **`lib/utils/discover-problems-catalog.ts` 抽出 + 7 件の unit test 追加** — PR #465 で `bin/infrastructure.ts` 直書きだった helper を utils に外出し。bin が 299 → 254 行に縮む
- **`ProblemDeployBackendStack` の dead code 削除** — 外部参照ゼロの public field 5 件 (`deploymentsTableName` / `deploymentsTableArn` / `deployCreateStateMachine` / `participantPortalUrl` / `participantPortalApiUrl`) と未使用 import を撤去
- **`DeployCodeBuildProject` の no-op install phase 削除** — `echo` 1 行だけの phase は削る。`BATTLE_PROBLEM_DIR` / `TEAM_SLUG` の hard-coded default (`problems/challenges/hello-world` / `demo-team`) を `<unset-overridden-by-step-functions>` placeholder に変更 — 手動 build 時に意図せず hello-world が deploy される罠を排除
- **`deploy.ts:buildSharedResources` の silent JSON parse failure 解消** — PR #465 の `/simplify` で `discoverProblemsCatalog` 側に `console.warn` を入れたのと整合させる。Lambda log で operator が catalog 不整合に気づける

### Phase 2 ADRs (commit 2)

- **ADR-002 (cross-account federation)** — Issue #459 の A/B/C/D 設計判断を確定。tenant 単位 ExternalId (A2) + `CompetitorAccounts` DDB + SSM SecureString (B2+B3) + 5-step onboarding + DeployForm の Select 化
- **ADR-003 (problem catalog DDB)** — PR #465 の filesystem 自動 discovery を Phase 2 で「S3 + DDB + visibility filter」の本来形に置き換える設計。`problems/` は seed data として残し `make seed-problems` で初回流し込み

## なぜ今これが要るか

- MVP-1 (#460〜#465) を急ぎ書きで通したので、dead code / 重複 / silent failure が散らかっていた。本 PR でリファクタ
- Phase 2 着手前に 2 つの主要設計判断 (cross-account federation / problem catalog DDB) を ADR として固定し、実装段階で迷わないようにする

## 物理影響

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| ProblemDeployBackendStack | DeployCodeBuild Project (CFn) | UPDATE in-place | buildSpec の install phase 削除 + env default 変更。Step Functions override が常に上書きするため deploy 経路は不変 |
| (その他) | (なし) | NO-OP | CDK 構成不変、ADR 2 件は doc のみ |

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | `discoverProblemsCatalog` の挙動 | bin/infrastructure.ts CDK synth | ✅ 7 件の新規 unit test で固定 |
| 2 | `ProblemDeployBackendStack` の public field 利用側 | tenant-template-stack | ✅ `grep -rn` で `deployApiLambda` だけが外部参照、他 5 件は内部利用ゼロ |
| 3 | CodeBuild install phase 削除 | 実 CodeBuild 起動 | ✅ install phase は echo 1 行のみで挙動に影響なし |
| 4 | `BATTLE_PROBLEM_DIR` default 変更 | Step Functions / 手動 build | ✅ Step Functions が常に override、手動 build は新 placeholder で deploy-battles.sh が即 fail (誤 deploy 防止) |
| 5 | `BATTLE_PROBLEMS_CATALOG` parse failure | Lambda runtime | ✅ silent {} → warn + {} に変わるだけで戻り値は同じ |

## Verification

- [x] `make before-commit` exit 0 (lint / typecheck / test 283 件 / validate-problems)
- [x] 新規 7 unit test `discover-problems-catalog.test.ts` 全 pass
- [x] `grep -rn` で削除した public field 5 件が外部参照ゼロを確認
- [x] textlint / markdownlint clean (ADR 2 件含む 17 md ファイル)
- [x] PR #465 merge 後の deploy CodeBuild が動作確認済 (`tc-hello-world-test` 成功 log を観測)

## Rollback 手順

`git revert <merge-sha>` のみ。CFn 構成は in-place UPDATE のみで、buildSpec 変更が反映されるだけ。ADR 2 件は doc なので影響ゼロ。

## 既知の deferred (本 PR で解消しない)

別 PR で順次対応する課題:

- **deploy job が PENDING で固まる** (#159 task) — State Machine に DDB UpdateItem (success / failure) を追加する必要あり。MVP-1 で `StatusUpdaterLambda` を削除した後の穴
- **サイドバーから deploy job 一覧が見えない** (#160 task) — application-admin-console の `<SideNavigation>` に entry 追加 + 一覧画面実装
- **Problem CRUD UI** (= 本 PR 着手中の user feedback) — Application 管理者向けの問題 deploy / dedeploy / 一覧の画面が UI 上で完結しない。次 PR で対応
- **SBT pipeline (`CdkCodeBuildProject98C8CAB8`) failure** — 本 PR の deploy 経路 CodeBuild とは別の provisioning pipeline。別 issue で追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)