### PR TITLE
feat(scoring): scoring engine MVP — Challenge flag + Battle uptime + describeStacks

### DIFF
--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -2,21 +2,37 @@ import type { ApiClient } from "./client";
 
 export const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
+/**
+ * DDB の `stackOutputs` 文字列を `{key: value}` map に変換。次の 2 形式を許容する:
+ *   1. `{key: value}` (Lambda 由来)
+ *   2. `[{OutputKey, OutputValue}, ...]` (Step Functions describeStacks 由来)
+ *
+ * 壊れた JSON / 非 string value は無視 (best-effort 表示、ページを落とさない)。
+ */
 export function parseStackOutputs(json: string | undefined): Record<string, string> {
   if (!json) return {};
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(json);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const out: Record<string, string> = {};
-      for (const [k, v] of Object.entries(parsed)) {
-        if (typeof v === "string") out[k] = v;
-      }
-      return out;
-    }
+    parsed = JSON.parse(json);
   } catch {
-    // stackOutputs は best-effort 表示。壊れた JSON でページを落とさない。
+    return {};
   }
-  return {};
+  if (!parsed || typeof parsed !== "object") return {};
+  const out: Record<string, string> = {};
+  if (Array.isArray(parsed)) {
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object") {
+        const k = (entry as { OutputKey?: unknown }).OutputKey;
+        const v = (entry as { OutputValue?: unknown }).OutputValue;
+        if (typeof k === "string" && typeof v === "string") out[k] = v;
+      }
+    }
+    return out;
+  }
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
 }
 
 export type DeploymentStatus =

--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -7,6 +7,9 @@ export const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
  *   1. `{key: value}` (Lambda 由来)
  *   2. `[{OutputKey, OutputValue}, ...]` (Step Functions describeStacks 由来)
  *
+ * Backend (`infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts`) に同じ
+ * 関数の sister 実装あり。両者は意味的に同一にする (frontend / backend の DTO 共有)。
+ *
  * 壊れた JSON / 非 string value は無視 (best-effort 表示、ページを落とさない)。
  */
 export function parseStackOutputs(json: string | undefined): Record<string, string> {

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -12,6 +12,17 @@ export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
   "DELETED",
 ]);
 
+export interface ParticipantScoringInfo {
+  readonly kind: "flag" | "uptime";
+  /** flag 形式での 1 提出あたりの獲得点。 */
+  readonly points?: number;
+  /** uptime 形式での 1 回成功あたりの獲得点。 */
+  readonly pointsPerSuccess?: number;
+  readonly hints?: readonly string[];
+  /** flag 形式で既に正解済みなら true (= 再提出は加点されない)。 */
+  readonly flagSubmitted?: boolean;
+}
+
 export interface ParticipantView {
   readonly jobId: string;
   readonly problemId: string;
@@ -24,7 +35,17 @@ export interface ParticipantView {
   readonly stackOutputs: Record<string, string>;
   readonly failureReason?: string;
   readonly expiresAt: number;
+  /** チーム累計スコア (deploy 単位)。 */
+  readonly score: number;
+  readonly lastScoredAt?: string;
+  readonly lastResult?: "ok" | "fail";
+  readonly scoring?: ParticipantScoringInfo;
 }
+
+export type SubmitFlagOutcome =
+  | { kind: "ok"; scoreDelta: number; totalScore: number }
+  | { kind: "already_scored"; totalScore: number }
+  | { kind: "wrong" };
 
 export class PortalValidationError extends Error {
   constructor(public readonly errorCode: string) {
@@ -110,4 +131,37 @@ export async function updateTeamName(
     throw new PortalNetworkError(res.status, body);
   }
   return (await res.json()) as ParticipantView;
+}
+
+/**
+ * Flag を提出する。`POST /portal/me/submit-flag { flag }`.
+ *  - 200 { kind: "ok" | "already_scored" | "wrong" }: 提出受理 (採点結果は kind で分岐)
+ *  - 400 not_flag_problem / no_outputs / invalid_flag → `PortalValidationError`
+ *  - 401 bearer 失効 → `PortalAuthError`
+ */
+export async function submitFlag(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  flag: string,
+  signal?: AbortSignal,
+): Promise<SubmitFlagOutcome> {
+  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me/submit-flag"), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${teamLoginKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ flag }),
+    signal,
+  });
+  if (res.status === 400) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new PortalValidationError(body.error ?? "invalid_flag");
+  }
+  if (res.status === 401) throw new PortalAuthError();
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+  return (await res.json()) as SubmitFlagOutcome;
 }

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -37,6 +37,26 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   DELETED: "stopped",
 };
 
+const SCORING_KIND_LABEL = {
+  flag: "Challenge (flag 提出)",
+  uptime: "Battle (uptime 加点)",
+} as const;
+
+/** Polling 結果が前回と意味的に同じなら true → setView を skip し React 再 render を抑制。 */
+function viewIsUnchanged(prev: ParticipantView | null, next: ParticipantView): boolean {
+  if (!prev) return false;
+  return (
+    prev.status === next.status &&
+    prev.score === next.score &&
+    prev.lastScoredAt === next.lastScoredAt &&
+    prev.lastResult === next.lastResult &&
+    prev.scoring?.flagSubmitted === next.scoring?.flagSubmitted &&
+    prev.teamName === next.teamName &&
+    prev.failureReason === next.failureReason &&
+    JSON.stringify(prev.stackOutputs) === JSON.stringify(next.stackOutputs)
+  );
+}
+
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const teamName = auth.session?.teamName ?? "(unknown)";
@@ -51,9 +71,13 @@ export function HomePage({ config }: { config: AppConfig }) {
     if (!isBackend || !sessionToken) return;
     try {
       const next = await getPortalMe(config.apiBaseUrl, sessionToken);
-      setView(next);
+      setView((prev) => (viewIsUnchanged(prev, next) ? prev : next));
       setError(null);
-      if (TERMINAL_STATUSES.has(next.status)) stopPollingRef.current = true;
+      // uptime 採点は COMPLETE になっても polling を続けたい (= score が増え続ける)。
+      // Terminal 停止は FAILED / DELETED のみに限定。
+      if (next.status === "FAILED" || next.status === "DELETED") {
+        stopPollingRef.current = true;
+      }
     } catch (err) {
       if (err instanceof PortalAuthError) {
         auth.logout();
@@ -162,43 +186,24 @@ export function HomePage({ config }: { config: AppConfig }) {
 }
 
 function ScorePanel({ view }: { view: ParticipantView }) {
+  const kindLabel = view.scoring ? SCORING_KIND_LABEL[view.scoring.kind] : "(未設定)";
   return (
     <Container header={<Header variant="h2">スコア</Header>}>
-      <ColumnLayout columns={3} variant="text-grid">
-        <KeyValuePairs
-          items={[
-            {
-              label: "現在の累計",
-              value: (
-                <Box variant="awsui-value-large" color="text-status-success">
-                  {view.score} pt
-                </Box>
-              ),
-            },
-          ]}
-        />
-        <KeyValuePairs
-          items={[
-            {
-              label: "形式",
-              value:
-                view.scoring?.kind === "flag"
-                  ? "Challenge (flag 提出)"
-                  : view.scoring?.kind === "uptime"
-                    ? "Battle (uptime 加点)"
-                    : "(未設定)",
-            },
-          ]}
-        />
-        <KeyValuePairs
-          items={[
-            {
-              label: "最終チェック",
-              value: view.lastScoredAt ?? "(まだ未採点)",
-            },
-          ]}
-        />
-      </ColumnLayout>
+      <KeyValuePairs
+        columns={3}
+        items={[
+          {
+            label: "現在の累計",
+            value: (
+              <Box variant="awsui-value-large" color="text-status-success">
+                {view.score} pt
+              </Box>
+            ),
+          },
+          { label: "形式", value: kindLabel },
+          { label: "最終チェック", value: view.lastScoredAt ?? "(まだ未採点)" },
+        ]}
+      />
     </Container>
   );
 }

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -1,8 +1,12 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator, {
@@ -14,6 +18,9 @@ import {
   getPortalMe,
   type ParticipantView,
   PortalAuthError,
+  PortalValidationError,
+  type SubmitFlagOutcome,
+  submitFlag,
   TERMINAL_STATUSES,
 } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
@@ -49,7 +56,6 @@ export function HomePage({ config }: { config: AppConfig }) {
       if (TERMINAL_STATUSES.has(next.status)) stopPollingRef.current = true;
     } catch (err) {
       if (err instanceof PortalAuthError) {
-        // セッションが backend で無効化された (削除等)。logout して login へ戻す。
         auth.logout();
         return;
       }
@@ -78,6 +84,8 @@ export function HomePage({ config }: { config: AppConfig }) {
       <Header variant="h1" description={`${config.eventTitle} へようこそ`}>
         Welcome, {teamName}
       </Header>
+
+      {view && <ScorePanel view={view} />}
 
       <Container header={<Header variant="h2">問題のデプロイ状況</Header>}>
         <SpaceBetween size="m">
@@ -139,13 +147,172 @@ export function HomePage({ config }: { config: AppConfig }) {
         </SpaceBetween>
       </Container>
 
-      <Container header={<Header variant="h2">これからやること</Header>}>
-        <Box variant="p">
-          上のステータスが <strong>COMPLETE</strong> になると、CloudFormation Outputs に 表示される
-          URL から問題に取り組めます。スコア状況は <strong>Scoreboard</strong>
-          、得点履歴は <strong>Score events</strong> から確認してください。
-        </Box>
-      </Container>
+      {view?.scoring?.kind === "flag" && view.status === "COMPLETE" && (
+        <FlagSubmissionPanel
+          apiBaseUrl={config.apiBaseUrl}
+          sessionToken={sessionToken ?? ""}
+          flagSubmitted={view.scoring.flagSubmitted ?? false}
+          points={view.scoring.points ?? 0}
+          hints={view.scoring.hints ?? []}
+          onScored={tick}
+        />
+      )}
     </SpaceBetween>
+  );
+}
+
+function ScorePanel({ view }: { view: ParticipantView }) {
+  return (
+    <Container header={<Header variant="h2">スコア</Header>}>
+      <ColumnLayout columns={3} variant="text-grid">
+        <KeyValuePairs
+          items={[
+            {
+              label: "現在の累計",
+              value: (
+                <Box variant="awsui-value-large" color="text-status-success">
+                  {view.score} pt
+                </Box>
+              ),
+            },
+          ]}
+        />
+        <KeyValuePairs
+          items={[
+            {
+              label: "形式",
+              value:
+                view.scoring?.kind === "flag"
+                  ? "Challenge (flag 提出)"
+                  : view.scoring?.kind === "uptime"
+                    ? "Battle (uptime 加点)"
+                    : "(未設定)",
+            },
+          ]}
+        />
+        <KeyValuePairs
+          items={[
+            {
+              label: "最終チェック",
+              value: view.lastScoredAt ?? "(まだ未採点)",
+            },
+          ]}
+        />
+      </ColumnLayout>
+    </Container>
+  );
+}
+
+function FlagSubmissionPanel({
+  apiBaseUrl,
+  sessionToken,
+  flagSubmitted,
+  points,
+  hints,
+  onScored,
+}: {
+  apiBaseUrl: string;
+  sessionToken: string;
+  flagSubmitted: boolean;
+  points: number;
+  hints: readonly string[];
+  onScored: () => Promise<void>;
+}) {
+  const [flag, setFlag] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  if (flagSubmitted) {
+    return (
+      <Container header={<Header variant="h2">Flag 提出</Header>}>
+        <Alert type="success" header="提出済み">
+          このチームは既に正解を提出済みです (+{points} pt)。
+        </Alert>
+      </Container>
+    );
+  }
+
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+    if (!flag.trim() || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    setOutcome(null);
+    try {
+      const result = await submitFlag(apiBaseUrl, sessionToken, flag);
+      setOutcome(result);
+      if (result.kind === "ok" || result.kind === "already_scored") {
+        await onScored();
+      }
+    } catch (err) {
+      if (err instanceof PortalValidationError) {
+        setSubmitError(`バリデーションエラー: ${err.errorCode}`);
+      } else {
+        setSubmitError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={`正解を入力すると +${points} pt 獲得します。`}>
+          Flag 提出
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {hints.length > 0 && (
+          <Alert type="info" header="ヒント">
+            <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
+              {hints.map((h) => (
+                <li key={h}>{h}</li>
+              ))}
+            </ul>
+          </Alert>
+        )}
+        <form onSubmit={handleSubmit}>
+          <Form
+            actions={
+              <Button variant="primary" loading={submitting} formAction="submit">
+                提出
+              </Button>
+            }
+          >
+            <FormField label="Flag (Stack Output 値)">
+              <Input
+                value={flag}
+                onChange={(e) => setFlag(e.detail.value)}
+                placeholder="例: Hello from tc-hello-world-..."
+                disabled={submitting}
+              />
+            </FormField>
+          </Form>
+        </form>
+        {outcome?.kind === "ok" && (
+          <Alert type="success" header={`正解 (+${outcome.scoreDelta} pt)`}>
+            合計スコア: {outcome.totalScore} pt
+          </Alert>
+        )}
+        {outcome?.kind === "wrong" && (
+          <Alert type="warning" header="不正解">
+            値を確認して再度提出してください。
+          </Alert>
+        )}
+        {outcome?.kind === "already_scored" && (
+          <Alert type="info" header="提出済み">
+            既に正解済みです (合計 {outcome.totalScore} pt)。
+          </Alert>
+        )}
+        {submitError && (
+          <Alert type="error" header="提出に失敗しました">
+            {submitError}
+          </Alert>
+        )}
+      </SpaceBetween>
+    </Container>
   );
 }

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -15,7 +15,10 @@ import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
 import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stack";
 import { loadConfig } from "../lib/utils/config-loader";
-import { discoverProblemsCatalog } from "../lib/utils/discover-problems-catalog";
+import {
+  discoverProblemsCatalog,
+  discoverProblemsScoring,
+} from "../lib/utils/discover-problems-catalog";
 
 // TenkaCloud の env 読み込み。`infrastructure/environments/<env>/.env` がある場合だけ load。
 // ref の bin は CDK_PARAM_* を全部 process.env から直読みするので、ここで先に注入しておく。
@@ -160,7 +163,9 @@ const participantPortal = enableParticipantPortal
 // 本ファイルを書き換える必要はない (frontend `data/problems.ts` も同 metadata を Vite glob
 // で読むので、3 重管理を避ける)。
 // Phase 2 (ADR-003) で DDB ベース問題管理に置換するまでの自動 discovery 経路。
-const problemsCatalog = discoverProblemsCatalog(path.resolve(__dirname, "..", "..", "problems"));
+const problemsRoot = path.resolve(__dirname, "..", "..", "problems");
+const problemsCatalog = discoverProblemsCatalog(problemsRoot);
+const problemsScoring = discoverProblemsScoring(problemsRoot);
 
 const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
   ...stackEnv,
@@ -168,6 +173,7 @@ const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDep
   sourceBucketName: s3SourceBucket,
   sourceObjectKey: sourceZip,
   problemsCatalog,
+  problemsScoring,
   participantPortal,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(

--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -1,4 +1,4 @@
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import type { Project } from "aws-cdk-lib/aws-codebuild";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
@@ -10,6 +10,7 @@ import {
   StateMachine,
 } from "aws-cdk-lib/aws-stepfunctions";
 import {
+  CallAwsService,
   CodeBuildStartBuild,
   DynamoAttributeValue,
   DynamoUpdateItem,
@@ -63,17 +64,40 @@ export class DeployCreateStateMachine extends Construct {
         BATTLE_PROBLEM_DIR: { value: JsonPath.stringAt("$.detail.problemDir") },
         TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
       },
-      // 後続 task が `$.detail` を参照できるよう、CodeBuild 結果を sub-path に格納。
       resultPath: "$.codebuild",
+    });
+
+    // CodeBuild 完了後に CFn から Outputs と StackId を取得。Outputs は
+    // `[{OutputKey, OutputValue, ...}]` の配列形で返るので、stackOutputs に JSON
+    // 文字列として格納し、portal 側 (cfn-status.ts) が array / object 両方を解釈する。
+    const describeStacks = new CallAwsService(this, "DescribeStack", {
+      service: "cloudformation",
+      action: "describeStacks",
+      parameters: { StackName: JsonPath.stringAt("$.detail.namePrefix") },
+      iamResources: [
+        Stack.of(this).formatArn({
+          service: "cloudformation",
+          resource: "stack",
+          resourceName: "*",
+        }),
+      ],
+      iamAction: "cloudformation:DescribeStacks",
+      resultPath: "$.cfn",
     });
 
     const markSucceeded = this.buildMarkSucceeded(props.deploymentsTable);
     const markFailed = this.buildMarkFailed(props.deploymentsTable);
 
+    // CodeBuild 失敗 / DescribeStacks 失敗、いずれも MarkFailed (= status=FAILED) に倒す。
+    // DescribeStacks は基本失敗しないが、稀な throttle / 競技者 account 側の Roles で
+    // 落ちうる。その場合 stackOutputs 不在のまま FAILED にして operator が再試行する。
     startCodeBuild.addCatch(markFailed, { resultPath: "$.error" });
+    describeStacks.addCatch(markFailed, { resultPath: "$.error" });
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
-      definitionBody: DefinitionBody.fromChainable(startCodeBuild.next(markSucceeded)),
+      definitionBody: DefinitionBody.fromChainable(
+        startCodeBuild.next(describeStacks).next(markSucceeded),
+      ),
       timeout: Duration.minutes(60),
       logs: { destination: logGroup, level: LogLevel.ALL },
       tracingEnabled: true,
@@ -87,11 +111,18 @@ export class DeployCreateStateMachine extends Construct {
     return new DynamoUpdateItem(this, "MarkSucceeded", {
       table,
       key: deploymentKey(),
-      updateExpression: "SET #status = :status, updatedAt = :updatedAt",
+      updateExpression:
+        "SET #status = :status, updatedAt = :updatedAt, stackId = :stackId, stackOutputs = :stackOutputs",
       expressionAttributeNames: { "#status": "status" },
       expressionAttributeValues: {
         ":status": DynamoAttributeValue.fromString("COMPLETE"),
         ":updatedAt": stateEnteredTime(),
+        ":stackId": DynamoAttributeValue.fromString(JsonPath.stringAt("$.cfn.Stacks[0].StackId")),
+        // CFn `Outputs: [{OutputKey, OutputValue, ...}]` の配列を JSON 文字列で格納。
+        // 読み出し側 (cfn-status.ts:parseStackOutputs) は array / object どちらも解釈する。
+        ":stackOutputs": DynamoAttributeValue.fromString(
+          JsonPath.jsonToString(JsonPath.objectAt("$.cfn.Stacks[0].Outputs")),
+        ),
       },
     });
   }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -86,6 +86,17 @@ export interface DeploymentItem {
   /** Reserved for bulk deploy. */
   accountGroupId?: string;
   problemSetId?: string;
+
+  /** Scoring engine が加算したチームの累計ポイント。0 default。 */
+  score?: number;
+  /** 最後に scoring が走った時刻 (ISO 8601)。 */
+  lastScoredAt?: string;
+  /** Battle (uptime) で最後の health check が成功したか。 */
+  lastResult?: "ok" | "fail";
+  /**
+   * Challenge (flag) で 1 度でも正解 submit されたら true。再提出での重複加算を防ぐ。
+   */
+  flagSubmitted?: boolean;
 }
 
 export const DeployResponseSchema = z.object({

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -1,59 +1,27 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 
 /**
  * EventBridge Scheduler `rate(1 minute)` で起動される Lambda。
  *
- * 各 status=COMPLETE な deployment について、metadata の `scoring` が `uptime` 形式
- * なら declared endpoints を probe し、すべて 2xx (or expectStatus) ならスコア加点。
- * 失敗時は score 加点せず lastResult=fail のみ更新する。
+ * 各 status=COMPLETE な deployment について metadata の `scoring.kind=uptime` の
+ * declared endpoints を probe し、すべて 2xx (or expectStatus) ならスコア加点、
+ * 失敗時は `lastResult=fail` のみ更新する。
  *
- * MVP-1 は scan + filter (= 1 RCU 内に収まる規模)。Phase 2 で 100+ deployments に
- * なったら GSI3 (PK=STATUS#COMPLETE) を追加して query 化する。
+ * MVP-1 規模 (= ~50 deployments) は Scan + FilterExpression で十分。
  */
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-// 遅延 lookup: module load 時に env が無い (= test 環境) でも import がコケない。
-// Lambda runtime では handler 呼び出し時に env は確実にあるので問題なし。
-function getTableName(): string {
-  return getEnv("DEPLOYMENTS_TABLE_NAME");
-}
-
-interface UptimeScoringConfig {
-  kind: "uptime";
-  endpoints: { outputKey: string; path: string; expectStatus: number[] }[];
-  pointsPerSuccess: number;
-}
-
-function parseScoringMap(): Record<string, unknown> {
-  const raw = process.env.BATTLE_PROBLEMS_SCORING ?? "";
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    /* ignore */
-  }
-  return {};
-}
-
-function asUptimeScoring(value: unknown): UptimeScoringConfig | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const v = value as { kind?: unknown };
-  if (v.kind !== "uptime") return undefined;
-  const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
-  if (!Array.isArray(u.endpoints) || typeof u.pointsPerSuccess !== "number") return undefined;
-  return value as UptimeScoringConfig;
-}
+// 遅延 lookup: module load 時に env が無くても import がコケない (test 互換)。
+const tableName = (): string => getEnv("DEPLOYMENTS_TABLE_NAME");
 
 const PROBE_TIMEOUT_MS = 8_000;
 
-async function probe(url: string, expectStatus: number[]): Promise<boolean> {
+async function probe(url: string, expectStatus: readonly number[]): Promise<boolean> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
   try {
@@ -66,70 +34,66 @@ async function probe(url: string, expectStatus: number[]): Promise<boolean> {
   }
 }
 
-function joinUrl(base: string, path: string): string {
-  if (!path) return base;
-  if (path.startsWith("http://") || path.startsWith("https://")) return path;
-  if (base.endsWith("/") && path.startsWith("/")) return base + path.slice(1);
-  if (!base.endsWith("/") && !path.startsWith("/")) return `${base}/${path}`;
-  return base + path;
-}
-
-async function checkOne(
-  item: Partial<DeploymentItem>,
-  scoring: UptimeScoringConfig,
-): Promise<void> {
-  if (!item.PK) return;
-  const outputs = parseStackOutputs(item.stackOutputs);
-  const probes = scoring.endpoints
-    .map((e) => {
-      const base = outputs[e.outputKey];
-      if (!base) return undefined;
-      return probe(joinUrl(base, e.path), e.expectStatus);
-    })
-    .filter((p): p is Promise<boolean> => p !== undefined);
-
-  if (probes.length === 0) return;
-
-  const results = await Promise.all(probes);
-  const allOk = results.every((ok) => ok);
-  const now = new Date().toISOString();
-
-  if (allOk) {
-    await ddb.send(
-      new UpdateCommand({
-        TableName: getTableName(),
-        Key: { PK: item.PK, SK: "META" },
-        UpdateExpression:
-          "ADD score :pts SET lastScoredAt = :now, lastResult = :ok, updatedAt = :now",
-        ExpressionAttributeValues: {
-          ":pts": scoring.pointsPerSuccess,
-          ":now": now,
-          ":ok": "ok",
-        },
-      }),
-    );
-  } else {
-    await ddb.send(
-      new UpdateCommand({
-        TableName: getTableName(),
-        Key: { PK: item.PK, SK: "META" },
-        UpdateExpression: "SET lastScoredAt = :now, lastResult = :fail, updatedAt = :now",
-        ExpressionAttributeValues: { ":now": now, ":fail": "fail" },
-      }),
-    );
+/** `new URL(path, base)` で base + relative path を合成する。 */
+function joinUrl(base: string, relPath: string): string {
+  if (!relPath) return base;
+  try {
+    return new URL(relPath).toString();
+  } catch {
+    return new URL(relPath, base.endsWith("/") ? base : `${base}/`).toString();
   }
 }
 
-export async function handler(): Promise<void> {
-  const scoringMap = parseScoringMap();
+type UptimeScoring = Extract<ProblemScoringMetadata, { kind: "uptime" }>;
 
-  // MVP-1 規模 (= ~50 deployments) は Scan + FilterExpression で十分。Phase 2 で
-  // 100+ になったら GSI3 (PK=STATUS#{status}) を追加して Query 化する。
+async function checkOne(item: Partial<DeploymentItem>, scoring: UptimeScoring): Promise<void> {
+  if (!item.PK) return;
+  const outputs = parseStackOutputs(item.stackOutputs);
+  const probes: Promise<boolean>[] = [];
+  for (const e of scoring.endpoints) {
+    const base = outputs[e.outputKey];
+    if (!base) continue;
+    probes.push(probe(joinUrl(base, e.path), e.expectStatus));
+  }
+  if (probes.length === 0) return;
+
+  const allOk = (await Promise.all(probes)).every((ok) => ok);
+  const now = new Date().toISOString();
+  await ddb.send(buildHealthUpdate(item.PK, allOk, scoring.pointsPerSuccess, now));
+}
+
+/** 成功 / 失敗で UpdateCommand の expression が分岐するが、Key と timestamp は共通。 */
+function buildHealthUpdate(
+  pk: string,
+  allOk: boolean,
+  pointsPerSuccess: number,
+  now: string,
+): UpdateCommand {
+  if (allOk) {
+    return new UpdateCommand({
+      TableName: tableName(),
+      Key: { PK: pk, SK: "META" },
+      UpdateExpression:
+        "ADD score :pts SET lastScoredAt = :now, lastResult = :ok, updatedAt = :now",
+      ExpressionAttributeValues: { ":pts": pointsPerSuccess, ":now": now, ":ok": "ok" },
+    });
+  }
+  return new UpdateCommand({
+    TableName: tableName(),
+    Key: { PK: pk, SK: "META" },
+    UpdateExpression: "SET lastScoredAt = :now, lastResult = :fail, updatedAt = :now",
+    ExpressionAttributeValues: { ":now": now, ":fail": "fail" },
+  });
+}
+
+export async function handler(): Promise<void> {
+  const scoringMap = parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING);
+
   let exclusiveStartKey: Record<string, unknown> | undefined;
   do {
     const out = await ddb.send(
       new ScanCommand({
-        TableName: getTableName(),
+        TableName: tableName(),
         FilterExpression: "#status = :complete",
         ExpressionAttributeNames: { "#status": "status" },
         ExpressionAttributeValues: { ":complete": "COMPLETE" },
@@ -138,19 +102,25 @@ export async function handler(): Promise<void> {
       }),
     );
     const items = (out.Items ?? []) as Partial<DeploymentItem>[];
-    for (const item of items) {
-      const scoring = item.problemId ? asUptimeScoring(scoringMap[item.problemId]) : undefined;
-      if (!scoring) continue;
-      try {
-        await checkOne(item, scoring);
-      } catch (err) {
-        console.warn(`[health-check] failed for jobId=${item.jobId}`, {
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+
+    // 全 deployment を **並列** に check する。Lambda timeout 2 min 内に収まるよう、
+    // sequential だと N × PROBE_TIMEOUT_MS で容易に超過する。1 deployment 失敗が
+    // 他に波及しないよう catch して log に残す。
+    await Promise.all(
+      items.map(async (item) => {
+        const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
+        if (scoring?.kind !== "uptime") return;
+        try {
+          await checkOne(item, scoring);
+        } catch (err) {
+          console.warn(`[health-check] failed for jobId=${item.jobId}`, {
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
     exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
 }
 
-export { asUptimeScoring, joinUrl, parseScoringMap };
+export { joinUrl };

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -1,0 +1,156 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { parseStackOutputs } from "../shared/cfn-status.js";
+
+/**
+ * EventBridge Scheduler `rate(1 minute)` で起動される Lambda。
+ *
+ * 各 status=COMPLETE な deployment について、metadata の `scoring` が `uptime` 形式
+ * なら declared endpoints を probe し、すべて 2xx (or expectStatus) ならスコア加点。
+ * 失敗時は score 加点せず lastResult=fail のみ更新する。
+ *
+ * MVP-1 は scan + filter (= 1 RCU 内に収まる規模)。Phase 2 で 100+ deployments に
+ * なったら GSI3 (PK=STATUS#COMPLETE) を追加して query 化する。
+ */
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+// 遅延 lookup: module load 時に env が無い (= test 環境) でも import がコケない。
+// Lambda runtime では handler 呼び出し時に env は確実にあるので問題なし。
+function getTableName(): string {
+  return getEnv("DEPLOYMENTS_TABLE_NAME");
+}
+
+interface UptimeScoringConfig {
+  kind: "uptime";
+  endpoints: { outputKey: string; path: string; expectStatus: number[] }[];
+  pointsPerSuccess: number;
+}
+
+function parseScoringMap(): Record<string, unknown> {
+  const raw = process.env.BATTLE_PROBLEMS_SCORING ?? "";
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+function asUptimeScoring(value: unknown): UptimeScoringConfig | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as { kind?: unknown };
+  if (v.kind !== "uptime") return undefined;
+  const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
+  if (!Array.isArray(u.endpoints) || typeof u.pointsPerSuccess !== "number") return undefined;
+  return value as UptimeScoringConfig;
+}
+
+const PROBE_TIMEOUT_MS = 8_000;
+
+async function probe(url: string, expectStatus: number[]): Promise<boolean> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { method: "GET", signal: ctrl.signal });
+    return expectStatus.includes(res.status);
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function joinUrl(base: string, path: string): string {
+  if (!path) return base;
+  if (path.startsWith("http://") || path.startsWith("https://")) return path;
+  if (base.endsWith("/") && path.startsWith("/")) return base + path.slice(1);
+  if (!base.endsWith("/") && !path.startsWith("/")) return `${base}/${path}`;
+  return base + path;
+}
+
+async function checkOne(
+  item: Partial<DeploymentItem>,
+  scoring: UptimeScoringConfig,
+): Promise<void> {
+  if (!item.PK) return;
+  const outputs = parseStackOutputs(item.stackOutputs);
+  const probes = scoring.endpoints
+    .map((e) => {
+      const base = outputs[e.outputKey];
+      if (!base) return undefined;
+      return probe(joinUrl(base, e.path), e.expectStatus);
+    })
+    .filter((p): p is Promise<boolean> => p !== undefined);
+
+  if (probes.length === 0) return;
+
+  const results = await Promise.all(probes);
+  const allOk = results.every((ok) => ok);
+  const now = new Date().toISOString();
+
+  if (allOk) {
+    await ddb.send(
+      new UpdateCommand({
+        TableName: getTableName(),
+        Key: { PK: item.PK, SK: "META" },
+        UpdateExpression:
+          "ADD score :pts SET lastScoredAt = :now, lastResult = :ok, updatedAt = :now",
+        ExpressionAttributeValues: {
+          ":pts": scoring.pointsPerSuccess,
+          ":now": now,
+          ":ok": "ok",
+        },
+      }),
+    );
+  } else {
+    await ddb.send(
+      new UpdateCommand({
+        TableName: getTableName(),
+        Key: { PK: item.PK, SK: "META" },
+        UpdateExpression: "SET lastScoredAt = :now, lastResult = :fail, updatedAt = :now",
+        ExpressionAttributeValues: { ":now": now, ":fail": "fail" },
+      }),
+    );
+  }
+}
+
+export async function handler(): Promise<void> {
+  const scoringMap = parseScoringMap();
+
+  // MVP-1 規模 (= ~50 deployments) は Scan + FilterExpression で十分。Phase 2 で
+  // 100+ になったら GSI3 (PK=STATUS#{status}) を追加して Query 化する。
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: getTableName(),
+        FilterExpression: "#status = :complete",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":complete": "COMPLETE" },
+        Limit: 200,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+    for (const item of items) {
+      const scoring = item.problemId ? asUptimeScoring(scoringMap[item.problemId]) : undefined;
+      if (!scoring) continue;
+      try {
+        await checkOne(item, scoring);
+      } catch (err) {
+        console.warn(`[health-check] failed for jobId=${item.jobId}`, {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+}
+
+export { asUptimeScoring, joinUrl, parseScoringMap };

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -10,17 +10,18 @@ import {
 import { extractBearerToken } from "./auth.js";
 import { lookupByTeamLoginKey } from "./lookup.js";
 import { buildParticipantSharedResources } from "./shared.js";
+import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
 
 /**
  * Participant Portal backend Lambda の Hono app。routes:
  *   GET   /portal/healthz
- *   GET   /portal/me     — Authorization: Bearer <teamLoginKey>
- *   PATCH /portal/me     — body: { teamName: string }
+ *   GET   /portal/me                — Authorization: Bearer <teamLoginKey>
+ *   PATCH /portal/me                — body: { teamName: string }
+ *   POST  /portal/me/submit-flag    — body: { flag: string }
  *
  * Function URL は `AuthType=NONE` で公開し、`teamLoginKey` 自体を bearer として
- * Lambda 内で検証する (Cognito を介さない)。teamLoginKey は POST /problems/:id/deploy
- * のレスポンスで 1 度だけ露出する 24 文字 base64url の短命キー。
+ * Lambda 内で検証する。
  */
 const shared = buildParticipantSharedResources();
 const app = new Hono();
@@ -63,6 +64,35 @@ app.patch("/portal/me", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[portal] update failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.post("/portal/me/submit-flag", async (c) => {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
+  }
+  const flag = (body as { flag?: unknown })?.flag;
+  if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
+    return c.json({ error: "invalid_flag" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await submitFlag(shared, shared.problemsScoring, token, flag);
+    if (outcome.kind === "unauthorized")
+      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+    if (outcome.kind === "not_flag_problem") {
+      return c.json({ error: "not_flag_problem" }, HTTP_BAD_REQUEST);
+    }
+    if (outcome.kind === "no_outputs") return c.json({ error: "no_outputs" }, HTTP_BAD_REQUEST);
+    return c.json(outcome, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[portal] submitFlag failed", { message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -1,4 +1,5 @@
 import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import type { ParticipantSharedResources } from "./shared.js";
@@ -37,43 +38,6 @@ export type ParticipantView = Pick<
 
 const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
-interface FlagScoringConfig {
-  kind: "flag";
-  flagOutputKey: string;
-  points: number;
-  hints?: string[];
-}
-interface UptimeScoringConfig {
-  kind: "uptime";
-  pointsPerSuccess: number;
-}
-type AnyScoringConfig = FlagScoringConfig | UptimeScoringConfig | undefined;
-
-function asScoringConfig(value: unknown): AnyScoringConfig {
-  if (!value || typeof value !== "object") return undefined;
-  const v = value as { kind?: unknown };
-  if (v.kind === "flag") {
-    const f = value as { flagOutputKey?: unknown; points?: unknown; hints?: unknown };
-    if (typeof f.flagOutputKey === "string" && typeof f.points === "number") {
-      return {
-        kind: "flag",
-        flagOutputKey: f.flagOutputKey,
-        points: f.points,
-        hints: Array.isArray(f.hints)
-          ? (f.hints.filter((h) => typeof h === "string") as string[])
-          : undefined,
-      };
-    }
-  }
-  if (v.kind === "uptime") {
-    const u = value as { pointsPerSuccess?: unknown };
-    if (typeof u.pointsPerSuccess === "number") {
-      return { kind: "uptime", pointsPerSuccess: u.pointsPerSuccess };
-    }
-  }
-  return undefined;
-}
-
 /**
  * DDB の生 row → `ParticipantView` 変換。`lookupByTeamLoginKey` と
  * `setDisplayTeamName` (UpdateCommand `ReturnValues=ALL_NEW`) の両方から呼ばれる。
@@ -87,7 +51,7 @@ function asScoringConfig(value: unknown): AnyScoringConfig {
  */
 export function toView(
   item: Partial<DeploymentItem>,
-  scoringMap: Record<string, unknown> = {},
+  scoringMap: Record<string, ProblemScoringMetadata> = {},
 ): ParticipantView | undefined {
   const status = (item.status ?? "PENDING") as DeploymentStatus;
   if (DELETED_LIKE_STATUSES.has(status)) return undefined;
@@ -95,7 +59,7 @@ export function toView(
   const display = typeof item.displayTeamName === "string" ? item.displayTeamName : undefined;
 
   const stackOutputs = parseStackOutputs(item.stackOutputs);
-  const scoring = item.problemId ? asScoringConfig(scoringMap[item.problemId]) : undefined;
+  const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
   if (scoring?.kind === "flag") {
     delete stackOutputs[scoring.flagOutputKey];
   }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -8,12 +8,18 @@ import type { ParticipantSharedResources } from "./shared.js";
  * で派生させることで、`DeploymentItem` に新規フィールドが増えたときに「明示的に
  * include する / 除外する」判断を強制する (operator 内部情報の意図せぬ漏洩を防ぐ)。
  *
- * `teamName` は `displayTeamName ?? <operator slug>` で resolve した最終表示名。
- * `teamNameSetByCompetitor` は競技者が自分で名前を決めたかの flag (UI が「初回
- * セットアップ画面」を出すかの判断に使う)。
- *
  * stackOutputs は DDB に JSON 文字列で入っているが、UI に返す前に object へ展開する。
+ * `flagOutputKey` で指定された field は **競技者に出さない** (= 当てる対象なので)。
  */
+export interface ParticipantScoringInfo {
+  readonly kind: "flag" | "uptime";
+  readonly points?: number;
+  readonly pointsPerSuccess?: number;
+  readonly hints?: readonly string[];
+  /** Challenge / flag のとき、提出済みなら true。再提出は加点されない。 */
+  readonly flagSubmitted?: boolean;
+}
+
 export type ParticipantView = Pick<
   DeploymentItem,
   "jobId" | "problemId" | "region" | "expiresAt"
@@ -23,9 +29,50 @@ export type ParticipantView = Pick<
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
   readonly failureReason?: string;
+  readonly score: number;
+  readonly lastScoredAt?: string;
+  readonly lastResult?: "ok" | "fail";
+  readonly scoring?: ParticipantScoringInfo;
 };
 
 const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
+
+interface FlagScoringConfig {
+  kind: "flag";
+  flagOutputKey: string;
+  points: number;
+  hints?: string[];
+}
+interface UptimeScoringConfig {
+  kind: "uptime";
+  pointsPerSuccess: number;
+}
+type AnyScoringConfig = FlagScoringConfig | UptimeScoringConfig | undefined;
+
+function asScoringConfig(value: unknown): AnyScoringConfig {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as { kind?: unknown };
+  if (v.kind === "flag") {
+    const f = value as { flagOutputKey?: unknown; points?: unknown; hints?: unknown };
+    if (typeof f.flagOutputKey === "string" && typeof f.points === "number") {
+      return {
+        kind: "flag",
+        flagOutputKey: f.flagOutputKey,
+        points: f.points,
+        hints: Array.isArray(f.hints)
+          ? (f.hints.filter((h) => typeof h === "string") as string[])
+          : undefined,
+      };
+    }
+  }
+  if (v.kind === "uptime") {
+    const u = value as { pointsPerSuccess?: unknown };
+    if (typeof u.pointsPerSuccess === "number") {
+      return { kind: "uptime", pointsPerSuccess: u.pointsPerSuccess };
+    }
+  }
+  return undefined;
+}
 
 /**
  * DDB の生 row → `ParticipantView` 変換。`lookupByTeamLoginKey` と
@@ -33,12 +80,26 @@ const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING"
  *
  * status が DELETING / DELETED の場合は `undefined` を返す。これは sparse 化が
  * 崩れた行 (GSI2PK が残ったまま teardown が進んだケース) への防御。
+ *
+ * `scoringMap` から該当 problemId の scoring 設定を引き、participant 側に出してよい
+ * 情報だけ (= flagOutputKey の値は出さない、kind / points / hints のみ) を含める。
+ * stackOutputs からも flagOutputKey フィールドは strip し、答えが見えないようにする。
  */
-export function toView(item: Partial<DeploymentItem>): ParticipantView | undefined {
+export function toView(
+  item: Partial<DeploymentItem>,
+  scoringMap: Record<string, unknown> = {},
+): ParticipantView | undefined {
   const status = (item.status ?? "PENDING") as DeploymentStatus;
   if (DELETED_LIKE_STATUSES.has(status)) return undefined;
   const operatorTeamSlug = String(item.teamName ?? "");
   const display = typeof item.displayTeamName === "string" ? item.displayTeamName : undefined;
+
+  const stackOutputs = parseStackOutputs(item.stackOutputs);
+  const scoring = item.problemId ? asScoringConfig(scoringMap[item.problemId]) : undefined;
+  if (scoring?.kind === "flag") {
+    delete stackOutputs[scoring.flagOutputKey];
+  }
+
   return {
     jobId: String(item.jobId ?? ""),
     problemId: String(item.problemId ?? ""),
@@ -46,9 +107,24 @@ export function toView(item: Partial<DeploymentItem>): ParticipantView | undefin
     teamNameSetByCompetitor: display !== undefined,
     region: String(item.region ?? ""),
     status,
-    stackOutputs: parseStackOutputs(item.stackOutputs),
+    stackOutputs,
     failureReason: status === "FAILED" ? item.failureReason : undefined,
     expiresAt: Number(item.expiresAt ?? 0),
+    score: Number(item.score ?? 0),
+    lastScoredAt: typeof item.lastScoredAt === "string" ? item.lastScoredAt : undefined,
+    lastResult: item.lastResult,
+    scoring: scoring
+      ? {
+          kind: scoring.kind,
+          ...(scoring.kind === "flag"
+            ? {
+                points: scoring.points,
+                hints: scoring.hints,
+                flagSubmitted: item.flagSubmitted === true,
+              }
+            : { pointsPerSuccess: scoring.pointsPerSuccess }),
+        }
+      : undefined,
   };
 }
 
@@ -77,5 +153,5 @@ export async function lookupByTeamLoginKey(
   );
   const item = (out.Items?.[0] ?? undefined) as Partial<DeploymentItem> | undefined;
   if (!item) return undefined;
-  return toView(item);
+  return toView(item, shared.problemsScoring);
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import { parseProblemsScoring } from "./submit-flag.js";
 
 /**
  * Participant Lambda は DDB Query しか叩かない。Deploy Worker / API が使う
@@ -11,11 +12,14 @@ import { getEnv } from "../../../helper-functions.js";
 export interface ParticipantSharedResources {
   readonly tableName: string;
   readonly ddb: DynamoDBDocumentClient;
+  /** `{ [problemId]: scoring }`。submit-flag が採点に使う。 */
+  readonly problemsScoring: Record<string, unknown>;
 }
 
 export function buildParticipantSharedResources(): ParticipantSharedResources {
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+    problemsScoring: parseProblemsScoring(process.env.BATTLE_PROBLEMS_SCORING),
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
-import { parseProblemsScoring } from "./submit-flag.js";
+import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 
 /**
  * Participant Lambda は DDB Query しか叩かない。Deploy Worker / API が使う
@@ -12,14 +12,14 @@ import { parseProblemsScoring } from "./submit-flag.js";
 export interface ParticipantSharedResources {
   readonly tableName: string;
   readonly ddb: DynamoDBDocumentClient;
-  /** `{ [problemId]: scoring }`。submit-flag が採点に使う。 */
-  readonly problemsScoring: Record<string, unknown>;
+  /** `{ [problemId]: ProblemScoringMetadata }`。submit-flag が採点に使う。 */
+  readonly problemsScoring: Record<string, ProblemScoringMetadata>;
 }
 
 export function buildParticipantSharedResources(): ParticipantSharedResources {
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
-    problemsScoring: parseProblemsScoring(process.env.BATTLE_PROBLEMS_SCORING),
+    problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,0 +1,120 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { parseStackOutputs } from "../shared/cfn-status.js";
+import type { ParticipantSharedResources } from "./shared.js";
+
+export type SubmitFlagOutcome =
+  | { kind: "ok"; scoreDelta: number; totalScore: number }
+  | { kind: "already_scored"; totalScore: number }
+  | { kind: "wrong" }
+  | { kind: "not_flag_problem" }
+  | { kind: "no_outputs" }
+  | { kind: "unauthorized" };
+
+interface ScoringFlagConfig {
+  kind: "flag";
+  flagOutputKey: string;
+  points: number;
+}
+
+/**
+ * env `BATTLE_PROBLEMS_SCORING` から `{ [problemId]: scoring }` を decode する。
+ * 不正 / 欠損は空 map を返す (= 全 problemId が not_flag_problem になる、安全側)。
+ */
+export function parseProblemsScoring(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* fallthrough */
+  }
+  return {};
+}
+
+function isFlagConfig(value: unknown): value is ScoringFlagConfig {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { kind?: unknown; flagOutputKey?: unknown; points?: unknown };
+  return (
+    v.kind === "flag" &&
+    typeof v.flagOutputKey === "string" &&
+    typeof v.points === "number" &&
+    Number.isFinite(v.points) &&
+    v.points > 0
+  );
+}
+
+/** 競技者 input と stack output 値を比較。両端 trim、case-sensitive。 */
+function flagMatches(submitted: string, expected: string): boolean {
+  return submitted.trim() === expected.trim();
+}
+
+/**
+ * teamLoginKey で deployment 行を引き、flag を採点する。正解なら `ADD score :pts`
+ * + `SET flagSubmitted = true` を 1 UpdateItem で atomic に行う。
+ *
+ * - kind=flag 以外の問題は `not_flag_problem`
+ * - stackOutputs に flagOutputKey が無い (= deploy 未完了等) は `no_outputs`
+ * - 既に flagSubmitted=true なら `already_scored` (= 重複加算しない)
+ */
+export async function submitFlag(
+  shared: ParticipantSharedResources,
+  scoringMap: Record<string, unknown>,
+  teamLoginKey: string,
+  submittedFlag: string,
+): Promise<SubmitFlagOutcome> {
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      IndexName: "GSI2",
+      KeyConditionExpression: "GSI2PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
+      Limit: 1,
+    }),
+  );
+  const item = (out.Items?.[0] ?? undefined) as Partial<DeploymentItem> | undefined;
+  if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
+
+  const scoring = scoringMap[item.problemId];
+  if (!isFlagConfig(scoring)) return { kind: "not_flag_problem" };
+
+  if (item.flagSubmitted === true) {
+    return { kind: "already_scored", totalScore: Number(item.score ?? 0) };
+  }
+
+  const outputs = parseStackOutputs(item.stackOutputs);
+  const expected = outputs[scoring.flagOutputKey];
+  if (typeof expected !== "string") return { kind: "no_outputs" };
+
+  if (!flagMatches(submittedFlag, expected)) return { kind: "wrong" };
+
+  // ConditionExpression で flagSubmitted=true への 2 重加算を防ぐ。レース勝者だけが
+  // 加点される。
+  try {
+    const updated = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: item.PK, SK: "META" },
+        UpdateExpression:
+          "ADD score :pts SET flagSubmitted = :true, lastScoredAt = :now, updatedAt = :now",
+        ConditionExpression: "attribute_not_exists(flagSubmitted) OR flagSubmitted = :false",
+        ExpressionAttributeValues: {
+          ":pts": scoring.points,
+          ":true": true,
+          ":false": false,
+          ":now": new Date().toISOString(),
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const totalScore = Number((updated.Attributes as { score?: unknown })?.score ?? scoring.points);
+    return { kind: "ok", scoreDelta: scoring.points, totalScore };
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ConditionalCheckFailedException") {
+      return { kind: "already_scored", totalScore: Number(item.score ?? 0) + scoring.points };
+    }
+    throw err;
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,4 +1,5 @@
 import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import type { ParticipantSharedResources } from "./shared.js";
@@ -10,41 +11,6 @@ export type SubmitFlagOutcome =
   | { kind: "not_flag_problem" }
   | { kind: "no_outputs" }
   | { kind: "unauthorized" };
-
-interface ScoringFlagConfig {
-  kind: "flag";
-  flagOutputKey: string;
-  points: number;
-}
-
-/**
- * env `BATTLE_PROBLEMS_SCORING` から `{ [problemId]: scoring }` を decode する。
- * 不正 / 欠損は空 map を返す (= 全 problemId が not_flag_problem になる、安全側)。
- */
-export function parseProblemsScoring(raw: string | undefined): Record<string, unknown> {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    /* fallthrough */
-  }
-  return {};
-}
-
-function isFlagConfig(value: unknown): value is ScoringFlagConfig {
-  if (!value || typeof value !== "object") return false;
-  const v = value as { kind?: unknown; flagOutputKey?: unknown; points?: unknown };
-  return (
-    v.kind === "flag" &&
-    typeof v.flagOutputKey === "string" &&
-    typeof v.points === "number" &&
-    Number.isFinite(v.points) &&
-    v.points > 0
-  );
-}
 
 /** 競技者 input と stack output 値を比較。両端 trim、case-sensitive。 */
 function flagMatches(submitted: string, expected: string): boolean {
@@ -61,7 +27,7 @@ function flagMatches(submitted: string, expected: string): boolean {
  */
 export async function submitFlag(
   shared: ParticipantSharedResources,
-  scoringMap: Record<string, unknown>,
+  scoringMap: Record<string, ProblemScoringMetadata>,
   teamLoginKey: string,
   submittedFlag: string,
 ): Promise<SubmitFlagOutcome> {
@@ -78,7 +44,7 @@ export async function submitFlag(
   if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
 
   const scoring = scoringMap[item.problemId];
-  if (!isFlagConfig(scoring)) return { kind: "not_flag_problem" };
+  if (scoring?.kind !== "flag") return { kind: "not_flag_problem" };
 
   if (item.flagSubmitted === true) {
     return { kind: "already_scored", totalScore: Number(item.score ?? 0) };

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
@@ -72,7 +72,7 @@ export async function setDisplayTeamName(
   );
   const updated = updateOut.Attributes as Partial<DeploymentItem> | undefined;
   if (!updated) return { kind: "unauthorized" };
-  const view = toView(updated);
+  const view = toView(updated, shared.problemsScoring);
   if (!view) return { kind: "unauthorized" };
   return { kind: "ok", view };
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
@@ -82,22 +82,38 @@ export function serializeStackOutputs(outputs: Output[] | undefined): string {
 }
 
 /**
- * `serializeStackOutputs` の逆。DDB に保存された JSON 文字列を `Record<string,string>`
- * に戻す。壊れた JSON / 非 object / 配列 / 非 string value は無視 (best-effort)。
+ * DDB に保存された JSON 文字列を `Record<string,string>` に戻す。次の 2 形式を許容する:
+ *
+ *   1. `{key: value}` map — `serializeStackOutputs` (Lambda 由来) が書き込む形式
+ *   2. `[{OutputKey, OutputValue}, ...]` array — Step Functions の
+ *      `cloudformation:describeStacks` task が `States.JsonToString` で書き込む CFn 生形式
+ *
+ * 壊れた JSON / 非 object / array 内の不正 entry は無視 (best-effort)。
  */
 export function parseStackOutputs(json: string | undefined): Record<string, string> {
   if (!json) return {};
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(json);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(parsed)) {
-      if (typeof v === "string") out[k] = v;
-    }
-    return out;
+    parsed = JSON.parse(json);
   } catch {
     return {};
   }
+  if (!parsed || typeof parsed !== "object") return {};
+  const out: Record<string, string> = {};
+  if (Array.isArray(parsed)) {
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object") {
+        const k = (entry as { OutputKey?: unknown }).OutputKey;
+        const v = (entry as { OutputValue?: unknown }).OutputValue;
+        if (typeof k === "string" && typeof v === "string") out[k] = v;
+      }
+    }
+    return out;
+  }
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
 }
 
 export function extractStackContext(stack: Stack | undefined): {

--- a/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts
@@ -88,6 +88,9 @@ export function serializeStackOutputs(outputs: Output[] | undefined): string {
  *   2. `[{OutputKey, OutputValue}, ...]` array — Step Functions の
  *      `cloudformation:describeStacks` task が `States.JsonToString` で書き込む CFn 生形式
  *
+ * Frontend (`apps/application-admin-console/src/api/deploy-client.ts`) に同じ関数の
+ * sister 実装あり。両者は意味的に同一にする。
+ *
  * 壊れた JSON / 非 object / array 内の不正 entry は無視 (best-effort)。
  */
 export function parseStackOutputs(json: string | undefined): Record<string, string> {

--- a/infrastructure/lib/problem-deploy/health-check-lambda.ts
+++ b/infrastructure/lib/problem-deploy/health-check-lambda.ts
@@ -1,0 +1,66 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface HealthCheckLambdaProps {
+  readonly deploymentsTable: ITable;
+  /**
+   * `{ [problemId]: scoring }` 形の scoring 設定。`uptime` 形式の問題のみが probe 対象。
+   */
+  readonly problemsScoring: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * 問題が deploy された後、定期的にエンドポイントを probe してスコアを加減する Lambda。
+ *
+ * EventBridge `rate(1 minute)` で定期起動され、Deployments DDB を scan して
+ * `status=COMPLETE` の各 deployment について metadata の `scoring.kind=uptime` を
+ * 確認、declared endpoints を fetch し、すべて 2xx (or expectStatus) なら
+ * `score += pointsPerSuccess`、失敗なら `lastResult=fail` のみ更新する。
+ *
+ * MVP-1 規模 (~50 deployments) は Scan + FilterExpression で十分。Phase 2 で
+ * 100+ になったら GSI3 (PK=STATUS#{status}) を追加して Query 化する。
+ */
+export class HealthCheckLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: HealthCheckLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/health-check-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.minutes(2),
+      memorySize: 256,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // Lambda が deployments table を Scan + UpdateItem できるよう許可。
+    props.deploymentsTable.grantReadWriteData(this.fn);
+
+    // EventBridge `rate(1 minute)`. Lambda 自身に invoke 権限は LambdaFunction target が
+    // 自動付与する。
+    new Rule(this, "Schedule", {
+      schedule: Schedule.rate(Duration.minutes(1)),
+      description: "TenkaCloud uptime scoring health check (1 minute interval).",
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -20,6 +20,12 @@ import { Construct } from "constructs";
 
 export interface ParticipantPortalLambdaProps {
   readonly deploymentsTable: ITable;
+  /**
+   * `{ [problemId]: { kind, flagOutputKey, points, ... } }` 形の scoring 設定。
+   * `discoverProblemsScoring` で metadata.json から自動収集して synth 時に注入する。
+   * 競技者が submit-flag したとき、この map を参照して採点する。
+   */
+  readonly problemsScoring: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -73,6 +79,7 @@ export class ParticipantPortalLambda extends Construct {
       role,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -87,7 +94,7 @@ export class ParticipantPortalLambda extends Construct {
       authType: FunctionUrlAuthType.NONE,
       cors: {
         allowedOrigins: ["*"],
-        allowedMethods: [HttpMethod.GET, HttpMethod.PATCH],
+        allowedMethods: [HttpMethod.GET, HttpMethod.PATCH, HttpMethod.POST],
         allowedHeaders: ["content-type", "authorization"],
         maxAge: Duration.minutes(10),
       },

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -9,6 +9,7 @@ import { DeployCodeBuildProject } from "./deploy-codebuild-project";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine";
 import { DeployEventRule } from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
+import { HealthCheckLambda } from "./health-check-lambda";
 import {
   DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
   ParticipantPortalHosting,
@@ -37,6 +38,12 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * `problemDir` を解決する。Phase 2 (ADR-003) で DDB catalog に置換。
    */
   readonly problemsCatalog: Readonly<Record<string, string>>;
+  /**
+   * `problemId → scoring` の map (`{ kind: "flag", flagOutputKey, points, ... }`)。
+   * Participant Portal Lambda が submit-flag 採点に使う。`scoring` を持たない問題は
+   * このキーが無い (= 採点無効)。
+   */
+  readonly problemsScoring: Readonly<Record<string, unknown>>;
   /**
    * 競技者向け Participant Portal を S3 + CloudFront で配信する。指定された
    * `runtimeConfig` が runtime-config.json として配置される。Portal backend が
@@ -97,9 +104,19 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       stateMachine: stateMachine.stateMachine,
     });
 
+    // 1 分間隔で uptime 採点する Health Check Lambda。`scoring.kind=uptime` の問題のみが
+    // 対象。`flag` 形式は Portal Lambda が submit-flag 経路で採点するため別系統。
+    if (Object.keys(props.problemsScoring).length > 0) {
+      new HealthCheckLambda(this, "HealthCheck", {
+        deploymentsTable: deployments.table,
+        problemsScoring: props.problemsScoring,
+      });
+    }
+
     if (props.participantPortal) {
       const portalLambda = new ParticipantPortalLambda(this, "ParticipantPortalLambda", {
         deploymentsTable: deployments.table,
+        problemsScoring: props.problemsScoring,
       });
       new CfnOutput(this, "ParticipantPortalApiUrl", {
         value: portalLambda.url.url,

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -2,26 +2,64 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 /**
+ * Scoring engine が読む metadata.json の `scoring` section の最低限 shape。
+ * SCHEMA.json の oneOf と整合させる。
+ */
+export type ProblemScoringMetadata =
+  | { kind: "flag"; flagOutputKey: string; points: number; hints?: string[] }
+  | {
+      kind: "uptime";
+      endpoints: { outputKey: string; path: string; expectStatus: number[] }[];
+      pointsPerSuccess: number;
+    };
+
+/**
  * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
- * `{ [problemId]: "problems/<category>/<id>" }` の map を返す。frontend の Vite glob と
- * 同じ正本 (filesystem) から問題カタログを引くためのヘルパー。
- *
- * - `problemsRoot` が存在しない / metadata.json が無い場合は空 map を返す (synth 時に
- *   problems/ を埋める前に typecheck が走るケースの防御)
- * - id は metadata.json の `id` field を採用 (ディレクトリ名と一致するのは規約だが、
- *   一致しない場合は metadata 側を信用する)
- *
- * Phase 2 (ADR-003) で DDB ベースの問題カタログに置換されるまでの自動 discovery 経路。
+ * `{ [problemId]: "problems/<category>/<id>" }` の map を返す。
  */
 export function discoverProblemsCatalog(problemsRoot: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const meta of iterateProblemsMetadata(problemsRoot)) {
+    result[meta.id] = `problems/${meta.category}/${meta.dirName}`;
+  }
+  return result;
+}
+
+/**
+ * `discoverProblemsCatalog` の sibling。同じ走査で `scoring` section を抜き、
+ * `{ [problemId]: ProblemScoringMetadata }` の map を返す。`scoring` を持たない
+ * 問題はキーごと出さない (= scoring 無効)。
+ *
+ * Lambda env vars (`BATTLE_PROBLEMS_SCORING`) として deploy-handler / participant-
+ * handler に渡し、両 Lambda が同じ scoring 規則を共有する。
+ */
+export function discoverProblemsScoring(
+  problemsRoot: string,
+): Record<string, ProblemScoringMetadata> {
+  const result: Record<string, ProblemScoringMetadata> = {};
+  for (const meta of iterateProblemsMetadata(problemsRoot)) {
+    if (isValidScoring(meta.scoring)) {
+      result[meta.id] = meta.scoring;
+    }
+  }
+  return result;
+}
+
+interface ProblemMetadataEntry {
+  id: string;
+  category: string;
+  dirName: string;
+  scoring: unknown;
+}
+
+function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetadataEntry> {
   if (!fs.existsSync(problemsRoot)) {
     console.warn(
       `[discoverProblemsCatalog] ${problemsRoot} not found — assuming pre-install or wrong cwd. ` +
         `Catalog will be empty; tenant API will reject all problemId.`,
     );
-    return {};
+    return;
   }
-  const catalog: Record<string, string> = {};
   for (const category of fs.readdirSync(problemsRoot, { withFileTypes: true })) {
     if (!category.isDirectory()) continue;
     const categoryDir = path.join(problemsRoot, category.name);
@@ -30,12 +68,20 @@ export function discoverProblemsCatalog(problemsRoot: string): Record<string, st
       const metadataPath = path.join(categoryDir, problem.name, "metadata.json");
       if (!fs.existsSync(metadataPath)) continue;
       try {
-        const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { id?: unknown };
+        const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as {
+          id?: unknown;
+          scoring?: unknown;
+        };
         if (typeof meta.id !== "string" || meta.id.length === 0) {
           console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
           continue;
         }
-        catalog[meta.id] = `problems/${category.name}/${problem.name}`;
+        yield {
+          id: meta.id,
+          category: category.name,
+          dirName: problem.name,
+          scoring: meta.scoring,
+        };
       } catch (err) {
         console.warn(
           `[discoverProblemsCatalog] ${metadataPath}: parse failed (${(err as Error).message}). ` +
@@ -44,5 +90,18 @@ export function discoverProblemsCatalog(problemsRoot: string): Record<string, st
       }
     }
   }
-  return catalog;
+}
+
+function isValidScoring(value: unknown): value is ProblemScoringMetadata {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { kind?: unknown };
+  if (v.kind === "flag") {
+    const f = value as { flagOutputKey?: unknown; points?: unknown };
+    return typeof f.flagOutputKey === "string" && typeof f.points === "number";
+  }
+  if (v.kind === "uptime") {
+    const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
+    return Array.isArray(u.endpoints) && typeof u.pointsPerSuccess === "number";
+  }
+  return false;
 }

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -1,17 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { type ProblemScoringMetadata, parseScoringMetadata } from "./scoring-metadata";
 
-/**
- * Scoring engine が読む metadata.json の `scoring` section の最低限 shape。
- * SCHEMA.json の oneOf と整合させる。
- */
-export type ProblemScoringMetadata =
-  | { kind: "flag"; flagOutputKey: string; points: number; hints?: string[] }
-  | {
-      kind: "uptime";
-      endpoints: { outputKey: string; path: string; expectStatus: number[] }[];
-      pointsPerSuccess: number;
-    };
+export type { ProblemScoringMetadata };
 
 /**
  * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
@@ -38,9 +29,8 @@ export function discoverProblemsScoring(
 ): Record<string, ProblemScoringMetadata> {
   const result: Record<string, ProblemScoringMetadata> = {};
   for (const meta of iterateProblemsMetadata(problemsRoot)) {
-    if (isValidScoring(meta.scoring)) {
-      result[meta.id] = meta.scoring;
-    }
+    const cfg = parseScoringMetadata(meta.scoring);
+    if (cfg) result[meta.id] = cfg;
   }
   return result;
 }
@@ -90,18 +80,4 @@ function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetada
       }
     }
   }
-}
-
-function isValidScoring(value: unknown): value is ProblemScoringMetadata {
-  if (!value || typeof value !== "object") return false;
-  const v = value as { kind?: unknown };
-  if (v.kind === "flag") {
-    const f = value as { flagOutputKey?: unknown; points?: unknown };
-    return typeof f.flagOutputKey === "string" && typeof f.points === "number";
-  }
-  if (v.kind === "uptime") {
-    const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
-    return Array.isArray(u.endpoints) && typeof u.pointsPerSuccess === "number";
-  }
-  return false;
 }

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -1,0 +1,81 @@
+/**
+ * 問題の `metadata.json:scoring` section の type-safe な parser。
+ *
+ * 同じ shape を CDK synth 時 (`discoverProblemsScoring`) と Lambda runtime
+ * (Portal `submit-flag`、HealthCheck `health-check-handler`、`lookup.toView`) の
+ * 両方で参照するため、ここに 1 箇所に集約する。SCHEMA.json と整合させる。
+ */
+
+export type ProblemScoringMetadata =
+  | {
+      kind: "flag";
+      flagOutputKey: string;
+      points: number;
+      hints?: readonly string[];
+    }
+  | {
+      kind: "uptime";
+      endpoints: readonly { outputKey: string; path: string; expectStatus: readonly number[] }[];
+      pointsPerSuccess: number;
+    };
+
+/** 1 件の `scoring` value を ProblemScoringMetadata に narrow する。不正なら undefined。 */
+export function parseScoringMetadata(value: unknown): ProblemScoringMetadata | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as { kind?: unknown };
+  if (v.kind === "flag") {
+    const f = value as { flagOutputKey?: unknown; points?: unknown; hints?: unknown };
+    if (
+      typeof f.flagOutputKey === "string" &&
+      typeof f.points === "number" &&
+      Number.isFinite(f.points) &&
+      f.points > 0
+    ) {
+      return {
+        kind: "flag",
+        flagOutputKey: f.flagOutputKey,
+        points: f.points,
+        hints: Array.isArray(f.hints)
+          ? (f.hints.filter((h) => typeof h === "string") as string[])
+          : undefined,
+      };
+    }
+  }
+  if (v.kind === "uptime") {
+    const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
+    if (Array.isArray(u.endpoints) && typeof u.pointsPerSuccess === "number") {
+      return {
+        kind: "uptime",
+        endpoints: u.endpoints as ProblemScoringMetadata extends {
+          kind: "uptime";
+          endpoints: infer E;
+        }
+          ? E
+          : never,
+        pointsPerSuccess: u.pointsPerSuccess,
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Lambda env (`BATTLE_PROBLEMS_SCORING`) を decode し、`{ [problemId]: ProblemScoringMetadata }`
+ * に narrow する。不正な entry (parse 失敗 / non-object / shape mismatch) は drop。
+ */
+export function parseScoringEnv(raw: string | undefined): Record<string, ProblemScoringMetadata> {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const out: Record<string, ProblemScoringMetadata> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    const cfg = parseScoringMetadata(v);
+    if (cfg) out[k] = cfg;
+  }
+  return out;
+}

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -2,7 +2,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { discoverProblemsCatalog } from "../lib/utils/discover-problems-catalog";
+import {
+  discoverProblemsCatalog,
+  discoverProblemsScoring,
+} from "../lib/utils/discover-problems-catalog";
 
 /**
  * discoverProblemsCatalog: `problems/<category>/<id>/metadata.json` を 2 階層 scan して
@@ -111,5 +114,64 @@ describe("discoverProblemsCatalog", () => {
     const catalog = discoverProblemsCatalog(workspace);
 
     expect(catalog).toEqual({ "hello-world": "problems/challenges/hello-world" });
+  });
+});
+
+describe("discoverProblemsScoring", () => {
+  it("flag 形式の scoring を採集するべき", () => {
+    writeProblem("challenges", "hello-world", {
+      id: "hello-world",
+      scoring: { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
+    });
+    expect(discoverProblemsScoring(workspace)).toEqual({
+      "hello-world": { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
+    });
+  });
+
+  it("uptime 形式の scoring を採集するべき", () => {
+    writeProblem("battles", "battle-1", {
+      id: "battle-1",
+      scoring: {
+        kind: "uptime",
+        endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      },
+    });
+    expect(discoverProblemsScoring(workspace)).toEqual({
+      "battle-1": {
+        kind: "uptime",
+        endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      },
+    });
+  });
+
+  it("scoring を持たない problem は map に含めないべき", () => {
+    writeProblem("challenges", "hello-world", { id: "hello-world" });
+    writeProblem("challenges", "with-scoring", {
+      id: "with-scoring",
+      scoring: { kind: "flag", flagOutputKey: "X", points: 1 },
+    });
+    expect(discoverProblemsScoring(workspace)).toEqual({
+      "with-scoring": { kind: "flag", flagOutputKey: "X", points: 1 },
+    });
+  });
+
+  it("scoring の shape が壊れているもの (= kind 不正 / 必須 field 欠損) は drop するべき", () => {
+    writeProblem("challenges", "broken-1", {
+      id: "broken-1",
+      scoring: { kind: "wrong-kind" },
+    });
+    writeProblem("challenges", "broken-2", {
+      id: "broken-2",
+      scoring: { kind: "flag" }, // flagOutputKey / points 欠損
+    });
+    writeProblem("challenges", "good", {
+      id: "good",
+      scoring: { kind: "flag", flagOutputKey: "X", points: 1 },
+    });
+    expect(discoverProblemsScoring(workspace)).toEqual({
+      good: { kind: "flag", flagOutputKey: "X", points: 1 },
+    });
   });
 });

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -14,6 +14,7 @@ function synthDefault(): Template {
     problemsCatalog: {
       "hello-world": "problems/challenges/hello-world",
     },
+    problemsScoring: {},
   });
   return Template.fromStack(stack);
 }

--- a/infrastructure/test/problem-deploy/cfn-status.test.ts
+++ b/infrastructure/test/problem-deploy/cfn-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  parseStackOutputs,
   resolveDeploymentStatus,
   serializeStackOutputs,
 } from "../../lib/problem-deploy/handlers/shared/cfn-status";
@@ -92,5 +93,46 @@ describe("serializeStackOutputs", () => {
       { OutputKey: "OnlyKey" },
     ]);
     expect(JSON.parse(json)).toEqual({ FrontendUrl: "http://example.com" });
+  });
+});
+
+describe("parseStackOutputs", () => {
+  it("undefined / 空文字 / 壊れた JSON は空オブジェクトを返すべき", () => {
+    expect(parseStackOutputs(undefined)).toEqual({});
+    expect(parseStackOutputs("")).toEqual({});
+    expect(parseStackOutputs("{not-json")).toEqual({});
+  });
+
+  it("`{key: value}` 形式 (Lambda 由来) を Record<string,string> に戻すべき", () => {
+    expect(
+      parseStackOutputs(JSON.stringify({ FrontendUrl: "http://x", ApiUrl: "http://y" })),
+    ).toEqual({
+      FrontendUrl: "http://x",
+      ApiUrl: "http://y",
+    });
+  });
+
+  it("`[{OutputKey, OutputValue}, ...]` 形式 (Step Functions describeStacks 由来) も解釈するべき", () => {
+    const cfnNative = JSON.stringify([
+      { OutputKey: "ParameterValue", OutputValue: "Hello from tc-...", Description: "x" },
+      { OutputKey: "ParameterName", OutputValue: "/tc-.../hello" },
+    ]);
+    expect(parseStackOutputs(cfnNative)).toEqual({
+      ParameterValue: "Hello from tc-...",
+      ParameterName: "/tc-.../hello",
+    });
+  });
+
+  it("非 string 値の entry は skip するべき (= best-effort)", () => {
+    expect(parseStackOutputs(JSON.stringify({ A: "ok", B: 123, C: null }))).toEqual({ A: "ok" });
+    expect(
+      parseStackOutputs(
+        JSON.stringify([
+          { OutputKey: "A", OutputValue: "ok" },
+          { OutputKey: "B", OutputValue: 123 },
+          { OutputKey: 999, OutputValue: "skipped" },
+        ]),
+      ),
+    ).toEqual({ A: "ok" });
   });
 });

--- a/infrastructure/test/problem-deploy/health-check-handler.test.ts
+++ b/infrastructure/test/problem-deploy/health-check-handler.test.ts
@@ -1,66 +1,10 @@
 import { describe, expect, it } from "vitest";
-import {
-  asUptimeScoring,
-  joinUrl,
-  parseScoringMap,
-} from "../../lib/problem-deploy/handlers/health-check-handler";
+import { joinUrl } from "../../lib/problem-deploy/handlers/health-check-handler";
 
 /**
- * Health Check Lambda 内部のヘルパー (純粋関数) を単体テストで固める。
- * Lambda handler 自体 (DDB Scan + 並列 probe) は実 fetch / DDB の integration テスト
- * 経路で確認する想定で、ここでは scoring の解釈と URL 生成だけを pin する。
+ * Health Check Lambda 内の URL helper を pin する。Scoring の解釈は
+ * `lib/utils/scoring-metadata.ts` 側で集約され、別 test file が cover する。
  */
-
-describe("parseScoringMap", () => {
-  it("env 未設定なら空 map を返すべき", () => {
-    delete process.env.BATTLE_PROBLEMS_SCORING;
-    expect(parseScoringMap()).toEqual({});
-  });
-  it("正常な JSON object はそのまま返すべき", () => {
-    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
-      "p-1": { kind: "uptime", endpoints: [], pointsPerSuccess: 50 },
-    });
-    expect(parseScoringMap()).toEqual({
-      "p-1": { kind: "uptime", endpoints: [], pointsPerSuccess: 50 },
-    });
-  });
-  it("array や primitive は空 map を返すべき", () => {
-    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify(["x"]);
-    expect(parseScoringMap()).toEqual({});
-    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify(123);
-    expect(parseScoringMap()).toEqual({});
-  });
-  it("壊れた JSON は空 map を返すべき", () => {
-    process.env.BATTLE_PROBLEMS_SCORING = "{not-json";
-    expect(parseScoringMap()).toEqual({});
-  });
-});
-
-describe("asUptimeScoring", () => {
-  it("kind=uptime + pointsPerSuccess + endpoints が揃っていれば返すべき", () => {
-    const cfg = {
-      kind: "uptime",
-      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
-      pointsPerSuccess: 100,
-    };
-    expect(asUptimeScoring(cfg)).toEqual(cfg);
-  });
-
-  it("kind=flag は uptime として認識しない", () => {
-    expect(asUptimeScoring({ kind: "flag", flagOutputKey: "X", points: 100 })).toBeUndefined();
-  });
-
-  it("endpoints が array でない / pointsPerSuccess が無いと undefined を返すべき", () => {
-    expect(asUptimeScoring({ kind: "uptime", pointsPerSuccess: 50 })).toBeUndefined();
-    expect(asUptimeScoring({ kind: "uptime", endpoints: [] })).toBeUndefined();
-  });
-
-  it("primitive / null は undefined を返すべき", () => {
-    expect(asUptimeScoring(null)).toBeUndefined();
-    expect(asUptimeScoring(123)).toBeUndefined();
-    expect(asUptimeScoring("uptime")).toBeUndefined();
-  });
-});
 
 describe("joinUrl", () => {
   it("path 空ならそのまま base を返すべき", () => {

--- a/infrastructure/test/problem-deploy/health-check-handler.test.ts
+++ b/infrastructure/test/problem-deploy/health-check-handler.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  asUptimeScoring,
+  joinUrl,
+  parseScoringMap,
+} from "../../lib/problem-deploy/handlers/health-check-handler";
+
+/**
+ * Health Check Lambda 内部のヘルパー (純粋関数) を単体テストで固める。
+ * Lambda handler 自体 (DDB Scan + 並列 probe) は実 fetch / DDB の integration テスト
+ * 経路で確認する想定で、ここでは scoring の解釈と URL 生成だけを pin する。
+ */
+
+describe("parseScoringMap", () => {
+  it("env 未設定なら空 map を返すべき", () => {
+    delete process.env.BATTLE_PROBLEMS_SCORING;
+    expect(parseScoringMap()).toEqual({});
+  });
+  it("正常な JSON object はそのまま返すべき", () => {
+    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
+      "p-1": { kind: "uptime", endpoints: [], pointsPerSuccess: 50 },
+    });
+    expect(parseScoringMap()).toEqual({
+      "p-1": { kind: "uptime", endpoints: [], pointsPerSuccess: 50 },
+    });
+  });
+  it("array や primitive は空 map を返すべき", () => {
+    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify(["x"]);
+    expect(parseScoringMap()).toEqual({});
+    process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify(123);
+    expect(parseScoringMap()).toEqual({});
+  });
+  it("壊れた JSON は空 map を返すべき", () => {
+    process.env.BATTLE_PROBLEMS_SCORING = "{not-json";
+    expect(parseScoringMap()).toEqual({});
+  });
+});
+
+describe("asUptimeScoring", () => {
+  it("kind=uptime + pointsPerSuccess + endpoints が揃っていれば返すべき", () => {
+    const cfg = {
+      kind: "uptime",
+      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+      pointsPerSuccess: 100,
+    };
+    expect(asUptimeScoring(cfg)).toEqual(cfg);
+  });
+
+  it("kind=flag は uptime として認識しない", () => {
+    expect(asUptimeScoring({ kind: "flag", flagOutputKey: "X", points: 100 })).toBeUndefined();
+  });
+
+  it("endpoints が array でない / pointsPerSuccess が無いと undefined を返すべき", () => {
+    expect(asUptimeScoring({ kind: "uptime", pointsPerSuccess: 50 })).toBeUndefined();
+    expect(asUptimeScoring({ kind: "uptime", endpoints: [] })).toBeUndefined();
+  });
+
+  it("primitive / null は undefined を返すべき", () => {
+    expect(asUptimeScoring(null)).toBeUndefined();
+    expect(asUptimeScoring(123)).toBeUndefined();
+    expect(asUptimeScoring("uptime")).toBeUndefined();
+  });
+});
+
+describe("joinUrl", () => {
+  it("path 空ならそのまま base を返すべき", () => {
+    expect(joinUrl("https://x.example.com", "")).toBe("https://x.example.com");
+  });
+
+  it("base 末尾 / と path 先頭 / の二重スラッシュを正規化", () => {
+    expect(joinUrl("https://x.example.com/", "/foo")).toBe("https://x.example.com/foo");
+  });
+
+  it("base 末尾 / 無し + path 先頭 / 無しは / を補う", () => {
+    expect(joinUrl("https://x.example.com", "foo")).toBe("https://x.example.com/foo");
+  });
+
+  it("path が絶対 URL ならそのまま採用 (= override)", () => {
+    expect(joinUrl("https://x.example.com", "https://other.example.com/health")).toBe(
+      "https://other.example.com/health",
+    );
+  });
+
+  it("通常 case: 末尾 / 無し base + 先頭 / path", () => {
+    expect(joinUrl("https://x.example.com", "/healthz")).toBe("https://x.example.com/healthz");
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lookupByTeamLoginKey } from "../../lib/problem-deploy/handlers/participant-handler/lookup";
 import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
 
-function buildShared(scoring: Record<string, unknown> = {}): {
+function buildShared(scoring: ParticipantSharedResources["problemsScoring"] = {}): {
   shared: ParticipantSharedResources;
   ddbSend: ReturnType<typeof vi.fn>;
 } {

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lookupByTeamLoginKey } from "../../lib/problem-deploy/handlers/participant-handler/lookup";
 import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
 
-function buildShared(): {
+function buildShared(scoring: Record<string, unknown> = {}): {
   shared: ParticipantSharedResources;
   ddbSend: ReturnType<typeof vi.fn>;
 } {
@@ -11,6 +11,7 @@ function buildShared(): {
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: scoring,
   };
   return { shared, ddbSend };
 }
@@ -149,5 +150,62 @@ describe("lookupByTeamLoginKey", () => {
 
     const view = await lookupByTeamLoginKey(shared, "KEY1");
     expect(view?.stackOutputs).toEqual({});
+  });
+
+  it("flag 形式 problem では flagOutputKey の値を stackOutputs から strip するべき (= 答え露出防止)", async () => {
+    const scoring = {
+      "security-battle-royale": {
+        kind: "flag",
+        flagOutputKey: "FlagAnswer",
+        points: 100,
+      },
+    };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          stackOutputs: JSON.stringify({
+            FrontendUrl: "https://x.example.com",
+            FlagAnswer: "the-secret-answer",
+          }),
+        }),
+      ],
+    });
+
+    const view = await lookupByTeamLoginKey(shared, "KEY1");
+    expect(view?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
+    expect(view?.scoring?.kind).toBe("flag");
+    expect(view?.scoring?.points).toBe(100);
+  });
+
+  it("score / lastScoredAt / lastResult / scoring を participant view に含めるべき", async () => {
+    const scoring = {
+      "security-battle-royale": { kind: "uptime", pointsPerSuccess: 50 },
+    };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          score: 250,
+          lastScoredAt: "2026-05-05T10:00:00.000Z",
+          lastResult: "ok",
+        }),
+      ],
+    });
+
+    const view = await lookupByTeamLoginKey(shared, "KEY1");
+    expect(view?.score).toBe(250);
+    expect(view?.lastScoredAt).toBe("2026-05-05T10:00:00.000Z");
+    expect(view?.lastResult).toBe("ok");
+    expect(view?.scoring?.kind).toBe("uptime");
+    expect(view?.scoring?.pointsPerSuccess).toBe(50);
+  });
+
+  it("score 未設定の row は 0 を返すべき (default)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+
+    const view = await lookupByTeamLoginKey(shared, "KEY1");
+    expect(view?.score).toBe(0);
   });
 });

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -14,6 +14,7 @@ function buildShared(): {
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
   };
   return { shared, ddbSend };
 }

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -1,10 +1,8 @@
 import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
-import {
-  parseProblemsScoring,
-  submitFlag,
-} from "../../lib/problem-deploy/handlers/participant-handler/submit-flag";
+import { submitFlag } from "../../lib/problem-deploy/handlers/participant-handler/submit-flag";
+import type { ProblemScoringMetadata } from "../../lib/utils/scoring-metadata";
 
 function buildShared(): {
   shared: ParticipantSharedResources;
@@ -37,28 +35,13 @@ const sampleRow = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-const flagScoring = {
+const flagScoring: Record<string, ProblemScoringMetadata> = {
   "hello-world": {
     kind: "flag",
     flagOutputKey: "ParameterValue",
     points: 100,
   },
 };
-
-describe("parseProblemsScoring", () => {
-  it("undefined / 空文字 / 壊れた JSON は空 map を返すべき", () => {
-    expect(parseProblemsScoring(undefined)).toEqual({});
-    expect(parseProblemsScoring("")).toEqual({});
-    expect(parseProblemsScoring("{not-json")).toEqual({});
-  });
-  it("正常な JSON object はそのまま返すべき", () => {
-    expect(parseProblemsScoring(JSON.stringify(flagScoring))).toEqual(flagScoring);
-  });
-  it("array や primitive は空 map を返すべき (= shape mismatch)", () => {
-    expect(parseProblemsScoring(JSON.stringify(["x"]))).toEqual({});
-    expect(parseProblemsScoring(JSON.stringify(123))).toEqual({});
-  });
-});
 
 describe("submitFlag", () => {
   let shared: ParticipantSharedResources;

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -1,0 +1,148 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+import {
+  parseProblemsScoring,
+  submitFlag,
+} from "../../lib/problem-deploy/handlers/participant-handler/submit-flag";
+
+function buildShared(): {
+  shared: ParticipantSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#JOB1",
+  SK: "META",
+  jobId: "JOB1",
+  problemId: "hello-world",
+  tenantId: "tenant-acme",
+  teamName: "alpha",
+  namePrefix: "tc-hello-world-alpha",
+  status: "COMPLETE",
+  // CFn array shape を模す。parseStackOutputs が両形式を解釈する。
+  stackOutputs: JSON.stringify([
+    { OutputKey: "ParameterValue", OutputValue: "Hello from tc-hello-world-alpha" },
+    { OutputKey: "ParameterName", OutputValue: "/tc-hello-world-alpha/hello" },
+  ]),
+  expiresAt: 9_999_999_999,
+  ...over,
+});
+
+const flagScoring = {
+  "hello-world": {
+    kind: "flag",
+    flagOutputKey: "ParameterValue",
+    points: 100,
+  },
+};
+
+describe("parseProblemsScoring", () => {
+  it("undefined / 空文字 / 壊れた JSON は空 map を返すべき", () => {
+    expect(parseProblemsScoring(undefined)).toEqual({});
+    expect(parseProblemsScoring("")).toEqual({});
+    expect(parseProblemsScoring("{not-json")).toEqual({});
+  });
+  it("正常な JSON object はそのまま返すべき", () => {
+    expect(parseProblemsScoring(JSON.stringify(flagScoring))).toEqual(flagScoring);
+  });
+  it("array や primitive は空 map を返すべき (= shape mismatch)", () => {
+    expect(parseProblemsScoring(JSON.stringify(["x"]))).toEqual({});
+    expect(parseProblemsScoring(JSON.stringify(123))).toEqual({});
+  });
+});
+
+describe("submitFlag", () => {
+  let shared: ParticipantSharedResources;
+  let ddbSend: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    const built = buildShared();
+    shared = built.shared;
+    ddbSend = built.ddbSend;
+  });
+
+  it("teamLoginKey が一致する row が無いときは unauthorized を返すべき", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await submitFlag(shared, flagScoring, "BAD_KEY", "Hello from tc-...");
+    expect(out).toEqual({ kind: "unauthorized" });
+  });
+
+  it("scoring 設定が無い problemId は not_flag_problem を返すべき", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ problemId: "no-scoring" })] });
+    const out = await submitFlag(shared, flagScoring, "KEY", "anything");
+    expect(out).toEqual({ kind: "not_flag_problem" });
+  });
+
+  it("既に flagSubmitted=true なら already_scored を返すべき (= 重複加算しない)", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ flagSubmitted: true, score: 100 })],
+    });
+    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
+    // UpdateItem は呼ばれないこと (= Query の 1 回のみ)
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("stackOutputs に flagOutputKey が無いとき (= deploy 未完了) は no_outputs を返すべき", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ stackOutputs: undefined })],
+    });
+    const out = await submitFlag(shared, flagScoring, "KEY", "anything");
+    expect(out).toEqual({ kind: "no_outputs" });
+  });
+
+  it("submitted flag が expected と一致しなければ wrong を返すべき (UpdateItem 呼ばない)", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    const out = await submitFlag(shared, flagScoring, "KEY", "wrong-answer");
+    expect(out).toEqual({ kind: "wrong" });
+    expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、Update なし
+  });
+
+  it("正解なら ADD score :pts SET flagSubmitted=true で UpdateItem し ok を返すべき", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    expect(out).toEqual({ kind: "ok", scoreDelta: 100, totalScore: 100 });
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    expect(updateCmd).toBeInstanceOf(UpdateCommand);
+    expect(updateCmd.input.UpdateExpression).toContain("ADD score :pts");
+    expect(updateCmd.input.UpdateExpression).toContain("flagSubmitted = :true");
+    expect(updateCmd.input.ConditionExpression).toContain("attribute_not_exists(flagSubmitted)");
+  });
+
+  it("trim した値が一致すれば ok を返すべき (= 末尾改行などで弾かない)", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+    const out = await submitFlag(shared, flagScoring, "KEY", "  Hello from tc-hello-world-alpha\n");
+    expect(out.kind).toBe("ok");
+  });
+
+  it("ConditionalCheckFailedException は already_scored で吸収するべき (= 並行 submit 対策)", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 0 })] });
+    const condErr = Object.assign(new Error("conditional check failed"), {
+      name: "ConditionalCheckFailedException",
+    });
+    ddbSend.mockRejectedValueOnce(condErr);
+    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
+  });
+
+  it("Query は GSI2 を `TEAMKEY#<key>` で叩くべき", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+    await submitFlag(shared, flagScoring, "MYKEY", "Hello from tc-hello-world-alpha");
+    const queryCmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(queryCmd).toBeInstanceOf(QueryCommand);
+    expect(queryCmd.input.IndexName).toBe("GSI2");
+    expect(queryCmd.input.ExpressionAttributeValues).toEqual({ ":pk": "TEAMKEY#MYKEY" });
+  });
+});

--- a/infrastructure/test/scoring-metadata.test.ts
+++ b/infrastructure/test/scoring-metadata.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { parseScoringEnv, parseScoringMetadata } from "../lib/utils/scoring-metadata";
+
+/**
+ * `lib/utils/scoring-metadata.ts` は CDK synth と Lambda runtime の両方で参照される
+ * scoring shape parser。SCHEMA.json と整合した shape narrowing を pin する。
+ */
+
+describe("parseScoringMetadata", () => {
+  describe("flag 形式", () => {
+    it("flagOutputKey + points が揃っていれば narrow するべき", () => {
+      expect(
+        parseScoringMetadata({ kind: "flag", flagOutputKey: "ParameterValue", points: 100 }),
+      ).toEqual({
+        kind: "flag",
+        flagOutputKey: "ParameterValue",
+        points: 100,
+        hints: undefined,
+      });
+    });
+
+    it("hints が string array なら filter して保持するべき", () => {
+      expect(
+        parseScoringMetadata({
+          kind: "flag",
+          flagOutputKey: "X",
+          points: 1,
+          hints: ["use AWS Console", 123, "second hint", null],
+        }),
+      ).toEqual({
+        kind: "flag",
+        flagOutputKey: "X",
+        points: 1,
+        hints: ["use AWS Console", "second hint"],
+      });
+    });
+
+    it("flagOutputKey が string でない / points が無い / 0 以下は undefined", () => {
+      expect(
+        parseScoringMetadata({ kind: "flag", flagOutputKey: 123, points: 100 }),
+      ).toBeUndefined();
+      expect(parseScoringMetadata({ kind: "flag", flagOutputKey: "X" })).toBeUndefined();
+      expect(parseScoringMetadata({ kind: "flag", flagOutputKey: "X", points: 0 })).toBeUndefined();
+      expect(
+        parseScoringMetadata({ kind: "flag", flagOutputKey: "X", points: -1 }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("uptime 形式", () => {
+    it("endpoints が array + pointsPerSuccess が number なら narrow するべき", () => {
+      const cfg = {
+        kind: "uptime",
+        endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      };
+      expect(parseScoringMetadata(cfg)).toEqual(cfg);
+    });
+
+    it("endpoints が array でない / pointsPerSuccess が無いと undefined", () => {
+      expect(parseScoringMetadata({ kind: "uptime", pointsPerSuccess: 50 })).toBeUndefined();
+      expect(parseScoringMetadata({ kind: "uptime", endpoints: [] })).toBeUndefined();
+    });
+  });
+
+  describe("無効入力", () => {
+    it.each([
+      null,
+      undefined,
+      123,
+      "uptime",
+      [],
+      { kind: "wrong-kind" },
+      { points: 100 },
+    ])("%s は undefined を返すべき", (input) => {
+      expect(parseScoringMetadata(input)).toBeUndefined();
+    });
+  });
+});
+
+describe("parseScoringEnv", () => {
+  it("undefined / 空文字 / 壊れた JSON は空 map を返すべき", () => {
+    expect(parseScoringEnv(undefined)).toEqual({});
+    expect(parseScoringEnv("")).toEqual({});
+    expect(parseScoringEnv("{not-json")).toEqual({});
+  });
+
+  it("array や primitive は空 map を返すべき", () => {
+    expect(parseScoringEnv(JSON.stringify(["x"]))).toEqual({});
+    expect(parseScoringEnv(JSON.stringify(123))).toEqual({});
+  });
+
+  it("混在 entries は valid なものだけ拾うべき", () => {
+    const raw = JSON.stringify({
+      "valid-flag": { kind: "flag", flagOutputKey: "X", points: 100 },
+      "valid-uptime": {
+        kind: "uptime",
+        endpoints: [{ outputKey: "Url", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      },
+      "invalid-shape": { kind: "flag" },
+      "invalid-kind": { kind: "wrong" },
+    });
+    const out = parseScoringEnv(raw);
+    expect(Object.keys(out).sort()).toEqual(["valid-flag", "valid-uptime"]);
+    expect(out["valid-flag"]?.kind).toBe("flag");
+    expect(out["valid-uptime"]?.kind).toBe("uptime");
+  });
+});

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -103,6 +103,72 @@
       "type": "object",
       "additionalProperties": { "type": "string" },
       "description": "CFn template の Parameters に渡す値を {ParameterName: value} で宣言する。`NamePrefix` は script が自動注入するので含めない。`__RANDOM_PASSWORD__` を value にすると、deploy ごとに 32 桁ランダム英数字を生成して渡す (DbPassword 等の secret 用途)。省略可 (Parameters 全部に default が付いているテンプレートでは不要)。"
+    },
+    "scoring": {
+      "description": "Scoring engine がポイントを加算する条件。省略時はスコアリング無効 (= deploy のみで競技要素なし)。Challenge 系は通常 `flag`、Battle 系は通常 `uptime`。",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "flagOutputKey", "points"],
+          "properties": {
+            "kind": { "const": "flag" },
+            "flagOutputKey": {
+              "type": "string",
+              "description": "CFn template Outputs のうち、競技者が当てる「正解」値の OutputKey (例: \"ParameterValue\")。Portal は本 outputKey の値を participant に出さず、submitted flag と一致するか backend で検証する。"
+            },
+            "points": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "正解時の獲得ポイント (1 deploy につき 1 回まで加算)。"
+            },
+            "hints": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "競技者画面に表示するヒント。複数行表示可。"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "endpoints", "pointsPerSuccess"],
+          "properties": {
+            "kind": { "const": "uptime" },
+            "endpoints": {
+              "type": "array",
+              "minItems": 1,
+              "description": "Health Check Lambda が定期 probe する endpoint 群。すべてが expectStatus に該当する HTTP 応答を返したら 1 回成功とみなす。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["outputKey", "path", "expectStatus"],
+                "properties": {
+                  "outputKey": {
+                    "type": "string",
+                    "description": "CFn Outputs のうち、URL を持つ OutputKey (例: \"FrontendUrl\")。"
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "上記 URL に追加する path (例: \"/\" や \"/healthz\")。"
+                  },
+                  "expectStatus": {
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 100, "maximum": 599 },
+                    "minItems": 1,
+                    "description": "期待する HTTP status code 群 (例: [200, 204])。"
+                  }
+                }
+              }
+            },
+            "pointsPerSuccess": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1 回の health check 成功あたりの獲得ポイント。"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/problems/challenges/hello-world/metadata.json
+++ b/problems/challenges/hello-world/metadata.json
@@ -6,11 +6,23 @@
   "status": "ready",
   "difficulty": 1,
   "estimatedDuration": "1 分",
-  "shortDescription": "TenkaCloud デプロイ機構の smoke test 用サンプル問題。SSM Parameter を 1 つだけ作る無害なスタック。",
-  "description": "deploy-battles.sh / Step Functions などのデプロイ経路を smoke test するためのサンプル。本問題は SSM Parameter (`/{NamePrefix}/hello`) を 1 つ作るだけで、EC2 / VPC / 公開エンドポイント / 脆弱性のあるソフトウェアは一切含まない。コストはゼロ。\n\n通常の競技には使わず、開発者が `make deploy-battles BATTLES=problems/challenges/hello-world` で deploy 機構の正しさを確かめるためだけに用意している。",
-  "tags": ["sample", "smoke-test", "ssm"],
+  "shortDescription": "Challenge / flag 提出形式の最小 sample。SSM Parameter Store に書かれた値を当てて入力すると 100 点獲得。",
+  "description": "Challenge / flag 提出形式の最小 sample。\n\nDeploy すると競技者の AWS アカウントに SSM Parameter `/{NamePrefix}/hello` が 1 つ作られる。値は `Hello from {NamePrefix}` の形。競技者は AWS Console / CLI でこの Parameter を読み出し、Participant Portal の入力欄に値を貼り付けて submit する。一致すれば +100 ポイント。\n\nコストはゼロ (SSM Standard tier、EC2 / VPC / 公開エンドポイントなし)。問題作成 / scoring engine の動作確認用。",
+  "tags": ["sample", "challenge", "flag", "ssm"],
   "exposedPorts": [{ "port": 1, "name": "(no public endpoint — SSM Parameter only, port unused)" }],
-  "learningGoals": ["TenkaCloud のデプロイ機構が end-to-end で動くことを smoke test で確認する"],
+  "learningGoals": [
+    "AWS Console / CLI で SSM Parameter Store の値を読み出す経路を体験する",
+    "TenkaCloud の deploy → flag 提出 → 加点 経路が end-to-end で動くことを確認する"
+  ],
   "cfnTemplate": "template.yaml",
-  "cfnParameters": {}
+  "cfnParameters": {},
+  "scoring": {
+    "kind": "flag",
+    "flagOutputKey": "ParameterValue",
+    "points": 100,
+    "hints": [
+      "AWS Console (SSM Parameter Store) または `aws ssm get-parameter --name /{NamePrefix}/hello` で値を読み出してください",
+      "値は `Hello from tc-...` の形式で、Stack 名 prefix を含みます"
+    ]
+  }
 }


### PR DESCRIPTION
## この PR が解決すること

ユーザー指摘「定期的にチェックが走ってポイントが加減されていく」end-to-end loop。
Challenge (flag 提出) と Battle (定期 uptime) 両形式の scoring loop を本 PR で立ち上げる。

合わせて PR #467 deferred 項目 (`describeStacks → stackOutputs を DDB に書く`) も解消。

## 動く end-to-end フロー

### Challenge (flag 提出)
1. operator が Hello World (Sample) を deploy → CodeBuild → describeStacks → DDB row に
   `stackOutputs` 格納 (= ParameterValue: `Hello from tc-...`)
2. operator が teamLoginKey を競技者に渡す
3. 競技者が Participant Portal にログイン → 自チームの ScorePanel と Flag 提出フォーム表示
4. 競技者が AWS Console で SSM Parameter `/{NamePrefix}/hello` を読む
5. 競技者が値をフォームに貼り付けて submit → backend が一致判定 → +100 pt
6. UI に `合計スコア: 100 pt` 表示、再提出は弾く

### Battle (uptime)
1. operator が `kind=uptime` の問題を deploy
2. EventBridge `rate(1 minute)` で HealthCheckLambda 起動
3. Lambda が DDB scan で `status=COMPLETE` の deployments を集める
4. 各 row の `metadata.scoring.endpoints` を Promise.all で並列 probe
5. すべて 2xx → `score += pointsPerSuccess`, 失敗 → `lastResult=fail`
6. 競技者の Portal は 5 秒 polling で score / lastResult を反映

## 主な変更点

- **`problems/SCHEMA.json`**: `scoring` section (oneOf flag/uptime) 追加
- **`problems/challenges/hello-world/metadata.json`**: Challenge flag 形式に書き換え
- **`infrastructure/lib/problem-deploy/deploy-create-state-machine.ts`**: describeStacks
  task 追加 + stackOutputs/stackId を DDB に書く
- **`infrastructure/lib/problem-deploy/handlers/shared/cfn-status.ts`**: parseStackOutputs
  を array / object 両形式対応
- **`infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts`** (新規):
  flag 提出採点ロジック (ConditionExpression で重複加算防止)
- **`infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts`**: ParticipantView
  に score / scoring info 露出 + flagOutputKey の strip (= 答え漏洩防止)
- **`infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts`** (新規):
  EventBridge Scheduler 駆動の uptime 採点 Lambda
- **`infrastructure/lib/problem-deploy/health-check-lambda.ts`** (新規): CDK construct
- **`infrastructure/lib/utils/discover-problems-catalog.ts`**: `discoverProblemsScoring`
  を追加して metadata.scoring を Lambda env に injection
- **`apps/participant-portal/src/pages/Home.tsx`**: ScorePanel + FlagSubmissionPanel UI
- **`apps/participant-portal/src/api/portal-client.ts`**: submitFlag client + score field

## 物理影響

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| ProblemDeployBackendStack | DescribeStack task (新規) | UPDATE | State Machine に CallAwsService task 1 個追加 |
| ProblemDeployBackendStack | State Machine IAM Role | UPDATE | cloudformation:DescribeStacks 権限追加 |
| ProblemDeployBackendStack | HealthCheckLambda + Schedule (新規) | CREATE | Lambda + EventBridge Rule + Lambda IAM Role |
| ProblemDeployBackendStack | Portal Lambda env | UPDATE | BATTLE_PROBLEMS_SCORING 追加、CORS allowed methods に POST 追加 |

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | 既存 \`parseStackOutputs\` 形式 (\`{key: value}\` map) | 既存 deploy 後の表示 | ✅ array / object 両対応に拡張、4 unit test で固定 |
| 2 | 既存 \`lookupByTeamLoginKey\` 戻り値 shape | participant-portal frontend | ✅ score / lastScoredAt / scoring が optional 追加。flagOutputKey の strip も新規だが、既存 deploy の stackOutputs に flagOutputKey と一致する key が無い限り無影響 |
| 3 | 既存 \`setDisplayTeamName\` 経路 | participant-portal | ✅ toView の signature に \`scoringMap = {}\` default を追加、後方互換 |
| 4 | DescribeStack task 失敗時 | deploy 経路 | ✅ markFailed を catch target に追加、deploy が CodeBuild 成功で終わっていても describe 失敗で FAILED 表示 (極稀ケース、operator 再 deploy で復旧) |
| 5 | EventBridge Schedule 起動回数 | コスト | ✅ rate(1 min) → 月 43200 invocation、Lambda free tier 1M 内 |
| 6 | Health Check Lambda が deploy 失敗 row を probe | Worker | ✅ status=COMPLETE filter を ScanCommand で適用、PENDING / FAILED / DELETING は probe 対象外 |

## Verification

- [x] \`make before-commit\` exit 0 (lint / typecheck / test 320 件 / validate-problems)
- [x] \`make typecheck\` 全 4 workspace exit 0
- [x] 新規 36 unit test pass (parseStackOutputs / submitFlag / discoverProblemsScoring / health-check-handler / participant-lookup with scoring)

## 既知の deferred (本 PR で解消しない)

- **hello-world-battle** (3-tier sample with Aurora Serverless v2 min=0) — Battle uptime
  scoring の sample。本 PR で uptime engine は動くが、それを使う sample 問題が無い。
  別 PR で \`problems/battles/hello-world-battle/\` を新規追加。task #169
- **問題 CRUD UI** (Application 管理者向け、問題作成 / 編集) — Phase 2 (ADR-003 実装)
- **Battle 攻撃時の即時通知** (lastResult=fail を participant に push) — task #166
- **Scoreboard / Leaderboard** (全チームのランキング表示) — Phase 2

## Rollback 手順

\`git revert <merge-sha>\` のみ。HealthCheckLambda + Schedule を含む新規 resource は
削除されるが、既存 DDB row は無影響 (新 column は optional)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flag submission capability allowing participants to submit solutions and earn points in the participant portal
  * Implemented automated health-check system that monitors uptime of deployed challenges and records scoring results
  * Enhanced participant view to display current score, last scoring timestamp, and scoring result status

* **Bug Fixes**
  * Improved stack output parsing to robustly handle multiple backend response formats

* **Documentation**
  * Updated problem schema to support flag-based and uptime-based scoring configurations for challenges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->