### PR TITLE
feat(problem): hello-world-battle — Battle uptime engine の最小 sample

### DIFF
--- a/problems/battles/hello-world-battle/metadata.json
+++ b/problems/battles/hello-world-battle/metadata.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "hello-world-battle",
+  "name": "Hello World Battle (Sample)",
+  "category": "Battle",
+  "status": "ready",
+  "difficulty": 1,
+  "estimatedDuration": "30 分",
+  "shortDescription": "Battle uptime scoring の最小 sample。EC2 上で nginx (frontend) + Python (API) を起動し、両方が 200 を返す間スコアが 1 分ごとに +100 加算。",
+  "description": "Battle uptime scoring の動作確認用 sample。\n\nDeploy すると競技者の AWS アカウントに次が作られる:\n  - 専用 VPC (10.99.0.0/16) + 公開 subnet + IGW\n  - EC2 t3.micro (Amazon Linux 2023, Public IP)\n    - nginx (port 80) で frontend ページを serve\n    - python3 http.server (port 8080) で `/healthz` API を serve\n\nHealth Check Lambda が 1 分ごとに FrontendUrl + ApiUrl を probe し、両方が 200 を返せば +100 pt 加算。どちらかが落ちている / 改ざんされていれば lastResult=fail として加算停止。\n\n## 攻撃 / 防御 (Battle 形式の体験)\n\n- **攻撃側** が同じ EC2 / Security Group を弄って frontend や API を停止すると、防御側のスコアが止まる\n- **防御側** は SSM Session Manager で SSH 不要で接続し、サービスを復旧する\n- いずれの操作も 1 EC2 内で完結するので、cross-tenant 影響なし (= 自テナント内の競技として安全)\n\n## コスト\n\n- EC2 t3.micro: AWS Free Tier 750 hr/月 (12 ヶ月) 内\n- VPC / IGW / SG: 無料\n- 競技 1 回 (~30 分) のコストは Free Tier 範囲ならゼロ",
+  "tags": ["sample", "battle", "uptime", "ec2", "nginx"],
+  "exposedPorts": [
+    { "port": 80, "name": "frontend (nginx)" },
+    { "port": 8080, "name": "api (python http.server)" }
+  ],
+  "learningGoals": [
+    "TenkaCloud の Battle uptime scoring engine が実 endpoint で動くことを確認する",
+    "EC2 + nginx + Python の最小 web stack で health check probe を受ける流れを体験する",
+    "SSM Session Manager で SSH 不要に接続し、サービスを start / stop する操作"
+  ],
+  "cfnTemplate": "template.yaml",
+  "cfnParameters": {},
+  "scoring": {
+    "kind": "uptime",
+    "endpoints": [
+      { "outputKey": "FrontendUrl", "path": "/", "expectStatus": [200] },
+      { "outputKey": "ApiUrl", "path": "/healthz", "expectStatus": [200] }
+    ],
+    "pointsPerSuccess": 100
+  }
+}

--- a/problems/battles/hello-world-battle/template.yaml
+++ b/problems/battles/hello-world-battle/template.yaml
@@ -1,0 +1,232 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud problem — hello-world-battle.
+  Minimal Battle uptime sample. Single EC2 (Amazon Linux 2023, t3.micro) running
+  nginx (port 80) and python3 http.server (port 8080). Both endpoints expected to
+  return 200; HealthCheckLambda probes them every 1 minute and grants +100 pt
+  when both succeed.
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    ConstraintDescription: >
+      `tc-{problemSlug}-{teamSlug}` 形式 (英小文字 / 数字 / ハイフン)。
+      application-admin-console の DeployForm が生成する prefix を渡す。
+    Description: >
+      すべてのリソース名に冠する共通 prefix。同一 Account / Region に複数チームの
+      スタックが共存しても衝突しないようにする。
+  AllowedCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+    Description: frontend (80) / api (8080) を許可する CIDR。
+  InstanceType:
+    Type: String
+    Default: t3.micro
+    AllowedValues:
+      - t3.micro
+      - t3.small
+    Description: EC2 インスタンスタイプ。t3.micro が AWS Free Tier 対象。
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
+    Description: SSM-backed Amazon Linux 2023 AMI (auto-resolved)。
+
+Resources:
+  # ----- VPC + Networking -----
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.99.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.99.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet"
+
+  Igw:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-igw"
+
+  IgwAttach:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref Igw
+
+  Rt:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rt"
+
+  RtRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IgwAttach
+    Properties:
+      RouteTableId: !Ref Rt
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref Igw
+
+  RtAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref Rt
+      SubnetId: !Ref PublicSubnet
+
+  # ----- Security Group -----
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: !Sub "${NamePrefix} hello-world-battle access"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref AllowedCidr
+          Description: frontend (nginx)
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          CidrIp: !Ref AllowedCidr
+          Description: api (python http.server)
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-sg"
+
+  # ----- IAM (SSM Session Manager only — for ops debug + Battle 体験用) -----
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-instance-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub "${NamePrefix}-instance-profile"
+      Roles:
+        - !Ref InstanceRole
+
+  # ----- EC2 -----
+  Ec2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref Sg
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2"
+        - Key: TenkaCloud:Problem
+          Value: hello-world-battle
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+          dnf update -y
+          dnf install -y nginx python3
+
+          # ----- frontend (nginx, port 80) -----
+          cat > /usr/share/nginx/html/index.html <<HTML
+          <!doctype html>
+          <html lang="ja"><head><meta charset="utf-8">
+          <title>${NamePrefix}</title></head>
+          <body style="font-family: system-ui; padding: 2em">
+          <h1>Hello from ${NamePrefix} frontend</h1>
+          <p>このページが 200 を返している間、HealthCheckLambda がスコアを加点します。</p>
+          <p>Battle 体験: 攻撃側が <code>systemctl stop nginx</code> したらスコアが止まります。</p>
+          </body></html>
+          HTML
+          systemctl enable --now nginx
+
+          # ----- API (python http.server, port 8080) -----
+          mkdir -p /opt/tenkacloud
+          cat > /opt/tenkacloud/api.py <<'PY'
+          from http.server import HTTPServer, BaseHTTPRequestHandler
+          import os, json
+          NAME_PREFIX = os.environ.get("NAME_PREFIX", "unknown")
+          class H(BaseHTTPRequestHandler):
+              def do_GET(self):
+                  if self.path == "/healthz":
+                      self.send_response(200)
+                      self.send_header("Content-type", "application/json")
+                      self.end_headers()
+                      self.wfile.write(json.dumps({"ok": True, "namePrefix": NAME_PREFIX}).encode())
+                      return
+                  self.send_response(404)
+                  self.send_header("Content-type", "text/plain")
+                  self.end_headers()
+                  self.wfile.write(b"not found")
+              def log_message(self, *args, **kwargs):
+                  pass
+          if __name__ == "__main__":
+              HTTPServer(("0.0.0.0", 8080), H).serve_forever()
+          PY
+
+          cat > /etc/systemd/system/tenkacloud-api.service <<UNIT
+          [Unit]
+          Description=TenkaCloud hello-world-battle API
+          After=network.target
+          [Service]
+          Environment=NAME_PREFIX=${NamePrefix}
+          ExecStart=/usr/bin/python3 /opt/tenkacloud/api.py
+          Restart=always
+          RestartSec=3
+          [Install]
+          WantedBy=multi-user.target
+          UNIT
+          systemctl daemon-reload
+          systemctl enable --now tenkacloud-api
+
+Outputs:
+  FrontendUrl:
+    Description: 参加者向け frontend (nginx) URL。HealthCheck の probe 対象。
+    Value: !Sub "http://${Ec2.PublicDnsName}"
+  ApiUrl:
+    Description: 参加者向け API (python http.server) URL。/healthz が probe 対象。
+    Value: !Sub "http://${Ec2.PublicDnsName}:8080"
+  InstanceId:
+    Description: SSM Session Manager で SSH 不要に接続するための EC2 InstanceId。
+    Value: !Ref Ec2
+  SsmStartSessionCommand:
+    Description: 接続用 aws cli コマンド (Battle 体験で攻撃 / 防御に使う)。
+    Value: !Sub "aws ssm start-session --target ${Ec2}"
+  NamePrefix:
+    Description: スタック共通 prefix (deploy script から渡された値)。
+    Value: !Ref NamePrefix


### PR DESCRIPTION
## この PR が解決すること

PR #469 で立ち上げた Battle uptime scoring engine を、実 deploy で end-to-end 動作確認する最小 sample。

## 構成

- 専用 VPC (10.99.0.0/16) + 公開 subnet + IGW
- EC2 t3.micro (Amazon Linux 2023, AWS Free Tier 対象)
  - nginx (port 80) — frontend HTML page を serve
  - python3 http.server (port 8080, systemd service) — `/healthz` を 200 で返す
- IAM Role: SSM Session Manager (SSH 不要、Battle 体験の攻撃 / 防御で使う)

## scoring

\`metadata.json\` の \`scoring\`:

\`\`\`json
{
  "kind": "uptime",
  "endpoints": [
    { "outputKey": "FrontendUrl", "path": "/", "expectStatus": [200] },
    { "outputKey": "ApiUrl", "path": "/healthz", "expectStatus": [200] }
  ],
  "pointsPerSuccess": 100
}
\`\`\`

HealthCheckLambda が 1 分ごとに両 endpoint を probe し、両方 2xx なら +100 pt 加算、
どちらか落ちていれば lastResult=fail で加算停止。

## Battle 体験

- **攻撃側**: SSM Session で接続 → \`systemctl stop nginx\` or \`systemctl stop tenkacloud-api\` でサービス停止 → 防御側のスコアが止まる
- **防御側**: 同じく SSM Session で接続 → \`systemctl start nginx\` 等で復旧 → スコア再開
- 1 EC2 内完結なので cross-tenant 影響なし

## 物理影響

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| (deploy 時の per-team CFn) | VPC / EC2 / SG / IAM Role / Subnet 等 | CREATE | 競技者 AWS account 上に新規作成。Free Tier 内 |
| 既存 deploy 経路 | (なし) | NO-OP | TenkaCloud 側の Stack 構成不変 |

\`metadata.json\` 配置だけで PR #465 の auto-discovery (frontend Vite glob + backend CDK synth) が拾うので、wiring 追加なし。

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | 既存 problemsCatalog の auto-discover | bin/infrastructure.ts | ✅ 3 problem (hello-world / security-battle-royale / hello-world-battle) が catalog に入る |
| 2 | frontend カタログ表示 | application-admin-console | ✅ Vite glob が 3 件取り込み、Cards で表示される |
| 3 | scoring engine (HealthCheckLambda) | uptime engine | ✅ \`scoring.kind=uptime\` 設定が \`BATTLE_PROBLEMS_SCORING\` env に渡る |
| 4 | EventBridge Schedule 起動回数 | コスト | ✅ 既存 \`rate(1 minute)\` 不変 |

## Verification

- [x] \`make before-commit\` exit 0 (lint / typecheck / test 328 件 / validate-problems 3 件)
- [x] \`make validate-problems\` で metadata.json + scoring section が SCHEMA に整合
- [ ] (merge 後実 AWS で確認) UI Deploy → CodeBuild → describeStacks → DDB stackOutputs に FrontendUrl + ApiUrl 反映 → 1 分後に Health Check Lambda が +100 pt 加算

## Rollback 手順

\`git revert <merge-sha>\` のみ。\`problems/battles/hello-world-battle/\` ディレクトリ削除のみで auto-discovery が外れる。CDK 構成不変。

## 既知の deferred

- **本格 3-tier (S3 + EC2 + Aurora Serverless v2 min=0)** — 本 sample は 1-EC2 で frontend / API 兼ねる最小構成。RDB 込みの 3-tier sample は別 problem で追加 (Phase 2)
- **Battle 攻撃時の即時通知 UX** — task #166 で別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Hello World Battle," a new beginner-level battle scenario featuring AWS infrastructure deployment with load balancing and health endpoint monitoring. Includes uptime-based scoring and hands-on learning objectives for cloud configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->