### PR TITLE
feat(problem-detail): 問題ごとの deploy 一覧 + 削除を ProblemDetail に統合

### DIFF
--- a/apps/application-admin-console/src/pages/Deployments.tsx
+++ b/apps/application-admin-console/src/pages/Deployments.tsx
@@ -16,10 +16,12 @@ import {
   listAllDeployments,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
-
-const POLL_INTERVAL_MS = 10_000;
-
-const EMPTY_ITEMS: readonly DeploymentSummary[] = [];
+import {
+  DEPLOYMENT_LIST_PAGE_SIZE,
+  DEPLOYMENT_LIST_POLL_INTERVAL_MS,
+  deploymentsChanged,
+  EMPTY_DEPLOYMENT_ITEMS,
+} from "../utils/deployments";
 
 function buildColumnDefinitions(
   navigate: NavigateFunction,
@@ -68,28 +70,6 @@ function buildColumnDefinitions(
   ];
 }
 
-/** 行が変わっていれば true。同 jobId の status / updatedAt / displayTeamName を比較する。 */
-function deploymentsChanged(
-  prev: readonly DeploymentSummary[],
-  next: readonly DeploymentSummary[],
-): boolean {
-  if (prev.length !== next.length) return true;
-  for (let i = 0; i < next.length; i++) {
-    const a = prev[i];
-    const b = next[i];
-    if (!a || !b) return true;
-    if (
-      a.jobId !== b.jobId ||
-      a.status !== b.status ||
-      a.updatedAt !== b.updatedAt ||
-      a.displayTeamName !== b.displayTeamName
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function DeploymentsPage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
   const navigate = useNavigate();
@@ -104,7 +84,7 @@ export function DeploymentsPage({ config }: { config: AppConfig }) {
       if (!apiClient) return;
       if (showSpinner) setManualRefreshing(true);
       try {
-        const res = await listAllDeployments(apiClient, { limit: 50 });
+        const res = await listAllDeployments(apiClient, { limit: DEPLOYMENT_LIST_PAGE_SIZE });
         setItems((prev) => (prev && !deploymentsChanged(prev, res.items) ? prev : res.items));
         setError(null);
       } catch (err) {
@@ -123,7 +103,7 @@ export function DeploymentsPage({ config }: { config: AppConfig }) {
       await fetchOnce();
     };
     void tick();
-    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    const interval = setInterval(tick, DEPLOYMENT_LIST_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(interval);
@@ -161,7 +141,7 @@ export function DeploymentsPage({ config }: { config: AppConfig }) {
       </Header>
 
       <Table
-        items={items ?? EMPTY_ITEMS}
+        items={items ?? EMPTY_DEPLOYMENT_ITEMS}
         columnDefinitions={columnDefinitions}
         empty={
           <Box textAlign="center" color="inherit" padding="xxl">

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -5,9 +5,20 @@ import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table, { type TableProps } from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Navigate, type NavigateFunction, useNavigate, useParams } from "react-router";
+import { useApiClient } from "../api/client";
+import {
+  DEPLOYMENT_STATUS_INDICATOR,
+  type DeploymentSummary,
+  deleteDeployment,
+  listDeployments,
+} from "../api/deploy-client";
 import { DeployFormModal } from "../components/DeployForm";
 import type { AppConfig } from "../config";
 import { findProblem } from "../data/problems";
@@ -118,6 +129,8 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
         </SpaceBetween>
       </Container>
 
+      <ProblemDeploymentsSection config={config} problemId={problem.id} />
+
       <DeployFormModal
         config={config}
         problemId={problem.id}
@@ -126,6 +139,210 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
         onDismiss={() => setConfirmingDeploy(false)}
       />
     </SpaceBetween>
+  );
+}
+
+const POLL_INTERVAL_MS = 10_000;
+const EMPTY_ITEMS: readonly DeploymentSummary[] = [];
+
+function deploymentsChanged(
+  prev: readonly DeploymentSummary[],
+  next: readonly DeploymentSummary[],
+): boolean {
+  if (prev.length !== next.length) return true;
+  for (let i = 0; i < next.length; i++) {
+    const a = prev[i];
+    const b = next[i];
+    if (!a || !b) return true;
+    if (
+      a.jobId !== b.jobId ||
+      a.status !== b.status ||
+      a.updatedAt !== b.updatedAt ||
+      a.displayTeamName !== b.displayTeamName
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function buildColumns(
+  navigate: NavigateFunction,
+  onAskDelete: (item: DeploymentSummary) => void,
+): TableProps.ColumnDefinition<DeploymentSummary>[] {
+  return [
+    {
+      id: "team",
+      header: "チーム",
+      cell: (item) => (
+        <Link
+          fontSize="body-m"
+          href={`/deployments/${encodeURIComponent(item.jobId)}`}
+          onFollow={(e) => {
+            e.preventDefault();
+            navigate(`/deployments/${encodeURIComponent(item.jobId)}`);
+          }}
+        >
+          {item.displayTeamName ?? item.teamName}
+        </Link>
+      ),
+    },
+    {
+      id: "status",
+      header: "ステータス",
+      cell: (item) => (
+        <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>
+          {item.status}
+        </StatusIndicator>
+      ),
+    },
+    {
+      id: "namePrefix",
+      header: "Stack 名",
+      cell: (item) => <code>{item.namePrefix}</code>,
+    },
+    {
+      id: "createdAt",
+      header: "作成",
+      cell: (item) => item.createdAt,
+    },
+    {
+      id: "actions",
+      header: "操作",
+      cell: (item) => (
+        <Button
+          variant="normal"
+          iconName="delete-marker"
+          disabled={item.status === "DELETING" || item.status === "DELETED"}
+          onClick={() => onAskDelete(item)}
+        >
+          削除
+        </Button>
+      ),
+    },
+  ];
+}
+
+/**
+ * ProblemDetail に埋め込むこの問題の deploy 一覧。tenant scope の `listDeployments(problemId)`
+ * を 10 秒 polling し、status / 削除操作を operator が直接管理できるようにする。
+ */
+function ProblemDeploymentsSection({
+  config,
+  problemId,
+}: {
+  config: AppConfig;
+  problemId: string;
+}) {
+  const apiClient = useApiClient(config);
+  const navigate = useNavigate();
+  const [items, setItems] = useState<readonly DeploymentSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [askDelete, setAskDelete] = useState<DeploymentSummary | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    if (!apiClient) return;
+    try {
+      const res = await listDeployments(apiClient, problemId, { limit: 50 });
+      setItems((prev) => (prev && !deploymentsChanged(prev, res.items) ? prev : res.items));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [apiClient, problemId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await fetchOnce();
+    };
+    void tick();
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [fetchOnce]);
+
+  const columns = useMemo(() => buildColumns(navigate, (item) => setAskDelete(item)), [navigate]);
+
+  const handleDelete = async () => {
+    if (!apiClient || !askDelete) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteDeployment(apiClient, askDelete.jobId);
+      setAskDelete(null);
+      await fetchOnce();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={`この問題の進行中 / 過去のデプロイジョブ一覧。`}>
+          デプロイ状況
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {error && (
+          <Alert type="error" header="一覧の取得に失敗しました">
+            {error}
+          </Alert>
+        )}
+        <Table
+          items={items ?? EMPTY_ITEMS}
+          columnDefinitions={columns}
+          loading={items === null && !error}
+          loadingText="読み込み中"
+          empty={
+            <Box textAlign="center" color="inherit" padding="xxl">
+              この問題のデプロイ履歴はまだありません。
+            </Box>
+          }
+        />
+      </SpaceBetween>
+
+      <Modal
+        visible={askDelete !== null}
+        onDismiss={() => setAskDelete(null)}
+        header={askDelete ? `「${askDelete.teamName}」のデプロイを削除` : ""}
+        size="medium"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setAskDelete(null)} disabled={deleting}>
+                キャンセル
+              </Button>
+              <Button variant="primary" loading={deleting} onClick={handleDelete}>
+                削除する
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        {askDelete && (
+          <SpaceBetween size="s">
+            <Box>
+              競技アカウント (<code>{askDelete.awsAccountId}</code> / {askDelete.region}) で
+              起動中の CloudFormation Stack <code>{askDelete.namePrefix}</code> を削除します。
+            </Box>
+            <Box variant="small" color="text-status-warning">
+              この操作は取り消せません。実際の削除は次の周期で実行されます。
+            </Box>
+            {deleteError && <Alert type="error">{deleteError}</Alert>}
+          </SpaceBetween>
+        )}
+      </Modal>
+    </Container>
   );
 }
 

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -22,6 +22,12 @@ import {
 import { DeployFormModal } from "../components/DeployForm";
 import type { AppConfig } from "../config";
 import { findProblem } from "../data/problems";
+import {
+  DEPLOYMENT_LIST_PAGE_SIZE,
+  DEPLOYMENT_LIST_POLL_INTERVAL_MS,
+  deploymentsChanged,
+  EMPTY_DEPLOYMENT_ITEMS,
+} from "../utils/deployments";
 
 const DIFFICULTY_LABEL = {
   1: "入門",
@@ -142,30 +148,6 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
   );
 }
 
-const POLL_INTERVAL_MS = 10_000;
-const EMPTY_ITEMS: readonly DeploymentSummary[] = [];
-
-function deploymentsChanged(
-  prev: readonly DeploymentSummary[],
-  next: readonly DeploymentSummary[],
-): boolean {
-  if (prev.length !== next.length) return true;
-  for (let i = 0; i < next.length; i++) {
-    const a = prev[i];
-    const b = next[i];
-    if (!a || !b) return true;
-    if (
-      a.jobId !== b.jobId ||
-      a.status !== b.status ||
-      a.updatedAt !== b.updatedAt ||
-      a.displayTeamName !== b.displayTeamName
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function buildColumns(
   navigate: NavigateFunction,
   onAskDelete: (item: DeploymentSummary) => void,
@@ -245,7 +227,9 @@ function ProblemDeploymentsSection({
   const fetchOnce = useCallback(async () => {
     if (!apiClient) return;
     try {
-      const res = await listDeployments(apiClient, problemId, { limit: 50 });
+      const res = await listDeployments(apiClient, problemId, {
+        limit: DEPLOYMENT_LIST_PAGE_SIZE,
+      });
       setItems((prev) => (prev && !deploymentsChanged(prev, res.items) ? prev : res.items));
       setError(null);
     } catch (err) {
@@ -260,7 +244,7 @@ function ProblemDeploymentsSection({
       await fetchOnce();
     };
     void tick();
-    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    const interval = setInterval(tick, DEPLOYMENT_LIST_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(interval);
@@ -299,7 +283,7 @@ function ProblemDeploymentsSection({
           </Alert>
         )}
         <Table
-          items={items ?? EMPTY_ITEMS}
+          items={items ?? EMPTY_DEPLOYMENT_ITEMS}
           columnDefinitions={columns}
           loading={items === null && !error}
           loadingText="読み込み中"

--- a/apps/application-admin-console/src/utils/deployments.ts
+++ b/apps/application-admin-console/src/utils/deployments.ts
@@ -1,0 +1,42 @@
+import type { DeploymentSummary } from "../api/deploy-client";
+
+/** Polling list pages の polling 間隔。`Deployments.tsx` / `ProblemDetail.tsx` 両方で共有。 */
+export const DEPLOYMENT_LIST_POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Polling 結果の安定 reference 用 frozen const。`items ?? EMPTY_DEPLOYMENT_ITEMS` で
+ * Cloudscape `<Table>` の prop を毎 render 新規確保しないようにする。
+ */
+export const EMPTY_DEPLOYMENT_ITEMS: readonly DeploymentSummary[] = Object.freeze([]);
+
+/** 1 ページの最大件数。MVP-1 規模 (~10 deployments) は 1 ページで収まる。 */
+export const DEPLOYMENT_LIST_PAGE_SIZE = 50;
+
+/**
+ * Polling で取得した `DeploymentSummary[]` の前回 / 今回が「意味的に同じ」なら true。
+ * `setItems((prev) => deploymentsChanged(prev, next) ? next : prev)` の guard で
+ * polling tick の no-op render を抑制する。
+ *
+ * 比較対象は jobId / status / updatedAt / displayTeamName のみ。
+ * stackOutputs / score 等は今のところ list 表示で使わないので除外。
+ */
+export function deploymentsChanged(
+  prev: readonly DeploymentSummary[],
+  next: readonly DeploymentSummary[],
+): boolean {
+  if (prev.length !== next.length) return true;
+  for (let i = 0; i < next.length; i++) {
+    const a = prev[i];
+    const b = next[i];
+    if (!a || !b) return true;
+    if (
+      a.jobId !== b.jobId ||
+      a.status !== b.status ||
+      a.updatedAt !== b.updatedAt ||
+      a.displayTeamName !== b.displayTeamName
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/application-admin-console/test/utils/deployments.test.ts
+++ b/apps/application-admin-console/test/utils/deployments.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { DeploymentSummary } from "../../src/api/deploy-client";
+import {
+  DEPLOYMENT_LIST_PAGE_SIZE,
+  DEPLOYMENT_LIST_POLL_INTERVAL_MS,
+  deploymentsChanged,
+  EMPTY_DEPLOYMENT_ITEMS,
+} from "../../src/utils/deployments";
+
+/**
+ * `deploymentsChanged` は polling tick の no-op render guard。`Deployments.tsx` と
+ * `ProblemDetail.tsx` 両 page から共有される core ロジック。
+ */
+
+const baseRow = (over: Partial<DeploymentSummary> = {}): DeploymentSummary => ({
+  jobId: "01HABC",
+  problemId: "hello-world",
+  tenantId: "tenant-acme",
+  awsAccountId: "999999999999",
+  region: "ap-northeast-1",
+  teamName: "alpha",
+  namePrefix: "tc-hello-world-alpha",
+  status: "COMPLETE",
+  createdAt: "2026-05-05T10:00:00.000Z",
+  updatedAt: "2026-05-05T10:01:00.000Z",
+  expiresAt: 9_999_999_999,
+  ...over,
+});
+
+describe("deploymentsChanged", () => {
+  it("空 → 空 は false", () => {
+    expect(deploymentsChanged([], [])).toBe(false);
+  });
+
+  it("長さが異なれば true", () => {
+    expect(deploymentsChanged([baseRow()], [])).toBe(true);
+    expect(deploymentsChanged([], [baseRow()])).toBe(true);
+    expect(deploymentsChanged([baseRow()], [baseRow(), baseRow()])).toBe(true);
+  });
+
+  it("同じ shape なら false (= polling 結果が変わっていない)", () => {
+    expect(deploymentsChanged([baseRow()], [baseRow()])).toBe(false);
+  });
+
+  it("jobId が異なれば true", () => {
+    expect(deploymentsChanged([baseRow({ jobId: "A" })], [baseRow({ jobId: "B" })])).toBe(true);
+  });
+
+  it("status が変わっていれば true", () => {
+    expect(
+      deploymentsChanged([baseRow({ status: "PENDING" })], [baseRow({ status: "COMPLETE" })]),
+    ).toBe(true);
+  });
+
+  it("updatedAt が変わっていれば true", () => {
+    expect(
+      deploymentsChanged(
+        [baseRow({ updatedAt: "2026-05-05T10:00:00.000Z" })],
+        [baseRow({ updatedAt: "2026-05-05T10:05:00.000Z" })],
+      ),
+    ).toBe(true);
+  });
+
+  it("displayTeamName の有無 / 値変更で true (= 競技者がチーム名を設定したケース)", () => {
+    expect(
+      deploymentsChanged(
+        [baseRow({ displayTeamName: undefined })],
+        [baseRow({ displayTeamName: "わたしのチーム" })],
+      ),
+    ).toBe(true);
+    expect(
+      deploymentsChanged(
+        [baseRow({ displayTeamName: "before" })],
+        [baseRow({ displayTeamName: "after" })],
+      ),
+    ).toBe(true);
+  });
+
+  it("createdAt のみ変わっていても false (= 比較対象外)", () => {
+    expect(
+      deploymentsChanged(
+        [baseRow({ createdAt: "2026-05-05T10:00:00.000Z" })],
+        [baseRow({ createdAt: "2026-05-05T11:00:00.000Z" })],
+      ),
+    ).toBe(false);
+  });
+
+  it("score / stackOutputs などの未比較フィールドは false", () => {
+    expect(
+      deploymentsChanged(
+        [baseRow({ stackOutputs: '{"FrontendUrl":"http://a"}' })],
+        [baseRow({ stackOutputs: '{"FrontendUrl":"http://b"}' })],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("constants", () => {
+  it("page size と polling 間隔の妥当性", () => {
+    expect(DEPLOYMENT_LIST_PAGE_SIZE).toBe(50);
+    expect(DEPLOYMENT_LIST_POLL_INTERVAL_MS).toBe(10_000);
+  });
+
+  it("EMPTY_DEPLOYMENT_ITEMS は frozen で同 reference を再利用 (Table prop 安定化)", () => {
+    expect(EMPTY_DEPLOYMENT_ITEMS).toEqual([]);
+    expect(EMPTY_DEPLOYMENT_ITEMS).toBe(EMPTY_DEPLOYMENT_ITEMS);
+    expect(Object.isFrozen(EMPTY_DEPLOYMENT_ITEMS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## この PR が解決すること

ユーザー指摘「Application 管理者画面で問題のデプロイ / dedeploy CRUD を完結させたい」 (#162)。

ProblemDetail 画面に当該問題のデプロイ一覧 + 削除操作を統合し、operator が 1 画面で CRUD を完結できるようにする。

## 統合後の operator 体験

| 操作 | 入口 |
|---|---|
| **Create** (deploy) | 画面上部の「競技アカウントへデプロイ」 (= 既存 DeployFormModal) |
| **Read** (この問題の一覧) | **新規** `<ProblemDeploymentsSection>` table |
| **Read** (詳細) | 行 click で `/deployments/:jobId` 詳細画面 |
| **Delete** (dedeploy) | **新規** 行ごとの「削除」ボタン → confirmation modal |

サイドバー「デプロイ履歴」(全テナント tenant-wide) は引き続き有効。**問題ごとの deploy 状況** はこの section から見られるようになり、両経路で重複する情報なし。

## 実装

`apps/application-admin-console/src/pages/ProblemDetail.tsx` に新 component `<ProblemDeploymentsSection>`:

- tenant scope の `listDeployments(client, problemId)` を 10 秒 polling
- Cloudscape `<Table>`: チーム / ステータス / Stack 名 / 作成日時 / 操作
- 削除ボタン → confirmation modal → `deleteDeployment(jobId)` 呼び出し
- DELETING / DELETED 行の削除ボタンは disabled
- polling 結果が unchanged なら `setItems` skip (PR #469 /simplify の \`viewIsUnchanged\` パターン)

## 物理影響

なし。frontend のみ、backend API (\`GET /problems/:id/deployments\` / \`DELETE /deployments/:jobId\`) は既存。

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | 既存 ProblemDetail layout | application-admin-console | ✅ 末尾に section 追加、既存 section 不変 |
| 2 | DeployFormModal | application-admin-console | ✅ 不変 |
| 3 | listDeployments / deleteDeployment | backend | ✅ 既存呼び出し、新 endpoint なし |
| 4 | polling no-op render | UI | ✅ deploymentsChanged guard で抑制 |

## Verification

- [x] \`make before-commit\` exit 0 (lint / typecheck / test 328 件 / validate-problems)
- [ ] (merge 後実 AWS) Hello World deploy → ProblemDetail で行が出る、削除で teardown される

## Rollback 手順

\`git revert <merge-sha>\` のみ。

## 既知の deferred

- **問題作成 / 編集 UI** (新規 problem を UI から登録) — Phase 2 (ADR-003 実装と同 PR)
- **Bulk delete** — 複数選択 + 一括削除。MVP は per-row で十分

🤖 Generated with [Claude Code](https://claude.com/claude-code)