### PR TITLE
fix(kms): KMS Key の削除待機期間を 30 → 7 日に短縮 (make destroy 後の課金抑制)

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -8,6 +8,7 @@ import { AdminConsoleHostingStack } from "../lib/admin-console-hosting";
 import { BootstrapTemplateStack } from "../lib/bootstrap-template/bootstrap-template-stack";
 import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
+import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
 import { getEnv } from "../lib/helper-functions";
 import type { ParticipantPortalRuntimeConfig } from "../lib/problem-deploy/participant-portal-hosting";
@@ -31,6 +32,10 @@ if (fs.existsSync(envFilePath)) {
 }
 
 const app = new cdk.App();
+
+// 全 stack の KMS Key 削除待機期間を default 30 日 → 7 日に短縮 (`make destroy` 後の
+// 課金期間を縮める)。SBT が内部生成する CodeBuild EncryptionKey 等も含む。
+cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow());
 
 // required input parameters
 if (!process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL) {

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -108,9 +108,17 @@ const dynamoWriteCapacity = Number(
   process.env.CDK_PARAM_DYNAMODB_WRITE_CAPACITY || ddb?.writeCapacity || 1,
 );
 // KMS Key 削除スケジューリング後の待機期間 (日)。AWS KMS の許容範囲は 7〜30。
+//
+//   - config.json: `kmsConfig.pendingWindowInDays`
+//   - .env       : `KMS_PENDING_WINDOW_DAYS` で override (config.json の placeholder 経由)
+//   - 後方互換  : `CDK_PARAM_KMS_PENDING_WINDOW_DAYS` env も尊重 (set されていれば config 値より優先)
+//
 // `make destroy` 後の課金期間を最小化するため dev / training は default 7。production
-// で監査要件があれば env で 30 を指定して override する。default 発生箇所はここ 1 箇所。
-const kmsPendingWindowInDays = Number(process.env.CDK_PARAM_KMS_PENDING_WINDOW_DAYS || 7);
+// で監査要件があれば env / config で 14〜30 を指定して override する。default 発生箇所
+// は config.json の `${KMS_PENDING_WINDOW_DAYS:-7}` placeholder の 1 箇所。
+const kmsPendingWindowInDays = Number(
+  process.env.CDK_PARAM_KMS_PENDING_WINDOW_DAYS || config?.kmsConfig?.pendingWindowInDays || 7,
+);
 
 // 全 stack の KMS Key 削除待機期間を上記値に揃える Aspect を App scope に apply。
 // SBT が内部生成する CodeBuild EncryptionKey 等も含む全 `AWS::KMS::Key` が対象。

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -33,10 +33,6 @@ if (fs.existsSync(envFilePath)) {
 
 const app = new cdk.App();
 
-// 全 stack の KMS Key 削除待機期間を default 30 日 → 7 日に短縮 (`make destroy` 後の
-// 課金期間を縮める)。SBT が内部生成する CodeBuild EncryptionKey 等も含む。
-cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow());
-
 // required input parameters
 if (!process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL) {
   throw new Error("Please provide system admin email");
@@ -111,6 +107,14 @@ const dynamoReadCapacity = Number(
 const dynamoWriteCapacity = Number(
   process.env.CDK_PARAM_DYNAMODB_WRITE_CAPACITY || ddb?.writeCapacity || 1,
 );
+// KMS Key 削除スケジューリング後の待機期間 (日)。AWS KMS の許容範囲は 7〜30。
+// `make destroy` 後の課金期間を最小化するため dev / training は default 7。production
+// で監査要件があれば env で 30 を指定して override する。default 発生箇所はここ 1 箇所。
+const kmsPendingWindowInDays = Number(process.env.CDK_PARAM_KMS_PENDING_WINDOW_DAYS || 7);
+
+// 全 stack の KMS Key 削除待機期間を上記値に揃える Aspect を App scope に apply。
+// SBT が内部生成する CodeBuild EncryptionKey 等も含む全 `AWS::KMS::Key` が対象。
+cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(kmsPendingWindowInDays));
 // Cognito UserPool domain は region globally unique なので env / tenantId / accountId を
 // 入れて衝突回避する (#83)。AdminConsoleHostingStack 用にも同じ値が要るので前倒しで定義。
 const awsRegion = process.env.CDK_PARAM_AWS_REGION ?? process.env.CDK_DEFAULT_REGION ?? "";

--- a/infrastructure/environments/development/config.json
+++ b/infrastructure/environments/development/config.json
@@ -33,5 +33,8 @@
     "billingMode": "${DYNAMODB_BILLING_MODE:-PROVISIONED}",
     "readCapacity": "${DYNAMODB_READ_CAPACITY:-1}",
     "writeCapacity": "${DYNAMODB_WRITE_CAPACITY:-1}"
+  },
+  "kmsConfig": {
+    "pendingWindowInDays": "${KMS_PENDING_WINDOW_DAYS:-7}"
   }
 }

--- a/infrastructure/environments/production/config.json
+++ b/infrastructure/environments/production/config.json
@@ -21,5 +21,8 @@
     "billingMode": "${DYNAMODB_BILLING_MODE:-PROVISIONED}",
     "readCapacity": "${DYNAMODB_READ_CAPACITY:-1}",
     "writeCapacity": "${DYNAMODB_WRITE_CAPACITY:-1}"
+  },
+  "kmsConfig": {
+    "pendingWindowInDays": "${KMS_PENDING_WINDOW_DAYS:-7}"
   }
 }

--- a/infrastructure/lib/cdk-aspect/kms-key-short-pending-window.ts
+++ b/infrastructure/lib/cdk-aspect/kms-key-short-pending-window.ts
@@ -1,0 +1,24 @@
+import type { IAspect } from "aws-cdk-lib";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+import type { IConstruct } from "constructs";
+
+/**
+ * 全ての KMS Key (`AWS::KMS::Key`) の `PendingWindowInDays` を 7 に揃える Aspect。
+ *
+ * AWS KMS は key 削除をスケジュールしてから実削除までの待機期間が必須で、許容範囲は
+ * 7〜30 日。default 30 日のまま `make destroy` を実行すると、削除予定の key が 30 日間
+ * "Pending Deletion" 状態のまま AWS Free Tier 枠 ($1/key/月) を消費し続ける。
+ *
+ * 待機期間を最短 7 日に短縮することで、誤削除時の rollback 余地を残しつつ teardown 後の
+ * 課金期間を縮める。training / demo 用途の TenkaCloud では誤削除しても再 deploy で
+ * 復旧可能なため 7 日で十分。
+ *
+ * 対象は CDK / SBT (`@cdklabs/sbt-aws`) が内部的に自動生成する KMS Key (CodeBuild の
+ * EncryptionKey 等) を含む全ての `AWS::KMS::Key`。
+ */
+export class KmsKeyShortPendingWindow implements IAspect {
+  public visit(node: IConstruct): void {
+    if (!(node instanceof CfnKey)) return;
+    node.pendingWindowInDays = 7;
+  }
+}

--- a/infrastructure/lib/cdk-aspect/kms-key-short-pending-window.ts
+++ b/infrastructure/lib/cdk-aspect/kms-key-short-pending-window.ts
@@ -2,23 +2,44 @@ import type { IAspect } from "aws-cdk-lib";
 import { CfnKey } from "aws-cdk-lib/aws-kms";
 import type { IConstruct } from "constructs";
 
+/** AWS KMS 削除待機期間の許容範囲 (= AWS 仕様)。 */
+export const KMS_PENDING_WINDOW_MIN_DAYS = 7;
+export const KMS_PENDING_WINDOW_MAX_DAYS = 30;
+
 /**
- * 全ての KMS Key (`AWS::KMS::Key`) の `PendingWindowInDays` を 7 に揃える Aspect。
+ * 全ての KMS Key (`AWS::KMS::Key`) の `PendingWindowInDays` を caller 指定値に揃える Aspect。
  *
  * AWS KMS は key 削除をスケジュールしてから実削除までの待機期間が必須で、許容範囲は
  * 7〜30 日。default 30 日のまま `make destroy` を実行すると、削除予定の key が 30 日間
  * "Pending Deletion" 状態のまま AWS Free Tier 枠 ($1/key/月) を消費し続ける。
  *
- * 待機期間を最短 7 日に短縮することで、誤削除時の rollback 余地を残しつつ teardown 後の
- * 課金期間を縮める。training / demo 用途の TenkaCloud では誤削除しても再 deploy で
- * 復旧可能なため 7 日で十分。
+ * caller (`bin/infrastructure.ts`) が env / config から値を渡し、stack 横断で適用する。
+ * dev / training は最短 7、production は監査要件に応じて伸ばすなど、環境別に調整可能。
  *
  * 対象は CDK / SBT (`@cdklabs/sbt-aws`) が内部的に自動生成する KMS Key (CodeBuild の
  * EncryptionKey 等) を含む全ての `AWS::KMS::Key`。
+ *
+ * 設計: default 値はコンストラクタに入れない。env 由来の値が来ているかどうかが判別不能
+ * になりデバッグ困難になるため、default の決定は単一箇所 (env 読み出し) に閉じる
+ * (`DynamoDbLowCapacity` Aspect と同じ方針)。
  */
 export class KmsKeyShortPendingWindow implements IAspect {
+  constructor(private readonly pendingWindowInDays: number) {
+    if (
+      !Number.isInteger(pendingWindowInDays) ||
+      pendingWindowInDays < KMS_PENDING_WINDOW_MIN_DAYS ||
+      pendingWindowInDays > KMS_PENDING_WINDOW_MAX_DAYS
+    ) {
+      throw new Error(
+        `KmsKeyShortPendingWindow: pendingWindowInDays must be an integer in ` +
+          `[${KMS_PENDING_WINDOW_MIN_DAYS}, ${KMS_PENDING_WINDOW_MAX_DAYS}] (AWS KMS spec). ` +
+          `Got: ${pendingWindowInDays}`,
+      );
+    }
+  }
+
   public visit(node: IConstruct): void {
     if (!(node instanceof CfnKey)) return;
-    node.pendingWindowInDays = 7;
+    node.pendingWindowInDays = this.pendingWindowInDays;
   }
 }

--- a/infrastructure/lib/config/config-interface.ts
+++ b/infrastructure/lib/config/config-interface.ts
@@ -11,6 +11,21 @@ export interface Config {
   readonly controlPlaneConfig: ControlPlaneConfig;
   readonly bootstrapConfig: BootstrapConfig;
   readonly dynamoDbConfig?: DynamoDbConfig;
+  readonly kmsConfig?: KmsConfig;
+}
+
+/**
+ * KMS Key の削除待機期間。`make destroy` 後 KMS Key が "Pending Deletion" 状態のまま
+ * 課金される期間 ($1/key/月) を縮めるため、AWS KMS の許容範囲 [7, 30] 内で指定。
+ *
+ *   - dev / training: 7 (= 最短、課金最小化)
+ *   - production: 14〜30 (= 監査要件 / 誤削除時の rollback 余地)
+ *
+ * 値は config.json + `${ENV_VAR:-default}` placeholder から渡るため、文字列で来ること
+ * がある (placeholder 展開後は string)。bin で `Number()` 正規化する。
+ */
+export interface KmsConfig {
+  readonly pendingWindowInDays?: number | string;
 }
 
 /**

--- a/infrastructure/lib/utils/config-loader.ts
+++ b/infrastructure/lib/utils/config-loader.ts
@@ -8,9 +8,10 @@ import type { Config } from "../config/config-interface";
 export interface ExpandOptions {
   /**
    * true なら env 未設定 + default 無しの placeholder を throw せず literal `${VAR}` のまま残す。
-   * 用途: bin/infrastructure.ts は config 全体のうち `dynamoDbConfig` セクションしか consume
-   * しないので、無関係セクション (`${TenkaCloud_ADMIN_EMAIL}` 等) の env 未設定で全体が落ちる
-   * のを避ける。consumer 側 (bin) が読まない field なら literal `${VAR}` で残っていても無害。
+   * 用途: bin/infrastructure.ts は config 全体のうち `dynamoDbConfig` / `kmsConfig` 等の
+   * 限定セクションしか consume しないので、無関係セクション (`${TenkaCloud_ADMIN_EMAIL}`
+   * 等) の env 未設定で全体が落ちるのを避ける。consumer 側 (bin) が読まない field なら
+   * literal `${VAR}` で残っていても無害。
    */
   tolerant?: boolean;
 }
@@ -99,10 +100,10 @@ export function parseConfig(configContent: string, logger: Logger): Config {
  *   - placeholder は env で展開、未設定 + default 無しは tolerant=true なら literal `${VAR}` のまま残る
  *   - JSON parse して `Config` interface に揃える (validateConfig は呼ばない)
  *
- * tolerant が default なのは、bin 側の段階導入を許すため: 現状 `dynamoDbConfig` 以外の
- * field (controlPlaneConfig 等) は bin が直接 process.env を読んでおり config.json 経由
- * ではない。それらに literal `${VAR}` が残っていても bin が無視するので安全。後続 PR で
- * 段階的に config.json 経由に寄せていく前提。
+ * tolerant が default なのは、bin 側の段階導入を許すため: 現状 `dynamoDbConfig` /
+ * `kmsConfig` 以外の field (controlPlaneConfig 等) は bin が直接 process.env を読んで
+ * おり config.json 経由ではない。それらに literal `${VAR}` が残っていても bin が無視
+ * するので安全。後続 PR で段階的に config.json 経由に寄せていく前提。
  */
 export function loadConfig(envName: string, baseDir: string): Config | undefined {
   const configPath = path.resolve(baseDir, `../environments/${envName}/config.json`);

--- a/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
+++ b/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
@@ -2,32 +2,46 @@ import { App, Aspects, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { Key } from "aws-cdk-lib/aws-kms";
 import { describe, expect, it } from "vitest";
-import { KmsKeyShortPendingWindow } from "../../lib/cdk-aspect/kms-key-short-pending-window";
+import {
+  KMS_PENDING_WINDOW_MAX_DAYS,
+  KMS_PENDING_WINDOW_MIN_DAYS,
+  KmsKeyShortPendingWindow,
+} from "../../lib/cdk-aspect/kms-key-short-pending-window";
 
 /**
- * KMS Key の `PendingWindowInDays` が aspect 適用で 7 日になることを pin する。
+ * KMS Key の `PendingWindowInDays` が aspect 適用で caller 指定値になることを pin する。
  * SBT の BashJobRunner が内部で作る CodeBuild encryption key 等、操作者が直接触れない
  * KMS Key にも適用されるべき (全 stack 横断の Aspect)。
  */
 
-describe("KmsKeyShortPendingWindow", () => {
-  it("明示的に作った KMS Key の PendingWindowInDays を 7 にするべき", () => {
-    const app = new App();
-    const stack = new Stack(app, "TestStack");
-    new Key(stack, "MyKey");
-    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+function buildHarness(pendingWindow: number): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  new Key(stack, "MyKey");
+  Aspects.of(stack).add(new KmsKeyShortPendingWindow(pendingWindow));
+  return Template.fromStack(stack);
+}
 
-    const tpl = Template.fromStack(stack);
-    tpl.hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 7 });
+describe("KmsKeyShortPendingWindow", () => {
+  it("caller が 7 を渡すと PendingWindowInDays=7 になるべき", () => {
+    buildHarness(7).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 7 });
   });
 
-  it("複数の KMS Key が混在する stack でも全件に適用されるべき", () => {
+  it("caller が 30 を渡すと PendingWindowInDays=30 になるべき (= production 想定)", () => {
+    buildHarness(30).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 30 });
+  });
+
+  it("caller が範囲内の任意値 (= 14) を渡すと PendingWindowInDays=14 になるべき", () => {
+    buildHarness(14).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 14 });
+  });
+
+  it("複数の KMS Key が混在する stack でも全件に同じ値が適用されるべき", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new Key(stack, "KeyA");
     new Key(stack, "KeyB");
     new Key(stack, "KeyC");
-    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+    Aspects.of(stack).add(new KmsKeyShortPendingWindow(7));
 
     const tpl = Template.fromStack(stack);
     tpl.resourceCountIs("AWS::KMS::Key", 3);
@@ -40,9 +54,28 @@ describe("KmsKeyShortPendingWindow", () => {
   it("KMS Key が無い stack には影響しないべき", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
-    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+    Aspects.of(stack).add(new KmsKeyShortPendingWindow(7));
 
     const tpl = Template.fromStack(stack);
     tpl.resourceCountIs("AWS::KMS::Key", 0);
+  });
+
+  describe("validation", () => {
+    it("AWS KMS の許容範囲 [7, 30] 外は throw するべき", () => {
+      expect(() => new KmsKeyShortPendingWindow(6)).toThrow(/must be an integer in \[7, 30\]/);
+      expect(() => new KmsKeyShortPendingWindow(31)).toThrow(/must be an integer in \[7, 30\]/);
+      expect(() => new KmsKeyShortPendingWindow(0)).toThrow(/must be an integer in \[7, 30\]/);
+      expect(() => new KmsKeyShortPendingWindow(-1)).toThrow(/must be an integer in \[7, 30\]/);
+    });
+
+    it("非整数 (= 14.5 / NaN) は throw するべき", () => {
+      expect(() => new KmsKeyShortPendingWindow(14.5)).toThrow(/must be an integer/);
+      expect(() => new KmsKeyShortPendingWindow(Number.NaN)).toThrow(/must be an integer/);
+    });
+
+    it("境界値 (= 7 / 30) は許容すべき", () => {
+      expect(() => new KmsKeyShortPendingWindow(KMS_PENDING_WINDOW_MIN_DAYS)).not.toThrow();
+      expect(() => new KmsKeyShortPendingWindow(KMS_PENDING_WINDOW_MAX_DAYS)).not.toThrow();
+    });
   });
 });

--- a/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
+++ b/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
@@ -1,0 +1,48 @@
+import { App, Aspects, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { describe, expect, it } from "vitest";
+import { KmsKeyShortPendingWindow } from "../../lib/cdk-aspect/kms-key-short-pending-window";
+
+/**
+ * KMS Key の `PendingWindowInDays` が aspect 適用で 7 日になることを pin する。
+ * SBT の BashJobRunner が内部で作る CodeBuild encryption key 等、操作者が直接触れない
+ * KMS Key にも適用されるべき (全 stack 横断の Aspect)。
+ */
+
+describe("KmsKeyShortPendingWindow", () => {
+  it("明示的に作った KMS Key の PendingWindowInDays を 7 にするべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new Key(stack, "MyKey");
+    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 7 });
+  });
+
+  it("複数の KMS Key が混在する stack でも全件に適用されるべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new Key(stack, "KeyA");
+    new Key(stack, "KeyB");
+    new Key(stack, "KeyC");
+    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+
+    const tpl = Template.fromStack(stack);
+    tpl.resourceCountIs("AWS::KMS::Key", 3);
+    const keys = tpl.findResources("AWS::KMS::Key");
+    for (const [, resource] of Object.entries(keys)) {
+      expect(resource.Properties.PendingWindowInDays).toBe(7);
+    }
+  });
+
+  it("KMS Key が無い stack には影響しないべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    Aspects.of(stack).add(new KmsKeyShortPendingWindow());
+
+    const tpl = Template.fromStack(stack);
+    tpl.resourceCountIs("AWS::KMS::Key", 0);
+  });
+});


### PR DESCRIPTION
## この PR が解決すること

ユーザー指摘:

> make destroy のときに KMS のキーも削除スケジューリングされるのはいいのですが 30 日は長くて課金されてしまいます。7 日に変更できるようにできませんか

KMS Key は削除コマンド後、実削除までの待機期間が必須 (許容範囲 7〜30 日)。default 30 日のままだと \`make destroy\` 後 30 日間 "Pending Deletion" 状態で **\$1/key/月** が課金される。

## 修正

CDK Aspect で全 stack の \`AWS::KMS::Key\` に \`PendingWindowInDays: 7\` (= 最短値) を強制。

\`bin/infrastructure.ts\` で App scope に apply:

\`\`\`typescript
cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow());
\`\`\`

CDK / SBT (\`@cdklabs/sbt-aws\`) が auto-生成する CodeBuild EncryptionKey 等も含めた**全 KMS Key** が対象。

## 影響範囲

確認した既存 KMS Key (cdk.out 上):

- \`AppPlaneStack\`:
  - \`ProvisioningJobcodeBuildProjectEncryptionKey15C52B5A\` (SBT BashJobRunner 内部)
  - \`DeprovisioningJobcodeBuildProjectEncryptionKey248A1861\` (同上)
- \`BootstrapTemplateStack\`, \`serverless-saas-ref-arch-bootstrap-stack\` にも 1+ 件 (SBT 内部)

## なぜ 7 日

- 7 は AWS KMS 許容範囲の最短値
- 誤削除時の rollback 余地 (= cancel-key-deletion) を残しつつ teardown 後の課金期間を最小化
- TenkaCloud は training / demo 用途、誤削除しても再 deploy で復旧可能

## 物理影響

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| 全 stack の \`AWS::KMS::Key\` | PendingWindowInDays | UPDATE in-place | 30 → 7 |
| (その他) | (なし) | NO-OP |

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 |
|---|---|---|---|
| 1 | 既存 KMS Key の運用 | AWS account | ✅ in-place UPDATE のみ、key identity / 暗号化は不変 |
| 2 | DestroyPolicySetter aspect との競合 | bootstrap-stack 等 | ✅ 別属性 (RemovalPolicy vs PendingWindowInDays)、競合無し |
| 3 | SBT 内部 Key | AppPlaneStack | ✅ Aspect で全件 visit |
| 4 | Aspect 適用順序 | App scope | ✅ Stack ごとの aspect と独立 |

## Verification

- [x] \`make before-commit\` exit 0 (lint / typecheck / test 358 件 / validate-problems)
- [x] 新規 3 件 unit test (\`kms-key-short-pending-window.test.ts\`)
- [ ] (merge 後実 AWS) \`cdk diff\` で既存 Key の PendingWindowInDays 30 → 7 が出ること、\`cdk deploy\` 後 AWS Console で確認

## Rollback 手順

\`git revert <merge-sha>\` のみ。in-place UPDATE で既存 Key の identity 不変、影響は PendingWindowInDays 属性 1 つだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default KMS key deletion window from 30 to 7 days across all infrastructure resources.

* **Tests**
  * Added comprehensive test suite validating KMS key deletion window configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->