### PR TITLE
fix(install): Participant Portal を deploy 対象に含める + URL 表示

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,6 +96,14 @@ find "${STAGING}" -name ".DS_Store" -delete
 mkdir -p "${STAGING}/apps/application-admin-console"
 cp -R "${TenkaCloud_ROOT}/apps/application-admin-console/dist" "${STAGING}/apps/application-admin-console/"
 
+# participant-portal も dist を staging に置く。現状 ProblemDeployBackendStack は
+# host 環境 (phase 1) でしか deploy されないので、host の `apps/participant-portal/dist`
+# 直参照で動く。が、将来 CodeBuild から再 deploy する経路を増やしたとき、source.zip 内に
+# dist が無いと Source.asset が解決できず失敗する。application-admin-console と同じ流儀
+# で予め staging に同梱して将来リスクを抑える (claude-review PR 475 の指摘)。
+mkdir -p "${STAGING}/apps/participant-portal"
+cp -R "${TenkaCloud_ROOT}/apps/participant-portal/dist" "${STAGING}/apps/participant-portal/"
+
 cd "${STAGING}"
 zip -rq "${CDK_SOURCE_NAME}" .
 export CDK_PARAM_COMMIT_ID=$(aws s3api put-object --bucket "${CDK_PARAM_S3_BUCKET_NAME}" --key "source.zip" --body "./${CDK_SOURCE_NAME}" --output text)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,17 @@ echo "Building apps/application-admin-console (used by both pooled stack at host
 (cd "${TenkaCloud_ROOT}/apps/application-admin-console" && bun install && bun run build)
 echo "  → dist/ generated"
 
+# apps/participant-portal を host build。ProblemDeployBackendStack の
+# ParticipantPortalHosting が `apps/participant-portal/dist/` を Source.asset で読む。
+# `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` のときだけ stack 側で生成される。
+echo "Building apps/participant-portal (used by ParticipantPortalHosting in ProblemDeployBackendStack)..."
+(cd "${TenkaCloud_ROOT}/apps/participant-portal" && bun install && bun run build)
+echo "  → dist/ generated"
+
+# Participant Portal を ProblemDeployBackendStack に含める (CDK 側で条件付き作成)。
+# eventTitle はオプション (default は "TenkaCloud Battle")。
+export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL="true"
+
 echo "Staging source.zip at ${STAGING}..."
 # infrastructure → cdk にリネーム、src と scripts はそのまま
 cp -R infrastructure "${STAGING}/cdk"
@@ -201,6 +212,11 @@ POOLED_APP_CONSOLE_URL=$(aws cloudformation describe-stacks \
   --query "Stacks[0].Outputs[?OutputKey=='ApplicationAdminConsoleUrl'].OutputValue" \
   --output text 2>/dev/null || echo "(not deployed yet)")
 
+PARTICIPANT_PORTAL_URL=$(aws cloudformation describe-stacks \
+  --stack-name "ProblemDeployBackendStack" \
+  --query "Stacks[0].Outputs[?OutputKey=='ParticipantPortalUrl'].OutputValue" \
+  --output text 2>/dev/null || echo "(not deployed)")
+
 echo ""
 echo "=============================================="
 echo "Deploy complete!"
@@ -208,6 +224,7 @@ echo "=============================================="
 echo ""
 echo "Admin Console URL                  : ${ADMIN_CONSOLE_URL}"
 echo "Application Admin Console (pooled) : ${POOLED_APP_CONSOLE_URL}"
+echo "Participant Portal URL             : ${PARTICIPANT_PORTAL_URL}"
 echo ""
 echo "1. SystemAdmin 初回招待メール (${CDK_PARAM_SYSTEM_ADMIN_EMAIL}) が届いてるはずなので開く"
 echo "2. ${ADMIN_CONSOLE_URL} にブラウザで access"


### PR DESCRIPTION
## Summary

\`apps/participant-portal/\` 配下に SPA + \`ParticipantPortalHosting\` (S3+CloudFront) の CDK 実装は既にあったが、\`scripts/install.sh\` で \`CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true\` を export しておらず、bin の \`enableParticipantPortal\` が常に false になり、stack 自体が synth されない状態だった。結果として \`make deploy\` 後にも Participant Portal の URL が AWS 上に存在せず、application-admin-console の「Participant Portal にログイン」案内が飛び先のない死リンクになっていた。

修正:

- \`apps/participant-portal/\` を install.sh の phase 1 前に host build (\`apps/application-admin-console/\` と同じ流儀)
- phase 1 開始前に \`CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true\` を export
- 完了 banner に \`Participant Portal URL\` を \`aws cloudformation describe-stacks\` 経由で表示

## Regression 分析

- 既存の admin-console / application-admin-console hosting は無変更
- \`ProblemDeployBackendStack\` 側は \`participantPortal\` プロパティが指定されたときだけ Portal stack を構築する (CDK は本 PR では一切編集しない)。env を立てるだけで条件分岐が走り、未 deploy 環境にも非破壊的に新規 stack 追加できる
- backend Lambda Function URL の認証は AuthType=NONE (teamLoginKey bearer を Lambda 内検証) で、CDK 側で既に整合済

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| CREATE | \`AWS::S3::Bucket\` (ParticipantPortal SiteBucket) | private + OAI |
| CREATE | \`AWS::CloudFront::Distribution\` (ParticipantPortal) | PRICE_CLASS_100 |
| CREATE | \`AWS::Lambda::Function\` (ParticipantPortalLambda + Function URL) | DDB Read + 自行 Update のみ |
| CREATE | \`AWS::S3::BucketDeployment\` (SiteDeployment + RuntimeConfig) | dist/ 配置 |
| NO-OP  | 既存 Deployments / DeployApi / 他 stack | 不変 |

\`ProblemDeployBackendStack\` 内に追加されるリソース。新規 stack ではない。

## Test plan

- [x] \`make before-commit\` 緑 (lint / typecheck / test 全 374 件 / build / validate-problems)
- [ ] AWS 上で \`make deploy\` → 完了 banner に Portal URL が出ることを確認
- [ ] application-admin-console から teamLoginKey を発行して Portal にログインできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)