### PR TITLE
docs(api): API リファレンスを plane 分離した OpenAPI 3.1 で整備

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,178 @@
+# TenkaCloud API リファレンス
+
+TenkaCloud の HTTP API 仕様。3 つの API サーフェスを **plane (= オーディエンス) ごとに
+分離した OpenAPI 3.1 spec** で持つ。本書はその俯瞰 narrative。
+
+| サーフェス | 仕様ファイル | 配信先 SPA / Stack |
+| --- | --- | --- |
+| Control Plane API | [`control-plane.openapi.yaml`](./control-plane.openapi.yaml) | `apps/admin-console` / `ControlPlaneStack` |
+| Tenant API | [`tenant.openapi.yaml`](./tenant.openapi.yaml) | `apps/application-admin-console` / `TenantTemplateStack` |
+| Participant API | [`participant.openapi.yaml`](./participant.openapi.yaml) | `apps/participant-portal` / `ProblemDeployBackendStack` |
+| 共通スキーマ | [`_components.yaml`](./_components.yaml) | (paths を持たない、`$ref` 専用) |
+
+3 ファイルに分割した理由は **Plane 分離 (Control Plane vs Application Plane) が SBT
+由来の architectural invariant** だから。1 サーフェス multi-tenant SaaS (Slack, Stripe)
+は 1 ファイルが多数派だが、TenkaCloud のような multi-plane / multi-audience SaaS は
+Auth0 (Management API + Authentication API) や Atlassian (Admin API + Product API) など
+分割が定石。
+
+## サーフェス概要
+
+| サーフェス | 用途 | 認証 | 提供元 |
+| --- | --- | --- | --- |
+| **Control Plane API** | テナント (= 主催者組織) の CRUD | Cognito JWT (System Admin) | SBT `ControlPlane` (`@cdklabs/sbt-aws` 0.3.9) |
+| **Tenant API** | 問題の deploy / 一覧 / 詳細 / 削除 | Cognito JWT (Tenant Admin) | `TenantTemplateStack` 内 `ApiGateway` |
+| **Participant API** | 競技者がチームの問題状態を取得 / flag を提出 | `teamLoginKey` を bearer | `ProblemDeployBackendStack` の Lambda Function URL |
+
+3 つの URL は **`runtime-config.json` 経由で SPA に注入** される (CloudFront 配下)。
+URL を build 成果物に焼かない (= dist は tenant 共有可) — `docs/architecture/harness.md`
+の `INVARIANT_APP_CODE_IS_UNMODIFIED` に従う。
+
+## 認証
+
+### Cognito JWT (Control Plane / Tenant API)
+
+```
+Authorization: Bearer <cognito_id_token>
+```
+
+- Hosted UI + OAuth Code + PKCE で取得
+- ID Token (`access_token` ではない) を渡す。`custom:tenantId` claim から tenantId を解決する
+- 期限切れは 401 (refresh は SPA 側で `aws-amplify` が自動実行)
+
+### teamLoginKey (Participant API)
+
+```
+Authorization: Bearer <teamLoginKey>
+```
+
+- Tenant Admin が `POST /problems/:id/deploy` を呼んだときに **1 度だけ** レスポンスに含まれる
+- 競技者に hand-off (口頭 / 安全な手段で) する短命キー
+- DDB の TTL (`expiresAt`) で自動失効
+- key 自体を bearer にしているため、leak したらそのチームの状態が外部から見える
+
+## API ごとの実行権限 (最小権限の早見表)
+
+クライアント側の認証 (誰が呼べるか) と、実体 Lambda が AWS 上で持つ IAM の両方を、
+3 サーフェスごとに分離しています。
+
+| サーフェス | クライアント認証 | 公開 URL | 実体 Lambda | Lambda の IAM (= 触れる AWS リソース) |
+| --- | --- | --- | --- | --- |
+| Control Plane API | Cognito JWT (`SystemAdmin` group) | API GW + Cognito Authorizer | SBT 内蔵 (TenantDetails CRUD) | DDB `TenantDetails` のみ + EventBridge `onboardingRequest` publish |
+| Tenant API | Cognito JWT (`TenantAdmin` custom claim) | per-tenant API GW + Cognito Authorizer | `DeployApi` Lambda | DDB `Deployments` (RW) + EventBridge bus (PutEvents) のみ。**CFn 権限は持たない** |
+| Participant API | `teamLoginKey` を bearer (Lambda 内検証) | Lambda Function URL (`AuthType=NONE`) | `ParticipantPortal` Lambda | DDB `Deployments` Query (GSI2 経由) + UpdateItem のみ。**CFn / EventBridge / 他テーブル権限なし** |
+| Health Check (内部) | EventBridge `rate(1 minute)` で起動 | (公開なし) | `HealthCheck` Lambda | DDB `Deployments` (RW) + 競技者エンドポイントへの outbound HTTP のみ |
+| Deploy 実体 (内部) | Step Functions Task | (公開なし) | `DeployCodeBuildProject` (CodeBuild) | CFn (Create/Update/Delete/Describe) + EC2/IAM/SSM/Logs/S3/Events/Lambda の `*` (= 問題テンプレが必要なリソースを作成するため) |
+
+### 設計原則
+
+1. **API Lambda 自身は CFn を直接触らない**
+   - `DeployApi` は EventBridge publish するだけ。実 deploy / delete は CodeBuild Project が
+     行う。これにより API Lambda の権限を「DDB + EventBridge」に閉じ込めて、もし API Lambda
+     が乗っ取られても CFn を勝手に発火できないようにしている。
+2. **Participant Lambda は read 寄り + 自分の行の Update だけ**
+   - `dynamodb:UpdateItem` は table 全体に向けて grant されているが、Lambda コード側で
+     teamLoginKey の所有者の行 (GSI2 で引いた 1 行) しか触らない実装になっている。
+3. **削除権限は CodeBuild Project に集約**
+   - `cloudformation:DeleteStack` を持つのは CodeBuild Project Role のみ。
+     DeployApi Lambda には付与しない (= 削除のトリガーは EventBridge 経由のみ)。
+4. **Participant Portal の Function URL は AuthType=NONE**
+   - Cognito を per-team 払い出すと運営コストが大きいため、`teamLoginKey` をそのまま
+     bearer として Lambda 内で検証する。Function URL の AuthType は NONE。
+5. **クロステナント漏洩防止**
+   - `tenantId` mismatch は 404 (存在を漏らさない)。read 経路すべてで `where tenantId = caller`
+     を強制する。
+
+## エラー方針
+
+```jsonc
+// 4xx
+{ "error": "<machine_readable_code>" }
+
+// validation error (Zod)
+{ "error": "validation failed", "issues": [...] }
+
+// 5xx
+{ "error": "internal_error" }
+```
+
+### クロステナント漏洩防止
+
+read 経路で `tenantId` mismatch を見つけた場合は **`404 not_found` を返す**
+(403 / "wrong tenant" を返さない)。存在を漏らさないため。
+
+## デプロイ / 削除のライフサイクル
+
+Tenant API の `/problems/:id/deploy` と `/deployments/:jobId` (DELETE) は、
+**SBT の `ScriptJob` 同型** な構造で動きます。
+
+```
+[Tenant API Lambda]
+   │ ① validation + DDB Put + EventBridge PutEvents
+   ▼
+[EventBridge bus] ── DeployCreateRequested / DeployDeleteRequested
+   │
+   ▼
+[Step Functions State Machine]
+   │ ② CodeBuildStartBuild .sync (RUN_JOB integration)
+   ▼
+[CodeBuild Project]
+   │ ③ scripts/deploy-battles.sh (create) または scripts/delete-battles.sh (delete)
+   ▼
+[CloudFormation]
+   │ ④ CreateStack / DeleteStack
+   ▼
+[State Machine 完了] → DDB row の status を COMPLETE / DELETED / FAILED に書き戻す
+```
+
+### Status 遷移
+
+```
+PENDING ─→ IN_PROGRESS ─→ COMPLETE ─→ DELETING ─→ DELETED
+                       └→ FAILED   ─→ DELETING ─→ DELETED
+```
+
+- `PENDING / IN_PROGRESS / COMPLETE / FAILED` から DELETE → `DELETING`
+- `DELETING / DELETED` への DELETE は `200 already_deleted` (no-op)
+- DELETING 中に CFn が失敗したら `FAILED` + `failureReason` (operator が再試行)
+
+## Scoring
+
+問題 metadata の `scoring.kind` で 2 系統に分かれる。
+
+- `flag` (Challenge): 競技者が `POST /portal/me/submit-flag` で flag を提出 → Lambda が
+  CFn Outputs と照合して採点する。
+- `uptime` (Battle): `HealthCheck` Lambda が 1 分間隔で endpoint を probe し、
+  防御側が止まっていたら点数を伸ばさない (攻撃側のスコア優位)。
+
+詳細は [`docs/requirements/`](../requirements/) を参照。
+
+## 仕様の更新フロー
+
+1. Hono handler の zod スキーマを変える
+2. 該当サーフェスの `*.openapi.yaml` を手で同期する。共通スキーマは
+   `_components.yaml` 側を直す。現状は手書きで、Phase 2 で `@hono/zod-openapi`
+   自動生成へ移行する
+3. `make before-commit` で lint + typecheck + test を通す
+
+将来: zod スキーマ → OpenAPI 自動生成 (`@hono/zod-openapi`) で 2 重管理を解消する。
+
+## レンダリング
+
+ローカルプレビューは任意のレンダラで行う。3 サーフェスを別々に build する
+(plane 分離思想と整合)。
+
+```bash
+# Redoc CLI で各 plane の HTML を吐く
+nlx @redocly/cli build-docs docs/api/control-plane.openapi.yaml -o docs/api/control-plane.html
+nlx @redocly/cli build-docs docs/api/tenant.openapi.yaml        -o docs/api/tenant.html
+nlx @redocly/cli build-docs docs/api/participant.openapi.yaml   -o docs/api/participant.html
+
+# Swagger UI を docker で起動 (例: tenant API)
+docker run --rm -p 8080:8080 \
+  -e SWAGGER_JSON=/spec/tenant.openapi.yaml \
+  -v "$(pwd)/docs/api:/spec" \
+  swaggerapi/swagger-ui
+```
+
+CI では `nlx @redocly/cli lint docs/api/*.openapi.yaml` を回して破綻を検知する想定。

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -49,7 +49,8 @@ Authorization: Bearer <teamLoginKey>
 - Tenant Admin が `POST /problems/:id/deploy` を呼んだときに **1 度だけ** レスポンスに含まれる
 - 競技者に hand-off (口頭 / 安全な手段で) する短命キー
 - DDB の TTL (`expiresAt`) で自動失効
-- key 自体を bearer にしているため、leak したらそのチームの状態が外部から見える
+- key 自体を bearer にしているため、leak すると **そのチームの状態が外部から閲覧されるだけでなく、
+  `POST /portal/me/submit-flag` で不正に flag を提出され勝手に加点される** リスクがある
 
 ## API ごとの実行権限 (最小権限の早見表)
 

--- a/docs/api/_components.yaml
+++ b/docs/api/_components.yaml
@@ -189,27 +189,61 @@ components:
           type: string
           description: 次ページの cursor (base64url JSON)
 
+    ParticipantScoringInfo:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [flag, uptime]
+        points:
+          type: integer
+          description: Challenge (flag) で正解時の獲得点数
+        pointsPerSuccess:
+          type: integer
+          description: Battle (uptime) で 1 health check 成功あたりの加点
+        hints:
+          type: array
+          items: { type: string }
+          description: Challenge のヒント (operator が metadata.json で宣言)
+        flagSubmitted:
+          type: boolean
+          description: Challenge (flag) で正解 submit 済みなら true (重複加算防止)
+
     ParticipantView:
       type: object
-      required: [jobId, problemId, status, createdAt, expiresAt]
+      required: [jobId, problemId, region, status, stackOutputs, score, expiresAt, teamName, teamNameSetByCompetitor]
       properties:
         jobId: { type: string }
         problemId: { type: string }
-        teamName: { type: string }
-        displayTeamName: { type: string }
+        region: { type: string }
+        teamName:
+          type: string
+          description: 表示名 (競技者が PATCH /portal/me で設定済みならそれ、未設定なら operator が deploy 時に入力した内部 slug)
+        teamNameSetByCompetitor:
+          type: boolean
+          description: 競技者自身が表示名を設定済みなら true (= operator slug をそのまま使っていれば false)
         status: { $ref: "#/components/schemas/DeploymentStatus" }
-        score: { type: integer }
+        stackOutputs:
+          type: object
+          additionalProperties: { type: string }
+          description: |
+            CFn Outputs を object に展開したもの。`flagOutputKey` で指定された field は
+            **競技者に出さない** (= 当てる対象なので strip 済み)。
+        failureReason:
+          type: string
+          description: status=FAILED のときのみ含まれる
+        score:
+          type: integer
+          description: チームの累計点数
+        lastScoredAt:
+          type: string
+          format: date-time
+          description: 最後に scoring が走った時刻
         lastResult:
           type: string
           enum: [ok, fail]
           description: Battle (uptime) で最後の health check 結果
-        endpointsHealth:
-          type: object
-          description: |
-            endpoint ごとの直近 probe 結果。`{ [outputKey]: { ok, checkedAt, since? } }`。
-            `since` は ok=false が続いている開始時刻 (= 攻撃検知時刻)。
-        flagSubmitted:
-          type: boolean
-          description: Challenge (flag) で正解 submit 済みなら true
-        createdAt: { type: string, format: date-time }
+        scoring:
+          $ref: "#/components/schemas/ParticipantScoringInfo"
         expiresAt: { type: integer }

--- a/docs/api/_components.yaml
+++ b/docs/api/_components.yaml
@@ -1,0 +1,215 @@
+# 3 サーフェス共通の schema / securityScheme / responses。
+# control-plane.openapi.yaml / tenant.openapi.yaml / participant.openapi.yaml から
+# `$ref: "./_components.yaml#/components/..."` で参照する。
+#
+# このファイルは単独 spec ではない (paths を持たない) ので、Redoc / Swagger UI で
+# 直接 render しない。
+openapi: 3.1.0
+info:
+  title: TenkaCloud API — Shared Components
+  version: 1.0.0-mvp1
+  description: |
+    3 サーフェス (Control Plane / Tenant / Participant) で共有する schema 定義。
+    paths は持たない。
+paths: {}
+
+components:
+  securitySchemes:
+    cognitoSystemAdmin:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Cognito ID Token (`SystemAdmin` group)
+    cognitoTenantAdmin:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Cognito ID Token (`TenantAdmin` custom claim 含む)
+    teamLoginKey:
+      type: http
+      scheme: bearer
+      description: Tenant Admin が deploy 時に発行した短命チーム共有キー
+
+  responses:
+    ValidationError:
+      description: Zod validation 失敗
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: "validation failed"
+              issues:
+                type: array
+                items: { type: object }
+    NotFound:
+      description: 行が無い、または tenantId mismatch (存在を漏らさないため 404)
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Unauthorized:
+      description: bearer token 無効 / 期限切れ
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }
+
+    Tier:
+      type: string
+      enum: [basic, advanced, platinum]
+      description: |
+        SaaS tier。`platinum` だけが silo stack (per-tenant CDK deploy)。
+        他は pooled stack を共有する。
+
+    Tenant:
+      type: object
+      required: [tenantId, tenantName, email, tier, tenantStatus]
+      properties:
+        tenantId: { type: string }
+        tenantName: { type: string }
+        email: { type: string, format: email }
+        tier: { $ref: "#/components/schemas/Tier" }
+        tenantStatus:
+          type: string
+          description: '"In progress" | "Complete" | "Deleted" など SBT 由来の文字列'
+        isActive: { type: boolean }
+        tenantConfig:
+          type: string
+          description: |
+            provision-tenant.sh が CFn outputs を JSON 文字列として書き戻す。
+            `{userPoolId, appClientId, apiGatewayUrl, applicationAdminConsoleUrl, ...}`
+        createdAt: { type: string, format: date-time }
+
+    CreateTenantRequest:
+      type: object
+      required: [tenantName, email, tier]
+      properties:
+        tenantName: { type: string }
+        email: { type: string, format: email }
+        tier: { $ref: "#/components/schemas/Tier" }
+        tenantPhone: { type: string }
+        tenantAddress: { type: string }
+
+    DeploymentStatus:
+      type: string
+      enum: [PENDING, IN_PROGRESS, COMPLETE, FAILED, DELETING, DELETED]
+
+    DeployRequest:
+      type: object
+      required: [region, awsAccountId, teamName]
+      properties:
+        region:
+          type: string
+          pattern: "^[a-z]{2}-[a-z]+-\\d+$"
+          example: "ap-northeast-1"
+        awsAccountId:
+          type: string
+          pattern: "^\\d{12}$"
+          example: "123456789012"
+        teamName:
+          type: string
+          minLength: 1
+          maxLength: 40
+          pattern: "^[A-Za-z0-9 _-]+$"
+        accountGroupId:
+          type: string
+          description: bulk deploy 用の予約フィールド (現状未使用)
+        problemSetId:
+          type: string
+          description: bulk deploy 用の予約フィールド (現状未使用)
+
+    DeployResponse:
+      type: object
+      required: [jobId, status, namePrefix, teamLoginKey, expiresAt]
+      properties:
+        jobId: { type: string }
+        status: { $ref: "#/components/schemas/DeploymentStatus" }
+        namePrefix:
+          type: string
+          description: CFn StackName の prefix (`tc-{problemId}-{teamSlug}`)
+        teamLoginKey:
+          type: string
+          description: 短命チーム共有キー (この経路でしか露出しない)
+        expiresAt:
+          type: integer
+          description: TTL (epoch seconds)
+
+    DeploymentSummary:
+      type: object
+      required:
+        [jobId, problemId, tenantId, awsAccountId, region, teamName, namePrefix, status, createdAt, updatedAt, expiresAt]
+      properties:
+        jobId: { type: string }
+        problemId: { type: string }
+        tenantId: { type: string }
+        awsAccountId: { type: string }
+        region: { type: string }
+        teamName: { type: string }
+        displayTeamName:
+          type: string
+          description: 競技者が PATCH /portal/me で設定した表示名
+        namePrefix: { type: string }
+        status: { $ref: "#/components/schemas/DeploymentStatus" }
+        stackId: { type: string }
+        stackOutputs:
+          type: string
+          description: CFn Outputs を JSON 文字列で格納
+        failureReason: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        expiresAt: { type: integer }
+
+    DeploymentDetail:
+      allOf:
+        - $ref: "#/components/schemas/DeploymentSummary"
+        - type: object
+          properties:
+            teamLoginKey:
+              type: string
+              description: 詳細取得経路でのみ露出 (一覧経路では含まれない)
+
+    DeploymentListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/DeploymentSummary" }
+        nextCursor:
+          type: string
+          description: 次ページの cursor (base64url JSON)
+
+    ParticipantView:
+      type: object
+      required: [jobId, problemId, status, createdAt, expiresAt]
+      properties:
+        jobId: { type: string }
+        problemId: { type: string }
+        teamName: { type: string }
+        displayTeamName: { type: string }
+        status: { $ref: "#/components/schemas/DeploymentStatus" }
+        score: { type: integer }
+        lastResult:
+          type: string
+          enum: [ok, fail]
+          description: Battle (uptime) で最後の health check 結果
+        endpointsHealth:
+          type: object
+          description: |
+            endpoint ごとの直近 probe 結果。`{ [outputKey]: { ok, checkedAt, since? } }`。
+            `since` は ok=false が続いている開始時刻 (= 攻撃検知時刻)。
+        flagSubmitted:
+          type: boolean
+          description: Challenge (flag) で正解 submit 済みなら true
+        createdAt: { type: string, format: date-time }
+        expiresAt: { type: integer }

--- a/docs/api/control-plane.openapi.yaml
+++ b/docs/api/control-plane.openapi.yaml
@@ -1,0 +1,101 @@
+openapi: 3.1.0
+info:
+  title: TenkaCloud Control Plane API
+  version: 1.0.0-mvp1
+  summary: System Admin がテナント (= 主催者組織) を CRUD する API
+  description: |
+    `ControlPlaneStack` (= SBT `@cdklabs/sbt-aws` 0.3.9 の `ControlPlane` construct) が
+    払い出す REST API。System Admin (Cognito UserPool の `SystemAdmin` group) のみ
+    アクセス可。
+
+    本 API のレスポンスで作成された tenant は EventBridge `onboardingRequest` イベントを
+    発火し、`ServerlessSaaSPipeline` が tier に応じて pooled / silo の Application Plane
+    stack を deploy する。
+
+    エラー方針 / 認証の詳細は [`./README.md`](./README.md) を参照。
+servers:
+  - url: "{controlPlaneApiUrl}"
+    description: Control Plane API (per-deployment URL)
+    variables:
+      controlPlaneApiUrl:
+        default: https://example.execute-api.ap-northeast-1.amazonaws.com/prod
+
+tags:
+  - name: control-plane
+    description: System Admin がテナント (= 主催者組織) を CRUD する。
+
+security:
+  - cognitoSystemAdmin: []
+
+paths:
+  /tenants:
+    get:
+      tags: [control-plane]
+      summary: テナント一覧取得
+      responses:
+        "200":
+          description: テナント一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "./_components.yaml#/components/schemas/Tenant"
+    post:
+      tags: [control-plane]
+      summary: テナント作成
+      description: |
+        作成と同時に EventBridge `onboardingRequest` イベントが publish され、
+        BASIC / STANDARD / PREMIUM tier は pooled stack を共有、PLATINUM tier は
+        `ServerlessSaaSPipeline` が CodeBuild を起動して silo stack を deploy する。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./_components.yaml#/components/schemas/CreateTenantRequest"
+      responses:
+        "200":
+          description: 作成完了
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "./_components.yaml#/components/schemas/Tenant"
+
+  /tenants/{tenantId}:
+    parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [control-plane]
+      summary: テナント詳細取得
+      responses:
+        "200":
+          description: テナント詳細
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/Tenant"
+    delete:
+      tags: [control-plane]
+      summary: テナント無効化 (soft delete)
+      description: |
+        SBT 0.3.9 の挙動として `isActive = false` にする (物理削除はしない)。
+        後続のリソース解放は別経路で行う想定。
+      responses:
+        "204":
+          description: 無効化完了
+
+components:
+  securitySchemes:
+    cognitoSystemAdmin:
+      $ref: "./_components.yaml#/components/securitySchemes/cognitoSystemAdmin"

--- a/docs/api/participant.openapi.yaml
+++ b/docs/api/participant.openapi.yaml
@@ -1,0 +1,137 @@
+openapi: 3.1.0
+info:
+  title: TenkaCloud Participant API
+  version: 1.0.0-mvp1
+  summary: 競技者がチームの問題状態を取得 / flag を提出する API
+  description: |
+    `ProblemDeployBackendStack` の `ParticipantPortal` Lambda が提供する Function URL
+    (`AuthType=NONE`) ベースの API。`teamLoginKey` を bearer として Lambda 内で検証する。
+
+    Tenant Admin が `POST /problems/:id/deploy` (Tenant API) を呼んだときに 1 度だけ
+    レスポンスに含まれる `teamLoginKey` を、競技者が手元に控えて本 API の bearer に使う。
+    Cognito を per-team 払い出すと運営コストが大きいため、短命キーを bearer にして
+    オペレーションコストをゼロに寄せる設計。
+
+    エラー方針 / 認証の詳細は [`./README.md`](./README.md) を参照。
+servers:
+  - url: "{participantApiUrl}"
+    description: Participant API (Lambda Function URL)
+    variables:
+      participantApiUrl:
+        default: https://abc.lambda-url.ap-northeast-1.on.aws
+
+tags:
+  - name: participant
+    description: 競技者用。teamLoginKey 認証でチームの問題状態 / flag 提出。
+  - name: meta
+    description: ヘルスチェック等。
+
+security:
+  - teamLoginKey: []
+
+paths:
+  /portal/healthz:
+    get:
+      tags: [meta]
+      summary: Participant API Lambda の生存確認
+      security: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+
+  /portal/me:
+    get:
+      tags: [participant]
+      summary: 自チームの問題状態を取得
+      description: |
+        `Authorization: Bearer <teamLoginKey>` で認証。`teamLoginKey` は Tenant Admin
+        が deploy 時に発行した短命キー。
+      responses:
+        "200":
+          description: 自チームの状態
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/ParticipantView"
+        "401":
+          $ref: "./_components.yaml#/components/responses/Unauthorized"
+    patch:
+      tags: [participant]
+      summary: 表示用チーム名を更新 (チームビルディング)
+      description: |
+        operator が deploy 時に入力した内部 slug ではなく、チーム自身が表示名を選ぶ。
+        既に削除中 (`DELETING`/`DELETED`) のチームは更新不可。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [teamName]
+              properties:
+                teamName:
+                  type: string
+                  minLength: 1
+                  maxLength: 40
+      responses:
+        "200":
+          description: 更新後の view
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/ParticipantView"
+        "400":
+          description: 不正なチーム名
+        "401":
+          $ref: "./_components.yaml#/components/responses/Unauthorized"
+
+  /portal/me/submit-flag:
+    post:
+      tags: [participant]
+      summary: Flag を提出 (Challenge 形式)
+      description: |
+        問題 metadata の `scoring.kind` が `flag` のときのみ受け付ける (Battle uptime 形式は
+        scoring engine 側で自動採点)。同一チームが既に正解 submit 済みなら再加算しない。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [flag]
+              properties:
+                flag:
+                  type: string
+                  minLength: 1
+                  maxLength: 200
+      responses:
+        "200":
+          description: 採点結果
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  kind:
+                    type: string
+                    enum: [correct, incorrect, already_solved]
+                  awarded:
+                    type: integer
+                  totalScore:
+                    type: integer
+        "400":
+          description: invalid_flag / not_flag_problem / no_outputs
+        "401":
+          $ref: "./_components.yaml#/components/responses/Unauthorized"
+
+components:
+  securitySchemes:
+    teamLoginKey:
+      $ref: "./_components.yaml#/components/securitySchemes/teamLoginKey"

--- a/docs/api/participant.openapi.yaml
+++ b/docs/api/participant.openapi.yaml
@@ -117,17 +117,32 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  kind:
-                    type: string
-                    enum: [correct, incorrect, already_solved]
-                  awarded:
-                    type: integer
-                  totalScore:
-                    type: integer
+                oneOf:
+                  - type: object
+                    required: [kind, scoreDelta, totalScore]
+                    properties:
+                      kind: { type: string, enum: [ok] }
+                      scoreDelta:
+                        type: integer
+                        description: 今回の正解で加算された点数
+                      totalScore: { type: integer }
+                  - type: object
+                    required: [kind, totalScore]
+                    properties:
+                      kind: { type: string, enum: [already_scored] }
+                      totalScore: { type: integer }
+                  - type: object
+                    required: [kind]
+                    properties:
+                      kind: { type: string, enum: [wrong] }
         "400":
-          description: invalid_flag / not_flag_problem / no_outputs
+          description: |
+            invalid_flag (form 不正) / not_flag_problem (kind=uptime の問題に submit) /
+            no_outputs (deploy 未完了で flag が CFn Outputs に無い)
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/ErrorResponse"
         "401":
           $ref: "./_components.yaml#/components/responses/Unauthorized"
 

--- a/docs/api/tenant.openapi.yaml
+++ b/docs/api/tenant.openapi.yaml
@@ -1,0 +1,197 @@
+openapi: 3.1.0
+info:
+  title: TenkaCloud Tenant API
+  version: 1.0.0-mvp1
+  summary: Tenant Admin が問題を競技者アカウントへ deploy / 削除 / 一覧する API
+  description: |
+    `TenantTemplateStack` に 1 tenant に 1 つ立つ REST API。Cognito (per-tenant
+    UserPool) で認可。Tenant Admin が「問題カタログ → 競技アカウントへデプロイ」を
+    起動する経路。
+
+    deploy / delete はいずれも非同期 (Lambda → EventBridge → Step Functions →
+    CodeBuild → CloudFormation)。詳細は [`./README.md`](./README.md) のライフサイクル節
+    を参照。
+
+    エラー方針 / 認証の詳細も [`./README.md`](./README.md) を参照。
+servers:
+  - url: "{tenantApiUrl}"
+    description: Tenant API (per-tenant URL, runtime-config.json 経由)
+    variables:
+      tenantApiUrl:
+        default: https://example.execute-api.ap-northeast-1.amazonaws.com/prod
+
+tags:
+  - name: tenant
+    description: Tenant Admin 用。問題 deploy の起動 / 状態管理。
+  - name: meta
+    description: ヘルスチェック等。
+
+security:
+  - cognitoTenantAdmin: []
+
+paths:
+  /healthz:
+    get:
+      tags: [meta]
+      summary: Tenant API Lambda の生存確認
+      security: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+
+  /problems/{problemId}/deploy:
+    parameters:
+      - name: problemId
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$"
+    post:
+      tags: [tenant]
+      summary: 問題を競技者アカウントへデプロイ
+      description: |
+        deploy job を 1 件作成し、EventBridge `DeployCreateRequested` event を publish する。
+        実際の deploy は `DeployCreateStateMachine` が CodeBuild Project (= `scripts/deploy-battles.sh`)
+        を起動して非同期に実行される。
+
+        レスポンスの `teamLoginKey` は **この経路でしか露出しない短命キー**。Tenant Admin が
+        競技者に hand-off する。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./_components.yaml#/components/schemas/DeployRequest"
+      responses:
+        "202":
+          description: 受付完了 (実 deploy は非同期)
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/DeployResponse"
+        "400":
+          $ref: "./_components.yaml#/components/responses/ValidationError"
+        "404":
+          description: 未知の problemId
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/ErrorResponse"
+
+  /problems/{problemId}/deployments:
+    parameters:
+      - name: problemId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+      - name: cursor
+        in: query
+        schema: { type: string }
+    get:
+      tags: [tenant]
+      summary: 指定問題の deploy ジョブ一覧
+      responses:
+        "200":
+          description: deploy ジョブ一覧
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/DeploymentListResponse"
+
+  /deployments:
+    get:
+      tags: [tenant]
+      summary: tenant 全体の deploy ジョブ一覧 (新しい順)
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - name: cursor
+          in: query
+          schema: { type: string }
+      responses:
+        "200":
+          description: deploy ジョブ一覧
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/DeploymentListResponse"
+
+  /deployments/{jobId}:
+    parameters:
+      - name: jobId
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$"
+          description: ULID
+    get:
+      tags: [tenant]
+      summary: deploy ジョブ詳細
+      description: 詳細取得経路では `teamLoginKey` を含む (一覧経路では露出しない)。
+      responses:
+        "200":
+          description: deploy ジョブ
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/DeploymentDetail"
+        "404":
+          $ref: "./_components.yaml#/components/responses/NotFound"
+    delete:
+      tags: [tenant]
+      summary: deploy ジョブを削除 (CFn DeleteStack 起動)
+      description: |
+        `DELETING` に status を上げ、EventBridge `DeployDeleteRequested` event を
+        publish する。`DeployDeleteStateMachine` が CodeBuild Project (`OPERATION=delete`)
+        で `scripts/delete-battles.sh` を実行し、同一 account の CFn DeleteStack を
+        非同期に発火する。完了で status は `DELETED`、失敗で `FAILED` になる。
+      responses:
+        "202":
+          description: 受付完了 (実 削除は非同期)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [accepted]
+                  previousStatus:
+                    $ref: "./_components.yaml#/components/schemas/DeploymentStatus"
+        "200":
+          description: 既に削除中 / 削除済み (no-op)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [already_deleted]
+        "404":
+          $ref: "./_components.yaml#/components/responses/NotFound"
+        "409":
+          description: 並行更新による race
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/ErrorResponse"
+
+components:
+  securitySchemes:
+    cognitoTenantAdmin:
+      $ref: "./_components.yaml#/components/securitySchemes/cognitoTenantAdmin"


### PR DESCRIPTION
## Summary

旧 docs-site/guide/api/{tenant,problem}.md (PR-D 削除済) で提供されていた API リファレンスを v2 構造に合わせて再構築する。

設計判断: 1 ファイル統合か plane 分離 (3 ファイル) か。Slack / Stripe / GitHub 等の **single-audience multi-tenant SaaS** は 1 ファイル統合が多数派だが、TenkaCloud は Auth0 / Atlassian / Microsoft Graph 等と同じ **multi-plane / multi-audience** SaaS であり、責務 / 凝集性の観点で plane 分離が筋。本 repo の \`INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER\` (Plane 分離思想) とも整合する。

ファイル構成:

- \`README.md\`               — 全 plane の俯瞰 + 認証 + IAM 最小権限早見表
- \`_components.yaml\`        — 共通 schema / securityScheme / responses
- \`control-plane.openapi.yaml\` — System Admin (テナント CRUD)
- \`tenant.openapi.yaml\`     — Tenant Admin (問題 deploy / 一覧 / 削除)
- \`participant.openapi.yaml\` — 競技者 (teamLoginKey 認証 + flag 提出)

各 plane は Stack / SPA / API GW と 1:1 対応する。

特筆: 「API ごとの実行権限」を README に表で整理。Lambda 自身は CFn を直接触らない (= 削除権限は CodeBuild Project Role に集約)、Participant Lambda は read 寄り + 自分の行の Update のみ等の最小権限設計を明示する。

## Regression 分析

- ドキュメント追加のみ。コード / インフラに影響なし
- Hono handler の zod スキーマと OpenAPI は **手動同期** が前提 (Phase 2 で \`@hono/zod-openapi\` 自動生成へ移行予定)。今回の追加で zod と spec が乖離すると参照ガイドとして信頼を失うが、初期版なので問題ない

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| CREATE | \`docs/api/\` 配下 5 ファイル | 仕様 + 共通 components + narrative |
| NO-OP  | コード / CDK / DDB | 不変 |

## Test plan

- [x] markdownlint / textlint / biome 緑
- [x] 既存 374 件 testsuite 緑 (\`make before-commit\`)
- [ ] \`nlx @redocly/cli build-docs docs/api/tenant.openapi.yaml -o /tmp/preview.html\` でローカルプレビュー (任意)

🤖 Generated with [Claude Code](https://claude.com/claude-code)