### PR TITLE
feat(events): ADR-004 Phase 1 — Events/Teams Table + CRUD API

### DIFF
--- a/docs/api/_components.yaml
+++ b/docs/api/_components.yaml
@@ -189,6 +189,131 @@ components:
           type: string
           description: 次ページの cursor (base64url JSON)
 
+    EventStatus:
+      type: string
+      enum: [DRAFT, DEPLOYING, READY, TEARDOWN, ARCHIVED]
+      description: |
+        Event のライフサイクル状態 (ADR-004 §2)。
+        DRAFT → DEPLOYING (Bulk Deploy 中) → READY → TEARDOWN → ARCHIVED。
+
+    EventProblemTarget:
+      type: object
+      required: [problemId, defaultAwsAccountId, defaultRegion]
+      properties:
+        problemId:
+          type: string
+          pattern: "^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$"
+        defaultAwsAccountId:
+          type: string
+          pattern: "^\\d{12}$"
+        defaultRegion:
+          type: string
+          pattern: "^[a-z]{2}-[a-z]+-\\d+$"
+
+    CreateEventRequest:
+      type: object
+      required: [name, teams, problems]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        teams:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            type: object
+            required: [internalSlug]
+            properties:
+              internalSlug:
+                type: string
+                minLength: 1
+                maxLength: 40
+                pattern: "^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$"
+        problems:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            $ref: "#/components/schemas/EventProblemTarget"
+
+    CreateEventResponse:
+      type: object
+      required: [eventId, status, createdAt, expiresAt, teams, problems]
+      properties:
+        eventId:
+          type: string
+          description: ULID
+        status: { $ref: "#/components/schemas/EventStatus" }
+        createdAt: { type: string, format: date-time }
+        expiresAt: { type: integer, description: TTL (epoch seconds) }
+        teams:
+          type: array
+          items:
+            type: object
+            required: [teamId, internalSlug, teamLoginKey]
+            properties:
+              teamId: { type: string }
+              internalSlug: { type: string }
+              teamLoginKey:
+                type: string
+                description: 短命キー、この経路でしか露出しない
+        problems:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventProblemTarget"
+
+    EventSummary:
+      type: object
+      required: [eventId, name, status, teamCount, problemCount, createdAt, updatedAt, expiresAt]
+      properties:
+        eventId: { type: string }
+        name: { type: string }
+        status: { $ref: "#/components/schemas/EventStatus" }
+        teamCount: { type: integer }
+        problemCount: { type: integer }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        expiresAt: { type: integer }
+
+    EventListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/EventSummary" }
+        nextCursor:
+          type: string
+          description: 次ページの cursor (base64url JSON)
+
+    TeamSummary:
+      type: object
+      required: [teamId, internalSlug]
+      properties:
+        teamId: { type: string }
+        internalSlug: { type: string }
+        displayName:
+          type: string
+          description: 競技者が PATCH /portal/me で設定した表示名
+        teamLoginKey:
+          type: string
+          description: 詳細経路でのみ露出 (operator の再取得用、一覧では含まれない)
+
+    EventDetail:
+      allOf:
+        - $ref: "#/components/schemas/EventSummary"
+        - type: object
+          required: [teams, problems]
+          properties:
+            teams:
+              type: array
+              items: { $ref: "#/components/schemas/TeamSummary" }
+            problems:
+              type: array
+              items: { $ref: "#/components/schemas/EventProblemTarget" }
+
     ParticipantScoringInfo:
       type: object
       required: [kind]

--- a/docs/api/tenant.openapi.yaml
+++ b/docs/api/tenant.openapi.yaml
@@ -23,6 +23,8 @@ servers:
 tags:
   - name: tenant
     description: Tenant Admin 用。問題 deploy の起動 / 状態管理。
+  - name: events
+    description: ADR-004 Phase 1。1 競技イベント = 1 行で teams + problems を持つ。
   - name: meta
     description: ヘルスチェック等。
 
@@ -190,6 +192,78 @@ paths:
             application/json:
               schema:
                 $ref: "./_components.yaml#/components/schemas/ErrorResponse"
+
+  /events:
+    get:
+      tags: [events]
+      summary: tenant の Event 一覧 (新しい順)
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - name: cursor
+          in: query
+          schema: { type: string }
+      responses:
+        "200":
+          description: Event 一覧
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/EventListResponse"
+    post:
+      tags: [events]
+      summary: 競技イベントを作成 (Event + Teams を原子的に書く)
+      description: |
+        Event 1 行 + Teams N 行を **DDB TransactWrite で原子的に書く**。レスポンスに含まれる
+        `teams[].teamLoginKey` は **この経路でしか露出しない短命キー**。Tenant Admin が
+        競技者に hand-off する。
+
+        制約:
+        - `teams.length` は 1〜100 (TransactWrite items 上限の 100 から event 1 行を引く)
+        - `problems.length` は 1〜50
+        - `teams[].internalSlug` 重複は `400 duplicate_internal_slug`
+        - `problems[].problemId` 重複は `400 duplicate_problem_id`
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "./_components.yaml#/components/schemas/CreateEventRequest"
+      responses:
+        "201":
+          description: 作成完了 (teamLoginKey はこの経路でしか露出しない)
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/CreateEventResponse"
+        "400":
+          $ref: "./_components.yaml#/components/responses/ValidationError"
+
+  /events/{eventId}:
+    parameters:
+      - name: eventId
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$"
+          description: ULID
+    get:
+      tags: [events]
+      summary: Event 詳細 (Event + Teams + Problems を返す)
+      description: |
+        詳細経路では `teams[].teamLoginKey` を **再露出する** (operator が hand-off で
+        紛失した場合の再取得用)。一覧経路 (`GET /events`) では露出しない。
+      responses:
+        "200":
+          description: Event 詳細
+          content:
+            application/json:
+              schema:
+                $ref: "./_components.yaml#/components/schemas/EventDetail"
+        "404":
+          $ref: "./_components.yaml#/components/responses/NotFound"
 
 components:
   securitySchemes:

--- a/docs/architecture/adr-004-event-team-model.md
+++ b/docs/architecture/adr-004-event-team-model.md
@@ -1,0 +1,201 @@
+# ADR-004: Event / Team モデルを正本にして、Deployment を (Event, Team, Problem) の派生にする
+
+- **Status**: Proposed (2026-05-07)
+- **Related ADR**: [ADR-001](./adr-001-problem-deploy-crud.md) (FR-1 / FR-6 を本 ADR で具体化)、[ADR-003](./adr-003-problem-catalog-ddb.md) (Problems の正本)
+- **Related issues**: #471 (problem-detail から deploy/削除)、Participant Portal 削除 UX 不在
+
+## Context
+
+現状実装は **「1 deployment = 1 (problem, team, account, region) の組み合わせ」** で、`teamLoginKey` も per-deployment に発行している。これは要件文書 [`docs/requirements/problem-deploy.md`](../requirements/problem-deploy.md) の FR-1 / FR-6 と整合しない。
+
+要件側の前提は次のとおり。
+
+- **FR-1**: 1 batch = 25 チーム × 30 問 = **750 stacks**。チームと問題は **2 軸**
+- **FR-6**: operator UI は「(1) 競技者アカウントの接続情報を登録 → (2) 25 × 30 の Challenge セットを選択して Deploy」(= **Event 単位の操作**)
+- ユーザ要望 (2026-05-07):「イベント作成時にやることは参加するチーム数を指定する。次にどの問題をデプロイするのか選ぶ (複数選べる、かつどのアカウント、どのリージョンにデプロイするのか問題ごとに指定できる)」
+
+つまり実体としては次のような階層がある。
+
+```
+Event (1)                              ← 1 競技イベント (例: "JAWS-UG 春の陣 2026")
+ ├─ Teams [N]                          ← 参加チーム
+ │   ├─ teamLoginKey (team scope)      ← 1 team = 1 key (event 中の M 問題で共有)
+ │   └─ displayTeamName / 内部 slug
+ └─ Deployments [N × M]
+     └─ (team_i, problem_j, awsAccount, region)
+         status / stackId / stackOutputs / score / ...
+```
+
+現状コードは Event / Team を概念として持たず、Deployment が単独で立っているため次の問題が出る。
+
+1. **チームに loginKey が複数発生する**: `team-alpha` が 30 問 deploy されると 30 個の `teamLoginKey` が発行され、競技者は問題ごとに別の key で login しなおす羽目になる
+2. **Operator が「イベント単位」で操作できない**: 750 stacks の create / status 把握 / cleanup を 1 ボタンで実行する経路がない (現状は ProblemDetail から 1 件ずつ deploy する手動運用)
+3. **Participant Portal で「自チームの全問題」を見せられない**: GSI2 が `TEAMKEY#<key>` だが、key が deployment ごとに変わるので 1 key で複数 deployment を引けない
+
+## Decision
+
+### 1. 3 つの Aggregate を別 DDB Table に立てる (= TenkaCloud の流儀)
+
+CLAUDE.md の方針「DynamoDB シングルテーブル設計はしない。stack ごとに専用テーブル」に従う。`ProblemDeployBackendStack` 内に **Events / Teams / Deployments の 3 Table を並列に持つ**。
+
+```
+[DDB] Events
+  PK: EVENT#<eventId>
+  SK: META
+  attrs: { eventId, tenantId, name, status, problems[], createdAt, updatedAt, expiresAt }
+  GSI1: TENANT#<tenantId> / createdAt        ← tenant の event 一覧 (新しい順)
+
+[DDB] Teams
+  PK: EVENT#<eventId>
+  SK: TEAM#<teamId>
+  attrs: { eventId, teamId, tenantId, displayName?, internalSlug, teamLoginKey, createdAt, expiresAt }
+  GSI1: TENANT#<tenantId> / EVENT#<eventId>  ← tenant 全 event の team 横断
+  GSI2: TEAMKEY#<teamLoginKey> / META        ← Participant Portal が key で引く
+
+[DDB] Deployments  (既存テーブルを Event-aware に再設計)
+  PK: EVENT#<eventId>
+  SK: TEAM#<teamId>#PROBLEM#<problemId>
+  attrs: { eventId, teamId, problemId, tenantId, awsAccountId, region,
+           namePrefix, status, stackId, stackOutputs, failureReason,
+           score, lastResult, endpointsHealth, flagSubmitted,
+           createdAt, updatedAt, expiresAt }
+  GSI1: TENANT#<tenantId> / createdAt        ← 既存の tenant 横断一覧 (互換維持)
+  GSI2: TEAMKEY#<teamLoginKey> / PROBLEM#<problemId>  ← Portal が team の問題リスト取得
+```
+
+設計ポイントは次のとおり。
+
+- **`teamLoginKey` は Teams に 1 つ**。Deployments には保存しない (重複の禁止)
+- Deployments の GSI2 PK は **Team.teamLoginKey をコピー** (= denormalize)。Portal が `Bearer <teamLoginKey>` で来たら Teams をまず引かずに直接 Deployments を Query できる
+- 旧 `(jobId, displayTeamName)` フィールドは削除。jobId 相当は `EVENT#<eventId>#TEAM#<teamId>#PROBLEM#<problemId>` の合成 ID で表現する
+
+### 2. CRUD operations は EventTemplate API + Bulk Apply で揃える
+
+Operations は次のとおり。
+
+| 操作 | endpoint | 認可 | 副作用 |
+|---|---|---|---|
+| Event Create | `POST /events` | TenantAdmin | Events 1 行 + Teams N 行 + (空の) Deployments table state |
+| Event Detail | `GET /events/{eventId}` | TenantAdmin | Event + Teams + Deployments の matrix |
+| Event List | `GET /events` | TenantAdmin | tenant の event 一覧 |
+| Bulk Deploy | `POST /events/{eventId}/deploy` | TenantAdmin | 選択された (team × problem × account/region) 組み合わせを **N × M 並列** で State Machine 起動 |
+| Bulk Delete | `POST /events/{eventId}/teardown` | TenantAdmin | event 配下の COMPLETE / FAILED な Deployments を全 DELETE |
+| Single Re-deploy | `POST /events/{eventId}/deployments/{teamId}/{problemId}/redeploy` | TenantAdmin | 失敗した 1 cell の retry |
+| Single Delete | `DELETE /events/{eventId}/deployments/{teamId}/{problemId}` | TenantAdmin | 1 cell の手動 teardown |
+| Event Delete | `DELETE /events/{eventId}` | TenantAdmin | Bulk Delete を発火 + 完了後に Event/Team 行を削除 |
+
+Bulk operations は **Step Functions Distributed Map** で並列化する (= ADR-001 §1 の経路を本格運用)。
+
+```
+POST /events/{id}/deploy
+  └ Lambda: Event/Teams を読んで (team × problem) を入力配列に組み立て
+     └ EventBridge "BulkDeployRequested" publish
+        └ State Machine (Distributed Map): 並列に既存 DeployCreate 経路を呼ぶ
+           └ CodeBuild × N×M → CFn CreateStack
+```
+
+### 3. Event Create 時に Teams を一括発番 (= teamLoginKey を一度に N 個発行)
+
+UI フローは次のとおり。
+
+1. operator が「Event 作成」画面で次の情報を入力する。
+   - Event 名 (例: "JAWS-UG 春の陣 2026")
+   - **チーム数** (例: 25)
+   - **問題セット** (チェックボックスで N 問選択)
+   - 各問題ごとに **default account / region**
+2. `POST /events` で次の処理が走る。
+   - Events 1 行 + Teams 25 行 (teamLoginKey を 25 個生成) を **TransactWrite** で原子的に書く
+   - 各 problem の deploy target (account/region) は Event.problems[]内に保存
+3. UI が teamLoginKey × 25 を **1 度だけ** 表示 (`Event 作成完了` モーダル)。CSV ダウンロード可
+4. operator が「Bulk Deploy」を押すと、25 × N の Deployments 行が PENDING で作成され、Distributed Map が並列起動
+
+### 4. Participant Portal は team scope に切り替える
+
+`GET /portal/me` のレスポンスを **「自チームに紐づく全問題のリスト」** に変える。
+
+```jsonc
+{
+  "team": {
+    "teamId": "...",
+    "displayTeamName": "Team Alpha",
+    "eventId": "...",
+    "eventName": "JAWS-UG 春の陣 2026"
+  },
+  "problems": [
+    {
+      "problemId": "hello-world-battle",
+      "status": "COMPLETE",
+      "score": 240,
+      "endpointsHealth": {...},
+      "flagSubmitted": false
+    },
+    // ... event の他問題
+  ]
+}
+```
+
+Lambda は `Bearer <teamLoginKey>` から Teams GSI2 で 1 行引き、`teamId` で Deployments を Query する (GSI2 で `TEAMKEY#<key>` でも可、片方を選ぶ)。
+
+### 5. 旧 deployment 経路は段階的に廃止
+
+破壊的変更を一気に入れない。**Phase 化** で進める。
+
+- **Phase 1 (本 ADR で承認後すぐ)**: Events / Teams Table を追加 + `POST /events` / `GET /events` / `GET /events/{id}` を新設。既存 `POST /problems/{id}/deploy` 経路は残す
+- **Phase 2**: `POST /events/{id}/deploy` (Distributed Map) を導入。UI に Event 作成 / Detail 画面を追加
+- **Phase 3**: 既存 `POST /problems/{id}/deploy` を deprecate (UI からの呼び出し削除)
+- **Phase 4**: 既存 routes と DDB の jobId-based 行を削除
+
+各 Phase は 1〜2 PR に閉じる。Phase 間で動く SaaS が壊れないことを `ONE_PASS_LOCAL` / `ONE_PASS_AWS` invariant で保証する。
+
+### 6. 既存 Deployments 行の扱い
+
+旧 (jobId-based) 行は **migration せず捨てる**。理由は次のとおり。
+
+- training / dev 用途のデータしか入っていない (本番運用前)
+- migration script を書くコストが、新規 deploy し直すコストより高い
+- Phase 4 で `make destroy` → 再 deploy で完全クリーンな状態にする
+
+ユーザに「Phase 4 で旧データは消えます。本番投入は新モデルで」と明示する。
+
+## Consequences
+
+### Positive
+
+- ✅ Operator が **Event 単位 1 ボタン** で 750 stacks を扱える (FR-1 達成)
+- ✅ 競技者が **1 つの teamLoginKey** で event の全問題にアクセス可 (UX 単純化)
+- ✅ Participant Portal で「自チームの全問題リスト + スコア合計」が出せる (Battle/Challenge UX 統一)
+- ✅ 削除も Event 単位 / Team 単位 / 1 cell 単位の 3 階層で操作可
+- ✅ ADR-001 が想定していた **Distributed Map** の本格運用に到達
+
+### Negative
+
+- ❌ 既存 Deployments の jobId 構造が破壊される。training データは捨てる
+- ❌ DDB Table が 1 → 3 に増える (各 1 RCU/WCU PROVISIONED で約 +$0.5/月、Free Tier 25 内に収まる)
+- ❌ Lambda + UI の同時改修が大きい (4 Phase に分けて mitigation)
+- ❌ Step Functions Distributed Map の AWS quota (default 1000 並列) に注意。FR-1 750 stacks は OK だが、複数 event を同時に走らせると衝突する → operator UI で「同時 1 event のみ」制約を入れる
+
+### Risks (= 失敗したら戻る経路)
+
+- TransactWrite 上限 (100 items) の制約 — 1 event = 100 teams を超えるイベントには対応しない (要件は 25 teams なので余裕)
+- Distributed Map の Step Functions cost — 750 stacks × $0.025 / 1000 transitions × 数 transitions = 数セント / event。許容
+- Phase 3 の deprecation 後に既存 UI 経路を呼ぶ古い browser タブ → 410 Gone を返して reload 促す
+
+## Open questions (本 ADR では決めず deferred)
+
+1. **Event のスケジュール (start / end)** — 自動 teardown の起点を Event.endAt にするか、現行の TTL 8 時間を維持するか
+2. **Team の動的追加 / 削除** — Event 開始後に team 追加 (= teamLoginKey 追加) は許すか
+3. **採点 leaderboard** — Event scope で `Top N teams` を返す `GET /events/{id}/leaderboard` を Phase 5 で追加
+4. **Cross-account の AssumeRole** — ADR-002 と組み合わせて Phase 5 で
+
+## Phase 1 のスコープ (即着手分)
+
+本 PR で行う作業は次のとおり。
+
+1. ADR-004 起草 (本ファイル)
+2. (CDK) `Events` / `Teams` Table を `ProblemDeployBackendStack` に追加
+3. (Lambda) `POST /events` / `GET /events` / `GET /events/{id}` の handler 追加
+4. (Tenant API) routes を api-gateway.ts に追加
+5. テスト追加 (TransactWrite 原子性、TenantId mismatch 404、teamLoginKey 一意性)
+6. `tenant.openapi.yaml` 更新
+
+UI 追加 (EventCreate / EventList / EventDetail) は Phase 2 に回す。

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -232,6 +232,7 @@ const tenantTemplateStack = new TenantTemplateStack(
     tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
     commitId,
     deployApiLambda: problemDeployBackendStack.deployApiLambda,
+    eventApiLambda: problemDeployBackendStack.eventApiLambda,
   },
 );
 

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -1,0 +1,57 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface EventApiLambdaProps {
+  readonly eventsTable: Table;
+  readonly teamsTable: Table;
+  /**
+   * tenantId として handler に渡す `DEFAULT_TENANT_ID` env (DeployApi と同じ fallback)。
+   * Cognito JWT 結線後は JWT claim から取る。
+   */
+  readonly defaultTenantId?: string;
+}
+
+/**
+ * Event / Team CRUD 用の Lambda (ADR-004 Phase 1)。
+ *
+ * tenant API (TenantTemplateStack の REST API + Cognito authorizer) から
+ * `LambdaIntegration` で invoke される。Phase 1 は CRUD のみで、Bulk Deploy /
+ * Bulk Teardown は Phase 2 で別 Lambda + Step Functions Distributed Map に拡張する。
+ */
+export class EventApiLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: EventApiLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/event-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(15),
+      memorySize: 256,
+      environment: {
+        EVENTS_TABLE_NAME: props.eventsTable.tableName,
+        TEAMS_TABLE_NAME: props.teamsTable.tableName,
+        DEFAULT_TENANT_ID: props.defaultTenantId ?? "unknown-tenant",
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // 必要な権限: Events / Teams 両 Table の RW (TransactWrite で同時 Put + 詳細取得 Query)。
+    // EventBridge は Phase 2 (Bulk Deploy) で初めて要る、Phase 1 では publish しない。
+    props.eventsTable.grantReadWriteData(this.fn);
+    props.teamsTable.grantReadWriteData(this.fn);
+  }
+}

--- a/infrastructure/lib/problem-deploy/events-table.ts
+++ b/infrastructure/lib/problem-deploy/events-table.ts
@@ -1,0 +1,51 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * 1 競技イベント (= 1 Event) を 1 行で記録する DynamoDB テーブル (ADR-004 Phase 1)。
+ *
+ * Schema:
+ *   PK: EVENT#<eventId>     (eventId = ULID)
+ *   SK: META
+ *
+ * 主な属性:
+ *   eventId / tenantId / name / status / problems[] / createdAt / updatedAt / expiresAt
+ *
+ * `problems[]` は { problemId, defaultAwsAccountId, defaultRegion } の配列で、
+ * Bulk Deploy 時に各 team × problem の deploy target を解決するのに使う。
+ *
+ * GSI1 (テナント別の event 一覧):
+ *   PK: TENANT#<tenantId>
+ *   SK: createdAt (ISO8601)
+ *
+ * Capacity / lifecycle:
+ *   provisioned 1/1 (DynamoDbLowCapacity Aspect でさらに均す)。training / 競技イベント
+ *   中の用途で QPS 極小、コスト 0 原則を優先する。
+ *   削除方針: RETAIN。stack delete でユーザの event 履歴を意図せず消さない。
+ */
+export class EventsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+      timeToLiveAttribute: "expiresAt",
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI1",
+      partitionKey: { name: "GSI1PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
@@ -1,0 +1,156 @@
+import { TransactWriteCommand, type TransactWriteCommandInput } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+import { generateTeamLoginKey } from "../deploy-handler/team-key.js";
+import type { EventSharedResources } from "./shared.js";
+import type { CreateEventRequest, CreateEventResponse, EventItem, TeamItem } from "./types.js";
+
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 日
+
+const toEpochSeconds = (ms: number): number => Math.floor(ms / 1000);
+
+export interface CreateEventContext {
+  readonly tenantId: string;
+  readonly nowMs: number;
+  readonly ttlMs?: number;
+}
+
+export class DuplicateInternalSlugError extends Error {
+  constructor(public readonly slug: string) {
+    super(`duplicate internalSlug in request: ${slug}`);
+    this.name = "DuplicateInternalSlugError";
+  }
+}
+
+export class DuplicateProblemIdError extends Error {
+  constructor(public readonly problemId: string) {
+    super(`duplicate problemId in request: ${problemId}`);
+    this.name = "DuplicateProblemIdError";
+  }
+}
+
+/**
+ * Event 1 行 + Teams N 行を **TransactWrite で原子的に書く**。
+ *
+ * 失敗セマンティクス: TransactWrite は all-or-nothing なので、teamLoginKey の重複等で
+ * 1 件でも失敗したら全行が書かれない。caller は呼び直しで OK (eventId は ULID なので
+ * idempotent ではない、新規生成する)。
+ *
+ * `teams` の internalSlug 重複と `problems` の problemId 重複は **caller 側で validate**
+ * すべきだが、defense-in-depth で本関数でもチェックする (ConditionalCheckFailed より分かりやすい)。
+ */
+export async function createEvent(
+  shared: EventSharedResources,
+  ctx: CreateEventContext,
+  req: CreateEventRequest,
+): Promise<CreateEventResponse> {
+  validateNoDuplicateSlugs(req);
+  validateNoDuplicateProblems(req);
+
+  const eventId = ulid();
+  const nowMs = ctx.nowMs;
+  const createdAt = new Date(nowMs).toISOString();
+  const expiresAt = toEpochSeconds(nowMs + (ctx.ttlMs ?? DEFAULT_TTL_MS));
+
+  const teams = req.teams.map((t) => {
+    const teamId = ulid();
+    const teamLoginKey = generateTeamLoginKey();
+    const item: TeamItem = {
+      PK: `EVENT#${eventId}`,
+      SK: `TEAM#${teamId}`,
+      GSI1PK: `TENANT#${ctx.tenantId}`,
+      GSI1SK: `EVENT#${eventId}#TEAM#${teamId}`,
+      GSI2PK: `TEAMKEY#${teamLoginKey}`,
+      GSI2SK: "META",
+      eventId,
+      teamId,
+      tenantId: ctx.tenantId,
+      internalSlug: t.internalSlug,
+      teamLoginKey,
+      createdAt,
+      updatedAt: createdAt,
+      expiresAt,
+    };
+    return item;
+  });
+
+  const eventItem: EventItem = {
+    PK: `EVENT#${eventId}`,
+    SK: "META",
+    GSI1PK: `TENANT#${ctx.tenantId}`,
+    GSI1SK: createdAt,
+    eventId,
+    tenantId: ctx.tenantId,
+    name: req.name,
+    status: "DRAFT",
+    problems: req.problems,
+    teamCount: teams.length,
+    createdAt,
+    updatedAt: createdAt,
+    expiresAt,
+  };
+
+  // TransactWrite は 100 items が AWS の上限。teams.max(100) + event 1 = 最大 101 で
+  // 上限を超えるが、検証で teams を <= 99 に絞るより、teams を <= 100 にして event を
+  // 別 PutCommand で先に書く方針は採らない (atomicity を優先)。
+  // → Schema で teams.max(100) としているが、実際は 99 がワーカブル上限。安全側に寄せて
+  //   teams.max(99) にする方針もあるが、Phase 1 はまず TransactWrite 上限ギリギリで動かし、
+  //   Phase 2 (Distributed Map) で chunk 化する。
+  if (teams.length + 1 > 100) {
+    // 上限の早期チェック (TransactWrite が ValidationException を返すのを待たず明示的に)
+    throw new Error(`TransactWrite items > 100 (teams=${teams.length} + event=1)`);
+  }
+
+  const transact: TransactWriteCommandInput = {
+    TransactItems: [
+      {
+        Put: {
+          TableName: shared.eventsTableName,
+          Item: eventItem,
+          // 同一 eventId 二重生成防止 (実質起こらないが defense-in-depth)
+          ConditionExpression: "attribute_not_exists(PK)",
+        },
+      },
+      ...teams.map((t) => ({
+        Put: {
+          TableName: shared.teamsTableName,
+          Item: t,
+          ConditionExpression: "attribute_not_exists(PK)",
+        },
+      })),
+    ],
+  };
+  await shared.ddb.send(new TransactWriteCommand(transact));
+
+  return {
+    eventId,
+    status: eventItem.status,
+    createdAt,
+    expiresAt,
+    teams: teams.map((t) => ({
+      teamId: t.teamId,
+      internalSlug: t.internalSlug,
+      teamLoginKey: t.teamLoginKey,
+    })),
+    problems: req.problems,
+  };
+}
+
+function validateNoDuplicateSlugs(req: CreateEventRequest): void {
+  const seen = new Set<string>();
+  for (const team of req.teams) {
+    if (seen.has(team.internalSlug)) {
+      throw new DuplicateInternalSlugError(team.internalSlug);
+    }
+    seen.add(team.internalSlug);
+  }
+}
+
+function validateNoDuplicateProblems(req: CreateEventRequest): void {
+  const seen = new Set<string>();
+  for (const p of req.problems) {
+    if (seen.has(p.problemId)) {
+      throw new DuplicateProblemIdError(p.problemId);
+    }
+    seen.add(p.problemId);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -1,0 +1,125 @@
+import { Hono } from "hono";
+import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
+import { handle } from "hono/aws-lambda";
+import { cors } from "hono/cors";
+import { resolveTenantId } from "../deploy-handler/auth.js";
+import {
+  HTTP_BAD_REQUEST,
+  HTTP_CREATED,
+  HTTP_INTERNAL_ERROR,
+  HTTP_NOT_FOUND,
+  HTTP_OK,
+} from "../shared/http-status.js";
+import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
+import { getEventDetail, listEvents } from "./list.js";
+import { buildEventSharedResources } from "./shared.js";
+import { CreateEventRequestSchema } from "./types.js";
+
+/**
+ * Event API Lambda の Hono app (ADR-004 Phase 1)。routes:
+ *   POST /events
+ *   GET  /events
+ *   GET  /events/:eventId
+ *
+ * Auth: tenant API GW + Cognito JWT authorizer。tenantId は JWT `custom:tenantId` claim
+ * から `resolveTenantId` で抽出する (DeployApi Lambda と同じ shape)。
+ */
+
+const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID
+const LIST_LIMIT_MAX = 200;
+
+const shared = buildEventSharedResources();
+
+function parseLimit(value: string | undefined): { ok: true; limit: number | undefined } | null {
+  if (value === undefined) return { ok: true, limit: undefined };
+  const limit = Number.parseInt(value, 10);
+  if (!Number.isFinite(limit) || limit < 1 || limit > LIST_LIMIT_MAX) return null;
+  return { ok: true, limit };
+}
+
+const app = new Hono();
+
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    maxAge: 600,
+  }),
+);
+
+app.get("/events/healthz", (c) => c.json({ ok: true }));
+
+app.post("/events", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "request body must be JSON" }, HTTP_BAD_REQUEST);
+  }
+
+  const parsed = CreateEventRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "validation failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
+  }
+
+  try {
+    const response = await createEvent(
+      shared,
+      { tenantId: resolveTenantId(c), nowMs: Date.now() },
+      parsed.data,
+    );
+    return c.json(response, HTTP_CREATED);
+  } catch (err) {
+    if (err instanceof DuplicateInternalSlugError) {
+      return c.json({ error: "duplicate_internal_slug", slug: err.slug }, HTTP_BAD_REQUEST);
+    }
+    if (err instanceof DuplicateProblemIdError) {
+      return c.json({ error: "duplicate_problem_id", problemId: err.problemId }, HTTP_BAD_REQUEST);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] createEvent failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.get("/events", async (c) => {
+  const parsedLimit = parseLimit(c.req.query("limit"));
+  if (!parsedLimit) return c.json({ error: "invalid limit" }, HTTP_BAD_REQUEST);
+  try {
+    const response = await listEvents(shared, {
+      tenantId: resolveTenantId(c),
+      limit: parsedLimit.limit,
+      cursor: c.req.query("cursor"),
+    });
+    return c.json(response, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] listEvents failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.get("/events/:eventId", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const detail = await getEventDetail(shared, resolveTenantId(c), eventId);
+    if (!detail) return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    return c.json(detail, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] getEventDetail failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+export const handler = handle(app) as (
+  event: LambdaEvent,
+  context: LambdaContext,
+) => Promise<unknown>;
+
+export { app };

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -1,0 +1,125 @@
+import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { EventSharedResources } from "./shared.js";
+import type { EventDetail, EventItem, EventSummary, TeamItem, TeamSummary } from "./types.js";
+
+export interface ListEventsRequest {
+  readonly tenantId: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export interface ListEventsResponse {
+  readonly items: readonly EventSummary[];
+  readonly nextCursor?: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), "utf8").toString("base64url");
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> | undefined {
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // 不正な cursor は無視して最初から
+  }
+  return undefined;
+}
+
+function toSummary(item: Partial<EventItem>): EventSummary {
+  return {
+    eventId: String(item.eventId ?? ""),
+    name: String(item.name ?? ""),
+    status: (item.status ?? "DRAFT") as EventSummary["status"],
+    teamCount: Number(item.teamCount ?? 0),
+    problemCount: Array.isArray(item.problems) ? item.problems.length : 0,
+    createdAt: String(item.createdAt ?? ""),
+    updatedAt: String(item.updatedAt ?? ""),
+    expiresAt: Number(item.expiresAt ?? 0),
+  };
+}
+
+/**
+ * 指定 tenant の Event 一覧を新しい順に返す (GSI1: TENANT#<tenantId> / createdAt)。
+ */
+export async function listEvents(
+  shared: EventSharedResources,
+  req: ListEventsRequest,
+): Promise<ListEventsResponse> {
+  const limit = Math.min(Math.max(req.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const exclusiveStartKey = req.cursor ? decodeCursor(req.cursor) : undefined;
+
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.eventsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TENANT#${req.tenantId}` },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  const items = (out.Items ?? []).map((i) => toSummary(i as Partial<EventItem>));
+  const nextCursor = out.LastEvaluatedKey
+    ? encodeCursor(out.LastEvaluatedKey as Record<string, unknown>)
+    : undefined;
+  return { items, nextCursor };
+}
+
+/**
+ * 指定 eventId の Event 詳細 + Teams 一覧を返す。`tenantId` 不一致は undefined (404 相当)。
+ *
+ * teams[].teamLoginKey は **詳細経路でのみ露出** (operator が hand-off に使うため)。
+ * 一覧経路 (`listEvents`) では teams 自体を返さない。
+ */
+export async function getEventDetail(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+): Promise<EventDetail | undefined> {
+  const eventOut = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+    }),
+  );
+  const event = eventOut.Item as Partial<EventItem> | undefined;
+  if (!event) return undefined;
+  if (event.tenantId !== tenantId) return undefined;
+
+  // Teams は EVENT#<eventId> をパーティションに、SK begins_with TEAM# で全件取る。
+  // teams.max(100) なので 1 query で確定。
+  const teamsOut = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.teamsTableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :tprefix)",
+      ExpressionAttributeValues: {
+        ":pk": `EVENT#${eventId}`,
+        ":tprefix": "TEAM#",
+      },
+    }),
+  );
+  const teamItems = (teamsOut.Items ?? []) as Partial<TeamItem>[];
+  const teams: TeamSummary[] = teamItems.map((t) => ({
+    teamId: String(t.teamId ?? ""),
+    internalSlug: String(t.internalSlug ?? ""),
+    displayName: typeof t.displayName === "string" ? t.displayName : undefined,
+    teamLoginKey: typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
+  }));
+
+  const summary = toSummary(event);
+  return {
+    ...summary,
+    problems: Array.isArray(event.problems) ? (event.problems as EventDetail["problems"]) : [],
+    teams,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -86,28 +86,31 @@ export async function getEventDetail(
   tenantId: string,
   eventId: string,
 ): Promise<EventDetail | undefined> {
-  const eventOut = await shared.ddb.send(
-    new GetCommand({
-      TableName: shared.eventsTableName,
-      Key: { PK: `EVENT#${eventId}`, SK: "META" },
-    }),
-  );
+  // Event Get と Teams Query は依存関係なし → 並列発火でラウンドトリップを 1 回分節約。
+  // 不正 eventId のとき teams query が無駄になるが、空 partition の query は 1 RCU 程度。
+  // teams.max(100) なので 1 query で確定。
+  const [eventOut, teamsOut] = await Promise.all([
+    shared.ddb.send(
+      new GetCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+      }),
+    ),
+    shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.teamsTableName,
+        KeyConditionExpression: "PK = :pk AND begins_with(SK, :tprefix)",
+        ExpressionAttributeValues: {
+          ":pk": `EVENT#${eventId}`,
+          ":tprefix": "TEAM#",
+        },
+      }),
+    ),
+  ]);
   const event = eventOut.Item as Partial<EventItem> | undefined;
   if (!event) return undefined;
   if (event.tenantId !== tenantId) return undefined;
 
-  // Teams は EVENT#<eventId> をパーティションに、SK begins_with TEAM# で全件取る。
-  // teams.max(100) なので 1 query で確定。
-  const teamsOut = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.teamsTableName,
-      KeyConditionExpression: "PK = :pk AND begins_with(SK, :tprefix)",
-      ExpressionAttributeValues: {
-        ":pk": `EVENT#${eventId}`,
-        ":tprefix": "TEAM#",
-      },
-    }),
-  );
   const teamItems = (teamsOut.Items ?? []) as Partial<TeamItem>[];
   const teams: TeamSummary[] = teamItems.map((t) => ({
     teamId: String(t.teamId ?? ""),

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -1,0 +1,21 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+
+/**
+ * Event handler Lambda module-scope で 1 度だけ build される shared resources。
+ * Events / Teams の 2 Table 名と DocumentClient を保持する。
+ */
+export interface EventSharedResources {
+  readonly eventsTableName: string;
+  readonly teamsTableName: string;
+  readonly ddb: DynamoDBDocumentClient;
+}
+
+export function buildEventSharedResources(): EventSharedResources {
+  return {
+    eventsTableName: getEnv("EVENTS_TABLE_NAME"),
+    teamsTableName: getEnv("TEAMS_TABLE_NAME"),
+    ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+/**
+ * 1 競技イベント (= ADR-004 の Event aggregate) の DDB 行 shape。
+ *
+ *   PK     = `EVENT#<eventId>` / SK = `META`
+ *   GSI1PK = `TENANT#<tenantId>` / GSI1SK = `<createdAt>` (ISO8601)
+ */
+export interface EventItem {
+  PK: string;
+  SK: "META";
+  GSI1PK: string;
+  GSI1SK: string;
+
+  eventId: string;
+  tenantId: string;
+  name: string;
+  status: EventStatus;
+  problems: EventProblemTarget[];
+  teamCount: number;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: number;
+}
+
+export const EventStatusSchema = z.enum(["DRAFT", "DEPLOYING", "READY", "TEARDOWN", "ARCHIVED"]);
+export type EventStatus = z.infer<typeof EventStatusSchema>;
+
+/**
+ * Event 内の 1 問題ごとの **デフォルト deploy target**。Bulk Deploy 時に各 team に対して
+ * この account / region で deploy する。team ごとに override したい場合は将来拡張。
+ */
+export const EventProblemTargetSchema = z.object({
+  problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
+  defaultAwsAccountId: z.string().regex(/^\d{12}$/, "AWS Account ID は 12 桁の数字"),
+  defaultRegion: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/, "AWS region 形式が不正です"),
+});
+export type EventProblemTarget = z.infer<typeof EventProblemTargetSchema>;
+
+/**
+ * Team aggregate の DDB 行 shape。
+ *
+ *   PK     = `EVENT#<eventId>` / SK = `TEAM#<teamId>`
+ *   GSI1PK = `TENANT#<tenantId>` / GSI1SK = `EVENT#<eventId>#TEAM#<teamId>`
+ *   GSI2PK = `TEAMKEY#<teamLoginKey>` / GSI2SK = `META` (sparse)
+ */
+export interface TeamItem {
+  PK: string;
+  SK: string;
+  GSI1PK: string;
+  GSI1SK: string;
+  GSI2PK?: string;
+  GSI2SK?: string;
+
+  eventId: string;
+  teamId: string;
+  tenantId: string;
+  /** 競技者が portal `PATCH /portal/me` で設定する表示名。未設定時は internalSlug を使う。 */
+  displayName?: string;
+  /** operator 入力 (or 自動生成) の内部 slug。CFn StackName 由来になる、deploy 後 immutable。 */
+  internalSlug: string;
+  /** 短命 bearer。team scope (1 key で event 内 N 問題にアクセス可)。 */
+  teamLoginKey: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: number;
+}
+
+/**
+ * `POST /events` のリクエスト body。
+ *
+ * `teams` には internalSlug を operator が指定する。チーム数だけ array を送る。
+ * `problems` には deploy する problemId と各々の default account / region。
+ */
+export const CreateEventRequestSchema = z.object({
+  name: z.string().min(1).max(120),
+  teams: z
+    .array(
+      z.object({
+        internalSlug: z
+          .string()
+          .min(1)
+          .max(40)
+          .regex(
+            /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/,
+            "internalSlug は a-z0-9- (RFC1035-ish) のみ",
+          ),
+      }),
+    )
+    .min(1)
+    .max(100, "1 event あたり 100 teams が DDB TransactWrite 上限"),
+  problems: z.array(EventProblemTargetSchema).min(1).max(50),
+});
+export type CreateEventRequest = z.infer<typeof CreateEventRequestSchema>;
+
+/**
+ * `POST /events` のレスポンス。teamLoginKey は **この経路でしか露出しない短命キー**。
+ * 競技者への hand-off は本レスポンスを保存して operator が手動配布する。
+ */
+export const CreateEventResponseSchema = z.object({
+  eventId: z.string(),
+  status: EventStatusSchema,
+  createdAt: z.string(),
+  expiresAt: z.number(),
+  teams: z.array(
+    z.object({
+      teamId: z.string(),
+      internalSlug: z.string(),
+      teamLoginKey: z.string(),
+    }),
+  ),
+  problems: z.array(EventProblemTargetSchema),
+});
+export type CreateEventResponse = z.infer<typeof CreateEventResponseSchema>;
+
+export const EventSummarySchema = z.object({
+  eventId: z.string(),
+  name: z.string(),
+  status: EventStatusSchema,
+  teamCount: z.number(),
+  problemCount: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  expiresAt: z.number(),
+});
+export type EventSummary = z.infer<typeof EventSummarySchema>;
+
+export const TeamSummarySchema = z.object({
+  teamId: z.string(),
+  internalSlug: z.string(),
+  displayName: z.string().optional(),
+  /** 詳細経路でのみ teamLoginKey を返す。一覧経路には含めない。 */
+  teamLoginKey: z.string().optional(),
+});
+export type TeamSummary = z.infer<typeof TeamSummarySchema>;
+
+export const EventDetailSchema = EventSummarySchema.extend({
+  problems: z.array(EventProblemTargetSchema),
+  teams: z.array(TeamSummarySchema),
+});
+export type EventDetail = z.infer<typeof EventDetailSchema>;

--- a/infrastructure/lib/problem-deploy/handlers/shared/http-status.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/http-status.ts
@@ -5,6 +5,7 @@
  * Hono の `ContentfulStatusCode` は number union なので as const で number 互換に保つ。
  */
 export const HTTP_OK = 200 as const;
+export const HTTP_CREATED = 201 as const;
 export const HTTP_ACCEPTED = 202 as const;
 export const HTTP_BAD_REQUEST = 400 as const;
 export const HTTP_UNAUTHORIZED = 401 as const;

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -10,6 +10,8 @@ import { DeployCreateStateMachine } from "./deploy-create-state-machine";
 import { DeployDeleteStateMachine } from "./deploy-delete-state-machine";
 import { DeployDeleteEventRule, DeployEventRule } from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
+import { EventApiLambda } from "./event-api-lambda";
+import { EventsTable } from "./events-table";
 import { HealthCheckLambda } from "./health-check-lambda";
 import {
   DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
@@ -17,6 +19,7 @@ import {
   type ParticipantPortalRuntimeConfig,
 } from "./participant-portal-hosting";
 import { ParticipantPortalLambda } from "./participant-portal-lambda";
+import { TeamsTable } from "./teams-table";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
   /** SBT ControlPlane の EventBus ARN。Deploy 系イベントを流す。 */
@@ -71,11 +74,19 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
 export class ProblemDeployBackendStack extends cdk.Stack {
   /** tenant API から `LambdaIntegration` で invoke される Lambda。 */
   public readonly deployApiLambda: IFunction;
+  /**
+   * Event / Team CRUD 用の Lambda (ADR-004 Phase 1)。tenant API から invoke される。
+   */
+  public readonly eventApiLambda: IFunction;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
 
     const deployments = new DeploymentsTable(this, "Deployments");
+    // ADR-004 Phase 1: Event / Team の 2 Table を Deployments と並列に持つ。
+    // Phase 2 で Bulk Deploy / Bulk Teardown を State Machine 経由で動かす。
+    const events = new EventsTable(this, "Events");
+    const teams = new TeamsTable(this, "Teams");
     const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
@@ -86,6 +97,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsCatalog: props.problemsCatalog,
     });
     this.deployApiLambda = deployApi.fn;
+
+    // ADR-004 Phase 1: Event / Team CRUD Lambda。tenant API から invoke される。
+    const eventApi = new EventApiLambda(this, "EventApi", {
+      eventsTable: events.table,
+      teamsTable: teams.table,
+      defaultTenantId: props.defaultTenantId,
+    });
+    this.eventApiLambda = eventApi.fn;
 
     // CodeBuild Project: source.zip から `scripts/deploy-battles.sh` を実行する。
     const sourceBucket = Bucket.fromBucketName(this, "SourceBucket", props.sourceBucketName);
@@ -155,6 +174,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     new CfnOutput(this, "DeploymentsTableName", {
       value: deployments.table.tableName,
       description: "Deploy ジョブを記録する DynamoDB テーブル名。",
+    });
+    new CfnOutput(this, "EventsTableName", {
+      value: events.table.tableName,
+      description: "ADR-004 Events table 名 (1 競技イベント = 1 行)。",
+    });
+    new CfnOutput(this, "TeamsTableName", {
+      value: teams.table.tableName,
+      description: "ADR-004 Teams table 名 (1 チーム = 1 行、teamLoginKey は team scope)。",
     });
     new CfnOutput(this, "DeployCreateStateMachineArn", {
       value: stateMachine.stateMachine.stateMachineArn,

--- a/infrastructure/lib/problem-deploy/teams-table.ts
+++ b/infrastructure/lib/problem-deploy/teams-table.ts
@@ -1,0 +1,63 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * 1 競技イベントに参加する 1 チームを 1 行で記録する DynamoDB テーブル (ADR-004 Phase 1)。
+ *
+ * Schema:
+ *   PK: EVENT#<eventId>
+ *   SK: TEAM#<teamId>     (teamId = ULID)
+ *
+ * 主な属性:
+ *   eventId / teamId / tenantId / displayName? / internalSlug / teamLoginKey /
+ *   createdAt / updatedAt / expiresAt
+ *
+ * `teamLoginKey` は **team scope の短命 bearer**。1 team = 1 key で event 内の N 問題の
+ * Participant Portal アクセスを共通化する (ADR-004 §3)。
+ *
+ * GSI1 (テナント横断で全 team を引く / event 横断):
+ *   PK: TENANT#<tenantId>
+ *   SK: EVENT#<eventId>#TEAM#<teamId>
+ *
+ * GSI2 (Participant Portal が teamLoginKey で 1 行引く):
+ *   PK: TEAMKEY#<teamLoginKey>
+ *   SK: META
+ *   sparse — 失効した team は GSI2PK 属性ごと削除して index から外す
+ *
+ * Capacity / lifecycle:
+ *   provisioned 1/1。RETAIN (operator が後で参照したい場合のため)。
+ */
+export class TeamsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+      timeToLiveAttribute: "expiresAt",
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI1",
+      partitionKey: { name: "GSI1PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI2",
+      partitionKey: { name: "GSI2PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI2SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+  }
+}

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -24,6 +24,11 @@ interface ApiGatewayProps {
    * `LambdaIntegration` で本 Lambda を invoke する。
    */
   deployApiLambda: IFunction;
+  /**
+   * `ProblemDeployBackendStack.eventApiLambda` のクロススタック参照 (ADR-004 Phase 1)。
+   * Event / Team CRUD routes が本 Lambda を invoke する。
+   */
+  eventApiLambda: IFunction;
   apiKeyBasicTier: CustomApiKey;
   apiKeyStandardTier: CustomApiKey;
   apiKeyPremiumTier: CustomApiKey;
@@ -77,5 +82,15 @@ export class ApiGateway extends Construct {
     const deployment = deployments.addResource("{jobId}");
     deployment.addMethod("GET", deployIntegration, deployMethodOptions);
     deployment.addMethod("DELETE", deployIntegration, deployMethodOptions);
+
+    // ADR-004 Phase 1: /events — 1 競技イベント = 1 行で teams + problems を持つ
+    // /events             POST = create / GET = list
+    // /events/{eventId}   GET  = detail (teams + problems)
+    const eventIntegration = new LambdaIntegration(props.eventApiLambda);
+    const events = this.restApi.root.addResource("events");
+    events.addMethod("GET", eventIntegration, deployMethodOptions);
+    events.addMethod("POST", eventIntegration, deployMethodOptions);
+    const event = events.addResource("{eventId}");
+    event.addMethod("GET", eventIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -40,6 +40,11 @@ interface TenantTemplateStackProps extends StackProps {
    * `LambdaIntegration` で invoke する (ADR-001 / Issue #458)。
    */
   deployApiLambda: IFunction;
+  /**
+   * `ProblemDeployBackendStack.eventApiLambda` をクロススタック参照で受ける (ADR-004 Phase 1)。
+   * tenant API の `/events*` routes が本 Lambda を invoke する。
+   */
+  eventApiLambda: IFunction;
 }
 
 export class TenantTemplateStack extends Stack {
@@ -81,6 +86,7 @@ export class TenantTemplateStack extends Stack {
       idpDetails: identityProvider.identityDetails,
       userPool: identityProvider.tenantUserPool,
       deployApiLambda: props.deployApiLambda,
+      eventApiLambda: props.eventApiLambda,
       apiKeyBasicTier: {
         apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.basic.keyId),
         value: this.ssmLookup(props.ApiKeySSMParameterNames.basic.value),

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -23,10 +23,10 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを 1 つ持ち、PK/SK + PROVISIONED 1/1 であるべき", () => {
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 1);
-      // BillingMode は default (PROVISIONED) のとき CFn template に出力されないので、
-      // ProvisionedThroughput と KeySchema で確認する。
+    it("DDB テーブルを Deployments / Events / Teams の 3 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+      // ADR-004 Phase 1 で Events / Teams を追加。3 Table すべて DynamoDbLowCapacity Aspect で
+      // 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 3);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({

--- a/infrastructure/test/problem-deploy/event-create.test.ts
+++ b/infrastructure/test/problem-deploy/event-create.test.ts
@@ -1,0 +1,163 @@
+import { TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEvent,
+  DuplicateInternalSlugError,
+  DuplicateProblemIdError,
+} from "../../lib/problem-deploy/handlers/event-handler/create";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+import type { CreateEventRequest } from "../../lib/problem-deploy/handlers/event-handler/types";
+
+const NOW_MS = 1_700_000_000_000;
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRequest = (over: Partial<CreateEventRequest> = {}): CreateEventRequest => ({
+  name: "JAWS-UG 春の陣 2026",
+  teams: [{ internalSlug: "team-alpha" }, { internalSlug: "team-beta" }],
+  problems: [
+    {
+      problemId: "hello-world-battle",
+      defaultAwsAccountId: "999999999999",
+      defaultRegion: "ap-northeast-1",
+    },
+  ],
+  ...over,
+});
+
+describe("createEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Event 1 行 + Teams N 行を 1 つの TransactWrite で書くべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await createEvent(
+      shared,
+      { tenantId: "tenant-acme", nowMs: NOW_MS },
+      sampleRequest(),
+    );
+
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+    const cmd = ddbSend.mock.calls[0]?.[0] as TransactWriteCommand;
+    expect(cmd).toBeInstanceOf(TransactWriteCommand);
+    const items = cmd.input.TransactItems ?? [];
+    // Events 1 + Teams 2 = 3 行
+    expect(items).toHaveLength(3);
+
+    // 1 件目は Event
+    const eventPut = items[0]?.Put;
+    expect(eventPut?.TableName).toBe("TestEvents");
+    expect(eventPut?.Item?.SK).toBe("META");
+    expect(eventPut?.Item?.tenantId).toBe("tenant-acme");
+    expect(eventPut?.Item?.status).toBe("DRAFT");
+    expect(eventPut?.Item?.teamCount).toBe(2);
+
+    // 2 件目以降は Teams
+    for (let i = 1; i <= 2; i++) {
+      const teamPut = items[i]?.Put;
+      expect(teamPut?.TableName).toBe("TestTeams");
+      expect(teamPut?.Item?.tenantId).toBe("tenant-acme");
+      expect(typeof teamPut?.Item?.teamLoginKey).toBe("string");
+      expect((teamPut?.Item?.teamLoginKey as string).length).toBeGreaterThan(20);
+    }
+
+    // 各 team の teamLoginKey が一意
+    const keys = items.slice(1).map((i) => i.Put?.Item?.teamLoginKey);
+    expect(new Set(keys).size).toBe(keys.length);
+
+    // レスポンスに teamLoginKey が含まれる (1 度だけ露出)
+    expect(out.teams).toHaveLength(2);
+    expect(out.teams[0]?.teamLoginKey).toBeTruthy();
+    expect(out.eventId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(out.status).toBe("DRAFT");
+  });
+
+  it("teams の internalSlug 重複は DuplicateInternalSlugError を投げ TransactWrite を呼ばないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    await expect(
+      createEvent(
+        shared,
+        { tenantId: "tenant-acme", nowMs: NOW_MS },
+        sampleRequest({
+          teams: [{ internalSlug: "dup" }, { internalSlug: "dup" }],
+        }),
+      ),
+    ).rejects.toBeInstanceOf(DuplicateInternalSlugError);
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("problems の problemId 重複は DuplicateProblemIdError を投げ TransactWrite を呼ばないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    await expect(
+      createEvent(
+        shared,
+        { tenantId: "tenant-acme", nowMs: NOW_MS },
+        sampleRequest({
+          problems: [
+            {
+              problemId: "p",
+              defaultAwsAccountId: "999999999999",
+              defaultRegion: "ap-northeast-1",
+            },
+            {
+              problemId: "p",
+              defaultAwsAccountId: "888888888888",
+              defaultRegion: "us-east-1",
+            },
+          ],
+        }),
+      ),
+    ).rejects.toBeInstanceOf(DuplicateProblemIdError);
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("Teams Put には GSI1 (TENANT) と GSI2 (TEAMKEY) の attribute が必ず付くべき (sparse 失効に備えて)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    await createEvent(shared, { tenantId: "tenant-acme", nowMs: NOW_MS }, sampleRequest());
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as TransactWriteCommand;
+    const teamItem = cmd.input.TransactItems?.[1]?.Put?.Item;
+    expect(teamItem?.GSI1PK).toBe("TENANT#tenant-acme");
+    expect(teamItem?.GSI1SK).toMatch(/^EVENT#[0-9A-HJKMNP-TV-Z]{26}#TEAM#[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(teamItem?.GSI2PK).toBe(`TEAMKEY#${teamItem?.teamLoginKey}`);
+    expect(teamItem?.GSI2SK).toBe("META");
+  });
+
+  it("Event Put には GSI1 (TENANT / createdAt) が付き、新しい順 query を可能にするべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    await createEvent(shared, { tenantId: "tenant-acme", nowMs: NOW_MS }, sampleRequest());
+
+    const eventItem = (ddbSend.mock.calls[0]?.[0] as TransactWriteCommand).input.TransactItems?.[0]
+      ?.Put?.Item;
+    expect(eventItem?.GSI1PK).toBe("TENANT#tenant-acme");
+    expect(eventItem?.GSI1SK).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("ConditionExpression で同一 PK の二重生成を防ぐべき (defense in depth)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    await createEvent(shared, { tenantId: "tenant-acme", nowMs: NOW_MS }, sampleRequest());
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as TransactWriteCommand;
+    for (const item of cmd.input.TransactItems ?? []) {
+      expect(item.Put?.ConditionExpression).toBe("attribute_not_exists(PK)");
+    }
+  });
+});

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -115,16 +115,20 @@ describe("getEventDetail", () => {
     expect(teamsQuery.input.ExpressionAttributeValues?.[":tprefix"]).toBe("TEAM#");
   });
 
-  it("Event 行が無ければ undefined を返し Teams Query を呼ばないべき", async () => {
+  it("Event 行が無ければ undefined を返し teams 結果を漏らさないべき", async () => {
+    // Get と Query は Promise.all で並列発火するため、Event 不在でも teams query
+    // 自体は走る (空 partition なので 1 RCU 程度)。重要なのは結果が caller に返らないこと。
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ teamId: "LEAKED", internalSlug: "leaked", teamLoginKey: "should-not-leak" }],
+    });
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeUndefined();
-    expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("tenantId 不一致は undefined を返し Teams Query を呼ばないべき (クロステナント漏洩防止)", async () => {
+  it("tenantId 不一致は undefined を返し teams 結果を漏らさないべき (クロステナント漏洩防止)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -133,9 +137,11 @@ describe("getEventDetail", () => {
         name: "イベント B",
       },
     });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ teamId: "T1", internalSlug: "other-team", teamLoginKey: "other-key" }],
+    });
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeUndefined();
-    expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 });

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -1,0 +1,141 @@
+import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEventDetail, listEvents } from "../../lib/problem-deploy/handlers/event-handler/list";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+  };
+  return { shared, ddbSend };
+}
+
+describe("listEvents", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GSI1 (TENANT#) を新しい順で query するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          eventId: "EV1",
+          name: "イベント A",
+          status: "DRAFT",
+          teamCount: 5,
+          problems: [{ problemId: "p1" }, { problemId: "p2" }],
+          createdAt: "2026-05-07T08:00:00.000Z",
+          updatedAt: "2026-05-07T08:00:00.000Z",
+          expiresAt: 9_999_999_999,
+        },
+      ],
+    });
+
+    const out = await listEvents(shared, { tenantId: "tenant-acme" });
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd).toBeInstanceOf(QueryCommand);
+    expect(cmd.input.IndexName).toBe("GSI1");
+    expect(cmd.input.KeyConditionExpression).toContain("GSI1PK = :pk");
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+    expect(cmd.input.ScanIndexForward).toBe(false);
+
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]).toMatchObject({
+      eventId: "EV1",
+      teamCount: 5,
+      problemCount: 2,
+    });
+  });
+
+  it("LastEvaluatedKey があれば nextCursor を base64url で返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [],
+      LastEvaluatedKey: { PK: "EVENT#X", SK: "META" },
+    });
+    const out = await listEvents(shared, { tenantId: "tenant-acme" });
+    expect(out.nextCursor).toBeTruthy();
+    const decoded = JSON.parse(Buffer.from(out.nextCursor!, "base64url").toString("utf8"));
+    expect(decoded).toEqual({ PK: "EVENT#X", SK: "META" });
+  });
+});
+
+describe("getEventDetail", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: Event + Teams を返し teamLoginKey も含むべき (詳細経路は露出する)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        name: "イベント A",
+        status: "DRAFT",
+        teamCount: 2,
+        problems: [
+          { problemId: "p1", defaultAwsAccountId: "999999999999", defaultRegion: "ap-northeast-1" },
+        ],
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", internalSlug: "team-alpha", teamLoginKey: "key-1" },
+        { teamId: "T2", internalSlug: "team-beta", teamLoginKey: "key-2" },
+      ],
+    });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out).toBeDefined();
+    expect(out?.eventId).toBe("EV1");
+    expect(out?.problems).toHaveLength(1);
+    expect(out?.teams).toHaveLength(2);
+    expect(out?.teams[0]).toMatchObject({
+      teamId: "T1",
+      internalSlug: "team-alpha",
+      teamLoginKey: "key-1",
+    });
+
+    // 1 件目は GetCommand (Event)
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
+    // 2 件目は QueryCommand (Teams)
+    const teamsQuery = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    expect(teamsQuery).toBeInstanceOf(QueryCommand);
+    expect(teamsQuery.input.KeyConditionExpression).toContain("PK = :pk");
+    expect(teamsQuery.input.KeyConditionExpression).toContain("begins_with(SK, :tprefix)");
+    expect(teamsQuery.input.ExpressionAttributeValues?.[":pk"]).toBe("EVENT#EV1");
+    expect(teamsQuery.input.ExpressionAttributeValues?.[":tprefix"]).toBe("TEAM#");
+  });
+
+  it("Event 行が無ければ undefined を返し Teams Query を呼ばないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out).toBeUndefined();
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("tenantId 不一致は undefined を返し Teams Query を呼ばないべき (クロステナント漏洩防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-other",
+        name: "イベント B",
+      },
+    });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out).toBeUndefined();
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -22,6 +22,11 @@ function buildHarness() {
     code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
     handler: "index.handler",
   });
+  const eventFn = new LambdaFunction(stack, "EventApi", {
+    runtime: Runtime.NODEJS_20_X,
+    code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
+    handler: "index.handler",
+  });
   const apiKey: CustomApiKey = {
     id: "key-id",
     apiKey: { keyId: "k", keyArn: "arn:aws:apigateway:::/apikeys/k", keyName: "k" },
@@ -42,6 +47,7 @@ function buildHarness() {
     },
     userPool,
     deployApiLambda: fn,
+    eventApiLambda: eventFn,
     apiKeyBasicTier: apiKey,
     apiKeyStandardTier: apiKey,
     apiKeyPremiumTier: apiKey,


### PR DESCRIPTION
> **Stack PR**: docs/api-spec (PR-3) に派生。PR-3 マージ後に main に rebase 可能。

## Summary

ADR-004 で定めた Event/Team モデルの **Phase 1 実装**。1 競技イベント = 1 Event + N Teams + M Problems の階層を導入し、teamLoginKey を team scope (1 key で event の N 問題に共通アクセス) に変える基盤を作る。

### Phase 1 スコープ

- DDB Table 2 つ追加 (Events / Teams)
- Lambda CRUD API 3 routes (\`POST /events\` / \`GET /events\` / \`GET /events/{id}\`)
- TransactWrite で Event 1 + Teams N を原子書き込み
- \`tenant.openapi.yaml\` に events 追記、\`_components.yaml\` に events schemas 追記

### Phase 2 以降 (本 PR では実装しない)

- Bulk Deploy (\`POST /events/{id}/deploy\`) — Step Functions Distributed Map
- application-admin-console UI (EventCreate / EventList / EventDetail)
- Participant Portal を team scope に切り替え

## Regression 分析

- Events / Teams Table は **新規追加** (既存 Deployments テーブルは無変更)。PROVISIONED 1/1 で Free Tier 25 RCU/WCU 内に収まる
- 新 EventApi Lambda は Events / Teams Table への RW のみで、CFn / EventBridge 権限は持たない (= API Lambda の最小権限を維持)
- 既存 Deploy 経路 (\`POST /problems/:id/deploy\`) は無変更。Phase 3 まで残し、Phase 4 で deprecate 予定
- TransactWrite 上限 100 items (= teams.max(99) + event 1)。Phase 2 Distributed Map で chunk 化するまでは 1 event 99 teams を上限として早期 reject

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| CREATE | \`AWS::DynamoDB::Table\` (Events) | PK/SK + GSI1 (TENANT 一覧) |
| CREATE | \`AWS::DynamoDB::Table\` (Teams) | PK/SK + GSI1 (TENANT) + GSI2 (TEAMKEY) |
| CREATE | \`AWS::Lambda::Function\` (EventApi) | Events / Teams RW のみ |
| CREATE | \`AWS::ApiGateway::Resource/Method\` (/events, /events/{id}) | tenant API GW に追加 |
| CREATE | CfnOutput (EventsTableName / TeamsTableName) | install.sh から参照 |
| NO-OP  | 既存 Deployments / DeployApi / 削除経路 | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (lint / typecheck / test 全 374 件 / build / validate-problems)
- [x] event-create.test.ts: TransactWrite shape / 重複検出 / GSI 属性 / ConditionExpression (6 件)
- [x] event-list.test.ts: GSI1 query / cursor / tenantId mismatch 404 (5 件)
- [x] CDK synth: DDB Table 数 1 → 3、Aspect で 1/1 強制継続
- [ ] AWS 上で \`make destroy\` → DDB delete-table → \`make deploy\` で動作確認
- [ ] curl で \`POST /events\` → teamLoginKey N 個発番されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)