### PR TITLE
feat(events): ADR-004 Phase 2b — operator UI (EventList / EventCreate / EventDetail)

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -6,6 +6,9 @@ import type { AppConfig } from "./config";
 import { CallbackPage } from "./pages/Callback";
 import { DeploymentDetailPage } from "./pages/DeploymentDetail";
 import { DeploymentsPage } from "./pages/Deployments";
+import { EventCreatePage } from "./pages/EventCreate";
+import { EventDetailPage } from "./pages/EventDetail";
+import { EventListPage } from "./pages/EventList";
 import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { ProblemDetailPage } from "./pages/ProblemDetail";
@@ -42,6 +45,12 @@ export function App({ config }: { config: AppConfig }) {
         <Route
           path="/deployments/:jobId"
           element={guarded(config, <DeploymentDetailPage config={config} />)}
+        />
+        <Route path="/events" element={guarded(config, <EventListPage config={config} />)} />
+        <Route path="/events/new" element={guarded(config, <EventCreatePage config={config} />)} />
+        <Route
+          path="/events/:eventId"
+          element={guarded(config, <EventDetailPage config={config} />)}
         />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/application-admin-console/src/api/client.ts
+++ b/apps/application-admin-console/src/api/client.ts
@@ -11,6 +11,8 @@ export interface ApiClient {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body: unknown): Promise<T>;
   del(path: string): Promise<void>;
+  /** 削除系で JSON body を返す経路 (例: bulk teardown の集計結果)。 */
+  delJson<T>(path: string): Promise<T>;
 }
 
 export function createApiClient(baseUrl: string, idToken: string): ApiClient {
@@ -44,6 +46,9 @@ export function createApiClient(baseUrl: string, idToken: string): ApiClient {
     },
     async del(path: string): Promise<void> {
       await request(path, { method: "DELETE" });
+    },
+    async delJson<T>(path: string): Promise<T> {
+      return (await request(path, { method: "DELETE" })).json() as Promise<T>;
     },
   };
 }

--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -1,0 +1,99 @@
+import type { ApiClient } from "./client";
+
+export const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+export type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "TEARDOWN" | "ARCHIVED";
+
+export interface EventProblemTarget {
+  problemId: string;
+  defaultAwsAccountId: string;
+  defaultRegion: string;
+}
+
+export interface EventSummary {
+  eventId: string;
+  name: string;
+  status: EventStatus;
+  teamCount: number;
+  problemCount: number;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: number;
+}
+
+export interface EventListResponse {
+  items: readonly EventSummary[];
+  nextCursor?: string;
+}
+
+export interface TeamSummary {
+  teamId: string;
+  internalSlug: string;
+  displayName?: string;
+  /** 詳細経路 (`GET /events/{id}`) でのみ含まれる短命キー。 */
+  teamLoginKey?: string;
+}
+
+export interface EventDetail extends EventSummary {
+  teams: readonly TeamSummary[];
+  problems: readonly EventProblemTarget[];
+}
+
+export interface CreateEventTeamInput {
+  internalSlug: string;
+}
+
+export interface CreateEventRequest {
+  name: string;
+  teams: readonly CreateEventTeamInput[];
+  problems: readonly EventProblemTarget[];
+}
+
+export interface CreateEventResponse {
+  eventId: string;
+  status: EventStatus;
+  createdAt: string;
+  expiresAt: number;
+  teams: readonly {
+    teamId: string;
+    internalSlug: string;
+    teamLoginKey: string;
+  }[];
+  problems: readonly EventProblemTarget[];
+}
+
+export interface BulkResult {
+  eventId: string;
+  enqueued: number;
+  skipped: number;
+}
+
+export async function listEvents(
+  api: ApiClient,
+  options: { limit?: number; cursor?: string } = {},
+): Promise<EventListResponse> {
+  const params = new URLSearchParams();
+  if (options.limit) params.set("limit", String(options.limit));
+  if (options.cursor) params.set("cursor", options.cursor);
+  const qs = params.toString();
+  return api.get<EventListResponse>(qs ? `events?${qs}` : "events");
+}
+
+export async function getEvent(api: ApiClient, eventId: string): Promise<EventDetail> {
+  return api.get<EventDetail>(`events/${encodeURIComponent(eventId)}`);
+}
+
+export async function createEvent(
+  api: ApiClient,
+  body: CreateEventRequest,
+): Promise<CreateEventResponse> {
+  return api.post<CreateEventResponse>("events", body);
+}
+
+export async function bulkDeployEvent(api: ApiClient, eventId: string): Promise<BulkResult> {
+  return api.post<BulkResult>(`events/${encodeURIComponent(eventId)}/deploy`, {});
+}
+
+export async function bulkTeardownEvent(api: ApiClient, eventId: string): Promise<BulkResult> {
+  return api.delJson<BulkResult>(`events/${encodeURIComponent(eventId)}`);
+}

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -51,6 +51,7 @@ export function ShellLayout({
             header={{ href: "/", text: "メニュー" }}
             items={[
               { type: "link", href: "/", text: "ホーム" },
+              { type: "link", href: "/events", text: "イベント" },
               { type: "link", href: "/problems", text: "問題カタログ" },
               { type: "link", href: "/deployments", text: "デプロイ履歴" },
             ]}

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -1,0 +1,308 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { useApiClient } from "../api/client";
+import {
+  type CreateEventResponse,
+  createEvent,
+  type EventProblemTarget,
+} from "../api/events-client";
+import type { AppConfig } from "../config";
+import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
+import { listProblemSummaries } from "../data/problems";
+
+const NAME_MAX = 120;
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
+const ACCOUNT_ID_RE = /^\d{12}$/;
+const TEAMS_MIN = 1;
+const TEAMS_MAX = 99;
+
+const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
+  value: r.code,
+  label: r.label,
+}));
+
+interface ProblemRow extends EventProblemTarget {
+  problemName: string;
+}
+
+/**
+ * Event 作成 form。
+ *
+ * 入力:
+ *   - Event 名 (1〜120 文字)
+ *   - チーム数 (1〜99) — 作成時に `team-1`, `team-2` ... の internalSlug が自動付番される
+ *   - 問題セット (`Multiselect`) — 各問題ごとに deploy 先 account / region を入力
+ *
+ * 提出後、レスポンスの `teams[].teamLoginKey` を Modal で 1 度だけ表示する (= operator が
+ * 控える / CSV ダウンロードする)。
+ */
+export function EventCreatePage({ config }: { config: AppConfig }) {
+  const apiClient = useApiClient(config);
+  const navigate = useNavigate();
+
+  const allProblems = useMemo(() => listProblemSummaries(), []);
+  const problemOptions: MultiselectProps.Option[] = useMemo(
+    () => allProblems.map((p) => ({ value: p.id, label: `${p.name} (${p.id})` })),
+    [allProblems],
+  );
+
+  const [name, setName] = useState("");
+  const [teamCount, setTeamCount] = useState("3");
+  const [selectedProblems, setSelectedProblems] = useState<readonly MultiselectProps.Option[]>([]);
+  const [problemRows, setProblemRows] = useState<ProblemRow[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [response, setResponse] = useState<CreateEventResponse | null>(null);
+
+  // Multiselect 変更時は problemRows を sync (既存行は値保持、新規分は default)。
+  const onProblemsChange = (next: readonly MultiselectProps.Option[]) => {
+    setSelectedProblems(next);
+    setProblemRows((prev) => {
+      const byId = new Map(prev.map((r) => [r.problemId, r]));
+      return next
+        .filter((o): o is MultiselectProps.Option & { value: string } => !!o.value)
+        .map((opt) => {
+          const existing = byId.get(opt.value);
+          if (existing) return existing;
+          const meta = allProblems.find((p) => p.id === opt.value);
+          return {
+            problemId: opt.value,
+            problemName: meta?.name ?? opt.value,
+            defaultAwsAccountId: "",
+            defaultRegion: DEFAULT_AWS_REGION.code,
+          };
+        });
+    });
+  };
+
+  const updateProblemRow = (problemId: string, patch: Partial<ProblemRow>) => {
+    setProblemRows((rows) => rows.map((r) => (r.problemId === problemId ? { ...r, ...patch } : r)));
+  };
+
+  const teamCountNum = Number.parseInt(teamCount, 10);
+  const teamCountInvalid =
+    !Number.isFinite(teamCountNum) || teamCountNum < TEAMS_MIN || teamCountNum > TEAMS_MAX;
+  const nameInvalid = name.length === 0 || name.length > NAME_MAX;
+  const allAccountsValid = problemRows.every((r) => ACCOUNT_ID_RE.test(r.defaultAwsAccountId));
+  const canSubmit =
+    !!apiClient &&
+    !submitting &&
+    !nameInvalid &&
+    !teamCountInvalid &&
+    problemRows.length > 0 &&
+    allAccountsValid;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !apiClient) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const teams = Array.from({ length: teamCountNum }, (_, i) => ({
+        internalSlug: `team-${i + 1}`,
+      }));
+      // SLUG_RE 違反は zod / 受け側でも弾かれるが UX 的に事前 validate
+      const slugInvalid = teams.find((t) => !SLUG_RE.test(t.internalSlug));
+      if (slugInvalid) {
+        throw new Error(`team slug の形式が不正: ${slugInvalid.internalSlug}`);
+      }
+      const res = await createEvent(apiClient, {
+        name,
+        teams,
+        problems: problemRows.map((r) => ({
+          problemId: r.problemId,
+          defaultAwsAccountId: r.defaultAwsAccountId,
+          defaultRegion: r.defaultRegion,
+        })),
+      });
+      setResponse(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="チーム数と問題セットを指定して Event を作成します。teamLoginKey は完了画面で 1 度だけ表示されます。"
+      >
+        新規 Event 作成
+      </Header>
+
+      <Form>
+        <SpaceBetween size="l">
+          {error && (
+            <Alert type="error" header="作成に失敗しました">
+              {error}
+            </Alert>
+          )}
+
+          <Container header={<Header variant="h2">基本情報</Header>}>
+            <ColumnLayout columns={2}>
+              <FormField
+                label="Event 名"
+                description="例: JAWS-UG 春の陣 2026"
+                errorText={nameInvalid && name.length > 0 ? `1〜${NAME_MAX} 文字` : undefined}
+              >
+                <Input
+                  value={name}
+                  onChange={({ detail }) => setName(detail.value)}
+                  invalid={nameInvalid && name.length > 0}
+                />
+              </FormField>
+              <FormField
+                label="チーム数"
+                description={`${TEAMS_MIN}〜${TEAMS_MAX} (= TransactWrite 上限から event 1 行を引いた値)`}
+                errorText={teamCountInvalid ? `${TEAMS_MIN}〜${TEAMS_MAX} の整数` : undefined}
+              >
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  value={teamCount}
+                  onChange={({ detail }) =>
+                    setTeamCount(detail.value.replace(/\D/g, "").slice(0, 3))
+                  }
+                  invalid={teamCountInvalid}
+                />
+              </FormField>
+            </ColumnLayout>
+          </Container>
+
+          <Container header={<Header variant="h2">問題セット</Header>}>
+            <SpaceBetween size="m">
+              <FormField label="使用する問題" description="複数選択可。順序は問わない。">
+                <Multiselect
+                  selectedOptions={selectedProblems}
+                  options={problemOptions}
+                  placeholder="問題を選んでください"
+                  onChange={({ detail }) => onProblemsChange(detail.selectedOptions)}
+                />
+              </FormField>
+
+              {problemRows.length > 0 && (
+                <Table
+                  variant="embedded"
+                  items={problemRows}
+                  columnDefinitions={[
+                    { id: "name", header: "問題", cell: (r) => r.problemName },
+                    {
+                      id: "account",
+                      header: "AWS Account ID",
+                      cell: (r) => (
+                        <Input
+                          value={r.defaultAwsAccountId}
+                          placeholder="123456789012"
+                          inputMode="numeric"
+                          invalid={
+                            r.defaultAwsAccountId.length > 0 &&
+                            !ACCOUNT_ID_RE.test(r.defaultAwsAccountId)
+                          }
+                          onChange={({ detail }) =>
+                            updateProblemRow(r.problemId, {
+                              defaultAwsAccountId: detail.value.replace(/\D/g, "").slice(0, 12),
+                            })
+                          }
+                        />
+                      ),
+                    },
+                    {
+                      id: "region",
+                      header: "Region",
+                      cell: (r) => (
+                        <Select
+                          selectedOption={
+                            REGION_OPTIONS.find((o) => o.value === r.defaultRegion) ??
+                            REGION_OPTIONS[0]
+                          }
+                          options={REGION_OPTIONS}
+                          onChange={({ detail }) =>
+                            updateProblemRow(r.problemId, {
+                              defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
+                            })
+                          }
+                        />
+                      ),
+                    },
+                  ]}
+                />
+              )}
+            </SpaceBetween>
+          </Container>
+
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => navigate("/events")}>キャンセル</Button>
+              <Button
+                variant="primary"
+                loading={submitting}
+                disabled={!canSubmit}
+                onClick={handleSubmit}
+              >
+                Event を作成
+              </Button>
+            </SpaceBetween>
+          </Box>
+        </SpaceBetween>
+      </Form>
+
+      <Modal
+        visible={response !== null}
+        header="Event 作成完了 — チームログインキーを控えてください"
+        size="large"
+        onDismiss={() => {
+          if (!response) return;
+          navigate(`/events/${response.eventId}`);
+        }}
+        footer={
+          <Box float="right">
+            <Button
+              variant="primary"
+              onClick={() => response && navigate(`/events/${response.eventId}`)}
+            >
+              Event 詳細へ
+            </Button>
+          </Box>
+        }
+      >
+        {response && (
+          <SpaceBetween size="m">
+            <Alert type="warning" header="teamLoginKey はこの画面でしか表示されません">
+              安全な手段で各チームに hand-off してください。閉じた後は再表示できません (= Phase 2c
+              で operator 用の再取得 API を検討)。
+            </Alert>
+            <Box>
+              Event ID: <Box variant="code">{response.eventId}</Box>
+            </Box>
+            <Table
+              items={[...response.teams]}
+              columnDefinitions={[
+                { id: "team", header: "Team", cell: (t) => t.internalSlug },
+                {
+                  id: "key",
+                  header: "teamLoginKey",
+                  cell: (t) => <Box variant="code">{t.teamLoginKey}</Box>,
+                },
+              ]}
+            />
+          </SpaceBetween>
+        )}
+      </Modal>
+    </SpaceBetween>
+  );
+}

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -1,0 +1,270 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router";
+import { useApiClient } from "../api/client";
+import {
+  type BulkResult,
+  bulkDeployEvent,
+  bulkTeardownEvent,
+  EVENT_ID_RE,
+  type EventDetail,
+  type EventStatus,
+  getEvent,
+} from "../api/events-client";
+import type { AppConfig } from "../config";
+
+const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
+  DRAFT: "blue",
+  DEPLOYING: "blue",
+  READY: "green",
+  TEARDOWN: "red",
+  ARCHIVED: "grey",
+};
+
+export function EventDetailPage({ config }: { config: AppConfig }) {
+  const { eventId } = useParams<{ eventId: string }>();
+  const navigate = useNavigate();
+  const apiClient = useApiClient(config);
+  const [detail, setDetail] = useState<EventDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [bulkResult, setBulkResult] = useState<BulkResult | null>(null);
+  const [bulkInFlight, setBulkInFlight] = useState<"deploy" | "teardown" | null>(null);
+  const [confirmTeardown, setConfirmTeardown] = useState(false);
+
+  const eventIdValid = !!eventId && EVENT_ID_RE.test(eventId);
+
+  const refresh = useCallback(async () => {
+    if (!apiClient || !eventIdValid || !eventId) return;
+    try {
+      const d = await getEvent(apiClient, eventId);
+      setDetail(d);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [apiClient, eventId, eventIdValid]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (!eventIdValid || !eventId) {
+    return <Navigate to="/events" replace />;
+  }
+
+  const handleBulkDeploy = async () => {
+    if (!apiClient || bulkInFlight) return;
+    setBulkInFlight("deploy");
+    setError(null);
+    try {
+      const res = await bulkDeployEvent(apiClient, eventId);
+      setBulkResult(res);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBulkInFlight(null);
+    }
+  };
+
+  const handleBulkTeardown = async () => {
+    if (!apiClient || bulkInFlight) return;
+    setBulkInFlight("teardown");
+    setConfirmTeardown(false);
+    setError(null);
+    try {
+      const res = await bulkTeardownEvent(apiClient, eventId);
+      setBulkResult(res);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBulkInFlight(null);
+    }
+  };
+
+  if (!detail && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 読み込み中…
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={`Event ID: ${eventId}`}
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={() => navigate("/events")}>一覧へ戻る</Button>
+            <Button
+              variant="primary"
+              loading={bulkInFlight === "deploy"}
+              disabled={!detail || detail.problems.length === 0 || detail.teams.length === 0}
+              onClick={handleBulkDeploy}
+            >
+              Bulk Deploy
+            </Button>
+            <Button
+              loading={bulkInFlight === "teardown"}
+              disabled={!detail}
+              onClick={() => setConfirmTeardown(true)}
+            >
+              Bulk Teardown
+            </Button>
+          </SpaceBetween>
+        }
+      >
+        {detail?.name ?? "(loading)"}
+      </Header>
+
+      {error && (
+        <Alert type="error" header="エラー">
+          {error}
+        </Alert>
+      )}
+      {bulkResult && (
+        <Alert
+          type="success"
+          dismissible
+          onDismiss={() => setBulkResult(null)}
+          header="Bulk 操作 受付"
+        >
+          受付: {bulkResult.enqueued} 件 / skipped: {bulkResult.skipped} 件 (実 deploy / delete は
+          State Machine が非同期に進めます。数分後に再読み込みしてください)
+        </Alert>
+      )}
+
+      {detail && (
+        <Container header={<Header variant="h2">Event 概要</Header>}>
+          <ColumnLayout columns={4} variant="text-grid">
+            <Field label="ステータス">
+              <Badge color={STATUS_COLOR[detail.status]}>{detail.status}</Badge>
+            </Field>
+            <Field label="チーム数">{detail.teamCount}</Field>
+            <Field label="問題数">{detail.problems.length}</Field>
+            <Field label="作成">{detail.createdAt}</Field>
+          </ColumnLayout>
+        </Container>
+      )}
+
+      {detail && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="このイベントで使う問題と、各問題の deploy 先 (account / region)"
+            >
+              問題セット ({detail.problems.length} 問)
+            </Header>
+          }
+        >
+          <Table
+            variant="embedded"
+            items={[...detail.problems]}
+            columnDefinitions={[
+              { id: "id", header: "Problem ID", cell: (p) => <code>{p.problemId}</code> },
+              { id: "account", header: "Default AWS Account", cell: (p) => p.defaultAwsAccountId },
+              { id: "region", header: "Default Region", cell: (p) => p.defaultRegion },
+            ]}
+            empty={<Box>未設定 — Event 編集 (Phase 2c+) で追加できる予定</Box>}
+          />
+        </Container>
+      )}
+
+      {detail && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="teamLoginKey は作成完了時に 1 度だけ表示されたキーです。再表示はできません。"
+            >
+              チーム ({detail.teams.length})
+            </Header>
+          }
+        >
+          <Table
+            variant="embedded"
+            items={[...detail.teams]}
+            columnDefinitions={[
+              { id: "slug", header: "Internal Slug", cell: (t) => <code>{t.internalSlug}</code> },
+              {
+                id: "displayName",
+                header: "表示名 (競技者選択)",
+                cell: (t) =>
+                  t.displayName ?? (
+                    <Box variant="small" color="text-status-inactive">
+                      (未設定)
+                    </Box>
+                  ),
+              },
+              {
+                id: "key",
+                header: "teamLoginKey",
+                cell: (t) =>
+                  t.teamLoginKey ? (
+                    <Box variant="code" fontSize="body-s">
+                      {t.teamLoginKey}
+                    </Box>
+                  ) : (
+                    <Box variant="small" color="text-status-inactive">
+                      (詳細で再表示可)
+                    </Box>
+                  ),
+              },
+            ]}
+            empty={<Box>チームがありません</Box>}
+          />
+        </Container>
+      )}
+
+      <Modal
+        visible={confirmTeardown}
+        header="Bulk Teardown を実行しますか?"
+        onDismiss={() => setConfirmTeardown(false)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setConfirmTeardown(false)}>キャンセル</Button>
+              <Button variant="primary" onClick={handleBulkTeardown}>
+                実行
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            このイベント配下の全 deployment を <code>DELETING</code> 状態に倒し、CFn DeleteStack
+            を非同期実行します。teams × problems の組み合わせ全てが対象です。
+          </Box>
+          <Box variant="small" color="text-status-warning">
+            既に DELETING / DELETED な行は idempotent で skip されます。Phase 3+ で
+            「失敗した行のみ再試行」を追加予定です。
+          </Box>
+        </SpaceBetween>
+      </Modal>
+    </SpaceBetween>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <Box variant="awsui-key-label">{label}</Box>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -1,0 +1,128 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table, { type TableProps } from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { type NavigateFunction, useNavigate } from "react-router";
+import { useApiClient } from "../api/client";
+import { type EventStatus, type EventSummary, listEvents } from "../api/events-client";
+import type { AppConfig } from "../config";
+
+const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
+  DRAFT: "blue",
+  DEPLOYING: "blue",
+  READY: "green",
+  TEARDOWN: "red",
+  ARCHIVED: "grey",
+};
+
+const POLL_INTERVAL_MS = 10_000;
+const PAGE_SIZE = 50;
+
+function buildColumns(navigate: NavigateFunction): TableProps.ColumnDefinition<EventSummary>[] {
+  return [
+    {
+      id: "name",
+      header: "Event 名",
+      cell: (item) => (
+        <Link
+          fontSize="body-m"
+          href={`/events/${encodeURIComponent(item.eventId)}`}
+          onFollow={(e) => {
+            e.preventDefault();
+            navigate(`/events/${encodeURIComponent(item.eventId)}`);
+          }}
+        >
+          {item.name}
+        </Link>
+      ),
+    },
+    {
+      id: "status",
+      header: "ステータス",
+      cell: (item) => <Badge color={STATUS_COLOR[item.status]}>{item.status}</Badge>,
+    },
+    { id: "teamCount", header: "チーム数", cell: (item) => item.teamCount },
+    { id: "problemCount", header: "問題数", cell: (item) => item.problemCount },
+    { id: "createdAt", header: "作成", cell: (item) => item.createdAt },
+  ];
+}
+
+export function EventListPage({ config }: { config: AppConfig }) {
+  const apiClient = useApiClient(config);
+  const navigate = useNavigate();
+  const [items, setItems] = useState<readonly EventSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const columns = useMemo(() => buildColumns(navigate), [navigate]);
+
+  const fetchOnce = useCallback(async () => {
+    if (!apiClient) return;
+    try {
+      const res = await listEvents(apiClient, { limit: PAGE_SIZE });
+      setItems(res.items);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [apiClient]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await fetchOnce();
+    };
+    void tick();
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [fetchOnce]);
+
+  if (!items && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 読み込み中…
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="競技イベント (Event) 一覧。1 event = N teams × M problems を一括 deploy / teardown できます。"
+        actions={
+          <Button variant="primary" onClick={() => navigate("/events/new")}>
+            新規 Event 作成
+          </Button>
+        }
+      >
+        Event 一覧
+      </Header>
+
+      {error && (
+        <Alert type="error" header="一覧の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+
+      <Table
+        items={items ?? []}
+        columnDefinitions={columns}
+        loadingText="読み込み中"
+        empty={
+          <Box textAlign="center" color="inherit" padding="xxl">
+            まだ Event はありません。「新規 Event 作成」から始めてください。
+          </Box>
+        }
+      />
+    </SpaceBetween>
+  );
+}

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -30,6 +30,10 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
       calls.push({ path, method: "DELETE" });
       return Promise.resolve();
     }),
+    delJson: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve(response);
+    }),
   };
   return { client, calls };
 }

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../src/api/client";
+import {
+  bulkDeployEvent,
+  bulkTeardownEvent,
+  createEvent,
+  EVENT_ID_RE,
+  getEvent,
+  listEvents,
+} from "../../src/api/events-client";
+
+interface CapturedCall {
+  path: string;
+  method: "GET" | "POST" | "DELETE";
+  body?: unknown;
+}
+
+function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const client: ApiClient = {
+    get: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "GET" });
+      return Promise.resolve(response);
+    }),
+    post: vi.fn().mockImplementation((path: string, body: unknown) => {
+      calls.push({ path, method: "POST", body });
+      return Promise.resolve(response);
+    }),
+    del: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve();
+    }),
+    delJson: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve(response);
+    }),
+  };
+  return { client, calls };
+}
+
+describe("EVENT_ID_RE", () => {
+  it("ULID 形式のみマッチするべき", () => {
+    expect(EVENT_ID_RE.test("01KQZRZSTT6EQC9JVK4FQKRKKM")).toBe(true);
+    expect(EVENT_ID_RE.test("not-a-ulid")).toBe(false);
+    expect(EVENT_ID_RE.test("01kqzrzstt6eqc9jvk4fqkrkkm")).toBe(false); // lowercase
+    expect(EVENT_ID_RE.test("01IQZRZSTT6EQC9JVK4FQKRKKM")).toBe(false); // I は Crockford Base32 から除外
+  });
+});
+
+describe("listEvents", () => {
+  it("limit / cursor を query string に詰めるべき", async () => {
+    const { client, calls } = fakeClient({ items: [] });
+    await listEvents(client, { limit: 50, cursor: "abc" });
+    expect(calls[0]?.path).toBe("events?limit=50&cursor=abc");
+  });
+
+  it("オプション無しは plain `events` を呼ぶべき", async () => {
+    const { client, calls } = fakeClient({ items: [] });
+    await listEvents(client);
+    expect(calls[0]?.path).toBe("events");
+  });
+});
+
+describe("getEvent", () => {
+  it("eventId を URL encode して GET するべき", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1" });
+    await getEvent(client, "EV1");
+    expect(calls[0]?.path).toBe("events/EV1");
+    expect(calls[0]?.method).toBe("GET");
+  });
+});
+
+describe("createEvent", () => {
+  it("POST /events に body をそのまま送るべき", async () => {
+    const { client, calls } = fakeClient({
+      eventId: "EV1",
+      status: "DRAFT",
+      createdAt: "now",
+      expiresAt: 0,
+      teams: [],
+      problems: [],
+    });
+    await createEvent(client, {
+      name: "Spring",
+      teams: [{ internalSlug: "team-1" }],
+      problems: [
+        {
+          problemId: "hello-world",
+          defaultAwsAccountId: "999999999999",
+          defaultRegion: "ap-northeast-1",
+        },
+      ],
+    });
+    expect(calls[0]?.path).toBe("events");
+    expect(calls[0]?.method).toBe("POST");
+    expect((calls[0]?.body as { name?: string })?.name).toBe("Spring");
+  });
+});
+
+describe("bulkDeployEvent", () => {
+  it("POST /events/{id}/deploy を空 body で呼び結果 BulkResult を返すべき", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 6, skipped: 0 });
+    const out = await bulkDeployEvent(client, "EV1");
+    expect(calls[0]?.path).toBe("events/EV1/deploy");
+    expect(calls[0]?.method).toBe("POST");
+    expect(out.enqueued).toBe(6);
+  });
+});
+
+describe("bulkTeardownEvent", () => {
+  it("DELETE /events/{id} を呼んで BulkResult を返すべき (delJson 経由)", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 6, skipped: 0 });
+    const out = await bulkTeardownEvent(client, "EV1");
+    expect(calls[0]?.path).toBe("events/EV1");
+    expect(calls[0]?.method).toBe("DELETE");
+    expect(out.enqueued).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

application-admin-console に Event を一覧 / 作成 / 詳細表示 + Bulk Deploy / Bulk Teardown する UI を追加。Phase 2a で立てた \`/events*\` API を結線する。

### 追加ページ

- **EventListPage** (\`/events\`): 自テナントの Event 一覧 (10s polling)。Badge で status 表示
- **EventCreatePage** (\`/events/new\`): name + チーム数 + 問題セット (Multiselect) + 各問題の deploy 先 (account / region) を入力 → \`POST /events\` で原子作成 → 完了 Modal で teamLoginKey × N を一度だけ表示
- **EventDetailPage** (\`/events/:eventId\`): Event 概要 / 問題セット / チーム一覧 + Bulk Deploy / Bulk Teardown ボタン (Bulk Teardown は確認 Modal)

### 追加 API client

- \`apps/application-admin-console/src/api/events-client.ts\`: listEvents / getEvent / createEvent / bulkDeployEvent / bulkTeardownEvent
- \`ApiClient\` に \`delJson<T>(path)\` を追加 (DELETE で JSON body を返す経路、bulk teardown が enqueued/skipped 集計を返すため)

### サイドバー

「イベント」リンクを「ホーム」と「問題カタログ」の間に追加

## Regression 分析

- 既存ページ (Home / Problems / ProblemDetail / Deployments / DeploymentDetail) は無変更。サイドバーに項目 1 つ追加のみ
- \`ApiClient\` interface に \`delJson\` 追加 — 既存実装 (\`createApiClient\`) は新規メソッドを追加実装、test の fakeClient 全箇所も対応 (deploy-client.test.ts は更新済)
- 旧 \`POST /problems/:id/deploy\` 経路 (= ProblemDetail から個別 deploy) は無変更。Phase 3 まで残す

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| CREATE | apps/application-admin-console: 3 ページ + api client + tests | UI のみ |
| UPDATE | App.tsx routes + AppLayout サイドバー | リンク追加 |
| UPDATE | api/client.ts interface (delJson 追加) | 後方互換 (新メソッド) |
| NO-OP  | infrastructure / 他 SPA | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (testsuite 全 73 件 / lint / typecheck / build)
- [x] events-client.test.ts: 8 件 (URL encode / query string / EVENT_ID_RE / each route)
- [x] deploy-client.test.ts: fakeClient に delJson stub を追加 (interface 拡張)
- [ ] AWS 上で実 deploy → EventList → EventCreate → teamLoginKey 表示 → Bulk Deploy → EventDetail で deploy 完了確認 → Bulk Teardown を E2E 確認

## Phase 2b で意図的に保留した項目 (= follow-up)

- Event 編集 (problems の追加/削除、team の追加) — 現状は read-only
- teamLoginKey の **再露出** API (詳細経路で operator が紛失時に取れる必要があるが、Phase 1 / 2a backend は対応済、UI から呼ぶ導線が無い)
- Deployment matrix view (team × problem の各 deploy 状況をグリッド表示) — Phase 2c で必要なら追加
- CSV ダウンロード (teamLoginKey × N の一括書き出し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Events management section with dedicated navigation menu item
  * Events list page displays all events with status, team count, and problem information
  * Create new events with team setup and AWS account configuration for problems
  * Event detail page provides comprehensive event information including teams and current status
  * Bulk deploy and bulk teardown operations available for event management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->