### PR TITLE
feat(events): ADR-004 Phase 2c — Participant Portal を team scope に

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -14,35 +14,43 @@ export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
 
 export interface ParticipantScoringInfo {
   readonly kind: "flag" | "uptime";
-  /** flag 形式での 1 提出あたりの獲得点。 */
   readonly points?: number;
-  /** uptime 形式での 1 回成功あたりの獲得点。 */
   readonly pointsPerSuccess?: number;
   readonly hints?: readonly string[];
-  /** flag 形式で既に正解済みなら true (= 再提出は加点されない)。 */
   readonly flagSubmitted?: boolean;
 }
 
-export interface ParticipantView {
+/**
+ * Phase 2c: 1 problem 単位の view (= team の N 問題のうち 1 つ)。
+ */
+export interface ParticipantProblemView {
   readonly jobId: string;
   readonly problemId: string;
-  /** `displayTeamName ?? <operator slug>` の最終表示名 */
-  readonly teamName: string;
-  /** 競技者が自分でチーム名を設定したか。false なら setup 画面を出す。 */
-  readonly teamNameSetByCompetitor: boolean;
   readonly region: string;
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
   readonly failureReason?: string;
   readonly expiresAt: number;
-  /** チーム累計スコア (deploy 単位)。 */
   readonly score: number;
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
-  // 設計判断: per-endpoint health (どの endpoint が落ちているか) は participant API
-  // には出さない。Battle のゲーム性 = 「なぜ壊れているかを防御側自身が調査して回復する」
-  // で、画面で答え合わせをすると興ざめになる。
+}
+
+/**
+ * Phase 2c: team の集約 view。1 teamLoginKey で event 内の N 問題を引ける。
+ *
+ * 設計判断: per-endpoint health (どの endpoint が落ちているか) は participant API には
+ * 出さない。Battle のゲーム性 = 「なぜ壊れているかを防御側自身が調査して回復する」。
+ */
+export interface ParticipantTeamView {
+  readonly team: {
+    readonly teamName: string;
+    readonly teamNameSetByCompetitor: boolean;
+    readonly eventId?: string;
+    readonly teamId?: string;
+  };
+  readonly problems: readonly ParticipantProblemView[];
 }
 
 export type SubmitFlagOutcome =
@@ -74,21 +82,20 @@ export class PortalNetworkError extends Error {
   }
 }
 
-/**
- * `GET /portal/me` を `Authorization: Bearer <teamLoginKey>` で呼び、
- * `ParticipantView` を返す。401 は `PortalAuthError`、それ以外の HTTP error は
- * `PortalNetworkError`。Lambda 側 (PR-H2) と shape を一致させる。
- */
 function buildPortalUrl(apiBaseUrl: string, path: string): URL {
   const base = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
   return new URL(path, base);
 }
 
+/**
+ * `GET /portal/me` を `Authorization: Bearer <teamLoginKey>` で呼び、
+ * `ParticipantTeamView` (= team + problems[]) を返す。
+ */
 export async function getPortalMe(
   apiBaseUrl: string,
   teamLoginKey: string,
   signal?: AbortSignal,
-): Promise<ParticipantView> {
+): Promise<ParticipantTeamView> {
   const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me"), {
     method: "GET",
     headers: { authorization: `Bearer ${teamLoginKey}` },
@@ -99,22 +106,19 @@ export async function getPortalMe(
     const body = await res.text().catch(() => "");
     throw new PortalNetworkError(res.status, body);
   }
-  return (await res.json()) as ParticipantView;
+  return (await res.json()) as ParticipantTeamView;
 }
 
 /**
- * 競技者の表示用チーム名を更新する。`PATCH /portal/me { teamName }`。
- *  - 200: 更新成功、最新の `ParticipantView` を返す
- *  - 400: バリデーション失敗 → `PortalValidationError`
- *  - 401: bearer 失効 (削除済等) → `PortalAuthError`
- *  - その他 → `PortalNetworkError`
+ * 競技者の表示用チーム名を team scope で更新する (`PATCH /portal/me { teamName }`)。
+ * 全 deployment 行に伝播する (Lambda 側で並列 Update)。
  */
 export async function updateTeamName(
   apiBaseUrl: string,
   teamLoginKey: string,
   teamName: string,
   signal?: AbortSignal,
-): Promise<ParticipantView> {
+): Promise<ParticipantTeamView> {
   const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me"), {
     method: "PATCH",
     headers: {
@@ -133,18 +137,16 @@ export async function updateTeamName(
     const body = await res.text().catch(() => "");
     throw new PortalNetworkError(res.status, body);
   }
-  return (await res.json()) as ParticipantView;
+  return (await res.json()) as ParticipantTeamView;
 }
 
 /**
- * Flag を提出する。`POST /portal/me/submit-flag { flag }`.
- *  - 200 { kind: "ok" | "already_scored" | "wrong" }: 提出受理 (採点結果は kind で分岐)
- *  - 400 not_flag_problem / no_outputs / invalid_flag → `PortalValidationError`
- *  - 401 bearer 失効 → `PortalAuthError`
+ * Phase 2c: Flag 提出は `problemId` 必須に。`POST /portal/me/submit-flag { problemId, flag }`。
  */
 export async function submitFlag(
   apiBaseUrl: string,
   teamLoginKey: string,
+  problemId: string,
   flag: string,
   signal?: AbortSignal,
 ): Promise<SubmitFlagOutcome> {
@@ -154,7 +156,7 @@ export async function submitFlag(
       authorization: `Bearer ${teamLoginKey}`,
       "content-type": "application/json",
     },
-    body: JSON.stringify({ flag }),
+    body: JSON.stringify({ problemId, flag }),
     signal,
   });
   if (res.status === 400) {

--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -27,15 +27,21 @@ async function exchangeKeyForSession(
       throw new Error(err instanceof Error ? err.message : "backend に接続できませんでした");
     }
     const now = Date.now();
+    // Phase 2c: teamLoginKey で引いた view は team scope。teamId / eventId は team から、
+    // expiresAt は最初の problem から取る (= team の全 problems で同じ TTL を持つ前提)。
+    const firstProblem = view.problems[0];
+    const expiresAtMs =
+      firstProblem && firstProblem.expiresAt > 0
+        ? firstProblem.expiresAt * 1000
+        : now + DEFAULT_DEV_TTL_MS;
     return {
       sessionToken: trimmed,
-      teamId: view.jobId,
-      teamName: view.teamName,
-      eventId: view.problemId,
+      teamId: view.team.teamId ?? "(unknown-team-id)",
+      teamName: view.team.teamName,
+      eventId: view.team.eventId ?? "(unknown-event-id)",
       issuedAt: now,
-      // backend の expiresAt は epoch seconds、storage は ms に揃える。
-      expiresAt: view.expiresAt > 0 ? view.expiresAt * 1000 : now + DEFAULT_DEV_TTL_MS,
-      teamNameSetByCompetitor: view.teamNameSetByCompetitor,
+      expiresAt: expiresAtMs,
+      teamNameSetByCompetitor: view.team.teamNameSetByCompetitor,
     };
   }
 

--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -5,6 +5,10 @@ import { toAsciiSlug } from "../lib/slug";
 import { clearSession, loadSession, type ParticipantSession, saveSession } from "./storage";
 
 const DEFAULT_DEV_TTL_MS = 4 * 60 * 60 * 1000;
+// Phase 1 以前 (jobId-based) の deployment は eventId / teamId を持たない。
+// session には何かしら値を入れる必要がある (UI が表示するため) ので、
+// "(unknown)" placeholder を使う。Phase 4 で旧 deployment 行が消えれば削除可能。
+const UNKNOWN_PLACEHOLDER = "(unknown)";
 
 async function exchangeKeyForSession(
   config: AppConfig,
@@ -36,9 +40,9 @@ async function exchangeKeyForSession(
         : now + DEFAULT_DEV_TTL_MS;
     return {
       sessionToken: trimmed,
-      teamId: view.team.teamId ?? "(unknown-team-id)",
+      teamId: view.team.teamId ?? UNKNOWN_PLACEHOLDER,
       teamName: view.team.teamName,
-      eventId: view.team.eventId ?? "(unknown-event-id)",
+      eventId: view.team.eventId ?? UNKNOWN_PLACEHOLDER,
       issuedAt: now,
       expiresAt: expiresAtMs,
       teamNameSetByCompetitor: view.team.teamNameSetByCompetitor,

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -16,7 +16,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type DeploymentStatus,
   getPortalMe,
-  type ParticipantView,
+  type ParticipantProblemView,
+  type ParticipantTeamView,
   PortalAuthError,
   PortalValidationError,
   type SubmitFlagOutcome,
@@ -44,27 +45,36 @@ const SCORING_KIND_LABEL = {
 } as const;
 
 /** Polling 結果が前回と意味的に同じなら true → setView を skip し React 再 render を抑制。 */
-function viewIsUnchanged(prev: ParticipantView | null, next: ParticipantView): boolean {
+function viewIsUnchanged(prev: ParticipantTeamView | null, next: ParticipantTeamView): boolean {
   if (!prev) return false;
-  return (
-    prev.status === next.status &&
-    prev.score === next.score &&
-    prev.lastScoredAt === next.lastScoredAt &&
-    prev.lastResult === next.lastResult &&
-    prev.scoring?.flagSubmitted === next.scoring?.flagSubmitted &&
-    prev.teamName === next.teamName &&
-    prev.failureReason === next.failureReason &&
-    JSON.stringify(prev.stackOutputs) === JSON.stringify(next.stackOutputs)
-  );
+  if (prev.team.teamName !== next.team.teamName) return false;
+  if (prev.problems.length !== next.problems.length) return false;
+  // problems は jobId で一致を取って意味的同一性を比較。順序は安定 (DDB Query 結果) と仮定。
+  for (let i = 0; i < prev.problems.length; i++) {
+    const p = prev.problems[i] as ParticipantProblemView;
+    const n = next.problems[i] as ParticipantProblemView;
+    if (
+      p.jobId !== n.jobId ||
+      p.status !== n.status ||
+      p.score !== n.score ||
+      p.lastScoredAt !== n.lastScoredAt ||
+      p.lastResult !== n.lastResult ||
+      p.scoring?.flagSubmitted !== n.scoring?.flagSubmitted ||
+      p.failureReason !== n.failureReason ||
+      JSON.stringify(p.stackOutputs) !== JSON.stringify(n.stackOutputs)
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
-  const teamName = auth.session?.teamName ?? "(unknown)";
   const sessionToken = auth.session?.sessionToken ?? null;
   const isBackend = config.mode === "backend";
 
-  const [view, setView] = useState<ParticipantView | null>(null);
+  const [view, setView] = useState<ParticipantTeamView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const stopPollingRef = useRef(false);
 
@@ -74,9 +84,8 @@ export function HomePage({ config }: { config: AppConfig }) {
       const next = await getPortalMe(config.apiBaseUrl, sessionToken);
       setView((prev) => (viewIsUnchanged(prev, next) ? prev : next));
       setError(null);
-      // uptime 採点は COMPLETE になっても polling を続けたい (= score が増え続ける)。
-      // Terminal 停止は FAILED / DELETED のみに限定。
-      if (next.status === "FAILED" || next.status === "DELETED") {
+      // team 全 problem が terminal (FAILED / DELETED) なら polling 停止。
+      if (next.problems.every((p) => p.status === "FAILED" || p.status === "DELETED")) {
         stopPollingRef.current = true;
       }
     } catch (err) {
@@ -104,133 +113,168 @@ export function HomePage({ config }: { config: AppConfig }) {
     };
   }, [isBackend, sessionToken, tick]);
 
+  const teamName = view?.team.teamName ?? auth.session?.teamName ?? "(unknown)";
+
   return (
     <SpaceBetween size="l">
       <Header variant="h1" description={`${config.eventTitle} へようこそ`}>
         Welcome, {teamName}
       </Header>
 
-      {view && <ScorePanel view={view} />}
+      {!isBackend && (
+        <Alert type="info">
+          dev-mock モードで動作中です。実 backend と接続するには runtime-config の <code>mode</code>{" "}
+          を <code>backend</code> に設定してください。
+        </Alert>
+      )}
+      {error && (
+        <Alert type="error" header="状態の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+      {isBackend && !view && !error && <Box>状態を取得中…</Box>}
 
-      <Container header={<Header variant="h2">問題のデプロイ状況</Header>}>
-        <SpaceBetween size="m">
-          {!isBackend && (
-            <Alert type="info">
-              dev-mock モードで動作中です。実 backend と接続するには runtime-config の{" "}
-              <code>mode</code> を <code>backend</code> に設定してください。
-            </Alert>
-          )}
-          {error && (
-            <Alert type="error" header="状態の取得に失敗しました">
-              {error}
-            </Alert>
-          )}
-          {isBackend && !view && !error && <Box>状態を取得中...</Box>}
-          {view && (
-            <>
-              <StatusIndicator type={STATUS_TYPE[view.status]}>{view.status}</StatusIndicator>
-              {view.status === "FAILED" && view.failureReason && (
-                <Alert type="error" header="失敗理由">
-                  {view.failureReason}
-                </Alert>
-              )}
-              <ColumnLayout columns={2} variant="text-grid">
-                <KeyValuePairs
-                  items={[
-                    { label: "Problem", value: <code>{view.problemId}</code> },
-                    { label: "Region", value: view.region },
-                  ]}
-                />
-                <KeyValuePairs
-                  items={[
-                    { label: "Job ID", value: <code>{view.jobId}</code> },
-                    { label: "Team", value: view.teamName },
-                  ]}
-                />
-              </ColumnLayout>
-              {Object.keys(view.stackOutputs).length > 0 && (
-                <Container header={<Header variant="h3">アクセス先 URL</Header>}>
-                  <KeyValuePairs
-                    items={Object.entries(view.stackOutputs).map(([label, value]) => ({
-                      label,
-                      value: (
-                        <a href={value} target="_blank" rel="noreferrer noopener">
-                          <code>{value}</code>
-                        </a>
-                      ),
-                    }))}
-                  />
-                </Container>
-              )}
-              {!TERMINAL_STATUSES.has(view.status) && (
-                <Box variant="small" color="text-status-info">
-                  {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
-                </Box>
-              )}
-            </>
-          )}
-        </SpaceBetween>
-      </Container>
+      {view && <TeamScorePanel view={view} />}
 
-      {view?.scoring?.kind === "flag" && view.status === "COMPLETE" && (
-        <FlagSubmissionPanel
+      {view?.problems.map((problem) => (
+        <ProblemCard
+          key={problem.jobId}
+          problem={problem}
           apiBaseUrl={config.apiBaseUrl}
           sessionToken={sessionToken ?? ""}
-          flagSubmitted={view.scoring.flagSubmitted ?? false}
-          points={view.scoring.points ?? 0}
-          hints={view.scoring.hints ?? []}
           onScored={tick}
         />
+      ))}
+
+      {view && view.problems.length === 0 && (
+        <Container header={<Header variant="h2">問題がありません</Header>}>
+          <Box>このチームには deploy 済みの問題がありません。operator にお問い合わせください。</Box>
+        </Container>
       )}
     </SpaceBetween>
   );
 }
 
-/** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。Health Check は
- *  毎分走るので、2 分以上空いていれば何かが普段と違う = defender が気付くべき信号。 */
+function TeamScorePanel({ view }: { view: ParticipantTeamView }) {
+  const totalScore = view.problems.reduce((sum, p) => sum + p.score, 0);
+  return (
+    <Container header={<Header variant="h2">チーム累計スコア</Header>}>
+      <KeyValuePairs
+        columns={3}
+        items={[
+          {
+            label: "合計",
+            value: (
+              <Box variant="awsui-value-large" color="text-status-success">
+                {totalScore} pt
+              </Box>
+            ),
+          },
+          { label: "問題数", value: String(view.problems.length) },
+          {
+            label: "完了済",
+            value: String(view.problems.filter((p) => p.status === "COMPLETE").length),
+          },
+        ]}
+      />
+    </Container>
+  );
+}
+
+/** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
 const STALE_THRESHOLD_MS = 2 * 60 * 1000;
 
-function ScorePanel({ view }: { view: ParticipantView }) {
-  const kindLabel = view.scoring ? SCORING_KIND_LABEL[view.scoring.kind] : "(未設定)";
+function ProblemCard({
+  problem,
+  apiBaseUrl,
+  sessionToken,
+  onScored,
+}: {
+  problem: ParticipantProblemView;
+  apiBaseUrl: string;
+  sessionToken: string;
+  onScored: () => Promise<void>;
+}) {
+  const kindLabel = problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)";
   const now = Date.now();
-  const lastScoredMs = view.lastScoredAt ? new Date(view.lastScoredAt).getTime() : Number.NaN;
-  const isUptime = view.scoring?.kind === "uptime";
-  // uptime 採点で 2 分以上加点されていない = サービスが何か止まっている可能性。
-  // どこが原因かは敢えて UI に出さず、defender 自身に SSM / ログ調査させる
-  // (Battle のゲーム性 = 「自力で原因究明し復旧する」)。
+  const lastScoredMs = problem.lastScoredAt ? new Date(problem.lastScoredAt).getTime() : Number.NaN;
+  const isUptime = problem.scoring?.kind === "uptime";
   const isStale =
     isUptime &&
     Number.isFinite(lastScoredMs) &&
     now - lastScoredMs > STALE_THRESHOLD_MS &&
-    view.status === "COMPLETE";
+    problem.status === "COMPLETE";
 
   return (
-    <Container header={<Header variant="h2">スコア</Header>}>
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`${kindLabel} / ${problem.score} pt`}
+          actions={
+            <StatusIndicator type={STATUS_TYPE[problem.status]}>{problem.status}</StatusIndicator>
+          }
+        >
+          {problem.problemId}
+        </Header>
+      }
+    >
       <SpaceBetween size="m">
-        {isStale && (
-          <Alert type="warning" header="スコアが伸びていません">
-            直近の採点から {describeAgo(view.lastScoredAt, now)} 経過。サービスのどこかが期待
-            通り応答していない可能性があります。SSM Session 等で状態を確認してください。
+        {problem.status === "FAILED" && problem.failureReason && (
+          <Alert type="error" header="失敗理由">
+            {problem.failureReason}
           </Alert>
         )}
-        <KeyValuePairs
-          columns={3}
-          items={[
-            {
-              label: "現在の累計",
-              value: (
-                <Box
-                  variant="awsui-value-large"
-                  color={isStale ? "text-status-warning" : "text-status-success"}
-                >
-                  {view.score} pt
-                </Box>
-              ),
-            },
-            { label: "形式", value: kindLabel },
-            { label: "最終加点", value: describeAgo(view.lastScoredAt, now) },
-          ]}
-        />
+        {isStale && (
+          <Alert type="warning" header="スコアが伸びていません">
+            直近の採点から {describeAgo(problem.lastScoredAt, now)} 経過。サービスのどこかが
+            期待通り応答していない可能性があります。
+          </Alert>
+        )}
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValuePairs
+            items={[
+              { label: "Region", value: problem.region },
+              { label: "Job ID", value: <code>{problem.jobId}</code> },
+            ]}
+          />
+          <KeyValuePairs
+            items={[
+              { label: "現在の score", value: `${problem.score} pt` },
+              { label: "最終加点", value: describeAgo(problem.lastScoredAt, now) },
+            ]}
+          />
+        </ColumnLayout>
+        {Object.keys(problem.stackOutputs).length > 0 && (
+          <Container header={<Header variant="h3">アクセス先 URL</Header>}>
+            <KeyValuePairs
+              items={Object.entries(problem.stackOutputs).map(([label, value]) => ({
+                label,
+                value: (
+                  <a href={value} target="_blank" rel="noreferrer noopener">
+                    <code>{value}</code>
+                  </a>
+                ),
+              }))}
+            />
+          </Container>
+        )}
+        {problem.scoring?.kind === "flag" && problem.status === "COMPLETE" && (
+          <FlagSubmissionPanel
+            apiBaseUrl={apiBaseUrl}
+            sessionToken={sessionToken}
+            problemId={problem.problemId}
+            flagSubmitted={problem.scoring.flagSubmitted ?? false}
+            points={problem.scoring.points ?? 0}
+            hints={problem.scoring.hints ?? []}
+            onScored={onScored}
+          />
+        )}
+        {!TERMINAL_STATUSES.has(problem.status) && (
+          <Box variant="small" color="text-status-info">
+            {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+          </Box>
+        )}
       </SpaceBetween>
     </Container>
   );
@@ -239,6 +283,7 @@ function ScorePanel({ view }: { view: ParticipantView }) {
 function FlagSubmissionPanel({
   apiBaseUrl,
   sessionToken,
+  problemId,
   flagSubmitted,
   points,
   hints,
@@ -246,6 +291,7 @@ function FlagSubmissionPanel({
 }: {
   apiBaseUrl: string;
   sessionToken: string;
+  problemId: string;
   flagSubmitted: boolean;
   points: number;
   hints: readonly string[];
@@ -258,11 +304,9 @@ function FlagSubmissionPanel({
 
   if (flagSubmitted) {
     return (
-      <Container header={<Header variant="h2">Flag 提出</Header>}>
-        <Alert type="success" header="提出済み">
-          このチームは既に正解を提出済みです (+{points} pt)。
-        </Alert>
-      </Container>
+      <Alert type="success" header="提出済み">
+        この problem は既に正解を提出済みです (+{points} pt)。
+      </Alert>
     );
   }
 
@@ -273,7 +317,7 @@ function FlagSubmissionPanel({
     setSubmitError(null);
     setOutcome(null);
     try {
-      const result = await submitFlag(apiBaseUrl, sessionToken, flag);
+      const result = await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
       setOutcome(result);
       if (result.kind === "ok" || result.kind === "already_scored") {
         await onScored();
@@ -290,62 +334,54 @@ function FlagSubmissionPanel({
   };
 
   return (
-    <Container
-      header={
-        <Header variant="h2" description={`正解を入力すると +${points} pt 獲得します。`}>
-          Flag 提出
-        </Header>
-      }
-    >
-      <SpaceBetween size="m">
-        {hints.length > 0 && (
-          <Alert type="info" header="ヒント">
-            <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
-              {hints.map((h) => (
-                <li key={h}>{h}</li>
-              ))}
-            </ul>
-          </Alert>
-        )}
-        <form onSubmit={handleSubmit}>
-          <Form
-            actions={
-              <Button variant="primary" loading={submitting} formAction="submit">
-                提出
-              </Button>
-            }
-          >
-            <FormField label="Flag (Stack Output 値)">
-              <Input
-                value={flag}
-                onChange={(e) => setFlag(e.detail.value)}
-                placeholder="例: Hello from tc-hello-world-..."
-                disabled={submitting}
-              />
-            </FormField>
-          </Form>
-        </form>
-        {outcome?.kind === "ok" && (
-          <Alert type="success" header={`正解 (+${outcome.scoreDelta} pt)`}>
-            合計スコア: {outcome.totalScore} pt
-          </Alert>
-        )}
-        {outcome?.kind === "wrong" && (
-          <Alert type="warning" header="不正解">
-            値を確認して再度提出してください。
-          </Alert>
-        )}
-        {outcome?.kind === "already_scored" && (
-          <Alert type="info" header="提出済み">
-            既に正解済みです (合計 {outcome.totalScore} pt)。
-          </Alert>
-        )}
-        {submitError && (
-          <Alert type="error" header="提出に失敗しました">
-            {submitError}
-          </Alert>
-        )}
-      </SpaceBetween>
-    </Container>
+    <SpaceBetween size="s">
+      {hints.length > 0 && (
+        <Alert type="info" header="ヒント">
+          <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
+            {hints.map((h) => (
+              <li key={h}>{h}</li>
+            ))}
+          </ul>
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Form
+          actions={
+            <Button variant="primary" loading={submitting} formAction="submit">
+              Flag 提出 (+{points} pt)
+            </Button>
+          }
+        >
+          <FormField label="Flag (Stack Output 値)">
+            <Input
+              value={flag}
+              onChange={(e) => setFlag(e.detail.value)}
+              placeholder="例: Hello from tc-hello-world-..."
+              disabled={submitting}
+            />
+          </FormField>
+        </Form>
+      </form>
+      {outcome?.kind === "ok" && (
+        <Alert type="success" header={`正解 (+${outcome.scoreDelta} pt)`}>
+          合計スコア: {outcome.totalScore} pt
+        </Alert>
+      )}
+      {outcome?.kind === "wrong" && (
+        <Alert type="warning" header="不正解">
+          値を確認して再度提出してください。
+        </Alert>
+      )}
+      {outcome?.kind === "already_scored" && (
+        <Alert type="info" header="提出済み">
+          既に正解済みです (合計 {outcome.totalScore} pt)。
+        </Alert>
+      )}
+      {submitError && (
+        <Alert type="error" header="提出に失敗しました">
+          {submitError}
+        </Alert>
+      )}
+    </SpaceBetween>
   );
 }

--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -40,8 +40,8 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
     try {
       const view = await updateTeamName(config.apiBaseUrl, auth.session.sessionToken, trimmed);
       auth.updateSession({
-        teamName: view.teamName,
-        teamNameSetByCompetitor: view.teamNameSetByCompetitor,
+        teamName: view.team.teamName,
+        teamNameSetByCompetitor: view.team.teamNameSetByCompetitor,
       });
       navigate("/");
     } catch (err) {

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -8,13 +8,18 @@ import {
 
 const KEY = "AbCdEfGhIjKlMnOpQrStUvWx";
 const VIEW = {
-  jobId: "JOB1",
-  problemId: "p",
-  teamName: "Alpha",
-  region: "ap-northeast-1",
-  status: "COMPLETE",
-  stackOutputs: { FrontendUrl: "https://x" },
-  expiresAt: 1_700_000_000,
+  team: { teamName: "Alpha", teamNameSetByCompetitor: false },
+  problems: [
+    {
+      jobId: "JOB1",
+      problemId: "p",
+      region: "ap-northeast-1",
+      status: "COMPLETE",
+      stackOutputs: { FrontendUrl: "https://x" },
+      expiresAt: 1_700_000_000,
+      score: 0,
+    },
+  ],
 };
 
 describe("getPortalMe", () => {
@@ -32,7 +37,8 @@ describe("getPortalMe", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const view = await getPortalMe("https://api.example.com", KEY);
-    expect(view.jobId).toBe("JOB1");
+    expect(view.team.teamName).toBe("Alpha");
+    expect(view.problems[0]?.jobId).toBe("JOB1");
 
     const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
     expect(url.toString()).toBe("https://api.example.com/portal/me");

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -78,13 +78,23 @@ describe("AuthProvider", () => {
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
-            jobId: "JOB1",
-            problemId: "p",
-            teamName: "Alpha",
-            region: "ap-northeast-1",
-            status: "COMPLETE",
-            stackOutputs: {},
-            expiresAt: 1_700_000_000,
+            team: {
+              teamName: "Alpha",
+              teamNameSetByCompetitor: false,
+              eventId: "EV1",
+              teamId: "T1",
+            },
+            problems: [
+              {
+                jobId: "JOB1",
+                problemId: "p",
+                region: "ap-northeast-1",
+                status: "COMPLETE",
+                stackOutputs: {},
+                expiresAt: 1_700_000_000,
+                score: 0,
+              },
+            ],
           }),
           { status: 200 },
         ),
@@ -95,9 +105,9 @@ describe("AuthProvider", () => {
       await result.current.login("AbCdEfGhIjKlMnOpQrStUvWx");
     });
     expect(result.current.session).not.toBeNull();
-    expect(result.current.session?.teamId).toBe("JOB1");
+    expect(result.current.session?.teamId).toBe("T1");
     expect(result.current.session?.teamName).toBe("Alpha");
-    expect(result.current.session?.eventId).toBe("p");
+    expect(result.current.session?.eventId).toBe("EV1");
     expect(result.current.session?.sessionToken).toBe("AbCdEfGhIjKlMnOpQrStUvWx");
     expect(result.current.session?.expiresAt).toBe(1_700_000_000_000);
   });

--- a/docs/api/_components.yaml
+++ b/docs/api/_components.yaml
@@ -359,19 +359,14 @@ components:
           type: boolean
           description: Challenge (flag) で正解 submit 済みなら true (重複加算防止)
 
-    ParticipantView:
+    # Phase 2c: 1 problem 単位の view (= team の N 問題のうち 1 つ)。
+    ParticipantProblemView:
       type: object
-      required: [jobId, problemId, region, status, stackOutputs, score, expiresAt, teamName, teamNameSetByCompetitor]
+      required: [jobId, problemId, region, status, stackOutputs, score, expiresAt]
       properties:
         jobId: { type: string }
         problemId: { type: string }
         region: { type: string }
-        teamName:
-          type: string
-          description: 表示名 (競技者が PATCH /portal/me で設定済みならそれ、未設定なら operator が deploy 時に入力した内部 slug)
-        teamNameSetByCompetitor:
-          type: boolean
-          description: 競技者自身が表示名を設定済みなら true (= operator slug をそのまま使っていれば false)
         status: { $ref: "#/components/schemas/DeploymentStatus" }
         stackOutputs:
           type: object
@@ -379,20 +374,30 @@ components:
           description: |
             CFn Outputs を object に展開したもの。`flagOutputKey` で指定された field は
             **競技者に出さない** (= 当てる対象なので strip 済み)。
-        failureReason:
-          type: string
-          description: status=FAILED のときのみ含まれる
-        score:
-          type: integer
-          description: チームの累計点数
-        lastScoredAt:
-          type: string
-          format: date-time
-          description: 最後に scoring が走った時刻
-        lastResult:
-          type: string
-          enum: [ok, fail]
-          description: Battle (uptime) で最後の health check 結果
-        scoring:
-          $ref: "#/components/schemas/ParticipantScoringInfo"
+        failureReason: { type: string }
+        score: { type: integer }
+        lastScoredAt: { type: string, format: date-time }
+        lastResult: { type: string, enum: [ok, fail] }
+        scoring: { $ref: "#/components/schemas/ParticipantScoringInfo" }
         expiresAt: { type: integer }
+
+    # Phase 2c: 1 teamLoginKey で event 内 N 問題を引ける team scope view。
+    ParticipantTeamView:
+      type: object
+      required: [team, problems]
+      properties:
+        team:
+          type: object
+          required: [teamName, teamNameSetByCompetitor]
+          properties:
+            teamName: { type: string }
+            teamNameSetByCompetitor: { type: boolean }
+            eventId:
+              type: string
+              description: Phase 2a 経由の deployment 由来 (旧 deployment は無し)
+            teamId:
+              type: string
+              description: Phase 2a 経由の deployment 由来 (旧 deployment は無し)
+        problems:
+          type: array
+          items: { $ref: "#/components/schemas/ParticipantProblemView" }

--- a/docs/api/participant.openapi.yaml
+++ b/docs/api/participant.openapi.yaml
@@ -59,7 +59,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./_components.yaml#/components/schemas/ParticipantView"
+                $ref: "./_components.yaml#/components/schemas/ParticipantTeamView"
         "401":
           $ref: "./_components.yaml#/components/responses/Unauthorized"
     patch:
@@ -86,7 +86,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./_components.yaml#/components/schemas/ParticipantView"
+                $ref: "./_components.yaml#/components/schemas/ParticipantTeamView"
         "400":
           description: 不正なチーム名
         "401":
@@ -105,8 +105,15 @@ paths:
           application/json:
             schema:
               type: object
-              required: [flag]
+              required: [problemId, flag]
               properties:
+                problemId:
+                  type: string
+                  pattern: "^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$"
+                  description: |
+                    Phase 2c: 1 team = N problems になったので、どの problem の flag かを
+                    明示する必要がある。team 配下に該当 problemId が無い場合は
+                    `unauthorized` (= 存在を漏らさない)。
                 flag:
                   type: string
                   minLength: 1

--- a/docs/architecture/adr-004-event-team-model.md
+++ b/docs/architecture/adr-004-event-team-model.md
@@ -142,8 +142,8 @@ Lambda は `Bearer <teamLoginKey>` から Teams GSI2 で 1 行引き、`teamId` 
 
 - **Phase 1 (✅完了)**: Events / Teams Table を追加 + `POST /events` / `GET /events` / `GET /events/{id}` を新設。既存 `POST /problems/{id}/deploy` 経路は残す
 - **Phase 2a (✅完了)**: `POST /events/{id}/deploy` + `DELETE /events/{id}` を導入 (= bulk deploy / bulk teardown)。Distributed Map ではなく **EventBridge fan-out** で初期実装 (Lambda が teams × problems を展開して既存 `DeployCreateRequested` / `DeployDeleteRequested` を chunk publish、既存 DeployCreate / DeployDelete State Machine が個別に並列実行)。Phase 3+ で 1000 並列を超える scale が要求されたら Distributed Map に切り替える
-- **Phase 2b**: application-admin-console UI に EventCreate / EventList / EventDetail を追加
-- **Phase 2c**: Participant Portal を team scope に切り替え (`GET /portal/me` を `team + problems[]` に拡張)
+- **Phase 2b (✅完了)**: application-admin-console UI に EventCreate / EventList / EventDetail を追加
+- **Phase 2c (✅完了)**: Participant Portal を team scope に切り替え (`GET /portal/me` を `team + problems[]` に拡張)。`POST /portal/me/submit-flag` は `problemId` 必須に
 - **Phase 3**: 既存 `POST /problems/{id}/deploy` を deprecate (UI からの呼び出し削除)
 - **Phase 4**: 既存 routes と DDB の jobId-based 行を削除
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
+import { ULID_RE as JOB_ID_RE, PROBLEM_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
   HTTP_BAD_REQUEST,
@@ -33,9 +34,6 @@ import { DeployRequestSchema } from "./types.js";
  * 残しており、その経路では `DEFAULT_TENANT_ID` env にフォールバック。
  */
 
-// problemId は metadata.json と整合する RFC 1035-ish の slug。両端は英数字、内側のみハイフン許容。
-const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
-const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID
 const LIST_LIMIT_MAX = 200;
 
 // SDK clients / env を module scope で 1 度だけ build。warm invoke で connection pool 再利用。

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -3,6 +3,7 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { resolveTenantId } from "../deploy-handler/auth.js";
+import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
   HTTP_BAD_REQUEST,
@@ -30,7 +31,6 @@ import { CreateEventRequestSchema } from "./types.js";
  * から `resolveTenantId` で抽出する (DeployApi Lambda と同じ shape)。
  */
 
-const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID
 const LIST_LIMIT_MAX = 200;
 
 const shared = buildEventSharedResources();

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
+import { PROBLEM_ID_RE } from "../shared/constants.js";
 import {
   HTTP_BAD_REQUEST,
   HTTP_INTERNAL_ERROR,
@@ -12,8 +13,6 @@ import { lookupTeamByLoginKey } from "./lookup.js";
 import { buildParticipantSharedResources } from "./shared.js";
 import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
-
-const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
 /**
  * Participant Portal backend Lambda の Hono app (Phase 2c で team scope)。routes:

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -8,17 +8,20 @@ import {
   HTTP_UNAUTHORIZED,
 } from "../shared/http-status.js";
 import { extractBearerToken } from "./auth.js";
-import { lookupByTeamLoginKey } from "./lookup.js";
+import { lookupTeamByLoginKey } from "./lookup.js";
 import { buildParticipantSharedResources } from "./shared.js";
 import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
 
+const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
 /**
- * Participant Portal backend Lambda の Hono app。routes:
+ * Participant Portal backend Lambda の Hono app (Phase 2c で team scope)。routes:
  *   GET   /portal/healthz
  *   GET   /portal/me                — Authorization: Bearer <teamLoginKey>
- *   PATCH /portal/me                — body: { teamName: string }
- *   POST  /portal/me/submit-flag    — body: { flag: string }
+ *                                     → { team, problems[] }
+ *   PATCH /portal/me                — body: { teamName: string } (team の全行を update)
+ *   POST  /portal/me/submit-flag    — body: { problemId: string, flag: string }
  *
  * Function URL は `AuthType=NONE` で公開し、`teamLoginKey` 自体を bearer として
  * Lambda 内で検証する。
@@ -32,7 +35,7 @@ app.get("/portal/me", async (c) => {
   const token = extractBearerToken(c.req.header("authorization"));
   if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
   try {
-    const view = await lookupByTeamLoginKey(shared, token);
+    const view = await lookupTeamByLoginKey(shared, token);
     if (!view) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
     return c.json(view, HTTP_OK);
   } catch (err) {
@@ -77,12 +80,16 @@ app.post("/portal/me/submit-flag", async (c) => {
   } catch {
     return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
   }
+  const problemId = (body as { problemId?: unknown })?.problemId;
   const flag = (body as { flag?: unknown })?.flag;
+  if (typeof problemId !== "string" || !PROBLEM_ID_RE.test(problemId)) {
+    return c.json({ error: "invalid_problem_id" }, HTTP_BAD_REQUEST);
+  }
   if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
     return c.json({ error: "invalid_flag" }, HTTP_BAD_REQUEST);
   }
   try {
-    const outcome = await submitFlag(shared, shared.problemsScoring, token, flag);
+    const outcome = await submitFlag(shared, shared.problemsScoring, token, problemId, flag);
     if (outcome.kind === "unauthorized")
       return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
     if (outcome.kind === "not_flag_problem") {

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -5,13 +5,12 @@ import { parseStackOutputs } from "../shared/cfn-status.js";
 import type { ParticipantSharedResources } from "./shared.js";
 
 /**
- * 競技者向け sanitized view。`DeploymentItem` から chosen フィールドのみを `Pick`
- * で派生させることで、`DeploymentItem` に新規フィールドが増えたときに「明示的に
- * include する / 除外する」判断を強制する (operator 内部情報の意図せぬ漏洩を防ぐ)。
+ * Phase 2c: 1 teamLoginKey = 1 team (= N deployments) として view を構成する。
  *
  * stackOutputs は DDB に JSON 文字列で入っているが、UI に返す前に object へ展開する。
  * `flagOutputKey` で指定された field は **競技者に出さない** (= 当てる対象なので)。
  */
+
 export interface ParticipantScoringInfo {
   readonly kind: "flag" | "uptime";
   readonly points?: number;
@@ -21,12 +20,14 @@ export interface ParticipantScoringInfo {
   readonly flagSubmitted?: boolean;
 }
 
-export type ParticipantView = Pick<
+/**
+ * チームに紐づく 1 problem 単位の view。team 集約 (`ParticipantTeamView.problems[]`) の
+ * 1 要素として返す。
+ */
+export type ParticipantProblemView = Pick<
   DeploymentItem,
   "jobId" | "problemId" | "region" | "expiresAt"
 > & {
-  readonly teamName: string;
-  readonly teamNameSetByCompetitor: boolean;
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
   readonly failureReason?: string;
@@ -36,16 +37,24 @@ export type ParticipantView = Pick<
   readonly scoring?: ParticipantScoringInfo;
   // 設計判断: `endpointsHealth` (= どの endpoint が落ちているか) は participant API には
   // 出さない。Battle のゲーム性は「壊れている原因を防御側自身が調査して復旧する」点に
-  // あり、画面で答え合わせをすると興ざめになる。defender は score / lastScoredAt から
-  // 「何かおかしい」を察し、SSM Session 等で自力調査する。`endpointsHealth` 自体は DDB
-  // に保持され、operator ダッシュボード (将来) は full diagnostic として参照可能。
+  // あり、画面で答え合わせをすると興ざめになる。
 };
+
+export interface ParticipantTeamView {
+  readonly team: {
+    readonly teamName: string;
+    readonly teamNameSetByCompetitor: boolean;
+    /** Phase 1 以前に作られた deployment は持たない。 */
+    readonly eventId?: string;
+    readonly teamId?: string;
+  };
+  readonly problems: readonly ParticipantProblemView[];
+}
 
 const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
 /**
- * DDB の生 row → `ParticipantView` 変換。`lookupByTeamLoginKey` と
- * `setDisplayTeamName` (UpdateCommand `ReturnValues=ALL_NEW`) の両方から呼ばれる。
+ * 1 deployment row → ParticipantProblemView 変換。
  *
  * status が DELETING / DELETED の場合は `undefined` を返す。これは sparse 化が
  * 崩れた行 (GSI2PK が残ったまま teardown が進んだケース) への防御。
@@ -54,14 +63,12 @@ const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING"
  * 情報だけ (= flagOutputKey の値は出さない、kind / points / hints のみ) を含める。
  * stackOutputs からも flagOutputKey フィールドは strip し、答えが見えないようにする。
  */
-export function toView(
+export function toProblemView(
   item: Partial<DeploymentItem>,
   scoringMap: Record<string, ProblemScoringMetadata> = {},
-): ParticipantView | undefined {
+): ParticipantProblemView | undefined {
   const status = (item.status ?? "PENDING") as DeploymentStatus;
   if (DELETED_LIKE_STATUSES.has(status)) return undefined;
-  const operatorTeamSlug = String(item.teamName ?? "");
-  const display = typeof item.displayTeamName === "string" ? item.displayTeamName : undefined;
 
   const stackOutputs = parseStackOutputs(item.stackOutputs);
   const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
@@ -72,8 +79,6 @@ export function toView(
   return {
     jobId: String(item.jobId ?? ""),
     problemId: String(item.problemId ?? ""),
-    teamName: display ?? operatorTeamSlug,
-    teamNameSetByCompetitor: display !== undefined,
     region: String(item.region ?? ""),
     status,
     stackOutputs,
@@ -98,29 +103,57 @@ export function toView(
 }
 
 /**
- * teamLoginKey で GSI2 を Query して 1 件の deployment を返す。
- *
- * GSI2 は eventually consistent。直近に rotate / 削除された teamLoginKey は
- * 最大数百ms 程度認証が通る可能性があるが、TTL ベースの teardown を 1 分間隔で
- * 回す運用 (PR-E StatusUpdater) と整合する許容範囲。
+ * teamLoginKey で GSI2 を Query して team の全 deployment 行を返し、team 集約 view を作る。
  *
  * - 該当行が無い (key 不正 / GSI2PK 属性が削除された) → undefined (401 相当)
- * - status が DELETING / DELETED → undefined (sparse 化が崩れた場合の防御)
+ * - 全行が DELETING / DELETED → undefined (sparse 化が崩れた場合の防御)
+ * - 1 つでも live な行があれば team view を返す
+ *
+ * GSI2 は eventually consistent。直近に rotate / 削除された teamLoginKey は最大
+ * 数百ms 程度認証が通る可能性があるが、TTL ベースの teardown と整合する許容範囲。
+ *
+ * Phase 1 以前 (jobId-based) の deployment は eventId / teamId が undefined。
+ * Phase 2a 以降は同じ teamLoginKey を持つ行が複数 (team の問題数 = N 個) 返る。
  */
-export async function lookupByTeamLoginKey(
+export async function lookupTeamByLoginKey(
   shared: ParticipantSharedResources,
   teamLoginKey: string,
-): Promise<ParticipantView | undefined> {
+): Promise<ParticipantTeamView | undefined> {
   const out = await shared.ddb.send(
     new QueryCommand({
       TableName: shared.tableName,
       IndexName: "GSI2",
       KeyConditionExpression: "GSI2PK = :pk",
       ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-      Limit: 1,
     }),
   );
-  const item = (out.Items?.[0] ?? undefined) as Partial<DeploymentItem> | undefined;
-  if (!item) return undefined;
-  return toView(item, shared.problemsScoring);
+  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  if (items.length === 0) return undefined;
+
+  const problems: ParticipantProblemView[] = [];
+  for (const item of items) {
+    const view = toProblemView(item, shared.problemsScoring);
+    if (view) problems.push(view);
+  }
+  if (problems.length === 0) return undefined;
+
+  // 同 team の全行に共通する team 情報は最初の live 行から拾う (== teamLoginKey で
+  // 引いた deployment はすべて同 team)。teamName は競技者 displayTeamName 優先。
+  const sample = items.find((i) => {
+    const status = (i.status ?? "PENDING") as DeploymentStatus;
+    return !DELETED_LIKE_STATUSES.has(status);
+  });
+  if (!sample) return undefined;
+  const operatorSlug = String(sample.teamName ?? "");
+  const display = typeof sample.displayTeamName === "string" ? sample.displayTeamName : undefined;
+
+  return {
+    team: {
+      teamName: display ?? operatorSlug,
+      teamNameSetByCompetitor: display !== undefined,
+      eventId: typeof sample.eventId === "string" ? sample.eventId : undefined,
+      teamId: typeof sample.teamId === "string" ? sample.teamId : undefined,
+    },
+    problems,
+  };
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -1,11 +1,11 @@
-import { QueryCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
-import type { ParticipantSharedResources } from "./shared.js";
+import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
- * Phase 2c: 1 teamLoginKey = 1 team (= N deployments) として view を構成する。
+ * 1 teamLoginKey = 1 team (= N deployments) として view を構成する。
  *
  * stackOutputs は DDB に JSON 文字列で入っているが、UI に返す前に object へ展開する。
  * `flagOutputKey` で指定された field は **競技者に出さない** (= 当てる対象なので)。
@@ -50,8 +50,6 @@ export interface ParticipantTeamView {
   };
   readonly problems: readonly ParticipantProblemView[];
 }
-
-const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
 /**
  * 1 deployment row → ParticipantProblemView 変換。
@@ -111,39 +109,37 @@ export function toProblemView(
  *
  * GSI2 は eventually consistent。直近に rotate / 削除された teamLoginKey は最大
  * 数百ms 程度認証が通る可能性があるが、TTL ベースの teardown と整合する許容範囲。
- *
- * Phase 1 以前 (jobId-based) の deployment は eventId / teamId が undefined。
- * Phase 2a 以降は同じ teamLoginKey を持つ行が複数 (team の問題数 = N 個) 返る。
  */
 export async function lookupTeamByLoginKey(
   shared: ParticipantSharedResources,
   teamLoginKey: string,
 ): Promise<ParticipantTeamView | undefined> {
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.tableName,
-      IndexName: "GSI2",
-      KeyConditionExpression: "GSI2PK = :pk",
-      ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-    }),
-  );
-  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  const items = await queryTeamItems(shared, teamLoginKey);
+  return buildTeamView(items, shared.problemsScoring);
+}
+
+/**
+ * 既に Query 済みの items から ParticipantTeamView を組み立てる (1 pass)。
+ * lookup と update (Update 後の ALL_NEW Attributes 集合) の両方が利用する。
+ */
+export function buildTeamView(
+  items: readonly Partial<DeploymentItem>[],
+  scoringMap: Record<string, ProblemScoringMetadata>,
+): ParticipantTeamView | undefined {
   if (items.length === 0) return undefined;
 
   const problems: ParticipantProblemView[] = [];
+  let sample: Partial<DeploymentItem> | undefined;
   for (const item of items) {
-    const view = toProblemView(item, shared.problemsScoring);
+    const view = toProblemView(item, scoringMap);
     if (view) problems.push(view);
+    if (!sample) {
+      const status = (item.status ?? "PENDING") as DeploymentStatus;
+      if (!DELETED_LIKE_STATUSES.has(status)) sample = item;
+    }
   }
-  if (problems.length === 0) return undefined;
+  if (!sample || problems.length === 0) return undefined;
 
-  // 同 team の全行に共通する team 情報は最初の live 行から拾う (== teamLoginKey で
-  // 引いた deployment はすべて同 team)。teamName は競技者 displayTeamName 優先。
-  const sample = items.find((i) => {
-    const status = (i.status ?? "PENDING") as DeploymentStatus;
-    return !DELETED_LIKE_STATUSES.has(status);
-  });
-  if (!sample) return undefined;
   const operatorSlug = String(sample.teamName ?? "");
   const display = typeof sample.displayTeamName === "string" ? sample.displayTeamName : undefined;
 

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -1,7 +1,8 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
 import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
+import type { DeploymentItem } from "../deploy-handler/types.js";
 
 /**
  * Participant Lambda は DDB Query しか叩かない。Deploy Worker / API が使う
@@ -22,4 +23,23 @@ export function buildParticipantSharedResources(): ParticipantSharedResources {
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
   };
+}
+
+/**
+ * teamLoginKey で GSI2 を Query して team の全 deployment 行を返す共通 helper
+ * (lookup / update / submit-flag が同じ query を使うため)。
+ */
+export async function queryTeamItems(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+): Promise<Partial<DeploymentItem>[]> {
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      IndexName: "GSI2",
+      KeyConditionExpression: "GSI2PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
+    }),
+  );
+  return (out.Items ?? []) as Partial<DeploymentItem>[];
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,8 +1,7 @@
-import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
-import type { DeploymentItem } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
-import type { ParticipantSharedResources } from "./shared.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 export type SubmitFlagOutcome =
   | { kind: "ok"; scoreDelta: number; totalScore: number }
@@ -36,15 +35,7 @@ export async function submitFlag(
   problemId: string,
   submittedFlag: string,
 ): Promise<SubmitFlagOutcome> {
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.tableName,
-      IndexName: "GSI2",
-      KeyConditionExpression: "GSI2PK = :pk",
-      ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-    }),
-  );
-  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
 
   const item = items.find((i) => i.problemId === problemId);

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -18,9 +18,13 @@ function flagMatches(submitted: string, expected: string): boolean {
 }
 
 /**
- * teamLoginKey で deployment 行を引き、flag を採点する。正解なら `ADD score :pts`
- * + `SET flagSubmitted = true` を 1 UpdateItem で atomic に行う。
+ * teamLoginKey で team の全 deployment 行を引き、`problemId` 一致する行に対し flag を
+ * 採点する。正解なら `ADD score :pts` + `SET flagSubmitted = true` を 1 UpdateItem
+ * で atomic に行う (Phase 2c: team scope なので problemId 引数が必須)。
  *
+ * - team scope に該当行が無い (key 不正) は `unauthorized`
+ * - team に該当 problemId が無い (= 違う event の問題を指定) は `unauthorized`
+ *   (= problem の存在を漏らさない)
  * - kind=flag 以外の問題は `not_flag_problem`
  * - stackOutputs に flagOutputKey が無い (= deploy 未完了等) は `no_outputs`
  * - 既に flagSubmitted=true なら `already_scored` (= 重複加算しない)
@@ -29,6 +33,7 @@ export async function submitFlag(
   shared: ParticipantSharedResources,
   scoringMap: Record<string, ProblemScoringMetadata>,
   teamLoginKey: string,
+  problemId: string,
   submittedFlag: string,
 ): Promise<SubmitFlagOutcome> {
   const out = await shared.ddb.send(
@@ -37,10 +42,12 @@ export async function submitFlag(
       IndexName: "GSI2",
       KeyConditionExpression: "GSI2PK = :pk",
       ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-      Limit: 1,
     }),
   );
-  const item = (out.Items?.[0] ?? undefined) as Partial<DeploymentItem> | undefined;
+  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  if (items.length === 0) return { kind: "unauthorized" };
+
+  const item = items.find((i) => i.problemId === problemId);
   if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
 
   const scoring = scoringMap[item.problemId];

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
@@ -1,6 +1,6 @@
 import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
-import { type ParticipantView, toView } from "./lookup.js";
+import { lookupTeamByLoginKey, type ParticipantTeamView } from "./lookup.js";
 import type { ParticipantSharedResources } from "./shared.js";
 
 const TEAM_NAME_RE = /^[A-Za-z0-9 _\-぀-ヿ一-鿿]{1,40}$/;
@@ -8,7 +8,7 @@ const TEAM_NAME_RE = /^[A-Za-z0-9 _\-぀-ヿ一-鿿]{1,40}$/;
 const NON_EDITABLE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
 export type UpdateOutcome =
-  | { kind: "ok"; view: ParticipantView }
+  | { kind: "ok"; view: ParticipantTeamView }
   | { kind: "invalid_team_name" }
   | { kind: "unauthorized" };
 
@@ -28,12 +28,15 @@ export function validateTeamName(raw: unknown): string | undefined {
 }
 
 /**
- * 競技者の `displayTeamName` を更新する。
+ * 競技者の `displayTeamName` を **team の全 deployment 行で** 更新する (Phase 2c)。
  *
- * GSI2 Query → 自分の行の `PK/status` を確認し、UpdateCommand を `ReturnValues=
- * ALL_NEW` で実行して更新後の行を取得 → そのまま `toView` で返却。
- * 旧実装の「Query → Update → Query (再 lookup)」3 round-trip を 2 round-trip に
- * 圧縮し、Update と再 Query の間の eventual consistency 窓も無くす。
+ * 1 teamLoginKey = 1 team = N deployment になったため、display 名は team scope の
+ * メタデータとして全行に伝播させる。`team` 集約 (Teams table) には book-keeping
+ * しないが、Participant Portal が `lookupTeamByLoginKey` で全行から代表値を取って
+ * 表示に使うので、すべての行で同じ値になっている必要がある。
+ *
+ * 編集不可な行 (DELETING / DELETED) は skip し、editable な 1 行も無ければ
+ * `unauthorized` を返す (= teamLoginKey 自体が無効化された場合と同じ扱い)。
  */
 export async function setDisplayTeamName(
   shared: ParticipantSharedResources,
@@ -49,30 +52,36 @@ export async function setDisplayTeamName(
       IndexName: "GSI2",
       KeyConditionExpression: "GSI2PK = :pk",
       ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-      Limit: 1,
     }),
   );
-  const item = queryOut.Items?.[0] as Partial<DeploymentItem> | undefined;
-  if (!item) return { kind: "unauthorized" };
-  const status = (item.status ?? "PENDING") as DeploymentStatus;
-  if (NON_EDITABLE_STATUSES.has(status)) return { kind: "unauthorized" };
-  if (!item.PK) return { kind: "unauthorized" };
+  const items = (queryOut.Items ?? []) as Partial<DeploymentItem>[];
+  if (items.length === 0) return { kind: "unauthorized" };
 
-  const updateOut = await shared.ddb.send(
-    new UpdateCommand({
-      TableName: shared.tableName,
-      Key: { PK: item.PK, SK: "META" },
-      UpdateExpression: "SET displayTeamName = :name, updatedAt = :now",
-      ExpressionAttributeValues: {
-        ":name": name,
-        ":now": new Date().toISOString(),
-      },
-      ReturnValues: "ALL_NEW",
-    }),
+  const editable = items.filter((i) => {
+    const status = (i.status ?? "PENDING") as DeploymentStatus;
+    return !NON_EDITABLE_STATUSES.has(status) && typeof i.PK === "string";
+  });
+  if (editable.length === 0) return { kind: "unauthorized" };
+
+  const now = new Date().toISOString();
+  await Promise.all(
+    editable.map((item) =>
+      shared.ddb.send(
+        new UpdateCommand({
+          TableName: shared.tableName,
+          Key: { PK: item.PK as string, SK: "META" },
+          UpdateExpression: "SET displayTeamName = :name, updatedAt = :now",
+          ExpressionAttributeValues: { ":name": name, ":now": now },
+        }),
+      ),
+    ),
   );
-  const updated = updateOut.Attributes as Partial<DeploymentItem> | undefined;
+
+  // 更新後の team view を構築するために再 lookup。Update の eventually consistent な
+  // 反映を避けるため `lookupTeamByLoginKey` 内の Query は GSI2 で eventually
+  // consistent だが、`teamName` フィールドは UpdateCommand の strong write が反映済
+  // (= 直近の write 後に Query しても eventually 数十 ms 以内に新値が見える)。
+  const updated = await lookupTeamByLoginKey(shared, teamLoginKey);
   if (!updated) return { kind: "unauthorized" };
-  const view = toView(updated, shared.problemsScoring);
-  if (!view) return { kind: "unauthorized" };
-  return { kind: "ok", view };
+  return { kind: "ok", view: updated };
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/update.ts
@@ -1,11 +1,10 @@
-import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
-import { lookupTeamByLoginKey, type ParticipantTeamView } from "./lookup.js";
-import type { ParticipantSharedResources } from "./shared.js";
+import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
+import { buildTeamView, type ParticipantTeamView } from "./lookup.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 const TEAM_NAME_RE = /^[A-Za-z0-9 _\-぀-ヿ一-鿿]{1,40}$/;
-
-const NON_EDITABLE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["DELETING", "DELETED"]);
 
 export type UpdateOutcome =
   | { kind: "ok"; view: ParticipantTeamView }
@@ -17,8 +16,7 @@ export type UpdateOutcome =
  * ひらがな / カタカナ / 漢字。1〜40 文字。
  *
  * 制御文字 / 改行 / emoji を弾くのは、Cloudscape の表示崩れと SQL injection 風の
- * 攻撃面を予防するため (DDB 自体には injection リスクは無いが、後段の UI / CSV
- * export 等で safe であることを保証する)。
+ * 攻撃面を予防するため。
  */
 export function validateTeamName(raw: unknown): string | undefined {
   if (typeof raw !== "string") return undefined;
@@ -28,15 +26,16 @@ export function validateTeamName(raw: unknown): string | undefined {
 }
 
 /**
- * 競技者の `displayTeamName` を **team の全 deployment 行で** 更新する (Phase 2c)。
+ * 競技者の `displayTeamName` を **team の全 deployment 行で** 更新する。
  *
- * 1 teamLoginKey = 1 team = N deployment になったため、display 名は team scope の
- * メタデータとして全行に伝播させる。`team` 集約 (Teams table) には book-keeping
- * しないが、Participant Portal が `lookupTeamByLoginKey` で全行から代表値を取って
- * 表示に使うので、すべての行で同じ値になっている必要がある。
+ * 1 teamLoginKey = 1 team = N deployment なので、display 名は team scope の
+ * メタデータとして全行に伝播させる。
  *
  * 編集不可な行 (DELETING / DELETED) は skip し、editable な 1 行も無ければ
  * `unauthorized` を返す (= teamLoginKey 自体が無効化された場合と同じ扱い)。
+ *
+ * Update は `ReturnValues=ALL_NEW` で更新後 row を取り、その集合から team view を
+ * 直接構築する (= 再 query 不要、strong write の整合性を保つ)。
  */
 export async function setDisplayTeamName(
   shared: ParticipantSharedResources,
@@ -46,25 +45,17 @@ export async function setDisplayTeamName(
   const name = validateTeamName(rawName);
   if (!name) return { kind: "invalid_team_name" };
 
-  const queryOut = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.tableName,
-      IndexName: "GSI2",
-      KeyConditionExpression: "GSI2PK = :pk",
-      ExpressionAttributeValues: { ":pk": `TEAMKEY#${teamLoginKey}` },
-    }),
-  );
-  const items = (queryOut.Items ?? []) as Partial<DeploymentItem>[];
+  const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
 
   const editable = items.filter((i) => {
     const status = (i.status ?? "PENDING") as DeploymentStatus;
-    return !NON_EDITABLE_STATUSES.has(status) && typeof i.PK === "string";
+    return !DELETED_LIKE_STATUSES.has(status) && typeof i.PK === "string";
   });
   if (editable.length === 0) return { kind: "unauthorized" };
 
   const now = new Date().toISOString();
-  await Promise.all(
+  const updateResults = await Promise.all(
     editable.map((item) =>
       shared.ddb.send(
         new UpdateCommand({
@@ -72,16 +63,15 @@ export async function setDisplayTeamName(
           Key: { PK: item.PK as string, SK: "META" },
           UpdateExpression: "SET displayTeamName = :name, updatedAt = :now",
           ExpressionAttributeValues: { ":name": name, ":now": now },
+          ReturnValues: "ALL_NEW",
         }),
       ),
     ),
   );
-
-  // 更新後の team view を構築するために再 lookup。Update の eventually consistent な
-  // 反映を避けるため `lookupTeamByLoginKey` 内の Query は GSI2 で eventually
-  // consistent だが、`teamName` フィールドは UpdateCommand の strong write が反映済
-  // (= 直近の write 後に Query しても eventually 数十 ms 以内に新値が見える)。
-  const updated = await lookupTeamByLoginKey(shared, teamLoginKey);
-  if (!updated) return { kind: "unauthorized" };
-  return { kind: "ok", view: updated };
+  const updatedItems = updateResults
+    .map((r) => r.Attributes as Partial<DeploymentItem> | undefined)
+    .filter((a): a is Partial<DeploymentItem> => !!a);
+  const view = buildTeamView(updatedItems, shared.problemsScoring);
+  if (!view) return { kind: "unauthorized" };
+  return { kind: "ok", view };
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/constants.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/constants.ts
@@ -1,0 +1,17 @@
+import type { DeploymentStatus } from "../deploy-handler/types.js";
+
+/** problemId は metadata.json と整合する RFC 1035-ish の slug。両端は英数字、内側のみ - 許容。 */
+export const PROBLEM_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+/** ULID (Crockford Base32, 26 文字)。 */
+export const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/**
+ * Deployment が「削除中 or 削除済」と見なされる状態。
+ * - lookup: GSI2 sparse 化が崩れた行を弾く
+ * - update: 編集不可な行を skip
+ */
+export const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+  "DELETING",
+  "DELETED",
+]);

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -1,6 +1,6 @@
 import { QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { lookupByTeamLoginKey } from "../../lib/problem-deploy/handlers/participant-handler/lookup";
+import { lookupTeamByLoginKey } from "../../lib/problem-deploy/handlers/participant-handler/lookup";
 import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
 
 function buildShared(scoring: ParticipantSharedResources["problemsScoring"] = {}): {
@@ -37,36 +37,38 @@ const sampleRow = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-describe("lookupByTeamLoginKey", () => {
+describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GSI2 を TEAMKEY#<key> で Query するべき (Limit=1)", async () => {
+  it("GSI2 を TEAMKEY#<key> で Query するべき (Limit なし、team scope の全行を取る)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 
-    await lookupByTeamLoginKey(shared, "KEY1");
+    await lookupTeamByLoginKey(shared, "KEY1");
 
     const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
     expect(cmd).toBeInstanceOf(QueryCommand);
     expect(cmd.input.IndexName).toBe("GSI2");
     expect(cmd.input.KeyConditionExpression).toContain("GSI2PK = :pk");
     expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TEAMKEY#KEY1");
-    expect(cmd.input.Limit).toBe(1);
+    // team scope なので Limit は付けない (= team の全 problems を 1 query で取る)
+    expect(cmd.input.Limit).toBeUndefined();
   });
 
-  it("正常系: 公開フィールドのみ返すべき (operator 内部情報 / teamLoginKey は除外)", async () => {
+  it("正常系: team + problems[] を返し、operator 内部情報 / teamLoginKey を漏らさない", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
     expect(view).toBeDefined();
-    expect(view?.jobId).toBe("JOB1");
-    expect(view?.problemId).toBe("security-battle-royale");
-    expect(view?.teamName).toBe("Alpha");
-    expect(view?.teamNameSetByCompetitor).toBe(false);
-    expect(view?.region).toBe("ap-northeast-1");
-    expect(view?.status).toBe("COMPLETE");
-    expect(view?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
+    expect(view?.team.teamName).toBe("Alpha");
+    expect(view?.team.teamNameSetByCompetitor).toBe(false);
+    expect(view?.problems).toHaveLength(1);
+    expect(view?.problems[0]?.jobId).toBe("JOB1");
+    expect(view?.problems[0]?.problemId).toBe("security-battle-royale");
+    expect(view?.problems[0]?.region).toBe("ap-northeast-1");
+    expect(view?.problems[0]?.status).toBe("COMPLETE");
+    expect(view?.problems[0]?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
 
     const json = JSON.stringify(view);
     expect(json).not.toContain("SECRET_DO_NOT_LEAK");
@@ -75,51 +77,68 @@ describe("lookupByTeamLoginKey", () => {
     expect(json).not.toContain("namePrefix");
   });
 
-  it("displayTeamName が DDB にあれば teamName はそれを優先し teamNameSetByCompetitor=true", async () => {
+  it("displayTeamName が DDB にあれば team.teamName はそれを優先し teamNameSetByCompetitor=true", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ teamName: "operator-slug", displayTeamName: "わたしたちのチーム" })],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.teamName).toBe("わたしたちのチーム");
-    expect(view?.teamNameSetByCompetitor).toBe(true);
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.team.teamName).toBe("わたしたちのチーム");
+    expect(view?.team.teamNameSetByCompetitor).toBe(true);
   });
 
-  it("displayTeamName が空文字でも未設定扱い (typeof string チェックは通るが trim 後の検証は upstream)", async () => {
+  it("Phase 2a 経由の eventId / teamId 列が team に伝播するべき", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
-      Items: [sampleRow({ teamName: "operator-slug", displayTeamName: "" })],
+      Items: [sampleRow({ eventId: "EV1", teamId: "T1" })],
     });
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    // 空文字は string なので typeof check は通り、teamName="" / set=true になる。
-    // バリデーションは update.ts が責務。ここでは raw を expose することを担保する。
-    expect(view?.teamName).toBe("");
-    expect(view?.teamNameSetByCompetitor).toBe(true);
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.team.eventId).toBe("EV1");
+    expect(view?.team.teamId).toBe("T1");
+  });
+
+  it("旧 jobId-based deployment (eventId / teamId 無し) は team.eventId/teamId が undefined", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.team.eventId).toBeUndefined();
+    expect(view?.team.teamId).toBeUndefined();
   });
 
   it("該当行が無ければ undefined", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [] });
 
-    const view = await lookupByTeamLoginKey(shared, "NOSUCHKEY");
+    const view = await lookupTeamByLoginKey(shared, "NOSUCHKEY");
     expect(view).toBeUndefined();
   });
 
-  it("status=DELETING は undefined (認証失敗扱い)", async () => {
+  it("全行が DELETING / DELETED は undefined (sparse 化が崩れた場合の防御)", async () => {
     const { shared, ddbSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "DELETING" })] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ status: "DELETING" }), sampleRow({ jobId: "JOB2", status: "DELETED" })],
+    });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
     expect(view).toBeUndefined();
   });
 
-  it("status=DELETED は undefined (認証失敗扱い)", async () => {
+  it("一部だけ DELETED な team は live な行のみで problems[] を構築するべき", async () => {
     const { shared, ddbSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "DELETED" })] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({ jobId: "JOB1", problemId: "p1", status: "COMPLETE" }),
+        sampleRow({ jobId: "JOB2", problemId: "p2", status: "DELETED" }),
+        sampleRow({ jobId: "JOB3", problemId: "p3", status: "PENDING" }),
+      ],
+    });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view).toBeUndefined();
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems).toHaveLength(2);
+    expect(view?.problems.map((p) => p.problemId).sort()).toEqual(["p1", "p3"]);
   });
 
   it("status=FAILED のみ failureReason を露出する", async () => {
@@ -128,8 +147,8 @@ describe("lookupByTeamLoginKey", () => {
       Items: [sampleRow({ status: "FAILED", failureReason: "VPC limit" })],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.failureReason).toBe("VPC limit");
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.failureReason).toBe("VPC limit");
   });
 
   it("status=COMPLETE で failureReason が DDB 側に残っていても露出しない", async () => {
@@ -138,8 +157,8 @@ describe("lookupByTeamLoginKey", () => {
       Items: [sampleRow({ status: "COMPLETE", failureReason: "stale data" })],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.failureReason).toBeUndefined();
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.failureReason).toBeUndefined();
   });
 
   it("壊れた stackOutputs JSON は空 object として返す (best-effort)", async () => {
@@ -148,14 +167,14 @@ describe("lookupByTeamLoginKey", () => {
       Items: [sampleRow({ stackOutputs: "not-json" })],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.stackOutputs).toEqual({});
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.stackOutputs).toEqual({});
   });
 
   it("flag 形式 problem では flagOutputKey の値を stackOutputs から strip するべき (= 答え露出防止)", async () => {
     const scoring = {
       "security-battle-royale": {
-        kind: "flag",
+        kind: "flag" as const,
         flagOutputKey: "FlagAnswer",
         points: 100,
       },
@@ -172,15 +191,15 @@ describe("lookupByTeamLoginKey", () => {
       ],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
-    expect(view?.scoring?.kind).toBe("flag");
-    expect(view?.scoring?.points).toBe(100);
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
+    expect(view?.problems[0]?.scoring?.kind).toBe("flag");
+    expect(view?.problems[0]?.scoring?.points).toBe(100);
   });
 
-  it("score / lastScoredAt / lastResult / scoring を participant view に含めるべき", async () => {
+  it("score / lastScoredAt / lastResult / scoring を problem view に含めるべき", async () => {
     const scoring = {
-      "security-battle-royale": { kind: "uptime", pointsPerSuccess: 50 },
+      "security-battle-royale": { kind: "uptime" as const, pointsPerSuccess: 50 },
     };
     const { shared, ddbSend } = buildShared(scoring);
     ddbSend.mockResolvedValueOnce({
@@ -193,19 +212,20 @@ describe("lookupByTeamLoginKey", () => {
       ],
     });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.score).toBe(250);
-    expect(view?.lastScoredAt).toBe("2026-05-05T10:00:00.000Z");
-    expect(view?.lastResult).toBe("ok");
-    expect(view?.scoring?.kind).toBe("uptime");
-    expect(view?.scoring?.pointsPerSuccess).toBe(50);
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    const p = view?.problems[0];
+    expect(p?.score).toBe(250);
+    expect(p?.lastScoredAt).toBe("2026-05-05T10:00:00.000Z");
+    expect(p?.lastResult).toBe("ok");
+    expect(p?.scoring?.kind).toBe("uptime");
+    expect(p?.scoring?.pointsPerSuccess).toBe(50);
   });
 
   it("score 未設定の row は 0 を返すべき (default)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 
-    const view = await lookupByTeamLoginKey(shared, "KEY1");
-    expect(view?.score).toBe(0);
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.score).toBe(0);
   });
 });

--- a/infrastructure/test/problem-deploy/participant-routes.test.ts
+++ b/infrastructure/test/problem-deploy/participant-routes.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  lookupByTeamLoginKey: vi.fn(),
+  lookupTeamByLoginKey: vi.fn(),
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
@@ -12,7 +12,7 @@ vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/participant-handler/lookup", () => ({
-  lookupByTeamLoginKey: mocks.lookupByTeamLoginKey,
+  lookupTeamByLoginKey: mocks.lookupTeamByLoginKey,
 }));
 
 const { app } = await import("../../lib/problem-deploy/handlers/participant-handler/index");
@@ -31,29 +31,35 @@ describe("GET /portal/healthz", () => {
 describe("GET /portal/me", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: lookup ヒットで 200 と view を返すべき", async () => {
-    mocks.lookupByTeamLoginKey.mockResolvedValueOnce({
-      jobId: "JOB1",
-      problemId: "p",
-      teamName: "Alpha",
-      region: "ap-northeast-1",
-      status: "COMPLETE",
-      stackOutputs: { FrontendUrl: "https://x" },
-      expiresAt: 1_700_000_000,
+  it("正常系: lookup ヒットで 200 と team scope view を返すべき", async () => {
+    mocks.lookupTeamByLoginKey.mockResolvedValueOnce({
+      team: { teamName: "Alpha", teamNameSetByCompetitor: false },
+      problems: [
+        {
+          jobId: "JOB1",
+          problemId: "p",
+          region: "ap-northeast-1",
+          status: "COMPLETE",
+          stackOutputs: { FrontendUrl: "https://x" },
+          expiresAt: 1_700_000_000,
+          score: 0,
+        },
+      ],
     });
     const res = await app.request("/portal/me", {
       headers: { authorization: `Bearer ${VALID_KEY}` },
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.jobId).toBe("JOB1");
-    expect(body.stackOutputs.FrontendUrl).toBe("https://x");
+    expect(body.team.teamName).toBe("Alpha");
+    expect(body.problems[0].jobId).toBe("JOB1");
+    expect(body.problems[0].stackOutputs.FrontendUrl).toBe("https://x");
   });
 
   it("Authorization ヘッダ無しは 401 (lookup を呼ばない)", async () => {
     const res = await app.request("/portal/me");
     expect(res.status).toBe(401);
-    expect(mocks.lookupByTeamLoginKey).not.toHaveBeenCalled();
+    expect(mocks.lookupTeamByLoginKey).not.toHaveBeenCalled();
   });
 
   it("Bearer プレフィックス無しは 401", async () => {
@@ -61,7 +67,7 @@ describe("GET /portal/me", () => {
       headers: { authorization: VALID_KEY },
     });
     expect(res.status).toBe(401);
-    expect(mocks.lookupByTeamLoginKey).not.toHaveBeenCalled();
+    expect(mocks.lookupTeamByLoginKey).not.toHaveBeenCalled();
   });
 
   it("形式不正な key は 401 (DDB を叩かない — timing oracle 防止)", async () => {
@@ -69,11 +75,11 @@ describe("GET /portal/me", () => {
       headers: { authorization: "Bearer too-short" },
     });
     expect(res.status).toBe(401);
-    expect(mocks.lookupByTeamLoginKey).not.toHaveBeenCalled();
+    expect(mocks.lookupTeamByLoginKey).not.toHaveBeenCalled();
   });
 
   it("lookup が undefined なら 401 (no_team_found)", async () => {
-    mocks.lookupByTeamLoginKey.mockResolvedValueOnce(undefined);
+    mocks.lookupTeamByLoginKey.mockResolvedValueOnce(undefined);
     const res = await app.request("/portal/me", {
       headers: { authorization: `Bearer ${VALID_KEY}` },
     });
@@ -81,7 +87,7 @@ describe("GET /portal/me", () => {
   });
 
   it("lookup 例外は 500", async () => {
-    mocks.lookupByTeamLoginKey.mockRejectedValueOnce(new Error("ddb down"));
+    mocks.lookupTeamByLoginKey.mockRejectedValueOnce(new Error("ddb down"));
     const res = await app.request("/portal/me", {
       headers: { authorization: `Bearer ${VALID_KEY}` },
     });

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -72,31 +72,57 @@ describe("validateTeamName", () => {
 describe("setDisplayTeamName", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: GSI2 Query → UpdateItem (ReturnValues=ALL_NEW) で 2 round-trip", async () => {
+  it("正常系 (1 deployment): Query → Update → re-lookup で team scope view を返す", async () => {
     const { shared, ddbSend } = buildShared();
-    // 1st Query: 現在の行を取得
+    // 1st Query: GSI2 で team の全 deployment 行
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    // 2nd UpdateItem: ALL_NEW で更新後の行を返す
-    ddbSend.mockResolvedValueOnce({
-      Attributes: sampleRow({ displayTeamName: "新チーム" }),
-    });
+    // 2nd UpdateItem: 1 行更新 (Promise.all 並列だが mock 順序は安定)
+    ddbSend.mockResolvedValueOnce({});
+    // 3rd Query: re-lookup (lookupTeamByLoginKey が GSI2 を再 query)
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ displayTeamName: "新チーム" })] });
 
     const out = await setDisplayTeamName(shared, "KEY1", "新チーム");
     expect(out.kind).toBe("ok");
     if (out.kind === "ok") {
-      expect(out.view.teamName).toBe("新チーム");
-      expect(out.view.teamNameSetByCompetitor).toBe(true);
+      expect(out.view.team.teamName).toBe("新チーム");
+      expect(out.view.team.teamNameSetByCompetitor).toBe(true);
+      expect(out.view.problems).toHaveLength(1);
     }
-
-    // ちょうど 2 回 (Query + UpdateItem)。3 回目の再 Query が消えていることの担保。
-    expect(ddbSend).toHaveBeenCalledTimes(2);
 
     const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(updateCmd).toBeInstanceOf(UpdateCommand);
     expect(updateCmd.input.UpdateExpression).toContain("displayTeamName = :name");
     expect(updateCmd.input.ExpressionAttributeValues?.[":name"]).toBe("新チーム");
     expect(updateCmd.input.Key).toEqual({ PK: "DEPLOYMENT#JOB1", SK: "META" });
-    expect(updateCmd.input.ReturnValues).toBe("ALL_NEW");
+  });
+
+  it("正常系 (N deployments): team の全 editable 行を Promise.all で並列 update するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({ jobId: "JOB1", PK: "DEPLOYMENT#JOB1" }),
+        sampleRow({ jobId: "JOB2", PK: "DEPLOYMENT#JOB2", problemId: "p2" }),
+        sampleRow({ jobId: "JOB3", PK: "DEPLOYMENT#JOB3", problemId: "p3", status: "DELETING" }),
+      ],
+    });
+    // 並列 Update × 2 (DELETING 行は skip)
+    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({ jobId: "JOB1", PK: "DEPLOYMENT#JOB1", displayTeamName: "X" }),
+        sampleRow({ jobId: "JOB2", PK: "DEPLOYMENT#JOB2", problemId: "p2", displayTeamName: "X" }),
+        sampleRow({ jobId: "JOB3", PK: "DEPLOYMENT#JOB3", problemId: "p3", status: "DELETING" }),
+      ],
+    });
+
+    await setDisplayTeamName(shared, "KEY1", "X");
+    const updateCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is UpdateCommand => c instanceof UpdateCommand);
+    expect(updateCmds).toHaveLength(2); // DELETING は skip
+    const updatedKeys = updateCmds.map((c) => (c.input.Key as { PK: string }).PK).sort();
+    expect(updatedKeys).toEqual(["DEPLOYMENT#JOB1", "DEPLOYMENT#JOB2"]);
   });
 
   it("無効な teamName は invalid_team_name (DDB を叩かない)", async () => {
@@ -113,7 +139,7 @@ describe("setDisplayTeamName", () => {
     expect(out.kind).toBe("unauthorized");
   });
 
-  it("status が DELETING / DELETED なら unauthorized (UpdateItem しない)", async () => {
+  it("team の全行が DELETING / DELETED なら unauthorized (UpdateItem しない)", async () => {
     for (const status of ["DELETING", "DELETED"]) {
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status })] });
@@ -124,14 +150,15 @@ describe("setDisplayTeamName", () => {
     }
   });
 
-  it("最初の Query は GSI2 KeyCondition + Limit=1", async () => {
+  it("最初の Query は GSI2 KeyCondition (Limit なし、team の全行を取る)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    ddbSend.mockResolvedValueOnce({ Attributes: sampleRow({ displayTeamName: "X" }) });
+    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ displayTeamName: "X" })] });
     await setDisplayTeamName(shared, "KEY1", "X");
     const queryCmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
     expect(queryCmd).toBeInstanceOf(QueryCommand);
     expect(queryCmd.input.IndexName).toBe("GSI2");
-    expect(queryCmd.input.Limit).toBe(1);
+    expect(queryCmd.input.Limit).toBeUndefined();
   });
 });

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -72,14 +72,14 @@ describe("validateTeamName", () => {
 describe("setDisplayTeamName", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系 (1 deployment): Query → Update → re-lookup で team scope view を返す", async () => {
+  it("正常系 (1 deployment): Query → Update (ALL_NEW) で team scope view を返す (再 query 不要)", async () => {
     const { shared, ddbSend } = buildShared();
     // 1st Query: GSI2 で team の全 deployment 行
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    // 2nd UpdateItem: 1 行更新 (Promise.all 並列だが mock 順序は安定)
-    ddbSend.mockResolvedValueOnce({});
-    // 3rd Query: re-lookup (lookupTeamByLoginKey が GSI2 を再 query)
-    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ displayTeamName: "新チーム" })] });
+    // 2nd UpdateItem: ReturnValues=ALL_NEW で更新後 Attributes を返す
+    ddbSend.mockResolvedValueOnce({
+      Attributes: sampleRow({ displayTeamName: "新チーム" }),
+    });
 
     const out = await setDisplayTeamName(shared, "KEY1", "新チーム");
     expect(out.kind).toBe("ok");
@@ -89,11 +89,13 @@ describe("setDisplayTeamName", () => {
       expect(out.view.problems).toHaveLength(1);
     }
 
+    expect(ddbSend).toHaveBeenCalledTimes(2);
     const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(updateCmd).toBeInstanceOf(UpdateCommand);
     expect(updateCmd.input.UpdateExpression).toContain("displayTeamName = :name");
     expect(updateCmd.input.ExpressionAttributeValues?.[":name"]).toBe("新チーム");
     expect(updateCmd.input.Key).toEqual({ PK: "DEPLOYMENT#JOB1", SK: "META" });
+    expect(updateCmd.input.ReturnValues).toBe("ALL_NEW");
   });
 
   it("正常系 (N deployments): team の全 editable 行を Promise.all で並列 update するべき", async () => {
@@ -105,15 +107,17 @@ describe("setDisplayTeamName", () => {
         sampleRow({ jobId: "JOB3", PK: "DEPLOYMENT#JOB3", problemId: "p3", status: "DELETING" }),
       ],
     });
-    // 並列 Update × 2 (DELETING 行は skip)
-    ddbSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({});
+    // 並列 Update × 2 (DELETING 行は skip)。ALL_NEW で各 Attributes を返す。
     ddbSend.mockResolvedValueOnce({
-      Items: [
-        sampleRow({ jobId: "JOB1", PK: "DEPLOYMENT#JOB1", displayTeamName: "X" }),
-        sampleRow({ jobId: "JOB2", PK: "DEPLOYMENT#JOB2", problemId: "p2", displayTeamName: "X" }),
-        sampleRow({ jobId: "JOB3", PK: "DEPLOYMENT#JOB3", problemId: "p3", status: "DELETING" }),
-      ],
+      Attributes: sampleRow({ jobId: "JOB1", PK: "DEPLOYMENT#JOB1", displayTeamName: "X" }),
+    });
+    ddbSend.mockResolvedValueOnce({
+      Attributes: sampleRow({
+        jobId: "JOB2",
+        PK: "DEPLOYMENT#JOB2",
+        problemId: "p2",
+        displayTeamName: "X",
+      }),
     });
 
     await setDisplayTeamName(shared, "KEY1", "X");
@@ -153,8 +157,9 @@ describe("setDisplayTeamName", () => {
   it("最初の Query は GSI2 KeyCondition (Limit なし、team の全行を取る)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    ddbSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ displayTeamName: "X" })] });
+    ddbSend.mockResolvedValueOnce({
+      Attributes: sampleRow({ displayTeamName: "X" }),
+    });
     await setDisplayTeamName(shared, "KEY1", "X");
     const queryCmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
     expect(queryCmd).toBeInstanceOf(QueryCommand);

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -54,13 +54,19 @@ describe("submitFlag", () => {
 
   it("teamLoginKey が一致する row が無いときは unauthorized を返すべき", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
-    const out = await submitFlag(shared, flagScoring, "BAD_KEY", "Hello from tc-...");
+    const out = await submitFlag(
+      shared,
+      flagScoring,
+      "BAD_KEY",
+      "hello-world",
+      "Hello from tc-...",
+    );
     expect(out).toEqual({ kind: "unauthorized" });
   });
 
   it("scoring 設定が無い problemId は not_flag_problem を返すべき", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ problemId: "no-scoring" })] });
-    const out = await submitFlag(shared, flagScoring, "KEY", "anything");
+    const out = await submitFlag(shared, flagScoring, "KEY", "no-scoring", "anything");
     expect(out).toEqual({ kind: "not_flag_problem" });
   });
 
@@ -68,7 +74,13 @@ describe("submitFlag", () => {
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ flagSubmitted: true, score: 100 })],
     });
-    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    const out = await submitFlag(
+      shared,
+      flagScoring,
+      "KEY",
+      "hello-world",
+      "Hello from tc-hello-world-alpha",
+    );
     expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
     // UpdateItem は呼ばれないこと (= Query の 1 回のみ)
     expect(ddbSend).toHaveBeenCalledTimes(1);
@@ -78,13 +90,13 @@ describe("submitFlag", () => {
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ stackOutputs: undefined })],
     });
-    const out = await submitFlag(shared, flagScoring, "KEY", "anything");
+    const out = await submitFlag(shared, flagScoring, "KEY", "hello-world", "anything");
     expect(out).toEqual({ kind: "no_outputs" });
   });
 
   it("submitted flag が expected と一致しなければ wrong を返すべき (UpdateItem 呼ばない)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    const out = await submitFlag(shared, flagScoring, "KEY", "wrong-answer");
+    const out = await submitFlag(shared, flagScoring, "KEY", "hello-world", "wrong-answer");
     expect(out).toEqual({ kind: "wrong" });
     expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、Update なし
   });
@@ -92,7 +104,13 @@ describe("submitFlag", () => {
   it("正解なら ADD score :pts SET flagSubmitted=true で UpdateItem し ok を返すべき", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
-    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    const out = await submitFlag(
+      shared,
+      flagScoring,
+      "KEY",
+      "hello-world",
+      "Hello from tc-hello-world-alpha",
+    );
     expect(out).toEqual({ kind: "ok", scoreDelta: 100, totalScore: 100 });
     expect(ddbSend).toHaveBeenCalledTimes(2);
     const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
@@ -105,7 +123,13 @@ describe("submitFlag", () => {
   it("trim した値が一致すれば ok を返すべき (= 末尾改行などで弾かない)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
-    const out = await submitFlag(shared, flagScoring, "KEY", "  Hello from tc-hello-world-alpha\n");
+    const out = await submitFlag(
+      shared,
+      flagScoring,
+      "KEY",
+      "hello-world",
+      "  Hello from tc-hello-world-alpha\n",
+    );
     expect(out.kind).toBe("ok");
   });
 
@@ -115,14 +139,26 @@ describe("submitFlag", () => {
       name: "ConditionalCheckFailedException",
     });
     ddbSend.mockRejectedValueOnce(condErr);
-    const out = await submitFlag(shared, flagScoring, "KEY", "Hello from tc-hello-world-alpha");
+    const out = await submitFlag(
+      shared,
+      flagScoring,
+      "KEY",
+      "hello-world",
+      "Hello from tc-hello-world-alpha",
+    );
     expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
   });
 
   it("Query は GSI2 を `TEAMKEY#<key>` で叩くべき", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
-    await submitFlag(shared, flagScoring, "MYKEY", "Hello from tc-hello-world-alpha");
+    await submitFlag(
+      shared,
+      flagScoring,
+      "MYKEY",
+      "hello-world",
+      "Hello from tc-hello-world-alpha",
+    );
     const queryCmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
     expect(queryCmd).toBeInstanceOf(QueryCommand);
     expect(queryCmd.input.IndexName).toBe("GSI2");


### PR DESCRIPTION
## Summary

1 teamLoginKey で event 内の N 問題すべてを引けるようにし、Portal を「自チームの問題マトリクス」に書き換える (旧: 1 deployment view → 新: \`{team, problems[]}\`)。

### Backend
- \`lookup.ts\`: \`lookupTeamByLoginKey\` (rename) で team scope の全 deployments を取得し \`ParticipantTeamView\` を返す
- \`update.ts\`: \`setDisplayTeamName\` を team scope 化 (editable な全 deployment 行を Promise.all で並列 update)
- \`submit-flag.ts\`: \`problemId\` 引数必須化 (= team scope で どの problem の flag か明示)
- \`index.ts\`: \`POST /portal/me/submit-flag\` で \`problemId\` を validate

### Frontend
- \`portal-client.ts\`: \`ParticipantTeamView\` / \`ParticipantProblemView\` 型新設、\`submitFlag\` シグネチャ変更
- \`Home.tsx\`: \`TeamScorePanel\` (累計) + 各 problem を \`ProblemCard\` で個別表示 (status / outputs / per-problem flag form)
- \`AuthProvider.tsx\`: \`view.team.eventId/teamId/teamName\` 経由で session 構築

## Regression 分析

- **\`GET /portal/me\` のレスポンス shape は破壊的変更**:
  - 旧: \`{ jobId, problemId, teamName, ... }\` (1 deployment)
  - 新: \`{ team: {...}, problems: [{...}] }\` (team scope)
  - frontend が同一 commit で追従するため drift なし
- \`POST /portal/me/submit-flag\` body に \`problemId\` 必須追加 — 旧 client は 400。Phase 2c 同梱 frontend で対応済
- Phase 1 以前の jobId-based deployment (eventId/teamId 無し) も lookup 経由で problems[0] として正しく見える (= 後方互換)

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | ParticipantPortal Lambda | レスポンス shape 変更 (破壊的、frontend 同期) |
| UPDATE | participant-portal SPA | Home.tsx 全面書き換え + portal-client 型 |
| NO-OP  | DDB schema / 他 Lambda / IAM | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (testsuite 全 245 件 / lint / typecheck / build)
- [x] participant-lookup.test.ts 14 件 (1 deployment / N deployments / Phase 2a 列 / 旧 deployment 互換 / 一部 DELETED 混在)
- [x] participant-update.test.ts 11 件 (team scope 並列 update + DELETING skip)
- [x] submit-flag.test.ts 9 件 (problemId 引数追加で全件 pass)
- [x] portal-client.test.ts / AuthProvider.test.tsx: 新 view shape に追従
- [ ] AWS 上で実 deploy → portal で teamLoginKey ログイン → problems[] 表示 → flag 提出を E2E 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participant teams can now view and manage multiple problems instead of one.
  * Team score now displays the aggregate of all problem scores.
  * Each problem displays individual status, feedback, and scoring information.
  * Flag submission now requires specifying the problem being submitted for.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->