### PR TITLE
chore: tenkacloud- prefix で衝突回避 (ProtoShip 併存対応)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ bootstrap:            env-check build ; $(CDK) bootstrap
 deploy:               env-check
 	@cd scripts && bash install.sh "$${SYSTEM_ADMIN_EMAIL}"
 # stack 単位の deploy (直接呼ぶ時用。source.zip + CDK_PARAM_COMMIT_ID を事前 export しておく前提)
-deploy-control-plane: env-check build ; $(CDK) deploy ControlPlaneStack $(APPROVAL)
-deploy-bootstrap:     env-check build ; $(CDK) deploy serverless-saas-ref-arch-bootstrap-stack $(APPROVAL)
+deploy-control-plane: env-check build ; $(CDK) deploy tenkacloud-control-plane $(APPROVAL)
+deploy-bootstrap:     env-check build ; $(CDK) deploy tenkacloud-bootstrap $(APPROVAL)
 destroy:              env-check       ; bash scripts/cleanup.sh
 
 # ===== Problem deploy smoke test (MVP-0, ADR-001 PR-1.5) =====

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -145,7 +145,7 @@ const apiKeySSMParameterNames = {
 const stackEnv =
   awsAccountId && awsRegion ? { env: { account: awsAccountId, region: awsRegion } } : {};
 
-const controlPlaneStack = new ControlPlaneStack(app, "ControlPlaneStack", {
+const controlPlaneStack = new ControlPlaneStack(app, "tenkacloud-control-plane", {
   ...stackEnv,
   systemAdminEmail,
 });
@@ -184,7 +184,7 @@ const problemsRoot = path.resolve(__dirname, "..", "..", "problems");
 const problemsCatalog = discoverProblemsCatalog(problemsRoot);
 const problemsScoring = discoverProblemsScoring(problemsRoot);
 
-const problemDeployBackendStack = new ProblemDeployBackendStack(app, "ProblemDeployBackendStack", {
+const problemDeployBackendStack = new ProblemDeployBackendStack(app, "tenkacloud-problem-deploy", {
   ...stackEnv,
   eventBusArn: controlPlaneStack.eventBusArn,
   sourceBucketName: s3SourceBucket,
@@ -197,44 +197,36 @@ cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
 );
 
-const bootstrapTemplateStack = new BootstrapTemplateStack(
-  app,
-  "serverless-saas-ref-arch-bootstrap-stack",
-  {
-    ...stackEnv,
-    systemAdminEmail,
-    eventBusArn: controlPlaneStack.eventBusArn,
-    apiKeyPlatinumTierParameter,
-    apiKeyPremiumTierParameter,
-    apiKeyStandardTierParameter,
-    apiKeyBasicTierParameter,
-    apiKeySSMParameterNames,
-    tenantMappingTableBillingMode: dynamoBillingMode,
-    tenantMappingTableReadCapacity: isDynamoProvisioned ? dynamoReadCapacity : undefined,
-    tenantMappingTableWriteCapacity: isDynamoProvisioned ? dynamoWriteCapacity : undefined,
-  },
-);
+const bootstrapTemplateStack = new BootstrapTemplateStack(app, "tenkacloud-bootstrap", {
+  ...stackEnv,
+  systemAdminEmail,
+  eventBusArn: controlPlaneStack.eventBusArn,
+  apiKeyPlatinumTierParameter,
+  apiKeyPremiumTierParameter,
+  apiKeyStandardTierParameter,
+  apiKeyBasicTierParameter,
+  apiKeySSMParameterNames,
+  tenantMappingTableBillingMode: dynamoBillingMode,
+  tenantMappingTableReadCapacity: isDynamoProvisioned ? dynamoReadCapacity : undefined,
+  tenantMappingTableWriteCapacity: isDynamoProvisioned ? dynamoWriteCapacity : undefined,
+});
 cdk.Aspects.of(bootstrapTemplateStack).add(new DestroyPolicySetter());
 
-const tenantTemplateStack = new TenantTemplateStack(
-  app,
-  `serverless-saas-ref-arch-tenant-template-${tenantId}`,
-  {
-    ...stackEnv,
-    tenantId,
-    tenantName,
-    environment,
-    stageName,
-    lambdaReserveConcurrency,
-    lambdaCanaryDeploymentPreference,
-    isPooledDeploy,
-    ApiKeySSMParameterNames: apiKeySSMParameterNames,
-    tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
-    commitId,
-    deployApiLambda: problemDeployBackendStack.deployApiLambda,
-    eventApiLambda: problemDeployBackendStack.eventApiLambda,
-  },
-);
+const tenantTemplateStack = new TenantTemplateStack(app, `tenkacloud-tenant-template-${tenantId}`, {
+  ...stackEnv,
+  tenantId,
+  tenantName,
+  environment,
+  stageName,
+  lambdaReserveConcurrency,
+  lambdaCanaryDeploymentPreference,
+  isPooledDeploy,
+  ApiKeySSMParameterNames: apiKeySSMParameterNames,
+  tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
+  commitId,
+  deployApiLambda: problemDeployBackendStack.deployApiLambda,
+  eventApiLambda: problemDeployBackendStack.eventApiLambda,
+});
 
 tenantTemplateStack.addDependency(problemDeployBackendStack);
 
@@ -243,7 +235,7 @@ cdk.Tags.of(tenantTemplateStack).add("TenantId", tenantId);
 cdk.Tags.of(tenantTemplateStack).add("IsPooledDeploy", String(isPooledDeploy));
 cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());
 
-const serverlessSaaSPipeline = new ServerlessSaaSPipeline(app, "ServerlessSaaSPipeline", {
+const serverlessSaaSPipeline = new ServerlessSaaSPipeline(app, "tenkacloud-saas-pipeline", {
   ...stackEnv,
   tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
   s3SourceBucket,
@@ -266,15 +258,19 @@ const provisioningCodeBuildProject =
 // awsRegion / awsAccountId は TenantTemplateStack のために前倒しで定義済み (上を参照)。
 
 if (adminConsoleApiUrl && adminConsoleCognitoDomain && adminConsoleUserClientId) {
-  const adminConsoleHosting = new AdminConsoleHostingStack(app, "AdminConsoleHostingStack", {
-    ...stackEnv,
-    apiUrl: adminConsoleApiUrl,
-    cognitoDomain: adminConsoleCognitoDomain,
-    userClientId: adminConsoleUserClientId,
-    pooledApplicationAdminConsoleUrl: pooledAppConsoleUrl,
-    provisioningCodeBuildProject,
-    awsRegion,
-    awsAccountId,
-  });
+  const adminConsoleHosting = new AdminConsoleHostingStack(
+    app,
+    "tenkacloud-admin-console-hosting",
+    {
+      ...stackEnv,
+      apiUrl: adminConsoleApiUrl,
+      cognitoDomain: adminConsoleCognitoDomain,
+      userClientId: adminConsoleUserClientId,
+      pooledApplicationAdminConsoleUrl: pooledAppConsoleUrl,
+      provisioningCodeBuildProject,
+      awsRegion,
+      awsAccountId,
+    },
+  );
   cdk.Aspects.of(adminConsoleHosting).add(new DestroyPolicySetter());
 }

--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -16,6 +16,8 @@ import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as stepfunctions from "aws-cdk-lib/aws-stepfunctions";
 import type { Construct } from "constructs";
 
+const DEPLOYMENT_STATE_MACHINE_NAME = "tenkacloud-saas-deployment-machine";
+
 export interface ServerlessSaaSPipelineInterface extends cdk.StackProps {
   tenantMappingTable: Table;
   s3SourceBucket: string;
@@ -251,7 +253,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
         TENANT_MAPPING_TABLE: props.tenantMappingTable.tableName,
         CODE_BUILD_PROJECT_NAME: codeBuildProject.projectName,
       },
-      stateMachineName: "tenkacloud-saas-deployment-machine",
+      stateMachineName: DEPLOYMENT_STATE_MACHINE_NAME,
       stateMachineType: "STANDARD",
       tracingConfiguration: {
         enabled: true,
@@ -269,7 +271,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
     const stateMachine = stepfunctions.StateMachine.fromStateMachineName(
       this,
       "DeploymentStateMachine",
-      "tenkacloud-saas-deployment-machine",
+      DEPLOYMENT_STATE_MACHINE_NAME,
     );
 
     const stepFunctionAction = new codepipeline_actions.StepFunctionInvokeAction({

--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -126,7 +126,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
 
     // Define CodePipeline.
     const pipeline = new codepipeline.Pipeline(this, "Pipeline", {
-      pipelineName: "serverless-saas-pipeline",
+      pipelineName: "tenkacloud-saas-pipeline",
       artifactBucket: artifactsBucket,
     });
 
@@ -251,7 +251,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
         TENANT_MAPPING_TABLE: props.tenantMappingTable.tableName,
         CODE_BUILD_PROJECT_NAME: codeBuildProject.projectName,
       },
-      stateMachineName: "serverless-saas-deployment-machine",
+      stateMachineName: "tenkacloud-saas-deployment-machine",
       stateMachineType: "STANDARD",
       tracingConfiguration: {
         enabled: true,
@@ -269,7 +269,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
     const stateMachine = stepfunctions.StateMachine.fromStateMachineName(
       this,
       "DeploymentStateMachine",
-      "serverless-saas-deployment-machine",
+      "tenkacloud-saas-deployment-machine",
     );
 
     const stepFunctionAction = new codepipeline_actions.StepFunctionInvokeAction({

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -73,7 +73,14 @@ fi
 # 非空 bucket が残ると stack 削除が DELETE_FAILED で連鎖するので先に空にする。
 # autoDeleteObjects 付きも保険で含める。
 log "emptying related buckets (including all versions / delete markers)..."
-bucket_patterns="^${SOURCE_BUCKET}$|^tenkacloud-saas-pipeline-artifactsbucket-|^tenkacloud-control-plane-staticsitedistrostaticsitedistr-|^tenkacloud-tenant-template-|^tenkacloud-admin-console-hosting-"
+bucket_prefix_patterns=(
+  "^${SOURCE_BUCKET}$"
+  "^tenkacloud-saas-pipeline-artifactsbucket-"
+  "^tenkacloud-control-plane-staticsitedistrostaticsitedistr-"
+  "^tenkacloud-tenant-template-"
+  "^tenkacloud-admin-console-hosting-"
+)
+bucket_patterns=$(IFS='|'; echo "${bucket_prefix_patterns[*]}")
 while IFS= read -r bucket; do
   empty_versioned_bucket "$bucket"
 done < <(aws s3 ls 2>/dev/null | awk '{print $3}' | grep -E "$bucket_patterns" || true)

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -53,7 +53,7 @@ fi
 
 export REGION="$(aws configure get region)"
 export ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-SOURCE_BUCKET="serverless-saas-${ACCOUNT_ID}-${REGION}"
+SOURCE_BUCKET="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
 
 # bin/infrastructure.ts が CDK_PARAM_* を要求し、fromBucketName は DNS 検証で短い値だと synth が落ちる。
 # shell に残る empty/"NA" 等の汚染が export を貫通した実害があったので unset → export の順で衛生化。
@@ -73,7 +73,7 @@ fi
 # 非空 bucket が残ると stack 削除が DELETE_FAILED で連鎖するので先に空にする。
 # autoDeleteObjects 付きも保険で含める。
 log "emptying related buckets (including all versions / delete markers)..."
-bucket_patterns="^${SOURCE_BUCKET}$|^serverlesssaaspipeline-artifactsbucket-|^controlplanestack-staticsitedistrostaticsitedistr-|^serverless-saas-ref-arch-serverlesssaasrefarchten-|^adminconsolehostingstack-"
+bucket_patterns="^${SOURCE_BUCKET}$|^tenkacloud-saas-pipeline-artifactsbucket-|^tenkacloud-control-plane-staticsitedistrostaticsitedistr-|^tenkacloud-tenant-template-|^tenkacloud-admin-console-hosting-"
 while IFS= read -r bucket; do
   empty_versioned_bucket "$bucket"
 done < <(aws s3 ls 2>/dev/null | awk '{print $3}' | grep -E "$bucket_patterns" || true)
@@ -83,17 +83,17 @@ done < <(aws s3 ls 2>/dev/null | awk '{print $3}' | grep -E "$bucket_patterns" |
 # 生成 Lambda は存在しない)。GameDay deploy pipeline で生成される CFn stack は
 # CFn 管理下なので cdk destroy --all で消える。
 
-# AdminConsoleHostingStack は bin/infrastructure.ts が CDK_PARAM_CONTROL_PLANE_* と
+# tenkacloud-admin-console-hosting は bin/infrastructure.ts が CDK_PARAM_CONTROL_PLANE_* と
 # apps/admin-console/dist/ を要求するため cdk destroy では synth が落ちる。CFN 直 delete で迂回。
-if aws cloudformation describe-stacks --stack-name AdminConsoleHostingStack >/dev/null 2>&1; then
-  log "deleting AdminConsoleHostingStack via CloudFormation..."
-  aws cloudformation delete-stack --stack-name AdminConsoleHostingStack
+if aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting >/dev/null 2>&1; then
+  log "deleting tenkacloud-admin-console-hosting via CloudFormation..."
+  aws cloudformation delete-stack --stack-name tenkacloud-admin-console-hosting
   # wait は timeout / DELETE_FAILED の両方で non-zero。どちらも後段の cdk destroy --all が
   # 再試行 + CFN エラーを surface するので、ここでは warn だけで先に進める。
-  aws cloudformation wait stack-delete-complete --stack-name AdminConsoleHostingStack \
+  aws cloudformation wait stack-delete-complete --stack-name tenkacloud-admin-console-hosting \
     || log "  stack-delete wait did not succeed; later steps will surface the cause"
 else
-  log "AdminConsoleHostingStack not found; skip"
+  log "tenkacloud-admin-console-hosting not found; skip"
 fi
 
 # 動的 tenant stack (pipeline 経由で provision された tenant 単位 stack) を先に destroy。
@@ -106,10 +106,10 @@ STACK_FILTER=(
 )
 tenant_stacks=$(aws cloudformation list-stacks \
   --stack-status-filter "${STACK_FILTER[@]}" \
-  --query "StackSummaries[?starts_with(StackName, 'serverless-saas-ref-arch-tenant-template-') && StackName != 'serverless-saas-ref-arch-tenant-template-pooled'].StackName" \
+  --query "StackSummaries[?starts_with(StackName, 'tenkacloud-tenant-template-') && StackName != 'tenkacloud-tenant-template-pooled'].StackName" \
   --output text)
 for stack_name in $tenant_stacks; do
-  tenant_id="${stack_name#serverless-saas-ref-arch-tenant-template-}"
+  tenant_id="${stack_name#tenkacloud-tenant-template-}"
   log "  destroying ${stack_name} (tenant_id=${tenant_id})"
   CDK_PARAM_TENANT_ID="$tenant_id" bunx cdk destroy "$stack_name" --force \
     || log "    skip (already gone or conflict)"

--- a/scripts/deprovision-tenant.sh
+++ b/scripts/deprovision-tenant.sh
@@ -18,7 +18,7 @@ export CDK_PARAM_TENANT_ID=$tenantId
 export TIER=$tier
 
 # Define variables
-STACK_NAME="serverless-saas-ref-arch-tenant-template-pooled"
+STACK_NAME="tenkacloud-tenant-template-pooled"
 USER_POOL_OUTPUT_PARAM_NAME="TenantUserpoolId"
 PRODUCT_TABLE_OUTPUT_PARAM_NAME="ProductTableName"
 ORDER_TABLE_OUTPUT_PARAM_NAME="OrderTableName"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ export REGION=$(aws configure get region)
 export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # --- Source bucket 準備 (ref 準拠) ---
-export CDK_PARAM_S3_BUCKET_NAME="serverless-saas-${ACCOUNT_ID}-${REGION}"
+export CDK_PARAM_S3_BUCKET_NAME="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
 echo "CDK_PARAM_S3_BUCKET_NAME: ${CDK_PARAM_S3_BUCKET_NAME}"
 export CDK_SOURCE_NAME="source.zip"
 
@@ -126,11 +126,11 @@ echo "=============================================="
 echo "Phase 1: Deploy backend stacks"
 echo "=============================================="
 bunx cdk deploy \
-  ControlPlaneStack \
-  serverless-saas-ref-arch-bootstrap-stack \
-  ProblemDeployBackendStack \
-  serverless-saas-ref-arch-tenant-template-pooled \
-  ServerlessSaaSPipeline \
+  tenkacloud-control-plane \
+  tenkacloud-bootstrap \
+  tenkacloud-problem-deploy \
+  tenkacloud-tenant-template-pooled \
+  tenkacloud-saas-pipeline \
   --require-approval never --concurrency 4
 
 # ============================================================================
@@ -144,9 +144,9 @@ echo ""
 echo "=============================================="
 echo "Phase 2: Build admin-console + deploy CloudFront"
 echo "=============================================="
-API_URL=$(aws cloudformation describe-stacks --stack-name ControlPlaneStack --query "Stacks[0].Outputs[?OutputKey=='controlPlaneAPIEndpoint'].OutputValue" --output text)
-USER_POOL_ID=$(aws cloudformation describe-stacks --stack-name ControlPlaneStack --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpUserPoolId')].OutputValue" --output text)
-CLIENT_ID=$(aws cloudformation describe-stacks --stack-name ControlPlaneStack --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpClientId')].OutputValue" --output text)
+API_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?OutputKey=='controlPlaneAPIEndpoint'].OutputValue" --output text)
+USER_POOL_ID=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpUserPoolId')].OutputValue" --output text)
+CLIENT_ID=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpClientId')].OutputValue" --output text)
 COGNITO_DOMAIN_PREFIX=$(aws cognito-idp describe-user-pool --user-pool-id "${USER_POOL_ID}" --query "UserPool.Domain" --output text)
 COGNITO_DOMAIN="https://${COGNITO_DOMAIN_PREFIX}.auth.${REGION}.amazoncognito.com"
 
@@ -167,7 +167,7 @@ echo "  → dist/ generated"
 # 出すため。silo platinum tenant は provision-tenant.sh が tenantConfig に書く)。
 # pooled stack は phase 1 で既に立っているので CFn output から取れる。
 POOLED_APP_CONSOLE_URL=$(aws cloudformation describe-stacks \
-  --stack-name "serverless-saas-ref-arch-tenant-template-pooled" \
+  --stack-name "tenkacloud-tenant-template-pooled" \
   --query "Stacks[0].Outputs[?OutputKey=='ApplicationAdminConsoleUrl'].OutputValue" \
   --output text)
 echo "  Pooled App URL: ${POOLED_APP_CONSOLE_URL}"
@@ -195,7 +195,7 @@ export CDK_PARAM_POOLED_APP_CONSOLE_URL="${POOLED_APP_CONSOLE_URL}"
 export CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT="${PROVISIONING_CODEBUILD_PROJECT}"
 export CDK_PARAM_AWS_REGION="${REGION}"
 export CDK_PARAM_AWS_ACCOUNT_ID="${ACCOUNT_ID}"
-bunx cdk deploy AdminConsoleHostingStack --require-approval never
+bunx cdk deploy tenkacloud-admin-console-hosting --require-approval never
 
 # ============================================================================
 # Phase 3: ControlPlaneStack 再 deploy — CloudFront URL を callback/CORS に足す
@@ -204,10 +204,10 @@ echo ""
 echo "=============================================="
 echo "Phase 3: Update ControlPlaneStack with admin-console CloudFront URL"
 echo "=============================================="
-ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name AdminConsoleHostingStack --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
+ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
 export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"
 echo "  CloudFront URL: ${ADMIN_CONSOLE_URL}"
-bunx cdk deploy ControlPlaneStack --require-approval never
+bunx cdk deploy tenkacloud-control-plane --require-approval never
 
 # ============================================================================
 # 完了
@@ -216,12 +216,12 @@ bunx cdk deploy ControlPlaneStack --require-approval never
 # tenant が共有する 1 console)。silo (PLATINUM) tenant の URL は admin-console の
 # テナント一覧から開けるので install.sh 側では出さない。
 POOLED_APP_CONSOLE_URL=$(aws cloudformation describe-stacks \
-  --stack-name "serverless-saas-ref-arch-tenant-template-pooled" \
+  --stack-name "tenkacloud-tenant-template-pooled" \
   --query "Stacks[0].Outputs[?OutputKey=='ApplicationAdminConsoleUrl'].OutputValue" \
   --output text 2>/dev/null || echo "(not deployed yet)")
 
 PARTICIPANT_PORTAL_URL=$(aws cloudformation describe-stacks \
-  --stack-name "ProblemDeployBackendStack" \
+  --stack-name "tenkacloud-problem-deploy" \
   --query "Stacks[0].Outputs[?OutputKey=='ParticipantPortalUrl'].OutputValue" \
   --output text 2>/dev/null || echo "(not deployed)")
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -202,7 +202,7 @@ bunx cdk deploy tenkacloud-admin-console-hosting --require-approval never
 # ============================================================================
 echo ""
 echo "=============================================="
-echo "Phase 3: Update ControlPlaneStack with admin-console CloudFront URL"
+echo "Phase 3: Update tenkacloud-control-plane with admin-console CloudFront URL"
 echo "=============================================="
 ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
 export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -19,7 +19,7 @@ export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 echo "ACCOUNT_ID: ${ACCOUNT_ID}"
 
 # Download serverless reference solution from S3 bucket.
-export CDK_PARAM_S3_BUCKET_NAME="serverless-saas-${ACCOUNT_ID}-${REGION}"
+export CDK_PARAM_S3_BUCKET_NAME="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
 echo "CDK_PARAM_S3_BUCKET_NAME: ${CDK_PARAM_S3_BUCKET_NAME}"
 export CDK_SOURCE_NAME="source.zip"
 
@@ -43,7 +43,7 @@ export TENANT_ADMIN_EMAIL=$email
 
 # Define variables
 TENANT_ADMIN_USERNAME="tenant-admin-$CDK_PARAM_TENANT_ID"
-STACK_NAME="serverless-saas-ref-arch-tenant-template-pooled"
+STACK_NAME="tenkacloud-tenant-template-pooled"
 USER_POOL_OUTPUT_PARAM_NAME="TenantUserpoolId"
 API_GATEWAY_URL_OUTPUT_PARAM_NAME="ApiGatewayUrl"
 APP_CLIENT_ID_OUTPUT_PARAM_NAME="UserPoolClientId"
@@ -51,7 +51,7 @@ APPLICATION_ADMIN_CONSOLE_URL_OUTPUT_PARAM_NAME="ApplicationAdminConsoleUrl"
 
 # Deploy the tenant template for platinum tier(silo)
 if [[ $TIER == "PLATINUM" ]]; then
-  STACK_NAME="serverless-saas-ref-arch-tenant-template-$CDK_PARAM_TENANT_ID"
+  STACK_NAME="tenkacloud-tenant-template-$CDK_PARAM_TENANT_ID"
   export CDK_PARAM_CONTROL_PLANE_SOURCE='sbt-control-plane-api'
   export CDK_PARAM_ONBOARDING_DETAIL_TYPE='Onboarding'
   export CDK_PARAM_PROVISIONING_DETAIL_TYPE=$CDK_PARAM_ONBOARDING_DETAIL_TYPE

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -15,7 +15,7 @@ export CDK_PARAM_TENANT_ID=$TENANT_ID
 export REGION=$AWS_REGION
 export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
-export CDK_PARAM_S3_BUCKET_NAME="serverless-saas-${ACCOUNT_ID}-${REGION}"
+export CDK_PARAM_S3_BUCKET_NAME="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
 echo "CDK_PARAM_S3_BUCKET_NAME: ${CDK_PARAM_S3_BUCKET_NAME}"
 export CDK_SOURCE_NAME="source.zip"
 


### PR DESCRIPTION
## Summary

同一 AWS account / region で **TenkaCloud + ProtoShip** を併存 deploy できるようにするため、固定名リソースに `tenkacloud-` prefix を付ける。両プロダクトとも SaaS Reference Architecture 派生で同じ stack id (`ControlPlaneStack`, `ServerlessSaaSPipeline`, `serverless-saas-ref-arch-bootstrap-stack` 等) を使っていたため衝突していた。

### Renames

| 種別 | 旧 | 新 |
| --- | --- | --- |
| CFn stack id | `ControlPlaneStack` | `tenkacloud-control-plane` |
| CFn stack id | `ProblemDeployBackendStack` | `tenkacloud-problem-deploy` |
| CFn stack id | `serverless-saas-ref-arch-bootstrap-stack` | `tenkacloud-bootstrap` |
| CFn stack id | `serverless-saas-ref-arch-tenant-template-<id>` | `tenkacloud-tenant-template-<id>` |
| CFn stack id | `ServerlessSaaSPipeline` | `tenkacloud-saas-pipeline` |
| CFn stack id | `AdminConsoleHostingStack` | `tenkacloud-admin-console-hosting` |
| Pipeline name | `serverless-saas-pipeline` | `tenkacloud-saas-pipeline` |
| State Machine name | `serverless-saas-deployment-machine` | `tenkacloud-saas-deployment-machine` |
| S3 source bucket | `serverless-saas-<acct>-<region>` | `tenkacloud-source-<acct>-<region>` |

TS class 名は変更しない (import / test に影響を与えないため)。CFn id (= 物理 stack 名) のみリネーム。

## Test plan

- [x] `make before-commit` 緑 (245 件全 pass / lint / build)
- [ ] `make deploy` を fresh AWS 環境で実行 → 3-phase 全部通る
- [ ] ProtoShip も同 account / region に deploy 済の状態で TenkaCloud を deploy → 衝突無し

## Regression 分析

- 既存 stack を destroy 済みの環境からの fresh deploy 前提 (ユーザー確認済 — 旧 stack は既に削除済)
- TS class 名 (`ControlPlaneStack` 等) は据え置き → import / test に影響なし
- `CDK_PARAM_S3_BUCKET_NAME` を変えるので install.sh と provision/update-tenant.sh で同じ bucket 名を生成する必要あり (両方更新済)
- cleanup.sh の bucket prefix pattern (`controlplanestack-staticsitedistro...` 等) も新 prefix で書き直し済
- Makefile の `deploy-control-plane` / `deploy-bootstrap` ターゲットも追従済

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| REPLACE | 全 CFn stack | 旧 stack 削除済み → 新 prefix で fresh create |
| REPLACE | source S3 bucket | 旧 bucket は cleanup 済 |
| NO-OP   | TS class / Lambda code / DDB schema / IAM | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)