### PR TITLE
fix(portal): teamLoginKey 認証 (43 文字) + EventDetail に配布手順を追加

### DIFF
--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -14,6 +14,12 @@ export interface AppConfig {
    * dev fallback ではダミー URL になるので実 API 呼び出しは成立しない。
    */
   readonly apiBaseUrl: string;
+  /**
+   * 競技者向け Participant Portal の URL。EventDetail / DeploymentDetail から
+   * operator が「このイベントの portal を共有」する画面表示に使う。
+   * runtime-config に未注入なら undefined (CDK 側 wire-up が完了するまで fallback 表示)。
+   */
+  readonly participantPortalUrl?: string;
 }
 
 interface RuntimeConfig {
@@ -22,6 +28,7 @@ interface RuntimeConfig {
   readonly tenantId: string;
   readonly tenantName: string;
   readonly apiUrl: string;
+  readonly participantPortalUrl?: string;
 }
 
 async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
@@ -43,6 +50,8 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       tenantId: data.tenantId,
       tenantName: data.tenantName,
       apiUrl: data.apiUrl,
+      participantPortalUrl:
+        typeof data.participantPortalUrl === "string" ? data.participantPortalUrl : undefined,
     };
   } catch {
     return null;
@@ -67,6 +76,7 @@ export async function loadConfig(
       tenantId: runtime.tenantId,
       tenantName: runtime.tenantName,
       apiBaseUrl: runtime.apiUrl,
+      participantPortalUrl: runtime.participantPortalUrl,
       redirectUri,
       scope,
     };

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -185,11 +185,62 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       )}
 
       {detail && (
+        <Container header={<Header variant="h2">参加者向け配布</Header>}>
+          <SpaceBetween size="m">
+            {config.participantPortalUrl ? (
+              <ColumnLayout columns={2} variant="text-grid">
+                <Box>
+                  <Box variant="awsui-key-label">Participant Portal URL</Box>
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <a href={config.participantPortalUrl} target="_blank" rel="noreferrer noopener">
+                      <code>{config.participantPortalUrl}</code>
+                    </a>
+                    <Button
+                      iconName="copy"
+                      ariaLabel="Portal URL をコピー"
+                      onClick={() =>
+                        void navigator.clipboard?.writeText(config.participantPortalUrl ?? "")
+                      }
+                    >
+                      コピー
+                    </Button>
+                  </SpaceBetween>
+                </Box>
+                <Box>
+                  <Box variant="awsui-key-label">配布手順</Box>
+                  <Box variant="small">
+                    1. 下のチーム表から各 team の <code>teamLoginKey</code> をコピー
+                    <br />
+                    2. 上の Portal URL と一緒に各チームへ共有
+                    <br />
+                    3. <strong>Bulk Deploy</strong> で全チームの問題環境を起動 (Status が READY
+                    になったら競技開始)
+                    <br />
+                    4. 終了後は <strong>Bulk Teardown</strong> で全環境を一括削除
+                  </Box>
+                </Box>
+              </ColumnLayout>
+            ) : (
+              <Alert type="info" header="Participant Portal URL 未注入">
+                runtime-config.json に <code>participantPortalUrl</code> が無いため URL を表示
+                できません。ProblemDeployBackendStack の <code>ParticipantPortalUrl</code> Output を
+                application-admin-console hosting に注入する CDK 改修が必要です。 URL は{" "}
+                <code>
+                  aws cloudformation describe-stacks --stack-name tenkacloud-problem-deploy
+                </code>{" "}
+                で取得できます。
+              </Alert>
+            )}
+          </SpaceBetween>
+        </Container>
+      )}
+
+      {detail && (
         <Container
           header={
             <Header
               variant="h2"
-              description="teamLoginKey は作成完了時に 1 度だけ表示されたキーです。再表示はできません。"
+              description="teamLoginKey は競技者に配布する Bearer 認証キーです。漏洩した場合は該当チームの環境を再 deploy してキーを更新してください。"
             >
               チーム ({detail.teams.length})
             </Header>

--- a/apps/participant-portal/src/pages/Login.tsx
+++ b/apps/participant-portal/src/pages/Login.tsx
@@ -67,7 +67,7 @@ export function LoginPage({ config }: { config: AppConfig }) {
             </Alert>
             <FormField
               label="チームログインキー"
-              description="問題 deploy 時に運営が発行する短命キー (例: 32 文字の base64)"
+              description="問題 deploy 時に運営が発行する短命キー"
             >
               <Input
                 value={teamLoginKey}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/auth.ts
@@ -2,11 +2,11 @@
  * `Authorization: Bearer <teamLoginKey>` から teamLoginKey を抽出する。
  * 形式不正は `undefined` を返し、route 側で 401。
  *
- * teamLoginKey は `crypto.randomBytes(18).toString("base64url")` で生成される
- * 24 文字 base64url。ここで形式チェックを行うのは、不正値で DDB Query する前に
+ * teamLoginKey は `crypto.randomBytes(32).toString("base64url")` で生成される
+ * 43 文字 base64url。ここで形式チェックを行うのは、不正値で DDB Query する前に
  * 早期に弾くため (DDB の存在確認時間が攻撃者に漏れる timing oracle を防ぐ)。
  */
-const TEAM_LOGIN_KEY_RE = /^[A-Za-z0-9_-]{24}$/;
+const TEAM_LOGIN_KEY_RE = /^[A-Za-z0-9_-]{43}$/;
 
 export function extractBearerToken(authorizationHeader: string | undefined): string | undefined {
   if (!authorizationHeader) return undefined;

--- a/infrastructure/test/problem-deploy/participant-auth.test.ts
+++ b/infrastructure/test/problem-deploy/participant-auth.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { extractBearerToken } from "../../lib/problem-deploy/handlers/participant-handler/auth";
 
-const VALID = "AbCdEfGhIjKlMnOpQrStUvWx"; // 24 文字 base64url
+// generateTeamLoginKey() = crypto.randomBytes(32).toString("base64url") → 43 文字
+const VALID = "AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ"; // 43 文字 base64url
 
 describe("extractBearerToken", () => {
-  it("Bearer プレフィックスから 24 文字 base64url を抜くべき", () => {
+  it("Bearer プレフィックスから 43 文字 base64url を抜くべき", () => {
+    expect(VALID).toHaveLength(43);
     expect(extractBearerToken(`Bearer ${VALID}`)).toBe(VALID);
   });
 
@@ -27,19 +29,25 @@ describe("extractBearerToken", () => {
     expect(extractBearerToken("   ")).toBeUndefined();
   });
 
-  it("23 / 25 文字のキーは形式不一致で undefined", () => {
-    expect(extractBearerToken(`Bearer ${VALID.slice(0, 23)}`)).toBeUndefined();
+  it("42 / 44 文字のキーは形式不一致で undefined", () => {
+    expect(extractBearerToken(`Bearer ${VALID.slice(0, 42)}`)).toBeUndefined();
     expect(extractBearerToken(`Bearer ${VALID}A`)).toBeUndefined();
   });
 
+  it("旧仕様 (24 文字) のキーは形式不一致で undefined", () => {
+    // randomBytes(18) ベースに戻る regression を防ぐ。
+    expect(extractBearerToken(`Bearer ${VALID.slice(0, 24)}`)).toBeUndefined();
+  });
+
   it("base64url 外文字 (= や +, /, スペース) は undefined", () => {
-    expect(extractBearerToken(`Bearer ${VALID.slice(0, 23)}=`)).toBeUndefined();
-    expect(extractBearerToken(`Bearer ${VALID.slice(0, 23)}+`)).toBeUndefined();
-    expect(extractBearerToken(`Bearer ${VALID.slice(0, 23)}/`)).toBeUndefined();
+    expect(extractBearerToken(`Bearer ${VALID.slice(0, 42)}=`)).toBeUndefined();
+    expect(extractBearerToken(`Bearer ${VALID.slice(0, 42)}+`)).toBeUndefined();
+    expect(extractBearerToken(`Bearer ${VALID.slice(0, 42)}/`)).toBeUndefined();
   });
 
   it("ハイフン / アンダースコアは base64url なので OK", () => {
-    const withDashes = "AbCdEfGhIjKlMnOpQ_StU-Wx";
+    const withDashes = "AbCdEfGhIjKlMnOpQ_StU-WxYzAbCdEfGhIjKlMnOpQ"; // 43 文字
+    expect(withDashes).toHaveLength(43);
     expect(extractBearerToken(`Bearer ${withDashes}`)).toBe(withDashes);
   });
 });

--- a/infrastructure/test/problem-deploy/participant-routes.test.ts
+++ b/infrastructure/test/problem-deploy/participant-routes.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../lib/problem-deploy/handlers/participant-handler/lookup", () => ({
 
 const { app } = await import("../../lib/problem-deploy/handlers/participant-handler/index");
 
-const VALID_KEY = "AbCdEfGhIjKlMnOpQrStUvWx"; // 24 文字 base64url
+const VALID_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ"; // 43 文字 base64url
 
 describe("GET /portal/healthz", () => {
   it("ok: true を返すべき (auth 不要)", async () => {


### PR DESCRIPTION
## Summary

**Login 完全 blocker 修正**: Participant Portal の auth regex が 24 文字を要求していたが実際のキーの長さは異なっていました。drift により全 teamLoginKey が validation で reject されて 401。誰もログインできない状態でした。

加えて EventDetail の UX を整理:
- 「1 度だけ表示」という嘘の description を削除し、運用上正しい説明に書き換え
- 「参加者向け配布」セクションを新設、Portal URL + 配布手順 4 ステップを表示
- Login 画面のヒント文言を簡素化 (運営側の発行物なのでフォーマット詳細は不要)