### PR TITLE
fix(deploy): Step Functions に MarkInProgress を追加 — PENDING 固定問題を解消

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -58,6 +58,21 @@ export class DeployCreateStateMachine extends Construct {
       retention: RetentionDays.ONE_WEEK,
     });
 
+    // PENDING (deploy.ts が初期 row を書く時の値) を IN_PROGRESS に倒す。CodeBuild の
+    // RUN_JOB は同期で 5〜15 分待つので、この中間遷移が無いと operator UI は polling
+    // しても PENDING のまま固定で「動いていない」ように見える (実際は deploy 進行中)。
+    const markInProgress = new DynamoUpdateItem(this, "MarkInProgress", {
+      table: props.deploymentsTable,
+      key: deploymentKey(),
+      updateExpression: "SET #status = :status, updatedAt = :updatedAt",
+      expressionAttributeNames: { "#status": "status" },
+      expressionAttributeValues: {
+        ":status": DynamoAttributeValue.fromString("IN_PROGRESS"),
+        ":updatedAt": stateEnteredTime(),
+      },
+      resultPath: JsonPath.DISCARD,
+    });
+
     const startCodeBuild = new CodeBuildStartBuild(this, "StartDeployCodeBuild", {
       project: props.codeBuildProject,
       integrationPattern: IntegrationPattern.RUN_JOB,
@@ -89,15 +104,17 @@ export class DeployCreateStateMachine extends Construct {
     const markSucceeded = this.buildMarkSucceeded(props.deploymentsTable);
     const markFailed = this.buildMarkFailed(props.deploymentsTable);
 
-    // CodeBuild 失敗 / DescribeStacks 失敗、いずれも MarkFailed (= status=FAILED) に倒す。
-    // DescribeStacks は基本失敗しないが、稀な throttle / 競技者 account 側の Roles で
+    // MarkInProgress / CodeBuild / DescribeStacks のいずれの失敗も MarkFailed (= status=FAILED)
+    // に倒す。MarkInProgress は DDB throttle くらいでしか落ちないが落とし穴を残さないため
+    // catch を付ける。DescribeStacks も稀な throttle / 競技者 account 側 Role の問題で
     // 落ちうる。その場合 stackOutputs 不在のまま FAILED にして operator が再試行する。
+    markInProgress.addCatch(markFailed, { resultPath: "$.error" });
     startCodeBuild.addCatch(markFailed, { resultPath: "$.error" });
     describeStacks.addCatch(markFailed, { resultPath: "$.error" });
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
       definitionBody: DefinitionBody.fromChainable(
-        startCodeBuild.next(describeStacks).next(markSucceeded),
+        markInProgress.next(startCodeBuild).next(describeStacks).next(markSucceeded),
       ),
       timeout: Duration.minutes(60),
       logs: { destination: logGroup, level: LogLevel.ALL },

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -97,6 +97,15 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       tpl.resourceCountIs("AWS::StepFunctions::StateMachine", 2);
     });
 
+    it("Create State Machine は CodeBuild 起動前に PENDING → IN_PROGRESS の中間遷移を書くべき", () => {
+      // RUN_JOB 同期 CodeBuild は 5〜15 分かかるため、この中間書込が無いと operator UI が
+      // PENDING のまま固定して polling が機能していないように見える (#159 の再発防止)。
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const synthJson = JSON.stringify(stateMachines);
+      expect(synthJson).toContain("MarkInProgress");
+      expect(synthJson).toContain("IN_PROGRESS");
+    });
+
     it("EventBridge Rule を Create / Delete でそれぞれ 1 つずつ持つべき", () => {
       tpl.resourceCountIs("AWS::Events::Rule", 2);
       tpl.hasResourceProperties(


### PR DESCRIPTION
## Summary

operator UI のジョブ詳細ページが「PENDING / 5 秒ごとに自動更新します」と表示しているのに、ステータスがいつまでも変わらない。CodeBuild ログを見ると実際は deploy が進行している (`Waiting for stack create/update to complete`)。

## 原因

`DeployCreateStateMachine` の chain は次の 3 ステップしかなく、`PENDING → IN_PROGRESS` の中間書込が欠けていた:

```
[StartCodeBuild (RUN_JOB 同期, 5〜15 分)] → [DescribeStacks] → [MarkSucceeded]
```

CodeBuild は `.sync` 統合でビルド完了まで状態が変わらないため、その間 DDB row の status は `deploy.ts` が初期書込した `PENDING` のまま固定。frontend polling は 5 秒ごとに正しく fire しているが、毎回同じデータを取るので画面が変化せず、operator は「polling が壊れている」と誤解する。

## 修正

State Machine の chain 先頭に `MarkInProgress` (DynamoUpdateItem) を挿入:

```
[MarkInProgress (status=IN_PROGRESS)] → [StartCodeBuild] → [DescribeStacks] → [MarkSucceeded]
```

これで POST /deployments 後 数秒で `PENDING → IN_PROGRESS` に切り替わり、UI で polling が機能していることが視認できるようになる。

`MarkInProgress` 自体が DDB throttle 等で落ちた場合も `markFailed` で受けるように `addCatch` を追加 (CodeBuild / DescribeStacks と同じ扱い)。

## Test plan

- [x] make before-commit 緑 (246 件全 pass / +1 件: MarkInProgress 存在 assertion)
- [ ] AWS 上で実 deploy → ジョブ詳細ページが数秒以内に PENDING → IN_PROGRESS に切り替わることを目視確認

## Regression 分析

- 既存の `MarkSucceeded` / `MarkFailed` の挙動は不変
- chain に状態が 1 つ増えるだけで、入力 event shape / 出力 DDB row 構造は変わらない
- `resultPath: JsonPath.DISCARD` で MarkInProgress の結果を破棄、後続の startCodeBuild が依存する `\$.detail.*` は保たれる

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | DeployCreateStateMachine の DefinitionString | state を 1 つ追加 |
| NO-OP  | DDB schema / IAM / Lambda code | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)