### PR TITLE
fix(events): EventDetail で競技者の displayTeamName を表示

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -87,9 +87,11 @@ export async function getEventDetail(
   eventId: string,
 ): Promise<EventDetail | undefined> {
   // Event Get と Teams Query は依存関係なし → 並列発火でラウンドトリップを 1 回分節約。
-  // 不正 eventId のとき teams query が無駄になるが、空 partition の query は 1 RCU 程度。
-  // teams.max(100) なので 1 query で確定。
-  const [eventOut, teamsOut] = await Promise.all([
+  // Event / Teams / Deployments を並列発火。Deployments は競技者が PATCH /portal/me で
+  // 設定した displayTeamName を引くため必要 (TeamsTable には participant が直接書け
+  // ないので displayName が常に空のままになる、という ADR-004 Phase 2c 統合ギャップ
+  // への補正)。GSI1 = TENANT#<tenantId> 全件取得 → eventId で in-memory filter。
+  const [eventOut, teamsOut, deploymentsOut] = await Promise.all([
     shared.ddb.send(
       new GetCommand({
         TableName: shared.eventsTableName,
@@ -106,18 +108,46 @@ export async function getEventDetail(
         },
       }),
     ),
+    shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
+        ProjectionExpression: "teamId, eventId, displayTeamName",
+      }),
+    ),
   ]);
   const event = eventOut.Item as Partial<EventItem> | undefined;
   if (!event) return undefined;
   if (event.tenantId !== tenantId) return undefined;
 
   const teamItems = (teamsOut.Items ?? []) as Partial<TeamItem>[];
-  const teams: TeamSummary[] = teamItems.map((t) => ({
-    teamId: String(t.teamId ?? ""),
-    internalSlug: String(t.internalSlug ?? ""),
-    displayName: typeof t.displayName === "string" ? t.displayName : undefined,
-    teamLoginKey: typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
-  }));
+
+  // teamId → displayTeamName の最新値 map を作る。同じ team の N 行のうち、operator
+  // 起動時には全て同じ値で埋まる (update.ts が Promise.all で全行を更新するため)。
+  // 念のため最後に拾った非空文字列を採用 (=「設定済」優先)。
+  const displayNameByTeamId = new Map<string, string>();
+  for (const d of deploymentsOut.Items ?? []) {
+    const row = d as { teamId?: unknown; eventId?: unknown; displayTeamName?: unknown };
+    if (row.eventId !== eventId) continue;
+    if (typeof row.teamId !== "string" || typeof row.displayTeamName !== "string") continue;
+    if (row.displayTeamName.length === 0) continue;
+    displayNameByTeamId.set(row.teamId, row.displayTeamName);
+  }
+
+  const teams: TeamSummary[] = teamItems.map((t) => {
+    const teamId = String(t.teamId ?? "");
+    const fromTeamsTable = typeof t.displayName === "string" ? t.displayName : undefined;
+    return {
+      teamId,
+      internalSlug: String(t.internalSlug ?? ""),
+      // 競技者が portal で設定した名前 (Deployments 経由) を優先、無ければ
+      // TeamsTable.displayName (operator 事前設定があれば)、それも無ければ undefined。
+      displayName: displayNameByTeamId.get(teamId) ?? fromTeamsTable,
+      teamLoginKey: typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
+    };
+  });
 
   const summary = toSummary(event);
   return {

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -11,7 +11,11 @@ function buildShared(): {
   const shared: EventSharedResources = {
     eventsTableName: "TestEvents",
     teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
     ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: { send: vi.fn() } as unknown as EventSharedResources["events"],
+    problemsCatalog: {},
   };
   return { shared, ddbSend };
 }
@@ -92,6 +96,9 @@ describe("getEventDetail", () => {
         { teamId: "T2", internalSlug: "team-beta", teamLoginKey: "key-2" },
       ],
     });
+    // Deployments query (3rd parallel call) — 競技者がまだ portal で名前を設定して
+    // いないので displayTeamName 行は無し。
+    ddbSend.mockResolvedValueOnce({ Items: [] });
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeDefined();
@@ -113,6 +120,57 @@ describe("getEventDetail", () => {
     expect(teamsQuery.input.KeyConditionExpression).toContain("begins_with(SK, :tprefix)");
     expect(teamsQuery.input.ExpressionAttributeValues?.[":pk"]).toBe("EVENT#EV1");
     expect(teamsQuery.input.ExpressionAttributeValues?.[":tprefix"]).toBe("TEAM#");
+    // 3 件目は QueryCommand (Deployments GSI1 = TENANT#)
+    const deploymentsQuery = ddbSend.mock.calls[2]?.[0] as QueryCommand;
+    expect(deploymentsQuery).toBeInstanceOf(QueryCommand);
+    expect(deploymentsQuery.input.IndexName).toBe("GSI1");
+    expect(deploymentsQuery.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+  });
+
+  it("競技者が portal で設定した displayTeamName を Deployments から merge するべき", async () => {
+    // ADR-004 Phase 2c 統合ギャップの再発防止。participant の PATCH /portal/me は
+    // DeploymentsTable のみ書き込む (TeamsTable には書けない) ため、operator 側 read で
+    // merge する必要がある。
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        name: "イベント A",
+        status: "DRAFT",
+        teamCount: 2,
+        problems: [],
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", internalSlug: "team-1", teamLoginKey: "key-1" },
+        { teamId: "T2", internalSlug: "team-2", teamLoginKey: "key-2" },
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        // T1 の 2 deployment 行 (両方とも sample111 で同期済み)
+        { teamId: "T1", eventId: "EV1", displayTeamName: "sample111" },
+        { teamId: "T1", eventId: "EV1", displayTeamName: "sample111" },
+        // T2 は competitor が未ログインで displayTeamName 無し
+        { teamId: "T2", eventId: "EV1" },
+        // 別 event (= filter で除外されるべき)
+        { teamId: "T1", eventId: "EV-OTHER", displayTeamName: "leak-from-other-event" },
+      ],
+    });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out?.teams).toHaveLength(2);
+    const t1 = out?.teams.find((t) => t.teamId === "T1");
+    const t2 = out?.teams.find((t) => t.teamId === "T2");
+    expect(t1?.displayName).toBe("sample111");
+    expect(t2?.displayName).toBeUndefined();
+    // 別 event の displayTeamName が混入しないこと
+    expect(JSON.stringify(out)).not.toContain("leak-from-other-event");
   });
 
   it("Event 行が無ければ undefined を返し teams 結果を漏らさないべき", async () => {
@@ -123,6 +181,7 @@ describe("getEventDetail", () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ teamId: "LEAKED", internalSlug: "leaked", teamLoginKey: "should-not-leak" }],
     });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeUndefined();
@@ -140,6 +199,7 @@ describe("getEventDetail", () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ teamId: "T1", internalSlug: "other-team", teamLoginKey: "other-key" }],
     });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeUndefined();


### PR DESCRIPTION
## Summary

競技者が Participant Portal で team 名 (例: \`sample111\`) を設定しても、operator の EventDetail で「(未設定)」のまま — 競技者の入力が operator UI に伝わらないバグ。Lambda コードのみで修正 (CDK / IAM 変更不要)。

## 原因

ADR-004 Phase 2c の統合ギャップ。Operator が EventDetail で読む \`TeamsTable.displayName\` には誰も書き込まないため、常に空。

| Phase | テーブル | displayName 書込み |
| --- | --- | --- |
| Phase 2a (Events 作成時) | TeamsTable | ❌ 書かれない |
| Phase 2c (Portal /portal/me PATCH) | DeploymentsTable | ✅ 書かれる |

→ operator は TeamsTable しか見ないので、競技者の入力が永久に届かない。

## 修正

\`getEventDetail\` を 2 並列 query (Event + Teams) → 3 並列 query に拡張し、Deployments の displayTeamName を merge する:

\`\`\`
Event (TeamsTable read)        ─┐
                                ├─> teams[i].displayName = deployments[teamId] ?? teams[i].displayName
Deployments (GSI1=TENANT# read) ─┘
\`\`\`

event-api Lambda は既に DeploymentsTable に \`grantReadWriteData\` 済 + env 注入済なので Lambda コード差分のみ。

## Test plan

- [x] make before-commit 緑 (248 件 / +1 件: displayTeamName merge / +1 件: 別 event 漏洩防止)
- [ ] AWS で実 deploy → 競技者が portal で名前変更 → operator EventDetail で即時反映を目視確認

## Regression 分析

- Portal 未ログイン team は displayName=undefined (既存挙動)
- 別 event の deployments は eventId filter で除外 (クロスイベント漏洩防止 test 追加済)
- Deployments は GSI1 TENANT# の全件取得後 in-memory filter — tenant の active deployment <100 程度なら問題なし。スケール時は GSI3=EVENT# 追加で最適化可能 (CDK 領域、別 PR)

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | event-api Lambda | getEventDetail の query +1 (Promise.all で並列発火) |
| NO-OP  | DDB schema / IAM / 他 Lambda / EventBridge / CDK | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)