### PR TITLE
fix(portal): TopNav の Score 表示を実データに繋ぐ

### DIFF
--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -1,0 +1,122 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  getPortalMe,
+  type ParticipantProblemView,
+  type ParticipantTeamView,
+  PortalAuthError,
+} from "../api/portal-client";
+import type { AppConfig } from "../config";
+import { useAuth } from "./AuthProvider";
+
+const POLL_INTERVAL_MS = 5_000;
+
+interface TeamViewState {
+  readonly view: ParticipantTeamView | null;
+  readonly error: string | null;
+  /** Home の flag 提出後に呼ばれて即時再フェッチする経路。 */
+  readonly refresh: () => Promise<void>;
+}
+
+const Ctx = createContext<TeamViewState>({
+  view: null,
+  error: null,
+  refresh: async () => {
+    /* default no-op */
+  },
+});
+
+export function useTeamView(): TeamViewState {
+  return useContext(Ctx);
+}
+
+/**
+ * Polling 結果が前回と意味的に同じなら true → setView を skip し React 再 render を抑制。
+ * Home / TopNav の両方が context 経由で再 render するため、no-op 検出は重要。
+ */
+function viewIsUnchanged(prev: ParticipantTeamView | null, next: ParticipantTeamView): boolean {
+  if (!prev) return false;
+  if (prev.team.teamName !== next.team.teamName) return false;
+  if (prev.problems.length !== next.problems.length) return false;
+  for (let i = 0; i < prev.problems.length; i++) {
+    const p = prev.problems[i] as ParticipantProblemView;
+    const n = next.problems[i] as ParticipantProblemView;
+    if (
+      p.jobId !== n.jobId ||
+      p.status !== n.status ||
+      p.score !== n.score ||
+      p.lastScoredAt !== n.lastScoredAt ||
+      p.lastResult !== n.lastResult ||
+      p.scoring?.flagSubmitted !== n.scoring?.flagSubmitted ||
+      p.failureReason !== n.failureReason ||
+      JSON.stringify(p.stackOutputs) !== JSON.stringify(n.stackOutputs)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Authenticated 領域 (`ShellLayout`) の中で 1 度だけ動く polling を提供する Context。
+ *
+ * Home page (累計スコアパネル + ProblemCard) と TopNav (Score / Rank widget) が同じ
+ * `/portal/me` レスポンスを共有することで、polling が 2 つに増えるのを防ぐ。
+ *
+ * `mode === "dev-mock"` のときは backend を叩かない。session が無いときも polling
+ * 起動しない (= /login や /setup の guarded 外で何もしない)。
+ *
+ * 全 problem が FAILED / DELETED に到達したら polling を停止する (`stopPollingRef`)。
+ * 既存の Home polling と同じ条件。
+ */
+export function TeamViewProvider({ config, children }: { config: AppConfig; children: ReactNode }) {
+  const auth = useAuth();
+  const sessionToken = auth.session?.sessionToken ?? null;
+  const isBackend = config.mode === "backend";
+  const [view, setView] = useState<ParticipantTeamView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const stopPollingRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!isBackend || !sessionToken) return;
+    try {
+      const next = await getPortalMe(config.apiBaseUrl, sessionToken);
+      setView((prev) => (viewIsUnchanged(prev, next) ? prev : next));
+      setError(null);
+      if (next.problems.every((p) => p.status === "FAILED" || p.status === "DELETED")) {
+        stopPollingRef.current = true;
+      }
+    } catch (err) {
+      if (err instanceof PortalAuthError) {
+        auth.logout();
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
+
+  useEffect(() => {
+    if (!isBackend || !sessionToken) return;
+    let cancelled = false;
+    stopPollingRef.current = false;
+    const tick = async () => {
+      if (cancelled || stopPollingRef.current) return;
+      await refresh();
+    };
+    void tick();
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isBackend, sessionToken, refresh]);
+
+  return <Ctx.Provider value={{ view, error, refresh }}>{children}</Ctx.Provider>;
+}

--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -10,12 +10,16 @@ import TopNavigation, {
 import { type ReactNode, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
+import { TeamViewProvider, useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
 
 /**
  * Participant Portal の shell。AWS GameDay の参考画面に倣って TopNavigation +
  * 3 セクション SideNavigation (Event / Quests / Tools) を組み立てる。
- * Score / Rank は scoring backend (別 PR) が繋がるまで placeholder 表示。
+ *
+ * Score は `TeamViewProvider` 経由で `/portal/me` polling 結果を共有 (Home の
+ * 累計スコアパネルと同じ source)。Rank は leaderboard 実装後 (#163 follow-up) に
+ * 有効化する — それまでは "—" 表示。
  */
 
 const SIDE_NAV_ITEMS: SideNavigationProps.Item[] = [
@@ -42,13 +46,28 @@ const SIDE_NAV_ITEMS: SideNavigationProps.Item[] = [
 ];
 
 export function ShellLayout({ config, children }: { config: AppConfig; children: ReactNode }) {
+  return (
+    <TeamViewProvider config={config}>
+      <ShellInner config={config}>{children}</ShellInner>
+    </TeamViewProvider>
+  );
+}
+
+function ShellInner({ config, children }: { config: AppConfig; children: ReactNode }) {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const teamView = useTeamView();
 
   const utilities = useMemo<TopNavigationProps.Utility[]>(() => {
     if (!auth.session) return [];
-    const score = "—";
+    // Score: backend mode のときだけ実値、未取得なら "…"、dev-mock なら "—"。
+    const totalScore = teamView.view
+      ? teamView.view.problems.reduce((sum, p) => sum + p.score, 0)
+      : null;
+    const score =
+      config.mode === "backend" ? (totalScore !== null ? `${totalScore} pt` : "…") : "—";
+    // Rank は leaderboard API 接続前なので placeholder 維持。
     const rank = "—";
     return [
       {
@@ -70,7 +89,7 @@ export function ShellLayout({ config, children }: { config: AppConfig; children:
         },
       },
     ];
-  }, [auth.session, auth.logout, navigate]);
+  }, [auth.session, auth.logout, navigate, teamView.view, config.mode]);
 
   return (
     <>

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -12,19 +12,18 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator, {
   type StatusIndicatorProps,
 } from "@cloudscape-design/components/status-indicator";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import {
   type DeploymentStatus,
-  getPortalMe,
   type ParticipantProblemView,
   type ParticipantTeamView,
-  PortalAuthError,
   PortalValidationError,
   type SubmitFlagOutcome,
   submitFlag,
   TERMINAL_STATUSES,
 } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
+import { useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
 import { describeAgo } from "../lib/format";
 
@@ -44,74 +43,12 @@ const SCORING_KIND_LABEL = {
   uptime: "Battle (uptime 加点)",
 } as const;
 
-/** Polling 結果が前回と意味的に同じなら true → setView を skip し React 再 render を抑制。 */
-function viewIsUnchanged(prev: ParticipantTeamView | null, next: ParticipantTeamView): boolean {
-  if (!prev) return false;
-  if (prev.team.teamName !== next.team.teamName) return false;
-  if (prev.problems.length !== next.problems.length) return false;
-  // problems は jobId で一致を取って意味的同一性を比較。順序は安定 (DDB Query 結果) と仮定。
-  for (let i = 0; i < prev.problems.length; i++) {
-    const p = prev.problems[i] as ParticipantProblemView;
-    const n = next.problems[i] as ParticipantProblemView;
-    if (
-      p.jobId !== n.jobId ||
-      p.status !== n.status ||
-      p.score !== n.score ||
-      p.lastScoredAt !== n.lastScoredAt ||
-      p.lastResult !== n.lastResult ||
-      p.scoring?.flagSubmitted !== n.scoring?.flagSubmitted ||
-      p.failureReason !== n.failureReason ||
-      JSON.stringify(p.stackOutputs) !== JSON.stringify(n.stackOutputs)
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const sessionToken = auth.session?.sessionToken ?? null;
   const isBackend = config.mode === "backend";
-
-  const [view, setView] = useState<ParticipantTeamView | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const stopPollingRef = useRef(false);
-
-  const tick = useCallback(async () => {
-    if (!isBackend || !sessionToken) return;
-    try {
-      const next = await getPortalMe(config.apiBaseUrl, sessionToken);
-      setView((prev) => (viewIsUnchanged(prev, next) ? prev : next));
-      setError(null);
-      // team 全 problem が terminal (FAILED / DELETED) なら polling 停止。
-      if (next.problems.every((p) => p.status === "FAILED" || p.status === "DELETED")) {
-        stopPollingRef.current = true;
-      }
-    } catch (err) {
-      if (err instanceof PortalAuthError) {
-        auth.logout();
-        return;
-      }
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
-
-  useEffect(() => {
-    if (!isBackend || !sessionToken) return;
-    let cancelled = false;
-    stopPollingRef.current = false;
-    const run = async () => {
-      if (cancelled || stopPollingRef.current) return;
-      await tick();
-    };
-    void run();
-    const interval = setInterval(run, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [isBackend, sessionToken, tick]);
+  // Polling は ShellLayout の TeamViewProvider で一括管理される (TopNav も同じデータを共有)。
+  const { view, error, refresh } = useTeamView();
 
   const teamName = view?.team.teamName ?? auth.session?.teamName ?? "(unknown)";
 
@@ -142,7 +79,7 @@ export function HomePage({ config }: { config: AppConfig }) {
           problem={problem}
           apiBaseUrl={config.apiBaseUrl}
           sessionToken={sessionToken ?? ""}
-          onScored={tick}
+          onScored={refresh}
         />
       ))}
 


### PR DESCRIPTION
## Summary

Participant Portal の TopNavigation 右上 widget が「Score: — / Rank: —」placeholder 固定。Home の累計スコアパネルが実値 (例: 3200 pt) を表示しているのに TopNav に反映されない。\`AppLayout.tsx:51-52\` で hardcoded \`"—"\` のまま、scoring backend (Phase 2c で完成) との接続が漏れていた。

## 修正

新規 \`auth/TeamViewProvider\` を導入し、Home / TopNav が \`/portal/me\` polling 結果を共有:

- \`ShellLayout\` 内で 5 秒 polling (既存 Home polling と同条件)
- \`useTeamView()\` hook で \`{ view, error, refresh }\` を context 共有
- TopNav: \`view.problems[].score\` 合計を表示
- Home page: 自前 polling 撤去 → \`useTeamView()\` に統一 (= polling 1 つに集約)

Rank は leaderboard API 接続前なので "—" 維持 (#163 follow-up)。

## Test plan

- [x] make before-commit 緑 (248 件全 pass)
- [ ] AWS で実 deploy → Portal にログイン → TopNav に \`X pt\` が表示されることを目視確認

## Regression 分析

- dev-mock モードでは backend を叩かず TopNav は "—" のまま (既存挙動を保つ)
- session 不在時は polling 起動しない (= /login や /setup で動かない、起動コスト 0)
- 全 problem terminal で polling 停止 (Home と同じ条件)
- 同一性チェック (\`viewIsUnchanged\`) を共通化、no-op 再 render を抑制

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | participant-portal SPA | TopNav score + Home polling 共通化 |
| NO-OP  | Lambda / DDB / IAM / CDK | 不変 |

## 残 TODO

- **Rank 表示**: leaderboard API (\`GET /portal/leaderboard\`) 実装後に有効化 (#163 next)
- **status DRAFT 固定**: 別 PR で Event lifecycle (status transition + 開始日時 schedule) を実装予定 — 現状 Bulk Deploy しても DRAFT のまま、scoring も即座開始してしまう

🤖 Generated with [Claude Code](https://claude.com/claude-code)