### PR TITLE
feat(events): 競技開始時刻 schedule + 採点 gate (status / 誤加算 / コスト 3 件まとめて修正)

### DIFF
--- a/apps/application-admin-console/src/api/client.ts
+++ b/apps/application-admin-console/src/api/client.ts
@@ -10,6 +10,7 @@ import type { AppConfig } from "../config";
 export interface ApiClient {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body: unknown): Promise<T>;
+  patch<T>(path: string, body: unknown): Promise<T>;
   del(path: string): Promise<void>;
   /** 削除系で JSON body を返す経路 (例: bulk teardown の集計結果)。 */
   delJson<T>(path: string): Promise<T>;
@@ -42,6 +43,11 @@ export function createApiClient(baseUrl: string, idToken: string): ApiClient {
     async post<T>(path: string, body: unknown): Promise<T> {
       return (
         await request(path, { method: "POST", body: JSON.stringify(body) })
+      ).json() as Promise<T>;
+    },
+    async patch<T>(path: string, body: unknown): Promise<T> {
+      return (
+        await request(path, { method: "PATCH", body: JSON.stringify(body) })
       ).json() as Promise<T>;
     },
     async del(path: string): Promise<void> {

--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -19,6 +19,8 @@ export interface EventSummary {
   createdAt: string;
   updatedAt: string;
   expiresAt: number;
+  /** 競技開始時刻 (ISO8601, UTC)。未設定なら HealthCheck は採点しない (= deploy 直後の誤加算防止)。 */
+  startsAt?: string;
 }
 
 export interface EventListResponse {
@@ -96,4 +98,21 @@ export async function bulkDeployEvent(api: ApiClient, eventId: string): Promise<
 
 export async function bulkTeardownEvent(api: ApiClient, eventId: string): Promise<BulkResult> {
   return api.delJson<BulkResult>(`events/${encodeURIComponent(eventId)}`);
+}
+
+export interface SetScheduleResult {
+  startsAt: string;
+  updatedDeployments: number;
+}
+
+/**
+ * 競技開始時刻を設定する。`{ startsAt }` で日時指定、`{ startNow: true }` で server now 採用。
+ * Event + 紐づく全 deployment 行に伝播する (eventStartsAt の denormalize)。
+ */
+export async function setEventSchedule(
+  api: ApiClient,
+  eventId: string,
+  body: { startsAt: string } | { startNow: true },
+): Promise<SetScheduleResult> {
+  return api.patch<SetScheduleResult>(`events/${encodeURIComponent(eventId)}/schedule`, body);
 }

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -4,11 +4,14 @@ import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
+import DatePicker from "@cloudscape-design/components/date-picker";
+import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
+import TimeInput from "@cloudscape-design/components/time-input";
 import { useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useApiClient } from "../api/client";
@@ -20,6 +23,7 @@ import {
   type EventDetail,
   type EventStatus,
   getEvent,
+  setEventSchedule,
 } from "../api/events-client";
 import type { AppConfig } from "../config";
 
@@ -40,6 +44,10 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [bulkResult, setBulkResult] = useState<BulkResult | null>(null);
   const [bulkInFlight, setBulkInFlight] = useState<"deploy" | "teardown" | null>(null);
   const [confirmTeardown, setConfirmTeardown] = useState(false);
+  const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
+  const [scheduleDate, setScheduleDate] = useState("");
+  const [scheduleTime, setScheduleTime] = useState("");
+  const [scheduleInFlight, setScheduleInFlight] = useState<"now" | "scheduled" | null>(null);
 
   const eventIdValid = !!eventId && EVENT_ID_RE.test(eventId);
 
@@ -90,6 +98,47 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBulkInFlight(null);
+    }
+  };
+
+  const handleStartNow = async () => {
+    if (!apiClient || scheduleInFlight) return;
+    setScheduleInFlight("now");
+    setError(null);
+    try {
+      await setEventSchedule(apiClient, eventId, { startNow: true });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setScheduleInFlight(null);
+    }
+  };
+
+  const handleScheduledStart = async () => {
+    if (!apiClient || scheduleInFlight) return;
+    if (!scheduleDate || !scheduleTime) {
+      setError("日付と時刻の両方を指定してください");
+      return;
+    }
+    // DatePicker は YYYY-MM-DD、TimeInput は HH:mm。秒は :00 固定で組む (operator UX が分精度想定)。
+    const local = new Date(`${scheduleDate}T${scheduleTime}:00`);
+    if (Number.isNaN(local.getTime())) {
+      setError("日時の形式が不正です");
+      return;
+    }
+    setScheduleInFlight("scheduled");
+    setError(null);
+    try {
+      await setEventSchedule(apiClient, eventId, { startsAt: local.toISOString() });
+      setScheduleModalOpen(false);
+      setScheduleDate("");
+      setScheduleTime("");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setScheduleInFlight(null);
     }
   };
 
@@ -156,6 +205,58 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             <Field label="チーム数">{detail.teamCount}</Field>
             <Field label="問題数">{detail.problems.length}</Field>
             <Field label="作成">{detail.createdAt}</Field>
+          </ColumnLayout>
+        </Container>
+      )}
+
+      {detail && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="競技開始時刻を指定するまで Health Check は probe / 採点を skip します (deploy 直後の誤加算を防ぎ、Lambda 呼出 / outbound 通信コストも抑制)。"
+              actions={
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button
+                    onClick={() => setScheduleModalOpen(true)}
+                    disabled={!apiClient || scheduleInFlight !== null}
+                  >
+                    日時を指定して開始
+                  </Button>
+                  <Button
+                    variant="primary"
+                    loading={scheduleInFlight === "now"}
+                    disabled={!apiClient || scheduleInFlight === "scheduled"}
+                    onClick={handleStartNow}
+                  >
+                    即座に開始
+                  </Button>
+                </SpaceBetween>
+              }
+            >
+              競技スケジュール
+            </Header>
+          }
+        >
+          <ColumnLayout columns={2} variant="text-grid">
+            <Field label="開始時刻 (UTC)">
+              {detail.startsAt ? (
+                <code>{detail.startsAt}</code>
+              ) : (
+                <Box variant="small" color="text-status-inactive">
+                  未設定 (採点停止中)
+                </Box>
+              )}
+            </Field>
+            <Field label="採点ステータス">
+              {!detail.startsAt ? (
+                <Badge color="grey">未開始</Badge>
+              ) : new Date(detail.startsAt).getTime() > Date.now() ? (
+                <Badge color="blue">開始予定</Badge>
+              ) : (
+                <Badge color="green">採点中</Badge>
+              )}
+            </Field>
           </ColumnLayout>
         </Container>
       )}
@@ -305,6 +406,49 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             既に DELETING / DELETED な行は idempotent で skip されます。Phase 3+ で
             「失敗した行のみ再試行」を追加予定です。
           </Box>
+        </SpaceBetween>
+      </Modal>
+
+      <Modal
+        visible={scheduleModalOpen}
+        onDismiss={() => setScheduleModalOpen(false)}
+        header="競技開始日時を指定"
+        size="medium"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setScheduleModalOpen(false)}>キャンセル</Button>
+              <Button
+                variant="primary"
+                loading={scheduleInFlight === "scheduled"}
+                onClick={handleScheduledStart}
+              >
+                設定
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            指定時刻を超えると HealthCheck が採点を開始します。ブラウザのローカル時刻で入力した値を
+            UTC に変換して保存します (分精度)。
+          </Box>
+          <FormField label="日付 (YYYY-MM-DD)">
+            <DatePicker
+              value={scheduleDate}
+              onChange={(e) => setScheduleDate(e.detail.value)}
+              placeholder="YYYY/MM/DD"
+            />
+          </FormField>
+          <FormField label="時刻 (HH:mm)">
+            <TimeInput
+              value={scheduleTime}
+              format="hh:mm"
+              placeholder="hh:mm"
+              onChange={(e) => setScheduleTime(e.detail.value)}
+            />
+          </FormField>
         </SpaceBetween>
       </Modal>
     </SpaceBetween>

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -248,15 +248,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                 </Box>
               )}
             </Field>
-            <Field label="採点ステータス">
-              {!detail.startsAt ? (
-                <Badge color="grey">未開始</Badge>
-              ) : new Date(detail.startsAt).getTime() > Date.now() ? (
-                <Badge color="blue">開始予定</Badge>
-              ) : (
-                <Badge color="green">採点中</Badge>
-              )}
-            </Field>
+            <Field label="採点ステータス">{scoringBadge(detail.startsAt)}</Field>
           </ColumnLayout>
         </Container>
       )}
@@ -453,6 +445,16 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       </Modal>
     </SpaceBetween>
   );
+}
+
+/**
+ * Event の採点状況バッジ。3 分岐: 未設定 / 開始予定 / 採点中。
+ * 時刻判定は新しいレンダ時の `Date.now()` を使うので polling refresh で自然に更新される。
+ */
+function scoringBadge(startsAt: string | undefined) {
+  if (!startsAt) return <Badge color="grey">未開始</Badge>;
+  if (new Date(startsAt).getTime() > Date.now()) return <Badge color="blue">開始予定</Badge>;
+  return <Badge color="green">採点中</Badge>;
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -11,7 +11,7 @@ import {
 
 interface CapturedCall {
   path: string;
-  method: "GET" | "POST" | "DELETE";
+  method: "GET" | "POST" | "PATCH" | "DELETE";
   body?: unknown;
 }
 
@@ -24,6 +24,10 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
     }),
     post: vi.fn().mockImplementation((path: string, body: unknown) => {
       calls.push({ path, method: "POST", body });
+      return Promise.resolve(response);
+    }),
+    patch: vi.fn().mockImplementation((path: string, body: unknown) => {
+      calls.push({ path, method: "PATCH", body });
       return Promise.resolve(response);
     }),
     del: vi.fn().mockImplementation((path: string) => {

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -11,7 +11,7 @@ import {
 
 interface CapturedCall {
   path: string;
-  method: "GET" | "POST" | "DELETE";
+  method: "GET" | "POST" | "PATCH" | "DELETE";
   body?: unknown;
 }
 
@@ -24,6 +24,10 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
     }),
     post: vi.fn().mockImplementation((path: string, body: unknown) => {
       calls.push({ path, method: "POST", body });
+      return Promise.resolve(response);
+    }),
+    patch: vi.fn().mockImplementation((path: string, body: unknown) => {
+      calls.push({ path, method: "PATCH", body });
       return Promise.resolve(response);
     }),
     del: vi.fn().mockImplementation((path: string) => {

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -94,6 +94,14 @@ export interface DeploymentItem {
   eventId?: string;
   teamId?: string;
 
+  /**
+   * 競技開始時刻 (ISO8601) を Event から denormalize したコピー。HealthCheckLambda が
+   * probe / 採点 gate で参照する (now < eventStartsAt なら skip)。Bulk Deploy 時に
+   * Event.startsAt をコピーし、operator が schedule API で更新したら全 deployment 行へ
+   * 伝播する (event-handler/schedule.ts)。未設定 → 採点無し (= deploy 直後の誤加算防止)。
+   */
+  eventStartsAt?: string;
+
   /** Scoring engine が加算したチームの累計ポイント。0 default。 */
   score?: number;
   /** 最後に scoring が走った時刻 (ISO 8601)。 */

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -1,6 +1,6 @@
 import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
-import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import type { DeploymentStatus } from "../deploy-handler/types.js";
 import {
   type DeployDeleteRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -1,12 +1,12 @@
 import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
-import { GetCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
 import {
   type DeployDeleteRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
   EVENT_SOURCE,
 } from "../shared/events.js";
-import type { EventSharedResources } from "./shared.js";
+import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js";
 import type { EventItem } from "./types.js";
 
 export interface BulkTeardownResult {
@@ -51,19 +51,7 @@ export async function bulkTeardownEvent(
   const event = eventOut.Item as Partial<EventItem> | undefined;
   if (!event || event.tenantId !== tenantId) return { kind: "not_found" };
 
-  // Phase 3+ で eventId 専用 GSI に切り替えれば 1 query で済むが、Phase 2a は
-  // tenant 全体を取って in-memory フィルタする。750 行規模で 1 query / 750 RCU。
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.deploymentsTableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
-    }),
-  );
-  const targets = ((out.Items ?? []) as Partial<DeploymentItem>[]).filter(
-    (i) => i.eventId === eventId,
-  );
+  const targets = await queryDeploymentsByEvent(shared, tenantId, eventId);
   if (targets.length === 0) {
     return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
   }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -178,13 +178,14 @@ export async function bulkDeployEvent(
     const chunk = entries.slice(i, i + PUT_EVENTS_BATCH);
     putChunks.push(shared.events.send(new PutEventsCommand({ Entries: chunk })));
   }
-  await Promise.all(putChunks);
 
   // Event status を DRAFT → DEPLOYING に倒す。operator が EventDetail の status badge で
   // 「Bulk Deploy が走っている」ことを視認できるようにするため。
-  // ConditionExpression で他 status (TEARDOWN 等) を踏み越えない安全弁。
-  try {
-    await shared.ddb.send(
+  // ConditionExpression で他 status (TEARDOWN 等) を踏み越えない安全弁。CCF は
+  // 既に TEARDOWN/ARCHIVED 等の終端状態 → 触らないだけで成功扱い。
+  // PutEvents と並列実行 (互いに依存なし、書き込み先が別 service なのでラウンドトリップ節約)。
+  const updateStatus = shared.ddb
+    .send(
       new UpdateCommand({
         TableName: shared.eventsTableName,
         Key: { PK: `EVENT#${eventId}`, SK: "META" },
@@ -198,13 +199,13 @@ export async function bulkDeployEvent(
           ":now": createdAt,
         },
       }),
-    );
-  } catch (err) {
-    // ConditionalCheckFailedException = 既に TEARDOWN/ARCHIVED 等の終端状態 → 触らない。
-    if (err instanceof Error && err.name !== "ConditionalCheckFailedException") {
-      throw err;
-    }
-  }
+    )
+    .catch((err: unknown) => {
+      if (err instanceof Error && err.name !== "ConditionalCheckFailedException") {
+        throw err;
+      }
+    });
+  await Promise.all([...putChunks, updateStatus]);
 
   return { kind: "ok", result: { eventId, enqueued: items.length, skipped } };
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -4,6 +4,7 @@ import {
   QueryCommand,
   TransactWriteCommand,
   type TransactWriteCommandInput,
+  UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { buildStackPrefix, slugify } from "../deploy-handler/naming.js";
@@ -83,6 +84,9 @@ export async function bulkDeployEvent(
 
   const createdAt = new Date(nowMs).toISOString();
   const expiresAt = toEpochSeconds(nowMs + DEFAULT_TTL_MS);
+  // Event.startsAt が未設定 = 競技開始時刻が決まっていないので採点開始しない gate に倒す。
+  // operator は EventDetail の「日時を設定」or「即座に開始」で後から有効化できる。
+  const eventStartsAt = typeof event.startsAt === "string" ? event.startsAt : undefined;
 
   // teams × problems を全展開し、deployment 行 + publish entry を組み立てる。
   // shared.problemsCatalog (problemId → problemDir) に存在しない problemId は skip。
@@ -120,6 +124,7 @@ export async function bulkDeployEvent(
         expiresAt,
         eventId,
         teamId: team.teamId,
+        eventStartsAt,
       };
       items.push(item);
 
@@ -174,6 +179,32 @@ export async function bulkDeployEvent(
     putChunks.push(shared.events.send(new PutEventsCommand({ Entries: chunk })));
   }
   await Promise.all(putChunks);
+
+  // Event status を DRAFT → DEPLOYING に倒す。operator が EventDetail の status badge で
+  // 「Bulk Deploy が走っている」ことを視認できるようにするため。
+  // ConditionExpression で他 status (TEARDOWN 等) を踏み越えない安全弁。
+  try {
+    await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression: "SET #status = :deploying, updatedAt = :now",
+        ConditionExpression: "#status = :draft OR #status = :ready OR #status = :deploying",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":deploying": "DEPLOYING",
+          ":draft": "DRAFT",
+          ":ready": "READY",
+          ":now": createdAt,
+        },
+      }),
+    );
+  } catch (err) {
+    // ConditionalCheckFailedException = 既に TEARDOWN/ARCHIVED 等の終端状態 → 触らない。
+    if (err instanceof Error && err.name !== "ConditionalCheckFailedException") {
+      throw err;
+    }
+  }
 
   return { kind: "ok", result: { eventId, enqueued: items.length, skipped } };
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -16,8 +16,9 @@ import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
 import { getEventDetail, listEvents } from "./list.js";
+import { setEventSchedule } from "./schedule.js";
 import { buildEventSharedResources } from "./shared.js";
-import { CreateEventRequestSchema } from "./types.js";
+import { CreateEventRequestSchema, ScheduleEventRequestSchema } from "./types.js";
 
 /**
  * Event API Lambda の Hono app (ADR-004 Phase 1+2a)。routes:
@@ -49,7 +50,7 @@ app.use(
   cors({
     origin: "*",
     allowHeaders: ["Authorization", "Content-Type"],
-    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     maxAge: 600,
   }),
 );
@@ -118,6 +119,38 @@ app.get("/events/:eventId", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] getEventDetail failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.patch("/events/:eventId/schedule", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "request body must be JSON" }, HTTP_BAD_REQUEST);
+  }
+  const parsed = ScheduleEventRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "validation failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
+  }
+  const nowMs = Date.now();
+  // `startNow: true` は server now を ISO8601 化して採用 (= 即座に開始ボタンの裏挙動)。
+  const startsAt = "startNow" in parsed.data ? new Date(nowMs).toISOString() : parsed.data.startsAt;
+  try {
+    const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, startsAt, nowMs);
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    return c.json(
+      { startsAt: outcome.startsAt, updatedDeployments: outcome.updatedDeployments },
+      HTTP_OK,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] setEventSchedule failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -43,6 +43,7 @@ function toSummary(item: Partial<EventItem>): EventSummary {
     createdAt: String(item.createdAt ?? ""),
     updatedAt: String(item.updatedAt ?? ""),
     expiresAt: Number(item.expiresAt ?? 0),
+    startsAt: typeof item.startsAt === "string" ? item.startsAt : undefined,
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
@@ -1,0 +1,93 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import type { EventSharedResources } from "./shared.js";
+import type { EventItem } from "./types.js";
+
+/**
+ * `setEventSchedule` の結果。
+ * - `not_found`: tenant 不一致 / event 不在 → 404 相当
+ * - `ok`: 更新後の startsAt + 影響を受けた deployment 数を返す
+ */
+export type SetEventScheduleOutcome =
+  | { kind: "not_found" }
+  | { kind: "ok"; startsAt: string; updatedDeployments: number };
+
+/**
+ * Event の `startsAt` を更新し、紐づく全 deployment 行に `eventStartsAt` を denormalize する。
+ *
+ * HealthCheckLambda は deployment 行の `eventStartsAt` を見て probe / 採点 gate するため、
+ * Event 単独更新では足りない (event-handler Lambda は Deployments table に R/W 権限を持つので
+ * CDK 改修不要)。
+ *
+ * `startsAt` は ISO8601 文字列。caller 側 (handler/index.ts) で zod validate 済を前提とする。
+ *
+ * tenant 跨ぎ参照防止: Event 行の tenantId が引数 `tenantId` と一致しない場合は `not_found`。
+ */
+export async function setEventSchedule(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  startsAt: string,
+  nowMs: number,
+): Promise<SetEventScheduleOutcome> {
+  // Event の存在 + tenantId 確認のため UpdateItem の ConditionExpression で防御。
+  // 同時に Deployments の対象行 (eventId 一致) を Query で集める。
+  const now = new Date(nowMs).toISOString();
+
+  let updatedEvent: Partial<EventItem> | undefined;
+  try {
+    const updateOut = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression: "SET startsAt = :startsAt, updatedAt = :now",
+        ConditionExpression: "tenantId = :tenantId",
+        ExpressionAttributeValues: {
+          ":startsAt": startsAt,
+          ":now": now,
+          ":tenantId": tenantId,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    updatedEvent = updateOut.Attributes as Partial<EventItem> | undefined;
+  } catch (err) {
+    // ConditionalCheckFailedException = 行不在 or tenant 不一致 → not_found
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      return { kind: "not_found" };
+    }
+    throw err;
+  }
+  if (!updatedEvent) return { kind: "not_found" };
+
+  // 紐づく deployment 行を全部引いて eventStartsAt を伝播。GSI1 (TENANT#) で全件取得し
+  // eventId フィルタ — 同 tenant 内 deployment <100 程度の運用想定で in-memory 処理可。
+  const deploymentsOut = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.deploymentsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
+      ProjectionExpression: "PK, eventId",
+    }),
+  );
+  const targets = (deploymentsOut.Items ?? [])
+    .map((d) => d as Pick<DeploymentItem, "PK" | "eventId">)
+    .filter((d) => d.eventId === eventId && typeof d.PK === "string");
+
+  // Promise.all で並列 update。各 row は冪等な単一フィールド update (UpdateExpression)。
+  await Promise.all(
+    targets.map((d) =>
+      shared.ddb.send(
+        new UpdateCommand({
+          TableName: shared.deploymentsTableName,
+          Key: { PK: d.PK, SK: "META" },
+          UpdateExpression: "SET eventStartsAt = :s, updatedAt = :now",
+          ExpressionAttributeValues: { ":s": startsAt, ":now": now },
+        }),
+      ),
+    ),
+  );
+
+  return { kind: "ok", startsAt, updatedDeployments: targets.length };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
@@ -1,6 +1,6 @@
-import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem } from "../deploy-handler/types.js";
-import type { EventSharedResources } from "./shared.js";
+import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js";
 import type { EventItem } from "./types.js";
 
 /**
@@ -60,20 +60,11 @@ export async function setEventSchedule(
   }
   if (!updatedEvent) return { kind: "not_found" };
 
-  // 紐づく deployment 行を全部引いて eventStartsAt を伝播。GSI1 (TENANT#) で全件取得し
-  // eventId フィルタ — 同 tenant 内 deployment <100 程度の運用想定で in-memory 処理可。
-  const deploymentsOut = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.deploymentsTableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
-      ProjectionExpression: "PK, eventId",
-    }),
-  );
-  const targets = (deploymentsOut.Items ?? [])
-    .map((d) => d as Pick<DeploymentItem, "PK" | "eventId">)
-    .filter((d) => d.eventId === eventId && typeof d.PK === "string");
+  // 紐づく deployment 行を全部引いて eventStartsAt を伝播 (PK だけあれば update 可)。
+  const deploymentsOut = await queryDeploymentsByEvent(shared, tenantId, eventId, "PK");
+  const targets = deploymentsOut
+    .map((d) => d as Pick<DeploymentItem, "PK">)
+    .filter((d) => typeof d.PK === "string");
 
   // Promise.all で並列 update。各 row は冪等な単一フィールド update (UpdateExpression)。
   await Promise.all(

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -1,7 +1,8 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import type { DeploymentItem } from "../deploy-handler/types.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
 
 /**
@@ -33,4 +34,37 @@ export function buildEventSharedResources(): EventSharedResources {
     events: new EventBridgeClient({}),
     problemsCatalog: parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG),
   };
+}
+
+/**
+ * Deployments table から指定 event の全行を取得する共通 helper。
+ *
+ * 内部的に GSI1 (TENANT#<tenantId>) を query し、`FilterExpression` で eventId 一致だけ
+ * を返す。Filter は post-read のため RCU は変わらないが、ネットワーク転送 + Lambda 内
+ * 処理量は削減できる (= ~750 行規模で意味のある差)。
+ *
+ * Phase 3+ で eventId 専用 GSI に切り替えれば 1 query で済むが、現状は単一 tenant 内
+ * 全 deployment が <100 程度の運用想定で十分。Phase 2a の bulk-delete から、Phase 2c
+ * 経由の schedule (eventStartsAt 伝播) まで同じ query が必要なので 1 箇所に集約。
+ */
+export async function queryDeploymentsByEvent(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  projectionExpression?: string,
+): Promise<Partial<DeploymentItem>[]> {
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.deploymentsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      FilterExpression: "eventId = :ev",
+      ExpressionAttributeValues: {
+        ":pk": `TENANT#${tenantId}`,
+        ":ev": eventId,
+      },
+      ...(projectionExpression ? { ProjectionExpression: projectionExpression } : {}),
+    }),
+  );
+  return (out.Items ?? []) as Partial<DeploymentItem>[];
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -21,6 +21,12 @@ export interface EventItem {
   createdAt: string;
   updatedAt: string;
   expiresAt: number;
+  /**
+   * 競技開始時刻 (ISO8601, UTC)。これより前は HealthCheckLambda が probe / 採点を skip。
+   * 未設定なら採点は始まらない (= deploy 直後に勝手にスコアが加算されるのを防ぐ)。
+   * 値は分精度想定 (operator UI が DatePicker + TimeInput で入力)。
+   */
+  startsAt?: string;
 }
 
 export const EventStatusSchema = z.enum(["DRAFT", "DEPLOYING", "READY", "TEARDOWN", "ARCHIVED"]);
@@ -122,8 +128,20 @@ export const EventSummarySchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   expiresAt: z.number(),
+  startsAt: z.string().optional(),
 });
 export type EventSummary = z.infer<typeof EventSummarySchema>;
+
+/**
+ * `PATCH /events/:eventId/schedule` body。
+ * - `{ startsAt: ISO8601 }`: operator 指定の日時 (分精度)
+ * - `{ startNow: true }`: 即座に開始 (= server now を採用)
+ */
+export const ScheduleEventRequestSchema = z.union([
+  z.object({ startsAt: z.string().datetime({ offset: true }) }),
+  z.object({ startNow: z.literal(true) }),
+]);
+export type ScheduleEventRequest = z.infer<typeof ScheduleEventRequestSchema>;
 
 export const TeamSummarySchema = z.object({
   teamId: z.string(),

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -132,6 +132,7 @@ export async function handler(): Promise<void> {
     );
     const items = (out.Items ?? []) as Partial<DeploymentItem>[];
 
+    const nowIso = new Date().toISOString();
     // 全 deployment を **並列** に check する。Lambda timeout 2 min 内に収まるよう、
     // sequential だと N × PROBE_TIMEOUT_MS で容易に超過する。1 deployment 失敗が
     // 他に波及しないよう catch して log に残す。
@@ -139,6 +140,10 @@ export async function handler(): Promise<void> {
       items.map(async (item) => {
         const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
         if (scoring?.kind !== "uptime") return;
+        // Event 開始時刻 (eventStartsAt) より前は probe + 採点を skip。
+        //   - deploy 直後の意図しない加点を防ぐ (operator が「即座に開始」or 日時設定するまで停止)
+        //   - 競技開始前の Lambda 呼び出し / outbound HTTP probe を抑制 (無駄なコスト削減)
+        if (!isScoringActive(item, nowIso)) return;
         try {
           await checkOne(item, scoring);
         } catch (err) {
@@ -153,3 +158,17 @@ export async function handler(): Promise<void> {
 }
 
 export { joinUrl };
+
+/**
+ * deployment が採点対象かを判定。`eventStartsAt` が未設定 / 未来なら false。
+ * - 未設定: 旧 jobId-based deployment / Event.startsAt 未設定 → 採点無し
+ * - 未来: operator が schedule 済だがまだ時刻に到達していない → skip
+ * 比較は ISO8601 文字列の辞書順比較で安全 (UTC ISO は時系列ソート可能)。
+ */
+export function isScoringActive(
+  item: Pick<DeploymentItem, "eventStartsAt">,
+  nowIso: string,
+): boolean {
+  if (typeof item.eventStartsAt !== "string") return false;
+  return nowIso >= item.eventStartsAt;
+}

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -1,5 +1,5 @@
 import type { PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { GetCommand, type QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bulkTeardownEvent } from "../../lib/problem-deploy/handlers/event-handler/bulk-delete";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
@@ -52,11 +52,11 @@ describe("bulkTeardownEvent", () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // Get(Event)
     ddbSend.mockResolvedValueOnce({
-      // Query(Deployments) — tenant 全件
+      // Query(Deployments) — server-side FilterExpression が EV1 のみ返す
+      // (OTHER event は DDB が事前に除外、test mock は事後の状態を再現)
       Items: [
         dep({ jobId: "01A", namePrefix: "tc-p-t1" }),
         dep({ jobId: "01B", namePrefix: "tc-p-t2", eventId: "EV1" }),
-        dep({ jobId: "01C", namePrefix: "tc-q-t1", eventId: "OTHER" }),
       ],
     });
     ddbSend.mockResolvedValue({}); // 並列 Update * 2
@@ -67,6 +67,13 @@ describe("bulkTeardownEvent", () => {
       kind: "ok",
       result: { eventId: "EV1", enqueued: 2, skipped: 0 },
     });
+
+    // Query が FilterExpression で eventId 一致を要求し、cross-event 漏洩を防ぐ
+    const queryCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is QueryCommand => c instanceof QueryCommand);
+    expect(queryCmds[0]?.input.FilterExpression).toBe("eventId = :ev");
+    expect(queryCmds[0]?.input.ExpressionAttributeValues?.[":ev"]).toBe("EV1");
 
     const updateCmds = ddbSend.mock.calls
       .map((c) => c[0])

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -1,5 +1,10 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { GetCommand, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  GetCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { bulkDeployEvent } from "../../lib/problem-deploy/handlers/event-handler/bulk-deploy";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
@@ -189,5 +194,57 @@ describe("bulkDeployEvent", () => {
     for (const item of transactCmd.input.TransactItems ?? []) {
       expect(item.Put?.ConditionExpression).toBe("attribute_not_exists(PK)");
     }
+  });
+
+  it("Event.startsAt を deployment 行に eventStartsAt として denormalize するべき", async () => {
+    // operator が Bulk Deploy 前に schedule 済 (startsAt 設定済) だった場合、
+    // 新規 deployment 行が gate 値を持って作られるシナリオ。
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: sampleEvent({ startsAt: "2026-05-08T10:00:00.000Z" }),
+    });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    for (const item of transactCmd.input.TransactItems ?? []) {
+      expect(item.Put?.Item?.eventStartsAt).toBe("2026-05-08T10:00:00.000Z");
+    }
+  });
+
+  it("Event.startsAt 未設定の場合は eventStartsAt も undefined (採点 gate に倒す)", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // startsAt 無し
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    for (const item of transactCmd.input.TransactItems ?? []) {
+      expect(item.Put?.Item?.eventStartsAt).toBeUndefined();
+    }
+  });
+
+  it("成功後に Event status を DRAFT → DEPLOYING に倒すべき (status badge 視認用)", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const updateCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is UpdateCommand => c instanceof UpdateCommand);
+    expect(updateCmds).toHaveLength(1);
+    const cmd = updateCmds[0] as UpdateCommand;
+    expect(cmd.input.UpdateExpression).toContain("#status = :deploying");
+    expect(cmd.input.ExpressionAttributeValues?.[":deploying"]).toBe("DEPLOYING");
+    // TEARDOWN/ARCHIVED は触らない (ConditionExpression で DRAFT/READY/DEPLOYING のみ許可)
+    expect(cmd.input.ExpressionAttributeValues?.[":draft"]).toBe("DRAFT");
+    expect(cmd.input.ExpressionAttributeValues).not.toHaveProperty(":teardown");
   });
 });

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -1,0 +1,124 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setEventSchedule } from "../../lib/problem-deploy/handlers/event-handler/schedule";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_ISO = new Date(NOW_MS).toISOString();
+const STARTS_AT = "2026-05-08T10:00:00.000Z";
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: { send: vi.fn() } as unknown as EventSharedResources["events"],
+    problemsCatalog: {},
+  };
+  return { shared, ddbSend };
+}
+
+describe("setEventSchedule", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: Event 行 + 紐づく全 deployment 行の eventStartsAt を更新するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    // 1st: Event UpdateCommand returns Attributes (= 行が存在 + tenantId 一致)
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        startsAt: STARTS_AT,
+      },
+    });
+    // 2nd: Deployments QueryCommand (GSI1 = TENANT#)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "DEPLOYMENT#J1", eventId: "EV1" },
+        { PK: "DEPLOYMENT#J2", eventId: "EV1" },
+        { PK: "DEPLOYMENT#J3", eventId: "EV-OTHER" }, // 別 event は除外
+        { PK: "DEPLOYMENT#J4", eventId: "EV1" },
+      ],
+    });
+    // 3rd-5th: Deployments UpdateCommand × 3 (J1, J2, J4 — EV-OTHER は skip)
+    ddbSend.mockResolvedValue({});
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    expect(out).toEqual({ kind: "ok", startsAt: STARTS_AT, updatedDeployments: 3 });
+
+    // Event 更新の ConditionExpression が tenantId 一致を要求する
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(eventUpd).toBeInstanceOf(UpdateCommand);
+    expect(eventUpd.input.ConditionExpression).toBe("tenantId = :tenantId");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBe(STARTS_AT);
+
+    // Deployments query は GSI1 = TENANT#tenant-acme
+    const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    expect(queryCmd).toBeInstanceOf(QueryCommand);
+    expect(queryCmd.input.IndexName).toBe("GSI1");
+    expect(queryCmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+
+    // Deployment update が EV1 行のみ走り、EV-OTHER は触らない
+    const updCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
+    expect(updCmds).toHaveLength(3);
+    const updatedPks = updCmds.map((c) => (c.input.Key as { PK: string }).PK).sort();
+    expect(updatedPks).toEqual(["DEPLOYMENT#J1", "DEPLOYMENT#J2", "DEPLOYMENT#J4"]);
+    for (const cmd of updCmds) {
+      expect(cmd.input.ExpressionAttributeValues?.[":s"]).toBe(STARTS_AT);
+    }
+  });
+
+  it("Event 行不在 / tenant 不一致は ConditionalCheckFailedException → not_found", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = new Error("conditional failed");
+    err.name = "ConditionalCheckFailedException";
+    ddbSend.mockRejectedValueOnce(err);
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+    // Deployments query / update は 1 度も走らない (= 漏洩防止)
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("対象 deployment が 0 件でも ok を返し updatedDeployments=0 (= 即座に schedule のみの shortcut)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    expect(out).toEqual({ kind: "ok", startsAt: STARTS_AT, updatedDeployments: 0 });
+    // Deployment Update は走らない (Promise.all([]))
+    const updCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
+    expect(updCmds).toHaveLength(0);
+  });
+
+  it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }],
+    });
+    ddbSend.mockResolvedValue({});
+
+    await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
+    expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+    expect(deployUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+  });
+});

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -37,16 +37,15 @@ describe("setEventSchedule", () => {
         startsAt: STARTS_AT,
       },
     });
-    // 2nd: Deployments QueryCommand (GSI1 = TENANT#)
+    // 2nd: Deployments QueryCommand (FilterExpression で EV1 のみ server 側で除外済み)
     ddbSend.mockResolvedValueOnce({
       Items: [
         { PK: "DEPLOYMENT#J1", eventId: "EV1" },
         { PK: "DEPLOYMENT#J2", eventId: "EV1" },
-        { PK: "DEPLOYMENT#J3", eventId: "EV-OTHER" }, // 別 event は除外
         { PK: "DEPLOYMENT#J4", eventId: "EV1" },
       ],
     });
-    // 3rd-5th: Deployments UpdateCommand × 3 (J1, J2, J4 — EV-OTHER は skip)
+    // 3rd-5th: Deployments UpdateCommand × 3
     ddbSend.mockResolvedValue({});
 
     const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
@@ -59,13 +58,15 @@ describe("setEventSchedule", () => {
     expect(eventUpd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
     expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBe(STARTS_AT);
 
-    // Deployments query は GSI1 = TENANT#tenant-acme
+    // Deployments query は GSI1 = TENANT# + FilterExpression で eventId 一致 (cross-event 漏洩防止)
     const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;
     expect(queryCmd).toBeInstanceOf(QueryCommand);
     expect(queryCmd.input.IndexName).toBe("GSI1");
     expect(queryCmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+    expect(queryCmd.input.FilterExpression).toBe("eventId = :ev");
+    expect(queryCmd.input.ExpressionAttributeValues?.[":ev"]).toBe("EV1");
 
-    // Deployment update が EV1 行のみ走り、EV-OTHER は触らない
+    // Deployment update が EV1 行 3 件のみ走る
     const updCmds = ddbSend.mock.calls
       .map((c) => c[0])
       .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);

--- a/infrastructure/test/problem-deploy/health-check-handler.test.ts
+++ b/infrastructure/test/problem-deploy/health-check-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { joinUrl } from "../../lib/problem-deploy/handlers/health-check-handler";
+import { isScoringActive, joinUrl } from "../../lib/problem-deploy/handlers/health-check-handler";
 import {
   computeSince,
   type EndpointHealth,
@@ -10,6 +10,26 @@ import {
  * Health Check Lambda 内のヘルパーを pin する。Scoring の解釈は
  * `lib/utils/scoring-metadata.ts` 側で集約され、別 test file が cover する。
  */
+
+describe("isScoringActive", () => {
+  const NOW = "2026-05-08T10:00:00.000Z";
+
+  it("eventStartsAt 未設定なら false (= deploy 直後の意図しない加点を防ぐ)", () => {
+    expect(isScoringActive({}, NOW)).toBe(false);
+    expect(isScoringActive({ eventStartsAt: undefined }, NOW)).toBe(false);
+  });
+
+  it("eventStartsAt が現在時刻より未来なら false (= operator が schedule 済だが時刻未到達)", () => {
+    expect(isScoringActive({ eventStartsAt: "2026-05-08T10:00:00.001Z" }, NOW)).toBe(false);
+    expect(isScoringActive({ eventStartsAt: "2026-05-08T11:00:00.000Z" }, NOW)).toBe(false);
+  });
+
+  it("eventStartsAt が現在時刻と同じか過去なら true (= 競技開始済、採点 active)", () => {
+    expect(isScoringActive({ eventStartsAt: NOW }, NOW)).toBe(true);
+    expect(isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z" }, NOW)).toBe(true);
+    expect(isScoringActive({ eventStartsAt: "2025-01-01T00:00:00.000Z" }, NOW)).toBe(true);
+  });
+});
 
 describe("joinUrl", () => {
   it("path 空ならそのまま base を返すべき", () => {


### PR DESCRIPTION
## Summary

3 つの関連バグを 1 つの lifecycle 設計で解決:

1. **status が DRAFT 固定**: Bulk Deploy しても EventDetail の status badge が動かない
2. **deploy 直後に勝手に採点が始まる**: 競技開始前にスコアが付いてしまう
3. **無駄な Lambda 呼出 + outbound HTTP**: HealthCheck が deploy 直後から probe を飛ばす

## 仕様

- \`Event.startsAt: ISO8601\` を新規 field として追加
- 新 API \`PATCH /events/:eventId/schedule\`:
  - \`{ startsAt: ISO8601 }\` → 日時指定
  - \`{ startNow: true }\` → 即座に開始 (server now を採用)
- Bulk Deploy: \`Event.startsAt\` を全 deployment 行へ \`eventStartsAt\` として denormalize し、\`Event.status\` を DRAFT/READY/DEPLOYING → DEPLOYING に倒す (TEARDOWN/ARCHIVED は ConditionExpression で防御)
- HealthCheck gate (\`isScoringActive\`): \`eventStartsAt\` 未設定 / 未来 → probe + 採点 skip
- Operator UI EventDetail: 「競技スケジュール」Container 新設、DatePicker + TimeInput モーダル、即座に開始ボタン、採点ステータス badge (未開始 / 開始予定 / 採点中)

## 動線 (operator UX)

1. Event 作成 (DRAFT)
2. Bulk Deploy → status DEPLOYING、deployments 起動
3. EventDetail で「即座に開始」or「日時を指定して開始」
4. 採点開始 → uptime / flag が加算される
5. Bulk Teardown で終了

## 設計判断

- **denormalization 戦略**: HealthCheck Lambda は EventsTable に IAM 権限なし → schedule API が両テーブルへ書く責務を持つ (CDK 改修不要)
- **採点開始 = 時刻ベース**: status (READY → STARTED) ではなく時刻ベースで gate。operator が時刻設定すれば自動で採点が始まる
- **status 遷移 (本 PR)**: bulk-deploy 完了直後に DEPLOYING へ遷移。READY 遷移 (= 全 deployment が COMPLETE になった時) は別 PR で cron Lambda or DDB Stream 経由

## Test plan

- [x] \`make before-commit\` 緑 (258 件 = 既存 248 + 新規 10)
  - \`isScoringActive\`: 未設定 / 未来 / 過去-現在 の 3 ケース
  - bulk-deploy: \`eventStartsAt\` denormalization × 2 + status 遷移 × 1
  - \`setEventSchedule\`: 正常系 / tenant 不一致 / 0 件 / updatedAt 整合性
- [ ] AWS で実 deploy → 「即座に開始」ボタンで採点開始確認
- [ ] DatePicker + TimeInput で日時指定 → 時刻到達まで HealthCheck CloudWatch ログに probe ログ無し / 到達後に出ることを確認

## Regression 分析

- 既存の旧 jobId-based deployment (\`eventStartsAt\` 無し) は採点されなくなる (= 旧経路の誤加算も結果的に止まる、副次効果として good)
- HealthCheck gate は probe 自体を skip → 開始前の Lambda invocation コスト 0
- bulk-deploy の status 遷移は ConditionExpression で TEARDOWN/ARCHIVED を踏み越えない
- schedule API は ConditionExpression で tenant 一致確認 → 不一致は 404 化、deployments query を走らせない (cross-tenant 漏洩防止)

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | event-api Lambda | 新 route + bulk-deploy 拡張 |
| UPDATE | health-check Lambda | gate 1 行 (probe / score skip) |
| UPDATE | application-admin-console SPA | EventDetail UI + ApiClient.patch |
| UPDATE | DDB items | \`Event.startsAt\` / \`Deployment.eventStartsAt\` (sparse) |
| NO-OP  | DDB schema / IAM / CDK / 他 Lambda | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)