### PR TITLE
feat(portal): 問題一覧 (Quests) ページ実装

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -6,6 +6,7 @@ import type { AppConfig } from "./config";
 import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { PlaceholderPage } from "./pages/Placeholder";
+import { QuestsPage } from "./pages/Quests";
 import { ScoreboardPage } from "./pages/Scoreboard";
 import { TeamSetupPage } from "./pages/TeamSetup";
 
@@ -71,17 +72,7 @@ export function App({ config }: { config: AppConfig }) {
             />,
           )}
         />
-        <Route
-          path="/problems"
-          element={guarded(
-            config,
-            <PlaceholderPage
-              title="問題一覧 (Quests)"
-              description="自チームに deploy された問題の入口"
-              comingSoon="deploy backend が完成すると、自チーム向けに deploy 済みの問題 (URL / API URL) がここに並びます。"
-            />,
-          )}
-        />
+        <Route path="/problems" element={guarded(config, <QuestsPage config={config} />)} />
         <Route
           path="/problems/:problemId"
           element={guarded(

--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -6,6 +6,7 @@ import type { AppConfig } from "./config";
 import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { PlaceholderPage } from "./pages/Placeholder";
+import { ProblemDetailPage } from "./pages/ProblemDetail";
 import { QuestsPage } from "./pages/Quests";
 import { ScoreboardPage } from "./pages/Scoreboard";
 import { TeamSetupPage } from "./pages/TeamSetup";
@@ -75,14 +76,7 @@ export function App({ config }: { config: AppConfig }) {
         <Route path="/problems" element={guarded(config, <QuestsPage config={config} />)} />
         <Route
           path="/problems/:problemId"
-          element={guarded(
-            config,
-            <PlaceholderPage
-              title="問題ダッシュボード"
-              description="Battle / Challenge の状態 + 操作 UI"
-              comingSoon="Battle: Attack Statistics / Application Status / Attack History の 3 タブを後段 PR で実装します。"
-            />,
-          )}
+          element={guarded(config, <ProblemDetailPage config={config} />)}
         />
         <Route
           path="/tools/sso"

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -1,0 +1,249 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator, {
+  type StatusIndicatorProps,
+} from "@cloudscape-design/components/status-indicator";
+import { useState } from "react";
+import {
+  type DeploymentStatus,
+  type ParticipantProblemView,
+  PortalValidationError,
+  type SubmitFlagOutcome,
+  submitFlag,
+  TERMINAL_STATUSES,
+} from "../api/portal-client";
+import { describeAgo } from "../lib/format";
+
+const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "success",
+  FAILED: "error",
+  DELETING: "in-progress",
+  DELETED: "stopped",
+};
+
+const SCORING_KIND_LABEL = {
+  flag: "Challenge (flag 提出)",
+  uptime: "Battle (uptime 加点)",
+} as const;
+
+/** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
+const STALE_THRESHOLD_MS = 2 * 60 * 1000;
+
+const POLL_INTERVAL_MS = 5_000;
+
+/**
+ * 1 problem 単位の詳細パネル。Home (= 全 problem を縦並べ) と ProblemDetail
+ * (= 1 problem 専用ページ) の両方から使う共通 component。
+ */
+export function ProblemPanel({
+  problem,
+  apiBaseUrl,
+  sessionToken,
+  onScored,
+}: {
+  problem: ParticipantProblemView;
+  apiBaseUrl: string;
+  sessionToken: string;
+  onScored: () => Promise<void>;
+}) {
+  const kindLabel = problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)";
+  const now = Date.now();
+  const lastScoredMs = problem.lastScoredAt ? new Date(problem.lastScoredAt).getTime() : Number.NaN;
+  const isUptime = problem.scoring?.kind === "uptime";
+  const isStale =
+    isUptime &&
+    Number.isFinite(lastScoredMs) &&
+    now - lastScoredMs > STALE_THRESHOLD_MS &&
+    problem.status === "COMPLETE";
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`${kindLabel} / ${problem.score} pt`}
+          actions={
+            <StatusIndicator type={STATUS_TYPE[problem.status]}>{problem.status}</StatusIndicator>
+          }
+        >
+          {problem.problemId}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {problem.status === "FAILED" && problem.failureReason && (
+          <Alert type="error" header="失敗理由">
+            {problem.failureReason}
+          </Alert>
+        )}
+        {isStale && (
+          <Alert type="warning" header="スコアが伸びていません">
+            直近の採点から {describeAgo(problem.lastScoredAt, now)} 経過。サービスのどこかが
+            期待通り応答していない可能性があります。
+          </Alert>
+        )}
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValuePairs
+            items={[
+              { label: "Region", value: problem.region },
+              { label: "Job ID", value: <code>{problem.jobId}</code> },
+            ]}
+          />
+          <KeyValuePairs
+            items={[
+              { label: "現在の score", value: `${problem.score} pt` },
+              { label: "最終加点", value: describeAgo(problem.lastScoredAt, now) },
+            ]}
+          />
+        </ColumnLayout>
+        {Object.keys(problem.stackOutputs).length > 0 && (
+          <Container header={<Header variant="h3">アクセス先 URL</Header>}>
+            <KeyValuePairs
+              items={Object.entries(problem.stackOutputs).map(([label, value]) => ({
+                label,
+                value: (
+                  <a href={value} target="_blank" rel="noreferrer noopener">
+                    <code>{value}</code>
+                  </a>
+                ),
+              }))}
+            />
+          </Container>
+        )}
+        {problem.scoring?.kind === "flag" && problem.status === "COMPLETE" && (
+          <FlagSubmissionPanel
+            apiBaseUrl={apiBaseUrl}
+            sessionToken={sessionToken}
+            problemId={problem.problemId}
+            flagSubmitted={problem.scoring.flagSubmitted ?? false}
+            points={problem.scoring.points ?? 0}
+            hints={problem.scoring.hints ?? []}
+            onScored={onScored}
+          />
+        )}
+        {!TERMINAL_STATUSES.has(problem.status) && (
+          <Box variant="small" color="text-status-info">
+            {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+          </Box>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}
+
+function FlagSubmissionPanel({
+  apiBaseUrl,
+  sessionToken,
+  problemId,
+  flagSubmitted,
+  points,
+  hints,
+  onScored,
+}: {
+  apiBaseUrl: string;
+  sessionToken: string;
+  problemId: string;
+  flagSubmitted: boolean;
+  points: number;
+  hints: readonly string[];
+  onScored: () => Promise<void>;
+}) {
+  const [flag, setFlag] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  if (flagSubmitted) {
+    return (
+      <Alert type="success" header="提出済み">
+        この problem は既に正解を提出済みです (+{points} pt)。
+      </Alert>
+    );
+  }
+
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+    if (!flag.trim() || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    setOutcome(null);
+    try {
+      const result = await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
+      setOutcome(result);
+      if (result.kind === "ok" || result.kind === "already_scored") {
+        await onScored();
+      }
+    } catch (err) {
+      if (err instanceof PortalValidationError) {
+        setSubmitError(`バリデーションエラー: ${err.errorCode}`);
+      } else {
+        setSubmitError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SpaceBetween size="s">
+      {hints.length > 0 && (
+        <Alert type="info" header="ヒント">
+          <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
+            {hints.map((h) => (
+              <li key={h}>{h}</li>
+            ))}
+          </ul>
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Form
+          actions={
+            <Button variant="primary" loading={submitting} formAction="submit">
+              Flag 提出 (+{points} pt)
+            </Button>
+          }
+        >
+          <FormField label="Flag (Stack Output 値)">
+            <Input
+              value={flag}
+              onChange={(e) => setFlag(e.detail.value)}
+              placeholder="例: Hello from tc-hello-world-..."
+              disabled={submitting}
+            />
+          </FormField>
+        </Form>
+      </form>
+      {outcome?.kind === "ok" && (
+        <Alert type="success" header={`正解 (+${outcome.scoreDelta} pt)`}>
+          合計スコア: {outcome.totalScore} pt
+        </Alert>
+      )}
+      {outcome?.kind === "wrong" && (
+        <Alert type="warning" header="不正解">
+          値を確認して再度提出してください。
+        </Alert>
+      )}
+      {outcome?.kind === "already_scored" && (
+        <Alert type="info" header="提出済み">
+          既に正解済みです (合計 {outcome.totalScore} pt)。
+        </Alert>
+      )}
+      {submitError && (
+        <Alert type="error" header="提出に失敗しました">
+          {submitError}
+        </Alert>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -1,47 +1,14 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
-import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
-import Form from "@cloudscape-design/components/form";
-import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
-import Input from "@cloudscape-design/components/input";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import StatusIndicator, {
-  type StatusIndicatorProps,
-} from "@cloudscape-design/components/status-indicator";
-import { useState } from "react";
-import {
-  type DeploymentStatus,
-  type ParticipantProblemView,
-  type ParticipantTeamView,
-  PortalValidationError,
-  type SubmitFlagOutcome,
-  submitFlag,
-  TERMINAL_STATUSES,
-} from "../api/portal-client";
+import type { ParticipantTeamView } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
+import { ProblemPanel } from "../components/ProblemPanel";
 import type { AppConfig } from "../config";
-import { describeAgo } from "../lib/format";
-
-const POLL_INTERVAL_MS = 5_000;
-
-const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
-  PENDING: "pending",
-  IN_PROGRESS: "in-progress",
-  COMPLETE: "success",
-  FAILED: "error",
-  DELETING: "in-progress",
-  DELETED: "stopped",
-};
-
-const SCORING_KIND_LABEL = {
-  flag: "Challenge (flag 提出)",
-  uptime: "Battle (uptime 加点)",
-} as const;
 
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
@@ -74,7 +41,7 @@ export function HomePage({ config }: { config: AppConfig }) {
       {view && <TeamScorePanel view={view} />}
 
       {view?.problems.map((problem) => (
-        <ProblemCard
+        <ProblemPanel
           key={problem.jobId}
           problem={problem}
           apiBaseUrl={config.apiBaseUrl}
@@ -115,210 +82,5 @@ function TeamScorePanel({ view }: { view: ParticipantTeamView }) {
         ]}
       />
     </Container>
-  );
-}
-
-/** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
-const STALE_THRESHOLD_MS = 2 * 60 * 1000;
-
-function ProblemCard({
-  problem,
-  apiBaseUrl,
-  sessionToken,
-  onScored,
-}: {
-  problem: ParticipantProblemView;
-  apiBaseUrl: string;
-  sessionToken: string;
-  onScored: () => Promise<void>;
-}) {
-  const kindLabel = problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)";
-  const now = Date.now();
-  const lastScoredMs = problem.lastScoredAt ? new Date(problem.lastScoredAt).getTime() : Number.NaN;
-  const isUptime = problem.scoring?.kind === "uptime";
-  const isStale =
-    isUptime &&
-    Number.isFinite(lastScoredMs) &&
-    now - lastScoredMs > STALE_THRESHOLD_MS &&
-    problem.status === "COMPLETE";
-
-  return (
-    <Container
-      header={
-        <Header
-          variant="h2"
-          description={`${kindLabel} / ${problem.score} pt`}
-          actions={
-            <StatusIndicator type={STATUS_TYPE[problem.status]}>{problem.status}</StatusIndicator>
-          }
-        >
-          {problem.problemId}
-        </Header>
-      }
-    >
-      <SpaceBetween size="m">
-        {problem.status === "FAILED" && problem.failureReason && (
-          <Alert type="error" header="失敗理由">
-            {problem.failureReason}
-          </Alert>
-        )}
-        {isStale && (
-          <Alert type="warning" header="スコアが伸びていません">
-            直近の採点から {describeAgo(problem.lastScoredAt, now)} 経過。サービスのどこかが
-            期待通り応答していない可能性があります。
-          </Alert>
-        )}
-        <ColumnLayout columns={2} variant="text-grid">
-          <KeyValuePairs
-            items={[
-              { label: "Region", value: problem.region },
-              { label: "Job ID", value: <code>{problem.jobId}</code> },
-            ]}
-          />
-          <KeyValuePairs
-            items={[
-              { label: "現在の score", value: `${problem.score} pt` },
-              { label: "最終加点", value: describeAgo(problem.lastScoredAt, now) },
-            ]}
-          />
-        </ColumnLayout>
-        {Object.keys(problem.stackOutputs).length > 0 && (
-          <Container header={<Header variant="h3">アクセス先 URL</Header>}>
-            <KeyValuePairs
-              items={Object.entries(problem.stackOutputs).map(([label, value]) => ({
-                label,
-                value: (
-                  <a href={value} target="_blank" rel="noreferrer noopener">
-                    <code>{value}</code>
-                  </a>
-                ),
-              }))}
-            />
-          </Container>
-        )}
-        {problem.scoring?.kind === "flag" && problem.status === "COMPLETE" && (
-          <FlagSubmissionPanel
-            apiBaseUrl={apiBaseUrl}
-            sessionToken={sessionToken}
-            problemId={problem.problemId}
-            flagSubmitted={problem.scoring.flagSubmitted ?? false}
-            points={problem.scoring.points ?? 0}
-            hints={problem.scoring.hints ?? []}
-            onScored={onScored}
-          />
-        )}
-        {!TERMINAL_STATUSES.has(problem.status) && (
-          <Box variant="small" color="text-status-info">
-            {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
-          </Box>
-        )}
-      </SpaceBetween>
-    </Container>
-  );
-}
-
-function FlagSubmissionPanel({
-  apiBaseUrl,
-  sessionToken,
-  problemId,
-  flagSubmitted,
-  points,
-  hints,
-  onScored,
-}: {
-  apiBaseUrl: string;
-  sessionToken: string;
-  problemId: string;
-  flagSubmitted: boolean;
-  points: number;
-  hints: readonly string[];
-  onScored: () => Promise<void>;
-}) {
-  const [flag, setFlag] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  if (flagSubmitted) {
-    return (
-      <Alert type="success" header="提出済み">
-        この problem は既に正解を提出済みです (+{points} pt)。
-      </Alert>
-    );
-  }
-
-  const handleSubmit = async (e: { preventDefault: () => void }) => {
-    e.preventDefault();
-    if (!flag.trim() || submitting) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    setOutcome(null);
-    try {
-      const result = await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
-      setOutcome(result);
-      if (result.kind === "ok" || result.kind === "already_scored") {
-        await onScored();
-      }
-    } catch (err) {
-      if (err instanceof PortalValidationError) {
-        setSubmitError(`バリデーションエラー: ${err.errorCode}`);
-      } else {
-        setSubmitError(err instanceof Error ? err.message : String(err));
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <SpaceBetween size="s">
-      {hints.length > 0 && (
-        <Alert type="info" header="ヒント">
-          <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
-            {hints.map((h) => (
-              <li key={h}>{h}</li>
-            ))}
-          </ul>
-        </Alert>
-      )}
-      <form onSubmit={handleSubmit}>
-        <Form
-          actions={
-            <Button variant="primary" loading={submitting} formAction="submit">
-              Flag 提出 (+{points} pt)
-            </Button>
-          }
-        >
-          <FormField label="Flag (Stack Output 値)">
-            <Input
-              value={flag}
-              onChange={(e) => setFlag(e.detail.value)}
-              placeholder="例: Hello from tc-hello-world-..."
-              disabled={submitting}
-            />
-          </FormField>
-        </Form>
-      </form>
-      {outcome?.kind === "ok" && (
-        <Alert type="success" header={`正解 (+${outcome.scoreDelta} pt)`}>
-          合計スコア: {outcome.totalScore} pt
-        </Alert>
-      )}
-      {outcome?.kind === "wrong" && (
-        <Alert type="warning" header="不正解">
-          値を確認して再度提出してください。
-        </Alert>
-      )}
-      {outcome?.kind === "already_scored" && (
-        <Alert type="info" header="提出済み">
-          既に正解済みです (合計 {outcome.totalScore} pt)。
-        </Alert>
-      )}
-      {submitError && (
-        <Alert type="error" header="提出に失敗しました">
-          {submitError}
-        </Alert>
-      )}
-    </SpaceBetween>
   );
 }

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -1,0 +1,64 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { Navigate, useNavigate, useParams } from "react-router";
+import { useAuth } from "../auth/AuthProvider";
+import { useTeamView } from "../auth/TeamViewProvider";
+import { ProblemPanel } from "../components/ProblemPanel";
+import type { AppConfig } from "../config";
+
+/**
+ * 1 問題の詳細ページ。Quests から click で来る。`useTeamView()` の問題リストから
+ * `:problemId` 一致する 1 件を見つけて `ProblemPanel` を 1 つだけ表示する。
+ *
+ * 不在 (= deploy されていない / 旧 deployment) の場合は Quests へ navigate。
+ */
+export function ProblemDetailPage({ config }: { config: AppConfig }) {
+  const { problemId } = useParams<{ problemId: string }>();
+  const navigate = useNavigate();
+  const auth = useAuth();
+  const sessionToken = auth.session?.sessionToken ?? null;
+  const { view, error, refresh } = useTeamView();
+
+  if (!problemId) return <Navigate to="/problems" replace />;
+
+  const problem = view?.problems.find((p) => p.problemId === problemId);
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={<Button onClick={() => navigate("/problems")}>問題一覧へ戻る</Button>}
+      >
+        {problemId}
+      </Header>
+
+      {error && (
+        <Alert type="error" header="状態の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+
+      {!problem && view && (
+        <Alert type="warning" header="この問題は自チームに deploy されていません">
+          <Box variant="p">
+            <code>{problemId}</code> は自チームの deploy リストに無いため、詳細を表示できません。
+            operator にお問い合わせください。
+          </Box>
+        </Alert>
+      )}
+      {!problem && !view && !error && <Box>状態を取得中…</Box>}
+
+      {problem && (
+        <ProblemPanel
+          problem={problem}
+          apiBaseUrl={config.apiBaseUrl}
+          sessionToken={sessionToken ?? ""}
+          onScored={refresh}
+        />
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -1,0 +1,143 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Cards from "@cloudscape-design/components/cards";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator, {
+  type StatusIndicatorProps,
+} from "@cloudscape-design/components/status-indicator";
+import type { DeploymentStatus, ParticipantProblemView } from "../api/portal-client";
+import { useTeamView } from "../auth/TeamViewProvider";
+import type { AppConfig } from "../config";
+
+const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "success",
+  FAILED: "error",
+  DELETING: "in-progress",
+  DELETED: "stopped",
+};
+
+const SCORING_KIND_LABEL = {
+  flag: "Challenge (flag 提出)",
+  uptime: "Battle (uptime 加点)",
+} as const;
+
+/**
+ * 自チーム向け deploy 済問題のカタログ画面 (sidebar 「問題一覧」)。Home に対する
+ * compact な navigation focus 版で、各問題の status / score / アクセス先 URL を
+ * カード表示する。
+ *
+ * データ source は `useTeamView()` (= ShellLayout 内の `/portal/me` polling 結果を共有)。
+ * 専用 polling は持たない (Home / TopNav と同じ context を使う)。
+ */
+export function QuestsPage({ config }: { config: AppConfig }) {
+  const { view, error } = useTeamView();
+  const isBackend = config.mode === "backend";
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="自チームに deploy された問題のカタログ。各カードからアクセス先 URL に直接遷移できます。"
+      >
+        問題一覧 (Quests)
+      </Header>
+
+      {!isBackend && (
+        <Alert type="info">
+          dev-mock モードで動作中です。実 backend と接続するには runtime-config の <code>mode</code>{" "}
+          を <code>backend</code> に設定してください。
+        </Alert>
+      )}
+      {error && (
+        <Alert type="error" header="状態の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+
+      <Cards<ParticipantProblemView>
+        items={view ? [...view.problems] : []}
+        loading={isBackend && !view && !error}
+        loadingText="問題を取得中…"
+        cardDefinition={{
+          header: (problem) => (
+            <Box variant="h3">
+              <code>{problem.problemId}</code>
+            </Box>
+          ),
+          sections: [
+            {
+              id: "status",
+              header: "ステータス",
+              content: (problem) => (
+                <StatusIndicator type={STATUS_TYPE[problem.status]}>
+                  {problem.status}
+                </StatusIndicator>
+              ),
+            },
+            {
+              id: "kind",
+              header: "形式",
+              content: (problem) =>
+                problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)",
+            },
+            {
+              id: "score",
+              header: "現在の Score",
+              content: (problem) => (
+                <Box variant="strong" color="text-status-success">
+                  {problem.score} pt
+                </Box>
+              ),
+            },
+            {
+              id: "region",
+              header: "Region",
+              content: (problem) => problem.region,
+            },
+            {
+              id: "outputs",
+              header: "アクセス先 URL",
+              content: (problem) => {
+                const entries = Object.entries(problem.stackOutputs);
+                if (entries.length === 0) {
+                  return (
+                    <Box variant="small" color="text-status-inactive">
+                      まだ deploy 完了していません
+                    </Box>
+                  );
+                }
+                return (
+                  <SpaceBetween size="xs">
+                    {entries.map(([label, value]) => (
+                      <Box key={label}>
+                        <Box variant="awsui-key-label">{label}</Box>
+                        <a href={value} target="_blank" rel="noreferrer noopener">
+                          <code>{value}</code>
+                        </a>
+                      </Box>
+                    ))}
+                  </SpaceBetween>
+                );
+              },
+            },
+          ],
+        }}
+        cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}
+        empty={
+          <Container>
+            <Box textAlign="center" padding="l">
+              <Box variant="strong">問題がありません</Box>
+              <Box variant="small" color="text-status-inactive" padding={{ top: "s" }}>
+                このチームには deploy 済みの問題がありません。operator にお問い合わせください。
+              </Box>
+            </Box>
+          </Container>
+        }
+      />
+    </SpaceBetween>
+  );
+}

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -3,10 +3,12 @@ import Box from "@cloudscape-design/components/box";
 import Cards from "@cloudscape-design/components/cards";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator, {
   type StatusIndicatorProps,
 } from "@cloudscape-design/components/status-indicator";
+import { useNavigate } from "react-router";
 import type { DeploymentStatus, ParticipantProblemView } from "../api/portal-client";
 import { useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
@@ -35,6 +37,7 @@ const SCORING_KIND_LABEL = {
  */
 export function QuestsPage({ config }: { config: AppConfig }) {
   const { view, error } = useTeamView();
+  const navigate = useNavigate();
   const isBackend = config.mode === "backend";
 
   return (
@@ -64,9 +67,16 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         loadingText="問題を取得中…"
         cardDefinition={{
           header: (problem) => (
-            <Box variant="h3">
+            <Link
+              fontSize="heading-m"
+              href={`/problems/${encodeURIComponent(problem.problemId)}`}
+              onFollow={(e) => {
+                e.preventDefault();
+                navigate(`/problems/${encodeURIComponent(problem.problemId)}`);
+              }}
+            >
               <code>{problem.problemId}</code>
-            </Box>
+            </Link>
           ),
           sections: [
             {


### PR DESCRIPTION
## Summary

#163 の残 placeholder のうち最も軽量な \`/problems\` sidebar を実機能に置換。

自チームに deploy された問題のカタログを Cloudscape \`Cards\` で grid 表示。Home ページの詳細表示に対する **navigation focus 版** で、operator URL に直接アクセスしたい時の入口になる。

## 仕様

各カード:
- problemId (h3 + code style)
- ステータス (StatusIndicator)
- 形式: Challenge (flag 提出) / Battle (uptime 加点)
- 現在の Score (大きく緑色)
- Region
- アクセス先 URL — \`stackOutputs\` を target=_blank の link で展開

データ source は \`useTeamView()\` (= ShellLayout の polling 結果を共有)。専用 polling 無し。dev-mock / error / loading / empty の各状態を網羅。レスポンシブ (1 列 / 2 列、minWidth=600)。

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | participant-portal SPA | 新ページ (Quests.tsx) + /problems route swap |
| NO-OP  | Lambda / IAM / DDB / EventBridge / CDK | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (425 件全 pass、新規 unit test 無し — UI のみ)
- [ ] AWS で実 deploy → \`/problems\` で複数 problem の grid 表示を目視確認
- [ ] 「アクセス先 URL」リンクから新タブで開けることを確認

## Regression 分析

- 既存の Home / Scoreboard / TeamSetup には影響なし
- /problems は guarded route で auth gate 通過、TeamViewProvider 経由のデータ表示
- Home と同じ data source なので polling 増加無し

## 残 placeholder (本 PR 範囲外)

- **Score events** — 加点履歴。DDB に submission log の write 追加が必要 (中規模)
- **Notifications** — 運営→競技者 push (新 DDB + 大規模)
- **SSO Credentials** — Identity Center 連携 (アーキテクチャ追加、後回し)
- **\`/problems/:problemId\` 詳細ページ** — Battle UI 設計 (#164) 後で実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)