### PR TITLE
feat(portal): Score events ページ実装 (加点履歴の時系列 view)

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -7,6 +7,7 @@ import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { PlaceholderPage } from "./pages/Placeholder";
 import { ScoreboardPage } from "./pages/Scoreboard";
+import { ScoreEventsPage } from "./pages/ScoreEvents";
 import { TeamSetupPage } from "./pages/TeamSetup";
 
 function RequireAuth({
@@ -51,14 +52,7 @@ export function App({ config }: { config: AppConfig }) {
         <Route path="/scoreboard" element={guarded(config, <ScoreboardPage config={config} />)} />
         <Route
           path="/score-events"
-          element={guarded(
-            config,
-            <PlaceholderPage
-              title="Score events"
-              description="自チーム + 全体の得点履歴"
-              comingSoon="scoring backend を別 PR で接続後、ここに時刻 / source / 説明 / points の履歴が表示されます。"
-            />,
-          )}
+          element={guarded(config, <ScoreEventsPage config={config} />)}
         />
         <Route
           path="/notifications"

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -141,6 +141,44 @@ export async function updateTeamName(
 }
 
 /**
+ * Phase 3: 自チームの加点履歴 (時系列降順)。flag 提出と uptime probe 成功の両方を含む。
+ */
+export interface ScoreEventView {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly source: "uptime" | "flag";
+  readonly points: number;
+  readonly result: "ok";
+  readonly occurredAt: string;
+}
+
+export interface ScoreEventsResponse {
+  readonly entries: readonly ScoreEventView[];
+}
+
+/**
+ * `GET /portal/me/score-events` を `Authorization: Bearer <teamLoginKey>` で呼ぶ。
+ * occurredAt 降順で 100 件まで。team の全 deployment 横断で merge 済。
+ */
+export async function getScoreEvents(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  signal?: AbortSignal,
+): Promise<ScoreEventsResponse> {
+  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me/score-events"), {
+    method: "GET",
+    headers: { authorization: `Bearer ${teamLoginKey}` },
+    signal,
+  });
+  if (res.status === 401) throw new PortalAuthError();
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+  return (await res.json()) as ScoreEventsResponse;
+}
+
+/**
  * Phase 3: Event scope の team ランキング (= Scoreboard)。
  * 同じ event 内の全 team を score 降順 + 同点は teamName 昇順で並べた配列を返す。
  */

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -1,0 +1,156 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useState } from "react";
+import {
+  getScoreEvents,
+  PortalAuthError,
+  type ScoreEventsResponse,
+  type ScoreEventView,
+} from "../api/portal-client";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+import { describeAgo } from "../lib/format";
+
+const POLL_INTERVAL_MS = 5_000;
+
+const SOURCE_LABEL: Record<ScoreEventView["source"], string> = {
+  uptime: "Battle (uptime)",
+  flag: "Challenge (flag)",
+};
+
+const SOURCE_COLOR: Record<ScoreEventView["source"], "blue" | "green" | "grey" | "red"> = {
+  uptime: "green",
+  flag: "blue",
+};
+
+/**
+ * 自チームの加点履歴 (sidebar 「Score events」)。新しい順 100 件まで表示。
+ *
+ * データ source は `getScoreEvents` を 5 秒間隔で polling。HealthCheck (uptime 成功) と
+ * 競技者の flag 提出 (正解) の両方を merge 済。
+ */
+export function ScoreEventsPage({ config }: { config: AppConfig }) {
+  const auth = useAuth();
+  const sessionToken = auth.session?.sessionToken ?? null;
+  const isBackend = config.mode === "backend";
+
+  const [data, setData] = useState<ScoreEventsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const tick = useCallback(async () => {
+    if (!isBackend || !sessionToken) return;
+    try {
+      const next = await getScoreEvents(config.apiBaseUrl, sessionToken);
+      setData(next);
+      setError(null);
+    } catch (err) {
+      if (err instanceof PortalAuthError) {
+        auth.logout();
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
+
+  useEffect(() => {
+    if (!isBackend || !sessionToken) return;
+    let cancelled = false;
+    const run = async () => {
+      if (cancelled) return;
+      await tick();
+    };
+    void run();
+    const interval = setInterval(run, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isBackend, sessionToken, tick]);
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={`自チームの加点履歴 (${POLL_INTERVAL_MS / 1000} 秒ごと自動更新、新しい順 100 件まで)`}
+      >
+        Score events
+      </Header>
+
+      {!isBackend && (
+        <Alert type="info">
+          dev-mock モードで動作中です。実 backend と接続するには runtime-config の <code>mode</code>{" "}
+          を <code>backend</code> に設定してください。
+        </Alert>
+      )}
+      {error && (
+        <Alert type="error" header="状態の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+      {isBackend && !data && !error && (
+        <Box textAlign="center" padding="l">
+          <Spinner /> 状態を取得中…
+        </Box>
+      )}
+
+      {data && (
+        <Container header={<Header variant="h2">{`履歴 (${data.entries.length})`}</Header>}>
+          <Table<ScoreEventView>
+            variant="embedded"
+            items={[...data.entries]}
+            columnDefinitions={[
+              {
+                id: "occurredAt",
+                header: "発生時刻",
+                cell: (e) => (
+                  <Box>
+                    <Box variant="small">{e.occurredAt}</Box>
+                    <Box variant="small" color="text-status-inactive">
+                      {describeAgo(e.occurredAt, Date.now())}
+                    </Box>
+                  </Box>
+                ),
+              },
+              {
+                id: "problemId",
+                header: "問題",
+                cell: (e) => <code>{e.problemId}</code>,
+              },
+              {
+                id: "source",
+                header: "種類",
+                cell: (e) => <Badge color={SOURCE_COLOR[e.source]}>{SOURCE_LABEL[e.source]}</Badge>,
+                width: 180,
+              },
+              {
+                id: "points",
+                header: "加点",
+                cell: (e) => (
+                  <Box variant="strong" color="text-status-success">
+                    +{e.points} pt
+                  </Box>
+                ),
+                width: 100,
+              },
+            ]}
+            empty={
+              <Box textAlign="center" padding="l">
+                <Box variant="strong">まだ加点履歴がありません</Box>
+                <Box variant="small" color="text-status-inactive" padding={{ top: "s" }}>
+                  競技開始後、HealthCheck の uptime 成功や flag
+                  提出で加点されると履歴がここに並びます。
+                </Box>
+              </Box>
+            }
+          />
+        </Container>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -9,6 +9,7 @@ import {
   type EndpointHealth,
   parseEndpointsHealth,
 } from "../shared/endpoints-health.js";
+import { writeScoreEvent } from "../shared/score-event.js";
 
 /**
  * EventBridge Scheduler `rate(1 minute)` で起動される Lambda。
@@ -81,6 +82,32 @@ async function checkOne(item: Partial<DeploymentItem>, scoring: UptimeScoring): 
   }
 
   await ddb.send(buildHealthUpdate(item.PK, allOk, scoring.pointsPerSuccess, now, newHealth));
+
+  // 全 endpoint OK のときだけ score event を書き込む。失敗イベントは現状 history に
+  // 残さない (= 加点ログのみ)。Put 失敗は best-effort として log に残す (= 採点は
+  // 既に確定しているので整合性より可用性優先)。
+  if (allOk && item.jobId && item.problemId) {
+    try {
+      await writeScoreEvent(
+        ddb,
+        tableName(),
+        {
+          jobId: item.jobId,
+          problemId: item.problemId,
+          teamId: item.teamId,
+          eventId: item.eventId,
+          expiresAt: item.expiresAt ?? 0,
+        },
+        "uptime",
+        scoring.pointsPerSuccess,
+        now,
+      );
+    } catch (err) {
+      console.warn(`[health-check] score-event write failed jobId=${item.jobId}`, {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 }
 
 /** 成功 / 失敗で UpdateCommand の expression が分岐するが、Key と timestamp は共通。 */

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -12,6 +12,7 @@ import {
 import { extractBearerToken } from "./auth.js";
 import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
+import { listScoreEvents } from "./score-events.js";
 import { buildParticipantSharedResources } from "./shared.js";
 import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
@@ -20,6 +21,7 @@ import { setDisplayTeamName } from "./update.js";
  * Participant Portal backend Lambda の Hono app (Phase 2c で team scope)。routes:
  *   GET   /portal/healthz
  *   GET   /portal/leaderboard       — event scope の team ランキング
+ *   GET   /portal/me/score-events   — 自チームの加点履歴 (時系列降順)
  *   GET   /portal/me                — Authorization: Bearer <teamLoginKey>
  *                                     → { team, problems[] }
  *   PATCH /portal/me                — body: { teamName: string } (team の全行を update)
@@ -43,6 +45,22 @@ app.get("/portal/me", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[portal] lookup failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.get("/portal/me/score-events", async (c) => {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+  try {
+    const outcome = await listScoreEvents(shared, token);
+    if (outcome.kind === "unauthorized") {
+      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+    }
+    return c.json(outcome.response, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[portal] score-events failed", { message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
@@ -1,0 +1,94 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
+import type { ScoreEventItem } from "../shared/score-event.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+
+/** participant 向けに公開する score event 1 行 (内部 PK/SK 等は出さない)。 */
+export interface ScoreEventView {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly source: "uptime" | "flag";
+  readonly points: number;
+  readonly result: "ok";
+  readonly occurredAt: string;
+}
+
+export interface ScoreEventsResponse {
+  readonly entries: readonly ScoreEventView[];
+}
+
+export type ScoreEventsOutcome =
+  | { kind: "ok"; response: ScoreEventsResponse }
+  | { kind: "unauthorized" };
+
+const DEFAULT_LIMIT = 100;
+
+/**
+ * teamLoginKey で team の全 deployment を引き、各 PK 配下の `EVENT#` SK 行を並列で
+ * query して時系列降順 (occurredAt desc) でマージする。
+ *
+ * GSI を新設せず base table の PK + begins_with(SK, "EVENT#") query で済ます。
+ * team 内の deployment 数は典型 <10 なので並列 N query は許容。
+ *
+ * teamId / eventId / tenantId / awsAccountId 等の operator 内部情報は **絶対に出さない**
+ * (= ScoreEventView に存在しない field なので構造的に漏れない)。
+ */
+export async function listScoreEvents(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  limit: number = DEFAULT_LIMIT,
+): Promise<ScoreEventsOutcome> {
+  const myItems = await queryTeamItems(shared, teamLoginKey);
+  if (myItems.length === 0) return { kind: "unauthorized" };
+
+  // editable な (live) 行のみから event 行を引く。DELETING / DELETED の親は無視。
+  const liveJobs = myItems.filter((i) => {
+    const status = (i.status ?? "PENDING") as DeploymentStatus;
+    return !DELETED_LIKE_STATUSES.has(status) && typeof i.PK === "string" && i.jobId;
+  }) as Array<Pick<DeploymentItem, "PK" | "jobId">>;
+
+  if (liveJobs.length === 0) return { kind: "unauthorized" };
+
+  // 各 deployment の event 行を並列に query。N query を Promise.all で発火。
+  const eventChunks = await Promise.all(
+    liveJobs.map(async (job) => {
+      const out = await shared.ddb.send(
+        new QueryCommand({
+          TableName: shared.tableName,
+          KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
+          ExpressionAttributeValues: {
+            ":pk": job.PK,
+            ":evpfx": "EVENT#",
+          },
+          ScanIndexForward: false,
+          Limit: limit,
+        }),
+      );
+      return ((out.Items ?? []) as Partial<ScoreEventItem>[]).map(toView);
+    }),
+  );
+
+  const merged = eventChunks.flat().filter((e): e is ScoreEventView => e !== undefined);
+  // occurredAt 降順 sort + 全 deployment 横断の上位 limit 件を返す。
+  merged.sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : a.occurredAt > b.occurredAt ? -1 : 0));
+  const entries = merged.slice(0, limit);
+  return { kind: "ok", response: { entries } };
+}
+
+/** ScoreEventItem (DDB row) → ScoreEventView (公開 shape)。不正な行は undefined。 */
+function toView(item: Partial<ScoreEventItem>): ScoreEventView | undefined {
+  if (typeof item.jobId !== "string") return undefined;
+  if (typeof item.problemId !== "string") return undefined;
+  if (item.source !== "uptime" && item.source !== "flag") return undefined;
+  if (item.result !== "ok") return undefined;
+  if (typeof item.occurredAt !== "string") return undefined;
+  return {
+    jobId: item.jobId,
+    problemId: item.problemId,
+    source: item.source,
+    points: Number(item.points ?? 0),
+    result: item.result,
+    occurredAt: item.occurredAt,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,6 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
+import { writeScoreEvent } from "../shared/score-event.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 export type SubmitFlagOutcome =
@@ -56,6 +57,7 @@ export async function submitFlag(
 
   // ConditionExpression で flagSubmitted=true への 2 重加算を防ぐ。レース勝者だけが
   // 加点される。
+  const now = new Date().toISOString();
   try {
     const updated = await shared.ddb.send(
       new UpdateCommand({
@@ -68,12 +70,38 @@ export async function submitFlag(
           ":pts": scoring.points,
           ":true": true,
           ":false": false,
-          ":now": new Date().toISOString(),
+          ":now": now,
         },
         ReturnValues: "ALL_NEW",
       }),
     );
     const totalScore = Number((updated.Attributes as { score?: unknown })?.score ?? scoring.points);
+
+    // 加点成功時のみ score event 行を append。失敗 (= already_scored の race) では
+    // 既存の event 行が記録済みなので二重に書かない。Put 失敗は best-effort で log。
+    if (item.jobId) {
+      try {
+        await writeScoreEvent(
+          shared.ddb,
+          shared.tableName,
+          {
+            jobId: item.jobId,
+            problemId: item.problemId,
+            teamId: item.teamId,
+            eventId: item.eventId,
+            expiresAt: item.expiresAt ?? 0,
+          },
+          "flag",
+          scoring.points,
+          now,
+        );
+      } catch (err) {
+        console.warn(`[submit-flag] score-event write failed jobId=${item.jobId}`, {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     return { kind: "ok", scoreDelta: scoring.points, totalScore };
   } catch (err) {
     if ((err as { name?: string })?.name === "ConditionalCheckFailedException") {

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -1,0 +1,69 @@
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+
+/**
+ * 1 採点イベント (= スコア加算の単位) を Deployments table に書き込むときの shape。
+ *
+ *   PK = `DEPLOYMENT#<jobId>` (= 親 deployment と同じ partition)
+ *   SK = `EVENT#<isoTimestamp>#<ulid>` (時系列ソート + 衝突防止)
+ *
+ * 既存の SK="META" 行を巻き込まないので /portal/me lookup と GSI2 に影響しない
+ * (sparse な追加行)。TTL は親 deployment の `expiresAt` を継承し、event teardown
+ * 時に一緒に消える。
+ */
+export interface ScoreEventItem {
+  PK: string;
+  SK: string;
+
+  jobId: string;
+  problemId: string;
+  /** Phase 2a 以前の旧 deployment は持たない (= history 列も undefined)。 */
+  teamId?: string;
+  eventId?: string;
+  /** 加点の発生源。`uptime` = HealthCheck の probe 成功、`flag` = 競技者の flag 提出。 */
+  source: "uptime" | "flag";
+  /** 加算ポイント。flag は scoring.points、uptime は scoring.pointsPerSuccess。 */
+  points: number;
+  /**
+   * 結果。`uptime` で全 endpoint OK or `flag` で正解なら "ok"。
+   * 失敗イベントは現状書き込まない (= history は加点ログのみ)。将来 fail も書くなら
+   * extend 可能。
+   */
+  result: "ok";
+  occurredAt: string;
+  /** 親 deployment の TTL を継承。0 なら無期限 (旧 deployment 互換)。 */
+  expiresAt: number;
+}
+
+/**
+ * 採点イベントを 1 行 PutItem する。HealthCheck (uptime) と submit-flag (flag) の両方
+ * から呼ばれるので shared/ に置く。書き込み失敗は親 score 加算と整合性が崩れるが、
+ * caller が catch して log のみ残す方針 (= MVP は best-effort)。
+ *
+ * `parent` から jobId / teamId / eventId / expiresAt を継承して event row を組む。
+ */
+export async function writeScoreEvent(
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  parent: Pick<DeploymentItem, "jobId" | "problemId" | "teamId" | "eventId" | "expiresAt">,
+  source: ScoreEventItem["source"],
+  points: number,
+  occurredAt: string,
+): Promise<void> {
+  const item: ScoreEventItem = {
+    PK: `DEPLOYMENT#${parent.jobId}`,
+    SK: `EVENT#${occurredAt}#${ulid()}`,
+    jobId: parent.jobId,
+    problemId: parent.problemId,
+    teamId: parent.teamId,
+    eventId: parent.eventId,
+    source,
+    points,
+    result: "ok",
+    occurredAt,
+    expiresAt: Number(parent.expiresAt ?? 0),
+  };
+  await ddb.send(new PutCommand({ TableName: tableName, Item: item }));
+}

--- a/infrastructure/test/problem-deploy/participant-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/participant-score-events.test.ts
@@ -1,0 +1,165 @@
+import type { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listScoreEvents } from "../../lib/problem-deploy/handlers/participant-handler/score-events";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+function buildShared(): {
+  shared: ParticipantSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+  };
+  return { shared, ddbSend };
+}
+
+const meta = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#J1",
+  SK: "META",
+  GSI2PK: "TEAMKEY#KEY1",
+  jobId: "J1",
+  problemId: "p1",
+  status: "COMPLETE",
+  ...over,
+});
+
+const event = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#J1",
+  SK: "EVENT#2026-05-08T10:00:00.000Z#01HX",
+  jobId: "J1",
+  problemId: "p1",
+  source: "uptime",
+  points: 5,
+  result: "ok",
+  occurredAt: "2026-05-08T10:00:00.000Z",
+  ...over,
+});
+
+describe("listScoreEvents", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: GSI2 で team を引き、各 PK で EVENT# query → occurredAt 降順 merge", async () => {
+    const { shared, ddbSend } = buildShared();
+    // 1st: GSI2 query (team の deployments)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        meta({ jobId: "J1", PK: "DEPLOYMENT#J1" }),
+        meta({ jobId: "J2", PK: "DEPLOYMENT#J2", problemId: "p2" }),
+      ],
+    });
+    // 2nd & 3rd: 各 PK の EVENT# query (Promise.all)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({ occurredAt: "2026-05-08T10:00:00.000Z", source: "uptime", points: 5 }),
+        event({ occurredAt: "2026-05-08T10:01:00.000Z", source: "uptime", points: 5 }),
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({
+          PK: "DEPLOYMENT#J2",
+          jobId: "J2",
+          problemId: "p2",
+          occurredAt: "2026-05-08T10:00:30.000Z",
+          source: "flag",
+          points: 100,
+        }),
+      ],
+    });
+
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(3);
+      // occurredAt 降順
+      expect(out.response.entries[0]?.occurredAt).toBe("2026-05-08T10:01:00.000Z");
+      expect(out.response.entries[1]?.occurredAt).toBe("2026-05-08T10:00:30.000Z");
+      expect(out.response.entries[2]?.occurredAt).toBe("2026-05-08T10:00:00.000Z");
+      // flag / uptime 両方含まれる
+      expect(out.response.entries[1]).toMatchObject({ source: "flag", points: 100, jobId: "J2" });
+    }
+
+    // EVENT# query は ScanIndexForward=false (新しい順)
+    const eventQueries = ddbSend.mock.calls.slice(1).map((c) => c[0] as QueryCommand);
+    expect(eventQueries[0]?.input.ScanIndexForward).toBe(false);
+    expect(eventQueries[0]?.input.KeyConditionExpression).toContain("begins_with(SK, :evpfx)");
+    expect(eventQueries[0]?.input.ExpressionAttributeValues?.[":evpfx"]).toBe("EVENT#");
+  });
+
+  it("teamLoginKey 不正は unauthorized (= EVENT# query 走らない)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await listScoreEvents(shared, "INVALID");
+    expect(out).toEqual({ kind: "unauthorized" });
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("全 deployment が DELETING / DELETED は unauthorized", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [meta({ status: "DELETING" }), meta({ status: "DELETED" })],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out).toEqual({ kind: "unauthorized" });
+  });
+
+  it("limit を超える merge は上位 N 件で truncate", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    // 5 events
+    ddbSend.mockResolvedValueOnce({
+      Items: Array.from({ length: 5 }, (_, i) =>
+        event({ occurredAt: `2026-05-08T10:0${i}:00.000Z` }),
+      ),
+    });
+    const out = await listScoreEvents(shared, "KEY1", 3);
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(3);
+    }
+  });
+
+  it("不正な event 行 (source 不明 / result fail) は除外", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({ source: "invalid" }),
+        event({ result: "fail" }),
+        event({ source: "uptime", result: "ok" }),
+      ],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(1);
+    }
+  });
+
+  it("teamId / eventId / tenantId 等 operator 内部情報を出力に含めないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({
+          // 一意で日付タイムスタンプに混ざらない sentinel 値で漏洩 assertion を確実化。
+          teamId: "TEAMID_LEAK_SENTINEL",
+          eventId: "EVENTID_LEAK_SENTINEL",
+          tenantId: "TENANTID_LEAK_SENTINEL",
+          expiresAt: 1_700_000_000_001,
+        }),
+      ],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    if (out.kind === "ok") {
+      const json = JSON.stringify(out.response);
+      expect(json).not.toContain("TEAMID_LEAK_SENTINEL");
+      expect(json).not.toContain("EVENTID_LEAK_SENTINEL");
+      expect(json).not.toContain("TENANTID_LEAK_SENTINEL");
+      expect(json).not.toContain("1700000000001");
+    }
+  });
+});

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -112,7 +112,8 @@ describe("submitFlag", () => {
       "Hello from tc-hello-world-alpha",
     );
     expect(out).toEqual({ kind: "ok", scoreDelta: 100, totalScore: 100 });
-    expect(ddbSend).toHaveBeenCalledTimes(2);
+    // 1: GSI2 query, 2: UpdateItem(score), 3: PutItem(score event log)
+    expect(ddbSend).toHaveBeenCalledTimes(3);
     const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(updateCmd).toBeInstanceOf(UpdateCommand);
     expect(updateCmd.input.UpdateExpression).toContain("ADD score :pts");


### PR DESCRIPTION
## Summary

#163 残 placeholder の 1 つ \`/score-events\` を実機能に置換。HealthCheck の uptime 成功 + flag 提出正解が時系列で並ぶ。

## DDB schema 追加

既存 Deployments table に新 SK パターン (sparse 追加):
\`\`\`
PK = DEPLOYMENT#<jobId>            (= 親 deployment と同じ partition)
SK = EVENT#<isoTimestamp>#<ulid>   (時系列ソート + 衝突防止)
\`\`\`
attributes: jobId / problemId / teamId? / eventId? / source ("uptime"|"flag") / points / result ("ok") / occurredAt / expiresAt (= 親 TTL 継承)。

既存 SK="META" 行と GSI2 (TEAMKEY#) に影響なし。

## Backend

- \`shared/score-event.ts\` 新規 (write helper)
- HealthCheck: probe 全 OK 時に best-effort で書き込み (失敗は log のみ、採点は確定済)
- submit-flag: 正解時に 1 件書き込み (重複加算 race では追加書込なし)
- \`participant-handler/score-events.ts\` 新規: GSI2 で team を引き各 PK で \`EVENT#\` query → 並列 merge → occurredAt 降順 100 件
- 新 route \`GET /portal/me/score-events\`
- 漏洩防止: teamId / eventId / tenantId / awsAccountId は構造的に出さない (test で確認)

## Frontend

- \`portal-client.ts\`: \`getScoreEvents()\` + types
- \`ScoreEvents.tsx\` (新): 5 秒 polling + Cloudscape Table、Battle uptime / Challenge flag を Badge 色分け

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | participant-portal Lambda | 新 route + score-events.ts |
| UPDATE | health-check Lambda | writeScoreEvent best-effort |
| UPDATE | participant-portal SPA | ScoreEvents.tsx + getScoreEvents |
| UPDATE | DDB items (write 増) | EVENT# row が probe 成功 / flag 正解で +1 (TTL 付) |
| NO-OP  | DDB schema / IAM / 他 Lambda / CDK | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (276 件 = 既存 270 + 新規 6)
  - listScoreEvents 6 ケース
  - submit-flag 既存 test 追従 (callcount 2 → 3、PutItem 追加分)
- [ ] AWS 上で実 deploy → 採点 → \`/score-events\` で履歴表示確認

## Regression 分析

- 既存 GSI2 query (= /portal/me, /portal/leaderboard) は SK="META" のみ拾う前提。新 EVENT# 行は GSI2PK を持たないため index に乗らない (sparse) → 既存 behavior 不変
- DDB write 増 (probe 成功 1 件 = 1 PutItem 追加): 1 WCU の budget 内 (5 deploy × 1 probe/min = 0.083 writes/sec)
- HealthCheck の write 失敗は best-effort (catch + log) で親 score 加算に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)