### PR TITLE
fix: participantPortalUrl を CDK 経由で runtime-config に注入 + code scanning dismiss

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -226,6 +226,7 @@ const tenantTemplateStack = new TenantTemplateStack(app, `tenkacloud-tenant-temp
   commitId,
   deployApiLambda: problemDeployBackendStack.deployApiLambda,
   eventApiLambda: problemDeployBackendStack.eventApiLambda,
+  participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
 });
 
 tenantTemplateStack.addDependency(problemDeployBackendStack);

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -78,6 +78,12 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * Event / Team CRUD 用の Lambda (ADR-004 Phase 1)。tenant API から invoke される。
    */
   public readonly eventApiLambda: IFunction;
+  /**
+   * Participant Portal の CloudFront URL。Participant Portal が無効化された tenant
+   * では undefined。`TenantTemplateStack` が application-admin-console の runtime-config に
+   * 注入するため publicly export する。
+   */
+  public readonly participantPortalUrl?: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -169,6 +175,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         apiBaseUrl: portalLambda.url.url,
         mode: "backend",
       });
+      this.participantPortalUrl = portal.distributionUrl;
       new CfnOutput(this, "ParticipantPortalUrl", {
         value: portal.distributionUrl,
         description: "Participant Portal CloudFront URL.",

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -81,7 +81,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
   /**
    * Participant Portal の CloudFront URL。Participant Portal が無効化された tenant
    * では undefined。`TenantTemplateStack` が application-admin-console の runtime-config に
-   * 注入するため publicly export する。
+   * 注入するため publicly export する (兄弟 deployApiLambda / eventApiLambda と同 pattern)。
    */
   public readonly participantPortalUrl?: string;
 

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -136,11 +136,12 @@ export class ApplicationAdminConsoleHosting extends Construct {
    * IdentityProvider + ApiGateway 確定後に呼び出して、application-admin-console が
    * 起動時に fetch する `/runtime-config.json` を CloudFront に配置する。
    *
-   * 中身は `{ cognitoDomain, userClientId, tenantId, tenantName, apiUrl }`。
+   * 中身は `{ cognitoDomain, userClientId, tenantId, tenantName, apiUrl, participantPortalUrl? }`。
    *   - cognitoDomain / userClientId: 認証で使う
    *   - tenantId: 内部 (API 呼び出し等)
    *   - tenantName: 画面表示用 (HomePage 等)
    *   - apiUrl: アプリ管理 API の base URL (POST /apps 等、#40-d)
+   *   - participantPortalUrl: 競技者向け Portal の CloudFront URL (sparse、未設定なら field 自体を出さない)
    */
   deployRuntimeConfig(props: RuntimeConfigProps): void {
     const data: Record<string, string> = {

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -43,6 +43,12 @@ interface RuntimeConfigProps {
    * ApiGateway.restApi.url (末尾スラッシュ有) から渡す。
    */
   readonly apiUrl: string;
+  /**
+   * Participant Portal の CloudFront URL。EventDetail / DeploymentDetail で operator が
+   * 「このイベントの portal を共有」できるようにするため runtime-config.json に注入する。
+   * 未設定 (Participant Portal 無効化時) なら undefined → frontend は fallback 表示。
+   */
+  readonly participantPortalUrl?: string;
 }
 
 /**
@@ -143,6 +149,7 @@ export class ApplicationAdminConsoleHosting extends Construct {
       tenantId: props.tenantId,
       tenantName: props.tenantName,
       apiUrl: props.apiUrl.replace(/\/$/, ""),
+      ...(props.participantPortalUrl ? { participantPortalUrl: props.participantPortalUrl } : {}),
     };
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [Source.jsonData("runtime-config.json", data)],

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -45,6 +45,13 @@ interface TenantTemplateStackProps extends StackProps {
    * tenant API の `/events*` routes が本 Lambda を invoke する。
    */
   eventApiLambda: IFunction;
+  /**
+   * Participant Portal の CloudFront URL。`ProblemDeployBackendStack` の
+   * `participantPortalUrl` をクロススタック参照で受け、application-admin-console の
+   * runtime-config.json に注入する (operator が EventDetail 等で「Portal URL を共有」
+   * できるようにするため)。Participant Portal が無効化された tenant では undefined。
+   */
+  participantPortalUrl?: string;
 }
 
 export class TenantTemplateStack extends Stack {
@@ -114,6 +121,7 @@ export class TenantTemplateStack extends Stack {
       tenantId: props.tenantId,
       tenantName: props.tenantName,
       apiUrl: apiGateway.restApi.url,
+      participantPortalUrl: props.participantPortalUrl,
     });
 
     new AwsCustomResource(this, "CreateTenantMapping", {

--- a/problems/battles/security-battle-royale/api/api.py
+++ b/problems/battles/security-battle-royale/api/api.py
@@ -1,3 +1,11 @@
+# =====================================================================
+# WARNING — INTENTIONALLY VULNERABLE CODE
+# このファイルは Battle 競技問題 "security-battle-royale" の被攻撃対象 API
+# として意図的に SQL injection / SSRF / RCE / debug-mode 等を含んでいる。
+# プレイヤーがこれらの脆弱性を攻撃することで採点 endpoint を落とすゲーム性。
+# CodeQL / 静的解析からの警告は「ゲームプレイの一部」として dismiss される。
+# 本番アプリのコードとして参考にしないこと。
+# =====================================================================
 import json
 import logging
 import os


### PR DESCRIPTION
Closes #491.

## Summary

operator UI の EventDetail で「Participant Portal URL 未注入」 Alert が出ていた件 (PR-482 で frontend 受け入れ済、CDK wire-up が後回し)。今回 CDK で値を流すようにした。

合わせて GitHub Code scanning の 6 件の alert (\`security-battle-royale/api/api.py\`) を「won't fix - intentional gameplay」で dismiss。これは意図的に脆弱な競技問題のソース (= プレイヤーが SQL injection / SSRF / RCE で採点 endpoint を落とす Battle 問題)。

## CDK 経由の伝播

cross-stack reference で \`ProblemDeployBackendStack\` → \`TenantTemplateStack\` → \`ApplicationAdminConsoleHosting\` → \`runtime-config.json\` に流す:

1. \`problem-deploy-backend-stack.ts\`: \`participantPortalUrl?: string\` を public field で expose (Portal hosting が立ったときだけ set)
2. \`bin/infrastructure.ts\`: \`tenantTemplateStack\` に prop で渡す
3. \`tenant-template-stack.ts\`: 新 prop を \`deployRuntimeConfig\` に転送
4. \`application-admin-console-hosting.ts\`: \`RuntimeConfigProps\` に追加、JSON 出力に sparse 含める

## Code scanning

GitHub API で 6 件 (#15-#20) を \`won't fix\` 理由付きで dismiss。\`security-battle-royale/api/api.py\` 先頭に WARNING comment を追加 (= 将来の reader 向け)。

## Test plan

- [x] \`make before-commit\` 緑 (276 件 + 全 frontend pass)
- [ ] AWS で実 deploy → application-admin-console を再 build → EventDetail で Portal URL Alert 消失 + URL link 表示確認
- [x] code scanning alerts 全 6 件 dismiss 済

## Regression 分析

- \`participantPortalUrl\` は optional → 無効化された tenant では undefined → frontend は fallback Alert 維持 (= 既存挙動互換)
- runtime-config.json への sparse 追加なので旧 frontend が JSON parse error にならない

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | TenantTemplateStack | 新 prop を runtime-config に inject |
| UPDATE | ProblemDeployBackendStack | participantPortalUrl public field を export |
| UPDATE | runtime-config.json | participantPortalUrl key (sparse) |
| NO-OP  | Lambda / IAM / DDB / 他 stack | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)