### PR TITLE
fix(portal): SSO Credentials sidebar 削除 + Quest link を jobId ベースに

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -69,7 +69,7 @@ export function App({ config }: { config: AppConfig }) {
         />
         <Route path="/problems" element={guarded(config, <QuestsPage config={config} />)} />
         <Route
-          path="/problems/:problemId"
+          path="/problems/:jobId"
           element={guarded(config, <ProblemDetailPage config={config} />)}
         />
         <Route

--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -38,11 +38,9 @@ const SIDE_NAV_ITEMS: SideNavigationProps.Item[] = [
     text: "Quests",
     items: [{ type: "link", href: "/problems", text: "問題一覧" }],
   },
-  {
-    type: "section",
-    text: "Tools",
-    items: [{ type: "link", href: "/tools/sso", text: "SSO Credentials" }],
-  },
+  // Tools section (SSO Credentials) は Identity Center 連携の ADR が固まるまで
+  // 非表示 (Issue #500)。route 自体は placeholder で残置しているので bookmark 経由の
+  // 直接アクセスは可能だが、sidebar からは導線を切る。
 ];
 
 export function ShellLayout({ config, children }: { config: AppConfig; children: ReactNode }) {

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -11,20 +11,21 @@ import type { AppConfig } from "../config";
 
 /**
  * 1 問題の詳細ページ。Quests から click で来る。`useTeamView()` の問題リストから
- * `:problemId` 一致する 1 件を見つけて `ProblemPanel` を 1 つだけ表示する。
+ * `:jobId` 一致する 1 件を見つけて `ProblemPanel` を 1 つだけ表示する。
  *
- * 不在 (= deploy されていない / 旧 deployment) の場合は Quests へ navigate。
+ * URL key は jobId (ULID) を採用。problemId (slug) は metadata 上 unique 前提だが、
+ * 同名 problem の link 衝突を回避する防御。問題不在の場合は Alert で説明。
  */
 export function ProblemDetailPage({ config }: { config: AppConfig }) {
-  const { problemId } = useParams<{ problemId: string }>();
+  const { jobId } = useParams<{ jobId: string }>();
   const navigate = useNavigate();
   const auth = useAuth();
   const sessionToken = auth.session?.sessionToken ?? null;
   const { view, error, refresh } = useTeamView();
 
-  if (!problemId) return <Navigate to="/problems" replace />;
+  if (!jobId) return <Navigate to="/problems" replace />;
 
-  const problem = view?.problems.find((p) => p.problemId === problemId);
+  const problem = view?.problems.find((p) => p.jobId === jobId);
 
   return (
     <SpaceBetween size="l">
@@ -32,7 +33,7 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
         variant="h1"
         actions={<Button onClick={() => navigate("/problems")}>問題一覧へ戻る</Button>}
       >
-        {problemId}
+        {problem?.problemId ?? jobId}
       </Header>
 
       {error && (
@@ -44,7 +45,7 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       {!problem && view && (
         <Alert type="warning" header="この問題は自チームに deploy されていません">
           <Box variant="p">
-            <code>{problemId}</code> は自チームの deploy リストに無いため、詳細を表示できません。
+            jobId <code>{jobId}</code> は自チームの deploy リストに無いため、詳細を表示できません。
             operator にお問い合わせください。
           </Box>
         </Alert>

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -66,13 +66,15 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         loading={isBackend && !view && !error}
         loadingText="問題を取得中…"
         cardDefinition={{
+          // jobId (ULID) を URL key にする。problemId (slug) は metadata 上 unique 前提だが、
+          // 将来 problemId を意図せず重複登録された場合の link 衝突を回避する防御。
           header: (problem) => (
             <Link
               fontSize="heading-m"
-              href={`/problems/${encodeURIComponent(problem.problemId)}`}
+              href={`/problems/${encodeURIComponent(problem.jobId)}`}
               onFollow={(e) => {
                 e.preventDefault();
-                navigate(`/problems/${encodeURIComponent(problem.problemId)}`);
+                navigate(`/problems/${encodeURIComponent(problem.jobId)}`);
               }}
             >
               <code>{problem.problemId}</code>


### PR DESCRIPTION
## Summary

ユーザー報告 2 件への対応:
1. **「SSO Credentials がまだ動かない」** → Identity Center 連携 ADR が固まるまで sidebar から削除 (Issue #500 で defer 推奨と判断済の現状を UI に反映)
2. **「Quest link が問題名 (slug) で同名問題があるとどっちにリンクされる?」** → URL key を problemId (slug) → jobId (ULID) に変更して衝突を防ぐ

## 1. SSO Credentials sidebar 削除

\`AppLayout.tsx\` の Tools section を撤去。route \`/tools/sso\` は placeholder で残置 (= bookmark の直接アクセスは引き続き機能)。Issue #500 が固まったときに sidebar 復活させる。

## 2. Quest link → jobId

- \`Quests.tsx\`: \`<Link href={\\\`/problems/\${jobId}\\\`}>\` に変更 (表示は problemId のまま、可読性維持)
- \`App.tsx\`: route を \`/problems/:problemId\` → \`/problems/:jobId\`
- \`ProblemDetail.tsx\`: \`useParams<{ jobId }>\` で受け、\`view.problems.find(p => p.jobId === jobId)\` で抽出。Header は \`problem?.problemId ?? jobId\` で表示

副次効果: 同 problemId の deploy が複数あっても URL が完全一意なので確実に正しい行に navigate する。

## Test plan

- [x] \`make before-commit\` 緑 (425 件全 pass)
- [ ] AWS で実 deploy → sidebar から SSO Credentials が消える
- [ ] Quest クリックで jobId-based URL で詳細遷移
- [ ] 旧 \`/problems/<slug>\` URL を bookmark していた場合は \`/problems\` に redirect

## Regression 分析

- 旧 \`/problems/:problemId\` URL を bookmark していた競技者は \`useParams.jobId\` が undefined → Quests に redirect (= ProblemDetail.tsx の \`if (!jobId) return <Navigate to="/problems" />\` でカバー)
- SSO Credentials の bookmark / 直接アクセスはまだ機能 (placeholder)
- Lambda / DDB / API は不変

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | participant-portal SPA | sidebar 1 行削除 + 3 ファイルの URL key 変更 |
| NO-OP  | Lambda / IAM / DDB / CDK / API | 不変 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)