### PR TITLE
feat(portal): SSO を federation 化 — AWS Console ワンクリックログイン

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -10,6 +10,7 @@ import { ProblemDetailPage } from "./pages/ProblemDetail";
 import { QuestsPage } from "./pages/Quests";
 import { ScoreboardPage } from "./pages/Scoreboard";
 import { ScoreEventsPage } from "./pages/ScoreEvents";
+import { SsoCredentialsPage } from "./pages/SsoCredentials";
 import { TeamSetupPage } from "./pages/TeamSetup";
 
 function RequireAuth({
@@ -74,14 +75,7 @@ export function App({ config }: { config: AppConfig }) {
         />
         <Route
           path="/tools/sso"
-          element={guarded(
-            config,
-            <PlaceholderPage
-              title="SSO Credentials"
-              description="AWS Console へのサインイン情報"
-              comingSoon="チーム単位の Identity Center 認証情報をここに表示します。発行は deploy backend 側。"
-            />,
-          )}
+          element={guarded(config, <SsoCredentialsPage config={config} />)}
         />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -224,6 +224,37 @@ export async function getLeaderboard(
 }
 
 /**
+ * SSO Credentials: AWS Console ワンクリック login URL を発行する API。
+ * 競技者が click すると Lambda が STS AssumeRole + federation で SigninToken を
+ * 発行し、URL を返す。frontend は window.open でその URL を開く (= 自前 AWS ログイン不要)。
+ */
+export async function getConsoleSigninUrl(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const url = buildPortalUrl(apiBaseUrl, "portal/me/console-signin-url");
+  url.searchParams.set("jobId", jobId);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { authorization: `Bearer ${teamLoginKey}` },
+    signal,
+  });
+  if (res.status === 401) throw new PortalAuthError();
+  if (res.status === 400) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new PortalValidationError(body.error ?? "invalid_request");
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+  const data = (await res.json()) as { loginUrl: string };
+  return data.loginUrl;
+}
+
+/**
  * Phase 2c: Flag 提出は `problemId` 必須に。`POST /portal/me/submit-flag { problemId, flag }`。
  */
 export async function submitFlag(

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -27,6 +27,8 @@ export interface ParticipantProblemView {
   readonly jobId: string;
   readonly problemId: string;
   readonly region: string;
+  /** 競技アカウント ID。SSO Credentials の AWS Console switch role URL で使う。 */
+  readonly awsAccountId: string;
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
   readonly failureReason?: string;

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -27,7 +27,7 @@ export interface ParticipantProblemView {
   readonly jobId: string;
   readonly problemId: string;
   readonly region: string;
-  /** 競技アカウント ID。SSO Credentials の AWS Console switch role URL で使う。 */
+  /** 競技アカウント ID。SSO Credentials の AWS Console federation で使う。 */
   readonly awsAccountId: string;
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
@@ -89,6 +89,54 @@ function buildPortalUrl(apiBaseUrl: string, path: string): URL {
   return new URL(path, base);
 }
 
+interface PortalFetchOptions {
+  readonly method?: "GET" | "POST" | "PATCH";
+  readonly query?: Readonly<Record<string, string>>;
+  readonly body?: unknown;
+  readonly signal?: AbortSignal;
+  /** 400 を `PortalValidationError(error)` に変換する (応答 body の `error` フィールドを採用)。 */
+  readonly throwOn400?: boolean;
+  /** 404 を `undefined` として返す (= "存在しない" を許容するエンドポイント)。 */
+  readonly returnUndefinedOn404?: boolean;
+}
+
+/**
+ * Portal API 共通 fetch。401→PortalAuthError / !ok→PortalNetworkError は全 endpoint
+ * 共通なので 1 箇所に集約。400 (validation) と 404 (no-content) は opt-in。
+ */
+async function portalFetch<T>(
+  apiBaseUrl: string,
+  path: string,
+  teamLoginKey: string,
+  options: PortalFetchOptions = {},
+): Promise<T | undefined> {
+  const url = buildPortalUrl(apiBaseUrl, path);
+  if (options.query) {
+    for (const [k, v] of Object.entries(options.query)) url.searchParams.set(k, v);
+  }
+  const headers: Record<string, string> = { authorization: `Bearer ${teamLoginKey}` };
+  const hasBody = options.body !== undefined;
+  if (hasBody) headers["content-type"] = "application/json";
+
+  const res = await fetch(url, {
+    method: options.method ?? "GET",
+    headers,
+    body: hasBody ? JSON.stringify(options.body) : undefined,
+    signal: options.signal,
+  });
+  if (res.status === 401) throw new PortalAuthError();
+  if (res.status === 404 && options.returnUndefinedOn404) return undefined;
+  if (res.status === 400 && options.throwOn400) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new PortalValidationError(body.error ?? "invalid_request");
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+  return (await res.json()) as T;
+}
+
 /**
  * `GET /portal/me` を `Authorization: Bearer <teamLoginKey>` で呼び、
  * `ParticipantTeamView` (= team + problems[]) を返す。
@@ -98,17 +146,9 @@ export async function getPortalMe(
   teamLoginKey: string,
   signal?: AbortSignal,
 ): Promise<ParticipantTeamView> {
-  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me"), {
-    method: "GET",
-    headers: { authorization: `Bearer ${teamLoginKey}` },
+  return (await portalFetch<ParticipantTeamView>(apiBaseUrl, "portal/me", teamLoginKey, {
     signal,
-  });
-  if (res.status === 401) throw new PortalAuthError();
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  return (await res.json()) as ParticipantTeamView;
+  })) as ParticipantTeamView;
 }
 
 /**
@@ -121,25 +161,12 @@ export async function updateTeamName(
   teamName: string,
   signal?: AbortSignal,
 ): Promise<ParticipantTeamView> {
-  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me"), {
+  return (await portalFetch<ParticipantTeamView>(apiBaseUrl, "portal/me", teamLoginKey, {
     method: "PATCH",
-    headers: {
-      authorization: `Bearer ${teamLoginKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ teamName }),
+    body: { teamName },
+    throwOn400: true,
     signal,
-  });
-  if (res.status === 400) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new PortalValidationError(body.error ?? "invalid_team_name");
-  }
-  if (res.status === 401) throw new PortalAuthError();
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  return (await res.json()) as ParticipantTeamView;
+  })) as ParticipantTeamView;
 }
 
 /**
@@ -167,17 +194,12 @@ export async function getScoreEvents(
   teamLoginKey: string,
   signal?: AbortSignal,
 ): Promise<ScoreEventsResponse> {
-  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me/score-events"), {
-    method: "GET",
-    headers: { authorization: `Bearer ${teamLoginKey}` },
-    signal,
-  });
-  if (res.status === 401) throw new PortalAuthError();
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  return (await res.json()) as ScoreEventsResponse;
+  return (await portalFetch<ScoreEventsResponse>(
+    apiBaseUrl,
+    "portal/me/score-events",
+    teamLoginKey,
+    { signal },
+  )) as ScoreEventsResponse;
 }
 
 /**
@@ -209,18 +231,10 @@ export async function getLeaderboard(
   teamLoginKey: string,
   signal?: AbortSignal,
 ): Promise<LeaderboardResponse | undefined> {
-  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/leaderboard"), {
-    method: "GET",
-    headers: { authorization: `Bearer ${teamLoginKey}` },
+  return await portalFetch<LeaderboardResponse>(apiBaseUrl, "portal/leaderboard", teamLoginKey, {
+    returnUndefinedOn404: true,
     signal,
   });
-  if (res.status === 401) throw new PortalAuthError();
-  if (res.status === 404) return undefined;
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  return (await res.json()) as LeaderboardResponse;
 }
 
 /**
@@ -234,23 +248,12 @@ export async function getConsoleSigninUrl(
   jobId: string,
   signal?: AbortSignal,
 ): Promise<string> {
-  const url = buildPortalUrl(apiBaseUrl, "portal/me/console-signin-url");
-  url.searchParams.set("jobId", jobId);
-  const res = await fetch(url, {
-    method: "GET",
-    headers: { authorization: `Bearer ${teamLoginKey}` },
-    signal,
-  });
-  if (res.status === 401) throw new PortalAuthError();
-  if (res.status === 400) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new PortalValidationError(body.error ?? "invalid_request");
-  }
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  const data = (await res.json()) as { loginUrl: string };
+  const data = (await portalFetch<{ loginUrl: string }>(
+    apiBaseUrl,
+    "portal/me/console-signin-url",
+    teamLoginKey,
+    { query: { jobId }, throwOn400: true, signal },
+  )) as { loginUrl: string };
   return data.loginUrl;
 }
 
@@ -264,23 +267,10 @@ export async function submitFlag(
   flag: string,
   signal?: AbortSignal,
 ): Promise<SubmitFlagOutcome> {
-  const res = await fetch(buildPortalUrl(apiBaseUrl, "portal/me/submit-flag"), {
+  return (await portalFetch<SubmitFlagOutcome>(apiBaseUrl, "portal/me/submit-flag", teamLoginKey, {
     method: "POST",
-    headers: {
-      authorization: `Bearer ${teamLoginKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ problemId, flag }),
+    body: { problemId, flag },
+    throwOn400: true,
     signal,
-  });
-  if (res.status === 400) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new PortalValidationError(body.error ?? "invalid_flag");
-  }
-  if (res.status === 401) throw new PortalAuthError();
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
-  return (await res.json()) as SubmitFlagOutcome;
+  })) as SubmitFlagOutcome;
 }

--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -38,9 +38,11 @@ const SIDE_NAV_ITEMS: SideNavigationProps.Item[] = [
     text: "Quests",
     items: [{ type: "link", href: "/problems", text: "問題一覧" }],
   },
-  // Tools section (SSO Credentials) は Identity Center 連携の ADR が固まるまで
-  // 非表示 (Issue #500)。route 自体は placeholder で残置しているので bookmark 経由の
-  // 直接アクセスは可能だが、sidebar からは導線を切る。
+  {
+    type: "section",
+    text: "Tools",
+    items: [{ type: "link", href: "/tools/sso", text: "SSO Credentials" }],
+  },
 ];
 
 export function ShellLayout({ config, children }: { config: AppConfig; children: ReactNode }) {

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -1,0 +1,144 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useTeamView } from "../auth/TeamViewProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * 競技アカウントの IAM Role 名 (= operator が `templates/competitor-bootstrap.yaml`
+ * 経由で立てる role の固定名)。switch role URL の `roleName` パラメータに使う。
+ *
+ * 異なる名前で role を作っている operator は CDK env / runtime-config で上書き可能に
+ * する余地があるが、現状はテンプレートの default 値で固定。
+ */
+const COMPETITOR_ROLE_NAME = "TenkaCloudCompetitorBootstrap";
+
+/**
+ * 自分の AWS アカウントから competitor role に switch role するための AWS Console URL を組み立てる。
+ *
+ *   https://signin.aws.amazon.com/switchrole?
+ *     account=<accountId>&roleName=<roleName>&displayName=<label>&region=<region>
+ *
+ * 競技者が **既に AWS Console にログイン済** であれば、URL を開くだけで confirm
+ * ダイアログ → role 切替が完了する。ログインしていないと AWS のログインを要求される。
+ *
+ * フル federation (= operator アカウントから token を発行して 1-click ログイン)
+ * は cross-account AssumeRole + ExternalId 管理が必要で MVP-1 にはまだ無い (Issue #500)。
+ * 当面はこの switch role URL で代替し、競技者は自身の AWS アカウントからアクセスする。
+ */
+function buildSwitchRoleUrl(params: {
+  accountId: string;
+  region: string;
+  problemId: string;
+  jobId: string;
+}): string {
+  const display = `TC-${params.problemId}-${params.jobId.slice(0, 8)}`;
+  const qs = new URLSearchParams({
+    account: params.accountId,
+    roleName: COMPETITOR_ROLE_NAME,
+    displayName: display,
+    region: params.region,
+  });
+  return `https://signin.aws.amazon.com/switchrole?${qs.toString()}`;
+}
+
+export function SsoCredentialsPage({ config }: { config: AppConfig }) {
+  const { view, error } = useTeamView();
+  const isBackend = config.mode === "backend";
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="自チームに deploy された問題の競技アカウントへ AWS Console から直接アクセスする手段。"
+      >
+        SSO Credentials
+      </Header>
+
+      {!isBackend && (
+        <Alert type="info">
+          dev-mock モードで動作中です。実 backend と接続するには runtime-config の <code>mode</code>{" "}
+          を <code>backend</code> に設定してください。
+        </Alert>
+      )}
+      {error && (
+        <Alert type="error" header="状態の取得に失敗しました">
+          {error}
+        </Alert>
+      )}
+
+      <Alert type="info" header="使い方">
+        <Box variant="p">
+          下のボタンは AWS Console の <strong>Switch Role</strong> 画面に飛びます。 先に各自の AWS
+          アカウントで{" "}
+          <a href="https://signin.aws.amazon.com/" target="_blank" rel="noreferrer noopener">
+            AWS Console
+          </a>{" "}
+          にログインしておいてください (普段使っている個人アカウント /
+          会社アカウント等で構いません)。 ログイン後にボタンを押すと、競技用の IAM Role
+          に切り替わって対象の問題環境に access できます。
+        </Box>
+        <Box variant="small" color="text-status-info" padding={{ top: "s" }}>
+          ※ ワンクリック federation (= 自前 AWS ログイン不要) は cross-account AssumeRole +
+          ExternalId 管理が要るため、後続 PR で実装予定 (Issue #500)。
+        </Box>
+      </Alert>
+
+      {isBackend && !view && !error && <Box>状態を取得中…</Box>}
+
+      {view && view.problems.length === 0 && (
+        <Container>
+          <Box textAlign="center" padding="l">
+            <Box variant="strong">問題がありません</Box>
+          </Box>
+        </Container>
+      )}
+
+      {view?.problems
+        .filter((p) => p.awsAccountId)
+        .map((problem) => {
+          const url = buildSwitchRoleUrl({
+            accountId: problem.awsAccountId,
+            region: problem.region,
+            problemId: problem.problemId,
+            jobId: problem.jobId,
+          });
+          return (
+            <Container
+              key={problem.jobId}
+              header={
+                <Header
+                  variant="h2"
+                  actions={
+                    <Button
+                      variant="primary"
+                      iconName="external"
+                      ariaLabel={`${problem.problemId} の AWS Console を開く`}
+                      onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+                    >
+                      AWS Console を開く
+                    </Button>
+                  }
+                >
+                  <code>{problem.problemId}</code>
+                </Header>
+              }
+            >
+              <KeyValuePairs
+                columns={3}
+                items={[
+                  { label: "AWS Account", value: <code>{problem.awsAccountId}</code> },
+                  { label: "Region", value: problem.region },
+                  { label: "Switch Role 先", value: <code>{COMPETITOR_ROLE_NAME}</code> },
+                ]}
+              />
+            </Container>
+          );
+        })}
+    </SpaceBetween>
+  );
+}

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -5,56 +5,56 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+import { getConsoleSigninUrl, PortalAuthError, PortalValidationError } from "../api/portal-client";
+import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
 
 /**
- * 競技アカウントの IAM Role 名 (= operator が `templates/competitor-bootstrap.yaml`
- * 経由で立てる role の固定名)。switch role URL の `roleName` パラメータに使う。
+ * AWS Console ワンクリック login。競技者は自前 AWS ログイン不要で、Portal の button
+ * を押すと backend Lambda が STS AssumeRole + signin federation を実行して
+ * `signin.aws.amazon.com/federation?Action=login` URL を発行 → 新タブで開く。
  *
- * 異なる名前で role を作っている operator は CDK env / runtime-config で上書き可能に
- * する余地があるが、現状はテンプレートの default 値で固定。
+ * Lambda が assume するのは `ConsoleViewerRole` (= ReadOnlyAccess managed policy)。
+ * 競技者は AWS Console で stack 状態を read-only で確認可能。
  */
-const COMPETITOR_ROLE_NAME = "TenkaCloudCompetitorBootstrap";
-
-/**
- * 自分の AWS アカウントから competitor role に switch role するための AWS Console URL を組み立てる。
- *
- *   https://signin.aws.amazon.com/switchrole?
- *     account=<accountId>&roleName=<roleName>&displayName=<label>&region=<region>
- *
- * 競技者が **既に AWS Console にログイン済** であれば、URL を開くだけで confirm
- * ダイアログ → role 切替が完了する。ログインしていないと AWS のログインを要求される。
- *
- * フル federation (= operator アカウントから token を発行して 1-click ログイン)
- * は cross-account AssumeRole + ExternalId 管理が必要で MVP-1 にはまだ無い (Issue #500)。
- * 当面はこの switch role URL で代替し、競技者は自身の AWS アカウントからアクセスする。
- */
-function buildSwitchRoleUrl(params: {
-  accountId: string;
-  region: string;
-  problemId: string;
-  jobId: string;
-}): string {
-  const display = `TC-${params.problemId}-${params.jobId.slice(0, 8)}`;
-  const qs = new URLSearchParams({
-    account: params.accountId,
-    roleName: COMPETITOR_ROLE_NAME,
-    displayName: display,
-    region: params.region,
-  });
-  return `https://signin.aws.amazon.com/switchrole?${qs.toString()}`;
-}
-
 export function SsoCredentialsPage({ config }: { config: AppConfig }) {
+  const auth = useAuth();
+  const sessionToken = auth.session?.sessionToken ?? null;
   const { view, error } = useTeamView();
   const isBackend = config.mode === "backend";
+
+  const [pending, setPending] = useState<string | null>(null); // jobId
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  const openConsole = async (jobId: string) => {
+    if (!sessionToken || pending) return;
+    setPending(jobId);
+    setOpenError(null);
+    try {
+      const loginUrl = await getConsoleSigninUrl(config.apiBaseUrl, sessionToken, jobId);
+      window.open(loginUrl, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      if (err instanceof PortalAuthError) {
+        auth.logout();
+        return;
+      }
+      if (err instanceof PortalValidationError) {
+        setOpenError(`バリデーションエラー: ${err.errorCode}`);
+        return;
+      }
+      setOpenError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(null);
+    }
+  };
 
   return (
     <SpaceBetween size="l">
       <Header
         variant="h1"
-        description="自チームに deploy された問題の競技アカウントへ AWS Console から直接アクセスする手段。"
+        description="AWS Console にワンクリックで federate ログイン。自前の AWS アカウント不要。"
       >
         SSO Credentials
       </Header>
@@ -70,21 +70,21 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
           {error}
         </Alert>
       )}
+      {openError && (
+        <Alert
+          type="error"
+          header="AWS Console を開けませんでした"
+          dismissible
+          onDismiss={() => setOpenError(null)}
+        >
+          {openError}
+        </Alert>
+      )}
 
       <Alert type="info" header="使い方">
         <Box variant="p">
-          下のボタンは AWS Console の <strong>Switch Role</strong> 画面に飛びます。 先に各自の AWS
-          アカウントで{" "}
-          <a href="https://signin.aws.amazon.com/" target="_blank" rel="noreferrer noopener">
-            AWS Console
-          </a>{" "}
-          にログインしておいてください (普段使っている個人アカウント /
-          会社アカウント等で構いません)。 ログイン後にボタンを押すと、競技用の IAM Role
-          に切り替わって対象の問題環境に access できます。
-        </Box>
-        <Box variant="small" color="text-status-info" padding={{ top: "s" }}>
-          ※ ワンクリック federation (= 自前 AWS ログイン不要) は cross-account AssumeRole +
-          ExternalId 管理が要るため、後続 PR で実装予定 (Issue #500)。
+          下のボタンを押すと新しいタブで AWS Console (CloudFormation スタック画面)
+          が自動でログイン状態で開きます。session の TTL は 1 時間です。
         </Box>
       </Alert>
 
@@ -100,45 +100,39 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
 
       {view?.problems
         .filter((p) => p.awsAccountId)
-        .map((problem) => {
-          const url = buildSwitchRoleUrl({
-            accountId: problem.awsAccountId,
-            region: problem.region,
-            problemId: problem.problemId,
-            jobId: problem.jobId,
-          });
-          return (
-            <Container
-              key={problem.jobId}
-              header={
-                <Header
-                  variant="h2"
-                  actions={
-                    <Button
-                      variant="primary"
-                      iconName="external"
-                      ariaLabel={`${problem.problemId} の AWS Console を開く`}
-                      onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
-                    >
-                      AWS Console を開く
-                    </Button>
-                  }
-                >
-                  <code>{problem.problemId}</code>
-                </Header>
-              }
-            >
-              <KeyValuePairs
-                columns={3}
-                items={[
-                  { label: "AWS Account", value: <code>{problem.awsAccountId}</code> },
-                  { label: "Region", value: problem.region },
-                  { label: "Switch Role 先", value: <code>{COMPETITOR_ROLE_NAME}</code> },
-                ]}
-              />
-            </Container>
-          );
-        })}
+        .map((problem) => (
+          <Container
+            key={problem.jobId}
+            header={
+              <Header
+                variant="h2"
+                actions={
+                  <Button
+                    variant="primary"
+                    iconName="external"
+                    loading={pending === problem.jobId}
+                    disabled={pending !== null && pending !== problem.jobId}
+                    ariaLabel={`${problem.problemId} の AWS Console を開く`}
+                    onClick={() => void openConsole(problem.jobId)}
+                  >
+                    AWS Console を開く
+                  </Button>
+                }
+              >
+                <code>{problem.problemId}</code>
+              </Header>
+            }
+          >
+            <KeyValuePairs
+              columns={3}
+              items={[
+                { label: "AWS Account", value: <code>{problem.awsAccountId}</code> },
+                { label: "Region", value: problem.region },
+                { label: "Status", value: problem.status },
+              ]}
+            />
+          </Container>
+        ))}
     </SpaceBetween>
   );
 }

--- a/infrastructure/lib/problem-deploy/console-viewer-role.ts
+++ b/infrastructure/lib/problem-deploy/console-viewer-role.ts
@@ -1,5 +1,5 @@
-import { Aws, Duration } from "aws-cdk-lib";
-import { ManagedPolicy, type PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Duration } from "aws-cdk-lib";
+import { AccountRootPrincipal, ManagedPolicy, Role } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
 /**
@@ -9,15 +9,8 @@ import { Construct } from "constructs";
  * 取得し、`signin.aws.amazon.com/federation` 経由で SigninToken を発行 → 競技者は
  * 自前の AWS ログイン無しで AWS Console に federate される。
  *
- * 権限スコープ:
- *   - `ReadOnlyAccess` managed policy (= AWS 全 service の read-only)
- *   - 多テナント環境で「他 tenant の deployment が見える」リスクは残るが、操作系
- *     (Create / Modify / Delete) は不可。Phase 4+ で session policy で stack 単位に
- *     scope する余地。
- *
- * Trust:
- *   - 同 account の Lambda role のみ assume 可能 (cross-account は別 Role でカバー)
- *   - MaxSession 1 hour = federation token の TTL と一致
+ * 権限スコープ: `ReadOnlyAccess`。Trust は同 account root (= Lambda 側の policy で
+ * 二重ゲート、cross-account は別 Role でカバー)。MaxSession 1h = federation TTL と一致。
  */
 export class ConsoleViewerRole extends Construct {
   public readonly role: Role;
@@ -25,30 +18,10 @@ export class ConsoleViewerRole extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.role = new Role(this, "Role", {
-      // 同 account の Lambda が assume できるように root を信頼。Lambda 側の
-      // role policy に sts:AssumeRole を別途付ける (= 二重ゲート)。
-      assumedBy: new ServicePrincipal("lambda.amazonaws.com").withConditions({}),
+      assumedBy: new AccountRootPrincipal(),
       maxSessionDuration: Duration.hours(1),
       managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
       description: "Federation target for participant AWS Console one-click login.",
     });
-    // assumedBy: 同 account の root を信頼するので Principal を root ARN に書き直す
-    // (ServicePrincipal だと service action principal、AssumeRole API には不適)
-    const cfn = this.role.node.defaultChild as import("aws-cdk-lib/aws-iam").CfnRole;
-    cfn.assumeRolePolicyDocument = {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${Aws.ACCOUNT_ID}:root` },
-          Action: "sts:AssumeRole",
-        },
-      ],
-    };
-  }
-
-  /** 任意の追加 policy を attach するためのインターフェース。 */
-  addPolicy(statement: PolicyStatement): void {
-    this.role.addToPolicy(statement);
   }
 }

--- a/infrastructure/lib/problem-deploy/console-viewer-role.ts
+++ b/infrastructure/lib/problem-deploy/console-viewer-role.ts
@@ -1,0 +1,54 @@
+import { Aws, Duration } from "aws-cdk-lib";
+import { ManagedPolicy, type PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+
+/**
+ * 競技者が AWS Console にワンクリック login するためのフェデレーション先 IAM Role。
+ *
+ * Participant Portal Lambda が `sts:AssumeRole` してこの Role の temp 認証情報を
+ * 取得し、`signin.aws.amazon.com/federation` 経由で SigninToken を発行 → 競技者は
+ * 自前の AWS ログイン無しで AWS Console に federate される。
+ *
+ * 権限スコープ:
+ *   - `ReadOnlyAccess` managed policy (= AWS 全 service の read-only)
+ *   - 多テナント環境で「他 tenant の deployment が見える」リスクは残るが、操作系
+ *     (Create / Modify / Delete) は不可。Phase 4+ で session policy で stack 単位に
+ *     scope する余地。
+ *
+ * Trust:
+ *   - 同 account の Lambda role のみ assume 可能 (cross-account は別 Role でカバー)
+ *   - MaxSession 1 hour = federation token の TTL と一致
+ */
+export class ConsoleViewerRole extends Construct {
+  public readonly role: Role;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.role = new Role(this, "Role", {
+      // 同 account の Lambda が assume できるように root を信頼。Lambda 側の
+      // role policy に sts:AssumeRole を別途付ける (= 二重ゲート)。
+      assumedBy: new ServicePrincipal("lambda.amazonaws.com").withConditions({}),
+      maxSessionDuration: Duration.hours(1),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
+      description: "Federation target for participant AWS Console one-click login.",
+    });
+    // assumedBy: 同 account の root を信頼するので Principal を root ARN に書き直す
+    // (ServicePrincipal だと service action principal、AssumeRole API には不適)
+    const cfn = this.role.node.defaultChild as import("aws-cdk-lib/aws-iam").CfnRole;
+    cfn.assumeRolePolicyDocument = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${Aws.ACCOUNT_ID}:root` },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    };
+  }
+
+  /** 任意の追加 policy を attach するためのインターフェース。 */
+  addPolicy(statement: PolicyStatement): void {
+    this.role.addToPolicy(statement);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -2,16 +2,10 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { PROBLEM_ID_RE } from "../shared/constants.js";
-import {
-  HTTP_BAD_REQUEST,
-  HTTP_INTERNAL_ERROR,
-  HTTP_NOT_FOUND,
-  HTTP_OK,
-  HTTP_UNAUTHORIZED,
-} from "../shared/http-status.js";
-import { extractBearerToken } from "./auth.js";
+import { HTTP_OK } from "../shared/http-status.js";
 import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
+import { respondError, withBearerAuth } from "./route-helpers.js";
 import { listScoreEvents } from "./score-events.js";
 import { buildParticipantSharedResources } from "./shared.js";
 import { getConsoleSigninUrl } from "./sso.js";
@@ -21,156 +15,87 @@ import { setDisplayTeamName } from "./update.js";
 /**
  * Participant Portal backend Lambda の Hono app (Phase 2c で team scope)。routes:
  *   GET   /portal/healthz
- *   GET   /portal/leaderboard       — event scope の team ランキング
- *   GET   /portal/me/score-events   — 自チームの加点履歴 (時系列降順)
- *   GET   /portal/me                — Authorization: Bearer <teamLoginKey>
- *                                     → { team, problems[] }
- *   PATCH /portal/me                — body: { teamName: string } (team の全行を update)
- *   POST  /portal/me/submit-flag    — body: { problemId: string, flag: string }
+ *   GET   /portal/leaderboard           — event scope の team ランキング
+ *   GET   /portal/me/score-events       — 自チームの加点履歴 (時系列降順)
+ *   GET   /portal/me                    — Authorization: Bearer <teamLoginKey>
+ *                                         → { team, problems[] }
+ *   GET   /portal/me/console-signin-url — AWS Console federation login URL 発行
+ *   PATCH /portal/me                    — body: { teamName: string }
+ *   POST  /portal/me/submit-flag        — body: { problemId: string, flag: string }
  *
  * Function URL は `AuthType=NONE` で公開し、`teamLoginKey` 自体を bearer として
- * Lambda 内で検証する。
+ * Lambda 内で検証する。ボイラープレート (token 抽出 / 500 ハンドリング / outcome→HTTP)
+ * は `route-helpers.ts` に集約。
  */
 const shared = buildParticipantSharedResources();
 const app = new Hono();
 
 app.get("/portal/healthz", (c) => c.json({ ok: true }));
 
-app.get("/portal/me", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  try {
+app.get("/portal/me", (c) =>
+  withBearerAuth(c, "lookup", async (token) => {
     const view = await lookupTeamByLoginKey(shared, token);
-    if (!view) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+    if (!view) return respondError(c, "unauthorized");
     return c.json(view, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] lookup failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+  }),
+);
 
-app.get("/portal/me/score-events", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  try {
+app.get("/portal/me/score-events", (c) =>
+  withBearerAuth(c, "score-events", async (token) => {
     const outcome = await listScoreEvents(shared, token);
-    if (outcome.kind === "unauthorized") {
-      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-    }
+    if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
     return c.json(outcome.response, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] score-events failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+  }),
+);
 
-app.get("/portal/me/console-signin-url", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  const jobId = c.req.query("jobId");
-  if (!jobId) return c.json({ error: "missing_jobid" }, HTTP_BAD_REQUEST);
-  try {
+app.get("/portal/me/console-signin-url", (c) =>
+  withBearerAuth(c, "sso", async (token) => {
+    const jobId = c.req.query("jobId");
+    if (!jobId) return respondError(c, "missing_jobid");
     const outcome = await getConsoleSigninUrl(shared, token, jobId);
-    if (outcome.kind === "unauthorized") {
-      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-    }
-    if (outcome.kind === "invalid_jobid") {
-      return c.json({ error: "invalid_jobid" }, HTTP_BAD_REQUEST);
-    }
-    if (outcome.kind === "not_ready") {
-      return c.json({ error: "not_ready" }, HTTP_BAD_REQUEST);
-    }
-    if (outcome.kind === "misconfigured") {
-      return c.json({ error: "misconfigured" }, HTTP_INTERNAL_ERROR);
-    }
-    return c.json({ loginUrl: outcome.loginUrl }, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] sso failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+    if (outcome.kind === "ok") return c.json({ loginUrl: outcome.loginUrl }, HTTP_OK);
+    return respondError(c, outcome.kind);
+  }),
+);
 
-app.get("/portal/leaderboard", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  try {
+app.get("/portal/leaderboard", (c) =>
+  withBearerAuth(c, "leaderboard", async (token) => {
     const outcome = await getLeaderboard(shared, token);
-    if (outcome.kind === "unauthorized") {
-      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-    }
-    if (outcome.kind === "no_event") {
-      // Phase 1 以前 / 旧 jobId-based deployment は event scope の leaderboard 不可
-      return c.json({ error: "no_event" }, HTTP_NOT_FOUND);
-    }
-    return c.json(outcome.response, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] leaderboard failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+    if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
+    return respondError(c, outcome.kind);
+  }),
+);
 
-app.patch("/portal/me", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-  const teamName = (body as { teamName?: unknown })?.teamName;
-  try {
+app.patch("/portal/me", (c) =>
+  withBearerAuth(c, "update", async (token) => {
+    const body = await c.req.json().catch(() => null);
+    if (body === null) return respondError(c, "invalid_body");
+    const teamName = (body as { teamName?: unknown }).teamName;
     const outcome = await setDisplayTeamName(shared, token, teamName);
-    if (outcome.kind === "invalid_team_name") {
-      return c.json({ error: "invalid_team_name" }, HTTP_BAD_REQUEST);
-    }
-    if (outcome.kind === "unauthorized") {
-      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-    }
-    return c.json(outcome.view, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] update failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+    if (outcome.kind === "ok") return c.json(outcome.view, HTTP_OK);
+    return respondError(c, outcome.kind);
+  }),
+);
 
-app.post("/portal/me/submit-flag", async (c) => {
-  const token = extractBearerToken(c.req.header("authorization"));
-  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-  const problemId = (body as { problemId?: unknown })?.problemId;
-  const flag = (body as { flag?: unknown })?.flag;
-  if (typeof problemId !== "string" || !PROBLEM_ID_RE.test(problemId)) {
-    return c.json({ error: "invalid_problem_id" }, HTTP_BAD_REQUEST);
-  }
-  if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
-    return c.json({ error: "invalid_flag" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await submitFlag(shared, shared.problemsScoring, token, problemId, flag);
-    if (outcome.kind === "unauthorized")
-      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
-    if (outcome.kind === "not_flag_problem") {
-      return c.json({ error: "not_flag_problem" }, HTTP_BAD_REQUEST);
+app.post("/portal/me/submit-flag", (c) =>
+  withBearerAuth(c, "submitFlag", async (token) => {
+    const body = await c.req.json().catch(() => null);
+    if (body === null) return respondError(c, "invalid_body");
+    const problemId = (body as { problemId?: unknown }).problemId;
+    const flag = (body as { flag?: unknown }).flag;
+    if (typeof problemId !== "string" || !PROBLEM_ID_RE.test(problemId)) {
+      return respondError(c, "invalid_problem_id");
     }
-    if (outcome.kind === "no_outputs") return c.json({ error: "no_outputs" }, HTTP_BAD_REQUEST);
+    if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
+      return respondError(c, "invalid_flag");
+    }
+    const outcome = await submitFlag(shared, shared.problemsScoring, token, problemId, flag);
+    if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
+    if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
+    if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
     return c.json(outcome, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[portal] submitFlag failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+  }),
+);
 
 export const handler = handle(app) as (
   event: LambdaEvent,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -14,6 +14,7 @@ import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
 import { listScoreEvents } from "./score-events.js";
 import { buildParticipantSharedResources } from "./shared.js";
+import { getConsoleSigninUrl } from "./sso.js";
 import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
 
@@ -61,6 +62,33 @@ app.get("/portal/me/score-events", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[portal] score-events failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.get("/portal/me/console-signin-url", async (c) => {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+  const jobId = c.req.query("jobId");
+  if (!jobId) return c.json({ error: "missing_jobid" }, HTTP_BAD_REQUEST);
+  try {
+    const outcome = await getConsoleSigninUrl(shared, token, jobId);
+    if (outcome.kind === "unauthorized") {
+      return c.json({ error: "unauthorized" }, HTTP_UNAUTHORIZED);
+    }
+    if (outcome.kind === "invalid_jobid") {
+      return c.json({ error: "invalid_jobid" }, HTTP_BAD_REQUEST);
+    }
+    if (outcome.kind === "not_ready") {
+      return c.json({ error: "not_ready" }, HTTP_BAD_REQUEST);
+    }
+    if (outcome.kind === "misconfigured") {
+      return c.json({ error: "misconfigured" }, HTTP_INTERNAL_ERROR);
+    }
+    return c.json({ loginUrl: outcome.loginUrl }, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[portal] sso failed", { message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -26,7 +26,7 @@ export interface ParticipantScoringInfo {
  */
 export type ParticipantProblemView = Pick<
   DeploymentItem,
-  "jobId" | "problemId" | "region" | "expiresAt"
+  "jobId" | "problemId" | "region" | "expiresAt" | "awsAccountId"
 > & {
   readonly status: DeploymentStatus;
   readonly stackOutputs: Record<string, string>;
@@ -38,6 +38,8 @@ export type ParticipantProblemView = Pick<
   // 設計判断: `endpointsHealth` (= どの endpoint が落ちているか) は participant API には
   // 出さない。Battle のゲーム性は「壊れている原因を防御側自身が調査して復旧する」点に
   // あり、画面で答え合わせをすると興ざめになる。
+  // `awsAccountId` は AWS Console 直接アクセス (SSO Credentials) のため公開する。
+  // AWS の account id は機密ではない (= IAM role 信頼ポリシーや CFn template にも露出する)。
 };
 
 export interface ParticipantTeamView {
@@ -78,6 +80,7 @@ export function toProblemView(
     jobId: String(item.jobId ?? ""),
     problemId: String(item.problemId ?? ""),
     region: String(item.region ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
     status,
     stackOutputs,
     failureReason: status === "FAILED" ? item.failureReason : undefined,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -1,0 +1,55 @@
+import type { Context } from "hono";
+import {
+  HTTP_BAD_REQUEST,
+  HTTP_INTERNAL_ERROR,
+  HTTP_NOT_FOUND,
+  HTTP_UNAUTHORIZED,
+} from "../shared/http-status.js";
+import { extractBearerToken } from "./auth.js";
+
+/**
+ * 業務ロジックが返す失敗 outcome の kind 一覧と HTTP status の対応表。
+ * route handler が個別に if-cascade で書いていた mapping を 1 箇所に集約する
+ * (新 outcome 追加時の触る場所を減らす)。
+ */
+const ERROR_STATUS = {
+  unauthorized: HTTP_UNAUTHORIZED,
+  invalid_jobid: HTTP_BAD_REQUEST,
+  invalid_team_name: HTTP_BAD_REQUEST,
+  invalid_problem_id: HTTP_BAD_REQUEST,
+  invalid_flag: HTTP_BAD_REQUEST,
+  invalid_body: HTTP_BAD_REQUEST,
+  missing_jobid: HTTP_BAD_REQUEST,
+  not_ready: HTTP_BAD_REQUEST,
+  not_flag_problem: HTTP_BAD_REQUEST,
+  no_outputs: HTTP_BAD_REQUEST,
+  no_event: HTTP_NOT_FOUND,
+  misconfigured: HTTP_INTERNAL_ERROR,
+  internal_error: HTTP_INTERNAL_ERROR,
+} as const;
+
+export type ErrorKind = keyof typeof ERROR_STATUS;
+
+export function respondError(c: Context, kind: ErrorKind) {
+  return c.json({ error: kind }, ERROR_STATUS[kind]);
+}
+
+/**
+ * Bearer token 必須 route の共通テンプレ。token 抽出 + try/catch + 500 ログ。
+ * handler 側は token を受け取って outcome / Response を返すだけ。
+ */
+export async function withBearerAuth(
+  c: Context,
+  routeName: string,
+  handler: (token: string) => Promise<Response>,
+): Promise<Response> {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) return respondError(c, "unauthorized");
+  try {
+    return await handler(token);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error(`[portal] ${routeName} failed`, { message });
+    return respondError(c, "internal_error");
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -14,6 +14,60 @@ const FEDERATION_ENDPOINT = "https://signin.aws.amazon.com/federation";
 const FEDERATION_SESSION_DURATION_SEC = 3600;
 const TENKACLOUD_ISSUER = "https://tenkacloud.example/portal";
 
+/**
+ * AssumeRole 時の inline session policy。`ConsoleViewerRole` の `ReadOnlyAccess` を
+ * 「stack の状態が見れる + 競技対象 service の Describe」だけに**さらに絞る**ための gate。
+ *
+ * 必要: 競技者は自分の deployment の CFn / EC2 / Logs だけ見えればよい。
+ * 危険: ReadOnlyAccess 単体だと operator account の DDB Deployments テーブル
+ * (= 全チームの teamLoginKey が入っている) を Scan されて bearer token が漏れる。
+ * → `dynamodb:*` / `secretsmanager:*` / `ssm:Get*` / `kms:Decrypt` / `iam:*` を Deny で殺す。
+ *
+ * セッションポリシーは Role の policy との **AND** で評価される (= Allow の和集合では
+ * なく交差) なので、ここで Allow したものは元 Role に無ければ通らない。
+ */
+const SESSION_POLICY = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: [
+        "cloudformation:DescribeStacks",
+        "cloudformation:GetTemplate",
+        "cloudformation:ListStackResources",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStackResources",
+        "ec2:Describe*",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "lambda:GetFunction",
+        "lambda:ListFunctions",
+        "apigateway:GET",
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+      ],
+      Resource: "*",
+    },
+    {
+      Effect: "Deny",
+      Action: [
+        "dynamodb:*",
+        "secretsmanager:*",
+        "ssm:Get*",
+        "ssm:Describe*",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "iam:*",
+        "sts:AssumeRole",
+      ],
+      Resource: "*",
+    },
+  ],
+});
+
 const sts = new STSClient({});
 
 /**
@@ -51,12 +105,14 @@ export async function getConsoleSigninUrl(
   const region = typeof deployment.region === "string" ? deployment.region : undefined;
   if (!region) return { kind: "not_ready" };
 
-  // STS AssumeRole. ExternalId は同 account 内なので省略 (cross-account は別 Role でカバー)。
+  // STS AssumeRole + inline session policy で `ReadOnlyAccess` をさらに絞る。
+  // ExternalId は同 account 内なので省略 (cross-account は別 Role でカバー)。
   const session = await sts.send(
     new AssumeRoleCommand({
       RoleArn: roleArn,
-      RoleSessionName: `participant-${jobId}`.slice(0, 64),
+      RoleSessionName: `participant-${jobId}`,
       DurationSeconds: FEDERATION_SESSION_DURATION_SEC,
+      Policy: SESSION_POLICY,
     }),
   );
   const creds = session.Credentials;

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -1,0 +1,89 @@
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import { DELETED_LIKE_STATUSES, ULID_RE } from "../shared/constants.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+
+export type SsoOutcome =
+  | { kind: "ok"; loginUrl: string }
+  | { kind: "unauthorized" }
+  | { kind: "not_ready" }
+  | { kind: "invalid_jobid" }
+  | { kind: "misconfigured" };
+
+const FEDERATION_ENDPOINT = "https://signin.aws.amazon.com/federation";
+const FEDERATION_SESSION_DURATION_SEC = 3600;
+const TENKACLOUD_ISSUER = "https://tenkacloud.example/portal";
+
+const sts = new STSClient({});
+
+/**
+ * AWS Console ワンクリック login URL を発行する。
+ *
+ * 流れ:
+ *   1. teamLoginKey で team の deployment を引き、jobId 一致行を抽出
+ *   2. STS AssumeRole で `ConsoleViewerRole` (ReadOnlyAccess) の temp credentials 取得
+ *   3. `signin.aws.amazon.com/federation?Action=getSigninToken` で SigninToken 交換
+ *   4. `Action=login` URL を組み立てて返す (= 競技者が click すると AWS Console 開く)
+ *
+ * 競技者は自前 AWS アカウント不要。1-hour TTL で自動 expire。
+ *
+ * 行不在 / DELETING / DELETED → unauthorized。stack 未起動 (namePrefix 無し) → not_ready。
+ * `CONSOLE_VIEWER_ROLE_ARN` env 未設定 → misconfigured (= CDK 未 deploy)。
+ */
+export async function getConsoleSigninUrl(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  jobId: string,
+): Promise<SsoOutcome> {
+  if (!ULID_RE.test(jobId)) return { kind: "invalid_jobid" };
+  const roleArn = process.env.CONSOLE_VIEWER_ROLE_ARN;
+  if (!roleArn) return { kind: "misconfigured" };
+
+  const items = await queryTeamItems(shared, teamLoginKey);
+  if (items.length === 0) return { kind: "unauthorized" };
+
+  const deployment = items.find((i) => i.jobId === jobId) as Partial<DeploymentItem> | undefined;
+  if (!deployment) return { kind: "unauthorized" };
+
+  const status = (deployment.status ?? "PENDING") as DeploymentStatus;
+  if (DELETED_LIKE_STATUSES.has(status)) return { kind: "unauthorized" };
+  if (typeof deployment.namePrefix !== "string") return { kind: "not_ready" };
+  const region = typeof deployment.region === "string" ? deployment.region : undefined;
+  if (!region) return { kind: "not_ready" };
+
+  // STS AssumeRole. ExternalId は同 account 内なので省略 (cross-account は別 Role でカバー)。
+  const session = await sts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: `participant-${jobId}`.slice(0, 64),
+      DurationSeconds: FEDERATION_SESSION_DURATION_SEC,
+    }),
+  );
+  const creds = session.Credentials;
+  if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+    return { kind: "misconfigured" };
+  }
+
+  // signin.aws.amazon.com/federation 仕様の Session JSON。
+  //   sessionId = AccessKeyId
+  //   sessionKey = SecretAccessKey
+  //   sessionToken = SessionToken
+  const sessionJson = JSON.stringify({
+    sessionId: creds.AccessKeyId,
+    sessionKey: creds.SecretAccessKey,
+    sessionToken: creds.SessionToken,
+  });
+
+  const tokenUrl = `${FEDERATION_ENDPOINT}?Action=getSigninToken&SessionDuration=${FEDERATION_SESSION_DURATION_SEC}&Session=${encodeURIComponent(sessionJson)}`;
+  const tokenRes = await fetch(tokenUrl, { method: "GET" });
+  if (!tokenRes.ok) return { kind: "misconfigured" };
+  const tokenJson = (await tokenRes.json()) as { SigninToken?: unknown };
+  if (typeof tokenJson.SigninToken !== "string") return { kind: "misconfigured" };
+
+  // CloudFormation スタック画面に直接遷移するための destination URL。
+  // 自分の deployment の namePrefix で stacks フィルタ済の view にする。
+  const destination = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(region)}#/stacks?filteringText=${encodeURIComponent(deployment.namePrefix)}`;
+  const loginUrl = `${FEDERATION_ENDPOINT}?Action=login&Issuer=${encodeURIComponent(TENKACLOUD_ISSUER)}&Destination=${encodeURIComponent(destination)}&SigninToken=${encodeURIComponent(tokenJson.SigninToken)}`;
+
+  return { kind: "ok", loginUrl };
+}

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -26,6 +26,11 @@ export interface ParticipantPortalLambdaProps {
    * 競技者が submit-flag したとき、この map を参照して採点する。
    */
   readonly problemsScoring: Readonly<Record<string, unknown>>;
+  /**
+   * `ConsoleViewerRole` の ARN。AWS Console federation login URL 発行のため
+   * Lambda が `sts:AssumeRole` する。caller side で IAM grant も付与する。
+   */
+  readonly consoleViewerRoleArn: string;
 }
 
 /**
@@ -81,6 +86,7 @@ export class ParticipantPortalLambda extends Construct {
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
+        CONSOLE_VIEWER_ROLE_ARN: props.consoleViewerRoleArn,
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -4,6 +4,7 @@ import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
+import { ConsoleViewerRole } from "./console-viewer-role";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine";
@@ -156,10 +157,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     }
 
     if (props.participantPortal) {
+      const consoleViewerRole = new ConsoleViewerRole(this, "ConsoleViewerRole");
       const portalLambda = new ParticipantPortalLambda(this, "ParticipantPortalLambda", {
         deploymentsTable: deployments.table,
         problemsScoring: props.problemsScoring,
+        consoleViewerRoleArn: consoleViewerRole.role.roleArn,
       });
+      // Lambda role に AssumeRole 権限を付与 (= federation flow の前提)。
+      consoleViewerRole.role.grantAssumeRole(portalLambda.fn.grantPrincipal);
       new CfnOutput(this, "ParticipantPortalApiUrl", {
         value: portalLambda.url.url,
         description: "Participant Portal Lambda Function URL (auth via teamLoginKey bearer).",

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -73,8 +73,10 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     const json = JSON.stringify(view);
     expect(json).not.toContain("SECRET_DO_NOT_LEAK");
     expect(json).not.toContain("tenantId");
-    expect(json).not.toContain("999999999999");
     expect(json).not.toContain("namePrefix");
+    // awsAccountId は SSO Credentials (AWS Console switch role) で必要なため公開する
+    // (= AWS account id は機密ではない、IAM trust policy / CFn template にも露出する)。
+    expect(view?.problems[0]?.awsAccountId).toBe("999999999999");
   });
 
   it("displayTeamName が DDB にあれば team.teamName はそれを優先し teamNameSetByCompetitor=true", async () => {

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -131,6 +131,46 @@ describe("getConsoleSigninUrl", () => {
     expect(result.loginUrl).toContain(encodeURIComponent("tc-security-battle-royale-alpha"));
   });
 
+  it("AssumeRole に inline session policy を渡し、DDB / Secrets Manager / KMS / IAM を Deny で殺すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIAFAKE",
+        SecretAccessKey: "SECRETFAKE",
+        SessionToken: "TOKENFAKE",
+        Expiration: new Date(),
+      },
+    });
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ SigninToken: "TOKEN" }), { status: 200 }),
+    );
+
+    await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+
+    const cmd = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    const policyRaw = cmd.input.Policy;
+    expect(typeof policyRaw).toBe("string");
+    const policy = JSON.parse(policyRaw as string) as {
+      Statement: Array<{ Effect: string; Action: string[] }>;
+    };
+    const denyActions = policy.Statement.filter((s) => s.Effect === "Deny").flatMap(
+      (s) => s.Action,
+    );
+    // 他チームの teamLoginKey が DDB Deployments に入っているので必須
+    expect(denyActions).toContain("dynamodb:*");
+    expect(denyActions).toContain("secretsmanager:*");
+    expect(denyActions).toContain("kms:Decrypt");
+    expect(denyActions).toContain("iam:*");
+    // 連鎖 AssumeRole も封じる (= 別 Role に乗り換えられない)
+    expect(denyActions).toContain("sts:AssumeRole");
+    // CFn の閲覧は Allow されている
+    const allowActions = policy.Statement.filter((s) => s.Effect === "Allow").flatMap(
+      (s) => s.Action,
+    );
+    expect(allowActions).toContain("cloudformation:DescribeStacks");
+  });
+
   it("getSigninToken が 5xx を返したら misconfigured", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -1,0 +1,150 @@
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+import { getConsoleSigninUrl } from "../../lib/problem-deploy/handlers/participant-handler/sso";
+
+const { stsSend } = vi.hoisted(() => ({ stsSend: vi.fn() }));
+
+vi.mock("@aws-sdk/client-sts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aws-sdk/client-sts")>();
+  return {
+    ...actual,
+    STSClient: class {
+      send = stsSend;
+    },
+  };
+});
+
+const VALID_JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const TEAM_KEY = "KEY1";
+
+function buildShared(): { shared: ParticipantSharedResources; ddbSend: ReturnType<typeof vi.fn> } {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  PK: `DEPLOYMENT#${VALID_JOB_ID}`,
+  SK: "META",
+  GSI2PK: `TEAMKEY#${TEAM_KEY}`,
+  jobId: VALID_JOB_ID,
+  problemId: "security-battle-royale",
+  region: "ap-northeast-1",
+  awsAccountId: "999999999999",
+  namePrefix: "tc-security-battle-royale-alpha",
+  status: "COMPLETE",
+  ...over,
+});
+
+describe("getConsoleSigninUrl", () => {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+  const ORIGINAL_ENV = process.env.CONSOLE_VIEWER_ROLE_ARN;
+
+  beforeEach(() => {
+    process.env.CONSOLE_VIEWER_ROLE_ARN = "arn:aws:iam::123456789012:role/ConsoleViewerRole";
+    stsSend.mockReset();
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.CONSOLE_VIEWER_ROLE_ARN = ORIGINAL_ENV;
+  });
+
+  it("不正な jobId (ULID 形式でない) は invalid_jobid を返すべき", async () => {
+    const { shared } = buildShared();
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, "not-ulid");
+    expect(result).toEqual({ kind: "invalid_jobid" });
+  });
+
+  it("CONSOLE_VIEWER_ROLE_ARN env が無ければ misconfigured を返すべき", async () => {
+    process.env.CONSOLE_VIEWER_ROLE_ARN = "";
+    const { shared } = buildShared();
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "misconfigured" });
+  });
+
+  it("teamLoginKey に該当 deployment が無ければ unauthorized を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "unauthorized" });
+  });
+
+  it("jobId が team の deployment 一覧に無ければ unauthorized を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ jobId: "01HZX0K3M3K9ZQHB3MRQHBA1B3" })] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "unauthorized" });
+  });
+
+  it("DELETED な deployment には access させない (unauthorized)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "DELETED" })] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "unauthorized" });
+  });
+
+  it("namePrefix 未設定 (stack 未起動) は not_ready", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ namePrefix: undefined, status: "PENDING" })],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+  });
+
+  it("正常系: STS AssumeRole + getSigninToken fetch を経由して signin login URL を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIAFAKE",
+        SecretAccessKey: "SECRETFAKE",
+        SessionToken: "TOKENFAKE",
+        Expiration: new Date(),
+      },
+    });
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ SigninToken: "SIGNIN_TOKEN_VALUE" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+
+    expect(stsSend).toHaveBeenCalledTimes(1);
+    const sentCmd = stsSend.mock.calls[0]?.[0];
+    expect(sentCmd).toBeInstanceOf(AssumeRoleCommand);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.loginUrl).toContain("https://signin.aws.amazon.com/federation");
+    expect(result.loginUrl).toContain("Action=login");
+    expect(result.loginUrl).toContain("SigninToken=SIGNIN_TOKEN_VALUE");
+    expect(result.loginUrl).toContain("cloudformation");
+    // 競技者の namePrefix で stacks フィルタを掛ける
+    expect(result.loginUrl).toContain(encodeURIComponent("tc-security-battle-royale-alpha"));
+  });
+
+  it("getSigninToken が 5xx を返したら misconfigured", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIAFAKE",
+        SecretAccessKey: "SECRETFAKE",
+        SessionToken: "TOKENFAKE",
+        Expiration: new Date(),
+      },
+    });
+    fetchSpy.mockResolvedValueOnce(new Response("server error", { status: 500 }));
+
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "misconfigured" });
+  });
+});


### PR DESCRIPTION
## Summary

PR-505 で sidebar から削除した SSO Credentials を復活し、**Stage 2 federation** に到達。
競技者は Portal の button を 1 回押すだけで AWS Console (CloudFormation スタック画面)
にログイン状態で遷移できる。自前 AWS アカウント不要。

> 当初 Stage 1 (switch-role URL) で起票・push したが、ユーザーから「自前 AWS ログイン
> 不要のワンクリック」を明示要求されたため、最終 commit で federation 実装に置換。

## 仕組み (Stage 2)

1. 競技者が `/sso-credentials` で「AWS Console を開く」を click
2. frontend が `GET /portal/me/console-signin-url?jobId=<ulid>` を bearer 付で叩く
3. Lambda が teamLoginKey + jobId から自分の deployment 行を確定
4. STS `AssumeRole` で operator account 内の `ConsoleViewerRole` の temp credentials を取得
   (※ inline session policy で `ReadOnlyAccess` を必要十分に絞る — 後述)
5. `signin.aws.amazon.com/federation?Action=getSigninToken` に session を渡して
   `SigninToken` を交換
6. `Action=login&Destination=...cloudformation/home?filteringText=<namePrefix>` URL を
   組み立てて返却
7. frontend が `window.open` で新タブを開く → 自動で AWS Console にログイン済

session TTL は **1 時間**で自動 expire。

## セキュリティ: session policy で ReadOnlyAccess をさらに絞る

`ConsoleViewerRole` に付与した managed `ReadOnlyAccess` だけだと、競技者が federation
で AWS Console を開いた後に DDB Deployments テーブルを Scan して、他チームの
`teamLoginKey` (= bearer token) を取得 → 成りすましという exfil 経路があった。

`AssumeRoleCommand` に inline session policy を追加して以下のように絞る (session
policy は元 Role の policy と **AND** で評価):

- **Allow**: cloudformation:Describe* / GetTemplate / ListStackResources、ec2:Describe*、
  logs:Describe*/GetLogEvents/FilterLogEvents、lambda:GetFunction、apigateway:GET、
  s3:GetBucketLocation/ListBucket
- **Deny**: dynamodb:*、secretsmanager:*、ssm:Get*/Describe*、kms:Decrypt/GenerateDataKey、
  iam:*、sts:AssumeRole

これで他チームの teamLoginKey 入り DDB テーブルは Scan 不能、連鎖 AssumeRole も封じる。

## 物理影響

| 種別   | リソース                                    | 注                                                              |
| ------ | ------------------------------------------- | --------------------------------------------------------------- |
| CREATE | `ConsoleViewerRole` (IAM)                  | ReadOnlyAccess managed policy、self-account の trust            |
| UPDATE | `ParticipantPortalLambda`                  | env `CONSOLE_VIEWER_ROLE_ARN` 追加 + grantAssumeRole 付与       |
| UPDATE | `ProblemDeployBackendStack`                | ConsoleViewerRole instantiate                                   |
| UPDATE | participant-portal SPA                     | switch-role URL ヘルパ撤去 → API call へ置換                    |
| NO-OP  | application-admin-console / DDB / 他 stack | 不変                                                            |

## Test plan

- [x] `make before-commit` 緑 (sso 9 件追加、計 285 infra + 37 + 73 + 45 frontend pass)
- [x] sso.ts unit test: invalid_jobid / misconfigured / unauthorized / DELETED / not_ready
      / 正常系 / fetch 5xx / **session policy assertion (deny dynamodb / secretsmanager / kms / iam / sts)**
- [ ] AWS deploy 後、SSO Credentials ページから 1-click で AWS Console (CFn 画面) が
      ログイン済の状態で開くこと
- [ ] AWS Console から DynamoDB ページに遷移すると AccessDeniedException が出ること

## Regression 分析

- 旧 Stage 1 switch-role URL flow は撤去 (UI / API 両方差し替え済)。Stage 1 は同 PR 内の
  short-lived 状態だったので、競技者影響無し。
- `CONSOLE_VIEWER_ROLE_ARN` env 未設定時は API は明示的に misconfigured (500) を返す。
  握り潰しなし、deploy 漏れに気付ける。
- session policy で competition に必要 service (CFn / EC2 / Logs / Lambda / API GW / S3
  metadata) のみ allow。漏れていた場合は AccessDenied で fail-explicit。
- 1-hour TTL で session 自動 expire。
- jobId は ULID 検証 + team スコープ filter (= 自チームの deployment しか触れない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSO Credentials page: one-click AWS Console sign-in from the participant portal with per-job loading state and error alerts.
  * "SSO Credentials" added to Tools in the side navigation.
  * Page shows console-accessible account info for each relevant job and displays a dev-mode warning when backend is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->