### PR TITLE
feat(portal): Quests に Battle/Challenge filter タブ + category badge

### DIFF
--- a/apps/participant-portal/src/lib/category.ts
+++ b/apps/participant-portal/src/lib/category.ts
@@ -1,0 +1,18 @@
+import type { ParticipantScoringInfo } from "../api/portal-client";
+
+export type ProblemCategory = "battle" | "challenge";
+
+/**
+ * scoring.kind から「Battle / Challenge」表示用カテゴリを推定する。
+ * 現状の運用 (1 problem は uptime か flag いずれか単独) では:
+ *   - `uptime` → Battle (= 防御問題)
+ *   - `flag`   → Challenge (= CTF)
+ *
+ * 将来 1 problem が両方の scoring を持つようになる場合 (Battle 内 sub-quest 等、
+ * Issue #502 注釈参照) は backend が metadata.json の `category` を view に流す
+ * 形に切り替える。
+ */
+export function categoryOf(scoring: ParticipantScoringInfo | undefined): ProblemCategory | null {
+  if (!scoring) return null;
+  return scoring.kind === "uptime" ? "battle" : "challenge";
+}

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -1,17 +1,25 @@
 import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Cards from "@cloudscape-design/components/cards";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
+import SegmentedControl from "@cloudscape-design/components/segmented-control";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator, {
   type StatusIndicatorProps,
 } from "@cloudscape-design/components/status-indicator";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import type { DeploymentStatus, ParticipantProblemView } from "../api/portal-client";
+import type {
+  DeploymentStatus,
+  ParticipantProblemView,
+  ParticipantScoringInfo,
+} from "../api/portal-client";
 import { useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
+import { categoryOf } from "../lib/category";
 
 const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   PENDING: "pending",
@@ -22,10 +30,14 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   DELETED: "stopped",
 };
 
-const SCORING_KIND_LABEL = {
-  flag: "Challenge (flag 提出)",
-  uptime: "Battle (uptime 加点)",
-} as const;
+type CategoryFilter = "all" | "battle" | "challenge";
+
+function categoryBadge(scoring: ParticipantScoringInfo | undefined) {
+  const cat = categoryOf(scoring);
+  if (cat === "battle") return <Badge color="red">Battle</Badge>;
+  if (cat === "challenge") return <Badge color="blue">Challenge</Badge>;
+  return <Badge color="grey">未分類</Badge>;
+}
 
 /**
  * 自チーム向け deploy 済問題のカタログ画面 (sidebar 「問題一覧」)。Home に対する
@@ -39,6 +51,22 @@ export function QuestsPage({ config }: { config: AppConfig }) {
   const { view, error } = useTeamView();
   const navigate = useNavigate();
   const isBackend = config.mode === "backend";
+  const [filter, setFilter] = useState<CategoryFilter>("all");
+
+  const counts = useMemo(() => {
+    const all = view?.problems ?? [];
+    return {
+      all: all.length,
+      battle: all.filter((p) => categoryOf(p.scoring) === "battle").length,
+      challenge: all.filter((p) => categoryOf(p.scoring) === "challenge").length,
+    };
+  }, [view]);
+
+  const filteredItems = useMemo(() => {
+    const all = view?.problems ?? [];
+    if (filter === "all") return [...all];
+    return all.filter((p) => categoryOf(p.scoring) === filter);
+  }, [view, filter]);
 
   return (
     <SpaceBetween size="l">
@@ -61,24 +89,38 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         </Alert>
       )}
 
+      <SegmentedControl
+        selectedId={filter}
+        onChange={({ detail }) => setFilter(detail.selectedId as CategoryFilter)}
+        options={[
+          { id: "all", text: `すべて (${counts.all})` },
+          { id: "battle", text: `Battle (${counts.battle})` },
+          { id: "challenge", text: `Challenge (${counts.challenge})` },
+        ]}
+        label="カテゴリで絞り込み"
+      />
+
       <Cards<ParticipantProblemView>
-        items={view ? [...view.problems] : []}
+        items={filteredItems}
         loading={isBackend && !view && !error}
         loadingText="問題を取得中…"
         cardDefinition={{
           // jobId (ULID) を URL key にする。problemId (slug) は metadata 上 unique 前提だが、
           // 将来 problemId を意図せず重複登録された場合の link 衝突を回避する防御。
           header: (problem) => (
-            <Link
-              fontSize="heading-m"
-              href={`/problems/${encodeURIComponent(problem.jobId)}`}
-              onFollow={(e) => {
-                e.preventDefault();
-                navigate(`/problems/${encodeURIComponent(problem.jobId)}`);
-              }}
-            >
-              <code>{problem.problemId}</code>
-            </Link>
+            <SpaceBetween size="xs" direction="horizontal" alignItems="center">
+              <Link
+                fontSize="heading-m"
+                href={`/problems/${encodeURIComponent(problem.jobId)}`}
+                onFollow={(e) => {
+                  e.preventDefault();
+                  navigate(`/problems/${encodeURIComponent(problem.jobId)}`);
+                }}
+              >
+                <code>{problem.problemId}</code>
+              </Link>
+              {categoryBadge(problem.scoring)}
+            </SpaceBetween>
           ),
           sections: [
             {
@@ -89,12 +131,6 @@ export function QuestsPage({ config }: { config: AppConfig }) {
                   {problem.status}
                 </StatusIndicator>
               ),
-            },
-            {
-              id: "kind",
-              header: "形式",
-              content: (problem) =>
-                problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)",
             },
             {
               id: "score",
@@ -142,9 +178,15 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         empty={
           <Container>
             <Box textAlign="center" padding="l">
-              <Box variant="strong">問題がありません</Box>
+              <Box variant="strong">
+                {filter === "all"
+                  ? "問題がありません"
+                  : `${filter === "battle" ? "Battle" : "Challenge"} カテゴリに該当する問題がありません`}
+              </Box>
               <Box variant="small" color="text-status-inactive" padding={{ top: "s" }}>
-                このチームには deploy 済みの問題がありません。operator にお問い合わせください。
+                {filter === "all"
+                  ? "このチームには deploy 済みの問題がありません。operator にお問い合わせください。"
+                  : "他カテゴリは「すべて」タブで確認できます。"}
               </Box>
             </Box>
           </Container>

--- a/apps/participant-portal/test/lib/category.test.ts
+++ b/apps/participant-portal/test/lib/category.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import type { ParticipantScoringInfo } from "../../src/api/portal-client";
+import { categoryOf } from "../../src/lib/category";
+
+describe("categoryOf", () => {
+  it("scoring が undefined なら null を返すべき (= 未分類)", () => {
+    expect(categoryOf(undefined)).toBeNull();
+  });
+
+  it("kind=uptime は battle を返すべき", () => {
+    const scoring: ParticipantScoringInfo = { kind: "uptime", pointsPerSuccess: 5 };
+    expect(categoryOf(scoring)).toBe("battle");
+  });
+
+  it("kind=flag は challenge を返すべき", () => {
+    const scoring: ParticipantScoringInfo = { kind: "flag", points: 100 };
+    expect(categoryOf(scoring)).toBe("challenge");
+  });
+});


### PR DESCRIPTION
## Summary

Issue (#502) の縮小スコープ実装。当初予定していた multi-mode scoring (1 problem が
flag + uptime 両持ちの array 化) は具体需要が無いので **見送り** (YAGNI)、表示分離
だけを小さく入れる。

- Quests 画面に Battle/Challenge filter タブを追加 (SegmentedControl)
- 各 card header に category badge (Battle=red / Challenge=blue)
- 旧「形式」section は header badge と二重なので削除

## 仕組み

\`scoring.kind\` から category を推定する helper を \`src/lib/category.ts\` に切り出し:
- \`uptime\` → Battle
- \`flag\`   → Challenge

これは現運用の 1:1 対応に基づく。将来 1 problem が両 scoring を持つ場合は、backend
が \`category\` を view に流す形に切り替える (Issue (#502) 注釈)。

## 物理影響

| 種別  | リソース | 注 |
| ----- | -------- | --- |
| UPDATE | participant-portal SPA | Quests UI のみ |
| NO-OP | backend / IaC / DDB / metadata schema | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (lib/category 3 件追加、portal 48 件、全体 443 件 pass)
- [ ] 実 deploy 後 Quests 画面で Battle / Challenge / All フィルタ切替動作確認

## Regression 分析

- \`scoring\` undefined の問題は「未分類」grey badge + どの filter にも入らない
  (現運用では metadata.json で scoring 必須なので発生しないが防御的処理)
- 旧「形式」sub-section 削除は header badge と二重だったため UX 改善
- backend / API / DDB / metadata schema 不変 = 旧 portal frontend / 旧 Lambda との互換維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category filters (Battle and Challenge) to organize and display problems
  * Problem cards now display colored category badges for quick identification
  * Filter shows problem counts per category
  * Empty state messaging updates based on selected filter

* **Tests**
  * Added test coverage for category classification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->