### PR TITLE
fix(portal): session 永続化を sessionStorage → localStorage に切替

### DIFF
--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -21,7 +21,7 @@ async function exchangeKeyForSession(
 
   if (config.mode === "backend") {
     // teamLoginKey 自体が bearer。backend が view を返したらそれを session 化する。
-    // sessionToken には teamLoginKey そのものを保管 (sessionStorage は same-origin
+    // sessionToken には teamLoginKey そのものを保管 (localStorage は same-origin
     // 隔離されている前提) し、以降の polling でも同じキーを Authorization に乗せる。
     let view: Awaited<ReturnType<typeof getPortalMe>>;
     try {

--- a/apps/participant-portal/src/auth/storage.ts
+++ b/apps/participant-portal/src/auth/storage.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 
 /**
- * Participant session の sessionStorage 永続化層。
+ * Participant session の `localStorage` 永続化層。
  *
- * Cognito ではなく per-team ログインキーで認証するので、ローカルでは
- * sessionStorage に session token + チーム情報を保存し、ブラウザを閉じたら消える形にする。
- * (localStorage を使わない理由: 競技中は同一 tab で完結する想定 + ブラウザ共用時の安全)
+ * Cognito ではなく per-team ログインキーで認証する。session の生存期間 (TTL) は
+ * `expiresAt` で持っているので、保存は `localStorage` で十分かつ tab/reload を
+ * またいで保たれる。`sessionStorage` だと tab を閉じる / 別 tab を開くたびに再
+ * ログインが必要になり、競技中の UX を著しく損なう (Issue #495 報告)。
  *
- * sessionStorage は private window やブラウザ設定で利用不可なケースがある。その場合は
+ * `localStorage` は private window やブラウザ設定で利用不可なケースがある。その場合は
  * setter / getter とも throw せず無効化扱いにする (graceful degradation)。
  */
 
@@ -34,7 +35,7 @@ export type ParticipantSession = z.infer<typeof ParticipantSessionSchema>;
 export function loadSession(): ParticipantSession | null {
   let raw: string | null;
   try {
-    raw = sessionStorage.getItem(STORAGE_KEY);
+    raw = localStorage.getItem(STORAGE_KEY);
   } catch {
     return null;
   }
@@ -44,12 +45,22 @@ export function loadSession(): ParticipantSession | null {
   try {
     parsedUnknown = JSON.parse(raw);
   } catch {
+    console.warn("[portal] session JSON parse failed, clearing");
     clearSession();
     return null;
   }
 
   const result = ParticipantSessionSchema.safeParse(parsedUnknown);
-  if (!result.success || result.data.expiresAt <= Date.now()) {
+  if (!result.success) {
+    // 旧 shape の session が残っている / 手動編集された場合はここで落ちる。
+    // 原因特定のため issues 一覧をログに出す (= プレーンテキスト、PII なし)。
+    console.warn("[portal] session schema violation, clearing", {
+      issues: result.error.issues.map((i) => ({ path: i.path.join("."), code: i.code })),
+    });
+    clearSession();
+    return null;
+  }
+  if (result.data.expiresAt <= Date.now()) {
     clearSession();
     return null;
   }
@@ -58,7 +69,7 @@ export function loadSession(): ParticipantSession | null {
 
 export function saveSession(session: ParticipantSession): void {
   try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
   } catch {
     // 利用不可。次回 load で null になり再ログインが要求される
   }
@@ -66,7 +77,7 @@ export function saveSession(session: ParticipantSession): void {
 
 export function clearSession(): void {
   try {
-    sessionStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(STORAGE_KEY);
   } catch {
     // ignore
   }

--- a/apps/participant-portal/src/auth/storage.ts
+++ b/apps/participant-portal/src/auth/storage.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
  * setter / getter とも throw せず無効化扱いにする (graceful degradation)。
  */
 
-const STORAGE_KEY = "TenkaCloud.participant.session";
+export const STORAGE_KEY = "TenkaCloud.participant.session";
 
 export const ParticipantSessionSchema = z.object({
   sessionToken: z.string().min(1),

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -24,6 +24,7 @@ const renderAuth = (config: AppConfig) =>
 
 describe("AuthProvider", () => {
   afterEach(() => {
+    localStorage.clear();
     sessionStorage.clear();
     vi.restoreAllMocks();
   });

--- a/apps/participant-portal/test/auth/storage.test.ts
+++ b/apps/participant-portal/test/auth/storage.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearSession,
   loadSession,
   type ParticipantSession,
   saveSession,
 } from "../../src/auth/storage";
+
+const STORAGE_KEY = "TenkaCloud.participant.session";
 
 const sample = (): ParticipantSession => ({
   sessionToken: "abc.def.ghi",
@@ -17,7 +19,11 @@ const sample = (): ParticipantSession => ({
 });
 
 describe("storage", () => {
-  afterEach(() => sessionStorage.clear());
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
 
   describe("loadSession", () => {
     it("初期状態では null を返すべき", () => {
@@ -37,37 +43,49 @@ describe("storage", () => {
       const s: ParticipantSession = { ...sample(), expiresAt: Date.now() - 1 };
       saveSession(s);
       expect(loadSession()).toBeNull();
-      expect(sessionStorage.getItem("TenkaCloud.participant.session")).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
     it("不正な JSON が入っていたら null + 削除を返すべき", () => {
-      sessionStorage.setItem("TenkaCloud.participant.session", "not-a-json");
+      vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      localStorage.setItem(STORAGE_KEY, "not-a-json");
       expect(loadSession()).toBeNull();
-      expect(sessionStorage.getItem("TenkaCloud.participant.session")).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
     it("schema 違反 (必須フィールド欠落) なら null + 削除を返すべき", () => {
-      sessionStorage.setItem(
-        "TenkaCloud.participant.session",
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      localStorage.setItem(
+        STORAGE_KEY,
         JSON.stringify({ sessionToken: "x", teamId: "y" }), // 多くのフィールドが欠落
       );
       expect(loadSession()).toBeNull();
-      expect(sessionStorage.getItem("TenkaCloud.participant.session")).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      // 旧 shape 残存 / 手動編集の原因特定用に diag log を残しているか
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[portal] session schema violation, clearing",
+        expect.objectContaining({ issues: expect.any(Array) }),
+      );
     });
 
     it("expiresAt が文字列 (型違反) なら null + 削除を返すべき", () => {
-      sessionStorage.setItem(
-        "TenkaCloud.participant.session",
-        JSON.stringify({ ...sample(), expiresAt: "later" }),
-      );
+      vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...sample(), expiresAt: "later" }));
       expect(loadSession()).toBeNull();
+    });
+
+    it("`localStorage` に保存され、tab を閉じても (= sessionStorage が空でも) 復元できるべき", () => {
+      saveSession(sample());
+      sessionStorage.clear(); // tab を閉じた相当
+      const loaded = loadSession();
+      expect(loaded?.teamId).toBe("team-1");
     });
   });
 
   describe("saveSession", () => {
-    it("schema を満たすなら保存できるべき", () => {
+    it("schema を満たすなら `localStorage` に保存できるべき", () => {
       saveSession(sample());
-      const stored = sessionStorage.getItem("TenkaCloud.participant.session");
+      const stored = localStorage.getItem(STORAGE_KEY);
       expect(stored).not.toBeNull();
       if (stored === null) {
         throw new Error("session が保存されるべき");
@@ -75,13 +93,18 @@ describe("storage", () => {
       const parsed = JSON.parse(stored);
       expect(parsed.teamName).toBe("Team Alpha");
     });
+
+    it("`sessionStorage` には保存されないべき (= reload 越しに保たれる契約)", () => {
+      saveSession(sample());
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
   });
 
   describe("clearSession", () => {
     it("保存済み session を削除できるべき", () => {
       saveSession(sample());
       clearSession();
-      expect(sessionStorage.getItem("TenkaCloud.participant.session")).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
       expect(loadSession()).toBeNull();
     });
 

--- a/apps/participant-portal/test/auth/storage.test.ts
+++ b/apps/participant-portal/test/auth/storage.test.ts
@@ -1,12 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSession,
   loadSession,
   type ParticipantSession,
+  STORAGE_KEY,
   saveSession,
 } from "../../src/auth/storage";
-
-const STORAGE_KEY = "TenkaCloud.participant.session";
 
 const sample = (): ParticipantSession => ({
   sessionToken: "abc.def.ghi",
@@ -19,6 +18,12 @@ const sample = (): ParticipantSession => ({
 });
 
 describe("storage", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
   afterEach(() => {
     localStorage.clear();
     sessionStorage.clear();
@@ -47,14 +52,12 @@ describe("storage", () => {
     });
 
     it("不正な JSON が入っていたら null + 削除を返すべき", () => {
-      vi.spyOn(console, "warn").mockImplementation(() => undefined);
       localStorage.setItem(STORAGE_KEY, "not-a-json");
       expect(loadSession()).toBeNull();
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
     it("schema 違反 (必須フィールド欠落) なら null + 削除を返すべき", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({ sessionToken: "x", teamId: "y" }), // 多くのフィールドが欠落
@@ -69,7 +72,6 @@ describe("storage", () => {
     });
 
     it("expiresAt が文字列 (型違反) なら null + 削除を返すべき", () => {
-      vi.spyOn(console, "warn").mockImplementation(() => undefined);
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...sample(), expiresAt: "later" }));
       expect(loadSession()).toBeNull();
     });


### PR DESCRIPTION
## Summary

Issue (#495) — Participant Portal の画面リロードで毎回ログインキー入力を求められる
件の修正。sessionStorage は tab を閉じる / 別 tab を開くたびに消えるので、競技中の
UX を著しく損なっていた。

## 変更点

- \`src/auth/storage.ts\`: \`sessionStorage\` → \`localStorage\` に置換
- safeParse fail 時に \`console.warn\` で issues (path / code) をログ (旧 shape 残存
  などの原因特定用、PII 無し)
- tests: \`localStorage\` 経路に変更 + 「tab 閉じ相当でも復元できる」アサート追加
- \`AuthProvider.test.tsx\` の afterEach に localStorage.clear() を追加 (test 間漏れ防止)

## 物理影響

frontend のみ (NO-OP for backend / IaC / DDB / metadata schema)。

## Test plan

- [x] \`make before-commit\` 緑 (portal 50 件、全体 445 件 pass)
- [ ] 実 deploy 後、ログイン後にブラウザリロード → ログイン状態維持
- [ ] 同 origin の別 tab でも自動ログイン状態
- [ ] expiresAt 経過後の reload は自動 logout

## Regression 分析

- localStorage 化により「ブラウザ共有時に他ユーザーが既存 session を引き継ぐ」リスクは
  存在する。ただし元の sessionStorage でも同 tab 共有なら同じリスクがあり、競技者は
  自前デバイスを使う前提なので運用で許容
- \`expiresAt\` past 判定 / 不正 JSON の clear ロジックは不変 (= self-recovery 維持)
- 旧 sessionStorage に残っていた古い session は localStorage には無いので、ユーザーは
  1 回だけ再ログインが必要 (= 移行コスト 1 回)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Participant sessions now persist across browser restarts using more durable client storage; expired or corrupted sessions are detected and cleared automatically (with diagnostic warnings).
* **Tests**
  * Test suites updated to clear persisted auth state between runs to prevent state leakage and ensure consistent test behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/508)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->