### PR TITLE
feat(operator): EventDetail 問題セット行に deploy status / job リンクを表示

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -36,9 +36,28 @@ export interface TeamSummary {
   teamLoginKey?: string;
 }
 
+export type EventDeploymentStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "COMPLETE"
+  | "FAILED"
+  | "DELETING"
+  | "DELETED";
+
+export interface EventDeploymentSummary {
+  jobId: string;
+  teamId: string;
+  status: EventDeploymentStatus;
+}
+
 export interface EventDetail extends EventSummary {
   teams: readonly TeamSummary[];
   problems: readonly EventProblemTarget[];
+  /**
+   * `problemId` ごとの deploy job 一覧 (= 全 team 分)。Bulk Deploy 前は空 record。
+   * 旧 jobId-based deployment は eventId が無いので含まれない。
+   */
+  deploymentsByProblem: Readonly<Record<string, readonly EventDeploymentSummary[]>>;
 }
 
 export interface CreateEventTeamInput {

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -43,9 +43,7 @@ const DEPLOY_STATUS_COLOR: Record<EventDeploymentStatus, "blue" | "green" | "gre
  * 1 problem 行の deploy 状況サマリ: `成功 N / 全 M` + 失敗があれば赤 Badge を併記。
  * Bulk Deploy 未実行 (deployments 無し) なら "未デプロイ" 表示。
  */
-function renderProblemDeployStatus(
-  deployments: readonly EventDeploymentSummary[] | undefined,
-): JSX.Element {
+function renderProblemDeployStatus(deployments: readonly EventDeploymentSummary[] | undefined) {
   if (!deployments || deployments.length === 0) {
     return (
       <Box variant="small" color="text-status-inactive">
@@ -74,9 +72,7 @@ function renderProblemDeployStatus(
  * 1 problem 行の deploy job click-through link 列。各 jobId を /deployments/:jobId に
  * 飛ばす (= per-team の deploy 詳細ページ)。
  */
-function renderProblemJobLinks(
-  deployments: readonly EventDeploymentSummary[] | undefined,
-): JSX.Element {
+function renderProblemJobLinks(deployments: readonly EventDeploymentSummary[] | undefined) {
   if (!deployments || deployments.length === 0) {
     return (
       <Box variant="small" color="text-status-inactive">

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -7,6 +7,7 @@ import Container from "@cloudscape-design/components/container";
 import DatePicker from "@cloudscape-design/components/date-picker";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
@@ -20,12 +21,83 @@ import {
   bulkDeployEvent,
   bulkTeardownEvent,
   EVENT_ID_RE,
+  type EventDeploymentStatus,
+  type EventDeploymentSummary,
   type EventDetail,
   type EventStatus,
   getEvent,
   setEventSchedule,
 } from "../api/events-client";
 import type { AppConfig } from "../config";
+
+const DEPLOY_STATUS_COLOR: Record<EventDeploymentStatus, "blue" | "green" | "grey" | "red"> = {
+  PENDING: "grey",
+  IN_PROGRESS: "blue",
+  COMPLETE: "green",
+  FAILED: "red",
+  DELETING: "grey",
+  DELETED: "grey",
+};
+
+/**
+ * 1 problem 行の deploy 状況サマリ: `成功 N / 全 M` + 失敗があれば赤 Badge を併記。
+ * Bulk Deploy 未実行 (deployments 無し) なら "未デプロイ" 表示。
+ */
+function renderProblemDeployStatus(
+  deployments: readonly EventDeploymentSummary[] | undefined,
+): JSX.Element {
+  if (!deployments || deployments.length === 0) {
+    return (
+      <Box variant="small" color="text-status-inactive">
+        未デプロイ
+      </Box>
+    );
+  }
+  const total = deployments.length;
+  const complete = deployments.filter((d) => d.status === "COMPLETE").length;
+  const failed = deployments.filter((d) => d.status === "FAILED").length;
+  const inFlight = deployments.filter(
+    (d) => d.status === "PENDING" || d.status === "IN_PROGRESS",
+  ).length;
+  return (
+    <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+      <Box variant="strong">
+        {complete} / {total}
+      </Box>
+      {failed > 0 && <Badge color="red">FAILED {failed}</Badge>}
+      {inFlight > 0 && <Badge color="blue">進行中 {inFlight}</Badge>}
+    </SpaceBetween>
+  );
+}
+
+/**
+ * 1 problem 行の deploy job click-through link 列。各 jobId を /deployments/:jobId に
+ * 飛ばす (= per-team の deploy 詳細ページ)。
+ */
+function renderProblemJobLinks(
+  deployments: readonly EventDeploymentSummary[] | undefined,
+): JSX.Element {
+  if (!deployments || deployments.length === 0) {
+    return (
+      <Box variant="small" color="text-status-inactive">
+        —
+      </Box>
+    );
+  }
+  return (
+    <SpaceBetween direction="horizontal" size="xxs">
+      {deployments.map((d) => (
+        <Link
+          key={d.jobId}
+          href={`/deployments/${encodeURIComponent(d.jobId)}`}
+          ariaLabel={`Deploy job ${d.jobId} (status: ${d.status})`}
+        >
+          <Badge color={DEPLOY_STATUS_COLOR[d.status]}>{d.status}</Badge>
+        </Link>
+      ))}
+    </SpaceBetween>
+  );
+}
 
 const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   DRAFT: "blue",
@@ -271,6 +343,16 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               { id: "id", header: "Problem ID", cell: (p) => <code>{p.problemId}</code> },
               { id: "account", header: "Default AWS Account", cell: (p) => p.defaultAwsAccountId },
               { id: "region", header: "Default Region", cell: (p) => p.defaultRegion },
+              {
+                id: "status",
+                header: "Deploy Status",
+                cell: (p) => renderProblemDeployStatus(detail.deploymentsByProblem[p.problemId]),
+              },
+              {
+                id: "jobs",
+                header: "Job Links",
+                cell: (p) => renderProblemJobLinks(detail.deploymentsByProblem[p.problemId]),
+              },
             ]}
             empty={<Box>未設定 — Event 編集 (Phase 2c+) で追加できる予定</Box>}
           />

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -1,6 +1,30 @@
 import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import type { EventSharedResources } from "./shared.js";
-import type { EventDetail, EventItem, EventSummary, TeamItem, TeamSummary } from "./types.js";
+import type {
+  EventDeploymentSummary,
+  EventDetail,
+  EventItem,
+  EventSummary,
+  TeamItem,
+  TeamSummary,
+} from "./types.js";
+
+const DEPLOYMENT_STATUS_VALUES = [
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "FAILED",
+  "DELETING",
+  "DELETED",
+] as const;
+type DeploymentStatus = (typeof DEPLOYMENT_STATUS_VALUES)[number];
+
+function parseDeploymentStatus(raw: unknown): DeploymentStatus | undefined {
+  if (typeof raw !== "string") return undefined;
+  return (DEPLOYMENT_STATUS_VALUES as readonly string[]).includes(raw)
+    ? (raw as DeploymentStatus)
+    : undefined;
+}
 
 export interface ListEventsRequest {
   readonly tenantId: string;
@@ -115,7 +139,10 @@ export async function getEventDetail(
         IndexName: "GSI1",
         KeyConditionExpression: "GSI1PK = :pk",
         ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
-        ProjectionExpression: "teamId, eventId, displayTeamName",
+        // problemId / jobId / status は per-problem deploy 状況を組み立てるのに必要。
+        // displayTeamName は既存の teams[].displayName 上書き用。
+        ProjectionExpression: "teamId, eventId, displayTeamName, problemId, jobId, #s",
+        ExpressionAttributeNames: { "#s": "status" },
       }),
     ),
   ]);
@@ -129,12 +156,35 @@ export async function getEventDetail(
   // 起動時には全て同じ値で埋まる (update.ts が Promise.all で全行を更新するため)。
   // 念のため最後に拾った非空文字列を採用 (=「設定済」優先)。
   const displayNameByTeamId = new Map<string, string>();
+  // problemId → deployment summary[]。本 event の deployment のみ集める。
+  const deploymentsByProblem: Record<string, EventDeploymentSummary[]> = {};
   for (const d of deploymentsOut.Items ?? []) {
-    const row = d as { teamId?: unknown; eventId?: unknown; displayTeamName?: unknown };
+    const row = d as {
+      teamId?: unknown;
+      eventId?: unknown;
+      displayTeamName?: unknown;
+      problemId?: unknown;
+      jobId?: unknown;
+      status?: unknown;
+    };
     if (row.eventId !== eventId) continue;
-    if (typeof row.teamId !== "string" || typeof row.displayTeamName !== "string") continue;
-    if (row.displayTeamName.length === 0) continue;
-    displayNameByTeamId.set(row.teamId, row.displayTeamName);
+    if (typeof row.teamId === "string" && typeof row.displayTeamName === "string") {
+      if (row.displayTeamName.length > 0) {
+        displayNameByTeamId.set(row.teamId, row.displayTeamName);
+      }
+    }
+    if (
+      typeof row.problemId !== "string" ||
+      typeof row.jobId !== "string" ||
+      typeof row.teamId !== "string"
+    ) {
+      continue;
+    }
+    const status = parseDeploymentStatus(row.status);
+    if (!status) continue;
+    const list = deploymentsByProblem[row.problemId] ?? [];
+    list.push({ jobId: row.jobId, teamId: row.teamId, status });
+    deploymentsByProblem[row.problemId] = list;
   }
 
   const teams: TeamSummary[] = teamItems.map((t) => {
@@ -155,5 +205,6 @@ export async function getEventDetail(
     ...summary,
     problems: Array.isArray(event.problems) ? (event.problems as EventDetail["problems"]) : [],
     teams,
+    deploymentsByProblem,
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -152,8 +152,25 @@ export const TeamSummarySchema = z.object({
 });
 export type TeamSummary = z.infer<typeof TeamSummarySchema>;
 
+/**
+ * EventDetail の問題セット行に紐づく deploy job の最小情報。
+ * operator が「どの team のどの問題が PENDING/COMPLETE/FAILED か」を一目で
+ * 確認できるようにし、jobId 経由で /deployments/:jobId に click-through できる。
+ */
+export const EventDeploymentSummarySchema = z.object({
+  jobId: z.string(),
+  teamId: z.string(),
+  status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETE", "FAILED", "DELETING", "DELETED"]),
+});
+export type EventDeploymentSummary = z.infer<typeof EventDeploymentSummarySchema>;
+
 export const EventDetailSchema = EventSummarySchema.extend({
   problems: z.array(EventProblemTargetSchema),
   teams: z.array(TeamSummarySchema),
+  /**
+   * `problemId` ごとの deploy job 一覧 (= 全 team 分)。Bulk Deploy 前は空 record。
+   * 旧 jobId-based deployment は eventId が無いので含まれない。
+   */
+  deploymentsByProblem: z.record(z.string(), z.array(EventDeploymentSummarySchema)),
 });
 export type EventDetail = z.infer<typeof EventDetailSchema>;

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -204,4 +204,100 @@ describe("getEventDetail", () => {
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out).toBeUndefined();
   });
+
+  it("Deployments の問題ごと jobId / teamId / status を deploymentsByProblem にまとめるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        name: "イベント A",
+        status: "DRAFT",
+        teamCount: 2,
+        problems: [
+          { problemId: "p1", defaultAwsAccountId: "1", defaultRegion: "ap-northeast-1" },
+          { problemId: "p2", defaultAwsAccountId: "1", defaultRegion: "ap-northeast-1" },
+        ],
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ teamId: "T1", internalSlug: "alpha", teamLoginKey: "k1" }],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J1", status: "COMPLETE" },
+        { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J2", status: "FAILED" },
+        { teamId: "T1", eventId: "EV1", problemId: "p2", jobId: "J3", status: "IN_PROGRESS" },
+        // 別 event の deployment は除外されるべき
+        { teamId: "T1", eventId: "EV-OTHER", problemId: "p1", jobId: "J-LEAK", status: "COMPLETE" },
+      ],
+    });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out?.deploymentsByProblem.p1).toHaveLength(2);
+    expect(out?.deploymentsByProblem.p2).toHaveLength(1);
+    expect(out?.deploymentsByProblem.p1?.[0]).toMatchObject({
+      jobId: "J1",
+      teamId: "T1",
+      status: "COMPLETE",
+    });
+    expect(out?.deploymentsByProblem.p2?.[0]).toMatchObject({
+      jobId: "J3",
+      status: "IN_PROGRESS",
+    });
+    // 別 event の jobId が漏れないこと
+    expect(JSON.stringify(out?.deploymentsByProblem)).not.toContain("J-LEAK");
+  });
+
+  it("Bulk Deploy 未実行 (Deployments 空) なら deploymentsByProblem は空 record", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        name: "イベント A",
+        status: "DRAFT",
+        teamCount: 1,
+        problems: [{ problemId: "p1", defaultAwsAccountId: "1", defaultRegion: "ap-northeast-1" }],
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out?.deploymentsByProblem).toEqual({});
+  });
+
+  it("不明な status 値の deployment 行は deploymentsByProblem から除外するべき (防御的)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        problems: [{ problemId: "p1", defaultAwsAccountId: "1", defaultRegion: "ap-northeast-1" }],
+        status: "DRAFT",
+        teamCount: 1,
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J1", status: "BOGUS" },
+        { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J2", status: "COMPLETE" },
+      ],
+    });
+
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out?.deploymentsByProblem.p1).toHaveLength(1);
+    expect(out?.deploymentsByProblem.p1?.[0]?.jobId).toBe("J2");
+  });
 });


### PR DESCRIPTION
## Summary

Issue (#492) — EventDetail の「問題セット」表に各問題の deploy 状況が見えなかった件。
backend の既存 Deployments GSI1 query に projection を 3 つ足して、新 frontend 列で
\`{COMPLETE} / {total}\` サマリ + 各 jobId への click-through link を表示する。

## 物理影響

| 種別  | リソース | 注 |
| --- | --- | --- |
| UPDATE | event-handler Lambda | GET /events/:id に \`deploymentsByProblem\` 追加 |
| UPDATE | application-admin-console SPA | 問題セット表に Status / Job Links 列追加 |
| NO-OP | DDB schema / IAM / 他 stack | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (+3 infra テスト、全体 484 件 pass)
- [ ] AWS deploy 後、Bulk Deploy 実行 → EventDetail で Status / Job Links 確認
- [ ] FAILED が赤、IN_PROGRESS が青、COMPLETE が緑

## Regression 分析

- 旧 jobId-based deployment (eventId 無し) は \`deploymentsByProblem\` に含まれない
- projection 拡張は同 query path で追加 RCU は projection 数 × データサイズの微増のみ
- 旧 SPA との後方互換: \`deploymentsByProblem\` は新 field、旧 SPA は無視

🤖 Generated with [Claude Code](https://claude.com/claude-code)