### PR TITLE
feat(portal): /login は既ログイン時に Home へ redirect

### DIFF
--- a/apps/participant-portal/src/pages/Login.tsx
+++ b/apps/participant-portal/src/pages/Login.tsx
@@ -8,13 +8,18 @@ import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 
 /**
  * 競技者ログイン画面。チーム単位で発行されたログインキーを入力すると、
  * backend (現状 mock) が session を発行する。
+ *
+ * 既存 session がある状態で /login に来た場合は **無条件で / にリダイレクト** する
+ * (Issue #496)。これにより「同 browser でログイン中のまま別 team key を黙って入力 →
+ * 黙って team が切り替わる」事故を防ぐ。team 切替には TopNav の「サインアウト」を
+ * 経由する必要がある。
  */
 export function LoginPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
@@ -22,6 +27,12 @@ export function LoginPage({ config }: { config: AppConfig }) {
   const [teamLoginKey, setTeamLoginKey] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // 既ログイン状態で /login に来た場合は home に redirect (= 別 key 黙々上書き防止)。
+  // ready=false の間は loadSession の結果待ちで何も決められないので render を保留。
+  if (auth.ready && auth.session) {
+    return <Navigate to="/" replace />;
+  }
 
   const onSubmit = async () => {
     setSubmitting(true);

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { App } from "../src/App";
 import type { AppConfig } from "../src/config";
 
@@ -21,6 +21,14 @@ function renderApp(initialPath: string) {
 }
 
 describe("App", () => {
+  // 1 つの test 内で auth.login が走ると localStorage に session が残るため、
+  // 別 test (= 新規 render) でも redirect 挙動が引き継がれてしまう。各 test 後に
+  // 明示的にクリアする (Issue #495 で localStorage 化したのに合わせた追加掃除)。
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
   describe("/login にアクセスしたとき", () => {
     it("LoginPage が表示されサインインボタンを持つべき", async () => {
       renderApp("/login");
@@ -57,6 +65,27 @@ describe("App", () => {
       expect(
         await screen.findByRole("heading", { level: 1, name: /Welcome,/ }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("既ログイン状態で /login に再アクセスしたとき (Issue #496)", () => {
+    it("Home に redirect されサインイン画面は表示されないべき (= 黙々 team 切替の防止)", async () => {
+      const user = userEvent.setup();
+      // 1 度ログインして session を作る
+      const { unmount } = renderApp("/login");
+      const input = screen.getByPlaceholderText("チームに配布されたキー");
+      await user.type(input, "TEAM-A-KEY");
+      await user.click(await screen.findByRole("button", { name: "サインイン" }));
+      await screen.findByRole("heading", { level: 1, name: /Welcome,/ });
+      unmount();
+
+      // session が localStorage に残ったまま /login に直接アクセスしても
+      // login form は出ず、Home (Welcome) にすぐ遷移するべき
+      renderApp("/login");
+      expect(
+        await screen.findByRole("heading", { level: 1, name: /Welcome,/ }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "サインイン" })).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue (#496) — 同 browser でログイン中に \`/login\` に直接アクセスして別 team の
ログインキーを入力すると、黙って team が切り替わってしまう UX 事故を防止。

- \`LoginPage\`: \`auth.session\` があれば \`<Navigate to="/" replace />\` で home へ
- team 切替は TopNav の「サインアウト」を経由する必要があり、明示的な意思表示を強制
- App.test.tsx に「既ログイン /login → Home redirect」test を追加 + localStorage の
  test 間共通 cleanup を top describe に集約

## 物理影響

frontend のみ (NO-OP for backend / IaC / DDB / metadata schema)。

## Test plan

- [x] \`make before-commit\` 緑 (portal 51 件、全体 484 件 pass)
- [ ] 実 deploy 後、ログイン状態で /login 直叩き → Home に redirect
- [ ] サインアウト → /login で別 key を受け付ける

## Regression 分析

- 未ログイン時の /login は従来通り form 表示 (= 既存挙動維持)
- expiresAt 切れ session は loadSession が null を返すので auth.session=null → form が出る
- 操作コストは "redirect → ログアウト → 再ログイン" に増えるが、事故は確実に防げる

🤖 Generated with [Claude Code](https://claude.com/claude-code)