### PR TITLE
feat(operator): Event 終了ボタン (READY → ENDED) で採点を停止

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -2,7 +2,7 @@ import type { ApiClient } from "./client";
 
 export const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
-export type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "TEARDOWN" | "ARCHIVED";
+export type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "ENDED" | "TEARDOWN" | "ARCHIVED";
 
 export interface EventProblemTarget {
   problemId: string;
@@ -115,4 +115,17 @@ export async function setEventSchedule(
   body: { startsAt: string } | { startNow: true },
 ): Promise<SetScheduleResult> {
   return api.patch<SetScheduleResult>(`events/${encodeURIComponent(eventId)}/schedule`, body);
+}
+
+export interface EndEventResult {
+  endsAt: string;
+  updatedDeployments: number;
+}
+
+/**
+ * Event を ENDED 状態に遷移させ、紐づく全 deployment 行に \`eventEndsAt\` を伝播する。
+ * READY 状態の event のみ受理 (= 二重操作 / 未開始 event の終了は 409)。
+ */
+export async function endEvent(api: ApiClient, eventId: string): Promise<EndEventResult> {
+  return api.post<EndEventResult>(`events/${encodeURIComponent(eventId)}/end`, {});
 }

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -22,6 +22,7 @@ import {
   EVENT_ID_RE,
   type EventDetail,
   type EventStatus,
+  endEvent,
   getEvent,
   setEventSchedule,
 } from "../api/events-client";
@@ -31,6 +32,7 @@ const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   DRAFT: "blue",
   DEPLOYING: "blue",
   READY: "green",
+  ENDED: "grey",
   TEARDOWN: "red",
   ARCHIVED: "grey",
 };
@@ -48,6 +50,8 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [scheduleDate, setScheduleDate] = useState("");
   const [scheduleTime, setScheduleTime] = useState("");
   const [scheduleInFlight, setScheduleInFlight] = useState<"now" | "scheduled" | null>(null);
+  const [endInFlight, setEndInFlight] = useState(false);
+  const [confirmEnd, setConfirmEnd] = useState(false);
 
   const eventIdValid = !!eventId && EVENT_ID_RE.test(eventId);
 
@@ -142,6 +146,21 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     }
   };
 
+  const handleEndEvent = async () => {
+    if (!apiClient || endInFlight) return;
+    setEndInFlight(true);
+    setConfirmEnd(false);
+    setError(null);
+    try {
+      await endEvent(apiClient, eventId);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEndInFlight(false);
+    }
+  };
+
   if (!detail && !error) {
     return (
       <Box textAlign="center" padding="l">
@@ -161,10 +180,24 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             <Button
               variant="primary"
               loading={bulkInFlight === "deploy"}
-              disabled={!detail || detail.problems.length === 0 || detail.teams.length === 0}
+              disabled={
+                !detail ||
+                detail.problems.length === 0 ||
+                detail.teams.length === 0 ||
+                detail.status === "ENDED" ||
+                detail.status === "TEARDOWN" ||
+                detail.status === "ARCHIVED"
+              }
               onClick={handleBulkDeploy}
             >
               Bulk Deploy
+            </Button>
+            <Button
+              loading={endInFlight}
+              disabled={!detail || detail.status !== "READY"}
+              onClick={() => setConfirmEnd(true)}
+            >
+              Event を終了
             </Button>
             <Button
               loading={bulkInFlight === "teardown"}
@@ -373,6 +406,32 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           />
         </Container>
       )}
+
+      <Modal
+        visible={confirmEnd}
+        header="Event を終了しますか?"
+        onDismiss={() => setConfirmEnd(false)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setConfirmEnd(false)}>キャンセル</Button>
+              <Button variant="primary" onClick={handleEndEvent}>
+                終了
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            Event を <code>ENDED</code> に遷移し、HealthCheck の採点を停止します (deployment
+            は残るので Bulk Teardown は別途必要)。
+          </Box>
+          <Box variant="small" color="text-status-warning">
+            この操作は取り消せません。READY 状態の event のみ終了できます。
+          </Box>
+        </SpaceBetween>
+      </Modal>
 
       <Modal
         visible={confirmTeardown}

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -15,7 +15,7 @@ import Table from "@cloudscape-design/components/table";
 import TimeInput from "@cloudscape-design/components/time-input";
 import { useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
-import { useApiClient } from "../api/client";
+import { ApiError, useApiClient } from "../api/client";
 import {
   type BulkResult,
   bulkDeployEvent,
@@ -223,6 +223,19 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       await endEvent(apiClient, eventId);
       await refresh();
     } catch (err) {
+      // 409 not_endable: backend は body に `currentStatus` を載せているので、
+      // どの status だったかを operator に伝える (= refresh 押せばいいのか、別操作が
+      // 要るのかを判断しやすくする)。
+      if (err instanceof ApiError && err.status === 409) {
+        const match = err.message.match(/"currentStatus"\s*:\s*"([A-Z_]+)"/);
+        const current = match?.[1];
+        setError(
+          current
+            ? `Event は READY 状態でのみ終了できます (現在: ${current})`
+            : "Event は READY 状態でのみ終了できます",
+        );
+        return;
+      }
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setEndInFlight(false);
@@ -506,7 +519,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             は残るので Bulk Teardown は別途必要)。
           </Box>
           <Box variant="small" color="text-status-warning">
-            この操作は取り消せません。READY 状態の event のみ終了できます。
+            ENDED 状態から READY に戻すことはできません。再開するには Event を作り直して下さい。
           </Box>
         </SpaceBetween>
       </Modal>

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -17,6 +17,7 @@ const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   DRAFT: "blue",
   DEPLOYING: "blue",
   READY: "green",
+  ENDED: "grey",
   TEARDOWN: "red",
   ARCHIVED: "grey",
 };

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -5,6 +5,7 @@ import {
   bulkTeardownEvent,
   createEvent,
   EVENT_ID_RE,
+  endEvent,
   getEvent,
   listEvents,
 } from "../../src/api/events-client";
@@ -118,5 +119,20 @@ describe("bulkTeardownEvent", () => {
     expect(calls[0]?.path).toBe("events/EV1");
     expect(calls[0]?.method).toBe("DELETE");
     expect(out.enqueued).toBe(6);
+  });
+});
+
+describe("endEvent", () => {
+  it("POST /events/{id}/end を空 body で呼び EndEventResult を返すべき", async () => {
+    const { client, calls } = fakeClient({
+      endsAt: "2026-05-08T10:00:00.000Z",
+      updatedDeployments: 12,
+    });
+    const out = await endEvent(client, "EV1");
+    expect(calls[0]?.path).toBe("events/EV1/end");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.body).toEqual({});
+    expect(out.endsAt).toBe("2026-05-08T10:00:00.000Z");
+    expect(out.updatedDeployments).toBe(12);
   });
 });

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -101,6 +101,13 @@ export interface DeploymentItem {
    * 伝播する (event-handler/schedule.ts)。未設定 → 採点無し (= deploy 直後の誤加算防止)。
    */
   eventStartsAt?: string;
+  /**
+   * 競技終了時刻 (ISO8601) を Event から denormalize したコピー。HealthCheckLambda が
+   * probe / 採点 gate で参照する (eventEndsAt <= now なら skip)。`POST /events/:id/end`
+   * で operator が明示的に終了させたとき、event-handler が全 deployment 行へ伝播する。
+   * 未設定 → 終了 gate 無し (= 旧 deployment / 終了未指示の event で既存挙動を保つ)。
+   */
+  eventEndsAt?: string;
 
   /** Scoring engine が加算したチームの累計ポイント。0 default。 */
   score?: number;

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -87,6 +87,9 @@ export async function bulkDeployEvent(
   // Event.startsAt が未設定 = 競技開始時刻が決まっていないので採点開始しない gate に倒す。
   // operator は EventDetail の「日時を設定」or「即座に開始」で後から有効化できる。
   const eventStartsAt = typeof event.startsAt === "string" ? event.startsAt : undefined;
+  // Event.endsAt が設定済 (= 既に終了済 event) なら deploy 行にも denormalize して
+  // 採点 gate を即時 close する。READY 状態のみ end-event 可能なので通常は undefined。
+  const eventEndsAt = typeof event.endsAt === "string" ? event.endsAt : undefined;
 
   // teams × problems を全展開し、deployment 行 + publish entry を組み立てる。
   // shared.problemsCatalog (problemId → problemDir) に存在しない problemId は skip。
@@ -125,6 +128,7 @@ export async function bulkDeployEvent(
         eventId,
         teamId: team.teamId,
         eventStartsAt,
+        eventEndsAt,
       };
       items.push(item);
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/end-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/end-event.ts
@@ -1,0 +1,94 @@
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js";
+import type { EventItem } from "./types.js";
+
+/**
+ * `endEvent` の結果。
+ * - `not_found`: tenant 不一致 / event 不在 → 404 相当
+ * - `not_endable`: status が END に遷移可能でない (DRAFT / DEPLOYING / TEARDOWN /
+ *    ARCHIVED / ENDED) → 409 相当。READY のみ許可。
+ * - `ok`: 終了完了。endsAt と影響を受けた deployment 数を返す。
+ */
+export type EndEventOutcome =
+  | { kind: "not_found" }
+  | { kind: "not_endable"; status: string }
+  | { kind: "ok"; endsAt: string; updatedDeployments: number };
+
+/**
+ * Event を `ENDED` 状態にし、紐づく全 deployment 行に `eventEndsAt` を denormalize する。
+ *
+ * HealthCheckLambda は deployment 行の `eventEndsAt` を見て probe / 採点 gate を切る
+ * (now >= eventEndsAt なら skip)。Bulk Teardown 待たずに採点を停めるための path
+ * (Issue #494)。Event 単独更新では足りないので schedule.ts と同じ denormalize 戦略。
+ *
+ * `READY` 状態のみ「終了」可能。
+ *   - `DRAFT` / `DEPLOYING`: まだ動いていないので無意味
+ *   - `TEARDOWN` / `ARCHIVED`: 既に teardown 済 → 終了は redundant
+ *   - `ENDED`: 二重操作防止
+ */
+export async function endEvent(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  nowMs: number,
+): Promise<EndEventOutcome> {
+  const now = new Date(nowMs).toISOString();
+
+  let updatedEvent: Partial<EventItem> | undefined;
+  try {
+    const updateOut = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression: "SET #s = :ended, endsAt = :now, updatedAt = :now",
+        // tenant 跨ぎ防止 + status=READY のみ許可
+        ConditionExpression: "tenantId = :tenantId AND #s = :ready",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":ended": "ENDED",
+          ":ready": "READY",
+          ":now": now,
+          ":tenantId": tenantId,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    updatedEvent = updateOut.Attributes as Partial<EventItem> | undefined;
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      // tenant 不一致 / 行不在 / status != READY のいずれか。区別するため Get で確認。
+      const probe = await shared.ddb.send(
+        new (await import("@aws-sdk/lib-dynamodb")).GetCommand({
+          TableName: shared.eventsTableName,
+          Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        }),
+      );
+      const item = probe.Item as Partial<EventItem> | undefined;
+      if (!item || item.tenantId !== tenantId) return { kind: "not_found" };
+      return { kind: "not_endable", status: typeof item.status === "string" ? item.status : "?" };
+    }
+    throw err;
+  }
+  if (!updatedEvent) return { kind: "not_found" };
+
+  const deploymentsOut = await queryDeploymentsByEvent(shared, tenantId, eventId, "PK");
+  const targets = deploymentsOut
+    .map((d) => d as Pick<DeploymentItem, "PK">)
+    .filter((d) => typeof d.PK === "string");
+
+  await Promise.all(
+    targets.map((d) =>
+      shared.ddb.send(
+        new UpdateCommand({
+          TableName: shared.deploymentsTableName,
+          Key: { PK: d.PK, SK: "META" },
+          UpdateExpression: "SET eventEndsAt = :e, updatedAt = :now",
+          ExpressionAttributeValues: { ":e": now, ":now": now },
+        }),
+      ),
+    ),
+  );
+
+  return { kind: "ok", endsAt: now, updatedDeployments: targets.length };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -7,6 +7,7 @@ import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
   HTTP_BAD_REQUEST,
+  HTTP_CONFLICT,
   HTTP_CREATED,
   HTTP_INTERNAL_ERROR,
   HTTP_NOT_FOUND,
@@ -15,6 +16,7 @@ import {
 import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
+import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
 import { setEventSchedule } from "./schedule.js";
 import { buildEventSharedResources } from "./shared.js";
@@ -151,6 +153,28 @@ app.patch("/events/:eventId/schedule", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] setEventSchedule failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.post("/events/:eventId/end", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await endEvent(shared, resolveTenantId(c), eventId, Date.now());
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    if (outcome.kind === "not_endable") {
+      return c.json({ error: "not_endable", currentStatus: outcome.status }, HTTP_CONFLICT);
+    }
+    return c.json(
+      { endsAt: outcome.endsAt, updatedDeployments: outcome.updatedDeployments },
+      HTTP_OK,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] endEvent failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -27,9 +27,22 @@ export interface EventItem {
    * 値は分精度想定 (operator UI が DatePicker + TimeInput で入力)。
    */
   startsAt?: string;
+  /**
+   * 競技終了時刻 (ISO8601, UTC)。これ以降は HealthCheckLambda が probe / 採点を skip。
+   * operator が「Event を終了」 button を押した時点で `now()` が書かれ、status も
+   * `ENDED` に遷移する。Bulk Teardown 待たずに採点を停めるための gate (Issue #494)。
+   */
+  endsAt?: string;
 }
 
-export const EventStatusSchema = z.enum(["DRAFT", "DEPLOYING", "READY", "TEARDOWN", "ARCHIVED"]);
+export const EventStatusSchema = z.enum([
+  "DRAFT",
+  "DEPLOYING",
+  "READY",
+  "ENDED",
+  "TEARDOWN",
+  "ARCHIVED",
+]);
 export type EventStatus = z.infer<typeof EventStatusSchema>;
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -190,12 +190,15 @@ export { joinUrl };
  * deployment が採点対象かを判定。`eventStartsAt` が未設定 / 未来なら false。
  * - 未設定: 旧 jobId-based deployment / Event.startsAt 未設定 → 採点無し
  * - 未来: operator が schedule 済だがまだ時刻に到達していない → skip
+ * - 終了済み: `eventEndsAt` が設定されていて now >= eventEndsAt → skip (Issue #494)
  * 比較は ISO8601 文字列の辞書順比較で安全 (UTC ISO は時系列ソート可能)。
  */
 export function isScoringActive(
-  item: Pick<DeploymentItem, "eventStartsAt">,
+  item: Pick<DeploymentItem, "eventStartsAt" | "eventEndsAt">,
   nowIso: string,
 ): boolean {
   if (typeof item.eventStartsAt !== "string") return false;
-  return nowIso >= item.eventStartsAt;
+  if (nowIso < item.eventStartsAt) return false;
+  if (typeof item.eventEndsAt === "string" && nowIso >= item.eventEndsAt) return false;
+  return true;
 }

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -88,6 +88,7 @@ export class ApiGateway extends Construct {
     // /events/{eventId}            GET   = detail   / DELETE = bulk teardown
     // /events/{eventId}/deploy     POST  = bulk deploy (teams × problems を fan-out)
     // /events/{eventId}/schedule   PATCH = 競技開始時刻 (startsAt) を設定 (Phase 2b 追加)
+    // /events/{eventId}/end        POST  = Event を ENDED 状態にし採点を停止 (Issue #494)
     const eventIntegration = new LambdaIntegration(props.eventApiLambda);
     const events = this.restApi.root.addResource("events");
     events.addMethod("GET", eventIntegration, deployMethodOptions);
@@ -97,5 +98,6 @@ export class ApiGateway extends Construct {
     event.addMethod("DELETE", eventIntegration, deployMethodOptions);
     event.addResource("deploy").addMethod("POST", eventIntegration, deployMethodOptions);
     event.addResource("schedule").addMethod("PATCH", eventIntegration, deployMethodOptions);
+    event.addResource("end").addMethod("POST", eventIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/event-end.test.ts
+++ b/infrastructure/test/problem-deploy/event-end.test.ts
@@ -1,0 +1,172 @@
+import { GetCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { endEvent } from "../../lib/problem-deploy/handlers/event-handler/end-event";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: { send: vi.fn() } as unknown as EventSharedResources["events"],
+    problemsCatalog: {},
+  };
+  return { shared, ddbSend };
+}
+
+function conditionalFailure(): Error {
+  const err = new Error("conditional failed");
+  err.name = "ConditionalCheckFailedException";
+  return err;
+}
+
+describe("endEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: Event 行を ENDED に更新し全 deployment 行に eventEndsAt を伝播するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    // 1st: Event UpdateCommand returns Attributes (= status=READY が条件を満たした)
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        status: "ENDED",
+        endsAt: NOW_ISO,
+      },
+    });
+    // 2nd: Deployments QueryCommand
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "DEPLOYMENT#J1", eventId: "EV1" },
+        { PK: "DEPLOYMENT#J2", eventId: "EV1" },
+        { PK: "DEPLOYMENT#J3", eventId: "EV1" },
+      ],
+    });
+    // 3rd-5th: Deployments UpdateCommand × 3
+    ddbSend.mockResolvedValue({});
+
+    const out = await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "ok", endsAt: NOW_ISO, updatedDeployments: 3 });
+
+    // Event 更新の ConditionExpression が tenantId 一致 + status=READY を要求する
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(eventUpd).toBeInstanceOf(UpdateCommand);
+    expect(eventUpd.input.ConditionExpression).toBe("tenantId = :tenantId AND #s = :ready");
+    expect(eventUpd.input.ExpressionAttributeNames?.["#s"]).toBe("status");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":ready"]).toBe("READY");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":ended"]).toBe("ENDED");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+
+    // Deployments query は GSI1 = TENANT# + FilterExpression eventId 一致 (cross-event 漏洩防止)
+    const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    expect(queryCmd).toBeInstanceOf(QueryCommand);
+    expect(queryCmd.input.IndexName).toBe("GSI1");
+    expect(queryCmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+    expect(queryCmd.input.FilterExpression).toBe("eventId = :ev");
+    expect(queryCmd.input.ExpressionAttributeValues?.[":ev"]).toBe("EV1");
+
+    // Deployment update は EV1 行 3 件のみ走り、eventEndsAt = NOW_ISO を SET
+    const updCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
+    expect(updCmds).toHaveLength(3);
+    const updatedPks = updCmds.map((c) => (c.input.Key as { PK: string }).PK).sort();
+    expect(updatedPks).toEqual(["DEPLOYMENT#J1", "DEPLOYMENT#J2", "DEPLOYMENT#J3"]);
+    for (const cmd of updCmds) {
+      expect(cmd.input.UpdateExpression).toContain("eventEndsAt = :e");
+      expect(cmd.input.ExpressionAttributeValues?.[":e"]).toBe(NOW_ISO);
+    }
+  });
+
+  it("status != READY (= DRAFT 等) なら not_endable で 409 相当を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    // 1st: Event Update が ConditionalCheckFailed
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    // 2nd: probe Get で行は存在 + tenantId 一致 + status=DRAFT
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-acme", status: "DRAFT" },
+    });
+
+    const out = await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_endable", status: "DRAFT" });
+
+    // probe Get は GetCommand
+    expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(GetCommand);
+    // Deployments query / update は 1 度も走らない
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("Event 行不在 (probe で Item 無し) は not_found を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("tenant 不一致 (probe で別 tenant) は not_found を返すべき (cross-tenant 漏洩防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-other", status: "READY" },
+    });
+
+    const out = await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+    // 他 tenant の status を露出しないため not_endable ではなく not_found
+  });
+
+  it("対象 deployment が 0 件でも ok を返し updatedDeployments=0", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", status: "ENDED", endsAt: NOW_ISO },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    const out = await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "ok", endsAt: NOW_ISO, updatedDeployments: 0 });
+    // Deployment Update は走らない (Promise.all([]))
+    const updCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
+    expect(updCmds).toHaveLength(0);
+  });
+
+  it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", status: "ENDED", endsAt: NOW_ISO },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }] });
+    ddbSend.mockResolvedValue({});
+
+    await endEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
+    expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+    expect(deployUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+  });
+
+  it("ConditionalCheckFailedException 以外の DDB エラーはそのまま throw する", async () => {
+    const { shared, ddbSend } = buildShared();
+    const transientErr = new Error("ProvisionedThroughputExceededException");
+    transientErr.name = "ProvisionedThroughputExceededException";
+    ddbSend.mockRejectedValueOnce(transientErr);
+
+    await expect(endEvent(shared, "tenant-acme", "EV1", NOW_MS)).rejects.toThrow(
+      "ProvisionedThroughputExceededException",
+    );
+  });
+});

--- a/infrastructure/test/problem-deploy/health-check-handler.test.ts
+++ b/infrastructure/test/problem-deploy/health-check-handler.test.ts
@@ -29,6 +29,48 @@ describe("isScoringActive", () => {
     expect(isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z" }, NOW)).toBe(true);
     expect(isScoringActive({ eventStartsAt: "2025-01-01T00:00:00.000Z" }, NOW)).toBe(true);
   });
+
+  it("eventEndsAt 未設定は終了 gate 無し (= 旧 deployment / 終了未指示の event の既存挙動)", () => {
+    expect(isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z" }, NOW)).toBe(true);
+    expect(
+      isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z", eventEndsAt: undefined }, NOW),
+    ).toBe(true);
+  });
+
+  it("eventEndsAt が設定済で now < eventEndsAt なら true (= まだ競技中)", () => {
+    expect(
+      isScoringActive(
+        {
+          eventStartsAt: "2026-05-08T09:00:00.000Z",
+          eventEndsAt: "2026-05-08T11:00:00.000Z",
+        },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("eventEndsAt 設定済で now >= eventEndsAt なら false (= operator が終了済、採点停止)", () => {
+    // ちょうど終了時刻 (= 境界値、含む側) は false
+    expect(
+      isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z", eventEndsAt: NOW }, NOW),
+    ).toBe(false);
+    // 既に過去
+    expect(
+      isScoringActive(
+        {
+          eventStartsAt: "2026-05-08T09:00:00.000Z",
+          eventEndsAt: "2026-05-08T09:30:00.000Z",
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("eventStartsAt 未到達なら eventEndsAt が未設定でも false (= 開始 gate が優先)", () => {
+    expect(
+      isScoringActive({ eventStartsAt: "2026-05-08T11:00:00.000Z", eventEndsAt: undefined }, NOW),
+    ).toBe(false);
+  });
 });
 
 describe("joinUrl", () => {


### PR DESCRIPTION
## Summary

Issue (#494) — Event を「終わらせる」操作が無く、Bulk Teardown するまで採点が継続
していた問題。READY 状態の event を ENDED に遷移させ、HealthCheck の採点 gate を
即時 close する path を追加。

## 変更点

- backend: \`EventStatus\` に \`ENDED\` 追加、\`POST /events/:id/end\` handler、
  全 deployment 行への \`eventEndsAt\` 伝播、\`isScoringActive\` で gate 追加
- bulk-deploy: 新 deployment 行に eventEndsAt をコピー (= 既に終了済 event に
  追加 deploy したときの整合性)
- tenant API GW: \`POST /events/{eventId}/end\` route 追加
- frontend: 「Event を終了」 button (READY のみ enable) + 確認 Modal、
  ENDED / TEARDOWN / ARCHIVED 状態で Bulk Deploy も disable

## 物理影響

| 種別  | リソース | 注 |
| --- | --- | --- |
| UPDATE | event-handler Lambda | 新 route /end |
| UPDATE | tenant API GW | POST /events/{eventId}/end |
| UPDATE | health-check Lambda | isScoringActive に eventEndsAt gate |
| UPDATE | events / deployments 行 | 列追加 (sparse = 既存挙動維持) |
| UPDATE | application-admin-console SPA | UI 追加 |
| NO-OP | DDB schema (列追加のみ) / IAM / 他 stack | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (全体 484 件 pass)
- [ ] AWS deploy 後、READY 状態 event を「Event を終了」 → status=ENDED
- [ ] HealthCheck の次 tick で probe / 採点が skip される
- [ ] READY 以外の状態では button が disable

## Regression 分析

- 旧 deployment (eventEndsAt 未設定) は追加 gate に引っ掛からない (= 既存挙動維持)
- READY 以外で /end を叩くと 409 not_endable (= 二重操作 / 未開始 event の終了防止)
- ConditionExpression で tenantId + status=READY を atomic check (= レース防止)
- bulk-deploy への eventEndsAt copy は新 row のみに作用、既 row 影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)