### PR TITLE
fix(schedule): timezone offset を Zod で UTC Z に正規化

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -149,9 +149,20 @@ export type EventSummary = z.infer<typeof EventSummarySchema>;
  * `PATCH /events/:eventId/schedule` body。
  * - `{ startsAt: ISO8601 }`: operator 指定の日時 (分精度)
  * - `{ startNow: true }`: 即座に開始 (= server now を採用)
+ *
+ * `startsAt` は `+09:00` 等の non-Z オフセットも入力としては受け付けるが、
+ * **canonical UTC Z 形式に transform して persist する** (Issue #497)。
+ * 理由: HealthCheck の `isScoringActive` は ISO 8601 の辞書順比較を時系列比較として使うが、
+ * `Z` (0x5A) と `+` (0x2B) は code point 順が逆転するので、混在すると
+ * 「同年月日の異 timezone」の比較が壊れる。入り口で 1 形式に揃えてしまう。
  */
 export const ScheduleEventRequestSchema = z.union([
-  z.object({ startsAt: z.string().datetime({ offset: true }) }),
+  z.object({
+    startsAt: z
+      .string()
+      .datetime({ offset: true })
+      .transform((s) => new Date(s).toISOString()),
+  }),
   z.object({ startNow: z.literal(true) }),
 ]);
 export type ScheduleEventRequest = z.infer<typeof ScheduleEventRequestSchema>;

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -2,6 +2,7 @@ import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setEventSchedule } from "../../lib/problem-deploy/handlers/event-handler/schedule";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+import { ScheduleEventRequestSchema } from "../../lib/problem-deploy/handlers/event-handler/types";
 
 const NOW_MS = 1_700_000_000_000;
 const NOW_ISO = new Date(NOW_MS).toISOString();
@@ -121,5 +122,64 @@ describe("setEventSchedule", () => {
     const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
     expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
     expect(deployUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+  });
+});
+
+/**
+ * Issue #497: timezone offset の Zod 厳格化。
+ * `+09:00` 等の non-Z オフセットも入力では受理するが、出力は必ず Z 形式に正規化する
+ * (= 辞書順 ISO 8601 比較を HealthCheck の isScoringActive で安全に使うため)。
+ */
+describe("ScheduleEventRequestSchema (Issue #497)", () => {
+  it("Z 終端の ISO 8601 はそのまま受理されるべき (= 既存挙動維持)", () => {
+    const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T10:00:00.000Z" });
+    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
+    expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
+  });
+
+  it("`+09:00` オフセットは UTC Z に transform されるべき", () => {
+    const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T19:00:00+09:00" });
+    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
+    // JST 19:00 = UTC 10:00
+    expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
+  });
+
+  it("`-12:00` オフセットも UTC Z に transform されるべき (= 全 timezone を 1 形式に揃える)", () => {
+    const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T22:00:00-12:00" });
+    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
+    // -12:00 22:00 = UTC 翌日 10:00
+    expect(out.startsAt).toBe("2026-05-09T10:00:00.000Z");
+  });
+
+  it("オフセット無し (= naive) は reject (Zod datetime のデフォルト挙動)", () => {
+    const result = ScheduleEventRequestSchema.safeParse({
+      startsAt: "2026-05-08T10:00:00",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("不正な ISO 8601 文字列は reject", () => {
+    expect(ScheduleEventRequestSchema.safeParse({ startsAt: "not-a-date" }).success).toBe(false);
+    expect(ScheduleEventRequestSchema.safeParse({ startsAt: "2026-13-50" }).success).toBe(false);
+  });
+
+  it("`{ startNow: true }` は transform 対象外でそのまま通る", () => {
+    const out = ScheduleEventRequestSchema.parse({ startNow: true });
+    expect(out).toEqual({ startNow: true });
+  });
+
+  it("正規化後の値は辞書順比較が時系列順と一致するべき (Issue #497 root cause)", () => {
+    // `+12:00` 早朝 と `Z` 同日午前: 元の文字列で比べると "Z" > "+" なので壊れる
+    const tzPlus = ScheduleEventRequestSchema.parse({
+      startsAt: "2026-05-08T12:00:00+12:00", // = UTC 00:00
+    });
+    const utc = ScheduleEventRequestSchema.parse({
+      startsAt: "2026-05-08T05:00:00.000Z",
+    });
+    if (!("startsAt" in tzPlus) || !("startsAt" in utc)) throw new Error("分岐エラー");
+    // 正規化後は両方 Z 形式 → 辞書順 = 時系列順
+    expect(tzPlus.startsAt < utc.startsAt).toBe(true);
+    expect(tzPlus.startsAt).toBe("2026-05-08T00:00:00.000Z");
+    expect(utc.startsAt).toBe("2026-05-08T05:00:00.000Z");
   });
 });


### PR DESCRIPTION
## Summary

Issue (#497) (security review F1 follow-up): \`PATCH /events/:id/schedule\` の
\`startsAt\` zod が \`{ offset: true }\` で non-Z オフセット (\`+09:00\` 等) を許容して
いたが、persist 後に **辞書順 ISO 8601 比較で時系列が壊れる** (= \`isScoringActive\` で
混乱)。\`Z\` (0x5A) と \`+\` (0x2B) の code point 順が逆転するため。

## 修正

\`ScheduleEventRequestSchema\` に \`.transform((s) => new Date(s).toISOString())\` を追加し、
入力を **入り口で UTC Z 形式に正規化**:

\`\`\`ts
z.string()
  .datetime({ offset: true })
  .transform((s) => new Date(s).toISOString())
\`\`\`

- 入力 UX: そのまま (\`+09:00\` / \`-12:00\` / \`Z\` どれでも受理)
- 内部: 全 startsAt が canonical Z 形式 → 辞書順 = 時系列順
- HealthCheck \`isScoringActive\` の比較が timezone 跨ぎでも正しく動く

旧案 \`.datetime()\` (Z-only) より operator UX が良い (DatePicker の出力をそのまま送れる)。

## 物理影響

frontend / IaC / DDB schema 不変。Lambda の event-handler のみ。

## Test plan

- [x] \`make before-commit\` 緑 (event-schedule.test.ts +7 件)
- [x] 既存 \`setEventSchedule\` 4 ケース pass (= persist 経路の挙動不変)
- [ ] 実 deploy 後、operator UI から日時設定 → DDB 上の \`startsAt\` が Z 形式
- [ ] curl で \`+09:00\` を送って正規化されることを確認

## Regression 分析

- 既存 4 ケースは Z 形式を渡すので transform 後も同値 → no behavioral change
- \`.transform\` は zod 検証通過後に発火 → 不正 ISO は従来通り 400 reject
- DDB に既に保存済の non-Z startsAt は影響無し (= schedule 変更の都度正規化)
- frontend DatePicker は元から Z 出力なので影響無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)