### PR TITLE
feat(operator): Event アーカイブ UI と API

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -148,3 +148,16 @@ export interface EndEventResult {
 export async function endEvent(api: ApiClient, eventId: string): Promise<EndEventResult> {
   return api.post<EndEventResult>(`events/${encodeURIComponent(eventId)}/end`, {});
 }
+
+export interface ArchiveEventResult {
+  archivedAt: string;
+}
+
+/**
+ * Event を ARCHIVED 状態にして EventList のデフォルト view から外す soft delete (Issue #493)。
+ * 許可: DRAFT (一度も deploy していない) / ENDED (採点停止済) / TEARDOWN (一括削除済)。
+ * 拒否: DEPLOYING / READY / ARCHIVED は 409 で拒否される。
+ */
+export async function archiveEvent(api: ApiClient, eventId: string): Promise<ArchiveEventResult> {
+  return api.post<ArchiveEventResult>(`events/${encodeURIComponent(eventId)}/archive`, {});
+}

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -2,15 +2,22 @@ import Alert from "@cloudscape-design/components/alert";
 import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
+import Checkbox from "@cloudscape-design/components/checkbox";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
+import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { type NavigateFunction, useNavigate } from "react-router";
-import { useApiClient } from "../api/client";
-import { type EventStatus, type EventSummary, listEvents } from "../api/events-client";
+import { type ApiClient, ApiError, useApiClient } from "../api/client";
+import {
+  archiveEvent,
+  type EventStatus,
+  type EventSummary,
+  listEvents,
+} from "../api/events-client";
 import type { AppConfig } from "../config";
 
 const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
@@ -22,10 +29,19 @@ const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   ARCHIVED: "grey",
 };
 
+/** Archive 操作が許可される Event status (backend の archive.ts と一致)。 */
+const ARCHIVABLE_STATUSES: ReadonlySet<EventStatus> = new Set(["DRAFT", "ENDED", "TEARDOWN"]);
+
 const POLL_INTERVAL_MS = 10_000;
 const PAGE_SIZE = 50;
 
-function buildColumns(navigate: NavigateFunction): TableProps.ColumnDefinition<EventSummary>[] {
+interface ColumnContext {
+  navigate: NavigateFunction;
+  onArchiveClick: (item: EventSummary) => void;
+  archivingId: string | null;
+}
+
+function buildColumns(ctx: ColumnContext): TableProps.ColumnDefinition<EventSummary>[] {
   return [
     {
       id: "name",
@@ -36,7 +52,7 @@ function buildColumns(navigate: NavigateFunction): TableProps.ColumnDefinition<E
           href={`/events/${encodeURIComponent(item.eventId)}`}
           onFollow={(e) => {
             e.preventDefault();
-            navigate(`/events/${encodeURIComponent(item.eventId)}`);
+            ctx.navigate(`/events/${encodeURIComponent(item.eventId)}`);
           }}
         >
           {item.name}
@@ -51,6 +67,21 @@ function buildColumns(navigate: NavigateFunction): TableProps.ColumnDefinition<E
     { id: "teamCount", header: "チーム数", cell: (item) => item.teamCount },
     { id: "problemCount", header: "問題数", cell: (item) => item.problemCount },
     { id: "createdAt", header: "作成", cell: (item) => item.createdAt },
+    {
+      id: "actions",
+      header: "操作",
+      cell: (item) => (
+        <Button
+          variant="link"
+          loading={ctx.archivingId === item.eventId}
+          disabled={!ARCHIVABLE_STATUSES.has(item.status)}
+          onClick={() => ctx.onArchiveClick(item)}
+          ariaLabel={`Event ${item.name} をアーカイブ`}
+        >
+          アーカイブ
+        </Button>
+      ),
+    },
   ];
 }
 
@@ -59,7 +90,9 @@ export function EventListPage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const [items, setItems] = useState<readonly EventSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const columns = useMemo(() => buildColumns(navigate), [navigate]);
+  const [showArchived, setShowArchived] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<EventSummary | null>(null);
+  const [archivingId, setArchivingId] = useState<string | null>(null);
 
   const fetchOnce = useCallback(async () => {
     if (!apiClient) return;
@@ -86,6 +119,51 @@ export function EventListPage({ config }: { config: AppConfig }) {
     };
   }, [fetchOnce]);
 
+  const visible = useMemo(() => {
+    if (!items) return [];
+    return showArchived ? items : items.filter((i) => i.status !== "ARCHIVED");
+  }, [items, showArchived]);
+
+  const archivedCount = useMemo(
+    () => items?.filter((i) => i.status === "ARCHIVED").length ?? 0,
+    [items],
+  );
+
+  const onArchiveClick = useCallback((item: EventSummary) => {
+    setArchiveTarget(item);
+  }, []);
+
+  const handleArchiveConfirm = async () => {
+    if (!apiClient || !archiveTarget) return;
+    const target = archiveTarget;
+    setArchivingId(target.eventId);
+    setArchiveTarget(null);
+    setError(null);
+    try {
+      await archive(apiClient, target.eventId);
+      await fetchOnce();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        const match = err.message.match(/"currentStatus"\s*:\s*"([A-Z_]+)"/);
+        const current = match?.[1];
+        setError(
+          current
+            ? `Event "${target.name}" はアーカイブできません (現在: ${current}、許可: DRAFT / ENDED / TEARDOWN)`
+            : `Event "${target.name}" はアーカイブできません`,
+        );
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setArchivingId(null);
+    }
+  };
+
+  const columns = useMemo(
+    () => buildColumns({ navigate, onArchiveClick, archivingId }),
+    [navigate, onArchiveClick, archivingId],
+  );
+
   if (!items && !error) {
     return (
       <Box textAlign="center" padding="l">
@@ -109,21 +187,64 @@ export function EventListPage({ config }: { config: AppConfig }) {
       </Header>
 
       {error && (
-        <Alert type="error" header="一覧の取得に失敗しました">
+        <Alert type="error" header="エラー" dismissible onDismiss={() => setError(null)}>
           {error}
         </Alert>
       )}
 
+      {archivedCount > 0 && (
+        <Checkbox checked={showArchived} onChange={({ detail }) => setShowArchived(detail.checked)}>
+          アーカイブ済 ({archivedCount}) も表示
+        </Checkbox>
+      )}
+
       <Table
-        items={items ?? []}
+        items={visible}
         columnDefinitions={columns}
         loadingText="読み込み中"
         empty={
           <Box textAlign="center" color="inherit" padding="xxl">
-            まだ Event はありません。「新規 Event 作成」から始めてください。
+            {showArchived
+              ? "まだ Event はありません。「新規 Event 作成」から始めてください。"
+              : archivedCount > 0
+                ? "表示対象の Event はありません (アーカイブ済を含めるには上のチェックボックスを ON)。"
+                : "まだ Event はありません。「新規 Event 作成」から始めてください。"}
           </Box>
         }
       />
+
+      <Modal
+        visible={archiveTarget !== null}
+        header="Event をアーカイブしますか?"
+        onDismiss={() => setArchiveTarget(null)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setArchiveTarget(null)}>キャンセル</Button>
+              <Button variant="primary" onClick={handleArchiveConfirm}>
+                アーカイブ
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            Event <Box variant="strong">{archiveTarget?.name}</Box> をアーカイブし、 一覧の default
+            view から外します。
+          </Box>
+          <Box variant="small" color="text-status-info">
+            ARCHIVED から戻すことはできませんが、配下の deployment / Team 行は TTL で
+            自動消去されます。Bulk Teardown が未済の場合は先に実施してください。
+          </Box>
+        </SpaceBetween>
+      </Modal>
     </SpaceBetween>
   );
+}
+
+// archive を indirect 化して archive ボタンの onClick からだけ呼べるようにする (= test
+// で fakeClient を渡すための seam)。export しない。
+async function archive(client: ApiClient, eventId: string): Promise<void> {
+  await archiveEvent(client, eventId);
 }

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "../../src/api/client";
 import {
+  archiveEvent,
   bulkDeployEvent,
   bulkTeardownEvent,
   createEvent,
@@ -134,5 +135,16 @@ describe("endEvent", () => {
     expect(calls[0]?.body).toEqual({});
     expect(out.endsAt).toBe("2026-05-08T10:00:00.000Z");
     expect(out.updatedDeployments).toBe(12);
+  });
+});
+
+describe("archiveEvent", () => {
+  it("POST /events/{id}/archive を空 body で呼び ArchiveEventResult を返すべき", async () => {
+    const { client, calls } = fakeClient({ archivedAt: "2026-05-09T10:00:00.000Z" });
+    const out = await archiveEvent(client, "EV1");
+    expect(calls[0]?.path).toBe("events/EV1/archive");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.body).toEqual({});
+    expect(out.archivedAt).toBe("2026-05-09T10:00:00.000Z");
   });
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/archive.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/archive.ts
@@ -1,0 +1,79 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { EventSharedResources } from "./shared.js";
+import type { EventItem } from "./types.js";
+
+/**
+ * `archiveEvent` の結果。
+ * - `not_found`: tenant 不一致 / event 不在 → 404 相当
+ * - `not_archivable`: 進行中 (DEPLOYING / READY) や ARCHIVED 重複 → 409 相当
+ * - `ok`: ARCHIVED 遷移完了
+ */
+export type ArchiveEventOutcome =
+  | { kind: "not_found" }
+  | { kind: "not_archivable"; status: string }
+  | { kind: "ok"; archivedAt: string };
+
+/**
+ * 許可: DRAFT (一度も deploy していない) / ENDED (採点停止済) / TEARDOWN (一括削除済)。
+ * 拒否: DEPLOYING (deploy 中で展開中) / READY (現役 event) / ARCHIVED (二重操作)。
+ */
+const ARCHIVABLE_STATUSES = new Set(["DRAFT", "ENDED", "TEARDOWN"]);
+
+/**
+ * Event を `ARCHIVED` 状態に遷移させ、EventList のデフォルト view から外す soft delete。
+ *
+ * Issue #493: 完了 event を一覧から消す手段が無い問題への対応。Team 行 / Deployments の
+ * 物理削除はしない (= TTL に任せる)。これは:
+ *   - Bulk Teardown 済の event は deployment 行が DELETED 状態で残るが、TTL で消える
+ *   - Team 行も TTL を持つので放っておけば消える
+ *   - 物理削除を別 op にすると確認 modal が増えて UX 重くなる
+ *
+ * 状態遷移は `ConditionExpression` で atomic に check (= 並列操作のレース防止)。
+ */
+export async function archiveEvent(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  nowMs: number,
+): Promise<ArchiveEventOutcome> {
+  const now = new Date(nowMs).toISOString();
+
+  try {
+    await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression: "SET #s = :archived, archivedAt = :now, updatedAt = :now",
+        // tenant 跨ぎ防止 + 許可状態のみに限定 (DRAFT / ENDED / TEARDOWN)
+        ConditionExpression: "tenantId = :tenantId AND #s IN (:draft, :ended, :teardown)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":archived": "ARCHIVED",
+          ":draft": "DRAFT",
+          ":ended": "ENDED",
+          ":teardown": "TEARDOWN",
+          ":now": now,
+          ":tenantId": tenantId,
+        },
+      }),
+    );
+    return { kind: "ok", archivedAt: now };
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      // 行不在 / tenant 不一致 / 許可外状態のいずれか → probe で区別
+      const probe = await shared.ddb.send(
+        new GetCommand({
+          TableName: shared.eventsTableName,
+          Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        }),
+      );
+      const item = probe.Item as Partial<EventItem> | undefined;
+      if (!item || item.tenantId !== tenantId) return { kind: "not_found" };
+      const status = typeof item.status === "string" ? item.status : "?";
+      return { kind: "not_archivable", status };
+    }
+    throw err;
+  }
+}
+
+export const ARCHIVABLE_STATUSES_SET: ReadonlySet<string> = ARCHIVABLE_STATUSES;

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -13,6 +13,7 @@ import {
   HTTP_NOT_FOUND,
   HTTP_OK,
 } from "../shared/http-status.js";
+import { archiveEvent } from "./archive.js";
 import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
@@ -175,6 +176,25 @@ app.post("/events/:eventId/end", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] endEvent failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.post("/events/:eventId/archive", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await archiveEvent(shared, resolveTenantId(c), eventId, Date.now());
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    if (outcome.kind === "not_archivable") {
+      return c.json({ error: "not_archivable", currentStatus: outcome.status }, HTTP_CONFLICT);
+    }
+    return c.json({ archivedAt: outcome.archivedAt }, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] archiveEvent failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -33,6 +33,11 @@ export interface EventItem {
    * `ENDED` に遷移する。Bulk Teardown 待たずに採点を停めるための gate (Issue #494)。
    */
   endsAt?: string;
+  /**
+   * Archive 操作で `status=ARCHIVED` に遷移した時刻 (ISO 8601, UTC)。Issue #493。
+   * EventList が ARCHIVED を default view から外すときの sort key としても使える。
+   */
+  archivedAt?: string;
 }
 
 export const EventStatusSchema = z.enum([

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -99,5 +99,6 @@ export class ApiGateway extends Construct {
     event.addResource("deploy").addMethod("POST", eventIntegration, deployMethodOptions);
     event.addResource("schedule").addMethod("PATCH", eventIntegration, deployMethodOptions);
     event.addResource("end").addMethod("POST", eventIntegration, deployMethodOptions);
+    event.addResource("archive").addMethod("POST", eventIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/event-archive.test.ts
+++ b/infrastructure/test/problem-deploy/event-archive.test.ts
@@ -1,0 +1,124 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { archiveEvent } from "../../lib/problem-deploy/handlers/event-handler/archive";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: { send: vi.fn() } as unknown as EventSharedResources["events"],
+    problemsCatalog: {},
+  };
+  return { shared, ddbSend };
+}
+
+function conditionalFailure(): Error {
+  const err = new Error("conditional failed");
+  err.name = "ConditionalCheckFailedException";
+  return err;
+}
+
+describe("archiveEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系 (DRAFT): status を ARCHIVED に + archivedAt = now を SET するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "ok", archivedAt: NOW_ISO });
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd).toBeInstanceOf(UpdateCommand);
+    expect(cmd.input.UpdateExpression).toContain("#s = :archived");
+    expect(cmd.input.UpdateExpression).toContain("archivedAt = :now");
+    expect(cmd.input.ExpressionAttributeValues?.[":archived"]).toBe("ARCHIVED");
+    expect(cmd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+    // ConditionExpression が tenantId 一致 + status IN (DRAFT/ENDED/TEARDOWN) を要求
+    expect(cmd.input.ConditionExpression).toBe(
+      "tenantId = :tenantId AND #s IN (:draft, :ended, :teardown)",
+    );
+    expect(cmd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
+    expect(cmd.input.ExpressionAttributeValues?.[":draft"]).toBe("DRAFT");
+    expect(cmd.input.ExpressionAttributeValues?.[":ended"]).toBe("ENDED");
+    expect(cmd.input.ExpressionAttributeValues?.[":teardown"]).toBe("TEARDOWN");
+    // probe Get は走らない (= 1 回で完結)
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("status=READY (進行中) は not_archivable で 409 相当", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-acme", status: "READY" },
+    });
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_archivable", status: "READY" });
+    expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(GetCommand);
+  });
+
+  it("status=DEPLOYING も not_archivable", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-acme", status: "DEPLOYING" },
+    });
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_archivable", status: "DEPLOYING" });
+  });
+
+  it("status=ARCHIVED への二重 archive も not_archivable (= 冪等にせずレース防止を露出)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-acme", status: "ARCHIVED" },
+    });
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_archivable", status: "ARCHIVED" });
+  });
+
+  it("Event 行不在は not_found", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("tenant 不一致は not_found (cross-tenant 漏洩防止 = status を露出しない)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(conditionalFailure());
+    ddbSend.mockResolvedValueOnce({
+      Item: { eventId: "EV1", tenantId: "tenant-other", status: "DRAFT" },
+    });
+
+    const out = await archiveEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("ConditionalCheckFailedException 以外の DDB エラーは throw", async () => {
+    const { shared, ddbSend } = buildShared();
+    const transient = new Error("ProvisionedThroughputExceededException");
+    transient.name = "ProvisionedThroughputExceededException";
+    ddbSend.mockRejectedValueOnce(transient);
+
+    await expect(archiveEvent(shared, "tenant-acme", "EV1", NOW_MS)).rejects.toThrow(
+      "ProvisionedThroughputExceededException",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Issue (#493) — EventList から完了 event を一覧から外す手段が無かった。Event 行の
物理削除は TTL に任せ、operator には soft delete (= status を \`ARCHIVED\` に遷移 +
EventList default view から hide) を提供する。

- backend: \`POST /events/:id/archive\` (DRAFT / ENDED / TEARDOWN のみ許可)
- frontend: 各行に「アーカイブ」 button + 確認 Modal + 「アーカイブ済も表示」 Checkbox
- 409 エラーは \`currentStatus\` を抽出して具体的なメッセージ表示

## 物理影響

| 種別  | リソース | 注 |
| --- | --- | --- |
| UPDATE | event-handler Lambda | 新 route \`/archive\` |
| UPDATE | tenant API GW | POST /events/{eventId}/archive |
| UPDATE | events table 行 | archivedAt 列追加 (sparse) |
| UPDATE | application-admin-console SPA | UI 追加 |
| NO-OP | DDB schema (列追加のみ) / IAM / 他 stack | 不変 |

## Test plan

- [x] \`make before-commit\` 緑 (infra +7 / frontend +1、全体 503 件 pass)
- [ ] 実 deploy 後、ENDED 状態の event を「アーカイブ」 → status=ARCHIVED、一覧から消える
- [ ] 「アーカイブ済も表示」 ON で再表示
- [ ] READY 状態は button が disable
- [ ] curl で READY を archive すると 409

## Regression 分析

- 既存 event 行は \`archivedAt\` 未設定 → 既存挙動維持
- ARCHIVED は元から EventStatusSchema に含まれていたが、書き込み path が無かった
- ARCHIVED の event も EventDetail から閲覧可能 (EventList は表示 filter のみ)
- 物理削除は別途必要になったら follow-up issue で

🤖 Generated with [Claude Code](https://claude.com/claude-code)