### PR TITLE
docs(adr): ADR-006 Notifications 機能を起草 (HTML)

### DIFF
--- a/docs/architecture/adr-006-notifications.html
+++ b/docs/architecture/adr-006-notifications.html
@@ -1,0 +1,688 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-006: 運営 → 競技者 Notifications を Events table 同居 + 60 秒 polling で配信する</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.muted   { background: var(--c-bg-soft); color: var(--c-muted); }
+  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .8rem; margin: 1rem 0; }
+  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
+  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .decision-card .body { font-size: 0.88rem; color: var(--c-text); }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+
+  /* mockup styles */
+  .mock {
+    border: 1px solid var(--c-border); border-radius: 8px; background: #fafbfc;
+    padding: 1rem 1.25rem; margin: 1rem 0 1.5rem;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .mock-title {
+    font-size: 0.78rem; font-weight: 700; color: var(--c-link);
+    letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: .4rem;
+  }
+  .mock-frame {
+    background: #fff; border: 1px solid var(--c-border); border-radius: 6px;
+    padding: 1rem 1.25rem; min-height: 200px;
+  }
+  .mock h4 { margin: 0 0 .6rem; font-size: 1rem; color: var(--c-text); }
+  .pill-status {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: 4px 12px; border-radius: 16px; font-size: 0.85rem; font-weight: 600;
+  }
+  .pill-status::before { content: ""; width: 8px; height: 8px; border-radius: 50%; }
+  .pill-status.info { background: #cfe5ff; color: var(--c-link); }
+  .pill-status.info::before { background: var(--c-link); }
+  .pill-status.warning { background: #fff8c5; color: var(--c-warn); }
+  .pill-status.warning::before { background: var(--c-warn); }
+  .topnav-mock {
+    display: flex; align-items: center; gap: .8rem; padding: .6rem 1rem;
+    background: #232f3e; color: #fff; border-radius: 4px; font-size: 0.88rem;
+  }
+  .topnav-mock .brand { font-weight: 700; }
+  .topnav-mock .spacer { flex: 1; }
+  .topnav-mock .nav-item {
+    position: relative; padding: 4px 12px; border-radius: 3px; cursor: pointer;
+  }
+  .topnav-mock .nav-item:hover { background: rgba(255,255,255,0.1); }
+  .topnav-mock .badge-dot {
+    position: absolute; top: -2px; right: 0;
+    background: var(--c-reject); color: #fff; border-radius: 10px;
+    font-size: 0.7rem; padding: 1px 6px; min-width: 16px; text-align: center;
+    line-height: 1.4; font-weight: 700;
+  }
+  .notif-list { display: flex; flex-direction: column; gap: .6rem; }
+  .notif-item {
+    border: 1px solid var(--c-border); border-radius: 4px;
+    padding: .8rem 1rem; background: #fff; display: flex; gap: .8rem; align-items: flex-start;
+  }
+  .notif-item.unread { background: #f1f8ff; border-color: #c8e1ff; }
+  .notif-item .body { flex: 1; }
+  .notif-item .title { font-weight: 600; margin-bottom: .2rem; }
+  .notif-item .meta-row { font-size: 0.78rem; color: var(--c-muted); margin-top: .3rem; }
+  .modal-mock {
+    border: 1px solid var(--c-border); border-radius: 6px; background: #fff;
+    padding: 1rem 1.25rem; max-width: 480px; margin: 0 auto;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  }
+  .modal-mock h5 { margin: 0 0 .6rem; font-size: 1rem; }
+  .modal-mock .form-row { margin-bottom: .8rem; }
+  .modal-mock label { display: block; font-size: 0.82rem; color: var(--c-muted); margin-bottom: .2rem; }
+  .modal-mock input, .modal-mock textarea, .modal-mock select {
+    width: 100%; box-sizing: border-box; padding: 6px 10px;
+    border: 1px solid var(--c-border); border-radius: 3px; font-size: 0.9rem;
+  }
+  .modal-mock .btn-row {
+    display: flex; gap: .4rem; justify-content: flex-end; margin-top: .8rem;
+    padding-top: .6rem; border-top: 1px solid var(--c-border);
+  }
+  .btn { padding: 5px 14px; border-radius: 3px; font-size: 0.88rem; cursor: pointer;
+         border: 1px solid var(--c-border); background: var(--c-bg); }
+  .btn.primary { background: var(--c-link); color: #fff; border-color: var(--c-link); }
+
+  /* api block */
+  .api-block { border: 1px solid var(--c-border); border-radius: 6px; padding: 1rem 1.25rem;
+               margin: 1rem 0; background: var(--c-bg); }
+  .api-head { display: flex; gap: .6rem; align-items: baseline; margin-bottom: .6rem;
+              border-bottom: 1px solid var(--c-border); padding-bottom: .5rem; }
+  .api-method { display: inline-block; padding: 2px 10px; border-radius: 4px;
+                font-family: monospace; font-size: 0.8rem; font-weight: 700; }
+  .api-method.GET   { background: #ddf4e0; color: var(--c-accept); }
+  .api-method.POST  { background: #cfe5ff; color: var(--c-link); }
+  .api-path { font-family: monospace; font-size: 1rem; font-weight: 600; }
+  .api-tag  { font-size: 0.78rem; color: var(--c-muted); margin-left: auto; }
+  .api-block h4 { margin: .8rem 0 .3rem; font-size: 0.85rem; color: var(--c-muted);
+                  text-transform: uppercase; letter-spacing: 0.05em; }
+  .api-block pre { background: var(--c-code-bg); padding: .8rem 1rem; border-radius: 4px;
+                   overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: .3rem 0; }
+  .api-block td.req { color: var(--c-reject); font-weight: 600; }
+  .api-block td.opt { color: var(--c-muted); }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-006: 運営 → 競技者 Notifications を Events table 同居 + 60 秒 polling で配信する</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-10</div>
+    <div><b>Issue:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/499">#499</a></div>
+    <div><b>Related ADR:</b>
+      <a href="./adr-004-event-team-model.md">ADR-004</a> (Event/Team)、
+      <a href="./adr-005-battle-portal-ui.html">ADR-005</a> (polling 60s 統一)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>Participant Portal の <code>/notifications</code> route は現状 <code>PlaceholderPage</code>
+が貼ってある状態で、運営から競技者への通知 (例: 「14:00 に競技開始します」「メンテナンスで
+5 分停止します」「scoring 再開しました」) を出す機能が無い。本 ADR は (a) 通知データの保存
+場所、(b) 配信経路 (push vs pull)、(c) 既読管理、(d) 運営 UI、(e) 参加者 UI の 5 軸を確定する。</p>
+
+<table>
+<thead><tr><th>制約</th><th>由来</th><th>本 ADR への影響</th></tr></thead>
+<tbody>
+<tr><td>polling over SSE</td><td>memory <code>feedback_polling_over_sse</code></td>
+    <td>Web Push / WebSocket / SSE は使わない</td></tr>
+<tr><td>polling 60s 統一</td><td>ADR-005 D4</td>
+    <td>notifications 専用 polling も 60s で統一</td></tr>
+<tr><td>DDB は 1 RCU/1 WCU PROVISIONED</td><td><code>DynamoDbLowCapacity</code> Aspect</td>
+    <td>新テーブル増設は避ける</td></tr>
+<tr><td>tenant 分離はインフラ層で</td><td><code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code></td>
+    <td>notifications は EVENT# (tenant scope) で閉じる</td></tr>
+<tr><td>運営は tenant API + Cognito JWT、参加者は teamLoginKey bearer</td>
+    <td>既存 ADR-004 / ADR-005</td>
+    <td>同じ 2 経路に乗せる</td></tr>
+</tbody>
+</table>
+
+<h3>現状</h3>
+<ul>
+<li>frontend: <code>apps/participant-portal/src/App.tsx</code> で <code>/notifications</code> →
+  <code>PlaceholderPage</code> (「運営からの通知をここに表示します」)</li>
+<li>backend: 該当 API なし</li>
+<li>運営側: 通知を出す手段なし (= Slack 等の外部チャネル運用)</li>
+</ul>
+</section>
+
+<section>
+<h2>解くべき設計判断</h2>
+
+<h3>D1. データの保存先</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D1-A</b></td><td><span class="badge accept">採用</span></td>
+   <td>既存 <b>Events table</b> に同 partition で乗せる: <code>PK=EVENT#&lt;eventId&gt;</code>、<code>SK=NOTIFICATION#&lt;isoTimestamp&gt;#&lt;ulid&gt;</code></td>
+   <td>1 partition 内に META と Notification 行が混在 (= sparse single-table design)、Events Query に begins_with 必要</td></tr>
+<tr class="hide"><td>D1-B</td><td><span class="badge reject">却下</span></td>
+   <td>新 DDB <code>NotificationsTable</code></td>
+   <td>新テーブル増設で <code>DynamoDbLowCapacity</code> Aspect 影響範囲が広がる、運用コストも 1 段階増</td></tr>
+<tr class="hide"><td>D1-C</td><td><span class="badge reject">却下</span></td>
+   <td>Deployments table に <code>PK=NOTIFICATION#&lt;eventId&gt;</code></td>
+   <td>Deployments table の責務 (= 1 deployment 単位) を超えて混乱、ParticipantPortalLambda が DDB Read 権限を別 partition へ拡張する必要</td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D1-A の詳細 schema</summary>
+<table>
+<thead><tr><th>属性</th><th>型</th><th>説明</th></tr></thead>
+<tbody>
+<tr><td><code>PK</code></td><td>String</td><td><code>EVENT#&lt;eventId&gt;</code> (既存と同じ)</td></tr>
+<tr><td><code>SK</code></td><td>String</td><td><code>NOTIFICATION#&lt;occurredAt&gt;#&lt;ulid&gt;</code> (時系列で sort 可能)</td></tr>
+<tr><td><code>tenantId</code></td><td>String</td><td>tenant 跨ぎ防止 check 用</td></tr>
+<tr><td><code>eventId</code></td><td>String</td><td>解析しやすさのため復元</td></tr>
+<tr><td><code>notificationId</code></td><td>String</td><td>ULID (= SK 内の ulid と同じ)</td></tr>
+<tr><td><code>title</code></td><td>String</td><td>1 行サマリ、120 chars max</td></tr>
+<tr><td><code>body</code></td><td>String</td><td>本文、2000 chars max</td></tr>
+<tr><td><code>severity</code></td><td>String</td><td><code>"info"</code> | <code>"warning"</code> (D4)</td></tr>
+<tr><td><code>createdBy</code></td><td>String</td><td>operator の Cognito sub (監査用)</td></tr>
+<tr><td><code>occurredAt</code></td><td>String</td><td>ISO 8601 UTC、SK 内と同じ値を attribute にも</td></tr>
+<tr><td><code>expiresAt</code></td><td>Number</td><td>DDB TTL、event の expiresAt と同じ</td></tr>
+</tbody>
+</table>
+</details>
+
+<h3>D2. 既読管理</h3>
+
+<p>既読 (read state) を <b>server-side で管理しない</b>。理由:</p>
+<ul>
+<li>1 team = 複数競技者でログインキー共有運用 (Phase 2c) なので「user 単位の既読」概念が
+  そもそも曖昧 (= 同 team の別ブラウザで読んだら既読扱い? それとも全員別?)</li>
+<li>per-user read tracking を始めると DDB row が爆発 (= notifications × users)、
+  <code>DynamoDbLowCapacity</code> Aspect の 1 WCU では捌けない</li>
+<li>shared 運用では「最後に表示した notification の occurredAt」を <b>browser localStorage</b>
+  に保存し、それより新しいものを「unread」と扱うのが UX として十分</li>
+</ul>
+
+<p>→ Decision 2: <b>localStorage に <code>lastSeenAt</code> を保存、それより新しい notification 数を
+unread として TopNav に表示</b>。サーバー API には read endpoint を作らない。</p>
+
+<h3>D3. 配信経路 (push vs pull)</h3>
+
+<p>Web Push / SSE / WebSocket は <code>feedback_polling_over_sse</code> + ADR-005 D4 と
+整合させて使わない。<b>polling 60 秒</b> で統一する (ADR-005 と同じ tick)。</p>
+
+<table>
+<thead><tr><th>層</th><th>tick</th><th>備考</th></tr></thead>
+<tbody>
+<tr><td>backend (運営の write)</td><td>operator が手動 trigger</td>
+    <td>頻度低 (1 イベント数件想定)、batch / scheduler 不要</td></tr>
+<tr><td>frontend (TopNav 未読 badge)</td><td>60 秒</td>
+    <td>TeamViewProvider と同じ tick に乗せて 1 系統に集約 (= 別 polling は立てない)</td></tr>
+<tr><td>frontend (/notifications page)</td><td>page open 時 + 60 秒</td>
+    <td>page を見ている間だけ更新、closing 時に lastSeenAt を localStorage に commit</td></tr>
+</tbody>
+</table>
+
+<h3>D4. severity</h3>
+
+<p>初期 release では <b>2 段階</b> のみ。後で必要になれば追加。</p>
+
+<table>
+<thead><tr><th>severity</th><th>意図</th><th>UI 表現</th></tr></thead>
+<tbody>
+<tr><td><code>info</code></td><td>普通の通知 (例: 「scoring 再開しました」)</td>
+    <td>青い <code>pill-status info</code> badge、TopNav badge は普通色</td></tr>
+<tr><td><code>warning</code></td><td>注意喚起 (例: 「30 分後にメンテで 5 分停止」)</td>
+    <td>黄色い <code>pill-status warning</code> badge、TopNav badge は強調色</td></tr>
+</tbody>
+</table>
+
+<p>(参考: 案として <code>urgent</code> / <code>error</code> もあり得るが、Battle のゲーム性に
+通知 spam で影響を与えるリスクがあるので <b>導入しない</b>。本当に urgent なら Slack 等で別配信)</p>
+
+<h3>D5. ライフタイム / TTL</h3>
+
+<p>Notification 行の <code>expiresAt</code> は <b>event 行の <code>expiresAt</code> と同じ値</b>
+を使う。理由:</p>
+<ul>
+<li>event 終了後に古い notification を残す意味が薄い (= 競技者は次 event の通知を見る)</li>
+<li>DDB TTL に乗せて自動削除 (= 運用 op 不要)</li>
+<li>event archive (= ARCHIVED) しても TTL までは見える (= 競技者の振り返り猶予)</li>
+</ul>
+
+<h3>D6. 運営 UI 配置</h3>
+
+<p>運営側の通知作成 UI は <b>EventDetail 画面の中に modal で組み込む</b>。理由:</p>
+<ul>
+<li>「event 単位で通知を打つ」が自然 (= cross-event の通知は要求されていない)</li>
+<li>新 page を立てると navigation 増、既存 EventDetail に「通知」 section と modal を貼れば 1 画面で完結</li>
+<li>operator の workflow: 競技開始時刻設定 → Bulk Deploy → 通知発信、と同じ画面で完結</li>
+</ul>
+
+<h3>D7. Web Push / Browser Notification API</h3>
+
+<p><b>本 ADR では扱わない</b> (= Phase 4+ 以降)。理由:</p>
+<ul>
+<li>Web Push は Service Worker + VAPID key + browser permission 必要 (= 実装規模大)</li>
+<li>polling 60s で「2 分以内に届けば十分」が満たせるので、push の必要性は低い</li>
+<li>競技者は Portal を開いて競技中なので、画面内 TopNav badge で十分視認できる</li>
+</ul>
+</section>
+
+<section>
+<h2>Decision (まとめ)</h2>
+
+<div class="decisions">
+  <div class="decision-card">
+    <div class="num">D1</div>
+    <div class="title">storage</div>
+    <div class="body">既存 Events table に同 partition で乗せる (<code>SK=NOTIFICATION#...</code>)。新 DDB は立てない</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D2</div>
+    <div class="title">既読管理</div>
+    <div class="body">server-side で管理しない。browser <code>localStorage</code> に <code>lastSeenAt</code> を保存、それより新しい数を unread として表示</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D3</div>
+    <div class="title">配信経路</div>
+    <div class="body">polling 60 秒 (ADR-005 と統一)。SSE / Web Push 不使用</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D4</div>
+    <div class="title">severity</div>
+    <div class="body"><code>info</code> / <code>warning</code> の 2 段階のみ。<code>urgent</code> 等は導入しない</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D5</div>
+    <div class="title">TTL</div>
+    <div class="body">event の <code>expiresAt</code> と同じ値で DDB TTL に乗せて自動削除</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D6</div>
+    <div class="title">運営 UI</div>
+    <div class="body">EventDetail 画面内の modal。新 page は立てない</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D7</div>
+    <div class="title">Web Push</div>
+    <div class="body">本 ADR では扱わない (Phase 4+)</div>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>UI モックアップ (動作する prototype)</h2>
+
+<div class="mock">
+  <div class="mock-title">Mockup 1 — 運営 EventDetail 内の通知 modal (D6)</div>
+  <div class="mock-frame">
+    <div class="modal-mock">
+      <h5>通知を送る — Event "Spring Battle 2026"</h5>
+      <div class="form-row">
+        <label for="m-title">タイトル (120 chars max)</label>
+        <input id="m-title" type="text" value="14:30 から scoring を再開します"/>
+      </div>
+      <div class="form-row">
+        <label for="m-body">本文 (2000 chars max)</label>
+        <textarea id="m-body" rows="4">メンテナンスのため一時停止していた scoring を 14:30 から再開します。各チームの健全性確認が完了次第、攻撃を開始してください。</textarea>
+      </div>
+      <div class="form-row">
+        <label for="m-severity">Severity</label>
+        <select id="m-severity">
+          <option>info — 普通の通知</option>
+          <option>warning — 注意喚起</option>
+        </select>
+      </div>
+      <div class="btn-row">
+        <button class="btn">キャンセル</button>
+        <button class="btn primary">送信</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mock">
+  <div class="mock-title">Mockup 2 — 参加者 TopNav 未読 badge</div>
+  <div class="mock-frame" style="padding-bottom: 1.4rem;">
+    <div class="topnav-mock">
+      <span class="brand">TenkaCloud — Spring Battle 2026</span>
+      <span class="spacer"></span>
+      <span class="nav-item">Score: 1380 pt / Rank: 2/4</span>
+      <span class="nav-item">
+        通知
+        <span class="badge-dot">3</span>
+      </span>
+      <span class="nav-item">Bravo (あなた) ▾</span>
+    </div>
+    <p style="font-size:0.85rem;color:var(--c-muted);margin-top:.6rem;">
+      ⓘ unread 数 (= localStorage の <code>lastSeenAt</code> 以降の notification 数) を赤い dot badge で表示。
+      0 件のときは badge を出さない。click で <code>/notifications</code> 画面へ遷移し、その時点の最新
+      notification の <code>occurredAt</code> を <code>lastSeenAt</code> に commit する。
+    </p>
+  </div>
+</div>
+
+<div class="mock">
+  <div class="mock-title">Mockup 3 — 参加者 /notifications 一覧画面</div>
+  <div class="mock-frame">
+    <h4>通知 <span style="font-size:0.85rem;color:var(--c-muted);font-weight:400;">— Spring Battle 2026、新しい順、1 分ごと自動更新</span></h4>
+    <div class="notif-list">
+      <div class="notif-item unread">
+        <span class="pill-status warning">warning</span>
+        <div class="body">
+          <div class="title">14:50 から 5 分メンテナンス停止します</div>
+          <div>scoring engine の hotfix 適用のため、14:50 〜 14:55 に scoring を一時停止します。攻撃 / 防御は継続できますが、score は加算されません。</div>
+          <div class="meta-row">2026-05-10 14:42:18 ・ 運営</div>
+        </div>
+      </div>
+      <div class="notif-item unread">
+        <span class="pill-status info">info</span>
+        <div class="body">
+          <div class="title">14:30 から scoring を再開します</div>
+          <div>メンテナンスのため一時停止していた scoring を 14:30 から再開します。各チームの健全性確認が完了次第、攻撃を開始してください。</div>
+          <div class="meta-row">2026-05-10 14:28:00 ・ 運営</div>
+        </div>
+      </div>
+      <div class="notif-item unread">
+        <span class="pill-status info">info</span>
+        <div class="body">
+          <div class="title">競技開始しました!</div>
+          <div>Spring Battle 2026 の競技時間が開始されました。10 問の Battle / Challenge の混成です。Quests から各問題を確認してください。</div>
+          <div class="meta-row">2026-05-10 13:00:00 ・ 運営</div>
+        </div>
+      </div>
+      <div class="notif-item">
+        <span class="pill-status info">info</span>
+        <div class="body">
+          <div class="title">[テスト] hello-world 問題のお知らせ</div>
+          <div>テスト通知です。本通知が見えていれば notifications 機能は正常に動いています。</div>
+          <div class="meta-row">2026-05-10 12:55:00 ・ 運営</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>API 設計</h2>
+
+<h3>新設 API</h3>
+
+<div class="api-block">
+  <div class="api-head">
+    <span class="api-method POST">POST</span>
+    <span class="api-path">/events/:eventId/notifications</span>
+    <span class="api-tag">運営側、Cognito JWT 認可</span>
+  </div>
+
+  <p>operator が指定 event に対して通知を 1 件作成する。</p>
+
+  <h4>Auth</h4>
+  <p>tenant API (= application-admin-console) 経由で <code>Authorization: Bearer &lt;cognitoIdToken&gt;</code>。
+  <code>resolveTenantId</code> で <code>custom:tenantId</code> claim を取り出し、対象 event の
+  tenantId と一致することを check。</p>
+
+  <h4>Request body</h4>
+  <pre>{
+  "title": "14:30 から scoring を再開します",
+  "body": "メンテナンスのため...",
+  "severity": "info"
+}</pre>
+  <table>
+  <thead><tr><th>field</th><th>必須</th><th>制約</th></tr></thead>
+  <tbody>
+  <tr><td><code>title</code></td><td class="req">required</td><td>1 〜 120 chars</td></tr>
+  <tr><td><code>body</code></td><td class="req">required</td><td>1 〜 2000 chars</td></tr>
+  <tr><td><code>severity</code></td><td class="opt">optional (default <code>info</code>)</td><td><code>"info"</code> | <code>"warning"</code></td></tr>
+  </tbody>
+  </table>
+
+  <h4>Response 201 Created</h4>
+  <pre>{
+  "notificationId": "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+  "occurredAt": "2026-05-10T14:42:18.000Z"
+}</pre>
+
+  <h4>Errors</h4>
+  <table>
+  <thead><tr><th>code</th><th>body</th><th>条件</th></tr></thead>
+  <tbody>
+  <tr><td>400</td><td><code>{"error":"validation_failed","issues":[...]}</code></td><td>title / body / severity が制約違反</td></tr>
+  <tr><td>404</td><td><code>{"error":"not_found"}</code></td><td>event 不在 / tenant 不一致</td></tr>
+  </tbody>
+  </table>
+</div>
+
+<div class="api-block">
+  <div class="api-head">
+    <span class="api-method GET">GET</span>
+    <span class="api-path">/portal/me/notifications</span>
+    <span class="api-tag">参加者、Bearer teamLoginKey 認可</span>
+  </div>
+
+  <p>自 team が紐づく event の通知一覧を時系列降順で返す (最新が先頭)。</p>
+
+  <h4>Auth</h4>
+  <p><code>Authorization: Bearer &lt;teamLoginKey&gt;</code></p>
+
+  <h4>Request — Query parameters</h4>
+  <table>
+  <thead><tr><th>名前</th><th>必須</th><th>制約</th><th>意味</th></tr></thead>
+  <tbody>
+  <tr><td><code>limit</code></td><td class="opt">optional (default 100)</td><td>1 〜 200</td><td>取得件数上限</td></tr>
+  </tbody>
+  </table>
+
+  <h4>Response 200 OK</h4>
+  <pre>{
+  "eventId": "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+  "items": [
+    {
+      "notificationId": "01J0...",
+      "title": "14:30 から scoring を再開します",
+      "body": "メンテナンスのため...",
+      "severity": "info",
+      "occurredAt": "2026-05-10T14:28:00.000Z"
+    }
+  ]
+}</pre>
+
+  <h4>Errors</h4>
+  <table>
+  <thead><tr><th>code</th><th>body</th><th>条件</th></tr></thead>
+  <tbody>
+  <tr><td>401</td><td><code>{"error":"unauthorized"}</code></td><td>bearer 不在 / teamLoginKey 不一致</td></tr>
+  <tr><td>404</td><td><code>{"error":"no_event"}</code></td><td>team が event に紐づいていない (= 旧 jobId-based deployment)</td></tr>
+  </tbody>
+  </table>
+
+  <h4>Backend 実装</h4>
+  <ul>
+  <li>handler: <code>infrastructure/lib/problem-deploy/handlers/participant-handler/notifications.ts</code> (新規)</li>
+  <li>auth: 既存 <code>queryTeamItems</code> で teamLoginKey から team の deployments → eventId を解決</li>
+  <li>DDB Query: <code>PK=EVENT#&lt;eventId&gt;</code> AND <code>begins_with(SK, "NOTIFICATION#")</code>、<code>ScanIndexForward=false</code> で降順</li>
+  </ul>
+</div>
+
+<h3>変更しない API</h3>
+<table>
+<thead><tr><th>endpoint</th><th>変更</th></tr></thead>
+<tbody>
+<tr><td><code>GET /portal/me</code></td><td>不変 (TopNav 未読 badge は本 endpoint の polling 結果には乗せず、別 endpoint <code>/portal/me/notifications</code> から取る)</td></tr>
+<tr><td><code>GET /events/:eventId</code></td><td>不変。EventDetail で notification 一覧を見たい場合は新 endpoint <code>/events/:eventId/notifications</code> (operator 用 GET) が将来必要、本 ADR では unscope</td></tr>
+</tbody>
+</table>
+
+<h3>API GW / IAM</h3>
+<ul>
+<li>tenant API GW: <code>events/{eventId}/notifications</code> を追加 (POST、Cognito JWT authorizer)</li>
+<li>Function URL (Participant Portal Lambda): path-pattern なしで Hono が振り分け、CDK 変更不要</li>
+<li>IAM: ParticipantPortalLambda の DDB policy に <code>events</code> table の <code>Query</code> 権限を追加 (= 既存は Deployments table のみ参照)</li>
+</ul>
+</section>
+
+<section>
+<h2>Implementation ownership</h2>
+
+<table>
+<thead><tr><th>領域</th><th>Owner</th><th>備考</th></tr></thead>
+<tbody>
+<tr><td>tenant API GW <code>events/{eventId}/notifications</code> POST 配線</td>
+    <td><span class="badge warn">user</span></td><td>既存 <code>api-gateway.ts</code> の延長</td></tr>
+<tr><td>ParticipantPortalLambda の IAM policy 拡張 (events table の <code>Query</code> 権限追加)</td>
+    <td><span class="badge warn">user</span></td><td><code>participant-portal-lambda.ts</code> の inlinePolicies</td></tr>
+<tr><td>event-handler に <code>POST /events/:id/notifications</code> handler 追加</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td><code>handlers/event-handler/notifications.ts</code> 新規</td></tr>
+<tr><td>participant-handler に <code>GET /portal/me/notifications</code> handler 追加</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td><code>handlers/participant-handler/notifications.ts</code> 新規</td></tr>
+<tr><td>frontend operator: EventDetail に「通知を送る」 modal + 履歴 section</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>既存 EventDetail に追加</td></tr>
+<tr><td>frontend participant: <code>/notifications</code> page 実体化 + TopNav 未読 badge</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>PlaceholderPage 置換、AppLayout に badge 追加</td></tr>
+<tr><td>localStorage の <code>lastSeenAt</code> 管理 helper</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td><code>auth/storage.ts</code> 同居 or <code>lib/notifications-read-state.ts</code></td></tr>
+<tr><td>backend / frontend tests</td>
+    <td><span class="badge accept">Claude</span></td><td>handler unit test + frontend integration</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Migration</h2>
+
+<details open>
+<summary>Phase 4.1 (本 ADR 実装の最初の PR、scope 中)</summary>
+<ol>
+<li>Events table の write 権限を持つ event-handler Lambda が <code>NOTIFICATION#&lt;ts&gt;#&lt;ulid&gt;</code> SK で行を書けることを CDK レベルで確認 (= 既存権限で OK と想定、不足なら追加)</li>
+<li><code>POST /events/:id/notifications</code> handler 実装 (validation + DDB PutItem)</li>
+<li>tenant API GW route 追加 (<b>user 担当</b>)</li>
+<li>ParticipantPortalLambda の IAM に events table Query 追加 (<b>user 担当</b>)</li>
+<li><code>GET /portal/me/notifications</code> handler 実装 (auth → eventId 解決 → DDB Query)</li>
+</ol>
+
+<h4>追加するテスト (Phase 4.1)</h4>
+<ul>
+<li>POST: title 121 chars / body 2001 chars / severity 不正 → 400</li>
+<li>POST: tenant 不一致 / event 不在 → 404</li>
+<li>POST: 正常系で notification row が DDB に書き込まれる + Response 201</li>
+<li>GET: bearer 不在 → 401、team が event 紐付き無し → 404</li>
+<li>GET: 正常系で <code>occurredAt</code> 降順</li>
+<li>GET: <code>limit</code> 上限 200、不正値で 400</li>
+</ul>
+</details>
+
+<details>
+<summary>Phase 4.2 (frontend、scope 中)</summary>
+<ol>
+<li>EventDetail に「通知を送る」 button + Modal + 過去通知 list</li>
+<li>Participant Portal の <code>/notifications</code> page 実装 (PlaceholderPage 置換)</li>
+<li>TopNav 未読 badge (TeamViewProvider と同じ 60 秒 polling に乗せる)</li>
+<li><code>lastSeenAt</code> localStorage 管理 (= page 開いたときに最新 occurredAt を保存)</li>
+</ol>
+</details>
+
+<details>
+<summary>Phase 4.3 (運用ガイドライン)</summary>
+<ul>
+<li><code>docs/operations/notifications.md</code> 新設、運営向け「いつ何を通知すべきか」のガイド</li>
+<li>severity 使い分けガイドライン (info vs warning)</li>
+</ul>
+</details>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>Positive</h3>
+<ul>
+<li>運営が Slack 等の外部チャネルに依存せず Portal 内で完結して通知できる</li>
+<li>新 DDB を立てない (D1-A) ので運用コスト 0、<code>DynamoDbLowCapacity</code> Aspect の影響範囲不変</li>
+<li>polling 60 秒で 2 分以内に届くので Battle のゲーム性に十分</li>
+<li>localStorage 既読管理 (D2) で per-user read tracking の DDB 爆発を回避</li>
+</ul>
+
+<h3>Negative</h3>
+<ul>
+<li>shared teamLoginKey 運用なので「同 team の別 user が既読にした」を別 user は知らない (= 各人 localStorage、別 device は別管理)</li>
+<li>Web Push が無いので Portal を閉じている人には届かない (= 競技中は Portal 開きっぱなし前提)</li>
+<li>Events table の partition に異種 row (META + NOTIFICATION) が混在し、Query 時の begins_with 必須</li>
+</ul>
+
+<h3>Capacity 見積もり</h3>
+
+<table>
+<thead><tr><th>項目</th><th>値</th><th>根拠</th></tr></thead>
+<tbody>
+<tr><td>1 event の通知件数</td><td>5 〜 20 件</td><td>運用想定 (開始 / 中盤 / 終了 + メンテ通知)</td></tr>
+<tr><td>1 行サイズ</td><td>~2 KB (title + body 含む)</td><td>body 最大 2000 chars + meta</td></tr>
+<tr><td>Query (1 event 全件) のサイズ</td><td>~40 KB (20 行 × 2KB)</td><td>begins_with で notification のみ</td></tr>
+<tr><td>必要 RCU (eventually consistent)</td><td>~5 RCU</td><td>40KB / 8KB = 5 RCU/req、25 teams × 60s polling = 25/min = 0.4 req/s</td></tr>
+<tr><td>burst capacity</td><td>OK</td><td>DDB 標準 burst 5 分で十分吸収可</td></tr>
+</tbody>
+</table>
+
+<p><b>結論</b>: <code>DynamoDbLowCapacity</code> Aspect の 1 RCU PROVISIONED でも burst capacity
+で吸収可。継続的に 25 teams 同時 polling する場合の peak は ~10 RCU 相当だが、毎分の
+spike なので burst credit (= 300 RCU/min 相当) で十分。実測でスロットルが起きたら
+Phase 4 の follow-up で <code>limit</code> 既定値を 50 に下げるか auto-scaling 検討。</p>
+</section>
+
+<section>
+<h2>関連リソース</h2>
+<table>
+<thead><tr><th>リソース</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td><a href="https://github.com/susumutomita/TenkaCloud/issues/499">Issue 499</a></td><td>本 ADR の起票元</td></tr>
+<tr><td><a href="./adr-004-event-team-model.md">ADR-004</a></td><td>Events table の partition 設計、本 ADR は同 partition に NOTIFICATION SK を追加する</td></tr>
+<tr><td><a href="./adr-005-battle-portal-ui.html">ADR-005</a></td><td>polling 60 秒の決定。本 ADR も同じ tick に揃える</td></tr>
+<tr><td><a href="../../apps/participant-portal/src/App.tsx"><code>App.tsx</code></a></td><td><code>/notifications</code> route の PlaceholderPage を Phase 4.2 で置換</td></tr>
+<tr><td><a href="../../apps/participant-portal/src/components/AppLayout.tsx"><code>AppLayout.tsx</code></a></td><td>TopNav 未読 badge の追加先</td></tr>
+<tr><td><a href="../../apps/application-admin-console/src/pages/EventDetail.tsx"><code>EventDetail.tsx</code></a></td><td>運営側 modal + 履歴 section の追加先</td></tr>
+</tbody>
+</table>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Issue (#499) に対する ADR-006 を **HTML** で新規起草。運営 → 競技者の通知機能を
**Events table 同居 + 60 秒 polling + localStorage 既読管理** で配信する。ADR-005 と
同じ HTML format + 動くモックアップ + API spec 付き。

## 7 Decisions

| # | 内容 |
| - | ---- |
| D1 | storage = 既存 Events table に同 partition で乗せる (\`PK=EVENT#<id>\`、\`SK=NOTIFICATION#<ts>#<ulid>\`)。新 DDB は立てない |
| D2 | 既読管理 = server-side で持たない。browser localStorage に \`lastSeenAt\` を保存し、それ以降の数を unread として TopNav badge 表示 |
| D3 | 配信経路 = polling 60 秒 (ADR-005 と統一)、SSE / Web Push 不使用 |
| D4 | severity = \`info\` / \`warning\` の 2 段階のみ (urgent は導入しない) |
| D5 | TTL = event の \`expiresAt\` と同じ値で DDB TTL 自動削除 |
| D6 | 運営 UI = EventDetail 画面内の modal (新 page 立てない) |
| D7 | Web Push / Browser Notification API = Phase 4+ で扱う、本 ADR ではスコープ外 |

## API 設計

新設 2 endpoint を contract レベルで定義:

- **\`POST /events/:eventId/notifications\`** (運営、Cognito JWT) — title / body / severity
- **\`GET /portal/me/notifications\`** (参加者、Bearer teamLoginKey) — 自 event 一覧

## UI モックアップ 3 枚を埋め込み (D6 で動作確認)

1. **運営 EventDetail 内の通知 modal** — title / body / severity input + 送信 button
2. **参加者 TopNav 未読 badge** — 赤い dot + 件数
3. **参加者 /notifications 一覧画面** — severity badge (info/warning) + unread highlight + 時系列降順

## Capacity 見積もり

20 通知 × 25 teams × 60s polling = ~5 RCU/req peak、DDB burst capacity で吸収可。
1 RCU PROVISIONED でも実用上問題なし。

## 物理影響

docs のみ。コード / CDK / DDB 不変。Issue #499 の completion criteria のうち
「設計判断」「データモデル」「2 経路の API spec」を満たす。実装は Phase 4 PR 群で別途。

## Regression 分析

- **既存 ADR との矛盾**: ADR-001〜005 を grep、矛盾なし。本 ADR は ADR-004 (Events
  table partition) を拡張し ADR-005 (polling 60s) に同調する形
- **harness.md との整合**: \`INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER\` 維持 (notifications
  も EVENT# tenant scope)
- **既存コードの前提**: Events table への新 SK 追加なので既存 META row 影響なし、
  既存 \`getEventDetail\` の begins_with(SK,"TEAM#") にも干渉しない

## Test plan

- [x] \`make lint\` 緑 (md 対象 / html 対象外)
- [ ] user が browser で開いて視認性確認 (mockup 3 枚 + API spec)
- [ ] user レビューで Decision に齟齬無いか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)