### PR TITLE
chore(infra): SBT BashJobRunner の customer-managed KMS Key を strip (/year cost saving)

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -6,6 +6,7 @@ import { BillingMode } from "aws-cdk-lib/aws-dynamodb";
 import * as dotenv from "dotenv";
 import { AdminConsoleHostingStack } from "../lib/admin-console-hosting";
 import { BootstrapTemplateStack } from "../lib/bootstrap-template/bootstrap-template-stack";
+import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms";
 import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
 import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
@@ -123,6 +124,11 @@ const kmsPendingWindowInDays = Number(
 // 全 stack の KMS Key 削除待機期間を上記値に揃える Aspect を App scope に apply。
 // SBT が内部生成する CodeBuild EncryptionKey 等も含む全 `AWS::KMS::Key` が対象。
 cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(kmsPendingWindowInDays));
+
+// SBT BashJobRunner が CodeBuild project artifact 暗号化用に作る customer-managed
+// KMS Key ($1/key/月) を AWS-managed alias `alias/aws/s3` (無料) に置き換え、
+// 不要になった KMS Key resource を template から除く Aspect (cost cleanup)。
+cdk.Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
 // Cognito UserPool domain は region globally unique なので env / tenantId / accountId を
 // 入れて衝突回避する (#83)。AdminConsoleHostingStack 用にも同じ値が要るので前倒しで定義。
 const awsRegion = process.env.CDK_PARAM_AWS_REGION ?? process.env.CDK_DEFAULT_REGION ?? "";

--- a/infrastructure/lib/cdk-aspect/codebuild-use-aws-managed-kms.ts
+++ b/infrastructure/lib/cdk-aspect/codebuild-use-aws-managed-kms.ts
@@ -56,7 +56,17 @@ export class CodeBuildUseAwsManagedKms implements IAspect {
       if (filtered.length === statements.length) return; // 無変更
       if (filtered.length === 0) {
         // 全 statement が消えた = この policy は全部 KMS key 用だった。policy ごと削除。
-        node.node.scope?.node.tryRemoveChild(node.node.id);
+        // scope が無い CfnPolicy が存在することは現 SBT では無いが、将来構造が変わって
+        // scope=undefined になったら silent failure (空 PolicyDocument が template に残り
+        // CFn validation で失敗) するので明示的に throw する。
+        const parent = node.node.scope;
+        if (!parent) {
+          throw new Error(
+            `[CodeBuildUseAwsManagedKms] CfnPolicy '${node.node.path}' has no scope; ` +
+              `cannot remove orphan empty policy. SBT 構造が変わった可能性、本 Aspect の追従が必要。`,
+          );
+        }
+        parent.node.tryRemoveChild(node.node.id);
         return;
       }
       node.addPropertyOverride("PolicyDocument.Statement", filtered);
@@ -91,9 +101,19 @@ interface PolicyStatement {
 }
 
 /**
- * Statement の Resource が `Fn::GetAtt` で削除対象 KMS key を参照しているか判定する。
+ * Statement の **全 Resource** が `Fn::GetAtt` で削除対象 KMS key を参照しているか判定する。
  * Resource は string / array / object のいずれか。object は `{ "Fn::GetAtt": [logicalId, attr] }`
  * の形なので logical ID を見て "EncryptionKey" を含むかで判定。
+ *
+ * `.some()` でなく `.every()` を使う理由: 1 statement の Resource array に
+ * EncryptionKey 参照と他 ARN が混在する場合に `.some()` だと statement 全体を破棄
+ * して非 KMS 権限まで道連れにしてしまう。SBT 0.3.9 の BashJobRunner は kms statement
+ * に他 ARN を混ぜないので現状は影響無いが、将来 `@cdklabs/sbt-aws` が statement を
+ * consolidate しても安全に動くよう defensive に書く。
+ *
+ * Resource が string literal (= ARN 直書き) の場合は false-negative になる (= statement
+ * は維持)。SBT 0.3.9 の BashJobRunner は ARN を string literal で書かないので現状は
+ * 問題無し。リスクを取らず温存する側に倒す方針。
  *
  * `JSON.stringify().includes(...)` だと statement の他の場所に "EncryptionKey" 文字列が
  * あれば false-positive する (= Sid 等)。Resource を構造的に見ることで誤判定を避ける。
@@ -102,7 +122,7 @@ function referencesEncryptionKey(statement: PolicyStatement): boolean {
   const resource = statement.Resource;
   if (resource == null) return false;
   const resources = Array.isArray(resource) ? resource : [resource];
-  return resources.some((r) => {
+  return resources.every((r) => {
     if (typeof r !== "object" || r === null) return false;
     const getAtt = (r as { "Fn::GetAtt"?: unknown[] })["Fn::GetAtt"];
     if (!Array.isArray(getAtt) || getAtt.length === 0) return false;

--- a/infrastructure/lib/cdk-aspect/codebuild-use-aws-managed-kms.ts
+++ b/infrastructure/lib/cdk-aspect/codebuild-use-aws-managed-kms.ts
@@ -1,0 +1,112 @@
+import { type IAspect, Stack } from "aws-cdk-lib";
+import { CfnProject } from "aws-cdk-lib/aws-codebuild";
+import { CfnPolicy } from "aws-cdk-lib/aws-iam";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+import type { IConstruct } from "constructs";
+
+/**
+ * SBT (`@cdklabs/sbt-aws`) の `BashJobRunner` (= ScriptJob) は CodeBuild project の
+ * artifact 暗号化用に **customer-managed KMS Key** を per-runner で 1 つ作る (= per-stack
+ * で 2 つの BashJobRunner、合計 2 keys × N stack)。これは standing cost $1/key/month を
+ * 試合ごとに払い続ける形になり、TenkaCloud の build artifact (= bash log + CFn output)
+ * の機密性に対して過剰。
+ *
+ * 本 Aspect は CFn template の整合性を保ったまま customer-managed KMS Key 経路を
+ * 取り除く。3 step 構成:
+ *
+ *   1. `AWS::CodeBuild::Project` の `EncryptionKey` property を **完全削除**
+ *      (= CodeBuild が AWS-managed `alias/aws/s3` 既定に倒れる、無料)
+ *   2. `AWS::IAM::Policy` の中で customer-managed KMS Key を `Fn::GetAtt` で参照する
+ *      statement (= Resource の logical ID に "EncryptionKey" を含むもの) を **statement
+ *      単位で除去**。AWS-managed key は CodeBuild service role に kms:* 権限が無くても
+ *      透過的に使える
+ *   3. 上で参照を切った customer-managed `AWS::KMS::Key` resource を template から除く。
+ *      construct path に "EncryptionKey" を含む key の最上位 ancestor を tryRemoveChild
+ *
+ * セキュリティ: encryption-at-rest 要件は AWS-managed key でも満たす。CodeBuild
+ * artifact は provision/deprovision の bash log と CFn output (DDB 名 / Lambda ARN)
+ * 程度で、customer-managed key で守るほどの機密性は無い。
+ *
+ * 範囲: ノード path に `EncryptionKey` を含む `CfnKey` および IAM Policy statement
+ * のみ対象。`KmsKeyShortPendingWindow` Aspect が pending window を絞っている他用途の
+ * KMS Key (将来追加されたとき) には影響しない。
+ *
+ * 参考: ProtoShip 同型 PR https://github.com/maishu-kobo/ProtoShip/pull/151
+ */
+export class CodeBuildUseAwsManagedKms implements IAspect {
+  public visit(node: IConstruct): void {
+    if (node instanceof CfnProject) {
+      // step 1. EncryptionKey property を完全削除 → CodeBuild の AWS-managed default に倒れる。
+      // 明示的に "alias/aws/s3" をセットするより future-proof (= AWS default が変わっても追従)。
+      node.addPropertyDeletionOverride("EncryptionKey");
+      return;
+    }
+
+    if (node instanceof CfnPolicy) {
+      // step 2. policyDocument を resolve して plain JSON にし、Resource の Fn::GetAtt が
+      // EncryptionKey 系の logical ID を指す statement を除去する。残った statement で
+      // property override する。
+      const stack = Stack.of(node);
+      const resolved = stack.resolve(node.policyDocument) as
+        | { Statement?: PolicyStatement[]; Version?: string }
+        | undefined;
+      const statements = resolved?.Statement;
+      if (!Array.isArray(statements)) return;
+      const filtered = statements.filter((s) => !referencesEncryptionKey(s));
+      if (filtered.length === statements.length) return; // 無変更
+      if (filtered.length === 0) {
+        // 全 statement が消えた = この policy は全部 KMS key 用だった。policy ごと削除。
+        node.node.scope?.node.tryRemoveChild(node.node.id);
+        return;
+      }
+      node.addPropertyOverride("PolicyDocument.Statement", filtered);
+      return;
+    }
+
+    if (node instanceof CfnKey) {
+      // step 3. CfnKey の Construct path に "EncryptionKey" が含まれていることを確認した
+      // 上で、その「EncryptionKey」セグメントに対応する L2 Key construct (= ancestor) を
+      // 親から remove する。SBT BashJobRunner の構造は 2 種類ある:
+      //   - L1 直接型: parent / "ProvisioningJobcodeBuildProjectEncryptionKey..." (CfnKey)
+      //     → CfnKey の id に "EncryptionKey" が含まれる
+      //   - L2 wrapper 型: parent / "EncryptionKey" (L2 Key) / "Resource" (CfnKey)
+      //     → "EncryptionKey" L2 Key を find して remove する
+      if (!node.node.path.includes("EncryptionKey")) return;
+      let target: IConstruct = node;
+      while (!target.node.id.includes("EncryptionKey") && target.node.scope) {
+        target = target.node.scope;
+      }
+      if (target.node.id.includes("EncryptionKey")) {
+        target.node.scope?.node.tryRemoveChild(target.node.id);
+      }
+    }
+  }
+}
+
+interface PolicyStatement {
+  Action?: unknown;
+  Effect?: string;
+  Resource?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Statement の Resource が `Fn::GetAtt` で削除対象 KMS key を参照しているか判定する。
+ * Resource は string / array / object のいずれか。object は `{ "Fn::GetAtt": [logicalId, attr] }`
+ * の形なので logical ID を見て "EncryptionKey" を含むかで判定。
+ *
+ * `JSON.stringify().includes(...)` だと statement の他の場所に "EncryptionKey" 文字列が
+ * あれば false-positive する (= Sid 等)。Resource を構造的に見ることで誤判定を避ける。
+ */
+function referencesEncryptionKey(statement: PolicyStatement): boolean {
+  const resource = statement.Resource;
+  if (resource == null) return false;
+  const resources = Array.isArray(resource) ? resource : [resource];
+  return resources.some((r) => {
+    if (typeof r !== "object" || r === null) return false;
+    const getAtt = (r as { "Fn::GetAtt"?: unknown[] })["Fn::GetAtt"];
+    if (!Array.isArray(getAtt) || getAtt.length === 0) return false;
+    const logicalId = getAtt[0];
+    return typeof logicalId === "string" && logicalId.includes("EncryptionKey");
+  });
+}

--- a/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
+++ b/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
@@ -1,0 +1,68 @@
+import { App, Aspects, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { BuildSpec, Project, Source } from "aws-cdk-lib/aws-codebuild";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { describe, expect, it } from "vitest";
+import { CodeBuildUseAwsManagedKms } from "../../lib/cdk-aspect/codebuild-use-aws-managed-kms";
+
+function buildStackWithCodeBuild(): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  // SBT BashJobRunner と同じ shape を再現: CodeBuild project に customer-managed KMS Key を attach
+  const encryptionKey = new Key(stack, "EncryptionKey", { description: "build artifact key" });
+  new Project(stack, "Build", {
+    source: Source.gitHub({ owner: "x", repo: "y" }),
+    encryptionKey,
+    buildSpec: BuildSpec.fromObject({ version: "0.2", phases: { build: { commands: ["true"] } } }),
+  });
+  Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
+  return Template.fromStack(stack);
+}
+
+describe("CodeBuildUseAwsManagedKms", () => {
+  it("CodeBuild Project から EncryptionKey property が削除されるべき (= AWS-managed default にフォールバック)", () => {
+    const template = buildStackWithCodeBuild();
+    const projects = template.findResources("AWS::CodeBuild::Project");
+    const projectKeys = Object.keys(projects);
+    expect(projectKeys.length).toBeGreaterThan(0);
+    for (const key of projectKeys) {
+      expect(projects[key]?.Properties?.EncryptionKey).toBeUndefined();
+    }
+  });
+
+  it("'EncryptionKey' を含む Construct path の AWS::KMS::Key resource は template から消えるべき", () => {
+    const template = buildStackWithCodeBuild();
+    template.resourceCountIs("AWS::KMS::Key", 0);
+  });
+
+  it("CodeBuild Role の IAM Policy の kms:* statement は除去されるべき (= 残った statement に kms action が無い)", () => {
+    const template = buildStackWithCodeBuild();
+    const policies = template.findResources("AWS::IAM::Policy");
+    for (const policy of Object.values(policies)) {
+      const statements = (policy as { Properties: { PolicyDocument: { Statement: unknown[] } } })
+        .Properties.PolicyDocument.Statement;
+      for (const s of statements) {
+        const json = JSON.stringify(s);
+        expect(json).not.toContain("kms:");
+      }
+    }
+  });
+
+  it("CodeBuild Role の IAM Policy の Resource に Fn::GetAtt EncryptionKey 参照は残らないべき", () => {
+    const template = buildStackWithCodeBuild();
+    const policies = template.findResources("AWS::IAM::Policy");
+    for (const policy of Object.values(policies)) {
+      const json = JSON.stringify(policy);
+      expect(json).not.toContain("EncryptionKey");
+    }
+  });
+
+  it("EncryptionKey と無関係な KMS Key (= 別用途) は影響を受けないべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "OtherStack");
+    new Key(stack, "DataAtRestKey", { description: "別用途の KMS、削除されてはいけない" });
+    Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::KMS::Key", 1);
+  });
+});

--- a/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
+++ b/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
@@ -42,8 +42,19 @@ describe("CodeBuildUseAwsManagedKms", () => {
       const statements = (policy as { Properties: { PolicyDocument: { Statement: unknown[] } } })
         .Properties.PolicyDocument.Statement;
       for (const s of statements) {
-        const json = JSON.stringify(s);
-        expect(json).not.toContain("kms:");
+        const stmt = s as { Action?: string | string[] };
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : stmt.Action != null
+            ? [stmt.Action]
+            : [];
+        // `kms:` prefix で始まる action が残っていないこと。
+        // 旧 test は JSON.stringify().includes("kms:") だったが、これだと
+        // alias/aws/s3 ARN 等の "arn:...kms:..." にも誤 match する。
+        // statement.Action だけを構造的に check する。
+        for (const action of actions) {
+          expect(action.startsWith("kms:")).toBe(false);
+        }
       }
     }
   });
@@ -64,5 +75,40 @@ describe("CodeBuildUseAwsManagedKms", () => {
     Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
     const template = Template.fromStack(stack);
     template.resourceCountIs("AWS::KMS::Key", 1);
+  });
+
+  it("mixed Resource (EncryptionKey + 他 ARN) の statement は維持されるべき (.every() defensive)", async () => {
+    const { App, Aspects, Stack } = await import("aws-cdk-lib");
+    const { Role, ServicePrincipal, PolicyStatement, Effect, Policy } = await import(
+      "aws-cdk-lib/aws-iam"
+    );
+    const { Key } = await import("aws-cdk-lib/aws-kms");
+    const app = new App();
+    const stack = new Stack(app, "MixedStack");
+    const key = new Key(stack, "EncryptionKey");
+    const role = new Role(stack, "Role", {
+      assumedBy: new ServicePrincipal("codebuild.amazonaws.com"),
+    });
+    new Policy(stack, "Pol", {
+      roles: [role],
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:GetObject", "kms:Decrypt"],
+          resources: [key.keyArn, "arn:aws:s3:::other-bucket/*"],
+        }),
+      ],
+    });
+    Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
+    const template = Template.fromStack(stack);
+    // mixed Resource statement は .every() で false 判定 → 維持される
+    const policies = template.findResources("AWS::IAM::Policy");
+    const policyStatements = Object.values(policies).flatMap(
+      (p) =>
+        (p as { Properties: { PolicyDocument: { Statement: unknown[] } } }).Properties
+          .PolicyDocument.Statement,
+    );
+    // 1 statement が残っている (= 削除されなかった)
+    expect(policyStatements.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

ユーザー調査: SBT (\`sbt-aws\` 0.3.9) の \`BashJobRunner\` が CodeBuild project artifact
暗号化用に customer-managed KMS Key を per-runner で 1 つ作る (= per-stack で 2 つ、
合計 6 keys × \$1/key/月 = **\$72/年 standing cost**)。

CodeBuild artifact = provision/deprovision の bash log + CFn output (DDB 名 / Lambda ARN)
程度で、customer-managed key で守るほどの機密性は無い。AWS-managed default で
encryption-at-rest 要件は満たす (= \`alias/aws/s3\`、無料)。

## 実装

新 Aspect \`CodeBuildUseAwsManagedKms\` (\`infrastructure/lib/cdk-aspect/\`) を追加し、
\`bin/infrastructure.ts\` で App scope に apply。3 step で template の整合性を保ったまま
KMS Key 経路を取り除く:

1. **\`CfnProject.EncryptionKey\` を property 削除** (\`addPropertyDeletionOverride\`) → CodeBuild
   が AWS-managed default に倒れる
2. **IAM Policy の Resource Fn::GetAtt が EncryptionKey logical ID を指す statement を除去**
   (= AWS-managed key は role に kms 権限なくても透過的に使える、\`PolicyDocument\` を
   \`Stack.resolve\` → filter → \`addPropertyOverride\`)
3. **CfnKey resource を template から削除** (= construct path に "EncryptionKey" を含む key の
   最上位 ancestor を \`tryRemoveChild\`、L1 直接型 / L2 wrapper 型の両対応で walk-up)

## 同型 PR の参考

ProtoShip の [PR-151](https://github.com/maishu-kobo/ProtoShip/pull/151) と同型。
ProtoShip の改善点を 2 点取り込み:

- \`addPropertyDeletionOverride\` で property 完全削除 (= \`alias/aws/s3\` を明示セットより
  future-proof)
- IAM Policy filter で Resource Fn::GetAtt logical ID を構造的に check (= JSON.stringify
  全文 grep より誤判定が少ない)

独自改善: walk-up で SBT の logical ID 命名差異 (\`codeBuildProjectEncryptionKey\` vs
\`EncryptionKey\` 等) を吸収 (ProtoShip は固定文字列依存)。

## 検証 (cdk synth)

| stack | KMS keys (before) | KMS keys (after) | EncryptionKey property |
| --- | --- | --- | --- |
| tenkacloud-bootstrap | 2 | **0** | (deleted) × 2 |
| tenkacloud-tenant-template-pooled | 0 | 0 | — |
| tenkacloud-saas-pipeline | 1 | **0** | (deleted) |
| tenkacloud-control-plane | 0 | 0 | — |
| tenkacloud-problem-deploy | 1 | **0** | (deleted) |

合計 4 keys 削除 → \$48/年 saving (per-tenant pool runner も同様に削減されるので tenant
数分で更に効く)。orphan \`Fn::GetAtt\` 0 件。

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| DELETE | 4 つの \`AWS::KMS::Key\` (CodeBuild artifact 用) | template から消える、CFn update で実 stack も削除 |
| UPDATE | 4 つの \`AWS::CodeBuild::Project\` | EncryptionKey property 削除 |
| UPDATE | 4 つの \`AWS::IAM::Policy\` | kms:* statement 除去 |
| NO-OP | DDB / Lambda / 他 stack | 不変 |

## Test plan

- [x] \`make synth\` 緑 (5 stack 全て)
- [x] \`make before-commit\` 緑 (新 unit test 5 件 + 既存全 pass)
- [x] template の AWS::KMS::Key resource count = 0
- [x] template の orphan Fn::GetAtt EncryptionKey 0 件
- [x] CodeBuild Project の EncryptionKey property 削除済
- [ ] AWS deploy で実 stack を update し、KMS Key resource が削除される (= remove via CFn update)
- [ ] CodeBuild build が AWS-managed S3 key で正常完了

## Regression 分析

- 既存 deploy 済 KMS Key は CFn の \`DeletionPolicy: Retain\` (SBT 既定) が付いているので
  CFn update で **削除されない** (= AWS console で手動削除が必要、PendingWindow 7 日で完全停止)。本 PR は新 deploy 分の cost を 0 化、既存 key の解放は手動 op
- AWS-managed alias \`alias/aws/s3\` は account 単位で 1 つで tenant 跨ぎ分離は壊れない (= S3 service が internal 管理)
- \`KmsKeyShortPendingWindow\` Aspect は target がいなくなるので空振り、挙動上の問題なし
- Aspect 適用順は CDK ランタイム依存だが、step 1〜3 は冪等で順序非依存

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CodeBuild projects now use AWS-managed KMS encryption for artifacts instead of customer-managed keys, reducing infrastructure management overhead.

* **Tests**
  * Added tests validating CodeBuild encryption configuration handling and KMS key behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->