### PR TITLE
feat(portal): ADR-005 Phase 3.1 — Battle Portal backend (attack-detected event + aggregate view + battle-attacks endpoint)

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -21,6 +21,19 @@ export interface ParticipantScoringInfo {
 }
 
 /**
+ * Battle (uptime kind) の集約 health (ADR-005 D1)。per-endpoint URL / 名前は **絶対に
+ * 露出しない** (= ゲーム性のため)。Challenge (flag kind) では undefined。
+ */
+export type ApplicationStatusOverall = "healthy" | "degraded" | "down" | "unknown";
+
+export interface ApplicationStatus {
+  readonly overall: ApplicationStatusOverall;
+  readonly healthyCount: number;
+  readonly totalCount: number;
+  readonly checkedAt?: string;
+}
+
+/**
  * Phase 2c: 1 problem 単位の view (= team の N 問題のうち 1 つ)。
  */
 export interface ParticipantProblemView {
@@ -37,6 +50,8 @@ export interface ParticipantProblemView {
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  /** ADR-005 Phase 3.1: Battle (uptime) のみ aggregate health を露出。 */
+  readonly applicationStatus?: ApplicationStatus;
 }
 
 /**
@@ -255,6 +270,46 @@ export async function getConsoleSigninUrl(
     { query: { jobId }, throwOn400: true, signal },
   )) as { loginUrl: string };
   return data.loginUrl;
+}
+
+/**
+ * ADR-005 Phase 3.1: 自 team の指定 deployment における attack-detected event の
+ * 時系列。Battle Portal の Attack Statistics / Attack History タブが poll する。
+ */
+export interface BattleAttackEventView {
+  readonly occurredAt: string;
+  readonly source: "attack-detected";
+  readonly result: "down";
+  readonly recoveredAt: string | null;
+}
+
+export interface BattleAttacksResponse {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly sinceMin: number;
+  readonly events: readonly BattleAttackEventView[];
+}
+
+/**
+ * `GET /portal/me/battle-attacks?jobId=&sinceMin=` を `Authorization: Bearer <teamLoginKey>`
+ * で呼ぶ。直近 sinceMin (default 30、上限 60) 分内の attack-detected event を時系列降順
+ * で返す。invalid_jobid / invalid_sincemin / not_found は `PortalValidationError` で throw。
+ */
+export async function getBattleAttacks(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  jobId: string,
+  sinceMin?: number,
+  signal?: AbortSignal,
+): Promise<BattleAttacksResponse> {
+  const query: Record<string, string> = { jobId };
+  if (sinceMin !== undefined) query.sinceMin = String(sinceMin);
+  return (await portalFetch<BattleAttacksResponse>(
+    apiBaseUrl,
+    "portal/me/battle-attacks",
+    teamLoginKey,
+    { query, throwOn400: true, signal },
+  )) as BattleAttacksResponse;
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -83,27 +83,41 @@ async function checkOne(item: Partial<DeploymentItem>, scoring: UptimeScoring): 
 
   await ddb.send(buildHealthUpdate(item.PK, allOk, scoring.pointsPerSuccess, now, newHealth));
 
-  // 全 endpoint OK のときだけ score event を書き込む。失敗イベントは現状 history に
-  // 残さない (= 加点ログのみ)。Put 失敗は best-effort として log に残す (= 採点は
-  // 既に確定しているので整合性より可用性優先)。
-  if (allOk && item.jobId && item.problemId) {
+  // ok / fail に応じて 2 種類の score event を best-effort で書き込む。Put 失敗は log のみ
+  // (= 採点 / 健全性 update は既に確定済、整合性より可用性優先)。
+  //
+  // - allOk = true  → "uptime" event (加点 marker、source=uptime / result=ok / points=N)
+  // - allOk = false かつ 直前 tick が ok → "attack-detected" event (= 攻撃検知の遷移
+  //   marker、source=attack-detected / result=down / points=0)。**連続 fail tick では
+  //   書かない** (= row 爆発防止、ADR-005 D2-A の hard guard)
+  if (!item.jobId || !item.problemId) return;
+  const parent = {
+    jobId: item.jobId,
+    problemId: item.problemId,
+    teamId: item.teamId,
+    eventId: item.eventId,
+    expiresAt: item.expiresAt ?? 0,
+  };
+
+  if (allOk) {
     try {
-      await writeScoreEvent(
-        ddb,
-        tableName(),
-        {
-          jobId: item.jobId,
-          problemId: item.problemId,
-          teamId: item.teamId,
-          eventId: item.eventId,
-          expiresAt: item.expiresAt ?? 0,
-        },
-        "uptime",
-        scoring.pointsPerSuccess,
-        now,
-      );
+      await writeScoreEvent(ddb, tableName(), parent, "uptime", scoring.pointsPerSuccess, now);
     } catch (err) {
       console.warn(`[health-check] score-event write failed jobId=${item.jobId}`, {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return;
+  }
+
+  // 直前 tick が ok だった場合のみ attack-detected を書く (= 連続 fail tick での重複
+  // write を防ぐ hard guard)。`undefined` (= probe 未実行 / 旧 deployment) は ok 扱い
+  // しない (= 初回 deploy 直後の誤検知を避ける)。
+  if (item.lastResult === "ok") {
+    try {
+      await writeScoreEvent(ddb, tableName(), parent, "attack-detected", 0, now);
+    } catch (err) {
+      console.warn(`[health-check] attack-detected write failed jobId=${item.jobId}`, {
         message: err instanceof Error ? err.message : String(err),
       });
     }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/battle-attacks.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/battle-attacks.ts
@@ -1,0 +1,129 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { ULID_RE } from "../shared/constants.js";
+import type { ScoreEventItem } from "../shared/score-event.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+
+/**
+ * `GET /portal/me/battle-attacks?jobId=&sinceMin=` の response shape (ADR-005 D2)。
+ *
+ * Battle Portal の Attack Statistics / Attack History タブが poll する。`recoveredAt` は
+ * その attack-detected event の **後で** 観測された最初の `uptime` event (= 復旧 marker)
+ * の occurredAt を server-side で結合して返す。未復旧なら null。
+ */
+export interface BattleAttackEventView {
+  readonly occurredAt: string;
+  readonly source: "attack-detected";
+  readonly result: "down";
+  readonly recoveredAt: string | null;
+}
+
+export interface BattleAttacksResponse {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly sinceMin: number;
+  readonly events: readonly BattleAttackEventView[];
+}
+
+export type BattleAttacksOutcome =
+  | { kind: "ok"; response: BattleAttacksResponse }
+  | { kind: "unauthorized" }
+  | { kind: "not_found" }
+  | { kind: "invalid_jobid" }
+  | { kind: "invalid_sincemin" };
+
+/** sinceMin の上限。ADR-005 D2 で RCU 暴発防止のため設定。 */
+export const BATTLE_ATTACKS_SINCE_MIN_MAX = 60;
+/** sinceMin 既定値。明示的にクエリパラメータが無い場合に使う。 */
+export const BATTLE_ATTACKS_SINCE_MIN_DEFAULT = 30;
+
+/**
+ * 自 team の指定 jobId の deployment について、直近 sinceMin 分内に観測された
+ * attack-detected event を時系列降順で返す。recoveredAt は同 jobId の uptime event
+ * (= 復旧 tick) を結合して計算する。
+ *
+ * 認可: teamLoginKey で team の deployment 一覧を取得し、jobId が含まれることを check
+ * (= 自 team の deployment かを保証)。
+ *
+ * 設計: per-endpoint 情報は **絶対に出さない** (ADR-005 D1)。response の view shape
+ * から構造的に漏れない (= occurredAt / source / result / recoveredAt のみ)。
+ */
+export async function listBattleAttacks(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  jobIdRaw: string,
+  sinceMinRaw: number,
+  nowMs: number = Date.now(),
+): Promise<BattleAttacksOutcome> {
+  if (!ULID_RE.test(jobIdRaw)) return { kind: "invalid_jobid" };
+  if (
+    !Number.isInteger(sinceMinRaw) ||
+    sinceMinRaw < 1 ||
+    sinceMinRaw > BATTLE_ATTACKS_SINCE_MIN_MAX
+  ) {
+    return { kind: "invalid_sincemin" };
+  }
+
+  const myItems = await queryTeamItems(shared, teamLoginKey);
+  if (myItems.length === 0) return { kind: "unauthorized" };
+
+  const target = myItems.find((i) => i.jobId === jobIdRaw) as
+    | Pick<DeploymentItem, "PK" | "jobId" | "problemId">
+    | undefined;
+  if (!target || typeof target.PK !== "string") return { kind: "not_found" };
+
+  const sinceIso = new Date(nowMs - sinceMinRaw * 60_000).toISOString();
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
+      // FilterExpression は server 側で時間絞り込みする。GSI を新設せずに済ませる。
+      FilterExpression: "occurredAt >= :since",
+      ExpressionAttributeValues: {
+        ":pk": target.PK,
+        ":evpfx": "EVENT#",
+        ":since": sinceIso,
+      },
+      // 降順で取り出して time-window 内のみ抽出。typical row 数は 100 以下を想定 (ADR-005)。
+      ScanIndexForward: false,
+    }),
+  );
+
+  const events = ((out.Items ?? []) as Partial<ScoreEventItem>[]).filter(
+    (i): i is Partial<ScoreEventItem> => typeof i.source === "string",
+  );
+
+  // attack-detected と uptime を分けて、attack-detected の各行に recoveredAt を結合する。
+  const attacks = events.filter((e) => e.source === "attack-detected");
+  const recoveries = events
+    .filter((e) => e.source === "uptime")
+    .map((e) => String(e.occurredAt ?? ""))
+    .filter((t) => t.length > 0)
+    .sort(); // ascending order for binary-search-style "next after"
+
+  const view: BattleAttackEventView[] = attacks
+    .map((e) => {
+      const occurredAt = String(e.occurredAt ?? "");
+      if (!occurredAt) return undefined;
+      // この attack より後で最初に観測された uptime event の occurredAt が recoveredAt。
+      const recoveredAt = recoveries.find((t) => t > occurredAt) ?? null;
+      return {
+        occurredAt,
+        source: "attack-detected" as const,
+        result: "down" as const,
+        recoveredAt,
+      };
+    })
+    .filter((v): v is BattleAttackEventView => v !== undefined)
+    .sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : a.occurredAt > b.occurredAt ? -1 : 0));
+
+  return {
+    kind: "ok",
+    response: {
+      jobId: target.jobId ?? jobIdRaw,
+      problemId: String(target.problemId ?? ""),
+      sinceMin: sinceMinRaw,
+      events: view,
+    },
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/battle-attacks.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/battle-attacks.ts
@@ -1,6 +1,6 @@
 import { QueryCommand } from "@aws-sdk/lib-dynamodb";
-import type { DeploymentItem } from "../deploy-handler/types.js";
-import { ULID_RE } from "../shared/constants.js";
+import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import { DELETED_LIKE_STATUSES, ULID_RE } from "../shared/constants.js";
 import type { ScoreEventItem } from "../shared/score-event.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
@@ -67,31 +67,44 @@ export async function listBattleAttacks(
   const myItems = await queryTeamItems(shared, teamLoginKey);
   if (myItems.length === 0) return { kind: "unauthorized" };
 
-  const target = myItems.find((i) => i.jobId === jobIdRaw) as
-    | Pick<DeploymentItem, "PK" | "jobId" | "problemId">
-    | undefined;
+  // DELETING / DELETED な行は teardown 中の sparse 残骸 (GSI2PK が消えていない race) の
+  // 可能性があるので除外。team key が teardown 後も battle-attacks を叩けてしまう穴を塞ぐ。
+  const target = myItems.find((i) => {
+    if (i.jobId !== jobIdRaw) return false;
+    const status = (i.status ?? "PENDING") as DeploymentStatus;
+    return !DELETED_LIKE_STATUSES.has(status);
+  }) as Pick<DeploymentItem, "PK" | "jobId" | "problemId"> | undefined;
   if (!target || typeof target.PK !== "string") return { kind: "not_found" };
 
   const sinceIso = new Date(nowMs - sinceMinRaw * 60_000).toISOString();
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.tableName,
-      KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
-      // FilterExpression は server 側で時間絞り込みする。GSI を新設せずに済ませる。
-      FilterExpression: "occurredAt >= :since",
-      ExpressionAttributeValues: {
-        ":pk": target.PK,
-        ":evpfx": "EVENT#",
-        ":since": sinceIso,
-      },
-      // 降順で取り出して time-window 内のみ抽出。typical row 数は 100 以下を想定 (ADR-005)。
-      ScanIndexForward: false,
-    }),
-  );
+  // 時間窓は SK の prefix `EVENT#<isoTimestamp>#<ulid>` を使い key condition で BETWEEN
+  // 絞り込み。FilterExpression は post-read filter なので RCU を実数据えしないし、
+  // LastEvaluatedKey を放置すると 1 page を超えた瞬間に欠損する (= 旧実装のバグ)。
+  // 上限 sentinel `EVENT#~` は ASCII で `Z` (ISO 8601 末尾) より大きい固定値。
+  const skStart = `EVENT#${sinceIso}`;
+  const skEnd = "EVENT#~";
 
-  const events = ((out.Items ?? []) as Partial<ScoreEventItem>[]).filter(
-    (i): i is Partial<ScoreEventItem> => typeof i.source === "string",
-  );
+  const events: Partial<ScoreEventItem>[] = [];
+  let exclusiveStart: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.tableName,
+        KeyConditionExpression: "PK = :pk AND SK BETWEEN :sk_start AND :sk_end",
+        ExpressionAttributeValues: {
+          ":pk": target.PK,
+          ":sk_start": skStart,
+          ":sk_end": skEnd,
+        },
+        ScanIndexForward: false,
+        ExclusiveStartKey: exclusiveStart,
+      }),
+    );
+    for (const item of (out.Items ?? []) as Partial<ScoreEventItem>[]) {
+      if (typeof item.source === "string") events.push(item);
+    }
+    exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStart);
 
   // attack-detected と uptime を分けて、attack-detected の各行に recoveredAt を結合する。
   const attacks = events.filter((e) => e.source === "attack-detected");

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -64,10 +64,11 @@ app.get("/portal/me/battle-attacks", (c) =>
     const jobId = c.req.query("jobId");
     if (!jobId) return respondError(c, "missing_jobid");
     const sinceMinRaw = c.req.query("sinceMin");
+    // `Number` を使い "60.9" / "1abc" のような non-integer は NaN または float に
+    // して `listBattleAttacks` 側の `Number.isInteger` で reject させる。`parseInt` は
+    // truncate するので "60.9"→60 / "1abc"→1 と silently 通ってしまう。
     const sinceMin =
-      sinceMinRaw === undefined
-        ? BATTLE_ATTACKS_SINCE_MIN_DEFAULT
-        : Number.parseInt(sinceMinRaw, 10);
+      sinceMinRaw === undefined ? BATTLE_ATTACKS_SINCE_MIN_DEFAULT : Number(sinceMinRaw);
     const outcome = await listBattleAttacks(shared, token, jobId, sinceMin);
     if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
     return respondError(c, outcome.kind);

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -3,6 +3,7 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { PROBLEM_ID_RE } from "../shared/constants.js";
 import { HTTP_OK } from "../shared/http-status.js";
+import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
 import { respondError, withBearerAuth } from "./route-helpers.js";
@@ -54,6 +55,21 @@ app.get("/portal/me/console-signin-url", (c) =>
     if (!jobId) return respondError(c, "missing_jobid");
     const outcome = await getConsoleSigninUrl(shared, token, jobId);
     if (outcome.kind === "ok") return c.json({ loginUrl: outcome.loginUrl }, HTTP_OK);
+    return respondError(c, outcome.kind);
+  }),
+);
+
+app.get("/portal/me/battle-attacks", (c) =>
+  withBearerAuth(c, "battle-attacks", async (token) => {
+    const jobId = c.req.query("jobId");
+    if (!jobId) return respondError(c, "missing_jobid");
+    const sinceMinRaw = c.req.query("sinceMin");
+    const sinceMin =
+      sinceMinRaw === undefined
+        ? BATTLE_ATTACKS_SINCE_MIN_DEFAULT
+        : Number.parseInt(sinceMinRaw, 10);
+    const outcome = await listBattleAttacks(shared, token, jobId, sinceMin);
+    if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
     return respondError(c, outcome.kind);
   }),
 );

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -2,6 +2,7 @@ import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js"
 import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
+import { parseEndpointsHealth } from "../shared/endpoints-health.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
@@ -24,6 +25,24 @@ export interface ParticipantScoringInfo {
  * チームに紐づく 1 problem 単位の view。team 集約 (`ParticipantTeamView.problems[]`) の
  * 1 要素として返す。
  */
+/**
+ * Battle 系 (uptime kind) deployment の health 集約。`endpointsHealth` JSON を per-endpoint
+ * のまま露出すると「どの endpoint が落ちているか」が見えてしまい Battle のゲーム性
+ * (= 防御側が自分で調査) を破壊するため、aggregate のみに絞る (ADR-005 D1)。
+ *
+ * 旧 deployment / probe 未実行 / Challenge 系 (= flag kind、HealthCheck 対象外) は
+ * `unknown` を返す。
+ */
+export type ApplicationStatusOverall = "healthy" | "degraded" | "down" | "unknown";
+
+export interface ApplicationStatus {
+  readonly overall: ApplicationStatusOverall;
+  readonly healthyCount: number;
+  readonly totalCount: number;
+  /** 最後の probe 時刻 (ISO 8601)。`unknown` のときは undefined。 */
+  readonly checkedAt?: string;
+}
+
 export type ParticipantProblemView = Pick<
   DeploymentItem,
   "jobId" | "problemId" | "region" | "expiresAt" | "awsAccountId"
@@ -35,9 +54,14 @@ export type ParticipantProblemView = Pick<
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  /**
+   * Battle (uptime kind) の集約 health。per-endpoint の URL / 名前は **絶対に出さない**
+   * (ADR-005 D1)。Challenge 形式 (flag kind) では undefined。
+   */
+  readonly applicationStatus?: ApplicationStatus;
   // 設計判断: `endpointsHealth` (= どの endpoint が落ちているか) は participant API には
   // 出さない。Battle のゲーム性は「壊れている原因を防御側自身が調査して復旧する」点に
-  // あり、画面で答え合わせをすると興ざめになる。
+  // あり、画面で答え合わせをすると興ざめになる。露出するのは aggregate のみ。
   // `awsAccountId` は AWS Console 直接アクセス (SSO Credentials) のため公開する。
   // AWS の account id は機密ではない (= IAM role 信頼ポリシーや CFn template にも露出する)。
 };
@@ -100,7 +124,36 @@ export function toProblemView(
             : { pointsPerSuccess: scoring.pointsPerSuccess }),
         }
       : undefined,
+    applicationStatus: scoring?.kind === "uptime" ? toApplicationStatus(item) : undefined,
   };
+}
+
+/**
+ * `endpointsHealth` JSON を aggregate (overall / healthyCount / totalCount / checkedAt)
+ * に変換する。**per-endpoint URL / 名前は絶対に出さない** (ADR-005 D1)。
+ *
+ * 判定ルール:
+ *   - probe 未実行 (= endpointsHealth が無い / 空) → `unknown`
+ *   - 全 endpoint OK → `healthy`
+ *   - 全 endpoint NG → `down`
+ *   - 一部 OK → `degraded`
+ */
+function toApplicationStatus(item: Partial<DeploymentItem>): ApplicationStatus {
+  const health = parseEndpointsHealth(item.endpointsHealth);
+  const entries = Object.values(health);
+  if (entries.length === 0) {
+    return { overall: "unknown", healthyCount: 0, totalCount: 0 };
+  }
+  const healthyCount = entries.filter((e) => e.ok).length;
+  const totalCount = entries.length;
+  const checkedAt = entries[0]?.checkedAt;
+  let overall: ApplicationStatusOverall;
+  if (healthyCount === totalCount) overall = "healthy";
+  else if (healthyCount === 0) overall = "down";
+  else overall = "degraded";
+  return checkedAt
+    ? { overall, healthyCount, totalCount, checkedAt }
+    : { overall, healthyCount, totalCount };
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -15,6 +15,7 @@ import { extractBearerToken } from "./auth.js";
 const ERROR_STATUS = {
   unauthorized: HTTP_UNAUTHORIZED,
   invalid_jobid: HTTP_BAD_REQUEST,
+  invalid_sincemin: HTTP_BAD_REQUEST,
   invalid_team_name: HTTP_BAD_REQUEST,
   invalid_problem_id: HTTP_BAD_REQUEST,
   invalid_flag: HTTP_BAD_REQUEST,
@@ -24,6 +25,7 @@ const ERROR_STATUS = {
   not_flag_problem: HTTP_BAD_REQUEST,
   no_outputs: HTTP_BAD_REQUEST,
   no_event: HTTP_NOT_FOUND,
+  not_found: HTTP_NOT_FOUND,
   misconfigured: HTTP_INTERNAL_ERROR,
   internal_error: HTTP_INTERNAL_ERROR,
 } as const;

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
@@ -51,25 +51,43 @@ export async function listScoreEvents(
   if (liveJobs.length === 0) return { kind: "unauthorized" };
 
   // 各 deployment の event 行を並列に query。N query を Promise.all で発火。
+  // attack-detected 行 (ADR-005 D2-A) は同 EVENT# partition に共存し、`toView` で
+  // undefined になる。Limit は scan 量に効くので、そのまま 100 にすると markers が
+  // 詰まったときに valid scoring 行が押し出される。LastEvaluatedKey で paginate して
+  // valid 行が limit 件集まる (or 親なし) まで読む。MAX_PAGES で暴走防止。
+  const MAX_PAGES = 5;
   const eventChunks = await Promise.all(
     liveJobs.map(async (job) => {
-      const out = await shared.ddb.send(
-        new QueryCommand({
-          TableName: shared.tableName,
-          KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
-          ExpressionAttributeValues: {
-            ":pk": job.PK,
-            ":evpfx": "EVENT#",
-          },
-          ScanIndexForward: false,
-          Limit: limit,
-        }),
-      );
-      return ((out.Items ?? []) as Partial<ScoreEventItem>[]).map(toView);
+      const collected: ScoreEventView[] = [];
+      let exclusiveStart: Record<string, unknown> | undefined;
+      let pages = 0;
+      while (collected.length < limit && pages < MAX_PAGES) {
+        const out = await shared.ddb.send(
+          new QueryCommand({
+            TableName: shared.tableName,
+            KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
+            ExpressionAttributeValues: {
+              ":pk": job.PK,
+              ":evpfx": "EVENT#",
+            },
+            ScanIndexForward: false,
+            Limit: limit,
+            ExclusiveStartKey: exclusiveStart,
+          }),
+        );
+        for (const item of (out.Items ?? []) as Partial<ScoreEventItem>[]) {
+          const v = toView(item);
+          if (v) collected.push(v);
+        }
+        exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+        pages++;
+        if (!exclusiveStart) break;
+      }
+      return collected;
     }),
   );
 
-  const merged = eventChunks.flat().filter((e): e is ScoreEventView => e !== undefined);
+  const merged = eventChunks.flat();
   // occurredAt 降順 sort + 全 deployment 横断の上位 limit 件を返す。
   merged.sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : a.occurredAt > b.occurredAt ? -1 : 0));
   const entries = merged.slice(0, limit);

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -4,7 +4,7 @@ import { ulid } from "ulid";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 
 /**
- * 1 採点イベント (= スコア加算の単位) を Deployments table に書き込むときの shape。
+ * 1 採点イベント (= スコア加算 / 攻撃検知の単位) を Deployments table に書き込むときの shape。
  *
  *   PK = `DEPLOYMENT#<jobId>` (= 親 deployment と同じ partition)
  *   SK = `EVENT#<isoTimestamp>#<ulid>` (時系列ソート + 衝突防止)
@@ -22,27 +22,39 @@ export interface ScoreEventItem {
   /** Phase 2a 以前の旧 deployment は持たない (= history 列も undefined)。 */
   teamId?: string;
   eventId?: string;
-  /** 加点の発生源。`uptime` = HealthCheck の probe 成功、`flag` = 競技者の flag 提出。 */
-  source: "uptime" | "flag";
-  /** 加算ポイント。flag は scoring.points、uptime は scoring.pointsPerSuccess。 */
+  /**
+   * イベント発生源。
+   * - `uptime`: HealthCheck の probe で全 endpoint OK
+   * - `flag`: 競技者の flag 提出が正解
+   * - `attack-detected`: HealthCheck で `lastResult: ok → fail` 遷移を検知 (ADR-005 D2-A、
+   *   Battle Portal の Attack Statistics / History で使う)
+   */
+  source: "uptime" | "flag" | "attack-detected";
+  /**
+   * 加算ポイント。`uptime` = scoring.pointsPerSuccess、`flag` = scoring.points、
+   * `attack-detected` = 0 (= イベント marker のみ、score 加算なし)。
+   */
   points: number;
   /**
-   * 結果。`uptime` で全 endpoint OK or `flag` で正解なら "ok"。
-   * 失敗イベントは現状書き込まない (= history は加点ログのみ)。将来 fail も書くなら
-   * extend 可能。
+   * 結果。
+   * - `ok`: `uptime` で全 endpoint OK or `flag` で正解
+   * - `down`: `attack-detected` (= 攻撃が刺さって uptime が落ちた)
+   *
+   * Phase 2 以前の event 行は `"ok"` のみ書かれているので backward compatible。
    */
-  result: "ok";
+  result: "ok" | "down";
   occurredAt: string;
   /** 親 deployment の TTL を継承。0 なら無期限 (旧 deployment 互換)。 */
   expiresAt: number;
 }
 
 /**
- * 採点イベントを 1 行 PutItem する。HealthCheck (uptime) と submit-flag (flag) の両方
- * から呼ばれるので shared/ に置く。書き込み失敗は親 score 加算と整合性が崩れるが、
- * caller が catch して log のみ残す方針 (= MVP は best-effort)。
+ * 採点イベントを 1 行 PutItem する。HealthCheck (uptime / attack-detected) と
+ * submit-flag (flag) から呼ばれるので shared/ に置く。書き込み失敗は親 score 加算と
+ * 整合性が崩れるが、caller が catch して log のみ残す方針 (= MVP は best-effort)。
  *
  * `parent` から jobId / teamId / eventId / expiresAt を継承して event row を組む。
+ * `result` は source に応じて自動決定 (= attack-detected なら "down"、それ以外は "ok")。
  */
 export async function writeScoreEvent(
   ddb: DynamoDBDocumentClient,
@@ -61,7 +73,7 @@ export async function writeScoreEvent(
     eventId: parent.eventId,
     source,
     points,
-    result: "ok",
+    result: source === "attack-detected" ? "down" : "ok",
     occurredAt,
     expiresAt: Number(parent.expiresAt ?? 0),
   };

--- a/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
+++ b/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
@@ -1,0 +1,164 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BATTLE_ATTACKS_SINCE_MIN_MAX,
+  listBattleAttacks,
+} from "../../lib/problem-deploy/handlers/participant-handler/battle-attacks";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+const VALID_JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const TEAM_KEY = "KEY1";
+const NOW_MS = new Date("2026-05-10T10:00:00.000Z").getTime();
+
+function buildShared(): { shared: ParticipantSharedResources; ddbSend: ReturnType<typeof vi.fn> } {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+  };
+  return { shared, ddbSend };
+}
+
+const teamRow = (over: Record<string, unknown> = {}) => ({
+  PK: `DEPLOYMENT#${VALID_JOB_ID}`,
+  SK: "META",
+  GSI2PK: `TEAMKEY#${TEAM_KEY}`,
+  jobId: VALID_JOB_ID,
+  problemId: "security-battle-royale",
+  status: "COMPLETE",
+  ...over,
+});
+
+describe("listBattleAttacks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("不正な jobId (ULID 形式でない) は invalid_jobid を返すべき", async () => {
+    const { shared } = buildShared();
+    const out = await listBattleAttacks(shared, TEAM_KEY, "not-ulid", 30, NOW_MS);
+    expect(out).toEqual({ kind: "invalid_jobid" });
+  });
+
+  it("sinceMin が 0 / 負 / 超過 / 非整数 なら invalid_sincemin", async () => {
+    const { shared } = buildShared();
+    expect((await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 0, NOW_MS)).kind).toBe(
+      "invalid_sincemin",
+    );
+    expect((await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, -1, NOW_MS)).kind).toBe(
+      "invalid_sincemin",
+    );
+    expect(
+      (
+        await listBattleAttacks(
+          shared,
+          TEAM_KEY,
+          VALID_JOB_ID,
+          BATTLE_ATTACKS_SINCE_MIN_MAX + 1,
+          NOW_MS,
+        )
+      ).kind,
+    ).toBe("invalid_sincemin");
+    expect((await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 1.5, NOW_MS)).kind).toBe(
+      "invalid_sincemin",
+    );
+  });
+
+  it("teamLoginKey が無効 (= deployment 0 件) なら unauthorized", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+    expect(out).toEqual({ kind: "unauthorized" });
+  });
+
+  it("jobId が自 team の deployment にない (= 別 team の jobId 等) なら not_found", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [teamRow({ jobId: "01HZX0K3M3K9ZQHB3MRQHBA1B3" })], // 違う jobId
+    });
+    const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("正常系: PK=DEPLOYMENT#<jobId> + SK begins_with EVENT# + occurredAt >= since で Query", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+
+    const q = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    expect(q).toBeInstanceOf(QueryCommand);
+    expect(q.input.KeyConditionExpression).toContain("PK = :pk");
+    expect(q.input.KeyConditionExpression).toContain("begins_with(SK, :evpfx)");
+    expect(q.input.ExpressionAttributeValues?.[":pk"]).toBe(`DEPLOYMENT#${VALID_JOB_ID}`);
+    expect(q.input.ExpressionAttributeValues?.[":evpfx"]).toBe("EVENT#");
+    expect(q.input.FilterExpression).toBe("occurredAt >= :since");
+    // since = NOW − 30 分 = "2026-05-10T09:30:00.000Z"
+    expect(q.input.ExpressionAttributeValues?.[":since"]).toBe("2026-05-10T09:30:00.000Z");
+    expect(q.input.ScanIndexForward).toBe(false);
+  });
+
+  it("attack-detected event を時系列降順で返し、後続 uptime event を recoveredAt として結合する", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        // 14:32 attack → 14:35 uptime で復旧
+        {
+          source: "attack-detected",
+          occurredAt: "2026-05-10T09:32:00.000Z",
+          result: "down",
+        },
+        {
+          source: "uptime",
+          occurredAt: "2026-05-10T09:35:00.000Z",
+          result: "ok",
+        },
+        // 14:42 attack → 後続 uptime 無し = 未復旧
+        {
+          source: "attack-detected",
+          occurredAt: "2026-05-10T09:42:00.000Z",
+          result: "down",
+        },
+        // 別種の event は無視 (attack のみ返す)
+        {
+          source: "flag",
+          occurredAt: "2026-05-10T09:55:00.000Z",
+          result: "ok",
+        },
+      ],
+    });
+
+    const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.response.events).toHaveLength(2);
+    // 降順
+    expect(out.response.events[0]?.occurredAt).toBe("2026-05-10T09:42:00.000Z");
+    expect(out.response.events[0]?.recoveredAt).toBeNull(); // 未復旧
+    expect(out.response.events[1]?.occurredAt).toBe("2026-05-10T09:32:00.000Z");
+    expect(out.response.events[1]?.recoveredAt).toBe("2026-05-10T09:35:00.000Z"); // 復旧
+  });
+
+  it("response shape: jobId / problemId / sinceMin / events のみで内部情報を露出しない", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [teamRow({ tenantId: "tenant-acme", teamLoginKey: "SECRET", namePrefix: "tc-x" })],
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 15, NOW_MS);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.response).toEqual({
+      jobId: VALID_JOB_ID,
+      problemId: "security-battle-royale",
+      sinceMin: 15,
+      events: [],
+    });
+    const json = JSON.stringify(out.response);
+    expect(json).not.toContain("SECRET");
+    expect(json).not.toContain("tenantId");
+    expect(json).not.toContain("namePrefix");
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
+++ b/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
@@ -79,7 +79,7 @@ describe("listBattleAttacks", () => {
     expect(out).toEqual({ kind: "not_found" });
   });
 
-  it("正常系: PK=DEPLOYMENT#<jobId> + SK begins_with EVENT# + occurredAt >= since で Query", async () => {
+  it("正常系: PK=DEPLOYMENT#<jobId> + SK BETWEEN EVENT#<since> AND EVENT#~ で Query (時間窓は key-condition で絞る)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
     ddbSend.mockResolvedValueOnce({ Items: [] });
@@ -89,13 +89,49 @@ describe("listBattleAttacks", () => {
     const q = ddbSend.mock.calls[1]?.[0] as QueryCommand;
     expect(q).toBeInstanceOf(QueryCommand);
     expect(q.input.KeyConditionExpression).toContain("PK = :pk");
-    expect(q.input.KeyConditionExpression).toContain("begins_with(SK, :evpfx)");
+    expect(q.input.KeyConditionExpression).toContain("SK BETWEEN :sk_start AND :sk_end");
     expect(q.input.ExpressionAttributeValues?.[":pk"]).toBe(`DEPLOYMENT#${VALID_JOB_ID}`);
-    expect(q.input.ExpressionAttributeValues?.[":evpfx"]).toBe("EVENT#");
-    expect(q.input.FilterExpression).toBe("occurredAt >= :since");
     // since = NOW − 30 分 = "2026-05-10T09:30:00.000Z"
-    expect(q.input.ExpressionAttributeValues?.[":since"]).toBe("2026-05-10T09:30:00.000Z");
+    expect(q.input.ExpressionAttributeValues?.[":sk_start"]).toBe("EVENT#2026-05-10T09:30:00.000Z");
+    expect(q.input.ExpressionAttributeValues?.[":sk_end"]).toBe("EVENT#~");
+    // FilterExpression は使わず key condition のみ (post-read filter で RCU 暴発しないように)
+    expect(q.input.FilterExpression).toBeUndefined();
     expect(q.input.ScanIndexForward).toBe(false);
+  });
+
+  it("DELETING / DELETED 状態の deployment 行は target にしない (= teardown 中の sparse 残骸対策)", async () => {
+    for (const status of ["DELETING", "DELETED"] as const) {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [teamRow({ status })] });
+      const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+      expect(out).toEqual({ kind: "not_found" });
+      // 1 回目 (queryTeamItems) のみ呼ばれて event query には到達しない
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("LastEvaluatedKey があれば paginate して残りの page も読む", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { source: "attack-detected", occurredAt: "2026-05-10T09:55:00.000Z", result: "down" },
+      ],
+      LastEvaluatedKey: { PK: "x", SK: "y" },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { source: "attack-detected", occurredAt: "2026-05-10T09:35:00.000Z", result: "down" },
+      ],
+    });
+
+    const out = await listBattleAttacks(shared, TEAM_KEY, VALID_JOB_ID, 30, NOW_MS);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.response.events).toHaveLength(2);
+    // 2 page 目への ExclusiveStartKey が指定されている
+    const secondPage = ddbSend.mock.calls[2]?.[0] as QueryCommand;
+    expect(secondPage.input.ExclusiveStartKey).toEqual({ PK: "x", SK: "y" });
   });
 
   it("attack-detected event を時系列降順で返し、後続 uptime event を recoveredAt として結合する", async () => {

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -230,4 +230,117 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     const view = await lookupTeamByLoginKey(shared, "KEY1");
     expect(view?.problems[0]?.score).toBe(0);
   });
+
+  /* ADR-005 Phase 3.1: applicationStatus aggregate ----------------------- */
+
+  it("uptime kind problem の applicationStatus を aggregate (healthy) で返すべき", async () => {
+    const scoring = {
+      "security-battle-royale": {
+        kind: "uptime" as const,
+        pointsPerSuccess: 5,
+        endpoints: [],
+      },
+    };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          endpointsHealth: JSON.stringify({
+            FrontendUrl: { ok: true, checkedAt: "2026-05-10T09:55:00.000Z" },
+            ApiUrl: { ok: true, checkedAt: "2026-05-10T09:55:00.000Z" },
+          }),
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.applicationStatus).toEqual({
+      overall: "healthy",
+      healthyCount: 2,
+      totalCount: 2,
+      checkedAt: "2026-05-10T09:55:00.000Z",
+    });
+  });
+
+  it("uptime kind: 一部 NG なら degraded、全 NG なら down", async () => {
+    const scoring = { p: { kind: "uptime" as const, pointsPerSuccess: 5, endpoints: [] } };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          jobId: "J1",
+          PK: "DEPLOYMENT#J1",
+          problemId: "p",
+          endpointsHealth: JSON.stringify({
+            FrontendUrl: { ok: true, checkedAt: "2026-05-10T09:55:00.000Z" },
+            ApiUrl: { ok: false, checkedAt: "2026-05-10T09:55:00.000Z" },
+          }),
+        }),
+        sampleRow({
+          jobId: "J2",
+          PK: "DEPLOYMENT#J2",
+          problemId: "p",
+          endpointsHealth: JSON.stringify({
+            FrontendUrl: { ok: false, checkedAt: "2026-05-10T09:55:00.000Z" },
+            ApiUrl: { ok: false, checkedAt: "2026-05-10T09:55:00.000Z" },
+          }),
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.applicationStatus?.overall).toBe("degraded");
+    expect(view?.problems[1]?.applicationStatus?.overall).toBe("down");
+  });
+
+  it("uptime kind: endpointsHealth が無い (probe 未実行) なら unknown", async () => {
+    const scoring = { p: { kind: "uptime" as const, pointsPerSuccess: 5, endpoints: [] } };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ problemId: "p", endpointsHealth: undefined })],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.applicationStatus?.overall).toBe("unknown");
+    expect(view?.problems[0]?.applicationStatus?.totalCount).toBe(0);
+  });
+
+  it("flag kind problem は applicationStatus を露出しないべき (= Challenge は対象外)", async () => {
+    const scoring = {
+      "hello-world": { kind: "flag" as const, flagOutputKey: "F", points: 100 },
+    };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          problemId: "hello-world",
+          endpointsHealth: JSON.stringify({ X: { ok: true, checkedAt: "x" } }),
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.applicationStatus).toBeUndefined();
+  });
+
+  it("applicationStatus に endpoint 名 / URL を絶対に含めないべき (snapshot guard)", async () => {
+    const scoring = { p: { kind: "uptime" as const, pointsPerSuccess: 5, endpoints: [] } };
+    const { shared, ddbSend } = buildShared(scoring);
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          problemId: "p",
+          endpointsHealth: JSON.stringify({
+            FrontendUrl: { ok: false, checkedAt: "2026-05-10T09:55:00.000Z" },
+            SecretInternalProbeName: { ok: true, checkedAt: "2026-05-10T09:55:00.000Z" },
+          }),
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    const json = JSON.stringify(view?.problems[0]?.applicationStatus);
+    expect(json).not.toContain("FrontendUrl");
+    expect(json).not.toContain("SecretInternalProbeName");
+  });
 });

--- a/infrastructure/test/problem-deploy/participant-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/participant-score-events.test.ts
@@ -139,6 +139,36 @@ describe("listScoreEvents", () => {
     }
   });
 
+  it("attack-detected が 1 page 目を埋め尽くしても次 page を読んで scoring 行を回収する", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    // 1 page 目: 全部 attack-detected (= toView で undefined になり 0 件)
+    ddbSend.mockResolvedValueOnce({
+      Items: Array.from({ length: 3 }, (_, i) =>
+        event({
+          source: "attack-detected",
+          result: "down",
+          occurredAt: `2026-05-08T10:0${i}:00.000Z`,
+        }),
+      ),
+      LastEvaluatedKey: { PK: "DEPLOYMENT#J1", SK: "EVENT#x" },
+    });
+    // 2 page 目: 有効な uptime row
+    ddbSend.mockResolvedValueOnce({
+      Items: [event({ occurredAt: "2026-05-08T09:00:00.000Z", source: "uptime" })],
+    });
+
+    const out = await listScoreEvents(shared, "KEY1", 1);
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(1);
+      expect(out.response.entries[0]?.source).toBe("uptime");
+    }
+    // 2 page 目の query には ExclusiveStartKey が乗る
+    const secondPage = ddbSend.mock.calls[2]?.[0] as QueryCommand;
+    expect(secondPage.input.ExclusiveStartKey).toEqual({ PK: "DEPLOYMENT#J1", SK: "EVENT#x" });
+  });
+
   it("teamId / eventId / tenantId 等 operator 内部情報を出力に含めないべき", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });

--- a/infrastructure/test/problem-deploy/score-event.test.ts
+++ b/infrastructure/test/problem-deploy/score-event.test.ts
@@ -1,0 +1,64 @@
+import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { describe, expect, it, vi } from "vitest";
+import { writeScoreEvent } from "../../lib/problem-deploy/handlers/shared/score-event";
+
+const parent = {
+  jobId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+  problemId: "security-battle-royale",
+  teamId: "T1",
+  eventId: "E1",
+  expiresAt: 1_700_000_000,
+};
+
+describe("writeScoreEvent (ADR-005 Phase 3.1: source extension)", () => {
+  it("source=uptime のとき result=ok / points=指定値で書き込む", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(ddb, "T", parent, "uptime", 5, "2026-05-10T10:00:00.000Z");
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd).toBeInstanceOf(PutCommand);
+    expect(cmd.input.Item).toMatchObject({
+      source: "uptime",
+      points: 5,
+      result: "ok",
+      occurredAt: "2026-05-10T10:00:00.000Z",
+    });
+  });
+
+  it("source=flag のとき result=ok / points=指定値で書き込む (= 既存挙動維持)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(ddb, "T", parent, "flag", 100, "2026-05-10T10:00:00.000Z");
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      source: "flag",
+      points: 100,
+      result: "ok",
+    });
+  });
+
+  it("source=attack-detected のとき result=down / points=0 で書き込む (新仕様)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(ddb, "T", parent, "attack-detected", 0, "2026-05-10T10:00:00.000Z");
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      source: "attack-detected",
+      points: 0,
+      result: "down",
+      occurredAt: "2026-05-10T10:00:00.000Z",
+    });
+  });
+
+  it("PK / SK が DEPLOYMENT#<jobId> / EVENT#<ts>#<ulid> 形になる", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(ddb, "T", parent, "uptime", 5, "2026-05-10T10:00:00.000Z");
+    const item = (send.mock.calls[0]?.[0] as PutCommand).input.Item as {
+      PK: string;
+      SK: string;
+    };
+    expect(item.PK).toBe(`DEPLOYMENT#${parent.jobId}`);
+    expect(item.SK).toMatch(/^EVENT#2026-05-10T10:00:00\.000Z#[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Issue (#520) — ADR-005 Phase 3.1 の backend 実装。Battle 形式問題の Portal UI が依存する
3 つの backend 変更を 1 PR でまとめる。Phase 3.2 (frontend Tabs) は次の PR。

## 主な変更

### Step 1: \`shared/score-event.ts\` — source 拡張
- type \`source\` に \`"attack-detected"\` 追加 (uptime / flag / attack-detected)
- type \`result\` に \`"down"\` 追加 (ok / down)
- writeScoreEvent で source=attack-detected → result を自動で "down" に決定

### Step 2: health-check-handler — ok→fail 遷移で attack-detected 1 件
- allOk=true → "uptime" event (= 既存挙動)
- allOk=false かつ 直前 lastResult==="ok" → "attack-detected" 1 件 (points=0, result=down)
- 連続 fail tick では書かない (= ADR-005 D2-A の row 爆発防止 hard guard)
- lastResult が undefined (probe 未実行) は書かない (= 初回 deploy 直後の誤検知防止)

### Step 3: \`lookup.ts\` — applicationStatus aggregate
- ParticipantProblemView に \`applicationStatus?\` 追加 (uptime kind のみ露出)
- 判定: 全 OK → healthy / 全 NG → down / 一部 → degraded / 空 → unknown
- per-endpoint URL / 名前は **絶対に出さない** (ADR-005 D1)、snapshot test で固定

### Step 4: \`GET /portal/me/battle-attacks\` 新設
- Auth: queryTeamItems で team の jobId 一致 check
- DDB Query: PK=DEPLOYMENT#<jobId> + EVENT# prefix + occurredAt >= since
- recoveredAt: server-side で uptime event を結合 (= 復旧 marker)
- sinceMin: default 30 / 上限 60、超過は 400
- response shape は ADR-005 API spec と完全一致

### Step 5: frontend portal-client — type-only
- ApplicationStatus / BattleAttackEventView / BattleAttacksResponse 型追加
- getBattleAttacks API helper 追加 (= 既存 portalFetch 流用)
- UI 自体は Phase 3.2

## 物理影響

| 種別 | リソース | 注 |
| --- | --- | --- |
| UPDATE | health-check Lambda | ok→fail 遷移時に attack-detected 1 件 write |
| UPDATE | participant-handler Lambda | 新 route + lookup view 拡張 |
| UPDATE | shared/score-event | source / result enum 拡張 |
| UPDATE | participant-portal SPA | type-only、UI 不変 |
| NO-OP | CDK / DDB schema / IAM / API GW | Function URL は path-pattern なし |

## Test plan

- [x] \`make before-commit\` 緑 (新 17 件 + 既存 全 500 件 pass)
- [x] battle-attacks: invalid_jobid / invalid_sincemin × 4 / unauthorized / not_found / 正常 Query / recoveredAt 結合 / response shape 内部情報非露出
- [x] lookup applicationStatus: healthy / degraded+down / unknown / flag kind 非露出 / endpoint 名非露出 snapshot
- [x] score-event: uptime/flag/attack-detected の result+points+source / SK 形式
- [ ] AWS deploy 後、Battle deployment で probe fail → score event row 追加
- [ ] curl で \`/portal/me/battle-attacks?jobId=&sinceMin=\` が ADR-005 spec の shape

## Regression 分析

- 既存 score event consumer は source 値が 1 種類増えるだけで shape 不変
- lookup view から endpointsHealth 直接露出は **元から無し** (= 既存設計の念押し)
- HealthCheck の追加 write は ok→fail transition のみ、平常時は従来通り 1 write/tick
- sinceMin 上限 60 分で RCU 暴発を防ぐ (ADR-005 Capacity 見積もり済)

## 次の Phase

- **Phase 3.2**: ProblemDetail に Tabs / Cloudscape LineChart
- **Phase 3.3**: \`problems/README.md\` に attack-detected の前提を追記

Closes #520 (ADR-005 Phase 3.1 完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added application health status aggregation showing overall service health (healthy/degraded/down/unknown) with endpoint counts
  * New battle attacks API endpoint to retrieve detected service attacks with recovery timestamps
  * Enhanced event tracking to record attack occurrences and recovery information for uptime monitoring

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->