### PR TITLE
fix(scripts): provision/deprovision の冪等性 — 再実行で死なないように guard 追加

### DIFF
--- a/scripts/deprovision-tenant.sh
+++ b/scripts/deprovision-tenant.sh
@@ -79,9 +79,15 @@ if [[ $TIER == "PLATINUM" ]]; then
     --query 'Item.stackName.S')
 
   echo "Stack name from $TENANT_STACK_MAPPING_TABLE is  $STACK_NAME"
-  # Clone the serverless reference solution repository
+  # Clone the serverless reference solution repository (idempotent — 再実行で
+  # "destination path already exists" にならないよう、既存 dir があればそのまま使う)。
+  # cdk destroy は CFn 既存 stack に対して動くので、ローカル CDK code は最低限あれば十分。
   export CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME="aws-saas-factory-ref-solution-serverless-saas"
-  git clone codecommit://$CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME
+  if [ ! -d "$CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME" ]; then
+    git clone codecommit://$CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME
+  else
+    echo "Repository already cloned: $CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME (skip clone)"
+  fi
   cd $CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME/server
   npm install
 

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -72,17 +72,26 @@ API_GATEWAY_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --
 # operator が確認する)。
 APPLICATION_ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='$APPLICATION_ADMIN_CONSOLE_URL_OUTPUT_PARAM_NAME'].OutputValue" --output text)
 
-# Create tenant admin user
-aws cognito-idp admin-create-user \
-  --user-pool-id "$SAAS_APP_USERPOOL_ID" \
-  --username "$TENANT_ADMIN_USERNAME" \
-  --user-attributes Name=email,Value="$TENANT_ADMIN_EMAIL" Name=email_verified,Value="True" Name=phone_number,Value="+11234567890" Name="custom:userRole",Value="TenantAdmin" Name="custom:tenantId",Value="$CDK_PARAM_TENANT_ID" Name="custom:tenantTier",Value="$TIER" \
-  --desired-delivery-mediums EMAIL
+# Create tenant admin user (idempotent — provisioning が中途で失敗 → SBT が再実行
+# したとき UsernameExistsException で死なないよう、既存 user は skip)。
+if aws cognito-idp admin-get-user --user-pool-id "$SAAS_APP_USERPOOL_ID" --username "$TENANT_ADMIN_USERNAME" >/dev/null 2>&1; then
+  echo "Tenant admin user already exists: $TENANT_ADMIN_USERNAME (skip create)"
+else
+  aws cognito-idp admin-create-user \
+    --user-pool-id "$SAAS_APP_USERPOOL_ID" \
+    --username "$TENANT_ADMIN_USERNAME" \
+    --user-attributes Name=email,Value="$TENANT_ADMIN_EMAIL" Name=email_verified,Value="True" Name=phone_number,Value="+11234567890" Name="custom:userRole",Value="TenantAdmin" Name="custom:tenantId",Value="$CDK_PARAM_TENANT_ID" Name="custom:tenantTier",Value="$TIER" \
+    --desired-delivery-mediums EMAIL
+fi
 
-# Create tenant user group
-aws cognito-idp create-group \
-  --user-pool-id "$SAAS_APP_USERPOOL_ID" \
-  --group-name "$CDK_PARAM_TENANT_ID"
+# Create tenant user group (idempotent — 再実行で GroupExistsException にならないよう skip)
+if aws cognito-idp get-group --user-pool-id "$SAAS_APP_USERPOOL_ID" --group-name "$CDK_PARAM_TENANT_ID" >/dev/null 2>&1; then
+  echo "Tenant user group already exists: $CDK_PARAM_TENANT_ID (skip create)"
+else
+  aws cognito-idp create-group \
+    --user-pool-id "$SAAS_APP_USERPOOL_ID" \
+    --group-name "$CDK_PARAM_TENANT_ID"
+fi
 
 # Add tenant admin user to tenant user group
 aws cognito-idp admin-add-user-to-group \


### PR DESCRIPTION
## Summary

PR-521 で見つかった `unzip` 非冪等問題の同種スキャンで、CodeBuild 内 (BashJobRunner / CodePipeline) で動くスクリプトの 2 回目以降の build で死ぬ pattern を 3 件発見。修正。

- `scripts/provision-tenant.sh` — `cognito-idp admin-create-user` / `create-group` を `admin-get-user` / `get-group` で pre-check して skip
- `scripts/deprovision-tenant.sh` — `git clone codecommit://...` を `[ ! -d ]` guard で skip

別途進行中の `unzip -o` 修正 (provision-tenant.sh:31 と update-tenant.sh:27) とは独立。

## 物理影響

bash scripts のみ (NO-OP for IaC / CDK / DDB / Lambda / metadata)。

## Regression 分析

- 初回 provision / deprovision の正常系は変わらない (existence check が false → 旧経路)
- 中途失敗後の再実行で skip log が出るのが新挙動 (= debug ログとしては有用)
- cognito の `admin-get-user` / `get-group` は describe 系 API なので追加コストは microscopic
- 競合 race (2 つの provision が同時に走る) — SBT は同 tenantId の re-onboarding を serialize する設計なので発生しない前提

## Test plan

CodeBuild 内でのみ動く script なので unit test 不可。次の `make deploy` で実機検証:

- [ ] 初回 tenant 作成 → 正常完了 (`admin-create-user` / `create-group` が走る)
- [ ] 同じ tenantId で再 onboarding → "already exists ... skip create" がログに出て成功
- [ ] tenant 削除 → 正常完了
- [ ] 失敗後の再 deprovision → "Repository already cloned ... skip clone" が出て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tenant provisioning now safely handles re-execution by checking for existing admin users and groups before creation, preventing duplicate resource errors
  * Tenant deprovisioning now safely handles re-execution by detecting existing repositories and skipping unnecessary clone operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->