### PR TITLE
feat(notifications): ADR-006 Phase 4.1 backend handler (operator POST + participant GET)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -21,3 +21,15 @@ export function resolveTenantId(c: Context): string {
   if (fromJwt) return fromJwt;
   return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;
 }
+
+/**
+ * Cognito `sub` claim を取り出す (= operator の安定識別子)。Notifications の
+ * `createdBy` 監査用などで使う。JWT 認可が無い経路 (= tests / local fallback) は
+ * `"unknown"` を返す。
+ */
+export function resolveCognitoSub(c: Context): string {
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const sub = claims?.sub;
+  return typeof sub === "string" && sub.length > 0 ? sub : "unknown";
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/create-notification.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/create-notification.ts
@@ -1,0 +1,64 @@
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+import type { NotificationCreateRequest, NotificationItem } from "../shared/notification.js";
+import type { EventSharedResources } from "./shared.js";
+import type { EventItem } from "./types.js";
+
+/**
+ * `createNotification` の結果。
+ * - `not_found`: tenant 不一致 / event 不在 → 404 相当
+ * - `ok`       : 書き込み完了。notificationId / occurredAt を返す。
+ */
+export type CreateNotificationOutcome =
+  | { kind: "not_found" }
+  | { kind: "ok"; notificationId: string; occurredAt: string };
+
+/**
+ * Event に紐づく 1 通知行を Events table に PutItem する (ADR-006)。
+ *
+ * `severity` 既定値は `info`。`expiresAt` は親 event 行と同値 (epoch seconds、TTL 同期)。
+ * `createdBy` は operator の Cognito sub (tenant API GW + JWT authorizer から渡る `sub` claim)。
+ *
+ * 失敗セマンティクス:
+ *   - tenant 不一致 / event 不在 → `not_found`
+ *   - DDB 書き込み失敗 → throw (caller が 500 にする)
+ *
+ * 1 partition (= 1 event) に N 通知が並ぶが、SK = NOTIFICATION#<isoTs>#<ulid> なので
+ * 同 ms の race も ulid suffix で衝突回避できる (= 採点 event 行と同じ流儀)。
+ */
+export async function createNotification(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  createdBy: string,
+  req: NotificationCreateRequest,
+  nowMs: number = Date.now(),
+): Promise<CreateNotificationOutcome> {
+  const probe = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+    }),
+  );
+  const event = probe.Item as Partial<EventItem> | undefined;
+  if (!event || event.tenantId !== tenantId) return { kind: "not_found" };
+
+  const notificationId = ulid();
+  const occurredAt = new Date(nowMs).toISOString();
+  const item: NotificationItem = {
+    PK: `EVENT#${eventId}`,
+    SK: `NOTIFICATION#${occurredAt}#${notificationId}`,
+    notificationId,
+    tenantId,
+    eventId,
+    title: req.title,
+    body: req.body,
+    severity: req.severity ?? "info",
+    createdBy,
+    occurredAt,
+    expiresAt: Number(event.expiresAt ?? 0),
+  };
+
+  await shared.ddb.send(new PutCommand({ TableName: shared.eventsTableName, Item: item }));
+  return { kind: "ok", notificationId, occurredAt };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
-import { resolveTenantId } from "../deploy-handler/auth.js";
+import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
 import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
@@ -13,10 +13,12 @@ import {
   HTTP_NOT_FOUND,
   HTTP_OK,
 } from "../shared/http-status.js";
+import { NotificationCreateRequestSchema } from "../shared/notification.js";
 import { archiveEvent } from "./archive.js";
 import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
+import { createNotification } from "./create-notification.js";
 import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
 import { setEventSchedule } from "./schedule.js";
@@ -24,12 +26,13 @@ import { buildEventSharedResources } from "./shared.js";
 import { CreateEventRequestSchema, ScheduleEventRequestSchema } from "./types.js";
 
 /**
- * Event API Lambda の Hono app (ADR-004 Phase 1+2a)。routes:
+ * Event API Lambda の Hono app (ADR-004 Phase 1+2a, ADR-006 Notifications)。routes:
  *   POST   /events
  *   GET    /events
  *   GET    /events/:eventId
- *   POST   /events/:eventId/deploy   — Bulk deploy (teams × problems を fan-out)
- *   DELETE /events/:eventId          — Bulk teardown
+ *   POST   /events/:eventId/deploy         — Bulk deploy (teams × problems を fan-out)
+ *   POST   /events/:eventId/notifications  — 運営 → 競技者 通知 1 件作成 (ADR-006)
+ *   DELETE /events/:eventId                — Bulk teardown
  *
  * Auth: tenant API GW + Cognito JWT authorizer。tenantId は JWT `custom:tenantId` claim
  * から `resolveTenantId` で抽出する (DeployApi Lambda と同じ shape)。
@@ -176,6 +179,41 @@ app.post("/events/:eventId/end", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] endEvent failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.post("/events/:eventId/notifications", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "request body must be JSON" }, HTTP_BAD_REQUEST);
+  }
+  const parsed = NotificationCreateRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await createNotification(
+      shared,
+      resolveTenantId(c),
+      eventId,
+      resolveCognitoSub(c),
+      parsed.data,
+    );
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    return c.json(
+      { notificationId: outcome.notificationId, occurredAt: outcome.occurredAt },
+      HTTP_CREATED,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] createNotification failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -6,6 +6,7 @@ import { HTTP_OK } from "../shared/http-status.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
+import { listNotifications, NOTIFICATIONS_DEFAULT_LIMIT } from "./notifications.js";
 import { respondError, withBearerAuth } from "./route-helpers.js";
 import { listScoreEvents } from "./score-events.js";
 import { buildParticipantSharedResources } from "./shared.js";
@@ -18,6 +19,7 @@ import { setDisplayTeamName } from "./update.js";
  *   GET   /portal/healthz
  *   GET   /portal/leaderboard           — event scope の team ランキング
  *   GET   /portal/me/score-events       — 自チームの加点履歴 (時系列降順)
+ *   GET   /portal/me/notifications      — 自 event 宛の運営通知 (ADR-006、時系列降順)
  *   GET   /portal/me                    — Authorization: Bearer <teamLoginKey>
  *                                         → { team, problems[] }
  *   GET   /portal/me/console-signin-url — AWS Console federation login URL 発行
@@ -55,6 +57,18 @@ app.get("/portal/me/console-signin-url", (c) =>
     if (!jobId) return respondError(c, "missing_jobid");
     const outcome = await getConsoleSigninUrl(shared, token, jobId);
     if (outcome.kind === "ok") return c.json({ loginUrl: outcome.loginUrl }, HTTP_OK);
+    return respondError(c, outcome.kind);
+  }),
+);
+
+app.get("/portal/me/notifications", (c) =>
+  withBearerAuth(c, "notifications", async (token) => {
+    const limitRaw = c.req.query("limit");
+    // `Number` で strict parse — "100.5" や "10abc" は NaN/float になり listNotifications
+    // 側の `Number.isInteger` で reject。`parseInt` だと truncate されて silent pass する。
+    const limit = limitRaw === undefined ? NOTIFICATIONS_DEFAULT_LIMIT : Number(limitRaw);
+    const outcome = await listNotifications(shared, token, limit);
+    if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
     return respondError(c, outcome.kind);
   }),
 );

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/notifications.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/notifications.ts
@@ -1,0 +1,88 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { NotificationItem, NotificationView } from "../shared/notification.js";
+import type { ParticipantSharedResources } from "./shared.js";
+import { queryTeamItems } from "./shared.js";
+
+/**
+ * `GET /portal/me/notifications` の response shape (ADR-006)。
+ */
+export interface NotificationsResponse {
+  readonly eventId: string;
+  readonly items: readonly NotificationView[];
+}
+
+export type ListNotificationsOutcome =
+  | { kind: "ok"; response: NotificationsResponse }
+  | { kind: "unauthorized" }
+  | { kind: "no_event" }
+  | { kind: "invalid_limit" };
+
+/** limit 既定値 / 上限 (ADR-006 API 設計)。*/
+export const NOTIFICATIONS_DEFAULT_LIMIT = 100;
+export const NOTIFICATIONS_MAX_LIMIT = 200;
+
+/**
+ * 自 team が紐づく event の通知一覧を時系列降順で返す。
+ *
+ * 認可: teamLoginKey で GSI2 を Query → team の deployments を取得。`eventId` は
+ * 同 team の deployment 全行で一定 (= ADR-004 で event 1 件に紐づく構造) のため、
+ * 任意の 1 行から拾えば十分。旧 jobId-based deployment (eventId 無し) は `no_event`。
+ *
+ * Events table を `PK = EVENT#<eventId>` AND `begins_with(SK, "NOTIFICATION#")` で
+ * Query (ScanIndexForward=false で降順)。`limit` で取得件数制限。
+ *
+ * 設計: tenantId / createdBy / 内部 PK/SK は **絶対に出さない** (NotificationView に
+ * field が無いので構造的に漏れない)。
+ */
+export async function listNotifications(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  limitRaw: number = NOTIFICATIONS_DEFAULT_LIMIT,
+): Promise<ListNotificationsOutcome> {
+  if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > NOTIFICATIONS_MAX_LIMIT) {
+    return { kind: "invalid_limit" };
+  }
+
+  const myItems = await queryTeamItems(shared, teamLoginKey);
+  if (myItems.length === 0) return { kind: "unauthorized" };
+
+  const eventId = myItems
+    .map((i) => (typeof i.eventId === "string" ? i.eventId : undefined))
+    .find((e): e is string => typeof e === "string" && e.length > 0);
+  if (!eventId) return { kind: "no_event" };
+
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.eventsTableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :prefix)",
+      ExpressionAttributeValues: {
+        ":pk": `EVENT#${eventId}`,
+        ":prefix": "NOTIFICATION#",
+      },
+      ScanIndexForward: false,
+      Limit: limitRaw,
+    }),
+  );
+
+  const items = ((out.Items ?? []) as Partial<NotificationItem>[])
+    .map(toView)
+    .filter((v): v is NotificationView => v !== undefined);
+
+  return { kind: "ok", response: { eventId, items } };
+}
+
+/** NotificationItem (DDB row) → NotificationView (公開 shape)。不正な行は undefined。 */
+function toView(item: Partial<NotificationItem>): NotificationView | undefined {
+  if (typeof item.notificationId !== "string") return undefined;
+  if (typeof item.title !== "string") return undefined;
+  if (typeof item.body !== "string") return undefined;
+  if (item.severity !== "info" && item.severity !== "warning") return undefined;
+  if (typeof item.occurredAt !== "string") return undefined;
+  return {
+    notificationId: item.notificationId,
+    title: item.title,
+    body: item.body,
+    severity: item.severity,
+    occurredAt: item.occurredAt,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -16,6 +16,7 @@ const ERROR_STATUS = {
   unauthorized: HTTP_UNAUTHORIZED,
   invalid_jobid: HTTP_BAD_REQUEST,
   invalid_sincemin: HTTP_BAD_REQUEST,
+  invalid_limit: HTTP_BAD_REQUEST,
   invalid_team_name: HTTP_BAD_REQUEST,
   invalid_problem_id: HTTP_BAD_REQUEST,
   invalid_flag: HTTP_BAD_REQUEST,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -12,6 +12,12 @@ import type { DeploymentItem } from "../deploy-handler/types.js";
  */
 export interface ParticipantSharedResources {
   readonly tableName: string;
+  /**
+   * Events table 名 (ADR-006 Notifications で参照)。`GET /portal/me/notifications` が
+   * `PK=EVENT#<eventId>` の partition で `begins_with(SK, "NOTIFICATION#")` を
+   * Query する。CDK 側で IAM `dynamodb:Query` を Events table にも付与する。
+   */
+  readonly eventsTableName: string;
   readonly ddb: DynamoDBDocumentClient;
   /** `{ [problemId]: ProblemScoringMetadata }`。submit-flag が採点に使う。 */
   readonly problemsScoring: Record<string, ProblemScoringMetadata>;
@@ -20,6 +26,7 @@ export interface ParticipantSharedResources {
 export function buildParticipantSharedResources(): ParticipantSharedResources {
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
+    eventsTableName: getEnv("EVENTS_TABLE_NAME"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
   };

--- a/infrastructure/lib/problem-deploy/handlers/shared/notification.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/notification.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+/**
+ * 運営 → 競技者 Notification の DDB 行 shape (ADR-006)。
+ *
+ *   PK = `EVENT#<eventId>` (= 既存 Events partition と同居)
+ *   SK = `NOTIFICATION#<occurredAt>#<ulid>` (時系列降順 sort + 衝突防止)
+ *
+ * 既存 META 行を巻き込まないので Event detail / list の Query には影響しない
+ * (sparse な追加行)。TTL は親 event の `expiresAt` を継承し、event archive 後も
+ * TTL までは残す (= 競技者の振り返り猶予、ADR-006 D5)。
+ */
+export interface NotificationItem {
+  PK: string;
+  SK: string;
+
+  notificationId: string;
+  tenantId: string;
+  eventId: string;
+  title: string;
+  body: string;
+  severity: "info" | "warning";
+  /** 監査用に operator の Cognito sub を残す。UI には出さない。 */
+  createdBy: string;
+  occurredAt: string;
+  /** DDB TTL。event 行の `expiresAt` と同値 (epoch seconds)。 */
+  expiresAt: number;
+}
+
+/**
+ * `POST /events/:eventId/notifications` 受信 body (ADR-006 API 設計)。
+ *
+ * - `title` 1〜120 chars
+ * - `body`  1〜2000 chars
+ * - `severity` optional、default `info`
+ */
+export const NotificationCreateRequestSchema = z.object({
+  title: z.string().min(1).max(120),
+  body: z.string().min(1).max(2000),
+  severity: z.enum(["info", "warning"]).optional(),
+});
+export type NotificationCreateRequest = z.infer<typeof NotificationCreateRequestSchema>;
+
+/**
+ * 競技者向けに公開する Notification 1 行 (内部 PK/SK / tenantId / createdBy 等は出さない)。
+ */
+export interface NotificationView {
+  readonly notificationId: string;
+  readonly title: string;
+  readonly body: string;
+  readonly severity: "info" | "warning";
+  readonly occurredAt: string;
+}

--- a/infrastructure/test/problem-deploy/event-create-notification.test.ts
+++ b/infrastructure/test/problem-deploy/event-create-notification.test.ts
@@ -1,0 +1,131 @@
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNotification } from "../../lib/problem-deploy/handlers/event-handler/create-notification";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const TENANT_ID = "tenant-acme";
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const NOW_MS = new Date("2026-05-10T14:42:18.000Z").getTime();
+
+function buildShared(): { shared: EventSharedResources; ddbSend: ReturnType<typeof vi.fn> } {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "TestBus",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: {} as unknown as EventSharedResources["events"],
+    problemsCatalog: {},
+  };
+  return { shared, ddbSend };
+}
+
+const eventRow = (over: Record<string, unknown> = {}) => ({
+  PK: `EVENT#${EVENT_ID}`,
+  SK: "META",
+  eventId: EVENT_ID,
+  tenantId: TENANT_ID,
+  status: "READY",
+  expiresAt: 1_700_000_000,
+  ...over,
+});
+
+describe("createNotification (ADR-006)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("event 不在は not_found", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+    const out = await createNotification(
+      shared,
+      TENANT_ID,
+      EVENT_ID,
+      "operator-sub-1",
+      { title: "t", body: "b" },
+      NOW_MS,
+    );
+    expect(out).toEqual({ kind: "not_found" });
+    expect(ddbSend).toHaveBeenCalledTimes(1); // PutCommand には行かない
+  });
+
+  it("tenant 不一致は not_found (= 別 tenant の event を gestures しても情報を与えない)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: eventRow({ tenantId: "tenant-other" }) });
+    const out = await createNotification(
+      shared,
+      TENANT_ID,
+      EVENT_ID,
+      "operator-sub-1",
+      { title: "t", body: "b" },
+      NOW_MS,
+    );
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("正常系: PK=EVENT#<eventId> + SK=NOTIFICATION#<isoTs>#<ulid> で PutItem する", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: eventRow() });
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await createNotification(
+      shared,
+      TENANT_ID,
+      EVENT_ID,
+      "operator-sub-1",
+      { title: "scoring 再開", body: "メンテ完了" },
+      NOW_MS,
+    );
+
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.occurredAt).toBe("2026-05-10T14:42:18.000Z");
+
+    const get = ddbSend.mock.calls[0]?.[0] as GetCommand;
+    expect(get).toBeInstanceOf(GetCommand);
+    expect(get.input.Key).toEqual({ PK: `EVENT#${EVENT_ID}`, SK: "META" });
+
+    const put = ddbSend.mock.calls[1]?.[0] as PutCommand;
+    expect(put).toBeInstanceOf(PutCommand);
+    expect(put.input.TableName).toBe("TestEvents");
+    const item = put.input.Item as {
+      PK: string;
+      SK: string;
+      title: string;
+      body: string;
+      severity: string;
+      tenantId: string;
+      eventId: string;
+      createdBy: string;
+      occurredAt: string;
+      expiresAt: number;
+    };
+    expect(item.PK).toBe(`EVENT#${EVENT_ID}`);
+    expect(item.SK).toMatch(/^NOTIFICATION#2026-05-10T14:42:18\.000Z#[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(item.title).toBe("scoring 再開");
+    expect(item.body).toBe("メンテ完了");
+    expect(item.severity).toBe("info");
+    expect(item.tenantId).toBe(TENANT_ID);
+    expect(item.eventId).toBe(EVENT_ID);
+    expect(item.createdBy).toBe("operator-sub-1");
+    expect(item.expiresAt).toBe(1_700_000_000);
+  });
+
+  it("severity 指定 (warning) を尊重する", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: eventRow() });
+    ddbSend.mockResolvedValueOnce({});
+
+    await createNotification(
+      shared,
+      TENANT_ID,
+      EVENT_ID,
+      "op",
+      { title: "メンテ予告", body: "30 分後に 5 分停止", severity: "warning" },
+      NOW_MS,
+    );
+
+    const put = ddbSend.mock.calls[1]?.[0] as PutCommand;
+    expect((put.input.Item as { severity: string }).severity).toBe("warning");
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
+++ b/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
@@ -14,6 +14,7 @@ function buildShared(): { shared: ParticipantSharedResources; ddbSend: ReturnTyp
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };

--- a/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
+++ b/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
@@ -13,6 +13,7 @@ function buildShared(): {
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -10,6 +10,7 @@ function buildShared(scoring: ParticipantSharedResources["problemsScoring"] = {}
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: scoring,
   };

--- a/infrastructure/test/problem-deploy/participant-notifications.test.ts
+++ b/infrastructure/test/problem-deploy/participant-notifications.test.ts
@@ -1,0 +1,170 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listNotifications,
+  NOTIFICATIONS_MAX_LIMIT,
+} from "../../lib/problem-deploy/handlers/participant-handler/notifications";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+const TEAM_KEY = "KEY1";
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+function buildShared(): {
+  shared: ParticipantSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+  };
+  return { shared, ddbSend };
+}
+
+const teamRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#J1",
+  SK: "META",
+  GSI2PK: `TEAMKEY#${TEAM_KEY}`,
+  jobId: "J1",
+  problemId: "p1",
+  eventId: EVENT_ID,
+  status: "COMPLETE",
+  ...over,
+});
+
+describe("listNotifications (ADR-006)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("limit が 0 / 負 / 上限超 / 非整数 は invalid_limit", async () => {
+    const { shared } = buildShared();
+    expect((await listNotifications(shared, TEAM_KEY, 0)).kind).toBe("invalid_limit");
+    expect((await listNotifications(shared, TEAM_KEY, -1)).kind).toBe("invalid_limit");
+    expect((await listNotifications(shared, TEAM_KEY, NOTIFICATIONS_MAX_LIMIT + 1)).kind).toBe(
+      "invalid_limit",
+    );
+    expect((await listNotifications(shared, TEAM_KEY, 1.5)).kind).toBe("invalid_limit");
+  });
+
+  it("teamLoginKey 不正 (deployment 0 件) は unauthorized", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    expect((await listNotifications(shared, TEAM_KEY, 50)).kind).toBe("unauthorized");
+  });
+
+  it("旧 jobId-based deployment (eventId 無し) は no_event を返す", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [teamRow({ eventId: undefined })],
+    });
+    expect((await listNotifications(shared, TEAM_KEY, 50)).kind).toBe("no_event");
+  });
+
+  it("正常系: PK=EVENT#<eventId> + begins_with(SK, NOTIFICATION#) で降順 Query", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          notificationId: "01J0NEW",
+          title: "新しい",
+          body: "本文 1",
+          severity: "info",
+          occurredAt: "2026-05-10T14:42:00.000Z",
+        },
+        {
+          notificationId: "01J0OLD",
+          title: "古い",
+          body: "本文 2",
+          severity: "warning",
+          occurredAt: "2026-05-10T13:00:00.000Z",
+        },
+      ],
+    });
+
+    const out = await listNotifications(shared, TEAM_KEY, 50);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.response.eventId).toBe(EVENT_ID);
+    expect(out.response.items).toHaveLength(2);
+    expect(out.response.items[0]?.title).toBe("新しい");
+    expect(out.response.items[1]?.severity).toBe("warning");
+
+    const q = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    expect(q).toBeInstanceOf(QueryCommand);
+    expect(q.input.TableName).toBe("TestEvents");
+    expect(q.input.KeyConditionExpression).toContain("PK = :pk");
+    expect(q.input.KeyConditionExpression).toContain("begins_with(SK, :prefix)");
+    expect(q.input.ExpressionAttributeValues?.[":pk"]).toBe(`EVENT#${EVENT_ID}`);
+    expect(q.input.ExpressionAttributeValues?.[":prefix"]).toBe("NOTIFICATION#");
+    expect(q.input.ScanIndexForward).toBe(false); // 降順
+    expect(q.input.Limit).toBe(50);
+  });
+
+  it("response shape: tenantId / createdBy / 内部 PK/SK は出力に含めない (D1 漏洩防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: `EVENT#${EVENT_ID}`,
+          SK: `NOTIFICATION#2026-05-10T14:42:00.000Z#01J0`,
+          notificationId: "01J0",
+          tenantId: "TENANT_LEAK_SENTINEL",
+          eventId: EVENT_ID,
+          createdBy: "OPERATOR_SUB_LEAK_SENTINEL",
+          title: "t",
+          body: "b",
+          severity: "info",
+          occurredAt: "2026-05-10T14:42:00.000Z",
+          expiresAt: 1_700_000_000,
+        },
+      ],
+    });
+
+    const out = await listNotifications(shared, TEAM_KEY, 50);
+    if (out.kind === "ok") {
+      const json = JSON.stringify(out.response);
+      expect(json).not.toContain("TENANT_LEAK_SENTINEL");
+      expect(json).not.toContain("OPERATOR_SUB_LEAK_SENTINEL");
+      expect(json).not.toContain("NOTIFICATION#"); // SK そのまま漏らさない
+      expect(json).not.toContain("1700000000"); // expiresAt 漏らさない
+    }
+  });
+
+  it("不正な行 (severity 不明 / title 欠落) は除外", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [teamRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        // 有効
+        {
+          notificationId: "1",
+          title: "ok",
+          body: "b",
+          severity: "info",
+          occurredAt: "2026-05-10T14:00:00.000Z",
+        },
+        // severity 不正
+        {
+          notificationId: "2",
+          title: "bad",
+          body: "b",
+          severity: "critical",
+          occurredAt: "2026-05-10T13:00:00.000Z",
+        },
+        // title 欠落
+        {
+          notificationId: "3",
+          body: "b",
+          severity: "info",
+          occurredAt: "2026-05-10T12:00:00.000Z",
+        },
+      ],
+    });
+
+    const out = await listNotifications(shared, TEAM_KEY, 50);
+    if (out.kind === "ok") expect(out.response.items).toHaveLength(1);
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-routes.test.ts
+++ b/infrastructure/test/problem-deploy/participant-routes.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
   buildParticipantSharedResources: () => ({
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: vi.fn() },
   }),
 }));

--- a/infrastructure/test/problem-deploy/participant-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/participant-score-events.test.ts
@@ -10,6 +10,7 @@ function buildShared(): {
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -22,6 +22,7 @@ function buildShared(): { shared: ParticipantSharedResources; ddbSend: ReturnTyp
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -13,6 +13,7 @@ function buildShared(): {
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -11,6 +11,7 @@ function buildShared(): {
   const ddbSend = vi.fn();
   const shared: ParticipantSharedResources = {
     tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
     ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
     problemsScoring: {},
   };


### PR DESCRIPTION
## Summary

Issue (#499) ADR-006 Notifications の Phase 4.1 backend handler 実装 (Claude スコープ分)。

新設 API 2 本:

- \`POST /events/:eventId/notifications\` (operator、Cognito JWT)
- \`GET /portal/me/notifications\` (participant、Bearer teamLoginKey)

DDB は **既存 Events table に同居** (ADR-006 D1): \`PK=EVENT#<eventId>\` \`SK=NOTIFICATION#<isoTs>#<ulid>\`。新テーブル不要、TTL は親 event 行を継承。

## 物理影響

handler code のみ。**本 PR 単体では runtime 動作しない** (CDK 配線が別途必要)。merge 後に user 側で次の CDK PR を出すと runtime で動く:

1. ParticipantPortalLambda の env に \`EVENTS_TABLE_NAME\` 追加
2. ParticipantPortalLambda の IAM に Events table の \`dynamodb:Query\` 追加
3. tenant API GW に \`events/{eventId}/notifications\` POST route 配線

(Issue #499 Phase 4.1 umbrella の \`(user)\` checkbox)

## Test plan

- [x] \`make typecheck\` 緑
- [x] \`make test\` 緑 (infra 348 + portal 51 + app-admin 75 + admin 37 = **511** tests)
- [x] handler unit tests 10 件追加 (event-create-notification 4 件 + participant-notifications 6 件)
- [ ] 実 deploy: user CDK PR merge 後、\`POST /events/:id/notifications\` → \`GET /portal/me/notifications\` で 1 通知が見える

## Regression 分析

- \`EVENTS_TABLE_NAME\` env を \`getEnv\` で必須化 — CDK 配線前は Lambda init で throw (= 設定漏れを silent 通過させない)
- 既存 \`/portal/me*\` 経路は \`eventsTableName\` を読まないので影響なし
- 既存 7 participant test fixture には \`eventsTableName: \"TestEvents\"\` を追加しただけで挙動不変
- \`resolveCognitoSub\` は新関数なので既存呼び出し影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification Management: Event creators can create notifications with title, body, and severity levels. Notifications automatically track creation timestamps and inherit expiration settings from parent events.
  * Notifications Portal: Participants can now view all notifications related to their events through a new portal endpoint. The endpoint supports configurable pagination with a default limit of 100 and maximum limit of 200 items.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/524)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->