### PR TITLE
feat(docs): docs/**/*.md を HTML に build する SSG (build-docs) を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export JSII_DEPRECATED := quiet
 .DEFAULT_GOAL := help
 
 .PHONY: help install install_ci build typecheck test check before-commit beforecommit \
+        build-docs check-docs \
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
@@ -27,8 +28,10 @@ build:         ; bun run build
 typecheck:     ; bun run typecheck
 test:          ; bun run test
 validate-problems: ; bun run validate:problems
-check:         install lint test validate-problems
-before-commit: lint test validate-problems
+build-docs:    ; bun run scripts/build-docs.ts
+check-docs:    ; bun run scripts/build-docs.ts --check
+check:         install lint test validate-problems check-docs
+before-commit: lint test validate-problems check-docs
 
 # ===== Lint / Fix =====
 lint:   lint-md lint-text lint-format

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
         "husky": "^9.1.4",
         "markdownlint-cli2": "^0.21.0",
+        "marked": "^18.0.3",
         "textlint": "^15.5.2",
         "textlint-filter-rule-comments": "^1.3.0",
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
@@ -1243,6 +1244,8 @@
     "markdownlint-cli2": ["markdownlint-cli2@0.21.0", "", { "dependencies": { "globby": "16.1.0", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "markdown-it": "14.1.1", "markdownlint": "0.40.0", "markdownlint-cli2-formatter-default": "0.0.6", "micromatch": "4.0.8" }, "bin": { "markdownlint-cli2": "markdownlint-cli2-bin.mjs" } }, "sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw=="],
 
     "markdownlint-cli2-formatter-default": ["markdownlint-cli2-formatter-default@0.0.6", "", { "peerDependencies": { "markdownlint-cli2": ">=0.0.4" } }, "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ=="],
+
+    "marked": ["marked@18.0.3", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA=="],
 
     "match-index": ["match-index@1.0.3", "", { "dependencies": { "regexp.prototype.flags": "^1.1.1" } }, "sha512-1XjyBWqCvEFFUDW/MPv0RwbITRD4xQXOvKoPYtLDq8IdZTfdF/cQSo5Yn4qvhfSSZgjgkTFsqJD2wOUG4ovV8Q=="],
 

--- a/docs/api/README.html
+++ b/docs/api/README.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud API リファレンス</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud API リファレンス</h1>
+<p>TenkaCloud の HTTP API 仕様。3 つの API サーフェスを <strong>plane (= オーディエンス) ごとに
+分離した OpenAPI 3.1 spec</strong> で持つ。本書はその俯瞰 narrative。</p>
+<table>
+<thead>
+<tr>
+<th>サーフェス</th>
+<th>仕様ファイル</th>
+<th>配信先 SPA / Stack</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Control Plane API</td>
+<td><a href="./control-plane.openapi.yaml"><code>control-plane.openapi.yaml</code></a></td>
+<td><code>apps/admin-console</code> / <code>ControlPlaneStack</code></td>
+</tr>
+<tr>
+<td>Tenant API</td>
+<td><a href="./tenant.openapi.yaml"><code>tenant.openapi.yaml</code></a></td>
+<td><code>apps/application-admin-console</code> / <code>TenantTemplateStack</code></td>
+</tr>
+<tr>
+<td>Participant API</td>
+<td><a href="./participant.openapi.yaml"><code>participant.openapi.yaml</code></a></td>
+<td><code>apps/participant-portal</code> / <code>ProblemDeployBackendStack</code></td>
+</tr>
+<tr>
+<td>共通スキーマ</td>
+<td><a href="./_components.yaml"><code>_components.yaml</code></a></td>
+<td>(paths を持たない、<code>$ref</code> 専用)</td>
+</tr>
+</tbody></table>
+<p>3 ファイルに分割した理由は <strong>Plane 分離 (Control Plane vs Application Plane) が SBT
+由来の architectural invariant</strong> だから。1 サーフェス multi-tenant SaaS (Slack, Stripe)
+は 1 ファイルが多数派だが、TenkaCloud のような multi-plane / multi-audience SaaS は
+Auth0 (Management API + Authentication API) や Atlassian (Admin API + Product API) など
+分割が定石。</p>
+<h2>サーフェス概要</h2>
+<table>
+<thead>
+<tr>
+<th>サーフェス</th>
+<th>用途</th>
+<th>認証</th>
+<th>提供元</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Control Plane API</strong></td>
+<td>テナント (= 主催者組織) の CRUD</td>
+<td>Cognito JWT (System Admin)</td>
+<td>SBT <code>ControlPlane</code> (<code>@cdklabs/sbt-aws</code> 0.3.9)</td>
+</tr>
+<tr>
+<td><strong>Tenant API</strong></td>
+<td>問題の deploy / 一覧 / 詳細 / 削除</td>
+<td>Cognito JWT (Tenant Admin)</td>
+<td><code>TenantTemplateStack</code> 内 <code>ApiGateway</code></td>
+</tr>
+<tr>
+<td><strong>Participant API</strong></td>
+<td>競技者がチームの問題状態を取得 / flag を提出</td>
+<td><code>teamLoginKey</code> を bearer</td>
+<td><code>ProblemDeployBackendStack</code> の Lambda Function URL</td>
+</tr>
+</tbody></table>
+<p>3 つの URL は <strong><code>runtime-config.json</code> 経由で SPA に注入</strong> される (CloudFront 配下)。
+URL を build 成果物に焼かない (= dist は tenant 共有可) — <code>docs/architecture/harness.md</code>
+の <code>INVARIANT_APP_CODE_IS_UNMODIFIED</code> に従う。</p>
+<h2>認証</h2>
+<h3>Cognito JWT (Control Plane / Tenant API)</h3>
+<pre><code>Authorization: Bearer &lt;cognito_id_token&gt;
+</code></pre>
+<ul>
+<li>Hosted UI + OAuth Code + PKCE で取得</li>
+<li>ID Token (<code>access_token</code> ではない) を渡す。<code>custom:tenantId</code> claim から tenantId を解決する</li>
+<li>期限切れは 401 (refresh は SPA 側で <code>aws-amplify</code> が自動実行)</li>
+</ul>
+<h3>teamLoginKey (Participant API)</h3>
+<pre><code>Authorization: Bearer &lt;teamLoginKey&gt;
+</code></pre>
+<ul>
+<li>Tenant Admin が <code>POST /problems/:id/deploy</code> を呼んだときに <strong>1 度だけ</strong> レスポンスに含まれる</li>
+<li>競技者に hand-off (口頭 / 安全な手段で) する短命キー</li>
+<li>DDB の TTL (<code>expiresAt</code>) で自動失効</li>
+<li>key 自体を bearer にしているため、leak すると <strong>そのチームの状態が外部から閲覧されるだけでなく、
+<code>POST /portal/me/submit-flag</code> で不正に flag を提出され勝手に加点される</strong> リスクがある</li>
+</ul>
+<h2>API ごとの実行権限 (最小権限の早見表)</h2>
+<p>クライアント側の認証 (誰が呼べるか) と、実体 Lambda が AWS 上で持つ IAM の両方を、
+3 サーフェスごとに分離しています。</p>
+<table>
+<thead>
+<tr>
+<th>サーフェス</th>
+<th>クライアント認証</th>
+<th>公開 URL</th>
+<th>実体 Lambda</th>
+<th>Lambda の IAM (= 触れる AWS リソース)</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Control Plane API</td>
+<td>Cognito JWT (<code>SystemAdmin</code> group)</td>
+<td>API GW + Cognito Authorizer</td>
+<td>SBT 内蔵 (TenantDetails CRUD)</td>
+<td>DDB <code>TenantDetails</code> のみ + EventBridge <code>onboardingRequest</code> publish</td>
+</tr>
+<tr>
+<td>Tenant API</td>
+<td>Cognito JWT (<code>TenantAdmin</code> custom claim)</td>
+<td>per-tenant API GW + Cognito Authorizer</td>
+<td><code>DeployApi</code> Lambda</td>
+<td>DDB <code>Deployments</code> (RW) + EventBridge bus (PutEvents) のみ。<strong>CFn 権限は持たない</strong></td>
+</tr>
+<tr>
+<td>Participant API</td>
+<td><code>teamLoginKey</code> を bearer (Lambda 内検証)</td>
+<td>Lambda Function URL (<code>AuthType=NONE</code>)</td>
+<td><code>ParticipantPortal</code> Lambda</td>
+<td>DDB <code>Deployments</code> Query (GSI2 経由) + UpdateItem のみ。<strong>CFn / EventBridge / 他テーブル権限なし</strong></td>
+</tr>
+<tr>
+<td>Health Check (内部)</td>
+<td>EventBridge <code>rate(1 minute)</code> で起動</td>
+<td>(公開なし)</td>
+<td><code>HealthCheck</code> Lambda</td>
+<td>DDB <code>Deployments</code> (RW) + 競技者エンドポイントへの outbound HTTP のみ</td>
+</tr>
+<tr>
+<td>Deploy 実体 (内部)</td>
+<td>Step Functions Task</td>
+<td>(公開なし)</td>
+<td><code>DeployCodeBuildProject</code> (CodeBuild)</td>
+<td>CFn (Create/Update/Delete/Describe) + EC2/IAM/SSM/Logs/S3/Events/Lambda の <code>*</code> (= 問題テンプレが必要なリソースを作成するため)</td>
+</tr>
+</tbody></table>
+<h3>設計原則</h3>
+<ol>
+<li><strong>API Lambda 自身は CFn を直接触らない</strong><ul>
+<li><code>DeployApi</code> は EventBridge publish するだけ。実 deploy / delete は CodeBuild Project が
+行う。これにより API Lambda の権限を「DDB + EventBridge」に閉じ込めて、もし API Lambda
+が乗っ取られても CFn を勝手に発火できないようにしている。</li>
+</ul>
+</li>
+<li><strong>Participant Lambda は read 寄り + 自分の行の Update だけ</strong><ul>
+<li><code>dynamodb:UpdateItem</code> は table 全体に向けて grant されているが、Lambda コード側で
+teamLoginKey の所有者の行 (GSI2 で引いた 1 行) しか触らない実装になっている。</li>
+</ul>
+</li>
+<li><strong>削除権限は CodeBuild Project に集約</strong><ul>
+<li><code>cloudformation:DeleteStack</code> を持つのは CodeBuild Project Role のみ。
+DeployApi Lambda には付与しない (= 削除のトリガーは EventBridge 経由のみ)。</li>
+</ul>
+</li>
+<li><strong>Participant Portal の Function URL は AuthType=NONE</strong><ul>
+<li>Cognito を per-team 払い出すと運営コストが大きいため、<code>teamLoginKey</code> をそのまま
+bearer として Lambda 内で検証する。Function URL の AuthType は NONE。</li>
+</ul>
+</li>
+<li><strong>クロステナント漏洩防止</strong><ul>
+<li><code>tenantId</code> mismatch は 404 (存在を漏らさない)。read 経路すべてで <code>where tenantId = caller</code>
+を強制する。</li>
+</ul>
+</li>
+</ol>
+<h2>エラー方針</h2>
+<pre><code class="language-jsonc">// 4xx
+{ &quot;error&quot;: &quot;&lt;machine_readable_code&gt;&quot; }
+
+// validation error (Zod)
+{ &quot;error&quot;: &quot;validation failed&quot;, &quot;issues&quot;: [...] }
+
+// 5xx
+{ &quot;error&quot;: &quot;internal_error&quot; }
+</code></pre>
+<h3>クロステナント漏洩防止</h3>
+<p>read 経路で <code>tenantId</code> mismatch を見つけた場合は <strong><code>404 not_found</code> を返す</strong>
+(403 / &quot;wrong tenant&quot; を返さない)。存在を漏らさないため。</p>
+<h2>デプロイ / 削除のライフサイクル</h2>
+<p>Tenant API の <code>/problems/:id/deploy</code> と <code>/deployments/:jobId</code> (DELETE) は、
+<strong>SBT の <code>ScriptJob</code> 同型</strong> な構造で動きます。</p>
+<pre><code>[Tenant API Lambda]
+   │ ① validation + DDB Put + EventBridge PutEvents
+   ▼
+[EventBridge bus] ── DeployCreateRequested / DeployDeleteRequested
+   │
+   ▼
+[Step Functions State Machine]
+   │ ② CodeBuildStartBuild .sync (RUN_JOB integration)
+   ▼
+[CodeBuild Project]
+   │ ③ scripts/deploy-battles.sh (create) または scripts/delete-battles.sh (delete)
+   ▼
+[CloudFormation]
+   │ ④ CreateStack / DeleteStack
+   ▼
+[State Machine 完了] → DDB row の status を COMPLETE / DELETED / FAILED に書き戻す
+</code></pre>
+<h3>Status 遷移</h3>
+<pre><code>PENDING ─→ IN_PROGRESS ─→ COMPLETE ─→ DELETING ─→ DELETED
+                       └→ FAILED   ─→ DELETING ─→ DELETED
+</code></pre>
+<ul>
+<li><code>PENDING / IN_PROGRESS / COMPLETE / FAILED</code> から DELETE → <code>DELETING</code></li>
+<li><code>DELETING / DELETED</code> への DELETE は <code>200 already_deleted</code> (no-op)</li>
+<li>DELETING 中に CFn が失敗したら <code>FAILED</code> + <code>failureReason</code> (operator が再試行)</li>
+</ul>
+<h2>Scoring</h2>
+<p>問題 metadata の <code>scoring.kind</code> で 2 系統に分かれる。</p>
+<ul>
+<li><code>flag</code> (Challenge): 競技者が <code>POST /portal/me/submit-flag</code> で flag を提出 → Lambda が
+CFn Outputs と照合して採点する。</li>
+<li><code>uptime</code> (Battle): <code>HealthCheck</code> Lambda が 1 分間隔で endpoint を probe し、
+防御側が止まっていたら点数を伸ばさない (攻撃側のスコア優位)。</li>
+</ul>
+<p>詳細は <a href="../requirements/"><code>docs/requirements/</code></a> を参照。</p>
+<h2>仕様の更新フロー</h2>
+<ol>
+<li>Hono handler の zod スキーマを変える</li>
+<li>該当サーフェスの <code>*.openapi.yaml</code> を手で同期する。共通スキーマは
+<code>_components.yaml</code> 側を直す。現状は手書きで、Phase 2 で <code>@hono/zod-openapi</code>
+自動生成へ移行する</li>
+<li><code>make before-commit</code> で lint + typecheck + test を通す</li>
+</ol>
+<p>将来: zod スキーマ → OpenAPI 自動生成 (<code>@hono/zod-openapi</code>) で 2 重管理を解消する。</p>
+<h2>レンダリング</h2>
+<p>ローカルプレビューは任意のレンダラで行う。3 サーフェスを別々に build する
+(plane 分離思想と整合)。</p>
+<pre><code class="language-bash"># Redoc CLI で各 plane の HTML を吐く
+nlx @redocly/cli build-docs docs/api/control-plane.openapi.yaml -o docs/api/control-plane.html
+nlx @redocly/cli build-docs docs/api/tenant.openapi.yaml        -o docs/api/tenant.html
+nlx @redocly/cli build-docs docs/api/participant.openapi.yaml   -o docs/api/participant.html
+
+# Swagger UI を docker で起動 (例: tenant API)
+docker run --rm -p 8080:8080 \
+  -e SWAGGER_JSON=/spec/tenant.openapi.yaml \
+  -v &quot;$(pwd)/docs/api:/spec&quot; \
+  swaggerapi/swagger-ui
+</code></pre>
+<p>CI では <code>nlx @redocly/cli lint docs/api/*.openapi.yaml</code> を回して破綻を検知する想定。</p>
+
+<div class="doc-source">Source: <code>docs/api/README.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/api/README.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/architecture/harness.html
+++ b/docs/architecture/harness.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Architecture Harness</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud Architecture Harness</h1>
+<p>この文書は、セッションが変わっても壊してはいけない原則を機械可読な ID つきで固定する正本です。</p>
+<h2>Invariants</h2>
+<ul>
+<li><p><code>INVARIANT_CONTROL_PLANE_USES_SBT</code>
+Control Plane は <code>@cdklabs/sbt-aws</code> の ControlPlane construct に乗せる。Cognito User Pool / API Gateway / EventBridge を自前で再実装しない。sbt-aws の更新に追従する。</p>
+</li>
+<li><p><code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code>
+Control Plane は tenant manager であり、tenant runtime host ではない。AssumeRole + CloudFormation 経由の問題 deploy は tenant Application Plane (<code>ProblemDeployBackendStack</code>) 側に閉じ込め、Control Plane stack には持ち込まない。</p>
+</li>
+<li><p><code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code>
+テナント分離はインフラ層で実現する。DynamoDB は PK にテナント ID を含める。アプリコードでは tenant 識別ロジックを書かない（アプリは自分が誰のためのインスタンスか知らなくていい）。</p>
+</li>
+<li><p><code>INVARIANT_APP_CODE_IS_UNMODIFIED</code>
+<code>apps/</code> 配下のアプリケーションコードは tenant ごとにフォークしたり書き換えない。同じ build artifact (<code>dist/</code>) を pooled stack と silo stack の両方で使い回し、tenant 差分は CDK が <code>runtime-config.json</code> 経由で注入する。tenant ごとに変わる可能性があるのは config だけで、コードは 1 セット。これが崩れた瞬間に「customer 1 = fork 1」になり SaaS の経済が壊れる。</p>
+</li>
+<li><p><code>INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER</code>
+認証 (Cognito UserPool / Hosted UI / JWT) はインフラ層で注入する。アプリコードに認証バイパス (<code>AUTH_SKIP</code> 的な分岐) や tenant 識別ロジックを書かない。production / dev で別のフロー要件が出ても、CDK 側で UserPool を分けるか callback URL を切り替えるかで対応する。アプリ側の <code>if (isDev)</code> でのバイパス禁止。</p>
+</li>
+</ul>
+<h2>One Pass</h2>
+<p>セッションが変わっても、次の 2 つのフローを 1 回で通せる状態を保つ。</p>
+<ul>
+<li><p><code>ONE_PASS_LOCAL</code>
+ローカル開発で <code>make install</code> → 各 SPA の <code>make dev</code> を起動した後、<code>apps/admin-console</code> から <code>apps/application-admin-console</code> へ繋いで「tenant 作成 → application console → 問題 deploy form 表示 → participant portal でログイン」までブラウザ操作だけで一気通貫で動くこと。途中で別ターミナルでスクリプトを叩く / .env を手で書き換える必要が発生したら、その時点で原因を CDK / scripts に戻して恒久化する。</p>
+</li>
+<li><p><code>ONE_PASS_AWS</code>
+AWS deploy では <code>infrastructure/environments/&lt;env&gt;/.env</code> に必須値だけ入れて <code>make deploy</code> 1 発で「Phase 1 (backend) → Phase 2 (admin-console hosting) → Phase 3 (callback 更新)」が通り、SystemAdmin 招待メール → admin-console ログイン → tenant 作成 → application-admin-console から問題 deploy → 競技者 portal でログイン → 問題エンドポイント表示まで一気通貫で動くこと。teardown は <code>make destroy</code> で冪等。途中失敗時は同じコマンドで resume できる。</p>
+</li>
+</ul>
+<h2>PR Discipline</h2>
+<p>商用 SaaS として出す以上、「動くものを小さくインクリメンタルに積み上げる」規律を PR 単位で強制する。ここでいう「動くもの」は商用運用に耐える状態を指す。小さい scope でも、テストされていて、意図が明示されていて、場当たり対応が混ざっていない。デモのためのハリボテ、proof-of-concept、後続 PR が前提の scaffolding は対象外。</p>
+<p>参考ケース: <code>https://zenn.dev/nttdata_tech/articles/8a010aff542625</code>。AI-native 開発の失敗パターンとして、テスト観点不足・PR 単位の不明瞭・仕様の埋没があり、これらは統合テストまでリグレッション検出を遅らせる。PR 単位でこの視点を強制する。</p>
+<ul>
+<li><p><code>INVARIANT_PR_SHIPS_WORKING_INCREMENT</code>
+PR 単体を main に merge した後、ユーザー観察可能な機能が 1 つ以上 start working すること。次の 3 条件を同時に満たすこと。</p>
+<ul>
+<li>小さい (1 PR = 1 関心事、触るファイル数はおおむね 10 を超えない)</li>
+<li>商用品質 (テストされていて意図が明確、場当たり的な hardcode / TODO 残しが無い)</li>
+<li>独立に価値を持つ (「別 PR の土台」「scaffolding」「consumer 待ちのライブラリ」は単独では merge しない)</li>
+</ul>
+</li>
+<li><p><code>INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE</code>
+コード変更と、そのコードの振る舞いを固定するテストを同じ PR に含める。既存テストでカバーされている場合は「この PR で追加したテストはゼロ」と明記してよい。ただし、どの既存テストがどの挙動を守るかを PR body で明示する。AI 生成テストを含める場合、主張する code path を実際に exercise しているか手で確認する。claim と実体の食い違いが起きる場合もある。</p>
+</li>
+<li><p><code>INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED</code>
+PR body の <code>## Regression 分析</code> セクションで、merge で壊しうる既存挙動を列挙する。確認方法 (grep / code read / test run / 実環境観察) を項目ごとに書く。未確認が 1 つでも残っている PR は DRAFT のまま残す。テストが green であることは Regression 分析の代替にならない。テストが existing behavior をカバーしているか自体の確認が別途必要。</p>
+</li>
+<li><p><code>INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED</code>
+PR body に <code>## 物理影響</code> セクションを置く。そこで <code>make deploy</code> で変わる AWS リソース、<code>make build</code> で変わる成果物を列挙する。CFT 差分ゼロの場合も明示し、reviewer に推論させない。種別は CREATE / UPDATE / REPLACE / DELETE / NO-OP から選ぶ。</p>
+</li>
+</ul>
+<h2>Banned Assumptions</h2>
+<ul>
+<li>アプリコード内で tenant ID を引き回す前提（<code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code> 違反）</li>
+<li>「一部画面が出た」「synth だけ通る」を one-pass completion と見なす運用</li>
+<li>「テストが green だから merge OK」思考。Regression 分析を省略する言い訳にしない。テストが existing behavior をカバーしているかどうかは別途確認</li>
+<li>「small PR だから影響範囲も小さい」という前提 (diff の行数と影響範囲は独立。小さい IAM 変更 1 行で本番が止まる)</li>
+<li>「動くまでチェイン PR が要る」形の scaffolding PR を単独 merge する運用 (<code>INVARIANT_PR_SHIPS_WORKING_INCREMENT</code> 違反)。consumer と束ねて 1 PR にするか、rebase で順序を整える</li>
+<li>「動くもの = 最小のハリボテでもよい」誤解 (商用品質が条件。小さい scope ≠ 雑でよい)</li>
+<li>AI 生成テストの実効性を人間が検証しない運用。claim している code path を実際に exercise しているか確認しないまま merge する</li>
+</ul>
+<h2>Enforcement Rules</h2>
+<p>Invariants に加えて、実装レベルの原則を機械検査するルールを harness が持つ。ルール ID は <code>secrets-manager-forbidden</code> のようにケバブケースで命名する。</p>
+<ul>
+<li><p><code>secrets-manager-forbidden</code>
+<code>@aws-sdk/client-secrets-manager</code> の import を TS/JS ファイルで検出すると error。TenkaCloud はコスト 0 運用を原則とし、秘匿値は SSM Parameter Store (SecureString, Standard tier = 無料) に置く。Secrets Manager はシークレット 1 件あたり月額課金が発生する。</p>
+</li>
+<li><p><code>handler-must-not-call-fetch</code>
+<code>lib/handlers/</code> 配下のファイルで <code>fetch(</code> の直接呼び出しを検出すると error。handler (Controller 層) は入力検証と Service 呼び出しとレスポンス整形のみを担い、外部 API 通信は Repository 層に閉じ込める。Controller に fetch を入れると Service / Repository の境界が崩れ、ユニットテストが HTTP モック前提になる。</p>
+</li>
+</ul>
+<h2>Enforcement</h2>
+<ul>
+<li><code>make harness</code> (= <code>bun run .claude/harness/bin/architecture.ts --staged --fail-on=error</code>)</li>
+<li><code>make harness-test</code> (= <code>cd .claude/harness &amp;&amp; bunx vitest run</code>)</li>
+<li><code>make tech-debt</code> (= <code>bun run .claude/harness/bin/tech-debt.ts</code>)</li>
+<li><code>make before-commit</code>（<code>.claude/settings.json</code> の PreToolUse hook と <code>.husky/pre-commit</code> から自動実行）</li>
+</ul>
+<h2>Harness Commands</h2>
+<ul>
+<li>Staged ファイルに対する strict run: <code>make harness</code></li>
+<li>Harness ルール自体のユニットテスト: <code>make harness-test</code></li>
+<li>技術的負債レポート生成: <code>make tech-debt</code></li>
+<li>コミット前チェック: <code>make before-commit</code></li>
+</ul>
+<p>Git hook と AI エージェント向けガイドは、この文書を参照して同じ判定に従う。</p>
+
+<div class="doc-source">Source: <code>docs/architecture/harness.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/architecture/harness.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/notifications.html
+++ b/docs/operations/notifications.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Notifications 運用ガイド</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Notifications 運用ガイド</h1>
+<p>ADR-006 に基づく運営 → 競技者通知機能の使い方と運用上の制約。実装の経緯と設計判断は
+<a href="../architecture/adr-006-notifications.html">ADR-006</a> を参照。本 doc は現場で迷ったときに見る運用ガイド。</p>
+<h2>通知の届き方</h2>
+<table>
+<thead>
+<tr>
+<th>項目</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>配信方式</td>
+<td>Pull (= participant portal が polling)</td>
+</tr>
+<tr>
+<td>Polling 間隔</td>
+<td>TeamViewProvider tick (現状 5 秒)</td>
+</tr>
+<tr>
+<td>競技者の体感遅延</td>
+<td><strong>最大 5 秒</strong> (画面開いている場合)</td>
+</tr>
+<tr>
+<td>画面を閉じている競技者</td>
+<td><strong>届かない</strong> (Web Push 不採用、ADR-006 D7)</td>
+</tr>
+<tr>
+<td>Severity 段階</td>
+<td><code>info</code> / <code>warning</code> の 2 段</td>
+</tr>
+<tr>
+<td>一覧の保持期間</td>
+<td>親 event の <code>expiresAt</code> まで (DDB TTL で自動削除)</td>
+</tr>
+<tr>
+<td>編集 / 削除</td>
+<td><strong>不可</strong> (= 一度送ったら取り消せない、idempotent な書き出し前提)</td>
+</tr>
+<tr>
+<td>既読管理</td>
+<td>競技者ブラウザ localStorage (= 同一ブラウザ内で完結)</td>
+</tr>
+</tbody></table>
+<p>ENDED / TEARDOWN / ARCHIVED 状態の event でも DDB TTL までは履歴が残るので、競技後の
+振り返りで参照できる。</p>
+<h2>いつ何を通知すべきか</h2>
+<h3><code>info</code> を使うケース</h3>
+<ul>
+<li>競技ステータスのアナウンス:「14:30 から scoring 再開しました」「全 team 配備完了」</li>
+<li>進行情報:「現在 5 / 8 problem を deploy 済み、残り 3 問は順次解放」</li>
+<li>軽微な FAQ:「Battle 系問題で endpoint URL は SSO Credentials ページから取得可能」</li>
+</ul>
+<blockquote>
+<p><strong>判断基準</strong>: 競技者が <strong>今すぐ行動を変えなくてもいい</strong> 通知。確認して脳内 update できれば
+十分なもの。</p>
+</blockquote>
+<h3><code>warning</code> を使うケース</h3>
+<ul>
+<li>メンテ予告:「30 分後に 5 分間 health check を停止」</li>
+<li>障害告知:「特定 region で AWS 側障害が発生中、一時的に scoring 反映遅延あり」</li>
+<li>競技ルール変更:「flag 形式を 1 問差し替え。提出前に最新要件を要確認」</li>
+</ul>
+<blockquote>
+<p><strong>判断基準</strong>: 競技者がそれを把握していないと <strong>不利益を被る</strong> か、<strong>行動の手戻り</strong> が
+出る通知。</p>
+</blockquote>
+<h3>使い分けに迷ったら</h3>
+<ul>
+<li>1 event あたり <code>warning</code> は <strong>5 件以下</strong> に抑える (頻発するとオオカミ少年化して <code>info</code>
+と区別がつかなくなる)</li>
+<li>「これは <code>warning</code> か?」と迷ったら基本 <code>info</code></li>
+<li>競技者の Battle Portal は防御中で集中している → 通知を送りすぎない (= 1 時間に 1 件
+程度を上限の目安に)</li>
+</ul>
+<h2>操作手順</h2>
+<ol>
+<li>application admin console から対象 event の <strong>Event Detail</strong> ページを開く</li>
+<li>ヘッダー右上の <strong>「通知を送る」</strong> ボタン (DRAFT / TEARDOWN / ARCHIVED 状態では disabled。
+READY / ENDED / DEPLOYING 状態のみ送信可能)</li>
+<li>Modal で <strong>タイトル</strong> (1〜120 文字) + <strong>本文</strong> (1〜2000 文字) + <strong>severity</strong> を入力</li>
+<li><strong>送信</strong> で 201 Created。送信成功 Alert が画面上部に出る</li>
+<li>競技者の Participant Portal <code>/notifications</code> で次の polling tick (最大 5 秒) で表示</li>
+</ol>
+<h3>競技者目線の確認方法</h3>
+<p>別 browser のセッションでテスト team の <code>teamLoginKey</code> でログインし、<code>/notifications</code>
+ページを開けば確認できる (本番チームの未読 badge を勝手に既読化しないこと)。</p>
+<h2>失敗時の挙動</h2>
+<table>
+<thead>
+<tr>
+<th>状況</th>
+<th>挙動</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>入力 validation 違反 (空文字 / 上限超)</td>
+<td>Modal 内 Alert で表示、送信されない</td>
+</tr>
+<tr>
+<td>event 不在 / tenant 不一致</td>
+<td>404 → Modal 内 Alert</td>
+</tr>
+<tr>
+<td>競技者ブラウザの localStorage 不可 (private mode)</td>
+<td>既読管理が無効化、毎回全件未読扱い (graceful degradation)</td>
+</tr>
+<tr>
+<td>participant が旧 jobId-based deployment</td>
+<td>404 → portal 側で「通知配信対象外」 Alert</td>
+</tr>
+<tr>
+<td>backend Lambda init 失敗 (<code>EVENTS_TABLE_NAME</code> 未設定 等)</td>
+<td>participant 側 polling が一時的にエラーになるが、他経路 (<code>/portal/me</code> / <code>/portal/leaderboard</code>) は影響を受けない</td>
+</tr>
+</tbody></table>
+<h2>設計上の制約</h2>
+<p>今後やらないこと、やるなら別 ADR。</p>
+<ul>
+<li><strong>編集 / 削除 API は持たない</strong>: 一度送ったら確定。typo を訂正したい場合は <strong>続報を送る</strong></li>
+<li><strong>Web Push / Browser Notification API 不採用</strong>: Service Worker / VAPID key の運用負荷
+が高く、polling で十分カバーできるため (ADR-006 D7)</li>
+<li><strong>server-side 既読管理なし</strong>: 既読は competitor ブラウザの localStorage のみ。別 PC /
+別 browser でログインすると未読バッジが「リセット」される</li>
+<li><strong>operator 側 GET API はまだ無い</strong>: <code>EventDetail</code> 上で履歴を一覧する UI も unscope
+(= 必要なら別 PR で <code>GET /events/:eventId/notifications</code> を追加)</li>
+</ul>
+<h2>関連</h2>
+<ul>
+<li><a href="../architecture/adr-006-notifications.html">ADR-006</a> — 設計判断 D1〜D7</li>
+<li><a href="../architecture/adr-005-battle-portal-ui.html">ADR-005</a> — polling 60s 統一の親規約</li>
+<li><a href="../api/tenant.openapi.yaml"><code>docs/api/tenant.openapi.yaml</code></a> — operator 側 API spec</li>
+<li><a href="../api/participant.openapi.yaml"><code>docs/api/participant.openapi.yaml</code></a> — participant 側 API spec</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/notifications.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/notifications.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/notifications.md
+++ b/docs/operations/notifications.md
@@ -1,0 +1,91 @@
+# Notifications 運用ガイド
+
+ADR-006 に基づく運営 → 競技者通知機能の使い方と運用上の制約。実装の経緯と設計判断は
+[ADR-006](../architecture/adr-006-notifications.html) を参照。本 doc は現場で迷ったときに見る運用ガイド。
+
+## 通知の届き方
+
+| 項目 | 値 |
+|---|---|
+| 配信方式 | Pull (= participant portal が polling) |
+| Polling 間隔 | TeamViewProvider tick (現状 5 秒) |
+| 競技者の体感遅延 | **最大 5 秒** (画面開いている場合) |
+| 画面を閉じている競技者 | **届かない** (Web Push 不採用、ADR-006 D7) |
+| Severity 段階 | `info` / `warning` の 2 段 |
+| 一覧の保持期間 | 親 event の `expiresAt` まで (DDB TTL で自動削除) |
+| 編集 / 削除 | **不可** (= 一度送ったら取り消せない、idempotent な書き出し前提) |
+| 既読管理 | 競技者ブラウザ localStorage (= 同一ブラウザ内で完結) |
+
+ENDED / TEARDOWN / ARCHIVED 状態の event でも DDB TTL までは履歴が残るので、競技後の
+振り返りで参照できる。
+
+## いつ何を通知すべきか
+
+### `info` を使うケース
+
+- 競技ステータスのアナウンス:「14:30 から scoring 再開しました」「全 team 配備完了」
+- 進行情報:「現在 5 / 8 problem を deploy 済み、残り 3 問は順次解放」
+- 軽微な FAQ:「Battle 系問題で endpoint URL は SSO Credentials ページから取得可能」
+
+> **判断基準**: 競技者が **今すぐ行動を変えなくてもいい** 通知。確認して脳内 update できれば
+> 十分なもの。
+
+### `warning` を使うケース
+
+- メンテ予告:「30 分後に 5 分間 health check を停止」
+- 障害告知:「特定 region で AWS 側障害が発生中、一時的に scoring 反映遅延あり」
+- 競技ルール変更:「flag 形式を 1 問差し替え。提出前に最新要件を要確認」
+
+> **判断基準**: 競技者がそれを把握していないと **不利益を被る** か、**行動の手戻り** が
+> 出る通知。
+
+### 使い分けに迷ったら
+
+- 1 event あたり `warning` は **5 件以下** に抑える (頻発するとオオカミ少年化して `info`
+  と区別がつかなくなる)
+- 「これは `warning` か?」と迷ったら基本 `info`
+- 競技者の Battle Portal は防御中で集中している → 通知を送りすぎない (= 1 時間に 1 件
+  程度を上限の目安に)
+
+## 操作手順
+
+1. application admin console から対象 event の **Event Detail** ページを開く
+2. ヘッダー右上の **「通知を送る」** ボタン (DRAFT / TEARDOWN / ARCHIVED 状態では disabled。
+   READY / ENDED / DEPLOYING 状態のみ送信可能)
+3. Modal で **タイトル** (1〜120 文字) + **本文** (1〜2000 文字) + **severity** を入力
+4. **送信** で 201 Created。送信成功 Alert が画面上部に出る
+5. 競技者の Participant Portal `/notifications` で次の polling tick (最大 5 秒) で表示
+
+### 競技者目線の確認方法
+
+別 browser のセッションでテスト team の `teamLoginKey` でログインし、`/notifications`
+ページを開けば確認できる (本番チームの未読 badge を勝手に既読化しないこと)。
+
+## 失敗時の挙動
+
+| 状況 | 挙動 |
+|---|---|
+| 入力 validation 違反 (空文字 / 上限超) | Modal 内 Alert で表示、送信されない |
+| event 不在 / tenant 不一致 | 404 → Modal 内 Alert |
+| 競技者ブラウザの localStorage 不可 (private mode) | 既読管理が無効化、毎回全件未読扱い (graceful degradation) |
+| participant が旧 jobId-based deployment | 404 → portal 側で「通知配信対象外」 Alert |
+| backend Lambda init 失敗 (`EVENTS_TABLE_NAME` 未設定 等) | participant 側 polling が一時的にエラーになるが、他経路 (`/portal/me` / `/portal/leaderboard`) は影響を受けない |
+
+## 設計上の制約
+
+今後やらないこと、やるなら別 ADR。
+
+- **編集 / 削除 API は持たない**: 一度送ったら確定。typo を訂正したい場合は **続報を送る**
+- **Web Push / Browser Notification API 不採用**: Service Worker / VAPID key の運用負荷
+  が高く、polling で十分カバーできるため (ADR-006 D7)
+- **server-side 既読管理なし**: 既読は competitor ブラウザの localStorage のみ。別 PC /
+  別 browser でログインすると未読バッジが「リセット」される
+- **operator 側 GET API はまだ無い**: `EventDetail` 上で履歴を一覧する UI も unscope
+  (= 必要なら別 PR で `GET /events/:eventId/notifications` を追加)
+
+## 関連
+
+- [ADR-006](../architecture/adr-006-notifications.html) — 設計判断 D1〜D7
+- [ADR-005](../architecture/adr-005-battle-portal-ui.html) — polling 60s 統一の親規約
+- [`docs/api/tenant.openapi.yaml`](../api/tenant.openapi.yaml) — operator 側 API spec
+- [`docs/api/participant.openapi.yaml`](../api/participant.openapi.yaml) — participant 側 API spec

--- a/docs/requirements/problem-deploy.html
+++ b/docs/requirements/problem-deploy.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Problem Deploy 機能 要件定義</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Problem Deploy 機能 要件定義</h1>
+<ul>
+<li><strong>Status</strong>: Approved (2026-05-05)</li>
+<li><strong>Scope</strong>: TenkaCloud の operator が SaaS UI から「問題スタック」を競技者の AWS アカウントへ deploy する機能。本ドキュメントは要件 (= 何を満たせば成功か) を定義する。実装方針 (= どう作るか) は別途 ADR で決める。</li>
+<li><strong>Related</strong>: ADR-001 (本要件に基づく実装案)</li>
+</ul>
+<h2>ゴール</h2>
+<p>operator (TenkaCloud 顧客企業の運営担当) が、自社競技イベント (Battle / Challenge) を <strong>TenkaCloud SaaS の画面操作だけで</strong> 開催 → 運営 → 撤収まで通せる。AWS Console は触らない、コマンドラインは叩かない。</p>
+<p>operator が達成したい仕事は次のとおり。</p>
+<ol>
+<li><strong>Pre-event</strong>: イベント当日に向けて、参加者全員分の問題環境を「ボタン 1 つで」競技者アカウント側に展開する</li>
+<li><strong>During-event</strong>: 各参加者の deploy 状況を画面で把握する。失敗していたら再実行ボタンで取り戻す (operator はデバッグできないので、それ以上の操作は要求しない)</li>
+<li><strong>Post-event</strong>: 全環境を「ボタン 1 つで」撤収する</li>
+</ol>
+<h2>アクター</h2>
+<table>
+<thead>
+<tr>
+<th>アクター</th>
+<th>TenkaCloud から見た位置</th>
+<th>操作する場所</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>operator</strong> (運営担当者)</td>
+<td>TenkaCloud のテナント (顧客企業) の admin</td>
+<td>TenkaCloud SaaS (<code>application-admin-console</code>) のみ。AWS Console / CLI は触らない、触れない前提</td>
+</tr>
+<tr>
+<td><strong>participant</strong> (競技者)</td>
+<td>1 チームに 1 名以上</td>
+<td>TenkaCloud SaaS (<code>participant-portal</code>) のみ</td>
+</tr>
+<tr>
+<td><strong>問題作者</strong></td>
+<td>operator と同一人物のことが多い</td>
+<td>TenkaCloud SaaS の問題管理画面 (要 設計)</td>
+</tr>
+</tbody></table>
+<h2>システム境界</h2>
+<table>
+<thead>
+<tr>
+<th>AWS account</th>
+<th>誰の管理下</th>
+<th>何が動く</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>TenkaCloud 自社 AWS account</strong></td>
+<td>TenkaCloud (= SaaS 提供側)</td>
+<td>Control Plane / Application Plane 全部、Step Functions / Lambda / DDB / S3 / Cognito</td>
+</tr>
+<tr>
+<td><strong>競技者 AWS account</strong></td>
+<td>competitor (= 競技参加者 or 主催者が用意した使い捨てアカウント)</td>
+<td>問題スタックの CFn 配下のリソースのみ。<code>competitor-bootstrap.yaml</code> で IAM Role + ExternalId が事前設定済</td>
+</tr>
+</tbody></table>
+<p>operator の AWS account は <strong>登場しない</strong>。operator は TenkaCloud SaaS の顧客であり、TenkaCloud の sub-account を持たない。</p>
+<p>competitor account は <strong>TenkaCloud の AWS Organizations 配下にあるとは限らない</strong> (野良 AWS account を許す前提)。これは Service Catalog の Org 単位 portfolio 共有が<strong>使えない</strong>という設計制約に直結する。</p>
+<h2>Functional Requirements</h2>
+<h3>FR-1. 規模 (Scale)</h3>
+<table>
+<thead>
+<tr>
+<th>競技形式</th>
+<th>1 イベントの典型値</th>
+<th>1 batch の最大 deploy 数</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Battle</strong></td>
+<td>25 チーム × 1 問</td>
+<td>25 stacks</td>
+</tr>
+<tr>
+<td><strong>Challenge</strong></td>
+<td>25 チーム × 30 問</td>
+<td><strong>750 stacks</strong></td>
+</tr>
+</tbody></table>
+<p>設計はこの規模を <strong>1 batch で起動できる</strong> ことを前提とする。Challenge 規模 (750 stacks) を operator が手作業で 1 つずつ起動することは要件として認めない (= bulk operation が必須)。</p>
+<h3>FR-2. CRUD 4 操作すべて要る</h3>
+<table>
+<thead>
+<tr>
+<th>操作</th>
+<th>必要</th>
+<th>主な利用シーン</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>Create</strong></td>
+<td>✅ 必須</td>
+<td>新規 deploy。FR-1 規模 (= 25 × 30 = 750 stacks/batch)</td>
+</tr>
+<tr>
+<td><strong>Read</strong></td>
+<td>✅ 必須</td>
+<td>operator が UI で deploy の状況を見られる</td>
+</tr>
+<tr>
+<td><strong>Update</strong></td>
+<td>✅ 必須</td>
+<td><strong>問題作成 iteration</strong>: test deploy → CFn テンプレを直す → Update で同 stack を新版に切り替える → 動作確認 …のループを問題作者が回す</td>
+</tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td>✅ 必須</td>
+<td>イベント終了時の bulk teardown、または iteration 中の不要 stack 撤去</td>
+</tr>
+</tbody></table>
+<p>Update のスコープは <strong>問題作成 (authoring) の iteration</strong> が主用途。1 件単位の Update を機敏に回せることが重要 (= bulk 1 batch 内の更新ではなく、1 問題 × 1 test account の小回り Update)。</p>
+<p>イベント本番中に既 deploy へ hot-fix を流す運用は想定しないが、Update 機能自体は authoring iteration のために必要なので CRUD は 4 操作すべて持つ。</p>
+<h3>FR-3. 失敗時の operator UX</h3>
+<p>operator はデバッグできない前提。</p>
+<ul>
+<li>失敗 item は UI に「N 件失敗」とだけ表示</li>
+<li>operator は <strong>「失敗した分だけ再実行」ボタン 1 つで部分 retry</strong> できる</li>
+<li>再実行は前回の input で再起動するだけ (内部的な詳細を operator に問わない)</li>
+<li>連続失敗時の代替手段 (チケット起票、サポート問い合わせ) は SaaS の operational support に委ねる (本機能の責務外)</li>
+</ul>
+<h3>FR-4. cleanup の保証範囲</h3>
+<p>operator が「Delete」を押せば、CFn <code>DeleteStack</code> が成功するところまでを TenkaCloud が保証する。</p>
+<p>それ以外は次のとおり扱う。</p>
+<ul>
+<li>CFn 配下に閉じ込められていない実リソース (CFn 外で API 直叩きで作ったもの等) の漏れは <strong>問題作者の責任</strong></li>
+<li>問題テンプレ規約として「<code>DeletionPolicy: Delete</code> を全 resource に明示」「CFn の外でリソースを作らない」ことをガイドラインに明記</li>
+<li>TenkaCloud は実リソース漏れ検知・強制削除の機能を持たない</li>
+</ul>
+<h3>FR-5. 問題カタログ + authoring iteration</h3>
+<p>operator (= 問題作者) は <strong>TenkaCloud SaaS UI から問題を作成・更新・削除できる</strong>。</p>
+<ul>
+<li>問題には CFn テンプレートが紐付く (バージョン管理あり)</li>
+<li>可視範囲を選べる: <code>public</code> / <code>org-shared</code> / <code>private</code></li>
+<li>public は全 tenant が deploy 対象として選べる</li>
+<li>org-shared / private のセマンティクスは ADR で詳細化 (<code>組織</code> というエンティティの定義含む)</li>
+</ul>
+<p>問題のメタデータ (タイトル、説明、可視範囲、template URL 等) は SaaS の DDB で管理。CFn テンプレ実体は S3 上に置く (バージョンごとに別 key、または S3 versioning)。</p>
+<p><strong>Authoring iteration</strong>: 問題作者は次のループを TenkaCloud SaaS UI 上で回せる。</p>
+<ol>
+<li>新規問題を作る (テンプレートを upload)</li>
+<li>自分の test 用 competitor account に <strong>1 件だけ deploy</strong> (= 単発 Create)</li>
+<li>動作確認 (participant-portal や AWS Console から確認)</li>
+<li>不具合があればテンプレートを upload し直し (新バージョン)</li>
+<li>同じ test stack に <strong>Update</strong> を流す (= 単発 Update)</li>
+<li>CFn Update が drift / <code>UPDATE_ROLLBACK_FAILED</code> 等で詰まったときは <strong>Delete</strong> で test stack を捨てて、ステップ 2 に戻って再作成する</li>
+<li>OK になったら可視範囲を <code>public</code> 等に切り替えて公開</li>
+</ol>
+<p>このループを「単発 (1 問題 × 1 account) の小回り CRUD」として扱う。FR-1 の bulk 規模 (750 stacks) とは別経路だが、API・state machine は共通でよい (Map iterator が 1 件回るだけ)。</p>
+<h3>FR-6. operator UI workflow</h3>
+<p>最低限の操作フローは次のとおり。</p>
+<ol>
+<li>問題カタログ画面で問題を複数選択</li>
+<li>競技者アカウント情報 (account ID + ExternalId + region) を複数選択 (登録済 account から)</li>
+<li>「Deploy」ボタン → batch 実行開始</li>
+<li>batch 進捗画面で N/M 件成功・失敗を見られる</li>
+<li>失敗があれば「失敗分を再実行」ボタンが出る</li>
+<li>イベント終了時、batch 一覧画面から「Delete」ボタンで teardown</li>
+</ol>
+<p>competitor account の登録 (account ID + ExternalId + competitor が立てた IAM Role 名) は別 UI が要る。これは別 Issue (#459) で扱う。</p>
+<h2>Non-functional Requirements</h2>
+<h3>NFR-1. operator の AWS 習熟度を期待しない</h3>
+<p>operator は IAM, CFn, Step Functions, EventBridge を 1 つも触ったことがない人を想定する。SaaS UI の用語も「AssumeRole」「ExternalId」のような AWS 専門語を画面に出さず、「競技者アカウントの接続情報」のような業務用語に翻訳する。</p>
+<p>competitor account 側の <code>competitor-bootstrap.yaml</code> を participant に流してもらう手順だけは AWS 知識を要するため、これは participant (or その所属組織の AWS 担当) 向けの手順書として別途用意する。</p>
+<h3>NFR-2. operator は TenkaCloud の AWS account を一切触らない</h3>
+<p>これは SaaS の本質。operator が TenkaCloud のリソース (Step Functions の Console 等) を直接見る運用は一切想定しない。失敗時の状態は SaaS UI に翻訳して提示する。</p>
+<h3>NFR-3. 競技者アカウントの組織関係を仮定しない</h3>
+<p>競技者 AWS account は TenkaCloud の AWS Organizations 配下にあるとは限らない (野良 account ありえる)。</p>
+<p>これは AWS Service Catalog の <strong>AWS Organizations 単位の portfolio 共有が使えない</strong> ことを意味する。cross-account access は全て <strong>IAM AssumeRole + ExternalId</strong> (<code>competitor-bootstrap.yaml</code> で立てた Role) で行う。</p>
+<h3>NFR-4. 問題テンプレ規約</h3>
+<p>問題作成者向けの規約として次の事項を明文化する。</p>
+<ul>
+<li>すべての AWS リソースを CFn 配下に作る (API 直叩きでリソースを作らない)</li>
+<li><code>DeletionPolicy</code> は明示的に <code>Delete</code> (デフォルトの場合は省略可、<code>Retain</code> を使うときは合理的な理由を README に書く)</li>
+<li><code>competitor-bootstrap.yaml</code> の IAM Role が持つ権限の範囲内で作れるリソースだけを使う</li>
+</ul>
+<p>詳細は別ドキュメント (<code>problems/CONVENTIONS.md</code> 想定) で展開。</p>
+<h2>暗黙の前提として禁止する事項</h2>
+<p>要件外として、次の事項は本機能の scope に<strong>含めない</strong>。</p>
+<ul>
+<li>❌ operator が AWS Console / CLI を直接触ること</li>
+<li>❌ operator が TenkaCloud の AWS account にアクセスすること</li>
+<li>❌ AWS Service Catalog の UI を operator に直接見せる構成</li>
+<li>❌ AWS Organizations 単位での competitor account 共有を前提にする構成</li>
+<li>❌ 問題テンプレ実体を SaaS DDB に直書き (= S3 に置く前提)</li>
+<li>❌ イベント本番中に operator が既 deploy へ hot-fix を流す運用 (Update 機能自体は authoring iteration 用に持つが、live-event hot-fix の UX は提供しない)</li>
+</ul>
+<h2>Service Catalog 採否の判断基準</h2>
+<p>ADR で実装案を比較するときの基準を要件側から固定する。</p>
+<p>Service Catalog を採用するためには下記すべてを満たす必要がある。</p>
+<table>
+<thead>
+<tr>
+<th>条件</th>
+<th>Service Catalog で満たせるか</th>
+<th>結論</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>operator が SaaS UI から問題を upload して即 deploy 可能にできる</td>
+<td>△ Service Catalog はもともと admin が portfolio を組む前提。SaaS Lambda が Service Catalog API を叩いて product version を登録する仕組みは作れる</td>
+<td>仕組み次第</td>
+</tr>
+<tr>
+<td>野良 (TenkaCloud Org 外) AWS account へ deploy できる</td>
+<td>❌ Service Catalog の portfolio 共有は AWS Organizations 単位</td>
+<td><strong>不可</strong></td>
+</tr>
+<tr>
+<td>operator に AWS Console を見せない</td>
+<td>❌ Service Catalog の主 UI は AWS Console</td>
+<td><strong>不可</strong> (provisioning engine 専用利用ならいけるが、その場合 UI は SaaS 側で作るので Service Catalog のメリットが薄れる)</td>
+</tr>
+</tbody></table>
+<p><strong>判断</strong>: NFR-3 (野良 account 許容) の時点で Service Catalog の cross-account 機構が使えない。ADR では Step Functions による自前実装を採用する。Service Catalog は採用しない。</p>
+<h2>受け入れ基準 (Acceptance Criteria)</h2>
+<p>要件が満たされた状態を operationally に判定するチェックリストを次に示す。</p>
+<ul>
+<li><input disabled="" type="checkbox"> <code>make deploy</code> を 1 回流して、operator が次のフローを SaaS UI だけで完走できる<ul>
+<li>詳細手順:</li>
+</ul>
+<ol>
+<li>operator がログイン</li>
+<li>25 チーム × 30 問の Challenge セットを選択して Deploy</li>
+<li>進捗画面で全 750 件の状況が見える</li>
+<li>失敗があれば「失敗分を再実行」で部分 retry できる</li>
+<li>イベント終了で「Delete」を押せば全 750 stack が CFn DeleteStack 成功する</li>
+</ol>
+</li>
+<li><input disabled="" type="checkbox"> operator は AWS Console / CLI を一度も触らずに完走できる</li>
+<li><input disabled="" type="checkbox"> operator は IAM / CFn / Step Functions / Lambda の語を SaaS 画面上で目にしない</li>
+<li><input disabled="" type="checkbox"> competitor account を野良 AWS account にしてもフローが通る</li>
+<li><input disabled="" type="checkbox"> 750 件 batch が現実的時間内に完了する (上限は ADR で詳細化、SLO 候補: 1 hour 以内)</li>
+<li><input disabled="" type="checkbox"> 1 batch 内の 1 件失敗が他 749 件の成功を妨げない</li>
+<li><input disabled="" type="checkbox"> CFn DeleteStack が成功するところまでを cleanup 完了とみなす (実リソース漏れは問題作者責任)</li>
+<li><input disabled="" type="checkbox"> 問題作者が TenkaCloud SaaS UI 上で次のループを回せる: 新規作成 → 1 件 deploy → テンプレ修正 → Update → 動作確認 → 公開</li>
+</ul>
+<h2>Open questions (要件レベルで未確定、ADR 着手前に確定が必要)</h2>
+<ol>
+<li><strong><code>org-shared</code> の &quot;組織&quot; の定義</strong> — tenant のグループか、tenant 内の team か、ACL 列か (ADR-003 候補)</li>
+<li><strong>競技者アカウント登録 UI と ExternalId 管理</strong> — Issue (#459) で別途</li>
+<li><strong>問題作成者と operator の権限関係</strong> — 同一テナント内で role 分離するか、operator なら誰でも問題を作れるか</li>
+<li><strong>batch SLO の具体値</strong> — Acceptance Criteria 記載の「1 hour 以内」は仮置き</li>
+</ol>
+<h2>References</h2>
+<ul>
+<li>Issue (#458) — Deploy 操作の publish 経路 (本要件文書で再整理、現実装案は ADR-001 で書き直し)</li>
+<li>Issue (#459) — Cross-account federation (ExternalId 管理) — 本要件の前提</li>
+<li><code>infrastructure/templates/competitor-bootstrap.yaml</code> — 競技者側 IAM Role 定義</li>
+<li>ADR-001 (Draft) — 本要件確定後に Decision を書き直す対象</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/requirements/problem-deploy.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/requirements/problem-deploy.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
     "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
-    "markdownlint-cli2": "^0.21.0",
     "husky": "^9.1.4",
+    "markdownlint-cli2": "^0.21.0",
+    "marked": "^18.0.3",
     "textlint": "^15.5.2",
     "textlint-filter-rule-comments": "^1.3.0",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * docs/**\/*.md を共通 HTML テンプレに流し込んで `.html` を生成する static site builder。
+ *
+ * - source: `docs/<...>.md`
+ * - output: `docs/<...>.html` (同じディレクトリに併置)
+ *
+ * ADR 系 (`docs/architecture/adr-*.html`) は **md ソースを持たない手書き HTML** で、
+ * この build script は触らない (= 上書きしない、削除しない)。表現力 (mockup / SVG /
+ * collapsible) を失わないため (memory feedback_design_docs_html)。
+ *
+ * 使い方:
+ *   bun run scripts/build-docs.ts          (= make build-docs)
+ *   bun run scripts/build-docs.ts --check  (out-of-sync 検出、pre-commit / CI 用)
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { marked } from "marked";
+
+const DOCS_ROOT = resolve(import.meta.dir, "..", "docs");
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+/** 共通 HTML テンプレ。1 ファイル 1 ページ、自己完結 (= 外部 CSS / JS なし)。 */
+function template({
+  title,
+  bodyHtml,
+  sourcePath,
+}: {
+  title: string;
+  bodyHtml: string;
+  sourcePath: string;
+}): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+${bodyHtml}
+<div class="doc-source">Source: <code>${escapeHtml(sourcePath)}</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>${escapeHtml(sourcePath)}</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>
+`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** 再帰的に dir を walk して .md ファイルを集める。 */
+function walkMd(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walkMd(full));
+    } else if (name.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractTitle(md: string, fallback: string): string {
+  const m = md.match(/^#\s+(.+?)\s*$/m);
+  return m?.[1] ?? fallback;
+}
+
+async function buildOne(mdPath: string): Promise<{ htmlPath: string; html: string }> {
+  const md = readFileSync(mdPath, "utf8");
+  const htmlPath = mdPath.replace(/\.md$/, ".html");
+  const sourceRel = relative(REPO_ROOT, mdPath);
+  const title = extractTitle(md, sourceRel);
+  const bodyHtml = await marked.parse(md, { async: true });
+  return {
+    htmlPath,
+    html: template({ title, bodyHtml, sourcePath: sourceRel }),
+  };
+}
+
+async function main(): Promise<void> {
+  const checkMode = process.argv.includes("--check");
+  const mds = walkMd(DOCS_ROOT);
+  let outOfSync = 0;
+  for (const mdPath of mds) {
+    const { htmlPath, html } = await buildOne(mdPath);
+    const sourceRel = relative(REPO_ROOT, mdPath);
+    if (checkMode) {
+      let existing = "";
+      try {
+        existing = readFileSync(htmlPath, "utf8");
+      } catch {
+        // 存在しないので out-of-sync
+      }
+      if (existing !== html) {
+        outOfSync++;
+        console.error(`[build-docs] out of sync: ${sourceRel}`);
+      }
+    } else {
+      writeFileSync(htmlPath, html, "utf8");
+      console.log(`[build-docs] wrote ${relative(REPO_ROOT, htmlPath)}`);
+    }
+  }
+  if (checkMode && outOfSync > 0) {
+    console.error(`\n${outOfSync} doc(s) are out of sync. Run \`make build-docs\` to regenerate.`);
+    process.exit(1);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

ops / api / requirements / harness 系の doc が markdown のままで github 上のレンダリングしか想定されていなかったのを、ADR と同じく HTML 配信される形に揃える。

### Hybrid 方針

- **ADR (`docs/architecture/adr-*.html`)** — 引き続き手書き HTML。SSG だと表現力 (mockup / SVG / collapsible) が削られるため、build script は触らない
- **それ以外の docs (`*.md`)** — md をソースに保ち、`scripts/build-docs.ts` で `.html` を併置生成
  - md = 編集ソース (PR レビュー / github render / AI agent Read 用)
  - html = 配信用レンダリング (ブラウザ直接 view)

### 主な変更

- `scripts/build-docs.ts` 新規 (marked v18、共通テンプレ込み、`--check` で out-of-sync 検出)
- `make build-docs` / `make check-docs` 新規 + `before-commit` で auto-check
- 既存 4 md (`api/README.md` / `architecture/harness.md` / `requirements/problem-deploy.md`) を無編集のまま `.html` 併置生成
- `docs/operations/notifications.md` 新規 + `.html` 生成 (= ADR-006 Phase 4.3 運用ガイド、PR-526 で書こうとしたが SSG に載せ替え)

## 物理影響

doc / scripts / Makefile のみ。CFn / IaC / Lambda / DDB は NO-OP。`marked@18.0.3` が root devDependencies に追加 (build script 専用、production ランタイム不影響)。

## Regression 分析

- 既存 .md は無編集で残る (= github render や AI Read 経路は不変)
- CLAUDE.md / AGENTS.md の「`docs/architecture/harness.md`」リンクも .md のまま機能する (source pointer)
- pre-commit hook が `check-docs` を呼ぶ: md 編集して build-docs を忘れるとコミット失敗 (out-of-sync 検出)
- ADR の手書き html は build-docs の対象外 (.md ソースを持たないので上書きされない)

## Test plan

- [x] `make build-docs` で 4 ファイル生成
- [x] `make check-docs` 緑 (out-of-sync なし)
- [x] `make before-commit` 緑 (lint + test + validate-problems + check-docs)
- [x] 生成された `docs/operations/notifications.html` をブラウザで開いて目視確認
- [ ] CLAUDE.md の harness 参照を辿って `docs/architecture/harness.md` (md ソース) が変わらず読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)