### PR TITLE
fix(portal): #535 Portal 502 regression — EVENTS_TABLE_NAME 未配線で Lambda init throw を回避

### DIFF
--- a/infrastructure/lib/helper-functions.ts
+++ b/infrastructure/lib/helper-functions.ts
@@ -5,3 +5,17 @@ export const getEnv = (varName: string): string => {
   }
   return val;
 };
+
+/**
+ * 任意 env を取り出す ( **未設定は throw しない** )。CDK 配線が遅れて入る予定の env で、
+ * 「未設定 = この機能だけ disabled」として feature gate 的に使う handler 向け。
+ *
+ * `getEnv` を Lambda module scope で使うと、env が無い場合に **Lambda init 全体が
+ * throw して全 route が 502** になるリスクがある (= PR-524 で portal が落ちた件)。
+ * 配線完了が unblock-pr の条件になっている env は本 helper を使い、handler 内で
+ * undefined を check して 500 / misconfigured outcome を返す。
+ */
+export const getOptionalEnv = (varName: string): string | undefined => {
+  const val = process.env[varName];
+  return val && val.length > 0 ? val : undefined;
+};

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/notifications.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/notifications.ts
@@ -15,7 +15,12 @@ export type ListNotificationsOutcome =
   | { kind: "ok"; response: NotificationsResponse }
   | { kind: "unauthorized" }
   | { kind: "no_event" }
-  | { kind: "invalid_limit" };
+  | { kind: "invalid_limit" }
+  /**
+   * `EVENTS_TABLE_NAME` env が CDK 側で配線されておらず Notifications backend が
+   * disabled な状態。500 で返して frontend に「設定漏れ」を伝える。他 route は通常動作。
+   */
+  | { kind: "misconfigured" };
 
 /** limit 既定値 / 上限 (ADR-006 API 設計)。*/
 export const NOTIFICATIONS_DEFAULT_LIMIT = 100;
@@ -39,6 +44,10 @@ export async function listNotifications(
   teamLoginKey: string,
   limitRaw: number = NOTIFICATIONS_DEFAULT_LIMIT,
 ): Promise<ListNotificationsOutcome> {
+  // CDK 配線前 (= EVENTS_TABLE_NAME 未設定) に portal 全体を 502 で落とさないよう、
+  // 本 handler だけ misconfigured で 500 を返す (#535 regression 対策)。
+  if (!shared.eventsTableName) return { kind: "misconfigured" };
+
   if (!Number.isInteger(limitRaw) || limitRaw < 1 || limitRaw > NOTIFICATIONS_MAX_LIMIT) {
     return { kind: "invalid_limit" };
   }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import { getEnv } from "../../../helper-functions.js";
+import { getEnv, getOptionalEnv } from "../../../helper-functions.js";
 import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 
@@ -16,17 +16,29 @@ export interface ParticipantSharedResources {
    * Events table 名 (ADR-006 Notifications で参照)。`GET /portal/me/notifications` が
    * `PK=EVENT#<eventId>` の partition で `begins_with(SK, "NOTIFICATION#")` を
    * Query する。CDK 側で IAM `dynamodb:Query` を Events table にも付与する。
+   *
+   * **undefined を許容する** (= optional): CDK 配線が遅れて入る予定なので、未配線でも
+   * Lambda init で throw させない (= 過去 PR-524 で portal 全 route が 502 になった
+   * regression #535 の対策)。`/portal/me/notifications` handler 側で undefined を
+   * check し、`misconfigured` outcome (= 500) を返す。
    */
-  readonly eventsTableName: string;
+  readonly eventsTableName: string | undefined;
   readonly ddb: DynamoDBDocumentClient;
   /** `{ [problemId]: ProblemScoringMetadata }`。submit-flag が採点に使う。 */
   readonly problemsScoring: Record<string, ProblemScoringMetadata>;
 }
 
 export function buildParticipantSharedResources(): ParticipantSharedResources {
+  const eventsTableName = getOptionalEnv("EVENTS_TABLE_NAME");
+  if (!eventsTableName) {
+    // CloudWatch Logs に init 時 1 回だけ警告。CDK 配線忘れの早期検知。
+    console.warn(
+      "[participant-portal] EVENTS_TABLE_NAME env が未設定。/portal/me/notifications は 500 を返します (= ADR-006 backend は disabled)。CDK 側で env と IAM を配線するまで他の route は通常動作します。",
+    );
+  }
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
-    eventsTableName: getEnv("EVENTS_TABLE_NAME"),
+    eventsTableName,
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
   };

--- a/infrastructure/test/helper-functions.test.ts
+++ b/infrastructure/test/helper-functions.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getEnv, getOptionalEnv } from "../lib/helper-functions";
+
+const TEST_ENV = "TENKACLOUD_HELPER_TEST_ENV";
+
+beforeEach(() => {
+  delete process.env[TEST_ENV];
+});
+afterEach(() => {
+  delete process.env[TEST_ENV];
+});
+
+describe("getEnv", () => {
+  it("env が set されていれば値を返すべき", () => {
+    process.env[TEST_ENV] = "value-1";
+    expect(getEnv(TEST_ENV)).toBe("value-1");
+  });
+
+  it("env が未設定なら throw するべき (= Lambda init で fail-fast、設定漏れを silent 通過させない)", () => {
+    expect(() => getEnv(TEST_ENV)).toThrow(`${TEST_ENV} is empty`);
+  });
+
+  it("env が空文字なら throw するべき (= 設定漏れ扱い)", () => {
+    process.env[TEST_ENV] = "";
+    expect(() => getEnv(TEST_ENV)).toThrow(`${TEST_ENV} is empty`);
+  });
+});
+
+describe("getOptionalEnv", () => {
+  it("env が set されていれば値を返すべき", () => {
+    process.env[TEST_ENV] = "value-1";
+    expect(getOptionalEnv(TEST_ENV)).toBe("value-1");
+  });
+
+  it("env が未設定なら undefined を返すべき (throw しない、Lambda init を生かす)", () => {
+    expect(getOptionalEnv(TEST_ENV)).toBeUndefined();
+  });
+
+  it("env が空文字なら undefined を返すべき (= 未設定と同義)", () => {
+    process.env[TEST_ENV] = "";
+    expect(getOptionalEnv(TEST_ENV)).toBeUndefined();
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-notifications.test.ts
+++ b/infrastructure/test/problem-deploy/participant-notifications.test.ts
@@ -37,6 +37,13 @@ const teamRow = (over: Record<string, unknown> = {}) => ({
 describe("listNotifications (ADR-006)", () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it("EVENTS_TABLE_NAME 未配線 (= eventsTableName undefined) は misconfigured を返し、DDB を叩かない (#535 regression 対策)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const sharedNoEnv: ParticipantSharedResources = { ...shared, eventsTableName: undefined };
+    expect((await listNotifications(sharedNoEnv, TEAM_KEY, 50)).kind).toBe("misconfigured");
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
   it("limit が 0 / 負 / 上限超 / 非整数 は invalid_limit", async () => {
     const { shared } = buildShared();
     expect((await listNotifications(shared, TEAM_KEY, 0)).kind).toBe("invalid_limit");

--- a/infrastructure/test/problem-deploy/participant-shared.test.ts
+++ b/infrastructure/test/problem-deploy/participant-shared.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  process.env.DEPLOYMENTS_TABLE_NAME = "TestDeployments";
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.restoreAllMocks();
+});
+
+describe("buildParticipantSharedResources (Lambda init resilience #535)", () => {
+  it("EVENTS_TABLE_NAME 未設定でも throw せず eventsTableName=undefined で build できる (Lambda init を死なせない)", () => {
+    delete process.env.EVENTS_TABLE_NAME;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const shared = buildParticipantSharedResources();
+    expect(shared.eventsTableName).toBeUndefined();
+    expect(shared.tableName).toBe("TestDeployments");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("EVENTS_TABLE_NAME env が未設定"));
+  });
+
+  it("EVENTS_TABLE_NAME が設定されていれば値が反映され、warning は出ない", () => {
+    process.env.EVENTS_TABLE_NAME = "TestEvents";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const shared = buildParticipantSharedResources();
+    expect(shared.eventsTableName).toBe("TestEvents");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("DEPLOYMENTS_TABLE_NAME は必須 (= 未設定なら throw、portal 自体が動かないので fail-fast)", () => {
+    delete process.env.DEPLOYMENTS_TABLE_NAME;
+    expect(() => buildParticipantSharedResources()).toThrow("DEPLOYMENTS_TABLE_NAME is empty");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #535. PR-524 (notifications backend) で <code>getEnv("EVENTS_TABLE_NAME")</code> を <code>buildParticipantSharedResources</code> の **module load 時** に呼んでおり、CDK 側の env 配線が来る前に merge した結果 Lambda init で throw → portal **全 route が 502** になる regression が発生。

## アプローチ (= 雑な \`?? ""\` ではなく丁寧に)

| 層 | 変更 | 狙い |
|---|---|---|
| \`helper-functions.ts\` | \`getOptionalEnv\` 新設 (\`getEnv\` の sibling) | \`getEnv\` の必須セマンティクスを残しつつ「Lambda init を死なせない optional env」を type-safe に分離 |
| \`participant-handler/shared.ts\` | \`eventsTableName: string \| undefined\` + 起動時 \`console.warn\` | CDK 配線忘れを CloudWatch Logs で早期検知 |
| \`participant-handler/notifications.ts\` | \`misconfigured\` outcome 追加、entry で early return | DDB を叩かず即 500 を返し、operator にも frontend にも「設定漏れ」と明示 |

雑な \`?? ""\` だと handler 内で空文字 TableName が DDB Query に渡って ValidationException 経由 500 になり、エラー内容が「table name required」になるだけで原因究明が遅れる。 misconfigured outcome なら frontend Alert で「未配線」と表示できる。

## tests (+10)

- \`helper-functions.test.ts\` (新規): \`getEnv\` / \`getOptionalEnv\` の throw / undefined 挙動
- \`participant-shared.test.ts\` (新規): EVENTS_TABLE_NAME 未設定で build が throw せず undefined + warning / 必須 DEPLOYMENTS_TABLE_NAME は throw
- \`participant-notifications.test.ts\`: \`eventsTableName=undefined\` で misconfigured + DDB を叩かない assert

合計 528 → **538 tests** 全部緑。

## 物理影響

backend code only (NO-OP for IaC / DDB / Lambda CFn 出力)。本 fix の re-deploy で portal が即時復旧。CDK 配線が来たら notifications も自動で動き出す。

## Regression 分析

- 既存 portal route 5 系統 (\`/portal/me\` / \`/portal/leaderboard\` / \`/portal/me/score-events\` / \`/portal/me/console-signin-url\` / \`/portal/me/battle-attacks\`) は eventsTableName を読まないので影響なし
- \`getEnv\` の挙動は完全に据え置き (= 既存呼び出しは throw 維持)
- 既存 7 fixture (\`eventsTableName: "TestEvents"\`) はそのまま動く
- \`console.warn\` は CloudWatch Logs にしか出ないので user-facing には漏れない

## Test plan

- [x] \`make typecheck\` 緑
- [x] \`make test\` 緑 (538 tests)
- [x] \`make before-commit\` 緑 (lint + test + validate-problems + check-docs)
- [ ] **実 deploy 後に portal sign-in が 200 で通り、 \`/portal/me\` が view を返す**
- [ ] CloudWatch Logs に \`[participant-portal] EVENTS_TABLE_NAME env が未設定\` の WARN が 1 回出ている (= 配線忘れの早期検知が機能)
- [ ] CDK 側で EVENTS_TABLE_NAME 配線後、\`/portal/me/notifications\` が 200 で通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Notifications endpoint now returns a "misconfigured" response when required configuration is missing, preventing unhandled runtime errors.
  * System emits diagnostic warnings to CloudWatch when notifications feature is improperly configured.

* **Tests**
  * Added comprehensive test coverage for environment variable handling and configuration validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/543)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->