### PR TITLE
fix(infra): #535 Portal 502 — ParticipantPortalLambda に Events table 配線 (env + IAM)

### DIFF
--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -21,6 +21,11 @@ import { Construct } from "constructs";
 export interface ParticipantPortalLambdaProps {
   readonly deploymentsTable: ITable;
   /**
+   * Events table (ADR-006 Notifications で参照)。
+   * `GET /portal/me/notifications` が `PK=EVENT#<eventId>` で `dynamodb:Query`。
+   */
+  readonly eventsTable: ITable;
+  /**
    * `{ [problemId]: { kind, flagOutputKey, points, ... } }` 形の scoring 設定。
    * `discoverProblemsScoring` で metadata.json から自動収集して synth 時に注入する。
    * 競技者が submit-flag したとき、この map を参照して採点する。
@@ -69,6 +74,16 @@ export class ParticipantPortalLambda extends Construct {
             }),
           ],
         }),
+        // ADR-006 Notifications: Events table の partition Query 権限のみ。
+        // 書き込みは event-handler / health-check 側に閉じる (= participant は read-only)。
+        EventsRead: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ["dynamodb:Query"],
+              resources: [props.eventsTable.tableArn],
+            }),
+          ],
+        }),
       },
       managedPolicies: [
         ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
@@ -85,6 +100,7 @@ export class ParticipantPortalLambda extends Construct {
       role,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        EVENTS_TABLE_NAME: props.eventsTable.tableName,
         BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
         CONSOLE_VIEWER_ROLE_ARN: props.consoleViewerRoleArn,
         NODE_OPTIONS: "--enable-source-maps",

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -160,6 +160,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       const consoleViewerRole = new ConsoleViewerRole(this, "ConsoleViewerRole");
       const portalLambda = new ParticipantPortalLambda(this, "ParticipantPortalLambda", {
         deploymentsTable: deployments.table,
+        eventsTable: events.table,
         problemsScoring: props.problemsScoring,
         consoleViewerRoleArn: consoleViewerRole.role.roleArn,
       });

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -144,3 +144,67 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
     });
   });
 });
+
+/**
+ * ParticipantPortalLambda を含む synth (= participantPortal prop あり)。
+ * EVENTS_TABLE_NAME 配線 + Events table への Query IAM 付与を assert する。
+ */
+function synthWithParticipantPortal(): Template {
+  const app = new cdk.App();
+  const stack = new ProblemDeployBackendStack(app, "TestStack", {
+    eventBusArn: "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus",
+    sourceBucketName: "test-source-bucket",
+    sourceObjectKey: "source.zip",
+    problemsCatalog: {
+      "hello-world": "problems/challenges/hello-world",
+    },
+    problemsScoring: {},
+    participantPortal: { runtimeConfig: "default-dev-mock" },
+  });
+  return Template.fromStack(stack);
+}
+
+describe("ProblemDeployBackendStack — ParticipantPortalLambda wiring (#535)", () => {
+  const tpl = synthWithParticipantPortal();
+
+  it("ParticipantPortal Lambda の environment に EVENTS_TABLE_NAME が設定されるべき", () => {
+    // ADR-006 Notifications backend (PR-524) が Module load 時に EVENTS_TABLE_NAME を
+    // 必須で読むので、CDK 配線が無いと Lambda init で throw して portal 全 route が
+    // 502 になる (= #535 regression)。本 assertion で再発防止。
+    tpl.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: Match.objectLike({
+          Variables: Match.objectLike({
+            DEPLOYMENTS_TABLE_NAME: Match.anyValue(),
+            EVENTS_TABLE_NAME: Match.anyValue(),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("ParticipantPortal Lambda の IAM Role に Events table の dynamodb:Query を付与するべき", () => {
+    // ADR-006: GET /portal/me/notifications が Events table を Query する。
+    // 配線が無いと AccessDenied で 500 になる。Role 直貼りの inline policy なので
+    // `AWS::IAM::Role` の Policies 配列を見る。
+    tpl.hasResourceProperties(
+      "AWS::IAM::Role",
+      Match.objectLike({
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyName: "EventsRead",
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([
+                Match.objectLike({
+                  Action: "dynamodb:Query",
+                  Effect: "Allow",
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { describe, expect, it } from "vitest";
+import { ParticipantPortalLambda } from "../lib/problem-deploy/participant-portal-lambda";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 
 // 全 it() で同じ Template を使い回す。stack 構造は default props で固定なので、
@@ -146,26 +147,35 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
 });
 
 /**
- * ParticipantPortalLambda を含む synth (= participantPortal prop あり)。
- * EVENTS_TABLE_NAME 配線 + Events table への Query IAM 付与を assert する。
+ * ParticipantPortalLambda 単体 synth (#535 再発防止)。
+ *
+ * Stack 全体を synth すると `ParticipantPortalHosting` が
+ * `apps/participant-portal/dist` の asset を要求し、CI 環境 (= dist 未 build) で
+ * fail する。Lambda の env / IAM だけ確認できれば十分なので、Lambda construct を
+ * 単体で synth する。
  */
-function synthWithParticipantPortal(): Template {
+function synthParticipantPortalLambdaOnly(): Template {
   const app = new cdk.App();
-  const stack = new ProblemDeployBackendStack(app, "TestStack", {
-    eventBusArn: "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus",
-    sourceBucketName: "test-source-bucket",
-    sourceObjectKey: "source.zip",
-    problemsCatalog: {
-      "hello-world": "problems/challenges/hello-world",
-    },
+  const stack = new cdk.Stack(app, "TestStack");
+  const deployments = new cdk.aws_dynamodb.Table(stack, "Deployments", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  const events = new cdk.aws_dynamodb.Table(stack, "Events", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  new ParticipantPortalLambda(stack, "ParticipantPortal", {
+    deploymentsTable: deployments,
+    eventsTable: events,
     problemsScoring: {},
-    participantPortal: { runtimeConfig: "default-dev-mock" },
+    consoleViewerRoleArn: "arn:aws:iam::123456789012:role/console-viewer",
   });
   return Template.fromStack(stack);
 }
 
-describe("ProblemDeployBackendStack — ParticipantPortalLambda wiring (#535)", () => {
-  const tpl = synthWithParticipantPortal();
+describe("ParticipantPortalLambda wiring (#535)", () => {
+  const tpl = synthParticipantPortalLambdaOnly();
 
   it("ParticipantPortal Lambda の environment に EVENTS_TABLE_NAME が設定されるべき", () => {
     // ADR-006 Notifications backend (PR-524) が Module load 時に EVENTS_TABLE_NAME を


### PR DESCRIPTION
## Summary

Closes #535. PR-524 (notifications backend) で \`getEnv("EVENTS_TABLE_NAME")\` が module load 時に必須読み込みされるが、CDK 側の env / IAM 配線が **そもそも入っていなかった** ため Lambda init で throw → portal **全 route が 502** になっていた。

「実装が完成していない」だけが原因なので、雑な graceful fallback を Lambda 側に入れるのではなく **CDK で配線して実装を完成させる** 方針で対応 (= PR-543 の graceful 路線は close 済)。

## 変更点

- \`participant-portal-lambda.ts\`: props に \`eventsTable\` 追加、IAM \`EventsRead\` policy で \`dynamodb:Query\`、env に \`EVENTS_TABLE_NAME\`
- \`problem-deploy-backend-stack.ts\`: \`eventsTable: events.table\` を渡す
- tests +2: 環境変数の存在 / IAM Query 付与の CFn assertion (= 同じ regression を再発させない)

\`getEnv\` の挙動は据え置き (= 必須 env として fail-fast 維持)。CDK 配線が将来また外れたら Lambda init で throw する想定 (= 設定漏れを silent 通過させない)。

## 物理影響

CFn 差分:
- \`ParticipantPortalLambda\` の \`Environment.Variables\` に \`EVENTS_TABLE_NAME\` 追加 (UPDATE)
- \`ParticipantPortalLambda\` の Role に inline policy \`EventsRead\` 追加 (UPDATE)

Lambda 自体の置換は無し。

## Test plan

- [x] \`make typecheck\` 緑
- [x] \`make test\` 緑 (530 tests)
- [x] CDK synth で env + IAM が生成されることを assertion
- [ ] **実 deploy 後**: portal sign-in が 200 で通ること、\`/portal/me/notifications\` が 200 で空 \`items: []\` を返すこと

## Regression 分析

- 既存 portal route は EVENTS_TABLE_NAME を読まないので機能影響なし。本 PR は init throw を解消するだけ
- IAM Query は Events table base のみ (= GSI に付与しない、PK partition Query のみ使うので最小権限)

🤖 Generated with [Claude Code](https://claude.com/claude-code)