### PR TITLE
fix(scripts): CodeBuild の update-tenant / provision-tenant — node 20 + unzip -o (CdkCodeBuildProject failure)

### DIFF
--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -2,12 +2,22 @@
 
 # Install dependencies
 sudo yum update -y
-sudo yum install -y nodejs
 sudo yum install -y jq
 sudo yum install -y python3-pip
-sudo yum install -y npm
-sudo npm install -g aws-cdk
 sudo python3 -m pip install --upgrade setuptools
+
+# CodeBuild の default node が 14.x で、CDK 2 系 / aws-sdk v3 / @cdklabs/sbt-aws 0.3.9
+# などが node >=18 (一部 >=20) を要求するため、build 開始時に nvm で node 20 を入れる。
+# yum install -y nodejs だと AL2 系では node 16 等になり要件を満たさない場合がある。
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 20
+nvm use 20
+node --version
+npm --version
+
+npm install -g aws-cdk
 
 # Enable nocasematch option
 shopt -s nocasematch
@@ -28,7 +38,10 @@ CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
 echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
 
 aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
-unzip $CDK_SOURCE_NAME
+# `-o`: 既存ファイルを silent overwrite (CodeBuild は workspace 再利用でファイルが残ることが
+# あり、prompt が出ると stdin EOF で `[N]one` 扱いになって展開不完全 → 後段 `cd cdk` などで
+# silent fail。`-o` で必ず上書きする。
+unzip -o $CDK_SOURCE_NAME
 
 cd cdk
 npm install

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -1,5 +1,20 @@
 #!/bin/bash -xe
 
+# CodeBuild の default node が 14.x で、CDK 2 系 / aws-sdk v3 / @cdklabs/sbt-aws 0.3.9
+# などが node >=18 (一部 >=20) を要求するため、build 開始時に nvm で node 20 を入れる。
+# `n` ではなく `nvm` を使うのは CodeBuild standard image に既に nvm が同梱されている
+# (= 追加 install 不要、cold start で速い) ため。
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 20
+nvm use 20
+node --version
+npm --version
+
+# 古い node で global install された aws-cdk は捨てて、node 20 で再 install。
+npm install -g aws-cdk
+
 export CDK_PARAM_CONTROL_PLANE_SOURCE='sbt-control-plane-api'
 export CDK_PARAM_ONBOARDING_DETAIL_TYPE='Onboarding'
 export CDK_PARAM_PROVISIONING_DETAIL_TYPE=$CDK_PARAM_ONBOARDING_DETAIL_TYPE
@@ -24,7 +39,10 @@ export CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
 echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
 
 aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
-unzip $CDK_SOURCE_NAME
+# `-o`: 既存ファイルを silent overwrite (CodeBuild は workspace 再利用でファイルが残ることが
+# あり、prompt が出ると stdin EOF で `[N]one` 扱いになって展開不完全 → 後段 `cd cdk` などで
+# silent fail。`-o` で必ず上書きする。
+unzip -o $CDK_SOURCE_NAME
 
 cd cdk
 npm install


### PR DESCRIPTION
## Summary

CdkCodeBuildProject の build が \`Unexpected token '{'\` で失敗する root cause を解消。CloudWatch log 観察:

1. **\`unzip\` が prompt → \`[N]one\` で展開不完全**:
   \`replace cdk/test/problem-deploy-backend-stack.test.ts? [y]es,[n]o,[A]ll,[N]one,[r]ename: NULL (EOF or read error, treating as "[N]one"...)\`
   CodeBuild の workspace 再利用で既存ファイル発見、stdin EOF で no 扱い。

2. **\`npx cdk deploy\` で \`Unexpected token '{'\`**:
   CodeBuild standard image の default node が **14.21.3**、CDK 2 系 / aws-sdk v3 / @cdklabs/sbt-aws 0.3.9 が軒並み node >=18 を要求。"Unsupported engine" warning が大量に出ていた:
   \`wanted: {"node":">= 20.0.0"} (current: {"node":"14.21.3","npm":"6.14.18"})\`

## 変更点

### \`scripts/update-tenant.sh\`
- 冒頭に **nvm install 20 + nvm use 20** (= CodeBuild image 同梱 nvm を使う)
- node 20 で \`npm install -g aws-cdk\` を再実行 (= 古い node 14 で install された binary を上書き)
- \`unzip\` → \`unzip -o\` で silent overwrite

### \`scripts/provision-tenant.sh\`
- \`sudo yum install -y nodejs\` / \`sudo npm install -g aws-cdk\` を撤去 (= AL2 系で node 16 等が入る運不安)
- 代わりに nvm install 20 + npm install -g aws-cdk
- 同じく \`unzip -o\`

## 物理影響

CodeBuild の build script が変わるだけ (CFn / Lambda / DDB は NO-OP)。nvm install 20 で初回 cold start に +20〜30 秒程度の overhead。

## Regression 分析

- 既存の jq / python3-pip 等の install は維持
- nvm が image に無い場合 (= 異常系) は \`[ -s "$NVM_DIR/nvm.sh" ]\` guard で source skip し、その後 \`nvm install 20\` で fail → \`set -e\` で build fail (silent 通過させない)
- \`unzip -o\` は冪等。既存ファイル無くても warning 出ない

## Test plan

- [x] make before-commit 緑
- [ ] **実 deploy**: tenant 作成 → CdkCodeBuildProject build が COMPLETED で終わる + cdk deploy が走る
- [ ] 2 回目以降の build (= workspace 再利用) でも unzip prompt で死なない

🤖 Generated with [Claude Code](https://claude.com/claude-code)