### PR TITLE
fix(scripts): #560 CodeBuild 'nvm: not found' — NodeSource yum で image 非依存にする

### DIFF
--- a/scripts/lib/install-node.sh
+++ b/scripts/lib/install-node.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# CodeBuild の provision-tenant.sh / update-tenant.sh で source する Node セットアップ helper。
+#
+# `.nvmrc` を読んで NodeSource yum repo から install する。
+#
+# Why NodeSource: image 非依存で動く (AL2 / AL2023 / standard:7.0)。CodeBuild image に
+# nvm が無いケースで silent fail した旧 nvm 経路 (#560) の置換。
+# Why .nvmrc 経由: バージョン値を repo root の 1 ファイルに集約し、ローカル dev (`nvm use`)
+# と CodeBuild で同じ version を使う。
+# Why pipefail: caller 側で `set -o pipefail` を有効化していること前提。`curl ... | sudo bash -`
+# の途中失敗を取りこぼさないため。
+
+install_node_from_nvmrc() {
+  local node_major
+  # `.nvmrc` は `20` / `20.11` / `v20.11.1` のいずれの nvm 互換形式でも受ける。
+  # whitespace と leading `v` を strip → major を取り、numeric 検証 (= setup_v20.x のような不正 URL 構築を防ぐ)。
+  node_major="$(tr -d '[:space:]' < .nvmrc | sed -E 's/^v//' | cut -d. -f1)"
+  if ! [[ "$node_major" =~ ^[0-9]+$ ]]; then
+    echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style" >&2
+    return 1
+  fi
+  curl -fsSL "https://rpm.nodesource.com/setup_${node_major}.x" | sudo bash -
+  sudo yum install -y nodejs
+  node --version
+  npm --version
+}

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -30,18 +30,18 @@ aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAM
 # silent fail。`-o` で必ず上書きする。
 unzip -o $CDK_SOURCE_NAME
 
-# Node 切替は **`.nvmrc` (= source of truth、repo root に commit、install.sh が source.zip 同梱)**
-# を読む。CodeBuild standard image 同梱の nvm を使うので追加 install 不要。
-# 上げる時はリポジトリ root の `.nvmrc` を 1 か所書き換えれば全 script + ローカル dev に伝搬する
-# (= ハードコード版数の散乱を防ぐ)。
-NODE_VERSION=$(cat .nvmrc)
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-# shellcheck disable=SC1091
-. "$NVM_DIR/nvm.sh"
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
+# Node version は **`.nvmrc` (= source of truth、repo root に commit、install.sh が
+# source.zip 同梱)** を読み、NodeSource yum repo で OS-level に install。
+# 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
+# cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
+# 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
+NODE_MAJOR=$(cut -d. -f1 .nvmrc)
+echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
+curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
+sudo yum install -y nodejs
 node --version
-npm install -g aws-cdk
+npm --version
+sudo npm install -g aws-cdk
 
 cd cdk
 npm install

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -e
+set -o pipefail
+# pipefail: `curl ... | sudo bash -` のような pipe で curl が落ちても silent に続行しないよう、
+# pipeline 全体の終了 code を最後に失敗した command のものに統一する (= -e と組み合わせて
+# 即 exit させる)。NodeSource bootstrap が壊れた download で silent install すると後段が
+# 古い node のまま動いて debug が困難になるため必須 (CodeRabbit PR-562 review 指摘)。
 
 # Install dependencies
 sudo yum update -y
@@ -35,13 +40,22 @@ unzip -o $CDK_SOURCE_NAME
 # 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
 # cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
 # 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
-NODE_MAJOR=$(cut -d. -f1 .nvmrc)
+# `.nvmrc` は `20` / `20.11` / `v20.11.1` どの形式でも受ける (= 一般的な nvm 互換)。
+# whitespace + leading `v` を strip してから major を取り、numeric 検証 (= setup_v20.x のような
+# 不正 URL を防ぐ、CodeRabbit PR-562 review 指摘)。
+NODE_MAJOR="$(tr -d '[:space:]' < .nvmrc | sed -E 's/^v//' | cut -d. -f1)"
+if ! [[ "$NODE_MAJOR" =~ ^[0-9]+$ ]]; then
+  echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style"
+  exit 1
+fi
 echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
 curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
 sudo yum install -y nodejs
 node --version
 npm --version
-sudo npm install -g aws-cdk
+# aws-cdk は cdk/package.json の devDependencies に入っているので、後段の `cd cdk && npm install`
+# 後に `npx cdk` で local 版が解決される。global install は AWS docs 推奨と project 規約 (= npx/bunx)
+# どちらにも反するので撤去 (CodeRabbit PR-562 review 指摘)。
 
 cd cdk
 npm install

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -e
+# pipefail: `curl ... | sudo bash -` の curl 失敗を silent に続行させない (NodeSource bootstrap
+# が壊れた download で古い node のまま動いて debug 困難になるのを防ぐ、#560 の延長)。
 set -o pipefail
-# pipefail: `curl ... | sudo bash -` のような pipe で curl が落ちても silent に続行しないよう、
-# pipeline 全体の終了 code を最後に失敗した command のものに統一する (= -e と組み合わせて
-# 即 exit させる)。NodeSource bootstrap が壊れた download で silent install すると後段が
-# 古い node のまま動いて debug が困難になるため必須 (CodeRabbit PR-562 review 指摘)。
 
 # Install dependencies
 sudo yum update -y
@@ -30,32 +28,13 @@ CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
 echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
 
 aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
-# `-o`: 既存ファイルを silent overwrite (CodeBuild は workspace 再利用でファイルが残ることが
-# あり、prompt が出ると stdin EOF で `[N]one` 扱いになって展開不完全 → 後段 `cd cdk` などで
-# silent fail。`-o` で必ず上書きする。
+# `-o`: 既存ファイルを silent overwrite (CodeBuild の workspace 再利用で残ったファイルに対し、
+# prompt が出ると stdin EOF で `[N]one` 扱い → 展開不完全 → 後段で silent fail するのを防ぐ)。
 unzip -o $CDK_SOURCE_NAME
 
-# Node version は **`.nvmrc` (= source of truth、repo root に commit、install.sh が
-# source.zip 同梱)** を読み、NodeSource yum repo で OS-level に install。
-# 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
-# cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
-# 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
-# `.nvmrc` は `20` / `20.11` / `v20.11.1` どの形式でも受ける (= 一般的な nvm 互換)。
-# whitespace + leading `v` を strip してから major を取り、numeric 検証 (= setup_v20.x のような
-# 不正 URL を防ぐ、CodeRabbit PR-562 review 指摘)。
-NODE_MAJOR="$(tr -d '[:space:]' < .nvmrc | sed -E 's/^v//' | cut -d. -f1)"
-if ! [[ "$NODE_MAJOR" =~ ^[0-9]+$ ]]; then
-  echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style"
-  exit 1
-fi
-echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
-curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
-sudo yum install -y nodejs
-node --version
-npm --version
-# aws-cdk は cdk/package.json の devDependencies に入っているので、後段の `cd cdk && npm install`
-# 後に `npx cdk` で local 版が解決される。global install は AWS docs 推奨と project 規約 (= npx/bunx)
-# どちらにも反するので撤去 (CodeRabbit PR-562 review 指摘)。
+# shellcheck source=lib/install-node.sh
+source ./scripts/lib/install-node.sh
+install_node_from_nvmrc
 
 cd cdk
 npm install
@@ -86,7 +65,7 @@ if [[ $TIER == "PLATINUM" ]]; then
   export CDK_PARAM_DEPROVISIONING_DETAIL_TYPE=$CDK_PARAM_OFFBOARDING_DETAIL_TYPE
   export CDK_PARAM_PROVISIONING_EVENT_SOURCE="sbt-application-plane-api"
   export CDK_PARAM_APPLICATION_NAME_PLANE_SOURCE="sbt-application-plane-api"
-  cdk deploy $STACK_NAME --require-approval never
+  npx cdk deploy $STACK_NAME --require-approval never
 fi
 
 # Read tenant details from the cloudformation stack output parameters

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -29,19 +29,19 @@ aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAM
 # silent fail。`-o` で必ず上書きする。
 unzip -o $CDK_SOURCE_NAME
 
-# Node 切替は **`.nvmrc` (= source of truth、repo root に commit、install.sh が source.zip 同梱)**
-# を読む。CodeBuild standard image 同梱の nvm を使うので追加 install 不要。
-# 上げる時はリポジトリ root の `.nvmrc` を 1 か所書き換えれば全 script + ローカル dev に伝搬する
-# (= ハードコード版数の散乱を防ぐ)。
-NODE_VERSION=$(cat .nvmrc)
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-# shellcheck disable=SC1091
-. "$NVM_DIR/nvm.sh"
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
+# Node version は **`.nvmrc` (= source of truth、repo root に commit、install.sh が
+# source.zip 同梱)** を読み、NodeSource yum repo で OS-level に install。
+# 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
+# cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
+# 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
+NODE_MAJOR=$(cut -d. -f1 .nvmrc)
+echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
+curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
+sudo yum install -y nodejs
 node --version
-# 古い node で global install された aws-cdk を上書き (= npx 経由 fallback の保険)。
-npm install -g aws-cdk
+npm --version
+# Node 20 で global install された aws-cdk を入れ直す (= 古い node 14 binary を上書き)。
+sudo npm install -g aws-cdk
 
 cd cdk
 npm install

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -xe
+# pipefail: `curl ... | sudo bash -` の curl 失敗を silent に続行させない (#560 の延長)。
 set -o pipefail
-# pipefail: `curl ... | sudo bash -` のような pipe で curl が落ちても silent に続行しないよう、
-# pipeline 全体の終了 code を最後に失敗した command のものに統一する (= -e と組み合わせて
-# 即 exit させる)。NodeSource bootstrap が壊れた download で silent install すると後段が
-# 古い node のまま動いて debug が困難になるため必須 (CodeRabbit PR-562 review 指摘)。
 
 export CDK_PARAM_CONTROL_PLANE_SOURCE='sbt-control-plane-api'
 export CDK_PARAM_ONBOARDING_DETAIL_TYPE='Onboarding'
@@ -29,32 +26,13 @@ export CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
 echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
 
 aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
-# `-o`: 既存ファイルを silent overwrite (CodeBuild は workspace 再利用でファイルが残ることが
-# あり、prompt が出ると stdin EOF で `[N]one` 扱いになって展開不完全 → 後段 `cd cdk` などで
-# silent fail。`-o` で必ず上書きする。
+# `-o`: 既存ファイルを silent overwrite (CodeBuild の workspace 再利用で残ったファイルに対し、
+# prompt が出ると stdin EOF で `[N]one` 扱い → 展開不完全 → 後段で silent fail するのを防ぐ)。
 unzip -o $CDK_SOURCE_NAME
 
-# Node version は **`.nvmrc` (= source of truth、repo root に commit、install.sh が
-# source.zip 同梱)** を読み、NodeSource yum repo で OS-level に install。
-# 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
-# cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
-# 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
-# `.nvmrc` は `20` / `20.11` / `v20.11.1` どの形式でも受ける (= 一般的な nvm 互換)。
-# whitespace + leading `v` を strip してから major を取り、numeric 検証 (= setup_v20.x のような
-# 不正 URL を防ぐ、CodeRabbit PR-562 review 指摘)。
-NODE_MAJOR="$(tr -d '[:space:]' < .nvmrc | sed -E 's/^v//' | cut -d. -f1)"
-if ! [[ "$NODE_MAJOR" =~ ^[0-9]+$ ]]; then
-  echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style"
-  exit 1
-fi
-echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
-curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
-sudo yum install -y nodejs
-node --version
-npm --version
-# aws-cdk は cdk/package.json の devDependencies に入っているので、後段の `cd cdk && npm install`
-# 後に `npx cdk` で local 版が解決される。global install は AWS docs 推奨と project 規約 (= npx/bunx)
-# どちらにも反するので撤去 (CodeRabbit PR-562 review 指摘)。
+# shellcheck source=lib/install-node.sh
+source ./scripts/lib/install-node.sh
+install_node_from_nvmrc
 
 cd cdk
 npm install

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -xe
+set -o pipefail
+# pipefail: `curl ... | sudo bash -` のような pipe で curl が落ちても silent に続行しないよう、
+# pipeline 全体の終了 code を最後に失敗した command のものに統一する (= -e と組み合わせて
+# 即 exit させる)。NodeSource bootstrap が壊れた download で silent install すると後段が
+# 古い node のまま動いて debug が困難になるため必須 (CodeRabbit PR-562 review 指摘)。
 
 export CDK_PARAM_CONTROL_PLANE_SOURCE='sbt-control-plane-api'
 export CDK_PARAM_ONBOARDING_DETAIL_TYPE='Onboarding'
@@ -34,14 +39,22 @@ unzip -o $CDK_SOURCE_NAME
 # 旧 nvm 経由は CodeBuild image に nvm が無いケースで silent fail し、結局 default node 14 で
 # cdk が "Unexpected token '{'" になる regression を起こした (#560)。NodeSource なら image 非依存。
 # 上げる時は repo root の `.nvmrc` を 1 行書き換えるだけで全 script + ローカル dev に伝搬。
-NODE_MAJOR=$(cut -d. -f1 .nvmrc)
+# `.nvmrc` は `20` / `20.11` / `v20.11.1` どの形式でも受ける (= 一般的な nvm 互換)。
+# whitespace + leading `v` を strip してから major を取り、numeric 検証 (= setup_v20.x のような
+# 不正 URL を防ぐ、CodeRabbit PR-562 review 指摘)。
+NODE_MAJOR="$(tr -d '[:space:]' < .nvmrc | sed -E 's/^v//' | cut -d. -f1)"
+if ! [[ "$NODE_MAJOR" =~ ^[0-9]+$ ]]; then
+  echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style"
+  exit 1
+fi
 echo "Installing Node.js ${NODE_MAJOR}.x via NodeSource yum repo..."
 curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" | sudo bash -
 sudo yum install -y nodejs
 node --version
 npm --version
-# Node 20 で global install された aws-cdk を入れ直す (= 古い node 14 binary を上書き)。
-sudo npm install -g aws-cdk
+# aws-cdk は cdk/package.json の devDependencies に入っているので、後段の `cd cdk && npm install`
+# 後に `npx cdk` で local 版が解決される。global install は AWS docs 推奨と project 規約 (= npx/bunx)
+# どちらにも反するので撤去 (CodeRabbit PR-562 review 指摘)。
 
 cd cdk
 npm install


### PR DESCRIPTION
Closes #560.

## Summary

PR-545 / PR-546 の nvm 経路は **CodeBuild image に nvm が同梱されている前提** で書いていたが、SBT BashJobRunner が選ぶ default image (= 古い AL2 系) には nvm が無く:

\`\`\`
/codebuild/output/tmp/script.sh: 13: nvm: not found
v14.21.3
...
Unexpected token '{'
\`\`\`

\`[ -s "$NVM_DIR/nvm.sh" ]\` guard が silent skip → \`nvm install\` が "not found" → そのまま node 14 で進行 → \`npx cdk\` が parse error で死亡。

## 修正

- update-tenant.sh / provision-tenant.sh の node setup を **NodeSource yum** に置換
- \`.nvmrc\` source-of-truth は維持: \`NODE_MAJOR=$(cut -d. -f1 .nvmrc)\` で major version を読む
- nvm 依存を完全撤去 → image 非依存 (= AL2 / AL2023 / standard:7.0 どれでも動く)
- \`sudo npm install -g aws-cdk\` で root に install (= 古い node 14 binary を上書き)

## postmortem

実 CodeBuild log を確認せずに「nvm 同梱」 assumption で merge したのが root cause。本日 30+ 件 issue を生んだ「dogfood 不在」の同種 case で、構造的予防策は #561 (ADR-007 outside-in architecture) で議論。

## Test plan

- [x] \`bash -n\` 構文 check 緑
- [x] \`make before-commit\` 緑
- [ ] **実 CodeBuild build**: tenant 作成で CdkCodeBuildProject の build が node 20 で正常終了
- [ ] CloudWatch Logs に \`v20.x.x\` が出る (= node version 期待通り)
- [ ] \`Unexpected token '{'\` が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js installation process in provisioning and deployment scripts for improved reliability and consistency with version specifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/562)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->