### PR TITLE
fix(test): biome noNonNullAssertion 違反を type narrowing に置換

### DIFF
--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -65,7 +65,8 @@ describe("listEvents", () => {
     });
     const out = await listEvents(shared, { tenantId: "tenant-acme" });
     expect(out.nextCursor).toBeTruthy();
-    const decoded = JSON.parse(Buffer.from(out.nextCursor!, "base64url").toString("utf8"));
+    if (!out.nextCursor) throw new Error("nextCursor should be set");
+    const decoded = JSON.parse(Buffer.from(out.nextCursor, "base64url").toString("utf8"));
     expect(decoded).toEqual({ PK: "EVENT#X", SK: "META" });
   });
 });


### PR DESCRIPTION
## Summary

\`infrastructure/test/problem-deploy/event-list.test.ts:68\` で \`out.nextCursor!\` の non-null assertion が biome \`lint/style/noNonNullAssertion\` で warning。\`bun run lint:format\` (= biome) でノイズになっていた。

\`expect(...).toBeTruthy()\` は biome の type narrowing には伝わらないので、続く \`if (!x) throw\` の早期 throw pattern に置換した (= 既存 \`application-admin-console-hosting.test.ts:121\` / \`event-schedule.test.ts:136\` 等で使われている narrowing 慣習に合わせる)。

## 変更点

\`\`\`diff
     const out = await listEvents(shared, { tenantId: "tenant-acme" });
     expect(out.nextCursor).toBeTruthy();
-    const decoded = JSON.parse(Buffer.from(out.nextCursor!, "base64url").toString("utf8"));
+    if (!out.nextCursor) throw new Error("nextCursor should be set");
+    const decoded = JSON.parse(Buffer.from(out.nextCursor, "base64url").toString("utf8"));
\`\`\`

## Regression 分析

- 挙動同一。\`toBeTruthy()\` 後の throw 行は実行されない (= happy path 不変)
- cursor が \`undefined\` の regression が起きた場合、旧コード = ランタイム TypeError、新コード = \"nextCursor should be set\" で test fail (= message が明示的、むしろ debug しやすい)

## 物理影響

test code のみ。CFn / Lambda / DDB は **NO-OP**。

## Test plan

- [x] \`bunx biome check\` → 233 files, 0 warning
- [x] \`bunx vitest run test/problem-deploy/event-list.test.ts\` → 9/9 passed
- [x] \`make before-commit\` 全 green (pre-commit hook で確認済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)