### PR TITLE
fix(#553): tenant API GW に /events/{eventId}/notifications POST route を配線

### DIFF
--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -84,11 +84,12 @@ export class ApiGateway extends Construct {
     deployment.addMethod("DELETE", deployIntegration, deployMethodOptions);
 
     // ADR-004 Phase 1+2a/2b: /events — 1 競技イベント = 1 行で teams + problems を持つ
-    // /events                      POST  = create   / GET = list
-    // /events/{eventId}            GET   = detail   / DELETE = bulk teardown
-    // /events/{eventId}/deploy     POST  = bulk deploy (teams × problems を fan-out)
-    // /events/{eventId}/schedule   PATCH = 競技開始時刻 (startsAt) を設定 (Phase 2b 追加)
-    // /events/{eventId}/end        POST  = Event を ENDED 状態にし採点を停止 (Issue #494)
+    // /events                          POST  = create   / GET = list
+    // /events/{eventId}                GET   = detail   / DELETE = bulk teardown
+    // /events/{eventId}/deploy         POST  = bulk deploy (teams × problems を fan-out)
+    // /events/{eventId}/schedule       PATCH = 競技開始時刻 (startsAt) を設定 (Phase 2b 追加)
+    // /events/{eventId}/end            POST  = Event を ENDED 状態にし採点を停止 (Issue #494)
+    // /events/{eventId}/notifications  POST  = 運営 → 競技者 通知 1 件作成 (ADR-006、#553)
     const eventIntegration = new LambdaIntegration(props.eventApiLambda);
     const events = this.restApi.root.addResource("events");
     events.addMethod("GET", eventIntegration, deployMethodOptions);
@@ -100,5 +101,6 @@ export class ApiGateway extends Construct {
     event.addResource("schedule").addMethod("PATCH", eventIntegration, deployMethodOptions);
     event.addResource("end").addMethod("POST", eventIntegration, deployMethodOptions);
     event.addResource("archive").addMethod("POST", eventIntegration, deployMethodOptions);
+    event.addResource("notifications").addMethod("POST", eventIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -101,4 +101,20 @@ describe("tenant ApiGateway", () => {
     expect(findResource("deploy")).toBeDefined();
     expect(findResource("{problemId}")).toBeDefined();
   });
+
+  it("/events/{eventId}/notifications resource + POST method が存在するべき (#553)", () => {
+    // backend handler `POST /events/:eventId/notifications` (= ADR-006 通知 push) と
+    // API Gateway route の配線がセットでないと frontend は "Failed to fetch" になる。
+    // #535 と同種の「backend だけ merge、CDK 後追い」 regression を再発させないための pin。
+    const notificationsResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { PathPart: "notifications" },
+      }),
+    )[0]?.[0];
+    expect(notificationsResourceId).toBeDefined();
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "POST",
+      ResourceId: { Ref: notificationsResourceId },
+    });
+  });
 });


### PR DESCRIPTION
[Critical] EventDetail の「通知を送る」 modal が "Failed to fetch" で失敗していた regression。

## 原因

backend handler (\`event-handler/index.ts:186\` の \`POST /events/:eventId/notifications\`、ADR-006) は PR-524 で merge 済だが、tenant API Gateway 側で resource / method が**作られていなかった**。フロントが 403 / CORS 拒否で fetch level \"Failed to fetch\" として観測。

(#535) と同種の \"backend 先 merge → CDK 配線後追い\" regression。再発防止は (#561) ADR-007 で別途扱う。

## 変更点

- \`tenant-template/api-gateway.ts\` に \`event.addResource(\"notifications\").addMethod(\"POST\", ...)\` 追加 (既存 \`/events/{eventId}/deploy\` と同じ流儀)
- CDK assertion test: \`PathPart: \"notifications\"\` resource + POST method が template に存在することを pin

## Regression 分析

- frontend / Hono handler 側は無変更 → happy path 不変
- 既存 events 配下 route (deploy / schedule / end / archive) の挙動は影響なし
- CORS preflight は既存 RestApi 全体の \`defaultCorsPreflightOptions\` でカバー済

## 物理影響

| 場所 | 種別 | 影響 |
|---|---|---|
| \`tenkacloud-tenant-template-pooled\` (CFn) | UPDATE | 新規 \`AWS::ApiGateway::Resource (notifications)\` + \`AWS::ApiGateway::Method (POST)\` |
| eventApi Lambda | NO-OP | 既に handler 内で受理 |
| stack output / runtime-config | NO-OP | API base URL 同一 |

## Test plan

- [x] \`bunx vitest run test/tenant-template/api-gateway.test.ts\` → 5/5 passed
- [ ] **deploy 後**: 通知送信 → 201 + Portal の Notifications で表示

Closes (#553)

🤖 Generated with [Claude Code](https://claude.com/claude-code)