### PR TITLE
fix(portal): TopNav Score/Rank と Score events 時刻 UI (#547 #548)

### DIFF
--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -95,11 +95,17 @@ function ShellInner({ config, children }: { config: AppConfig; children: ReactNo
             ? `${myEntry.rank}/${totalEntries}`
             : "…";
     return [
+      // #547: 旧 `menu-dropdown` + 空 items は chevron で展開できそうに見えて何も出ない
+      // という UX bug。Score / Rank の click は scoreboard ページへの遷移が自然なので
+      // `type: "button"` + onClick で /scoreboard に飛ばす (= dropdown の意図不明
+      // affordance を排除)。
       {
-        type: "menu-dropdown",
+        type: "button",
         text: `Score: ${score}  /  Rank: ${rank}`,
         iconName: "status-positive",
-        items: [],
+        onClick: () => {
+          navigate("/scoreboard");
+        },
       },
       {
         type: "menu-dropdown",

--- a/apps/participant-portal/src/lib/format.ts
+++ b/apps/participant-portal/src/lib/format.ts
@@ -1,4 +1,20 @@
 /**
+ * Score events cell の hover tooltip 用「UTC + ローカル時刻」併記文字列。
+ *
+ * 一次情報は相対時刻 (= 「何分前」、即時 feedback) で十分、絶対時刻は **必要なときだけ**
+ * 引きたいので tooltip に逃がす設計 (#548)。`Intl.DateTimeFormat` でブラウザ環境の
+ * ローカル TZ を解決し、UTC ISO と並べて返す。Invalid な ISO は `?` で防御。
+ */
+export function formatOccurredAtTooltip(iso: string | undefined): string {
+  if (!iso) return "未採点";
+  const ms = new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return "?";
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const local = new Date(ms).toLocaleString(undefined, { timeZone: tz });
+  return `${iso}\n${local} (${tz})`;
+}
+
+/**
  * 「N 秒前 / N 分前 / N 時間 N 分前」の人間可読フォーマット。
  *
  * Battle 中の defender が score の停滞時間を察知するための display helper。

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -15,7 +15,7 @@ import {
 } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
-import { describeAgo } from "../lib/format";
+import { describeAgo, formatOccurredAtTooltip } from "../lib/format";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -108,13 +108,14 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
               {
                 id: "occurredAt",
                 header: "発生時刻",
+                // #548: 相対時刻だけ表示し、絶対時刻 (UTC + ローカル) は cell hover の
+                // tooltip (= title 属性) で出す。ISO + 相対が連結して読めない bug と
+                // UTC 表示が直感的でない問題を同時に解消。Score events は「最近採点
+                // されたか」の即時 feedback が主用途なので relative 表示が一次情報。
                 cell: (e) => (
-                  <Box>
-                    <Box variant="small">{e.occurredAt}</Box>
-                    <Box variant="small" color="text-status-inactive">
-                      {describeAgo(e.occurredAt, Date.now())}
-                    </Box>
-                  </Box>
+                  <span title={formatOccurredAtTooltip(e.occurredAt)}>
+                    {describeAgo(e.occurredAt, Date.now())}
+                  </span>
                 ),
               },
               {


### PR DESCRIPTION
Participant Portal の 2 つの UI bug を同 PR で修正。どちらも apps/participant-portal の表示層差し替えで CFn / Lambda / DDB は **NO-OP**。

## (#547) TopNav Score/Rank dropdown が空

旧: \`type: \"menu-dropdown\"\` + \`items: []\` で chevron 展開しても popover が空 → 「機能してないと誤解される」 UX bug。

新: \`type: \"button\"\` + \`onClick: () => navigate(\"/scoreboard\")\`。Score / Rank は scoreboard の indicator なので click で詳細へ遷移するのが自然 (Cloudscape \`TopNavigationProps.Utility\` の button type 標準 API)。

## (#548) Score events 発生時刻 cell の連結 bug + UTC 表示

旧:
\`\`\`
| 2026-05-10T12:57:36.832Z51 秒前 |
\`\`\`
\`Box variant=\"small\"\` 2 つを縦に並べる意図だが table cell 内で inline 描画 → 連結。さらに UTC ISO 表示のまま。

新: 相対時刻だけ cell に出し、絶対時刻 (UTC ISO + ローカル TZ) は \`title\` 属性で hover tooltip。\`Intl.DateTimeFormat().resolvedOptions().timeZone\` でブラウザ TZ を解決した \`formatOccurredAtTooltip\` helper を新設。即時 feedback (= 「最近採点されたか」) の一次情報は相対時刻、絶対時刻は副次情報なので tooltip に逃がす設計。

## Regression 分析

- AppLayout の他 utility (team name dropdown / logout) は無変更
- Score events polling / data shape は不変、表示層のみ差し替え
- empty state で \`Box\` を引き続き使うので import 除去せず

## 物理影響

frontend のみ。\`participant-portal\` の S3 + CloudFront artifact が次 deploy で更新される。

## Test plan

- [x] \`bun run typecheck\` → green
- [x] \`bunx vitest run\` → 9 files / 63 tests passed
- [ ] **deploy 後**: TopNav の Score/Rank click → /scoreboard 遷移
- [ ] **deploy 後**: Score events cell が「N 秒前」のみ、hover で UTC + ローカル併記 tooltip

Closes (#547) (#548)

🤖 Generated with [Claude Code](https://claude.com/claude-code)