### PR TITLE
fix(#537): startsAt 過去日時を frontend / backend 両方で reject

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -202,6 +202,14 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       setError("日時の形式が不正です");
       return;
     }
+    // #537: 過去日時 reject (第一防衛線、frontend)。SLACK 60s で server 側と揃える。
+    // 過去にしたいなら「即座に開始」 button を使うべき。
+    if (local.getTime() < Date.now() - 60_000) {
+      setError(
+        "過去の日時は指定できません。即座に開始するには「即座に開始」 button を使ってください。",
+      );
+      return;
+    }
     setScheduleInFlight("scheduled");
     setError(null);
     try {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -150,6 +150,20 @@ app.patch("/events/:eventId/schedule", async (c) => {
   try {
     const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, startsAt, nowMs);
     if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    if (outcome.kind === "past_starts_at") {
+      // #537: 過去日時を frontend が迂回した場合の防御線。SLACK_MS (= 60s) より過去なら
+      // 「即座に開始」 button を使うべきなので reject。message は frontend で表示する。
+      return c.json(
+        {
+          error: "past_starts_at",
+          message:
+            "startsAt が過去の時刻です。「即座に開始」 button を使うか、未来の時刻を指定してください。",
+          startsAt: outcome.startsAt,
+          serverNow: new Date(outcome.nowMs).toISOString(),
+        },
+        HTTP_BAD_REQUEST,
+      );
+    }
     return c.json(
       { startsAt: outcome.startsAt, updatedDeployments: outcome.updatedDeployments },
       HTTP_OK,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
@@ -6,11 +6,22 @@ import type { EventItem } from "./types.js";
 /**
  * `setEventSchedule` の結果。
  * - `not_found`: tenant 不一致 / event 不在 → 404 相当
+ * - `past_starts_at`: 指定 startsAt が `now - SLACK_MS` 以前 → 400 相当 (#537)
  * - `ok`: 更新後の startsAt + 影響を受けた deployment 数を返す
  */
 export type SetEventScheduleOutcome =
   | { kind: "not_found" }
+  | { kind: "past_starts_at"; startsAt: string; nowMs: number }
   | { kind: "ok"; startsAt: string; updatedDeployments: number };
+
+/**
+ * 過去日時 reject の slack (= clock skew tolerance、#537)。これより過去の startsAt は
+ * 「即座に開始」 button を使うべきなので backend 側で reject する。
+ *
+ * 60s = LB / Lambda の clock drift 経験上の上限。これより緩いと typo 起因の誤入力を
+ * 通してしまうし、これより厳しいと真っ当な「ちょっと前の時刻」も弾いてしまう。
+ */
+const PAST_STARTS_AT_SLACK_MS = 60_000;
 
 /**
  * Event の `startsAt` を更新し、紐づく全 deployment 行に `eventStartsAt` を denormalize する。
@@ -30,6 +41,14 @@ export async function setEventSchedule(
   startsAt: string,
   nowMs: number,
 ): Promise<SetEventScheduleOutcome> {
+  // #537: 過去日時 reject (第二防衛線、frontend 迂回 / API 直叩き対策)。「即座に開始」は
+  // handler で `startNow: true` 経路に振られて server now を採用するので、ここに到達する
+  // `startsAt` は operator 入力 (= 任意時刻)。`nowMs - SLACK_MS` より前なら past_starts_at。
+  const startsAtMs = new Date(startsAt).getTime();
+  if (Number.isFinite(startsAtMs) && startsAtMs < nowMs - PAST_STARTS_AT_SLACK_MS) {
+    return { kind: "past_starts_at", startsAt, nowMs };
+  }
+
   // Event の存在 + tenantId 確認のため UpdateItem の ConditionExpression で防御。
   // 同時に Deployments の対象行 (eventId 一致) を Query で集める。
   const now = new Date(nowMs).toISOString();

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -107,6 +107,27 @@ describe("setEventSchedule", () => {
     expect(updCmds).toHaveLength(0);
   });
 
+  it("startsAt が now - 60s より過去なら past_starts_at で DDB に触れず reject すべき (#537)", async () => {
+    const { shared, ddbSend } = buildShared();
+    // NOW_MS の 5 分前 (= SLACK 60s より十分過去)
+    const pastStartsAt = new Date(NOW_MS - 5 * 60_000).toISOString();
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", pastStartsAt, NOW_MS);
+    expect(out).toEqual({ kind: "past_starts_at", startsAt: pastStartsAt, nowMs: NOW_MS });
+    // DDB call は 0 (= 過去日時 reject は DDB 触れない、副作用なし)
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("startsAt が now - 30s (= SLACK 内) なら過去扱いせず通すべき (#537 clock skew tolerance)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: NOW_ISO },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const slackOk = new Date(NOW_MS - 30_000).toISOString();
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", slackOk, NOW_MS);
+    expect(out.kind).toBe("ok");
+  });
+
   it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
EventDetail の「日時を指定して開始」 modal で過去時刻を保存できてしまい、保存瞬間に「採点中」遷移 → 採点履歴整合崩れの bug を二重防御で塞ぐ。

## 設計判断

- **slack 60s** で frontend / backend を揃える (clock skew tolerance)
- 「即座に開始」 button は handler で \`startNow: true\` → server now 採用なので影響なし
- 過去日時を入れたい運用は「即座に開始」 button に誘導 (= 過去入力を許す motivation 無い)

## 変更点

| 場所 | 変更 |
|---|---|
| \`schedule.ts\` | \`SetEventScheduleOutcome\` に \`past_starts_at\` 分岐追加。\`startsAt < nowMs - 60_000\` なら DDB 触れず early return |
| \`event-handler/index.ts\` | \`past_starts_at\` → \`400 { error: \"past_starts_at\", message, serverNow }\` |
| \`event-schedule.test.ts\` | 2 ケース追加 (5 分前 → past_starts_at + DDB 不触 / 30 秒前 → slack 内で ok) |
| \`EventDetail.tsx\` | submit 直前に \`local < now - 60_000\` チェックして errorText reject |

## Regression 分析

- 既存 happy path (= 未来時刻) 不変。既存 schedule test 4 件は通る
- \`startNow: true\` は handler の startsAt 分岐に振られないので past_starts_at に到達しない
- backend / frontend を同値 slack (60_000) に揃えて race 防止

## 物理影響

- \`event-handler\` Lambda: handler 内 1 分岐追加。CFn Lambda asset hash が回るだけで IAM / table / API GW resource は **NO-OP**
- \`application-admin-console\` S3 artifact: bundle 更新

## Test plan

- [x] \`bunx vitest run test/problem-deploy/event-schedule.test.ts\` → 13/13 passed
- [x] application-admin-console vitest → 80/80 passed
- [x] typecheck green
- [ ] **deploy 後**: 過去日時で「設定」 → errorText + button reject / curl 直叩きで 400 \`past_starts_at\`

Closes (#537)

🤖 Generated with [Claude Code](https://claude.com/claude-code)