### PR TITLE
refactor(ui): EventDetail / ProblemDetail / Quests UX cleanup (#556 #540 #541 #533 #549 #554)

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -71,8 +71,12 @@ function renderProblemDeployStatus(deployments: readonly EventDeploymentSummary[
 }
 
 /**
- * 1 problem 行の deploy job click-through link 列。各 jobId を /deployments/:jobId に
- * 飛ばす (= per-team の deploy 詳細ページ)。
+ * 1 problem 行の deploy job click-through link 列 (#533)。
+ *
+ * 旧: Badge を Link でラップしただけだと click 可能か視覚的にわからない (= hover でしか
+ * cursor が変わらない)。新: Link テキスト + status badge を **横並び** にし、Link 部分に
+ * external icon を付けて click 可能 affordance を明示する。status badge は同色で残し、
+ * 「これは link であり、横の badge はその job の状態」の visual identity を分離する。
  */
 function renderProblemJobLinks(deployments: readonly EventDeploymentSummary[] | undefined) {
   if (!deployments || deployments.length === 0) {
@@ -83,15 +87,18 @@ function renderProblemJobLinks(deployments: readonly EventDeploymentSummary[] | 
     );
   }
   return (
-    <SpaceBetween direction="horizontal" size="xxs">
-      {deployments.map((d) => (
-        <Link
-          key={d.jobId}
-          href={`/deployments/${encodeURIComponent(d.jobId)}`}
-          ariaLabel={`Deploy job ${d.jobId} (status: ${d.status})`}
-        >
+    <SpaceBetween direction="vertical" size="xxs">
+      {deployments.map((d, i) => (
+        <SpaceBetween key={d.jobId} direction="horizontal" size="xxs" alignItems="center">
+          <Link
+            href={`/deployments/${encodeURIComponent(d.jobId)}`}
+            external={false}
+            ariaLabel={`Deploy job 詳細 (status: ${d.status})`}
+          >
+            Job #{i + 1} ↗
+          </Link>
           <Badge color={DEPLOY_STATUS_COLOR[d.status]}>{d.status}</Badge>
-        </Link>
+        </SpaceBetween>
       ))}
     </SpaceBetween>
   );
@@ -274,7 +281,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               }
               onClick={handleBulkDeploy}
             >
-              Bulk Deploy
+              Deploy
             </Button>
             <Button
               disabled={
@@ -299,7 +306,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               disabled={!detail}
               onClick={() => setConfirmTeardown(true)}
             >
-              Bulk Teardown
+              Delete
             </Button>
           </SpaceBetween>
         }
@@ -317,7 +324,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           type="success"
           dismissible
           onDismiss={() => setBulkResult(null)}
-          header="Bulk 操作 受付"
+          header="Deploy / Delete 受付"
         >
           受付: {bulkResult.enqueued} 件 / skipped: {bulkResult.skipped} 件 (実 deploy / delete は
           State Machine が非同期に進めます。数分後に再読み込みしてください)
@@ -444,10 +451,10 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                     <br />
                     2. 上の Portal URL と一緒に各チームへ共有
                     <br />
-                    3. <strong>Bulk Deploy</strong> で全チームの問題環境を起動 (Status が READY
+                    3. <strong>Deploy</strong> で全チームの問題環境を起動 (Status が READY
                     になったら競技開始)
                     <br />
-                    4. 終了後は <strong>Bulk Teardown</strong> で全環境を一括削除
+                    4. 終了後は <strong>Delete</strong> で全環境を一括削除
                   </Box>
                 </Box>
               </ColumnLayout>
@@ -495,11 +502,21 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               {
                 id: "key",
                 header: "teamLoginKey",
+                // #554: copy button を併設して text 選択 + Ctrl-C より早く配布できるように。
+                // Cloudscape Button の iconName="copy" + ariaLabel で a11y も担保。
                 cell: (t) =>
                   t.teamLoginKey ? (
-                    <Box variant="code" fontSize="body-s">
-                      {t.teamLoginKey}
-                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+                      <Box variant="code" fontSize="body-s">
+                        {t.teamLoginKey}
+                      </Box>
+                      <Button
+                        iconName="copy"
+                        variant="inline-icon"
+                        ariaLabel={`${t.internalSlug} の teamLoginKey をコピー`}
+                        onClick={() => void navigator.clipboard?.writeText(t.teamLoginKey ?? "")}
+                      />
+                    </SpaceBetween>
                   ) : (
                     <Box variant="small" color="text-status-inactive">
                       (詳細で再表示可)
@@ -540,7 +557,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
 
       <Modal
         visible={confirmTeardown}
-        header="Bulk Teardown を実行しますか?"
+        header="Event 全 deployment を削除しますか?"
         onDismiss={() => setConfirmTeardown(false)}
         footer={
           <Box float="right">

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -6,7 +6,6 @@ import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
@@ -16,7 +15,6 @@ import { useApiClient } from "../api/client";
 import {
   DEPLOYMENT_STATUS_INDICATOR,
   type DeploymentSummary,
-  deleteDeployment,
   listDeployments,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
@@ -68,11 +66,6 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       >
         {problem.name}
       </Header>
-
-      <Alert type="info" header="この問題を deploy するには Event 経由で">
-        単発 deploy 経路は廃止しました。Event を作成して Bulk Deploy してください。Event
-        紐付きが無い deployment は scoreboard / 集計に表示されません。
-      </Alert>
 
       <Container header={<Header variant="h2">概要</Header>}>
         <ColumnLayout columns={4} variant="text-grid">
@@ -137,8 +130,10 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
 
 function buildColumns(
   navigate: NavigateFunction,
-  onAskDelete: (item: DeploymentSummary) => void,
 ): TableProps.ColumnDefinition<DeploymentSummary>[] {
+  // #541: 単発「削除」 button は撤去。削除は EventDetail の「Delete」 (= 旧 Bulk Teardown)
+  // に集約。orphan single delete を残すと「片付け済の hidden 行が見えないまま課金される」
+  // 危険性があり、operator 視点で削除フローが 1 箇所に集まっている方が事故が少ない。
   return [
     {
       id: "team",
@@ -175,20 +170,6 @@ function buildColumns(
       header: "作成",
       cell: (item) => item.createdAt,
     },
-    {
-      id: "actions",
-      header: "操作",
-      cell: (item) => (
-        <Button
-          variant="normal"
-          iconName="delete-marker"
-          disabled={item.status === "DELETING" || item.status === "DELETED"}
-          onClick={() => onAskDelete(item)}
-        >
-          削除
-        </Button>
-      ),
-    },
   ];
 }
 
@@ -207,9 +188,6 @@ function ProblemDeploymentsSection({
   const navigate = useNavigate();
   const [items, setItems] = useState<readonly DeploymentSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [askDelete, setAskDelete] = useState<DeploymentSummary | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const fetchOnce = useCallback(async () => {
     if (!apiClient) return;
@@ -238,22 +216,7 @@ function ProblemDeploymentsSection({
     };
   }, [fetchOnce]);
 
-  const columns = useMemo(() => buildColumns(navigate, (item) => setAskDelete(item)), [navigate]);
-
-  const handleDelete = async () => {
-    if (!apiClient || !askDelete) return;
-    setDeleting(true);
-    setDeleteError(null);
-    try {
-      await deleteDeployment(apiClient, askDelete.jobId);
-      setAskDelete(null);
-      await fetchOnce();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setDeleting(false);
-    }
-  };
+  const columns = useMemo(() => buildColumns(navigate), [navigate]);
 
   return (
     <Container
@@ -281,38 +244,6 @@ function ProblemDeploymentsSection({
           }
         />
       </SpaceBetween>
-
-      <Modal
-        visible={askDelete !== null}
-        onDismiss={() => setAskDelete(null)}
-        header={askDelete ? `「${askDelete.teamName}」のデプロイを削除` : ""}
-        size="medium"
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button onClick={() => setAskDelete(null)} disabled={deleting}>
-                キャンセル
-              </Button>
-              <Button variant="primary" loading={deleting} onClick={handleDelete}>
-                削除する
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        {askDelete && (
-          <SpaceBetween size="s">
-            <Box>
-              競技アカウント (<code>{askDelete.awsAccountId}</code> / {askDelete.region}) で
-              起動中の CloudFormation Stack <code>{askDelete.namePrefix}</code> を削除します。
-            </Box>
-            <Box variant="small" color="text-status-warning">
-              この操作は取り消せません。実際の削除は次の周期で実行されます。
-            </Box>
-            {deleteError && <Alert type="error">{deleteError}</Alert>}
-          </SpaceBetween>
-        )}
-      </Modal>
     </Container>
   );
 }

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -30,6 +30,24 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   DELETED: "stopped",
 };
 
+/**
+ * 競技者語彙の status label (#549)。
+ *
+ * deployment status (`COMPLETE` / `IN_PROGRESS` / ...) は operator 視点の語彙で、
+ * 競技者目線では「自分が解いた = COMPLETE」と誤解されていた。インフラ状態を抽象化して
+ * 「プレイ可能か」の軸に変換する。本来は scoring kind ごとに「正解/未提出」「防御中/攻撃検知」
+ * を出すべきだが (issue 内 案 A)、それは participant API の拡張が要るので別 issue
+ * (#163 / #164) で対応する。本 PR では **「環境の起動状態」** を競技者語彙に統一する第一弾。
+ */
+const STATUS_PARTICIPANT_LABEL: Record<DeploymentStatus, string> = {
+  PENDING: "起動準備中",
+  IN_PROGRESS: "起動中…",
+  COMPLETE: "起動中",
+  FAILED: "起動失敗",
+  DELETING: "停止中",
+  DELETED: "停止済",
+};
+
 type CategoryFilter = "all" | "battle" | "challenge";
 
 function categoryBadge(scoring: ParticipantScoringInfo | undefined) {
@@ -125,10 +143,10 @@ export function QuestsPage({ config }: { config: AppConfig }) {
           sections: [
             {
               id: "status",
-              header: "ステータス",
+              header: "環境ステータス",
               content: (problem) => (
                 <StatusIndicator type={STATUS_TYPE[problem.status]}>
-                  {problem.status}
+                  {STATUS_PARTICIPANT_LABEL[problem.status]}
                 </StatusIndicator>
               ),
             },


### PR DESCRIPTION
dogfood 観察で見つかった 6 件の UI 改善を 1 PR にまとめる (= 全部 frontend, backend / CFn / DDB は **NO-OP**)。

## 変更内訳

| Issue | 場所 | 変更 |
|---|---|---|
| (#556) | EventDetail | \"Bulk Deploy\" / \"Bulk Teardown\" button → \"Deploy\" / \"Delete\"。Bulk じゃない経路が無いので prefix 冗長、Teardown は CFn DeleteStack と用語不整合 |
| (#556) | EventDetail | Alert / 配布手順本文 / modal header の Bulk Deploy/Teardown 文言も更新 |
| (#533) | EventDetail | Job Links column を \`Badge wrap-in-Link\` → \`Link (Job #N ↗) + Badge\` に分離。click affordance が text + arrow で明示、status badge は別 visual identity |
| (#554) | EventDetail | teamLoginKey cell に Cloudscape inline copy button 併設 |
| (#540) | ProblemDetail | 「単発 deploy 経路は廃止」 Alert (legacy 互換用) を撤去 |
| (#541) | ProblemDetail | 「デプロイ状況」 table の 単発「削除」 column / handler / modal を全削除 (= 削除は EventDetail Delete に集約) |
| (#549) | Quests (portal) | \"ステータス: COMPLETE\" → \"環境ステータス: 起動中\" に競技者語彙化。\`STATUS_PARTICIPANT_LABEL\` で 6 status を「起動準備中/起動中…/起動中/起動失敗/停止中/停止済」に変換。scoring kind 別の「正解/防御中」は (#163) (#164) で別途 |

## Regression 分析

- EventDetail: button onClick / disabled 条件は無変更、表面 wording のみ
- Job Links: link href / encodeURIComponent 同一、visual のみ変更
- ProblemDetail 単発削除撤去: 同 API (\`DELETE /deployments/:jobId\`) は EventDetail の bulk teardown が引き続き使う → API surface は無変更
- Quests: deployment status 生値は不変、表示マッピングのみ。\`STATUS_TYPE\` も同一なので indicator color 同一

## 物理影響

frontend のみ。\`application-admin-console\` / \`participant-portal\` の S3+CloudFront artifact が次 deploy で更新される。CFn / Lambda / DDB / API は **NO-OP**。

## Test plan

- [x] application-admin-console typecheck + vitest → 80/80 passed
- [x] participant-portal typecheck + vitest → 63/63 passed
- [ ] **deploy 後**:
  - EventDetail で \"Deploy\" / \"Delete\" 表示
  - Job Links が link 形式で click 可能と分かる
  - teamLoginKey cell の copy button が動く
  - ProblemDetail に legacy alert / 単発削除 button が無い
  - Quests page で「環境ステータス: 起動中」表示

Closes (#556) (#540) (#541) (#533) (#549) (#554)

🤖 Generated with [Claude Code](https://claude.com/claude-code)