### PR TITLE
fix(#557): bulkTeardownEvent が Event status を TEARDOWN に倒すように (partial)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -129,7 +129,34 @@ export async function bulkTeardownEvent(
     const chunk = entries.slice(i, i + PUT_EVENTS_BATCH);
     putChunks.push(shared.events.send(new PutEventsCommand({ Entries: chunk })));
   }
-  await Promise.all(putChunks);
+
+  // #557: Event status を TEARDOWN に倒す。bulk-deploy が DRAFT → DEPLOYING にする
+  // 対称で、こちらは「終端化中」 marker。`updateEventScheduledStatus` の対と同じ pattern。
+  // ConditionExpression で ARCHIVED は踏み越えない (= 一度 archive 済の event を逆走させない)。
+  // CCF は既に ARCHIVED か行不在 → 触らないだけで成功扱い (handler は GetCommand で確認済)。
+  // PutEvents と並列実行 (互いに依存なし)。
+  const updateStatus = shared.ddb
+    .send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression: "SET #status = :teardown, updatedAt = :now",
+        ConditionExpression: "tenantId = :tenantId AND #status <> :archived",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":teardown": "TEARDOWN",
+          ":archived": "ARCHIVED",
+          ":tenantId": tenantId,
+          ":now": updatedAt,
+        },
+      }),
+    )
+    .catch((err: unknown) => {
+      if (err instanceof Error && err.name !== "ConditionalCheckFailedException") {
+        throw err;
+      }
+    });
+  await Promise.all([...putChunks, updateStatus]);
 
   return { kind: "ok", result: { eventId, enqueued: entries.length, skipped } };
 }

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -78,11 +78,22 @@ describe("bulkTeardownEvent", () => {
     const updateCmds = ddbSend.mock.calls
       .map((c) => c[0])
       .filter((c): c is UpdateCommand => c instanceof UpdateCommand);
-    expect(updateCmds).toHaveLength(2);
-    for (const cmd of updateCmds) {
-      expect(cmd.input.ExpressionAttributeValues?.[":deleting"]).toBe("DELETING");
+    // 2 deployment updates (DELETING) + 1 Event status update (TEARDOWN, #557)
+    expect(updateCmds).toHaveLength(3);
+    const depUpdates = updateCmds.filter(
+      (c) => c.input.ExpressionAttributeValues?.[":deleting"] === "DELETING",
+    );
+    expect(depUpdates).toHaveLength(2);
+    for (const cmd of depUpdates) {
       expect(cmd.input.ConditionExpression).toContain("tenantId = :tenantId");
     }
+    // #557: Event status TEARDOWN への遷移を pin
+    const eventStatusUpdate = updateCmds.find(
+      (c) => c.input.ExpressionAttributeValues?.[":teardown"] === "TEARDOWN",
+    );
+    expect(eventStatusUpdate).toBeDefined();
+    expect(eventStatusUpdate?.input.ConditionExpression).toContain("#status <> :archived");
+    expect(eventStatusUpdate?.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
 
     const putCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
     expect(putCmd.input.Entries).toHaveLength(2);
@@ -141,6 +152,9 @@ describe("bulkTeardownEvent", () => {
 
   it("ConditionalCheckFailed (並行更新) は skip して例外を伝播しないべき", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
+    // Event status update (= 後続の 4th call) は通常 success を返す fallback。
+    // #557 で 1 deployment + Event status の 2 件目 UpdateCommand が増えたため。
+    ddbSend.mockResolvedValue({});
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: [dep()] });
     ddbSend.mockImplementationOnce(async (cmd) => {
@@ -155,6 +169,32 @@ describe("bulkTeardownEvent", () => {
     const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
     expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 1 } });
     expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("Event status update が CCF (= ARCHIVED 等) でも例外を伝播せず deployment 削除は完了するべき (#557)", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent({ status: "ARCHIVED" }) });
+    // GetCommand 後の "ARCHIVED" 判定は handler では行わないので Query へ進む。
+    ddbSend.mockResolvedValueOnce({ Items: [dep()] });
+    // deployment update success
+    ddbSend.mockResolvedValueOnce({});
+    eventsSend.mockResolvedValue({});
+    // Event status update で CCF を投げる (= ARCHIVED から踏み越えられない条件)
+    ddbSend.mockImplementationOnce(async (cmd) => {
+      if (
+        cmd instanceof UpdateCommand &&
+        cmd.input.ExpressionAttributeValues?.[":teardown"] === "TEARDOWN"
+      ) {
+        const err: Error & { name?: string } = new Error("archived");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      }
+      return {};
+    });
+
+    const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    // handler は正常に完了 (= deployment は DELETING に倒した)
+    expect(out.kind).toBe("ok");
   });
 
   it("Deployments query は GSI1 (TENANT) を引いて in-memory で eventId フィルタするべき", async () => {


### PR DESCRIPTION
dogfood: 「Delete」 (= 旧 Bulk Teardown) を押した後も Event status が DEPLOYING のまま動かず、operator が「片付いた」と判断する経路が無くなっていた。

## 設計判断

bulk-deploy.ts の symmetric pattern と揃える。bulk-deploy が \`DRAFT/READY/DEPLOYING → DEPLOYING\` にするのと同じ流儀で、bulk-delete も \`(not ARCHIVED) → TEARDOWN\` に倒す。ConditionalCheckFailedException は「既に ARCHIVED」or「行不在」だが handler 上は Get で確認済なので前者扱いで silent skip。

PutEvents (= EventBridge publish) と \`Promise.all\` で並列実行する点も bulk-deploy と同じ (= 書き込み先が別 service、互いに依存無し)。

## 変更点

- \`bulk-delete.ts\`: \`Promise.all([...putChunks, updateStatus])\` に Event status update 追加
- \`event-bulk-delete.test.ts\`: 正常系を \`:deleting\` フィルタで pin。Event status update が同時に走ることを別 assertion で pin。CCF (ARCHIVED 等) で例外伝播しない test ケース追加

## 残課題 (= 別 PR で扱う)

- (#539) Bulk Deploy 完了後の auto-transition \`DEPLOYING → READY\` (= 全 deployment 終端時)
- (#557 残部) \`TEARDOWN → ARCHIVED\` の auto-transition (= 全 deployment DELETED 時)

両方とも HealthCheck Lambda の 1 分周期 tick で reconcile loop を回す設計が筋。\`eventsTable\` R/W 権限 + \`EVENTS_TABLE_NAME\` env + reconciler 関数の 3 点が必要で、本 PR とは別 scope。

## 物理影響

- \`event-handler\` Lambda: 1 update 追加。bulk-delete は元々 PutEvents を投げるので EventBridge 課金には影響なし
- CFn / IAM / table / API GW resource は **NO-OP**
- event-handler は既に Events table R/W 権限を持つので追加 grant 不要

## Test plan

- [x] \`bunx vitest run test/problem-deploy/event-bulk-delete.test.ts\` → 8/8 passed
- [ ] **deploy 後**: EventDetail で「Delete」 click 直後に status badge が TEARDOWN (赤) に切り替わる

Closes (#557) (partial)
Relates (#539)

🤖 Generated with [Claude Code](https://claude.com/claude-code)