### PR TITLE
docs: Issue 引用は Closes #N に統一 (= GitHub auto-close を機能させる)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,20 @@ end-user / operator が確認できる振る舞い。
 
 <!-- 2-3 文。無いと何に困るか、他の解との比較、優先度の根拠 -->
 
+## 関連 Issue
+
+<!--
+GitHub の auto-close keyword (= `Closes #N` / `Fixes #N` / `Resolves #N`) を **括弧なし** で
+書く。`(#N)` のように括弧で囲むと auto-close されない (= merge 後も Issue が開いたまま残る、
+手動で close 漏れの原因)。複数 issue は別行に書く。
+
+partial fix で issue を残したい場合は `Relates #N` (= auto-close されない) を使う。
+全 close 不要な PR (refactor / docs / chore 等) はこのセクションごと削除可。
+-->
+
+- Closes #
+- Relates #
+
 ## 変更前 → 変更後のフロー
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,13 +56,16 @@ CI (`.github/workflows/ci.yml`) は `make install_ci` → textlint → format ch
 - **マージ済みブランチに push しない**。PR を出す前に必ず `gh pr view --json state` で state を確認。`MERGED` / `CLOSED` なら新ブランチを切る。
 - 小さな意味単位で PR を分ける。`feat(...)` `fix(...)` `refactor(...)` `docs(...)` `test(...)` `chore(...)` のいずれか (Conventional Commits)。
 - PR タイトルは 70 文字以内。本文に Summary + Test plan を書く。
-- コミット / PR で `#番号` 形式の Issue 引用は **禁止** (auto-close されるため)。`(PR-F1)` `(#446)` 等の別記法を使う。
+- Issue 引用は GitHub の auto-close keyword に揃える:
+  - **解決して閉じる** = `Closes #553` / `Fixes #553` / `Resolves #553` (= merge 時に GitHub が auto-close)
+  - **関連だが閉じない (= partial fix / backlink)** = `Relates #553` または非 keyword 位置で `#553` を書く
+  - **PR 同士の参照** = `PR-565` のように番号 prefix
+  - 旧ルール (= `(#N)` の括弧で auto-close 抑止) は誤解だった。`Closes` などの keyword が無ければ `#N` 単独で auto-close されない (= backlink のみ作る)。
 
 ## 禁止事項
 
 - `npx` → `bunx` または `nlx`
 - `rm` (環境破壊リスク) → `git rm`
-- `#番号` 形式の Issue 引用 (本文・コミット message)
 - モック / スタブで握り潰す fallback / 空配列を返して見せかける処理
 - 設定ファイル (`biome.json`, `vitest.config.*`, `tsconfig.json`) の直接編集
 - DynamoDB の on-demand (`PAY_PER_REQUEST`) 化 — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED 強制

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,13 +130,19 @@ describe("AdminConsoleHostingStack", () => {
 
 ### Issue 引用ルール
 
-コミットや PR 本文で `#番号` 形式は使わない（auto-close されてしまうので）。代わりに `(PR-F1)` `(#446)` のようにスペース区切りや別記法で指す。
+GitHub の auto-close keyword は **括弧なし** で書く。
+
+- **解決して issue を閉じる** = `Closes #553` / `Fixes #553` / `Resolves #553` (= merge 時に auto-close)
+- **関連だが閉じない (= partial fix / 単なる backlink)** = `Relates #553` または本文中で `#553` を非 keyword 位置で言及
+- **PR 同士の参照** = `PR-565` のように番号 prefix で書く (issue 番号と区別)
+
+旧ルール (= `(#N)` の括弧で囲って auto-close を抑止) は仕様誤解だった。`Closes` などの
+keyword が無ければ `#N` 単独でも auto-close されない (= backlink のみ作る)。
 
 ## 禁止事項
 
 - **`npx` 禁止** → `bunx` または `nlx` を使う
 - **`rm` コマンド禁止** → ファイル削除は `git rm` 経由で扱う
-- **コミット / PR で `#番号` 形式の Issue 引用禁止** — 自動クローズ防止
 - **モック / スタブで握り潰す fallback 禁止** — 失敗するなら明示的に失敗させる
 - **DynamoDB を on-demand (PAY_PER_REQUEST) で立てない** — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED に強制している。これを破る変更は CFn 出力で必ず引っかかる
 - **設定ファイル (`biome.json`, 各 `vitest.config.ts`, `tsconfig.json`) の直接変更禁止** — コード側を修正する


### PR DESCRIPTION
dogfood: 直近 7 PR (565-571) を merge したのに 13 件の Issue が手動 close 待ちで残った。原因は PR 本文 / CLAUDE.md / AGENTS.md の旧ルールが「\`#N\` 形式は auto-close されるので括弧で囲って抑止」と書いていたが、実際の GitHub 仕様では \`Closes\` / \`Fixes\` / \`Resolves\` などの keyword + \`#N\` だけが auto-close 対象。括弧 \`(#N)\` も裸の \`#N\` も keyword 無しなら backlink のみで close されない。

= 旧ルールは GitHub 仕様の誤解。\`Closes #N\` を **書きたいのに書けない** 状態だった。

## 変更点

| 場所 | 変更 |
|---|---|
| \`.github/PULL_REQUEST_TEMPLATE.md\` | 「関連 Issue」 section を追加し \`Closes #\` / \`Relates #\` の使い分けを明記 |
| \`CLAUDE.md\` | 「Issue 引用ルール」を書き換え。auto-close は \`Closes #N\` (括弧なし)、partial / backlink は \`Relates #N\`。旧誤解の説明も明記 |
| \`AGENTS.md\` | 同上の書き換え。禁止事項から「#番号禁止」項を削除 |

## Regression 分析

| # | 壊しうる挙動 | 確認 | 対処 |
|---|---|---|---|
| 1 | 既存 merged PR (565-571) の body は \`(#N)\` 形式 → 影響なし (= 既に手動 close 済) | ✅ | 13 件を \`gh issue close\` で手動 close 済 |
| 2 | open PR (#570) の body も \`(#N)\` 形式 → 影響なし (= 仕様上 auto-close されない) | ✅ | partial 扱いなので手動 close でよい |
| 3 | 今後の PR で \`Closes #N\` を書くと auto-close 発火する | ✅ | これが意図 |

## 物理影響

docs / template のみ。CFn / Lambda / DDB / API / build artifact は **NO-OP**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)