### PR TITLE
fix(#557 #539): Event status auto-transition reconciler (HealthCheck Lambda)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -1,5 +1,10 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
 import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
@@ -24,6 +29,7 @@ import { writeScoreEvent } from "../shared/score-event.js";
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 // 遅延 lookup: module load 時に env が無くても import がコケない (test 互換)。
 const tableName = (): string => getEnv("DEPLOYMENTS_TABLE_NAME");
+const eventsTableName = (): string => getEnv("EVENTS_TABLE_NAME");
 
 const PROBE_TIMEOUT_MS = 8_000;
 
@@ -156,8 +162,145 @@ function buildHealthUpdate(
   });
 }
 
+/**
+ * #557 / #539: Event status の auto-transition 判定 (pure function、test-friendly)。
+ *
+ * - `DEPLOYING`: 子 deployment が **全て terminal** (`COMPLETE` / `FAILED`) → `READY`。
+ *   1 件でも進行中 (`PENDING` / `IN_PROGRESS`) があれば `undefined` (= 触らない)。
+ * - `TEARDOWN`: 子 deployment が **全て終端** (`DELETED` / `FAILED`) → `ARCHIVED`。
+ *   `DELETING` が残っていれば `undefined`。
+ * - 子 deployment 0 件: `undefined` (= bulk-deploy/bulk-delete 前の race state、触らない)。
+ * - その他 status (`DRAFT` / `READY` / `ENDED` / `ARCHIVED`): caller でフィルタ済前提だが
+ *   defense-in-depth で `undefined`。
+ *
+ * `FAILED` を terminal に含む理由: deploy が失敗した行も「これ以上進行しない」状態なので
+ * Event 全体としては前進可能 (= operator 視点で再実行 or skip 判断)。同様に teardown 失敗も
+ * 引きずらない (= 最終手段は operator 手動削除)。
+ */
+export function resolveEventStatusTransition(
+  eventStatus: string,
+  deploymentStatuses: readonly string[],
+): "READY" | "ARCHIVED" | undefined {
+  if (deploymentStatuses.length === 0) return undefined;
+  if (eventStatus === "DEPLOYING") {
+    const allTerminal = deploymentStatuses.every((s) => s === "COMPLETE" || s === "FAILED");
+    return allTerminal ? "READY" : undefined;
+  }
+  if (eventStatus === "TEARDOWN") {
+    const allDone = deploymentStatuses.every((s) => s === "DELETED" || s === "FAILED");
+    return allDone ? "ARCHIVED" : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Events table を scan して `DEPLOYING` / `TEARDOWN` 状態の Event について、
+ * 子 deployment 集約 status を見て `READY` / `ARCHIVED` に遷移させる (#557 #539)。
+ *
+ * 各 Event の判定は **並列**: 1 件遅い tenant が他を block しない。Update が CCF
+ * (= operator 手動遷移などの race) で失敗した行は silent skip (= 次の tick で再評価)。
+ *
+ * Scan limit 100: TenkaCloud MVP 規模 (events ~10 件 / tenant、~5 tenants) で 1 tick で
+ * 全件処理できる範囲。Phase 2+ で増えたら GSI3 (PK=STATUS) で query 化を検討。
+ */
+export async function reconcileEventStatuses(nowIso: string): Promise<void> {
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: eventsTableName(),
+        ProjectionExpression: "PK, tenantId, eventId, #status",
+        ExpressionAttributeNames: { "#status": "status" },
+        FilterExpression: "#status = :deploying OR #status = :teardown",
+        ExpressionAttributeValues: {
+          ":deploying": "DEPLOYING",
+          ":teardown": "TEARDOWN",
+        },
+        Limit: 100,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    const items = (out.Items ?? []) as Array<{
+      PK?: string;
+      tenantId?: string;
+      eventId?: string;
+      status?: string;
+    }>;
+
+    await Promise.all(
+      items.map(async (event) => {
+        if (!event.tenantId || !event.eventId || !event.status || !event.PK) return;
+        // 子 deployments を GSI1 (TENANT#) で query → 同 event のものに in-memory filter。
+        const depsOut = await ddb.send(
+          new QueryCommand({
+            TableName: tableName(),
+            IndexName: "GSI1",
+            KeyConditionExpression: "GSI1PK = :pk",
+            FilterExpression: "eventId = :ev",
+            ProjectionExpression: "#status",
+            ExpressionAttributeNames: { "#status": "status" },
+            ExpressionAttributeValues: {
+              ":pk": `TENANT#${event.tenantId}`,
+              ":ev": event.eventId,
+            },
+          }),
+        );
+        const depStatuses = (depsOut.Items ?? [])
+          .map((d) => String((d as { status?: string }).status ?? ""))
+          .filter((s) => s.length > 0);
+        const next = resolveEventStatusTransition(event.status, depStatuses);
+        if (!next) return;
+
+        try {
+          await ddb.send(
+            new UpdateCommand({
+              TableName: eventsTableName(),
+              Key: { PK: event.PK, SK: "META" },
+              UpdateExpression: "SET #status = :next, updatedAt = :now",
+              // race 防止: 期待 current status と一致しているときのみ更新 (= operator が
+              // 手動 archive / 再 deploy で先に動かしてたら CCF で skip)。
+              ConditionExpression: "tenantId = :tenant AND #status = :current",
+              ExpressionAttributeNames: { "#status": "status" },
+              ExpressionAttributeValues: {
+                ":tenant": event.tenantId,
+                ":current": event.status,
+                ":next": next,
+                ":now": nowIso,
+              },
+            }),
+          );
+          console.log("[health-check] Event status auto-transition", {
+            eventId: event.eventId,
+            from: event.status,
+            to: next,
+          });
+        } catch (err) {
+          const code = (err as { name?: string })?.name ?? "";
+          if (code === "ConditionalCheckFailedException") return;
+          console.warn("[health-check] Event status update failed", {
+            eventId: event.eventId,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+}
+
 export async function handler(): Promise<void> {
   const scoringMap = parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING);
+  const nowIso = new Date().toISOString();
+
+  // Event 状態 reconcile (#557 #539) と uptime 採点を並列実行。互いに依存なし、
+  // 別 table / 別 row を触るので race も無い。reconcile 失敗が scoring を巻き込まない
+  // よう catch して log に残す (1 tick の失敗は次 tick で再評価される)。
+  const reconcilePromise = reconcileEventStatuses(nowIso).catch((err) => {
+    console.warn("[health-check] reconcileEventStatuses failed", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+  });
 
   let exclusiveStartKey: Record<string, unknown> | undefined;
   do {
@@ -173,7 +316,6 @@ export async function handler(): Promise<void> {
     );
     const items = (out.Items ?? []) as Partial<DeploymentItem>[];
 
-    const nowIso = new Date().toISOString();
     // 全 deployment を **並列** に check する。Lambda timeout 2 min 内に収まるよう、
     // sequential だと N × PROBE_TIMEOUT_MS で容易に超過する。1 deployment 失敗が
     // 他に波及しないよう catch して log に残す。
@@ -196,6 +338,10 @@ export async function handler(): Promise<void> {
     );
     exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
+
+  // reconcile を最後に await して invocation 終了前に確実に完了させる
+  // (= Lambda が return すると未完了 Promise が中断される)。
+  await reconcilePromise;
 }
 
 export { joinUrl };

--- a/infrastructure/lib/problem-deploy/health-check-lambda.ts
+++ b/infrastructure/lib/problem-deploy/health-check-lambda.ts
@@ -10,21 +10,30 @@ import { Construct } from "constructs";
 export interface HealthCheckLambdaProps {
   readonly deploymentsTable: ITable;
   /**
+   * Events table。Event status の auto-transition (#557 / #539) を 1-min tick で reconcile する。
+   * uptime 採点とは独立の責務だが、cron schedule (= rate(1 minute)) を共有することで
+   * Lambda 数 / EventBridge rule 数を抑える (Free Tier 維持)。
+   */
+  readonly eventsTable: ITable;
+  /**
    * `{ [problemId]: scoring }` 形の scoring 設定。`uptime` 形式の問題のみが probe 対象。
    */
   readonly problemsScoring: Readonly<Record<string, unknown>>;
 }
 
 /**
- * 問題が deploy された後、定期的にエンドポイントを probe してスコアを加減する Lambda。
+ * 1 分間隔で 2 つの reconcile 処理を回す Lambda:
  *
- * EventBridge `rate(1 minute)` で定期起動され、Deployments DDB を scan して
- * `status=COMPLETE` の各 deployment について metadata の `scoring.kind=uptime` を
- * 確認、declared endpoints を fetch し、すべて 2xx (or expectStatus) なら
- * `score += pointsPerSuccess`、失敗なら `lastResult=fail` のみ更新する。
+ * 1. **uptime 採点** (`scoring.kind=uptime` の問題のみ): Deployments DDB を scan し
+ *    `status=COMPLETE` 行の endpoints を probe、成功なら `score += pointsPerSuccess`。
+ *    MVP-1 規模 (~50 deployments) は Scan + FilterExpression で十分。Phase 2 で 100+ に
+ *    なったら GSI3 (PK=STATUS#{status}) を追加して Query 化する。
+ * 2. **Event status auto-transition** (#557 #539): Events DDB を scan し `DEPLOYING` /
+ *    `TEARDOWN` 状態の Event について子 deployments の集約 status を見て `READY` /
+ *    `ARCHIVED` に遷移。子 deployment が全 terminal で初めて遷移する設計。
  *
- * MVP-1 規模 (~50 deployments) は Scan + FilterExpression で十分。Phase 2 で
- * 100+ になったら GSI3 (PK=STATUS#{status}) を追加して Query 化する。
+ * 両方とも EventBridge `rate(1 minute)` で起動。互いに依存なし (= 別 table / 別 row)
+ * なので Promise.all で並列実行できる。
  */
 export class HealthCheckLambda extends Construct {
   public readonly fn: NodejsFunction;
@@ -41,6 +50,7 @@ export class HealthCheckLambda extends Construct {
       memorySize: 256,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        EVENTS_TABLE_NAME: props.eventsTable.tableName,
         BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
         NODE_OPTIONS: "--enable-source-maps",
       },
@@ -54,12 +64,15 @@ export class HealthCheckLambda extends Construct {
 
     // Lambda が deployments table を Scan + UpdateItem できるよう許可。
     props.deploymentsTable.grantReadWriteData(this.fn);
+    // Events table も同様: Scan で DEPLOYING / TEARDOWN 行を拾い、ConditionExpression 付き
+    // UpdateItem で次状態 (READY / ARCHIVED) に遷移させる (#557 #539)。
+    props.eventsTable.grantReadWriteData(this.fn);
 
     // EventBridge `rate(1 minute)`. Lambda 自身に invoke 権限は LambdaFunction target が
     // 自動付与する。
     new Rule(this, "Schedule", {
       schedule: Schedule.rate(Duration.minutes(1)),
-      description: "TenkaCloud uptime scoring health check (1 minute interval).",
+      description: "TenkaCloud 1-min tick: uptime scoring + Event status reconcile (#557 #539).",
       targets: [new LambdaFunction(this.fn)],
     });
   }

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -147,14 +147,17 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       stateMachine: deleteStateMachine.stateMachine,
     });
 
-    // 1 分間隔で uptime 採点する Health Check Lambda。`scoring.kind=uptime` の問題のみが
-    // 対象。`flag` 形式は Portal Lambda が submit-flag 経路で採点するため別系統。
-    if (Object.keys(props.problemsScoring).length > 0) {
-      new HealthCheckLambda(this, "HealthCheck", {
-        deploymentsTable: deployments.table,
-        problemsScoring: props.problemsScoring,
-      });
-    }
+    // 1 分間隔の Health Check Lambda は 2 つの責務を持つ:
+    // - uptime 採点 (`scoring.kind=uptime` の問題のみ)。`flag` 形式は Portal Lambda の
+    //   submit-flag 経路で採点するため別系統。
+    // - Event status auto-transition (#557 #539): DEPLOYING→READY / TEARDOWN→ARCHIVED。
+    //   uptime 問題が無い tenant でも reconcile は要るので **常に instantiate** (= 旧
+    //   `if (problemsScoring.length > 0)` ガードは撤去)。
+    new HealthCheckLambda(this, "HealthCheck", {
+      deploymentsTable: deployments.table,
+      eventsTable: events.table,
+      problemsScoring: props.problemsScoring,
+    });
 
     if (props.participantPortal) {
       const consoleViewerRole = new ConsoleViewerRole(this, "ConsoleViewerRole");

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -107,8 +107,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(synthJson).toContain("IN_PROGRESS");
     });
 
-    it("EventBridge Rule を Create / Delete でそれぞれ 1 つずつ持つべき", () => {
-      tpl.resourceCountIs("AWS::Events::Rule", 2);
+    it("EventBridge Rule を Create / Delete / HealthCheck schedule で 3 つ持つべき", () => {
+      // 旧 2 (Create / Delete state-machine event rules) + HealthCheck schedule rate(1 min)
+      // = 3。HealthCheck は #557 / #539 reconciler で uptime 採点とは独立に常時 instantiate
+      // される (= 旧「scoring 0 件なら skip」ガード撤去)。
+      tpl.resourceCountIs("AWS::Events::Rule", 3);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -125,6 +128,13 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
             source: ["tenkacloud.deploy"],
             "detail-type": ["DeployDeleteRequested"],
           }),
+        }),
+      );
+      // HealthCheck の rate(1 minute) schedule (= #557 #539 reconciler + uptime 採点)
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          ScheduleExpression: "rate(1 minute)",
         }),
       );
     });

--- a/infrastructure/test/problem-deploy/health-check-reconcile.test.ts
+++ b/infrastructure/test/problem-deploy/health-check-reconcile.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #557 / #539: HealthCheck Lambda の Event status auto-transition reconciler の test。
+ *
+ * 2 階層に分けて test する:
+ *   1. `resolveEventStatusTransition` (pure function、入出力のみ) — 8 ケース
+ *   2. `reconcileEventStatuses` (DDB mock 越し) — Scan → Query × N → conditional Update の
+ *      シーケンスを pin
+ *
+ * mock した DDB に対して Scan / Query / Update Command を発行する順序と引数を assert する。
+ */
+
+const ddbSend = vi.fn();
+
+vi.mock("@aws-sdk/lib-dynamodb", async () => {
+  const actual =
+    await vi.importActual<typeof import("@aws-sdk/lib-dynamodb")>("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: () => ({ send: ddbSend }),
+    },
+  };
+});
+
+// env を読む関数は遅延 lookup なので、module load 時に env が無くてもよい。test 内で set。
+process.env.DEPLOYMENTS_TABLE_NAME = "TestDeployments";
+process.env.EVENTS_TABLE_NAME = "TestEvents";
+
+const { reconcileEventStatuses, resolveEventStatusTransition } = await import(
+  "../../lib/problem-deploy/handlers/health-check-handler/index"
+);
+
+describe("resolveEventStatusTransition (#557 #539 pure logic)", () => {
+  it("DEPLOYING + 全 COMPLETE → READY", () => {
+    expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "COMPLETE"])).toBe("READY");
+  });
+
+  it("DEPLOYING + COMPLETE/FAILED 混在 → READY (FAILED も terminal 扱い)", () => {
+    expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "FAILED", "COMPLETE"])).toBe(
+      "READY",
+    );
+  });
+
+  it("DEPLOYING + PENDING が 1 件でも残る → undefined (= まだ動かさない)", () => {
+    expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "PENDING"])).toBeUndefined();
+  });
+
+  it("DEPLOYING + IN_PROGRESS が残る → undefined", () => {
+    expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "IN_PROGRESS"])).toBeUndefined();
+  });
+
+  it("TEARDOWN + 全 DELETED → ARCHIVED", () => {
+    expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "DELETED"])).toBe("ARCHIVED");
+  });
+
+  it("TEARDOWN + DELETED/FAILED 混在 → ARCHIVED (= teardown 失敗行も引きずらない)", () => {
+    expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "FAILED"])).toBe("ARCHIVED");
+  });
+
+  it("TEARDOWN + DELETING が残る → undefined (= まだ削除中)", () => {
+    expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "DELETING"])).toBeUndefined();
+  });
+
+  it("子 deployment 0 件 → undefined (= bulk-deploy/delete 前の race state、触らない)", () => {
+    expect(resolveEventStatusTransition("DEPLOYING", [])).toBeUndefined();
+    expect(resolveEventStatusTransition("TEARDOWN", [])).toBeUndefined();
+  });
+
+  it("対象外 status (DRAFT / READY / ENDED / ARCHIVED) は defense-in-depth で undefined", () => {
+    expect(resolveEventStatusTransition("DRAFT", ["COMPLETE"])).toBeUndefined();
+    expect(resolveEventStatusTransition("READY", ["COMPLETE"])).toBeUndefined();
+    expect(resolveEventStatusTransition("ENDED", ["DELETED"])).toBeUndefined();
+    expect(resolveEventStatusTransition("ARCHIVED", ["DELETED"])).toBeUndefined();
+  });
+});
+
+const NOW_ISO = "2026-05-11T00:00:00.000Z";
+
+describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
+  beforeEach(() => ddbSend.mockReset());
+  afterEach(() => ddbSend.mockReset());
+
+  it("DEPLOYING で子 deployments 全 COMPLETE → Update で READY に遷移", async () => {
+    // 1. Scan Events: 1 件 DEPLOYING を返す
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "EVENT#EV1", tenantId: "tenant-acme", eventId: "EV1", status: "DEPLOYING" }],
+      LastEvaluatedKey: undefined,
+    });
+    // 2. Query Deployments: 2 件 COMPLETE
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "COMPLETE" }, { status: "COMPLETE" }],
+    });
+    // 3. Update Events: 成功
+    ddbSend.mockResolvedValueOnce({});
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    expect(ddbSend).toHaveBeenCalledTimes(3);
+    const updateCmd = ddbSend.mock.calls[2]?.[0] as {
+      input: {
+        UpdateExpression: string;
+        ConditionExpression: string;
+        ExpressionAttributeValues: Record<string, string>;
+      };
+    };
+    expect(updateCmd.input.UpdateExpression).toContain("SET #status = :next");
+    expect(updateCmd.input.ExpressionAttributeValues[":next"]).toBe("READY");
+    expect(updateCmd.input.ExpressionAttributeValues[":current"]).toBe("DEPLOYING");
+    expect(updateCmd.input.ConditionExpression).toContain("tenantId = :tenant");
+    expect(updateCmd.input.ConditionExpression).toContain("#status = :current");
+  });
+
+  it("TEARDOWN で子 deployments 全 DELETED → Update で ARCHIVED に遷移", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "EVENT#EV2", tenantId: "tenant-acme", eventId: "EV2", status: "TEARDOWN" }],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "DELETED" }, { status: "DELETED" }, { status: "DELETED" }],
+    });
+    ddbSend.mockResolvedValueOnce({});
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    const updateCmd = ddbSend.mock.calls[2]?.[0] as {
+      input: { ExpressionAttributeValues: Record<string, string> };
+    };
+    expect(updateCmd.input.ExpressionAttributeValues[":next"]).toBe("ARCHIVED");
+    expect(updateCmd.input.ExpressionAttributeValues[":current"]).toBe("TEARDOWN");
+  });
+
+  it("DEPLOYING で PENDING が残る → Update を発行しない (= まだ READY ではない)", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "EVENT#EV3", tenantId: "tenant-acme", eventId: "EV3", status: "DEPLOYING" }],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "COMPLETE" }, { status: "PENDING" }],
+    });
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    // 2 calls (Scan + Query)。Update は走らない
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("複数 Event を **並列** に処理する (= 1 件遅延が他を block しない)", async () => {
+    // Scan: 2 Event (DEPLOYING + TEARDOWN、それぞれ READY / ARCHIVED 候補)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "EVENT#A", tenantId: "tenant-acme", eventId: "A", status: "DEPLOYING" },
+        { PK: "EVENT#B", tenantId: "tenant-acme", eventId: "B", status: "TEARDOWN" },
+      ],
+    });
+    // Query を Command 内容で出し分け: Event A は COMPLETE、Event B は DELETED
+    ddbSend.mockImplementation(
+      async (cmd: { input?: { ExpressionAttributeValues?: Record<string, string> } }) => {
+        const ev = cmd.input?.ExpressionAttributeValues?.[":ev"];
+        if (ev === "A") return { Items: [{ status: "COMPLETE" }] };
+        if (ev === "B") return { Items: [{ status: "DELETED" }] };
+        return {}; // Update 等の他 command は無事返す
+      },
+    );
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    // 1 Scan + 2 Query + 2 Update = 5 calls (= 並列 fan-out が走った証拠)
+    expect(ddbSend).toHaveBeenCalledTimes(5);
+  });
+
+  it("Event 更新の CCF (= operator race) は throw せず silent skip", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "EVENT#EV4", tenantId: "tenant-acme", eventId: "EV4", status: "DEPLOYING" }],
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ status: "COMPLETE" }] });
+    // Update が CCF を throw — race 状態
+    ddbSend.mockImplementationOnce(async () => {
+      const err: Error & { name?: string } = new Error("conditional check failed");
+      err.name = "ConditionalCheckFailedException";
+      throw err;
+    });
+
+    // 例外が外に漏れずに完了する
+    await expect(reconcileEventStatuses(NOW_ISO)).resolves.toBeUndefined();
+  });
+
+  it("Scan が pagination する (= LastEvaluatedKey 有り → 次 Scan)", async () => {
+    // 1 ページ目: 1 Event + LastEvaluatedKey 有り
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ PK: "EVENT#P1", tenantId: "t", eventId: "P1", status: "DEPLOYING" }],
+      LastEvaluatedKey: { PK: "cursor" },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ status: "COMPLETE" }] });
+    ddbSend.mockResolvedValueOnce({}); // Update
+    // 2 ページ目: 0 件 + LastEvaluatedKey 無し
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    // 1 Scan + 1 Query + 1 Update + 1 Scan = 4 calls
+    expect(ddbSend).toHaveBeenCalledTimes(4);
+    // 2 回目 Scan の ExclusiveStartKey が 1 回目の LastEvaluatedKey と一致
+    const scan2 = ddbSend.mock.calls[3]?.[0] as {
+      input: { ExclusiveStartKey?: Record<string, unknown> };
+    };
+    expect(scan2.input.ExclusiveStartKey).toEqual({ PK: "cursor" });
+  });
+
+  it("Event filter は DEPLOYING または TEARDOWN のみ (= READY / ENDED は触らない)", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    await reconcileEventStatuses(NOW_ISO);
+
+    const scanCmd = ddbSend.mock.calls[0]?.[0] as {
+      input: {
+        FilterExpression: string;
+        ExpressionAttributeValues: Record<string, string>;
+      };
+    };
+    expect(scanCmd.input.FilterExpression).toBe("#status = :deploying OR #status = :teardown");
+    expect(scanCmd.input.ExpressionAttributeValues[":deploying"]).toBe("DEPLOYING");
+    expect(scanCmd.input.ExpressionAttributeValues[":teardown"]).toBe("TEARDOWN");
+  });
+});


### PR DESCRIPTION
PR-569 で bulk-delete が Event status を TEARDOWN に倒す同期部分は入った。本 PR は残りの **async 部分**:

- **#539** DEPLOYING → READY (= 全 deployment が COMPLETE/FAILED で terminal)
- **#557** TEARDOWN → ARCHIVED (= 全 deployment が DELETED/FAILED で terminal)

を HealthCheck Lambda の 1-min tick に乗せて reconcile する。

## 設計判断

別 Lambda を立てず、既存 HealthCheck (= \`rate(1 minute)\` uptime 採点 cron) に相乗りする:
- EventBridge rule / Lambda が増えない (Free Tier 維持)
- 同 cron 周期で十分 (= operator 視点で「数分以内に status が動く」体感)
- uptime 採点との依存なし (= 別 table、別 row、\`Promise.all\` で並列実行)

旧「scoring 0 件なら HealthCheck instantiate しない」ガードは撤去。reconciler は uptime 問題が無い tenant でも必要なので **常に instantiate**。

## resolveEventStatusTransition (pure function)

\`\`\`
DEPLOYING + 全 [COMPLETE|FAILED]   → READY
TEARDOWN  + 全 [DELETED|FAILED]    → ARCHIVED
それ以外 (PENDING/IN_PROGRESS/DELETING が残る or 子 0 件) → undefined (touch しない)
\`\`\`

FAILED を terminal に含める理由: deploy 失敗行も「これ以上動かない」状態なので Event 全体は前進可能 (= operator 視点で再 deploy or skip 判断)。teardown 失敗も同様に引きずらない。

## reconcileEventStatuses (DDB integration)

1. Scan Events (\`#status IN (DEPLOYING, TEARDOWN)\`、Limit 100、pagination 対応)
2. \`Promise.all\` で各 Event を並列処理:
   - Query Deployments by GSI1 (\`TENANT#\`) + FilterExpression eventId
   - resolveEventStatusTransition で次状態決定
   - ConditionExpression (\`#status = :current\`) 付き Update → race で CCF は silent skip

## 変更点

| 場所 | 変更 |
|---|---|
| \`health-check-handler/index.ts\` | resolveEventStatusTransition + reconcileEventStatuses 追加。handler() は scoring loop と並列発火 |
| \`health-check-lambda.ts\` | \`eventsTable\` prop 追加 + \`EVENTS_TABLE_NAME\` env + grantReadWriteData |
| \`problem-deploy-backend-stack.ts\` | HealthCheck の scoring-only ガード撤去、events.table を渡す |
| \`test/problem-deploy/health-check-reconcile.test.ts\` 新規 | 16 tests (pure 9 + integration 7) |
| \`test/problem-deploy-backend-stack.test.ts\` | EventBridge Rule 数 2 → 3 を pin |

## Regression 分析

| # | 壊しうる挙動 | 確認 | 対処 |
|---|---|---|---|
| 1 | uptime scoring loop | ✅ | scan/probe/update path 無変更、reconcile は別 path で並列発火 |
| 2 | scoring 0 件の tenant | ✅ | 旧: Lambda 非 instantiate → 新: 常時 instantiate (cost: 1 min × 1 Lambda invoke ≈ Free Tier 内) |
| 3 | operator が手動で status を動かす race | ✅ | ConditionExpression で CCF → silent skip、test で pin |
| 4 | bulk-delete の TEARDOWN 遷移 (PR-569) | ✅ | reconciler は TEARDOWN を読んで ARCHIVED に進めるだけ |
| 5 | 既存 tests | ✅ | EventBridge Rule 数 expected 2 → 3 に test 更新 |

## 物理影響

| 場所 | 種別 | 影響 |
|---|---|---|
| HealthCheck Lambda env | UPDATE | \`EVENTS_TABLE_NAME\` 追加 |
| HealthCheck Lambda IAM | UPDATE | Events table への ReadWriteData grant 追加 (Scan / UpdateItem / Query) |
| HealthCheck Lambda schedule rule description | UPDATE | text のみ |
| HealthCheck Lambda instantiation guard | UPDATE | scoring 0 件でも instantiate されるようになる |

## Test plan

- [x] vitest infra → **40 files / 373/373 passed** (= 既存 357 + 新規 16)
- [x] typecheck (4 packages) green
- [x] biome check green
- [x] make check-http-status green
- [ ] **deploy 後**: Bulk Deploy → 全 deployment COMPLETE → 1 min 内に DEPLOYING → READY
- [ ] **deploy 後**: Delete → 全 deployment DELETED → 1 min 内に TEARDOWN → ARCHIVED

Closes #557
Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)