### PR TITLE
feat(ui): 通知の発見性を上げる EventDetail 専用 section (#552)

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -293,17 +293,6 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               Deploy
             </Button>
             <Button
-              disabled={
-                !detail ||
-                detail.status === "DRAFT" ||
-                detail.status === "TEARDOWN" ||
-                detail.status === "ARCHIVED"
-              }
-              onClick={() => setNotifyModalOpen(true)}
-            >
-              通知を送る
-            </Button>
-            <Button
               loading={endInFlight}
               disabled={!detail || detail.status !== "READY"}
               onClick={() => setConfirmEnd(true)}
@@ -394,6 +383,56 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             </Field>
             <Field label="採点ステータス">{scoringBadge(detail.startsAt)}</Field>
           </ColumnLayout>
+        </Container>
+      )}
+
+      {/* #552: 通知の発見性を上げる専用 section。旧 UX では「通知を送る」 button が
+       *   Header actions (= Deploy / Delete 等と同列) に埋もれており、初見 operator から
+       *   見つけにくかった。説明文 + 単独 button にして「通知って何ができる?」が
+       *   1 画面で完結するようにする。過去履歴 list は別 PR で (= GET endpoint が要る)。 */}
+      {detail && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="競技中の全チームの Participant Portal にアナウンスを送ります。Portal の Notifications page に表示され、競技者は赤バッジで未読件数を確認できます。"
+              actions={
+                <Button
+                  variant="primary"
+                  iconName="notification"
+                  disabled={
+                    detail.status === "DRAFT" ||
+                    detail.status === "TEARDOWN" ||
+                    detail.status === "ARCHIVED"
+                  }
+                  onClick={() => setNotifyModalOpen(true)}
+                >
+                  通知を送る
+                </Button>
+              }
+            >
+              通知 (お知らせ)
+            </Header>
+          }
+        >
+          <SpaceBetween size="s">
+            <Box variant="small" color="text-status-inactive">
+              送信タイミング例: 「競技開始 5 分前」「Battle で攻撃検知が増えた」「問題ファイルに
+              typo があった」など。 送信内容は競技者全員に同時配信されます (=
+              チーム選択は不可、ADR-006)。
+            </Box>
+            {detail.status === "DRAFT" && (
+              <Alert type="info">
+                Event 作成直後 (DRAFT) は通知できません。Deploy 後に有効化されます。
+              </Alert>
+            )}
+            {(detail.status === "TEARDOWN" || detail.status === "ARCHIVED") && (
+              <Alert type="info">
+                {detail.status === "TEARDOWN" ? "削除中" : "アーカイブ済"} の Event
+                には通知できません。
+              </Alert>
+            )}
+          </SpaceBetween>
         </Container>
       )}
 


### PR DESCRIPTION
dogfood で「どこから通知を出せるか」が初見の operator から分かりにくいと観察。旧 UX では「通知を送る」 button が EventDetail header actions (Deploy / Delete / Event を終了 と同列) に埋もれていた。

## 変更点

- Header actions から「通知を送る」 button を撤去
- 新規 Container section「通知 (お知らせ)」 を 競技スケジュール と 問題セット の間に追加
  - 説明文: \"Participant Portal に表示される、競技者全員に同時配信されます (= ADR-006)\"
  - 送信タイミング例 (= 開始 5 分前 / 攻撃検知増 / typo 修正 等)
  - DRAFT / TEARDOWN / ARCHIVED 時の disable 理由を Alert で明示
  - 「通知を送る」 button を section actions に配置 (\`variant=\"primary\"\` / \`iconName=\"notification\"\`)

## スコープ縮小 (= 後続 PR で対応)

issue は「**過去履歴 list**」も提案しているが、これは新 backend endpoint (\`GET /events/:eventId/notifications\` operator scope) が要りスコープ大。本 PR は **発見性向上のみ**。履歴 list は別 PR。

## Regression 分析

| # | 壊しうる挙動 | 確認 |
|---|---|---|
| 1 | SendNotificationModal の挙動 | ✅ 無変更 |
| 2 | onClick → \`setNotifyModalOpen(true)\` 経路 | ✅ 同じ、配置のみ移動 |
| 3 | disable 条件 (DRAFT/TEARDOWN/ARCHIVED) | ✅ 完全同一 |
| 4 | 既存 admin-console vitest | ✅ 11 files / **80/80 passed** |

## 物理影響

\`application-admin-console\` frontend のみ。CFn / Lambda / DDB / API は **NO-OP**。

## Test plan

- [x] vitest (admin-console) → 80/80
- [x] typecheck / biome / \`make check-http-status\` 全 green
- [ ] **deploy 後**: 「通知 (お知らせ)」 section が独立して見え、初見でも発見しやすい

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added dedicated notification section with descriptive guidance and status-specific informational alerts
- Notification button relocated with improved visibility and streamlined access

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/577)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->