### PR TITLE
feat(#536): 競技スケジュールに 終了時刻の予約 (scheduled endsAt) を追加

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -21,6 +21,9 @@ export interface EventSummary {
   expiresAt: number;
   /** 競技開始時刻 (ISO8601, UTC)。未設定なら HealthCheck は採点しない (= deploy 直後の誤加算防止)。 */
   startsAt?: string;
+  /** 競技終了時刻 (ISO8601, UTC、#536)。HealthCheck は `now >= endsAt` で採点 gate 閉。
+   *  「Event を終了」 button (= 即時終了) と「日時を指定して終了」 (= 予約) の両方が書き込む。 */
+  endsAt?: string;
 }
 
 export interface EventListResponse {
@@ -120,18 +123,29 @@ export async function bulkTeardownEvent(api: ApiClient, eventId: string): Promis
 }
 
 export interface SetScheduleResult {
-  startsAt: string;
+  /** #536: backend は指定された field のみ返す。startsAt 未指定なら undefined */
+  startsAt?: string;
+  /** #536: endsAt も同様 */
+  endsAt?: string;
   updatedDeployments: number;
 }
 
 /**
- * 競技開始時刻を設定する。`{ startsAt }` で日時指定、`{ startNow: true }` で server now 採用。
- * Event + 紐づく全 deployment 行に伝播する (eventStartsAt の denormalize)。
+ * 競技開始/終了時刻を設定する。`{ startsAt }` で日時指定、`{ startNow: true }` で server now 採用。
+ * #536: `{ endsAt }` も同 endpoint で受ける (= 終了予約)。組み合わせ可:
+ *   `{ startsAt }` / `{ startNow: true }` / `{ endsAt }` / `{ startsAt, endsAt }` /
+ *   `{ startNow: true, endsAt }`
+ * Event + 紐づく全 deployment 行に伝播する (eventStartsAt / eventEndsAt の denormalize)。
  */
+export interface SetEventScheduleBody {
+  startsAt?: string;
+  startNow?: true;
+  endsAt?: string;
+}
 export async function setEventSchedule(
   api: ApiClient,
   eventId: string,
-  body: { startsAt: string } | { startNow: true },
+  body: SetEventScheduleBody,
 ): Promise<SetScheduleResult> {
   return api.patch<SetScheduleResult>(`events/${encodeURIComponent(eventId)}/schedule`, body);
 }

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -127,6 +127,11 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [scheduleDate, setScheduleDate] = useState("");
   const [scheduleTime, setScheduleTime] = useState("");
   const [scheduleInFlight, setScheduleInFlight] = useState<"now" | "scheduled" | null>(null);
+  // #536: 終了予約 modal の state (= 開始 modal と独立)
+  const [endsAtModalOpen, setEndsAtModalOpen] = useState(false);
+  const [endsAtDate, setEndsAtDate] = useState("");
+  const [endsAtTime, setEndsAtTime] = useState("");
+  const [endsAtInFlight, setEndsAtInFlight] = useState(false);
   const [endInFlight, setEndInFlight] = useState(false);
   const [confirmEnd, setConfirmEnd] = useState(false);
   const [notifyModalOpen, setNotifyModalOpen] = useState(false);
@@ -230,6 +235,50 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setScheduleInFlight(null);
+    }
+  };
+
+  // #536: 「日時を指定して終了」 modal の submit。endsAt を未来時刻で予約する。
+  // 既存「Event を終了」 button (= POST /events/:id/end、status=ENDED 即遷移) とは別経路:
+  // こちらは status は触らず HealthCheck の gate で時刻 gate するだけ (operator の負担減)。
+  const handleScheduleEnd = async () => {
+    if (!apiClient || endsAtInFlight) return;
+    if (!endsAtDate || !endsAtTime) {
+      setError("終了の日付と時刻の両方を指定してください");
+      return;
+    }
+    const local = new Date(`${endsAtDate}T${endsAtTime}:00`);
+    if (Number.isNaN(local.getTime())) {
+      setError("終了日時の形式が不正です");
+      return;
+    }
+    // #536 frontend 防御線: 過去 endsAt を弾く (= SLACK 60s で backend と揃える)
+    if (local.getTime() < Date.now() - 60_000) {
+      setError(
+        "過去の日時は指定できません。今すぐ終了するには「Event を終了」 button を使ってください。",
+      );
+      return;
+    }
+    // #536 frontend 防御線: endsAt が startsAt 以前なら弾く (= 競技時間 0 / 負を防ぐ)
+    if (detail?.startsAt) {
+      const startsAtMs = new Date(detail.startsAt).getTime();
+      if (Number.isFinite(startsAtMs) && local.getTime() <= startsAtMs) {
+        setError("終了時刻は開始時刻より後の時刻を指定してください。");
+        return;
+      }
+    }
+    setEndsAtInFlight(true);
+    setError(null);
+    try {
+      await setEventSchedule(apiClient, eventId, { endsAt: local.toISOString() });
+      setEndsAtModalOpen(false);
+      setEndsAtDate("");
+      setEndsAtTime("");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEndsAtInFlight(false);
     }
   };
 
@@ -347,8 +396,22 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           header={
             <Header
               variant="h2"
-              description="競技開始時刻を指定するまで Health Check は probe / 採点を skip します (deploy 直後の誤加算を防ぎ、Lambda 呼出 / outbound 通信コストも抑制)。"
-              actions={
+              description="開始時刻を指定すると HealthCheck が probe / 採点を開始、終了時刻を指定すると自動で gate を閉めます (= operator が「Event を終了」を押し忘れても採点が垂れ流しにならない、#536)。"
+            >
+              競技スケジュール
+            </Header>
+          }
+        >
+          <ColumnLayout columns={2} variant="text-grid">
+            <Field label="開始時刻 (UTC)">
+              <SpaceBetween size="xs">
+                {detail.startsAt ? (
+                  <code>{detail.startsAt}</code>
+                ) : (
+                  <Box variant="small" color="text-status-inactive">
+                    未設定 (採点停止中)
+                  </Box>
+                )}
                 <SpaceBetween direction="horizontal" size="xs">
                   <Button
                     onClick={() => setScheduleModalOpen(true)}
@@ -365,24 +428,32 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                     即座に開始
                   </Button>
                 </SpaceBetween>
-              }
-            >
-              競技スケジュール
-            </Header>
-          }
-        >
-          <ColumnLayout columns={2} variant="text-grid">
-            <Field label="開始時刻 (UTC)">
-              {detail.startsAt ? (
-                <code>{detail.startsAt}</code>
-              ) : (
-                <Box variant="small" color="text-status-inactive">
-                  未設定 (採点停止中)
-                </Box>
-              )}
+              </SpaceBetween>
             </Field>
-            <Field label="採点ステータス">{scoringBadge(detail.startsAt)}</Field>
+            {/* #536: 終了時刻 column (= 予約終了)。「Event を終了」 button (= 即終了) は
+             *   Header actions に既存、こちらは未来時刻を予約する経路。両方とも endsAt
+             *   field を書き、HealthCheck が `now >= endsAt` で gate を閉じる。 */}
+            <Field label="終了時刻 (UTC)">
+              <SpaceBetween size="xs">
+                {detail.endsAt ? (
+                  <code>{detail.endsAt}</code>
+                ) : (
+                  <Box variant="small" color="text-status-inactive">
+                    未設定 (= 手動「Event を終了」まで採点継続)
+                  </Box>
+                )}
+                <Button
+                  onClick={() => setEndsAtModalOpen(true)}
+                  disabled={!apiClient || endsAtInFlight}
+                >
+                  日時を指定して終了
+                </Button>
+              </SpaceBetween>
+            </Field>
           </ColumnLayout>
+          <Box margin={{ top: "m" }}>
+            <Field label="採点ステータス">{scoringBadge(detail.startsAt)}</Field>
+          </Box>
         </Container>
       )}
 
@@ -668,6 +739,54 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               format="hh:mm"
               placeholder="hh:mm"
               onChange={(e) => setScheduleTime(e.detail.value)}
+            />
+          </FormField>
+        </SpaceBetween>
+      </Modal>
+
+      {/* #536: 競技終了予約 modal。開始 modal とは独立 (= 単一目的の方が初見でも分かる)。
+       *   未来時刻のみ受理、past_ends_at / ends_before_starts は backend で第二防衛線。 */}
+      <Modal
+        visible={endsAtModalOpen}
+        onDismiss={() => setEndsAtModalOpen(false)}
+        header="競技終了日時を指定 (予約)"
+        size="medium"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setEndsAtModalOpen(false)}>キャンセル</Button>
+              <Button variant="primary" loading={endsAtInFlight} onClick={handleScheduleEnd}>
+                設定
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            指定時刻を超えると HealthCheck が採点を停止します。「Event を終了」 button (= 即時)
+            と違い、status は READY のまま (= operator は手動で「Event を終了」
+            を押す必要なし)。ブラウザのローカル時刻で入力した値を UTC に変換します (分精度)。
+          </Box>
+          {detail?.startsAt && (
+            <Box variant="small" color="text-status-inactive">
+              開始時刻: <code>{detail.startsAt}</code> —
+              終了時刻はこれより後の時刻を指定してください。
+            </Box>
+          )}
+          <FormField label="日付 (YYYY-MM-DD)">
+            <DatePicker
+              value={endsAtDate}
+              onChange={(e) => setEndsAtDate(e.detail.value)}
+              placeholder="YYYY/MM/DD"
+            />
+          </FormField>
+          <FormField label="時刻 (HH:mm)">
+            <TimeInput
+              value={endsAtTime}
+              format="hh:mm"
+              placeholder="hh:mm"
+              onChange={(e) => setEndsAtTime(e.detail.value)}
             />
           </FormField>
         </SpaceBetween>

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -162,14 +162,22 @@ app.patch("/events/:eventId/schedule", async (c) => {
     return c.json({ error: "validation failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
   }
   const nowMs = Date.now();
-  // `startNow: true` は server now を ISO8601 化して採用 (= 即座に開始ボタンの裏挙動)。
-  const startsAt = "startNow" in parsed.data ? new Date(nowMs).toISOString() : parsed.data.startsAt;
+  // `startNow: true` は server now を ISO8601 化して startsAt に解決 (= 即座に開始)。
+  // #536: endsAt も同 endpoint で受け、predictive scheduling を可能に。
+  const resolvedStartsAt = parsed.data.startNow
+    ? new Date(nowMs).toISOString()
+    : parsed.data.startsAt;
+  const resolvedEndsAt = parsed.data.endsAt;
   try {
-    const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, startsAt, nowMs);
+    const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, {
+      startsAt: resolvedStartsAt,
+      endsAt: resolvedEndsAt,
+      nowMs,
+    });
     if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
     if (outcome.kind === "past_starts_at") {
-      // #537: 過去日時を frontend が迂回した場合の防御線。SLACK_MS (= 60s) より過去なら
-      // 「即座に開始」 button を使うべきなので reject。message は frontend で表示する。
+      // #537: 過去 startsAt を frontend が迂回した場合の防御線。SLACK (= 60s) より過去なら
+      // 「即座に開始」 button を使うべきなので reject。
       return c.json(
         {
           error: "past_starts_at",
@@ -181,8 +189,41 @@ app.patch("/events/:eventId/schedule", async (c) => {
         HTTP_BAD_REQUEST,
       );
     }
+    if (outcome.kind === "past_ends_at") {
+      // #536: 過去 endsAt を弾く。「Event を終了」 button (= 即終了) は別 endpoint なので、
+      // 本 schedule API には未来の endsAt のみ来る想定。
+      return c.json(
+        {
+          error: "past_ends_at",
+          message:
+            "endsAt が過去の時刻です。「Event を終了」 button (= 即時) を使うか、未来の時刻を指定してください。",
+          endsAt: outcome.endsAt,
+          serverNow: new Date(outcome.nowMs).toISOString(),
+        },
+        HTTP_BAD_REQUEST,
+      );
+    }
+    if (outcome.kind === "ends_before_starts") {
+      // #536: 競技時間 0 以下を弾く。
+      return c.json(
+        {
+          error: "ends_before_starts",
+          message: "endsAt は startsAt より後の時刻を指定してください。",
+          startsAt: outcome.startsAt,
+          endsAt: outcome.endsAt,
+        },
+        HTTP_BAD_REQUEST,
+      );
+    }
+    if (outcome.kind === "no_op") {
+      return c.json({ error: "no_op", message: "更新対象が指定されていません" }, HTTP_BAD_REQUEST);
+    }
     return c.json(
-      { startsAt: outcome.startsAt, updatedDeployments: outcome.updatedDeployments },
+      {
+        startsAt: outcome.startsAt,
+        endsAt: outcome.endsAt,
+        updatedDeployments: outcome.updatedDeployments,
+      },
       HTTP_OK,
     );
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -68,6 +68,7 @@ function toSummary(item: Partial<EventItem>): EventSummary {
     updatedAt: String(item.updatedAt ?? ""),
     expiresAt: Number(item.expiresAt ?? 0),
     startsAt: typeof item.startsAt === "string" ? item.startsAt : undefined,
+    endsAt: typeof item.endsAt === "string" ? item.endsAt : undefined,
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
@@ -4,33 +4,60 @@ import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js"
 import type { EventItem } from "./types.js";
 
 /**
+ * `setEventSchedule` の引数 (= startsAt / endsAt の組み合わせを 1 object で受ける)。
+ * caller (handler/index.ts) が `startNow: true` を server now に解決した後に渡す形。
+ */
+export interface SetEventScheduleParams {
+  /** 競技開始時刻 (ISO8601 Z)。未指定なら既存値を保持 */
+  readonly startsAt?: string;
+  /** 競技終了予約時刻 (ISO8601 Z、#536)。未指定なら既存値を保持 */
+  readonly endsAt?: string;
+  /** 現在時刻 (ms)。validation の比較基準 */
+  readonly nowMs: number;
+}
+
+/**
  * `setEventSchedule` の結果。
  * - `not_found`: tenant 不一致 / event 不在 → 404 相当
  * - `past_starts_at`: 指定 startsAt が `now - SLACK_MS` 以前 → 400 相当 (#537)
- * - `ok`: 更新後の startsAt + 影響を受けた deployment 数を返す
+ * - `past_ends_at`: 指定 endsAt が `now - SLACK_MS` 以前 → 400 相当 (#536)
+ * - `ends_before_starts`: 指定 endsAt <= startsAt → 400 相当 (#536)
+ * - `no_op`: 何も指定なし (= zod 通過後ありえない、defense-in-depth)
+ * - `ok`: 更新後の startsAt / endsAt + 影響を受けた deployment 数
  */
 export type SetEventScheduleOutcome =
   | { kind: "not_found" }
   | { kind: "past_starts_at"; startsAt: string; nowMs: number }
-  | { kind: "ok"; startsAt: string; updatedDeployments: number };
+  | { kind: "past_ends_at"; endsAt: string; nowMs: number }
+  | { kind: "ends_before_starts"; startsAt: string; endsAt: string }
+  | { kind: "no_op" }
+  | {
+      kind: "ok";
+      startsAt?: string;
+      endsAt?: string;
+      updatedDeployments: number;
+    };
 
 /**
- * 過去日時 reject の slack (= clock skew tolerance、#537)。これより過去の startsAt は
- * 「即座に開始」 button を使うべきなので backend 側で reject する。
+ * 過去日時 reject の slack (= clock skew tolerance、#537 #536)。これより過去の startsAt /
+ * endsAt は backend 側で reject する。
  *
  * 60s = LB / Lambda の clock drift 経験上の上限。これより緩いと typo 起因の誤入力を
  * 通してしまうし、これより厳しいと真っ当な「ちょっと前の時刻」も弾いてしまう。
  */
-const PAST_STARTS_AT_SLACK_MS = 60_000;
+const SCHEDULE_SLACK_MS = 60_000;
 
 /**
- * Event の `startsAt` を更新し、紐づく全 deployment 行に `eventStartsAt` を denormalize する。
+ * Event の `startsAt` / `endsAt` を更新し、紐づく全 deployment 行にも denormalize する。
  *
- * HealthCheckLambda は deployment 行の `eventStartsAt` を見て probe / 採点 gate するため、
- * Event 単独更新では足りない (event-handler Lambda は Deployments table に R/W 権限を持つので
- * CDK 改修不要)。
+ * HealthCheckLambda は deployment 行の `eventStartsAt` / `eventEndsAt` を見て probe / 採点
+ * gate するため、Event 単独更新では足りない。event-handler Lambda は Deployments table に
+ * R/W 権限を持つので CDK 改修不要。
  *
- * `startsAt` は ISO8601 文字列。caller 側 (handler/index.ts) で zod validate 済を前提とする。
+ * caller (handler/index.ts) は zod validate 済を前提。validation:
+ *   - past_starts_at: startsAt < now - SLACK
+ *   - past_ends_at:   endsAt   < now - SLACK
+ *   - ends_before_starts: 両方指定時、endsAt <= startsAt
  *
  * tenant 跨ぎ参照防止: Event 行の tenantId が引数 `tenantId` と一致しない場合は `not_found`。
  */
@@ -38,20 +65,56 @@ export async function setEventSchedule(
   shared: EventSharedResources,
   tenantId: string,
   eventId: string,
-  startsAt: string,
-  nowMs: number,
+  params: SetEventScheduleParams,
 ): Promise<SetEventScheduleOutcome> {
-  // #537: 過去日時 reject (第二防衛線、frontend 迂回 / API 直叩き対策)。「即座に開始」は
-  // handler で `startNow: true` 経路に振られて server now を採用するので、ここに到達する
-  // `startsAt` は operator 入力 (= 任意時刻)。`nowMs - SLACK_MS` より前なら past_starts_at。
-  const startsAtMs = new Date(startsAt).getTime();
-  if (Number.isFinite(startsAtMs) && startsAtMs < nowMs - PAST_STARTS_AT_SLACK_MS) {
-    return { kind: "past_starts_at", startsAt, nowMs };
+  const { startsAt, endsAt, nowMs } = params;
+  // zod 通過済なので両方 undefined にはならない想定だが、defense-in-depth。
+  if (startsAt === undefined && endsAt === undefined) {
+    return { kind: "no_op" };
   }
 
-  // Event の存在 + tenantId 確認のため UpdateItem の ConditionExpression で防御。
-  // 同時に Deployments の対象行 (eventId 一致) を Query で集める。
-  const now = new Date(nowMs).toISOString();
+  // #537: 過去 startsAt reject。「即座に開始」は handler で server now に解決済なので、
+  // ここに到達する startsAt は operator 入力 (= 任意時刻)。
+  if (startsAt !== undefined) {
+    const startsAtMs = new Date(startsAt).getTime();
+    if (Number.isFinite(startsAtMs) && startsAtMs < nowMs - SCHEDULE_SLACK_MS) {
+      return { kind: "past_starts_at", startsAt, nowMs };
+    }
+  }
+  // #536: 過去 endsAt reject。「Event を終了」 button は別 endpoint
+  // (POST /events/:id/end) で server now を書く経路があるので、本 schedule API には
+  // 未来の endsAt のみが来る想定。
+  if (endsAt !== undefined) {
+    const endsAtMs = new Date(endsAt).getTime();
+    if (Number.isFinite(endsAtMs) && endsAtMs < nowMs - SCHEDULE_SLACK_MS) {
+      return { kind: "past_ends_at", endsAt, nowMs };
+    }
+  }
+  // #536: 両方指定時に endsAt <= startsAt を弾く (= 競技時間 0 や負を防ぐ)。
+  if (startsAt !== undefined && endsAt !== undefined) {
+    const startsAtMs = new Date(startsAt).getTime();
+    const endsAtMs = new Date(endsAt).getTime();
+    if (Number.isFinite(startsAtMs) && Number.isFinite(endsAtMs) && endsAtMs <= startsAtMs) {
+      return { kind: "ends_before_starts", startsAt, endsAt };
+    }
+  }
+
+  // dynamic UpdateExpression: 指定 field のみ更新 (= 既存値を保持)。
+  // ExpressionAttributeNames で "endsAt" は予約語衝突なしだが symmetry で `#` 付に。
+  const setParts: string[] = ["updatedAt = :now"];
+  const exprValues: Record<string, string> = {
+    ":now": new Date(nowMs).toISOString(),
+    ":tenantId": tenantId,
+  };
+  if (startsAt !== undefined) {
+    setParts.push("startsAt = :startsAt");
+    exprValues[":startsAt"] = startsAt;
+  }
+  if (endsAt !== undefined) {
+    setParts.push("endsAt = :endsAt");
+    exprValues[":endsAt"] = endsAt;
+  }
+  const updateExpression = `SET ${setParts.join(", ")}`;
 
   let updatedEvent: Partial<EventItem> | undefined;
   try {
@@ -59,13 +122,9 @@ export async function setEventSchedule(
       new UpdateCommand({
         TableName: shared.eventsTableName,
         Key: { PK: `EVENT#${eventId}`, SK: "META" },
-        UpdateExpression: "SET startsAt = :startsAt, updatedAt = :now",
+        UpdateExpression: updateExpression,
         ConditionExpression: "tenantId = :tenantId",
-        ExpressionAttributeValues: {
-          ":startsAt": startsAt,
-          ":now": now,
-          ":tenantId": tenantId,
-        },
+        ExpressionAttributeValues: exprValues,
         ReturnValues: "ALL_NEW",
       }),
     );
@@ -79,25 +138,38 @@ export async function setEventSchedule(
   }
   if (!updatedEvent) return { kind: "not_found" };
 
-  // 紐づく deployment 行を全部引いて eventStartsAt を伝播 (PK だけあれば update 可)。
+  // 紐づく deployment 行を全部引いて eventStartsAt / eventEndsAt を伝播。
   const deploymentsOut = await queryDeploymentsByEvent(shared, tenantId, eventId, "PK");
   const targets = deploymentsOut
     .map((d) => d as Pick<DeploymentItem, "PK">)
     .filter((d) => typeof d.PK === "string");
 
-  // Promise.all で並列 update。各 row は冪等な単一フィールド update (UpdateExpression)。
+  // deployment 側も dynamic UpdateExpression — startsAt のみ / endsAt のみ / 両方 を対応
+  const depSetParts: string[] = ["updatedAt = :now"];
+  const depExprValues: Record<string, string> = { ":now": exprValues[":now"] ?? "" };
+  if (startsAt !== undefined) {
+    depSetParts.push("eventStartsAt = :s");
+    depExprValues[":s"] = startsAt;
+  }
+  if (endsAt !== undefined) {
+    depSetParts.push("eventEndsAt = :e");
+    depExprValues[":e"] = endsAt;
+  }
+  const depUpdateExpression = `SET ${depSetParts.join(", ")}`;
+
+  // Promise.all で並列 update。各 row は冪等な field update。
   await Promise.all(
     targets.map((d) =>
       shared.ddb.send(
         new UpdateCommand({
           TableName: shared.deploymentsTableName,
           Key: { PK: d.PK, SK: "META" },
-          UpdateExpression: "SET eventStartsAt = :s, updatedAt = :now",
-          ExpressionAttributeValues: { ":s": startsAt, ":now": now },
+          UpdateExpression: depUpdateExpression,
+          ExpressionAttributeValues: depExprValues,
         }),
       ),
     ),
   );
 
-  return { kind: "ok", startsAt, updatedDeployments: targets.length };
+  return { kind: "ok", startsAt, endsAt, updatedDeployments: targets.length };
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -147,29 +147,50 @@ export const EventSummarySchema = z.object({
   updatedAt: z.string(),
   expiresAt: z.number(),
   startsAt: z.string().optional(),
+  /** 競技終了時刻 (#536)。HealthCheck が `now >= endsAt` で gate 閉。
+   *  「Event を終了」 button = now を書く / 「日時を指定して終了」 = 未来時刻を書く。 */
+  endsAt: z.string().optional(),
 });
 export type EventSummary = z.infer<typeof EventSummarySchema>;
 
 /**
  * `PATCH /events/:eventId/schedule` body。
- * - `{ startsAt: ISO8601 }`: operator 指定の日時 (分精度)
- * - `{ startNow: true }`: 即座に開始 (= server now を採用)
  *
- * `startsAt` は `+09:00` 等の non-Z オフセットも入力としては受け付けるが、
- * **canonical UTC Z 形式に transform して persist する** (Issue #497)。
- * 理由: HealthCheck の `isScoringActive` は ISO 8601 の辞書順比較を時系列比較として使うが、
- * `Z` (0x5A) と `+` (0x2B) は code point 順が逆転するので、混在すると
- * 「同年月日の異 timezone」の比較が壊れる。入り口で 1 形式に揃えてしまう。
+ * 3 種の field を組み合わせ:
+ * - `startsAt: ISO8601` — operator 指定の競技開始日時 (分精度)
+ * - `startNow: true` — 即座に開始 (= server now を採用)。`startsAt` とは同時指定不可
+ * - `endsAt: ISO8601` — 競技終了予約時刻 (#536)。HealthCheck が `now >= endsAt` で
+ *   採点 gate を閉じるので、operator は手動で「Event を終了」を押さなくてよい
+ *
+ * 少なくとも 1 つは指定必須。同時指定可能な組:
+ *   `{ startsAt }` / `{ startNow: true }` / `{ endsAt }` / `{ startsAt, endsAt }` /
+ *   `{ startNow: true, endsAt }`
+ *
+ * datetime は `+09:00` 等の non-Z オフセット入力も受け付けるが、**canonical UTC Z 形式
+ * に transform して persist する** (Issue #497)。理由: HealthCheck の `isScoringActive`
+ * は ISO 8601 の辞書順比較を時系列比較として使うが、`Z` (0x5A) と `+` (0x2B) は code point
+ * 順が逆転するので、混在すると「同年月日の異 timezone」の比較が壊れる。入り口で 1 形式に揃える。
  */
-export const ScheduleEventRequestSchema = z.union([
-  z.object({
+export const ScheduleEventRequestSchema = z
+  .object({
     startsAt: z
       .string()
       .datetime({ offset: true })
-      .transform((s) => new Date(s).toISOString()),
-  }),
-  z.object({ startNow: z.literal(true) }),
-]);
+      .transform((s) => new Date(s).toISOString())
+      .optional(),
+    startNow: z.literal(true).optional(),
+    endsAt: z
+      .string()
+      .datetime({ offset: true })
+      .transform((s) => new Date(s).toISOString())
+      .optional(),
+  })
+  .refine((v) => v.startsAt !== undefined || v.startNow === true || v.endsAt !== undefined, {
+    message: "startsAt / startNow / endsAt のいずれかは必須",
+  })
+  .refine((v) => !(v.startsAt !== undefined && v.startNow === true), {
+    message: "startsAt と startNow は同時指定不可",
+  });
 export type ScheduleEventRequest = z.infer<typeof ScheduleEventRequestSchema>;
 
 export const TeamSummarySchema = z.object({

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -1,4 +1,4 @@
-import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { type QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setEventSchedule } from "../../lib/problem-deploy/handlers/event-handler/schedule";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
@@ -7,6 +7,7 @@ import { ScheduleEventRequestSchema } from "../../lib/problem-deploy/handlers/ev
 const NOW_MS = 1_700_000_000_000;
 const NOW_ISO = new Date(NOW_MS).toISOString();
 const STARTS_AT = "2026-05-08T10:00:00.000Z";
+const ENDS_AT = "2026-05-08T12:00:00.000Z";
 
 function buildShared(): {
   shared: EventSharedResources;
@@ -25,20 +26,14 @@ function buildShared(): {
   return { shared, ddbSend };
 }
 
-describe("setEventSchedule", () => {
+describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("正常系: Event 行 + 紐づく全 deployment 行の eventStartsAt を更新するべき", async () => {
     const { shared, ddbSend } = buildShared();
-    // 1st: Event UpdateCommand returns Attributes (= 行が存在 + tenantId 一致)
     ddbSend.mockResolvedValueOnce({
-      Attributes: {
-        eventId: "EV1",
-        tenantId: "tenant-acme",
-        startsAt: STARTS_AT,
-      },
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
-    // 2nd: Deployments QueryCommand (FilterExpression で EV1 のみ server 側で除外済み)
     ddbSend.mockResolvedValueOnce({
       Items: [
         { PK: "DEPLOYMENT#J1", eventId: "EV1" },
@@ -46,36 +41,39 @@ describe("setEventSchedule", () => {
         { PK: "DEPLOYMENT#J4", eventId: "EV1" },
       ],
     });
-    // 3rd-5th: Deployments UpdateCommand × 3
     ddbSend.mockResolvedValue({});
 
-    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
-    expect(out).toEqual({ kind: "ok", startsAt: STARTS_AT, updatedDeployments: 3 });
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: STARTS_AT,
+      nowMs: NOW_MS,
+    });
+    expect(out).toEqual({
+      kind: "ok",
+      startsAt: STARTS_AT,
+      endsAt: undefined,
+      updatedDeployments: 3,
+    });
 
-    // Event 更新の ConditionExpression が tenantId 一致を要求する
     const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
     expect(eventUpd).toBeInstanceOf(UpdateCommand);
     expect(eventUpd.input.ConditionExpression).toBe("tenantId = :tenantId");
     expect(eventUpd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
     expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBe(STARTS_AT);
+    // endsAt 未指定なので update 対象に含まれない
+    expect(eventUpd.input.ExpressionAttributeValues?.[":endsAt"]).toBeUndefined();
 
-    // Deployments query は GSI1 = TENANT# + FilterExpression で eventId 一致 (cross-event 漏洩防止)
     const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;
-    expect(queryCmd).toBeInstanceOf(QueryCommand);
     expect(queryCmd.input.IndexName).toBe("GSI1");
     expect(queryCmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
     expect(queryCmd.input.FilterExpression).toBe("eventId = :ev");
-    expect(queryCmd.input.ExpressionAttributeValues?.[":ev"]).toBe("EV1");
 
-    // Deployment update が EV1 行 3 件のみ走る
     const updCmds = ddbSend.mock.calls
       .map((c) => c[0])
       .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
     expect(updCmds).toHaveLength(3);
-    const updatedPks = updCmds.map((c) => (c.input.Key as { PK: string }).PK).sort();
-    expect(updatedPks).toEqual(["DEPLOYMENT#J1", "DEPLOYMENT#J2", "DEPLOYMENT#J4"]);
     for (const cmd of updCmds) {
       expect(cmd.input.ExpressionAttributeValues?.[":s"]).toBe(STARTS_AT);
+      expect(cmd.input.ExpressionAttributeValues?.[":e"]).toBeUndefined();
     }
   });
 
@@ -85,46 +83,51 @@ describe("setEventSchedule", () => {
     err.name = "ConditionalCheckFailedException";
     ddbSend.mockRejectedValueOnce(err);
 
-    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: STARTS_AT,
+      nowMs: NOW_MS,
+    });
     expect(out).toEqual({ kind: "not_found" });
-    // Deployments query / update は 1 度も走らない (= 漏洩防止)
     expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("対象 deployment が 0 件でも ok を返し updatedDeployments=0 (= 即座に schedule のみの shortcut)", async () => {
+  it("対象 deployment が 0 件でも ok を返し updatedDeployments=0", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
     ddbSend.mockResolvedValueOnce({ Items: [] });
 
-    const out = await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
-    expect(out).toEqual({ kind: "ok", startsAt: STARTS_AT, updatedDeployments: 0 });
-    // Deployment Update は走らない (Promise.all([]))
-    const updCmds = ddbSend.mock.calls
-      .map((c) => c[0])
-      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
-    expect(updCmds).toHaveLength(0);
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: STARTS_AT,
+      nowMs: NOW_MS,
+    });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") expect(out.updatedDeployments).toBe(0);
   });
 
-  it("startsAt が now - 60s より過去なら past_starts_at で DDB に触れず reject すべき (#537)", async () => {
+  it("startsAt が now - 60s より過去なら past_starts_at で DDB に触れず reject (#537)", async () => {
     const { shared, ddbSend } = buildShared();
-    // NOW_MS の 5 分前 (= SLACK 60s より十分過去)
     const pastStartsAt = new Date(NOW_MS - 5 * 60_000).toISOString();
-    const out = await setEventSchedule(shared, "tenant-acme", "EV1", pastStartsAt, NOW_MS);
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: pastStartsAt,
+      nowMs: NOW_MS,
+    });
     expect(out).toEqual({ kind: "past_starts_at", startsAt: pastStartsAt, nowMs: NOW_MS });
-    // DDB call は 0 (= 過去日時 reject は DDB 触れない、副作用なし)
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("startsAt が now - 30s (= SLACK 内) なら過去扱いせず通すべき (#537 clock skew tolerance)", async () => {
+  it("startsAt が now - 30s (SLACK 内) なら通すべき (#537 clock skew)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: NOW_ISO },
     });
     ddbSend.mockResolvedValueOnce({ Items: [] });
     const slackOk = new Date(NOW_MS - 30_000).toISOString();
-    const out = await setEventSchedule(shared, "tenant-acme", "EV1", slackOk, NOW_MS);
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: slackOk,
+      nowMs: NOW_MS,
+    });
     expect(out.kind).toBe("ok");
   });
 
@@ -133,12 +136,10 @@ describe("setEventSchedule", () => {
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
-    ddbSend.mockResolvedValueOnce({
-      Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }],
-    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }] });
     ddbSend.mockResolvedValue({});
 
-    await setEventSchedule(shared, "tenant-acme", "EV1", STARTS_AT, NOW_MS);
+    await setEventSchedule(shared, "tenant-acme", "EV1", { startsAt: STARTS_AT, nowMs: NOW_MS });
     const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
     const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
     expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
@@ -146,61 +147,162 @@ describe("setEventSchedule", () => {
   });
 });
 
+describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("endsAt のみ指定 → Event の endsAt + deployments の eventEndsAt を更新、startsAt は触らない", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { eventId: "EV1", tenantId: "tenant-acme", endsAt: ENDS_AT },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }] });
+    ddbSend.mockResolvedValue({});
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      endsAt: ENDS_AT,
+      nowMs: NOW_MS,
+    });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.startsAt).toBeUndefined();
+      expect(out.endsAt).toBe(ENDS_AT);
+    }
+
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(eventUpd.input.ExpressionAttributeValues?.[":endsAt"]).toBe(ENDS_AT);
+    expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBeUndefined();
+
+    const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
+    expect(deployUpd.input.ExpressionAttributeValues?.[":e"]).toBe(ENDS_AT);
+    expect(deployUpd.input.ExpressionAttributeValues?.[":s"]).toBeUndefined();
+  });
+
+  it("startsAt + endsAt 両方指定 → 1 回の UpdateCommand で両方更新するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        startsAt: STARTS_AT,
+        endsAt: ENDS_AT,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [{ PK: "DEPLOYMENT#J1", eventId: "EV1" }] });
+    ddbSend.mockResolvedValue({});
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: STARTS_AT,
+      endsAt: ENDS_AT,
+      nowMs: NOW_MS,
+    });
+    expect(out.kind).toBe("ok");
+
+    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(eventUpd.input.UpdateExpression).toContain("startsAt = :startsAt");
+    expect(eventUpd.input.UpdateExpression).toContain("endsAt = :endsAt");
+    expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBe(STARTS_AT);
+    expect(eventUpd.input.ExpressionAttributeValues?.[":endsAt"]).toBe(ENDS_AT);
+  });
+
+  it("endsAt が now - 60s より過去なら past_ends_at で DDB に触れず reject (#536)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const pastEnds = new Date(NOW_MS - 5 * 60_000).toISOString();
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      endsAt: pastEnds,
+      nowMs: NOW_MS,
+    });
+    expect(out).toEqual({ kind: "past_ends_at", endsAt: pastEnds, nowMs: NOW_MS });
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("endsAt <= startsAt は ends_before_starts で reject (#536 0 分競技を防ぐ)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const start = "2026-05-08T10:00:00.000Z";
+    const earlierEnd = "2026-05-08T09:00:00.000Z";
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: start,
+      endsAt: earlierEnd,
+      nowMs: NOW_MS,
+    });
+    expect(out).toEqual({
+      kind: "ends_before_starts",
+      startsAt: start,
+      endsAt: earlierEnd,
+    });
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("endsAt === startsAt も ends_before_starts (= 競技時間 0 分は無効)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const same = "2026-05-08T10:00:00.000Z";
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      startsAt: same,
+      endsAt: same,
+      nowMs: NOW_MS,
+    });
+    expect(out.kind).toBe("ends_before_starts");
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("startsAt も endsAt も無指定 → no_op (DDB 不触)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", { nowMs: NOW_MS });
+    expect(out).toEqual({ kind: "no_op" });
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+});
+
 /**
- * Issue #497: timezone offset の Zod 厳格化。
- * `+09:00` 等の non-Z オフセットも入力では受理するが、出力は必ず Z 形式に正規化する
- * (= 辞書順 ISO 8601 比較を HealthCheck の isScoringActive で安全に使うため)。
+ * Issue #497 + #536: ScheduleEventRequestSchema の shape を pin。
+ * - `+09:00` 等の non-Z オフセットは UTC Z に transform される (= 辞書順比較の安全性)
+ * - startsAt / startNow / endsAt の組み合わせ refinement
  */
-describe("ScheduleEventRequestSchema (Issue #497)", () => {
-  it("Z 終端の ISO 8601 はそのまま受理されるべき (= 既存挙動維持)", () => {
+describe("ScheduleEventRequestSchema", () => {
+  it("Z 終端の ISO 8601 はそのまま受理されるべき", () => {
     const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T10:00:00.000Z" });
-    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
     expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
   });
 
   it("`+09:00` オフセットは UTC Z に transform されるべき", () => {
     const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T19:00:00+09:00" });
-    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
-    // JST 19:00 = UTC 10:00
     expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
   });
 
-  it("`-12:00` オフセットも UTC Z に transform されるべき (= 全 timezone を 1 形式に揃える)", () => {
-    const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T22:00:00-12:00" });
-    if (!("startsAt" in out)) throw new Error("startsAt 分岐になるはず");
-    // -12:00 22:00 = UTC 翌日 10:00
-    expect(out.startsAt).toBe("2026-05-09T10:00:00.000Z");
+  it("endsAt も同様にオフセットを Z に transform するべき (#536)", () => {
+    const out = ScheduleEventRequestSchema.parse({ endsAt: "2026-05-08T21:00:00+09:00" });
+    expect(out.endsAt).toBe("2026-05-08T12:00:00.000Z");
   });
 
-  it("オフセット無し (= naive) は reject (Zod datetime のデフォルト挙動)", () => {
+  it("オフセット無し (naive) は reject", () => {
+    expect(ScheduleEventRequestSchema.safeParse({ startsAt: "2026-05-08T10:00:00" }).success).toBe(
+      false,
+    );
+  });
+
+  it("`{ startNow: true }` のみで通る (既存 UX 互換)", () => {
+    const out = ScheduleEventRequestSchema.parse({ startNow: true });
+    expect(out.startNow).toBe(true);
+  });
+
+  it("`{ startNow: true, endsAt: ... }` は startNow + 終了予約の組み合わせ (#536)", () => {
+    const out = ScheduleEventRequestSchema.parse({
+      startNow: true,
+      endsAt: "2026-05-08T12:00:00.000Z",
+    });
+    expect(out.startNow).toBe(true);
+    expect(out.endsAt).toBe("2026-05-08T12:00:00.000Z");
+  });
+
+  it("startsAt と startNow の同時指定は refinement で reject", () => {
     const result = ScheduleEventRequestSchema.safeParse({
-      startsAt: "2026-05-08T10:00:00",
+      startsAt: "2026-05-08T10:00:00.000Z",
+      startNow: true,
     });
     expect(result.success).toBe(false);
   });
 
-  it("不正な ISO 8601 文字列は reject", () => {
-    expect(ScheduleEventRequestSchema.safeParse({ startsAt: "not-a-date" }).success).toBe(false);
-    expect(ScheduleEventRequestSchema.safeParse({ startsAt: "2026-13-50" }).success).toBe(false);
-  });
-
-  it("`{ startNow: true }` は transform 対象外でそのまま通る", () => {
-    const out = ScheduleEventRequestSchema.parse({ startNow: true });
-    expect(out).toEqual({ startNow: true });
-  });
-
-  it("正規化後の値は辞書順比較が時系列順と一致するべき (Issue #497 root cause)", () => {
-    // `+12:00` 早朝 と `Z` 同日午前: 元の文字列で比べると "Z" > "+" なので壊れる
-    const tzPlus = ScheduleEventRequestSchema.parse({
-      startsAt: "2026-05-08T12:00:00+12:00", // = UTC 00:00
-    });
-    const utc = ScheduleEventRequestSchema.parse({
-      startsAt: "2026-05-08T05:00:00.000Z",
-    });
-    if (!("startsAt" in tzPlus) || !("startsAt" in utc)) throw new Error("分岐エラー");
-    // 正規化後は両方 Z 形式 → 辞書順 = 時系列順
-    expect(tzPlus.startsAt < utc.startsAt).toBe(true);
-    expect(tzPlus.startsAt).toBe("2026-05-08T00:00:00.000Z");
-    expect(utc.startsAt).toBe("2026-05-08T05:00:00.000Z");
+  it("startsAt / startNow / endsAt のいずれも未指定は refinement で reject", () => {
+    const result = ScheduleEventRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
(#537) で startsAt の事前 schedule + validation を入れた**対称形**。\`14:00 開始 / 16:00 自動終了\` の競技スロット pre-set が可能に。「Event を終了」 button (= 即時終了) を operator が押し忘れて HealthCheck が深夜まで回り続けるコスト垂れ流しを防ぐ。

## 設計判断 (issue 案 A 採用)

\`endsAt\` field の意味を「予約終了時刻」に拡張 (= 即時終了の \`now()\` と予約の \`future time\` は同じ field を共有)。

HealthCheck の \`isScoringActive\` は既に \`now >= eventEndsAt\` で gate 閉じるので、status と独立に時刻 gate で十分。\`POST /events/:id/end\` (= 即時) は status=ENDED に遷移するが、\`PATCH /events/:id/schedule\` の endsAt は **status を触らない** (= READY のまま endsAt が future の状態が新)。

## API 変更

\`PATCH /events/:eventId/schedule\` の body schema を union → object refinement に拡張:

旧: \`{ startsAt }\` | \`{ startNow: true }\`
新: \`{ startsAt?, startNow?, endsAt? }\` (refinement: 少なくとも 1 つ必須、startsAt+startNow 排他)

組み合わせ可: \`{ startsAt }\` / \`{ startNow: true }\` / \`{ endsAt }\` / \`{ startsAt, endsAt }\` / \`{ startNow: true, endsAt }\`

新 outcome: \`past_ends_at\` / \`ends_before_starts\` / \`no_op\` を 400 で返す。

## Regression 分析

| # | 壊しうる挙動 | 確認 | 対処 |
|---|---|---|---|
| 1 | 既存 startsAt フロー (\"即座に開始\" / \"日時を指定して開始\") | ✅ | schema object 化したが既存 field は互換、refinement で守る |
| 2 | SetScheduleResult.startsAt 必須 → optional | ✅ | EventDetail は refresh() で getEvent するので影響なし |
| 3 | 既存 event-schedule test | ✅ | signature 変更に追従、20/20 passed |
| 4 | bulk-deploy / bulk-delete の Event status update | ✅ | schedule.ts は独立 |
| 5 | HealthCheck の isScoringActive | ✅ | 既に eventEndsAt を見る、endsAt 書き込みで自動 gate |

## 物理影響

- event-handler Lambda: handler 内追加 validation + dynamic UpdateExpression、CFn asset hash 回るだけ
- IAM / table / API GW resource は **NO-OP**
- application-admin-console frontend bundle 更新

## Test plan

- [x] vitest infra → 40 files / **380/380 passed**
- [x] vitest admin-console → 80/80
- [x] typecheck (4 packages) green
- [x] biome check green
- [x] \`make check-http-status\` OK
- [ ] **deploy 後**: EventDetail で「日時を指定して終了」 modal、指定時刻超過で score gate 閉

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Events now support scheduled end times that automatically gate health checks without changing event status
  - Added UI to reserve and schedule event end dates and times with comprehensive validation
  - Schedule display now includes event end time information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/579)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->