### PR TITLE
feat(#528): 新規 Event 作成 form に per-team AWS Account ID 入力を追加

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -6,7 +6,9 @@ export type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "ENDED" | "TEARDOWN"
 
 export interface EventProblemTarget {
   problemId: string;
-  defaultAwsAccountId: string;
+  /** @deprecated #528: AWS Account は team 単位 (= TeamSummary.awsAccountId) に移行。
+   *  旧 Event の fallback としてのみ残す。Phase 2 で削除予定。 */
+  defaultAwsAccountId?: string;
   defaultRegion: string;
 }
 
@@ -37,6 +39,8 @@ export interface TeamSummary {
   displayName?: string;
   /** 詳細経路 (`GET /events/{id}`) でのみ含まれる短命キー。 */
   teamLoginKey?: string;
+  /** #528: team の deploy 先 AWS Account ID (12 桁)。旧 Event は undefined。 */
+  awsAccountId?: string;
 }
 
 export type EventDeploymentStatus =
@@ -65,6 +69,8 @@ export interface EventDetail extends EventSummary {
 
 export interface CreateEventTeamInput {
   internalSlug: string;
+  /** #528: 各 team の deploy 先 AWS Account ID (12 桁数字)。必須。 */
+  awsAccountId: string;
 }
 
 export interface CreateEventRequest {

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -20,10 +20,15 @@ import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
 import { listProblemSummaries } from "../data/problems";
 
 const NAME_MAX = 120;
+// MUST match infrastructure/lib/problem-deploy/handlers/event-handler/types.ts (zod schema)。
+// drift すると frontend が通した値を backend が reject する。
 const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
 const ACCOUNT_ID_RE = /^\d{12}$/;
+const ACCOUNT_ID_MAX_LEN = 12;
 const TEAMS_MIN = 1;
 const TEAMS_MAX = 99;
+const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
+const INITIAL_TEAM_COUNT = 3;
 
 const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
   value: r.code,
@@ -69,21 +74,24 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   );
 
   const [name, setName] = useState("");
-  // #528: チーム数を変えると teamRows が動的に伸縮 (= 初期 3 行)。
+  // チーム数を変えると teamRows が動的に伸縮 (= 初期 INITIAL_TEAM_COUNT 行)。
   const [teamRows, setTeamRows] = useState<TeamRow[]>(() =>
-    Array.from({ length: 3 }, (_, i) => ({ internalSlug: `team-${i + 1}`, awsAccountId: "" })),
+    Array.from({ length: INITIAL_TEAM_COUNT }, (_, i) => ({
+      internalSlug: `team-${i + 1}`,
+      awsAccountId: "",
+    })),
   );
   const [selectedProblems, setSelectedProblems] = useState<readonly MultiselectProps.Option[]>([]);
   const [problemRows, setProblemRows] = useState<ProblemRow[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  /** #528: チーム数の Input が変わったら teamRows を伸縮する。
-   *   - 増えるとき: 既存 row はそのまま、新 row は `team-N` の internalSlug + 空 account
-   *   - 減るとき: 末尾を捨てる (= operator が入力した内容を可能な限り保持) */
+  /** チーム数の Input 変更で teamRows を伸縮。同数なら same-reference を返して
+   *  無駄な再 render を防ぐ。減るとき末尾捨て、増えるとき新 row 追加。 */
   const handleTeamCountChange = (next: number) => {
     setTeamRows((prev) => {
-      if (next <= prev.length) return prev.slice(0, Math.max(next, 0));
+      if (next === prev.length) return prev;
+      if (next < prev.length) return prev.slice(0, Math.max(next, 0));
       const additions = Array.from({ length: next - prev.length }, (_, i) => ({
         internalSlug: `team-${prev.length + i + 1}`,
         awsAccountId: "",
@@ -120,27 +128,36 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
     setProblemRows((rows) => rows.map((r) => (r.problemId === problemId ? { ...r, ...patch } : r)));
   };
 
+  // teamRows ベースの validation を 1 pass に集約 (= 4 つ .every() / IIFE を回す代わり)。
+  // teamRows 変更時のみ再評価され、render path の負担を減らす。
+  const teamValidation = useMemo(() => {
+    let allSlugsValid = true;
+    let allAccountsValid = true;
+    const slugs = new Set<string>();
+    let hasDuplicateSlug = false;
+    for (const t of teamRows) {
+      if (!SLUG_RE.test(t.internalSlug)) allSlugsValid = false;
+      if (!ACCOUNT_ID_RE.test(t.awsAccountId)) allAccountsValid = false;
+      if (slugs.has(t.internalSlug)) hasDuplicateSlug = true;
+      else slugs.add(t.internalSlug);
+    }
+    return { allSlugsValid, allAccountsValid, hasDuplicateSlug };
+  }, [teamRows]);
+  // Table の items に渡す配列を teamRows ベースで memo 化。Cloudscape Table は items の
+  // shallow identity で再 render 判定するので、毎 render 新 array を渡すと無駄に重い
+  // (= 99 行 × 2 column の Input が全部 reconcile される)。
+  const teamTableItems = useMemo(() => teamRows.map((t, i) => ({ ...t, idx: i })), [teamRows]);
   const teamCountInvalid = teamRows.length < TEAMS_MIN || teamRows.length > TEAMS_MAX;
   const nameInvalid = name.length === 0 || name.length > NAME_MAX;
-  const allTeamSlugsValid = teamRows.every((t) => SLUG_RE.test(t.internalSlug));
-  const allTeamAccountsValid = teamRows.every((t) => ACCOUNT_ID_RE.test(t.awsAccountId));
-  const duplicateSlugs = (() => {
-    const seen = new Set<string>();
-    for (const t of teamRows) {
-      if (seen.has(t.internalSlug)) return true;
-      seen.add(t.internalSlug);
-    }
-    return false;
-  })();
   const canSubmit =
     !!apiClient &&
     !submitting &&
     !nameInvalid &&
     !teamCountInvalid &&
     problemRows.length > 0 &&
-    allTeamSlugsValid &&
-    allTeamAccountsValid &&
-    !duplicateSlugs;
+    teamValidation.allSlugsValid &&
+    teamValidation.allAccountsValid &&
+    !teamValidation.hasDuplicateSlug;
 
   const handleSubmit = async () => {
     if (!canSubmit || !apiClient) return;
@@ -149,18 +166,16 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
     try {
       const res = await createEvent(apiClient, {
         name,
-        // #528: teams は internalSlug + awsAccountId のペア。
         teams: teamRows.map((t) => ({
           internalSlug: t.internalSlug,
           awsAccountId: t.awsAccountId,
         })),
-        // 問題側は region のみ (account は team 側に移動)。
         problems: problemRows.map((r) => ({
           problemId: r.problemId,
           defaultRegion: r.defaultRegion,
         })),
       });
-      // #530: 作成直後に EventDetail へ。teamLoginKey は EventDetail で常時表示。
+      // teamLoginKey は EventDetail で常時表示するので作成直後に遷移 (#530)。
       navigate(`/events/${res.eventId}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -209,7 +224,10 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                   inputMode="numeric"
                   value={String(teamRows.length)}
                   onChange={({ detail }) => {
-                    const next = Number.parseInt(detail.value.replace(/\D/g, "").slice(0, 3), 10);
+                    const next = Number.parseInt(
+                      detail.value.replace(/\D/g, "").slice(0, TEAM_COUNT_INPUT_MAX_LEN),
+                      10,
+                    );
                     if (Number.isFinite(next))
                       handleTeamCountChange(Math.max(0, Math.min(TEAMS_MAX, next)));
                   }}
@@ -239,7 +257,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
             ) : (
               <Table
                 variant="embedded"
-                items={teamRows.map((t, i) => ({ ...t, idx: i }))}
+                items={teamTableItems}
                 columnDefinitions={[
                   {
                     id: "slug",
@@ -266,7 +284,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                         invalid={t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)}
                         onChange={({ detail }) =>
                           updateTeamRow(t.idx, {
-                            awsAccountId: detail.value.replace(/\D/g, "").slice(0, 12),
+                            awsAccountId: detail.value
+                              .replace(/\D/g, "")
+                              .slice(0, ACCOUNT_ID_MAX_LEN),
                           })
                         }
                       />
@@ -275,7 +295,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                 ]}
               />
             )}
-            {duplicateSlugs && (
+            {teamValidation.hasDuplicateSlug && (
               <Box variant="small" color="text-status-error" padding={{ top: "xs" }}>
                 重複する internalSlug があります。各 team で固有の slug を指定してください。
               </Box>

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -14,7 +14,7 @@ import Table from "@cloudscape-design/components/table";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
-import { createEvent, type EventProblemTarget } from "../api/events-client";
+import { createEvent } from "../api/events-client";
 import type { AppConfig } from "../config";
 import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
 import { listProblemSummaries } from "../data/problems";
@@ -30,8 +30,19 @@ const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
   label: r.label,
 }));
 
-interface ProblemRow extends EventProblemTarget {
+interface ProblemRow {
+  problemId: string;
   problemName: string;
+  defaultRegion: string;
+}
+
+/**
+ * #528: 各 team の deploy 先 AWS Account ID は **team 単位** に。region は問題テンプレが
+ * 特定 region 依存の場合があるので問題単位を維持。
+ */
+interface TeamRow {
+  internalSlug: string;
+  awsAccountId: string;
 }
 
 /**
@@ -39,8 +50,9 @@ interface ProblemRow extends EventProblemTarget {
  *
  * 入力:
  *   - Event 名 (1〜120 文字)
- *   - チーム数 (1〜99) — 作成時に `team-1`, `team-2` ... の internalSlug が自動付番される
- *   - 問題セット (`Multiselect`) — 各問題ごとに deploy 先 account / region を入力
+ *   - チーム数 (1〜99) を変えると Teams table の行が動的に増減
+ *   - **Teams table** (#528): 各 team の internalSlug + AWS Account ID を入力
+ *   - 問題セット (`Multiselect`) — 各問題ごとに deploy region を選ぶ (account は team 単位)
  *
  * 提出後は EventDetail に直接 navigate する (#530)。teamLoginKey は EventDetail の
  * 「チーム」 table で常時表示 + 各行にコピー button があるので、modal で 1 度きり露出
@@ -57,13 +69,34 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   );
 
   const [name, setName] = useState("");
-  const [teamCount, setTeamCount] = useState("3");
+  // #528: チーム数を変えると teamRows が動的に伸縮 (= 初期 3 行)。
+  const [teamRows, setTeamRows] = useState<TeamRow[]>(() =>
+    Array.from({ length: 3 }, (_, i) => ({ internalSlug: `team-${i + 1}`, awsAccountId: "" })),
+  );
   const [selectedProblems, setSelectedProblems] = useState<readonly MultiselectProps.Option[]>([]);
   const [problemRows, setProblemRows] = useState<ProblemRow[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Multiselect 変更時は problemRows を sync (既存行は値保持、新規分は default)。
+  /** #528: チーム数の Input が変わったら teamRows を伸縮する。
+   *   - 増えるとき: 既存 row はそのまま、新 row は `team-N` の internalSlug + 空 account
+   *   - 減るとき: 末尾を捨てる (= operator が入力した内容を可能な限り保持) */
+  const handleTeamCountChange = (next: number) => {
+    setTeamRows((prev) => {
+      if (next <= prev.length) return prev.slice(0, Math.max(next, 0));
+      const additions = Array.from({ length: next - prev.length }, (_, i) => ({
+        internalSlug: `team-${prev.length + i + 1}`,
+        awsAccountId: "",
+      }));
+      return [...prev, ...additions];
+    });
+  };
+
+  const updateTeamRow = (idx: number, patch: Partial<TeamRow>) => {
+    setTeamRows((rows) => rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  };
+
+  // Multiselect 変更時は problemRows を sync (既存行は値保持、新規分は default region)。
   const onProblemsChange = (next: readonly MultiselectProps.Option[]) => {
     setSelectedProblems(next);
     setProblemRows((prev) => {
@@ -77,7 +110,6 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
           return {
             problemId: opt.value,
             problemName: meta?.name ?? opt.value,
-            defaultAwsAccountId: "",
             defaultRegion: DEFAULT_AWS_REGION.code,
           };
         });
@@ -88,44 +120,47 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
     setProblemRows((rows) => rows.map((r) => (r.problemId === problemId ? { ...r, ...patch } : r)));
   };
 
-  const teamCountNum = Number.parseInt(teamCount, 10);
-  const teamCountInvalid =
-    !Number.isFinite(teamCountNum) || teamCountNum < TEAMS_MIN || teamCountNum > TEAMS_MAX;
+  const teamCountInvalid = teamRows.length < TEAMS_MIN || teamRows.length > TEAMS_MAX;
   const nameInvalid = name.length === 0 || name.length > NAME_MAX;
-  const allAccountsValid = problemRows.every((r) => ACCOUNT_ID_RE.test(r.defaultAwsAccountId));
+  const allTeamSlugsValid = teamRows.every((t) => SLUG_RE.test(t.internalSlug));
+  const allTeamAccountsValid = teamRows.every((t) => ACCOUNT_ID_RE.test(t.awsAccountId));
+  const duplicateSlugs = (() => {
+    const seen = new Set<string>();
+    for (const t of teamRows) {
+      if (seen.has(t.internalSlug)) return true;
+      seen.add(t.internalSlug);
+    }
+    return false;
+  })();
   const canSubmit =
     !!apiClient &&
     !submitting &&
     !nameInvalid &&
     !teamCountInvalid &&
     problemRows.length > 0 &&
-    allAccountsValid;
+    allTeamSlugsValid &&
+    allTeamAccountsValid &&
+    !duplicateSlugs;
 
   const handleSubmit = async () => {
     if (!canSubmit || !apiClient) return;
     setSubmitting(true);
     setError(null);
     try {
-      const teams = Array.from({ length: teamCountNum }, (_, i) => ({
-        internalSlug: `team-${i + 1}`,
-      }));
-      // SLUG_RE 違反は zod / 受け側でも弾かれるが UX 的に事前 validate
-      const slugInvalid = teams.find((t) => !SLUG_RE.test(t.internalSlug));
-      if (slugInvalid) {
-        throw new Error(`team slug の形式が不正: ${slugInvalid.internalSlug}`);
-      }
       const res = await createEvent(apiClient, {
         name,
-        teams,
+        // #528: teams は internalSlug + awsAccountId のペア。
+        teams: teamRows.map((t) => ({
+          internalSlug: t.internalSlug,
+          awsAccountId: t.awsAccountId,
+        })),
+        // 問題側は region のみ (account は team 側に移動)。
         problems: problemRows.map((r) => ({
           problemId: r.problemId,
-          defaultAwsAccountId: r.defaultAwsAccountId,
           defaultRegion: r.defaultRegion,
         })),
       });
-      // #530: 旧 UX は「teamLoginKey は一度きり表示」 modal を出していたが、operator が
-      // 配布チャンスを逃すと event 作り直しになる非可逆 UX。EventDetail で常時 teamLoginKey
-      // を表示する方針に合わせ、modal は廃止して直接 EventDetail に navigate。
+      // #530: 作成直後に EventDetail へ。teamLoginKey は EventDetail で常時表示。
       navigate(`/events/${res.eventId}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -172,14 +207,79 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                 <Input
                   type="number"
                   inputMode="numeric"
-                  value={teamCount}
-                  onChange={({ detail }) =>
-                    setTeamCount(detail.value.replace(/\D/g, "").slice(0, 3))
-                  }
+                  value={String(teamRows.length)}
+                  onChange={({ detail }) => {
+                    const next = Number.parseInt(detail.value.replace(/\D/g, "").slice(0, 3), 10);
+                    if (Number.isFinite(next))
+                      handleTeamCountChange(Math.max(0, Math.min(TEAMS_MAX, next)));
+                  }}
                   invalid={teamCountInvalid}
                 />
               </FormField>
             </ColumnLayout>
+          </Container>
+
+          {/* #528: Teams section — 各 team の internalSlug + AWS Account ID を per-team で入力。
+           *   旧 UX は problem 単位で 1 account 共有だったが、real competition では各 team が
+           *   自社 account を持つため per-team 入力にする。 */}
+          <Container
+            header={
+              <Header
+                variant="h2"
+                description="各 team の deploy 先 AWS Account ID を入力します (12 桁数字)。internalSlug は CFn StackName 由来になり deploy 後 immutable。"
+              >
+                Teams ({teamRows.length})
+              </Header>
+            }
+          >
+            {teamRows.length === 0 ? (
+              <Box variant="small" color="text-status-inactive">
+                チーム数を 1 以上に設定してください。
+              </Box>
+            ) : (
+              <Table
+                variant="embedded"
+                items={teamRows.map((t, i) => ({ ...t, idx: i }))}
+                columnDefinitions={[
+                  {
+                    id: "slug",
+                    header: "internalSlug",
+                    cell: (t) => (
+                      <Input
+                        value={t.internalSlug}
+                        placeholder="team-1"
+                        invalid={!SLUG_RE.test(t.internalSlug)}
+                        onChange={({ detail }) =>
+                          updateTeamRow(t.idx, { internalSlug: detail.value })
+                        }
+                      />
+                    ),
+                  },
+                  {
+                    id: "account",
+                    header: "AWS Account ID",
+                    cell: (t) => (
+                      <Input
+                        value={t.awsAccountId}
+                        placeholder="123456789012"
+                        inputMode="numeric"
+                        invalid={t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)}
+                        onChange={({ detail }) =>
+                          updateTeamRow(t.idx, {
+                            awsAccountId: detail.value.replace(/\D/g, "").slice(0, 12),
+                          })
+                        }
+                      />
+                    ),
+                  },
+                ]}
+              />
+            )}
+            {duplicateSlugs && (
+              <Box variant="small" color="text-status-error" padding={{ top: "xs" }}>
+                重複する internalSlug があります。各 team で固有の slug を指定してください。
+              </Box>
+            )}
           </Container>
 
           <Container header={<Header variant="h2">問題セット</Header>}>
@@ -199,26 +299,6 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                   items={problemRows}
                   columnDefinitions={[
                     { id: "name", header: "問題", cell: (r) => r.problemName },
-                    {
-                      id: "account",
-                      header: "AWS Account ID",
-                      cell: (r) => (
-                        <Input
-                          value={r.defaultAwsAccountId}
-                          placeholder="123456789012"
-                          inputMode="numeric"
-                          invalid={
-                            r.defaultAwsAccountId.length > 0 &&
-                            !ACCOUNT_ID_RE.test(r.defaultAwsAccountId)
-                          }
-                          onChange={({ detail }) =>
-                            updateProblemRow(r.problemId, {
-                              defaultAwsAccountId: detail.value.replace(/\D/g, "").slice(0, 12),
-                            })
-                          }
-                        />
-                      ),
-                    },
                     {
                       id: "region",
                       header: "Region",

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -619,6 +619,19 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                   ),
               },
               {
+                // #528: team 単位の deploy 先 AWS Account ID。旧 Event は undefined。
+                id: "account",
+                header: "AWS Account ID",
+                cell: (t) =>
+                  t.awsAccountId ? (
+                    <code>{t.awsAccountId}</code>
+                  ) : (
+                    <Box variant="small" color="text-status-inactive">
+                      (旧 Event: problem 既定値を使用)
+                    </Box>
+                  ),
+              },
+              {
                 id: "key",
                 header: "teamLoginKey",
                 // #554: copy button を併設して text 選択 + Ctrl-C より早く配布できるように。

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -88,11 +88,11 @@ describe("createEvent", () => {
     });
     await createEvent(client, {
       name: "Spring",
-      teams: [{ internalSlug: "team-1" }],
+      // #528: 各 team は自社 AWS account を持つ。problem からは defaultAwsAccountId が消えた
+      teams: [{ internalSlug: "team-1", awsAccountId: "111111111111" }],
       problems: [
         {
           problemId: "hello-world",
-          defaultAwsAccountId: "999999999999",
           defaultRegion: "ap-northeast-1",
         },
       ],

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -93,13 +93,24 @@ export async function bulkDeployEvent(
 
   // teams × problems を全展開し、deployment 行 + publish entry を組み立てる。
   // shared.problemsCatalog (problemId → problemDir) に存在しない problemId は skip。
+  // #528: deploy target の awsAccountId は team から (= 各 team は自社 AWS account)、region は
+  // problem から (= 問題テンプレが特定 region 依存)。team.awsAccountId が無い旧 Event は
+  // problem.defaultAwsAccountId に fallback (Phase 2 で fallback も削除予定)。
   const items: DeploymentItem[] = [];
   const entries: PutEventsRequestEntry[] = [];
   let skipped = 0;
   for (const team of teams) {
+    const teamAwsAccountId = team.awsAccountId;
     for (const problem of problems) {
       const problemDir = shared.problemsCatalog[problem.problemId];
       if (!problemDir) {
+        skipped++;
+        continue;
+      }
+      // #528: team.awsAccountId が新 source-of-truth。旧 Event は problem.defaultAwsAccountId
+      // を fallback として使う。両方無いと deploy target を組めないので skip。
+      const awsAccountId = teamAwsAccountId ?? problem.defaultAwsAccountId;
+      if (!awsAccountId) {
         skipped++;
         continue;
       }
@@ -116,7 +127,7 @@ export async function bulkDeployEvent(
         jobId,
         problemId: problem.problemId,
         tenantId,
-        awsAccountId: problem.defaultAwsAccountId,
+        awsAccountId,
         region: problem.defaultRegion,
         teamName: team.internalSlug,
         namePrefix,
@@ -140,7 +151,7 @@ export async function bulkDeployEvent(
         teamSlug,
         namePrefix,
         region: problem.defaultRegion,
-        awsAccountId: problem.defaultAwsAccountId,
+        awsAccountId,
       };
       entries.push({
         EventBusName: shared.eventBusName,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
@@ -66,6 +66,7 @@ export async function createEvent(
       tenantId: ctx.tenantId,
       internalSlug: t.internalSlug,
       teamLoginKey,
+      awsAccountId: t.awsAccountId,
       createdAt,
       updatedAt: createdAt,
       expiresAt,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -198,6 +198,8 @@ export async function getEventDetail(
       // TeamsTable.displayName (operator 事前設定があれば)、それも無ければ undefined。
       displayName: displayNameByTeamId.get(teamId) ?? fromTeamsTable,
       teamLoginKey: typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
+      // #528: team の deploy 先 AWS Account ID。旧 Event は undefined。
+      awsAccountId: typeof t.awsAccountId === "string" ? t.awsAccountId : undefined,
     };
   });
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -51,12 +51,23 @@ export const EventStatusSchema = z.enum([
 export type EventStatus = z.infer<typeof EventStatusSchema>;
 
 /**
- * Event 内の 1 問題ごとの **デフォルト deploy target**。Bulk Deploy 時に各 team に対して
- * この account / region で deploy する。team ごとに override したい場合は将来拡張。
+ * Event 内の 1 問題ごとの deploy target。region は問題テンプレが特定 region 依存の場合が
+ * あるため **problem 単位** で固定。AWS Account ID は #528 以降 **team 単位** に移行する
+ * (= 各 team は自社 AWS account で全問題を deploy する運用モデル)。
+ *
+ * `defaultAwsAccountId` は migration 期間中 optional に保つ:
+ *   - 新規 Event: 不要 (= team.awsAccountId を使う)
+ *   - 旧 Event: 既存値を fallback として使う (bulk-deploy.ts の `team.awsAccountId ??`)
+ *
+ * Phase 2 で `defaultAwsAccountId` を完全削除する予定。
  */
 export const EventProblemTargetSchema = z.object({
   problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
-  defaultAwsAccountId: z.string().regex(/^\d{12}$/, "AWS Account ID は 12 桁の数字"),
+  /** @deprecated #528 で team 単位 (team.awsAccountId) に移行。旧 Event の fallback としてのみ残す */
+  defaultAwsAccountId: z
+    .string()
+    .regex(/^\d{12}$/, "AWS Account ID は 12 桁の数字")
+    .optional(),
   defaultRegion: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/, "AWS region 形式が不正です"),
 });
 export type EventProblemTarget = z.infer<typeof EventProblemTargetSchema>;
@@ -85,6 +96,9 @@ export interface TeamItem {
   internalSlug: string;
   /** 短命 bearer。team scope (1 key で event 内 N 問題にアクセス可)。 */
   teamLoginKey: string;
+  /** #528: team の deploy 先 AWS Account ID (12 桁数字)。Bulk Deploy で problem.defaultRegion と
+   *  組み合わせて使う。旧 Event は持たない (= bulk-deploy で problem.defaultAwsAccountId に fallback)。 */
+  awsAccountId?: string;
   createdAt: string;
   updatedAt: string;
   expiresAt: number;
@@ -109,6 +123,8 @@ export const CreateEventRequestSchema = z.object({
             /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/,
             "internalSlug は a-z0-9- (RFC1035-ish) のみ",
           ),
+        /** #528: 各 team の deploy 先 AWS Account ID。problem.defaultAwsAccountId 廃止に伴い必須化 */
+        awsAccountId: z.string().regex(/^\d{12}$/, "AWS Account ID は 12 桁の数字"),
       }),
     )
     .min(1)
@@ -199,6 +215,8 @@ export const TeamSummarySchema = z.object({
   displayName: z.string().optional(),
   /** 詳細経路でのみ teamLoginKey を返す。一覧経路には含めない。 */
   teamLoginKey: z.string().optional(),
+  /** #528: team の deploy 先 AWS Account ID。旧 Event は undefined。 */
+  awsAccountId: z.string().optional(),
 });
 export type TeamSummary = z.infer<typeof TeamSummarySchema>;
 

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -61,6 +61,9 @@ const sampleTeams = (n: number) =>
     tenantId: "tenant-acme",
     internalSlug: `team-${i + 1}`,
     teamLoginKey: `key-${i + 1}`,
+    // #528: 各 team に独自 awsAccountId。test は 12 桁数字で 111... / 222... / ... と
+    // pad して別 account を pin する。fallback test では明示的に外す。
+    awsAccountId: `${i + 1}`.repeat(12).slice(0, 12),
   }));
 
 describe("bulkDeployEvent", () => {
@@ -226,6 +229,87 @@ describe("bulkDeployEvent", () => {
     for (const item of transactCmd.input.TransactItems ?? []) {
       expect(item.Put?.Item?.eventStartsAt).toBeUndefined();
     }
+  });
+
+  it("#528: deployment 行の awsAccountId は **team** の awsAccountId を使うべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+
+    const transactCmd = ddbSend.mock.calls.find((c) => c[0] instanceof TransactWriteCommand)?.[0];
+    const items = (transactCmd as TransactWriteCommand).input.TransactItems ?? [];
+    // 2 teams × 2 problems = 4 items
+    expect(items).toHaveLength(4);
+    // T1 (awsAccountId=111111111111) と T2 (awsAccountId=222222222222) で別 account に
+    const accountsByTeam = new Map<string, Set<string>>();
+    for (const it of items) {
+      const teamId = String(it.Put?.Item?.teamId ?? "");
+      const acct = String(it.Put?.Item?.awsAccountId ?? "");
+      if (!accountsByTeam.has(teamId)) accountsByTeam.set(teamId, new Set());
+      accountsByTeam.get(teamId)?.add(acct);
+    }
+    // T1 の 2 deploy はすべて 111111111111、T2 の 2 deploy はすべて 222222222222
+    expect([...(accountsByTeam.get("T1") ?? [])]).toEqual(["111111111111"]);
+    expect([...(accountsByTeam.get("T2") ?? [])]).toEqual(["222222222222"]);
+  });
+
+  it("#528 migration: team.awsAccountId 無い旧 Event は problem.defaultAwsAccountId に fallback", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    // sampleTeams から awsAccountId を意図的に外す (旧 Event)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          eventId: "EV1",
+          teamId: "T1",
+          tenantId: "tenant-acme",
+          internalSlug: "team-1",
+          teamLoginKey: "key-1",
+        },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const transactCmd = ddbSend.mock.calls.find((c) => c[0] instanceof TransactWriteCommand)?.[0];
+    const items = (transactCmd as TransactWriteCommand).input.TransactItems ?? [];
+    expect(items.length).toBeGreaterThan(0);
+    // problem.defaultAwsAccountId (= 999999999999、sampleEvent 内) に fallback
+    for (const it of items) {
+      expect(it.Put?.Item?.awsAccountId).toBe("999999999999");
+    }
+  });
+
+  it("#528: team.awsAccountId も problem.defaultAwsAccountId も無いと skip するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    // problem.defaultAwsAccountId を外した event
+    ddbSend.mockResolvedValueOnce({
+      Item: sampleEvent({
+        problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+      }),
+    });
+    // team.awsAccountId も無い旧 team
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          eventId: "EV1",
+          teamId: "T1",
+          tenantId: "tenant-acme",
+          internalSlug: "team-1",
+          teamLoginKey: "key-1",
+        },
+      ],
+    });
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    // 1 team × 1 problem = 1、awsAccountId 無いので全 skip
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 1 } });
+    expect(eventsSend).not.toHaveBeenCalled();
   });
 
   it("成功後に Event status を DRAFT → DEPLOYING に倒すべき (status badge 視認用)", async () => {

--- a/infrastructure/test/problem-deploy/event-create.test.ts
+++ b/infrastructure/test/problem-deploy/event-create.test.ts
@@ -25,11 +25,15 @@ function buildShared(): {
 
 const sampleRequest = (over: Partial<CreateEventRequest> = {}): CreateEventRequest => ({
   name: "JAWS-UG 春の陣 2026",
-  teams: [{ internalSlug: "team-alpha" }, { internalSlug: "team-beta" }],
+  // #528: 各 team は自社 AWS account を持つ。test data は別 account を割り当て、
+  // 「team A が team B の account に deploy しない」を pin できるようにする。
+  teams: [
+    { internalSlug: "team-alpha", awsAccountId: "111111111111" },
+    { internalSlug: "team-beta", awsAccountId: "222222222222" },
+  ],
   problems: [
     {
       problemId: "hello-world-battle",
-      defaultAwsAccountId: "999999999999",
       defaultRegion: "ap-northeast-1",
     },
   ],
@@ -91,7 +95,10 @@ describe("createEvent", () => {
         shared,
         { tenantId: "tenant-acme", nowMs: NOW_MS },
         sampleRequest({
-          teams: [{ internalSlug: "dup" }, { internalSlug: "dup" }],
+          teams: [
+            { internalSlug: "dup", awsAccountId: "111111111111" },
+            { internalSlug: "dup", awsAccountId: "222222222222" },
+          ],
         }),
       ),
     ).rejects.toBeInstanceOf(DuplicateInternalSlugError);


### PR DESCRIPTION
旧 UX: 問題ごとに \`defaultAwsAccountId\` を 1 つ持ち、全 team が同じ AWS account に deploy。real competition (= 各 team が自社 account) で破綻していた。新 UX: AWS Account ID を **team 単位**、region は **問題単位** で持つ。

## 設計判断

| 軸 | scope | 理由 |
|---|---|---|
| AWS Account ID | **team** | 各 team は自社 1 account で全問題 deploy するのが運用モデル |
| Region | problem (現状維持) | 問題テンプレが特定 region 依存のことがある (例: us-east-1 のみ) |

旧 \`EventProblemTarget.defaultAwsAccountId\` は **optional に保つ** (= deprecated alias、旧 Event 用 fallback)。Phase 2 で完全削除予定。

## 変更点

**Backend**:
- \`types.ts\`: CreateEventRequest.teams[i] に awsAccountId 必須、EventProblemTarget.defaultAwsAccountId optional 化、TeamItem / TeamSummary に awsAccountId optional 追加
- \`create.ts\`: TeamItem 書き込みに awsAccountId 含める
- \`bulk-deploy.ts\`: deploy target を team.awsAccountId から取り、旧 Event は problem.defaultAwsAccountId に fallback、両方無いと skip
- \`list.ts\`: GET /events/:id の team summary に awsAccountId 含める

**Frontend (application-admin-console)**:
- \`EventCreate.tsx\`: 旧「問題ごとに AWS Account ID」を削除、新「Teams」 section を追加。チーム数を変えると行が動的に伸縮、各 team で internalSlug + awsAccountId 入力。duplicate slug / invalid account の validation 付き
- \`EventDetail.tsx\`: 「チーム」 table に「AWS Account ID」 column 追加、旧 Event は「(旧 Event: problem 既定値を使用)」表示
- \`events-client.ts\`: type 拡張

## Regression 分析

| # | 壊しうる挙動 | 確認 |
|---|---|---|
| 1 | 既存 Event の bulk-deploy | ✅ fallback で旧 Event も deploy 可、test で pin |
| 2 | EventDetail / EventList rendering | ✅ TeamSummary に optional 追加のみ、欠落時は「旧 Event」表示 |
| 3 | DDB schema breaking | ❌ 完全に additive。awsAccountId は新 field |
| 4 | API breaking | ❌ defaultAwsAccountId optional 化は backward compat |
| 5 | 既存 tests | ✅ infra 40 files / **383/383**、admin-console 11 files / 80/80 |

## 物理影響

- event-handler Lambda: type + handler logic 変更、CFn asset hash 回るだけ
- IAM / table schema / API GW resource は **NO-OP** (= DDB は schemaless、新 field 追加のみ)
- application-admin-console frontend bundle 更新

## Test plan

- [x] vitest infra → 40 files / 383/383 passed (+3 #528 関連)
- [x] vitest admin-console → 11 files / 80/80
- [x] typecheck (4 packages) green
- [x] biome / \`make check-http-status\` green
- [ ] **deploy 後**: EventCreate で 3 team の awsAccountId を別 account で入力 → Bulk Deploy で各 team が指定 account に deploy、EventDetail で確認

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event creation now supports AWS account configuration per team; each team requires a dedicated AWS account ID assignment during setup
  * Event details page displays assigned AWS account ID for each team
  * Deployment targeting updated to use per-team AWS account assignments

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/580)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->