### PR TITLE
feat: ADR-008 v2 + microservice-migration-battle 雛形 (#572)

### DIFF
--- a/docs/architecture/adr-008-problem-payload-separation.html
+++ b/docs/architecture/adr-008-problem-payload-separation.html
@@ -1,0 +1,808 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-008: 問題カタログを Community Contribution Registry にする (DDB-backed catalog + S3 multi-tenant payload + GitHub PR 寄稿フロー)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+    --c-public: #0969da;
+    --c-private: #8250df;
+    --c-runtime: #1a7f37;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 1040px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-code-bg); padding: .8rem 1rem; border-radius: 4px; overflow-x: auto;
+        font-size: 0.85rem; line-height: 1.5; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.muted   { background: var(--c-bg-soft); color: var(--c-muted); }
+  .badge.public  { background: #cfe5ff; color: var(--c-public); }
+  .badge.private { background: #ece4ff; color: var(--c-private); }
+  .badge.runtime { background: #ddf4e0; color: var(--c-runtime); }
+  .badge.v1      { background: #f6f8fa; color: var(--c-muted); border: 1px solid var(--c-border); }
+  .badge.v2      { background: #cfe5ff; color: var(--c-link); }
+  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+               gap: .8rem; margin: 1rem 0; }
+  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem;
+                   background: var(--c-bg-soft); }
+  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .decision-card .body { font-size: 0.88rem; color: var(--c-text); }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0;
+            border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+  blockquote { margin: 0.6rem 0; padding: .6rem 1rem; border-left: 4px solid var(--c-warn);
+               background: #fff8c5; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
+  .versionbar {
+    background: linear-gradient(90deg, #ece4ff 0%, #cfe5ff 100%);
+    border-radius: 4px; padding: .5rem .8rem; margin: .8rem 0 1.2rem;
+    font-size: 0.88rem; display: flex; gap: 1rem; align-items: center;
+  }
+  .versionbar .arrow { color: var(--c-muted); }
+
+  .arch-fig {
+    border: 1px solid var(--c-border); border-radius: 8px; background: #fff;
+    padding: 1rem 1.25rem 1.5rem; margin: 1rem 0 1.5rem;
+  }
+  .arch-fig .cap {
+    font-size: 0.78rem; font-weight: 700; color: var(--c-link);
+    letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: .6rem;
+  }
+  .arch-fig svg { display: block; max-width: 100%; height: auto; }
+
+  .seq {
+    background: var(--c-bg-soft); border: 1px solid var(--c-border);
+    border-radius: 6px; padding: .8rem 1rem; margin: .8rem 0;
+    font-family: monospace; font-size: 0.86rem; line-height: 1.7;
+    white-space: pre-wrap;
+  }
+
+  .repo-block {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0;
+  }
+  .repo-card {
+    border: 2px solid var(--c-border); border-radius: 8px; padding: .8rem 1rem;
+    background: var(--c-bg-soft);
+  }
+  .repo-card.public  { border-color: var(--c-public); }
+  .repo-card.private { border-color: var(--c-private); background: #faf6ff; }
+  .repo-card h4 { margin: 0 0 .4rem; color: var(--c-text); }
+  .repo-card pre {
+    background: #fff; border: 1px solid var(--c-border); padding: .6rem .8rem;
+    margin: .4rem 0 0; font-size: 0.78rem; line-height: 1.45;
+  }
+  .repo-card .role {
+    font-size: 0.78rem; color: var(--c-muted); margin: .2rem 0 .6rem;
+  }
+
+  @media (max-width: 720px) {
+    .repo-block { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>ADR-008: 問題カタログを Community Contribution Registry にする</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-11</div>
+    <div><b>Version:</b><span class="badge v2">v2</span> — community contribution model 中心に大幅改訂</div>
+    <div><b>Driver:</b><code>#572</code> (microservice-migration-battle) + user feedback「コミュニティでオリジナル問題を追加できる設計に」</div>
+    <div><b>Tracking:</b><code>#574</code></div>
+  </div>
+
+  <div class="versionbar">
+    <span class="badge v1">v1</span>
+    <span>「自分用 private repo + 答え漏れ防止」モデル</span>
+    <span class="arrow">→</span>
+    <span class="badge v2">v2</span>
+    <span><strong>寄稿モデルが本筋</strong>。v1 は「寄稿モデルの特殊ケース 1 つ」として吸収</span>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>v1 は <code>#572</code> (microservice-migration-battle) で「完成形のサービスコード自体が答え」となる
+Battle が起票され、答えが public repo にあると競技が成立しないという問題を解くために、
+「自分用 private repo + 運営 S3 publish + presigned URL fetch」を提案した。</p>
+
+<p>v1 を書いた直後 (2026-05-11)、ユーザーから次のフィードバックが入った:</p>
+
+<blockquote>
+要はオリジナル問題をコミュニティで追加できる設計になっていればいいんだけど。
+S3 とかにプッシュしてそこからロードしているとかならサードパーティーの問題もプッシュしてもらえばいい。
+</blockquote>
+
+<p>これを受けて v1 を見直すと、「自分が答え漏れを気にする」のは寄稿モデルの <strong>1 ユースケース</strong>
+にすぎず、本筋は「<strong>誰でも問題を追加できる仕組み</strong>」(= 答え漏れも結果として解決) である
+ことが分かった。本 ADR v2 はそれを設計する。</p>
+
+<h3>現状アーキテクチャの寄稿不可性</h3>
+
+<p>Explore agent で本体 repo の問題ロード経路を調査した結果 (= 2026-05-11 セッション):</p>
+
+<table>
+<tr><th>layer</th><th>現状</th><th>寄稿の障害</th></tr>
+<tr><td>カタログ表示</td>
+    <td><code>apps/application-admin-console/src/data/problems.ts:61-64</code> で Vite <code>import.meta.glob</code> が <strong>build 時に <code>problems/*/*/metadata.json</code> を bundle</strong></td>
+    <td>サードパーティー問題追加 = 本体 repo の rebuild & redeploy 必要</td></tr>
+<tr><td>CDK 配線</td>
+    <td><code>infrastructure/bin/infrastructure.ts:214</code> の <code>discoverProblemsCatalog()</code> が build 時に走査 → Lambda env <code>BATTLE_PROBLEMS_CATALOG</code> に inject</td>
+    <td>build 時固定、動的追加不可</td></tr>
+<tr><td>template.yaml の deploy</td>
+    <td><code>install.sh</code> が <strong>repo 全体を zip → S3</strong>、CodeBuild が <code>source.zip</code> 内の <code>problems/&lt;id&gt;/template.yaml</code> を <strong>直読</strong></td>
+    <td>問題が「本体 repo の一部」前提。S3 に他者が push しても CodeBuild は見ない</td></tr>
+<tr><td>validate-problems</td>
+    <td><code>scripts/validate-problems.ts</code> が <code>problems/SCHEMA.json</code> で全 metadata.json を JSON Schema 検証</td>
+    <td>本体 repo にあるものしか検証できない</td></tr>
+</table>
+
+<p>つまり現状は <strong>「問題 = TenkaCloud 本体のコードベース」</strong> が完全に前提で、
+寄稿の余地がない。寄稿モデル化は MVP-1 → ADR-003 Phase 2 (= DB-backed catalog) への
+移行と合流させる形で、本 ADR で前倒しする。</p>
+
+<h3>制約 (= 既存方針として動かさないもの)</h3>
+
+<ul>
+<li><strong>本体 repo は public OSS のまま</strong>(<code>CLAUDE.md</code>)</li>
+<li><strong>カタログ UX を維持</strong> — admin-console / participant-portal の表示・検索・フィルタが既存と等価以上に動く</li>
+<li><strong>deploy パイプラインの I/F を維持</strong> — Worker Lambda の <code>DeployRequested</code> 処理、ExternalId による cross-account AssumeRole (ADR-002) はそのまま</li>
+<li><strong>CFn ペライチ規約</strong> (<code>problems/README.md</code>) を維持</li>
+<li><strong>Free Tier 25 RCU/WCU 内</strong> (<code>DynamoDbLowCapacity</code> Aspect)</li>
+</ul>
+</section>
+
+<section>
+<h2>解くべき設計判断</h2>
+
+<h3>D1. カタログ storage</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="hide"><td>D1-A</td><td><span class="badge reject">却下</span></td>
+    <td>本体 repo の <code>problems/&lt;id&gt;/metadata.json</code> 静的ファイル (= 現状)</td>
+    <td>寄稿に rebuild 必要、寄稿者 PR を待つしかない</td></tr>
+<tr class="hide"><td>D1-B</td><td><span class="badge reject">却下</span></td>
+    <td>本体 repo の <code>problems/index.json</code> 集約 (= v1 案)</td>
+    <td>動的 CRUD ができない、寄稿者 metadata の attribution / 検索ができない</td></tr>
+<tr class="show"><td><b>D1-C</b></td><td><span class="badge accept">採用</span></td>
+    <td><strong>DDB <code>ProblemRegistry</code> table</strong> (= ADR-003 Phase 2 を前倒し)</td>
+    <td>動的 CRUD / 寄稿者 attribution / 検索 / フィルタ / 検証ステータス管理がすべて 1 ヶ所で完結</td></tr>
+</table>
+
+<h3>D2. 問題 payload (template.yaml + 実装ファイル) の storage</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="hide"><td>D2-A</td><td><span class="badge reject">却下</span></td>
+    <td>本体 repo の <code>problems/&lt;id&gt;/</code> (= 現状)</td>
+    <td>寄稿不可</td></tr>
+<tr class="hide"><td>D2-B</td><td><span class="badge reject">却下</span></td>
+    <td>GitHub Releases (寄稿者の repo の release artifact)</td>
+    <td>寄稿者ごとの GitHub 認証管理が複雑、CFn ペライチ規約と合わない</td></tr>
+<tr class="hide"><td>D2-C</td><td><span class="badge reject">却下</span></td>
+    <td>ECR private images にビルド済イメージを置く</td>
+    <td>CFn 規約と無関係、寄稿者ハードル高い</td></tr>
+<tr class="show"><td><b>D2-D</b></td><td><span class="badge accept">採用</span></td>
+    <td><strong>S3 multi-tenant prefix</strong> (<code>s3://tc-challenges-&lt;env&gt;/&lt;contributor&gt;/&lt;problem-id&gt;/&lt;version&gt;/</code>)</td>
+    <td>AWS-native / 寄稿者ごとに prefix 分離 / presigned URL 経路を流用 / 既存 S3 zip 配信モデルと自然に共存</td></tr>
+</table>
+
+<h3>D3. 寄稿フロー (= 寄稿者の入口)</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="show"><td><b>D3-A</b></td><td><span class="badge accept">採用 (MVP)</span></td>
+    <td><strong>GitHub PR ベース</strong>。寄稿者は本体 repo に <code>contributions/&lt;contributor&gt;/&lt;problem-id&gt;/{metadata.json,template.yaml}</code> + 実装ファイルを PR</td>
+    <td>OSS 慣習 / レビュー文化が継続 / MVP の実装最小 / 検証 = GitHub Actions に乗せられる</td></tr>
+<tr class="hide"><td>D3-B</td><td><span class="badge muted">後回し</span></td>
+    <td>Web UI (admin-console から template.yaml ドラッグ&ドロップ)</td>
+    <td>寄稿者ハードル低いが検証 UI / プレビューの実装重い、Phase 6+ で追加</td></tr>
+<tr class="hide"><td>D3-C</td><td><span class="badge muted">後回し</span></td>
+    <td>CLI (<code>tc challenge publish ./my-problem</code>)</td>
+    <td>git なしで投稿可能だが CLI 配布 / 認証が独立、Phase 7+ で追加</td></tr>
+</table>
+
+<p>MVP は <strong>A のみ</strong>。B / C は将来の追加経路として interface (= 検証 Lambda + S3 + DDB) を共有する設計にしておけば、後付けで足せる。</p>
+
+<h3>D4. 検証パイプライン</h3>
+
+<p>寄稿者が任意のテンプレートを投げてくる以上、運営アカウントが攻撃される / 課金爆弾を仕掛けられる
+リスクがある。完全マニュアルレビューは scale しないので、自動 + 人間承認の二段構成にする。</p>
+
+<table>
+<tr><th>レイヤー</th><th>内容</th><th>実装</th></tr>
+<tr><td>自動 (CI 段階)</td>
+    <td>① CFn lint (<code>cfn-lint</code>) / ② IAM 権限スキャン (<code>cfn-policy-validator</code> 相当) / ③ cost estimator (<code>infracost</code> or AWS Pricing API) / ④ 禁止リソース検査 (例: <code>AWS::Lambda::Function</code> の reserved concurrency 上限)</td>
+    <td>GitHub Actions on PR + 検証 Lambda</td></tr>
+<tr><td>運営承認</td>
+    <td>System Admin が PR を最終 review。問題説明 / scoring 設計 / 学習目的の妥当性</td>
+    <td>GitHub PR の review = merge 権限</td></tr>
+<tr><td>publish 後</td>
+    <td>S3 への upload は merge 後の Actions が OIDC role で実行</td>
+    <td>GitHub Actions OIDC + IAM</td></tr>
+</table>
+
+<p>「悪意ある寄稿者の deploy 一発で運営 acct が破綻する」事態を防ぐため、<strong>publish された
+template.yaml は競技者 acct 側にしか展開されない</strong> (= 運営 acct 側で展開しない)
+原則を厳守する。これは ADR-002 の cross-account federation で既に成立。</p>
+
+<h3>D5. 寄稿者 identity</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="show"><td><b>D5-A</b></td><td><span class="badge accept">採用</span></td>
+    <td><strong>GitHub OAuth / GitHub App</strong> (= 寄稿者は GitHub username で identify)</td>
+    <td>D3-A (GitHub PR フロー) と自然に整合 / 追加の認証基盤不要 / 寄稿者ハンドル = GitHub username</td></tr>
+<tr class="hide"><td>D5-B</td><td><span class="badge reject">却下</span></td>
+    <td>Cognito (= System Admin と同じプール)</td>
+    <td>寄稿者にとって sign-up ハードルが高い、外部寄稿促進に逆行</td></tr>
+<tr class="hide"><td>D5-C</td><td><span class="badge reject">却下</span></td>
+    <td>API token のみ</td>
+    <td>identity の attribution ができない (= 誰が投稿したか不明)</td></tr>
+</table>
+
+<h3>D6. 答え漏れ (= visibility)</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="hide"><td>D6-A</td><td><span class="badge reject">却下</span></td>
+    <td>全問題 public で OK (= 答え漏れ気にしない)</td>
+    <td><code>#572</code> 系の競技性問題が成立しない</td></tr>
+<tr class="show"><td><b>D6-B</b></td><td><span class="badge accept">採用</span></td>
+    <td><strong>寄稿時に <code>visibility: public | private</code> を選択</strong>。public = 全 file が見える / private = metadata + 説明だけ表示、payload は <strong>15 分 TTL presigned URL</strong> で deploy 時のみ取得</td>
+    <td>教材性のある問題と競技性のある問題が共存 / 寄稿者が選択責任</td></tr>
+<tr class="hide"><td>D6-C</td><td><span class="badge reject">却下</span></td>
+    <td>全問題 private (= 一切公開しない)</td>
+    <td>OSS 教材としての価値を失う / 既存 3 問題と矛盾</td></tr>
+</table>
+
+<p>private 問題の payload S3 URL は presigned URL 発行のみ。<strong>S3 bucket は BlockPublicAccess + bucket policy で Worker Lambda role からのみ read 可</strong>。</p>
+
+<h3>D7. 既存 <code>problems/</code> の扱い</h3>
+
+<table>
+<tr><th>案</th><th>採否</th><th>概要</th><th>主な決め手</th></tr>
+<tr class="hide"><td>D7-A</td><td><span class="badge reject">却下</span></td>
+    <td>削除して全部 DDB Registry に移行</td>
+    <td>OSS としての教材価値を失う / 既存 vitest / validate-problems が壊れる</td></tr>
+<tr class="show"><td><b>D7-B</b></td><td><span class="badge accept">採用</span></td>
+    <td><strong>既存 3 問題は public sample として残し、Registry には <code>contributor: "system"</code> として seed import</strong></td>
+    <td>既存資産を壊さず、Registry の動作確認の seed として使える / 「公式問題」と「寄稿問題」が同じ仕組みで共存</td></tr>
+<tr class="hide"><td>D7-C</td><td><span class="badge reject">却下</span></td>
+    <td>そのまま残し、Registry とは別管理</td>
+    <td>2 系統並列運用は複雑、カタログ表示の分岐が増える</td></tr>
+</table>
+
+<h3>D8. 検索 / フィルタリング UX</h3>
+
+<p>寄稿者が増えると問題数も増えるので、カタログ画面で facet 検索を提供する:</p>
+
+<ul>
+<li><strong>contributor</strong> (= GitHub username)</li>
+<li><strong>category</strong> (Battle / Challenge)</li>
+<li><strong>difficulty</strong> (1〜5)</li>
+<li><strong>tags</strong> (= metadata.json の tags)</li>
+<li><strong>validation status</strong> (validated / pending / rejected)</li>
+<li><strong>visibility</strong> (public / private)</li>
+</ul>
+
+<p>full-text search (= description 内容まで検索) は Phase 6+ で追加 (OpenSearch などを足す)。</p>
+
+<h3>D9. version 管理と stack 同一性</h3>
+
+<table>
+<tr><th>項目</th><th>決定</th></tr>
+<tr><td>version 識別子</td><td>git SHA 短縮 8 桁 + semver 任意 (例: <code>1.2.0+a1b2c3d4</code>)</td></tr>
+<tr><td>同一問題の version 上書き</td><td><span class="badge reject">禁止</span> — immutable</td></tr>
+<tr><td>競技中の version 固定</td><td><code>Deployments</code> DDB に <code>problemVersion</code> 列追加。teardown まで固定</td></tr>
+<tr><td>新 version 投稿</td><td>新 PR を立てて検証 → publish。古い version は deprecated にできるが、競技中の stack には影響なし</td></tr>
+<tr><td>S3 layout</td><td><code>s3://&lt;bucket&gt;/&lt;contributor&gt;/&lt;problem-id&gt;/&lt;version&gt;/{metadata.json,template.yaml,code.zip}</code></td></tr>
+</table>
+</section>
+
+<section>
+<h2>Decision (まとめ)</h2>
+
+<div class="decisions">
+  <div class="decision-card">
+    <div class="num">D1</div>
+    <div class="title">カタログ storage</div>
+    <div class="body">DDB <code>ProblemRegistry</code> table。ADR-003 Phase 2 を前倒し</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D2</div>
+    <div class="title">payload storage</div>
+    <div class="body">S3 multi-tenant prefix <code>tc-challenges-&lt;env&gt;/&lt;contributor&gt;/&lt;problem-id&gt;/&lt;version&gt;/</code></div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D3</div>
+    <div class="title">寄稿フロー</div>
+    <div class="body">GitHub PR ベース MVP。Web UI / CLI は将来追加</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D4</div>
+    <div class="title">検証パイプライン</div>
+    <div class="body">CFn lint + IAM scan + cost estimator + 禁止リソース検査 (自動) + 運営承認 (人間)</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D5</div>
+    <div class="title">寄稿者 identity</div>
+    <div class="body">GitHub OAuth / GitHub App。寄稿者ハンドル = GitHub username</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D6</div>
+    <div class="title">答え漏れ</div>
+    <div class="body">寄稿時に <code>visibility: public | private</code> 選択。private は 15min TTL presigned URL</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D7</div>
+    <div class="title">既存 problems/</div>
+    <div class="body">既存 3 問題は public sample で残し、<code>contributor: "system"</code> として Registry に seed import</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D8</div>
+    <div class="title">検索 / フィルタ</div>
+    <div class="body">contributor / category / difficulty / tags / validation / visibility の facet 検索。full-text は後回し</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D9</div>
+    <div class="title">version 管理</div>
+    <div class="body">immutable, 上書き禁止。Deployments に <code>problemVersion</code> 列を追加し競技中固定</div>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>アーキテクチャ図</h2>
+
+<div class="arch-fig">
+  <div class="cap">Figure 1 — 寄稿者 → 検証 → 配信 → deploy のライフサイクル</div>
+  <svg viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg"
+       font-family="-apple-system,BlinkMacSystemFont,Hiragino Sans,Yu Gothic UI,sans-serif" font-size="13">
+    <defs>
+      <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5"
+              markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0,0 L10,5 L0,10 z" fill="#59636e"/>
+      </marker>
+    </defs>
+
+    <rect x="20" y="30" width="200" height="100" rx="8" fill="#faf6ff" stroke="#8250df" stroke-width="2"/>
+    <text x="32" y="55" font-weight="700" fill="#8250df">① Contributor</text>
+    <text x="32" y="78" fill="#1f2328">GitHub user (任意)</text>
+    <text x="32" y="96" fill="#1f2328">自分の repo or 本体 fork</text>
+    <text x="32" y="114" fill="#1f2328">metadata + template + 実装</text>
+
+    <rect x="280" y="30" width="200" height="100" rx="8" fill="#fff8c5" stroke="#9a6700" stroke-width="2"/>
+    <text x="292" y="55" font-weight="700" fill="#9a6700">② GitHub PR</text>
+    <text x="292" y="78" fill="#1f2328">本体 repo に PR</text>
+    <text x="292" y="96" fill="#1f2328">contributions/&lt;user&gt;/&lt;id&gt;/</text>
+    <text x="292" y="114" fill="#1f2328">{metadata, template, code/}</text>
+
+    <rect x="540" y="30" width="200" height="100" rx="8" fill="#ddf4e0" stroke="#1a7f37" stroke-width="2"/>
+    <text x="552" y="55" font-weight="700" fill="#1a7f37">③ CI Validation</text>
+    <text x="552" y="78" fill="#1f2328">CFn lint / IAM scan</text>
+    <text x="552" y="96" fill="#1f2328">cost estimator</text>
+    <text x="552" y="114" fill="#1f2328">禁止リソース検査</text>
+
+    <rect x="800" y="30" width="180" height="100" rx="8" fill="#cfe5ff" stroke="#0969da" stroke-width="2"/>
+    <text x="812" y="55" font-weight="700" fill="#0969da">④ Operator Review</text>
+    <text x="812" y="78" fill="#1f2328">System Admin が</text>
+    <text x="812" y="96" fill="#1f2328">学習目的 / 妥当性</text>
+    <text x="812" y="114" fill="#1f2328">を最終 review → merge</text>
+
+    <line x1="220" y1="80" x2="280" y2="80" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <line x1="480" y1="80" x2="540" y2="80" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <line x1="740" y1="80" x2="800" y2="80" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+    <rect x="280" y="180" width="460" height="80" rx="8" fill="#fff8c5" stroke="#9a6700" stroke-width="2"/>
+    <text x="292" y="205" font-weight="700" fill="#9a6700">⑤ Post-merge GitHub Actions (OIDC)</text>
+    <text x="292" y="226" fill="#1f2328">1. zip code → 2. AssumeRole (短期 token)</text>
+    <text x="292" y="244" fill="#1f2328">3. s3 cp → 4. DDB ProblemRegistry に upsert (version, sha256, validatedAt)</text>
+
+    <line x1="510" y1="130" x2="510" y2="180" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+    <rect x="20" y="310" width="320" height="120" rx="8" fill="#cfe5ff" stroke="#0969da" stroke-width="2"/>
+    <text x="32" y="335" font-weight="700" fill="#0969da">⑥ DDB ProblemRegistry</text>
+    <text x="32" y="356" fill="#1f2328">PK: PROBLEM#&lt;id&gt;</text>
+    <text x="32" y="374" fill="#1f2328">SK: VERSION#&lt;version&gt;</text>
+    <text x="32" y="392" fill="#1f2328">attrs: contributor, visibility, sha256</text>
+    <text x="32" y="410" fill="#1f2328">       s3Bucket, s3KeyPrefix, status</text>
+
+    <rect x="380" y="310" width="320" height="120" rx="8" fill="#cfe5ff" stroke="#0969da" stroke-width="2"/>
+    <text x="392" y="335" font-weight="700" fill="#0969da">⑦ S3 tc-challenges-&lt;env&gt;</text>
+    <text x="392" y="356" fill="#1f2328">&lt;contributor&gt;/&lt;id&gt;/&lt;version&gt;/</text>
+    <text x="408" y="374" fill="#1f2328">  ├ metadata.json</text>
+    <text x="408" y="392" fill="#1f2328">  ├ template.yaml</text>
+    <text x="408" y="410" fill="#1f2328">  └ code.zip</text>
+
+    <line x1="450" y1="260" x2="450" y2="310" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+    <rect x="740" y="310" width="240" height="120" rx="8" fill="#ddf4e0" stroke="#1a7f37" stroke-width="2"/>
+    <text x="752" y="335" font-weight="700" fill="#1a7f37">⑧ Catalog UI</text>
+    <text x="752" y="356" fill="#1f2328">admin-console</text>
+    <text x="752" y="374" fill="#1f2328">application-admin-console</text>
+    <text x="752" y="392" fill="#1f2328">participant-portal</text>
+    <text x="752" y="410" fill="#1f2328">→ DDB から GET /problems</text>
+
+    <line x1="340" y1="370" x2="740" y2="370" stroke="#59636e" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+
+    <rect x="20" y="470" width="340" height="100" rx="8" fill="#ddf4e0" stroke="#1a7f37" stroke-width="2"/>
+    <text x="32" y="495" font-weight="700" fill="#1a7f37">⑨ ProblemDeploy Worker Lambda</text>
+    <text x="32" y="516" fill="#1f2328">DeployRequested → DDB lookup</text>
+    <text x="32" y="534" fill="#1f2328">→ S3 fetch template.yaml</text>
+    <text x="32" y="552" fill="#1f2328">→ presigned URL (15min) for code.zip</text>
+
+    <line x1="180" y1="430" x2="180" y2="470" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <line x1="540" y1="430" x2="290" y2="470" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+    <rect x="400" y="470" width="280" height="100" rx="8" fill="#f6f8fa" stroke="#59636e" stroke-width="2"/>
+    <text x="412" y="495" font-weight="700">⑩ 競技者 AWS account</text>
+    <text x="412" y="516" fill="#1f2328">CFn が template.yaml 展開</text>
+    <text x="412" y="534" fill="#1f2328">UserData curl &lt;presigned&gt; → code.zip</text>
+    <text x="412" y="552" fill="#1f2328">→ unzip → 起動</text>
+
+    <line x1="360" y1="520" x2="400" y2="520" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+    <rect x="720" y="470" width="260" height="100" rx="8" fill="#fff" stroke="#d1d9e0" stroke-width="2"/>
+    <text x="732" y="495" font-weight="700">⑪ 競技者 (browser)</text>
+    <text x="732" y="516" fill="#1f2328">participant-portal で問題を見る</text>
+    <text x="732" y="534" fill="#1f2328">問題 endpoint にアクセス</text>
+    <text x="732" y="552" fill="#1f2328">スコア獲得</text>
+
+    <line x1="680" y1="520" x2="720" y2="520" stroke="#59636e" stroke-width="1.5" marker-end="url(#arr)"/>
+  </svg>
+</div>
+
+<p><strong>図の読み方</strong>: ① の寄稿者は誰でも (自分含む)。② の PR が ③ の自動検証と ④ の運営承認の二段で merge される。⑤ で OIDC publish → ⑥ DDB と ⑦ S3 が更新。⑧ は DDB だけ見る。⑨ は deploy 時に DDB と S3 両方を見る。private 問題でも答えは ⑦ の S3 にしか存在せず、⑪ の競技者 browser からは見えない。</p>
+</section>
+
+<section>
+<h2>寄稿フロー (= MVP の入口、D3-A の詳細)</h2>
+
+<div class="seq">contributor 側:
+  $ git clone https://github.com/susumutomita/TenkaCloud
+  $ cd TenkaCloud
+  $ mkdir -p contributions/&lt;your-handle&gt;/&lt;problem-id&gt;/
+  $ cp problems/SCHEMA.json …  (= metadata.json を SCHEMA に沿って書く)
+  $ vim metadata.json  template.yaml  …
+  $ git checkout -b contrib/&lt;your-handle&gt;/&lt;problem-id&gt;
+  $ git push -u origin HEAD
+  $ gh pr create --title "feat(contrib): &lt;problem-name&gt; by &lt;your-handle&gt;" …
+
+CI (= 自動検証):
+  on pull_request:
+    .github/workflows/contrib-validate.yml が走る
+    ├─ cfn-lint contributions/&lt;handle&gt;/&lt;id&gt;/template.yaml
+    ├─ iam-scan (= 過剰権限 / wildcard resource 検出)
+    ├─ cost-estimate (= deploy の月額試算上限を 5 USD/team とか)
+    └─ schema validate metadata.json
+
+operator (= System Admin):
+  PR を開いて学習目的 / scoring / 説明の妥当性を review
+  → approve → merge
+
+post-merge (= GitHub Actions):
+  on push to main で contrib-publish.yml が走る (changed paths: contributions/**)
+    ├─ AssumeRole (OIDC, 短期 token)
+    ├─ zip contributions/&lt;handle&gt;/&lt;id&gt;/code/ → code.zip
+    ├─ aws s3 cp template.yaml metadata.json code.zip  (= s3://tc-challenges-&lt;env&gt;/&lt;handle&gt;/&lt;id&gt;/&lt;sha&gt;/)
+    └─ DDB upsert: ProblemRegistry に PROBLEM#&lt;id&gt; / VERSION#&lt;sha&gt; を入れる
+
+これ以降、catalog UI に「contributor: &lt;handle&gt;」付きで表示される。
+</div>
+
+<p>寄稿者の repo は <strong>本体 repo の fork で十分</strong> (= 別 repo でも可だが、PR 経路は本体 repo に投げる)。
+寄稿者は GitHub アカウントさえあれば追加の sign-up 不要。</p>
+</section>
+
+<section>
+<h2>DDB <code>ProblemRegistry</code> schema</h2>
+
+<table>
+<tr><th>属性</th><th>型</th><th>用途</th></tr>
+<tr><td><code>PK</code></td><td>S</td><td><code>PROBLEM#&lt;problem-id&gt;</code></td></tr>
+<tr><td><code>SK</code></td><td>S</td><td><code>VERSION#&lt;version&gt;</code> (= git SHA 短縮 + semver 任意)</td></tr>
+<tr><td><code>contributor</code></td><td>S</td><td>GitHub username (寄稿者ハンドル)。"system" = 公式</td></tr>
+<tr><td><code>category</code></td><td>S</td><td><code>Battle</code> | <code>Challenge</code></td></tr>
+<tr><td><code>visibility</code></td><td>S</td><td><code>public</code> | <code>private</code> (D6)</td></tr>
+<tr><td><code>status</code></td><td>S</td><td><code>validated</code> | <code>pending</code> | <code>rejected</code> | <code>deprecated</code></td></tr>
+<tr><td><code>metadata</code></td><td>M</td><td>SCHEMA.json 準拠の metadata 全体 (inline、UI 表示用)</td></tr>
+<tr><td><code>s3Bucket</code></td><td>S</td><td><code>tc-challenges-&lt;env&gt;</code></td></tr>
+<tr><td><code>s3KeyPrefix</code></td><td>S</td><td><code>&lt;contributor&gt;/&lt;problem-id&gt;/&lt;version&gt;/</code></td></tr>
+<tr><td><code>sha256</code></td><td>S</td><td>template.yaml + code.zip の SHA-256 (= immutable 証明)</td></tr>
+<tr><td><code>validatedAt</code></td><td>S</td><td>ISO 8601 timestamp</td></tr>
+<tr><td><code>publishedAt</code></td><td>S</td><td>ISO 8601</td></tr>
+<tr><td><code>tags</code></td><td>SS</td><td>tag set (= 検索 / フィルタ用)</td></tr>
+</table>
+
+<p>GSI:</p>
+
+<ul>
+<li><strong>GSI-1 (contributor-index)</strong>: PK = <code>contributor</code>, SK = <code>publishedAt</code> — 寄稿者ごとの問題一覧</li>
+<li><strong>GSI-2 (category-status-index)</strong>: PK = <code>category</code>, SK = <code>status#publishedAt</code> — カテゴリ別表示 / 検索</li>
+</ul>
+
+<p>RCU/WCU は 1/1 PROVISIONED (= <code>DynamoDbLowCapacity</code> Aspect 強制)。GSI も同じ。</p>
+</section>
+
+<section>
+<h2>Repo / Stack 構造</h2>
+
+<div class="repo-block">
+  <div class="repo-card public">
+    <h4><span class="badge public">public</span> TenkaCloud (本体)</h4>
+    <div class="role">プラットフォーム + カタログ + 寄稿受け入れ口</div>
+<pre>TenkaCloud/
+├── apps/                # SPA 群 (DDB API 経由のカタログに切替)
+├── infrastructure/lib/
+│   ├── problem-registry/        # ← 新設 stack
+│   │   ├── ddb.ts               # ProblemRegistry table
+│   │   ├── s3.ts                # tc-challenges-&lt;env&gt; bucket
+│   │   ├── validation-lambda/   # CI から叩く検証 Lambda
+│   │   └── github-oidc-role.ts  # contrib publish 用
+│   └── problem-deploy/
+│       └── handlers/deploy-handler/
+│           └── s3-fetcher.ts    # ← 新規 (DDB lookup + presigned)
+├── problems/                    # 公式 sample (= visibility:public, contributor:"system")
+│   ├── SCHEMA.json              # visibility / contributor field 追加
+│   ├── battles/{hello-world,security-battle-royale}/
+│   └── challenges/hello-world/
+├── contributions/               # ← 新ディレクトリ (= 寄稿者の PR 受け口)
+│   └── &lt;handle&gt;/&lt;problem-id&gt;/
+│       ├── metadata.json
+│       ├── template.yaml
+│       └── code/                # 実装ファイル
+├── docs/architecture/
+│   ├── adr-008-problem-payload-separation.html  # 本 ADR (= v2)
+│   └── ...
+└── .github/workflows/
+    ├── contrib-validate.yml     # PR validation
+    └── contrib-publish.yml      # post-merge S3 + DDB publish</pre>
+  </div>
+
+  <div class="repo-card private">
+    <h4><span class="badge private">private (任意)</span> 自分用 / 寄稿者の作業 repo</h4>
+    <div class="role">寄稿前の試作 / 内部設計の置き場</div>
+<pre>my-tenka-problem/  (= 例、各寄稿者が任意)
+├── &lt;problem-id&gt;/
+│   ├── metadata.json
+│   ├── template.yaml
+│   ├── services/                # 答えを含む実装
+│   └── design.html              # 内部設計 (= 答えあり)
+├── README.md
+└── .github/workflows/sync.yml   # 任意: 本体に PR を投げるヘルパー
+
+→ 本体 TenkaCloud に PR を投げる時に
+  contributions/&lt;handle&gt;/&lt;problem-id&gt;/ にコピーする</pre>
+  </div>
+</div>
+
+<p>v1 で提案した「自分用 <code>TenkaCloudChallenges</code> private repo」は v2 では「<strong>寄稿者の任意の作業 repo</strong>」に格下げ (= 必須ではなくなった)。本体 repo の <code>contributions/</code> 配下に直接 PR を出しても良いし、自分用の repo で試作してから本体に PR を出しても良い。</p>
+</section>
+
+<section>
+<h2>API 変更</h2>
+
+<h3>カタログ取得 API (新設)</h3>
+
+<table>
+<tr><th>endpoint</th><th>用途</th><th>権限</th></tr>
+<tr><td><code>GET /catalog/problems</code></td>
+    <td>カタログ全件 (filter: category / contributor / visibility / status)</td>
+    <td>Cognito JWT (System Admin / Tenant Admin / Participant)</td></tr>
+<tr><td><code>GET /catalog/problems/:id</code></td>
+    <td>特定問題の最新 version</td><td>同上</td></tr>
+<tr><td><code>GET /catalog/problems/:id/versions</code></td>
+    <td>version 一覧 (運営のみ)</td><td>System Admin のみ</td></tr>
+</table>
+
+<h3>Worker Lambda の変更</h3>
+
+<pre>// 現状 (= MVP-1, build-time bundle)
+const template = readFileSync(`./problems/${id}/template.yaml`);
+
+// 変更後 (= ADR-008 v2)
+const entry = await registry.lookup(id);  // DDB GetItem
+const { templateBody, codeBundleUrl } = await s3Fetcher.fetch(entry);
+//   ├ public 問題: codeBundleUrl は public S3 URL or 同梱
+//   └ private 問題: codeBundleUrl は 15min TTL presigned URL
+await cfn.createStack({
+  TemplateBody: templateBody,
+  Parameters: [
+    ...,
+    { ParameterKey: "CodeBundleUrl", ParameterValue: codeBundleUrl },
+  ],
+});</pre>
+
+<h3>検証 Lambda (新設)</h3>
+
+<p>GitHub Actions の <code>contrib-validate.yml</code> から API GW 経由で叩かれる。受け取った
+<code>template.yaml</code> + <code>metadata.json</code> を以下で検証:</p>
+
+<ul>
+<li>cfn-lint で構文 / リソース妥当性</li>
+<li>IAM ポリシー scan (= wildcard resource / 過剰 action 検出)</li>
+<li>cost estimator で月額上限超過チェック</li>
+<li>禁止リソース検査 (= reserved concurrency 上限など)</li>
+<li>SCHEMA.json で metadata.json validate</li>
+</ul>
+
+<p>結果を JSON で返し、Actions が PR にコメント。</p>
+</section>
+
+<section>
+<h2>Implementation ownership</h2>
+
+<table>
+<tr><th>タスク</th><th>担当</th><th>備考</th></tr>
+<tr><td>本 ADR v2 の review</td><td><span class="badge warn">user</span></td><td>方向確定</td></tr>
+<tr><td><code>ProblemRegistry</code> stack (DDB + S3 + GitHub OIDC role)</td>
+    <td><span class="badge warn">user</span></td>
+    <td><code>infrastructure/lib/problem-registry/</code> に新設、CDK</td></tr>
+<tr><td>GitHub App / OAuth App の登録 (= 認証用)</td>
+    <td><span class="badge warn">user</span></td><td>外部副作用 (GitHub 側の設定)</td></tr>
+<tr><td>検証 Lambda の実装</td><td><span class="badge accept">Claude</span></td>
+    <td>cfn-lint / iam scan / cost estimator のラッパ</td></tr>
+<tr><td>Worker Lambda の DDB lookup + S3 fetch + presigned URL</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td><code>handlers/deploy-handler/s3-fetcher.ts</code></td></tr>
+<tr><td>カタログ取得 API (Hono on Lambda)</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>新 handler + DDB query</td></tr>
+<tr><td>admin-console / app-admin / portal を DDB API に切替</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>Vite glob 廃止、API client 追加</td></tr>
+<tr><td><code>SCHEMA.json</code> に <code>visibility</code> / <code>contributor</code> 追加</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>後方互換 (default <code>public</code> / <code>"system"</code>)</td></tr>
+<tr><td>既存 3 問題の seed import script</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td><code>scripts/seed-problem-registry.ts</code></td></tr>
+<tr><td>GitHub Actions <code>contrib-validate.yml</code> + <code>contrib-publish.yml</code></td>
+    <td><span class="badge accept">Claude</span></td><td>OIDC 設定は user 担当</td></tr>
+<tr><td>microservice-migration-battle 本実装</td>
+    <td><span class="badge accept">Claude</span></td>
+    <td>本 ADR v2 と並行で <code>problems/battles/</code> に skeleton (= 寄稿問題第 1 号として後で <code>contributions/</code> に移動)</td></tr>
+</table>
+</section>
+
+<section>
+<h2>Migration plan</h2>
+
+<ol>
+<li><strong>Phase 1</strong> — <code>ProblemRegistry</code> stack (CDK by user)
+  <ul>
+    <li>DDB <code>ProblemRegistry</code> + GSI 2 本</li>
+    <li>S3 <code>tc-challenges-&lt;env&gt;</code> bucket (BlockPublicAccess + bucket policy)</li>
+    <li>GitHub OIDC role (<code>tc-challenges-publisher</code>)</li>
+    <li>Worker Lambda role に S3 read 追加</li>
+  </ul>
+</li>
+<li><strong>Phase 2</strong> — schema 拡張 + seed (Claude)
+  <ul>
+    <li><code>SCHEMA.json</code> に <code>visibility</code> / <code>contributor</code> field 追加 (default 後方互換)</li>
+    <li><code>seed-problem-registry.ts</code> で既存 3 問題を <code>contributor: "system"</code> として DDB に upsert</li>
+    <li><code>validate-problems</code> を新 schema に対応</li>
+  </ul>
+</li>
+<li><strong>Phase 3</strong> — カタログ DDB 化 (Claude)
+  <ul>
+    <li>カタログ API (<code>GET /catalog/problems</code> 等) 新設</li>
+    <li>admin-console / app-admin / portal の Vite glob を API client に置換</li>
+    <li>Worker Lambda を DDB lookup + S3 fetch に切替 (= public 問題は従来パス互換、private は presigned URL)</li>
+  </ul>
+</li>
+<li><strong>Phase 4</strong> — 寄稿パイプライン (Claude + user)
+  <ul>
+    <li>検証 Lambda 実装</li>
+    <li><code>.github/workflows/contrib-validate.yml</code> + <code>contrib-publish.yml</code></li>
+    <li><code>contributions/&lt;handle&gt;/&lt;id&gt;/</code> ディレクトリ規約をドキュメント化</li>
+  </ul>
+</li>
+<li><strong>Phase 5</strong> — microservice-migration-battle 本実装 (Claude, <code>#572</code>)
+  <ul>
+    <li>本 ADR v2 と <strong>並行</strong>で <code>problems/battles/microservice-migration-battle/</code> に skeleton 作成 (= 後で <code>contributions/&lt;your-handle&gt;/</code> に移動)</li>
+    <li>3 サービス (users / orders / catalog) の FastAPI 実装 + slow endpoint 仕掛け</li>
+    <li>EC2 + docker compose の template.yaml</li>
+    <li>scoring engine は次 PR (= 共通基盤として切り出し)</li>
+  </ul>
+</li>
+</ol>
+
+<p>Phase 1〜4 を順次走らせている間に Phase 5 を並行で進められる
+(= 既存パイプラインで public 問題として動かせるので、Phase 1〜3 完了後に <code>contributions/</code> 配下に移動するだけ)。</p>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>Pros</h3>
+<ul>
+<li><strong>コミュニティ寄稿が一級市民</strong> — 自分の問題も他人の問題も同じ仕組みで配信</li>
+<li><strong>答え漏れも結果として解決</strong> — private visibility + presigned URL で payload は本体 repo に出ない</li>
+<li><strong>ADR-003 Phase 2 (DB-backed catalog) を自然に達成</strong> — 既存の方向性と整合</li>
+<li><strong>カタログが動的</strong> — 寄稿のたびに本体 rebuild 不要</li>
+<li><strong>寄稿者 attribution</strong> — 誰の問題か分かる、コミュニティ評価が機能する</li>
+<li><strong>既存 deploy パイプライン互換</strong> — 公式 3 問題はそのまま動く (Phase 3 の Worker Lambda 改修で吸収)</li>
+</ul>
+
+<h3>Cons / 注意</h3>
+<ul>
+<li><strong>新 stack 増 (DDB + S3 + 検証 Lambda + OIDC)</strong> — Free Tier 範囲だが運用面は増える</li>
+<li><strong>検証パイプラインの実装コスト</strong> — Phase 4 が最大の工数</li>
+<li><strong>悪意ある寄稿リスク</strong> — 自動検証 + 運営承認の二段で防ぐが、完全ではない (例: 課金爆弾の new pattern)</li>
+<li><strong>カタログ API の遅延</strong> — DDB 経由で 1 段増、cache が必要かも</li>
+<li><strong>Vite glob 廃止</strong> — 既存 frontend のテスト書き換え</li>
+<li><strong>multi-version 管理の運用</strong> — 古い version の cleanup ポリシーが要る</li>
+</ul>
+</section>
+
+<section>
+<h2>Open Questions</h2>
+
+<ol>
+<li><strong>DDB schema 詳細</strong>: GSI を 2 本で足りるか / status の transition (pending → validated → deprecated) を別 attribute にすべきか</li>
+<li><strong>GitHub App vs OAuth App</strong>: 公式 review 自動化 (PR コメント) には App、寄稿者の identify には OAuth が便利。両方使う構成が自然か</li>
+<li><strong>cost estimator</strong>: AWS Pricing API 直接 / <code>infracost</code> ラップ / 自作。Free Tier 内に収まる手段</li>
+<li><strong>検証失敗時の UX</strong>: PR コメントだけ / Web UI dashboard / メール通知</li>
+<li><strong>寄稿者 rate limit</strong>: 1 寄稿者あたり PR 数 / S3 storage 上限</li>
+<li><strong>悪意ある寄稿者の ban</strong>: System Admin が GitHub username を blocklist に入れる UI が要るか</li>
+<li><strong>多言語対応</strong>: <code>metadata.json</code> の <code>name</code> / <code>description</code> を i18n マップにすべきか</li>
+<li><strong>バージョン deprecation の運用</strong>: 競技中の stack に影響しない前提で、いつ削除するか / S3 オブジェクトの lifecycle policy</li>
+<li><strong>full-text search の必要性</strong>: 問題数が増えたら OpenSearch / Algolia 連携を Phase 6+ で追加するか</li>
+</ol>
+</section>
+
+<section>
+<h2>関連リソース</h2>
+
+<ul>
+<li><strong>v1 ADR</strong> (= 同 ADR の前バージョン、本 v2 で上書き吸収)</li>
+<li><code>#572</code> — microservice-migration-battle (本 ADR の driver)</li>
+<li><code>#574</code> — ADR-008 tracking issue</li>
+<li>ADR-001 — Problem Deploy CRUD (= 本 ADR が拡張する deploy パイプライン)</li>
+<li>ADR-002 — Cross-account federation (= 競技者 acct への AssumeRole)</li>
+<li>ADR-003 — Problem Catalog DDB (= 本 ADR で Phase 2 を実現)</li>
+<li>ADR-007 候補 (<code>#561</code>) — outside-in architecture (= 寄稿パイプラインの E2E test 設計の指針)</li>
+<li><code>problems/SCHEMA.json</code> — Phase 2 で <code>visibility</code> / <code>contributor</code> field 追加</li>
+<li><code>infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts</code> — Phase 3 で S3 fetch 追加</li>
+<li><code>apps/application-admin-console/src/data/problems.ts</code> — Phase 3 で Vite glob 廃止</li>
+</ul>
+</section>
+
+</body>
+</html>

--- a/problems/battles/microservice-migration-battle/README.md
+++ b/problems/battles/microservice-migration-battle/README.md
@@ -1,0 +1,93 @@
+# Microservice Migration Battle
+
+> EC2 1 台に同居する 3 サービス (`users` / `orders` / `catalog`) を、競技時間内に Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner の 3 種の異なるホスティングに分割していく Battle 問題。
+
+## あらすじ
+
+あなたは EC2 1 台に同居している 3 つのサービス (`users` / `orders` / `catalog`) を運用するスタートアップの SRE。EC2 はそろそろ劣化し始めており、レガシーから抜け出さないと顧客への応答が遅くなりポイントが激減する。競技時間内に各サービスを別々のホスティングに切り出し、可用性とスコアを守れ。
+
+## 学習目的
+
+- モノリスからマイクロサービスへの段階的移行 (strangler fig パターン) を体験する
+- Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner のトレードオフを比較する
+- スコアが時間経過で劣化する制約下で、優先順位を判断する経験を積む
+- コードを読み解いて意図的に仕込まれた遅延処理を取り除き、再デプロイで復旧する経験を積む
+
+## 競技フロー
+
+1. **deploy 完了**: 運営側が競技者アカウントに本問題を deploy する。EC2 1 台に 3 サービスが docker compose で起動し、`http://<ec2>/users/score` `/orders/score` `/catalog/score` が払い出される。
+2. **登録フェーズ**: 競技者は participant-portal で **3 つのスコア対象 endpoint URL** を登録する (初期は空)。
+3. **採点フェーズ**: 運営側スコアエンジンが **1 分毎** に各登録 endpoint を polling し、レスポンス内容に応じてスコアを加減算する。
+4. **EC2 劣化フェーズ** (= デフォルト競技開始 60 分後 / イベントパラメータで変更可): EC2 上の 3 サービスが劣化し、EC2 採点値が大幅減。
+5. **遅延 endpoint 切替フェーズ** (= デフォルト 90 分後 / 同じくパラメータ): スコアエンジンが checks する path を `/score` から **コード内に仕込まれた legacy endpoint** に切り替える。参加者はコードを読み解き、遅延の原因を取り除いて再デプロイする必要がある。
+
+## 提供される URL (deploy 完了後)
+
+| 名前 | URL 例 | 用途 |
+|------|--------|------|
+| `FrontendUrl` | `http://<public-dns>/` | nginx の入り口 |
+| `UsersEndpoint` | `http://<public-dns>/users/score` | users サービスのスコア endpoint |
+| `OrdersEndpoint` | `http://<public-dns>/orders/score` | orders サービスのスコア endpoint |
+| `CatalogEndpoint` | `http://<public-dns>/catalog/score` | catalog サービスのスコア endpoint |
+| `InstanceId` | `i-xxxxxxxx` | 運営側のデバッグ用 |
+
+## 各サービスのインタフェース契約
+
+3 サービスは共通で以下の HTTP endpoint を持つ。
+
+| Method | Path | 用途 | レスポンス例 |
+|--------|------|------|-------------|
+| `GET` | `/health` | ヘルスチェック | `{"status": "ok"}` |
+| `GET` | `/meta` | サービス情報 | `{"service": "users", "platform": "ec2", "version": "1.0.0"}` |
+| `GET` | `/score` | スコア (= 高速経路) | `{"service": "users", "score": 87}` |
+| `GET` | `/score?legacy=true` | スコア (= 旧経路 / **要修正**) | `{"service": "users", "score": 87}` (※遅い) |
+
+### `platform` 値
+
+`/meta` の `platform` field は次のいずれかを返す。スコアエンジンはこれをもとに加点係数を判定する。
+
+- `ec2` — 初期状態 (この問題テンプレートが提供する状態)
+- `lambda` — Lambda + API Gateway に移行済
+- `ecs` — ECS Fargate に移行済
+- `apprunner` — AWS App Runner に移行済
+
+`platform` は環境変数 `TC_PLATFORM` で制御する。Lambda / ECS / App Runner に移植する際は、コンテナ env を `TC_PLATFORM=lambda` 等に設定すること。
+
+## マイクロサービス化の指針
+
+3 サービスを **異なる 3 種のホスティング** に分けることを推奨する。組み合わせは自由。
+
+| ホスティング | 強み | 学べること |
+|------------|------|-----------|
+| **Lambda + API Gateway** | 関数粒度のスケール / cold start / event-driven | Serverless の運用感 |
+| **ECS (Fargate)** | 長時間実行 / 永続接続 / VPC 統合 | コンテナオーケストレーションと ALB |
+| **AWS App Runner** | URL 1 発で公開 / managed container | Lambda と ECS の中間、source-deploy |
+
+## 攻略のコツ
+
+- 早く分離するほど点数が伸びる設計
+- 1 サービスでも分離できれば EC2 劣化フェーズの影響を逃せる
+- 遅延 endpoint への切替は事前告知される (Battle Portal の timeline 参照) — 切替前にコード修正を完了させておくと点数を維持できる
+- 答えは 1 つではない。3 サービスをすべて Lambda にしても良いし、混在でも良い
+
+## ローカルでの動作確認 (= 寄稿者向け)
+
+```bash
+cd services
+docker compose up --build
+curl http://localhost/users/score
+curl http://localhost/orders/meta
+curl 'http://localhost/catalog/score?legacy=true'  # 約 2 秒遅延
+```
+
+## 参考リンク
+
+- [AWS Lambda](https://aws.amazon.com/lambda/) / [API Gateway HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html)
+- [Amazon ECS Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html)
+- [AWS App Runner](https://docs.aws.amazon.com/apprunner/latest/dg/what-is-apprunner.html)
+- [Strangler Fig pattern (Martin Fowler)](https://martinfowler.com/bliki/StranglerFigApplication.html)
+
+## 関連 Issue
+
+- 設計 Issue: 本問題の動機と詳細設計
+- ADR-008 v2: 問題カタログを Community Contribution Registry にする (= 本問題は寄稿問題第 1 号として位置づけ)

--- a/problems/battles/microservice-migration-battle/design.html
+++ b/problems/battles/microservice-migration-battle/design.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Microservice Migration Battle — 内部設計 (答えを含む)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+    --c-spoiler: #ece4ff;
+    --c-spoiler-border: #8250df;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 1040px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-code-bg); padding: .8rem 1rem; border-radius: 4px; overflow-x: auto;
+        font-size: 0.85rem; line-height: 1.5; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.spoiler { background: var(--c-spoiler); color: var(--c-spoiler-border);
+                   border: 1px solid var(--c-spoiler-border); }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+  blockquote { margin: 0.6rem 0; padding: .6rem 1rem; border-left: 4px solid var(--c-warn);
+               background: #fff8c5; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
+  .spoiler-banner {
+    background: linear-gradient(90deg, #ece4ff 0%, #ffe9e9 100%);
+    border-radius: 4px; padding: .8rem 1rem; margin: 1rem 0;
+    font-weight: 600; color: var(--c-spoiler-border);
+    border: 1px solid var(--c-spoiler-border);
+  }
+
+  /* timeline */
+  .timeline {
+    border-left: 3px solid var(--c-link); padding-left: 1.2rem; margin: 1rem 0 1.5rem 1rem;
+  }
+  .timeline-item {
+    position: relative; margin-bottom: 1.2rem;
+  }
+  .timeline-item::before {
+    content: ""; position: absolute; left: -1.55rem; top: .45rem;
+    width: 12px; height: 12px; border-radius: 50%; background: var(--c-link);
+  }
+  .timeline-item.warn::before { background: var(--c-warn); }
+  .timeline-item.danger::before { background: var(--c-reject); }
+  .timeline-item h4 { margin: 0 0 .2rem; font-size: 1rem; }
+  .timeline-item .when {
+    font-size: 0.78rem; color: var(--c-muted); margin-bottom: .3rem;
+  }
+
+  /* score table */
+  .score-table td.delta { text-align: right; font-family: monospace; font-weight: 600; }
+  .score-table td.delta.plus    { color: var(--c-accept); }
+  .score-table td.delta.minus   { color: var(--c-reject); }
+  .score-table td.delta.neutral { color: var(--c-muted); }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Microservice Migration Battle — 内部設計</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Draft</span> 2026-05-11</div>
+    <div><b>Visibility:</b><span class="badge spoiler">private (= 答え含む)</span></div>
+    <div><b>関連:</b><code>#572</code> (起票) / ADR-008 v2 (寄稿問題第 1 号として登録)</div>
+  </div>
+
+  <div class="spoiler-banner">
+    ⚠ このドキュメントは <strong>競技者には見せない</strong>。<br>
+    ADR-008 v2 Phase 4 完了後は <code>contributions/&lt;handle&gt;/microservice-migration-battle/</code> に移動した上で、競技開始時に S3 private prefix にしか置かない (= 答え漏れ防止)。
+  </div>
+</header>
+
+<section>
+<h2>問題の物理構成</h2>
+
+<p>EC2 1 台 (t3.small / Amazon Linux 2023) に <strong>docker compose</strong> で 4 コンテナ:</p>
+
+<table>
+<tr><th>コンテナ</th><th>image</th><th>役割</th><th>port</th></tr>
+<tr><td><code>nginx</code></td><td><code>nginx:1.27-alpine</code></td>
+    <td>frontend (= 唯一の外部公開)、3 サービスへの reverse proxy</td><td>80</td></tr>
+<tr><td><code>users</code></td><td>build (Python 3.12)</td>
+    <td>FastAPI、score/meta/health endpoint</td><td>8000 (内部)</td></tr>
+<tr><td><code>orders</code></td><td>build (Python 3.12)</td>
+    <td>同上、ただし legacy は N+1 風 sleep</td><td>8000 (内部)</td></tr>
+<tr><td><code>catalog</code></td><td>build (Python 3.12)</td>
+    <td>同上、legacy は cache 同期 sleep</td><td>8000 (内部)</td></tr>
+</table>
+
+<p>nginx が <code>/users/</code> <code>/orders/</code> <code>/catalog/</code> を各サービス
+(<code>http://&lt;name&gt;:8000/</code>) に proxy。EC2 SG は port 80 のみ ingress。</p>
+
+<p>VPC は per-team で新規作成 (= 10.99.0.0/16)、Subnet 1 つ + IGW + Route Table。
+SSM Session Manager 用 IAM Role はあり (= 運営デバッグ用)、competitor 側からは触れない。</p>
+</section>
+
+<section>
+<h2>仕掛け (= "答え" の中身)</h2>
+
+<h3>① 各サービスに仕込んだ legacy endpoint</h3>
+
+<p>3 サービス共通インターフェイス:</p>
+
+<ul>
+<li><code>GET /score</code> — 高速経路。即座にレスポンス。</li>
+<li><code>GET /score?legacy=true</code> — <strong>意図的な遅延経路</strong>。スコアエンジンが切替フェーズで叩きにくる。</li>
+</ul>
+
+<table>
+<tr><th>サービス</th><th>遅延の仕組み</th><th>修正方針 (= 答え)</th><th>file</th></tr>
+<tr><td><code>users</code></td>
+    <td><code>time.sleep(2.0)</code> 単発</td>
+    <td><code>_legacy_score()</code> 内の <code>time.sleep</code> を削除して <code>_fast_score()</code> と統合</td>
+    <td><code>services/users/main.py:64</code></td></tr>
+<tr><td><code>orders</code></td>
+    <td>5 回ループで <code>time.sleep(0.45)</code> = 合計 2.25 秒 (= N+1 風)</td>
+    <td>ループ自体を削除し <code>random</code> ベースの集計を 1 回にまとめる</td>
+    <td><code>services/orders/main.py:65-72</code></td></tr>
+<tr><td><code>catalog</code></td>
+    <td>「外部キャッシュ更新」のフリをする <code>time.sleep(2.2)</code></td>
+    <td>cache を non-blocking にする (= sleep を削除、async タスクへ)</td>
+    <td><code>services/catalog/main.py:64</code></td></tr>
+</table>
+
+<p>3 つとも legacy 関数の <strong>戻り値は fast 関数と等価</strong> (= 機能的には同じ)。
+唯一の違いは応答時間。これにより「スコアエンジンが切り替えても返る値の妥当性チェックは
+通る、ただし応答時間からスコアが下がる」という設計になる。</p>
+
+<h3>② プラットフォーム自己申告</h3>
+
+<p><code>GET /meta</code> が <code>{"service": "...", "platform": "ec2|lambda|ecs|apprunner", "version": "..."}</code>
+を返す。<code>platform</code> は環境変数 <code>TC_PLATFORM</code> で制御。</p>
+
+<p>初期値 (= EC2 docker compose) では <code>TC_PLATFORM=ec2</code>。競技者が Lambda に
+移植したら <code>TC_PLATFORM=lambda</code> を設定すれば <code>/meta</code> が変わり、
+スコアエンジンが「Lambda にマイクロサービス化された」と判定して大幅加点に切り替わる。</p>
+
+<p>cross-validate (= DNS pattern や response header) は MVP ではしない。Battle は
+チーム間で互いを攻撃しないので緩めで良いと判断 (ADR-008 v2 D6 と整合)。</p>
+</section>
+
+<section>
+<h2>スコアリング仕様</h2>
+
+<p>スコアエンジンは 1 分毎に各登録 endpoint を polling し、以下のルールで加減算する。</p>
+
+<table class="score-table">
+<tr><th>状態</th><th>判定</th><th>1 check (1分) あたり</th></tr>
+<tr><td>endpoint 未登録 / 200 以外 / timeout</td>
+    <td>HTTP status != 200 or no response in 5s</td>
+    <td class="delta minus">-100</td></tr>
+<tr><td>EC2 上 (劣化前)</td>
+    <td><code>/meta.platform == "ec2"</code> and 応答 &lt; 500ms</td>
+    <td class="delta plus">+100</td></tr>
+<tr><td>EC2 上 (劣化後 = degradationMinutes 経過)</td>
+    <td>同上、ただしフェーズ判定で adjust</td>
+    <td class="delta plus">+10</td></tr>
+<tr><td>Lambda + API GW にマイグレ済</td>
+    <td><code>/meta.platform == "lambda"</code></td>
+    <td class="delta plus">+1,000</td></tr>
+<tr><td>ECS Fargate にマイグレ済</td>
+    <td><code>/meta.platform == "ecs"</code></td>
+    <td class="delta plus">+1,000</td></tr>
+<tr><td>App Runner にマイグレ済</td>
+    <td><code>/meta.platform == "apprunner"</code></td>
+    <td class="delta plus">+1,000</td></tr>
+<tr><td>3 サービス全分離達成 (= 一括ボーナス)</td>
+    <td>3 endpoint の <code>platform</code> が全て ec2 以外</td>
+    <td class="delta plus">+5,000 (1 回限り)</td></tr>
+<tr><td>遅延 endpoint (応答 &gt; 1.5s) を返した</td>
+    <td>切替フェーズ後の <code>/score?legacy=true</code> に対して</td>
+    <td class="delta plus">+10</td></tr>
+</table>
+
+<p>劣化前 1 時間放置 (3 endpoint 登録済): 60 × 100 × 3 = <strong>18,000 / h</strong><br>
+劣化後 1 時間放置: 60 × 10 × 3 = <strong>1,800 / h</strong> (= 10 分の 1)<br>
+30 分で 1 サービスを Lambda に移行: 30 × 100 × 3 + 30 × (100 × 2 + 1000 × 1) = <strong>9,000 + 36,000 = 45,000 / 1h</strong></p>
+
+<p>→ 1 サービスでも分離すれば EC2 滞在を大きく上回る = 強い移行インセンティブ。</p>
+
+<h3>イベントパラメータ (= 運営側で設定可)</h3>
+
+<table>
+<tr><th>パラメータ名</th><th>型</th><th>デフォルト</th><th>用途</th></tr>
+<tr><td><code>degradationMinutes</code></td><td>int</td><td>60</td>
+    <td>EC2 劣化フェーズ開始 (分)</td></tr>
+<tr><td><code>legacySwitchMinutes</code></td><td>int</td><td>90</td>
+    <td>遅延 endpoint 切替フェーズ開始 (分)</td></tr>
+<tr><td><code>scoreCheckIntervalSec</code></td><td>int</td><td>60</td>
+    <td>スコア polling 間隔</td></tr>
+<tr><td><code>emptyPenaltyPerCheck</code></td><td>int</td><td>-100</td>
+    <td>未登録 endpoint への減点</td></tr>
+<tr><td><code>microservicePoints</code></td><td>int</td><td>1000</td>
+    <td>マイクロサービス化 endpoint への加点</td></tr>
+<tr><td><code>fullMigrationBonus</code></td><td>int</td><td>5000</td>
+    <td>3 サービス全分離達成ボーナス</td></tr>
+</table>
+</section>
+
+<section>
+<h2>競技タイムライン (= デフォルト値)</h2>
+
+<div class="timeline">
+  <div class="timeline-item">
+    <h4>T+0 min — 競技開始</h4>
+    <div class="when">deploy 完了直後</div>
+    <p>3 サービスが EC2 で稼働中。endpoint URL が払い出され、競技者が participant-portal で 3 endpoint を登録する。<br>
+    <strong>登録しないと -100/min の出血</strong>。</p>
+  </div>
+
+  <div class="timeline-item">
+    <h4>T+0〜60 min — EC2 通常フェーズ</h4>
+    <div class="when">degradationMinutes まで</div>
+    <p>EC2 のままでも +100/min × 3 = 18,000/h の高加点。ただしマイクロサービス化すれば +1,000/min × 3 = 180,000/h で 10 倍差。<br>
+    <strong>最初の 1 サービス分離を 30 分以内に終わらせるのが目安。</strong></p>
+  </div>
+
+  <div class="timeline-item warn">
+    <h4>T+60 min — EC2 劣化フェーズ開始</h4>
+    <div class="when">degradationMinutes 到達</div>
+    <p>スコアエンジンが「EC2 上の endpoint」を発見すると加点を +10/min に下げる (= 90% 減)。EC2 残留チームのスコア急減。Battle Portal の timeline で「EC2 劣化フェーズに入りました」と通知。</p>
+  </div>
+
+  <div class="timeline-item warn">
+    <h4>T+87 min — 遅延切替の 3 分前告知</h4>
+    <div class="when">legacySwitchMinutes - 3</div>
+    <p>「3 分後に legacy endpoint への切替が起きます」と Battle Portal に告知。</p>
+  </div>
+
+  <div class="timeline-item danger">
+    <h4>T+90 min — 遅延 endpoint 切替フェーズ</h4>
+    <div class="when">legacySwitchMinutes 到達</div>
+    <p>スコアエンジンが polling 対象を <code>/score</code> → <code>/score?legacy=true</code> に切り替える。事前にコード修正していないと、応答 &gt; 1.5s 判定で +10/min まで落ちる。<br>
+    <strong>修正方針</strong>: コード読み → <code>time.sleep</code> / N+1 ループを取り除き → 再デプロイ。Lambda / ECS / App Runner どこに乗っていても作業は同じ (= ソース修正 + redeploy)。</p>
+  </div>
+
+  <div class="timeline-item">
+    <h4>T+120 min — 競技終了</h4>
+    <div class="when">合計 2 時間</div>
+    <p>累積スコアでランキング。3 サービスを早期に異なる 3 ホスティングに分離 + 遅延修正完了したチームが上位。</p>
+  </div>
+</div>
+</section>
+
+<section>
+<h2>期待される攻略順序 (= 想定解の 1 つ)</h2>
+
+<ol>
+<li><strong>T+0〜10 min</strong>: deploy 完了確認 / 3 endpoint を participant-portal に登録 / コードを cat (= 仕掛けの存在に気づく)</li>
+<li><strong>T+10〜30 min</strong>: 最も簡単な <code>users</code> サービスを <strong>AWS App Runner</strong> に乗せる (= source-deploy 1 発で公開可、最短)</li>
+<li><strong>T+30〜55 min</strong>: <code>orders</code> を <strong>Lambda + API Gateway</strong> に乗せる (= FastAPI を Mangum でラップして lambda handler 化)</li>
+<li><strong>T+55〜80 min</strong>: <code>catalog</code> を <strong>ECS Fargate</strong> に乗せる (= 一番設定が重いが、長時間稼働 / VPC 統合の練習になる)。3 サービス全分離ボーナス +5,000 を取りに行く</li>
+<li><strong>T+80〜90 min</strong>: 各サービスのコードから legacy 遅延処理を取り除く → 再デプロイ。切替前に間に合わせる</li>
+<li><strong>T+90〜120 min</strong>: 残時間で安定運用。失敗 endpoint があれば修正</li>
+</ol>
+
+<p>もちろん別解も可能 (= 全部 Lambda、全部 App Runner 等)。ホスティング多様性ボーナスは
+ない (= ADR レベルで「学習目的」に多様性を強く要請しているが、スコアでは強制しない)。</p>
+</section>
+
+<section>
+<h2>運営側スコアエンジン (= 別 PR、現時点未実装)</h2>
+
+<p>本 PR では <strong>問題テンプレート部分のみ</strong> 実装。スコアエンジン (= 1 分毎 polling Lambda + endpoint 登録 UI) は次 PR に分離する。理由:</p>
+
+<ul>
+<li>endpoint 登録 → polling → スコア event 配信は <strong>他 Battle でも使い回せる共通基盤</strong> になりうる (= microservice-migration-battle 専用にしない)</li>
+<li>本 PR の <code>INVARIANT_PR_SHIPS_WORKING_INCREMENT</code> は「3 サービスが立ち上がって <code>/score</code> が叩ける」で満たせる (= スコアエンジン無しでも観察可能)</li>
+<li>スコアエンジンの実装は ADR-008 v2 Phase 4 (= 検証パイプライン) と同じく独立した複雑性</li>
+</ul>
+
+<h3>次 PR で作るスコアエンジン (= 設計案)</h3>
+
+<ul>
+<li>EventBridge Scheduler で 1 分毎に Polling Lambda を起動</li>
+<li>DDB <code>EndpointRegistry</code> table (PK: <code>TenantId#TeamId</code>, SK: <code>SLOT#1|2|3</code>)</li>
+<li>Polling Lambda が各 endpoint を fetch → ScoreEvent 発行 → 既存 score stream に乗せる</li>
+<li>participant-portal に endpoint 登録 UI (3 slot)</li>
+<li>Battle Portal の timeline card に「次フェーズまでの残り時間」を表示</li>
+</ul>
+
+<p>microservice-migration-battle 以外の今後の Battle (= 「N 個の endpoint を polling
+してスコアを増減」型) でも同じ仕組みを使えるよう、<strong>generic な polling 基盤</strong>
+として切り出す。</p>
+</section>
+
+<section>
+<h2>ホスティング移植のヒント (= 競技者向けには公開しない)</h2>
+
+<h3>users → AWS App Runner</h3>
+
+<pre>$ apprunner create-service \
+    --service-name tc-users \
+    --source-configuration '{
+      "AutoDeploymentsEnabled": false,
+      "ImageRepository": {
+        "ImageIdentifier": "&lt;your-ecr&gt;/users:latest",
+        "ImageRepositoryType": "ECR",
+        "ImageConfiguration": {
+          "Port": "8000",
+          "RuntimeEnvironmentVariables": { "TC_PLATFORM": "apprunner" }
+        }
+      }
+    }'</pre>
+
+<p>App Runner は ECR から自動 pull → URL 即発行。所要 5〜10 分。</p>
+
+<h3>orders → Lambda + API Gateway</h3>
+
+<p>FastAPI を Lambda で動かすために <code>mangum</code> を入れる:</p>
+
+<pre># requirements.txt に追加
+mangum==0.17.0
+
+# main.py に追加
+from mangum import Mangum
+handler = Mangum(app)</pre>
+
+<p>Lambda は container image で deploy (Python 3.12 base image + uvicorn は不要、mangum が ASGI を Lambda event に変換)。</p>
+
+<h3>catalog → ECS Fargate</h3>
+
+<p>標準的な手順 (Task Definition + Service + ALB)。VPC / ENI / Target Group が必要な分、3 つの中で最も config が重い。</p>
+</section>
+
+<section>
+<h2>ADR-008 v2 への適合 (= 寄稿問題第 1 号としての位置づけ)</h2>
+
+<table>
+<tr><th>ADR-008 v2 上の field</th><th>本問題での値</th></tr>
+<tr><td><code>contributor</code></td><td><code>"system"</code> (= 公式問題、後で寄稿者ハンドルに変更可)</td></tr>
+<tr><td><code>visibility</code></td><td><code>"private"</code> (= 答えあり、competition 中に payload 漏洩防止)</td></tr>
+<tr><td><code>category</code></td><td><code>"Battle"</code></td></tr>
+<tr><td><code>status</code></td><td><code>"draft"</code> → ADR Phase 5 完了後 <code>"validated"</code></td></tr>
+<tr><td><code>version</code></td><td>初回 publish 時の git SHA 短縮 8 桁</td></tr>
+<tr><td>S3 path</td>
+    <td><code>s3://tc-challenges-&lt;env&gt;/system/microservice-migration-battle/&lt;version&gt;/</code></td></tr>
+</table>
+
+<p>本 design.html は <strong>S3 にも本体 repo にも置かない</strong> — private repo 側
+(= 寄稿者の作業 repo) または運営内の限定共有のみ。ADR-008 v2 Phase 4 完了後は
+<code>contributions/system/microservice-migration-battle/</code> に metadata + template + code/
+だけを移し、design.html は private 側に残す。</p>
+</section>
+
+<section>
+<h2>Open Questions</h2>
+
+<ol>
+<li><strong>遅延の閾値 1.5s が妥当か</strong>: orders の N+1 ループは合計 2.25s なので
+1.5s 閾値で正しく検出される。users / catalog の 2.0s / 2.2s も同様。閾値を 1.0s に
+下げると network jitter で false positive のリスクあり</li>
+<li><strong>EC2 劣化の実装方法</strong>: <code>tc qdisc</code> で latency 注入 vs サービス
+側で「<code>/var/run/tc-degraded</code> flag が存在したら sleep」分岐。後者は
+プラットフォーム移植性が高い (= Lambda / ECS でも動く) が、移植したら劣化の影響を
+受けないので「マイグレーションのインセンティブ」としては正しい</li>
+<li><strong>3 サービスの 1 つだけ移行した時のスコアバランス</strong>: 例の試算は妥当か
+<code>microservicePoints</code> を 800 に下げる / EC2 通常を 80 に下げる等で調整可</li>
+<li><strong>scoring engine を本問題に inline するか generic 基盤として切り出すか</strong>:
+本ドキュメントでは後者を推奨 (= 別 PR)。ただし microservice-migration-battle 専用の
+仕様 (= platform 判定 / フェーズ進行) もあるので、「generic polling + 問題ごとの scoring config」
+の分離設計が必要</li>
+<li><strong>競技者がコードを書き換える前提なので、本体 repo の services/ を直接書き換えると
+他チームに影響</strong>: 各チームは <strong>自分の AWS account 内で</strong> 編集
+(= EC2 上の <code>/opt/tenkacloud/repo/.../services/</code> を vim) するので影響なし。
+ただし git fetch がレースする可能性 → UserData は初回 clone 時のみ実行、再起動しても
+git pull しない設計にする</li>
+</ol>
+</section>
+
+</body>
+</html>

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "microservice-migration-battle",
+  "name": "Microservice Migration Battle",
+  "category": "Battle",
+  "status": "draft",
+  "difficulty": 4,
+  "estimatedDuration": "90〜120 分",
+  "shortDescription": "EC2 同居の 3 サービスを Lambda+APIGW / ECS Fargate / App Runner に分割し、劣化前にマイクロサービス化を完了させる。",
+  "description": "EC2 1 台に同居する 3 サービス (users / orders / catalog) のモノリス構成を、競技時間内に Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner の 3 種の異なるホスティングに分割していく Battle 問題。\n\n参加者は競技開始時に「採点対象とするスコア endpoint」を 3 つ登録する。スコアエンジンが 1 分毎に各 endpoint を polling し、レスポンス内容と応答時間からスコアを加減算する。\n\n競技開始から一定時間 (= イベントパラメータ degradationMinutes / デフォルト 60 分) が経過すると EC2 上のサービスが劣化し、得点効率が大幅に下がる。さらに進行 (= legacySwitchMinutes / デフォルト 90 分) するとスコアエンジンがコード内に仕込まれた legacy endpoint を polling 対象に切り替える。参加者はコードを読み解き、不要な処理を取り除いて再デプロイする必要がある。\n\n3 種類のホスティングのトレードオフを実体験し、strangler fig パターンを段階的に体験するアウトカム重視の設計。",
+  "tags": ["microservices", "migration", "lambda", "ecs", "app-runner", "strangler-fig"],
+  "exposedPorts": [{ "port": 80, "name": "frontend (nginx → users / orders / catalog)" }],
+  "learningGoals": [
+    "モノリスからマイクロサービスへの段階的移行 (strangler fig パターン) を体験する",
+    "Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner のトレードオフを比較する",
+    "スコアが時間経過で劣化する制約下で「どのサービスから分離すべきか」の優先順位を判断する",
+    "コードを読み解き、意図的に仕込まれた遅延処理を取り除いて再デプロイで復旧する経験を積む"
+  ],
+  "cfnTemplate": "template.yaml"
+}

--- a/problems/battles/microservice-migration-battle/services/catalog/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/catalog/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/problems/battles/microservice-migration-battle/services/catalog/main.py
+++ b/problems/battles/microservice-migration-battle/services/catalog/main.py
@@ -1,0 +1,66 @@
+"""catalog service for Microservice Migration Battle.
+
+EC2 上の docker compose / Lambda + API Gateway / ECS Fargate / AWS App Runner の
+いずれにも乗せられるよう、依存は FastAPI + uvicorn のみに絞っている。
+
+`/score` は高速経路、`/score?legacy=true` は意図的に遅い経路 (= 競技者が修正対象)。
+プラットフォームは環境変数 TC_PLATFORM で切り替える (ec2 / lambda / ecs / apprunner)。
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any
+
+from fastapi import FastAPI
+
+SERVICE_NAME = "catalog"
+VERSION = "1.0.0"
+
+app = FastAPI(title=f"TenkaCloud Battle — {SERVICE_NAME}")
+
+
+def _platform() -> str:
+    return os.environ.get("TC_PLATFORM", "ec2")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/meta")
+def meta() -> dict[str, str]:
+    return {
+        "service": SERVICE_NAME,
+        "platform": _platform(),
+        "version": VERSION,
+    }
+
+
+@app.get("/score")
+def score(legacy: bool = False) -> dict[str, Any]:
+    if legacy:
+        return _legacy_score()
+    return _fast_score()
+
+
+def _fast_score() -> dict[str, Any]:
+    return {
+        "service": SERVICE_NAME,
+        "score": random.randint(70, 120),
+        "via": "fast",
+    }
+
+
+def _legacy_score() -> dict[str, Any]:
+    # 旧実装の名残: 同期的な「外部キャッシュ更新」のフリをする 2.2 秒の sleep。
+    # 競技者はこの sleep を取り除き、cache を non-blocking にすること。
+    time.sleep(2.2)
+    return {
+        "service": SERVICE_NAME,
+        "score": random.randint(70, 120),
+        "via": "legacy",
+    }

--- a/problems/battles/microservice-migration-battle/services/catalog/requirements.txt
+++ b/problems/battles/microservice-migration-battle/services/catalog/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.4
+uvicorn[standard]==0.32.0

--- a/problems/battles/microservice-migration-battle/services/docker-compose.yml
+++ b/problems/battles/microservice-migration-battle/services/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  users:
+    build: ./users
+    environment:
+      - TC_PLATFORM=${TC_PLATFORM:-ec2}
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  orders:
+    build: ./orders
+    environment:
+      - TC_PLATFORM=${TC_PLATFORM:-ec2}
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  catalog:
+    build: ./catalog
+    environment:
+      - TC_PLATFORM=${TC_PLATFORM:-ec2}
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - users
+      - orders
+      - catalog
+    restart: unless-stopped

--- a/problems/battles/microservice-migration-battle/services/nginx.conf
+++ b/problems/battles/microservice-migration-battle/services/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # ルートはランディング (= どの service URL を叩くべきか競技者に示す)
+    location = / {
+        default_type text/html;
+        return 200 '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Microservice Migration Battle</title></head><body><h1>Microservice Migration Battle</h1><ul><li><a href="/users/meta">/users/meta</a></li><li><a href="/orders/meta">/orders/meta</a></li><li><a href="/catalog/meta">/catalog/meta</a></li></ul></body></html>';
+    }
+
+    location = /health {
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /users/ {
+        proxy_pass http://users:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /orders/ {
+        proxy_pass http://orders:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /catalog/ {
+        proxy_pass http://catalog:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/problems/battles/microservice-migration-battle/services/orders/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/orders/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/problems/battles/microservice-migration-battle/services/orders/main.py
+++ b/problems/battles/microservice-migration-battle/services/orders/main.py
@@ -1,0 +1,69 @@
+"""orders service for Microservice Migration Battle.
+
+EC2 上の docker compose / Lambda + API Gateway / ECS Fargate / AWS App Runner の
+いずれにも乗せられるよう、依存は FastAPI + uvicorn のみに絞っている。
+
+`/score` は高速経路、`/score?legacy=true` は意図的に遅い経路 (= 競技者が修正対象)。
+プラットフォームは環境変数 TC_PLATFORM で切り替える (ec2 / lambda / ecs / apprunner)。
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any
+
+from fastapi import FastAPI
+
+SERVICE_NAME = "orders"
+VERSION = "1.0.0"
+
+app = FastAPI(title=f"TenkaCloud Battle — {SERVICE_NAME}")
+
+
+def _platform() -> str:
+    return os.environ.get("TC_PLATFORM", "ec2")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/meta")
+def meta() -> dict[str, str]:
+    return {
+        "service": SERVICE_NAME,
+        "platform": _platform(),
+        "version": VERSION,
+    }
+
+
+@app.get("/score")
+def score(legacy: bool = False) -> dict[str, Any]:
+    if legacy:
+        return _legacy_score()
+    return _fast_score()
+
+
+def _fast_score() -> dict[str, Any]:
+    return {
+        "service": SERVICE_NAME,
+        "score": random.randint(60, 110),
+        "via": "fast",
+    }
+
+
+def _legacy_score() -> dict[str, Any]:
+    # 旧実装の名残: N+1 風に複数回 sleep して合計 2 秒以上の遅延を生じる。
+    # 競技者はこのループを取り除くこと。
+    aggregate = 0
+    for _ in range(5):
+        time.sleep(0.45)
+        aggregate += random.randint(10, 20)
+    return {
+        "service": SERVICE_NAME,
+        "score": aggregate + 50,
+        "via": "legacy",
+    }

--- a/problems/battles/microservice-migration-battle/services/orders/requirements.txt
+++ b/problems/battles/microservice-migration-battle/services/orders/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.4
+uvicorn[standard]==0.32.0

--- a/problems/battles/microservice-migration-battle/services/users/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/users/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/problems/battles/microservice-migration-battle/services/users/main.py
+++ b/problems/battles/microservice-migration-battle/services/users/main.py
@@ -1,0 +1,66 @@
+"""users service for Microservice Migration Battle.
+
+EC2 上の docker compose / Lambda + API Gateway / ECS Fargate / AWS App Runner の
+いずれにも乗せられるよう、依存は FastAPI + uvicorn のみに絞っている。
+
+`/score` は高速経路、`/score?legacy=true` は意図的に遅い経路 (= 競技者が修正対象)。
+プラットフォームは環境変数 TC_PLATFORM で切り替える (ec2 / lambda / ecs / apprunner)。
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any
+
+from fastapi import FastAPI
+
+SERVICE_NAME = "users"
+VERSION = "1.0.0"
+
+app = FastAPI(title=f"TenkaCloud Battle — {SERVICE_NAME}")
+
+
+def _platform() -> str:
+    return os.environ.get("TC_PLATFORM", "ec2")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/meta")
+def meta() -> dict[str, str]:
+    return {
+        "service": SERVICE_NAME,
+        "platform": _platform(),
+        "version": VERSION,
+    }
+
+
+@app.get("/score")
+def score(legacy: bool = False) -> dict[str, Any]:
+    if legacy:
+        return _legacy_score()
+    return _fast_score()
+
+
+def _fast_score() -> dict[str, Any]:
+    return {
+        "service": SERVICE_NAME,
+        "score": random.randint(50, 100),
+        "via": "fast",
+    }
+
+
+def _legacy_score() -> dict[str, Any]:
+    # 旧実装の名残: 同じ結果を返すために 2 秒待たせる必要は本当はない。
+    # 競技者はこの遅延を取り除くこと。
+    time.sleep(2.0)
+    return {
+        "service": SERVICE_NAME,
+        "score": random.randint(50, 100),
+        "via": "legacy",
+    }

--- a/problems/battles/microservice-migration-battle/services/users/requirements.txt
+++ b/problems/battles/microservice-migration-battle/services/users/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.4
+uvicorn[standard]==0.32.0

--- a/problems/battles/microservice-migration-battle/template.yaml
+++ b/problems/battles/microservice-migration-battle/template.yaml
@@ -1,0 +1,214 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud problem — microservice-migration-battle.
+  Single-EC2 (Amazon Linux 2023) + docker compose で 3 サービス (users / orders / catalog)
+  を同居起動。競技者は時間内に各サービスを Lambda+APIGW / ECS Fargate / App Runner の
+  いずれかに分割して再ホスティングする。
+
+# 同一 (Account, Region) に複数チームの問題スタックが共存できるよう、すべての
+# リソース名は ${NamePrefix} (= "tc-{problemSlug}-{teamSlug}", UI 側 buildStackPrefix
+# と一致) を冠する。
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    ConstraintDescription: >
+      `tc-{problemSlug}-{teamSlug}` 形式 (英小文字 / 数字 / ハイフン)。
+      application-admin-console の DeployForm が生成する prefix を渡す。
+    Description: >
+      すべてのリソース名に冠する共通 prefix。同一 Account / Region に複数チームの
+      スタックが共存しても衝突しないようにする。
+  AllowedCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+    Description: frontend (80) を許可する CIDR。
+  InstanceType:
+    Type: String
+    Default: t3.small
+    AllowedValues:
+      - t3.micro
+      - t3.small
+      - t3.medium
+    Description: EC2 インスタンスタイプ。
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
+    Description: SSM-backed Amazon Linux 2023 AMI (auto-resolved)。
+  RepoUrl:
+    Type: String
+    Default: https://github.com/susumutomita/TenkaCloud.git
+    Description: >
+      services/ ディレクトリを含む repo URL。
+      ADR-008 v2 (Phase 3) 完了後は S3 presigned URL に切替予定。
+  RepoRef:
+    Type: String
+    Default: main
+    Description: チェックアウトする branch / tag / commit。
+
+Resources:
+  # ----- VPC + Networking -----
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.99.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.99.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet"
+
+  Igw:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-igw"
+
+  IgwAttach:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref Igw
+
+  Rt:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rt"
+
+  RtRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IgwAttach
+    Properties:
+      RouteTableId: !Ref Rt
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref Igw
+
+  RtAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref Rt
+      SubnetId: !Ref PublicSubnet
+
+  # ----- Security Group -----
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: !Sub "${NamePrefix} problem instance access"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref AllowedCidr
+          Description: frontend (nginx)
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-sg"
+
+  # ----- IAM (SSM Session Manager only) -----
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-instance-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub "${NamePrefix}-instance-profile"
+      Roles:
+        - !Ref InstanceRole
+
+  # ----- EC2 -----
+  Ec2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref Sg
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2"
+        - Key: TenkaCloud:Problem
+          Value: microservice-migration-battle
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+          dnf update -y
+          dnf install -y docker git
+          systemctl enable --now docker
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64" \
+            -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+          mkdir -p /opt/tenkacloud
+          cd /opt/tenkacloud
+          # branch / tag / commit いずれも指せるよう、shallow fetch + checkout 形式
+          git clone "${RepoUrl}" repo
+          cd repo
+          git fetch origin "${RepoRef}" || git fetch --all
+          git checkout "${RepoRef}" || git checkout FETCH_HEAD
+
+          PROBLEM_ROOT=/opt/tenkacloud/repo/problems/battles/microservice-migration-battle
+          cd "$PROBLEM_ROOT/services"
+
+          # 競技開始時は全サービス EC2 上で起動
+          TC_PLATFORM=ec2 docker compose up -d --build
+
+Outputs:
+  FrontendUrl:
+    Description: 参加者向け frontend (nginx) の入り口 URL。
+    Value: !Sub "http://${Ec2.PublicDnsName}"
+  UsersEndpoint:
+    Description: users サービスのスコア endpoint (= 採点対象として登録)。
+    Value: !Sub "http://${Ec2.PublicDnsName}/users/score"
+  OrdersEndpoint:
+    Description: orders サービスのスコア endpoint。
+    Value: !Sub "http://${Ec2.PublicDnsName}/orders/score"
+  CatalogEndpoint:
+    Description: catalog サービスのスコア endpoint。
+    Value: !Sub "http://${Ec2.PublicDnsName}/catalog/score"
+  InstanceId:
+    Description: EC2 インスタンス ID (運営者が SSM Session Manager から接続する際に使う)。
+    Value: !Ref Ec2
+  SsmStartSessionCommand:
+    Description: 運営者がインスタンスへ Session Manager で接続するコマンド。
+    Value: !Sub "aws ssm start-session --target ${Ec2}"
+  NamePrefix:
+    Description: 本スタックが利用した共通リソース prefix。
+    Value: !Ref NamePrefix


### PR DESCRIPTION
## Summary

- **ADR-008 v2** (大幅改訂): 問題カタログを **Community Contribution Registry** にする設計を確定 (= DDB-backed catalog + S3 multi-tenant payload + GitHub PR 寄稿フロー)
- **microservice-migration-battle 雛形**: EC2 同居の 3 サービス (`users` / `orders` / `catalog`) を docker compose で起動する Battle 問題。寄稿問題第 1 号として位置づけ

driver: #572 / tracking: #574

### ADR v1 → v2 の主な変更

| 領域 | v1 | v2 |
|------|----|----|
| 主軸 | 自分用 private repo + 答え漏れ防止 | **コミュニティ寄稿が一級市民** |
| カタログ | 本体 repo の `index.json` 静的 | **DDB `ProblemRegistry`** (ADR-003 Phase 2 前倒し) |
| payload | 自分用 S3 prefix | **S3 multi-tenant prefix** (`<contributor>/<id>/<version>/`) |
| 寄稿フロー | 自分の repo の CI で publish | **GitHub PR ベース MVP** (Web UI / CLI は後付け) |
| 答え漏れ | 主目的 | **副産物として解決** (= visibility=private + 15min presigned URL) |

設計判断 D1〜D9 + DDB schema + SVG アーキテクチャ図 + Migration 5 phase + Open Questions 9 件を `docs/architecture/adr-008-problem-payload-separation.html` に。

### microservice-migration-battle のスコア設計

| 状態 | 1 check あたり |
|------|----------------|
| 未登録 / timeout | -100 |
| EC2 通常 | +100 |
| EC2 劣化 (= 60min 経過後) | +10 |
| マイクロサービス化 (Lambda/ECS/App Runner) | +1,000 |
| 3 サービス全分離ボーナス | +5,000 (1 回限り) |
| 遅延 endpoint 切替 (= 90min 経過後 / 修正前) | +10 |

スコアエンジン (1 分毎 polling Lambda + endpoint 登録 UI) は **別 PR** に分離。他 Battle でも使い回す generic polling 基盤として切り出す予定。

## Test plan

- [x] `make validate-problems` 通過 (4/4 OK、新 metadata.json schema validate)
- [x] textlint / biome format check 通過 (= pre-commit hook 経由)
- [ ] ローカル動作確認: `cd problems/battles/microservice-migration-battle/services && TC_PLATFORM=ec2 docker compose up --build` → `curl http://localhost/users/score` / `curl 'http://localhost/users/score?legacy=true'` (= 約 2 秒遅延を確認)
- [ ] (merge 後) main の次回 deploy で catalog UI に `microservice-migration-battle` が表示されることを確認
- [ ] (merge 後) `make deploy` で本問題スタックを 1 チーム分立てて EC2 → 3 サービスが起動することを確認

## Regression 分析

新規ファイルのみで既存コードは未変更:

- 既存 3 問題 (`hello-world-battle` / `security-battle-royale` / `hello-world`) には影響なし
- `apps/application-admin-console/src/data/problems.ts:61` の Vite `import.meta.glob` が新問題を自動 pick-up → カタログに 1 件追加 (= 既存問題の表示には影響なし)
- `infrastructure/bin/infrastructure.ts:214` の `discoverProblemsCatalog()` も同様、build 時に新問題を Lambda env に注入
- ADR-008 v2 で予告した `SCHEMA.json` への `visibility` / `contributor` field 追加は **本 PR では未実装** (= Phase 2 で別 PR)
- 検証 Lambda / DDB ProblemRegistry / S3 publish パイプラインは本 PR には含まれない (= Phase 1〜4 は後続 PR)

## 物理影響

- **CREATE**: `docs/architecture/adr-008-problem-payload-separation.html` — ADR v2 設計ドキュメント (HTML)
- **CREATE**: `problems/battles/microservice-migration-battle/` 配下 15 ファイル — 問題テンプレート (metadata / README / design.html / template.yaml / services × 3)
- **本 PR 単体では AWS リソースの差分なし**: CDK stack / Lambda 配線は触らない
- **次回 main deploy 後**: Lambda env `BATTLE_PROBLEMS_CATALOG` に `microservice-migration-battle` が含まれ、admin-console / app-admin-console / participant-portal のカタログに新問題が表示される (= ここから deploy 可能になる)
- competitor account への deploy が実際に走った時の **物理影響**: EC2 1 台 (t3.small) + VPC + Subnet + IGW + RouteTable + SecurityGroup (port 80 ingress) + IAM Role/Profile (SSM Session Manager のみ)。teardown は ADR-002 の cross-account AssumeRole 経路で行う

## 次の作業 (= 後続 PR の見取り図)

1. **ADR-008 v2 Phase 1** — `ProblemRegistry` stack (DDB + S3 + GitHub OIDC role) を CDK で追加 (user 担当 = インフラ)
2. **Phase 2** — `SCHEMA.json` に `visibility` / `contributor` 追加 + 既存 4 問題を seed import
3. **Phase 3** — カタログ DDB 化 (Vite glob 廃止) + Worker Lambda の S3 fetch 化
4. **Phase 4** — 寄稿パイプライン (`contrib-validate.yml` / `contrib-publish.yml` + 検証 Lambda)
5. **microservice-migration-battle スコアエンジン** — 1 分毎 polling Lambda + endpoint 登録 UI (= generic 基盤として他 Battle でも使い回す)

## 関連

- Relates #572 (driver、microservice-migration-battle の設計 issue)
- Relates #574 (ADR-008 tracking issue)
- Relates ADR-001 (Problem Deploy CRUD、本 ADR が拡張する pipeline)
- Relates ADR-002 (Cross-account federation、競技者 acct への AssumeRole)
- Relates ADR-003 (Problem Catalog DDB、本 ADR で Phase 2 を実現)

🤖 Generated with [Claude Code](https://claude.com/claude-code)