### PR TITLE
feat(#531): EventDetail Wizard CTA — 初見 operator 向け次アクション誘導

### DIFF
--- a/apps/application-admin-console/src/lib/event-wizard.ts
+++ b/apps/application-admin-console/src/lib/event-wizard.ts
@@ -1,0 +1,162 @@
+import type { EventDeploymentSummary, EventStatus } from "../api/events-client";
+
+export type WizardStepKey =
+  | "draft"
+  | "deploying"
+  | "ready_unscheduled"
+  | "scheduled"
+  | "in_competition"
+  | "ended"
+  | "teardown"
+  | "archived";
+
+export type WizardPrimary = "deploy" | "start" | "end" | "delete" | null;
+
+export interface WizardState {
+  readonly step: WizardStepKey;
+  readonly stepIndex: number;
+  readonly primary: WizardPrimary;
+  readonly cta: string;
+  readonly alertType: "info" | "success" | "warning";
+}
+
+export interface EventWizardInput {
+  readonly status: EventStatus;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+  readonly deploymentsByProblem?: Readonly<Record<string, readonly EventDeploymentSummary[]>>;
+}
+
+/**
+ * #531 Wizard step ラベル (5 段表示)。READY 状態 (= 3, 4) は startsAt / 現在時刻で
+ * 「開始待ち / 採点中」を分岐する。TEARDOWN / ARCHIVED は終了系として step 5 に集約。
+ */
+export const WIZARD_STEPS: readonly { key: WizardStepKey; label: string }[] = [
+  { key: "draft", label: "作成" },
+  { key: "deploying", label: "Deploy" },
+  { key: "ready_unscheduled", label: "開始時刻設定" },
+  { key: "in_competition", label: "競技中" },
+  { key: "ended", label: "終了" },
+] as const;
+
+function deploymentProgress(deploymentsByProblem: EventWizardInput["deploymentsByProblem"]): {
+  total: number;
+  complete: number;
+  failed: number;
+} {
+  let total = 0;
+  let complete = 0;
+  let failed = 0;
+  if (!deploymentsByProblem) return { total, complete, failed };
+  for (const list of Object.values(deploymentsByProblem)) {
+    for (const d of list) {
+      total += 1;
+      if (d.status === "COMPLETE") complete += 1;
+      if (d.status === "FAILED") failed += 1;
+    }
+  }
+  return { total, complete, failed };
+}
+
+/**
+ * #531: EventDetail の「初見でも次に何を押せばいいか」を表す Wizard state。
+ *
+ * status + startsAt + 現在時刻 + deployment 進捗 を入力に、
+ *   - step: 5 段の進捗 (作成 → Deploy → 開始時刻設定 → 競技中 → 終了)
+ *   - primary: その state で primary variant にすべき action button
+ *   - cta: Alert banner に出す operator 向け案内文
+ *   - alertType: Alert の type (info = 要操作、success = 進行中)
+ * を返す純粋関数。
+ *
+ * - DRAFT: Deploy 待ち。primary=deploy
+ * - DEPLOYING: 進行中。primary=null (進捗だけ見せる)
+ * - READY + startsAt なし: 開始時刻設定待ち。primary=start
+ * - READY + startsAt 未来: 開始予定。primary=null
+ * - READY + startsAt 過去: 競技中。primary=null (採点中、操作不要)
+ * - ENDED: 終了。primary=delete (= Bulk Teardown)
+ * - TEARDOWN: 削除中。primary=null
+ * - ARCHIVED: アーカイブ済。primary=null
+ */
+export function computeEventWizardState(input: EventWizardInput, nowMs: number): WizardState {
+  const { status, startsAt, deploymentsByProblem } = input;
+
+  if (status === "DRAFT") {
+    return {
+      step: "draft",
+      stepIndex: 0,
+      primary: "deploy",
+      cta: "Event を作成しました。「Deploy」 button で全 team × 全問題の deploy を開始してください。",
+      alertType: "info",
+    };
+  }
+
+  if (status === "DEPLOYING") {
+    const { total, complete, failed } = deploymentProgress(deploymentsByProblem);
+    const tail = total > 0 ? ` (${complete} / ${total} 完了、失敗 ${failed} 件)` : "";
+    return {
+      step: "deploying",
+      stepIndex: 1,
+      primary: null,
+      cta: `Deploy 進行中${tail}。全 deployment が COMPLETE になると自動で READY に遷移します。`,
+      alertType: "success",
+    };
+  }
+
+  if (status === "READY") {
+    if (!startsAt) {
+      return {
+        step: "ready_unscheduled",
+        stepIndex: 2,
+        primary: "start",
+        cta: "Deploy 完了。競技開始時刻を設定すると HealthCheck が採点を開始します。「即座に開始」 または 「日時を指定して開始」 を押してください。",
+        alertType: "info",
+      };
+    }
+    const startsAtMs = new Date(startsAt).getTime();
+    if (Number.isFinite(startsAtMs) && startsAtMs > nowMs) {
+      return {
+        step: "scheduled",
+        stepIndex: 2,
+        primary: null,
+        cta: `開始時刻設定済 (${startsAt})。指定時刻まで採点は停止中。`,
+        alertType: "success",
+      };
+    }
+    return {
+      step: "in_competition",
+      stepIndex: 3,
+      primary: null,
+      cta: "競技中。スコアが Participant Portal で更新中です。終了するときは 「Event を終了」 を押すか、終了時刻 (endsAt) を設定してください。",
+      alertType: "success",
+    };
+  }
+
+  if (status === "ENDED") {
+    return {
+      step: "ended",
+      stepIndex: 4,
+      primary: "delete",
+      cta: "Event 終了。採点は停止しています。「Delete」 で全 deployment を一括削除できます。",
+      alertType: "info",
+    };
+  }
+
+  if (status === "TEARDOWN") {
+    return {
+      step: "ended",
+      stepIndex: 4,
+      primary: null,
+      cta: "deployment 削除中… 全削除が完了すると自動で ARCHIVED に遷移します。",
+      alertType: "warning",
+    };
+  }
+
+  // ARCHIVED
+  return {
+    step: "archived",
+    stepIndex: 4,
+    primary: null,
+    cta: "アーカイブ済 (deployment は全削除済)。閲覧のみ可能です。",
+    alertType: "success",
+  };
+}

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -14,7 +14,7 @@ import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
 import TimeInput from "@cloudscape-design/components/time-input";
 import { StatusCodes } from "http-status-codes";
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { ApiError, useApiClient } from "../api/client";
 import {
@@ -32,6 +32,7 @@ import {
 } from "../api/events-client";
 import { SendNotificationModal } from "../components/SendNotificationModal";
 import type { AppConfig } from "../config";
+import { computeEventWizardState, WIZARD_STEPS } from "../lib/event-wizard";
 
 const DEPLOY_STATUS_COLOR: Record<EventDeploymentStatus, "blue" | "green" | "grey" | "red"> = {
   PENDING: "grey",
@@ -318,6 +319,11 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     );
   }
 
+  // #531: 「今 operator が押すべき primary action」を 1 つだけ強調する。
+  // wizard.primary が一致した button のみ variant=primary、それ以外は default。
+  // 状態と一致しない button (= DRAFT で「即座に開始」など) は disabled で抑止する。
+  const wizard = detail ? computeEventWizardState(detail, Date.now()) : null;
+
   return (
     <SpaceBetween size="l">
       <Header
@@ -327,7 +333,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           <SpaceBetween direction="horizontal" size="xs">
             <Button onClick={() => navigate("/events")}>一覧へ戻る</Button>
             <Button
-              variant="primary"
+              variant={wizard?.primary === "deploy" ? "primary" : "normal"}
               loading={bulkInFlight === "deploy"}
               disabled={
                 !detail ||
@@ -349,6 +355,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
               Event を終了
             </Button>
             <Button
+              variant={wizard?.primary === "delete" ? "primary" : "normal"}
               loading={bulkInFlight === "teardown"}
               disabled={!detail}
               onClick={() => setConfirmTeardown(true)}
@@ -360,6 +367,38 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       >
         {detail?.name ?? "(loading)"}
       </Header>
+
+      {/* #531: Wizard StepIndicator + CTA banner — 初見 operator が「次に何を押すか」を
+       *   1 画面で分かるようにする。Step 表示は 5 段固定 (作成 → Deploy → 開始時刻設定 →
+       *   競技中 → 終了)、CTA Alert は status 依存。primary button 表示は Header actions
+       *   / Schedule Container の既存 button と variant 同期。 */}
+      {wizard && (
+        <Container>
+          <SpaceBetween size="m">
+            <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+              {WIZARD_STEPS.map((step, i) => (
+                <Fragment key={step.key}>
+                  {i > 0 && (
+                    <Box color="text-status-inactive" variant="small">
+                      →
+                    </Box>
+                  )}
+                  <Badge
+                    color={
+                      i < wizard.stepIndex ? "green" : i === wizard.stepIndex ? "blue" : "grey"
+                    }
+                  >
+                    {i + 1}. {step.label}
+                  </Badge>
+                </Fragment>
+              ))}
+            </SpaceBetween>
+            <Alert type={wizard.alertType} header="次のアクション">
+              {wizard.cta}
+            </Alert>
+          </SpaceBetween>
+        </Container>
+      )}
 
       {error && (
         <Alert type="error" header="エラー">
@@ -420,7 +459,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                     日時を指定して開始
                   </Button>
                   <Button
-                    variant="primary"
+                    variant={wizard?.primary === "start" ? "primary" : "normal"}
                     loading={scheduleInFlight === "now"}
                     disabled={!apiClient || scheduleInFlight === "scheduled"}
                     onClick={handleStartNow}

--- a/apps/application-admin-console/test/lib/event-wizard.test.ts
+++ b/apps/application-admin-console/test/lib/event-wizard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { computeEventWizardState, WIZARD_STEPS } from "../../src/lib/event-wizard";
+
+const NOW_MS = new Date("2026-05-11T12:00:00Z").getTime();
+
+describe("computeEventWizardState", () => {
+  it("DRAFT のとき primary=deploy で「Deploy を押せ」を CTA に出すべき", () => {
+    const out = computeEventWizardState({ status: "DRAFT" }, NOW_MS);
+    expect(out.step).toBe("draft");
+    expect(out.stepIndex).toBe(0);
+    expect(out.primary).toBe("deploy");
+    expect(out.cta).toMatch(/Deploy/);
+    expect(out.alertType).toBe("info");
+  });
+
+  it("DEPLOYING のとき primary=null で進捗 N/M を CTA に含めるべき", () => {
+    const out = computeEventWizardState(
+      {
+        status: "DEPLOYING",
+        deploymentsByProblem: {
+          p1: [
+            { jobId: "j1", teamId: "t1", status: "COMPLETE" },
+            { jobId: "j2", teamId: "t2", status: "IN_PROGRESS" },
+          ],
+          p2: [{ jobId: "j3", teamId: "t1", status: "PENDING" }],
+        },
+      },
+      NOW_MS,
+    );
+    expect(out.step).toBe("deploying");
+    expect(out.stepIndex).toBe(1);
+    expect(out.primary).toBeNull();
+    expect(out.cta).toMatch(/1 \/ 3/);
+    expect(out.cta).toMatch(/失敗 0/);
+    expect(out.alertType).toBe("success");
+  });
+
+  it("READY + startsAt なしのとき primary=start で「開始時刻を設定」を促すべき", () => {
+    const out = computeEventWizardState({ status: "READY" }, NOW_MS);
+    expect(out.step).toBe("ready_unscheduled");
+    expect(out.stepIndex).toBe(2);
+    expect(out.primary).toBe("start");
+    expect(out.cta).toMatch(/開始時刻/);
+    expect(out.alertType).toBe("info");
+  });
+
+  it("READY + startsAt 未来のとき primary=null で開始予定を示すべき", () => {
+    const future = new Date(NOW_MS + 60 * 60 * 1000).toISOString();
+    const out = computeEventWizardState({ status: "READY", startsAt: future }, NOW_MS);
+    expect(out.step).toBe("scheduled");
+    expect(out.stepIndex).toBe(2);
+    expect(out.primary).toBeNull();
+    expect(out.cta).toContain(future);
+    expect(out.alertType).toBe("success");
+  });
+
+  it("READY + startsAt 過去のとき step=in_competition で primary=null になるべき", () => {
+    const past = new Date(NOW_MS - 60 * 1000).toISOString();
+    const out = computeEventWizardState({ status: "READY", startsAt: past }, NOW_MS);
+    expect(out.step).toBe("in_competition");
+    expect(out.stepIndex).toBe(3);
+    expect(out.primary).toBeNull();
+    expect(out.cta).toMatch(/競技中/);
+    expect(out.alertType).toBe("success");
+  });
+
+  it("ENDED のとき primary=delete で「Bulk Teardown を案内」すべき", () => {
+    const out = computeEventWizardState({ status: "ENDED" }, NOW_MS);
+    expect(out.step).toBe("ended");
+    expect(out.stepIndex).toBe(4);
+    expect(out.primary).toBe("delete");
+    expect(out.cta).toMatch(/Delete/);
+    expect(out.alertType).toBe("info");
+  });
+
+  it("TEARDOWN のとき primary=null で「削除中」を warning で表示すべき", () => {
+    const out = computeEventWizardState({ status: "TEARDOWN" }, NOW_MS);
+    expect(out.primary).toBeNull();
+    expect(out.cta).toMatch(/削除中/);
+    expect(out.alertType).toBe("warning");
+  });
+
+  it("ARCHIVED のとき primary=null で「閲覧のみ」と示すべき", () => {
+    const out = computeEventWizardState({ status: "ARCHIVED" }, NOW_MS);
+    expect(out.step).toBe("archived");
+    expect(out.primary).toBeNull();
+    expect(out.cta).toMatch(/アーカイブ/);
+  });
+
+  it("WIZARD_STEPS は重複なしの 5 段で順序固定であるべき", () => {
+    expect(WIZARD_STEPS).toHaveLength(5);
+    const keys = WIZARD_STEPS.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual(["draft", "deploying", "ready_unscheduled", "in_competition", "ended"]);
+  });
+});

--- a/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return {
+    ...actual,
+    getEvent: mocks.getEvent,
+  };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Test Event",
+  status: "DRAFT",
+  teamCount: 2,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  teams: [
+    { teamId: "t1", internalSlug: "team-alpha" },
+    { teamId: "t2", internalSlug: "team-beta" },
+  ],
+  problems: [{ problemId: "hello-world-battle", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {},
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventDetailPage #531 Wizard", () => {
+  it("DRAFT のとき「次のアクション」 Alert で Deploy を案内するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DRAFT" });
+    renderPage();
+    await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));
+    const alert = await screen.findByText(/「Deploy」 button で全 team/);
+    expect(alert).toBeInTheDocument();
+  });
+
+  it("READY + startsAt なしのとき開始時刻設定を案内するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "READY", startsAt: undefined });
+    renderPage();
+    const alert = await screen.findByText(/競技開始時刻を設定/);
+    expect(alert).toBeInTheDocument();
+  });
+
+  it("ENDED のとき Bulk Teardown (Delete) を案内するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "ENDED" });
+    renderPage();
+    const alert = await screen.findByText(/「Delete」 で全 deployment/);
+    expect(alert).toBeInTheDocument();
+  });
+
+  it("Wizard StepIndicator は 5 段のラベル (作成 / Deploy / 開始時刻設定 / 競技中 / 終了) を表示すべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DRAFT" });
+    renderPage();
+    await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));
+    expect(screen.getByText(/1\. 作成/)).toBeInTheDocument();
+    expect(screen.getByText(/2\. Deploy/)).toBeInTheDocument();
+    expect(screen.getByText(/3\. 開始時刻設定/)).toBeInTheDocument();
+    expect(screen.getByText(/4\. 競技中/)).toBeInTheDocument();
+    expect(screen.getByText(/5\. 終了/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

EventDetail を開いて「次に何を押すか」が初見で分からない問題 (#531) を解消する。

- Header 直下に **5 段 Wizard StepIndicator** を追加 (作成 → Deploy → 開始時刻設定 → 競技中 → 終了)
- 状態別 **CTA Alert** (「次のアクション」) で operator にやるべきことを文章で示す
- Deploy / 即座に開始 / Delete の `variant` を status に応じて primary に flip — primary が画面に 1 つだけ残る

## 設計判断

- **Wizard component は自前**: Cloudscape `Wizard` は全画面置き換え型で既存 EventDetail と衝突するため、`Badge` + 矢印の inline 構成にした。既存の Container 群を全く触らない
- **state machine**: status + startsAt + 現在時刻で sub-state (READY → ready_unscheduled / scheduled / in_competition) を切り分け
- **1 source of truth**: `computeEventWizardState()` 純粋関数で `step / primary / cta / alertType` を返し、UI 各所が同じ state に従う

## 変更点

| 場所 | 変更 |
|---|---|
| `src/lib/event-wizard.ts` (新規) | `computeEventWizardState()` + `WIZARD_STEPS` |
| `src/pages/EventDetail.tsx` | Header 直下に Wizard Container 追加、Deploy / 即座に開始 / Delete の variant 動的化 |
| `test/lib/event-wizard.test.ts` (新規) | 9 件、全 status の step/primary/cta を pin |
| `test/pages/EventDetail.wizard.test.tsx` (新規) | 4 件、DRAFT/READY-unscheduled/ENDED で CTA Alert + Step ラベル を pin |

## Regression 分析

| # | 壊しうる挙動 | 確認 |
|---|---|---|
| 1 | Deploy / Delete button の disable 条件 | ✅ 不変、variant のみ動的化 |
| 2 | schedule modal の submit handler | ✅ 無変更 |
| 3 | bulkResult Alert | ✅ Wizard Container は別 element |
| 4 | DRAFT 以外で Deploy が primary 表示 | ✅ wizard.primary === "deploy" は DRAFT のみ |
| 5 | startsAt past + status=READY | ✅ step="in_competition"、primary=null |
| 6 | 既存 vitest | ✅ admin-console 13 files / 93/93、全 workspace 582/582 |

## 物理影響

- application-admin-console frontend のみ
- CFn / Lambda / DDB / API は NO-OP
- bundle 増 < 1 KB

## Test plan

- [x] typecheck (4 packages) green
- [x] vitest 全 workspace → 67 files / 582/582
- [x] biome / textlint / check-http-status / validate-problems / check-docs green
- [ ] deploy 後: EventCreate → EventDetail (DRAFT) で「Deploy を押せ」 Alert + Deploy が primary 強調 → 押下 → DEPLOYING で進捗 N/M → READY で「開始時刻を設定」 Alert + 即座に開始 が primary → 即座に開始 → 競技中 Alert → Event を終了 → ENDED で「Delete」 Alert + Delete が primary

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event workflow wizard with step-by-step guidance through the event lifecycle.
  * Visual indicators show current progress and emphasize the next required action.
  * Dynamic alerts inform users about event status and upcoming steps.
  * Action buttons intelligently highlight based on current workflow stage.

* **Tests**
  * Added comprehensive test coverage for wizard logic and UI rendering across event statuses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/584)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->