### PR TITLE
feat(#532): tenant 一覧 provisioning 状態 badge を実値に整合 + 色マッピング修正

### DIFF
--- a/apps/admin-console/src/api/tenants.ts
+++ b/apps/admin-console/src/api/tenants.ts
@@ -10,7 +10,68 @@ import type { ApiClient } from "./client";
  */
 export type Tier = "basic" | "advanced" | "platinum";
 
-export type TenantStatus = "In progress" | "Complete" | "Deleted" | string;
+/**
+ * Tenant の provisioning 状態。provision-tenant.sh / deprovision-tenant.sh が
+ * 実際に書き込む文字列リテラルを正本とする:
+ *   - "In progress" — SBT が POST /tenants で初期値として書く (createTenant 参照)
+ *   - "Complete"   — provision-tenant.sh:134 で BashJobRunner が export
+ *   - "Failed"     — BashJobRunner が exit non-zero のとき (SBT 内蔵)
+ *   - "Deleted"    — deprovision-tenant.sh:136 で export
+ * 比較は大文字 / 小文字非依存 (SBT が経路によって case を変えるため安全側に倒す)。
+ */
+export type TenantStatus = "In progress" | "Complete" | "Failed" | "Deleted" | string;
+
+/**
+ * Cloudscape Badge / StatusIndicator で使う色名 (BadgeProps["color"] と互換)。
+ * Badge component に直接渡せるよう値だけを返す軽量関数として export し、UI 層から
+ * 切り離して unit test 可能にする。
+ */
+export type StatusBadgeColor = "green" | "blue" | "red" | "grey";
+
+/**
+ * `tenantStatus` 文字列 → Badge 色のマッピング。`provision-tenant.sh` が
+ * `tenantStatus="Complete"`、`deprovision-tenant.sh` が `tenantStatus="Deleted"`、
+ * SBT 初期化が `"In progress"`、BashJobRunner 失敗時が `"Failed"` を書くので
+ * それを正本に色を決める。SBT 経路によって case が揺れるため case-insensitive。
+ *
+ * 既知でない値 (空 / undefined / 想定外文字列) は grey にフォールバックする
+ * (= 状態不明であることを UI 上で示すが、エラー扱いはしない)。
+ */
+export function tenantStatusBadgeColor(tenantStatus: string | undefined): StatusBadgeColor {
+  switch ((tenantStatus ?? "").toLowerCase()) {
+    case "complete":
+      return "green";
+    case "in progress":
+      return "blue";
+    case "failed":
+      return "red";
+    case "deleted":
+    case "deprovisioned":
+      return "grey";
+    default:
+      return "grey";
+  }
+}
+
+/**
+ * Tier → Badge 色のマッピング。silo 専用 stack を立てる "platinum" を最も目立つ色
+ * (green) に、pooled stack 共有の "basic" / "advanced" は控えめにする。
+ *
+ * `provision-tenant.sh` の `if [[ $TIER == "PLATINUM" ]]` 大文字比較に合わせて
+ * case-insensitive で判定する。未知の tier は grey フォールバック。
+ */
+export function tierBadgeColor(tier: string | undefined): StatusBadgeColor {
+  switch ((tier ?? "").toLowerCase()) {
+    case "platinum":
+      return "green";
+    case "advanced":
+      return "blue";
+    case "basic":
+      return "grey";
+    default:
+      return "grey";
+  }
+}
 
 export interface Tenant {
   tenantId: string;

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -1,5 +1,5 @@
 import Alert from "@cloudscape-design/components/alert";
-import Badge, { type BadgeProps } from "@cloudscape-design/components/badge";
+import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Header from "@cloudscape-design/components/header";
@@ -15,20 +15,10 @@ import {
   listTenants,
   parseTenantConfig,
   type Tenant,
-  type TenantStatus,
+  tenantStatusBadgeColor,
+  tierBadgeColor,
 } from "../api/tenants";
 import type { AppConfig } from "../config";
-
-const STATUS_BADGE_COLOR: Partial<Record<TenantStatus, BadgeProps["color"]>> = {
-  ACTIVE: "green",
-  PROVISIONING: "blue",
-  DEPROVISIONING: "grey",
-  DELETED: "grey",
-};
-
-function statusBadgeColor(tenantStatus: string): BadgeProps["color"] {
-  return STATUS_BADGE_COLOR[tenantStatus as TenantStatus] ?? "grey";
-}
 
 /**
  * deprovision 済みの tenant かどうかを判定する。
@@ -124,11 +114,17 @@ export function TenantListPage({ config }: { config: AppConfig }) {
           { id: "tenantId", header: "テナント ID", cell: (t) => t.tenantId },
           { id: "tenantName", header: "名称", cell: (t) => t.tenantName },
           { id: "email", header: "管理者メール", cell: (t) => t.email },
-          { id: "tier", header: "Tier", cell: (t) => <Badge>{t.tier}</Badge> },
+          {
+            id: "tier",
+            header: "Tier",
+            cell: (t) => <Badge color={tierBadgeColor(t.tier)}>{t.tier}</Badge>,
+          },
           {
             id: "status",
             header: "状態",
-            cell: (t) => <Badge color={statusBadgeColor(t.tenantStatus)}>{t.tenantStatus}</Badge>,
+            cell: (t) => (
+              <Badge color={tenantStatusBadgeColor(t.tenantStatus)}>{t.tenantStatus}</Badge>
+            ),
           },
           {
             id: "appConsole",

--- a/apps/admin-console/test/tenants.test.ts
+++ b/apps/admin-console/test/tenants.test.ts
@@ -6,6 +6,8 @@ import {
   deleteTenant,
   listTenants,
   parseTenantConfig,
+  tenantStatusBadgeColor,
+  tierBadgeColor,
 } from "../src/api/tenants";
 
 function buildApiMock(overrides: Partial<ApiClient> = {}): {
@@ -298,6 +300,86 @@ describe("buildCodeBuildBuildUrl", () => {
           accountId: "111",
         }),
       ).toBeNull();
+    });
+  });
+});
+
+describe("tenantStatusBadgeColor", () => {
+  describe("provision-tenant.sh が書き込む実際の tenantStatus 値に対して", () => {
+    it("'Complete' を green にマップすべき (= provisioning 完了)", () => {
+      expect(tenantStatusBadgeColor("Complete")).toBe("green");
+    });
+
+    it("'In progress' を blue にマップすべき (= provisioning 進行中)", () => {
+      expect(tenantStatusBadgeColor("In progress")).toBe("blue");
+    });
+
+    it("'Failed' を red にマップすべき (= provisioning 失敗)", () => {
+      expect(tenantStatusBadgeColor("Failed")).toBe("red");
+    });
+
+    it("'Deleted' を grey にマップすべき (= deprovisioned tenant)", () => {
+      expect(tenantStatusBadgeColor("Deleted")).toBe("grey");
+    });
+  });
+
+  describe("大文字 / 小文字ゆれを吸収するとき", () => {
+    it("'complete' (小文字) でも green を返すべき", () => {
+      expect(tenantStatusBadgeColor("complete")).toBe("green");
+    });
+
+    it("'COMPLETE' (大文字) でも green を返すべき", () => {
+      expect(tenantStatusBadgeColor("COMPLETE")).toBe("green");
+    });
+
+    it("'failed' (小文字) でも red を返すべき", () => {
+      expect(tenantStatusBadgeColor("failed")).toBe("red");
+    });
+
+    it("'in progress' (小文字) でも blue を返すべき", () => {
+      expect(tenantStatusBadgeColor("in progress")).toBe("blue");
+    });
+  });
+
+  describe("未知の値が来たとき", () => {
+    it("grey にフォールバックすべき (= 未定義状態)", () => {
+      expect(tenantStatusBadgeColor("Unknown")).toBe("grey");
+    });
+
+    it("空文字でも grey を返すべき", () => {
+      expect(tenantStatusBadgeColor("")).toBe("grey");
+    });
+
+    it("undefined / null 相当の文字列でも grey を返すべき", () => {
+      expect(tenantStatusBadgeColor("undefined")).toBe("grey");
+    });
+  });
+});
+
+describe("tierBadgeColor", () => {
+  describe("各 tier に異なる色を割り当てるとき", () => {
+    it("basic は grey (= pooled の最小構成) であるべき", () => {
+      expect(tierBadgeColor("basic")).toBe("grey");
+    });
+
+    it("advanced は blue (= pooled の中間構成) であるべき", () => {
+      expect(tierBadgeColor("advanced")).toBe("blue");
+    });
+
+    it("platinum は green (= silo 専用 stack) であるべき", () => {
+      expect(tierBadgeColor("platinum")).toBe("green");
+    });
+  });
+
+  describe("大文字 / 小文字ゆれを吸収するとき", () => {
+    it("'PLATINUM' でも green を返すべき (provision-tenant.sh の TIER 大文字比較に整合)", () => {
+      expect(tierBadgeColor("PLATINUM")).toBe("green");
+    });
+  });
+
+  describe("未知の tier 値が来たとき", () => {
+    it("grey にフォールバックすべき", () => {
+      expect(tierBadgeColor("nonexistent")).toBe("grey");
     });
   });
 });


### PR DESCRIPTION
## Summary

- admin-console (System Admin Control Plane UI) のテナント一覧で、`tenantStatus` badge 色マッピングが backend 実値とズレていた bug を修正
- `provision-tenant.sh` / `deprovision-tenant.sh` / SBT 初期化 / BashJobRunner 失敗時の実際の値 (`"Complete"` / `"In progress"` / `"Failed"` / `"Deleted"`) に整合させる
- `tenantStatusBadgeColor` / `tierBadgeColor` を `api/tenants.ts` に純粋関数として切り出し、case-insensitive で SBT 経路差を吸収。React 依存なしで unit test 可能に
- Tier badge にも色 (basic=grey / advanced=blue / platinum=green) を付与

## 設計判断

詳細は commit message 参照。要点:

- 既存コードは `ACTIVE` / `PROVISIONING` / `DEPROVISIONING` / `DELETED` という別の状態名にマップしていたが、backend が実際に書く値は `"In progress"` / `"Complete"` / `"Failed"` / `"Deleted"` なので、全 tenant が grey badge になっていた
- Cloudscape `Badge` (issue 指定) を採用、`StatusIndicator` は不採用
- 未知値は grey にフォールバック (= 状態不明だがエラー扱いしない)
- `"Failed"` を `TenantStatus` union に明示追加 (SBT BashJobRunner 失敗時の実値)

## Regression 分析

- **Status / Tier 列の表示色が変わる**: 既存は grey 一色 (bug)。本 PR 後は実状態に応じて色付き。表示テキスト自体は API レスポンスそのままで情報は減らない
- **`TenantStatus` 型の拡張**: union に `"Failed"` 追加。既存コードは string リテラルで使用していたため互換
- **CodeBuild link / App Console link / deprovision modal**: 無変更
- **他 workspace への影響**: `application-admin-console/src/pages/Problems.tsx` の `STATUS_BADGE_COLOR` は無関係 (問題ステータス用、名前衝突なし)

## 物理影響

- **CFn**: NO-OP (infra / cdk stack 変更なし)
- **成果物**: `apps/admin-console/dist/` の JS bundle が UPDATE (~数百 byte)。次回 `make deploy` Phase 2 で CloudFront invalidation
- **DynamoDB / API**: NO-OP (backend / API contract 変更なし、既存の SBT TenantDetails フィールドのみ使用)

## Test plan

- [x] `bun run --filter '@TenkaCloud/admin-console' test` — 53 passed (16 new)
- [x] `bun run --filter '@TenkaCloud/admin-console' typecheck` — 0 error
- [x] `make lint` — 0 error
- [x] `make check-http-status` — magic number なし
- [x] `make before-commit` — 全 workspace で test pass、lint pass、validate-problems pass
- [ ] Manual: `make deploy` 後、admin-console テナント一覧で
  - Complete tenant が green badge
  - In progress tenant が blue badge
  - Failed tenant が red badge (BashJobRunner を意図的に失敗させて確認)
  - Failed tenant 行から CodeBuild log に 1 click で飛べる
  - Complete tenant 行から application-admin-console を新 tab で開ける

Closes #532