### PR TITLE
feat(#534): deploy job 詳細に CFn 進行状況 (StackEvents / Resources / console link)

### DIFF
--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -118,6 +118,58 @@ export function getDeployment(client: ApiClient, jobId: string): Promise<Deploym
   return client.get<DeploymentSummary>(`/deployments/${encodeURIComponent(jobId)}`);
 }
 
+/**
+ * #534: deploy job 詳細ページに CFn 進行状況を出すための DTO。Backend
+ * (`infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts`) の
+ * `StackProgress` と意味的に同一。新規 field を追加するときは両側で同期する。
+ */
+export interface StackProgressEvent {
+  readonly timestamp: string;
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+}
+
+export interface StackProgressResource {
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+  readonly physicalResourceId?: string;
+}
+
+export interface StackProgress {
+  readonly jobId: string;
+  readonly stackName: string;
+  readonly region: string;
+  readonly consoleUrl: string;
+  readonly events: readonly StackProgressEvent[];
+  readonly resources: readonly StackProgressResource[];
+  readonly stackStatus?: string;
+}
+
+export function getStackProgress(client: ApiClient, jobId: string): Promise<StackProgress> {
+  return client.get<StackProgress>(`/deployments/${encodeURIComponent(jobId)}/stack-progress`);
+}
+
+/**
+ * CFn ResourceStatus を Cloudscape の `StatusIndicator` type にマップする。
+ * 未知 status は "in-progress" にフォールバック (= 新しい CFn status が来ても落ちない)。
+ *
+ * 評価順は **specific → general**: `DELETE_COMPLETE` を先に判定しないと
+ * 「`_COMPLETE` で終わる」rule が拾ってしまう。
+ */
+export function statusToIndicator(
+  status: string,
+): "success" | "error" | "in-progress" | "warning" | "stopped" {
+  if (status === "DELETE_COMPLETE") return "stopped";
+  if (status.endsWith("_FAILED")) return "error";
+  if (status.includes("ROLLBACK")) return "warning";
+  if (status.endsWith("_COMPLETE")) return "success";
+  return "in-progress";
+}
+
 export function deleteDeployment(client: ApiClient, jobId: string): Promise<void> {
   return client.del(`/deployments/${encodeURIComponent(jobId)}`);
 }

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -5,20 +5,28 @@ import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { StatusCodes } from "http-status-codes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
-import { useApiClient } from "../api/client";
+import { ApiError, useApiClient } from "../api/client";
 import {
   DEPLOYMENT_STATUS_INDICATOR,
   type DeploymentSummary,
   deleteDeployment,
   getDeployment,
+  getStackProgress,
   JOB_ID_RE,
   parseStackOutputs,
+  type StackProgress,
+  type StackProgressEvent,
+  type StackProgressResource,
+  statusToIndicator,
   TERMINAL_STATUSES,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
@@ -35,6 +43,14 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const stopPollingRef = useRef(false);
+  // #534: StackEvents / Resources は基本情報と独立 state。CFn API が throttle / 権限不足で
+  // 落ちても基本情報まで巻き込まない (= 別 state に閉じる)。
+  const [stackProgress, setStackProgress] = useState<StackProgress | null>(null);
+  const [stackProgressError, setStackProgressError] = useState<{
+    message: string;
+    notYetCreated: boolean;
+  } | null>(null);
+  const [stackProgressPending, setStackProgressPending] = useState(false);
 
   // showSpinner=true は手動再読み込みボタンからの呼び出し時のみ。auto polling は
   // 5 秒ごとに spinner を点滅させずバックグラウンド更新する。
@@ -56,12 +72,33 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
     [apiClient, jobId],
   );
 
+  const fetchStackProgress = useCallback(async () => {
+    if (!apiClient || !jobId || !JOB_ID_RE.test(jobId)) return;
+    setStackProgressPending(true);
+    try {
+      const progress = await getStackProgress(apiClient, jobId);
+      setStackProgress(progress);
+      setStackProgressError(null);
+    } catch (err) {
+      // CFn 失敗は基本情報を巻き込まない (= 別 state に閉じる)。
+      // 409 (= stack 未割当 / deploy 極初期) は別 message に分けて「準備中」表示する。
+      const notYetCreated = err instanceof ApiError && err.status === StatusCodes.CONFLICT;
+      const message = err instanceof Error ? err.message : String(err);
+      setStackProgressError({ message, notYetCreated });
+    } finally {
+      setStackProgressPending(false);
+    }
+  }, [apiClient, jobId]);
+
   useEffect(() => {
     let cancelled = false;
     stopPollingRef.current = false;
     const tick = async () => {
       if (cancelled || stopPollingRef.current) return;
-      await fetchOnce();
+      // 基本情報 + stack-progress を並列に fetch。stack-progress の error は基本情報を
+      // 巻き込まない (= 別 state に閉じる)。Terminal 後も最終 stack 状態を 1 回 fetch するため
+      // stopPollingRef は両 promise の after に評価する。
+      await Promise.all([fetchOnce(), fetchStackProgress()]);
     };
     void tick();
     const interval = setInterval(tick, POLL_INTERVAL_MS);
@@ -69,7 +106,7 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [fetchOnce]);
+  }, [fetchOnce, fetchStackProgress]);
 
   const handleDelete = useCallback(async () => {
     if (!apiClient || !jobId) return;
@@ -188,6 +225,12 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
         </ColumnLayout>
       </Container>
 
+      <StackProgressSection
+        progress={stackProgress}
+        error={stackProgressError}
+        pending={stackProgressPending}
+      />
+
       {teamLoginKey && (
         <Container
           header={
@@ -263,5 +306,180 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
         </SpaceBetween>
       </Modal>
     </SpaceBetween>
+  );
+}
+
+/**
+ * #534: CFn 進行状況セクション。Events / Resources / Console deep link を出す。
+ *
+ * - 初回 fetch 待ち (= progress === null かつ pending) → Spinner
+ * - 取得失敗 → Alert (基本情報は別途表示済、ここの error は基本情報を汚さない)
+ * - stack 未割当 (= deploy 極初期 / DDB 行はあるが CFn CreateStack 前) → 控えめな notice
+ * - 成功 → Events / Resources の Table + 「CFn console を開く」link
+ *
+ * FAILED event があれば最上位に Alert で強調 (= operator が一目で原因を特定できる)。
+ */
+function StackProgressSection(props: {
+  readonly progress: StackProgress | null;
+  readonly error: { message: string; notYetCreated: boolean } | null;
+  readonly pending: boolean;
+}) {
+  const { progress, error, pending } = props;
+
+  // 初回ローディング: error も progress も無く、fetch in-flight。
+  if (!progress && !error && pending) {
+    return (
+      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
+        <Box textAlign="center" padding="m">
+          <Spinner /> CFn から取得中...
+        </Box>
+      </Container>
+    );
+  }
+
+  // Error 表示。stack 未割当 (= API 側の `stack_not_yet_created` 409) は別 message に分ける。
+  if (error && !progress) {
+    return (
+      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
+        {error.notYetCreated ? (
+          <Box color="text-status-info">
+            CFn Stack はまだ作成されていません。deploy worker (CodeBuild) が起動し次第、 ここに
+            StackEvents / Resources が表示されます。
+          </Box>
+        ) : (
+          <Alert type="warning" header="CFn の進行状況を取得できませんでした">
+            {error.message}
+          </Alert>
+        )}
+      </Container>
+    );
+  }
+
+  if (!progress) return null;
+
+  // 失敗 event を抽出 (= CREATE_FAILED / UPDATE_FAILED 等)。最初に検出した 1 件を Alert で
+  // 強調する: operator が AWS Console を開かずに原因 logical id + reason を読める。
+  const firstFailure = progress.events.find((e) => e.resourceStatus.endsWith("_FAILED"));
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={
+            progress.stackStatus
+              ? `現在の CFn Stack 状態: ${progress.stackStatus}`
+              : "CFn StackEvents / Resources を CFn API から直接取得しています。"
+          }
+          actions={
+            <Link href={progress.consoleUrl} external>
+              CFn console を開く
+            </Link>
+          }
+        >
+          Stack 進行状況
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {firstFailure && (
+          <Alert type="error" header={`失敗: ${firstFailure.logicalResourceId}`}>
+            <Box>
+              <code>{firstFailure.resourceType}</code> が <code>{firstFailure.resourceStatus}</code>{" "}
+              になりました。
+            </Box>
+            {firstFailure.resourceStatusReason && (
+              <Box variant="small">{firstFailure.resourceStatusReason}</Box>
+            )}
+          </Alert>
+        )}
+
+        <Table<StackProgressEvent>
+          variant="embedded"
+          header={<Header variant="h3">StackEvents (最新 {progress.events.length} 件)</Header>}
+          items={[...progress.events]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              StackEvents はまだありません。
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: "timestamp",
+              header: "時刻",
+              cell: (e) => e.timestamp,
+              width: 200,
+            },
+            {
+              id: "logicalResourceId",
+              header: "LogicalId",
+              cell: (e) => <code>{e.logicalResourceId}</code>,
+              width: 220,
+            },
+            {
+              id: "resourceType",
+              header: "Type",
+              cell: (e) => <code>{e.resourceType}</code>,
+              width: 220,
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (e) => (
+                <StatusIndicator type={statusToIndicator(e.resourceStatus)}>
+                  {e.resourceStatus}
+                </StatusIndicator>
+              ),
+              width: 240,
+            },
+            {
+              id: "reason",
+              header: "Reason",
+              cell: (e) => e.resourceStatusReason ?? "",
+            },
+          ]}
+        />
+
+        <Table<StackProgressResource>
+          variant="embedded"
+          header={<Header variant="h3">Resources ({progress.resources.length} 件)</Header>}
+          items={[...progress.resources]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              Resources はまだ作成されていません。
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: "logicalResourceId",
+              header: "LogicalId",
+              cell: (r) => <code>{r.logicalResourceId}</code>,
+              width: 220,
+            },
+            {
+              id: "resourceType",
+              header: "Type",
+              cell: (r) => <code>{r.resourceType}</code>,
+              width: 220,
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (r) => (
+                <StatusIndicator type={statusToIndicator(r.resourceStatus)}>
+                  {r.resourceStatus}
+                </StatusIndicator>
+              ),
+              width: 240,
+            },
+            {
+              id: "physicalResourceId",
+              header: "PhysicalId",
+              cell: (r) => (r.physicalResourceId ? <code>{r.physicalResourceId}</code> : ""),
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Container>
   );
 }

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -4,8 +4,10 @@ import {
   type DeployRequestBody,
   deleteDeployment,
   getDeployment,
+  getStackProgress,
   listDeployments,
   startDeployment,
+  statusToIndicator,
   TERMINAL_STATUSES,
 } from "../../src/api/deploy-client";
 
@@ -141,5 +143,62 @@ describe("TERMINAL_STATUSES", () => {
     expect(TERMINAL_STATUSES.has("PENDING")).toBe(false);
     expect(TERMINAL_STATUSES.has("IN_PROGRESS")).toBe(false);
     expect(TERMINAL_STATUSES.has("DELETING")).toBe(false);
+  });
+});
+
+describe("getStackProgress", () => {
+  it("GET /deployments/:jobId/stack-progress を呼ぶべき", async () => {
+    const { client, calls } = fakeClient({
+      jobId: "01H",
+      stackName: "tc-x-y",
+      region: "ap-northeast-1",
+      consoleUrl: "https://example.com",
+      events: [],
+      resources: [],
+    });
+    await getStackProgress(client, "01H");
+    expect(calls[0]).toEqual({ path: "/deployments/01H/stack-progress", method: "GET" });
+  });
+
+  it("jobId に特殊文字が来ても URL encode するべき", async () => {
+    const { client, calls } = fakeClient({
+      jobId: "a/b",
+      stackName: "x",
+      region: "r",
+      consoleUrl: "u",
+      events: [],
+      resources: [],
+    });
+    await getStackProgress(client, "a/b");
+    expect(calls[0]?.path).toBe("/deployments/a%2Fb/stack-progress");
+  });
+});
+
+describe("statusToIndicator", () => {
+  it("CREATE_COMPLETE は success にすべき", () => {
+    expect(statusToIndicator("CREATE_COMPLETE")).toBe("success");
+    expect(statusToIndicator("UPDATE_COMPLETE")).toBe("success");
+  });
+
+  it("CREATE_FAILED は error にすべき", () => {
+    expect(statusToIndicator("CREATE_FAILED")).toBe("error");
+    expect(statusToIndicator("UPDATE_FAILED")).toBe("error");
+  });
+
+  it("ROLLBACK 系は warning にすべき", () => {
+    expect(statusToIndicator("ROLLBACK_IN_PROGRESS")).toBe("warning");
+    expect(statusToIndicator("UPDATE_ROLLBACK_COMPLETE")).toBe("warning");
+  });
+
+  it("DELETE_COMPLETE は stopped にすべき", () => {
+    expect(statusToIndicator("DELETE_COMPLETE")).toBe("stopped");
+  });
+
+  it("CREATE_IN_PROGRESS は in-progress にすべき", () => {
+    expect(statusToIndicator("CREATE_IN_PROGRESS")).toBe("in-progress");
+  });
+
+  it("未知 status は in-progress にフォールバックすべき", () => {
+    expect(statusToIndicator("SOMETHING_NEW_FROM_FUTURE_CFN")).toBe("in-progress");
   });
 });

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import type { IEventBus } from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -65,5 +66,17 @@ export class DeployApiLambda extends Construct {
     // 同一 account 内 deploy のみ)。
     props.deploymentsTable.grantReadWriteData(this.fn);
     props.eventBus.grantPutEventsTo(this.fn);
+
+    // #534: deploy job 詳細ページから CFn StackEvents / StackResources を引く読み取り権限。
+    // MVP-1 は same-account のみなので Resource は account 内全 stack を許可するが、
+    // action は **Describe* read-only に限定** (= 副作用なし、最小権限)。Phase 2 で cross-account
+    // になったら ここを sts:AssumeRole に置き換え、target account 側で role に持たせる。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudformation:DescribeStackEvents", "cloudformation:DescribeStackResources"],
+        resources: ["*"],
+      }),
+    );
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -21,6 +21,7 @@ import {
   UnknownProblemError,
 } from "./deploy.js";
 import { getDeployment, listDeployments } from "./list.js";
+import { defaultCfnClient, getStackProgress } from "./stack-progress.js";
 import { DeployRequestSchema } from "./types.js";
 
 /**
@@ -167,6 +168,54 @@ app.get("/deployments/:jobId", async (c) => {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[deploy] getDeployment failed", { jobId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+// #534: CFn StackEvents / StackResources / console deep link を返す。
+// `getDeployment` と分離する理由は:
+//   - DDB 行は即返せるのに対し CFn API は ~300ms × 2 で遅い (= 別 endpoint で 5 秒 polling)
+//   - CFn API throttle / 権限不足は detail page の基本情報まで道連れにしない
+app.get("/deployments/:jobId/stack-progress", async (c) => {
+  const jobId = c.req.param("jobId");
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
+    return c.json({ error: "invalid jobId" }, StatusCodes.BAD_REQUEST);
+  }
+  try {
+    const outcome = await getStackProgress(
+      shared,
+      { cfnClient: defaultCfnClient },
+      resolveTenantId(c),
+      jobId,
+    );
+    if (outcome.kind === "not_found") {
+      return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    if (outcome.kind === "stack_not_yet_created") {
+      // CFn stack 未割当 (= deploy 進行極初期) は 409 で返し、UI 側で「準備中」表示にする。
+      // 200 + 空 events で返す案もあるが、不在を error 型で明示した方が UI 分岐がしやすい。
+      return c.json({ error: "stack_not_yet_created" }, StatusCodes.CONFLICT);
+    }
+    if (outcome.kind === "stack_not_found_in_cfn") {
+      // CFn API が「stack なし」を返したケース (= 削除済 / 未作成 race)。events / resources
+      // は空、console URL のみ提供して operator が手動確認可能にする。
+      return c.json(
+        {
+          jobId,
+          stackName: "",
+          region: "",
+          consoleUrl: outcome.consoleUrl,
+          events: [],
+          resources: [],
+          stackStatus: undefined,
+        },
+        StatusCodes.OK,
+      );
+    }
+    return c.json(outcome.progress, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[deploy] getStackProgress failed", { jobId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
@@ -1,0 +1,195 @@
+import {
+  CloudFormationClient,
+  DescribeStackEventsCommand,
+  DescribeStackResourcesCommand,
+  type StackEvent,
+  type StackResource,
+} from "@aws-sdk/client-cloudformation";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploySharedResources } from "./deploy.js";
+import type { DeploymentItem } from "./types.js";
+
+export interface StackProgressEvent {
+  readonly timestamp: string;
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+}
+
+export interface StackProgressResource {
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+  readonly physicalResourceId?: string;
+}
+
+export interface StackProgress {
+  readonly jobId: string;
+  readonly stackName: string;
+  readonly region: string;
+  /** Console deep link (= `https://<region>.console.aws.amazon.com/cloudformation/...`) */
+  readonly consoleUrl: string;
+  /** 時系列降順 (最新が先頭) で最大 `EVENTS_LIMIT` 件。 */
+  readonly events: readonly StackProgressEvent[];
+  /** Stack に紐づく resource 一覧 (logicalId asc)。 */
+  readonly resources: readonly StackProgressResource[];
+  /**
+   * CFn API で stack を引いた瞬間に分かる stack 状態 (= `CREATE_IN_PROGRESS` 等)。
+   * UI で「全体としての現在の CFn 状態」を 1 行で出すために使う。
+   */
+  readonly stackStatus?: string;
+}
+
+export type StackProgressOutcome =
+  | { kind: "ok"; progress: StackProgress }
+  | { kind: "not_found" }
+  | { kind: "stack_not_yet_created" }
+  | { kind: "stack_not_found_in_cfn"; consoleUrl: string };
+
+/** UI で見せる stack events 件数 (= 最新から ~20 件)。CFn 1 page で十分。 */
+const EVENTS_LIMIT = 20;
+
+/**
+ * CloudFormation の region 別 console URL。`stackId` (= ARN) があれば stack detail page
+ * に直接飛ぶ。Stack 未作成段階 (= stackId 未割当) では filteringText 経由で stack 一覧から
+ * 見つけられる URL を返す (= operator が「これから出てくる stack」を待ち受けられる)。
+ */
+export function buildCfnConsoleUrl(region: string, stackName: string, stackId?: string): string {
+  const base = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(region)}`;
+  if (stackId) {
+    return `${base}#/stacks/stackinfo?stackId=${encodeURIComponent(stackId)}`;
+  }
+  return `${base}#/stacks?filteringText=${encodeURIComponent(stackName)}`;
+}
+
+function toProgressEvent(e: StackEvent): StackProgressEvent {
+  return {
+    timestamp: e.Timestamp ? e.Timestamp.toISOString() : "",
+    logicalResourceId: e.LogicalResourceId ?? "",
+    resourceType: e.ResourceType ?? "",
+    resourceStatus: e.ResourceStatus ?? "",
+    resourceStatusReason: e.ResourceStatusReason,
+  };
+}
+
+function toProgressResource(r: StackResource): StackProgressResource {
+  return {
+    logicalResourceId: r.LogicalResourceId ?? "",
+    resourceType: r.ResourceType ?? "",
+    resourceStatus: r.ResourceStatus ?? "",
+    resourceStatusReason: r.ResourceStatusReason,
+    physicalResourceId: r.PhysicalResourceId,
+  };
+}
+
+/** CFn が「stack なし」を投げる場合に true。SDK エラー名 + message 両方で判定。 */
+function isStackNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { name?: unknown; message?: unknown };
+  if (typeof e.name === "string" && e.name === "ValidationError") {
+    // ValidationError は権限不足等もあるが、message に "does not exist" を含む
+    // ケース (= CFn が「Stack with id <X> does not exist」を返す) のみ stack 未在として扱う。
+    if (typeof e.message === "string" && e.message.includes("does not exist")) return true;
+  }
+  return false;
+}
+
+export interface StackProgressDeps {
+  /**
+   * region 別の CFn client を返す factory。region は同一 account に固定 (MVP-1) なので
+   * AssumeRole は不要。テスト時には mock client を返す stub に差し替える。
+   */
+  readonly cfnClient: (region: string) => CloudFormationClient;
+}
+
+/** module-scope の lazy cache。region ごとに 1 度だけ build する (warm invoke で再利用)。 */
+const clientCache = new Map<string, CloudFormationClient>();
+export const defaultCfnClient = (region: string): CloudFormationClient => {
+  let c = clientCache.get(region);
+  if (!c) {
+    c = new CloudFormationClient({ region });
+    clientCache.set(region, c);
+  }
+  return c;
+};
+
+/**
+ * 指定 jobId の deploy job について、CFn StackEvents / StackResources を取得して
+ * UI が表示可能な shape に整える。
+ *
+ * - DDB に jobId が無い / tenantId mismatch → `not_found` (404 等価)
+ * - DDB 行はあるが namePrefix 未割当 → `stack_not_yet_created` (= PENDING の極初期)
+ * - CFn から見て stack が無い (= まだ CreateStack 前 / 既に削除済) → `stack_not_found_in_cfn`
+ *   この場合は console URL のみ返す (= operator が手動確認可能)。
+ *
+ * region は DDB 行の `region` を使う。CFn API は同一 account 内 (MVP-1 制約) を想定し、
+ * AssumeRole は行わない。Phase 2 で cross-account になったら ExternalId 経由の AssumeRole
+ * を追加する。
+ */
+export async function getStackProgress(
+  shared: DeploySharedResources,
+  deps: StackProgressDeps,
+  tenantId: string,
+  jobId: string,
+): Promise<StackProgressOutcome> {
+  const got = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = got.Item as Partial<DeploymentItem> | undefined;
+  if (!item) return { kind: "not_found" };
+  if (item.tenantId !== tenantId) return { kind: "not_found" };
+
+  const stackName = item.namePrefix;
+  const region = item.region;
+  if (!stackName || !region) return { kind: "stack_not_yet_created" };
+
+  const consoleUrl = buildCfnConsoleUrl(region, stackName, item.stackId);
+  // CFn は StackName / StackId のどちらでも引ける。stackId が確定済ならそれを使う
+  // (= 万一 stack を delete → 同名再作成した場合に旧 stack の events に混入しない)。
+  const stackRef = item.stackId ?? stackName;
+  const cfn = deps.cfnClient(region);
+
+  let events: StackEvent[];
+  let resources: StackResource[];
+  let stackStatus: string | undefined;
+  try {
+    // Events と Resources は独立で並列発行 (= 各 ~300ms × 2 を 1 round-trip に圧縮)。
+    const [eventsRes, resourcesRes] = await Promise.all([
+      cfn.send(new DescribeStackEventsCommand({ StackName: stackRef })),
+      cfn.send(new DescribeStackResourcesCommand({ StackName: stackRef })),
+    ]);
+    events = (eventsRes.StackEvents ?? []).slice(0, EVENTS_LIMIT);
+    resources = resourcesRes.StackResources ?? [];
+    // 直近 event の `ResourceStatus` が stack 自身 (LogicalResourceId === stackName)
+    // ならそれを stack 状態として採用。
+    const stackLevel = events.find((e) => e.LogicalResourceId === stackName);
+    stackStatus = stackLevel?.ResourceStatus;
+  } catch (err) {
+    if (isStackNotFoundError(err)) {
+      return { kind: "stack_not_found_in_cfn", consoleUrl };
+    }
+    throw err;
+  }
+
+  const sortedResources = [...resources].sort((a, b) =>
+    (a.LogicalResourceId ?? "").localeCompare(b.LogicalResourceId ?? ""),
+  );
+
+  return {
+    kind: "ok",
+    progress: {
+      jobId,
+      stackName,
+      region,
+      consoleUrl,
+      events: events.map(toProgressEvent),
+      resources: sortedResources.map(toProgressResource),
+      stackStatus,
+    },
+  };
+}

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -73,6 +73,27 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
         }),
       );
     });
+
+    // #534: CFn StackEvents / StackResources を読む IAM Allow を持つべき
+    // (= deploy job 詳細ページから直接 CFn API を叩くため)。
+    it("CFn DescribeStackEvents / DescribeStackResources を Allow にすべき", () => {
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Action: Match.arrayWith([
+                  "cloudformation:DescribeStackEvents",
+                  "cloudformation:DescribeStackResources",
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
   });
 
   describe("CodeBuild Project (deploy-battles.sh を実行)", () => {

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   listDeployments: vi.fn(),
   getDeployment: vi.fn(),
   requestTeardown: vi.fn(),
+  getStackProgress: vi.fn(),
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", () => ({
@@ -25,6 +26,11 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/list", () => ({
 
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
   requestTeardown: mocks.requestTeardown,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/stack-progress", () => ({
+  getStackProgress: mocks.getStackProgress,
+  defaultCfnClient: vi.fn(),
 }));
 
 const { app } = await import("../../lib/problem-deploy/handlers/deploy-handler/index");
@@ -153,5 +159,70 @@ describe("DELETE /deployments/:jobId", () => {
     mocks.requestTeardown.mockRejectedValueOnce(new Error("boom"));
     const res = await app.request(`/deployments/${ULID}`, { method: "DELETE" });
     expect(res.status).toBe(500);
+  });
+});
+
+describe("GET /deployments/:jobId/stack-progress", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 200 と progress を返すべき", async () => {
+    mocks.getStackProgress.mockResolvedValueOnce({
+      kind: "ok",
+      progress: {
+        jobId: ULID,
+        stackName: "tc-x-y",
+        region: "ap-northeast-1",
+        consoleUrl: "https://example.com/cfn",
+        events: [],
+        resources: [],
+        stackStatus: "CREATE_IN_PROGRESS",
+      },
+    });
+    const res = await app.request(`/deployments/${ULID}/stack-progress`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobId).toBe(ULID);
+    expect(body.stackStatus).toBe("CREATE_IN_PROGRESS");
+  });
+
+  it("不正な jobId (ULID 形式でない) は 400", async () => {
+    const res = await app.request("/deployments/not-a-ulid/stack-progress");
+    expect(res.status).toBe(400);
+    expect(mocks.getStackProgress).not.toHaveBeenCalled();
+  });
+
+  it("DDB 行不在は 404", async () => {
+    mocks.getStackProgress.mockResolvedValueOnce({ kind: "not_found" });
+    const res = await app.request(`/deployments/${ULID}/stack-progress`);
+    expect(res.status).toBe(404);
+  });
+
+  it("stack 未割当 (deploy 極初期) は 409 を返すべき", async () => {
+    mocks.getStackProgress.mockResolvedValueOnce({ kind: "stack_not_yet_created" });
+    const res = await app.request(`/deployments/${ULID}/stack-progress`);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("stack_not_yet_created");
+  });
+
+  it("CFn 上で stack 未在は 200 + consoleUrl のみ返すべき", async () => {
+    mocks.getStackProgress.mockResolvedValueOnce({
+      kind: "stack_not_found_in_cfn",
+      consoleUrl: "https://example.com/cfn",
+    });
+    const res = await app.request(`/deployments/${ULID}/stack-progress`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.consoleUrl).toBe("https://example.com/cfn");
+    expect(body.events).toEqual([]);
+    expect(body.resources).toEqual([]);
+  });
+
+  it("内部エラーは 500", async () => {
+    mocks.getStackProgress.mockRejectedValueOnce(new Error("CFn throttling"));
+    const res = await app.request(`/deployments/${ULID}/stack-progress`);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("internal_error");
   });
 });

--- a/infrastructure/test/problem-deploy/stack-progress.test.ts
+++ b/infrastructure/test/problem-deploy/stack-progress.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
+import {
+  buildCfnConsoleUrl,
+  getStackProgress,
+} from "../../lib/problem-deploy/handlers/deploy-handler/stack-progress";
+
+const TENANT = "tenant-acme";
+const JOB_ID = "01HXYZ12345678901234567890";
+const STACK_NAME = "tc-hello-world-team-alpha";
+const STACK_ID = `arn:aws:cloudformation:ap-northeast-1:999999999999:stack/${STACK_NAME}/uuid`;
+const REGION = "ap-northeast-1";
+
+function buildShared(): {
+  shared: DeploySharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: DeploySharedResources = {
+    tableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    events: {} as unknown as DeploySharedResources["events"],
+  };
+  return { shared, ddbSend };
+}
+
+const sampleRow = (over: Record<string, unknown> = {}) => ({
+  jobId: JOB_ID,
+  tenantId: TENANT,
+  region: REGION,
+  namePrefix: STACK_NAME,
+  stackId: STACK_ID,
+  ...over,
+});
+
+function buildCfn(events: unknown[], resources: unknown[]) {
+  return {
+    send: vi.fn(async (cmd: { constructor: { name: string } }) => {
+      const name = cmd.constructor.name;
+      if (name === "DescribeStackEventsCommand") return { StackEvents: events };
+      if (name === "DescribeStackResourcesCommand") return { StackResources: resources };
+      throw new Error(`unexpected CFn command: ${name}`);
+    }),
+  };
+}
+
+describe("buildCfnConsoleUrl", () => {
+  it("stackId があれば stackinfo deep link を返すべき", () => {
+    const url = buildCfnConsoleUrl(REGION, STACK_NAME, STACK_ID);
+    expect(url).toContain("ap-northeast-1.console.aws.amazon.com/cloudformation");
+    expect(url).toContain("#/stacks/stackinfo");
+    expect(url).toContain(encodeURIComponent(STACK_ID));
+  });
+
+  it("stackId が無ければ filteringText 経由の一覧 URL を返すべき", () => {
+    const url = buildCfnConsoleUrl(REGION, STACK_NAME);
+    expect(url).toContain("#/stacks?filteringText=");
+    expect(url).toContain(encodeURIComponent(STACK_NAME));
+  });
+});
+
+describe("getStackProgress", () => {
+  it("DDB に行が無ければ not_found を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const out = await getStackProgress(
+      shared,
+      { cfnClient: () => buildCfn([], []) as never },
+      TENANT,
+      JOB_ID,
+    );
+
+    expect(out.kind).toBe("not_found");
+  });
+
+  it("tenantId が一致しない行は not_found を返すべき (クロステナント漏洩防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-evil" }) });
+
+    const out = await getStackProgress(
+      shared,
+      { cfnClient: () => buildCfn([], []) as never },
+      TENANT,
+      JOB_ID,
+    );
+
+    expect(out.kind).toBe("not_found");
+  });
+
+  it("namePrefix が未設定なら stack_not_yet_created を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: sampleRow({ namePrefix: undefined, stackId: undefined }),
+    });
+
+    const out = await getStackProgress(
+      shared,
+      { cfnClient: () => buildCfn([], []) as never },
+      TENANT,
+      JOB_ID,
+    );
+
+    expect(out.kind).toBe("stack_not_yet_created");
+  });
+
+  it("CFn から StackEvents と StackResources を取得して返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    const events = [
+      {
+        Timestamp: new Date("2026-05-11T10:00:01Z"),
+        LogicalResourceId: STACK_NAME,
+        ResourceType: "AWS::CloudFormation::Stack",
+        ResourceStatus: "CREATE_IN_PROGRESS",
+      },
+      {
+        Timestamp: new Date("2026-05-11T10:00:00Z"),
+        LogicalResourceId: "MyTable",
+        ResourceType: "AWS::DynamoDB::Table",
+        ResourceStatus: "CREATE_COMPLETE",
+      },
+    ];
+    const resources = [
+      {
+        LogicalResourceId: "BBB",
+        ResourceType: "AWS::EC2::Instance",
+        ResourceStatus: "CREATE_IN_PROGRESS",
+        PhysicalResourceId: "i-abc",
+      },
+      {
+        LogicalResourceId: "AAA",
+        ResourceType: "AWS::IAM::Role",
+        ResourceStatus: "CREATE_COMPLETE",
+        PhysicalResourceId: "role-abc",
+      },
+    ];
+
+    const out = await getStackProgress(
+      shared,
+      { cfnClient: () => buildCfn(events, resources) as never },
+      TENANT,
+      JOB_ID,
+    );
+
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.progress.events).toHaveLength(2);
+    expect(out.progress.events[0]?.timestamp).toBe("2026-05-11T10:00:01.000Z");
+    expect(out.progress.events[0]?.resourceStatus).toBe("CREATE_IN_PROGRESS");
+    // resources は logicalId 昇順
+    expect(out.progress.resources.map((r) => r.logicalResourceId)).toEqual(["AAA", "BBB"]);
+    // stack-level event から stackStatus を抽出
+    expect(out.progress.stackStatus).toBe("CREATE_IN_PROGRESS");
+    expect(out.progress.consoleUrl).toContain("ap-northeast-1.console.aws.amazon.com");
+    expect(out.progress.consoleUrl).toContain("#/stacks/stackinfo");
+  });
+
+  it("最新 20 件に events を切り詰めるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    const events = Array.from({ length: 50 }, (_, i) => ({
+      Timestamp: new Date(`2026-05-11T10:${String(i).padStart(2, "0")}:00Z`),
+      LogicalResourceId: `R${i}`,
+      ResourceType: "AWS::IAM::Role",
+      ResourceStatus: "CREATE_COMPLETE",
+    }));
+
+    const out = await getStackProgress(
+      shared,
+      { cfnClient: () => buildCfn(events, []) as never },
+      TENANT,
+      JOB_ID,
+    );
+
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.progress.events).toHaveLength(20);
+  });
+
+  it("CFn が ValidationError(does not exist) を返したら stack_not_found_in_cfn にすべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    const cfn = {
+      send: vi.fn(async () => {
+        const err = new Error("Stack with id tc-x-y does not exist");
+        (err as { name: string }).name = "ValidationError";
+        throw err;
+      }),
+    };
+
+    const out = await getStackProgress(shared, { cfnClient: () => cfn as never }, TENANT, JOB_ID);
+
+    expect(out.kind).toBe("stack_not_found_in_cfn");
+    if (out.kind !== "stack_not_found_in_cfn") return;
+    expect(out.consoleUrl).toContain("cloudformation");
+  });
+
+  it("その他の CFn エラーは throw して呼び出し側で 500 を返させるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+
+    const cfn = {
+      send: vi.fn(async () => {
+        throw new Error("Throttling");
+      }),
+    };
+
+    await expect(
+      getStackProgress(shared, { cfnClient: () => cfn as never }, TENANT, JOB_ID),
+    ).rejects.toThrow("Throttling");
+  });
+
+  it("stackId が確定済なら CFn 呼び出しに stackId を渡すべき (同名再作成事故防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
+    const cfn = buildCfn([], []);
+
+    await getStackProgress(shared, { cfnClient: () => cfn as never }, TENANT, JOB_ID);
+
+    const events = cfn.send.mock.calls[0]?.[0] as { input: { StackName?: string } };
+    expect(events.input.StackName).toBe(STACK_ID);
+  });
+
+  it("stackId 未割当なら namePrefix を CFn 引数に使うべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ stackId: undefined }) });
+    const cfn = buildCfn([], []);
+
+    await getStackProgress(shared, { cfnClient: () => cfn as never }, TENANT, JOB_ID);
+
+    const events = cfn.send.mock.calls[0]?.[0] as { input: { StackName?: string } };
+    expect(events.input.StackName).toBe(STACK_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

- Deploy job 詳細ページ (`application-admin-console/src/pages/DeploymentDetail.tsx`)
  に CFn 進行状況セクションを追加。最新 20 件の StackEvents、Stack Resources 一覧、
  Console deep link、最初の `_FAILED` event を強調 Alert で表示する。
- Backend `GET /deployments/:jobId/stack-progress` 追加。CFn
  `DescribeStackEvents` + `DescribeStackResources` を並列発行して 20 件 +
  Resources + console URL を返す。MVP-1 は same-account なので AssumeRole 不要、
  Lambda role に最小権限 (`cloudformation:DescribeStack{Events,Resources}`) のみ付与。
- Polling は既存 5 秒 interval に同居 (SSE/WebSocket 不使用)。`Promise.all` で
  基本情報と並列発行し、stack-progress の error は基本情報 state を巻き込まない。

## 設計判断

- backend 分離: CFn API ~300ms × 2 を `getDeployment` (DDB) と一緒にすると初期描画が
  遅くなる。throttle / 権限不足が基本情報まで巻き込むのも避けたい (UI 階層化)。
- AssumeRole なし: `deploy-codebuild-project.ts` の前提 (= MVP-1 は same-account) に
  従う。Phase 2 で cross-account になったら ExternalId 経由の AssumeRole に置換する。
- 失敗 detection は 1st `_FAILED` event を Alert: operator が AWS Console を開かずに
  失敗 logical id + reason を読める (issue Acceptance Criteria の中核)。
- stack 未割当 (deploy 極初期) は **409** を返し、UI 側で「準備中」notice に分岐。

## Phase

issue は Phase 1 (Stepper + console link) と Phase 2 (StackEvents キャッシュ) の
分割案を提示していたが、CFn `Describe*` を Lambda 内で直接叩く方が **キャッシュ
パイプライン (= DDB 列追加 + EventBridge Scheduler の延長) を増やさず**、かつ
operator 単独 polling では throttle 影響が無視できる規模 (1 tick あたり 2 req) と
判断したので、Phase 1 + 2 を 1 PR にまとめた。Phase 2 で論じた DDB キャッシュは
将来 operator 数が 10 名超 / tick 数が増えた段階で `HealthCheck` Lambda に
StackEvents snapshot を取り込む方向で別 issue 化する。

## Regression 分析

- 既存 `GET /deployments/:jobId` の挙動は変えていない (= deploy-handler 一覧 +
  既存 frontend `getDeployment` 経路は無変更、`DeploymentSummary` shape も同じ)。
- CFn API throttle / 5xx は新 endpoint だけが 500 を返し、基本情報 (DDB) endpoint
  は影響を受けない (= frontend 側で別 state に閉じる)。
- Lambda IAM が広がるが `Describe*` は read-only。Resource は `*` だが
  same-account 前提なので tenant 分離は DDB `tenantId` のチェックで担保
  (= `getStackProgress` 冒頭で `item.tenantId !== caller` なら not_found)。
- `statusToIndicator` の DELETE_COMPLETE vs `_COMPLETE` rule 順序 bug を test で
  発見して修正済 (specific → general の評価順)。

## 物理影響

- CREATE: `cloudformation:DescribeStackEvents` + `cloudformation:DescribeStackResources`
  を Allow にする IAM Policy 1 件 (Resource `*`)
- UPDATE: NO-OP (Lambda 本体 / DDB / EventBus / CodeBuild / DDB schema は変更なし)
- DELETE: なし

## Test plan

- [x] `bun run --filter '@TenkaCloud/infrastructure' test` (41 files / 403 pass、stack-progress 10 件 + route 6 件 + IAM 1 件追加)
- [x] `bun run --filter '@TenkaCloud/application-admin-console' test` (13 files / 101 pass、getStackProgress + statusToIndicator 8 件追加)
- [x] `make lint` (biome / markdownlint / textlint 全通り)
- [x] `make check-http-status` (`StatusCodes.CONFLICT` を使う、magic number なし)
- [x] `bun run --filter '@TenkaCloud/application-admin-console' build` (vite, dist OK)
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [ ] AWS 実機: IN_PROGRESS な job 詳細を開き、StackEvents がリアルタイムで増える、FAILED 時に Alert + Reason が見える、CFn console link がスタック詳細画面に遷移する (issue Acceptance Criteria)

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deploy job detail pages now display comprehensive CloudFormation stack progress information.
  * View stack events and resources with visual status indicators.
  * Convenient link to open CloudFormation console for further inspection.
  * Handles various deployment states including in-progress, completed, failed, and not-yet-created scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/588)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->