### PR TITLE
feat(#558): Event scoring lock/unlock — 表彰フェーズで採点凍結 + 解除

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -26,6 +26,10 @@ export interface EventSummary {
   /** 競技終了時刻 (ISO8601, UTC、#536)。HealthCheck は `now >= endsAt` で採点 gate 閉。
    *  「Event を終了」 button (= 即時終了) と「日時を指定して終了」 (= 予約) の両方が書き込む。 */
   endsAt?: string;
+  /** #558: 採点 lock flag。true なら加点経路全停止 (= 表彰フェーズ)、leaderboard read は許可。 */
+  scoringLocked?: boolean;
+  /** #558: scoringLocked=true にした時刻 (ISO 8601, UTC)。 */
+  scoringLockedAt?: string;
 }
 
 export interface EventListResponse {
@@ -171,6 +175,35 @@ export async function endEvent(api: ApiClient, eventId: string): Promise<EndEven
 
 export interface ArchiveEventResult {
   archivedAt: string;
+}
+
+export interface LockScoringResult {
+  scoringLocked: boolean;
+  scoringLockedAt?: string;
+  /** idempotent: 既に target 状態だった (= no-op で 200) のときに true。 */
+  idempotent?: boolean;
+}
+
+/**
+ * #558: Event の採点を lock (= 表彰フェーズ、加点経路全停止)。
+ * READY / ENDED のみ受理 (= 409 not_lockable for other statuses)。idempotent: 既に
+ * locked のときも 200 + `idempotent: true` で返す。
+ */
+export async function lockEventScoring(
+  api: ApiClient,
+  eventId: string,
+): Promise<LockScoringResult> {
+  return api.post<LockScoringResult>(`events/${encodeURIComponent(eventId)}/lock-scoring`, {});
+}
+
+/**
+ * #558: Event の採点 lock を解除 (= reversible)。同じく READY / ENDED のみ受理。
+ */
+export async function unlockEventScoring(
+  api: ApiClient,
+  eventId: string,
+): Promise<LockScoringResult> {
+  return api.delJson<LockScoringResult>(`events/${encodeURIComponent(eventId)}/lock-scoring`);
 }
 
 /**

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -28,7 +28,9 @@ import {
   type EventStatus,
   endEvent,
   getEvent,
+  lockEventScoring,
   setEventSchedule,
+  unlockEventScoring,
 } from "../api/events-client";
 import { SendNotificationModal } from "../components/SendNotificationModal";
 import type { AppConfig } from "../config";
@@ -137,6 +139,8 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [confirmEnd, setConfirmEnd] = useState(false);
   const [notifyModalOpen, setNotifyModalOpen] = useState(false);
   const [notifyJustSent, setNotifyJustSent] = useState(false);
+  // #558: scoring lock/unlock の in-flight 状態。"lock" / "unlock" / null を持つ。
+  const [scoringLockInFlight, setScoringLockInFlight] = useState<"lock" | "unlock" | null>(null);
 
   const eventIdValid = !!eventId && EVENT_ID_RE.test(eventId);
 
@@ -283,6 +287,47 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     }
   };
 
+  // #558: 採点を lock (= 表彰フェーズ、加点経路全停止)。
+  //   - server side: READY / ENDED の event のみ受理 (= 409 not_lockable for other)
+  //   - idempotent: 既に locked のときも 200 + idempotent=true
+  const handleLockScoring = async () => {
+    if (!apiClient || scoringLockInFlight) return;
+    setScoringLockInFlight("lock");
+    setError(null);
+    try {
+      await lockEventScoring(apiClient, eventId);
+      await refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === StatusCodes.CONFLICT) {
+        setError(
+          "Event は READY / ENDED 状態でのみ採点を lock できます。現在 status を確認してください。",
+        );
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setScoringLockInFlight(null);
+    }
+  };
+
+  const handleUnlockScoring = async () => {
+    if (!apiClient || scoringLockInFlight) return;
+    setScoringLockInFlight("unlock");
+    setError(null);
+    try {
+      await unlockEventScoring(apiClient, eventId);
+      await refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === StatusCodes.CONFLICT) {
+        setError("採点 lock の解除は READY / ENDED 状態でのみ可能です。");
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setScoringLockInFlight(null);
+    }
+  };
+
   const handleEndEvent = async () => {
     if (!apiClient || endInFlight) return;
     setEndInFlight(true);
@@ -354,6 +399,17 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             >
               Event を終了
             </Button>
+            {/* #558: 採点 lock/unlock — READY / ENDED の event でのみ表示 (= 表彰フェーズ
+             *   用途)。現在 locked / unlocked で button label と loading 状態を分ける。 */}
+            {detail && (detail.status === "READY" || detail.status === "ENDED") && (
+              <Button
+                loading={scoringLockInFlight !== null}
+                disabled={!apiClient}
+                onClick={detail.scoringLocked === true ? handleUnlockScoring : handleLockScoring}
+              >
+                {detail.scoringLocked === true ? "採点 lock を解除" : "採点を lock"}
+              </Button>
+            )}
             <Button
               variant={wizard?.primary === "delete" ? "primary" : "normal"}
               loading={bulkInFlight === "teardown"}
@@ -419,14 +475,33 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
 
       {detail && (
         <Container header={<Header variant="h2">Event 概要</Header>}>
-          <ColumnLayout columns={4} variant="text-grid">
-            <Field label="ステータス">
-              <Badge color={STATUS_COLOR[detail.status]}>{detail.status}</Badge>
-            </Field>
-            <Field label="チーム数">{detail.teamCount}</Field>
-            <Field label="問題数">{detail.problems.length}</Field>
-            <Field label="作成">{detail.createdAt}</Field>
-          </ColumnLayout>
+          <SpaceBetween size="m">
+            {/* #558: 採点 lock 中の警告 banner (= 全体に視覚的に強く出す)。表彰フェーズの
+             *   競技者 / operator 双方への明示的通知。unlock するまで lock 中であることが
+             *   一目で分かるよう dismissible は付けない。 */}
+            {detail.scoringLocked === true && (
+              <Alert
+                type="warning"
+                statusIconAriaLabel="scoring locked"
+                header="採点 lock 中 (表彰フェーズ)"
+              >
+                加点経路 (flag 提出 / HealthCheck uptime) は全停止しています。leaderboard / score
+                events の閲覧は可能です。
+                {detail.scoringLockedAt && ` Locked at: ${detail.scoringLockedAt}`}
+              </Alert>
+            )}
+            <ColumnLayout columns={4} variant="text-grid">
+              <Field label="ステータス">
+                <SpaceBetween direction="horizontal" size="xxs">
+                  <Badge color={STATUS_COLOR[detail.status]}>{detail.status}</Badge>
+                  {detail.scoringLocked === true && <Badge color="red">SCORING LOCKED</Badge>}
+                </SpaceBetween>
+              </Field>
+              <Field label="チーム数">{detail.teamCount}</Field>
+              <Field label="問題数">{detail.problems.length}</Field>
+              <Field label="作成">{detail.createdAt}</Field>
+            </ColumnLayout>
+          </SpaceBetween>
         </Container>
       )}
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -22,6 +22,7 @@ import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from
 import { createNotification } from "./create-notification.js";
 import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
+import { lockScoring, unlockScoring } from "./lock-scoring.js";
 import { setEventSchedule } from "./schedule.js";
 import { buildEventSharedResources } from "./shared.js";
 import { CreateEventRequestSchema, ScheduleEventRequestSchema } from "./types.js";
@@ -251,6 +252,68 @@ app.post("/events/:eventId/end", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] endEvent failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+// #558: scoring lock — operator が表彰フェーズで採点を凍結 / 解除する。
+//   - POST  /events/:eventId/lock-scoring : 採点 lock (scoringLocked=true)
+//   - DELETE /events/:eventId/lock-scoring : 採点 unlock (scoringLocked を REMOVE)
+// idempotent: already locked / unlocked のときは 200 + body に現状を返す。
+// status=READY / ENDED のみ lockable (= 加点経路があり得る state)。
+app.post("/events/:eventId/lock-scoring", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await lockScoring(
+      shared,
+      resolveTenantId(c),
+      eventId,
+      resolveCognitoSub(c),
+      Date.now(),
+    );
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    if (outcome.kind === "not_lockable") {
+      return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
+    }
+    return c.json(
+      {
+        scoringLocked: outcome.scoringLocked,
+        scoringLockedAt: outcome.kind === "ok" ? outcome.scoringLockedAt : undefined,
+        idempotent: outcome.kind === "already",
+      },
+      HTTP_OK,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] lockScoring failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.delete("/events/:eventId/lock-scoring", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const outcome = await unlockScoring(shared, resolveTenantId(c), eventId, Date.now());
+    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    if (outcome.kind === "not_lockable") {
+      return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
+    }
+    return c.json(
+      {
+        scoringLocked: outcome.scoringLocked,
+        idempotent: outcome.kind === "already",
+      },
+      HTTP_OK,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[events] unlockScoring failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -69,6 +69,8 @@ function toSummary(item: Partial<EventItem>): EventSummary {
     expiresAt: Number(item.expiresAt ?? 0),
     startsAt: typeof item.startsAt === "string" ? item.startsAt : undefined,
     endsAt: typeof item.endsAt === "string" ? item.endsAt : undefined,
+    scoringLocked: item.scoringLocked === true ? true : undefined,
+    scoringLockedAt: typeof item.scoringLockedAt === "string" ? item.scoringLockedAt : undefined,
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/lock-scoring.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/lock-scoring.ts
@@ -1,0 +1,147 @@
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { EventSharedResources } from "./shared.js";
+import type { EventItem } from "./types.js";
+
+/**
+ * #558 `lockScoring` / `unlockScoring` の結果。
+ * - `not_found`: tenant 不一致 / event 不在 → 404
+ * - `not_lockable`: status が DRAFT / DEPLOYING / TEARDOWN / ARCHIVED (= まだ採点無し or 既に teardown) → 409
+ * - `already`: lock を true→true / false→false に切り替えようとした (= no-op、idempotent OK で 200)
+ * - `ok`: 切替完了
+ */
+export type LockScoringOutcome =
+  | { kind: "not_found" }
+  | { kind: "not_lockable"; status: string }
+  | { kind: "already"; scoringLocked: boolean }
+  | { kind: "ok"; scoringLocked: boolean; scoringLockedAt?: string };
+
+const LOCKABLE_STATUSES = new Set(["READY", "ENDED"]);
+
+/**
+ * #558: Event の採点 lock を true に切り替える。
+ *
+ * 設計判断:
+ * - `READY` / `ENDED` の event のみ lock 可能 (= 採点が走りうる状態)。DRAFT / DEPLOYING /
+ *   TEARDOWN / ARCHIVED は加点経路自体が無いので lock 無意味
+ * - status とは独立な軸として `scoringLocked` flag を立てる (D1: 案 A、boolean orthogonal)
+ * - audit: 誰がいつ lock したかを attribute に残す
+ * - reversible: unlockScoring で false に戻せる
+ *
+ * 加点経路への影響 (本関数の外):
+ * - HealthCheck Lambda が event の scoringLocked を check して probe / 加点 skip
+ * - submit-flag handler が event の scoringLocked を check して `scoring_locked` outcome 返す
+ */
+export async function lockScoring(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  lockedBy: string,
+  nowMs: number,
+): Promise<LockScoringOutcome> {
+  const now = new Date(nowMs).toISOString();
+
+  try {
+    const updateOut = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression:
+          "SET scoringLocked = :t, scoringLockedAt = :now, scoringLockedBy = :who, updatedAt = :now",
+        ConditionExpression:
+          "tenantId = :tenantId AND (#s = :ready OR #s = :ended) AND (attribute_not_exists(scoringLocked) OR scoringLocked = :f)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":t": true,
+          ":f": false,
+          ":now": now,
+          ":who": lockedBy,
+          ":tenantId": tenantId,
+          ":ready": "READY",
+          ":ended": "ENDED",
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const item = updateOut.Attributes as Partial<EventItem> | undefined;
+    if (!item) return { kind: "not_found" };
+    return { kind: "ok", scoringLocked: true, scoringLockedAt: now };
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      return resolveLockFailure(shared, tenantId, eventId, true);
+    }
+    throw err;
+  }
+}
+
+/**
+ * #558: Event の採点 lock を false に切り替える (unlock)。
+ *
+ * idempotent: 既に unlocked なら `already` outcome を返す (= 200 OK で副作用無し)。
+ * status check は lockScoring と同じ (READY / ENDED のみ)。
+ */
+export async function unlockScoring(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  nowMs: number,
+): Promise<LockScoringOutcome> {
+  const now = new Date(nowMs).toISOString();
+
+  try {
+    const updateOut = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        UpdateExpression:
+          "REMOVE scoringLocked, scoringLockedAt, scoringLockedBy SET updatedAt = :now",
+        ConditionExpression:
+          "tenantId = :tenantId AND (#s = :ready OR #s = :ended) AND scoringLocked = :t",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":t": true,
+          ":now": now,
+          ":tenantId": tenantId,
+          ":ready": "READY",
+          ":ended": "ENDED",
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const item = updateOut.Attributes as Partial<EventItem> | undefined;
+    if (!item) return { kind: "not_found" };
+    return { kind: "ok", scoringLocked: false };
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      return resolveLockFailure(shared, tenantId, eventId, false);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Condition fail 時の理由を Get で確認して outcome を組み立てる。
+ *   - 行不在 / tenant 不一致 → not_found
+ *   - status が lockable でない → not_lockable
+ *   - 既に target 状態 → already (idempotent)
+ */
+async function resolveLockFailure(
+  shared: EventSharedResources,
+  tenantId: string,
+  eventId: string,
+  targetLock: boolean,
+): Promise<LockScoringOutcome> {
+  const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+  const probe = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+    }),
+  );
+  const item = probe.Item as Partial<EventItem> | undefined;
+  if (!item || item.tenantId !== tenantId) return { kind: "not_found" };
+  const status = typeof item.status === "string" ? item.status : "?";
+  if (!LOCKABLE_STATUSES.has(status)) return { kind: "not_lockable", status };
+  const current = item.scoringLocked === true;
+  if (current === targetLock) return { kind: "already", scoringLocked: current };
+  return { kind: "not_lockable", status };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -38,6 +38,19 @@ export interface EventItem {
    * EventList が ARCHIVED を default view から外すときの sort key としても使える。
    */
   archivedAt?: string;
+  /**
+   * 採点 lock flag (#558)。`true` のとき:
+   *   - HealthCheck Lambda は uptime 加点 / probe を skip
+   *   - submit-flag handler は `scoring_locked` outcome を返し score 不変
+   *   - leaderboard / score-events の read は許可 (= 表彰画面で最終 score を見せる)
+   * status (DRAFT/.../ARCHIVED) と直交する軸として持つ (`status=READY (locked)` 等の合成)。
+   * reversible — operator が表彰中に bug 発見した場合 unlock 可能。
+   */
+  scoringLocked?: boolean;
+  /** scoringLocked を true にした時刻 (ISO 8601, UTC)。unlock 時は undefined に戻す。 */
+  scoringLockedAt?: string;
+  /** scoringLocked を変更した operator の Cognito sub (= audit 用)。 */
+  scoringLockedBy?: string;
 }
 
 export const EventStatusSchema = z.enum([
@@ -166,6 +179,10 @@ export const EventSummarySchema = z.object({
   /** 競技終了時刻 (#536)。HealthCheck が `now >= endsAt` で gate 閉。
    *  「Event を終了」 button = now を書く / 「日時を指定して終了」 = 未来時刻を書く。 */
   endsAt: z.string().optional(),
+  /** 採点 lock flag (#558)。true なら加点経路全停止、read のみ可。 */
+  scoringLocked: z.boolean().optional(),
+  /** scoringLocked を true にした時刻 (#558)。 */
+  scoringLockedAt: z.string().optional(),
 });
 export type EventSummary = z.infer<typeof EventSummarySchema>;
 

--- a/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/health-check-handler/index.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
+  BatchGetCommand,
   DynamoDBDocumentClient,
   QueryCommand,
   ScanCommand,
@@ -316,6 +317,12 @@ export async function handler(): Promise<void> {
     );
     const items = (out.Items ?? []) as Partial<DeploymentItem>[];
 
+    // #558: deployment が属する event の `scoringLocked` を per-invocation で BatchGet 取得。
+    // deployment ごとに Event GET すると 1 deployment × 1 Read = throughput を喰うが、
+    // 1 invocation あたり distinct eventId は通常 << 10 件なので 1-2 BatchGetItem (各 100 件
+    // まで) で済む。値は Map に cache して isScoringActive と並列に gate する。
+    const lockedMap = await fetchScoringLockedMap(items);
+
     // 全 deployment を **並列** に check する。Lambda timeout 2 min 内に収まるよう、
     // sequential だと N × PROBE_TIMEOUT_MS で容易に超過する。1 deployment 失敗が
     // 他に波及しないよう catch して log に残す。
@@ -327,6 +334,8 @@ export async function handler(): Promise<void> {
         //   - deploy 直後の意図しない加点を防ぐ (operator が「即座に開始」or 日時設定するまで停止)
         //   - 競技開始前の Lambda 呼び出し / outbound HTTP probe を抑制 (無駄なコスト削減)
         if (!isScoringActive(item, nowIso)) return;
+        // #558: scoring lock が立っている event は probe / 加点を skip (= 表彰フェーズ)
+        if (item.eventId && lockedMap.get(item.eventId) === true) return;
         try {
           await checkOne(item, scoring);
         } catch (err) {
@@ -361,4 +370,52 @@ export function isScoringActive(
   if (nowIso < item.eventStartsAt) return false;
   if (typeof item.eventEndsAt === "string" && nowIso >= item.eventEndsAt) return false;
   return true;
+}
+
+/**
+ * #558: 同 invocation 内 deployments の distinct eventId について Events table を BatchGet
+ * し、scoringLocked=true な eventId の Map を返す。lock されていない event は Map に入らない
+ * (= `lockedMap.get(eventId) === true` で gate 判定するのが API)。
+ *
+ * 1 BatchGet で 100 件まで。本 MVP 規模 (< 30 event/tenant) では 1 回で済むので分割は省略。
+ * 失敗は best-effort: BatchGet が throw したら警告 log + 空 Map を返す (= lock 中の event でも
+ * 採点続行する fail-open。lock が効かない方が "scoring が止まる" より運用上マシ)。
+ */
+async function fetchScoringLockedMap(
+  items: Partial<DeploymentItem>[],
+): Promise<Map<string, boolean>> {
+  const eventIds = Array.from(
+    new Set(
+      items
+        .map((i) => i.eventId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+  if (eventIds.length === 0) return new Map();
+  try {
+    const out = await ddb.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [eventsTableName()]: {
+            Keys: eventIds.map((eventId) => ({ PK: `EVENT#${eventId}`, SK: "META" })),
+            ProjectionExpression: "eventId, scoringLocked",
+          },
+        },
+      }),
+    );
+    const rows = out.Responses?.[eventsTableName()] ?? [];
+    const map = new Map<string, boolean>();
+    for (const row of rows) {
+      const r = row as { eventId?: string; scoringLocked?: boolean };
+      if (typeof r.eventId === "string" && r.scoringLocked === true) {
+        map.set(r.eventId, true);
+      }
+    }
+    return map;
+  } catch (err) {
+    console.warn("[health-check] fetchScoringLockedMap failed (fail-open)", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return new Map();
+  }
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -124,6 +124,7 @@ app.post("/portal/me/submit-flag", (c) =>
     if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
     if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
     if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
+    if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
     return c.json(outcome, HTTP_OK);
   }),
 );

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import {
   HTTP_BAD_REQUEST,
+  HTTP_CONFLICT,
   HTTP_INTERNAL_ERROR,
   HTTP_NOT_FOUND,
   HTTP_UNAUTHORIZED,
@@ -27,6 +28,7 @@ const ERROR_STATUS = {
   no_outputs: HTTP_BAD_REQUEST,
   no_event: HTTP_NOT_FOUND,
   not_found: HTTP_NOT_FOUND,
+  scoring_locked: HTTP_CONFLICT,
   misconfigured: HTTP_INTERNAL_ERROR,
   internal_error: HTTP_INTERNAL_ERROR,
 } as const;

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,4 +1,4 @@
-import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import { writeScoreEvent } from "../shared/score-event.js";
@@ -10,11 +10,39 @@ export type SubmitFlagOutcome =
   | { kind: "wrong" }
   | { kind: "not_flag_problem" }
   | { kind: "no_outputs" }
+  | { kind: "scoring_locked" }
   | { kind: "unauthorized" };
 
 /** 競技者 input と stack output 値を比較。両端 trim、case-sensitive。 */
 function flagMatches(submitted: string, expected: string): boolean {
   return submitted.trim() === expected.trim();
+}
+
+/**
+ * #558: Event の scoringLocked flag を read-through で取得する。
+ * - 行不在 / フィールド無し → false (= unlocked と同義)
+ * - error → false (fail-open。lock が効かない方が「採点ストップ」より運用上マシ、健全な状態に戻る)
+ */
+async function isEventScoringLocked(
+  shared: ParticipantSharedResources,
+  eventId: string,
+): Promise<boolean> {
+  try {
+    const out = await shared.ddb.send(
+      new GetCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        ProjectionExpression: "scoringLocked",
+      }),
+    );
+    return (out.Item as { scoringLocked?: boolean } | undefined)?.scoringLocked === true;
+  } catch (err) {
+    console.warn("[submit-flag] isEventScoringLocked failed (fail-open)", {
+      eventId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
 }
 
 /**
@@ -41,6 +69,14 @@ export async function submitFlag(
 
   const item = items.find((i) => i.problemId === problemId);
   if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
+
+  // #558: scoring lock check — Event 単位で lock されていたら加点経路を返さない
+  // (= 提出履歴は残さず、`scoring_locked` outcome で UI に伝える)。Event GET は 1 RCU、
+  // submit-flag は per-attempt の rare path なので read-through で十分。
+  if (typeof item.eventId === "string" && item.eventId.length > 0) {
+    const locked = await isEventScoringLocked(shared, item.eventId);
+    if (locked) return { kind: "scoring_locked" };
+  }
 
   const scoring = scoringMap[item.problemId];
   if (scoring?.kind !== "flag") return { kind: "not_flag_problem" };

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -90,6 +90,7 @@ export class ApiGateway extends Construct {
     // /events/{eventId}/schedule       PATCH = 競技開始時刻 (startsAt) を設定 (Phase 2b 追加)
     // /events/{eventId}/end            POST  = Event を ENDED 状態にし採点を停止 (Issue #494)
     // /events/{eventId}/notifications  POST  = 運営 → 競技者 通知 1 件作成 (ADR-006、#553)
+    // /events/{eventId}/lock-scoring   POST  = 採点を lock (表彰フェーズ)、DELETE = unlock (#558)
     const eventIntegration = new LambdaIntegration(props.eventApiLambda);
     const events = this.restApi.root.addResource("events");
     events.addMethod("GET", eventIntegration, deployMethodOptions);
@@ -102,5 +103,8 @@ export class ApiGateway extends Construct {
     event.addResource("end").addMethod("POST", eventIntegration, deployMethodOptions);
     event.addResource("archive").addMethod("POST", eventIntegration, deployMethodOptions);
     event.addResource("notifications").addMethod("POST", eventIntegration, deployMethodOptions);
+    const lockScoring = event.addResource("lock-scoring");
+    lockScoring.addMethod("POST", eventIntegration, deployMethodOptions);
+    lockScoring.addMethod("DELETE", eventIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/event-lock-scoring.test.ts
+++ b/infrastructure/test/problem-deploy/event-lock-scoring.test.ts
@@ -1,0 +1,160 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  lockScoring,
+  unlockScoring,
+} from "../../lib/problem-deploy/handlers/event-handler/lock-scoring";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "TestBus",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: {} as EventSharedResources["events"],
+    problemsCatalog: {},
+  };
+  return { shared, ddbSend };
+}
+
+describe("lockScoring", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("READY + 未 lock 状態のとき scoringLocked=true / scoringLockedAt / scoringLockedBy を SET し ok を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { tenantId: "t1", status: "READY", scoringLocked: true },
+    });
+
+    const out = await lockScoring(
+      shared,
+      "t1",
+      "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+      "sub-operator",
+      NOW_MS,
+    );
+
+    expect(out).toEqual({ kind: "ok", scoringLocked: true, scoringLockedAt: NOW_ISO });
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd).toBeInstanceOf(UpdateCommand);
+    expect(cmd.input.TableName).toBe("TestEvents");
+    expect(cmd.input.UpdateExpression).toContain("scoringLocked = :t");
+    expect(cmd.input.ExpressionAttributeValues?.[":t"]).toBe(true);
+    expect(cmd.input.ExpressionAttributeValues?.[":who"]).toBe("sub-operator");
+    expect(cmd.input.ConditionExpression).toContain("tenantId = :tenantId");
+  });
+
+  it("ENDED 状態でも lock 可能であるべき (= 表彰フェーズ用途)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { tenantId: "t1", status: "ENDED", scoringLocked: true },
+    });
+
+    const out = await lockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", "sub-op", NOW_MS);
+
+    expect(out.kind).toBe("ok");
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd.input.ConditionExpression).toContain(":ended");
+  });
+
+  it("ConditionalCheckFailed + 行不在のとき not_found を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({ Item: undefined });
+
+    const out = await lockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", "sub", NOW_MS);
+
+    expect(out).toEqual({ kind: "not_found" });
+    expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(GetCommand);
+  });
+
+  it("ConditionalCheckFailed + tenant 不一致のとき not_found を返すべき (= tenant 跨ぎ防止)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ Item: { tenantId: "other-tenant", status: "READY" } });
+
+    const out = await lockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", "sub", NOW_MS);
+
+    expect(out).toEqual({ kind: "not_found" });
+  });
+
+  it("ConditionalCheckFailed + status=DRAFT のとき not_lockable を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ Item: { tenantId: "t1", status: "DRAFT" } });
+
+    const out = await lockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", "sub", NOW_MS);
+
+    expect(out).toEqual({ kind: "not_lockable", status: "DRAFT" });
+  });
+
+  it("ConditionalCheckFailed + 既に lock 済のとき already を返すべき (= idempotent)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({
+      Item: { tenantId: "t1", status: "READY", scoringLocked: true },
+    });
+
+    const out = await lockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", "sub", NOW_MS);
+
+    expect(out).toEqual({ kind: "already", scoringLocked: true });
+  });
+});
+
+describe("unlockScoring", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("lock 済 + READY のとき scoringLocked を REMOVE し ok を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: { tenantId: "t1", status: "READY" },
+    });
+
+    const out = await unlockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", NOW_MS);
+
+    expect(out).toEqual({ kind: "ok", scoringLocked: false });
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd.input.UpdateExpression).toContain("REMOVE scoringLocked");
+    expect(cmd.input.UpdateExpression).toContain("scoringLockedAt");
+    expect(cmd.input.UpdateExpression).toContain("scoringLockedBy");
+    expect(cmd.input.ConditionExpression).toContain("scoringLocked = :t");
+  });
+
+  it("そもそも unlocked のとき already を返すべき (= idempotent)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({
+      Item: { tenantId: "t1", status: "READY" },
+    });
+
+    const out = await unlockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", NOW_MS);
+
+    expect(out).toEqual({ kind: "already", scoringLocked: false });
+  });
+
+  it("status=ARCHIVED で lock=true のとき not_lockable を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
+    ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({
+      Item: { tenantId: "t1", status: "ARCHIVED", scoringLocked: true },
+    });
+
+    const out = await unlockScoring(shared, "t1", "01HZX0K3M3K9ZQHB3MRQHBA1B2", NOW_MS);
+
+    expect(out).toEqual({ kind: "not_lockable", status: "ARCHIVED" });
+  });
+});


### PR DESCRIPTION
## Summary

Event を ENDED にしても HealthCheck uptime / flag 提出が動き続けて最終 score が確定しない問題 (#558) を、`scoringLocked` boolean flag + lock/unlock API で解決。

- backend: `POST/DELETE /events/:id/lock-scoring`、HealthCheck per-invocation BatchGet で skip gate、submit-flag は per-attempt Event GET で gate
- frontend (admin-console): EventDetail に「採点を lock / 解除」 button + 警告 Alert + SCORING LOCKED badge
- participant-portal banner は **別 PR で対応 (follow-up)** — operator-side 機能のみ本 PR で

## 設計判断

| # | 決定 | 理由 |
|---|---|---|
| D1 | boolean `scoringLocked` flag | status enum 増設は status / lock が直交する軸を混ぜる |
| D2 | denormalize しない (= deployment 行に書かない) | 100 team × 30 problem = 3000 write/lock は不健全 |
| D3 | HealthCheck per-invocation BatchGet で Event meta を取る | 1 RCU per minute、burst credit に余裕 |
| D4 | submit-flag per-attempt Event GET | rare path、影響無視可 |
| D5 | fail-open: lock fetch 失敗時は採点続行 | 採点ストップ より マシ |
| D6 | READY / ENDED のみ lockable | 加点経路があり得る state に限定 |

## 変更点

- backend: 12 ファイル (types / lock-scoring / index 配線 / list / api-gateway / health-check / submit-flag)
- frontend admin-console: events-client + EventDetail
- tests: 9 件追加 (lockScoring / unlockScoring 全 outcome を pin)

## Regression 分析

| # | 壊しうる挙動 | 確認 |
|---|---|---|
| 1 | 既存 endEvent / archiveEvent / setSchedule | ✅ 無変更 |
| 2 | uptime 採点 (lock 未設定 event) | ✅ scoringLocked 未設定 = fail-open で従来通り |
| 3 | submit-flag の他 outcome | ✅ scoring_locked は items 確定後の最初の check、他 path 不変 |
| 4 | tenant 跨ぎ | ✅ ConditionExpression で tenantId 必須、CCF で not_found に倒れる |
| 5 | 全 workspace tests | ✅ 591/591 (= infra 394 +9 / admin 37 / app-admin 93 / portal 67) |

## 物理影響

- tenant-template API GW: `/events/{eventId}/lock-scoring` resource + POST/DELETE method UPDATE
- event-handler / health-check / participant-handler Lambda: bundle UPDATE (CFn asset hash)
- DDB tables: NO-OP (schemaless、scoringLocked optional)
- IAM: 既存 read 権限を流用、追加なし

## Test plan

- [x] make before-commit (lint / typecheck / 591 tests / validate-problems / check-docs / check-http-status) 全 green
- [ ] deploy 後: lock → flag 提出 409、HealthCheck 加点停止 → unlock で復旧
- [ ] participant-portal の lock 中 banner / submit disable は別 issue で

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)