### PR TITLE
docs(#578): ADR-010 API-first / CLI / MCP — operator 経路を AI native 化

### DIFF
--- a/docs/architecture/adr-010-api-first-cli-mcp.html
+++ b/docs/architecture/adr-010-api-first-cli-mcp.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-010: API-first / CLI / MCP — operator 経路を AI native 化する</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.muted   { background: var(--c-bg-soft); color: var(--c-muted); }
+  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .8rem; margin: 1rem 0; }
+  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
+  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .decision-card .body { font-size: 0.88rem; color: var(--c-text); }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+  pre {
+    background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px;
+    overflow-x: auto; font-size: 0.85rem; line-height: 1.45;
+  }
+  .quote {
+    border-left: 3px solid var(--c-warn); background: #fff8c5;
+    padding: .5rem .9rem; margin: .8rem 0; border-radius: 0 4px 4px 0; font-size: 0.92rem;
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-010: API-first / CLI / MCP — operator 経路を AI native 化する</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-11</div>
+    <div><b>Issue:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/578">#578</a></div>
+    <div><b>Related ADR:</b>
+      <a href="./adr-001-problem-deploy-crud.html">ADR-001</a>、
+      <a href="./adr-004-event-team-model.html">ADR-004</a>、
+      <a href="./adr-007-outside-in.html">ADR-007</a>
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>TenkaCloud の operator 操作 (event 作成 / bulk deploy / schedule / notify) は <strong>web UI (application-admin-console) 経由のみ</strong> 提供されている。認証は Cognito Hosted UI による OAuth Code + PKCE フローで <strong>browser 必須</strong>。これにより CLI / AI agent (Claude Code / Cursor / Codex 等) が operator API を直接呼べない。</p>
+
+<div class="quote">
+「AI 対応がなければレガシー」(= 2026 年時点の SaaS 評価軸)。本 ADR で <b>API-first 化を段階的にロールアウト</b> し、operator 操作を browser から CLI / AI に解放する。
+</div>
+
+<h3>現状評価</h3>
+
+<table>
+<thead><tr><th>領域</th><th>状態</th></tr></thead>
+<tbody>
+<tr><td>HTTP API (operator)</td><td><span class="badge accept">✅</span> 既に存在、JSON response、<code>StatusCodes.*</code> 規約化済</td></tr>
+<tr><td>HTTP API (participant)</td><td><span class="badge accept">✅</span> Function URL + <code>teamLoginKey</code> Bearer、CLI-friendly</td></tr>
+<tr><td>operator 認証</td><td><span class="badge reject">❌</span> browser 必須 (OAuth Code + PKCE)</td></tr>
+<tr><td>OpenAPI / JSON Schema spec</td><td><span class="badge reject">❌</span> Hono router ベタ書き、spec 不在</td></tr>
+<tr><td>CLI binary</td><td><span class="badge reject">❌</span> <code>tenkacloud</code> 相当なし</td></tr>
+<tr><td>宣言的操作 (Terraform 風)</td><td><span class="badge reject">❌</span> event create → deploy → schedule は N 回 POST</td></tr>
+<tr><td>MCP server</td><td><span class="badge reject">❌</span> Claude Code から自然言語 operator 不可</td></tr>
+</tbody>
+</table>
+
+<table>
+<thead><tr><th>制約</th><th>由来</th><th>本 ADR への影響</th></tr></thead>
+<tbody>
+<tr><td>polling over SSE</td><td>memory <code>feedback_polling_over_sse</code></td>
+    <td>CLI / MCP の状態取得も polling、subscription API は作らない</td></tr>
+<tr><td>cost 最小化 (Lambda + DDB 1/1)</td><td>repo 設計</td>
+    <td>CLI 専用 backend を立てず、既存 tenant API GW を流用</td></tr>
+<tr><td>npx 禁止</td><td>memory <code>feedback_no_npx</code></td>
+    <td>CLI は <code>bunx tenkacloud</code> / <code>nlx tenkacloud</code> で起動可能に</td></tr>
+<tr><td>tenant 分離はインフラ層</td><td><code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code></td>
+    <td>M2M token も per-tenant scope、cross-tenant call 不可</td></tr>
+<tr><td>secrets-manager-forbidden</td><td>harness rule</td>
+    <td>Client Credentials の secret は SSM Parameter Store SecureString に保存</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>解くべき設計判断</h2>
+
+<div class="decisions">
+  <div class="decision-card"><div class="num">D1</div><div class="title">M2M 認証方式</div><div class="body">Cognito Client Credentials / API Key / mTLS / SigV4</div></div>
+  <div class="decision-card"><div class="num">D2</div><div class="title">OpenAPI 生成方式</div><div class="body">@hono/zod-openapi / 手書き / tsoa / 別 SaaS</div></div>
+  <div class="decision-card"><div class="num">D3</div><div class="title">CLI runtime</div><div class="body">Node + bun npm package / Go binary / Rust binary</div></div>
+  <div class="decision-card"><div class="num">D4</div><div class="title">宣言的 spec 形式</div><div class="body">YAML (kubectl 風) / HCL (Terraform 風) / TypeScript (CDK 風)</div></div>
+  <div class="decision-card"><div class="num">D5</div><div class="title">MCP server 配置</div><div class="body">local subprocess / remote Lambda / 両方</div></div>
+  <div class="decision-card"><div class="num">D6</div><div class="title">段階的ロールアウトの順序</div><div class="body">Phase 0-4 のどれを先に / 並列に</div></div>
+  <div class="decision-card"><div class="num">D7</div><div class="title">既存 web UI との関係</div><div class="body">置換 / 並存 / 段階的移行</div></div>
+</div>
+
+<h3>D1. M2M 認証方式</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D1-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b>Cognito Client Credentials grant</b>。既存 tenant Cognito UserPool に <code>App Client (no secret)</code> ではなく <code>Client Credentials</code> 対応の app client を新設。<code>POST /oauth2/token</code> で client_id + client_secret から JWT を取得</td>
+   <td>tenant 単位で app client を払い出す運用必要 (= operator が CLI 用 token を生成する画面が要る)</td></tr>
+<tr class="hide"><td>D1-B</td><td><span class="badge reject">却下</span></td>
+   <td>独自 API Key (DDB に保存 + hash 比較)</td>
+   <td>Cognito JWT 経路と二重管理。既存 authorizer の置換が大きい</td></tr>
+<tr class="hide"><td>D1-C</td><td><span class="badge reject">却下</span></td>
+   <td>mTLS / IAM SigV4</td>
+   <td>operator 体験が劣る (鍵 / 証明書管理が複雑)、Cognito 既存資産が無駄になる</td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D1-A の運用フロー</summary>
+<ol>
+<li>operator が application-admin-console で「CLI トークン発行」 ボタンを押す</li>
+<li>backend が Cognito <code>CreateUserPoolClient</code> で新 client (generateSecret=true) を tenant scope に作成</li>
+<li>client_id + client_secret を画面に 1 度だけ表示 (= operator が CLI 環境変数 / config に保存)</li>
+<li>DDB の <code>CliTokens</code> table に発行履歴を記録 (id / createdAt / createdBy / lastUsedAt)、revoke 可能に</li>
+<li>operator は CLI で <code>tenkacloud auth login --client-id ... --client-secret ...</code> 実行 → access_token を <code>~/.tenkacloud/credentials</code> に保存</li>
+</ol>
+</details>
+
+<h3>D2. OpenAPI 生成方式</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D2-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b><code>@hono/zod-openapi</code></b>。既存 Hono routers + 既存 zod schemas (= types.ts の <code>CreateEventRequestSchema</code> 等) を <code>OpenAPIHono</code> に書き換えるだけで自動生成。生成された OpenAPI 3.x spec を CI で artifact 化</td>
+   <td>既存 routers 全て (= event / deploy / participant / notification) の置換が必要。1 router あたり ~50 行の書き換え</td></tr>
+<tr class="hide"><td>D2-B</td><td><span class="badge reject">却下</span></td>
+   <td>手書き <code>openapi.yaml</code></td>
+   <td>handler と spec の drift が即発生。type 安全性なし</td></tr>
+<tr class="hide"><td>D2-C</td><td><span class="badge reject">却下</span></td>
+   <td><code>tsoa</code> (TypeScript controllers + decorator)</td>
+   <td>Hono と相反するパラダイム (= controllers vs functional router)、既存実装の置換コスト最大</td></tr>
+</tbody>
+</table>
+
+<h3>D3. CLI runtime</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D3-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b>Node + bun (npm package <code>@tenkacloud/cli</code>)</b>。repo の他 package と同じ TypeScript / vitest stack を流用。<code>bunx @tenkacloud/cli</code> で 1 回実行可能</td>
+   <td>operator 環境に Node 22+ / bun が必要 (= AWS CloudShell には bun が未デフォルト、curl install が要る)</td></tr>
+<tr class="hide"><td>D3-B</td><td><span class="badge reject">却下</span></td>
+   <td>Go binary (single static binary)</td>
+   <td>repo の言語 stack が分裂。OpenAPI client 生成は Go でも可能だが、tenkacloud のドメインモデルが TS で書かれている</td></tr>
+<tr class="hide"><td>D3-C</td><td><span class="badge reject">却下</span></td>
+   <td>Rust binary</td>
+   <td>同上 + 開発速度の問題</td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D3-A の package 構造</summary>
+<pre>
+packages/cli/
+├── package.json              # name: "@tenkacloud/cli", bin: "tenkacloud"
+├── src/
+│   ├── index.ts              # CLI entry (commander.js or yargs)
+│   ├── auth/
+│   │   ├── login.ts          # Client Credentials → ~/.tenkacloud/credentials
+│   │   ├── logout.ts
+│   │   └── token-store.ts    # `~/.tenkacloud/credentials` の load/save
+│   ├── commands/
+│   │   ├── event/{create,list,get,delete,deploy,schedule,end}.ts
+│   │   ├── deploy/{list,get,delete}.ts
+│   │   └── notify/send.ts
+│   ├── api-client.ts         # openapi-fetch で OpenAPI typed client
+│   └── config.ts             # ~/.tenkacloud/config (= apiBaseUrl, tenantId 切替)
+└── tests/                    # vitest, mock fetch
+</pre>
+</details>
+
+<h3>D4. 宣言的 spec 形式</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D4-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b>YAML (kubectl 風)</b>。<code>tenkacloud apply event.yaml</code> で event spec を冪等適用。<code>apiVersion: tenkacloud.io/v1</code> / <code>kind: Event</code> / <code>spec: {...}</code> の慣用フォーマット</td>
+   <td>operator が YAML を書く必要 (= UI と比べて初見障壁高い、CLI/AI 経路のみ)</td></tr>
+<tr class="hide"><td>D4-B</td><td><span class="badge reject">却下</span></td>
+   <td>HCL (Terraform 風)</td>
+   <td>operator に追加文法。生態系が AWS-IaC に偏っており competition spec には過剰</td></tr>
+<tr class="hide"><td>D4-C</td><td><span class="badge reject">却下</span></td>
+   <td>TypeScript (CDK 風 imperative)</td>
+   <td>「宣言的」が崩れる、apply の冪等性が手書きロジック依存になる</td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D4-A の event.yaml 例</summary>
+<pre>
+apiVersion: tenkacloud.io/v1
+kind: Event
+metadata:
+  name: jaws-ug-spring-2026
+spec:
+  teams:
+    - internalSlug: team-alpha
+      awsAccountId: "111111111111"
+    - internalSlug: team-beta
+      awsAccountId: "222222222222"
+  problems:
+    - problemId: hello-world-battle
+      defaultRegion: ap-northeast-1
+  schedule:
+    startsAt: 2026-05-11T14:00:00+09:00
+    endsAt:   2026-05-11T17:00:00+09:00
+</pre>
+<code>tenkacloud apply -f event.yaml</code> で:
+<ol>
+<li>name で既存 event を検索 (= label selector)、なければ create</li>
+<li>teams / problems の diff を計算、必要なら patch / bulk deploy enqueue</li>
+<li>schedule の startsAt / endsAt を patch</li>
+<li>dry-run mode: 上記 diff を表示のみで apply しない</li>
+</ol>
+</details>
+
+<h3>D5. MCP server 配置</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D5-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b>local subprocess (= Claude Code が <code>npx @tenkacloud/mcp-server</code> を起動)</b>。MCP server は M2M token を CLI と同じ <code>~/.tenkacloud/credentials</code> から読む</td>
+   <td>operator のローカル環境に bun / node が必要</td></tr>
+<tr class="hide"><td>D5-B</td><td><span class="badge reject">却下</span></td>
+   <td>remote Lambda (= MCP 経路を HTTP で expose)</td>
+   <td>1st-party MCP の現行仕様 (stdio / SSE) と整合しない、追加 Lambda + IAM のコスト</td></tr>
+<tr class="hide"><td>D5-C</td><td><span class="badge reject">却下</span></td>
+   <td>local + remote 両モード</td>
+   <td>MVP には過剰、Phase 5+ で remote が要りそうになったら別 ADR で扱う</td></tr>
+</tbody>
+</table>
+
+<h3>D6. 段階的ロールアウトの順序</h3>
+
+<table>
+<thead><tr><th>Phase</th><th>scope</th><th>依存</th><th>並列可</th></tr></thead>
+<tbody>
+<tr><td><b>0</b></td>
+    <td>M2M auth (Cognito Client Credentials app client + ADR)</td>
+    <td>なし</td><td>—</td></tr>
+<tr><td><b>1</b></td>
+    <td>OpenAPI 生成 (zod-openapi 全 routers 置換 + CI artifact)</td>
+    <td>なし</td><td>Phase 0 と並列</td></tr>
+<tr><td><b>2</b></td>
+    <td>CLI scaffold (<code>packages/cli/</code> + 主要 subcommands)</td>
+    <td>Phase 0 + 1</td><td>—</td></tr>
+<tr><td><b>3</b></td>
+    <td>宣言的 apply (<code>tenkacloud apply event.yaml</code> + reconciler)</td>
+    <td>Phase 2</td><td>Phase 4 と並列</td></tr>
+<tr><td><b>4</b></td>
+    <td>MCP server (<code>packages/mcp-server/</code> + Claude Code 向け manifest)</td>
+    <td>Phase 2</td><td>Phase 3 と並列</td></tr>
+</tbody>
+</table>
+
+<p><strong>採用順:</strong> 0 → 1 (並列) → 2 → 3 / 4 (並列)。Phase 0 と 1 は独立に開発できるので 2 並列で開始する。Phase 2 が完了したら Phase 3 と 4 を 2 並列でロールアウト可能。</p>
+
+<h3>D7. 既存 web UI との関係</h3>
+
+<p><strong>並存</strong>。CLI / MCP は web UI を置き換えない。理由:</p>
+
+<ul>
+<li>operator の onboarding は web UI の方が compelling (= Cloudscape の UX、ドキュメント不要)</li>
+<li>競技中の <strong>1 件だけ手動操作</strong> (= 特定 team の問題 status を確認、通知 1 件送信) は CLI より UI の方が早い</li>
+<li>CLI は <strong>自動化 + AI 経路</strong> の専用、bulk 操作 / repeat-able 操作に強い</li>
+<li>両者は同じ HTTP API を share するので、片方で起きた変更は他方からも観察可能 (= ADR-007 outside-in scenario との整合)</li>
+</ul>
+</section>
+
+<section>
+<h2>Decision (まとめ)</h2>
+
+<table>
+<thead><tr><th>#</th><th>決定</th><th>実装場所</th></tr></thead>
+<tbody>
+<tr><td>D1</td><td>Cognito Client Credentials</td><td>tenant Cognito UserPool 拡張 + 新 endpoint <code>POST /admin/cli-tokens</code></td></tr>
+<tr><td>D2</td><td><code>@hono/zod-openapi</code></td><td>既存 routers 全置換 + CI で <code>openapi.json</code> 出力</td></tr>
+<tr><td>D3</td><td>Node + bun npm package</td><td><code>packages/cli/</code> 新規 workspace</td></tr>
+<tr><td>D4</td><td>YAML (kubectl 風)</td><td><code>tenkacloud apply -f event.yaml</code> reconciler</td></tr>
+<tr><td>D5</td><td>local subprocess MCP</td><td><code>packages/mcp-server/</code></td></tr>
+<tr><td>D6</td><td>Phase 0+1 並列 → 2 → 3+4 並列</td><td>各 phase 別 PR</td></tr>
+<tr><td>D7</td><td>web UI と CLI を並存</td><td>既存 application-admin-console は無変更で維持</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Phase 別 Acceptance Criteria</h2>
+
+<h3>Phase 0 (M2M auth、本 ADR 採択直後の次 PR)</h3>
+<ul>
+<li><code>aws cognito-idp admin-initiate-auth</code> 経路で operator JWT を取得できる</li>
+<li>その JWT で <code>POST /events</code> が <code>200</code> を返す</li>
+<li>既存 web UI (admin-console) OAuth Code + PKCE は無変更で動く (= regression なし)</li>
+<li>integration test: M2M で event create → list → delete の full cycle が pass</li>
+</ul>
+
+<h3>Phase 1 (OpenAPI)</h3>
+<ul>
+<li><code>infrastructure/openapi.json</code> が CI で出力される</li>
+<li>主要 routers (event-handler / deploy-handler / participant-handler) すべて <code>OpenAPIHono</code> 形式</li>
+<li>diff 検出: 既存 API の breaking change が PR review で見える</li>
+</ul>
+
+<h3>Phase 2 (CLI)</h3>
+<ul>
+<li><code>tenkacloud event create</code> / <code>list</code> / <code>delete</code> / <code>deploy</code> / <code>schedule</code> / <code>end</code> / <code>notify</code> が動く</li>
+<li><code>tenkacloud --help</code> が subcommand を一覧</li>
+<li><code>tenkacloud auth login</code> で M2M token を <code>~/.tenkacloud/credentials</code> に保存</li>
+</ul>
+
+<h3>Phase 3 (宣言的 apply)</h3>
+<ul>
+<li><code>tenkacloud apply -f event.yaml</code> で event spec を冪等適用</li>
+<li><code>tenkacloud apply -f event.yaml --dry-run</code> で diff のみ表示</li>
+<li>spec 削除 (= <code>kubectl delete</code> 相当) は明示コマンド (<code>tenkacloud delete -f event.yaml</code>)、apply では暗黙削除しない</li>
+</ul>
+
+<h3>Phase 4 (MCP server)</h3>
+<ul>
+<li>Claude Code から <code>「event を作って全 team に deploy して 14:00 開始」</code> を 1 文で実行できる</li>
+<li>MCP tools: <code>event_create / event_list / event_deploy / event_schedule / notify_send</code></li>
+<li>MCP resources: <code>tenkacloud://events</code> で event 一覧を read</li>
+</ul>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>positive</h3>
+<ul>
+<li><b>AI agent (Claude Code / Cursor / Codex) から operator 操作可能</b>。本 repo 自体の dogfood に dogfood 経路が増える</li>
+<li><b>OpenAPI 化で typed client / SDK 自動生成</b>。CLI / MCP / 他言語 client が同一 spec から再現可能</li>
+<li><b>競技運営の自動化</b> (= event を YAML で declare、git で版数管理、CI で apply)</li>
+<li><b>新 operator のオンボード時間短縮</b> (= CLI <code>--help</code> + OpenAPI spec で API 表面を発見可能)</li>
+<li><b>ADR-007 outside-in scenario との相補性</b>: Playwright scenario と同じ操作を CLI でも記述できる (= dual surface validation)</li>
+</ul>
+
+<h3>negative</h3>
+<ul>
+<li>Phase 0-4 で <b>5 つの大型 PR</b> が必要。完成まで数週間以上</li>
+<li>OpenAPI 化 (Phase 1) は既存 routers 全置換、regression risk あり (= 慎重に段階移行)</li>
+<li>CLI package のメンテナンス cost (= 新規 endpoint 追加時に CLI subcommand も追加が要る、CI で自動生成しない限り)</li>
+<li>MCP server の AI 経路は <b>誤操作リスク</b> (= 自然言語が compile されて bulk delete されるシナリオ) — Phase 4 で MCP tools に <code>dry-run</code> + <code>confirm</code> mode 設計が要る</li>
+</ul>
+
+<h3>open questions (= follow-up issue)</h3>
+<ul>
+<li>Phase 0 で発行する Client Credentials の <b>scope 細分化</b> (= read-only / event-write / deploy-write の分離)</li>
+<li>CLI の <b>multi-tenant 切替 UX</b> (= <code>~/.tenkacloud/credentials</code> に複数 profile or env 変数で切替)</li>
+<li>CLI の <b>backward-compat policy</b> (= API breaking change に CLI でどう対応するか)</li>
+<li>MCP tools の <b>dry-run / confirm</b> 設計 (= 破壊的操作の事前確認)</li>
+<li>participant 経路の CLI 化 (= 競技者用 <code>tenkacloud-participant</code> 別 binary を立てるか、operator CLI と同居か)</li>
+</ul>
+</section>
+
+<section>
+<h2>関連リソース</h2>
+<ul>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/578">#578</a> — 本 ADR 起票元</li>
+<li><a href="./adr-007-outside-in.html">ADR-007</a> — outside-in scenario は CLI でも記述可能 (= scenario language として相補)</li>
+<li>memory <code>feedback_polling_over_sse</code> — CLI / MCP も polling</li>
+<li>memory <code>feedback_no_npx</code> — CLI は <code>bunx</code> / <code>nlx</code> で起動</li>
+<li><a href="https://github.com/honojs/middleware/tree/main/packages/zod-openapi"><code>@hono/zod-openapi</code></a> — Phase 1 で採用</li>
+<li><a href="https://modelcontextprotocol.io/">Model Context Protocol</a> — Phase 4 で採用</li>
+</ul>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary

ADR-007 (outside-in) と相補的に、operator 操作を browser 必須から CLI / AI agent 対応に解放する段階的 ADR を起草。

## 決定 (D1〜D7)

- **D1**: Cognito Client Credentials grant (= M2M JWT、既存 OAuth Code + PKCE と並存)
- **D2**: `@hono/zod-openapi` で OpenAPI 3.x 自動生成 (= 既存 zod schemas を流用)
- **D3**: Node + bun npm package `@tenkacloud/cli` (repo の他 package と同じ TS stack)
- **D4**: YAML (kubectl 風) `tenkacloud apply event.yaml` で冪等適用
- **D5**: local subprocess MCP server (Claude Code が `bunx @tenkacloud/mcp-server` 起動)
- **D6**: Phase 0+1 並列 → Phase 2 → Phase 3+4 並列
- **D7**: web UI と CLI を **並存** (置換しない、operator onboarding は UI / 自動化は CLI)

## 段階的ロールアウト

| Phase | scope | 依存 |
|---|---|---|
| 0 | M2M auth (Cognito Client Credentials + 発行 endpoint) | なし |
| 1 | OpenAPI 生成 (zod-openapi 全 routers 置換 + CI artifact) | なし (0 と並列) |
| 2 | CLI scaffold (`tenkacloud event create / deploy / schedule / end / notify`) | 0 + 1 |
| 3 | 宣言的 apply (`tenkacloud apply -f event.yaml` + reconciler) | 2 |
| 4 | MCP server (Claude Code 経路) | 2 (3 と並列可) |

## 物理影響

- doc-only PR、HTML 1 ファイル追加 のみ
- CFn / Lambda / DDB / コード変更 一切なし
- Phase 0 以降の実装は別 PR で

## Test plan

- [x] make lint green
- [x] make check-docs green
- [ ] user review → Accepted 化 → Phase 0 (M2M auth) を別 PR で着手

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)