### PR TITLE
feat(#555): 失敗 deployment のみ retry できる「失敗分を再実行」 button

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -124,8 +124,25 @@ export async function createEvent(
   return api.post<CreateEventResponse>("events", body);
 }
 
-export async function bulkDeployEvent(api: ApiClient, eventId: string): Promise<BulkResult> {
-  return api.post<BulkResult>(`events/${encodeURIComponent(eventId)}/deploy`, {});
+/**
+ * #555: `POST /events/:id/deploy` の opt-in body。全フィールド optional:
+ *   - `retryFailedOnly: true` — FAILED 状態の deployment 行だけ再実行 (= 失敗分 retry)
+ *   - `teamIds` — 指定 team のみ deploy (= 後追い team / 該当 team の env 再構築)
+ *   - `problemIds` — 指定 problem のみ deploy (= 後追い問題 / 修正済問題の全 team 再 deploy)
+ *
+ * 何も指定しないと従来通り teams × problems を全展開 (= idempotent skip で衝突は飛ばす)。
+ */
+export interface BulkDeployBody {
+  retryFailedOnly?: true;
+  teamIds?: readonly string[];
+  problemIds?: readonly string[];
+}
+export async function bulkDeployEvent(
+  api: ApiClient,
+  eventId: string,
+  body: BulkDeployBody = {},
+): Promise<BulkResult> {
+  return api.post<BulkResult>(`events/${encodeURIComponent(eventId)}/deploy`, body);
 }
 
 export async function bulkTeardownEvent(api: ApiClient, eventId: string): Promise<BulkResult> {

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -18,6 +18,7 @@ import { Fragment, useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { ApiError, useApiClient } from "../api/client";
 import {
+  type BulkDeployBody,
   type BulkResult,
   bulkDeployEvent,
   bulkTeardownEvent,
@@ -124,7 +125,10 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [detail, setDetail] = useState<EventDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [bulkResult, setBulkResult] = useState<BulkResult | null>(null);
-  const [bulkInFlight, setBulkInFlight] = useState<"deploy" | "teardown" | null>(null);
+  // #555: 「失敗分を再実行」も同じ POST /deploy 経路。in-flight 状態を 3 値に拡張。
+  const [bulkInFlight, setBulkInFlight] = useState<"deploy" | "teardown" | "retry-failed" | null>(
+    null,
+  );
   const [confirmTeardown, setConfirmTeardown] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [scheduleDate, setScheduleDate] = useState("");
@@ -163,12 +167,12 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     return <Navigate to="/events" replace />;
   }
 
-  const handleBulkDeploy = async () => {
+  const handleBulkDeploy = async (body: BulkDeployBody = {}) => {
     if (!apiClient || bulkInFlight) return;
-    setBulkInFlight("deploy");
+    setBulkInFlight(body.retryFailedOnly ? "retry-failed" : "deploy");
     setError(null);
     try {
-      const res = await bulkDeployEvent(apiClient, eventId);
+      const res = await bulkDeployEvent(apiClient, eventId, body);
       setBulkResult(res);
       await refresh();
     } catch (err) {
@@ -369,6 +373,15 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   // 状態と一致しない button (= DRAFT で「即座に開始」など) は disabled で抑止する。
   const wizard = detail ? computeEventWizardState(detail, Date.now()) : null;
 
+  // #555: FAILED 状態の deployment 件数を全 problem 横断で集計。> 0 なら
+  // 「失敗分を再実行」 button を表示し、operator が部分 retry できるようにする (FR-3)。
+  const failedCount = detail
+    ? Object.values(detail.deploymentsByProblem).reduce(
+        (acc, list) => acc + list.filter((d) => d.status === "FAILED").length,
+        0,
+      )
+    : 0;
+
   return (
     <SpaceBetween size="l">
       <Header
@@ -388,10 +401,28 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                 detail.status === "TEARDOWN" ||
                 detail.status === "ARCHIVED"
               }
-              onClick={handleBulkDeploy}
+              onClick={() => handleBulkDeploy()}
             >
               Deploy
             </Button>
+            {/* #555: FAILED の deployment がある場合のみ「失敗分を再実行」 button を出す
+             *   (= 要件 FR-3「N 件失敗」の retry path)。同じ POST /deploy 経路を retryFailedOnly:
+             *   true で呼ぶ。旧 FAILED 行は backend で DELETE → 新 PENDING で CREATE される。 */}
+            {failedCount > 0 && (
+              <Button
+                loading={bulkInFlight === "retry-failed"}
+                disabled={
+                  !detail ||
+                  detail.status === "TEARDOWN" ||
+                  detail.status === "ARCHIVED" ||
+                  bulkInFlight !== null
+                }
+                iconName="refresh"
+                onClick={() => handleBulkDeploy({ retryFailedOnly: true })}
+              >
+                失敗分を再実行 ({failedCount} 件)
+              </Button>
+            )}
             <Button
               loading={endInFlight}
               disabled={!detail || detail.status !== "READY"}

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -109,7 +109,22 @@ describe("bulkDeployEvent", () => {
     const out = await bulkDeployEvent(client, "EV1");
     expect(calls[0]?.path).toBe("events/EV1/deploy");
     expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.body).toEqual({});
     expect(out.enqueued).toBe(6);
+  });
+
+  // #555: opt-in body の partial deploy / retry-failed 経路
+  it("retryFailedOnly: true を body にそのまま乗せて POST するべき", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
+    await bulkDeployEvent(client, "EV1", { retryFailedOnly: true });
+    expect(calls[0]?.path).toBe("events/EV1/deploy");
+    expect(calls[0]?.body).toEqual({ retryFailedOnly: true });
+  });
+
+  it("teamIds / problemIds を body にそのまま乗せて POST するべき (部分 deploy)", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
+    await bulkDeployEvent(client, "EV1", { teamIds: ["t1"], problemIds: ["hello-world"] });
+    expect(calls[0]?.body).toEqual({ teamIds: ["t1"], problemIds: ["hello-world"] });
   });
 });
 

--- a/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+  bulkDeployEvent: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return {
+    ...actual,
+    getEvent: mocks.getEvent,
+    bulkDeployEvent: mocks.bulkDeployEvent,
+  };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Test Event",
+  status: "DEPLOYING",
+  teamCount: 2,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  teams: [
+    { teamId: "t1", internalSlug: "team-alpha" },
+    { teamId: "t2", internalSlug: "team-beta" },
+  ],
+  problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {},
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+  mocks.bulkDeployEvent.mockResolvedValue({
+    eventId: EVENT_ID,
+    enqueued: 0,
+    skipped: 0,
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventDetailPage #555 失敗分を再実行 button", () => {
+  it("FAILED な deployment が 0 件のときは button を表示しないべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [
+          { jobId: "J1", teamId: "t1", status: "COMPLETE" },
+          { jobId: "J2", teamId: "t2", status: "PENDING" },
+        ],
+      },
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/失敗分を再実行/)).not.toBeInTheDocument();
+  });
+
+  it("FAILED な deployment があると 件数つきで button を表示するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [
+          { jobId: "J1", teamId: "t1", status: "FAILED" },
+          { jobId: "J2", teamId: "t2", status: "FAILED" },
+        ],
+      },
+    });
+    renderPage();
+    expect(await screen.findByText(/失敗分を再実行 \(2 件\)/)).toBeInTheDocument();
+  });
+
+  it("button を押すと bulkDeployEvent を retryFailedOnly=true で呼ぶべき", async () => {
+    mocks.getEvent.mockResolvedValue({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [{ jobId: "J1", teamId: "t1", status: "FAILED" }],
+      },
+    });
+    renderPage();
+    const button = await screen.findByText(/失敗分を再実行 \(1 件\)/);
+    await userEvent.click(button);
+    await waitFor(() => expect(mocks.bulkDeployEvent).toHaveBeenCalled());
+    expect(mocks.bulkDeployEvent).toHaveBeenCalledWith(expect.anything(), EVENT_ID, {
+      retryFailedOnly: true,
+    });
+  });
+
+  it("ARCHIVED 状態の event では button を disable するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({
+      ...baseDetail,
+      status: "ARCHIVED",
+      deploymentsByProblem: {
+        "hello-world": [{ jobId: "J1", teamId: "t1", status: "FAILED" }],
+      },
+    });
+    renderPage();
+    const button = await screen.findByText(/失敗分を再実行 \(1 件\)/);
+    // Cloudscape Button は内部で <button> をレンダリング。disabled は祖先ボタンの属性
+    const buttonEl = button.closest("button");
+    expect(buttonEl?.disabled).toBe(true);
+  });
+});

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -14,8 +14,8 @@ import {
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   EVENT_SOURCE,
 } from "../shared/events.js";
-import type { EventSharedResources } from "./shared.js";
-import type { EventItem, EventProblemTarget, TeamItem } from "./types.js";
+import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js";
+import type { BulkDeployRequest, EventItem, EventProblemTarget, TeamItem } from "./types.js";
 
 /**
  * `POST /events/{eventId}/deploy` のレスポンス。N×M (teams × problems) の deployment
@@ -44,17 +44,26 @@ const toEpochSeconds = (ms: number): number => Math.floor(ms / 1000);
  * 各 deployment 行は eventId / teamId / teamLoginKey (Team 行と同値) を持ち、
  * Phase 2c の Participant Portal は teamLoginKey で `team の全 deployment` を引ける。
  *
- * 既存 deployment と (eventId, teamId, problemId) が衝突する場合は idempotent に skip
- * する (`attribute_not_exists(PK)` の ConditionExpression)。
+ * 既存 deployment と (eventId, teamId, problemId) が衝突する場合は in-memory で
+ * 検出して skipped に計上する (= 後追い deploy で既行を二重生成しない)。
  *
  * `tenantId` mismatch / event 不在は `not_found`。teams / problems 両方 0 件はそのまま
  * `enqueued: 0` を返す (= operator の即時 dry-run 用途)。
+ *
+ * `request` (#555):
+ *   - `undefined` / `{}` → 従来通り全展開 (= 既存衝突分のみ skip)
+ *   - `{ retryFailedOnly: true }` → FAILED 状態の旧行を DELETE → 同 (teamId, problemId) で
+ *     新 jobId の PENDING を CREATE。旧 jobId は失われる (= 履歴より状態のクリーンさを優先、
+ *     failureReason の monitoring は publish 直後の CloudWatch Logs に残る)。
+ *   - `{ teamIds }` / `{ problemIds }` → 範囲を絞る (後追い team / 問題用)
+ *   - 組み合わせ可能 (= `{ retryFailedOnly: true, teamIds: [t1] }` で「team t1 の失敗のみ retry」)
  */
 export async function bulkDeployEvent(
   shared: EventSharedResources,
   tenantId: string,
   eventId: string,
   nowMs: number,
+  request?: BulkDeployRequest,
 ): Promise<BulkDeployOutcome> {
   // Event Get と Teams Query は依存なし → Promise.all で 1 ラウンドトリップ節約。
   // 不正 eventId のとき teams query が無駄になるが空 partition で 1 RCU 程度。
@@ -76,9 +85,53 @@ export async function bulkDeployEvent(
   const event = eventOut.Item as Partial<EventItem> | undefined;
   if (!event || event.tenantId !== tenantId) return { kind: "not_found" };
 
-  const teams = (teamsOut.Items ?? []) as TeamItem[];
-  const problems = (Array.isArray(event.problems) ? event.problems : []) as EventProblemTarget[];
+  const allTeams = (teamsOut.Items ?? []) as TeamItem[];
+  const allProblems = (Array.isArray(event.problems) ? event.problems : []) as EventProblemTarget[];
+  if (allTeams.length === 0 || allProblems.length === 0) {
+    return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
+  }
+
+  // #555: opt-in filter / retry-failed の選択肢を解釈する。
+  //   - teamIds / problemIds → in-memory で範囲を絞る (= 後追い team / 問題用)。
+  //   - retryFailedOnly → 既存 FAILED 行を query し、その (teamId, problemId) に絞る。
+  //     旧 FAILED 行は後段 TransactWrite で Put + Delete を 1 transaction にし、jobId を
+  //     更新する (履歴より状態のクリーンさを優先 — Issue #555 設計判断)。
+  const teamIdFilter = request?.teamIds ? new Set(request.teamIds) : undefined;
+  const problemIdFilter = request?.problemIds ? new Set(request.problemIds) : undefined;
+  const teams = teamIdFilter ? allTeams.filter((t) => teamIdFilter.has(t.teamId)) : allTeams;
+  const problems = problemIdFilter
+    ? allProblems.filter((p) => problemIdFilter.has(p.problemId))
+    : allProblems;
   if (teams.length === 0 || problems.length === 0) {
+    return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
+  }
+
+  // #555: 既存 deployment 行を読む。retryFailedOnly のときは「FAILED 行のみを再生成」
+  // の対象 set を作る目的、それ以外でも「(eventId, teamId, problemId) 衝突は in-memory
+  // skip」に使う (= 後追い deploy の二重生成防止)。
+  const existingDeployments = await queryDeploymentsByEvent(
+    shared,
+    tenantId,
+    eventId,
+    "jobId, teamId, problemId, #s",
+  );
+  // (teamId, problemId) → 旧 FAILED 行の jobId (retryFailedOnly のとき DELETE 対象)。
+  const failedByKey = new Map<string, { jobId: string }>();
+  // (teamId, problemId) → status を問わず存在する組 (skipped 計算用)。
+  const existingKey = new Set<string>();
+  for (const d of existingDeployments) {
+    const tId = String(d.teamId ?? "");
+    const pId = String(d.problemId ?? "");
+    if (!tId || !pId) continue;
+    const k = `${tId} ${pId}`;
+    existingKey.add(k);
+    if (d.status === "FAILED" && !failedByKey.has(k)) {
+      failedByKey.set(k, { jobId: String(d.jobId ?? "") });
+    }
+  }
+  const retryFailedOnly = request?.retryFailedOnly === true;
+  // retryFailedOnly でかつ FAILED 行が 0 件 → 何もしない (= enqueued: 0、skipped: 0)。
+  if (retryFailedOnly && failedByKey.size === 0) {
     return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
   }
 
@@ -96,12 +149,26 @@ export async function bulkDeployEvent(
   // #528: deploy target の awsAccountId は team から (= 各 team は自社 AWS account)、region は
   // problem から (= 問題テンプレが特定 region 依存)。team.awsAccountId が無い旧 Event は
   // problem.defaultAwsAccountId に fallback (Phase 2 で fallback も削除予定)。
-  const items: DeploymentItem[] = [];
-  const entries: PutEventsRequestEntry[] = [];
+  interface PlanEntry {
+    readonly item: DeploymentItem;
+    readonly entry: PutEventsRequestEntry;
+    /** retryFailedOnly = true のとき、対応する旧 FAILED 行の jobId (= これを DELETE)。 */
+    readonly replacesJobId?: string;
+  }
+  const plan: PlanEntry[] = [];
   let skipped = 0;
   for (const team of teams) {
     const teamAwsAccountId = team.awsAccountId;
     for (const problem of problems) {
+      const k = `${team.teamId} ${problem.problemId}`;
+      if (retryFailedOnly) {
+        // FAILED で無い組み合わせは対象外 (= silent skip、skipped にも計上しない)。
+        if (!failedByKey.has(k)) continue;
+      } else if (existingKey.has(k)) {
+        // 既存 (status を問わず) と衝突 → idempotent skip (全展開 / 部分指定 共通)。
+        skipped++;
+        continue;
+      }
       const problemDir = shared.problemsCatalog[problem.problemId];
       if (!problemDir) {
         skipped++;
@@ -141,8 +208,6 @@ export async function bulkDeployEvent(
         eventStartsAt,
         eventEndsAt,
       };
-      items.push(item);
-
       const detail: DeployCreateRequestedDetail = {
         jobId,
         tenantId,
@@ -153,37 +218,64 @@ export async function bulkDeployEvent(
         region: problem.defaultRegion,
         awsAccountId,
       };
-      entries.push({
+      const entry: PutEventsRequestEntry = {
         EventBusName: shared.eventBusName,
         Source: EVENT_SOURCE,
         DetailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
         Detail: JSON.stringify(detail),
         Resources: [`tenkacloud:deployment:${jobId}`],
+      };
+      plan.push({
+        item,
+        entry,
+        replacesJobId: retryFailedOnly ? failedByKey.get(k)?.jobId : undefined,
       });
     }
   }
 
-  if (items.length === 0) {
+  if (plan.length === 0) {
     return { kind: "ok", result: { eventId, enqueued: 0, skipped } };
   }
 
-  // DDB TransactWrite は 1 call 25 items まで。chunk を Promise.all で並列発火。
+  // DDB TransactWrite は 1 call 25 items まで (Put + Delete を合算)。retryFailedOnly では
+  // 1 plan entry につき Put + Delete の 2 op が要るので chunk 上限を半減させる。
   // ConditionExpression で同 jobId 二重生成を防ぐ (ULID 衝突は実質起こらないが defense)。
+  const opsPerEntry = retryFailedOnly ? 2 : 1;
+  const planPerChunk = Math.floor(TRANSACT_WRITE_BATCH / opsPerEntry);
   const transactChunks: Promise<unknown>[] = [];
-  for (let i = 0; i < items.length; i += TRANSACT_WRITE_BATCH) {
-    const chunk = items.slice(i, i + TRANSACT_WRITE_BATCH);
-    const transact: TransactWriteCommandInput = {
-      TransactItems: chunk.map((item) => ({
+  for (let i = 0; i < plan.length; i += planPerChunk) {
+    const chunk = plan.slice(i, i + planPerChunk);
+    const transactItems: TransactWriteCommandInput["TransactItems"] = [];
+    for (const p of chunk) {
+      transactItems.push({
         Put: {
           TableName: shared.deploymentsTableName,
-          Item: item,
+          Item: p.item,
           ConditionExpression: "attribute_not_exists(PK)",
         },
-      })),
-    };
-    transactChunks.push(shared.ddb.send(new TransactWriteCommand(transact)));
+      });
+      if (p.replacesJobId) {
+        // 旧 FAILED 行を同 transaction で DELETE (= jobId 履歴より状態のクリーンさを優先、
+        // failureReason の monitoring は publish 直後の CloudWatch Logs に残る)。
+        // tenantId で cross-tenant 削除を防ぐ ConditionExpression を必ず付ける。
+        transactItems.push({
+          Delete: {
+            TableName: shared.deploymentsTableName,
+            Key: { PK: `DEPLOYMENT#${p.replacesJobId}`, SK: "META" },
+            ConditionExpression: "tenantId = :tenantId",
+            ExpressionAttributeValues: { ":tenantId": tenantId },
+          },
+        });
+      }
+    }
+    transactChunks.push(
+      shared.ddb.send(new TransactWriteCommand({ TransactItems: transactItems })),
+    );
   }
   await Promise.all(transactChunks);
+
+  const items = plan.map((p) => p.item);
+  const entries = plan.map((p) => p.entry);
 
   // EventBridge PutEvents は 1 call 10 entries まで。chunk を Promise.all で並列発火。
   // 途中で publish が失敗した chunk があると半端な行が残るが、operator が再度 deploy を

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -25,7 +25,11 @@ import { getEventDetail, listEvents } from "./list.js";
 import { lockScoring, unlockScoring } from "./lock-scoring.js";
 import { setEventSchedule } from "./schedule.js";
 import { buildEventSharedResources } from "./shared.js";
-import { CreateEventRequestSchema, ScheduleEventRequestSchema } from "./types.js";
+import {
+  BulkDeployRequestSchema,
+  CreateEventRequestSchema,
+  ScheduleEventRequestSchema,
+} from "./types.js";
 
 /**
  * Event API Lambda の Hono app (ADR-004 Phase 1+2a, ADR-006 Notifications)。routes:
@@ -377,8 +381,29 @@ app.post("/events/:eventId/deploy", async (c) => {
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid eventId" }, HTTP_BAD_REQUEST);
   }
+  // #555: body は opt-in。空 body は bulk-all 扱い (= 後方互換)。値が来た場合だけ
+  // validate (= retryFailedOnly / teamIds / problemIds の filter として使う)。
+  let body: unknown = {};
+  const raw = await c.req.text().catch(() => "");
+  if (raw.length > 0) {
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      return c.json({ error: "request body must be JSON" }, HTTP_BAD_REQUEST);
+    }
+  }
+  const parsed = BulkDeployRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "validation failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
+  }
   try {
-    const outcome = await bulkDeployEvent(shared, resolveTenantId(c), eventId, Date.now());
+    const outcome = await bulkDeployEvent(
+      shared,
+      resolveTenantId(c),
+      eventId,
+      Date.now(),
+      parsed.data,
+    );
     if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
     return c.json(outcome.result, HTTP_ACCEPTED);
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -259,3 +259,29 @@ export const EventDetailSchema = EventSummarySchema.extend({
   deploymentsByProblem: z.record(z.string(), z.array(EventDeploymentSummarySchema)),
 });
 export type EventDetail = z.infer<typeof EventDetailSchema>;
+
+/**
+ * `POST /events/:eventId/deploy` の opt-in body (#555 partial deploy / retry failed)。
+ *
+ * 全フィールド optional:
+ *   - **何も指定しない** (body `{}` / 無し) → 従来通り teams × problems を全展開
+ *   - `retryFailedOnly: true` → status=FAILED の deployment 行のみ抽出。旧 DDB 行を
+ *     DELETE → 同 (teamId, problemId) で新 jobId で PENDING を CREATE する (= 旧 jobId は
+ *     消える)。Issue #555 / 要件 FR-3 の「失敗分を再実行」 button の backend。
+ *   - `teamIds` / `problemIds` → 指定された team / problem だけに範囲を絞る (= 後追い参加
+ *     team / 後追い投入問題のみを deploy)。`retryFailedOnly: true` と組み合わせ可能
+ *     (= 「team t1 の失敗だけ retry」)。
+ *
+ * idempotent semantics: 既存 deployment と (eventId, teamId, problemId) が衝突する組は
+ * 全展開モードでも skipped に計上する (= 後追い deploy が二重生成しないため)。
+ * `retryFailedOnly` は旧 FAILED 行を必ず DELETE してから新 PENDING を CREATE するので
+ * idempotent (= 連打しても二重生成しない)。
+ */
+export const BulkDeployRequestSchema = z
+  .object({
+    retryFailedOnly: z.literal(true).optional(),
+    teamIds: z.array(z.string().min(1)).min(1).max(100).optional(),
+    problemIds: z.array(z.string().min(1)).min(1).max(50).optional(),
+  })
+  .strict();
+export type BulkDeployRequest = z.infer<typeof BulkDeployRequestSchema>;

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -73,7 +73,8 @@ describe("bulkDeployEvent", () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // GetCommand
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(3) }); // QueryCommand teams
-    ddbSend.mockResolvedValue({}); // TransactWrite chunks (1 chunk for 6 items)
+    // #555: 3 件目は既存 deployments の QueryCommand (空)、その後 TransactWrite + Update
+    ddbSend.mockResolvedValue({});
     eventsSend.mockResolvedValue({}); // PutEvents chunks (1 chunk for 6 entries)
 
     const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
@@ -87,13 +88,17 @@ describe("bulkDeployEvent", () => {
     expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
     // 2 件目: QueryCommand (Teams)
     expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(QueryCommand);
-    // 3 件目: TransactWriteCommand (6 items / 1 chunk)
-    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    // 3 件目: QueryCommand (#555 既存 deployments lookup、idempotent skip 用)
+    expect(ddbSend.mock.calls[2]?.[0]).toBeInstanceOf(QueryCommand);
+    // TransactWriteCommand (6 items / 1 chunk)
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
     expect(transactCmd).toBeInstanceOf(TransactWriteCommand);
-    expect(transactCmd.input.TransactItems).toHaveLength(6);
+    expect(transactCmd?.input.TransactItems).toHaveLength(6);
 
     // 各 item に eventId / teamId / teamLoginKey が入る
-    const firstItem = transactCmd.input.TransactItems?.[0]?.Put?.Item;
+    const firstItem = transactCmd?.input.TransactItems?.[0]?.Put?.Item;
     expect(firstItem?.eventId).toBe("EV1");
     expect(firstItem?.teamId).toBe("T1");
     expect(firstItem?.teamLoginKey).toBe("key-1");
@@ -193,7 +198,11 @@ describe("bulkDeployEvent", () => {
     eventsSend.mockResolvedValue({});
 
     await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
-    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find(
+        (c): c is TransactWriteCommand => c instanceof TransactWriteCommand,
+      ) as TransactWriteCommand;
     for (const item of transactCmd.input.TransactItems ?? []) {
       expect(item.Put?.ConditionExpression).toBe("attribute_not_exists(PK)");
     }
@@ -211,7 +220,11 @@ describe("bulkDeployEvent", () => {
     eventsSend.mockResolvedValue({});
 
     await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
-    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find(
+        (c): c is TransactWriteCommand => c instanceof TransactWriteCommand,
+      ) as TransactWriteCommand;
     for (const item of transactCmd.input.TransactItems ?? []) {
       expect(item.Put?.Item?.eventStartsAt).toBe("2026-05-08T10:00:00.000Z");
     }
@@ -225,7 +238,11 @@ describe("bulkDeployEvent", () => {
     eventsSend.mockResolvedValue({});
 
     await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
-    const transactCmd = ddbSend.mock.calls[2]?.[0] as TransactWriteCommand;
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find(
+        (c): c is TransactWriteCommand => c instanceof TransactWriteCommand,
+      ) as TransactWriteCommand;
     for (const item of transactCmd.input.TransactItems ?? []) {
       expect(item.Put?.Item?.eventStartsAt).toBeUndefined();
     }
@@ -305,6 +322,8 @@ describe("bulkDeployEvent", () => {
         },
       ],
     });
+    // #555: 既存 deployments query (空)
+    ddbSend.mockResolvedValue({});
 
     const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
     // 1 team × 1 problem = 1、awsAccountId 無いので全 skip
@@ -330,5 +349,170 @@ describe("bulkDeployEvent", () => {
     // TEARDOWN/ARCHIVED は触らない (ConditionExpression で DRAFT/READY/DEPLOYING のみ許可)
     expect(cmd.input.ExpressionAttributeValues?.[":draft"]).toBe("DRAFT");
     expect(cmd.input.ExpressionAttributeValues).not.toHaveProperty(":teardown");
+  });
+
+  // #555: 既存 (teamId, problemId) と衝突する組は再 PUT しない (= idempotent skip)
+  it("既存 deployment 行と (eventId, teamId, problemId) が衝突する組は skipped に計上するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
+    // 既存: T1×hello-world (COMPLETE) と T2×hello-world-battle (FAILED) は重複
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "OLD1", status: "COMPLETE" },
+        { teamId: "T2", problemId: "hello-world-battle", jobId: "OLD2", status: "FAILED" },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    // 4 通りのうち 2 件衝突、残り 2 件のみ enqueue
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 2 } });
+  });
+
+  // #555: retryFailedOnly = true → FAILED 行のみ再生成、PENDING/COMPLETE はスルー
+  it("retryFailedOnly = true は FAILED 行だけ DELETE + 新規 PENDING を CREATE するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
+    // 既存 4 行のうち FAILED は 2 件
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "OLD-OK", status: "COMPLETE" },
+        { teamId: "T1", problemId: "hello-world-battle", jobId: "OLD-FAIL-1", status: "FAILED" },
+        { teamId: "T2", problemId: "hello-world", jobId: "OLD-FAIL-2", status: "FAILED" },
+        { teamId: "T2", problemId: "hello-world-battle", jobId: "OLD-PENDING", status: "PENDING" },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      retryFailedOnly: true,
+    });
+    // FAILED 2 件のみ再生成 (skipped は 0、retryFailedOnly は対象外を silent skip)
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 0 } });
+
+    // TransactWrite には Put (新) + Delete (旧 FAILED) が含まれる
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    expect(items).toHaveLength(4); // 2 Put + 2 Delete
+    const puts = items.filter((it) => it.Put);
+    const deletes = items.filter((it) => it.Delete);
+    expect(puts).toHaveLength(2);
+    expect(deletes).toHaveLength(2);
+    // 旧 FAILED jobId が DELETE される
+    const deletedKeys = deletes.map((d) => String(d.Delete?.Key?.PK ?? ""));
+    expect(deletedKeys.sort()).toEqual(["DEPLOYMENT#OLD-FAIL-1", "DEPLOYMENT#OLD-FAIL-2"].sort());
+    // Delete は tenantId condition で cross-tenant 削除を防ぐ
+    for (const d of deletes) {
+      expect(d.Delete?.ConditionExpression).toContain("tenantId");
+      expect(d.Delete?.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
+    }
+  });
+
+  // #555: retryFailedOnly でも FAILED が無ければ何もしない
+  it("retryFailedOnly = true で FAILED 行が 0 件なら enqueued=0 で write も publish もしないべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "J1", status: "COMPLETE" },
+        { teamId: "T2", problemId: "hello-world", jobId: "J2", status: "PENDING" },
+      ],
+    });
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      retryFailedOnly: true,
+    });
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 0 } });
+    expect(ddbSend.mock.calls.filter((c) => c[0] instanceof TransactWriteCommand)).toHaveLength(0);
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  // #555: teamIds で range を絞る (= 後追い team / 該当 team の env だけ deploy)
+  it("teamIds 指定 で指定 team のみ deploy するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(3) }); // 3 teams、うち T2 のみ deploy
+    ddbSend.mockResolvedValueOnce({ Items: [] }); // 既存 deployments 無し
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      teamIds: ["T2"],
+    });
+    // 1 team × 2 problems = 2
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 0 } });
+
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    for (const it of items) {
+      expect(it.Put?.Item?.teamId).toBe("T2");
+    }
+  });
+
+  // #555: problemIds で range を絞る (= 後追い問題 / 修正済問題だけ deploy)
+  it("problemIds 指定 で指定 problem のみ deploy するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams、うち hello-world のみ
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      problemIds: ["hello-world"],
+    });
+    // 2 teams × 1 problem = 2
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 0 } });
+
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    for (const it of items) {
+      expect(it.Put?.Item?.problemId).toBe("hello-world");
+    }
+  });
+
+  // #555: retryFailedOnly + teamIds の組み合わせ (= 特定 team の失敗だけ retry)
+  it("retryFailedOnly + teamIds の組み合わせで指定 team の FAILED だけ retry するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // T1, T2
+    // T1 / T2 とも FAILED あり、だが teamIds で T1 のみに絞る
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "F1", status: "FAILED" },
+        { teamId: "T2", problemId: "hello-world", jobId: "F2", status: "FAILED" },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      retryFailedOnly: true,
+      teamIds: ["T1"],
+    });
+    // T1 × hello-world のみ retry (= 1 件)
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 1, skipped: 0 } });
+
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    // 1 Put + 1 Delete = 2 items
+    expect(items).toHaveLength(2);
+    const put = items.find((it) => it.Put);
+    expect(put?.Put?.Item?.teamId).toBe("T1");
+    const del = items.find((it) => it.Delete);
+    expect(del?.Delete?.Key?.PK).toBe("DEPLOYMENT#F1");
   });
 });


### PR DESCRIPTION
## Summary

- 既存 `POST /events/:eventId/deploy` を opt-in body `{ retryFailedOnly?, teamIds?, problemIds? }` で拡張 (= 新 route は増やさず後方互換に倒す)
- EventDetail に「失敗分を再実行 ({N} 件)」 button を追加 — FAILED な deployment があるときだけ表示し、click で `retryFailedOnly: true` の bulk-deploy 経路を叩く (要件 FR-3)
- backend は旧 FAILED 行を DELETE → 新 jobId で PENDING を CREATE する 1 transaction で実装 (= 履歴より状態のクリーンさを優先)

`teamIds` / `problemIds` の部分 deploy backend も同 PR で実装済 (= 後追い team / 後追い問題のための path)。UI からの呼び出し (= Table 選択 → 「選択分を deploy」等) は follow-up PR で UI だけ足せばよい。

## 設計判断

- **Option A (extend existing route)** を採用。新 route 増やさず opt-in body で機能拡張。空 body は従来通り全展開 (後方互換)。
- **retry-failed の jobId 扱い**: 旧 FAILED 行を DELETE → 新 jobId で CREATE (1 TransactWrite)。in-place UpdateCommand で FAILED → PENDING に遷移する alternative も検討したが、旧 `failureReason` / `stackId` / `stackOutputs` が新 attempt にも残ってしまい誤読を招くため不採用。`failureReason` の監視は publish 直後の CloudWatch Logs に残るので情報損失は小さい。
- **idempotent semantics**: 全展開モードでも `(eventId, teamId, problemId)` 衝突を in-memory skipped に計上。これは旧コードの意図せざる二重生成バグ (= ULID 衝突しか防いでいなかった) の修正も兼ねる。
- **frontend phase 分割**: 本 PR は「失敗分を再実行」 button のみ (FR-3 最低限要件)。Table multi-select → 部分 deploy UI は follow-up PR で。

## 変更点

### backend (`infrastructure/lib/problem-deploy/handlers/event-handler/`)

- `types.ts` — `BulkDeployRequestSchema` (strict / 全 optional)
- `bulkDeployEvent` — 第 5 引数 `request?: BulkDeployRequest` を opt-in。`queryDeploymentsByEvent` で既存行を読み、`teamIds` / `problemIds` で in-memory フィルタ。`retryFailedOnly: true` は FAILED 行のみ抽出し Put + Delete を 1 TransactWrite で発火 (chunk 上限を 25 → 12 に半減)。Delete は `tenantId` ConditionExpression で cross-tenant 削除を防止
- `index.ts` — `POST /events/:eventId/deploy` で body を opt-in validate (空 body は後方互換 path)

### frontend (`apps/application-admin-console/`)

- `events-client.ts` — `BulkDeployBody` 型と `bulkDeployEvent(api, eventId, body?)` の引数追加
- `EventDetail.tsx`
  - `Object.values(detail.deploymentsByProblem).flat().filter(d => d.status === \"FAILED\").length` で件数集計
  - `failedCount > 0` のとき Header actions に「失敗分を再実行 ({N} 件)」 button を表示
  - `bulkInFlight` を `\"deploy\" | \"teardown\" | \"retry-failed\" | null` に拡張
  - ARCHIVED / TEARDOWN では disabled

### test

- backend (`event-bulk-deploy.test.ts`): 6 case 追加 — 衝突 skip / retryFailedOnly + DELETE + Put / FAILED 0 件 / teamIds / problemIds / 組み合わせ (合計 20 tests pass)
- frontend (`EventDetail.retry-failed.test.tsx`): 4 case — button 表示条件 / click → retryFailedOnly: true で呼ぶ / ARCHIVED で disable
- API client: opt-in body の test 2 case

## Regression 分析

- **全展開モード (= 従来動作)**: body 空 / 未指定で従来通り `enqueued = teams × problems - skipped` を返す。既存 14 tests pass。
- **既存 deployment との衝突**: 旧コードは jobId ConditionExpression (= ULID 衝突しか防がない) だったが、新コードは `(eventId, teamId, problemId)` 衝突を in-memory skip。つまり **同 event を 2 度 Deploy しても deployment 行が 2 倍にならない** (= 旧挙動の意図せざる二重生成バグの修正にも該当)。
- **retryFailedOnly での旧 jobId 消失**: 旧 jobId は DELETE される。`/deployments/<oldJobId>` を bookmark していた operator は再 deploy 後に 404 になる (設計判断、上述)。
- **`POST /deploy` body parsing**: 旧コードは body を読まなかった。新コードは `c.req.text()` 経由で読み、空 body / 不正 JSON はそれぞれ「bulk-all」「400 Bad Request」に倒す。既存 client (= 空 body POST) は影響受けない。

## 物理影響

- **CFn**: NO-OP (Lambda code 変更のみ、API GW 経路 / IAM 不変)
- **DDB**: NO-OP (新 attribute / 新 GSI 無し)
- **Lambda code**: UPDATE — event-handler の 3 ファイルが changed → 次 deploy で Lambda asset hash が変わり Function::Code が更新される
- **frontend bundle**: UPDATE — `application-admin-console/dist/` のチャンクハッシュが変わる (= CloudFront invalidation 不要、新 file は新 hash で配信)
- **新規 API**: 無し (既存 `POST /events/:eventId/deploy` の body schema を拡張)

## Test plan

- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` (423/423 pass)
- [x] `bun run --filter '@TenkaCloud/application-admin-console' typecheck`
- [x] `bun run --filter '@TenkaCloud/application-admin-console' test` (107/107 pass — 4 new in retry-failed.test.tsx)
- [x] `make lint` (0 error)
- [x] `make check-http-status`
- [x] `make before-commit` (lint + typecheck + test + validate-problems + http-status — pre-commit hook で実行)

## Follow-up

- Table 選択 → 「選択分を deploy / delete / re-deploy」 UI (backend は本 PR で対応済 = `teamIds` / `problemIds`)
- 競技中に新規 team / 新規問題が追加された場合の operator UX (= EventEdit page で追加 → 自動で部分 deploy 呼び出し)

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)