### PR TITLE
feat(#459): cross-account federation Phase 2.1 — per-tenant ExternalId

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
 import { CallbackPage } from "./pages/Callback";
+import { CompetitorAccountsPage } from "./pages/CompetitorAccounts";
 import { DeploymentDetailPage } from "./pages/DeploymentDetail";
 import { DeploymentsPage } from "./pages/Deployments";
 import { EventCreatePage } from "./pages/EventCreate";
@@ -45,6 +46,10 @@ export function App({ config }: { config: AppConfig }) {
         <Route
           path="/deployments/:jobId"
           element={guarded(config, <DeploymentDetailPage config={config} />)}
+        />
+        <Route
+          path="/competitor-accounts"
+          element={guarded(config, <CompetitorAccountsPage config={config} />)}
         />
         <Route path="/events" element={guarded(config, <EventListPage config={config} />)} />
         <Route path="/events/new" element={guarded(config, <EventCreatePage config={config} />)} />

--- a/apps/application-admin-console/src/api/competitor-accounts-client.ts
+++ b/apps/application-admin-console/src/api/competitor-accounts-client.ts
@@ -1,0 +1,64 @@
+import type { ApiClient } from "./client";
+
+/**
+ * Competitor Accounts API client (Issue #459 / ADR-002 Phase 2.1)。
+ *
+ * tenant API の `/admin/competitor-accounts*` routes を叩く。`tenantId` は JWT claim
+ * から backend が解決するので、frontend では path に乗せない。
+ */
+
+export interface CompetitorAccountSummary {
+  awsAccountId: string;
+  region: string;
+  competitorRoleName: string;
+  alias?: string;
+  verified: boolean;
+  verifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCompetitorAccountRequest {
+  awsAccountId: string;
+  region?: string;
+  competitorRoleName?: string;
+  alias?: string;
+}
+
+export interface CreateCompetitorAccountResponse extends CompetitorAccountSummary {
+  /** 競技者に **1 度だけ** 露出する secret。`competitor-bootstrap.yaml` の Parameter に渡す。 */
+  externalId: string;
+  /** 競技者に伝える TenkaCloud 側の AWS Account ID (CFn Parameter として要る)。 */
+  tenkaCloudAccountId: string;
+}
+
+export interface ListCompetitorAccountsResponse {
+  items: readonly CompetitorAccountSummary[];
+}
+
+export async function listCompetitorAccounts(
+  api: ApiClient,
+): Promise<ListCompetitorAccountsResponse> {
+  return api.get<ListCompetitorAccountsResponse>("admin/competitor-accounts");
+}
+
+export async function createCompetitorAccount(
+  api: ApiClient,
+  body: CreateCompetitorAccountRequest,
+): Promise<CreateCompetitorAccountResponse> {
+  return api.post<CreateCompetitorAccountResponse>("admin/competitor-accounts", body);
+}
+
+export async function verifyCompetitorAccount(
+  api: ApiClient,
+  awsAccountId: string,
+): Promise<CompetitorAccountSummary> {
+  return api.post<CompetitorAccountSummary>(
+    `admin/competitor-accounts/${encodeURIComponent(awsAccountId)}/verify`,
+    {},
+  );
+}
+
+export async function deleteCompetitorAccount(api: ApiClient, awsAccountId: string): Promise<void> {
+  return api.del(`admin/competitor-accounts/${encodeURIComponent(awsAccountId)}`);
+}

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -54,6 +54,7 @@ export function ShellLayout({
               { type: "link", href: "/events", text: "イベント" },
               { type: "link", href: "/problems", text: "問題カタログ" },
               { type: "link", href: "/deployments", text: "デプロイ履歴" },
+              { type: "link", href: "/competitor-accounts", text: "Competitor Accounts" },
             ]}
             onFollow={(e) => {
               if (!e.detail.external) {

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -1,0 +1,409 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table, { type TableProps } from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ApiError, useApiClient } from "../api/client";
+import {
+  type CompetitorAccountSummary,
+  type CreateCompetitorAccountResponse,
+  createCompetitorAccount,
+  deleteCompetitorAccount,
+  listCompetitorAccounts,
+  verifyCompetitorAccount,
+} from "../api/competitor-accounts-client";
+import type { AppConfig } from "../config";
+
+const ACCOUNT_ID_RE = /^\d{12}$/;
+const ALIAS_MAX = 120;
+
+/**
+ * Competitor Accounts 管理画面 (Issue #459 / ADR-002 Phase 2.1)。
+ *
+ * 一覧 / 追加 / Verify / 削除の 4 操作。`externalId` は **追加直後の modal でのみ** 1 度
+ * 露出 (= 競技者にコピペで渡してもらう secret)。verified=false の row は赤、true は緑。
+ *
+ * 「Verify」 button は STS AssumeRole sanity check を tenant 側で発行する (= 競技者が
+ * `competitor-bootstrap.yaml` を deploy し終えたかを operator がワンクリックで確認)。
+ */
+export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
+  const apiClient = useApiClient(config);
+  const [items, setItems] = useState<readonly CompetitorAccountSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [addModalVisible, setAddModalVisible] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<CompetitorAccountSummary | null>(null);
+  const [verifyInFlight, setVerifyInFlight] = useState<string | null>(null);
+  const [deleteInFlight, setDeleteInFlight] = useState(false);
+  const [showSecret, setShowSecret] = useState<CreateCompetitorAccountResponse | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!apiClient) return;
+    try {
+      const res = await listCompetitorAccounts(apiClient);
+      setItems(res.items);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [apiClient]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleVerify = useCallback(
+    async (awsAccountId: string) => {
+      if (!apiClient) return;
+      setVerifyInFlight(awsAccountId);
+      try {
+        await verifyCompetitorAccount(apiClient, awsAccountId);
+        await reload();
+      } catch (err) {
+        const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
+        setError(message);
+      } finally {
+        setVerifyInFlight(null);
+      }
+    },
+    [apiClient, reload],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!apiClient || !deleteTarget) return;
+    setDeleteInFlight(true);
+    try {
+      await deleteCompetitorAccount(apiClient, deleteTarget.awsAccountId);
+      setDeleteTarget(null);
+      await reload();
+    } catch (err) {
+      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
+      setError(message);
+    } finally {
+      setDeleteInFlight(false);
+    }
+  }, [apiClient, deleteTarget, reload]);
+
+  const columnDefinitions = useMemo<TableProps.ColumnDefinition<CompetitorAccountSummary>[]>(
+    () => [
+      {
+        id: "awsAccountId",
+        header: "AWS Account ID",
+        cell: (item) => <code>{item.awsAccountId}</code>,
+      },
+      {
+        id: "alias",
+        header: "Alias",
+        cell: (item) => item.alias ?? <Box color="text-status-inactive">(未設定)</Box>,
+      },
+      {
+        id: "region",
+        header: "Region",
+        cell: (item) => <code>{item.region}</code>,
+      },
+      {
+        id: "competitorRoleName",
+        header: "IAM Role 名",
+        cell: (item) => <code>{item.competitorRoleName}</code>,
+      },
+      {
+        id: "verified",
+        header: "状態",
+        cell: (item) =>
+          item.verified ? (
+            <Badge color="green">Verified</Badge>
+          ) : (
+            <Badge color="red">Unverified</Badge>
+          ),
+      },
+      {
+        id: "actions",
+        header: "操作",
+        cell: (item) => (
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="normal"
+              loading={verifyInFlight === item.awsAccountId}
+              disabled={verifyInFlight !== null}
+              onClick={() => handleVerify(item.awsAccountId)}
+            >
+              {item.verified ? "再 Verify" : "Verify"}
+            </Button>
+            <Button variant="link" onClick={() => setDeleteTarget(item)}>
+              削除
+            </Button>
+          </SpaceBetween>
+        ),
+      },
+    ],
+    [handleVerify, verifyInFlight],
+  );
+
+  if (!items && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 一覧を取得中...
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="tenant に紐付ける競技者 AWS account の一覧。verified=true のみ deploy 可能です。"
+        actions={
+          <Button variant="primary" onClick={() => setAddModalVisible(true)}>
+            アカウントを追加
+          </Button>
+        }
+      >
+        Competitor Accounts
+      </Header>
+
+      {error && (
+        <Alert type="error" header="エラー">
+          {error}
+        </Alert>
+      )}
+
+      <Table
+        items={items ?? []}
+        columnDefinitions={columnDefinitions}
+        empty={
+          <Box textAlign="center" color="inherit" padding="xxl">
+            まだ Competitor Account が登録されていません。「アカウントを追加」から開始してください。
+          </Box>
+        }
+      />
+
+      <AddAccountModal
+        config={config}
+        visible={addModalVisible}
+        onDismiss={() => setAddModalVisible(false)}
+        onSuccess={(res) => {
+          setAddModalVisible(false);
+          setShowSecret(res);
+          void reload();
+        }}
+      />
+
+      <SecretRevealModal details={showSecret} onDismiss={() => setShowSecret(null)} />
+
+      <Modal
+        visible={deleteTarget !== null}
+        onDismiss={() => setDeleteTarget(null)}
+        header="アカウントを削除"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setDeleteTarget(null)} disabled={deleteInFlight}>
+                キャンセル
+              </Button>
+              <Button variant="primary" loading={deleteInFlight} onClick={handleConfirmDelete}>
+                削除する
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <p>
+          AWS Account <code>{deleteTarget?.awsAccountId}</code> を tenant から外しますか？
+        </p>
+        <p>
+          この操作で tenant に残る最後の row だった場合は、SSM の ExternalId も同時に削除されます (=
+          鍵漏洩リスク削減)。
+        </p>
+      </Modal>
+    </SpaceBetween>
+  );
+}
+
+interface AddAccountModalProps {
+  config: AppConfig;
+  visible: boolean;
+  onDismiss: () => void;
+  onSuccess: (res: CreateCompetitorAccountResponse) => void;
+}
+
+function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountModalProps) {
+  const apiClient = useApiClient(config);
+  const [awsAccountId, setAwsAccountId] = useState("");
+  const [alias, setAlias] = useState("");
+  const [region, setRegion] = useState("ap-northeast-1");
+  const [competitorRoleName, setCompetitorRoleName] = useState("TenkaCloud-CompetitorDeploy-Role");
+  const [inFlight, setInFlight] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setAwsAccountId("");
+    setAlias("");
+    setRegion("ap-northeast-1");
+    setCompetitorRoleName("TenkaCloud-CompetitorDeploy-Role");
+    setError(null);
+  };
+
+  const handleDismiss = () => {
+    if (inFlight) return;
+    reset();
+    onDismiss();
+  };
+
+  const awsAccountIdInvalid = awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(awsAccountId);
+  const aliasInvalid = alias.length > ALIAS_MAX;
+  const submitDisabled =
+    !apiClient || inFlight || awsAccountId.length === 0 || awsAccountIdInvalid || aliasInvalid;
+
+  const handleSubmit = async () => {
+    if (!apiClient || submitDisabled) return;
+    setInFlight(true);
+    setError(null);
+    try {
+      const res = await createCompetitorAccount(apiClient, {
+        awsAccountId,
+        region,
+        competitorRoleName,
+        ...(alias.length > 0 ? { alias } : {}),
+      });
+      reset();
+      onSuccess(res);
+    } catch (err) {
+      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
+      setError(message);
+    } finally {
+      setInFlight(false);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={handleDismiss}
+      header="Competitor Account を追加"
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={handleDismiss} disabled={inFlight}>
+              キャンセル
+            </Button>
+            <Button
+              variant="primary"
+              loading={inFlight}
+              disabled={submitDisabled}
+              onClick={handleSubmit}
+            >
+              追加
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        {error && (
+          <Alert type="error" header="登録に失敗しました">
+            {error}
+          </Alert>
+        )}
+        <FormField
+          label="AWS Account ID"
+          description="12 桁の数字"
+          errorText={awsAccountIdInvalid ? "12 桁の数字で入力してください" : undefined}
+        >
+          <Input
+            value={awsAccountId}
+            onChange={(e) => setAwsAccountId(e.detail.value)}
+            invalid={awsAccountIdInvalid}
+            placeholder="123456789012"
+            disabled={inFlight}
+          />
+        </FormField>
+        <FormField label="Alias (任意)" description="operator 表示用ラベル">
+          <Input
+            value={alias}
+            onChange={(e) => setAlias(e.detail.value)}
+            invalid={aliasInvalid}
+            placeholder="Team Acme prod"
+            disabled={inFlight}
+          />
+        </FormField>
+        <FormField label="Region" description="deploy 先 region (default: ap-northeast-1)">
+          <Input value={region} onChange={(e) => setRegion(e.detail.value)} disabled={inFlight} />
+        </FormField>
+        <FormField
+          label="IAM Role 名"
+          description="競技者側 bootstrap で deploy する Role 名 (default: TenkaCloud-CompetitorDeploy-Role)"
+        >
+          <Input
+            value={competitorRoleName}
+            onChange={(e) => setCompetitorRoleName(e.detail.value)}
+            disabled={inFlight}
+          />
+        </FormField>
+      </SpaceBetween>
+    </Modal>
+  );
+}
+
+interface SecretRevealModalProps {
+  details: CreateCompetitorAccountResponse | null;
+  onDismiss: () => void;
+}
+
+function SecretRevealModal({ details, onDismiss }: SecretRevealModalProps) {
+  if (!details) return null;
+  return (
+    <Modal
+      visible
+      onDismiss={onDismiss}
+      header="競技者に共有する情報"
+      footer={
+        <Box float="right">
+          <Button variant="primary" onClick={onDismiss}>
+            閉じる
+          </Button>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        <Alert type="warning" header="この画面でのみ ExternalId を確認できます">
+          ExternalId は SecureString として保存されており、閉じると再表示できません。
+          競技者に渡すコピーは **今** 取ってください。
+        </Alert>
+        <ColumnLayout columns={1} variant="text-grid">
+          <div>
+            <Box variant="awsui-key-label">TenkaCloud Account ID</Box>
+            <code>{details.tenkaCloudAccountId}</code>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">ExternalId</Box>
+            <code style={{ wordBreak: "break-all" }}>{details.externalId}</code>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Competitor Role 名</Box>
+            <code>{details.competitorRoleName}</code>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">次のステップ</Box>
+            <ol>
+              <li>
+                競技者が <code>infrastructure/templates/competitor-bootstrap.yaml</code> を 自分の
+                AWS account で 1 回 deploy する (上の値を Parameter として渡す)
+              </li>
+              <li>
+                deploy 完了後、この画面の「Verify」 button で STS AssumeRole sanity check を行う
+              </li>
+              <li>verified=true になれば deploy 経路で利用可能になる</li>
+            </ol>
+          </div>
+        </ColumnLayout>
+      </SpaceBetween>
+    </Modal>
+  );
+}

--- a/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
+++ b/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../src/api/client";
+import {
+  createCompetitorAccount,
+  deleteCompetitorAccount,
+  listCompetitorAccounts,
+  verifyCompetitorAccount,
+} from "../../src/api/competitor-accounts-client";
+
+interface CapturedCall {
+  path: string;
+  method: "GET" | "POST" | "DELETE";
+  body?: unknown;
+}
+
+function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const client: ApiClient = {
+    get: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "GET" });
+      return Promise.resolve(response);
+    }),
+    post: vi.fn().mockImplementation((path: string, body: unknown) => {
+      calls.push({ path, method: "POST", body });
+      return Promise.resolve(response);
+    }),
+    patch: vi.fn().mockImplementation(() => Promise.resolve(response)),
+    del: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve();
+    }),
+    delJson: vi.fn().mockImplementation((path: string) => {
+      calls.push({ path, method: "DELETE" });
+      return Promise.resolve(response);
+    }),
+  };
+  return { client, calls };
+}
+
+describe("listCompetitorAccounts", () => {
+  it("GET /admin/competitor-accounts を呼ぶべき", async () => {
+    const { client, calls } = fakeClient({ items: [] });
+    await listCompetitorAccounts(client);
+    expect(calls[0]?.path).toBe("admin/competitor-accounts");
+    expect(calls[0]?.method).toBe("GET");
+  });
+});
+
+describe("createCompetitorAccount", () => {
+  it("POST /admin/competitor-accounts に body を送り externalId を含む response を返すべき", async () => {
+    const { client, calls } = fakeClient({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: false,
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T00:00:00.000Z",
+      externalId: "abc",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const res = await createCompetitorAccount(client, {
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+    });
+    expect(calls[0]?.path).toBe("admin/competitor-accounts");
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.body).toMatchObject({ awsAccountId: "222222222222" });
+    expect(res.externalId).toBe("abc");
+    expect(res.tenkaCloudAccountId).toBe("111111111111");
+  });
+});
+
+describe("verifyCompetitorAccount", () => {
+  it("POST /admin/competitor-accounts/{awsAccountId}/verify を呼ぶべき (URL encode)", async () => {
+    const { client, calls } = fakeClient({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T00:00:00.000Z",
+    });
+    const res = await verifyCompetitorAccount(client, "222222222222");
+    expect(calls[0]?.path).toBe("admin/competitor-accounts/222222222222/verify");
+    expect(calls[0]?.method).toBe("POST");
+    expect(res.verified).toBe(true);
+  });
+});
+
+describe("deleteCompetitorAccount", () => {
+  it("DELETE /admin/competitor-accounts/{awsAccountId} を呼ぶべき", async () => {
+    const { client, calls } = fakeClient({});
+    await deleteCompetitorAccount(client, "222222222222");
+    expect(calls[0]?.path).toBe("admin/competitor-accounts/222222222222");
+    expect(calls[0]?.method).toBe("DELETE");
+  });
+});

--- a/docs/architecture/adr-009-cross-account-federation.html
+++ b/docs/architecture/adr-009-cross-account-federation.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-009: Cross-account federation Phase 2.1 — CompetitorAccounts + ExternalId Onboarding 実装</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.reject  { background: #ffd8d3; color: var(--c-reject); }
+  details { margin-top: 1rem; }
+  summary { cursor: pointer; padding: .4rem 0; font-weight: 600; }
+  pre { background: var(--c-code-bg); padding: .8rem 1rem; border-radius: 4px;
+        overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
+  .api-method { display: inline-block; padding: 2px 10px; border-radius: 4px;
+                font-family: monospace; font-size: 0.8rem; font-weight: 700; margin-right: .4rem; }
+  .api-method.GET    { background: #ddf4e0; color: var(--c-accept); }
+  .api-method.POST   { background: #cfe5ff; color: var(--c-link); }
+  .api-method.DELETE { background: #ffd8d3; color: var(--c-reject); }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-009: Cross-account federation Phase 2.1 — <code>CompetitorAccounts</code> + ExternalId Onboarding 実装</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Accepted</span> 2026-05-11 — Issue 459 の Phase 2.1 (= ADR-002 で確定した設計判断の実装) を確定。</div>
+    <div><b>Related issues:</b> Issue 459 (cross-account federation 設計)</div>
+    <div><b>Related ADR:</b>
+      <a href="./adr-002-cross-account-federation.html">ADR-002</a> (設計判断 A2 + B2/B3 + C + D の原本)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p><a href="./adr-002-cross-account-federation.html">ADR-002</a> で「ExternalId は <strong>tenant 単位 (A2)</strong>」「メタデータは <strong>新 DDB <code>CompetitorAccounts</code> (B2)</strong> + ExternalId は <strong>SSM SecureString (B3)</strong>」「Onboarding は 5-step (C)」「legacy env は <strong>dev fallback として残す (D)</strong>」を確定した。本 ADR は ADR-002 の Phase 2.1 に該当する <strong>実装 PR の決定事項</strong> を残す。</p>
+
+<p>Issue 459 のオリジナル要求では「やること」が backend / frontend / infra の三方に跨り 1 PR で消化するには重い。本 ADR は分割スコープの境界を明確化し、Phase 2.1 / 2.2 / 3 をそれぞれ独立して観察可能にする。</p>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<h3>1. Phase 2.1 = 本 PR で扱う scope</h3>
+
+<ul>
+<li><strong>backend (= Claude 担当)</strong>:
+  <ul>
+    <li><code>CompetitorAccountsTable</code> CDK construct (PROVISIONED 1/1)</li>
+    <li><code>CompetitorAccountsApiLambda</code> CDK construct + IAM (SSM / STS / KMS)</li>
+    <li>SSM SecureString helper (<code>handlers/shared/external-id-store.ts</code>)</li>
+    <li>Hono handler 一式 (<code>POST</code> / <code>GET</code> / <code>POST .../verify</code> / <code>DELETE</code>)</li>
+    <li>tenant API GW route の配線 (<code>/admin/competitor-accounts*</code>) + Cognito JWT authorizer 共通化</li>
+  </ul>
+</li>
+<li><strong>frontend (= Claude 担当)</strong>:
+  <ul>
+    <li>新 API client (<code>api/competitor-accounts-client.ts</code>)</li>
+    <li>新 page <code>CompetitorAccountsPage</code> (一覧 / Add modal / Verify / Delete)</li>
+    <li><code>AppLayout</code> SideNavigation への link 追加</li>
+    <li>「Add account」直後の <strong>1 度きり</strong> Reveal modal (ExternalId 表示)</li>
+  </ul>
+</li>
+<li><strong>tests</strong>:
+  <ul>
+    <li>backend: store / verify / handler routes / stack synth (4 ファイル、計 17 テスト)</li>
+    <li>frontend: API client (4 テスト)</li>
+    <li><strong>「ExternalId 付き STS AssumeRole」が常に発行されることを pin</strong> (= Confused Deputy 対策が剥がれないように)</li>
+  </ul>
+</li>
+</ul>
+
+<h3>2. Phase 2.2 = 別 PR / 別 Issue</h3>
+
+<p>本 PR で <strong>同梱しない</strong>:</p>
+
+<ul>
+<li><code>EventCreate</code> の AWS Account ID 自由入力 → verified-account drop-down 移行</li>
+<li>Worker Lambda (= 実 deploy 経路) の ExternalId injection (現状の Worker は same-account のみで cross-account を呼ばないため、Phase 2.2 で Worker を cross-account 化するときに同時に実装する)</li>
+<li><code>CDK_PARAM_DEPLOY_EXTERNAL_ID</code> 撤去 / rename (Worker が cross-account になるまで触らない)</li>
+<li>migration script (旧 deployment 行への <code>externalId</code> 補填) — 現状 cross-account deploy が稼働していないため migration 対象が 0 件</li>
+</ul>
+
+<p>これらは新 Issue として切り出し、Phase 2.1 が user により本番 deploy + 動作確認された後に着手する。</p>
+
+<h3>3. Onboarding (実装)</h3>
+
+<table>
+<thead><tr><th>step</th><th>actor</th><th>動作</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>operator</td><td>application-admin-console / Competitor Accounts 画面で「アカウントを追加」</td></tr>
+<tr><td>2</td><td>backend</td><td>SSM <code>/{env}/tenants/{tenantId}/external-id</code> が無ければ 64 char hex を生成 + Put。DDB <code>CompetitorAccounts</code> に <code>verified=false</code> の row。</td></tr>
+<tr><td>3</td><td>operator</td><td>Reveal modal に表示された <code>{ tenkaCloudAccountId, externalId, competitorRoleName }</code> を競技者にコピペで渡す</td></tr>
+<tr><td>4</td><td>競技者</td><td><code>competitor-bootstrap.yaml</code> を Parameter (= ExternalId / TrustedAccountId) 付きで自分の AWS account へ deploy</td></tr>
+<tr><td>5</td><td>operator</td><td>画面で「Verify」 button → backend が STS AssumeRole sanity check → 成功で <code>verified=true</code></td></tr>
+</tbody>
+</table>
+
+<h3>4. IAM 最小権限</h3>
+
+<p><code>CompetitorAccountsApiLambda</code> の execution role に付与する権限:</p>
+
+<ul>
+<li>DDB <code>CompetitorAccounts</code> の RW (table-scoped)</li>
+<li>SSM <code>arn:aws:ssm:{region}:{account}:parameter/{env}/tenants/*/external-id</code> の <code>GetParameter</code> / <code>PutParameter</code> / <code>DeleteParameter</code></li>
+<li>KMS <code>Decrypt</code> / <code>Encrypt</code> (= AWS managed key <code>alias/aws/ssm</code> 用、Condition で <code>kms:EncryptionContext:PARAMETER_ARN</code> を SSM path に絞る)</li>
+<li>STS <code>AssumeRole</code> on <code>arn:aws:iam::*:role/TenkaCloud-*</code> (= account 全体ではなく Role 名 pattern で絞る、IAM 越境攻撃の余地を最小化)</li>
+</ul>
+
+<p>本 ADR では tenant 単位の SSM path 絞り込みを <strong>session tag injection 無しで</strong> 開始する (= Phase 2.1 では Lambda の IAM が tenant 全体の <code>parameter/{env}/tenants/*/external-id</code> を許可する)。理由は ADR-002 §2.2 と同じ: Cognito identity propagation で per-tenant session tag を inject する経路は Phase 3 で実装する。</p>
+
+<h3>5. API 形状</h3>
+
+<p>すべて tenant API GW + Cognito JWT authorizer 経由。<code>tenantId</code> は JWT <code>custom:tenantId</code> claim から backend が解決し、<strong>request body の <code>tenantId</code> は信頼しない</strong>。</p>
+
+<details open>
+<summary><span class="api-method POST">POST</span> <code>/admin/competitor-accounts</code> — register</summary>
+<p>Body (Zod validated): <code>{ awsAccountId, region?, competitorRoleName?, alias? }</code></p>
+<p>動作: SSM に ExternalId を冪等に確保 (既存ならそのまま) → DDB に row を <code>verified=false</code> で Put → response に <code>{ ..., externalId, tenkaCloudAccountId }</code>。</p>
+<p>失敗:</p>
+<ul>
+  <li><code>validation_failed</code> (400) — Zod の issue を返す</li>
+  <li><code>duplicate_account</code> (409) — 同 <code>(tenantId, awsAccountId)</code> が既存</li>
+</ul>
+</details>
+
+<details>
+<summary><span class="api-method GET">GET</span> <code>/admin/competitor-accounts</code> — list</summary>
+<p>Response: <code>{ items: CompetitorAccountSummary[] }</code>。<strong><code>externalId</code> は含めない</strong> (= SecureString は POST 直後の 1 度きり露出)。</p>
+</details>
+
+<details>
+<summary><span class="api-method POST">POST</span> <code>/admin/competitor-accounts/{awsAccountId}/verify</code> — sanity check</summary>
+<p>動作: DDB.Get で row 取得 → SSM.Get で ExternalId 取得 → STS.AssumeRole 発行 (= <code>RoleArn</code>, <code>ExternalId</code>, <code>DurationSeconds=900</code>) → 成功なら DDB に <code>verified=true</code> / <code>verifiedAt</code> を Update。</p>
+<p>失敗:</p>
+<ul>
+  <li><code>not_found</code> (404)</li>
+  <li><code>external_id_missing</code> (409) — SSM が空 (= 整合性違反)</li>
+  <li><code>assume_role_failed</code> (422) — STS Error name を <code>underlyingErrorName</code> として operator に返す (<code>AccessDenied</code> / <code>ExternalIdMismatch</code> 等を画面で識別可能)</li>
+</ul>
+</details>
+
+<details>
+<summary><span class="api-method DELETE">DELETE</span> <code>/admin/competitor-accounts/{awsAccountId}</code> — remove</summary>
+<p>動作: 存在確認 (Get) → 無ければ 404 → DeleteCommand 発行 → 残行 0 件なら SSM の ExternalId も同時に削除 (= 鍵漏洩リスク削減)。</p>
+</details>
+
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>Positive</h3>
+<ul>
+<li>ADR-002 で確定した tenant 単位 ExternalId が実装され、漏洩時の blast RADIUS が 1 tenant に閉じる</li>
+<li>operator が画面上で competitor account を一覧 / 追加 / verify / 削除できる (= 「どの account が deploy 可能か」を画面で可視化)</li>
+<li>Phase 2.1 はテストで <strong>STS AssumeRole が ExternalId 付きで発行される</strong> ことを pin (= Confused Deputy 対策の regression を防ぐ)</li>
+<li>Phase 2.2 (= DeployForm migration / Worker cross-account 化) は別 PR で扱う前提に整理されており、PR の review burden が下がる</li>
+</ul>
+
+<h3>Negative / 未解決</h3>
+<ul>
+<li>Phase 2.1 単独では「verified=true の account を強制する」 backend 制約が無い (= 実 deploy 経路がまだ same-account 前提)。Phase 2.2 で Worker を cross-account 化する際に同時に立てる</li>
+<li>session tag による per-tenant SSM 絞り込みは Phase 3 待ち</li>
+<li><code>EventCreate</code> 画面の <code>awsAccountId</code> 自由入力は本 PR では撤廃せず、互換のため残す</li>
+</ul>
+
+<h3>Migration / 互換性</h3>
+<ul>
+<li>本 PR 単独では既存 deploy 経路に影響無し (= 既存 EventCreate / DeployForm はそのまま動く)</li>
+<li>新 Lambda + DDB は Phase 2.1 で deploy するが、誰も呼ばなければ無料 (DDB 1/1 PROVISIONED = ~$0.60/月、SSM SecureString は無料の標準 tier 内)</li>
+<li>Worker が cross-account 化されたら、本 ADR 5 章の verify endpoint が事前要件になる (= verified=false の account では deploy が拒否される、Phase 2.2 で実装)</li>
+</ul>
+</section>
+
+</body>
+</html>

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -240,6 +240,9 @@ const problemDeployBackendStack = new ProblemDeployBackendStack(app, "tenkacloud
   problemsScoring,
   participantPortal,
   deployConcurrentBuildLimit,
+  // Issue #459 / ADR-002: SSM SecureString path `/{environmentName}/tenants/{tenantId}/external-id`
+  // の prefix。`environment` 変数 (= development / staging / production 等) と同じ値。
+  environmentName: environment,
 });
 cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
@@ -296,6 +299,7 @@ const tenantTemplateStack = new TenantTemplateStack(app, `tenkacloud-tenant-temp
   commitId,
   deployApiLambda: problemDeployBackendStack.deployApiLambda,
   eventApiLambda: problemDeployBackendStack.eventApiLambda,
+  competitorAccountsApiLambda: problemDeployBackendStack.competitorAccountsApiLambda,
   participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
 });
 

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -81,16 +81,20 @@ export class CompetitorAccountsApiLambda extends Construct {
       }),
     );
     // SSM SecureString は AWS managed key (alias/aws/ssm) で暗号化される。
-    // 復号には KMS Decrypt 権限が要る。AWS managed key の Resource ARN は account/region から
-    // 構築できないので、`Encryption Context: PARAMETER_ARN` で絞り込む。
+    //   - GetParameter(WithDecryption=true) → `kms:Decrypt` を要求
+    //   - PutParameter(Type=SecureString)  → `kms:GenerateDataKey` を要求 (envelope encryption)
+    // AWS managed key の Resource ARN は account/region から構築できないので Resource:* + Condition で絞る。
+    //
+    // **StringLike** が必須: SSM が runtime に渡してくる EncryptionContext は **具体 tenantId** に
+    // 展開された ARN (= `.../tenants/01HXYZ.../external-id`)。`StringEquals` だと wildcard を
+    // 文字 `*` として扱い literal 比較に倒れ Condition が永遠に false で fail-closed になる。
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ["kms:Decrypt", "kms:Encrypt"],
-        // Resource は `*` だが Condition で SSM context に限定 (= AWS managed key のみ実質効く)。
+        actions: ["kms:Decrypt", "kms:GenerateDataKey"],
         resources: ["*"],
         conditions: {
-          StringEquals: {
+          StringLike: {
             "kms:EncryptionContext:PARAMETER_ARN": ssmArn,
           },
         },

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -1,0 +1,111 @@
+import * as path from "node:path";
+import { Duration, Stack } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
+
+export interface CompetitorAccountsApiLambdaProps {
+  readonly competitorAccountsTable: Table;
+  /** SSM SecureString path 構築用 (`/<env>/tenants/<tenantId>/external-id`)。 */
+  readonly environmentName: string;
+}
+
+/**
+ * Competitor Accounts API Lambda (Issue #459 / ADR-002 Phase 2.1)。
+ *
+ * tenant API (TenantTemplateStack の REST API + Cognito JWT authorizer) から
+ * `LambdaIntegration` で invoke される。Hono routes:
+ *   POST   /admin/competitor-accounts
+ *   GET    /admin/competitor-accounts
+ *   POST   /admin/competitor-accounts/{awsAccountId}/verify
+ *   DELETE /admin/competitor-accounts/{awsAccountId}
+ *
+ * 最小権限の IAM (= scope を tenant の SSM path prefix に限定):
+ *   - DDB `CompetitorAccounts` 全 RW
+ *   - SSM `parameter/{env}/tenants/*\/external-id` の Get/Put/Delete (KMS managed key)
+ *   - STS `AssumeRole` (= verify endpoint。resource は 12 桁 account の Role なので
+ *     account 全体を `*` で許可、Action のみ限定する)
+ *
+ * 独立 Lambda にする理由 (= EventApi 等への相乗りを避ける):
+ *   1. SSM SecureString Read/Write は機密 IAM なので最小化したい
+ *   2. STS AssumeRole も同様 (= 他 handler に持たせると blast RADIUS が拡大)
+ */
+export class CompetitorAccountsApiLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: CompetitorAccountsApiLambdaProps) {
+    super(scope, id);
+
+    const stack = Stack.of(this);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/competitor-accounts-handler/index.ts"),
+      handler: "handler",
+      // verify endpoint は STS AssumeRole 1 回 (= ~1s) + DDB Update なので 10s で十分。
+      timeout: Duration.seconds(15),
+      memorySize: 256,
+      environment: {
+        COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
+        TENKACLOUD_ACCOUNT_ID: stack.account,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // 1. DDB CompetitorAccounts: PutItem / Query / GetItem / UpdateItem / DeleteItem
+    props.competitorAccountsTable.grantReadWriteData(this.fn);
+
+    // 2. SSM Parameter Store SecureString — tenant の path prefix で絞り込み。
+    //    `/{env}/tenants/*/external-id` (= tenantId は wildcard、env は固定)。
+    const ssmArn = buildExternalIdParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter", "ssm:PutParameter", "ssm:DeleteParameter"],
+        resources: [ssmArn],
+      }),
+    );
+    // SSM SecureString は AWS managed key (alias/aws/ssm) で暗号化される。
+    // 復号には KMS Decrypt 権限が要る。AWS managed key の Resource ARN は account/region から
+    // 構築できないので、`Encryption Context: PARAMETER_ARN` で絞り込む。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt", "kms:Encrypt"],
+        // Resource は `*` だが Condition で SSM context に限定 (= AWS managed key のみ実質効く)。
+        resources: ["*"],
+        conditions: {
+          StringEquals: {
+            "kms:EncryptionContext:PARAMETER_ARN": ssmArn,
+          },
+        },
+      }),
+    );
+
+    // 3. STS AssumeRole (verify endpoint)。Resource は 12 桁 account の競技者 IAM Role 形式に絞る。
+    //    具体的な競技者 account ID は deploy 時点では決まらないので account を `*` にし、
+    //    Role 名 pattern を `TenkaCloud-*` で絞る (= operator が好きな名前を付けても TenkaCloud- prefix は必須)。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
+      }),
+    );
+  }
+}

--- a/infrastructure/lib/problem-deploy/competitor-accounts-table.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-table.ts
@@ -1,0 +1,42 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * tenant 単位で「deploy 許可されている競技者 AWS account」を 1 行で記録する DDB テーブル
+ * (Issue #459 / ADR-002 Decision 2.1)。
+ *
+ * 本テーブルは **メタデータ専用**。ExternalId は同 stack の SSM SecureString に置く
+ * (= `secrets-manager-forbidden` enforcement と整合、coppy-paste 経路で漏洩しないため)。
+ *
+ * Schema:
+ *   PK: TENANT#<tenantId>
+ *   SK: ACCOUNT#<awsAccountId>     (= 12 桁 AWS Account ID)
+ *
+ * 主な属性:
+ *   tenantId / awsAccountId / region / competitorRoleName / alias? /
+ *   verified (boolean) / verifiedAt? / createdAt / updatedAt / createdBy
+ *
+ * GSI なし (PK 単一で tenant 内一覧を Query、個別取得は Get で SK 直接 lookup)。
+ *
+ * Capacity / lifecycle:
+ *   provisioned 1/1 (`DynamoDbLowCapacity` Aspect で更に均す)。training / 競技
+ *   イベント中の QPS 極小、コスト 0 原則を優先する。RETAIN — operator 操作で stack
+ *   を delete しても tenant ↔ account 紐付け履歴は残す。
+ */
+export class CompetitorAccountsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -1,0 +1,170 @@
+import { Hono } from "hono";
+import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
+import { handle } from "hono/aws-lambda";
+import { cors } from "hono/cors";
+import { StatusCodes } from "http-status-codes";
+import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
+import { buildCompetitorAccountsSharedResources } from "./shared.js";
+import {
+  CompetitorAccountNotFoundError,
+  createCompetitorAccount,
+  DuplicateCompetitorAccountError,
+  deleteCompetitorAccount,
+  listCompetitorAccounts,
+} from "./store.js";
+import { CreateCompetitorAccountRequestSchema } from "./types.js";
+import {
+  AssumeRoleSanityCheckFailedError,
+  ExternalIdMissingError,
+  verifyCompetitorAccount,
+} from "./verify.js";
+
+/**
+ * Competitor Accounts API Lambda の Hono app (Issue #459 / ADR-002 Phase 2.1)。
+ *
+ * routes (すべて tenant API + Cognito JWT authorizer 経由):
+ *   POST   /admin/competitor-accounts                       — register (= SSM Put + DDB Put)
+ *   GET    /admin/competitor-accounts                       — list (verified / unverified 両方)
+ *   POST   /admin/competitor-accounts/{awsAccountId}/verify — STS AssumeRole sanity check
+ *   DELETE /admin/competitor-accounts/{awsAccountId}        — remove (last row なら SSM 鍵も削除)
+ *
+ * Auth: tenant API GW + Cognito JWT authorizer。tenantId は JWT `custom:tenantId` claim
+ * から `resolveTenantId(c)` で抽出する。**request body の tenantId は信頼しない** (= IAM 越境攻撃の防止)。
+ */
+
+const AWS_ACCOUNT_ID_RE = /^\d{12}$/;
+
+const shared = buildCompetitorAccountsSharedResources();
+
+const app = new Hono();
+
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    maxAge: 600,
+  }),
+);
+
+// 想定外 throw を 500 JSON で返す (= CORS headers 付きで browser が body を読める、PR-559 同様)。
+app.onError((err, c) => {
+  const message = err instanceof Error ? err.message : "unknown error";
+  console.error("[competitor-accounts] uncaught handler error", {
+    path: c.req.path,
+    message,
+  });
+  return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+app.get("/admin/competitor-accounts/healthz", (c) => c.json({ ok: true }));
+
+app.post("/admin/competitor-accounts", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "request body must be JSON" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = CreateCompetitorAccountRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  try {
+    const response = await createCompetitorAccount(
+      shared,
+      {
+        tenantId: resolveTenantId(c),
+        nowMs: Date.now(),
+        createdBy: resolveCognitoSub(c),
+      },
+      parsed.data,
+    );
+    return c.json(response, StatusCodes.CREATED);
+  } catch (err) {
+    if (err instanceof DuplicateCompetitorAccountError) {
+      return c.json(
+        { error: "duplicate_account", awsAccountId: err.awsAccountId },
+        StatusCodes.CONFLICT,
+      );
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] create failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/competitor-accounts", async (c) => {
+  try {
+    const items = await listCompetitorAccounts(shared, resolveTenantId(c));
+    return c.json({ items }, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] list failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.post("/admin/competitor-accounts/:awsAccountId/verify", async (c) => {
+  const awsAccountId = c.req.param("awsAccountId");
+  if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
+    return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
+  }
+  try {
+    const account = await verifyCompetitorAccount(shared, {
+      tenantId: resolveTenantId(c),
+      awsAccountId,
+      nowMs: Date.now(),
+    });
+    return c.json(account, StatusCodes.OK);
+  } catch (err) {
+    if (err instanceof CompetitorAccountNotFoundError) {
+      return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    if (err instanceof ExternalIdMissingError) {
+      return c.json({ error: "external_id_missing" }, StatusCodes.CONFLICT);
+    }
+    if (err instanceof AssumeRoleSanityCheckFailedError) {
+      // STS の Error name を operator に渡す (= AccessDenied / ExternalIdMismatch を判別できる)。
+      return c.json(
+        {
+          error: "assume_role_failed",
+          underlyingErrorName: err.underlyingErrorName,
+        },
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      );
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] verify failed", { awsAccountId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
+  const awsAccountId = c.req.param("awsAccountId");
+  if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
+    return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
+  }
+  try {
+    await deleteCompetitorAccount(shared, resolveTenantId(c), awsAccountId);
+    return c.json({ deleted: true }, StatusCodes.OK);
+  } catch (err) {
+    if (err instanceof CompetitorAccountNotFoundError) {
+      return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] delete failed", { awsAccountId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+export const handler = handle(app) as (
+  event: LambdaEvent,
+  context: LambdaContext,
+) => Promise<unknown>;
+
+export { app };

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/shared.ts
@@ -1,0 +1,33 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { STSClient } from "@aws-sdk/client-sts";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+
+/**
+ * Competitor Accounts handler の module-scope shared resources。
+ *
+ * - `tableName` = `CompetitorAccounts` DDB (Issue #459 / ADR-002)
+ * - `env` / `tenkaCloudAccountId` = SSM path 構築 + 「Add account」レスポンスで返す値
+ *
+ * Lambda は warm invoke で SDK client を 1 つだけ持つ (= cold start 軽減)。
+ */
+export interface CompetitorAccountsSharedResources {
+  readonly tableName: string;
+  readonly env: string;
+  readonly tenkaCloudAccountId: string;
+  readonly ddb: DynamoDBDocumentClient;
+  readonly ssm: SSMClient;
+  readonly sts: STSClient;
+}
+
+export function buildCompetitorAccountsSharedResources(): CompetitorAccountsSharedResources {
+  return {
+    tableName: getEnv("COMPETITOR_ACCOUNTS_TABLE_NAME"),
+    env: getEnv("DEPLOY_ENVIRONMENT"),
+    tenkaCloudAccountId: getEnv("TENKACLOUD_ACCOUNT_ID"),
+    ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+    ssm: new SSMClient({}),
+    sts: new STSClient({}),
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
@@ -179,28 +179,40 @@ export async function markCompetitorAccountVerified(
 /**
  * row を削除。**同 tenant の最後の row** だった場合は SSM の ExternalId も削除する (= clean rotation)。
  *
- * 既に存在しない row の DELETE は idempotent: 削除前に `getCompetitorAccount` で確認し、
- * 無ければ `CompetitorAccountNotFoundError`。
+ * `ConditionExpression` で行不在を atomic 検出 (= TOCTOU 回避、1 round-trip 削減)。
+ * 残行確認は `Select: COUNT` + `Limit: 1` で wire payload を最小化する。
  */
 export async function deleteCompetitorAccount(
   shared: CompetitorAccountsSharedResources,
   tenantId: string,
   awsAccountId: string,
 ): Promise<void> {
-  // 削除前に存在確認 (= 404 を caller が返せるように)。
-  const existing = await getCompetitorAccount(shared, tenantId, awsAccountId);
-  if (!existing) throw new CompetitorAccountNotFoundError(awsAccountId);
+  try {
+    await shared.ddb.send(
+      new DeleteCommand({
+        TableName: shared.tableName,
+        Key: { PK: PK(tenantId), SK: SK(awsAccountId) },
+        ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+      }),
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      throw new CompetitorAccountNotFoundError(awsAccountId);
+    }
+    throw err;
+  }
 
-  await shared.ddb.send(
-    new DeleteCommand({
+  // 残行ゼロなら SSM の ExternalId も掃除する (= 鍵漏洩リスク減)。
+  const remaining = await shared.ddb.send(
+    new QueryCommand({
       TableName: shared.tableName,
-      Key: { PK: PK(tenantId), SK: SK(awsAccountId) },
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: { ":pk": PK(tenantId), ":sk": "ACCOUNT#" },
+      Select: "COUNT",
+      Limit: 1,
     }),
   );
-
-  // 残り行を確認し、tenant に 1 行も無くなれば SSM の ExternalId も掃除する (= 鍵漏洩リスク減)。
-  const remaining = await listCompetitorAccounts(shared, tenantId);
-  if (remaining.length === 0) {
+  if ((remaining.Count ?? 0) === 0) {
     await deleteExternalId({ ssm: shared.ssm as SSMClient, env: shared.env }, tenantId);
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
@@ -1,0 +1,206 @@
+import type { SSMClient } from "@aws-sdk/client-ssm";
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { deleteExternalId, ensureExternalId } from "../shared/external-id-store.js";
+import type { CompetitorAccountsSharedResources } from "./shared.js";
+import type {
+  CompetitorAccountItem,
+  CompetitorAccountSummary,
+  CreateCompetitorAccountRequest,
+  CreateCompetitorAccountResponse,
+} from "./types.js";
+
+const PK = (tenantId: string) => `TENANT#${tenantId}`;
+const SK = (awsAccountId: string) => `ACCOUNT#${awsAccountId}`;
+
+const toSummary = (item: Partial<CompetitorAccountItem>): CompetitorAccountSummary => ({
+  awsAccountId: String(item.awsAccountId ?? ""),
+  region: String(item.region ?? "ap-northeast-1"),
+  competitorRoleName: String(item.competitorRoleName ?? ""),
+  alias: typeof item.alias === "string" ? item.alias : undefined,
+  verified: item.verified === true,
+  verifiedAt: typeof item.verifiedAt === "string" ? item.verifiedAt : undefined,
+  createdAt: String(item.createdAt ?? ""),
+  updatedAt: String(item.updatedAt ?? ""),
+});
+
+export class DuplicateCompetitorAccountError extends Error {
+  constructor(public readonly awsAccountId: string) {
+    super(`competitor account ${awsAccountId} is already registered for this tenant`);
+    this.name = "DuplicateCompetitorAccountError";
+  }
+}
+
+export class CompetitorAccountNotFoundError extends Error {
+  constructor(public readonly awsAccountId: string) {
+    super(`competitor account ${awsAccountId} is not registered for this tenant`);
+    this.name = "CompetitorAccountNotFoundError";
+  }
+}
+
+export interface CreateCompetitorAccountContext {
+  readonly tenantId: string;
+  readonly nowMs: number;
+  readonly createdBy: string;
+}
+
+/**
+ * `(tenantId, awsAccountId)` の新規登録。
+ *
+ * 1. SSM の tenant ExternalId を冪等に確保 (= 既存なら回さない、未登録なら 64 文字 hex を発行)
+ * 2. DDB に行を Put — 同 (PK, SK) があれば `DuplicateCompetitorAccountError`
+ * 3. 戻り値に `externalId` / `tenkaCloudAccountId` を **1 度だけ** 露出 (一覧 API には載せない)
+ */
+export async function createCompetitorAccount(
+  shared: CompetitorAccountsSharedResources,
+  ctx: CreateCompetitorAccountContext,
+  req: CreateCompetitorAccountRequest,
+): Promise<CreateCompetitorAccountResponse> {
+  const { externalId } = await ensureExternalId(
+    { ssm: shared.ssm as SSMClient, env: shared.env },
+    ctx.tenantId,
+  );
+
+  const nowIso = new Date(ctx.nowMs).toISOString();
+  const item: CompetitorAccountItem = {
+    PK: PK(ctx.tenantId),
+    SK: SK(req.awsAccountId),
+    tenantId: ctx.tenantId,
+    awsAccountId: req.awsAccountId,
+    region: req.region,
+    competitorRoleName: req.competitorRoleName,
+    ...(req.alias !== undefined ? { alias: req.alias } : {}),
+    verified: false,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    createdBy: ctx.createdBy,
+  };
+  try {
+    await shared.ddb.send(
+      new PutCommand({
+        TableName: shared.tableName,
+        Item: item,
+        ConditionExpression: "attribute_not_exists(PK) AND attribute_not_exists(SK)",
+      }),
+    );
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    if (name === "ConditionalCheckFailedException") {
+      throw new DuplicateCompetitorAccountError(req.awsAccountId);
+    }
+    throw err;
+  }
+
+  return {
+    ...toSummary(item),
+    externalId,
+    tenkaCloudAccountId: shared.tenkaCloudAccountId,
+  };
+}
+
+/** tenant 内の全 competitor account を一覧する (= verified / unverified 両方)。 */
+export async function listCompetitorAccounts(
+  shared: CompetitorAccountsSharedResources,
+  tenantId: string,
+): Promise<readonly CompetitorAccountSummary[]> {
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: {
+        ":pk": PK(tenantId),
+        ":sk": "ACCOUNT#",
+      },
+    }),
+  );
+  return (out.Items ?? []).map((it) => toSummary(it as Partial<CompetitorAccountItem>));
+}
+
+export async function getCompetitorAccount(
+  shared: CompetitorAccountsSharedResources,
+  tenantId: string,
+  awsAccountId: string,
+): Promise<CompetitorAccountSummary | undefined> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: PK(tenantId), SK: SK(awsAccountId) },
+    }),
+  );
+  if (!out.Item) return undefined;
+  return toSummary(out.Item as Partial<CompetitorAccountItem>);
+}
+
+export interface MarkVerifiedContext {
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly verifiedAt: string;
+}
+
+/**
+ * `verified=true` + `verifiedAt` を 1 回 Update。row が無ければ `CompetitorAccountNotFoundError`。
+ *
+ * caller (handler) は STS AssumeRole が成功した後にのみ呼ぶこと。
+ */
+export async function markCompetitorAccountVerified(
+  shared: CompetitorAccountsSharedResources,
+  ctx: MarkVerifiedContext,
+): Promise<CompetitorAccountSummary> {
+  try {
+    const out = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: PK(ctx.tenantId), SK: SK(ctx.awsAccountId) },
+        UpdateExpression: "SET verified = :v, verifiedAt = :va, updatedAt = :ua",
+        ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+        ExpressionAttributeValues: {
+          ":v": true,
+          ":va": ctx.verifiedAt,
+          ":ua": ctx.verifiedAt,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    return toSummary((out.Attributes ?? {}) as Partial<CompetitorAccountItem>);
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    if (name === "ConditionalCheckFailedException") {
+      throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
+    }
+    throw err;
+  }
+}
+
+/**
+ * row を削除。**同 tenant の最後の row** だった場合は SSM の ExternalId も削除する (= clean rotation)。
+ *
+ * 既に存在しない row の DELETE は idempotent: 削除前に `getCompetitorAccount` で確認し、
+ * 無ければ `CompetitorAccountNotFoundError`。
+ */
+export async function deleteCompetitorAccount(
+  shared: CompetitorAccountsSharedResources,
+  tenantId: string,
+  awsAccountId: string,
+): Promise<void> {
+  // 削除前に存在確認 (= 404 を caller が返せるように)。
+  const existing = await getCompetitorAccount(shared, tenantId, awsAccountId);
+  if (!existing) throw new CompetitorAccountNotFoundError(awsAccountId);
+
+  await shared.ddb.send(
+    new DeleteCommand({
+      TableName: shared.tableName,
+      Key: { PK: PK(tenantId), SK: SK(awsAccountId) },
+    }),
+  );
+
+  // 残り行を確認し、tenant に 1 行も無くなれば SSM の ExternalId も掃除する (= 鍵漏洩リスク減)。
+  const remaining = await listCompetitorAccounts(shared, tenantId);
+  if (remaining.length === 0) {
+    await deleteExternalId({ ssm: shared.ssm as SSMClient, env: shared.env }, tenantId);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+/**
+ * `CompetitorAccounts` DDB 1 行の shape (Issue #459 / ADR-002 Decision 2.1)。
+ *
+ *   PK = `TENANT#<tenantId>`  /  SK = `ACCOUNT#<awsAccountId>`
+ *
+ * ExternalId は本テーブルに **保存しない** — 同じ tenant の SSM SecureString 経由 (= ADR-002 §2.2)。
+ */
+export interface CompetitorAccountItem {
+  PK: string;
+  SK: string;
+
+  tenantId: string;
+  awsAccountId: string;
+  region: string;
+  competitorRoleName: string;
+  alias?: string;
+  verified: boolean;
+  verifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  /** Cognito sub (= operator 監査用)。`unknown` の場合は JWT 解決失敗 (test / dev fallback)。 */
+  createdBy: string;
+}
+
+const AWS_ACCOUNT_ID_RE = /^\d{12}$/;
+const AWS_REGION_RE = /^[a-z]{2}-[a-z]+-\d+$/;
+// IAM Role 名の許容 charclass (CFn `competitor-bootstrap.yaml` の `AllowedPattern` と同じ)。
+const IAM_ROLE_NAME_RE = /^[A-Za-z0-9_+=,.@-]{1,64}$/;
+
+export const CreateCompetitorAccountRequestSchema = z
+  .object({
+    awsAccountId: z.string().regex(AWS_ACCOUNT_ID_RE, "AWS Account ID は 12 桁の数字"),
+    /**
+     * deploy 先 region (= `competitor-bootstrap.yaml` を deploy した region と一致)。
+     * default は `ap-northeast-1` (Tokyo)。
+     */
+    region: z.string().regex(AWS_REGION_RE, "AWS region 形式が不正です").default("ap-northeast-1"),
+    /**
+     * 競技者側 bootstrap が作る IAM Role 名。`competitor-bootstrap.yaml` の default は
+     * `TenkaCloud-CompetitorDeploy-Role`。tenant ごとに変える運用も許す。
+     */
+    competitorRoleName: z
+      .string()
+      .regex(IAM_ROLE_NAME_RE, "IAM Role 名の形式が不正です")
+      .default("TenkaCloud-CompetitorDeploy-Role"),
+    /** operator 表示用ラベル (例: `Team Acme prod`)。任意。 */
+    alias: z.string().min(1).max(120).optional(),
+  })
+  .strict();
+export type CreateCompetitorAccountRequest = z.infer<typeof CreateCompetitorAccountRequestSchema>;
+
+export interface CompetitorAccountSummary {
+  awsAccountId: string;
+  region: string;
+  competitorRoleName: string;
+  alias?: string;
+  verified: boolean;
+  verifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCompetitorAccountResponse extends CompetitorAccountSummary {
+  /**
+   * 競技者に **1 度だけ** 露出する secret。`competitor-bootstrap.yaml` の Parameter として渡す。
+   * 一覧 (`GET`) には含めない (= SSM SecureString から再取得が必要)。
+   */
+  externalId: string;
+  /** 競技者に伝える TenkaCloud 側の AWS Account ID (CFn template の Parameter として要る)。 */
+  tenkaCloudAccountId: string;
+}
+
+export interface ListCompetitorAccountsResponse {
+  items: readonly CompetitorAccountSummary[];
+}
+
+export interface VerifyCompetitorAccountResponse extends CompetitorAccountSummary {
+  /** STS AssumeRole が成功した時点の ISO 8601 (= `verifiedAt`)。 */
+  verifiedAt: string;
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
@@ -33,6 +33,8 @@ export interface VerifyCompetitorAccountContext {
 }
 
 const SANITY_CHECK_SESSION_NAME = "TenkaCloud-CompetitorAccount-Verify";
+// 最短 session 長 (= STS の最小値)。verify は credentials を実際に使わないので即破棄で良い。
+const MIN_ASSUME_ROLE_SESSION_SECONDS = 900;
 
 /**
  * `(tenantId, awsAccountId)` の競技者 IAM Role に対して STS AssumeRole を 1 度だけ発行し
@@ -51,10 +53,12 @@ export async function verifyCompetitorAccount(
   shared: CompetitorAccountsSharedResources,
   ctx: VerifyCompetitorAccountContext,
 ): Promise<CompetitorAccountSummary> {
-  const account = await getCompetitorAccount(shared, ctx.tenantId, ctx.awsAccountId);
+  // DDB Get と SSM GetParameter は互いに独立 (= tenantId / awsAccountId が確定済) なので並列発火。
+  const [account, externalId] = await Promise.all([
+    getCompetitorAccount(shared, ctx.tenantId, ctx.awsAccountId),
+    getExternalId({ ssm: shared.ssm, env: shared.env }, ctx.tenantId),
+  ]);
   if (!account) throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
-
-  const externalId = await getExternalId({ ssm: shared.ssm, env: shared.env }, ctx.tenantId);
   if (!externalId) throw new ExternalIdMissingError(ctx.tenantId);
 
   const roleArn = `arn:aws:iam::${ctx.awsAccountId}:role/${account.competitorRoleName}`;
@@ -64,8 +68,7 @@ export async function verifyCompetitorAccount(
         RoleArn: roleArn,
         RoleSessionName: SANITY_CHECK_SESSION_NAME,
         ExternalId: externalId,
-        // 最短 15 分。verify は credentials を実際に使わないので即破棄して良い。
-        DurationSeconds: 900,
+        DurationSeconds: MIN_ASSUME_ROLE_SESSION_SECONDS,
       }),
     );
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
@@ -1,0 +1,86 @@
+import { AssumeRoleCommand, type STSClient } from "@aws-sdk/client-sts";
+import { getExternalId } from "../shared/external-id-store.js";
+import type { CompetitorAccountsSharedResources } from "./shared.js";
+import {
+  CompetitorAccountNotFoundError,
+  getCompetitorAccount,
+  markCompetitorAccountVerified,
+} from "./store.js";
+import type { CompetitorAccountSummary } from "./types.js";
+
+export class ExternalIdMissingError extends Error {
+  constructor(public readonly tenantId: string) {
+    super(`external id parameter is missing for tenant ${tenantId}`);
+    this.name = "ExternalIdMissingError";
+  }
+}
+
+export class AssumeRoleSanityCheckFailedError extends Error {
+  constructor(
+    public readonly awsAccountId: string,
+    public readonly underlyingErrorName: string,
+    underlyingMessage: string,
+  ) {
+    super(`AssumeRole sanity check failed: ${underlyingErrorName}: ${underlyingMessage}`);
+    this.name = "AssumeRoleSanityCheckFailedError";
+  }
+}
+
+export interface VerifyCompetitorAccountContext {
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly nowMs: number;
+}
+
+const SANITY_CHECK_SESSION_NAME = "TenkaCloud-CompetitorAccount-Verify";
+
+/**
+ * `(tenantId, awsAccountId)` の競技者 IAM Role に対して STS AssumeRole を 1 度だけ発行し
+ * (= ExternalId 付き、最短 15 分 session)、成功なら DDB の `verified=true` を立てる。
+ *
+ * 失敗ケース:
+ *   - row が無い → `CompetitorAccountNotFoundError` (404 等価)
+ *   - SSM に ExternalId が無い → `ExternalIdMissingError` (= 不整合、500 等価)
+ *   - STS AssumeRole が失敗 → `AssumeRoleSanityCheckFailedError`
+ *     (= ErrorName: AccessDenied / ExternalIdMismatch / etc. を operator に伝える)
+ *
+ * 注意: STS は 4xx を `name` 属性で示す (`AccessDenied` / `Forbidden` 等)。caller (handler) で
+ * `error.underlyingErrorName` を見て operator にユーザフレンドリ表示する。
+ */
+export async function verifyCompetitorAccount(
+  shared: CompetitorAccountsSharedResources,
+  ctx: VerifyCompetitorAccountContext,
+): Promise<CompetitorAccountSummary> {
+  const account = await getCompetitorAccount(shared, ctx.tenantId, ctx.awsAccountId);
+  if (!account) throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
+
+  const externalId = await getExternalId({ ssm: shared.ssm, env: shared.env }, ctx.tenantId);
+  if (!externalId) throw new ExternalIdMissingError(ctx.tenantId);
+
+  const roleArn = `arn:aws:iam::${ctx.awsAccountId}:role/${account.competitorRoleName}`;
+  try {
+    await (shared.sts as STSClient).send(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: SANITY_CHECK_SESSION_NAME,
+        ExternalId: externalId,
+        // 最短 15 分。verify は credentials を実際に使わないので即破棄して良い。
+        DurationSeconds: 900,
+      }),
+    );
+  } catch (err) {
+    const underlyingErrorName = err instanceof Error ? err.name : "Unknown";
+    const underlyingMessage = err instanceof Error ? err.message : String(err);
+    throw new AssumeRoleSanityCheckFailedError(
+      ctx.awsAccountId,
+      underlyingErrorName,
+      underlyingMessage,
+    );
+  }
+
+  return markCompetitorAccountVerified(shared, {
+    tenantId: ctx.tenantId,
+    awsAccountId: ctx.awsAccountId,
+    verifiedAt: new Date(ctx.nowMs).toISOString(),
+  });
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
@@ -23,6 +23,12 @@ import {
 /** SSM の許容 char class (`[A-Za-z0-9_=,.@:/-]`) + 長さ要件を満たす 64 文字の random hex。 */
 const EXTERNAL_ID_BYTE_LENGTH = 32; // hex 化で 64 文字 → competitor-bootstrap.yaml の MaxLength=128 内、MinLength=16 を満たす
 
+// SSM SDK は ParameterNotFound を class でも err.name でも投げる (= 環境 / version 依存の挙動を吸収)。
+function isParameterNotFound(err: unknown): boolean {
+  if (err instanceof ParameterNotFound) return true;
+  return err instanceof Error && err.name === "ParameterNotFound";
+}
+
 export function buildExternalIdParameterName(env: string, tenantId: string): string {
   // env / tenantId は POSIX 風 path の segment に直接埋めるため、許容 charclass の事前 sanitize は caller 側責任。
   // 実運用では env={development,staging,production}, tenantId は ULID なので問題なし。
@@ -63,10 +69,7 @@ export async function getExternalId(
     const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
     return out.Parameter?.Value;
   } catch (err) {
-    if (err instanceof ParameterNotFound) return undefined;
-    // SSM client は MissingParameter / ParameterNotFound のどちらかを投げる場合があるため name 確認も併用。
-    const name = err instanceof Error ? err.name : "";
-    if (name === "ParameterNotFound") return undefined;
+    if (isParameterNotFound(err)) return undefined;
     throw err;
   }
 }
@@ -107,8 +110,7 @@ export async function deleteExternalId(deps: ExternalIdStoreDeps, tenantId: stri
   try {
     await deps.ssm.send(new DeleteParameterCommand({ Name: name }));
   } catch (err) {
-    if (err instanceof ParameterNotFound) return;
-    if (err instanceof Error && err.name === "ParameterNotFound") return;
+    if (isParameterNotFound(err)) return;
     throw err;
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
@@ -1,0 +1,114 @@
+import { randomBytes } from "node:crypto";
+import {
+  DeleteParameterCommand,
+  GetParameterCommand,
+  ParameterNotFound,
+  ParameterType,
+  PutParameterCommand,
+  type SSMClient,
+} from "@aws-sdk/client-ssm";
+
+/**
+ * SSM Parameter Store SecureString ベースの per-tenant ExternalId ストア
+ * (Issue #459 / ADR-002 Decision 2.2)。
+ *
+ * path 規約: `/{env}/tenants/{tenantId}/external-id`
+ *   - 1 tenant 1 値 (Decision 1 = A2 と整合: 同 tenant 配下の複数 competitor account は同じ ExternalId を共有)
+ *   - KMS は AWS managed (`alias/aws/ssm`、コスト 0)
+ *   - tenantId を path 末端より前に置き、IAM policy で path prefix 絞り込みを行う
+ *
+ * `secrets-manager-forbidden` enforcement と整合: Secrets Manager は使わない。
+ */
+
+/** SSM の許容 char class (`[A-Za-z0-9_=,.@:/-]`) + 長さ要件を満たす 64 文字の random hex。 */
+const EXTERNAL_ID_BYTE_LENGTH = 32; // hex 化で 64 文字 → competitor-bootstrap.yaml の MaxLength=128 内、MinLength=16 を満たす
+
+export function buildExternalIdParameterName(env: string, tenantId: string): string {
+  // env / tenantId は POSIX 風 path の segment に直接埋めるため、許容 charclass の事前 sanitize は caller 側責任。
+  // 実運用では env={development,staging,production}, tenantId は ULID なので問題なし。
+  return `/${env}/tenants/${tenantId}/external-id`;
+}
+
+export function buildExternalIdParameterArnPattern(
+  region: string,
+  account: string,
+  env: string,
+): string {
+  // IAM policy 用。tenantId を `*` でワイルドカード化する (= deploy 時点では具体 tenantId を知らない)。
+  return `arn:aws:ssm:${region}:${account}:parameter/${env}/tenants/*/external-id`;
+}
+
+/**
+ * `randomBytes(32).toString("hex")` で 64 文字の hex を生成。
+ * `competitor-bootstrap.yaml` の `AllowedPattern: ^[A-Za-z0-9_=,.@:/-]+$` を満たす。
+ */
+export function generateExternalId(): string {
+  return randomBytes(EXTERNAL_ID_BYTE_LENGTH).toString("hex");
+}
+
+export interface ExternalIdStoreDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly env: string;
+}
+
+/**
+ * tenant の ExternalId を取得。未登録なら `undefined` を返す (= not found を上位で 404 等に変換する余地を残す)。
+ */
+export async function getExternalId(
+  deps: ExternalIdStoreDeps,
+  tenantId: string,
+): Promise<string | undefined> {
+  const name = buildExternalIdParameterName(deps.env, tenantId);
+  try {
+    const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+    return out.Parameter?.Value;
+  } catch (err) {
+    if (err instanceof ParameterNotFound) return undefined;
+    // SSM client は MissingParameter / ParameterNotFound のどちらかを投げる場合があるため name 確認も併用。
+    const name = err instanceof Error ? err.name : "";
+    if (name === "ParameterNotFound") return undefined;
+    throw err;
+  }
+}
+
+/**
+ * tenant の ExternalId が無ければ生成 + Put して返す。既存なら既存値を返す (= 冪等)。
+ *
+ * 「Add account」を 2 回目以降に押しても ExternalId は **回さない** (ADR-002 Decision 3.1)。
+ */
+export async function ensureExternalId(
+  deps: ExternalIdStoreDeps,
+  tenantId: string,
+): Promise<{ readonly externalId: string; readonly created: boolean }> {
+  const existing = await getExternalId(deps, tenantId);
+  if (existing) return { externalId: existing, created: false };
+  const name = buildExternalIdParameterName(deps.env, tenantId);
+  const externalId = generateExternalId();
+  await deps.ssm.send(
+    new PutParameterCommand({
+      Name: name,
+      Value: externalId,
+      Type: ParameterType.SECURE_STRING,
+      Overwrite: false,
+      // KMS は AWS managed (alias/aws/ssm)。明示 KeyId を渡さない場合に SSM が自動採用する。
+    }),
+  );
+  return { externalId, created: true };
+}
+
+/**
+ * tenant の ExternalId を削除。存在しない場合は no-op (= idempotent)。
+ *
+ * 注意: 同 tenant 配下に **他の verified account が残っている場合は呼ぶべきでない** (= caller 責任)。
+ * 本関数は SSM API 側で他の account の参照を確認する手段が無いため、削除の判断は handler 側で行う。
+ */
+export async function deleteExternalId(deps: ExternalIdStoreDeps, tenantId: string): Promise<void> {
+  const name = buildExternalIdParameterName(deps.env, tenantId);
+  try {
+    await deps.ssm.send(new DeleteParameterCommand({ Name: name }));
+  } catch (err) {
+    if (err instanceof ParameterNotFound) return;
+    if (err instanceof Error && err.name === "ParameterNotFound") return;
+    throw err;
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -5,6 +5,8 @@ import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
+import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda";
+import { CompetitorAccountsTable } from "./competitor-accounts-table";
 import { ConsoleViewerRole } from "./console-viewer-role";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project";
@@ -69,6 +71,12 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * 詳細は `DeployCodeBuildProjectProps.concurrentBuildLimit` の docs を参照。
    */
   readonly deployConcurrentBuildLimit?: number;
+  /**
+   * SSM SecureString path 構築用の environment 名 (Issue #459 / ADR-002 Phase 2.1)。
+   * `/{environmentName}/tenants/{tenantId}/external-id` の prefix として使う。
+   * 例: `development` / `staging` / `production`。
+   */
+  readonly environmentName: string;
 }
 
 /**
@@ -90,6 +98,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * Event / Team CRUD 用の Lambda (ADR-004 Phase 1)。tenant API から invoke される。
    */
   public readonly eventApiLambda: IFunction;
+  /**
+   * Competitor Accounts CRUD + verify 用 Lambda (Issue #459 / ADR-002 Phase 2.1)。
+   * tenant API の `/admin/competitor-accounts*` route から invoke される。
+   */
+  public readonly competitorAccountsApiLambda: IFunction;
   /**
    * Participant Portal の CloudFront URL。Participant Portal が無効化された tenant
    * では undefined。`TenantTemplateStack` が application-admin-console の runtime-config に
@@ -121,6 +134,9 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     this.deploymentsTable = deployments.table;
     this.eventsTable = events.table;
     this.teamsTable = teams.table;
+    // Issue #459 / ADR-002 Phase 2.1: tenant ↔ 競技者 AWS account の許可表。
+    // 1 行 = 1 (tenantId, awsAccountId)。verified=false は deploy 不可。
+    const competitorAccounts = new CompetitorAccountsTable(this, "CompetitorAccounts");
     const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
@@ -143,6 +159,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       defaultTenantId: props.defaultTenantId,
     });
     this.eventApiLambda = eventApi.fn;
+
+    // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + STS verify Lambda。
+    // 独立 Lambda にする理由: SSM SecureString R/W + STS AssumeRole の IAM scope を最小化するため。
+    const competitorAccountsApi = new CompetitorAccountsApiLambda(this, "CompetitorAccountsApi", {
+      competitorAccountsTable: competitorAccounts.table,
+      environmentName: props.environmentName,
+    });
+    this.competitorAccountsApiLambda = competitorAccountsApi.fn;
 
     // CodeBuild Project: source.zip から `scripts/deploy-battles.sh` を実行する。
     // #538: Bulk Deploy 並列度の hard cap は account-wide CodeBuild concurrent build
@@ -233,6 +257,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     new CfnOutput(this, "TeamsTableName", {
       value: teams.table.tableName,
       description: "ADR-004 Teams table 名 (1 チーム = 1 行、teamLoginKey は team scope)。",
+    });
+    new CfnOutput(this, "CompetitorAccountsTableName", {
+      value: competitorAccounts.table.tableName,
+      description:
+        "Issue #459 / ADR-002 Competitor Accounts table 名 (tenant ↔ 競技者 AWS account 紐付け)。",
     });
     new CfnOutput(this, "DeployCreateStateMachineArn", {
       value: stateMachine.stateMachine.stateMachineArn,

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -29,6 +29,11 @@ interface ApiGatewayProps {
    * Event / Team CRUD routes が本 Lambda を invoke する。
    */
   eventApiLambda: IFunction;
+  /**
+   * `ProblemDeployBackendStack.competitorAccountsApiLambda` のクロススタック参照
+   * (Issue #459 / ADR-002 Phase 2.1)。`/admin/competitor-accounts*` routes を proxy する。
+   */
+  competitorAccountsApiLambda: IFunction;
   apiKeyBasicTier: CustomApiKey;
   apiKeyStandardTier: CustomApiKey;
   apiKeyPremiumTier: CustomApiKey;
@@ -106,5 +111,20 @@ export class ApiGateway extends Construct {
     const lockScoring = event.addResource("lock-scoring");
     lockScoring.addMethod("POST", eventIntegration, deployMethodOptions);
     lockScoring.addMethod("DELETE", eventIntegration, deployMethodOptions);
+
+    // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + verify
+    //   /admin/competitor-accounts                       POST=register, GET=list
+    //   /admin/competitor-accounts/{awsAccountId}        DELETE=remove (last row なら SSM 鍵も掃除)
+    //   /admin/competitor-accounts/{awsAccountId}/verify POST=STS AssumeRole sanity check
+    const competitorAccountsIntegration = new LambdaIntegration(props.competitorAccountsApiLambda);
+    const admin = this.restApi.root.addResource("admin");
+    const competitorAccounts = admin.addResource("competitor-accounts");
+    competitorAccounts.addMethod("GET", competitorAccountsIntegration, deployMethodOptions);
+    competitorAccounts.addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
+    const competitorAccount = competitorAccounts.addResource("{awsAccountId}");
+    competitorAccount.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
+    competitorAccount
+      .addResource("verify")
+      .addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -46,6 +46,12 @@ interface TenantTemplateStackProps extends StackProps {
    */
   eventApiLambda: IFunction;
   /**
+   * `ProblemDeployBackendStack.competitorAccountsApiLambda` をクロススタック参照で受ける
+   * (Issue #459 / ADR-002 Phase 2.1)。tenant API の `/admin/competitor-accounts*` routes が
+   * 本 Lambda を invoke する。
+   */
+  competitorAccountsApiLambda: IFunction;
+  /**
    * Participant Portal の CloudFront URL。`ProblemDeployBackendStack` の
    * `participantPortalUrl` をクロススタック参照で受け、application-admin-console の
    * runtime-config.json に注入する (operator が EventDetail 等で「Portal URL を共有」
@@ -94,6 +100,7 @@ export class TenantTemplateStack extends Stack {
       userPool: identityProvider.tenantUserPool,
       deployApiLambda: props.deployApiLambda,
       eventApiLambda: props.eventApiLambda,
+      competitorAccountsApiLambda: props.competitorAccountsApiLambda,
       apiKeyBasicTier: {
         apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.basic.keyId),
         value: this.ssmLookup(props.ApiKeySSMParameterNames.basic.value),

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -261,6 +261,32 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["CompetitorAccountsTableName"]));
     });
+
+    it("KMS policy は StringLike + Decrypt/GenerateDataKey を持つべき (= SSM SecureString GET/PUT 双方を動かす)", () => {
+      // **regression 防止**: 旧実装は StringEquals + Decrypt/Encrypt の組合せだった (PR-594
+      // /security-review Vuln 1)。`StringEquals` は wildcard 展開しないので Condition が
+      // 永久に false で fail-closed、Encrypt は SecureString PUT に不適合 (GenerateDataKey 必要)。
+      // この test で StringLike + Decrypt + GenerateDataKey の組合せを pin する。
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Action: Match.arrayWith(["kms:Decrypt", "kms:GenerateDataKey"]),
+                Resource: "*",
+                Condition: Match.objectLike({
+                  StringLike: Match.objectLike({
+                    "kms:EncryptionContext:PARAMETER_ARN": Match.anyValue(),
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
   });
 });
 

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -16,6 +16,7 @@ function synthDefault(): Template {
       "hello-world": "problems/challenges/hello-world",
     },
     problemsScoring: {},
+    environmentName: "development",
   });
   return Template.fromStack(stack);
 }
@@ -24,10 +25,10 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams の 3 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
-      // ADR-004 Phase 1 で Events / Teams を追加。3 Table すべて DynamoDbLowCapacity Aspect で
-      // 1/1 PROVISIONED に均される。
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 3);
+    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts の 4 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+      // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts。
+      // 4 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 4);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({
@@ -135,6 +136,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
         problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
         problemsScoring: {},
         deployConcurrentBuildLimit: 200,
+        environmentName: "development",
       });
       const limited = Template.fromStack(stack);
       limited.hasResourceProperties(
@@ -203,6 +205,61 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   describe("legacy 経路の廃止", () => {
     it("旧 DeployApiGateway (HTTP API) を作らないべき", () => {
       tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 0);
+    });
+  });
+
+  describe("Competitor Accounts API Lambda (Issue #459 / ADR-002 Phase 2.1)", () => {
+    it("Lambda が COMPETITOR_ACCOUNTS_TABLE_NAME / DEPLOY_ENVIRONMENT / TENKACLOUD_ACCOUNT_ID env を持つべき", () => {
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs20.x",
+          Architectures: ["arm64"],
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              COMPETITOR_ACCOUNTS_TABLE_NAME: Match.anyValue(),
+              DEPLOY_ENVIRONMENT: "development",
+              TENKACLOUD_ACCOUNT_ID: Match.anyValue(),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("Lambda Role に SSM Parameter Store + STS AssumeRole の最小権限を付与するべき", () => {
+      // SSM は path prefix で絞り込み、STS は TenkaCloud- Role 名 pattern で絞り込み。
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Action: Match.arrayWith(["ssm:GetParameter", "ssm:PutParameter"]),
+              }),
+            ]),
+          }),
+        }),
+      );
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Action: "sts:AssumeRole",
+                Resource: "arn:aws:iam::*:role/TenkaCloud-*",
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("Output に CompetitorAccountsTableName を含むべき", () => {
+      const outputs = tpl.findOutputs("*");
+      expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["CompetitorAccountsTableName"]));
     });
   });
 });

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -1,0 +1,225 @@
+import { StatusCodes } from "http-status-codes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createCompetitorAccount: vi.fn(),
+  listCompetitorAccounts: vi.fn(),
+  deleteCompetitorAccount: vi.fn(),
+  verifyCompetitorAccount: vi.fn(),
+  DuplicateCompetitorAccountError: class extends Error {
+    constructor(public readonly awsAccountId: string) {
+      super("dup");
+      this.name = "DuplicateCompetitorAccountError";
+    }
+  },
+  CompetitorAccountNotFoundError: class extends Error {
+    constructor(public readonly awsAccountId: string) {
+      super("404");
+      this.name = "CompetitorAccountNotFoundError";
+    }
+  },
+  AssumeRoleSanityCheckFailedError: class extends Error {
+    constructor(
+      public readonly awsAccountId: string,
+      public readonly underlyingErrorName: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "AssumeRoleSanityCheckFailedError";
+    }
+  },
+  ExternalIdMissingError: class extends Error {
+    constructor(public readonly tenantId: string) {
+      super("missing");
+      this.name = "ExternalIdMissingError";
+    }
+  },
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/shared", () => ({
+  buildCompetitorAccountsSharedResources: () => ({
+    tableName: "TestCompetitorAccounts",
+    env: "development",
+    tenkaCloudAccountId: "111111111111",
+    ddb: { send: vi.fn() },
+    ssm: { send: vi.fn() },
+    sts: { send: vi.fn() },
+  }),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/store", () => ({
+  createCompetitorAccount: mocks.createCompetitorAccount,
+  listCompetitorAccounts: mocks.listCompetitorAccounts,
+  deleteCompetitorAccount: mocks.deleteCompetitorAccount,
+  DuplicateCompetitorAccountError: mocks.DuplicateCompetitorAccountError,
+  CompetitorAccountNotFoundError: mocks.CompetitorAccountNotFoundError,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify", () => ({
+  verifyCompetitorAccount: mocks.verifyCompetitorAccount,
+  AssumeRoleSanityCheckFailedError: mocks.AssumeRoleSanityCheckFailedError,
+  ExternalIdMissingError: mocks.ExternalIdMissingError,
+}));
+
+const { app } = await import("../../lib/problem-deploy/handlers/competitor-accounts-handler/index");
+
+describe("POST /admin/competitor-accounts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("201 で externalId / tenkaCloudAccountId を含む body を返すべき", async () => {
+    mocks.createCompetitorAccount.mockResolvedValueOnce({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: false,
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T00:00:00.000Z",
+      externalId: "abc123",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const res = await app.request("/admin/competitor-accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      }),
+    });
+    expect(res.status).toBe(StatusCodes.CREATED);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.externalId).toBe("abc123");
+    expect(body.tenkaCloudAccountId).toBe("111111111111");
+    expect(body.verified).toBe(false);
+  });
+
+  it("validation 失敗 (= awsAccountId が 12 桁でない) は 400 を返すべき", async () => {
+    const res = await app.request("/admin/competitor-accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ awsAccountId: "abc" }),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.createCompetitorAccount).not.toHaveBeenCalled();
+  });
+
+  it("Duplicate は 409 を返すべき", async () => {
+    mocks.createCompetitorAccount.mockRejectedValueOnce(
+      new mocks.DuplicateCompetitorAccountError("222222222222"),
+    );
+    const res = await app.request("/admin/competitor-accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      }),
+    });
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+  });
+});
+
+describe("GET /admin/competitor-accounts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("一覧 (verified 混在) を返し externalId は含めないべき", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce([
+      {
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        createdAt: "2026-05-11T00:00:00.000Z",
+        updatedAt: "2026-05-11T00:00:00.000Z",
+      },
+      {
+        awsAccountId: "333333333333",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-05-11T00:00:00.000Z",
+        updatedAt: "2026-05-11T00:00:00.000Z",
+      },
+    ]);
+    const res = await app.request("/admin/competitor-accounts");
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as { items: Array<Record<string, unknown>> };
+    expect(body.items).toHaveLength(2);
+    expect(body.items[0]).not.toHaveProperty("externalId");
+  });
+});
+
+describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("STS 成功時は 200 + verified=true を返すべき", async () => {
+    mocks.verifyCompetitorAccount.mockResolvedValueOnce({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T00:00:00.000Z",
+    });
+    const res = await app.request("/admin/competitor-accounts/222222222222/verify", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.verified).toBe(true);
+  });
+
+  it("STS AssumeRole 失敗時は 422 + underlyingErrorName を返すべき", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(
+      new mocks.AssumeRoleSanityCheckFailedError("222222222222", "AccessDenied", "denied"),
+    );
+    const res = await app.request("/admin/competitor-accounts/222222222222/verify", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.underlyingErrorName).toBe("AccessDenied");
+  });
+
+  it("row なしは 404 を返すべき", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(
+      new mocks.CompetitorAccountNotFoundError("999999999999"),
+    );
+    const res = await app.request("/admin/competitor-accounts/999999999999/verify", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("awsAccountId が 12 桁でないと 400", async () => {
+    const res = await app.request("/admin/competitor-accounts/abc/verify", { method: "POST" });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.verifyCompetitorAccount).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /admin/competitor-accounts/:awsAccountId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("200 + deleted=true を返すべき", async () => {
+    mocks.deleteCompetitorAccount.mockResolvedValueOnce(undefined);
+    const res = await app.request("/admin/competitor-accounts/222222222222", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.deleted).toBe(true);
+  });
+
+  it("not found は 404", async () => {
+    mocks.deleteCompetitorAccount.mockRejectedValueOnce(
+      new mocks.CompetitorAccountNotFoundError("999999999999"),
+    );
+    const res = await app.request("/admin/competitor-accounts/999999999999", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+});

--- a/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
@@ -1,0 +1,316 @@
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  DeleteCommand,
+  type GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/shared";
+import {
+  CompetitorAccountNotFoundError,
+  createCompetitorAccount,
+  DuplicateCompetitorAccountError,
+  deleteCompetitorAccount,
+  getCompetitorAccount,
+  listCompetitorAccounts,
+  markCompetitorAccountVerified,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/store";
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function buildShared(): {
+  shared: CompetitorAccountsSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  ssmSend: ReturnType<typeof vi.fn>;
+  stsSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const ssmSend = vi.fn();
+  const stsSend = vi.fn();
+  const shared: CompetitorAccountsSharedResources = {
+    tableName: "TestCompetitorAccounts",
+    env: "development",
+    tenkaCloudAccountId: "111111111111",
+    ddb: { send: ddbSend } as unknown as CompetitorAccountsSharedResources["ddb"],
+    ssm: { send: ssmSend } as unknown as CompetitorAccountsSharedResources["ssm"],
+    sts: { send: stsSend } as unknown as CompetitorAccountsSharedResources["sts"],
+  };
+  return { shared, ddbSend, ssmSend, stsSend };
+}
+
+describe("createCompetitorAccount", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SSM SecureString に ExternalId を Put し DDB に verified=false の row を書くべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    // 1 回目の SSM.Get は ParameterNotFound、続く Put は成功、最後 DDB.Put 成功。
+    ssmSend
+      .mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }))
+      .mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await createCompetitorAccount(
+      shared,
+      { tenantId: "tenant-acme", nowMs: NOW_MS, createdBy: "user-sub-1" },
+      {
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      },
+    );
+
+    // SSM Put が SecureString 型で呼ばれる
+    const putParamCall = ssmSend.mock.calls[1]?.[0] as PutParameterCommand;
+    expect(putParamCall).toBeInstanceOf(PutParameterCommand);
+    expect(putParamCall.input.Type).toBe("SecureString");
+    expect(putParamCall.input.Name).toBe("/development/tenants/tenant-acme/external-id");
+    expect(putParamCall.input.Overwrite).toBe(false);
+    // ExternalId は 64 文字の hex
+    expect(typeof putParamCall.input.Value).toBe("string");
+    expect((putParamCall.input.Value as string).length).toBe(64);
+
+    // DDB Put が verified=false の正しい shape を書く
+    const ddbPut = ddbSend.mock.calls[0]?.[0] as PutCommand;
+    expect(ddbPut).toBeInstanceOf(PutCommand);
+    expect(ddbPut.input.Item).toMatchObject({
+      PK: "TENANT#tenant-acme",
+      SK: "ACCOUNT#222222222222",
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      verified: false,
+      createdBy: "user-sub-1",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+    });
+    expect(ddbPut.input.ConditionExpression).toContain("attribute_not_exists(PK)");
+
+    // 戻り値に externalId / tenkaCloudAccountId が 1 度だけ露出される
+    expect(out.externalId).toBe(putParamCall.input.Value);
+    expect(out.tenkaCloudAccountId).toBe("111111111111");
+    expect(out.verified).toBe(false);
+  });
+
+  it("SSM に既存値があれば ExternalId を回さず既存値を返すべき (= 冪等)", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "existing-external-id-xyz" } });
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await createCompetitorAccount(
+      shared,
+      { tenantId: "tenant-acme", nowMs: NOW_MS, createdBy: "user-sub-1" },
+      {
+        awsAccountId: "333333333333",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      },
+    );
+
+    // PutParameter は呼ばれない
+    expect(ssmSend.mock.calls.length).toBe(1);
+    expect(out.externalId).toBe("existing-external-id-xyz");
+  });
+
+  it("同 (tenantId, awsAccountId) を 2 度作ろうとすると DuplicateCompetitorAccountError を投げるべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "ext-id" } });
+    ddbSend.mockRejectedValueOnce(
+      Object.assign(new Error("conflict"), { name: "ConditionalCheckFailedException" }),
+    );
+
+    await expect(
+      createCompetitorAccount(
+        shared,
+        { tenantId: "tenant-acme", nowMs: NOW_MS, createdBy: "user-sub-1" },
+        {
+          awsAccountId: "222222222222",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        },
+      ),
+    ).rejects.toBeInstanceOf(DuplicateCompetitorAccountError);
+  });
+});
+
+describe("listCompetitorAccounts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Query PK=TENANT# / SK begins_with ACCOUNT# で全 row を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          tenantId: "tenant-acme",
+          awsAccountId: "222222222222",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+          verifiedAt: NOW_ISO,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+        },
+        {
+          tenantId: "tenant-acme",
+          awsAccountId: "333333333333",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: false,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+        },
+      ],
+    });
+
+    const out = await listCompetitorAccounts(shared, "tenant-acme");
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd).toBeInstanceOf(QueryCommand);
+    expect(cmd.input.KeyConditionExpression).toBe("PK = :pk AND begins_with(SK, :sk)");
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+
+    expect(out).toHaveLength(2);
+    expect(out[0]?.verified).toBe(true);
+    expect(out[1]?.verified).toBe(false);
+  });
+});
+
+describe("getCompetitorAccount", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Get が undefined Item を返すと undefined を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+    const out = await getCompetitorAccount(shared, "tenant-acme", "999999999999");
+    expect(out).toBeUndefined();
+    const cmd = ddbSend.mock.calls[0]?.[0] as GetCommand;
+    expect(cmd.input.Key).toEqual({ PK: "TENANT#tenant-acme", SK: "ACCOUNT#999999999999" });
+  });
+});
+
+describe("markCompetitorAccountVerified", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("UpdateCommand で verified=true / verifiedAt を立てるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        verifiedAt: NOW_ISO,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+      },
+    });
+
+    const out = await markCompetitorAccountVerified(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      verifiedAt: NOW_ISO,
+    });
+
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd).toBeInstanceOf(UpdateCommand);
+    expect(cmd.input.ConditionExpression).toContain("attribute_exists(PK)");
+    expect(cmd.input.UpdateExpression).toContain("verified = :v");
+    expect(cmd.input.ExpressionAttributeValues?.[":v"]).toBe(true);
+    expect(cmd.input.ExpressionAttributeValues?.[":va"]).toBe(NOW_ISO);
+
+    expect(out.verified).toBe(true);
+    expect(out.verifiedAt).toBe(NOW_ISO);
+  });
+
+  it("ConditionalCheckFailedException は CompetitorAccountNotFoundError に変換するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockRejectedValueOnce(
+      Object.assign(new Error("conflict"), { name: "ConditionalCheckFailedException" }),
+    );
+
+    await expect(
+      markCompetitorAccountVerified(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "999999999999",
+        verifiedAt: NOW_ISO,
+      }),
+    ).rejects.toBeInstanceOf(CompetitorAccountNotFoundError);
+  });
+});
+
+describe("deleteCompetitorAccount", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("row が存在しなければ CompetitorAccountNotFoundError を投げるべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({}); // Get → not found
+
+    await expect(
+      deleteCompetitorAccount(shared, "tenant-acme", "999999999999"),
+    ).rejects.toBeInstanceOf(CompetitorAccountNotFoundError);
+
+    // DeleteCommand は呼ばれない
+    expect(ddbSend.mock.calls.length).toBe(1);
+    expect(ssmSend.mock.calls.length).toBe(0);
+  });
+
+  it("最後の 1 行を消したら SSM の ExternalId も削除するべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    ddbSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: "tenant-acme",
+          awsAccountId: "222222222222",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+        },
+      })
+      // DeleteCommand 成功
+      .mockResolvedValueOnce({})
+      // QueryCommand で残行 0 件
+      .mockResolvedValueOnce({ Items: [] });
+    // SSM DeleteParameter
+    ssmSend.mockResolvedValueOnce({});
+
+    await deleteCompetitorAccount(shared, "tenant-acme", "222222222222");
+
+    expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(DeleteCommand);
+    expect(ssmSend.mock.calls.length).toBe(1);
+  });
+
+  it("他の row が残っていれば SSM の ExternalId は触らないべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    ddbSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: "tenant-acme",
+          awsAccountId: "222222222222",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+        },
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: "tenant-acme",
+            awsAccountId: "333333333333",
+            verified: false,
+            createdAt: NOW_ISO,
+            updatedAt: NOW_ISO,
+          },
+        ],
+      });
+
+    await deleteCompetitorAccount(shared, "tenant-acme", "222222222222");
+
+    expect(ssmSend.mock.calls.length).toBe(0);
+  });
+});

--- a/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
@@ -244,13 +244,16 @@ describe("deleteCompetitorAccount", () => {
 
   it("row が存在しなければ CompetitorAccountNotFoundError を投げるべき", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({}); // Get → not found
+    // ConditionExpression が落ちて ConditionalCheckFailedException を SDK が投げる挙動。
+    ddbSend.mockRejectedValueOnce(
+      Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" }),
+    );
 
     await expect(
       deleteCompetitorAccount(shared, "tenant-acme", "999999999999"),
     ).rejects.toBeInstanceOf(CompetitorAccountNotFoundError);
 
-    // DeleteCommand は呼ばれない
+    // 残行 Count Query は呼ばない (= Delete 失敗で短絡)
     expect(ddbSend.mock.calls.length).toBe(1);
     expect(ssmSend.mock.calls.length).toBe(0);
   });
@@ -258,56 +261,25 @@ describe("deleteCompetitorAccount", () => {
   it("最後の 1 行を消したら SSM の ExternalId も削除するべき", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ddbSend
-      .mockResolvedValueOnce({
-        Item: {
-          tenantId: "tenant-acme",
-          awsAccountId: "222222222222",
-          region: "ap-northeast-1",
-          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
-          verified: true,
-          createdAt: NOW_ISO,
-          updatedAt: NOW_ISO,
-        },
-      })
       // DeleteCommand 成功
       .mockResolvedValueOnce({})
-      // QueryCommand で残行 0 件
-      .mockResolvedValueOnce({ Items: [] });
+      // QueryCommand (Select=COUNT) で残行 0 件
+      .mockResolvedValueOnce({ Count: 0 });
     // SSM DeleteParameter
     ssmSend.mockResolvedValueOnce({});
 
     await deleteCompetitorAccount(shared, "tenant-acme", "222222222222");
 
-    expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(DeleteCommand);
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(DeleteCommand);
     expect(ssmSend.mock.calls.length).toBe(1);
   });
 
   it("他の row が残っていれば SSM の ExternalId は触らないべき", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ddbSend
-      .mockResolvedValueOnce({
-        Item: {
-          tenantId: "tenant-acme",
-          awsAccountId: "222222222222",
-          region: "ap-northeast-1",
-          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
-          verified: true,
-          createdAt: NOW_ISO,
-          updatedAt: NOW_ISO,
-        },
-      })
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({
-        Items: [
-          {
-            tenantId: "tenant-acme",
-            awsAccountId: "333333333333",
-            verified: false,
-            createdAt: NOW_ISO,
-            updatedAt: NOW_ISO,
-          },
-        ],
-      });
+      // COUNT=1 (= 残行あり)
+      .mockResolvedValueOnce({ Count: 1 });
 
     await deleteCompetitorAccount(shared, "tenant-acme", "222222222222");
 

--- a/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
@@ -1,0 +1,158 @@
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/shared";
+import { CompetitorAccountNotFoundError } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/store";
+import {
+  AssumeRoleSanityCheckFailedError,
+  ExternalIdMissingError,
+  verifyCompetitorAccount,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/verify";
+
+const NOW_MS = 1_700_000_000_000;
+
+function buildShared(): {
+  shared: CompetitorAccountsSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  ssmSend: ReturnType<typeof vi.fn>;
+  stsSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const ssmSend = vi.fn();
+  const stsSend = vi.fn();
+  const shared: CompetitorAccountsSharedResources = {
+    tableName: "TestCompetitorAccounts",
+    env: "development",
+    tenkaCloudAccountId: "111111111111",
+    ddb: { send: ddbSend } as unknown as CompetitorAccountsSharedResources["ddb"],
+    ssm: { send: ssmSend } as unknown as CompetitorAccountsSharedResources["ssm"],
+    sts: { send: stsSend } as unknown as CompetitorAccountsSharedResources["sts"],
+  };
+  return { shared, ddbSend, ssmSend, stsSend };
+}
+
+describe("verifyCompetitorAccount", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("STS AssumeRole を ExternalId 付きで発行し、成功時に verified=true を立てるべき", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    // 1. DDB.Get で row 取得
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    // 2. SSM.Get で ExternalId
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
+    // 3. STS.AssumeRole 成功
+    stsSend.mockResolvedValueOnce({});
+    // 4. DDB.Update で verified=true
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        verifiedAt: new Date(NOW_MS).toISOString(),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: new Date(NOW_MS).toISOString(),
+      },
+    });
+
+    const out = await verifyCompetitorAccount(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      nowMs: NOW_MS,
+    });
+
+    // AssumeRole が ExternalId 付きで呼ばれていること (= Confused Deputy 対策)
+    const stsCmd = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    expect(stsCmd).toBeInstanceOf(AssumeRoleCommand);
+    expect(stsCmd.input.RoleArn).toBe(
+      "arn:aws:iam::222222222222:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(stsCmd.input.ExternalId).toBe("external-id-abc");
+    expect(stsCmd.input.RoleSessionName).toBeTruthy();
+
+    expect(out.verified).toBe(true);
+    expect(out.verifiedAt).toBeTruthy();
+  });
+
+  it("row が無ければ CompetitorAccountNotFoundError を投げるべき", async () => {
+    const { shared, ddbSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({});
+
+    await expect(
+      verifyCompetitorAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "999999999999",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(CompetitorAccountNotFoundError);
+
+    // STS は呼ばれない
+    expect(stsSend.mock.calls.length).toBe(0);
+  });
+
+  it("SSM に ExternalId が無ければ ExternalIdMissingError を投げ STS を呼ばないべき", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
+
+    await expect(
+      verifyCompetitorAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(ExternalIdMissingError);
+    expect(stsSend.mock.calls.length).toBe(0);
+  });
+
+  it("STS AssumeRole 失敗時は AssumeRoleSanityCheckFailedError に変換するべき (= operator に AccessDenied を見せる)", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
+    stsSend.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "AccessDenied" }));
+
+    const thrown = await verifyCompetitorAccount(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      nowMs: NOW_MS,
+    }).then(
+      () => null,
+      (e) => e as unknown,
+    );
+    expect(thrown).toBeInstanceOf(AssumeRoleSanityCheckFailedError);
+    expect((thrown as AssumeRoleSanityCheckFailedError).underlyingErrorName).toBe("AccessDenied");
+
+    // verify 失敗時は DDB.Update は呼ばれない (= verified=false のまま残る)
+    expect(ddbSend.mock.calls.length).toBe(1);
+  });
+});

--- a/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
@@ -85,8 +85,10 @@ describe("verifyCompetitorAccount", () => {
   });
 
   it("row が無ければ CompetitorAccountNotFoundError を投げるべき", async () => {
-    const { shared, ddbSend, stsSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({});
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    // DDB Get + SSM GetParameter は Promise.all で並列発火されるので両方 mock 必要
+    ddbSend.mockResolvedValueOnce({}); // not found
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
 
     await expect(
       verifyCompetitorAccount(shared, {

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -27,6 +27,11 @@ function buildHarness() {
     code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
     handler: "index.handler",
   });
+  const competitorAccountsFn = new LambdaFunction(stack, "CompetitorAccountsApi", {
+    runtime: Runtime.NODEJS_20_X,
+    code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
+    handler: "index.handler",
+  });
   const apiKey: CustomApiKey = {
     id: "key-id",
     apiKey: { keyId: "k", keyArn: "arn:aws:apigateway:::/apikeys/k", keyName: "k" },
@@ -48,6 +53,7 @@ function buildHarness() {
     userPool,
     deployApiLambda: fn,
     eventApiLambda: eventFn,
+    competitorAccountsApiLambda: competitorAccountsFn,
     apiKeyBasicTier: apiKey,
     apiKeyStandardTier: apiKey,
     apiKeyPremiumTier: apiKey,
@@ -115,6 +121,29 @@ describe("tenant ApiGateway", () => {
     tpl.hasResourceProperties("AWS::ApiGateway::Method", {
       HttpMethod: "POST",
       ResourceId: { Ref: notificationsResourceId },
+    });
+  });
+
+  it("/admin/competitor-accounts と /admin/competitor-accounts/{awsAccountId}/verify を持つべき (Issue #459)", () => {
+    // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + verify
+    expect(findResource("admin")).toBeDefined();
+    expect(findResource("competitor-accounts")).toBeDefined();
+    expect(findResource("{awsAccountId}")).toBeDefined();
+    expect(findResource("verify")).toBeDefined();
+
+    const caResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { PathPart: "competitor-accounts" },
+      }),
+    )[0]?.[0];
+    expect(caResourceId).toBeDefined();
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "GET",
+      ResourceId: { Ref: caResourceId },
+    });
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "POST",
+      ResourceId: { Ref: caResourceId },
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue #459 / [ADR-002](./docs/architecture/adr-002-cross-account-federation.html) で確定済の
**Phase 2.1** を実装。詳細は新規 [ADR-009](./docs/architecture/adr-009-cross-account-federation.html)。

- **A2** = ExternalId は **tenant 単位** で発行 (= 漏洩 blast RADIUS は 1 tenant 閉)
- **B2 + B3** = メタデータは新 DDB `CompetitorAccounts` (PROVISIONED 1/1) + ExternalId は SSM SecureString (= `secrets-manager-forbidden` enforcement と整合)
- **C** = 5-step onboarding (画面 Add → Reveal modal → 競技者 bootstrap deploy → Verify button → verified=true)
- **D** = legacy env `CDK_PARAM_DEPLOY_EXTERNAL_ID` 撤去 / rename は Phase 2.2 に分離 (現状の Worker は same-account のみで env を読まないため本 PR では unchanged)

### 新しい API (tenant API + Cognito JWT authorizer 経由、全 4 route)

| Method | Path | 動作 |
|---|---|---|
| `POST` | `/admin/competitor-accounts` | register: SSM Put + DDB Put (= ExternalId が無ければ 64 char hex 発行、`verified=false`)。response に **1 度きり** `externalId` / `tenkaCloudAccountId` を露出 |
| `GET` | `/admin/competitor-accounts` | list (verified / unverified 両方)。`externalId` は含めない |
| `POST` | `/admin/competitor-accounts/{awsAccountId}/verify` | STS AssumeRole sanity check (= ExternalId 付き、15 分 session)。成功で `verified=true` |
| `DELETE` | `/admin/competitor-accounts/{awsAccountId}` | remove。tenant の最後の row なら SSM の ExternalId も削除 |

### 新しい画面

`/competitor-accounts` (application-admin-console SideNavigation 経由) — 一覧 + Add modal + Verify + Delete confirm。Add 直後の Reveal modal で TenkaCloud Account ID / ExternalId / Role 名を 1 度だけ表示。

## 設計判断

- **request body の `tenantId` は信頼しない** — backend は JWT `custom:tenantId` claim から `resolveTenantId(c)` で抽出
- **独立 Lambda** にする (= EventApi に同居しない) 理由: SSM SecureString R/W + STS AssumeRole の IAM scope を最小化する (= blast RADIUS 削減)
- IAM 最小権限:
  - SSM: `arn:aws:ssm:{region}:{account}:parameter/{env}/tenants/*/external-id` (Get/Put/Delete)
  - STS: `arn:aws:iam::*:role/TenkaCloud-*` (Role 名 pattern で絞り込み、account 全体ではない)
  - KMS: `kms:EncryptionContext:PARAMETER_ARN` で SSM context に限定 (= AWS managed key `alias/aws/ssm` のみ実質効く)

## Regression 分析

| 壊しうる挙動 | 対策 |
|---|---|
| 既存 EventCreate / DeployForm の Account ID 自由入力経路 | **本 PR では撤廃しない** (= Phase 2.2 別 PR)。既存運用への影響 0 |
| Worker Lambda の AssumeRole 経路 | 現状 same-account のみで `CDK_PARAM_DEPLOY_EXTERNAL_ID` を読まない。env 撤去は Worker が cross-account 化される Phase 2.2 で同時に |
| `ProblemDeployBackendStack` の synth | 新 prop `environmentName` を **required** で追加。`bin/infrastructure.ts` caller も同時更新、既存テストにも `environmentName: "development"` を追加して通る |
| `TenantTemplateStack` API GW route 追加 | 新 path `/admin/competitor-accounts*` を追加するのみ。既存 route には変更なし。`competitorAccountsApiLambda` prop が ApiGateway / TenantTemplateStack に必須追加 |
| Cognito JWT authorizer | 既存 `deployMethodOptions` を再利用 (= 既存 tenant Cognito Pool で認可) |
| 既存 DDB / Lambda / State Machine / EventBridge Rule | CompetitorAccounts table + Lambda は **新規 CREATE のみ**。既存リソースは touch しない |

## 物理影響

- **CREATE**: `AWS::DynamoDB::Table` (CompetitorAccounts) 1 個 / `AWS::Lambda::Function` (CompetitorAccountsApi) 1 個 / `AWS::IAM::Role` + `AWS::IAM::Policy` (Lambda 用) / `AWS::ApiGateway::Resource` 4 個 (`admin` / `competitor-accounts` / `{awsAccountId}` / `verify`) / `AWS::ApiGateway::Method` 4 個 (GET POST DELETE POST)
- **UPDATE**: `ProblemDeployBackendStack` outputs に `CompetitorAccountsTableName` 1 個追加
- **NO-OP**: 既存 Deployments / Events / Teams / DeployApi / EventApi / HealthCheck / CodeBuild / StepFunctions / EventBridge Rule / Participant Portal は変更なし
- **費用**: DDB 1/1 PROVISIONED ~$0.60/月、SSM SecureString standard tier 無料 (10,000 params 上限内)、Lambda + API GW は invoke 課金 (operator 操作頻度なので実質無料)

## Test plan

- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` — 445 tests passed (新規 17 tests)
  - `CompetitorAccountsTable` が 4 つめの DDB として PROVISIONED 1/1 で synth される
  - `CompetitorAccountsApiLambda` の env / IAM (SSM / STS / KMS) の shape pin
  - tenant API GW に `/admin/competitor-accounts*` route が配線されている
  - `createCompetitorAccount` が SSM Put + DDB Put を発行 (mocked SSM/DDB)
  - 既存 ExternalId があれば SSM Put を skip (= 冪等)
  - **`verifyCompetitorAccount` が STS AssumeRole に ExternalId を渡す** (= Confused Deputy 対策の pin、`Issue #459` の白眉)
  - 失敗時 (AccessDenied / ExternalIdMissing / NotFound) の error mapping
  - 最後の row 削除時に SSM の ExternalId も削除される
  - 4 route × 各 happy / sad path の HTTP status (200 / 201 / 400 / 404 / 409 / 422 / 500)
- [x] `bun run --filter '@TenkaCloud/application-admin-console' typecheck`
- [x] `bun run --filter '@TenkaCloud/application-admin-console' test` — 105 tests passed (新規 4 tests for API client)
- [x] `make check-http-status` — magic number 0 件
- [x] `make lint` — biome / markdownlint / textlint pass
- [x] `make before-commit` (pre-commit hook で実行) — lint / test / validate-problems / http-status すべて pass

### 手動 test plan (deploy 後)

- [ ] `make deploy ENV=development` で新 DDB + Lambda + API GW route が立つ
- [ ] application-admin-console の SideNavigation に「Competitor Accounts」 link が出る
- [ ] 「アカウントを追加」 modal で 12 桁 ID + alias を入力 → 201 + Reveal modal に ExternalId が表示される
- [ ] Reveal modal の値を `competitor-bootstrap.yaml` の Parameter に渡して別 AWS account で deploy
- [ ] Verify button → STS AssumeRole sanity check 成功 → 行が verified=true (green badge)
- [ ] Verify button → STS 失敗 (= 別 ExternalId 渡した場合) → 422 + `underlyingErrorName: AccessDenied`
- [ ] Delete → row 消える、tenant の最後の row なら SSM Parameter も消える (= `aws ssm get-parameter --name /development/tenants/<tenantId>/external-id` が ParameterNotFound)

## Migration

Phase 2.1 単独では既存 deploy 経路に **影響無し**。新 Lambda + DDB は誰も呼ばなければ実質無料 ($0.60/月)。

**Phase 2.2 (別 PR)** で次を実装する:
- `EventCreate` / `DeployForm` の Account ID 自由入力 → verified-account drop-down 化
- Worker Lambda を cross-account 化 (= deployment 行から `awsAccountId` → CompetitorAccounts 行 → SSM ExternalId → STS AssumeRole → CFn CreateStack)
- `verified=true` でない account への deploy を backend で reject
- `CDK_PARAM_DEPLOY_EXTERNAL_ID` env を rename / 廃止

**Phase 3 (別 PR)** で ExternalId rotation API (= SSM Parameter version 機能で 7 日 grace、競技者には新 ExternalId と CFn update 手順を画面で案内)。

Relates #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)