### PR TITLE
feat(#590): Phase 1.A AdminInsightApiLambda + tenant 一覧 deploy 集計 column

### DIFF
--- a/apps/admin-console/src/api/insight.ts
+++ b/apps/admin-console/src/api/insight.ts
@@ -1,0 +1,82 @@
+import { StatusCodes } from "http-status-codes";
+import type { AppConfig } from "../config";
+
+/**
+ * 1 tenant 分の deploy / event 集計 (ADR-011 #590 Phase 1.A)。
+ * backend (`AdminInsightApiLambda`) が返す正本 shape と一致させる。
+ */
+export interface TenantInsightSummary {
+  readonly tenantId: string;
+  readonly activeDeploys: number;
+  readonly failedDeploys: number;
+  readonly totalEvents: number;
+}
+
+export interface TenantsInsightSummaryResponse {
+  readonly items: readonly TenantInsightSummary[];
+}
+
+/**
+ * AdminInsight API は SBT ControlPlane API と別 origin (= API GW HTTP API) で動く。
+ * 既存の `ApiClient` (= ControlPlane API base URL に固定) は使えないので、専用 fetch
+ * 関数を用意する。idToken は AuthProvider から caller が渡す。
+ *
+ * 空 tenant 一覧 (= caller が tenants 0 件のときに呼ぶ) は API 呼び出しを完全に skip して
+ * `{ items: [] }` を返す (= Free Tier RCU 圧迫を回避 + 不要 cold start を避ける)。
+ *
+ * config.adminInsightApiUrl が空文字 (= phase 2 初回 deploy 前 / dev 未配線) なら null
+ * を返す。caller (TenantList) は null を見て column を hide する。
+ */
+export async function fetchTenantsInsightSummary(
+  config: AppConfig,
+  idToken: string,
+  tenantIds: readonly string[],
+): Promise<TenantsInsightSummaryResponse | null> {
+  if (!config.adminInsightApiUrl) {
+    return null;
+  }
+  if (tenantIds.length === 0) {
+    return { items: [] };
+  }
+  const base = config.adminInsightApiUrl.endsWith("/")
+    ? config.adminInsightApiUrl
+    : `${config.adminInsightApiUrl}/`;
+  // 100 件超は backend 側で 400 を返すため、frontend で先に chunk する余地はあるが、
+  // Phase 1.A の MVP scale (~5 tenants) では問題にならない。Phase 3 dashboard で必要なら
+  // chunk 化する。
+  const url = new URL("admin/insight/tenants/summary", base);
+  url.searchParams.set("tenantIds", tenantIds.join(","));
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${idToken}`,
+      "content-type": "application/json",
+    },
+  });
+  if (!res.ok) {
+    if (res.status === StatusCodes.FORBIDDEN) {
+      // Tenant Admin が token を持ってきた場合 (= cognito:groups に SystemAdmin が無い)。
+      // 例外を throw すると tenant 一覧本体まで巻き込んで UI が壊れる。null を返して
+      // caller が「未表示」扱いにする (= 集計 column 単体だけ static 値 0 を出す)。
+      return null;
+    }
+    const detail = await res.text().catch(() => "");
+    throw new Error(`AdminInsight API ${res.status}: ${detail || res.statusText}`);
+  }
+  return (await res.json()) as TenantsInsightSummaryResponse;
+}
+
+/**
+ * `summary.items` を tenantId をキーにした Record に変換する。
+ * TenantList が tenants との join で使う (= O(1) lookup)。
+ * 同じ tenantId が複数行ある (= backend bug) ケースでは後勝ち。
+ */
+export function indexSummaryByTenantId(
+  summary: TenantsInsightSummaryResponse,
+): Record<string, TenantInsightSummary> {
+  const out: Record<string, TenantInsightSummary> = {};
+  for (const item of summary.items) {
+    out[item.tenantId] = item;
+  }
+  return out;
+}

--- a/apps/admin-console/src/config.ts
+++ b/apps/admin-console/src/config.ts
@@ -20,6 +20,12 @@ export interface AppConfig {
   readonly awsRegion: string;
   /** AWS account ID。CodeBuild console URL の {accountId} に埋める。 */
   readonly awsAccountId: string;
+  /**
+   * Admin Insight API のエンドポイント (ADR-011 / #590 Phase 1.A)。tenant 一覧の
+   * deploy 集計 column (activeDeploys / failedDeploys) を取得するのに使う。
+   * 空文字なら admin-console は集計 fetch をスキップする (= phase 2 初回 deploy の race 対策)。
+   */
+  readonly adminInsightApiUrl: string;
 }
 
 /**
@@ -34,6 +40,7 @@ interface RuntimeConfig {
   readonly provisioningCodeBuildProject?: string;
   readonly awsRegion?: string;
   readonly awsAccountId?: string;
+  readonly adminInsightApiUrl?: string;
 }
 
 async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
@@ -50,6 +57,7 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       provisioningCodeBuildProject: data.provisioningCodeBuildProject,
       awsRegion: data.awsRegion,
       awsAccountId: data.awsAccountId,
+      adminInsightApiUrl: data.adminInsightApiUrl,
     };
   } catch {
     return null;
@@ -86,6 +94,7 @@ export async function loadConfig(
       provisioningCodeBuildProject: runtime.provisioningCodeBuildProject ?? "unknown",
       awsRegion: runtime.awsRegion ?? "",
       awsAccountId: runtime.awsAccountId ?? "",
+      adminInsightApiUrl: runtime.adminInsightApiUrl ?? "",
     };
   }
 
@@ -106,5 +115,7 @@ export async function loadConfig(
     provisioningCodeBuildProject: "unknown",
     awsRegion: "",
     awsAccountId: "",
+    // ADR-011 #590: dev では admin-insight API も未配線 (= 集計 column を skip)
+    adminInsightApiUrl: env.VITE_ADMIN_INSIGHT_API_URL ?? "",
   };
 }

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -10,6 +10,11 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
 import {
+  fetchTenantsInsightSummary,
+  indexSummaryByTenantId,
+  type TenantInsightSummary,
+} from "../api/insight";
+import {
   buildCodeBuildBuildUrl,
   deleteTenant,
   listTenants,
@@ -18,7 +23,15 @@ import {
   tenantStatusBadgeColor,
   tierBadgeColor,
 } from "../api/tenants";
+import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+
+/**
+ * ADR-011 #590 Phase 1.A: 60s polling 周期。SSE / WebSocket は禁止 (Lambda 運用と整合せず)。
+ * 5 tenants × ~50 deployments を 60s ごとに refresh して RCU 消費は 1 tenant あたり ~1 query。
+ * Phase 3 dashboard で tenant 数が伸びるなら pre-aggregation table に置き換え。
+ */
+const INSIGHT_POLLING_INTERVAL_MS = 60 * 1000;
 
 /**
  * deprovision 済みの tenant かどうかを判定する。
@@ -46,9 +59,17 @@ function inactiveCell(label = "(deprovisioned)") {
 export function TenantListPage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const api = useApiClient(config);
+  const auth = useAuth();
   const [tenants, setTenants] = useState<Tenant[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingDeprovision, setPendingDeprovision] = useState<Tenant | null>(null);
+  // ADR-011 #590 Phase 1.A: tenantId → 集計 の lookup。
+  // - null = まだ fetch していない / AdminInsight API が未配線 (= column hide)
+  // - {} = fetch 済みで対象 tenant が無い (= 集計 0 表示)
+  const [insightByTenantId, setInsightByTenantId] = useState<Record<
+    string,
+    TenantInsightSummary
+  > | null>(null);
 
   const refresh = useCallback(async () => {
     if (!api) return;
@@ -63,6 +84,36 @@ export function TenantListPage({ config }: { config: AppConfig }) {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // tenants が解決済みなら AdminInsight API を叩いて集計を join する。
+  // tokens が無い / config.adminInsightApiUrl 未設定なら fetch を skip して null のまま
+  // にしておく (= column 自体を表示しない、UI に「未配線」状態を持ち込まない安全装置)。
+  useEffect(() => {
+    const idToken = auth.tokens?.idToken;
+    if (!idToken || !tenants || !config.adminInsightApiUrl) return;
+    const tenantIds = tenants.map((t) => t.tenantId);
+
+    let cancelled = false;
+    const fetchInsight = async () => {
+      try {
+        const summary = await fetchTenantsInsightSummary(config, idToken, tenantIds);
+        if (cancelled) return;
+        // null = 403 forbidden 等 (= SystemAdmin claim 無し)。column hide のため state も null。
+        setInsightByTenantId(summary ? indexSummaryByTenantId(summary) : null);
+      } catch {
+        // tenant 一覧の primary 表示は壊さない。集計列だけ未取得扱いにする (= null)。
+        if (!cancelled) setInsightByTenantId(null);
+      }
+    };
+    void fetchInsight();
+    const handle = window.setInterval(() => {
+      void fetchInsight();
+    }, INSIGHT_POLLING_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [auth.tokens?.idToken, tenants, config]);
 
   const confirmDeprovision = async () => {
     if (!api || !pendingDeprovision) return;
@@ -125,6 +176,36 @@ export function TenantListPage({ config }: { config: AppConfig }) {
             cell: (t) => (
               <Badge color={tenantStatusBadgeColor(t.tenantStatus)}>{t.tenantStatus}</Badge>
             ),
+          },
+          // ADR-011 #590 Phase 1.A: AdminInsight 集計 column。insightByTenantId が null
+          // (= API 未配線 / fetch 失敗 / 403) なら cell は "—" を返し、deprovision 済みは
+          // 灰色 "(deprovisioned)" にする。背景色 / badge で異常 (failed > 0) を識別可能。
+          {
+            id: "activeDeploys",
+            header: "稼働中 deploy",
+            cell: (t) => {
+              if (isDeprovisioned(t)) return inactiveCell();
+              if (insightByTenantId === null) {
+                return <Box color="text-status-inactive">—</Box>;
+              }
+              const summary = insightByTenantId[t.tenantId];
+              const count = summary?.activeDeploys ?? 0;
+              return <Badge color={count > 0 ? "blue" : "grey"}>{count}</Badge>;
+            },
+          },
+          {
+            id: "failedDeploys",
+            header: "失敗 deploy",
+            cell: (t) => {
+              if (isDeprovisioned(t)) return inactiveCell();
+              if (insightByTenantId === null) {
+                return <Box color="text-status-inactive">—</Box>;
+              }
+              const summary = insightByTenantId[t.tenantId];
+              const count = summary?.failedDeploys ?? 0;
+              // 0 件は灰色 (= 正常)、>0 は赤 badge (= 運営要対応のシグナル)。
+              return <Badge color={count > 0 ? "red" : "grey"}>{count}</Badge>;
+            },
           },
           {
             id: "appConsole",

--- a/apps/admin-console/test/api-client.test.ts
+++ b/apps/admin-console/test/api-client.test.ts
@@ -12,6 +12,7 @@ const config: AppConfig = {
   provisioningCodeBuildProject: "unknown",
   awsRegion: "",
   awsAccountId: "",
+  adminInsightApiUrl: "",
 };
 
 describe("createApiClient", () => {

--- a/apps/admin-console/test/cognito.test.ts
+++ b/apps/admin-console/test/cognito.test.ts
@@ -12,6 +12,7 @@ const config: AppConfig = {
   provisioningCodeBuildProject: "unknown",
   awsRegion: "",
   awsAccountId: "",
+  adminInsightApiUrl: "",
 };
 
 describe("loadStoredTokens", () => {

--- a/apps/admin-console/test/insight.test.ts
+++ b/apps/admin-console/test/insight.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchTenantsInsightSummary,
+  indexSummaryByTenantId,
+  type TenantInsightSummary,
+} from "../src/api/insight";
+import type { AppConfig } from "../src/config";
+
+const baseConfig: AppConfig = {
+  cognitoDomain: "https://example.com",
+  cognitoClientId: "client-id",
+  redirectUri: "http://localhost/callback",
+  apiBaseUrl: "https://control.example.com/",
+  scope: "openid",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "https://insight.example.com",
+};
+
+describe("fetchTenantsInsightSummary", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("AdminInsight URL が空文字 (= 未配線) のとき null を返すべき", async () => {
+    const res = await fetchTenantsInsightSummary(
+      { ...baseConfig, adminInsightApiUrl: "" },
+      "id-token",
+      ["t-1"],
+    );
+    expect(res).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("tenantIds が空配列なら fetch せず { items: [] } を返すべき", async () => {
+    const res = await fetchTenantsInsightSummary(baseConfig, "id-token", []);
+    expect(res).toEqual({ items: [] });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("正常系: AdminInsight API を bearer 認証付きで叩くべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [{ tenantId: "t-1", activeDeploys: 1, failedDeploys: 0, totalEvents: 2 }],
+        }),
+        { status: 200 },
+      ),
+    );
+    const res = await fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1", "t-2"]);
+    expect(res?.items[0].tenantId).toBe("t-1");
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toContain("admin/insight/tenants/summary");
+    expect(String(calledUrl)).toContain("tenantIds=t-1%2Ct-2");
+    expect((init as RequestInit).headers).toMatchObject({
+      authorization: "Bearer id-token",
+    });
+  });
+
+  it("403 (SystemAdmin claim 無し) のときは null を返すべき (= column hide)", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "forbidden" }), { status: 403 }),
+    );
+    const res = await fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"]);
+    expect(res).toBeNull();
+  });
+
+  it("500 など 403 以外の error は throw すべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "internal" }), { status: 500 }),
+    );
+    await expect(fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"])).rejects.toThrow(
+      /500/,
+    );
+  });
+});
+
+describe("indexSummaryByTenantId", () => {
+  it("tenantId をキーにした Record を返すべき", () => {
+    const items: TenantInsightSummary[] = [
+      { tenantId: "t-1", activeDeploys: 1, failedDeploys: 0, totalEvents: 2 },
+      { tenantId: "t-2", activeDeploys: 0, failedDeploys: 3, totalEvents: 1 },
+    ];
+    const index = indexSummaryByTenantId({ items });
+    expect(index["t-1"]?.failedDeploys).toBe(0);
+    expect(index["t-2"]?.failedDeploys).toBe(3);
+  });
+
+  it("空 items で空 Record を返すべき", () => {
+    expect(indexSummaryByTenantId({ items: [] })).toEqual({});
+  });
+});

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -5,6 +5,7 @@ import * as cdk from "aws-cdk-lib";
 import { BillingMode } from "aws-cdk-lib/aws-dynamodb";
 import * as dotenv from "dotenv";
 import { AdminConsoleHostingStack } from "../lib/admin-console-hosting";
+import { AdminConsoleInsightStack } from "../lib/admin-insight/admin-console-insight-stack";
 import { BootstrapTemplateStack } from "../lib/bootstrap-template/bootstrap-template-stack";
 import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms";
 import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
@@ -244,6 +245,28 @@ cdk.Aspects.of(problemDeployBackendStack).add(
   new DynamoDbLowCapacity(dynamoReadCapacity, dynamoWriteCapacity),
 );
 
+// AdminConsoleInsightStack (ADR-011 / issue #590 Phase 1.A): System Admin が tenant 横断で
+// deploy 進捗を観察するための新 HTTP API + Lambda。ControlPlane の Cognito UserPool +
+// ProblemDeployBackend の DDB tables を cross-stack で参照する。
+// 本 stack の出力 (AdminInsightApiUrl) は admin-console の runtime-config.json に注入される
+// — phase 2 deploy 時点で本 stack が立っている必要があるため、phase 1 で作る (= 常に instantiate)。
+const adminConsoleOriginForCors = process.env.CDK_PARAM_ADMIN_CONSOLE_ORIGIN;
+const adminConsoleInsightStack = new AdminConsoleInsightStack(
+  app,
+  "tenkacloud-admin-console-insight",
+  {
+    ...stackEnv,
+    cognitoUserPool: controlPlaneStack.cognitoUserPool,
+    cognitoUserClientId: controlPlaneStack.cognitoUserClientId,
+    deploymentsTable: problemDeployBackendStack.deploymentsTable,
+    eventsTable: problemDeployBackendStack.eventsTable,
+    teamsTable: problemDeployBackendStack.teamsTable,
+    adminConsoleOrigin: adminConsoleOriginForCors,
+  },
+);
+adminConsoleInsightStack.addDependency(controlPlaneStack);
+adminConsoleInsightStack.addDependency(problemDeployBackendStack);
+
 const bootstrapTemplateStack = new BootstrapTemplateStack(app, "tenkacloud-bootstrap", {
   ...stackEnv,
   systemAdminEmail,
@@ -305,6 +328,11 @@ const provisioningCodeBuildProject =
   process.env.CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT ?? "unknown";
 // awsRegion / awsAccountId は TenantTemplateStack のために前倒しで定義済み (上を参照)。
 
+// ADR-011 / #590 Phase 1.A: AdminConsoleInsight HTTP API URL を runtime-config に注入する。
+// install.sh phase 2 が `tenkacloud-admin-console-insight` stack の output を読んで本 env に
+// export する。未設定なら admin-console 側で「未発行」表示にする (空文字 fallback)。
+const adminInsightApiUrl = process.env.CDK_PARAM_ADMIN_INSIGHT_API_URL ?? "";
+
 if (adminConsoleApiUrl && adminConsoleCognitoDomain && adminConsoleUserClientId) {
   const adminConsoleHosting = new AdminConsoleHostingStack(
     app,
@@ -318,6 +346,7 @@ if (adminConsoleApiUrl && adminConsoleCognitoDomain && adminConsoleUserClientId)
       provisioningCodeBuildProject,
       awsRegion,
       awsAccountId,
+      adminInsightApiUrl,
     },
   );
   cdk.Aspects.of(adminConsoleHosting).add(new DestroyPolicySetter());

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -38,6 +38,15 @@ export interface AdminConsoleHostingStackProps extends cdk.StackProps {
    * AWS account ID。CodeBuild console URL の {accountId} に埋める。
    */
   readonly awsAccountId: string;
+  /**
+   * Admin Insight API のエンドポイント (ADR-011 / #590 Phase 1.A)。System Admin が
+   * tenant 横断で deploy 進捗を read する経路。phase 1.A では tenant 一覧の deploy 集計 column
+   * (= activeDeploys / failedDeploys) を表示するのに使う。
+   *
+   * 空文字 fallback は admin-console 側で「未発行」表示にしてリクエスト送信をスキップする
+   * (= phase 2 初回 deploy の race 状態でも UI が壊れない安全装置)。
+   */
+  readonly adminInsightApiUrl: string;
 }
 
 /**
@@ -107,6 +116,8 @@ export class AdminConsoleHostingStack extends cdk.Stack {
       provisioningCodeBuildProject: props.provisioningCodeBuildProject,
       awsRegion: props.awsRegion,
       awsAccountId: props.awsAccountId,
+      // ADR-011 #590 Phase 1.A
+      adminInsightApiUrl: props.adminInsightApiUrl.replace(/\/$/, ""),
     };
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [Source.jsonData("runtime-config.json", runtimeConfig)],

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -1,0 +1,128 @@
+import * as cdk from "aws-cdk-lib";
+import { CfnOutput } from "aws-cdk-lib";
+import { CorsHttpMethod, HttpApi, HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpUserPoolAuthorizer } from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import type { IUserPool } from "aws-cdk-lib/aws-cognito";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import type { Construct } from "constructs";
+import { AdminInsightApiLambda } from "./admin-insight-api-lambda";
+
+export interface AdminConsoleInsightStackProps extends cdk.StackProps {
+  /**
+   * SBT ControlPlane の Cognito UserPool。System Admin が登録される pool。
+   * HTTP API JWT Authorizer の audience に渡す。
+   */
+  readonly cognitoUserPool: IUserPool;
+  /**
+   * SBT 内蔵 UserPoolUserClient の client ID (= admin-console が OAuth Code+PKCE で使う client)。
+   * JWT Authorizer は本 client を audience とみなして token を検証する。
+   */
+  readonly cognitoUserClientId: string;
+  /**
+   * 問題 deploy 状況 (active / failed) を集計するため `ProblemDeployBackendStack` の
+   * Deployments table を cross-stack 参照する。Read-only。
+   */
+  readonly deploymentsTable: Table;
+  /**
+   * 競技 Event の総数を集計するため `ProblemDeployBackendStack` の Events table を
+   * cross-stack 参照する。Read-only。
+   */
+  readonly eventsTable: Table;
+  /**
+   * Phase 1.B 以降の drill-down で読む Teams table。Phase 1.A では env として渡すのみ
+   * (Lambda 側で read 権限は付与しない、ADR-011 D6 最小権限)。
+   */
+  readonly teamsTable: Table;
+  /**
+   * admin-console (System Admin SPA) の CloudFront origin。CORS allow-list に明示する。
+   * 未設定 (= phase 1 初回 deploy 時) は localhost dev origin のみ許可。
+   */
+  readonly adminConsoleOrigin?: string;
+}
+
+/**
+ * Admin Console Insight Stack (ADR-011 / issue #590 Phase 1.A)。
+ *
+ * System Admin が tenant 横断で deploy 進捗を観察するための専用 HTTP API + Lambda を提供する。
+ *
+ * 設計判断 (ADR-011 から):
+ * - **D1 採用**: 新 Lambda + 新 API を立てる (= 既存 tenant API に admin 例外を漏らさない)
+ * - **D2 採用**: SBT 標準 SystemAdmin group の Cognito claim で authorize。JWT Authorizer
+ *   (1 段目) + handler 内の claim 再検査 (2 段目) で 403 を返す
+ * - **D6 Phase 1**: read-only に限定 (write は別 ADR が必要)
+ *
+ * 物理影響:
+ * - HTTP API (API GW v2) 1 個 + Lambda 1 個 + JWT Authorizer 1 個。新 table は無し
+ * - Free Tier 内で完結 (= API GW v2 100 万 req/月 free、Lambda 100 万 req + 400k GB-s free)
+ */
+export class AdminConsoleInsightStack extends cdk.Stack {
+  /**
+   * Admin Insight HTTP API の base URL (例: `https://abc.execute-api.ap-northeast-1.amazonaws.com`)。
+   * admin-console の runtime-config.json に注入される。
+   */
+  public readonly apiUrl: string;
+
+  constructor(scope: Construct, id: string, props: AdminConsoleInsightStackProps) {
+    super(scope, id, props);
+
+    const lambda = new AdminInsightApiLambda(this, "AdminInsightApiLambda", {
+      deploymentsTable: props.deploymentsTable,
+      eventsTable: props.eventsTable,
+      teamsTable: props.teamsTable,
+    });
+
+    // JWT Authorizer: ControlPlane UserPool の token を検証する。
+    // (= cognito:groups claim の SystemAdmin チェックは handler 側で実施する 2 段防御)
+    const authorizer = new HttpUserPoolAuthorizer("AdminInsightAuthorizer", props.cognitoUserPool, {
+      userPoolClients: [
+        // SBT が払い出した admin 用 client。`fromUserPoolClientId` を使うには別途
+        // UserPoolClient 参照が要るので、ControlPlaneStack で expose した client id を
+        // identitySource の audience matcher として使う。
+        cdk.aws_cognito.UserPoolClient.fromUserPoolClientId(
+          this,
+          "AdminInsightUserPoolClient",
+          props.cognitoUserClientId,
+        ),
+      ],
+      authorizerName: "AdminInsightSystemAdminAuth",
+    });
+
+    const allowOrigins = [
+      // localhost dev ports — ControlPlaneStack の LOCALHOST_CORS_ORIGINS と揃える。
+      "http://localhost:5173",
+      "http://localhost:4173",
+      "http://localhost:4180",
+      ...(props.adminConsoleOrigin ? [props.adminConsoleOrigin] : []),
+    ];
+
+    const httpApi = new HttpApi(this, "AdminInsightHttpApi", {
+      apiName: `admin-insight-${this.stackName}`,
+      description:
+        "TenkaCloud Admin Insight API (ADR-011 Phase 1.A). System Admin が tenant 横断で deploy 進捗を read する経路。",
+      defaultAuthorizer: authorizer,
+      corsPreflight: {
+        allowOrigins,
+        allowHeaders: ["Authorization", "Content-Type"],
+        allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.OPTIONS],
+        maxAge: cdk.Duration.minutes(10),
+      },
+    });
+
+    const integration = new HttpLambdaIntegration("AdminInsightLambdaIntegration", lambda.fn);
+
+    httpApi.addRoutes({
+      path: "/admin/insight/tenants/summary",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+
+    this.apiUrl = httpApi.apiEndpoint;
+
+    new CfnOutput(this, "AdminInsightApiUrl", {
+      value: httpApi.apiEndpoint,
+      description:
+        "Admin Insight HTTP API のエンドポイント (admin-console の runtime-config.json に注入する)。",
+    });
+  }
+}

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -1,0 +1,75 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface AdminInsightApiLambdaProps {
+  /**
+   * 問題 deploy 状況 (active / failed 集計) の出元。`ProblemDeployBackendStack` の
+   * `Deployments` table を cross-stack 参照する。Read-only (= ADR-011 D6 Phase 1 は read-only)。
+   */
+  readonly deploymentsTable: Table;
+  /**
+   * 競技 Event 総数の出元。`ProblemDeployBackendStack` の `Events` table を cross-stack 参照する。
+   * Read-only。
+   */
+  readonly eventsTable: Table;
+  /**
+   * Phase 1.B 以降の drill-down 拡張 (team 別 / event 詳細) で読み取り対象になる Teams table。
+   * Phase 1.A では env として注入のみ行い、read 権限は付与しない (= 最小権限)。
+   */
+  readonly teamsTable: Table;
+}
+
+/**
+ * Admin Insight API Lambda (ADR-011 / issue #590 Phase 1.A)。
+ *
+ * System Admin が admin-console から cross-tenant に deploy 進捗を見る経路。
+ * tenant 専用 Lambda (= DeployApi / EventApi) と分離して認可境界を明確にする (ADR-011 D1 採用案)。
+ *
+ * routes (Phase 1.A):
+ *   GET /admin/insight/tenants/summary?tenantIds=t1,t2,t3
+ *     → per-tenant の activeDeploys / failedDeploys / totalEvents 集計
+ *
+ * Auth: 呼び出し側の AdminConsoleInsightStack で HTTP API + JWT Authorizer (ControlPlane
+ * UserPool) を結線する。Handler は更に `cognito:groups` ⊇ {SystemAdmin} の claim 検査を行う。
+ */
+export class AdminInsightApiLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: AdminInsightApiLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/admin-insight-handler/index.ts"),
+      handler: "handler",
+      // Per-tenant Query を Promise.all で並列発火するので、tenant 数 100 件 × DDB 往復 ~50ms
+      // ≒ 5s が最大。安全側で 15s。
+      timeout: Duration.seconds(15),
+      memorySize: 256,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        EVENTS_TABLE_NAME: props.eventsTable.tableName,
+        TEAMS_TABLE_NAME: props.teamsTable.tableName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // ADR-011 Phase 1 D6: read-only に限定。Deployments / Events への read のみ grant し、
+    // Teams は Phase 1.B 以降で drill-down が要るときに read 追加する。
+    // GSI も含めて read できる必要があるので grantReadData (= GetItem / Query / Scan + index)
+    // を使う (= 個別 PolicyStatement で限定するより SBT 同型の grantRead で十分)。
+    props.deploymentsTable.grantReadData(this.fn);
+    props.eventsTable.grantReadData(this.fn);
+  }
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts
@@ -1,0 +1,49 @@
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+import type { Context } from "hono";
+
+type JwtClaimValue = string | number | boolean | string[];
+type JwtClaims = { readonly [name: string]: JwtClaimValue };
+
+/**
+ * Cognito `sub` claim を取り出す (= operator の安定識別子)。
+ * ADR-011 D5 の structured audit log (`admin.insight.read`) に `admin` フィールドとして埋める。
+ * JWT 認可が無い経路 (= tests / local fallback) は `"unknown"` を返す。
+ */
+export function resolveCognitoSub(c: Context): string {
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const sub = claims?.sub;
+  return typeof sub === "string" && sub.length > 0 ? sub : "unknown";
+}
+
+/**
+ * Cognito `cognito:groups` claim に `SystemAdmin` が含まれているか判定する。
+ * ADR-011 D2 採用案 = SBT 標準 SystemAdmin group の Cognito claim を必須化。
+ *
+ * API GW の JWT Authorizer (= group check 機能なし) で認可は通っても、claim 検査は
+ * 二重防御として handler 側でもう一度行う。`SystemAdmin` group に属さない token を
+ * 持つ Tenant Admin が誤って本 API を叩いても 403 で弾く。
+ *
+ * `cognito:groups` claim は spec 上 `string[]` だが、API Gateway v2 JWT Authorizer は
+ * 単一要素を string に潰すことがあるため、両形式を受け付ける。
+ */
+export function isSystemAdmin(c: Context): boolean {
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const raw = claims?.["cognito:groups"];
+  if (raw === undefined) return false;
+  if (typeof raw === "string") {
+    // API GW v2 が `"[SystemAdmin]"` / `"SystemAdmin"` / `"foo,SystemAdmin,bar"` 等いずれの
+    // 表現で渡してきても拾えるように、bracket / comma で粗く split して trim する。
+    return raw
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .split(",")
+      .map((s) => s.trim())
+      .includes("SystemAdmin");
+  }
+  if (Array.isArray(raw)) {
+    return raw.includes("SystemAdmin");
+  }
+  return false;
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -1,0 +1,115 @@
+import { Hono } from "hono";
+import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
+import { handle } from "hono/aws-lambda";
+import { cors } from "hono/cors";
+import { StatusCodes } from "http-status-codes";
+import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
+import { buildSharedResources } from "./shared.js";
+import { summarizeTenants } from "./summary.js";
+
+/**
+ * Admin Insight API Lambda の Hono app (ADR-011 Phase 1.A、issue #590)。
+ *
+ * routes (Phase 1.A):
+ *   GET /admin/insight/tenants/summary?tenantIds=t1,t2,t3
+ *     → { items: [{ tenantId, activeDeploys, failedDeploys, totalEvents }] }
+ *
+ * Auth:
+ *   - API Gateway HTTP API + JWT Authorizer (ControlPlane UserPool) で 1 段目を通す
+ *   - handler 内で `cognito:groups` claim ⊇ {SystemAdmin} を再検査 (2 段目)。Tenant Admin
+ *     の token が誤って届いた場合は 403 で弾く (= ADR-011 D2 採用案)
+ *
+ * Audit:
+ *   - 各 read API で `console.log({ event: "admin.insight.read", admin: sub, path })` を出力
+ *   - operator は CloudWatch Logs Insights で `admin.insight.read` を query して誰がいつ
+ *     何を見たか追える (= ADR-011 D5 採用案)
+ *
+ * 非機能:
+ *   - polling 60s (frontend 側で setInterval) を前提に response は <500ms 目標
+ *   - tenant 数 ~5 × deployments/tenant ~50 ≒ 250 行 query で Free Tier RCU 内に収まる
+ *   - Phase 3 (dashboard) で tenant 数が伸びるなら summary.ts の query 戦略を pre-aggregation に置換
+ */
+
+// SDK clients / env は module scope で 1 度だけ build。warm invoke で connection pool 再利用。
+const shared = buildSharedResources();
+
+const TENANT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_TENANT_IDS = 100;
+
+const app = new Hono();
+
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "OPTIONS"],
+    maxAge: 600,
+  }),
+);
+
+// 既存 handler (deploy / event) と同じ defensive layer。handler 内 try/catch を漏れた
+// throw (= middleware や module init で発生) を 500 + CORS headers で返し、browser が
+// "Failed to fetch" で詰まないようにする。response body には message を含めない (= 内部
+// IAM ARN / table 名 / stack trace の漏洩を防ぐ)。
+app.onError((err, c) => {
+  const message = err instanceof Error ? err.message : "unknown error";
+  console.error("[admin-insight] uncaught handler error", { path: c.req.path, message });
+  return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+app.get("/admin/insight/healthz", (c) => c.json({ ok: true }, StatusCodes.OK));
+
+app.get("/admin/insight/tenants/summary", async (c) => {
+  // ADR-011 D2: 2 段目の SystemAdmin claim check。1 段目は API GW JWT Authorizer。
+  if (!isSystemAdmin(c)) {
+    return c.json({ error: "forbidden" }, StatusCodes.FORBIDDEN);
+  }
+
+  // ADR-011 D5: structured audit log。tenant 一覧の中身を log には残さず、admin sub と
+  // path だけを残す (= 監査要件は「誰がいつ覗いたか」が分かれば十分、内容は別 storage)。
+  const sub = resolveCognitoSub(c);
+  console.log({
+    event: "admin.insight.read",
+    admin: sub,
+    path: "/admin/insight/tenants/summary",
+  });
+
+  const raw = c.req.query("tenantIds") ?? "";
+  // 空 query なら 200 + 空配列を返す (= frontend の初期状態 / tenant 0 件で副作用無し)。
+  if (raw.trim() === "") {
+    return c.json({ items: [] }, StatusCodes.OK);
+  }
+
+  const tenantIds = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  // ID 形式 validation。tenant ID は SBT の UUID 形式 (or 自前識別子) を想定。
+  // DDB query の partition key に直接埋めるので、安全側で文字種を絞る。
+  const invalid = tenantIds.find((id) => !TENANT_ID_RE.test(id));
+  if (invalid !== undefined) {
+    return c.json({ error: "invalid_tenant_id", value: invalid }, StatusCodes.BAD_REQUEST);
+  }
+  // Free Tier 圧迫防止 + 単一 invoke の timeout 防止のため上限 100 件 (= MVP-1 想定の 5 倍)。
+  if (tenantIds.length > MAX_TENANT_IDS) {
+    return c.json({ error: "too_many_tenant_ids", max: MAX_TENANT_IDS }, StatusCodes.BAD_REQUEST);
+  }
+
+  try {
+    const response = await summarizeTenants(shared, tenantIds);
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] summarizeTenants failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+export const handler = handle(app) as (
+  event: LambdaEvent,
+  context: LambdaContext,
+) => Promise<unknown>;
+
+export { app };

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
@@ -1,0 +1,35 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * AdminInsight Lambda が module load で 1 度だけ作るリソース束。
+ *
+ * Lambda warm invoke で SDK client / connection pool を使い回すため、handler 外で
+ * `buildSharedResources()` を呼ぶ。env が無い場合は **module 評価時に throw** して
+ * `Initialization Error` で落とす (= 後段 routes が `undefined` 参照で意味不明な 500 を
+ * 返すよりは fail-fast)。
+ */
+export interface AdminInsightSharedResources {
+  readonly deploymentsTableName: string;
+  readonly eventsTableName: string;
+  readonly teamsTableName: string;
+  readonly ddb: DynamoDBDocumentClient;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`AdminInsight Lambda の env ${name} が未設定です`);
+  }
+  return value;
+}
+
+export function buildSharedResources(): AdminInsightSharedResources {
+  const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  return {
+    deploymentsTableName: requireEnv("DEPLOYMENTS_TABLE_NAME"),
+    eventsTableName: requireEnv("EVENTS_TABLE_NAME"),
+    teamsTableName: requireEnv("TEAMS_TABLE_NAME"),
+    ddb,
+  };
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/summary.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/summary.ts
@@ -1,0 +1,136 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { AdminInsightSharedResources } from "./shared.js";
+
+/**
+ * 1 tenant 分の deploy / event 集計。ADR-011 Phase 1 API の正本 shape:
+ *   {
+ *     tenantId,
+ *     activeDeploys,   // status ∈ {PENDING, IN_PROGRESS} の Deployments 件数
+ *     failedDeploys,   // status === "FAILED" の Deployments 件数
+ *     totalEvents,     // Events GSI1 (TENANT#<id>) で得られる総件数
+ *   }
+ *
+ * `name` / `tier` は SBT TenantDetails 管轄なので本 backend では返さない。frontend が
+ * `listTenants` の結果 (= SBT ControlPlane API 由来) と tenantId で join する (Phase 1.A 設計)。
+ * Phase 1.B 以降で SBT TenantDetails table の read を本 Lambda に同居させるなら本 shape を拡張する。
+ */
+export interface TenantSummary {
+  readonly tenantId: string;
+  readonly activeDeploys: number;
+  readonly failedDeploys: number;
+  readonly totalEvents: number;
+}
+
+export interface TenantsSummaryResponse {
+  readonly items: readonly TenantSummary[];
+}
+
+const ACTIVE_DEPLOY_STATUSES = new Set(["PENDING", "IN_PROGRESS"]);
+
+/**
+ * 1 tenant の Deployments GSI1 を全 page 読みつつ status カウントを返す。
+ *
+ * GSI1PK = `TENANT#<tenantId>`、Sort key は createdAt 降順で良いが、本集計では順序は問わない
+ * のでデフォルト (= 昇順 / `ScanIndexForward: true`) のまま使う。`ProjectionExpression` で
+ * `status` のみ取り、payload を最小化する (= Free Tier RCU 圧迫を避ける)。
+ *
+ * Phase 1.A は tenant 数 ~5 × deployments/tenant ~50 ≒ 250 行で十分。Phase 3 (dashboard)
+ * では tenant 数が伸びてくるので、本 query ロジックを置き換える (= reverse-aggregated 行を
+ * 別 GSI / pre-aggregation table に置く設計に切替)。
+ */
+async function countTenantDeployments(
+  shared: AdminInsightSharedResources,
+  tenantId: string,
+): Promise<{ activeDeploys: number; failedDeploys: number }> {
+  let activeDeploys = 0;
+  let failedDeploys = 0;
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
+        // `status` は DDB reserved word なので ExpressionAttributeNames で alias する。
+        ProjectionExpression: "#s",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExclusiveStartKey: lastEvaluatedKey,
+      }),
+    );
+    for (const item of out.Items ?? []) {
+      const status = String((item as { status?: unknown }).status ?? "");
+      if (ACTIVE_DEPLOY_STATUSES.has(status)) activeDeploys += 1;
+      else if (status === "FAILED") failedDeploys += 1;
+    }
+    lastEvaluatedKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastEvaluatedKey);
+  return { activeDeploys, failedDeploys };
+}
+
+/**
+ * 1 tenant の Events 総件数。Events GSI1 (TENANT#<id>) を Select=COUNT で叩く。
+ * AggregationCount で page 跨ぎを安全に集計する。
+ */
+async function countTenantEvents(
+  shared: AdminInsightSharedResources,
+  tenantId: string,
+): Promise<number> {
+  let total = 0;
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.eventsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
+        // payload 不要 (COUNT のみで良い)。
+        Select: "COUNT",
+        ExclusiveStartKey: lastEvaluatedKey,
+      }),
+    );
+    total += out.Count ?? 0;
+    lastEvaluatedKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastEvaluatedKey);
+  return total;
+}
+
+/**
+ * 指定 tenant 一覧の deploy / event 集計を一括取得する。
+ *
+ * - tenant 単位の Query を `Promise.all` で並列発火する。Phase 1.A は MVP scale (~5 tenants ×
+ *   ~50 deployments) なので各 tenant 並列 = 5 並列 ≒ 1 RCU/wave × 5 wave で済む。
+ *   Phase 3 (dashboard) で tenant 数が伸びる場合は chunk 並列 / pre-aggregation で書き換える。
+ * - 重複 tenantId は Set で除去 (= caller が double 送ってきても 1 回しか query しない)。
+ * - 結果順は input 順を保つ (= frontend で join するときの安定性のため)。
+ */
+export async function summarizeTenants(
+  shared: AdminInsightSharedResources,
+  tenantIds: readonly string[],
+): Promise<TenantsSummaryResponse> {
+  // 重複除去 + 入力順を維持する uniqueIds。
+  const seen = new Set<string>();
+  const uniqueIds: string[] = [];
+  for (const id of tenantIds) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      uniqueIds.push(id);
+    }
+  }
+  const summaries = await Promise.all(
+    uniqueIds.map(async (tenantId): Promise<TenantSummary> => {
+      const [deploys, totalEvents] = await Promise.all([
+        countTenantDeployments(shared, tenantId),
+        countTenantEvents(shared, tenantId),
+      ]);
+      return {
+        tenantId,
+        activeDeploys: deploys.activeDeploys,
+        failedDeploys: deploys.failedDeploys,
+        totalEvents,
+      };
+    }),
+  );
+  return { items: summaries };
+}

--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -1,6 +1,6 @@
 import { CognitoAuth, ControlPlane } from "@cdklabs/sbt-aws";
 import * as cdk from "aws-cdk-lib";
-import type { CfnUserPoolClient, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import type { CfnUserPoolClient, IUserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
 import { EventBus, Rule } from "aws-cdk-lib/aws-events";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { Construct } from "constructs";
@@ -31,6 +31,17 @@ const LOCALHOST_CORS_ORIGINS = [
 export class ControlPlaneStack extends cdk.Stack {
   public readonly regApiGatewayUrl: string;
   public readonly eventBusArn: string;
+  /**
+   * SBT 内蔵 Cognito UserPool (= System Admin が登録される pool)。
+   * Issue #590 / ADR-011 (Phase 1.A) で AdminInsight HTTP API の JWT Authorizer に渡す。
+   * 同 pool の SystemAdmin group claim を required scope として扱う。
+   */
+  public readonly cognitoUserPool: IUserPool;
+  /**
+   * SBT 内蔵 UserPoolUserClient の client ID (= admin-console が OAuth Code+PKCE で使う)。
+   * AdminInsight HTTP API の JWT Authorizer も同 client を audience とみなす。
+   */
+  public readonly cognitoUserClientId: string;
 
   constructor(scope: Construct, id: string, props: ControlPlaneStackProps) {
     super(scope, id, props);
@@ -96,5 +107,9 @@ export class ControlPlaneStack extends cdk.Stack {
 
     this.eventBusArn = controlPlane.eventManager.busArn;
     this.regApiGatewayUrl = controlPlane.controlPlaneAPIGatewayUrl;
+    // SBT CognitoAuth が払い出した UserPool / UserClient を兄弟 stack
+    // (AdminConsoleInsightStack) の JWT Authorizer 用に export する。
+    this.cognitoUserPool = cognitoAuth.userPool;
+    this.cognitoUserClientId = cognitoAuth.userClientId;
   }
 }

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { CfnOutput } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
@@ -95,6 +96,18 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * 注入するため publicly export する (兄弟 deployApiLambda / eventApiLambda と同 pattern)。
    */
   public readonly participantPortalUrl?: string;
+  /**
+   * Deployments table (ADR-011 #590 で AdminConsoleInsightStack が read-only に
+   * 跨ぐため公開)。grantReadData は呼び出し側で行う。
+   */
+  public readonly deploymentsTable: Table;
+  /** Events table (ADR-011 #590 で AdminConsoleInsightStack が cross-stack read する)。 */
+  public readonly eventsTable: Table;
+  /**
+   * Teams table (ADR-011 Phase 1.B 以降で drill-down 用に読む)。Phase 1.A では
+   * 参照のみ (read 権限は付与しない)。
+   */
+  public readonly teamsTable: Table;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -104,6 +117,10 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     // Phase 2 で Bulk Deploy / Bulk Teardown を State Machine 経由で動かす。
     const events = new EventsTable(this, "Events");
     const teams = new TeamsTable(this, "Teams");
+    // ADR-011 #590: AdminConsoleInsightStack に cross-stack で渡すため expose する。
+    this.deploymentsTable = deployments.table;
+    this.eventsTable = events.table;
+    this.teamsTable = teams.table;
     const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。

--- a/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
+++ b/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
@@ -1,0 +1,169 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { UserPool } from "aws-cdk-lib/aws-cognito";
+import { Table } from "aws-cdk-lib/aws-dynamodb";
+import { describe, expect, it } from "vitest";
+import { AdminConsoleInsightStack } from "../../lib/admin-insight/admin-console-insight-stack";
+
+/**
+ * ADR-011 #590 Phase 1.A — AdminConsoleInsightStack の CFn 構造を assertion で固定する。
+ * cross-stack 参照を simulate するため UserPool / Tables は同 app 内 helper stack に作る。
+ */
+function synthInsightStack(adminConsoleOrigin?: string): Template {
+  const app = new cdk.App();
+  const fixtures = new cdk.Stack(app, "Fixtures", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const userPool = new UserPool(fixtures, "UserPool", {
+    selfSignUpEnabled: false,
+  });
+  const userPoolClient = userPool.addClient("UserClient");
+  const deployments = new Table(fixtures, "Deployments", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  const events = new Table(fixtures, "Events", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  const teams = new Table(fixtures, "Teams", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+
+  const stack = new AdminConsoleInsightStack(app, "InsightStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+    cognitoUserPool: userPool,
+    cognitoUserClientId: userPoolClient.userPoolClientId,
+    deploymentsTable: deployments,
+    eventsTable: events,
+    teamsTable: teams,
+    adminConsoleOrigin,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
+  describe("Lambda", () => {
+    it("AdminInsight Lambda を Node.js 20 / arm64 で 1 個 立てるべき", () => {
+      const tpl = synthInsightStack();
+      tpl.resourceCountIs("AWS::Lambda::Function", 1);
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs20.x",
+          Architectures: ["arm64"],
+        }),
+      );
+    });
+
+    it("Lambda env に Deployments / Events / Teams Table 名を渡すべき", () => {
+      const tpl = synthInsightStack();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              DEPLOYMENTS_TABLE_NAME: Match.anyValue(),
+              EVENTS_TABLE_NAME: Match.anyValue(),
+              TEAMS_TABLE_NAME: Match.anyValue(),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("HTTP API + Cognito JWT Authorizer", () => {
+    it("HTTP API (API GW v2) を 1 つ持つべき", () => {
+      const tpl = synthInsightStack();
+      tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 1);
+    });
+
+    it("JWT Authorizer (= Cognito UserPool 連動) を持つべき", () => {
+      const tpl = synthInsightStack();
+      tpl.hasResourceProperties(
+        "AWS::ApiGatewayV2::Authorizer",
+        Match.objectLike({
+          AuthorizerType: "JWT",
+          IdentitySource: ["$request.header.Authorization"],
+        }),
+      );
+    });
+
+    it("GET /admin/insight/tenants/summary route が JWT Authorizer に紐づくべき", () => {
+      const tpl = synthInsightStack();
+      const routes = tpl.findResources("AWS::ApiGatewayV2::Route", {
+        Properties: { RouteKey: "GET /admin/insight/tenants/summary" },
+      });
+      expect(Object.keys(routes)).toHaveLength(1);
+      const route = Object.values(routes)[0] as {
+        Properties: { AuthorizerId: unknown; AuthorizationType: string };
+      };
+      expect(route.Properties.AuthorizationType).toBe("JWT");
+      expect(route.Properties.AuthorizerId).toBeDefined();
+    });
+
+    it("CORS allowOrigins に localhost dev を入れるべき", () => {
+      const tpl = synthInsightStack();
+      tpl.hasResourceProperties(
+        "AWS::ApiGatewayV2::Api",
+        Match.objectLike({
+          CorsConfiguration: Match.objectLike({
+            AllowOrigins: Match.arrayWith([
+              "http://localhost:5173",
+              "http://localhost:4173",
+              "http://localhost:4180",
+            ]),
+            AllowMethods: Match.arrayWith(["GET", "OPTIONS"]),
+          }),
+        }),
+      );
+    });
+
+    it("CDK_PARAM_ADMIN_CONSOLE_ORIGIN 相当の adminConsoleOrigin を CORS に追加するべき", () => {
+      const tpl = synthInsightStack("https://abc.cloudfront.net");
+      tpl.hasResourceProperties(
+        "AWS::ApiGatewayV2::Api",
+        Match.objectLike({
+          CorsConfiguration: Match.objectLike({
+            AllowOrigins: Match.arrayWith(["https://abc.cloudfront.net"]),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("IAM 権限 (ADR-011 D6 read-only)", () => {
+    it("Deployments / Events Table の read のみを Allow するべき (write は禁止)", () => {
+      const tpl = synthInsightStack();
+      // Lambda role に attach された IAM Policy の中に DynamoDB write action が無いことを
+      // 強めに検証する (= 旧 grantReadWriteData で誤 wire したら test が落ちる)。
+      const policies = tpl.findResources("AWS::IAM::Policy");
+      const writeActions = ["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:DeleteItem"];
+      const allActions: string[] = [];
+      for (const p of Object.values(policies)) {
+        const statements = (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } })
+          .Properties?.PolicyDocument?.Statement;
+        for (const s of statements ?? []) {
+          const action = (s as { Action?: string | string[] }).Action;
+          if (Array.isArray(action)) allActions.push(...action);
+          else if (typeof action === "string") allActions.push(action);
+        }
+      }
+      for (const w of writeActions) {
+        expect(allActions).not.toContain(w);
+      }
+      // 同時に read action は最低 1 つ (Query / GetItem) 含むこと。
+      expect(allActions.some((a) => a === "dynamodb:Query" || a === "dynamodb:GetItem")).toBe(true);
+    });
+  });
+
+  describe("Outputs", () => {
+    it("AdminInsightApiUrl を Output として出すべき", () => {
+      const tpl = synthInsightStack();
+      const outputs = tpl.findOutputs("*");
+      expect(Object.keys(outputs)).toContain("AdminInsightApiUrl");
+    });
+  });
+});

--- a/infrastructure/test/admin-insight/admin-insight-routes.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-routes.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  summarizeTenants: vi.fn(),
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/shared", () => ({
+  buildSharedResources: () => ({
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send: vi.fn() },
+  }),
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/summary", () => ({
+  summarizeTenants: mocks.summarizeTenants,
+}));
+
+const { app } = await import("../../lib/admin-insight/handlers/admin-insight-handler/index");
+
+/**
+ * API GW v2 JWT Authorizer 経由で渡される event の最小 shape。
+ * `c.env.event.requestContext.authorizer.jwt.claims` に `cognito:groups` / `sub` を入れる
+ * (= handler の `isSystemAdmin` / `resolveCognitoSub` がこのパスを読む)。
+ */
+function withClaims(claims: Record<string, unknown>) {
+  return {
+    requestContext: {
+      authorizer: { jwt: { claims } },
+    },
+  };
+}
+
+describe("GET /admin/insight/tenants/summary", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin group claim があれば 200 を返すべき", async () => {
+    mocks.summarizeTenants.mockResolvedValueOnce({
+      items: [{ tenantId: "t-1", activeDeploys: 2, failedDeploys: 0, totalEvents: 3 }],
+    });
+    const res = await app.request(
+      "/admin/insight/tenants/summary?tenantIds=t-1",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "user-1" }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{ tenantId: string; activeDeploys: number }>;
+    };
+    expect(body.items[0].tenantId).toBe("t-1");
+  });
+
+  it("SystemAdmin claim 無し (Tenant Admin) は 403 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/summary?tenantIds=t-1",
+      {},
+      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "user-1" }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.summarizeTenants).not.toHaveBeenCalled();
+  });
+
+  it("claims が無い (= JWT 経路を通っていない) なら 403 を返すべき", async () => {
+    const res = await app.request("/admin/insight/tenants/summary?tenantIds=t-1");
+    expect(res.status).toBe(403);
+  });
+
+  it("cognito:groups が string で SystemAdmin を含むなら認可するべき", async () => {
+    mocks.summarizeTenants.mockResolvedValueOnce({ items: [] });
+    const res = await app.request(
+      "/admin/insight/tenants/summary?tenantIds=t-1",
+      {},
+      { event: withClaims({ "cognito:groups": "[SystemAdmin]", sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("tenantIds query が空なら 200 + 空 items を返すべき (DDB は叩かない)", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/summary",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ items: [] });
+    expect(mocks.summarizeTenants).not.toHaveBeenCalled();
+  });
+
+  it("不正な tenant ID 文字種 (例: `tenant 1` スペース) は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/summary?tenantIds=tenant%201",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.summarizeTenants).not.toHaveBeenCalled();
+  });
+
+  it("tenantIds 100 件超は 400", async () => {
+    const many = Array.from({ length: 101 }, (_, i) => `t${i}`).join(",");
+    const res = await app.request(
+      `/admin/insight/tenants/summary?tenantIds=${many}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.summarizeTenants).not.toHaveBeenCalled();
+  });
+
+  it("内部 throw は 500 + body { error: 'internal_error' } を返すべき", async () => {
+    mocks.summarizeTenants.mockRejectedValueOnce(new Error("ddb down"));
+    const res = await app.request(
+      "/admin/insight/tenants/summary?tenantIds=t-1",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("internal_error");
+    // message が body に漏れていないことも確認 (PR-570 同型の defensive 規約)。
+    expect(JSON.stringify(body)).not.toContain("ddb down");
+  });
+
+  it("ADR-011 D5 audit log: 各 read で admin.insight.read を console.log するべき", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    mocks.summarizeTenants.mockResolvedValueOnce({ items: [] });
+    await app.request(
+      "/admin/insight/tenants/summary?tenantIds=t-1",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "admin-sub-xyz" }) },
+    );
+    const calls = spy.mock.calls.map((c) => c[0]);
+    expect(
+      calls.some(
+        (c) =>
+          typeof c === "object" &&
+          c !== null &&
+          (c as { event?: string }).event === "admin.insight.read" &&
+          (c as { admin?: string }).admin === "admin-sub-xyz",
+      ),
+    ).toBe(true);
+    spy.mockRestore();
+  });
+});
+
+describe("GET /admin/insight/healthz", () => {
+  it("認可不要で 200 を返すべき (= API GW で除外する余地もあるが Lambda 側も対応)", async () => {
+    const res = await app.request("/admin/insight/healthz");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+});

--- a/infrastructure/test/admin-insight/auth.test.ts
+++ b/infrastructure/test/admin-insight/auth.test.ts
@@ -1,0 +1,60 @@
+import type { Context } from "hono";
+import { describe, expect, it } from "vitest";
+import {
+  isSystemAdmin,
+  resolveCognitoSub,
+} from "../../lib/admin-insight/handlers/admin-insight-handler/auth";
+
+function buildContext(claims?: Record<string, unknown>): Context {
+  return {
+    env: {
+      event: claims ? { requestContext: { authorizer: { jwt: { claims } } } } : undefined,
+    },
+  } as unknown as Context;
+}
+
+describe("isSystemAdmin", () => {
+  it("cognito:groups が string[] で SystemAdmin を含むなら true", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": ["SystemAdmin"] }))).toBe(true);
+  });
+
+  it("cognito:groups が string[] で SystemAdmin を含まないなら false", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": ["TenantAdmin"] }))).toBe(false);
+  });
+
+  it("cognito:groups が string で `[SystemAdmin]` 形式でも true", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": "[SystemAdmin]" }))).toBe(true);
+  });
+
+  it("cognito:groups が string で comma 区切りに SystemAdmin が混じるなら true", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": "Foo,SystemAdmin,Bar" }))).toBe(true);
+  });
+
+  it("cognito:groups が string で SystemAdmin を含まないなら false", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": "TenantAdmin" }))).toBe(false);
+  });
+
+  it("claim が無いなら false", () => {
+    expect(isSystemAdmin(buildContext())).toBe(false);
+    expect(isSystemAdmin(buildContext({}))).toBe(false);
+  });
+
+  it("cognito:groups が未知 type (例: number) なら false", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": 42 }))).toBe(false);
+  });
+});
+
+describe("resolveCognitoSub", () => {
+  it("sub claim があればその文字列を返すべき", () => {
+    expect(resolveCognitoSub(buildContext({ sub: "abc-123" }))).toBe("abc-123");
+  });
+
+  it("sub が無いなら 'unknown' を返すべき", () => {
+    expect(resolveCognitoSub(buildContext())).toBe("unknown");
+    expect(resolveCognitoSub(buildContext({}))).toBe("unknown");
+  });
+
+  it("sub が空文字なら 'unknown' を返すべき", () => {
+    expect(resolveCognitoSub(buildContext({ sub: "" }))).toBe("unknown");
+  });
+});

--- a/infrastructure/test/admin-insight/summary.test.ts
+++ b/infrastructure/test/admin-insight/summary.test.ts
@@ -1,0 +1,119 @@
+import type { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { summarizeTenants } from "../../lib/admin-insight/handlers/admin-insight-handler/summary";
+
+function buildShared(send: ReturnType<typeof vi.fn>) {
+  return {
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient,
+  };
+}
+
+describe("summarizeTenants", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("単一 tenant: active/failed deploy + total events を正しく集計するべき", async () => {
+    const send = vi.fn().mockImplementation(async (cmd: QueryCommand) => {
+      const tableName = cmd.input.TableName;
+      if (tableName === "TestDeployments") {
+        return {
+          Items: [
+            { status: "PENDING" },
+            { status: "IN_PROGRESS" },
+            { status: "IN_PROGRESS" },
+            { status: "FAILED" },
+            { status: "COMPLETE" }, // active / failed どちらでもないので counter には入らない
+            { status: "DELETED" },
+          ],
+        };
+      }
+      if (tableName === "TestEvents") {
+        return { Count: 7 };
+      }
+      throw new Error(`unexpected table: ${tableName}`);
+    });
+    const shared = buildShared(send);
+    const result = await summarizeTenants(shared, ["tenant-a"]);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      tenantId: "tenant-a",
+      activeDeploys: 3, // PENDING + IN_PROGRESS × 2
+      failedDeploys: 1,
+      totalEvents: 7,
+    });
+  });
+
+  it("重複 tenantId は 1 度しか query しないべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
+    const shared = buildShared(send);
+    await summarizeTenants(shared, ["tenant-a", "tenant-a", "tenant-a"]);
+    // 1 tenant あたり Deployments query + Events query = 2 invocation。
+    // 重複除去が効いていれば 2 回しか送らない。
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("結果順は入力順 (重複除去後) を保つべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
+    const shared = buildShared(send);
+    const result = await summarizeTenants(shared, ["tenant-c", "tenant-a", "tenant-b"]);
+    expect(result.items.map((i) => i.tenantId)).toEqual(["tenant-c", "tenant-a", "tenant-b"]);
+  });
+
+  it("空 tenantIds で空 items を返すべき (DDB を叩かない)", async () => {
+    const send = vi.fn();
+    const shared = buildShared(send);
+    const result = await summarizeTenants(shared, []);
+    expect(result.items).toEqual([]);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("page 跨ぎ (LastEvaluatedKey) があれば全 page 集計するべき", async () => {
+    let deployCall = 0;
+    const send = vi.fn().mockImplementation(async (cmd: QueryCommand) => {
+      const tableName = cmd.input.TableName;
+      if (tableName === "TestDeployments") {
+        deployCall += 1;
+        if (deployCall === 1) {
+          return {
+            Items: [{ status: "PENDING" }, { status: "FAILED" }],
+            LastEvaluatedKey: { PK: "DEPLOYMENT#x" },
+          };
+        }
+        return { Items: [{ status: "IN_PROGRESS" }] };
+      }
+      return { Count: 0 };
+    });
+    const shared = buildShared(send);
+    const result = await summarizeTenants(shared, ["tenant-a"]);
+    expect(result.items[0]).toMatchObject({
+      tenantId: "tenant-a",
+      activeDeploys: 2, // PENDING + IN_PROGRESS
+      failedDeploys: 1,
+    });
+  });
+
+  it("Deployments query は GSI1 + TENANT#<id> partition key を使うべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
+    const shared = buildShared(send);
+    await summarizeTenants(shared, ["tenant-acme"]);
+    const deployQuery = send.mock.calls
+      .map((call) => call[0] as QueryCommand)
+      .find((cmd) => cmd.input.TableName === "TestDeployments");
+    expect(deployQuery).toBeDefined();
+    expect(deployQuery?.input.IndexName).toBe("GSI1");
+    expect(deployQuery?.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+  });
+
+  it("Events query は Select=COUNT で payload を最小化するべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
+    const shared = buildShared(send);
+    await summarizeTenants(shared, ["tenant-acme"]);
+    const eventsQuery = send.mock.calls
+      .map((call) => call[0] as QueryCommand)
+      .find((cmd) => cmd.input.TableName === "TestEvents");
+    expect(eventsQuery).toBeDefined();
+    expect(eventsQuery?.input.Select).toBe("COUNT");
+  });
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,6 +132,7 @@ bunx cdk deploy \
   tenkacloud-control-plane \
   tenkacloud-bootstrap \
   tenkacloud-problem-deploy \
+  tenkacloud-admin-console-insight \
   tenkacloud-tenant-template-pooled \
   tenkacloud-saas-pipeline \
   --require-approval never --concurrency 4
@@ -188,6 +189,18 @@ if [ -z "${PROVISIONING_CODEBUILD_PROJECT}" ]; then
 fi
 echo "  Provisioning CodeBuild Project: ${PROVISIONING_CODEBUILD_PROJECT}"
 
+# ADR-011 #590 Phase 1.A: AdminConsole Insight API URL を runtime-config に注入する。
+# Phase 1 で立てた tenkacloud-admin-console-insight stack の CFn output を取得。
+ADMIN_INSIGHT_API_URL=$(aws cloudformation describe-stacks \
+  --stack-name "tenkacloud-admin-console-insight" \
+  --query "Stacks[0].Outputs[?OutputKey=='AdminInsightApiUrl'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+if [ -z "${ADMIN_INSIGHT_API_URL}" ]; then
+  echo "  Warning: AdminInsightApiUrl が解決できない (admin-console の集計 column は無効化される)"
+  ADMIN_INSIGHT_API_URL=""
+fi
+echo "  AdminInsight API URL: ${ADMIN_INSIGHT_API_URL}"
+
 # AdminConsoleHostingStack deploy: backend outputs を CDK_PARAM_* env に渡す
 # (stack が runtime-config.json に書いて S3 に配置する)
 cd "${TenkaCloud_ROOT}/infrastructure"
@@ -198,6 +211,7 @@ export CDK_PARAM_POOLED_APP_CONSOLE_URL="${POOLED_APP_CONSOLE_URL}"
 export CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT="${PROVISIONING_CODEBUILD_PROJECT}"
 export CDK_PARAM_AWS_REGION="${REGION}"
 export CDK_PARAM_AWS_ACCOUNT_ID="${ACCOUNT_ID}"
+export CDK_PARAM_ADMIN_INSIGHT_API_URL="${ADMIN_INSIGHT_API_URL}"
 bunx cdk deploy tenkacloud-admin-console-hosting --require-approval never
 
 # ============================================================================


### PR DESCRIPTION
## Summary

ADR-011 (PR-593) Phase 1.A 実装。System Admin が admin-console から cross-tenant に deploy 進捗を観察できる経路を新設。tenant 一覧 → 各 tenant の Active / Failed deployment 件数を Cloudscape badge で表示。

## 決定 (ADR-011 D1-D6 採択)

- **D1**: 新 Lambda `AdminInsightApiLambda` を新 stack `AdminConsoleInsightStack` に分離
- **D2**: SBT 標準 SystemAdmin group claim で authorize
- **D3**: 4 段 drill-down のうち **L1 (tenant summary) のみ本 PR**、L2-L4 は follow-up
- **D4**: same-account CFn Describe (Phase 1)
- **D5**: CloudWatch Logs structured log で監査
- **D6**: read-only (GET のみ)

## 変更点

| 場所 | 種別 | 内容 |
|---|---|---|
| `infrastructure/lib/admin-insight/` | 新規 directory | Stack / Lambda / handlers (auth, summary, shared) |
| `infrastructure/bin/infrastructure.ts` | UPDATE | AdminConsoleInsightStack 配線 |
| `infrastructure/lib/control-plane-stack.ts` | UPDATE | UserPool output 追加 (insight stack へ参照) |
| `infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts` | UPDATE | Deployments / Events table の cross-stack export |
| `infrastructure/lib/admin-console-hosting.ts` | UPDATE | insight API URL を runtime-config 経由で注入 |
| `scripts/install.sh` | UPDATE | deploy 経路に insight stack 追加 |
| `apps/admin-console/src/api/insight.ts` | 新規 | insight API client |
| `apps/admin-console/src/pages/TenantList.tsx` | UPDATE | Active / Failed Deploys 2 column 追加 |

## Regression 分析

- ✅ 既存 ControlPlane / SBT 配線: UserPool output 追加のみ、tenant CRUD 無変更
- ✅ 既存 admin-console TenantList: 新 column 追加のみ、tenant 表示は無変更
- ✅ Application Plane: read-only access、書き込み権限なし
- ✅ Tenant 跨ぎ防御: SystemAdmin group claim 検査で 403
- ✅ 全 681/681 tests pass (= infra 453 / admin 60 / app-admin 101 / portal 67)

## 物理影響

- **CREATE**: 新 stack `AdminConsoleInsightStack` (HTTP API + Lambda + IAM + log group)
- **UPDATE**: `ControlPlaneStack` / `ProblemDeployBackendStack` / `AdminConsoleHostingStack` (cross-stack output 追加 + runtime-config 注入)
- **NO-OP**: DDB table、tenant API、Worker Lambda、CodeBuild

## Test plan

- [x] typecheck (4 packages) green
- [x] vitest 全 workspace → 681/681
- [x] biome / textlint / check-http-status / validate-problems green
- [ ] deploy 後: admin-console TenantList で Active / Failed Deploys 表示、Tenant Admin から `/admin/insight/*` 叩くと 403

## Follow-up (Phase 1.B、別 PR)

- `/admin/insight/tenants/{tenantId}/events*` (L2-L4)
- 対応する admin-console 新 page (TenantEvents / EventDetail / DeploymentDetail)

Relates #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deployment health metrics to tenant management, displaying per-tenant active and failed deployment counts with automatic refresh
  * Gracefully handles unavailable metrics without affecting core tenant administration functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/597)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->