### PR TITLE
feat(#598): Phase 1.B admin drill-down — events / event detail / deploy job

### DIFF
--- a/apps/admin-console/src/App.tsx
+++ b/apps/admin-console/src/App.tsx
@@ -3,9 +3,12 @@ import { Navigate, Route, Routes } from "react-router";
 import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
+import { AdminDeploymentDetailPage } from "./pages/AdminDeploymentDetail";
+import { AdminEventDetailPage } from "./pages/AdminEventDetail";
 import { CallbackPage } from "./pages/Callback";
 import { LoginPage } from "./pages/Login";
 import { TenantCreatePage } from "./pages/TenantCreate";
+import { TenantEventsPage } from "./pages/TenantEvents";
 import { TenantListPage } from "./pages/TenantList";
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -37,6 +40,37 @@ export function App({ config }: { config: AppConfig }) {
             <RequireAuth>
               <ShellLayout>
                 <TenantCreatePage config={config} />
+              </ShellLayout>
+            </RequireAuth>
+          }
+        />
+        {/* Phase 1.B drill-down (ADR-011 / #598) */}
+        <Route
+          path="/tenants/:tenantId/events"
+          element={
+            <RequireAuth>
+              <ShellLayout>
+                <TenantEventsPage config={config} />
+              </ShellLayout>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/tenants/:tenantId/events/:eventId"
+          element={
+            <RequireAuth>
+              <ShellLayout>
+                <AdminEventDetailPage config={config} />
+              </ShellLayout>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/tenants/:tenantId/deployments/:jobId"
+          element={
+            <RequireAuth>
+              <ShellLayout>
+                <AdminDeploymentDetailPage config={config} />
               </ShellLayout>
             </RequireAuth>
           }

--- a/apps/admin-console/src/api/admin-drill-down.ts
+++ b/apps/admin-console/src/api/admin-drill-down.ts
@@ -1,0 +1,295 @@
+import { StatusCodes } from "http-status-codes";
+import type { AppConfig } from "../config";
+
+/**
+ * ADR-011 / #598 Phase 1.B drill-down 用 API client。
+ *
+ * AdminInsight API は ControlPlane API とは別 origin (= API GW HTTP API) で動く。
+ * 既存の `ApiClient` は ControlPlane base URL に固定で使えないため、専用 fetch 関数を
+ * 用意する。
+ *
+ * 全 endpoint で:
+ *   - `config.adminInsightApiUrl` が空文字なら **null を返す** (= 未配線、UI は読み込み中扱い)
+ *   - 403 (SystemAdmin claim 無し) は `PortalForbiddenError` で throw → caller が
+ *     「権限不足」 banner を出す
+ *   - 404 / 409 は ApiError として throw (status を保ったまま) → caller が分岐
+ *   - その他 5xx / network error は通常の Error
+ */
+
+export type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "ENDED" | "TEARDOWN" | "ARCHIVED";
+export type DeploymentStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "COMPLETE"
+  | "FAILED"
+  | "DELETING"
+  | "DELETED";
+
+export interface EventSummary {
+  readonly eventId: string;
+  readonly name: string;
+  readonly status: EventStatus;
+  readonly teamCount: number;
+  readonly problemCount: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+  readonly scoringLocked?: boolean;
+  readonly scoringLockedAt?: string;
+}
+
+export interface ListEventsResponse {
+  readonly items: readonly EventSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface EventProblemTarget {
+  readonly problemId: string;
+  readonly defaultAwsAccountId?: string;
+  readonly defaultRegion: string;
+}
+
+export interface TeamSummary {
+  readonly teamId: string;
+  readonly internalSlug: string;
+  readonly displayName?: string;
+  /**
+   * **System Admin 経路では常に undefined**。backend (`redactTeams`) が必ず潰す。
+   * shape 上 field を残すのは、application-admin-console mirror が同じ shape を読むため。
+   */
+  readonly teamLoginKey?: string;
+  readonly awsAccountId?: string;
+}
+
+export interface EventDeploymentSummary {
+  readonly jobId: string;
+  readonly teamId: string;
+  readonly status: DeploymentStatus;
+}
+
+export interface EventDetail extends EventSummary {
+  readonly problems: readonly EventProblemTarget[];
+  readonly teams: readonly TeamSummary[];
+  readonly deploymentsByProblem: Readonly<Record<string, readonly EventDeploymentSummary[]>>;
+}
+
+export interface DeploymentDetail {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly region: string;
+  readonly teamName: string;
+  readonly displayTeamName?: string;
+  readonly namePrefix: string;
+  readonly status: DeploymentStatus;
+  readonly stackId?: string;
+  readonly stackOutputs?: string;
+  readonly failureReason?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+  readonly eventId?: string;
+  readonly teamId?: string;
+  /** **常に undefined**。System Admin 経路では露出しない。 */
+  readonly teamLoginKey?: undefined;
+}
+
+export interface StackProgressEvent {
+  readonly timestamp: string;
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+}
+
+export interface StackProgressResource {
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+  readonly physicalResourceId?: string;
+}
+
+export interface StackProgress {
+  readonly jobId: string;
+  readonly stackName: string;
+  readonly region: string;
+  readonly consoleUrl: string;
+  readonly events: readonly StackProgressEvent[];
+  readonly resources: readonly StackProgressResource[];
+  readonly stackStatus?: string;
+}
+
+export class AdminInsightApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(`AdminInsight API ${status}: ${message}`);
+    this.name = "AdminInsightApiError";
+  }
+}
+
+function buildBaseUrl(config: AppConfig): string | null {
+  if (!config.adminInsightApiUrl) return null;
+  return config.adminInsightApiUrl.endsWith("/")
+    ? config.adminInsightApiUrl
+    : `${config.adminInsightApiUrl}/`;
+}
+
+async function adminInsightGet<T>(
+  config: AppConfig,
+  idToken: string,
+  pathWithQuery: string,
+): Promise<T | null> {
+  const base = buildBaseUrl(config);
+  if (!base) return null;
+  const url = new URL(pathWithQuery.replace(/^\//, ""), base);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${idToken}`,
+      "content-type": "application/json",
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new AdminInsightApiError(res.status, detail || res.statusText);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * GET /admin/insight/tenants/{tenantId}/events
+ */
+export async function fetchTenantEvents(
+  config: AppConfig,
+  idToken: string,
+  tenantId: string,
+  options: { limit?: number; cursor?: string } = {},
+): Promise<ListEventsResponse | null> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.cursor) params.set("cursor", options.cursor);
+  const qs = params.toString();
+  const path = `admin/insight/tenants/${encodeURIComponent(tenantId)}/events${qs ? `?${qs}` : ""}`;
+  return adminInsightGet<ListEventsResponse>(config, idToken, path);
+}
+
+/**
+ * GET /admin/insight/tenants/{tenantId}/events/{eventId}
+ *
+ * 404 (event 不在) は `AdminInsightApiError` で throw する (= status を残して caller 分岐)。
+ */
+export async function fetchTenantEventDetail(
+  config: AppConfig,
+  idToken: string,
+  tenantId: string,
+  eventId: string,
+): Promise<EventDetail | null> {
+  const path = `admin/insight/tenants/${encodeURIComponent(tenantId)}/events/${encodeURIComponent(
+    eventId,
+  )}`;
+  return adminInsightGet<EventDetail>(config, idToken, path);
+}
+
+/**
+ * GET /admin/insight/tenants/{tenantId}/deployments/{jobId}
+ */
+export async function fetchTenantDeploymentDetail(
+  config: AppConfig,
+  idToken: string,
+  tenantId: string,
+  jobId: string,
+): Promise<DeploymentDetail | null> {
+  const path = `admin/insight/tenants/${encodeURIComponent(tenantId)}/deployments/${encodeURIComponent(
+    jobId,
+  )}`;
+  return adminInsightGet<DeploymentDetail>(config, idToken, path);
+}
+
+/**
+ * GET /admin/insight/tenants/{tenantId}/deployments/{jobId}/stack-progress
+ *
+ * 409 (stack 未割当 = deploy 極初期) は AdminInsightApiError で throw する。
+ * caller (AdminDeploymentDetail) が status を見て「準備中」表示に切替える。
+ */
+export async function fetchTenantStackProgress(
+  config: AppConfig,
+  idToken: string,
+  tenantId: string,
+  jobId: string,
+): Promise<StackProgress | null> {
+  const path = `admin/insight/tenants/${encodeURIComponent(tenantId)}/deployments/${encodeURIComponent(
+    jobId,
+  )}/stack-progress`;
+  return adminInsightGet<StackProgress>(config, idToken, path);
+}
+
+/**
+ * CFn ResourceStatus を Cloudscape の StatusIndicator type に map する。
+ * application-admin-console の `statusToIndicator` と同じセマンティクス。
+ */
+export function cfnStatusToIndicator(
+  status: string,
+): "success" | "error" | "in-progress" | "warning" | "stopped" {
+  if (status === "DELETE_COMPLETE") return "stopped";
+  if (status.endsWith("_FAILED")) return "error";
+  if (status.includes("ROLLBACK")) return "warning";
+  if (status.endsWith("_COMPLETE")) return "success";
+  return "in-progress";
+}
+
+/**
+ * Deployment status → StatusIndicator type の固定 map。
+ */
+export const DEPLOYMENT_STATUS_INDICATOR: Record<
+  DeploymentStatus,
+  "pending" | "in-progress" | "success" | "error" | "stopped"
+> = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "success",
+  FAILED: "error",
+  DELETING: "in-progress",
+  DELETED: "stopped",
+};
+
+/**
+ * `StatusCodes.CONFLICT` 等で判定するときの shorthand。
+ * caller: `if (err instanceof AdminInsightApiError && err.status === StatusCodes.CONFLICT)`
+ */
+export const ADMIN_INSIGHT_STATUS = StatusCodes;
+
+/**
+ * `stackOutputs` 文字列を `{key: value}` map に変換。
+ * deploy-client.ts の `parseStackOutputs` と同等。
+ */
+export function parseStackOutputs(json: string | undefined): Record<string, string> {
+  if (!json) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object") return {};
+  const out: Record<string, string> = {};
+  if (Array.isArray(parsed)) {
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object") {
+        const k = (entry as { OutputKey?: unknown }).OutputKey;
+        const v = (entry as { OutputValue?: unknown }).OutputValue;
+        if (typeof k === "string" && typeof v === "string") out[k] = v;
+      }
+    }
+    return out;
+  }
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}

--- a/apps/admin-console/src/pages/AdminDeploymentDetail.tsx
+++ b/apps/admin-console/src/pages/AdminDeploymentDetail.tsx
@@ -1,0 +1,461 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { StatusCodes } from "http-status-codes";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import {
+  AdminInsightApiError,
+  cfnStatusToIndicator,
+  DEPLOYMENT_STATUS_INDICATOR,
+  type DeploymentDetail,
+  fetchTenantDeploymentDetail,
+  fetchTenantStackProgress,
+  parseStackOutputs,
+  type StackProgress,
+  type StackProgressEvent,
+  type StackProgressResource,
+} from "../api/admin-drill-down";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * Phase 1.B drill-down — Deploy job 詳細 (read-only mirror、ADR-011 / #598)。
+ *
+ * Application Admin Console の DeploymentDetail.tsx と異なる点:
+ *   - read-only。**「削除」 button は持たない** (= SystemAdmin は tenant の deploy を削除しない)
+ *   - 「競技者 hand-off」 (= teamLoginKey 表示) section は **無い**。SystemAdmin 経路では
+ *     一切露出しない (ADR-011 D2)
+ *
+ * polling 5s で基本情報 + CFn StackProgress を更新する (= operator UX を Tenant Admin
+ * console と揃える)。Terminal status (COMPLETE / FAILED / DELETED) に遷移したら停止。
+ */
+const POLL_INTERVAL_MS = 5_000;
+const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const TERMINAL_STATUSES = new Set(["COMPLETE", "FAILED", "DELETED"]);
+
+export function AdminDeploymentDetailPage({ config }: { config: AppConfig }) {
+  const { tenantId, jobId } = useParams<{ tenantId: string; jobId: string }>();
+  const navigate = useNavigate();
+  const auth = useAuth();
+  const [item, setItem] = useState<DeploymentDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [stackProgress, setStackProgress] = useState<StackProgress | null>(null);
+  const [stackProgressError, setStackProgressError] = useState<{
+    message: string;
+    notYetCreated: boolean;
+  } | null>(null);
+  const [stackProgressPending, setStackProgressPending] = useState(false);
+  const stopPollingRef = useRef(false);
+
+  const idToken = auth.tokens?.idToken;
+
+  const fetchDetail = useCallback(async () => {
+    if (!idToken || !tenantId || !jobId) return;
+    try {
+      const res = await fetchTenantDeploymentDetail(config, idToken, tenantId, jobId);
+      if (res === null) return; // adminInsightApiUrl 未配線
+      setItem(res);
+      setError(null);
+      setForbidden(false);
+      setNotFound(false);
+      if (TERMINAL_STATUSES.has(res.status)) stopPollingRef.current = true;
+    } catch (err) {
+      if (err instanceof AdminInsightApiError) {
+        if (err.status === StatusCodes.FORBIDDEN) {
+          setForbidden(true);
+          return;
+        }
+        if (err.status === StatusCodes.NOT_FOUND) {
+          setNotFound(true);
+          return;
+        }
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [config, idToken, tenantId, jobId]);
+
+  const fetchProgress = useCallback(async () => {
+    if (!idToken || !tenantId || !jobId) return;
+    setStackProgressPending(true);
+    try {
+      const res = await fetchTenantStackProgress(config, idToken, tenantId, jobId);
+      if (res === null) return;
+      setStackProgress(res);
+      setStackProgressError(null);
+    } catch (err) {
+      const notYetCreated =
+        err instanceof AdminInsightApiError && err.status === StatusCodes.CONFLICT;
+      const message = err instanceof Error ? err.message : String(err);
+      setStackProgressError({ message, notYetCreated });
+    } finally {
+      setStackProgressPending(false);
+    }
+  }, [config, idToken, tenantId, jobId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    stopPollingRef.current = false;
+    const tick = async () => {
+      if (cancelled || stopPollingRef.current) return;
+      await Promise.all([fetchDetail(), fetchProgress()]);
+    };
+    void tick();
+    const handle = window.setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [fetchDetail, fetchProgress]);
+
+  if (!tenantId || !jobId || !JOB_ID_RE.test(jobId)) {
+    return <Alert type="error">不正なパラメータです。</Alert>;
+  }
+
+  if (forbidden) {
+    return (
+      <Alert type="error" header="権限がありません">
+        この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。
+      </Alert>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <SpaceBetween size="l">
+        <Header
+          variant="h1"
+          actions={
+            <Button
+              variant="normal"
+              onClick={() => navigate(`/tenants/${encodeURIComponent(tenantId)}/events`)}
+            >
+              Event 一覧に戻る
+            </Button>
+          }
+        >
+          Deploy Job が見つかりません
+        </Header>
+        <Alert type="warning">
+          Tenant {tenantId} に Job {jobId} は存在しません。
+        </Alert>
+      </SpaceBetween>
+    );
+  }
+
+  if (!item && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 状態を取得中…
+      </Box>
+    );
+  }
+
+  if (error && !item) {
+    return (
+      <Alert type="error" header="Deploy Job 詳細の取得に失敗しました">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!item) return null;
+
+  const outputs = parseStackOutputs(item.stackOutputs);
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={
+          <>
+            Tenant: <code>{tenantId}</code> / Job ID: <code>{item.jobId}</code>
+          </>
+        }
+        actions={
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="normal"
+              onClick={() => navigate(`/tenants/${encodeURIComponent(tenantId)}/events`)}
+            >
+              Event 一覧に戻る
+            </Button>
+            {item.eventId && (
+              <Button
+                variant="normal"
+                onClick={() => {
+                  const parentEventId = item.eventId;
+                  if (parentEventId) {
+                    navigate(
+                      `/tenants/${encodeURIComponent(tenantId)}/events/${encodeURIComponent(parentEventId)}`,
+                    );
+                  }
+                }}
+              >
+                親 Event に戻る
+              </Button>
+            )}
+          </SpaceBetween>
+        }
+      >
+        Deploy「{item.displayTeamName ?? item.teamName}」
+      </Header>
+
+      {error && (
+        <Alert
+          type="warning"
+          header="再読み込みに失敗しました"
+          dismissible
+          onDismiss={() => setError(null)}
+        >
+          {error}
+        </Alert>
+      )}
+
+      <Container header={<Header variant="h2">ステータス</Header>}>
+        <SpaceBetween size="m">
+          <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>
+            {item.status}
+          </StatusIndicator>
+          {item.status === "FAILED" && item.failureReason && (
+            <Alert type="error" header="失敗理由">
+              {item.failureReason}
+            </Alert>
+          )}
+          {!TERMINAL_STATUSES.has(item.status) && (
+            <Box variant="small" color="text-status-info">
+              {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+            </Box>
+          )}
+        </SpaceBetween>
+      </Container>
+
+      <Container header={<Header variant="h2">基本情報</Header>}>
+        <ColumnLayout columns={2} variant="text-grid">
+          <KeyValuePairs
+            items={[
+              { label: "Problem ID", value: <code>{item.problemId}</code> },
+              { label: "表示名 (競技者選択)", value: item.displayTeamName ?? "(未設定)" },
+              { label: "内部 slug (operator 入力)", value: <code>{item.teamName}</code> },
+              { label: "AWS Account", value: <code>{item.awsAccountId}</code> },
+              { label: "Region", value: item.region },
+            ]}
+          />
+          <KeyValuePairs
+            items={[
+              { label: "Stack 名 prefix", value: <code>{item.namePrefix}</code> },
+              {
+                label: "Stack ID",
+                value: item.stackId ? <code>{item.stackId}</code> : "(未割当)",
+              },
+              { label: "作成", value: item.createdAt },
+              { label: "更新", value: item.updatedAt },
+              {
+                label: "Event ID",
+                value: item.eventId ? <code>{item.eventId}</code> : "(該当なし)",
+              },
+            ]}
+          />
+        </ColumnLayout>
+        <Box variant="small" color="text-status-info" padding={{ top: "s" }}>
+          ※ ログインキー (`teamLoginKey`) は SystemAdmin 経路では露出しません (ADR-011 D2)。
+        </Box>
+      </Container>
+
+      <StackProgressSection
+        progress={stackProgress}
+        error={stackProgressError}
+        pending={stackProgressPending}
+      />
+
+      {Object.keys(outputs).length > 0 && (
+        <Container header={<Header variant="h2">CloudFormation Outputs</Header>}>
+          <KeyValuePairs
+            items={Object.entries(outputs).map(([label, value]) => ({
+              label,
+              value: <code>{value}</code>,
+            }))}
+          />
+        </Container>
+      )}
+    </SpaceBetween>
+  );
+}
+
+/**
+ * CFn 進行状況セクション。application-admin-console の StackProgressSection と
+ * **同じ shape / behaviour** だが、read-only なので 「再試行」 button は持たない。
+ */
+function StackProgressSection(props: {
+  readonly progress: StackProgress | null;
+  readonly error: { message: string; notYetCreated: boolean } | null;
+  readonly pending: boolean;
+}) {
+  const { progress, error, pending } = props;
+
+  if (!progress && !error && pending) {
+    return (
+      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
+        <Box textAlign="center" padding="m">
+          <Spinner /> CFn から取得中…
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error && !progress) {
+    return (
+      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
+        {error.notYetCreated ? (
+          <Box color="text-status-info">
+            CFn Stack はまだ作成されていません。deploy worker が起動し次第、ここに StackEvents /
+            Resources が表示されます。
+          </Box>
+        ) : (
+          <Alert type="warning" header="CFn の進行状況を取得できませんでした">
+            {error.message}
+          </Alert>
+        )}
+      </Container>
+    );
+  }
+
+  if (!progress) return null;
+
+  const firstFailure = progress.events.find((e) => e.resourceStatus.endsWith("_FAILED"));
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={
+            progress.stackStatus
+              ? `現在の CFn Stack 状態: ${progress.stackStatus}`
+              : "CFn StackEvents / Resources を CFn API から直接取得しています。"
+          }
+          actions={
+            <Link href={progress.consoleUrl} external>
+              CFn console を開く
+            </Link>
+          }
+        >
+          Stack 進行状況
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {firstFailure && (
+          <Alert type="error" header={`失敗: ${firstFailure.logicalResourceId}`}>
+            <Box>
+              <code>{firstFailure.resourceType}</code> が <code>{firstFailure.resourceStatus}</code>{" "}
+              になりました。
+            </Box>
+            {firstFailure.resourceStatusReason && (
+              <Box variant="small">{firstFailure.resourceStatusReason}</Box>
+            )}
+          </Alert>
+        )}
+
+        <Table<StackProgressEvent>
+          variant="embedded"
+          header={<Header variant="h3">StackEvents (最新 {progress.events.length} 件)</Header>}
+          items={[...progress.events]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              StackEvents はまだありません。
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: "timestamp",
+              header: "時刻",
+              cell: (e) => e.timestamp,
+              width: 200,
+            },
+            {
+              id: "logicalResourceId",
+              header: "LogicalId",
+              cell: (e) => <code>{e.logicalResourceId}</code>,
+              width: 220,
+            },
+            {
+              id: "resourceType",
+              header: "Type",
+              cell: (e) => <code>{e.resourceType}</code>,
+              width: 220,
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (e) => (
+                <StatusIndicator type={cfnStatusToIndicator(e.resourceStatus)}>
+                  {e.resourceStatus}
+                </StatusIndicator>
+              ),
+              width: 240,
+            },
+            {
+              id: "reason",
+              header: "Reason",
+              cell: (e) => e.resourceStatusReason ?? "",
+            },
+          ]}
+        />
+
+        <Table<StackProgressResource>
+          variant="embedded"
+          header={<Header variant="h3">Resources ({progress.resources.length} 件)</Header>}
+          items={[...progress.resources]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              Resources はまだ作成されていません。
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: "logicalResourceId",
+              header: "LogicalId",
+              cell: (r) => <code>{r.logicalResourceId}</code>,
+              width: 220,
+            },
+            {
+              id: "resourceType",
+              header: "Type",
+              cell: (r) => <code>{r.resourceType}</code>,
+              width: 220,
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (r) => (
+                <StatusIndicator type={cfnStatusToIndicator(r.resourceStatus)}>
+                  {r.resourceStatus}
+                </StatusIndicator>
+              ),
+              width: 240,
+            },
+            {
+              id: "physicalResourceId",
+              header: "PhysicalId",
+              cell: (r) => (r.physicalResourceId ? <code>{r.physicalResourceId}</code> : ""),
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/apps/admin-console/src/pages/AdminEventDetail.tsx
+++ b/apps/admin-console/src/pages/AdminEventDetail.tsx
@@ -1,0 +1,357 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table from "@cloudscape-design/components/table";
+import { StatusCodes } from "http-status-codes";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import {
+  AdminInsightApiError,
+  type DeploymentStatus,
+  type EventDeploymentSummary,
+  type EventDetail,
+  type EventStatus,
+  fetchTenantEventDetail,
+  type TeamSummary,
+} from "../api/admin-drill-down";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * Phase 1.B drill-down — Event 詳細 (read-only mirror、ADR-011 / #598)。
+ *
+ * Application Admin Console の EventDetail.tsx と異なる点:
+ *   - read-only。Bulk Deploy / Archive / Schedule の **operator 操作 button は持たない**
+ *   - `teamLoginKey` は **`••••` で blackout**。backend が undefined を返す前提だが、
+ *     仮に何らかで残ってもここで再度マスクする (= 二重防御)
+ *
+ * polling 30s。Event detail は team / deploy job 状況が動くので、それなりに頻度を上げる。
+ */
+const POLL_INTERVAL_MS = 30_000;
+const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
+  DRAFT: "blue",
+  DEPLOYING: "blue",
+  READY: "green",
+  ENDED: "grey",
+  TEARDOWN: "red",
+  ARCHIVED: "grey",
+};
+
+const DEPLOY_STATUS_COLOR: Record<DeploymentStatus, "blue" | "green" | "grey" | "red"> = {
+  PENDING: "grey",
+  IN_PROGRESS: "blue",
+  COMPLETE: "green",
+  FAILED: "red",
+  DELETING: "grey",
+  DELETED: "grey",
+};
+
+/**
+ * teamLoginKey は **black-out**。backend は undefined を返すが、UI 側でも常に `••••` 表示で
+ * 「ここには見えないし、見せない」 という意図を明示する (= ADR-011 D2)。
+ */
+function renderTeamLoginKeyBlackout() {
+  return (
+    <Box variant="small" color="text-status-inactive">
+      ••••
+    </Box>
+  );
+}
+
+function renderProblemDeployStatus(deployments: readonly EventDeploymentSummary[] | undefined) {
+  if (!deployments || deployments.length === 0) {
+    return (
+      <Box variant="small" color="text-status-inactive">
+        未デプロイ
+      </Box>
+    );
+  }
+  const total = deployments.length;
+  const complete = deployments.filter((d) => d.status === "COMPLETE").length;
+  const failed = deployments.filter((d) => d.status === "FAILED").length;
+  const inFlight = deployments.filter(
+    (d) => d.status === "PENDING" || d.status === "IN_PROGRESS",
+  ).length;
+  return (
+    <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+      <Box variant="strong">
+        {complete} / {total}
+      </Box>
+      {failed > 0 && <Badge color="red">FAILED {failed}</Badge>}
+      {inFlight > 0 && <Badge color="blue">進行中 {inFlight}</Badge>}
+    </SpaceBetween>
+  );
+}
+
+export function AdminEventDetailPage({ config }: { config: AppConfig }) {
+  const { tenantId, eventId } = useParams<{ tenantId: string; eventId: string }>();
+  const navigate = useNavigate();
+  const auth = useAuth();
+  const [detail, setDetail] = useState<EventDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  const idToken = auth.tokens?.idToken;
+
+  const fetchOnce = useCallback(async () => {
+    if (!idToken || !tenantId || !eventId) return;
+    try {
+      const res = await fetchTenantEventDetail(config, idToken, tenantId, eventId);
+      if (res === null) return; // adminInsightApiUrl 未配線
+      setDetail(res);
+      setError(null);
+      setForbidden(false);
+      setNotFound(false);
+    } catch (err) {
+      if (err instanceof AdminInsightApiError) {
+        if (err.status === StatusCodes.FORBIDDEN) {
+          setForbidden(true);
+          return;
+        }
+        if (err.status === StatusCodes.NOT_FOUND) {
+          setNotFound(true);
+          return;
+        }
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [config, idToken, tenantId, eventId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await fetchOnce();
+    };
+    void tick();
+    const handle = window.setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [fetchOnce]);
+
+  if (!tenantId || !eventId || !EVENT_ID_RE.test(eventId)) {
+    return <Alert type="error">不正なパラメータです。</Alert>;
+  }
+
+  if (forbidden) {
+    return (
+      <Alert type="error" header="権限がありません">
+        この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。
+      </Alert>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <SpaceBetween size="l">
+        <Header
+          variant="h1"
+          actions={
+            <Button
+              variant="normal"
+              onClick={() => navigate(`/tenants/${encodeURIComponent(tenantId)}/events`)}
+            >
+              Event 一覧に戻る
+            </Button>
+          }
+        >
+          Event が見つかりません
+        </Header>
+        <Alert type="warning">
+          Tenant {tenantId} に event {eventId} は存在しません。
+        </Alert>
+      </SpaceBetween>
+    );
+  }
+
+  if (!detail && !error) {
+    return (
+      <Box textAlign="center" padding="l">
+        <Spinner /> 状態を取得中…
+      </Box>
+    );
+  }
+
+  if (error && !detail) {
+    return (
+      <Alert type="error" header="Event 詳細の取得に失敗しました">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!detail) return null;
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={
+          <>
+            Tenant: <code>{tenantId}</code> / Event ID: <code>{detail.eventId}</code>
+          </>
+        }
+        actions={
+          <Button
+            variant="normal"
+            onClick={() => navigate(`/tenants/${encodeURIComponent(tenantId)}/events`)}
+          >
+            Event 一覧に戻る
+          </Button>
+        }
+      >
+        {detail.name}
+      </Header>
+
+      {error && (
+        <Alert
+          type="warning"
+          header="再読み込みに失敗しました"
+          dismissible
+          onDismiss={() => setError(null)}
+        >
+          {error}
+        </Alert>
+      )}
+
+      <Container header={<Header variant="h2">サマリー</Header>}>
+        <KeyValuePairs
+          columns={3}
+          items={[
+            {
+              label: "ステータス",
+              value: <Badge color={STATUS_COLOR[detail.status]}>{detail.status}</Badge>,
+            },
+            { label: "チーム数", value: detail.teamCount },
+            { label: "問題数", value: detail.problemCount },
+            { label: "作成", value: detail.createdAt },
+            { label: "更新", value: detail.updatedAt },
+            { label: "開始時刻", value: detail.startsAt ?? "(未設定)" },
+            { label: "終了時刻", value: detail.endsAt ?? "(未設定)" },
+            {
+              label: "採点 lock",
+              value: detail.scoringLocked ? (
+                <Badge color="red">LOCKED</Badge>
+              ) : (
+                <Box variant="small" color="text-status-inactive">
+                  unlocked
+                </Box>
+              ),
+            },
+          ]}
+        />
+      </Container>
+
+      <Container header={<Header variant="h2">問題セット ({detail.problems.length})</Header>}>
+        <Table
+          variant="embedded"
+          items={[...detail.problems]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              問題セットは登録されていません。
+            </Box>
+          }
+          columnDefinitions={[
+            { id: "problemId", header: "Problem ID", cell: (p) => <code>{p.problemId}</code> },
+            { id: "region", header: "Default Region", cell: (p) => p.defaultRegion },
+            {
+              id: "deployStatus",
+              header: "Deploy 状況",
+              cell: (p) => renderProblemDeployStatus(detail.deploymentsByProblem[p.problemId]),
+            },
+            {
+              id: "jobs",
+              header: "Deploy Job",
+              cell: (p) => {
+                const list = detail.deploymentsByProblem[p.problemId];
+                if (!list || list.length === 0) {
+                  return (
+                    <Box variant="small" color="text-status-inactive">
+                      —
+                    </Box>
+                  );
+                }
+                return (
+                  <SpaceBetween direction="vertical" size="xxs">
+                    {list.map((d) => (
+                      <SpaceBetween
+                        key={d.jobId}
+                        direction="horizontal"
+                        size="xxs"
+                        alignItems="center"
+                      >
+                        <Link
+                          href={`/tenants/${encodeURIComponent(tenantId)}/deployments/${encodeURIComponent(d.jobId)}`}
+                          onFollow={(e) => {
+                            e.preventDefault();
+                            navigate(
+                              `/tenants/${encodeURIComponent(tenantId)}/deployments/${encodeURIComponent(d.jobId)}`,
+                            );
+                          }}
+                        >
+                          <Box variant="small">
+                            <code>{d.jobId.slice(0, 8)}…</code>
+                          </Box>
+                        </Link>
+                        <Badge color={DEPLOY_STATUS_COLOR[d.status]}>{d.status}</Badge>
+                      </SpaceBetween>
+                    ))}
+                  </SpaceBetween>
+                );
+              },
+            },
+          ]}
+        />
+      </Container>
+
+      <Container header={<Header variant="h2">チーム ({detail.teams.length})</Header>}>
+        <Table<TeamSummary>
+          variant="embedded"
+          items={[...detail.teams]}
+          empty={
+            <Box textAlign="center" color="inherit" padding="l">
+              チームは登録されていません。
+            </Box>
+          }
+          columnDefinitions={[
+            { id: "teamId", header: "Team ID", cell: (t) => <code>{t.teamId}</code> },
+            { id: "internalSlug", header: "Slug", cell: (t) => <code>{t.internalSlug}</code> },
+            {
+              id: "displayName",
+              header: "表示名 (競技者選択)",
+              cell: (t) => t.displayName ?? "(未設定)",
+            },
+            {
+              id: "awsAccountId",
+              header: "AWS Account",
+              cell: (t) => (t.awsAccountId ? <code>{t.awsAccountId}</code> : "(未設定)"),
+            },
+            {
+              id: "teamLoginKey",
+              header: "ログインキー",
+              cell: () => renderTeamLoginKeyBlackout(),
+            },
+          ]}
+        />
+        <Box variant="small" color="text-status-info" padding={{ top: "s" }}>
+          ※ ログインキーは SystemAdmin 経路では露出しません (ADR-011 D2)。Tenant Admin の Event
+          詳細ページで参照してください。
+        </Box>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/apps/admin-console/src/pages/TenantEvents.tsx
+++ b/apps/admin-console/src/pages/TenantEvents.tsx
@@ -1,0 +1,186 @@
+import Alert from "@cloudscape-design/components/alert";
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import Table from "@cloudscape-design/components/table";
+import { StatusCodes } from "http-status-codes";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import {
+  AdminInsightApiError,
+  type EventStatus,
+  type EventSummary,
+  fetchTenantEvents,
+} from "../api/admin-drill-down";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * Phase 1.B drill-down (ADR-011 / #598)。
+ *
+ * System Admin が tenant 一覧から行を click し、その tenant に紐づく Event の一覧に到達
+ * するページ。Event 行 click で `AdminEventDetail` に遷移。
+ *
+ * 設計:
+ *   - polling 30s (= read-only / SystemAdmin scope なので high-freq は不要)
+ *   - 403 (= claim 不足) は専用 Alert で表示。再ログインで復旧することを案内する
+ *   - Tenant Admin の EventList は write 操作 (archive 等) を持つが、本 page は **read-only**
+ */
+const POLL_INTERVAL_MS = 30_000;
+const PAGE_SIZE = 50;
+
+const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
+  DRAFT: "blue",
+  DEPLOYING: "blue",
+  READY: "green",
+  ENDED: "grey",
+  TEARDOWN: "red",
+  ARCHIVED: "grey",
+};
+
+export function TenantEventsPage({ config }: { config: AppConfig }) {
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const [items, setItems] = useState<readonly EventSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [notConfigured, setNotConfigured] = useState(false);
+
+  const idToken = auth.tokens?.idToken;
+
+  const fetchOnce = useCallback(async () => {
+    if (!idToken || !tenantId) return;
+    try {
+      const res = await fetchTenantEvents(config, idToken, tenantId, { limit: PAGE_SIZE });
+      if (res === null) {
+        // adminInsightApiUrl 未配線 (= phase 2 deploy 前 / dev)
+        setNotConfigured(true);
+        return;
+      }
+      setItems(res.items);
+      setError(null);
+      setForbidden(false);
+    } catch (err) {
+      if (err instanceof AdminInsightApiError && err.status === StatusCodes.FORBIDDEN) {
+        setForbidden(true);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }, [config, idToken, tenantId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await fetchOnce();
+    };
+    void tick();
+    const handle = window.setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [fetchOnce]);
+
+  if (!tenantId) {
+    return <Alert type="error">tenantId が指定されていません。</Alert>;
+  }
+
+  if (notConfigured) {
+    return (
+      <Alert type="info" header="AdminInsight API が未配線です">
+        本環境では admin-insight API URL が runtime-config に設定されていません。Phase 2 deploy
+        を完了してください。
+      </Alert>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <Alert type="error" header="権限がありません">
+        この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。
+      </Alert>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={`Tenant ID: ${tenantId}`}
+        actions={
+          <Button variant="normal" onClick={() => navigate("/tenants")}>
+            テナント一覧に戻る
+          </Button>
+        }
+      >
+        テナント Event 一覧
+      </Header>
+
+      {error && (
+        <Alert
+          type="error"
+          header="読み込みに失敗しました"
+          dismissible
+          onDismiss={() => setError(null)}
+        >
+          {error}
+        </Alert>
+      )}
+
+      {items === null && !error ? (
+        <Box textAlign="center" padding="l">
+          <Spinner /> 読み込み中…
+        </Box>
+      ) : (
+        <Table<EventSummary>
+          variant="container"
+          items={[...(items ?? [])]}
+          trackBy="eventId"
+          empty={
+            <Box textAlign="center" color="inherit" padding="xxl">
+              この tenant にはまだ Event がありません。
+            </Box>
+          }
+          columnDefinitions={[
+            {
+              id: "name",
+              header: "Event 名",
+              cell: (item) => (
+                <Link
+                  fontSize="body-m"
+                  href={`/tenants/${encodeURIComponent(tenantId)}/events/${encodeURIComponent(item.eventId)}`}
+                  onFollow={(e) => {
+                    e.preventDefault();
+                    navigate(
+                      `/tenants/${encodeURIComponent(tenantId)}/events/${encodeURIComponent(item.eventId)}`,
+                    );
+                  }}
+                >
+                  {item.name}
+                </Link>
+              ),
+            },
+            {
+              id: "status",
+              header: "ステータス",
+              cell: (item) => <Badge color={STATUS_COLOR[item.status]}>{item.status}</Badge>,
+            },
+            { id: "teamCount", header: "チーム数", cell: (item) => item.teamCount },
+            { id: "problemCount", header: "問題数", cell: (item) => item.problemCount },
+            { id: "createdAt", header: "作成", cell: (item) => item.createdAt },
+            { id: "updatedAt", header: "更新", cell: (item) => item.updatedAt },
+          ]}
+        />
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -3,6 +3,7 @@ import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
@@ -163,7 +164,30 @@ export function TenantListPage({ config }: { config: AppConfig }) {
         }
         columnDefinitions={[
           { id: "tenantId", header: "テナント ID", cell: (t) => t.tenantId },
-          { id: "tenantName", header: "名称", cell: (t) => t.tenantName },
+          {
+            id: "tenantName",
+            header: "名称",
+            // Phase 1.B drill-down (#598): 名称 cell を Link 化し、tenant の Event 一覧へ
+            // ナビゲートする。deprovisioned tenant は link を出さず灰色テキスト表示。
+            cell: (t) => {
+              if (isDeprovisioned(t)) {
+                return <Box color="text-status-inactive">{t.tenantName}</Box>;
+              }
+              const href = `/tenants/${encodeURIComponent(t.tenantId)}/events`;
+              return (
+                <Link
+                  fontSize="body-m"
+                  href={href}
+                  onFollow={(e) => {
+                    e.preventDefault();
+                    navigate(href);
+                  }}
+                >
+                  {t.tenantName}
+                </Link>
+              );
+            },
+          },
           { id: "email", header: "管理者メール", cell: (t) => t.email },
           {
             id: "tier",

--- a/apps/admin-console/test/admin-drill-down.test.ts
+++ b/apps/admin-console/test/admin-drill-down.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AdminInsightApiError,
+  cfnStatusToIndicator,
+  fetchTenantDeploymentDetail,
+  fetchTenantEventDetail,
+  fetchTenantEvents,
+  fetchTenantStackProgress,
+  parseStackOutputs,
+} from "../src/api/admin-drill-down";
+import type { AppConfig } from "../src/config";
+
+const baseConfig: AppConfig = {
+  cognitoDomain: "https://example.com",
+  cognitoClientId: "client-id",
+  redirectUri: "http://localhost/callback",
+  apiBaseUrl: "https://control.example.com/",
+  scope: "openid",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "https://insight.example.com",
+};
+
+describe("fetchTenantEvents (#598 Phase 1.B)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("adminInsightApiUrl が空文字なら null を返し fetch を呼ばないべき", async () => {
+    const res = await fetchTenantEvents(
+      { ...baseConfig, adminInsightApiUrl: "" },
+      "id-token",
+      "t-1",
+    );
+    expect(res).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("正常系: tenant-scoped events URL を bearer 認証付きで叩くべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [], nextCursor: undefined }), { status: 200 }),
+    );
+    const res = await fetchTenantEvents(baseConfig, "id-token", "t-acme", { limit: 25 });
+    expect(res).toEqual({ items: [], nextCursor: undefined });
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toContain("/admin/insight/tenants/t-acme/events");
+    expect(String(calledUrl)).toContain("limit=25");
+    expect((init as RequestInit).headers).toMatchObject({
+      authorization: "Bearer id-token",
+    });
+  });
+
+  it("403 は AdminInsightApiError として throw すべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "forbidden" }), { status: 403 }),
+    );
+    await expect(fetchTenantEvents(baseConfig, "id-token", "t-1")).rejects.toBeInstanceOf(
+      AdminInsightApiError,
+    );
+  });
+});
+
+describe("fetchTenantEventDetail (#598 Phase 1.B)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("404 は AdminInsightApiError (status=404) として throw すべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
+    );
+    try {
+      await fetchTenantEventDetail(baseConfig, "id-token", "t-1", "01HZX0K3M3K9ZQHB3MRQHBA1B2");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdminInsightApiError);
+      expect((err as AdminInsightApiError).status).toBe(404);
+    }
+  });
+});
+
+describe("fetchTenantDeploymentDetail (#598 Phase 1.B)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("正常系: jobId が URL-encode されたパスで叩かれるべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ jobId: "01HZ" }), { status: 200 }),
+    );
+    await fetchTenantDeploymentDetail(baseConfig, "id-token", "t-1", "01HZ");
+    const [calledUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toContain("/admin/insight/tenants/t-1/deployments/01HZ");
+  });
+});
+
+describe("fetchTenantStackProgress (#598 Phase 1.B)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("409 (stack 未割当) は AdminInsightApiError (status=409) として throw すべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "stack_not_yet_created" }), { status: 409 }),
+    );
+    try {
+      await fetchTenantStackProgress(baseConfig, "id-token", "t-1", "01HZ");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdminInsightApiError);
+      expect((err as AdminInsightApiError).status).toBe(409);
+    }
+  });
+});
+
+describe("cfnStatusToIndicator", () => {
+  it("DELETE_COMPLETE は stopped", () => {
+    expect(cfnStatusToIndicator("DELETE_COMPLETE")).toBe("stopped");
+  });
+  it("_FAILED suffix は error", () => {
+    expect(cfnStatusToIndicator("CREATE_FAILED")).toBe("error");
+  });
+  it("ROLLBACK を含むなら warning", () => {
+    expect(cfnStatusToIndicator("UPDATE_ROLLBACK_COMPLETE")).toBe("warning");
+  });
+  it("_COMPLETE suffix は success", () => {
+    expect(cfnStatusToIndicator("CREATE_COMPLETE")).toBe("success");
+  });
+  it("未知 status は in-progress (fallback)", () => {
+    expect(cfnStatusToIndicator("XYZ_UNKNOWN")).toBe("in-progress");
+  });
+});
+
+describe("parseStackOutputs", () => {
+  it("空 / undefined は空 record", () => {
+    expect(parseStackOutputs(undefined)).toEqual({});
+    expect(parseStackOutputs("")).toEqual({});
+  });
+  it("壊れた JSON は空 record (= ページを落とさない)", () => {
+    expect(parseStackOutputs("{not json")).toEqual({});
+  });
+  it("Lambda 由来 {key: value} を読めるべき", () => {
+    expect(parseStackOutputs(JSON.stringify({ ApiUrl: "https://x.com" }))).toEqual({
+      ApiUrl: "https://x.com",
+    });
+  });
+  it("Step Functions 由来 [{OutputKey,OutputValue}] を読めるべき", () => {
+    expect(parseStackOutputs(JSON.stringify([{ OutputKey: "K1", OutputValue: "v1" }]))).toEqual({
+      K1: "v1",
+    });
+  });
+});

--- a/apps/admin-console/test/pages/AdminDeploymentDetail.test.tsx
+++ b/apps/admin-console/test/pages/AdminDeploymentDetail.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchTenantDeploymentDetail: vi.fn(),
+  fetchTenantStackProgress: vi.fn(),
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../../src/api/admin-drill-down", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/admin-drill-down")>();
+  return {
+    ...actual,
+    fetchTenantDeploymentDetail: mocks.fetchTenantDeploymentDetail,
+    fetchTenantStackProgress: mocks.fetchTenantStackProgress,
+  };
+});
+
+vi.mock("../../src/auth/AuthProvider", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.com",
+  cognitoClientId: "client-id",
+  redirectUri: "http://localhost/callback",
+  apiBaseUrl: "https://control.example.com/",
+  scope: "openid",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "https://insight.example.com",
+};
+
+const JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B3";
+const TENANT_ID = "t-acme";
+
+const { AdminDeploymentDetailPage } = await import("../../src/pages/AdminDeploymentDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/tenants/${TENANT_ID}/deployments/${JOB_ID}`]}>
+      <Routes>
+        <Route
+          path="/tenants/:tenantId/deployments/:jobId"
+          element={<AdminDeploymentDetailPage config={config} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useAuth.mockReturnValue({
+    tokens: { idToken: "id-token", accessToken: "a", expiresAt: 0 },
+    ready: true,
+    login: () => undefined,
+    logout: () => undefined,
+    setTokens: () => undefined,
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("AdminDeploymentDetailPage (#598 Phase 1.B)", () => {
+  it("マウント時に fetchTenantDeploymentDetail を tenantId / jobId 指定で呼ぶべき", async () => {
+    mocks.fetchTenantDeploymentDetail.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      problemId: "p1",
+      tenantId: TENANT_ID,
+      awsAccountId: "123456789012",
+      region: "ap-northeast-1",
+      teamName: "team-alpha",
+      namePrefix: "team-alpha-p1",
+      status: "COMPLETE",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T01:00:00.000Z",
+      expiresAt: 0,
+    });
+    mocks.fetchTenantStackProgress.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      stackName: "team-alpha-p1",
+      region: "ap-northeast-1",
+      consoleUrl: "https://console.aws.amazon.com/cfn",
+      events: [],
+      resources: [],
+    });
+    renderPage();
+    await waitFor(() => expect(mocks.fetchTenantDeploymentDetail).toHaveBeenCalled());
+    const args = mocks.fetchTenantDeploymentDetail.mock.calls[0];
+    expect(args[2]).toBe(TENANT_ID);
+    expect(args[3]).toBe(JOB_ID);
+  });
+
+  it("teamLoginKey フィールドは画面 DOM に出てこないべき (security regression pin)", async () => {
+    mocks.fetchTenantDeploymentDetail.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      problemId: "p1",
+      tenantId: TENANT_ID,
+      awsAccountId: "123456789012",
+      region: "ap-northeast-1",
+      teamName: "team-alpha",
+      namePrefix: "team-alpha-p1",
+      status: "COMPLETE",
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+      // backend が誤って leak しても表示しないことを assert する。
+      teamLoginKey: "SHOULD-NEVER-RENDER" as unknown as undefined,
+    });
+    mocks.fetchTenantStackProgress.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      stackName: "team-alpha-p1",
+      region: "ap-northeast-1",
+      consoleUrl: "https://console.aws.amazon.com/cfn",
+      events: [],
+      resources: [],
+    });
+    const { container } = renderPage();
+    await screen.findByText("team-alpha-p1");
+    expect(container.textContent ?? "").not.toContain("SHOULD-NEVER-RENDER");
+  });
+
+  it("StackProgress section は console URL を出すべき", async () => {
+    mocks.fetchTenantDeploymentDetail.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      problemId: "p1",
+      tenantId: TENANT_ID,
+      awsAccountId: "123456789012",
+      region: "ap-northeast-1",
+      teamName: "team-alpha",
+      namePrefix: "team-alpha-p1",
+      status: "COMPLETE",
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+    });
+    mocks.fetchTenantStackProgress.mockResolvedValueOnce({
+      jobId: JOB_ID,
+      stackName: "team-alpha-p1",
+      region: "ap-northeast-1",
+      consoleUrl: "https://ap-northeast-1.console.aws.amazon.com/cloudformation/home",
+      events: [],
+      resources: [],
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/CFn console を開く/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/admin-console/test/pages/AdminEventDetail.test.tsx
+++ b/apps/admin-console/test/pages/AdminEventDetail.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchTenantEventDetail: vi.fn(),
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../../src/api/admin-drill-down", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/admin-drill-down")>();
+  return {
+    ...actual,
+    fetchTenantEventDetail: mocks.fetchTenantEventDetail,
+  };
+});
+
+vi.mock("../../src/auth/AuthProvider", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.com",
+  cognitoClientId: "client-id",
+  redirectUri: "http://localhost/callback",
+  apiBaseUrl: "https://control.example.com/",
+  scope: "openid",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "https://insight.example.com",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const TENANT_ID = "t-acme";
+
+const { AdminEventDetailPage } = await import("../../src/pages/AdminEventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/tenants/${TENANT_ID}/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route
+          path="/tenants/:tenantId/events/:eventId"
+          element={<AdminEventDetailPage config={config} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useAuth.mockReturnValue({
+    tokens: { idToken: "id-token", accessToken: "a", expiresAt: 0 },
+    ready: true,
+    login: () => undefined,
+    logout: () => undefined,
+    setTokens: () => undefined,
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("AdminEventDetailPage (#598 Phase 1.B)", () => {
+  it("マウント時に fetchTenantEventDetail を tenantId / eventId 指定で呼ぶべき", async () => {
+    mocks.fetchTenantEventDetail.mockResolvedValueOnce({
+      eventId: EVENT_ID,
+      name: "Event Z",
+      status: "READY",
+      teamCount: 1,
+      problemCount: 1,
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T01:00:00.000Z",
+      expiresAt: 0,
+      problems: [],
+      teams: [],
+      deploymentsByProblem: {},
+    });
+    renderPage();
+    await waitFor(() => expect(mocks.fetchTenantEventDetail).toHaveBeenCalled());
+    const args = mocks.fetchTenantEventDetail.mock.calls[0];
+    expect(args[2]).toBe(TENANT_ID);
+    expect(args[3]).toBe(EVENT_ID);
+  });
+
+  it("teamLoginKey は UI に表示されず、`••••` blackout を表示すべき", async () => {
+    mocks.fetchTenantEventDetail.mockResolvedValueOnce({
+      eventId: EVENT_ID,
+      name: "Event Z",
+      status: "READY",
+      teamCount: 1,
+      problemCount: 0,
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+      problems: [],
+      teams: [
+        {
+          teamId: "t1",
+          internalSlug: "team-alpha",
+          // backend が漏らしても UI は表示しないことを確認するため、敢えて undefined 以外で渡す。
+          teamLoginKey: "SHOULD-NEVER-RENDER",
+        },
+      ],
+      deploymentsByProblem: {},
+    });
+    const { container } = renderPage();
+    await screen.findByText("Event Z");
+    // 「ログインキー」列で `••••` blackout が出ているべき。
+    expect(screen.getAllByText("••••").length).toBeGreaterThan(0);
+    // teamLoginKey の値そのものは画面 DOM に乗っていないこと (security regression pin)。
+    expect(container.textContent ?? "").not.toContain("SHOULD-NEVER-RENDER");
+  });
+
+  it("404 (not_found) を AdminInsightApiError で受けたら Alert を出すべき", async () => {
+    const { AdminInsightApiError } = await import("../../src/api/admin-drill-down");
+    mocks.fetchTenantEventDetail.mockRejectedValueOnce(new AdminInsightApiError(404, "not_found"));
+    renderPage();
+    expect(await screen.findByText(/Event が見つかりません/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin-console/test/pages/TenantEvents.test.tsx
+++ b/apps/admin-console/test/pages/TenantEvents.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchTenantEvents: vi.fn(),
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../../src/api/admin-drill-down", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/admin-drill-down")>();
+  return {
+    ...actual,
+    fetchTenantEvents: mocks.fetchTenantEvents,
+  };
+});
+
+vi.mock("../../src/auth/AuthProvider", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.com",
+  cognitoClientId: "client-id",
+  redirectUri: "http://localhost/callback",
+  apiBaseUrl: "https://control.example.com/",
+  scope: "openid",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "https://insight.example.com",
+};
+
+const { TenantEventsPage } = await import("../../src/pages/TenantEvents");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/tenants/t-acme/events"]}>
+      <Routes>
+        <Route path="/tenants/:tenantId/events" element={<TenantEventsPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useAuth.mockReturnValue({
+    tokens: { idToken: "id-token", accessToken: "a", expiresAt: 0 },
+    ready: true,
+    login: () => undefined,
+    logout: () => undefined,
+    setTokens: () => undefined,
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("TenantEventsPage (#598 Phase 1.B)", () => {
+  it("マウント時に fetchTenantEvents を tenantId 指定で呼ぶべき", async () => {
+    mocks.fetchTenantEvents.mockResolvedValueOnce({ items: [] });
+    renderPage();
+    await waitFor(() => expect(mocks.fetchTenantEvents).toHaveBeenCalled());
+    const [, , tenantId] = mocks.fetchTenantEvents.mock.calls[0];
+    expect(tenantId).toBe("t-acme");
+  });
+
+  it("Event 名 を Link として render すべき", async () => {
+    mocks.fetchTenantEvents.mockResolvedValueOnce({
+      items: [
+        {
+          eventId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+          name: "Sample Event",
+          status: "READY",
+          teamCount: 3,
+          problemCount: 2,
+          createdAt: "2026-05-11T00:00:00.000Z",
+          updatedAt: "2026-05-11T01:00:00.000Z",
+          expiresAt: 0,
+        },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("Sample Event")).toBeInTheDocument();
+  });
+
+  it("403 (forbidden) Alert を表示すべき", async () => {
+    const { AdminInsightApiError } = await import("../../src/api/admin-drill-down");
+    mocks.fetchTenantEvents.mockRejectedValueOnce(new AdminInsightApiError(403, "forbidden"));
+    renderPage();
+    expect(await screen.findByText(/権限がありません/)).toBeInTheDocument();
+  });
+});

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -117,6 +117,30 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       integration,
     });
 
+    // Phase 1.B drill-down routes (#598)。
+    // 全 route は同じ Lambda integration / JWT Authorizer に接続される (= 1 Lambda で
+    // 全 path を受ける Hono ルーティング)。
+    httpApi.addRoutes({
+      path: "/admin/insight/tenants/{tenantId}/events",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+    httpApi.addRoutes({
+      path: "/admin/insight/tenants/{tenantId}/events/{eventId}",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+    httpApi.addRoutes({
+      path: "/admin/insight/tenants/{tenantId}/deployments/{jobId}",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+    httpApi.addRoutes({
+      path: "/admin/insight/tenants/{tenantId}/deployments/{jobId}/stack-progress",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+
     this.apiUrl = httpApi.apiEndpoint;
 
     new CfnOutput(this, "AdminInsightApiUrl", {

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -17,8 +18,10 @@ export interface AdminInsightApiLambdaProps {
    */
   readonly eventsTable: Table;
   /**
-   * Phase 1.B 以降の drill-down 拡張 (team 別 / event 詳細) で読み取り対象になる Teams table。
-   * Phase 1.A では env として注入のみ行い、read 権限は付与しない (= 最小権限)。
+   * Phase 1.B drill-down で読み取り対象になる Teams table (#598)。
+   * EventDetail の teams[] を組み立てるのに read 権限を付与する (= read-only)。
+   * teamLoginKey は handler 層で undefined に潰すため、本 IAM では projection 制限を
+   * かけない (= GetItem/Query レベルで全 attribute を引けるが、handler が出口で塗りつぶす)。
    */
   readonly teamsTable: Table;
 }
@@ -65,11 +68,25 @@ export class AdminInsightApiLambda extends Construct {
       },
     });
 
-    // ADR-011 Phase 1 D6: read-only に限定。Deployments / Events への read のみ grant し、
-    // Teams は Phase 1.B 以降で drill-down が要るときに read 追加する。
+    // ADR-011 Phase 1 D6: read-only に限定。Phase 1.A は Deployments / Events のみだったが、
+    // Phase 1.B drill-down (#598) で Teams も読む必要が出たため read を追加する。
     // GSI も含めて read できる必要があるので grantReadData (= GetItem / Query / Scan + index)
     // を使う (= 個別 PolicyStatement で限定するより SBT 同型の grantRead で十分)。
     props.deploymentsTable.grantReadData(this.fn);
     props.eventsTable.grantReadData(this.fn);
+    props.teamsTable.grantReadData(this.fn);
+
+    // Phase 1.B (#598) CFn Describe: deploy job 詳細ページの "Stack 進行状況" セクションが
+    // DescribeStackEvents / DescribeStackResources を直接叩く。Resource:* なのは、CFn の
+    // これら API は ARN ベースの IAM 絞り込みをサポートしていない (= account 内全 stack に
+    // 同列で適用される) ため。同一 account 内のみで、cross-account は ExternalId 経由の
+    // AssumeRole が別途必要 (= Phase 2 ADR-011 D4 で実装)。
+    this.fn.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["cloudformation:DescribeStackEvents", "cloudformation:DescribeStackResources"],
+        resources: ["*"],
+      }),
+    );
   }
 }

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/deployments.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/deployments.ts
@@ -1,0 +1,252 @@
+import {
+  CloudFormationClient,
+  DescribeStackEventsCommand,
+  DescribeStackResourcesCommand,
+  type StackEvent,
+  type StackResource,
+} from "@aws-sdk/client-cloudformation";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import type { AdminInsightSharedResources } from "./shared.js";
+
+/**
+ * Phase 1.B drill-down deployment 詳細 + CFn StackProgress (ADR-011 / #598)。
+ *
+ * 設計判断:
+ * - **read-only / same-account**: Phase 1 では CFn API を tenant 自身の AWS Account
+ *   (= Lambda 実行 account = same-account) 内 stack に対してのみ叩く。Phase 2 で
+ *   ExternalId 経由の AssumeRole + cross-account StackEvents 読みに拡張する (= ADR-011 D4)。
+ * - **teamLoginKey は black-out**: getDeploymentForTenant でも `teamLoginKey` を undefined
+ *   に潰す。Tests pin する。
+ * - shape は application-admin-console 側の DeploymentSummary / StackProgress と同じ
+ *   (= frontend で mirror 描画する)。
+ */
+
+type DeploymentStatus = "PENDING" | "IN_PROGRESS" | "COMPLETE" | "FAILED" | "DELETING" | "DELETED";
+
+export interface DeploymentDetail {
+  readonly jobId: string;
+  readonly problemId: string;
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly region: string;
+  readonly teamName: string;
+  readonly displayTeamName?: string;
+  readonly namePrefix: string;
+  readonly status: DeploymentStatus;
+  readonly stackId?: string;
+  readonly stackOutputs?: string;
+  readonly failureReason?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+  readonly eventId?: string;
+  readonly teamId?: string;
+  /**
+   * **常に undefined**。System Admin 経路では tenant の短命 bearer を露出しない
+   * (ADR-011 D2)。shape 上は frontend mirror のため field を残すが値は出さない。
+   */
+  readonly teamLoginKey?: undefined;
+}
+
+export interface StackProgressEvent {
+  readonly timestamp: string;
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+}
+
+export interface StackProgressResource {
+  readonly logicalResourceId: string;
+  readonly resourceType: string;
+  readonly resourceStatus: string;
+  readonly resourceStatusReason?: string;
+  readonly physicalResourceId?: string;
+}
+
+export interface StackProgress {
+  readonly jobId: string;
+  readonly stackName: string;
+  readonly region: string;
+  readonly consoleUrl: string;
+  readonly events: readonly StackProgressEvent[];
+  readonly resources: readonly StackProgressResource[];
+  readonly stackStatus?: string;
+}
+
+export type StackProgressOutcome =
+  | { kind: "ok"; progress: StackProgress }
+  | { kind: "not_found" }
+  | { kind: "stack_not_yet_created" }
+  | { kind: "stack_not_found_in_cfn"; consoleUrl: string };
+
+const EVENTS_LIMIT = 20;
+
+export function buildCfnConsoleUrl(region: string, stackName: string, stackId?: string): string {
+  const base = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(
+    region,
+  )}`;
+  if (stackId) {
+    return `${base}#/stacks/stackinfo?stackId=${encodeURIComponent(stackId)}`;
+  }
+  return `${base}#/stacks?filteringText=${encodeURIComponent(stackName)}`;
+}
+
+function toProgressEvent(e: StackEvent): StackProgressEvent {
+  return {
+    timestamp: e.Timestamp ? e.Timestamp.toISOString() : "",
+    logicalResourceId: e.LogicalResourceId ?? "",
+    resourceType: e.ResourceType ?? "",
+    resourceStatus: e.ResourceStatus ?? "",
+    resourceStatusReason: e.ResourceStatusReason,
+  };
+}
+
+function toProgressResource(r: StackResource): StackProgressResource {
+  return {
+    logicalResourceId: r.LogicalResourceId ?? "",
+    resourceType: r.ResourceType ?? "",
+    resourceStatus: r.ResourceStatus ?? "",
+    resourceStatusReason: r.ResourceStatusReason,
+    physicalResourceId: r.PhysicalResourceId,
+  };
+}
+
+function isStackNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { name?: unknown; message?: unknown };
+  if (typeof e.name === "string" && e.name === "ValidationError") {
+    if (typeof e.message === "string" && e.message.includes("does not exist")) return true;
+  }
+  return false;
+}
+
+/**
+ * 指定 jobId の Deployment 詳細。
+ *
+ * `tenantId` が caller (System Admin が path param で指定した tenant) と一致しない行は
+ * `undefined` で返す。これは「テナント分離をパス境界で再検査する」防御で、admin が誤って
+ * 別 tenant の jobId を指定しても他テナントの deploy が見えないようにする。
+ *
+ * `teamLoginKey` は **必ず undefined**。一覧と同じ規律 (= 詳細経路でも System Admin 経路
+ * では短命 bearer を露出しない)。
+ */
+export async function getDeploymentForTenant(
+  shared: AdminInsightSharedResources,
+  tenantId: string,
+  jobId: string,
+): Promise<DeploymentDetail | undefined> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.deploymentsTableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = out.Item as Record<string, unknown> | undefined;
+  if (!item) return undefined;
+  if (item.tenantId !== tenantId) return undefined;
+
+  return {
+    jobId: String(item.jobId ?? ""),
+    problemId: String(item.problemId ?? ""),
+    tenantId: String(item.tenantId ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
+    region: String(item.region ?? ""),
+    teamName: String(item.teamName ?? ""),
+    displayTeamName: typeof item.displayTeamName === "string" ? item.displayTeamName : undefined,
+    namePrefix: String(item.namePrefix ?? ""),
+    status: (item.status ?? "PENDING") as DeploymentStatus,
+    stackId: typeof item.stackId === "string" ? item.stackId : undefined,
+    stackOutputs: typeof item.stackOutputs === "string" ? item.stackOutputs : undefined,
+    failureReason: typeof item.failureReason === "string" ? item.failureReason : undefined,
+    createdAt: String(item.createdAt ?? ""),
+    updatedAt: String(item.updatedAt ?? ""),
+    expiresAt: Number(item.expiresAt ?? 0),
+    eventId: typeof item.eventId === "string" ? item.eventId : undefined,
+    teamId: typeof item.teamId === "string" ? item.teamId : undefined,
+    teamLoginKey: undefined, // 常に undefined (= System Admin 経路では bearer 不開示)
+  };
+}
+
+export interface StackProgressDeps {
+  readonly cfnClient: (region: string) => CloudFormationClient;
+}
+
+const clientCache = new Map<string, CloudFormationClient>();
+export const defaultCfnClient = (region: string): CloudFormationClient => {
+  let c = clientCache.get(region);
+  if (!c) {
+    c = new CloudFormationClient({ region });
+    clientCache.set(region, c);
+  }
+  return c;
+};
+
+/**
+ * 指定 jobId の CFn StackEvents / StackResources を取得。
+ *
+ * application-admin-console の `getStackProgress` (= problem-deploy backend) と同型。
+ * Phase 1 は same-account のみ (= Worker Lambda の execution role で CFn を引く)、
+ * Phase 2 で cross-account AssumeRole に拡張する。
+ */
+export async function getStackProgressForTenant(
+  shared: AdminInsightSharedResources,
+  deps: StackProgressDeps,
+  tenantId: string,
+  jobId: string,
+): Promise<StackProgressOutcome> {
+  const got = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.deploymentsTableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = got.Item as Record<string, unknown> | undefined;
+  if (!item) return { kind: "not_found" };
+  if (item.tenantId !== tenantId) return { kind: "not_found" };
+
+  const stackName = typeof item.namePrefix === "string" ? item.namePrefix : undefined;
+  const region = typeof item.region === "string" ? item.region : undefined;
+  if (!stackName || !region) return { kind: "stack_not_yet_created" };
+
+  const stackId = typeof item.stackId === "string" ? item.stackId : undefined;
+  const consoleUrl = buildCfnConsoleUrl(region, stackName, stackId);
+  const stackRef = stackId ?? stackName;
+  const cfn = deps.cfnClient(region);
+
+  let events: StackEvent[];
+  let resources: StackResource[];
+  let stackStatus: string | undefined;
+  try {
+    const [eventsRes, resourcesRes] = await Promise.all([
+      cfn.send(new DescribeStackEventsCommand({ StackName: stackRef })),
+      cfn.send(new DescribeStackResourcesCommand({ StackName: stackRef })),
+    ]);
+    events = (eventsRes.StackEvents ?? []).slice(0, EVENTS_LIMIT);
+    resources = resourcesRes.StackResources ?? [];
+    const stackLevel = events.find((e) => e.LogicalResourceId === stackName);
+    stackStatus = stackLevel?.ResourceStatus;
+  } catch (err) {
+    if (isStackNotFoundError(err)) {
+      return { kind: "stack_not_found_in_cfn", consoleUrl };
+    }
+    throw err;
+  }
+
+  const sortedResources = [...resources].sort((a, b) =>
+    (a.LogicalResourceId ?? "").localeCompare(b.LogicalResourceId ?? ""),
+  );
+
+  return {
+    kind: "ok",
+    progress: {
+      jobId,
+      stackName,
+      region,
+      consoleUrl,
+      events: events.map(toProgressEvent),
+      resources: sortedResources.map(toProgressResource),
+      stackStatus,
+    },
+  };
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/events.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/events.ts
@@ -1,0 +1,282 @@
+import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { AdminInsightSharedResources } from "./shared.js";
+
+/**
+ * Phase 1.B drill-down (ADR-011 / #598)。
+ *
+ * Tenant-scoped に Events / Teams / Deployments を read-only で集計し、System Admin の
+ * 「tenant 行 click → events 一覧 → event 詳細 → deploy job 詳細」 という UX を 1 度も
+ * ログインし直さず通すために必要な小さい read API 群。
+ *
+ * 設計判断 (ADR-011 残部):
+ * - **teamLoginKey は black-out**: System Admin 経路で短命 bearer を素通しさせると、
+ *   admin が tenant を impersonate できる事になり権限境界が崩れる。EventDetail の
+ *   teams[].teamLoginKey は本ファイルの中で `undefined` に潰す (`assertTeamLoginKeyHidden`
+ *   helper で test pin する)。
+ * - shape は application-admin-console 側の EventSummary / EventDetail と一致させる
+ *   (= frontend を mirror で書けるようにする)。ただし黒塗りのため `teamLoginKey?: string`
+ *   フィールドは shape 上は残し、値が常に `undefined` なところで防御する。
+ */
+
+type EventStatus = "DRAFT" | "DEPLOYING" | "READY" | "ENDED" | "TEARDOWN" | "ARCHIVED";
+type DeploymentStatus = "PENDING" | "IN_PROGRESS" | "COMPLETE" | "FAILED" | "DELETING" | "DELETED";
+
+const DEPLOYMENT_STATUS_VALUES: readonly DeploymentStatus[] = [
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "FAILED",
+  "DELETING",
+  "DELETED",
+];
+
+function parseDeploymentStatus(raw: unknown): DeploymentStatus | undefined {
+  if (typeof raw !== "string") return undefined;
+  return (DEPLOYMENT_STATUS_VALUES as readonly string[]).includes(raw)
+    ? (raw as DeploymentStatus)
+    : undefined;
+}
+
+export interface EventSummary {
+  readonly eventId: string;
+  readonly name: string;
+  readonly status: EventStatus;
+  readonly teamCount: number;
+  readonly problemCount: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly expiresAt: number;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+  readonly scoringLocked?: boolean;
+  readonly scoringLockedAt?: string;
+}
+
+export interface ListEventsResponse {
+  readonly items: readonly EventSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface EventProblemTarget {
+  readonly problemId: string;
+  readonly defaultAwsAccountId?: string;
+  readonly defaultRegion: string;
+}
+
+export interface TeamSummary {
+  readonly teamId: string;
+  readonly internalSlug: string;
+  readonly displayName?: string;
+  /**
+   * 詳細経路でのみ persist 行に含まれる短命 bearer。
+   * **本 admin-insight 経路では常に undefined にする** (ADR-011 D2: SystemAdmin は
+   * tenant を impersonate しない権限境界)。Tests pin する。
+   */
+  readonly teamLoginKey?: string;
+  readonly awsAccountId?: string;
+}
+
+export interface EventDeploymentSummary {
+  readonly jobId: string;
+  readonly teamId: string;
+  readonly status: DeploymentStatus;
+}
+
+export interface EventDetail extends EventSummary {
+  readonly problems: readonly EventProblemTarget[];
+  readonly teams: readonly TeamSummary[];
+  readonly deploymentsByProblem: Readonly<Record<string, readonly EventDeploymentSummary[]>>;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), "utf8").toString("base64url");
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> | undefined {
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // 不正 cursor は無視 (= 先頭から再開)。
+  }
+  return undefined;
+}
+
+function toEventSummary(item: Record<string, unknown>): EventSummary {
+  const problems = item.problems;
+  return {
+    eventId: String(item.eventId ?? ""),
+    name: String(item.name ?? ""),
+    status: (item.status ?? "DRAFT") as EventStatus,
+    teamCount: Number(item.teamCount ?? 0),
+    problemCount: Array.isArray(problems) ? problems.length : 0,
+    createdAt: String(item.createdAt ?? ""),
+    updatedAt: String(item.updatedAt ?? ""),
+    expiresAt: Number(item.expiresAt ?? 0),
+    startsAt: typeof item.startsAt === "string" ? item.startsAt : undefined,
+    endsAt: typeof item.endsAt === "string" ? item.endsAt : undefined,
+    scoringLocked: item.scoringLocked === true ? true : undefined,
+    scoringLockedAt: typeof item.scoringLockedAt === "string" ? item.scoringLockedAt : undefined,
+  };
+}
+
+export interface ListEventsRequest {
+  readonly tenantId: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+/**
+ * 指定 tenant の Event 一覧を新しい順に返す (GSI1: TENANT#<tenantId> / createdAt)。
+ * application-admin-console の `listEvents` と同等の shape。
+ */
+export async function listEventsForTenant(
+  shared: AdminInsightSharedResources,
+  req: ListEventsRequest,
+): Promise<ListEventsResponse> {
+  const limit = Math.min(Math.max(req.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const exclusiveStartKey = req.cursor ? decodeCursor(req.cursor) : undefined;
+
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.eventsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      ExpressionAttributeValues: { ":pk": `TENANT#${req.tenantId}` },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  const items = (out.Items ?? []).map((i) => toEventSummary(i as Record<string, unknown>));
+  const nextCursor = out.LastEvaluatedKey
+    ? encodeCursor(out.LastEvaluatedKey as Record<string, unknown>)
+    : undefined;
+  return { items, nextCursor };
+}
+
+/**
+ * teamLoginKey が response 上で消えていることを test 経路で固定する helper。
+ * `assertTeamLoginKeyHidden(detail)` が throw すれば security regression。
+ *
+ * 本 file 内では `redactTeams` で必ず undefined に潰してから return する。
+ */
+export function redactTeams(teams: readonly TeamSummary[]): readonly TeamSummary[] {
+  return teams.map((t) => ({
+    teamId: t.teamId,
+    internalSlug: t.internalSlug,
+    displayName: t.displayName,
+    awsAccountId: t.awsAccountId,
+    // teamLoginKey は **常に undefined**。System Admin 経路では一切露出しない。
+    teamLoginKey: undefined,
+  }));
+}
+
+/**
+ * 指定 eventId の Event 詳細 + Teams 一覧 + Deployments 集計を返す。
+ *
+ * `tenantId` 不一致 / event 不在は `undefined` (= caller が 404 を返す)。
+ *
+ * application-admin-console 経路 (`getEventDetail`) との差分:
+ *   - teams[].teamLoginKey を `undefined` に潰す (= System Admin に短命 bearer を渡さない)。
+ *   - displayTeamName を Deployments から補完する logic は同じ (= participant が PATCH した
+ *     表示名を operator 経路の teams[].displayName に乗せる)。
+ */
+export async function getEventDetailForTenant(
+  shared: AdminInsightSharedResources,
+  tenantId: string,
+  eventId: string,
+): Promise<EventDetail | undefined> {
+  const [eventOut, teamsOut, deploymentsOut] = await Promise.all([
+    shared.ddb.send(
+      new GetCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+      }),
+    ),
+    shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.teamsTableName,
+        KeyConditionExpression: "PK = :pk AND begins_with(SK, :tprefix)",
+        ExpressionAttributeValues: {
+          ":pk": `EVENT#${eventId}`,
+          ":tprefix": "TEAM#",
+        },
+      }),
+    ),
+    shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
+        // problemId / jobId / status / teamId だけ pull。teamLoginKey は projection に
+        // 含めない (= 念のため payload 自体にも乗らないようにする)。
+        ProjectionExpression: "teamId, eventId, displayTeamName, problemId, jobId, #s",
+        ExpressionAttributeNames: { "#s": "status" },
+      }),
+    ),
+  ]);
+
+  const event = eventOut.Item as Record<string, unknown> | undefined;
+  if (!event) return undefined;
+  if (event.tenantId !== tenantId) return undefined;
+
+  const teamItems = (teamsOut.Items ?? []) as Record<string, unknown>[];
+
+  // teamId → displayTeamName lookup (Deployments 由来。participant が PATCH した値)。
+  const displayNameByTeamId = new Map<string, string>();
+  const deploymentsByProblem: Record<string, EventDeploymentSummary[]> = {};
+  for (const d of deploymentsOut.Items ?? []) {
+    const row = d as Record<string, unknown>;
+    if (row.eventId !== eventId) continue;
+    if (typeof row.teamId === "string" && typeof row.displayTeamName === "string") {
+      if (row.displayTeamName.length > 0) {
+        displayNameByTeamId.set(row.teamId, row.displayTeamName);
+      }
+    }
+    if (
+      typeof row.problemId !== "string" ||
+      typeof row.jobId !== "string" ||
+      typeof row.teamId !== "string"
+    ) {
+      continue;
+    }
+    const status = parseDeploymentStatus(row.status);
+    if (!status) continue;
+    const list = deploymentsByProblem[row.problemId] ?? [];
+    list.push({ jobId: row.jobId, teamId: row.teamId, status });
+    deploymentsByProblem[row.problemId] = list;
+  }
+
+  const teamsRaw: TeamSummary[] = teamItems.map((t) => {
+    const teamId = String(t.teamId ?? "");
+    const fromTeamsTable = typeof t.displayName === "string" ? t.displayName : undefined;
+    return {
+      teamId,
+      internalSlug: String(t.internalSlug ?? ""),
+      displayName: displayNameByTeamId.get(teamId) ?? fromTeamsTable,
+      awsAccountId: typeof t.awsAccountId === "string" ? t.awsAccountId : undefined,
+      // teamLoginKey は **読まない**。redactTeams で念押しで undefined に潰す。
+    };
+  });
+  const teams = redactTeams(teamsRaw);
+
+  const summary = toEventSummary(event);
+  const problems = Array.isArray(event.problems)
+    ? (event.problems as readonly EventProblemTarget[])
+    : [];
+  return {
+    ...summary,
+    problems,
+    teams,
+    deploymentsByProblem,
+  };
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -1,18 +1,31 @@
+import type { Context } from "hono";
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
+import {
+  defaultCfnClient,
+  getDeploymentForTenant,
+  getStackProgressForTenant,
+} from "./deployments.js";
+import { getEventDetailForTenant, listEventsForTenant } from "./events.js";
 import { buildSharedResources } from "./shared.js";
 import { summarizeTenants } from "./summary.js";
 
 /**
- * Admin Insight API Lambda の Hono app (ADR-011 Phase 1.A、issue #590)。
+ * Admin Insight API Lambda の Hono app (ADR-011、issue #590 Phase 1.A + #598 Phase 1.B)。
  *
- * routes (Phase 1.A):
- *   GET /admin/insight/tenants/summary?tenantIds=t1,t2,t3
- *     → { items: [{ tenantId, activeDeploys, failedDeploys, totalEvents }] }
+ * routes:
+ *   Phase 1.A (issue #590, merged):
+ *     GET /admin/insight/tenants/summary?tenantIds=t1,t2,t3
+ *
+ *   Phase 1.B drill-down (issue #598):
+ *     GET /admin/insight/tenants/:tenantId/events
+ *     GET /admin/insight/tenants/:tenantId/events/:eventId
+ *     GET /admin/insight/tenants/:tenantId/deployments/:jobId
+ *     GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
  *
  * Auth:
  *   - API Gateway HTTP API + JWT Authorizer (ControlPlane UserPool) で 1 段目を通す
@@ -21,20 +34,21 @@ import { summarizeTenants } from "./summary.js";
  *
  * Audit:
  *   - 各 read API で `console.log({ event: "admin.insight.read", admin: sub, path })` を出力
- *   - operator は CloudWatch Logs Insights で `admin.insight.read` を query して誰がいつ
- *     何を見たか追える (= ADR-011 D5 採用案)
+ *   - drill-down 詳細では tenantId / eventId / jobId も含めて log (= 誰がどの行を覗いたかが追える)
  *
  * 非機能:
  *   - polling 60s (frontend 側で setInterval) を前提に response は <500ms 目標
- *   - tenant 数 ~5 × deployments/tenant ~50 ≒ 250 行 query で Free Tier RCU 内に収まる
- *   - Phase 3 (dashboard) で tenant 数が伸びるなら summary.ts の query 戦略を pre-aggregation に置換
+ *   - 詳細 endpoint は単 query / Get なので RCU 消費は更に小さい
  */
 
 // SDK clients / env は module scope で 1 度だけ build。warm invoke で connection pool 再利用。
 const shared = buildSharedResources();
 
 const TENANT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const EVENT_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const MAX_TENANT_IDS = 100;
+const LIST_LIMIT_MAX = 200;
 
 const app = new Hono();
 
@@ -48,10 +62,6 @@ app.use(
   }),
 );
 
-// 既存 handler (deploy / event) と同じ defensive layer。handler 内 try/catch を漏れた
-// throw (= middleware や module init で発生) を 500 + CORS headers で返し、browser が
-// "Failed to fetch" で詰まないようにする。response body には message を含めない (= 内部
-// IAM ARN / table 名 / stack trace の漏洩を防ぐ)。
 app.onError((err, c) => {
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[admin-insight] uncaught handler error", { path: c.req.path, message });
@@ -59,6 +69,39 @@ app.onError((err, c) => {
 });
 
 app.get("/admin/insight/healthz", (c) => c.json({ ok: true }, StatusCodes.OK));
+
+/**
+ * `cognito:groups` ⊇ {SystemAdmin} 検査 + audit log を 1 行に集約した route guard。
+ * 各 drill-down endpoint で `auditAndAuthorize(c, "/admin/insight/...")` を呼ぶ。
+ *
+ * 戻り値:
+ *   - `null` (= 認可 OK、続行可)
+ *   - `Response` (= 403)
+ */
+function auditAndAuthorize(
+  c: Context,
+  pathLogLabel: string,
+  extra: Record<string, unknown> = {},
+): Response | null {
+  if (!isSystemAdmin(c)) {
+    return c.json({ error: "forbidden" }, StatusCodes.FORBIDDEN);
+  }
+  const sub = resolveCognitoSub(c);
+  console.log({
+    event: "admin.insight.read",
+    admin: sub,
+    path: pathLogLabel,
+    ...extra,
+  });
+  return null;
+}
+
+function parseLimit(value: string | undefined): { ok: true; limit: number | undefined } | null {
+  if (value === undefined) return { ok: true, limit: undefined };
+  const limit = Number.parseInt(value, 10);
+  if (!Number.isFinite(limit) || limit < 1 || limit > LIST_LIMIT_MAX) return null;
+  return { ok: true, limit };
+}
 
 app.get("/admin/insight/tenants/summary", async (c) => {
   // ADR-011 D2: 2 段目の SystemAdmin claim check。1 段目は API GW JWT Authorizer。
@@ -103,6 +146,147 @@ app.get("/admin/insight/tenants/summary", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[admin-insight] summarizeTenants failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// ====== Phase 1.B drill-down (#598) ======
+
+app.get("/admin/insight/tenants/:tenantId/events", async (c) => {
+  const tenantId = c.req.param("tenantId");
+  if (!tenantId || !TENANT_ID_RE.test(tenantId)) {
+    return c.json({ error: "invalid_tenant_id" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/tenants/:tenantId/events", { tenantId });
+  if (forbidden) return forbidden;
+
+  const parsedLimit = parseLimit(c.req.query("limit"));
+  if (!parsedLimit) {
+    return c.json({ error: "invalid_limit" }, StatusCodes.BAD_REQUEST);
+  }
+
+  try {
+    const response = await listEventsForTenant(shared, {
+      tenantId,
+      limit: parsedLimit.limit,
+      cursor: c.req.query("cursor"),
+    });
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] listEventsForTenant failed", { tenantId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/insight/tenants/:tenantId/events/:eventId", async (c) => {
+  const tenantId = c.req.param("tenantId");
+  const eventId = c.req.param("eventId");
+  if (!tenantId || !TENANT_ID_RE.test(tenantId)) {
+    return c.json({ error: "invalid_tenant_id" }, StatusCodes.BAD_REQUEST);
+  }
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid_event_id" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/tenants/:tenantId/events/:eventId", {
+    tenantId,
+    eventId,
+  });
+  if (forbidden) return forbidden;
+
+  try {
+    const detail = await getEventDetailForTenant(shared, tenantId, eventId);
+    if (!detail) return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    return c.json(detail, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] getEventDetailForTenant failed", {
+      tenantId,
+      eventId,
+      message,
+    });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/insight/tenants/:tenantId/deployments/:jobId", async (c) => {
+  const tenantId = c.req.param("tenantId");
+  const jobId = c.req.param("jobId");
+  if (!tenantId || !TENANT_ID_RE.test(tenantId)) {
+    return c.json({ error: "invalid_tenant_id" }, StatusCodes.BAD_REQUEST);
+  }
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
+    return c.json({ error: "invalid_job_id" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/tenants/:tenantId/deployments/:jobId", {
+    tenantId,
+    jobId,
+  });
+  if (forbidden) return forbidden;
+
+  try {
+    const detail = await getDeploymentForTenant(shared, tenantId, jobId);
+    if (!detail) return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    return c.json(detail, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] getDeploymentForTenant failed", { tenantId, jobId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress", async (c) => {
+  const tenantId = c.req.param("tenantId");
+  const jobId = c.req.param("jobId");
+  if (!tenantId || !TENANT_ID_RE.test(tenantId)) {
+    return c.json({ error: "invalid_tenant_id" }, StatusCodes.BAD_REQUEST);
+  }
+  if (!jobId || !JOB_ID_RE.test(jobId)) {
+    return c.json({ error: "invalid_job_id" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(
+    c,
+    "/admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress",
+    { tenantId, jobId },
+  );
+  if (forbidden) return forbidden;
+
+  try {
+    const outcome = await getStackProgressForTenant(
+      shared,
+      { cfnClient: defaultCfnClient },
+      tenantId,
+      jobId,
+    );
+    if (outcome.kind === "not_found") {
+      return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    if (outcome.kind === "stack_not_yet_created") {
+      // CFn stack 未割当 (= deploy 進行極初期) は 409 で返し、UI 側で「準備中」表示にする。
+      return c.json({ error: "stack_not_yet_created" }, StatusCodes.CONFLICT);
+    }
+    if (outcome.kind === "stack_not_found_in_cfn") {
+      return c.json(
+        {
+          jobId,
+          stackName: "",
+          region: "",
+          consoleUrl: outcome.consoleUrl,
+          events: [],
+          resources: [],
+          stackStatus: undefined,
+        },
+        StatusCodes.OK,
+      );
+    }
+    return c.json(outcome.progress, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] getStackProgressForTenant failed", {
+      tenantId,
+      jobId,
+      message,
+    });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
+++ b/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
@@ -104,6 +104,26 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       expect(route.Properties.AuthorizerId).toBeDefined();
     });
 
+    it("Phase 1.B drill-down 4 route (events / event detail / deployment / stack-progress) を持つべき", () => {
+      const tpl = synthInsightStack();
+      const expected = [
+        "GET /admin/insight/tenants/{tenantId}/events",
+        "GET /admin/insight/tenants/{tenantId}/events/{eventId}",
+        "GET /admin/insight/tenants/{tenantId}/deployments/{jobId}",
+        "GET /admin/insight/tenants/{tenantId}/deployments/{jobId}/stack-progress",
+      ];
+      for (const routeKey of expected) {
+        const routes = tpl.findResources("AWS::ApiGatewayV2::Route", {
+          Properties: { RouteKey: routeKey },
+        });
+        expect(Object.keys(routes), `route ${routeKey} should exist`).toHaveLength(1);
+        const route = Object.values(routes)[0] as {
+          Properties: { AuthorizationType: string };
+        };
+        expect(route.Properties.AuthorizationType).toBe("JWT");
+      }
+    });
+
     it("CORS allowOrigins に localhost dev を入れるべき", () => {
       const tpl = synthInsightStack();
       tpl.hasResourceProperties(
@@ -135,12 +155,8 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
   });
 
   describe("IAM 権限 (ADR-011 D6 read-only)", () => {
-    it("Deployments / Events Table の read のみを Allow するべき (write は禁止)", () => {
-      const tpl = synthInsightStack();
-      // Lambda role に attach された IAM Policy の中に DynamoDB write action が無いことを
-      // 強めに検証する (= 旧 grantReadWriteData で誤 wire したら test が落ちる)。
+    function collectActions(tpl: Template): string[] {
       const policies = tpl.findResources("AWS::IAM::Policy");
-      const writeActions = ["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:DeleteItem"];
       const allActions: string[] = [];
       for (const p of Object.values(policies)) {
         const statements = (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } })
@@ -151,11 +167,38 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
           else if (typeof action === "string") allActions.push(action);
         }
       }
+      return allActions;
+    }
+
+    it("Deployments / Events / Teams Table の read のみを Allow するべき (write は禁止)", () => {
+      const tpl = synthInsightStack();
+      // Lambda role に attach された IAM Policy の中に DynamoDB write action が無いことを
+      // 強めに検証する (= 旧 grantReadWriteData で誤 wire したら test が落ちる)。
+      const writeActions = ["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:DeleteItem"];
+      const allActions = collectActions(tpl);
       for (const w of writeActions) {
         expect(allActions).not.toContain(w);
       }
       // 同時に read action は最低 1 つ (Query / GetItem) 含むこと。
       expect(allActions.some((a) => a === "dynamodb:Query" || a === "dynamodb:GetItem")).toBe(true);
+    });
+
+    it("Phase 1.B: Teams table の read を grant するべき (#598)", () => {
+      const tpl = synthInsightStack();
+      // Teams は Phase 1.A では env 注入のみだったが、Phase 1.B drill-down で read 権限を
+      // 追加する。Policy が Teams table の ARN を参照する Statement を 1 つ以上持つこと。
+      const policies = tpl.findResources("AWS::IAM::Policy");
+      const policyJsonAll = JSON.stringify(policies);
+      // CDK は Table.tableArn を Fn::GetAtt で参照するので、policy JSON 内に Teams<HashSuffix>
+      // / TeamsResource 等のリソース名が含まれる。tableName よりも logicalId で固定。
+      expect(policyJsonAll).toContain("Teams");
+    });
+
+    it("Phase 1.B: CFn DescribeStackEvents / DescribeStackResources を grant するべき (#598)", () => {
+      const tpl = synthInsightStack();
+      const allActions = collectActions(tpl);
+      expect(allActions).toContain("cloudformation:DescribeStackEvents");
+      expect(allActions).toContain("cloudformation:DescribeStackResources");
     });
   });
 

--- a/infrastructure/test/admin-insight/admin-insight-routes.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-routes.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   summarizeTenants: vi.fn(),
+  listEventsForTenant: vi.fn(),
+  getEventDetailForTenant: vi.fn(),
+  getDeploymentForTenant: vi.fn(),
+  getStackProgressForTenant: vi.fn(),
 }));
 
 vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/shared", () => ({
@@ -15,6 +19,19 @@ vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/shared", () => (
 
 vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/summary", () => ({
   summarizeTenants: mocks.summarizeTenants,
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/events", () => ({
+  listEventsForTenant: mocks.listEventsForTenant,
+  getEventDetailForTenant: mocks.getEventDetailForTenant,
+  // redactTeams は handler 層では未使用だが、import 経路が同 module なので no-op stub。
+  redactTeams: (teams: unknown[]) => teams,
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/deployments", () => ({
+  getDeploymentForTenant: mocks.getDeploymentForTenant,
+  getStackProgressForTenant: mocks.getStackProgressForTenant,
+  defaultCfnClient: () => undefined,
 }));
 
 const { app } = await import("../../lib/admin-insight/handlers/admin-insight-handler/index");
@@ -31,6 +48,9 @@ function withClaims(claims: Record<string, unknown>) {
     },
   };
 }
+
+const VALID_EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const VALID_JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B3";
 
 describe("GET /admin/insight/tenants/summary", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -151,5 +171,317 @@ describe("GET /admin/insight/healthz", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ ok: true });
+  });
+});
+
+// ============ Phase 1.B drill-down routes (#598) ============
+
+describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin claim 無しは 403 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/t1/events",
+      {},
+      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.listEventsForTenant).not.toHaveBeenCalled();
+  });
+
+  it("正常系: listEventsForTenant を tenantId 指定で呼ぶべき", async () => {
+    mocks.listEventsForTenant.mockResolvedValueOnce({
+      items: [
+        {
+          eventId: VALID_EVENT_ID,
+          name: "Event A",
+          status: "READY",
+          teamCount: 2,
+          problemCount: 1,
+          createdAt: "2026-05-11T00:00:00.000Z",
+          updatedAt: "2026-05-11T00:00:00.000Z",
+          expiresAt: 0,
+        },
+      ],
+    });
+    const res = await app.request(
+      "/admin/insight/tenants/t-acme/events?limit=10",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.listEventsForTenant).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tenantId: "t-acme", limit: 10 }),
+    );
+  });
+
+  it("不正な tenantId は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/has%20space/events",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.listEventsForTenant).not.toHaveBeenCalled();
+  });
+
+  it("limit=9999 のような範囲外は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/t1/events?limit=9999",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("内部 throw は 500", async () => {
+    mocks.listEventsForTenant.mockRejectedValueOnce(new Error("ddb down"));
+    const res = await app.request(
+      "/admin/insight/tenants/t1/events",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toContain("ddb down");
+  });
+});
+
+describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin claim 無しは 403 を返すべき", async () => {
+    const res = await app.request(
+      `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.getEventDetailForTenant).not.toHaveBeenCalled();
+  });
+
+  it("正常系: getEventDetailForTenant を呼んで 200", async () => {
+    mocks.getEventDetailForTenant.mockResolvedValueOnce({
+      eventId: VALID_EVENT_ID,
+      name: "E",
+      status: "READY",
+      teamCount: 1,
+      problemCount: 1,
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+      problems: [],
+      teams: [],
+      deploymentsByProblem: {},
+    });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.getEventDetailForTenant).toHaveBeenCalledWith(
+      expect.anything(),
+      "t1",
+      VALID_EVENT_ID,
+    );
+  });
+
+  it("不正な eventId は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/t1/events/bad-event",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Event 不在は 404", async () => {
+    mocks.getEventDetailForTenant.mockResolvedValueOnce(undefined);
+    const res = await app.request(
+      `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("teamLoginKey は response に含まれない (security regression pin)", async () => {
+    // mock 関数自体は redactTeams を経た shape を返す前提だが、handler 層は受け取った値を
+    // そのまま return する。ここでは「もし mock が誤って leak しても body に出ない」 ことを
+    // assert する代わりに、shape が teamLoginKey undefined のときに passthrough されることを
+    // 確認する。
+    mocks.getEventDetailForTenant.mockResolvedValueOnce({
+      eventId: VALID_EVENT_ID,
+      name: "E",
+      status: "READY",
+      teamCount: 1,
+      problemCount: 1,
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+      problems: [],
+      teams: [{ teamId: "t1", internalSlug: "a", teamLoginKey: undefined }],
+      deploymentsByProblem: {},
+    });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    const body = (await res.json()) as {
+      teams: Array<{ teamLoginKey?: string }>;
+    };
+    expect(body.teams[0].teamLoginKey).toBeUndefined();
+  });
+});
+
+describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId (Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin claim 無しは 403", async () => {
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.getDeploymentForTenant).not.toHaveBeenCalled();
+  });
+
+  it("正常系: getDeploymentForTenant 経由で 200", async () => {
+    mocks.getDeploymentForTenant.mockResolvedValueOnce({
+      jobId: VALID_JOB_ID,
+      problemId: "p1",
+      tenantId: "t1",
+      awsAccountId: "123",
+      region: "ap-northeast-1",
+      teamName: "team-a",
+      namePrefix: "team-a-p1",
+      status: "COMPLETE",
+      createdAt: "x",
+      updatedAt: "x",
+      expiresAt: 0,
+    });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.getDeploymentForTenant).toHaveBeenCalledWith(
+      expect.anything(),
+      "t1",
+      VALID_JOB_ID,
+    );
+  });
+
+  it("不正な jobId は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/tenants/t1/deployments/not-a-ulid",
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Deployment 不在は 404", async () => {
+    mocks.getDeploymentForTenant.mockResolvedValueOnce(undefined);
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress (Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin claim 無しは 403", async () => {
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.getStackProgressForTenant).not.toHaveBeenCalled();
+  });
+
+  it("kind=ok のとき progress 本体を返すべき", async () => {
+    mocks.getStackProgressForTenant.mockResolvedValueOnce({
+      kind: "ok",
+      progress: {
+        jobId: VALID_JOB_ID,
+        stackName: "team-a-p1",
+        region: "ap-northeast-1",
+        consoleUrl: "https://console.aws.amazon.com/...",
+        events: [],
+        resources: [],
+      },
+    });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { jobId: string; consoleUrl: string };
+    expect(body.jobId).toBe(VALID_JOB_ID);
+  });
+
+  it("kind=not_found は 404", async () => {
+    mocks.getStackProgressForTenant.mockResolvedValueOnce({ kind: "not_found" });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("kind=stack_not_yet_created は 409", async () => {
+    mocks.getStackProgressForTenant.mockResolvedValueOnce({ kind: "stack_not_yet_created" });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("kind=stack_not_found_in_cfn は 200 + 空 events + consoleUrl", async () => {
+    mocks.getStackProgressForTenant.mockResolvedValueOnce({
+      kind: "stack_not_found_in_cfn",
+      consoleUrl: "https://console.aws.amazon.com/cfn",
+    });
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      events: unknown[];
+      resources: unknown[];
+      consoleUrl: string;
+    };
+    expect(body.events).toEqual([]);
+    expect(body.resources).toEqual([]);
+    expect(body.consoleUrl).toBe("https://console.aws.amazon.com/cfn");
+  });
+
+  it("内部 throw は 500", async () => {
+    mocks.getStackProgressForTenant.mockRejectedValueOnce(new Error("cfn down"));
+    const res = await app.request(
+      `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
+      {},
+      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toContain("cfn down");
   });
 });

--- a/infrastructure/test/admin-insight/deployments.test.ts
+++ b/infrastructure/test/admin-insight/deployments.test.ts
@@ -1,0 +1,221 @@
+import {
+  type CloudFormationClient,
+  DescribeStackEventsCommand,
+  DescribeStackResourcesCommand,
+} from "@aws-sdk/client-cloudformation";
+import type { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCfnConsoleUrl,
+  getDeploymentForTenant,
+  getStackProgressForTenant,
+} from "../../lib/admin-insight/handlers/admin-insight-handler/deployments";
+
+function buildShared(send: ReturnType<typeof vi.fn>) {
+  return {
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient,
+  };
+}
+
+describe("getDeploymentForTenant (ADR-011 / #598 Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const baseItem = {
+    PK: "DEPLOYMENT#01HZ",
+    SK: "META",
+    jobId: "01HZ",
+    problemId: "p1",
+    tenantId: "t1",
+    awsAccountId: "123456789012",
+    region: "ap-northeast-1",
+    teamName: "team-alpha",
+    namePrefix: "team-alpha-p1",
+    status: "COMPLETE",
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T01:00:00.000Z",
+    expiresAt: 0,
+    teamLoginKey: "SECRET-DO-NOT-LEAK",
+  };
+
+  it("DDB に行が無ければ undefined を返すべき (= 404 相当)", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: undefined });
+    const result = await getDeploymentForTenant(buildShared(send), "t1", "01HZ");
+    expect(result).toBeUndefined();
+  });
+
+  it("tenantId 不一致なら undefined を返すべき (= cross-tenant 漏洩防止)", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: { ...baseItem, tenantId: "OTHER" } });
+    const result = await getDeploymentForTenant(buildShared(send), "t1", "01HZ");
+    expect(result).toBeUndefined();
+  });
+
+  it("teamLoginKey は response に乗らないべき (security regression pin)", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: baseItem });
+    const result = await getDeploymentForTenant(buildShared(send), "t1", "01HZ");
+    expect(result?.teamLoginKey).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("SECRET-DO-NOT-LEAK");
+  });
+
+  it("DDB の Get で正しい PK / SK を引くべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: baseItem });
+    await getDeploymentForTenant(buildShared(send), "t1", "01HZ");
+    const cmd = send.mock.calls[0][0] as GetCommand;
+    expect(cmd.input.TableName).toBe("TestDeployments");
+    expect(cmd.input.Key).toEqual({ PK: "DEPLOYMENT#01HZ", SK: "META" });
+  });
+
+  it("成功時は jobId / problemId / status / stackId 等を返すべき (mirror shape)", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Item: { ...baseItem, stackId: "arn:cfn:stack/abc", failureReason: undefined },
+    });
+    const result = await getDeploymentForTenant(buildShared(send), "t1", "01HZ");
+    expect(result).toMatchObject({
+      jobId: "01HZ",
+      problemId: "p1",
+      tenantId: "t1",
+      awsAccountId: "123456789012",
+      region: "ap-northeast-1",
+      teamName: "team-alpha",
+      namePrefix: "team-alpha-p1",
+      status: "COMPLETE",
+      stackId: "arn:cfn:stack/abc",
+    });
+  });
+});
+
+describe("getStackProgressForTenant (ADR-011 / #598 Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const baseItem = {
+    PK: "DEPLOYMENT#01HZ",
+    SK: "META",
+    jobId: "01HZ",
+    tenantId: "t1",
+    namePrefix: "team-alpha-p1",
+    region: "ap-northeast-1",
+    stackId: "arn:aws:cloudformation:ap-northeast-1:111:stack/team-alpha-p1/abc",
+  };
+
+  function buildCfnFactory(stub: Partial<CloudFormationClient>): {
+    cfnClient: (region: string) => CloudFormationClient;
+  } {
+    return {
+      cfnClient: () => stub as unknown as CloudFormationClient,
+    };
+  }
+
+  it("行不在なら kind=not_found を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: undefined });
+    const cfnSend = vi.fn();
+    const outcome = await getStackProgressForTenant(
+      buildShared(send),
+      buildCfnFactory({ send: cfnSend as unknown as CloudFormationClient["send"] }),
+      "t1",
+      "01HZ",
+    );
+    expect(outcome.kind).toBe("not_found");
+    expect(cfnSend).not.toHaveBeenCalled();
+  });
+
+  it("tenantId 不一致なら kind=not_found を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: { ...baseItem, tenantId: "OTHER" } });
+    const outcome = await getStackProgressForTenant(
+      buildShared(send),
+      buildCfnFactory({ send: vi.fn() as unknown as CloudFormationClient["send"] }),
+      "t1",
+      "01HZ",
+    );
+    expect(outcome.kind).toBe("not_found");
+  });
+
+  it("namePrefix / region 未割当なら kind=stack_not_yet_created を返すべき", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValue({ Item: { ...baseItem, namePrefix: undefined, region: undefined } });
+    const outcome = await getStackProgressForTenant(
+      buildShared(send),
+      buildCfnFactory({ send: vi.fn() as unknown as CloudFormationClient["send"] }),
+      "t1",
+      "01HZ",
+    );
+    expect(outcome.kind).toBe("stack_not_yet_created");
+  });
+
+  it("CFn DescribeStackEvents / DescribeStackResources を並列発行するべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: baseItem });
+    const cfnSend = vi.fn().mockImplementation(async (cmd) => {
+      if (cmd instanceof DescribeStackEventsCommand) {
+        return {
+          StackEvents: [
+            {
+              Timestamp: new Date("2026-05-11T00:00:00Z"),
+              LogicalResourceId: "team-alpha-p1",
+              ResourceType: "AWS::CloudFormation::Stack",
+              ResourceStatus: "CREATE_COMPLETE",
+            },
+          ],
+        };
+      }
+      if (cmd instanceof DescribeStackResourcesCommand) {
+        return {
+          StackResources: [
+            {
+              LogicalResourceId: "MyBucket",
+              ResourceType: "AWS::S3::Bucket",
+              ResourceStatus: "CREATE_COMPLETE",
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected cmd: ${cmd.constructor.name}`);
+    });
+    const outcome = await getStackProgressForTenant(
+      buildShared(send),
+      buildCfnFactory({ send: cfnSend as unknown as CloudFormationClient["send"] }),
+      "t1",
+      "01HZ",
+    );
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") throw new Error("unreachable");
+    expect(outcome.progress.events).toHaveLength(1);
+    expect(outcome.progress.resources).toHaveLength(1);
+    expect(outcome.progress.stackStatus).toBe("CREATE_COMPLETE");
+    expect(outcome.progress.consoleUrl).toContain("ap-northeast-1");
+    expect(cfnSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("CFn が 'does not exist' を投げたら kind=stack_not_found_in_cfn を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Item: baseItem });
+    const cfnSend = vi.fn().mockRejectedValue(
+      Object.assign(new Error("Stack with id team-alpha-p1 does not exist"), {
+        name: "ValidationError",
+      }),
+    );
+    const outcome = await getStackProgressForTenant(
+      buildShared(send),
+      buildCfnFactory({ send: cfnSend as unknown as CloudFormationClient["send"] }),
+      "t1",
+      "01HZ",
+    );
+    expect(outcome.kind).toBe("stack_not_found_in_cfn");
+    if (outcome.kind !== "stack_not_found_in_cfn") throw new Error("unreachable");
+    expect(outcome.consoleUrl).toContain("ap-northeast-1");
+  });
+});
+
+describe("buildCfnConsoleUrl", () => {
+  it("stackId があれば stackinfo deep link を返すべき", () => {
+    const url = buildCfnConsoleUrl("ap-northeast-1", "team-alpha-p1", "arn:cfn:stack/abc/123");
+    expect(url).toContain("ap-northeast-1");
+    expect(url).toContain("stackinfo?stackId=");
+    expect(url).toContain(encodeURIComponent("arn:cfn:stack/abc/123"));
+  });
+
+  it("stackId が無ければ filteringText 経由の stack 一覧 URL を返すべき", () => {
+    const url = buildCfnConsoleUrl("us-east-1", "stack-x");
+    expect(url).toContain("filteringText=stack-x");
+  });
+});

--- a/infrastructure/test/admin-insight/events.test.ts
+++ b/infrastructure/test/admin-insight/events.test.ts
@@ -1,0 +1,206 @@
+import { GetCommand, type QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getEventDetailForTenant,
+  listEventsForTenant,
+  redactTeams,
+} from "../../lib/admin-insight/handlers/admin-insight-handler/events";
+
+function buildShared(send: ReturnType<typeof vi.fn>) {
+  return {
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient,
+  };
+}
+
+describe("listEventsForTenant (ADR-011 / #598 Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Events table を GSI1 で query して EventSummary 配列を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Items: [
+        {
+          eventId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+          name: "Event A",
+          status: "READY",
+          teamCount: 3,
+          problems: [{ problemId: "p1" }],
+          createdAt: "2026-05-11T00:00:00.000Z",
+          updatedAt: "2026-05-11T01:00:00.000Z",
+          expiresAt: 0,
+        },
+      ],
+    });
+    const result = await listEventsForTenant(buildShared(send), { tenantId: "t1" });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].name).toBe("Event A");
+    expect(result.items[0].problemCount).toBe(1);
+    const cmd = send.mock.calls[0][0] as QueryCommand;
+    expect(cmd.input.TableName).toBe("TestEvents");
+    expect(cmd.input.IndexName).toBe("GSI1");
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#t1");
+    expect(cmd.input.ScanIndexForward).toBe(false);
+  });
+
+  it("LastEvaluatedKey があれば nextCursor を base64url で encode するべき", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValue({ Items: [], LastEvaluatedKey: { PK: "EVENT#x", SK: "META" } });
+    const result = await listEventsForTenant(buildShared(send), { tenantId: "t1" });
+    const cursor = result.nextCursor;
+    expect(cursor).toBeDefined();
+    if (!cursor) throw new Error("nextCursor was undefined");
+    const decoded = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    expect(decoded).toEqual({ PK: "EVENT#x", SK: "META" });
+  });
+
+  it("limit は 1..200 の範囲に clamp するべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [] });
+    await listEventsForTenant(buildShared(send), { tenantId: "t1", limit: 9999 });
+    const cmd = send.mock.calls[0][0] as QueryCommand;
+    expect(cmd.input.Limit).toBe(200);
+  });
+});
+
+describe("redactTeams (security regression pin)", () => {
+  it("teamLoginKey を **必ず** undefined に潰すべき (ADR-011 D2)", () => {
+    const result = redactTeams([
+      {
+        teamId: "t1",
+        internalSlug: "team-a",
+        teamLoginKey: "secret-bearer-DO-NOT-LEAK",
+      },
+    ]);
+    expect(result[0].teamLoginKey).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("secret-bearer-DO-NOT-LEAK");
+  });
+
+  it("displayName / awsAccountId / internalSlug は素通しするべき (= read-only mirror)", () => {
+    const result = redactTeams([
+      {
+        teamId: "t1",
+        internalSlug: "team-a",
+        displayName: "Alpha",
+        awsAccountId: "123456789012",
+        teamLoginKey: "shhh",
+      },
+    ]);
+    expect(result[0]).toMatchObject({
+      teamId: "t1",
+      internalSlug: "team-a",
+      displayName: "Alpha",
+      awsAccountId: "123456789012",
+    });
+  });
+});
+
+describe("getEventDetailForTenant (ADR-011 / #598 Phase 1.B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const eventItem = {
+    PK: "EVENT#01HZX0K3M3K9ZQHB3MRQHBA1B2",
+    SK: "META",
+    eventId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+    tenantId: "t1",
+    name: "My Event",
+    status: "READY",
+    teamCount: 2,
+    problems: [{ problemId: "p1", defaultRegion: "ap-northeast-1" }],
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T01:00:00.000Z",
+    expiresAt: 0,
+  };
+
+  function send3(
+    eventOut: unknown,
+    teamsOut: unknown,
+    deploysOut: unknown,
+  ): ReturnType<typeof vi.fn> {
+    return vi.fn().mockImplementation(async (cmd: GetCommand | QueryCommand) => {
+      if (cmd instanceof GetCommand) return eventOut;
+      const input = (cmd as QueryCommand).input;
+      if (input.TableName === "TestTeams") return teamsOut;
+      if (input.TableName === "TestDeployments") return deploysOut;
+      throw new Error(`unexpected: ${JSON.stringify(input)}`);
+    });
+  }
+
+  it("Event 不在なら undefined を返すべき (= 404 相当)", async () => {
+    const send = send3({ Item: undefined }, { Items: [] }, { Items: [] });
+    const result = await getEventDetailForTenant(buildShared(send), "t1", eventItem.eventId);
+    expect(result).toBeUndefined();
+  });
+
+  it("tenantId 不一致なら undefined を返すべき (= cross-tenant 漏洩防止)", async () => {
+    const send = send3({ Item: { ...eventItem, tenantId: "OTHER" } }, { Items: [] }, { Items: [] });
+    const result = await getEventDetailForTenant(buildShared(send), "t1", eventItem.eventId);
+    expect(result).toBeUndefined();
+  });
+
+  it("teams[].teamLoginKey は response に乗らないべき (security regression pin)", async () => {
+    const send = send3(
+      { Item: eventItem },
+      {
+        Items: [
+          {
+            teamId: "team-1",
+            internalSlug: "team-alpha",
+            teamLoginKey: "SECRET-DO-NOT-LEAK",
+            displayName: "Alpha",
+          },
+        ],
+      },
+      { Items: [] },
+    );
+    const result = await getEventDetailForTenant(buildShared(send), "t1", eventItem.eventId);
+    expect(result).toBeDefined();
+    expect(result?.teams[0].teamLoginKey).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("SECRET-DO-NOT-LEAK");
+  });
+
+  it("Deployments を problemId ごとに集約し、displayTeamName を teams[] に転記するべき", async () => {
+    const send = send3(
+      { Item: eventItem },
+      {
+        Items: [
+          { teamId: "team-1", internalSlug: "team-alpha" },
+          { teamId: "team-2", internalSlug: "team-beta" },
+        ],
+      },
+      {
+        Items: [
+          {
+            eventId: eventItem.eventId,
+            teamId: "team-1",
+            problemId: "p1",
+            jobId: "job-1",
+            status: "COMPLETE",
+            displayTeamName: "AlphaDisplay",
+          },
+          {
+            eventId: eventItem.eventId,
+            teamId: "team-2",
+            problemId: "p1",
+            jobId: "job-2",
+            status: "FAILED",
+          },
+          // 別 event の row は無視されるべき
+          {
+            eventId: "OTHER",
+            teamId: "team-1",
+            problemId: "p1",
+            jobId: "job-99",
+            status: "COMPLETE",
+          },
+        ],
+      },
+    );
+    const result = await getEventDetailForTenant(buildShared(send), "t1", eventItem.eventId);
+    expect(result?.deploymentsByProblem.p1).toHaveLength(2);
+    expect(result?.deploymentsByProblem.p1.map((d) => d.jobId)).toEqual(["job-1", "job-2"]);
+    const team1 = result?.teams.find((t) => t.teamId === "team-1");
+    expect(team1?.displayName).toBe("AlphaDisplay");
+  });
+});


### PR DESCRIPTION
## Summary

ADR-011 Phase 1.B drill-down を実装。System Admin が admin-console から「テナント一覧 →
tenant 行 click → Event 一覧 → Event 行 click → Event 詳細 → Deploy job 行 click →
CFn StackEvents 詳細」 まで **1 度もログインし直さず** ドリルダウン可能になる。

- **Backend (4 新 endpoint、既存 AdminInsightApiLambda に追加)**: `/tenants/:id/events`、
  `/tenants/:id/events/:eventId`、`/tenants/:id/deployments/:jobId`、
  `/tenants/:id/deployments/:jobId/stack-progress`
- **Frontend (3 新 page)**: TenantEvents / AdminEventDetail / AdminDeploymentDetail
  (= application-admin-console の read-only mirror)
- **Security**: `teamLoginKey` は System Admin 経路で **完全 black-out**。backend
  (`redactTeams`) で必ず `undefined` に潰し、UI でも `••••` 表示。両側で security
  regression test pin あり

## 設計判断 (ADR-011)

- **D2 SystemAdmin 認可**: 全 drill-down endpoint で `cognito:groups` ⊇ {SystemAdmin}
  を handler 内で再検査 (= API GW JWT Authorizer の二段防御)。
- **D4 same-account CFn**: Phase 1 は same-account のみ。Worker Lambda の execution
  role で `cloudformation:DescribeStackEvents` / `DescribeStackResources` を grant
  (Resource: * — CFn API は ARN 絞り込み非対応)。Phase 2 (#595 merge 後) で
  ExternalId 経由の AssumeRole 経路に拡張する。
- **D6 read-only**: AdminInsightApiLambda は read-only。Teams table を Phase 1.B で
  追加 grant。write 系 action が IAM Policy に含まれないことを stack test で固定。

## Regression 分析

- **既存 Phase 1.A `/tenants/summary`**: 触っていない。routes.test の existing 11
  ケースは green のまま。新 endpoint は別 path / 別 handler で完全分離。
- **AdminInsightApiLambda の IAM**: Teams read + CFn DescribeStack* を **追加**。
  既存 grant (Deployments / Events read) は維持。stack.test で write action 0 件を
  pin しつつ、追加 action を 1 件ずつ assert (= 想定外の権限拡張を防ぐ)。
- **AdminConsoleInsightStack HTTP API**: 既存 `/tenants/summary` route はそのまま、
  4 new route を `addRoutes` で追加 (同 Lambda integration / 同 JWT Authorizer)。
  既存 1 route の挙動は変わらない。
- **TenantList の click 経路**: 「名称」 cell のみ Link 化。tenantId / Tier / Status
  等の cell は無変更。deprovisioned 行は従来通り灰色テキストで Link 化しない。
- **application-admin-console**: 1 行も触っていない (= read-only mirror で完全分離)。

## 物理影響

- `AdminInsightApiLambda` Lambda function: **UPDATE** (bundle 中身が変わる、handler
  routes 4 増 + helper 関数 2 増、env 不変)
- `AdminInsightApiLambda` IAM Role の inline policy: **UPDATE**
  (Teams table grantReadData による action 追加 + CFn DescribeStack* PolicyStatement 追加)
- `AdminConsoleInsightStack` HTTP API: **UPDATE** (Route 4 + Integration 4 +
  各 route の Lambda invoke permission)
- `apps/admin-console/dist/`: **UPDATE** (新 page 3 個 + routing 追加で bundle 増)
- `runtime-config.json` schema: **NO-OP** (`adminInsightApiUrl` は Phase 1.A で既に在る)
- DynamoDB Tables (Deployments / Events / Teams): **NO-OP** (schema 不変、IAM のみ)

## Test plan

- [x] `make lint` → 0 error
- [x] `make check-http-status` → no magic numbers
- [x] `bun run --filter @TenkaCloud/infrastructure typecheck` → 0 error
- [x] `bun run --filter @TenkaCloud/infrastructure test` → 532/532 green
- [x] `bun run --filter @TenkaCloud/admin-console typecheck` → 0 error
- [x] `bun run --filter @TenkaCloud/admin-console test` → 84/84 green
- [x] `bun run --filter @TenkaCloud/admin-console build` → 0 error
- [x] pre-commit hook (= `make before-commit`) → 全 workspace test green

### 手動確認 (Phase 2 deploy 後に予定)

- [ ] System Admin: tenant 一覧から名称を click → Events 一覧表示
- [ ] Event 行 click → Event 詳細 (teams[].teamLoginKey 列は `••••` で blackout)
- [ ] Deploy job 行 click → Deploy 詳細 + CFn StackEvents 表示
- [ ] Tenant Admin token で同 API を叩くと 403 が返る
- [ ] CloudWatch Logs Insights で `admin.insight.read` の audit log に tenantId /
      eventId / jobId が記録される

Closes #598

## 関連

- PR-597 — Phase 1.A (本 PR の前提)
- PR-593 — ADR-011 (本 PR の設計母体)
- PR-588 — application-admin-console deploy 詳細 (本 L4 と同型 API、流用)
- Issue #595 — Phase 2.2 (= cross-account StackEvents 統合)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin drill-down functionality enabling system administrators to navigate through tenants, view their events, inspect event details including problem targets and team information, and track CloudFormation deployment progress with real-time stack status and resources.
  * Enhanced tenant list to link directly to event listings.
  * Deployment detail pages now display CloudFormation console links and stack event/resource tables.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/599)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->