### PR TITLE
feat(#459): Phase 2.2 Worker cross-account 化 + verified-only DeployForm

### DIFF
--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -7,13 +7,18 @@ import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
+import Link from "@cloudscape-design/components/link";
 import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
 import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { useApiClient } from "../api/client";
+import { type ApiClient, useApiClient } from "../api/client";
+import {
+  type CompetitorAccountSummary,
+  listCompetitorAccounts,
+} from "../api/competitor-accounts-client";
 import { createEvent } from "../api/events-client";
 import type { AppConfig } from "../config";
 import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
@@ -24,7 +29,6 @@ const NAME_MAX = 120;
 // drift すると frontend が通した値を backend が reject する。
 const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
 const ACCOUNT_ID_RE = /^\d{12}$/;
-const ACCOUNT_ID_MAX_LEN = 12;
 const TEAMS_MIN = 1;
 const TEAMS_MAX = 99;
 const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
@@ -71,6 +75,40 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   const problemOptions: MultiselectProps.Option[] = useMemo(
     () => allProblems.map((p) => ({ value: p.id, label: `${p.name} (${p.id})` })),
     [allProblems],
+  );
+
+  // Phase 2.2 (Issue #459): verified=true な CompetitorAccounts のみを Select の選択肢にする。
+  // 自由入力の Input は廃止 (= operator が verified 済 account しか選べない fail-closed UX)。
+  const [competitorAccounts, setCompetitorAccounts] = useState<
+    readonly CompetitorAccountSummary[] | null
+  >(null);
+  const [accountsLoadError, setAccountsLoadError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!apiClient) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await listCompetitorAccounts(apiClient as ApiClient);
+        if (!cancelled) setCompetitorAccounts(res.items);
+      } catch (err) {
+        if (!cancelled) setAccountsLoadError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient]);
+  const verifiedAccounts = useMemo(
+    () => (competitorAccounts ?? []).filter((a) => a.verified === true),
+    [competitorAccounts],
+  );
+  const accountOptions: SelectProps.Option[] = useMemo(
+    () =>
+      verifiedAccounts.map((a) => ({
+        value: a.awsAccountId,
+        label: a.alias ? `${a.alias} (${a.awsAccountId})` : a.awsAccountId,
+      })),
+    [verifiedAccounts],
   );
 
   const [name, setName] = useState("");
@@ -239,12 +277,33 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
 
           {/* #528: Teams section — 各 team の internalSlug + AWS Account ID を per-team で入力。
            *   旧 UX は problem 単位で 1 account 共有だったが、real competition では各 team が
-           *   自社 account を持つため per-team 入力にする。 */}
+           *   自社 account を持つため per-team 入力にする。
+           *   Phase 2.2 (Issue #459): account は verified=true な CompetitorAccounts のみ選択
+           *   できる drop-down。0 件のときは Competitor Accounts ページへの導線を出す。 */}
+          {accountsLoadError && (
+            <Alert type="error" header="Competitor Accounts の取得に失敗しました">
+              {accountsLoadError}
+            </Alert>
+          )}
+          {competitorAccounts !== null && verifiedAccounts.length === 0 && !accountsLoadError && (
+            <Alert
+              type="warning"
+              header="verified=true な Competitor Account がありません"
+              action={
+                <Link href="#/competitor-accounts" external={false}>
+                  Competitor Accounts へ移動
+                </Link>
+              }
+            >
+              Event 作成前に Competitor Accounts ページで AWS Account を追加 → STS Verify を実行
+              してください。verified=true でない account には deploy できません。
+            </Alert>
+          )}
           <Container
             header={
               <Header
                 variant="h2"
-                description="各 team の deploy 先 AWS Account ID を入力します (12 桁数字)。internalSlug は CFn StackName 由来になり deploy 後 immutable。"
+                description="各 team の deploy 先 AWS Account を選択します (verified=true 行のみ)。internalSlug は CFn StackName 由来になり deploy 後 immutable。"
               >
                 Teams ({teamRows.length})
               </Header>
@@ -275,22 +334,30 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                   },
                   {
                     id: "account",
-                    header: "AWS Account ID",
-                    cell: (t) => (
-                      <Input
-                        value={t.awsAccountId}
-                        placeholder="123456789012"
-                        inputMode="numeric"
-                        invalid={t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)}
-                        onChange={({ detail }) =>
-                          updateTeamRow(t.idx, {
-                            awsAccountId: detail.value
-                              .replace(/\D/g, "")
-                              .slice(0, ACCOUNT_ID_MAX_LEN),
-                          })
-                        }
-                      />
-                    ),
+                    header: "AWS Account ID (verified)",
+                    cell: (t) => {
+                      const selected =
+                        accountOptions.find((o) => o.value === t.awsAccountId) ?? null;
+                      return (
+                        <Select
+                          selectedOption={selected}
+                          options={accountOptions}
+                          placeholder={
+                            accountOptions.length === 0
+                              ? "verified account 未登録"
+                              : "verified account を選択"
+                          }
+                          disabled={accountOptions.length === 0}
+                          empty="verified=true な競技者 account がありません"
+                          onChange={({ detail }) =>
+                            updateTeamRow(t.idx, {
+                              awsAccountId: detail.selectedOption?.value ?? "",
+                            })
+                          }
+                          invalid={t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)}
+                        />
+                      );
+                    },
                   },
                 ]}
               />

--- a/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Phase 2.2 (Issue #459) EventCreate verified-only drop-down 移行のテスト。
+ *
+ * - verified=true な CompetitorAccount のみが Select の選択肢に出る
+ * - verified=false / 未登録は drop-down に出ない (UI 上で deploy 不可)
+ * - 0 件のときは「Competitor Accounts へ移動」の導線を出す
+ *
+ * 1 ファイルで完結させるため、`useApiClient` / `listCompetitorAccounts` を vi.mock し、
+ * `createEvent` は touch しない (= submit 経路は別 test の責務)。
+ */
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  listCompetitorAccounts: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/competitor-accounts-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/competitor-accounts-client")>();
+  return {
+    ...actual,
+    listCompetitorAccounts: mocks.listCompetitorAccounts,
+  };
+});
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const { EventCreatePage } = await import("../../src/pages/EventCreate");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/events/new"]}>
+      <Routes>
+        <Route path="/events/new" element={<EventCreatePage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventCreatePage (Phase 2.2 verified-only)", () => {
+  it("0 件のとき Competitor Accounts への導線 (Alert) を表示するべき", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce({ items: [] });
+    renderPage();
+    // listCompetitorAccounts が呼ばれた後、warning Alert が出る
+    await waitFor(() => {
+      expect(
+        screen.getByText(/verified=true な Competitor Account がありません/),
+      ).toBeInTheDocument();
+    });
+    // 導線として Competitor Accounts への link を出す
+    expect(screen.getByText(/Competitor Accounts へ移動/)).toBeInTheDocument();
+  });
+
+  it("verified=false の account は drop-down 選択肢に出さないべき", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce({
+      items: [
+        {
+          awsAccountId: "111111111111",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          alias: "Verified Team A",
+          verified: true,
+          verifiedAt: "2026-05-10T00:00:00.000Z",
+          createdAt: "2026-05-09T00:00:00.000Z",
+          updatedAt: "2026-05-10T00:00:00.000Z",
+        },
+        {
+          awsAccountId: "222222222222",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          alias: "Unverified Team B",
+          verified: false,
+          createdAt: "2026-05-09T00:00:00.000Z",
+          updatedAt: "2026-05-09T00:00:00.000Z",
+        },
+      ],
+    });
+    renderPage();
+    // listCompetitorAccounts が呼ばれる
+    await waitFor(() => {
+      expect(mocks.listCompetitorAccounts).toHaveBeenCalled();
+    });
+    // Cloudscape Select の placeholder で「verified=true 行のみ」を operator に明示
+    // verified=false (222) は drop-down に出ないことを確認するため、placeholder の存在を pin
+    // (= verified=true な選択肢があるなら placeholder は「verified account を選択」)。
+    await waitFor(() => {
+      const trigger = screen.queryAllByText(/verified account を選択/);
+      expect(trigger.length).toBeGreaterThan(0);
+    });
+    // verified=false な account の alias は drop-down trigger に出ない
+    // (closed 状態では選択肢 ul が DOM に無いので、alias 文字列がページ上に出ない)
+    expect(screen.queryByText(/Unverified Team B/)).not.toBeInTheDocument();
+  });
+
+  it("API 取得 error は赤 Alert で operator に通知するべき", async () => {
+    mocks.listCompetitorAccounts.mockRejectedValueOnce(new Error("network down"));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Competitor Accounts の取得に失敗しました/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/network down/)).toBeInTheDocument();
+  });
+});

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -1,15 +1,21 @@
 import * as path from "node:path";
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import type { IEventBus } from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
+import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DeployApiLambdaProps {
   readonly deploymentsTable: Table;
   readonly eventBus: IEventBus;
+  /**
+   * Phase 2.2 (Issue #459): single-deploy / stack-progress が verified=true 行のみ
+   * 許可する gate のため、CompetitorAccounts table を Read する。
+   */
+  readonly competitorAccountsTable: Table;
   /**
    * tenantId として handler に渡す `DEFAULT_TENANT_ID` env。Cognito JWT authorizer
    * 結線後は JWT claim から取るが、Function URL 直叩き / dev / unit test では本値を使う。
@@ -22,6 +28,10 @@ export interface DeployApiLambdaProps {
    * 入力 (`detail.problemDir`) に詰める。Phase 2 (ADR-003) で DDB ベースの catalog に置換。
    */
   readonly problemsCatalog: Readonly<Record<string, string>>;
+  /**
+   * SSM SecureString path 構築用の env 名 (Phase 2.2、`/<environmentName>/tenants/...`)。
+   */
+  readonly environmentName: string;
 }
 
 /**
@@ -49,6 +59,9 @@ export class DeployApiLambda extends Construct {
       memorySize: 256,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        // Phase 2.2 (Issue #459)
+        COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         DEFAULT_TENANT_ID: props.defaultTenantId ?? "unknown-tenant",
         BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
@@ -62,20 +75,59 @@ export class DeployApiLambda extends Construct {
       },
     });
 
-    // 必要な権限: DDB CRUD + EventBus PutEvents (cross-account AssumeRole は不要、MVP-1 は
-    // 同一 account 内 deploy のみ)。
+    // 必要な権限: DDB CRUD + EventBus PutEvents + CompetitorAccounts Read。
+    // Phase 2.2 (Issue #459): verified-only gate のために CompetitorAccounts は read-only で
+    // 引く。AssumeRole / SSM SecureString は CompetitorAccountsApiLambda + State Machine 経由
+    // (= 本 Lambda は同期 API 経路のみ担う)。
     props.deploymentsTable.grantReadWriteData(this.fn);
+    props.competitorAccountsTable.grantReadData(this.fn);
     props.eventBus.grantPutEventsTo(this.fn);
 
     // #534: deploy job 詳細ページから CFn StackEvents / StackResources を引く読み取り権限。
-    // MVP-1 は same-account のみなので Resource は account 内全 stack を許可するが、
-    // action は **Describe* read-only に限定** (= 副作用なし、最小権限)。Phase 2 で cross-account
-    // になったら ここを sts:AssumeRole に置き換え、target account 側で role に持たせる。
+    // same-account 経路 (= dev / 旧 deployment 行) では本 Lambda Role が直接呼ぶため Describe*
+    // を ALLOW する。Phase 2.2 (Issue #459) の cross-account では AssumeRole 経由になるが、
+    // verified=true 行が無いケースで fallback として残るので削除しない。
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["cloudformation:DescribeStackEvents", "cloudformation:DescribeStackResources"],
         resources: ["*"],
+      }),
+    );
+
+    // Phase 2.2 (Issue #459): stack-progress の cross-account 経路で必要な権限。
+    //   - SSM SecureString Read (= tenant path prefix scope)
+    //   - kms:Decrypt (= SSM SecureString 復号、AWS managed key + EncryptionContext で絞る)
+    //   - sts:AssumeRole (= 競技者 IAM Role `TenkaCloud-*`)
+    // CompetitorAccountsApiLambda と同じ pattern (= 最小権限 + path prefix scope)。
+    const stack = Stack.of(this);
+    const ssmArn = buildExternalIdParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: [ssmArn],
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: {
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": ssmArn },
+        },
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
       }),
     );
   }

--- a/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
+++ b/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
@@ -1,4 +1,4 @@
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import {
   BuildEnvironmentVariableType,
   BuildSpec,
@@ -10,6 +10,7 @@ import {
 import * as iam from "aws-cdk-lib/aws-iam";
 import type { IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
+import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DeployCodeBuildProjectProps {
   /**
@@ -43,6 +44,11 @@ export interface DeployCodeBuildProjectProps {
    * dev / sandbox では小さい値 (例: 5) に絞ってコスト暴走を防ぐ用途にも使う。
    */
   readonly concurrentBuildLimit?: number;
+  /**
+   * Phase 2.2 (Issue #459): SSM SecureString path 構築用 env (例: `development`)。
+   * CodeBuild Role に `ssm:GetParameter` を付与する scope (= 同 tenant prefix) を作る。
+   */
+  readonly environmentName: string;
 }
 
 /**
@@ -114,6 +120,20 @@ export class DeployCodeBuildProject extends Construct {
           type: BuildEnvironmentVariableType.PLAINTEXT,
           value: "<unset-overridden-by-step-functions>",
         },
+        // Phase 2.2 (Issue #459): cross-account AssumeRole metadata。State Machine が
+        // event detail から override する。空文字 default = same-account fallback。
+        COMPETITOR_ROLE_ARN: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: "",
+        },
+        EXTERNAL_ID_SSM_PARAMETER: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: "",
+        },
+        DEPLOY_REGION: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: "",
+        },
       },
       buildSpec: BuildSpec.fromObject({
         version: "0.2",
@@ -165,6 +185,45 @@ export class DeployCodeBuildProject extends Construct {
         effect: iam.Effect.ALLOW,
         actions: ["ec2:*", "iam:*", "ssm:*", "logs:*", "s3:*", "events:*", "lambda:*"],
         resources: ["*"],
+      }),
+    );
+
+    // Phase 2.2 (Issue #459): cross-account 経路。CodeBuild script (deploy-battles.sh /
+    // delete-battles.sh) が:
+    //   1. SSM SecureString から ExternalId を read (= `ssm:GetParameter` + `kms:Decrypt`)
+    //   2. `arn:aws:iam::<account>:role/TenkaCloud-*` に AssumeRole (with ExternalId)
+    //   3. 取得した tmp credentials で `aws cloudformation deploy` を target account に実行
+    // を行うため、本 Project Role に各権限を付与する。
+    const stack = Stack.of(this);
+    const ssmArn = buildExternalIdParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    this.project.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: [ssmArn],
+      }),
+    );
+    this.project.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: {
+          // CompetitorAccountsApiLambda と同じ pattern。StringLike で wildcard を許容。
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": ssmArn },
+        },
+      }),
+    );
+    this.project.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        // 競技者アカウントの IAM Role 名 pattern (= `TenkaCloud-*` prefix 必須)。
+        resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
       }),
     );
   }

--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -73,12 +73,31 @@ export class DeployCreateStateMachine extends Construct {
       resultPath: JsonPath.DISCARD,
     });
 
+    // Phase 2.2 (Issue #459): `$.detail.competitorRoleArn` / `$.detail.externalIdParameterName`
+    // を CodeBuild env に渡す。`deploy-battles.sh` 内で `COMPETITOR_ROLE_ARN` が空でなければ
+    // AssumeRole + ExternalId 経路に倒し、空なら same-account fallback (dev / 未 verify) を残す。
+    // Step Functions の `States.Format` / 直接 path 参照は path が `undefined` だと fail する
+    // (= optional field を入れるのが難しい)。bulk-deploy / startDeployment は verified=true
+    // のときのみ field を埋めているため、verified-only 経路では必ず存在する。
+    // 未 verified だった場合は publish そのものが起きないので path 参照しても to-end は安全。
+    // ただ後方互換 (= 旧 event detail に competitorRoleArn 無し) を保つため、CodeBuild env は
+    // 任意 path 経由で参照する。
     const startCodeBuild = new CodeBuildStartBuild(this, "StartDeployCodeBuild", {
       project: props.codeBuildProject,
       integrationPattern: IntegrationPattern.RUN_JOB,
       environmentVariablesOverride: {
         BATTLE_PROBLEM_DIR: { value: JsonPath.stringAt("$.detail.problemDir") },
         TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
+        // Phase 2.2: AssumeRole metadata。verified=true 行のみ埋められるので、unverified 経路
+        // で State Machine が起動することは無い (= bulk-deploy / startDeployment が事前に gate)。
+        // `States.Format` を使って `null` 安全 (= 値が無いなら空文字)。
+        COMPETITOR_ROLE_ARN: {
+          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.competitorRoleArn")),
+        },
+        EXTERNAL_ID_SSM_PARAMETER: {
+          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.externalIdParameterName")),
+        },
+        DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
       },
       resultPath: "$.codebuild",
     });

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -65,6 +65,14 @@ export class DeployDeleteStateMachine extends Construct {
         OPERATION: { value: "delete" },
         DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
         DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+        // Phase 2.2 (Issue #459): cross-account delete でも AssumeRole metadata を渡す。
+        // detail に値が無いケース (旧 deployment 行) は `States.Format` で空文字に倒れる。
+        COMPETITOR_ROLE_ARN: {
+          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.competitorRoleArn")),
+        },
+        EXTERNAL_ID_SSM_PARAMETER: {
+          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.externalIdParameterName")),
+        },
       },
       resultPath: "$.codebuild",
     });

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -15,6 +15,11 @@ export interface EventApiLambdaProps {
    */
   readonly deploymentsTable: Table;
   /**
+   * Phase 2.2 (Issue #459): Bulk Deploy が deploy 前に verified=true 行のみ許可する
+   * gate のため、CompetitorAccounts table を Read する。
+   */
+  readonly competitorAccountsTable: Table;
+  /**
    * Phase 2a で `DeployCreateRequested` / `DeployDeleteRequested` を fan-out publish
    * するため、ControlPlane の共通 EventBus への PutEvents 権限を grant する。
    */
@@ -29,6 +34,12 @@ export interface EventApiLambdaProps {
    * Cognito JWT 結線後は JWT claim から取る。
    */
   readonly defaultTenantId?: string;
+  /**
+   * SSM SecureString path 構築用の env 名 (Phase 2.2)。Bulk Deploy が DeployCreate-
+   * Requested detail に詰める `externalIdParameterName` のために必要 (= CompetitorAccountsApi
+   * Lambda と同じ env 名)。
+   */
+  readonly environmentName: string;
 }
 
 /**
@@ -61,6 +72,10 @@ export class EventApiLambda extends Construct {
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         TEAMS_TABLE_NAME: props.teamsTable.tableName,
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        // Phase 2.2 (Issue #459): bulk-deploy が CompetitorAccounts table を引いて verified-only
+        // gate を実現するため、table 名と SSM path 構築用 env 名を Lambda 環境に注入する。
+        COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         DEFAULT_TENANT_ID: props.defaultTenantId ?? "unknown-tenant",
         BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
@@ -79,6 +94,10 @@ export class EventApiLambda extends Construct {
     props.eventsTable.grantReadWriteData(this.fn);
     props.teamsTable.grantReadWriteData(this.fn);
     props.deploymentsTable.grantReadWriteData(this.fn);
+    // Phase 2.2 (Issue #459): CompetitorAccounts は read-only (verified gate のみ)。
+    // verify / Put / Delete は CompetitorAccountsApiLambda 側で行うので、本 Lambda には
+    // RW を付与しない (= 最小権限)。
+    props.competitorAccountsTable.grantReadData(this.fn);
     props.eventBus.grantPutEventsTo(this.fn);
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -1,4 +1,5 @@
 import { GetCommand, UpdateCommand, type UpdateCommandInput } from "@aws-sdk/lib-dynamodb";
+import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import {
   type DeployDeleteRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
@@ -86,12 +87,27 @@ export async function requestTeardown(
     throw err;
   }
 
+  // Phase 2.2 (Issue #459): delete も cross-account 化。verified=true 行が見つかった
+  // 場合のみ AssumeRole 用 metadata を詰める (= 旧 deployment 行で competitor が未登録の
+  // ケースは undefined のまま — CodeBuild は同 account 経路に倒れる)。
+  const verified = await resolveVerifiedCompetitorAccount(
+    {
+      ddb: shared.ddb,
+      competitorAccountsTableName: shared.competitorAccountsTableName,
+      env: shared.env,
+    },
+    tenantId,
+    awsAccountId,
+  );
+
   const detail: DeployDeleteRequestedDetail = {
     jobId,
     tenantId,
     stackName,
     region,
     awsAccountId,
+    competitorRoleArn: verified?.competitorRoleArn,
+    externalIdParameterName: verified?.externalIdParameterName,
   };
   try {
     await publishProblemEvent({

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -4,6 +4,7 @@ import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
+import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import {
   type DeployCreateRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
@@ -15,6 +16,12 @@ import type { DeploymentItem, DeployRequest, DeployResponse } from "./types.js";
 
 export interface DeployContext {
   readonly tableName: string;
+  /**
+   * Phase 2.2 (Issue #459): CompetitorAccounts table 名 + SSM SecureString path env 名。
+   * `startDeployment` が verified=true gate と AssumeRole metadata 注入に使う。
+   */
+  readonly competitorAccountsTableName: string;
+  readonly env: string;
   readonly eventBusName: string;
   readonly ddb: DynamoDBDocumentClient;
   readonly events: EventBridgeClient;
@@ -26,7 +33,7 @@ export interface DeployContext {
   readonly tenantId: string;
   /**
    * problemId → problemDir のマップ (例: `{"hello-world": "problems/challenges/hello-world"}`)。
-   * MVP-1 で env (`BATTLE_PROBLEMS_CATALOG` JSON) から injected される hard-coded catalog。
+   * MVP-1 で env (`BATTLE_PROBLEMS_CATALOG` JSON) from inject される hard-coded catalog。
    * Phase 2 (ADR-003) で DDB ベースの問題カタログに置換する。
    */
   readonly problemsCatalog: Readonly<Record<string, string>>;
@@ -48,6 +55,18 @@ export class UnknownProblemError extends Error {
 }
 
 /**
+ * Phase 2.2 (Issue #459): verified=true 行が CompetitorAccounts table に無い (tenantId,
+ * awsAccountId) 組への deploy を reject するために throw する error。
+ * handler 側で 409 Conflict / 422 Unprocessable に変換する。
+ */
+export class UnverifiedCompetitorAccountError extends Error {
+  constructor(public readonly awsAccountId: string) {
+    super(`competitor account ${awsAccountId} is not verified for this tenant`);
+    this.name = "UnverifiedCompetitorAccountError";
+  }
+}
+
+/**
  * 1 件の deploy job を起動する。
  *
  * DDB Put → EventBridge Publish の順序は失敗セマンティクスが要求する: PutEvents が
@@ -59,6 +78,19 @@ export async function startDeployment(
 ): Promise<DeployResponse> {
   const problemDir = ctx.problemsCatalog[request.problemId];
   if (!problemDir) throw new UnknownProblemError(request.problemId);
+
+  // Phase 2.2 (Issue #459): verified=true な行が無ければ deploy しない (= fail-closed)。
+  // 同 account deploy の dev fallback も廃止 — 全 deploy は verified なれた account のみ。
+  const verified = await resolveVerifiedCompetitorAccount(
+    {
+      ddb: ctx.ddb,
+      competitorAccountsTableName: ctx.competitorAccountsTableName,
+      env: ctx.env,
+    },
+    ctx.tenantId,
+    request.awsAccountId,
+  );
+  if (!verified) throw new UnverifiedCompetitorAccountError(request.awsAccountId);
 
   const jobId = ulid();
   const teamLoginKey = generateTeamLoginKey();
@@ -108,6 +140,11 @@ export async function startDeployment(
     namePrefix: item.namePrefix,
     region: item.region,
     awsAccountId: item.awsAccountId,
+    // Phase 2.2: AssumeRole 用 metadata。`resolveVerifiedCompetitorAccount` の戻り値から
+    // そのまま詰める。CodeBuild script (deploy-battles.sh wrapper) が SSM ExternalId を
+    // fetch して AssumeRole する。
+    competitorRoleArn: verified.competitorRoleArn,
+    externalIdParameterName: verified.externalIdParameterName,
   };
   await publishProblemEvent({
     client: ctx.events,
@@ -132,6 +169,8 @@ export async function startDeployment(
  */
 export interface DeploySharedResources {
   readonly tableName: string;
+  readonly competitorAccountsTableName: string;
+  readonly env: string;
   readonly eventBusName: string;
   readonly ddb: DynamoDBDocumentClient;
   readonly events: EventBridgeClient;
@@ -141,6 +180,8 @@ export interface DeploySharedResources {
 export function buildSharedResources(): DeploySharedResources {
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
+    competitorAccountsTableName: getEnv("COMPETITOR_ACCOUNTS_TABLE_NAME"),
+    env: getEnv("DEPLOY_ENVIRONMENT"),
     eventBusName: getEnv("DEPLOY_EVENT_BUS_NAME"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     events: new EventBridgeClient({}),

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -19,9 +19,14 @@ import {
   buildSharedResources,
   startDeployment,
   UnknownProblemError,
+  UnverifiedCompetitorAccountError,
 } from "./deploy.js";
 import { getDeployment, listDeployments } from "./list.js";
-import { defaultCfnClient, getStackProgress } from "./stack-progress.js";
+import {
+  defaultCfnClient,
+  defaultCfnClientForCompetitor,
+  getStackProgress,
+} from "./stack-progress.js";
 import { DeployRequestSchema } from "./types.js";
 
 /**
@@ -110,6 +115,20 @@ app.post("/problems/:problemId/deploy", async (c) => {
     if (err instanceof UnknownProblemError) {
       return c.json({ error: "unknown_problem", problemId }, HTTP_NOT_FOUND);
     }
+    // Phase 2.2 (Issue #459): verified=true 行が無い account への deploy は 422 (semantically
+    // 適切: request 自体は well-formed だが、business invariant が満たされない)。operator は
+    // CompetitorAccounts ページで verify を済ませてから retry する。
+    if (err instanceof UnverifiedCompetitorAccountError) {
+      return c.json(
+        {
+          error: "unverified_competitor_account",
+          awsAccountId: err.awsAccountId,
+          message:
+            "AWS Account ID が CompetitorAccounts table で verified=true 状態でないため deploy できません。",
+        },
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      );
+    }
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[deploy] startDeployment failed", { problemId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
@@ -183,7 +202,7 @@ app.get("/deployments/:jobId/stack-progress", async (c) => {
   try {
     const outcome = await getStackProgress(
       shared,
-      { cfnClient: defaultCfnClient },
+      { cfnClient: defaultCfnClient, cfnClientForCompetitor: defaultCfnClientForCompetitor },
       resolveTenantId(c),
       jobId,
     );

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
@@ -5,7 +5,10 @@ import {
   type StackEvent,
   type StackResource,
 } from "@aws-sdk/client-cloudformation";
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import type { DeploySharedResources } from "./deploy.js";
 import type { DeploymentItem } from "./types.js";
 
@@ -98,10 +101,22 @@ function isStackNotFoundError(err: unknown): boolean {
 
 export interface StackProgressDeps {
   /**
-   * region 別の CFn client を返す factory。region は同一 account に固定 (MVP-1) なので
-   * AssumeRole は不要。テスト時には mock client を返す stub に差し替える。
+   * region 別の CFn client を返す factory。same-account fallback で使う。
+   * Phase 2.2 (Issue #459) cross-account 経路では `cfnClientForCompetitor` 経由で
+   * AssumeRole 済 credentials で client を組む (= 本 factory は dev / 未 verify 用)。
    */
   readonly cfnClient: (region: string) => CloudFormationClient;
+  /**
+   * Phase 2.2: cross-account 用 CFn client を返す factory (default impl は同 module 内
+   * `defaultCfnClientForCompetitor`)。tenantId + awsAccountId + region + competitorRoleArn +
+   * SSM path から AssumeRole + ExternalId fetch を行い、tmp credentials の CFn client を作る。
+   * テスト時には mock client を返す stub に差し替える (= STS call を握り潰す)。
+   */
+  readonly cfnClientForCompetitor?: (params: {
+    readonly region: string;
+    readonly competitorRoleArn: string;
+    readonly externalIdParameterName: string;
+  }) => Promise<CloudFormationClient>;
 }
 
 /** module-scope の lazy cache。region ごとに 1 度だけ build する (warm invoke で再利用)。 */
@@ -114,6 +129,55 @@ export const defaultCfnClient = (region: string): CloudFormationClient => {
   }
   return c;
 };
+
+/**
+ * Phase 2.2 (Issue #459): cross-account CFn client factory の default 実装。
+ *
+ * 1. SSM SecureString から ExternalId を取得 (= `kms:Decrypt` で復号)
+ * 2. STS AssumeRole (with ExternalId) で 15 分 tmp credentials を取得
+ * 3. credentials を CloudFormationClient に注入して返す
+ *
+ * caller (= `getStackProgress`) は session 内で 1 度 build した client を `Promise.all` で
+ * 並列に使う (= DescribeStackEvents + DescribeStackResources)。15 分 session 内なら 1 回の
+ * AssumeRole で複数 API を捌ける。session を warm Lambda invoke 跨ぎでキャッシュすると鍵
+ * 漏洩リスクが上がるので、本実装ではキャッシュしない (cold session every request)。
+ */
+const moduleSts = new STSClient({});
+const moduleSsm = new SSMClient({});
+
+export async function defaultCfnClientForCompetitor(params: {
+  readonly region: string;
+  readonly competitorRoleArn: string;
+  readonly externalIdParameterName: string;
+}): Promise<CloudFormationClient> {
+  const ssmOut = await moduleSsm.send(
+    new GetParameterCommand({ Name: params.externalIdParameterName, WithDecryption: true }),
+  );
+  const externalId = ssmOut.Parameter?.Value;
+  if (!externalId) {
+    throw new Error(`ExternalId not found in SSM SecureString: ${params.externalIdParameterName}`);
+  }
+  const stsOut = await moduleSts.send(
+    new AssumeRoleCommand({
+      RoleArn: params.competitorRoleArn,
+      RoleSessionName: `tenkacloud-stack-progress-${Date.now()}`,
+      ExternalId: externalId,
+      DurationSeconds: 900,
+    }),
+  );
+  const creds = stsOut.Credentials;
+  if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+    throw new Error("AssumeRole returned incomplete credentials");
+  }
+  return new CloudFormationClient({
+    region: params.region,
+    credentials: {
+      accessKeyId: creds.AccessKeyId,
+      secretAccessKey: creds.SecretAccessKey,
+      sessionToken: creds.SessionToken,
+    },
+  });
+}
 
 /**
  * 指定 jobId の deploy job について、CFn StackEvents / StackResources を取得して
@@ -152,7 +216,26 @@ export async function getStackProgress(
   // CFn は StackName / StackId のどちらでも引ける。stackId が確定済ならそれを使う
   // (= 万一 stack を delete → 同名再作成した場合に旧 stack の events に混入しない)。
   const stackRef = item.stackId ?? stackName;
-  const cfn = deps.cfnClient(region);
+  // Phase 2.2 (Issue #459): verified=true 行が CompetitorAccounts table にあれば
+  // AssumeRole 経由で cross-account client を組む。無ければ同 account 経路 (= dev /
+  // 旧 deployment 行 / 未 verify) で従来通り。
+  const verified = await resolveVerifiedCompetitorAccount(
+    {
+      ddb: shared.ddb,
+      competitorAccountsTableName: shared.competitorAccountsTableName,
+      env: shared.env,
+    },
+    tenantId,
+    String(item.awsAccountId ?? ""),
+  );
+  const cfn: CloudFormationClient =
+    verified && deps.cfnClientForCompetitor
+      ? await deps.cfnClientForCompetitor({
+          region,
+          competitorRoleArn: verified.competitorRoleArn,
+          externalIdParameterName: verified.externalIdParameterName,
+        })
+      : deps.cfnClient(region);
 
   let events: StackEvent[];
   let resources: StackResource[];

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -10,6 +10,10 @@ import { ulid } from "ulid";
 import { buildStackPrefix, slugify } from "../deploy-handler/naming.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import {
+  resolveVerifiedCompetitorAccount,
+  type VerifiedCompetitorAccount,
+} from "../shared/competitor-account-lookup.js";
+import {
   type DeployCreateRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   EVENT_SOURCE,
@@ -26,6 +30,14 @@ export interface BulkDeployResult {
   readonly enqueued: number;
   /** 既存 deployment 行と問題 ID 衝突で skip された組み合わせ数 (再 deploy 防止)。 */
   readonly skipped: number;
+  /**
+   * Phase 2.2 (Issue #459): verified=false / 未登録の awsAccountId のため reject された
+   * team 数。`unverifiedAccounts` には実 awsAccountId を入れて operator が補正できるよう
+   * 通知する。
+   */
+  readonly unverified?: number;
+  /** Phase 2.2: 上記の補足情報。重複は除く (Set 化)。 */
+  readonly unverifiedAccounts?: readonly string[];
 }
 
 export type BulkDeployOutcome = { kind: "ok"; result: BulkDeployResult } | { kind: "not_found" };
@@ -135,6 +147,33 @@ export async function bulkDeployEvent(
     return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
   }
 
+  // Phase 2.2 (Issue #459): bulk-deploy 前に CompetitorAccounts table で verified=true 行が
+  // ある (tenantId, awsAccountId) のみ許可する。verified=false / 未登録の team は plan から
+  // 落ちる (= unverified にカウント、`unverifiedAccounts` で operator に通知)。
+  //
+  // teams × problems の plan ループに入る前に 1 度だけ解決して in-memory map 化する。
+  // problem.defaultAwsAccountId fallback 経路も同じ map で評価できるよう、unique な
+  // awsAccountId set を作って一度に解決する。
+  const candidateAccountIds = new Set<string>();
+  for (const t of teams) if (t.awsAccountId) candidateAccountIds.add(t.awsAccountId);
+  for (const p of problems)
+    if (p.defaultAwsAccountId) candidateAccountIds.add(p.defaultAwsAccountId);
+  const verifiedByAccount = new Map<string, VerifiedCompetitorAccount>();
+  await Promise.all(
+    Array.from(candidateAccountIds).map(async (aId) => {
+      const v = await resolveVerifiedCompetitorAccount(
+        {
+          ddb: shared.ddb,
+          competitorAccountsTableName: shared.competitorAccountsTableName,
+          env: shared.env,
+        },
+        tenantId,
+        aId,
+      );
+      if (v) verifiedByAccount.set(aId, v);
+    }),
+  );
+
   const createdAt = new Date(nowMs).toISOString();
   const expiresAt = toEpochSeconds(nowMs + DEFAULT_TTL_MS);
   // Event.startsAt が未設定 = 競技開始時刻が決まっていないので採点開始しない gate に倒す。
@@ -157,6 +196,7 @@ export async function bulkDeployEvent(
   }
   const plan: PlanEntry[] = [];
   let skipped = 0;
+  const unverifiedAccounts = new Set<string>();
   for (const team of teams) {
     const teamAwsAccountId = team.awsAccountId;
     for (const problem of problems) {
@@ -179,6 +219,13 @@ export async function bulkDeployEvent(
       const awsAccountId = teamAwsAccountId ?? problem.defaultAwsAccountId;
       if (!awsAccountId) {
         skipped++;
+        continue;
+      }
+      // Phase 2.2 (Issue #459): verified=true な行が無い account は reject。
+      // plan に乗せない (= worker が走らない) ため fail-closed。
+      const verified = verifiedByAccount.get(awsAccountId);
+      if (!verified) {
+        unverifiedAccounts.add(awsAccountId);
         continue;
       }
       const jobId = ulid();
@@ -217,6 +264,10 @@ export async function bulkDeployEvent(
         namePrefix,
         region: problem.defaultRegion,
         awsAccountId,
+        // Phase 2.2: cross-account 経路で CodeBuild が AssumeRole に使う metadata。
+        // verified=true 行が解決できたときのみ詰める (= 未指定なら same-account fallback)。
+        competitorRoleArn: verified.competitorRoleArn,
+        externalIdParameterName: verified.externalIdParameterName,
       };
       const entry: PutEventsRequestEntry = {
         EventBusName: shared.eventBusName,
@@ -234,7 +285,10 @@ export async function bulkDeployEvent(
   }
 
   if (plan.length === 0) {
-    return { kind: "ok", result: { eventId, enqueued: 0, skipped } };
+    return {
+      kind: "ok",
+      result: buildResult({ eventId, enqueued: 0, skipped, unverifiedAccounts }),
+    };
   }
 
   // DDB TransactWrite は 1 call 25 items まで (Put + Delete を合算)。retryFailedOnly では
@@ -314,5 +368,32 @@ export async function bulkDeployEvent(
     });
   await Promise.all([...putChunks, updateStatus]);
 
-  return { kind: "ok", result: { eventId, enqueued: items.length, skipped } };
+  return {
+    kind: "ok",
+    result: buildResult({ eventId, enqueued: items.length, skipped, unverifiedAccounts }),
+  };
+}
+
+/**
+ * Phase 2.2 (Issue #459): result builder。`unverifiedAccounts` が空のときは
+ * `unverified` / `unverifiedAccounts` フィールド自体を出さない (= 既存 client が
+ * 後方互換)。あるときは sorted array で安定出力する (= operator UI 表示用)。
+ */
+function buildResult(args: {
+  readonly eventId: string;
+  readonly enqueued: number;
+  readonly skipped: number;
+  readonly unverifiedAccounts: Set<string>;
+}): BulkDeployResult {
+  const base: BulkDeployResult = {
+    eventId: args.eventId,
+    enqueued: args.enqueued,
+    skipped: args.skipped,
+  };
+  if (args.unverifiedAccounts.size === 0) return base;
+  return {
+    ...base,
+    unverified: args.unverifiedAccounts.size,
+    unverifiedAccounts: Array.from(args.unverifiedAccounts).sort(),
+  };
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -13,12 +13,18 @@ import { parseProblemsCatalog } from "../shared/catalog.js";
  * への書き込み + EventBridge publish (DeployCreateRequested / DeployDeleteRequested)
  * が必要になったため拡張する。problemsCatalog は bulk deploy 時に problemId → problemDir
  * を解決するため env (BATTLE_PROBLEMS_CATALOG) から JSON parse する。
+ *
+ * Issue #459 / ADR-002 Phase 2.2: bulk-deploy が verified=true 行のみを許可する
+ * gate を持つため、`CompetitorAccounts` table 名と SSM SecureString path 構築用の
+ * `env` を share する。
  */
 export interface EventSharedResources {
   readonly eventsTableName: string;
   readonly teamsTableName: string;
   readonly deploymentsTableName: string;
+  readonly competitorAccountsTableName: string;
   readonly eventBusName: string;
+  readonly env: string;
   readonly ddb: DynamoDBDocumentClient;
   readonly events: EventBridgeClient;
   readonly problemsCatalog: Readonly<Record<string, string>>;
@@ -29,7 +35,9 @@ export function buildEventSharedResources(): EventSharedResources {
     eventsTableName: getEnv("EVENTS_TABLE_NAME"),
     teamsTableName: getEnv("TEAMS_TABLE_NAME"),
     deploymentsTableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
+    competitorAccountsTableName: getEnv("COMPETITOR_ACCOUNTS_TABLE_NAME"),
     eventBusName: getEnv("DEPLOY_EVENT_BUS_NAME"),
+    env: getEnv("DEPLOY_ENVIRONMENT"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     events: new EventBridgeClient({}),
     problemsCatalog: parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG),

--- a/infrastructure/lib/problem-deploy/handlers/shared/competitor-account-lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/competitor-account-lookup.ts
@@ -1,0 +1,75 @@
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { buildExternalIdParameterName } from "./external-id-store.js";
+
+/**
+ * `CompetitorAccounts` DDB 行から「verified=true 行のみ」を引く lookup (Issue #459 Phase 2.2)。
+ *
+ * Worker 経路 (= bulk-deploy / single-deploy / stack-progress) が deploy 前に呼ぶ。
+ * 戻り値が `null` の場合は 「verified=true な行が存在しない」 = backend で reject すべき。
+ *
+ * 本 helper は次の正本 (= single source of truth) を担う:
+ *   - `(tenantId, awsAccountId)` の検証 (verified=true)
+ *   - `competitorRoleName` の解決 (= AssumeRole 対象 Role 名)
+ *   - SSM SecureString path の構築 (= caller が CodeBuild env 等に渡す)
+ *
+ * **ExternalId は SSM から fetch しない** — caller (Worker / CodeBuild script) が必要な
+ * 時に SSM SecureString を直接読む。Lambda 側で plain text を返り値に乗せると、不必要に
+ * 漏洩経路が増える (= 同 Lambda の他の error log / response にも露出するリスク)。
+ *
+ * Schema:
+ *   PK = `TENANT#<tenantId>` / SK = `ACCOUNT#<awsAccountId>`
+ *   {verified: boolean, competitorRoleName: string, region: string, ...}
+ */
+export interface CompetitorAccountResolveDeps {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  readonly competitorAccountsTableName: string;
+  readonly env: string;
+}
+
+export interface VerifiedCompetitorAccount {
+  readonly awsAccountId: string;
+  readonly competitorRoleName: string;
+  readonly region: string;
+  /** SSM SecureString path (= `/<env>/tenants/<tenantId>/external-id`)。 */
+  readonly externalIdParameterName: string;
+  /**
+   * AssumeRole 対象の RoleArn (= `arn:aws:iam::<awsAccountId>:role/<competitorRoleName>`)。
+   * caller (CodeBuild env / STS client) は本値をそのまま使う。
+   */
+  readonly competitorRoleArn: string;
+}
+
+/**
+ * verified=true な競技者 account を解決して返す。verified=false / 未登録なら `null`。
+ *
+ * caller の呼び出しパターン:
+ *   const verified = await resolveVerifiedCompetitorAccount(deps, tenantId, awsAccountId);
+ *   if (!verified) throw new UnverifiedCompetitorAccountError(awsAccountId);
+ */
+export async function resolveVerifiedCompetitorAccount(
+  deps: CompetitorAccountResolveDeps,
+  tenantId: string,
+  awsAccountId: string,
+): Promise<VerifiedCompetitorAccount | null> {
+  const out = await deps.ddb.send(
+    new GetCommand({
+      TableName: deps.competitorAccountsTableName,
+      Key: { PK: `TENANT#${tenantId}`, SK: `ACCOUNT#${awsAccountId}` },
+    }),
+  );
+  const item = out.Item;
+  if (!item) return null;
+  if (item.verified !== true) return null;
+  const competitorRoleName = String(item.competitorRoleName ?? "");
+  if (!competitorRoleName) return null;
+  const region = String(item.region ?? "");
+  const externalIdParameterName = buildExternalIdParameterName(deps.env, tenantId);
+  return {
+    awsAccountId,
+    competitorRoleName,
+    region,
+    externalIdParameterName,
+    competitorRoleArn: `arn:aws:iam::${awsAccountId}:role/${competitorRoleName}`,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -38,6 +38,19 @@ export const DeployCreateRequestedDetailSchema = z.object({
   namePrefix: z.string().regex(/^tc-[a-z0-9]+(?:-[a-z0-9]+)+$/),
   region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
   awsAccountId: z.string().regex(/^\d{12}$/),
+  /**
+   * Phase 2.2 (Issue #459): cross-account deploy 用の AssumeRole 対象 RoleArn
+   * (= `arn:aws:iam::<awsAccountId>:role/<competitorRoleName>`)。CodeBuild が
+   * `aws sts assume-role` を実行するときに使う。verified=true な行が CompetitorAccounts
+   * DDB にあるときのみ詰める。同 account deploy (= dev fallback) では undefined。
+   */
+  competitorRoleArn: z.string().optional(),
+  /**
+   * Phase 2.2: SSM SecureString path (`/<env>/tenants/<tenantId>/external-id`)。
+   * CodeBuild が `aws ssm get-parameter --with-decryption` で ExternalId を取り、
+   * AssumeRole の `--external-id` に渡す。`competitorRoleArn` と同時にのみ詰める。
+   */
+  externalIdParameterName: z.string().optional(),
 });
 export type DeployCreateRequestedDetail = z.infer<typeof DeployCreateRequestedDetailSchema>;
 
@@ -56,6 +69,10 @@ export const DeployDeleteRequestedDetailSchema = z.object({
   stackName: z.string().min(1),
   region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
   awsAccountId: z.string().regex(/^\d{12}$/),
+  /** Phase 2.2: AssumeRole 対象 RoleArn (delete 経路。`DeployCreateRequestedDetail` と同じ役割)。 */
+  competitorRoleArn: z.string().optional(),
+  /** Phase 2.2: SSM SecureString path (delete 経路)。 */
+  externalIdParameterName: z.string().optional(),
 });
 export type DeployDeleteRequestedDetail = z.infer<typeof DeployDeleteRequestedDetailSchema>;
 

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -140,23 +140,29 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
+    // Phase 2.2 (Issue #459): CompetitorAccounts table + env を渡して verified-only gate を有効化。
     const deployApi = new DeployApiLambda(this, "DeployApi", {
       deploymentsTable: deployments.table,
+      competitorAccountsTable: competitorAccounts.table,
       eventBus,
       defaultTenantId: props.defaultTenantId,
       problemsCatalog: props.problemsCatalog,
+      environmentName: props.environmentName,
     });
     this.deployApiLambda = deployApi.fn;
 
     // ADR-004 Phase 1+2a: Event / Team CRUD + Bulk Deploy/Teardown Lambda。
     // Phase 2a で deployment 行の作成 / status 更新 + EventBridge fan-out publish を担う。
+    // Phase 2.2 (Issue #459): CompetitorAccounts table + env を渡して verified-only gate を有効化。
     const eventApi = new EventApiLambda(this, "EventApi", {
       eventsTable: events.table,
       teamsTable: teams.table,
       deploymentsTable: deployments.table,
+      competitorAccountsTable: competitorAccounts.table,
       eventBus,
       problemsCatalog: props.problemsCatalog,
       defaultTenantId: props.defaultTenantId,
+      environmentName: props.environmentName,
     });
     this.eventApiLambda = eventApi.fn;
 
@@ -177,6 +183,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       sourceBucket,
       sourceObjectKey: props.sourceObjectKey,
       concurrentBuildLimit: props.deployConcurrentBuildLimit,
+      environmentName: props.environmentName,
     });
 
     const stateMachine = new DeployCreateStateMachine(this, "DeployCreate", {

--- a/infrastructure/test/problem-deploy/competitor-account-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-account-lookup.test.ts
@@ -1,0 +1,69 @@
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { describe, expect, it, vi } from "vitest";
+import { resolveVerifiedCompetitorAccount } from "../../lib/problem-deploy/handlers/shared/competitor-account-lookup";
+
+const TENANT_ID = "tenant-acme";
+const ACCOUNT_ID = "123456789012";
+
+function buildDeps(send: ReturnType<typeof vi.fn>) {
+  return {
+    ddb: { send } as unknown as Parameters<typeof resolveVerifiedCompetitorAccount>[0]["ddb"],
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
+  };
+}
+
+describe("resolveVerifiedCompetitorAccount", () => {
+  it("verified=true の行が存在するとき RoleArn / externalIdParameterName を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Item: {
+        PK: `TENANT#${TENANT_ID}`,
+        SK: `ACCOUNT#${ACCOUNT_ID}`,
+        tenantId: TENANT_ID,
+        awsAccountId: ACCOUNT_ID,
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+      },
+    });
+    const out = await resolveVerifiedCompetitorAccount(buildDeps(send), TENANT_ID, ACCOUNT_ID);
+    expect(out).toEqual({
+      awsAccountId: ACCOUNT_ID,
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      region: "ap-northeast-1",
+      externalIdParameterName: `/development/tenants/${TENANT_ID}/external-id`,
+      competitorRoleArn: `arn:aws:iam::${ACCOUNT_ID}:role/TenkaCloud-CompetitorDeploy-Role`,
+    });
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
+  });
+
+  it("verified=false の行は null を返すべき (= backend reject の trigger)", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Item: {
+        PK: `TENANT#${TENANT_ID}`,
+        SK: `ACCOUNT#${ACCOUNT_ID}`,
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+      },
+    });
+    const out = await resolveVerifiedCompetitorAccount(buildDeps(send), TENANT_ID, ACCOUNT_ID);
+    expect(out).toBeNull();
+  });
+
+  it("行が存在しないとき null を返すべき", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const out = await resolveVerifiedCompetitorAccount(buildDeps(send), TENANT_ID, ACCOUNT_ID);
+    expect(out).toBeNull();
+  });
+
+  it("competitorRoleName が空文字のとき null を返すべき (= deploy 不能の防御)", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Item: {
+        verified: true,
+        competitorRoleName: "",
+      },
+    });
+    const out = await resolveVerifiedCompetitorAccount(buildDeps(send), TENANT_ID, ACCOUNT_ID);
+    expect(out).toBeNull();
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
@@ -16,12 +16,16 @@ import { DeployCodeBuildProject } from "../../lib/problem-deploy/deploy-codebuil
  */
 function synth(props?: { concurrentBuildLimit?: number }): Template {
   const app = new App();
-  const stack = new Stack(app, "TestStack");
+  // ssm:GetParameter ARN を build するため account / region を pin する。
+  const stack = new Stack(app, "TestStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
   const sourceBucket = Bucket.fromBucketName(stack, "SourceBucket", "test-source-bucket");
   new DeployCodeBuildProject(stack, "DeployCodeBuild", {
     sourceBucket,
     sourceObjectKey: "source.zip",
     concurrentBuildLimit: props?.concurrentBuildLimit,
+    environmentName: "development",
   });
   return Template.fromStack(stack);
 }
@@ -56,6 +60,61 @@ describe("DeployCodeBuildProject — concurrent build limit (#538)", () => {
     tpl.hasResourceProperties(
       "AWS::CodeBuild::Project",
       Match.objectLike({ ConcurrentBuildLimit: 60 }),
+    );
+  });
+});
+
+describe("DeployCodeBuildProject — Phase 2.2 cross-account perms (Issue #459)", () => {
+  it("CodeBuild Project Role に sts:AssumeRole (`arn:aws:iam::*:role/TenkaCloud-*`) を付与するべき", () => {
+    const tpl = synth();
+    // Project Role の inline policy に AssumeRole を含む statement が出るべき。
+    tpl.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: "sts:AssumeRole",
+              Resource: "arn:aws:iam::*:role/TenkaCloud-*",
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("CodeBuild Project Role に SSM SecureString Read (= tenant path prefix scope) を付与するべき", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: "ssm:GetParameter",
+              Resource:
+                "arn:aws:ssm:ap-northeast-1:123456789012:parameter/development/tenants/*/external-id",
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("CodeBuild env variables に COMPETITOR_ROLE_ARN / EXTERNAL_ID_SSM_PARAMETER を宣言するべき", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::CodeBuild::Project",
+      Match.objectLike({
+        Environment: Match.objectLike({
+          EnvironmentVariables: Match.arrayWith([
+            Match.objectLike({ Name: "COMPETITOR_ROLE_ARN" }),
+            Match.objectLike({ Name: "EXTERNAL_ID_SSM_PARAMETER" }),
+          ]),
+        }),
+      }),
     );
   });
 });

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -6,17 +6,43 @@ import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/de
 
 const NOW_MS = 1_700_000_000_000;
 
-function buildShared(): {
+/**
+ * Phase 2.2 (Issue #459): requestTeardown は CompetitorAccounts table も Get するため、
+ * GetCommand を TableName で振り分けて mock する。verified 行は default で常に存在 (=
+ * 旧 deploy 行を delete する際に「verified=true 行が無い」状態を pin したいときだけ
+ * `unverified` option を渡す)。
+ */
+function buildShared(options: { unverified?: boolean } = {}): {
   shared: DeploySharedResources;
   ddbSend: ReturnType<typeof vi.fn>;
   eventsSend: ReturnType<typeof vi.fn>;
 } {
   const ddbSend = vi.fn();
   const eventsSend = vi.fn();
+  const wrappedSend = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand && cmd.input.TableName === "TestCompetitorAccounts") {
+      if (options.unverified) return { Item: undefined };
+      const sk = String(cmd.input.Key?.SK ?? "");
+      const awsAccountId = sk.replace(/^ACCOUNT#/, "");
+      return {
+        Item: {
+          PK: cmd.input.Key?.PK,
+          SK: cmd.input.Key?.SK,
+          awsAccountId,
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+        },
+      };
+    }
+    return ddbSend(cmd);
+  });
   const shared: DeploySharedResources = {
     tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
     eventBusName: "test-bus",
-    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    ddb: { send: wrappedSend } as unknown as DeploySharedResources["ddb"],
     events: { send: eventsSend } as unknown as DeploySharedResources["events"],
     problemsCatalog: {},
   };

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -8,16 +8,29 @@ const mocks = vi.hoisted(() => ({
   getStackProgress: vi.fn(),
 }));
 
-vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", () => ({
-  buildSharedResources: () => ({
-    tableName: "TestDeployments",
-    eventBusName: "test-bus",
-    ddb: { send: vi.fn() },
-    events: { send: vi.fn() },
-  }),
-  buildContext: (shared: unknown, tenantId: string) => ({ ...(shared as object), tenantId }),
-  startDeployment: mocks.startDeployment,
-}));
+// `UnknownProblemError` / `UnverifiedCompetitorAccountError` は handler の instanceof 判定
+// で使われるため、本物の class 実装を mock の factory 内で `importActual` して露出する (=
+// class identity が production と一致する)。`vi.mock` は hoisted されるので body 内で
+// `importActual` を呼ぶ async factory にする。
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/deploy-handler/deploy")
+  >("../../lib/problem-deploy/handlers/deploy-handler/deploy");
+  return {
+    buildSharedResources: () => ({
+      tableName: "TestDeployments",
+      competitorAccountsTableName: "TestCompetitorAccounts",
+      env: "development",
+      eventBusName: "test-bus",
+      ddb: { send: vi.fn() },
+      events: { send: vi.fn() },
+    }),
+    buildContext: (shared: unknown, tenantId: string) => ({ ...(shared as object), tenantId }),
+    startDeployment: mocks.startDeployment,
+    UnknownProblemError: actual.UnknownProblemError,
+    UnverifiedCompetitorAccountError: actual.UnverifiedCompetitorAccountError,
+  };
+});
 
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/list", () => ({
   listDeployments: mocks.listDeployments,
@@ -31,11 +44,44 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/stack-progress", () => ({
   getStackProgress: mocks.getStackProgress,
   defaultCfnClient: vi.fn(),
+  // Phase 2.2 (Issue #459): index.ts が `defaultCfnClientForCompetitor` も import するため、
+  // mock 経由でも露出する。test では実 STS / SSM を呼ばないよう dummy で返す。
+  defaultCfnClientForCompetitor: vi.fn(),
 }));
 
+// `app` import を mock 設定後に行う必要がある (= hoisted vi.mock の後)。
 const { app } = await import("../../lib/problem-deploy/handlers/deploy-handler/index");
+// real deploy module を test 側からも touch して error class を共有する。
+const { UnverifiedCompetitorAccountError } = await import(
+  "../../lib/problem-deploy/handlers/deploy-handler/deploy"
+);
 
 const ULID = "01H8XGJWBWBAQ4N6RZHM4S2KMV";
+
+const VALID_DEPLOY_BODY = {
+  region: "ap-northeast-1",
+  awsAccountId: "123456789012",
+  teamName: "Alpha Team",
+};
+
+describe("POST /problems/:problemId/deploy", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Phase 2.2: UnverifiedCompetitorAccountError は 422 + awsAccountId を返すべき", async () => {
+    mocks.startDeployment.mockRejectedValueOnce(
+      new UnverifiedCompetitorAccountError("123456789012"),
+    );
+    const res = await app.request("/problems/security-battle-royale/deploy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(VALID_DEPLOY_BODY),
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("unverified_competitor_account");
+    expect(body.awsAccountId).toBe("123456789012");
+  });
+});
 
 describe("GET /problems/:problemId/deployments", () => {
   beforeEach(() => vi.clearAllMocks());

--- a/infrastructure/test/problem-deploy/deploy-handler.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler.test.ts
@@ -1,21 +1,53 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type DeployContext,
   type DeployInvocation,
   startDeployment,
+  UnverifiedCompetitorAccountError,
 } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
 
-function buildContext(overrides: Partial<DeployContext> = {}): {
+/**
+ * Phase 2.2 (Issue #459): startDeployment が事前に CompetitorAccounts table を Get
+ * (verified=true gate) するようになった。test では default で「verified=true」を返し、
+ * `unverified=true` option で「verified=false」を pin する。
+ */
+function buildContext(
+  overrides: Partial<DeployContext> = {},
+  options: { unverified?: boolean } = {},
+): {
   ctx: DeployContext;
-  ddbSend: ReturnType<typeof vi.fn>;
+  putSend: ReturnType<typeof vi.fn>;
   eventsSend: ReturnType<typeof vi.fn>;
 } {
-  const ddbSend = vi.fn().mockResolvedValue({});
+  const putSend = vi.fn().mockResolvedValue({});
   const eventsSend = vi.fn().mockResolvedValue({});
+  // GetCommand (CompetitorAccounts) を verified=true / unverified=false に振り分け、
+  // それ以外 (PutCommand 等) は putSend に流す。test 側 assertion は putSend の最後の
+  // call を見るのが基本。
+  const ddbSend = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand && cmd.input.TableName === "TestCompetitorAccounts") {
+      if (options.unverified) return { Item: undefined };
+      const sk = String(cmd.input.Key?.SK ?? "");
+      const awsAccountId = sk.replace(/^ACCOUNT#/, "");
+      return {
+        Item: {
+          PK: cmd.input.Key?.PK,
+          SK: cmd.input.Key?.SK,
+          awsAccountId,
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+        },
+      };
+    }
+    return putSend(cmd);
+  });
   const ctx: DeployContext = {
     tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
     eventBusName: "test-bus",
     ddb: { send: ddbSend } as unknown as DeployContext["ddb"],
     events: { send: eventsSend } as unknown as DeployContext["events"],
@@ -28,7 +60,7 @@ function buildContext(overrides: Partial<DeployContext> = {}): {
     },
     ...overrides,
   };
-  return { ctx, ddbSend, eventsSend };
+  return { ctx, putSend, eventsSend };
 }
 
 const sampleRequest = (overrides: Partial<DeployInvocation> = {}): DeployInvocation => ({
@@ -43,10 +75,10 @@ describe("startDeployment", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("DDB に PutItem を 1 回 送るべき", async () => {
-    const { ctx, ddbSend } = buildContext();
+    const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
-    expect(ddbSend).toHaveBeenCalledOnce();
-    const cmd = ddbSend.mock.calls[0]?.[0] as PutCommand;
+    expect(putSend).toHaveBeenCalledOnce();
+    const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
     expect(cmd).toBeInstanceOf(PutCommand);
     const item = cmd.input.Item;
     expect(cmd.input.TableName).toBe("TestDeployments");
@@ -59,9 +91,9 @@ describe("startDeployment", () => {
   });
 
   it("GSI2PK = TEAMKEY#<teamLoginKey> を sparse index 用に書き込むべき", async () => {
-    const { ctx, ddbSend } = buildContext();
+    const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
-    const cmd = ddbSend.mock.calls[0]?.[0] as PutCommand;
+    const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
     const item = cmd.input.Item;
     expect(typeof item?.teamLoginKey).toBe("string");
     expect(item?.GSI2PK).toBe(`TEAMKEY#${item?.teamLoginKey}`);
@@ -103,25 +135,48 @@ describe("startDeployment", () => {
   });
 
   it("DDB Put が失敗したら EventBridge を呼ばずに throw するべき", async () => {
-    const { ctx, eventsSend } = buildContext();
-    (ctx.ddb.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("DDB down"));
+    const { ctx, putSend, eventsSend } = buildContext();
+    putSend.mockRejectedValueOnce(new Error("DDB down"));
     await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow("DDB down");
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
   it("forward-compat フィールド (accountGroupId / problemSetId) も保存するべき", async () => {
-    const { ctx, ddbSend } = buildContext();
+    const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest({ accountGroupId: "group-1", problemSetId: "set-1" }));
-    const cmd = ddbSend.mock.calls[0]?.[0] as PutCommand;
+    const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
     expect(cmd.input.Item?.accountGroupId).toBe("group-1");
     expect(cmd.input.Item?.problemSetId).toBe("set-1");
   });
 
   it("default TTL は 8 時間 (秒単位)", async () => {
     const fixedNow = 1_700_000_000_000;
-    const { ctx, ddbSend } = buildContext({ ttlMs: undefined, now: () => fixedNow });
+    const { ctx, putSend } = buildContext({ ttlMs: undefined, now: () => fixedNow });
     await startDeployment(ctx, sampleRequest());
-    const cmd = ddbSend.mock.calls[0]?.[0] as PutCommand;
+    const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
     expect(cmd.input.Item?.expiresAt).toBe(Math.floor((fixedNow + 8 * 60 * 60 * 1000) / 1000));
+  });
+
+  // Phase 2.2 (Issue #459): verified=true 行が無いと UnverifiedCompetitorAccountError を投げるべき
+  it("CompetitorAccounts に verified=true 行が無い awsAccountId は reject (Unverified… throw) するべき", async () => {
+    const { ctx, putSend, eventsSend } = buildContext({}, { unverified: true });
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toBeInstanceOf(
+      UnverifiedCompetitorAccountError,
+    );
+    expect(putSend).not.toHaveBeenCalled();
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  // Phase 2.2: DeployCreateRequested detail に competitorRoleArn / externalIdParameterName を含めるべき
+  it("DeployCreateRequested detail に AssumeRole 用 competitorRoleArn / externalIdParameterName を詰めるべき", async () => {
+    const { ctx, eventsSend } = buildContext();
+    await startDeployment(ctx, sampleRequest());
+    const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    const entry = cmd.input.Entries?.[0];
+    const detail = JSON.parse(entry?.Detail ?? "{}");
+    expect(detail.competitorRoleArn).toBe(
+      "arn:aws:iam::123456789012:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
 });

--- a/infrastructure/test/problem-deploy/deploy-list.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-list.test.ts
@@ -14,9 +14,12 @@ function buildShared(): {
   const ddbSend = vi.fn();
   const shared: DeploySharedResources = {
     tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
     eventBusName: "test-bus",
     ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
     events: {} as unknown as DeploySharedResources["events"],
+    problemsCatalog: {},
   };
   return { shared, ddbSend };
 }

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -11,19 +11,65 @@ import type { EventSharedResources } from "../../lib/problem-deploy/handlers/eve
 
 const NOW_MS = 1_700_000_000_000;
 
-function buildShared(over: Partial<EventSharedResources> = {}): {
+/**
+ * Phase 2.2 (Issue #459): bulk-deploy が CompetitorAccounts table を引いて verified=true
+ * のみ許可するようになった。test helper 側で「verified account の集合」を default で
+ * 「全 awsAccountId を許可」に倒し、unverified を試す test だけ override する形にする。
+ *
+ * 既存 test の `mockResolvedValueOnce` で順次 Event Get / Teams Query / 既存 deployments
+ * Query / TransactWrite / UpdateCommand を返す順序は保てない (CompetitorAccounts Get が
+ * Promise.all で並列に挟まる)。helper で `mockImplementation` を 1 度だけ仕掛け、
+ * Command 種別 + TableName で振り分ける形に切り替える。
+ */
+const VERIFIED_ALL = Symbol("verified-all");
+type VerifiedSet = Set<string> | typeof VERIFIED_ALL;
+
+function buildShared(
+  over: Partial<EventSharedResources> = {},
+  verifiedAccounts: VerifiedSet = VERIFIED_ALL,
+): {
   shared: EventSharedResources;
   ddbSend: ReturnType<typeof vi.fn>;
   eventsSend: ReturnType<typeof vi.fn>;
+  setVerifiedAccounts: (next: VerifiedSet) => void;
 } {
   const ddbSend = vi.fn();
   const eventsSend = vi.fn();
+  let verified = verifiedAccounts;
+  // CompetitorAccounts Get を `mockResolvedValueOnce` queue とは別経路で処理する。
+  // ddbSend の queue が空 or 一致しない場合は CompetitorAccounts 用の verified record を返す。
+  const originalSend = ddbSend;
+  const wrappedSend = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand) {
+      const tn = (cmd as GetCommand).input.TableName;
+      if (tn === "TestCompetitorAccounts") {
+        const key = (cmd as GetCommand).input.Key ?? {};
+        const sk = String(key.SK ?? "");
+        const awsAccountId = sk.replace(/^ACCOUNT#/, "");
+        const isVerified = verified === VERIFIED_ALL || verified.has(awsAccountId);
+        if (!isVerified) return { Item: undefined };
+        return {
+          Item: {
+            PK: key.PK,
+            SK: key.SK,
+            awsAccountId,
+            region: "ap-northeast-1",
+            competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+            verified: true,
+          },
+        };
+      }
+    }
+    return originalSend(cmd);
+  });
   const shared: EventSharedResources = {
     eventsTableName: "TestEvents",
     teamsTableName: "TestTeams",
     deploymentsTableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
     eventBusName: "test-bus",
-    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    env: "development",
+    ddb: { send: wrappedSend } as unknown as EventSharedResources["ddb"],
     events: { send: eventsSend } as unknown as EventSharedResources["events"],
     problemsCatalog: {
       "hello-world": "problems/challenges/hello-world",
@@ -31,7 +77,14 @@ function buildShared(over: Partial<EventSharedResources> = {}): {
     },
     ...over,
   };
-  return { shared, ddbSend, eventsSend };
+  return {
+    shared,
+    ddbSend,
+    eventsSend,
+    setVerifiedAccounts: (next) => {
+      verified = next;
+    },
+  };
 }
 
 const sampleEvent = (over: Record<string, unknown> = {}) => ({
@@ -514,5 +567,77 @@ describe("bulkDeployEvent", () => {
     expect(put?.Put?.Item?.teamId).toBe("T1");
     const del = items.find((it) => it.Delete);
     expect(del?.Delete?.Key?.PK).toBe("DEPLOYMENT#F1");
+  });
+
+  // Phase 2.2 (Issue #459) Worker cross-account 化:
+  // CompetitorAccounts table で verified=true 行が無い awsAccountId は reject されるべき
+  it("verified=false / 未登録の awsAccountId は plan から落ちて unverified に計上するべき", async () => {
+    const { shared, ddbSend, eventsSend, setVerifiedAccounts } = buildShared();
+    // T1 (111111111111) のみ verified、T2 (222222222222) は未登録
+    setVerifiedAccounts(new Set(["111111111111"]));
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // T1, T2
+    ddbSend.mockResolvedValueOnce({ Items: [] }); // 既存 deployments 空
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    // T1×2 problems = 2 enqueue、T2×2 problems = 2 reject、unverified set は {222...}
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.result.enqueued).toBe(2);
+    expect(out.result.unverified).toBe(1);
+    expect(out.result.unverifiedAccounts).toEqual(["222222222222"]);
+
+    // sampleEvent の problem.defaultAwsAccountId (= 999999999999) もあるが、team.awsAccountId
+    // が両 team とも埋まっているので fallback は使われない → 999... は plan に来ない。
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    for (const it of items) {
+      expect(it.Put?.Item?.awsAccountId).toBe("111111111111");
+    }
+  });
+
+  // Phase 2.2: 全 team が unverified なら write も publish もしない (fail-closed)
+  it("全 team が unverified なら write / publish せず enqueued=0 で返すべき", async () => {
+    const { shared, ddbSend, eventsSend, setVerifiedAccounts } = buildShared();
+    setVerifiedAccounts(new Set()); // verified なし
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.result.enqueued).toBe(0);
+    expect(out.result.unverified).toBe(2);
+    expect(out.result.unverifiedAccounts).toEqual(["111111111111", "222222222222"]);
+    expect(ddbSend.mock.calls.filter((c) => c[0] instanceof TransactWriteCommand)).toHaveLength(0);
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  // Phase 2.2: DeployCreateRequested の detail に competitorRoleArn / externalIdParameterName を埋めるべき
+  it("DeployCreateRequested detail に AssumeRole 用の competitorRoleArn と externalIdParameterName を含めるべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) }); // T1 only
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    const putCmd = eventsSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is PutEventsCommand => c instanceof PutEventsCommand);
+    const detailRaw = putCmd?.input.Entries?.[0]?.Detail;
+    expect(detailRaw).toBeDefined();
+    const detail = JSON.parse(String(detailRaw ?? "{}"));
+    // T1 awsAccountId は 111111111111、SSM path は `/development/tenants/tenant-acme/external-id`
+    expect(detail.competitorRoleArn).toBe(
+      "arn:aws:iam::111111111111:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
 });

--- a/infrastructure/test/problem-deploy/stack-progress.test.ts
+++ b/infrastructure/test/problem-deploy/stack-progress.test.ts
@@ -11,16 +11,49 @@ const STACK_NAME = "tc-hello-world-team-alpha";
 const STACK_ID = `arn:aws:cloudformation:ap-northeast-1:999999999999:stack/${STACK_NAME}/uuid`;
 const REGION = "ap-northeast-1";
 
-function buildShared(): {
+/**
+ * Phase 2.2 (Issue #459): getStackProgress は CompetitorAccounts table も Get するため、
+ * GetCommand を TableName で振り分ける wrapper を使う。default は「未登録」(= verified 行
+ * 無し) に倒し、cross-account を試したい test だけ override する。
+ */
+function buildShared(options: { verified?: boolean } = {}): {
   shared: DeploySharedResources;
   ddbSend: ReturnType<typeof vi.fn>;
 } {
   const ddbSend = vi.fn();
+  const wrappedSend = vi.fn(async (cmd: unknown) => {
+    type GetLike = { input: { TableName?: string; Key?: { PK?: string; SK?: string } } };
+    if (
+      typeof cmd === "object" &&
+      cmd !== null &&
+      "input" in cmd &&
+      (cmd as GetLike).input?.TableName === "TestCompetitorAccounts"
+    ) {
+      if (!options.verified) return { Item: undefined };
+      const key = (cmd as GetLike).input.Key ?? {};
+      const sk = String(key.SK ?? "");
+      const awsAccountId = sk.replace(/^ACCOUNT#/, "");
+      return {
+        Item: {
+          PK: key.PK,
+          SK: key.SK,
+          awsAccountId,
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+        },
+      };
+    }
+    return ddbSend(cmd);
+  });
   const shared: DeploySharedResources = {
     tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
     eventBusName: "test-bus",
-    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    ddb: { send: wrappedSend } as unknown as DeploySharedResources["ddb"],
     events: {} as unknown as DeploySharedResources["events"],
+    problemsCatalog: {},
   };
   return { shared, ddbSend };
 }

--- a/scripts/delete-battles.sh
+++ b/scripts/delete-battles.sh
@@ -25,6 +25,12 @@ STACK_NAME="$1"
 # 第 2 引数 > AWS_REGION env > aws cli config の順 (resolve_aws_region は env/cli config を見る)。
 REGION="${2:-$(resolve_aws_region)}"
 
+# Phase 2.2 (Issue #459): cross-account 化。`COMPETITOR_ROLE_ARN` が set されていれば
+# AssumeRole + ExternalId で tmp credentials に切り替える。
+# DEPLOY_REGION も export し直す (delete でも target region を AssumeRole 後に固定する)。
+export DEPLOY_REGION="${REGION}"
+assume_competitor_role_if_configured
+
 echo "=========================================="
 echo "Deleting stack"
 echo "  StackName : ${STACK_NAME}"

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -55,6 +55,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 TEAM_SLUG="${TEAM_SLUG:-demo-team}"
+
+# Phase 2.2 (Issue #459): COMPETITOR_ROLE_ARN が set されているなら、aws CLI 呼び出し前に
+# AssumeRole + ExternalId で tmp credentials に切り替える。空なら same-account 経路で動く。
+assume_competitor_role_if_configured
+
 AWS_REGION="$(resolve_aws_region)"
 
 # metadata.json の cfnParameters を `Key=Value` 形式の配列に展開する。`__RANDOM_PASSWORD__`

--- a/scripts/lib/battles-common.sh
+++ b/scripts/lib/battles-common.sh
@@ -26,3 +26,62 @@ resolve_aws_region() {
   fi
   echo "${region}"
 }
+
+# Phase 2.2 (Issue #459) cross-account AssumeRole helper。
+#
+# `COMPETITOR_ROLE_ARN` env が空でなければ:
+#   1. `EXTERNAL_ID_SSM_PARAMETER` から SSM SecureString で ExternalId を取得
+#   2. `aws sts assume-role` に `--external-id` を付けて 15 分の tmp credentials を取得
+#   3. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN を export
+#      (= 以降の aws CLI 呼び出しは target account の権限で動く)
+#
+# 空なら no-op (= same-account deploy 経路を残す。dev / 未 verify 用)。
+#
+# 副作用: 上記 3 env をシェルに export する。caller の sub-shell scope 内で呼び、
+# 別アカウントへ切り替えたあと元に戻す必要があれば `AWS_*` env を退避すること。
+#
+# 失敗時は非ゼロで return (caller の `set -e` で fail-fast)。
+assume_competitor_role_if_configured() {
+  local role_arn="${COMPETITOR_ROLE_ARN:-}"
+  local ssm_param="${EXTERNAL_ID_SSM_PARAMETER:-}"
+
+  # 両方空 = same-account 経路 (= dev / unconfigured)。
+  if [[ -z "${role_arn}" && -z "${ssm_param}" ]]; then
+    return 0
+  fi
+
+  # 片方だけ空は構成エラー (= 落とす)。
+  if [[ -z "${role_arn}" || -z "${ssm_param}" ]]; then
+    echo "error: COMPETITOR_ROLE_ARN と EXTERNAL_ID_SSM_PARAMETER は両方必須です (片方のみ設定済)" >&2
+    return 1
+  fi
+
+  echo "[cross-account] Assuming role: ${role_arn} (ExternalId from SSM: ${ssm_param})"
+
+  local external_id
+  external_id="$(aws ssm get-parameter --name "${ssm_param}" --with-decryption --query "Parameter.Value" --output text)"
+  if [[ -z "${external_id}" || "${external_id}" == "None" ]]; then
+    echo "error: ExternalId not found in SSM SecureString: ${ssm_param}" >&2
+    return 1
+  fi
+
+  # 15 分は AWS STS の minimum session duration。短くするほど token 漏洩リスクが小さい。
+  local sts_json
+  sts_json="$(aws sts assume-role \
+    --role-arn "${role_arn}" \
+    --role-session-name "tenkacloud-deploy-$(date +%s)" \
+    --external-id "${external_id}" \
+    --duration-seconds 900)"
+
+  AWS_ACCESS_KEY_ID="$(echo "${sts_json}" | jq -r '.Credentials.AccessKeyId')"
+  AWS_SECRET_ACCESS_KEY="$(echo "${sts_json}" | jq -r '.Credentials.SecretAccessKey')"
+  AWS_SESSION_TOKEN="$(echo "${sts_json}" | jq -r '.Credentials.SessionToken')"
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  # CodeBuild Project が `AWS_DEFAULT_REGION` を inject していないと target account の
+  # region 解決が空になる事故があるので、明示的に DEPLOY_REGION (= event detail.region) を反映。
+  if [[ -n "${DEPLOY_REGION:-}" ]]; then
+    export AWS_REGION="${DEPLOY_REGION}"
+    export AWS_DEFAULT_REGION="${DEPLOY_REGION}"
+  fi
+  echo "[cross-account] AssumeRole succeeded (session valid for 900s)."
+}


### PR DESCRIPTION
Phase 2.1 (PR-594) で per-tenant ExternalId + Competitor Accounts CRUD/verify を実装した。
本 PR は Phase 2.2 = **実 deploy 経路を cross-account 化** + **DeployForm を verified-only
drop-down に移行** を扱う。これで Issue #459 の cross-account federation 設計が完結する。

## Summary

- **verified-only fail-closed gate**: bulk-deploy / single-deploy 両方が CompetitorAccounts
  table の `verified=true` 行を gate にし、未登録 / unverified には 422 で reject。
  DeployForm 側は drop-down が verified=true 行しか表示しない (UI + backend で二重)。
- **CodeBuild Worker cross-account 化**: `deploy-battles.sh` / `delete-battles.sh` が
  `COMPETITOR_ROLE_ARN` env を見て `aws sts assume-role --external-id` を実行 → tmp credentials
  で target account の CFn を deploy / delete。ExternalId は SSM SecureString から都度 fetch。
- **stack-progress cross-account 化**: deploy-handler Lambda が verified=true 行のときは
  AssumeRole 経由で CFn DescribeStackEvents / DescribeStackResources を target account に投げる。
- **EventCreate UI**: 各 team の AWS Account ID 自由入力 `Input` を verified=true な
  `CompetitorAccountSummary` で populate される Cloudscape `Select` に置換。0 件のときは
  Competitor Accounts ページへの導線 Alert を出す。
- **`CDK_PARAM_DEPLOY_EXTERNAL_ID` env**: Phase 2.1 で既に未使用 (= grep 0 件)。本 PR では
  再確認のみで実 code 影響なし。SSM SecureString が単一 source of truth。

## 設計判断

- **verified gate は backend 必須**: UI が迂回しても backend が 422 を返す (= fail-closed)。
- **Worker AssumeRole は bash 内で**: STS session を Step Functions 入力に乗せると鍵漏洩
  surface を拡大するため、CodeBuild script で都度 fresh session を取る方が小さい。
- **stack-progress は Lambda 内 AssumeRole**: 同期 API なので script 経路は無く、Lambda
  Role に sts/ssm/kms を付与し runtime に cross-account CFn client を組む。
- **後方互換**: DeployCreate/DeleteRequested detail の `competitorRoleArn` /
  `externalIdParameterName` は optional。旧 deployment 行 (= 未 verify) を delete する経路は
  script 側で空文字 detect → same-account fallback。

## Regression 分析

- **既存 verified=true な bulk-deploy**: detail に 2 field 増えるだけで挙動変化なし。
  State Machine は `JsonPath.format("{}", ...)` で null-safe。
- **既存 verified=true な単体 deploy**: `startDeployment` 内で CompetitorAccounts table を
  追加で Get する (= +1 RCU)。verified=true 行なら通常通り PENDING を作る。
- **dev / 未 verify 環境**: backend gate が `UnverifiedCompetitorAccountError` を投げて
  deploy 不能。Phase 2.1 の Competitor Accounts UI で自社 account を登録 → STS Verify を
  済ませる手順が前提。
- **stack-progress cross-account 切替**: verified=true 行があれば AssumeRole 経由、無ければ
  従来通り same-account API (= behavior 変化は verify 済 deploy のみ)。
- **旧 deployment 行 delete**: `delete.ts` は verified 行を query するが、未 verify なら
  optional metadata が undefined のまま publish される (= 旧挙動を保つ)。

## 物理影響

- **CFn UPDATE**: `tenkacloud-problem-deploy` stack
  - `DeployApi` Lambda env に `COMPETITOR_ACCOUNTS_TABLE_NAME` / `DEPLOY_ENVIRONMENT` 追加
  - `EventApi` Lambda env に同上
  - `DeployApi` Lambda Role に SSM Get / KMS Decrypt / sts:AssumeRole / DDB Read 追加
  - `EventApi` Lambda Role に DDB Read 追加
  - `DeployCodeBuild` Project Role policy に SSM Get / KMS Decrypt / sts:AssumeRole 追加
  - `DeployCreate` / `DeployDelete` State Machine 定義に env override 3 つ追加
- **REPLACE**: Lambda source bundles (DeployApi / EventApi)、State Machine の definitionBody
- **CREATE**: 無し
- **DELETE**: 無し
- **NO-OP**: DDB tables、CompetitorAccounts table (Phase 2.1 で作成済)

## Migration

旧 deployment 行 (`competitorRoleArn` / `externalIdParameterName` を持たない) は同 account
経路でそのまま動く (script が env 空文字を no-op で skip)。新 deploy は CompetitorAccounts
table に verified=true 行が必要。operator は \`/competitor-accounts\` ページで Add account
→ STS Verify を済ませる Phase 2.1 の 5-step flow を踏む。

## Test plan

- [x] \`make lint\` (markdown + textlint + biome)
- [x] \`make typecheck\` (infrastructure / application-admin-console / participant-portal)
- [x] \`make test\` (501 + 60 + 114 + 67 = 742 件 全 pass)
- [x] \`make check-http-status\` (magic number 0 件)
- [ ] manual: bulk-deploy で verified=true な team は CFn deploy 成功、unverified team は
      plan から除外、response の \`unverifiedAccounts\` に列挙される
- [ ] manual: \`POST /problems/:id/deploy\` の unverified account → 422 +
      \`error: unverified_competitor_account\` を返す
- [ ] manual: EventCreate UI で verified=false な account は drop-down に出ない
- [ ] manual: 0 件のとき Competitor Accounts ページへの導線 Alert が出る

Closes #459
Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)