### PR TITLE
feat(deployment): DeploymentDetail を Netlify 風 phase + 拡大 log view に

### DIFF
--- a/apps/application-admin-console/src/lib/deploy-phases.ts
+++ b/apps/application-admin-console/src/lib/deploy-phases.ts
@@ -1,0 +1,264 @@
+/**
+ * DeploymentDetail を Netlify 風の 5 phase に変換するロジック。
+ *
+ * 既存の backend を変えずに、`DeploymentSummary` + `StackProgress` だけから派生する。
+ * Phase の status は次の順で決まる:
+ *   1. Enqueued — deployment row が存在すれば必ず Complete (= 観測時点で row はある)
+ *   2. Building — CodeBuild step の代理。stack events / resources が 1 件でも観測されたら
+ *      Complete、まだなら IN_PROGRESS は In Progress、FAILED + 観測なし は Failed。
+ *   3. CloudFormation Deploy — events を見て判定。すべて `_COMPLETE` なら Complete、
+ *      `_FAILED` を含めば Failed、`_IN_PROGRESS` を含めば In Progress、空なら Pending。
+ *   4. Health Check — placeholder。常に Skipped (= 将来の Lambda 連携枠)。
+ *   5. Complete / Teardown — deployment.status を素直に反映。
+ *
+ * Backend を変えない frontend-only の派生なので、ここに集約することで View 側を薄く保つ。
+ */
+
+import type {
+  DeploymentStatus,
+  DeploymentSummary,
+  StackProgress,
+  StackProgressEvent,
+} from "../api/deploy-client";
+
+export type PhaseStatus = "complete" | "in-progress" | "failed" | "skipped" | "pending";
+
+export type PhaseId = "enqueued" | "building" | "cfn-deploy" | "health-check" | "complete";
+
+export interface DeployPhase {
+  readonly id: PhaseId;
+  readonly name: string;
+  readonly status: PhaseStatus;
+  /** Phase の中身を組み立てるためのヒント。View 側はこの id で switch する。 */
+  readonly note?: string;
+}
+
+const COMPLETE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["COMPLETE", "FAILED", "DELETED"]);
+
+function eventsToPhaseStatus(events: readonly StackProgressEvent[]): PhaseStatus {
+  if (events.length === 0) return "pending";
+  const hasFailed = events.some((e) => e.resourceStatus.endsWith("_FAILED"));
+  if (hasFailed) return "failed";
+  const hasInProgress = events.some((e) => e.resourceStatus.endsWith("_IN_PROGRESS"));
+  if (hasInProgress) return "in-progress";
+  // すべて `_COMPLETE` で終わる前提 (= rollback 系は `_FAILED` で拾われている)。
+  return "complete";
+}
+
+/**
+ * 5 phase 派生のコア関数。`stackProgress` は未取得 (= null) を許容する:
+ * その場合 `Building` / `CloudFormation Deploy` は status だけから推定する。
+ */
+export function derivePhases(
+  deployment: DeploymentSummary,
+  stackProgress: StackProgress | null,
+): readonly DeployPhase[] {
+  const status = deployment.status;
+  const events = stackProgress?.events ?? [];
+  const hasObservedCfn = events.length > 0 || (stackProgress?.resources.length ?? 0) > 0;
+
+  // Phase 1: Enqueued — deployment row が存在する時点で常に Complete。
+  const enqueued: DeployPhase = {
+    id: "enqueued",
+    name: "Enqueued",
+    status: "complete",
+  };
+
+  // Phase 2: Building — CodeBuild step。
+  // - CFn 進行が観測されている (= events / resources がある) → Build は Complete
+  // - status=FAILED かつ CFn 進行が観測されていない → Build で Failed (= CodeBuild 失敗)
+  // - status=IN_PROGRESS かつ CFn 未観測 → In Progress
+  // - status=PENDING → Pending
+  // - status=COMPLETE / DELETING / DELETED → Complete (terminal)
+  let buildingStatus: PhaseStatus;
+  if (hasObservedCfn) {
+    buildingStatus = "complete";
+  } else if (status === "PENDING") {
+    buildingStatus = "pending";
+  } else if (status === "IN_PROGRESS") {
+    buildingStatus = "in-progress";
+  } else if (status === "FAILED") {
+    buildingStatus = "failed";
+  } else {
+    // COMPLETE / DELETING / DELETED — CFn が観測できなくても build は通っていた。
+    buildingStatus = "complete";
+  }
+  const building: DeployPhase = {
+    id: "building",
+    name: "Building",
+    status: buildingStatus,
+  };
+
+  // Phase 3: CloudFormation Deploy — stack events を見る。
+  // CFn 未割当 (= events 空 + status=PENDING/IN_PROGRESS) は Pending。
+  // status=FAILED かつ events 空 → 上の Building で Failed を消化したので CFn 側は Pending のまま。
+  let cfnStatus: PhaseStatus;
+  if (events.length === 0) {
+    if (status === "COMPLETE") cfnStatus = "complete";
+    else if (status === "FAILED") cfnStatus = "pending";
+    else if (status === "DELETING" || status === "DELETED") cfnStatus = "skipped";
+    else cfnStatus = "pending";
+  } else {
+    cfnStatus = eventsToPhaseStatus(events);
+  }
+  const cfnDeploy: DeployPhase = {
+    id: "cfn-deploy",
+    name: "CloudFormation Deploy",
+    status: cfnStatus,
+  };
+
+  // Phase 4: Health Check — 将来枠。常に Skipped。
+  const healthCheck: DeployPhase = {
+    id: "health-check",
+    name: "Health Check",
+    status: "skipped",
+    note: "Skipped — will be wired to HealthCheck Lambda in a future iteration",
+  };
+
+  // Phase 5: Complete / Teardown — deployment.status を素直に。
+  let finalStatus: PhaseStatus;
+  if (status === "COMPLETE") finalStatus = "complete";
+  else if (status === "FAILED") finalStatus = "failed";
+  else if (status === "DELETING") finalStatus = "in-progress";
+  else if (status === "DELETED") finalStatus = "skipped";
+  else if (COMPLETE_STATUSES.has(status)) finalStatus = "complete";
+  else finalStatus = "pending";
+  const complete: DeployPhase = {
+    id: "complete",
+    name: "Complete / Teardown",
+    status: finalStatus,
+  };
+
+  return [enqueued, building, cfnDeploy, healthCheck, complete];
+}
+
+/**
+ * deployment + stackProgress から 1 行サマリ ("Deploy succeeded for ..." 等) を作る。
+ */
+export function deploySummaryTitle(deployment: DeploymentSummary): string {
+  const label = deployment.displayTeamName ?? deployment.teamName;
+  switch (deployment.status) {
+    case "COMPLETE":
+      return `Deploy succeeded for ${label}`;
+    case "FAILED":
+      return `Deploy failed for ${label}`;
+    case "IN_PROGRESS":
+      return `Deploy in progress for ${label}`;
+    case "PENDING":
+      return `Deploy queued for ${label}`;
+    case "DELETING":
+      return `Tearing down ${label}`;
+    case "DELETED":
+      return `Deploy removed for ${label}`;
+    default:
+      return `Deploy for ${label}`;
+  }
+}
+
+/**
+ * stack event の timestamp を `HH:MM:SS AM/PM` 形式にする。parse できなければ原文を返す。
+ * locale-sensitive な変換は en-US (= Netlify と同じ表記) に固定する。
+ */
+export function formatLogTimestamp(timestamp: string): string {
+  const d = new Date(timestamp);
+  if (Number.isNaN(d.getTime())) return timestamp;
+  return d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+}
+
+export interface LogLine {
+  /** Section header (= phase 開始行) かどうか。terminal で色を変える。 */
+  readonly header: boolean;
+  readonly timestamp?: string;
+  readonly text: string;
+}
+
+/**
+ * 5 phase を 1 本の terminal log に展開する。phase ヘッダ行 + events 行を順に並べる。
+ */
+export function buildTerminalLog(
+  deployment: DeploymentSummary,
+  stackProgress: StackProgress | null,
+  phases: readonly DeployPhase[],
+): readonly LogLine[] {
+  const lines: LogLine[] = [];
+
+  for (const phase of phases) {
+    lines.push({
+      header: true,
+      text: `> ${phase.name} [${phase.status}]`,
+    });
+
+    switch (phase.id) {
+      case "enqueued":
+        lines.push({
+          header: false,
+          timestamp: formatLogTimestamp(deployment.createdAt),
+          text: `Enqueued deployment ${deployment.jobId}`,
+        });
+        lines.push({
+          header: false,
+          timestamp: formatLogTimestamp(deployment.createdAt),
+          text: `tenantId=${deployment.tenantId} problemId=${deployment.problemId} teamName=${deployment.teamName}`,
+        });
+        break;
+      case "building":
+        if (stackProgress?.consoleUrl) {
+          lines.push({
+            header: false,
+            text: `CodeBuild console: ${stackProgress.consoleUrl}`,
+          });
+        } else {
+          lines.push({
+            header: false,
+            text: "CodeBuild console URL not yet available",
+          });
+        }
+        break;
+      case "cfn-deploy": {
+        const events = stackProgress?.events ?? [];
+        if (events.length === 0) {
+          lines.push({
+            header: false,
+            text: "No CloudFormation events observed yet.",
+          });
+        } else {
+          for (const e of events) {
+            const reason = e.resourceStatusReason ? ` — ${e.resourceStatusReason}` : "";
+            lines.push({
+              header: false,
+              timestamp: formatLogTimestamp(e.timestamp),
+              text: `${e.resourceStatus} ${e.logicalResourceId} (${e.resourceType})${reason}`,
+            });
+          }
+        }
+        break;
+      }
+      case "health-check":
+        lines.push({
+          header: false,
+          text: phase.note ?? "Skipped",
+        });
+        break;
+      case "complete":
+        lines.push({
+          header: false,
+          timestamp: formatLogTimestamp(deployment.updatedAt),
+          text: `Deployment status: ${deployment.status}`,
+        });
+        if (deployment.failureReason) {
+          lines.push({
+            header: false,
+            text: `Failure reason: ${deployment.failureReason}`,
+          });
+        }
+        break;
+    }
+  }
+
+  return lines;
+}

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -3,20 +3,22 @@ import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
+import ExpandableSection from "@cloudscape-design/components/expandable-section";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import Link from "@cloudscape-design/components/link";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
-import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import StatusIndicator, {
+  type StatusIndicatorProps,
+} from "@cloudscape-design/components/status-indicator";
 import Table from "@cloudscape-design/components/table";
 import { StatusCodes } from "http-status-codes";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router";
 import { ApiError, useApiClient } from "../api/client";
 import {
-  DEPLOYMENT_STATUS_INDICATOR,
   type DeploymentSummary,
   deleteDeployment,
   getDeployment,
@@ -30,8 +32,34 @@ import {
   TERMINAL_STATUSES,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
+import {
+  buildTerminalLog,
+  type DeployPhase,
+  deploySummaryTitle,
+  derivePhases,
+  formatLogTimestamp,
+  type LogLine,
+  type PhaseStatus,
+} from "../lib/deploy-phases";
 
 const POLL_INTERVAL_MS = 5_000;
+
+/** Phase status を Cloudscape StatusIndicator にマップ。Netlify と意味的に揃える。 */
+const PHASE_STATUS_INDICATOR: Record<PhaseStatus, StatusIndicatorProps.Type> = {
+  complete: "success",
+  "in-progress": "in-progress",
+  failed: "error",
+  skipped: "stopped",
+  pending: "pending",
+};
+
+const PHASE_STATUS_LABEL: Record<PhaseStatus, string> = {
+  complete: "Complete",
+  "in-progress": "In Progress",
+  failed: "Failed",
+  skipped: "Skipped",
+  pending: "Pending",
+};
 
 export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const { jobId } = useParams<{ jobId: string }>();
@@ -42,7 +70,9 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [logModalOpen, setLogModalOpen] = useState(false);
   const stopPollingRef = useRef(false);
+  const deployLogRef = useRef<HTMLDivElement | null>(null);
   // #534: StackEvents / Resources は基本情報と独立 state。CFn API が throttle / 権限不足で
   // 落ちても基本情報まで巻き込まない (= 別 state に閉じる)。
   const [stackProgress, setStackProgress] = useState<StackProgress | null>(null);
@@ -126,6 +156,21 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
     }
   }, [apiClient, jobId, fetchOnce]);
 
+  const phases = useMemo(
+    () => (item ? derivePhases(item, stackProgress) : []),
+    [item, stackProgress],
+  );
+  const terminalLog = useMemo(
+    () => (item ? buildTerminalLog(item, stackProgress, phases) : []),
+    [item, stackProgress, phases],
+  );
+
+  const scrollDeployLog = useCallback((direction: "top" | "bottom") => {
+    const el = deployLogRef.current;
+    if (!el) return;
+    el.scrollIntoView({ block: direction === "top" ? "start" : "end", behavior: "smooth" });
+  }, []);
+
   if (!jobId || !JOB_ID_RE.test(jobId)) {
     return <Alert type="error">不正な Job ID です。</Alert>;
   }
@@ -151,51 +196,106 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
   const outputs = parseStackOutputs(item.stackOutputs);
   const canDelete = item.status !== "DELETING" && item.status !== "DELETED";
   const teamLoginKey = item.teamLoginKey;
+  const summaryTitle = deploySummaryTitle(item);
 
   return (
     <SpaceBetween size="l">
-      <Header
-        variant="h1"
-        actions={
-          <SpaceBetween direction="horizontal" size="xs">
-            <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
-              再読み込み
-            </Button>
-            <Button
-              variant="normal"
-              iconName="delete-marker"
-              disabled={!canDelete}
-              onClick={() => {
-                setDeleteError(null);
-                setDeleteModalOpen(true);
-              }}
-            >
-              削除
-            </Button>
-          </SpaceBetween>
-        }
-        description={`Job ID: ${item.jobId}`}
-      >
-        デプロイジョブ「{item.displayTeamName ?? item.teamName}」
-      </Header>
-
-      <Container header={<Header variant="h2">ステータス</Header>}>
-        <SpaceBetween size="m">
-          <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>
-            {item.status}
-          </StatusIndicator>
-          {item.status === "FAILED" && item.failureReason && (
-            <Alert type="error" header="失敗理由">
-              {item.failureReason}
-            </Alert>
-          )}
-          {!TERMINAL_STATUSES.has(item.status) && (
-            <Box variant="small" color="text-status-info">
-              {POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。
+      {/* Top summary card (Netlify 風)。Cloudscape Container を dark background で
+          stylize する。Job ID + 主要メタを 1 枚で見せる。 */}
+      <Container disableContentPaddings>
+        <div className="tc-deploy-summary">
+          <SpaceBetween size="xs">
+            <Box variant="h1" color="inherit">
+              {summaryTitle}
             </Box>
-          )}
-        </SpaceBetween>
+            <Box variant="p" color="inherit">
+              {item.problemId} · {item.displayTeamName ?? item.teamName}
+            </Box>
+            <Box variant="small" color="inherit">
+              {formatLogTimestamp(item.createdAt)} · Job <code>{item.jobId}</code> · Tenant{" "}
+              <code>{item.tenantId}</code>
+            </Box>
+            <div className="tc-deploy-summary-actions">
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
+                  再読み込み
+                </Button>
+                <Button
+                  variant="normal"
+                  iconName="delete-marker"
+                  disabled={!canDelete}
+                  onClick={() => {
+                    setDeleteError(null);
+                    setDeleteModalOpen(true);
+                  }}
+                >
+                  削除
+                </Button>
+              </SpaceBetween>
+            </div>
+          </SpaceBetween>
+        </div>
       </Container>
+
+      {item.status === "FAILED" && item.failureReason && (
+        <Alert type="error" header="失敗理由">
+          {item.failureReason}
+        </Alert>
+      )}
+
+      {/* Deploy log (= phase list)。Netlify の collapsed phase 列を模す。 */}
+      <div ref={deployLogRef}>
+        <Container
+          header={
+            <Header
+              variant="h2"
+              actions={
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button
+                    variant="icon"
+                    iconName="angle-up"
+                    ariaLabel="ログの先頭にスクロール"
+                    onClick={() => scrollDeployLog("top")}
+                  />
+                  <Button
+                    variant="icon"
+                    iconName="angle-down"
+                    ariaLabel="ログの末尾にスクロール"
+                    onClick={() => scrollDeployLog("bottom")}
+                  />
+                  <Button
+                    iconName="expand"
+                    onClick={() => setLogModalOpen(true)}
+                    data-testid="maximize-log"
+                  >
+                    Maximize log
+                  </Button>
+                </SpaceBetween>
+              }
+              description={
+                !TERMINAL_STATUSES.has(item.status)
+                  ? `${POLL_INTERVAL_MS / 1000} 秒ごとに自動更新します。`
+                  : undefined
+              }
+            >
+              Deploy log
+            </Header>
+          }
+        >
+          <SpaceBetween size="xxs">
+            {phases.map((phase) => (
+              <PhaseRow
+                key={phase.id}
+                phase={phase}
+                deployment={item}
+                stackProgress={stackProgress}
+                stackProgressError={stackProgressError}
+                stackProgressPending={stackProgressPending}
+              />
+            ))}
+          </SpaceBetween>
+        </Container>
+      </div>
 
       <Container header={<Header variant="h2">基本情報</Header>}>
         <ColumnLayout columns={2} variant="text-grid">
@@ -224,12 +324,6 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
           />
         </ColumnLayout>
       </Container>
-
-      <StackProgressSection
-        progress={stackProgress}
-        error={stackProgressError}
-        pending={stackProgressPending}
-      />
 
       {teamLoginKey && (
         <Container
@@ -305,21 +399,136 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
           {deleteError && <Alert type="error">{deleteError}</Alert>}
         </SpaceBetween>
       </Modal>
+
+      {/* Maximize log: terminal-style 全 phase の log。Cloudscape の Modal size="max"。 */}
+      <Modal
+        visible={logModalOpen}
+        onDismiss={() => setLogModalOpen(false)}
+        header="Deploy log"
+        size="max"
+        data-testid="deploy-log-modal"
+      >
+        <TerminalLogView lines={terminalLog} />
+      </Modal>
+
+      <DeploySummaryStyles />
     </SpaceBetween>
   );
 }
 
 /**
- * #534: CFn 進行状況セクション。Events / Resources / Console deep link を出す。
- *
- * - 初回 fetch 待ち (= progress === null かつ pending) → Spinner
- * - 取得失敗 → Alert (基本情報は別途表示済、ここの error は基本情報を汚さない)
- * - stack 未割当 (= deploy 極初期 / DDB 行はあるが CFn CreateStack 前) → 控えめな notice
- * - 成功 → Events / Resources の Table + 「CFn console を開く」link
- *
- * FAILED event があれば最上位に Alert で強調 (= operator が一目で原因を特定できる)。
+ * 1 phase 行。ExpandableSection で `>` chevron + 展開を Cloudscape に任せる。
+ * Header に phase 名 + StatusIndicator を並べる。Body は phase ごとに切替。
  */
-function StackProgressSection(props: {
+function PhaseRow(props: {
+  readonly phase: DeployPhase;
+  readonly deployment: DeploymentSummary;
+  readonly stackProgress: StackProgress | null;
+  readonly stackProgressError: { message: string; notYetCreated: boolean } | null;
+  readonly stackProgressPending: boolean;
+}) {
+  const { phase, deployment, stackProgress, stackProgressError, stackProgressPending } = props;
+
+  return (
+    <ExpandableSection
+      variant="default"
+      headerText={
+        <span className="tc-phase-header" data-testid={`phase-${phase.id}`}>
+          <span className="tc-phase-name">{phase.name}</span>
+          <span className="tc-phase-status">
+            <StatusIndicator type={PHASE_STATUS_INDICATOR[phase.status]}>
+              {PHASE_STATUS_LABEL[phase.status]}
+            </StatusIndicator>
+          </span>
+        </span>
+      }
+    >
+      <PhaseBody
+        phase={phase}
+        deployment={deployment}
+        stackProgress={stackProgress}
+        stackProgressError={stackProgressError}
+        stackProgressPending={stackProgressPending}
+      />
+    </ExpandableSection>
+  );
+}
+
+function PhaseBody(props: {
+  readonly phase: DeployPhase;
+  readonly deployment: DeploymentSummary;
+  readonly stackProgress: StackProgress | null;
+  readonly stackProgressError: { message: string; notYetCreated: boolean } | null;
+  readonly stackProgressPending: boolean;
+}) {
+  const { phase, deployment, stackProgress, stackProgressError, stackProgressPending } = props;
+
+  switch (phase.id) {
+    case "enqueued":
+      return (
+        <KeyValuePairs
+          items={[
+            { label: "Enqueued at", value: deployment.createdAt },
+            { label: "Tenant ID", value: <code>{deployment.tenantId}</code> },
+            { label: "Problem ID", value: <code>{deployment.problemId}</code> },
+            {
+              label: "Team",
+              value: deployment.displayTeamName ?? deployment.teamName,
+            },
+          ]}
+        />
+      );
+    case "building":
+      return (
+        <SpaceBetween size="s">
+          <Box variant="p">
+            CodeBuild が問題テンプレートを競技者アカウントへ deploy するための CFn を組み立てます。
+          </Box>
+          {stackProgress?.consoleUrl ? (
+            <Link href={stackProgress.consoleUrl} external>
+              Open CodeBuild / CloudFormation logs in AWS Console
+            </Link>
+          ) : (
+            <Box variant="small" color="text-status-info">
+              CodeBuild console URL is not yet available.
+            </Box>
+          )}
+        </SpaceBetween>
+      );
+    case "cfn-deploy":
+      return (
+        <StackProgressBody
+          progress={stackProgress}
+          error={stackProgressError}
+          pending={stackProgressPending}
+        />
+      );
+    case "health-check":
+      return (
+        <Box variant="p" color="text-status-info">
+          {phase.note ?? "Skipped"}
+        </Box>
+      );
+    case "complete":
+      return (
+        <KeyValuePairs
+          items={[
+            { label: "Final status", value: <code>{deployment.status}</code> },
+            { label: "Last updated", value: deployment.updatedAt },
+            ...(deployment.failureReason
+              ? [{ label: "Failure reason", value: deployment.failureReason }]
+              : []),
+          ]}
+        />
+      );
+  }
+}
+
+/**
+ * #534: CFn 進行状況セクション。Events / Resources / Console deep link を出す。
+ * Phase 3 (CloudFormation Deploy) の body として PhaseBody から呼ばれる。
+ */
+function StackProgressBody(props: {
   readonly progress: StackProgress | null;
   readonly error: { message: string; notYetCreated: boolean } | null;
   readonly pending: boolean;
@@ -329,157 +538,257 @@ function StackProgressSection(props: {
   // 初回ローディング: error も progress も無く、fetch in-flight。
   if (!progress && !error && pending) {
     return (
-      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
-        <Box textAlign="center" padding="m">
-          <Spinner /> CFn から取得中...
-        </Box>
-      </Container>
+      <Box textAlign="center" padding="m">
+        <Spinner /> CFn から取得中...
+      </Box>
     );
   }
 
   // Error 表示。stack 未割当 (= API 側の `stack_not_yet_created` 409) は別 message に分ける。
   if (error && !progress) {
-    return (
-      <Container header={<Header variant="h2">Stack 進行状況</Header>}>
-        {error.notYetCreated ? (
-          <Box color="text-status-info">
-            CFn Stack はまだ作成されていません。deploy worker (CodeBuild) が起動し次第、 ここに
-            StackEvents / Resources が表示されます。
-          </Box>
-        ) : (
-          <Alert type="warning" header="CFn の進行状況を取得できませんでした">
-            {error.message}
-          </Alert>
-        )}
-      </Container>
+    return error.notYetCreated ? (
+      <Box color="text-status-info">
+        CFn Stack はまだ作成されていません。deploy worker (CodeBuild) が起動し次第、 ここに
+        StackEvents / Resources が表示されます。
+      </Box>
+    ) : (
+      <Alert type="warning" header="CFn の進行状況を取得できませんでした">
+        {error.message}
+      </Alert>
     );
   }
 
   if (!progress) return null;
 
-  // 失敗 event を抽出 (= CREATE_FAILED / UPDATE_FAILED 等)。最初に検出した 1 件を Alert で
-  // 強調する: operator が AWS Console を開かずに原因 logical id + reason を読める。
+  // 失敗 event を抽出 (= CREATE_FAILED / UPDATE_FAILED 等)。
   const firstFailure = progress.events.find((e) => e.resourceStatus.endsWith("_FAILED"));
 
   return (
-    <Container
-      header={
-        <Header
-          variant="h2"
-          description={
-            progress.stackStatus
-              ? `現在の CFn Stack 状態: ${progress.stackStatus}`
-              : "CFn StackEvents / Resources を CFn API から直接取得しています。"
-          }
-          actions={
-            <Link href={progress.consoleUrl} external>
-              CFn console を開く
-            </Link>
-          }
-        >
-          Stack 進行状況
-        </Header>
-      }
-    >
-      <SpaceBetween size="m">
-        {firstFailure && (
-          <Alert type="error" header={`失敗: ${firstFailure.logicalResourceId}`}>
-            <Box>
-              <code>{firstFailure.resourceType}</code> が <code>{firstFailure.resourceStatus}</code>{" "}
-              になりました。
-            </Box>
-            {firstFailure.resourceStatusReason && (
-              <Box variant="small">{firstFailure.resourceStatusReason}</Box>
-            )}
-          </Alert>
+    <SpaceBetween size="m">
+      <Box>
+        <Link href={progress.consoleUrl} external>
+          Open CloudFormation console
+        </Link>
+        {progress.stackStatus && (
+          <Box variant="small" margin={{ top: "xxs" }}>
+            現在の CFn Stack 状態: <code>{progress.stackStatus}</code>
+          </Box>
         )}
+      </Box>
 
-        <Table<StackProgressEvent>
-          variant="embedded"
-          header={<Header variant="h3">StackEvents (最新 {progress.events.length} 件)</Header>}
-          items={[...progress.events]}
-          empty={
-            <Box textAlign="center" color="inherit" padding="l">
-              StackEvents はまだありません。
-            </Box>
-          }
-          columnDefinitions={[
-            {
-              id: "timestamp",
-              header: "時刻",
-              cell: (e) => e.timestamp,
-              width: 200,
-            },
-            {
-              id: "logicalResourceId",
-              header: "LogicalId",
-              cell: (e) => <code>{e.logicalResourceId}</code>,
-              width: 220,
-            },
-            {
-              id: "resourceType",
-              header: "Type",
-              cell: (e) => <code>{e.resourceType}</code>,
-              width: 220,
-            },
-            {
-              id: "status",
-              header: "Status",
-              cell: (e) => (
-                <StatusIndicator type={statusToIndicator(e.resourceStatus)}>
-                  {e.resourceStatus}
-                </StatusIndicator>
-              ),
-              width: 240,
-            },
-            {
-              id: "reason",
-              header: "Reason",
-              cell: (e) => e.resourceStatusReason ?? "",
-            },
-          ]}
-        />
+      {firstFailure && (
+        <Alert type="error" header={`失敗: ${firstFailure.logicalResourceId}`}>
+          <Box>
+            <code>{firstFailure.resourceType}</code> が <code>{firstFailure.resourceStatus}</code>{" "}
+            になりました。
+          </Box>
+          {firstFailure.resourceStatusReason && (
+            <Box variant="small">{firstFailure.resourceStatusReason}</Box>
+          )}
+        </Alert>
+      )}
 
-        <Table<StackProgressResource>
-          variant="embedded"
-          header={<Header variant="h3">Resources ({progress.resources.length} 件)</Header>}
-          items={[...progress.resources]}
-          empty={
-            <Box textAlign="center" color="inherit" padding="l">
-              Resources はまだ作成されていません。
-            </Box>
-          }
-          columnDefinitions={[
-            {
-              id: "logicalResourceId",
-              header: "LogicalId",
-              cell: (r) => <code>{r.logicalResourceId}</code>,
-              width: 220,
-            },
-            {
-              id: "resourceType",
-              header: "Type",
-              cell: (r) => <code>{r.resourceType}</code>,
-              width: 220,
-            },
-            {
-              id: "status",
-              header: "Status",
-              cell: (r) => (
-                <StatusIndicator type={statusToIndicator(r.resourceStatus)}>
-                  {r.resourceStatus}
-                </StatusIndicator>
-              ),
-              width: 240,
-            },
-            {
-              id: "physicalResourceId",
-              header: "PhysicalId",
-              cell: (r) => (r.physicalResourceId ? <code>{r.physicalResourceId}</code> : ""),
-            },
-          ]}
-        />
-      </SpaceBetween>
-    </Container>
+      <Table<StackProgressEvent>
+        variant="embedded"
+        header={<Header variant="h3">StackEvents (最新 {progress.events.length} 件)</Header>}
+        items={[...progress.events]}
+        empty={
+          <Box textAlign="center" color="inherit" padding="l">
+            StackEvents はまだありません。
+          </Box>
+        }
+        columnDefinitions={[
+          {
+            id: "timestamp",
+            header: "時刻",
+            cell: (e) => e.timestamp,
+            width: 200,
+          },
+          {
+            id: "logicalResourceId",
+            header: "LogicalId",
+            cell: (e) => <code>{e.logicalResourceId}</code>,
+            width: 220,
+          },
+          {
+            id: "resourceType",
+            header: "Type",
+            cell: (e) => <code>{e.resourceType}</code>,
+            width: 220,
+          },
+          {
+            id: "status",
+            header: "Status",
+            cell: (e) => (
+              <StatusIndicator type={statusToIndicator(e.resourceStatus)}>
+                {e.resourceStatus}
+              </StatusIndicator>
+            ),
+            width: 240,
+          },
+          {
+            id: "reason",
+            header: "Reason",
+            cell: (e) => e.resourceStatusReason ?? "",
+          },
+        ]}
+      />
+
+      <Table<StackProgressResource>
+        variant="embedded"
+        header={<Header variant="h3">Resources ({progress.resources.length} 件)</Header>}
+        items={[...progress.resources]}
+        empty={
+          <Box textAlign="center" color="inherit" padding="l">
+            Resources はまだ作成されていません。
+          </Box>
+        }
+        columnDefinitions={[
+          {
+            id: "logicalResourceId",
+            header: "LogicalId",
+            cell: (r) => <code>{r.logicalResourceId}</code>,
+            width: 220,
+          },
+          {
+            id: "resourceType",
+            header: "Type",
+            cell: (r) => <code>{r.resourceType}</code>,
+            width: 220,
+          },
+          {
+            id: "status",
+            header: "Status",
+            cell: (r) => (
+              <StatusIndicator type={statusToIndicator(r.resourceStatus)}>
+                {r.resourceStatus}
+              </StatusIndicator>
+            ),
+            width: 240,
+          },
+          {
+            id: "physicalResourceId",
+            header: "PhysicalId",
+            cell: (r) => (r.physicalResourceId ? <code>{r.physicalResourceId}</code> : ""),
+          },
+        ]}
+      />
+    </SpaceBetween>
+  );
+}
+
+/**
+ * Terminal-style log renderer。Netlify の expanded log view を模す。
+ * - 左 gutter: 行番号 (right-aligned, dim)
+ * - 中央 gutter: timestamp
+ * - 右: log text (section header は cyan)
+ */
+function TerminalLogView({ lines }: { lines: readonly LogLine[] }) {
+  // 行番号は append-only な log なので index で問題ないが、key には text + ts を
+  // 組み合わせた stable な値を使う (biome の useArrayKey 規約)。同一行が重複するケース
+  // のために locallyUnique counter を ts+text で消化する。
+  const keys = (() => {
+    const seen = new Map<string, number>();
+    return lines.map((line) => {
+      const base = `${line.timestamp ?? ""}|${line.header ? "H" : "L"}|${line.text}`;
+      const dup = seen.get(base) ?? 0;
+      seen.set(base, dup + 1);
+      return dup === 0 ? base : `${base}#${dup}`;
+    });
+  })();
+  return (
+    <div className="tc-terminal-log" data-testid="terminal-log">
+      <pre className="tc-terminal-log-pre">
+        {lines.map((line, idx) => {
+          const number = String(idx + 1).padStart(3, " ");
+          const ts = line.timestamp ?? "";
+          return (
+            <div
+              key={keys[idx]}
+              className={line.header ? "tc-log-line tc-log-header" : "tc-log-line"}
+            >
+              <span className="tc-log-number">{number}</span>
+              <span className="tc-log-ts">{ts && `${ts}:`}</span>
+              <span className="tc-log-text">{line.text}</span>
+            </div>
+          );
+        })}
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * Component-scoped CSS。Cloudscape primitive で表現しきれない:
+ *   - dark background の summary card
+ *   - terminal-style log の三列 grid
+ * をここで閉じる。global stylesheet を汚さない。
+ */
+function DeploySummaryStyles() {
+  return (
+    <style>{`
+.tc-deploy-summary {
+  background: #0f1419;
+  color: #e8eaed;
+  padding: 24px 32px;
+  border-radius: 12px;
+}
+.tc-deploy-summary code {
+  color: #9ad3ff;
+}
+.tc-deploy-summary-actions {
+  margin-top: 12px;
+}
+.tc-phase-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+}
+.tc-phase-name {
+  font-weight: 600;
+}
+.tc-phase-status {
+  margin-left: auto;
+}
+.tc-terminal-log {
+  background: #0f1419;
+  color: #e8eaed;
+  padding: 16px;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow: auto;
+}
+.tc-terminal-log-pre {
+  margin: 0;
+  font-family: "SF Mono", Monaco, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.tc-log-line {
+  display: grid;
+  grid-template-columns: 4ch 11ch 1fr;
+  gap: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tc-log-number {
+  text-align: right;
+  color: #5a6470;
+  font-variant-numeric: tabular-nums;
+}
+.tc-log-ts {
+  color: #8a99a8;
+  font-variant-numeric: tabular-nums;
+}
+.tc-log-text {
+  color: #e8eaed;
+}
+.tc-log-header .tc-log-text {
+  color: #66d9ef;
+  font-weight: 600;
+}
+`}</style>
   );
 }

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type { DeploymentSummary, StackProgress } from "../../src/api/deploy-client";
+import {
+  buildTerminalLog,
+  type DeployPhase,
+  deploySummaryTitle,
+  derivePhases,
+  type PhaseId,
+} from "../../src/lib/deploy-phases";
+
+function pick(phases: readonly DeployPhase[], id: PhaseId): DeployPhase {
+  const found = phases.find((p) => p.id === id);
+  if (!found) throw new Error(`phase ${id} not found`);
+  return found;
+}
+
+const baseDeployment: DeploymentSummary = {
+  jobId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+  problemId: "hello-world-battle",
+  tenantId: "tenant-test",
+  awsAccountId: "111122223333",
+  region: "ap-northeast-1",
+  teamName: "team-alpha",
+  displayTeamName: "Alpha Team",
+  namePrefix: "tc-team-alpha",
+  status: "PENDING",
+  createdAt: "2026-05-11T01:08:58.000Z",
+  updatedAt: "2026-05-11T01:09:30.000Z",
+  expiresAt: 0,
+};
+
+const emptyProgress: StackProgress = {
+  jobId: baseDeployment.jobId,
+  stackName: "tc-team-alpha-stack",
+  region: "ap-northeast-1",
+  consoleUrl: "https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks",
+  events: [],
+  resources: [],
+};
+
+const progressWithCreateInProgress: StackProgress = {
+  ...emptyProgress,
+  events: [
+    {
+      timestamp: "2026-05-11T01:09:00.000Z",
+      logicalResourceId: "MyBucket",
+      resourceType: "AWS::S3::Bucket",
+      resourceStatus: "CREATE_IN_PROGRESS",
+    },
+  ],
+};
+
+const progressAllComplete: StackProgress = {
+  ...emptyProgress,
+  events: [
+    {
+      timestamp: "2026-05-11T01:09:00.000Z",
+      logicalResourceId: "MyBucket",
+      resourceType: "AWS::S3::Bucket",
+      resourceStatus: "CREATE_COMPLETE",
+    },
+    {
+      timestamp: "2026-05-11T01:09:10.000Z",
+      logicalResourceId: "MyStack",
+      resourceType: "AWS::CloudFormation::Stack",
+      resourceStatus: "CREATE_COMPLETE",
+    },
+  ],
+};
+
+const progressWithFailed: StackProgress = {
+  ...emptyProgress,
+  events: [
+    {
+      timestamp: "2026-05-11T01:09:00.000Z",
+      logicalResourceId: "MyBucket",
+      resourceType: "AWS::S3::Bucket",
+      resourceStatus: "CREATE_IN_PROGRESS",
+    },
+    {
+      timestamp: "2026-05-11T01:09:30.000Z",
+      logicalResourceId: "MyBucket",
+      resourceType: "AWS::S3::Bucket",
+      resourceStatus: "CREATE_FAILED",
+      resourceStatusReason: "Bucket name already exists",
+    },
+  ],
+};
+
+describe("derivePhases", () => {
+  it("status=COMPLETE のとき 5 phase が全部 Complete (or Skipped) で表示されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
+    expect(phases.map((p) => p.id)).toEqual([
+      "enqueued",
+      "building",
+      "cfn-deploy",
+      "health-check",
+      "complete",
+    ]);
+    expect(phases[0].status).toBe("complete"); // Enqueued
+    expect(phases[1].status).toBe("complete"); // Building
+    expect(phases[2].status).toBe("complete"); // CFn Deploy
+    expect(phases[3].status).toBe("skipped"); // Health Check (placeholder)
+    expect(phases[4].status).toBe("complete"); // Final
+  });
+
+  it("status=FAILED かつ CFn 進行ありのとき CloudFormation Deploy phase が Failed で表示されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "FAILED" }, progressWithFailed);
+    expect(pick(phases, "building").status).toBe("complete"); // CFn 観測あり → Build は通った
+    expect(pick(phases, "cfn-deploy").status).toBe("failed");
+    expect(pick(phases, "complete").status).toBe("failed");
+  });
+
+  it("status=FAILED かつ CFn 未観測のとき Building phase が Failed で表示されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "FAILED" }, emptyProgress);
+    expect(pick(phases, "building").status).toBe("failed");
+    expect(pick(phases, "cfn-deploy").status).toBe("pending");
+  });
+
+  it("status=IN_PROGRESS かつ CFn 進行中のとき該当 phase が In Progress で表示されるべき", () => {
+    const phases = derivePhases(
+      { ...baseDeployment, status: "IN_PROGRESS" },
+      progressWithCreateInProgress,
+    );
+    expect(pick(phases, "building").status).toBe("complete"); // events 観測 → build 通った
+    expect(pick(phases, "cfn-deploy").status).toBe("in-progress");
+  });
+
+  it("stackEvents が空かつ status=IN_PROGRESS のとき CloudFormation Deploy phase は Pending で表示されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "IN_PROGRESS" }, emptyProgress);
+    expect(pick(phases, "cfn-deploy").status).toBe("pending");
+  });
+
+  it("stackProgress=null のときも phase 列が 5 個生成されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "PENDING" }, null);
+    expect(phases).toHaveLength(5);
+    expect(phases[1].status).toBe("pending"); // building pending
+    expect(phases[2].status).toBe("pending"); // cfn pending
+  });
+
+  it("status=DELETED のとき Final phase が Skipped で表示されるべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "DELETED" }, progressAllComplete);
+    expect(pick(phases, "complete").status).toBe("skipped");
+  });
+});
+
+describe("deploySummaryTitle", () => {
+  it("COMPLETE のとき succeeded を含むべき", () => {
+    expect(deploySummaryTitle({ ...baseDeployment, status: "COMPLETE" })).toMatch(/succeeded/);
+  });
+  it("FAILED のとき failed を含むべき", () => {
+    expect(deploySummaryTitle({ ...baseDeployment, status: "FAILED" })).toMatch(/failed/);
+  });
+});
+
+describe("buildTerminalLog", () => {
+  it("Phase ごとの header 行と events 行を出すべき", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
+    const lines = buildTerminalLog(
+      { ...baseDeployment, status: "COMPLETE" },
+      progressAllComplete,
+      phases,
+    );
+    const headers = lines.filter((l) => l.header).map((l) => l.text);
+    expect(headers).toEqual([
+      "> Enqueued [complete]",
+      "> Building [complete]",
+      "> CloudFormation Deploy [complete]",
+      "> Health Check [skipped]",
+      "> Complete / Teardown [complete]",
+    ]);
+    // CFn events 行に logicalResourceId が含まれるべき。
+    expect(lines.some((l) => l.text.includes("MyBucket"))).toBe(true);
+  });
+
+  it("consoleUrl があるとき Building phase 内に CodeBuild console link が出るべき", () => {
+    const phases = derivePhases(
+      { ...baseDeployment, status: "IN_PROGRESS" },
+      progressWithCreateInProgress,
+    );
+    const lines = buildTerminalLog(
+      { ...baseDeployment, status: "IN_PROGRESS" },
+      progressWithCreateInProgress,
+      phases,
+    );
+    expect(lines.some((l) => l.text.includes("CodeBuild console:"))).toBe(true);
+  });
+});

--- a/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
@@ -1,0 +1,227 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getDeployment: vi.fn(),
+  getStackProgress: vi.fn(),
+  deleteDeployment: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/deploy-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/deploy-client")>();
+  return {
+    ...actual,
+    getDeployment: mocks.getDeployment,
+    getStackProgress: mocks.getStackProgress,
+    deleteDeployment: mocks.deleteDeployment,
+  };
+});
+
+import type { DeploymentSummary, StackProgress } from "../../src/api/deploy-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+const baseDeployment: DeploymentSummary = {
+  jobId: JOB_ID,
+  problemId: "hello-world-battle",
+  tenantId: "tenant-test",
+  awsAccountId: "111122223333",
+  region: "ap-northeast-1",
+  teamName: "team-alpha",
+  displayTeamName: "Alpha Team",
+  namePrefix: "tc-team-alpha",
+  status: "PENDING",
+  createdAt: "2026-05-11T01:08:58.000Z",
+  updatedAt: "2026-05-11T01:09:30.000Z",
+  expiresAt: 0,
+};
+
+const emptyProgress: StackProgress = {
+  jobId: JOB_ID,
+  stackName: "tc-team-alpha-stack",
+  region: "ap-northeast-1",
+  consoleUrl: "https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1",
+  events: [],
+  resources: [],
+};
+
+const { DeploymentDetailPage } = await import("../../src/pages/DeploymentDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/deployments/${JOB_ID}`]}>
+      <Routes>
+        <Route path="/deployments/:jobId" element={<DeploymentDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
+  it("deployment status=COMPLETE のとき 5 phase が全部 Complete (or Skipped) で表示されるべき", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "COMPLETE" });
+    mocks.getStackProgress.mockResolvedValue({
+      ...emptyProgress,
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_COMPLETE",
+        },
+      ],
+      resources: [
+        {
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_COMPLETE",
+        },
+      ],
+    });
+    renderPage();
+    await waitFor(() => expect(mocks.getDeployment).toHaveBeenCalled());
+    await screen.findByTestId("phase-enqueued");
+
+    // 5 phase が表示されているべき
+    for (const id of ["enqueued", "building", "cfn-deploy", "health-check", "complete"]) {
+      expect(screen.getByTestId(`phase-${id}`)).toBeInTheDocument();
+    }
+
+    // それぞれの phase に Complete または Skipped status が出る
+    const enqueued = within(screen.getByTestId("phase-enqueued"));
+    expect(enqueued.getByText("Complete")).toBeInTheDocument();
+
+    const building = within(screen.getByTestId("phase-building"));
+    expect(building.getByText("Complete")).toBeInTheDocument();
+
+    const cfn = within(screen.getByTestId("phase-cfn-deploy"));
+    expect(cfn.getByText("Complete")).toBeInTheDocument();
+
+    const health = within(screen.getByTestId("phase-health-check"));
+    expect(health.getByText("Skipped")).toBeInTheDocument();
+
+    const completePhase = within(screen.getByTestId("phase-complete"));
+    expect(completePhase.getByText("Complete")).toBeInTheDocument();
+  });
+
+  it("deployment status=FAILED のとき Building / CloudFormation Deploy phase が Failed で表示されるべき", async () => {
+    mocks.getDeployment.mockResolvedValue({
+      ...baseDeployment,
+      status: "FAILED",
+      failureReason: "CodeBuild failed",
+    });
+    // 空 progress (= CFn 観測なし) → Building が Failed になる
+    mocks.getStackProgress.mockResolvedValue(emptyProgress);
+    renderPage();
+    await waitFor(() => expect(mocks.getDeployment).toHaveBeenCalled());
+    await screen.findByTestId("phase-building");
+
+    const building = within(screen.getByTestId("phase-building"));
+    expect(building.getByText("Failed")).toBeInTheDocument();
+
+    // CFn 観測なし + status=FAILED → CFn phase は Pending
+    const cfn = within(screen.getByTestId("phase-cfn-deploy"));
+    expect(cfn.getByText("Pending")).toBeInTheDocument();
+
+    // Top に failureReason の Alert (Complete phase の body にも出る可能性があるので getAllByText)
+    expect(screen.getAllByText(/CodeBuild failed/).length).toBeGreaterThan(0);
+  });
+
+  it("deployment status=IN_PROGRESS のとき 該当 phase が In Progress で表示されるべき", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
+    mocks.getStackProgress.mockResolvedValue({
+      ...emptyProgress,
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_IN_PROGRESS",
+        },
+      ],
+    });
+    renderPage();
+    await screen.findByTestId("phase-cfn-deploy");
+
+    const cfn = within(screen.getByTestId("phase-cfn-deploy"));
+    expect(cfn.getByText("In Progress")).toBeInTheDocument();
+  });
+
+  it("stackEvents が空のとき CloudFormation Deploy phase は Pending で表示されるべき", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
+    mocks.getStackProgress.mockResolvedValue(emptyProgress);
+    renderPage();
+    await screen.findByTestId("phase-cfn-deploy");
+    const cfn = within(screen.getByTestId("phase-cfn-deploy"));
+    expect(cfn.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("Maximize log button を押すと modal が開いて terminal-style log が表示されるべき", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
+    mocks.getStackProgress.mockResolvedValue({
+      ...emptyProgress,
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_IN_PROGRESS",
+        },
+      ],
+    });
+    renderPage();
+    await screen.findByTestId("maximize-log");
+
+    fireEvent.click(screen.getByTestId("maximize-log"));
+
+    const terminalLog = await screen.findByTestId("terminal-log");
+    expect(terminalLog).toBeInTheDocument();
+    // phase header 行が含まれる
+    expect(within(terminalLog).getByText(/> Enqueued/)).toBeInTheDocument();
+    expect(within(terminalLog).getByText(/> CloudFormation Deploy/)).toBeInTheDocument();
+    // CFn event 行が含まれる
+    expect(within(terminalLog).getByText(/CREATE_IN_PROGRESS MyBucket/)).toBeInTheDocument();
+  });
+
+  it("consoleUrl があるとき Building phase 内に CodeBuild console link が出るべき", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
+    mocks.getStackProgress.mockResolvedValue({
+      ...emptyProgress,
+      consoleUrl: "https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1",
+    });
+    renderPage();
+    await screen.findByTestId("phase-building");
+
+    // ExpandableSection の body は collapsed でも DOM には存在する (Cloudscape spec)。
+    // Building phase body 内の link を text で拾う。
+    expect(screen.getByText(/Open CodeBuild \/ CloudFormation logs/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- DeploymentDetail を Netlify 風 UI に再構築。5 phase (Enqueued / Building / CloudFormation Deploy / Health Check / Complete) を `ExpandableSection` で展開、各 phase に `StatusIndicator` を付ける。
- 「Maximize log」を押すと `Modal size=\"max\"` で terminal-style (行番号 + timestamp + text の 3 列 grid) の log を表示。
- Backend 改修なし。既存 `getDeployment` / `getStackProgress` 5s polling から派生。

## 設計判断

5 phase の意味:
- **Enqueued** — DDB row 観測時点で必ず Complete
- **Building** — CodeBuild step の代理。CFn 観測 → Complete、status=FAILED & CFn 未観測 → Failed
- **CloudFormation Deploy** — `stackEvents` を見て in-progress / complete / failed
- **Health Check** — 将来枠。常に Skipped (HealthCheck Lambda 連携 placeholder)
- **Complete / Teardown** — deployment.status を素直に反映

Phase 派生 logic は `apps/application-admin-console/src/lib/deploy-phases.ts` に集約 (`derivePhases` / `buildTerminalLog` / `deploySummaryTitle`)。View 側を薄く保つ。

## 変更点

- `src/lib/deploy-phases.ts` (新規) — Phase 派生 + terminal log 組み立て + summary title
- `src/pages/DeploymentDetail.tsx`
  - 上部 dark background の summary card
  - Deploy log section: 5 phase + 右上 icon button (scroll up / down / Maximize log)
  - Maximize log で `Modal size=\"max\"` を開き terminal-style 表示
  - 既存 StackEvents / Resources Table は CFn Deploy phase の body に移動
- `test/lib/deploy-phases.test.ts` (新規) — 11 test
- `test/pages/DeploymentDetail.test.tsx` (新規) — 6 test

## Regression 分析

- 既存 polling (5s) / delete モーダル / fetch 同時並列 / stack-progress error 分離は無変更
- `DEPLOYMENT_STATUS_INDICATOR` の import を本ページから削除。Deployments.tsx / ProblemDetail.tsx は別ファイルで継続使用 (= 影響なし)
- `derivePhases` は新規 helper でこのページ専用。global な status 解釈には触れない
- Health Check phase は常に Skipped — 既存挙動と矛盾しない placeholder

## 物理影響

- CFn / Lambda / API: **NO-OP** (frontend-only PR)
- 成果物:
  - **CREATE**: `apps/application-admin-console/src/lib/deploy-phases.ts`
  - **CREATE**: `apps/application-admin-console/test/lib/deploy-phases.test.ts`
  - **CREATE**: `apps/application-admin-console/test/pages/DeploymentDetail.test.tsx`
  - **UPDATE**: `apps/application-admin-console/src/pages/DeploymentDetail.tsx`
  - **DELETE**: なし

## Test plan

- [x] `bun run --filter '@TenkaCloud/application-admin-console' typecheck`
- [x] `bun run --filter '@TenkaCloud/application-admin-console' test` (17 file / 128 test pass)
- [x] `make lint` (only warnings, 0 errors)
- [x] `make check-http-status`
- [x] `make before-commit` 全段通過 (infra 488 + admin-console 60 + application-admin-console 128 + portal 67 = 743 test pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)