### PR TITLE
feat(#596): Phase 3.1 ExternalId rotation API + Rotate UI

### DIFF
--- a/apps/application-admin-console/src/api/competitor-accounts-client.ts
+++ b/apps/application-admin-console/src/api/competitor-accounts-client.ts
@@ -16,6 +16,8 @@ export interface CompetitorAccountSummary {
   verifiedAt?: string;
   createdAt: string;
   updatedAt: string;
+  /** 最後に ExternalId を rotate した時刻 (Issue #596 / ADR-002 Phase 3.1)。未 rotate なら undefined。 */
+  rotatedAt?: string;
 }
 
 export interface CreateCompetitorAccountRequest {
@@ -30,6 +32,16 @@ export interface CreateCompetitorAccountResponse extends CompetitorAccountSummar
   externalId: string;
   /** 競技者に伝える TenkaCloud 側の AWS Account ID (CFn Parameter として要る)。 */
   tenkaCloudAccountId: string;
+}
+
+/**
+ * `/admin/competitor-accounts/{awsAccountId}/rotate-external-id` の response (Issue #596 / Phase 3.1)。
+ * Create と同じく `externalId` を 1 度きり露出する。`rotatedAt` は rotation 時刻 ISO 8601。
+ */
+export interface RotateExternalIdResponse extends CompetitorAccountSummary {
+  externalId: string;
+  tenkaCloudAccountId: string;
+  rotatedAt: string;
 }
 
 export interface ListCompetitorAccountsResponse {
@@ -61,4 +73,18 @@ export async function verifyCompetitorAccount(
 
 export async function deleteCompetitorAccount(api: ApiClient, awsAccountId: string): Promise<void> {
   return api.del(`admin/competitor-accounts/${encodeURIComponent(awsAccountId)}`);
+}
+
+/**
+ * 既存 account に紐付く tenant の ExternalId を rotate する (Issue #596 / ADR-002 Phase 3.1)。
+ * 新 ExternalId は response の `externalId` で 1 度だけ露出する。
+ */
+export async function rotateExternalId(
+  api: ApiClient,
+  awsAccountId: string,
+): Promise<RotateExternalIdResponse> {
+  return api.post<RotateExternalIdResponse>(
+    `admin/competitor-accounts/${encodeURIComponent(awsAccountId)}/rotate-external-id`,
+    {},
+  );
 }

--- a/apps/application-admin-console/src/lib/rotation-age.ts
+++ b/apps/application-admin-console/src/lib/rotation-age.ts
@@ -1,0 +1,43 @@
+/**
+ * Competitor Account の ExternalId rotation 経過日数を計算する (Issue #596 / ADR-002 Phase 3.1)。
+ *
+ * `rotatedAt` が存在すればそれ基準、無ければ `createdAt` 基準。ms → 日数に丸める
+ * (= floor。「過去 1 日未満」の row は 0 日で表示する)。
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** rotation 経過を warning にする閾値 (= 90 日を超えたら yellow badge)。 */
+export const ROTATION_AGE_WARNING_DAYS = 90;
+
+export interface RotationAgeInput {
+  readonly createdAt: string;
+  readonly rotatedAt?: string;
+  readonly nowMs: number;
+}
+
+export interface RotationAgeResult {
+  readonly ageDays: number;
+  /** `rotatedAt` ベースなら true、`createdAt` fallback なら false。 */
+  readonly hasRotated: boolean;
+  readonly isStale: boolean;
+}
+
+/**
+ * `rotatedAt` (無ければ `createdAt`) と `nowMs` の差から経過日数を返す。
+ * 不正な ISO 文字列は `NaN` を返さず 0 日として扱う (= UI で誤表示しないため)。
+ */
+export function computeRotationAge(input: RotationAgeInput): RotationAgeResult {
+  const baseIso = input.rotatedAt ?? input.createdAt;
+  const baseMs = Date.parse(baseIso);
+  if (!Number.isFinite(baseMs)) {
+    return { ageDays: 0, hasRotated: Boolean(input.rotatedAt), isStale: false };
+  }
+  const diffMs = Math.max(0, input.nowMs - baseMs);
+  const ageDays = Math.floor(diffMs / MS_PER_DAY);
+  return {
+    ageDays,
+    hasRotated: Boolean(input.rotatedAt),
+    isStale: ageDays > ROTATION_AGE_WARNING_DAYS,
+  };
+}

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -18,9 +18,12 @@ import {
   createCompetitorAccount,
   deleteCompetitorAccount,
   listCompetitorAccounts,
+  type RotateExternalIdResponse,
+  rotateExternalId,
   verifyCompetitorAccount,
 } from "../api/competitor-accounts-client";
 import type { AppConfig } from "../config";
+import { computeRotationAge, ROTATION_AGE_WARNING_DAYS } from "../lib/rotation-age";
 
 const ACCOUNT_ID_RE = /^\d{12}$/;
 const ALIAS_MAX = 120;
@@ -40,9 +43,13 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
   const [error, setError] = useState<string | null>(null);
   const [addModalVisible, setAddModalVisible] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CompetitorAccountSummary | null>(null);
+  const [rotateTarget, setRotateTarget] = useState<CompetitorAccountSummary | null>(null);
   const [verifyInFlight, setVerifyInFlight] = useState<string | null>(null);
   const [deleteInFlight, setDeleteInFlight] = useState(false);
-  const [showSecret, setShowSecret] = useState<CreateCompetitorAccountResponse | null>(null);
+  const [rotateInFlight, setRotateInFlight] = useState(false);
+  const [showSecret, setShowSecret] = useState<
+    CreateCompetitorAccountResponse | RotateExternalIdResponse | null
+  >(null);
 
   const reload = useCallback(async () => {
     if (!apiClient) return;
@@ -91,6 +98,26 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
     }
   }, [apiClient, deleteTarget, reload]);
 
+  const handleConfirmRotate = useCallback(async () => {
+    if (!apiClient || !rotateTarget) return;
+    setRotateInFlight(true);
+    try {
+      const res = await rotateExternalId(apiClient, rotateTarget.awsAccountId);
+      setRotateTarget(null);
+      setShowSecret(res);
+      await reload();
+    } catch (err) {
+      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
+      setError(message);
+    } finally {
+      setRotateInFlight(false);
+    }
+  }, [apiClient, rotateTarget, reload]);
+
+  // 一覧 mount 時の wall clock。re-render ごとに揺らがないよう state 化する
+  // (= 1 秒未満の差で age 表示が点滅するのを防ぐ)。
+  const [nowMs] = useState(() => Date.now());
+
   const columnDefinitions = useMemo<TableProps.ColumnDefinition<CompetitorAccountSummary>[]>(
     () => [
       {
@@ -124,6 +151,11 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
           ),
       },
       {
+        id: "rotationAge",
+        header: "Rotation 経過",
+        cell: (item) => <RotationAgeBadge item={item} nowMs={nowMs} />,
+      },
+      {
         id: "actions",
         header: "操作",
         cell: (item) => (
@@ -136,6 +168,14 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
             >
               {item.verified ? "再 Verify" : "Verify"}
             </Button>
+            <Button
+              variant="normal"
+              iconName="refresh"
+              onClick={() => setRotateTarget(item)}
+              data-testid={`rotate-${item.awsAccountId}`}
+            >
+              Rotate ExternalId
+            </Button>
             <Button variant="link" onClick={() => setDeleteTarget(item)}>
               削除
             </Button>
@@ -143,7 +183,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         ),
       },
     ],
-    [handleVerify, verifyInFlight],
+    [handleVerify, verifyInFlight, nowMs],
   );
 
   if (!items && !error) {
@@ -222,8 +262,66 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
           鍵漏洩リスク削減)。
         </p>
       </Modal>
+
+      <Modal
+        visible={rotateTarget !== null}
+        onDismiss={() => (rotateInFlight ? undefined : setRotateTarget(null))}
+        header="ExternalId を rotate"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setRotateTarget(null)} disabled={rotateInFlight}>
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                loading={rotateInFlight}
+                onClick={handleConfirmRotate}
+                data-testid="rotate-confirm"
+              >
+                Rotate する
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <Alert type="warning" header="現在の ExternalId は即時失効します">
+          AWS Account <code>{rotateTarget?.awsAccountId}</code> に紐付く tenant の ExternalId
+          を新値で 上書きします。この操作後、競技者は <code>competitor-bootstrap.yaml</code> stack
+          の Parameter を <strong>新 ExternalId</strong> で update する必要があります (= 古い値での
+          AssumeRole は 失敗するようになります)。
+        </Alert>
+        <p>
+          同 tenant 配下の他 account も同じ ExternalId を共有するため、tenant に複数 account が
+          登録されている場合は <strong>全 competitor に新値を共有</strong>してください。
+        </p>
+      </Modal>
     </SpaceBetween>
   );
+}
+
+interface RotationAgeBadgeProps {
+  item: CompetitorAccountSummary;
+  nowMs: number;
+}
+
+function RotationAgeBadge({ item, nowMs }: RotationAgeBadgeProps) {
+  const age = computeRotationAge({
+    createdAt: item.createdAt,
+    rotatedAt: item.rotatedAt,
+    nowMs,
+  });
+  const label = age.hasRotated
+    ? `${age.ageDays} 日前 rotate`
+    : `${age.ageDays} 日前作成 (未 rotate)`;
+  if (age.isStale) {
+    return (
+      <Badge color="severity-medium">
+        {label} (要 rotation: {ROTATION_AGE_WARNING_DAYS} 日超)
+      </Badge>
+    );
+  }
+  return <Box color="text-status-inactive">{label}</Box>;
 }
 
 interface AddAccountModalProps {
@@ -352,7 +450,7 @@ function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountMo
 }
 
 interface SecretRevealModalProps {
-  details: CreateCompetitorAccountResponse | null;
+  details: CreateCompetitorAccountResponse | RotateExternalIdResponse | null;
   onDismiss: () => void;
 }
 

--- a/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
+++ b/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
@@ -4,6 +4,7 @@ import {
   createCompetitorAccount,
   deleteCompetitorAccount,
   listCompetitorAccounts,
+  rotateExternalId,
   verifyCompetitorAccount,
 } from "../../src/api/competitor-accounts-client";
 
@@ -95,5 +96,28 @@ describe("deleteCompetitorAccount", () => {
     await deleteCompetitorAccount(client, "222222222222");
     expect(calls[0]?.path).toBe("admin/competitor-accounts/222222222222");
     expect(calls[0]?.method).toBe("DELETE");
+  });
+});
+
+describe("rotateExternalId", () => {
+  it("POST /admin/competitor-accounts/{awsAccountId}/rotate-external-id を呼び新 externalId を返すべき", async () => {
+    const { client, calls } = fakeClient({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      rotatedAt: "2026-05-12T00:00:00.000Z",
+      externalId: "rotated-new-value",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const res = await rotateExternalId(client, "222222222222");
+    expect(calls[0]?.path).toBe("admin/competitor-accounts/222222222222/rotate-external-id");
+    expect(calls[0]?.method).toBe("POST");
+    expect(res.externalId).toBe("rotated-new-value");
+    expect(res.rotatedAt).toBe("2026-05-12T00:00:00.000Z");
+    expect(res.tenkaCloudAccountId).toBe("111111111111");
   });
 });

--- a/apps/application-admin-console/test/lib/rotation-age.test.ts
+++ b/apps/application-admin-console/test/lib/rotation-age.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { computeRotationAge, ROTATION_AGE_WARNING_DAYS } from "../../src/lib/rotation-age";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("computeRotationAge", () => {
+  it("rotatedAt があれば rotatedAt 基準で日数を返すべき", () => {
+    const baseIso = "2026-04-01T00:00:00.000Z";
+    const nowMs = Date.parse(baseIso) + 5 * DAY_MS;
+    const res = computeRotationAge({
+      createdAt: "2026-01-01T00:00:00.000Z",
+      rotatedAt: baseIso,
+      nowMs,
+    });
+    expect(res.ageDays).toBe(5);
+    expect(res.hasRotated).toBe(true);
+    expect(res.isStale).toBe(false);
+  });
+
+  it("rotatedAt が無ければ createdAt 基準で日数を返すべき", () => {
+    const baseIso = "2026-01-01T00:00:00.000Z";
+    const nowMs = Date.parse(baseIso) + 30 * DAY_MS;
+    const res = computeRotationAge({ createdAt: baseIso, nowMs });
+    expect(res.ageDays).toBe(30);
+    expect(res.hasRotated).toBe(false);
+  });
+
+  it("経過日数が ROTATION_AGE_WARNING_DAYS を超えると isStale=true になるべき", () => {
+    const baseIso = "2026-01-01T00:00:00.000Z";
+    const nowMs = Date.parse(baseIso) + (ROTATION_AGE_WARNING_DAYS + 1) * DAY_MS;
+    const res = computeRotationAge({ createdAt: baseIso, nowMs });
+    expect(res.isStale).toBe(true);
+  });
+
+  it("境界値 (= ちょうど ROTATION_AGE_WARNING_DAYS 日) では isStale=false のままであるべき", () => {
+    const baseIso = "2026-01-01T00:00:00.000Z";
+    const nowMs = Date.parse(baseIso) + ROTATION_AGE_WARNING_DAYS * DAY_MS;
+    const res = computeRotationAge({ createdAt: baseIso, nowMs });
+    expect(res.ageDays).toBe(ROTATION_AGE_WARNING_DAYS);
+    expect(res.isStale).toBe(false);
+  });
+
+  it("nowMs が base より過去でも ageDays=0 を返すべき (= マイナスを出さない)", () => {
+    const baseIso = "2026-05-01T00:00:00.000Z";
+    const nowMs = Date.parse(baseIso) - 5 * DAY_MS;
+    const res = computeRotationAge({ createdAt: baseIso, nowMs });
+    expect(res.ageDays).toBe(0);
+  });
+});

--- a/apps/application-admin-console/test/pages/CompetitorAccounts.rotate.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.rotate.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  listCompetitorAccounts: vi.fn(),
+  createCompetitorAccount: vi.fn(),
+  deleteCompetitorAccount: vi.fn(),
+  verifyCompetitorAccount: vi.fn(),
+  rotateExternalId: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/competitor-accounts-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/competitor-accounts-client")>();
+  return {
+    ...actual,
+    listCompetitorAccounts: mocks.listCompetitorAccounts,
+    createCompetitorAccount: mocks.createCompetitorAccount,
+    deleteCompetitorAccount: mocks.deleteCompetitorAccount,
+    verifyCompetitorAccount: mocks.verifyCompetitorAccount,
+    rotateExternalId: mocks.rotateExternalId,
+  };
+});
+
+import type { AppConfig } from "../../src/config";
+
+const { CompetitorAccountsPage } = await import("../../src/pages/CompetitorAccounts");
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const baseAccount = {
+  awsAccountId: "222222222222",
+  region: "ap-northeast-1",
+  competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+  verified: true,
+  verifiedAt: "2026-05-11T00:00:00.000Z",
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CompetitorAccountsPage config={config} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+  mocks.listCompetitorAccounts.mockResolvedValue({ items: [baseAccount] });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("CompetitorAccountsPage rotate flow (Issue #596 / Phase 3.1)", () => {
+  it("Rotate ExternalId button を押すと confirmation modal が出るべき", async () => {
+    renderPage();
+    await waitFor(() => expect(mocks.listCompetitorAccounts).toHaveBeenCalled());
+
+    const rotateBtn = await screen.findByTestId(`rotate-${baseAccount.awsAccountId}`);
+    fireEvent.click(rotateBtn);
+
+    // confirmation modal の warning Alert が見える
+    expect(await screen.findByText(/現在の ExternalId は即時失効します/)).toBeInTheDocument();
+  });
+
+  it("確認 modal の Rotate ボタンで API を呼び成功すると Reveal modal を表示するべき", async () => {
+    mocks.rotateExternalId.mockResolvedValueOnce({
+      ...baseAccount,
+      rotatedAt: "2026-05-12T00:00:00.000Z",
+      externalId: "new-rotated-secret-value",
+      tenkaCloudAccountId: "111111111111",
+    });
+
+    renderPage();
+    await waitFor(() => expect(mocks.listCompetitorAccounts).toHaveBeenCalled());
+
+    fireEvent.click(await screen.findByTestId(`rotate-${baseAccount.awsAccountId}`));
+    fireEvent.click(await screen.findByTestId("rotate-confirm"));
+
+    await waitFor(() =>
+      expect(mocks.rotateExternalId).toHaveBeenCalledWith(
+        expect.anything(),
+        baseAccount.awsAccountId,
+      ),
+    );
+
+    // Reveal modal: 新 ExternalId の値が DOM に出る
+    expect(await screen.findByText("new-rotated-secret-value")).toBeInTheDocument();
+    // 一覧 reload (= 2 度目の list 呼び出し)
+    await waitFor(() => expect(mocks.listCompetitorAccounts).toHaveBeenCalledTimes(2));
+  });
+
+  it("rotatedAt が 90 日以上前なら警告 badge を表示するべき", async () => {
+    // 100 日前の rotatedAt
+    const longAgo = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    mocks.listCompetitorAccounts.mockResolvedValueOnce({
+      items: [{ ...baseAccount, rotatedAt: longAgo }],
+    });
+
+    renderPage();
+    await waitFor(() => expect(mocks.listCompetitorAccounts).toHaveBeenCalled());
+
+    expect(await screen.findByText(/要 rotation/)).toBeInTheDocument();
+  });
+});

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -10,7 +10,9 @@ import {
   createCompetitorAccount,
   DuplicateCompetitorAccountError,
   deleteCompetitorAccount,
+  ExternalIdMissingForRotationError,
   listCompetitorAccounts,
+  rotateExternalIdForAccount,
 } from "./store.js";
 import { CreateCompetitorAccountRequestSchema } from "./types.js";
 import {
@@ -23,10 +25,11 @@ import {
  * Competitor Accounts API Lambda の Hono app (Issue #459 / ADR-002 Phase 2.1)。
  *
  * routes (すべて tenant API + Cognito JWT authorizer 経由):
- *   POST   /admin/competitor-accounts                       — register (= SSM Put + DDB Put)
- *   GET    /admin/competitor-accounts                       — list (verified / unverified 両方)
- *   POST   /admin/competitor-accounts/{awsAccountId}/verify — STS AssumeRole sanity check
- *   DELETE /admin/competitor-accounts/{awsAccountId}        — remove (last row なら SSM 鍵も削除)
+ *   POST   /admin/competitor-accounts                                    — register (= SSM Put + DDB Put)
+ *   GET    /admin/competitor-accounts                                    — list (verified / unverified 両方)
+ *   POST   /admin/competitor-accounts/{awsAccountId}/verify              — STS AssumeRole sanity check
+ *   POST   /admin/competitor-accounts/{awsAccountId}/rotate-external-id  — ExternalId rotation (Phase 3.1)
+ *   DELETE /admin/competitor-accounts/{awsAccountId}                     — remove (last row なら SSM 鍵も削除)
  *
  * Auth: tenant API GW + Cognito JWT authorizer。tenantId は JWT `custom:tenantId` claim
  * から `resolveTenantId(c)` で抽出する。**request body の tenantId は信頼しない** (= IAM 越境攻撃の防止)。
@@ -140,6 +143,31 @@ app.post("/admin/competitor-accounts/:awsAccountId/verify", async (c) => {
     }
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[competitor-accounts] verify failed", { awsAccountId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c) => {
+  const awsAccountId = c.req.param("awsAccountId");
+  if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
+    return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
+  }
+  try {
+    const response = await rotateExternalIdForAccount(shared, {
+      tenantId: resolveTenantId(c),
+      awsAccountId,
+      nowMs: Date.now(),
+    });
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    if (err instanceof CompetitorAccountNotFoundError) {
+      return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    if (err instanceof ExternalIdMissingForRotationError) {
+      return c.json({ error: "external_id_missing" }, StatusCodes.CONFLICT);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] rotate failed", { awsAccountId, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
@@ -6,13 +6,19 @@ import {
   QueryCommand,
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
-import { deleteExternalId, ensureExternalId } from "../shared/external-id-store.js";
+import {
+  deleteExternalId,
+  ensureExternalId,
+  getExternalId,
+  rotateExternalId,
+} from "../shared/external-id-store.js";
 import type { CompetitorAccountsSharedResources } from "./shared.js";
 import type {
   CompetitorAccountItem,
   CompetitorAccountSummary,
   CreateCompetitorAccountRequest,
   CreateCompetitorAccountResponse,
+  RotateExternalIdResponse,
 } from "./types.js";
 
 const PK = (tenantId: string) => `TENANT#${tenantId}`;
@@ -27,6 +33,7 @@ const toSummary = (item: Partial<CompetitorAccountItem>): CompetitorAccountSumma
   verifiedAt: typeof item.verifiedAt === "string" ? item.verifiedAt : undefined,
   createdAt: String(item.createdAt ?? ""),
   updatedAt: String(item.updatedAt ?? ""),
+  rotatedAt: typeof item.rotatedAt === "string" ? item.rotatedAt : undefined,
 });
 
 export class DuplicateCompetitorAccountError extends Error {
@@ -214,5 +221,88 @@ export async function deleteCompetitorAccount(
   );
   if ((remaining.Count ?? 0) === 0) {
     await deleteExternalId({ ssm: shared.ssm as SSMClient, env: shared.env }, tenantId);
+  }
+}
+
+export interface RotateExternalIdContext {
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly nowMs: number;
+}
+
+export class ExternalIdMissingForRotationError extends Error {
+  constructor(public readonly tenantId: string) {
+    super(`external id parameter is missing for tenant ${tenantId}; cannot rotate`);
+    this.name = "ExternalIdMissingForRotationError";
+  }
+}
+
+/**
+ * 既存 (tenantId, awsAccountId) に対して ExternalId を rotate (Issue #596 / Phase 3.1)。
+ *
+ * 手順:
+ *  1. DDB の該当 row が存在することを確認 (= row 不在なら `CompetitorAccountNotFoundError`)。
+ *  2. SSM の現 ExternalId が存在することを確認 (= 不在は不整合、`ExternalIdMissingForRotationError`)。
+ *  3. SSM SecureString を `Overwrite: true` で新 64 文字 hex に上書き
+ *     (= SSM 内部で version 履歴が増える)。
+ *  4. DDB の `rotatedAt` / `updatedAt` を更新。
+ *  5. 新 ExternalId + tenkaCloudAccountId を 1 度だけ返す (= Create と同じ Reveal payload)。
+ *
+ * 同 tenant 配下の他 account 行も同じ SSM Parameter を共有するため、rotate 直後は **全 account
+ * の競技者側 CFn stack の Parameter を update する必要がある**。caller (handler) はその警告を
+ * operator に出すこと (= frontend の confirmation modal で文言済み)。
+ */
+export async function rotateExternalIdForAccount(
+  shared: CompetitorAccountsSharedResources,
+  ctx: RotateExternalIdContext,
+): Promise<RotateExternalIdResponse> {
+  // 1. row 存在確認 (Get で取り出して PATCH 用に使う)。
+  const existing = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: PK(ctx.tenantId), SK: SK(ctx.awsAccountId) },
+    }),
+  );
+  if (!existing.Item) throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
+
+  // 2. 現 ExternalId 存在確認 (= 鍵が完全消失している tenant に対する rotate は誤操作のサイン)。
+  const currentExternalId = await getExternalId(
+    { ssm: shared.ssm as SSMClient, env: shared.env },
+    ctx.tenantId,
+  );
+  if (!currentExternalId) throw new ExternalIdMissingForRotationError(ctx.tenantId);
+
+  // 3. SSM Overwrite で新値を Put (= version 履歴は SSM 側に蓄積)。
+  const { externalId: newExternalId } = await rotateExternalId(
+    { ssm: shared.ssm as SSMClient, env: shared.env },
+    ctx.tenantId,
+  );
+
+  // 4. DDB の rotatedAt / updatedAt を Update。row 不在は (1) で弾いているはずだが、TOCTOU
+  //    に備えて ConditionExpression で再確認する。
+  const rotatedAt = new Date(ctx.nowMs).toISOString();
+  try {
+    const out = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: PK(ctx.tenantId), SK: SK(ctx.awsAccountId) },
+        UpdateExpression: "SET rotatedAt = :r, updatedAt = :u",
+        ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+        ExpressionAttributeValues: { ":r": rotatedAt, ":u": rotatedAt },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const summary = toSummary((out.Attributes ?? {}) as Partial<CompetitorAccountItem>);
+    return {
+      ...summary,
+      rotatedAt,
+      externalId: newExternalId,
+      tenkaCloudAccountId: shared.tenkaCloudAccountId,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === "ConditionalCheckFailedException") {
+      throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
+    }
+    throw err;
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
@@ -20,6 +20,11 @@ export interface CompetitorAccountItem {
   verifiedAt?: string;
   createdAt: string;
   updatedAt: string;
+  /**
+   * 最後に ExternalId を rotate した時刻 (Issue #596 / ADR-002 Phase 3.1)。
+   * 過去 row には存在しない (= undefined のときは「未 rotate = createdAt から経過」とみなす)。
+   */
+  rotatedAt?: string;
   /** Cognito sub (= operator 監査用)。`unknown` の場合は JWT 解決失敗 (test / dev fallback)。 */
   createdBy: string;
 }
@@ -60,6 +65,8 @@ export interface CompetitorAccountSummary {
   verifiedAt?: string;
   createdAt: string;
   updatedAt: string;
+  /** 最後に ExternalId を rotate した時刻 (Issue #596 / ADR-002 Phase 3.1)。未 rotate なら undefined。 */
+  rotatedAt?: string;
 }
 
 export interface CreateCompetitorAccountResponse extends CompetitorAccountSummary {
@@ -79,4 +86,14 @@ export interface ListCompetitorAccountsResponse {
 export interface VerifyCompetitorAccountResponse extends CompetitorAccountSummary {
   /** STS AssumeRole が成功した時点の ISO 8601 (= `verifiedAt`)。 */
   verifiedAt: string;
+}
+
+/**
+ * Rotate response (Issue #596 / ADR-002 Phase 3.1)。
+ * Create と同じく `externalId` を 1 度だけ露出する。`rotatedAt` には rotate 時刻が入る。
+ */
+export interface RotateExternalIdResponse extends CompetitorAccountSummary {
+  externalId: string;
+  tenkaCloudAccountId: string;
+  rotatedAt: string;
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
@@ -100,6 +100,35 @@ export async function ensureExternalId(
 }
 
 /**
+ * tenant の ExternalId を強制的に rotate する (Issue #596 / ADR-002 Phase 3.1)。
+ *
+ * 既存の SSM SecureString を `Overwrite: true` で上書きする。SSM は内部で
+ * version 履歴 (最大 100 version) を保持するので、grace 期間の旧値 fallback が
+ * 必要になったときは `$LATEST` 以外の version 指定で取り出せる
+ * (= 旧値 fallback の実装は Phase 3.2 で別 PR)。
+ *
+ * `ensureExternalId` と違って必ず新 ExternalId を発行する。caller (handler) は
+ * 「該当 tenant に競技者 account が登録されている」ことを事前に保証すること
+ * (= 未登録 tenant に新 SSM Parameter を作るのは create path の責任)。
+ */
+export async function rotateExternalId(
+  deps: ExternalIdStoreDeps,
+  tenantId: string,
+): Promise<{ readonly externalId: string }> {
+  const name = buildExternalIdParameterName(deps.env, tenantId);
+  const externalId = generateExternalId();
+  await deps.ssm.send(
+    new PutParameterCommand({
+      Name: name,
+      Value: externalId,
+      Type: ParameterType.SECURE_STRING,
+      Overwrite: true,
+    }),
+  );
+  return { externalId };
+}
+
+/**
  * tenant の ExternalId を削除。存在しない場合は no-op (= idempotent)。
  *
  * 注意: 同 tenant 配下に **他の verified account が残っている場合は呼ぶべきでない** (= caller 責任)。

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -113,9 +113,10 @@ export class ApiGateway extends Construct {
     lockScoring.addMethod("DELETE", eventIntegration, deployMethodOptions);
 
     // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + verify
-    //   /admin/competitor-accounts                       POST=register, GET=list
-    //   /admin/competitor-accounts/{awsAccountId}        DELETE=remove (last row なら SSM 鍵も掃除)
-    //   /admin/competitor-accounts/{awsAccountId}/verify POST=STS AssumeRole sanity check
+    //   /admin/competitor-accounts                                     POST=register, GET=list
+    //   /admin/competitor-accounts/{awsAccountId}                      DELETE=remove (last row なら SSM 鍵も掃除)
+    //   /admin/competitor-accounts/{awsAccountId}/verify               POST=STS AssumeRole sanity check
+    //   /admin/competitor-accounts/{awsAccountId}/rotate-external-id   POST=ExternalId rotation (Issue #596 / Phase 3.1)
     const competitorAccountsIntegration = new LambdaIntegration(props.competitorAccountsApiLambda);
     const admin = this.restApi.root.addResource("admin");
     const competitorAccounts = admin.addResource("competitor-accounts");
@@ -125,6 +126,9 @@ export class ApiGateway extends Construct {
     competitorAccount.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
     competitorAccount
       .addResource("verify")
+      .addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
+    competitorAccount
+      .addResource("rotate-external-id")
       .addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   listCompetitorAccounts: vi.fn(),
   deleteCompetitorAccount: vi.fn(),
   verifyCompetitorAccount: vi.fn(),
+  rotateExternalIdForAccount: vi.fn(),
   DuplicateCompetitorAccountError: class extends Error {
     constructor(public readonly awsAccountId: string) {
       super("dup");
@@ -16,6 +17,12 @@ const mocks = vi.hoisted(() => ({
     constructor(public readonly awsAccountId: string) {
       super("404");
       this.name = "CompetitorAccountNotFoundError";
+    }
+  },
+  ExternalIdMissingForRotationError: class extends Error {
+    constructor(public readonly tenantId: string) {
+      super("missing");
+      this.name = "ExternalIdMissingForRotationError";
     }
   },
   AssumeRoleSanityCheckFailedError: class extends Error {
@@ -51,8 +58,10 @@ vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/store", (
   createCompetitorAccount: mocks.createCompetitorAccount,
   listCompetitorAccounts: mocks.listCompetitorAccounts,
   deleteCompetitorAccount: mocks.deleteCompetitorAccount,
+  rotateExternalIdForAccount: mocks.rotateExternalIdForAccount,
   DuplicateCompetitorAccountError: mocks.DuplicateCompetitorAccountError,
   CompetitorAccountNotFoundError: mocks.CompetitorAccountNotFoundError,
+  ExternalIdMissingForRotationError: mocks.ExternalIdMissingForRotationError,
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify", () => ({
@@ -197,6 +206,63 @@ describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
     const res = await app.request("/admin/competitor-accounts/abc/verify", { method: "POST" });
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
     expect(mocks.verifyCompetitorAccount).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("200 + 新 externalId + tenkaCloudAccountId を含む Reveal payload を返すべき", async () => {
+    mocks.rotateExternalIdForAccount.mockResolvedValueOnce({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      rotatedAt: "2026-05-12T00:00:00.000Z",
+      externalId: "new-rotated-id",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.externalId).toBe("new-rotated-id");
+    expect(body.tenkaCloudAccountId).toBe("111111111111");
+    expect(body.rotatedAt).toBe("2026-05-12T00:00:00.000Z");
+  });
+
+  it("row なしは 404 を返すべき", async () => {
+    mocks.rotateExternalIdForAccount.mockRejectedValueOnce(
+      new mocks.CompetitorAccountNotFoundError("999999999999"),
+    );
+    const res = await app.request("/admin/competitor-accounts/999999999999/rotate-external-id", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("SSM に現 ExternalId が無いと 409 (external_id_missing) を返すべき", async () => {
+    mocks.rotateExternalIdForAccount.mockRejectedValueOnce(
+      new mocks.ExternalIdMissingForRotationError("tenant-acme"),
+    );
+    const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("external_id_missing");
+  });
+
+  it("awsAccountId が 12 桁でないと 400", async () => {
+    const res = await app.request("/admin/competitor-accounts/abc/rotate-external-id", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.rotateExternalIdForAccount).not.toHaveBeenCalled();
   });
 });
 

--- a/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
@@ -1,7 +1,7 @@
 import { PutParameterCommand } from "@aws-sdk/client-ssm";
 import {
   DeleteCommand,
-  type GetCommand,
+  GetCommand,
   PutCommand,
   QueryCommand,
   UpdateCommand,
@@ -13,9 +13,11 @@ import {
   createCompetitorAccount,
   DuplicateCompetitorAccountError,
   deleteCompetitorAccount,
+  ExternalIdMissingForRotationError,
   getCompetitorAccount,
   listCompetitorAccounts,
   markCompetitorAccountVerified,
+  rotateExternalIdForAccount,
 } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/store";
 
 const NOW_MS = 1_700_000_000_000;
@@ -284,5 +286,124 @@ describe("deleteCompetitorAccount", () => {
     await deleteCompetitorAccount(shared, "tenant-acme", "222222222222");
 
     expect(ssmSend.mock.calls.length).toBe(0);
+  });
+});
+
+describe("rotateExternalIdForAccount", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SSM Parameter を Overwrite=true で Put し DDB の rotatedAt を更新するべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    // 1. DDB Get で既存 row 確認 → Item あり
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        PK: "TENANT#tenant-acme",
+        SK: "ACCOUNT#222222222222",
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        verifiedAt: NOW_ISO,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+      },
+    });
+    // 2. SSM GetParameter で現値あり
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "old-external-id" } });
+    // 3. SSM PutParameter (Overwrite=true)
+    ssmSend.mockResolvedValueOnce({});
+    // 4. DDB Update — Attributes には rotatedAt が乗る
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        verifiedAt: NOW_ISO,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+        rotatedAt: NOW_ISO,
+      },
+    });
+
+    const out = await rotateExternalIdForAccount(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      nowMs: NOW_MS,
+    });
+
+    // SSM PutParameter 呼び出しを検査 (= Overwrite:true, SecureString, 64 文字 hex)
+    const putParamCall = ssmSend.mock.calls[1]?.[0] as PutParameterCommand;
+    expect(putParamCall).toBeInstanceOf(PutParameterCommand);
+    expect(putParamCall.input.Type).toBe("SecureString");
+    expect(putParamCall.input.Overwrite).toBe(true);
+    expect(putParamCall.input.Name).toBe("/development/tenants/tenant-acme/external-id");
+    expect(typeof putParamCall.input.Value).toBe("string");
+    expect((putParamCall.input.Value as string).length).toBe(64);
+
+    // DDB Update が rotatedAt を立てている
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    expect(updateCmd).toBeInstanceOf(UpdateCommand);
+    expect(updateCmd.input.UpdateExpression).toContain("rotatedAt = :r");
+    expect(updateCmd.input.ExpressionAttributeValues?.[":r"]).toBe(NOW_ISO);
+    expect(updateCmd.input.ExpressionAttributeValues?.[":u"]).toBe(NOW_ISO);
+
+    // 戻り値: 新 ExternalId + tenkaCloudAccountId + rotatedAt
+    expect(out.externalId).toBe(putParamCall.input.Value);
+    expect(out.externalId).not.toBe("old-external-id");
+    expect(out.tenkaCloudAccountId).toBe("111111111111");
+    expect(out.rotatedAt).toBe(NOW_ISO);
+  });
+
+  it("row が無ければ CompetitorAccountNotFoundError を投げ SSM Put しないべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    // Get が Item を返さない
+    ddbSend.mockResolvedValueOnce({});
+
+    await expect(
+      rotateExternalIdForAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "999999999999",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(CompetitorAccountNotFoundError);
+
+    // GetCommand 1 度のみ。SSM は触らない。
+    expect(ddbSend.mock.calls.length).toBe(1);
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
+    expect(ssmSend.mock.calls.length).toBe(0);
+  });
+
+  it("SSM に現 ExternalId が無ければ ExternalIdMissingForRotationError を投げ Put しないべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    // 1. Get Item OK
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        PK: "TENANT#tenant-acme",
+        SK: "ACCOUNT#222222222222",
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: true,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+      },
+    });
+    // 2. SSM GetParameter で ParameterNotFound
+    ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
+
+    await expect(
+      rotateExternalIdForAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(ExternalIdMissingForRotationError);
+
+    // SSM Get 1 度のみ、Put は呼ばない
+    expect(ssmSend.mock.calls.length).toBe(1);
   });
 });

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -146,4 +146,19 @@ describe("tenant ApiGateway", () => {
       ResourceId: { Ref: caResourceId },
     });
   });
+
+  it("/admin/competitor-accounts/{awsAccountId}/rotate-external-id POST を持つべき (Issue #596)", () => {
+    // Issue #596 / ADR-002 Phase 3.1: ExternalId rotation route
+    expect(findResource("rotate-external-id")).toBeDefined();
+    const rotateResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { PathPart: "rotate-external-id" },
+      }),
+    )[0]?.[0];
+    expect(rotateResourceId).toBeDefined();
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "POST",
+      ResourceId: { Ref: rotateResourceId },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Issue #596 = ADR-002 Phase 3 (ExternalId rotation) のうち、operator が画面でいつでも
ExternalId を rotate できる経路を Phase 3.1 として実装した。Worker grace fallback と
scheduled SSM cleanup + CloudWatch metric は Phase 3.2 (#603) として follow-up issue
を別途切ってある。

- backend: `POST /admin/competitor-accounts/{awsAccountId}/rotate-external-id` を新設し、
  SSM SecureString を `Overwrite: true` で更新 (= SSM 内部の version 履歴は自動で +1)、
  DDB の `rotatedAt` も更新。Reveal payload (新 `externalId` + `tenkaCloudAccountId`) を
  1 度だけ返す。
- frontend: 一覧 row に「Rotate ExternalId」 button (Cloudscape `variant="normal"` +
  `iconName="refresh"`) と confirmation modal を追加。成功時は既存 `SecretRevealModal` を
  そのまま再利用して新 ExternalId を表示する。`rotatedAt` (無ければ `createdAt`) と現在時刻の
  差を「Rotation 経過」列で表示し、90 日超なら yellow badge で警告する。
- tests: 11 件追加 (handler 3 + route 4 + api-gateway synth 1 + frontend client 1 +
  frontend page 3 + helper 5)。

## 設計判断

Phase 3 を 2 段階に割った理由:
- Phase 3.1 (本 PR) — operator が手で rotate する経路を最優先で出す (= 鍵漏洩時の
  即時対応経路を確立)。
- Phase 3.2 (#603) — Worker Lambda grace fallback + scheduled cleanup + CloudWatch
  metric は Worker integration と並列に進める。

SSM の version 履歴は `Overwrite: true` で SSM が自動的に保持する (100 version cap)。
本 PR では追加の version 管理 code を持たず、operator が明示的に rotate を発火する
境界を確立することに専念した。

## Regression 分析

- 同 tenant 配下の既存 account の AssumeRole が rotate 直後に失敗する。ExternalId は
  tenant 1 値で共有 (ADR-002 §2.2) なので、rotate 後は同 tenant の全 competitor が
  新値で bootstrap を update し直す必要がある。confirmation modal の文言で operator
  に明示している。
- Worker Lambda の AssumeRole 経路は本 PR では grace fallback を持たない。rotate 直後
  の deploy job は失敗しうる。本 PR では Worker を変更せず、Phase 3.2 (#603) で
  「新 ExternalId 失敗 → 旧 SSM version で fallback」を別 PR として入れる。
- Phase 2.1 の `ensureExternalId` 冪等性を破らない。`rotateExternalId` は別関数として
  追加した。Add account は引き続き `Overwrite: false` のままで、既存テストは全 pass。
- 既存 `CompetitorAccountItem` row は `rotatedAt` 列を持たない。optional 属性 +
  undefined fallback (= `createdAt` 基準で表示) にしてある。migration なしで動く。

## 物理影響

- CFn `serverless-saas-ref-arch-tenant-template-pooled` (および silo): **UPDATE** —
  `AWS::ApiGateway::Resource` (`rotate-external-id`) + `AWS::ApiGateway::Method`
  (POST + OPTIONS) が増える。
- Lambda `CompetitorAccountsApi` の code bundle: **UPDATE** — rotate route が追加
  されるが env / IAM policy は変更なし (= 既存 SSM PutParameter 権限を再利用)。
- DynamoDB `CompetitorAccounts` table: **NO-OP** — schema 不変、`rotatedAt` は
  optional attribute として書き込まれるだけで GSI も増えない。
- SSM Parameter Store: **NO-OP** at deploy 時。実行時に operator が rotate を発火
  すると既存 path `/{env}/tenants/{tenantId}/external-id` の version が +1 される。
- CloudFront distribution `application-admin-console`: **UPDATE** — JS bundle に新
  page ロジック (rotate button + modal + age column) が混じる。

## Test plan

- [x] `make lint`
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` (553 passed)
- [x] `bun run --filter '@TenkaCloud/application-admin-console' typecheck`
- [x] `bun run --filter '@TenkaCloud/application-admin-console' test` (140 passed)
- [x] `make check-http-status`
- [ ] Deploy 後の手動確認 (= operator 画面で実際に rotate → 新値で Verify が再度通る)
- [ ] Phase 3.2 (#603) で Worker grace fallback + scheduled cleanup を deploy する

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rotate External IDs for competitor accounts with confirmation workflow
  * Track rotation age and display warning indicators when External IDs exceed 90 days without rotation
  * View newly generated External ID immediately after successful rotation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->