### PR TITLE
feat(#603): Phase 3.2 grace fallback + rotation age metric + audit log

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-cloudformation": "^3.1030.0",
+        "@aws-sdk/client-cloudwatch": "^3.1040.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.1040.0",
         "@aws-sdk/client-dynamodb": "^3.1030.0",
         "@aws-sdk/client-eventbridge": "^3.1030.0",
@@ -170,6 +171,8 @@
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
     "@aws-sdk/client-cloudformation": ["@aws-sdk/client-cloudformation@3.1041.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-rO9yo34SAR7vNw1V97SY5V7J6oo13FPShhn5NN2vFxiOIx4hjJ74OYDatQ2RBLVO7ER1eyjLnxVNrbpxDQFM0A=="],
+
+    "@aws-sdk/client-cloudwatch": ["@aws-sdk/client-cloudwatch@3.1045.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-compression": "^4.3.46", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-aZiQpgEdg+0np5bvxsBfzvlJKcbdvRYnyGCFTA3TxwIdqCOEEwWCDivazBizFa9rYQHvfXsOkm/kS6L+nvujnw=="],
 
     "@aws-sdk/client-cognito-identity-provider": ["@aws-sdk/client-cognito-identity-provider@3.1041.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-rv8Ogf84/N6TSYeAp3IdU6naYU+z+jZ1XedvD/cS8yrgmb4OyU/fBJjQJcJTfjFIL+OYdne2kVfUd8+OrnFsbg=="],
 
@@ -498,6 +501,8 @@
     "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw=="],
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/middleware-compression": ["@smithy/middleware-compression@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "fflate": "0.8.1", "tslib": "^2.6.2" } }, "sha512-p5HLi70K05XqhXHPQEhANMv3xhFAgcz0O11sCd8MZEXI45Y86A5hLEwDNQPbvoHh3U3B+NKdh1vqlsjpiozfXw=="],
 
     "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.14", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw=="],
 
@@ -970,6 +975,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fflate": ["fflate@0.8.1", "", {}, "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="],
 
     "file-entry-cache": ["file-entry-cache@10.1.4", "", { "dependencies": { "flat-cache": "^6.1.13" } }, "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA=="],
 
@@ -1890,6 +1897,8 @@
     "@cdklabs/sbt-aws/@aws-cdk/aws-lambda-python-alpha": ["@aws-cdk/aws-lambda-python-alpha@2.114.1-alpha.0", "", { "peerDependencies": { "aws-cdk-lib": "^2.114.1", "constructs": "^10.0.0" } }, "sha512-ozpcGNBrNjfrEOkTC8gpTJu9g1PCKV62NNGV3kE3hOkqjphss9ytwKjIfUIvS+yjqy8D8/BHM0btJKrNur0RoQ=="],
 
     "@cloudscape-design/component-toolkit/weekstart": ["weekstart@2.0.0", "", {}, "sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg=="],
+
+    "@smithy/middleware-compression/@smithy/core": ["@smithy/core@3.24.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 

--- a/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
+++ b/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
@@ -1,0 +1,92 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface ExternalIdAuditLambdaProps {
+  /** `CompetitorAccounts` DDB table (rotatedAt / createdAt を読み取る)。 */
+  readonly competitorAccountsTable: ITable;
+  /**
+   * CloudWatch メトリクスの `Environment` dimension 値。`development` / `staging` /
+   * `production` (= `ProblemDeployBackendStack` の `environmentName` と同じ)。
+   */
+  readonly environmentName: string;
+}
+
+/**
+ * Phase 3.2 / Issue #603: ExternalId rotation age 監査 Lambda。
+ *
+ * 1 日 1 回 EventBridge Scheduler (= `rate(1 day)`) から起動。CompetitorAccounts DDB を
+ * 全件 Scan し、各行の `rotatedAt` (= 未 rotate なら `createdAt`) から経過した日数を
+ * CloudWatch メトリクス `TenkaCloud/CompetitorAccounts/RotationAge` に publish する。
+ *
+ * **明示的な SSM version cleanup Lambda は作らない**:
+ *   SSM Parameter Store は最新 100 version を auto-retain し、それ以上は自動 drop する。
+ *   TenkaCloud の rotation cadence (= 四半期に 1 回程度) では 100 version cap に到達する
+ *   現実が無いため、cleanup を Lambda で書く費用対効果は negative。代わりに「rotation
+ *   していない tenant」を operator が CloudWatch Alarm で観察できる本 Lambda を入れる
+ *   (Issue #603 の honest scope evaluation)。
+ *
+ * 必要権限:
+ *   - DDB `CompetitorAccounts` 全行 Scan
+ *   - CloudWatch `PutMetricData` (namespace を Condition で絞る)
+ */
+export class ExternalIdAuditLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: ExternalIdAuditLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/external-id-audit-handler/index.ts"),
+      handler: "handler",
+      // DDB Scan + PutMetricData 1 回。MVP 規模で 5s 以内に終わる想定だが余裕で 60s。
+      timeout: Duration.seconds(60),
+      memorySize: 256,
+      environment: {
+        COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // DDB Scan の権限 (CompetitorAccounts のみ)。Read のみ — 監査 lambda は write しない。
+    props.competitorAccountsTable.grantReadData(this.fn);
+
+    // CloudWatch PutMetricData。namespace を Condition で絞り、他 namespace に書けないようにする
+    // (= 最小権限。`cloudwatch:Namespace` Condition は AWS が PutMetricData 入力から評価する)。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudwatch:PutMetricData"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: {
+            "cloudwatch:namespace": "TenkaCloud/CompetitorAccounts",
+          },
+        },
+      }),
+    );
+
+    // 1 日 1 回起動。`Duration.days(1)` は EventBridge では `rate(1 day)` に展開される。
+    new Rule(this, "Schedule", {
+      schedule: Schedule.rate(Duration.days(1)),
+      description:
+        "TenkaCloud ExternalId rotation age audit (Phase 3.2 / Issue #603): 1 日 1 回 CompetitorAccounts を Scan し RotationAge metric を emit。",
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -152,12 +152,29 @@ app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c
   if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
     return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
   }
+  const tenantId = resolveTenantId(c);
+  const rotatedBy = resolveCognitoSub(c);
   try {
     const response = await rotateExternalIdForAccount(shared, {
-      tenantId: resolveTenantId(c),
+      tenantId,
       awsAccountId,
       nowMs: Date.now(),
     });
+    // Phase 3.2 / Issue #603: rotation 監査ログ (structured 1-line)。
+    //
+    // CloudWatch Logs Insights で `event = "competitor-accounts.rotate"` を grep し、
+    // 「いつ・どの operator (Cognito sub) が・どの (tenant, account) を rotate したか」を
+    // 後追いできる。DDB の専用 audit table を作らない代わりに log を正本にする
+    // (= ZERO 新 infra、operator 監査は infrequent なので Logs Insights で十分)。
+    console.log(
+      JSON.stringify({
+        event: "competitor-accounts.rotate",
+        tenantId,
+        awsAccountId,
+        rotatedBy,
+        rotatedAt: response.rotatedAt,
+      }),
+    );
     return c.json(response, StatusCodes.OK);
   } catch (err) {
     if (err instanceof CompetitorAccountNotFoundError) {

--- a/infrastructure/lib/problem-deploy/handlers/external-id-audit-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/external-id-audit-handler/index.ts
@@ -1,0 +1,155 @@
+import {
+  CloudWatchClient,
+  type CloudWatchClientConfig,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import type { CompetitorAccountItem } from "../competitor-accounts-handler/types.js";
+
+/**
+ * Phase 3.2 / Issue #603: ExternalId rotation 監査 Lambda。
+ *
+ * 1 日 1 回 EventBridge Scheduler から起動され、`CompetitorAccounts` table を Scan し、
+ * 各 (tenantId, awsAccountId) の **rotation age (= 「最終 rotate からの経過日数」)** を
+ * CloudWatch メトリクスとして emit する。`rotatedAt` が無い行 (= 未 rotate) は
+ * `createdAt` を基準にする (= 初期 ExternalId が発行されてから何日経ったか)。
+ *
+ * 設計判断:
+ *   - **SSM Parameter Store の 100-version cap で auto-drop が走るため、明示的な version
+ *     cleanup Lambda は不要** (= TenkaCloud 規模 = 四半期に 1 回程度の rotate cadence なら
+ *     100 version 上限に永遠に達しない)。代わりに「rotate していない tenant」を operator が
+ *     可視化できる metric を emit する。
+ *   - DDB Scan は MVP 規模 (= tenant ~50 / account ~150) で 1 page で完了する想定。
+ *     成長してきたら EventBridge bus 経由で per-tenant fan-out に置き換える。
+ *   - 1 metric = 1 (tenantId, awsAccountId) dimension。operator が CloudWatch Alarm で
+ *     "RotationAge > 90 days" を 1 ルールでカバーできる。
+ *
+ * Metric namespace / dimension:
+ *   - Namespace: `TenkaCloud/CompetitorAccounts`
+ *   - MetricName: `RotationAge`
+ *   - Dimensions: `TenantId`, `AwsAccountId`, `Environment`
+ *   - Unit: `None` (= 日数 raw)
+ */
+
+const METRIC_NAMESPACE = "TenkaCloud/CompetitorAccounts";
+const METRIC_NAME = "RotationAge";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * PutMetricData は 1 call あたり 1000 datapoint まで。MVP 規模で 1000 を超えることは
+ * 無いが、防御的に chunk 化する。
+ */
+const PUT_METRIC_BATCH_SIZE = 1000;
+
+export interface AuditDependencies {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  readonly cw: Pick<CloudWatchClient, "send">;
+  readonly tableName: string;
+  readonly environmentName: string;
+  readonly now: () => number;
+}
+
+export function computeRotationAgeDays(
+  item: Partial<CompetitorAccountItem>,
+  nowMs: number,
+): number {
+  // `rotatedAt` が無い行は `createdAt` を基準にする (= 初期発行から何日経ったか)。
+  // 両方無い場合 (= 不正データ) は 0 を返す (= 後段の alarm を誤発火させない安全側)。
+  const reference = item.rotatedAt ?? item.createdAt;
+  if (typeof reference !== "string" || reference.length === 0) return 0;
+  const parsed = Date.parse(reference);
+  if (Number.isNaN(parsed)) return 0;
+  const ageMs = nowMs - parsed;
+  if (ageMs <= 0) return 0;
+  return Math.floor(ageMs / MS_PER_DAY);
+}
+
+interface AuditDatapoint {
+  readonly tenantId: string;
+  readonly awsAccountId: string;
+  readonly ageDays: number;
+}
+
+export async function collectRotationAges(deps: AuditDependencies): Promise<AuditDatapoint[]> {
+  const nowMs = deps.now();
+  const datapoints: AuditDatapoint[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await deps.ddb.send(
+      new ScanCommand({
+        TableName: deps.tableName,
+        ProjectionExpression: "tenantId, awsAccountId, rotatedAt, createdAt",
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    const items = (out.Items ?? []) as Partial<CompetitorAccountItem>[];
+    for (const item of items) {
+      if (typeof item.tenantId !== "string" || typeof item.awsAccountId !== "string") continue;
+      datapoints.push({
+        tenantId: item.tenantId,
+        awsAccountId: item.awsAccountId,
+        ageDays: computeRotationAgeDays(item, nowMs),
+      });
+    }
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+  return datapoints;
+}
+
+export async function emitRotationAgeMetrics(
+  deps: AuditDependencies,
+  datapoints: readonly AuditDatapoint[],
+): Promise<void> {
+  if (datapoints.length === 0) return;
+  const timestamp = new Date(deps.now());
+  for (let i = 0; i < datapoints.length; i += PUT_METRIC_BATCH_SIZE) {
+    const slice = datapoints.slice(i, i + PUT_METRIC_BATCH_SIZE);
+    await deps.cw.send(
+      new PutMetricDataCommand({
+        Namespace: METRIC_NAMESPACE,
+        MetricData: slice.map((d) => ({
+          MetricName: METRIC_NAME,
+          Value: d.ageDays,
+          Unit: "None",
+          Timestamp: timestamp,
+          Dimensions: [
+            { Name: "TenantId", Value: d.tenantId },
+            { Name: "AwsAccountId", Value: d.awsAccountId },
+            { Name: "Environment", Value: deps.environmentName },
+          ],
+        })),
+      }),
+    );
+  }
+}
+
+export async function runAudit(deps: AuditDependencies): Promise<{ readonly count: number }> {
+  const datapoints = await collectRotationAges(deps);
+  await emitRotationAgeMetrics(deps, datapoints);
+  return { count: datapoints.length };
+}
+
+// Lambda module-scope client (warm invoke で reuse、cold start 軽減)。
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const cw = new CloudWatchClient({} satisfies CloudWatchClientConfig);
+
+export async function handler(): Promise<void> {
+  const deps: AuditDependencies = {
+    ddb,
+    cw,
+    tableName: getEnv("COMPETITOR_ACCOUNTS_TABLE_NAME"),
+    environmentName: getEnv("DEPLOY_ENVIRONMENT"),
+    now: () => Date.now(),
+  };
+  const result = await runAudit(deps);
+  console.log(
+    JSON.stringify({
+      event: "competitor-accounts.audit",
+      datapointCount: result.count,
+      environment: deps.environmentName,
+    }),
+  );
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
@@ -75,6 +75,59 @@ export async function getExternalId(
 }
 
 /**
+ * tenant の ExternalId を **現 version 番号付き** で取得 (Phase 3.2 / Issue #603)。
+ *
+ * `GetParameter` は `Parameter.Version` を返すので、それを caller に伝えて grace fallback
+ * (= version-1 で再取得) に使う。version は 1 起点で `Overwrite: true` 毎にインクリメント
+ * される (= SSM 仕様)。
+ *
+ * 未登録は `undefined`。`isParameterNotFound` で吸収する点は `getExternalId` と同じ。
+ */
+export async function getExternalIdWithVersion(
+  deps: ExternalIdStoreDeps,
+  tenantId: string,
+): Promise<{ readonly value: string; readonly version: number } | undefined> {
+  const name = buildExternalIdParameterName(deps.env, tenantId);
+  try {
+    const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+    const value = out.Parameter?.Value;
+    const version = out.Parameter?.Version;
+    if (typeof value !== "string" || typeof version !== "number") return undefined;
+    return { value, version };
+  } catch (err) {
+    if (isParameterNotFound(err)) return undefined;
+    throw err;
+  }
+}
+
+/**
+ * 旧 version の ExternalId を取得 (Phase 3.2 grace fallback / Issue #603)。
+ *
+ * `SSM` は `Name` に `:<version>` を付けると pinned version の値を返す。1 generation 前まで
+ * しか fallback しない (= AGENTS.md の指針: 旧値 long tail で grace を引き伸ばさない)。
+ *
+ * `version <= 0` (= 直前 version が存在しない、= rotate 未経験) なら `undefined`。
+ * `ParameterVersionNotFound` (= 100 version cap で auto-drop 済) も `undefined` 扱い。
+ */
+export async function getExternalIdByVersion(
+  deps: ExternalIdStoreDeps,
+  tenantId: string,
+  version: number,
+): Promise<string | undefined> {
+  if (!Number.isInteger(version) || version <= 0) return undefined;
+  const name = `${buildExternalIdParameterName(deps.env, tenantId)}:${version}`;
+  try {
+    const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+    return out.Parameter?.Value;
+  } catch (err) {
+    if (isParameterNotFound(err)) return undefined;
+    // ParameterVersionNotFound: SSM が 100 version cap で auto-drop 済 (= 旧 version が消えた)。
+    if (err instanceof Error && err.name === "ParameterVersionNotFound") return undefined;
+    throw err;
+  }
+}
+
+/**
  * tenant の ExternalId が無ければ生成 + Put して返す。既存なら既存値を返す (= 冪等)。
  *
  * 「Add account」を 2 回目以降に押しても ExternalId は **回さない** (ADR-002 Decision 3.1)。

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -16,6 +16,7 @@ import { DeployDeleteEventRule, DeployEventRule } from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
 import { EventApiLambda } from "./event-api-lambda";
 import { EventsTable } from "./events-table";
+import { ExternalIdAuditLambda } from "./external-id-audit-lambda";
 import { HealthCheckLambda } from "./health-check-lambda";
 import {
   DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
@@ -219,6 +220,16 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       deploymentsTable: deployments.table,
       eventsTable: events.table,
       problemsScoring: props.problemsScoring,
+    });
+
+    // Phase 3.2 / Issue #603: ExternalId rotation age 監査 Lambda。1 日 1 回起動して
+    // CompetitorAccounts table を Scan し、各 (tenantId, awsAccountId) の rotation age を
+    // CloudWatch メトリクス `TenkaCloud/CompetitorAccounts/RotationAge` に publish する。
+    // SSM Parameter Store は 100 version で auto-drop するため明示的な cleanup Lambda は
+    // 入れない (= 説明は `external-id-audit-lambda.ts` の docblock を参照)。
+    new ExternalIdAuditLambda(this, "ExternalIdAudit", {
+      competitorAccountsTable: competitorAccounts.table,
+      environmentName: props.environmentName,
     });
 
     if (props.participantPortal) {

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.1030.0",
+    "@aws-sdk/client-cloudwatch": "^3.1040.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1040.0",
     "@aws-sdk/client-dynamodb": "^3.1030.0",
     "@aws-sdk/client-eventbridge": "^3.1030.0",

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -160,11 +160,12 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(synthJson).toContain("IN_PROGRESS");
     });
 
-    it("EventBridge Rule を Create / Delete / HealthCheck schedule で 3 つ持つべき", () => {
-      // 旧 2 (Create / Delete state-machine event rules) + HealthCheck schedule rate(1 min)
-      // = 3。HealthCheck は #557 / #539 reconciler で uptime 採点とは独立に常時 instantiate
-      // される (= 旧「scoring 0 件なら skip」ガード撤去)。
-      tpl.resourceCountIs("AWS::Events::Rule", 3);
+    it("EventBridge Rule を Create / Delete / HealthCheck / ExternalIdAudit schedule で 4 つ持つべき", () => {
+      // 旧 2 (Create / Delete state-machine event rules)
+      //   + HealthCheck schedule rate(1 minute) (= #557 #539 reconciler + uptime 採点)
+      //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
+      // = 4。HealthCheck は uptime 採点とは独立に常時 instantiate される。
+      tpl.resourceCountIs("AWS::Events::Rule", 4);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -188,6 +189,13 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
         "AWS::Events::Rule",
         Match.objectLike({
           ScheduleExpression: "rate(1 minute)",
+        }),
+      );
+      // ExternalIdAudit の rate(1 day) schedule (Phase 3.2 / Issue #603)
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          ScheduleExpression: "rate(1 day)",
         }),
       );
     });
@@ -260,6 +268,42 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
     it("Output に CompetitorAccountsTableName を含むべき", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["CompetitorAccountsTableName"]));
+    });
+
+    it("Phase 3.2 / Issue #603: ExternalIdAudit Lambda が rate(1 day) で起動し PutMetricData (namespace 絞り込み) を持つべき", () => {
+      // rate(1 day) schedule は上の resourceCountIs(Rule, 4) の test でも assert 済だが、ここでは
+      // ExternalIdAudit 経路の代表 evidence (COMPETITOR_ACCOUNTS_TABLE_NAME env + namespace 絞り込み IAM) を pin する。
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs20.x",
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              COMPETITOR_ACCOUNTS_TABLE_NAME: Match.anyValue(),
+              DEPLOY_ENVIRONMENT: "development",
+            }),
+          }),
+        }),
+      );
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Effect: "Allow",
+                Action: "cloudwatch:PutMetricData",
+                Resource: "*",
+                Condition: Match.objectLike({
+                  StringEquals: Match.objectLike({
+                    "cloudwatch:namespace": "TenkaCloud/CompetitorAccounts",
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
     });
 
     it("KMS policy は StringLike + Decrypt/GenerateDataKey を持つべき (= SSM SecureString GET/PUT 双方を動かす)", () => {

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -264,6 +264,61 @@ describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id", () 
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
     expect(mocks.rotateExternalIdForAccount).not.toHaveBeenCalled();
   });
+
+  it("Phase 3.2 / Issue #603: rotate 成功時に structured audit log を 1 行出力するべき", async () => {
+    mocks.rotateExternalIdForAccount.mockResolvedValueOnce({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      rotatedAt: "2026-05-12T00:00:00.000Z",
+      externalId: "new-rotated-id",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
+        method: "POST",
+      });
+      expect(res.status).toBe(StatusCodes.OK);
+      // 「event=competitor-accounts.rotate」を含む structured 1-line log がちょうど 1 つ出ること。
+      const auditLines = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .filter((line) => line.includes("competitor-accounts.rotate"));
+      expect(auditLines).toHaveLength(1);
+      const parsed = JSON.parse(auditLines[0] as string) as Record<string, unknown>;
+      expect(parsed.event).toBe("competitor-accounts.rotate");
+      expect(parsed.awsAccountId).toBe("222222222222");
+      expect(parsed.rotatedAt).toBe("2026-05-12T00:00:00.000Z");
+      // tenantId / rotatedBy は test 環境では JWT 解決 fallback (= "unknown-tenant" / "unknown") を取る。
+      expect(typeof parsed.tenantId).toBe("string");
+      expect(typeof parsed.rotatedBy).toBe("string");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("Phase 3.2 / Issue #603: rotate 失敗時には audit log を出さないべき", async () => {
+    mocks.rotateExternalIdForAccount.mockRejectedValueOnce(
+      new mocks.CompetitorAccountNotFoundError("999999999999"),
+    );
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const res = await app.request("/admin/competitor-accounts/999999999999/rotate-external-id", {
+        method: "POST",
+      });
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
+      const auditLines = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .filter((line) => line.includes("competitor-accounts.rotate"));
+      expect(auditLines).toHaveLength(0);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });
 
 describe("DELETE /admin/competitor-accounts/:awsAccountId", () => {

--- a/infrastructure/test/problem-deploy/external-id-audit-handler.test.ts
+++ b/infrastructure/test/problem-deploy/external-id-audit-handler.test.ts
@@ -1,0 +1,214 @@
+import { PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AuditDependencies,
+  collectRotationAges,
+  computeRotationAgeDays,
+  emitRotationAgeMetrics,
+  runAudit,
+} from "../../lib/problem-deploy/handlers/external-id-audit-handler/index";
+
+// Phase 3.2 / Issue #603: ExternalId rotation 監査 Lambda のユニットテスト。
+//
+// Lambda は CompetitorAccounts DDB を Scan し、`rotatedAt` (= 未 rotate なら `createdAt`) からの
+// 経過日数を CloudWatch メトリクスに publish する。pure function (`computeRotationAgeDays`) +
+// adapter 経路 (`runAudit`) の 2 層で検証する。
+
+const NOW_MS = Date.parse("2026-05-12T00:00:00.000Z");
+
+function buildDeps(): {
+  deps: AuditDependencies;
+  ddbSend: ReturnType<typeof vi.fn>;
+  cwSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const cwSend = vi.fn();
+  const deps: AuditDependencies = {
+    ddb: { send: ddbSend } as unknown as AuditDependencies["ddb"],
+    cw: { send: cwSend } as unknown as AuditDependencies["cw"],
+    tableName: "TestCompetitorAccounts",
+    environmentName: "development",
+    now: () => NOW_MS,
+  };
+  return { deps, ddbSend, cwSend };
+}
+
+describe("computeRotationAgeDays (pure)", () => {
+  it("rotatedAt が設定されていれば rotate からの経過日数を返すべき", () => {
+    // 7 日前 = 7 days ago。
+    const sevenDaysAgo = new Date(NOW_MS - 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(
+      computeRotationAgeDays(
+        { rotatedAt: sevenDaysAgo, createdAt: "2025-01-01T00:00:00.000Z" },
+        NOW_MS,
+      ),
+    ).toBe(7);
+  });
+
+  it("rotatedAt が無ければ createdAt からの経過日数で fallback するべき (= 初期発行から何日)", () => {
+    const thirtyDaysAgo = new Date(NOW_MS - 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(computeRotationAgeDays({ createdAt: thirtyDaysAgo }, NOW_MS)).toBe(30);
+  });
+
+  it("rotatedAt も createdAt も無い行は 0 を返すべき (= alarm 誤発火を防ぐ安全側)", () => {
+    expect(computeRotationAgeDays({}, NOW_MS)).toBe(0);
+  });
+
+  it("rotatedAt が parse 不能な文字列なら 0 を返すべき", () => {
+    expect(computeRotationAgeDays({ rotatedAt: "not-a-date" }, NOW_MS)).toBe(0);
+  });
+
+  it("rotatedAt が未来 (= clock skew) なら 0 を返すべき", () => {
+    const future = new Date(NOW_MS + 24 * 60 * 60 * 1000).toISOString();
+    expect(computeRotationAgeDays({ rotatedAt: future }, NOW_MS)).toBe(0);
+  });
+});
+
+describe("collectRotationAges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("DDB Scan の Items を datapoint に変換するべき", async () => {
+    const { deps, ddbSend } = buildDeps();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          tenantId: "tenant-acme",
+          awsAccountId: "222222222222",
+          rotatedAt: new Date(NOW_MS - 14 * 24 * 60 * 60 * 1000).toISOString(),
+          createdAt: "2025-01-01T00:00:00.000Z",
+        },
+        {
+          tenantId: "tenant-beta",
+          awsAccountId: "333333333333",
+          createdAt: new Date(NOW_MS - 100 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+      ],
+    });
+
+    const datapoints = await collectRotationAges(deps);
+
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(ScanCommand);
+    expect(datapoints).toHaveLength(2);
+    expect(datapoints[0]).toEqual({
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      ageDays: 14,
+    });
+    expect(datapoints[1]).toEqual({
+      tenantId: "tenant-beta",
+      awsAccountId: "333333333333",
+      ageDays: 100,
+    });
+  });
+
+  it("LastEvaluatedKey が返れば 2 ページ目を Scan するべき", async () => {
+    const { deps, ddbSend } = buildDeps();
+    ddbSend
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: "tenant-1",
+            awsAccountId: "111111111111",
+            createdAt: new Date(NOW_MS - 10 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        ],
+        LastEvaluatedKey: { PK: "TENANT#tenant-1", SK: "ACCOUNT#111111111111" },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: "tenant-2",
+            awsAccountId: "222222222222",
+            createdAt: new Date(NOW_MS - 20 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        ],
+      });
+
+    const datapoints = await collectRotationAges(deps);
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+    expect(datapoints).toHaveLength(2);
+    const secondScan = ddbSend.mock.calls[1]?.[0] as ScanCommand;
+    expect(secondScan.input.ExclusiveStartKey).toEqual({
+      PK: "TENANT#tenant-1",
+      SK: "ACCOUNT#111111111111",
+    });
+  });
+
+  it("tenantId / awsAccountId 欠落行は skip するべき (= 不整合データの混入を吸収)", async () => {
+    const { deps, ddbSend } = buildDeps();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          tenantId: "tenant-ok",
+          awsAccountId: "222222222222",
+          createdAt: "2026-05-01T00:00:00.000Z",
+        },
+        { tenantId: "tenant-bad" /* no awsAccountId */ },
+        { awsAccountId: "333333333333" /* no tenantId */ },
+      ],
+    });
+    const datapoints = await collectRotationAges(deps);
+    expect(datapoints).toHaveLength(1);
+    expect(datapoints[0]?.tenantId).toBe("tenant-ok");
+  });
+});
+
+describe("emitRotationAgeMetrics", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PutMetricData で TenkaCloud/CompetitorAccounts namespace に書くべき", async () => {
+    const { deps, cwSend } = buildDeps();
+    cwSend.mockResolvedValueOnce({});
+    await emitRotationAgeMetrics(deps, [
+      { tenantId: "tenant-acme", awsAccountId: "222222222222", ageDays: 42 },
+    ]);
+    expect(cwSend).toHaveBeenCalledTimes(1);
+    const cmd = cwSend.mock.calls[0]?.[0] as PutMetricDataCommand;
+    expect(cmd).toBeInstanceOf(PutMetricDataCommand);
+    expect(cmd.input.Namespace).toBe("TenkaCloud/CompetitorAccounts");
+    const data = cmd.input.MetricData;
+    expect(data).toHaveLength(1);
+    const datum = data?.[0];
+    expect(datum?.MetricName).toBe("RotationAge");
+    expect(datum?.Value).toBe(42);
+    expect(datum?.Unit).toBe("None");
+    expect(datum?.Dimensions).toEqual([
+      { Name: "TenantId", Value: "tenant-acme" },
+      { Name: "AwsAccountId", Value: "222222222222" },
+      { Name: "Environment", Value: "development" },
+    ]);
+  });
+
+  it("datapoint が空なら PutMetricData を呼ばないべき", async () => {
+    const { deps, cwSend } = buildDeps();
+    await emitRotationAgeMetrics(deps, []);
+    expect(cwSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("runAudit (integration)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Scan + PutMetricData を順に呼び、件数を返すべき", async () => {
+    const { deps, ddbSend, cwSend } = buildDeps();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          tenantId: "tenant-acme",
+          awsAccountId: "222222222222",
+          rotatedAt: new Date(NOW_MS - 5 * 24 * 60 * 60 * 1000).toISOString(),
+          createdAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    cwSend.mockResolvedValueOnce({});
+
+    const out = await runAudit(deps);
+
+    expect(out.count).toBe(1);
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+    expect(cwSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/infrastructure/test/problem-deploy/external-id-store.test.ts
+++ b/infrastructure/test/problem-deploy/external-id-store.test.ts
@@ -1,0 +1,89 @@
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ExternalIdStoreDeps,
+  getExternalIdByVersion,
+  getExternalIdWithVersion,
+} from "../../lib/problem-deploy/handlers/shared/external-id-store";
+
+// Phase 3.2 / Issue #603: rotate 直後の grace fallback のための SSM Parameter Store version 系
+// helper のユニットテスト。
+
+function buildDeps(): { deps: ExternalIdStoreDeps; ssmSend: ReturnType<typeof vi.fn> } {
+  const ssmSend = vi.fn();
+  const deps: ExternalIdStoreDeps = {
+    ssm: { send: ssmSend } as unknown as ExternalIdStoreDeps["ssm"],
+    env: "development",
+  };
+  return { deps, ssmSend };
+}
+
+describe("getExternalIdWithVersion", () => {
+  it("Value + Version をペアで返すべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockResolvedValueOnce({
+      Parameter: { Value: "current-external-id", Version: 7 },
+    });
+    const out = await getExternalIdWithVersion(deps, "tenant-acme");
+    expect(out).toEqual({ value: "current-external-id", version: 7 });
+    const cmd = ssmSend.mock.calls[0]?.[0] as GetParameterCommand;
+    expect(cmd).toBeInstanceOf(GetParameterCommand);
+    expect(cmd.input.Name).toBe("/development/tenants/tenant-acme/external-id");
+    expect(cmd.input.WithDecryption).toBe(true);
+  });
+
+  it("ParameterNotFound なら undefined を返すべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
+    const out = await getExternalIdWithVersion(deps, "tenant-acme");
+    expect(out).toBeUndefined();
+  });
+
+  it("Value または Version が欠落していれば undefined を返すべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "only-value" } });
+    const out = await getExternalIdWithVersion(deps, "tenant-acme");
+    expect(out).toBeUndefined();
+  });
+});
+
+describe("getExternalIdByVersion", () => {
+  it("Name に `:<version>` を付けて旧 version を取得するべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "old-external-id" } });
+    const value = await getExternalIdByVersion(deps, "tenant-acme", 6);
+    expect(value).toBe("old-external-id");
+    const cmd = ssmSend.mock.calls[0]?.[0] as GetParameterCommand;
+    expect(cmd.input.Name).toBe("/development/tenants/tenant-acme/external-id:6");
+    expect(cmd.input.WithDecryption).toBe(true);
+  });
+
+  it("version が 0 以下なら SSM を叩かず undefined を返すべき (= rotate 未経験 / 1 generation back 不存在)", async () => {
+    const { deps, ssmSend } = buildDeps();
+    expect(await getExternalIdByVersion(deps, "tenant-acme", 0)).toBeUndefined();
+    expect(await getExternalIdByVersion(deps, "tenant-acme", -1)).toBeUndefined();
+    expect(ssmSend).not.toHaveBeenCalled();
+  });
+
+  it("ParameterNotFound なら undefined を返すべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
+    const value = await getExternalIdByVersion(deps, "tenant-acme", 6);
+    expect(value).toBeUndefined();
+  });
+
+  it("ParameterVersionNotFound (= 100 version cap で auto-drop 済) も undefined を返すべき", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockRejectedValueOnce(
+      Object.assign(new Error("version dropped"), { name: "ParameterVersionNotFound" }),
+    );
+    const value = await getExternalIdByVersion(deps, "tenant-acme", 1);
+    expect(value).toBeUndefined();
+  });
+
+  it("その他 error は再 throw するべき (= 握り潰し fallback 禁止)", async () => {
+    const { deps, ssmSend } = buildDeps();
+    ssmSend.mockRejectedValueOnce(Object.assign(new Error("throttled"), { name: "Throttling" }));
+    await expect(getExternalIdByVersion(deps, "tenant-acme", 6)).rejects.toThrow("throttled");
+  });
+});

--- a/scripts/lib/battles-common.sh
+++ b/scripts/lib/battles-common.sh
@@ -40,6 +40,12 @@ resolve_aws_region() {
 # 副作用: 上記 3 env をシェルに export する。caller の sub-shell scope 内で呼び、
 # 別アカウントへ切り替えたあと元に戻す必要があれば `AWS_*` env を退避すること。
 #
+# Phase 3.2 (Issue #603): rotate 直後の grace fallback を実装。
+# 現 ExternalId で AssumeRole が `AccessDenied` 系 error で失敗したら、SSM Parameter Store の
+# **1 つ前の version** で 1 度だけ再試行する。これは「rotate UI で更新 → 競技者が CFn stack
+# を update しきる」までの数分〜数日の grace を埋める安全網。**N-1 のみ** (= 1 generation
+# back) で打ち止め (= 旧 ExternalId で deploy がいつまでも通る状態を作らない)。
+#
 # 失敗時は非ゼロで return (caller の `set -e` で fail-fast)。
 assume_competitor_role_if_configured() {
   local role_arn="${COMPETITOR_ROLE_ARN:-}"
@@ -58,24 +64,73 @@ assume_competitor_role_if_configured() {
 
   echo "[cross-account] Assuming role: ${role_arn} (ExternalId from SSM: ${ssm_param})"
 
-  local external_id
-  external_id="$(aws ssm get-parameter --name "${ssm_param}" --with-decryption --query "Parameter.Value" --output text)"
-  if [[ -z "${external_id}" || "${external_id}" == "None" ]]; then
+  # 現 version の値 + version 番号を 1 回の API call で取り出す (= grace fallback 用)。
+  local current_json current_external_id current_version
+  current_json="$(aws ssm get-parameter --name "${ssm_param}" --with-decryption --output json 2>/dev/null)"
+  current_external_id="$(echo "${current_json}" | jq -r '.Parameter.Value // empty')"
+  current_version="$(echo "${current_json}" | jq -r '.Parameter.Version // 0')"
+  if [[ -z "${current_external_id}" || "${current_external_id}" == "None" ]]; then
     echo "error: ExternalId not found in SSM SecureString: ${ssm_param}" >&2
     return 1
   fi
 
-  # 15 分は AWS STS の minimum session duration。短くするほど token 漏洩リスクが小さい。
+  if _try_assume_role_with_external_id "${role_arn}" "${current_external_id}"; then
+    echo "[cross-account] AssumeRole succeeded (session valid for 900s)."
+    _apply_assumed_credentials
+    return 0
+  fi
+
+  # 現 version で失敗。grace fallback を 1 generation back で 1 回だけ試す。
+  local previous_version=$((current_version - 1))
+  if [[ "${previous_version}" -le 0 ]]; then
+    echo "error: AssumeRole failed with current ExternalId (version=${current_version}) and no previous version is available." >&2
+    return 1
+  fi
+
+  echo "[cross-account] AssumeRole failed with current ExternalId; trying previous version ${previous_version} (grace fallback)."
+  local previous_external_id
+  previous_external_id="$(aws ssm get-parameter --name "${ssm_param}:${previous_version}" --with-decryption --query "Parameter.Value" --output text 2>/dev/null || echo "")"
+  if [[ -z "${previous_external_id}" || "${previous_external_id}" == "None" ]]; then
+    echo "error: AssumeRole failed and previous SSM version ${previous_version} is unavailable (auto-dropped or never existed)." >&2
+    return 1
+  fi
+
+  if _try_assume_role_with_external_id "${role_arn}" "${previous_external_id}"; then
+    # grace fallback の利用は **warning level で必ず log** する (= operator が dashboard /
+    # CloudWatch Logs Insights で「rotate 後 grace を使った deploy」を観察できる)。
+    echo "[cross-account][WARN] grace_fallback_used: AssumeRole succeeded with previous ExternalId version=${previous_version} (= rotate 直後で競技者 stack 未更新の可能性)。"
+    _apply_assumed_credentials
+    return 0
+  fi
+
+  echo "error: AssumeRole failed with both current and previous (version=${previous_version}) ExternalId. Competitor stack の Update が必要、または rotate が誤って行われた可能性。" >&2
+  return 1
+}
+
+# Internal helper: 指定 ExternalId で sts:AssumeRole を 1 回試す。
+# 成功時: `__ASSUME_ROLE_JSON` シェル変数に response JSON を格納し 0 を返す。
+# 失敗時: 非ゼロを返す (= caller が次の version で retry する余地を残す)。
+_try_assume_role_with_external_id() {
+  local role_arn="$1"
+  local external_id="$2"
   local sts_json
-  sts_json="$(aws sts assume-role \
+  if ! sts_json="$(aws sts assume-role \
     --role-arn "${role_arn}" \
     --role-session-name "tenkacloud-deploy-$(date +%s)" \
     --external-id "${external_id}" \
-    --duration-seconds 900)"
+    --duration-seconds 900 \
+    --output json 2>&1)"; then
+    return 1
+  fi
+  __ASSUME_ROLE_JSON="${sts_json}"
+  return 0
+}
 
-  AWS_ACCESS_KEY_ID="$(echo "${sts_json}" | jq -r '.Credentials.AccessKeyId')"
-  AWS_SECRET_ACCESS_KEY="$(echo "${sts_json}" | jq -r '.Credentials.SecretAccessKey')"
-  AWS_SESSION_TOKEN="$(echo "${sts_json}" | jq -r '.Credentials.SessionToken')"
+# Internal helper: `__ASSUME_ROLE_JSON` から Credentials を AWS_* env に export する。
+_apply_assumed_credentials() {
+  AWS_ACCESS_KEY_ID="$(echo "${__ASSUME_ROLE_JSON}" | jq -r '.Credentials.AccessKeyId')"
+  AWS_SECRET_ACCESS_KEY="$(echo "${__ASSUME_ROLE_JSON}" | jq -r '.Credentials.SecretAccessKey')"
+  AWS_SESSION_TOKEN="$(echo "${__ASSUME_ROLE_JSON}" | jq -r '.Credentials.SessionToken')"
   export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
   # CodeBuild Project が `AWS_DEFAULT_REGION` を inject していないと target account の
   # region 解決が空になる事故があるので、明示的に DEPLOY_REGION (= event detail.region) を反映。
@@ -83,5 +138,4 @@ assume_competitor_role_if_configured() {
     export AWS_REGION="${DEPLOY_REGION}"
     export AWS_DEFAULT_REGION="${DEPLOY_REGION}"
   fi
-  echo "[cross-account] AssumeRole succeeded (session valid for 900s)."
 }


### PR DESCRIPTION
## Summary

Cross-account federation Phase 3.2 (= Issue #603 follow-up to PR-602 Phase 3.1)。
rotate 後の deploy 失敗を防ぐ grace fallback + rotation age 可視化を追加。

- **Worker grace fallback** (`scripts/lib/battles-common.sh`): SSM 現 version で
  AssumeRole 失敗時、SSM `:N-1` で 1 回だけ retry (= 旧 ExternalId fallback)。
  N-1 のみ (= 1 generation back) で打ち止め。利用時 WARN log。
- **`ExternalIdAuditLambda` (新規)**: rate(1 day) で CompetitorAccounts DDB を
  Scan し `TenkaCloud/CompetitorAccounts/RotationAge` メトリクスを emit。
  operator が CloudWatch Alarm で「90 日超未 rotate な tenant」を観察できる。
- **Audit log**: rotate handler に structured 1-line log
  (`event=competitor-accounts.rotate`) を追加。Logs Insights で query 可能。

## 設計判断 (honest skip)

**明示的な SSM version cleanup Lambda は作らなかった**。
SSM Parameter Store は最新 100 version を auto-retain して以上は自動 drop する。
TenkaCloud は手動 rotate が中心 (四半期に 1 回未満) で、100 version cap には
現実的に到達しない (= 25 年 / tenant)。明示的な cleanup を Lambda で書く費用対効果は
negative。代わりに同じ rate(1 day) schedule で **rotation age を可視化** する Lambda に
振り替えた (= 「rotate していない tenant」を operator が見える方が現実的に有用)。

専用 audit DDB table も作らない。操作監査は infrequent なので CloudWatch Logs Insights で十分。

## Regression 分析

- **既存 same-account 経路 (= COMPETITOR_ROLE_ARN 空)**: 早期 return で挙動 unchanged
- **既存 cross-account 経路 (= grace fallback 不要 / 現 version で AssumeRole 成功)**:
  1 回目 AssumeRole 成功 → 以前と同じ env export + region 反映
- **rotate API**: 成功時に `console.log` が 1 行増えるだけ、response body unchanged
- **EventBridge Rule 数**: 3 → 4 (HealthCheck rate(1 min) + ExternalIdAudit rate(1 day))
- **新規 Lambda の cold start 失敗**: best-effort、未 emit でも既存 deploy / rotate UI は無影響

## 物理影響

- **CREATE** `AWS::Lambda::Function` ExternalIdAuditLambda
- **CREATE** `AWS::Lambda::Permission` (EventBridge → audit Lambda)
- **CREATE** `AWS::Events::Rule` rate(1 day) schedule
- **CREATE** `AWS::IAM::Role` + `AWS::IAM::Policy` for audit Lambda
  (DDB Scan read + `cloudwatch:PutMetricData` with namespace=TenkaCloud/CompetitorAccounts condition)
- **UPDATE** `scripts/lib/battles-common.sh` (= source.zip 経由で CodeBuild が新 logic を実行)
- **NO-OP** 既存 stack の他リソース (CompetitorAccounts DDB / 既存 Lambda /
  既存 EventBridge Rule) は変更なし

## Test plan

- [x] `bun run --filter '@TenkaCloud/infrastructure' test` (575 passed)
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [x] `make lint`
- [x] `make check-http-status`
- [x] `make before-commit` (= lint + typecheck + test + validate-problems + check-http-status)
- [ ] 手動: rotate UI で新 ExternalId 発行 → 旧 ExternalId の deploy job で WARN
  「grace_fallback_used」が log に出ること (deploy 環境必須、本 PR では未実施)
- [ ] 手動: 1 日後 CloudWatch メトリクス `TenkaCloud/CompetitorAccounts/RotationAge`
  に datapoint が出ること (deploy 環境必須、本 PR では未実施)

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated daily audit of ExternalId rotation age with CloudWatch metrics
  * Structured audit logging for competitor account rotation events
  * Grace fallback mechanism for cross-account role assumption when ExternalId rotates

* **Tests**
  * Comprehensive test coverage for audit operations, rotation logging, and ExternalId management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->