### PR TITLE
feat(#572): Phase 1 problem files for microservice migration battle

### DIFF
--- a/problems/battles/microservice-migration-battle/README.md
+++ b/problems/battles/microservice-migration-battle/README.md
@@ -1,0 +1,165 @@
+# Microservice Migration Battle
+
+> **Status: Phase 1 (draft)** — Phase 1 では EC2 上のモノリス問題ファイル一式のみを出荷する。スコアエンジン / 登録 UI / EC2 劣化 cron / フェーズ進行ロジックは Phase 2 / Phase 3 で追加される (= issue #572 のフォローアップ)。
+
+EC2 1 台に同居する 3 サービス (`users` / `orders` / `catalog`) のモノリスを、競技時間 90〜120 分の間に **Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner** の 3 種類の異なるホスティングへマイクロサービスとして分割していく Battle 問題。
+
+## 競技概要
+
+- カテゴリ: Battle (リアルタイム対戦)
+- 難易度: 4 / 5
+- 想定時間: 90 〜 120 分
+- 学習目的:
+  - モノリス → マイクロサービスへの段階的移行 (strangler fig パターン) を体験する
+  - Lambda function / managed container / orchestrated container のスペクトラムを実機で比較する
+  - スコア劣化制約下で「どのサービスから分離すべきか」の優先順位を判断する
+  - コード内に意図的に仕込まれた遅延コードパス (`?legacy=true`) を読み解いて除去する
+
+## アーキテクチャ
+
+### 初期状態 (deploy 直後 / Phase 1 で実装する範囲)
+
+```text
+┌─────────────── EC2 (t3.small, Amazon Linux 2023) ───────────────┐
+│                                                                  │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                       │
+│  │  users   │  │  orders  │  │ catalog  │  ← docker compose      │
+│  │  :3001   │  │  :3002   │  │  :3003   │     で同居             │
+│  └──────────┘  └──────────┘  └──────────┘                       │
+│         ▲             ▲             ▲                            │
+│         └─────────────┴─────────────┘                            │
+│                       │                                          │
+│  ┌────────────────────────────────────────────┐                  │
+│  │  nginx :80  →  /users/*   /orders/*        │                  │
+│  │             →  /catalog/*                  │                  │
+│  └────────────────────────────────────────────┘                  │
+└──────────────────────────────────────────────────────────────────┘
+                       ▲
+                       │ Score Engine が 1 分毎 polling
+                       │ (Phase 2 で実装)
+                       │ /users/score, /orders/score, /catalog/score
+```
+
+### 想定終形 (= 競技者がフル分割した姿)
+
+```text
+                ┌────────── Lambda + API Gateway ───────────┐
+                │  /users   → handler (Hono on Lambda)        │
+                └─────────────────────────────────────────────┘
+
+                ┌────────── ECS Fargate Service ─────────────┐
+                │  /orders  → ALB → Fargate Task (Container)  │
+                └─────────────────────────────────────────────┘
+
+                ┌────────── AWS App Runner ──────────────────┐
+                │  /catalog → App Runner Service (Container)  │
+                └─────────────────────────────────────────────┘
+```
+
+> どのサービスをどのホスティングに割り当てるかは競技者の自由。3! = 6 通りの組み合わせがあり、各チームの戦略になる。
+
+## 各サービスの仕様
+
+3 サービスは同型 (= Hono on Node.js 20、ports と service 名だけ違う)。
+
+| service   | port | platform 自己申告 (`/meta`) | ハンドラ           |
+| --------- | ---- | --------------------------- | ------------------ |
+| `users`   | 3001 | `ec2`                       | `/meta`, `/score`, `/healthz` |
+| `orders`  | 3002 | `ec2`                       | 同上               |
+| `catalog` | 3003 | `ec2`                       | 同上               |
+
+### エンドポイント
+
+各サービス共通の HTTP routes。
+
+- `GET /meta` → `{ "service": "<name>", "platform": "ec2" | "lambda" | "ecs" | "apprunner", "version": "1.0.0" }`
+- `GET /score` → `{ "score": <int> }` (fast path、~5ms)
+- `GET /score?legacy=true` → 同じ shape を返すが **2 秒の意図的遅延** が入る (= 競技終盤ギミック、Phase 2 で score engine が切替対象にする)
+- `GET /healthz` → `{ "ok": true, "service": "<name>" }`
+
+### ローカル開発
+
+```bash
+cd problems/battles/microservice-migration-battle/services
+docker compose up --build
+curl http://localhost/users/score
+curl http://localhost/orders/score
+curl http://localhost/catalog/score
+```
+
+## 採点ルール (Phase 2 で実装する score engine の仕様)
+
+| 状態                                       | 1 check あたり | 1 時間換算 |
+| ------------------------------------------ | -------------- | ---------- |
+| 未登録 / 200 以外 / timeout                | -100           | -6,000     |
+| EC2 上のレスポンス (劣化前)                | +100           | +6,000     |
+| EC2 上のレスポンス (劣化後)                | +10            | +600       |
+| Lambda + API GW にホスティング済           | +1,000         | +60,000    |
+| ECS Fargate にホスティング済               | +1,000         | +60,000    |
+| App Runner にホスティング済                | +1,000         | +60,000    |
+| 3 サービス全て分離完了                     | +5,000 (一括ボーナス、1 回限り) |          |
+| 遅延 endpoint (応答 > 1.5 秒) を返した     | +10            | +600       |
+
+ホスティング判定は `GET /meta` の `platform` フィールドを自己申告として読む (Phase 1 設計判断)。
+
+## フェーズタイムライン
+
+| 時刻       | フェーズ           | 内容                                                                  |
+| ---------- | ------------------ | --------------------------------------------------------------------- |
+| 0 分       | 開始               | EC2 deploy 完了 / 3 サービス起動 / `BaseUrl` 払い出し                 |
+| 60 分後    | EC2 劣化           | `tc qdisc` で latency 注入 (Phase 2 実装) → EC2 加点が +100 → +10 に減 |
+| 90 分後    | legacy switch      | Score Engine が `/score` → `/score?legacy=true` に切替 → 遅延発覚      |
+| 90〜120 分 | 仕込み除去 + 再 deploy | コードを読んで `legacy` 分岐を消し、各ホスティングに再 push          |
+
+## ヒント: 各ホスティングへの最小デプロイ
+
+> いずれも本リポジトリの `services/<name>/Dockerfile` をそのまま使える。
+
+### Lambda + API Gateway
+
+1. Hono を `hono/aws-lambda` adapter で wrap (handler を export)
+2. `npm install -g esbuild` で bundle、または container image で `npx tsx` 起動
+3. `aws lambda create-function --package-type Image --code ImageUri=<ECR URI>` で関数化
+4. API Gateway HTTP API → integration target に Lambda function を指定
+5. 環境変数 `PLATFORM=lambda` を設定
+
+### ECS Fargate
+
+1. `docker build -t <ECR URI>:latest services/orders` → ECR push
+2. Task Definition (CPU 256 / Memory 512、container port 3002、`PLATFORM=ecs`)
+3. ECS Cluster + Service (1 task)、ALB Target Group (port 3002) に登録
+4. ALB の Listener Rule で `/orders/*` を Target Group に転送
+
+### App Runner
+
+1. `docker build -t <ECR URI>:latest services/catalog` → ECR push
+2. App Runner Service 作成 (Source = ECR、port 3003、`PLATFORM=apprunner`)
+3. 払い出された App Runner URL をそのまま endpoint として登録
+
+> 各 IaC 最小例は Phase 2 で `services/iac-examples/` 配下に追加予定。
+
+## 競技後の振り返り (= なぜこの 3 種を並行体験するのか)
+
+| 観点         | Lambda + API GW         | ECS Fargate                       | App Runner                          |
+| ------------ | ----------------------- | --------------------------------- | ----------------------------------- |
+| 単位         | 関数 (event-driven)     | コンテナ + クラスタ管理           | コンテナ (managed)                  |
+| スケール     | per-request, cold start | per-task (Auto Scaling Group)     | per-request, auto                   |
+| 設定の重さ   | 軽 (HTTP API 1 発)      | 重 (VPC / ALB / Service / TaskDef) | 中 (URL 1 発、VPC 不要)             |
+| 主な学び     | event-driven, 非同期    | orchestration, 永続化, network    | managed container, source deploy    |
+
+Lambda (関数) ↔ App Runner (managed container) ↔ ECS (orchestrated container) の 3 段階のスペクトラムを 1 競技で体験できるよう設計してある。
+
+## Phase 1 で出荷しないもの (= 後続 PR)
+
+- スコアエンジン (1 分間隔 polling Lambda + EventBridge Scheduler)
+- 登録エンドポイントの DDB テーブル
+- フェーズ進行管理 (degradationMinutes / legacySwitchMinutes)
+- EC2 劣化 cron (`tc qdisc`)
+- participant-portal の endpoint 登録 UI (3 slot)
+- Battle Portal のフェーズタイムライン card
+
+これらは Phase 2 / Phase 3 の follow-up issue で実装する。
+
+## 既知の制限
+
+- 遅延コードパス (`?legacy=true` で 2 秒 sleep) は本リポジトリ内で公開されているため、ADR-008 (= 問題実装の private repo 化、issue #574) が ship するまで仕掛けは事前に読まれる可能性がある。

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "microservice-migration-battle",
+  "name": "Microservice Migration Battle",
+  "category": "Battle",
+  "status": "draft",
+  "difficulty": 4,
+  "estimatedDuration": "90〜120 分",
+  "shortDescription": "EC2 1 台に同居する 3 サービス (users / orders / catalog) を Lambda + API Gateway / ECS Fargate / App Runner の 3 種ホスティングに分割するレース。",
+  "description": "EC2 1 台に同居する 3 サービス (users / orders / catalog) のモノリスを、競技時間内に Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner の 3 種類の異なるホスティングへマイクロサービスとして分割していく Battle。\n\nDeploy 完了後、各チームには EC2 上で動くモノリスのベース URL が払い出される。3 つのスコア対象エンドポイント (`/users/score` / `/orders/score` / `/catalog/score`) を運営側スコアエンジンが 1 分毎に polling し、レスポンスに応じてポイントを加減算する。\n\n## 学習目的\n\n- モノリスからマイクロサービスへの段階的移行 (strangler fig パターン) を実体験する\n- Lambda function / managed container (App Runner) / orchestrated container (ECS Fargate) の 3 段階を比較する\n- どのサービスから分離すべきかをスコア最大化の観点で判断する\n- コード内に意図的に仕込まれた「遅延コードパス」を読み解いて取り除く\n\n## アーキテクチャ (Phase 1 = この PR の deploy 範囲)\n\n```\n┌─────────────── EC2 (t3.small) ───────────────┐\n│  nginx :80  →  /users/* → users:3001           │\n│              →  /orders/* → orders:3002        │\n│              →  /catalog/* → catalog:3003      │\n│         docker compose で 3 サービス + nginx │\n└──────────────────────────────────────────────┘\n         ↑ Score Engine が 1 分毎 polling\n```\n\n各サービスは Node.js 20 + Hono の最小 HTTP サーバーで、`GET /meta` (= platform 自己申告) と `GET /score` を公開する。Dockerfile は Lambda / App Runner / ECS Fargate のいずれにもそのまま乗せ替え可能。\n\n## 採点ルール (Phase 2 で score engine を実装)\n\n| 状態                                       | 1 check あたり |\n| ------------------------------------------ | -------------- |\n| 未登録 / 200 以外 / timeout                | -100           |\n| EC2 上のレスポンス (劣化前)                | +100           |\n| EC2 上のレスポンス (劣化後 = 開始 60 分後) | +10            |\n| Lambda + API GW にホスティング済           | +1,000         |\n| ECS Fargate にホスティング済               | +1,000         |\n| App Runner にホスティング済                | +1,000         |\n| 3 サービス全て分離完了                     | +5,000 (1 回)  |\n\n## フェーズタイムライン\n\n- 0 分: deploy 完了 → 競技開始\n- 60 分: EC2 劣化 (`tc qdisc` 注入予定 / Phase 2)\n- 90 分: スコアエンジンが `/score` → `/score?legacy=true` へ切替 → 各サービスコードに仕込まれた遅延コードパスを取り除いて再デプロイする必要あり\n\n## 制約 / 既知の制限\n\n- 遅延コードパス (`?legacy=true` で 2 秒 sleep) は本リポジトリ内で公開されているため、ADR-008 (= 問題実装の private repo 化) が ship するまで仕掛けは事前に読まれる可能性がある。Phase 2 ship までに ADR-008 を解決する。\n- Phase 1 では score engine / endpoint 登録 UI / EC2 劣化 cron / フェーズ進行 logic は未実装 (= Phase 2 / Phase 3 で追加)。",
+  "tags": ["microservices", "migration", "lambda", "ecs", "apprunner", "ec2", "docker"],
+  "exposedPorts": [{ "port": 80, "name": "nginx reverse proxy (users / orders / catalog)" }],
+  "learningGoals": [
+    "モノリスから 3 ホスティング (Lambda / ECS Fargate / App Runner) へのマイクロサービス分割を体験する",
+    "サーバレス / マネージドコンテナ / オーケストレーションのトレードオフを実機で比較する",
+    "EC2 劣化と遅延コードパスというスコア制約下で、移行優先順位を判断する",
+    "意図的に仕込まれた遅延コードパスを読み解いて取り除く"
+  ],
+  "cfnTemplate": "template.yaml",
+  "cfnParameters": {},
+  "scoring": {
+    "kind": "uptime",
+    "endpoints": [
+      { "outputKey": "BaseUrl", "path": "/users/score", "expectStatus": [200] },
+      { "outputKey": "BaseUrl", "path": "/orders/score", "expectStatus": [200] },
+      { "outputKey": "BaseUrl", "path": "/catalog/score", "expectStatus": [200] }
+    ],
+    "pointsPerSuccess": 100
+  }
+}

--- a/problems/battles/microservice-migration-battle/services/catalog/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/catalog/Dockerfile
@@ -1,0 +1,19 @@
+# catalog service — Microservice Migration Battle (Phase 1)
+# users / orders と同型。詳細は users/Dockerfile のヘッダを参照。
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=optional --no-audit --no-fund
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3003
+COPY --from=deps /app/node_modules ./node_modules
+COPY tsconfig.json ./
+COPY src ./src
+COPY package.json ./
+
+EXPOSE 3003
+CMD ["npx", "tsx", "src/index.ts"]

--- a/problems/battles/microservice-migration-battle/services/catalog/package.json
+++ b/problems/battles/microservice-migration-battle/services/catalog/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tenkacloud-microservice-migration-battle-catalog",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "catalog service for Microservice Migration Battle. Hono on Node.js 20. Trivially copy-deployable to Lambda + API Gateway / ECS Fargate / App Runner.",
+  "scripts": {
+    "start": "node --import=tsx/esm src/index.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "1.13.2",
+    "hono": "4.6.9"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.6.3",
+    "@types/node": "20.16.11"
+  }
+}

--- a/problems/battles/microservice-migration-battle/services/catalog/src/index.ts
+++ b/problems/battles/microservice-migration-battle/services/catalog/src/index.ts
@@ -1,0 +1,52 @@
+// catalog service — Microservice Migration Battle (Phase 1)
+//
+// 構造は users / orders と同型。詳細は users/src/index.ts のヘッダを参照。
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+
+const SERVICE_NAME = "catalog" as const;
+const PORT = Number.parseInt(process.env.PORT ?? "3003", 10);
+const PLATFORM = (process.env.PLATFORM ?? "ec2") as "ec2" | "lambda" | "ecs" | "apprunner";
+const VERSION = "1.0.0";
+
+const app = new Hono();
+
+app.get("/meta", (c) =>
+  c.json({
+    service: SERVICE_NAME,
+    platform: PLATFORM,
+    version: VERSION,
+  }),
+);
+
+app.get("/score", async (c) => {
+  // LEGACY_PATH: 本来不要 / Phase 2 で score engine が ?legacy=true に切替予定。
+  // 競技者はこの分岐に気づいたら削除して再デプロイする (= 競技の終盤ギミック)。
+  const legacy = c.req.query("legacy") === "true";
+  if (legacy) {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    return c.json({ score: computeLegacyScore() });
+  }
+  return c.json({ score: computeScore() });
+});
+
+app.get("/healthz", (c) => c.json({ ok: true, service: SERVICE_NAME }));
+
+function computeScore(): number {
+  return 99;
+}
+
+function computeLegacyScore(): number {
+  return 99;
+}
+
+serve(
+  {
+    fetch: app.fetch,
+    port: PORT,
+  },
+  (info) => {
+    console.log(`[${SERVICE_NAME}] listening on :${info.port} (platform=${PLATFORM})`);
+  },
+);

--- a/problems/battles/microservice-migration-battle/services/catalog/tsconfig.json
+++ b/problems/battles/microservice-migration-battle/services/catalog/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/problems/battles/microservice-migration-battle/services/docker-compose.yml
+++ b/problems/battles/microservice-migration-battle/services/docker-compose.yml
@@ -1,0 +1,55 @@
+# Microservice Migration Battle (Phase 1) — EC2 上で動かす docker compose 構成
+#
+# 3 Node.js + Hono サービス + nginx reverse proxy。
+# 競技者は EC2 にこのまま deploy されたモノリスを、競技中に Lambda / ECS Fargate /
+# App Runner に分割していく (= 各サービスのコードはそのまま流用可能)。
+#
+# Score Engine (Phase 2) は nginx 配下の `/{service}/score` を 1 分毎 polling する。
+# `NAME_PREFIX` は CFn template 側の UserData から .env 経由で注入される。
+
+services:
+  users:
+    build:
+      context: ./users
+    container_name: users
+    environment:
+      - PORT=3001
+      - PLATFORM=ec2
+    expose:
+      - "3001"
+    restart: unless-stopped
+
+  orders:
+    build:
+      context: ./orders
+    container_name: orders
+    environment:
+      - PORT=3002
+      - PLATFORM=ec2
+    expose:
+      - "3002"
+    restart: unless-stopped
+
+  catalog:
+    build:
+      context: ./catalog
+    container_name: catalog
+    environment:
+      - PORT=3003
+      - PLATFORM=ec2
+    expose:
+      - "3003"
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: nginx
+    depends_on:
+      - users
+      - orders
+      - catalog
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped

--- a/problems/battles/microservice-migration-battle/services/nginx.conf
+++ b/problems/battles/microservice-migration-battle/services/nginx.conf
@@ -1,0 +1,43 @@
+# Microservice Migration Battle (Phase 1) — nginx reverse proxy
+#
+# EC2 上 nginx (port 80) が 3 サービスを単一 URL の配下にまとめる。
+# 競技者の移行後は、competitor が DNS / ALB / API GW Custom Domain で
+# `/users/*` だけを Lambda、`/orders/*` を ECS、`/catalog/*` を App Runner
+# に切り替える、というシナリオを想定。
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # Score Engine が叩く path:
+    #   GET /users/score   → users:3001/score
+    #   GET /orders/score  → orders:3002/score
+    #   GET /catalog/score → catalog:3003/score
+
+    location /users/ {
+        proxy_pass http://users:3001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /orders/ {
+        proxy_pass http://orders:3002/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /catalog/ {
+        proxy_pass http://catalog:3003/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # 単純な root health (= EC2 instance liveness の確認用)
+    location = / {
+        default_type text/plain;
+        return 200 "tenkacloud microservice-migration-battle ec2 monolith\n";
+    }
+}

--- a/problems/battles/microservice-migration-battle/services/orders/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/orders/Dockerfile
@@ -1,0 +1,19 @@
+# orders service — Microservice Migration Battle (Phase 1)
+# users / catalog と同型。詳細は users/Dockerfile のヘッダを参照。
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=optional --no-audit --no-fund
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3002
+COPY --from=deps /app/node_modules ./node_modules
+COPY tsconfig.json ./
+COPY src ./src
+COPY package.json ./
+
+EXPOSE 3002
+CMD ["npx", "tsx", "src/index.ts"]

--- a/problems/battles/microservice-migration-battle/services/orders/package.json
+++ b/problems/battles/microservice-migration-battle/services/orders/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tenkacloud-microservice-migration-battle-orders",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "orders service for Microservice Migration Battle. Hono on Node.js 20. Trivially copy-deployable to Lambda + API Gateway / ECS Fargate / App Runner.",
+  "scripts": {
+    "start": "node --import=tsx/esm src/index.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "1.13.2",
+    "hono": "4.6.9"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.6.3",
+    "@types/node": "20.16.11"
+  }
+}

--- a/problems/battles/microservice-migration-battle/services/orders/src/index.ts
+++ b/problems/battles/microservice-migration-battle/services/orders/src/index.ts
@@ -1,0 +1,52 @@
+// orders service — Microservice Migration Battle (Phase 1)
+//
+// 構造は users / catalog と同型。詳細は users/src/index.ts のヘッダを参照。
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+
+const SERVICE_NAME = "orders" as const;
+const PORT = Number.parseInt(process.env.PORT ?? "3002", 10);
+const PLATFORM = (process.env.PLATFORM ?? "ec2") as "ec2" | "lambda" | "ecs" | "apprunner";
+const VERSION = "1.0.0";
+
+const app = new Hono();
+
+app.get("/meta", (c) =>
+  c.json({
+    service: SERVICE_NAME,
+    platform: PLATFORM,
+    version: VERSION,
+  }),
+);
+
+app.get("/score", async (c) => {
+  // LEGACY_PATH: 本来不要 / Phase 2 で score engine が ?legacy=true に切替予定。
+  // 競技者はこの分岐に気づいたら削除して再デプロイする (= 競技の終盤ギミック)。
+  const legacy = c.req.query("legacy") === "true";
+  if (legacy) {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    return c.json({ score: computeLegacyScore() });
+  }
+  return c.json({ score: computeScore() });
+});
+
+app.get("/healthz", (c) => c.json({ ok: true, service: SERVICE_NAME }));
+
+function computeScore(): number {
+  return 7;
+}
+
+function computeLegacyScore(): number {
+  return 7;
+}
+
+serve(
+  {
+    fetch: app.fetch,
+    port: PORT,
+  },
+  (info) => {
+    console.log(`[${SERVICE_NAME}] listening on :${info.port} (platform=${PLATFORM})`);
+  },
+);

--- a/problems/battles/microservice-migration-battle/services/orders/tsconfig.json
+++ b/problems/battles/microservice-migration-battle/services/orders/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/problems/battles/microservice-migration-battle/services/users/Dockerfile
+++ b/problems/battles/microservice-migration-battle/services/users/Dockerfile
@@ -1,0 +1,28 @@
+# users service — Microservice Migration Battle (Phase 1)
+#
+# Node.js 20 Alpine ベース。3 サービス共通の構成。
+# Lambda + API Gateway / ECS Fargate / App Runner のいずれにも乗せられる:
+#   - Lambda: hono/aws-lambda adapter を追加 + entrypoint を handler に変える
+#   - ECS Fargate / App Runner: 本 Dockerfile を ECR push → そのまま起動
+#
+# 競技中の再デプロイ高速化のため、依存と src を別レイヤに分けている。
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+# 依存だけ先に解決 (lockfile を後で添付する手も検討中)
+RUN npm install --omit=optional --no-audit --no-fund
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3001
+COPY --from=deps /app/node_modules ./node_modules
+COPY tsconfig.json ./
+COPY src ./src
+COPY package.json ./
+
+EXPOSE 3001
+# tsx で TypeScript を直接実行 (ビルド工程不要)。
+# Lambda 移行時は `node` + transpile 済み JS に切り替えるか、esbuild bundle を使う。
+CMD ["npx", "tsx", "src/index.ts"]

--- a/problems/battles/microservice-migration-battle/services/users/package.json
+++ b/problems/battles/microservice-migration-battle/services/users/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tenkacloud-microservice-migration-battle-users",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "users service for Microservice Migration Battle. Hono on Node.js 20. Trivially copy-deployable to Lambda + API Gateway / ECS Fargate / App Runner.",
+  "scripts": {
+    "start": "node --import=tsx/esm src/index.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "1.13.2",
+    "hono": "4.6.9"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.6.3",
+    "@types/node": "20.16.11"
+  }
+}

--- a/problems/battles/microservice-migration-battle/services/users/src/index.ts
+++ b/problems/battles/microservice-migration-battle/services/users/src/index.ts
@@ -1,0 +1,72 @@
+// users service — Microservice Migration Battle (Phase 1)
+//
+// Hono on Node.js 20. 3 サービス (users / orders / catalog) のうち users 担当。
+// Phase 1 では nginx reverse proxy 配下 (/users/*) で listen し、Score Engine が
+// `GET /users/score` を 1 分毎 polling する。
+//
+// このコードは Lambda + API Gateway / ECS Fargate / App Runner のいずれにも
+// **そのまま** 乗せ替え可能になっている (= Hono 公式 adapter で互換性確保)。
+//   - Lambda: `hono/aws-lambda` adapter で handler 化
+//   - ECS Fargate: 本 Dockerfile + ALB Target Group (port 3001)
+//   - App Runner: 本 Dockerfile を ECR push → App Runner Service 作成
+//
+// 競技中に競技者が読むのはこの index.ts と /catalog, /orders 配下の同型コード。
+// 同じ shape なので一気に 3 サービス分の Lambda function or App Runner service を
+// 作れるようにしておく (= 学習負荷を下げる意図)。
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+
+const SERVICE_NAME = "users" as const;
+const PORT = Number.parseInt(process.env.PORT ?? "3001", 10);
+
+// platform 自己申告。Phase 2 score engine が `/meta` を読んで platform を判定する。
+// 移行先 (Lambda / ECS / App Runner) では起動時 env で上書きすること。
+//   例: Lambda function の env に PLATFORM=lambda、App Runner なら PLATFORM=apprunner
+const PLATFORM = (process.env.PLATFORM ?? "ec2") as "ec2" | "lambda" | "ecs" | "apprunner";
+const VERSION = "1.0.0";
+
+const app = new Hono();
+
+app.get("/meta", (c) =>
+  c.json({
+    service: SERVICE_NAME,
+    platform: PLATFORM,
+    version: VERSION,
+  }),
+);
+
+app.get("/score", async (c) => {
+  // LEGACY_PATH: 本来不要 / Phase 2 で score engine が ?legacy=true に切替予定。
+  // 競技者はこの分岐に気づいたら削除して再デプロイする (= 競技の終盤ギミック)。
+  const legacy = c.req.query("legacy") === "true";
+  if (legacy) {
+    // 意図的な 2 秒遅延。SLA 違反を誘発するための仕掛け。
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    return c.json({ score: computeLegacyScore() });
+  }
+  return c.json({ score: computeScore() });
+});
+
+app.get("/healthz", (c) => c.json({ ok: true, service: SERVICE_NAME }));
+
+function computeScore(): number {
+  // 5 ms 程度で済む軽量計算。Phase 1 では deterministic な値を返す。
+  return 42;
+}
+
+function computeLegacyScore(): number {
+  // legacy 互換用 "重い" 計算。実体は同じ値を返すが、上の await sleep で遅延が出る。
+  return 42;
+}
+
+serve(
+  {
+    fetch: app.fetch,
+    port: PORT,
+  },
+  (info) => {
+    // 起動時ログを stdout に出して docker logs / CloudWatch Logs から確認できるようにする
+    console.log(`[${SERVICE_NAME}] listening on :${info.port} (platform=${PLATFORM})`);
+  },
+);

--- a/problems/battles/microservice-migration-battle/services/users/tsconfig.json
+++ b/problems/battles/microservice-migration-battle/services/users/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/problems/battles/microservice-migration-battle/template.yaml
+++ b/problems/battles/microservice-migration-battle/template.yaml
@@ -1,0 +1,218 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud problem — microservice-migration-battle (Phase 1).
+  Single EC2 (Amazon Linux 2023, t3.small) running 3 Node.js + Hono services
+  (users / orders / catalog) behind an nginx reverse proxy on port 80. Competitors
+  split this monolith into Lambda + API Gateway / ECS Fargate / App Runner
+  during a timed Battle. Phase 1 ships only the EC2 monolith; Phase 2 adds the
+  score engine + EC2 degradation + legacy switch, and Phase 3 adds the
+  endpoint registration UI.
+
+  同一 (Account, Region) に複数チームの problem stack が共存できるよう、
+  リソース名は全て ${NamePrefix} (= "tc-{problemSlug}-{teamSlug}", UI の
+  buildStackPrefix と一致) を冠する。
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    ConstraintDescription: >
+      `tc-{problemSlug}-{teamSlug}` 形式 (英小文字 / 数字 / ハイフン)。
+      application-admin-console の DeployForm が生成する prefix を渡す。
+    Description: >
+      すべてのリソース名に冠する共通 prefix。同一 Account / Region に複数チームの
+      スタックが共存しても衝突しないようにする。
+  AllowedCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+    Description: nginx (port 80) を許可する CIDR。
+  InstanceType:
+    Type: String
+    Default: t3.small
+    AllowedValues:
+      - t3.small
+      - t3.medium
+    Description: EC2 インスタンスタイプ。3 Node.js プロセス + nginx 同居なので t3.small 推奨。
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
+    Description: SSM-backed Amazon Linux 2023 AMI (auto-resolved)。
+  RepoUrl:
+    Type: String
+    Default: https://github.com/susumutomita/TenkaCloud.git
+    Description: 問題ソース取得元 (公開 GitHub リポジトリ前提)。
+  RepoRef:
+    Type: String
+    Default: main
+    Description: チェックアウトする branch / tag / commit。
+
+Resources:
+  # ----- VPC + Networking -----
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.99.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.99.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet"
+
+  Igw:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-igw"
+
+  IgwAttach:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref Igw
+
+  Rt:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rt"
+
+  RtRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IgwAttach
+    Properties:
+      RouteTableId: !Ref Rt
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref Igw
+
+  RtAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref Rt
+      SubnetId: !Ref PublicSubnet
+
+  # ----- Security Group -----
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: !Sub "${NamePrefix} microservice-migration-battle access"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref AllowedCidr
+          Description: nginx reverse proxy (users / orders / catalog)
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-sg"
+
+  # ----- IAM (SSM Session Manager only) -----
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-instance-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub "${NamePrefix}-instance-profile"
+      Roles:
+        - !Ref InstanceRole
+
+  # ----- EC2 -----
+  Ec2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref Sg
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2"
+        - Key: TenkaCloud:Problem
+          Value: microservice-migration-battle
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+          dnf update -y
+          dnf install -y docker git
+          systemctl enable --now docker
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64" \
+            -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+          mkdir -p /opt/tenkacloud
+          cd /opt/tenkacloud
+          # branch / tag / commit いずれも指せるよう shallow fetch + checkout 形式
+          git clone "${RepoUrl}" repo
+          cd repo
+          git fetch origin "${RepoRef}" || git fetch --all
+          git checkout "${RepoRef}" || git checkout FETCH_HEAD
+
+          PROBLEM_ROOT=/opt/tenkacloud/repo/problems/battles/microservice-migration-battle
+          cd "$PROBLEM_ROOT/services"
+
+          cat > .env <<ENVEOF
+          NAME_PREFIX=${NamePrefix}
+          REGION=${AWS::Region}
+          ENVEOF
+
+          docker compose up -d --build
+
+Outputs:
+  BaseUrl:
+    Description: 参加者向け nginx reverse proxy URL。Score Engine が `/users/score` / `/orders/score` / `/catalog/score` を probe する。
+    Value: !Sub "http://${Ec2.PublicDnsName}"
+  UsersScoreUrl:
+    Description: users service の初期エンドポイント (EC2 上)。
+    Value: !Sub "http://${Ec2.PublicDnsName}/users/score"
+  OrdersScoreUrl:
+    Description: orders service の初期エンドポイント (EC2 上)。
+    Value: !Sub "http://${Ec2.PublicDnsName}/orders/score"
+  CatalogScoreUrl:
+    Description: catalog service の初期エンドポイント (EC2 上)。
+    Value: !Sub "http://${Ec2.PublicDnsName}/catalog/score"
+  InstanceId:
+    Description: EC2 インスタンス ID (運営者が SSM Session Manager から接続する際に使う)。
+    Value: !Ref Ec2
+  SsmStartSessionCommand:
+    Description: 運営者がインスタンスへ Session Manager で接続するコマンド。
+    Value: !Sub "aws ssm start-session --target ${Ec2}"
+  NamePrefix:
+    Description: 本スタックが利用した共通リソース prefix。
+    Value: !Ref NamePrefix


### PR DESCRIPTION
## Summary

EC2 1 台に同居する 3 サービス (`users` / `orders` / `catalog`) を **Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner** に分割していく Battle 問題を新設する。Phase 1 では **問題ファイル一式 (metadata / CFn template / 3 Hono サービス + nginx + docker compose / README)** のみを ship する。Score engine / endpoint 登録 UI / EC2 劣化 cron / legacy switch logic は Phase 2 / Phase 3 follow-up issue で実装する。

- 新 problem: `problems/battles/microservice-migration-battle/`
- カテゴリ: Battle / 難易度: 4 / 想定 90〜120 分 / status: draft
- スコアリング: `kind: "uptime"`、`endpoints` で `BaseUrl + /{service}/score` を 3 個宣言 (= 既存 HealthCheck Lambda がそのまま読める形)

## 設計判断 (issue #572 Open Questions の Phase 1 デフォルト)

| # | Open Question | Phase 1 default |
|---|---|---|
| 1 | Hosting platform cross-validation | `/meta` 自己申告のみ (Phase 2 で X-Forwarded-By 拡張可) |
| 2 | 3 番目のホスティング | **App Runner** (issue 推奨どおり、Lambda ↔ App Runner ↔ ECS の 3 段階) |
| 3 | ベース言語 | **Node.js + TypeScript + Hono** (repo stack に揃える、3 ホスティングすべてに乗る) |
| 4 | EC2 劣化実装 | **Phase 2 で `tc qdisc` cron 注入** (Phase 1 では code path 未実装) |
| 5 | Platform breakdown viz | Phase 3 で議論 |
| 6 | Bonus 構造 | **lump-sum +5000** (issue デフォルト) |
| 7 | EC2 上の legacy switch | **yes** (全 platform 共通の `/score?legacy=true`、シンプル) |

## 変更点

- `metadata.json` — `category: "Battle"` / `difficulty: 4` / `estimatedDuration: "90〜120 分"` / `scoring.kind: "uptime"` / `endpoints` 3 個 (BaseUrl + /users/score, /orders/score, /catalog/score)
- `template.yaml` — `security-battle-royale` パターン踏襲。EC2 t3.small + 専用 VPC/Subnet/IGW + SG (port 80 only) + SSM-managed AMI、UserData が `git clone` → `docker compose up -d --build`
- `services/{users,orders,catalog}/` — Hono on Node.js 20 同型コード (port: 3001/3002/3003)。
  - `GET /meta` → platform 自己申告 (`ec2` | `lambda` | `ecs` | `apprunner`)
  - `GET /score` → 高速パス (~5ms)
  - `GET /score?legacy=true` → **2 秒の意図的遅延** (Phase 2 ギミック、コメントで明示)
  - `GET /healthz`
- `services/docker-compose.yml` + `services/nginx.conf` — nginx :80 が `/users/* /orders/* /catalog/*` を内部 service にプロキシ
- `README.md` — 競技概要 / アーキテクチャ図 (初期 + 想定終形) / 仕様 / 採点ルール / フェーズタイムライン / Lambda / ECS / App Runner それぞれへのデプロイ最小手順 / 振り返り

## 物理影響

- **CREATE**: `problems/battles/microservice-migration-battle/` 1 ディレクトリ (17 ファイル)
- **NO-OP**: AWS リソース全般 (= 問題ファイルのみ、既存 infrastructure / problem-deploy / scoring engine / participant-portal の挙動には触れない)

## Regression 分析

- `make validate-problems` の SCHEMA.json 検査が新 metadata.json をカバー (通過確認済)
- 既存 Battle (`security-battle-royale` / `hello-world-battle`) の metadata / CFn / scoring engine には触れていない
- 新規問題は `status: "draft"` のため、Portal の catalog の `status==="ready"` filter で表示されない前提
- HealthCheck Lambda (`infrastructure/lib/problem-deploy/handlers/health-check-handler/`) の `outputs[e.outputKey] + path` 読み出しと metadata.json の `endpoints` 形式が一致することを確認

## 既知の制限 / 正直に記す注意点

- **遅延コードパス (`?legacy=true` で 2 秒 sleep) が public repo 内で可読** — ADR-008 (#574 = 問題実装の private repo 化) が ship するまで仕掛けが事前に読まれる可能性がある。Phase 2 ship までに ADR-008 を解決する前提で進める。
- **EC2 deploy 時の `git clone` 元 branch は `main`** — Phase 1 でこの PR が merge される前に deploy を試すと、UserData の `git checkout main` で本問題ディレクトリが見つからない (= merge 後にのみ deploy 可)。
- **Lambda / ECS / App Runner 用の IaC sample は同梱していない** — 競技者が自前で書くか、Phase 2 で `services/iac-examples/` 配下に同梱する予定。
- **competitor-bootstrap.yaml の IAM 範囲** — 現状の EC2 + VPC + SG + IAM Role 作成は `security-battle-royale` で実績がある (= 同じ範囲内で動く前提)。実機 deploy は merge 後に検証する。

## Follow-up issues

- Phase 2 (score engine + endpoint registration DDB + phase progression) — 別 issue で起票
- Phase 3 (frontend endpoint registration UI + phase countdown timeline) — 別 issue で起票

## Test plan

- [x] `make validate-problems` (SCHEMA.json 検査) が通る
- [x] `make lint` (markdownlint + textlint + biome) が通る
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck` が通る
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` (575 件) が通る
- [x] `make check-http-status` が通る
- [ ] (merge 後 / Phase 2) 競技者アカウントで `aws cloudformation deploy` を実機で動かして EC2 ↑ → docker compose ↑ → 3 サービス ↑ → `curl http://<ec2>/users/score` が 200 を返すまでを通す

Relates #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Microservice Migration Battle" challenge featuring three deployable microservices (users, orders, catalog)
  * Supports multiple deployment platforms including EC2, Lambda, ECS, and App Runner
  * Includes Docker Compose configuration for local development and testing
  * Provided AWS CloudFormation template for automated cloud deployment with configurable settings and endpoint monitoring

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->