### PR TITLE
feat(#606): Phase 2 microservice-migration score engine

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -300,6 +300,8 @@ const tenantTemplateStack = new TenantTemplateStack(app, `tenkacloud-tenant-temp
   deployApiLambda: problemDeployBackendStack.deployApiLambda,
   eventApiLambda: problemDeployBackendStack.eventApiLambda,
   competitorAccountsApiLambda: problemDeployBackendStack.competitorAccountsApiLambda,
+  microserviceMigrationRegistrationApiLambda:
+    problemDeployBackendStack.microserviceMigrationRegistrationApiLambda,
   participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
 });
 

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/index.ts
@@ -1,0 +1,377 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { writeScoreEvent } from "../shared/score-event.js";
+import { fetchPlatform, probeScore } from "./probe.js";
+import {
+  computePhase,
+  isFullyMigrated,
+  MICROSERVICE_MIGRATION_FULL_BONUS_POINTS,
+  MICROSERVICE_MIGRATION_PROBLEM_ID,
+  type Platform,
+  type ProbeResult,
+  resolveScorePath,
+  scoreFromProbe,
+} from "./scoring.js";
+
+/**
+ * Microservice Migration Battle (Phase 2 / Issue #606) の 1 min polling Lambda。
+ *
+ * 1. `MicroserviceMigrationScoresTable` を Scan → 登録済 (slot, registeredUrl) 行を取得
+ * 2. tenant 別に group 化、`Deployments` table の GSI1 (TENANT#) を引いて当該 problemId
+ *    deployment の jobId / createdAt / teamId / eventId / expiresAt を取得
+ * 3. createdAt + env (degradationMinutes / legacySwitchMinutes) で phase を計算
+ * 4. 各 slot 並列に `/meta` + `/score` を probe → scoring.ts で +/- points を決定
+ * 5. ScoreEvent (= Deployments table の sparse EVENT 行) に source=microservice-migration で書き込み
+ * 6. slot row の observation 列 (platform / lastProbeAt / lastResult / lastPoints) を upsert
+ * 7. 3 slot 全 non-ec2 になったら +5000 lump-sum (source=microservice-migration-bonus) を
+ *    1 度だけ発行し、`fullMigrationBonusAwarded=true` を立てる
+ *
+ * **`fetch` 直接呼び出しの exception**: 本 Lambda は EventBridge tick で起動する outbound
+ * probe で tenant 認可フローに関与しない。`health-check-handler` と同 pattern (= scoring の
+ * ための outbound HTTP)。実 fetch は `./probe.ts` に閉じ込めているので tests から差し替え可能。
+ */
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+const scoresTableName = (): string => getEnv("MICROSERVICE_MIGRATION_SCORES_TABLE_NAME");
+const deploymentsTableName = (): string => getEnv("DEPLOYMENTS_TABLE_NAME");
+
+const DEGRADATION_MINUTES_DEFAULT = 60;
+const LEGACY_SWITCH_MINUTES_DEFAULT = 90;
+
+function readMinutesEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+interface SlotRow {
+  PK: string;
+  SK: string;
+  tenantId: string;
+  slot: string;
+  registeredUrl: string;
+  platform?: string;
+  fullMigrationBonusAwarded?: boolean;
+}
+
+interface TenantDeployment {
+  jobId: string;
+  problemId: string;
+  teamId?: string;
+  eventId?: string;
+  expiresAt: number;
+  createdAt: string;
+  eventStartsAt?: string;
+  eventEndsAt?: string;
+}
+
+/**
+ * 1 tenant の microservice-migration-battle deployment 行を引く。複数 deployment があれば
+ * 一番新しい (createdAt) を採用。無ければ undefined。
+ *
+ * deployments table の GSI1 (PK=TENANT#) で Query → in-memory で problemId filter する。
+ * tenant あたり deployments は MVP-1 規模で << 10 件、Filter する Read コストは無視可能。
+ */
+async function findTenantDeployment(tenantId: string): Promise<TenantDeployment | undefined> {
+  const out = await ddb.send(
+    new QueryCommand({
+      TableName: deploymentsTableName(),
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      FilterExpression: "problemId = :pid AND #status = :complete",
+      ExpressionAttributeNames: { "#status": "status" },
+      ExpressionAttributeValues: {
+        ":pk": `TENANT#${tenantId}`,
+        ":pid": MICROSERVICE_MIGRATION_PROBLEM_ID,
+        ":complete": "COMPLETE",
+      },
+    }),
+  );
+  const rows = (out.Items ?? []) as Partial<DeploymentItem>[];
+  if (rows.length === 0) return undefined;
+  // 一番新しい createdAt を採用
+  rows.sort((a, b) => String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")));
+  const top = rows[0];
+  if (!top?.jobId || !top.problemId || !top.createdAt) return undefined;
+  return {
+    jobId: top.jobId,
+    problemId: top.problemId,
+    teamId: top.teamId,
+    eventId: top.eventId,
+    expiresAt: Number(top.expiresAt ?? 0),
+    createdAt: top.createdAt,
+    eventStartsAt: top.eventStartsAt,
+    eventEndsAt: top.eventEndsAt,
+  };
+}
+
+/**
+ * Slot row の observation 列を更新する (= polling Lambda 専用 attributes)。
+ *
+ * - platform / lastProbeAt / lastResult / lastPoints / lastResponseTimeMs を上書き
+ * - registeredUrl / registeredAt 等は触らない (= 登録 API 専管)
+ */
+async function updateSlotObservation(
+  pk: string,
+  sk: string,
+  observation: {
+    platform: string;
+    lastProbeAt: string;
+    lastResult: "ok" | "fail" | "timeout";
+    lastPoints: number;
+    lastResponseTimeMs: number;
+  },
+): Promise<void> {
+  await ddb.send(
+    new UpdateCommand({
+      TableName: scoresTableName(),
+      Key: { PK: pk, SK: sk },
+      UpdateExpression: [
+        "SET platform = :platform,",
+        "lastProbeAt = :now,",
+        "lastResult = :result,",
+        "lastPoints = :points,",
+        "lastResponseTimeMs = :rt",
+      ].join(" "),
+      ExpressionAttributeValues: {
+        ":platform": observation.platform,
+        ":now": observation.lastProbeAt,
+        ":result": observation.lastResult,
+        ":points": observation.lastPoints,
+        ":rt": observation.lastResponseTimeMs,
+      },
+    }),
+  );
+}
+
+/**
+ * `fullMigrationBonusAwarded=true` を立てる条件付き Update。既に true ならスキップ。
+ * race (= 同 invocation 内で他の slot row が先に true 化) を防ぐためにこの row だけ立てる
+ * 単純設計: 「users 行の attribute」を tenant 単位の sentinel として使う。
+ */
+async function tryAwardFullMigrationBonus(usersPk: string, usersSk: string): Promise<boolean> {
+  try {
+    await ddb.send(
+      new UpdateCommand({
+        TableName: scoresTableName(),
+        Key: { PK: usersPk, SK: usersSk },
+        UpdateExpression: "SET fullMigrationBonusAwarded = :t",
+        ConditionExpression:
+          "attribute_not_exists(fullMigrationBonusAwarded) OR fullMigrationBonusAwarded = :f",
+        ExpressionAttributeValues: { ":t": true, ":f": false },
+      }),
+    );
+    return true;
+  } catch (err) {
+    const name = (err as { name?: string })?.name ?? "";
+    if (name === "ConditionalCheckFailedException") return false;
+    throw err;
+  }
+}
+
+/**
+ * 1 slot 分の probe + scoring を実行し、ScoreEvent + slot row 更新を行う。
+ *
+ * 戻り値: 観測 platform (= 全分離判定で集約するため)。probe 失敗時は undefined。
+ */
+async function processSlot(
+  slotRow: SlotRow,
+  deployment: TenantDeployment,
+  nowIso: string,
+  degradationMinutes: number,
+  legacySwitchMinutes: number,
+): Promise<Platform | undefined> {
+  const phase = computePhase(deployment.createdAt, nowIso, degradationMinutes, legacySwitchMinutes);
+  const platform = await fetchPlatform(slotRow.registeredUrl);
+  const scoreObs = await probeScore(slotRow.registeredUrl, resolveScorePath(phase.legacy));
+  const probe: ProbeResult = {
+    ok: scoreObs.ok,
+    status: scoreObs.status,
+    responseTimeMs: scoreObs.responseTimeMs,
+    platform,
+    reason: scoreObs.reason,
+  };
+  const points = scoreFromProbe(probe, phase);
+
+  const lastResult: "ok" | "fail" | "timeout" =
+    probe.reason === "timeout" ? "timeout" : probe.ok ? "ok" : "fail";
+
+  await updateSlotObservation(slotRow.PK, slotRow.SK, {
+    platform: platform ?? "unknown",
+    lastProbeAt: nowIso,
+    lastResult,
+    lastPoints: points,
+    lastResponseTimeMs: probe.responseTimeMs,
+  });
+
+  // ScoreEvent (= Deployments table の sparse EVENT 行) に書き込み。best-effort。
+  try {
+    await writeScoreEvent(
+      ddb,
+      deploymentsTableName(),
+      {
+        jobId: deployment.jobId,
+        problemId: deployment.problemId,
+        teamId: deployment.teamId,
+        eventId: deployment.eventId,
+        expiresAt: deployment.expiresAt,
+      },
+      "microservice-migration",
+      points,
+      nowIso,
+    );
+  } catch (err) {
+    console.warn("[microservice-migration-poller] writeScoreEvent failed", {
+      jobId: deployment.jobId,
+      slot: slotRow.slot,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return platform;
+}
+
+/**
+ * 1 tenant の全 slot を並列に処理。3 slot 全 non-ec2 になり、かつ bonus 未発行なら
+ * +5000 lump-sum を Deployments table の ScoreEvent + slot row sentinel で記録する。
+ *
+ * `users` slot row を bonus sentinel に使う (= 任意の slot で良いが固定する)。`users`
+ * 行が無い場合は bonus を発行できない (= 3 slot 揃ってない場合と同義なので問題なし)。
+ */
+async function processTenant(
+  tenantId: string,
+  slotRows: SlotRow[],
+  nowIso: string,
+  degradationMinutes: number,
+  legacySwitchMinutes: number,
+): Promise<void> {
+  const deployment = await findTenantDeployment(tenantId);
+  if (!deployment) {
+    console.warn("[microservice-migration-poller] no deployment found for tenant", { tenantId });
+    return;
+  }
+
+  // 各 slot を並列に処理。1 slot の失敗は他の slot を巻き込まない。
+  const platforms = await Promise.all(
+    slotRows.map(async (row) => {
+      try {
+        return await processSlot(row, deployment, nowIso, degradationMinutes, legacySwitchMinutes);
+      } catch (err) {
+        console.warn("[microservice-migration-poller] processSlot failed", {
+          tenantId,
+          slot: row.slot,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return undefined;
+      }
+    }),
+  );
+
+  // 全 3 slot 揃って non-ec2 達成かつ未発行のとき bonus を 1 度発行する。
+  // sentinel は users slot row に立てる (= tenant 単位で 1 行に集約)。
+  const usersRow = slotRows.find((r) => r.slot === "users");
+  if (!usersRow) return;
+  if (usersRow.fullMigrationBonusAwarded === true) return;
+  if (!isFullyMigrated(platforms)) return;
+
+  const awarded = await tryAwardFullMigrationBonus(usersRow.PK, usersRow.SK);
+  if (!awarded) return; // race: 他の tick が先に発行済 → skip
+  try {
+    await writeScoreEvent(
+      ddb,
+      deploymentsTableName(),
+      {
+        jobId: deployment.jobId,
+        problemId: deployment.problemId,
+        teamId: deployment.teamId,
+        eventId: deployment.eventId,
+        expiresAt: deployment.expiresAt,
+      },
+      "microservice-migration-bonus",
+      MICROSERVICE_MIGRATION_FULL_BONUS_POINTS,
+      nowIso,
+    );
+  } catch (err) {
+    console.warn("[microservice-migration-poller] bonus writeScoreEvent failed", {
+      tenantId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Scan MicroserviceMigrationScoresTable で登録済 (slot, registeredUrl) 行を tenant 別に集約。
+ * MVP-1 規模 (3 slot × ~10 tenant = 30 行) は 1 Scan で十分。
+ */
+async function listSlotRowsGroupedByTenant(): Promise<Map<string, SlotRow[]>> {
+  const grouped = new Map<string, SlotRow[]>();
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: scoresTableName(),
+        FilterExpression: "attribute_exists(registeredUrl)",
+        Limit: 200,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    const items = (out.Items ?? []) as Partial<SlotRow>[];
+    for (const item of items) {
+      if (!item.PK || !item.SK || !item.tenantId || !item.slot || !item.registeredUrl) continue;
+      const row: SlotRow = {
+        PK: item.PK,
+        SK: item.SK,
+        tenantId: item.tenantId,
+        slot: item.slot,
+        registeredUrl: item.registeredUrl,
+        platform: typeof item.platform === "string" ? item.platform : undefined,
+        fullMigrationBonusAwarded: item.fullMigrationBonusAwarded === true,
+      };
+      const list = grouped.get(item.tenantId) ?? [];
+      list.push(row);
+      grouped.set(item.tenantId, list);
+    }
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+  return grouped;
+}
+
+export async function handler(): Promise<void> {
+  const nowIso = new Date().toISOString();
+  const degradationMinutes = readMinutesEnv(
+    "MICROSERVICE_MIGRATION_DEGRADATION_MINUTES",
+    DEGRADATION_MINUTES_DEFAULT,
+  );
+  const legacySwitchMinutes = readMinutesEnv(
+    "MICROSERVICE_MIGRATION_LEGACY_SWITCH_MINUTES",
+    LEGACY_SWITCH_MINUTES_DEFAULT,
+  );
+
+  const grouped = await listSlotRowsGroupedByTenant();
+  if (grouped.size === 0) return;
+
+  await Promise.all(
+    Array.from(grouped.entries()).map(async ([tenantId, rows]) => {
+      try {
+        await processTenant(tenantId, rows, nowIso, degradationMinutes, legacySwitchMinutes);
+      } catch (err) {
+        console.warn("[microservice-migration-poller] processTenant failed", {
+          tenantId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }),
+  );
+}
+
+// Pure helpers for tests
+export { findTenantDeployment, listSlotRowsGroupedByTenant, processSlot, processTenant };

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/probe.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/probe.ts
@@ -1,0 +1,99 @@
+import type { Platform, ProbeResult } from "./scoring.js";
+
+/**
+ * Microservice Migration Battle (Phase 2) polling Lambda の outbound HTTP probe。
+ *
+ * **`fetch` 直接呼び出しの exception**:
+ *   harness の `handler-must-not-call-fetch` rule は `lib/handlers/` 内での tenant API
+ *   handler が外部依存を埋めるのを防ぐためのもの。本 Lambda は EventBridge から
+ *   1 min tick で起動する outbound probe で、対象は競技者が登録した URL であり、
+ *   tenant 認可フローには関与しない。同じ理由で `health-check-handler` も `fetch` を
+ *   呼ぶことが許されている (= EventBridge tick 経路の outbound probe)。
+ *
+ * 本ファイルを probe.ts として handler ディレクトリ直下に置き、scoring (pure) と
+ * 分けることで、テスト時の `vi.mock("./probe")` で fetch 自体をスタブできるよう
+ * にしている。
+ */
+
+const META_TIMEOUT_MS = 4_000;
+const SCORE_TIMEOUT_MS = 8_000;
+
+const KNOWN_PLATFORMS = new Set<Platform>(["ec2", "lambda", "ecs", "apprunner"]);
+
+function joinUrl(base: string, relPath: string): string {
+  if (!relPath) return base;
+  try {
+    return new URL(relPath).toString();
+  } catch {
+    return new URL(relPath, base.endsWith("/") ? base : `${base}/`).toString();
+  }
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    return await fetch(url, { method: "GET", signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * `GET <url>/meta` を叩いて platform を取り出す (= 競技者の自己申告)。
+ * 値が KNOWN_PLATFORMS に無いなら `unknown` に倒す (= 不正値 / typo を安全側に倒す)。
+ * 失敗 (timeout / non-2xx / parse 失敗) なら undefined を返す。
+ */
+export async function fetchPlatform(baseUrl: string): Promise<Platform | undefined> {
+  try {
+    const res = await fetchWithTimeout(joinUrl(baseUrl, "/meta"), META_TIMEOUT_MS);
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as unknown;
+    if (!body || typeof body !== "object") return undefined;
+    const raw = (body as { platform?: unknown }).platform;
+    if (typeof raw !== "string") return undefined;
+    return KNOWN_PLATFORMS.has(raw as Platform) ? (raw as Platform) : "unknown";
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `GET <url>/score(?legacy=true)` を叩いて status + 応答時間を観測する。
+ *
+ * - timeout: status=0 / reason=timeout
+ * - network error: status=0 / reason=network
+ * - non-2xx: ok=false / reason=non-2xx
+ * - 2xx: ok=true
+ *
+ * platform は別 RPC (`fetchPlatform`) の結果を呼び出し側で merge する想定。
+ */
+export async function probeScore(
+  baseUrl: string,
+  scorePath: "/score" | "/score?legacy=true",
+): Promise<{
+  ok: boolean;
+  status: number;
+  responseTimeMs: number;
+  reason?: ProbeResult["reason"];
+}> {
+  const url = joinUrl(baseUrl, scorePath);
+  const startedAt = Date.now();
+  try {
+    const res = await fetchWithTimeout(url, SCORE_TIMEOUT_MS);
+    const elapsed = Date.now() - startedAt;
+    if (res.status >= 200 && res.status < 300) {
+      return { ok: true, status: res.status, responseTimeMs: elapsed };
+    }
+    return { ok: false, status: res.status, responseTimeMs: elapsed, reason: "non-2xx" };
+  } catch (err) {
+    const elapsed = Date.now() - startedAt;
+    const name = (err as { name?: string })?.name ?? "";
+    if (name === "AbortError") {
+      return { ok: false, status: 0, responseTimeMs: elapsed, reason: "timeout" };
+    }
+    return { ok: false, status: 0, responseTimeMs: elapsed, reason: "network" };
+  }
+}
+
+export { joinUrl };

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/scoring.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-poller-handler/scoring.ts
@@ -1,0 +1,118 @@
+/**
+ * Microservice Migration Battle (Phase 2 / #606) のスコア計算ロジック (pure functions)。
+ *
+ * - probe 結果 + 経過時間 → 1 tick あたり加減算ポイントを算出
+ * - polling Lambda が用いる時間ベース「フェーズ判定」(= EC2 劣化 / legacy switch)
+ *
+ * pure / IO 無しに保ち、`scoring.test.ts` で単体テストできるようにする。
+ */
+
+/**
+ * /meta が自己申告する platform。`ec2` だけが「未移行」とみなす。
+ * 未知 (= /meta レスポンスに platform 属性が無い / 想定外の値) も移行未完了扱いとする
+ * (= 競技者が誤って `unknown` を返した場合に最低スコアにならないよう、EC2 と同扱い)。
+ */
+export type Platform = "ec2" | "lambda" | "ecs" | "apprunner" | "unknown";
+
+export interface ProbeResult {
+  readonly ok: boolean;
+  /** HTTP status code (timeout 時は 0)。 */
+  readonly status: number;
+  /** /score の応答時間 (ms)。timeout 時は 0。 */
+  readonly responseTimeMs: number;
+  /** /meta から取得した platform。失敗時は undefined。 */
+  readonly platform: Platform | undefined;
+  /** 失敗理由 ("timeout" / "network" / "non-2xx" / undefined)。 */
+  readonly reason?: "timeout" | "network" | "non-2xx";
+}
+
+export interface MicroserviceMigrationPhase {
+  /** deploy 時刻から `degradationMinutes` 経過したか (= EC2 score が +100 → +10 に落ちる)。 */
+  readonly degraded: boolean;
+  /** deploy 時刻から `legacySwitchMinutes` 経過したか (= polling が `/score?legacy=true` を叩く)。 */
+  readonly legacy: boolean;
+}
+
+const LATENCY_PENALTY_MS = 1_500;
+const LATENCY_PENALTY_POINTS = -10;
+
+const POINTS = {
+  failure: -100,
+  ec2Pre: 100,
+  ec2Post: 10,
+  migrated: 1_000,
+} as const;
+
+/**
+ * deploy createdAt + 現在時刻から degraded / legacy フラグを判定する。
+ *
+ * createdAt が未定義 (= 旧 deployment / 取得失敗) なら pre-degradation 扱い
+ * (= 採点境界の安全側、deploy 直後と同等)。
+ */
+export function computePhase(
+  createdAt: string | undefined,
+  nowIso: string,
+  degradationMinutes: number,
+  legacySwitchMinutes: number,
+): MicroserviceMigrationPhase {
+  if (!createdAt) return { degraded: false, legacy: false };
+  const createdMs = Date.parse(createdAt);
+  const nowMs = Date.parse(nowIso);
+  if (Number.isNaN(createdMs) || Number.isNaN(nowMs)) {
+    return { degraded: false, legacy: false };
+  }
+  const elapsedMin = (nowMs - createdMs) / 60_000;
+  return {
+    degraded: elapsedMin >= degradationMinutes,
+    legacy: elapsedMin >= legacySwitchMinutes,
+  };
+}
+
+export function resolveScorePath(legacy: boolean): "/score" | "/score?legacy=true" {
+  return legacy ? "/score?legacy=true" : "/score";
+}
+
+/**
+ * 1 probe の結果から 1 tick あたりの加減算ポイントを返す。
+ *
+ * - 失敗 (timeout / network / non-2xx): -100 で確定 (= 応答時間 penalty も適用しない)
+ * - 成功時: platform 別の base score
+ *   - ec2 (劣化前 phase): +100
+ *   - ec2 (劣化後 phase): +10
+ *   - lambda / ecs / apprunner: +1000
+ *   - unknown / undefined: ec2 と同じ扱い (= 移行未完了視点)
+ * - 応答時間 > 1500ms ペナルティ: 上記 base から -10
+ */
+export function scoreFromProbe(probe: ProbeResult, phase: MicroserviceMigrationPhase): number {
+  if (!probe.ok) return POINTS.failure;
+
+  const base = resolveBaseScore(probe.platform, phase);
+  const penalty = probe.responseTimeMs > LATENCY_PENALTY_MS ? LATENCY_PENALTY_POINTS : 0;
+  return base + penalty;
+}
+
+function resolveBaseScore(
+  platform: Platform | undefined,
+  phase: MicroserviceMigrationPhase,
+): number {
+  if (platform === "lambda" || platform === "ecs" || platform === "apprunner") {
+    return POINTS.migrated;
+  }
+  // ec2 / unknown / undefined は EC2 と同じ扱い (= 移行未完了)。
+  return phase.degraded ? POINTS.ec2Post : POINTS.ec2Pre;
+}
+
+/**
+ * 3 slot 全てが non-ec2 platform なら "全分離達成" — Phase 2 の +5000 lump-sum bonus 対象。
+ *
+ * `unknown` は EC2 と同じく「未移行」扱い (= bonus 対象外、安全側)。
+ */
+export function isFullyMigrated(platforms: ReadonlyArray<Platform | undefined>): boolean {
+  if (platforms.length < 3) return false;
+  return platforms.every((p) => p === "lambda" || p === "ecs" || p === "apprunner");
+}
+
+export const MICROSERVICE_MIGRATION_FULL_BONUS_POINTS = 5_000;
+export const MICROSERVICE_MIGRATION_PROBLEM_ID = "microservice-migration-battle";
+export const MICROSERVICE_MIGRATION_SLOTS = ["users", "orders", "catalog"] as const;
+export type MicroserviceMigrationSlot = (typeof MICROSERVICE_MIGRATION_SLOTS)[number];

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/index.ts
@@ -1,0 +1,95 @@
+import { Hono } from "hono";
+import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
+import { handle } from "hono/aws-lambda";
+import { cors } from "hono/cors";
+import { StatusCodes } from "http-status-codes";
+import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
+import { buildMicroserviceMigrationRegistrationSharedResources } from "./shared.js";
+import { listEndpoints, registerEndpoint } from "./store.js";
+import { RegisterEndpointRequestSchema } from "./types.js";
+
+/**
+ * Microservice Migration Battle (Phase 2 / Issue #606) の endpoint 登録 API Lambda。
+ *
+ * routes (tenant API + Cognito JWT authorizer 経由 — `/admin/competitor-accounts` と同 pattern):
+ *   POST /problems/microservice-migration-battle/endpoints   — 登録 (slot / url を upsert)
+ *   GET  /problems/microservice-migration-battle/endpoints   — 一覧 (tenant 内の現状を返す)
+ *
+ * 認可: tenant API GW + Cognito JWT authorizer。tenantId は JWT `custom:tenantId` claim から
+ * `resolveTenantId(c)` で抽出する (= request body の tenantId は信頼しない / IAM 越境攻撃の防止)。
+ */
+
+const shared = buildMicroserviceMigrationRegistrationSharedResources();
+
+const app = new Hono();
+
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    maxAge: 600,
+  }),
+);
+
+app.onError((err, c) => {
+  const message = err instanceof Error ? err.message : "unknown error";
+  console.error("[microservice-migration-registration] uncaught handler error", {
+    path: c.req.path,
+    message,
+  });
+  return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+app.get("/problems/microservice-migration-battle/endpoints/healthz", (c) => c.json({ ok: true }));
+
+app.post("/problems/microservice-migration-battle/endpoints", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "request body must be JSON" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = RegisterEndpointRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  try {
+    const response = await registerEndpoint(
+      shared,
+      {
+        tenantId: resolveTenantId(c),
+        nowMs: Date.now(),
+        registeredBy: resolveCognitoSub(c),
+      },
+      parsed.data,
+    );
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[microservice-migration-registration] register failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/problems/microservice-migration-battle/endpoints", async (c) => {
+  try {
+    const response = await listEndpoints(shared, resolveTenantId(c));
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[microservice-migration-registration] list failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+export const handler = handle(app) as (
+  event: LambdaEvent,
+  context: LambdaContext,
+) => Promise<unknown>;
+
+export { app };

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/shared.ts
@@ -1,0 +1,23 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+
+/**
+ * Microservice Migration Registration handler の module-scope shared resources。
+ *
+ * - `tableName` = `MicroserviceMigrationScoresTable` の DDB 物理名 (env 注入)
+ *
+ * Lambda は warm invoke で 1 つの SDK client を使い回す (cold start 軽減)。
+ * 別 SDK (S3 / SSM 等) は登録 API では不要なので持たない (= IAM blast-radius 縮小)。
+ */
+export interface MicroserviceMigrationRegistrationSharedResources {
+  readonly tableName: string;
+  readonly ddb: DynamoDBDocumentClient;
+}
+
+export function buildMicroserviceMigrationRegistrationSharedResources(): MicroserviceMigrationRegistrationSharedResources {
+  return {
+    tableName: getEnv("MICROSERVICE_MIGRATION_SCORES_TABLE_NAME"),
+    ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/store.ts
@@ -1,0 +1,109 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  MICROSERVICE_MIGRATION_PROBLEM_ID,
+  type MicroserviceMigrationSlot,
+} from "../microservice-migration-poller-handler/scoring.js";
+import type { MicroserviceMigrationRegistrationSharedResources } from "./shared.js";
+import {
+  buildScorePk,
+  buildScoreSk,
+  type ListEndpointsResponse,
+  type MicroserviceMigrationScoreItem,
+  type RegisterEndpointRequest,
+  type RegisterEndpointResponse,
+} from "./types.js";
+
+export interface RegisterEndpointContext {
+  readonly tenantId: string;
+  readonly nowMs: number;
+  readonly registeredBy: string;
+}
+
+/**
+ * 1 slot の endpoint を upsert する。
+ *
+ * - 既存 row があれば `registeredUrl` / `registeredAt` / `registeredBy` のみ上書き。
+ * - polling Lambda が書く observation 系属性 (`platform` / `lastProbeAt` 等) は保持
+ *   (= UpdateExpression で触る属性を限定するため)。
+ *
+ * race (登録と probe 同時): 最後勝ち (LWW) で十分 — 1 min 以内に polling が
+ * observation 列を埋め直す。
+ */
+export async function registerEndpoint(
+  shared: MicroserviceMigrationRegistrationSharedResources,
+  ctx: RegisterEndpointContext,
+  req: RegisterEndpointRequest,
+): Promise<RegisterEndpointResponse> {
+  const nowIso = new Date(ctx.nowMs).toISOString();
+  const pk = buildScorePk(ctx.tenantId);
+  const sk = buildScoreSk(req.slot);
+
+  await shared.ddb.send(
+    new UpdateCommand({
+      TableName: shared.tableName,
+      Key: { PK: pk, SK: sk },
+      UpdateExpression: [
+        "SET",
+        "tenantId = :tenant,",
+        "problemId = :problemId,",
+        "slot = :slot,",
+        "registeredUrl = :url,",
+        "registeredAt = :now,",
+        "registeredBy = :by",
+      ].join(" "),
+      ExpressionAttributeValues: {
+        ":tenant": ctx.tenantId,
+        ":problemId": MICROSERVICE_MIGRATION_PROBLEM_ID,
+        ":slot": req.slot,
+        ":url": req.url,
+        ":now": nowIso,
+        ":by": ctx.registeredBy,
+      },
+    }),
+  );
+
+  return {
+    slot: req.slot,
+    registeredUrl: req.url,
+    registeredAt: nowIso,
+  };
+}
+
+/**
+ * 1 tenant 分の登録 slot を返す (最大 3 件: users / orders / catalog)。
+ *
+ * PK = `TENANT#<tenantId>#PROBLEM#microservice-migration-battle` で Query。GSI 不要。
+ */
+export async function listEndpoints(
+  shared: MicroserviceMigrationRegistrationSharedResources,
+  tenantId: string,
+): Promise<ListEndpointsResponse> {
+  const pk = buildScorePk(tenantId);
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      KeyConditionExpression: "PK = :pk",
+      ExpressionAttributeValues: { ":pk": pk },
+    }),
+  );
+  type Item = ListEndpointsResponse["items"][number];
+  const items: Item[] = [];
+  for (const row of (out.Items ?? []) as Partial<MicroserviceMigrationScoreItem>[]) {
+    if (!row.slot || !row.registeredUrl || !row.registeredAt) continue;
+    const item: Item = {
+      slot: row.slot as MicroserviceMigrationSlot,
+      registeredUrl: row.registeredUrl,
+      registeredAt: row.registeredAt,
+      ...(typeof row.platform === "string" ? { platform: row.platform } : {}),
+      ...(row.lastResult ? { lastResult: row.lastResult } : {}),
+      ...(typeof row.lastProbeAt === "string" ? { lastProbeAt: row.lastProbeAt } : {}),
+      ...(typeof row.lastPoints === "number" ? { lastPoints: row.lastPoints } : {}),
+      ...(typeof row.lastResponseTimeMs === "number"
+        ? { lastResponseTimeMs: row.lastResponseTimeMs }
+        : {}),
+    };
+    items.push(item);
+  }
+
+  return { items };
+}

--- a/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/types.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import {
+  MICROSERVICE_MIGRATION_PROBLEM_ID,
+  MICROSERVICE_MIGRATION_SLOTS,
+  type MicroserviceMigrationSlot,
+} from "../microservice-migration-poller-handler/scoring.js";
+
+/**
+ * `MicroserviceMigrationScoresTable` 1 行の shape (Issue #606 / Phase 2)。
+ *
+ *   PK = `TENANT#<tenantId>#PROBLEM#microservice-migration-battle`
+ *   SK = `SLOT#<users|orders|catalog>`
+ *
+ * 競技者が登録した移行先 endpoint と、polling Lambda の最新観測結果を持つ単一の行。
+ * 採点 event 自体は既存 `ScoreEvent` ストリーム経由 (Deployments テーブル) で発行する。
+ *
+ * 全 slot で `platform != "ec2"` を達成した瞬間に +5000 lump-sum bonus を一度だけ発行する
+ * (二重発行防止のため `fullMigrationBonusAwarded` を立てる)。
+ */
+export interface MicroserviceMigrationScoreItem {
+  PK: string;
+  SK: string;
+
+  tenantId: string;
+  problemId: typeof MICROSERVICE_MIGRATION_PROBLEM_ID;
+  slot: MicroserviceMigrationSlot;
+  /** 競技者が `POST /problems/microservice-migration-battle/endpoints` で登録した URL。 */
+  registeredUrl: string;
+  /** 登録時刻 (ISO 8601)。 */
+  registeredAt: string;
+  /** 登録ユーザー (Cognito sub)。観測 / 監査用。 */
+  registeredBy?: string;
+
+  // polling Lambda が書き込む結果。初回 probe 前は undefined。
+  /** 直近 probe の時刻 (ISO 8601)。 */
+  lastProbeAt?: string;
+  /** /meta `platform` の自己申告値 (= 直近観測)。 */
+  platform?: string;
+  /** 直近 probe の集約結果 (ok / fail / timeout 等の短い名前)。 */
+  lastResult?: "ok" | "fail" | "timeout";
+  /** 直近 probe の score 加減算ポイント (= ScoreEvent と整合)。 */
+  lastPoints?: number;
+  /** 直近 probe の `/score` レスポンスタイム (ms)。 */
+  lastResponseTimeMs?: number;
+
+  /** 3 slot 全分離 +5000 bonus を発行済か (tenant 全体で 1 度のみ)。 */
+  fullMigrationBonusAwarded?: boolean;
+}
+
+const URL_MAX_LEN = 2_048;
+const HTTP_URL_RE = /^https?:\/\/[^\s]{1,2046}$/i;
+
+const SlotEnum = z.enum(MICROSERVICE_MIGRATION_SLOTS);
+
+export const RegisterEndpointRequestSchema = z
+  .object({
+    slot: SlotEnum,
+    url: z
+      .string()
+      .min(1)
+      .max(URL_MAX_LEN)
+      .regex(HTTP_URL_RE, "URL は http(s):// で始まる絶対 URL を指定してください"),
+  })
+  .strict();
+export type RegisterEndpointRequest = z.infer<typeof RegisterEndpointRequestSchema>;
+
+export interface RegisterEndpointResponse {
+  readonly slot: MicroserviceMigrationSlot;
+  readonly registeredUrl: string;
+  readonly registeredAt: string;
+}
+
+export interface ListEndpointsResponse {
+  readonly items: ReadonlyArray<{
+    readonly slot: MicroserviceMigrationSlot;
+    readonly registeredUrl: string;
+    readonly registeredAt: string;
+    readonly platform?: string;
+    readonly lastResult?: "ok" | "fail" | "timeout";
+    readonly lastProbeAt?: string;
+    readonly lastPoints?: number;
+    readonly lastResponseTimeMs?: number;
+  }>;
+}
+
+export function buildScorePk(tenantId: string): string {
+  return `TENANT#${tenantId}#PROBLEM#${MICROSERVICE_MIGRATION_PROBLEM_ID}`;
+}
+
+export function buildScoreSk(slot: MicroserviceMigrationSlot): string {
+  return `SLOT#${slot}`;
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -28,17 +28,28 @@ export interface ScoreEventItem {
    * - `flag`: 競技者の flag 提出が正解
    * - `attack-detected`: HealthCheck で `lastResult: ok → fail` 遷移を検知 (ADR-005 D2-A、
    *   Battle Portal の Attack Statistics / History で使う)
+   * - `microservice-migration`: Microservice Migration Battle (Phase 2 / #606) の 1 tick
+   *   probe 結果 (`platform` / `phase` 別に points が変動)。`uptime` と分けて持つことで
+   *   Battle Portal の history / leaderboard 側で混入を防ぐ。
+   * - `microservice-migration-bonus`: 3 slot 全分離達成の +5000 lump-sum bonus (1 度のみ)。
    */
-  source: "uptime" | "flag" | "attack-detected";
+  source:
+    | "uptime"
+    | "flag"
+    | "attack-detected"
+    | "microservice-migration"
+    | "microservice-migration-bonus";
   /**
    * 加算ポイント。`uptime` = scoring.pointsPerSuccess、`flag` = scoring.points、
-   * `attack-detected` = 0 (= イベント marker のみ、score 加算なし)。
+   * `attack-detected` = 0 (= イベント marker のみ、score 加算なし)、
+   * `microservice-migration*` = scoring.ts が計算する platform / phase 別ポイント。
    */
   points: number;
   /**
    * 結果。
-   * - `ok`: `uptime` で全 endpoint OK or `flag` で正解
-   * - `down`: `attack-detected` (= 攻撃が刺さって uptime が落ちた)
+   * - `ok`: `uptime` で全 endpoint OK or `flag` で正解 or `microservice-migration` で +score
+   * - `down`: `attack-detected` (= 攻撃が刺さって uptime が落ちた) or `microservice-migration`
+   *   で probe 失敗 (= -100 減点)
    *
    * Phase 2 以前の event 行は `"ok"` のみ書かれているので backward compatible。
    */
@@ -54,7 +65,10 @@ export interface ScoreEventItem {
  * 整合性が崩れるが、caller が catch して log のみ残す方針 (= MVP は best-effort)。
  *
  * `parent` から jobId / teamId / eventId / expiresAt を継承して event row を組む。
- * `result` は source に応じて自動決定 (= attack-detected なら "down"、それ以外は "ok")。
+ * `result` は source / points に応じて自動決定:
+ *   - `attack-detected` → "down" (固定)
+ *   - `microservice-migration` → points が負 (= probe 失敗減点) なら "down"、正なら "ok"
+ *   - その他 (uptime / flag / microservice-migration-bonus) → "ok"
  */
 export async function writeScoreEvent(
   ddb: DynamoDBDocumentClient,
@@ -73,9 +87,15 @@ export async function writeScoreEvent(
     eventId: parent.eventId,
     source,
     points,
-    result: source === "attack-detected" ? "down" : "ok",
+    result: resolveResult(source, points),
     occurredAt,
     expiresAt: Number(parent.expiresAt ?? 0),
   };
   await ddb.send(new PutCommand({ TableName: tableName, Item: item }));
+}
+
+function resolveResult(source: ScoreEventItem["source"], points: number): "ok" | "down" {
+  if (source === "attack-detected") return "down";
+  if (source === "microservice-migration" && points < 0) return "down";
+  return "ok";
 }

--- a/infrastructure/lib/problem-deploy/microservice-migration-poller-lambda.ts
+++ b/infrastructure/lib/problem-deploy/microservice-migration-poller-lambda.ts
@@ -1,0 +1,95 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface MicroserviceMigrationPollerLambdaProps {
+  readonly scoresTable: ITable;
+  /**
+   * `Deployments` DDB。本 Lambda は GSI1 を Query して tenant の jobId / createdAt /
+   * eventId / expiresAt を取得し、ScoreEvent (= sparse EVENT 行) を Put する。
+   */
+  readonly deploymentsTable: ITable;
+  /**
+   * EC2 劣化フェーズ突入までの分数 (`degradationMinutes` env)。default 60。
+   * EC2 score が +100 → +10 に切り替わる閾値。問題 `template.yaml` の cron 設定とは
+   * 独立 (= operator が runtime で本 env を上書きしても EC2 側 cron は事前に焼かれた値)。
+   */
+  readonly degradationMinutes?: number;
+  /**
+   * `/score` → `/score?legacy=true` 切替までの分数 (`legacySwitchMinutes` env)。default 90。
+   * 競技者が legacy code path (= 意図的 sleep) を取り除いて再デプロイすることを促す閾値。
+   */
+  readonly legacySwitchMinutes?: number;
+}
+
+const DEFAULT_DEGRADATION_MINUTES = 60;
+const DEFAULT_LEGACY_SWITCH_MINUTES = 90;
+
+/**
+ * Microservice Migration Battle (Phase 2 / Issue #606) の 1 min polling Lambda。
+ *
+ * EventBridge `rate(1 minute)` で起動 (= 既存 `HealthCheckLambda` と同 pattern)。本 Lambda は
+ * `health-check-handler` とは別系統で持つ:
+ *   - health-check は `scoring.kind=uptime` 用に declared endpoints (`stackOutputs[outputKey]`) を probe
+ *   - 本 Lambda は競技者が動的に登録した URL (= microservice-migration scores table) を probe
+ *
+ * 責務分離理由:
+ *   - 採点ルールが完全に違う (= platform 別 + phase 別 + bonus)。同居させると scoring.ts の責任が肥大化
+ *   - 本問題の polling は 3 slot per tenant の small dataset。health-check は全 deployment scan で
+ *     I/O profile が違う (= cron スケジュールも将来分離可能)
+ *
+ * ScoreEvent は `writeScoreEvent` 経由で Deployments table に書く (= 既存の Battle Portal /
+ * leaderboard と整合)。`source=microservice-migration` / `microservice-migration-bonus` を区別。
+ */
+export class MicroserviceMigrationPollerLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: MicroserviceMigrationPollerLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/microservice-migration-poller-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.minutes(2),
+      memorySize: 256,
+      environment: {
+        MICROSERVICE_MIGRATION_SCORES_TABLE_NAME: props.scoresTable.tableName,
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        MICROSERVICE_MIGRATION_DEGRADATION_MINUTES: String(
+          props.degradationMinutes ?? DEFAULT_DEGRADATION_MINUTES,
+        ),
+        MICROSERVICE_MIGRATION_LEGACY_SWITCH_MINUTES: String(
+          props.legacySwitchMinutes ?? DEFAULT_LEGACY_SWITCH_MINUTES,
+        ),
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    // 観測列を上書きする + bonus sentinel を立てるため scores table は RW。
+    props.scoresTable.grantReadWriteData(this.fn);
+    // Deployments table は ScoreEvent を Put + GSI1 を Query する (= RW 必要)。
+    // (Put 自体は新 sparse EVENT row を足すだけ、META 行は触らない)
+    props.deploymentsTable.grantReadWriteData(this.fn);
+
+    // EventBridge rate(1 minute) の独立 Rule (= HealthCheck と共有しない、責務分離)。
+    new Rule(this, "Schedule", {
+      schedule: Schedule.rate(Duration.minutes(1)),
+      description:
+        "TenkaCloud 1-min tick: Microservice Migration Battle (Phase 2 / #606) scoring poller.",
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/microservice-migration-registration-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/microservice-migration-registration-api-lambda.ts
@@ -1,0 +1,57 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface MicroserviceMigrationRegistrationApiLambdaProps {
+  /** `MicroserviceMigrationScoresTable` の DDB (RW)。 */
+  readonly scoresTable: Table;
+}
+
+/**
+ * Microservice Migration Battle (Phase 2 / Issue #606) の endpoint 登録 API Lambda。
+ *
+ * tenant API (TenantTemplateStack の REST API + Cognito JWT authorizer) から
+ * `LambdaIntegration` で invoke される。Hono routes:
+ *   POST /problems/microservice-migration-battle/endpoints — slot / url を upsert
+ *   GET  /problems/microservice-migration-battle/endpoints — 登録済 + 観測結果を一覧
+ *
+ * IAM scope は `scoresTable` 全 RW のみ (= polling Lambda が別 IAM で観測列を書く設計)。
+ */
+export class MicroserviceMigrationRegistrationApiLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: MicroserviceMigrationRegistrationApiLambdaProps,
+  ) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(
+        __dirname,
+        "handlers/microservice-migration-registration-handler/index.ts",
+      ),
+      handler: "handler",
+      timeout: Duration.seconds(10),
+      memorySize: 256,
+      environment: {
+        MICROSERVICE_MIGRATION_SCORES_TABLE_NAME: props.scoresTable.tableName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    props.scoresTable.grantReadWriteData(this.fn);
+  }
+}

--- a/infrastructure/lib/problem-deploy/microservice-migration-scores-table.ts
+++ b/infrastructure/lib/problem-deploy/microservice-migration-scores-table.ts
@@ -1,0 +1,42 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * Microservice Migration Battle (Phase 2 / Issue #606) の登録 endpoint + 観測結果テーブル。
+ *
+ * Schema:
+ *   PK: TENANT#<tenantId>#PROBLEM#microservice-migration-battle
+ *   SK: SLOT#<users|orders|catalog>
+ *
+ * 主な属性 (詳細は `handlers/microservice-migration-registration-handler/types.ts`):
+ *   - 登録 (registration handler 専管): tenantId / problemId / slot / registeredUrl /
+ *     registeredAt / registeredBy
+ *   - 観測 (polling Lambda 専管): platform / lastProbeAt / lastResult / lastPoints /
+ *     lastResponseTimeMs
+ *   - lump-sum bonus sentinel (1 tenant につき users slot の row に立てる):
+ *     fullMigrationBonusAwarded
+ *
+ * GSI 無し: tenant 内 1 Query で全 slot を取れる (PK 単一)。
+ *
+ * Capacity / lifecycle:
+ *   PROVISIONED 1/1 (`DynamoDbLowCapacity` Aspect で更に均す)。1 min polling × 最大
+ *   ~10 tenant × 3 slot = 1 invocation あたり ~30 row read で十分。RETAIN — 競技中
+ *   stack delete でも登録履歴は残す。
+ */
+export class MicroserviceMigrationScoresTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -18,6 +18,9 @@ import { EventApiLambda } from "./event-api-lambda";
 import { EventsTable } from "./events-table";
 import { ExternalIdAuditLambda } from "./external-id-audit-lambda";
 import { HealthCheckLambda } from "./health-check-lambda";
+import { MicroserviceMigrationPollerLambda } from "./microservice-migration-poller-lambda";
+import { MicroserviceMigrationRegistrationApiLambda } from "./microservice-migration-registration-api-lambda";
+import { MicroserviceMigrationScoresTable } from "./microservice-migration-scores-table";
 import {
   DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
   ParticipantPortalHosting,
@@ -78,6 +81,18 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * 例: `development` / `staging` / `production`。
    */
   readonly environmentName: string;
+  /**
+   * Microservice Migration Battle (Phase 2 / Issue #606) の EC2 劣化フェーズ突入までの分数。
+   * polling Lambda が `degradationMinutes` 経過後に EC2 score を +100 → +10 に切替える。
+   * 未指定なら default 60 を Lambda 内で使う。problem template の cron 設定と一致させること
+   * (= EC2 内 cron は CFn parameter で同値を受け取る)。
+   */
+  readonly microserviceMigrationDegradationMinutes?: number;
+  /**
+   * Microservice Migration Battle (Phase 2 / #606) の `/score?legacy=true` 切替までの分数。
+   * 未指定なら default 90。
+   */
+  readonly microserviceMigrationLegacySwitchMinutes?: number;
 }
 
 /**
@@ -104,6 +119,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * tenant API の `/admin/competitor-accounts*` route から invoke される。
    */
   public readonly competitorAccountsApiLambda: IFunction;
+  /**
+   * Microservice Migration Battle (Phase 2 / Issue #606) の endpoint 登録 API Lambda。
+   * tenant API の `/problems/microservice-migration-battle/endpoints` route から invoke される。
+   */
+  public readonly microserviceMigrationRegistrationApiLambda: IFunction;
   /**
    * Participant Portal の CloudFront URL。Participant Portal が無効化された tenant
    * では undefined。`TenantTemplateStack` が application-admin-console の runtime-config に
@@ -174,6 +194,29 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       environmentName: props.environmentName,
     });
     this.competitorAccountsApiLambda = competitorAccountsApi.fn;
+
+    // Issue #606 Phase 2: Microservice Migration Battle 用 score engine の 3 構成要素。
+    //   1. MicroserviceMigrationScoresTable (DDB, 1/1 PROVISIONED)
+    //   2. Registration API Lambda (tenant API 経由で /problems/.../endpoints を持つ)
+    //   3. Polling Lambda (rate(1 minute) で probe + ScoreEvent 発行)
+    // テーブル + 2 Lambda を分けて IAM scope を最小化する (= 登録 API は scoresTable のみ、
+    // polling Lambda は scoresTable + Deployments table の RW)。
+    const microserviceMigrationScores = new MicroserviceMigrationScoresTable(
+      this,
+      "MicroserviceMigrationScores",
+    );
+    const microserviceMigrationRegistrationApi = new MicroserviceMigrationRegistrationApiLambda(
+      this,
+      "MicroserviceMigrationRegistrationApi",
+      { scoresTable: microserviceMigrationScores.table },
+    );
+    this.microserviceMigrationRegistrationApiLambda = microserviceMigrationRegistrationApi.fn;
+    new MicroserviceMigrationPollerLambda(this, "MicroserviceMigrationPoller", {
+      scoresTable: microserviceMigrationScores.table,
+      deploymentsTable: deployments.table,
+      degradationMinutes: props.microserviceMigrationDegradationMinutes,
+      legacySwitchMinutes: props.microserviceMigrationLegacySwitchMinutes,
+    });
 
     // CodeBuild Project: source.zip から `scripts/deploy-battles.sh` を実行する。
     // #538: Bulk Deploy 並列度の hard cap は account-wide CodeBuild concurrent build
@@ -280,6 +323,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       value: competitorAccounts.table.tableName,
       description:
         "Issue #459 / ADR-002 Competitor Accounts table 名 (tenant ↔ 競技者 AWS account 紐付け)。",
+    });
+    new CfnOutput(this, "MicroserviceMigrationScoresTableName", {
+      value: microserviceMigrationScores.table.tableName,
+      description:
+        "Issue #606 Phase 2 Microservice Migration Battle の slot 登録 + 観測テーブル名。",
     });
     new CfnOutput(this, "DeployCreateStateMachineArn", {
       value: stateMachine.stateMachine.stateMachineArn,

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -34,6 +34,11 @@ interface ApiGatewayProps {
    * (Issue #459 / ADR-002 Phase 2.1)。`/admin/competitor-accounts*` routes を proxy する。
    */
   competitorAccountsApiLambda: IFunction;
+  /**
+   * `ProblemDeployBackendStack.microserviceMigrationRegistrationApiLambda` のクロススタック参照
+   * (Issue #606 Phase 2)。`/problems/microservice-migration-battle/endpoints` route を proxy する。
+   */
+  microserviceMigrationRegistrationApiLambda: IFunction;
   apiKeyBasicTier: CustomApiKey;
   apiKeyStandardTier: CustomApiKey;
   apiKeyPremiumTier: CustomApiKey;
@@ -79,6 +84,26 @@ export class ApiGateway extends Construct {
     const problem = problems.addResource("{problemId}");
     problem.addResource("deploy").addMethod("POST", deployIntegration, deployMethodOptions);
     problem.addResource("deployments").addMethod("GET", deployIntegration, deployMethodOptions);
+
+    // Issue #606 Phase 2: Microservice Migration Battle 専用の endpoint 登録 routes。
+    //   /problems/microservice-migration-battle/endpoints  POST=登録 / GET=一覧 + 観測結果
+    // tenant API GW の Cognito JWT authorizer を共有。registration Lambda 自体は
+    // ProblemDeployBackendStack 側に置き、本 API GW は LambdaIntegration で proxy する。
+    const microserviceMigrationIntegration = new LambdaIntegration(
+      props.microserviceMigrationRegistrationApiLambda,
+    );
+    const microserviceMigrationProblem = problems.addResource("microservice-migration-battle");
+    const microserviceMigrationEndpoints = microserviceMigrationProblem.addResource("endpoints");
+    microserviceMigrationEndpoints.addMethod(
+      "POST",
+      microserviceMigrationIntegration,
+      deployMethodOptions,
+    );
+    microserviceMigrationEndpoints.addMethod(
+      "GET",
+      microserviceMigrationIntegration,
+      deployMethodOptions,
+    );
 
     // /deployments — tenant 内全 deploy job 一覧 (サイドバー「デプロイ履歴」用)
     // /deployments/{jobId} — 1 件の取得 / 削除

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -52,6 +52,12 @@ interface TenantTemplateStackProps extends StackProps {
    */
   competitorAccountsApiLambda: IFunction;
   /**
+   * `ProblemDeployBackendStack.microserviceMigrationRegistrationApiLambda` をクロススタック参照で受ける
+   * (Issue #606 Phase 2)。tenant API の `/problems/microservice-migration-battle/endpoints` route が
+   * 本 Lambda を invoke する。
+   */
+  microserviceMigrationRegistrationApiLambda: IFunction;
+  /**
    * Participant Portal の CloudFront URL。`ProblemDeployBackendStack` の
    * `participantPortalUrl` をクロススタック参照で受け、application-admin-console の
    * runtime-config.json に注入する (operator が EventDetail 等で「Portal URL を共有」
@@ -101,6 +107,7 @@ export class TenantTemplateStack extends Stack {
       deployApiLambda: props.deployApiLambda,
       eventApiLambda: props.eventApiLambda,
       competitorAccountsApiLambda: props.competitorAccountsApiLambda,
+      microserviceMigrationRegistrationApiLambda: props.microserviceMigrationRegistrationApiLambda,
       apiKeyBasicTier: {
         apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.basic.keyId),
         value: this.ssmLookup(props.ApiKeySSMParameterNames.basic.value),

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -25,10 +25,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts の 4 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
-      // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts。
-      // 4 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 4);
+    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / MicroserviceMigrationScores の 5 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+      // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts、
+      // Issue #606 Phase 2 で MicroserviceMigrationScores。
+      // 5 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 5);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({
@@ -160,12 +161,13 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(synthJson).toContain("IN_PROGRESS");
     });
 
-    it("EventBridge Rule を Create / Delete / HealthCheck / ExternalIdAudit schedule で 4 つ持つべき", () => {
+    it("EventBridge Rule を Create / Delete / HealthCheck / ExternalIdAudit / MicroserviceMigrationPoller schedule で 5 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + HealthCheck schedule rate(1 minute) (= #557 #539 reconciler + uptime 採点)
-      //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
-      // = 4。HealthCheck は uptime 採点とは独立に常時 instantiate される。
-      tpl.resourceCountIs("AWS::Events::Rule", 4);
+      //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603)
+      //   + MicroserviceMigrationPoller schedule rate(1 minute) (= Issue #606 Phase 2)
+      // = 5。HealthCheck と MicroserviceMigrationPoller は責務分離のため別 cron。
+      tpl.resourceCountIs("AWS::Events::Rule", 5);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -303,6 +305,41 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
             ]),
           }),
         }),
+      );
+    });
+
+    it("Issue #606 Phase 2: Microservice Migration Battle 用に scoresTable + 2 Lambda + 1 schedule を持つべき", () => {
+      // Registration Lambda + Poller Lambda の env を pin する (= MICROSERVICE_MIGRATION_SCORES_TABLE_NAME 必須)
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs20.x",
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              MICROSERVICE_MIGRATION_SCORES_TABLE_NAME: Match.anyValue(),
+            }),
+          }),
+        }),
+      );
+      // Poller Lambda は degradation / legacy switch 分数 env を持つ
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs20.x",
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              MICROSERVICE_MIGRATION_DEGRADATION_MINUTES: "60",
+              MICROSERVICE_MIGRATION_LEGACY_SWITCH_MINUTES: "90",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("Issue #606 Phase 2: Output に MicroserviceMigrationScoresTableName を含むべき", () => {
+      const outputs = tpl.findOutputs("*");
+      expect(Object.keys(outputs)).toEqual(
+        expect.arrayContaining(["MicroserviceMigrationScoresTableName"]),
       );
     });
 

--- a/infrastructure/test/problem-deploy/microservice-migration-poller-handler.test.ts
+++ b/infrastructure/test/problem-deploy/microservice-migration-poller-handler.test.ts
@@ -1,0 +1,254 @@
+import { ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Microservice Migration Battle (Phase 2 / #606) polling Lambda の handler() レベル test。
+ *
+ * fetch は probe.ts のヘルパー (fetchPlatform / probeScore) 経由でしか呼ばれないので
+ * そこを `vi.mock` で差し替える。DDB は `@aws-sdk/lib-dynamodb` の Document client の
+ * `send` を mock して 1 invocation 中の全 command を観察する。
+ */
+
+const probeMocks = vi.hoisted(() => ({
+  fetchPlatform: vi.fn(),
+  probeScore: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/microservice-migration-poller-handler/probe", () => ({
+  fetchPlatform: probeMocks.fetchPlatform,
+  probeScore: probeMocks.probeScore,
+}));
+
+const sendMock = vi.fn();
+vi.mock("@aws-sdk/lib-dynamodb", async () => {
+  const actual =
+    await vi.importActual<typeof import("@aws-sdk/lib-dynamodb")>("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: () => ({ send: sendMock }),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.MICROSERVICE_MIGRATION_SCORES_TABLE_NAME = "TestScores";
+  process.env.DEPLOYMENTS_TABLE_NAME = "TestDeployments";
+  process.env.MICROSERVICE_MIGRATION_DEGRADATION_MINUTES = "60";
+  process.env.MICROSERVICE_MIGRATION_LEGACY_SWITCH_MINUTES = "90";
+});
+
+afterEach(() => {
+  delete process.env.MICROSERVICE_MIGRATION_SCORES_TABLE_NAME;
+  delete process.env.DEPLOYMENTS_TABLE_NAME;
+});
+
+const { handler } = await import(
+  "../../lib/problem-deploy/handlers/microservice-migration-poller-handler/index"
+);
+
+function buildSlotRow(
+  tenantId: string,
+  slot: string,
+  url: string,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    PK: `TENANT#${tenantId}#PROBLEM#microservice-migration-battle`,
+    SK: `SLOT#${slot}`,
+    tenantId,
+    slot,
+    registeredUrl: url,
+    ...extra,
+  };
+}
+
+function buildDeploymentRow(tenantId: string, createdAt: string) {
+  return {
+    PK: "DEPLOYMENT#JOB1",
+    SK: "META",
+    GSI1PK: `TENANT#${tenantId}`,
+    GSI1SK: createdAt,
+    jobId: "JOB1",
+    problemId: "microservice-migration-battle",
+    tenantId,
+    teamId: "T1",
+    eventId: "E1",
+    expiresAt: 1_900_000_000,
+    createdAt,
+    status: "COMPLETE",
+  };
+}
+
+describe("handler() (microservice-migration poller, #606)", () => {
+  it("登録 0 件なら DDB に Scan しか発行しないべき", async () => {
+    sendMock.mockResolvedValueOnce({ Items: [] }); // Scan
+    await handler();
+    // Scan 1 回のみ
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0]?.[0]).toBeInstanceOf(ScanCommand);
+  });
+
+  it("registered slot 1 件: probe → ScoreEvent / observation 更新を発行すべき", async () => {
+    const createdAt = new Date(Date.now() - 30 * 60_000).toISOString(); // 30 min 前 (pre-degradation)
+
+    sendMock.mockResolvedValueOnce({
+      Items: [buildSlotRow("tA", "users", "https://x.example.com")],
+    }); // Scan
+    sendMock.mockResolvedValueOnce({
+      Items: [buildDeploymentRow("tA", createdAt)],
+    }); // findTenantDeployment Query
+    sendMock.mockResolvedValueOnce({}); // updateSlotObservation
+    sendMock.mockResolvedValueOnce({}); // writeScoreEvent Put
+
+    probeMocks.fetchPlatform.mockResolvedValueOnce("lambda");
+    probeMocks.probeScore.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      responseTimeMs: 100,
+    });
+
+    await handler();
+
+    // probe.ts が 1 slot ぶん 1 回ずつ呼ばれる
+    expect(probeMocks.fetchPlatform).toHaveBeenCalledWith("https://x.example.com");
+    expect(probeMocks.probeScore).toHaveBeenCalledWith("https://x.example.com", "/score");
+
+    // updateSlotObservation の UpdateCommand に platform=lambda / points=1000 が入る
+    const updateCalls = sendMock.mock.calls
+      .map((c) => c[0])
+      .filter((cmd): cmd is UpdateCommand => cmd instanceof UpdateCommand);
+    const obsUpdate = updateCalls.find(
+      (cmd) =>
+        typeof cmd.input.UpdateExpression === "string" &&
+        cmd.input.UpdateExpression.includes("platform"),
+    );
+    expect(obsUpdate).toBeDefined();
+    expect(obsUpdate?.input.ExpressionAttributeValues?.[":platform"]).toBe("lambda");
+    expect(obsUpdate?.input.ExpressionAttributeValues?.[":points"]).toBe(1_000);
+    expect(obsUpdate?.input.ExpressionAttributeValues?.[":result"]).toBe("ok");
+  });
+
+  it("3 slot 全 non-ec2 達成時に +5000 lump-sum bonus を 1 度発行すべき", async () => {
+    const createdAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    sendMock.mockResolvedValueOnce({
+      Items: [
+        buildSlotRow("tA", "users", "https://u.example.com"),
+        buildSlotRow("tA", "orders", "https://o.example.com"),
+        buildSlotRow("tA", "catalog", "https://c.example.com"),
+      ],
+    });
+    sendMock.mockResolvedValueOnce({ Items: [buildDeploymentRow("tA", createdAt)] });
+    // 3 slot 並列処理: updateSlotObservation × 3 + writeScoreEvent × 3 の任意順
+    // → 残り全 send は {} で OK
+    sendMock.mockResolvedValue({});
+
+    probeMocks.fetchPlatform.mockResolvedValue("lambda");
+    probeMocks.probeScore.mockResolvedValue({
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+    });
+
+    await handler();
+
+    // ConditionExpression 付き UpdateCommand (fullMigrationBonusAwarded sentinel) が
+    // 1 回呼ばれているはず
+    const bonusUpdate = sendMock.mock.calls
+      .map((c) => c[0])
+      .filter((cmd): cmd is UpdateCommand => cmd instanceof UpdateCommand)
+      .find(
+        (cmd) =>
+          typeof cmd.input.UpdateExpression === "string" &&
+          cmd.input.UpdateExpression.includes("fullMigrationBonusAwarded"),
+      );
+    expect(bonusUpdate).toBeDefined();
+    expect(bonusUpdate?.input.ConditionExpression).toContain("fullMigrationBonusAwarded");
+  });
+
+  it("既に fullMigrationBonusAwarded=true なら bonus sentinel を発行しないべき (= 二重発行防止)", async () => {
+    const createdAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    sendMock.mockResolvedValueOnce({
+      Items: [
+        buildSlotRow("tA", "users", "https://u.example.com", { fullMigrationBonusAwarded: true }),
+        buildSlotRow("tA", "orders", "https://o.example.com"),
+        buildSlotRow("tA", "catalog", "https://c.example.com"),
+      ],
+    });
+    sendMock.mockResolvedValueOnce({ Items: [buildDeploymentRow("tA", createdAt)] });
+    sendMock.mockResolvedValue({});
+    probeMocks.fetchPlatform.mockResolvedValue("lambda");
+    probeMocks.probeScore.mockResolvedValue({
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+    });
+
+    await handler();
+
+    // ConditionExpression 付き sentinel UpdateCommand が 0 件であることを確認
+    const bonusUpdates = sendMock.mock.calls
+      .map((c) => c[0])
+      .filter((cmd): cmd is UpdateCommand => cmd instanceof UpdateCommand)
+      .filter(
+        (cmd) =>
+          typeof cmd.input.UpdateExpression === "string" &&
+          cmd.input.UpdateExpression.includes("fullMigrationBonusAwarded"),
+      );
+    expect(bonusUpdates).toHaveLength(0);
+  });
+
+  it("90 分経過後は /score?legacy=true を probe すべき", async () => {
+    const createdAt = new Date(Date.now() - 100 * 60_000).toISOString(); // 100 min 前
+    sendMock.mockResolvedValueOnce({
+      Items: [buildSlotRow("tA", "users", "https://x.example.com")],
+    });
+    sendMock.mockResolvedValueOnce({ Items: [buildDeploymentRow("tA", createdAt)] });
+    sendMock.mockResolvedValue({});
+
+    probeMocks.fetchPlatform.mockResolvedValueOnce("lambda");
+    probeMocks.probeScore.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+    });
+
+    await handler();
+
+    expect(probeMocks.probeScore).toHaveBeenCalledWith(
+      "https://x.example.com",
+      "/score?legacy=true",
+    );
+  });
+
+  it("probe 失敗時は lastResult=fail / points=-100 で記録すべき", async () => {
+    const createdAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    sendMock.mockResolvedValueOnce({
+      Items: [buildSlotRow("tA", "users", "https://x.example.com")],
+    });
+    sendMock.mockResolvedValueOnce({ Items: [buildDeploymentRow("tA", createdAt)] });
+    sendMock.mockResolvedValue({});
+
+    probeMocks.fetchPlatform.mockResolvedValueOnce(undefined);
+    probeMocks.probeScore.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      responseTimeMs: 100,
+      reason: "non-2xx",
+    });
+
+    await handler();
+
+    const obsUpdate = sendMock.mock.calls
+      .map((c) => c[0])
+      .filter((cmd): cmd is UpdateCommand => cmd instanceof UpdateCommand)
+      .find(
+        (cmd) =>
+          typeof cmd.input.UpdateExpression === "string" &&
+          cmd.input.UpdateExpression.includes("platform"),
+      );
+    expect(obsUpdate?.input.ExpressionAttributeValues?.[":result"]).toBe("fail");
+    expect(obsUpdate?.input.ExpressionAttributeValues?.[":points"]).toBe(-100);
+  });
+});

--- a/infrastructure/test/problem-deploy/microservice-migration-registration-routes.test.ts
+++ b/infrastructure/test/problem-deploy/microservice-migration-registration-routes.test.ts
@@ -1,0 +1,116 @@
+import { StatusCodes } from "http-status-codes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  registerEndpoint: vi.fn(),
+  listEndpoints: vi.fn(),
+}));
+
+vi.mock(
+  "../../lib/problem-deploy/handlers/microservice-migration-registration-handler/shared",
+  () => ({
+    buildMicroserviceMigrationRegistrationSharedResources: () => ({
+      tableName: "TestMicroserviceMigrationScores",
+      ddb: { send: vi.fn() },
+    }),
+  }),
+);
+
+vi.mock(
+  "../../lib/problem-deploy/handlers/microservice-migration-registration-handler/store",
+  () => ({
+    registerEndpoint: mocks.registerEndpoint,
+    listEndpoints: mocks.listEndpoints,
+  }),
+);
+
+const { app } = await import(
+  "../../lib/problem-deploy/handlers/microservice-migration-registration-handler/index"
+);
+
+describe("POST /problems/microservice-migration-battle/endpoints", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("200 で登録 slot を返すべき", async () => {
+    mocks.registerEndpoint.mockResolvedValueOnce({
+      slot: "users",
+      registeredUrl: "https://users.example.com",
+      registeredAt: "2026-05-12T10:00:00.000Z",
+    });
+    const res = await app.request("/problems/microservice-migration-battle/endpoints", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "users", url: "https://users.example.com" }),
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.slot).toBe("users");
+    expect(body.registeredUrl).toBe("https://users.example.com");
+    expect(mocks.registerEndpoint).toHaveBeenCalledTimes(1);
+  });
+
+  it("slot が想定外なら 400 を返すべき", async () => {
+    const res = await app.request("/problems/microservice-migration-battle/endpoints", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "payments", url: "https://x.example.com" }),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.registerEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("URL が http(s) prefix でないなら 400 を返すべき", async () => {
+    const res = await app.request("/problems/microservice-migration-battle/endpoints", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "users", url: "ftp://x.example.com" }),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.registerEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("body が JSON でないなら 400 を返すべき", async () => {
+    const res = await app.request("/problems/microservice-migration-battle/endpoints", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("store が throw したら 500 を返すべき", async () => {
+    mocks.registerEndpoint.mockRejectedValueOnce(new Error("ddb down"));
+    const res = await app.request("/problems/microservice-migration-battle/endpoints", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "orders", url: "https://orders.example.com" }),
+    });
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
+});
+
+describe("GET /problems/microservice-migration-battle/endpoints", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("登録済 slot 一覧を返すべき", async () => {
+    mocks.listEndpoints.mockResolvedValueOnce({
+      items: [
+        {
+          slot: "users",
+          registeredUrl: "https://users.example.com",
+          registeredAt: "2026-05-12T10:00:00.000Z",
+          platform: "lambda",
+          lastResult: "ok",
+          lastProbeAt: "2026-05-12T10:01:00.000Z",
+          lastPoints: 1000,
+          lastResponseTimeMs: 50,
+        },
+      ],
+    });
+    const res = await app.request("/problems/microservice-migration-battle/endpoints");
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as { items: Array<Record<string, unknown>> };
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.platform).toBe("lambda");
+  });
+});

--- a/infrastructure/test/problem-deploy/microservice-migration-registration-store.test.ts
+++ b/infrastructure/test/problem-deploy/microservice-migration-registration-store.test.ts
@@ -1,0 +1,131 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { describe, expect, it, vi } from "vitest";
+import {
+  listEndpoints,
+  registerEndpoint,
+} from "../../lib/problem-deploy/handlers/microservice-migration-registration-handler/store";
+
+const buildShared = () => {
+  const send = vi.fn().mockResolvedValue({});
+  return {
+    send,
+    shared: {
+      tableName: "TestMicroserviceMigrationScores",
+      ddb: { send } as unknown as Parameters<typeof registerEndpoint>[0]["ddb"],
+    },
+  };
+};
+
+describe("registerEndpoint", () => {
+  it("PK = TENANT#... + SK = SLOT#users で UpdateCommand を発行すべき", async () => {
+    const { send, shared } = buildShared();
+    await registerEndpoint(
+      shared,
+      { tenantId: "tenant-A", nowMs: Date.parse("2026-05-12T10:00:00.000Z"), registeredBy: "u1" },
+      { slot: "users", url: "https://users.example.com" },
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    const cmd = send.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd).toBeInstanceOf(UpdateCommand);
+    expect(cmd.input.Key).toEqual({
+      PK: "TENANT#tenant-A#PROBLEM#microservice-migration-battle",
+      SK: "SLOT#users",
+    });
+  });
+
+  it("UpdateExpression は observation 系 (platform / lastProbeAt 等) を触らないべき", async () => {
+    const { send, shared } = buildShared();
+    await registerEndpoint(
+      shared,
+      { tenantId: "t", nowMs: Date.parse("2026-05-12T10:00:00.000Z"), registeredBy: "u1" },
+      { slot: "orders", url: "https://orders.example.com" },
+    );
+    const cmd = send.mock.calls[0]?.[0] as UpdateCommand;
+    const expr = cmd.input.UpdateExpression ?? "";
+    expect(expr).toContain("registeredUrl");
+    expect(expr).toContain("registeredAt");
+    // observation 系は polling Lambda 専管 (= UpdateExpression に出てきてはいけない)
+    expect(expr).not.toContain("platform");
+    expect(expr).not.toContain("lastProbeAt");
+    expect(expr).not.toContain("lastResult");
+    expect(expr).not.toContain("fullMigrationBonusAwarded");
+  });
+
+  it("response に slot / registeredUrl / registeredAt を返すべき", async () => {
+    const { shared } = buildShared();
+    const res = await registerEndpoint(
+      shared,
+      { tenantId: "t", nowMs: Date.parse("2026-05-12T10:00:00.000Z"), registeredBy: "u1" },
+      { slot: "catalog", url: "https://catalog.example.com" },
+    );
+    expect(res).toEqual({
+      slot: "catalog",
+      registeredUrl: "https://catalog.example.com",
+      registeredAt: "2026-05-12T10:00:00.000Z",
+    });
+  });
+});
+
+describe("listEndpoints", () => {
+  it("QueryCommand で PK 単位で取得すべき", async () => {
+    const send = vi.fn().mockResolvedValueOnce({ Items: [] });
+    const shared = {
+      tableName: "TestMicroserviceMigrationScores",
+      ddb: { send } as unknown as Parameters<typeof listEndpoints>[0]["ddb"],
+    };
+    await listEndpoints(shared, "tenant-A");
+    const cmd = send.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd).toBeInstanceOf(QueryCommand);
+    expect(cmd.input.ExpressionAttributeValues).toEqual({
+      ":pk": "TENANT#tenant-A#PROBLEM#microservice-migration-battle",
+    });
+  });
+
+  it("DDB 行を summary 形 (slot / registeredUrl / 等) に整形して返すべき", async () => {
+    const send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        {
+          slot: "users",
+          registeredUrl: "https://users.example.com",
+          registeredAt: "2026-05-12T10:00:00.000Z",
+          platform: "lambda",
+          lastResult: "ok",
+          lastProbeAt: "2026-05-12T10:01:00.000Z",
+          lastPoints: 1_000,
+          lastResponseTimeMs: 42,
+        },
+      ],
+    });
+    const shared = {
+      tableName: "T",
+      ddb: { send } as unknown as Parameters<typeof listEndpoints>[0]["ddb"],
+    };
+    const out = await listEndpoints(shared, "t");
+    expect(out.items).toEqual([
+      {
+        slot: "users",
+        registeredUrl: "https://users.example.com",
+        registeredAt: "2026-05-12T10:00:00.000Z",
+        platform: "lambda",
+        lastResult: "ok",
+        lastProbeAt: "2026-05-12T10:01:00.000Z",
+        lastPoints: 1_000,
+        lastResponseTimeMs: 42,
+      },
+    ]);
+  });
+
+  it("不完全な行 (= slot / registeredUrl 欠落) は除外すべき", async () => {
+    const send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        { slot: "users", registeredAt: "2026-05-12T10:00:00.000Z" }, // registeredUrl 無し
+      ],
+    });
+    const shared = {
+      tableName: "T",
+      ddb: { send } as unknown as Parameters<typeof listEndpoints>[0]["ddb"],
+    };
+    const out = await listEndpoints(shared, "t");
+    expect(out.items).toEqual([]);
+  });
+});

--- a/infrastructure/test/problem-deploy/microservice-migration-scoring.test.ts
+++ b/infrastructure/test/problem-deploy/microservice-migration-scoring.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePhase,
+  type MicroserviceMigrationPhase,
+  type ProbeResult,
+  resolveScorePath,
+  scoreFromProbe,
+} from "../../lib/problem-deploy/handlers/microservice-migration-poller-handler/scoring";
+
+/**
+ * Microservice Migration Battle (Phase 2) のスコア計算ロジックを pin する。
+ *
+ * 採点表 (issue #572 / #606):
+ *   未登録 / 200 以外 / timeout: -100
+ *   EC2 (劣化前):                +100
+ *   EC2 (劣化後 = degradationMinutes 経過):  +10
+ *   Lambda / ECS Fargate / App Runner:        +1000
+ *   応答時間 > 1500ms ペナルティ:              -10 (= 採点と独立に減点)
+ *
+ * 3 slot 全てが non-ec2 になったら +5000 lump-sum bonus は store 側で one-shot 判定。
+ */
+
+describe("computePhase", () => {
+  // 競技開始 = deploy createdAt
+  const DEPLOYED_AT = "2026-05-12T10:00:00.000Z";
+
+  it("0 分時点なら pre-degradation / score 経路", () => {
+    expect(computePhase(DEPLOYED_AT, "2026-05-12T10:00:00.000Z", 60, 90)).toEqual({
+      degraded: false,
+      legacy: false,
+    });
+  });
+
+  it("degradationMinutes 経過直後は degraded=true / legacy=false", () => {
+    // 60 min ちょうど
+    expect(computePhase(DEPLOYED_AT, "2026-05-12T11:00:00.000Z", 60, 90)).toEqual({
+      degraded: true,
+      legacy: false,
+    });
+  });
+
+  it("legacySwitchMinutes 経過後は degraded=true / legacy=true", () => {
+    // 90 min ちょうど
+    expect(computePhase(DEPLOYED_AT, "2026-05-12T11:30:00.000Z", 60, 90)).toEqual({
+      degraded: true,
+      legacy: true,
+    });
+  });
+
+  it("createdAt が無効な場合は pre-degradation 扱い (= 採点境界の安全側、競技開始直後扱い)", () => {
+    expect(computePhase(undefined, "2026-05-12T15:00:00.000Z", 60, 90)).toEqual({
+      degraded: false,
+      legacy: false,
+    });
+  });
+});
+
+describe("resolveScorePath", () => {
+  it("legacy=false なら /score を返すべき", () => {
+    expect(resolveScorePath(false)).toBe("/score");
+  });
+  it("legacy=true なら /score?legacy=true を返すべき", () => {
+    expect(resolveScorePath(true)).toBe("/score?legacy=true");
+  });
+});
+
+describe("scoreFromProbe", () => {
+  const phasePre: MicroserviceMigrationPhase = { degraded: false, legacy: false };
+  const phasePost: MicroserviceMigrationPhase = { degraded: true, legacy: false };
+
+  it("timeout / network error は -100 を返すべき", () => {
+    const probe: ProbeResult = {
+      ok: false,
+      status: 0,
+      responseTimeMs: 0,
+      platform: undefined,
+      reason: "timeout",
+    };
+    expect(scoreFromProbe(probe, phasePre)).toBe(-100);
+  });
+
+  it("non-200 は -100 を返すべき", () => {
+    const probe: ProbeResult = {
+      ok: false,
+      status: 500,
+      responseTimeMs: 100,
+      platform: "ec2",
+    };
+    expect(scoreFromProbe(probe, phasePre)).toBe(-100);
+  });
+
+  it("EC2 / 劣化前 / 応答 OK は +100", () => {
+    const probe: ProbeResult = { ok: true, status: 200, responseTimeMs: 50, platform: "ec2" };
+    expect(scoreFromProbe(probe, phasePre)).toBe(100);
+  });
+
+  it("EC2 / 劣化後 / 応答 OK は +10", () => {
+    const probe: ProbeResult = { ok: true, status: 200, responseTimeMs: 50, platform: "ec2" };
+    expect(scoreFromProbe(probe, phasePost)).toBe(10);
+  });
+
+  it("Lambda / 応答 OK は +1000", () => {
+    const probe: ProbeResult = {
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+      platform: "lambda",
+    };
+    expect(scoreFromProbe(probe, phasePre)).toBe(1000);
+  });
+
+  it("ECS / 応答 OK は +1000", () => {
+    const probe: ProbeResult = { ok: true, status: 200, responseTimeMs: 50, platform: "ecs" };
+    expect(scoreFromProbe(probe, phasePost)).toBe(1000);
+  });
+
+  it("App Runner / 応答 OK は +1000", () => {
+    const probe: ProbeResult = {
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+      platform: "apprunner",
+    };
+    expect(scoreFromProbe(probe, phasePre)).toBe(1000);
+  });
+
+  it("応答時間が 1500ms 超なら追加で -10 ペナルティ (= score - 10)", () => {
+    const probe: ProbeResult = {
+      ok: true,
+      status: 200,
+      responseTimeMs: 1_600,
+      platform: "lambda",
+    };
+    // +1000 - 10 = 990
+    expect(scoreFromProbe(probe, phasePre)).toBe(990);
+  });
+
+  it("platform 未知 (= /meta の値が想定外) は EC2 と同じ扱いをすべき (= 移行未完了とみなす)", () => {
+    const probe: ProbeResult = {
+      ok: true,
+      status: 200,
+      responseTimeMs: 50,
+      platform: "unknown",
+    };
+    expect(scoreFromProbe(probe, phasePre)).toBe(100);
+  });
+});

--- a/infrastructure/test/problem-deploy/score-event.test.ts
+++ b/infrastructure/test/problem-deploy/score-event.test.ts
@@ -50,6 +50,63 @@ describe("writeScoreEvent (ADR-005 Phase 3.1: source extension)", () => {
     });
   });
 
+  it("source=microservice-migration + points>0 のとき result=ok で書き込む (#606 Phase 2)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(
+      ddb,
+      "T",
+      parent,
+      "microservice-migration",
+      1_000,
+      "2026-05-10T10:00:00.000Z",
+    );
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      source: "microservice-migration",
+      points: 1_000,
+      result: "ok",
+    });
+  });
+
+  it("source=microservice-migration + points<0 (probe 失敗) のとき result=down で書き込む (#606 Phase 2)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(
+      ddb,
+      "T",
+      parent,
+      "microservice-migration",
+      -100,
+      "2026-05-10T10:00:00.000Z",
+    );
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      source: "microservice-migration",
+      points: -100,
+      result: "down",
+    });
+  });
+
+  it("source=microservice-migration-bonus は常に result=ok で書き込む (#606 Phase 2、+5000 lump-sum)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];
+    await writeScoreEvent(
+      ddb,
+      "T",
+      parent,
+      "microservice-migration-bonus",
+      5_000,
+      "2026-05-10T10:00:00.000Z",
+    );
+    const cmd = send.mock.calls[0]?.[0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      source: "microservice-migration-bonus",
+      points: 5_000,
+      result: "ok",
+    });
+  });
+
   it("PK / SK が DEPLOYMENT#<jobId> / EVENT#<ts>#<ulid> 形になる", async () => {
     const send = vi.fn().mockResolvedValue({});
     const ddb = { send } as unknown as Parameters<typeof writeScoreEvent>[0];

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -32,6 +32,15 @@ function buildHarness() {
     code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
     handler: "index.handler",
   });
+  const microserviceMigrationRegistrationFn = new LambdaFunction(
+    stack,
+    "MicroserviceMigrationRegistrationApi",
+    {
+      runtime: Runtime.NODEJS_20_X,
+      code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 })"),
+      handler: "index.handler",
+    },
+  );
   const apiKey: CustomApiKey = {
     id: "key-id",
     apiKey: { keyId: "k", keyArn: "arn:aws:apigateway:::/apikeys/k", keyName: "k" },
@@ -54,6 +63,7 @@ function buildHarness() {
     deployApiLambda: fn,
     eventApiLambda: eventFn,
     competitorAccountsApiLambda: competitorAccountsFn,
+    microserviceMigrationRegistrationApiLambda: microserviceMigrationRegistrationFn,
     apiKeyBasicTier: apiKey,
     apiKeyStandardTier: apiKey,
     apiKeyPremiumTier: apiKey,

--- a/problems/battles/microservice-migration-battle/template.yaml
+++ b/problems/battles/microservice-migration-battle/template.yaml
@@ -48,6 +48,16 @@ Parameters:
     Type: String
     Default: main
     Description: チェックアウトする branch / tag / commit。
+  DegradationMinutes:
+    Type: Number
+    Default: 60
+    MinValue: 1
+    MaxValue: 1440
+    Description: >
+      競技開始から EC2 ネットワーク劣化を起動するまでの分数 (Phase 2 / Issue #606)。
+      score engine の `MICROSERVICE_MIGRATION_DEGRADATION_MINUTES` と同値にすること。
+      EC2 UserData の cron が boot から本値分後に `tc qdisc` を流し、200ms の遅延を注入する
+      (= EC2 残置への penalty を実機で再現)。デフォルト 60 分。
 
 Resources:
   # ----- VPC + Networking -----
@@ -169,7 +179,8 @@ Resources:
           #!/bin/bash
           set -euxo pipefail
           dnf update -y
-          dnf install -y docker git
+          # iproute-tc は `tc qdisc` (Phase 2 / Issue #606 ネットワーク劣化 cron) で使う。
+          dnf install -y docker git iproute-tc
           systemctl enable --now docker
           mkdir -p /usr/local/lib/docker/cli-plugins
           curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64" \
@@ -193,6 +204,70 @@ Resources:
           ENVEOF
 
           docker compose up -d --build
+
+          # ----- Phase 2 / Issue #606: EC2 劣化シミュレーション (= ネットワーク遅延注入) -----
+          #
+          # マイクロサービス分割の incentive (= EC2 残置の penalty) を実機で再現する。
+          # `DegradationMinutes` 分後に primary NIC へ `tc qdisc ... netem delay 200ms` を
+          # 流し、EC2 上の `/score` 応答時間が 1500ms threshold を超えやすくする
+          # (= polling Lambda 側で score < migration platform スコアに沈める)。
+          #
+          # ⚠️ 本 cron は **問題の仕掛け** であって malware ではない。再起動でも仕掛けが
+          #    効くように systemd timer に書き込み、`docker compose` 起動後の独立 unit
+          #    にしてある (= compose 失敗時は劣化を起こさない、運営トラブルシュート簡易化)。
+          PRIMARY_NIC="$(ip -o -4 route show to default | awk '{print $5}' | head -n1)"
+          if [[ -z "$PRIMARY_NIC" ]]; then
+            echo "[degradation] PRIMARY_NIC could not be detected, skip degradation setup" >&2
+          else
+            mkdir -p /opt/tenkacloud/degradation
+
+            # inject.sh は heredoc を 'INJECT' (quoted) で囲い、shell expansion を防ぐ。
+            cat > /opt/tenkacloud/degradation/inject.sh <<'INJECT'
+          #!/bin/bash
+          # 本 script は Phase 2 / Issue #606 の劣化シミュレーション。
+          # 200ms 遅延を primary NIC root qdisc に注入する。`add` が ALREADY EXISTS の
+          # 場合は `change` で冪等に上書きする (= timer 再 trigger でも崩れない)。
+          NIC="$1"
+          if [[ -z "$NIC" ]]; then
+            echo "[degradation] NIC unset, skip" >&2
+            exit 0
+          fi
+          /sbin/tc qdisc add dev "$NIC" root netem delay 200ms 2>/dev/null || \
+            /sbin/tc qdisc change dev "$NIC" root netem delay 200ms
+          echo "[degradation] netem delay 200ms applied on $NIC at $(date -Is)"
+          INJECT
+            chmod +x /opt/tenkacloud/degradation/inject.sh
+
+            # NIC 値を unit に焼き込む (= systemd は shell expansion しないので、書き出し時に展開)。
+            cat > /etc/systemd/system/tenkacloud-degradation.service <<UNIT
+          [Unit]
+          Description=TenkaCloud Microservice Migration Battle - EC2 network degradation (Phase 2 / #606)
+          After=docker.service network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/opt/tenkacloud/degradation/inject.sh $PRIMARY_NIC
+          UNIT
+
+            # OnBootSec で `DegradationMinutes` 分後に oneshot service を発火する。
+            # CFn `${DegradationMinutes}` は Fn::Sub で展開済 (= 例 60min)。
+            cat > /etc/systemd/system/tenkacloud-degradation.timer <<TIMER
+          [Unit]
+          Description=TenkaCloud Microservice Migration Battle - degradation trigger (boot + ${DegradationMinutes} min)
+
+          [Timer]
+          OnBootSec=${DegradationMinutes}min
+          Unit=tenkacloud-degradation.service
+          Persistent=true
+
+          [Install]
+          WantedBy=timers.target
+          TIMER
+
+            systemctl daemon-reload
+            systemctl enable --now tenkacloud-degradation.timer
+          fi
 
 Outputs:
   BaseUrl:


### PR DESCRIPTION
## Summary

Issue #606 (= #572 親) Phase 2 — Monolith → Microservices Migration Battle 用の
score engine を実装する。Phase 1 (PR-605) で deploy 済 EC2 モノリス問題に対し、
競技者が登録した移行先 endpoint を 1 分毎 polling し platform 別 + phase 別の
ポイントを加減算する。

- 新 DDB `MicroserviceMigrationScoresTable` (PK=TENANT#<id>#PROBLEM#... / SK=SLOT#<users|orders|catalog>, PROVISIONED 1/1)
- 新 Hono Lambda `MicroserviceMigrationRegistrationApiLambda` (`POST/GET /problems/microservice-migration-battle/endpoints`、tenant API + Cognito JWT)
- 新 polling Lambda `MicroserviceMigrationPollerLambda` (EventBridge `rate(1 minute)`、`/meta` + `/score` を probe → score 計算 → `writeScoreEvent` で ScoreEvent 発行)
- 採点表 (#572 issue body): -100 / EC2 pre +100 / EC2 post +10 / migrated +1000 / 応答 >1500ms -10 / 3 slot 全分離 +5000 lump-sum (one-shot)
- `degradationMinutes` (default 60) / `legacySwitchMinutes` (default 90) を Lambda env で受ける、deploy `createdAt` 基準で phase を計算
- `problems/battles/microservice-migration-battle/template.yaml` に `DegradationMinutes` CFn parameter + EC2 `OnBootSec` systemd timer (`tc qdisc netem delay 200ms`) を追加

## 設計判断

- 既存 `HealthCheckLambda` (= `scoring.kind=uptime`) は declared endpoint 用なので、競技者が動的登録する 3 slot 用に **独立した polling Lambda** を立てる (= scoring rule / cron tick の責務分離)。
- ScoreEvent 連携は既存 `writeScoreEvent` の `source` union を `microservice-migration` / `microservice-migration-bonus` に拡張する形で再利用 — Battle Portal / leaderboard と整合し shim 不要。security-battle-royale との混入を防ぐため source で区別。
- `fetch` 直接呼び出しは `health-check-handler` と同様、EventBridge tick 起動の outbound probe で tenant 認可フローに関与しないため exception。実 fetch は `probe.ts` に閉じ込め、test では `vi.mock` で差し替える。
- EC2 劣化は systemd timer (`OnBootSec=${DegradationMinutes}min`) で実装。CFn parameter から timer 値を焼き込み、Lambda env と同値運用。再起動でも仕掛けが効く + docker compose と独立 unit なので運営トラブルシュート時に劣化のみ無効化できる。
- `fullMigrationBonusAwarded` sentinel は users slot row 1 行に集約し ConditionExpression で one-shot 化。

## Regression 分析

- `writeScoreEvent` の `source` union 拡張: 既存 caller (uptime / flag / attack-detected) は型 union メンバー追加のみで挙動不変。`result` 決定で `microservice-migration` + points<0 のときだけ `down` になる分岐を追加。security-battle-royale 系の caller は新 source を渡さないので非関与。`score-event.test.ts` に新 source の test を 3 件追加。
- `ProblemDeployBackendStack`: DDB Table 4→5 / EventBridge Rule 4→5 に増加。test (`problem-deploy-backend-stack.test.ts`) の `resourceCountIs` を 5 に同期。Aspect 強制の 1/1 PROVISIONED は新テーブルにも適用済。
- 競技者 AWS account への AssumeRole は **発生しない** (= polling は運営側 account 内で完結、競技者の登録 URL を public HTTP で叩く)。`competitor-bootstrap.yaml` の IAM 変更は不要。
- EC2 UserData 変更は `dnf install iproute-tc` 一発の依存追加。`docker compose up` より後段で実行されるので compose 失敗時には劣化注入も走らない (= 整合性のある部分実行)。NIC 検出失敗時は graceful skip。`OnBootSec` は boot 経過時間ベースで CFn deploy 時刻と完全一致しないが (= 数十秒の boot 差) 競技時間スケールでは誤差 < 0.1%。

## 物理影響

- **CREATE**: DynamoDB Table × 1 (`MicroserviceMigrationScoresTable`), Lambda × 2 (Registration API + Poller), IAM Role × 2, EventBridge Rule × 1 (rate(1 minute)), API Gateway Resource × 2 (`/problems/microservice-migration-battle` + `/endpoints`), CfnOutput × 1
- **UPDATE**: `score-event.ts` shared module → bundled handler asset hash 更新 (HealthCheck / Portal Lambda asset hash も再計算)
- **UPDATE**: `problems/battles/microservice-migration-battle/template.yaml` (CFn parameter `DegradationMinutes` 追加 + UserData に systemd timer cron 追記)。本 template が deploy 済の microservice-migration-battle stack は CFn Update 対象 (parameter 追加は backward compatible、UserData は新規 EC2 でのみ反映 = 既存 instance は replace されない)
- **NO-OP**: tenant Cognito UserPool / Control Plane / 既存 Lambda の IAM Role / 競技者 IAM (`competitor-bootstrap.yaml`)
- **DELETE / REPLACE**: 無し

## Test plan

- [x] scoring.ts 単体 unit tests 15 件 (computePhase / resolveScorePath / scoreFromProbe 全分岐) — pass
- [x] registration handler routes / store tests 12 件 (`POST /endpoints` 200/400/500、`GET /endpoints`、`registerEndpoint` UpdateExpression が observation 列を触らない pin、`listEndpoints` フィルタ) — pass
- [x] poller handler tests 6 件 (登録 0 件 / 1 件 happy path / 3 slot 全分離 +5000 / bonus 二重発行防止 / 90 分後 legacy switch / probe 失敗時 -100) — pass
- [x] score-event.test.ts に `microservice-migration` (points>0 / <0) + `microservice-migration-bonus` の 3 ケース追加 — pass
- [x] CDK synth assertions (`problem-deploy-backend-stack.test.ts`): DDB Table 数 (4→5) / EventBridge Rule 数 (4→5) / Lambda env (`MICROSERVICE_MIGRATION_SCORES_TABLE_NAME` / `MICROSERVICE_MIGRATION_DEGRADATION_MINUTES` / `MICROSERVICE_MIGRATION_LEGACY_SWITCH_MINUTES`) / Output `MicroserviceMigrationScoresTableName` を pin — pass
- [x] `make typecheck` / `make test` (613 infra tests + 全 SPA tests) / `make lint` / `make check-http-status` / `make validate-problems` 全て green
- [ ] AWS への実 deploy (operator 担当): EC2 boot 60 分後に `tc qdisc` が当たり `/score` 応答時間 > 1500ms になることを CloudWatch Logs で確認
- [ ] 競技者 happy path (operator 担当): 3 slot を Lambda + ECS + App Runner に切り替えて +5000 lump-sum bonus が発火することを 1 度だけ

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microservice Migration Battle Phase 2 infrastructure with endpoint registration and automated scoring.
  * Users can now register service endpoints and receive scores based on platform migration progress and latency metrics.
  * Implemented automatic full-migration bonus awards and network degradation simulation capabilities.
  * Added tenant API routes for endpoint management (`POST`/`GET /problems/microservice-migration-battle/endpoints`).

* **Tests**
  * Added comprehensive test coverage for endpoint registration, scoring logic, and probe behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->