### PR TITLE
docs(ADR-012): Problem plugin architecture — 問題は plugin、platform は host

### DIFF
--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<title>ADR-012: Problem plugin architecture — 3 アセット + metadata DSL + platform 内 generic scoring Lambda</title>
+<title>ADR-012: Problem plugin architecture — 3-asset model + thick metadata DSL + platform-side generic scoring dispatcher</title>
 <style>
   :root {
     --c-text: #1f2328;
@@ -34,215 +34,133 @@
   .meta b { color: var(--c-muted); margin-right: .3rem; }
   .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
            font-weight: 600; line-height: 1.4; }
-  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
-  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
-  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.proposed { background: #fff8c5; color: var(--c-warn); }
   pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
-  .quote { border-left: 3px solid var(--c-warn); background: #fff8c5; padding: .5rem .9rem; margin: .8rem 0; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
   details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
   details > summary { cursor: pointer; font-weight: 600; }
 </style>
 </head>
 <body>
 <header>
-  <h1>ADR-012: Problem plugin architecture — 3 アセット + 厚 metadata DSL + platform 1 つの generic scoring Lambda</h1>
+  <h1>ADR-012: Problem plugin architecture</h1>
+  <p><em>3-asset model + thick metadata DSL + platform-side generic scoring dispatcher</em></p>
   <div class="meta">
-    <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-12</div>
-    <div><b>Trigger:</b> PR-608 (#606 Phase 2 score engine) close</div>
-    <div><b>Related ADR:</b>
+    <div><b>Status:</b> <span class="badge proposed">Proposed</span> 2026-05-12</div>
+    <div><b>Related:</b>
       <a href="./adr-001-problem-deploy-crud.html">ADR-001</a>、
       <a href="./adr-005-battle-portal-ui.html">ADR-005</a>、
-      ADR-008 (#574 user WIP)
-    </div>
-    <div><b>Related Issue:</b>
-      <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a>、
-      <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a>
+      <a href="./adr-008-problem-payload-separation.html">ADR-008</a>、
+      <a href="./adr-010-api-first-cli-mcp.html">ADR-010</a>
     </div>
   </div>
 </header>
 
 <section>
-<h2>ゲームの本質 — Platform が提供すべき要素</h2>
+<h2>Context</h2>
 
-<div class="quote">
-ユーザー指摘 (2026-05-12): 「<b>ゲームというものの本質を捉えていかないといかない</b>」「<b>Overcooked! 的に要素が積まれていて、マルチタスク・得点・妨害の要素が組み込めるようになっていればかなり面白くなる</b>」
-</div>
+<p>TenkaCloud は AWS マルチテナント SaaS の cloud competition platform。 競技問題は <code>problems/&lt;category&gt;/&lt;id&gt;/</code> ディレクトリに格納され、 platform の Worker Lambda が CloudFormation template を競技者 AWS account に deploy する (<a href="./adr-001-problem-deploy-crud.html">ADR-001</a>)。</p>
 
-<p>Overcooked! (= 協力料理アクション) の面白さは <strong>同時に進行する複数 task を限られた時間で捌く</strong> ところにある。 TenkaCloud Battle が「ゲーム」として面白くなる要素を分解すると:</p>
+<p>本 ADR 起草時点で 4 問題が repo 内に存在する:</p>
 
-<table>
-<thead><tr><th>Overcooked! 要素</th><th>TenkaCloud Battle に置換すると</th><th>Platform が提供する仕組み</th></tr></thead>
-<tbody>
-<tr><td>マルチタスク (= 焼く + 切る + 配膳を同時)</td>
-    <td>複数 endpoint slot を同時管理 / 複数 phase 進行 / 複数 disruption に対処</td>
-    <td>metadata の <code>endpoints[]</code> N slot / <code>phases[]</code> 多段 / <code>disruptions[]</code> 複数。 portal が同時に複数 panel で状態を表示</td></tr>
-<tr><td>Score (= リアルタイムにお皿が出る)</td>
-    <td>得点が動くのが視覚的に分かる</td>
-    <td>ScoreEvent stream の live 表示 / per-event delta animation / leaderboard リアルタイム更新 / 1 分間隔 polling で sparkline</td></tr>
-<tr><td>妨害 (= 床が動く / 火災 / 客の文句)</td>
-    <td>競技中の active 妨害 (S3 content swap / latency 注入 等)</td>
-    <td>metadata <code>disruptions[]</code> で declarative 宣言、 platform が時刻 / 条件 で発動を orchestrate、 operator UI で予告 / 即発動</td></tr>
-<tr><td>時間制限 + カオス累積</td>
-    <td>競技時間が進むほど妨害が重なる</td>
-    <td>phase 多段 (= 60min 劣化 → 90min legacy → 120min 終了 等)、 segment ごとの累積効果</td></tr>
-<tr><td>視覚的フィードバック (= "皿が割れた!")</td>
-    <td>状況を一目で把握できる UI</td>
-    <td>portal の StatusPanel に "次フェーズまで残り XX:XX" / 妨害発動時 toast / score delta の色付け</td></tr>
-<tr><td>チームプレイ</td>
-    <td>1 team 内で役割分担</td>
-    <td>team scope の portal (= 既存 ADR-005)、 同 team 内では同じ画面を共有</td></tr>
-</tbody>
-</table>
+<ul>
+<li><code>hello-world</code> (Challenge) — flag 提出型</li>
+<li><code>hello-world-battle</code> (Battle minimal) — uptime probe 型</li>
+<li><code>security-battle-royale</code> (Battle) — 攻撃検知 + 複数 endpoint 監視</li>
+<li><code>microservice-migration-battle</code> (Battle) — 多段 phase + 妨害 + 3 hosting platform 分類</li>
+</ul>
 
-<p>= <strong>これら 6 要素を組み合わせて 1 つの問題を構成できる platform にすれば、 problem author が「ゲームとしての面白さ」を design できる</strong>。 Authoring 体験がここに乗る:</p>
+<p>「Battle」 「Challenge」 は TenkaCloud 固有のカテゴリ用語 (= 対戦型 / 個別演習型) で、 AWS GameDay 等の業界標準用語ではない。</p>
+
+<h3>現状の課題</h3>
+
+<p>初期実装では、 個別問題の scoring logic / mid-contest disruption mechanism / dashboard を <code>infrastructure/lib/problem-deploy/</code> 配下の platform Lambda にハードコードする方向で進めた。 結果として:</p>
 
 <ol>
-<li>Author は metadata で「 N slot + N phase + N disruption」 を宣言</li>
-<li>Platform は各要素を generic に dispatch / 可視化</li>
-<li>競技者は同時進行を捌く面白さを体感</li>
+<li><strong>新問題追加が platform 改修を伴う</strong>: 例えば microservice-migration-battle の score engine は <code>handlers/microservice-migration-registration-handler/</code> という問題名付き Lambda を platform に追加する必要があった</li>
+<li><strong>問題固有 logic が複数 Lambda に散在</strong>: scoring / disruption / endpoint registration が別々の handler に分かれ、 問題ごとに platform を改造</li>
+<li><strong>第三者寄稿が困難</strong>: 問題を寄稿するために platform stack の改修が要るので、 contribution boundary が明確でない</li>
 </ol>
 
-<p><strong>Platform は building blocks を提供、problem author が組み立てる</strong> という構図 (= レゴブロック)。 1 つの block が無いと「ゲームらしさ」が落ちるので、 Phase 2-5 で 6 要素を漏れなく実装する。</p>
+<p>= <strong>問題が self-contained でなく、 platform を伴走改修する設計</strong> になっていた。</p>
 </section>
 
 <section>
-<h2>設計の山場: developer-friendly + AI-friendly な problem authoring</h2>
-
-<div class="quote">
-ユーザー指摘 (2026-05-12): 「この仕組みを誰でも実装で組み込めるようにプラットフォームで <b>ガイドしないと、問題が作れない / 誰も乗れないプラットフォーム</b>になってしまう」 「<b>開発者フレンドリー / AI フレンドリーに作らないと全くダメ</b>」 「ここが体験の見せ所、設計の山場」
-</div>
-
-<p>本 ADR の <strong>核心は問題作成体験</strong>。 3 アセット / 厚 metadata DSL / disruption 機構は すべて「人間 + AI agent が <strong>1 時間以内に新問題を ship できる</strong>」 ことを目的とする。 platform がどれだけ強力でも、 problem を作る人が居なければ何も起きない。</p>
-
-<h3>Developer-friendly な要件</h3>
-
-<ol>
-<li><strong>30 分 onboarding</strong>: 新規 problem author が初回 PR を出すまでの目標時間</li>
-<li><strong>Scaffolding コマンド</strong>: <code>tenkacloud problem create &lt;id&gt; --kind battle</code> で雛形 dir 生成 (metadata.json + template.yaml + portal/ + tests)</li>
-<li><strong>Local dev loop</strong>: <code>tenkacloud problem dev &lt;id&gt;</code> で localhost で問題を起動、 portal UI も local rendering、 metadata 変更で hot reload。AWS deploy 不要で iteration</li>
-<li><strong>Validation</strong>: <code>tenkacloud problem validate &lt;id&gt;</code> が
-  <ul>
-    <li>metadata DSL を JSON Schema で lint</li>
-    <li>template.yaml を cfn-lint</li>
-    <li>required endpoint / CFn output / disruption Lambda の存在確認</li>
-    <li>具体的なエラーメッセージ (= 「<code>scoring.kind</code> が unknown: <code>'phasing-pollign'</code> (= <code>'phased-polling'</code> の typo?)」)</li>
-  </ul>
-</li>
-<li><strong>Sample 問題が教材</strong>: 既存 4 問題 (hello-world / hello-world-battle / security-battle-royale / microservice-migration) を <strong>完成形 with rich コメント</strong> で配置。author は copy-paste-edit で済む</li>
-<li><strong>Documentation</strong>: <code>docs/problems/AUTHORING.html</code> で step-by-step 30 分 onboarding guide</li>
-</ol>
-
-<h3>AI-friendly な要件</h3>
-
-<ol start="7">
-<li><strong>JSON Schema に AI hint を埋める</strong>: 各 field に <code>description</code> / <code>examples</code> / <code>aiContext</code> (= "When in doubt about <code>scoring.kind</code>, default to <code>uptime-flat</code> for Challenge, <code>phased-polling</code> for Battle")</li>
-<li><strong><code>/create-problem</code> skill を AI 対話型に拡張</strong>: 「難易度は?」「想定時間?」「妨害種類?」「3rd party hosting?」 を AI に質問させ、 完成した metadata + template + portal を一気に生成</li>
-<li><strong>AGENTS.md に "Problem Authoring" セクション</strong>: AI agent が問題を作る時の参照リソース。 ヒューマン向け AUTHORING.html と pair で整備</li>
-<li><strong>既存問題が training data</strong>: 4 sample 問題は code comment / metadata description / portal component を <strong>AI が読んで模倣しやすい</strong> よう冗長気味に書く (= imperative 命令文 + WHY コメント)</li>
-</ol>
-
-<h3>Pattern library: 既存 4 sample を copy 元として配置</h3>
+<h2>Goals</h2>
 
 <table>
-<thead><tr><th>「こういう問題作りたい」</th><th>copy 元 sample</th></tr></thead>
+<thead><tr><th>軸</th><th>目標</th></tr></thead>
 <tbody>
-<tr><td>flag 提出だけの個別演習</td><td><code>hello-world</code> (Challenge)</td></tr>
-<tr><td>1 endpoint uptime 監視</td><td><code>hello-world-battle</code> (Battle minimal)</td></tr>
-<tr><td>複数 endpoint 監視 + 攻撃検知</td><td><code>security-battle-royale</code></td></tr>
-<tr><td>多段 phase + 妨害 + 3 hosting platform 分類</td><td><code>microservice-migration-battle</code></td></tr>
+<tr><td>責務分離</td><td>問題固有 logic は <code>problems/&lt;id&gt;/</code> 内で完結。 platform は generic dispatcher</td></tr>
+<tr><td>表現力</td><td>既存 4 問題 (flag / uptime / 多段 phase / 攻撃検知) を全カバー</td></tr>
+<tr><td>Authoring</td><td>30 分 onboarding 目標。 human + AI agent どちらも新問題を作れる</td></tr>
+<tr><td>Game design</td><td>マルチタスク / 得点 / 妨害 / 時間制限 を組み合わせやすい building blocks</td></tr>
+<tr><td>拡張</td><td>第三者寄稿 + <a href="./adr-008-problem-payload-separation.html">ADR-008</a> private repo separation と整合</td></tr>
 </tbody>
 </table>
-
-<h3>Claude Code skill + template library が AI-friendly authoring の核</h3>
-
-<p>ユーザー指摘 (2026-05-12): 「<strong>Claude Code の skill として問題作成を組み込んだりテンプレートを用意したりする必要がある</strong>」</p>
-
-<table>
-<thead><tr><th>component</th><th>役割</th></tr></thead>
-<tbody>
-<tr><td><strong><code>.claude/skills/create-problem/</code> の拡張</strong></td>
-    <td>既存 skill を新 metadata DSL 対応に拡張。 AI 対話で問題定義 (= category / kind / endpoints / disruptions) を聞き出し、 完成形 dir を生成。 既存問題を context として AI に渡し模倣を促す</td></tr>
-<tr><td><strong><code>.claude/templates/problems/&lt;kind&gt;/</code></strong></td>
-    <td>5 kind 各々の skeleton template。 <code>tenkacloud problem create</code> が copy 元として使う。 各 kind の完成形に近い metadata + template.yaml + portal/ + tests を含む</td></tr>
-<tr><td><strong>AGENTS.md "Problem Authoring" セクション</strong></td>
-    <td>AI agent が問題を作る時の context 集約: 「skill 呼び方 / template 場所 / 既存 4 sample の URL / metadata DSL の JSON Schema / よくある落とし穴」</td></tr>
-<tr><td><strong>JSON Schema の <code>aiContext</code> field</strong></td>
-    <td>標準の <code>description</code> に加え AI 向け hint を埋める (= 「<code>scoring.kind</code> 選び方の判断軸: Challenge なら <code>flag</code> / <code>uptime-flat</code>、 Battle で時刻依存採点なら <code>phased-polling</code>」 等)</td></tr>
-<tr><td><strong>4 sample 問題の rich コメント</strong></td>
-    <td>code comment / metadata description / portal component を AI 模倣しやすい imperative + WHY コメント密度で書く (= existing 4 problems を training data 化)</td></tr>
-</tbody>
-</table>
-
-<h3>CLI 一覧 (= ADR-010 #578 と統合)</h3>
-
-<pre>tenkacloud problem create &lt;id&gt; --kind &lt;flag|uptime-flat|uptime-multi|phased-polling|attack-detection&gt;
-tenkacloud problem dev &lt;id&gt;
-tenkacloud problem validate &lt;id&gt;
-tenkacloud problem package &lt;id&gt;
-tenkacloud problem publish &lt;id&gt; --env &lt;staging|production&gt;</pre>
-
-<p><strong>この CLI + Claude Code skill + template + 4 sample が揃わなければ ADR-012 はどんなに綺麗でも実用化されない</strong>。 Phase 2 で必ず ship。</p>
-
-<p><em>注: 「Battle」 は TenkaCloud 固有の用語 (= 対戦型問題カテゴリ)。 AWS GameDay 等の用語ではないので、外部資料と並べる時は明確に区別する。</em></p>
 </section>
 
 <section>
-<h2>1 枚で分かる構造</h2>
+<h2>Decision</h2>
+
+<h3>3-asset model</h3>
 
 <pre>problems/&lt;id&gt;/
-├── metadata.json    # 厚 DSL    = endpoint slot / 採点 rule / phase / 攻撃 / dashboard slot を全部宣言
-├── template.yaml    # ①リソース = 競技者 AWS account に立つ CFn。passive 仕掛け (= cron 等) 同梱可
-└── portal/          # ②ダッシュボード = Battle 固有 UI (Challenge は不要、generic 流用)</pre>
+├── metadata.json    # 厚 DSL: endpoint slot / scoring rule / phase / disruption / dashboard slot 宣言
+├── template.yaml    # ① Resources: 競技者 AWS account に立つ CFn (passive 仕掛けはここに同梱可)
+└── portal/          # ② Dashboard: Battle 固有 UI (Challenge は generic 流用、 dir 自体省略可)</pre>
+
+<p>「採点 Lambda」 や「engine Lambda」 を <code>problems/&lt;id&gt;/</code> 内に持たせない。 problem authors は <strong>コード 0 行</strong> (= metadata + CFn template + 任意 portal component) で新問題を作れることを目標とする。 採点 logic は metadata DSL で declarative に表現し、 platform 側に 1 つの generic scoring Lambda が dispatcher として動く。</p>
+
+<h3>Platform-side runtime</h3>
 
 <table>
-<thead><tr><th></th><th>採点 (= 観測 → score)</th><th>攻撃 (= 時間駆動の状態変化)</th></tr></thead>
+<thead><tr><th>Component</th><th>役割</th></tr></thead>
 <tbody>
-<tr><td><strong>誰が宣言</strong></td><td>問題側 <code>metadata.json</code></td><td>問題側 (template.yaml or metadata.json)</td></tr>
-<tr><td><strong>誰が実行</strong></td><td>platform 内 1 つの generic scoring Lambda</td><td>passive: 競技者 account 内の cron/Lambda (= template.yaml 同梱) / active: platform scoring Lambda が metadata phase 宣言に従って分岐</td></tr>
-<tr><td><strong>問題側の Lambda コード</strong></td><td><strong>なし</strong> (= 問題ごとに Lambda 立てるとぐちゃぐちゃになる、ユーザー指摘 5 / 2026-05-12)</td><td>なし</td></tr>
+<tr><td><strong>Deploy worker</strong> (既存)</td><td><code>template.yaml</code> を競技者 account に CFn deploy</td></tr>
+<tr><td><strong>Endpoint registry</strong></td><td>(1) deploy 時に CFn output から default URL を team ごと set (2) 競技者の override を受付 (3) effective URL (= override || default) を scoring に渡す</td></tr>
+<tr><td><strong>Generic scoring Lambda</strong></td><td>1 分間隔で全 (tenant × team × problem × slot) を iterate。 metadata.<code>scoring.kind</code> を読んで 5 種の builtin handler に dispatch。 ScoreEvent stream に emit</td></tr>
+<tr><td><strong>Portal plugin loader</strong></td><td>participant-portal が metadata.<code>dashboard.slots</code> を読んで該当 component を S3 から <code>React.lazy</code> で動的 load</td></tr>
 </tbody>
 </table>
 
-<p><strong>新問題追加 = この dir 1 個 git add するだけ</strong>。platform は触らない。 metadata DSL が表現できる範囲なら code 0 行で新問題が動く。</p>
-</section>
-
-<section>
-<h2>ユーザー指摘 (= 設計の制約)</h2>
-
-<div class="quote">
-2026-05-12 順序付きで:<br>
-<b>1.</b>「採点 / リソース / ダッシュボードが欲しい機能」<br>
-<b>2.</b>「攻撃とかの仕組みは問題側のコード (= template / metadata) で作ればいい」<br>
-<b>3.</b>「Challenge は共通化できる、Battle は柔軟性が必要」<br>
-<b>4.</b>「endpoint は default を問題で指定、競技者が override 可能」<br>
-<b>5.</b>「採点 Lambda は platform 側に 1 個、問題ごとに立てない (= ぐちゃぐちゃ防止)」<br>
-<b>6.</b>「endpoint 数と default 値 (= deploy 時 CFn output から team ごと set) を指定できないといけない」<br>
-<b>7.</b>「だからかなり metadata の作り込みをしないといけない」
-</div>
-
-<p>= <strong>厚 metadata DSL で問題固有性を吸収し、platform は generic 1 個に保つ</strong>。</p>
-</section>
-
-<section>
-<h2>厚 metadata DSL (= 本 ADR の主役)</h2>
-
-<h3>骨子</h3>
-
-<p>metadata.json で次を宣言できる必要がある:</p>
+<p><strong>5 種の builtin scoring kind</strong>:</p>
 
 <table>
-<thead><tr><th>領域</th><th>宣言する内容</th><th>例 (microservice-migration)</th></tr></thead>
+<thead><tr><th>kind</th><th>用途</th><th>例</th></tr></thead>
 <tbody>
-<tr><td>endpoint slot</td><td>N 個の slot 名 / default URL の取得元 / override 可否</td><td>3 slot (users / orders / catalog)、deploy 時 CFn output <code>Ec2BaseUrl</code> + appendPath で default を team ごとに set、競技者は override 可</td></tr>
-<tr><td>採点 kind</td><td>5 つの builtin から選択 (flag / uptime-flat / uptime-multi / phased-polling / attack-detection)</td><td><code>phased-polling</code></td></tr>
-<tr><td>採点 rule</td><td>kind に応じた detail パラメータ (= 配点表 / platform 分類 / bonus 条件 等)</td><td>下記 "phased-polling" の details</td></tr>
-<tr><td>phase 進行</td><td>deploy からの経過時間で switch する rule</td><td>60 min: EC2 degradation 開始 / 90 min: scoring path を <code>/score?legacy=true</code> に切替</td></tr>
-<tr><td>dashboard slot</td><td>portal の標準 slot に対する custom component の有無 (= "RegistrationPanel" / "StatusPanel" 等)</td><td>StatusPanel + RegistrationPanel に custom 指定</td></tr>
+<tr><td><code>flag</code></td><td>1 回提出型、 StackOutput と比較</td><td>hello-world</td></tr>
+<tr><td><code>uptime-flat</code></td><td>固定 endpoint 群を polling、 ok=+pt / fail=skip</td><td>hello-world-battle</td></tr>
+<tr><td><code>uptime-multi</code></td><td>N 個 endpoint を全 probe、 全 OK で配点</td><td>security-battle-royale (= main + admin 同時生存)</td></tr>
+<tr><td><code>phased-polling</code></td><td>時刻で score rule が変わる、 platform 分類 / bonus 対応</td><td>microservice-migration-battle</td></tr>
+<tr><td><code>attack-detection</code></td><td>CloudWatch Logs / StackOutput の counter から攻撃数で配点</td><td>security-battle-royale の攻撃検知部</td></tr>
 </tbody>
 </table>
 
-<h3>具体例: microservice-migration-battle</h3>
+<p>5 種で表現できない問題が出た時は本 ADR の拡張で kind を増やす。 「問題ごとに Lambda を立てる」 ことはしない。</p>
 
+<h3>Endpoint model: default + override の slot</h3>
+
+<p>各 endpoint は <code>metadata.endpoints[]</code> で slot として宣言する。</p>
+
+<table>
+<thead><tr><th>要素</th><th>説明</th></tr></thead>
+<tbody>
+<tr><td><strong>slot</strong></td><td>問題が宣言する endpoint の役割名 (例: <code>main</code> / <code>admin</code> / <code>users</code>)</td></tr>
+<tr><td><strong>default URL</strong></td><td>CFn output から team ごとに deploy 時 set (= 固定値も可)</td></tr>
+<tr><td><strong>override</strong></td><td>競技者が portal UI で別 URL に変更可能。 effective URL = <code>override ?? default</code></td></tr>
+</tbody>
+</table>
+
+<p>この model は次のケースを 1 contract で吸収する:</p>
+
+<ul>
+<li><strong>1 endpoint</strong> (例: hello-world-battle) — slot 1 個、 CFn output から default、 競技者は通常 override しない</li>
+<li><strong>N endpoint</strong> (例: security-battle-royale) — slot N 個、 default は CFn output、 競技者が WAF / CDN を被せたら override</li>
+<li><strong>N slot を競技者が後追い登録</strong> (例: microservice-migration-battle) — default は EC2 path、 Lambda / ECS / App Runner に切り出したら slot ごとに override</li>
+</ul>
+
+<details>
+<summary>metadata.json 例 (microservice-migration-battle)</summary>
 <pre>{
   "id": "microservice-migration-battle",
   "category": "Battle",
@@ -250,31 +168,15 @@ tenkacloud problem publish &lt;id&gt; --env &lt;staging|production&gt;</pre>
   "estimatedMinutes": 120,
 
   "endpoints": [
-    {
-      "slot": "users",
-      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/users" },
-      "overridable": true,
-      "label": "users service URL"
-    },
-    {
-      "slot": "orders",
-      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/orders" },
-      "overridable": true
-    },
-    {
-      "slot": "catalog",
-      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/catalog" },
-      "overridable": true
-    }
+    { "slot": "users",   "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/users" },   "overridable": true },
+    { "slot": "orders",  "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/orders" },  "overridable": true },
+    { "slot": "catalog", "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/catalog" }, "overridable": true }
   ],
 
   "scoring": {
     "kind": "phased-polling",
     "intervalMinutes": 1,
-    "probe": {
-      "metaPath": "/meta",          // 各 slot で platform 自己申告を読む
-      "scorePath": "/score"
-    },
+    "probe": { "metaPath": "/meta", "scorePath": "/score" },
     "platformRules": {
       "ec2":       { "points": 100,  "degradedPoints": 10 },
       "lambda":    { "points": 1000 },
@@ -282,359 +184,214 @@ tenkacloud problem publish &lt;id&gt; --env &lt;staging|production&gt;</pre>
       "apprunner": { "points": 1000 }
     },
     "failurePenalty": -100,
-    "responsePenalties": [
-      { "if": "responseTimeMs > 1500", "points": 10 }
-    ],
+    "responsePenalties": [ { "if": "responseTimeMs > 1500", "points": 10 } ],
     "bonuses": [
       { "kind": "all-slots-on-platforms", "platforms": ["lambda","ecs","apprunner"], "points": 5000, "once": true }
     ]
   },
 
   "phases": [
-    {
-      "name":  "degraded",
-      "afterMinutes": 60,
-      "effect": { "switchPlatformToDegraded": ["ec2"] }
-    },
-    {
-      "name":  "legacy",
-      "afterMinutes": 90,
-      "effect": { "scorePathOverride": "/score?legacy=true" }
-    }
+    { "name": "degraded", "afterMinutes": 60, "effect": { "switchPlatformToDegraded": ["ec2"] } },
+    { "name": "legacy",   "afterMinutes": 90, "effect": { "scorePathOverride": "/score?legacy=true" } }
   ],
 
   "dashboard": {
     "slots": {
       "RegistrationPanel": "portal/RegistrationPanel.tsx",
       "StatusPanel":       "portal/StatusPanel.tsx"
-    },
-    "routes": [
-      { "path": "/migration-help", "component": "portal/MigrationGuide.tsx" }
-    ]
+    }
   }
 }</pre>
+</details>
 
-<p>= <strong>~50 行 JSON で問題の全ロジックが宣言される</strong>。Platform 側に問題固有 Lambda は一切要らない。</p>
+<h3>Disruption model</h3>
 
-<h3>採点 kind の 5 つ (= MVP set、必要なら拡張)</h3>
+<p>Battle problem で要求される mid-contest 条件変更 (= S3 静的コンテンツ swap / EC2 latency 注入 / IAM 剥奪等) は 2 phase で実装する。</p>
 
-<table>
-<thead><tr><th>kind</th><th>用途</th><th>例</th></tr></thead>
-<tbody>
-<tr><td><code>flag</code></td><td>1 回提出型、StackOutput 値と比較</td><td><code>hello-world</code></td></tr>
-<tr><td><code>uptime-flat</code></td><td>固定 endpoint 群を polling、ok=+pt / fail=skip</td><td><code>hello-world-battle</code></td></tr>
-<tr><td><code>uptime-multi</code></td><td>N 個の endpoint を全部 probe、 全 OK で配点</td><td><code>security-battle-royale</code> (= main + admin の両方が生きてないと点取れない)</td></tr>
-<tr><td><code>phased-polling</code></td><td>時間で score 計算 rule が変わる、platform 分類 / bonus 対応</td><td><code>microservice-migration-battle</code></td></tr>
-<tr><td><code>attack-detection</code></td><td>CloudWatch Logs / stack output の counter を読んで攻撃数で配点</td><td><code>security-battle-royale</code> の attack 検知部分</td></tr>
-</tbody>
-</table>
-</section>
+<h4>Disruption Phase 1 (本 ADR): Self-triggered via template.yaml-bundled Scheduler</h4>
 
-<section>
-<h2>Platform 側 = 1 つの generic scoring Lambda + endpoint registry + portal loader</h2>
-
-<table>
-<thead><tr><th>platform 機能</th><th>役割</th><th>備考</th></tr></thead>
-<tbody>
-<tr><td><strong>Deploy</strong></td><td>template.yaml を競技者 account に CFn deploy</td><td>既存 (ADR-001 / ADR-002)</td></tr>
-<tr><td><strong>Endpoint registry</strong></td><td>(1) deploy 時に CFn output から default URL を抽出して per-team で書き込む (2) 競技者の override を受け付ける (3) effective URL (override || default) を scoring に渡す</td><td>新規。1 つの DDB <code>ProblemEndpoints</code></td></tr>
-<tr><td><strong>Generic scoring Lambda</strong></td><td>1 min 毎に全 (tenant × team × problem × slot) を iterate。各問題の metadata <code>scoring.kind</code> を読んで分岐 (= 5 kind の builtin handler)。phase 進行は metadata の <code>phases</code> 配列から経過時間で評価。ScoreEvent を発行</td><td><strong>新規・platform 1 つ・全問題で共有</strong>。 既存 health-check-handler を refactor して取り込む</td></tr>
-<tr><td><strong>Portal plugin loader</strong></td><td>participant-portal が metadata.<code>dashboard.slots</code> を読んで該当 component を S3 から <code>React.lazy</code> 動的 load</td><td>新規、Battle 用</td></tr>
-</tbody>
-</table>
-
-<p><strong>Platform は 5 kind の builtin scoring を持つだけで全問題に対応</strong>。問題が 5 kind で表現できなければ ADR を 1 個増やす (= 6 つ目の kind を足す)。Lambda は増えない。</p>
-</section>
-
-<section>
-<h2>Challenge と Battle のスタンス差</h2>
-
-<table>
-<thead><tr><th></th><th>Challenge</th><th>Battle</th></tr></thead>
-<tbody>
-<tr><td>性格</td>
-    <td>静的・個別演習</td>
-    <td>動的・対戦型、時間駆動の攻撃 / phase / 多段</td></tr>
-<tr><td>metadata の厚さ</td>
-    <td><strong>薄い</strong> (= <code>kind: flag</code> + flagOutputKey 等の数 field)</td>
-    <td><strong>厚い</strong> (= endpoint slot 多段 / phase / platform 分類 / bonus / dashboard slot を詰める)</td></tr>
-<tr><td>template.yaml</td>
-    <td>flag を出す CFn のみ</td>
-    <td>CFn + passive 仕掛け cron 同梱可</td></tr>
-<tr><td>portal/</td>
-    <td><strong>不要</strong> (generic flag form 流用)</td>
-    <td><strong>必要</strong> (Battle 固有 UI を custom component で)</td></tr>
-<tr><td>新問題追加コスト</td>
-    <td>metadata + template ほぼコピペ</td>
-    <td>metadata 厚く書く + portal component 数本 + template の仕掛け設計</td></tr>
-</tbody>
-</table>
-</section>
-
-<section>
-<h2>portal plugin contract (= ② asset の中身)</h2>
-
-<p>participant-portal が runtime で動的 load する React module。metadata の <code>dashboard.slots</code> で「どの標準 slot に custom component を挿すか」を宣言。</p>
-
-<pre>// problems/&lt;id&gt;/portal/StatusPanel.tsx (= 例)
-import type { PortalSlotProps } from "@tenkacloud/portal-plugin-sdk";
-
-export default function StatusPanel({ team, endpoints, scores, phase, nextPhaseAt }: PortalSlotProps) {
-  return (
-    &lt;Container&gt;
-      &lt;Header&gt;3 slot 状態&lt;/Header&gt;
-      {Object.entries(endpoints).map(([slot, url]) =&gt; (
-        &lt;Box key={slot}&gt;{slot}: {url} / score {scores[slot]}&lt;/Box&gt;
-      ))}
-      &lt;Box&gt;次フェーズまで残り {formatCountdown(nextPhaseAt)}&lt;/Box&gt;
-    &lt;/Container&gt;
-  );
-}</pre>
-
-<table>
-<thead><tr><th>項目</th><th>仕様</th></tr></thead>
-<tbody>
-<tr><td>build</td><td>Vite で plugin 単体を ESM bundle 化 (~50 KB target)、S3 配信</td></tr>
-<tr><td>load</td><td>portal が <code>React.lazy(() =&gt; import(/* @vite-ignore */ pluginUrl))</code></td></tr>
-<tr><td>共有 design system</td><td>Cloudscape は SDK 経由で peer-dep (= bundle 二重化を避ける)</td></tr>
-<tr><td>CSP</td><td>portal hosting で plugin URL を <code>script-src</code> 許可リスト化</td></tr>
-<tr><td>SDK</td><td><code>@tenkacloud/portal-plugin-sdk</code> が <code>PortalSlotProps</code> 等の型を export</td></tr>
-</tbody>
-</table>
-</section>
-
-<section>
-<h2>Disruption mechanism (= 妨害 / mid-contest 条件変更)</h2>
-
-<p>Battle 問題ではコンテスト中に「S3 コンテンツが攻撃後版に差し替わる」「EC2 に latency 注入」「IAM が剥奪される」などの <strong>妨害 / 条件変更</strong> を仕掛ける。 ユーザー指摘 (2026-05-12):</p>
-
-<div class="quote">
-「application 管理用の画面で <b>どこでどのような妨害をいれるか / 変えられるように</b> しておかないといけない」<br>
-「問題アカウントに <b>遅延なく</b> 展開できないといけない」
-</div>
-
-<h3>2 つの仕組み</h3>
-
-<table>
-<thead><tr><th></th><th>① Operator UI</th><th>② Cross-account event transport</th></tr></thead>
-<tbody>
-<tr><td>場所</td>
-    <td>application-admin-console 内 "Disruption Planner" page (新規)</td>
-    <td>Platform 中央 EventBridge bus → 競技者 account 内 rule + Lambda</td></tr>
-<tr><td>役割</td>
-    <td>operator が妨害種類 / 時刻 / 強度を画面で edit、Trigger NOW で即発火</td>
-    <td>Platform から PutEvents → 競技者 account の Lambda が ~1 秒で実行</td></tr>
-<tr><td>必要権限</td>
-    <td>Tenant Admin JWT</td>
-    <td>EventBridge bus policy で competitor account を許可 (= AssumeRole 不要)</td></tr>
-</tbody>
-</table>
-
-<h3>① Operator UI 要件</h3>
+<p>template.yaml に EventBridge Scheduler + Disruption Lambda を bake する。 deploy 時刻 + offset で self-fire。 platform は cross-account write 権限を持たず、 全ロジックが競技者 account 内で完結する。</p>
 
 <ul>
-<li><strong>Disruption catalog 表示</strong>: metadata.<code>disruptions[]</code> で問題が宣言した妨害種類を一覧</li>
-<li><strong>Per-team / per-disruption の schedule 表</strong>: 「team-A の S3 swap → 14:00 予定 / team-B キャンセル」</li>
-<li><strong>Edit</strong>: trigger 時刻 / パラメータ (= 妨害強度 / target slot / コンテンツ variant 等) を画面で変更</li>
-<li><strong>Trigger NOW</strong>: schedule を待たず即発火</li>
-<li><strong>All-teams broadcast</strong>: 「全 team の S3 swap を 5 min 後に同時発動」</li>
-<li><strong>Cancel</strong>: 予定中の disruption を取消</li>
+<li><strong>operator UI</strong>: problem deploy 前に application-admin-console で disruption parameters / timing を設定。 値は CFn parameter として template.yaml の Scheduler に注入される</li>
+<li><strong>blast radius</strong>: 1 team 1 deploy に閉じる</li>
+<li><strong>制約</strong>: deploy 後に動的変更不可 (= 変更には CFn update が必要)</li>
 </ul>
 
-<h3>② Cross-account event transport の配線</h3>
+<details>
+<summary>template.yaml 例 (= S3 content swap disruption)</summary>
+<pre>Parameters:
+  ContentSwapAfterMinutes: { Type: Number, Default: 60 }
 
-<pre>[application-admin-console (operator)]
-        │
-        ▼ "Trigger NOW" click
-[Platform DisruptionApi Lambda] ──┐
-                                   │
-[Platform EventBridge Scheduler] ──┘  (scheduled fire も同経路)
-        │
-        ▼ PutEvents (= e.g. "disruption.s3-content-swap")
-[Platform central EventBridge bus "tenkacloud-disruption"]
-        │
-        ├─→ team-A account ▶ EventBridge rule ▶ DisruptionHandler Lambda
-        ├─→ team-B account ▶ EventBridge rule ▶ DisruptionHandler Lambda
-        └─→ ... (= 全 team、 sub-second 配信)</pre>
+Resources:
+  ContentBucket: { Type: AWS::S3::Bucket, ... }
 
-<p><strong>EventBridge cross-account を選ぶ理由</strong>:</p>
-
-<ul>
-<li><strong>AssumeRole 不要</strong> = ADR-009 (#459) の federation を read-only に保てる、 write 経路を別 IAM で発行する必要なし</li>
-<li><strong>Sub-second 配信</strong> = ユーザー要件「遅延なく」を満たす</li>
-<li><strong>N team scaling 不要</strong> = Platform は 1 回 PutEvents するだけ、各 team の rule subscription が独立に拾う</li>
-<li><strong>blast radius = 1 team account に閉じる</strong> = DisruptionHandler Lambda は自 team の resources にしか触れない</li>
-</ul>
-
-<h3>metadata.json での宣言例</h3>
-
-<pre>{
-  "disruptions": [
-    {
-      "id": "content-swap",
-      "name": "S3 静的コンテンツを攻撃後版に差替",
-      "defaultAfterMinutes": 60,
-      "operatorEditable": ["afterMinutes", "contentVariant"],
-      "parameters": {
-        "contentVariant": {
-          "type": "enum",
-          "options": ["broken", "vandalized", "phishing"],
-          "default": "broken"
-        }
-      },
-      "eventDetailType": "disruption.content-swap"
-    },
-    {
-      "id": "latency-injection",
-      "name": "EC2 に latency 注入",
-      "defaultAfterMinutes": 30,
-      "operatorEditable": ["afterMinutes", "delayMs"],
-      "parameters": {
-        "delayMs": { "type": "int", "default": 200, "min": 50, "max": 2000 }
-      },
-      "eventDetailType": "disruption.latency-injection"
-    }
-  ]
-}</pre>
-
-<h3>template.yaml の受信側</h3>
-
-<pre>Resources:
-  # 競技者 account 内、Platform からの event を受ける専用 bus
-  DisruptionEventBus:
-    Type: AWS::Events::EventBus
-    Properties: { Name: !Sub "tenkacloud-disruption-${TeamId}" }
-
-  # Platform account からの PutEvents を許可
-  CrossAccountSource:
-    Type: AWS::Events::EventBusPolicy
-    Properties:
-      EventBusName: !Ref DisruptionEventBus
-      StatementId: tenkacloud-allow-platform
-      Statement:
-        Effect: Allow
-        Principal: { AWS: !Sub "arn:aws:iam::${TenkaCloudAccountId}:root" }
-        Action: events:PutEvents
-        Resource: !GetAtt DisruptionEventBus.Arn
-
-  # 妨害種別ごとに rule + Lambda (= metadata.disruptions[] と 1:1)
-  ContentSwapRule:
-    Type: AWS::Events::Rule
-    Properties:
-      EventBusName: !Ref DisruptionEventBus
-      EventPattern:
-        detail-type: ["disruption.content-swap"]
-        detail: { teamId: [!Ref TeamId] }
-      Targets:
-        - Arn: !GetAtt ContentSwapLambda.Arn
-
-  ContentSwapLambda:
+  SwapContentFunction:
     Type: AWS::Lambda::Function
     Properties:
       Code:
         ZipFile: |
           import boto3
           def handler(event, _):
-              variant = event["detail"]["parameters"]["contentVariant"]
               boto3.client("s3").copy_object(
                 Bucket="<bucket>", Key="index.html",
-                CopySource=f"<bucket>/_staging/{variant}/index.html"
-              )</pre>
+                CopySource="<bucket>/_staging/post-attack/index.html"
+              )
 
-<h3>Platform 側に追加するもの</h3>
-
-<table>
-<thead><tr><th>component</th><th>役割</th></tr></thead>
-<tbody>
-<tr><td><strong>DisruptionApi Lambda</strong></td>
-    <td>application-admin-console から受ける CRUD: <code>POST /events/:id/disruptions</code> (schedule 設定) / <code>POST .../disruptions/:id/trigger-now</code> / <code>DELETE .../disruptions/:id</code></td></tr>
-<tr><td><strong>DisruptionSchedule DDB</strong></td>
-    <td>Per (tenant, event, team, disruptionId) の予定情報 (= triggerAt / parameters / status) を保管。PROVISIONED 1/1</td></tr>
-<tr><td><strong>EventBridge Scheduler</strong></td>
-    <td>schedule された disruption の予定時刻 invoke 用。 1 つの central scheduler が DDB を見て fire する model</td></tr>
-<tr><td><strong>Central EventBridge bus "tenkacloud-disruption"</strong></td>
-    <td>全 competitor account が subscribe する publish-only bus</td></tr>
-</tbody>
-</table>
-
-<h3>operator UI mockup</h3>
-
-<details>
-<summary>Disruption Planner page (展開)</summary>
-<pre>┌─────────────────────────────────────────────────────────────────┐
-│  Spring Contest 2026 (event-01HZX...) &gt; 妨害設定               │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│ 全 team broadcast:  [全 team の content-swap を] [5min 後] [発動]│
-│                                                                 │
-│ ┌──────────┬──────────────────┬──────────┬─────────────────┐  │
-│ │ team     │ disruption       │ 予定時刻   │ 操作             │  │
-│ ├──────────┼──────────────────┼──────────┼─────────────────┤  │
-│ │ team-A   │ content-swap     │ 14:00:00 │ Edit  NOW  Cancel│  │
-│ │ team-A   │ latency-injection│ 13:30:00 │ Edit  NOW  Cancel│  │
-│ │ team-B   │ content-swap     │ 14:00:00 │ Edit  NOW  Cancel│  │
-│ │ team-B   │ latency-injection│ — (取消)  │ Restore          │  │
-│ │ team-C   │ ...              │ ...      │ ...              │  │
-│ └──────────┴──────────────────┴──────────┴─────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘</pre>
+  Phase2Schedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      ScheduleExpression: !Sub "rate(${ContentSwapAfterMinutes} minutes)"
+      Target: { Arn: !GetAtt SwapContentFunction.Arn }</pre>
 </details>
 
-<p>= operator は「 team-A だけ EC2 latency を 200ms → 500ms に上げる」「team-C の content swap を 1 min 後に NOW 発動」 等を画面で操作可能。 全部 sub-second で全 competitor account に反映される。</p>
+<h4>Disruption Phase 2 (Future, separate ADR): Condition-triggered by platform</h4>
+
+<p>scoring Lambda が観測条件 (= 競技者 score / 経過時間 / 任意 metric) を検知し、 cross-account EventBridge 経由で sub-second に disruption を trigger する。 operator は runtime に強度 / timing を動的調整できる。 詳細は別 ADR で扱う。</p>
 </section>
 
 <section>
-<h2>段階的ロールアウト</h2>
+<h2>Game design building blocks</h2>
+
+<p>Battle problem を「ゲームとして面白い」 ものにするための 6 building blocks を platform が提供する。 problem author はこれらを組み合わせて作る。</p>
 
 <table>
-<thead><tr><th>Phase</th><th>scope</th></tr></thead>
+<thead><tr><th>Element</th><th>Mechanism (platform-provided)</th></tr></thead>
 <tbody>
-<tr><td>1 (本 PR)</td><td>ADR 採択。metadata DSL の schema 詳細を確定 (= JSON schema 草案 + 5 kind 各々の rule field)</td></tr>
-<tr><td>2</td><td><code>problems/SCHEMA.json</code> を拡張。既存 3 問題 (hello-world / hello-world-battle / security-battle-royale) の metadata を新 DSL に書き直す (= 既存挙動 unchanged)</td></tr>
-<tr><td>3</td><td>endpoint registry (DDB + API) と generic scoring Lambda (5 kind builtin handler) を実装。 既存 health-check-handler / submit-flag handler を generic scoring Lambda に統合 refactor</td></tr>
-<tr><td>4</td><td><code>microservice-migration-battle</code> の Phase 2 (= score engine) を本 DSL で再実装 (= PR-608 の代替)。 problem dir に <code>portal/</code> 追加</td></tr>
-<tr><td>5</td><td>portal plugin loader 実装 (= React.lazy + CSP + SDK package <code>@tenkacloud/portal-plugin-sdk</code> 公開)</td></tr>
-<tr><td>6</td><td>ADR-008 (#574) 統合 — metadata + template + portal の private 配信 (= 答え漏れ防止)</td></tr>
+<tr><td>マルチタスク</td><td>metadata <code>endpoints[]</code> N slot / <code>phases[]</code> 多段 / <code>disruptions[]</code> 複数。 portal が同時に複数 panel で状態表示</td></tr>
+<tr><td>Score visualization</td><td>ScoreEvent stream の live 表示 / per-event delta animation / leaderboard リアルタイム更新 / 1 分 polling での sparkline</td></tr>
+<tr><td>Disruption</td><td>template.yaml-bundled Scheduler + Disruption Lambda (Phase 1)、 metadata <code>disruptions[]</code> で predict / portal で予告表示</td></tr>
+<tr><td>Time pressure</td><td><code>event.endsAt</code> / <code>phases[].afterMinutes</code> による段階的 close (= 既存 <a href="./adr-005-battle-portal-ui.html">ADR-005</a>)</td></tr>
+<tr><td>Visual feedback</td><td>portal StatusPanel の countdown / toast notification / score delta 色付け</td></tr>
+<tr><td>Team play</td><td>team scope の portal (= 既存 <a href="./adr-005-battle-portal-ui.html">ADR-005</a>、 ADR-004)</td></tr>
 </tbody>
 </table>
+</section>
+
+<section>
+<h2>Authoring experience</h2>
+
+<p>Plugin architecture を提供しても、 problem author の onboarding が悪ければ platform に問題が乗らない。 本 ADR は authoring experience を一級設計目標として扱う。</p>
+
+<h3>Developer-facing</h3>
+
+<table>
+<thead><tr><th>Tool</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td><code>tenkacloud problem create &lt;id&gt; --kind &lt;5 kind&gt;</code></td><td>5 種の skeleton から雛形 dir 生成 (= metadata.json + template.yaml stub + portal/ stub + tests)</td></tr>
+<tr><td><code>tenkacloud problem dev &lt;id&gt;</code></td><td>localhost で問題を起動、 portal UI も local rendering、 metadata 変更で hot reload</td></tr>
+<tr><td><code>tenkacloud problem validate &lt;id&gt;</code></td><td>metadata DSL を JSON Schema で lint + template.yaml を cfn-lint + endpoint / output / disruption 配線の存在確認</td></tr>
+<tr><td><code>tenkacloud problem package &lt;id&gt;</code></td><td>S3 配信用 bundle 生成</td></tr>
+<tr><td><code>tenkacloud problem publish &lt;id&gt; --env &lt;staging|production&gt;</code></td><td>upload + catalog 更新</td></tr>
+</tbody>
+</table>
+
+<p>CLI 全体は <a href="./adr-010-api-first-cli-mcp.html">ADR-010</a> の <code>tenkacloud</code> CLI に subcommand として統合する。</p>
+
+<h3>AI-facing</h3>
+
+<table>
+<thead><tr><th>Asset</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td><code>.claude/skills/create-problem</code> (拡張)</td><td>AI agent が対話形式で問題要件 (= category / kind / endpoints / disruptions) を聞き出し、 完成形 dir を生成。 既存問題を context として模倣を促す</td></tr>
+<tr><td><code>.claude/templates/problems/&lt;kind&gt;/</code></td><td>5 種 kind 各々の skeleton template。 <code>tenkacloud problem create</code> が copy 元として使う</td></tr>
+<tr><td><code>AGENTS.md</code> "Problem Authoring" 節</td><td>AI agent が問題を作る時の参照 context。 ヒューマン向け AUTHORING.html と pair で整備</td></tr>
+<tr><td>JSON Schema の <code>aiContext</code> field</td><td>各 metadata field に AI 向け hint を埋める (= 「Challenge なら <code>flag</code>、 Battle で時刻依存採点なら <code>phased-polling</code>」 等の判断軸)</td></tr>
+<tr><td>4 sample 問題の rich comment</td><td>code comment / metadata description / portal component を AI が模倣しやすい imperative + WHY コメント密度で書く</td></tr>
+</tbody>
+</table>
+
+<h3>Pattern library</h3>
+
+<p>新問題作成は「既存問題のどれかから差分を作る」 形式が基本となる。</p>
+
+<table>
+<thead><tr><th>「こういう問題作りたい」</th><th>Copy 元 sample</th></tr></thead>
+<tbody>
+<tr><td>flag 提出だけの個別演習</td><td><code>hello-world</code></td></tr>
+<tr><td>1 endpoint uptime 監視</td><td><code>hello-world-battle</code></td></tr>
+<tr><td>複数 endpoint 監視 + 攻撃検知</td><td><code>security-battle-royale</code></td></tr>
+<tr><td>多段 phase + 妨害 + hosting platform 分類</td><td><code>microservice-migration-battle</code></td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Challenge vs Battle stance</h2>
+
+<table>
+<thead><tr><th></th><th>Challenge</th><th>Battle</th></tr></thead>
+<tbody>
+<tr><td>性格</td><td>静的・個別演習</td><td>動的・対戦型、 時間駆動の攻撃 / phase / 多段</td></tr>
+<tr><td>metadata の厚さ</td><td>薄い (= <code>kind: flag</code> + flagOutputKey 等)</td><td>厚い (= multi-slot / phase / disruption / dashboard slot)</td></tr>
+<tr><td>template.yaml</td><td>flag を出す CFn のみ</td><td>CFn + passive 仕掛け cron 同梱可</td></tr>
+<tr><td><code>portal/</code></td><td>不要 (generic flag form 流用)</td><td>必要 (Battle 固有 UI を custom component で)</td></tr>
+<tr><td>新問題追加コスト</td><td>metadata + template ほぼコピペ</td><td>metadata 厚く書く + portal component + template の仕掛け設計、 30〜60 分目安</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Rollout</h2>
+
+<table>
+<thead><tr><th>Phase</th><th>Scope</th></tr></thead>
+<tbody>
+<tr><td>1 (本 ADR)</td><td>本 ADR 採択。 metadata DSL の JSON Schema 詳細を確定 (= 5 kind 各々の rule field)</td></tr>
+<tr><td>2</td><td><code>problems/SCHEMA.json</code> 拡張 + 既存 4 問題 metadata の新 DSL 書き換え (= 既存挙動 unchanged で確認)</td></tr>
+<tr><td>3</td><td>Endpoint registry (DDB + API) + Generic scoring Lambda (= 5 builtin kind handler) 実装。 既存 health-check-handler / submit-flag handler を generic dispatcher に統合 refactor</td></tr>
+<tr><td>4</td><td>Disruption Phase 1 (= self-triggered Scheduler) を template.yaml の標準 pattern 化。 既存 <code>security-battle-royale</code> の hidden platform-bleed を audit し、 必要なら新 DSL に移行。 <code>microservice-migration-battle</code> の score engine を新 DSL で再実装</td></tr>
+<tr><td>5</td><td>Portal plugin loader (= React.lazy + Cloudscape peer-dep + CSP) と SDK package <code>@tenkacloud/portal-plugin-sdk</code> を公開</td></tr>
+<tr><td>6</td><td>Authoring CLI + Claude Code skill 拡張 + 4 sample の rich comment 化 + AUTHORING.html 整備</td></tr>
+<tr><td>7</td><td><a href="./adr-008-problem-payload-separation.html">ADR-008</a> 統合 — metadata + template + portal の private 配信</td></tr>
+</tbody>
+</table>
+
+<p>各 phase は別 Issue で tracking する (= 本 ADR merge 時点で起票)。</p>
 </section>
 
 <section>
 <h2>Consequences</h2>
 
-<h3>positive</h3>
+<h3>Positive</h3>
 <ul>
-<li>新問題追加が <strong>dir 1 個 git add</strong> で済む。platform に手を入れる必要なし</li>
-<li>採点 Lambda は <strong>1 つ</strong>。IAM / CFn / lifecycle がぐちゃぐちゃにならない</li>
-<li>metadata DSL が型 (JSON Schema) で固まるので、 PR review が機械化可</li>
-<li>community contribution 時、寄稿者は問題 dir だけ理解すれば OK</li>
-<li>Phase 3 で既存 health-check-handler / submit-flag handler を refactor 統合できる (= 同じ generic dispatcher に乗る)</li>
+<li>新問題追加 = problem dir 1 個 git add で済む。 platform 改修不要</li>
+<li>採点 Lambda は <strong>1 つ</strong>に集約。 IAM / CFn / lifecycle 管理が一元化</li>
+<li>community contribution / AI agent authoring に対応可能な API surface</li>
+<li>game design building blocks (= 6 要素) が明示され、 problem author が「面白さ」 を設計しやすい</li>
 </ul>
 
-<h3>negative</h3>
+<h3>Negative</h3>
 <ul>
-<li>metadata DSL <strong>作り込みコストが大きい</strong> (= ユーザー指摘 7)。5 kind 各々の rule field を精緻に設計しないと、後から breaking 拡張で全問題の metadata を直すことになる</li>
-<li>5 kind の builtin で表現できない問題が出たら、 新 kind を ADR 1 個増やして足す必要 (= 拡張コスト)</li>
-<li>generic scoring Lambda が問題ごとの分岐を 1 つの Lambda に背負うので、 PR review で慎重さが要る (= regression risk が問題横断)</li>
+<li>metadata DSL の初期設計コストが大きい (= 5 kind の rule field を精緻に設計しないと、 後の breaking 拡張で全 problem の metadata を直すことになる)</li>
+<li>5 kind で表現できない問題が出たら ADR を追加して kind を増やす拡張作業が必要</li>
+<li>Generic scoring Lambda が問題横断の責務を持つため、 PR review で慎重さが要る (= regression risk が問題横断)</li>
+<li>Disruption の runtime 動的変更が Phase 1 では不可 (= CFn redeploy が要る)。 動的需要は Disruption Phase 2 (= 別 ADR) で対応</li>
 </ul>
 
-<h3>open questions</h3>
+<h3>Risk: Hidden platform-bleed in existing code</h3>
+<p>既存 <code>security-battle-royale</code> の scoring / attack detection logic にも platform-bleed が残っている可能性がある。 Phase 4 で audit し、 新 DSL に移行できないものは本 ADR の拡張で扱う。</p>
+</section>
+
+<section>
+<h2>Open questions</h2>
+
 <ul>
-<li>metadata DSL の <strong>5 kind が真に MVP として十分か</strong> (= security-battle-royale 既存ロジックを <code>uptime-multi</code> + <code>attack-detection</code> 2 kind で全部表現できるか、 audit が必要)</li>
-<li>phase 進行で expressible でない非定常な攻撃 (= 競技者の行動依存で trigger される攻撃) が要るか、 要るならどう宣言するか</li>
-<li>operator (= 競技運営) 側にも problem 固有 UI が要るか (= application-admin-console plugin slot は本 ADR の scope 外)</li>
-<li>ADR-008 確定との順序 (= 待たずに Phase 2-5 を進めて Phase 6 で後付け、で OK か)</li>
-<li>同 problemId の versioning (= 同 event で複数 version 並走可能性)</li>
+<li>metadata DSL の 5 kind が真に MVP として十分か (= security-battle-royale の既存ロジックを <code>uptime-multi</code> + <code>attack-detection</code> 2 kind で表現できるか、 audit が必要)</li>
+<li>非定常な攻撃 (= 競技者の行動依存で trigger される攻撃) を Disruption Phase 1 (= self-triggered Scheduler) でカバーできない場合の暫定対応</li>
+<li>operator (= 競技運営) 側の application-admin-console に問題固有 UI plugin slot を追加する必要性</li>
+<li><a href="./adr-008-problem-payload-separation.html">ADR-008</a> 採択との順序: Phase 2-6 を本 ADR 単独で進めて Phase 7 で後付け、 で問題ないか</li>
+<li>同 problemId の versioning (= 同 event で複数 version 並走運用)</li>
 </ul>
 </section>
 
 <section>
-<h2>関連リソース</h2>
+<h2>References</h2>
 <ul>
-<li>PR-608 (close 済) — 本 ADR の trigger</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 4 で再実装</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue (= Phase 4 + Phase 5 で完結)</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR Phase 6 で統合</li>
-<li>memory <code>feedback_problems_as_plugins</code></li>
+<li><a href="./adr-001-problem-deploy-crud.html">ADR-001</a> — Problem deploy CRUD (= 本 ADR の前提となる deploy pipeline)</li>
+<li><a href="./adr-005-battle-portal-ui.html">ADR-005</a> — Battle Portal UI (= portal plugin の host)</li>
+<li><a href="./adr-008-problem-payload-separation.html">ADR-008</a> — Problem payload private repo separation (= Phase 7 で統合)</li>
+<li><a href="./adr-010-api-first-cli-mcp.html">ADR-010</a> — API-first / CLI / MCP (= authoring CLI が ここに乗る)</li>
 </ul>
 </section>
 </body>

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<title>ADR-012: Problem plugin architecture — 4 アセット (resources / scoring / engine / portal) + generic dispatcher</title>
+<title>ADR-012: Problem plugin architecture — 3 アセット + metadata DSL + platform 内 generic scoring Lambda</title>
 <style>
   :root {
     --c-text: #1f2328;
@@ -29,9 +29,6 @@
   table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
   th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
   th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
-  tr.show td { background: #ddf4e0; }
-  tr.hide td { background: #ffe9e9; }
-  tr.warn td { background: #fff8c5; }
   .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
           border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
   .meta b { color: var(--c-muted); margin-right: .3rem; }
@@ -44,16 +41,11 @@
   .quote { border-left: 3px solid var(--c-warn); background: #fff8c5; padding: .5rem .9rem; margin: .8rem 0; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
   details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
   details > summary { cursor: pointer; font-weight: 600; }
-  .asset-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .8rem; margin: 1rem 0; }
-  .asset-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
-  .asset-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
-  .asset-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
-  .asset-card .body { font-size: 0.88rem; }
 </style>
 </head>
 <body>
 <header>
-  <h1>ADR-012: Problem plugin architecture — 4 アセット (resources / scoring / engine / portal) + generic dispatcher</h1>
+  <h1>ADR-012: Problem plugin architecture — 3 アセット + 厚 metadata DSL + platform 1 つの generic scoring Lambda</h1>
   <div class="meta">
     <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-12</div>
     <div><b>Trigger:</b> PR-608 (#606 Phase 2 score engine) close</div>
@@ -70,25 +62,163 @@
 </header>
 
 <section>
-<h2>欲しい姿 (= 一目で分かる version)</h2>
-
-<p>1 問題は <strong>4 つのアセット</strong> を持つ。Platform は 4 つを <strong>generic に host するだけ</strong>。</p>
+<h2>1 枚で分かる構造</h2>
 
 <pre>problems/&lt;id&gt;/
-├── metadata.json    # 宣言 (既存)
-├── template.yaml    # ①リソース      = 競技者 AWS account に立つ CFn
-├── scoring/         # ②採点          = 観測 → スコア計算
-│   └── index.ts
-├── engine/          # ③攻撃 / 仕組み = 時間駆動の active な変化 (Battle 主用途)
-│   └── index.ts
-└── portal/          # ④ダッシュボード = 競技者の画面
-    └── index.tsx</pre>
+├── metadata.json    # 厚 DSL    = endpoint slot / 採点 rule / phase / 攻撃 / dashboard slot を全部宣言
+├── template.yaml    # ①リソース = 競技者 AWS account に立つ CFn。passive 仕掛け (= cron 等) 同梱可
+└── portal/          # ②ダッシュボード = Battle 固有 UI (Challenge は不要、generic 流用)</pre>
 
-<p><strong>新問題を足す = この dir を 1 個 git add するだけ</strong>。 platform は触らない。 差し替えも同 dir を更新するだけ。</p>
+<table>
+<thead><tr><th></th><th>採点 (= 観測 → score)</th><th>攻撃 (= 時間駆動の状態変化)</th></tr></thead>
+<tbody>
+<tr><td><strong>誰が宣言</strong></td><td>問題側 <code>metadata.json</code></td><td>問題側 (template.yaml or metadata.json)</td></tr>
+<tr><td><strong>誰が実行</strong></td><td>platform 内 1 つの generic scoring Lambda</td><td>passive: 競技者 account 内の cron/Lambda (= template.yaml 同梱) / active: platform scoring Lambda が metadata phase 宣言に従って分岐</td></tr>
+<tr><td><strong>問題側の Lambda コード</strong></td><td><strong>なし</strong> (= 問題ごとに Lambda 立てるとぐちゃぐちゃになる、ユーザー指摘 5 / 2026-05-12)</td><td>なし</td></tr>
+</tbody>
+</table>
+
+<p><strong>新問題追加 = この dir 1 個 git add するだけ</strong>。platform は触らない。 metadata DSL が表現できる範囲なら code 0 行で新問題が動く。</p>
+</section>
+
+<section>
+<h2>ユーザー指摘 (= 設計の制約)</h2>
 
 <div class="quote">
-ユーザー指摘 (2026-05-12): 「<b>攻撃とかの仕組みは問題側のコードで作ればいい</b>」 + 「<b>Challenge は共通化できるが、Battle は柔軟性が必要</b>」 = この ADR の根本方針。
+2026-05-12 順序付きで:<br>
+<b>1.</b>「採点 / リソース / ダッシュボードが欲しい機能」<br>
+<b>2.</b>「攻撃とかの仕組みは問題側のコード (= template / metadata) で作ればいい」<br>
+<b>3.</b>「Challenge は共通化できる、Battle は柔軟性が必要」<br>
+<b>4.</b>「endpoint は default を問題で指定、競技者が override 可能」<br>
+<b>5.</b>「採点 Lambda は platform 側に 1 個、問題ごとに立てない (= ぐちゃぐちゃ防止)」<br>
+<b>6.</b>「endpoint 数と default 値 (= deploy 時 CFn output から team ごと set) を指定できないといけない」<br>
+<b>7.</b>「だからかなり metadata の作り込みをしないといけない」
 </div>
+
+<p>= <strong>厚 metadata DSL で問題固有性を吸収し、platform は generic 1 個に保つ</strong>。</p>
+</section>
+
+<section>
+<h2>厚 metadata DSL (= 本 ADR の主役)</h2>
+
+<h3>骨子</h3>
+
+<p>metadata.json で次を宣言できる必要がある:</p>
+
+<table>
+<thead><tr><th>領域</th><th>宣言する内容</th><th>例 (microservice-migration)</th></tr></thead>
+<tbody>
+<tr><td>endpoint slot</td><td>N 個の slot 名 / default URL の取得元 / override 可否</td><td>3 slot (users / orders / catalog)、deploy 時 CFn output <code>Ec2BaseUrl</code> + appendPath で default を team ごとに set、競技者は override 可</td></tr>
+<tr><td>採点 kind</td><td>5 つの builtin から選択 (flag / uptime-flat / uptime-multi / phased-polling / attack-detection)</td><td><code>phased-polling</code></td></tr>
+<tr><td>採点 rule</td><td>kind に応じた detail パラメータ (= 配点表 / platform 分類 / bonus 条件 等)</td><td>下記 "phased-polling" の details</td></tr>
+<tr><td>phase 進行</td><td>deploy からの経過時間で switch する rule</td><td>60 min: EC2 degradation 開始 / 90 min: scoring path を <code>/score?legacy=true</code> に切替</td></tr>
+<tr><td>dashboard slot</td><td>portal の標準 slot に対する custom component の有無 (= "RegistrationPanel" / "StatusPanel" 等)</td><td>StatusPanel + RegistrationPanel に custom 指定</td></tr>
+</tbody>
+</table>
+
+<h3>具体例: microservice-migration-battle</h3>
+
+<pre>{
+  "id": "microservice-migration-battle",
+  "category": "Battle",
+  "difficulty": 4,
+  "estimatedMinutes": 120,
+
+  "endpoints": [
+    {
+      "slot": "users",
+      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/users" },
+      "overridable": true,
+      "label": "users service URL"
+    },
+    {
+      "slot": "orders",
+      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/orders" },
+      "overridable": true
+    },
+    {
+      "slot": "catalog",
+      "default":   { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/catalog" },
+      "overridable": true
+    }
+  ],
+
+  "scoring": {
+    "kind": "phased-polling",
+    "intervalMinutes": 1,
+    "probe": {
+      "metaPath": "/meta",          // 各 slot で platform 自己申告を読む
+      "scorePath": "/score"
+    },
+    "platformRules": {
+      "ec2":       { "points": 100,  "degradedPoints": 10 },
+      "lambda":    { "points": 1000 },
+      "ecs":       { "points": 1000 },
+      "apprunner": { "points": 1000 }
+    },
+    "failurePenalty": -100,
+    "responsePenalties": [
+      { "if": "responseTimeMs > 1500", "points": 10 }
+    ],
+    "bonuses": [
+      { "kind": "all-slots-on-platforms", "platforms": ["lambda","ecs","apprunner"], "points": 5000, "once": true }
+    ]
+  },
+
+  "phases": [
+    {
+      "name":  "degraded",
+      "afterMinutes": 60,
+      "effect": { "switchPlatformToDegraded": ["ec2"] }
+    },
+    {
+      "name":  "legacy",
+      "afterMinutes": 90,
+      "effect": { "scorePathOverride": "/score?legacy=true" }
+    }
+  ],
+
+  "dashboard": {
+    "slots": {
+      "RegistrationPanel": "portal/RegistrationPanel.tsx",
+      "StatusPanel":       "portal/StatusPanel.tsx"
+    },
+    "routes": [
+      { "path": "/migration-help", "component": "portal/MigrationGuide.tsx" }
+    ]
+  }
+}</pre>
+
+<p>= <strong>~50 行 JSON で問題の全ロジックが宣言される</strong>。Platform 側に問題固有 Lambda は一切要らない。</p>
+
+<h3>採点 kind の 5 つ (= MVP set、必要なら拡張)</h3>
+
+<table>
+<thead><tr><th>kind</th><th>用途</th><th>例</th></tr></thead>
+<tbody>
+<tr><td><code>flag</code></td><td>1 回提出型、StackOutput 値と比較</td><td><code>hello-world</code></td></tr>
+<tr><td><code>uptime-flat</code></td><td>固定 endpoint 群を polling、ok=+pt / fail=skip</td><td><code>hello-world-battle</code></td></tr>
+<tr><td><code>uptime-multi</code></td><td>N 個の endpoint を全部 probe、 全 OK で配点</td><td><code>security-battle-royale</code> (= main + admin の両方が生きてないと点取れない)</td></tr>
+<tr><td><code>phased-polling</code></td><td>時間で score 計算 rule が変わる、platform 分類 / bonus 対応</td><td><code>microservice-migration-battle</code></td></tr>
+<tr><td><code>attack-detection</code></td><td>CloudWatch Logs / stack output の counter を読んで攻撃数で配点</td><td><code>security-battle-royale</code> の attack 検知部分</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Platform 側 = 1 つの generic scoring Lambda + endpoint registry + portal loader</h2>
+
+<table>
+<thead><tr><th>platform 機能</th><th>役割</th><th>備考</th></tr></thead>
+<tbody>
+<tr><td><strong>Deploy</strong></td><td>template.yaml を競技者 account に CFn deploy</td><td>既存 (ADR-001 / ADR-002)</td></tr>
+<tr><td><strong>Endpoint registry</strong></td><td>(1) deploy 時に CFn output から default URL を抽出して per-team で書き込む (2) 競技者の override を受け付ける (3) effective URL (override || default) を scoring に渡す</td><td>新規。1 つの DDB <code>ProblemEndpoints</code></td></tr>
+<tr><td><strong>Generic scoring Lambda</strong></td><td>1 min 毎に全 (tenant × team × problem × slot) を iterate。各問題の metadata <code>scoring.kind</code> を読んで分岐 (= 5 kind の builtin handler)。phase 進行は metadata の <code>phases</code> 配列から経過時間で評価。ScoreEvent を発行</td><td><strong>新規・platform 1 つ・全問題で共有</strong>。 既存 health-check-handler を refactor して取り込む</td></tr>
+<tr><td><strong>Portal plugin loader</strong></td><td>participant-portal が metadata.<code>dashboard.slots</code> を読んで該当 component を S3 から <code>React.lazy</code> 動的 load</td><td>新規、Battle 用</td></tr>
+</tbody>
+</table>
+
+<p><strong>Platform は 5 kind の builtin scoring を持つだけで全問題に対応</strong>。問題が 5 kind で表現できなければ ADR を 1 個増やす (= 6 つ目の kind を足す)。Lambda は増えない。</p>
 </section>
 
 <section>
@@ -98,292 +228,52 @@
 <thead><tr><th></th><th>Challenge</th><th>Battle</th></tr></thead>
 <tbody>
 <tr><td>性格</td>
-    <td>静的・個別演習。flag 提出 or 単純 uptime</td>
-    <td>動的・対戦型。時間駆動の攻撃 / 妨害 / 多段 phase</td></tr>
-<tr><td>採点 (②)</td>
-    <td><strong>宣言で十分</strong> (= 80% case)。metadata.json の <code>scoring.kind = "flag"</code> or <code>"uptime-flat"</code> で platform 内蔵 evaluator が動く。<code>scoring/index.ts</code> は <strong>不要</strong></td>
-    <td><strong>カスタム Lambda 推奨</strong> (= 80% case)。<code>scoring/index.ts</code> を問題側で書き、phase / platform 分類 / 多段配点 / bonus を自由に表現</td></tr>
-<tr><td>攻撃 / 仕組み (③)</td>
-    <td><strong>原則無し</strong>。Challenge は時間駆動の active 攻撃を持たない</td>
-    <td><strong>必須</strong> (= 多くの Battle で)。<code>engine/index.ts</code> を schedule で invoke、競技者環境を能動的に変える (= EC2 latency 注入 / phase flag flip / 攻撃発動)</td></tr>
-<tr><td>portal (④)</td>
-    <td><strong>generic で十分</strong>。flag 提出 form + score 表示は platform 内蔵 component を流用。<code>portal/</code> は<strong>不要</strong></td>
-    <td><strong>カスタム推奨</strong>。Battle 固有 UX (= phase countdown / 攻撃 timeline / multi-slot 登録 form) を <code>portal/index.tsx</code> で書く</td></tr>
-<tr><td>具体例</td>
-    <td><code>hello-world</code> (flag) / <code>hello-world-battle</code> (uptime-flat 中身は実は Challenge 寄り)</td>
-    <td><code>security-battle-royale</code> / <code>microservice-migration-battle</code></td></tr>
+    <td>静的・個別演習</td>
+    <td>動的・対戦型、時間駆動の攻撃 / phase / 多段</td></tr>
+<tr><td>metadata の厚さ</td>
+    <td><strong>薄い</strong> (= <code>kind: flag</code> + flagOutputKey 等の数 field)</td>
+    <td><strong>厚い</strong> (= endpoint slot 多段 / phase / platform 分類 / bonus / dashboard slot を詰める)</td></tr>
+<tr><td>template.yaml</td>
+    <td>flag を出す CFn のみ</td>
+    <td>CFn + passive 仕掛け cron 同梱可</td></tr>
+<tr><td>portal/</td>
+    <td><strong>不要</strong> (generic flag form 流用)</td>
+    <td><strong>必要</strong> (Battle 固有 UI を custom component で)</td></tr>
+<tr><td>新問題追加コスト</td>
+    <td>metadata + template ほぼコピペ</td>
+    <td>metadata 厚く書く + portal component 数本 + template の仕掛け設計</td></tr>
 </tbody>
 </table>
-
-<p><strong>運用ルール</strong>: Challenge は metadata + template だけで完結 (= 雛形がほぼコピペ)。Battle は 4 つ揃える前提で書く (= 個別 build / test が必要)。Platform はどちらにも対応する generic dispatcher。</p>
 </section>
 
 <section>
-<h2>4 アセットの contract</h2>
+<h2>portal plugin contract (= ② asset の中身)</h2>
 
-<h3>① リソース (<code>template.yaml</code>) — 既存</h3>
+<p>participant-portal が runtime で動的 load する React module。metadata の <code>dashboard.slots</code> で「どの標準 slot に custom component を挿すか」を宣言。</p>
 
-<p>CFn template。競技者 AWS account に deploy される。<strong>passive な仕掛け</strong> (= EC2 user-data 内の cron / EventBridge Scheduler rule 等で deploy 直後から自動進行する妨害) はここに同梱して良い。</p>
+<pre>// problems/&lt;id&gt;/portal/StatusPanel.tsx (= 例)
+import type { PortalSlotProps } from "@tenkacloud/portal-plugin-sdk";
 
-<details>
-<summary>例: microservice-migration-battle の passive 仕掛け</summary>
-<pre>Resources:
-  Ec2Instance:
-    Type: AWS::EC2::Instance
-    Properties:
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash
-          # 60 min 後に tc qdisc で 200ms latency 注入 (= EC2 劣化攻撃)
-          echo "0 */60 * * * /usr/sbin/tc qdisc add dev eth0 root netem delay 200ms" | crontab -</pre>
-<p>UserData 内なので platform は知らない、ただ deploy するだけ。</p>
-</details>
-
-<h3>endpoint = default + override 可能な slot (= 統一モデル)</h3>
-
-<p>全 endpoint は <strong>1 つの統一モデル</strong> で扱う:</p>
-
-<table>
-<thead><tr><th>要素</th><th>内容</th></tr></thead>
-<tbody>
-<tr><td><strong>slot</strong></td><td>問題が宣言する endpoint の役割名 (例: <code>main</code> / <code>admin</code> / <code>users</code>)</td></tr>
-<tr><td><strong>default URL</strong></td><td>CFn output から自動取得 or 固定値。deploy 直後はこれが使われる</td></tr>
-<tr><td><strong>override</strong></td><td>競技者が portal UI で別 URL に変更可能。 <strong>effective URL = override || default</strong></td></tr>
-</tbody>
-</table>
-
-<p><strong>なぜこの形か</strong>: Battle 問題では競技者が deploy 直後の構成を <strong>変えていく</strong> ことが本質的:</p>
-
-<ul>
-<li><code>security-battle-royale</code>: default は S3 直 URL → 競技者が CloudFront を前段に置いたら新 URL で override</li>
-<li><code>microservice-migration-battle</code>: default は EC2 の 3 path → Lambda / ECS / App Runner に切り出したら slot ごとに override</li>
-<li><code>hello-world-battle</code>: default の EC2 URL のまま (= override 不要)、あるいは CDN を被せて override</li>
-</ul>
-
-<pre>// problems/&lt;id&gt;/metadata.json (= security-battle-royale 例)
-{
-  "endpoints": [
-    {
-      "slot": "main",
-      "default": { "from": "cfn-output", "key": "EndpointUrl" },
-      "overridable": true,
-      "label": "メイン endpoint",
-      "description": "deploy 直後は S3 直、CDN / WAF 等を被せて変更可能"
-    },
-    {
-      "slot": "admin",
-      "default": { "from": "cfn-output", "key": "AdminUrl" },
-      "overridable": true
-    }
-  ]
+export default function StatusPanel({ team, endpoints, scores, phase, nextPhaseAt }: PortalSlotProps) {
+  return (
+    &lt;Container&gt;
+      &lt;Header&gt;3 slot 状態&lt;/Header&gt;
+      {Object.entries(endpoints).map(([slot, url]) =&gt; (
+        &lt;Box key={slot}&gt;{slot}: {url} / score {scores[slot]}&lt;/Box&gt;
+      ))}
+      &lt;Box&gt;次フェーズまで残り {formatCountdown(nextPhaseAt)}&lt;/Box&gt;
+    &lt;/Container&gt;
+  );
 }</pre>
-
-<pre>// microservice-migration-battle 例 (= 3 slot、各 slot を別 hosting に切り出す)
-{
-  "endpoints": [
-    { "slot": "users",   "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/users" },   "overridable": true },
-    { "slot": "orders",  "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/orders" },  "overridable": true },
-    { "slot": "catalog", "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/catalog" }, "overridable": true }
-  ]
-}</pre>
-
-<p>Platform は <strong>3 機能の generic な endpoint registry</strong> を提供:</p>
-
-<ol>
-<li>deploy 直後に CFn output から default URL を抽出して各 slot に書き込む</li>
-<li>競技者の override (<code>POST /problems/:id/endpoints { slot, url }</code>) を受け付ける</li>
-<li>effective URL (= override があれば override、無ければ default) を scoring / engine に渡す</li>
-</ol>
-
-<p><code>scoring/index.ts</code> / <code>engine/index.ts</code> には統一形で渡る:</p>
-
-<pre>event.endpoints = {
-  users:   "https://d12345.cloudfront.net/users",     // ← competitor が CDN 被せて override
-  orders:  "http://ec2-abc.amazonaws.com/orders",     // ← default のまま (未 override)
-  catalog: "https://api-gw.execute-api.../catalog"    // ← Lambda + API GW に移して override
-}</pre>
-
-<p>問題側は slot 名で endpoint を引いて probe するだけ。endpoint が <strong>1 つでも N 個でも</strong>同じ contract。</p>
-
-<p><strong>Challenge (flag 系)</strong> は endpoint 概念を持たない (= 提出 form 経由)。<code>metadata.json</code> の <code>endpoints</code> 配列を省略するだけ。</p>
-
-<h3>② 採点 (<code>scoring/index.ts</code>) — Battle 主用途、Challenge は省略可</h3>
-
-<p><strong>Platform から 1 分毎に invoke される Lambda</strong>。観測 → スコア delta を返す pure function。 副作用 (= state 書き換え / 攻撃発動) は ③ engine に分離。</p>
-
-<pre>// problems/&lt;id&gt;/scoring/index.ts
-import type { ProblemScoringHandler } from "@tenkacloud/scoring-sdk";
-
-export const score: ProblemScoringHandler = async (event) =&gt; {
-  // event: { tenantId, teamId, deployedAt, registeredEndpoints, prevState, phaseElapsedMin }
-  // 戻り値: { delta: number, source: string, emitEvent: boolean, newState?: object }
-
-  // 例: microservice-migration の phase-aware 採点
-  if (event.phaseElapsedMin &gt; 90) {
-    const ok = await probe(`${event.registeredEndpoints.users}/score?legacy=true`);
-    return { delta: ok ? 1000 : -100, source: "users-legacy", emitEvent: true };
-  }
-  // ... 通常採点
-};</pre>
 
 <table>
 <thead><tr><th>項目</th><th>仕様</th></tr></thead>
 <tbody>
-<tr><td>signature</td><td>固定 (<code>@tenkacloud/scoring-sdk</code> が型を export)</td></tr>
-<tr><td>呼出し頻度</td><td>1 min 間隔 (= ADR-005 の polling 統一)</td></tr>
-<tr><td>状態</td><td><code>prevState</code> / <code>newState</code> 経由で per-team の小さな state を platform DDB に保管。問題は直接 DDB を触らない</td></tr>
-<tr><td>IAM</td><td>per-problem 専用 role。外部 HTTP allow (= 競技者 endpoint probe)、AWS SDK は限定 (cross-tenant 不可)</td></tr>
-<tr><td>戻り値</td><td><code>delta</code> を ScoreEvent stream に乗せる。<code>source</code> は問題ごと unique にして集計を分離</td></tr>
-</tbody>
-</table>
-
-<h3>③ 攻撃 / 仕組み (<code>engine/index.ts</code>) — Battle 主用途</h3>
-
-<p><strong>Platform が schedule (cron / time-of-day) で invoke する Lambda</strong>。state を変える / 競技者環境を能動的に揺らす。 採点と分離する理由は (a) 副作用と純粋関数を分けたい (b) 1 min より粗い頻度で十分なことが多い (c) state 変更の権限が要る (= IAM scope を採点と分離)。</p>
-
-<pre>// problems/&lt;id&gt;/engine/index.ts
-import type { ProblemEngineHandler, ProblemEngineSchedule } from "@tenkacloud/scoring-sdk";
-
-export const schedule: ProblemEngineSchedule = [
-  { name: "ec2-degradation", afterDeployMinutes: 60 },
-  { name: "legacy-switch",   afterDeployMinutes: 90 },
-];
-
-export const tick: ProblemEngineHandler = async (event) =&gt; {
-  // event: { tenantId, teamId, deployedAt, scheduleName, registeredEndpoints, prevState }
-  if (event.scheduleName === "ec2-degradation") {
-    // SSM RunCommand で competitor EC2 に tc qdisc を追加 (= 攻撃発動)
-    await ssm.send(new SendCommandCommand({ ... }));
-    return { newState: { ec2Degraded: true } };
-  }
-  if (event.scheduleName === "legacy-switch") {
-    return { newState: { legacyMode: true } };  // scoring がこれを読んで挙動を変える
-  }
-};</pre>
-
-<table>
-<thead><tr><th>項目</th><th>仕様</th></tr></thead>
-<tbody>
-<tr><td>signature</td><td><code>schedule</code> 配列 (= いつ呼ぶか) + <code>tick</code> 関数 (= 何をやるか)</td></tr>
-<tr><td>呼出し</td><td>Platform が EventBridge Scheduler で時刻指定 invoke (deploy 時刻 + offset)</td></tr>
-<tr><td>権限</td><td>per-problem role。SSM RunCommand / EC2 stop / Lambda invoke / DDB write 等を明示許可。<strong>cross-tenant 不可</strong>、自分が deploy した resources にのみ触れる</td></tr>
-<tr><td>state</td><td>scoring と共有 (<code>prevState</code> / <code>newState</code> per-team)</td></tr>
-</tbody>
-</table>
-
-<h3>④ ダッシュボード (<code>portal/index.tsx</code>) — Battle 主用途、Challenge は generic flow 流用</h3>
-
-<p>participant-portal が <strong>動的に load する React モジュール</strong>。問題固有 UI を提供。</p>
-
-<pre>// problems/&lt;id&gt;/portal/index.tsx
-import type { ProblemPortalPlugin } from "@tenkacloud/portal-plugin-sdk";
-
-export default {
-  problemId: "microservice-migration-battle",
-  slots: {
-    // 既定 slot に問題固有 component を挿す
-    StatusPanel:       ({ team, scores, phase }) =&gt; (...),  // 各 slot の現状 + phase countdown
-    RegistrationPanel: ({ slots, onRegister })   =&gt; (...),  // 3 endpoint URL 登録 form
-  },
-  routes: [
-    { path: "/migration-help", element: &lt;MigrationGuide /&gt; },
-  ],
-} satisfies ProblemPortalPlugin;</pre>
-
-<table>
-<thead><tr><th>項目</th><th>仕様</th></tr></thead>
-<tbody>
-<tr><td>build</td><td>Vite で plugin 単体を ESM bundle 化 (target ~50 KB)、S3 配信</td></tr>
-<tr><td>load</td><td>portal が runtime-config の <code>problems[].pluginUrl</code> から <code>React.lazy(() =&gt; import(url))</code></td></tr>
+<tr><td>build</td><td>Vite で plugin 単体を ESM bundle 化 (~50 KB target)、S3 配信</td></tr>
+<tr><td>load</td><td>portal が <code>React.lazy(() =&gt; import(/* @vite-ignore */ pluginUrl))</code></td></tr>
 <tr><td>共有 design system</td><td>Cloudscape は SDK 経由で peer-dep (= bundle 二重化を避ける)</td></tr>
 <tr><td>CSP</td><td>portal hosting で plugin URL を <code>script-src</code> 許可リスト化</td></tr>
-</tbody>
-</table>
-</section>
-
-<section>
-<h2>Platform 側 = generic dispatcher</h2>
-
-<p>Platform はこの 4 つの contract を満たす generic な host だけ実装する。問題固有のことは <strong>一切しない</strong>。</p>
-
-<table>
-<thead><tr><th>platform 機能</th><th>役割</th><th>新規 / 既存</th></tr></thead>
-<tbody>
-<tr><td><strong>Deploy</strong></td>
-    <td><code>template.yaml</code> を競技者 account に CFn deploy</td>
-    <td>既存 (ADR-001 / ADR-002)</td></tr>
-<tr><td><strong>Scoring runtime</strong></td>
-    <td>(a) Challenge: metadata の <code>scoring.kind</code> を解釈する 内蔵 evaluator (= flag / uptime-flat)<br>
-        (b) Battle: per-problem <code>scoring/index.ts</code> Lambda を 1 min 毎に invoke</td>
-    <td>新規 (Phase 2-3)</td></tr>
-<tr><td><strong>Engine runtime</strong></td>
-    <td>per-problem <code>engine/index.ts</code> の <code>schedule</code> 宣言を読んで EventBridge Scheduler rule を立てる。時刻になったら invoke</td>
-    <td>新規 (Phase 4)</td></tr>
-<tr><td><strong>State store</strong></td>
-    <td>per-(problem, tenant, team) の小さな state を保管する generic DDB (= scoring / engine が <code>prevState</code> / <code>newState</code> で出し入れ)</td>
-    <td>新規 (Phase 3)</td></tr>
-<tr><td><strong>Portal mount</strong></td>
-    <td>portal が起動時に runtime-config から plugin URL 一覧を読み、 該当画面で <code>React.lazy</code> 動的 load</td>
-    <td>新規 (Phase 5)</td></tr>
-<tr><td><strong>IAM 発行</strong></td>
-    <td>per-problem Lambda role を problem deploy 時に発行、最小権限</td>
-    <td>新規 (Phase 4)</td></tr>
-</tbody>
-</table>
-</section>
-
-<section>
-<h2>具体例 — 既存 + 新規 問題のマッピング</h2>
-
-<table>
-<thead><tr><th>問題</th><th>カテゴリ</th><th>①template</th><th>②scoring</th><th>③engine</th><th>④portal</th></tr></thead>
-<tbody>
-<tr><td><code>hello-world</code></td><td>Challenge</td>
-    <td>flag を出力する CFn (=既存)</td>
-    <td><strong>不要</strong> (metadata <code>kind: flag</code>)</td>
-    <td>不要</td>
-    <td><strong>不要</strong> (generic flag form 流用)</td></tr>
-<tr><td><code>hello-world-battle</code></td><td>Battle (sample)</td>
-    <td>endpoint を出す CFn (=既存)</td>
-    <td><strong>不要</strong> (metadata <code>kind: uptime-flat</code>)</td>
-    <td>不要</td>
-    <td><strong>不要</strong> (generic uptime widget 流用)</td></tr>
-<tr><td><code>security-battle-royale</code></td><td>Battle</td>
-    <td>攻撃可能な web app CFn (=既存)</td>
-    <td><strong>必要</strong> (攻撃検知ロジック を問題側で)</td>
-    <td><strong>必要</strong> (攻撃 trigger / mitigation)</td>
-    <td><strong>必要</strong> (攻撃 timeline UI)</td></tr>
-<tr><td><code>microservice-migration-battle</code></td><td>Battle</td>
-    <td>EC2 + docker compose (=PR-605)</td>
-    <td><strong>必要</strong> (phased-polling + platform 分類 + bonus)</td>
-    <td><strong>必要</strong> (60min EC2 劣化 / 90min legacy switch)</td>
-    <td><strong>必要</strong> (3-slot 登録 form + phase countdown)</td></tr>
-</tbody>
-</table>
-</section>
-
-<section>
-<h2>SDK が定める contract</h2>
-
-<p>plugin 作者が import する型を <code>@tenkacloud/scoring-sdk</code> + <code>@tenkacloud/portal-plugin-sdk</code> として packages で公開。<strong>SDK が問題側コードと platform を decouple する唯一の接面</strong>。</p>
-
-<table>
-<thead><tr><th>SDK</th><th>export</th><th>説明</th></tr></thead>
-<tbody>
-<tr><td rowspan="3"><code>@tenkacloud/scoring-sdk</code></td>
-    <td><code>type ProblemScoringHandler</code></td>
-    <td>② signature</td></tr>
-<tr><td><code>type ProblemEngineSchedule</code></td>
-    <td>③ schedule 宣言型</td></tr>
-<tr><td><code>type ProblemEngineHandler</code></td>
-    <td>③ tick signature</td></tr>
-<tr><td rowspan="3"><code>@tenkacloud/portal-plugin-sdk</code></td>
-    <td><code>type ProblemPortalPlugin</code></td>
-    <td>④ default export 型</td></tr>
-<tr><td><code>type PortalSlotComponents</code></td>
-    <td>portal 標準 slot 群 (= StatusPanel / RegistrationPanel / HelpDrawer 等)</td></tr>
-<tr><td><code>type PortalRouteDef</code></td>
-    <td>問題固有 sub-route</td></tr>
+<tr><td>SDK</td><td><code>@tenkacloud/portal-plugin-sdk</code> が <code>PortalSlotProps</code> 等の型を export</td></tr>
 </tbody>
 </table>
 </section>
@@ -392,26 +282,14 @@ export default {
 <h2>段階的ロールアウト</h2>
 
 <table>
-<thead><tr><th>Phase</th><th>scope</th><th>影響</th></tr></thead>
+<thead><tr><th>Phase</th><th>scope</th></tr></thead>
 <tbody>
-<tr><td>1 (本 PR)</td>
-    <td>本 ADR 採択 + 4 アセットの contract + SDK 型定義の skeleton</td>
-    <td>doc のみ</td></tr>
-<tr><td>2</td>
-    <td><code>problems/SCHEMA.json</code> 拡張 (= Challenge 用の declarative <code>kind</code> 5 種を formalize) + 既存 hello-world / hello-world-battle metadata を新 schema に rewrite (挙動 unchanged)</td>
-    <td>既存 Challenge 系を新 schema に乗せる、platform 既存 evaluator はそのまま</td></tr>
-<tr><td>3</td>
-    <td>per-problem state 用 DDB <code>ProblemPluginState</code> + scoring runtime (= Battle 用の <code>scoring/index.ts</code> Lambda を invoke する dispatcher)。SDK package <code>@tenkacloud/scoring-sdk</code> 公開</td>
-    <td>新 DDB + 新 dispatcher Lambda。既存 health-check-handler を refactor して dispatcher に統合</td></tr>
-<tr><td>4</td>
-    <td>engine runtime (= <code>engine/index.ts</code> schedule から EventBridge rule を生成し時刻 invoke)。 microservice-migration-battle を本 architecture で再実装 (= PR-608 の代替)</td>
-    <td>#572 完結。<code>security-battle-royale</code> の platform-bleed を audit + migrate</td></tr>
-<tr><td>5</td>
-    <td>portal plugin runtime (= participant-portal の動的 load + Cloudscape peer dep + CSP)。SDK package <code>@tenkacloud/portal-plugin-sdk</code> 公開。 microservice-migration の 3-slot 登録 UI を plugin で実装</td>
-    <td>portal hosting に plugin URL config 追加。 既存問題は generic flow 流用で UI 変更なし</td></tr>
-<tr><td>6</td>
-    <td>ADR-008 (#574) 統合: plugin code (= scoring / engine / portal) を private repo の S3 経由 presigned URL で配信。public 同梱は dev / sample のみ</td>
-    <td>本格運用問題の答え漏れ防止 (= microservice-migration の slow endpoint コード等)</td></tr>
+<tr><td>1 (本 PR)</td><td>ADR 採択。metadata DSL の schema 詳細を確定 (= JSON schema 草案 + 5 kind 各々の rule field)</td></tr>
+<tr><td>2</td><td><code>problems/SCHEMA.json</code> を拡張。既存 3 問題 (hello-world / hello-world-battle / security-battle-royale) の metadata を新 DSL に書き直す (= 既存挙動 unchanged)</td></tr>
+<tr><td>3</td><td>endpoint registry (DDB + API) と generic scoring Lambda (5 kind builtin handler) を実装。 既存 health-check-handler / submit-flag handler を generic scoring Lambda に統合 refactor</td></tr>
+<tr><td>4</td><td><code>microservice-migration-battle</code> の Phase 2 (= score engine) を本 DSL で再実装 (= PR-608 の代替)。 problem dir に <code>portal/</code> 追加</td></tr>
+<tr><td>5</td><td>portal plugin loader 実装 (= React.lazy + CSP + SDK package <code>@tenkacloud/portal-plugin-sdk</code> 公開)</td></tr>
+<tr><td>6</td><td>ADR-008 (#574) 統合 — metadata + template + portal の private 配信 (= 答え漏れ防止)</td></tr>
 </tbody>
 </table>
 </section>
@@ -421,44 +299,38 @@ export default {
 
 <h3>positive</h3>
 <ul>
-<li><strong>新問題追加は dir 1 個 + git add</strong>。platform に手を入れる必要なし</li>
-<li><strong>問題の差し替えが容易</strong>。同 problemId で 4 アセットを update するだけ</li>
-<li><strong>Battle の柔軟性 = 問題作者が好きに書ける</strong>。攻撃の発動タイミング / 採点ロジック / UI 全部 plugin で</li>
-<li><strong>Challenge の共通化 = 雛形で済む</strong>。metadata + template だけで動く、SDK 学習不要</li>
-<li><strong>ADR-008 と統合可能</strong>: plugin code が private repo + S3 + presigned URL に乗れば答え漏れ対策完了</li>
-<li><strong>Community contribution の準備</strong>: 第三者が問題を寄稿する場合、 SDK で contract が明確なので review が機械化しやすい</li>
+<li>新問題追加が <strong>dir 1 個 git add</strong> で済む。platform に手を入れる必要なし</li>
+<li>採点 Lambda は <strong>1 つ</strong>。IAM / CFn / lifecycle がぐちゃぐちゃにならない</li>
+<li>metadata DSL が型 (JSON Schema) で固まるので、 PR review が機械化可</li>
+<li>community contribution 時、寄稿者は問題 dir だけ理解すれば OK</li>
+<li>Phase 3 で既存 health-check-handler / submit-flag handler を refactor 統合できる (= 同じ generic dispatcher に乗る)</li>
 </ul>
 
 <h3>negative</h3>
 <ul>
-<li>SDK の ABI 安定が必要 (= 一度公開した signature を不用意に変えると全 problem PR が壊れる)</li>
-<li>per-problem Lambda の cold start (1 min 毎 invoke、~1s × 60 = 60s/h を許容)</li>
-<li>UI plugin の lazy load による初回 200ms 程度の表示遅延 (= preload で緩和可)</li>
-<li>初期 setup: Phase 2-5 で計 ~5 PR 規模</li>
-<li><strong>既存 security-battle-royale の platform-bleed audit</strong> が必要 (= 隠れた問題固有 logic が platform にある可能性)</li>
+<li>metadata DSL <strong>作り込みコストが大きい</strong> (= ユーザー指摘 7)。5 kind 各々の rule field を精緻に設計しないと、後から breaking 拡張で全問題の metadata を直すことになる</li>
+<li>5 kind の builtin で表現できない問題が出たら、 新 kind を ADR 1 個増やして足す必要 (= 拡張コスト)</li>
+<li>generic scoring Lambda が問題ごとの分岐を 1 つの Lambda に背負うので、 PR review で慎重さが要る (= regression risk が問題横断)</li>
 </ul>
 
 <h3>open questions</h3>
 <ul>
-<li>scoring Lambda の <strong>言語</strong>: TypeScript 縛り or Python も許容 (Container Image 化)</li>
-<li>engine の権限上限: SSM RunCommand まで許可するか / EC2 stop / Lambda invoke 等の暴れ枠</li>
-<li>operator (= 競技運営) 側に問題固有 UI が要るか (= application-admin-console plugin slot を追加するか、本 ADR の scope 外)</li>
-<li>scoring / engine の同 lambda 統合 vs 分離: 副作用の有無で物理 Lambda を分けるか、1 Lambda の export を 2 つにするか</li>
-<li>ADR-008 確定との順序: 待たずに Phase 2-5 を進めて Phase 6 で後付け、で OK か</li>
-<li>同 problemId の versioning (= A/B 並走運用)</li>
+<li>metadata DSL の <strong>5 kind が真に MVP として十分か</strong> (= security-battle-royale 既存ロジックを <code>uptime-multi</code> + <code>attack-detection</code> 2 kind で全部表現できるか、 audit が必要)</li>
+<li>phase 進行で expressible でない非定常な攻撃 (= 競技者の行動依存で trigger される攻撃) が要るか、 要るならどう宣言するか</li>
+<li>operator (= 競技運営) 側にも problem 固有 UI が要るか (= application-admin-console plugin slot は本 ADR の scope 外)</li>
+<li>ADR-008 確定との順序 (= 待たずに Phase 2-5 を進めて Phase 6 で後付け、で OK か)</li>
+<li>同 problemId の versioning (= 同 event で複数 version 並走可能性)</li>
 </ul>
 </section>
 
 <section>
 <h2>関連リソース</h2>
 <ul>
-<li>PR-608 (close 済) — 本 ADR の trigger となった platform-bleed の実例</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 4 で再実装する対象</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue (= Phase 4 で 4 アセット揃って完結)</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR Phase 6 で統合する private repo + S3 配信</li>
-<li>ADR <a href="./adr-005-battle-portal-ui.html">ADR-005</a> — Battle Portal UI 基盤 (= ④ Portal plugin の host)</li>
-<li>ADR <a href="./adr-001-problem-deploy-crud.html">ADR-001</a> — Problem Deploy 基盤 (= ① template.yaml の deploy 経路)</li>
-<li>memory <code>feedback_problems_as_plugins</code> — 本 ADR のトリガー</li>
+<li>PR-608 (close 済) — 本 ADR の trigger</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 4 で再実装</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue (= Phase 4 + Phase 5 で完結)</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR Phase 6 で統合</li>
+<li>memory <code>feedback_problems_as_plugins</code></li>
 </ul>
 </section>
 </body>

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -62,6 +62,131 @@
 </header>
 
 <section>
+<h2>ゲームの本質 — Platform が提供すべき要素</h2>
+
+<div class="quote">
+ユーザー指摘 (2026-05-12): 「<b>ゲームというものの本質を捉えていかないといかない</b>」「<b>Overcooked! 的に要素が積まれていて、マルチタスク・得点・妨害の要素が組み込めるようになっていればかなり面白くなる</b>」
+</div>
+
+<p>Overcooked! (= 協力料理アクション) の面白さは <strong>同時に進行する複数 task を限られた時間で捌く</strong> ところにある。 TenkaCloud Battle が「ゲーム」として面白くなる要素を分解すると:</p>
+
+<table>
+<thead><tr><th>Overcooked! 要素</th><th>TenkaCloud Battle に置換すると</th><th>Platform が提供する仕組み</th></tr></thead>
+<tbody>
+<tr><td>マルチタスク (= 焼く + 切る + 配膳を同時)</td>
+    <td>複数 endpoint slot を同時管理 / 複数 phase 進行 / 複数 disruption に対処</td>
+    <td>metadata の <code>endpoints[]</code> N slot / <code>phases[]</code> 多段 / <code>disruptions[]</code> 複数。 portal が同時に複数 panel で状態を表示</td></tr>
+<tr><td>Score (= リアルタイムにお皿が出る)</td>
+    <td>得点が動くのが視覚的に分かる</td>
+    <td>ScoreEvent stream の live 表示 / per-event delta animation / leaderboard リアルタイム更新 / 1 分間隔 polling で sparkline</td></tr>
+<tr><td>妨害 (= 床が動く / 火災 / 客の文句)</td>
+    <td>競技中の active 妨害 (S3 content swap / latency 注入 等)</td>
+    <td>metadata <code>disruptions[]</code> で declarative 宣言、 platform が時刻 / 条件 で発動を orchestrate、 operator UI で予告 / 即発動</td></tr>
+<tr><td>時間制限 + カオス累積</td>
+    <td>競技時間が進むほど妨害が重なる</td>
+    <td>phase 多段 (= 60min 劣化 → 90min legacy → 120min 終了 等)、 segment ごとの累積効果</td></tr>
+<tr><td>視覚的フィードバック (= "皿が割れた!")</td>
+    <td>状況を一目で把握できる UI</td>
+    <td>portal の StatusPanel に "次フェーズまで残り XX:XX" / 妨害発動時 toast / score delta の色付け</td></tr>
+<tr><td>チームプレイ</td>
+    <td>1 team 内で役割分担</td>
+    <td>team scope の portal (= 既存 ADR-005)、 同 team 内では同じ画面を共有</td></tr>
+</tbody>
+</table>
+
+<p>= <strong>これら 6 要素を組み合わせて 1 つの問題を構成できる platform にすれば、 problem author が「ゲームとしての面白さ」を design できる</strong>。 Authoring 体験がここに乗る:</p>
+
+<ol>
+<li>Author は metadata で「 N slot + N phase + N disruption」 を宣言</li>
+<li>Platform は各要素を generic に dispatch / 可視化</li>
+<li>競技者は同時進行を捌く面白さを体感</li>
+</ol>
+
+<p><strong>Platform は building blocks を提供、problem author が組み立てる</strong> という構図 (= レゴブロック)。 1 つの block が無いと「ゲームらしさ」が落ちるので、 Phase 2-5 で 6 要素を漏れなく実装する。</p>
+</section>
+
+<section>
+<h2>設計の山場: developer-friendly + AI-friendly な problem authoring</h2>
+
+<div class="quote">
+ユーザー指摘 (2026-05-12): 「この仕組みを誰でも実装で組み込めるようにプラットフォームで <b>ガイドしないと、問題が作れない / 誰も乗れないプラットフォーム</b>になってしまう」 「<b>開発者フレンドリー / AI フレンドリーに作らないと全くダメ</b>」 「ここが体験の見せ所、設計の山場」
+</div>
+
+<p>本 ADR の <strong>核心は問題作成体験</strong>。 3 アセット / 厚 metadata DSL / disruption 機構は すべて「人間 + AI agent が <strong>1 時間以内に新問題を ship できる</strong>」 ことを目的とする。 platform がどれだけ強力でも、 problem を作る人が居なければ何も起きない。</p>
+
+<h3>Developer-friendly な要件</h3>
+
+<ol>
+<li><strong>30 分 onboarding</strong>: 新規 problem author が初回 PR を出すまでの目標時間</li>
+<li><strong>Scaffolding コマンド</strong>: <code>tenkacloud problem create &lt;id&gt; --kind battle</code> で雛形 dir 生成 (metadata.json + template.yaml + portal/ + tests)</li>
+<li><strong>Local dev loop</strong>: <code>tenkacloud problem dev &lt;id&gt;</code> で localhost で問題を起動、 portal UI も local rendering、 metadata 変更で hot reload。AWS deploy 不要で iteration</li>
+<li><strong>Validation</strong>: <code>tenkacloud problem validate &lt;id&gt;</code> が
+  <ul>
+    <li>metadata DSL を JSON Schema で lint</li>
+    <li>template.yaml を cfn-lint</li>
+    <li>required endpoint / CFn output / disruption Lambda の存在確認</li>
+    <li>具体的なエラーメッセージ (= 「<code>scoring.kind</code> が unknown: <code>'phasing-pollign'</code> (= <code>'phased-polling'</code> の typo?)」)</li>
+  </ul>
+</li>
+<li><strong>Sample 問題が教材</strong>: 既存 4 問題 (hello-world / hello-world-battle / security-battle-royale / microservice-migration) を <strong>完成形 with rich コメント</strong> で配置。author は copy-paste-edit で済む</li>
+<li><strong>Documentation</strong>: <code>docs/problems/AUTHORING.html</code> で step-by-step 30 分 onboarding guide</li>
+</ol>
+
+<h3>AI-friendly な要件</h3>
+
+<ol start="7">
+<li><strong>JSON Schema に AI hint を埋める</strong>: 各 field に <code>description</code> / <code>examples</code> / <code>aiContext</code> (= "When in doubt about <code>scoring.kind</code>, default to <code>uptime-flat</code> for Challenge, <code>phased-polling</code> for Battle")</li>
+<li><strong><code>/create-problem</code> skill を AI 対話型に拡張</strong>: 「難易度は?」「想定時間?」「妨害種類?」「3rd party hosting?」 を AI に質問させ、 完成した metadata + template + portal を一気に生成</li>
+<li><strong>AGENTS.md に "Problem Authoring" セクション</strong>: AI agent が問題を作る時の参照リソース。 ヒューマン向け AUTHORING.html と pair で整備</li>
+<li><strong>既存問題が training data</strong>: 4 sample 問題は code comment / metadata description / portal component を <strong>AI が読んで模倣しやすい</strong> よう冗長気味に書く (= imperative 命令文 + WHY コメント)</li>
+</ol>
+
+<h3>Pattern library: 既存 4 sample を copy 元として配置</h3>
+
+<table>
+<thead><tr><th>「こういう問題作りたい」</th><th>copy 元 sample</th></tr></thead>
+<tbody>
+<tr><td>flag 提出だけの個別演習</td><td><code>hello-world</code> (Challenge)</td></tr>
+<tr><td>1 endpoint uptime 監視</td><td><code>hello-world-battle</code> (Battle minimal)</td></tr>
+<tr><td>複数 endpoint 監視 + 攻撃検知</td><td><code>security-battle-royale</code></td></tr>
+<tr><td>多段 phase + 妨害 + 3 hosting platform 分類</td><td><code>microservice-migration-battle</code></td></tr>
+</tbody>
+</table>
+
+<h3>Claude Code skill + template library が AI-friendly authoring の核</h3>
+
+<p>ユーザー指摘 (2026-05-12): 「<strong>Claude Code の skill として問題作成を組み込んだりテンプレートを用意したりする必要がある</strong>」</p>
+
+<table>
+<thead><tr><th>component</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td><strong><code>.claude/skills/create-problem/</code> の拡張</strong></td>
+    <td>既存 skill を新 metadata DSL 対応に拡張。 AI 対話で問題定義 (= category / kind / endpoints / disruptions) を聞き出し、 完成形 dir を生成。 既存問題を context として AI に渡し模倣を促す</td></tr>
+<tr><td><strong><code>.claude/templates/problems/&lt;kind&gt;/</code></strong></td>
+    <td>5 kind 各々の skeleton template。 <code>tenkacloud problem create</code> が copy 元として使う。 各 kind の完成形に近い metadata + template.yaml + portal/ + tests を含む</td></tr>
+<tr><td><strong>AGENTS.md "Problem Authoring" セクション</strong></td>
+    <td>AI agent が問題を作る時の context 集約: 「skill 呼び方 / template 場所 / 既存 4 sample の URL / metadata DSL の JSON Schema / よくある落とし穴」</td></tr>
+<tr><td><strong>JSON Schema の <code>aiContext</code> field</strong></td>
+    <td>標準の <code>description</code> に加え AI 向け hint を埋める (= 「<code>scoring.kind</code> 選び方の判断軸: Challenge なら <code>flag</code> / <code>uptime-flat</code>、 Battle で時刻依存採点なら <code>phased-polling</code>」 等)</td></tr>
+<tr><td><strong>4 sample 問題の rich コメント</strong></td>
+    <td>code comment / metadata description / portal component を AI 模倣しやすい imperative + WHY コメント密度で書く (= existing 4 problems を training data 化)</td></tr>
+</tbody>
+</table>
+
+<h3>CLI 一覧 (= ADR-010 #578 と統合)</h3>
+
+<pre>tenkacloud problem create &lt;id&gt; --kind &lt;flag|uptime-flat|uptime-multi|phased-polling|attack-detection&gt;
+tenkacloud problem dev &lt;id&gt;
+tenkacloud problem validate &lt;id&gt;
+tenkacloud problem package &lt;id&gt;
+tenkacloud problem publish &lt;id&gt; --env &lt;staging|production&gt;</pre>
+
+<p><strong>この CLI + Claude Code skill + template + 4 sample が揃わなければ ADR-012 はどんなに綺麗でも実用化されない</strong>。 Phase 2 で必ず ship。</p>
+
+<p><em>注: 「Battle」 は TenkaCloud 固有の用語 (= 対戦型問題カテゴリ)。 AWS GameDay 等の用語ではないので、外部資料と並べる時は明確に区別する。</em></p>
+</section>
+
+<section>
 <h2>1 枚で分かる構造</h2>
 
 <pre>problems/&lt;id&gt;/
@@ -276,6 +401,185 @@ export default function StatusPanel({ team, endpoints, scores, phase, nextPhaseA
 <tr><td>SDK</td><td><code>@tenkacloud/portal-plugin-sdk</code> が <code>PortalSlotProps</code> 等の型を export</td></tr>
 </tbody>
 </table>
+</section>
+
+<section>
+<h2>Disruption mechanism (= 妨害 / mid-contest 条件変更)</h2>
+
+<p>Battle 問題ではコンテスト中に「S3 コンテンツが攻撃後版に差し替わる」「EC2 に latency 注入」「IAM が剥奪される」などの <strong>妨害 / 条件変更</strong> を仕掛ける。 ユーザー指摘 (2026-05-12):</p>
+
+<div class="quote">
+「application 管理用の画面で <b>どこでどのような妨害をいれるか / 変えられるように</b> しておかないといけない」<br>
+「問題アカウントに <b>遅延なく</b> 展開できないといけない」
+</div>
+
+<h3>2 つの仕組み</h3>
+
+<table>
+<thead><tr><th></th><th>① Operator UI</th><th>② Cross-account event transport</th></tr></thead>
+<tbody>
+<tr><td>場所</td>
+    <td>application-admin-console 内 "Disruption Planner" page (新規)</td>
+    <td>Platform 中央 EventBridge bus → 競技者 account 内 rule + Lambda</td></tr>
+<tr><td>役割</td>
+    <td>operator が妨害種類 / 時刻 / 強度を画面で edit、Trigger NOW で即発火</td>
+    <td>Platform から PutEvents → 競技者 account の Lambda が ~1 秒で実行</td></tr>
+<tr><td>必要権限</td>
+    <td>Tenant Admin JWT</td>
+    <td>EventBridge bus policy で competitor account を許可 (= AssumeRole 不要)</td></tr>
+</tbody>
+</table>
+
+<h3>① Operator UI 要件</h3>
+
+<ul>
+<li><strong>Disruption catalog 表示</strong>: metadata.<code>disruptions[]</code> で問題が宣言した妨害種類を一覧</li>
+<li><strong>Per-team / per-disruption の schedule 表</strong>: 「team-A の S3 swap → 14:00 予定 / team-B キャンセル」</li>
+<li><strong>Edit</strong>: trigger 時刻 / パラメータ (= 妨害強度 / target slot / コンテンツ variant 等) を画面で変更</li>
+<li><strong>Trigger NOW</strong>: schedule を待たず即発火</li>
+<li><strong>All-teams broadcast</strong>: 「全 team の S3 swap を 5 min 後に同時発動」</li>
+<li><strong>Cancel</strong>: 予定中の disruption を取消</li>
+</ul>
+
+<h3>② Cross-account event transport の配線</h3>
+
+<pre>[application-admin-console (operator)]
+        │
+        ▼ "Trigger NOW" click
+[Platform DisruptionApi Lambda] ──┐
+                                   │
+[Platform EventBridge Scheduler] ──┘  (scheduled fire も同経路)
+        │
+        ▼ PutEvents (= e.g. "disruption.s3-content-swap")
+[Platform central EventBridge bus "tenkacloud-disruption"]
+        │
+        ├─→ team-A account ▶ EventBridge rule ▶ DisruptionHandler Lambda
+        ├─→ team-B account ▶ EventBridge rule ▶ DisruptionHandler Lambda
+        └─→ ... (= 全 team、 sub-second 配信)</pre>
+
+<p><strong>EventBridge cross-account を選ぶ理由</strong>:</p>
+
+<ul>
+<li><strong>AssumeRole 不要</strong> = ADR-009 (#459) の federation を read-only に保てる、 write 経路を別 IAM で発行する必要なし</li>
+<li><strong>Sub-second 配信</strong> = ユーザー要件「遅延なく」を満たす</li>
+<li><strong>N team scaling 不要</strong> = Platform は 1 回 PutEvents するだけ、各 team の rule subscription が独立に拾う</li>
+<li><strong>blast radius = 1 team account に閉じる</strong> = DisruptionHandler Lambda は自 team の resources にしか触れない</li>
+</ul>
+
+<h3>metadata.json での宣言例</h3>
+
+<pre>{
+  "disruptions": [
+    {
+      "id": "content-swap",
+      "name": "S3 静的コンテンツを攻撃後版に差替",
+      "defaultAfterMinutes": 60,
+      "operatorEditable": ["afterMinutes", "contentVariant"],
+      "parameters": {
+        "contentVariant": {
+          "type": "enum",
+          "options": ["broken", "vandalized", "phishing"],
+          "default": "broken"
+        }
+      },
+      "eventDetailType": "disruption.content-swap"
+    },
+    {
+      "id": "latency-injection",
+      "name": "EC2 に latency 注入",
+      "defaultAfterMinutes": 30,
+      "operatorEditable": ["afterMinutes", "delayMs"],
+      "parameters": {
+        "delayMs": { "type": "int", "default": 200, "min": 50, "max": 2000 }
+      },
+      "eventDetailType": "disruption.latency-injection"
+    }
+  ]
+}</pre>
+
+<h3>template.yaml の受信側</h3>
+
+<pre>Resources:
+  # 競技者 account 内、Platform からの event を受ける専用 bus
+  DisruptionEventBus:
+    Type: AWS::Events::EventBus
+    Properties: { Name: !Sub "tenkacloud-disruption-${TeamId}" }
+
+  # Platform account からの PutEvents を許可
+  CrossAccountSource:
+    Type: AWS::Events::EventBusPolicy
+    Properties:
+      EventBusName: !Ref DisruptionEventBus
+      StatementId: tenkacloud-allow-platform
+      Statement:
+        Effect: Allow
+        Principal: { AWS: !Sub "arn:aws:iam::${TenkaCloudAccountId}:root" }
+        Action: events:PutEvents
+        Resource: !GetAtt DisruptionEventBus.Arn
+
+  # 妨害種別ごとに rule + Lambda (= metadata.disruptions[] と 1:1)
+  ContentSwapRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventBusName: !Ref DisruptionEventBus
+      EventPattern:
+        detail-type: ["disruption.content-swap"]
+        detail: { teamId: [!Ref TeamId] }
+      Targets:
+        - Arn: !GetAtt ContentSwapLambda.Arn
+
+  ContentSwapLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import boto3
+          def handler(event, _):
+              variant = event["detail"]["parameters"]["contentVariant"]
+              boto3.client("s3").copy_object(
+                Bucket="<bucket>", Key="index.html",
+                CopySource=f"<bucket>/_staging/{variant}/index.html"
+              )</pre>
+
+<h3>Platform 側に追加するもの</h3>
+
+<table>
+<thead><tr><th>component</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td><strong>DisruptionApi Lambda</strong></td>
+    <td>application-admin-console から受ける CRUD: <code>POST /events/:id/disruptions</code> (schedule 設定) / <code>POST .../disruptions/:id/trigger-now</code> / <code>DELETE .../disruptions/:id</code></td></tr>
+<tr><td><strong>DisruptionSchedule DDB</strong></td>
+    <td>Per (tenant, event, team, disruptionId) の予定情報 (= triggerAt / parameters / status) を保管。PROVISIONED 1/1</td></tr>
+<tr><td><strong>EventBridge Scheduler</strong></td>
+    <td>schedule された disruption の予定時刻 invoke 用。 1 つの central scheduler が DDB を見て fire する model</td></tr>
+<tr><td><strong>Central EventBridge bus "tenkacloud-disruption"</strong></td>
+    <td>全 competitor account が subscribe する publish-only bus</td></tr>
+</tbody>
+</table>
+
+<h3>operator UI mockup</h3>
+
+<details>
+<summary>Disruption Planner page (展開)</summary>
+<pre>┌─────────────────────────────────────────────────────────────────┐
+│  Spring Contest 2026 (event-01HZX...) &gt; 妨害設定               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ 全 team broadcast:  [全 team の content-swap を] [5min 後] [発動]│
+│                                                                 │
+│ ┌──────────┬──────────────────┬──────────┬─────────────────┐  │
+│ │ team     │ disruption       │ 予定時刻   │ 操作             │  │
+│ ├──────────┼──────────────────┼──────────┼─────────────────┤  │
+│ │ team-A   │ content-swap     │ 14:00:00 │ Edit  NOW  Cancel│  │
+│ │ team-A   │ latency-injection│ 13:30:00 │ Edit  NOW  Cancel│  │
+│ │ team-B   │ content-swap     │ 14:00:00 │ Edit  NOW  Cancel│  │
+│ │ team-B   │ latency-injection│ — (取消)  │ Restore          │  │
+│ │ team-C   │ ...              │ ...      │ ...              │  │
+│ └──────────┴──────────────────┴──────────┴─────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘</pre>
+</details>
+
+<p>= operator は「 team-A だけ EC2 latency を 200ms → 500ms に上げる」「team-C の content swap を 1 min 後に NOW 発動」 等を画面で操作可能。 全部 sub-second で全 competitor account に反映される。</p>
 </section>
 
 <section>

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-012: Problem plugin architecture — 問題は self-contained plugin、platform は generic host</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  tr.warn td { background: #fff8c5; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .8rem; margin: 1rem 0; }
+  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
+  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .decision-card .body { font-size: 0.88rem; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  .quote { border-left: 3px solid var(--c-warn); background: #fff8c5; padding: .5rem .9rem; margin: .8rem 0; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
+  .layer-diagram { background: var(--c-bg-soft); padding: 1rem; border-radius: 6px; font-family: monospace; font-size: 0.85rem; overflow-x: auto; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-012: Problem plugin architecture — 問題は self-contained plugin、platform は generic host</h1>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-12</div>
+    <div><b>Trigger:</b> PR-608 (#606 Phase 2 score engine) close</div>
+    <div><b>Related ADR:</b>
+      <a href="./adr-001-problem-deploy-crud.html">ADR-001</a>、
+      <a href="./adr-004-event-team-model.html">ADR-004</a>、
+      <a href="./adr-005-battle-portal-ui.html">ADR-005</a>、
+      ADR-008 (#574 user WIP)
+    </div>
+    <div><b>Related Issue:</b>
+      <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a>、
+      <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a>、
+      <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a>
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>2026-05-12: PR-608 (= #572 Microservices Migration Battle Phase 2 score engine) を close。理由は <strong>問題固有ロジック (DDB schema / endpoint registration API / polling Lambda / phase progression / +5,000 bonus) が platform 側 (<code>infrastructure/lib/problem-deploy/</code>) に書かれていた</strong>こと。これでは新問題を足すたびに platform を改造する設計になっており、 problem 追加が独立しない。</p>
+
+<div class="quote">
+ユーザー指摘 (2026-05-12): 「<b>問題側に評価関数や画面のコードがあったら追加できたり、差し替えたりできるようにできない</b>」 = problem は self-contained な plugin で、platform は generic host である<i>べき</i>。
+</div>
+
+<p>本 ADR で <strong>plugin architecture</strong> を確定する。問題は <code>problems/&lt;id&gt;/</code> 配下に scoring 宣言 + (任意) 評価関数 Lambda + (任意) Portal UI コンポーネント を同梱、platform は宣言を読んで dispatch する generic engine になる。</p>
+
+<table>
+<thead><tr><th>制約</th><th>由来</th><th>本 ADR への影響</th></tr></thead>
+<tbody>
+<tr><td>polling over SSE</td><td>memory <code>feedback_polling_over_sse</code></td>
+    <td>plugin scoring は polling 駆動、subscription は作らない</td></tr>
+<tr><td>cost 最小化 (DDB 1/1 PROVISIONED + Lambda only)</td><td>repo 経済設計</td>
+    <td>plugin Lambda の cold start / per-invoke cost を試算し、宣言的 DSL で済む 80% は Lambda 不要に</td></tr>
+<tr><td>secrets-manager-forbidden</td><td>harness rule</td>
+    <td>plugin code 配信は SSM Parameter Store SecureString / S3 + presigned URL のいずれか</td></tr>
+<tr><td>tenant 分離はインフラ層で</td><td><code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code></td>
+    <td>plugin Lambda は tenant 跨ぎできない IAM scope。DDB access は platform が proxy</td></tr>
+<tr><td>HTML 設計ドキュメント</td><td>memory <code>feedback_design_docs_html</code></td>
+    <td>本 ADR も HTML、plugin authoring guide も HTML</td></tr>
+<tr><td>private repo 分離計画</td><td>ADR-008 (#574 user WIP)</td>
+    <td>plugin code (= scoring + UI) も ADR-008 の S3 配信路に乗せる、設計を統合する</td></tr>
+</tbody>
+</table>
+
+<h3>現状 (= PR-608 で観測された設計違反)</h3>
+<ul>
+<li><code>infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/</code> — 問題名が platform ハンドラ名に出ている</li>
+<li><code>MicroserviceMigrationScoresTable</code> — 問題固有 DDB が platform stack に</li>
+<li><code>POST /problems/microservice-migration-battle/endpoints</code> — 問題名が route path に hard-coded</li>
+<li><code>scripts/deploy-battles.sh</code> + EC2 user-data の <code>tc qdisc</code> cron — phase 進行 logic が deploy script に</li>
+<li><strong>同じ罠が既存 <code>security-battle-royale</code> にもある可能性大</strong> (= 別 audit が要る)</li>
+</ul>
+</section>
+
+<section>
+<h2>解くべき設計判断</h2>
+
+<div class="decisions">
+  <div class="decision-card"><div class="num">D1</div><div class="title">宣言的 scoring DSL の形式</div><div class="body">metadata.json で何をどこまで宣言できるか</div></div>
+  <div class="decision-card"><div class="num">D2</div><div class="title">escape hatch (custom scoring Lambda)</div><div class="body">DSL で書けない 20% を per-problem Lambda で書ける仕組み</div></div>
+  <div class="decision-card"><div class="num">D3</div><div class="title">Portal UI 拡張機構</div><div class="body">問題ごとに React コンポーネント差し替え</div></div>
+  <div class="decision-card"><div class="num">D4</div><div class="title">plugin code 配信路</div><div class="body">scoring Lambda + UI bundle をどこに置きどう deliver するか</div></div>
+  <div class="decision-card"><div class="num">D5</div><div class="title">trust boundary / 信頼境界</div><div class="body">plugin code が誤動作 / 悪意 時に他 tenant / platform を巻き込まない</div></div>
+  <div class="decision-card"><div class="num">D6</div><div class="title">backward compat / migration</div><div class="body">既存 problem (security-battle-royale / hello-world / etc.) の取扱い</div></div>
+  <div class="decision-card"><div class="num">D7</div><div class="title">plugin author の開発体験</div><div class="body">local dev / test / debug</div></div>
+</div>
+
+<h3>D1. 宣言的 scoring DSL</h3>
+
+<p>metadata.json で 80% case を <strong>declarative</strong> に書ける DSL を定義する。Lambda 不要、JSON だけで済む。</p>
+
+<table>
+<thead><tr><th>kind</th><th>用途</th><th>schema 例</th></tr></thead>
+<tbody>
+<tr><td><code>uptime-flat</code></td>
+    <td>固定 endpoint を probe、ok=+pt / fail=skip (= 既存 hello-world-battle 等)</td>
+    <td><code>{ kind: "uptime-flat", endpoints: [{ outputKey, path, expectStatus, pointsPerSuccess }] }</code></td></tr>
+<tr><td><code>flag</code></td>
+    <td>1 回提出型 flag、StackOutput 比較 (= 既存 hello-world)</td>
+    <td><code>{ kind: "flag", flagOutputKey: "FlagValue", points: 100 }</code></td></tr>
+<tr><td><code>phased-polling</code></td>
+    <td>時刻でフェーズが進む polling、platform 別配点、bonus (= #572 microservice-migration)</td>
+    <td>下記の details 参照</td></tr>
+<tr><td><code>battle-attacks</code></td>
+    <td>Battle 攻撃検知 (= 既存 security-battle-royale)</td>
+    <td><code>{ kind: "battle-attacks", attackedEndpoints: [...], pointsPerAttack: -50 }</code></td></tr>
+<tr><td><code>custom</code></td>
+    <td>D2 escape hatch を発動 (= per-problem Lambda)</td>
+    <td><code>{ kind: "custom", lambdaSource: "scoring/index.ts" }</code></td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D1: <code>phased-polling</code> の具体 schema (= #572 を表現する)</summary>
+<pre>{
+  "kind": "phased-polling",
+  "slots": ["users", "orders", "catalog"],
+  "registrationApi": "platform.endpointRegistry",   // platform 側が generic endpoint registry を提供
+  "metaPath": "/meta",
+  "scorePath": "/score",
+  "platformRules": {
+    "ec2":       { "points": 100,  "degradedPoints": 10 },
+    "lambda":    { "points": 1000 },
+    "ecs":       { "points": 1000 },
+    "apprunner": { "points": 1000 }
+  },
+  "phases": [
+    { "name": "deploy",      "afterMinutes": 0  },
+    { "name": "degraded",    "afterMinutes": 60, "switchPlatformDegraded": ["ec2"] },
+    { "name": "legacy",      "afterMinutes": 90, "scorePathOverride": "/score?legacy=true" }
+  ],
+  "responsePenalties": [
+    { "if": "responseTimeMs > 1500", "points": 10 }
+  ],
+  "bonuses": [
+    { "kind": "all-slots-on-platforms", "platforms": ["lambda","ecs","apprunner"], "points": 5000 }
+  ]
+}</pre>
+<p>この schema を platform の <code>phased-polling</code> evaluator が 1 分毎の polling で解釈し、ScoreEvent を発行する。問題側コードは 0 行。</p>
+</details>
+
+<h3>D2. escape hatch — custom scoring Lambda</h3>
+
+<p>DSL で書けない複雑な評価 (= 例: SQL injection 検出 / 解の正解判定が動的に変わる / 競技者の発信した値を集計) は <strong>問題側に Lambda を同梱</strong>。</p>
+
+<table>
+<thead><tr><th>項目</th><th>仕様</th></tr></thead>
+<tbody>
+<tr><td>場所</td><td><code>problems/&lt;id&gt;/scoring/</code> (TypeScript)、entry は <code>scoring/index.ts</code> の <code>export async function score(event): Promise&lt;ScoreResult&gt;</code></td></tr>
+<tr><td>build</td><td>Phase 1: platform CDK が <code>NodejsFunction</code> で個別 Lambda を立てる (= problemId が Function 名 prefix)。Phase 2 で ADR-008 と統合し S3 + Lambda Layers / RIE で per-problem 配信に</td></tr>
+<tr><td>invocation</td><td>generic polling Lambda が <code>InvokeCommand</code> で問題ごとの scoring Lambda を呼ぶ (= EventBridge 経由 fanout は overkill)</td></tr>
+<tr><td>signature</td><td><code>(event: { tenantId, slot, registeredUrl, phaseElapsedMin, prevState }) =&gt; Promise&lt;{ delta, platform, emitEvent, newState }&gt;</code></td></tr>
+<tr><td>state</td><td>必要なら <code>prevState</code> + <code>newState</code> で per-(tenant, slot) state を保持。platform が DDB に書き込む</td></tr>
+<tr><td>限界</td><td>scoring Lambda は <strong>tenant 跨ぎ access 不可</strong> (= IAM が tenant scope に絞る)。外部 HTTP は許可 (= 競技者 endpoint probe)、AWS SDK は限定 IAM で許可</td></tr>
+</tbody>
+</table>
+
+<h3>D3. Portal UI 拡張機構</h3>
+
+<table>
+<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<tbody>
+<tr class="show"><td><b>D3-A</b></td><td><span class="badge accept">採用</span></td>
+   <td><b>動的 import + S3 配信</b>。問題側 <code>problems/&lt;id&gt;/portal/</code> を Vite で別 bundle にビルド (= ESM module、~50 KB target)、Cloudfront/S3 配信。participant-portal が <code>React.lazy(() =&gt; import(/* @vite-ignore */ pluginUrl))</code> で runtime load</td>
+   <td>build 1 段増 (= per-problem rollup)、CSP 設計が要る</td></tr>
+<tr class="hide"><td>D3-B</td><td><span class="badge reject">却下</span></td>
+   <td>Module Federation (Webpack Federation)</td>
+   <td>Vite ベースなので技術スタック分裂、SSR 想定なし</td></tr>
+<tr class="hide"><td>D3-C</td><td><span class="badge reject">却下</span></td>
+   <td>iframe 埋め込み</td>
+   <td>shared design system (Cloudscape) が使えない、cross-origin の状態同期が辛い</td></tr>
+<tr class="hide"><td>D3-D</td><td><span class="badge reject">却下</span></td>
+   <td>宣言的 UI schema (JSON で描画指定)</td>
+   <td>複雑な UI が表現不能、escape hatch が要る → 結局 D3-A と二重実装</td></tr>
+</tbody>
+</table>
+
+<details>
+<summary>D3-A の plugin component contract</summary>
+<pre>// problems/&lt;id&gt;/portal/index.tsx
+import type { ProblemPortalPlugin } from "@tenkacloud/portal-plugin-sdk";
+
+const plugin: ProblemPortalPlugin = {
+  problemId: "microservice-migration-battle",
+  components: {
+    RegistrationPanel: ({ slots, registered, onRegister }) =&gt; { /* JSX */ },
+    StatusPanel:       ({ team, scores })                   =&gt; { /* JSX */ },
+    HelpDrawer:        ({ language })                       =&gt; { /* JSX */ },
+  },
+  routes: [
+    { path: "/migration-progress", element: &lt;MigrationProgress /&gt; },
+  ],
+};
+
+export default plugin;
+</pre>
+<p>participant-portal は <code>config.problems[].pluginUrl</code> を runtime-config から読み、必要な component を slot に挿入する (= "RegistrationPanel" を Home に、"StatusPanel" を ScoreBoard に、等の slot 規約)。Cloudscape components は SDK 経由で共有 (= duplicate bundle を避ける)。</p>
+</details>
+
+<h3>D4. plugin code 配信路 (= ADR-008 と統合)</h3>
+
+<p><strong>scoring Lambda + UI bundle</strong> を以下の経路で配信する:</p>
+
+<table>
+<thead><tr><th>環境</th><th>scoring Lambda</th><th>UI bundle</th></tr></thead>
+<tbody>
+<tr><td>dev (local)</td>
+    <td><code>problems/&lt;id&gt;/scoring/</code> を直接 NodejsFunction で deploy</td>
+    <td><code>vite dev</code> で plugin 経路を inline serve</td></tr>
+<tr><td>production (= public problem)</td>
+    <td>CFn パイプラインが <code>problems/&lt;id&gt;/scoring/</code> を S3 にアップロード → Lambda を s3 source から作る</td>
+    <td>UI bundle も同じ S3 prefix にアップロード、CloudFront 配信</td></tr>
+<tr><td>production (= private problem、ADR-008)</td>
+    <td>private repo <code>TenkaCloudChallenges</code> の CI が S3 (= 運営 account の private bucket) に zip 配置、Worker が presigned URL でダウンロード</td>
+    <td>UI bundle も同じ private bucket に置き、portal が **15 分 TTL presigned URL** で fetch (= 答え漏れ対策)</td></tr>
+</tbody>
+</table>
+
+<p>ADR-008 (#574 user WIP) が確定したら、本 ADR-012 の "production private" 経路を ADR-008 の S3 + presigned URL spec に合致させる。Phase 1 は public 経路のみで MVP 立ち上げ。</p>
+
+<h3>D5. trust boundary / 信頼境界</h3>
+
+<p>plugin code (= scoring Lambda + UI bundle) は <strong>第三者寄稿の可能性</strong> (将来) + <strong>誤動作リスク</strong> を抱える。次の境界で隔離:</p>
+
+<table>
+<thead><tr><th>境界</th><th>scoring Lambda</th><th>UI bundle</th></tr></thead>
+<tbody>
+<tr><td>IAM</td>
+    <td>per-problem 専用 role、DDB は platform proxy table のみ Read/Write、 cross-tenant access 不可</td>
+    <td>(N/A、frontend)</td></tr>
+<tr><td>network</td>
+    <td>outbound HTTP は許可 (= 競技者 endpoint probe)。AWS API は IAM で絞る</td>
+    <td>portal-host の origin に同梱 (= CORS は同 origin で問題なし)</td></tr>
+<tr><td>memory / CPU</td>
+    <td>Lambda 標準 sandbox。timeout 30s 上限</td>
+    <td>browser tab sandbox</td></tr>
+<tr><td>secrets</td>
+    <td>SSM Parameter Store SecureString は read 不可 (platform proxy のみ可能)</td>
+    <td>tokenless (= portal の teamLoginKey は SDK が wrap)</td></tr>
+<tr><td>code review</td>
+    <td>PR ベースで人間 review (= ADR-008 community contribution review)</td>
+    <td>同上</td></tr>
+<tr><td>CSP</td>
+    <td>(N/A)</td>
+    <td>portal の CSP で <code>script-src</code> 制限。Plugin URL は許可リストで明示</td></tr>
+</tbody>
+</table>
+
+<h3>D6. backward compat / migration</h3>
+
+<p>既存 3 問題 (= <code>hello-world-battle</code> / <code>security-battle-royale</code> / <code>hello-world</code>) は本 ADR 採択後、段階的に新 plugin pattern に migrate する。</p>
+
+<table>
+<thead><tr><th>問題</th><th>現状</th><th>migration plan</th></tr></thead>
+<tbody>
+<tr><td><code>hello-world-battle</code></td>
+    <td>health-check-handler が metadata の <code>endpoints</code> を読んで polling (= ほぼ DSL)</td>
+    <td><code>kind: "uptime-flat"</code> declarative DSL に formalize、health-check-handler を generic evaluator として renaming</td></tr>
+<tr><td><code>security-battle-royale</code></td>
+    <td>battle-attacks handler が problem 固有の判定を含む可能性大 (= audit 必要)</td>
+    <td><code>kind: "battle-attacks"</code> として DSL 化、固有 logic は scoring Lambda escape hatch に移行</td></tr>
+<tr><td><code>hello-world</code></td>
+    <td>flag 提出型、submit-flag handler が generic</td>
+    <td><code>kind: "flag"</code> declarative DSL に formalize、submit-flag handler を generic evaluator として renaming</td></tr>
+<tr><td><code>microservice-migration-battle</code></td>
+    <td>Phase 1 ship 済 (problem files のみ)、Phase 2 (PR-608) は close</td>
+    <td><code>kind: "phased-polling"</code> DSL を実装 → metadata.json で declarative に書き直す。scoring Lambda は不要</td></tr>
+</tbody>
+</table>
+
+<h3>D7. plugin author の開発体験</h3>
+
+<ul>
+<li><code>/create-problem</code> skill が plugin pattern の雛形 (= <code>metadata.json</code> + <code>scoring/index.ts</code> stub + <code>portal/index.tsx</code> stub) を生成</li>
+<li>local dev: <code>bunx tenkacloud problem dev &lt;problemId&gt;</code> で plugin を local serve、participant-portal の dev server に hot-reload で挿す</li>
+<li>test: <code>problems/&lt;id&gt;/scoring/index.test.ts</code> で Lambda handler 単体テスト (= vitest + AWS SDK mock)。<code>portal/&lt;component&gt;.test.tsx</code> で UI render テスト</li>
+<li>schema validation: <code>make validate-problems</code> が DSL を SCHEMA.json 拡張で型 check</li>
+</ul>
+</section>
+
+<section>
+<h2>Decision (まとめ)</h2>
+
+<table>
+<thead><tr><th>#</th><th>決定</th><th>場所</th></tr></thead>
+<tbody>
+<tr><td>D1</td><td>declarative scoring DSL (5 kind: uptime-flat / flag / phased-polling / battle-attacks / custom)</td><td><code>problems/SCHEMA.json</code> 拡張 + platform <code>generic-scoring-engine</code> Lambda</td></tr>
+<tr><td>D2</td><td>escape hatch: per-problem scoring Lambda (signature 固定、IAM 最小)</td><td><code>problems/&lt;id&gt;/scoring/index.ts</code></td></tr>
+<tr><td>D3</td><td>動的 import + S3 配信 React.lazy plugin</td><td><code>problems/&lt;id&gt;/portal/index.tsx</code> + Vite plugin build + S3 + portal の <code>config.problems[].pluginUrl</code></td></tr>
+<tr><td>D4</td><td>scoring Lambda + UI bundle を ADR-008 の S3 経路に乗せる。MVP は public 同梱で立ち上げ</td><td>S3 prefix per problem + presigned URL (private 化時)</td></tr>
+<tr><td>D5</td><td>IAM scope per-problem role + portal CSP 許可リスト + PR-ベース code review</td><td>CDK + portal hosting CSP header</td></tr>
+<tr><td>D6</td><td>既存 4 問題は段階移行。hello-world / hello-world-battle は declarative 化、security-battle-royale は audit 後 DSL or escape hatch、microservice-migration は phased-polling DSL を実装</td><td>Phase 別 PR</td></tr>
+<tr><td>D7</td><td><code>/create-problem</code> 雛形 + <code>tenkacloud problem dev</code> CLI + vitest + SCHEMA.json validation</td><td>新 CLI subcommand (= ADR-010 #578 と整合) + skill 更新</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>段階的ロールアウト</h2>
+
+<table>
+<thead><tr><th>Phase</th><th>scope</th><th>依存</th></tr></thead>
+<tbody>
+<tr><td>Phase 1 (本 PR)</td>
+    <td>ADR-012 起草。SCHEMA.json 拡張仕様 / scoring Lambda signature / portal plugin contract を文書化</td>
+    <td>本 ADR 採択</td></tr>
+<tr><td>Phase 2</td>
+    <td><code>problems/SCHEMA.json</code> を 5 kind 対応に拡張 + <code>make validate-problems</code> が DSL を検証。既存 3 問題の metadata.json を新 DSL に書き換え (= 既存挙動を unchanged で再現)</td>
+    <td>Phase 1</td></tr>
+<tr><td>Phase 3</td>
+    <td>platform に generic-scoring-engine Lambda を導入 (= 既存 health-check-handler / submit-flag handler を refactor して DSL 駆動に)。3 既存問題が新 engine で動くことを e2e 検証</td>
+    <td>Phase 2</td></tr>
+<tr><td>Phase 4</td>
+    <td>escape hatch (D2): scoring Lambda per-problem の CDK pattern + IAM template を確立。microservice-migration-battle を Phase 1 で defer した phased-polling DSL で実装</td>
+    <td>Phase 3</td></tr>
+<tr><td>Phase 5</td>
+    <td>Portal plugin (D3): participant-portal の plugin loader 実装 + 1 sample problem (= microservice-migration-battle の Registration / Status Panel) を新 mechanism で実装</td>
+    <td>Phase 3</td></tr>
+<tr><td>Phase 6</td>
+    <td>ADR-008 (#574) と統合: private repo + S3 + presigned URL 経由の plugin 配信。public 同梱経路は dev / sample 限定に</td>
+    <td>ADR-008 採択</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>positive</h3>
+<ul>
+<li>新問題を足すのに <strong>platform を改造不要</strong> (= 問題ファイル + 任意 scoring/portal の追加だけ)</li>
+<li>問題の <strong>差し替え</strong> が可能 (= 同 problemId で metadata + scoring/index.ts を更新するだけ)</li>
+<li>community contribution (= ADR-008 が描く第三者寄稿) と整合: 寄稿者が repo 構造を理解する範囲は <code>problems/&lt;id&gt;/</code> だけで済む</li>
+<li>既存 <code>security-battle-royale</code> も同じ枠組みに乗せられる (= 現在の隠れた platform-bleed を解消)</li>
+<li>plugin author に <strong>明示 SDK</strong> (= <code>@tenkacloud/scoring-sdk</code> + <code>@tenkacloud/portal-plugin-sdk</code>) を提供することで、 platform-side ABI が安定し PR review が機械化できる</li>
+</ul>
+
+<h3>negative</h3>
+<ul>
+<li>初期 setup 工数大: 4 phase (= 5 PR 程度) の段階移行。dogfood 中の 0 user 環境を考えるとペイする</li>
+<li>per-problem scoring Lambda の cold start: 1 min 間隔 polling では invoke 頻度低いので worst-case 1 invoke/min × ~1s = 60s cold start hit / hour、許容</li>
+<li>UI plugin の lazy load による初回表示遅延: ~50 KB plugin bundle + CSS、~200ms 想定。preload で緩和可</li>
+<li>plugin author に SDK + dev workflow を学習させる必要 — ドキュメント整備コスト</li>
+<li>schema migration: 既存 metadata.json に <code>scoring.kind</code> 等の field を追加する breaking change。Phase 2 で一度に migrate</li>
+</ul>
+
+<h3>open questions (= follow-up)</h3>
+<ul>
+<li>scoring Lambda の <strong>言語</strong>: TypeScript 縛りで良いか / Python も許容するか (= NodejsFunction vs Function + Container Image)</li>
+<li>scoring Lambda の <strong>versioning</strong>: 同 problemId で複数 version 並存 (= A/B 競技開催) を許可するか</li>
+<li>portal plugin の <strong>i18n</strong>: ADR-008 / #583 i18n と整合する design / API surface</li>
+<li>plugin の <strong>circuit breaker</strong>: scoring Lambda が連続失敗したときの platform 側 fallback (= 0 点 vs skip vs operator alert)</li>
+<li>ADR-008 確定との <strong>順序</strong>: ADR-008 を待たずに本 ADR の Phase 2-5 を進められるか (= public 同梱で MVP 立ち上げて、Phase 6 で private 配信を後付け)</li>
+</ul>
+</section>
+
+<section>
+<h2>関連リソース</h2>
+<ul>
+<li>PR-608 (close 済) — 本 ADR の trigger となった platform-bleed の例</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 2 score engine、本 ADR 採択後に再実装する対象</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR と統合する private repo 分離設計</li>
+<li>ADR <a href="./adr-005-battle-portal-ui.html">ADR-005</a> — Battle Portal UI 基盤 (= D3 Portal plugin の host)</li>
+<li>ADR <a href="./adr-001-problem-deploy-crud.html">ADR-001</a> — Problem Deploy 基盤 (= 本 ADR の scoring engine が乗る台)</li>
+<li>memory <code>feedback_problems_as_plugins</code> — 本 ADR のトリガーとなったユーザー指摘</li>
+</ul>
+</section>
+</body>
+</html>

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -139,45 +139,73 @@
 <p>UserData 内なので platform は知らない、ただ deploy するだけ。</p>
 </details>
 
-<h3>endpoint 多様性 — 1 / N / N slot の 3 パターンを統一</h3>
+<h3>endpoint = default + override 可能な slot (= 統一モデル)</h3>
 
-<p>採点対象 endpoint は問題により <strong>数が違う</strong>。<code>metadata.json</code> で 2 種類を併用宣言:</p>
+<p>全 endpoint は <strong>1 つの統一モデル</strong> で扱う:</p>
 
 <table>
-<thead><tr><th>パターン</th><th>例</th><th>由来</th></tr></thead>
+<thead><tr><th>要素</th><th>内容</th></tr></thead>
 <tbody>
-<tr><td>1 endpoint (単一)</td><td><code>hello-world-battle</code></td><td>CFn output から 1 つ</td></tr>
-<tr><td>N endpoint (複数監視)</td><td><code>security-battle-royale</code></td><td>CFn output から N 個 (例: <code>/admin</code> + <code>/api</code> を両方 probe)</td></tr>
-<tr><td>N slot (競技者登録)</td><td><code>microservice-migration-battle</code></td><td>競技者が portal UI から N URL を登録</td></tr>
+<tr><td><strong>slot</strong></td><td>問題が宣言する endpoint の役割名 (例: <code>main</code> / <code>admin</code> / <code>users</code>)</td></tr>
+<tr><td><strong>default URL</strong></td><td>CFn output から自動取得 or 固定値。deploy 直後はこれが使われる</td></tr>
+<tr><td><strong>override</strong></td><td>競技者が portal UI で別 URL に変更可能。 <strong>effective URL = override || default</strong></td></tr>
 </tbody>
 </table>
 
-<pre>// problems/&lt;id&gt;/metadata.json
+<p><strong>なぜこの形か</strong>: Battle 問題では競技者が deploy 直後の構成を <strong>変えていく</strong> ことが本質的:</p>
+
+<ul>
+<li><code>security-battle-royale</code>: default は S3 直 URL → 競技者が CloudFront を前段に置いたら新 URL で override</li>
+<li><code>microservice-migration-battle</code>: default は EC2 の 3 path → Lambda / ECS / App Runner に切り出したら slot ごとに override</li>
+<li><code>hello-world-battle</code>: default の EC2 URL のまま (= override 不要)、あるいは CDN を被せて override</li>
+</ul>
+
+<pre>// problems/&lt;id&gt;/metadata.json (= security-battle-royale 例)
 {
-  "endpoints": {
-    "static": [
-      // CFn output 経由の fixed endpoints (= 問題の deploy 直後から確定)
-      { "outputKey": "EndpointUrl", "name": "main", "path": "/health" }
-    ],
-    "registered": [
-      // 競技者が portal UI で URL を入れる slot (= 動的、後追い登録)
-      { "slot": "users",   "required": true,  "label": "users service URL" },
-      { "slot": "orders",  "required": true },
-      { "slot": "catalog", "required": true }
-    ]
-  }
+  "endpoints": [
+    {
+      "slot": "main",
+      "default": { "from": "cfn-output", "key": "EndpointUrl" },
+      "overridable": true,
+      "label": "メイン endpoint",
+      "description": "deploy 直後は S3 直、CDN / WAF 等を被せて変更可能"
+    },
+    {
+      "slot": "admin",
+      "default": { "from": "cfn-output", "key": "AdminUrl" },
+      "overridable": true
+    }
+  ]
 }</pre>
 
-<p>Platform は <strong>generic な endpoint registry API</strong> (= <code>POST /problems/:id/endpoints { slot, url }</code>) を提供。problem 固有 route は不要。<code>scoring/index.ts</code> には統一形で渡される:</p>
+<pre>// microservice-migration-battle 例 (= 3 slot、各 slot を別 hosting に切り出す)
+{
+  "endpoints": [
+    { "slot": "users",   "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/users" },   "overridable": true },
+    { "slot": "orders",  "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/orders" },  "overridable": true },
+    { "slot": "catalog", "default": { "from": "cfn-output", "key": "Ec2BaseUrl", "appendPath": "/catalog" }, "overridable": true }
+  ]
+}</pre>
+
+<p>Platform は <strong>3 機能の generic な endpoint registry</strong> を提供:</p>
+
+<ol>
+<li>deploy 直後に CFn output から default URL を抽出して各 slot に書き込む</li>
+<li>競技者の override (<code>POST /problems/:id/endpoints { slot, url }</code>) を受け付ける</li>
+<li>effective URL (= override があれば override、無ければ default) を scoring / engine に渡す</li>
+</ol>
+
+<p><code>scoring/index.ts</code> / <code>engine/index.ts</code> には統一形で渡る:</p>
 
 <pre>event.endpoints = {
-  static:     { main:    "https://abc.execute-api.../" },
-  registered: { users:   "https://...",
-                orders:  undefined,       // 未登録
-                catalog: "https://..." }
+  users:   "https://d12345.cloudfront.net/users",     // ← competitor が CDN 被せて override
+  orders:  "http://ec2-abc.amazonaws.com/orders",     // ← default のまま (未 override)
+  catalog: "https://api-gw.execute-api.../catalog"    // ← Lambda + API GW に移して override
 }</pre>
 
-<p>問題側は必要な数だけ probe する (1 / N / N slot を同じ contract で扱える)。</p>
+<p>問題側は slot 名で endpoint を引いて probe するだけ。endpoint が <strong>1 つでも N 個でも</strong>同じ contract。</p>
+
+<p><strong>Challenge (flag 系)</strong> は endpoint 概念を持たない (= 提出 form 経由)。<code>metadata.json</code> の <code>endpoints</code> 配列を省略するだけ。</p>
 
 <h3>② 採点 (<code>scoring/index.ts</code>) — Battle 主用途、Challenge は省略可</h3>
 

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<title>ADR-012: Problem plugin architecture — 問題は self-contained plugin、platform は generic host</title>
+<title>ADR-012: Problem plugin architecture — 4 アセット (resources / scoring / engine / portal) + generic dispatcher</title>
 <style>
   :root {
     --c-text: #1f2328;
@@ -40,296 +40,322 @@
   .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
   .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
   .badge.warn    { background: #fff8c5; color: var(--c-warn); }
-  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .8rem; margin: 1rem 0; }
-  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
-  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
-  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
-  .decision-card .body { font-size: 0.88rem; }
-  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
-  details > summary { cursor: pointer; font-weight: 600; }
   pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
   .quote { border-left: 3px solid var(--c-warn); background: #fff8c5; padding: .5rem .9rem; margin: .8rem 0; border-radius: 0 4px 4px 0; font-size: 0.92rem; }
-  .layer-diagram { background: var(--c-bg-soft); padding: 1rem; border-radius: 6px; font-family: monospace; font-size: 0.85rem; overflow-x: auto; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  .asset-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .8rem; margin: 1rem 0; }
+  .asset-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
+  .asset-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .asset-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .asset-card .body { font-size: 0.88rem; }
 </style>
 </head>
 <body>
 <header>
-  <h1>ADR-012: Problem plugin architecture — 問題は self-contained plugin、platform は generic host</h1>
+  <h1>ADR-012: Problem plugin architecture — 4 アセット (resources / scoring / engine / portal) + generic dispatcher</h1>
   <div class="meta">
     <div><b>Status:</b><span class="badge accept">Proposed</span> 2026-05-12</div>
     <div><b>Trigger:</b> PR-608 (#606 Phase 2 score engine) close</div>
     <div><b>Related ADR:</b>
       <a href="./adr-001-problem-deploy-crud.html">ADR-001</a>、
-      <a href="./adr-004-event-team-model.html">ADR-004</a>、
       <a href="./adr-005-battle-portal-ui.html">ADR-005</a>、
       ADR-008 (#574 user WIP)
     </div>
     <div><b>Related Issue:</b>
       <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a>、
-      <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a>、
-      <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a>
+      <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a>
     </div>
   </div>
 </header>
 
 <section>
-<h2>Context</h2>
+<h2>欲しい姿 (= 一目で分かる version)</h2>
 
-<p>2026-05-12: PR-608 (= #572 Microservices Migration Battle Phase 2 score engine) を close。理由は <strong>問題固有ロジック (DDB schema / endpoint registration API / polling Lambda / phase progression / +5,000 bonus) が platform 側 (<code>infrastructure/lib/problem-deploy/</code>) に書かれていた</strong>こと。これでは新問題を足すたびに platform を改造する設計になっており、 problem 追加が独立しない。</p>
+<p>1 問題は <strong>4 つのアセット</strong> を持つ。Platform は 4 つを <strong>generic に host するだけ</strong>。</p>
+
+<pre>problems/&lt;id&gt;/
+├── metadata.json    # 宣言 (既存)
+├── template.yaml    # ①リソース      = 競技者 AWS account に立つ CFn
+├── scoring/         # ②採点          = 観測 → スコア計算
+│   └── index.ts
+├── engine/          # ③攻撃 / 仕組み = 時間駆動の active な変化 (Battle 主用途)
+│   └── index.ts
+└── portal/          # ④ダッシュボード = 競技者の画面
+    └── index.tsx</pre>
+
+<p><strong>新問題を足す = この dir を 1 個 git add するだけ</strong>。 platform は触らない。 差し替えも同 dir を更新するだけ。</p>
 
 <div class="quote">
-ユーザー指摘 (2026-05-12): 「<b>問題側に評価関数や画面のコードがあったら追加できたり、差し替えたりできるようにできない</b>」 = problem は self-contained な plugin で、platform は generic host である<i>べき</i>。
+ユーザー指摘 (2026-05-12): 「<b>攻撃とかの仕組みは問題側のコードで作ればいい</b>」 + 「<b>Challenge は共通化できるが、Battle は柔軟性が必要</b>」 = この ADR の根本方針。
 </div>
-
-<p>本 ADR で <strong>plugin architecture</strong> を確定する。問題は <code>problems/&lt;id&gt;/</code> 配下に scoring 宣言 + (任意) 評価関数 Lambda + (任意) Portal UI コンポーネント を同梱、platform は宣言を読んで dispatch する generic engine になる。</p>
-
-<table>
-<thead><tr><th>制約</th><th>由来</th><th>本 ADR への影響</th></tr></thead>
-<tbody>
-<tr><td>polling over SSE</td><td>memory <code>feedback_polling_over_sse</code></td>
-    <td>plugin scoring は polling 駆動、subscription は作らない</td></tr>
-<tr><td>cost 最小化 (DDB 1/1 PROVISIONED + Lambda only)</td><td>repo 経済設計</td>
-    <td>plugin Lambda の cold start / per-invoke cost を試算し、宣言的 DSL で済む 80% は Lambda 不要に</td></tr>
-<tr><td>secrets-manager-forbidden</td><td>harness rule</td>
-    <td>plugin code 配信は SSM Parameter Store SecureString / S3 + presigned URL のいずれか</td></tr>
-<tr><td>tenant 分離はインフラ層で</td><td><code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code></td>
-    <td>plugin Lambda は tenant 跨ぎできない IAM scope。DDB access は platform が proxy</td></tr>
-<tr><td>HTML 設計ドキュメント</td><td>memory <code>feedback_design_docs_html</code></td>
-    <td>本 ADR も HTML、plugin authoring guide も HTML</td></tr>
-<tr><td>private repo 分離計画</td><td>ADR-008 (#574 user WIP)</td>
-    <td>plugin code (= scoring + UI) も ADR-008 の S3 配信路に乗せる、設計を統合する</td></tr>
-</tbody>
-</table>
-
-<h3>現状 (= PR-608 で観測された設計違反)</h3>
-<ul>
-<li><code>infrastructure/lib/problem-deploy/handlers/microservice-migration-registration-handler/</code> — 問題名が platform ハンドラ名に出ている</li>
-<li><code>MicroserviceMigrationScoresTable</code> — 問題固有 DDB が platform stack に</li>
-<li><code>POST /problems/microservice-migration-battle/endpoints</code> — 問題名が route path に hard-coded</li>
-<li><code>scripts/deploy-battles.sh</code> + EC2 user-data の <code>tc qdisc</code> cron — phase 進行 logic が deploy script に</li>
-<li><strong>同じ罠が既存 <code>security-battle-royale</code> にもある可能性大</strong> (= 別 audit が要る)</li>
-</ul>
 </section>
 
 <section>
-<h2>解くべき設計判断</h2>
-
-<div class="decisions">
-  <div class="decision-card"><div class="num">D1</div><div class="title">宣言的 scoring DSL の形式</div><div class="body">metadata.json で何をどこまで宣言できるか</div></div>
-  <div class="decision-card"><div class="num">D2</div><div class="title">escape hatch (custom scoring Lambda)</div><div class="body">DSL で書けない 20% を per-problem Lambda で書ける仕組み</div></div>
-  <div class="decision-card"><div class="num">D3</div><div class="title">Portal UI 拡張機構</div><div class="body">問題ごとに React コンポーネント差し替え</div></div>
-  <div class="decision-card"><div class="num">D4</div><div class="title">plugin code 配信路</div><div class="body">scoring Lambda + UI bundle をどこに置きどう deliver するか</div></div>
-  <div class="decision-card"><div class="num">D5</div><div class="title">trust boundary / 信頼境界</div><div class="body">plugin code が誤動作 / 悪意 時に他 tenant / platform を巻き込まない</div></div>
-  <div class="decision-card"><div class="num">D6</div><div class="title">backward compat / migration</div><div class="body">既存 problem (security-battle-royale / hello-world / etc.) の取扱い</div></div>
-  <div class="decision-card"><div class="num">D7</div><div class="title">plugin author の開発体験</div><div class="body">local dev / test / debug</div></div>
-</div>
-
-<h3>D1. 宣言的 scoring DSL</h3>
-
-<p>metadata.json で 80% case を <strong>declarative</strong> に書ける DSL を定義する。Lambda 不要、JSON だけで済む。</p>
+<h2>Challenge と Battle のスタンス差</h2>
 
 <table>
-<thead><tr><th>kind</th><th>用途</th><th>schema 例</th></tr></thead>
+<thead><tr><th></th><th>Challenge</th><th>Battle</th></tr></thead>
 <tbody>
-<tr><td><code>uptime-flat</code></td>
-    <td>固定 endpoint を probe、ok=+pt / fail=skip (= 既存 hello-world-battle 等)</td>
-    <td><code>{ kind: "uptime-flat", endpoints: [{ outputKey, path, expectStatus, pointsPerSuccess }] }</code></td></tr>
-<tr><td><code>flag</code></td>
-    <td>1 回提出型 flag、StackOutput 比較 (= 既存 hello-world)</td>
-    <td><code>{ kind: "flag", flagOutputKey: "FlagValue", points: 100 }</code></td></tr>
-<tr><td><code>phased-polling</code></td>
-    <td>時刻でフェーズが進む polling、platform 別配点、bonus (= #572 microservice-migration)</td>
-    <td>下記の details 参照</td></tr>
-<tr><td><code>battle-attacks</code></td>
-    <td>Battle 攻撃検知 (= 既存 security-battle-royale)</td>
-    <td><code>{ kind: "battle-attacks", attackedEndpoints: [...], pointsPerAttack: -50 }</code></td></tr>
-<tr><td><code>custom</code></td>
-    <td>D2 escape hatch を発動 (= per-problem Lambda)</td>
-    <td><code>{ kind: "custom", lambdaSource: "scoring/index.ts" }</code></td></tr>
+<tr><td>性格</td>
+    <td>静的・個別演習。flag 提出 or 単純 uptime</td>
+    <td>動的・対戦型。時間駆動の攻撃 / 妨害 / 多段 phase</td></tr>
+<tr><td>採点 (②)</td>
+    <td><strong>宣言で十分</strong> (= 80% case)。metadata.json の <code>scoring.kind = "flag"</code> or <code>"uptime-flat"</code> で platform 内蔵 evaluator が動く。<code>scoring/index.ts</code> は <strong>不要</strong></td>
+    <td><strong>カスタム Lambda 推奨</strong> (= 80% case)。<code>scoring/index.ts</code> を問題側で書き、phase / platform 分類 / 多段配点 / bonus を自由に表現</td></tr>
+<tr><td>攻撃 / 仕組み (③)</td>
+    <td><strong>原則無し</strong>。Challenge は時間駆動の active 攻撃を持たない</td>
+    <td><strong>必須</strong> (= 多くの Battle で)。<code>engine/index.ts</code> を schedule で invoke、競技者環境を能動的に変える (= EC2 latency 注入 / phase flag flip / 攻撃発動)</td></tr>
+<tr><td>portal (④)</td>
+    <td><strong>generic で十分</strong>。flag 提出 form + score 表示は platform 内蔵 component を流用。<code>portal/</code> は<strong>不要</strong></td>
+    <td><strong>カスタム推奨</strong>。Battle 固有 UX (= phase countdown / 攻撃 timeline / multi-slot 登録 form) を <code>portal/index.tsx</code> で書く</td></tr>
+<tr><td>具体例</td>
+    <td><code>hello-world</code> (flag) / <code>hello-world-battle</code> (uptime-flat 中身は実は Challenge 寄り)</td>
+    <td><code>security-battle-royale</code> / <code>microservice-migration-battle</code></td></tr>
 </tbody>
 </table>
 
+<p><strong>運用ルール</strong>: Challenge は metadata + template だけで完結 (= 雛形がほぼコピペ)。Battle は 4 つ揃える前提で書く (= 個別 build / test が必要)。Platform はどちらにも対応する generic dispatcher。</p>
+</section>
+
+<section>
+<h2>4 アセットの contract</h2>
+
+<h3>① リソース (<code>template.yaml</code>) — 既存</h3>
+
+<p>CFn template。競技者 AWS account に deploy される。<strong>passive な仕掛け</strong> (= EC2 user-data 内の cron / EventBridge Scheduler rule 等で deploy 直後から自動進行する妨害) はここに同梱して良い。</p>
+
 <details>
-<summary>D1: <code>phased-polling</code> の具体 schema (= #572 を表現する)</summary>
-<pre>{
-  "kind": "phased-polling",
-  "slots": ["users", "orders", "catalog"],
-  "registrationApi": "platform.endpointRegistry",   // platform 側が generic endpoint registry を提供
-  "metaPath": "/meta",
-  "scorePath": "/score",
-  "platformRules": {
-    "ec2":       { "points": 100,  "degradedPoints": 10 },
-    "lambda":    { "points": 1000 },
-    "ecs":       { "points": 1000 },
-    "apprunner": { "points": 1000 }
-  },
-  "phases": [
-    { "name": "deploy",      "afterMinutes": 0  },
-    { "name": "degraded",    "afterMinutes": 60, "switchPlatformDegraded": ["ec2"] },
-    { "name": "legacy",      "afterMinutes": 90, "scorePathOverride": "/score?legacy=true" }
-  ],
-  "responsePenalties": [
-    { "if": "responseTimeMs > 1500", "points": 10 }
-  ],
-  "bonuses": [
-    { "kind": "all-slots-on-platforms", "platforms": ["lambda","ecs","apprunner"], "points": 5000 }
-  ]
-}</pre>
-<p>この schema を platform の <code>phased-polling</code> evaluator が 1 分毎の polling で解釈し、ScoreEvent を発行する。問題側コードは 0 行。</p>
+<summary>例: microservice-migration-battle の passive 仕掛け</summary>
+<pre>Resources:
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          # 60 min 後に tc qdisc で 200ms latency 注入 (= EC2 劣化攻撃)
+          echo "0 */60 * * * /usr/sbin/tc qdisc add dev eth0 root netem delay 200ms" | crontab -</pre>
+<p>UserData 内なので platform は知らない、ただ deploy するだけ。</p>
 </details>
 
-<h3>D2. escape hatch — custom scoring Lambda</h3>
+<h3>endpoint 多様性 — 1 / N / N slot の 3 パターンを統一</h3>
 
-<p>DSL で書けない複雑な評価 (= 例: SQL injection 検出 / 解の正解判定が動的に変わる / 競技者の発信した値を集計) は <strong>問題側に Lambda を同梱</strong>。</p>
+<p>採点対象 endpoint は問題により <strong>数が違う</strong>。<code>metadata.json</code> で 2 種類を併用宣言:</p>
+
+<table>
+<thead><tr><th>パターン</th><th>例</th><th>由来</th></tr></thead>
+<tbody>
+<tr><td>1 endpoint (単一)</td><td><code>hello-world-battle</code></td><td>CFn output から 1 つ</td></tr>
+<tr><td>N endpoint (複数監視)</td><td><code>security-battle-royale</code></td><td>CFn output から N 個 (例: <code>/admin</code> + <code>/api</code> を両方 probe)</td></tr>
+<tr><td>N slot (競技者登録)</td><td><code>microservice-migration-battle</code></td><td>競技者が portal UI から N URL を登録</td></tr>
+</tbody>
+</table>
+
+<pre>// problems/&lt;id&gt;/metadata.json
+{
+  "endpoints": {
+    "static": [
+      // CFn output 経由の fixed endpoints (= 問題の deploy 直後から確定)
+      { "outputKey": "EndpointUrl", "name": "main", "path": "/health" }
+    ],
+    "registered": [
+      // 競技者が portal UI で URL を入れる slot (= 動的、後追い登録)
+      { "slot": "users",   "required": true,  "label": "users service URL" },
+      { "slot": "orders",  "required": true },
+      { "slot": "catalog", "required": true }
+    ]
+  }
+}</pre>
+
+<p>Platform は <strong>generic な endpoint registry API</strong> (= <code>POST /problems/:id/endpoints { slot, url }</code>) を提供。problem 固有 route は不要。<code>scoring/index.ts</code> には統一形で渡される:</p>
+
+<pre>event.endpoints = {
+  static:     { main:    "https://abc.execute-api.../" },
+  registered: { users:   "https://...",
+                orders:  undefined,       // 未登録
+                catalog: "https://..." }
+}</pre>
+
+<p>問題側は必要な数だけ probe する (1 / N / N slot を同じ contract で扱える)。</p>
+
+<h3>② 採点 (<code>scoring/index.ts</code>) — Battle 主用途、Challenge は省略可</h3>
+
+<p><strong>Platform から 1 分毎に invoke される Lambda</strong>。観測 → スコア delta を返す pure function。 副作用 (= state 書き換え / 攻撃発動) は ③ engine に分離。</p>
+
+<pre>// problems/&lt;id&gt;/scoring/index.ts
+import type { ProblemScoringHandler } from "@tenkacloud/scoring-sdk";
+
+export const score: ProblemScoringHandler = async (event) =&gt; {
+  // event: { tenantId, teamId, deployedAt, registeredEndpoints, prevState, phaseElapsedMin }
+  // 戻り値: { delta: number, source: string, emitEvent: boolean, newState?: object }
+
+  // 例: microservice-migration の phase-aware 採点
+  if (event.phaseElapsedMin &gt; 90) {
+    const ok = await probe(`${event.registeredEndpoints.users}/score?legacy=true`);
+    return { delta: ok ? 1000 : -100, source: "users-legacy", emitEvent: true };
+  }
+  // ... 通常採点
+};</pre>
 
 <table>
 <thead><tr><th>項目</th><th>仕様</th></tr></thead>
 <tbody>
-<tr><td>場所</td><td><code>problems/&lt;id&gt;/scoring/</code> (TypeScript)、entry は <code>scoring/index.ts</code> の <code>export async function score(event): Promise&lt;ScoreResult&gt;</code></td></tr>
-<tr><td>build</td><td>Phase 1: platform CDK が <code>NodejsFunction</code> で個別 Lambda を立てる (= problemId が Function 名 prefix)。Phase 2 で ADR-008 と統合し S3 + Lambda Layers / RIE で per-problem 配信に</td></tr>
-<tr><td>invocation</td><td>generic polling Lambda が <code>InvokeCommand</code> で問題ごとの scoring Lambda を呼ぶ (= EventBridge 経由 fanout は overkill)</td></tr>
-<tr><td>signature</td><td><code>(event: { tenantId, slot, registeredUrl, phaseElapsedMin, prevState }) =&gt; Promise&lt;{ delta, platform, emitEvent, newState }&gt;</code></td></tr>
-<tr><td>state</td><td>必要なら <code>prevState</code> + <code>newState</code> で per-(tenant, slot) state を保持。platform が DDB に書き込む</td></tr>
-<tr><td>限界</td><td>scoring Lambda は <strong>tenant 跨ぎ access 不可</strong> (= IAM が tenant scope に絞る)。外部 HTTP は許可 (= 競技者 endpoint probe)、AWS SDK は限定 IAM で許可</td></tr>
+<tr><td>signature</td><td>固定 (<code>@tenkacloud/scoring-sdk</code> が型を export)</td></tr>
+<tr><td>呼出し頻度</td><td>1 min 間隔 (= ADR-005 の polling 統一)</td></tr>
+<tr><td>状態</td><td><code>prevState</code> / <code>newState</code> 経由で per-team の小さな state を platform DDB に保管。問題は直接 DDB を触らない</td></tr>
+<tr><td>IAM</td><td>per-problem 専用 role。外部 HTTP allow (= 競技者 endpoint probe)、AWS SDK は限定 (cross-tenant 不可)</td></tr>
+<tr><td>戻り値</td><td><code>delta</code> を ScoreEvent stream に乗せる。<code>source</code> は問題ごと unique にして集計を分離</td></tr>
 </tbody>
 </table>
 
-<h3>D3. Portal UI 拡張機構</h3>
+<h3>③ 攻撃 / 仕組み (<code>engine/index.ts</code>) — Battle 主用途</h3>
+
+<p><strong>Platform が schedule (cron / time-of-day) で invoke する Lambda</strong>。state を変える / 競技者環境を能動的に揺らす。 採点と分離する理由は (a) 副作用と純粋関数を分けたい (b) 1 min より粗い頻度で十分なことが多い (c) state 変更の権限が要る (= IAM scope を採点と分離)。</p>
+
+<pre>// problems/&lt;id&gt;/engine/index.ts
+import type { ProblemEngineHandler, ProblemEngineSchedule } from "@tenkacloud/scoring-sdk";
+
+export const schedule: ProblemEngineSchedule = [
+  { name: "ec2-degradation", afterDeployMinutes: 60 },
+  { name: "legacy-switch",   afterDeployMinutes: 90 },
+];
+
+export const tick: ProblemEngineHandler = async (event) =&gt; {
+  // event: { tenantId, teamId, deployedAt, scheduleName, registeredEndpoints, prevState }
+  if (event.scheduleName === "ec2-degradation") {
+    // SSM RunCommand で competitor EC2 に tc qdisc を追加 (= 攻撃発動)
+    await ssm.send(new SendCommandCommand({ ... }));
+    return { newState: { ec2Degraded: true } };
+  }
+  if (event.scheduleName === "legacy-switch") {
+    return { newState: { legacyMode: true } };  // scoring がこれを読んで挙動を変える
+  }
+};</pre>
 
 <table>
-<thead><tr><th>案</th><th>採否</th><th>内容</th><th>欠点</th></tr></thead>
+<thead><tr><th>項目</th><th>仕様</th></tr></thead>
 <tbody>
-<tr class="show"><td><b>D3-A</b></td><td><span class="badge accept">採用</span></td>
-   <td><b>動的 import + S3 配信</b>。問題側 <code>problems/&lt;id&gt;/portal/</code> を Vite で別 bundle にビルド (= ESM module、~50 KB target)、Cloudfront/S3 配信。participant-portal が <code>React.lazy(() =&gt; import(/* @vite-ignore */ pluginUrl))</code> で runtime load</td>
-   <td>build 1 段増 (= per-problem rollup)、CSP 設計が要る</td></tr>
-<tr class="hide"><td>D3-B</td><td><span class="badge reject">却下</span></td>
-   <td>Module Federation (Webpack Federation)</td>
-   <td>Vite ベースなので技術スタック分裂、SSR 想定なし</td></tr>
-<tr class="hide"><td>D3-C</td><td><span class="badge reject">却下</span></td>
-   <td>iframe 埋め込み</td>
-   <td>shared design system (Cloudscape) が使えない、cross-origin の状態同期が辛い</td></tr>
-<tr class="hide"><td>D3-D</td><td><span class="badge reject">却下</span></td>
-   <td>宣言的 UI schema (JSON で描画指定)</td>
-   <td>複雑な UI が表現不能、escape hatch が要る → 結局 D3-A と二重実装</td></tr>
+<tr><td>signature</td><td><code>schedule</code> 配列 (= いつ呼ぶか) + <code>tick</code> 関数 (= 何をやるか)</td></tr>
+<tr><td>呼出し</td><td>Platform が EventBridge Scheduler で時刻指定 invoke (deploy 時刻 + offset)</td></tr>
+<tr><td>権限</td><td>per-problem role。SSM RunCommand / EC2 stop / Lambda invoke / DDB write 等を明示許可。<strong>cross-tenant 不可</strong>、自分が deploy した resources にのみ触れる</td></tr>
+<tr><td>state</td><td>scoring と共有 (<code>prevState</code> / <code>newState</code> per-team)</td></tr>
 </tbody>
 </table>
 
-<details>
-<summary>D3-A の plugin component contract</summary>
+<h3>④ ダッシュボード (<code>portal/index.tsx</code>) — Battle 主用途、Challenge は generic flow 流用</h3>
+
+<p>participant-portal が <strong>動的に load する React モジュール</strong>。問題固有 UI を提供。</p>
+
 <pre>// problems/&lt;id&gt;/portal/index.tsx
 import type { ProblemPortalPlugin } from "@tenkacloud/portal-plugin-sdk";
 
-const plugin: ProblemPortalPlugin = {
+export default {
   problemId: "microservice-migration-battle",
-  components: {
-    RegistrationPanel: ({ slots, registered, onRegister }) =&gt; { /* JSX */ },
-    StatusPanel:       ({ team, scores })                   =&gt; { /* JSX */ },
-    HelpDrawer:        ({ language })                       =&gt; { /* JSX */ },
+  slots: {
+    // 既定 slot に問題固有 component を挿す
+    StatusPanel:       ({ team, scores, phase }) =&gt; (...),  // 各 slot の現状 + phase countdown
+    RegistrationPanel: ({ slots, onRegister })   =&gt; (...),  // 3 endpoint URL 登録 form
   },
   routes: [
-    { path: "/migration-progress", element: &lt;MigrationProgress /&gt; },
+    { path: "/migration-help", element: &lt;MigrationGuide /&gt; },
   ],
-};
-
-export default plugin;
-</pre>
-<p>participant-portal は <code>config.problems[].pluginUrl</code> を runtime-config から読み、必要な component を slot に挿入する (= "RegistrationPanel" を Home に、"StatusPanel" を ScoreBoard に、等の slot 規約)。Cloudscape components は SDK 経由で共有 (= duplicate bundle を避ける)。</p>
-</details>
-
-<h3>D4. plugin code 配信路 (= ADR-008 と統合)</h3>
-
-<p><strong>scoring Lambda + UI bundle</strong> を以下の経路で配信する:</p>
+} satisfies ProblemPortalPlugin;</pre>
 
 <table>
-<thead><tr><th>環境</th><th>scoring Lambda</th><th>UI bundle</th></tr></thead>
+<thead><tr><th>項目</th><th>仕様</th></tr></thead>
 <tbody>
-<tr><td>dev (local)</td>
-    <td><code>problems/&lt;id&gt;/scoring/</code> を直接 NodejsFunction で deploy</td>
-    <td><code>vite dev</code> で plugin 経路を inline serve</td></tr>
-<tr><td>production (= public problem)</td>
-    <td>CFn パイプラインが <code>problems/&lt;id&gt;/scoring/</code> を S3 にアップロード → Lambda を s3 source から作る</td>
-    <td>UI bundle も同じ S3 prefix にアップロード、CloudFront 配信</td></tr>
-<tr><td>production (= private problem、ADR-008)</td>
-    <td>private repo <code>TenkaCloudChallenges</code> の CI が S3 (= 運営 account の private bucket) に zip 配置、Worker が presigned URL でダウンロード</td>
-    <td>UI bundle も同じ private bucket に置き、portal が **15 分 TTL presigned URL** で fetch (= 答え漏れ対策)</td></tr>
+<tr><td>build</td><td>Vite で plugin 単体を ESM bundle 化 (target ~50 KB)、S3 配信</td></tr>
+<tr><td>load</td><td>portal が runtime-config の <code>problems[].pluginUrl</code> から <code>React.lazy(() =&gt; import(url))</code></td></tr>
+<tr><td>共有 design system</td><td>Cloudscape は SDK 経由で peer-dep (= bundle 二重化を避ける)</td></tr>
+<tr><td>CSP</td><td>portal hosting で plugin URL を <code>script-src</code> 許可リスト化</td></tr>
 </tbody>
 </table>
-
-<p>ADR-008 (#574 user WIP) が確定したら、本 ADR-012 の "production private" 経路を ADR-008 の S3 + presigned URL spec に合致させる。Phase 1 は public 経路のみで MVP 立ち上げ。</p>
-
-<h3>D5. trust boundary / 信頼境界</h3>
-
-<p>plugin code (= scoring Lambda + UI bundle) は <strong>第三者寄稿の可能性</strong> (将来) + <strong>誤動作リスク</strong> を抱える。次の境界で隔離:</p>
-
-<table>
-<thead><tr><th>境界</th><th>scoring Lambda</th><th>UI bundle</th></tr></thead>
-<tbody>
-<tr><td>IAM</td>
-    <td>per-problem 専用 role、DDB は platform proxy table のみ Read/Write、 cross-tenant access 不可</td>
-    <td>(N/A、frontend)</td></tr>
-<tr><td>network</td>
-    <td>outbound HTTP は許可 (= 競技者 endpoint probe)。AWS API は IAM で絞る</td>
-    <td>portal-host の origin に同梱 (= CORS は同 origin で問題なし)</td></tr>
-<tr><td>memory / CPU</td>
-    <td>Lambda 標準 sandbox。timeout 30s 上限</td>
-    <td>browser tab sandbox</td></tr>
-<tr><td>secrets</td>
-    <td>SSM Parameter Store SecureString は read 不可 (platform proxy のみ可能)</td>
-    <td>tokenless (= portal の teamLoginKey は SDK が wrap)</td></tr>
-<tr><td>code review</td>
-    <td>PR ベースで人間 review (= ADR-008 community contribution review)</td>
-    <td>同上</td></tr>
-<tr><td>CSP</td>
-    <td>(N/A)</td>
-    <td>portal の CSP で <code>script-src</code> 制限。Plugin URL は許可リストで明示</td></tr>
-</tbody>
-</table>
-
-<h3>D6. backward compat / migration</h3>
-
-<p>既存 3 問題 (= <code>hello-world-battle</code> / <code>security-battle-royale</code> / <code>hello-world</code>) は本 ADR 採択後、段階的に新 plugin pattern に migrate する。</p>
-
-<table>
-<thead><tr><th>問題</th><th>現状</th><th>migration plan</th></tr></thead>
-<tbody>
-<tr><td><code>hello-world-battle</code></td>
-    <td>health-check-handler が metadata の <code>endpoints</code> を読んで polling (= ほぼ DSL)</td>
-    <td><code>kind: "uptime-flat"</code> declarative DSL に formalize、health-check-handler を generic evaluator として renaming</td></tr>
-<tr><td><code>security-battle-royale</code></td>
-    <td>battle-attacks handler が problem 固有の判定を含む可能性大 (= audit 必要)</td>
-    <td><code>kind: "battle-attacks"</code> として DSL 化、固有 logic は scoring Lambda escape hatch に移行</td></tr>
-<tr><td><code>hello-world</code></td>
-    <td>flag 提出型、submit-flag handler が generic</td>
-    <td><code>kind: "flag"</code> declarative DSL に formalize、submit-flag handler を generic evaluator として renaming</td></tr>
-<tr><td><code>microservice-migration-battle</code></td>
-    <td>Phase 1 ship 済 (problem files のみ)、Phase 2 (PR-608) は close</td>
-    <td><code>kind: "phased-polling"</code> DSL を実装 → metadata.json で declarative に書き直す。scoring Lambda は不要</td></tr>
-</tbody>
-</table>
-
-<h3>D7. plugin author の開発体験</h3>
-
-<ul>
-<li><code>/create-problem</code> skill が plugin pattern の雛形 (= <code>metadata.json</code> + <code>scoring/index.ts</code> stub + <code>portal/index.tsx</code> stub) を生成</li>
-<li>local dev: <code>bunx tenkacloud problem dev &lt;problemId&gt;</code> で plugin を local serve、participant-portal の dev server に hot-reload で挿す</li>
-<li>test: <code>problems/&lt;id&gt;/scoring/index.test.ts</code> で Lambda handler 単体テスト (= vitest + AWS SDK mock)。<code>portal/&lt;component&gt;.test.tsx</code> で UI render テスト</li>
-<li>schema validation: <code>make validate-problems</code> が DSL を SCHEMA.json 拡張で型 check</li>
-</ul>
 </section>
 
 <section>
-<h2>Decision (まとめ)</h2>
+<h2>Platform 側 = generic dispatcher</h2>
+
+<p>Platform はこの 4 つの contract を満たす generic な host だけ実装する。問題固有のことは <strong>一切しない</strong>。</p>
 
 <table>
-<thead><tr><th>#</th><th>決定</th><th>場所</th></tr></thead>
+<thead><tr><th>platform 機能</th><th>役割</th><th>新規 / 既存</th></tr></thead>
 <tbody>
-<tr><td>D1</td><td>declarative scoring DSL (5 kind: uptime-flat / flag / phased-polling / battle-attacks / custom)</td><td><code>problems/SCHEMA.json</code> 拡張 + platform <code>generic-scoring-engine</code> Lambda</td></tr>
-<tr><td>D2</td><td>escape hatch: per-problem scoring Lambda (signature 固定、IAM 最小)</td><td><code>problems/&lt;id&gt;/scoring/index.ts</code></td></tr>
-<tr><td>D3</td><td>動的 import + S3 配信 React.lazy plugin</td><td><code>problems/&lt;id&gt;/portal/index.tsx</code> + Vite plugin build + S3 + portal の <code>config.problems[].pluginUrl</code></td></tr>
-<tr><td>D4</td><td>scoring Lambda + UI bundle を ADR-008 の S3 経路に乗せる。MVP は public 同梱で立ち上げ</td><td>S3 prefix per problem + presigned URL (private 化時)</td></tr>
-<tr><td>D5</td><td>IAM scope per-problem role + portal CSP 許可リスト + PR-ベース code review</td><td>CDK + portal hosting CSP header</td></tr>
-<tr><td>D6</td><td>既存 4 問題は段階移行。hello-world / hello-world-battle は declarative 化、security-battle-royale は audit 後 DSL or escape hatch、microservice-migration は phased-polling DSL を実装</td><td>Phase 別 PR</td></tr>
-<tr><td>D7</td><td><code>/create-problem</code> 雛形 + <code>tenkacloud problem dev</code> CLI + vitest + SCHEMA.json validation</td><td>新 CLI subcommand (= ADR-010 #578 と整合) + skill 更新</td></tr>
+<tr><td><strong>Deploy</strong></td>
+    <td><code>template.yaml</code> を競技者 account に CFn deploy</td>
+    <td>既存 (ADR-001 / ADR-002)</td></tr>
+<tr><td><strong>Scoring runtime</strong></td>
+    <td>(a) Challenge: metadata の <code>scoring.kind</code> を解釈する 内蔵 evaluator (= flag / uptime-flat)<br>
+        (b) Battle: per-problem <code>scoring/index.ts</code> Lambda を 1 min 毎に invoke</td>
+    <td>新規 (Phase 2-3)</td></tr>
+<tr><td><strong>Engine runtime</strong></td>
+    <td>per-problem <code>engine/index.ts</code> の <code>schedule</code> 宣言を読んで EventBridge Scheduler rule を立てる。時刻になったら invoke</td>
+    <td>新規 (Phase 4)</td></tr>
+<tr><td><strong>State store</strong></td>
+    <td>per-(problem, tenant, team) の小さな state を保管する generic DDB (= scoring / engine が <code>prevState</code> / <code>newState</code> で出し入れ)</td>
+    <td>新規 (Phase 3)</td></tr>
+<tr><td><strong>Portal mount</strong></td>
+    <td>portal が起動時に runtime-config から plugin URL 一覧を読み、 該当画面で <code>React.lazy</code> 動的 load</td>
+    <td>新規 (Phase 5)</td></tr>
+<tr><td><strong>IAM 発行</strong></td>
+    <td>per-problem Lambda role を problem deploy 時に発行、最小権限</td>
+    <td>新規 (Phase 4)</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>具体例 — 既存 + 新規 問題のマッピング</h2>
+
+<table>
+<thead><tr><th>問題</th><th>カテゴリ</th><th>①template</th><th>②scoring</th><th>③engine</th><th>④portal</th></tr></thead>
+<tbody>
+<tr><td><code>hello-world</code></td><td>Challenge</td>
+    <td>flag を出力する CFn (=既存)</td>
+    <td><strong>不要</strong> (metadata <code>kind: flag</code>)</td>
+    <td>不要</td>
+    <td><strong>不要</strong> (generic flag form 流用)</td></tr>
+<tr><td><code>hello-world-battle</code></td><td>Battle (sample)</td>
+    <td>endpoint を出す CFn (=既存)</td>
+    <td><strong>不要</strong> (metadata <code>kind: uptime-flat</code>)</td>
+    <td>不要</td>
+    <td><strong>不要</strong> (generic uptime widget 流用)</td></tr>
+<tr><td><code>security-battle-royale</code></td><td>Battle</td>
+    <td>攻撃可能な web app CFn (=既存)</td>
+    <td><strong>必要</strong> (攻撃検知ロジック を問題側で)</td>
+    <td><strong>必要</strong> (攻撃 trigger / mitigation)</td>
+    <td><strong>必要</strong> (攻撃 timeline UI)</td></tr>
+<tr><td><code>microservice-migration-battle</code></td><td>Battle</td>
+    <td>EC2 + docker compose (=PR-605)</td>
+    <td><strong>必要</strong> (phased-polling + platform 分類 + bonus)</td>
+    <td><strong>必要</strong> (60min EC2 劣化 / 90min legacy switch)</td>
+    <td><strong>必要</strong> (3-slot 登録 form + phase countdown)</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>SDK が定める contract</h2>
+
+<p>plugin 作者が import する型を <code>@tenkacloud/scoring-sdk</code> + <code>@tenkacloud/portal-plugin-sdk</code> として packages で公開。<strong>SDK が問題側コードと platform を decouple する唯一の接面</strong>。</p>
+
+<table>
+<thead><tr><th>SDK</th><th>export</th><th>説明</th></tr></thead>
+<tbody>
+<tr><td rowspan="3"><code>@tenkacloud/scoring-sdk</code></td>
+    <td><code>type ProblemScoringHandler</code></td>
+    <td>② signature</td></tr>
+<tr><td><code>type ProblemEngineSchedule</code></td>
+    <td>③ schedule 宣言型</td></tr>
+<tr><td><code>type ProblemEngineHandler</code></td>
+    <td>③ tick signature</td></tr>
+<tr><td rowspan="3"><code>@tenkacloud/portal-plugin-sdk</code></td>
+    <td><code>type ProblemPortalPlugin</code></td>
+    <td>④ default export 型</td></tr>
+<tr><td><code>type PortalSlotComponents</code></td>
+    <td>portal 標準 slot 群 (= StatusPanel / RegistrationPanel / HelpDrawer 等)</td></tr>
+<tr><td><code>type PortalRouteDef</code></td>
+    <td>問題固有 sub-route</td></tr>
 </tbody>
 </table>
 </section>
@@ -338,26 +364,26 @@ export default plugin;
 <h2>段階的ロールアウト</h2>
 
 <table>
-<thead><tr><th>Phase</th><th>scope</th><th>依存</th></tr></thead>
+<thead><tr><th>Phase</th><th>scope</th><th>影響</th></tr></thead>
 <tbody>
-<tr><td>Phase 1 (本 PR)</td>
-    <td>ADR-012 起草。SCHEMA.json 拡張仕様 / scoring Lambda signature / portal plugin contract を文書化</td>
-    <td>本 ADR 採択</td></tr>
-<tr><td>Phase 2</td>
-    <td><code>problems/SCHEMA.json</code> を 5 kind 対応に拡張 + <code>make validate-problems</code> が DSL を検証。既存 3 問題の metadata.json を新 DSL に書き換え (= 既存挙動を unchanged で再現)</td>
-    <td>Phase 1</td></tr>
-<tr><td>Phase 3</td>
-    <td>platform に generic-scoring-engine Lambda を導入 (= 既存 health-check-handler / submit-flag handler を refactor して DSL 駆動に)。3 既存問題が新 engine で動くことを e2e 検証</td>
-    <td>Phase 2</td></tr>
-<tr><td>Phase 4</td>
-    <td>escape hatch (D2): scoring Lambda per-problem の CDK pattern + IAM template を確立。microservice-migration-battle を Phase 1 で defer した phased-polling DSL で実装</td>
-    <td>Phase 3</td></tr>
-<tr><td>Phase 5</td>
-    <td>Portal plugin (D3): participant-portal の plugin loader 実装 + 1 sample problem (= microservice-migration-battle の Registration / Status Panel) を新 mechanism で実装</td>
-    <td>Phase 3</td></tr>
-<tr><td>Phase 6</td>
-    <td>ADR-008 (#574) と統合: private repo + S3 + presigned URL 経由の plugin 配信。public 同梱経路は dev / sample 限定に</td>
-    <td>ADR-008 採択</td></tr>
+<tr><td>1 (本 PR)</td>
+    <td>本 ADR 採択 + 4 アセットの contract + SDK 型定義の skeleton</td>
+    <td>doc のみ</td></tr>
+<tr><td>2</td>
+    <td><code>problems/SCHEMA.json</code> 拡張 (= Challenge 用の declarative <code>kind</code> 5 種を formalize) + 既存 hello-world / hello-world-battle metadata を新 schema に rewrite (挙動 unchanged)</td>
+    <td>既存 Challenge 系を新 schema に乗せる、platform 既存 evaluator はそのまま</td></tr>
+<tr><td>3</td>
+    <td>per-problem state 用 DDB <code>ProblemPluginState</code> + scoring runtime (= Battle 用の <code>scoring/index.ts</code> Lambda を invoke する dispatcher)。SDK package <code>@tenkacloud/scoring-sdk</code> 公開</td>
+    <td>新 DDB + 新 dispatcher Lambda。既存 health-check-handler を refactor して dispatcher に統合</td></tr>
+<tr><td>4</td>
+    <td>engine runtime (= <code>engine/index.ts</code> schedule から EventBridge rule を生成し時刻 invoke)。 microservice-migration-battle を本 architecture で再実装 (= PR-608 の代替)</td>
+    <td>#572 完結。<code>security-battle-royale</code> の platform-bleed を audit + migrate</td></tr>
+<tr><td>5</td>
+    <td>portal plugin runtime (= participant-portal の動的 load + Cloudscape peer dep + CSP)。SDK package <code>@tenkacloud/portal-plugin-sdk</code> 公開。 microservice-migration の 3-slot 登録 UI を plugin で実装</td>
+    <td>portal hosting に plugin URL config 追加。 既存問題は generic flow 流用で UI 変更なし</td></tr>
+<tr><td>6</td>
+    <td>ADR-008 (#574) 統合: plugin code (= scoring / engine / portal) を private repo の S3 経由 presigned URL で配信。public 同梱は dev / sample のみ</td>
+    <td>本格運用問題の答え漏れ防止 (= microservice-migration の slow endpoint コード等)</td></tr>
 </tbody>
 </table>
 </section>
@@ -367,42 +393,44 @@ export default plugin;
 
 <h3>positive</h3>
 <ul>
-<li>新問題を足すのに <strong>platform を改造不要</strong> (= 問題ファイル + 任意 scoring/portal の追加だけ)</li>
-<li>問題の <strong>差し替え</strong> が可能 (= 同 problemId で metadata + scoring/index.ts を更新するだけ)</li>
-<li>community contribution (= ADR-008 が描く第三者寄稿) と整合: 寄稿者が repo 構造を理解する範囲は <code>problems/&lt;id&gt;/</code> だけで済む</li>
-<li>既存 <code>security-battle-royale</code> も同じ枠組みに乗せられる (= 現在の隠れた platform-bleed を解消)</li>
-<li>plugin author に <strong>明示 SDK</strong> (= <code>@tenkacloud/scoring-sdk</code> + <code>@tenkacloud/portal-plugin-sdk</code>) を提供することで、 platform-side ABI が安定し PR review が機械化できる</li>
+<li><strong>新問題追加は dir 1 個 + git add</strong>。platform に手を入れる必要なし</li>
+<li><strong>問題の差し替えが容易</strong>。同 problemId で 4 アセットを update するだけ</li>
+<li><strong>Battle の柔軟性 = 問題作者が好きに書ける</strong>。攻撃の発動タイミング / 採点ロジック / UI 全部 plugin で</li>
+<li><strong>Challenge の共通化 = 雛形で済む</strong>。metadata + template だけで動く、SDK 学習不要</li>
+<li><strong>ADR-008 と統合可能</strong>: plugin code が private repo + S3 + presigned URL に乗れば答え漏れ対策完了</li>
+<li><strong>Community contribution の準備</strong>: 第三者が問題を寄稿する場合、 SDK で contract が明確なので review が機械化しやすい</li>
 </ul>
 
 <h3>negative</h3>
 <ul>
-<li>初期 setup 工数大: 4 phase (= 5 PR 程度) の段階移行。dogfood 中の 0 user 環境を考えるとペイする</li>
-<li>per-problem scoring Lambda の cold start: 1 min 間隔 polling では invoke 頻度低いので worst-case 1 invoke/min × ~1s = 60s cold start hit / hour、許容</li>
-<li>UI plugin の lazy load による初回表示遅延: ~50 KB plugin bundle + CSS、~200ms 想定。preload で緩和可</li>
-<li>plugin author に SDK + dev workflow を学習させる必要 — ドキュメント整備コスト</li>
-<li>schema migration: 既存 metadata.json に <code>scoring.kind</code> 等の field を追加する breaking change。Phase 2 で一度に migrate</li>
+<li>SDK の ABI 安定が必要 (= 一度公開した signature を不用意に変えると全 problem PR が壊れる)</li>
+<li>per-problem Lambda の cold start (1 min 毎 invoke、~1s × 60 = 60s/h を許容)</li>
+<li>UI plugin の lazy load による初回 200ms 程度の表示遅延 (= preload で緩和可)</li>
+<li>初期 setup: Phase 2-5 で計 ~5 PR 規模</li>
+<li><strong>既存 security-battle-royale の platform-bleed audit</strong> が必要 (= 隠れた問題固有 logic が platform にある可能性)</li>
 </ul>
 
-<h3>open questions (= follow-up)</h3>
+<h3>open questions</h3>
 <ul>
-<li>scoring Lambda の <strong>言語</strong>: TypeScript 縛りで良いか / Python も許容するか (= NodejsFunction vs Function + Container Image)</li>
-<li>scoring Lambda の <strong>versioning</strong>: 同 problemId で複数 version 並存 (= A/B 競技開催) を許可するか</li>
-<li>portal plugin の <strong>i18n</strong>: ADR-008 / #583 i18n と整合する design / API surface</li>
-<li>plugin の <strong>circuit breaker</strong>: scoring Lambda が連続失敗したときの platform 側 fallback (= 0 点 vs skip vs operator alert)</li>
-<li>ADR-008 確定との <strong>順序</strong>: ADR-008 を待たずに本 ADR の Phase 2-5 を進められるか (= public 同梱で MVP 立ち上げて、Phase 6 で private 配信を後付け)</li>
+<li>scoring Lambda の <strong>言語</strong>: TypeScript 縛り or Python も許容 (Container Image 化)</li>
+<li>engine の権限上限: SSM RunCommand まで許可するか / EC2 stop / Lambda invoke 等の暴れ枠</li>
+<li>operator (= 競技運営) 側に問題固有 UI が要るか (= application-admin-console plugin slot を追加するか、本 ADR の scope 外)</li>
+<li>scoring / engine の同 lambda 統合 vs 分離: 副作用の有無で物理 Lambda を分けるか、1 Lambda の export を 2 つにするか</li>
+<li>ADR-008 確定との順序: 待たずに Phase 2-5 を進めて Phase 6 で後付け、で OK か</li>
+<li>同 problemId の versioning (= A/B 並走運用)</li>
 </ul>
 </section>
 
 <section>
 <h2>関連リソース</h2>
 <ul>
-<li>PR-608 (close 済) — 本 ADR の trigger となった platform-bleed の例</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 2 score engine、本 ADR 採択後に再実装する対象</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue</li>
-<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR と統合する private repo 分離設計</li>
-<li>ADR <a href="./adr-005-battle-portal-ui.html">ADR-005</a> — Battle Portal UI 基盤 (= D3 Portal plugin の host)</li>
-<li>ADR <a href="./adr-001-problem-deploy-crud.html">ADR-001</a> — Problem Deploy 基盤 (= 本 ADR の scoring engine が乗る台)</li>
-<li>memory <code>feedback_problems_as_plugins</code> — 本 ADR のトリガーとなったユーザー指摘</li>
+<li>PR-608 (close 済) — 本 ADR の trigger となった platform-bleed の実例</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/606">#606</a> — Phase 4 で再実装する対象</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/572">#572</a> — Microservices Migration Battle 親 issue (= Phase 4 で 4 アセット揃って完結)</li>
+<li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/574">#574</a> — ADR-008 (user WIP)、本 ADR Phase 6 で統合する private repo + S3 配信</li>
+<li>ADR <a href="./adr-005-battle-portal-ui.html">ADR-005</a> — Battle Portal UI 基盤 (= ④ Portal plugin の host)</li>
+<li>ADR <a href="./adr-001-problem-deploy-crud.html">ADR-001</a> — Problem Deploy 基盤 (= ① template.yaml の deploy 経路)</li>
+<li>memory <code>feedback_problems_as_plugins</code> — 本 ADR のトリガー</li>
 </ul>
 </section>
 </body>


### PR DESCRIPTION
## Summary

PR-608 (#606 Phase 2 score engine) を close した trigger となった「問題コードが platform に染み出している」設計問題を構造的に解決する ADR。

## ユーザー指摘 (2026-05-12)

> 問題側に評価関数や画面のコードがあったら追加できたり、差し替えたりできるようにできない

= 問題は self-contained plugin、platform は generic host。

## 決定 (D1-D7)

- **D1**: declarative scoring DSL 5 kind (uptime-flat / flag / phased-polling / battle-attacks / custom)
- **D2**: escape hatch per-problem scoring Lambda (固定 signature)
- **D3**: 動的 import + S3 配信の React.lazy plugin (portal 拡張)
- **D4**: ADR-008 (#574) の private repo + S3 + presigned URL 経路に統合
- **D5**: IAM scope per-problem role + portal CSP + PR review
- **D6**: 既存 4 問題を段階移行
- **D7**: \`/create-problem\` 雛形 + \`tenkacloud problem dev\` CLI

## 段階的ロールアウト (6 phase)

| Phase | scope |
|---|---|
| 1 (本 PR) | ADR doc |
| 2 | SCHEMA.json 拡張 + 既存 metadata を新 DSL に書換え |
| 3 | generic-scoring-engine Lambda + 既存 handler refactor |
| 4 | scoring Lambda escape hatch + microservice-migration を phased-polling で実装 |
| 5 | Portal plugin loader + sample |
| 6 | ADR-008 と統合、private repo 配信 |

## 物理影響

- doc-only PR、HTML 1 ファイル追加 のみ

## Test plan

- [x] make lint green
- [x] make check-docs green
- [x] make before-commit 866 tests pass
- [ ] user review → Accepted 化 → Phase 2 着手

Relates #606, #572, #574, #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Japanese ADR describing a plugin-style "problem" architecture: richer problem metadata DSL, deployable problem assets (passive resources and optional portal UI), scoring kinds and phase-driven scoring, deploy-time endpoint registry and centralized scoring cadence, runtime portal loading, Challenge vs Battle distinctions, disruption/event mechanisms, a concrete example, six-phase rollout plan, consequences, and open questions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/609)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->