### PR TITLE
feat(#610): ADR-012 Phase 2 — SCHEMA.json 拡張 + 既存 4 metadata 移行

### DIFF
--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tenkacloud.example/schemas/problem-metadata.json",
   "title": "TenkaCloud Problem Metadata",
-  "description": "1 つの問題ディレクトリ (problems/<category>/<id>/) に置く metadata.json の構造を定義する。frontend カタログ表示と backend deploy パイプラインの両方が参照する正本。",
+  "description": "1 つの問題ディレクトリ (problems/<category>/<id>/) に置く metadata.json の構造を定義する。frontend カタログ表示と backend deploy パイプラインの両方が参照する正本。ADR-012 Phase 2 で thick metadata DSL に拡張済み (endpoints / phases / disruptions / dashboard.slots / scoring.kind 5 種)。Phase 3 で platform 側の generic scoring dispatcher が新 kind を読み始めるまでの間、旧 scoring.kind (flag/uptime) も legacy alias として valid。",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -104,15 +104,67 @@
       "additionalProperties": { "type": "string" },
       "description": "CFn template の Parameters に渡す値を {ParameterName: value} で宣言する。`NamePrefix` は script が自動注入するので含めない。`__RANDOM_PASSWORD__` を value にすると、deploy ごとに 32 桁ランダム英数字を生成して渡す (DbPassword 等の secret 用途)。省略可 (Parameters 全部に default が付いているテンプレートでは不要)。"
     },
+    "endpoints": {
+      "type": "array",
+      "description": "[ADR-012 Phase 2 / thick DSL] 問題が宣言する endpoint slot の集合。各 slot は (1) deploy 時に CFn output から自動算出される default URL と、(2) 競技者 portal で別 URL に上書きできる override の 2 階建てになる。effective URL = override ?? default を scoring engine が probe する。Challenge 系では通常省略 (= flag 提出のみ、 endpoint 概念なし)。Battle 系では複数 slot を宣言できる (例: microservice-migration-battle の users/orders/catalog)。aiContext: 1 endpoint しかなくても slot 名を付けて宣言すること (= 後で多 slot に拡張しやすい)。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["slot", "default"],
+        "properties": {
+          "slot": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "Endpoint の役割名 (kebab-case)。例: main / admin / users / orders / catalog。scoring rule や portal の slot 参照で key として使う。"
+          },
+          "default": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "key"],
+            "properties": {
+              "from": {
+                "type": "string",
+                "enum": ["cfn-output"],
+                "description": "default URL の供給源。現状は cfn-output のみサポート (= deploy 後の CFn Outputs から OutputKey で取得)。"
+              },
+              "key": {
+                "type": "string",
+                "description": "CFn template Outputs の OutputKey。例: FrontendUrl / Ec2BaseUrl / BaseUrl。"
+              },
+              "appendPath": {
+                "type": "string",
+                "description": "OutputKey 値の末尾に追加する path (例: '/users')。1 つの CFn Output (例: BaseUrl) を複数 slot で path 違いで使い回す時に使う。"
+              }
+            },
+            "description": "default URL の宣言。deploy 時に Endpoint registry が CFn output を読んで team ごとに記録する。"
+          },
+          "overridable": {
+            "type": "boolean",
+            "description": "競技者が portal UI で別 URL に変更可能か。true = 上書き可 (例: Lambda/ECS/App Runner に再ホストしたら登録)、false = 固定 (= 通常 1 endpoint uptime ケース)。省略時 false。"
+          },
+          "label": {
+            "type": "string",
+            "description": "portal 表示用の人間可読ラベル (任意)。"
+          },
+          "description": {
+            "type": "string",
+            "description": "endpoint の役割を競技者向けに説明する短文 (任意)。"
+          }
+        }
+      }
+    },
     "scoring": {
-      "description": "Scoring engine がポイントを加算する条件。省略時はスコアリング無効 (= deploy のみで競技要素なし)。Challenge 系は通常 `flag`、Battle 系は通常 `uptime`。",
+      "description": "Scoring engine がポイントを加算する条件。省略時はスコアリング無効 (= deploy のみで競技要素なし)。\n\n[ADR-012 Phase 2] 5 種の builtin kind を 1 problem につき 1 つ宣言する。1 problem に複数 kind は持てない (security-battle-royale の uptime-multi + attack-detection 同居等、複数主体が必要なケースは主要 1 kind を選び、残りは Phase 4 audit で扱う)。\n\nkind の選択軸:\n - 1 回提出して終わる Challenge → `flag`\n - 1〜N endpoint を polling し ok=+pt → `uptime-flat` (legacy alias: `uptime`)\n - N endpoint 全て生存している時だけ配点 → `uptime-multi`\n - 時間経過で score rule が変わる + platform 分類 → `phased-polling`\n - 攻撃検知 counter から配点 → `attack-detection`",
       "oneOf": [
         {
           "type": "object",
           "additionalProperties": false,
           "required": ["kind", "flagOutputKey", "points"],
           "properties": {
-            "kind": { "const": "flag" },
+            "kind": {
+              "const": "flag",
+              "description": "Challenge 型。1 deploy につき 1 回提出可、CFn Outputs の flagOutputKey と submitted flag を一致比較。"
+            },
             "flagOutputKey": {
               "type": "string",
               "description": "CFn template Outputs のうち、競技者が当てる「正解」値の OutputKey (例: \"ParameterValue\")。Portal は本 outputKey の値を participant に出さず、submitted flag と一致するか backend で検証する。"
@@ -127,14 +179,18 @@
               "items": { "type": "string" },
               "description": "競技者画面に表示するヒント。複数行表示可。"
             }
-          }
+          },
+          "description": "kind=flag (= Challenge 1 回提出形式)。example: hello-world は SSM Parameter 値を当てて +100 pt。"
         },
         {
           "type": "object",
           "additionalProperties": false,
           "required": ["kind", "endpoints", "pointsPerSuccess"],
           "properties": {
-            "kind": { "const": "uptime" },
+            "kind": {
+              "const": "uptime",
+              "description": "[Legacy alias for uptime-flat] 旧 SCHEMA の uptime 形式。Phase 2 の transition 期間中はそのまま読まれる。新規問題は uptime-flat を使うこと。"
+            },
             "endpoints": {
               "type": "array",
               "minItems": 1,
@@ -166,9 +222,339 @@
               "minimum": 1,
               "description": "1 回の health check 成功あたりの獲得ポイント。"
             }
-          }
+          },
+          "description": "kind=uptime (legacy)。 Phase 2 transition 期間中の互換用。 新規問題は kind=uptime-flat を使うこと。"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "endpoints", "pointsPerSuccess"],
+          "properties": {
+            "kind": {
+              "const": "uptime-flat",
+              "description": "1〜N endpoint を独立に probe し、成功した endpoint 分だけ加点 (= 部分稼働でも稼ぐ)。"
+            },
+            "endpoints": {
+              "type": "array",
+              "minItems": 1,
+              "description": "Health Check Lambda が定期 probe する endpoint 群。endpoints[].slot は metadata.endpoints[] の slot 名と一致させる (= slot 経由で effective URL を解決)。指定がない場合は outputKey ベースの旧式 binding にフォールバック (legacy uptime と互換)。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["path", "expectStatus"],
+                "properties": {
+                  "slot": {
+                    "type": "string",
+                    "description": "参照する metadata.endpoints[].slot 名。指定時は effective URL = override ?? default を probe。"
+                  },
+                  "outputKey": {
+                    "type": "string",
+                    "description": "[Legacy] slot を使わず CFn output から直接引く場合の OutputKey。新規問題は slot を使うこと。"
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "endpoint URL に追加する path (例: '/' や '/healthz')。"
+                  },
+                  "expectStatus": {
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 100, "maximum": 599 },
+                    "minItems": 1,
+                    "description": "期待する HTTP status code 群 (例: [200, 204])。"
+                  },
+                  "pointsPerSuccess": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "endpoint 個別 points 上書き。省略時は parent.pointsPerSuccess を使う。"
+                  }
+                }
+              }
+            },
+            "pointsPerSuccess": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1 endpoint 成功あたりの獲得ポイント (= デフォルト値)。endpoints[].pointsPerSuccess で個別上書き可。"
+            }
+          },
+          "description": "kind=uptime-flat。example: hello-world-battle (FrontendUrl + ApiUrl を独立に probe)。"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "probedSlots", "pointsAllOk"],
+          "properties": {
+            "kind": {
+              "const": "uptime-multi",
+              "description": "N 個 endpoint を probe し、全て OK の時だけ pointsAllOk を加点。1 つでも fail があれば加点せず failurePenalty を加算 (= 全体生存ボーナス、AND 条件)。"
+            },
+            "probedSlots": {
+              "type": "array",
+              "minItems": 1,
+              "description": "監視する slot 名と probe 詳細。各 entry は metadata.endpoints[].slot を参照。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["slot", "path", "expectStatus"],
+                "properties": {
+                  "slot": {
+                    "type": "string",
+                    "description": "metadata.endpoints[].slot 名と一致させる。"
+                  },
+                  "path": { "type": "string", "description": "endpoint URL に追加する path。" },
+                  "expectStatus": {
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 100, "maximum": 599 },
+                    "minItems": 1,
+                    "description": "期待する HTTP status code 群。"
+                  }
+                }
+              }
+            },
+            "pointsAllOk": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "全 probedSlots が成功した時の加点 (= 1 polling 周期につき 1 回)。"
+            },
+            "failurePenalty": {
+              "type": "integer",
+              "description": "1 つでも fail が混ざった時の加点 (通常 0 または負値)。省略時 0。"
+            }
+          },
+          "description": "kind=uptime-multi。example: security-battle-royale (frontend + api 同時生存中だけ加点)。"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "intervalMinutes", "probe", "platformRules"],
+          "properties": {
+            "kind": {
+              "const": "phased-polling",
+              "description": "時間経過で score rule が切り替わる polling 型。 phases[] と組み合わせて段階的 close / 劣化 / hosting platform 切替 を表現する。"
+            },
+            "intervalMinutes": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Polling 間隔 (分)。通常 1。"
+            },
+            "probe": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["metaPath", "scorePath"],
+              "properties": {
+                "metaPath": {
+                  "type": "string",
+                  "description": "サービス自己申告 endpoint の path (例: '/meta')。 platform 種別 (ec2/lambda/ecs/apprunner) を返す。"
+                },
+                "scorePath": {
+                  "type": "string",
+                  "description": "Score 取得 endpoint の path (例: '/score')。phases[].effect.scorePathOverride で動的に切り替え可。"
+                }
+              },
+              "description": "各 slot に対し probe する 2 つの path。"
+            },
+            "platformRules": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["points"],
+                "properties": {
+                  "points": {
+                    "type": "integer",
+                    "description": "通常時の加点 (per probe success)。"
+                  },
+                  "degradedPoints": {
+                    "type": "integer",
+                    "description": "phases[].effect.switchPlatformToDegraded で degraded 状態に切替えられた platform の加点。"
+                  }
+                }
+              },
+              "description": "platform 名 → 配点 rule の map。 platform 名は probe metaPath の応答 (= 自己申告) と照合する。 example platforms: ec2 / lambda / ecs / apprunner。"
+            },
+            "failurePenalty": {
+              "type": "integer",
+              "description": "probe 失敗 / timeout / 200 以外 / 未登録 時の加点 (通常負値、例: -100)。省略時 0。"
+            },
+            "responsePenalties": {
+              "type": "array",
+              "description": "応答時間や応答内容に応じた減点。 each entry は条件式 + 加点 (通常負値)。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["if", "points"],
+                "properties": {
+                  "if": {
+                    "type": "string",
+                    "description": "条件式 (DSL 文字列)。Phase 3 で parser を decide。 例: 'responseTimeMs > 1500'。"
+                  },
+                  "points": { "type": "integer", "description": "条件成立時の加点。" }
+                }
+              }
+            },
+            "bonuses": {
+              "type": "array",
+              "description": "条件達成ボーナス。 once=true なら 1 deploy につき 1 回まで。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "points"],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "description": "bonus 種別。 example: 'all-slots-on-platforms' (= 全 slot が指定 platform に乗ったら付与)。"
+                  },
+                  "points": { "type": "integer", "description": "獲得ポイント。" },
+                  "once": {
+                    "type": "boolean",
+                    "description": "true なら 1 deploy につき 1 回。 false / 省略時は条件成立中ずっと加点。"
+                  },
+                  "platforms": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "kind='all-slots-on-platforms' の時、全 slot が乗っている必要のある platform 群。"
+                  }
+                }
+              }
+            }
+          },
+          "description": "kind=phased-polling。example: microservice-migration-battle (EC2 vs Lambda/ECS/App Runner の hosting platform 分類 + 60 分劣化 + 90 分 legacy 切替)。"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "statsOutputKey", "pointsPerAttack"],
+          "properties": {
+            "kind": {
+              "const": "attack-detection",
+              "description": "問題 stack に同梱した attack counter (CFn Output / SSM Parameter / CloudWatch metric 等) を Phase 3 dispatcher が読み、 検知数に応じて加点する。"
+            },
+            "statsOutputKey": {
+              "type": "string",
+              "description": "CFn Outputs のうち、攻撃検知 counter を露出する OutputKey (例: 'AttackStatsParameterName')。 値は SSM Parameter name や CloudWatch Logs group ARN を入れる規約 (= Phase 3 で固める)。"
+            },
+            "pointsPerAttack": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1 検知あたりの加点。"
+            },
+            "categories": {
+              "type": "array",
+              "description": "検知種別ごとの個別 rule (任意)。 例: SQL injection / SSRF / RCE / IMDS access。",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "検知種別名 (例: 'sql-injection')。"
+                  },
+                  "pointsPerAttack": {
+                    "type": "integer",
+                    "description": "本 category の個別配点上書き。"
+                  }
+                }
+              }
+            }
+          },
+          "description": "kind=attack-detection。example: security-battle-royale の攻撃検知部 (= 防御側が WAF/IAM で塞ぐと検知数が頭打ちする設計)。"
         }
       ]
+    },
+    "phases": {
+      "type": "array",
+      "description": "[ADR-012 Phase 2 / thick DSL] 時間経過で scoring rule や endpoint binding を切り替える段階。 主に kind=phased-polling と組み合わせる。 phases[] は afterMinutes 昇順で並べる規約。 deploy 開始時刻からの相対時間で trigger。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "afterMinutes", "effect"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "phase の識別子 (kebab-case)。例: 'degraded' / 'legacy'。 portal で表示。"
+          },
+          "afterMinutes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "deploy 開始時刻からの経過分数。 この時刻以降、 effect が有効化される。"
+          },
+          "effect": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "scorePathOverride": {
+                "type": "string",
+                "description": "kind=phased-polling の probe.scorePath を上書きする (例: '/score?legacy=true')。"
+              },
+              "switchPlatformToDegraded": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "指定 platform を degraded 状態に切替 (= platformRules.degradedPoints を適用)。"
+              }
+            },
+            "description": "Phase が trigger された時の効果。 1 phase につき 1 種以上の effect を指定可。"
+          },
+          "description": {
+            "type": "string",
+            "description": "portal や運営 console で表示する phase 説明文 (任意)。"
+          }
+        }
+      }
+    },
+    "disruptions": {
+      "type": "array",
+      "description": "[ADR-012 Phase 4 future-facing] template.yaml に bake された Disruption (= EventBridge Scheduler + Disruption Lambda) を metadata 上で宣言する。 Phase 2 では portal で予告表示するためのカタログ用途のみ。 Phase 4 で operator UI から parameter を CFn parameter に注入して deploy。 aiContext: 「妨害」をゲーム要素として組み込む時に使う。 例: S3 content swap / EC2 latency injection / IAM 剥奪。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "eventDetailType"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "disruption の識別子 (kebab-case)。 例: 'content-swap' / 'latency-injection'。"
+          },
+          "name": {
+            "type": "string",
+            "description": "portal / operator UI 表示用の人間可読名。"
+          },
+          "defaultAfterMinutes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "デフォルト発火タイミング (deploy からの経過分数)。 operator が UI で上書き可。"
+          },
+          "operatorEditable": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "operator が deploy 時に上書きできる parameter キーの allow-list。 default は editable なし。"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "disruption の動作 parameters。 CFn template の Parameters に対応する key で書く。"
+          },
+          "eventDetailType": {
+            "type": "string",
+            "description": "EventBridge event の detail-type 値。 platform からの動的 trigger (Phase 2 = self-fire Scheduler) で参照される予定。"
+          }
+        }
+      }
+    },
+    "dashboard": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "[ADR-012 Phase 5 future-facing] Battle 固有の portal UI plugin slot 宣言。 participant-portal の plugin loader が dashboard.slots の path を S3 から React.lazy で動的 load する予定。 Challenge 系は通常省略 (= generic flag form 流用)。 aiContext: Battle 問題で「自チームの状態を可視化する panel」を作る時に使う。 ファイル path は同一 problem dir 内 (portal/ サブディレクトリ規約)。",
+      "properties": {
+        "slots": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._/-]+\\.tsx$",
+            "description": "問題 dir からの相対 path で portal component (.tsx) を指す。"
+          },
+          "description": "slot 名 → component path の map。 slot 名は portal が予約した名前 (StatusPanel / RegistrationPanel / LeaderboardPanel 等、 Phase 5 で固める) を使う。"
+        }
+      }
     }
   }
 }

--- a/problems/battles/hello-world-battle/metadata.json
+++ b/problems/battles/hello-world-battle/metadata.json
@@ -20,6 +20,22 @@
   ],
   "cfnTemplate": "template.yaml",
   "cfnParameters": {},
+  "endpoints": [
+    {
+      "slot": "frontend",
+      "default": { "from": "cfn-output", "key": "FrontendUrl" },
+      "overridable": false,
+      "label": "Frontend (nginx)",
+      "description": "EC2 上の nginx (port 80)。 防御側が落とすとスコア停止。"
+    },
+    {
+      "slot": "api",
+      "default": { "from": "cfn-output", "key": "ApiUrl" },
+      "overridable": false,
+      "label": "API (python http.server)",
+      "description": "EC2 上の python http.server (port 8080)。 `/healthz` で 200 を返す。"
+    }
+  ],
   "scoring": {
     "kind": "uptime",
     "endpoints": [

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -18,13 +18,68 @@
   ],
   "cfnTemplate": "template.yaml",
   "cfnParameters": {},
+  "endpoints": [
+    {
+      "slot": "users",
+      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/users" },
+      "overridable": true,
+      "label": "Users service",
+      "description": "初期は EC2 上の nginx reverse proxy 経由。 Lambda / ECS / App Runner に切り出したら override で登録する。"
+    },
+    {
+      "slot": "orders",
+      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/orders" },
+      "overridable": true,
+      "label": "Orders service",
+      "description": "初期は EC2 上の nginx reverse proxy 経由。 移行先の新 endpoint を override で登録。"
+    },
+    {
+      "slot": "catalog",
+      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/catalog" },
+      "overridable": true,
+      "label": "Catalog service",
+      "description": "初期は EC2 上の nginx reverse proxy 経由。 移行先の新 endpoint を override で登録。"
+    }
+  ],
   "scoring": {
-    "kind": "uptime",
-    "endpoints": [
-      { "outputKey": "BaseUrl", "path": "/users/score", "expectStatus": [200] },
-      { "outputKey": "BaseUrl", "path": "/orders/score", "expectStatus": [200] },
-      { "outputKey": "BaseUrl", "path": "/catalog/score", "expectStatus": [200] }
-    ],
-    "pointsPerSuccess": 100
+    "kind": "phased-polling",
+    "intervalMinutes": 1,
+    "probe": { "metaPath": "/meta", "scorePath": "/score" },
+    "platformRules": {
+      "ec2": { "points": 100, "degradedPoints": 10 },
+      "lambda": { "points": 1000 },
+      "ecs": { "points": 1000 },
+      "apprunner": { "points": 1000 }
+    },
+    "failurePenalty": -100,
+    "responsePenalties": [{ "if": "responseTimeMs > 1500", "points": -10 }],
+    "bonuses": [
+      {
+        "kind": "all-slots-on-platforms",
+        "platforms": ["lambda", "ecs", "apprunner"],
+        "points": 5000,
+        "once": true
+      }
+    ]
+  },
+  "phases": [
+    {
+      "name": "degraded",
+      "afterMinutes": 60,
+      "effect": { "switchPlatformToDegraded": ["ec2"] },
+      "description": "EC2 上の劣化フェーズ。 EC2 hosting platform の加点が degradedPoints (= 10) に切り替わる。"
+    },
+    {
+      "name": "legacy",
+      "afterMinutes": 90,
+      "effect": { "scorePathOverride": "/score?legacy=true" },
+      "description": "Legacy code path フェーズ。 各サービスに仕込まれた遅延 code path を取り除く必要が出る。"
+    }
+  ],
+  "dashboard": {
+    "slots": {
+      "RegistrationPanel": "portal/RegistrationPanel.tsx",
+      "StatusPanel": "portal/StatusPanel.tsx"
+    }
   }
 }

--- a/problems/battles/security-battle-royale/metadata.json
+++ b/problems/battles/security-battle-royale/metadata.json
@@ -21,5 +21,30 @@
   "cfnTemplate": "template.yaml",
   "cfnParameters": {
     "DbPassword": "__RANDOM_PASSWORD__"
+  },
+  "endpoints": [
+    {
+      "slot": "frontend",
+      "default": { "from": "cfn-output", "key": "FrontendUrl" },
+      "overridable": true,
+      "label": "Frontend (nginx)",
+      "description": "競技者が公開する商品ページ。 防御側は WAF / CDN を被せて override 可能。"
+    },
+    {
+      "slot": "api",
+      "default": { "from": "cfn-output", "key": "ApiUrl" },
+      "overridable": true,
+      "label": "API (Flask)",
+      "description": "JSON API endpoint。 SQL injection 等の標的。"
+    }
+  ],
+  "scoring": {
+    "kind": "uptime-multi",
+    "probedSlots": [
+      { "slot": "frontend", "path": "/", "expectStatus": [200] },
+      { "slot": "api", "path": "/healthz", "expectStatus": [200] }
+    ],
+    "pointsAllOk": 100,
+    "failurePenalty": 0
   }
 }


### PR DESCRIPTION
## Summary

ADR-012 (PR-609 で merge) の thick metadata DSL を `problems/SCHEMA.json` に formal definition として落とし、既存 4 問題の `metadata.json` を新 DSL で書き直す。**Phase 2 は schema + metadata only**。Platform Lambda は 1 行も触らない (= Phase 3 で switch する)。

- `problems/SCHEMA.json` — `scoring.kind` の oneOf を 6 variant に拡張 (legacy `flag`/`uptime` + 新 `flag`/`uptime-flat`/`uptime-multi`/`phased-polling`/`attack-detection`)。 新 top-level field `endpoints[]` / `phases[]` / `disruptions[]` / `dashboard.slots` を追加。各 field に description + AI hint を inline で記述
- 既存 4 metadata を新 DSL で表現 (詳細は本文下記)
- 既存 Platform code (`parseScoringMetadata`) は legacy keys (`flag` / `uptime`) を引き続き読めるため、active `status: ready` 問題 (hello-world / hello-world-battle) の scoring 挙動は 100% 不変

## 設計判断

**Strategy: backwards-compat keys** (Issue #610 Approach に従う)。

- 旧 SCHEMA の field を全て **optional として残す**
- 新 5 kind + 新 top-level field を **追加するだけ** (= breaking 拡張ではなく additive)
- Phase 2 transition 期間中は、新 DSL に未対応の Platform Lambda が legacy keys を読み続ける

## 変更点

### `problems/SCHEMA.json` (398 行 → 約 500 行)

| 追加 | 内容 |
| --- | --- |
| `scoring.oneOf` 4 新 variant | `uptime-flat` (= 1〜N endpoint 独立 probe、 ok=+pt)、`uptime-multi` (= 全 OK で配点 AND 条件)、`phased-polling` (= 時間軸で rule 切替)、`attack-detection` (= CFn Output に counter を出させる) |
| `endpoints[]` | slot (kebab-case) / `default` (cfn-output / appendPath) / overridable / label / description |
| `phases[]` | name / afterMinutes / effect (scorePathOverride / switchPlatformToDegraded) / description |
| `disruptions[]` (Phase 4 future) | id / name / defaultAfterMinutes / operatorEditable / parameters / eventDetailType |
| `dashboard.slots` (Phase 5 future) | slot 名 → `.tsx` 相対 path map |
| AI hints | 各 field の description 内に inline で記述 (JSON Schema 標準で `aiContext` 拡張は無いため) |

### 既存 4 metadata.json

| 問題 | status | 変更 |
| --- | --- | --- |
| `hello-world` (Challenge / flag) | ready | 変更なし — `kind: flag` は新 DSL でもそのまま valid |
| `hello-world-battle` (Battle / uptime) | ready | `endpoints[]` 2 slot (frontend / api) を追加。 **`scoring.kind` は `uptime` のまま保持** (= legacy alias、 Platform code 不変保証のため) |
| `security-battle-royale` (Battle) | draft | `endpoints[]` 2 slot (overridable=true) + `scoring.kind: uptime-multi` 追加 (元々 scoring 無宣言) |
| `microservice-migration-battle` (Battle) | draft | `endpoints[]` 3 slot (users/orders/catalog、BaseUrl+appendPath) + `phases[]` 2 phase (degraded 60min / legacy 90min) + `dashboard.slots` 2 (RegistrationPanel / StatusPanel) + `scoring.kind` を `uptime` → `phased-polling` migrate |

## 制約 / Honesty notes

- **1 metadata に 1 scoring kind しか持てない** (= `scoring` は `oneOf` で 1 variant のみ valid)
  - `security-battle-royale` は本来 `uptime-multi` (生存監視) + `attack-detection` (攻撃検知) 併用したいが、主要 1 kind (`uptime-multi`) のみ宣言。攻撃検知部は ADR-012 "Risk: Hidden platform-bleed" 節に従い **Phase 4 audit で扱う**
- **`hello-world-battle` の `kind` を `uptime` のまま据え置き**: 新 DSL example だと `kind: uptime-flat` だが、Phase 3 で Platform code を switch するまで legacy alias を維持。Schema は両方 valid。Phase 3 で `parseScoringMetadata` を `uptime-flat` ベースに refactor し、本 metadata の kind を `uptime-flat` に flip する
- **`microservice-migration-battle` の scoring が現行 Lambda map から drop する**: `parseScoringMetadata` は `phased-polling` を認識しない。但し本問題は `status: draft` で active deployment なし → runtime 観測影響なし。Phase 3 で generic dispatcher が `phased-polling` を読み始めれば復活

## Regression 分析

| 壊しうる挙動 | 影響 | 検証 |
| --- | --- | --- |
| `hello-world` (Challenge) の flag scoring | なし | shape 変更なし |
| `hello-world-battle` (ready) の uptime probe | なし | `kind: uptime` 保持、 endpoints 配列も同じ |
| `security-battle-royale` (draft) | なし | 元々 scoring 無宣言、 active deployment なし |
| `microservice-migration-battle` (draft) | scoring map から drop | active deployment なし、 Phase 3 で復活 |
| participant-portal catalog 表示 | なし | `data/problems.ts` は cherry-pick で id/name/category 等のみ読む。新 field 無視 |
| `discoverProblemsScoring` map content | hello-world + hello-world-battle (= 旧と同じ 2 件) | manual 実行 + scoring-metadata.test.ts 全 pass |
| 既存 vitest 全 workspace | 全 866 件 pass (infra 575 / admin 84 / app-admin 140 / portal 67) | `bun run test` 全 green |
| `make validate-problems` | 4/4 OK | `bun run validate:problems` |

## 物理影響

| 種別 | path | 操作 |
| --- | --- | --- |
| UPDATE | `problems/SCHEMA.json` | scoring.oneOf に 4 variant 追加 + endpoints/phases/disruptions/dashboard 追加 |
| UPDATE | `problems/battles/hello-world-battle/metadata.json` | endpoints[] 追加 (scoring 不変) |
| UPDATE | `problems/battles/security-battle-royale/metadata.json` | endpoints[] + scoring (uptime-multi) 追加 |
| UPDATE | `problems/battles/microservice-migration-battle/metadata.json` | endpoints[] + phases[] + dashboard.slots 追加 / scoring を phased-polling に migrate |
| NO-OP | `problems/challenges/hello-world/metadata.json` | 変更なし (新 DSL でも valid) |
| NO-OP | `infrastructure/lib/**` Lambda handler | Phase 2 では touch しない |
| NO-OP | CFn synth output | metadata only 変更、 CDK 出力に diff なし |

## Test plan

- [x] `make lint` (markdownlint + textlint + biome) green
- [x] `make validate-problems` で 4/4 OK
- [x] `make check-http-status` green
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck` exit 0
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` 全 575 件 pass
- [x] `bun run --filter '@TenkaCloud/participant-portal' test` 全 67 件 pass (= metadata 読み込み smoke test 含む)
- [x] `discoverProblemsScoring("./problems")` manual 実行で hello-world (flag) + hello-world-battle (uptime) のみ map に入ること目視確認
- [x] pre-commit hook (`bun run check`) で test 866 件 + validate-problems + check-http-status 全 pass

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple scoring strategies: flat uptime monitoring, all-or-nothing uptime scoring, phased polling with platform-specific rules, and attack detection-based scoring.
  * Added endpoint slot configuration for flexible service URL management with CloudFormation integration.
  * Added phase-based gameplay with time-ordered behavior changes and score path overrides.
  * Added dashboard customization via portal component slot mappings.
  * Added disruption metadata declarations for future operator-driven parameter injection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/618)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->