### PR TITLE
feat(#611): ADR-012 Phase 3.A — Endpoint registry (DDB + Portal API)

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -20,6 +20,7 @@ import { TenantTemplateStack } from "../lib/tenant-template/tenant-template-stac
 import { loadConfig } from "../lib/utils/config-loader";
 import {
   discoverProblemsCatalog,
+  discoverProblemsEndpoints,
   discoverProblemsScoring,
 } from "../lib/utils/discover-problems-catalog";
 
@@ -214,6 +215,8 @@ const participantPortal = enableParticipantPortal
 const problemsRoot = path.resolve(__dirname, "..", "..", "problems");
 const problemsCatalog = discoverProblemsCatalog(problemsRoot);
 const problemsScoring = discoverProblemsScoring(problemsRoot);
+// ADR-012 Phase 3.A: `endpoints[]` を持つ問題のみ集まる (= flag-only Challenge は不在キー)。
+const problemsEndpoints = discoverProblemsEndpoints(problemsRoot);
 
 // #538: Bulk Deploy 並列度 (CodeBuild concurrent build cap)。
 // `CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT` env で operator が tune する。未設定なら
@@ -238,6 +241,7 @@ const problemDeployBackendStack = new ProblemDeployBackendStack(app, "tenkacloud
   sourceObjectKey: sourceZip,
   problemsCatalog,
   problemsScoring,
+  problemsEndpoints,
   participantPortal,
   deployConcurrentBuildLimit,
   // Issue #459 / ADR-002: SSM SecureString path `/{environmentName}/tenants/{tenantId}/external-id`

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -1,6 +1,12 @@
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
+import { StatusCodes } from "http-status-codes";
+import {
+  deleteProblemEndpointOverride,
+  listProblemEndpoints,
+  upsertProblemEndpointOverride,
+} from "../problem-endpoints-handler/endpoints.js";
 import { PROBLEM_ID_RE } from "../shared/constants.js";
 import { HTTP_OK } from "../shared/http-status.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
@@ -13,6 +19,9 @@ import { buildParticipantSharedResources } from "./shared.js";
 import { getConsoleSigninUrl } from "./sso.js";
 import { submitFlag } from "./submit-flag.js";
 import { setDisplayTeamName } from "./update.js";
+
+/** ADR-012 Phase 3.A: slot 名は kebab-case (= metadata.endpoints[].slot pattern と同じ)。 */
+const SLOT_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 /**
  * Participant Portal backend Lambda の Hono app (Phase 2c で team scope)。routes:
@@ -126,6 +135,72 @@ app.post("/portal/me/submit-flag", (c) =>
     if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
     if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
     return c.json(outcome, HTTP_OK);
+  }),
+);
+
+// ADR-012 Phase 3.A: Endpoint registry (override) routes — 競技者が自 team の slot URL を
+// 再ホスト先 (Lambda / ECS / App Runner 等) に切り替えるための CRUD。auth は teamLoginKey
+// bearer (= submit-flag と同じ scope)。
+//
+//   GET    /portal/me/problems/:problemId/endpoints
+//   POST   /portal/me/problems/:problemId/endpoints/:slot  { url }
+//   DELETE /portal/me/problems/:problemId/endpoints/:slot
+app.get("/portal/me/problems/:problemId/endpoints", (c) =>
+  withBearerAuth(c, "list-endpoints", async (token) => {
+    const problemId = c.req.param("problemId");
+    if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+      return respondError(c, "invalid_problem_id");
+    }
+    const outcome = await listProblemEndpoints(shared, token, problemId);
+    if (outcome.kind === "ok") {
+      return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
+    }
+    return respondError(c, outcome.kind);
+  }),
+);
+
+app.post("/portal/me/problems/:problemId/endpoints/:slot", (c) =>
+  withBearerAuth(c, "put-endpoint", async (token) => {
+    const problemId = c.req.param("problemId");
+    if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+      return respondError(c, "invalid_problem_id");
+    }
+    const slot = c.req.param("slot");
+    if (!slot || !SLOT_NAME_RE.test(slot)) {
+      return respondError(c, "invalid_slot");
+    }
+    const body = (await c.req.json().catch(() => null)) as { url?: unknown } | null;
+    if (body === null) return respondError(c, "invalid_body");
+    const outcome = await upsertProblemEndpointOverride(
+      shared,
+      token,
+      problemId,
+      slot,
+      body.url,
+      new Date().toISOString(),
+    );
+    if (outcome.kind === "ok") {
+      return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
+    }
+    return respondError(c, outcome.kind);
+  }),
+);
+
+app.delete("/portal/me/problems/:problemId/endpoints/:slot", (c) =>
+  withBearerAuth(c, "delete-endpoint", async (token) => {
+    const problemId = c.req.param("problemId");
+    if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+      return respondError(c, "invalid_problem_id");
+    }
+    const slot = c.req.param("slot");
+    if (!slot || !SLOT_NAME_RE.test(slot)) {
+      return respondError(c, "invalid_slot");
+    }
+    const outcome = await deleteProblemEndpointOverride(shared, token, problemId, slot);
+    if (outcome.kind === "ok") {
+      return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
+    }
+    return respondError(c, outcome.kind);
   }),
 );
 

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -31,6 +31,12 @@ const ERROR_STATUS = {
   scoring_locked: HTTP_CONFLICT,
   misconfigured: HTTP_INTERNAL_ERROR,
   internal_error: HTTP_INTERNAL_ERROR,
+  // ADR-012 Phase 3.A: endpoint registry
+  no_endpoints: HTTP_NOT_FOUND,
+  unknown_slot: HTTP_BAD_REQUEST,
+  slot_not_overridable: HTTP_CONFLICT,
+  invalid_url: HTTP_BAD_REQUEST,
+  invalid_slot: HTTP_BAD_REQUEST,
 } as const;
 
 export type ErrorKind = keyof typeof ERROR_STATUS;

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/shared.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import { type ProblemEndpointSlot, parseEndpointsEnv } from "../../../utils/endpoints-metadata.js";
 import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 
@@ -18,17 +19,32 @@ export interface ParticipantSharedResources {
    * Query する。CDK 側で IAM `dynamodb:Query` を Events table にも付与する。
    */
   readonly eventsTableName: string;
+  /**
+   * ADR-012 Phase 3.A: Endpoint registry table 名 (= ProblemEndpoints)。
+   * `/portal/me/problems/:problemId/endpoints` 系 route が読み書きする。
+   * 未配線時 (= 古い deploy / Phase 3.A 適用前) は空文字、route 側で 503 ガード。
+   */
+  readonly endpointsTableName: string;
   readonly ddb: DynamoDBDocumentClient;
   /** `{ [problemId]: ProblemScoringMetadata }`。submit-flag が採点に使う。 */
   readonly problemsScoring: Record<string, ProblemScoringMetadata>;
+  /**
+   * ADR-012 Phase 3.A: `{ [problemId]: ProblemEndpointSlot[] }`。endpoint registry
+   * route が default URL 算出に使う。`endpoints[]` 宣言の無い problem は key ごと不在。
+   */
+  readonly problemsEndpoints: Record<string, readonly ProblemEndpointSlot[]>;
 }
 
 export function buildParticipantSharedResources(): ParticipantSharedResources {
   return {
     tableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
     eventsTableName: getEnv("EVENTS_TABLE_NAME"),
+    // 未配線時 (= legacy stack) でも import が落ちないよう env 必須にしない (= 空文字)。
+    // route 側で空チェックして 503 を返す経路にする。
+    endpointsTableName: process.env.PROBLEM_ENDPOINTS_TABLE_NAME ?? "",
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
+    problemsEndpoints: parseEndpointsEnv(process.env.PROBLEM_ENDPOINTS),
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
@@ -41,7 +41,14 @@ export async function listProblemEndpoints(
   if (items.length === 0) return { kind: "unauthorized" };
 
   const deployment = items.find((i) => i.problemId === problemId);
-  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+  // tenantId / teamId 両方の存在を要求 (= cross-tenant PK collision の defense-in-depth)。
+  if (
+    !deployment ||
+    typeof deployment.teamId !== "string" ||
+    deployment.teamId.length === 0 ||
+    typeof deployment.tenantId !== "string" ||
+    deployment.tenantId.length === 0
+  ) {
     return { kind: "unauthorized" };
   }
 
@@ -51,7 +58,7 @@ export async function listProblemEndpoints(
   const overrides = await queryOverrides(
     shared.ddb,
     shared.endpointsTableName,
-    deployment.tenantId ?? "",
+    deployment.tenantId,
     deployment.teamId,
     problemId,
   );
@@ -76,11 +83,34 @@ export type PutOverrideOutcome =
   | { kind: "no_endpoints" }
   | { kind: "misconfigured" };
 
+// SSRF defense-in-depth: write 時に host を拒否する blocklist。
+// Phase 3.B の fetcher (= 別 PR) で DNS-rebinding-safe な resolve-then-connect が要るが、
+// それまでも write 時に明白な metadata / loopback literal を弾いて attack surface を絞る。
+// 競技者が自分の AWS account 内 endpoint を登録する用途では public DNS / private VPC IP は許容、
+// 以下の host literal だけは「競技者所有 endpoint ではあり得ない」 ので拒否。
+const SSRF_BLOCKED_HOSTS = new Set([
+  // AWS EC2 / EKS / Fargate IMDS
+  "169.254.169.254",
+  "[fd00:ec2::254]",
+  "fd00:ec2::254",
+  // GCE metadata
+  "metadata.google.internal",
+  "metadata",
+  // Azure IMDS
+  "169.254.169.254", // same literal、 set なので dedupe される
+  // loopback
+  "127.0.0.1",
+  "[::1]",
+  "::1",
+  "localhost",
+]);
+
 /**
- * 競技者向け URL validation。`https?://...` のみ許容、private IP / localhost も許容する
+ * 競技者向け URL validation。`https?://...` のみ許容、 private IP / VPC 内 endpoint は許容
  * (= Battle で参加者が自分の AWS account 内 endpoint を登録するため public/private は問わない)。
  *
- * Phase 3.A の主な目的は「文字列が URL 形式か」「scheme が http(s) か」「長さが妥当か」の 3 点。
+ * ただし SSRF 対策として **metadata service / loopback literal は拒否**。 Phase 3.B fetcher で
+ * DNS-rebinding-safe な resolve-then-connect を行うまでの defense-in-depth。
  */
 function isValidOverrideUrl(value: unknown): value is string {
   if (typeof value !== "string") return false;
@@ -88,7 +118,12 @@ function isValidOverrideUrl(value: unknown): value is string {
   if (trimmed.length === 0 || trimmed.length > 2048) return false;
   try {
     const u = new URL(trimmed);
-    return u.protocol === "http:" || u.protocol === "https:";
+    if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+    const host = u.hostname.toLowerCase();
+    if (SSRF_BLOCKED_HOSTS.has(host)) return false;
+    // bracketed IPv6 literal も block
+    if (SSRF_BLOCKED_HOSTS.has(`[${host}]`)) return false;
+    return true;
   } catch {
     return false;
   }
@@ -115,7 +150,13 @@ export async function upsertProblemEndpointOverride(
   const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
   const deployment = items.find((i) => i.problemId === problemId);
-  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+  if (
+    !deployment ||
+    typeof deployment.teamId !== "string" ||
+    deployment.teamId.length === 0 ||
+    typeof deployment.tenantId !== "string" ||
+    deployment.tenantId.length === 0
+  ) {
     return { kind: "unauthorized" };
   }
 
@@ -127,7 +168,7 @@ export async function upsertProblemEndpointOverride(
   if (!slotDef.overridable) return { kind: "slot_not_overridable" };
   if (!isValidOverrideUrl(urlValue)) return { kind: "invalid_url" };
 
-  const tenantId = deployment.tenantId ?? "";
+  const tenantId = deployment.tenantId;
   await putOverride(shared.ddb, shared.endpointsTableName, {
     tenantId,
     teamId: deployment.teamId,
@@ -177,7 +218,13 @@ export async function deleteProblemEndpointOverride(
   const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
   const deployment = items.find((i) => i.problemId === problemId);
-  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+  if (
+    !deployment ||
+    typeof deployment.teamId !== "string" ||
+    deployment.teamId.length === 0 ||
+    typeof deployment.tenantId !== "string" ||
+    deployment.tenantId.length === 0
+  ) {
     return { kind: "unauthorized" };
   }
 
@@ -185,7 +232,7 @@ export async function deleteProblemEndpointOverride(
   if (slots.length === 0) return { kind: "no_endpoints" };
   if (!slots.some((s) => s.slot === slot)) return { kind: "unknown_slot" };
 
-  const tenantId = deployment.tenantId ?? "";
+  const tenantId = deployment.tenantId;
   await deleteOverride(shared.ddb, shared.endpointsTableName, {
     tenantId,
     teamId: deployment.teamId,

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
@@ -16,6 +16,21 @@ import { deleteOverride, putOverride, queryOverrides } from "./store.js";
  *      (= 別チームの problemId を指定しても unauthorized 扱い)。
  */
 
+/**
+ * deployment 行から teamId / tenantId を取り出す前段 guard。 cross-tenant PK collision を
+ * 物理的に防ぐため両方の string 非空を要求。 narrow した後の caller は `?? ""` 不要。
+ */
+type AuthorizedDeployment = DeploymentItem & { teamId: string; tenantId: string };
+function isAuthorizedDeployment(d: Partial<DeploymentItem> | undefined): d is AuthorizedDeployment {
+  return (
+    !!d &&
+    typeof d.teamId === "string" &&
+    d.teamId.length > 0 &&
+    typeof d.tenantId === "string" &&
+    d.tenantId.length > 0
+  );
+}
+
 export type ListEndpointsOutcome =
   | { kind: "ok"; endpoints: ResolvedEndpoint[]; teamId: string }
   | { kind: "unauthorized" }
@@ -41,16 +56,7 @@ export async function listProblemEndpoints(
   if (items.length === 0) return { kind: "unauthorized" };
 
   const deployment = items.find((i) => i.problemId === problemId);
-  // tenantId / teamId 両方の存在を要求 (= cross-tenant PK collision の defense-in-depth)。
-  if (
-    !deployment ||
-    typeof deployment.teamId !== "string" ||
-    deployment.teamId.length === 0 ||
-    typeof deployment.tenantId !== "string" ||
-    deployment.tenantId.length === 0
-  ) {
-    return { kind: "unauthorized" };
-  }
+  if (!isAuthorizedDeployment(deployment)) return { kind: "unauthorized" };
 
   const slots = shared.problemsEndpoints[problemId] ?? [];
   if (slots.length === 0) return { kind: "no_endpoints" };
@@ -83,24 +89,15 @@ export type PutOverrideOutcome =
   | { kind: "no_endpoints" }
   | { kind: "misconfigured" };
 
-// SSRF defense-in-depth: write 時に host を拒否する blocklist。
-// Phase 3.B の fetcher (= 別 PR) で DNS-rebinding-safe な resolve-then-connect が要るが、
-// それまでも write 時に明白な metadata / loopback literal を弾いて attack surface を絞る。
-// 競技者が自分の AWS account 内 endpoint を登録する用途では public DNS / private VPC IP は許容、
-// 以下の host literal だけは「競技者所有 endpoint ではあり得ない」 ので拒否。
+// SSRF defense-in-depth blocklist (Phase 3.B fetcher で DNS-rebinding-safe な
+// resolve-then-connect を実装するまでの暫定)。 host は IPv6 bracket を剥がし lowercase
+// 化した bare form に正規化してから lookup する。
 const SSRF_BLOCKED_HOSTS = new Set([
-  // AWS EC2 / EKS / Fargate IMDS
-  "169.254.169.254",
-  "[fd00:ec2::254]",
-  "fd00:ec2::254",
-  // GCE metadata
-  "metadata.google.internal",
+  "169.254.169.254", // AWS / Azure IMDS v4
+  "fd00:ec2::254", // AWS IMDS v6
+  "metadata.google.internal", // GCE metadata
   "metadata",
-  // Azure IMDS
-  "169.254.169.254", // same literal、 set なので dedupe される
-  // loopback
   "127.0.0.1",
-  "[::1]",
   "::1",
   "localhost",
 ]);
@@ -108,9 +105,7 @@ const SSRF_BLOCKED_HOSTS = new Set([
 /**
  * 競技者向け URL validation。`https?://...` のみ許容、 private IP / VPC 内 endpoint は許容
  * (= Battle で参加者が自分の AWS account 内 endpoint を登録するため public/private は問わない)。
- *
- * ただし SSRF 対策として **metadata service / loopback literal は拒否**。 Phase 3.B fetcher で
- * DNS-rebinding-safe な resolve-then-connect を行うまでの defense-in-depth。
+ * SSRF 対策として metadata service / loopback literal は拒否。
  */
 function isValidOverrideUrl(value: unknown): value is string {
   if (typeof value !== "string") return false;
@@ -119,11 +114,9 @@ function isValidOverrideUrl(value: unknown): value is string {
   try {
     const u = new URL(trimmed);
     if (u.protocol !== "http:" && u.protocol !== "https:") return false;
-    const host = u.hostname.toLowerCase();
-    if (SSRF_BLOCKED_HOSTS.has(host)) return false;
-    // bracketed IPv6 literal も block
-    if (SSRF_BLOCKED_HOSTS.has(`[${host}]`)) return false;
-    return true;
+    // Node の `URL.hostname` は IPv6 で `[::1]` のように bracket を含む。 lookup 前に strip。
+    const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return !SSRF_BLOCKED_HOSTS.has(host);
   } catch {
     return false;
   }
@@ -150,15 +143,7 @@ export async function upsertProblemEndpointOverride(
   const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
   const deployment = items.find((i) => i.problemId === problemId);
-  if (
-    !deployment ||
-    typeof deployment.teamId !== "string" ||
-    deployment.teamId.length === 0 ||
-    typeof deployment.tenantId !== "string" ||
-    deployment.tenantId.length === 0
-  ) {
-    return { kind: "unauthorized" };
-  }
+  if (!isAuthorizedDeployment(deployment)) return { kind: "unauthorized" };
 
   const slots = shared.problemsEndpoints[problemId] ?? [];
   if (slots.length === 0) return { kind: "no_endpoints" };
@@ -218,15 +203,7 @@ export async function deleteProblemEndpointOverride(
   const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
   const deployment = items.find((i) => i.problemId === problemId);
-  if (
-    !deployment ||
-    typeof deployment.teamId !== "string" ||
-    deployment.teamId.length === 0 ||
-    typeof deployment.tenantId !== "string" ||
-    deployment.tenantId.length === 0
-  ) {
-    return { kind: "unauthorized" };
-  }
+  if (!isAuthorizedDeployment(deployment)) return { kind: "unauthorized" };
 
   const slots = shared.problemsEndpoints[problemId] ?? [];
   if (slots.length === 0) return { kind: "no_endpoints" };

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
@@ -1,0 +1,214 @@
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { type ParticipantSharedResources, queryTeamItems } from "../participant-handler/shared.js";
+import { type ResolvedEndpoint, resolveEndpoints } from "./resolve.js";
+import { deleteOverride, putOverride, queryOverrides } from "./store.js";
+
+/**
+ * Endpoint registry (ADR-012 Phase 3.A) の business logic。
+ *
+ * 流れ:
+ *   1. teamLoginKey で team の deployments を引く (= GSI2 Query)
+ *   2. problemId に該当する deployment 行を絞る
+ *   3. problem の `metadata.endpoints[]` を shared.problemsEndpoints から取得
+ *   4. (slot 名, deployment.stackOutputs, ProblemEndpoints table の override 行) を merge
+ *
+ * Auth: caller が teamLoginKey で deployment 行を引けたら自チームの問題と確定する
+ *      (= 別チームの problemId を指定しても unauthorized 扱い)。
+ */
+
+export type ListEndpointsOutcome =
+  | { kind: "ok"; endpoints: ResolvedEndpoint[]; teamId: string }
+  | { kind: "unauthorized" }
+  | { kind: "no_endpoints" }
+  | { kind: "misconfigured" };
+
+/**
+ * GET /portal/me/problems/:problemId/endpoints — 該当 team × problem の slot 一覧を返す。
+ *
+ * - team に該当 problem の deployment が無い → unauthorized
+ * - metadata.endpoints[] が空 (= Challenge 系 flag-only 問題) → `no_endpoints`
+ *   (= UI 側で endpoint 機能を hide させる、404 と区別したいので別 kind)
+ * - registry table が未配線 (= env 空) → `misconfigured`
+ */
+export async function listProblemEndpoints(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  problemId: string,
+): Promise<ListEndpointsOutcome> {
+  if (!shared.endpointsTableName) return { kind: "misconfigured" };
+
+  const items = await queryTeamItems(shared, teamLoginKey);
+  if (items.length === 0) return { kind: "unauthorized" };
+
+  const deployment = items.find((i) => i.problemId === problemId);
+  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+    return { kind: "unauthorized" };
+  }
+
+  const slots = shared.problemsEndpoints[problemId] ?? [];
+  if (slots.length === 0) return { kind: "no_endpoints" };
+
+  const overrides = await queryOverrides(
+    shared.ddb,
+    shared.endpointsTableName,
+    deployment.tenantId ?? "",
+    deployment.teamId,
+    problemId,
+  );
+
+  return {
+    kind: "ok",
+    teamId: deployment.teamId,
+    endpoints: resolveEndpoints({
+      slots,
+      stackOutputs: deployment.stackOutputs,
+      overrides,
+    }),
+  };
+}
+
+export type PutOverrideOutcome =
+  | { kind: "ok"; endpoints: ResolvedEndpoint[]; teamId: string }
+  | { kind: "unauthorized" }
+  | { kind: "unknown_slot" }
+  | { kind: "slot_not_overridable" }
+  | { kind: "invalid_url" }
+  | { kind: "no_endpoints" }
+  | { kind: "misconfigured" };
+
+/**
+ * 競技者向け URL validation。`https?://...` のみ許容、private IP / localhost も許容する
+ * (= Battle で参加者が自分の AWS account 内 endpoint を登録するため public/private は問わない)。
+ *
+ * Phase 3.A の主な目的は「文字列が URL 形式か」「scheme が http(s) か」「長さが妥当か」の 3 点。
+ */
+function isValidOverrideUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 2048) return false;
+  try {
+    const u = new URL(trimmed);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POST /portal/me/problems/:problemId/endpoints — 1 slot の override URL を upsert。
+ *
+ * - team に該当 problem が無い → unauthorized
+ * - metadata 側で当該 slot が宣言されていない → unknown_slot
+ * - 宣言済だが `overridable=false` → slot_not_overridable
+ * - URL validation 失敗 → invalid_url
+ */
+export async function upsertProblemEndpointOverride(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  problemId: string,
+  slot: string,
+  urlValue: unknown,
+  nowIso: string,
+): Promise<PutOverrideOutcome> {
+  if (!shared.endpointsTableName) return { kind: "misconfigured" };
+
+  const items = await queryTeamItems(shared, teamLoginKey);
+  if (items.length === 0) return { kind: "unauthorized" };
+  const deployment = items.find((i) => i.problemId === problemId);
+  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+    return { kind: "unauthorized" };
+  }
+
+  const slots = shared.problemsEndpoints[problemId] ?? [];
+  if (slots.length === 0) return { kind: "no_endpoints" };
+
+  const slotDef = slots.find((s) => s.slot === slot);
+  if (!slotDef) return { kind: "unknown_slot" };
+  if (!slotDef.overridable) return { kind: "slot_not_overridable" };
+  if (!isValidOverrideUrl(urlValue)) return { kind: "invalid_url" };
+
+  const tenantId = deployment.tenantId ?? "";
+  await putOverride(shared.ddb, shared.endpointsTableName, {
+    tenantId,
+    teamId: deployment.teamId,
+    problemId,
+    slot,
+    overrideUrl: urlValue.trim(),
+    nowIso,
+  });
+
+  // 直後の GET と同等の view を返す (= UI から再 GET 不要)。
+  const overrides = await queryOverrides(
+    shared.ddb,
+    shared.endpointsTableName,
+    tenantId,
+    deployment.teamId,
+    problemId,
+  );
+  return {
+    kind: "ok",
+    teamId: deployment.teamId,
+    endpoints: resolveEndpoints({
+      slots,
+      stackOutputs: deployment.stackOutputs,
+      overrides,
+    }),
+  };
+}
+
+export type DeleteOverrideOutcome =
+  | { kind: "ok"; endpoints: ResolvedEndpoint[]; teamId: string }
+  | { kind: "unauthorized" }
+  | { kind: "unknown_slot" }
+  | { kind: "no_endpoints" }
+  | { kind: "misconfigured" };
+
+/**
+ * DELETE /portal/me/problems/:problemId/endpoints/:slot — override を解除 (= default に戻す)。
+ */
+export async function deleteProblemEndpointOverride(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  problemId: string,
+  slot: string,
+): Promise<DeleteOverrideOutcome> {
+  if (!shared.endpointsTableName) return { kind: "misconfigured" };
+
+  const items = await queryTeamItems(shared, teamLoginKey);
+  if (items.length === 0) return { kind: "unauthorized" };
+  const deployment = items.find((i) => i.problemId === problemId);
+  if (!deployment || typeof deployment.teamId !== "string" || deployment.teamId.length === 0) {
+    return { kind: "unauthorized" };
+  }
+
+  const slots = shared.problemsEndpoints[problemId] ?? [];
+  if (slots.length === 0) return { kind: "no_endpoints" };
+  if (!slots.some((s) => s.slot === slot)) return { kind: "unknown_slot" };
+
+  const tenantId = deployment.tenantId ?? "";
+  await deleteOverride(shared.ddb, shared.endpointsTableName, {
+    tenantId,
+    teamId: deployment.teamId,
+    problemId,
+    slot,
+  });
+  const overrides = await queryOverrides(
+    shared.ddb,
+    shared.endpointsTableName,
+    tenantId,
+    deployment.teamId,
+    problemId,
+  );
+  return {
+    kind: "ok",
+    teamId: deployment.teamId,
+    endpoints: resolveEndpoints({
+      slots,
+      stackOutputs: deployment.stackOutputs,
+      overrides,
+    }),
+  };
+}
+
+// Test 用に DeploymentItem を引きたいケースのために re-export。
+export type { DeploymentItem };

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/resolve.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/resolve.ts
@@ -1,0 +1,60 @@
+import { type ProblemEndpointSlot, resolveDefaultUrl } from "../../../utils/endpoints-metadata.js";
+import { parseStackOutputs } from "../shared/cfn-status.js";
+import type { EndpointOverrideItem } from "./store.js";
+
+/**
+ * 1 slot 分の「effective endpoint」を participant 向けに返す view。
+ *
+ * - `defaultUrl`: deployment の CFn output から read-through 算出した URL (= 未 deploy /
+ *   output 欠損なら undefined)
+ * - `overrideUrl`: 競技者が POST /endpoints で登録した URL (= 未登録なら undefined)
+ * - `effectiveUrl`: scoring engine が probe する実 URL = `overrideUrl ?? defaultUrl`
+ * - `overridable`: metadata 側の宣言 (= 競技者画面で edit UI を出すか)
+ */
+export interface ResolvedEndpoint {
+  readonly slot: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly overridable: boolean;
+  readonly defaultUrl?: string;
+  readonly overrideUrl?: string;
+  readonly effectiveUrl?: string;
+}
+
+/**
+ * problem の metadata.endpoints[] + 当該 deployment の stackOutputs + 既存 override 行を
+ * 突き合わせて、participant に返す effective endpoint 一覧を組み立てる (Phase 3.A)。
+ *
+ * - metadata に endpoints[] 宣言が無い問題は空配列を返す
+ * - deployment が無い / status が不適切な場合は caller でフィルタ済前提 (= 本関数は純関数)
+ * - stackOutputs に該当 key が無い slot は `defaultUrl=undefined` だが、override があれば
+ *   effectiveUrl は override で埋まる
+ */
+export function resolveEndpoints(args: {
+  slots: readonly ProblemEndpointSlot[];
+  stackOutputs: string | undefined;
+  overrides: readonly EndpointOverrideItem[];
+}): ResolvedEndpoint[] {
+  const outputs = parseStackOutputs(args.stackOutputs);
+  const overrideMap = new Map<string, EndpointOverrideItem>();
+  for (const o of args.overrides) overrideMap.set(o.slot, o);
+
+  return args.slots.map((slot) => {
+    const baseOutput = outputs[slot.default.key];
+    const defaultUrl =
+      typeof baseOutput === "string" && baseOutput.length > 0
+        ? resolveDefaultUrl(baseOutput, slot.default.appendPath)
+        : undefined;
+    const overrideUrl = overrideMap.get(slot.slot)?.overrideUrl;
+    const effectiveUrl = overrideUrl ?? defaultUrl;
+    return {
+      slot: slot.slot,
+      ...(slot.label !== undefined ? { label: slot.label } : {}),
+      ...(slot.description !== undefined ? { description: slot.description } : {}),
+      overridable: slot.overridable,
+      ...(defaultUrl !== undefined ? { defaultUrl } : {}),
+      ...(overrideUrl !== undefined ? { overrideUrl } : {}),
+      ...(effectiveUrl !== undefined ? { effectiveUrl } : {}),
+    };
+  });
+}

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/store.ts
@@ -1,0 +1,97 @@
+import {
+  DeleteCommand,
+  type DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { buildEndpointPK, buildEndpointSK } from "../../problem-endpoints-table.js";
+
+/**
+ * 1 (tenant, team, problem, slot) を表す DDB 行の最小 shape。
+ *
+ * `defaultCacheUrl` は Phase 3.A 時点では未使用 (= read-through 算出)。Phase 3.B で
+ * deploy 完了 hook が書き込む余地を残す。
+ */
+export interface EndpointOverrideItem {
+  PK: string;
+  SK: string;
+  tenantId: string;
+  teamId: string;
+  problemId: string;
+  slot: string;
+  overrideUrl?: string;
+  defaultCacheUrl?: string;
+  platform?: string;
+  updatedAt: string;
+}
+
+export interface PutOverrideArgs {
+  tenantId: string;
+  teamId: string;
+  problemId: string;
+  slot: string;
+  overrideUrl: string;
+  nowIso: string;
+}
+
+export async function putOverride(
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  args: PutOverrideArgs,
+): Promise<EndpointOverrideItem> {
+  const item: EndpointOverrideItem = {
+    PK: buildEndpointPK(args.tenantId, args.teamId, args.problemId),
+    SK: buildEndpointSK(args.slot),
+    tenantId: args.tenantId,
+    teamId: args.teamId,
+    problemId: args.problemId,
+    slot: args.slot,
+    overrideUrl: args.overrideUrl,
+    updatedAt: args.nowIso,
+  };
+  await ddb.send(new PutCommand({ TableName: tableName, Item: item }));
+  return item;
+}
+
+export interface DeleteOverrideArgs {
+  tenantId: string;
+  teamId: string;
+  problemId: string;
+  slot: string;
+}
+
+export async function deleteOverride(
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  args: DeleteOverrideArgs,
+): Promise<void> {
+  await ddb.send(
+    new DeleteCommand({
+      TableName: tableName,
+      Key: {
+        PK: buildEndpointPK(args.tenantId, args.teamId, args.problemId),
+        SK: buildEndpointSK(args.slot),
+      },
+    }),
+  );
+}
+
+export async function queryOverrides(
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  tenantId: string,
+  teamId: string,
+  problemId: string,
+): Promise<EndpointOverrideItem[]> {
+  const out = await ddb.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: {
+        ":pk": buildEndpointPK(tenantId, teamId, problemId),
+        ":sk": "SLOT#",
+      },
+    }),
+  );
+  return (out.Items ?? []) as EndpointOverrideItem[];
+}

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -26,11 +26,22 @@ export interface ParticipantPortalLambdaProps {
    */
   readonly eventsTable: ITable;
   /**
+   * ADR-012 Phase 3.A: Endpoint registry テーブル。
+   * `/portal/me/problems/:problemId/endpoints` 系 route が読み書きする。
+   */
+  readonly endpointsTable: ITable;
+  /**
    * `{ [problemId]: { kind, flagOutputKey, points, ... } }` 形の scoring 設定。
    * `discoverProblemsScoring` で metadata.json から自動収集して synth 時に注入する。
    * 競技者が submit-flag したとき、この map を参照して採点する。
    */
   readonly problemsScoring: Readonly<Record<string, unknown>>;
+  /**
+   * ADR-012 Phase 3.A: `{ [problemId]: ProblemEndpointSlot[] }` 形の endpoint 宣言。
+   * `discoverProblemsEndpoints` で metadata.json から自動収集して synth 時に注入する。
+   * GET /endpoints が default URL を CFn output から read-through 算出するため参照。
+   */
+  readonly problemsEndpoints: Readonly<Record<string, unknown>>;
   /**
    * `ConsoleViewerRole` の ARN。AWS Console federation login URL 発行のため
    * Lambda が `sts:AssumeRole` する。caller side で IAM grant も付与する。
@@ -84,6 +95,21 @@ export class ParticipantPortalLambda extends Construct {
             }),
           ],
         }),
+        // ADR-012 Phase 3.A: Endpoint registry の override 行 R/W。
+        // PutItem / DeleteItem / Query で 1 (tenant, team, problem, slot) を扱う。
+        EndpointsRW: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: [
+                "dynamodb:Query",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:GetItem",
+              ],
+              resources: [props.endpointsTable.tableArn],
+            }),
+          ],
+        }),
       },
       managedPolicies: [
         ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
@@ -101,7 +127,9 @@ export class ParticipantPortalLambda extends Construct {
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
+        PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
         BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
+        PROBLEM_ENDPOINTS: JSON.stringify(props.problemsEndpoints),
         CONSOLE_VIEWER_ROLE_ARN: props.consoleViewerRoleArn,
         NODE_OPTIONS: "--enable-source-maps",
       },
@@ -117,7 +145,8 @@ export class ParticipantPortalLambda extends Construct {
       authType: FunctionUrlAuthType.NONE,
       cors: {
         allowedOrigins: ["*"],
-        allowedMethods: [HttpMethod.GET, HttpMethod.PATCH, HttpMethod.POST],
+        // ADR-012 Phase 3.A: DELETE は endpoint override 解除 (= default に戻す) で必要。
+        allowedMethods: [HttpMethod.GET, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.DELETE],
         allowedHeaders: ["content-type", "authorization"],
         maxAge: Duration.minutes(10),
       },

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -24,6 +24,7 @@ import {
   type ParticipantPortalRuntimeConfig,
 } from "./participant-portal-hosting";
 import { ParticipantPortalLambda } from "./participant-portal-lambda";
+import { ProblemEndpointsTable } from "./problem-endpoints-table";
 import { TeamsTable } from "./teams-table";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
@@ -53,6 +54,13 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * このキーが無い (= 採点無効)。
    */
   readonly problemsScoring: Readonly<Record<string, unknown>>;
+  /**
+   * ADR-012 Phase 3.A: `problemId → endpoints[]` の map。`discoverProblemsEndpoints`
+   * で metadata.json から自動収集して synth 時に注入する。Participant Portal の
+   * `/portal/me/problems/:problemId/endpoints` route が default URL を CFn output から
+   * 算出するために参照する。`endpoints[]` を持たない問題はこのキーが無い。
+   */
+  readonly problemsEndpoints: Readonly<Record<string, unknown>>;
   /**
    * 競技者向け Participant Portal を S3 + CloudFront で配信する。指定された
    * `runtimeConfig` が runtime-config.json として配置される。Portal backend が
@@ -131,6 +139,9 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     // Phase 2 で Bulk Deploy / Bulk Teardown を State Machine 経由で動かす。
     const events = new EventsTable(this, "Events");
     const teams = new TeamsTable(this, "Teams");
+    // ADR-012 Phase 3.A: Endpoint registry。per (tenant, team, problem, slot) で override
+    // URL を保管する。default URL は read-through で deployment.stackOutputs から算出。
+    const endpoints = new ProblemEndpointsTable(this, "ProblemEndpoints");
     // ADR-011 #590: AdminConsoleInsightStack に cross-stack で渡すため expose する。
     this.deploymentsTable = deployments.table;
     this.eventsTable = events.table;
@@ -237,7 +248,9 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       const portalLambda = new ParticipantPortalLambda(this, "ParticipantPortalLambda", {
         deploymentsTable: deployments.table,
         eventsTable: events.table,
+        endpointsTable: endpoints.table,
         problemsScoring: props.problemsScoring,
+        problemsEndpoints: props.problemsEndpoints,
         consoleViewerRoleArn: consoleViewerRole.role.roleArn,
       });
       // Lambda role に AssumeRole 権限を付与 (= federation flow の前提)。
@@ -284,6 +297,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     new CfnOutput(this, "DeployCreateStateMachineArn", {
       value: stateMachine.stateMachine.stateMachineArn,
       description: "Deploy 起動を司る Step Functions State Machine の ARN。",
+    });
+    new CfnOutput(this, "ProblemEndpointsTableName", {
+      value: endpoints.table.tableName,
+      description:
+        "ADR-012 Phase 3.A Endpoint registry table 名 (per (tenant, team, problem, slot) の override 行)。",
     });
   }
 }

--- a/infrastructure/lib/problem-deploy/problem-endpoints-table.ts
+++ b/infrastructure/lib/problem-deploy/problem-endpoints-table.ts
@@ -1,0 +1,54 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * ADR-012 Phase 3.A: Endpoint registry の per (tenant, team, problem, slot) 行を 1 行に
+ * 記録する DynamoDB テーブル。
+ *
+ * Schema:
+ *   PK: TENANT#<tenantId>#TEAM#<teamId>#PROBLEM#<problemId>
+ *   SK: SLOT#<slotName>
+ *
+ * 主な属性:
+ *   overrideUrl    競技者が portal で上書きした URL (= absent なら default 採用)
+ *   platform       過去 probe で観測した platform 識別子 (Phase 3.B 以降で /meta から抽出)
+ *   defaultCacheUrl 直近 deploy 完了時に CFn output から算出した default のキャッシュ
+ *                  (任意、Phase 3.A は read-through 算出なので必須ではない)
+ *   updatedAt      ISO 8601
+ *
+ * Phase 3.A では override のみを永続化し、default URL は read-through で stackOutputs +
+ * problem metadata から算出する。Phase 3.B 以降で deploy 完了 hook (= Step Function 経由)
+ * を足して default も per-team で永続化する余地を残す。
+ *
+ * memory: provisioned 1/1 (DynamoDbLowCapacity Aspect で再均し)。override の write 頻度は
+ * 競技者 1 人 1 回 / 競技中 (= 極小)、GET は per-page-load (= 数 RCU/s) 想定。
+ *
+ * 削除方針: RETAIN。competitor の override 履歴を stack delete で意図せず消さない。
+ */
+export class ProblemEndpointsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+    });
+  }
+}
+
+/** PK 構築 helper — runtime / test で同一規約を保つ。 */
+export function buildEndpointPK(tenantId: string, teamId: string, problemId: string): string {
+  return `TENANT#${tenantId}#TEAM#${teamId}#PROBLEM#${problemId}`;
+}
+
+/** SK 構築 helper — slot 名 (kebab-case) は metadata 側で validation 済前提。 */
+export function buildEndpointSK(slot: string): string {
+  return `SLOT#${slot}`;
+}

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { type ProblemEndpointSlot, parseEndpointSlot } from "./endpoints-metadata";
 import { type ProblemScoringMetadata, parseScoringMetadata } from "./scoring-metadata";
 
-export type { ProblemScoringMetadata };
+export type { ProblemEndpointSlot, ProblemScoringMetadata };
 
 /**
  * `problems/<category>/<id>/metadata.json` を持つディレクトリを列挙し、
@@ -35,11 +36,36 @@ export function discoverProblemsScoring(
   return result;
 }
 
+/**
+ * `discoverProblemsCatalog` の sibling (ADR-012 Phase 3.A)。`endpoints[]` section を抜き、
+ * `{ [problemId]: ProblemEndpointSlot[] }` の map を返す。`endpoints` を持たない問題は
+ * キーごと出さない (= endpoint 無効、Challenge 系 flag-only 問題が該当)。
+ *
+ * Lambda env (`PROBLEM_ENDPOINTS`) として Participant Portal handler / scoring dispatcher
+ * に渡し、各 Lambda が default URL を CFn output から read-through 算出する。
+ */
+export function discoverProblemsEndpoints(
+  problemsRoot: string,
+): Record<string, readonly ProblemEndpointSlot[]> {
+  const result: Record<string, readonly ProblemEndpointSlot[]> = {};
+  for (const meta of iterateProblemsMetadata(problemsRoot)) {
+    if (!Array.isArray(meta.endpoints)) continue;
+    const slots: ProblemEndpointSlot[] = [];
+    for (const entry of meta.endpoints) {
+      const slot = parseEndpointSlot(entry);
+      if (slot) slots.push(slot);
+    }
+    if (slots.length > 0) result[meta.id] = slots;
+  }
+  return result;
+}
+
 interface ProblemMetadataEntry {
   id: string;
   category: string;
   dirName: string;
   scoring: unknown;
+  endpoints: unknown;
 }
 
 function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetadataEntry> {
@@ -61,6 +87,7 @@ function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetada
         const meta = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as {
           id?: unknown;
           scoring?: unknown;
+          endpoints?: unknown;
         };
         if (typeof meta.id !== "string" || meta.id.length === 0) {
           console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
@@ -71,6 +98,7 @@ function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetada
           category: category.name,
           dirName: problem.name,
           scoring: meta.scoring,
+          endpoints: meta.endpoints,
         };
       } catch (err) {
         console.warn(

--- a/infrastructure/lib/utils/endpoints-metadata.ts
+++ b/infrastructure/lib/utils/endpoints-metadata.ts
@@ -99,18 +99,18 @@ export function parseEndpointsEnv(
  * 合成 (= base が "https://x/" なら "/a" / "a" 両方とも "https://x/a" になる、URL
  * spec の resolution)。base 自体に末尾 "/" が無い場合に備えて補う。
  */
+function tryUrl(input: string, base?: string): string | undefined {
+  try {
+    return new URL(input, base).toString();
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveDefaultUrl(base: string, appendPath?: string): string | undefined {
   if (!appendPath) return base;
-  try {
-    return new URL(appendPath).toString();
-  } catch {
-    // appendPath が absolute URL でない場合は base に対する relative resolve を試みる。
-    // base 自体が malformed (= 非 URL 文字列) なら resolve も crash するので caller に
-    // undefined を返して degrade させる (= 「default URL 未確定」 として UI 側で扱う)。
-    try {
-      return new URL(appendPath, base.endsWith("/") ? base : `${base}/`).toString();
-    } catch {
-      return undefined;
-    }
-  }
+  // 1) appendPath が absolute URL なら採用 2) base に対する relative resolve を試みる
+  //    base 自体が malformed なら caller に undefined を返して degrade (= UI 側は "default 未確定")
+  const baseWithSlash = base.endsWith("/") ? base : `${base}/`;
+  return tryUrl(appendPath) ?? tryUrl(appendPath, baseWithSlash);
 }

--- a/infrastructure/lib/utils/endpoints-metadata.ts
+++ b/infrastructure/lib/utils/endpoints-metadata.ts
@@ -99,11 +99,18 @@ export function parseEndpointsEnv(
  * 合成 (= base が "https://x/" なら "/a" / "a" 両方とも "https://x/a" になる、URL
  * spec の resolution)。base 自体に末尾 "/" が無い場合に備えて補う。
  */
-export function resolveDefaultUrl(base: string, appendPath?: string): string {
+export function resolveDefaultUrl(base: string, appendPath?: string): string | undefined {
   if (!appendPath) return base;
   try {
     return new URL(appendPath).toString();
   } catch {
-    return new URL(appendPath, base.endsWith("/") ? base : `${base}/`).toString();
+    // appendPath が absolute URL でない場合は base に対する relative resolve を試みる。
+    // base 自体が malformed (= 非 URL 文字列) なら resolve も crash するので caller に
+    // undefined を返して degrade させる (= 「default URL 未確定」 として UI 側で扱う)。
+    try {
+      return new URL(appendPath, base.endsWith("/") ? base : `${base}/`).toString();
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/infrastructure/lib/utils/endpoints-metadata.ts
+++ b/infrastructure/lib/utils/endpoints-metadata.ts
@@ -1,0 +1,109 @@
+/**
+ * 問題の `metadata.json:endpoints[]` section の type-safe な parser (ADR-012 Phase 3.A)。
+ *
+ * `endpoints[]` は thick metadata DSL (Phase 2 で導入) の構成要素で、各 slot の
+ * default URL (= deploy 後の CFn output から自動算出) と override 可否を宣言する。
+ * Phase 3.A の Endpoint registry が「default の値を read-through で組み立てる」ために
+ * 同じ parse 結果を CDK synth 時と Lambda runtime で共有する。
+ */
+
+export interface ProblemEndpointSlotDefault {
+  /** default URL の供給源。現状は `cfn-output` のみ。 */
+  readonly from: "cfn-output";
+  /** CFn template Outputs の OutputKey (例: "FrontendUrl")。 */
+  readonly key: string;
+  /** OutputKey 値の末尾に追加する path (例: "/users")。複数 slot で同 base を使い回す用途。 */
+  readonly appendPath?: string;
+}
+
+export interface ProblemEndpointSlot {
+  readonly slot: string;
+  readonly default: ProblemEndpointSlotDefault;
+  /** 競技者 portal で別 URL に上書きできるか。省略時 false。 */
+  readonly overridable: boolean;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+/**
+ * 1 件の `endpoints[]` entry を ProblemEndpointSlot に narrow する。不正なら undefined。
+ *
+ * - `slot` / `default.from === "cfn-output"` / `default.key` は必須
+ * - `overridable` 省略時は false
+ * - 不明な field は単に無視 (= forward-compat)
+ */
+export function parseEndpointSlot(value: unknown): ProblemEndpointSlot | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as {
+    slot?: unknown;
+    default?: unknown;
+    overridable?: unknown;
+    label?: unknown;
+    description?: unknown;
+  };
+  if (typeof v.slot !== "string" || v.slot.length === 0) return undefined;
+  if (!v.default || typeof v.default !== "object") return undefined;
+  const d = v.default as { from?: unknown; key?: unknown; appendPath?: unknown };
+  if (d.from !== "cfn-output") return undefined;
+  if (typeof d.key !== "string" || d.key.length === 0) return undefined;
+  return {
+    slot: v.slot,
+    default: {
+      from: "cfn-output",
+      key: d.key,
+      ...(typeof d.appendPath === "string" ? { appendPath: d.appendPath } : {}),
+    },
+    overridable: v.overridable === true,
+    ...(typeof v.label === "string" ? { label: v.label } : {}),
+    ...(typeof v.description === "string" ? { description: v.description } : {}),
+  };
+}
+
+/**
+ * Lambda env (`PROBLEM_ENDPOINTS`) を decode し、`{ [problemId]: ProblemEndpointSlot[] }`
+ * に narrow する。不正な entry (parse 失敗 / non-object / 空配列) は drop。
+ *
+ * env から渡す理由: CDK synth 時に `discoverProblemsEndpoints` で metadata.json を
+ * 走査し、Lambda 起動時に再度 file IO せず単一 JSON 文字列で受け取る (= cold start
+ * 削減 + Lambda 内に problems/ ディレクトリを bundling しない)。
+ */
+export function parseEndpointsEnv(
+  raw: string | undefined,
+): Record<string, readonly ProblemEndpointSlot[]> {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const out: Record<string, readonly ProblemEndpointSlot[]> = {};
+  for (const [problemId, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const slots: ProblemEndpointSlot[] = [];
+    for (const entry of value) {
+      const slot = parseEndpointSlot(entry);
+      if (slot) slots.push(slot);
+    }
+    if (slots.length > 0) out[problemId] = slots;
+  }
+  return out;
+}
+
+/**
+ * `default.key` + `default.appendPath` から effective default URL を算出する。
+ *
+ * `base` = CFn output value (= 既に絶対 URL)。
+ * `appendPath` が無いなら base をそのまま返す。あれば `new URL(appendPath, base)` で
+ * 合成 (= base が "https://x/" なら "/a" / "a" 両方とも "https://x/a" になる、URL
+ * spec の resolution)。base 自体に末尾 "/" が無い場合に備えて補う。
+ */
+export function resolveDefaultUrl(base: string, appendPath?: string): string {
+  if (!appendPath) return base;
+  try {
+    return new URL(appendPath).toString();
+  } catch {
+    return new URL(appendPath, base.endsWith("/") ? base : `${base}/`).toString();
+  }
+}

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -16,6 +16,7 @@ function synthDefault(): Template {
       "hello-world": "problems/challenges/hello-world",
     },
     problemsScoring: {},
+    problemsEndpoints: {},
     environmentName: "development",
   });
   return Template.fromStack(stack);
@@ -25,10 +26,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts の 4 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
-      // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts。
-      // 4 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 4);
+    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints の 5 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+      // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts、
+      // ADR-012 Phase 3.A で ProblemEndpoints。
+      // 5 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 5);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({
@@ -135,6 +137,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
         sourceObjectKey: "source.zip",
         problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
         problemsScoring: {},
+        problemsEndpoints: {},
         deployConcurrentBuildLimit: 200,
         environmentName: "development",
       });
@@ -207,6 +210,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(Object.keys(outputs)).toEqual(
         expect.arrayContaining(["DeploymentsTableName", "DeployCreateStateMachineArn"]),
       );
+    });
+
+    it("ADR-012 Phase 3.A: ProblemEndpointsTableName を Output として持つべき", () => {
+      const outputs = tpl.findOutputs("*");
+      expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["ProblemEndpointsTableName"]));
     });
   });
 
@@ -353,10 +361,16 @@ function synthParticipantPortalLambdaOnly(): Template {
     partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
     sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
   });
+  const endpoints = new cdk.aws_dynamodb.Table(stack, "ProblemEndpoints", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
   new ParticipantPortalLambda(stack, "ParticipantPortal", {
     deploymentsTable: deployments,
     eventsTable: events,
+    endpointsTable: endpoints,
     problemsScoring: {},
+    problemsEndpoints: {},
     consoleViewerRoleArn: "arn:aws:iam::123456789012:role/console-viewer",
   });
   return Template.fromStack(stack);
@@ -396,6 +410,45 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
               Statement: Match.arrayWith([
                 Match.objectLike({
                   Action: "dynamodb:Query",
+                  Effect: "Allow",
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("ADR-012 Phase 3.A: environment に PROBLEM_ENDPOINTS_TABLE_NAME + PROBLEM_ENDPOINTS を持つべき", () => {
+    tpl.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: Match.objectLike({
+          Variables: Match.objectLike({
+            PROBLEM_ENDPOINTS_TABLE_NAME: Match.anyValue(),
+            PROBLEM_ENDPOINTS: Match.anyValue(),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("ADR-012 Phase 3.A: IAM Role に Endpoints table の Query / PutItem / DeleteItem 権限を付与するべき", () => {
+    tpl.hasResourceProperties(
+      "AWS::IAM::Role",
+      Match.objectLike({
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyName: "EndpointsRW",
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([
+                Match.objectLike({
+                  Action: Match.arrayWith([
+                    "dynamodb:Query",
+                    "dynamodb:PutItem",
+                    "dynamodb:DeleteItem",
+                  ]),
                   Effect: "Allow",
                 }),
               ]),

--- a/infrastructure/test/problem-deploy/endpoints-metadata.test.ts
+++ b/infrastructure/test/problem-deploy/endpoints-metadata.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseEndpointSlot,
+  parseEndpointsEnv,
+  resolveDefaultUrl,
+} from "../../lib/utils/endpoints-metadata";
+
+describe("parseEndpointSlot", () => {
+  it("最小構成 (= slot + default.from + default.key) を採用すべき", () => {
+    expect(
+      parseEndpointSlot({ slot: "main", default: { from: "cfn-output", key: "BaseUrl" } }),
+    ).toEqual({
+      slot: "main",
+      default: { from: "cfn-output", key: "BaseUrl" },
+      overridable: false,
+    });
+  });
+
+  it("overridable=true / label / description / appendPath を保持すべき", () => {
+    expect(
+      parseEndpointSlot({
+        slot: "users",
+        default: { from: "cfn-output", key: "BaseUrl", appendPath: "/users" },
+        overridable: true,
+        label: "Users API",
+        description: "顧客一覧",
+      }),
+    ).toEqual({
+      slot: "users",
+      default: { from: "cfn-output", key: "BaseUrl", appendPath: "/users" },
+      overridable: true,
+      label: "Users API",
+      description: "顧客一覧",
+    });
+  });
+
+  it("from が cfn-output 以外なら undefined を返すべき", () => {
+    expect(parseEndpointSlot({ slot: "x", default: { from: "manual", key: "Y" } })).toBeUndefined();
+  });
+
+  it("slot が空文字 / key が空文字なら undefined を返すべき", () => {
+    expect(
+      parseEndpointSlot({ slot: "", default: { from: "cfn-output", key: "Y" } }),
+    ).toBeUndefined();
+    expect(
+      parseEndpointSlot({ slot: "main", default: { from: "cfn-output", key: "" } }),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseEndpointsEnv", () => {
+  it("`{ [problemId]: ProblemEndpointSlot[] }` を採用すべき", () => {
+    const raw = JSON.stringify({
+      "hello-world-battle": [
+        { slot: "frontend", default: { from: "cfn-output", key: "FrontendUrl" } },
+        { slot: "api", default: { from: "cfn-output", key: "ApiUrl" } },
+      ],
+    });
+    expect(parseEndpointsEnv(raw)).toEqual({
+      "hello-world-battle": [
+        {
+          slot: "frontend",
+          default: { from: "cfn-output", key: "FrontendUrl" },
+          overridable: false,
+        },
+        {
+          slot: "api",
+          default: { from: "cfn-output", key: "ApiUrl" },
+          overridable: false,
+        },
+      ],
+    });
+  });
+
+  it("空文字 / 不正 JSON / non-object は空 map を返すべき", () => {
+    expect(parseEndpointsEnv(undefined)).toEqual({});
+    expect(parseEndpointsEnv("")).toEqual({});
+    expect(parseEndpointsEnv("{not-json")).toEqual({});
+    expect(parseEndpointsEnv("[1,2,3]")).toEqual({});
+  });
+
+  it("配列でない値 / 空配列の problemId は drop すべき", () => {
+    const raw = JSON.stringify({
+      "p-1": "not-array",
+      "p-2": [],
+      "p-3": [{ slot: "main", default: { from: "cfn-output", key: "X" } }],
+    });
+    expect(Object.keys(parseEndpointsEnv(raw))).toEqual(["p-3"]);
+  });
+
+  it("壊れた entry は drop し他は維持すべき", () => {
+    const raw = JSON.stringify({
+      "p-1": [
+        { slot: "good", default: { from: "cfn-output", key: "X" } },
+        { slot: "", default: { from: "cfn-output", key: "Y" } }, // empty slot → drop
+        { slot: "bad-from", default: { from: "manual", key: "Z" } }, // from not cfn-output → drop
+      ],
+    });
+    expect(parseEndpointsEnv(raw)).toEqual({
+      "p-1": [
+        {
+          slot: "good",
+          default: { from: "cfn-output", key: "X" },
+          overridable: false,
+        },
+      ],
+    });
+  });
+});
+
+describe("resolveDefaultUrl", () => {
+  it("appendPath 無しは base をそのまま返すべき", () => {
+    expect(resolveDefaultUrl("https://example.com/")).toBe("https://example.com/");
+    expect(resolveDefaultUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("appendPath を相対 path として base に合成すべき", () => {
+    expect(resolveDefaultUrl("https://example.com/", "/users")).toBe("https://example.com/users");
+    expect(resolveDefaultUrl("https://example.com", "users")).toBe("https://example.com/users");
+  });
+
+  it("appendPath が絶対 URL なら appendPath を採用すべき", () => {
+    expect(resolveDefaultUrl("https://base.example.com/", "https://other.example.com/path")).toBe(
+      "https://other.example.com/path",
+    );
+  });
+});

--- a/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
@@ -199,6 +199,34 @@ describe("upsertProblemEndpointOverride", () => {
     expect(r.kind).toBe("invalid_url");
   });
 
+  // SSRF defense-in-depth: metadata service / loopback literal を write 時に拒否する。
+  // Phase 3.B fetcher で DNS-rebinding-safe resolve-then-connect を行うまでの blocklist。
+  it.each([
+    ["AWS IMDS v4", "http://169.254.169.254/latest/meta-data/iam/security-credentials/"],
+    ["AWS IMDS v6", "http://[fd00:ec2::254]/latest/meta-data/"],
+    ["GCE metadata", "http://metadata.google.internal/computeMetadata/v1/"],
+    ["loopback IPv4", "http://127.0.0.1:9001/admin"],
+    ["loopback IPv6", "http://[::1]/"],
+    ["localhost literal", "http://localhost/"],
+  ])("SSRF blocklist: %s host は invalid_url を返すべき", async (_, url) => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn();
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend,
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "frontend",
+      url,
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("invalid_url");
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
   it("metadata に無い slot は unknown_slot を返すべき", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const shared = buildShared({

--- a/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteProblemEndpointOverride,
+  listProblemEndpoints,
+  upsertProblemEndpointOverride,
+} from "../../lib/problem-deploy/handlers/problem-endpoints-handler/endpoints";
+import type { ProblemEndpointSlot } from "../../lib/utils/endpoints-metadata";
+
+/**
+ * problem-endpoints-handler の business logic 単体テスト。`queryTeamItems` は
+ * `participant-handler/shared` の export を vi.mock で差し替えて DDB を叩かない。
+ *
+ * 設計上 store.ts は ddb client を呼ぶが、本テストでは shared.ddb をモック object に
+ * 差し替えるので実 SDK は不要。
+ */
+
+vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
+  queryTeamItems: vi.fn(),
+}));
+
+import { queryTeamItems } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+const mockedQueryTeamItems = queryTeamItems as unknown as ReturnType<typeof vi.fn>;
+
+function buildShared(opts: {
+  endpointsTableName?: string;
+  problemsEndpoints?: Record<string, readonly ProblemEndpointSlot[]>;
+  ddbSend?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    tableName: "Deployments",
+    eventsTableName: "Events",
+    endpointsTableName: opts.endpointsTableName ?? "ProblemEndpoints",
+    ddb: { send: opts.ddbSend ?? vi.fn() } as never,
+    problemsScoring: {},
+    problemsEndpoints: opts.problemsEndpoints ?? {},
+  };
+}
+
+const SLOT_FRONTEND: ProblemEndpointSlot = {
+  slot: "frontend",
+  default: { from: "cfn-output", key: "FrontendUrl" },
+  overridable: true,
+};
+const SLOT_API: ProblemEndpointSlot = {
+  slot: "api",
+  default: { from: "cfn-output", key: "ApiUrl" },
+  overridable: false,
+};
+
+const teamRow = {
+  PK: "DEPLOYMENT#job-1",
+  problemId: "battle-1",
+  tenantId: "tenant-x",
+  teamId: "team-y",
+  stackOutputs: JSON.stringify([
+    { OutputKey: "FrontendUrl", OutputValue: "https://front.example.com/" },
+    { OutputKey: "ApiUrl", OutputValue: "https://api.example.com/" },
+  ]),
+};
+
+beforeEach(() => {
+  mockedQueryTeamItems.mockReset();
+});
+
+describe("listProblemEndpoints", () => {
+  it("team の deployment が無いときは unauthorized を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([]);
+    const shared = buildShared({ problemsEndpoints: { "battle-1": [SLOT_FRONTEND] } });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("unauthorized");
+  });
+
+  it("team に該当 problemId が無いときも unauthorized を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([{ ...teamRow, problemId: "other-problem" }]);
+    const shared = buildShared({ problemsEndpoints: { "battle-1": [SLOT_FRONTEND] } });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("unauthorized");
+  });
+
+  it("metadata.endpoints[] が空 (= flag-only 問題) は no_endpoints を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const shared = buildShared({ problemsEndpoints: {} });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("no_endpoints");
+  });
+
+  it("override 無しで slot 一覧と default URL を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn().mockResolvedValueOnce({ Items: [] });
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND, SLOT_API] },
+      ddbSend,
+    });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.teamId).toBe("team-y");
+    expect(r.endpoints).toHaveLength(2);
+    expect(r.endpoints[0]).toMatchObject({
+      slot: "frontend",
+      defaultUrl: "https://front.example.com/",
+      effectiveUrl: "https://front.example.com/",
+      overridable: true,
+    });
+  });
+
+  it("override 行がある slot は effectiveUrl が override で埋まるべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn().mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "TENANT#tenant-x#TEAM#team-y#PROBLEM#battle-1",
+          SK: "SLOT#frontend",
+          slot: "frontend",
+          tenantId: "tenant-x",
+          teamId: "team-y",
+          problemId: "battle-1",
+          overrideUrl: "https://my-host.example.com/",
+          updatedAt: "2026-05-12T00:00:00.000Z",
+        },
+      ],
+    });
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend,
+    });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.endpoints[0]).toMatchObject({
+      defaultUrl: "https://front.example.com/",
+      overrideUrl: "https://my-host.example.com/",
+      effectiveUrl: "https://my-host.example.com/",
+    });
+  });
+
+  it("endpointsTableName が未配線なら misconfigured を返すべき", async () => {
+    const shared = buildShared({ endpointsTableName: "" });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("misconfigured");
+    expect(mockedQueryTeamItems).not.toHaveBeenCalled();
+  });
+});
+
+describe("upsertProblemEndpointOverride", () => {
+  it("override 不可 slot は slot_not_overridable を返し DDB Put しないべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn();
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_API] },
+      ddbSend,
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "api",
+      "https://new.example.com/",
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("slot_not_overridable");
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("URL が不正なら invalid_url を返し DDB Put しないべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn();
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend,
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "frontend",
+      "not a url",
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("invalid_url");
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("ftp:// など http(s) 以外の scheme は invalid_url を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend: vi.fn(),
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "frontend",
+      "ftp://example.com/",
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("invalid_url");
+  });
+
+  it("metadata に無い slot は unknown_slot を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend: vi.fn(),
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "nonexistent",
+      "https://x.example.com/",
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("unknown_slot");
+  });
+
+  it("成功時は DDB Put して view を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            slot: "frontend",
+            overrideUrl: "https://new.example.com/",
+            tenantId: "tenant-x",
+            teamId: "team-y",
+            problemId: "battle-1",
+            updatedAt: "2026-05-12T00:00:00.000Z",
+          },
+        ],
+      });
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend,
+    });
+    const r = await upsertProblemEndpointOverride(
+      shared,
+      "key",
+      "battle-1",
+      "frontend",
+      "https://new.example.com/",
+      "2026-05-12T00:00:00.000Z",
+    );
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.endpoints[0]?.overrideUrl).toBe("https://new.example.com/");
+    expect(r.endpoints[0]?.effectiveUrl).toBe("https://new.example.com/");
+    // 1 回目: PutCommand
+    expect(ddbSend.mock.calls[0]?.[0]).toMatchObject({
+      input: expect.objectContaining({
+        TableName: "ProblemEndpoints",
+        Item: expect.objectContaining({
+          PK: "TENANT#tenant-x#TEAM#team-y#PROBLEM#battle-1",
+          SK: "SLOT#frontend",
+          overrideUrl: "https://new.example.com/",
+        }),
+      }),
+    });
+  });
+});
+
+describe("deleteProblemEndpointOverride", () => {
+  it("metadata に無い slot は unknown_slot を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend: vi.fn(),
+    });
+    const r = await deleteProblemEndpointOverride(shared, "key", "battle-1", "nonexistent");
+    expect(r.kind).toBe("unknown_slot");
+  });
+
+  it("成功時は DDB DeleteItem を発行して view を返すべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
+    const ddbSend = vi.fn().mockResolvedValueOnce({}).mockResolvedValueOnce({ Items: [] });
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
+      ddbSend,
+    });
+    const r = await deleteProblemEndpointOverride(shared, "key", "battle-1", "frontend");
+    expect(r.kind).toBe("ok");
+    // 1 回目: DeleteCommand
+    expect(ddbSend.mock.calls[0]?.[0]).toMatchObject({
+      input: expect.objectContaining({
+        TableName: "ProblemEndpoints",
+        Key: {
+          PK: "TENANT#tenant-x#TEAM#team-y#PROBLEM#battle-1",
+          SK: "SLOT#frontend",
+        },
+      }),
+    });
+  });
+});

--- a/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { resolveEndpoints } from "../../lib/problem-deploy/handlers/problem-endpoints-handler/resolve";
+import type { EndpointOverrideItem } from "../../lib/problem-deploy/handlers/problem-endpoints-handler/store";
+import type { ProblemEndpointSlot } from "../../lib/utils/endpoints-metadata";
+
+/**
+ * resolveEndpoints は純関数なので vi.mock 不要。metadata + stackOutputs (= CFn output JSON) +
+ * override 行を merge して effective URL を組む。
+ */
+
+const slot = (
+  name: string,
+  key: string,
+  opts: Partial<ProblemEndpointSlot> = {},
+): ProblemEndpointSlot => ({
+  slot: name,
+  default: { from: "cfn-output", key },
+  overridable: false,
+  ...opts,
+});
+
+const override = (slotName: string, url: string): EndpointOverrideItem => ({
+  PK: "TENANT#t#TEAM#tm#PROBLEM#p",
+  SK: `SLOT#${slotName}`,
+  tenantId: "t",
+  teamId: "tm",
+  problemId: "p",
+  slot: slotName,
+  overrideUrl: url,
+  updatedAt: "2026-05-12T00:00:00.000Z",
+});
+
+describe("resolveEndpoints", () => {
+  it("CFn output 値を default URL として採用すべき (array 形式)", () => {
+    const stackOutputs = JSON.stringify([
+      { OutputKey: "FrontendUrl", OutputValue: "https://front.example.com/" },
+    ]);
+    const result = resolveEndpoints({
+      slots: [slot("frontend", "FrontendUrl")],
+      stackOutputs,
+      overrides: [],
+    });
+    expect(result).toEqual([
+      {
+        slot: "frontend",
+        overridable: false,
+        defaultUrl: "https://front.example.com/",
+        effectiveUrl: "https://front.example.com/",
+      },
+    ]);
+  });
+
+  it("CFn output に該当 key が無いとき defaultUrl は undefined、effectiveUrl も undefined になるべき", () => {
+    const result = resolveEndpoints({
+      slots: [slot("api", "MissingKey")],
+      stackOutputs: JSON.stringify([]),
+      overrides: [],
+    });
+    expect(result).toEqual([{ slot: "api", overridable: false }]);
+  });
+
+  it("override がある slot は effectiveUrl が override で埋まるべき", () => {
+    const stackOutputs = JSON.stringify([
+      { OutputKey: "FrontendUrl", OutputValue: "https://front.example.com/" },
+    ]);
+    const result = resolveEndpoints({
+      slots: [slot("frontend", "FrontendUrl", { overridable: true })],
+      stackOutputs,
+      overrides: [override("frontend", "https://my-host.example.com/")],
+    });
+    expect(result[0]).toMatchObject({
+      defaultUrl: "https://front.example.com/",
+      overrideUrl: "https://my-host.example.com/",
+      effectiveUrl: "https://my-host.example.com/",
+    });
+  });
+
+  it("appendPath を含めた default URL を組み立てるべき", () => {
+    const stackOutputs = JSON.stringify([
+      { OutputKey: "BaseUrl", OutputValue: "https://api.example.com/" },
+    ]);
+    const result = resolveEndpoints({
+      slots: [
+        slot("users", "BaseUrl", {
+          default: { from: "cfn-output", key: "BaseUrl", appendPath: "/users" },
+        }),
+      ],
+      stackOutputs,
+      overrides: [],
+    });
+    expect(result[0]?.defaultUrl).toBe("https://api.example.com/users");
+  });
+
+  it("label / description を保持すべき", () => {
+    const result = resolveEndpoints({
+      slots: [slot("frontend", "FrontendUrl", { label: "Frontend", description: "nginx" })],
+      stackOutputs: undefined,
+      overrides: [],
+    });
+    expect(result[0]).toMatchObject({
+      label: "Frontend",
+      description: "nginx",
+      overridable: false,
+    });
+  });
+
+  it("metadata.endpoints[] が空なら空配列を返すべき", () => {
+    expect(resolveEndpoints({ slots: [], stackOutputs: undefined, overrides: [] })).toEqual([]);
+  });
+});

--- a/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
@@ -1,0 +1,192 @@
+import { StatusCodes } from "http-status-codes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hono の dispatch path 通しの integration テスト (route → outcome → JSON)。
+ * business logic (= endpoints.ts) は vi.mock で stub し、HTTP status / body 形だけ assert する。
+ */
+
+const mocks = vi.hoisted(() => ({
+  listProblemEndpoints: vi.fn(),
+  upsertProblemEndpointOverride: vi.fn(),
+  deleteProblemEndpointOverride: vi.fn(),
+}));
+
+// `participant-handler/index.ts` が module load 時に `buildParticipantSharedResources()` を
+// 呼ぶので、env を必要としない stub に差し替える。
+vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", async () => {
+  const actual = (await vi.importActual(
+    "../../lib/problem-deploy/handlers/participant-handler/shared",
+  )) as { queryTeamItems: unknown };
+  return {
+    ...actual,
+    buildParticipantSharedResources: () => ({
+      tableName: "Deployments",
+      eventsTableName: "Events",
+      endpointsTableName: "ProblemEndpoints",
+      ddb: { send: vi.fn() },
+      problemsScoring: {},
+      problemsEndpoints: {},
+    }),
+  };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/problem-endpoints-handler/endpoints", () => ({
+  listProblemEndpoints: mocks.listProblemEndpoints,
+  upsertProblemEndpointOverride: mocks.upsertProblemEndpointOverride,
+  deleteProblemEndpointOverride: mocks.deleteProblemEndpointOverride,
+}));
+
+const { app } = await import("../../lib/problem-deploy/handlers/participant-handler/index");
+
+function bearer(token: string): HeadersInit {
+  return { authorization: `Bearer ${token}`, "content-type": "application/json" };
+}
+
+describe("GET /portal/me/problems/:problemId/endpoints", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("Authorization header が無いときは 401 を返すべき", async () => {
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints");
+    expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
+  });
+
+  it("problemId が pattern と合わないときは 400 を返すべき", async () => {
+    const res = await app.request("/portal/me/problems/INVALID_UPPER/endpoints", {
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.listProblemEndpoints).not.toHaveBeenCalled();
+  });
+
+  it("ok outcome は 200 と endpoints / teamId を返すべき", async () => {
+    mocks.listProblemEndpoints.mockResolvedValueOnce({
+      kind: "ok",
+      teamId: "team-x",
+      endpoints: [
+        {
+          slot: "frontend",
+          overridable: true,
+          defaultUrl: "https://front.example.com/",
+          effectiveUrl: "https://front.example.com/",
+        },
+      ],
+    });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints", {
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as { teamId: string; endpoints: unknown[] };
+    expect(body.teamId).toBe("team-x");
+    expect(body.endpoints).toHaveLength(1);
+  });
+
+  it("no_endpoints outcome は 404 を返すべき", async () => {
+    mocks.listProblemEndpoints.mockResolvedValueOnce({ kind: "no_endpoints" });
+    const res = await app.request("/portal/me/problems/hello-world/endpoints", {
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("unauthorized outcome は 401 を返すべき", async () => {
+    mocks.listProblemEndpoints.mockResolvedValueOnce({ kind: "unauthorized" });
+    const res = await app.request("/portal/me/problems/hello-world/endpoints", {
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
+  });
+});
+
+describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("body が JSON でなければ 400 を返すべき", async () => {
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "POST",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      body: "not-json",
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.upsertProblemEndpointOverride).not.toHaveBeenCalled();
+  });
+
+  it("slot が pattern と合わないなら 400 を返すべき", async () => {
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/UPPER_CASE", {
+      method: "POST",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      body: JSON.stringify({ url: "https://x.example.com/" }),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("invalid_url outcome は 400 を返すべき", async () => {
+    mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({ kind: "invalid_url" });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "POST",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      body: JSON.stringify({ url: "garbage" }),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("slot_not_overridable outcome は 409 を返すべき", async () => {
+    mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({ kind: "slot_not_overridable" });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "POST",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      body: JSON.stringify({ url: "https://x.example.com/" }),
+    });
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+  });
+
+  it("ok outcome は 200 と更新後 view を返すべき", async () => {
+    mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({
+      kind: "ok",
+      teamId: "team-x",
+      endpoints: [
+        {
+          slot: "frontend",
+          overridable: true,
+          defaultUrl: "https://default.example.com/",
+          overrideUrl: "https://new.example.com/",
+          effectiveUrl: "https://new.example.com/",
+        },
+      ],
+    });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "POST",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      body: JSON.stringify({ url: "https://new.example.com/" }),
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const body = (await res.json()) as { endpoints: { effectiveUrl: string }[] };
+    expect(body.endpoints[0]?.effectiveUrl).toBe("https://new.example.com/");
+  });
+});
+
+describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ok outcome は 200 を返すべき", async () => {
+    mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({
+      kind: "ok",
+      teamId: "team-x",
+      endpoints: [],
+    });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "DELETE",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+  });
+
+  it("unknown_slot outcome は 400 を返すべき", async () => {
+    mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "unknown_slot" });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "DELETE",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+});

--- a/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
@@ -189,4 +189,22 @@ describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
     });
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
   });
+
+  it("no_endpoints outcome は 404 を返すべき", async () => {
+    mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "no_endpoints" });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "DELETE",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("unauthorized outcome は 401 を返すべき", async () => {
+    mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "unauthorized" });
+    const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
+      method: "DELETE",
+      headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    });
+    expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
+  });
 });


### PR DESCRIPTION
## Summary

ADR-012 Phase 3.A: Endpoint registry を先行 ship。Generic scoring Lambda + 5 builtin kind handler (= Phase 3.B) は follow-up issue に分離。元 issue #611 は Phase 3 全体なので **Relates #611** (= 閉じない backlink)。

- 新 DDB `ProblemEndpoints` (PK=`TENANT#x#TEAM#y#PROBLEM#z`, SK=`SLOT#name`, PROVISIONED 1/1)
- Participant Portal Lambda に 3 routes (GET list / POST override / DELETE override)
- default URL は **read-through** で deployment.stackOutputs から算出 (= Step Function を触らない)

## 分離理由

元 scope = Endpoint registry + Generic scoring Lambda + 5 kind handler + 既存 health-check-handler refactor + tests。1 PR で 30+ files / 2500+ LOC になり review 不能と判断。Phase 3.A だけで 17 files / 1495 LOC、見通せる単位として分離。Phase 3.B は existing handler refactor + 新規 scoring 5 種なので別 PR で扱う。

## 設計判断 (詳細は commit message)

- **override は Participant Portal (teamLoginKey bearer) に乗せた** — 元 spec は "Cognito JWT" だったが、override 操作は競技者の action なので submit-flag と同型の auth に揃えた
- **default URL は read-through 算出** — deploy 完了 hook を入れず GET 時に stackOutputs を parse。State Machine を触らず、metadata 変更が即時反映。`defaultCacheUrl` field を予約して Phase 3.B で hook 追加の余地を残す
- **no_endpoints vs unauthorized の分離** — flag-only Challenge での GET には 404 (`no_endpoints`)、所有外 problem には 401 (`unauthorized`)

## Regression 分析

- **既存 hello-world / hello-world-battle**: unchanged。submit-flag (Challenge) / health-check uptime (Battle) の経路は今回触っていない。
- **Participant Portal Lambda の env 増加**: `PROBLEM_ENDPOINTS_TABLE_NAME` / `PROBLEM_ENDPOINTS` が増えるが、CFn ref で resolved されるので CDK deploy 経路で壊れない。
- **route-helpers ErrorKind 追加**: 新 kind のみで既存値は無変更。

## 物理影響

- **CREATE**: `AWS::DynamoDB::Table` ProblemEndpoints (PROVISIONED 1/1、RETAIN)
- **CREATE**: `AWS::CloudFormation::Output` ProblemEndpointsTableName
- **UPDATE**: ParticipantPortalLambda の Function (env 追加) と Role (EndpointsRW inline policy 追加)
- **UPDATE**: Function URL の CORS AllowedMethods に DELETE 追加
- **NO-OP**: 既存 DDB / Lambda / State Machine / API Gateway は無変更

## Test plan

- [x] `make lint` (markdownlint + textlint + biome)
- [x] `make validate-problems`
- [x] `make check-http-status`
- [x] `bun run --filter '@TenkaCloud/infrastructure' typecheck`
- [x] `bun run --filter '@TenkaCloud/infrastructure' test` — **620 passed (59 files)**, +4 new test files (endpoints-metadata / resolve / handler / routes), +2 it() in existing problem-deploy-backend-stack.test.ts

## Follow-up

Phase 3.B = Generic scoring Lambda + 5 builtin kind handler (= flag / uptime-flat / uptime-multi / phased-polling / attack-detection) は別 issue で起票して別 PR で ship。Phase 3.A の `defaultCacheUrl` field は予約済 (= deploy 完了 hook を Phase 3.B で足せる)。

Relates #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint registry for problems: view default endpoints and manage per-slot overrides via new portal routes and APIs.
* **Security**
  * Stricter URL validation with SSRF protections and host blacklist for submitted overrides.
* **Infrastructure**
  * New endpoints datastore, environment wiring, IAM access, and CORS allowing DELETE; deploy stack exports the table name.
* **Tests**
  * Added unit and integration tests for parsing, resolution, routes, and store behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/619)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->