### PR TITLE
feat(#612): ADR-012 Phase 4 — Disruption pattern + portal predict

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -40,4 +40,31 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(json).not.toContain("cfnTemplate");
     expect(json).not.toContain("cfnParameters");
   });
+
+  // ADR-012 Phase 4: phases / disruptions を portal が予告 panel に出すための data shape pin。
+  it("microservice-migration-battle で phases / disruptions が露出されるべき (ADR-012 Phase 4)", () => {
+    const m = findProblemMetadata("microservice-migration-battle");
+    expect(m).toBeDefined();
+    expect(m?.phases.length).toBeGreaterThanOrEqual(2);
+    expect(m?.phases.map((p) => p.name)).toEqual(expect.arrayContaining(["degraded", "legacy"]));
+    expect(m?.disruptions.length).toBeGreaterThanOrEqual(1);
+    expect(m?.disruptions[0]?.id).toBe("ec2-latency-injection");
+    expect(m?.disruptions[0]?.defaultAfterMinutes).toBe(60);
+  });
+
+  it("phases / disruptions に operator 内部 field (effect / parameters / eventDetailType) を露出しないべき", () => {
+    const m = findProblemMetadata("microservice-migration-battle");
+    const json = JSON.stringify(m);
+    // 採点 internals / Phase 2 用 trigger 情報は競技者には不要 (= 答えの hint や noise 防止)
+    expect(json).not.toContain("eventDetailType");
+    expect(json).not.toContain("operatorEditable");
+    expect(json).not.toContain("switchPlatformToDegraded");
+    expect(json).not.toContain("scorePathOverride");
+  });
+
+  it("phases / disruptions が無い問題は空配列を返すべき", () => {
+    const m = findProblemMetadata("hello-world");
+    expect(m?.phases).toEqual([]);
+    expect(m?.disruptions).toEqual([]);
+  });
 });

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -14,6 +14,23 @@ export type ProblemCategory = "Battle" | "Challenge";
 export type ProblemStatus = "ready" | "draft" | "deprecated";
 
 /**
+ * ADR-012 Phase 4 portal predict: 問題 metadata で宣言された phase / disruption の予告 entry。
+ * 競技者向けに「いつ何が起きるか」を見せるためだけの shape (= effect の中身 / score 値は隠す)。
+ */
+export interface ProblemPhaseEntry {
+  readonly name: string;
+  readonly afterMinutes: number;
+  readonly description?: string;
+}
+
+export interface ProblemDisruptionEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly defaultAfterMinutes?: number;
+  readonly description?: string;
+}
+
+/**
  * Portal で表示する問題メタ情報。`cfnTemplate` / `cfnParameters` 等の deploy 内部情報は
  * 含めない (= 答えのヒントを意図せず露出させないため)。
  */
@@ -28,6 +45,10 @@ export interface ProblemCatalogEntry {
   readonly description: string;
   readonly learningGoals: readonly string[];
   readonly tags: readonly string[];
+  /** ADR-012 Phase 4: 段階制の予告 (= afterMinutes で portal が countdown / status pill 表示)。 */
+  readonly phases: readonly ProblemPhaseEntry[];
+  /** ADR-012 Phase 4: 「妨害」予告 (= template.yaml-bundled self-triggered Scheduler)。 */
+  readonly disruptions: readonly ProblemDisruptionEntry[];
 }
 
 interface ProblemMetadata {
@@ -45,6 +66,21 @@ interface ProblemMetadata {
   exposedPorts?: { port: number; name: string }[];
   cfnTemplate?: string;
   cfnParameters?: Record<string, string>;
+  phases?: {
+    name: string;
+    afterMinutes: number;
+    effect?: Record<string, unknown>;
+    description?: string;
+  }[];
+  disruptions?: {
+    id: string;
+    name: string;
+    defaultAfterMinutes?: number;
+    operatorEditable?: string[];
+    parameters?: Record<string, unknown>;
+    eventDetailType?: string;
+    description?: string;
+  }[];
 }
 
 const metadataModules = import.meta.glob<{ default: ProblemMetadata }>(
@@ -64,6 +100,24 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
     description: metadata.description,
     learningGoals: metadata.learningGoals,
     tags: metadata.tags,
+    // 競技者向けには effect の中身 (= switchPlatformToDegraded / scorePathOverride 等の
+    // 採点 internals) は隠して、 name / afterMinutes / description だけ露出する。
+    phases:
+      metadata.phases?.map((p) => ({
+        name: p.name,
+        afterMinutes: p.afterMinutes,
+        ...(p.description ? { description: p.description } : {}),
+      })) ?? [],
+    // 同じく eventDetailType / parameters / operatorEditable 等の operator 向け internals は隠す。
+    disruptions:
+      metadata.disruptions?.map((d) => ({
+        id: d.id,
+        name: d.name,
+        ...(typeof d.defaultAfterMinutes === "number"
+          ? { defaultAfterMinutes: d.defaultAfterMinutes }
+          : {}),
+        ...(d.description ? { description: d.description } : {}),
+      })) ?? [],
   };
 }
 

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -72,6 +72,10 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       {/* #550: 競技者向けに problem の narrative を 1 section にまとめる。
        *   metadata 不在 (= 旧 problem 等) は section ごと skip。 */}
       {problem && metadata && <ProblemInfoSection metadata={metadata} />}
+      {/* ADR-012 Phase 4: phases / disruptions を予告 panel として表示。 両方とも空なら skip。 */}
+      {problem && metadata && (metadata.phases.length > 0 || metadata.disruptions.length > 0) && (
+        <TimelinePredictSection metadata={metadata} />
+      )}
 
       {problem && (
         <ProblemPanel
@@ -156,5 +160,62 @@ function InfoCell({ label, children }: { label: string; children: React.ReactNod
       <Box variant="awsui-key-label">{label}</Box>
       <div>{children}</div>
     </div>
+  );
+}
+
+/**
+ * ADR-012 Phase 4 portal predict: phases[] と disruptions[] を「いつ何が起きるか」 panel に
+ * 並べて表示する。 deploy 時刻 (= 自チーム deploy の startedAt) は portal API に未露出 (Phase 4
+ * scope 外) なので、 "deploy 後 N 分" の relative 表示に留める。 deploy 時刻が露出されたら
+ * countdown / 経過判定を後付けする (= 同じ data shape を使う前提)。
+ */
+function TimelinePredictSection({ metadata }: { metadata: ProblemCatalogEntry }) {
+  const phases = metadata.phases;
+  const disruptions = metadata.disruptions;
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description="このあと自動で発火するフェーズ / 妨害イベント。 各イベントの発火タイミングは metadata.json の宣言値で、 operator が deploy 時に上書きしている場合は実際の発火時刻と差が出ます。"
+        >
+          タイムライン (予告)
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {phases.length > 0 && (
+          <div>
+            <Box variant="awsui-key-label">フェーズ</Box>
+            <ul>
+              {phases.map((p) => (
+                <li key={p.name}>
+                  <Badge color="blue">+{p.afterMinutes} 分</Badge> <strong>{p.name}</strong>
+                  {p.description && <Box variant="p">{p.description}</Box>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {disruptions.length > 0 && (
+          <div>
+            <Box variant="awsui-key-label">妨害イベント</Box>
+            <ul>
+              {disruptions.map((d) => (
+                <li key={d.id}>
+                  {typeof d.defaultAfterMinutes === "number" && (
+                    <>
+                      <Badge color="red">+{d.defaultAfterMinutes} 分</Badge>{" "}
+                    </>
+                  )}
+                  <strong>{d.name}</strong>
+                  {d.description && <Box variant="p">{d.description}</Box>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </SpaceBetween>
+    </Container>
   );
 }

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -536,6 +536,10 @@
           "eventDetailType": {
             "type": "string",
             "description": "EventBridge event の detail-type 値。 platform からの動的 trigger (Phase 2 = self-fire Scheduler) で参照される予定。"
+          },
+          "description": {
+            "type": "string",
+            "description": "disruption の動作 / 戦術的影響を participant 向けに説明する文章。 portal の予告 panel で countdown と一緒に表示される (= player への hint)。"
           }
         }
       }

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -76,6 +76,17 @@
       "description": "Legacy code path フェーズ。 各サービスに仕込まれた遅延 code path を取り除く必要が出る。"
     }
   ],
+  "disruptions": [
+    {
+      "id": "ec2-latency-injection",
+      "name": "EC2 ネットワーク遅延注入",
+      "eventDetailType": "DegradedDisruptionFired",
+      "defaultAfterMinutes": 60,
+      "operatorEditable": ["afterMinutes"],
+      "parameters": { "delayMs": 200, "device": "eth0" },
+      "description": "deploy 後 60 分 (default) の self-triggered Scheduler が EC2 の eth0 に `tc qdisc add ... netem delay 200ms` を注入する。 phases[0]=degraded と同時刻で発火し、 score engine 側の degradedPoints 切替と組み合わさって accumulated latency による減点が始まる。 operator は deploy 時に afterMinutes を上書き可能 (CFn parameter `DegradedAfterMinutes`)。"
+    }
+  ],
   "dashboard": {
     "slots": {
       "RegistrationPanel": "portal/RegistrationPanel.tsx",

--- a/problems/battles/microservice-migration-battle/template.yaml
+++ b/problems/battles/microservice-migration-battle/template.yaml
@@ -48,6 +48,17 @@ Parameters:
     Type: String
     Default: main
     Description: チェックアウトする branch / tag / commit。
+  DegradedAfterMinutes:
+    Type: Number
+    Default: 60
+    MinValue: 1
+    MaxValue: 720
+    Description: >
+      [ADR-012 Phase 4 Disruption] deploy 後 N 分経過時点で EC2 上に `tc qdisc` の
+      network latency (200ms) を注入する self-triggered Scheduler の発火タイミング。
+      metadata.json の `phases[0].afterMinutes` と整合させる前提 (= 同じタイミングで
+      score engine が ec2 platform points を degradedPoints へ切替)。
+      operator が deploy 時に上書き可能。
 
 Resources:
   # ----- VPC + Networking -----
@@ -193,6 +204,107 @@ Resources:
           ENVEOF
 
           docker compose up -d --build
+
+  # ----- Disruption pattern (ADR-012 Phase 4) -----
+  # phases[0] (degraded) と整合する self-triggered Scheduler。 deploy 後
+  # DegradedAfterMinutes 経過時点で SSM RunCommand を発行し、 EC2 の eth0 に
+  # `tc qdisc` で 200ms の network latency を注入する。 同じタイミングで platform
+  # 側の score engine が ec2 points を degradedPoints (= 10) に切り替える (= 別 path
+  # で metadata.phases から駆動)。 portal は metadata.disruptions[] から countdown を
+  # 表示する (= predict)。
+  #
+  # 設計選択: `rate(N minutes)` を Scheduler に渡すと、 deploy 後 N 分後の最初の発火 +
+  # 以降 N 分毎にも発火する。 tc qdisc add は EEXIST で fail するので 2 回目以降は
+  # no-op (= idempotent)。 正確に 1 回だけ発火させたい場合は CustomResource で deploy
+  # 時刻 + offset の `at()` 式を組み立てる必要があるが、 Phase 1 reference impl では
+  # 簡潔さを優先して rate() + idempotent Lambda で実装する。
+  DisruptionFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-disruption-fn-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: SendCommandToOwnInstance
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ssm:SendCommand
+                Resource:
+                  - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${Ec2}"
+                  - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
+
+  DegradedDisruptionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${NamePrefix}-degraded-disruption"
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt DisruptionFunctionRole.Arn
+      Timeout: 30
+      Environment:
+        Variables:
+          INSTANCE_ID: !Ref Ec2
+      Code:
+        ZipFile: |
+          import os
+          import boto3
+
+          # phases[0]=degraded fire 時点で EC2 に network latency を注入する。
+          # `tc qdisc add` は 2 回目以降 EEXIST で fail するので `|| true` で握り潰す。
+          # Scheduler が rate(N min) で N 分毎に再発火するが、 1 回目以降は no-op。
+          def handler(event, context):
+              ssm = boto3.client("ssm")
+              ssm.send_command(
+                  InstanceIds=[os.environ["INSTANCE_ID"]],
+                  DocumentName="AWS-RunShellScript",
+                  Comment="TenkaCloud microservice-migration: phases[0] degraded fire",
+                  Parameters={
+                      "commands": [
+                          "tc qdisc add dev eth0 root netem delay 200ms || true",
+                      ],
+                  },
+              )
+              return {"ok": True}
+
+  SchedulerInvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${NamePrefix}-scheduler-invoke-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: scheduler.amazonaws.com }
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeDisruptionFunction
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt DegradedDisruptionFunction.Arn
+
+  DegradedDisruptionSchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Name: !Sub "${NamePrefix}-degraded-disruption"
+      Description: >
+        TenkaCloud microservice-migration-battle phases[0]=degraded の disruption schedule。
+        deploy 後 DegradedAfterMinutes 経過時点で EC2 上に network latency を注入する。
+      FlexibleTimeWindow: { Mode: "OFF" }
+      ScheduleExpression: !Sub "rate(${DegradedAfterMinutes} minutes)"
+      Target:
+        Arn: !GetAtt DegradedDisruptionFunction.Arn
+        RoleArn: !GetAtt SchedulerInvokeRole.Arn
 
 Outputs:
   BaseUrl:


### PR DESCRIPTION
## Summary

- microservice-migration-battle/template.yaml に self-triggered Scheduler + Disruption Lambda の reference 実装を bake。 deploy 後 \`DegradedAfterMinutes\` (= default 60 min) 経過で EC2 上に \`tc qdisc add ... netem delay 200ms\` を SSM RunCommand で注入。
- metadata.json に \`disruptions[]\` field を追加 (= portal 予告 + Phase 2 future-facing)。
- participant-portal: 「タイムライン (予告)」 panel を追加。 phases / disruptions の予告を badge (+N 分) + name + description で表示。
- \`findProblemMetadata\` 戻り値に \`phases\` / \`disruptions\` を追加。 operator 内部 field は portal 側で隠す。

## security-battle-royale audit

platform Lambda (\`infrastructure/lib/problem-deploy/handlers/\`) を grep し、 問題 ID に対する logic 分岐 / hardcode は存在しない (= 唯一の参照は kind handler の docstring 内 "想定" 文)。 metadata は既に \`uptime-multi\` kind を使っており Phase 3.B の generic dispatcher で動作。 \`attack-detection\` への migrate は不要 (= 攻撃検知は human-driven)。

## Test plan

- [x] \`make before-commit\` green (lint / typecheck / 全 SPA + infrastructure テスト / validate-problems)
- [x] portal で \`findProblemMetadata("microservice-migration-battle")\` が phases 2 件 + disruptions 1 件を返す test を追加
- [x] portal が operator internal field (\`effect\` / \`eventDetailType\` / \`operatorEditable\`) を露出しない test を追加
- [x] \`disruptions[]\` を持たない問題は \`disruptions: []\` を返す test を追加

## 物理影響

- problems/battles/microservice-migration-battle/template.yaml: CREATE 5 リソース (DisruptionFunctionRole / DegradedDisruptionFunction / SchedulerInvokeRole / DegradedDisruptionSchedule + parameter \`DegradedAfterMinutes\`)
- problems/SCHEMA.json: \`disruptions[].description\` 追加 (= optional、 既存 metadata 影響なし)
- 既存 score / phase 挙動は unchanged

## Regression 分析

- \`disruptions[]\` を持たない既存 3 問題は \`?? []\` default で空配列、 TimelinePredictSection skip
- 新 Scheduler は idempotent (\`tc qdisc add ... || true\`) で rate(60 min) 再発火しても問題なし

Closes #612
Relates #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Timeline Preview" section displaying phases and disruptions for selected problems
  * Disruption events now display timing information with scheduled delays in minutes
  * Added EC2 latency injection disruption to microservice-migration-battle problem (60-minute default delay)
  * Disruptions now support optional descriptions for enhanced participant context

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/623)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->