### PR TITLE
feat(#607): Phase countdown timeline + backend createdAt 露出

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -52,6 +52,10 @@ export interface ParticipantProblemView {
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  /** Issue #607: deploy 開始時刻 (DDB.createdAt の echo)。 portal の phase countdown が
+   *  metadata.phases / disruptions の afterMinutes との差で残時間を計算する。 deploy 中の
+   *  PENDING / IN_PROGRESS でも present。 */
+  readonly createdAt?: string;
   /** ADR-005 Phase 3.1: Battle (uptime) のみ aggregate health を露出。 */
   readonly applicationStatus?: ApplicationStatus;
 }

--- a/apps/participant-portal/src/components/PhaseCountdown.test.tsx
+++ b/apps/participant-portal/src/components/PhaseCountdown.test.tsx
@@ -1,0 +1,118 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PhaseCountdown, type PhaseCountdownEntry } from "./PhaseCountdown";
+
+/**
+ * Issue #607 PhaseCountdown: deployedAt + afterMinutes から live remaining time を表示する。
+ * fake timers で時刻を進めて 3 つの境界 (future / soon / past) を観測する。
+ */
+
+describe("PhaseCountdown (Issue #607)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 2026-05-13T10:00:00Z を "現在時刻" として固定
+    vi.setSystemTime(new Date("2026-05-13T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const baseEntry: PhaseCountdownEntry = {
+    id: "phase-degraded",
+    name: "degraded",
+    afterMinutes: 60,
+    variant: "phase",
+  };
+
+  it("entries が空なら何も render しないべき", () => {
+    const { container } = render(<PhaseCountdown entries={[]} deployedAt="2026-05-13T10:00:00Z" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("deployedAt が無い (= deploy 中) なら『deploy 時刻未確定』 表示にすべき", () => {
+    render(<PhaseCountdown entries={[baseEntry]} />);
+    expect(screen.getByText(/deploy 時刻未確定/)).toBeInTheDocument();
+    // +60 分 badge は静的に出る
+    expect(screen.getByText("+60 分")).toBeInTheDocument();
+  });
+
+  // 注: getByText は要素境界で分割されたテキストを match できないため、 残時間表示は
+  // container.textContent に対する正規表現で確認する。
+  it("deploy 直後 (= 残 60 分) は future 状態で残時間を表示すべき", () => {
+    const { container } = render(
+      <PhaseCountdown
+        entries={[baseEntry]}
+        deployedAt="2026-05-13T10:00:00.000Z" // 現在時刻と同じ → 残 60 分
+      />,
+    );
+    // 60 分は formatter で「1:00:00」 (= H:MM:SS) になる
+    expect(container.textContent).toMatch(/あと 1:00:00/);
+  });
+
+  it("setInterval で 1 秒後に残時間が減るべき", () => {
+    const { container } = render(
+      <PhaseCountdown
+        entries={[baseEntry]}
+        deployedAt="2026-05-13T10:00:00.000Z" // 残 60 分
+      />,
+    );
+    expect(container.textContent).toMatch(/あと 1:00:00/);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // 残 1 時間未満になったため H 部は省略され `あと 59:59` 形式
+    expect(container.textContent).toMatch(/あと 59:59/);
+  });
+
+  it("残 3 分以内は 'soon' 強調 (warn 色) にすべき", () => {
+    // 57 分前 deploy → 残 3 分丁度。 内部判定が <= 180_000 ms なので soon。
+    const { container } = render(
+      <PhaseCountdown
+        entries={[baseEntry]}
+        deployedAt="2026-05-13T09:03:00.000Z" // 57 分前 → 残 3 分
+      />,
+    );
+    expect(container.textContent).toMatch(/あと 3:00/);
+  });
+
+  it("残時間 0 以下は '発火済' badge にすべき", () => {
+    // 61 分前 deploy → 残 -1 分 (= 既に発火済)
+    const { container } = render(
+      <PhaseCountdown
+        entries={[baseEntry]}
+        deployedAt="2026-05-13T08:59:00.000Z" // 61 分前
+      />,
+    );
+    expect(container.textContent).toContain("発火済");
+  });
+
+  it("disruption variant は発火済時に '発火済' badge を表示すべき", () => {
+    const disruption: PhaseCountdownEntry = {
+      id: "d1",
+      name: "EC2 latency",
+      afterMinutes: 60,
+      variant: "disruption",
+    };
+    // 61 分前 → past
+    const { container } = render(
+      <PhaseCountdown entries={[disruption]} deployedAt="2026-05-13T08:59:00.000Z" />,
+    );
+    expect(container.textContent).toContain("発火済");
+  });
+
+  it("description は <p> として描画すべき", () => {
+    render(
+      <PhaseCountdown
+        entries={[{ ...baseEntry, description: "EC2 latency injection の説明" }]}
+        deployedAt="2026-05-13T10:00:00.000Z"
+      />,
+    );
+    expect(screen.getByText("EC2 latency injection の説明")).toBeInTheDocument();
+  });
+
+  it("malformed deployedAt は『deploy 時刻未確定』 fallback にすべき", () => {
+    render(<PhaseCountdown entries={[baseEntry]} deployedAt="not-an-iso-date" />);
+    expect(screen.getByText(/deploy 時刻未確定/)).toBeInTheDocument();
+  });
+});

--- a/apps/participant-portal/src/components/PhaseCountdown.tsx
+++ b/apps/participant-portal/src/components/PhaseCountdown.tsx
@@ -1,0 +1,110 @@
+/**
+ * Issue #607 Phase 3 / ADR-012 Phase 4 portal predict: phase / disruption の発火時刻までの
+ * 残時間を live countdown で表示する。
+ *
+ * 入力: `deployedAt` (= deployment.createdAt の ISO 8601) + `entries[]` (= name + afterMinutes
+ * + description)。 `Date.now()` との差で残分秒を計算し、 1 秒間隔で再 render。 deployedAt が
+ * 不在 (= 旧 deployment 互換 / PENDING で未確定) なら static な「+N 分」 表示に degrade する。
+ *
+ * 設計判断:
+ *   - polling 不要 (= 完全 client-side)。 server 側時刻と clock skew があり得るが phase 切替は
+ *     scoring engine 側 (= server) で発火するため、 portal の countdown は表示用 hint のみ。
+ *   - 残時間 < 0 (= 既に発火済) は "発火済" badge。
+ *   - 残時間 < 3 分 (= 180 秒) は "もうすぐ" の warn badge で強調 (= toast の代わり)。
+ *   - cleanup: unmount 時 setInterval を clear。
+ *
+ * Issue #607 toast 通知 (= phase 切替 3 分前から事前告知) は本 component の「もうすぐ」
+ * inline strong 表示で代用 (= Cloudscape Flashbar を別途配置するよりシンプル + 状態 1 source)。
+ */
+
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import { useEffect, useState } from "react";
+
+export interface PhaseCountdownEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly afterMinutes: number;
+  readonly description?: string;
+  /** Badge 色を切替えるための分類。 phase = blue、 disruption = red。 */
+  readonly variant: "phase" | "disruption";
+}
+
+interface PhaseCountdownProps {
+  readonly deployedAt?: string;
+  readonly entries: readonly PhaseCountdownEntry[];
+}
+
+/** `deployedAt` + `afterMinutes` から発火 epoch (ms) を計算。 deployedAt 不在なら undefined。 */
+function computeFireMs(deployedAt: string | undefined, afterMinutes: number): number | undefined {
+  if (!deployedAt) return undefined;
+  const deployedMs = Date.parse(deployedAt);
+  if (!Number.isFinite(deployedMs)) return undefined;
+  return deployedMs + afterMinutes * 60_000;
+}
+
+/** ms 単位の残時間を `M:SS` / `H:MM:SS` 表示にする。 負値は "発火済"。 */
+function formatRemaining(remainingMs: number): {
+  label: string;
+  status: "future" | "soon" | "past";
+} {
+  if (remainingMs <= 0) return { label: "発火済", status: "past" };
+  const totalSec = Math.ceil(remainingMs / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const seconds = totalSec % 60;
+  const label =
+    hours > 0
+      ? `あと ${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+      : `あと ${minutes}:${String(seconds).padStart(2, "0")}`;
+  // 3 分以内は "soon" 強調 (= Issue #607 の 「3 分前事前告知」)。
+  return { label, status: remainingMs <= 180_000 ? "soon" : "future" };
+}
+
+export function PhaseCountdown({ deployedAt, entries }: PhaseCountdownProps) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    // 1 秒間隔で時刻を進める (= 完全 client-side、 polling 不要)。 unmount で clear。
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+      {entries.map((entry) => {
+        const fireMs = computeFireMs(deployedAt, entry.afterMinutes);
+        const remainingMs = fireMs !== undefined ? fireMs - nowMs : undefined;
+        const formatted = remainingMs !== undefined ? formatRemaining(remainingMs) : undefined;
+        const badgeColor: "blue" | "red" | "grey" =
+          formatted?.status === "past" ? "grey" : entry.variant === "disruption" ? "red" : "blue";
+        return (
+          <li key={entry.id}>
+            <Badge color={badgeColor}>+{entry.afterMinutes} 分</Badge> <strong>{entry.name}</strong>{" "}
+            {formatted && (
+              <Box
+                variant="span"
+                color={
+                  formatted.status === "soon"
+                    ? "text-status-warning"
+                    : formatted.status === "past"
+                      ? "text-status-inactive"
+                      : "text-status-info"
+                }
+              >
+                ({formatted.label})
+              </Box>
+            )}
+            {!formatted && (
+              <Box variant="span" color="text-status-inactive">
+                (deploy 時刻未確定)
+              </Box>
+            )}
+            {entry.description && <Box variant="p">{entry.description}</Box>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -9,6 +9,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
+import { PhaseCountdown, type PhaseCountdownEntry } from "../components/PhaseCountdown";
 import { ProblemPanel } from "../components/ProblemPanel";
 import type { AppConfig } from "../config";
 import { findProblemMetadata, type ProblemCatalogEntry } from "../data/problems";
@@ -73,9 +74,11 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       {/* #550: 競技者向けに problem の narrative を 1 section にまとめる。
        *   metadata 不在 (= 旧 problem 等) は section ごと skip。 */}
       {problem && metadata && <ProblemInfoSection metadata={metadata} />}
-      {/* ADR-012 Phase 4: phases / disruptions を予告 panel として表示。 両方とも空なら skip。 */}
+      {/* ADR-012 Phase 4 / Issue #607: phases / disruptions を予告 panel + countdown timeline で表示。
+       *   両方とも空なら skip。 deployedAt が API から取れたら live countdown、 取れなければ
+       *   static な「+N 分」 表示に degrade。 */}
       {problem && metadata && (metadata.phases.length > 0 || metadata.disruptions.length > 0) && (
-        <TimelinePredictSection metadata={metadata} />
+        <TimelinePredictSection metadata={metadata} deployedAt={problem.createdAt} />
       )}
 
       {problem && (
@@ -177,55 +180,55 @@ function InfoCell({ label, children }: { label: string; children: React.ReactNod
 }
 
 /**
- * ADR-012 Phase 4 portal predict: phases[] と disruptions[] を「いつ何が起きるか」 panel に
- * 並べて表示する。 deploy 時刻 (= 自チーム deploy の startedAt) は portal API に未露出 (Phase 4
- * scope 外) なので、 "deploy 後 N 分" の relative 表示に留める。 deploy 時刻が露出されたら
- * countdown / 経過判定を後付けする (= 同じ data shape を使う前提)。
+ * ADR-012 Phase 4 + Issue #607: phases[] と disruptions[] を「いつ何が起きるか」 + live countdown
+ * で表示。 deployedAt (= problem.createdAt) があれば 1 秒間隔の残時間表示、 無ければ
+ * static「+N 分」 表示に degrade。 残時間 < 3 分は warn 強調 (= 事前告知)。
  */
-function TimelinePredictSection({ metadata }: { metadata: ProblemCatalogEntry }) {
+function TimelinePredictSection({
+  metadata,
+  deployedAt,
+}: {
+  metadata: ProblemCatalogEntry;
+  deployedAt?: string;
+}) {
   const phases = metadata.phases;
   const disruptions = metadata.disruptions;
+  const phaseEntries: PhaseCountdownEntry[] = phases.map((p) => ({
+    id: `phase-${p.name}`,
+    name: p.name,
+    afterMinutes: p.afterMinutes,
+    ...(p.description ? { description: p.description } : {}),
+    variant: "phase",
+  }));
+  const disruptionEntries: PhaseCountdownEntry[] = disruptions.map((d) => ({
+    id: `disruption-${d.id}`,
+    name: d.name,
+    afterMinutes: d.defaultAfterMinutes ?? 0,
+    ...(d.description ? { description: d.description } : {}),
+    variant: "disruption",
+  }));
   return (
     <Container
       header={
         <Header
           variant="h2"
-          description="このあと自動で発火するフェーズ / 妨害イベント。 各イベントの発火タイミングは metadata.json の宣言値で、 operator が deploy 時に上書きしている場合は実際の発火時刻と差が出ます。"
+          description="このあと自動で発火するフェーズ / 妨害イベント。 残 3 分以内のイベントは warn 強調で予告します。 各イベントの発火タイミングは metadata.json の宣言値で、 operator が deploy 時に上書きしている場合は実際の発火時刻と差が出ます。"
         >
           タイムライン (予告)
         </Header>
       }
     >
       <SpaceBetween size="m">
-        {phases.length > 0 && (
+        {phaseEntries.length > 0 && (
           <div>
             <Box variant="awsui-key-label">フェーズ</Box>
-            <ul>
-              {phases.map((p) => (
-                <li key={p.name}>
-                  <Badge color="blue">+{p.afterMinutes} 分</Badge> <strong>{p.name}</strong>
-                  {p.description && <Box variant="p">{p.description}</Box>}
-                </li>
-              ))}
-            </ul>
+            <PhaseCountdown entries={phaseEntries} {...(deployedAt ? { deployedAt } : {})} />
           </div>
         )}
-        {disruptions.length > 0 && (
+        {disruptionEntries.length > 0 && (
           <div>
             <Box variant="awsui-key-label">妨害イベント</Box>
-            <ul>
-              {disruptions.map((d) => (
-                <li key={d.id}>
-                  {typeof d.defaultAfterMinutes === "number" && (
-                    <>
-                      <Badge color="red">+{d.defaultAfterMinutes} 分</Badge>{" "}
-                    </>
-                  )}
-                  <strong>{d.name}</strong>
-                  {d.description && <Box variant="p">{d.description}</Box>}
-                </li>
-              ))}
-            </ul>
+            <PhaseCountdown entries={disruptionEntries} {...(deployedAt ? { deployedAt } : {})} />
           </div>
         )}
       </SpaceBetween>

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -67,6 +67,10 @@ export type ParticipantProblemView = Pick<
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  /** ADR-012 Phase 4 / Issue #607: deploy 開始時刻 (= DDB.createdAt の echo)。 portal の phase
+   *  countdown timeline (= metadata.phases[].afterMinutes の経過判定) に使う。 deploy 中の
+   *  PENDING / IN_PROGRESS でも present (= job 生成時刻)。 */
+  readonly createdAt?: string;
   /**
    * Battle (uptime kind) の集約 health。per-endpoint の URL / 名前は **絶対に出さない**
    * (ADR-005 D1)。Challenge 形式 (flag kind) では undefined。
@@ -126,6 +130,9 @@ export function toProblemView(
     lastScoredAt: typeof item.lastScoredAt === "string" ? item.lastScoredAt : undefined,
     lastResult: item.lastResult,
     scoring: scoring ? toScoringInfo(scoring, item) : undefined,
+    // Issue #607: deploy 開始時刻 (DDB.createdAt) を echo。 portal の phase countdown が
+    // metadata.phases[].afterMinutes との差で「+N 分まであと M 分」を計算する。
+    createdAt: typeof item.createdAt === "string" ? item.createdAt : undefined,
     // 全 uptime 系 (= legacy uptime + uptime-flat + uptime-multi + phased-polling) で
     // endpointsHealth aggregate を出す (ADR-005 D1: per-endpoint URL は隠す)。
     // attack-detection / flag では undefined (= probe しない kind)。

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -91,6 +91,14 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.team.teamNameSetByCompetitor).toBe(true);
   });
 
+  // Issue #607: createdAt を portal API に露出 (= phase countdown timeline で使う)。
+  it("Issue #607: problem.createdAt を ParticipantProblemView に echo するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.createdAt).toBe("2026-05-04T15:00:00.000Z");
+  });
+
   it("Phase 2a 経由の eventId / teamId 列が team に伝播するべき", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Issue #607 Phase 3 残スコープのうち **phase / disruption countdown timeline** を ship。 deployment.createdAt を ParticipantProblemView に echo、 portal で 1 秒間隔の live countdown を表示する PhaseCountdown component を追加。 残 3 分以内は warn 強調 (= toast の代わり)。

## Backend

- \`lookup.ts ParticipantProblemView\` に \`createdAt?: string\` 追加 (DDB.createdAt の echo)
- \`toProblemView\` で passthrough

## Frontend

- \`portal-client.ts ParticipantProblemView\` 型同期
- \`components/PhaseCountdown.tsx\`: 1 sec setInterval で nowMs 更新、 「あと M:SS」 / 「あと H:MM:SS」 表示。 残 ≤ 180s で warn 色、 ≤ 0 で grey 「発火済」、 deployedAt 不在は 「deploy 時刻未確定」 fallback
- \`pages/ProblemDetail.tsx\` TimelinePredictSection: static badge を PhaseCountdown に差替え

## Issue #607 完了候補

Toast 通知 (= 3 分前事前告知) は本 component の 「soon (warn 色)」 表示で代用 (= 状態 1 source + countdown と一体)。 Phase 3 frontend 残作業はこの PR で完了。

## Test plan

- [x] \`make before-commit\` green
- [x] PhaseCountdown 9 cases (empty / no-deployedAt / future / setInterval 進行 / soon 境界 / past / disruption variant past / description / malformed deployedAt)
- [x] participant-lookup test 1 件追加 (createdAt echo pin)
- [x] 全 portal 102 tests + 全 infra tests 維持

## 物理影響

- 新 file 2 件 (PhaseCountdown + test)
- 変更 file 3 件 (lookup.ts / portal-client.ts / ProblemDetail.tsx)
- 既存挙動への影響なし (= phases / disruptions 宣言なし問題は section が render されない)

## Regression 分析

- \`createdAt\` optional 追加で旧 deployment 互換維持
- 1 sec setInterval は unmount で clearInterval (= leak なし)
- countdown は polling 不要 (= 既存 5s polling と独立)

Closes #607
Relates #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)