### PR TITLE
feat(#574): ADR-008 Phase 1 — visibility field + portal badge

### DIFF
--- a/.claude/templates/problems/attack-detection/metadata.json
+++ b/.claude/templates/problems/attack-detection/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "攻撃検知 counter 差分で加点する attack-detection Battle skeleton。",

--- a/.claude/templates/problems/flag/metadata.json
+++ b/.claude/templates/problems/flag/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Challenge",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 2,
   "estimatedDuration": "30〜45 分",
   "shortDescription": "1 行サマリ (~200 字) — どんな問題か。",

--- a/.claude/templates/problems/phased-polling/metadata.json
+++ b/.claude/templates/problems/phased-polling/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "90〜120 分",
   "shortDescription": "時間経過で rule が変わる phased-polling 採点の Battle skeleton。",

--- a/.claude/templates/problems/uptime-flat/metadata.json
+++ b/.claude/templates/problems/uptime-flat/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "1 endpoint を稼働させ続けて defense する Battle 問題の skeleton (uptime-flat 採点)。",

--- a/.claude/templates/problems/uptime-multi/metadata.json
+++ b/.claude/templates/problems/uptime-multi/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "N slot を全部生存させ続ける uptime-multi 採点の Battle skeleton。",

--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -84,4 +84,17 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   it("endpoints[] が無い問題は空配列を返すべき", () => {
     expect(findProblemMetadata("hello-world")?.endpoints).toEqual([]);
   });
+
+  // ADR-008 / Issue #574 Phase 1: visibility field を catalog に露出する。
+  it("既存 4 問題はすべて visibility='public' で露出されるべき", () => {
+    for (const id of [
+      "hello-world",
+      "hello-world-battle",
+      "security-battle-royale",
+      "microservice-migration-battle",
+    ]) {
+      const m = findProblemMetadata(id);
+      expect(m?.visibility).toBe("public");
+    }
+  });
 });

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -12,6 +12,10 @@
 
 export type ProblemCategory = "Battle" | "Challenge";
 export type ProblemStatus = "ready" | "draft" | "deprecated";
+/** ADR-008 / Issue #574: 問題実装の公開境界。 public = 本体 repo に payload を持つ教材問題、
+ *  private = TenkaCloudChallenges 別 repo に payload を持ち S3 presigned URL で配信される
+ *  本格競技問題。 metadata に省略時は public 扱い (= 既存 metadata との互換)。 */
+export type ProblemVisibility = "public" | "private";
 
 /**
  * ADR-012 Phase 4 portal predict: 問題 metadata で宣言された phase / disruption の予告 entry。
@@ -63,6 +67,8 @@ export interface ProblemCatalogEntry {
   readonly name: string;
   readonly category: ProblemCategory;
   readonly status: ProblemStatus;
+  /** ADR-008 Phase 1 / Issue #574: 公開境界。 metadata 省略時は "public" を default に。 */
+  readonly visibility: ProblemVisibility;
   readonly difficulty: 1 | 2 | 3 | 4 | 5;
   readonly estimatedDuration: string;
   readonly shortDescription: string;
@@ -85,6 +91,7 @@ interface ProblemMetadata {
   name: string;
   category: ProblemCategory;
   status: ProblemStatus;
+  visibility?: ProblemVisibility;
   difficulty: 1 | 2 | 3 | 4 | 5;
   estimatedDuration: string;
   shortDescription: string;
@@ -148,6 +155,8 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
     name: metadata.name,
     category: metadata.category,
     status: metadata.status,
+    // metadata 省略時は public 扱い (= 既存問題互換 + ADR-008 D4 の "省略時 public" 規約)。
+    visibility: metadata.visibility ?? "public",
     difficulty: metadata.difficulty,
     estimatedDuration: metadata.estimatedDuration,
     shortDescription: metadata.shortDescription,

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -122,9 +122,13 @@ function ProblemInfoSection({ metadata }: { metadata: ProblemCatalogEntry }) {
       <SpaceBetween size="m">
         <ColumnLayout columns={4} variant="text-grid">
           <InfoCell label="カテゴリ">
-            <Badge color={metadata.category === "Battle" ? "red" : "blue"}>
-              {metadata.category}
-            </Badge>
+            <SpaceBetween direction="horizontal" size="xxs">
+              <Badge color={metadata.category === "Battle" ? "red" : "blue"}>
+                {metadata.category}
+              </Badge>
+              {/* ADR-008 Phase 1: private 問題には「答え非公開」 badge。 public は省略 (= ノイズ削減)。 */}
+              {metadata.visibility === "private" && <Badge color="severity-high">答え非公開</Badge>}
+            </SpaceBetween>
           </InfoCell>
           <InfoCell label="難易度">{DIFFICULTY_LABEL[metadata.difficulty]}</InfoCell>
           <InfoCell label="想定プレイ時間">{metadata.estimatedDuration}</InfoCell>

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -45,6 +45,11 @@
       "enum": ["ready", "draft", "deprecated"],
       "description": "公開ステータス。ready = 参加者向けデプロイ可能 / draft = 開発中 / deprecated = 廃止予定。"
     },
+    "visibility": {
+      "type": "string",
+      "enum": ["public", "private"],
+      "description": "[ADR-008] 問題実装の公開境界。 public = 本体 repo 内に template.yaml / api / frontend を持つ教材用 (= 答えが open でも成立する問題、 hello-world 系)。 private = TenkaCloudChallenges 別 private repo に payload を置き S3 + 15min presigned URL で配信する本格競技用 (= 答えが open だと成立しない microservice-migration-battle 系)。 省略時 public (= 既存 metadata との互換)。 Phase 1 では UI 表示のみ、 Phase 3 で Worker Lambda の S3 fetch 分岐を入れる。"
+    },
     "difficulty": {
       "type": "integer",
       "minimum": 1,

--- a/problems/battles/hello-world-battle/metadata.json
+++ b/problems/battles/hello-world-battle/metadata.json
@@ -4,6 +4,7 @@
   "name": "Hello World Battle (Sample)",
   "category": "Battle",
   "status": "ready",
+  "visibility": "public",
   "difficulty": 1,
   "estimatedDuration": "30 分",
   "shortDescription": "Battle uptime scoring の最小 sample。EC2 上で nginx (frontend) + Python (API) を起動し、両方が 200 を返す間スコアが 1 分ごとに +100 加算。",

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -4,6 +4,7 @@
   "name": "Microservice Migration Battle",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "90〜120 分",
   "shortDescription": "EC2 1 台に同居する 3 サービス (users / orders / catalog) を Lambda + API Gateway / ECS Fargate / App Runner の 3 種ホスティングに分割するレース。",

--- a/problems/battles/security-battle-royale/metadata.json
+++ b/problems/battles/security-battle-royale/metadata.json
@@ -4,6 +4,7 @@
   "name": "Security Battle Royale",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",

--- a/problems/challenges/hello-world/metadata.json
+++ b/problems/challenges/hello-world/metadata.json
@@ -4,6 +4,7 @@
   "name": "Hello World (Sample)",
   "category": "Challenge",
   "status": "ready",
+  "visibility": "public",
   "difficulty": 1,
   "estimatedDuration": "1 分",
   "shortDescription": "Challenge / flag 提出形式の最小 sample。SSM Parameter Store に書かれた値を当てて入力すると 100 点獲得。",


### PR DESCRIPTION
## Summary

Issue #574 / ADR-008 Phase 1 のうち Claude 担当部分を ship。 SCHEMA に \`visibility\` field を追加し、 既存 4 問題と 5 kind template skeleton 全てに \`visibility: \"public\"\` を明記、 portal で \`private\` 問題に「答え非公開」 Badge を表示。

Phase 2-5 (= S3 ChallengePayloadStack の CDK / Worker Lambda の S3 fetch / 別 private repo の bootstrap / microservice-migration-battle の private repo 移行) はインフラ / repo 作成を伴うため別 PR + user 担当。

## SCHEMA

- \`visibility\`: enum [\"public\", \"private\"]、 省略時 \"public\" (= 既存 metadata 互換)
- ADR-008 D5 の境界意図を description に明記

## Metadata 更新

- 既存 4 問題 + 5 kind template に \`\"visibility\": \"public\"\` を明示

## Portal

- \`ProblemCatalogEntry.visibility: ProblemVisibility\` を catalog に passthrough (\`?? \"public\"\`)
- ProblemDetail カテゴリ cell に「答え非公開」 Badge (= severity-high) を private のみ表示

## Test plan

- [x] \`make before-commit\` green
- [x] data/problems.test.ts に 「既存 4 問題はすべて visibility='public' で露出される」 pin

## 物理影響

- 変更 file: SCHEMA.json + 4 metadata.json + 5 template + portal data + ProblemDetail + test
- 既存 deploy / portal UI への影響なし (= field optional、 public default)

## Regression 分析

- visibility=public の 4 既存問題は従来と完全同等 (Badge 表示なし)
- 旧 metadata (visibility field なし) は default で public 扱いになり既存挙動互換

Relates #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)