### PR TITLE
feat(#583): i18n Phase 1.B + 1.C — admin-console / application-admin-console 基盤

### DIFF
--- a/apps/admin-console/src/components/AppLayout.tsx
+++ b/apps/admin-console/src/components/AppLayout.tsx
@@ -1,42 +1,68 @@
 import AppLayout from "@cloudscape-design/components/app-layout";
 import SideNavigation from "@cloudscape-design/components/side-navigation";
-import TopNavigation from "@cloudscape-design/components/top-navigation";
+import TopNavigation, {
+  type TopNavigationProps,
+} from "@cloudscape-design/components/top-navigation";
 import type { ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
+import { type LocaleCode, SUPPORTED_LOCALES, useI18n } from "../i18n";
+
+/** Issue #583 Phase 1.B: locale switcher の display 名 map (= 各 locale.json と同期)。 */
+const LOCALE_NAME: Record<LocaleCode, string> = {
+  ja: "日本語",
+  en: "English",
+  es: "Español",
+  zh: "中文",
+};
 
 export function ShellLayout({ children }: { children: ReactNode }) {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const { locale, setLocale, t } = useI18n();
+
+  const localeUtility: TopNavigationProps.Utility = {
+    type: "menu-dropdown",
+    iconName: "globe",
+    ariaLabel: "言語切替 / Language",
+    text: LOCALE_NAME[locale] ?? locale,
+    items: SUPPORTED_LOCALES.map((code) => ({ id: code, text: LOCALE_NAME[code] ?? code })),
+    onItemClick: ({ detail }) => {
+      if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
+        setLocale(detail.id as LocaleCode);
+      }
+    },
+  };
 
   return (
     <>
       <TopNavigation
-        identity={{ href: "/", title: "TenkaCloud Admin Console" }}
+        identity={{ href: "/", title: t("app.title") }}
         utilities={
           auth.tokens
             ? [
+                localeUtility,
                 {
                   type: "button",
-                  text: "サインアウト",
+                  text: t("auth.sign_out"),
                   onClick: () => {
                     auth.logout();
                     navigate("/login");
                   },
                 },
               ]
-            : []
+            : [localeUtility]
         }
       />
       <AppLayout
         navigation={
           <SideNavigation
             activeHref={location.pathname}
-            header={{ href: "/", text: "管理メニュー" }}
+            header={{ href: "/", text: t("nav.menu") }}
             items={[
-              { type: "link", href: "/tenants", text: "テナント一覧" },
-              { type: "link", href: "/tenants/new", text: "テナント作成" },
+              { type: "link", href: "/tenants", text: t("nav.tenants") },
+              { type: "link", href: "/tenants/new", text: t("nav.tenants_new") },
             ]}
             onFollow={(e) => {
               if (!e.detail.external) {

--- a/apps/admin-console/src/i18n/i18n.test.tsx
+++ b/apps/admin-console/src/i18n/i18n.test.tsx
@@ -1,0 +1,91 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _testInternals, I18nProvider, type LocaleCode, useI18n, useT } from "./index";
+
+/**
+ * Issue #583 i18n Phase 1.B: admin-console の自前 i18n の pin。
+ * dict lookup / fallback chain / localStorage persist / dictionary missing key の 4 path を検証。
+ */
+
+describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
+  beforeEach(() => {
+    if (typeof window !== "undefined") window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    if (typeof window !== "undefined") window.localStorage.clear();
+  });
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return <I18nProvider>{children}</I18nProvider>;
+  }
+
+  it("default locale は ja (navigator.language 未対応の test 環境 default)", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    expect(result.current.locale).toMatch(/^(ja|en|es|zh)$/);
+  });
+
+  it("setLocale が localStorage に永続化し次回起動で復元すべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("en"));
+    expect(result.current.locale).toBe("en");
+    // localStorage の値が保存されている
+    expect(window.localStorage.getItem("tenkacloud.admin.locale")).toBe("en");
+  });
+
+  it("t() は dot-separated key で nested dictionary を引くべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("ja"));
+    expect(result.current.t("app.title")).toBe("TenkaCloud 管理コンソール");
+    act(() => result.current.setLocale("en"));
+    expect(result.current.t("app.title")).toBe("TenkaCloud Admin Console");
+  });
+
+  it("locale で key 未定義なら en で fallback、 en にも無ければ raw key", () => {
+    const { result } = renderHook(() => useT(), { wrapper });
+    // 全 locale にあるキー → 翻訳成功
+    expect(result.current("nav.tenants")).toBeTruthy();
+    expect(result.current("nav.tenants")).not.toBe("nav.tenants");
+    // 全 locale に無い key → raw key 返し
+    expect(result.current("nonexistent.key")).toBe("nonexistent.key");
+  });
+
+  it("SUPPORTED_LOCALES = 4 言語 [ja, en, es, zh]", () => {
+    const supported: readonly LocaleCode[] = ["ja", "en", "es", "zh"];
+    for (const code of supported) {
+      const dict = _testInternals.LOCALE_DICTIONARIES[code];
+      expect(dict).toBeDefined();
+      // すべての locale が "locale.name" key を持つ (= UI switcher 表示用)
+      expect(_testInternals.resolveKey(dict, "locale.name")).toBeTruthy();
+    }
+  });
+
+  it("locale 変更時に <html lang> が追従すべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("zh"));
+    expect(document.documentElement.lang).toBe("zh");
+    act(() => result.current.setLocale("ja"));
+    expect(document.documentElement.lang).toBe("ja");
+  });
+
+  it("useI18n を Provider 外で呼ぶと throw すべき (= configuration error の早期発見)", () => {
+    // renderHook で wrapper を渡さないと throws する
+    expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
+  });
+
+  // 翻訳結果が UI に出ることを実 render で確認
+  it("Provider 配下で翻訳結果が UI に反映されるべき", () => {
+    function Probe() {
+      const t = useT();
+      return <div>{t("app.loading")}</div>;
+    }
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>,
+    );
+    // ja default で「読み込み中|Loading|Cargando|正在加载…」 が出る (navigator.language が ja/en どちらでも fallback で en に行く)
+    const el = screen.getByText(/(状態を取得中|Loading|Cargando|正在加载)…/);
+    expect(el).toBeInTheDocument();
+  });
+});

--- a/apps/admin-console/src/i18n/index.tsx
+++ b/apps/admin-console/src/i18n/index.tsx
@@ -1,0 +1,142 @@
+/**
+ * Issue #583 i18n Phase 1.A: participant-portal の i18n 基盤。
+ *
+ * 設計判断:
+ *   - **homegrown 実装** (= react-i18next 等の lib 非導入)。 4 言語 × ~30 keys 規模なら自前で
+ *     済む + supply-chain audit-baseline 更新が不要 + bundle size 増えない (= 50KB 削減)。
+ *     Phase 1.B で 3 SPA 全部に展開する時にライブラリ採択を再評価する。
+ *   - **navigator.language → localStorage** の 2 段検出: 起動時 navigator.language で auto-detect、
+ *     UI で切り替えたら localStorage に永続化、 次回起動はそれが優先。
+ *   - **fallback chain**: 指定 locale で key 不在 → en → key 文字列そのまま。 missing key を
+ *     見つけやすくする (= 「app.title」 のような raw key が出たら抽出忘れ)。
+ *   - **react context + hook**: Provider が現在 locale + setLocale を提供、 useT() hook で
+ *     翻訳関数を取り出す。 子 component は import なしで利用可。
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import en from "./locales/en.json";
+import es from "./locales/es.json";
+import ja from "./locales/ja.json";
+import zh from "./locales/zh.json";
+
+export const SUPPORTED_LOCALES = ["ja", "en", "es", "zh"] as const;
+export type LocaleCode = (typeof SUPPORTED_LOCALES)[number];
+
+const LOCALE_DICTIONARIES: Record<LocaleCode, Record<string, unknown>> = {
+  ja,
+  en,
+  es,
+  zh,
+};
+
+const LOCAL_STORAGE_KEY = "tenkacloud.admin.locale";
+
+/**
+ * `navigator.language` (= "en-US" / "ja-JP" 等) を SUPPORTED_LOCALES のいずれかに narrow。
+ * 一致なければ "ja" を default にする (= 既存 UI を維持)。
+ */
+function detectBrowserLocale(): LocaleCode {
+  if (typeof navigator === "undefined") return "ja";
+  const raw = (navigator.language || "ja").toLowerCase();
+  for (const code of SUPPORTED_LOCALES) {
+    if (raw.startsWith(code)) return code;
+  }
+  return "ja";
+}
+
+function loadStoredLocale(): LocaleCode | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
+      return stored as LocaleCode;
+    }
+  } catch {
+    // localStorage access denied (= incognito strict mode 等) → default fallback
+  }
+  return undefined;
+}
+
+function persistLocale(code: LocaleCode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * dot-separated key (e.g. "app.title") を nested object から取り出す。 未定義は undefined。
+ */
+function resolveKey(dict: Record<string, unknown>, key: string): string | undefined {
+  const parts = key.split(".");
+  let node: unknown = dict;
+  for (const p of parts) {
+    if (typeof node !== "object" || node === null) return undefined;
+    node = (node as Record<string, unknown>)[p];
+  }
+  return typeof node === "string" ? node : undefined;
+}
+
+interface I18nContextValue {
+  readonly locale: LocaleCode;
+  readonly setLocale: (code: LocaleCode) => void;
+  readonly t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<LocaleCode>(
+    () => loadStoredLocale() ?? detectBrowserLocale(),
+  );
+
+  // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const setLocale = useCallback((code: LocaleCode) => {
+    setLocaleState(code);
+    persistLocale(code);
+  }, []);
+
+  const t = useCallback(
+    (key: string): string => {
+      // 1) 指定 locale で lookup → 2) en で fallback → 3) raw key
+      const v = resolveKey(LOCALE_DICTIONARIES[locale], key);
+      if (v !== undefined) return v;
+      const fallback = resolveKey(LOCALE_DICTIONARIES.en, key);
+      return fallback ?? key;
+    },
+    [locale],
+  );
+
+  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error("useI18n must be called inside <I18nProvider>");
+  return ctx;
+}
+
+/** 翻訳関数だけが必要な hot path 用 shortcut。 */
+export function useT(): (key: string) => string {
+  return useI18n().t;
+}
+
+/** Tests / debug 用に dictionaries を露出。 portal 本体からは使わない。 */
+export const _testInternals = { LOCALE_DICTIONARIES, resolveKey, detectBrowserLocale };

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -1,0 +1,20 @@
+{
+  "locale": {
+    "name": "English"
+  },
+  "app": {
+    "title": "TenkaCloud Admin Console",
+    "loading": "Loading…"
+  },
+  "nav": {
+    "menu": "Admin menu",
+    "tenants": "Tenants",
+    "tenants_new": "Create tenant"
+  },
+  "auth": {
+    "sign_out": "Sign out"
+  },
+  "errors": {
+    "generic": "An error occurred"
+  }
+}

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -1,0 +1,20 @@
+{
+  "locale": {
+    "name": "Español"
+  },
+  "app": {
+    "title": "Consola de Administración TenkaCloud",
+    "loading": "Cargando…"
+  },
+  "nav": {
+    "menu": "Menú de administración",
+    "tenants": "Tenants",
+    "tenants_new": "Crear tenant"
+  },
+  "auth": {
+    "sign_out": "Cerrar sesión"
+  },
+  "errors": {
+    "generic": "Se produjo un error"
+  }
+}

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -1,0 +1,20 @@
+{
+  "locale": {
+    "name": "日本語"
+  },
+  "app": {
+    "title": "TenkaCloud 管理コンソール",
+    "loading": "読み込み中…"
+  },
+  "nav": {
+    "menu": "管理メニュー",
+    "tenants": "テナント一覧",
+    "tenants_new": "テナント作成"
+  },
+  "auth": {
+    "sign_out": "サインアウト"
+  },
+  "errors": {
+    "generic": "エラーが発生しました"
+  }
+}

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -1,0 +1,20 @@
+{
+  "locale": {
+    "name": "中文"
+  },
+  "app": {
+    "title": "TenkaCloud 管理控制台",
+    "loading": "正在加载…"
+  },
+  "nav": {
+    "menu": "管理菜单",
+    "tenants": "租户列表",
+    "tenants_new": "创建租户"
+  },
+  "auth": {
+    "sign_out": "退出登录"
+  },
+  "errors": {
+    "generic": "发生错误"
+  }
+}

--- a/apps/admin-console/src/main.tsx
+++ b/apps/admin-console/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { App } from "./App";
 import { loadConfig } from "./config";
+import { I18nProvider } from "./i18n";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root element missing from index.html");
@@ -11,9 +12,11 @@ loadConfig()
   .then((config) => {
     createRoot(root).render(
       <StrictMode>
-        <BrowserRouter>
-          <App config={config} />
-        </BrowserRouter>
+        <I18nProvider>
+          <BrowserRouter>
+            <App config={config} />
+          </BrowserRouter>
+        </I18nProvider>
       </StrictMode>,
     );
   })

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -1,10 +1,21 @@
 import AppLayout from "@cloudscape-design/components/app-layout";
 import SideNavigation from "@cloudscape-design/components/side-navigation";
-import TopNavigation from "@cloudscape-design/components/top-navigation";
+import TopNavigation, {
+  type TopNavigationProps,
+} from "@cloudscape-design/components/top-navigation";
 import type { ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+import { type LocaleCode, SUPPORTED_LOCALES, useI18n } from "../i18n";
+
+/** Issue #583 Phase 1.C: locale switcher display 名 map (= 各 locale.json と同期)。 */
+const LOCALE_NAME: Record<LocaleCode, string> = {
+  ja: "日本語",
+  en: "English",
+  es: "Español",
+  zh: "中文",
+};
 
 /**
  * application-admin-console の shell。TopNavigation はサインアウトのみ、
@@ -24,36 +35,51 @@ export function ShellLayout({
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+  const { locale, setLocale, t } = useI18n();
+
+  const localeUtility: TopNavigationProps.Utility = {
+    type: "menu-dropdown",
+    iconName: "globe",
+    ariaLabel: "言語切替 / Language",
+    text: LOCALE_NAME[locale] ?? locale,
+    items: SUPPORTED_LOCALES.map((code) => ({ id: code, text: LOCALE_NAME[code] ?? code })),
+    onItemClick: ({ detail }) => {
+      if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
+        setLocale(detail.id as LocaleCode);
+      }
+    },
+  };
 
   return (
     <>
       <TopNavigation
-        identity={{ href: "/", title: "TenkaCloud — Application Console" }}
+        identity={{ href: "/", title: t("app.title") }}
         utilities={
           auth.tokens
             ? [
+                localeUtility,
                 {
                   type: "button",
-                  text: "サインアウト",
+                  text: t("auth.sign_out"),
                   onClick: () => {
                     auth.logout();
                     navigate("/login");
                   },
                 },
               ]
-            : []
+            : [localeUtility]
         }
       />
       <AppLayout
         navigation={
           <SideNavigation
             activeHref={location.pathname}
-            header={{ href: "/", text: "メニュー" }}
+            header={{ href: "/", text: t("nav.menu") }}
             items={[
               { type: "link", href: "/", text: "ホーム" },
-              { type: "link", href: "/events", text: "イベント" },
-              { type: "link", href: "/problems", text: "問題カタログ" },
-              { type: "link", href: "/deployments", text: "デプロイ履歴" },
+              { type: "link", href: "/events", text: t("nav.events") },
+              { type: "link", href: "/problems", text: t("nav.problems") },
+              { type: "link", href: "/deployments", text: t("nav.deployments") },
               { type: "link", href: "/competitor-accounts", text: "Competitor Accounts" },
             ]}
             onFollow={(e) => {

--- a/apps/application-admin-console/src/i18n/i18n.test.tsx
+++ b/apps/application-admin-console/src/i18n/i18n.test.tsx
@@ -1,0 +1,91 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _testInternals, I18nProvider, type LocaleCode, useI18n, useT } from "./index";
+
+/**
+ * Issue #583 i18n Phase 1.C: application-admin-console の自前 i18n の pin。
+ * dict lookup / fallback chain / localStorage persist / dictionary missing key の 4 path を検証。
+ */
+
+describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
+  beforeEach(() => {
+    if (typeof window !== "undefined") window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    if (typeof window !== "undefined") window.localStorage.clear();
+  });
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return <I18nProvider>{children}</I18nProvider>;
+  }
+
+  it("default locale は ja (navigator.language 未対応の test 環境 default)", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    expect(result.current.locale).toMatch(/^(ja|en|es|zh)$/);
+  });
+
+  it("setLocale が localStorage に永続化し次回起動で復元すべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("en"));
+    expect(result.current.locale).toBe("en");
+    // localStorage の値が保存されている
+    expect(window.localStorage.getItem("tenkacloud.application-admin.locale")).toBe("en");
+  });
+
+  it("t() は dot-separated key で nested dictionary を引くべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("ja"));
+    expect(result.current.t("app.title")).toBe("TenkaCloud アプリケーション管理コンソール");
+    act(() => result.current.setLocale("en"));
+    expect(result.current.t("app.title")).toBe("TenkaCloud Application Admin Console");
+  });
+
+  it("locale で key 未定義なら en で fallback、 en にも無ければ raw key", () => {
+    const { result } = renderHook(() => useT(), { wrapper });
+    // 全 locale にあるキー → 翻訳成功
+    expect(result.current("nav.problems")).toBeTruthy();
+    expect(result.current("nav.problems")).not.toBe("nav.problems");
+    // 全 locale に無い key → raw key 返し
+    expect(result.current("nonexistent.key")).toBe("nonexistent.key");
+  });
+
+  it("SUPPORTED_LOCALES = 4 言語 [ja, en, es, zh]", () => {
+    const supported: readonly LocaleCode[] = ["ja", "en", "es", "zh"];
+    for (const code of supported) {
+      const dict = _testInternals.LOCALE_DICTIONARIES[code];
+      expect(dict).toBeDefined();
+      // すべての locale が "locale.name" key を持つ (= UI switcher 表示用)
+      expect(_testInternals.resolveKey(dict, "locale.name")).toBeTruthy();
+    }
+  });
+
+  it("locale 変更時に <html lang> が追従すべき", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("zh"));
+    expect(document.documentElement.lang).toBe("zh");
+    act(() => result.current.setLocale("ja"));
+    expect(document.documentElement.lang).toBe("ja");
+  });
+
+  it("useI18n を Provider 外で呼ぶと throw すべき (= configuration error の早期発見)", () => {
+    // renderHook で wrapper を渡さないと throws する
+    expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
+  });
+
+  // 翻訳結果が UI に出ることを実 render で確認
+  it("Provider 配下で翻訳結果が UI に反映されるべき", () => {
+    function Probe() {
+      const t = useT();
+      return <div>{t("app.loading")}</div>;
+    }
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>,
+    );
+    // ja default で「読み込み中|Loading|Cargando|正在加载…」 が出る (navigator.language が ja/en どちらでも fallback で en に行く)
+    const el = screen.getByText(/(状態を取得中|Loading|Cargando|正在加载)…/);
+    expect(el).toBeInTheDocument();
+  });
+});

--- a/apps/application-admin-console/src/i18n/index.tsx
+++ b/apps/application-admin-console/src/i18n/index.tsx
@@ -1,0 +1,142 @@
+/**
+ * Issue #583 i18n Phase 1.A: participant-portal の i18n 基盤。
+ *
+ * 設計判断:
+ *   - **homegrown 実装** (= react-i18next 等の lib 非導入)。 4 言語 × ~30 keys 規模なら自前で
+ *     済む + supply-chain audit-baseline 更新が不要 + bundle size 増えない (= 50KB 削減)。
+ *     Phase 1.B で 3 SPA 全部に展開する時にライブラリ採択を再評価する。
+ *   - **navigator.language → localStorage** の 2 段検出: 起動時 navigator.language で auto-detect、
+ *     UI で切り替えたら localStorage に永続化、 次回起動はそれが優先。
+ *   - **fallback chain**: 指定 locale で key 不在 → en → key 文字列そのまま。 missing key を
+ *     見つけやすくする (= 「app.title」 のような raw key が出たら抽出忘れ)。
+ *   - **react context + hook**: Provider が現在 locale + setLocale を提供、 useT() hook で
+ *     翻訳関数を取り出す。 子 component は import なしで利用可。
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import en from "./locales/en.json";
+import es from "./locales/es.json";
+import ja from "./locales/ja.json";
+import zh from "./locales/zh.json";
+
+export const SUPPORTED_LOCALES = ["ja", "en", "es", "zh"] as const;
+export type LocaleCode = (typeof SUPPORTED_LOCALES)[number];
+
+const LOCALE_DICTIONARIES: Record<LocaleCode, Record<string, unknown>> = {
+  ja,
+  en,
+  es,
+  zh,
+};
+
+const LOCAL_STORAGE_KEY = "tenkacloud.application-admin.locale";
+
+/**
+ * `navigator.language` (= "en-US" / "ja-JP" 等) を SUPPORTED_LOCALES のいずれかに narrow。
+ * 一致なければ "ja" を default にする (= 既存 UI を維持)。
+ */
+function detectBrowserLocale(): LocaleCode {
+  if (typeof navigator === "undefined") return "ja";
+  const raw = (navigator.language || "ja").toLowerCase();
+  for (const code of SUPPORTED_LOCALES) {
+    if (raw.startsWith(code)) return code;
+  }
+  return "ja";
+}
+
+function loadStoredLocale(): LocaleCode | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
+      return stored as LocaleCode;
+    }
+  } catch {
+    // localStorage access denied (= incognito strict mode 等) → default fallback
+  }
+  return undefined;
+}
+
+function persistLocale(code: LocaleCode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * dot-separated key (e.g. "app.title") を nested object から取り出す。 未定義は undefined。
+ */
+function resolveKey(dict: Record<string, unknown>, key: string): string | undefined {
+  const parts = key.split(".");
+  let node: unknown = dict;
+  for (const p of parts) {
+    if (typeof node !== "object" || node === null) return undefined;
+    node = (node as Record<string, unknown>)[p];
+  }
+  return typeof node === "string" ? node : undefined;
+}
+
+interface I18nContextValue {
+  readonly locale: LocaleCode;
+  readonly setLocale: (code: LocaleCode) => void;
+  readonly t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<LocaleCode>(
+    () => loadStoredLocale() ?? detectBrowserLocale(),
+  );
+
+  // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const setLocale = useCallback((code: LocaleCode) => {
+    setLocaleState(code);
+    persistLocale(code);
+  }, []);
+
+  const t = useCallback(
+    (key: string): string => {
+      // 1) 指定 locale で lookup → 2) en で fallback → 3) raw key
+      const v = resolveKey(LOCALE_DICTIONARIES[locale], key);
+      if (v !== undefined) return v;
+      const fallback = resolveKey(LOCALE_DICTIONARIES.en, key);
+      return fallback ?? key;
+    },
+    [locale],
+  );
+
+  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error("useI18n must be called inside <I18nProvider>");
+  return ctx;
+}
+
+/** 翻訳関数だけが必要な hot path 用 shortcut。 */
+export function useT(): (key: string) => string {
+  return useI18n().t;
+}
+
+/** Tests / debug 用に dictionaries を露出。 portal 本体からは使わない。 */
+export const _testInternals = { LOCALE_DICTIONARIES, resolveKey, detectBrowserLocale };

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -1,0 +1,22 @@
+{
+  "locale": {
+    "name": "English"
+  },
+  "app": {
+    "title": "TenkaCloud Application Admin Console",
+    "loading": "Loading…"
+  },
+  "nav": {
+    "menu": "Menu",
+    "events": "Events",
+    "teams": "Teams",
+    "problems": "Problems",
+    "deployments": "Deployments"
+  },
+  "auth": {
+    "sign_out": "Sign out"
+  },
+  "errors": {
+    "generic": "An error occurred"
+  }
+}

--- a/apps/application-admin-console/src/i18n/locales/es.json
+++ b/apps/application-admin-console/src/i18n/locales/es.json
@@ -1,0 +1,22 @@
+{
+  "locale": {
+    "name": "Español"
+  },
+  "app": {
+    "title": "Consola de Administración de Aplicación TenkaCloud",
+    "loading": "Cargando…"
+  },
+  "nav": {
+    "menu": "Menú",
+    "events": "Eventos",
+    "teams": "Equipos",
+    "problems": "Problemas",
+    "deployments": "Despliegues"
+  },
+  "auth": {
+    "sign_out": "Cerrar sesión"
+  },
+  "errors": {
+    "generic": "Se produjo un error"
+  }
+}

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -1,0 +1,22 @@
+{
+  "locale": {
+    "name": "日本語"
+  },
+  "app": {
+    "title": "TenkaCloud アプリケーション管理コンソール",
+    "loading": "読み込み中…"
+  },
+  "nav": {
+    "menu": "メニュー",
+    "events": "イベント",
+    "teams": "チーム",
+    "problems": "問題",
+    "deployments": "デプロイ"
+  },
+  "auth": {
+    "sign_out": "サインアウト"
+  },
+  "errors": {
+    "generic": "エラーが発生しました"
+  }
+}

--- a/apps/application-admin-console/src/i18n/locales/zh.json
+++ b/apps/application-admin-console/src/i18n/locales/zh.json
@@ -1,0 +1,22 @@
+{
+  "locale": {
+    "name": "中文"
+  },
+  "app": {
+    "title": "TenkaCloud 应用管理控制台",
+    "loading": "正在加载…"
+  },
+  "nav": {
+    "menu": "菜单",
+    "events": "活动",
+    "teams": "团队",
+    "problems": "题目",
+    "deployments": "部署"
+  },
+  "auth": {
+    "sign_out": "退出登录"
+  },
+  "errors": {
+    "generic": "发生错误"
+  }
+}

--- a/apps/application-admin-console/src/main.tsx
+++ b/apps/application-admin-console/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { App } from "./App";
 import { loadConfig } from "./config";
+import { I18nProvider } from "./i18n";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root element missing from index.html");
@@ -11,9 +12,11 @@ loadConfig()
   .then((config) => {
     createRoot(root).render(
       <StrictMode>
-        <BrowserRouter>
-          <App config={config} />
-        </BrowserRouter>
+        <I18nProvider>
+          <BrowserRouter>
+            <App config={config} />
+          </BrowserRouter>
+        </I18nProvider>
       </StrictMode>,
     );
   })

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it } from "vitest";
 import { App } from "../src/App";
 import type { AppConfig } from "../src/config";
+import { I18nProvider } from "../src/i18n";
 
 const config: AppConfig = {
   cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
@@ -34,10 +35,13 @@ function loginAs(claims: Record<string, string>) {
 }
 
 function renderApp(initialPath: string) {
+  // i18n Phase 1.C: main.tsx で I18nProvider が App を包むので test でも wrap する。
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <App config={config} />
-    </MemoryRouter>,
+    <I18nProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <App config={config} />
+      </MemoryRouter>
+    </I18nProvider>,
   );
 }
 


### PR DESCRIPTION
## Summary

Issue #583 i18n Phase 1.A の pattern (= homegrown I18nProvider + 4 言語 dictionaries + TopNavigation locale switcher) を残 2 SPA に mechanical 複製。 これで 3 SPA すべてに i18n 基盤が揃う。

## 実装 (1.A pattern と同 shape)

- **admin-console** (localStorage key: \`tenkacloud.admin.locale\`)
  - keys: app.title / nav.menu / nav.tenants / nav.tenants_new / auth.sign_out / errors.generic
- **application-admin-console** (localStorage key: \`tenkacloud.application-admin.locale\`)
  - keys: app.title / nav.menu / nav.events / nav.teams / nav.problems / nav.deployments / auth.sign_out / errors.generic

各 SPA で main.tsx を <I18nProvider> wrap + AppLayout.tsx の TopNavigation に locale switcher menu-dropdown 追加 + SideNavigation / sign-out を t() 化。

## Phase 2 残スコープ (別 PR)

- Phase 2: 各 SPA の page-level component 内日本語直書きを段階的に t() 置換
- Phase 3: backend error response の code-based 統一

## Test plan

- [x] \`make before-commit\` green
- [x] admin-console 92 tests pass (+8 i18n)
- [x] application-admin-console 148 tests pass (+8 i18n)
- [x] participant-portal 既存 tests に影響なし (= PR-630 で同基盤を ship 済)

## 物理影響

- 新 file 12 (各 SPA × 6 = i18n/index.tsx + 4 locales + test)
- 変更 file 5 (main × 2、 AppLayout × 2、 application-admin-console test)
- 各 SPA TopNav に locale switcher 1 menu-dropdown が追加 (= ノイズ最小)

## Regression 分析

- localStorage key は SPA 別で衝突なし
- 既存日本語固定 contributor は navigator.language ja で default ja のまま

Relates #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support with English, Spanish, Japanese, and Chinese localization.
  * Added locale switcher dropdown in navigation bar for users to change language preference.
  * UI strings (titles, navigation labels, buttons) now display in the selected language.

* **Tests**
  * Added comprehensive test coverage for internationalization system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/631)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->