### PR TITLE
feat(#615): ADR-013 Phase 1 — SCHEMA に disruptions[].triggers[] を追加

### DIFF
--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -541,6 +541,57 @@
           "description": {
             "type": "string",
             "description": "disruption の動作 / 戦術的影響を participant 向けに説明する文章。 portal の予告 panel で countdown と一緒に表示される (= player への hint)。"
+          },
+          "triggers": {
+            "type": "array",
+            "description": "[ADR-013 Phase 1 / Issue #615] disruption の発火条件宣言。 省略時は ADR-012 Phase 1 の self-fire (= `defaultAfterMinutes` で template.yaml-bundled Scheduler から起動) のみ。 triggers[] が宣言されると ADR-013 Phase 2 で導入される condition-triggered 発火が有効化される (= scoring Lambda 側 eval、 cross-account EventBridge bus 経由)。 複数 trigger は OR で結合 (= 最初に true になった条件で発火)。 同一 disruption の重複発火は idempotency key で抑制。",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["kind", "afterMinutes"],
+                  "properties": {
+                    "kind": {
+                      "const": "after-deploy",
+                      "description": "deploy 時刻 + offset で発火 (= ADR-012 Phase 1 の self-fire 等価)。 fail-safe として常に含めることを推奨。"
+                    },
+                    "afterMinutes": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "deploy からの経過分数。"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["kind", "threshold"],
+                  "properties": {
+                    "kind": {
+                      "const": "team-score-above",
+                      "description": "team の累計 score が threshold を上回ったら発火 (= 強チームへの handicap、 ゲームバランス調整用)。"
+                    },
+                    "threshold": { "type": "integer", "minimum": 0 }
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["kind", "phaseName"],
+                  "properties": {
+                    "kind": {
+                      "const": "phase-entered",
+                      "description": "phases[].name == phaseName のフェーズに突入したら発火 (= phased-polling 系で phase 遷移と同期した disruption)。"
+                    },
+                    "phaseName": {
+                      "type": "string",
+                      "description": "metadata.phases[].name の値を指す。"
+                    }
+                  }
+                }
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

ADR-013 Rollout Phase 1: \`disruptions[].triggers[]\` を SCHEMA に optional 追加。 既存 self-fire disruption は不変、 新規問題は triggers[] を宣言することで Phase 2 で導入される condition-triggered 発火を有効化できる準備。

## triggers[] の 3 kind

| kind | 発火条件 | 用途 |
|------|---------|------|
| \`after-deploy\` | deploy 時刻 + afterMinutes | Phase 1 self-fire の等価 (fail-safe) |
| \`team-score-above\` | team の累計 score > threshold | 強チーム handicap |
| \`phase-entered\` | phases[].name == phaseName 突入 | phased-polling 同期 |

複数 trigger は OR、 重複抑制は idempotency key (Phase 2 で実装)。

## Test plan

- [x] \`make validate-problems\` 通過 (既存 4 metadata が新 SCHEMA 互換)
- [x] \`make before-commit\` green

## 物理影響

- 変更 file 1 (SCHEMA.json)
- 既存挙動なし (triggers[] optional)
- 後続 Phase: 2 (user CDK) / 3 (Claude scoring Lambda eval) / 4 (Claude operator UI) / 5 (Claude POC integration)

Relates #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)