### PR TITLE
feat(#574): ADR-008 Phase 1.B — problems/index.json 生成 + before-commit drift 検出

### DIFF
--- a/.claude/templates/problems/attack-detection/metadata.json
+++ b/.claude/templates/problems/attack-detection/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "攻撃検知 counter 差分で加点する attack-detection Battle skeleton。",

--- a/.claude/templates/problems/flag/metadata.json
+++ b/.claude/templates/problems/flag/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Challenge",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 2,
   "estimatedDuration": "30〜45 分",
   "shortDescription": "1 行サマリ (~200 字) — どんな問題か。",

--- a/.claude/templates/problems/phased-polling/metadata.json
+++ b/.claude/templates/problems/phased-polling/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "90〜120 分",
   "shortDescription": "時間経過で rule が変わる phased-polling 採点の Battle skeleton。",

--- a/.claude/templates/problems/uptime-flat/metadata.json
+++ b/.claude/templates/problems/uptime-flat/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "1 endpoint を稼働させ続けて defense する Battle 問題の skeleton (uptime-flat 採点)。",

--- a/.claude/templates/problems/uptime-multi/metadata.json
+++ b/.claude/templates/problems/uptime-multi/metadata.json
@@ -4,6 +4,7 @@
   "name": "__PROBLEM_NAME__",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "N slot を全部生存させ続ける uptime-multi 採点の Battle skeleton。",

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export JSII_DEPRECATED := quiet
 .DEFAULT_GOAL := help
 
 .PHONY: help install install_ci build typecheck test check before-commit beforecommit \
-        build-docs check-docs audit-deps \
+        build-docs check-docs audit-deps build-problems-index check-problems-index \
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
@@ -34,12 +34,14 @@ build:         ; bun run build
 typecheck:     ; bun run typecheck
 test:          ; bun run test
 validate-problems: ; bun run validate:problems
+build-problems-index: ; bun run build:problems-index
+check-problems-index: ; bun run check:problems-index
 build-docs:    ; bun run scripts/build-docs.ts
 check-docs:    ; bun run scripts/build-docs.ts --check
 check-http-status: ; bun run scripts/check-http-magic-numbers.ts
 audit-deps:    ; bun run audit:dependencies
-check:         install lint test validate-problems check-docs check-http-status audit-deps
-before-commit: lint test validate-problems check-docs check-http-status audit-deps
+check:         install lint test validate-problems check-problems-index check-docs check-http-status audit-deps
+before-commit: lint test validate-problems check-problems-index check-docs check-http-status audit-deps
 
 # ===== Lint / Fix =====
 lint:   lint-md lint-text lint-format

--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -84,4 +84,17 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   it("endpoints[] が無い問題は空配列を返すべき", () => {
     expect(findProblemMetadata("hello-world")?.endpoints).toEqual([]);
   });
+
+  // ADR-008 / Issue #574 Phase 1: visibility field を catalog に露出する。
+  it("既存 4 問題はすべて visibility='public' で露出されるべき", () => {
+    for (const id of [
+      "hello-world",
+      "hello-world-battle",
+      "security-battle-royale",
+      "microservice-migration-battle",
+    ]) {
+      const m = findProblemMetadata(id);
+      expect(m?.visibility).toBe("public");
+    }
+  });
 });

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -12,6 +12,10 @@
 
 export type ProblemCategory = "Battle" | "Challenge";
 export type ProblemStatus = "ready" | "draft" | "deprecated";
+/** ADR-008 / Issue #574: 問題実装の公開境界。 public = 本体 repo に payload を持つ教材問題、
+ *  private = TenkaCloudChallenges 別 repo に payload を持ち S3 presigned URL で配信される
+ *  本格競技問題。 metadata に省略時は public 扱い (= 既存 metadata との互換)。 */
+export type ProblemVisibility = "public" | "private";
 
 /**
  * ADR-012 Phase 4 portal predict: 問題 metadata で宣言された phase / disruption の予告 entry。
@@ -63,6 +67,8 @@ export interface ProblemCatalogEntry {
   readonly name: string;
   readonly category: ProblemCategory;
   readonly status: ProblemStatus;
+  /** ADR-008 Phase 1 / Issue #574: 公開境界。 metadata 省略時は "public" を default に。 */
+  readonly visibility: ProblemVisibility;
   readonly difficulty: 1 | 2 | 3 | 4 | 5;
   readonly estimatedDuration: string;
   readonly shortDescription: string;
@@ -85,6 +91,7 @@ interface ProblemMetadata {
   name: string;
   category: ProblemCategory;
   status: ProblemStatus;
+  visibility?: ProblemVisibility;
   difficulty: 1 | 2 | 3 | 4 | 5;
   estimatedDuration: string;
   shortDescription: string;
@@ -148,6 +155,8 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
     name: metadata.name,
     category: metadata.category,
     status: metadata.status,
+    // metadata 省略時は public 扱い (= 既存問題互換 + ADR-008 D4 の "省略時 public" 規約)。
+    visibility: metadata.visibility ?? "public",
     difficulty: metadata.difficulty,
     estimatedDuration: metadata.estimatedDuration,
     shortDescription: metadata.shortDescription,

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -122,9 +122,13 @@ function ProblemInfoSection({ metadata }: { metadata: ProblemCatalogEntry }) {
       <SpaceBetween size="m">
         <ColumnLayout columns={4} variant="text-grid">
           <InfoCell label="カテゴリ">
-            <Badge color={metadata.category === "Battle" ? "red" : "blue"}>
-              {metadata.category}
-            </Badge>
+            <SpaceBetween direction="horizontal" size="xxs">
+              <Badge color={metadata.category === "Battle" ? "red" : "blue"}>
+                {metadata.category}
+              </Badge>
+              {/* ADR-008 Phase 1: private 問題には「答え非公開」 badge。 public は省略 (= ノイズ削減)。 */}
+              {metadata.visibility === "private" && <Badge color="severity-high">答え非公開</Badge>}
+            </SpaceBetween>
           </InfoCell>
           <InfoCell label="難易度">{DIFFICULTY_LABEL[metadata.difficulty]}</InfoCell>
           <InfoCell label="想定プレイ時間">{metadata.estimatedDuration}</InfoCell>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
     "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test",
     "validate:problems": "bun run scripts/validate-problems.ts",
+    "build:problems-index": "bun run scripts/build-problem-index.ts",
+    "check:problems-index": "bun run scripts/build-problem-index.ts --check",
     "audit:dependencies": "bun run scripts/audit-dependencies.ts",
     "lint:md": "markdownlint-cli2 '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist'",
     "lint:text": "textlint '**/*.md'",

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -45,6 +45,11 @@
       "enum": ["ready", "draft", "deprecated"],
       "description": "公開ステータス。ready = 参加者向けデプロイ可能 / draft = 開発中 / deprecated = 廃止予定。"
     },
+    "visibility": {
+      "type": "string",
+      "enum": ["public", "private"],
+      "description": "[ADR-008] 問題実装の公開境界。 public = 本体 repo 内に template.yaml / api / frontend を持つ教材用 (= 答えが open でも成立する問題、 hello-world 系)。 private = TenkaCloudChallenges 別 private repo に payload を置き S3 + 15min presigned URL で配信する本格競技用 (= 答えが open だと成立しない microservice-migration-battle 系)。 省略時 public (= 既存 metadata との互換)。 Phase 1 では UI 表示のみ、 Phase 3 で Worker Lambda の S3 fetch 分岐を入れる。"
+    },
     "difficulty": {
       "type": "integer",
       "minimum": 1,

--- a/problems/battles/hello-world-battle/metadata.json
+++ b/problems/battles/hello-world-battle/metadata.json
@@ -4,6 +4,7 @@
   "name": "Hello World Battle (Sample)",
   "category": "Battle",
   "status": "ready",
+  "visibility": "public",
   "difficulty": 1,
   "estimatedDuration": "30 分",
   "shortDescription": "Battle uptime scoring の最小 sample。EC2 上で nginx (frontend) + Python (API) を起動し、両方が 200 を返す間スコアが 1 分ごとに +100 加算。",

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -4,6 +4,7 @@
   "name": "Microservice Migration Battle",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 4,
   "estimatedDuration": "90〜120 分",
   "shortDescription": "EC2 1 台に同居する 3 サービス (users / orders / catalog) を Lambda + API Gateway / ECS Fargate / App Runner の 3 種ホスティングに分割するレース。",

--- a/problems/battles/security-battle-royale/metadata.json
+++ b/problems/battles/security-battle-royale/metadata.json
@@ -4,6 +4,7 @@
   "name": "Security Battle Royale",
   "category": "Battle",
   "status": "draft",
+  "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
   "shortDescription": "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",

--- a/problems/challenges/hello-world/metadata.json
+++ b/problems/challenges/hello-world/metadata.json
@@ -4,6 +4,7 @@
   "name": "Hello World (Sample)",
   "category": "Challenge",
   "status": "ready",
+  "visibility": "public",
   "difficulty": 1,
   "estimatedDuration": "1 分",
   "shortDescription": "Challenge / flag 提出形式の最小 sample。SSM Parameter Store に書かれた値を当てて入力すると 100 点獲得。",

--- a/problems/index.json
+++ b/problems/index.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "problems": [
+    {
+      "id": "hello-world",
+      "name": "Hello World (Sample)",
+      "category": "Challenge",
+      "status": "ready",
+      "visibility": "public",
+      "difficulty": 1,
+      "estimatedDuration": "1 分",
+      "shortDescription": "Challenge / flag 提出形式の最小 sample。SSM Parameter Store に書かれた値を当てて入力すると 100 点獲得。",
+      "tags": ["sample", "challenge", "flag", "ssm"],
+      "scoringKind": "flag"
+    },
+    {
+      "id": "hello-world-battle",
+      "name": "Hello World Battle (Sample)",
+      "category": "Battle",
+      "status": "ready",
+      "visibility": "public",
+      "difficulty": 1,
+      "estimatedDuration": "30 分",
+      "shortDescription": "Battle uptime scoring の最小 sample。EC2 上で nginx (frontend) + Python (API) を起動し、両方が 200 を返す間スコアが 1 分ごとに +100 加算。",
+      "tags": ["sample", "battle", "uptime", "ec2", "nginx"],
+      "scoringKind": "uptime"
+    },
+    {
+      "id": "microservice-migration-battle",
+      "name": "Microservice Migration Battle",
+      "category": "Battle",
+      "status": "draft",
+      "visibility": "public",
+      "difficulty": 4,
+      "estimatedDuration": "90〜120 分",
+      "shortDescription": "EC2 1 台に同居する 3 サービス (users / orders / catalog) を Lambda + API Gateway / ECS Fargate / App Runner の 3 種ホスティングに分割するレース。",
+      "tags": ["microservices", "migration", "lambda", "ecs", "apprunner", "ec2", "docker"],
+      "scoringKind": "phased-polling"
+    },
+    {
+      "id": "security-battle-royale",
+      "name": "Security Battle Royale",
+      "category": "Battle",
+      "status": "draft",
+      "visibility": "public",
+      "difficulty": 3,
+      "estimatedDuration": "60〜90 分",
+      "shortDescription": "意図的に脆弱性を仕込んだ Web アプリを攻撃 / 防御し、競技アカウント上で生き残るチームを決める。",
+      "tags": ["security", "web", "sql-injection", "rce", "ssrf"],
+      "scoringKind": "uptime-multi"
+    }
+  ]
+}

--- a/scripts/build-problem-index.ts
+++ b/scripts/build-problem-index.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env bun
+/**
+ * ADR-008 Phase 1 / Issue #574: `problems/index.json` を生成する。
+ *
+ * Usage:
+ *   bun run scripts/build-problem-index.ts            # 生成 (= overwrite)
+ *   bun run scripts/build-problem-index.ts --check    # 既存ファイルとの差分を検出 (CI 用)
+ *
+ * 目的:
+ *   ADR-008 で、 admin / portal が **catalog だけ** をロードして問題を列挙できるよう、
+ *   全 metadata.json のサマリだけを集約した `problems/index.json` を生成する。
+ *   Phase 4 で private repo (`TenkaCloudChallenges`) の publish CI が、 metadata の
+ *   diff を本体 repo に PR で同期する経路の **書き込み先** が本ファイル。
+ *
+ * 含めるフィールド (= portal / admin が一覧表示に使う最小集合):
+ *   id / name / category / status / visibility / difficulty / estimatedDuration /
+ *   shortDescription / tags / scoringKind
+ *
+ * 含めないフィールド (= 全文は metadata.json or S3 payload 側で持つ):
+ *   description / learningGoals / endpoints / cfnParameters / phases / disruptions /
+ *   dashboard / i18n
+ *
+ * 安定化:
+ *   - id 順で sort (= 並び順が決定的)
+ *   - `generatedAt` 等の timestamp は埋め込まない (= drift 検出が壊れる)
+ *   - JSON は 2 spaces indent + trailing newline (= biome / git diff と整合)
+ */
+
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+const INDEX_PATH = join(PROBLEMS_DIR, "index.json");
+
+interface ProblemMetadata {
+  id: string;
+  name: string;
+  category: "Battle" | "Challenge";
+  status: "ready" | "draft" | "deprecated";
+  visibility?: "public" | "private";
+  difficulty: 1 | 2 | 3 | 4 | 5;
+  estimatedDuration: string;
+  shortDescription: string;
+  tags?: readonly string[];
+  scoring?: { kind?: string };
+}
+
+interface ProblemIndexEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly category: "Battle" | "Challenge";
+  readonly status: "ready" | "draft" | "deprecated";
+  readonly visibility: "public" | "private";
+  readonly difficulty: 1 | 2 | 3 | 4 | 5;
+  readonly estimatedDuration: string;
+  readonly shortDescription: string;
+  readonly tags: readonly string[];
+  readonly scoringKind: string | null;
+}
+
+interface ProblemIndex {
+  readonly version: "1";
+  readonly problems: readonly ProblemIndexEntry[];
+}
+
+function findMetadataFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (entry === "node_modules") continue;
+    if (isDir) {
+      found.push(...findMetadataFiles(full));
+    } else if (entry === "metadata.json") {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function toEntry(m: ProblemMetadata): ProblemIndexEntry {
+  return {
+    id: m.id,
+    name: m.name,
+    category: m.category,
+    status: m.status,
+    visibility: m.visibility ?? "public",
+    difficulty: m.difficulty,
+    estimatedDuration: m.estimatedDuration,
+    shortDescription: m.shortDescription,
+    tags: m.tags ?? [],
+    scoringKind: m.scoring?.kind ?? null,
+  };
+}
+
+function buildIndex(): ProblemIndex {
+  const files = findMetadataFiles(PROBLEMS_DIR);
+  const entries: ProblemIndexEntry[] = [];
+  for (const file of files) {
+    const data = JSON.parse(readFileSync(file, "utf8")) as ProblemMetadata;
+    entries.push(toEntry(data));
+  }
+  entries.sort((a, b) => a.id.localeCompare(b.id));
+  return { version: "1", problems: entries };
+}
+
+/**
+ * JSON.stringify の出力に biome JSON formatter を被せる (= short array を inline 化する
+ * など、 既存 repo の JSON 整形ルールに揃える)。 そうしないと `--check` で drift と判定される。
+ * biome は stdin/stdout 経由で format できる (`biome format --stdin-file-path=...`)。
+ */
+function serialize(index: ProblemIndex): string {
+  const raw = `${JSON.stringify(index, null, 2)}\n`;
+  const result = spawnSync("bunx", ["biome", "format", "--stdin-file-path=problems/index.json"], {
+    input: raw,
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error(`biome format failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const isCheck = args.includes("--check");
+  const index = buildIndex();
+  const serialized = serialize(index);
+  const rel = relative(REPO_ROOT, INDEX_PATH);
+
+  if (isCheck) {
+    let existing = "";
+    try {
+      existing = readFileSync(INDEX_PATH, "utf8");
+    } catch {
+      console.error(
+        `NG  ${rel} が存在しません。 \`bun run build:problems-index\` で生成してください。`,
+      );
+      process.exit(1);
+    }
+    if (existing !== serialized) {
+      console.error(
+        `NG  ${rel} が metadata.json と乖離しています。 \`bun run build:problems-index\` で再生成してください。`,
+      );
+      process.exit(1);
+    }
+    console.log(`OK  ${rel} は ${index.problems.length} 件の metadata と一致しています`);
+    return;
+  }
+
+  writeFileSync(INDEX_PATH, serialized);
+  console.log(`Wrote ${rel} (${index.problems.length} entries)`);
+}
+
+main();


### PR DESCRIPTION
## Summary

ADR-008 Phase 1 の残作業 (= "problems/index.json 生成") を実装。 全 metadata.json から admin / portal 一覧表示に必要な最小集合 (= id / name / category / status / visibility / difficulty / shortDescription / tags / scoringKind) を抽出して `problems/index.json` に書き出す generator script を新設、 `make before-commit` に drift 検出を組み込む。

ADR-008 Phase 4 の private repo CI (= `TenkaCloudChallenges` の publish.yml / catalog-pr.yml) が、 metadata の diff を本体 repo に PR で同期する **書き込み先** が本ファイル。 本 Phase 1.B では public 4 問の metadata から自動生成する流れを敷くだけで、 admin / portal はまだ既存の `import.meta.glob` 経路で動く (= 互換)。

## 実装

- `scripts/build-problem-index.ts`: 再帰 walk で `problems/<category>/<id>/metadata.json` を集め、 id 順 sort で `ProblemIndex` を組み立てる。 `--check` で既存ファイルとの drift を検出 (= CI 用 / 非 0 exit)。 biome JSON formatter を spawn して既存 repo 規約 (short array inline 等) に揃える (= drift 検出が biome 整形と整合)。
- `problems/index.json`: 4 件の public 問題を含む生成済みファイル (= biome 整形済)。
- `Makefile`: `build-problems-index` / `check-problems-index` target を追加し、 `before-commit` / `check` に `check-problems-index` を組み込む。
- `package.json`: `build:problems-index` / `check:problems-index` scripts を追加。

## 含まれないフィールド (= 全文は metadata.json or S3 payload 側で持つ)

- `description` / `learningGoals` (= 長文、 i18n 候補)
- `endpoints` / `cfnParameters` (= deploy 機構が読む、 portal 一覧不要)
- `phases` / `disruptions` / `dashboard` / `i18n` (= 個別画面で読み込む)

## Test plan

- [x] `bun run scripts/build-problem-index.ts` で 4 件の entry を生成
- [x] `bun run scripts/build-problem-index.ts --check` で drift 無し
- [x] `make before-commit` (= lint / test / validate-problems / check-problems-index / check-docs / check-http-status / audit-deps) 全部 pass
- [x] biome の JSON 整形ルール (= short array inline) と一致

## 物理影響

- CREATE: `problems/index.json` (= 53 行、 4 entry の sorted index)
- CREATE: `scripts/build-problem-index.ts` (= 163 行)
- UPDATE: `Makefile` (= 2 target 追加 + before-commit に組み込み)
- UPDATE: `package.json` (= 2 script 追加)
- 既存 admin / portal の動作: 変化なし (= 既存 `import.meta.glob` 経路は維持、 index.json consumer は Phase 4 で接続)

## Regression 分析

- 既存 4 件の metadata.json は `visibility="public"` (= PR-629 で埋め込み済) → 既存表示は不変
- `before-commit` に `check-problems-index` が入るので、 metadata.json を編集して index.json を更新し忘れると CI が落ちる → contributor 向けには Makefile target で `make build-problems-index` を案内 (= AGENTS.md / CONTRIBUTING.md 追記は別 PR)
- biome JSON 整形が更新された場合、 spawnSync の出力が変わるので drift 検出が走る。 Renovate 等で biome update が走ったら一緒に再生成が必要 (= 既知の弱点だが、 実害は CI 失敗だけで data loss 不能)

## Stacking

本 PR は PR-629 (= `feat/574-visibility-phase1`) を base に持つ。 PR-629 で visibility field を SCHEMA / metadata / portal に通すので、 本 PR の `visibility ?? "public"` 経路は PR-629 merge 後に正しく動く。 GitHub が PR-629 merge 後に base を main へ自動 rebase する。

Relates #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)