### PR TITLE
fix(#653): Cognito 招待メール本文を上書き + Step Functions LogGroup の hardcoded 名を unique 化

### DIFF
--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -1,9 +1,15 @@
 import { CognitoAuth, ControlPlane } from "@cdklabs/sbt-aws";
 import * as cdk from "aws-cdk-lib";
-import type { CfnUserPoolClient, IUserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import type {
+  CfnUserPool,
+  CfnUserPoolClient,
+  IUserPool,
+  UserPoolClient,
+} from "aws-cdk-lib/aws-cognito";
 import { EventBus, Rule } from "aws-cdk-lib/aws-events";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { Construct } from "constructs";
+import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "./control-plane/invite-message";
 
 interface ControlPlaneStackProps extends cdk.StackProps {
   systemAdminEmail: string;
@@ -84,6 +90,20 @@ export class ControlPlaneStack extends cdk.Stack {
       ...LOCALHOST_LOGOUT_URLS,
       ...extraLogoutUrls,
     ]);
+
+    // Issue #653: SBT default の SystemAdmin 招待メール本文は `http://localhost` を
+    // 埋めてしまうため、 admin-console origin に書き換える。 Phase 1 deploy 時は
+    // CDK_PARAM_ADMIN_CONSOLE_ORIGIN 未確定なので fallback 文面、 Phase 3 再 deploy で
+    // CloudFront URL に解決される。
+    const cfnUserPool = cognitoAuth.userPool.node.defaultChild as CfnUserPool;
+    cfnUserPool.addPropertyOverride(
+      "AdminCreateUserConfig.InviteMessageTemplate.EmailSubject",
+      INVITE_EMAIL_SUBJECT,
+    );
+    cfnUserPool.addPropertyOverride(
+      "AdminCreateUserConfig.InviteMessageTemplate.EmailMessage",
+      buildInviteEmailBody(adminConsoleOrigin),
+    );
 
     const eventBus = EventBus.fromEventBusArn(this, "eventBus", controlPlane.eventManager.busArn);
 

--- a/infrastructure/lib/control-plane/invite-message.ts
+++ b/infrastructure/lib/control-plane/invite-message.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #653: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
+ * を override するためのテンプレ生成。 admin-console origin が解決できないときは
+ * 運営連絡先を促す fallback 文面を返す (= Phase 1 deploy 時)、 解決済なら CloudFront
+ * URL を本文に埋める (= Phase 3 再 deploy 後)。
+ */
+
+const FALLBACK_URL_PLACEHOLDER = "(deploy 完了後の admin-console URL は運営にお問い合わせください)";
+
+export const INVITE_EMAIL_SUBJECT =
+  "TenkaCloud Admin Console 招待 / Your TenkaCloud Admin Console invitation";
+
+/**
+ * 招待メール本文を組み立てる。 ja + en 並列で 1 通に並べる (PR-582 同様の方針)。
+ * Cognito placeholder の `{username}` / `{####}` はそのまま埋め、 Cognito 側で展開させる。
+ */
+export function buildInviteEmailBody(adminConsoleOrigin: string | undefined): string {
+  const url =
+    adminConsoleOrigin && adminConsoleOrigin.length > 0
+      ? adminConsoleOrigin
+      : FALLBACK_URL_PLACEHOLDER;
+  return [
+    "TenkaCloud Admin Console へようこそ。",
+    "",
+    `URL: ${url}`,
+    "ユーザー名: {username}",
+    "仮パスワード: {####}",
+    "",
+    "初回ログイン時に新しいパスワードの設定を求められます。",
+    "",
+    "—",
+    "Welcome to TenkaCloud Admin Console.",
+    "",
+    `URL: ${url}`,
+    "Username: {username}",
+    "Temporary password: {####}",
+    "",
+    "You will be prompted to set a new password on first sign-in.",
+  ].join("\n");
+}

--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -177,9 +177,11 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
       timeout: cdk.Duration.seconds(10),
     });
 
-    const stepfunctionLogGroup = new logs.LogGroup(this, "stepFunctionLG", {
-      logGroupName: "/aws/vendedlogs/states/StepFunctionLogging",
-    });
+    // logGroupName は省略して CFn auto-generate に任せる。
+    // 旧コードは `/aws/vendedlogs/states/StepFunctionLogging` を hardcode していて、
+    // 同 account 内に複数 deploy / 旧 stack 残骸との衝突 (= AlreadyExists) を起こしていた。
+    // CFn auto-name は `<stack>-stepFunctionLG-<hash>` で stack スコープに閉じる。
+    const stepfunctionLogGroup = new logs.LogGroup(this, "stepFunctionLG");
 
     const approvalQueue = new sqs.Queue(this, "ApprovalQueue", {
       enforceSSL: true,

--- a/infrastructure/test/control-plane-stack.test.ts
+++ b/infrastructure/test/control-plane-stack.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "../lib/control-plane/invite-message";
+
+/**
+ * Issue #653: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
+ * を override する pure function の挙動を pin。 stack 統合は cdk synth 経路で確認する
+ * (= Docker bundling 不要なら synth test、 必要なら e2e で確認)。
+ */
+describe("buildInviteEmailBody (Issue #653)", () => {
+  it("admin-console origin が解決済なら CloudFront URL を本文に埋めるべき", () => {
+    const body = buildInviteEmailBody("https://d1234abc.cloudfront.net");
+    expect(body).toContain("https://d1234abc.cloudfront.net");
+    expect(body).not.toMatch(/http:\/\/localhost/);
+  });
+
+  it("origin 未確定 (= Phase 1 deploy) は運営連絡先を促す fallback 文面を返すべき", () => {
+    const body = buildInviteEmailBody(undefined);
+    expect(body).toContain("運営にお問い合わせください");
+    expect(body).not.toMatch(/http:\/\/localhost/);
+  });
+
+  it("空文字列も fallback 扱いとすべき (= env 未設定と同等)", () => {
+    const body = buildInviteEmailBody("");
+    expect(body).toContain("運営にお問い合わせください");
+  });
+
+  it("Cognito placeholder ({username} / {####}) を本文に保持すべき", () => {
+    const body = buildInviteEmailBody("https://example.com");
+    expect(body).toContain("{username}");
+    expect(body).toContain("{####}");
+  });
+
+  it("ja / en の両方を 1 通に並列で含めるべき (PR-582 同方針)", () => {
+    const body = buildInviteEmailBody("https://example.com");
+    expect(body).toContain("TenkaCloud Admin Console へようこそ");
+    expect(body).toContain("Welcome to TenkaCloud Admin Console");
+  });
+
+  it("subject が TenkaCloud 名称に上書きされているべき", () => {
+    expect(INVITE_EMAIL_SUBJECT).toMatch(/TenkaCloud Admin Console/);
+    expect(INVITE_EMAIL_SUBJECT).not.toMatch(/control plane/i);
+  });
+
+  it("URL が body に 2 度出現すべき (= ja / en パートそれぞれ)", () => {
+    const body = buildInviteEmailBody("https://d999.cloudfront.net");
+    const matches = body.match(/https:\/\/d999\.cloudfront\.net/g);
+    expect(matches).toHaveLength(2);
+  });
+});

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -140,6 +140,17 @@ fi
 # tenkacloud- prefix の現行 API Key を残骸チェック。 CFn 管理下なら destroy で消えるが、
 # 過去の partial-rollback で stack だけ削除済 + API Key 残存というケースを救う。
 # 同名 API key が複数 region にまたがる可能性は低いので current region のみ scan。
+# 旧コードが LogGroup を hardcoded 名で作っていた残骸を削除 (= #653 / StepFunctionLogging 経路)。
+# 現在は CFn auto-name に切替済だが、 過去 deploy の残骸が出てくると AlreadyExists で 2 回目 deploy が落ちる。
+log "scanning for orphan LogGroups (legacy hardcoded names)..."
+for orphan_lg in "/aws/vendedlogs/states/StepFunctionLogging"; do
+  if aws logs describe-log-groups --log-group-name-prefix "${orphan_lg}" --query 'logGroups[?logGroupName==`'"${orphan_lg}"'`].logGroupName' --output text 2>/dev/null | grep -q .; then
+    log "  deleting orphan log group ${orphan_lg}"
+    aws logs delete-log-group --log-group-name "${orphan_lg}" 2>/dev/null \
+      || log "    skip (already gone or in-use)"
+  fi
+done
+
 log "scanning for orphan API Keys (server-Basic / Stand / Premi / Plati or tenkacloud-* tier keys)..."
 ORPHAN_KEY_IDS=$(aws apigateway get-api-keys --query \
   "items[?starts_with(name, 'server-Basic-') || starts_with(name, 'server-Stand-') || starts_with(name, 'server-Premi-') || starts_with(name, 'server-Plati-') || contains(name, '-basic-tier-key-') || contains(name, '-standard-tier-key-') || contains(name, '-premium-tier-key-') || contains(name, '-platinum-tier-key-')].id" \


### PR DESCRIPTION
## 症状

\`make deploy\` 後の状態 + 再 deploy で 2 種の問題が混在:

1. SystemAdmin に届く Cognito 招待メールの本文が SBT default の \`Login into control plane UI at http://localhost with username admin and temporary password ...\` で配信され、 受信者が \`http://localhost\` にアクセスして混乱
2. 再 deploy で \`tenkacloud-saas-pipeline\` が \`AWS::Logs::LogGroup\` \`/aws/vendedlogs/states/StepFunctionLogging\` の \`AlreadyExists\` で fail

## Root cause

両方とも **hardcoded resource name** の同パターン (= PR-652 API Key 衝突と同根):

1. SBT (\`@cdklabs/sbt-aws\`) 内部の \`CognitoAuth\` construct が \`userInvitation.emailBody\` を hard-code、 default \`controlPlaneCallbackURL\` が \`http://localhost\`
2. \`serverless-saas-pipeline.ts\` 内で \`logGroupName: \"/aws/vendedlogs/states/StepFunctionLogging\"\` を hard-code、 account 内の他 stack / 旧残骸との衝突

## Fix

1. **\`lib/control-plane/invite-message.ts\` を新設**: \`buildInviteEmailBody()\` で ja+en 並列の招待文を組み立て。 origin 未確定時 (Phase 1 deploy) は運営連絡を促す fallback、 確定時 (Phase 3 再 deploy) は CloudFront URL を埋める
2. **\`control-plane-stack.ts\` で CFn escape hatch**: \`CfnUserPool.addPropertyOverride()\` で \`AdminCreateUserConfig.InviteMessageTemplate.EmailSubject\` / \`EmailMessage\` を上書き。 UserPool 自体は replace されず、 既存 user 保護
3. **\`serverless-saas-pipeline.ts\`**: \`logGroupName\` 指定を削除 → CFn auto-name (\`<stack>-stepFunctionLG-<hash>\`)、 stack スコープに閉じる
4. **\`scripts/cleanup.sh\`**: 旧 hardcoded LogGroup (\`StepFunctionLogging\`) も orphan 削除対象に追加、 destroy → redeploy サイクルで衝突しない

## Test plan

- [x] \`buildInviteEmailBody\` の unit test 7 件 (URL 埋め込み / fallback / placeholder 保持 / ja-en 並列 / subject 上書き)
- [x] \`make before-commit\` 全 pass (712 tests + check-synth)
- [x] orphan LogGroup (\`/aws/vendedlogs/states/StepFunctionLogging\`) を AWS から削除済

## Regression 分析

- UserPool への property override は **in-place update** (= replace 無し、 既存 user 保護)
- LogGroup は **replace される** (旧 hardcoded → 新 auto-gen)。 destroy で旧名削除後 redeploy なら問題なし、 in-place update でも CFn は新名で create + 旧名 delete
- \`make destroy\` 経由なら cleanup.sh の orphan scan で旧 LogGroup も自動削除

## 物理影響

- **UPDATE in-place**: ControlPlaneStack \`AWS::Cognito::UserPool\` (= InviteMessageTemplate property のみ)
- **REPLACE**: \`tenkacloud-saas-pipeline\` の \`AWS::Logs::LogGroup\` (旧 hardcoded → 新 auto-gen)
- **NO-OP**: 他 stack 無影響

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customized admin console invitation emails now include bilingual (Japanese/English) content with improved formatting.

* **Bug Fixes**
  * Resolved CloudWatch log group naming collisions by implementing auto-generated naming within stack scope.
  * Enhanced cleanup script to remove legacy orphan log groups from previous infrastructure.

* **Tests**
  * Added test coverage for invitation email generation and bilingual content validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/654)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->