### PR TITLE
fix(#670,#672): bulk-deploy ProjectionExpression bug + participant-portal Lambda OOM

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -61,6 +61,10 @@ export async function queryDeploymentsByEvent(
   eventId: string,
   projectionExpression?: string,
 ): Promise<Partial<DeploymentItem>[]> {
+  // Issue #670: DDB は `status` 等の reserved word を ProjectionExpression / FilterExpression
+  // / UpdateExpression 全てで alias 必須。 caller が `#s` を含む projection を渡すケース
+  // (= bulk-deploy.ts が `jobId, teamId, problemId, #s` で呼ぶ) を黙ってサポートするため、
+  // alias を本 helper 側で定義する。 caller が `#s` を使わなくても extra alias は ignored。
   const out = await shared.ddb.send(
     new QueryCommand({
       TableName: shared.deploymentsTableName,
@@ -71,7 +75,14 @@ export async function queryDeploymentsByEvent(
         ":pk": `TENANT#${tenantId}`,
         ":ev": eventId,
       },
-      ...(projectionExpression ? { ProjectionExpression: projectionExpression } : {}),
+      ...(projectionExpression
+        ? {
+            ProjectionExpression: projectionExpression,
+            ...(projectionExpression.includes("#s")
+              ? { ExpressionAttributeNames: { "#s": "status" } }
+              : {}),
+          }
+        : {}),
     }),
   );
   return (out.Items ?? []) as Partial<DeploymentItem>[];

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -122,7 +122,10 @@ export class ParticipantPortalLambda extends Construct {
       entry: path.resolve(__dirname, "handlers/participant-handler/index.ts"),
       handler: "handler",
       timeout: Duration.seconds(10),
-      memorySize: 256,
+      // Issue #672: bundle が 33MB と巨大 (= AWS SDK / Hono / zod 等が含まれる) で
+      // 256MB だと Init Duration 1693ms で OOM → 502 Internal Server Error。
+      // 512MB に拡張 (= cold start 後の steady state Max Memory Used は 136MB 程度)。
+      memorySize: 512,
       role,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,

--- a/infrastructure/test/problem-deploy/event-handler-shared.test.ts
+++ b/infrastructure/test/problem-deploy/event-handler-shared.test.ts
@@ -1,0 +1,59 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { describe, expect, it, vi } from "vitest";
+import { queryDeploymentsByEvent } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+/**
+ * Issue #670: bulk-deploy が `jobId, teamId, problemId, #s` という projection で
+ * queryDeploymentsByEvent を呼び、 DDB が ExpressionAttributeNames に `#s` が
+ * 定義されていないため `Invalid ProjectionExpression` で 500 に潰れていた。
+ * helper 側で `#s` alias を自動定義することを pin。
+ */
+describe("queryDeploymentsByEvent (Issue #670)", () => {
+  const buildShared = (sendSpy: ReturnType<typeof vi.fn>) => ({
+    ddb: { send: sendSpy } as never,
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    eventBusName: "test-bus",
+    eventBridge: { send: vi.fn() } as never,
+    env: "development",
+    defaultTenantId: "tenant-acme",
+    problemsCatalog: {},
+  });
+
+  it("projection に `#s` が含まれるなら ExpressionAttributeNames で alias を提供すべき", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [] });
+    await queryDeploymentsByEvent(
+      buildShared(send),
+      "tenant-acme",
+      "evt-1",
+      "jobId, teamId, problemId, #s",
+    );
+    expect(send).toHaveBeenCalledOnce();
+    const cmd = send.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ProjectionExpression).toBe("jobId, teamId, problemId, #s");
+    expect(cmd.input.ExpressionAttributeNames).toEqual({ "#s": "status" });
+  });
+
+  it("projection に `#s` が無いなら ExpressionAttributeNames を提供しない (= 既存挙動互換)", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [] });
+    await queryDeploymentsByEvent(
+      buildShared(send),
+      "tenant-acme",
+      "evt-1",
+      "jobId, teamId, problemId",
+    );
+    const cmd = send.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ProjectionExpression).toBe("jobId, teamId, problemId");
+    expect(cmd.input.ExpressionAttributeNames).toBeUndefined();
+  });
+
+  it("projection 自体未指定なら ProjectionExpression を付けない", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [] });
+    await queryDeploymentsByEvent(buildShared(send), "tenant-acme", "evt-1");
+    const cmd = send.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ProjectionExpression).toBeUndefined();
+    expect(cmd.input.ExpressionAttributeNames).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Issue #670 (Event Deploy 500)

EventApi Lambda log:
\`\`\`
[events] bulkDeployEvent failed { eventId: ..., message:
  'Invalid ProjectionExpression: An expression attribute name used in the
   document path is not defined; attribute name: #s' }
\`\`\`

\`bulk-deploy.ts:128\` が \`queryDeploymentsByEvent\` に \`\"jobId, teamId, problemId, #s\"\` を ProjectionExpression として渡しているが、 helper が \`ExpressionAttributeNames\` で \`#s\` を定義していなかった (= \`status\` は DDB reserved word)。

**Fix**: helper 側で projection に \`#s\` が含まれれば自動で \`ExpressionAttributeNames: { \"#s\": \"status\" }\` を付与。

## Issue #672 (Portal 502)

participant-portal Lambda log:
\`\`\`
INIT_REPORT Init Duration: 1693.42 ms  Phase: init
  Status: error  Error Type: Runtime.OutOfMemory
\`\`\`

bundle 33.7MB に対して memorySize 256MB で cold start init OOM。

**Fix**: memorySize 256 → 512MB に拡張 (= 他 256MB Lambda の Max Memory Used 136MB で余裕、 portal は plugin SDK で saturate していた)。

## Closes

Closes #670
Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)