### PR TITLE
feat(#662,#663,#667): CompetitorAccounts modal — 1-click deploy + Copy + label clarification

### DIFF
--- a/apps/application-admin-console/src/components/CopyableField.tsx
+++ b/apps/application-admin-console/src/components/CopyableField.tsx
@@ -1,0 +1,37 @@
+import Button from "@cloudscape-design/components/button";
+import { useState } from "react";
+
+/**
+ * Issue #662: 1 line の value (= AccountId / ExternalId / RoleName 等) を
+ * 表示 + 1-click copy するための再利用 component。
+ * - Cloudscape の inline-icon button (📋) を value の右に置く
+ * - copy 後 2 秒 chip icon を ✓ に変えて feedback (= 競技者にコピー成功を視認)
+ */
+interface CopyableFieldProps {
+  readonly value: string;
+  readonly ariaLabel: string;
+  /** value 表示用の class (= long string は wordBreak: break-all 推奨) */
+  readonly valueClassName?: string;
+}
+
+export function CopyableField({ value, ariaLabel, valueClassName }: CopyableFieldProps) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <code className={valueClassName} style={{ wordBreak: "break-all", flex: 1 }}>
+        {value}
+      </code>
+      <Button
+        variant="inline-icon"
+        iconName={copied ? "status-positive" : "copy"}
+        ariaLabel={ariaLabel}
+        onClick={() => void onCopy()}
+      />
+    </div>
+  );
+}

--- a/apps/application-admin-console/src/lib/competitor-bootstrap.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.ts
@@ -1,0 +1,63 @@
+/**
+ * Issue #663: 競技者向け bootstrap CFn template の配信 helper。
+ * 競技者は本 repo に access できないため、 modal から:
+ *   - yaml を copy / download できる button を提供 (= 手動 deploy 経路)
+ *   - AWS CFn console の Quick-create URL を発行 (= 1 click deploy 経路)
+ *
+ * Launch Stack URL は public repo の raw.githubusercontent.com URL を templateURL に渡し、
+ * Parameter 3 つを query string で pre-fill する。 競技者は AWS SSO ログイン 1 回で deploy
+ * 確認画面に直行できる。
+ */
+
+const TEMPLATE_REPO = "susumutomita/TenkaCloud";
+const TEMPLATE_BRANCH = "main";
+const TEMPLATE_PATH = "infrastructure/templates/competitor-bootstrap.yaml";
+const DEFAULT_REGION = "ap-northeast-1";
+const DEFAULT_STACK_NAME = "tenkacloud-competitor-bootstrap";
+
+export const COMPETITOR_BOOTSTRAP_TEMPLATE_URL = `https://raw.githubusercontent.com/${TEMPLATE_REPO}/${TEMPLATE_BRANCH}/${TEMPLATE_PATH}`;
+
+export interface LaunchStackUrlInput {
+  readonly tenkaCloudAccountId: string;
+  readonly externalId: string;
+  readonly competitorRoleName: string;
+  readonly region?: string;
+}
+
+/**
+ * AWS CFn console の Quick-create deeplink を組み立てる。
+ * 競技者は click → SSO → 確認画面 で 1 stack 作成可能。
+ */
+export function buildLaunchStackUrl(input: LaunchStackUrlInput): string {
+  const region = input.region ?? DEFAULT_REGION;
+  const params = new URLSearchParams({
+    templateURL: COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
+    stackName: DEFAULT_STACK_NAME,
+    param_TenkaCloudAccountId: input.tenkaCloudAccountId,
+    param_ExternalId: input.externalId,
+    param_RoleName: input.competitorRoleName,
+  });
+  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/quickcreate?${params.toString()}`;
+}
+
+/**
+ * 「すべてコピー」 button が clipboard に書き込む 1 つの整形済 string。
+ * 競技者の作業手順 (= Slack / メールでそのまま送れる) を含む。
+ */
+export function buildShareablePayload(input: LaunchStackUrlInput): string {
+  return [
+    "TenkaCloud Competitor Bootstrap — お渡しする 3 値",
+    "",
+    `TenkaCloudAccountId: ${input.tenkaCloudAccountId}`,
+    `ExternalId:          ${input.externalId}`,
+    `RoleName:            ${input.competitorRoleName}`,
+    "",
+    "deploy 手順:",
+    `1. CFn テンプレ: ${COMPETITOR_BOOTSTRAP_TEMPLATE_URL}`,
+    "2. 競技者 AWS account にログインし、 上記 3 値を Parameter として CFn create-stack",
+    "3. Quick-create リンク (= 確認画面に pre-fill 済で直接遷移):",
+    `   ${buildLaunchStackUrl(input)}`,
+    "",
+    "完了後 operator にこの mail / msg を返信、 operator が「Verify」 で確認します。",
+  ].join("\n");
+}

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -22,7 +22,13 @@ import {
   rotateExternalId,
   verifyCompetitorAccount,
 } from "../api/competitor-accounts-client";
+import { CopyableField } from "../components/CopyableField";
 import type { AppConfig } from "../config";
+import {
+  buildLaunchStackUrl,
+  buildShareablePayload,
+  COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
+} from "../lib/competitor-bootstrap";
 import { computeRotationAge, ROTATION_AGE_WARNING_DAYS } from "../lib/rotation-age";
 
 const ACCOUNT_ID_RE = /^\d{12}$/;
@@ -455,7 +461,23 @@ interface SecretRevealModalProps {
 }
 
 function SecretRevealModal({ details, onDismiss }: SecretRevealModalProps) {
+  const [allCopied, setAllCopied] = useState(false);
   if (!details) return null;
+  const launchStackUrl = buildLaunchStackUrl({
+    tenkaCloudAccountId: details.tenkaCloudAccountId,
+    externalId: details.externalId,
+    competitorRoleName: details.competitorRoleName,
+  });
+  const payload = buildShareablePayload({
+    tenkaCloudAccountId: details.tenkaCloudAccountId,
+    externalId: details.externalId,
+    competitorRoleName: details.competitorRoleName,
+  });
+  const onCopyAll = async () => {
+    await navigator.clipboard.writeText(payload);
+    setAllCopied(true);
+    setTimeout(() => setAllCopied(false), 2000);
+  };
   return (
     <Modal
       visible
@@ -472,30 +494,69 @@ function SecretRevealModal({ details, onDismiss }: SecretRevealModalProps) {
       <SpaceBetween size="m">
         <Alert type="warning" header="この画面でのみ ExternalId を確認できます">
           ExternalId は SecureString として保存されており、閉じると再表示できません。
-          競技者に渡すコピーは **今** 取ってください。
+          競技者に渡すコピーは <strong>今</strong> 取ってください。
         </Alert>
+        <Box>
+          <Button
+            variant="primary"
+            iconName={allCopied ? "status-positive" : "copy"}
+            onClick={() => void onCopyAll()}
+          >
+            {allCopied ? "コピーしました" : "すべて (3 値 + 手順 + Launch Stack URL) をコピー"}
+          </Button>
+        </Box>
         <ColumnLayout columns={1} variant="text-grid">
           <div>
-            <Box variant="awsui-key-label">TenkaCloud Account ID</Box>
-            <code>{details.tenkaCloudAccountId}</code>
+            <Box variant="awsui-key-label">
+              TenkaCloud Account ID (= CFn Parameter <code>TenkaCloudAccountId</code>)
+            </Box>
+            <CopyableField
+              value={details.tenkaCloudAccountId}
+              ariaLabel="Copy TenkaCloudAccountId"
+            />
           </div>
           <div>
-            <Box variant="awsui-key-label">ExternalId</Box>
-            <code style={{ wordBreak: "break-all" }}>{details.externalId}</code>
+            <Box variant="awsui-key-label">
+              ExternalId (= CFn Parameter <code>ExternalId</code>)
+            </Box>
+            <CopyableField value={details.externalId} ariaLabel="Copy ExternalId" />
           </div>
           <div>
-            <Box variant="awsui-key-label">Competitor Role 名</Box>
-            <code>{details.competitorRoleName}</code>
+            <Box variant="awsui-key-label">
+              Competitor Role 名 (= CFn Parameter <code>RoleName</code>)
+            </Box>
+            <CopyableField value={details.competitorRoleName} ariaLabel="Copy RoleName" />
           </div>
           <div>
-            <Box variant="awsui-key-label">次のステップ</Box>
+            <Box variant="awsui-key-label">次のステップ — 競技者向け</Box>
             <ol>
               <li>
-                競技者が <code>infrastructure/templates/competitor-bootstrap.yaml</code> を 自分の
-                AWS account で 1 回 deploy する (上の値を Parameter として渡す)
+                上の「すべてコピー」 button で 3 値 + 手順を取得し Slack / メール等で競技者に送る
               </li>
               <li>
-                deploy 完了後、この画面の「Verify」 button で STS AssumeRole sanity check を行う
+                競技者は AWS CFn console で <strong>1 click deploy</strong>:
+                <br />
+                <Button href={launchStackUrl} target="_blank" iconName="external" iconAlign="right">
+                  Launch Stack (Quick-create deeplink)
+                </Button>
+                <br />
+                <Box variant="small" color="text-status-inactive">
+                  上の link は CFn create-stack 画面に直行し、 Parameter 3 値は pre-fill 済。
+                  競技者は SSO ログイン後 1 click で stack 作成可能。
+                </Box>
+              </li>
+              <li>
+                CFn template (= 競技者がレビューしたい場合):{" "}
+                <a
+                  href={COMPETITOR_BOOTSTRAP_TEMPLATE_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  competitor-bootstrap.yaml (raw)
+                </a>
+              </li>
+              <li>
+                deploy 完了後、 この画面の「Verify」 button で STS AssumeRole sanity check を行う
               </li>
               <li>verified=true になれば deploy 経路で利用可能になる</li>
             </ol>

--- a/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLaunchStackUrl,
+  buildShareablePayload,
+  COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
+} from "../../src/lib/competitor-bootstrap";
+
+describe("buildLaunchStackUrl", () => {
+  const baseInput = {
+    tenkaCloudAccountId: "123456789012",
+    externalId: "ext-abc-123",
+    competitorRoleName: "TenkaCloudCompetitorRole",
+  };
+
+  it("ap-northeast-1 を default region として CFn quickcreate URL を返すべき", () => {
+    const url = buildLaunchStackUrl(baseInput);
+    expect(url).toContain("https://ap-northeast-1.console.aws.amazon.com/cloudformation/home");
+    expect(url).toContain("#/stacks/quickcreate");
+  });
+
+  it("templateURL に public repo の raw URL が pre-fill されるべき", () => {
+    const url = buildLaunchStackUrl(baseInput);
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
+  });
+
+  it("Parameter 3 値が CFn pre-fill query string として埋め込まれるべき", () => {
+    const url = buildLaunchStackUrl(baseInput);
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain("param_TenkaCloudAccountId=123456789012");
+    expect(decoded).toContain("param_ExternalId=ext-abc-123");
+    expect(decoded).toContain("param_RoleName=TenkaCloudCompetitorRole");
+  });
+
+  it("region を上書きできるべき", () => {
+    const url = buildLaunchStackUrl({ ...baseInput, region: "us-east-1" });
+    expect(url).toContain("https://us-east-1.console.aws.amazon.com/");
+    expect(url).toContain("region=us-east-1");
+  });
+});
+
+describe("buildShareablePayload", () => {
+  const input = {
+    tenkaCloudAccountId: "123456789012",
+    externalId: "ext-abc-123",
+    competitorRoleName: "TenkaCloudCompetitorRole",
+  };
+
+  it("3 値すべてを含む shareable payload を返すべき", () => {
+    const payload = buildShareablePayload(input);
+    expect(payload).toContain("123456789012");
+    expect(payload).toContain("ext-abc-123");
+    expect(payload).toContain("TenkaCloudCompetitorRole");
+  });
+
+  it("CFn テンプレ raw URL と Quick-create URL の両方を含むべき", () => {
+    const payload = buildShareablePayload(input);
+    expect(payload).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
+    expect(payload).toContain("quickcreate");
+  });
+
+  it("競技者向けの手順テキストを含むべき", () => {
+    const payload = buildShareablePayload(input);
+    expect(payload).toContain("deploy 手順");
+    expect(payload).toContain("Verify");
+  });
+});
+
+describe("COMPETITOR_BOOTSTRAP_TEMPLATE_URL", () => {
+  it("public repo の raw URL を指すべき (= 競技者 access 可能)", () => {
+    expect(COMPETITOR_BOOTSTRAP_TEMPLATE_URL).toMatch(
+      /^https:\/\/raw\.githubusercontent\.com\/.+\/competitor-bootstrap\.yaml$/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

3 件の Issue を CompetitorAccounts modal 改善で 1 PR に bundle:

- **#662** — 3 値 (TenkaCloudAccountId / ExternalId / RoleName) に 1-click copy button + 「すべてコピー」 button
- **#663** — public repo raw URL を templateURL とする CFn quickcreate deeplink を "Launch Stack" button で発行 (= 競技者 SSO login 1 回で確認画面直行)
- **#667** — 各 label に CFn Parameter 名を併記 (例: `TenkaCloud Account ID (= CFn Parameter TenkaCloudAccountId)`)

## 設計

### `CopyableField` component (= 新設)

`apps/application-admin-console/src/components/CopyableField.tsx`

- Cloudscape `Button variant="inline-icon"` を value の右に置く
- copy 後 2 秒 ✓ chip に切り替えて feedback
- `navigator.clipboard.writeText()` を await して race condition を排除

### `competitor-bootstrap.ts` (= 新設 helper)

`apps/application-admin-console/src/lib/competitor-bootstrap.ts`

- `COMPETITOR_BOOTSTRAP_TEMPLATE_URL` — `raw.githubusercontent.com/<owner>/<repo>/main/infrastructure/templates/competitor-bootstrap.yaml`
- `buildLaunchStackUrl({ tenkaCloudAccountId, externalId, competitorRoleName, region? })` — CFn console quickcreate deeplink を pre-fill 済で組み立てる
- `buildShareablePayload(...)` — 3 値 + 手順 + URL を Slack / mail でそのまま送れる 1 string にまとめる

## Test plan

- [x] `apps/application-admin-console/test/lib/competitor-bootstrap.test.ts` で 8 tests pass
- [x] `make before-commit` (lint + typecheck + test + validate-problems + check-template-ascii + audit-deps + check-synth) all green
- [ ] modal を実際に開いて 3 つの CopyableField で clipboard 動作確認
- [ ] 「すべてコピー」 button が 3 値 + 手順を含む string を clipboard に書く
- [ ] "Launch Stack" button → AWS CFn console quickcreate 画面で Parameter が pre-fill 済になる

## Regression 分析

- 既存 modal は同じ 3 値を同じ場所に表示し続ける (= UI 後退なし)
- `CopyableField` は inline component で keyboard navigation / screen reader 経路を破壊しない
- "Launch Stack" は新規 button、 既存の "Verify" / "Delete" 経路には影響なし
- helper module は static const のみ export、 副作用なし

## 物理影響

- CREATE: `apps/application-admin-console/src/lib/competitor-bootstrap.ts`
- CREATE: `apps/application-admin-console/src/components/CopyableField.tsx`
- CREATE: `apps/application-admin-console/test/lib/competitor-bootstrap.test.ts` (= 8 tests)
- UPDATE: `apps/application-admin-console/src/pages/CompetitorAccounts.tsx` (modal body のみ)
- NO-OP: infra / CFn / bundle 出力には影響なし (= frontend SPA のみ)

Closes #662
Closes #663
Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)