### PR TITLE
fix(#665): Verify エラー UX を raw JSON から人間可読に整形

### DIFF
--- a/apps/application-admin-console/src/components/FriendlyErrorAlert.tsx
+++ b/apps/application-admin-console/src/components/FriendlyErrorAlert.tsx
@@ -15,6 +15,7 @@ export function FriendlyErrorAlert({ error }: { readonly error: FriendlyError })
           <Box variant="strong">考えられる原因:</Box>
           <ul style={{ marginTop: 4, marginBottom: 0, paddingLeft: 22 }}>
             {error.possibleCauses.map((cause) => (
+              // KNOWN_ERRORS は static const で cause text は問題ごとに unique なため key=text で安全
               <li key={cause}>{cause}</li>
             ))}
           </ul>

--- a/apps/application-admin-console/src/components/FriendlyErrorAlert.tsx
+++ b/apps/application-admin-console/src/components/FriendlyErrorAlert.tsx
@@ -1,0 +1,25 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import type { FriendlyError } from "../lib/friendly-error";
+
+/**
+ * Issue #665: backend error を人間可読に表示する Alert。
+ * title + hint + 原因候補 list を構造化して表示し、 raw JSON は出さない。
+ */
+export function FriendlyErrorAlert({ error }: { readonly error: FriendlyError }) {
+  return (
+    <Alert type="error" header={error.title}>
+      {error.hint ? <Box variant="p">{error.hint}</Box> : null}
+      {error.possibleCauses && error.possibleCauses.length > 0 ? (
+        <Box variant="div" padding={{ top: "xs" }}>
+          <Box variant="strong">考えられる原因:</Box>
+          <ul style={{ marginTop: 4, marginBottom: 0, paddingLeft: 22 }}>
+            {error.possibleCauses.map((cause) => (
+              <li key={cause}>{cause}</li>
+            ))}
+          </ul>
+        </Box>
+      ) : null}
+    </Alert>
+  );
+}

--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -1,0 +1,133 @@
+import { ApiError } from "../api/client";
+
+/**
+ * Issue #665: backend が返す `{ error: <code>, ... }` JSON を 人間可読に変換する helper。
+ *
+ * 旧来 `${err.status}: API ${status}: { "error": "assume_role_failed", ... }` のような
+ * 二重 prefix + raw JSON が UI に出ていた。本 module は ApiError のメッセージから
+ * error code を取り出し、 専用 mapping から日本語 message + 原因候補を返す。
+ *
+ * 既知の code が無い場合は、 raw JSON を読みやすい形に整形した generic fallback を返す。
+ */
+
+export interface FriendlyError {
+  readonly title: string;
+  readonly hint?: string;
+  readonly possibleCauses?: readonly string[];
+  /** 元の raw body (= 開発者用、 details として表示) */
+  readonly raw?: string;
+}
+
+interface BackendErrorEnvelope {
+  readonly error?: unknown;
+  readonly message?: unknown;
+  readonly underlyingErrorName?: unknown;
+  readonly detail?: unknown;
+}
+
+const ASSUME_ROLE_FAILED: FriendlyError = {
+  title: "AssumeRole に失敗しました (AccessDenied)",
+  hint: "TenkaCloud 側から競技者 account への STS AssumeRole が AWS に拒否されました",
+  possibleCauses: [
+    "ExternalId 値が異なる (rotate 後の伝達漏れの可能性)",
+    "Role 名が異なる (= 競技者が default 以外を選んだ)",
+    "competitor-bootstrap.yaml が deploy 未完了 / 削除済",
+    "Trust policy の Principal が TenkaCloud account ID と一致しない",
+  ],
+};
+
+const KNOWN_ERRORS: Readonly<Record<string, FriendlyError>> = {
+  assume_role_failed: ASSUME_ROLE_FAILED,
+  role_not_found: {
+    title: "競技者アカウントの IAM Role が見つかりません",
+    hint: "指定した Role 名が、 競技者の AWS account に存在しません",
+    possibleCauses: [
+      "competitor-bootstrap.yaml が deploy されていない",
+      "Role 名の入力が間違っている (= default `TenkaCloud-CompetitorDeploy-Role` か確認)",
+      "競技者が手動で Role を削除した",
+    ],
+  },
+  external_id_mismatch: {
+    title: "ExternalId の照合に失敗しました",
+    hint: "TenkaCloud が送信した ExternalId と、 競技者 Role の Trust policy が一致しません",
+    possibleCauses: [
+      "Rotate ExternalId 後、 競技者が新しい値で stack を update していない",
+      "管理者画面に表示された ExternalId を競技者にコピー漏れ",
+    ],
+  },
+  invalid_account_id: {
+    title: "AWS Account ID の形式が不正です",
+    hint: "12 桁の数値である必要があります",
+  },
+  duplicate_account: {
+    title: "この AWS Account ID は既に登録済です",
+    hint: "重複する Competitor Account は登録できません",
+  },
+  not_found: {
+    title: "対象が見つかりません",
+    hint: "他の operator が削除した可能性があります。 一覧を再読み込みしてください",
+  },
+};
+
+/**
+ * `{ "error": "assume_role_failed", "underlyingErrorName": "AccessDenied" }` のような
+ * backend response の raw body から error code を抽出する。
+ *
+ * ApiError.message は `"API 422: <raw body>"` 形式なので、 まず raw body を切り出してから
+ * JSON.parse を試みる。parse 失敗時は undefined を返し caller 側で fallback する。
+ */
+function extractBackendEnvelope(rawMessage: string): BackendErrorEnvelope | null {
+  let body = rawMessage;
+  while (true) {
+    const m = body.match(/^API \d+:\s*(.*)$/s);
+    if (!m) break;
+    body = m[1];
+  }
+  if (!body.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (parsed && typeof parsed === "object") {
+      return parsed as BackendErrorEnvelope;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function extractErrorCode(envelope: BackendErrorEnvelope): string | null {
+  const code = envelope.error;
+  return typeof code === "string" ? code : null;
+}
+
+/**
+ * `ApiError` や Error / unknown を `FriendlyError` に変換する。
+ *
+ * - 既知の backend error code は専用 mapping を返す
+ * - 未知の code でも、 raw JSON は drop して title だけ表示
+ * - HTTP status code は title に併記 (= 422 / 500 / 等を operator が判別可能に)
+ */
+export function toFriendlyError(err: unknown): FriendlyError {
+  if (err instanceof ApiError) {
+    const envelope = extractBackendEnvelope(err.message);
+    if (envelope) {
+      const code = extractErrorCode(envelope);
+      if (code && KNOWN_ERRORS[code]) {
+        return KNOWN_ERRORS[code];
+      }
+      const codeOrMsg = code ?? (typeof envelope.message === "string" ? envelope.message : null);
+      return {
+        title: codeOrMsg ? `エラー (${err.status}) — ${codeOrMsg}` : `エラー (${err.status})`,
+        hint: typeof envelope.message === "string" ? envelope.message : undefined,
+      };
+    }
+    return {
+      title: `エラー (${err.status})`,
+      hint: err.message.replace(/^API \d+:\s*/, "").trim() || undefined,
+    };
+  }
+  if (err instanceof Error) {
+    return { title: err.message };
+  }
+  return { title: String(err) };
+}

--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -14,8 +14,6 @@ export interface FriendlyError {
   readonly title: string;
   readonly hint?: string;
   readonly possibleCauses?: readonly string[];
-  /** 元の raw body (= 開発者用、 details として表示) */
-  readonly raw?: string;
 }
 
 interface BackendErrorEnvelope {
@@ -115,10 +113,13 @@ export function toFriendlyError(err: unknown): FriendlyError {
       if (code && KNOWN_ERRORS[code]) {
         return KNOWN_ERRORS[code];
       }
-      const codeOrMsg = code ?? (typeof envelope.message === "string" ? envelope.message : null);
+      // title に code (or message) を併記、 hint には message が code と異なる時のみ詰める
+      // (= title と hint で同じ文字列を表示しないため)。
+      const msg = typeof envelope.message === "string" ? envelope.message : undefined;
+      const codeOrMsg = code ?? msg;
       return {
         title: codeOrMsg ? `エラー (${err.status}) — ${codeOrMsg}` : `エラー (${err.status})`,
-        hint: typeof envelope.message === "string" ? envelope.message : undefined,
+        hint: code && msg ? msg : undefined,
       };
     }
     return {

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -11,7 +11,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ApiError, useApiClient } from "../api/client";
+import { useApiClient } from "../api/client";
 import {
   type CompetitorAccountSummary,
   type CreateCompetitorAccountResponse,
@@ -23,12 +23,14 @@ import {
   verifyCompetitorAccount,
 } from "../api/competitor-accounts-client";
 import { CopyableField } from "../components/CopyableField";
+import { FriendlyErrorAlert } from "../components/FriendlyErrorAlert";
 import type { AppConfig } from "../config";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
 } from "../lib/competitor-bootstrap";
+import { type FriendlyError, toFriendlyError } from "../lib/friendly-error";
 import { computeRotationAge, ROTATION_AGE_WARNING_DAYS } from "../lib/rotation-age";
 
 const ACCOUNT_ID_RE = /^\d{12}$/;
@@ -46,7 +48,7 @@ const ALIAS_MAX = 120;
 export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
   const [items, setItems] = useState<readonly CompetitorAccountSummary[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<FriendlyError | null>(null);
   const [addModalVisible, setAddModalVisible] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CompetitorAccountSummary | null>(null);
   const [rotateTarget, setRotateTarget] = useState<CompetitorAccountSummary | null>(null);
@@ -64,7 +66,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
       setItems(res.items);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(toFriendlyError(err));
     }
   }, [apiClient]);
 
@@ -80,8 +82,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         await verifyCompetitorAccount(apiClient, awsAccountId);
         await reload();
       } catch (err) {
-        const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
-        setError(message);
+        setError(toFriendlyError(err));
       } finally {
         setVerifyInFlight(null);
       }
@@ -97,8 +98,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
       setDeleteTarget(null);
       await reload();
     } catch (err) {
-      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
-      setError(message);
+      setError(toFriendlyError(err));
     } finally {
       setDeleteInFlight(false);
     }
@@ -113,8 +113,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
       setShowSecret(res);
       await reload();
     } catch (err) {
-      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
-      setError(message);
+      setError(toFriendlyError(err));
     } finally {
       setRotateInFlight(false);
     }
@@ -214,11 +213,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         Competitor Accounts
       </Header>
 
-      {error && (
-        <Alert type="error" header="エラー">
-          {error}
-        </Alert>
-      )}
+      {error && <FriendlyErrorAlert error={error} />}
 
       <Table
         items={items ?? []}
@@ -344,7 +339,7 @@ function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountMo
   const [region, setRegion] = useState("ap-northeast-1");
   const [competitorRoleName, setCompetitorRoleName] = useState("TenkaCloud-CompetitorDeploy-Role");
   const [inFlight, setInFlight] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<FriendlyError | null>(null);
 
   const reset = () => {
     setAwsAccountId("");
@@ -379,8 +374,7 @@ function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountMo
       reset();
       onSuccess(res);
     } catch (err) {
-      const message = err instanceof ApiError ? `${err.status}: ${err.message}` : String(err);
-      setError(message);
+      setError(toFriendlyError(err));
     } finally {
       setInFlight(false);
     }
@@ -410,11 +404,7 @@ function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountMo
       }
     >
       <SpaceBetween size="m">
-        {error && (
-          <Alert type="error" header="登録に失敗しました">
-            {error}
-          </Alert>
-        )}
+        {error && <FriendlyErrorAlert error={error} />}
         <FormField
           label="AWS Account ID"
           description="12 桁の数字"

--- a/apps/application-admin-console/test/lib/friendly-error.test.ts
+++ b/apps/application-admin-console/test/lib/friendly-error.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../../src/api/client";
+import { toFriendlyError } from "../../src/lib/friendly-error";
+
+describe("toFriendlyError", () => {
+  it("既知の backend error code (assume_role_failed) を日本語タイトル + 原因候補に展開すべき", () => {
+    const err = new ApiError(
+      422,
+      '{"error":"assume_role_failed","underlyingErrorName":"AccessDenied"}',
+    );
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/AssumeRole/);
+    expect(fe.possibleCauses).toBeDefined();
+    expect(fe.possibleCauses?.length).toBeGreaterThan(0);
+  });
+
+  it("既知 code (role_not_found) も mapping を引くべき", () => {
+    const err = new ApiError(404, '{"error":"role_not_found"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/IAM Role/);
+  });
+
+  it("未知の error code は title に status code を含み、 raw JSON を出さないべき", () => {
+    const err = new ApiError(500, '{"error":"unknown_thing","message":"boom"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toContain("500");
+    expect(fe.title).not.toContain("{");
+    expect(fe.title).not.toContain('"error"');
+  });
+
+  it("body が `API 422: ...` 形 (= upstream で既に prefix されていた regression case) でも解析できるべき", () => {
+    const err = new ApiError(422, 'API 422: {"error":"assume_role_failed"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/AssumeRole/);
+  });
+
+  it("backend が text のみ返した場合は raw text を hint に置くべき (= JSON でも error key も無い)", () => {
+    const err = new ApiError(500, "Internal Server Error");
+    const fe = toFriendlyError(err);
+    expect(fe.title).toContain("500");
+    expect(fe.hint).toBe("Internal Server Error");
+  });
+
+  it("ApiError 以外の Error は message のみを title にすべき", () => {
+    const fe = toFriendlyError(new Error("Network down"));
+    expect(fe.title).toBe("Network down");
+    expect(fe.possibleCauses).toBeUndefined();
+  });
+
+  it("string 等の non-Error も toString して title にすべき", () => {
+    const fe = toFriendlyError("plain string");
+    expect(fe.title).toBe("plain string");
+  });
+});


### PR DESCRIPTION
## Summary

CompetitorAccounts の 4 操作 (Verify / Add / Rotate / Delete) が失敗した時、 backend の `{ error: \"assume_role_failed\", ... }` JSON が `422: API 422: {...}` の二重 prefix + raw JSON で表示されていた。 error code → 日本語タイトル + 原因候補 mapping を入れて構造化済 Alert で表示する。

## Test plan

- [x] `bunx vitest run test/lib/friendly-error.test.ts` (= 7 tests pass)
- [x] `make before-commit` all green
- [ ] mock backend: `422 {error:\"assume_role_failed\"}` → \"AssumeRole に失敗しました\" + 4 原因候補 list が出る
- [ ] mock backend: `500 {error:\"unknown_xxx\"}` → \"エラー (500) — unknown_xxx\" のみ、 raw JSON は出ない

## Regression 分析

- backend error code (= `assume_role_failed` 等) は変えない、 frontend 表示層のみ
- Alert import は残置 (= warning alert 2 箇所がまだ Alert を使う)
- 二重 prefix `API 422: API 422: {...}` も loop で剥がす (regression case)

## 物理影響

- CREATE: `apps/application-admin-console/src/lib/friendly-error.ts`
- CREATE: `apps/application-admin-console/src/components/FriendlyErrorAlert.tsx`
- CREATE: `apps/application-admin-console/test/lib/friendly-error.test.ts` (= 7 tests)
- UPDATE: `apps/application-admin-console/src/pages/CompetitorAccounts.tsx`
- NO-OP: backend / infra / CFn (= frontend SPA のみ)

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling with user-friendly alert components that display error titles, contextual hints, and possible causes.
  * Improved error messages for backend failures with Japanese language support and clearer guidance for users.

* **Tests**
  * Added comprehensive test coverage for error message conversion and handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/676)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->