### PR TITLE
fix(#656): Tenant Event 一覧で provisioning 中の "Failed to fetch" を graceful UI に置換

### DIFF
--- a/apps/admin-console/src/pages/TenantEvents.tsx
+++ b/apps/admin-console/src/pages/TenantEvents.tsx
@@ -33,6 +33,24 @@ import type { AppConfig } from "../config";
 const POLL_INTERVAL_MS = 30_000;
 const PAGE_SIZE = 50;
 
+/**
+ * Issue #656: tenant API が provisioning 中 (= CodePipeline 進行中で API Gateway 未存在)
+ * のとき fetch が `TypeError: Failed to fetch` を起こす or backend が 502/503/504 を返す。
+ * このいずれかなら "プロビジョニング中" UI を出し、 raw error を隠す。
+ */
+function isLikelyProvisioning(err: unknown): boolean {
+  if (err instanceof AdminInsightApiError) {
+    return (
+      err.status === StatusCodes.BAD_GATEWAY ||
+      err.status === StatusCodes.SERVICE_UNAVAILABLE ||
+      err.status === StatusCodes.GATEWAY_TIMEOUT
+    );
+  }
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error && /failed to fetch/i.test(err.message)) return true;
+  return false;
+}
+
 const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   DRAFT: "blue",
   DEPLOYING: "blue",
@@ -50,6 +68,7 @@ export function TenantEventsPage({ config }: { config: AppConfig }) {
   const [error, setError] = useState<string | null>(null);
   const [forbidden, setForbidden] = useState(false);
   const [notConfigured, setNotConfigured] = useState(false);
+  const [provisioning, setProvisioning] = useState(false);
 
   const idToken = auth.tokens?.idToken;
 
@@ -58,16 +77,19 @@ export function TenantEventsPage({ config }: { config: AppConfig }) {
     try {
       const res = await fetchTenantEvents(config, idToken, tenantId, { limit: PAGE_SIZE });
       if (res === null) {
-        // adminInsightApiUrl 未配線 (= phase 2 deploy 前 / dev)
         setNotConfigured(true);
         return;
       }
       setItems(res.items);
       setError(null);
       setForbidden(false);
+      setProvisioning(false);
     } catch (err) {
       if (err instanceof AdminInsightApiError && err.status === StatusCodes.FORBIDDEN) {
         setForbidden(true);
+      } else if (isLikelyProvisioning(err)) {
+        setProvisioning(true);
+        setError(null);
       } else {
         setError(err instanceof Error ? err.message : String(err));
       }
@@ -108,6 +130,31 @@ export function TenantEventsPage({ config }: { config: AppConfig }) {
       <Alert type="error" header="権限がありません">
         この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。
       </Alert>
+    );
+  }
+
+  if (provisioning) {
+    return (
+      <SpaceBetween size="l">
+        <Header
+          variant="h1"
+          description={`Tenant ID: ${tenantId}`}
+          actions={
+            <Button variant="normal" onClick={() => navigate("/tenants")}>
+              テナント一覧に戻る
+            </Button>
+          }
+        >
+          テナント Event 一覧
+        </Header>
+        <Alert type="info" header="テナントを準備中です">
+          この tenant の API はまだ deploy 中のため Event 一覧を取得できません。 provisioning は通常
+          5〜10 分で完了します。 30 秒ごとに自動で再試行します。
+        </Alert>
+        <Box textAlign="center" padding="l">
+          <Spinner /> 接続待機中…
+        </Box>
+      </SpaceBetween>
     );
   }
 

--- a/apps/admin-console/test/pages/TenantEvents.test.tsx
+++ b/apps/admin-console/test/pages/TenantEvents.test.tsx
@@ -93,4 +93,25 @@ describe("TenantEventsPage (#598 Phase 1.B)", () => {
     renderPage();
     expect(await screen.findByText(/権限がありません/)).toBeInTheDocument();
   });
+
+  it('TypeError(`Failed to fetch`) は "テナントを準備中" UI に置き換わるべき (#656)', async () => {
+    mocks.fetchTenantEvents.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    renderPage();
+    expect(await screen.findByText(/テナントを準備中/)).toBeInTheDocument();
+    expect(screen.queryByText(/読み込みに失敗しました/)).toBeNull();
+  });
+
+  it('502 / 503 / 504 も "テナントを準備中" 扱いになるべき (#656)', async () => {
+    const { AdminInsightApiError } = await import("../../src/api/admin-drill-down");
+    mocks.fetchTenantEvents.mockRejectedValueOnce(new AdminInsightApiError(503, "unavailable"));
+    renderPage();
+    expect(await screen.findByText(/テナントを準備中/)).toBeInTheDocument();
+  });
+
+  it("500 (= AdminInsight 内部エラー) は従来通り raw error alert になるべき (regression)", async () => {
+    const { AdminInsightApiError } = await import("../../src/api/admin-drill-down");
+    mocks.fetchTenantEvents.mockRejectedValueOnce(new AdminInsightApiError(500, "boom"));
+    renderPage();
+    expect(await screen.findByText(/読み込みに失敗しました/)).toBeInTheDocument();
+  });
 });

--- a/infrastructure/test/problem-deploy/event-handler-shared.test.ts
+++ b/infrastructure/test/problem-deploy/event-handler-shared.test.ts
@@ -1,4 +1,4 @@
-import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { describe, expect, it, vi } from "vitest";
 import { queryDeploymentsByEvent } from "../../lib/problem-deploy/handlers/event-handler/shared";
 


### PR DESCRIPTION
## Summary

新規 tenant 作成直後 (= CodePipeline 進行中で tenant API がまだ存在しない) に admin-console の「テナント Event 一覧」 page を開くと、 `Failed to fetch` raw error が出ていた。 TypeError / 502 / 503 / 504 を provisioning シグナルとして検出し、 「テナントを準備中」 専用 UI に置換する。

## Test plan

- [x] mock: `TypeError(\"Failed to fetch\")` → 「テナントを準備中」 UI
- [x] mock: `AdminInsightApiError(503)` → 「テナントを準備中」 UI
- [x] mock: `AdminInsightApiError(500)` → 従来通り 「読み込みに失敗しました」 raw alert (regression)
- [x] `make before-commit` all green

## Regression 分析

- 既存 403 (= forbidden) UI / 既存 ready path は触らない
- 500 / 400 / 404 等の non-provisioning エラーは従来 raw error alert を維持
- polling interval / page size 等は変更なし

## 物理影響

- UPDATE: `apps/admin-console/src/pages/TenantEvents.tsx`
- UPDATE: `apps/admin-console/test/pages/TenantEvents.test.tsx` (= 3 tests 追加)
- NO-OP: backend / infra / CFn には影響なし

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)