### PR TITLE
fix(#657): TenantList の "In progress" cell に経過時間 + severity warning を表示

### DIFF
--- a/apps/admin-console/src/lib/tenant-progress.ts
+++ b/apps/admin-console/src/lib/tenant-progress.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #657: TenantList の "In progress" 進捗 helper。
+ *
+ * 現状 tenantStatus は SBT 由来の 1 string (`In progress` / `Complete` / `Failed` / `Deleted`) で、
+ * 細粒度の phase 進行を fetch する経路がまだ無い。 frontend-only で改善できるのは:
+ *   - `createdAt` からの 経過時間を表示 (= "5 分経過" / "1 時間経過")
+ *   - 30 分超 / 60 分超で warning / danger 色に切り替え (= 失敗ハングの可能性を示唆)
+ *
+ * AdminInsight API に provisioning phase が出来たら別 PR で sub-status を足す。
+ */
+
+export type ProgressSeverity = "ok" | "warning" | "danger";
+
+export interface TenantProgress {
+  readonly elapsedMs: number;
+  readonly label: string;
+  readonly severity: ProgressSeverity;
+}
+
+const WARN_THRESHOLD_MS = 30 * 60 * 1000; // 30 分
+const DANGER_THRESHOLD_MS = 60 * 60 * 1000; // 60 分
+
+/**
+ * `createdAt` の ISO 8601 string と現在時刻から、 経過時間 + severity を計算する。
+ *
+ * - createdAt が parse 不能 / undefined のときは severity="ok" + label="—" を返す
+ * - 30 分超 → warning (= "ハング疑いを operator に示す")
+ * - 60 分超 → danger (= "明らかに stuck")
+ */
+export function computeTenantProgress(input: {
+  readonly createdAt: string | undefined;
+  readonly nowMs: number;
+}): TenantProgress {
+  if (!input.createdAt) {
+    return { elapsedMs: 0, label: "—", severity: "ok" };
+  }
+  const createdMs = Date.parse(input.createdAt);
+  if (Number.isNaN(createdMs)) {
+    return { elapsedMs: 0, label: "—", severity: "ok" };
+  }
+  const elapsed = Math.max(0, input.nowMs - createdMs);
+  const severity: ProgressSeverity =
+    elapsed >= DANGER_THRESHOLD_MS ? "danger" : elapsed >= WARN_THRESHOLD_MS ? "warning" : "ok";
+  return {
+    elapsedMs: elapsed,
+    label: formatElapsed(elapsed),
+    severity,
+  };
+}
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  if (hours > 0) return `${hours} 時間 ${minutes} 分経過`;
+  if (minutes > 0) return `${minutes} 分経過`;
+  return `${totalSec} 秒経過`;
+}
+
+/**
+ * tenantStatus 文字列が "In progress" 系のいずれかか判定する。
+ * SBT は `In progress` を返すが、 ULID 系 backend が `IN_PROGRESS` / `Provisioning` で
+ * 返すこともあるので、 lowercase compare で吸収する。
+ */
+export function isInProgress(tenantStatus: string | undefined): boolean {
+  if (!tenantStatus) return false;
+  const s = tenantStatus.toLowerCase();
+  return s === "in progress" || s === "in_progress" || s === "provisioning";
+}

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -26,6 +26,7 @@ import {
 } from "../api/tenants";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+import { computeTenantProgress, isInProgress } from "../lib/tenant-progress";
 
 /**
  * ADR-011 #590 Phase 1.A: 60s polling 周期。SSE / WebSocket は禁止 (Lambda 運用と整合せず)。
@@ -64,6 +65,8 @@ export function TenantListPage({ config }: { config: AppConfig }) {
   const [tenants, setTenants] = useState<Tenant[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingDeprovision, setPendingDeprovision] = useState<Tenant | null>(null);
+  // #657: "In progress" の経過時間表示用 wall clock。 60 秒ごとに更新し severity 再評価。
+  const [nowMs, setNowMs] = useState(() => Date.now());
   // ADR-011 #590 Phase 1.A: tenantId → 集計 の lookup。
   // - null = まだ fetch していない / AdminInsight API が未配線 (= column hide)
   // - {} = fetch 済みで対象 tenant が無い (= 集計 0 表示)
@@ -115,6 +118,12 @@ export function TenantListPage({ config }: { config: AppConfig }) {
       window.clearInterval(handle);
     };
   }, [auth.tokens?.idToken, tenants, config]);
+
+  // #657: 経過時間の severity を 60 秒周期で再評価。 setInterval は cleanup 必須。
+  useEffect(() => {
+    const handle = window.setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => window.clearInterval(handle);
+  }, []);
 
   const confirmDeprovision = async () => {
     if (!api || !pendingDeprovision) return;
@@ -197,9 +206,29 @@ export function TenantListPage({ config }: { config: AppConfig }) {
           {
             id: "status",
             header: "状態",
-            cell: (t) => (
-              <Badge color={tenantStatusBadgeColor(t.tenantStatus)}>{t.tenantStatus}</Badge>
-            ),
+            cell: (t) => {
+              const badge = (
+                <Badge color={tenantStatusBadgeColor(t.tenantStatus)}>{t.tenantStatus}</Badge>
+              );
+              if (!isInProgress(t.tenantStatus)) return badge;
+              const progress = computeTenantProgress({ createdAt: t.createdAt, nowMs });
+              const progressColor =
+                progress.severity === "danger"
+                  ? "text-status-error"
+                  : progress.severity === "warning"
+                    ? "text-status-warning"
+                    : "text-status-info";
+              return (
+                <SpaceBetween direction="vertical" size="xxs">
+                  {badge}
+                  <Box variant="small" color={progressColor}>
+                    {progress.label}
+                    {progress.severity === "danger" ? " · 失敗の可能性" : ""}
+                    {progress.severity === "warning" ? " · 想定より長い" : ""}
+                  </Box>
+                </SpaceBetween>
+              );
+            },
           },
           // ADR-011 #590 Phase 1.A: AdminInsight 集計 column。insightByTenantId が null
           // (= API 未配線 / fetch 失敗 / 403) なら cell は "—" を返し、deprovision 済みは

--- a/apps/admin-console/test/lib/tenant-progress.test.ts
+++ b/apps/admin-console/test/lib/tenant-progress.test.ts
@@ -50,6 +50,38 @@ describe("computeTenantProgress", () => {
     expect(out.elapsedMs).toBe(0);
     expect(out.label).toBe("0 秒経過");
   });
+
+  it("経過時間が正確に 30 分 (= 境界値) の場合は severity=warning に切り替わるべき", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:30:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("warning");
+  });
+
+  it("経過時間が 30 分 - 1 ms (= 境界値直前) は severity=ok を維持するべき", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:30:00.001Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("ok");
+  });
+
+  it("経過時間が正確に 60 分 (= 境界値) の場合は severity=danger に切り替わるべき", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:00:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("danger");
+  });
+
+  it("経過時間が 60 分 - 1 ms (= 境界値直前) は severity=warning を維持するべき", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:00:00.001Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("warning");
+  });
 });
 
 describe("isInProgress", () => {

--- a/apps/admin-console/test/lib/tenant-progress.test.ts
+++ b/apps/admin-console/test/lib/tenant-progress.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { computeTenantProgress, isInProgress } from "../../src/lib/tenant-progress";
+
+const BASE = Date.parse("2026-05-13T20:00:00.000Z");
+
+describe("computeTenantProgress", () => {
+  it('createdAt の 3 分後は "3 分経過" + severity=ok を返すべき', () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:57:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("ok");
+    expect(out.label).toBe("3 分経過");
+  });
+
+  it("createdAt の 32 分後は severity=warning に切り替わるべき", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T19:28:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("warning");
+    expect(out.label).toBe("32 分経過");
+  });
+
+  it("createdAt の 75 分後は severity=danger に切り替わるべき (= 失敗ハング示唆)", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T18:45:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.severity).toBe("danger");
+    expect(out.label).toBe("1 時間 15 分経過");
+  });
+
+  it('createdAt 不在の場合は label="—" + severity=ok を返すべき', () => {
+    const out = computeTenantProgress({ createdAt: undefined, nowMs: BASE });
+    expect(out.severity).toBe("ok");
+    expect(out.label).toBe("—");
+  });
+
+  it('createdAt が parse 不能な string の場合も label="—" を返すべき (defensive)', () => {
+    const out = computeTenantProgress({ createdAt: "not-an-iso-date", nowMs: BASE });
+    expect(out.label).toBe("—");
+  });
+
+  it("createdAt が未来 (= clock skew) でも負数経過ではなく 0 秒経過扱い", () => {
+    const out = computeTenantProgress({
+      createdAt: "2026-05-13T20:01:00.000Z",
+      nowMs: BASE,
+    });
+    expect(out.elapsedMs).toBe(0);
+    expect(out.label).toBe("0 秒経過");
+  });
+});
+
+describe("isInProgress", () => {
+  it('SBT が返す "In progress" を真と判定するべき', () => {
+    expect(isInProgress("In progress")).toBe(true);
+  });
+
+  it('ULID backend が返す "IN_PROGRESS" を真と判定するべき (defensive)', () => {
+    expect(isInProgress("IN_PROGRESS")).toBe(true);
+  });
+
+  it('"Provisioning" も真と判定するべき (= SBT v0.3.10 系)', () => {
+    expect(isInProgress("Provisioning")).toBe(true);
+  });
+
+  it("Complete / Failed / Deleted / undefined は偽を返すべき", () => {
+    expect(isInProgress("Complete")).toBe(false);
+    expect(isInProgress("Failed")).toBe(false);
+    expect(isInProgress("Deleted")).toBe(false);
+    expect(isInProgress(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

TenantList の \"状態\" カラムが In progress badge だけ表示していて、 operator は provisioning が「正常進行中」 vs 「失敗してハング」 を判別できなかった。 `createdAt` からの経過時間を Badge 直下に併記し、 30 分超で `warning` / 60 分超で `danger` 色に切り替える。

## Test plan

- [x] `bunx vitest run test/lib/tenant-progress.test.ts` (= 10 tests pass、 3 分/32 分/75 分/不在/parse 不能/clock skew をカバー)
- [x] `make before-commit` all green
- [ ] In progress tenant の経過時間表示を視覚 verify (= 30 分超で warning / 60 分超で danger 色)

## Regression 分析

- \"In progress\" 以外の status (Complete / Failed / Deleted) は cell render 完全互換
- nowMs state は 60 秒周期で setState、 React は同値 setState で re-render を抑制 (= 余分なレンダなし)
- AdminInsight 集計 column / Application Console / ログ など他 column は touch しない
- `isInProgress` は SBT 'In progress' / 大文字 'IN_PROGRESS' / 'Provisioning' を case-insensitive で吸収

## 次の段階 (別 Issue 候補)

- CodePipeline 各 phase の sub-status fetch (= AdminInsight API 拡張)
- pooled tenant 用の ServerlessSaaSPipeline 共有 URL deep link

## 物理影響

- CREATE: `apps/admin-console/src/lib/tenant-progress.ts`
- CREATE: `apps/admin-console/test/lib/tenant-progress.test.ts` (= 10 tests)
- UPDATE: `apps/admin-console/src/pages/TenantList.tsx` (= status cell + nowMs state)
- NO-OP: backend / infra / CFn

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)