### PR TITLE
feat(#659): TenantStatusReconciler で "In progress" stuck の自動遷移

### DIFF
--- a/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
+++ b/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
@@ -12,6 +12,7 @@ import { EventBus } from "aws-cdk-lib/aws-events";
 import { PolicyDocument } from "aws-cdk-lib/aws-iam";
 import type { Construct } from "constructs";
 import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
+import { TenantStatusReconciler } from "../tenant-status-reconciler/tenant-status-reconciler";
 import { TenantApiKey } from "./tenant-api-key";
 
 interface BootstrapTemplateStackProps extends StackProps {
@@ -172,6 +173,13 @@ export class BootstrapTemplateStack extends Stack {
       apiKeyValue: props.apiKeyPlatinumTierParameter,
       ssmParameterApiKeyIdName: props.apiKeySSMParameterNames.platinum.keyId,
       ssmParameterApiValueName: props.apiKeySSMParameterNames.platinum.value,
+    });
+
+    // Issue #659: 2 分周期で TenantMappingTable を scan し、 provision-tenant.sh の
+    // 結果 (tenantConfig 充足 / 経過時間) で "In progress" stuck な行を "Complete" /
+    // "Failed" に自動遷移させる。
+    new TenantStatusReconciler(this, "TenantStatusReconciler", {
+      tenantMappingTable: this.tenantMappingTable,
     });
   }
 }

--- a/infrastructure/lib/tenant-status-reconciler/handlers/handler.ts
+++ b/infrastructure/lib/tenant-status-reconciler/handlers/handler.ts
@@ -1,0 +1,93 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { decideReconcile } from "../status-policy.js";
+
+/**
+ * Issue #659: TenantMappingTable を scan して "In progress" stuck な row を
+ * "Complete" / "Failed" に遷移させる。 EventBridge Schedule (= 2 分周期) から呼ばれる。
+ *
+ * RCU: TenantMappingTable はテナント数 = small (< 1000) を想定。 1 RCU = 4KB 行 1 read /
+ * sec。 2 分周期 + 全件 scan で十分耐えうる (= dev scale: 数行 / production: 数十行)。
+ * 大規模化したら GSI を `tenantStatus-createdAt` に切り、 status="In progress" のみを
+ * query で読み出す経路に移行する (= Phase 2)。
+ */
+
+const tableName = (() => {
+  const v = process.env.TENANT_MAPPING_TABLE_NAME;
+  if (!v) throw new Error("env TENANT_MAPPING_TABLE_NAME is required");
+  return v;
+})();
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+interface TenantRow {
+  readonly tenantId?: string;
+  readonly tenantStatus?: string;
+  readonly tenantConfig?: string;
+  readonly createdAt?: string;
+}
+
+export async function handler(): Promise<{ scanned: number; updated: number }> {
+  const nowMs = Date.now();
+  let scanned = 0;
+  let updated = 0;
+  let lastKey: Record<string, unknown> | undefined;
+
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: tableName,
+        ExclusiveStartKey: lastKey,
+        ProjectionExpression: "tenantId, tenantStatus, tenantConfig, createdAt",
+      }),
+    );
+    const items = (out.Items ?? []) as TenantRow[];
+    scanned += items.length;
+
+    for (const row of items) {
+      if (!row.tenantId) continue;
+      const verdict = decideReconcile({
+        tenantStatus: row.tenantStatus,
+        tenantConfig: row.tenantConfig,
+        createdAt: row.createdAt,
+        nowMs,
+      });
+      if (verdict.action === "skip") continue;
+
+      if (verdict.action === "complete") {
+        await ddb.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { tenantId: row.tenantId },
+            UpdateExpression: "SET tenantStatus = :s, reconciledAt = :t",
+            ExpressionAttributeValues: {
+              ":s": "Complete",
+              ":t": new Date(nowMs).toISOString(),
+            },
+          }),
+        );
+        updated += 1;
+        continue;
+      }
+
+      // action === "fail"
+      await ddb.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: { tenantId: row.tenantId },
+          UpdateExpression:
+            "SET tenantStatus = :s, failedAt = :t, failureReason = :r, reconciledAt = :t",
+          ExpressionAttributeValues: {
+            ":s": "Failed",
+            ":t": new Date(nowMs).toISOString(),
+            ":r": verdict.reason,
+          },
+        }),
+      );
+      updated += 1;
+    }
+    lastKey = out.LastEvaluatedKey;
+  } while (lastKey);
+
+  return { scanned, updated };
+}

--- a/infrastructure/lib/tenant-status-reconciler/status-policy.ts
+++ b/infrastructure/lib/tenant-status-reconciler/status-policy.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #659: TenantMappingTable の tenantStatus を CFn / provisioning 結果に合わせて
+ * 自動遷移するための pure policy。
+ *
+ * 入力は scan で取り出した row 1 件 + 現在時刻 (UTC ms)。 副作用なし、 純粋関数。
+ * Lambda handler は 各 row に本関数を適用し、 戻り値が "Complete" / "Failed" のときだけ
+ * UpdateItem を発行する (= "In progress" 維持の不要書込みを避ける)。
+ *
+ * 判定基準 (= 過剰判定を避けて conservative に):
+ *   - status が "In progress" / "IN_PROGRESS" / "Provisioning" でない → 触らない
+ *   - tenantConfig に applicationAdminConsoleUrl OR userPoolId が含まれる → "Complete"
+ *     (= provision-tenant.sh が CFn output を JSON 書き戻したシグナル)
+ *   - createdAt から 60 分超 + 上記未充足 → "Failed" + 推定理由
+ *   - それ以外 (= まだ deploy 中) → 維持
+ *
+ * Phase 2 で CodePipeline event を直接 listen する設計に移行可能だが、 SBT pipeline は
+ * 複数 tenant を batch 処理するため 1 execution = N tenants で対応 mapping を取れない。
+ * 本実装は CFn output 経由の indirection で十分に正確 (= bash 完了 = 安定状態)。
+ */
+
+const PROGRESS_TIMEOUT_MS = 60 * 60 * 1000; // 60 分
+
+export type ReconcileVerdict =
+  | { readonly action: "skip" }
+  | { readonly action: "complete" }
+  | { readonly action: "fail"; readonly reason: string };
+
+export interface ReconcilerInput {
+  readonly tenantStatus: string | undefined;
+  readonly tenantConfig: string | undefined;
+  readonly createdAt: string | undefined;
+  readonly nowMs: number;
+}
+
+function isInProgress(status: string | undefined): boolean {
+  if (!status) return false;
+  const s = status.toLowerCase();
+  return s === "in progress" || s === "in_progress" || s === "provisioning";
+}
+
+function hasMeaningfulTenantConfig(rawJson: string | undefined): boolean {
+  if (!rawJson) return false;
+  try {
+    const parsed = JSON.parse(rawJson) as Record<string, unknown>;
+    return Boolean(parsed.applicationAdminConsoleUrl) || Boolean(parsed.userPoolId);
+  } catch {
+    return false;
+  }
+}
+
+function parseCreatedAtMs(createdAt: string | undefined): number | null {
+  if (!createdAt) return null;
+  const t = Date.parse(createdAt);
+  return Number.isNaN(t) ? null : t;
+}
+
+export function decideReconcile(input: ReconcilerInput): ReconcileVerdict {
+  if (!isInProgress(input.tenantStatus)) return { action: "skip" };
+  if (hasMeaningfulTenantConfig(input.tenantConfig)) return { action: "complete" };
+
+  const createdMs = parseCreatedAtMs(input.createdAt);
+  if (createdMs !== null && input.nowMs - createdMs > PROGRESS_TIMEOUT_MS) {
+    return {
+      action: "fail",
+      reason: "Provisioning timed out (>60 min) without CFn output",
+    };
+  }
+
+  return { action: "skip" };
+}

--- a/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
+++ b/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
@@ -1,0 +1,64 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+
+export interface TenantStatusReconcilerProps {
+  /**
+   * Reconciliation 対象の TenantMappingTable。 Lambda は本テーブルを scan + update する。
+   */
+  readonly tenantMappingTable: ITable;
+  /**
+   * 実行周期。 default 2 分。 RCU を抑えたければ伸ばす。
+   */
+  readonly scheduleInterval?: Duration;
+}
+
+/**
+ * Issue #659: TenantMappingTable の "In progress" stuck 状態を自動遷移させる Reconciler。
+ *
+ * EventBridge Schedule (= default 2 分) で Lambda を起動し、 各 row を `decideReconcile()`
+ * policy で評価。 tenantConfig に CFn output が JSON 書き戻されていれば "Complete"、
+ * 60 分超で未充足なら "Failed" + failureReason に置く。
+ *
+ * SBT pipeline event 直接 listen 経路は採用していない (= 1 execution が複数 tenant を
+ * batch 処理するため 1:1 mapping が取れない)。 CFn output 経由の indirection で
+ * conservative かつ正確 (= bash 完了 = 安定状態) に判定する。
+ */
+export class TenantStatusReconciler extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly rule: Rule;
+
+  constructor(scope: Construct, id: string, props: TenantStatusReconcilerProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: Runtime.NODEJS_20_X,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/handler.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(60),
+      memorySize: 256,
+      environment: {
+        TENANT_MAPPING_TABLE_NAME: props.tenantMappingTable.tableName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: "node20",
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+    props.tenantMappingTable.grantReadWriteData(this.fn);
+
+    this.rule = new Rule(this, "Schedule", {
+      schedule: Schedule.rate(props.scheduleInterval ?? Duration.minutes(2)),
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/test/tenant-status-reconciler/status-policy.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/status-policy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { decideReconcile } from "../../lib/tenant-status-reconciler/status-policy";
+
+const NOW = Date.parse("2026-05-13T22:00:00.000Z");
+
+describe("decideReconcile", () => {
+  it('status が "In progress" でない場合は skip すべき (= 既に Complete/Failed/Deleted は触らない)', () => {
+    expect(
+      decideReconcile({
+        tenantStatus: "Complete",
+        tenantConfig: undefined,
+        createdAt: undefined,
+        nowMs: NOW,
+      }).action,
+    ).toBe("skip");
+    expect(
+      decideReconcile({
+        tenantStatus: "Failed",
+        tenantConfig: undefined,
+        createdAt: undefined,
+        nowMs: NOW,
+      }).action,
+    ).toBe("skip");
+  });
+
+  it('status が "In progress" + tenantConfig に applicationAdminConsoleUrl 充足 → complete', () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: '{"applicationAdminConsoleUrl":"https://d123.cloudfront.net"}',
+      createdAt: "2026-05-13T21:55:00.000Z",
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("complete");
+  });
+
+  it('"IN_PROGRESS" (大文字) でも同じく判定すべき (= case-insensitive)', () => {
+    expect(
+      decideReconcile({
+        tenantStatus: "IN_PROGRESS",
+        tenantConfig: '{"applicationAdminConsoleUrl":"https://x.cloudfront.net"}',
+        createdAt: "2026-05-13T21:55:00.000Z",
+        nowMs: NOW,
+      }).action,
+    ).toBe("complete");
+  });
+
+  it('"Provisioning" (SBT v0.3.10 系) でも同じく判定すべき', () => {
+    expect(
+      decideReconcile({
+        tenantStatus: "Provisioning",
+        tenantConfig: '{"userPoolId":"ap-northeast-1_abc"}',
+        createdAt: "2026-05-13T21:55:00.000Z",
+        nowMs: NOW,
+      }).action,
+    ).toBe("complete");
+  });
+
+  it("tenantConfig が userPoolId のみでも complete 判定 (= silo deploy 経路)", () => {
+    expect(
+      decideReconcile({
+        tenantStatus: "In progress",
+        tenantConfig: '{"userPoolId":"ap-northeast-1_xyz"}',
+        createdAt: "2026-05-13T21:55:00.000Z",
+        nowMs: NOW,
+      }).action,
+    ).toBe("complete");
+  });
+
+  it("tenantConfig が空 / なし + 60 分未満 → skip (= まだ進行中)", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: undefined,
+      createdAt: "2026-05-13T21:45:00.000Z", // 15 分前
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("skip");
+  });
+
+  it("tenantConfig 空 + 60 分超 → fail + reason", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: undefined,
+      createdAt: "2026-05-13T20:50:00.000Z", // 70 分前
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("fail");
+    if (out.action === "fail") {
+      expect(out.reason).toMatch(/timed out/i);
+    }
+  });
+
+  it("tenantConfig が malformed JSON でも fall through (= skip / fail に降りる)", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: "{ not-json",
+      createdAt: "2026-05-13T21:55:00.000Z",
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("skip");
+  });
+
+  it("tenantConfig に他の field のみ (= applicationAdminConsoleUrl / userPoolId 無し) は skip", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: '{"someOther":"value"}',
+      createdAt: "2026-05-13T21:55:00.000Z",
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("skip");
+  });
+
+  it("createdAt が parse 不能でも skip (= 60 分判定をスキップ)", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: undefined,
+      createdAt: "not-an-iso-date",
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("skip");
+  });
+
+  it("createdAt が未来 (clock skew) でも fail にはならない (= 経過時間が負になっても閾値超過しない)", () => {
+    const out = decideReconcile({
+      tenantStatus: "In progress",
+      tenantConfig: undefined,
+      createdAt: "2026-05-13T22:30:00.000Z", // 30 分後
+      nowMs: NOW,
+    });
+    expect(out.action).toBe("skip");
+  });
+});

--- a/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
@@ -1,0 +1,92 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { describe, expect, it } from "vitest";
+import { TenantStatusReconciler } from "../../lib/tenant-status-reconciler/tenant-status-reconciler";
+
+function synth() {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const table = new Table(stack, "TenantMappingTable", {
+    partitionKey: { name: "tenantId", type: AttributeType.STRING },
+    billingMode: BillingMode.PROVISIONED,
+    readCapacity: 1,
+    writeCapacity: 1,
+  });
+  new TenantStatusReconciler(stack, "Reconciler", { tenantMappingTable: table });
+  return { template: Template.fromStack(stack), stack };
+}
+
+describe("TenantStatusReconciler", () => {
+  it("Lambda + EventBridge Rule を 1 セット作るべき", () => {
+    const { template } = synth();
+    template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.resourceCountIs("AWS::Events::Rule", 1);
+  });
+
+  it("Schedule は 2 分周期がデフォルトであるべき", () => {
+    const { template } = synth();
+    template.hasResourceProperties(
+      "AWS::Events::Rule",
+      Match.objectLike({
+        ScheduleExpression: "rate(2 minutes)",
+      }),
+    );
+  });
+
+  it("Lambda の environment に TENANT_MAPPING_TABLE_NAME を渡すべき", () => {
+    const { template } = synth();
+    template.hasResourceProperties(
+      "AWS::Lambda::Function",
+      Match.objectLike({
+        Environment: Match.objectLike({
+          Variables: Match.objectLike({
+            TENANT_MAPPING_TABLE_NAME: Match.anyValue(),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("Lambda の IAM policy が TenantMappingTable への Scan + UpdateItem を grant すべき", () => {
+    const { template } = synth();
+    template.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(["dynamodb:Scan", "dynamodb:UpdateItem"]),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("scheduleInterval を override できるべき", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "T", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    const table = new Table(stack, "TenantMappingTable", {
+      partitionKey: { name: "tenantId", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+    new TenantStatusReconciler(stack, "Reconciler", {
+      tenantMappingTable: table,
+      scheduleInterval: cdk.Duration.minutes(5),
+    });
+    const t = Template.fromStack(stack);
+    t.hasResourceProperties(
+      "AWS::Events::Rule",
+      Match.objectLike({
+        ScheduleExpression: "rate(5 minutes)",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

新規 Lambda + EventBridge Schedule (= 2 分周期) を `BootstrapTemplateStack` に追加。 `TenantMappingTable` を scan し、 `provision-tenant.sh` の結果 (tenantConfig 充足 / 経過時間) に応じて `tenantStatus` を `Complete` / `Failed` に自動遷移させる。

## 設計判断 (SBT pipeline event は使わない)

SBT pipeline event を直接 listen する経路は採用していません:
- 1 pipeline execution が複数 tenant を batch 処理する (= Step Functions iterator)
- 1:1 mapping が取れず、 どの tenant が成功 / 失敗したか判別不可

代わりに **CFn output indirection** で conservative に判定:
| 条件 | アクション |
|---|---|
| `status` が `In progress` 系でない | skip (= 既に Complete/Failed/Deleted は触らない) |
| `tenantConfig` JSON に `applicationAdminConsoleUrl` OR `userPoolId` | → `Complete` |
| `createdAt` から 60 分超 + tenantConfig 未充足 | → `Failed` + `failureReason` |
| それ以外 | skip (= まだ deploy 中の可能性) |

provision-tenant.sh が CFn output を JSON 書き戻したら安定状態と判断できる、 という indirection。 conservative かつ正確。

## Test plan

- [x] `bunx vitest run test/tenant-status-reconciler/` (= 16 tests pass: 11 policy + 5 CDK)
- [x] `make before-commit` all green
- [ ] dev 環境で deploy → 既存の "In progress" stuck な tenant が 2 分以内に Complete 化
- [ ] 60 分超 stuck な tenant が Failed + failureReason に遷移

## Regression 分析

- 既存 SBT `onboardingRequest` 経路は触らない (= PROVISION_SUCCESS / DEPROVISION_SUCCESS event handler は変更なし)
- `tenantStatus` が `In progress` 系 **以外** の行は skip (= Complete / Failed / Deleted の上書きなし)
- TenantMappingTable schema 追加 field (`reconciledAt` / `failedAt` / `failureReason`) は optional で既存 reader への影響なし
- `tenantConfig` が malformed JSON でも fall through (= skip) で安全

## 物理影響

- CREATE: `infrastructure/lib/tenant-status-reconciler/status-policy.ts` (= pure policy、 副作用なし)
- CREATE: `infrastructure/lib/tenant-status-reconciler/handlers/handler.ts` (= Lambda handler)
- CREATE: `infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts` (= Construct)
- CREATE: `infrastructure/test/tenant-status-reconciler/*.test.ts` (= 16 tests)
- UPDATE: `infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts` (= 配線 1 行)
- **CFn diff**: BootstrapTemplateStack に新規 Lambda + EventBridge Rule + IAM Policy が追加
  - RCU 影響: 2 分周期 scan = 30 回 / 時 × 数行 → 既存 TenantMappingTable の 1 RCU で吸収可能

## 次の段階 (= 別 Issue 候補)

- admin-console で `failureReason` を tooltip 表示
- 30 / 60 分 threshold を env-tunable に
- GSI `tenantStatus-createdAt` で scan → query 化 (= 大規模化対応)

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)