### PR TITLE
fix(#658): Provisioning Jobs page の "Failed to fetch" を解消 + i18n 化

### DIFF
--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -72,6 +72,23 @@
     "tier_advanced": "Advanced — shared (Pooled)",
     "tier_platinum": "Platinum — dedicated (Silo: dedicated Cognito / Application Console)"
   },
+  "jobs_page": {
+    "header": "Provisioning Jobs",
+    "description": "Recent 50 executions of tenkacloud-saas-pipeline. Refreshes every 60 seconds.",
+    "not_configured_header": "AdminInsight API is not configured",
+    "not_configured_body": "The admin-insight API URL is not set in runtime-config. Complete Phase 2 deploy.",
+    "forbidden_header": "Not authorised",
+    "forbidden_body": "Only members of the SystemAdmin group can view this. Please sign in again.",
+    "error_header": "Failed to load",
+    "loading": "Loading…",
+    "empty": "No pipeline executions yet — you may not have created a tenant.",
+    "col_execution_id": "Execution ID",
+    "col_status": "Status",
+    "col_start_time": "Started",
+    "col_elapsed": "Elapsed",
+    "col_last_update": "Last update",
+    "open_console_aria": "Open execution {executionId} in AWS Console"
+  },
   "tenant_events": {
     "missing_tenant_id": "tenantId is required.",
     "not_configured_header": "AdminInsight API is not configured",

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -72,6 +72,23 @@
     "tier_advanced": "Advanced — compartido (Pooled)",
     "tier_platinum": "Platinum — dedicado (Silo: Cognito y Consola de aplicación dedicados)"
   },
+  "jobs_page": {
+    "header": "Trabajos de aprovisionamiento",
+    "description": "Últimas 50 ejecuciones de tenkacloud-saas-pipeline. Se actualiza cada 60 segundos.",
+    "not_configured_header": "AdminInsight API no está configurado",
+    "not_configured_body": "La URL de admin-insight API no está definida en runtime-config. Completa el deploy de Phase 2.",
+    "forbidden_header": "Sin permisos",
+    "forbidden_body": "Solo los miembros del grupo SystemAdmin pueden verlo. Vuelve a iniciar sesión.",
+    "error_header": "Error al cargar",
+    "loading": "Cargando…",
+    "empty": "Aún no hay ejecuciones de pipeline — es posible que aún no hayas creado un tenant.",
+    "col_execution_id": "ID de ejecución",
+    "col_status": "Estado",
+    "col_start_time": "Inicio",
+    "col_elapsed": "Tiempo transcurrido",
+    "col_last_update": "Última actualización",
+    "open_console_aria": "Abrir la ejecución {executionId} en la consola de AWS"
+  },
   "tenant_events": {
     "missing_tenant_id": "Falta el tenantId.",
     "not_configured_header": "AdminInsight API no está configurado",

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -72,6 +72,23 @@
     "tier_advanced": "Advanced — 共有環境 (Pooled)",
     "tier_platinum": "Platinum — 専用環境 (Silo: 専用 Cognito / Application Console)"
   },
+  "jobs_page": {
+    "header": "Provisioning Jobs",
+    "description": "tenkacloud-saas-pipeline の最近 50 件の execution。60 秒ごとに自動更新します。",
+    "not_configured_header": "AdminInsight API が未配線です",
+    "not_configured_body": "本環境では admin-insight API URL が runtime-config に設定されていません。Phase 2 deploy を完了してください。",
+    "forbidden_header": "権限がありません",
+    "forbidden_body": "この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。",
+    "error_header": "読み込みに失敗しました",
+    "loading": "読み込み中…",
+    "empty": "Pipeline execution の履歴がありません。tenant をまだ作成していない可能性があります。",
+    "col_execution_id": "Execution ID",
+    "col_status": "状態",
+    "col_start_time": "開始時刻",
+    "col_elapsed": "経過時間",
+    "col_last_update": "最終更新",
+    "open_console_aria": "Execution {executionId} を AWS Console で開く"
+  },
   "tenant_events": {
     "missing_tenant_id": "tenantId が指定されていません。",
     "not_configured_header": "AdminInsight API が未配線です",

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -72,6 +72,23 @@
     "tier_advanced": "Advanced — 共享环境 (Pooled)",
     "tier_platinum": "Platinum — 专用环境 (Silo: 专用 Cognito / 应用控制台)"
   },
+  "jobs_page": {
+    "header": "配置作业",
+    "description": "tenkacloud-saas-pipeline 最近 50 次执行。每 60 秒自动刷新一次。",
+    "not_configured_header": "AdminInsight API 未配置",
+    "not_configured_body": "本环境的 runtime-config 中没有设置 admin-insight API URL。请完成 Phase 2 部署。",
+    "forbidden_header": "无权限",
+    "forbidden_body": "此功能仅 SystemAdmin 组成员可查看。请重新登录。",
+    "error_header": "加载失败",
+    "loading": "正在加载…",
+    "empty": "暂无 pipeline execution 历史 — 可能尚未创建租户。",
+    "col_execution_id": "Execution ID",
+    "col_status": "状态",
+    "col_start_time": "开始时间",
+    "col_elapsed": "耗时",
+    "col_last_update": "最后更新",
+    "open_console_aria": "在 AWS 控制台打开 execution {executionId}"
+  },
   "tenant_events": {
     "missing_tenant_id": "未指定 tenantId。",
     "not_configured_header": "AdminInsight API 未配置",

--- a/apps/admin-console/src/pages/Jobs.tsx
+++ b/apps/admin-console/src/pages/Jobs.tsx
@@ -15,6 +15,7 @@ import {
 } from "../api/admin-drill-down";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+import { interpolate, useT } from "../i18n";
 
 /**
  * Issue #658: admin-console の Tenant Provisioning Jobs 一覧 page。
@@ -61,6 +62,7 @@ function formatElapsed(startIso: string | undefined, endIso: string | undefined)
 
 export function JobsPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
+  const t = useT();
   const [items, setItems] = useState<readonly PipelineExecutionItem[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [forbidden, setForbidden] = useState(false);
@@ -108,13 +110,15 @@ export function JobsPage({ config }: { config: AppConfig }) {
     () => [
       {
         id: "executionId",
-        header: "Execution ID",
+        header: t("jobs_page.col_execution_id"),
         cell: (item: PipelineExecutionItem) => (
           <Button
             variant="inline-link"
             href={item.consoleUrl}
             target="_blank"
-            ariaLabel={`Open execution ${item.executionId} in AWS Console`}
+            ariaLabel={interpolate(t("jobs_page.open_console_aria"), {
+              executionId: item.executionId,
+            })}
           >
             <code>{item.executionId.slice(0, 12)}…</code> ↗
           </Button>
@@ -122,61 +126,57 @@ export function JobsPage({ config }: { config: AppConfig }) {
       },
       {
         id: "status",
-        header: "状態",
+        header: t("jobs_page.col_status"),
         cell: (item: PipelineExecutionItem) => (
           <Badge color={colorFor(item.status)}>{item.status}</Badge>
         ),
       },
       {
         id: "startTime",
-        header: "開始時刻",
+        header: t("jobs_page.col_start_time"),
         cell: (item: PipelineExecutionItem) => item.startTimeIso ?? "—",
       },
       {
         id: "elapsed",
-        header: "経過時間",
+        header: t("jobs_page.col_elapsed"),
         cell: (item: PipelineExecutionItem) =>
           formatElapsed(item.startTimeIso, item.lastUpdateTimeIso),
       },
       {
         id: "lastUpdate",
-        header: "最終更新",
+        header: t("jobs_page.col_last_update"),
         cell: (item: PipelineExecutionItem) => item.lastUpdateTimeIso ?? "—",
       },
     ],
-    [],
+    [t],
   );
 
   if (notConfigured) {
     return (
-      <Alert type="info" header="AdminInsight API が未配線です">
-        本環境では admin-insight API URL が runtime-config に設定されていません。Phase 2 deploy
-        を完了してください。
+      <Alert type="info" header={t("jobs_page.not_configured_header")}>
+        {t("jobs_page.not_configured_body")}
       </Alert>
     );
   }
 
   if (forbidden) {
     return (
-      <Alert type="error" header="権限がありません">
-        この機能は SystemAdmin group のメンバーのみ閲覧できます。ログインし直してください。
+      <Alert type="error" header={t("jobs_page.forbidden_header")}>
+        {t("jobs_page.forbidden_body")}
       </Alert>
     );
   }
 
   return (
     <SpaceBetween size="l">
-      <Header
-        variant="h1"
-        description="tenkacloud-saas-pipeline の最近 50 件の execution。60 秒ごとに自動更新します。"
-      >
-        Provisioning Jobs
+      <Header variant="h1" description={t("jobs_page.description")}>
+        {t("jobs_page.header")}
       </Header>
 
       {error && (
         <Alert
           type="error"
-          header="読み込みに失敗しました"
+          header={t("jobs_page.error_header")}
           dismissible
           onDismiss={() => setError(null)}
         >
@@ -186,7 +186,7 @@ export function JobsPage({ config }: { config: AppConfig }) {
 
       {items === null && !error ? (
         <Box textAlign="center" padding="l">
-          <Spinner /> 読み込み中…
+          <Spinner /> {t("jobs_page.loading")}
         </Box>
       ) : (
         <Table<PipelineExecutionItem>
@@ -195,7 +195,7 @@ export function JobsPage({ config }: { config: AppConfig }) {
           trackBy="executionId"
           empty={
             <Box textAlign="center" color="inherit" padding="xxl">
-              Pipeline execution の履歴がありません。tenant をまだ作成していない可能性があります。
+              {t("jobs_page.empty")}
             </Box>
           }
           columnDefinitions={columns}

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -141,6 +141,15 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       integration,
     });
 
+    // Issue #658: Provisioning Jobs page が叩く CodePipeline 実行履歴 route。
+    // PR-683 で Lambda handler / IAM は追加したが API GW route 登録漏れで "Failed to fetch"
+    // (= CORS preflight が 404 に当たって TypeError) が出ていた。本 PR で追加。
+    httpApi.addRoutes({
+      path: "/admin/insight/pipeline-executions",
+      methods: [HttpMethod.GET],
+      integration,
+    });
+
     this.apiUrl = httpApi.apiEndpoint;
 
     new CfnOutput(this, "AdminInsightApiUrl", {


### PR DESCRIPTION
## Summary

PR-683 (#658) で Lambda handler / IAM は追加したが 2 つの落とし穴で page が動かなかった:

1. **API Gateway route 登録漏れ** — `httpApi.addRoutes()` は path 単位で明示登録が必要だが、 `/admin/insight/pipeline-executions` の addRoutes 呼び出しを忘れていた。 結果として未登録 path → CORS preflight 404 → frontend に `TypeError: Failed to fetch`
2. **Jobs page の hardcoded JP** — Header / column / Alert すべて日本語ハードコード。 PR-684 (= Phase 5.C) と整合させ 4 言語化

## 修正内容

- `admin-console-insight-stack.ts`: `/admin/insight/pipeline-executions` の `httpApi.addRoutes(...)` を追加
- `Jobs.tsx`: 15 strings を `useT()` + `interpolate()` 経由に refactor
- 4 言語 locale json に `jobs_page` namespace (= 15 keys × 4 言語)

## Test plan

- [x] `make before-commit` all green
- [x] `cdk synth` で API GW に新 route が含まれることを確認
- [ ] dev で `make deploy` → /jobs page を 4 言語で開く

## Regression 分析

- 既存 routes (= tenants/summary / drill-down) は touch しない
- API Gateway は新 route 追加のみで CORS / 認可設定変更なし
- Jobs.tsx は構造変更なし、 文字列のみ i18n key 経由に

## 物理影響

- UPDATE: `infrastructure/lib/admin-insight/admin-console-insight-stack.ts` (= 1 addRoutes 追加)
- UPDATE: `apps/admin-console/src/pages/Jobs.tsx`
- UPDATE: `apps/admin-console/src/i18n/locales/{ja,en,es,zh}.json` (= 15 keys × 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)