### PR TITLE
fix(#690): tenant-pipeline CodeBuild の set -o pipefail を bash heredoc 化

### DIFF
--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -112,7 +112,14 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
             commands: ["npm install -g aws-cdk"],
           },
           build: {
-            commands: [fs.readFileSync("../scripts/update-tenant.sh", "utf8")],
+            // #690: CodeBuild の default shell は dash (POSIX sh) で `set -o pipefail` を
+            // サポートしない。 script に shebang `#!/bin/bash` を書いても commands embed では
+            // 単なるコメント扱いで効かない。 `bash -ex <<'EOSCRIPT'` heredoc で明示的に bash に
+            // 流し込み、 PR-560 の pipefail 安全策を維持する (= -ex = errexit + xtrace、
+            // 元 shebang `#!/bin/bash -xe` と同等)。
+            commands: [
+              `bash -ex <<'TENANT_UPDATE_SCRIPT_EOF'\n${fs.readFileSync("../scripts/update-tenant.sh", "utf8")}\nTENANT_UPDATE_SCRIPT_EOF`,
+            ],
           },
         },
       }),


### PR DESCRIPTION
## Summary

新規 tenant 作成すると CodeBuild が BUILD phase 6 行目で **\`set: Illegal option -o pipefail\`** で即死していた。 CodeBuild の default shell は dash (POSIX sh) で `pipefail` 非対応、 script の shebang `#!/bin/bash -xe` は commands embed 経由では comment 扱いで効かない。

`bash -ex <<'EOSCRIPT' ... EOSCRIPT` heredoc で script 全体を bash subshell に流し込み、 PR-560 の pipefail 安全策 (= `curl ... | sudo bash -` の curl 失敗を silent に続行させない) を維持する。

## 設計

- `-ex` flag は元 shebang `#!/bin/bash -xe` (errexit + xtrace) と同等
- script 自体は変更不要 (= shebang / `set -o pipefail` line は bash 側で再評価される)
- 同 pattern が provision-tenant.sh にもあるが、 こちらは SBT BashJobRunner 経由 (= bash 確定) で別 path、 update-tenant.sh の ServerlessSaaSPipeline buildspec 経由が今回の事故 path

## Test plan

- [x] `make before-commit` all green (= cdk synth で buildspec 構造を確認)
- [ ] dev で `make deploy` → tenant 作成 → CodeBuild BUILD phase が進行
- [ ] curl パイプ失敗時 (= 障害 simulation) に build が exit 1 で停止 (= 旧 PR-560 の意図維持)

## Regression 分析

- 元の script 内容には触れていない、 invocation 経路だけ bash 明示化
- shebang / set -o pipefail の意図 (= PR-560) は heredoc で完全継承
- 他の buildspec (= problem-deploy / control-plane) は触らない

## 物理影響

- UPDATE: `infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts` (= 1 buildspec command)
- CFn diff: CodeBuild buildspec の commands string のみ変更 (= IAM / Lambda / pipeline 構造変更なし)

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)