### PR TITLE
fix(#692): CompetitorDeploy-Role に Lambda IAM を追加し問題 deploy の AccessDenied を解消

### DIFF
--- a/infrastructure/templates/competitor-bootstrap.yaml
+++ b/infrastructure/templates/competitor-bootstrap.yaml
@@ -148,6 +148,30 @@ Resources:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                 Resource: "*"
+
+              # Lambda resources created by problem CFn templates (= microservice-migration-battle
+              # disruption Lambdas etc.). Scope is narrowed to the tc-* function name prefix.
+              # Issue #692: CFn deploy requires lambda:GetFunction for stack drift / read-back,
+              # which was missing and caused ROLLBACK_COMPLETE with AccessDenied.
+              - Sid: LambdaForProblemFunctions
+                Effect: Allow
+                Action:
+                  - lambda:CreateFunction
+                  - lambda:DeleteFunction
+                  - lambda:GetFunction
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:TagResource
+                  - lambda:UntagResource
+                  - lambda:ListTags
+                  - lambda:AddPermission
+                  - lambda:RemovePermission
+                  - lambda:GetPolicy
+                  - lambda:PutFunctionConcurrency
+                  - lambda:DeleteFunctionConcurrency
+                  - lambda:GetFunctionConfiguration
+                Resource:
+                  - !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:tc-*"
       Tags:
         - Key: TenkaCloud:Purpose
           Value: competitor-deploy


### PR DESCRIPTION
## Summary

新規問題 deploy (= `microservice-migration-battle` 等 Lambda を含む) で CFn が **\`User ... is not authorized to perform: lambda:GetFunction\`** で ROLLBACK_COMPLETE になっていた。 `competitor-bootstrap.yaml` の IAM policy に Lambda 系 action が **1 つも無く**、 CFn の Lambda resource 作成 / drift detection が走らなかった。

`tc-*` function name prefix で scope を narrow にした最小権限で追加。

## 追加した action

| 用途 | actions |
|---|---|
| CRUD | `CreateFunction` / `DeleteFunction` / `UpdateFunctionCode` / `UpdateFunctionConfiguration` |
| read-back (= CFn drift) | `GetFunction` / `GetFunctionConfiguration` |
| Tag | `TagResource` / `UntagResource` / `ListTags` |
| Resource policy | `AddPermission` / `RemovePermission` / `GetPolicy` |
| 並行性 | `PutFunctionConcurrency` / `DeleteFunctionConcurrency` |

Resource scope: `arn:aws:lambda:*:${AWS::AccountId}:function:tc-*` のみ (= 競技者の他 Lambda には触れない)

## Test plan

- [x] `make before-commit` all green (= check-template-ascii で yaml 妥当性確認)
- [ ] 競技者: bootstrap CFn stack を update → 新 actions を含む trust 状態
- [ ] operator: `make deploy` → microservice-migration-battle を deploy → CREATE_COMPLETE 到達
- [ ] Lambda `tc-microservice-migration-battle-team-1-degraded-disruption` が作成される

## 競技者側の operational impact

⚠ **既存の bootstrap stack を update してもらう必要あり**:
- 競技者は CFn console で stack `tenkacloud-competitor-bootstrap` を update
- 新しい template (= 本 PR after merge) を指定
- 既存の Trust / RoleName / ExternalId は維持されるので **再 verify 不要**

PR-674 で配信した Launch Stack URL がそのまま update でも使える (= templateURL は raw.githubusercontent.com main pinned)。

## Regression 分析

- 既存 IAM 系 / S3 / EC2 等の Sid 群は変更なし
- Resource scope は `tc-*` prefix のみ (= 他 Lambda / 他 stack には grant 漏れなし)
- hello-world / hello-world-battle (= Lambda 無し問題) は本変更前でも動作、 影響なし

## 物理影響

- UPDATE: `infrastructure/templates/competitor-bootstrap.yaml` (= IAM Sid 1 つ追加)
- NO-OP: control-plane side CDK / Lambda / DDB schema には影響なし
- 競技者側: bootstrap stack の update 必要 (= 1 度きり手順)

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)