### PR TITLE
fix(#688): phased-polling 等の新 scoring kind も Battle 判定に含める

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -14,8 +14,22 @@ export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
   "DELETED",
 ]);
 
+/**
+ * ADR-012 で定義された 5 種の builtin scoring kind。
+ * Phase 1 (旧 view) は flag / uptime のみだったが、 Phase 3 で phased-polling /
+ * uptime-flat / uptime-multi / attack-detection が追加された。
+ * UI 表示 (= categoryOf) は ADR-005 で Battle / Challenge の 2 軸に collapse する。
+ */
+export type ScoringKind =
+  | "flag"
+  | "uptime"
+  | "uptime-flat"
+  | "uptime-multi"
+  | "phased-polling"
+  | "attack-detection";
+
 export interface ParticipantScoringInfo {
-  readonly kind: "flag" | "uptime";
+  readonly kind: ScoringKind;
   readonly points?: number;
   readonly pointsPerSuccess?: number;
   readonly hints?: readonly string[];

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -32,10 +32,16 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   DELETED: "stopped",
 };
 
-const SCORING_KIND_LABEL = {
+const SCORING_KIND_LABEL: Record<string, string> = {
   flag: "Challenge (flag 提出)",
   uptime: "Battle (uptime 加点)",
-} as const;
+  "uptime-flat": "Battle (uptime 加点)",
+  "uptime-multi": "Battle (uptime 加点)",
+  "phased-polling": "Battle (時間経過で加点ルール変動)",
+  "attack-detection": "Battle (攻撃 detection)",
+};
+
+const FALLBACK_KIND_LABEL = "(未設定)";
 
 /** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
 const STALE_THRESHOLD_MS = 2 * 60 * 1000;
@@ -57,10 +63,14 @@ export function ProblemPanel({
   sessionToken: string;
   onScored: () => Promise<void>;
 }) {
-  const kindLabel = problem.scoring ? SCORING_KIND_LABEL[problem.scoring.kind] : "(未設定)";
+  const kindLabel = problem.scoring
+    ? (SCORING_KIND_LABEL[problem.scoring.kind] ?? FALLBACK_KIND_LABEL)
+    : FALLBACK_KIND_LABEL;
   const now = Date.now();
   const lastScoredMs = problem.lastScoredAt ? new Date(problem.lastScoredAt).getTime() : Number.NaN;
-  const isUptime = problem.scoring?.kind === "uptime";
+  // #688: phased-polling / uptime-flat / uptime-multi / attack-detection も Battle 軸
+  // (= uptime と同じ \"古い lastScoredAt = stale\" UX を適用)。 flag だけ非 Battle。
+  const isUptime = problem.scoring ? problem.scoring.kind !== "flag" : false;
   const isStale =
     isUptime &&
     Number.isFinite(lastScoredMs) &&

--- a/apps/participant-portal/src/lib/category.ts
+++ b/apps/participant-portal/src/lib/category.ts
@@ -1,18 +1,34 @@
-import type { ParticipantScoringInfo } from "../api/portal-client";
+import type { ParticipantScoringInfo, ScoringKind } from "../api/portal-client";
 
 export type ProblemCategory = "battle" | "challenge";
 
 /**
- * scoring.kind から「Battle / Challenge」表示用カテゴリを推定する。
- * 現状の運用 (1 problem は uptime か flag いずれか単独) では:
- *   - `uptime` → Battle (= 防御問題)
- *   - `flag`   → Challenge (= CTF)
+ * scoring.kind から Battle / Challenge 表示用カテゴリを推定する。 ADR-012 で定義された
+ * 5 種の builtin kind を 2 軸に collapse する:
  *
- * 将来 1 problem が両方の scoring を持つようになる場合 (Battle 内 sub-quest 等、
- * Issue #502 注釈参照) は backend が metadata.json の `category` を view に流す
- * 形に切り替える。
+ *   - `flag`             -> challenge (= CTF / 1-shot 提出)
+ *   - `uptime` (= alias) -> battle    (= legacy、 Phase 1 互換)
+ *   - `uptime-flat`      -> battle    (= 単一 endpoint uptime 監視)
+ *   - `uptime-multi`     -> battle    (= 複数 endpoint uptime 監視)
+ *   - `phased-polling`   -> battle    (= microservice-migration-battle 等、 時間経過で採点 ruleが変化)
+ *   - `attack-detection` -> battle    (= 攻撃/防御 detection)
+ *
+ * Issue #688: phased-polling を challenge に誤分類していた regression を修正。
+ * 旧 logic は `kind === "uptime" ? battle : challenge` で battle 軸の新 kind が
+ * すべて challenge に流れていた。
+ *
+ * 将来 1 problem が両方の scoring を持つようになる場合 (Issue #502 注釈参照) は backend が
+ * metadata.json の `category` を直接 view に流す形に切り替える。
  */
+const BATTLE_KINDS: ReadonlySet<ScoringKind> = new Set<ScoringKind>([
+  "uptime",
+  "uptime-flat",
+  "uptime-multi",
+  "phased-polling",
+  "attack-detection",
+]);
+
 export function categoryOf(scoring: ParticipantScoringInfo | undefined): ProblemCategory | null {
   if (!scoring) return null;
-  return scoring.kind === "uptime" ? "battle" : "challenge";
+  return BATTLE_KINDS.has(scoring.kind) ? "battle" : "challenge";
 }

--- a/apps/participant-portal/test/lib/category.test.ts
+++ b/apps/participant-portal/test/lib/category.test.ts
@@ -16,4 +16,18 @@ describe("categoryOf", () => {
     const scoring: ParticipantScoringInfo = { kind: "flag", points: 100 };
     expect(categoryOf(scoring)).toBe("challenge");
   });
+
+  it("kind=phased-polling は battle を返すべき (#688 regression — phased-polling は battle 軸)", () => {
+    const scoring: ParticipantScoringInfo = { kind: "phased-polling" };
+    expect(categoryOf(scoring)).toBe("battle");
+  });
+
+  it("kind=uptime-flat / uptime-multi はいずれも battle を返すべき", () => {
+    expect(categoryOf({ kind: "uptime-flat" })).toBe("battle");
+    expect(categoryOf({ kind: "uptime-multi" })).toBe("battle");
+  });
+
+  it("kind=attack-detection は battle を返すべき", () => {
+    expect(categoryOf({ kind: "attack-detection" })).toBe("battle");
+  });
 });


### PR DESCRIPTION
## Summary

participant-portal の Quests page で **`microservice-migration-battle`** が `Challenge` バッジで表示されていた。 期待は `Battle`。

## Root cause

`categoryOf()` が `kind === \"uptime\" ? battle : challenge` の 2 軸 logic で、 ADR-012 で追加された 4 種の新 scoring kind (`uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) すべて **challenge に流れていた**。

`microservice-migration-battle` の `scoring.kind` は `phased-polling` (= 時間経過で採点ルールが変化する battle 軸の kind)、 旧 logic では「`uptime` じゃないから challenge」 と誤判定。

## 修正

1. `ParticipantScoringInfo.kind` を `"flag" | "uptime"` から 5 種 union `ScoringKind` に拡張
2. `categoryOf()` を BATTLE_KINDS Set ベースに refactor — `flag` のみ challenge、 残り全部 battle に正規化
3. 副次修正: `ProblemPanel.tsx` の `SCORING_KIND_LABEL` を Record + fallback に refactor、 `isUptime` 判定も Battle 扱い (= stale 表示 UX を battle 系全てに適用)

## Test plan

- [x] `bunx vitest run test/lib/category.test.ts` (= 6 tests pass、 5 kind すべて + undefined)
- [x] `make before-commit` all green
- [ ] dev で /quests を開いて microservice-migration-battle が `Battle` バッジ + `Battle (1)` filter

## Regression 分析

- 既存 `kind=uptime` / `kind=flag` の挙動は完全互換 (= 同じ category を返す)
- 新規 kind 4 種を battle 軸に classify (= ADR-012 で battle 系として定義された設計と整合)
- `SCORING_KIND_LABEL` は Record 化で type 緩和、 未知 kind は `(未設定)` fallback で安全

## 物理影響

- UPDATE: `apps/participant-portal/src/api/portal-client.ts` (= `ScoringKind` type export)
- UPDATE: `apps/participant-portal/src/lib/category.ts` (= Set ベース判定)
- UPDATE: `apps/participant-portal/src/components/ProblemPanel.tsx` (= label map + isUptime)
- UPDATE: `apps/participant-portal/test/lib/category.test.ts` (= 3 tests 追加)
- NO-OP: backend / infra / CFn

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended scoring support to include phased-polling, attack-detection, uptime-flat, and uptime-multi scoring types alongside existing flag and uptime methodologies.
  * Improved problem categorization logic to properly handle and display all supported scoring types.
  * Enhanced scoring kind labels for improved user clarity.

* **Bug Fixes**
  * Fixed phased-polling scoring incorrectly categorized as challenge instead of battle.

* **Tests**
  * Added comprehensive test coverage for new scoring types and categorization logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/696)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->