### PR TITLE
fix(#686): JWT tenantId 欠落で fail-closed (= silent "unknown-tenant" 書き込み防止)

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -75,7 +75,8 @@ export class DeployApiLambda extends Construct {
         COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
         DEPLOY_ENVIRONMENT: props.environmentName,
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
-        DEFAULT_TENANT_ID: props.defaultTenantId ?? "unknown-tenant",
+        // #686: legacy "unknown-tenant" fallback は削除 (= JWT claim 欠落時は handler が 401)
+        ...(props.defaultTenantId ? { DEFAULT_TENANT_ID: props.defaultTenantId } : {}),
         BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
         // ADR-008 Phase 3 (Issue #642): visibility + bucket env、 default は dormant
         BATTLE_PROBLEMS_VISIBILITY: JSON.stringify(props.problemsVisibility),

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -77,7 +77,8 @@ export class EventApiLambda extends Construct {
         COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
         DEPLOY_ENVIRONMENT: props.environmentName,
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
-        DEFAULT_TENANT_ID: props.defaultTenantId ?? "unknown-tenant",
+        // #686: legacy "unknown-tenant" fallback は削除 (= JWT claim 欠落時は handler が 401)
+        ...(props.defaultTenantId ? { DEFAULT_TENANT_ID: props.defaultTenantId } : {}),
         BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
         NODE_OPTIONS: "--enable-source-maps",
       },

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -3,7 +3,11 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
-import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
+import {
+  MissingTenantClaimError,
+  resolveCognitoSub,
+  resolveTenantId,
+} from "../deploy-handler/auth.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
 import {
   CompetitorAccountNotFoundError,
@@ -53,6 +57,13 @@ app.use(
 
 // 想定外 throw を 500 JSON で返す (= CORS headers 付きで browser が body を読める、PR-559 同様)。
 app.onError((err, c) => {
+  if (err instanceof MissingTenantClaimError) {
+    console.warn("[competitor-accounts] missing tenantId claim", { path: c.req.path });
+    return c.json(
+      { error: "missing_tenant_claim", message: err.message },
+      StatusCodes.UNAUTHORIZED,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[competitor-accounts] uncaught handler error", {
     path: c.req.path,

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -1,8 +1,6 @@
 import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
 import type { Context } from "hono";
 
-const FALLBACK_TENANT_ID = "unknown-tenant";
-
 type JwtClaimValue = string | number | boolean | string[];
 type JwtClaims = { readonly [name: string]: JwtClaimValue };
 
@@ -14,12 +12,31 @@ export function extractTenantIdFromClaims(claims: JwtClaims | undefined): string
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/**
+ * Issue #686: JWT に `custom:tenantId` が無い + `DEFAULT_TENANT_ID` env も unset の場合に
+ * silent fallback `"unknown-tenant"` を返していたため、 全 row が同 partition に書かれ
+ * UI に `Tenant: unknown-tenant` が出ていた。 fail-closed に変更し、 caller (handler) が
+ * 401 Unauthorized で弾けるよう Error を throw する。
+ *
+ * `DEFAULT_TENANT_ID` env は dev / local 経路向けの explicit override として残す。
+ */
+export class MissingTenantClaimError extends Error {
+  constructor() {
+    super(
+      "JWT に custom:tenantId claim がありません (tenant 招待メール経由で再ログインしてください)",
+    );
+    this.name = "MissingTenantClaimError";
+  }
+}
+
 export function resolveTenantId(c: Context): string {
   const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
   const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
   const fromJwt = extractTenantIdFromClaims(claims);
   if (fromJwt) return fromJwt;
-  return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;
+  const fromEnv = process.env.DEFAULT_TENANT_ID;
+  if (fromEnv && fromEnv.length > 0 && fromEnv !== "unknown-tenant") return fromEnv;
+  throw new MissingTenantClaimError();
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -12,7 +12,7 @@ import {
   HTTP_NOT_FOUND,
   HTTP_OK,
 } from "../shared/http-status.js";
-import { resolveTenantId } from "./auth.js";
+import { MissingTenantClaimError, resolveTenantId } from "./auth.js";
 import { requestTeardown } from "./delete.js";
 import {
   buildContext,
@@ -81,6 +81,16 @@ app.use(
 // stack trace 等が browser に漏れない、PR-570 review 指摘)。operator は CloudWatch Logs
 // の `[deploy] uncaught handler error` 行で詳細を引く。
 app.onError((err, c) => {
+  // Issue #686: JWT に custom:tenantId が無い場合は 401 で fail-closed (= silent
+  // "unknown-tenant" 書き込みを防ぐ)。 caller (frontend) は FriendlyErrorAlert で
+  // 「再ログインしてください」 を表示する。
+  if (err instanceof MissingTenantClaimError) {
+    console.warn("[deploy] missing tenantId claim", { path: c.req.path });
+    return c.json(
+      { error: "missing_tenant_claim", message: err.message },
+      StatusCodes.UNAUTHORIZED,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[deploy] uncaught handler error", { path: c.req.path, message });
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -3,7 +3,11 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
-import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
+import {
+  MissingTenantClaimError,
+  resolveCognitoSub,
+  resolveTenantId,
+} from "../deploy-handler/auth.js";
 import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
@@ -78,6 +82,13 @@ app.use(
 // stack trace 等が browser に漏れない、PR-570 review 指摘)。operator は CloudWatch Logs
 // の `[events] uncaught handler error` 行で詳細を引く。
 app.onError((err, c) => {
+  if (err instanceof MissingTenantClaimError) {
+    console.warn("[events] missing tenantId claim", { path: c.req.path });
+    return c.json(
+      { error: "missing_tenant_claim", message: err.message },
+      StatusCodes.UNAUTHORIZED,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[events] uncaught handler error", { path: c.req.path, message });
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -1,5 +1,12 @@
 import { StatusCodes } from "http-status-codes";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #686: `resolveTenantId` は JWT claim 欠落で MissingTenantClaimError を throw する。
+// route tests は `app.request()` で JWT を bypass するため、 dev override env で tenantId を
+// inject する。 prod では Cognito JWT が必ず claim を載せる前提なのでこの env は使わない。
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+});
 
 const mocks = vi.hoisted(() => ({
   createCompetitorAccount: vi.fn(),

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   extractTenantIdFromClaims,
+  MissingTenantClaimError,
   resolveTenantId,
 } from "../../lib/problem-deploy/handlers/deploy-handler/auth";
 
@@ -63,10 +64,16 @@ describe("resolveTenantId", () => {
     expect(resolveTenantId(c)).toBe("tenant-from-env");
   });
 
-  it("env も無ければ unknown-tenant に倒すべき", () => {
+  it("env も無ければ MissingTenantClaimError を throw すべき (#686 — fail-closed)", () => {
     delete process.env.DEFAULT_TENANT_ID;
     const c = buildCtx();
-    expect(resolveTenantId(c)).toBe("unknown-tenant");
+    expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
+  });
+
+  it('env が "unknown-tenant" でも throw すべき (= legacy stub を silent 受け入れない)', () => {
+    process.env.DEFAULT_TENANT_ID = "unknown-tenant";
+    const c = buildCtx();
+    expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
   });
 
   it("requestContext が存在しない (Function URL ops 経路) なら env にフォールバック", () => {

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -1,4 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #686: route tests は `app.request()` で JWT を bypass するため DEFAULT_TENANT_ID env で
+// tenantId を inject する。 prod では Cognito JWT が必ず claim を載せる前提。
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+});
 
 const mocks = vi.hoisted(() => ({
   startDeployment: vi.fn(),


### PR DESCRIPTION
## Summary

DeploymentDetail で **\`Tenant: unknown-tenant\`** が表示されていた regression を修正。 旧 `resolveTenantId()` は JWT に `custom:tenantId` が無い + `DEFAULT_TENANT_ID` env も unset の場合に **silent fallback** で `\"unknown-tenant\"` を返していた。 結果として:

- 全 deploy 行が同 partition (= `TENANT#unknown-tenant`) に集約
- 別 tenant の deploy が cross-tenant に見える potential 漏洩 risk
- UI に \"unknown-tenant\" がそのまま表示

## 修正

1. `resolveTenantId()` に `MissingTenantClaimError` を export し、 JWT 欠落 + env 欠落で throw
2. `DEFAULT_TENANT_ID` env は dev override 経路として残す (\`\"unknown-tenant\"\` 文字列は明示拒否)
3. 3 handler (deploy / event / competitor-accounts) の `app.onError` で `MissingTenantClaimError` を catch し **401 + `missing_tenant_claim`** で返す
4. CDK Lambda env の `DEFAULT_TENANT_ID ?? \"unknown-tenant\"` fallback を削除
5. test fixture (= competitor-accounts-routes / deploy-handler-routes) は `app.request()` で JWT を bypass するため `beforeAll(process.env.DEFAULT_TENANT_ID = \"tenant-test\")` を追加

## Test plan

- [x] `bunx vitest run` で infrastructure 全 743 tests pass (= 11 auth tests + 残 unrelated)
- [x] `make before-commit` all green
- [ ] dev で deploy → tenant 招待メール経由で再ログイン → JWT に custom:tenantId が含まれることを CloudWatch で確認
- [ ] JWT に claim が無い悪意 token (= test attempt) で 401 + `missing_tenant_claim` が返る

## Regression 分析

- 正規 JWT (= `custom:tenantId` 込み) からの request は影響なし (= 既存挙動と同じ)
- JWT 欠落時に **silent fallback** していた経路だけ 401 に変わる (= fail-closed)
- `DEFAULT_TENANT_ID` env は dev override として残置、 \`\"unknown-tenant\"\` 文字列は明示拒否
- 既存 DDB row の \`tenantId === \"unknown-tenant\"\` 残骸は本 PR では touch しない (= migration は別 PR)

## 物理影響

- UPDATE: `infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts` (= class export + throw)
- UPDATE: 3 handler index.ts の `app.onError` (= 401 mapping)
- UPDATE: 2 Lambda CDK env (= silent fallback 削除)
- UPDATE: 2 route tests に `beforeAll` 追加
- UPDATE: deploy-auth.test.ts に MissingTenantClaimError test 追加
- NO-OP: CFn / DDB schema / IAM 変更なし

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)