### PR TITLE
fix(#689): phases / disruptions の publicHint flag で portal ネタバレを抑制

### DIFF
--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -25,6 +25,8 @@ export interface ProblemPhaseEntry {
   readonly name: string;
   readonly afterMinutes: number;
   readonly description?: string;
+  /** Issue #689 / ADR-013 OQ#7: true のみ portal に流す (= ネタバレ防止)。 */
+  readonly publicHint?: boolean;
 }
 
 export interface ProblemDisruptionEntry {
@@ -32,6 +34,8 @@ export interface ProblemDisruptionEntry {
   readonly name: string;
   readonly defaultAfterMinutes?: number;
   readonly description?: string;
+  /** Issue #689 / ADR-013 OQ#7: true のみ portal に流す (= ネタバレ防止)。 */
+  readonly publicHint?: boolean;
 }
 
 /**
@@ -119,6 +123,7 @@ interface ProblemMetadata {
     afterMinutes: number;
     effect?: Record<string, unknown>;
     description?: string;
+    publicHint?: boolean;
   }[];
   disruptions?: {
     id: string;
@@ -128,6 +133,7 @@ interface ProblemMetadata {
     parameters?: Record<string, unknown>;
     eventDetailType?: string;
     description?: string;
+    publicHint?: boolean;
   }[];
   dashboard?: {
     slots?: Record<string, string>;
@@ -204,6 +210,7 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
             name: p.name,
             afterMinutes: p.afterMinutes,
             description: p.description,
+            publicHint: p.publicHint,
           }) as ProblemPhaseEntry,
       ) ?? [],
     disruptions:
@@ -214,6 +221,7 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
             name: d.name,
             defaultAfterMinutes: d.defaultAfterMinutes,
             description: d.description,
+            publicHint: d.publicHint,
           }) as ProblemDisruptionEntry,
       ) ?? [],
     ...(dashboardSlots && Object.keys(dashboardSlots).length > 0

--- a/apps/participant-portal/src/plugins/props-builder.test.ts
+++ b/apps/participant-portal/src/plugins/props-builder.test.ts
@@ -49,10 +49,16 @@ describe("buildPortalEndpointsFromOutputs", () => {
 });
 
 describe("buildPortalPhases", () => {
-  it("phases[] が宣言済の問題は narrow 後 array を返すべき (effect は plugin に渡さない)", () => {
+  it("publicHint=true な phases のみ返すべき (#689 — ネタバレ防止)", () => {
+    // microservice-migration-battle は phases[] に degraded / legacy を持つが、 default
+    // (= publicHint 未指定) では portal に出さない。 metadata 作者が明示的に publicHint=true
+    // を立てた entry のみ portal に届く。
     const phases = buildPortalPhases("microservice-migration-battle");
-    expect(phases.length).toBeGreaterThanOrEqual(2);
-    // operator 内部 field (effect) が plugin に渡らない (= 答えの hint や noise を防ぐ)
+    expect(phases.every((p) => p.publicHint === true)).toBe(true);
+  });
+
+  it("operator 内部 field (= effect / switchPlatformToDegraded) を plugin に流さない", () => {
+    const phases = buildPortalPhases("microservice-migration-battle");
     const json = JSON.stringify(phases);
     expect(json).not.toContain("switchPlatformToDegraded");
     expect(json).not.toContain("scorePathOverride");
@@ -64,9 +70,12 @@ describe("buildPortalPhases", () => {
 });
 
 describe("buildPortalDisruptions", () => {
-  it("disruptions[] が無い問題は空配列を返すべき (= Phase 4 disruptions[] 未追加の場合)", () => {
-    // disruptions[] は Phase 4 で microservice-migration-battle にのみ追加。
-    // 他問題は disruptions[] 無しのため空配列。
+  it("publicHint=true な disruptions のみ返すべき (#689 — ネタバレ防止)", () => {
+    const out = buildPortalDisruptions("microservice-migration-battle");
+    expect(out.every((d) => d.publicHint === true)).toBe(true);
+  });
+
+  it("disruptions[] が無い問題は空配列を返すべき", () => {
     expect(buildPortalDisruptions("hello-world")).toEqual([]);
     expect(buildPortalDisruptions("hello-world-battle")).toEqual([]);
     expect(buildPortalDisruptions("security-battle-royale")).toEqual([]);

--- a/apps/participant-portal/src/plugins/props-builder.ts
+++ b/apps/participant-portal/src/plugins/props-builder.ts
@@ -65,12 +65,21 @@ export function buildPortalEndpointsFromOutputs(
   });
 }
 
+/**
+ * Issue #689 (= ADR-013 OQ#7): 競技者にとって発見すべき phase / disruption 詳細を
+ * 事前にネタバレ表示しないため、 各 entry が `publicHint=true` を持つ場合のみ portal に
+ * 流す。 default は **hide** (= fail-closed)、 operator side (= admin-console) は別経路で
+ * 全 phase 表示できる前提。 metadata 作者が「これは事前に見せて OK」 と明示した entry だけが
+ * portal の StatusPanel に届く。
+ */
 export function buildPortalPhases(problemId: string): readonly PortalPhaseEntry[] {
-  return findProblemMetadata(problemId)?.phases ?? [];
+  const phases = findProblemMetadata(problemId)?.phases ?? [];
+  return phases.filter((p) => p.publicHint === true);
 }
 
 export function buildPortalDisruptions(problemId: string): readonly PortalDisruptionEntry[] {
-  return findProblemMetadata(problemId)?.disruptions ?? [];
+  const disruptions = findProblemMetadata(problemId)?.disruptions ?? [];
+  return disruptions.filter((d) => d.publicHint === true);
 }
 
 /**

--- a/packages/portal-plugin-sdk/src/index.ts
+++ b/packages/portal-plugin-sdk/src/index.ts
@@ -59,10 +59,16 @@ export interface PortalEndpoint {
   readonly effectiveUrl?: string;
 }
 
+/**
+ * Issue #689 (ADR-013 OQ#7): `publicHint=true` の entry のみ portal に流す前提で plugin
+ * は受け取る。 false / undefined は portal layer (= props-builder) で fail-closed に
+ * filter される。 plugin 側で publicHint flag を見る必要は無い (= 既に絞り込み済が来る)。
+ */
 export interface PortalPhaseEntry {
   readonly name: string;
   readonly afterMinutes: number;
   readonly description?: string;
+  readonly publicHint?: boolean;
 }
 
 export interface PortalDisruptionEntry {
@@ -70,6 +76,7 @@ export interface PortalDisruptionEntry {
   readonly name: string;
   readonly defaultAfterMinutes?: number;
   readonly description?: string;
+  readonly publicHint?: boolean;
 }
 
 /**

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -540,6 +540,10 @@
           "description": {
             "type": "string",
             "description": "portal や運営 console で表示する phase 説明文 (任意)。"
+          },
+          "publicHint": {
+            "type": "boolean",
+            "description": "[Issue #689 / ADR-013 OQ#7] true のとき participant-portal の StatusPanel に phase 詳細 (name + description) を予告表示する。 default (= undefined / false) では competitive UX を守るため hide。 operator 側 admin-console は publicHint に関わらず全 phase 表示する想定。"
           }
         }
       }
@@ -583,6 +587,10 @@
           "description": {
             "type": "string",
             "description": "disruption の動作 / 戦術的影響を participant 向けに説明する文章。 portal の予告 panel で countdown と一緒に表示される (= player への hint)。"
+          },
+          "publicHint": {
+            "type": "boolean",
+            "description": "[Issue #689 / ADR-013 OQ#7] true のとき participant-portal の StatusPanel に disruption 詳細 (name + description + defaultAfterMinutes) を予告表示する。 default (= undefined / false) では competitive UX を守るため hide。 operator 側 admin-console は publicHint に関わらず全 disruption を表示する想定。"
           },
           "triggers": {
             "type": "array",


### PR DESCRIPTION
## Summary

participant-portal の Microservice Migration plugin が \"Upcoming phases\" / \"Disruptions\" で degraded (+60 min) / legacy (+90 min) / EC2 latency injection の全詳細を事前露出していた。 ADR-013 OQ#7 の `publicHint` flag を本格実装し、 portal layer の props-builder で **publicHint=true な entry のみ** plugin に流す **fail-closed** filter を導入。

## 設計

- `problems/SCHEMA.json` の `phases[].publicHint` / `disruptions[].publicHint` を boolean field として正式追加 (= optional、 default = hide)
- `packages/portal-plugin-sdk` の `PortalPhaseEntry` / `PortalDisruptionEntry` にも同 field を expose
- `apps/participant-portal/src/plugins/props-builder.ts` の `buildPortalPhases` / `buildPortalDisruptions` で **publicHint === true** のみ通す filter
- `apps/participant-portal/src/data/problems.ts` の narrow 経路で publicHint を伝播

operator-side (= admin-console) は本 PR で扱わない (= 同 builder は使わず別 path)。 publicHint に関わらず全 phase / disruption を見るので、 運営は phase 進行を完全把握。

## Regression 分析

- 既存 portal の StatusPanel plugin: 旧 metadata に publicHint なしなので **全 phase が hide** (= 意図的、 ネタバレ抑制)
- 個別問題で publicHint=true にしたい場合は問題作者が metadata.json で明示
- type 拡張は optional field 追加のみで existing JSON 互換
- operator-side / scoring engine への影響なし (= portal layer のみ filter)

## Test plan

- [x] `bunx vitest run` で props-builder.test.ts 11 tests pass
- [x] `make before-commit` all green
- [ ] dev で /problems/<id> を開いて Microservice Migration の Upcoming phases / Disruptions が消えていることを視覚 verify
- [ ] metadata.json に publicHint=true を 1 entry 追加 → portal で見えることを verify

## 関連

- ADR-013 OQ#7 publicHint (= 本 PR で正本実装)
- ADR-012 Phase 4 (phases / disruptions 自体)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)