### PR TITLE
fix(#687): CFn 進行状況 fetch の "Failed to fetch" を "準備中" graceful 表示に集約

### DIFF
--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -110,9 +110,19 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
       setStackProgress(progress);
       setStackProgressError(null);
     } catch (err) {
-      // CFn 失敗は基本情報を巻き込まない (= 別 state に閉じる)。
-      // 409 (= stack 未割当 / deploy 極初期) は別 message に分けて「準備中」表示する。
-      const notYetCreated = err instanceof ApiError && err.status === StatusCodes.CONFLICT;
+      // #687: 「stack 未割当」(= deploy 初期で CFn 未着手) は次のいずれかで判定:
+      //   - 409 (= backend が `stack_not_yet_created` で返す正規 path)
+      //   - 5xx (= upstream Lambda が cold / API GW route 未配線 等の transient 状態)
+      //   - TypeError (= DNS / CORS preflight 失敗 = "Failed to fetch")
+      // いずれも "準備中" graceful UI に集約し、 raw error は出さない (#656 と同 pattern)。
+      const notYetCreated =
+        (err instanceof ApiError &&
+          (err.status === StatusCodes.CONFLICT ||
+            err.status === StatusCodes.BAD_GATEWAY ||
+            err.status === StatusCodes.SERVICE_UNAVAILABLE ||
+            err.status === StatusCodes.GATEWAY_TIMEOUT)) ||
+        err instanceof TypeError ||
+        (err instanceof Error && /failed to fetch/i.test(err.message));
       const message = err instanceof Error ? err.message : String(err);
       setStackProgressError({ message, notYetCreated });
     } finally {


### PR DESCRIPTION
## Summary

DeploymentDetail で **Building phase 中** に \"CFn の進行状況を取得できませんでした / Failed to fetch\" warning が出ていた。 ProblemDeployApi の `stack-progress` endpoint が極初期 (= deploy worker が CodeBuild 起動前 / Lambda cold start / CORS preflight) で 5xx や TypeError を返すと、 raw error が warning として表示されていた。

`notYetCreated` 判定を緩めて次すべてを **\"準備中\" 集約**:

| 条件 | 元の挙動 | 新挙動 |
|---|---|---|
| 409 (`stack_not_yet_created`) | 準備中 | 準備中 (= 同じ) |
| 502 / 503 / 504 | warning (raw) | **準備中** |
| TypeError: \"Failed to fetch\" | warning (raw) | **準備中** |
| その他 5xx / 4xx | warning (raw) | warning (= 同じ) |

#656 と **同じ pattern** を適用 (= TenantEvents の `isLikelyProvisioning` と同思想)。

## Test plan

- [x] `make before-commit` all green
- [ ] dev で新規 deploy → Building phase 中に \"準備中\" UI が出る
- [ ] CFn stack 作成後は通常の stack progress が出る

## Regression 分析

- 既存の 409 path は完全互換
- raw warning は **5xx + TypeError のみ** 隠す (4xx 400/401/403/404 等は引き続き warning で出る)

## 物理影響

- UPDATE: `apps/application-admin-console/src/pages/DeploymentDetail.tsx` (= 1 useCallback 内の判定 expression)
- NO-OP: backend / infra

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)