### PR TITLE
feat(#655): application-admin-console EventList を i18n 化 (Phase 5.D)

### DIFF
--- a/apps/application-admin-console/src/i18n/index.tsx
+++ b/apps/application-admin-console/src/i18n/index.tsx
@@ -93,7 +93,10 @@ interface I18nContextValue {
   readonly t: (key: string, params?: Readonly<Record<string, string | number>>) => string;
 }
 
-function interpolate(template: string, params?: Readonly<Record<string, string | number>>): string {
+export function interpolate(
+  template: string,
+  params?: Readonly<Record<string, string | number>>,
+): string {
   if (!params) return template;
   return template.replace(/\{(\w+)\}/g, (match, name) => {
     const v = params[name];

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -28,5 +28,30 @@
     "header_description": "TenkaCloud Battle / Challenge — Tenant admin console",
     "open_catalog": "Open problem catalog",
     "welcome": "Welcome, {displayName}"
+  },
+  "event_list": {
+    "header": "Events",
+    "description": "Competition events. One event = N teams x M problems that can be deployed and torn down in bulk.",
+    "create_button": "Create event",
+    "error_header": "Error",
+    "loading": "Loading…",
+    "show_archived": "Show archived ({count})",
+    "empty_no_event": "No events yet. Start by clicking \"Create event\".",
+    "empty_all_archived": "No events match. Tick the checkbox above to include archived ones.",
+    "col_name": "Event name",
+    "col_status": "Status",
+    "col_team_count": "Teams",
+    "col_problem_count": "Problems",
+    "col_created_at": "Created",
+    "col_actions": "Actions",
+    "archive_action": "Archive",
+    "archive_aria": "Archive event {name}",
+    "archive_modal_header": "Archive this event?",
+    "archive_modal_body": "Archiving event {name} removes it from the default view.",
+    "archive_modal_note": "You cannot un-archive, but child deployment / Team rows are auto-removed by TTL. Run Bulk Teardown first if you haven't.",
+    "archive_modal_cancel": "Cancel",
+    "archive_modal_confirm": "Archive",
+    "archive_conflict_known": "Event \"{name}\" cannot be archived (current: {current}, allowed: DRAFT / ENDED / TEARDOWN)",
+    "archive_conflict_unknown": "Event \"{name}\" cannot be archived"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/es.json
+++ b/apps/application-admin-console/src/i18n/locales/es.json
@@ -28,5 +28,30 @@
     "header_description": "TenkaCloud Battle / Challenge — Consola de administración del tenant",
     "open_catalog": "Abrir catálogo de problemas",
     "welcome": "Bienvenido, {displayName}"
+  },
+  "event_list": {
+    "header": "Eventos",
+    "description": "Eventos de competición. Un evento = N equipos x M problemas que se despliegan y desmontan en bloque.",
+    "create_button": "Crear evento",
+    "error_header": "Error",
+    "loading": "Cargando…",
+    "show_archived": "Mostrar archivados ({count})",
+    "empty_no_event": "Aún no hay eventos. Empieza con \"Crear evento\".",
+    "empty_all_archived": "Ningún evento coincide. Marca la casilla de arriba para incluir los archivados.",
+    "col_name": "Nombre del evento",
+    "col_status": "Estado",
+    "col_team_count": "Equipos",
+    "col_problem_count": "Problemas",
+    "col_created_at": "Creado",
+    "col_actions": "Acciones",
+    "archive_action": "Archivar",
+    "archive_aria": "Archivar evento {name}",
+    "archive_modal_header": "¿Archivar este evento?",
+    "archive_modal_body": "Al archivar el evento {name} se retira de la vista por defecto.",
+    "archive_modal_note": "No es posible desarchivar, pero las filas hijas de deployment / Team se eliminan automáticamente por TTL. Ejecuta Bulk Teardown primero si todavía no lo has hecho.",
+    "archive_modal_cancel": "Cancelar",
+    "archive_modal_confirm": "Archivar",
+    "archive_conflict_known": "El evento \"{name}\" no se puede archivar (actual: {current}, permitidos: DRAFT / ENDED / TEARDOWN)",
+    "archive_conflict_unknown": "El evento \"{name}\" no se puede archivar"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -28,5 +28,30 @@
     "header_description": "TenkaCloud Battle / Challenge — テナント管理コンソール",
     "open_catalog": "問題カタログを開く",
     "welcome": "ようこそ、{displayName} さん"
+  },
+  "event_list": {
+    "header": "Event 一覧",
+    "description": "競技イベント (Event) 一覧。1 event = N teams × M problems を一括 deploy / teardown できます。",
+    "create_button": "新規 Event 作成",
+    "error_header": "エラー",
+    "loading": "読み込み中…",
+    "show_archived": "アーカイブ済 ({count}) も表示",
+    "empty_no_event": "まだ Event はありません。「新規 Event 作成」から始めてください。",
+    "empty_all_archived": "表示対象の Event はありません (アーカイブ済を含めるには上のチェックボックスを ON)。",
+    "col_name": "Event 名",
+    "col_status": "ステータス",
+    "col_team_count": "チーム数",
+    "col_problem_count": "問題数",
+    "col_created_at": "作成",
+    "col_actions": "操作",
+    "archive_action": "アーカイブ",
+    "archive_aria": "Event {name} をアーカイブ",
+    "archive_modal_header": "Event をアーカイブしますか?",
+    "archive_modal_body": "Event {name} をアーカイブし、 一覧の default view から外します。",
+    "archive_modal_note": "ARCHIVED から戻すことはできませんが、配下の deployment / Team 行は TTL で自動消去されます。Bulk Teardown が未済の場合は先に実施してください。",
+    "archive_modal_cancel": "キャンセル",
+    "archive_modal_confirm": "アーカイブ",
+    "archive_conflict_known": "Event \"{name}\" はアーカイブできません (現在: {current}、許可: DRAFT / ENDED / TEARDOWN)",
+    "archive_conflict_unknown": "Event \"{name}\" はアーカイブできません"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/zh.json
+++ b/apps/application-admin-console/src/i18n/locales/zh.json
@@ -28,5 +28,30 @@
     "header_description": "TenkaCloud Battle / Challenge — 租户管理控制台",
     "open_catalog": "打开题目目录",
     "welcome": "欢迎, {displayName}"
+  },
+  "event_list": {
+    "header": "Event 列表",
+    "description": "比赛活动 (Event) 列表。一个 event = N 个团队 × M 个题目,可批量 deploy / teardown。",
+    "create_button": "新建 Event",
+    "error_header": "错误",
+    "loading": "正在加载…",
+    "show_archived": "显示已归档 ({count})",
+    "empty_no_event": "尚无 Event。点击 \"新建 Event\" 开始。",
+    "empty_all_archived": "没有符合条件的 Event。 勾选上方复选框可显示已归档项。",
+    "col_name": "Event 名称",
+    "col_status": "状态",
+    "col_team_count": "团队数",
+    "col_problem_count": "题目数",
+    "col_created_at": "创建时间",
+    "col_actions": "操作",
+    "archive_action": "归档",
+    "archive_aria": "归档 Event {name}",
+    "archive_modal_header": "是否归档此 Event?",
+    "archive_modal_body": "归档 Event {name} 后将从默认视图中移除。",
+    "archive_modal_note": "归档无法撤销,但其下的 deployment / Team 行由 TTL 自动清理。如尚未 Bulk Teardown,请先执行。",
+    "archive_modal_cancel": "取消",
+    "archive_modal_confirm": "归档",
+    "archive_conflict_known": "Event \"{name}\" 无法归档 (当前: {current},允许: DRAFT / ENDED / TEARDOWN)",
+    "archive_conflict_unknown": "Event \"{name}\" 无法归档"
   }
 }

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -20,6 +20,7 @@ import {
   listEvents,
 } from "../api/events-client";
 import type { AppConfig } from "../config";
+import { interpolate, useT } from "../i18n";
 
 const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   DRAFT: "blue",
@@ -40,13 +41,14 @@ interface ColumnContext {
   navigate: NavigateFunction;
   onArchiveClick: (item: EventSummary) => void;
   archivingId: string | null;
+  t: (key: string) => string;
 }
 
 function buildColumns(ctx: ColumnContext): TableProps.ColumnDefinition<EventSummary>[] {
   return [
     {
       id: "name",
-      header: "Event 名",
+      header: ctx.t("event_list.col_name"),
       cell: (item) => (
         <Link
           fontSize="body-m"
@@ -62,24 +64,32 @@ function buildColumns(ctx: ColumnContext): TableProps.ColumnDefinition<EventSumm
     },
     {
       id: "status",
-      header: "ステータス",
+      header: ctx.t("event_list.col_status"),
       cell: (item) => <Badge color={STATUS_COLOR[item.status]}>{item.status}</Badge>,
     },
-    { id: "teamCount", header: "チーム数", cell: (item) => item.teamCount },
-    { id: "problemCount", header: "問題数", cell: (item) => item.problemCount },
-    { id: "createdAt", header: "作成", cell: (item) => item.createdAt },
+    {
+      id: "teamCount",
+      header: ctx.t("event_list.col_team_count"),
+      cell: (item) => item.teamCount,
+    },
+    {
+      id: "problemCount",
+      header: ctx.t("event_list.col_problem_count"),
+      cell: (item) => item.problemCount,
+    },
+    { id: "createdAt", header: ctx.t("event_list.col_created_at"), cell: (item) => item.createdAt },
     {
       id: "actions",
-      header: "操作",
+      header: ctx.t("event_list.col_actions"),
       cell: (item) => (
         <Button
           variant="link"
           loading={ctx.archivingId === item.eventId}
           disabled={!ARCHIVABLE_STATUSES.has(item.status)}
           onClick={() => ctx.onArchiveClick(item)}
-          ariaLabel={`Event ${item.name} をアーカイブ`}
+          ariaLabel={interpolate(ctx.t("event_list.archive_aria"), { name: item.name })}
         >
-          アーカイブ
+          {ctx.t("event_list.archive_action")}
         </Button>
       ),
     },
@@ -89,6 +99,7 @@ function buildColumns(ctx: ColumnContext): TableProps.ColumnDefinition<EventSumm
 export function EventListPage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
   const navigate = useNavigate();
+  const t = useT();
   const [items, setItems] = useState<readonly EventSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showArchived, setShowArchived] = useState(false);
@@ -149,8 +160,8 @@ export function EventListPage({ config }: { config: AppConfig }) {
         const current = match?.[1];
         setError(
           current
-            ? `Event "${target.name}" はアーカイブできません (現在: ${current}、許可: DRAFT / ENDED / TEARDOWN)`
-            : `Event "${target.name}" はアーカイブできません`,
+            ? interpolate(t("event_list.archive_conflict_known"), { name: target.name, current })
+            : interpolate(t("event_list.archive_conflict_unknown"), { name: target.name }),
         );
       } else {
         setError(err instanceof Error ? err.message : String(err));
@@ -161,14 +172,14 @@ export function EventListPage({ config }: { config: AppConfig }) {
   };
 
   const columns = useMemo(
-    () => buildColumns({ navigate, onArchiveClick, archivingId }),
-    [navigate, onArchiveClick, archivingId],
+    () => buildColumns({ navigate, onArchiveClick, archivingId, t }),
+    [navigate, onArchiveClick, archivingId, t],
   );
 
   if (!items && !error) {
     return (
       <Box textAlign="center" padding="l">
-        <Spinner /> 読み込み中…
+        <Spinner /> {t("event_list.loading")}
       </Box>
     );
   }
@@ -177,53 +188,58 @@ export function EventListPage({ config }: { config: AppConfig }) {
     <SpaceBetween size="l">
       <Header
         variant="h1"
-        description="競技イベント (Event) 一覧。1 event = N teams × M problems を一括 deploy / teardown できます。"
+        description={t("event_list.description")}
         actions={
           <Button variant="primary" onClick={() => navigate("/events/new")}>
-            新規 Event 作成
+            {t("event_list.create_button")}
           </Button>
         }
       >
-        Event 一覧
+        {t("event_list.header")}
       </Header>
 
       {error && (
-        <Alert type="error" header="エラー" dismissible onDismiss={() => setError(null)}>
+        <Alert
+          type="error"
+          header={t("event_list.error_header")}
+          dismissible
+          onDismiss={() => setError(null)}
+        >
           {error}
         </Alert>
       )}
 
       {archivedCount > 0 && (
         <Checkbox checked={showArchived} onChange={({ detail }) => setShowArchived(detail.checked)}>
-          アーカイブ済 ({archivedCount}) も表示
+          {interpolate(t("event_list.show_archived"), { count: String(archivedCount) })}
         </Checkbox>
       )}
 
       <Table
         items={visible}
         columnDefinitions={columns}
-        loadingText="読み込み中"
+        loadingText={t("event_list.loading")}
         empty={
           <Box textAlign="center" color="inherit" padding="xxl">
-            {showArchived
-              ? "まだ Event はありません。「新規 Event 作成」から始めてください。"
-              : archivedCount > 0
-                ? "表示対象の Event はありません (アーカイブ済を含めるには上のチェックボックスを ON)。"
-                : "まだ Event はありません。「新規 Event 作成」から始めてください。"}
+            {showArchived || archivedCount === 0
+              ? t("event_list.empty_no_event")
+              : t("event_list.empty_all_archived")}
           </Box>
         }
       />
 
       <Modal
         visible={archiveTarget !== null}
-        header="Event をアーカイブしますか?"
+        header={t("event_list.archive_modal_header")}
         onDismiss={() => setArchiveTarget(null)}
         footer={
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
-              <Button onClick={() => setArchiveTarget(null)}>キャンセル</Button>
+              <Button onClick={() => setArchiveTarget(null)}>
+                {t("event_list.archive_modal_cancel")}
+              </Button>
               <Button variant="primary" onClick={handleArchiveConfirm}>
-                アーカイブ
+                {t("event_list.archive_modal_confirm")}
               </Button>
             </SpaceBetween>
           </Box>
@@ -231,12 +247,12 @@ export function EventListPage({ config }: { config: AppConfig }) {
       >
         <SpaceBetween size="s">
           <Box>
-            Event <Box variant="strong">{archiveTarget?.name}</Box> をアーカイブし、 一覧の default
-            view から外します。
+            {interpolate(t("event_list.archive_modal_body"), {
+              name: archiveTarget?.name ?? "",
+            })}
           </Box>
           <Box variant="small" color="text-status-info">
-            ARCHIVED から戻すことはできませんが、配下の deployment / Team 行は TTL で
-            自動消去されます。Bulk Teardown が未済の場合は先に実施してください。
+            {t("event_list.archive_modal_note")}
           </Box>
         </SpaceBetween>
       </Modal>


### PR DESCRIPTION
## Summary

Phase 5.C (= admin-console TenantCreate / TenantEvents) の続編。 application-admin-console の **EventList page** を `useT()` ベースに置換し、 4 言語 (ja/en/es/zh) で **24 keys** を `event_list.*` namespace に追加。

## 副次修正

`i18n/index.tsx` の `interpolate()` を named export 化:
- 旧来 private function、 EventList が直接呼ぶ必要が出たため public 化
- application-admin-console の他 page (= EventCreate / EventDetail 等) でも今後使える

## 翻訳した要素

| カテゴリ | 内容 |
|---|---|
| Header | header / description / Create button / Error alert |
| State | Loading spinner / show archived checkbox (count interpolation) |
| Table columns | 6 columns (Event 名 / ステータス / チーム数 / 問題数 / 作成 / 操作) |
| Archive | button action + aria-label with name interpolation |
| Modal | header / body with name / note / cancel / confirm |
| Conflict error | 2 variant (known currentStatus / unknown) |

## Test plan

- [x] `make before-commit` all green
- [x] cdk synth で build pass (= app build path)
- [ ] dev で /events を 4 言語切替表示確認

## 残作業 (= 後続 PR 候補)

- application-admin-console: CompetitorAccounts (558 行) / EventCreate (473) / EventDetail (994) / DeploymentDetail (794)
- admin-console: AdminEventDetail (357 行) / AdminDeploymentDetail (461)

## Regression 分析

- 既存 EventList の挙動は完全互換 (= 同 strings を JA で展開)
- archive 経路 / poll / column 構造は touch せず translation のみ
- interpolate export 化は additive (= 既存 import 経路に影響なし)

## 物理影響

- UPDATE: `apps/application-admin-console/src/pages/EventList.tsx` (= useT 化)
- UPDATE: `apps/application-admin-console/src/i18n/locales/{ja,en,es,zh}.json` (= 24 keys × 4)
- UPDATE: `apps/application-admin-console/src/i18n/index.tsx` (= interpolate export 化)
- NO-OP: backend / infra / CFn

Relates #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)