### PR TITLE
fix(#686 revisit): fail-closed rollback + Cognito readAttributes に custom:tenantId

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -13,12 +13,19 @@ export function extractTenantIdFromClaims(claims: JwtClaims | undefined): string
 }
 
 /**
- * Issue #686: JWT に `custom:tenantId` が無い + `DEFAULT_TENANT_ID` env も unset の場合に
- * silent fallback `"unknown-tenant"` を返していたため、 全 row が同 partition に書かれ
- * UI に `Tenant: unknown-tenant` が出ていた。 fail-closed に変更し、 caller (handler) が
- * 401 Unauthorized で弾けるよう Error を throw する。
+ * Issue #686 (revisit): 旧 fail-closed (= JWT claim 欠落で `MissingTenantClaimError` throw)
+ * は Cognito UserPoolClient の readAttributes 設定漏れで `custom:tenantId` が id_token に
+ * 載らない既存 tenant に対し GET /events が全部 500 になる regression を引き起こした
+ * (PR-697 deploy 後の事故報告)。
  *
- * `DEFAULT_TENANT_ID` env は dev / local 経路向けの explicit override として残す。
+ * 暫定 rollback: silent fallback `"unknown-tenant"` に戻す。 別途、
+ *  (a) tenant-template/identity-provider.ts の UserPoolClient `readAttributes` に
+ *      `custom:tenantId` を明示追加 (= JWT に確実に乗せる)
+ *  (b) frontend が `tenantId === "unknown-tenant"` を 「(自動検出中)」 で表示する band-aid
+ * の 2 経路で正解に近づける (= 別 PR)。
+ *
+ * `MissingTenantClaimError` class は handler 側 onError 配線が既に残っているため、
+ * type 互換のために残置 (= 将来 fail-closed 復帰時に再利用可能)。
  */
 export class MissingTenantClaimError extends Error {
   constructor() {
@@ -29,14 +36,14 @@ export class MissingTenantClaimError extends Error {
   }
 }
 
+const FALLBACK_TENANT_ID = "unknown-tenant";
+
 export function resolveTenantId(c: Context): string {
   const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
   const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
   const fromJwt = extractTenantIdFromClaims(claims);
   if (fromJwt) return fromJwt;
-  const fromEnv = process.env.DEFAULT_TENANT_ID;
-  if (fromEnv && fromEnv.length > 0 && fromEnv !== "unknown-tenant") return fromEnv;
-  throw new MissingTenantClaimError();
+  return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;
 }
 
 /**

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -222,6 +222,17 @@ export class IdentityProvider extends Construct {
       email: true,
     });
 
+    // Issue #686 (root cause): id_token に `custom:tenantId` が乗らず deploy 経路で
+    // tenant 識別ができなかった。 Cognito の readAttributes が unset だと default で全
+    // 標準 attribute が読めるが、 **custom: は明示的に追加しないと id_token claim に
+    // 出ない**。 readAttributes に `custom:tenantId` 等を明示する。
+    const readAttributes = new aws_cognito.ClientAttributes()
+      .withStandardAttributes({
+        email: true,
+        emailVerified: true,
+      })
+      .withCustomAttributes("tenantId", "userRole", "apiKey", "tenantTier");
+
     this.tenantUserPoolClient = new aws_cognito.UserPoolClient(this, "tenantUserPoolClient", {
       userPool: this.tenantUserPool,
       generateSecret: false,
@@ -232,6 +243,7 @@ export class IdentityProvider extends Construct {
         custom: false,
       },
       writeAttributes: writeAttributes,
+      readAttributes: readAttributes,
       oAuth: {
         scopes: [
           aws_cognito.OAuthScope.EMAIL,

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -2,7 +2,6 @@ import type { Context } from "hono";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   extractTenantIdFromClaims,
-  MissingTenantClaimError,
   resolveTenantId,
 } from "../../lib/problem-deploy/handlers/deploy-handler/auth";
 
@@ -64,16 +63,10 @@ describe("resolveTenantId", () => {
     expect(resolveTenantId(c)).toBe("tenant-from-env");
   });
 
-  it("env も無ければ MissingTenantClaimError を throw すべき (#686 — fail-closed)", () => {
+  it("env も無ければ unknown-tenant に倒すべき (= silent fallback、 PR-697 rollback)", () => {
     delete process.env.DEFAULT_TENANT_ID;
     const c = buildCtx();
-    expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
-  });
-
-  it('env が "unknown-tenant" でも throw すべき (= legacy stub を silent 受け入れない)', () => {
-    process.env.DEFAULT_TENANT_ID = "unknown-tenant";
-    const c = buildCtx();
-    expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
+    expect(resolveTenantId(c)).toBe("unknown-tenant");
   });
 
   it("requestContext が存在しない (Function URL ops 経路) なら env にフォールバック", () => {


### PR DESCRIPTION
## Summary

🔥 **Production 障害修正** — PR-697 (#686 第一弾) を deploy 後、 EventApi / DeployApi が **全 request で 500** を返していた。

CloudWatch logs で原因確定:

\`\`\`
2026-05-13T15:24:19 ERROR [events] listEvents failed {
  message: 'JWT に custom:tenantId claim がありません (tenant 招待メール経由で再ログインしてください)'
}
\`\`\`

10 秒間隔で 200 件以上の error が記録されていた (= 30 分間 service down)。

## 真の Root cause

Cognito UserPoolClient の `readAttributes` を **unset** にしていたため、 custom attributes が id_token claims に **出ない**。 Cognito default は標準 attribute のみで、 `custom:tenantId` を id_token に乗せるには `readAttributes` に明示追加が必要 (= AWS spec)。

`provision-tenant.sh` が `admin-create-user --user-attributes Name=custom:tenantId,Value=...` で値を set しても、 client の readAttributes に含まれないと token claim に乗らない。

## 修正

| 変更 | 目的 |
|---|---|
| `resolveTenantId()` を silent fallback `\"unknown-tenant\"` に rollback | 既存 deploy された UserPool で動作復帰させる (= hot-fix) |
| `MissingTenantClaimError` class は残置 | 将来 fail-closed 復帰時の互換性 |
| Cognito UserPoolClient に `readAttributes` 追加 | id_token に `custom:tenantId` / `userRole` / `apiKey` / `tenantTier` を明示的に乗せる |
| tests を rollback | fail-closed assertion を silent fallback assertion に戻す |

## Test plan

- [x] `make before-commit` all green
- [x] CloudWatch logs で 500 の root cause を特定 (= JWT claim 欠落)
- [ ] dev で `make deploy` → tenant template stack が UserPoolClient.readAttributes update
- [ ] tenant admin が **再ログイン** → 新 token に `custom:tenantId` が乗る
- [ ] EventList / DeploymentDetail で実 tenantId が表示される

## ⚠ Operational impact

- 既存 tenant の **全 admin user に再ログイン依頼**: 既存 JWT は readAttributes 未配線時の token で、新 readAttributes が反映されるには再認証が必要
- 再ログイン後は EventList が正常表示、 DeploymentDetail の Tenant 欄も実値表示

## 後続 (= 別 PR)

- DeploymentDetail で `tenantId === \"unknown-tenant\"` を 「(自動検出中)」 友好表示
- 全 tenant の readAttributes 修正が行き渡ったら fail-closed 復活

## Regression 分析

- 既存正規 JWT (= readAttributes 反映済) からは影響なし
- silent fallback "unknown-tenant" は PR-697 deploy 前と同じ挙動
- readAttributes 追加は additive で write 経路には影響なし

## 物理影響

- UPDATE: `infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts` (= fail-closed rollback)
- UPDATE: `infrastructure/lib/tenant-template/identity-provider.ts` (= readAttributes 追加)
- UPDATE: `infrastructure/test/problem-deploy/deploy-auth.test.ts` (= test assertion rollback)
- CFn diff: UserPoolClient.ReadAttributes プロパティが追加 (= UPDATE in place、 既存 user data は無影響)

Relates #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tenant identification system to gracefully handle scenarios where tenant information is missing from authentication credentials, now using a fallback mechanism instead of rejecting requests.
  * Configured custom user attributes (tenant, role, API key, and tier) to be properly included in authentication tokens for use by downstream services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/701)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->