### PR TITLE
perf: 全 polling 間隔を 30 秒に統一 (Lambda invocation コスト抑制)

### DIFF
--- a/apps/admin-console/src/pages/AdminDeploymentDetail.tsx
+++ b/apps/admin-console/src/pages/AdminDeploymentDetail.tsx
@@ -39,7 +39,8 @@ import type { AppConfig } from "../config";
  * polling 5s で基本情報 + CFn StackProgress を更新する (= operator UX を Tenant Admin
  * console と揃える)。Terminal status (COMPLETE / FAILED / DELETED) に遷移したら停止。
  */
-const POLL_INTERVAL_MS = 5_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/user で過多)。
+const POLL_INTERVAL_MS = 30_000;
 const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const TERMINAL_STATUSES = new Set(["COMPLETE", "FAILED", "DELETED"]);
 

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -42,7 +42,9 @@ import {
   type PhaseStatus,
 } from "../lib/deploy-phases";
 
-const POLL_INTERVAL_MS = 5_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒 polling は 12 req/min/user で過多)。
+// deploy phase の進行は CloudFormation 側で数十秒〜数分単位なので、 30 秒粒度で十分。
+const POLL_INTERVAL_MS = 30_000;
 
 /** Phase status を Cloudscape StatusIndicator にマップ。Netlify と意味的に揃える。 */
 const PHASE_STATUS_INDICATOR: Record<PhaseStatus, StatusIndicatorProps.Type> = {

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -34,7 +34,9 @@ const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
 /** Archive 操作が許可される Event status (backend の archive.ts と一致)。 */
 const ARCHIVABLE_STATUSES: ReadonlySet<EventStatus> = new Set(["DRAFT", "ENDED", "TEARDOWN"]);
 
-const POLL_INTERVAL_MS = 10_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 過去 10 秒 polling は 6 req/min/user で
+// EventApi 発火が過多)。 list 系は 30 秒粒度で十分。
+const POLL_INTERVAL_MS = 30_000;
 const PAGE_SIZE = 50;
 
 interface ColumnContext {

--- a/apps/application-admin-console/src/utils/deployments.ts
+++ b/apps/application-admin-console/src/utils/deployments.ts
@@ -1,7 +1,10 @@
 import type { DeploymentSummary } from "../api/deploy-client";
 
-/** Polling list pages の polling 間隔。`Deployments.tsx` / `ProblemDetail.tsx` 両方で共有。 */
-export const DEPLOYMENT_LIST_POLL_INTERVAL_MS = 10_000;
+/**
+ * Polling list pages の polling 間隔。`Deployments.tsx` / `ProblemDetail.tsx` 両方で共有。
+ * Lambda invocation コスト抑制のため 30 秒 (= 過去 10 秒 = 6 req/min/user で過多)。
+ */
+export const DEPLOYMENT_LIST_POLL_INTERVAL_MS = 30_000;
 
 /**
  * Polling 結果の安定 reference 用 frozen const。`items ?? EMPTY_DEPLOYMENT_ITEMS` で

--- a/apps/application-admin-console/test/utils/deployments.test.ts
+++ b/apps/application-admin-console/test/utils/deployments.test.ts
@@ -98,7 +98,7 @@ describe("deploymentsChanged", () => {
 describe("constants", () => {
   it("page size と polling 間隔の妥当性", () => {
     expect(DEPLOYMENT_LIST_PAGE_SIZE).toBe(50);
-    expect(DEPLOYMENT_LIST_POLL_INTERVAL_MS).toBe(10_000);
+    expect(DEPLOYMENT_LIST_POLL_INTERVAL_MS).toBe(30_000);
   });
 
   it("EMPTY_DEPLOYMENT_ITEMS は frozen で同 reference を再利用 (Table prop 安定化)", () => {

--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -21,7 +21,9 @@ import type { AppConfig } from "../config";
 import { countUnread, loadLastSeenAt, saveLastSeenAt } from "../lib/notifications-storage";
 import { useAuth } from "./AuthProvider";
 
-const POLL_INTERVAL_MS = 5_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/team で過多、 競技中に
+// N 競技者 = N team × 12 = N×12 req/min で participant-portal Lambda + DDB を圧迫していた)。
+const POLL_INTERVAL_MS = 30_000;
 /**
  * Notifications だけは 60 秒間隔で polling する (ADR-006 D3 + codex review)。
  * Events table は 1 RCU PROVISIONED なので、N 競技者 × 5 秒 polling で簡単に throttle

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -46,7 +46,8 @@ const FALLBACK_KIND_LABEL = "(未設定)";
 /** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
 const STALE_THRESHOLD_MS = 2 * 60 * 1000;
 
-const POLL_INTERVAL_MS = 5_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/user で過多)。
+const POLL_INTERVAL_MS = 30_000;
 
 /**
  * 1 problem 単位の詳細パネル。Home (= 全 problem を縦並べ) と ProblemDetail

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -17,7 +17,8 @@ import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { describeAgo, formatOccurredAtTooltip } from "../lib/format";
 
-const POLL_INTERVAL_MS = 5_000;
+// Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/user で過多)。
+const POLL_INTERVAL_MS = 30_000;
 
 const SOURCE_LABEL: Record<ScoreEventView["source"], string> = {
   uptime: "Battle (uptime)",


### PR DESCRIPTION
## Summary

CloudWatch logs で EventApi Lambda が **10 秒間隔で連続発火** していた (= PR-697 不具合調査中、 N 競技者 × 6〜12 req/min で Free Tier を圧迫する想定)。 ユーザー指示で **全 polling を 30 秒に統一**。

## 変更点

| Page | Before | After | Rationale |
|---|---|---|---|
| `EventList` (Tenant Admin) | 10s | 30s | list 系は 30 秒粒度で十分 |
| `Deployments` / `ProblemDetail` 共有 const | 10s | 30s | 同上 |
| `DeploymentDetail` (Tenant Admin) | 5s | 30s | CFn 進行は数十秒〜数分単位 |
| `AdminDeploymentDetail` (System Admin) | 5s | 30s | 同上 |
| `TeamViewProvider` (Participant Portal) | 5s | 30s | participant-portal Lambda + DDB の主な発火元 |
| `ProblemPanel` (Participant Portal) | 5s | 30s | score 更新は 1 分粒度で十分 |
| `ScoreEvents` (Participant Portal) | 5s | 30s | 同上 |

## コスト試算

- Tenant Admin 1 人が EventList を開く: **18 req/min → 6 req/min (-67%)**
- Participant N 人が Portal を開く: **N × 12 req/min → N × 2 req/min (-83%)**
- 競技中 20 team が同時に portal を開く想定: 旧 **240 req/min** → 新 **40 req/min**

## Test plan

- [x] `make before-commit` all green (= deployments.test.ts の `DEPLOYMENT_LIST_POLL_INTERVAL_MS === 30_000` も更新)
- [ ] dev で EventList / DeploymentDetail / Portal を開いて 30 秒で更新されることを視覚 verify

## Regression 分析

- polling の同一 logic / state shape は変更なし (= 30s 間隔で同じ data を fetch)
- deploy 進行の体感は若干遅くなる (= 5s→30s)、 ただし CodeBuild / CFn 側がそもそも数十秒単位
- live UX 重視なら将来 SSE / WebSocket に切り替える別 ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)