### PR TITLE
fix: install-node.sh が Ubuntu (deb) で fail する問題を OS family 検出で解消

### DIFF
--- a/scripts/lib/install-node.sh
+++ b/scripts/lib/install-node.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # CodeBuild の provision-tenant.sh / update-tenant.sh で source する Node セットアップ helper。
 #
-# `.nvmrc` を読んで NodeSource yum repo から install する。
+# `.nvmrc` を読んで NodeSource (deb / rpm) repo から install する。
 #
-# Why NodeSource: image 非依存で動く (AL2 / AL2023 / standard:7.0)。CodeBuild image に
-# nvm が無いケースで silent fail した旧 nvm 経路 (#560) の置換。
+# Why NodeSource: image 非依存で動く (AL2 / AL2023 / Ubuntu standard:5.0 / 7.0)。CodeBuild image
+# に nvm が無いケースで silent fail した旧 nvm 経路 (#560) の置換。
 # Why .nvmrc 経由: バージョン値を repo root の 1 ファイルに集約し、ローカル dev (`nvm use`)
 # と CodeBuild で同じ version を使う。
 # Why pipefail: caller 側で `set -o pipefail` を有効化していること前提。`curl ... | sudo bash -`
 # の途中失敗を取りこぼさないため。
+# Why OS detect: CodeBuild の LinuxBuildImage.STANDARD_5_0 は Ubuntu (deb) で
+# `rpm.nodesource.com` が `This script is intended for RPM-based systems` で fail する。
+# `apt-get` / `yum` (or `dnf`) のどちらが居るかで NodeSource URL とパッケージマネージャを切替える。
 
 install_node_from_nvmrc() {
   local node_major
@@ -19,8 +22,23 @@ install_node_from_nvmrc() {
     echo "Invalid .nvmrc format: expected '20' / '20.11' / 'v20.11.1' style" >&2
     return 1
   fi
-  curl -fsSL "https://rpm.nodesource.com/setup_${node_major}.x" | sudo bash -
-  sudo yum install -y nodejs
+
+  if command -v apt-get >/dev/null 2>&1; then
+    # deb 系 (= Ubuntu / Debian)。 NodeSource の deb setup script を使う。
+    curl -fsSL "https://deb.nodesource.com/setup_${node_major}.x" | sudo -E bash -
+    sudo apt-get install -y nodejs
+  elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+    # rpm 系 (= Amazon Linux / RHEL / Fedora)。 NodeSource の rpm setup script を使う。
+    curl -fsSL "https://rpm.nodesource.com/setup_${node_major}.x" | sudo bash -
+    if command -v dnf >/dev/null 2>&1; then
+      sudo dnf install -y nodejs
+    else
+      sudo yum install -y nodejs
+    fi
+  else
+    echo "Neither apt-get nor dnf/yum found. Cannot install Node.js." >&2
+    return 1
+  fi
   node --version
   npm --version
 }


### PR DESCRIPTION
## Summary

PR-693 (#690) の pipefail 修正後、 CodeBuild が次の段階で fail していた:

\`\`\`
2026-05-13 15:42:32 - Error: This script is intended for RPM-based systems.
\`\`\`

`scripts/lib/install-node.sh` が hardcode で `rpm.nodesource.com/setup_20.x` を叩いていたが、 CodeBuild の image (\`LinuxBuildImage.STANDARD_5_0\`) は **Ubuntu** (deb-based) なので失敗。

## 修正

`command -v apt-get` で OS family を検出 → 正しい NodeSource URL + パッケージマネージャに切替:

| OS family | URL | package manager |
|---|---|---|
| Ubuntu / Debian | `deb.nodesource.com/setup_N.x` | `apt-get install -y nodejs` |
| Amazon Linux 2023 | `rpm.nodesource.com/setup_N.x` | `dnf install -y nodejs` |
| AL2 / RHEL / Fedora | `rpm.nodesource.com/setup_N.x` | `yum install -y nodejs` |
| (どちらも無い) | — | fail-fast |

## Test plan

- [x] `make before-commit` all green
- [ ] CodeBuild で tenant 作成 → install-node phase が pass する
- [ ] local dev は影響なし (= nvm 経路、 本 script を呼ばない)

## Regression 分析

- AL2 / AL2023 (rpm) 経路は完全互換 (= 既存 URL / dnf 優先で yum fallback)
- Ubuntu 経路を **新規追加** (= 既存 deploy が動いていた image は AL であった可能性高、 STANDARD_5_0 への移行で発覚)
- どちらも無い image (= scratch / Alpine) は fail-fast で診断 friendly

## 関連

- #690 / PR-693 (pipefail bash heredoc、 同 deploy chain 上流)
- #692 / PR-694 (Lambda IAM、 BUILD phase 通過後に発火)

🤖 Generated with [Claude Code](https://claude.com/claude-code)