### PR TITLE
fix(#704): ConsoleViewerRole を tc-* 最小権限 + per-namePrefix session policy に narrow

### DIFF
--- a/infrastructure/lib/problem-deploy/console-viewer-role.ts
+++ b/infrastructure/lib/problem-deploy/console-viewer-role.ts
@@ -1,5 +1,11 @@
 import { Duration } from "aws-cdk-lib";
-import { AccountRootPrincipal, ManagedPolicy, Role } from "aws-cdk-lib/aws-iam";
+import {
+  AccountRootPrincipal,
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+} from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
 /**
@@ -9,8 +15,11 @@ import { Construct } from "constructs";
  * 取得し、`signin.aws.amazon.com/federation` 経由で SigninToken を発行 → 競技者は
  * 自前の AWS ログイン無しで AWS Console に federate される。
  *
- * 権限スコープ: `ReadOnlyAccess`。Trust は同 account root (= Lambda 側の policy で
- * 二重ゲート、cross-account は別 Role でカバー)。MaxSession 1h = federation TTL と一致。
+ * 旧実装は `ReadOnlyAccess` AWS managed policy を付与していたが、これだと CodePipeline /
+ * CodeBuild / Cognito UserPool list / 他テナント `tc-*` stack 等、 operator の deploy 業務
+ * 情報が競技者から丸見えだった (#704)。本 Role は `tc-*` 接頭辞リソースに対する
+ * 最小権限のみを inline で持つ。 さらに sso.ts の session policy で team 自身の
+ * namePrefix に絞る。
  */
 export class ConsoleViewerRole extends Construct {
   public readonly role: Role;
@@ -20,8 +29,66 @@ export class ConsoleViewerRole extends Construct {
     this.role = new Role(this, "Role", {
       assumedBy: new AccountRootPrincipal(),
       maxSessionDuration: Duration.hours(1),
-      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
-      description: "Federation target for participant AWS Console one-click login.",
+      description: "Federation target for participant AWS Console one-click login (tc-* scoped).",
+      inlinePolicies: {
+        TcReadOnly: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: [
+                "cloudformation:DescribeStacks",
+                "cloudformation:GetTemplate",
+                "cloudformation:ListStackResources",
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeStackResource",
+                "cloudformation:DescribeStackResources",
+              ],
+              resources: ["arn:aws:cloudformation:*:*:stack/tc-*"],
+            }),
+            // ListStacks は ARN 制約不可。 競技者 Console で stack 一覧を表示する
+            // ため必要。他チームの `tc-*` stack 名は名前だけ可視 (= leak は名前のみ)、
+            // events / resources は上の Resource 制約で gate される。
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: ["cloudformation:ListStacks"],
+              resources: ["*"],
+            }),
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: [
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:GetLogEvents",
+                "logs:FilterLogEvents",
+              ],
+              resources: [
+                "arn:aws:logs:*:*:log-group:/aws/lambda/tc-*",
+                "arn:aws:logs:*:*:log-group:/aws/lambda/tc-*:log-stream:*",
+              ],
+            }),
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: ["lambda:GetFunction", "lambda:ListFunctions"],
+              resources: ["arn:aws:lambda:*:*:function:tc-*"],
+            }),
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: ["s3:GetBucketLocation", "s3:ListBucket", "s3:GetObject"],
+              resources: ["arn:aws:s3:::tc-*", "arn:aws:s3:::tc-*/*"],
+            }),
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: ["ec2:DescribeInstances", "ec2:DescribeSecurityGroups", "ec2:DescribeVpcs"],
+              resources: ["*"],
+            }),
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: ["apigateway:GET"],
+              resources: ["*"],
+            }),
+          ],
+        }),
+      },
     });
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -24,58 +24,94 @@ const FEDERATION_SESSION_DURATION_SEC = 3600;
 const TENKACLOUD_ISSUER = "https://tenkacloud.example/portal";
 
 /**
- * AssumeRole 時の inline session policy。`ConsoleViewerRole` の `ReadOnlyAccess` を
- * 「stack の状態が見れる + 競技対象 service の Describe」だけに**さらに絞る**ための gate。
+ * AssumeRole 時の inline session policy を namePrefix scope で組み立てる。
  *
- * 必要: 競技者は自分の deployment の CFn / EC2 / Logs だけ見えればよい。
- * 危険: ReadOnlyAccess 単体だと operator account の DDB Deployments テーブル
- * (= 全チームの teamLoginKey が入っている) を Scan されて bearer token が漏れる。
- * → `dynamodb:*` / `secretsmanager:*` / `ssm:Get*` / `kms:Decrypt` / `iam:*` を Deny で殺す。
+ * 旧実装は Allow Resource を `"*"` で broad に開いていた (#704)。Role 側の
+ * `ReadOnlyAccess` を外し `tc-*` 接頭辞に絞ったので、 さらに本 session policy で
+ * **当該 team の `tc-{problemSlug}-{teamSlug}` だけ**に narrow する。
  *
  * セッションポリシーは Role の policy との **AND** で評価される (= Allow の和集合では
- * なく交差) なので、ここで Allow したものは元 Role に無ければ通らない。
+ * なく交差) ため、ここで Allow した範囲しか操作できない。
+ *
+ * Deny:
+ *   - codepipeline:* / codebuild:* → operator の deploy job (= 他テナント問題の進行) を遮蔽
+ *   - cognito-idp:* / cognito-identity:* → tenant UserPool 名 leak 防止
+ *   - dynamodb / secretsmanager / ssm:Get-Describe / kms:Decrypt / iam / sts:AssumeRole
+ *     → operator account の bearer token / KMS / 他 Role への乗り換えを禁止
  */
-const SESSION_POLICY = JSON.stringify({
-  Version: "2012-10-17",
-  Statement: [
-    {
-      Effect: "Allow",
-      Action: [
-        "cloudformation:DescribeStacks",
-        "cloudformation:GetTemplate",
-        "cloudformation:ListStackResources",
-        "cloudformation:DescribeStackEvents",
-        "cloudformation:DescribeStackResource",
-        "cloudformation:DescribeStackResources",
-        "ec2:Describe*",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
-        "logs:GetLogEvents",
-        "logs:FilterLogEvents",
-        "lambda:GetFunction",
-        "lambda:ListFunctions",
-        "apigateway:GET",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-      ],
-      Resource: "*",
-    },
-    {
-      Effect: "Deny",
-      Action: [
-        "dynamodb:*",
-        "secretsmanager:*",
-        "ssm:Get*",
-        "ssm:Describe*",
-        "kms:Decrypt",
-        "kms:GenerateDataKey",
-        "iam:*",
-        "sts:AssumeRole",
-      ],
-      Resource: "*",
-    },
-  ],
-});
+function buildSessionPolicy(namePrefix: string): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "cloudformation:DescribeStacks",
+          "cloudformation:GetTemplate",
+          "cloudformation:ListStackResources",
+          "cloudformation:DescribeStackEvents",
+          "cloudformation:DescribeStackResource",
+          "cloudformation:DescribeStackResources",
+        ],
+        Resource: [`arn:aws:cloudformation:*:*:stack/${namePrefix}/*`],
+      },
+      // ListStacks は ARN 制約不可。 Console UI の stack 一覧表示に必要なので Allow するが、
+      // events / resources の閲覧は上の per-namePrefix Allow で gate される (= 他チームの
+      // stack 詳細は AccessDenied)。
+      { Effect: "Allow", Action: "cloudformation:ListStacks", Resource: "*" },
+      {
+        Effect: "Allow",
+        Action: [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents",
+        ],
+        Resource: [
+          `arn:aws:logs:*:*:log-group:/aws/lambda/${namePrefix}*`,
+          `arn:aws:logs:*:*:log-group:/aws/lambda/${namePrefix}*:log-stream:*`,
+        ],
+      },
+      {
+        Effect: "Allow",
+        Action: ["lambda:GetFunction", "lambda:ListFunctions"],
+        Resource: [`arn:aws:lambda:*:*:function:${namePrefix}*`],
+      },
+      {
+        Effect: "Allow",
+        Action: ["s3:GetBucketLocation", "s3:ListBucket", "s3:GetObject"],
+        Resource: [`arn:aws:s3:::${namePrefix}*`, `arn:aws:s3:::${namePrefix}*/*`],
+      },
+      // ec2 Describe* は ARN 制約が効かない API があるため、 必要な subset だけ Allow。
+      // namePrefix tag による更なる絞り込みは template 側で `TenkaCloud:NamePrefix` tag が
+      // 必須化された Phase で導入予定。
+      {
+        Effect: "Allow",
+        Action: ["ec2:DescribeInstances", "ec2:DescribeSecurityGroups", "ec2:DescribeVpcs"],
+        Resource: "*",
+      },
+      { Effect: "Allow", Action: "apigateway:GET", Resource: "*" },
+      {
+        Effect: "Deny",
+        Action: [
+          "codepipeline:*",
+          "codebuild:*",
+          "cognito-idp:*",
+          "cognito-identity:*",
+          "dynamodb:*",
+          "secretsmanager:*",
+          "ssm:Get*",
+          "ssm:Describe*",
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "iam:*",
+          "sts:AssumeRole",
+        ],
+        Resource: "*",
+      },
+    ],
+  });
+}
 
 const sts = new STSClient({});
 
@@ -114,7 +150,7 @@ export async function getConsoleSigninUrl(
   const region = typeof deployment.region === "string" ? deployment.region : undefined;
   if (!region) return { kind: "not_ready" };
 
-  // STS AssumeRole + inline session policy で `ReadOnlyAccess` をさらに絞る。
+  // STS AssumeRole + inline session policy で当該 team の namePrefix だけに絞る。
   // ExternalId は同 account 内なので省略 (cross-account は別 Role でカバー)。
   let session: {
     Credentials?: { AccessKeyId?: string; SecretAccessKey?: string; SessionToken?: string };
@@ -125,7 +161,7 @@ export async function getConsoleSigninUrl(
         RoleArn: roleArn,
         RoleSessionName: `participant-${jobId}`,
         DurationSeconds: FEDERATION_SESSION_DURATION_SEC,
-        Policy: SESSION_POLICY,
+        Policy: buildSessionPolicy(deployment.namePrefix),
       }),
     );
   } catch (err) {

--- a/infrastructure/test/problem-deploy/console-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/console-viewer-role.test.ts
@@ -1,0 +1,67 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { ConsoleViewerRole } from "../../lib/problem-deploy/console-viewer-role.js";
+
+/**
+ * #704: 旧 `ReadOnlyAccess` 経路では competitor が AWS Console から operator の
+ * CodePipeline / CodeBuild / 他テナント tc-* stack を閲覧できてしまった。
+ * 本テストは Role に managed policy が無いこと + inline policy が `tc-*` 接頭辞に
+ * 絞られていることを保証する。
+ */
+describe("ConsoleViewerRole (#704)", () => {
+  function synthRole(): Template {
+    const app = new App();
+    const stack = new Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    new ConsoleViewerRole(stack, "ConsoleViewer");
+    return Template.fromStack(stack);
+  }
+
+  it("ReadOnlyAccess の AWS managed policy を attach していないべき", () => {
+    const template = synthRole();
+    const roles = template.findResources("AWS::IAM::Role");
+    const role = Object.values(roles)[0] as {
+      Properties: { ManagedPolicyArns?: unknown[] };
+    };
+    expect(role.Properties.ManagedPolicyArns ?? []).toEqual([]);
+  });
+
+  it("inline TcReadOnly policy の cloudformation/logs/lambda/s3 Allow が tc-* 接頭辞に scope されているべき", () => {
+    const template = synthRole();
+    const role = Object.values(template.findResources("AWS::IAM::Role"))[0] as {
+      Properties: {
+        Policies?: Array<{
+          PolicyName: string;
+          PolicyDocument: {
+            Statement: Array<{
+              Effect: string;
+              Action: string | string[];
+              Resource: string | string[];
+            }>;
+          };
+        }>;
+      };
+    };
+    const tcPolicy = role.Properties.Policies?.find((p) => p.PolicyName === "TcReadOnly");
+    expect(tcPolicy).toBeDefined();
+
+    const flatten = (r: string | string[]) => (Array.isArray(r) ? r : [r]);
+    const allowResources = tcPolicy?.PolicyDocument.Statement.filter((s) => s.Effect === "Allow")
+      .flatMap((s) => flatten(s.Resource))
+      .filter((r) => r !== "*");
+
+    expect(allowResources?.some((r) => r === "arn:aws:cloudformation:*:*:stack/tc-*")).toBe(true);
+    expect(allowResources?.some((r) => r === "arn:aws:logs:*:*:log-group:/aws/lambda/tc-*")).toBe(
+      true,
+    );
+    expect(allowResources?.some((r) => r === "arn:aws:lambda:*:*:function:tc-*")).toBe(true);
+    expect(allowResources?.some((r) => r === "arn:aws:s3:::tc-*")).toBe(true);
+  });
+
+  it("MaxSessionDuration は federation TTL と揃えて 1h にすべき", () => {
+    const template = synthRole();
+    template.hasResourceProperties("AWS::IAM::Role", { MaxSessionDuration: 3600 });
+  });
+});

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -153,10 +153,11 @@ describe("getConsoleSigninUrl", () => {
     const policyRaw = cmd.input.Policy;
     expect(typeof policyRaw).toBe("string");
     const policy = JSON.parse(policyRaw as string) as {
-      Statement: Array<{ Effect: string; Action: string[] }>;
+      Statement: Array<{ Effect: string; Action: string | string[]; Resource: string | string[] }>;
     };
-    const denyActions = policy.Statement.filter((s) => s.Effect === "Deny").flatMap(
-      (s) => s.Action,
+    const flattenAction = (a: string | string[]) => (Array.isArray(a) ? a : [a]);
+    const denyActions = policy.Statement.filter((s) => s.Effect === "Deny").flatMap((s) =>
+      flattenAction(s.Action),
     );
     // 他チームの teamLoginKey が DDB Deployments に入っているので必須
     expect(denyActions).toContain("dynamodb:*");
@@ -165,11 +166,56 @@ describe("getConsoleSigninUrl", () => {
     expect(denyActions).toContain("iam:*");
     // 連鎖 AssumeRole も封じる (= 別 Role に乗り換えられない)
     expect(denyActions).toContain("sts:AssumeRole");
+    // #704: operator の deploy ジョブと tenant UserPool を遮蔽
+    expect(denyActions).toContain("codepipeline:*");
+    expect(denyActions).toContain("codebuild:*");
+    expect(denyActions).toContain("cognito-idp:*");
     // CFn の閲覧は Allow されている
-    const allowActions = policy.Statement.filter((s) => s.Effect === "Allow").flatMap(
-      (s) => s.Action,
+    const allowActions = policy.Statement.filter((s) => s.Effect === "Allow").flatMap((s) =>
+      flattenAction(s.Action),
     );
     expect(allowActions).toContain("cloudformation:DescribeStacks");
+  });
+
+  it("#704: session policy の Allow Resource は deployment の namePrefix scope に絞られているべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIAFAKE",
+        SecretAccessKey: "SECRETFAKE",
+        SessionToken: "TOKENFAKE",
+        Expiration: new Date(),
+      },
+    });
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ SigninToken: "TOKEN" }), { status: 200 }),
+    );
+
+    await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+
+    const cmd = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    const policy = JSON.parse(cmd.input.Policy as string) as {
+      Statement: Array<{ Effect: string; Action: string | string[]; Resource: string | string[] }>;
+    };
+    const flatten = (r: string | string[]) => (Array.isArray(r) ? r : [r]);
+    const allowResources = policy.Statement.filter((s) => s.Effect === "Allow").flatMap((s) =>
+      flatten(s.Resource),
+    );
+    // CFn / logs / lambda / s3 は namePrefix で絞られている (= 他チームの tc-* は AccessDenied)
+    expect(
+      allowResources.some(
+        (r) => r === "arn:aws:cloudformation:*:*:stack/tc-security-battle-royale-alpha/*",
+      ),
+    ).toBe(true);
+    expect(
+      allowResources.some(
+        (r) => r === "arn:aws:lambda:*:*:function:tc-security-battle-royale-alpha*",
+      ),
+    ).toBe(true);
+    expect(allowResources.some((r) => r === "arn:aws:s3:::tc-security-battle-royale-alpha*")).toBe(
+      true,
+    );
   });
 
   it("getSigninToken が 5xx を返したら federation_endpoint_failed (#705)", async () => {


### PR DESCRIPTION
## Summary

旧 `ConsoleViewerRole` は `ReadOnlyAccess` AWS managed policy を attach していたため、 競技者が AWS Console federation login すると **operator の CodePipeline / CodeBuild deploy job / 他テナント `tc-*` stack / Cognito UserPool list** が見えていた (= ユーザー指摘 「デプロイのジョブを見せるわけにはいかない」)。

本 PR は 2 層で narrowing:

1. **`ConsoleViewerRole`** (`console-viewer-role.ts`): `ReadOnlyAccess` を外し、 inline policy `TcReadOnly` で `tc-*` 接頭辞 cloudformation / logs / lambda / s3 のみ Allow
2. **`buildSessionPolicy(namePrefix)`** (`sso.ts`): AssumeRole 時の session policy を当該 deployment の `tc-{problemSlug}-{teamSlug}` namePrefix で更に narrow、 `codepipeline:*` / `codebuild:*` / `cognito-idp:*` / `cognito-identity:*` を新規 Deny

session policy は Role policy と AND 評価 (= Allow の交差) なので、 competitor は自 team の stack 詳細だけ閲覧可能。

## Test plan

- [x] `bun vitest run test/problem-deploy/console-viewer-role.test.ts` — 3 件 pass (ManagedPolicyArns 空 / Allow Resource `tc-*` scope / MaxSession=1h)
- [x] `bun vitest run test/problem-deploy/participant-sso.test.ts` — 既存 8 件 + 新規 1 件 (per-namePrefix scope assertion) = 9 件 pass
- [x] `make before-commit` — lint / typecheck / test / build / validate-problems / cdk synth すべて OK
- [ ] `make deploy` 後の動作確認: 競技者 SSO で自 stack の CFn events が見える / `codepipeline:ListPipelines` が AccessDenied になる / 他チームの tc-* stack events も AccessDenied になる

## Regression 分析

- 競技者が必要とする view (= 自 stack の CFn events / Lambda logs / S3 artifacts) は維持
- ListStacks のみ Resource:`*` で残存 (= 他チームの tc-* **stack 名** は見える)。 events/resources の詳細閲覧は per-namePrefix Allow で gate される
- ec2:DescribeInstances 等は `*` だが、 deploy 経路で作成される EC2 は competition 想定外 (Free Tier 制約)。 必要に応じて tag 制約に narrow 可能
- federation login URL 形式 / DurationSeconds (3600s) は無変更 — 既存 7 tests を通過

## 物理影響

- UPDATE: `AWS::IAM::Role` (`ConsoleViewerRole`) の `Properties.ManagedPolicyArns` 削除 + `Properties.Policies` に inline `TcReadOnly` 追加 = **REPLACE** (Role 自体は同一 LogicalId だが Properties 差分大)
- NO-OP: STSAssumeRole 経路、 federation signin URL 経路自体は code path 無変更 (Policy 文字列のみ差し替え)

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)