### PR TITLE
fix(#703): Endpoint Effective URL 空欄を CFn Output key 名入り hint に置換

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -406,6 +406,12 @@ export interface ParticipantEndpointView {
   readonly overridable: boolean;
   readonly label?: string;
   readonly description?: string;
+  /**
+   * #703 診断用: 該当 slot の default URL を引く元 CFn Output key (= metadata.endpoints[i].default.key)。
+   * defaultUrl が undefined (= deploy 未完 / template Output 未宣言) のとき UI で「{key} 待ち」と
+   * 表示するために露出。 metadata.json 由来なので機密ではない。
+   */
+  readonly defaultKey: string;
   readonly defaultUrl?: string;
   readonly overrideUrl?: string;
   readonly effectiveUrl?: string;

--- a/apps/participant-portal/src/components/EndpointOverrideForm.test.tsx
+++ b/apps/participant-portal/src/components/EndpointOverrideForm.test.tsx
@@ -90,6 +90,28 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     expect(container.textContent).not.toContain("Endpoint 登録");
   });
 
+  it("#703: effectiveUrl 未取得 (= deploy 未完) なら raw `-` ではなく CFn Output key 名入りの hint を出すべき", async () => {
+    mockList.mockResolvedValue({
+      teamId: "t1",
+      endpoints: [
+        {
+          slot: "users",
+          overridable: true,
+          label: "Users service",
+          defaultKey: "BaseUrl",
+          // defaultUrl / effectiveUrl は undefined (= stackOutputs に BaseUrl がまだ無い)
+        },
+      ],
+    });
+    render(<EndpointOverrideForm {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Users service")).toBeInTheDocument());
+    // raw em-dash は表示しない
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+    // CFn Output key 名は表示する (= operator 切り分け diagnostic)
+    expect(screen.getByText("BaseUrl")).toBeInTheDocument();
+    expect(screen.getByText(/まだ取得できていません/)).toBeInTheDocument();
+  });
+
   it("登録ボタンで putProblemEndpointOverride を呼び、 response の endpoints で再描画すべき", async () => {
     const user = userEvent.setup();
     mockList.mockResolvedValue({

--- a/apps/participant-portal/src/components/EndpointOverrideForm.tsx
+++ b/apps/participant-portal/src/components/EndpointOverrideForm.tsx
@@ -165,7 +165,6 @@ export function EndpointOverrideForm({
         <SpaceBetween size="m">
           {endpoints.map((ep) => {
             const state = editState[ep.slot] ?? EMPTY_SLOT_STATE;
-            const effective = ep.effectiveUrl ?? "—";
             return (
               <Container
                 key={ep.slot}
@@ -177,7 +176,18 @@ export function EndpointOverrideForm({
               >
                 <SpaceBetween size="s">
                   <Box variant="awsui-key-label">Effective URL</Box>
-                  <Box variant="code">{effective}</Box>
+                  {ep.effectiveUrl ? (
+                    <Box variant="code">{ep.effectiveUrl}</Box>
+                  ) : (
+                    // #703: raw `—` を出すと competitor が「何が probe されているか」を判断できない。
+                    // deploy 未完 / template Output 未宣言で defaultUrl が引けない状態であることと、
+                    // どの CFn Output key を待っているかを併記する (= operator 切り分けも兼ねる)。
+                    <Box variant="small" color="text-status-info">
+                      まだ取得できていません — deploy 完了後に CFn Outputs.
+                      <code>{ep.defaultKey}</code> から自動取得します。 今すぐ自前の URL
+                      を登録するなら 下の「新しい URL を登録」 から override してください。
+                    </Box>
+                  )}
                   {ep.overrideUrl && (
                     <Box variant="small" color="text-status-info">
                       override 中 (default: <code>{ep.defaultUrl ?? "—"}</code>)

--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/resolve.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/resolve.ts
@@ -16,6 +16,12 @@ export interface ResolvedEndpoint {
   readonly label?: string;
   readonly description?: string;
   readonly overridable: boolean;
+  /**
+   * 競技者画面の診断用 (#703): 該当 slot の default URL が引かれる元 CFn Output key。
+   * `defaultUrl` が未取得時に「(CFn Outputs.${defaultKey} 待ち)」 と表示するため UI に露出。
+   * key 自体は metadata.json に既に公開済 (= 機密情報ではない)。
+   */
+  readonly defaultKey: string;
   readonly defaultUrl?: string;
   readonly overrideUrl?: string;
   readonly effectiveUrl?: string;
@@ -52,6 +58,7 @@ export function resolveEndpoints(args: {
       ...(slot.label !== undefined ? { label: slot.label } : {}),
       ...(slot.description !== undefined ? { description: slot.description } : {}),
       overridable: slot.overridable,
+      defaultKey: slot.default.key,
       ...(defaultUrl !== undefined ? { defaultUrl } : {}),
       ...(overrideUrl !== undefined ? { overrideUrl } : {}),
       ...(effectiveUrl !== undefined ? { effectiveUrl } : {}),

--- a/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
@@ -141,6 +141,29 @@ describe("listProblemEndpoints", () => {
     expect(r.kind).toBe("misconfigured");
     expect(mockedQueryTeamItems).not.toHaveBeenCalled();
   });
+
+  it("#703: defaultKey は常に metadata の default.key で埋まり、stackOutputs 無しでも UI が hint を出せるべき", async () => {
+    mockedQueryTeamItems.mockResolvedValueOnce([
+      { ...teamRow, stackOutputs: undefined, problemId: "battle-1" },
+    ]);
+    const ddbSend = vi.fn().mockResolvedValueOnce({ Items: [] });
+    const shared = buildShared({
+      problemsEndpoints: { "battle-1": [SLOT_FRONTEND, SLOT_API] },
+      ddbSend,
+    });
+    const r = await listProblemEndpoints(shared, "key", "battle-1");
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.endpoints[0]).toMatchObject({
+      slot: "frontend",
+      defaultKey: "FrontendUrl",
+      overridable: true,
+    });
+    // defaultUrl / effectiveUrl は stackOutputs 不在のため undefined
+    expect(r.endpoints[0]?.defaultUrl).toBeUndefined();
+    expect(r.endpoints[0]?.effectiveUrl).toBeUndefined();
+    expect(r.endpoints[1]?.defaultKey).toBe("ApiUrl");
+  });
 });
 
 describe("upsertProblemEndpointOverride", () => {

--- a/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
@@ -44,6 +44,7 @@ describe("resolveEndpoints", () => {
       {
         slot: "frontend",
         overridable: false,
+        defaultKey: "FrontendUrl",
         defaultUrl: "https://front.example.com/",
         effectiveUrl: "https://front.example.com/",
       },
@@ -56,7 +57,8 @@ describe("resolveEndpoints", () => {
       stackOutputs: JSON.stringify([]),
       overrides: [],
     });
-    expect(result).toEqual([{ slot: "api", overridable: false }]);
+    // #703: defaultKey は metadata 由来なので stackOutputs に無くても露出して UI 側 hint に使う
+    expect(result).toEqual([{ slot: "api", overridable: false, defaultKey: "MissingKey" }]);
   });
 
   it("override がある slot は effectiveUrl が override で埋まるべき", () => {


### PR DESCRIPTION
## Summary

`EndpointOverrideForm` で `effectiveUrl` 未取得時に raw \`—\` (em-dash) を出していたため、 competitor は「何が probe されているか」 「何待ちか」 を判断できなかった (ユーザー指摘の Provisioning 場面で発生)。

backend `ResolvedEndpoint` に `defaultKey: string` (= metadata.endpoints[i].default.key) を追加し、 frontend 側で「まだ取得できていません — deploy 完了後に CFn Outputs.\${defaultKey} から自動取得します」 という診断的 hint を出す。 競技者は待つのか自前 URL を override するのかを判断可能、 operator は template Output 名 mismatch を即発見できる。

## Test plan

- [x] backend: \`bun vitest run test/problem-deploy/problem-endpoints-handler.test.ts\` — 既存 6 + 新規 1 (defaultKey は stackOutputs 不在でも露出) = 7 件 pass
- [x] backend: \`bun vitest run test/problem-deploy/problem-endpoints-resolve.test.ts\` — 既存 6 件を defaultKey 込みで update
- [x] frontend: \`bun vitest run src/components/EndpointOverrideForm.test.tsx\` — 既存 7 + 新規 1 (hint 出るべき、 raw em-dash は出ないべき) = 8 件 pass
- [x] \`make before-commit\` — lint / typecheck / test / build / validate-problems / cdk synth すべて OK

## Regression 分析

- \`defaultKey\` は新フィールドなので旧 API consumer (= 競技 UI 以外) には不可視。 breaking change なし
- backend \`resolveEndpoints\` 純関数の signature は不変 (= return value に field 追加のみ)
- override 中の表示 (\"override 中 (default: ...)\") はそのまま

## 物理影響

- UPDATE: backend \`resolve.ts\` の ResolvedEndpoint shape (= field 追加のみ)
- UPDATE: frontend portal-client.ts type + EndpointOverrideForm 内 Effective URL 行 markup
- NO-OP: CFn / IAM / DDB schema は無変更 (= portal API の JSON shape 拡張のみ)

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint URL display: When an effective URL is unavailable, users now see a helpful message with the CloudFormation output key name and instructions to register a custom URL, replacing the previous placeholder indicator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/711)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->