### PR TITLE
fix(#706): Competitor Accounts に「Update bootstrap」 button + Quick-update modal

### DIFF
--- a/apps/application-admin-console/src/lib/competitor-bootstrap.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.ts
@@ -41,6 +41,30 @@ export function buildLaunchStackUrl(input: LaunchStackUrlInput): string {
 }
 
 /**
+ * #706: 既存 `tenkacloud-competitor-bootstrap` stack を **同 template の最新版** で update する
+ * deeplink を組み立てる。 PR-694 のような IAM 追加を反映するため operator が競技者に共有する用途。
+ *
+ * AWS CFn console の Update Stack 経路は `#/stacks/update/template` で、 `stackName` 指定 +
+ * `templateURL` 指定で 「Replace current template」 で update する。 既存 Parameter 値は競技者の
+ * CFn console 側で **Use existing value** が default になるため operator が externalId 等の
+ * 秘密値を再送する必要は無い。 SSO ログイン後 → 確認画面で diff を見せた上で 1 click で update できる。
+ *
+ * `region` は operator がレコードから渡す (= 別 region に bootstrap が無い前提)。
+ */
+export interface UpdateStackUrlInput {
+  readonly region?: string;
+}
+
+export function buildUpdateStackUrl(input: UpdateStackUrlInput = {}): string {
+  const region = input.region ?? DEFAULT_REGION;
+  const params = new URLSearchParams({
+    stackName: DEFAULT_STACK_NAME,
+    templateURL: COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
+  });
+  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/update/template?${params.toString()}`;
+}
+
+/**
  * 「すべてコピー」 button が clipboard に書き込む 1 つの整形済 string。
  * 競技者の作業手順 (= Slack / メールでそのまま送れる) を含む。
  */
@@ -59,5 +83,30 @@ export function buildShareablePayload(input: LaunchStackUrlInput): string {
     `   ${buildLaunchStackUrl(input)}`,
     "",
     "完了後 operator にこの mail / msg を返信、 operator が「Verify」 で確認します。",
+  ].join("\n");
+}
+
+/**
+ * #706: 既存 bootstrap stack を最新 template で update してもらう案内 payload。
+ * PR-694 (Lambda IAM 追加) のような新 IAM を反映する用途。 競技者に Slack / メールで送る。
+ *
+ * 既存 stack の Parameter 値は CFn console 側で「Use existing value」 が default になるので、
+ * 秘密値 (= ExternalId) を再送する必要は無い (= 公開 URL のみ含める)。
+ */
+export function buildUpdatePayload(input: UpdateStackUrlInput = {}): string {
+  return [
+    "TenkaCloud Competitor Bootstrap — 既存 stack の update のお願い",
+    "",
+    "deploy chain に新しい IAM (例: Lambda Function 操作) が追加されたため、 既に deploy 済の",
+    "`tenkacloud-competitor-bootstrap` stack を最新 template に update してください。",
+    "",
+    "update 手順 (= 1 click):",
+    "1. 競技者 AWS account にログイン (= 既存と同じ)",
+    "2. 下記 Update Stack リンクを開く (= 既存 stack の Replace current template 画面に直行):",
+    `   ${buildUpdateStackUrl(input)}`,
+    "3. Parameter 画面は「Use existing value」 のまま (= 秘密値 ExternalId は既存のまま再利用)。",
+    "4. 確認画面で diff (= 追加 IAM Statement 等) を確認して Update。",
+    "",
+    "完了後 operator にこの mail / msg を返信、 operator が「Verify」 で再確認します。",
   ].join("\n");
 }

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -28,6 +28,8 @@ import type { AppConfig } from "../config";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
+  buildUpdatePayload,
+  buildUpdateStackUrl,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
 } from "../lib/competitor-bootstrap";
 import { type FriendlyError, toFriendlyError } from "../lib/friendly-error";
@@ -58,6 +60,8 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
   const [showSecret, setShowSecret] = useState<
     CreateCompetitorAccountResponse | RotateExternalIdResponse | null
   >(null);
+  // #706: 既存 bootstrap stack の update 案内 modal (= row の「Update bootstrap」 button から開く)。
+  const [updateTarget, setUpdateTarget] = useState<CompetitorAccountSummary | null>(null);
 
   const reload = useCallback(async () => {
     if (!apiClient) return;
@@ -181,6 +185,14 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
             >
               Rotate ExternalId
             </Button>
+            <Button
+              variant="normal"
+              iconName="upload"
+              onClick={() => setUpdateTarget(item)}
+              data-testid={`update-bootstrap-${item.awsAccountId}`}
+            >
+              Update bootstrap
+            </Button>
             <Button variant="link" onClick={() => setDeleteTarget(item)}>
               削除
             </Button>
@@ -263,6 +275,8 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
           鍵漏洩リスク削減)。
         </p>
       </Modal>
+
+      <BootstrapUpdateModal target={updateTarget} onDismiss={() => setUpdateTarget(null)} />
 
       <Modal
         visible={rotateTarget !== null}
@@ -552,6 +566,82 @@ function SecretRevealModal({ details, onDismiss }: SecretRevealModalProps) {
             </ol>
           </div>
         </ColumnLayout>
+      </SpaceBetween>
+    </Modal>
+  );
+}
+
+interface BootstrapUpdateModalProps {
+  target: CompetitorAccountSummary | null;
+  onDismiss: () => void;
+}
+
+/**
+ * #706: 既存 bootstrap stack の update 案内 modal。
+ *
+ * PR-694 (Lambda IAM 追加) のように deploy chain 側で IAM が増えると、 競技者の
+ * `tenkacloud-competitor-bootstrap` stack を最新 template で update してもらわないと
+ * 「lambda:GetFunction AccessDenied」 等で deploy が失敗する。
+ *
+ * 本 modal は秘密値 (ExternalId) を含まないので、 既存 row から呼べる (= row には
+ * externalId が無い)。 競技者の CFn console で Parameter は default で existing value 再利用される。
+ */
+function BootstrapUpdateModal({ target, onDismiss }: BootstrapUpdateModalProps) {
+  const [copied, setCopied] = useState(false);
+  if (!target) return null;
+  const updateUrl = buildUpdateStackUrl({ region: target.region });
+  const payload = buildUpdatePayload({ region: target.region });
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(payload);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <Modal
+      visible
+      onDismiss={onDismiss}
+      header="bootstrap stack の update を依頼"
+      footer={
+        <Box float="right">
+          <Button variant="primary" onClick={onDismiss}>
+            閉じる
+          </Button>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        <Alert type="info" header="新しい IAM 反映には bootstrap stack の update が必要です">
+          deploy chain 側で IAM (例: Lambda 操作権限) が追加された場合、 competitor 側で
+          <code>tenkacloud-competitor-bootstrap</code> stack を最新 template に update して
+          もらう必要があります。 ExternalId 等の秘密値は競技者の既存 stack で再利用されるため、
+          operator から再送する必要はありません。
+        </Alert>
+        <Box>
+          <Button
+            variant="primary"
+            iconName={copied ? "status-positive" : "copy"}
+            onClick={() => void onCopy()}
+            data-testid="copy-update-payload"
+          >
+            {copied ? "コピーしました" : "update 依頼テキストをコピー (Slack / メール用)"}
+          </Button>
+        </Box>
+        <div>
+          <Box variant="awsui-key-label">Update Stack URL (= 競技者がワンクリックで開く)</Box>
+          <CopyableField value={updateUrl} ariaLabel="Copy Update Stack URL" />
+        </div>
+        <div>
+          <Box variant="awsui-key-label">最新 template (= レビュー用 raw URL)</Box>
+          <CopyableField
+            value={COMPETITOR_BOOTSTRAP_TEMPLATE_URL}
+            ariaLabel="Copy bootstrap template URL"
+          />
+        </div>
+        <Box variant="small" color="text-status-inactive">
+          競技者は SSO ログイン後、 Replace current template 画面に直行します。 Parameter 値は 「Use
+          existing value」 (= default) のままで OK。 confirm 画面で IAM diff (例: lambda:GetFunction
+          追加) を確認して Update。
+        </Box>
       </SpaceBetween>
     </Modal>
   );

--- a/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
+  buildUpdatePayload,
+  buildUpdateStackUrl,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
 } from "../../src/lib/competitor-bootstrap";
 
@@ -71,5 +73,48 @@ describe("COMPETITOR_BOOTSTRAP_TEMPLATE_URL", () => {
     expect(COMPETITOR_BOOTSTRAP_TEMPLATE_URL).toMatch(
       /^https:\/\/raw\.githubusercontent\.com\/.+\/competitor-bootstrap\.yaml$/,
     );
+  });
+});
+
+describe("buildUpdateStackUrl (#706)", () => {
+  it("Update Stack 経路 (#/stacks/update/template) を指すべき", () => {
+    const url = buildUpdateStackUrl();
+    expect(url).toContain("#/stacks/update/template");
+    expect(url).toContain("https://ap-northeast-1.console.aws.amazon.com/cloudformation/home");
+  });
+
+  it("templateURL + stackName を pre-fill し、 秘密値 Parameter は含まないべき (= existing 値再利用)", () => {
+    const decoded = decodeURIComponent(buildUpdateStackUrl());
+    expect(decoded).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
+    expect(decoded).toContain("stackName=tenkacloud-competitor-bootstrap");
+    // 秘密値 (ExternalId) を URL に含めない、 既存 stack の Parameter を Use existing で再利用する
+    expect(decoded).not.toContain("param_ExternalId");
+    expect(decoded).not.toContain("param_TenkaCloudAccountId");
+    expect(decoded).not.toContain("param_RoleName");
+  });
+
+  it("region を上書きできるべき", () => {
+    const url = buildUpdateStackUrl({ region: "us-east-1" });
+    expect(url).toContain("https://us-east-1.console.aws.amazon.com/");
+    expect(url).toContain("region=us-east-1");
+  });
+});
+
+describe("buildUpdatePayload (#706)", () => {
+  it("Update Stack URL と「update のお願い」 文言を含むべき", () => {
+    const payload = buildUpdatePayload();
+    expect(payload).toContain(buildUpdateStackUrl());
+    expect(payload).toContain("update");
+    expect(payload).toContain("既存");
+  });
+
+  it("Quick-create URL (= 新規 create 経路) は含まれないべき (= update 専用)", () => {
+    expect(buildUpdatePayload()).not.toContain("quickcreate");
+  });
+
+  it("秘密値 (ExternalId / TenkaCloudAccountId) は含まないべき (= 公開 URL のみ)", () => {
+    const payload = buildUpdatePayload();
+    expect(payload).not.toContain("ExternalId:");
+    expect(payload).not.toContain("123456789012");
   });
 });


### PR DESCRIPTION
## Summary

PR-694 (#692 fix) で competitor-bootstrap.yaml に Lambda IAM を追加したが、 既に deploy 済の competitor stack には反映されないため、 operator は依然として「lambda:GetFunction AccessDenied」 を踏む。

ユーザー指摘: 「PR-694 のような IAM 追加を反映するには、 competitor が CFn console で stack を update する必要がある。 operator は competitor に伝える経路が無い」

本 PR は Competitor Accounts 一覧の row 操作に **「Update bootstrap」 button** を追加し、 click で CFn console の Update Stack 画面 deeplink + Slack / メール用案内テキストを提示する modal を出す。 競技者は **SSO ログイン後 1 click** で stack を最新 template に置換可能、 ExternalId 等の秘密値は CFn console 側で「Use existing value」 default になるため operator から再送不要。

## 実装

- 新 helper:
  - \`buildUpdateStackUrl({ region })\` — \`#/stacks/update/template?stackName=...&templateURL=...\`
  - \`buildUpdatePayload({ region })\` — 競技者向け案内 1 つにまとまった text
- 新 UI:
  - Competitor Accounts 一覧の各 row 末尾 (Verify / Rotate / 削除 の隣) に \`Update bootstrap\` button
  - \`BootstrapUpdateModal\` — Update Stack URL + template raw URL + Slack 用案内テキスト + 1 click copy

## Test plan

- [x] \`bun vitest run test/lib/competitor-bootstrap.test.ts\` — 14 tests pass (8 既存 + 6 新規 #706)
- [x] \`bunx tsc --noEmit\` — typecheck OK
- [x] \`make before-commit\` — lint / format / test / build / cdk synth すべて OK
- [ ] 手動: dev 環境で row の Update bootstrap button → modal → URL コピー → CFn console deeplink で update 経路の動作確認

## Regression 分析

- 既存 Launch Stack URL (= buildLaunchStackUrl) は無変更。 新 helper は独立 export
- 既存 row 3 button (Verify / Rotate / 削除) は維持、 1 button 追加のみ
- 秘密値 (ExternalId / TenkaCloudAccountId) は URL / payload に含めない (= 公開可)

## 物理影響

- UPDATE: \`apps/application-admin-console/src/lib/competitor-bootstrap.ts\` に \`buildUpdateStackUrl\` + \`buildUpdatePayload\` を新規 export
- UPDATE: \`apps/application-admin-console/src/pages/CompetitorAccounts.tsx\` に row 操作 button + \`BootstrapUpdateModal\` を追加
- NO-OP: backend / IAM / CFn templates は無変更 (= 純 frontend 改善)

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)