### PR TITLE
fix(#708): EventDetail に Force ARCHIVED rescue button (TEARDOWN stuck 救出)

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -18,6 +18,7 @@ import { Fragment, useCallback, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { ApiError, useApiClient } from "../api/client";
 import {
+  archiveEvent,
   type BulkDeployBody,
   type BulkResult,
   bulkDeployEvent,
@@ -141,6 +142,9 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [endsAtInFlight, setEndsAtInFlight] = useState(false);
   const [endInFlight, setEndInFlight] = useState(false);
   const [confirmEnd, setConfirmEnd] = useState(false);
+  // #708: TEARDOWN が ROLLBACK_COMPLETE な stack で stuck したときの operator rescue。
+  const [confirmForceArchive, setConfirmForceArchive] = useState(false);
+  const [forceArchiveInFlight, setForceArchiveInFlight] = useState(false);
   const [notifyModalOpen, setNotifyModalOpen] = useState(false);
   const [notifyJustSent, setNotifyJustSent] = useState(false);
   // #558: scoring lock/unlock の in-flight 状態。"lock" / "unlock" / null を持つ。
@@ -332,6 +336,26 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     }
   };
 
+  /**
+   * #708: TEARDOWN で stuck している Event を operator 判断で ARCHIVED に倒す rescue。
+   * backend の archive endpoint は TEARDOWN を allow しているので追加 API 不要。
+   * 競技者 account 側に残る CFn stack (= ROLLBACK_COMPLETE 等) は別途競技者が手動削除する。
+   */
+  const handleForceArchive = async () => {
+    if (!apiClient || forceArchiveInFlight) return;
+    setForceArchiveInFlight(true);
+    setConfirmForceArchive(false);
+    setError(null);
+    try {
+      await archiveEvent(apiClient, eventId);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setForceArchiveInFlight(false);
+    }
+  };
+
   const handleEndEvent = async () => {
     if (!apiClient || endInFlight) return;
     setEndInFlight(true);
@@ -483,6 +507,31 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             <Alert type={wizard.alertType} header="次のアクション">
               {wizard.cta}
             </Alert>
+            {detail?.status === "TEARDOWN" && (
+              // #708: 子 deployment の DeleteStack が ROLLBACK_COMPLETE な stack で stuck
+              // すると TEARDOWN のまま ARCHIVED に遷移しない問題への operator rescue。
+              <Alert
+                type="info"
+                header="削除が進まない場合 (operator rescue)"
+                action={
+                  <Button
+                    loading={forceArchiveInFlight}
+                    onClick={() => setConfirmForceArchive(true)}
+                    data-testid="force-archive-button"
+                  >
+                    Force ARCHIVED に倒す
+                  </Button>
+                }
+              >
+                競技者 account 側で stack が <code>ROLLBACK_COMPLETE</code> 等の状態のまま
+                残っていると DeleteStack が no-op 扱いで進行せず、 Event が TEARDOWN のまま固まる
+                ことがあります。 5 分以上動かない場合は競技者に
+                <strong>CFn console で該当 stack の手動 Delete</strong> を依頼するか、 operator
+                判断で本 Event を <strong>Force ARCHIVED</strong> に倒してください (= 該当
+                deployment 行は DELETED に遷移済 / FAILED として扱われ、 Event view から 外れます)。
+                物理 stack は別途競技者の手動削除が必要なので注意。
+              </Alert>
+            )}
           </SpaceBetween>
         </Container>
       )}
@@ -829,6 +878,38 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           <Box variant="small" color="text-status-warning">
             ENDED 状態から READY に戻すことはできません。再開するには Event を作り直して下さい。
           </Box>
+        </SpaceBetween>
+      </Modal>
+
+      <Modal
+        visible={confirmForceArchive}
+        header="Event を Force ARCHIVED に倒しますか?"
+        onDismiss={() => setConfirmForceArchive(false)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setConfirmForceArchive(false)}>キャンセル</Button>
+              <Button
+                variant="primary"
+                loading={forceArchiveInFlight}
+                onClick={handleForceArchive}
+                data-testid="force-archive-confirm"
+              >
+                Force ARCHIVED 実行
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            Event を <code>ARCHIVED</code> に遷移し、 一覧の default view から外します。
+          </Box>
+          <Alert type="warning" header="物理 stack は別途競技者の手動削除が必要">
+            本 button は <strong>DDB の Event row を ARCHIVED に倒すだけ</strong> です。 競技者
+            account に残った <code>ROLLBACK_COMPLETE</code> 等の CFn stack は競技者が CFn console
+            で手動 Delete する必要があります。 競技者へ事前に依頼してから実行してください。
+          </Alert>
         </SpaceBetween>
       </Modal>
 

--- a/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #708: Event teardown が ROLLBACK_COMPLETE な stack で stuck したときの operator rescue。
+ * 旧 UX は TEARDOWN になると「削除中... 全削除が完了すると自動で ARCHIVED に遷移します」
+ * の Alert だけで、 進まない時の脱出経路が無かった。 本 PR は TEARDOWN 時に
+ * 「Force ARCHIVED に倒す」 button を出し、 confirm modal 経由で archiveEvent を呼ぶ。
+ */
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+  archiveEvent: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return { ...actual, useApiClient: mocks.useApiClient };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return { ...actual, getEvent: mocks.getEvent, archiveEvent: mocks.archiveEvent };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Stuck Teardown Event",
+  status: "TEARDOWN",
+  teamCount: 1,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  teams: [{ teamId: "t1", internalSlug: "team-alpha" }],
+  problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {
+    "hello-world": [{ jobId: "J1", teamId: "t1", status: "DELETING" }],
+  },
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventDetailPage #708 Force ARCHIVED rescue", () => {
+  it("TEARDOWN な Event では Force ARCHIVED button + rescue Alert を表示するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce(baseDetail);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Stuck Teardown Event/).length).toBeGreaterThan(0),
+    );
+    expect(await screen.findByTestId("force-archive-button")).toBeInTheDocument();
+    expect(screen.getByText(/削除が進まない場合/)).toBeInTheDocument();
+  });
+
+  it("DEPLOYING な Event では Force ARCHIVED rescue は表示しないべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DEPLOYING" });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Stuck Teardown Event/).length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByTestId("force-archive-button")).not.toBeInTheDocument();
+  });
+
+  it("Force ARCHIVED を確定すると archiveEvent が呼ばれるべき", async () => {
+    mocks.getEvent.mockResolvedValue(baseDetail);
+    mocks.archiveEvent.mockResolvedValue({ ok: true, archivedAt: "2026-05-13T00:00:00.000Z" });
+    renderPage();
+    const trigger = await screen.findByTestId("force-archive-button");
+    await userEvent.click(trigger);
+    const confirm = await screen.findByTestId("force-archive-confirm");
+    await userEvent.click(confirm);
+    await waitFor(() => expect(mocks.archiveEvent).toHaveBeenCalled());
+    expect(mocks.archiveEvent).toHaveBeenCalledWith(expect.anything(), EVENT_ID);
+  });
+});


### PR DESCRIPTION
## Summary

競技者 account 側で CFn stack が \`ROLLBACK_COMPLETE\` のまま残ると DeleteStack 経路で 進行せず、 Event の status が \`TEARDOWN\` のままで固まる (= UI は "削除中..." Alert だけで脱出経路無し)。

ユーザー指摘: 「event teardown 後も ROLLBACK_COMPLETE な CFn stack が残る、 operator の手作業必須」

本 PR は **app 側 rescue UX のみ** (= backend 無変更):

- \`EventDetail\` の wizard banner 内に rescue Alert を追加 (= 物理 stack は競技者の手動 Delete が必要、 と明示)
- 「Force ARCHIVED に倒す」 button + confirm modal を追加
- 既存 \`archiveEvent\` endpoint (\`POST /events/{id}/archive\`、 backend で TEARDOWN を allow 済) を呼んで DDB の Event row を ARCHIVED に倒す

## Test plan

- [x] \`bun vitest run test/pages/EventDetail.force-archive.test.tsx\` — 3 tests pass (TEARDOWN 時に button 表示 / DEPLOYING では非表示 / 確定で archiveEvent 呼び出し)
- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [ ] dev 環境で手動: TEARDOWN な Event の Force ARCHIVED → ARCHIVED 遷移確認

## Regression 分析

- 既存 archive endpoint は TEARDOWN を ARCHIVABLE に含めていたので backend 無変更
- EventList の archive button (= 別経路) は無変更
- 物理 stack は本 button では削除しない (= confirm Alert で operator に明示)
- 既存 5 cases (\`EventDetail.retry-failed.test.tsx\`) は無変更

## 物理影響

- UPDATE: \`apps/application-admin-console/src/pages/EventDetail.tsx\` で archiveEvent import + rescue UI 追加
- ADD: \`apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx\` (3 cases)
- NO-OP: backend / IAM / CFn templates は無変更

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)