### PR TITLE
fix(#714): SystemAdmin 招待メールを English-only + 各セクション空行分離

### DIFF
--- a/infrastructure/lib/control-plane/invite-message.ts
+++ b/infrastructure/lib/control-plane/invite-message.ts
@@ -1,17 +1,21 @@
 /**
- * Issue #653: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
+ * Issue #653 / #714: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
  * を override するためのテンプレ生成。 admin-console origin が解決できないときは
  * 運営連絡先を促す fallback 文面を返す (= Phase 1 deploy 時)、 解決済なら CloudFront
  * URL を本文に埋める (= Phase 3 再 deploy 後)。
+ *
+ * #714: 旧実装は ja + en を `—` で連結した 1 通だったが、 Gmail 等で改行が collapse されて
+ * 「1 段落の長文」 になり可読性が低かった。 English-only に統一し、 各セクションを空行で
+ * 分離する (= preview で改行が落ちても各 key:value が独立可読)。
  */
 
-const FALLBACK_URL_PLACEHOLDER = "(deploy 完了後の admin-console URL は運営にお問い合わせください)";
+const FALLBACK_URL_PLACEHOLDER =
+  "(Admin console URL will be provided after deploy. Please contact your operator.)";
 
-export const INVITE_EMAIL_SUBJECT =
-  "TenkaCloud Admin Console 招待 / Your TenkaCloud Admin Console invitation";
+export const INVITE_EMAIL_SUBJECT = "Your TenkaCloud Admin Console invitation";
 
 /**
- * 招待メール本文を組み立てる。 ja + en 並列で 1 通に並べる (PR-582 同様の方針)。
+ * 招待メール本文を組み立てる。 English 単一ロケール、 各 key を 1 行ずつ。
  * Cognito placeholder の `{username}` / `{####}` はそのまま埋め、 Cognito 側で展開させる。
  */
 export function buildInviteEmailBody(adminConsoleOrigin: string | undefined): string {
@@ -20,15 +24,6 @@ export function buildInviteEmailBody(adminConsoleOrigin: string | undefined): st
       ? adminConsoleOrigin
       : FALLBACK_URL_PLACEHOLDER;
   return [
-    "TenkaCloud Admin Console へようこそ。",
-    "",
-    `URL: ${url}`,
-    "ユーザー名: {username}",
-    "仮パスワード: {####}",
-    "",
-    "初回ログイン時に新しいパスワードの設定を求められます。",
-    "",
-    "—",
     "Welcome to TenkaCloud Admin Console.",
     "",
     `URL: ${url}`,

--- a/infrastructure/test/control-plane-stack.test.ts
+++ b/infrastructure/test/control-plane-stack.test.ts
@@ -2,26 +2,26 @@ import { describe, expect, it } from "vitest";
 import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "../lib/control-plane/invite-message";
 
 /**
- * Issue #653: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
- * を override する pure function の挙動を pin。 stack 統合は cdk synth 経路で確認する
- * (= Docker bundling 不要なら synth test、 必要なら e2e で確認)。
+ * Issue #653 / #714: SBT default の SystemAdmin 招待メール本文 (`http://localhost` を埋める)
+ * を override する pure function の挙動を pin。 #714 で English-only に揃え、 ja セクションは
+ * drop。 stack 統合は cdk synth 経路で確認する。
  */
-describe("buildInviteEmailBody (Issue #653)", () => {
+describe("buildInviteEmailBody (Issue #714 English-only)", () => {
   it("admin-console origin が解決済なら CloudFront URL を本文に埋めるべき", () => {
     const body = buildInviteEmailBody("https://d1234abc.cloudfront.net");
     expect(body).toContain("https://d1234abc.cloudfront.net");
     expect(body).not.toMatch(/http:\/\/localhost/);
   });
 
-  it("origin 未確定 (= Phase 1 deploy) は運営連絡先を促す fallback 文面を返すべき", () => {
+  it("origin 未確定 (= Phase 1 deploy) は operator 連絡を促す英語 fallback を返すべき", () => {
     const body = buildInviteEmailBody(undefined);
-    expect(body).toContain("運営にお問い合わせください");
+    expect(body).toMatch(/contact your operator/i);
     expect(body).not.toMatch(/http:\/\/localhost/);
   });
 
   it("空文字列も fallback 扱いとすべき (= env 未設定と同等)", () => {
     const body = buildInviteEmailBody("");
-    expect(body).toContain("運営にお問い合わせください");
+    expect(body).toMatch(/contact your operator/i);
   });
 
   it("Cognito placeholder ({username} / {####}) を本文に保持すべき", () => {
@@ -30,20 +30,31 @@ describe("buildInviteEmailBody (Issue #653)", () => {
     expect(body).toContain("{####}");
   });
 
-  it("ja / en の両方を 1 通に並列で含めるべき (PR-582 同方針)", () => {
+  it("English-only に揃え、 日本語セクションは含めないべき (#714)", () => {
     const body = buildInviteEmailBody("https://example.com");
-    expect(body).toContain("TenkaCloud Admin Console へようこそ");
     expect(body).toContain("Welcome to TenkaCloud Admin Console");
+    expect(body).not.toMatch(/へようこそ/);
+    expect(body).not.toMatch(/ユーザー名/);
+    expect(body).not.toMatch(/仮パスワード/);
+    expect(body).not.toMatch(/運営にお問い合わせください/);
   });
 
-  it("subject が TenkaCloud 名称に上書きされているべき", () => {
+  it("subject も英語のみで TenkaCloud 名称に上書きされているべき", () => {
     expect(INVITE_EMAIL_SUBJECT).toMatch(/TenkaCloud Admin Console/);
     expect(INVITE_EMAIL_SUBJECT).not.toMatch(/control plane/i);
+    expect(INVITE_EMAIL_SUBJECT).not.toMatch(/招待/);
   });
 
-  it("URL が body に 2 度出現すべき (= ja / en パートそれぞれ)", () => {
+  it("URL は body に 1 度だけ出現するべき (= 旧 ja+en 重複を排除)", () => {
     const body = buildInviteEmailBody("https://d999.cloudfront.net");
     const matches = body.match(/https:\/\/d999\.cloudfront\.net/g);
-    expect(matches).toHaveLength(2);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("各セクションを空行で分離し、 改行 collapse 耐性のある形にすべき (#714)", () => {
+    const body = buildInviteEmailBody("https://example.com");
+    // 空行が body に最低 1 つあり、 welcome / key:value block / next step instruction が分離される
+    expect(body).toMatch(/\n\n/);
+    expect(body.startsWith("Welcome to TenkaCloud Admin Console.")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

旧 SystemAdmin 招待メールは ja + en を \`—\` で連結した 1 通で、 Gmail 上で改行が collapse されて 1 段落の長文に潰れていた (= screenshot #714)。

ユーザー指摘: 「英語だけでいいのできちんと読めるようにしてほしい」

本 PR は \`buildInviteEmailBody\` を **English-only** に統一し、 welcome / key:value (URL / Username / Temporary password) / next-step instruction を **空行で分離**。 改行が一部 client で collapse されても各 key:value が独立可読になる。

Fallback URL placeholder も英語化: \`(Admin console URL will be provided after deploy. Please contact your operator.)\`

## Test plan

- [x] \`bun vitest run test/control-plane-stack.test.ts\` — 8 cases pass (ja drop / URL 1 度のみ / 空行分離)
- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [ ] dev で実 deploy 後の SystemAdmin invite を Gmail で受信確認

## Regression 分析

- 既存 ja 表示に依存している UI / docs は無い (= 純粋に Cognito email 本文)
- SBT default の \`InviteMessageTemplate\` override 経路は無変更 (= 文字列差し替えのみ)
- 旧 test の「ja + en 並列」 assertion は #714 で意図的に逆転

## 物理影響

- UPDATE: \`infrastructure/lib/control-plane/invite-message.ts\` (subject + body 関数の文字列差し替え)
- UPDATE: \`infrastructure/test/control-plane-stack.test.ts\` (8 cases を English-only に揃える)
- NO-OP: Cognito UserPool 設定 / CFn schema は無変更

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes to Invitation Emails**
  * Invitation email subjects are now displayed in English only (previously included Japanese)
  * Invitation email body formatting updated to English-only format with improved section separation
  * Updated fallback messaging for email delivery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/715)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->