### PR TITLE
fix(#716): install.sh Phase 3 で admin-console-insight も再 deploy (CORS 反映)

### DIFF
--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * #716: `scripts/install.sh` Phase 3 が `admin-console-insight` も再 deploy しないと、
+ * 該当 stack の HTTP API CORS allow-list が Phase 1 時点 (localhost-only) のままで
+ * Provisioning Jobs page が "Failed to fetch" を吐く。 本テストは Phase 3 の cdk deploy
+ * 行が `tenkacloud-admin-console-insight` を含むことを pin (= 退行防止)。
+ */
+
+const INSTALL_SH_PATH = join(__dirname, "..", "..", "scripts", "install.sh");
+
+describe("scripts/install.sh Phase 3 (#716)", () => {
+  const source = readFileSync(INSTALL_SH_PATH, "utf8");
+
+  it("Phase 3 の cdk deploy で control-plane と admin-console-insight の両方を指定すべき", () => {
+    const phase3Match = source.match(
+      /bunx cdk deploy[^\n]*tenkacloud-control-plane[^\n]*tenkacloud-admin-console-insight[^\n]*--require-approval never/,
+    );
+    expect(phase3Match).not.toBeNull();
+  });
+
+  it("Phase 3 で CDK_PARAM_ADMIN_CONSOLE_ORIGIN を再 export してから再 deploy すべき", () => {
+    const exportIdx = source.indexOf(
+      'export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"',
+    );
+    const deployIdx = source.indexOf(
+      "bunx cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight",
+    );
+    expect(exportIdx).toBeGreaterThan(0);
+    expect(deployIdx).toBeGreaterThan(exportIdx);
+  });
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,8 @@ set -eo pipefail
 #
 # Phase 1: Backend stacks (ControlPlane + Bootstrap + TenantTemplate-pooled + Pipeline)
 # Phase 2: AdminConsoleHostingStack (React admin-console を CloudFront+S3 配信)
-# Phase 3: ControlPlaneStack 再 deploy (CloudFront URL を callback/CORS に追加)
+# Phase 3: ControlPlaneStack + admin-console-insight 再 deploy
+#         (CloudFront URL を callback / CORS に追加、 #716)
 #
 # Usage:
 #   bash scripts/install.sh "admin@example.com"
@@ -215,16 +216,21 @@ export CDK_PARAM_ADMIN_INSIGHT_API_URL="${ADMIN_INSIGHT_API_URL}"
 bunx cdk deploy tenkacloud-admin-console-hosting --require-approval never
 
 # ============================================================================
-# Phase 3: ControlPlaneStack 再 deploy — CloudFront URL を callback/CORS に足す
+# Phase 3: ControlPlaneStack + admin-console-insight 再 deploy
+#   - control-plane の Cognito callback / OAuth allow-list に CloudFront URL を追加
+#   - admin-console-insight の HTTP API CORS allow-list にも同 URL を追加 (#716)
+#     旧実装は control-plane のみ再 deploy しており、 admin-console-insight の CORS は
+#     Phase 1 時点の localhost-only のままで Provisioning Jobs page が "Failed to fetch"
+#     を吐いていた。
 # ============================================================================
 echo ""
 echo "=============================================="
-echo "Phase 3: Update tenkacloud-control-plane with admin-console CloudFront URL"
+echo "Phase 3: Update tenkacloud-control-plane + admin-console-insight with admin-console CloudFront URL"
 echo "=============================================="
 ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
 export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"
 echo "  CloudFront URL: ${ADMIN_CONSOLE_URL}"
-bunx cdk deploy tenkacloud-control-plane --require-approval never
+bunx cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight --require-approval never
 
 # ============================================================================
 # 完了


### PR DESCRIPTION
## Summary

Provisioning Jobs page で「読み込みに失敗しました / Failed to fetch」 が出る (= screenshot)。

**Root cause**: \`scripts/install.sh\` Phase 3 は \`tenkacloud-control-plane\` のみ再 deploy しており、 \`tenkacloud-admin-console-insight\` の HTTP API CORS allow-list は Phase 1 時点の **localhost-only** のまま。 admin-console (CloudFront) origin から fetch すると browser preflight が \`Access-Control-Allow-Origin\` mismatch で reject → \`TypeError: Failed to fetch\`。

## Fix

\`scripts/install.sh\` Phase 3 の \`bunx cdk deploy\` ターゲットに \`tenkacloud-admin-console-insight\` を追加。 同 \`CDK_PARAM_ADMIN_CONSOLE_ORIGIN\` env で再 deploy → CFn が \`CorsConfiguration.AllowOrigins\` を CloudFront URL 込みに更新する。

加えて退行防止用の静的 test (\`infrastructure/test/install-script.test.ts\`) を追加: Phase 3 の cdk deploy 行に \`tenkacloud-admin-console-insight\` が含まれることを pin。

## Test plan

- [x] \`bun vitest run test/install-script.test.ts\` — 2 cases pass
- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [ ] \`make deploy\` で Phase 3 が control-plane + admin-console-insight の両方を再 deploy するか確認
- [ ] admin-console の Provisioning Jobs page が CloudFront から正常 fetch できるか確認

## Regression 分析

- Phase 1 / Phase 2 は無変更
- Phase 3 の cdk deploy 対象が 1 → 2 stack に増えるだけ。 失敗時は同じ exit code で abort
- localhost dev origin は引き続き allow-list に入る (= dev は無影響)
- 既存環境では \`make deploy\` 再実行で CORS が更新される

## 物理影響

- UPDATE: \`scripts/install.sh\` Phase 3 の \`bunx cdk deploy\` 行 + 注釈コメント
- UPDATE: 次回 \`make deploy\` で \`tenkacloud-admin-console-insight\` の \`AWS::ApiGatewayV2::Api\` Properties.CorsConfiguration.AllowOrigins に CloudFront URL が追加
- ADD: \`infrastructure/test/install-script.test.ts\` (2 cases、 Phase 3 静的 pin)
- NO-OP: Lambda / IAM / DDB は無変更

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)