### PR TITLE
fix(#719): Event 作成 form で verified account 0 件なら救済 Alert + link

### DIFF
--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -34,6 +34,7 @@ const TEAMS_MIN = 1;
 const TEAMS_MAX = 99;
 const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
 const INITIAL_TEAM_COUNT = 3;
+const NO_VERIFIED_ACCOUNTS_HELPER = "No verified accounts available. Add one first.";
 
 const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
   value: r.code,
@@ -118,6 +119,8 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
     () => filterVerifiedAccounts(competitorAccounts),
     [competitorAccounts],
   );
+  const noVerifiedAccounts = competitorAccounts !== null && verifiedAccounts.length === 0;
+  const showNoVerifiedAccountsHint = noVerifiedAccounts && !accountsLoadError;
   const accountOptions: SelectProps.Option[] = useMemo(
     () =>
       verifiedAccounts.map((a) => ({
@@ -318,7 +321,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
               dropdown に選択肢が出るまで数秒お待ちください。
             </Alert>
           )}
-          {competitorAccounts !== null && verifiedAccounts.length === 0 && !accountsLoadError && (
+          {showNoVerifiedAccountsHint && (
             <Alert
               type="warning"
               header="verified=true な Competitor Account がありません"
@@ -331,7 +334,14 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                   >
                     再読込
                   </Button>
-                  <Link href="#/competitor-accounts" external={false}>
+                  <Link
+                    href="/competitor-accounts"
+                    external={false}
+                    onFollow={(e) => {
+                      e.preventDefault();
+                      navigate("/competitor-accounts");
+                    }}
+                  >
                     Competitor Accounts へ移動
                   </Link>
                 </SpaceBetween>
@@ -382,23 +392,32 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                       const selected =
                         accountOptions.find((o) => o.value === t.awsAccountId) ?? null;
                       return (
-                        <Select
-                          selectedOption={selected}
-                          options={accountOptions}
-                          placeholder={
-                            accountOptions.length === 0
-                              ? "verified account 未登録"
-                              : "verified account を選択"
-                          }
-                          disabled={accountOptions.length === 0}
-                          empty="verified=true な競技者 account がありません"
-                          onChange={({ detail }) =>
-                            updateTeamRow(t.idx, {
-                              awsAccountId: detail.selectedOption?.value ?? "",
-                            })
-                          }
-                          invalid={t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)}
-                        />
+                        <SpaceBetween size="xxs">
+                          <Select
+                            selectedOption={selected}
+                            options={accountOptions}
+                            placeholder={
+                              noVerifiedAccounts
+                                ? NO_VERIFIED_ACCOUNTS_HELPER
+                                : "verified account を選択"
+                            }
+                            disabled={accountOptions.length === 0}
+                            empty="verified=true な競技者 account がありません"
+                            onChange={({ detail }) =>
+                              updateTeamRow(t.idx, {
+                                awsAccountId: detail.selectedOption?.value ?? "",
+                              })
+                            }
+                            invalid={
+                              t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)
+                            }
+                          />
+                          {noVerifiedAccounts && (
+                            <Box variant="small" color="text-status-inactive">
+                              {NO_VERIFIED_ACCOUNTS_HELPER}
+                            </Box>
+                          )}
+                        </SpaceBetween>
                       );
                     },
                   },

--- a/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  listCompetitorAccounts: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/competitor-accounts-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/competitor-accounts-client")>();
+  return {
+    ...actual,
+    listCompetitorAccounts: mocks.listCompetitorAccounts,
+  };
+});
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const { EventCreatePage } = await import("../../src/pages/EventCreate");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/events/new"]}>
+      <Routes>
+        <Route path="/events/new" element={<EventCreatePage config={config} />} />
+        <Route path="/competitor-accounts" element={<div>Competitor Accounts page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventCreatePage #719 verified account 0 件の救済 UX", () => {
+  it("verified account が 0 件なら Alert と Competitor Accounts link を表示すべき", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce({ items: [] });
+    renderPage();
+
+    expect(
+      await screen.findByText(/verified=true な Competitor Account がありません/),
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "Competitor Accounts へ移動" });
+    expect(link).toHaveAttribute("href", "/competitor-accounts");
+
+    const disabledSelect = screen
+      .getAllByText("No verified accounts available. Add one first.")
+      .map((node) => node.closest("button"))
+      .find((button): button is HTMLButtonElement => button instanceof HTMLButtonElement);
+    expect(disabledSelect).toBeDisabled();
+  });
+
+  it("verified=true が 1 件あれば Alert を出さず dropdown を通常 render すべき", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce({
+      items: [
+        {
+          awsAccountId: "111111111111",
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          alias: "Verified Team A",
+          verified: true,
+          verifiedAt: "2026-05-10T00:00:00.000Z",
+          createdAt: "2026-05-09T00:00:00.000Z",
+          updatedAt: "2026-05-10T00:00:00.000Z",
+        },
+      ],
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/verified account を選択/).length).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.queryByText(/verified=true な Competitor Account がありません/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No verified accounts available. Add one first."),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implemented by Codex CLI, reviewed by Claude.

application-admin-console の Event 作成 form で \`verified=true\` な Competitor Account が 0 件のとき、 旧 UX は dropdown が silent に空になって operator が dead-end だった。

本 PR は同 form 内に:
1. \`<Alert type="warning">\` で「verified=true な Competitor Account がありません」 を提示
2. \`/competitor-accounts\` への navigation link (SPA、 \`onFollow\` で full reload 回避)
3. dropdown 自体を disabled + helper text 「No verified accounts available. Add one first.」 を Select 下に併記

verified=true が 1 件以上ある場合は従来通り dropdown 通常 render。

## Test plan

- [x] \`bun run test test/pages/EventCreate.no-verified-hint.test.tsx test/pages/EventCreate.verified-only.test.tsx\` — 全 case pass
- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK

## Regression 分析

- verified account がある tenant では Alert / helper を出さず、 既存 dropdown 通常 UX 維持
- listCompetitorAccounts の既存 fetch 結果から表示制御するだけ、 backend API 契約は無変更
- \`/competitor-accounts\` 既存経路を再利用 (= 別 route 追加なし)

## 物理影響

- UPDATE: \`apps/application-admin-console/src/pages/EventCreate.tsx\`
- ADD: \`apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx\` (2 cases)
- NO-OP: backend / IAM / CFn

Closes #719

🤖 Implemented by Codex CLI, reviewed by Claude