### PR TITLE
fix(#720): State Machine MarkSucceeded/MarkFailed で CodeBuild buildId を DDB に永続化

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -3,6 +3,8 @@ import type { Project } from "aws-cdk-lib/aws-codebuild";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import {
+  Choice,
+  Condition,
   DefinitionBody,
   IntegrationPattern,
   JsonPath,
@@ -121,15 +123,25 @@ export class DeployCreateStateMachine extends Construct {
     });
 
     const markSucceeded = this.buildMarkSucceeded(props.deploymentsTable);
-    const markFailed = this.buildMarkFailed(props.deploymentsTable);
+    const markFailed = this.buildMarkFailed(props.deploymentsTable, "MarkFailed", true);
+    const markFailedWithoutBuildId = this.buildMarkFailed(
+      props.deploymentsTable,
+      "MarkFailedWithoutBuildId",
+      false,
+    );
+    const routeFailedDeployment = new Choice(this, "RouteFailedDeployment")
+      .when(Condition.isPresent("$.codebuild.Build.Id"), markFailed)
+      .otherwise(markFailedWithoutBuildId);
 
     // MarkInProgress / CodeBuild / DescribeStacks のいずれの失敗も MarkFailed (= status=FAILED)
     // に倒す。MarkInProgress は DDB throttle くらいでしか落ちないが落とし穴を残さないため
     // catch を付ける。DescribeStacks も稀な throttle / 競技者 account 側 Role の問題で
     // 落ちうる。その場合 stackOutputs 不在のまま FAILED にして operator が再試行する。
-    markInProgress.addCatch(markFailed, { resultPath: "$.error" });
-    startCodeBuild.addCatch(markFailed, { resultPath: "$.error" });
-    describeStacks.addCatch(markFailed, { resultPath: "$.error" });
+    // buildId は StartDeployCodeBuild が正常 output を返した後だけ存在するため、pre-CodeBuild
+    // 失敗では従来通り buildId 無しで FAILED を書く。
+    markInProgress.addCatch(routeFailedDeployment, { resultPath: "$.error" });
+    startCodeBuild.addCatch(routeFailedDeployment, { resultPath: "$.error" });
+    describeStacks.addCatch(routeFailedDeployment, { resultPath: "$.error" });
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
       definitionBody: DefinitionBody.fromChainable(
@@ -149,7 +161,7 @@ export class DeployCreateStateMachine extends Construct {
       table,
       key: deploymentKey(),
       updateExpression:
-        "SET #status = :status, updatedAt = :updatedAt, stackId = :stackId, stackOutputs = :stackOutputs",
+        "SET #status = :status, updatedAt = :updatedAt, stackId = :stackId, stackOutputs = :stackOutputs, buildId = :buildId",
       expressionAttributeNames: { "#status": "status" },
       expressionAttributeValues: {
         ":status": DynamoAttributeValue.fromString("COMPLETE"),
@@ -160,16 +172,18 @@ export class DeployCreateStateMachine extends Construct {
         ":stackOutputs": DynamoAttributeValue.fromString(
           JsonPath.jsonToString(JsonPath.objectAt("$.cfn.Stacks[0].Outputs")),
         ),
+        ":buildId": DynamoAttributeValue.fromString(JsonPath.stringAt("$.codebuild.Build.Id")),
       },
     });
   }
 
-  private buildMarkFailed(table: ITable): DynamoUpdateItem {
-    return new DynamoUpdateItem(this, "MarkFailed", {
+  private buildMarkFailed(table: ITable, id: string, persistBuildId: boolean): DynamoUpdateItem {
+    return new DynamoUpdateItem(this, id, {
       table,
       key: deploymentKey(),
       updateExpression:
-        "SET #status = :status, updatedAt = :updatedAt, #failureReason = :failureReason",
+        "SET #status = :status, updatedAt = :updatedAt, #failureReason = :failureReason" +
+        (persistBuildId ? ", buildId = :buildId" : ""),
       expressionAttributeNames: {
         "#status": "status",
         "#failureReason": "failureReason",
@@ -180,6 +194,13 @@ export class DeployCreateStateMachine extends Construct {
         // `$.error.Cause` は CodeBuild RUN_JOB の `States.TaskFailed` Cause (= build
         // 失敗 detail の JSON 文字列)。100 文字を超えるので JSON のまま格納する。
         ":failureReason": DynamoAttributeValue.fromString(JsonPath.stringAt("$.error.Cause")),
+        ...(persistBuildId
+          ? {
+              ":buildId": DynamoAttributeValue.fromString(
+                JsonPath.stringAt("$.codebuild.Build.Id"),
+              ),
+            }
+          : {}),
       },
     });
   }

--- a/infrastructure/lib/problem-deploy/deployments-table.ts
+++ b/infrastructure/lib/problem-deploy/deployments-table.ts
@@ -11,7 +11,7 @@ import { Construct } from "constructs";
  *
  * 主な属性:
  *   jobId / problemId / tenantId / awsAccountId / region / teamName /
- *   namePrefix / teamLoginKey / status / stackId / stackOutputs /
+ *   namePrefix / teamLoginKey / status / buildId / stackId / stackOutputs /
  *   failureReason / createdAt / updatedAt / expiresAt
  *
  * GSI1 (テナント別の deployment 一覧):

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/list.ts
@@ -21,6 +21,7 @@ export interface DeploymentSummary {
   readonly namePrefix: string;
   readonly status: DeploymentStatus;
   readonly stackId?: string;
+  readonly buildId?: string;
   readonly stackOutputs?: string;
   readonly failureReason?: string;
   readonly createdAt: string;
@@ -66,6 +67,7 @@ export function toSummary(item: Partial<DeploymentItem>): DeploymentSummary {
     namePrefix: String(item.namePrefix ?? ""),
     status: (item.status ?? "PENDING") as DeploymentStatus,
     stackId: item.stackId,
+    buildId: item.buildId,
     stackOutputs: item.stackOutputs,
     failureReason: item.failureReason,
     createdAt: String(item.createdAt ?? ""),

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -74,6 +74,8 @@ export interface DeploymentItem {
 
   /** worker (CFn 起動側) が埋める */
   stackId?: string;
+  /** Step Functions の CodeBuildStartBuild output (= `Build.Id`) から永続化する build ID。 */
+  buildId?: string;
   /** StatusUpdater が CFn Outputs を JSON 文字列で書き戻す */
   stackOutputs?: string;
   failureReason?: string;

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -165,6 +165,22 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(synthJson).toContain("IN_PROGRESS");
     });
 
+    it("Create State Machine は完了/失敗時に CodeBuild buildId を Deployments row へ保存すべき", () => {
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const createStateMachine = Object.values(stateMachines)
+        .map((stateMachine) => JSON.stringify(stateMachine))
+        .find((definition) => definition.includes("StartDeployCodeBuild"));
+
+      expect(createStateMachine).toBeDefined();
+      expect(createStateMachine).toContain("MarkSucceeded");
+      expect(createStateMachine).toContain("MarkFailed");
+      expect(createStateMachine).toContain(
+        "stackId = :stackId, stackOutputs = :stackOutputs, buildId = :buildId",
+      );
+      expect(createStateMachine).toContain("#failureReason = :failureReason, buildId = :buildId");
+      expect(createStateMachine).toContain("$.codebuild.Build.Id");
+    });
+
     it("EventBridge Rule を Create / Delete / GenericScoring / ExternalIdAudit schedule で 4 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)


### PR DESCRIPTION
## Summary

Implemented by Codex CLI, reviewed by Claude.

Deploy log で「CodeBuild console URL not yet available」 が permanent な placeholder のままだった原因は、 DeployCreate State Machine の `StartCodeBuild` task の output (`$.codebuild.Build.Id`) が DDB Deployments row に伝播していなかったため。 frontend は既に \`deployment.buildId\` を読んで CodeBuild console URL を組み立てる経路があるので、 backend 永続化のみで placeholder 解消。

## 実装内容

1. \`MarkSucceeded\` の UpdateExpression に \`buildId = :buildId\` を追加 (\`$.codebuild.Build.Id\` を JsonPath で参照)
2. **失敗 path に Choice state 追加**: \`RouteFailedDeployment\` が \`$.codebuild.Build.Id\` の存在を確認し、 CodeBuild output がある場合は新 \`MarkFailed\` (buildId 込み) に、 pre-CodeBuild 失敗は \`MarkFailedWithoutBuildId\` (= 既存挙動) に flow 分岐
3. \`DeploymentItem\` type に \`buildId?: string\` を追加
4. Deploy list response に \`buildId\` を surface (= teamLoginKey の露出範囲は無変更)
5. State Machine の CDK test (\`infrastructure/test/problem-deploy-backend-stack.test.ts\`) に assertion 追加

## Test plan

- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [ ] dev で実 deploy 後、 Deploy log modal で CodeBuild console URL が render されるか確認

## Regression 分析

- Success path: MarkSucceeded に新 attr (buildId) を保存する追加のみ
- Failure path: pre-CodeBuild 失敗 (= MarkInProgress 失敗等) は MarkFailedWithoutBuildId に流れ、 既存挙動が完全に保存される
- 既存テストは無修正で pass
- DDB Deployments table schema / capacity / index は無変更 (= 任意属性 buildId を utilize するだけ)

## 物理影響

- UPDATE: DeployCreate State Machine definition (MarkSucceeded / MarkFailed UpdateItem expression + Choice state)
- UPDATE: Deployments DDB item の任意属性 \`buildId\` を utilize 開始
- NO-OP: CodeBuild Project / IAM / DynamoDB table resource / frontend assets

Closes #720

🤖 Implemented by Codex CLI, reviewed by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now track and persist CodeBuild build IDs for improved visibility into both successful and failed deployment operations.

* **Tests**
  * Added test coverage for build ID persistence across deployment states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/727)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->