### PR TITLE
fix(#725): SSO が IN_PROGRESS / PENDING deployment で not_ready を返す

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -126,7 +126,8 @@ const sts = new STSClient({});
  *
  * 競技者は自前 AWS アカウント不要。1-hour TTL で自動 expire。
  *
- * 行不在 / DELETING / DELETED → unauthorized。stack 未起動 (namePrefix 無し) → not_ready。
+ * 行不在 / DELETING / DELETED → unauthorized。PENDING / IN_PROGRESS や stack 未起動
+ * (namePrefix 無し) → not_ready。
  * `CONSOLE_VIEWER_ROLE_ARN` env 未設定 → misconfigured (= CDK 未 deploy)。
  */
 export async function getConsoleSigninUrl(
@@ -146,6 +147,7 @@ export async function getConsoleSigninUrl(
 
   const status = (deployment.status ?? "PENDING") as DeploymentStatus;
   if (DELETED_LIKE_STATUSES.has(status)) return { kind: "unauthorized" };
+  if (status === "IN_PROGRESS" || status === "PENDING") return { kind: "not_ready" };
   if (typeof deployment.namePrefix !== "string") return { kind: "not_ready" };
   const region = typeof deployment.region === "string" ? deployment.region : undefined;
   if (!region) return { kind: "not_ready" };

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -90,6 +90,24 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "unauthorized" });
   });
 
+  it("IN_PROGRESS な deployment は AssumeRole せず not_ready を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "IN_PROGRESS" })] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    expect(stsSend).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("PENDING な deployment は AssumeRole せず not_ready を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "PENDING" })] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    expect(stsSend).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("namePrefix 未設定 (stack 未起動) は not_ready", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Implemented by Codex CLI, reviewed by Claude.

participant portal の SSO Credentials で IN_PROGRESS / PENDING な deployment に対して 「AWS Console を開く」 を押すと \`assume_role_failed\` (500) で UI が壊れていた。 deploy 中の Console open は本質的に意味が薄く、 UI 側は既に \`not_ready\` を「deploy 完了待ち」 として handle 済。

\`getConsoleSigninUrl\` の DELETED_LIKE check 直後に \`status === "IN_PROGRESS" || "PENDING"\` を guard で early return する 1 行を追加。

## Test plan

- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [x] 新規 2 cases: IN_PROGRESS / PENDING で stsSend / fetchSpy が **呼ばれない** ことを assert
- [ ] dev で deploy 中の deployment で SSO button を押して 「deploy 完了待ち」 UI が出るか確認

## Regression 分析

- COMPLETE は既存どおり AssumeRole 経路 (= 既存「正常系」 テストが pass)
- DELETED_LIKE → unauthorized 経路は無変更
- frontend / IAM / Lambda 配線は無変更

## 物理影響

- UPDATE: \`infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts\` (status guard 1 行 + JSDoc)
- UPDATE: \`infrastructure/test/problem-deploy/participant-sso.test.ts\` (2 cases 追加)
- NO-OP: backend IAM / DDB schema / frontend は無変更

Closes #725

🤖 Implemented by Codex CLI, reviewed by Claude