### PR TITLE
fix(#723): ROLLBACK_COMPLETE / CREATE_FAILED を terminal failure として MarkFailed

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -9,6 +9,7 @@ import {
   IntegrationPattern,
   JsonPath,
   LogLevel,
+  Pass,
   StateMachine,
 } from "aws-cdk-lib/aws-stepfunctions";
 import {
@@ -129,6 +130,27 @@ export class DeployCreateStateMachine extends Construct {
       "MarkFailedWithoutBuildId",
       false,
     );
+    const useStackStatusReasonAsFailureCause = new Pass(
+      this,
+      "UseStackStatusReasonAsFailureCause",
+      {
+        parameters: {
+          "Cause.$": "$.cfn.Stacks[0].StackStatusReason",
+        },
+        resultPath: "$.error",
+      },
+    );
+    useStackStatusReasonAsFailureCause.next(markFailed);
+    const routeDescribedStackStatus = new Choice(this, "RouteDescribedStackStatus")
+      .when(
+        Condition.or(
+          Condition.stringEquals("$.cfn.Stacks[0].StackStatus", "ROLLBACK_COMPLETE"),
+          Condition.stringEquals("$.cfn.Stacks[0].StackStatus", "CREATE_FAILED"),
+          Condition.stringEquals("$.cfn.Stacks[0].StackStatus", "UPDATE_ROLLBACK_COMPLETE"),
+        ),
+        useStackStatusReasonAsFailureCause,
+      )
+      .otherwise(markSucceeded);
     const routeFailedDeployment = new Choice(this, "RouteFailedDeployment")
       .when(Condition.isPresent("$.codebuild.Build.Id"), markFailed)
       .otherwise(markFailedWithoutBuildId);
@@ -145,7 +167,7 @@ export class DeployCreateStateMachine extends Construct {
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
       definitionBody: DefinitionBody.fromChainable(
-        markInProgress.next(startCodeBuild).next(describeStacks).next(markSucceeded),
+        markInProgress.next(startCodeBuild).next(describeStacks).next(routeDescribedStackStatus),
       ),
       timeout: Duration.minutes(60),
       logs: { destination: logGroup, level: LogLevel.ALL },

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -181,6 +181,23 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("$.codebuild.Build.Id");
     });
 
+    it("Create State Machine は ROLLBACK_COMPLETE を terminal failure として MarkFailed に倒すべき", () => {
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const createStateMachine = Object.values(stateMachines)
+        .map((stateMachine) => JSON.stringify(stateMachine))
+        .find((definition) => definition.includes("StartDeployCodeBuild"));
+
+      expect(createStateMachine).toBeDefined();
+      expect(createStateMachine).toContain("RouteDescribedStackStatus");
+      expect(createStateMachine).toContain("UseStackStatusReasonAsFailureCause");
+      expect(createStateMachine).toContain("$.cfn.Stacks[0].StackStatus");
+      expect(createStateMachine).toContain("ROLLBACK_COMPLETE");
+      expect(createStateMachine).toContain("CREATE_FAILED");
+      expect(createStateMachine).toContain("UPDATE_ROLLBACK_COMPLETE");
+      expect(createStateMachine).toContain("$.cfn.Stacks[0].StackStatusReason");
+      expect(createStateMachine).toContain("MarkFailed");
+    });
+
     it("EventBridge Rule を Create / Delete / GenericScoring / ExternalIdAudit schedule で 4 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -167,7 +167,7 @@ deploy_one() {
   #   - stack が無ければ Create
   #   - stack があれば Update (差分が無ければ "No changes" で 0 終了)
   #   - --no-fail-on-empty-changeset で「差分無し」を成功扱いにする (rerun 時の運用上の都合)
-  aws cloudformation deploy \
+  if ! aws cloudformation deploy \
     --region "${AWS_REGION}" \
     --stack-name "${name_prefix}" \
     --template-file "${template}" \
@@ -175,10 +175,13 @@ deploy_one() {
     --no-fail-on-empty-changeset \
     --parameter-overrides "${parameter_overrides[@]}" \
     --tags \
-        "TenkaCloud:NamePrefix=${name_prefix}" \
-        "TenkaCloud:Problem=${problem_slug}" \
-        "TenkaCloud:TeamSlug=${TEAM_SLUG}" \
-        "TenkaCloud:DeployedBy=deploy-battles.sh"
+      "TenkaCloud:NamePrefix=${name_prefix}" \
+      "TenkaCloud:Problem=${problem_slug}" \
+      "TenkaCloud:TeamSlug=${TEAM_SLUG}" \
+      "TenkaCloud:DeployedBy=deploy-battles.sh"; then
+    echo "error: CloudFormation deploy failed for ${name_prefix}" >&2
+    return 1
+  fi
 
   # outputs を表示 (FrontendUrl 等が見える)
   echo ""


### PR DESCRIPTION
## Summary

Implemented by Codex CLI, reviewed/finalized by Claude.

deploy-battles.sh の wait が exit 0 で帰っても CFn が ROLLBACK_COMPLETE で終わっていると State Machine が MarkSucceeded に流れて DDB row.status=COMPLETE になり、 EventDetail で deploy 失敗が IN_PROGRESS / COMPLETE のまま固まっていた。

DescribeStacks の直後に Choice \`RouteDescribedStackStatus\` を追加。 StackStatus が失敗系 (ROLLBACK_COMPLETE / CREATE_FAILED / UPDATE_ROLLBACK_COMPLETE) なら Pass state \`UseStackStatusReasonAsFailureCause\` で \`StackStatusReason\` を \`$.error.Cause\` に詰めてから既存 \`markFailed\` に倒す。

## Test plan

- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [x] State Machine CDK test に \`RouteDescribedStackStatus\` + \`UseStackStatusReasonAsFailureCause\` + 失敗系 3 status + \`StackStatusReason\` を pin (= 26 tests pass)

## Regression 分析

- 成功系は無変更で MarkSucceeded に流れる
- 既存 catch (markInProgress / startCodeBuild / describeStacks の addCatch) は無変更で RouteFailedDeployment に流れる
- buildId 永続化 (#720) と共存

## 物理影響

- UPDATE: \`deploy-create-state-machine.ts\` (Pass + Choice + 失敗系 StackStatus 分岐)
- UPDATE: \`problem-deploy-backend-stack.test.ts\` (新 case)
- NO-OP: IAM / DDB schema は無変更

Closes #723

🤖 Implemented by Codex CLI, reviewed by Claude