### PR TITLE
feat(#733): CloudWatch Dashboard で deploy chain / DDB / Lambda / API GW を 1 画面で監視

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -13,6 +13,7 @@ import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
 import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
 import { ControlPlaneStack } from "../lib/control-plane-stack";
 import { getEnv } from "../lib/helper-functions";
+import { ObservabilityStack } from "../lib/observability/cloudwatch-dashboard-stack";
 import type { ParticipantPortalRuntimeConfig } from "../lib/problem-deploy/participant-portal-hosting";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../lib/tenant-pipeline/serverless-saas-pipeline";
@@ -209,6 +210,9 @@ const apiKeyBasicTierParameter = resolveApiKey("CDK_PARAM_API_KEY_BASIC_TIER_PAR
 const stackEnv =
   awsAccountId && awsRegion ? { env: { account: awsAccountId, region: awsRegion } } : {};
 
+const apiIdFromExecuteApiUrl = (apiUrl: string): string =>
+  cdk.Fn.select(0, cdk.Fn.split(".", cdk.Fn.select(2, cdk.Fn.split("/", apiUrl))));
+
 const controlPlaneStack = new ControlPlaneStack(app, "tenkacloud-control-plane", {
   ...stackEnv,
   systemAdminEmail,
@@ -371,6 +375,70 @@ const serverlessSaaSPipeline = new ServerlessSaaSPipeline(app, "tenkacloud-saas-
   sourceZip,
 });
 cdk.Aspects.of(serverlessSaaSPipeline).add(new DestroyPolicySetter());
+
+const observabilityStack = new ObservabilityStack(app, "tenkacloud-observability", {
+  ...stackEnv,
+  environment,
+  stateMachines: {
+    deployCreateArn: problemDeployBackendStack.deployCreateStateMachineArn,
+    deployDeleteArn: problemDeployBackendStack.deployDeleteStateMachineArn,
+  },
+  codeBuildProjectNames: {
+    problemDeploy: problemDeployBackendStack.deployCodeBuildProjectName,
+    provisioning: serverlessSaaSPipeline.provisioningCodeBuildProjectName,
+  },
+  dynamoDbTableNames: {
+    deployments: problemDeployBackendStack.deploymentsTable.tableName,
+    events: problemDeployBackendStack.eventsTable.tableName,
+    teams: problemDeployBackendStack.teamsTable.tableName,
+    competitorAccounts: problemDeployBackendStack.competitorAccountsTable.tableName,
+    problemEndpoints: problemDeployBackendStack.problemEndpointsTable.tableName,
+    tenantMappingTable: bootstrapTemplateStack.tenantMappingTable.tableName,
+  },
+  lambdaFunctionNames: {
+    deployApi: problemDeployBackendStack.deployApiLambda.functionName,
+    eventApi: problemDeployBackendStack.eventApiLambda.functionName,
+    participantPortal: problemDeployBackendStack.participantPortalLambda?.functionName,
+    adminInsight: adminConsoleInsightStack.lambdaFunctionName,
+    competitorAccounts: problemDeployBackendStack.competitorAccountsApiLambda.functionName,
+    externalIdAudit: problemDeployBackendStack.externalIdAuditLambda.functionName,
+    genericScoring: problemDeployBackendStack.genericScoringLambda.functionName,
+  },
+  apiGateways: {
+    controlPlane: {
+      kind: "http",
+      label: "control-plane",
+      apiId: apiIdFromExecuteApiUrl(controlPlaneStack.regApiGatewayUrl),
+      stage: "$default",
+    },
+    tenant: {
+      kind: "rest",
+      label: "tenant",
+      apiName: tenantTemplateStack.tenantApiName,
+      stage: tenantTemplateStack.tenantApiStageName,
+    },
+    // ADR-001 以降 problem-deploy routes は tenant REST API に統合されているため、
+    // API Gateway metric は同じ API/stage を problem-deploy label でも表示する。
+    problemDeploy: {
+      kind: "rest",
+      label: "problem-deploy",
+      apiName: tenantTemplateStack.tenantApiName,
+      stage: tenantTemplateStack.tenantApiStageName,
+    },
+    adminInsight: {
+      kind: "http",
+      label: "admin-insight",
+      apiId: adminConsoleInsightStack.apiId,
+      stage: "$default",
+    },
+  },
+});
+observabilityStack.addDependency(controlPlaneStack);
+observabilityStack.addDependency(problemDeployBackendStack);
+observabilityStack.addDependency(adminConsoleInsightStack);
+observabilityStack.addDependency(bootstrapTemplateStack);
+observabilityStack.addDependency(tenantTemplateStack);
+observabilityStack.addDependency(serverlessSaaSPipeline);
 
 // AdminConsoleHostingStack: React admin-console を CloudFront+S3 で配信 + runtime-config.json 配置。
 // 3-phase deploy の phase 2 で deploy される (install.sh が backend outputs を env として渡す)。

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -62,6 +62,10 @@ export class AdminConsoleInsightStack extends cdk.Stack {
    * admin-console の runtime-config.json に注入される。
    */
   public readonly apiUrl: string;
+  /** Admin Insight HTTP API ID for CloudWatch metrics. */
+  public readonly apiId: string;
+  /** Admin Insight Lambda function name for CloudWatch metrics. */
+  public readonly lambdaFunctionName: string;
 
   constructor(scope: Construct, id: string, props: AdminConsoleInsightStackProps) {
     super(scope, id, props);
@@ -71,6 +75,7 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       eventsTable: props.eventsTable,
       teamsTable: props.teamsTable,
     });
+    this.lambdaFunctionName = lambda.fn.functionName;
 
     // JWT Authorizer: ControlPlane UserPool の token を検証する。
     // (= cognito:groups claim の SystemAdmin チェックは handler 側で実施する 2 段防御)
@@ -151,6 +156,7 @@ export class AdminConsoleInsightStack extends cdk.Stack {
     });
 
     this.apiUrl = httpApi.apiEndpoint;
+    this.apiId = httpApi.apiId;
 
     new CfnOutput(this, "AdminInsightApiUrl", {
       value: httpApi.apiEndpoint,

--- a/infrastructure/lib/observability/cloudwatch-dashboard-stack.ts
+++ b/infrastructure/lib/observability/cloudwatch-dashboard-stack.ts
@@ -1,0 +1,393 @@
+import * as cdk from "aws-cdk-lib";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import type { Construct } from "constructs";
+
+const DASHBOARD_PERIOD = cdk.Duration.minutes(5);
+
+interface NamedMetricTarget {
+  readonly label: string;
+  readonly name: string;
+}
+
+export interface ObservabilityStackProps extends cdk.StackProps {
+  readonly environment?: string;
+  readonly stateMachines: {
+    readonly deployCreateArn: string;
+    readonly deployDeleteArn: string;
+  };
+  readonly codeBuildProjectNames: {
+    readonly problemDeploy: string;
+    readonly provisioning?: string;
+  };
+  readonly dynamoDbTableNames: {
+    readonly deployments: string;
+    readonly events: string;
+    readonly teams: string;
+    readonly competitorAccounts: string;
+    readonly problemEndpoints: string;
+    readonly tenantMappingTable: string;
+  };
+  readonly lambdaFunctionNames: {
+    readonly deployApi: string;
+    readonly eventApi: string;
+    readonly participantPortal?: string;
+    readonly adminInsight: string;
+    readonly competitorAccounts: string;
+    readonly externalIdAudit: string;
+    readonly genericScoring: string;
+  };
+  readonly apiGateways: {
+    readonly controlPlane: ApiGatewayMetricTarget;
+    readonly tenant: ApiGatewayMetricTarget;
+    readonly problemDeploy?: ApiGatewayMetricTarget;
+    readonly adminInsight: ApiGatewayMetricTarget;
+  };
+}
+
+export type ApiGatewayMetricTarget =
+  | {
+      readonly kind: "http";
+      readonly label: string;
+      readonly apiId: string;
+      readonly stage?: string;
+    }
+  | {
+      readonly kind: "rest";
+      readonly label: string;
+      readonly apiName: string;
+      readonly stage?: string;
+    };
+
+/**
+ * TenkaCloud platform observability dashboard.
+ *
+ * Uses AWS managed CloudWatch metrics only. It intentionally does not add alarms,
+ * custom metrics, or IAM resources in this phase.
+ */
+export class ObservabilityStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: ObservabilityStackProps) {
+    super(scope, id, props);
+
+    const dashboard = new cloudwatch.Dashboard(this, "Dashboard", {
+      dashboardName: this.dashboardName(props.environment),
+      defaultInterval: cdk.Duration.hours(6),
+    });
+
+    dashboard.addWidgets(this.deployStateMachinesWidget(props), this.deployCodeBuildWidget(props));
+    dashboard.addWidgets(this.ddbCapacityWidget(props), this.ddbThrottleWidget(props));
+    dashboard.addWidgets(this.lambdaCriticalWidget(props), this.lambdaHelperWidget(props));
+    dashboard.addWidgets(this.apiGatewayTrafficWidget(props), this.apiGatewayLatencyWidget(props));
+  }
+
+  private dashboardName(environment?: string): string {
+    if (!environment) return "tenkacloud-observability";
+    const safeEnvironment = environment.replace(/[^A-Za-z0-9_-]/g, "-");
+    return `tenkacloud-observability-${safeEnvironment}`;
+  }
+
+  private deployStateMachinesWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const stateMachines = [
+      { label: "DeployCreate", arn: props.stateMachines.deployCreateArn },
+      { label: "DeployDelete", arn: props.stateMachines.deployDeleteArn },
+    ];
+
+    return new cloudwatch.GraphWidget({
+      title: "Deploy chain - Step Functions (DeployCreate / DeployDelete)",
+      width: 12,
+      height: 6,
+      left: stateMachines.flatMap((stateMachine) => [
+        this.stateMachineMetric(
+          "ExecutionsStarted",
+          stateMachine.arn,
+          `${stateMachine.label} started`,
+        ),
+        this.stateMachineMetric(
+          "ExecutionsSucceeded",
+          stateMachine.arn,
+          `${stateMachine.label} succeeded`,
+        ),
+        this.stateMachineMetric(
+          "ExecutionsFailed",
+          stateMachine.arn,
+          `${stateMachine.label} failed`,
+        ),
+      ]),
+      right: stateMachines.flatMap((stateMachine) => [
+        this.stateMachineMetric(
+          "ExecutionTime",
+          stateMachine.arn,
+          `${stateMachine.label} ExecutionTime p50`,
+          "p50",
+        ),
+        this.stateMachineMetric(
+          "ExecutionTime",
+          stateMachine.arn,
+          `${stateMachine.label} ExecutionTime p99`,
+          "p99",
+        ),
+      ]),
+      leftYAxis: { label: "executions", min: 0 },
+      rightYAxis: { label: "milliseconds", min: 0 },
+    });
+  }
+
+  private deployCodeBuildWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const projects = [
+      { label: "problem-deploy", name: props.codeBuildProjectNames.problemDeploy },
+      ...(props.codeBuildProjectNames.provisioning
+        ? [
+            {
+              label: "tenkacloud-saas-provisioning",
+              name: props.codeBuildProjectNames.provisioning,
+            },
+          ]
+        : []),
+    ];
+
+    return new cloudwatch.GraphWidget({
+      title: "Deploy chain - CodeBuild (tenkacloud-saas-provisioning / problem-deploy)",
+      width: 12,
+      height: 6,
+      left: projects.flatMap((project) => [
+        this.codeBuildMetric("Builds", project.name, `${project.label} builds`),
+        this.codeBuildMetric("SucceededBuilds", project.name, `${project.label} succeeded`),
+        this.codeBuildMetric("FailedBuilds", project.name, `${project.label} failed`),
+      ]),
+      right: projects.map((project) =>
+        this.codeBuildMetric("Duration", project.name, `${project.label} duration avg`, "Average"),
+      ),
+      leftYAxis: { label: "builds", min: 0 },
+      rightYAxis: { label: "seconds", min: 0 },
+    });
+  }
+
+  private ddbCapacityWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const tables = this.ddbTargets(props);
+
+    return new cloudwatch.GraphWidget({
+      title: "DDB tables - consumed capacity",
+      width: 12,
+      height: 6,
+      left: tables.map((table) =>
+        this.ddbMetric("ConsumedReadCapacityUnits", table.name, `${table.label} read`),
+      ),
+      right: tables.map((table) =>
+        this.ddbMetric("ConsumedWriteCapacityUnits", table.name, `${table.label} write`),
+      ),
+      leftYAxis: { label: "RCU", min: 0 },
+      rightYAxis: { label: "WCU", min: 0 },
+    });
+  }
+
+  private ddbThrottleWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const tables = this.ddbTargets(props);
+
+    return new cloudwatch.GraphWidget({
+      title: "DDB tables - throttles",
+      width: 12,
+      height: 6,
+      left: tables.map((table) =>
+        this.ddbMetric("ReadThrottleEvents", table.name, `${table.label} read throttles`),
+      ),
+      right: tables.map((table) =>
+        this.ddbMetric("WriteThrottleEvents", table.name, `${table.label} write throttles`),
+      ),
+      leftYAxis: { label: "read throttles", min: 0 },
+      rightYAxis: { label: "write throttles", min: 0 },
+    });
+  }
+
+  private lambdaCriticalWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const functions = this.criticalLambdaTargets(props);
+
+    return new cloudwatch.GraphWidget({
+      title: "Lambda - critical APIs",
+      width: 12,
+      height: 6,
+      left: functions.flatMap((fn) => [
+        this.lambdaMetric("Invocations", fn.name, `${fn.label} invocations`),
+        this.lambdaMetric("Errors", fn.name, `${fn.label} errors`),
+      ]),
+      right: functions.map((fn) =>
+        this.lambdaMetric("Duration", fn.name, `${fn.label} p99`, "p99"),
+      ),
+      leftYAxis: { label: "count", min: 0 },
+      rightYAxis: { label: "milliseconds", min: 0 },
+    });
+  }
+
+  private lambdaHelperWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const functions = [
+      { label: "external-id-audit", name: props.lambdaFunctionNames.externalIdAudit },
+      { label: "generic-scoring", name: props.lambdaFunctionNames.genericScoring },
+    ];
+
+    return new cloudwatch.GraphWidget({
+      title: "Lambda - helper functions",
+      width: 12,
+      height: 6,
+      left: functions.flatMap((fn) => [
+        this.lambdaMetric("Invocations", fn.name, `${fn.label} invocations`),
+        this.lambdaMetric("Errors", fn.name, `${fn.label} errors`),
+      ]),
+      right: functions.map((fn) =>
+        this.lambdaMetric("Duration", fn.name, `${fn.label} p99`, "p99"),
+      ),
+      leftYAxis: { label: "count", min: 0 },
+      rightYAxis: { label: "milliseconds", min: 0 },
+    });
+  }
+
+  private apiGatewayTrafficWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const apis = this.apiGatewayTargets(props);
+
+    return new cloudwatch.GraphWidget({
+      title: "ApiGateway - Count / 4XX / 5XX",
+      width: 12,
+      height: 6,
+      left: apis.flatMap((api) => [
+        this.apiGatewayMetric("Count", api, `${api.label} count`, "Sum"),
+        this.apiGatewayMetric(this.clientErrorMetricName(api), api, `${api.label} 4xx`, "Sum"),
+        this.apiGatewayMetric(this.serverErrorMetricName(api), api, `${api.label} 5xx`, "Sum"),
+      ]),
+      leftYAxis: { label: "requests", min: 0 },
+    });
+  }
+
+  private apiGatewayLatencyWidget(props: ObservabilityStackProps): cloudwatch.GraphWidget {
+    const apis = this.apiGatewayTargets(props);
+
+    return new cloudwatch.GraphWidget({
+      title: "ApiGateway - Latency P99",
+      width: 12,
+      height: 6,
+      left: apis.map((api) =>
+        this.apiGatewayMetric("Latency", api, `${api.label} latency p99`, "p99"),
+      ),
+      leftYAxis: { label: "milliseconds", min: 0 },
+    });
+  }
+
+  private ddbTargets(props: ObservabilityStackProps): NamedMetricTarget[] {
+    return [
+      { label: "Deployments", name: props.dynamoDbTableNames.deployments },
+      { label: "Events", name: props.dynamoDbTableNames.events },
+      { label: "Teams", name: props.dynamoDbTableNames.teams },
+      { label: "CompetitorAccounts", name: props.dynamoDbTableNames.competitorAccounts },
+      { label: "ProblemEndpoints", name: props.dynamoDbTableNames.problemEndpoints },
+      { label: "TenantMappingTable", name: props.dynamoDbTableNames.tenantMappingTable },
+    ];
+  }
+
+  private criticalLambdaTargets(props: ObservabilityStackProps): NamedMetricTarget[] {
+    const targets: Array<NamedMetricTarget | undefined> = [
+      { label: "deploy-api", name: props.lambdaFunctionNames.deployApi },
+      { label: "event-api", name: props.lambdaFunctionNames.eventApi },
+      props.lambdaFunctionNames.participantPortal
+        ? { label: "participant-portal-lambda", name: props.lambdaFunctionNames.participantPortal }
+        : undefined,
+      { label: "admin-insight", name: props.lambdaFunctionNames.adminInsight },
+      { label: "competitor-accounts", name: props.lambdaFunctionNames.competitorAccounts },
+    ];
+    return targets.filter((target): target is NamedMetricTarget => target !== undefined);
+  }
+
+  private apiGatewayTargets(props: ObservabilityStackProps): ApiGatewayMetricTarget[] {
+    return [
+      props.apiGateways.controlPlane,
+      props.apiGateways.tenant,
+      ...(props.apiGateways.problemDeploy ? [props.apiGateways.problemDeploy] : []),
+      props.apiGateways.adminInsight,
+    ];
+  }
+
+  private stateMachineMetric(
+    metricName: string,
+    stateMachineArn: string,
+    label: string,
+    statistic = "Sum",
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "AWS/States",
+      metricName,
+      dimensionsMap: { StateMachineArn: stateMachineArn },
+      statistic,
+      period: DASHBOARD_PERIOD,
+      label,
+    });
+  }
+
+  private codeBuildMetric(
+    metricName: string,
+    projectName: string,
+    label: string,
+    statistic = "Sum",
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "AWS/CodeBuild",
+      metricName,
+      dimensionsMap: { ProjectName: projectName },
+      statistic,
+      period: DASHBOARD_PERIOD,
+      label,
+    });
+  }
+
+  private ddbMetric(metricName: string, tableName: string, label: string): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "AWS/DynamoDB",
+      metricName,
+      dimensionsMap: { TableName: tableName },
+      statistic: "Sum",
+      period: DASHBOARD_PERIOD,
+      label,
+    });
+  }
+
+  private lambdaMetric(
+    metricName: string,
+    functionName: string,
+    label: string,
+    statistic = "Sum",
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "AWS/Lambda",
+      metricName,
+      dimensionsMap: { FunctionName: functionName },
+      statistic,
+      period: DASHBOARD_PERIOD,
+      label,
+    });
+  }
+
+  private apiGatewayMetric(
+    metricName: string,
+    api: ApiGatewayMetricTarget,
+    label: string,
+    statistic: string,
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "AWS/ApiGateway",
+      metricName,
+      dimensionsMap: this.apiGatewayDimensions(api),
+      statistic,
+      period: DASHBOARD_PERIOD,
+      label,
+    });
+  }
+
+  private apiGatewayDimensions(api: ApiGatewayMetricTarget): Record<string, string> {
+    if (api.kind === "http") {
+      return api.stage ? { ApiId: api.apiId, Stage: api.stage } : { ApiId: api.apiId };
+    }
+    return api.stage ? { ApiName: api.apiName, Stage: api.stage } : { ApiName: api.apiName };
+  }
+
+  private clientErrorMetricName(api: ApiGatewayMetricTarget): string {
+    return api.kind === "http" ? "4xx" : "4XXError";
+  }
+
+  private serverErrorMetricName(api: ApiGatewayMetricTarget): string {
+    return api.kind === "http" ? "5xx" : "5XXError";
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -131,6 +131,12 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * tenant API の `/admin/competitor-accounts*` route から invoke される。
    */
   public readonly competitorAccountsApiLambda: IFunction;
+  /** Optional Participant Portal backend Lambda. Undefined when portal hosting is disabled. */
+  public readonly participantPortalLambda?: IFunction;
+  /** Generic scoring dispatcher Lambda. */
+  public readonly genericScoringLambda: IFunction;
+  /** ExternalId rotation age audit Lambda. */
+  public readonly externalIdAuditLambda: IFunction;
   /**
    * Participant Portal の CloudFront URL。Participant Portal が無効化された tenant
    * では undefined。`TenantTemplateStack` が application-admin-console の runtime-config に
@@ -149,6 +155,16 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * 参照のみ (read 権限は付与しない)。
    */
   public readonly teamsTable: Table;
+  /** CompetitorAccounts table name is surfaced to ObservabilityStack metrics. */
+  public readonly competitorAccountsTable: Table;
+  /** ProblemEndpoints table name is surfaced to ObservabilityStack metrics. */
+  public readonly problemEndpointsTable: Table;
+  /** DeployCreate Step Functions State Machine ARN for CloudWatch metrics. */
+  public readonly deployCreateStateMachineArn: string;
+  /** DeployDelete Step Functions State Machine ARN for CloudWatch metrics. */
+  public readonly deployDeleteStateMachineArn: string;
+  /** Problem deploy CodeBuild project name for CloudWatch metrics. */
+  public readonly deployCodeBuildProjectName: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -168,6 +184,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     // Issue #459 / ADR-002 Phase 2.1: tenant ↔ 競技者 AWS account の許可表。
     // 1 行 = 1 (tenantId, awsAccountId)。verified=false は deploy 不可。
     const competitorAccounts = new CompetitorAccountsTable(this, "CompetitorAccounts");
+    this.competitorAccountsTable = competitorAccounts.table;
+    this.problemEndpointsTable = endpoints.table;
     const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
@@ -221,11 +239,13 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       concurrentBuildLimit: props.deployConcurrentBuildLimit,
       environmentName: props.environmentName,
     });
+    this.deployCodeBuildProjectName = codeBuild.project.projectName;
 
     const stateMachine = new DeployCreateStateMachine(this, "DeployCreate", {
       codeBuildProject: codeBuild.project,
       deploymentsTable: deployments.table,
     });
+    this.deployCreateStateMachineArn = stateMachine.stateMachine.stateMachineArn;
 
     // EventBridge Rule: `DeployCreateRequested` event を State Machine に流す。
     new DeployEventRule(this, "DeployCreateRule", {
@@ -240,6 +260,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       codeBuildProject: codeBuild.project,
       deploymentsTable: deployments.table,
     });
+    this.deployDeleteStateMachineArn = deleteStateMachine.stateMachine.stateMachineArn;
     new DeployDeleteEventRule(this, "DeployDeleteRule", {
       eventBus,
       stateMachine: deleteStateMachine.stateMachine,
@@ -252,7 +273,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     //
     // uptime 問題が無い tenant でも reconcile は要るので **常に instantiate** (= 旧
     // `if (problemsScoring.length > 0)` ガードは撤去のまま継続)。
-    new GenericScoringLambda(this, "GenericScoring", {
+    const genericScoring = new GenericScoringLambda(this, "GenericScoring", {
       deploymentsTable: deployments.table,
       eventsTable: events.table,
       endpointsTable: endpoints.table,
@@ -260,16 +281,18 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsEndpoints: props.problemsEndpoints,
       problemsPhases: props.problemsPhases ?? {},
     });
+    this.genericScoringLambda = genericScoring.fn;
 
     // Phase 3.2 / Issue #603: ExternalId rotation age 監査 Lambda。1 日 1 回起動して
     // CompetitorAccounts table を Scan し、各 (tenantId, awsAccountId) の rotation age を
     // CloudWatch メトリクス `TenkaCloud/CompetitorAccounts/RotationAge` に publish する。
     // SSM Parameter Store は 100 version で auto-drop するため明示的な cleanup Lambda は
     // 入れない (= 説明は `external-id-audit-lambda.ts` の docblock を参照)。
-    new ExternalIdAuditLambda(this, "ExternalIdAudit", {
+    const externalIdAudit = new ExternalIdAuditLambda(this, "ExternalIdAudit", {
       competitorAccountsTable: competitorAccounts.table,
       environmentName: props.environmentName,
     });
+    this.externalIdAuditLambda = externalIdAudit.fn;
 
     if (props.participantPortal) {
       const consoleViewerRole = new ConsoleViewerRole(this, "ConsoleViewerRole");
@@ -281,6 +304,7 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         problemsEndpoints: props.problemsEndpoints,
         consoleViewerRoleArn: consoleViewerRole.role.roleArn,
       });
+      this.participantPortalLambda = portalLambda.fn;
       // Lambda role に AssumeRole 権限を付与 (= federation flow の前提)。
       consoleViewerRole.role.grantAssumeRole(portalLambda.fn.grantPrincipal);
       new CfnOutput(this, "ParticipantPortalApiUrl", {

--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -25,6 +25,9 @@ export interface ServerlessSaaSPipelineInterface extends cdk.StackProps {
 }
 
 export class ServerlessSaaSPipeline extends cdk.Stack {
+  /** Tenant provisioning CodeBuild project name for CloudWatch metrics. */
+  public readonly provisioningCodeBuildProjectName: string;
+
   constructor(scope: Construct, id: string, props: ServerlessSaaSPipelineInterface) {
     super(scope, id, props);
 
@@ -124,6 +127,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
         },
       }),
     });
+    this.provisioningCodeBuildProjectName = codeBuildProject.projectName;
 
     // Add Permissions.
     codeBuildProject.addToRolePolicy(

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -69,6 +69,13 @@ interface TenantTemplateStackProps extends StackProps {
 }
 
 export class TenantTemplateStack extends Stack {
+  /** Tenant REST API ID for execute-api references. */
+  public readonly tenantApiId: string;
+  /** Tenant REST API name for REST API CloudWatch metrics. */
+  public readonly tenantApiName: string;
+  /** Tenant REST API deployment stage name for CloudWatch metrics. */
+  public readonly tenantApiStageName: string;
+
   constructor(scope: Construct, id: string, props: TenantTemplateStackProps) {
     super(scope, id, props);
     const waveNumber = props.waveNumber || "1";
@@ -126,6 +133,9 @@ export class TenantTemplateStack extends Stack {
         value: this.ssmLookup(props.ApiKeySSMParameterNames.platinum.value),
       },
     });
+    this.tenantApiId = apiGateway.restApi.restApiId;
+    this.tenantApiName = apiGateway.restApi.restApiName;
+    this.tenantApiStageName = apiGateway.restApi.deploymentStage.stageName;
 
     // apiGateway 確定後に runtime-config.json を配置する (apiUrl を詰めるため)。
     // ADR-001 / Issue #458: Deploy 系 endpoint は本 tenant API に統合されたので

--- a/infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts
+++ b/infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts
@@ -1,0 +1,116 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { ObservabilityStack } from "../../lib/observability/cloudwatch-dashboard-stack";
+
+function synthDefault(): Template {
+  const app = new cdk.App();
+  const stack = new ObservabilityStack(app, "ObservabilityStack", {
+    environment: "test",
+    stateMachines: {
+      deployCreateArn: "arn:aws:states:ap-northeast-1:123456789012:stateMachine:DeployCreate",
+      deployDeleteArn: "arn:aws:states:ap-northeast-1:123456789012:stateMachine:DeployDelete",
+    },
+    codeBuildProjectNames: {
+      problemDeploy: "tenkacloud-problem-deploy",
+      provisioning: "tenkacloud-saas-provisioning",
+    },
+    dynamoDbTableNames: {
+      deployments: "Deployments",
+      events: "Events",
+      teams: "Teams",
+      competitorAccounts: "CompetitorAccounts",
+      problemEndpoints: "ProblemEndpoints",
+      tenantMappingTable: "TenantMappingTable",
+    },
+    lambdaFunctionNames: {
+      deployApi: "deploy-api",
+      eventApi: "event-api",
+      participantPortal: "participant-portal-lambda",
+      adminInsight: "admin-insight",
+      competitorAccounts: "competitor-accounts",
+      externalIdAudit: "external-id-audit",
+      genericScoring: "generic-scoring",
+    },
+    apiGateways: {
+      controlPlane: {
+        kind: "http",
+        label: "control-plane",
+        apiId: "control-plane-api",
+        stage: "$default",
+      },
+      tenant: {
+        kind: "rest",
+        label: "tenant",
+        apiName: "TenantAPI-pooled",
+        stage: "prod",
+      },
+      problemDeploy: {
+        kind: "http",
+        label: "problem-deploy",
+        apiId: "problem-deploy-api",
+        stage: "$default",
+      },
+      adminInsight: {
+        kind: "http",
+        label: "admin-insight",
+        apiId: "admin-insight-api",
+        stage: "$default",
+      },
+    },
+  });
+  return Template.fromStack(stack);
+}
+
+function dashboardBody(template: Template): string {
+  const dashboards = template.findResources("AWS::CloudWatch::Dashboard");
+  const dashboard = Object.values(dashboards)[0] as {
+    Properties?: { DashboardBody?: unknown };
+  };
+  return JSON.stringify(dashboard.Properties?.DashboardBody);
+}
+
+describe("ObservabilityStack", () => {
+  const tpl = synthDefault();
+
+  it("CloudWatch Dashboard resource を 1 つ作るべき", () => {
+    tpl.resourceCountIs("AWS::CloudWatch::Dashboard", 1);
+    tpl.hasResourceProperties("AWS::CloudWatch::Dashboard", {
+      DashboardName: "tenkacloud-observability-test",
+    });
+  });
+
+  it("DashboardBody に deploy chain / DDB / Lambda / ApiGateway の監視対象を含むべき", () => {
+    const body = dashboardBody(tpl);
+
+    for (const expected of [
+      "Deploy chain",
+      "DeployCreate",
+      "DeployDelete",
+      "tenkacloud-saas-provisioning",
+      "DDB tables",
+      "Deployments",
+      "Events",
+      "Teams",
+      "CompetitorAccounts",
+      "ProblemEndpoints",
+      "TenantMappingTable",
+      "Lambda",
+      "deploy-api",
+      "event-api",
+      "participant-portal-lambda",
+      "admin-insight",
+      "competitor-accounts",
+      "external-id-audit",
+      "generic-scoring",
+      "ApiGateway",
+      "control-plane",
+      "tenant",
+      "problem-deploy",
+      "p50",
+      "p99",
+    ]) {
+      expect(body).toContain(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implemented by Codex CLI, reviewed by Claude.

TenkaCloud には CloudWatch Dashboard が無く、 deploy chain / scoring / API の健全性を operator が 1 画面で確認できる経路が無かった (= #708 #720 #723 #716 等の事故が CloudWatch logs を tail しないと検知できなかった)。

\`ObservabilityStack\` (Phase 1 deploy) を新規追加し、 5 section の Dashboard を提供:

| Section | Widget | 監視対象 |
|---|---|---|
| Deploy chain | StateMachine ExecutionsStarted/Succeeded/Failed + ExecutionTime P50/P99 | DeployCreate + DeployDelete state machine |
| | CodeBuild Builds/SucceededBuilds/FailedBuilds + Duration | tenkacloud-saas-provisioning Project |
| DDB tables | ConsumedReadCapacityUnits + ConsumedWriteCapacityUnits + Read/Write ThrottleEvents | Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / TenantMappingTable |
| Lambda | Invocations + Errors + Duration P99 | deploy-api / event-api / participant-portal / admin-insight / competitor-accounts / external-id-audit / generic-scoring |
| API Gateway | Count + 4XXError + 5XXError + Latency P99 | control-plane / tenant / problem-deploy / admin-insight HTTP API |

Dashboard 名: \`tenkacloud-observability-\${environment}\` (= dev / production 共存可能)。

## Test plan

- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて OK
- [x] CDK test (\`infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts\`) で DashboardBody JSON 中の各 section / metric / state machine 名等を assert
- [ ] dev \`make deploy\` で \`tenkacloud-observability-development\` Dashboard が CloudWatch console に出るか確認

## Regression 分析

- 新 stack 1 つ追加。 既存 stack の Properties は無変更 (Codex が public field exposure のため一部 stack に getter / readonly field を追加した可能性あり)
- AWS Managed metric を読むだけなので IAM 追加なし、 cost 増加なし (= 5 個までの Dashboard は無料)
- 既存 Lambda / DDB / API は無変更
- cdk-nag warning は Dashboard data-plane でないので大半は適用外

## 物理影響

- ADD: \`infrastructure/lib/observability/cloudwatch-dashboard-stack.ts\` (377 lines)
- ADD: \`infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts\`
- UPDATE: \`infrastructure/bin/infrastructure.ts\` (ObservabilityStack instantiation)
- UPDATE: 4 existing stack files (= getter / readonly field を露出するため)
- DEPLOY: 1 new \`AWS::CloudWatch::Dashboard\` resource (tenkacloud-observability-\${env})
- NO-OP: 既存 Lambda / DDB / API は無変更

## Follow-up issues (= 別 PR)

- Phase 2: Lambda log filter で custom metric 追加 (deploy failure rate / scoring failure 比率)
- Phase 3: CloudWatch Alarm + SNS で operator notification

Closes #733

🤖 Implemented by Codex CLI, reviewed by Claude