### PR TITLE
fix(#747): federation getSigninToken の SessionDuration param 削除 (SSO 復旧)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -133,7 +133,10 @@ export async function getConsoleSigninUrl(
     sessionToken: creds.SessionToken,
   });
 
-  const tokenUrl = `${FEDERATION_ENDPOINT}?Action=getSigninToken&SessionDuration=${FEDERATION_SESSION_DURATION_SEC}&Session=${encodeURIComponent(sessionJson)}`;
+  // #747: AssumeRole 由来の temporary credentials で federation する場合、 SessionDuration
+  // パラメータは **省略必須** (AWS 仕様)。 渡すと endpoint が 400 で reject する。
+  // session 寿命は AssumeRole 時の DurationSeconds (= 3600s) を継承する。
+  const tokenUrl = `${FEDERATION_ENDPOINT}?Action=getSigninToken&Session=${encodeURIComponent(sessionJson)}`;
   const tokenRes = await fetch(tokenUrl, { method: "GET" });
   if (!tokenRes.ok) {
     console.error("[sso] federation endpoint non-200", {

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -148,6 +148,12 @@ describe("getConsoleSigninUrl", () => {
     expect(result.loginUrl).toContain("cloudformation");
     // 競技者の namePrefix で stacks フィルタを掛ける
     expect(result.loginUrl).toContain(encodeURIComponent("tc-security-battle-royale-alpha"));
+
+    // #747: getSigninToken request URL に SessionDuration param が含まれてはいけない
+    // (AssumeRole 由来 credentials では federation endpoint が 400 を返すため)。
+    const fetchedUrl = fetchSpy.mock.calls[0]?.[0]?.toString() ?? "";
+    expect(fetchedUrl).toContain("Action=getSigninToken");
+    expect(fetchedUrl).not.toContain("SessionDuration");
   });
 
   it("AssumeRole に inline session policy を渡し、DDB / Secrets Manager / KMS / IAM を Deny で殺すべき", async () => {


### PR DESCRIPTION
## Summary

PR-743 (#737 Path A) で AssumeRole は成功するようになったが、 次の step (federation \`getSigninToken\`) が **400** で fail していた:

\`\`\`
ERROR  [sso] federation endpoint non-200 { jobId: '...', status: 400, statusText: '' }
\`\`\`

AWS docs ([Console SSO](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)): AssumeRole 由来の temporary credentials を federation で使うときは \`SessionDuration\` parameter を **省略必須**。 \`sso.ts\` は誤って \`SessionDuration=3600\` を URL に付けていたため endpoint が reject。

URL から \`SessionDuration\` を削除 (= 1 行修正)。 session 寿命は AssumeRole の \`DurationSeconds\` を継承。

## Test plan

- [x] \`make before-commit\` clean
- [x] 既存 7 cases (= AssumeRole で渡す DurationSeconds=3600 は無変更)、 + 新 assertion: \`getSigninToken\` request URL に \`SessionDuration\` が含まれない
- [ ] dev で実 deploy 後 COMPLETE な hello-world-battle で SSO が動くか確認

## Regression 分析

- AssumeRole の DurationSeconds=3600 は無変更
- federation session 寿命は AssumeRole credentials の残り (~1h) を継承
- 既存「正常系」 / 「Deny で殺すべき」 case は無変更で pass

## 物理影響

- UPDATE: \`sso.ts\` の \`tokenUrl\` から \`SessionDuration\` を削除 + 理由コメント
- UPDATE: test に「URL に SessionDuration を含まない」 assertion 追加
- NO-OP: その他

Closes #747

🤖 Implemented by Claude (Codex quota exhausted, 1-line fix done manually)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS SSO console sign-in URL construction to comply with AWS federation token requirements, ensuring sign-in requests are properly accepted and session duration is correctly inherited from the initial role assumption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/750)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->