### PR TITLE
fix(#745): Score events 0 件問題 — PutItem IAM grant + silent skip 排除

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -110,28 +110,26 @@ export async function submitFlag(
     const totalScore = Number((updated.Attributes as { score?: unknown })?.score ?? scoring.points);
 
     // 加点成功時のみ score event 行を append。失敗 (= already_scored の race) では
-    // 既存の event 行が記録済みなので二重に書かない。Put 失敗は best-effort で log。
+    // 既存の event 行が記録済みなので二重に書かない。
+    // #745: 旧実装は Put 失敗を console.warn で握り潰していたが、 score events 履歴が空のまま
+    // header の score だけ加点される矛盾を生んだ (= IAM 不足で silent skip)。 AGENTS.md
+    // 「モック / スタブで握り潰す fallback 禁止」 違反だったので、 失敗は throw して
+    // route-helpers の internal_error 経路で 500 を返す。
     if (item.jobId) {
-      try {
-        await writeScoreEvent(
-          shared.ddb,
-          shared.tableName,
-          {
-            jobId: item.jobId,
-            problemId: item.problemId,
-            teamId: item.teamId,
-            eventId: item.eventId,
-            expiresAt: item.expiresAt ?? 0,
-          },
-          "flag",
-          scoring.points,
-          now,
-        );
-      } catch (err) {
-        console.warn(`[submit-flag] score-event write failed jobId=${item.jobId}`, {
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
+      await writeScoreEvent(
+        shared.ddb,
+        shared.tableName,
+        {
+          jobId: item.jobId,
+          problemId: item.problemId,
+          teamId: item.teamId,
+          eventId: item.eventId,
+          expiresAt: item.expiresAt ?? 0,
+        },
+        "flag",
+        scoring.points,
+        now,
+      );
     }
 
     return { kind: "ok", scoreDelta: scoring.points, totalScore };

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -83,6 +83,14 @@ export class ParticipantPortalLambda extends Construct {
               actions: ["dynamodb:UpdateItem"],
               resources: [props.deploymentsTable.tableArn],
             }),
+            // #745: writeScoreEvent (= submit-flag handler が flag 正解時に PK=`DEPLOYMENT#${jobId}`
+            // / SK=`EVENT#${ts}#${ulid}` で score event 行を append) が PutItem を発行する。
+            // この grant が無いと AccessDenied で silent skip され、 UI で 「加点済だが履歴 0 件」
+            // の矛盾が発生していた (= CloudWatch logs で確認済)。
+            new PolicyStatement({
+              actions: ["dynamodb:PutItem"],
+              resources: [props.deploymentsTable.tableArn],
+            }),
           ],
         }),
         // ADR-006 Notifications: Events table の partition Query 権限のみ。


### PR DESCRIPTION
## Summary

CloudWatch logs で root cause 確定: \`ParticipantPortalLambda\` Role に \`dynamodb:PutItem\` grant 無し → \`writeScoreEvent\` が AccessDenied → \`submit-flag\` handler が \`console.warn\` で silent skip。 結果、 header score は加点済に見えるが score events 履歴は 0 件のままで UI が矛盾。

## Fix

1. IAM Role inline policy \`DeploymentsRead\` に \`dynamodb:PutItem\` を追加
2. submit-flag handler の try/catch で console.warn 握り潰しを排除 (= AGENTS.md 「モック / スタブで握り潰す fallback 禁止」 違反の根本是正)

## Test plan

- [x] \`make before-commit\` clean
- [ ] dev で実 deploy 後、 flag 提出 → score events page で履歴が並ぶか確認

## Regression 分析

- 加点 + score event が 1 transaction 的に成功
- 失敗時は 5xx UI 明示 (= 旧 silent skip 矛盾が再発しない)
- 既存 「flag 提出 → 加点」 経路は無変更で通る

## 物理影響

- UPDATE: \`infrastructure/lib/problem-deploy/participant-portal-lambda.ts\` (PutItem statement)
- UPDATE: \`infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts\` (try/catch 除去)
- NO-OP: DDB schema は無変更

Closes #745

🤖 Implemented by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for flag submissions to ensure scoring errors are properly surfaced instead of silently logged, improving system reliability.
  * Granted required permissions to enable proper persistence of flag submission score records to the database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/751)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->