### PR TITLE
fix(#746): GenericScoring Lambda memorySize 256 → 1024MB (cold start OOM 解消)

### DIFF
--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -73,7 +73,12 @@ export class GenericScoringLambda extends Construct {
       entry: path.resolve(__dirname, "handlers/generic-scoring-handler/index.ts"),
       handler: "handler",
       timeout: Duration.minutes(2),
-      memorySize: 256,
+      // #746: 旧 256MB だと cold start で OOM + init timeout が頻発し採点 Lambda が
+      // 起動すらしなかった (CloudWatch logs で Init Duration 10001ms timeout +
+      // Runtime.OutOfMemory を確認)。 同 ParticipantPortalLambda が #672 で 512MB に
+      // 上げた経緯と同じく、 bundle が AWS SDK / Hono / zod 込みで巨大なので 1024MB に
+      // 余裕を持たせる (= cold start 後の steady state は実測 256MB 未満で済むはず)。
+      memorySize: 1024,
       environment: {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,


### PR DESCRIPTION
## Summary

CloudWatch logs で root cause 確定: GenericScoring Lambda が 256MB で **cold start 中に OOM + init timeout** を繰り返し、 1-min schedule で起動するたびに失敗 → Battle uptime / phased-polling 採点が永遠に動かない。

\`\`\`
INIT_REPORT Init Duration: 10001.22 ms Status: timeout
REPORT Memory Size: 256 MB Max Memory Used: 256 MB Status: error Error Type: Runtime.OutOfMemory
\`\`\`

memorySize を 1024MB に拡張。 同 ParticipantPortalLambda が #672 で 512MB に上げた経緯と同型 (= bundle に AWS SDK / Hono / zod が含まれ巨大)。

## Test plan

- [x] \`make before-commit\` clean
- [ ] dev で実 deploy 後、 1-min schedule で Lambda が success exit するか / 採点ログが出るか確認

## Regression 分析

- cost: 1-min × 730h/月 × 1GB ≒ 44k GB-sec < 400k Free Tier、 増加無し
- 既存 handler / IAM / DDB schema は無変更

## 物理影響

- UPDATE: \`generic-scoring-lambda.ts\` の memorySize (1 行変更)
- NO-OP: その他

Closes #746

🤖 Implemented by Claude