### PR TITLE
fix(#756): 既存 event deployment の再デプロイを追加

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -127,6 +127,7 @@ export async function createEvent(
 /**
  * #555: `POST /events/:id/deploy` の opt-in body。全フィールド optional:
  *   - `retryFailedOnly: true` — FAILED 状態の deployment 行だけ再実行 (= 失敗分 retry)
+ *   - `forceRedeploy: true` — COMPLETE/FAILED/DELETED の既存 deployment を置換して再実行
  *   - `teamIds` — 指定 team のみ deploy (= 後追い team / 該当 team の env 再構築)
  *   - `problemIds` — 指定 problem のみ deploy (= 後追い問題 / 修正済問題の全 team 再 deploy)
  *
@@ -134,6 +135,7 @@ export async function createEvent(
  */
 export interface BulkDeployBody {
   retryFailedOnly?: true;
+  forceRedeploy?: true;
   teamIds?: readonly string[];
   problemIds?: readonly string[];
 }

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -126,10 +126,10 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const [detail, setDetail] = useState<EventDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [bulkResult, setBulkResult] = useState<BulkResult | null>(null);
-  // #555: 「失敗分を再実行」も同じ POST /deploy 経路。in-flight 状態を 3 値に拡張。
-  const [bulkInFlight, setBulkInFlight] = useState<"deploy" | "teardown" | "retry-failed" | null>(
-    null,
-  );
+  // #555/#756: deploy 系操作は同じ POST /deploy 経路。in-flight 状態だけ分けて表示する。
+  const [bulkInFlight, setBulkInFlight] = useState<
+    "deploy" | "teardown" | "retry-failed" | "redeploy" | null
+  >(null);
   const [confirmTeardown, setConfirmTeardown] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [scheduleDate, setScheduleDate] = useState("");
@@ -173,7 +173,9 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
 
   const handleBulkDeploy = async (body: BulkDeployBody = {}) => {
     if (!apiClient || bulkInFlight) return;
-    setBulkInFlight(body.retryFailedOnly ? "retry-failed" : "deploy");
+    setBulkInFlight(
+      body.retryFailedOnly ? "retry-failed" : body.forceRedeploy ? "redeploy" : "deploy",
+    );
     setError(null);
     try {
       const res = await bulkDeployEvent(apiClient, eventId, body);
@@ -405,6 +407,12 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
         0,
       )
     : 0;
+  const completeCount = detail
+    ? Object.values(detail.deploymentsByProblem).reduce(
+        (acc, list) => acc + list.filter((d) => d.status === "COMPLETE").length,
+        0,
+      )
+    : 0;
 
   return (
     <SpaceBetween size="l">
@@ -437,6 +445,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                 loading={bulkInFlight === "retry-failed"}
                 disabled={
                   !detail ||
+                  detail.status === "ENDED" ||
                   detail.status === "TEARDOWN" ||
                   detail.status === "ARCHIVED" ||
                   bulkInFlight !== null
@@ -445,6 +454,22 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                 onClick={() => handleBulkDeploy({ retryFailedOnly: true })}
               >
                 失敗分を再実行 ({failedCount} 件)
+              </Button>
+            )}
+            {completeCount > 0 && (
+              <Button
+                loading={bulkInFlight === "redeploy"}
+                disabled={
+                  !detail ||
+                  detail.status === "ENDED" ||
+                  detail.status === "TEARDOWN" ||
+                  detail.status === "ARCHIVED" ||
+                  bulkInFlight !== null
+                }
+                iconName="refresh"
+                onClick={() => handleBulkDeploy({ forceRedeploy: true })}
+              >
+                再デプロイ ({completeCount} 件)
               </Button>
             )}
             <Button

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -126,6 +126,12 @@ describe("bulkDeployEvent", () => {
     await bulkDeployEvent(client, "EV1", { teamIds: ["t1"], problemIds: ["hello-world"] });
     expect(calls[0]?.body).toEqual({ teamIds: ["t1"], problemIds: ["hello-world"] });
   });
+
+  it("forceRedeploy: true を body にそのまま乗せて POST するべき", async () => {
+    const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
+    await bulkDeployEvent(client, "EV1", { forceRedeploy: true });
+    expect(calls[0]?.body).toEqual({ forceRedeploy: true });
+  });
 });
 
 describe("bulkTeardownEvent", () => {

--- a/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
@@ -143,3 +143,50 @@ describe("EventDetailPage #555 失敗分を再実行 button", () => {
     expect(buttonEl?.disabled).toBe(true);
   });
 });
+
+describe("EventDetailPage #756 再デプロイ button", () => {
+  it("COMPLETE な deployment が 0 件のときは button を表示しないべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [
+          { jobId: "J1", teamId: "t1", status: "PENDING" },
+          { jobId: "J2", teamId: "t2", status: "FAILED" },
+        ],
+      },
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/再デプロイ/)).not.toBeInTheDocument();
+  });
+
+  it("COMPLETE な deployment があると 件数つきで button を表示するべき", async () => {
+    mocks.getEvent.mockResolvedValueOnce({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [
+          { jobId: "J1", teamId: "t1", status: "COMPLETE" },
+          { jobId: "J2", teamId: "t2", status: "COMPLETE" },
+        ],
+      },
+    });
+    renderPage();
+    expect(await screen.findByText(/再デプロイ \(2 件\)/)).toBeInTheDocument();
+  });
+
+  it("button を押すと bulkDeployEvent を forceRedeploy=true で呼ぶべき", async () => {
+    mocks.getEvent.mockResolvedValue({
+      ...baseDetail,
+      deploymentsByProblem: {
+        "hello-world": [{ jobId: "J1", teamId: "t1", status: "COMPLETE" }],
+      },
+    });
+    renderPage();
+    const button = await screen.findByText(/再デプロイ \(1 件\)/);
+    await userEvent.click(button);
+    await waitFor(() => expect(mocks.bulkDeployEvent).toHaveBeenCalled());
+    expect(mocks.bulkDeployEvent).toHaveBeenCalledWith(expect.anything(), EVENT_ID, {
+      forceRedeploy: true,
+    });
+  });
+});

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -67,6 +67,9 @@ const toEpochSeconds = (ms: number): number => Math.floor(ms / 1000);
  *   - `{ retryFailedOnly: true }` → FAILED 状態の旧行を DELETE → 同 (teamId, problemId) で
  *     新 jobId の PENDING を CREATE。旧 jobId は失われる (= 履歴より状態のクリーンさを優先、
  *     failureReason の monitoring は publish 直後の CloudWatch Logs に残る)。
+ *   - `{ forceRedeploy: true }` → COMPLETE / FAILED / DELETED の旧行を DELETE → 同
+ *     (teamId, problemId) で新 jobId の PENDING を CREATE。PENDING / IN_PROGRESS / DELETING
+ *     は二重実行防止のため skip。
  *   - `{ teamIds }` / `{ problemIds }` → 範囲を絞る (後追い team / 問題用)
  *   - 組み合わせ可能 (= `{ retryFailedOnly: true, teamIds: [t1] }` で「team t1 の失敗のみ retry」)
  */
@@ -129,6 +132,8 @@ export async function bulkDeployEvent(
   );
   // (teamId, problemId) → 旧 FAILED 行の jobId (retryFailedOnly のとき DELETE 対象)。
   const failedByKey = new Map<string, { jobId: string }>();
+  // (teamId, problemId) → 再 deploy で置換可能な terminal 行の jobId。
+  const forceRedeployByKey = new Map<string, { jobId: string }>();
   // (teamId, problemId) → status を問わず存在する組 (skipped 計算用)。
   const existingKey = new Set<string>();
   for (const d of existingDeployments) {
@@ -140,8 +145,15 @@ export async function bulkDeployEvent(
     if (d.status === "FAILED" && !failedByKey.has(k)) {
       failedByKey.set(k, { jobId: String(d.jobId ?? "") });
     }
+    if (
+      (d.status === "COMPLETE" || d.status === "FAILED" || d.status === "DELETED") &&
+      !forceRedeployByKey.has(k)
+    ) {
+      forceRedeployByKey.set(k, { jobId: String(d.jobId ?? "") });
+    }
   }
   const retryFailedOnly = request?.retryFailedOnly === true;
+  const forceRedeploy = request?.forceRedeploy === true;
   // retryFailedOnly でかつ FAILED 行が 0 件 → 何もしない (= enqueued: 0、skipped: 0)。
   if (retryFailedOnly && failedByKey.size === 0) {
     return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
@@ -191,7 +203,7 @@ export async function bulkDeployEvent(
   interface PlanEntry {
     readonly item: DeploymentItem;
     readonly entry: PutEventsRequestEntry;
-    /** retryFailedOnly = true のとき、対応する旧 FAILED 行の jobId (= これを DELETE)。 */
+    /** retry / force redeploy のとき、対応する旧行の jobId (= これを DELETE)。 */
     readonly replacesJobId?: string;
   }
   const plan: PlanEntry[] = [];
@@ -201,13 +213,22 @@ export async function bulkDeployEvent(
     const teamAwsAccountId = team.awsAccountId;
     for (const problem of problems) {
       const k = `${team.teamId} ${problem.problemId}`;
+      const replacement = retryFailedOnly
+        ? failedByKey.get(k)
+        : forceRedeploy
+          ? forceRedeployByKey.get(k)
+          : undefined;
       if (retryFailedOnly) {
         // FAILED で無い組み合わせは対象外 (= silent skip、skipped にも計上しない)。
-        if (!failedByKey.has(k)) continue;
+        if (!replacement) continue;
       } else if (existingKey.has(k)) {
-        // 既存 (status を問わず) と衝突 → idempotent skip (全展開 / 部分指定 共通)。
-        skipped++;
-        continue;
+        if (forceRedeploy && replacement) {
+          // terminal 行は下で DELETE + 新 PENDING CREATE。in-flight 行は通常通り skip。
+        } else {
+          // 既存 (status を問わず) と衝突 → idempotent skip (全展開 / 部分指定 共通)。
+          skipped++;
+          continue;
+        }
       }
       const problemDir = shared.problemsCatalog[problem.problemId];
       if (!problemDir) {
@@ -280,7 +301,7 @@ export async function bulkDeployEvent(
       plan.push({
         item,
         entry,
-        replacesJobId: retryFailedOnly ? failedByKey.get(k)?.jobId : undefined,
+        replacesJobId: replacement?.jobId,
       });
     }
   }
@@ -292,10 +313,10 @@ export async function bulkDeployEvent(
     };
   }
 
-  // DDB TransactWrite は 1 call 25 items まで (Put + Delete を合算)。retryFailedOnly では
-  // 1 plan entry につき Put + Delete の 2 op が要るので chunk 上限を半減させる。
+  // DDB TransactWrite は 1 call 25 items まで (Put + Delete を合算)。retry / force redeploy
+  // では 1 plan entry につき Put + Delete の 2 op が要るので chunk 上限を半減させる。
   // ConditionExpression で同 jobId 二重生成を防ぐ (ULID 衝突は実質起こらないが defense)。
-  const opsPerEntry = retryFailedOnly ? 2 : 1;
+  const opsPerEntry = retryFailedOnly || forceRedeploy ? 2 : 1;
   const planPerChunk = Math.floor(TRANSACT_WRITE_BATCH / opsPerEntry);
   const transactChunks: Promise<unknown>[] = [];
   for (let i = 0; i < plan.length; i += planPerChunk) {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -268,9 +268,12 @@ export type EventDetail = z.infer<typeof EventDetailSchema>;
  *   - `retryFailedOnly: true` → status=FAILED の deployment 行のみ抽出。旧 DDB 行を
  *     DELETE → 同 (teamId, problemId) で新 jobId で PENDING を CREATE する (= 旧 jobId は
  *     消える)。Issue #555 / 要件 FR-3 の「失敗分を再実行」 button の backend。
+ *   - `forceRedeploy: true` → 既存 terminal deployment (COMPLETE / FAILED / DELETED) を
+ *     DELETE → 同 (teamId, problemId) で新 jobId の PENDING を CREATE する。pre-#744 の
+ *     stackOutputs を持つ COMPLETE stack を最新 template で update し直す運用復旧用。
  *   - `teamIds` / `problemIds` → 指定された team / problem だけに範囲を絞る (= 後追い参加
- *     team / 後追い投入問題のみを deploy)。`retryFailedOnly: true` と組み合わせ可能
- *     (= 「team t1 の失敗だけ retry」)。
+ *     team / 後追い投入問題のみを deploy)。`retryFailedOnly: true` / `forceRedeploy: true` と
+ *     組み合わせ可能。
  *
  * idempotent semantics: 既存 deployment と (eventId, teamId, problemId) が衝突する組は
  * 全展開モードでも skipped に計上する (= 後追い deploy が二重生成しないため)。
@@ -280,8 +283,13 @@ export type EventDetail = z.infer<typeof EventDetailSchema>;
 export const BulkDeployRequestSchema = z
   .object({
     retryFailedOnly: z.literal(true).optional(),
+    forceRedeploy: z.literal(true).optional(),
     teamIds: z.array(z.string().min(1)).min(1).max(100).optional(),
     problemIds: z.array(z.string().min(1)).min(1).max(50).optional(),
   })
-  .strict();
+  .strict()
+  .refine((v) => !(v.retryFailedOnly && v.forceRedeploy), {
+    message: "retryFailedOnly and forceRedeploy are mutually exclusive",
+    path: ["forceRedeploy"],
+  });
 export type BulkDeployRequest = z.infer<typeof BulkDeployRequestSchema>;

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -487,6 +487,39 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
+  // #756: forceRedeploy = true → COMPLETE 済み stack を新 template で update し直す
+  it("forceRedeploy = true は COMPLETE 行を DELETE + 新規 PENDING を CREATE するべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "OLD-COMPLETE", status: "COMPLETE" },
+        { teamId: "T2", problemId: "hello-world-battle", jobId: "OLD-PENDING", status: "PENDING" },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS, {
+      forceRedeploy: true,
+    });
+
+    // COMPLETE は置換、未作成 2 件は通常 deploy、PENDING 1 件は skip。
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 3, skipped: 1 } });
+
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const items = transactCmd?.input.TransactItems ?? [];
+    expect(items.filter((it) => it.Put)).toHaveLength(3);
+    const deletes = items.filter((it) => it.Delete);
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]?.Delete?.Key?.PK).toBe("DEPLOYMENT#OLD-COMPLETE");
+    expect(deletes[0]?.Delete?.ConditionExpression).toContain("tenantId");
+    expect(deletes[0]?.Delete?.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
+  });
+
   // #555: teamIds で range を絞る (= 後追い team / 該当 team の env だけ deploy)
   it("teamIds 指定 で指定 team のみ deploy するべき", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();


### PR DESCRIPTION
## Summary

- `POST /events/:eventId/deploy` に `forceRedeploy: true` を追加し、既存 terminal deployment (`COMPLETE` / `FAILED` / `DELETED`) を新しい PENDING job に置換できるようにしました
- Application Admin Console の Event 詳細に COMPLETE 済み deployment 向けの「再デプロイ」ボタンを追加しました
- `retryFailedOnly` と `forceRedeploy` は同時指定不可にし、`PENDING` / `IN_PROGRESS` / `DELETING` は二重実行防止のため skip します

## Root Cause

#756 の復旧には pre-#744 template で作られた COMPLETE 済み problem stack を最新 template で update し直す必要がありますが、既存の bulk deploy は `(eventId, teamId, problemId)` が存在すると status に関係なく skip していたため、既存 event 内で再実行できませんでした。

## Test plan

- [x] `bun run --filter @TenkaCloud/infrastructure test -- event-bulk-deploy.test.ts`
- [x] `bun run --filter @TenkaCloud/application-admin-console test -- events-client.test.ts EventDetail.retry-failed.test.tsx`
- [x] `make before-commit`
- [ ] `make harness` は `.claude/harness/bin/architecture.ts` がこの checkout に存在せず実行不能 (`.claude/harness` は `node_modules` のみ)

Closes #756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "再デプロイ" button to the event detail page, enabling force redeploy of completed deployments
  * Extended the bulk deploy API to support force redeploy capability for replacing terminal deployments

* **Tests**
  * Added comprehensive test coverage for the new redeploy functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/760)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->