### PR TITLE
fix: show full verified account info in event create

### DIFF
--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -41,6 +41,23 @@ const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
   label: r.label,
 }));
 
+export function buildVerifiedAccountOption(a: CompetitorAccountSummary): SelectProps.Option {
+  const descriptionParts = [a.alias, a.region, a.competitorRoleName].filter(
+    (p): p is string => typeof p === "string" && p.length > 0,
+  );
+  return {
+    value: a.awsAccountId,
+    label: a.awsAccountId,
+    labelTag: a.alias,
+    description: descriptionParts.join(" / "),
+    filteringTags: descriptionParts,
+  };
+}
+
+export function formatVerifiedAccountSummary(a: CompetitorAccountSummary): string {
+  return a.alias ? `${a.awsAccountId} (${a.alias})` : a.awsAccountId;
+}
+
 interface ProblemRow {
   problemId: string;
   problemName: string;
@@ -122,11 +139,11 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   const noVerifiedAccounts = competitorAccounts !== null && verifiedAccounts.length === 0;
   const showNoVerifiedAccountsHint = noVerifiedAccounts && !accountsLoadError;
   const accountOptions: SelectProps.Option[] = useMemo(
-    () =>
-      verifiedAccounts.map((a) => ({
-        value: a.awsAccountId,
-        label: a.alias ? `${a.alias} (${a.awsAccountId})` : a.awsAccountId,
-      })),
+    () => verifiedAccounts.map((a) => buildVerifiedAccountOption(a)),
+    [verifiedAccounts],
+  );
+  const accountById = useMemo(
+    () => new Map(verifiedAccounts.map((a) => [a.awsAccountId, a])),
     [verifiedAccounts],
   );
 
@@ -391,6 +408,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                     cell: (t) => {
                       const selected =
                         accountOptions.find((o) => o.value === t.awsAccountId) ?? null;
+                      const selectedAccount = accountById.get(t.awsAccountId);
                       return (
                         <SpaceBetween size="xxs">
                           <Select
@@ -412,6 +430,13 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                               t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)
                             }
                           />
+                          {selectedAccount && (
+                            <Box variant="small" color="text-status-inactive">
+                              <span title={formatVerifiedAccountSummary(selectedAccount)}>
+                                {formatVerifiedAccountSummary(selectedAccount)}
+                              </span>
+                            </Box>
+                          )}
                           {noVerifiedAccounts && (
                             <Box variant="small" color="text-status-inactive">
                               {NO_VERIFIED_ACCOUNTS_HELPER}

--- a/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
@@ -46,7 +46,9 @@ const config: AppConfig = {
   apiBaseUrl: "https://api.example.com/prod",
 };
 
-const { EventCreatePage } = await import("../../src/pages/EventCreate");
+const { EventCreatePage, buildVerifiedAccountOption, formatVerifiedAccountSummary } = await import(
+  "../../src/pages/EventCreate"
+);
 
 function renderPage() {
   return render(
@@ -66,6 +68,25 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("EventCreatePage (Phase 2.2 verified-only)", () => {
+  it("account option は 12 桁 ID を主ラベルにして alias を補足表示するべき", () => {
+    const account = {
+      awsAccountId: "111111111111",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      alias: "production-shared-account",
+      verified: true,
+      verifiedAt: "2026-05-10T00:00:00.000Z",
+      createdAt: "2026-05-09T00:00:00.000Z",
+      updatedAt: "2026-05-10T00:00:00.000Z",
+    };
+    const option = buildVerifiedAccountOption(account);
+
+    expect(option.label).toBe("111111111111");
+    expect(option.labelTag).toBe("production-shared-account");
+    expect(option.description).toContain("production-shared-account");
+    expect(formatVerifiedAccountSummary(account)).toBe("111111111111 (production-shared-account)");
+  });
+
   it("0 件のとき Competitor Accounts への導線 (Alert) を表示するべき", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce({ items: [] });
     renderPage();


### PR DESCRIPTION
## Summary
- Show the 12-digit AWS account ID as the primary Select label in the Event create Teams section.
- Keep alias/region/role visible in the dropdown metadata and show the selected full account summary under the Select.
- Add coverage for the verified account option formatting.

## Test plan
- `bun run --filter @TenkaCloud/application-admin-console test -- EventCreate.verified-only.test.tsx EventCreate.no-verified-hint.test.tsx`
- `make before-commit`

## Notes
- `make harness` is blocked in this checkout because `.claude/harness/bin/architecture.ts` is missing before the harness logic starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced verified competitor account selection display in the event creation interface with improved account summary information for selected accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/761)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->