### PR TITLE
fix: handle cross-account deploy and delete state machines

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -1,6 +1,7 @@
-import { Duration, Stack } from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
 import type { Project } from "aws-cdk-lib/aws-codebuild";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import {
   Choice,
@@ -10,13 +11,15 @@ import {
   JsonPath,
   LogLevel,
   Pass,
+  Result,
   StateMachine,
+  TaskInput,
 } from "aws-cdk-lib/aws-stepfunctions";
 import {
-  CallAwsService,
   CodeBuildStartBuild,
   DynamoAttributeValue,
   DynamoUpdateItem,
+  LambdaInvoke,
 } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { Construct } from "constructs";
 import { deploymentKey, stateEnteredTime } from "./state-machine-helpers";
@@ -24,6 +27,12 @@ import { deploymentKey, stateEnteredTime } from "./state-machine-helpers";
 export interface DeployCreateStateMachineProps {
   /** 実体の deploy を担う CodeBuild Project (= `scripts/deploy-battles.sh` を実行)。 */
   readonly codeBuildProject: Project;
+  /**
+   * CodeBuild 完了後に competitor account 側の CloudFormation stack を読む Lambda。
+   * verified deployment は ExternalId 付き AssumeRole が必要なため、Step Functions の
+   * platform-account CallAwsService ではなく Lambda に閉じ込める。
+   */
+  readonly describeStackFunction: IFunction;
   /**
    * Deployment 行を持つ DDB Table。CodeBuild 完了時に `status` を `PENDING` →
    * `COMPLETE` / `FAILED` に更新するために必要。
@@ -76,51 +85,76 @@ export class DeployCreateStateMachine extends Construct {
       resultPath: JsonPath.DISCARD,
     });
 
-    // Phase 2.2 (Issue #459): `$.detail.competitorRoleArn` / `$.detail.externalIdParameterName`
-    // を CodeBuild env に渡す。`deploy-battles.sh` 内で `COMPETITOR_ROLE_ARN` が空でなければ
-    // AssumeRole + ExternalId 経路に倒し、空なら same-account fallback (dev / 未 verify) を残す。
-    // Step Functions の `States.Format` / 直接 path 参照は path が `undefined` だと fail する
-    // (= optional field を入れるのが難しい)。bulk-deploy / startDeployment は verified=true
-    // のときのみ field を埋めているため、verified-only 経路では必ず存在する。
-    // 未 verified だった場合は publish そのものが起きないので path 参照しても to-end は安全。
-    // ただ後方互換 (= 旧 event detail に competitorRoleArn 無し) を保つため、CodeBuild env は
-    // 任意 path 経由で参照する。
-    const startCodeBuild = new CodeBuildStartBuild(this, "StartDeployCodeBuild", {
+    // Phase 2.2 (Issue #459): AssumeRole metadata は 2 fields が両方あるときだけ
+    // CodeBuild env に渡す。Step Functions の optional path 直接参照は field 欠落時に
+    // States.Runtime で即死するため、Choice で cross-account / same-account を明示分岐する。
+    const startCodeBuildSameAccount = new CodeBuildStartBuild(this, "StartDeployCodeBuild", {
       project: props.codeBuildProject,
       integrationPattern: IntegrationPattern.RUN_JOB,
       environmentVariablesOverride: {
         BATTLE_PROBLEM_DIR: { value: JsonPath.stringAt("$.detail.problemDir") },
         TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
-        // Phase 2.2: AssumeRole metadata。verified=true 行のみ埋められるので、unverified 経路
-        // で State Machine が起動することは無い (= bulk-deploy / startDeployment が事前に gate)。
-        // `States.Format` を使って `null` 安全 (= 値が無いなら空文字)。
-        COMPETITOR_ROLE_ARN: {
-          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.competitorRoleArn")),
-        },
-        EXTERNAL_ID_SSM_PARAMETER: {
-          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.externalIdParameterName")),
-        },
         DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
         PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
       },
       resultPath: "$.codebuild",
     });
 
-    // CodeBuild 完了後に CFn から Outputs と StackId を取得。Outputs は
-    // `[{OutputKey, OutputValue, ...}]` の配列形で返るので、stackOutputs に JSON
-    // 文字列として格納し、portal 側 (cfn-status.ts) が array / object 両方を解釈する。
-    const describeStacks = new CallAwsService(this, "DescribeStack", {
-      service: "cloudformation",
-      action: "describeStacks",
-      parameters: { StackName: JsonPath.stringAt("$.detail.namePrefix") },
-      iamResources: [
-        Stack.of(this).formatArn({
-          service: "cloudformation",
-          resource: "stack",
-          resourceName: "*",
-        }),
-      ],
-      iamAction: "cloudformation:DescribeStacks",
+    const startCodeBuildCrossAccount = new CodeBuildStartBuild(
+      this,
+      "StartDeployCodeBuildCrossAccount",
+      {
+        project: props.codeBuildProject,
+        integrationPattern: IntegrationPattern.RUN_JOB,
+        environmentVariablesOverride: {
+          BATTLE_PROBLEM_DIR: { value: JsonPath.stringAt("$.detail.problemDir") },
+          TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
+          DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
+          PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+          COMPETITOR_ROLE_ARN: {
+            value: JsonPath.stringAt("$.detail.competitorRoleArn"),
+          },
+          EXTERNAL_ID_SSM_PARAMETER: {
+            value: JsonPath.stringAt("$.detail.externalIdParameterName"),
+          },
+        },
+        resultPath: "$.codebuild",
+      },
+    );
+
+    const invalidAssumeRoleMetadata = new Pass(this, "InvalidAssumeRoleMetadata", {
+      result: Result.fromObject({
+        Cause:
+          "competitorRoleArn and externalIdParameterName must be provided together for cross-account deploy",
+      }),
+      resultPath: "$.error",
+    });
+
+    const routeCreateInput = new Choice(this, "RouteCreateInput")
+      .when(
+        Condition.and(
+          Condition.isPresent("$.detail.competitorRoleArn"),
+          Condition.isPresent("$.detail.externalIdParameterName"),
+        ),
+        startCodeBuildCrossAccount,
+      )
+      .when(
+        Condition.and(
+          Condition.not(Condition.isPresent("$.detail.competitorRoleArn")),
+          Condition.not(Condition.isPresent("$.detail.externalIdParameterName")),
+        ),
+        startCodeBuildSameAccount,
+      )
+      .otherwise(invalidAssumeRoleMetadata);
+
+    // CodeBuild 完了後に CFn から Outputs と StackId を取得。verified deployment は
+    // competitor account への AssumeRole が必要なので DescribeStackLambda に state 全体を渡す。
+    // payloadResponseOnly=true により $.cfn は Lambda response (= DescribeStacks output)
+    // そのものになり、既存 MarkSucceeded の JSONPath 契約を維持する。
+    const describeStacks = new LambdaInvoke(this, "DescribeStack", {
+      lambdaFunction: props.describeStackFunction,
+      payload: TaskInput.fromJsonPathAt("$"),
+      payloadResponseOnly: true,
       resultPath: "$.cfn",
     });
 
@@ -163,13 +197,16 @@ export class DeployCreateStateMachine extends Construct {
     // buildId は StartDeployCodeBuild が正常 output を返した後だけ存在するため、pre-CodeBuild
     // 失敗では従来通り buildId 無しで FAILED を書く。
     markInProgress.addCatch(routeFailedDeployment, { resultPath: "$.error" });
-    startCodeBuild.addCatch(routeFailedDeployment, { resultPath: "$.error" });
+    startCodeBuildSameAccount.addCatch(routeFailedDeployment, { resultPath: "$.error" });
+    startCodeBuildCrossAccount.addCatch(routeFailedDeployment, { resultPath: "$.error" });
     describeStacks.addCatch(routeFailedDeployment, { resultPath: "$.error" });
+    describeStacks.next(routeDescribedStackStatus);
+    startCodeBuildSameAccount.next(describeStacks);
+    startCodeBuildCrossAccount.next(describeStacks);
+    invalidAssumeRoleMetadata.next(markFailedWithoutBuildId);
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
-      definitionBody: DefinitionBody.fromChainable(
-        markInProgress.next(startCodeBuild).next(describeStacks).next(routeDescribedStackStatus),
-      ),
+      definitionBody: DefinitionBody.fromChainable(markInProgress.next(routeCreateInput)),
       timeout: Duration.minutes(60),
       logs: { destination: logGroup, level: LogLevel.ALL },
       tracingEnabled: true,

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -3,10 +3,14 @@ import type { Project } from "aws-cdk-lib/aws-codebuild";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import {
+  Choice,
+  Condition,
   DefinitionBody,
   IntegrationPattern,
   JsonPath,
   LogLevel,
+  Pass,
+  Result,
   StateMachine,
 } from "aws-cdk-lib/aws-stepfunctions";
 import {
@@ -45,8 +49,9 @@ export interface DeployDeleteStateMachineProps {
  *     "awsAccountId": "123456789012"
  *   }
  *
- * MVP-1 は same-account のみ。Phase 2 で cross-account になったら CodeBuild Role に
- * `sts:AssumeRole` を足し、delete-battles.sh で AssumeRole する形に拡張する。
+ * verified deployment は `competitorRoleArn` / `externalIdParameterName` を CodeBuild に
+ * 渡し、delete-battles.sh が ExternalId 付き AssumeRole 後に target account の stack を消す。
+ * 旧 event detail は same-account fallback に倒す。
  */
 export class DeployDeleteStateMachine extends Construct {
   public readonly stateMachine: StateMachine;
@@ -58,32 +63,74 @@ export class DeployDeleteStateMachine extends Construct {
       retention: RetentionDays.ONE_WEEK,
     });
 
-    const startCodeBuild = new CodeBuildStartBuild(this, "StartDeleteCodeBuild", {
+    const startCodeBuildSameAccount = new CodeBuildStartBuild(this, "StartDeleteCodeBuild", {
       project: props.codeBuildProject,
       integrationPattern: IntegrationPattern.RUN_JOB,
       environmentVariablesOverride: {
         OPERATION: { value: "delete" },
         DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
         DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
-        // Phase 2.2 (Issue #459): cross-account delete でも AssumeRole metadata を渡す。
-        // detail に値が無いケース (旧 deployment 行) は `States.Format` で空文字に倒れる。
-        COMPETITOR_ROLE_ARN: {
-          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.competitorRoleArn")),
-        },
-        EXTERNAL_ID_SSM_PARAMETER: {
-          value: JsonPath.format("{}", JsonPath.stringAt("$.detail.externalIdParameterName")),
-        },
       },
       resultPath: "$.codebuild",
     });
 
+    const startCodeBuildCrossAccount = new CodeBuildStartBuild(
+      this,
+      "StartDeleteCodeBuildCrossAccount",
+      {
+        project: props.codeBuildProject,
+        integrationPattern: IntegrationPattern.RUN_JOB,
+        environmentVariablesOverride: {
+          OPERATION: { value: "delete" },
+          DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
+          DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+          COMPETITOR_ROLE_ARN: {
+            value: JsonPath.stringAt("$.detail.competitorRoleArn"),
+          },
+          EXTERNAL_ID_SSM_PARAMETER: {
+            value: JsonPath.stringAt("$.detail.externalIdParameterName"),
+          },
+        },
+        resultPath: "$.codebuild",
+      },
+    );
+
+    const invalidAssumeRoleMetadata = new Pass(this, "InvalidAssumeRoleMetadata", {
+      result: Result.fromObject({
+        Cause:
+          "competitorRoleArn and externalIdParameterName must be provided together for cross-account delete",
+      }),
+      resultPath: "$.error",
+    });
+
+    const routeDeleteInput = new Choice(this, "RouteDeleteInput")
+      .when(
+        Condition.and(
+          Condition.isPresent("$.detail.competitorRoleArn"),
+          Condition.isPresent("$.detail.externalIdParameterName"),
+        ),
+        startCodeBuildCrossAccount,
+      )
+      .when(
+        Condition.and(
+          Condition.not(Condition.isPresent("$.detail.competitorRoleArn")),
+          Condition.not(Condition.isPresent("$.detail.externalIdParameterName")),
+        ),
+        startCodeBuildSameAccount,
+      )
+      .otherwise(invalidAssumeRoleMetadata);
+
     const markDeleted = this.buildMarkDeleted(props.deploymentsTable);
     const markFailed = this.buildMarkFailed(props.deploymentsTable);
 
-    startCodeBuild.addCatch(markFailed, { resultPath: "$.error" });
+    startCodeBuildSameAccount.addCatch(markFailed, { resultPath: "$.error" });
+    startCodeBuildCrossAccount.addCatch(markFailed, { resultPath: "$.error" });
+    startCodeBuildSameAccount.next(markDeleted);
+    startCodeBuildCrossAccount.next(markDeleted);
+    invalidAssumeRoleMetadata.next(markFailed);
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
-      definitionBody: DefinitionBody.fromChainable(startCodeBuild.next(markDeleted)),
+      definitionBody: DefinitionBody.fromChainable(routeDeleteInput),
       timeout: Duration.minutes(60),
       logs: { destination: logGroup, level: LogLevel.ALL },
       tracingEnabled: true,

--- a/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
+++ b/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
@@ -1,0 +1,82 @@
+import * as path from "node:path";
+import { Duration, Stack } from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
+
+export interface DescribeStackLambdaProps {
+  readonly environmentName: string;
+}
+
+/**
+ * DeployCreate State Machine が CodeBuild 完了後に CFn StackId / Outputs を読むための
+ * Lambda。CloudFormation `DescribeStacks` は competitor account 側で実行する必要がある
+ * ため、verified deployment では ExternalId 付き AssumeRole を行う。
+ */
+export class DescribeStackLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: DescribeStackLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/describe-stack-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(30),
+      memorySize: 256,
+      environment: {
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: LAMBDA_NODEJS_BUNDLING_TARGET,
+        sourceMap: true,
+        externalModules: [],
+      },
+    });
+
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudformation:DescribeStacks"],
+        resources: ["*"],
+      }),
+    );
+
+    const stack = Stack.of(this);
+    const ssmArn = buildExternalIdParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: [ssmArn],
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: {
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": ssmArn },
+        },
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
+      }),
+    );
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -60,6 +60,8 @@ export interface DeploymentItem {
    * the first hop before assuming the per-problem ParticipantViewerRole.
    */
   competitorRoleArn?: string;
+  /** SSM SecureString path that stores the tenant ExternalId for cross-account operations. */
+  externalIdParameterName?: string;
   region: string;
   /**
    * 内部 slug。operator が deploy form で入力し、`namePrefix` (CFn StackName) の

--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -1,0 +1,152 @@
+import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import type { Credentials } from "@aws-sdk/client-sts";
+import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+
+export interface DescribeStackStateMachineInput {
+  readonly detail?: {
+    readonly jobId?: string;
+    readonly tenantId?: string;
+    readonly namePrefix?: string;
+    readonly region?: string;
+    readonly competitorRoleArn?: string;
+    readonly externalIdParameterName?: string;
+  };
+}
+
+export interface DescribeStackDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly sts: Pick<STSClient, "send">;
+  readonly cfnClient: (params: {
+    readonly region: string;
+    readonly credentials?: Credentials;
+  }) => Pick<CloudFormationClient, "send">;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`missing required field: ${field}`);
+  }
+  return value;
+}
+
+function assertCompleteCredentials(credentials: Credentials | undefined): Credentials {
+  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey || !credentials.SessionToken) {
+    throw new Error("AssumeRole returned incomplete credentials");
+  }
+  return credentials;
+}
+
+async function assumeCompetitorRole(
+  deps: DescribeStackDeps,
+  params: {
+    readonly region: string;
+    readonly jobId: string;
+    readonly competitorRoleArn?: string;
+    readonly externalIdParameterName?: string;
+  },
+): Promise<Credentials | undefined> {
+  const hasRole =
+    typeof params.competitorRoleArn === "string" && params.competitorRoleArn.length > 0;
+  const hasExternalId =
+    typeof params.externalIdParameterName === "string" && params.externalIdParameterName.length > 0;
+  if (!hasRole && !hasExternalId) return undefined;
+  if (!hasRole || !hasExternalId) {
+    throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
+  }
+
+  const externalIdOut = await deps.ssm.send(
+    new GetParameterCommand({
+      Name: params.externalIdParameterName,
+      WithDecryption: true,
+    }),
+  );
+  const externalId = externalIdOut.Parameter?.Value;
+  if (!externalId) {
+    throw new Error(`ExternalId not found in SSM SecureString: ${params.externalIdParameterName}`);
+  }
+
+  try {
+    return await assumeRoleWithExternalId(deps, params.competitorRoleArn, params.jobId, externalId);
+  } catch (currentErr) {
+    const previousVersion = Number(externalIdOut.Parameter?.Version ?? 0) - 1;
+    if (previousVersion <= 0) throw currentErr;
+    const previousExternalIdOut = await deps.ssm.send(
+      new GetParameterCommand({
+        Name: `${params.externalIdParameterName}:${previousVersion}`,
+        WithDecryption: true,
+      }),
+    );
+    const previousExternalId = previousExternalIdOut.Parameter?.Value;
+    if (!previousExternalId) throw currentErr;
+    const credentials = await assumeRoleWithExternalId(
+      deps,
+      params.competitorRoleArn,
+      params.jobId,
+      previousExternalId,
+    );
+    console.warn("[describe-stack] grace_fallback_used", {
+      jobId: params.jobId,
+      externalIdVersion: previousVersion,
+    });
+    return credentials;
+  }
+}
+
+async function assumeRoleWithExternalId(
+  deps: DescribeStackDeps,
+  roleArn: string,
+  jobId: string,
+  externalId: string,
+): Promise<Credentials> {
+  const assumeOut = await deps.sts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: `tenkacloud-describe-stack-${jobId.slice(0, 24)}`,
+      ExternalId: externalId,
+      DurationSeconds: 900,
+    }),
+  );
+  return assertCompleteCredentials(assumeOut.Credentials);
+}
+
+export async function describeStackForDeployment(
+  input: DescribeStackStateMachineInput,
+  deps: DescribeStackDeps,
+) {
+  const detail = input.detail ?? {};
+  const jobId = requireString(detail.jobId, "detail.jobId");
+  const stackName = requireString(detail.namePrefix, "detail.namePrefix");
+  const region = requireString(detail.region, "detail.region");
+  const credentials = await assumeCompetitorRole(deps, {
+    region,
+    jobId,
+    competitorRoleArn: detail.competitorRoleArn,
+    externalIdParameterName: detail.externalIdParameterName,
+  });
+  const cfn = deps.cfnClient({ region, credentials });
+  return cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+}
+
+const ssm = new SSMClient({});
+const sts = new STSClient({});
+
+export async function handler(input: DescribeStackStateMachineInput) {
+  return describeStackForDeployment(input, {
+    ssm,
+    sts,
+    cfnClient: ({ region, credentials }) =>
+      new CloudFormationClient({
+        region,
+        ...(credentials
+          ? {
+              credentials: {
+                accessKeyId: credentials.AccessKeyId ?? "",
+                secretAccessKey: credentials.SecretAccessKey ?? "",
+                sessionToken: credentials.SessionToken,
+              },
+            }
+          : {}),
+      }),
+  });
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -1,6 +1,7 @@
 import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentStatus } from "../deploy-handler/types.js";
+import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import {
   type DeployDeleteRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
@@ -104,6 +105,28 @@ export async function bulkTeardownEvent(
         region,
         awsAccountId,
       };
+      const rowHasAssumeRoleMetadata =
+        typeof item.competitorRoleArn === "string" &&
+        item.competitorRoleArn.length > 0 &&
+        typeof item.externalIdParameterName === "string" &&
+        item.externalIdParameterName.length > 0;
+      const verified = rowHasAssumeRoleMetadata
+        ? undefined
+        : await resolveVerifiedCompetitorAccount(
+            {
+              ddb: shared.ddb,
+              competitorAccountsTableName: shared.competitorAccountsTableName,
+              env: shared.env,
+            },
+            tenantId,
+            awsAccountId,
+          );
+      detail.competitorRoleArn = rowHasAssumeRoleMetadata
+        ? item.competitorRoleArn
+        : verified?.competitorRoleArn;
+      detail.externalIdParameterName = rowHasAssumeRoleMetadata
+        ? item.externalIdParameterName
+        : verified?.externalIdParameterName;
       return {
         entry: {
           EventBusName: shared.eventBusName,

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -13,6 +13,7 @@ import { DeployCreateStateMachine } from "./deploy-create-state-machine";
 import { DeployDeleteStateMachine } from "./deploy-delete-state-machine";
 import { DeployDeleteEventRule, DeployEventRule } from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
+import { DescribeStackLambda } from "./describe-stack-lambda";
 import { EventApiLambda } from "./event-api-lambda";
 import { EventsTable } from "./events-table";
 import { ExternalIdAuditLambda } from "./external-id-audit-lambda";
@@ -240,8 +241,13 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     });
     this.deployCodeBuildProjectName = codeBuild.project.projectName;
 
+    const describeStack = new DescribeStackLambda(this, "DescribeStack", {
+      environmentName: props.environmentName,
+    });
+
     const stateMachine = new DeployCreateStateMachine(this, "DeployCreate", {
       codeBuildProject: codeBuild.project,
+      describeStackFunction: describeStack.fn,
       deploymentsTable: deployments.table,
     });
     this.deployCreateStateMachineArn = stateMachine.stateMachine.stateMachineArn;

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -200,6 +200,38 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("MarkFailed");
     });
 
+    it("Create State Machine は DescribeStacks を Lambda 経由で実行すべき (#762)", () => {
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const createStateMachine = Object.values(stateMachines)
+        .map((stateMachine) => JSON.stringify(stateMachine))
+        .find((definition) => definition.includes("StartDeployCodeBuild"));
+
+      expect(createStateMachine).toBeDefined();
+      expect(createStateMachine).toContain("RouteCreateInput");
+      expect(createStateMachine).toContain("StartDeployCodeBuildCrossAccount");
+      expect(createStateMachine).toContain("DescribeStack");
+      expect(createStateMachine).toContain("DescribeStackFunction");
+      expect(createStateMachine).not.toContain(
+        "arn:aws:states:::aws-sdk:cloudformation:describeStacks",
+      );
+      expect(createStateMachine).not.toContain("States.Format('{}', $.detail.competitorRoleArn)");
+    });
+
+    it("Delete State Machine は AssumeRole metadata の有無を Choice で分岐し、欠落 path 参照で runtime 死しないべき (#758)", () => {
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const deleteStateMachine = Object.values(stateMachines)
+        .map((stateMachine) => JSON.stringify(stateMachine))
+        .find((definition) => definition.includes("StartDeleteCodeBuild"));
+
+      expect(deleteStateMachine).toBeDefined();
+      expect(deleteStateMachine).toContain("RouteDeleteInput");
+      expect(deleteStateMachine).toContain("StartDeleteCodeBuildCrossAccount");
+      expect(deleteStateMachine).toContain("InvalidAssumeRoleMetadata");
+      expect(deleteStateMachine).toContain("$.detail.competitorRoleArn");
+      expect(deleteStateMachine).toContain("$.detail.externalIdParameterName");
+      expect(deleteStateMachine).toContain("MarkFailed");
+    });
+
     it("EventBridge Rule を Create / Delete / GenericScoring / ExternalIdAudit schedule で 4 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)

--- a/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
+++ b/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
@@ -1,0 +1,145 @@
+import type { DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { describe, expect, it, vi } from "vitest";
+import { describeStackForDeployment } from "../../lib/problem-deploy/handlers/describe-stack-handler";
+
+const input = {
+  detail: {
+    jobId: "01KRK6BATCE8QZHX663MQFX4E3",
+    tenantId: "tenant-acme",
+    namePrefix: "tc-microservice-migration-battle-team-1",
+    region: "ap-northeast-1",
+  },
+};
+
+function deps(options: { externalId?: string } = {}) {
+  const ssmSend = vi.fn(async () => ({
+    Parameter: { Value: options.externalId ?? "external", Version: 3 },
+  }));
+  const stsSend = vi.fn(async () => ({
+    Credentials: {
+      AccessKeyId: "AKIA",
+      SecretAccessKey: "secret",
+      SessionToken: "token",
+    },
+  }));
+  const cfnSend = vi.fn(async () => ({
+    Stacks: [
+      {
+        StackId:
+          "arn:aws:cloudformation:ap-northeast-1:449699636068:stack/tc-microservice-migration-battle-team-1/uuid",
+        StackStatus: "CREATE_COMPLETE",
+        Outputs: [{ OutputKey: "ParticipantViewerRoleArn", OutputValue: "arn:aws:iam::x:role/y" }],
+      },
+    ],
+  }));
+  const cfnClient = vi.fn(() => ({ send: cfnSend }));
+  return {
+    deps: {
+      ssm: { send: ssmSend },
+      sts: { send: stsSend },
+      cfnClient,
+    },
+    ssmSend,
+    stsSend,
+    cfnSend,
+    cfnClient,
+  };
+}
+
+describe("describeStackForDeployment", () => {
+  it("competitorRoleArn がある場合は ExternalId 付き AssumeRole 後に DescribeStacks すべき", async () => {
+    const { deps: d, ssmSend, stsSend, cfnSend, cfnClient } = deps();
+
+    const out = await describeStackForDeployment(
+      {
+        detail: {
+          ...input.detail,
+          competitorRoleArn: "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+          externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+        },
+      },
+      d,
+    );
+
+    expect(out.Stacks?.[0]?.StackStatus).toBe("CREATE_COMPLETE");
+    expect(ssmSend.mock.calls[0]?.[0]).toBeInstanceOf(GetParameterCommand);
+    expect(stsSend.mock.calls[0]?.[0]).toBeInstanceOf(AssumeRoleCommand);
+    const assume = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    expect(assume.input.ExternalId).toBe("external");
+    expect(assume.input.RoleArn).toBe(
+      "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(cfnClient).toHaveBeenCalledWith({
+      region: "ap-northeast-1",
+      credentials: {
+        AccessKeyId: "AKIA",
+        SecretAccessKey: "secret",
+        SessionToken: "token",
+      },
+    });
+    const describeCmd = cfnSend.mock.calls[0]?.[0] as DescribeStacksCommand;
+    expect(describeCmd.input.StackName).toBe("tc-microservice-migration-battle-team-1");
+  });
+
+  it("AssumeRole metadata が無い旧 event は same-account DescribeStacks に倒すべき", async () => {
+    const { deps: d, ssmSend, stsSend, cfnClient } = deps();
+
+    await describeStackForDeployment(input, d);
+
+    expect(ssmSend).not.toHaveBeenCalled();
+    expect(stsSend).not.toHaveBeenCalled();
+    expect(cfnClient).toHaveBeenCalledWith({
+      region: "ap-northeast-1",
+      credentials: undefined,
+    });
+  });
+
+  it("AssumeRole metadata が片方だけなら構成エラーにすべき", async () => {
+    const { deps: d } = deps();
+
+    await expect(
+      describeStackForDeployment(
+        {
+          detail: {
+            ...input.detail,
+            competitorRoleArn: "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+          },
+        },
+        d,
+      ),
+    ).rejects.toThrow("competitorRoleArn and externalIdParameterName must be provided together");
+  });
+
+  it("current ExternalId で AssumeRole が失敗したら 1 世代前で再試行すべき", async () => {
+    const { deps: d, ssmSend, stsSend } = deps();
+    ssmSend
+      .mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } })
+      .mockResolvedValueOnce({ Parameter: { Value: "previous", Version: 2 } });
+    stsSend.mockRejectedValueOnce(new Error("AccessDenied")).mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIA2",
+        SecretAccessKey: "secret2",
+        SessionToken: "token2",
+      },
+    });
+
+    await describeStackForDeployment(
+      {
+        detail: {
+          ...input.detail,
+          competitorRoleArn: "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+          externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+        },
+      },
+      d,
+    );
+
+    expect(ssmSend).toHaveBeenCalledTimes(2);
+    const previousGet = ssmSend.mock.calls[1]?.[0] as GetParameterCommand;
+    expect(previousGet.input.Name).toBe("/development/tenants/tenant-acme/external-id:2");
+    const retryAssume = stsSend.mock.calls[1]?.[0] as AssumeRoleCommand;
+    expect(retryAssume.input.ExternalId).toBe("previous");
+  });
+});

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -17,7 +17,9 @@ function buildShared(): {
     eventsTableName: "TestEvents",
     teamsTableName: "TestTeams",
     deploymentsTableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
     eventBusName: "test-bus",
+    env: "development",
     ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
     events: { send: eventsSend } as unknown as EventSharedResources["events"],
     problemsCatalog: {},
@@ -39,6 +41,8 @@ const dep = (over: Record<string, unknown> = {}) => ({
   tenantId: "tenant-acme",
   problemId: "p",
   awsAccountId: "999999999999",
+  competitorRoleArn: "arn:aws:iam::999999999999:role/TenkaCloud-CompetitorDeploy-Role",
+  externalIdParameterName: "/development/tenants/tenant-acme/external-id",
   region: "ap-northeast-1",
   namePrefix: "tc-p-team-1",
   status: "COMPLETE",
@@ -138,6 +142,34 @@ describe("bulkTeardownEvent", () => {
       expect(out.result.enqueued).toBe(1);
       expect(out.result.skipped).toBe(2);
     }
+  });
+
+  it("DeployDeleteRequested detail に AssumeRole metadata を含めるべき (#758)", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        dep({
+          jobId: "01A",
+          competitorRoleArn: "arn:aws:iam::999999999999:role/TenkaCloud-CompetitorDeploy-Role",
+          externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+        }),
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
+
+    const putCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    const detail = JSON.parse(String(putCmd.input.Entries?.[0]?.Detail)) as {
+      competitorRoleArn?: string;
+      externalIdParameterName?: string;
+    };
+    expect(detail.competitorRoleArn).toBe(
+      "arn:aws:iam::999999999999:role/TenkaCloud-CompetitorDeploy-Role",
+    );
+    expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
 
   it("event は存在するが deployment 0 件 (まだ deploy してない) なら enqueued=0 を返すべき", async () => {


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

Cross-account problem deploy が成功したあと、platform account ではなく competitor account 側の CloudFormation stack を読んで deployment を COMPLETE にでき、Event delete / teardown も competitor account 側の stack delete に進めるようになります。

## なぜ今これが要るか

Cross-account deploy の CodeBuild は成功しているのに、State Machine の DescribeStacks が platform account で実行されるため deployment が FAILED になる false negative が起きています。Delete 側も AssumeRole metadata 欠落時に State Machine が `States.Runtime` で即死し、DDB が DELETING に固着します。どちらも実リソース漏れと競技者 UI の誤表示につながる P0 障害です。

## 関連 Issue

- Closes #762
- Closes #758
- Closes #735

## 変更前 → 変更後のフロー

```mermaid
flowchart LR
    A[DeployCreateRequested] --> B[CodeBuild deploy succeeds]
    B --> C_before[Before: SFN DescribeStacks in platform account]
    C_before --> D_before[FAILED false negative]
    B --> C_after[After: DescribeStack Lambda assumes competitor role]
    C_after --> D_after[MarkSucceeded with StackId and Outputs]

    E[DeployDeleteRequested] --> F_after[RouteDeleteInput Choice]
    F_after --> G_after[Cross-account CodeBuild delete with AssumeRole metadata]
    F_after --> H_after[Same-account fallback for legacy events]
    G_after --> I_after[MarkDeleted or MarkFailed]
    H_after --> I_after
```

## 物理影響

### AWS リソース (`make deploy`)

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| `tenkacloud-problem-deploy` | `DescribeStack` Lambda | CREATE | DeployCreate State Machine が CodeBuild 後の CFn DescribeStacks を委譲する Lambda を追加 |
| `tenkacloud-problem-deploy` | `DeployCreate` State Machine | UPDATE in-place | CodeBuild 起動を cross-account / same-account Choice に分岐し、DescribeStack Lambda を呼ぶ |
| `tenkacloud-problem-deploy` | `DeployDelete` State Machine | UPDATE in-place | AssumeRole metadata の有無を Choice で分岐し、欠損 path 参照による `States.Runtime` を防ぐ |
| `tenkacloud-problem-deploy` | IAM policies for DescribeStack Lambda | UPDATE in-place | CFn DescribeStacks, SSM ExternalId read, KMS decrypt, `TenkaCloud-*` AssumeRole を追加 |

### ビルド成果物 (`make build`)

| パッケージ | 変更 |
|---|---|
| `@TenkaCloud/infrastructure` | Problem deploy backend の Lambda bundle / Step Functions definition が更新 |
| `apps/*` | `make build` 実行により dist 生成のみ。アプリソース変更なし |

## ファイルごとの変更意図

- `infrastructure/lib/problem-deploy/describe-stack-lambda.ts` — cross-account DescribeStacks 用 Lambda の CDK construct と最小権限を追加
- `infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts` — ExternalId 付き AssumeRole 後に competitor account の CFn stack を読む処理を追加
- `infrastructure/lib/problem-deploy/deploy-create-state-machine.ts` — platform-account DescribeStacks を廃止し、CodeBuild 後に DescribeStack Lambda を呼ぶ
- `infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts` — delete 入力を Choice で検証し、optional JsonPath 欠落による runtime failure を防ぐ
- `infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts` — Bulk teardown の DeployDeleteRequested detail に AssumeRole metadata を含める
- `infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts` — deployment row に保存済みの `externalIdParameterName` を型に明示
- `infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts` — DescribeStack Lambda を stack に配線
- `infrastructure/test/problem-deploy/describe-stack-handler.test.ts` — cross-account describe / legacy fallback / metadata validation / ExternalId grace fallback を検証
- `infrastructure/test/problem-deploy-backend-stack.test.ts` — State Machine が Lambda 経由 describe と Choice 分岐になっていることを検証
- `infrastructure/test/problem-deploy/event-bulk-delete.test.ts` — Delete event に AssumeRole metadata が入ることを検証

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 / 対処 |
|---|---|---|---|---|
| 1 | same-account / legacy event detail で deploy/delete が動かなくなる | dev fallback / 旧 event | ✅ 確認済み | Create/Delete State Machine に same-account branch を残し、handler test で metadata 無し describe fallback を確認 |
| 2 | ExternalId rotate 直後に CodeBuild は成功するが DescribeStack Lambda が失敗する | cross-account deploy | ✅ 確認済み | DescribeStack handler に current failure → previous version retry を追加し、unit test で検証 |
| 3 | Delete event に片方だけ AssumeRole metadata があると DELETING 固着する | teardown | ✅ 確認済み | Delete State Machine は invalid branch で MarkFailed に倒す。CDK test で branch を pin |
| 4 | Bulk teardown が competitor account を削除できない | Event delete / #735 | ✅ 確認済み | deployment row / CompetitorAccounts lookup から `competitorRoleArn` と `externalIdParameterName` を event detail に詰める test を追加 |
| 5 | IAM が広がりすぎる | security | ✅ 確認済み | SSM は env/tenant prefix pattern、KMS は SSM encryption context、STS は `arn:aws:iam::*:role/TenkaCloud-*` に制限 |

## Rollback 手順

1. `git revert <merge-sha>` → 新 PR で main に戻す
2. `make deploy` で `tenkacloud-problem-deploy` の CFT 差分を適用
3. 既に COMPLETE / DELETED に遷移した deployment row はそのまま残る。rollback 後に再発した FAILED / DELETING 固着行は operator が再 deploy / teardown するか DDB 補正が必要

## テスト戦略

- 既存テストでカバーされる観点 — Deployments/EventBridge/DDB status update、CodeBuild project IAM、既存 app / portal regressions
- この PR で追加したテスト — `infrastructure/test/problem-deploy/describe-stack-handler.test.ts` で cross-account DescribeStacks と ExternalId fallback、`problem-deploy-backend-stack.test.ts` で ASL の Lambda/Choice 配線、`event-bulk-delete.test.ts` で Delete event metadata を検証
- 未カバー (受容する理由) — 実 AWS 上の competitor account Stack delete 実行は merge 後の deploy 環境で確認する

## Verification

### Merge 前 (DRAFT 解除条件)

- [x] `make test` (via `make before-commit`)
- [x] `make typecheck` (via `make before-commit`)
- [x] `make lint` (via `make before-commit`)
- [ ] `make harness` — blocked: `.claude/harness/bin/architecture.ts` が checkout に無く起動前に失敗
- [x] `make synth` (対象 stack 全部; sandbox 外で通過)
- [x] Regression 分析の未確認がゼロ
- [x] merge で動くようになる機能を 1 文で書けている

### Merge 後 (deploy 後 signal)

- [ ] `make deploy` 成功
- [ ] Cross-account deploy 成功後、deployment row が `COMPLETE` になり `stackId` / `stackOutputs` が competitor account の stack 由来で保存される
- [ ] Event delete 後、DeployDelete State Machine が `StartDeleteCodeBuildCrossAccount` を通り、deployment row が `DELETED` または失敗時 `FAILED` へ遷移する
- [ ] 既存 DELETING 固着行があれば、再 teardown または operator 補正方針を確認する

## 既知の未完了 (scope 外)

- 既に本番 DDB に残っている `DELETING` / false `FAILED` 行の一括補正 — この PR は再発防止。既存データ cleanup は deploy 後の観測結果に合わせて別途実施
- `make harness` の実行環境修復 — `.claude/harness/bin/architecture.ts` が checkout に無いため別対応