### PR TITLE
fix: expose stack progress route

### DIFF
--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -87,6 +87,9 @@ export class ApiGateway extends Construct {
     const deployment = deployments.addResource("{jobId}");
     deployment.addMethod("GET", deployIntegration, deployMethodOptions);
     deployment.addMethod("DELETE", deployIntegration, deployMethodOptions);
+    deployment
+      .addResource("stack-progress")
+      .addMethod("GET", deployIntegration, deployMethodOptions);
 
     // ADR-004 Phase 1+2a/2b: /events — 1 競技イベント = 1 行で teams + problems を持つ
     // /events                          POST  = create   / GET = list

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -9,9 +9,9 @@ import { LAMBDA_NODEJS_RUNTIME } from "../../lib/utils/lambda-runtime";
 
 /**
  * tenant API Gateway の resource / method shape を pin する。サイドバー「デプロイ履歴」が引く
- * `GET /deployments` (no path param) を含む全 5 route が、Lambda 内 Hono router と整合
- * していることを担保する (= PR #467 で Lambda には追加したが Gateway resource を入れ忘れて
- * 403 + CORS error になった regression を防ぐ)。
+ * `GET /deployments` (no path param) や `GET /deployments/{jobId}/stack-progress` を含む
+ * deploy route が、Lambda 内 Hono router と整合していることを担保する (= PR #467 で Lambda
+ * には追加したが Gateway resource を入れ忘れて 403 + CORS error になった regression を防ぐ)。
  */
 
 function buildHarness() {
@@ -101,6 +101,23 @@ describe("tenant ApiGateway", () => {
     tpl.hasResourceProperties("AWS::ApiGateway::Method", {
       HttpMethod: "DELETE",
       ResourceId: { Ref: jobIdResource },
+    });
+  });
+
+  it("/deployments/{jobId}/stack-progress に GET / OPTIONS method が紐づいているべき", () => {
+    const stackProgressResource = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { PathPart: "stack-progress" },
+      }),
+    )[0]?.[0];
+    expect(stackProgressResource).toBeDefined();
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "GET",
+      ResourceId: { Ref: stackProgressResource },
+    });
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "OPTIONS",
+      ResourceId: { Ref: stackProgressResource },
     });
   });
 


### PR DESCRIPTION
## この PR merge 後に何が動くようになるか

Application Admin Console の Deploy log が `/deployments/{jobId}/stack-progress` を polling できるようになり、Building / CloudFormation progress が CORS エラーで止まらず更新されます。

## なぜ今これが要るか

Deploy handler には `GET /deployments/:jobId/stack-progress` が実装済みでしたが、tenant REST API Gateway 側に `/deployments/{jobId}/stack-progress` route が無く、preflight が API Gateway レベルで落ちて Lambda の CORS middleware まで届いていませんでした。結果として deploy status polling が `Failed to fetch` になり、管理者が deploy の進行状況を確認できない状態でした。

## 関連 Issue

- Closes #755

## 変更前 → 変更後のフロー

```mermaid
flowchart LR
    A[Application Admin Console] --> B[GET /deployments/jobId/stack-progress]
    B --> C_before[Before: API Gateway route missing]
    C_before --> D_before[OPTIONS/GET fail before Lambda CORS]
    B --> C_after[After: Tenant REST API stack-progress resource]
    C_after --> D_after[DeployApi Lambda Hono route]
    D_after --> E[Stack progress JSON with CORS headers]
```

## 物理影響

### AWS リソース (`make deploy`)

| Stack | Resource | 種別 | 影響 |
|---|---|---|---|
| Tenant application plane stack | `AWS::ApiGateway::Resource` `/deployments/{jobId}/stack-progress` | CREATE | stack-progress endpoint の API Gateway resource を追加 |
| Tenant application plane stack | `AWS::ApiGateway::Method` GET / OPTIONS | CREATE | GET を DeployApi Lambda integration に接続し、CORS preflight を生成 |

### ビルド成果物 (`make build`)

| パッケージ | 変更 |
|---|---|
| `@TenkaCloud/infrastructure` | Tenant API Gateway の CloudFormation template が更新 |
| `apps/*` | 変更なし |

## ファイルごとの変更意図

- `infrastructure/lib/tenant-template/api-gateway.ts` — Lambda に存在する stack-progress route を tenant REST API Gateway に公開する
- `infrastructure/test/tenant-template/api-gateway.test.ts` — GET / OPTIONS method が生成されることを pin して同種の CORS regression を防ぐ

## Regression 分析

| # | 壊れうる既存挙動 | 影響範囲 | 確認状態 | 確認方法 / 対処 |
|---|---|---|---|---|
| 1 | `/deployments/{jobId}` の GET / DELETE 配線が変わる | Deploy detail / teardown | ✅ 確認済み | 既存 test で GET / DELETE method を pin したまま通過 |
| 2 | API Gateway CORS preflight が stack-progress で生成されない | Deploy status polling | ✅ 確認済み | 新規 test で `stack-progress` resource の GET / OPTIONS method を確認 |
| 3 | DeployApi Lambda の Hono route と Gateway route が不整合になる | stack-progress response | ✅ 確認済み | `deploy-handler-routes.test.ts` と `api-gateway.test.ts` を同時実行 |

## Rollback 手順

1. `git revert <merge-sha>` → 新 PR で main に戻す
2. `make deploy` で tenant application plane stack の API Gateway 差分を適用
3. rollback 後は `/deployments/{jobId}/stack-progress` が再び Gateway に存在しなくなるため、Deploy log polling は CORS/404 系で止まる

## テスト戦略

- 既存テストでカバーされる観点 — DeployApi Lambda の Hono `stack-progress` route と `/deployments/{jobId}` GET/DELETE の Gateway 配線
- この PR で追加したテスト — `infrastructure/test/tenant-template/api-gateway.test.ts` で `/deployments/{jobId}/stack-progress` の GET / OPTIONS method 生成を検証
- 未カバー (受容する理由) — 実 CloudFront origin からの browser preflight は merge 後 deploy 環境で確認する

## Verification

### Merge 前 (DRAFT 解除条件)

- [x] `make test` (via `make before-commit`)
- [x] `make typecheck`
- [x] `make lint` (via `make before-commit`)
- [ ] `make harness` — blocked: `.claude/harness/bin/architecture.ts` が checkout に無く起動前に失敗
- [x] `make synth` (via `make before-commit`)
- [x] Regression 分析の未確認がゼロ
- [x] merge で動くようになる機能を 1 文で書けている

### Merge 後 (deploy 後 signal)

- [ ] `make deploy` 成功
- [ ] Application Admin Console の Deploy detail で `GET /deployments/{jobId}/stack-progress` の preflight が 200 になり、Deploy log が更新される
- [ ] browser console に stack-progress の CORS error が出ない

## 既知の未完了 (scope 外)

- 既に開いている browser session の cache / 古い runtime-config 起因の失敗 — deploy 後に hard refresh で確認
- `make harness` の実行環境修復 — `.claude/harness/bin/architecture.ts` が checkout に無いため別対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New endpoint added to retrieve stack progress information for deployment jobs, enabling real-time monitoring of deployment operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/765)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->