### PR TITLE
fix: paginate deployment reconciliation queries

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
@@ -49,6 +49,41 @@ export interface ReconcileEventStatusesContext {
   readonly deploymentsTableName: string;
 }
 
+async function queryDeploymentStatusesForEvent(
+  ctx: ReconcileEventStatusesContext,
+  event: { tenantId: string; eventId: string },
+): Promise<string[]> {
+  const statuses: string[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+
+  do {
+    const depsOut = await ctx.ddb.send(
+      new QueryCommand({
+        TableName: ctx.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        FilterExpression: "eventId = :ev",
+        ProjectionExpression: "#status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${event.tenantId}`,
+          ":ev": event.eventId,
+        },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    statuses.push(
+      ...(depsOut.Items ?? [])
+        .map((d) => String((d as { status?: string }).status ?? ""))
+        .filter((s) => s.length > 0),
+    );
+    exclusiveStartKey = depsOut.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+
+  return statuses;
+}
+
 /**
  * Events table を scan して `DEPLOYING` / `TEARDOWN` 状態の Event について、
  * 子 deployment 集約 status を見て `READY` / `ARCHIVED` に遷移させる (#557 #539)。
@@ -89,24 +124,11 @@ export async function reconcileEventStatuses(
     await Promise.all(
       items.map(async (event) => {
         if (!event.tenantId || !event.eventId || !event.status || !event.PK) return;
-        // 子 deployments を GSI1 (TENANT#) で query → 同 event のものに in-memory filter。
-        const depsOut = await ctx.ddb.send(
-          new QueryCommand({
-            TableName: ctx.deploymentsTableName,
-            IndexName: "GSI1",
-            KeyConditionExpression: "GSI1PK = :pk",
-            FilterExpression: "eventId = :ev",
-            ProjectionExpression: "#status",
-            ExpressionAttributeNames: { "#status": "status" },
-            ExpressionAttributeValues: {
-              ":pk": `TENANT#${event.tenantId}`,
-              ":ev": event.eventId,
-            },
-          }),
-        );
-        const depStatuses = (depsOut.Items ?? [])
-          .map((d) => String((d as { status?: string }).status ?? ""))
-          .filter((s) => s.length > 0);
+        // 子 deployments を GSI1 (TENANT#) で query → eventId filter 後の全 page を集約。
+        const depStatuses = await queryDeploymentStatusesForEvent(ctx, {
+          tenantId: event.tenantId,
+          eventId: event.eventId,
+        });
         const next = resolveEventStatusTransition(event.status, depStatuses);
         if (!next) return;
 

--- a/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
@@ -187,6 +187,77 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(scan2.input.ExclusiveStartKey).toEqual({ PK: "cursor" });
   });
 
+  it("Deployment Query が pagination するべき (= Filter 後の空 page を越えて READY 判定する)", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "EVENT#EV-PAGED",
+          tenantId: "tenant-acme",
+          eventId: "EV-PAGED",
+          status: "DEPLOYING",
+        },
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [],
+      LastEvaluatedKey: { GSI1PK: "TENANT#tenant-acme", GSI1SK: "cursor" },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "COMPLETE" }, { status: "COMPLETE" }],
+    });
+    ddbSend.mockResolvedValueOnce({});
+
+    await reconcileEventStatuses(ctx, NOW_ISO);
+
+    expect(ddbSend).toHaveBeenCalledTimes(4);
+    const query1 = ddbSend.mock.calls[1]?.[0] as {
+      input: { ExclusiveStartKey?: Record<string, unknown> };
+    };
+    const query2 = ddbSend.mock.calls[2]?.[0] as {
+      input: { ExclusiveStartKey?: Record<string, unknown> };
+    };
+    const updateCmd = ddbSend.mock.calls[3]?.[0] as {
+      input: { ExpressionAttributeValues: Record<string, string> };
+    };
+    expect(query1.input.ExclusiveStartKey).toBeUndefined();
+    expect(query2.input.ExclusiveStartKey).toEqual({
+      GSI1PK: "TENANT#tenant-acme",
+      GSI1SK: "cursor",
+    });
+    expect(updateCmd.input.ExpressionAttributeValues[":next"]).toBe("READY");
+  });
+
+  it("Deployment Query の後続 page に非 terminal があれば READY にしないべき", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "EVENT#EV-PENDING",
+          tenantId: "tenant-acme",
+          eventId: "EV-PENDING",
+          status: "DEPLOYING",
+        },
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "COMPLETE" }],
+      LastEvaluatedKey: { GSI1PK: "TENANT#tenant-acme", GSI1SK: "cursor" },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ status: "PENDING" }],
+    });
+
+    await reconcileEventStatuses(ctx, NOW_ISO);
+
+    expect(ddbSend).toHaveBeenCalledTimes(3);
+    const query2 = ddbSend.mock.calls[2]?.[0] as {
+      input: { ExclusiveStartKey?: Record<string, unknown> };
+    };
+    expect(query2.input.ExclusiveStartKey).toEqual({
+      GSI1PK: "TENANT#tenant-acme",
+      GSI1SK: "cursor",
+    });
+  });
+
   it("Event filter は DEPLOYING または TEARDOWN のみであるべき (= READY / ENDED は触らない)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
     await reconcileEventStatuses(ctx, NOW_ISO);


### PR DESCRIPTION
## Summary
- Paginate deployment status queries in the event reconciler until `LastEvaluatedKey` is exhausted.
- Prevent DEPLOYING events from staying stuck when the first filtered DynamoDB Query page is empty.
- Add regression coverage for both delayed READY transition and premature READY prevention across query pages.

Closes #739

## Test plan
- `bun run --filter @TenkaCloud/infrastructure test -- generic-scoring-reconciler.test.ts`
- `bun run --filter @TenkaCloud/infrastructure typecheck`
- `make harness`
- `make before-commit`