### PR TITLE
chore: clear before-commit warnings

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findProblemMetadata, resolveLocalizedNarrative } from "./problems";
+import {
+  findProblemMetadata,
+  type ProblemCatalogEntry,
+  resolveLocalizedNarrative,
+} from "./problems";
 
 /**
  * #550: Portal の build-time catalog が `problems/<category>/<id>/metadata.json` を
@@ -9,6 +13,14 @@ import { findProblemMetadata, resolveLocalizedNarrative } from "./problems";
  * 既存 3 問 (hello-world / hello-world-battle / security-battle-royale) を pin する。
  * 新 problem 追加で test を更新する運用 (= CLAUDE.md の TDD タイトル「〜すべき」に沿う)。
  */
+
+function requireProblemMetadata(problemId: string): ProblemCatalogEntry {
+  const metadata = findProblemMetadata(problemId);
+  expect(metadata).toBeDefined();
+  if (!metadata) throw new Error(`problem metadata not found: ${problemId}`);
+  return metadata;
+}
+
 describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   it("hello-world (Challenge sample) が引けて narrative field を含むべき", () => {
     const m = findProblemMetadata("hello-world");
@@ -101,23 +113,23 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   // Issue #583 Phase 5: i18n override の locale fallback chain。
   describe("resolveLocalizedNarrative (Phase 5)", () => {
     it("locale='ja' なら top-level の値をそのまま返すべき", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "ja");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "ja");
       expect(r.name).toBe("Hello World (Sample)");
       expect(r.description).toContain("Challenge / flag 提出形式");
     });
 
     it("locale='en' の override が宣言されていれば英語を返すべき (hello-world)", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "en");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Minimal Challenge/);
       expect(r.description).toMatch(/Deploying creates a single SSM Parameter/);
       expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
     });
 
     it("locale='zh' の override が宣言されていれば中文を返すべき (hello-world)", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "zh");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "zh");
       expect(r.name).toContain("示例");
     });
 
@@ -137,14 +149,14 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     });
 
     it("security-battle-royale の locale='en' で英語翻訳を返すべき", () => {
-      const m = findProblemMetadata("security-battle-royale");
-      const r = resolveLocalizedNarrative(m!, "en");
+      const m = requireProblemMetadata("security-battle-royale");
+      const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Attack\/defend/);
     });
 
     it("locale='es' で security-battle-royale もスペイン語翻訳を返すべき", () => {
-      const m = findProblemMetadata("security-battle-royale");
-      const r = resolveLocalizedNarrative(m!, "es");
+      const m = requireProblemMetadata("security-battle-royale");
+      const r = resolveLocalizedNarrative(m, "es");
       expect(r.shortDescription).toMatch(/Ataca\/defiende/);
     });
   });

--- a/infrastructure/test/admin-insight/pipeline-executions.test.ts
+++ b/infrastructure/test/admin-insight/pipeline-executions.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildExecutionConsoleUrl,
+  type ListPipelineExecutionsDeps,
   listPipelineExecutions,
   summarizeExecution,
 } from "../../lib/admin-insight/handlers/admin-insight-handler/pipeline-executions";
+
+function buildDeps(send: ReturnType<typeof vi.fn>, region: string): ListPipelineExecutionsDeps {
+  return {
+    client: {
+      send: send as unknown as ListPipelineExecutionsDeps["client"]["send"],
+    },
+    region,
+  };
+}
 
 describe("buildExecutionConsoleUrl", () => {
   it("CodePipeline console の timeline deep link を組み立てるべき", () => {
@@ -64,10 +74,7 @@ describe("listPipelineExecutions", () => {
         },
       ],
     });
-    const out = await listPipelineExecutions(
-      { client: { send } as any, region: "ap-northeast-1" },
-      { limit: 10 },
-    );
+    const out = await listPipelineExecutions(buildDeps(send, "ap-northeast-1"), { limit: 10 });
     expect(send).toHaveBeenCalledTimes(1);
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { pipelineName: string; maxResults?: number };
@@ -80,7 +87,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit 未指定なら default=50 で呼ぶべき", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"));
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -89,7 +96,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit を 100 で頭打ち (= MAX_LIMIT)", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" }, { limit: 999 });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"), { limit: 999 });
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -98,7 +105,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit < 1 でも最低 1 で呼ぶべき (= defensive)", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" }, { limit: 0 });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"), { limit: 0 });
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -113,10 +120,7 @@ describe("listPipelineExecutions", () => {
         { pipelineExecutionId: "e2", status: "Running" },
       ],
     });
-    const out = await listPipelineExecutions({
-      client: { send } as any,
-      region: "ap-northeast-1",
-    });
+    const out = await listPipelineExecutions(buildDeps(send, "ap-northeast-1"));
     expect(out.items).toHaveLength(2);
     expect(out.items.map((i) => i.executionId)).toEqual(["e1", "e2"]);
   });

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -23,7 +23,7 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
 
   it("Phase 3 で CDK_PARAM_ADMIN_CONSOLE_ORIGIN を再 export してから再 deploy すべき", () => {
     const exportIdx = source.indexOf(
-      'export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"',
+      `export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="\${ADMIN_CONSOLE_URL}"`,
     );
     const deployIdx = source.indexOf(
       "bunx cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight",

--- a/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { TenantStatusReconciler } from "../../lib/tenant-status-reconciler/tenant-status-reconciler";
 
 function synth() {


### PR DESCRIPTION
## Summary
- Remove Biome warnings from existing tests without changing production behavior.
- Replace non-null assertions and test-only `any` casts with typed helpers.
- Clean up the template placeholder string and an unused import.

## Test plan
- `bun run lint:format`
- `bun run --filter @TenkaCloud/participant-portal test -- problems.test.ts`
- `bun run --filter @TenkaCloud/infrastructure test -- admin-insight/pipeline-executions.test.ts install-script.test.ts tenant-status-reconciler/tenant-status-reconciler.test.ts`
- `make harness`
- `make before-commit`