### PR TITLE
fix: validate scheduled event end time

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -119,6 +119,39 @@ const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
   ARCHIVED: "grey",
 };
 
+interface EndsAtValidation {
+  readonly canSubmit: boolean;
+  readonly errorText?: string;
+  readonly value?: Date;
+}
+
+function validateEndsAtInput(
+  date: string,
+  time: string,
+  startsAt: string | undefined,
+  nowMs: number,
+): EndsAtValidation {
+  if (!date || !time) return { canSubmit: false };
+  const value = new Date(`${date}T${time}:00`);
+  if (Number.isNaN(value.getTime())) {
+    return { canSubmit: false, errorText: "終了日時の形式が不正です" };
+  }
+  if (value.getTime() < nowMs - 60_000) {
+    return {
+      canSubmit: false,
+      errorText:
+        "過去の日時は指定できません。今すぐ終了するには「Event を終了」 button を使ってください。",
+    };
+  }
+  if (startsAt) {
+    const startsAtMs = new Date(startsAt).getTime();
+    if (Number.isFinite(startsAtMs) && value.getTime() <= startsAtMs) {
+      return { canSubmit: false, errorText: "終了時刻は開始時刻より後の時刻を指定してください。" };
+    }
+  }
+  return { canSubmit: true, value };
+}
+
 export function EventDetailPage({ config }: { config: AppConfig }) {
   const { eventId } = useParams<{ eventId: string }>();
   const navigate = useNavigate();
@@ -258,34 +291,15 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   // こちらは status は触らず HealthCheck の gate で時刻 gate するだけ (operator の負担減)。
   const handleScheduleEnd = async () => {
     if (!apiClient || endsAtInFlight) return;
-    if (!endsAtDate || !endsAtTime) {
-      setError("終了の日付と時刻の両方を指定してください");
+    const validation = validateEndsAtInput(endsAtDate, endsAtTime, detail?.startsAt, Date.now());
+    if (!validation.canSubmit || !validation.value) {
+      setError(validation.errorText ?? "終了の日付と時刻の両方を指定してください");
       return;
-    }
-    const local = new Date(`${endsAtDate}T${endsAtTime}:00`);
-    if (Number.isNaN(local.getTime())) {
-      setError("終了日時の形式が不正です");
-      return;
-    }
-    // #536 frontend 防御線: 過去 endsAt を弾く (= SLACK 60s で backend と揃える)
-    if (local.getTime() < Date.now() - 60_000) {
-      setError(
-        "過去の日時は指定できません。今すぐ終了するには「Event を終了」 button を使ってください。",
-      );
-      return;
-    }
-    // #536 frontend 防御線: endsAt が startsAt 以前なら弾く (= 競技時間 0 / 負を防ぐ)
-    if (detail?.startsAt) {
-      const startsAtMs = new Date(detail.startsAt).getTime();
-      if (Number.isFinite(startsAtMs) && local.getTime() <= startsAtMs) {
-        setError("終了時刻は開始時刻より後の時刻を指定してください。");
-        return;
-      }
     }
     setEndsAtInFlight(true);
     setError(null);
     try {
-      await setEventSchedule(apiClient, eventId, { endsAt: local.toISOString() });
+      await setEventSchedule(apiClient, eventId, { endsAt: validation.value.toISOString() });
       setEndsAtModalOpen(false);
       setEndsAtDate("");
       setEndsAtTime("");
@@ -413,6 +427,13 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
         0,
       )
     : 0;
+  const endsAtValidation = validateEndsAtInput(
+    endsAtDate,
+    endsAtTime,
+    detail?.startsAt,
+    Date.now(),
+  );
+  const endsAtInvalid = endsAtValidation.errorText !== undefined;
 
   return (
     <SpaceBetween size="l">
@@ -1019,7 +1040,12 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={() => setEndsAtModalOpen(false)}>キャンセル</Button>
-              <Button variant="primary" loading={endsAtInFlight} onClick={handleScheduleEnd}>
+              <Button
+                variant="primary"
+                loading={endsAtInFlight}
+                disabled={!endsAtValidation.canSubmit || endsAtInFlight}
+                onClick={handleScheduleEnd}
+              >
                 設定
               </Button>
             </SpaceBetween>
@@ -1034,23 +1060,24 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           </Box>
           {detail?.startsAt && (
             <Box variant="small" color="text-status-inactive">
-              開始時刻: <code>{detail.startsAt}</code> —
-              終了時刻はこれより後の時刻を指定してください。
+              開始時刻: <code>{detail.startsAt}</code>
             </Box>
           )}
-          <FormField label="日付 (YYYY-MM-DD)">
+          <FormField label="日付 (YYYY-MM-DD)" errorText={endsAtValidation.errorText}>
             <DatePicker
               value={endsAtDate}
               onChange={(e) => setEndsAtDate(e.detail.value)}
               placeholder="YYYY/MM/DD"
+              invalid={endsAtInvalid}
             />
           </FormField>
-          <FormField label="時刻 (HH:mm)">
+          <FormField label="時刻 (HH:mm)" errorText={endsAtValidation.errorText}>
             <TimeInput
               value={endsAtTime}
               format="hh:mm"
               placeholder="hh:mm"
               onChange={(e) => setEndsAtTime(e.detail.value)}
+              invalid={endsAtInvalid}
             />
           </FormField>
         </SpaceBetween>

--- a/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+  setEventSchedule: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return {
+    ...actual,
+    getEvent: mocks.getEvent,
+    setEventSchedule: mocks.setEventSchedule,
+  };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const STARTS_AT = "2026-05-14T10:00:00.000Z";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Schedule Validation Event",
+  status: "READY",
+  teamCount: 1,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  startsAt: STARTS_AT,
+  teams: [{ teamId: "t1", internalSlug: "team-alpha" }],
+  problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {},
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function localDateTimeParts(iso: string): { date: string; time: string } {
+  const d = new Date(iso);
+  const yyyy = String(d.getFullYear());
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return { date: `${yyyy}-${mm}-${dd}`, time: `${hh}:${min}` };
+}
+
+async function openEndsAtModal() {
+  renderPage();
+  await waitFor(() =>
+    expect(screen.getAllByText(/Schedule Validation Event/).length).toBeGreaterThan(0),
+  );
+  await userEvent.click(screen.getByRole("button", { name: "日時を指定して終了" }));
+  return screen.getByRole("dialog", { name: "競技終了日時を指定 (予約)" });
+}
+
+async function fillEndsAt(dialog: HTMLElement, iso: string) {
+  const { date, time } = localDateTimeParts(iso);
+  await userEvent.type(within(dialog).getByPlaceholderText("YYYY/MM/DD"), date);
+  await userEvent.type(within(dialog).getByPlaceholderText("hh:mm"), time);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(new Date("2026-05-14T00:00:00.000Z").getTime());
+  mocks.useApiClient.mockReturnValue({});
+  mocks.getEvent.mockResolvedValue(baseDetail);
+  mocks.setEventSchedule.mockResolvedValue({ endsAt: "2026-05-14T11:00:00.000Z" });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventDetailPage #741 終了予約 validation", () => {
+  it("開始時刻以前の終了日時なら errorText を出して 設定 button を disabled にすべき", async () => {
+    const dialog = await openEndsAtModal();
+    await fillEndsAt(dialog, "2026-05-14T09:00:00.000Z");
+
+    expect(
+      await within(dialog).findAllByText("終了時刻は開始時刻より後の時刻を指定してください。"),
+    ).toHaveLength(2);
+    const submit = within(dialog).getByRole("button", { name: "設定" });
+    expect(submit).toBeDisabled();
+    expect(mocks.setEventSchedule).not.toHaveBeenCalled();
+  });
+
+  it("開始時刻より後の終了日時なら 設定 button を有効化して schedule API を呼ぶべき", async () => {
+    const dialog = await openEndsAtModal();
+    await fillEndsAt(dialog, "2026-05-14T11:00:00.000Z");
+
+    const submit = within(dialog).getByRole("button", { name: "設定" });
+    expect(submit).not.toBeDisabled();
+    await userEvent.click(submit);
+
+    await waitFor(() => expect(mocks.setEventSchedule).toHaveBeenCalled());
+    expect(mocks.setEventSchedule).toHaveBeenCalledWith(expect.anything(), EVENT_ID, {
+      endsAt: new Date("2026-05-14T11:00:00.000Z").toISOString(),
+    });
+  });
+});

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/schedule.ts
@@ -1,4 +1,4 @@
-import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { type EventSharedResources, queryDeploymentsByEvent } from "./shared.js";
 import type { EventItem } from "./types.js";
@@ -57,7 +57,7 @@ const SCHEDULE_SLACK_MS = 60_000;
  * caller (handler/index.ts) は zod validate 済を前提。validation:
  *   - past_starts_at: startsAt < now - SLACK
  *   - past_ends_at:   endsAt   < now - SLACK
- *   - ends_before_starts: 両方指定時、endsAt <= startsAt
+ *   - ends_before_starts: effective endsAt <= effective startsAt
  *
  * tenant 跨ぎ参照防止: Event 行の tenantId が引数 `tenantId` と一致しない場合は `not_found`。
  */
@@ -96,6 +96,30 @@ export async function setEventSchedule(
     const endsAtMs = new Date(endsAt).getTime();
     if (Number.isFinite(startsAtMs) && Number.isFinite(endsAtMs) && endsAtMs <= startsAtMs) {
       return { kind: "ends_before_starts", startsAt, endsAt };
+    }
+  }
+
+  const currentOut = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+      ProjectionExpression: "tenantId, startsAt, endsAt",
+    }),
+  );
+  const currentEvent = currentOut.Item as Pick<EventItem, "tenantId" | "startsAt" | "endsAt">;
+  if (!currentEvent || currentEvent.tenantId !== tenantId) return { kind: "not_found" };
+
+  const effectiveStartsAt = startsAt ?? currentEvent.startsAt;
+  const effectiveEndsAt = endsAt ?? currentEvent.endsAt;
+  if (effectiveStartsAt !== undefined && effectiveEndsAt !== undefined) {
+    const startsAtMs = new Date(effectiveStartsAt).getTime();
+    const endsAtMs = new Date(effectiveEndsAt).getTime();
+    if (Number.isFinite(startsAtMs) && Number.isFinite(endsAtMs) && endsAtMs <= startsAtMs) {
+      return {
+        kind: "ends_before_starts",
+        startsAt: effectiveStartsAt,
+        endsAt: effectiveEndsAt,
+      };
     }
   }
 

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -1,4 +1,4 @@
-import { type QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, type QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setEventSchedule } from "../../lib/problem-deploy/handlers/event-handler/schedule";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
@@ -26,11 +26,19 @@ function buildShared(): {
   return { shared, ddbSend };
 }
 
+function mockCurrentEvent(
+  ddbSend: ReturnType<typeof vi.fn>,
+  item: { tenantId?: string; startsAt?: string; endsAt?: string } = { tenantId: "tenant-acme" },
+) {
+  ddbSend.mockResolvedValueOnce({ Item: item });
+}
+
 describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("正常系: Event 行 + 紐づく全 deployment 行の eventStartsAt を更新するべき", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
@@ -54,7 +62,10 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
       updatedDeployments: 3,
     });
 
-    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    const eventGet = ddbSend.mock.calls[0]?.[0] as GetCommand;
+    expect(eventGet).toBeInstanceOf(GetCommand);
+
+    const eventUpd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(eventUpd).toBeInstanceOf(UpdateCommand);
     expect(eventUpd.input.ConditionExpression).toBe("tenantId = :tenantId");
     expect(eventUpd.input.ExpressionAttributeValues?.[":tenantId"]).toBe("tenant-acme");
@@ -62,14 +73,14 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
     // endsAt 未指定なので update 対象に含まれない
     expect(eventUpd.input.ExpressionAttributeValues?.[":endsAt"]).toBeUndefined();
 
-    const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    const queryCmd = ddbSend.mock.calls[2]?.[0] as QueryCommand;
     expect(queryCmd.input.IndexName).toBe("GSI1");
     expect(queryCmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
     expect(queryCmd.input.FilterExpression).toBe("eventId = :ev");
 
     const updCmds = ddbSend.mock.calls
       .map((c) => c[0])
-      .filter((c, i): c is UpdateCommand => i > 0 && c instanceof UpdateCommand);
+      .filter((c, i): c is UpdateCommand => i > 1 && c instanceof UpdateCommand);
     expect(updCmds).toHaveLength(3);
     for (const cmd of updCmds) {
       expect(cmd.input.ExpressionAttributeValues?.[":s"]).toBe(STARTS_AT);
@@ -79,9 +90,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
 
   it("Event 行不在 / tenant 不一致は ConditionalCheckFailedException → not_found", async () => {
     const { shared, ddbSend } = buildShared();
-    const err = new Error("conditional failed");
-    err.name = "ConditionalCheckFailedException";
-    ddbSend.mockRejectedValueOnce(err);
+    ddbSend.mockResolvedValueOnce({});
 
     const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
       startsAt: STARTS_AT,
@@ -93,6 +102,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
 
   it("対象 deployment が 0 件でも ok を返し updatedDeployments=0", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
@@ -119,6 +129,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
 
   it("startsAt が now - 30s (SLACK 内) なら通すべき (#537 clock skew)", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: NOW_ISO },
     });
@@ -133,6 +144,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
 
   it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", startsAt: STARTS_AT },
     });
@@ -140,8 +152,8 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
     ddbSend.mockResolvedValue({});
 
     await setEventSchedule(shared, "tenant-acme", "EV1", { startsAt: STARTS_AT, nowMs: NOW_MS });
-    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
-    const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
+    const eventUpd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    const deployUpd = ddbSend.mock.calls[3]?.[0] as UpdateCommand;
     expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
     expect(deployUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
   });
@@ -152,6 +164,7 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
 
   it("endsAt のみ指定 → Event の endsAt + deployments の eventEndsAt を更新、startsAt は触らない", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend, { tenantId: "tenant-acme", startsAt: STARTS_AT });
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", endsAt: ENDS_AT },
     });
@@ -168,17 +181,18 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
       expect(out.endsAt).toBe(ENDS_AT);
     }
 
-    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    const eventUpd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(eventUpd.input.ExpressionAttributeValues?.[":endsAt"]).toBe(ENDS_AT);
     expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBeUndefined();
 
-    const deployUpd = ddbSend.mock.calls[2]?.[0] as UpdateCommand;
+    const deployUpd = ddbSend.mock.calls[3]?.[0] as UpdateCommand;
     expect(deployUpd.input.ExpressionAttributeValues?.[":e"]).toBe(ENDS_AT);
     expect(deployUpd.input.ExpressionAttributeValues?.[":s"]).toBeUndefined();
   });
 
   it("startsAt + endsAt 両方指定 → 1 回の UpdateCommand で両方更新するべき", async () => {
     const { shared, ddbSend } = buildShared();
+    mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
       Attributes: {
         eventId: "EV1",
@@ -197,7 +211,7 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
     });
     expect(out.kind).toBe("ok");
 
-    const eventUpd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    const eventUpd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
     expect(eventUpd.input.UpdateExpression).toContain("startsAt = :startsAt");
     expect(eventUpd.input.UpdateExpression).toContain("endsAt = :endsAt");
     expect(eventUpd.input.ExpressionAttributeValues?.[":startsAt"]).toBe(STARTS_AT);
@@ -230,6 +244,25 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
       endsAt: earlierEnd,
     });
     expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("endsAt のみ指定でも既存 startsAt 以前なら ends_before_starts で reject すべき (#741)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const laterStart = "2026-05-08T13:00:00.000Z";
+    mockCurrentEvent(ddbSend, { tenantId: "tenant-acme", startsAt: laterStart });
+
+    const out = await setEventSchedule(shared, "tenant-acme", "EV1", {
+      endsAt: ENDS_AT,
+      nowMs: NOW_MS,
+    });
+
+    expect(out).toEqual({
+      kind: "ends_before_starts",
+      startsAt: laterStart,
+      endsAt: ENDS_AT,
+    });
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
   });
 
   it("endsAt === startsAt も ends_before_starts (= 競技時間 0 分は無効)", async () => {


### PR DESCRIPTION
## Summary
- Disable the EventDetail scheduled-end submit button until a complete, valid end date/time is entered.
- Show Cloudscape field errors when the selected end time is in the past or not after `startsAt`.
- Enforce `effective endsAt > effective startsAt` in the backend when only one side is being updated.

Closes #741

## Test plan
- `bun run --filter @TenkaCloud/application-admin-console test -- EventDetail.ends-at-validation.test.tsx`
- `bun run --filter @TenkaCloud/infrastructure test -- event-schedule.test.ts`
- `bun run --filter @TenkaCloud/application-admin-console typecheck`
- `bun run --filter @TenkaCloud/infrastructure typecheck`
- `make harness`
- `make before-commit` (passes; existing Biome warnings are fixed separately in PR #772)