### PR TITLE
fix: add immediate schedule end action

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -297,6 +297,20 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     }
   };
 
+  const handleEndNowSchedule = async () => {
+    if (!apiClient || endsAtInFlight) return;
+    setEndsAtInFlight(true);
+    setError(null);
+    try {
+      await setEventSchedule(apiClient, eventId, { endsAt: new Date(Date.now()).toISOString() });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEndsAtInFlight(false);
+    }
+  };
+
   // #558: 採点を lock (= 表彰フェーズ、加点経路全停止)。
   //   - server side: READY / ENDED の event のみ受理 (= 409 not_lockable for other)
   //   - idempotent: 既に locked のときも 200 + idempotent=true
@@ -615,7 +629,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           header={
             <Header
               variant="h2"
-              description="開始時刻を指定すると HealthCheck が probe / 採点を開始、終了時刻を指定すると自動で gate を閉めます (= operator が「Event を終了」を押し忘れても採点が垂れ流しにならない、#536)。"
+              description="開始時刻を指定すると HealthCheck が probe / 採点を開始、終了時刻を指定すると status は変えずに採点 gate を閉じます。"
             >
               競技スケジュール
             </Header>
@@ -661,12 +675,21 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
                     未設定 (= 手動「Event を終了」まで採点継続)
                   </Box>
                 )}
-                <Button
-                  onClick={() => setEndsAtModalOpen(true)}
-                  disabled={!apiClient || endsAtInFlight}
-                >
-                  日時を指定して終了
-                </Button>
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button
+                    onClick={() => setEndsAtModalOpen(true)}
+                    disabled={!apiClient || endsAtInFlight}
+                  >
+                    日時を指定して終了
+                  </Button>
+                  <Button
+                    loading={endsAtInFlight}
+                    disabled={!apiClient}
+                    onClick={handleEndNowSchedule}
+                  >
+                    即座に終了
+                  </Button>
+                </SpaceBetween>
               </SpaceBetween>
             </Field>
           </ColumnLayout>

--- a/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+  setEventSchedule: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return {
+    ...actual,
+    useApiClient: mocks.useApiClient,
+  };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return {
+    ...actual,
+    getEvent: mocks.getEvent,
+    setEventSchedule: mocks.setEventSchedule,
+  };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const NOW_ISO = "2026-05-14T12:00:00.000Z";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Schedule Action Event",
+  status: "READY",
+  teamCount: 1,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  teams: [{ teamId: "t1", internalSlug: "team-alpha" }],
+  problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {},
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+      <Routes>
+        <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(new Date(NOW_ISO).getTime());
+  mocks.useApiClient.mockReturnValue({});
+  mocks.getEvent.mockResolvedValue(baseDetail);
+  mocks.setEventSchedule.mockResolvedValue({ endsAt: NOW_ISO });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("EventDetailPage #740 競技スケジュール終了操作", () => {
+  it("即座に終了 button で endsAt=now の schedule API を呼ぶべき", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Schedule Action Event/).length).toBeGreaterThan(0),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "即座に終了" }));
+
+    await waitFor(() => expect(mocks.setEventSchedule).toHaveBeenCalled());
+    expect(mocks.setEventSchedule).toHaveBeenCalledWith(expect.anything(), EVENT_ID, {
+      endsAt: NOW_ISO,
+    });
+  });
+
+  it("競技スケジュール section の説明に内部 issue 番号を表示しないべき", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Schedule Action Event/).length).toBeGreaterThan(0),
+    );
+
+    expect(screen.queryByText(/#\d{3,}/)).not.toBeInTheDocument();
+    expect(screen.getByText(/status は変えずに採点 gate を閉じます/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add an `即座に終了` action to the EventDetail schedule section.
- Call the existing schedule API with `endsAt = now` so scoring stops without changing Event status.
- Remove the internal issue number from the schedule section description and add a regression test.

Closes #740

## Test plan
- `bun run --filter @TenkaCloud/application-admin-console test -- EventDetail.end-now-schedule.test.tsx`
- `bun run --filter @TenkaCloud/application-admin-console typecheck`
- `rg "#[0-9]{3,}" apps/application-admin-console/src/pages apps/application-admin-console/src/components -g '*.tsx' | rg -v "//|/\\*|\\*"`
- `make harness`
- `make before-commit` (passes; existing Biome warnings are fixed separately in PR #772)