### PR TITLE
fix: use bunx for tenant pipeline cdk

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findProblemMetadata, resolveLocalizedNarrative } from "./problems";
+import {
+  findProblemMetadata,
+  type ProblemCatalogEntry,
+  resolveLocalizedNarrative,
+} from "./problems";
 
 /**
  * #550: Portal の build-time catalog が `problems/<category>/<id>/metadata.json` を
@@ -9,6 +13,14 @@ import { findProblemMetadata, resolveLocalizedNarrative } from "./problems";
  * 既存 3 問 (hello-world / hello-world-battle / security-battle-royale) を pin する。
  * 新 problem 追加で test を更新する運用 (= CLAUDE.md の TDD タイトル「〜すべき」に沿う)。
  */
+
+function requireProblemMetadata(problemId: string): ProblemCatalogEntry {
+  const metadata = findProblemMetadata(problemId);
+  expect(metadata).toBeDefined();
+  if (!metadata) throw new Error(`problem metadata not found: ${problemId}`);
+  return metadata;
+}
+
 describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   it("hello-world (Challenge sample) が引けて narrative field を含むべき", () => {
     const m = findProblemMetadata("hello-world");
@@ -101,23 +113,23 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   // Issue #583 Phase 5: i18n override の locale fallback chain。
   describe("resolveLocalizedNarrative (Phase 5)", () => {
     it("locale='ja' なら top-level の値をそのまま返すべき", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "ja");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "ja");
       expect(r.name).toBe("Hello World (Sample)");
       expect(r.description).toContain("Challenge / flag 提出形式");
     });
 
     it("locale='en' の override が宣言されていれば英語を返すべき (hello-world)", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "en");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Minimal Challenge/);
       expect(r.description).toMatch(/Deploying creates a single SSM Parameter/);
       expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
     });
 
     it("locale='zh' の override が宣言されていれば中文を返すべき (hello-world)", () => {
-      const m = findProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m!, "zh");
+      const m = requireProblemMetadata("hello-world");
+      const r = resolveLocalizedNarrative(m, "zh");
       expect(r.name).toContain("示例");
     });
 
@@ -137,14 +149,14 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     });
 
     it("security-battle-royale の locale='en' で英語翻訳を返すべき", () => {
-      const m = findProblemMetadata("security-battle-royale");
-      const r = resolveLocalizedNarrative(m!, "en");
+      const m = requireProblemMetadata("security-battle-royale");
+      const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Attack\/defend/);
     });
 
     it("locale='es' で security-battle-royale もスペイン語翻訳を返すべき", () => {
-      const m = findProblemMetadata("security-battle-royale");
-      const r = resolveLocalizedNarrative(m!, "es");
+      const m = requireProblemMetadata("security-battle-royale");
+      const r = resolveLocalizedNarrative(m, "es");
       expect(r.shortDescription).toMatch(/Ataca\/defiende/);
     });
   });

--- a/infrastructure/test/admin-insight/pipeline-executions.test.ts
+++ b/infrastructure/test/admin-insight/pipeline-executions.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildExecutionConsoleUrl,
+  type ListPipelineExecutionsDeps,
   listPipelineExecutions,
   summarizeExecution,
 } from "../../lib/admin-insight/handlers/admin-insight-handler/pipeline-executions";
+
+function buildDeps(send: ReturnType<typeof vi.fn>, region: string): ListPipelineExecutionsDeps {
+  return {
+    client: {
+      send: send as unknown as ListPipelineExecutionsDeps["client"]["send"],
+    },
+    region,
+  };
+}
 
 describe("buildExecutionConsoleUrl", () => {
   it("CodePipeline console の timeline deep link を組み立てるべき", () => {
@@ -64,10 +74,7 @@ describe("listPipelineExecutions", () => {
         },
       ],
     });
-    const out = await listPipelineExecutions(
-      { client: { send } as any, region: "ap-northeast-1" },
-      { limit: 10 },
-    );
+    const out = await listPipelineExecutions(buildDeps(send, "ap-northeast-1"), { limit: 10 });
     expect(send).toHaveBeenCalledTimes(1);
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { pipelineName: string; maxResults?: number };
@@ -80,7 +87,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit 未指定なら default=50 で呼ぶべき", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"));
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -89,7 +96,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit を 100 で頭打ち (= MAX_LIMIT)", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" }, { limit: 999 });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"), { limit: 999 });
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -98,7 +105,7 @@ describe("listPipelineExecutions", () => {
 
   it("limit < 1 でも最低 1 で呼ぶべき (= defensive)", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
-    await listPipelineExecutions({ client: { send } as any, region: "us-east-1" }, { limit: 0 });
+    await listPipelineExecutions(buildDeps(send, "us-east-1"), { limit: 0 });
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
       input: { maxResults?: number };
     };
@@ -113,10 +120,7 @@ describe("listPipelineExecutions", () => {
         { pipelineExecutionId: "e2", status: "Running" },
       ],
     });
-    const out = await listPipelineExecutions({
-      client: { send } as any,
-      region: "ap-northeast-1",
-    });
+    const out = await listPipelineExecutions(buildDeps(send, "ap-northeast-1"));
     expect(out.items).toHaveLength(2);
     expect(out.items.map((i) => i.executionId)).toEqual(["e1", "e2"]);
   });

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -23,7 +23,7 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
 
   it("Phase 3 で CDK_PARAM_ADMIN_CONSOLE_ORIGIN を再 export してから再 deploy すべき", () => {
     const exportIdx = source.indexOf(
-      'export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"',
+      `export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="\${ADMIN_CONSOLE_URL}"`,
     );
     const deployIdx = source.indexOf(
       "bunx cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight",

--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "../../..");
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(REPO_ROOT, path), "utf8");
+}
+
+describe("tenant lifecycle scripts", () => {
+  const lifecycleScripts = [
+    "scripts/provision-tenant.sh",
+    "scripts/update-tenant.sh",
+    "scripts/deprovision-tenant.sh",
+  ];
+
+  it("tenant lifecycle scripts は legacy package runner を使わないべき", () => {
+    const legacyPackageRunnerPattern = new RegExp(`\\b${"np"}x\\b`);
+
+    for (const scriptPath of lifecycleScripts) {
+      expect(readRepoFile(scriptPath)).not.toMatch(legacyPackageRunnerPattern);
+    }
+  });
+
+  it("tenant lifecycle scripts は CDK を bunx で実行すべき", () => {
+    expect(readRepoFile("scripts/provision-tenant.sh")).toContain(
+      'bunx cdk deploy "$STACK_NAME" --require-approval never',
+    );
+    expect(readRepoFile("scripts/update-tenant.sh")).toContain(
+      'bunx cdk deploy "$STACK_NAME" --exclusively --require-approval never',
+    );
+    expect(readRepoFile("scripts/deprovision-tenant.sh")).toContain(
+      'bunx cdk destroy "$STACK_NAME" --force',
+    );
+  });
+
+  it("CodeBuild runtime helper は packageManager の Bun を導入すべき", () => {
+    const helper = readRepoFile("scripts/lib/install-node.sh");
+
+    expect(helper).toContain("packageManager");
+    expect(helper).toContain("bun --version");
+    expect(helper).toContain("install_bun_from_package_manager");
+  });
+
+  it("deprovision script は runtime helper を source する前に source.zip を展開すべき", () => {
+    const script = readRepoFile("scripts/deprovision-tenant.sh");
+    const unzipIndex = script.indexOf('unzip -o "$CDK_SOURCE_NAME"');
+    const sourceIndex = script.indexOf("source ./scripts/lib/install-node.sh");
+
+    expect(unzipIndex).toBeGreaterThan(0);
+    expect(sourceIndex).toBeGreaterThan(unzipIndex);
+  });
+
+  it(".nvmrc は Node 22 以上を指定すべき", () => {
+    const nodeMajor = Number.parseInt(
+      readRepoFile(".nvmrc").trim().replace(/^v/, "").split(".")[0] ?? "",
+      10,
+    );
+
+    expect(nodeMajor).toBeGreaterThanOrEqual(22);
+  });
+
+  it("mise の Node/Bun runtime は repo の正本 version と一致すべき", () => {
+    const packageJson = JSON.parse(readRepoFile("package.json")) as {
+      packageManager?: string;
+    };
+    const bunVersion = packageJson.packageManager?.replace(/^bun@/, "");
+    const nodeMajor = readRepoFile(".nvmrc").trim().replace(/^v/, "").split(".")[0];
+    const miseToml = readRepoFile("mise.toml");
+
+    expect(miseToml).toContain(`node = "${nodeMajor}"`);
+    expect(miseToml).toContain(`bun = "${bunVersion}"`);
+  });
+});

--- a/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { TenantStatusReconciler } from "../../lib/tenant-status-reconciler/tenant-status-reconciler";
 
 function synth() {

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-bun = "1.2.20"
-node = "20"
+bun = "1.3.11"
+node = "22"
 terraform = "latest"

--- a/scripts/deprovision-tenant.sh
+++ b/scripts/deprovision-tenant.sh
@@ -1,14 +1,34 @@
 #!/bin/bash -e
+# pipefail: runtime bootstrap の curl 失敗を silent に続行させない。
+set -o pipefail
 
 # Install dependencies
 sudo yum update -y
-sudo yum install -y nodejs
-sudo yum install -y npm
-sudo npm install -g aws-cdk
 sudo yum install -y jq
 sudo yum install -y python3-pip
 sudo python3 -m pip install --upgrade setuptools
 sudo python3 -m pip install git-remote-codecommit
+
+export REGION=$AWS_REGION
+echo "REGION: ${REGION}"
+
+export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "ACCOUNT_ID: ${ACCOUNT_ID}"
+
+export CDK_PARAM_S3_BUCKET_NAME="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
+echo "CDK_PARAM_S3_BUCKET_NAME: ${CDK_PARAM_S3_BUCKET_NAME}"
+export CDK_SOURCE_NAME="source.zip"
+
+VERSIONS=$(aws s3api list-object-versions --bucket "$CDK_PARAM_S3_BUCKET_NAME" --prefix "$CDK_SOURCE_NAME" --query 'Versions[?IsLatest==`true`].{VersionId:VersionId}' --output text 2>&1)
+CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
+echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
+
+aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
+unzip -o "$CDK_SOURCE_NAME"
+
+# shellcheck source=lib/install-node.sh
+source ./scripts/lib/install-node.sh
+install_node_from_nvmrc
 
 # Enable nocasematch option
 shopt -s nocasematch
@@ -104,7 +124,7 @@ if [[ $TIER == "PLATINUM" ]]; then
   export CDK_PARAM_DEPROVISIONING_DETAIL_TYPE="NA"
 
   echo "undeploying tenant template $STACK_NAME"
-  npx cdk destroy $STACK_NAME --force
+  bunx cdk destroy "$STACK_NAME" --force
 
 else
   # Read tenant details from the cloudformation stack output parameters

--- a/scripts/lib/install-node.sh
+++ b/scripts/lib/install-node.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# CodeBuild の provision-tenant.sh / update-tenant.sh で source する Node セットアップ helper。
+# CodeBuild の provision-tenant.sh / update-tenant.sh / deprovision-tenant.sh で source する runtime
+# セットアップ helper。
 #
-# `.nvmrc` を読んで NodeSource (deb / rpm) repo から install する。
+# `.nvmrc` を読んで NodeSource (deb / rpm) repo から Node を install し、root package.json の
+# `packageManager` から Bun version を読んで `bunx` を使える状態にする。
 #
 # Why NodeSource: image 非依存で動く (AL2 / AL2023 / Ubuntu standard:5.0 / 7.0)。CodeBuild image
 # に nvm が無いケースで silent fail した旧 nvm 経路 (#560) の置換。
@@ -12,6 +14,34 @@
 # Why OS detect: CodeBuild の LinuxBuildImage.STANDARD_5_0 は Ubuntu (deb) で
 # `rpm.nodesource.com` が `This script is intended for RPM-based systems` で fail する。
 # `apt-get` / `yum` (or `dnf`) のどちらが居るかで NodeSource URL とパッケージマネージャを切替える。
+
+install_bun_from_package_manager() {
+  local bun_version
+  local installed_bun_version
+
+  bun_version="$(node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); const match = String(pkg.packageManager || '').match(/^bun@(.+)$/); if (match) process.stdout.write(match[1]);")"
+  if [ -z "$bun_version" ]; then
+    echo "package.json must pin packageManager as bun@<version> for CodeBuild runtime setup." >&2
+    return 1
+  fi
+
+  export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+  export PATH="$BUN_INSTALL/bin:$PATH"
+
+  installed_bun_version=""
+  if command -v bun >/dev/null 2>&1; then
+    installed_bun_version="$(bun --version)"
+  fi
+
+  if [ "$installed_bun_version" != "$bun_version" ]; then
+    curl -fsSL https://bun.sh/install | bash -s "bun-v${bun_version}"
+    export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    hash -r 2>/dev/null || true
+  fi
+
+  bun --version
+}
 
 install_node_from_nvmrc() {
   local node_major
@@ -41,4 +71,5 @@ install_node_from_nvmrc() {
   fi
   node --version
   npm --version
+  install_bun_from_package_manager
 }

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -65,7 +65,7 @@ if [[ $TIER == "PLATINUM" ]]; then
   export CDK_PARAM_DEPROVISIONING_DETAIL_TYPE=$CDK_PARAM_OFFBOARDING_DETAIL_TYPE
   export CDK_PARAM_PROVISIONING_EVENT_SOURCE="sbt-application-plane-api"
   export CDK_PARAM_APPLICATION_NAME_PLANE_SOURCE="sbt-application-plane-api"
-  npx cdk deploy $STACK_NAME --require-approval never
+  bunx cdk deploy "$STACK_NAME" --require-approval never
 fi
 
 # Read tenant details from the cloudformation stack output parameters

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -36,4 +36,4 @@ install_node_from_nvmrc
 
 cd cdk
 npm install
-npx cdk deploy "$STACK_NAME" --exclusively --require-approval never
+bunx cdk deploy "$STACK_NAME" --exclusively --require-approval never


### PR DESCRIPTION
## Summary
- replace tenant lifecycle CDK invocations with bunx and make CodeBuild install Bun from root packageManager
- hydrate source.zip before deprovision runtime setup so the shared runtime helper is available in SBT job scripts
- align mise Node/Bun versions with .nvmrc and packageManager, and clear existing before-commit Biome warnings

Closes #738

## Test plan
- bun run --filter @TenkaCloud/infrastructure test -- tenant-lifecycle-scripts.test.ts
- bun run --filter @TenkaCloud/infrastructure test -- tenant-pipeline
- bun run --filter @TenkaCloud/infrastructure typecheck
- make harness
- mise exec -- make before-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for tenant lifecycle scripts, including validation of provisioning and deprovisioning processes.
  * Improved test reliability for problem metadata and pipeline execution handling.

* **Chores**
  * Updated Node.js runtime from version 20 to 22.
  * Updated Bun from version 1.2.20 to 1.3.11.
  * Migrated CDK CLI invocation from npm (npx) to Bun (bunx) for faster tenant provisioning and deprovisioning operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/775)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->