### PR TITLE
test: add deployment chaos scenarios

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { S3Client } from "@aws-sdk/client-s3";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
@@ -184,13 +184,36 @@ export async function startDeployment(
     externalIdParameterName: verified.externalIdParameterName,
     ...(challengePayloadUrl ? { challengePayloadUrl } : {}),
   };
-  await publishProblemEvent({
-    client: ctx.events,
-    busName: ctx.eventBusName,
-    detailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
-    jobId,
-    detail,
-  });
+  try {
+    await publishProblemEvent({
+      client: ctx.events,
+      busName: ctx.eventBusName,
+      detailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+      jobId,
+      detail,
+    });
+  } catch (err) {
+    try {
+      await ctx.ddb.send(
+        new UpdateCommand({
+          TableName: ctx.tableName,
+          Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+          UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+          ConditionExpression: "#s = :pending",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: {
+            ":failed": "FAILED",
+            ":pending": "PENDING",
+            ":updatedAt": new Date(ctx.now()).toISOString(),
+            ":reason": "Failed to publish DeployCreateRequested event",
+          },
+        }),
+      );
+    } catch {
+      // best-effort: compensation failure should not hide the original publish error.
+    }
+    throw err;
+  }
 
   return {
     jobId,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -48,6 +48,13 @@ const PUT_EVENTS_BATCH = 10;
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const toEpochSeconds = (ms: number): number => Math.floor(ms / 1000);
 
+interface PlanEntry {
+  readonly item: DeploymentItem;
+  readonly entry: PutEventsRequestEntry;
+  /** retry / force redeploy のとき、対応する旧行の jobId (= これを DELETE)。 */
+  readonly replacesJobId?: string;
+}
+
 /**
  * `bulkDeployEvent` は Event / Teams を読み、選択された problems 全てに対して
  * teams × problems の deployment 行を一括 PUT し、既存 `DeployCreateRequested` を
@@ -200,12 +207,6 @@ export async function bulkDeployEvent(
   // #528: deploy target の awsAccountId は team から (= 各 team は自社 AWS account)、region は
   // problem から (= 問題テンプレが特定 region 依存)。team.awsAccountId が無い旧 Event は
   // problem.defaultAwsAccountId に fallback (Phase 2 で fallback も削除予定)。
-  interface PlanEntry {
-    readonly item: DeploymentItem;
-    readonly entry: PutEventsRequestEntry;
-    /** retry / force redeploy のとき、対応する旧行の jobId (= これを DELETE)。 */
-    readonly replacesJobId?: string;
-  }
   const plan: PlanEntry[] = [];
   let skipped = 0;
   const unverifiedAccounts = new Set<string>();
@@ -351,15 +352,14 @@ export async function bulkDeployEvent(
   await Promise.all(transactChunks);
 
   const items = plan.map((p) => p.item);
-  const entries = plan.map((p) => p.entry);
 
   // EventBridge PutEvents は 1 call 10 entries まで。chunk を Promise.all で並列発火。
-  // 途中で publish が失敗した chunk があると半端な行が残るが、operator が再度 deploy を
-  // 呼ぶと既行は idempotent skip され、未 publish 分だけ publish される (= 結果整合性)。
-  const putChunks: Promise<unknown>[] = [];
-  for (let i = 0; i < entries.length; i += PUT_EVENTS_BATCH) {
-    const chunk = entries.slice(i, i + PUT_EVENTS_BATCH);
-    putChunks.push(shared.events.send(new PutEventsCommand({ Entries: chunk })));
+  // DDB row 作成後の publish 失敗は PENDING 放置にしない。失敗分だけ FAILED に倒せば
+  // operator が retryFailedOnly で復旧でき、duplicate deploy は既存 row として skip される。
+  const putChunks: Promise<PublishFailure[]>[] = [];
+  for (let i = 0; i < plan.length; i += PUT_EVENTS_BATCH) {
+    const chunk = plan.slice(i, i + PUT_EVENTS_BATCH);
+    putChunks.push(publishPlanChunk(shared, chunk));
   }
 
   // Event status を DRAFT → DEPLOYING に倒す。operator が EventDetail の status badge で
@@ -388,12 +388,88 @@ export async function bulkDeployEvent(
         throw err;
       }
     });
-  await Promise.all([...putChunks, updateStatus]);
+  const [publishFailures] = await Promise.all([Promise.all(putChunks), updateStatus]);
+  const failures = publishFailures.flat();
+  if (failures.length > 0) {
+    await markPublishFailuresFailed(shared, tenantId, failures, createdAt);
+    throw new Error(
+      `EventBridge PutEvents failed for ${failures.length} deployment(s): ${failures
+        .map((f) => `${f.jobId} ${f.reason}`)
+        .join("; ")}`,
+    );
+  }
 
   return {
     kind: "ok",
     result: buildResult({ eventId, enqueued: items.length, skipped, unverifiedAccounts }),
   };
+}
+
+interface PublishFailure {
+  readonly jobId: string;
+  readonly reason: string;
+}
+
+async function publishPlanChunk(
+  shared: EventSharedResources,
+  chunk: readonly PlanEntry[],
+): Promise<PublishFailure[]> {
+  try {
+    const out = await shared.events.send(
+      new PutEventsCommand({ Entries: chunk.map((p) => p.entry) }),
+    );
+    if ((out.FailedEntryCount ?? 0) === 0) return [];
+    const failures = (out.Entries ?? [])
+      .map((entry, i): PublishFailure | undefined =>
+        entry.ErrorCode
+          ? {
+              jobId: chunk[i]?.item.jobId ?? "<unknown>",
+              reason: `${entry.ErrorCode}: ${entry.ErrorMessage ?? "unknown error"}`,
+            }
+          : undefined,
+      )
+      .filter((f): f is PublishFailure => f !== undefined);
+    return failures.length > 0
+      ? failures
+      : chunk.map((p) => ({ jobId: p.item.jobId, reason: "unknown error" }));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return chunk.map((p) => ({ jobId: p.item.jobId, reason }));
+  }
+}
+
+async function markPublishFailuresFailed(
+  shared: EventSharedResources,
+  tenantId: string,
+  failures: readonly PublishFailure[],
+  updatedAt: string,
+): Promise<void> {
+  await Promise.all(
+    failures.map(async (failure) => {
+      try {
+        await shared.ddb.send(
+          new UpdateCommand({
+            TableName: shared.deploymentsTableName,
+            Key: { PK: `DEPLOYMENT#${failure.jobId}`, SK: "META" },
+            UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+            ConditionExpression: "tenantId = :tenantId AND #s = :pending",
+            ExpressionAttributeNames: { "#s": "status" },
+            ExpressionAttributeValues: {
+              ":failed": "FAILED",
+              ":pending": "PENDING",
+              ":tenantId": tenantId,
+              ":updatedAt": updatedAt,
+              ":reason": `Failed to publish DeployCreateRequested event: ${failure.reason}`,
+            },
+          }),
+        );
+      } catch (err) {
+        if (!(err instanceof Error) || err.name !== "ConditionalCheckFailedException") {
+          throw err;
+        }
+      }
+    }),
+  );
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -84,6 +84,17 @@ export const DeployDeleteRequestedDetailSchema = z.object({
 });
 export type DeployDeleteRequestedDetail = z.infer<typeof DeployDeleteRequestedDetailSchema>;
 
+export class ProblemEventPublishError extends Error {
+  constructor(
+    public readonly detailType: string,
+    public readonly jobId: string,
+    public readonly reason: string,
+  ) {
+    super(`EventBridge PutEvents failed for ${detailType} ${jobId}: ${reason}`);
+    this.name = "ProblemEventPublishError";
+  }
+}
+
 /**
  * `tenkacloud.deploy` event を 1 件 publish する shared helper。
  * Resources は `tenkacloud:deployment:<jobId>` で統一し、subscriber が job 単位で
@@ -96,7 +107,7 @@ export async function publishProblemEvent(args: {
   jobId: string;
   detail: Record<string, unknown>;
 }): Promise<void> {
-  await args.client.send(
+  const out = await args.client.send(
     new PutEventsCommand({
       Entries: [
         {
@@ -108,5 +119,14 @@ export async function publishProblemEvent(args: {
         },
       ],
     }),
+  );
+  if ((out.FailedEntryCount ?? 0) === 0) return;
+  const failed = out.Entries?.[0];
+  throw new ProblemEventPublishError(
+    args.detailType,
+    args.jobId,
+    failed?.ErrorCode
+      ? `${failed.ErrorCode}: ${failed.ErrorMessage ?? "unknown error"}`
+      : "unknown error",
   );
 }

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -183,6 +183,21 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("$.codebuild.Build.Id");
     });
 
+    it("Create State Machine は CodeBuild timeout / AccessDenied を Catch して FAILED に倒すべき", () => {
+      const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
+      const createStateMachine = Object.values(stateMachines)
+        .map((stateMachine) => JSON.stringify(stateMachine))
+        .find((definition) => definition.includes("StartDeployCodeBuild"));
+
+      expect(createStateMachine).toBeDefined();
+      expect(createStateMachine).toContain("StartDeployCodeBuild");
+      expect(createStateMachine).toContain("StartDeployCodeBuildCrossAccount");
+      expect(createStateMachine).toContain("States.ALL");
+      expect(createStateMachine).toContain("RouteFailedDeployment");
+      expect(createStateMachine).toContain("MarkFailed");
+      expect(createStateMachine).toContain("MarkFailedWithoutBuildId");
+    });
+
     it("Create State Machine は ROLLBACK_COMPLETE を terminal failure として MarkFailed に倒すべき", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const createStateMachine = Object.values(stateMachines)

--- a/infrastructure/test/problem-deploy/deploy-handler.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler.test.ts
@@ -1,5 +1,5 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type DeployContext,
@@ -152,6 +152,31 @@ describe("startDeployment", () => {
     putSend.mockRejectedValueOnce(new Error("DDB down"));
     await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow("DDB down");
     expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("EventBridge publish が失敗したら deployment を FAILED に補償更新すべき", async () => {
+    const { ctx, putSend, eventsSend } = buildContext();
+    eventsSend.mockResolvedValueOnce({
+      FailedEntryCount: 1,
+      Entries: [{ ErrorCode: "InternalFailure", ErrorMessage: "event bus down" }],
+    });
+
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(/EventBridge PutEvents/);
+
+    const putCmd = putSend.mock.calls[0]?.[0] as PutCommand;
+    const updateCmd = putSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is UpdateCommand => c instanceof UpdateCommand);
+    expect(updateCmd).toBeInstanceOf(UpdateCommand);
+    expect(updateCmd?.input.Key).toEqual(
+      putCmd.input.Item ? { PK: putCmd.input.Item.PK, SK: "META" } : undefined,
+    );
+    expect(updateCmd?.input.UpdateExpression).toContain("#s = :failed");
+    expect(updateCmd?.input.ConditionExpression).toBe("#s = :pending");
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":failed"]).toBe("FAILED");
+    expect(updateCmd?.input.ExpressionAttributeValues?.[":reason"]).toBe(
+      "Failed to publish DeployCreateRequested event",
+    );
   });
 
   it("forward-compat フィールド (accountGroupId / problemSetId) も保存するべき", async () => {

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -243,6 +243,69 @@ describe("bulkDeployEvent", () => {
     expect(putCmds[2]?.input.Entries).toHaveLength(10);
   });
 
+  it("PutEvents の partial failure は該当 deployment を FAILED にして retry 可能にすべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValueOnce({
+      FailedEntryCount: 1,
+      Entries: [{}, { ErrorCode: "InternalFailure", ErrorMessage: "event bus down" }],
+    });
+
+    await expect(bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS)).rejects.toThrow(
+      /EventBridge PutEvents failed/,
+    );
+
+    const transactCmd = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((c): c is TransactWriteCommand => c instanceof TransactWriteCommand);
+    const failedJobId = transactCmd?.input.TransactItems?.[1]?.Put?.Item?.jobId;
+    const failureUpdates = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter(
+        (c): c is UpdateCommand =>
+          c instanceof UpdateCommand &&
+          c.input.TableName === "TestDeployments" &&
+          c.input.ExpressionAttributeValues?.[":failed"] === "FAILED",
+      );
+    expect(failureUpdates).toHaveLength(1);
+    expect(failureUpdates[0]?.input.Key).toEqual({ PK: `DEPLOYMENT#${failedJobId}`, SK: "META" });
+    expect(failureUpdates[0]?.input.ConditionExpression).toContain("#s = :pending");
+    expect(failureUpdates[0]?.input.ExpressionAttributeValues?.[":reason"]).toContain(
+      "InternalFailure: event bus down",
+    );
+  });
+
+  it("PutEvents の timeout/reject は chunk 内 deployment を FAILED にして retry 可能にすべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockRejectedValueOnce(new Error("EventBridge timeout"));
+
+    await expect(bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS)).rejects.toThrow(
+      /EventBridge PutEvents failed/,
+    );
+
+    const failureUpdates = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter(
+        (c): c is UpdateCommand =>
+          c instanceof UpdateCommand &&
+          c.input.TableName === "TestDeployments" &&
+          c.input.ExpressionAttributeValues?.[":failed"] === "FAILED",
+      );
+    expect(failureUpdates).toHaveLength(2);
+    expect(
+      failureUpdates.every((u) =>
+        String(u.input.ExpressionAttributeValues?.[":reason"] ?? "").includes(
+          "EventBridge timeout",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("各 deployment 行の ConditionExpression で同 jobId 二重生成を防ぐべき", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
@@ -422,6 +485,25 @@ describe("bulkDeployEvent", () => {
     const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
     // 4 通りのうち 2 件衝突、残り 2 件のみ enqueue
     expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 2 } });
+  });
+
+  it("duplicate event で全組み合わせが既存 PENDING なら write / publish しないべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) }); // 1 team = 2 通り
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", problemId: "hello-world", jobId: "P1", status: "PENDING" },
+        { teamId: "T1", problemId: "hello-world-battle", jobId: "P2", status: "PENDING" },
+      ],
+    });
+    ddbSend.mockResolvedValue({});
+
+    const out = await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 2 } });
+    expect(ddbSend.mock.calls.filter((c) => c[0] instanceof TransactWriteCommand)).toHaveLength(0);
+    expect(eventsSend).not.toHaveBeenCalled();
   });
 
   // #555: retryFailedOnly = true → FAILED 行のみ再生成、PENDING/COMPLETE はスルー


### PR DESCRIPTION
Summary
- Treat EventBridge PutEvents partial failures as publish errors instead of silent success.
- Compensate single and bulk deploy publish failures by marking affected PENDING deployments FAILED so retryFailedOnly can recover.
- Add chaos coverage for partial publish, publish timeout/reject, duplicate deploy events, and CodeBuild/cross-account failure catch paths.

Test plan
- bun run --filter @TenkaCloud/infrastructure test -- event-bulk-deploy.test.ts deploy-handler.test.ts problem-deploy-backend-stack.test.ts
- bun run --filter @TenkaCloud/infrastructure typecheck
- ./node_modules/.bin/biome check infrastructure/lib/problem-deploy/handlers/shared/events.ts infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts infrastructure/test/problem-deploy/deploy-handler.test.ts infrastructure/test/problem-deploy/event-bulk-deploy.test.ts infrastructure/test/problem-deploy-backend-stack.test.ts
- make harness
- mise exec -- make before-commit (lint/test/audit passed; final check-synth could not use cdk.out because an existing cdk deploy PID 19154 was running)
- mise exec -- bun run cdk synth --output cdk.out-codex-776 (passed; output moved to /private/tmp/tenkacloud-cdk-out-codex-776-ok)

Closes #776