### PR TITLE
fix(#749): admin-insight 認可 claim を cognito:groups → custom:userRole に修正

### DIFF
--- a/apps/admin-console/src/api/insight.ts
+++ b/apps/admin-console/src/api/insight.ts
@@ -55,7 +55,7 @@ export async function fetchTenantsInsightSummary(
   });
   if (!res.ok) {
     if (res.status === StatusCodes.FORBIDDEN) {
-      // Tenant Admin が token を持ってきた場合 (= cognito:groups に SystemAdmin が無い)。
+      // Tenant Admin が token を持ってきた場合 (= custom:userRole が "SystemAdmin" でない)。
       // 例外を throw すると tenant 一覧本体まで巻き込んで UI が壊れる。null を返して
       // caller が「未表示」扱いにする (= 集計 column 単体だけ static 値 0 を出す)。
       return null;

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts
@@ -4,6 +4,8 @@ import type { Context } from "hono";
 type JwtClaimValue = string | number | boolean | string[];
 type JwtClaims = { readonly [name: string]: JwtClaimValue };
 
+const SYSTEM_ADMIN_ROLE = "SystemAdmin";
+
 /**
  * Cognito `sub` claim を取り出す (= operator の安定識別子)。
  * ADR-011 D5 の structured audit log (`admin.insight.read`) に `admin` フィールドとして埋める。
@@ -17,33 +19,24 @@ export function resolveCognitoSub(c: Context): string {
 }
 
 /**
- * Cognito `cognito:groups` claim に `SystemAdmin` が含まれているか判定する。
- * ADR-011 D2 採用案 = SBT 標準 SystemAdmin group の Cognito claim を必須化。
+ * Cognito `custom:userRole` claim が `SystemAdmin` か判定する。
+ * ADR-011 D2 採用案 = SBT 標準の SystemAdmin identity を必須化。
  *
- * API GW の JWT Authorizer (= group check 機能なし) で認可は通っても、claim 検査は
- * 二重防御として handler 側でもう一度行う。`SystemAdmin` group に属さない token を
- * 持つ Tenant Admin が誤って本 API を叩いても 403 で弾く。
+ * SBT v0.3.9 の `auth-custom-resource/index.py` は admin user を `admin_create_user` で
+ * 作成するとき、`custom:userRole = "SystemAdmin"` を user attribute として埋める。
+ * Cognito Group ではなく custom attribute 経路を使うのが SBT の慣習なので、 group claim
+ * (`cognito:groups`) は空のまま id_token に乗らない。 admin-insight handler は SBT に
+ * 揃えて custom attribute で判定する。
  *
- * `cognito:groups` claim は spec 上 `string[]` だが、API Gateway v2 JWT Authorizer は
- * 単一要素を string に潰すことがあるため、両形式を受け付ける。
+ * Tenant Admin 経路は `custom:userRole = "TenantAdmin"` (= provision-tenant.sh / SBT
+ * UserManagementService が埋める)。 不一致な値は SystemAdmin と見なさない。
+ *
+ * API GW HTTP API JWT Authorizer は token 検証のみで role 値を見ないため、 本関数が
+ * handler 内の二重防御として機能する。
  */
 export function isSystemAdmin(c: Context): boolean {
   const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
   const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
-  const raw = claims?.["cognito:groups"];
-  if (raw === undefined) return false;
-  if (typeof raw === "string") {
-    // API GW v2 が `"[SystemAdmin]"` / `"SystemAdmin"` / `"foo,SystemAdmin,bar"` 等いずれの
-    // 表現で渡してきても拾えるように、bracket / comma で粗く split して trim する。
-    return raw
-      .replace(/^\[/, "")
-      .replace(/\]$/, "")
-      .split(",")
-      .map((s) => s.trim())
-      .includes("SystemAdmin");
-  }
-  if (Array.isArray(raw)) {
-    return raw.includes("SystemAdmin");
-  }
-  return false;
+  const role = claims?.["custom:userRole"];
+  return typeof role === "string" && role.trim() === SYSTEM_ADMIN_ROLE;
 }

--- a/infrastructure/test/admin-insight/admin-insight-routes.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-routes.test.ts
@@ -38,8 +38,9 @@ const { app } = await import("../../lib/admin-insight/handlers/admin-insight-han
 
 /**
  * API GW v2 JWT Authorizer 経由で渡される event の最小 shape。
- * `c.env.event.requestContext.authorizer.jwt.claims` に `cognito:groups` / `sub` を入れる
- * (= handler の `isSystemAdmin` / `resolveCognitoSub` がこのパスを読む)。
+ * `c.env.event.requestContext.authorizer.jwt.claims` に `custom:userRole` / `sub` を入れる
+ * (= handler の `isSystemAdmin` / `resolveCognitoSub` がこのパスを読む)。SBT 0.3.9 の
+ * `auth-custom-resource` が admin user に埋める `custom:userRole = "SystemAdmin"` を再現する。
  */
 function withClaims(claims: Record<string, unknown>) {
   return {
@@ -55,14 +56,14 @@ const VALID_JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B3";
 describe("GET /admin/insight/tenants/summary", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("SystemAdmin group claim があれば 200 を返すべき", async () => {
+  it("SystemAdmin role claim があれば 200 を返すべき", async () => {
     mocks.summarizeTenants.mockResolvedValueOnce({
       items: [{ tenantId: "t-1", activeDeploys: 2, failedDeploys: 0, totalEvents: 3 }],
     });
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "user-1" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "user-1" }) },
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -75,7 +76,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
-      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "user-1" }) },
+      { event: withClaims({ "custom:userRole": "TenantAdmin", sub: "user-1" }) },
     );
     expect(res.status).toBe(403);
     expect(mocks.summarizeTenants).not.toHaveBeenCalled();
@@ -86,12 +87,12 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(res.status).toBe(403);
   });
 
-  it("cognito:groups が string で SystemAdmin を含むなら認可するべき", async () => {
+  it("custom:userRole の前後 whitespace は trim して認可するべき", async () => {
     mocks.summarizeTenants.mockResolvedValueOnce({ items: [] });
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
-      { event: withClaims({ "cognito:groups": "[SystemAdmin]", sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "  SystemAdmin  ", sub: "u" }) },
     );
     expect(res.status).toBe(200);
   });
@@ -100,7 +101,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     const res = await app.request(
       "/admin/insight/tenants/summary",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -112,7 +113,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=tenant%201",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
     expect(mocks.summarizeTenants).not.toHaveBeenCalled();
@@ -123,7 +124,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     const res = await app.request(
       `/admin/insight/tenants/summary?tenantIds=${many}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
     expect(mocks.summarizeTenants).not.toHaveBeenCalled();
@@ -134,7 +135,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(500);
     const body = await res.json();
@@ -149,7 +150,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "admin-sub-xyz" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "admin-sub-xyz" }) },
     );
     const calls = spy.mock.calls.map((c) => c[0]);
     expect(
@@ -183,7 +184,7 @@ describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
     const res = await app.request(
       "/admin/insight/tenants/t1/events",
       {},
-      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "TenantAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(403);
     expect(mocks.listEventsForTenant).not.toHaveBeenCalled();
@@ -207,7 +208,7 @@ describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
     const res = await app.request(
       "/admin/insight/tenants/t-acme/events?limit=10",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     expect(mocks.listEventsForTenant).toHaveBeenCalledWith(
@@ -220,7 +221,7 @@ describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
     const res = await app.request(
       "/admin/insight/tenants/has%20space/events",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
     expect(mocks.listEventsForTenant).not.toHaveBeenCalled();
@@ -230,7 +231,7 @@ describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
     const res = await app.request(
       "/admin/insight/tenants/t1/events?limit=9999",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
   });
@@ -240,7 +241,7 @@ describe("GET /admin/insight/tenants/:tenantId/events (Phase 1.B)", () => {
     const res = await app.request(
       "/admin/insight/tenants/t1/events",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(500);
     const body = await res.json();
@@ -255,7 +256,7 @@ describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () 
     const res = await app.request(
       `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "TenantAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(403);
     expect(mocks.getEventDetailForTenant).not.toHaveBeenCalled();
@@ -278,7 +279,7 @@ describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () 
     const res = await app.request(
       `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     expect(mocks.getEventDetailForTenant).toHaveBeenCalledWith(
@@ -292,7 +293,7 @@ describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () 
     const res = await app.request(
       "/admin/insight/tenants/t1/events/bad-event",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
   });
@@ -302,7 +303,7 @@ describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () 
     const res = await app.request(
       `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(404);
   });
@@ -328,7 +329,7 @@ describe("GET /admin/insight/tenants/:tenantId/events/:eventId (Phase 1.B)", () 
     const res = await app.request(
       `/admin/insight/tenants/t1/events/${VALID_EVENT_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     const body = (await res.json()) as {
       teams: Array<{ teamLoginKey?: string }>;
@@ -344,7 +345,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId (Phase 1.B)", 
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "TenantAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(403);
     expect(mocks.getDeploymentForTenant).not.toHaveBeenCalled();
@@ -367,7 +368,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId (Phase 1.B)", 
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     expect(mocks.getDeploymentForTenant).toHaveBeenCalledWith(
@@ -381,7 +382,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId (Phase 1.B)", 
     const res = await app.request(
       "/admin/insight/tenants/t1/deployments/not-a-ulid",
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(400);
   });
@@ -391,7 +392,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId (Phase 1.B)", 
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(404);
   });
@@ -404,7 +405,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["TenantAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "TenantAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(403);
     expect(mocks.getStackProgressForTenant).not.toHaveBeenCalled();
@@ -425,7 +426,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { jobId: string; consoleUrl: string };
@@ -437,7 +438,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(404);
   });
@@ -447,7 +448,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(409);
   });
@@ -460,7 +461,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -478,7 +479,7 @@ describe("GET /admin/insight/tenants/:tenantId/deployments/:jobId/stack-progress
     const res = await app.request(
       `/admin/insight/tenants/t1/deployments/${VALID_JOB_ID}/stack-progress`,
       {},
-      { event: withClaims({ "cognito:groups": ["SystemAdmin"], sub: "u" }) },
+      { event: withClaims({ "custom:userRole": "SystemAdmin", sub: "u" }) },
     );
     expect(res.status).toBe(500);
     const body = await res.json();

--- a/infrastructure/test/admin-insight/auth.test.ts
+++ b/infrastructure/test/admin-insight/auth.test.ts
@@ -14,24 +14,21 @@ function buildContext(claims?: Record<string, unknown>): Context {
 }
 
 describe("isSystemAdmin", () => {
-  it("cognito:groups が string[] で SystemAdmin を含むなら true", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": ["SystemAdmin"] }))).toBe(true);
+  it("custom:userRole === 'SystemAdmin' なら true (= SBT が createAdminUser 経由で埋める claim)", () => {
+    expect(isSystemAdmin(buildContext({ "custom:userRole": "SystemAdmin" }))).toBe(true);
   });
 
-  it("cognito:groups が string[] で SystemAdmin を含まないなら false", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": ["TenantAdmin"] }))).toBe(false);
+  it("custom:userRole === 'TenantAdmin' なら false (= Tenant Admin token が誤って届いた case)", () => {
+    expect(isSystemAdmin(buildContext({ "custom:userRole": "TenantAdmin" }))).toBe(false);
   });
 
-  it("cognito:groups が string で `[SystemAdmin]` 形式でも true", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": "[SystemAdmin]" }))).toBe(true);
+  it("custom:userRole が大文字小文字違いなら false (= 完全一致以外は SystemAdmin と見なさない)", () => {
+    expect(isSystemAdmin(buildContext({ "custom:userRole": "systemadmin" }))).toBe(false);
+    expect(isSystemAdmin(buildContext({ "custom:userRole": "SYSTEMADMIN" }))).toBe(false);
   });
 
-  it("cognito:groups が string で comma 区切りに SystemAdmin が混じるなら true", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": "Foo,SystemAdmin,Bar" }))).toBe(true);
-  });
-
-  it("cognito:groups が string で SystemAdmin を含まないなら false", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": "TenantAdmin" }))).toBe(false);
+  it("custom:userRole の前後 whitespace は trim して評価すべき", () => {
+    expect(isSystemAdmin(buildContext({ "custom:userRole": "  SystemAdmin  " }))).toBe(true);
   });
 
   it("claim が無いなら false", () => {
@@ -39,8 +36,13 @@ describe("isSystemAdmin", () => {
     expect(isSystemAdmin(buildContext({}))).toBe(false);
   });
 
-  it("cognito:groups が未知 type (例: number) なら false", () => {
-    expect(isSystemAdmin(buildContext({ "cognito:groups": 42 }))).toBe(false);
+  it("custom:userRole が string 以外 (例: number / array) なら false", () => {
+    expect(isSystemAdmin(buildContext({ "custom:userRole": 42 }))).toBe(false);
+    expect(isSystemAdmin(buildContext({ "custom:userRole": ["SystemAdmin"] }))).toBe(false);
+  });
+
+  it("cognito:groups だけ届いていても custom:userRole が無ければ false (= 旧経路の互換は持たない)", () => {
+    expect(isSystemAdmin(buildContext({ "cognito:groups": ["SystemAdmin"] }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

admin-console の **Provisioning Jobs page (= `/jobs`)** が `権限がありません — この機能は SystemAdmin group のメンバーのみ閲覧できます。 ログインし直してください。` で開けない bug の根本対処。

## 真因

SBT v0.3.9 の `ControlPlane` は admin user を `auth-custom-resource/index.py` 経由で `admin_create_user` するとき、 **Cognito Group を使わず `custom:userRole = "SystemAdmin"` を user attribute として埋める**。 group は 1 件も作成しない。

一方 admin-insight handler の \`isSystemAdmin\` (= \`infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts\`) は \`claims["cognito:groups"]\` を見ていたため、 SBT default 環境では JWT に該当 claim が存在せず **常に 403 を返していた**。

## 確定エビデンス (本日、 本番 AWS)

- Cognito UserPool \`ap-northeast-1_zaIyuF1my\` (= ControlPlane の SBT 由来 pool)
  - \`list-groups\` → **0 件** (= SystemAdmin group 自体が無い)
  - \`admin\` user → \`Groups: []\`
  - \`admin\` user attributes → \`{ email, email_verified, custom:userRole = "SystemAdmin", sub }\`
- SBT v0.3.9 source 確認:
  - \`node_modules/@cdklabs/sbt-aws/resources/functions/auth-custom-resource/index.py:42\` で \`custom:userRole\` を埋める
  - \`UserPoolGroup\` / \`CfnUserPoolGroup\` / \`AdminAddUserToGroup\` の呼び出しは存在しない (= grep で 0 件)
  - TenantAdmin 経路 (\`cognito_user_management_service.py:26\`) も同様に \`custom:userRole\` 経路を使う
- 4 候補 (A-D) のうち候補 C (= 認可 logic が異なる claim path を見ている) が当たり

## 変更内容

| File | 変更 |
|---|---|
| \`infrastructure/lib/admin-insight/handlers/admin-insight-handler/auth.ts\` | \`isSystemAdmin\` を \`claims["custom:userRole"] === "SystemAdmin"\` (whitespace trim あり) で判定。 docblock で SBT との整合性を明示 |
| \`infrastructure/test/admin-insight/auth.test.ts\` | unit test fixture を \`cognito:groups\` → \`custom:userRole\` に差し替え。 大小文字違い / whitespace trim / 旧 cognito:groups 経路を信じない pin を追加 |
| \`infrastructure/test/admin-insight/admin-insight-routes.test.ts\` | route test fixture も同様に置き換え。 旧 \`"[SystemAdmin]"\` string 形式テストは whitespace trim ケースに差し替え |
| \`apps/admin-console/src/api/insight.ts\` | 403 ハンドラ内のコメント説明を実 claim 名に合わせる |

## Test plan

- [x] \`bunx vitest run test/admin-insight/\` (infrastructure) — 40 件 pass (auth 8 件 + routes 32 件)
- [x] \`bunx vitest run\` (apps/admin-console) — 115 件 pass
- [x] \`bunx tsc --noEmit\` (infrastructure) — clean
- [x] \`bunx biome check\` — clean
- [ ] **reviewer**: PR merge → \`make deploy\` 後、 admin-console の Provisioning Jobs page が 200 で開き、 CodePipeline 実行履歴が表示されること

## 真因仮説の検証 (#749 で挙げた 4 候補)

| 候補 | 結果 |
|---|---|
| A. Cognito UserPool の SystemAdmin group membership が削除されている | △ partial — group そのものが SBT で作成されない (= 削除ではなく 当初から存在しない) |
| B. JWT に \`cognito:groups\` claim が含まれていない | ✅ そのとおりだが原因は UserPoolClient \`readAttributes\` 抜けではなく **group 不在** |
| C. admin-insight API の JWT authorizer が \`cognito:groups\` vs \`custom:userRole\` で異なる field を見ている | ✅ **真因** |
| D. frontend gate が claim を読めていない | ❌ frontend 側は 403 を素直に \`forbidden\` 表示するだけで gating 自前 logic は持たない |

## Regression 分析

- ADR-011 D2 採用案 (= SBT 標準 SystemAdmin identity を必須化) は維持。 「2 段防御 (= API GW JWT Authorizer + handler 内の claim 再検査) で Tenant Admin token を 403 で弾く」動作は保つ
- 旧 \`cognito:groups\` 経路を信じていた caller は無し (= grep で確認、 SBT / 本 repo の他 handler も全部 \`custom:userRole\` 経路に統一されている)
- TenantAdmin 側 (= \`apps/application-admin-console\`) は別経路の認可で動作。 \`custom:userRole = "TenantAdmin"\` を見る既存 logic は touch しない
- 既存 unit test 40 件 + frontend test 115 件 すべて green を確認済
- whitespace trim を入れたため \`"  SystemAdmin  "\` も SystemAdmin として認可される (= SBT custom resource が将来 trim 漏れする regression 対策)。 完全 strict にしたい場合は別 PR で trim を外す方向に倒す余地はある

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | \`tenkacloud-admin-console-insight\` stack の AdminInsightApi Lambda bundle | bundling 後の JS が変わる (= IAM / function configuration は不変) |
| NO-OP | API Gateway / Cognito / DDB / EventBridge | 設定変更なし |
| NO-OP | \`apps/admin-console/dist/\` | insight.ts のコメント変更のみ、 実 bundle 出力は同等 |
| NO-OP | 他 stack (\`control-plane\`、 \`problem-deploy\` 等) | 触らない |

## 関連

- Closes #749
- 関連 issue (本日の調査で確認、 別 PR 既出): #756 (SSO 認可関連) / #758 (DeployDelete state machine) / #762 (cross-account DescribeStacks) — 本 PR とは独立
- ADR-011 D2 (= SBT 標準 SystemAdmin identity の必須化、 本 PR の根拠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)