### PR TITLE
feat(#768): deploy chain trace logging + correlationId 伝搬 + Logs Insights クエリ

### DIFF
--- a/docs/operations/deploy-trace.html
+++ b/docs/operations/deploy-trace.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Deploy chain trace logging 運用ガイド</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Deploy chain trace logging 運用ガイド</h1>
+<p><a href="https://github.com/susumutomita/TenkaCloud/issues/768">Issue #768</a> で導入した end-to-end deploy trace log の使い方。 EventBridge → Step Functions → CodeBuild → Lambda → 競技者 account CloudFormation の長い経路を <code>jobId</code> 1 つで横断検索できるようにする。</p>
+<h2>設計の要点</h2>
+<table>
+<thead>
+<tr>
+<th>項目</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>log format</td>
+<td>JSON 1 行 (= newline-delimited JSON in CloudWatch Logs)</td>
+</tr>
+<tr>
+<td>共通 field</td>
+<td><code>event</code> / <code>level</code> / <code>component</code> / <code>timestamp</code> / <code>jobId</code> / <code>correlationId</code></td>
+</tr>
+<tr>
+<td><code>correlationId</code> の値</td>
+<td>現状は <code>jobId</code> と同値 (= ULID)。将来 retry / fan-out が増えたら独立可能</td>
+</tr>
+<tr>
+<td>Lambda 経路</td>
+<td><code>infrastructure/lib/problem-deploy/handlers/shared/trace-log.ts</code> の <code>logDeployTrace</code> / <code>warnDeployTrace</code> / <code>errorDeployTrace</code></td>
+</tr>
+<tr>
+<td>Shell 経路</td>
+<td><code>scripts/lib/battles-common.sh</code> の <code>trace_log</code> (= 同じ JSON shape)</td>
+</tr>
+<tr>
+<td>State Machine 経路</td>
+<td><code>TENKACLOUD_CORRELATION_ID</code> env を CodeBuild に渡して shell から再 emit</td>
+</tr>
+</tbody></table>
+<h2>イベント分類</h2>
+<p><code>event</code> field は <code>deploy.&lt;phase&gt;.&lt;outcome&gt;</code> の dot-separated 形式。 横断 grep / Logs Insights filter で各 phase を抜けるように命名している。</p>
+<h3>Lambda 境界 (= problem-deploy stack)</h3>
+<table>
+<thead>
+<tr>
+<th>event</th>
+<th>出所</th>
+<th>level</th>
+<th>主な field</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>deploy.create.enqueued</code></td>
+<td><code>deploy-handler/deploy.ts:startDeployment</code></td>
+<td>info</td>
+<td><code>tenantId</code>, <code>problemId</code>, <code>teamSlug</code>, <code>region</code>, <code>awsAccountId</code>, <code>namePrefix</code></td>
+</tr>
+<tr>
+<td><code>deploy.delete.enqueued</code></td>
+<td><code>deploy-handler/delete.ts:requestTeardown</code></td>
+<td>info</td>
+<td><code>tenantId</code>, <code>stackName</code>, <code>region</code>, <code>awsAccountId</code></td>
+</tr>
+<tr>
+<td><code>deploy.eventbridge.publish.succeeded</code></td>
+<td><code>shared/events.ts:publishProblemEvent</code></td>
+<td>info</td>
+<td><code>detailType</code>, <code>eventBusName</code>, <code>resource</code></td>
+</tr>
+<tr>
+<td><code>deploy.describe-stack.start</code></td>
+<td><code>describe-stack-handler/index.ts</code></td>
+<td>info</td>
+<td><code>tenantId</code>, <code>stackName</code>, <code>region</code>, <code>hasCompetitorRole</code></td>
+</tr>
+<tr>
+<td><code>deploy.describe-stack.succeeded</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>stackName</code>, <code>region</code>, <code>stackStatus</code>, <code>stackId</code></td>
+</tr>
+<tr>
+<td><code>deploy.describe-stack.assume-role.grace-fallback</code></td>
+<td>同上</td>
+<td>warn</td>
+<td><code>region</code>, <code>externalIdVersion</code></td>
+</tr>
+</tbody></table>
+<h3>Shell 境界 (= CodeBuild の deploy-battles.sh / delete-battles.sh)</h3>
+<table>
+<thead>
+<tr>
+<th>event</th>
+<th>出所</th>
+<th>level</th>
+<th>主な field</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>deploy.codebuild.start</code></td>
+<td><code>deploy-battles.sh:73</code> / <code>delete-battles.sh:33</code></td>
+<td>info</td>
+<td><code>operation</code> (= <code>create</code> / <code>delete</code>), <code>region</code>, <code>teamSlug</code></td>
+</tr>
+<tr>
+<td><code>deploy.codebuild.succeeded</code></td>
+<td><code>deploy-battles.sh:234</code> / <code>delete-battles.sh:81</code></td>
+<td>info</td>
+<td><code>operation</code>, <code>region</code>, <code>problemCount</code></td>
+</tr>
+<tr>
+<td><code>deploy.codebuild.failed</code></td>
+<td><code>deploy-battles.sh:238</code></td>
+<td>info</td>
+<td><code>operation</code>, <code>region</code>, <code>failureCount</code></td>
+</tr>
+<tr>
+<td><code>deploy.cfn.deploy.start</code></td>
+<td><code>deploy-battles.sh:188</code></td>
+<td>info</td>
+<td><code>stackName</code>, <code>region</code>, <code>teamSlug</code>, <code>problemDir</code></td>
+</tr>
+<tr>
+<td><code>deploy.cfn.deploy.succeeded</code></td>
+<td><code>deploy-battles.sh:210</code></td>
+<td>info</td>
+<td>同上</td>
+</tr>
+<tr>
+<td><code>deploy.cfn.deploy.failed</code></td>
+<td><code>deploy-battles.sh:206</code></td>
+<td>info</td>
+<td>同上</td>
+</tr>
+<tr>
+<td><code>deploy.cfn.delete.start</code></td>
+<td><code>delete-battles.sh:40</code></td>
+<td>info</td>
+<td><code>stackName</code>, <code>region</code></td>
+</tr>
+<tr>
+<td><code>deploy.cfn.delete.succeeded</code></td>
+<td><code>delete-battles.sh:80</code></td>
+<td>info</td>
+<td>同上</td>
+</tr>
+<tr>
+<td><code>deploy.cfn.delete.failed</code></td>
+<td><code>delete-battles.sh:56</code> / <code>:74</code></td>
+<td>info</td>
+<td>同上</td>
+</tr>
+<tr>
+<td><code>deploy.cfn.delete.already_deleted</code></td>
+<td><code>delete-battles.sh:52</code> / <code>:70</code></td>
+<td>info</td>
+<td>同上 (= 冪等 no-op、 stuck 復旧時に便利)</td>
+</tr>
+</tbody></table>
+<p>Shell 経路の <code>correlationId</code> / <code>jobId</code> field は <code>TENKACLOUD_CORRELATION_ID</code> (現状 <code>PROBLEM_EXTERNAL_ID</code> と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。</p>
+<h2>CloudWatch Logs Insights クエリ</h2>
+<h3>A. jobId 1 つで全 phase を時系列に並べる (= 障害 triage の起点)</h3>
+<pre><code>fields @timestamp, @log, event, level, stackName, region, stackStatus, detailType
+| filter jobId = &quot;01KRX...&quot;
+| sort @timestamp asc
+| limit 200
+</code></pre>
+<p><code>@log</code> 列でどの CloudWatch Logs group (= Lambda function / CodeBuild project) かが見える。 Logs Insights は複数 log group を同時 select できるので、 検索対象には次を全部入れる。</p>
+<ul>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-DeployApiFunction*</code> (= startDeployment / requestTeardown)</li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-EventApiFunction*</code> (= bulk-deploy / bulk-delete)</li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-DescribeStackFunction*</code> (= cross-account describe)</li>
+<li><code>/aws/codebuild/&lt;DeployCodeBuildProject&gt;-*</code> (= shell trace_log の出力)</li>
+</ul>
+<h3>B. 失敗だけ抜き出して根本原因を 1 件 1 行で見る</h3>
+<pre><code>fields @timestamp, jobId, event, stackName, region, level
+| filter event like /\.failed$/ or level = &quot;warn&quot; or level = &quot;error&quot;
+| sort @timestamp desc
+| limit 100
+</code></pre>
+<p><code>event</code> の suffix が <code>.failed</code> の行と、 <code>level=warn|error</code> の行をまとめる。 <code>correlationId</code> / <code>jobId</code> を後続クエリの起点に使う。</p>
+<h3>C. 特定 stack の deploy / delete 状況を時系列で 1 ジョブだけ追う</h3>
+<pre><code>fields @timestamp, event, level, stackStatus
+| filter stackName = &quot;tc-&lt;problemId&gt;-&lt;teamSlug&gt;&quot;
+| sort @timestamp asc
+| limit 200
+</code></pre>
+<p><code>describe-stack-handler</code> の出力に <code>stackStatus</code> が乗るので、 CFn の状態遷移と Lambda 側ロジックがズレた時間帯が即見える (= #762 / #758 の調査で使った)。</p>
+<h3>D. cross-account AssumeRole の grace fallback を監視 (= rotation 直後のリスク監視)</h3>
+<pre><code>fields @timestamp, jobId, region, externalIdVersion
+| filter event = &quot;deploy.describe-stack.assume-role.grace-fallback&quot;
+| sort @timestamp desc
+| limit 50
+</code></pre>
+<p>連発しているなら ExternalId rotation 直後の窓に並走している兆候。 増加トレンドは <code>ExternalIdAudit</code> Lambda の metric と相関させる。</p>
+<h2>実装方針 (= 後続 PR で増やすときの拘束)</h2>
+<ol>
+<li><strong>新規 trace event を増やすときは <code>event</code> field を <code>deploy.&lt;phase&gt;.&lt;outcome&gt;</code> 形式で命名する</strong>。 既存名と衝突しないこと。 <code>phase</code> は CloudWatch Logs Insights で <code>like /^deploy\.cfn\./</code> 等の prefix filter を効かせやすいよう dot-separated に保つ。</li>
+<li><strong>必ず <code>jobId</code> (or <code>correlationId</code>) を field に入れる</strong>。 これが無いと jobId 検索 (= 受入条件) で行が落ちる。</li>
+<li><strong>失敗経路は <code>.failed</code> suffix で揃える</strong>。 クエリ B (= 失敗だけ抜く) が安定する。</li>
+<li><strong>shell 側の <code>trace_log</code> 呼び出しは <code>key value key value ...</code> 形式</strong>。 key は <code>[A-Za-z_][A-Za-z0-9_]*</code> のみ。 値は自動で JSON-escape される。</li>
+<li><strong>正規表現 detect されにくい絵文字 / 多言語を field 名に入れない</strong>。 ASCII の camelCase を維持する。</li>
+</ol>
+<h2>関連</h2>
+<ul>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/768">Issue #768</a>: 本機能の起票元</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/733">Issue #733</a>: CloudWatch Dashboard 整備 (= 本 trace と相補)</li>
+<li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>: EventBridge 駆動の state reconciliation 設計 (= 本 trace は同 path 上の観測点を増やす)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/759">Issue #759</a>: SSO 経路の observability gap (= 別 path、 別 PR で同じ trace 思想を再利用)</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/deploy-trace.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/deploy-trace.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/deploy-trace.md
+++ b/docs/operations/deploy-trace.md
@@ -1,0 +1,112 @@
+# Deploy chain trace logging 運用ガイド
+
+[Issue #768](https://github.com/susumutomita/TenkaCloud/issues/768) で導入した end-to-end deploy trace log の使い方。 EventBridge → Step Functions → CodeBuild → Lambda → 競技者 account CloudFormation の長い経路を `jobId` 1 つで横断検索できるようにする。
+
+## 設計の要点
+
+| 項目 | 値 |
+|---|---|
+| log format | JSON 1 行 (= newline-delimited JSON in CloudWatch Logs) |
+| 共通 field | `event` / `level` / `component` / `timestamp` / `jobId` / `correlationId` |
+| `correlationId` の値 | 現状は `jobId` と同値 (= ULID)。将来 retry / fan-out が増えたら独立可能 |
+| Lambda 経路 | `infrastructure/lib/problem-deploy/handlers/shared/trace-log.ts` の `logDeployTrace` / `warnDeployTrace` / `errorDeployTrace` |
+| Shell 経路 | `scripts/lib/battles-common.sh` の `trace_log` (= 同じ JSON shape) |
+| State Machine 経路 | `TENKACLOUD_CORRELATION_ID` env を CodeBuild に渡して shell から再 emit |
+
+## イベント分類
+
+`event` field は `deploy.<phase>.<outcome>` の dot-separated 形式。 横断 grep / Logs Insights filter で各 phase を抜けるように命名している。
+
+### Lambda 境界 (= problem-deploy stack)
+
+| event | 出所 | level | 主な field |
+|---|---|---|---|
+| `deploy.create.enqueued` | `deploy-handler/deploy.ts:startDeployment` | info | `tenantId`, `problemId`, `teamSlug`, `region`, `awsAccountId`, `namePrefix` |
+| `deploy.delete.enqueued` | `deploy-handler/delete.ts:requestTeardown` | info | `tenantId`, `stackName`, `region`, `awsAccountId` |
+| `deploy.eventbridge.publish.succeeded` | `shared/events.ts:publishProblemEvent` | info | `detailType`, `eventBusName`, `resource` |
+| `deploy.describe-stack.start` | `describe-stack-handler/index.ts` | info | `tenantId`, `stackName`, `region`, `hasCompetitorRole` |
+| `deploy.describe-stack.succeeded` | 同上 | info | `stackName`, `region`, `stackStatus`, `stackId` |
+| `deploy.describe-stack.assume-role.grace-fallback` | 同上 | warn | `region`, `externalIdVersion` |
+
+### Shell 境界 (= CodeBuild の deploy-battles.sh / delete-battles.sh)
+
+| event | 出所 | level | 主な field |
+|---|---|---|---|
+| `deploy.codebuild.start` | `deploy-battles.sh:73` / `delete-battles.sh:33` | info | `operation` (= `create` / `delete`), `region`, `teamSlug` |
+| `deploy.codebuild.succeeded` | `deploy-battles.sh:234` / `delete-battles.sh:81` | info | `operation`, `region`, `problemCount` |
+| `deploy.codebuild.failed` | `deploy-battles.sh:238` | info | `operation`, `region`, `failureCount` |
+| `deploy.cfn.deploy.start` | `deploy-battles.sh:188` | info | `stackName`, `region`, `teamSlug`, `problemDir` |
+| `deploy.cfn.deploy.succeeded` | `deploy-battles.sh:210` | info | 同上 |
+| `deploy.cfn.deploy.failed` | `deploy-battles.sh:206` | info | 同上 |
+| `deploy.cfn.delete.start` | `delete-battles.sh:40` | info | `stackName`, `region` |
+| `deploy.cfn.delete.succeeded` | `delete-battles.sh:80` | info | 同上 |
+| `deploy.cfn.delete.failed` | `delete-battles.sh:56` / `:74` | info | 同上 |
+| `deploy.cfn.delete.already_deleted` | `delete-battles.sh:52` / `:70` | info | 同上 (= 冪等 no-op、 stuck 復旧時に便利) |
+
+Shell 経路の `correlationId` / `jobId` field は `TENKACLOUD_CORRELATION_ID` (現状 `PROBLEM_EXTERNAL_ID` と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。
+
+## CloudWatch Logs Insights クエリ
+
+### A. jobId 1 つで全 phase を時系列に並べる (= 障害 triage の起点)
+
+```
+fields @timestamp, @log, event, level, stackName, region, stackStatus, detailType
+| filter jobId = "01KRX..."
+| sort @timestamp asc
+| limit 200
+```
+
+`@log` 列でどの CloudWatch Logs group (= Lambda function / CodeBuild project) かが見える。 Logs Insights は複数 log group を同時 select できるので、 検索対象には次を全部入れる。
+
+- `/aws/lambda/<problem-deploy stack>-DeployApiFunction*` (= startDeployment / requestTeardown)
+- `/aws/lambda/<problem-deploy stack>-EventApiFunction*` (= bulk-deploy / bulk-delete)
+- `/aws/lambda/<problem-deploy stack>-DescribeStackFunction*` (= cross-account describe)
+- `/aws/codebuild/<DeployCodeBuildProject>-*` (= shell trace_log の出力)
+
+### B. 失敗だけ抜き出して根本原因を 1 件 1 行で見る
+
+```
+fields @timestamp, jobId, event, stackName, region, level
+| filter event like /\.failed$/ or level = "warn" or level = "error"
+| sort @timestamp desc
+| limit 100
+```
+
+`event` の suffix が `.failed` の行と、 `level=warn|error` の行をまとめる。 `correlationId` / `jobId` を後続クエリの起点に使う。
+
+### C. 特定 stack の deploy / delete 状況を時系列で 1 ジョブだけ追う
+
+```
+fields @timestamp, event, level, stackStatus
+| filter stackName = "tc-<problemId>-<teamSlug>"
+| sort @timestamp asc
+| limit 200
+```
+
+`describe-stack-handler` の出力に `stackStatus` が乗るので、 CFn の状態遷移と Lambda 側ロジックがズレた時間帯が即見える (= #762 / #758 の調査で使った)。
+
+### D. cross-account AssumeRole の grace fallback を監視 (= rotation 直後のリスク監視)
+
+```
+fields @timestamp, jobId, region, externalIdVersion
+| filter event = "deploy.describe-stack.assume-role.grace-fallback"
+| sort @timestamp desc
+| limit 50
+```
+
+連発しているなら ExternalId rotation 直後の窓に並走している兆候。 増加トレンドは `ExternalIdAudit` Lambda の metric と相関させる。
+
+## 実装方針 (= 後続 PR で増やすときの拘束)
+
+1. **新規 trace event を増やすときは `event` field を `deploy.<phase>.<outcome>` 形式で命名する**。 既存名と衝突しないこと。 `phase` は CloudWatch Logs Insights で `like /^deploy\.cfn\./` 等の prefix filter を効かせやすいよう dot-separated に保つ。
+2. **必ず `jobId` (or `correlationId`) を field に入れる**。 これが無いと jobId 検索 (= 受入条件) で行が落ちる。
+3. **失敗経路は `.failed` suffix で揃える**。 クエリ B (= 失敗だけ抜く) が安定する。
+4. **shell 側の `trace_log` 呼び出しは `key value key value ...` 形式**。 key は `[A-Za-z_][A-Za-z0-9_]*` のみ。 値は自動で JSON-escape される。
+5. **正規表現 detect されにくい絵文字 / 多言語を field 名に入れない**。 ASCII の camelCase を維持する。
+
+## 関連
+
+- [Issue #768](https://github.com/susumutomita/TenkaCloud/issues/768): 本機能の起票元
+- [Issue #733](https://github.com/susumutomita/TenkaCloud/issues/733): CloudWatch Dashboard 整備 (= 本 trace と相補)
+- [ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html): EventBridge 駆動の state reconciliation 設計 (= 本 trace は同 path 上の観測点を増やす)
+- [Issue #759](https://github.com/susumutomita/TenkaCloud/issues/759): SSO 経路の observability gap (= 別 path、 別 PR で同じ trace 思想を再利用)

--- a/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
+++ b/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
@@ -64,6 +64,7 @@ export interface DeployCodeBuildProjectProps {
  *   - `TEAM_SLUG`: 例 `demo-team` (create 時のみ)
  *   - `DELETE_STACK_NAME`: CFn StackName / StackId (delete 時のみ)
  *   - `DELETE_REGION`: delete 対象 region (delete 時のみ)
+ *   - `TENKACLOUD_CORRELATION_ID`: operator trace 用。現状は deploy jobId と同値。
  *
  * 同一 AWS account 内 deploy のみ (MVP-1 制約)。Phase 2 で cross-account になったら
  * IAM Role に `sts:AssumeRole` 等を足す。
@@ -139,6 +140,10 @@ export class DeployCodeBuildProject extends Construct {
           value: Stack.of(this).account,
         },
         PROBLEM_EXTERNAL_ID: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: "",
+        },
+        TENKACLOUD_CORRELATION_ID: {
           type: BuildEnvironmentVariableType.PLAINTEXT,
           value: "",
         },

--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -96,6 +96,7 @@ export class DeployCreateStateMachine extends Construct {
         TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
         DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
         PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+        TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
       },
       resultPath: "$.codebuild",
     });
@@ -111,6 +112,7 @@ export class DeployCreateStateMachine extends Construct {
           TEAM_SLUG: { value: JsonPath.stringAt("$.detail.teamSlug") },
           DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
           PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+          TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           COMPETITOR_ROLE_ARN: {
             value: JsonPath.stringAt("$.detail.competitorRoleArn"),
           },

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -70,6 +70,8 @@ export class DeployDeleteStateMachine extends Construct {
         OPERATION: { value: "delete" },
         DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
         DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+        PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+        TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
       },
       resultPath: "$.codebuild",
     });
@@ -84,6 +86,8 @@ export class DeployDeleteStateMachine extends Construct {
           OPERATION: { value: "delete" },
           DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
           DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+          PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+          TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           COMPETITOR_ROLE_ARN: {
             value: JsonPath.stringAt("$.detail.competitorRoleArn"),
           },

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -5,6 +5,7 @@ import {
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
   publishProblemEvent,
 } from "../shared/events.js";
+import { logDeployTrace } from "../shared/trace-log.js";
 import type { DeploySharedResources } from "./deploy.js";
 import type { DeploymentItem, DeploymentStatus } from "./types.js";
 
@@ -102,6 +103,7 @@ export async function requestTeardown(
 
   const detail: DeployDeleteRequestedDetail = {
     jobId,
+    correlationId: jobId,
     tenantId,
     stackName,
     region,
@@ -116,6 +118,14 @@ export async function requestTeardown(
       detailType: EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
       jobId,
       detail,
+    });
+    logDeployTrace("deploy.delete.enqueued", {
+      jobId,
+      correlationId: jobId,
+      tenantId,
+      stackName,
+      region,
+      awsAccountId,
     });
   } catch (err) {
     // publish 失敗時の compensation: status を FAILED に倒し failureReason を残す。

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -11,6 +11,7 @@ import {
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   publishProblemEvent,
 } from "../shared/events.js";
+import { logDeployTrace } from "../shared/trace-log.js";
 import {
   type PrivateVisibility,
   parseProblemsVisibility,
@@ -170,6 +171,7 @@ export async function startDeployment(
 
   const detail: DeployCreateRequestedDetail = {
     jobId: item.jobId,
+    correlationId: item.jobId,
     tenantId: item.tenantId,
     problemId: item.problemId,
     problemDir,
@@ -214,6 +216,16 @@ export async function startDeployment(
     }
     throw err;
   }
+  logDeployTrace("deploy.create.enqueued", {
+    jobId,
+    correlationId: jobId,
+    tenantId: item.tenantId,
+    problemId: item.problemId,
+    teamSlug,
+    region: item.region,
+    awsAccountId: item.awsAccountId,
+    namePrefix: item.namePrefix,
+  });
 
   return {
     jobId,

--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -2,10 +2,12 @@ import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-clo
 import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import type { Credentials } from "@aws-sdk/client-sts";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import { logDeployTrace, warnDeployTrace } from "../shared/trace-log.js";
 
 export interface DescribeStackStateMachineInput {
   readonly detail?: {
     readonly jobId?: string;
+    readonly correlationId?: string;
     readonly tenantId?: string;
     readonly namePrefix?: string;
     readonly region?: string;
@@ -89,6 +91,12 @@ async function assumeCompetitorRole(
       jobId: params.jobId,
       externalIdVersion: previousVersion,
     });
+    warnDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
+      jobId: params.jobId,
+      correlationId: params.jobId,
+      region: params.region,
+      externalIdVersion: previousVersion,
+    });
     return credentials;
   }
 }
@@ -116,8 +124,17 @@ export async function describeStackForDeployment(
 ) {
   const detail = input.detail ?? {};
   const jobId = requireString(detail.jobId, "detail.jobId");
+  const correlationId = detail.correlationId || jobId;
   const stackName = requireString(detail.namePrefix, "detail.namePrefix");
   const region = requireString(detail.region, "detail.region");
+  logDeployTrace("deploy.describe-stack.start", {
+    jobId,
+    correlationId,
+    tenantId: detail.tenantId,
+    stackName,
+    region,
+    hasCompetitorRole: Boolean(detail.competitorRoleArn),
+  });
   const credentials = await assumeCompetitorRole(deps, {
     region,
     jobId,
@@ -125,7 +142,17 @@ export async function describeStackForDeployment(
     externalIdParameterName: detail.externalIdParameterName,
   });
   const cfn = deps.cfnClient({ region, credentials });
-  return cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+  const out = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+  logDeployTrace("deploy.describe-stack.succeeded", {
+    jobId,
+    correlationId,
+    tenantId: detail.tenantId,
+    stackName,
+    region,
+    stackStatus: out.Stacks?.[0]?.StackStatus,
+    stackId: out.Stacks?.[0]?.StackId,
+  });
+  return out;
 }
 
 const ssm = new SSMClient({});

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -100,6 +100,7 @@ export async function bulkTeardownEvent(
 
       const detail: DeployDeleteRequestedDetail = {
         jobId,
+        correlationId: jobId,
         tenantId,
         stackName,
         region,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -280,6 +280,7 @@ export async function bulkDeployEvent(
       };
       const detail: DeployCreateRequestedDetail = {
         jobId,
+        correlationId: jobId,
         tenantId,
         problemId: problem.problemId,
         problemDir,

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -1,6 +1,7 @@
 import type { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { z } from "zod";
+import { logDeployTrace } from "./trace-log.js";
 
 /**
  * Deploy backend で流れる EventBridge イベントの定義。
@@ -31,6 +32,7 @@ export const COMPETITOR_ROLE_NAME_DEFAULT = "TenkaCloud-CompetitorDeploy-Role" a
  */
 export const DeployCreateRequestedDetailSchema = z.object({
   jobId: z.string().min(1),
+  correlationId: z.string().min(1).optional(),
   tenantId: z.string().min(1),
   problemId: z.string().regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/),
   problemDir: z.string().regex(/^problems\/[a-z0-9-]+\/[a-z0-9-]+$/),
@@ -73,6 +75,7 @@ export type DeployCreateRequestedDetail = z.infer<typeof DeployCreateRequestedDe
  */
 export const DeployDeleteRequestedDetailSchema = z.object({
   jobId: z.string().min(1),
+  correlationId: z.string().min(1).optional(),
   tenantId: z.string().min(1),
   stackName: z.string().min(1),
   region: z.string().regex(/^[a-z]{2}-[a-z]+-\d+$/),
@@ -107,6 +110,11 @@ export async function publishProblemEvent(args: {
   jobId: string;
   detail: Record<string, unknown>;
 }): Promise<void> {
+  const correlationId =
+    typeof args.detail.correlationId === "string" && args.detail.correlationId.length > 0
+      ? args.detail.correlationId
+      : args.jobId;
+  const resource = `tenkacloud:deployment:${args.jobId}`;
   const out = await args.client.send(
     new PutEventsCommand({
       Entries: [
@@ -115,12 +123,21 @@ export async function publishProblemEvent(args: {
           Source: EVENT_SOURCE,
           DetailType: args.detailType,
           Detail: JSON.stringify(args.detail),
-          Resources: [`tenkacloud:deployment:${args.jobId}`],
+          Resources: [resource],
         },
       ],
     }),
   );
-  if ((out.FailedEntryCount ?? 0) === 0) return;
+  if ((out.FailedEntryCount ?? 0) === 0) {
+    logDeployTrace("deploy.eventbridge.publish.succeeded", {
+      jobId: args.jobId,
+      correlationId,
+      detailType: args.detailType,
+      eventBusName: args.busName,
+      resource,
+    });
+    return;
+  }
   const failed = out.Entries?.[0];
   throw new ProblemEventPublishError(
     args.detailType,

--- a/infrastructure/lib/problem-deploy/handlers/shared/trace-log.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/trace-log.ts
@@ -1,0 +1,34 @@
+type TraceFields = Readonly<Record<string, unknown>>;
+
+function cleanFields(fields: TraceFields): TraceFields {
+  return Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined));
+}
+
+function writeTrace(
+  writer: (message?: unknown, ...optionalParams: unknown[]) => void,
+  level: "info" | "warn" | "error",
+  event: string,
+  fields: TraceFields,
+): void {
+  writer(
+    JSON.stringify({
+      event,
+      level,
+      component: "problem-deploy",
+      timestamp: new Date().toISOString(),
+      ...cleanFields(fields),
+    }),
+  );
+}
+
+export function logDeployTrace(event: string, fields: TraceFields = {}): void {
+  writeTrace(console.log, "info", event, fields);
+}
+
+export function warnDeployTrace(event: string, fields: TraceFields = {}): void {
+  writeTrace(console.warn, "warn", event, fields);
+}
+
+export function errorDeployTrace(event: string, fields: TraceFields = {}): void {
+  writeTrace(console.error, "error", event, fields);
+}

--- a/infrastructure/test/problem-deploy/trace-log.test.ts
+++ b/infrastructure/test/problem-deploy/trace-log.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  errorDeployTrace,
+  logDeployTrace,
+  warnDeployTrace,
+} from "../../lib/problem-deploy/handlers/shared/trace-log";
+
+describe("trace-log helpers", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("logDeployTrace は JSON 1 行で event / level=info / component=problem-deploy / timestamp を出力するべき", () => {
+    logDeployTrace("deploy.create.enqueued", { jobId: "01ABC", correlationId: "01ABC" });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+    expect(payload.event).toBe("deploy.create.enqueued");
+    expect(payload.level).toBe("info");
+    expect(payload.component).toBe("problem-deploy");
+    expect(typeof payload.timestamp).toBe("string");
+    expect(payload.jobId).toBe("01ABC");
+    expect(payload.correlationId).toBe("01ABC");
+  });
+
+  it("warnDeployTrace は level=warn を吐くべき (= grace-fallback 等の通知用)", () => {
+    warnDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
+      jobId: "01XYZ",
+      externalIdVersion: 3,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(warnSpy.mock.calls[0]?.[0] as string);
+    expect(payload.level).toBe("warn");
+    expect(payload.externalIdVersion).toBe(3);
+  });
+
+  it("errorDeployTrace は level=error を吐くべき", () => {
+    errorDeployTrace("deploy.cfn.deploy.failed", { jobId: "01ZZZ" });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    expect(payload.level).toBe("error");
+  });
+
+  it("undefined な field は出力 JSON から除外すべき (= log size 節約 + Logs Insights の column 汚染防止)", () => {
+    logDeployTrace("deploy.test", {
+      jobId: "01ABC",
+      optional: undefined,
+      defined: "value",
+    });
+    const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+    expect(payload).not.toHaveProperty("optional");
+    expect(payload.defined).toBe("value");
+  });
+
+  it("fields 引数を省略しても crash せず最小 JSON を出すべき", () => {
+    logDeployTrace("deploy.healthz");
+    const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+    expect(payload.event).toBe("deploy.healthz");
+    expect(payload.level).toBe("info");
+  });
+
+  it("timestamp は ISO 8601 文字列で再 parse 可能であるべき", () => {
+    logDeployTrace("deploy.test");
+    const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+    const parsed = new Date(payload.timestamp);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+  });
+
+  it("net JSON はパース可能で多重 quote / newline を破壊しないべき", () => {
+    logDeployTrace("deploy.eventbridge.publish.succeeded", {
+      detailType: 'DeployCreate"Requested',
+      resource: "line1\nline2",
+    });
+    const raw = logSpy.mock.calls[0]?.[0] as string;
+    expect(() => JSON.parse(raw)).not.toThrow();
+    const payload = JSON.parse(raw);
+    expect(payload.detailType).toBe('DeployCreate"Requested');
+    expect(payload.resource).toBe("line1\nline2");
+  });
+});

--- a/scripts/delete-battles.sh
+++ b/scripts/delete-battles.sh
@@ -30,12 +30,14 @@ REGION="${2:-$(resolve_aws_region)}"
 # DEPLOY_REGION も export し直す (delete でも target region を AssumeRole 後に固定する)。
 export DEPLOY_REGION="${REGION}"
 assume_competitor_role_if_configured
+trace_log "deploy.codebuild.start" operation "delete" region "${REGION}" stackName "${STACK_NAME}"
 
 echo "=========================================="
 echo "Deleting stack"
 echo "  StackName : ${STACK_NAME}"
 echo "  Region    : ${REGION}"
 echo "=========================================="
+trace_log "deploy.cfn.delete.start" stackName "${STACK_NAME}" region "${REGION}"
 
 # DeleteStack 自体が冪等 (削除済み stack に対して呼んでも ValidationError を返すだけで
 # 既存リソースに影響なし)。pre-check の describe-stacks は TOCTOU race を生む (= check と
@@ -47,9 +49,11 @@ delete_err="$(
     --stack-name "${STACK_NAME}" 2>&1
 )" || {
   if grep -qiE "ValidationError|does not exist" <<<"${delete_err}"; then
+    trace_log "deploy.cfn.delete.already_deleted" stackName "${STACK_NAME}" region "${REGION}"
     echo "Stack ${STACK_NAME} は既に存在しない (already deleted) → no-op で終了"
     exit 0
   fi
+  trace_log "deploy.cfn.delete.failed" stackName "${STACK_NAME}" region "${REGION}"
   echo "error: delete-stack failed (auth/throttle/network 等を疑う): ${delete_err}" >&2
   exit 1
 }
@@ -63,12 +67,16 @@ wait_err="$(
     --stack-name "${STACK_NAME}" 2>&1
 )" || {
   if grep -qiE "ValidationError|does not exist" <<<"${wait_err}"; then
+    trace_log "deploy.cfn.delete.already_deleted" stackName "${STACK_NAME}" region "${REGION}"
     echo "Stack ${STACK_NAME} は既に削除済 (wait の前に消えた) → no-op で終了"
     exit 0
   fi
+  trace_log "deploy.cfn.delete.failed" stackName "${STACK_NAME}" region "${REGION}"
   echo "error: wait stack-delete-complete failed: ${wait_err}" >&2
   exit 1
 }
 
 echo ""
+trace_log "deploy.cfn.delete.succeeded" stackName "${STACK_NAME}" region "${REGION}"
+trace_log "deploy.codebuild.succeeded" operation "delete" region "${REGION}" stackName "${STACK_NAME}"
 echo "Stack ${STACK_NAME} deleted (region=${REGION})."

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -70,6 +70,7 @@ export TENKACLOUD_ACCOUNT_ID
 assume_competitor_role_if_configured
 
 AWS_REGION="$(resolve_aws_region)"
+trace_log "deploy.codebuild.start" operation "create" region "${AWS_REGION}" teamSlug "${TEAM_SLUG}" problemCount "$#"
 
 # metadata.json の cfnParameters を `Key=Value` 形式の配列に展開する。`__RANDOM_PASSWORD__`
 # トークンは 32 桁ランダム英数字に置換 (DbPassword 等の secret 用途)。`NamePrefix` は
@@ -184,6 +185,7 @@ deploy_one() {
   echo "  TeamSlug  : ${TEAM_SLUG}"
   echo "  Parameters: ${#parameter_overrides[@]} item(s) (NamePrefix + TenkaCloudAccountId + ExternalId + cfnParameters)"
   echo "=========================================="
+  trace_log "deploy.cfn.deploy.start" stackName "${name_prefix}" region "${AWS_REGION}" teamSlug "${TEAM_SLUG}" problemDir "${problem_dir}"
 
   # `aws cloudformation deploy` は CreateStack / UpdateStack を冪等に扱う:
   #   - stack が無ければ Create
@@ -201,9 +203,11 @@ deploy_one() {
       "TenkaCloud:Problem=${problem_slug}" \
       "TenkaCloud:TeamSlug=${TEAM_SLUG}" \
       "TenkaCloud:DeployedBy=deploy-battles.sh"; then
+    trace_log "deploy.cfn.deploy.failed" stackName "${name_prefix}" region "${AWS_REGION}" teamSlug "${TEAM_SLUG}" problemDir "${problem_dir}"
     echo "error: CloudFormation deploy failed for ${name_prefix}" >&2
     return 1
   fi
+  trace_log "deploy.cfn.deploy.succeeded" stackName "${name_prefix}" region "${AWS_REGION}" teamSlug "${TEAM_SLUG}" problemDir "${problem_dir}"
 
   # outputs を表示 (FrontendUrl 等が見える)
   echo ""
@@ -227,9 +231,11 @@ done
 echo ""
 echo "=========================================="
 if [[ ${#failures[@]} -eq 0 ]]; then
+  trace_log "deploy.codebuild.succeeded" operation "create" region "${AWS_REGION}" problemCount "$#"
   echo "All $# deploy(s) succeeded."
   exit 0
 else
+  trace_log "deploy.codebuild.failed" operation "create" region "${AWS_REGION}" failureCount "${#failures[@]}" problemCount "$#"
   echo "Failed deploys (${#failures[@]} of $#):"
   for f in "${failures[@]}"; do
     echo "  - ${f}"

--- a/scripts/lib/battles-common.sh
+++ b/scripts/lib/battles-common.sh
@@ -27,6 +27,34 @@ resolve_aws_region() {
   echo "${region}"
 }
 
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '%s' "${value}"
+}
+
+trace_log() {
+  local event="$1"
+  shift || true
+  local correlation_id="${TENKACLOUD_CORRELATION_ID:-${PROBLEM_EXTERNAL_ID:-}}"
+  local job_id="${PROBLEM_EXTERNAL_ID:-${TENKACLOUD_CORRELATION_ID:-}}"
+  local json
+  json="{\"event\":\"$(json_escape "${event}")\",\"level\":\"info\",\"component\":\"deploy-codebuild\",\"correlationId\":\"$(json_escape "${correlation_id}")\",\"jobId\":\"$(json_escape "${job_id}")\""
+  while [[ $# -ge 2 ]]; do
+    local key="$1"
+    local value="$2"
+    shift 2
+    if [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      json="${json},\"${key}\":\"$(json_escape "${value}")\""
+    fi
+  done
+  printf '%s}\n' "${json}"
+}
+
 # Phase 2.2 (Issue #459) cross-account AssumeRole helper。
 #
 # `COMPETITOR_ROLE_ARN` env が空でなければ:


### PR DESCRIPTION
## Summary

[Issue #768](https://github.com/susumutomita/TenkaCloud/issues/768) (P0 / observability) の実装。 deploy / delete chain (= EventBridge → Step Functions → CodeBuild → Lambda → 競技者 account CloudFormation) を **`jobId` 1 つで横断検索** できる end-to-end trace logging を入れる。

WIP として local working tree に残っていた skeleton を引き継ぎ、 main の最新 (`5dbe325` CFn stuck diagnosis + `91e6597` chaos test) に rebase + conflict 解消した上で、 受入条件にあった「CloudWatch Logs Insights query テンプレ追加 + docs 化」 を完成させた。

## 主な追加

| 種別 | path | 内容 |
|---|---|---|
| 新規 | \`infrastructure/lib/problem-deploy/handlers/shared/trace-log.ts\` | Lambda 側 JSON 1 行 trace helper (\`logDeployTrace\` / \`warnDeployTrace\` / \`errorDeployTrace\`) |
| 新規 | \`scripts/lib/battles-common.sh\` の \`trace_log\` | shell 側の同等 helper。 \`key value key value ...\` 引数で受け JSON 出力 |
| 新規 | \`infrastructure/test/problem-deploy/trace-log.test.ts\` | trace-log.ts の unit test 7 件 |
| 新規 | \`docs/operations/deploy-trace.md\` + \`.html\` | event taxonomy / 共通 field / Logs Insights クエリ 4 種 / 後続 PR の拘束 |
| UPDATE | \`shared/events.ts\` | \`DeployCreate/DeleteRequestedDetailSchema\` に optional \`correlationId\` 追加、 \`publishProblemEvent\` 成功時に \`deploy.eventbridge.publish.succeeded\` を emit |
| UPDATE | \`deploy-handler/{deploy,delete}.ts\` | publish 成功後に \`deploy.create.enqueued\` / \`deploy.delete.enqueued\` を emit |
| UPDATE | \`describe-stack-handler/index.ts\` | \`deploy.describe-stack.start\` / \`succeeded\` / \`assume-role.grace-fallback\` 3 イベント emit |
| UPDATE | \`event-handler/bulk-{deploy,delete}.ts\` | bulk 経路の detail にも \`correlationId = jobId\` を詰める |
| UPDATE | \`deploy-{create,delete}-state-machine.ts\` + \`deploy-codebuild-project.ts\` | CodeBuild env override に \`TENKACLOUD_CORRELATION_ID\` 追加、 delete 側には \`PROBLEM_EXTERNAL_ID\` も追加 |
| UPDATE | \`scripts/{deploy,delete}-battles.sh\` | \`trace_log\` を 9 箇所に挿入 (codebuild.start / succeeded / failed、 cfn.deploy.* / cfn.delete.*) |

## イベント分類

\`event\` field は \`deploy.<phase>.<outcome>\` の dot-separated 形式で命名。 横断 grep / Logs Insights prefix filter (\`like /^deploy\\.cfn\\./\` 等) で各 phase を抜けるようにする。 詳細は [\`docs/operations/deploy-trace.md\`](./docs/operations/deploy-trace.md) の表を参照。

\`correlationId\` は現状 \`jobId\` と同値 (= ULID) で transport する。 retry / fan-out で独立させたい局面が出てきたら schema は既に \`optional string\` で受け入れる形に拡張済。

## Logs Insights テンプレ (docs より抜粋)

### A. jobId 1 つで全 phase を時系列に並べる

\` \` \`
fields @timestamp, @log, event, level, stackName, region, stackStatus, detailType
| filter jobId = \"01KRX...\"
| sort @timestamp asc
| limit 200
\` \` \`

検索対象 log group:
- \`/aws/lambda/<problem-deploy stack>-DeployApiFunction*\` (= startDeployment / requestTeardown)
- \`/aws/lambda/<problem-deploy stack>-EventApiFunction*\` (= bulk-deploy / bulk-delete)
- \`/aws/lambda/<problem-deploy stack>-DescribeStackFunction*\` (= cross-account describe)
- \`/aws/codebuild/<DeployCodeBuildProject>-*\` (= shell trace_log の出力)

B (= 失敗だけ抜く) / C (= stack 単位) / D (= grace-fallback 監視) も docs に同形式で記載。

## Test plan

- [x] \`bunx vitest run\` (infrastructure) — 79 file / **797 件 pass**
- [x] \`bunx vitest run test/problem-deploy/trace-log.test.ts\` — trace-log 単体 **7 件 pass**
- [x] \`bunx tsc --noEmit\` (infrastructure) — clean
- [x] \`bunx biome check .claude/harness/src .claude/harness/bin infrastructure/lib/problem-deploy infrastructure/test/problem-deploy/trace-log.test.ts\` — clean
- [x] \`bunx markdownlint-cli2 docs/operations/deploy-trace.md\` — clean
- [x] \`bunx textlint docs/operations/deploy-trace.md\` — clean
- [ ] reviewer: merge + deploy 後、 1 件 deploy → Logs Insights クエリ A で全 phase の row が時系列に並ぶこと
- [ ] reviewer: 1 件 delete → \`deploy.cfn.delete.*\` が emit され、 stuck 復旧時の冪等経路 (\`already_deleted\`) も正しく log されること

## Regression 分析

- \`correlationId\` は schema 上 **optional** なので、 旧 detail shape (= correlationId 無し) の caller / 過去 EventBridge 在庫 event も throw せず通る。 確認方法: events.test.ts + bulk-deploy.test.ts (= 既存) で旧 shape を含む fixture が green
- 既存 \`publishProblemEvent\` の throw 動作 (= \`FailedEntryCount > 0\` で \`ProblemEventPublishError\`) は維持。 trace log は成功 path のみで emit (= 失敗 path では throw 先行で log に到達しない)。 conflict が events.ts で出た部分は throw と trace log を共存させる形で解消
- \`TENKACLOUD_CORRELATION_ID\` env は CodeBuild project 側で default 空文字を埋めてある (= state machine から override しない経路でも buildspec が crash しない)。 deploy-codebuild-project.ts:143 参照
- shell \`trace_log\` の \`json_escape\` は backslash / quote / 制御文字 (\`\\n\` / \`\\r\` / \`\\t\`) を escape。 \`JSON.parse\` 可能を unit test (trace-log.test.ts) で pin
- 旧 \`(\\ s|^)\$\\(.*\\.failed\$/\` のような既存 grep monitor (= 無い) と衝突しない命名にした。 後続 PR で event を増やす拘束は docs に明記
- harness rule (= adr-must-be-html / adr-self-contained) は本 PR の docs / source に違反しない (\`make harness\` no findings)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | \`tenkacloud-problem-deploy\` stack | DeployCreate/Delete State Machine の \`environmentVariablesOverride\` に env 1〜2 個追加。 DeployCodeBuildProject の environment に env 1 個追加。 Lambda function bundle (= deploy-handler / event-handler / describe-stack-handler / shared) に trace-log import が増える |
| NO-OP | IAM / Cognito / EventBridge bus / API Gateway / DDB / Step Functions の構造 | 設定変更なし |
| NO-OP | \`apps/*/dist/\` | frontend 修正なし |
| CREATE | \`docs/operations/deploy-trace.md\` + \`.html\` | 運用ガイド |

## 関連

- Closes #768
- 補完関係: [#733](https://github.com/susumutomita/TenkaCloud/issues/733) (CloudWatch Dashboard) / [ADR-014](./docs/architecture/adr-014-eventbridge-driven-state-reconciliation.html) (EventBridge 駆動 state reconciliation)
- 別 path で同思想を再利用予定: [#759](https://github.com/susumutomita/TenkaCloud/issues/759) (SSO observability gap) — 別 PR で対応
- ADR convention: PR-#770 で導入した \`adr-self-contained\` / \`adr-must-be-html\` rule に違反しないことを確認済

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive deployment trace logging operations guide with CloudWatch Logs Insights queries and structured event documentation for end-to-end deployment tracking.

* **Chores**
  * Enhanced deployment pipeline with improved trace logging infrastructure to provide better operational visibility and streamline failure diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/782)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->