### PR TITLE
fix(#759): SSO not_ready 6 経路に structured log — observability gap 解消

### DIFF
--- a/docs/operations/deploy-trace.html
+++ b/docs/operations/deploy-trace.html
@@ -202,6 +202,54 @@
 </tr>
 </tbody></table>
 <p>Shell 経路の <code>correlationId</code> / <code>jobId</code> field は <code>TENKACLOUD_CORRELATION_ID</code> (現状 <code>PROBLEM_EXTERNAL_ID</code> と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。</p>
+<h3>Participant Portal SSO 境界 (= Issue #759)</h3>
+<table>
+<thead>
+<tr>
+<th>event</th>
+<th>出所</th>
+<th>level</th>
+<th>主な field</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>portal.sso.not_ready.in_progress</code></td>
+<td><code>participant-handler/sso.ts</code> (= status IN_PROGRESS / PENDING)</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>status</code></td>
+</tr>
+<tr>
+<td><code>portal.sso.not_ready.namePrefix_missing</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>status</code></td>
+</tr>
+<tr>
+<td><code>portal.sso.not_ready.region_missing</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>status</code></td>
+</tr>
+<tr>
+<td><code>portal.sso.not_ready.tenantId_missing</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>status</code></td>
+</tr>
+<tr>
+<td><code>portal.sso.not_ready.competitorRoleArn_missing</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>tenantId</code></td>
+</tr>
+<tr>
+<td><code>portal.sso.not_ready.participantViewerRole_missing</code></td>
+<td>同上</td>
+<td>info</td>
+<td><code>jobId</code>, <code>problemId</code>, <code>tenantId</code>, <code>outputKeys</code> (= 世代不一致即特定用に CFn Outputs の他 key 一覧)</td>
+</tr>
+</tbody></table>
+<p>SSO の <code>not_ready</code> 6 経路は旧実装ではすべてサイレントで、 operator が DDB item を引いて目視確認するしかなかった。 #759 で各 gate に structured log を 1 件 emit するようにし、 Insights query E (下記) で 1 引きに切り分け可能にした。</p>
 <h2>CloudWatch Logs Insights クエリ</h2>
 <h3>A. jobId 1 つで全 phase を時系列に並べる (= 障害 triage の起点)</h3>
 <pre><code>fields @timestamp, @log, event, level, stackName, region, stackStatus, detailType
@@ -237,6 +285,13 @@
 | limit 50
 </code></pre>
 <p>連発しているなら ExternalId rotation 直後の窓に並走している兆候。 増加トレンドは <code>ExternalIdAudit</code> Lambda の metric と相関させる。</p>
+<h3>E. SSO <code>not_ready</code> がどの gate で落ちたかを 1 引きで切り分け (= Issue #759)</h3>
+<pre><code>fields @timestamp, jobId, problemId, event, status, tenantId, outputKeys
+| filter event like /^portal\.sso\.not_ready\./
+| sort @timestamp desc
+| limit 100
+</code></pre>
+<p>特定 jobId に絞るときは <code>filter jobId = &quot;01KRX...&quot;</code> を AND 結合する。 <code>portal.sso.not_ready.participantViewerRole_missing</code> の <code>outputKeys</code> field を見ると、 問題 template が古い世代 (= <code>ParticipantViewerRoleArn</code> Output 不在) かどうかが他 outputs の有無で即判定できる。</p>
 <h2>実装方針 (= 後続 PR で増やすときの拘束)</h2>
 <ol>
 <li><strong>新規 trace event を増やすときは <code>event</code> field を <code>deploy.&lt;phase&gt;.&lt;outcome&gt;</code> 形式で命名する</strong>。 既存名と衝突しないこと。 <code>phase</code> は CloudWatch Logs Insights で <code>like /^deploy\.cfn\./</code> 等の prefix filter を効かせやすいよう dot-separated に保つ。</li>

--- a/docs/operations/deploy-trace.md
+++ b/docs/operations/deploy-trace.md
@@ -45,6 +45,19 @@
 
 Shell 経路の `correlationId` / `jobId` field は `TENKACLOUD_CORRELATION_ID` (現状 `PROBLEM_EXTERNAL_ID` と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。
 
+### Participant Portal SSO 境界 (= Issue #759)
+
+| event | 出所 | level | 主な field |
+|---|---|---|---|
+| `portal.sso.not_ready.in_progress` | `participant-handler/sso.ts` (= status IN_PROGRESS / PENDING) | info | `jobId`, `problemId`, `status` |
+| `portal.sso.not_ready.namePrefix_missing` | 同上 | info | `jobId`, `problemId`, `status` |
+| `portal.sso.not_ready.region_missing` | 同上 | info | `jobId`, `problemId`, `status` |
+| `portal.sso.not_ready.tenantId_missing` | 同上 | info | `jobId`, `problemId`, `status` |
+| `portal.sso.not_ready.competitorRoleArn_missing` | 同上 | info | `jobId`, `problemId`, `tenantId` |
+| `portal.sso.not_ready.participantViewerRole_missing` | 同上 | info | `jobId`, `problemId`, `tenantId`, `outputKeys` (= 世代不一致即特定用に CFn Outputs の他 key 一覧) |
+
+SSO の `not_ready` 6 経路は旧実装ではすべてサイレントで、 operator が DDB item を引いて目視確認するしかなかった。 #759 で各 gate に structured log を 1 件 emit するようにし、 Insights query E (下記) で 1 引きに切り分け可能にした。
+
 ## CloudWatch Logs Insights クエリ
 
 ### A. jobId 1 つで全 phase を時系列に並べる (= 障害 triage の起点)
@@ -95,6 +108,17 @@ fields @timestamp, jobId, region, externalIdVersion
 ```
 
 連発しているなら ExternalId rotation 直後の窓に並走している兆候。 増加トレンドは `ExternalIdAudit` Lambda の metric と相関させる。
+
+### E. SSO `not_ready` がどの gate で落ちたかを 1 引きで切り分け (= Issue #759)
+
+```
+fields @timestamp, jobId, problemId, event, status, tenantId, outputKeys
+| filter event like /^portal\.sso\.not_ready\./
+| sort @timestamp desc
+| limit 100
+```
+
+特定 jobId に絞るときは `filter jobId = "01KRX..."` を AND 結合する。 `portal.sso.not_ready.participantViewerRole_missing` の `outputKeys` field を見ると、 問題 template が古い世代 (= `ParticipantViewerRoleArn` Output 不在) かどうかが他 outputs の有無で即判定できる。
 
 ## 実装方針 (= 後続 PR で増やすときの拘束)
 

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -3,6 +3,7 @@ import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.j
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import { DELETED_LIKE_STATUSES, ULID_RE } from "../shared/constants.js";
 import { getExternalId } from "../shared/external-id-store.js";
+import { logDeployTrace } from "../shared/trace-log.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
@@ -77,18 +78,55 @@ export async function getConsoleSigninUrl(
   if (!deployment) return { kind: "unauthorized" };
 
   const status = (deployment.status ?? "PENDING") as DeploymentStatus;
+  const problemId = typeof deployment.problemId === "string" ? deployment.problemId : undefined;
   if (DELETED_LIKE_STATUSES.has(status)) return { kind: "unauthorized" };
-  if (status === "IN_PROGRESS" || status === "PENDING") return { kind: "not_ready" };
-  if (typeof deployment.namePrefix !== "string") return { kind: "not_ready" };
+
+  // Issue #759: 各 not_ready 経路で structured log を 1 件 emit する。
+  // CloudWatch Logs Insights:
+  //   `filter event like /^portal\.sso\.not_ready\./ | sort @timestamp desc`
+  // で どの gate で死んだか 1 引きで切り分け可能にする。 旧実装は全 6 経路がサイレントで、
+  // operator が deployment item を引いて目視確認するしかなかった (= #756 調査で実体験)。
+  if (status === "IN_PROGRESS" || status === "PENDING") {
+    logDeployTrace("portal.sso.not_ready.in_progress", { jobId, problemId, status });
+    return { kind: "not_ready" };
+  }
+  if (typeof deployment.namePrefix !== "string") {
+    logDeployTrace("portal.sso.not_ready.namePrefix_missing", { jobId, problemId, status });
+    return { kind: "not_ready" };
+  }
   const region = typeof deployment.region === "string" ? deployment.region : undefined;
-  if (!region) return { kind: "not_ready" };
+  if (!region) {
+    logDeployTrace("portal.sso.not_ready.region_missing", { jobId, problemId, status });
+    return { kind: "not_ready" };
+  }
   const tenantId = typeof deployment.tenantId === "string" ? deployment.tenantId : undefined;
-  if (!tenantId) return { kind: "not_ready" };
+  if (!tenantId) {
+    logDeployTrace("portal.sso.not_ready.tenantId_missing", { jobId, problemId, status });
+    return { kind: "not_ready" };
+  }
   const competitorRoleArn =
     typeof deployment.competitorRoleArn === "string" ? deployment.competitorRoleArn : undefined;
-  if (!competitorRoleArn) return { kind: "not_ready" };
-  const participantRoleArn = parseStackOutputs(deployment.stackOutputs).ParticipantViewerRoleArn;
-  if (!participantRoleArn) return { kind: "not_ready" };
+  if (!competitorRoleArn) {
+    logDeployTrace("portal.sso.not_ready.competitorRoleArn_missing", {
+      jobId,
+      problemId,
+      tenantId,
+    });
+    return { kind: "not_ready" };
+  }
+  const parsedOutputs = parseStackOutputs(deployment.stackOutputs);
+  const participantRoleArn = parsedOutputs.ParticipantViewerRoleArn;
+  if (!participantRoleArn) {
+    // 世代不一致 (= problem template が ParticipantViewerRole を持つ世代より古い) の
+    // 切り分けを 1 引きで可能にするため、 stack outputs の他 key 一覧を log に残す。
+    logDeployTrace("portal.sso.not_ready.participantViewerRole_missing", {
+      jobId,
+      problemId,
+      tenantId,
+      outputKeys: Object.keys(parsedOutputs),
+    });
+    return { kind: "not_ready" };
+  }
   if (!shared.ssm || !shared.env) {
     console.error("[sso] ExternalId store is not configured", { jobId, tenantId });
     return { kind: "assume_role_failed", reason: "ExternalId store is not configured" };

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -305,3 +305,162 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "federation_token_malformed" });
   });
 });
+
+/**
+ * Issue #759: 各 not_ready 経路は structured log を 1 件 emit すべき。
+ * CloudWatch Logs Insights `filter event like /^portal\.sso\.not_ready\./` で
+ * どの gate で死んだか 1 引きで切り分け可能にする受入条件。
+ */
+describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () => {
+  const logSpy = vi.spyOn(console, "log");
+
+  beforeEach(() => {
+    stsSend.mockReset();
+    ssmSend.mockReset();
+    stsClientConfigs.length = 0;
+    logSpy.mockReset();
+    logSpy.mockImplementation(() => undefined);
+  });
+
+  afterEach(() => logSpy.mockReset());
+
+  function findEvent(name: string): Record<string, unknown> | undefined {
+    for (const call of logSpy.mock.calls) {
+      const raw = call[0];
+      if (typeof raw !== "string") continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      if (parsed && typeof parsed === "object" && (parsed as { event?: unknown }).event === name) {
+        return parsed as Record<string, unknown>;
+      }
+    }
+    return undefined;
+  }
+
+  it("IN_PROGRESS の deployment で portal.sso.not_ready.in_progress を info log すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "IN_PROGRESS" })] });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.in_progress");
+    expect(payload).toBeDefined();
+    expect(payload?.level).toBe("info");
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+    expect(payload?.problemId).toBe("security-battle-royale");
+    expect(payload?.status).toBe("IN_PROGRESS");
+  });
+
+  it("namePrefix 未設定で portal.sso.not_ready.namePrefix_missing を info log すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ namePrefix: undefined, status: "COMPLETE" })],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.namePrefix_missing");
+    expect(payload).toBeDefined();
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+  });
+
+  it("region 未設定で portal.sso.not_ready.region_missing を info log すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ region: undefined })],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.region_missing");
+    expect(payload).toBeDefined();
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+  });
+
+  it("tenantId 未設定で portal.sso.not_ready.tenantId_missing を info log すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ tenantId: undefined })],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.tenantId_missing");
+    expect(payload).toBeDefined();
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+  });
+
+  it("competitorRoleArn 未設定で portal.sso.not_ready.competitorRoleArn_missing を info log すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ competitorRoleArn: undefined })],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.competitorRoleArn_missing");
+    expect(payload).toBeDefined();
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+    expect(payload?.tenantId).toBe("tenant-acme");
+  });
+
+  it("ParticipantViewerRoleArn 不在で outputKeys を含む info log を emit すべき (世代不一致の即特定)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          stackOutputs: JSON.stringify({
+            BaseUrl: "http://example.com",
+            NamePrefix: "tc-foo-bar",
+          }),
+        }),
+      ],
+    });
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result).toEqual({ kind: "not_ready" });
+    const payload = findEvent("portal.sso.not_ready.participantViewerRole_missing");
+    expect(payload).toBeDefined();
+    expect(payload?.jobId).toBe(VALID_JOB_ID);
+    expect(payload?.outputKeys).toEqual(expect.arrayContaining(["BaseUrl", "NamePrefix"]));
+    expect(payload?.outputKeys).not.toContain("ParticipantViewerRoleArn");
+  });
+
+  it("成功経路では not_ready log は 1 件も emit しないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIADEPLOY",
+        SecretAccessKey: "DEPLOYSECRET",
+        SessionToken: "DEPLOYTOKEN",
+        Expiration: new Date(),
+      },
+    });
+    stsSend.mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIAFAKE",
+        SecretAccessKey: "SECRETFAKE",
+        SessionToken: "TOKENFAKE",
+        Expiration: new Date(),
+      },
+    });
+    const fetchSpy2 = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ SigninToken: "TOKEN" }), { status: 200 }),
+      );
+    const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
+    expect(result.kind).toBe("ok");
+    const notReadyEvents = logSpy.mock.calls.filter((c) => {
+      const raw = c[0];
+      if (typeof raw !== "string") return false;
+      try {
+        const parsed = JSON.parse(raw) as { event?: string };
+        return typeof parsed.event === "string" && parsed.event.startsWith("portal.sso.not_ready.");
+      } catch {
+        return false;
+      }
+    });
+    expect(notReadyEvents).toHaveLength(0);
+    fetchSpy2.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

[Issue #759](https://github.com/susumutomita/TenkaCloud/issues/759) (= SSO `not_ready` 6 経路がサイレント、 CloudWatch にどの gate で死んだか出ない) の解消。

旧実装は `getConsoleSigninUrl` の 6 個の `return { kind: \"not_ready\" }` 経路が全部 console 出力ナシで、 operator が deployment item を引いて目視確認するしかなかった (= 実際 #756 / #762 の SSO not_ready 調査で sso bundle を unzip して return 順を復元する羽目になった経験あり)。 PR-#782 で追加した \`logDeployTrace\` (= structured JSON、 level / event / timestamp / fields) に乗せて 1 引きで切り分け可能にする。

## 追加 log event

| event | gate | 主な fields |
|---|---|---|
| \`portal.sso.not_ready.in_progress\` | status IN_PROGRESS / PENDING | jobId, problemId, status |
| \`portal.sso.not_ready.namePrefix_missing\` | namePrefix が string でない | jobId, problemId, status |
| \`portal.sso.not_ready.region_missing\` | region が string でない | jobId, problemId, status |
| \`portal.sso.not_ready.tenantId_missing\` | tenantId が string でない | jobId, problemId, status |
| \`portal.sso.not_ready.competitorRoleArn_missing\` | competitorRoleArn が string でない | jobId, problemId, tenantId |
| \`portal.sso.not_ready.participantViewerRole_missing\` | stackOutputs.ParticipantViewerRoleArn 不在 (= 世代不一致の典型) | jobId, problemId, tenantId, **outputKeys** |

\`participantViewerRole_missing\` には \`outputKeys\` field を含めるため、 stack の他 Outputs 一覧から「問題 template が pre-#744 世代」 か即判定できる (= 私が #756 調査で必要だった情報を log で出すようにした)。

\`assume_role_failed\` / \`federation_*\` 系は既存 \`console.error\` が残っているので今回触らない (= 旧来通り error log が出る)。

## CloudWatch Logs Insights クエリ (= docs にも追加)

\` \` \`
fields @timestamp, jobId, problemId, event, status, tenantId, outputKeys
| filter event like /^portal\\.sso\\.not_ready\\./
| sort @timestamp desc
| limit 100
\` \` \`

特定 jobId に絞るときは \`filter jobId = \"01KRX...\"\` を AND 結合する。

## 変更ファイル

- \`infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts\`:
  各 not_ready return の直前に \`logDeployTrace\` を 1 行ずつ挿入 (level=info)。 trace-log.ts を import するだけ
- \`infrastructure/test/problem-deploy/participant-sso.test.ts\`:
  既存 14 件は touch せず、 新規 describe block で **7 件** の log emit 試験を追加 (各 gate に到達 + 成功経路では not_ready log を 0 件 emit)
- \`docs/operations/deploy-trace.md\` / \`.html\`:
  Participant Portal SSO 境界の event table + Insights query E を追加

## Test plan

- [x] \`bunx vitest run test/problem-deploy/participant-sso.test.ts\` — **21/21 pass** (= 既存 14 + 新規 7)
- [x] \`bunx vitest run test/problem-deploy/trace-log.test.ts\` — 7/7 pass (= trace helper の pin)
- [x] \`bunx vitest run\` (infrastructure 全体) — 797 件 pass
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [x] \`bunx markdownlint-cli2\` / \`bunx textlint\` — clean
- [ ] reviewer: merge + deploy 後、 SSO click で \`not_ready\` を 1 回意図的に発生 → Insights query E で event 1 行が出ること

## 受入条件 (#759)

- [x] 6 経路すべてに structured log が入っている
- [x] context に jobId + 該当する場合 problemId / status / outputKeys を含む
- [x] CloudWatch Insights クエリ例を docs / コメントに記載
- [x] vitest で「各 gate に到達したとき log を 1 件出す」を assert
- [x] level=info (= 業務 expected な拒否なので alarm に上げない)

## Regression 分析

- 既存 14 件の participant-sso test は touch せず、 すべて green。 return kind / HTTP status / frontend forbidden 表示の semantics は完全に維持
- \`logDeployTrace\` は \`console.log\` を呼ぶだけで例外を投げない (= trace-log.test.ts で pin)。 SSO の hot path に invariant 破壊なし
- log 追加コストは 1 SSO click あたり最大 1 行 (= CloudWatch Logs cost は無視可能)
- \`assume_role_failed\` / \`federation_*\` の既存 \`console.error\` には触らない (= alert ルートを変えない)
- 旧来 \`[sso]\` text-prefix 形式の log を信じている grep があった場合は壊れない (= 既存 \`console.error\` は残存。 新規 \`logDeployTrace\` は JSON 形式で並走)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | ParticipantPortal Lambda bundle | trace-log import + 6 行の \`logDeployTrace\` call が増える。 IAM / configuration / 接続先は不変 |
| NO-OP | CFn / DDB / Cognito / API Gateway 構造 | 設定変更なし |
| UPDATE | \`docs/operations/deploy-trace.md\` / \`.html\` | 6 行の event table + Insights query E |

## 関連

- Closes #759
- 前段: [PR-#770](https://github.com/susumutomita/TenkaCloud/pull/770) で導入した \`adr-self-contained\` rule に違反しない範囲で書いた / [PR-#782](https://github.com/susumutomita/TenkaCloud/pull/782) で導入した \`logDeployTrace\` を再利用
- 別 SSO 調査経路: [#756](https://github.com/susumutomita/TenkaCloud/issues/756) (= 本 PR の log があれば即解決していた case の典型)

🤖 Generated with [Claude Code](https://claude.com/claude-code)