### PR TITLE
feat(#767): Participant Portal per-team rate limiting + 429 response

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../problem-endpoints-handler/endpoints.js";
 import { PROBLEM_ID_RE } from "../shared/constants.js";
 import { HTTP_OK } from "../shared/http-status.js";
+import { RATE_LIMITS } from "../shared/rate-limiter.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { getLeaderboard } from "./leaderboard.js";
 import { lookupTeamByLoginKey } from "./lookup.js";
@@ -70,16 +71,22 @@ app.get("/portal/me/console-signin-url", (c) =>
   }),
 );
 
+// Issue #767: notifications は frontend polling が 5s 間隔 → READ_HIGH (= 2 RPS sustained / 60 burst)。
 app.get("/portal/me/notifications", (c) =>
-  withBearerAuth(c, "notifications", async (token) => {
-    const limitRaw = c.req.query("limit");
-    // `Number` で strict parse — "100.5" や "10abc" は NaN/float になり listNotifications
-    // 側の `Number.isInteger` で reject。`parseInt` だと truncate されて silent pass する。
-    const limit = limitRaw === undefined ? NOTIFICATIONS_DEFAULT_LIMIT : Number(limitRaw);
-    const outcome = await listNotifications(shared, token, limit);
-    if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
-    return respondError(c, outcome.kind);
-  }),
+  withBearerAuth(
+    c,
+    "notifications",
+    async (token) => {
+      const limitRaw = c.req.query("limit");
+      // `Number` で strict parse — "100.5" や "10abc" は NaN/float になり listNotifications
+      // 側の `Number.isInteger` で reject。`parseInt` だと truncate されて silent pass する。
+      const limit = limitRaw === undefined ? NOTIFICATIONS_DEFAULT_LIMIT : Number(limitRaw);
+      const outcome = await listNotifications(shared, token, limit);
+      if (outcome.kind === "ok") return c.json(outcome.response, HTTP_OK);
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.READ_HIGH,
+  ),
 );
 
 app.get("/portal/me/battle-attacks", (c) =>
@@ -106,36 +113,47 @@ app.get("/portal/leaderboard", (c) =>
   }),
 );
 
+// Issue #767: write 系は WRITE_LOW (= 10 burst / 0.2 RPS sustained = 12 RPM) で絞る。
 app.patch("/portal/me", (c) =>
-  withBearerAuth(c, "update", async (token) => {
-    const body = await c.req.json().catch(() => null);
-    if (body === null) return respondError(c, "invalid_body");
-    const teamName = (body as { teamName?: unknown }).teamName;
-    const outcome = await setDisplayTeamName(shared, token, teamName);
-    if (outcome.kind === "ok") return c.json(outcome.view, HTTP_OK);
-    return respondError(c, outcome.kind);
-  }),
+  withBearerAuth(
+    c,
+    "update",
+    async (token) => {
+      const body = await c.req.json().catch(() => null);
+      if (body === null) return respondError(c, "invalid_body");
+      const teamName = (body as { teamName?: unknown }).teamName;
+      const outcome = await setDisplayTeamName(shared, token, teamName);
+      if (outcome.kind === "ok") return c.json(outcome.view, HTTP_OK);
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
 );
 
 app.post("/portal/me/submit-flag", (c) =>
-  withBearerAuth(c, "submitFlag", async (token) => {
-    const body = await c.req.json().catch(() => null);
-    if (body === null) return respondError(c, "invalid_body");
-    const problemId = (body as { problemId?: unknown }).problemId;
-    const flag = (body as { flag?: unknown }).flag;
-    if (typeof problemId !== "string" || !PROBLEM_ID_RE.test(problemId)) {
-      return respondError(c, "invalid_problem_id");
-    }
-    if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
-      return respondError(c, "invalid_flag");
-    }
-    const outcome = await submitFlag(shared, shared.problemsScoring, token, problemId, flag);
-    if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
-    if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
-    if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
-    if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
-    return c.json(outcome, HTTP_OK);
-  }),
+  withBearerAuth(
+    c,
+    "submitFlag",
+    async (token) => {
+      const body = await c.req.json().catch(() => null);
+      if (body === null) return respondError(c, "invalid_body");
+      const problemId = (body as { problemId?: unknown }).problemId;
+      const flag = (body as { flag?: unknown }).flag;
+      if (typeof problemId !== "string" || !PROBLEM_ID_RE.test(problemId)) {
+        return respondError(c, "invalid_problem_id");
+      }
+      if (typeof flag !== "string" || flag.length === 0 || flag.length > 200) {
+        return respondError(c, "invalid_flag");
+      }
+      const outcome = await submitFlag(shared, shared.problemsScoring, token, problemId, flag);
+      if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
+      if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
+      if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
+      if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
+      return c.json(outcome, HTTP_OK);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
 );
 
 // ADR-012 Phase 3.A: Endpoint registry (override) routes — 競技者が自 team の slot URL を
@@ -160,48 +178,58 @@ app.get("/portal/me/problems/:problemId/endpoints", (c) =>
 );
 
 app.post("/portal/me/problems/:problemId/endpoints/:slot", (c) =>
-  withBearerAuth(c, "put-endpoint", async (token) => {
-    const problemId = c.req.param("problemId");
-    if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
-      return respondError(c, "invalid_problem_id");
-    }
-    const slot = c.req.param("slot");
-    if (!slot || !SLOT_NAME_RE.test(slot)) {
-      return respondError(c, "invalid_slot");
-    }
-    const body = (await c.req.json().catch(() => null)) as { url?: unknown } | null;
-    if (body === null) return respondError(c, "invalid_body");
-    const outcome = await upsertProblemEndpointOverride(
-      shared,
-      token,
-      problemId,
-      slot,
-      body.url,
-      new Date().toISOString(),
-    );
-    if (outcome.kind === "ok") {
-      return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
-    }
-    return respondError(c, outcome.kind);
-  }),
+  withBearerAuth(
+    c,
+    "put-endpoint",
+    async (token) => {
+      const problemId = c.req.param("problemId");
+      if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+        return respondError(c, "invalid_problem_id");
+      }
+      const slot = c.req.param("slot");
+      if (!slot || !SLOT_NAME_RE.test(slot)) {
+        return respondError(c, "invalid_slot");
+      }
+      const body = (await c.req.json().catch(() => null)) as { url?: unknown } | null;
+      if (body === null) return respondError(c, "invalid_body");
+      const outcome = await upsertProblemEndpointOverride(
+        shared,
+        token,
+        problemId,
+        slot,
+        body.url,
+        new Date().toISOString(),
+      );
+      if (outcome.kind === "ok") {
+        return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
+      }
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
 );
 
 app.delete("/portal/me/problems/:problemId/endpoints/:slot", (c) =>
-  withBearerAuth(c, "delete-endpoint", async (token) => {
-    const problemId = c.req.param("problemId");
-    if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
-      return respondError(c, "invalid_problem_id");
-    }
-    const slot = c.req.param("slot");
-    if (!slot || !SLOT_NAME_RE.test(slot)) {
-      return respondError(c, "invalid_slot");
-    }
-    const outcome = await deleteProblemEndpointOverride(shared, token, problemId, slot);
-    if (outcome.kind === "ok") {
-      return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
-    }
-    return respondError(c, outcome.kind);
-  }),
+  withBearerAuth(
+    c,
+    "delete-endpoint",
+    async (token) => {
+      const problemId = c.req.param("problemId");
+      if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
+        return respondError(c, "invalid_problem_id");
+      }
+      const slot = c.req.param("slot");
+      if (!slot || !SLOT_NAME_RE.test(slot)) {
+        return respondError(c, "invalid_slot");
+      }
+      const outcome = await deleteProblemEndpointOverride(shared, token, problemId, slot);
+      if (outcome.kind === "ok") {
+        return c.json({ endpoints: outcome.endpoints, teamId: outcome.teamId }, StatusCodes.OK);
+      }
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
 );
 
 export const handler = handle(app) as (

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import { StatusCodes } from "http-status-codes";
 import {
   HTTP_BAD_REQUEST,
   HTTP_CONFLICT,
@@ -6,6 +7,12 @@ import {
   HTTP_NOT_FOUND,
   HTTP_UNAUTHORIZED,
 } from "../shared/http-status.js";
+import {
+  participantRateLimiter,
+  RATE_LIMITS,
+  type RateLimitConfig,
+} from "../shared/rate-limiter.js";
+import { logDeployTrace } from "../shared/trace-log.js";
 import { extractBearerToken } from "./auth.js";
 
 /**
@@ -50,16 +57,38 @@ export function respondError(c: Context, kind: ErrorKind) {
 }
 
 /**
- * Bearer token 必須 route の共通テンプレ。token 抽出 + try/catch + 500 ログ。
+ * Bearer token 必須 route の共通テンプレ。 token 抽出 + per-team rate limit + try/catch + 500 ログ。
  * handler 側は token を受け取って outcome / Response を返すだけ。
+ *
+ * Issue #767: rateLimit を指定すると、 `(teamLoginKey, routeName)` 単位で token bucket を
+ * 引いて DoS / 暴走耐性を上げる。 デフォルトは READ_MID (= 60 burst / 1 RPS sustained)。
+ * 書き込み系 (submit-flag / endpoint override / patch /me) は WRITE_LOW を渡して厳しく絞る。
+ * 拒否時は 429 + Retry-After header を返し、 frontend は normal polling 文脈なら再試行する。
  */
 export async function withBearerAuth(
   c: Context,
   routeName: string,
   handler: (token: string) => Promise<Response>,
+  rateLimit: RateLimitConfig = RATE_LIMITS.READ_MID,
 ): Promise<Response> {
   const token = extractBearerToken(c.req.header("authorization"));
   if (!token) return respondError(c, "unauthorized");
+
+  const outcome = participantRateLimiter.take(`${token}|${routeName}`, rateLimit);
+  if (!outcome.allowed) {
+    logDeployTrace("portal.rate_limit.rejected", {
+      routeName,
+      retryAfterSec: outcome.retryAfterSec,
+      capacity: rateLimit.capacity,
+      refillPerSec: rateLimit.refillPerSec,
+    });
+    c.header("Retry-After", String(outcome.retryAfterSec));
+    return c.json(
+      { error: "rate_limited", retryAfterSec: outcome.retryAfterSec },
+      StatusCodes.TOO_MANY_REQUESTS,
+    );
+  }
+
   try {
     return await handler(token);
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
@@ -1,0 +1,102 @@
+/**
+ * Issue #767: Participant Portal の token bearer 経路で per-team rate limit を効かせる。
+ *
+ * Free Tier 制約 (= DDB 1/1 PROVISIONED) で DDB 経由の sliding window を入れると
+ * 1 request あたり 1 RCU + 1 WCU 消費し、 25 RCU/WCU quota を 25 RPS で食い切る。
+ * Lambda の reservedConcurrency = 1 を前提に、 **同 Lambda instance 内の in-memory
+ * token bucket** で代替する。 同時実行が増えた場合は warm Lambda instance ごとに
+ * 別 bucket になるが、 「同 team が同 instance を連打した場合」の DoS を確実に塞ぐ
+ * (= shared backend 劣化を防ぐ最低限の壁)。 厳密な distributed limit が必要に
+ * なったら DDB token bucket に差し替える設計余地は残す。
+ */
+
+export interface RateLimitConfig {
+  /** Bucket の最大トークン数 (= burst 許容上限)。 */
+  readonly capacity: number;
+  /** 1 秒あたりの refill レート (= sustained throughput)。 */
+  readonly refillPerSec: number;
+}
+
+interface Bucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export interface RateLimitOutcome {
+  readonly allowed: boolean;
+  /** リクエスト拒否時、 次にトークンが取得可能になるまでの秒数 (整数、 0 以上)。 */
+  readonly retryAfterSec: number;
+}
+
+export interface RateLimiterClock {
+  readonly now: () => number;
+}
+
+const defaultClock: RateLimiterClock = { now: () => Date.now() };
+
+/**
+ * Token bucket rate limiter (per key)。 module scope に Map を持つ singleton-like 構造。
+ *
+ * `key` は通常 `${teamLoginKey}|${action}` の form (= 同 team の同 action だけを束ねる、
+ * 別 action の usage と独立)。
+ *
+ * 戻り値の `allowed=false` は 429 Too Many Requests を返すべき signal。
+ * `retryAfterSec` は HTTP `Retry-After` header の値として使える。
+ */
+export function createRateLimiter(clock: RateLimiterClock = defaultClock) {
+  const buckets = new Map<string, Bucket>();
+
+  return {
+    /**
+     * key の bucket から 1 トークン消費を試みる。
+     * 不在の bucket は capacity 満タンで lazy 初期化。
+     */
+    take(key: string, config: RateLimitConfig): RateLimitOutcome {
+      const now = clock.now();
+      const bucket = buckets.get(key) ?? { tokens: config.capacity, lastRefillMs: now };
+      // Refill: 経過秒数 × refillPerSec を加算 (= sliding 補充)。capacity で cap。
+      const elapsedSec = Math.max(0, (now - bucket.lastRefillMs) / 1000);
+      const refilled = Math.min(config.capacity, bucket.tokens + elapsedSec * config.refillPerSec);
+      if (refilled >= 1) {
+        bucket.tokens = refilled - 1;
+        bucket.lastRefillMs = now;
+        buckets.set(key, bucket);
+        return { allowed: true, retryAfterSec: 0 };
+      }
+      // 不足。 次に 1 トークン貯まるまでの秒数を計算 (refillPerSec=0 のとき Infinity を 60 にクランプ)。
+      const needed = 1 - refilled;
+      const waitSec = config.refillPerSec > 0 ? Math.ceil(needed / config.refillPerSec) : 60;
+      bucket.tokens = refilled;
+      bucket.lastRefillMs = now;
+      buckets.set(key, bucket);
+      return { allowed: false, retryAfterSec: Math.max(1, waitSec) };
+    },
+
+    /** test 等で bucket を強制リセット。 */
+    reset(): void {
+      buckets.clear();
+    },
+
+    /** test 用 debug: 現在の bucket 残量 */
+    snapshot(): ReadonlyMap<string, Readonly<Bucket>> {
+      return new Map(buckets);
+    },
+  };
+}
+
+/**
+ * デフォルト config presets。 frontend polling 経路 (= 60s leaderboard / 5s notifications)
+ * を阻害しないよう、 read 系は capacity を読みやすめに取る。
+ *
+ *   - READ_HIGH: notification polling (= 5s 間隔) を 12 RPS burst で許容、 sustained 2 RPS
+ *   - READ_MID: leaderboard / score-events (= 60s 間隔) を 30 RPS burst で許容
+ *   - WRITE_LOW: submit-flag / endpoint override (= 人手の write) を 5 RPS burst、 1 RPS sustained
+ */
+export const RATE_LIMITS = {
+  READ_HIGH: { capacity: 60, refillPerSec: 2 } as const satisfies RateLimitConfig,
+  READ_MID: { capacity: 60, refillPerSec: 1 } as const satisfies RateLimitConfig,
+  WRITE_LOW: { capacity: 10, refillPerSec: 0.2 } as const satisfies RateLimitConfig,
+};
+
+/** Lambda module-scope singleton (warm invoke で共有)。 */
+export const participantRateLimiter = createRateLimiter();

--- a/infrastructure/test/problem-deploy/rate-limiter.test.ts
+++ b/infrastructure/test/problem-deploy/rate-limiter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRateLimiter,
+  RATE_LIMITS,
+} from "../../lib/problem-deploy/handlers/shared/rate-limiter";
+
+describe("createRateLimiter", () => {
+  it("初回 take は許可されるべき (lazy 初期化、 capacity 満タン)", () => {
+    const limiter = createRateLimiter({ now: () => 0 });
+    const out = limiter.take("k", RATE_LIMITS.WRITE_LOW);
+    expect(out.allowed).toBe(true);
+    expect(out.retryAfterSec).toBe(0);
+  });
+
+  it("capacity を使い切ったら次の take は拒否されるべき", () => {
+    const t = 0;
+    const limiter = createRateLimiter({ now: () => t });
+    const config = { capacity: 3, refillPerSec: 0 };
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(true);
+    const denied = limiter.take("k", config);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it("時間経過で refill されるべき (= refillPerSec=1 で 1 秒後に 1 トークン)", () => {
+    let t = 0;
+    const limiter = createRateLimiter({ now: () => t });
+    const config = { capacity: 1, refillPerSec: 1 };
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(false);
+    t = 1000;
+    expect(limiter.take("k", config).allowed).toBe(true);
+  });
+
+  it("capacity を超えて refill されないべき (= burst cap)", () => {
+    let t = 0;
+    const limiter = createRateLimiter({ now: () => t });
+    const config = { capacity: 2, refillPerSec: 5 };
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(false);
+    t = 60_000;
+    // 60 秒経っても capacity=2 を超えない (= 3 連続 take しても 3 つ目は拒否)
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(true);
+    expect(limiter.take("k", config).allowed).toBe(false);
+  });
+
+  it("別 key は独立した bucket を持つべき (team1 が使い切っても team2 は影響なし)", () => {
+    const limiter = createRateLimiter({ now: () => 0 });
+    const config = { capacity: 1, refillPerSec: 0 };
+    expect(limiter.take("team1", config).allowed).toBe(true);
+    expect(limiter.take("team1", config).allowed).toBe(false);
+    expect(limiter.take("team2", config).allowed).toBe(true);
+  });
+
+  it("retryAfterSec は次に 1 トークン取得可能な時間に近似されるべき (= refillPerSec 由来)", () => {
+    const t = 0;
+    const limiter = createRateLimiter({ now: () => t });
+    const config = { capacity: 1, refillPerSec: 0.5 };
+    expect(limiter.take("k", config).allowed).toBe(true);
+    const denied = limiter.take("k", config);
+    expect(denied.allowed).toBe(false);
+    // 1 トークン貯まるには 1 / 0.5 = 2 秒必要
+    expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
+    expect(denied.retryAfterSec).toBeLessThanOrEqual(2);
+  });
+
+  it("refillPerSec=0 (= 完全停止) の場合は retryAfterSec を 60 にクランプすべき", () => {
+    const limiter = createRateLimiter({ now: () => 0 });
+    const config = { capacity: 1, refillPerSec: 0 };
+    expect(limiter.take("k", config).allowed).toBe(true);
+    const denied = limiter.take("k", config);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBe(60);
+  });
+
+  it("reset() で全 bucket を消すべき", () => {
+    const limiter = createRateLimiter({ now: () => 0 });
+    const config = { capacity: 1, refillPerSec: 0 };
+    limiter.take("k", config);
+    expect(limiter.take("k", config).allowed).toBe(false);
+    limiter.reset();
+    expect(limiter.take("k", config).allowed).toBe(true);
+  });
+
+  it("RATE_LIMITS.WRITE_LOW は 10 burst / 0.2 RPS (= 12 RPM) であるべき (= submit-flag 設計値)", () => {
+    expect(RATE_LIMITS.WRITE_LOW.capacity).toBe(10);
+    expect(RATE_LIMITS.WRITE_LOW.refillPerSec).toBe(0.2);
+  });
+
+  it("RATE_LIMITS.READ_HIGH は 60 burst / 2 RPS であるべき (= 5s polling 阻害しない)", () => {
+    expect(RATE_LIMITS.READ_HIGH.capacity).toBe(60);
+    expect(RATE_LIMITS.READ_HIGH.refillPerSec).toBe(2);
+  });
+
+  it("RATE_LIMITS.READ_MID は 60 burst / 1 RPS であるべき (= 60s polling は余裕)", () => {
+    expect(RATE_LIMITS.READ_MID.capacity).toBe(60);
+    expect(RATE_LIMITS.READ_MID.refillPerSec).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

[Issue #767](https://github.com/susumutomita/TenkaCloud/issues/767) (= security / P1) の実装。 \`teamLoginKey\` bearer 経路に per-team rate limiting を入れ、 同 team の暴走 / DoS / 誤クライアント連打で shared backend (= 1 concurrent Lambda + 1/1 PROVISIONED DDB) を劣化させない壁を作る。

## 設計

- Lambda module-scope の **in-memory token bucket** (= \`Map<key, Bucket>\`)
  - key = \`\${teamLoginKey}|\${routeName}\` (= 同 team の別 action は独立 bucket)
  - DDB ベース sliding window は Free Tier 制約 (1/1 PROVISIONED) と整合せず採用しない (= 25 RPS で quota 枯渇)
  - Lambda の \`reservedConcurrency=1\` を前提に、 「同 instance 内の DoS 確実 block」 を最低限の壁にする。 分散環境化したら DDB token bucket に差し替える設計余地は残す
- 拒否時: HTTP 429 + \`{ error: \"rate_limited\", retryAfterSec: N }\` + \`Retry-After: N\` header
- \`logDeployTrace(\"portal.rate_limit.rejected\", { routeName, retryAfterSec, ... })\` で structured log (= PR-#782 の trace 経路に乗せる)

## Preset

| Preset | capacity (burst) | refillPerSec (sustained) | 用途 |
|---|---|---|---|
| READ_HIGH | 60 | 2 RPS | notifications (5s polling) |
| READ_MID (default) | 60 | 1 RPS | leaderboard / score-events / lookup / sso / battle-attacks |
| WRITE_LOW | 10 | 0.2 RPS (= 12 RPM) | submit-flag / endpoint override / patch /me |

## 変更ファイル

| File | 変更 |
|---|---|
| \`infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts\` (新規) | \`createRateLimiter\` + \`RATE_LIMITS\` preset + \`participantRateLimiter\` singleton |
| \`infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts\` | \`withBearerAuth\` が \`rateLimit\` 引数を取り、 拒否時 429 を返すように拡張 (= default READ_MID で既存 caller 互換) |
| \`infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts\` | notifications を READ_HIGH に、 submit-flag / patch /me / put-endpoint / delete-endpoint を WRITE_LOW に指定 |
| \`infrastructure/test/problem-deploy/rate-limiter.test.ts\` (新規) | unit test 11 件 |

## Test plan

- [x] \`bunx vitest run test/problem-deploy/rate-limiter.test.ts\` — **11/11 pass**
- [x] \`bunx vitest run\` (infrastructure 全体) — **808/808 pass**
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [ ] reviewer: merge + deploy 後、 1 つの team で submit-flag を 11 連発 → 11 回目から 429 + Retry-After: 5 で返ること確認
- [ ] reviewer: 同 team で notifications を 5s polling 維持 → 429 にならないこと確認 (= normal UX 維持)

## 受入条件 (#767)

- [x] 同 team が短時間大量送信しても backend が劣化しない (= write 系 10 burst / 12 RPM、 read 60 burst で線形に絞る)
- [x] 正常 polling UX は維持 (= notifications 5s polling = 5 RPM、 cap 60 + sustained 2 RPS で余裕)
- [x] test 追加 (= 11 件 unit test、 全 80 file 808 test green)

## Regression 分析

- 既存 \`withBearerAuth\` 呼び出しは default \`READ_MID\` (60 burst) で動作。 一般運用では絶対に超えない値なので、 既存 participant test (= 全 80 file 808 test) すべて green
- 429 response の semantics は HTTP 仕様準拠 (= Retry-After header、 body に \`retryAfterSec\`)。 frontend は 429 を generic error として扱う既存実装で壊れない。 polling 系は次の tick で自動 retry されるため UX 維持
- in-memory bucket は warm Lambda instance 内のみ。 cold start で bucket リセット (= 1 team が 60 burst 連発できる窓が cold start 跨ぎで発生しうるが、 init 1〜2 秒以下では実害無し)
- 同 team の同 action のみ rate-limit 対象。 別 team / 別 action は独立 bucket (= 単一 team の DoS を全 team / 全 path に波及させない)
- 旧 \`withBearerAuth\` の 3-arg signature は backward compatible (= 4th arg optional)
- HTTP status code は \`StatusCodes.TOO_MANY_REQUESTS\` (= magic number 禁止規約 / CLAUDE.md)
- ADR-self-contained / adr-must-be-html rule に違反しない範囲で書いた (= \`make harness\` no findings)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | ParticipantPortal Lambda bundle | rate-limiter import + \`withBearerAuth\` の 1 引数追加。 IAM / configuration / 接続先は不変 |
| NO-OP | CFn / DDB / Cognito / API Gateway 構造 | 設定変更なし |
| NO-OP | \`apps/*/dist/\` | frontend に修正なし |

## 関連

- Closes #767
- 前段: [PR-#782](https://github.com/susumutomita/TenkaCloud/pull/782) で導入した \`logDeployTrace\` を再利用 (= rate-limit 拒否を \`portal.rate_limit.rejected\` event で観測可能に)
- 将来検討: 分散 rate-limit (= DDB token bucket) は trace で実 RPS を観測してから判断 (= 現状の Lambda concurrency=1 を超えてから)
- 並行 PR (本日同セッション): [#783](https://github.com/susumutomita/TenkaCloud/pull/783) (#759 SSO observability) / [#784](https://github.com/susumutomita/TenkaCloud/pull/784) (#748 tenantName) / [#785](https://github.com/susumutomita/TenkaCloud/pull/785) (#766 CDK refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)