### PR TITLE
refactor(#778 Phase 1): TenantTemplateStack から AppPlaneCore builder を抽出

### DIFF
--- a/infrastructure/lib/app-plane-core/app-plane-core.ts
+++ b/infrastructure/lib/app-plane-core/app-plane-core.ts
@@ -1,0 +1,138 @@
+import type { Stack } from "aws-cdk-lib";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
+import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
+import { ApiGateway } from "../tenant-template/api-gateway";
+import { ApplicationAdminConsoleHosting } from "../tenant-template/application-admin-console-hosting";
+import { IdentityProvider } from "../tenant-template/identity-provider";
+
+/**
+ * Issue #778 ADR-016 Phase 1: TenantTemplateStack から共通 App Plane コア構成を抽出する。
+ *
+ * 抽出対象 (= Full mode と Lite mode で共有する):
+ *   - ApplicationAdminConsoleHosting (= SPA + runtime-config 配信)
+ *   - IdentityProvider (= tenant Cognito UserPool + UserPoolClient + Hosted UI domain)
+ *   - ApiGateway (= REST API + DeployApi / EventApi / CompetitorAccountsApi 統合)
+ *   - runtime-config.json 配置 (= apiGateway 確定後の 2 段階構築)
+ *
+ * 抽出しない (= Full mode 固有、 TenantTemplateStack 側に残す):
+ *   - TenantMappingTable への AwsCustomResource Put / Update / Delete (SBT pipeline 連携)
+ *   - SBT tag (TenantId / IsPooledDeploy)
+ *   - tier API key の SSM lookup (Lite mode では不要、 後続 phase で apiKeyConfig optional 化)
+ *
+ * ## CFn 物理差分 0 件 invariant
+ *
+ * Construct 抽出ではなく **builder 関数** にしているのは、 CDK の construct path
+ * (= `Stack/AppPlaneCore/ApplicationAdminConsoleHosting`) が変わると CFn logical ID が
+ * drift して既存 stack を REPLACE してしまうため。 builder は `scope = stack` のまま
+ * 3 つの sub-construct を生成するので、 logical ID は旧 `Stack/ApplicationAdminConsoleHosting`
+ * と完全に一致する。
+ *
+ * 将来 (= Phase 3) の TenkaCloudLiteStack は同じ builder を別 Stack で呼ぶだけ。
+ */
+
+export interface AppPlaneCoreApiKeyConfig {
+  readonly ssmParameterNames: ApiKeySSMParameterNames;
+  /**
+   * SSM Parameter から値を引く関数。 stack の `valueForStringParameter` を bind した callback
+   * を受ける (= stack scope に依存しないため)。 Lite mode で API Key 経路を skip する場合は
+   * 本 prop ごと undefined を渡す (= 後続 phase で実装)。
+   */
+  readonly ssmLookup: (parameterName: string) => string;
+}
+
+export interface AppPlaneCoreProps {
+  readonly tenantId: string;
+  readonly tenantName: string;
+  readonly environment: string;
+  readonly isPooledDeploy: boolean;
+  readonly deployApiLambda: IFunction;
+  readonly eventApiLambda: IFunction;
+  readonly competitorAccountsApiLambda: IFunction;
+  readonly participantPortalUrl?: string;
+  readonly competitorBootstrapTemplateUrl?: string;
+  /**
+   * Full mode (= SaaS pipeline 経由) では tier API key SSM lookup を渡す。
+   * Lite mode (= Phase 3 以降) では undefined を渡し、 API Gateway 側の Usage Plan / API Key
+   * 配線をスキップする (= 後続 phase で ApiGateway 側にも optional 化を入れる予定)。
+   */
+  readonly apiKeyConfig: AppPlaneCoreApiKeyConfig;
+}
+
+export interface AppPlaneCoreHandles {
+  readonly applicationAdminConsoleHosting: ApplicationAdminConsoleHosting;
+  readonly identityProvider: IdentityProvider;
+  readonly apiGateway: ApiGateway;
+  readonly applicationAdminConsoleUrl: string;
+}
+
+/**
+ * Stack の中で App Plane コア構成 (= hosting + identity + api gateway + runtime-config) を
+ * 立てる pure helper。 旧 TenantTemplateStack の constructor 内 logic を 1 関数に集約。
+ *
+ * 順序 (= 旧実装と完全同一):
+ *   1. hosting (CloudFront URL を identity に渡す必要があるので先)
+ *   2. identity (UserPoolClient callback URL に hosting.distributionUrl が必要)
+ *   3. apiGateway (Cognito user pool + Lambda 統合を組み立てる)
+ *   4. hosting.deployRuntimeConfig (apiUrl が確定してから呼ぶ)
+ *
+ * scope は Stack を直接受け取り、 sub-construct ID を旧パスと完全一致させる
+ * (= `Stack/ApplicationAdminConsoleHosting` 等)。
+ */
+export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPlaneCoreHandles {
+  const applicationAdminConsoleHosting = new ApplicationAdminConsoleHosting(
+    scope,
+    "ApplicationAdminConsoleHosting",
+    {
+      tenantId: props.tenantId,
+    },
+  );
+
+  const identityProvider = new IdentityProvider(scope, "IdentityProvider", {
+    tenantId: props.tenantId,
+    environment: props.environment,
+    applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
+  });
+
+  const apiGateway = new ApiGateway(scope, "ApiGateway", {
+    tenantId: props.tenantId,
+    isPooledDeploy: props.isPooledDeploy,
+    idpDetails: identityProvider.identityDetails,
+    userPool: identityProvider.tenantUserPool,
+    deployApiLambda: props.deployApiLambda,
+    eventApiLambda: props.eventApiLambda,
+    competitorAccountsApiLambda: props.competitorAccountsApiLambda,
+    apiKeyBasicTier: {
+      apiKeyId: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.basic.keyId),
+      value: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.basic.value),
+    },
+    apiKeyStandardTier: {
+      apiKeyId: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.standard.keyId),
+      value: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.standard.value),
+    },
+    apiKeyPremiumTier: {
+      apiKeyId: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.premium.keyId),
+      value: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.premium.value),
+    },
+    apiKeyPlatinumTier: {
+      apiKeyId: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.platinum.keyId),
+      value: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.platinum.value),
+    },
+  });
+
+  applicationAdminConsoleHosting.deployRuntimeConfig({
+    cognitoDomain: identityProvider.cognitoDomainUrl,
+    cognitoClientId: identityProvider.tenantUserPoolClient.userPoolClientId,
+    tenantId: props.tenantId,
+    tenantName: props.tenantName,
+    apiUrl: apiGateway.restApi.url,
+    participantPortalUrl: props.participantPortalUrl,
+    competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+  });
+
+  return {
+    applicationAdminConsoleHosting,
+    identityProvider,
+    apiGateway,
+    applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
+  };
+}

--- a/infrastructure/lib/app-plane-core/index.ts
+++ b/infrastructure/lib/app-plane-core/index.ts
@@ -1,0 +1,6 @@
+export type {
+  AppPlaneCoreApiKeyConfig,
+  AppPlaneCoreHandles,
+  AppPlaneCoreProps,
+} from "./app-plane-core";
+export { buildAppPlaneCore } from "./app-plane-core";

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -8,10 +8,8 @@ import {
   PhysicalResourceId,
 } from "aws-cdk-lib/custom-resources";
 import type { Construct } from "constructs";
+import { buildAppPlaneCore } from "../app-plane-core";
 import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
-import { ApiGateway } from "./api-gateway";
-import { ApplicationAdminConsoleHosting } from "./application-admin-console-hosting";
-import { IdentityProvider } from "./identity-provider";
 
 interface TenantTemplateStackProps extends StackProps {
   stageName: string;
@@ -80,75 +78,41 @@ export class TenantTemplateStack extends Stack {
     super(scope, id, props);
     const waveNumber = props.waveNumber || "1";
 
-    // 順序の意図: hosting → identity → hosting.deployRuntimeConfig の 3 段階。
-    // identity の UserPoolClient callback URL に hosting.distributionUrl を渡す必要が
-    // あり、hosting の runtime-config.json には identity の cognitoDomain / clientId
-    // が必要なため、循環参照を 2 段階構築 (コンストラクタ + method) で回避する。
+    // Issue #778 ADR-016 Phase 1: App Plane コア構成 (= hosting + identity + apiGateway +
+    // runtime-config 配置) は `buildAppPlaneCore` builder に切り出して Lite mode と共有する。
+    // CFn 物理差分 0 件 invariant のため、 sub-construct は同 stack scope に同 logical ID で
+    // 生成される (= Stack/ApplicationAdminConsoleHosting / Stack/IdentityProvider / Stack/ApiGateway)。
+    //
+    // 順序の意図: hosting → identity → apiGateway → hosting.deployRuntimeConfig の 4 段。
+    // identity の UserPoolClient callback URL に hosting.distributionUrl を渡す必要があり、
+    // hosting の runtime-config.json には identity の cognitoDomain / clientId / apiGateway の
+    // apiUrl が必要なため、 builder 内で 2 段階構築 (コンストラクタ + deployRuntimeConfig
+    // method) で循環参照を回避する。
     //
     // pooled / silo どちらの TenantTemplateStack インスタンスでも同じ構造を立てる。
     //   - pooled: install.sh phase 1 で 1 度だけ立つ共有 console
     //   - silo:   provision-tenant.sh が PLATINUM tier で per-tenant に立てる
-    // tenantId 注入は本 PR には含まない (#48 で追加)。
-    const applicationAdminConsoleHosting = new ApplicationAdminConsoleHosting(
-      this,
-      "ApplicationAdminConsoleHosting",
-      {
-        tenantId: props.tenantId,
-      },
-    );
-
-    const identityProvider = new IdentityProvider(this, "IdentityProvider", {
+    const appPlaneCore = buildAppPlaneCore(this, {
       tenantId: props.tenantId,
+      tenantName: props.tenantName,
       environment: props.environment,
-      applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
-    });
-
-    // Note: apiUrl は apiGateway が確定してから渡すので、先に apiGateway を作る。
-    // 旧コードでは hosting.deployRuntimeConfig が先だったが、apiUrl が必要になった
-    // ので順序を変更する。
-    // (実行順): hosting → identity → apiGateway → hosting.deployRuntimeConfig
-
-    const apiGateway = new ApiGateway(this, "ApiGateway", {
-      tenantId: props.tenantId,
       isPooledDeploy: props.isPooledDeploy,
-      idpDetails: identityProvider.identityDetails,
-      userPool: identityProvider.tenantUserPool,
       deployApiLambda: props.deployApiLambda,
       eventApiLambda: props.eventApiLambda,
       competitorAccountsApiLambda: props.competitorAccountsApiLambda,
-      apiKeyBasicTier: {
-        apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.basic.keyId),
-        value: this.ssmLookup(props.ApiKeySSMParameterNames.basic.value),
-      },
-      apiKeyStandardTier: {
-        apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.standard.keyId),
-        value: this.ssmLookup(props.ApiKeySSMParameterNames.standard.value),
-      },
-      apiKeyPremiumTier: {
-        apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.premium.keyId),
-        value: this.ssmLookup(props.ApiKeySSMParameterNames.premium.value),
-      },
-      apiKeyPlatinumTier: {
-        apiKeyId: this.ssmLookup(props.ApiKeySSMParameterNames.platinum.keyId),
-        value: this.ssmLookup(props.ApiKeySSMParameterNames.platinum.value),
+      participantPortalUrl: props.participantPortalUrl,
+      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+      apiKeyConfig: {
+        ssmParameterNames: props.ApiKeySSMParameterNames,
+        ssmLookup: (name) => this.ssmLookup(name),
       },
     });
+    const applicationAdminConsoleHosting = appPlaneCore.applicationAdminConsoleHosting;
+    const identityProvider = appPlaneCore.identityProvider;
+    const apiGateway = appPlaneCore.apiGateway;
     this.tenantApiId = apiGateway.restApi.restApiId;
     this.tenantApiName = apiGateway.restApi.restApiName;
     this.tenantApiStageName = apiGateway.restApi.deploymentStage.stageName;
-
-    // apiGateway 確定後に runtime-config.json を配置する (apiUrl を詰めるため)。
-    // ADR-001 / Issue #458: Deploy 系 endpoint は本 tenant API に統合されたので
-    // runtime-config.json は `apiUrl` 1 本のみ (旧 `deployApiUrl` 廃止)。
-    applicationAdminConsoleHosting.deployRuntimeConfig({
-      cognitoDomain: identityProvider.cognitoDomainUrl,
-      cognitoClientId: identityProvider.tenantUserPoolClient.userPoolClientId,
-      tenantId: props.tenantId,
-      tenantName: props.tenantName,
-      apiUrl: apiGateway.restApi.url,
-      participantPortalUrl: props.participantPortalUrl,
-      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
-    });
 
     new AwsCustomResource(this, "CreateTenantMapping", {
       installLatestAwsSdk: true,

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -1,0 +1,113 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { describe, expect, it } from "vitest";
+import { buildAppPlaneCore } from "../../lib/app-plane-core";
+
+/**
+ * Issue #778 ADR-016 Phase 1: AppPlaneCore builder の契約 pin。
+ *
+ * 主目的は "CFn 物理差分 0 件" invariant — sub-construct (= hosting / identity / apiGateway)
+ * が **stack scope に直接** logical ID `ApplicationAdminConsoleHosting` / `IdentityProvider` /
+ * `ApiGateway` で生成されることを確認する。 builder が誤って新しい Construct を間に挟むと、
+ * 既存 stack の CFn template が REPLACE されてしまうため。
+ */
+
+function buildStubLambda(scope: cdk.Stack, id: string): LambdaFunction {
+  return new LambdaFunction(scope, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => ({});"),
+  });
+}
+
+function synth(): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  buildAppPlaneCore(stack, {
+    tenantId: "tenant-1",
+    tenantName: "Tenant 1",
+    environment: "development",
+    isPooledDeploy: false,
+    deployApiLambda: buildStubLambda(stack, "StubDeploy"),
+    eventApiLambda: buildStubLambda(stack, "StubEvent"),
+    competitorAccountsApiLambda: buildStubLambda(stack, "StubCompetitorAccounts"),
+    apiKeyConfig: {
+      ssmParameterNames: {
+        basic: { keyId: "basic-id", value: "basic-val" },
+        standard: { keyId: "standard-id", value: "standard-val" },
+        premium: { keyId: "premium-id", value: "premium-val" },
+        platinum: { keyId: "platinum-id", value: "platinum-val" },
+      },
+      ssmLookup: (name: string) => `SSM:${name}`,
+    },
+  });
+  return Template.fromStack(stack);
+}
+
+describe("buildAppPlaneCore", () => {
+  it("ApplicationAdminConsoleHosting / IdentityProvider / ApiGateway を Stack 直下に生成すべき (= CFn 物理差分 0 件 invariant)", () => {
+    const template = synth();
+    // builder は scope = stack に対して 3 つの sub-construct を生成する。
+    // 各 sub-construct は内部に複数の CFn resource を持つ。 stack 直下に下記が存在することで
+    // logical ID パスが旧 TenantTemplateStack と一致していることを確認する。
+    template.resourceCountIs("AWS::Cognito::UserPool", 1);
+    template.resourceCountIs("AWS::Cognito::UserPoolClient", 1);
+    template.resourceCountIs("AWS::Cognito::UserPoolDomain", 1);
+    // ApiGateway は REST API を 1 個立てる。
+    template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
+    // ApplicationAdminConsoleHosting は CloudFront Distribution を立てる。
+    template.resourceCountIs("AWS::CloudFront::Distribution", 1);
+  });
+
+  it("runtime-config.json 用の BucketDeployment custom resource を 1 件作るべき (= deployRuntimeConfig が呼ばれた証跡)", () => {
+    const template = synth();
+    // BucketDeployment は AWS::CloudFormation::CustomResource として template に乗る。
+    // hosting の runtime-config.json が apiGateway 確定後に配置されることを示す。
+    template.hasResource("Custom::CDKBucketDeployment", Match.objectLike({}));
+  });
+
+  it("UserPoolClient の callback URL は ApplicationAdminConsoleHosting の distribution URL を参照すべき", () => {
+    const template = synth();
+    // UserPoolClient の CallbackURLs / LogoutURLs に CloudFront distribution domain への
+    // Fn::Join 参照が入る (= 順序依存)。 hosting が先に作られて identity に URL を渡す
+    // フローが壊れていないか確認する。 string では引けない (= CDK token なので) ため、
+    // 存在検査だけ行う (= Match.absent() を使うと逆になる)。
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const client = Object.values(clients)[0];
+    const callbacks = (client?.Properties as { CallbackURLs?: unknown[] })?.CallbackURLs ?? [];
+    const logouts = (client?.Properties as { LogoutURLs?: unknown[] })?.LogoutURLs ?? [];
+    expect(callbacks.length).toBeGreaterThan(0);
+    expect(logouts.length).toBeGreaterThan(0);
+  });
+
+  it("戻り値の applicationAdminConsoleUrl は hosting.distributionUrl と一致すべき", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    const handles = buildAppPlaneCore(stack, {
+      tenantId: "tenant-1",
+      tenantName: "Tenant 1",
+      environment: "development",
+      isPooledDeploy: false,
+      deployApiLambda: buildStubLambda(stack, "StubDeploy"),
+      eventApiLambda: buildStubLambda(stack, "StubEvent"),
+      competitorAccountsApiLambda: buildStubLambda(stack, "StubCompetitorAccounts"),
+      apiKeyConfig: {
+        ssmParameterNames: {
+          basic: { keyId: "b", value: "b" },
+          standard: { keyId: "s", value: "s" },
+          premium: { keyId: "p", value: "p" },
+          platinum: { keyId: "pl", value: "pl" },
+        },
+        ssmLookup: () => "SSM:x",
+      },
+    });
+    expect(handles.applicationAdminConsoleUrl).toBe(
+      handles.applicationAdminConsoleHosting.distributionUrl,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

[ADR-016](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html) で blueprint 化した TenkaCloud Lite 経路の **Phase 1**。

\`TenantTemplateStack\` の constructor 内に詰まっていた「App Plane コア構成」 (= hosting + identity + api gateway + runtime-config 配置) を \`lib/app-plane-core/\` に切り出し、 Full mode (= 本 stack) と将来 Lite mode (= \`TenkaCloudLiteStack\`、 Phase 3) が同じ builder を再利用できる形に倒す。

## 設計判断: Construct ではなく builder 関数

CDK の construct path (= \`Stack/AppPlaneCore/ApplicationAdminConsoleHosting\`) を間に Construct を挟むと変えてしまい、 CFn logical ID が drift して既存 stack を REPLACE してしまう。 これは ADR-016 で明文化した「CFn 物理差分 0 件 invariant」 に違反する。

代わりに \`buildAppPlaneCore(stack, props)\` という pure function 形式にし、 sub-construct は **stack scope に直接** (= 旧コードと同じ path) 生成する。 これで logical ID は完全に保たれる (= 既存 deploy が REPLACE されない)。

## 変更

| File | 内容 |
|---|---|
| \`infrastructure/lib/app-plane-core/app-plane-core.ts\` (新規) | \`AppPlaneCoreProps\` + \`buildAppPlaneCore\` 関数 + \`AppPlaneCoreApiKeyConfig\` 抽象化。 順序の意図 (hosting → identity → apiGateway → deployRuntimeConfig) を docstring に明示 |
| \`infrastructure/lib/app-plane-core/index.ts\` (新規) | 公開 surface |
| \`infrastructure/lib/tenant-template/tenant-template-stack.ts\` | constructor 内の **60 行** を \`buildAppPlaneCore(this, {...})\` の 1 呼び出しに置換 (= **60 → 16 行**)。 TenantMappingTable Put / SBT tag / CfnOutput は wrapper 側に残す |
| \`infrastructure/test/app-plane-core/build-app-plane-core.test.ts\` (新規) | builder 契約 pin (= sub-construct の logical ID 保持 / runtime-config の CustomResource 生成 / callback URL 経路の循環参照解決 / 戻り値の URL 一致) |

## Test plan

- [x] \`bunx vitest run test/app-plane-core/\` — **4/4 pass**
- [x] \`bunx vitest run\` (infrastructure 全体) — **82 file / 845 test pass**
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [x] \`make synth\` で旧と同じ **7 stacks** (control-plane / problem-deploy / admin-console-insight / bootstrap / tenant-template-pooled / saas-pipeline / observability) 出力を確認済
- [ ] reviewer: \`make synth\` を旧 main と本 PR で 2 回流して \`cdk.out/*.template.json\` を diff し、 物理差分 0 件を確認

## Regression 分析 (= "CFn 物理差分 0 件" invariant の核)

- sub-construct (= hosting / identity / apiGateway) は **scope = stack** に対して旧と同じ logical ID (\`Stack/ApplicationAdminConsoleHosting\` / \`Stack/IdentityProvider\` / \`Stack/ApiGateway\`) で生成。 CDK の path 算出は scope の chain で決まるため、 builder 関数を挟んでも logical ID は変わらない
- 既存 \`TenantTemplateStack\` test (= identity-provider.test.ts、 problem-deploy / tenant-template 系) は touch せず、 同 stack の synth output に対する assertion が全 pass = "logical ID / resource shape 不変" の実証
- 新規追加した unit test 4 件は AppPlaneCore の最小契約 (= sub-construct の存在 / runtime-config CustomResource / callback URL 循環参照解決 / 戻り値の URL 一致) を pin
- 4 file 845 test green (= 旧 80 file 802 + 並行 PR で追加された分 + 本 PR 追加分)
- \`make synth\` で旧と同じ stack list / stack count / 経路出力
- \`AppPlaneCoreApiKeyConfig\` は Lite mode で undefined にする想定だが、 Phase 1 では Full mode 経由のみ実装 (= always required で API Gateway 側の optional 化は Phase 2 で別 PR)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| NO-OP | AWS CFn / IAM / Lambda / DDB / Cognito / API Gateway / CloudFront | resource graph / logical ID / property すべて旧と同一 |
| NO-OP | \`apps/*/dist/\` | frontend 修正なし |
| CREATE | \`infrastructure/lib/app-plane-core/\` | 2 files (app-plane-core.ts / index.ts) |
| CREATE | \`infrastructure/test/app-plane-core/build-app-plane-core.test.ts\` | unit test 4 件 |
| UPDATE | \`infrastructure/lib/tenant-template/tenant-template-stack.ts\` | 60 行の構築 logic を builder 1 呼び出しに圧縮 (= wrapper 責務だけ残す) |

## ADR-016 Phase plan の進捗

- [x] **Phase 1**: AppPlaneCore 抽出 + TenantTemplateStack wrapper 化 ← **本 PR**
- [ ] Phase 2: ProblemDeployBackend \`eventBusArn\` optional 化 + local bus fallback
- [ ] Phase 3: TenkaCloudLiteStack 新設
- [ ] Phase 4: CLI runner (\`scripts/tenkacloud-lite.ts\`)
- [ ] Phase 5: サンプル問題で動作確認 + README に Lite mode セクション

## 関連

- Relates #778 (Phase 1。 Phase 2-5 は別 PR で順次)
- 前段 ADR-016: [\`docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html\`](./docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html) (= 本 PR の blueprint)
- 同 session 内の関連 PR (本日 merge 済): #783 / #784 / #785 / #786 / #787 / #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable App Plane Core module for streamlined tenant infrastructure setup, consolidating hosting, identity, and API Gateway construction into a cohesive builder pattern.

* **Tests**
  * Added comprehensive test coverage validating the App Plane Core builder's construction of core infrastructure components and runtime configuration deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/789)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->