### PR TITLE
feat(#778 Phase 2): ProblemDeployBackendStack.eventBusArn を optional 化

### DIFF
--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -28,8 +28,16 @@ import { ProblemEndpointsTable } from "./problem-endpoints-table";
 import { TeamsTable } from "./teams-table";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
-  /** SBT ControlPlane の EventBus ARN。Deploy 系イベントを流す。 */
-  readonly eventBusArn: string;
+  /**
+   * SBT ControlPlane の EventBus ARN。Deploy 系イベントを流す。
+   *
+   * Issue #778 ADR-016 Phase 2: Full mode (= ControlPlaneStack 経由) では SBT 同梱の
+   * EventBus を共有するため必須。 Lite mode (= TenkaCloudLiteStack、 Phase 3) では
+   * ControlPlane が存在しないので undefined を渡し、 本 stack 内で local EventBus を作って
+   * fallback する。 cross-stack event 受信は Full mode の ServerlessSaaSPipeline 側だけが
+   * 行うため、 Lite では local bus で自己完結する。
+   */
+  readonly eventBusArn?: string;
   /**
    * tenant API から deploy Lambda を invoke する経路で、JWT が解決できなかった場合の
    * `DEFAULT_TENANT_ID` env フォールバック値。
@@ -186,7 +194,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     const competitorAccounts = new CompetitorAccountsTable(this, "CompetitorAccounts");
     this.competitorAccountsTable = competitorAccounts.table;
     this.problemEndpointsTable = endpoints.table;
-    const eventBus = EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn);
+    // Issue #778 ADR-016 Phase 2: eventBusArn が渡されていれば既存の SBT bus を import、
+    // 渡されていなければ Lite mode と判定して local EventBus を新規に作る。 後者では Step
+    // Functions Rule も local bus にぶら下がるため、 cross-stack 依存が増えない。
+    const eventBus = props.eventBusArn
+      ? EventBus.fromEventBusArn(this, "ImportedEventBus", props.eventBusArn)
+      : new EventBus(this, "LocalEventBus", {
+          eventBusName: `tenkacloud-problem-deploy-local-${cdk.Stack.of(this).stackName}`,
+        });
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
     // Phase 2.2 (Issue #459): CompetitorAccounts table + env を渡して verified-only gate を有効化。

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -600,3 +600,44 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 });
+
+describe("ProblemDeployBackendStack (#778 ADR-016 Phase 2: eventBusArn optional 化)", () => {
+  function synthLite(): Template {
+    const app = new cdk.App();
+    const stack = new ProblemDeployBackendStack(app, "LiteStack", {
+      sourceBucketName: "test-source-bucket-lite",
+      sourceObjectKey: "source.zip",
+      problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
+      problemsScoring: {},
+      problemsEndpoints: {},
+      environmentName: "development",
+      // eventBusArn を省略 (= Lite mode)
+    });
+    return Template.fromStack(stack);
+  }
+
+  it("eventBusArn を省略すると local EventBus を 1 つ新規に作るべき (= Lite mode の自己完結)", () => {
+    const liteTemplate = synthLite();
+    liteTemplate.resourceCountIs("AWS::Events::EventBus", 1);
+    liteTemplate.hasResourceProperties(
+      "AWS::Events::EventBus",
+      Match.objectLike({
+        Name: Match.stringLikeRegexp("^tenkacloud-problem-deploy-local-"),
+      }),
+    );
+  });
+
+  it("eventBusArn を渡した既存 (= Full mode) では local EventBus を作らないべき", () => {
+    const fullTemplate = synthDefault();
+    fullTemplate.resourceCountIs("AWS::Events::EventBus", 0);
+  });
+
+  it("eventBusArn 省略でも DeployApi / EventApi / CompetitorAccountsApi / GenericScoring Lambda は同じ構成で生えるべき (= 機能 dormant にならない)", () => {
+    const liteTemplate = synthLite();
+    const lambdaCount = Object.keys(liteTemplate.findResources("AWS::Lambda::Function")).length;
+    expect(lambdaCount).toBeGreaterThan(0);
+    // EventBridge Rule (= Step Functions trigger) も local bus にぶら下がる。
+    const ruleCount = Object.keys(liteTemplate.findResources("AWS::Events::Rule")).length;
+    expect(ruleCount).toBeGreaterThan(0);
+  });
+});

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -602,42 +602,71 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
 });
 
 describe("ProblemDeployBackendStack (#778 ADR-016 Phase 2: eventBusArn optional 化)", () => {
-  function synthLite(): Template {
-    const app = new cdk.App();
-    const stack = new ProblemDeployBackendStack(app, "LiteStack", {
-      sourceBucketName: "test-source-bucket-lite",
-      sourceObjectKey: "source.zip",
-      problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
-      problemsScoring: {},
-      problemsEndpoints: {},
-      environmentName: "development",
-      // eventBusArn を省略 (= Lite mode)
-    });
-    return Template.fromStack(stack);
-  }
+  // synth は 5 個の NodejsFunction (= esbuild bundling) を含むため CI 上で ~7s かかる。
+  // vitest の default 5s timeout を 30s に拡張する (= 既存 #538 test と同じ pattern)。
+  const SYNTH_TIMEOUT_MS = 30_000;
 
-  it("eventBusArn を省略すると local EventBus を 1 つ新規に作るべき (= Lite mode の自己完結)", () => {
-    const liteTemplate = synthLite();
-    liteTemplate.resourceCountIs("AWS::Events::EventBus", 1);
-    liteTemplate.hasResourceProperties(
-      "AWS::Events::EventBus",
-      Match.objectLike({
-        Name: Match.stringLikeRegexp("^tenkacloud-problem-deploy-local-"),
-      }),
-    );
-  });
+  // describe scope で 1 度だけ synth して、 3 件の it で再利用 (= per-test の重複 synth で
+  // 21s 消費するのを 7s に圧縮)。
+  let liteTemplate: Template;
+  let fullTemplate: Template;
 
-  it("eventBusArn を渡した既存 (= Full mode) では local EventBus を作らないべき", () => {
-    const fullTemplate = synthDefault();
-    fullTemplate.resourceCountIs("AWS::Events::EventBus", 0);
-  });
+  it(
+    "eventBusArn を省略すると local EventBus を 1 つ新規に作るべき (= Lite mode の自己完結)",
+    () => {
+      const app = new cdk.App();
+      const stack = new ProblemDeployBackendStack(app, "LiteStack", {
+        sourceBucketName: "test-source-bucket-lite",
+        sourceObjectKey: "source.zip",
+        problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
+        problemsScoring: {},
+        problemsEndpoints: {},
+        environmentName: "development",
+        // eventBusArn を省略 (= Lite mode)
+      });
+      liteTemplate = Template.fromStack(stack);
+      liteTemplate.resourceCountIs("AWS::Events::EventBus", 1);
+      liteTemplate.hasResourceProperties(
+        "AWS::Events::EventBus",
+        Match.objectLike({
+          Name: Match.stringLikeRegexp("^tenkacloud-problem-deploy-local-"),
+        }),
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
 
-  it("eventBusArn 省略でも DeployApi / EventApi / CompetitorAccountsApi / GenericScoring Lambda は同じ構成で生えるべき (= 機能 dormant にならない)", () => {
-    const liteTemplate = synthLite();
-    const lambdaCount = Object.keys(liteTemplate.findResources("AWS::Lambda::Function")).length;
-    expect(lambdaCount).toBeGreaterThan(0);
-    // EventBridge Rule (= Step Functions trigger) も local bus にぶら下がる。
-    const ruleCount = Object.keys(liteTemplate.findResources("AWS::Events::Rule")).length;
-    expect(ruleCount).toBeGreaterThan(0);
-  });
+  it(
+    "eventBusArn を渡した既存 (= Full mode) では local EventBus を作らないべき",
+    () => {
+      fullTemplate = synthDefault();
+      fullTemplate.resourceCountIs("AWS::Events::EventBus", 0);
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "eventBusArn 省略でも DeployApi / EventApi / CompetitorAccountsApi / GenericScoring Lambda は同じ構成で生えるべき (= 機能 dormant にならない)",
+    () => {
+      // 前の test で立てた liteTemplate を再利用 (= synth コストを節約)。
+      if (!liteTemplate) {
+        const app = new cdk.App();
+        const stack = new ProblemDeployBackendStack(app, "LiteStack2", {
+          sourceBucketName: "test-source-bucket-lite-2",
+          sourceObjectKey: "source.zip",
+          problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
+          problemsScoring: {},
+          problemsEndpoints: {},
+          environmentName: "development",
+        });
+        liteTemplate = Template.fromStack(stack);
+      }
+      const lambdaCount = Object.keys(liteTemplate.findResources("AWS::Lambda::Function")).length;
+      expect(lambdaCount).toBeGreaterThan(0);
+      // EventBridge Rule (= Step Functions trigger) も local bus にぶら下がる。
+      const ruleCount = Object.keys(liteTemplate.findResources("AWS::Events::Rule")).length;
+      expect(ruleCount).toBeGreaterThan(0);
+    },
+    SYNTH_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

[ADR-016](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html) Phase 2: TenkaCloud Lite mode を支える小さな refactor。 \`ProblemDeployBackendStack\` の \`eventBusArn\` を optional 化し、 未指定時に local EventBus を新規作成する fallback を追加する。

- Full mode (= ControlPlaneStack 経由) では今までどおり SBT 同梱の EventBus を共有 (= 既存挙動完全維持)
- Lite mode (= 後続 Phase 3 で追加する \`TenkaCloudLiteStack\`) では \`eventBusArn\` 省略時に \`new EventBus(this, \"LocalEventBus\", ...)\` で stack 内に local bus を立てて自己完結

## 変更

| File | 内容 |
|---|---|
| \`infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts\` | \`eventBusArn: string\` → \`eventBusArn?: string\`、 \`undefined\` 時の local bus fallback を追加。 bus 名は \`tenkacloud-problem-deploy-local-\${stackName}\` で衝突回避 |
| \`infrastructure/test/problem-deploy-backend-stack.test.ts\` | Lite/Full mode の挙動を pin する describe block (3 件) を追加 |

## Test plan

- [x] \`bunx vitest run test/problem-deploy-backend-stack.test.ts\` — **34/34 pass**
- [x] \`bunx vitest run\` (infrastructure 全体) — **81 file / 844 test pass**
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [ ] reviewer: \`make synth\` を旧 main と本 PR で 2 回流し、 default 経路 (= \`eventBusArn\` を渡す) で CFn 物理差分 0 件を確認

## Regression 分析

- **Full mode (= bin/infrastructure.ts → ControlPlaneStack.eventBusArn) は不変**: \`eventBusArn\` が常に渡されるので import 経路を辿る。 stack の CFn 物理差分 0 件を invariant とする
- 既存 \`ProblemDeployBackendStack\` test は touch せず全 pass
- 新規 3 件は Lite mode の挙動 (= 省略時 local bus 生成、 Full mode との両立、 Lambda / Rule 構成不変) を pin
- IAM / DDB / API Gateway / Cognito 構造に変更なし
- ADR-015 harness rule (adr-self-contained / adr-must-be-html) に違反しない範囲で書いた

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| NO-OP | Full mode 既存 stack (= \`tenkacloud-problem-deploy\` が ControlPlane bus を import) | resource graph 同一 |
| CREATE | Lite mode 新 stack (= 後続 Phase 3 で実装) | 本 PR で追加した local bus fallback を使う |
| NO-OP | \`apps/*/dist/\` | frontend 修正なし |

## Phase plan の進捗

- [x] Phase 1: AppPlaneCore 抽出 ([#789](https://github.com/susumutomita/TenkaCloud/pull/789))
- [x] **Phase 2: ProblemDeployBackend.eventBusArn optional 化** ← **本 PR**
- [ ] Phase 3: TenkaCloudLiteStack 新設
- [ ] Phase 4: CLI runner (\`scripts/tenkacloud-lite.ts\`)
- [ ] Phase 5: サンプル問題で動作確認 + README に Lite mode セクション

Relates #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)