### PR TITLE
feat(#742 Phase 4): frontend ProblemPanel に progressive hint UI

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -28,11 +28,24 @@ export type ScoringKind =
   | "phased-polling"
   | "attack-detection";
 
+/**
+ * Issue #742 Phase 4: progressive hint view shape (= backend
+ * `ParticipantHintView` と同じ)。 revealed=false な hint は content 不在 (= 答えを
+ * frontend に漏らさない)、 revealed=true は content + revealedAt を含む。
+ */
+export interface ParticipantHintView {
+  readonly id: string;
+  readonly penalty: number;
+  readonly revealed: boolean;
+  readonly content?: string;
+  readonly revealedAt?: string;
+}
+
 export interface ParticipantScoringInfo {
   readonly kind: ScoringKind;
   readonly points?: number;
   readonly pointsPerSuccess?: number;
-  readonly hints?: readonly string[];
+  readonly hints?: readonly ParticipantHintView[];
   readonly flagSubmitted?: boolean;
 }
 
@@ -376,6 +389,37 @@ export async function getNotifications(
     teamLoginKey,
     { query, throwOn400: true, returnUndefinedOn404: true, signal },
   );
+}
+
+/**
+ * Issue #742 Phase 4: progressive hint reveal API。 `POST /portal/me/problems/{problemId}/hints/{hintId}/reveal`。
+ * 同 hintId 重複 reveal は idempotent (= 200 で kind=already_revealed)。
+ */
+export interface RevealHintResponse {
+  readonly kind: "ok" | "already_revealed";
+  readonly content: string;
+  readonly penaltyApplied: number;
+  readonly totalScore: number;
+  readonly revealedAt?: string;
+}
+
+export async function revealHint(
+  apiBaseUrl: string,
+  teamLoginKey: string,
+  problemId: string,
+  hintId: string,
+  signal?: AbortSignal,
+): Promise<RevealHintResponse> {
+  return (await portalFetch<RevealHintResponse>(
+    apiBaseUrl,
+    `portal/me/problems/${encodeURIComponent(problemId)}/hints/${encodeURIComponent(hintId)}/reveal`,
+    teamLoginKey,
+    {
+      method: "POST",
+      throwOn400: true,
+      signal,
+    },
+  )) as RevealHintResponse;
 }
 
 /**

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -15,8 +15,10 @@ import StatusIndicator, {
 import { useState } from "react";
 import {
   type DeploymentStatus,
+  type ParticipantHintView,
   type ParticipantProblemView,
   PortalValidationError,
+  revealHint,
   type SubmitFlagOutcome,
   submitFlag,
   TERMINAL_STATUSES,
@@ -167,7 +169,7 @@ function FlagSubmissionPanel({
   problemId: string;
   flagSubmitted: boolean;
   points: number;
-  hints: readonly string[];
+  hints: readonly ParticipantHintView[];
   onScored: () => Promise<void>;
 }) {
   const [flag, setFlag] = useState("");
@@ -209,13 +211,13 @@ function FlagSubmissionPanel({
   return (
     <SpaceBetween size="s">
       {hints.length > 0 && (
-        <Alert type="info" header="ヒント">
-          <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
-            {hints.map((h) => (
-              <li key={h}>{h}</li>
-            ))}
-          </ul>
-        </Alert>
+        <HintsPanel
+          apiBaseUrl={apiBaseUrl}
+          sessionToken={sessionToken}
+          problemId={problemId}
+          hints={hints}
+          onRevealed={onScored}
+        />
       )}
       <form onSubmit={handleSubmit}>
         <Form
@@ -256,5 +258,91 @@ function FlagSubmissionPanel({
         </Alert>
       )}
     </SpaceBetween>
+  );
+}
+
+/**
+ * Issue #742 Phase 4: progressive hint UI。
+ *
+ * - revealed=false (locked): 「ヒント N (-X pt)」 + 「reveal」 button
+ * - revealed=true (unlocked): hint content + revealedAt 表示
+ *
+ * reveal クリック時に POST /portal/me/problems/:problemId/hints/:hintId/reveal を叩き、
+ * 成功時に親 (= onScored) を呼んで score / hint 状態を refetch する (= optimistic に状態
+ * 更新せず、 server truth を読み直す)。 失敗時は inline error を表示。
+ */
+function HintsPanel({
+  apiBaseUrl,
+  sessionToken,
+  problemId,
+  hints,
+  onRevealed,
+}: {
+  apiBaseUrl: string;
+  sessionToken: string;
+  problemId: string;
+  hints: readonly ParticipantHintView[];
+  onRevealed: () => Promise<void>;
+}) {
+  const [revealing, setRevealing] = useState<string | null>(null);
+  const [revealError, setRevealError] = useState<string | null>(null);
+
+  const handleReveal = async (hintId: string) => {
+    if (revealing) return;
+    setRevealing(hintId);
+    setRevealError(null);
+    try {
+      await revealHint(apiBaseUrl, sessionToken, problemId, hintId);
+      await onRevealed();
+    } catch (err) {
+      if (err instanceof PortalValidationError) {
+        setRevealError(`バリデーションエラー: ${err.errorCode}`);
+      } else {
+        setRevealError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setRevealing(null);
+    }
+  };
+
+  return (
+    <Alert
+      type="info"
+      header={`ヒント (${hints.filter((h) => h.revealed).length} / ${hints.length} 公開済)`}
+    >
+      <SpaceBetween size="xs">
+        {hints.map((h, i) => (
+          <Box key={h.id}>
+            {h.revealed ? (
+              <Box>
+                <strong>ヒント {i + 1}:</strong> {h.content}
+                {h.revealedAt && (
+                  <Box variant="small" color="text-status-info" margin={{ top: "xxs" }}>
+                    公開済 ({describeAgo(h.revealedAt, Date.now())})
+                  </Box>
+                )}
+              </Box>
+            ) : (
+              <Box>
+                <strong>ヒント {i + 1}</strong> (公開すると -{h.penalty} pt){" "}
+                <Button
+                  variant="inline-link"
+                  loading={revealing === h.id}
+                  disabled={revealing !== null && revealing !== h.id}
+                  onClick={() => handleReveal(h.id)}
+                >
+                  公開する
+                </Button>
+              </Box>
+            )}
+          </Box>
+        ))}
+        {revealError && (
+          <Box color="text-status-error" variant="small">
+            {revealError}
+          </Box>
+        )}
+      </SpaceBetween>
+    </Alert>
   );
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -3,6 +3,7 @@ import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.j
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
 import { parseEndpointsHealth } from "../shared/endpoints-health.js";
+import { parseHintRevealedAttribute } from "../shared/hint-reveal.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
@@ -11,6 +12,25 @@ import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
  * stackOutputs は DDB に JSON 文字列で入っているが、UI に返す前に object へ展開する。
  * `flagOutputKey` で指定された field は **競技者に出さない** (= 当てる対象なので)。
  */
+
+/**
+ * Issue #742 Phase 4: progressive hint の view shape。 reveal 済 hint には content が乗り、
+ * 未 reveal hint は content を含まない (= server-side で revealed=false な行は content を
+ * 落として送り、 frontend に答えを漏らさない)。
+ *
+ *   - id: stable identifier (= scoring.hints[].id と同じ)
+ *   - penalty: reveal すると差し引かれるポイント (= 表示用、 0 許容)
+ *   - revealed: 既に reveal 済なら true
+ *   - content: revealed=true のときのみ存在
+ *   - revealedAt: revealed=true のときのみ、 ISO 8601 (= UI で reveal 時刻表示用)
+ */
+export interface ParticipantHintView {
+  readonly id: string;
+  readonly penalty: number;
+  readonly revealed: boolean;
+  readonly content?: string;
+  readonly revealedAt?: string;
+}
 
 /**
  * Participant 側に出してよい scoring 情報の view。`kind` は 5 種 builtin DSL のいずれか
@@ -29,7 +49,12 @@ export interface ParticipantScoringInfo {
   readonly pointsPerSuccess?: number;
   readonly pointsAllOk?: number;
   readonly pointsPerAttack?: number;
-  readonly hints?: readonly string[];
+  /**
+   * Issue #742 Phase 4: progressive hint。 revealed=false な hint は content を持たず、
+   * frontend は locked 表示 + reveal button を出す。 revealed=true は content を含み
+   * unlocked 表示 (= 旧 string[] 形式から正式 view 形式に migrate)。
+   */
+  readonly hints?: readonly ParticipantHintView[];
   /** Challenge / flag のとき、提出済みなら true。再提出は加点されない。 */
   readonly flagSubmitted?: boolean;
 }
@@ -159,15 +184,29 @@ function toScoringInfo(
   item: Partial<DeploymentItem>,
 ): ParticipantScoringInfo {
   if (scoring.kind === "flag") {
-    // Issue #742 Phase 1: hints は ProgressiveHint[] (= {id, content, penalty}) に正規化済。
-    // frontend (= ProblemPanel) は現状 string[] を期待しているので、 Phase 1 互換のため
-    // content だけを取り出して string[] に flatten する (= 既存挙動 = 全 hint 常時露出 を維持)。
-    // Phase 2 で reveal API + UI を追加するとき、 view interface を ProgressiveHint[] に
-    // 切り替える (= 別 PR でやる)。
+    // Issue #742 Phase 4: progressive hint view を組み立てる。 revealed=false な hint は
+    // content を落として送る (= 答えを frontend に漏らさない)。 revealed=true は content +
+    // revealedAt を含める。 reveal 状態は item.hintsRevealed (= Phase 2 で DDB に保存) から
+    // 読む。
+    const revealed = parseHintRevealedAttribute(item.hintsRevealed);
+    const revealedMap = new Map(revealed.map((r) => [r.hintId, r] as const));
+    const hintViews: ParticipantHintView[] | undefined = scoring.hints?.map((h) => {
+      const r = revealedMap.get(h.id);
+      if (r) {
+        return {
+          id: h.id,
+          penalty: h.penalty,
+          revealed: true,
+          content: h.content,
+          revealedAt: r.revealedAt,
+        };
+      }
+      return { id: h.id, penalty: h.penalty, revealed: false };
+    });
     return {
       kind: "flag",
       points: scoring.points,
-      ...(scoring.hints ? { hints: scoring.hints.map((h) => h.content) } : {}),
+      ...(hintViews ? { hints: hintViews } : {}),
       flagSubmitted: item.flagSubmitted === true,
     };
   }


### PR DESCRIPTION
## Summary

[Issue #742](https://github.com/susumutomita/TenkaCloud/issues/742) Phase 4: 競技者が hint を 1 つずつ reveal できる UI。 reveal すると backend (Phase 3 API、 [#792](https://github.com/susumutomita/TenkaCloud/pull/792)) を叩いて score を deduct + 既存 hint state を refetch。

## 変更

| File | 内容 |
|---|---|
| \`infrastructure/.../lookup.ts\` | \`ParticipantScoringInfo.hints\` を \`readonly ParticipantHintView[]\` に変更 (= 旧 \`string[]\` から migrate)。 \`ParticipantHintView\` = \`{ id, penalty, revealed, content?, revealedAt? }\`。 revealed=false なら content を落として送る (= 答えを frontend に漏らさない) |
| \`apps/participant-portal/.../portal-client.ts\` | \`ParticipantHintView\` type 追加、 \`revealHint\` API client function 追加 |
| \`apps/participant-portal/.../ProblemPanel.tsx\` | 新 \`HintsPanel\` component: locked hint は「公開する (-N pt)」button、 unlocked hint は content + revealedAt 表示。 「N / M 公開済」 header で進捗表示 |

## UI mock

\` \` \`
ヒント (1 / 3 公開済)
├ ヒント 1: AWS Console (SSM Parameter Store) で値を読み出す
│   公開済 (3 分前)
├ ヒント 2 (公開すると -10 pt)  [公開する]
└ ヒント 3 (公開すると -20 pt)  [公開する]
\` \` \`

## Test plan

- [x] \`bunx tsc --noEmit\` (infrastructure + apps/participant-portal) — clean
- [x] \`bunx vitest run\` (apps/participant-portal) — **17 file / 146 test pass**
- [x] \`bunx vitest run\` (infrastructure) — **83 file / 864 test pass**
- [x] \`bunx biome check\` — clean
- [ ] reviewer: dev server で hint を reveal → 不在 hint が unlock + score が deduct されることを確認
- [ ] reviewer: 既に reveal 済 hint を再 click → API が 200 already_revealed を返し、 UI が壊れないことを確認

## Regression 分析

- backend lookup.ts の view shape 変更: 旧 \`string[]\` を呼んでいた frontend は本 PR で更新済。 backend と frontend が同 PR で揃って migrate するため type mismatch が起きない
- 旧 portal Lambda + 新 frontend (= 一時的にロールアウト順序がずれた場合) は revealed flag 不在で全 locked 表示になる (= 機能退化、 動作崩壊なし)
- 既存 portal-client / infrastructure tests すべて green
- \`ParticipantHintView\` は backend / frontend で同 shape を共有 (= duplicated type だが、 cross-package import 経路を増やさないため意図的に分離)
- \`HintsPanel\` 内 \`revealing\` state は per-button (= 同時に複数 reveal させない、 rate limit + UX 両面で線形に保つ)
- revealHint API error は inline 表示 (= rate-limited / unknown_hint / unauthorized 等を error code として見せる)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | \`apps/participant-portal/dist/\` | HintsPanel component が新規 import される |
| UPDATE | ParticipantPortal Lambda bundle | lookup.ts の view shape 変更で IAM / DDB 構造は不変 |
| NO-OP | CFn / DDB structural / Cognito / API Gateway | 設定変更なし |

## Phase plan の進捗

- [x] Phase 1: scoring metadata の hints を ProgressiveHint shape に拡張 ([#788](https://github.com/susumutomita/TenkaCloud/pull/788))
- [x] Phase 2: hintsRevealed DDB attribute の typing + helper ([#790](https://github.com/susumutomita/TenkaCloud/pull/790))
- [x] Phase 3: backend reveal-hint API ([#792](https://github.com/susumutomita/TenkaCloud/pull/792))
- [x] **Phase 4: frontend ProblemPanel に progressive hint UI** ← **本 PR**
- [ ] Phase 5: 他 4 kind に同 hint shape を共通拡張

Relates #742 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)