### PR TITLE
feat(#742 Phase 5): hints を全 5 builtin scoring kind に共通拡張 / Closes #742

### DIFF
--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -51,6 +51,12 @@ export interface UptimeFlatEndpoint {
   readonly pointsPerSuccess?: number;
 }
 
+/**
+ * Issue #742 Phase 5: 全 5 種 builtin kind が hints を持てるよう共通 shape として
+ * `ProgressiveHint[]` を再利用。 flag 以外でも metadata に hints を書けば
+ * Phase 4 で導入した reveal UI が同じ動作で機能する (= phased-polling や
+ * uptime 系でも 「攻撃に対する初動 hint」 を penalty 付きで開放できる)。
+ */
 export interface UptimeFlatScoringMetadata {
   /**
    * `uptime-flat` は新名。`uptime` は legacy SCHEMA (= Phase 1) との互換を保つための alias。
@@ -59,6 +65,8 @@ export interface UptimeFlatScoringMetadata {
   readonly kind: "uptime-flat" | "uptime";
   readonly endpoints: readonly UptimeFlatEndpoint[];
   readonly pointsPerSuccess: number;
+  /** Issue #742 Phase 5: 全 5 種 builtin kind で hints を許容する共通 field。 */
+  readonly hints?: readonly ProgressiveHint[];
 }
 
 export interface UptimeMultiProbedSlot {
@@ -72,6 +80,8 @@ export interface UptimeMultiScoringMetadata {
   readonly probedSlots: readonly UptimeMultiProbedSlot[];
   readonly pointsAllOk: number;
   readonly failurePenalty?: number;
+  /** Issue #742 Phase 5: hints 共通 field。 */
+  readonly hints?: readonly ProgressiveHint[];
 }
 
 export interface PhasedPollingPlatformRule {
@@ -104,6 +114,8 @@ export interface PhasedPollingScoringMetadata {
   readonly failurePenalty?: number;
   readonly responsePenalties?: readonly PhasedPollingResponsePenalty[];
   readonly bonuses?: readonly PhasedPollingBonus[];
+  /** Issue #742 Phase 5: hints 共通 field。 */
+  readonly hints?: readonly ProgressiveHint[];
 }
 
 export interface AttackDetectionCategory {
@@ -116,6 +128,8 @@ export interface AttackDetectionScoringMetadata {
   readonly statsOutputKey: string;
   readonly pointsPerAttack: number;
   readonly categories?: readonly AttackDetectionCategory[];
+  /** Issue #742 Phase 5: hints 共通 field。 */
+  readonly hints?: readonly ProgressiveHint[];
 }
 
 export type ProblemScoringMetadata =
@@ -188,7 +202,7 @@ function parseUptimeFlat(
   value: unknown,
   kindLiteral: "uptime" | "uptime-flat",
 ): UptimeFlatScoringMetadata | undefined {
-  const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown };
+  const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown; hints?: unknown };
   if (!Array.isArray(u.endpoints) || u.endpoints.length === 0) return undefined;
   if (typeof u.pointsPerSuccess !== "number" || u.pointsPerSuccess <= 0) return undefined;
   const endpoints: UptimeFlatEndpoint[] = [];
@@ -222,11 +236,22 @@ function parseUptimeFlat(
   if (endpoints.length === 0) return undefined;
   // 入力 kind を保ったまま返す (= legacy `uptime` 採用 metadata の view 互換)。
   // dispatcher 側は両者を flat probe として処理する。
-  return { kind: kindLiteral, endpoints, pointsPerSuccess: u.pointsPerSuccess };
+  const hints = parseHints(u.hints);
+  return {
+    kind: kindLiteral,
+    endpoints,
+    pointsPerSuccess: u.pointsPerSuccess,
+    ...(hints ? { hints } : {}),
+  };
 }
 
 function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefined {
-  const u = value as { probedSlots?: unknown; pointsAllOk?: unknown; failurePenalty?: unknown };
+  const u = value as {
+    probedSlots?: unknown;
+    pointsAllOk?: unknown;
+    failurePenalty?: unknown;
+    hints?: unknown;
+  };
   if (!Array.isArray(u.probedSlots) || u.probedSlots.length === 0) return undefined;
   if (typeof u.pointsAllOk !== "number" || u.pointsAllOk <= 0) return undefined;
   const probedSlots: UptimeMultiProbedSlot[] = [];
@@ -240,11 +265,13 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     probedSlots.push({ slot: e.slot, path: e.path, expectStatus });
   }
   if (probedSlots.length === 0) return undefined;
+  const hints = parseHints(u.hints);
   return {
     kind: "uptime-multi",
     probedSlots,
     pointsAllOk: u.pointsAllOk,
     ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
+    ...(hints ? { hints } : {}),
   };
 }
 
@@ -256,6 +283,7 @@ function parsePhasedPolling(value: unknown): PhasedPollingScoringMetadata | unde
     failurePenalty?: unknown;
     responsePenalties?: unknown;
     bonuses?: unknown;
+    hints?: unknown;
   };
   if (typeof p.intervalMinutes !== "number" || p.intervalMinutes <= 0) return undefined;
   if (!p.probe || typeof p.probe !== "object") return undefined;
@@ -307,6 +335,7 @@ function parsePhasedPolling(value: unknown): PhasedPollingScoringMetadata | unde
     }
   }
 
+  const hints = parseHints(p.hints);
   return {
     kind: "phased-polling",
     intervalMinutes: p.intervalMinutes,
@@ -315,6 +344,7 @@ function parsePhasedPolling(value: unknown): PhasedPollingScoringMetadata | unde
     ...(typeof p.failurePenalty === "number" ? { failurePenalty: p.failurePenalty } : {}),
     ...(responsePenalties.length > 0 ? { responsePenalties } : {}),
     ...(bonuses.length > 0 ? { bonuses } : {}),
+    ...(hints ? { hints } : {}),
   };
 }
 
@@ -323,6 +353,7 @@ function parseAttackDetection(value: unknown): AttackDetectionScoringMetadata | 
     statsOutputKey?: unknown;
     pointsPerAttack?: unknown;
     categories?: unknown;
+    hints?: unknown;
   };
   if (typeof a.statsOutputKey !== "string" || a.statsOutputKey.length === 0) return undefined;
   if (typeof a.pointsPerAttack !== "number" || a.pointsPerAttack <= 0) return undefined;
@@ -338,11 +369,13 @@ function parseAttackDetection(value: unknown): AttackDetectionScoringMetadata | 
       });
     }
   }
+  const hints = parseHints(a.hints);
   return {
     kind: "attack-detection",
     statsOutputKey: a.statsOutputKey,
     pointsPerAttack: a.pointsPerAttack,
     ...(categories.length > 0 ? { categories } : {}),
+    ...(hints ? { hints } : {}),
   };
 }
 

--- a/infrastructure/test/scoring-metadata.test.ts
+++ b/infrastructure/test/scoring-metadata.test.ts
@@ -145,6 +145,70 @@ describe("parseScoringMetadata", () => {
     });
   });
 
+  describe("[#742 Phase 5] hints は全 5 kind に共通拡張", () => {
+    it("uptime-flat kind が hints を受け入れて ProgressiveHint[] に正規化すべき", () => {
+      const result = parseScoringMetadata({
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+        hints: [{ id: "h1", content: "first endpoint", penalty: 5 }],
+      });
+      expect(result?.kind).toBe("uptime-flat");
+      if (result?.kind !== "uptime-flat") return;
+      expect(result.hints).toEqual([{ id: "h1", content: "first endpoint", penalty: 5 }]);
+    });
+
+    it("uptime-multi kind が hints を受け入れるべき (v1 legacy も同様に動く)", () => {
+      const result = parseScoringMetadata({
+        kind: "uptime-multi",
+        probedSlots: [{ slot: "frontend", path: "/", expectStatus: [200] }],
+        pointsAllOk: 100,
+        hints: ["legacy hint"],
+      });
+      expect(result?.kind).toBe("uptime-multi");
+      if (result?.kind !== "uptime-multi") return;
+      expect(result.hints).toEqual([{ id: "hint-1", content: "legacy hint", penalty: 0 }]);
+    });
+
+    it("phased-polling kind が hints を受け入れるべき", () => {
+      const result = parseScoringMetadata({
+        kind: "phased-polling",
+        intervalMinutes: 1,
+        probe: { metaPath: "/meta", scorePath: "/score" },
+        platformRules: { ec2: { points: 100 } },
+        hints: [{ id: "phase-hint", content: "migrate to lambda first", penalty: 50 }],
+      });
+      expect(result?.kind).toBe("phased-polling");
+      if (result?.kind !== "phased-polling") return;
+      expect(result.hints).toEqual([
+        { id: "phase-hint", content: "migrate to lambda first", penalty: 50 },
+      ]);
+    });
+
+    it("attack-detection kind が hints を受け入れるべき", () => {
+      const result = parseScoringMetadata({
+        kind: "attack-detection",
+        statsOutputKey: "AttackCount",
+        pointsPerAttack: 10,
+        hints: [{ id: "attack-hint", content: "watch WAF logs", penalty: 5 }],
+      });
+      expect(result?.kind).toBe("attack-detection");
+      if (result?.kind !== "attack-detection") return;
+      expect(result.hints).toEqual([{ id: "attack-hint", content: "watch WAF logs", penalty: 5 }]);
+    });
+
+    it("hints を持たない既存 problem (= 全 4 kind) は touch されない", () => {
+      const uf = parseScoringMetadata({
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      });
+      expect(uf?.kind).toBe("uptime-flat");
+      if (uf?.kind !== "uptime-flat") return;
+      expect(uf.hints).toBeUndefined();
+    });
+  });
+
   describe("uptime 形式 (legacy alias of uptime-flat)", () => {
     it("endpoints が array + pointsPerSuccess が number なら narrow するべき", () => {
       const cfg = {


### PR DESCRIPTION
## Summary

[Issue #742](https://github.com/susumutomita/TenkaCloud/issues/742) **Phase 5 (最終 phase)**: 旧 flag kind 専用だった progressive hints を、 全 5 種 builtin scoring kind (flag / uptime / uptime-flat / uptime-multi / phased-polling / attack-detection) で書けるように parser を拡張する。

これで Battle 系問題でも 「攻撃に対する初動 hint」 を penalty 付きで開放できる。 Phase 1-4 で導入した DDB attribute + reveal API + UI は kind を区別せず動くので、 本 Phase は parser の type / runtime acceptance のみで完結する。

## 変更

| File | 内容 |
|---|---|
| \`infrastructure/lib/utils/scoring-metadata.ts\` | UptimeFlatScoringMetadata / UptimeMultiScoringMetadata / PhasedPollingScoringMetadata / AttackDetectionScoringMetadata に \`hints?: readonly ProgressiveHint[]\` 追加。 parseUptimeFlat / parseUptimeMulti / parsePhasedPolling / parseAttackDetection で \`parseHints\` helper を呼んで正規化 |
| \`infrastructure/test/scoring-metadata.test.ts\` | Phase 5 describe block で 5 件の test (= 4 kind それぞれ hints を受け入れる + 不在で touch しない regression pin) |

## SCHEMA.json の拡張は本 PR 外

\`problems/SCHEMA.json\` の各 kind に hints property を追加する SCHEMA 厳密化は将来 PR に分離。 TS parser は既に hints を受け入れるので、 runtime の挙動は本 PR で完結する (= SCHEMA strictness は \`validate-problems\` script の soft check のみが緩い状態)。 SCHEMA への追加は機械的 copy-paste 5 箇所なので、 別 PR で対応する。

## Test plan

- [x] \`bunx vitest run test/scoring-metadata.test.ts\` — **34/34 pass**
- [x] \`bunx vitest run\` (infrastructure 全体) — **83 file / 869 test pass**
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [x] \`make validate-problems\` — 既存 4 件すべて green
- [ ] reviewer: uptime-flat な問題 (例: hello-world-battle) に hints を 1 つ追加 → portal で reveal button が表示 → reveal で score 減点 が機能することを確認

## Regression 分析

- 既存 problem (= 5 種すべて hints 不在) は \`parseHints\` が undefined を返し、 output 型でも hints が undefined となり既存 test が green
- TS interface は optional field 追加のみ (= breaking change なし)
- 全 83 file 869 test green (= 旧 + 新 5 件)
- typecheck / biome / harness clean

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| UPDATE | ParticipantPortal / GenericScoring Lambda bundle | scoring-metadata parser の拡張差分のみ |
| NO-OP | DDB / CFn / IAM / Cognito / API Gateway 構造 | 設定変更なし |
| NO-OP | \`apps/*/dist/\` | frontend 修正なし (= Phase 4 で導入した HintsPanel が kind 不問で動く) |

## Phase plan の進捗 (= 完成)

- [x] Phase 1: scoring metadata の hints を ProgressiveHint shape に拡張 ([#788](https://github.com/susumutomita/TenkaCloud/pull/788))
- [x] Phase 2: hintsRevealed DDB attribute の typing + helper ([#790](https://github.com/susumutomita/TenkaCloud/pull/790))
- [x] Phase 3: backend reveal-hint API ([#792](https://github.com/susumutomita/TenkaCloud/pull/792))
- [x] Phase 4: frontend ProblemPanel に progressive hint UI ([#793](https://github.com/susumutomita/TenkaCloud/pull/793))
- [x] **Phase 5: 他 4 kind に同 hint shape を共通拡張** ← **本 PR**

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)