### PR TITLE
docs(ADR-017): Cloud Action Intent / Trust Bridge — cross-cloud authority transfer (#795)

### DIFF
--- a/docs/architecture/adr-017-cloud-action-intent-trust-bridge.html
+++ b/docs/architecture/adr-017-cloud-action-intent-trust-bridge.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-017: Cloud Action Intent / Trust Bridge — cross-cloud authority transfer</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.muted   { background: var(--c-bg-soft); color: var(--c-muted); }
+  .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .8rem; margin: 1rem 0; }
+  .decision-card { border: 1px solid var(--c-border); border-radius: 6px; padding: .8rem 1rem; background: var(--c-bg-soft); }
+  .decision-card .num { font-size: 0.78rem; font-weight: 700; color: var(--c-link); letter-spacing: 0.05em; }
+  .decision-card .title { font-weight: 600; margin: 0.2rem 0 0.4rem; }
+  .decision-card .body { font-size: 0.88rem; color: var(--c-text); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-017: Cloud Action Intent / Trust Bridge — cross-cloud authority transfer</h1>
+  <p><em>credentials を移送せず、 signed intents を移送して provider-native の短命 authority と交換する protocol 層を <code>packages/trust-bridge</code> として持つ</em></p>
+  <div class="meta">
+    <div><b>Status:</b><span class="badge accept">Accepted</span> 2026-05-15</div>
+    <div><b>Tracking:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/795">#795</a></div>
+    <div><b>Related:</b>
+      <a href="./adr-002-cross-account-federation.html">ADR-002</a>、
+      <a href="./adr-007-outside-in.html">ADR-007</a>、
+      <a href="./adr-010-api-first-cli-mcp.html">ADR-010</a>、
+      <a href="./adr-015-adr-convention-as-harness.html">ADR-015</a>、
+      <a href="./adr-016-tenkacloud-lite-app-plane-core.html">ADR-016</a>
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>TenkaCloud は AWS 専用の SaaS から、 多 cloud 競技 (= AWS + GCP + Azure + Cloudflare 上で問題を deploy / scoring する形) へ広げる構想がある。 同時に、 AI agent から自動 deploy / destroy を呼ぶ場面でも認可境界が課題になる。</p>
+
+<p>「multi-cloud で資源を扱う」 問題の hard part は provisioning ではなく <strong>authority transfer</strong> である。</p>
+
+<pre>あるクラウド上の workload が、 別 provider / 別 account でクラウド操作を実行する権限を、
+**長寿命 credential を信頼境界を越えて移送せず** に、 どう安全に得るか?</pre>
+
+<p>既存 primitive は十分にある:</p>
+
+<table>
+<thead><tr><th>Primitive</th><th>役割</th></tr></thead>
+<tbody>
+<tr><td>OIDC / JWT / JWS</td><td>標準的な signed token 表現</td></tr>
+<tr><td>OAuth Token Exchange (RFC 8693)</td><td>token → token の交換 protocol</td></tr>
+<tr><td>AWS <code>AssumeRole</code> / <code>AssumeRoleWithWebIdentity</code></td><td>短命 STS credentials の発行</td></tr>
+<tr><td>GCP Workload Identity Federation</td><td>外部 IdP の token で GCP service account を引く</td></tr>
+<tr><td>Azure Federated Identity Credential</td><td>外部 OIDC で Azure AD app を引く</td></tr>
+<tr><td>SPIFFE / SPIRE</td><td>workload identity 配布の標準</td></tr>
+<tr><td>OPA / Cedar</td><td>policy engine</td></tr>
+</tbody>
+</table>
+
+<p>しかし TenkaCloud には これらより 1 段上 の <strong>cloud action authority transfer protocol</strong> 層が無い。 具体的には、 「<em>誰</em>が、 <em>何の context</em> で (tenant / event / team / problem / deployment)、 <em>どの provider</em> に、 <em>どの action</em> を、 <em>どの scope</em> で、 <em>どれくらいの TTL</em> でやろうとしているか」 を構造化して signed 化する protocol が欠けている。</p>
+
+<h3>なぜ既存 primitive 単体では足りないか</h3>
+
+<p>OIDC や AssumeRole は <strong>identity</strong> や <strong>credential</strong> の primitives であって、 <strong>action intent</strong> の primitive ではない。 「Team Alpha が Problem hello-world の deploy を AWS account 449... に実行しようとしている」 のような <strong>context-aware request</strong> を運ぶ data model が無い。</p>
+
+<p>結果として、 多くの実装は次の anti-pattern に倒れる:</p>
+
+<pre>AWS runner が GCP service account key を保管する
+AWS runner が Azure client secret を保管する
+AWS runner が Cloudflare API token を保管する
+Terraform runner が全 provider credential を持ちこむ</pre>
+
+<p>これは enterprise-grade cloud automation / AI agent governance / cloud competition infrastructure のいずれの観点でも受け入れがたい。 TenkaCloud は <strong>credentials を移送せず、 signed intents を移送する</strong> モデルを採る。</p>
+
+<h3>制約</h3>
+
+<table>
+<thead><tr><th>制約</th><th>影響</th></tr></thead>
+<tbody>
+<tr><td>Custom cryptography 禁止</td><td>JWS / JWT / OIDC など標準 library を再利用。 独自署名 algorithm を発明しない</td></tr>
+<tr><td>既存 AWS flow を壊さない</td><td>ADR-002 で確立した CompetitorDeployRole + ExternalId の経路は protocol 層 (AwsAssumeRoleExchange) の入口として再利用する</td></tr>
+<tr><td>Cost 0 原則</td><td>Phase 1 では DDB / Lambda / IAM の追加リソースを最小に保つ。 token 検証は in-Lambda で完結する</td></tr>
+<tr><td>OAuth / OIDC / SPIFFE の置換ではない</td><td>本 library は higher-level protocol。 下位 primitive は既存 library に委譲</td></tr>
+<tr><td>1 つの universal standard を最初から狙わない</td><td>TenkaCloud 内部利用 → OSS 公開 → community feedback の順で熟す</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<p><strong>Accepted:</strong> <code>packages/trust-bridge</code> という TenkaCloud 内部 library を新設し、 <em>credentials を移送せず、 signed CloudActionIntent を移送して provider-native の短命 credential と交換する</em> protocol 層を担わせる。 当初は AWS adapter 1 件で内部利用、 後続 phase で GCP / Azure / 外部公開を進める。</p>
+
+<div class="decisions">
+  <div class="decision-card">
+    <div class="num">D1</div>
+    <div class="title">CloudActionIntent schema</div>
+    <div class="body">tenant / event / team / problem / deployment / target / action / constraints を構造化する claim shape。 Zod で type-safe に narrowing 可能</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D2</div>
+    <div class="title">JWS 署名 + 検証</div>
+    <div class="body">canonical JSON を JWS (RFC 7515) で署名。 既存 library (= <code>jose</code> or <code>panva/jose</code>) を再利用、 custom crypto は書かない</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D3</div>
+    <div class="title">ProviderTokenExchange interface</div>
+    <div class="body">provider 別の交換ロジックを pluggable に。 初版は AWS (AssumeRoleExchange)、 Phase 4 で GCP / Azure / Cloudflare adapter を追加</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D4</div>
+    <div class="title">PolicyEvaluator interface</div>
+    <div class="body">policy decision は library に hard-code せず hook 化。 inline allowlist / OPA / Cedar / metadata constraints を後付け可能</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D5</div>
+    <div class="title">CloudActionAuditRecord</div>
+    <div class="body">decision 1 件 = audit 1 件。 enterprise 監査 / incident investigation / AI agent governance / competition replay debug の起点</div>
+  </div>
+  <div class="decision-card">
+    <div class="num">D6</div>
+    <div class="title">5 phase rollout</div>
+    <div class="body">Phase 1 内部 skeleton → Phase 2 AWS adapter → Phase 3 Deploy API 統合 → Phase 4 GCP / Azure experiment → Phase 5 protocol 文書化</div>
+  </div>
+</div>
+
+<h3>D1: CloudActionIntent schema</h3>
+
+<p>TenkaCloud の domain model (= tenant → event → team → problem → deployment) を そのまま claim 化することで、 「context-aware authority bridge」 にする (= generic credential broker ではなく)。</p>
+
+<pre>export interface CloudActionIntent {
+  readonly version: "tenkacloud.cloud-action-intent.v1";
+  readonly requestId: string;       // ULID 形式
+  readonly nonce: string;            // replay 防止
+  readonly source: {
+    readonly system: "tenkacloud";
+    readonly tenantId: string;
+    readonly eventId?: string;
+    readonly teamId?: string;
+    readonly problemId?: string;
+    readonly deploymentId?: string;
+    readonly targetId?: string;
+    readonly workloadId: string;     // 発信元 workload の安定 ID
+  };
+  readonly target: {
+    readonly provider: "aws" | "azure" | "gcp" | "cloudflare";
+    readonly providerAccountRef: string;
+    readonly region?: string;
+    readonly resourceScope?: string;
+  };
+  readonly action: {
+    readonly type: "deploy" | "destroy" | "inspect" | "collectOutputs" | "verifyTrust";
+    readonly engine: "cloudformation" | "terraform" | "bicep" | "pulumi" | "script";
+    readonly entry?: string;
+    readonly requestedScopes: readonly string[];
+  };
+  readonly constraints: {
+    readonly ttlSeconds: number;
+    readonly notBefore?: string;
+    readonly expiresAt: string;
+    readonly maxEstimatedCostUsd?: number;
+    readonly allowPrivilegeEscalation: boolean;
+  };
+}
+</pre>
+
+<p>schema 互換性は <code>version</code> field で扱う (= 将来 v2 を追加するときは破壊変更を避けつつ並走させる)。</p>
+
+<h3>D2: JWS 署名 + 検証</h3>
+
+<p>署名は JWS (RFC 7515) に閉じる。 canonical JSON は <code>JSON.stringify</code> + keys ソート方式を採用 (= <code>canonical-json</code> npm 等)。 鍵管理は AWS KMS asymmetric key (= 既に Free Tier 内で使える) を first-class にする。 私鍵を Lambda env に置かない。</p>
+
+<p>library 出力:</p>
+
+<pre>export interface CloudActionToken {
+  readonly format: "jws";
+  readonly token: string;   // JWS compact serialization
+}
+</pre>
+
+<h3>D3: ProviderTokenExchange interface</h3>
+
+<p>provider 別の adapter を統一 interface に揃える。 既存 AWS の <code>AssumeRole + ExternalId</code> 経路を library の adapter として包み直す (= ADR-002 の経路を破壊せず、 library 経由でアクセスする形に変える)。</p>
+
+<pre>export interface ProviderTokenExchange {
+  readonly provider: "aws" | "azure" | "gcp" | "cloudflare";
+  exchange(
+    token: CloudActionToken,
+    context: ExchangeContext,
+  ): Promise&lt;ProviderCredential&gt;;
+}
+</pre>
+
+<p>Phase 4 で <code>GcpWorkloadIdentityFederationExchange</code> / <code>AzureFederatedCredentialExchange</code> / <code>CloudflareScopedTokenExchange</code> を追加する。 Cloudflare は OAuth Token Exchange 経路を採る。</p>
+
+<h3>D4: PolicyEvaluator interface</h3>
+
+<p>policy decision は library の責務外。 hook 経由で外注し、 implementation は組み合わせ自由にする (= inline allowlist / OPA / Cedar / tenant policy document / problem metadata constraints / Terraform plan / CFn template risk analysis)。</p>
+
+<pre>export interface PolicyEvaluator {
+  evaluate(intent: CloudActionIntent): Promise&lt;PolicyDecision&gt;;
+}
+
+export interface PolicyDecision {
+  readonly decision: "allow" | "deny" | "needs_approval";
+  readonly reason?: string;
+  readonly allowedScopes?: readonly string[];
+  readonly maxTtlSeconds?: number;
+  readonly policyVersion?: string;
+}
+</pre>
+
+<h3>D5: CloudActionAuditRecord</h3>
+
+<p>policy decision 1 件 = audit log 1 件。 「誰が、 いつ、 どの context で、 どの provider に、 何を要求して、 何が決定され、 何 TTL の token が発行されたか」 を構造化保存する。</p>
+
+<pre>export interface CloudActionAuditRecord {
+  readonly requestId: string;
+  readonly tenantId: string;
+  readonly eventId?: string;
+  readonly teamId?: string;
+  readonly problemId?: string;
+  readonly deploymentId?: string;
+  readonly targetId?: string;
+  readonly provider: string;
+  readonly action: string;
+  readonly decision: "allow" | "deny" | "needs_approval";
+  readonly issuedCredentialExpiresAt?: string;
+  readonly policyVersion?: string;
+  readonly createdAt: string;
+}
+</pre>
+
+<p>初版は CloudWatch Logs に structured JSON で出す (= ADR-015 で確立した trace-log と同じ format)。 後続で DDB / S3 archive へ落とす経路を検討する。</p>
+
+<h3>D6: 5 phase rollout</h3>
+
+<table>
+<thead><tr><th>Phase</th><th>内容</th><th>独立 PR で merge 可能か</th></tr></thead>
+<tbody>
+<tr><td>1</td><td><code>packages/trust-bridge</code> 新設、 schema / signing / verification / TTL / nonce / audit / unit test</td><td>Yes (= 内部 dormant library として独立価値)</td></tr>
+<tr><td>2</td><td><code>AwsAssumeRoleExchange</code> 実装、 既存 competitor account / ExternalId 経路を adapter 経由でラップ</td><td>Yes (= AWS 経路の挙動不変)</td></tr>
+<tr><td>3</td><td>Deploy API が <code>CloudActionIntent</code> を発行 → 検証 → exchange → AWS 操作 の経路を内部利用、 user-visible API は不変</td><td>Yes (= 内部実装の置き換え)</td></tr>
+<tr><td>4</td><td>GCP / Azure adapter prototype、 1 つの cross-cloud demo target</td><td>Yes (= 1 provider ずつ独立 PR)</td></tr>
+<tr><td>5</td><td><code>docs/architecture/cloud-action-intent.md</code> で protocol 仕様を公開 (= claim model / threat model / provider mapping / OAuth/OIDC/SPIFFE との関係)</td><td>Yes (= docs のみ)</td></tr>
+</tbody>
+</table>
+
+<p>各 phase は <code>INVARIANT_PR_SHIPS_WORKING_INCREMENT</code> に従う。 Phase 1 は dormant library で OK、 Phase 3 から既存 Deploy 経路が library 経由になる。</p>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>Positive</h3>
+
+<ul>
+<li><strong>cross-cloud authority の安全な経路を持つ</strong>: 私鍵を持ち回さず、 signed intent + provider-native short-lived credentials の組み合わせで cloud 操作を実行できる。 enterprise audit / AI agent governance / cloud competition の 3 ユースケースを同じ protocol で扱える</li>
+<li><strong>TenkaCloud domain model を活かす</strong>: tenant / event / team / problem / deployment が claim になっているので、 「Team Alpha の Problem hello-world の deploy 要求」 という形で意味を持った authority transfer が可能</li>
+<li><strong>policy hook で組織別の要件を吸収</strong>: OPA / Cedar / tenant 別 allowlist / 問題 metadata の上限額制限を後付けできる。 policy hard-code を避けることで library を再利用しやすくする</li>
+<li><strong>OSS 公開時の position が明確</strong>: 既存 primitive (= OIDC / SPIFFE / Token Exchange) の上位層であり、 universal standard を狙わずに TenkaCloud の domain knowledge を凝縮した library として出せる</li>
+<li><strong>AI agent からの cloud 操作を audit 可能にする</strong>: Claude Code / Codex CLI が自動 deploy を呼ぶ際、 全 decision が CloudActionAuditRecord として残るので 「AI が勝手に大規模 deploy した」 系の incident に対する追跡経路を提供する</li>
+</ul>
+
+<h3>Negative / Trade-off</h3>
+
+<ul>
+<li><strong>library を 1 つ maintain する負担</strong>: <code>packages/trust-bridge</code> の API / behavior / breaking change policy を管理する必要がある。 internal 利用 → OSS 公開の moment まで API を頻繁に変える</li>
+<li><strong>政治的合意形成のリスク</strong>: 「TenkaCloud 独自 protocol」 として始まるが、 業界標準にしたい場合は OAuth WG / IETF への提案が要る。 初版は標準化を狙わない (= 内部利用が成立してから議論)</li>
+<li><strong>provider adapter の脆さ</strong>: AWS / GCP / Azure / Cloudflare それぞれの federation API は仕様変更があり、 adapter ごとに maintenance burden が線形に積む</li>
+<li><strong>policy engine 選定の決定先送り</strong>: hook 化したことで OPA / Cedar / 独自 DSL の決定が後ろに送られる。 Phase 4-5 で 1 つに収束させないと policy 表現がバラバラになる</li>
+</ul>
+
+<h3>Risk</h3>
+
+<table>
+<thead><tr><th>Risk</th><th>影響</th><th>緩和策</th></tr></thead>
+<tbody>
+<tr><td>token replay</td><td>古い token で意図しない deploy が走る</td><td>短 TTL (= 1〜5 min) + nonce + audience binding の 3 段で防御。 nonce 保存は DDB 1 件 (= Free Tier 内)</td></tr>
+<tr><td>confused deputy</td><td>library が誤った tenant / team の claim で別 tenant の credential を発行</td><td>tenant / event / team / target の cross-check を library 内で常時実施。 policy hook が deny する経路も用意</td></tr>
+<tr><td>over-broad provider scope</td><td>requested scopes が広すぎて over-privilege な credential が出る</td><td>policy hook で <code>allowedScopes</code> を絞る。 default は <code>maxTtlSeconds: 300</code> + 最小 scope。 problem metadata の上限を constraint に</td></tr>
+<tr><td>tenant boundary escape</td><td>tenant A の signing key で tenant B の claim を作る</td><td>tenant 別 KMS key 分離 (= ADR-002 と同じ思想)。 audience binding に tenant 別 endpoint を入れる</td></tr>
+<tr><td>target account mismatch</td><td>claim の providerAccountRef と実 exchange 先の account がズレる</td><td>adapter が claim 内 providerAccountRef と adapter 設定 (= AssumeRole RoleArn) の account ID を strict 比較 (= mismatch なら deny)</td></tr>
+<tr><td>leaked signed token</td><td>token が log / network に漏れて再利用される</td><td>nonce で 1 度きりに制約 + TTL 5 min 以内 + audience binding (= 流出しても別 endpoint で使えない)</td></tr>
+<tr><td>malicious problem package</td><td>問題 template が過大権限を要求</td><td>problem metadata に scope 上限を宣言、 policy hook が問題側 metadata と組織側 policy の AND で評価</td></tr>
+<tr><td>destroy が context 不在で失敗</td><td>deploy 時の context が消えて destroy が新規 intent を作れない</td><td>destroy は別 signed intent で発行 (= 独立 audit を残す)。 deploy 時の context を deployment metadata に保存し、 destroy intent が参照する</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Alternatives considered</h2>
+
+<table>
+<thead><tr><th>選択肢</th><th>判定</th><th>理由</th></tr></thead>
+<tbody>
+<tr class="hide"><td>A. credential を Lambda env / DDB に保管して直接使う</td><td><span class="badge reject">却下</span></td><td>各 provider の long-lived credential を 1 workload に集約する anti-pattern。 enterprise / AI agent / 競技 infra の 3 use case すべてで受け入れがたい</td></tr>
+<tr class="hide"><td>B. SPIFFE / SPIRE を直接採用</td><td><span class="badge reject">却下</span></td><td>workload identity 配布の標準ではあるが、 cloud action intent 層の primitive ではない。 SPIFFE は本 library の 1 段下に位置する (= 将来 workloadId 配布で利用検討余地はある)</td></tr>
+<tr class="hide"><td>C. OAuth Token Exchange (RFC 8693) を直接採用</td><td><span class="badge reject">却下</span></td><td>token → token 交換の標準 protocol だが、 TenkaCloud の context (= tenant / event / team / problem) を claim に乗せる規約が無い。 本 library が context-aware に拡張する立ち位置</td></tr>
+<tr class="hide"><td>D. provider 別 library 4 つを並走 (= AWS 用 / GCP 用 / Azure 用 / Cloudflare 用)</td><td><span class="badge reject">却下</span></td><td>共通の claim shape / signing / policy hook / audit を 4 倍 maintain する。 abstraction を 1 つの library に固める方が長期保守コストが低い</td></tr>
+<tr class="show"><td>E. <code>packages/trust-bridge</code> 内部 library + provider adapter pattern</td><td><span class="badge accept">採用</span></td><td>既存 primitive を再利用しつつ、 TenkaCloud domain model を claim 化する higher-level layer を 1 個追加。 内部利用 → OSS 公開の順で熟す</td></tr>
+<tr class="hide"><td>F. 既存 AWS-only flow のまま multi-cloud を諦める</td><td><span class="badge reject">却下</span></td><td>戦略的 rationale に反する (= TenkaCloud Lite + Trust Bridge は adoption + 技術的 moat の 2 軸)。 Lite だけでは差別化が薄い</td></tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Open Questions</h2>
+
+<p>本 ADR では下記を Phase 1 着手時に再検討するものとして残す。</p>
+
+<ol>
+<li><strong>CloudActionIntent は JWT claim 直接か、 canonical JSON を JWS で wrap するか</strong>: JWS で wrap する方が canonical 形が安定する。 ただし JWT 直接の方が外部 library 互換性が高い。 Phase 1 で benchmark + 既存 audit エコシステムとの相性を見て決める</li>
+<li><strong>nonce 保存先</strong>: DDB 1 件 / Redis-like / caller 提供 のどれにするか。 TenkaCloud は DDB 1/1 PROVISIONED 制約があるため DDB を default にし、 nonce TTL 5 min で TTL 属性削除に任せる方針</li>
+<li><strong>policy engine は library 同梱か hook のみか</strong>: hook のみで一旦リリースし、 利用パターンが固まったら built-in evaluator (= inline allowlist) を 1 つ加える方針</li>
+<li><strong>パッケージ分割: 1 package or 4 package</strong>: 初版は <code>packages/trust-bridge</code> 1 個。 provider adapter が増えて bundle size が問題になったら <code>@tenkacloud/trust-bridge-core</code> + <code>@tenkacloud/trust-bridge-aws</code> 等に切り出す</li>
+<li><strong>Terraform plan approval flow との対応</strong>: <code>plan</code> → human approval → <code>apply</code> の flow で、 plan 段階で intent を生成し approval 後に exchange する 2 段モデルが自然。 Phase 3 で実装するときに固める</li>
+<li><strong>destroy は元 deploy context が必要か、 別 signed destroy intent か</strong>: 別 destroy intent を default にする。 deploy 時の deploymentId を destroy intent の <code>source.deploymentId</code> に書く形で audit chain を成立させる</li>
+<li><strong>CloudActionIntent を Provider Engine に直接公開するか</strong>: Phase 3 では TenkaCloud 内部のみ。 Phase 5 (docs 公開) と同時に外部 Provider Engine への公開を検討</li>
+<li><strong>最小 demo の定義</strong>: 「AWS account A の Lambda が、 AWS account B の CFn stack を deploy する」 を最小 demo にする (= 既存 AWS competitor account flow が adapter 経由で動く)。 Phase 2 完了で測定可能</li>
+</ol>
+</section>
+
+<section>
+<h2>Relationship to other ADRs</h2>
+
+<ul>
+<li><a href="./adr-002-cross-account-federation.html">ADR-002 (cross-account federation)</a>: 本 library の AWS adapter は ADR-002 で確立した <code>CompetitorDeployRole + ExternalId</code> 経路を内部利用する。 ADR-002 の wire 自体は変えない</li>
+<li><a href="./adr-016-tenkacloud-lite-app-plane-core.html">ADR-016 (TenkaCloud Lite)</a>: 同時並行で進む adoption surface 改善。 Lite mode は本 library に依存しない (= Phase 4-5 で <code>tenkacloud run</code> CLI が内部利用するときに合流)</li>
+<li><a href="./adr-007-outside-in.html">ADR-007 (outside-in architecture)</a>: 本 library は infrastructure 層に置き、 アプリ層に protocol 知識を漏らさない (= ADR-007 の規律に従う)</li>
+<li><a href="./adr-015-adr-convention-as-harness.html">ADR-015 (ADR convention as harness)</a>: 本 ADR は ADR-015 の <code>adr-self-contained</code> rule に準拠 (= chat 痕跡 / 段階反映 metadata を残さない)</li>
+</ul>
+</section>
+
+<section>
+<h2>Rollout</h2>
+
+<ul>
+<li>Phase 1 (= <code>packages/trust-bridge</code> scaffold + schema + signing + verification + audit) を最初の PR として出す。 internal dormant library として独立価値を持つ</li>
+<li>Phase 2-5 は順に独立 PR で merge する</li>
+<li>各 Phase 完了時点で <a href="https://github.com/susumutomita/TenkaCloud/issues/795">#795</a> の Phase checklist を更新</li>
+<li>既存 AWS deploy 経路 (= ADR-002) は phase 全期間で壊さない。 各 PR で <code>make synth</code> を旧 main と比較する手順を PR body に明記する</li>
+<li>Phase 5 完了時点で <code>docs/architecture/cloud-action-intent.md</code> を公開 + <code>README.md</code> に Trust Bridge セクションを追加 (= OSS user 向け参考実装)</li>
+</ul>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

[Issue #795](https://github.com/susumutomita/TenkaCloud/issues/795) (= adr / architecture / library / multicloud / security / trust-bridge / P0-ish) の **ADR draft 段階**。 multi-day の implementation 作業 (= 全体 5 phase) はこの ADR を blueprint として後続 PR 群で進める。 **本 PR は ADR document の追加のみ** で、 既存 CDK / Lambda / DDB / Cognito / API Gateway 構造に影響しない。

## 核となる提案

\` \` \`
credentials を移送せず、 signed cloud action intents を移送し、
provider-native の短命 authority と交換する protocol 層を持つ。
\` \` \`

既存 primitive (OIDC / JWS / AssumeRole / Workload Identity Federation / SPIFFE / OAuth Token Exchange) より 1 段上の **context-aware authority bridge** を、 TenkaCloud の domain model (tenant → event → team → problem → deployment) と結合した形で library 化する。

## Decision summary (D1-D6)

| ID | 内容 |
|---|---|
| D1 | \`CloudActionIntent\` schema (= tenant / event / team / problem / deployment / target / action / constraints を構造化、 Zod narrowing) |
| D2 | JWS 署名 + 検証 (= 既存 \`jose\` library 利用、 custom crypto 禁止、 AWS KMS asymmetric key first-class) |
| D3 | \`ProviderTokenExchange\` interface (= AWS / GCP / Azure / Cloudflare 別 adapter、 初版 AWS のみ) |
| D4 | \`PolicyEvaluator\` hook (= allow / deny / needs_approval、 OPA / Cedar / inline allowlist を後付け可能) |
| D5 | \`CloudActionAuditRecord\` (= decision 1 件 = audit log 1 件、 enterprise / AI agent governance / 競技 replay 用) |
| D6 | 5 phase rollout |

## Implementation phases (= 後続 PR 群)

| Phase | 内容 | 受入条件 |
|---|---|---|
| 1 | \`packages/trust-bridge\` 新設、 schema + signing + verification + TTL + nonce + audit + unit test | dormant library として synth / typecheck / test pass |
| 2 | \`AwsAssumeRoleExchange\` 実装、 既存 competitor account / ExternalId 経路を adapter 経由でラップ | AWS 経路の挙動不変、 unit test 追加 |
| 3 | Deploy API が CloudActionIntent を発行 → 検証 → exchange → AWS 操作 を内部利用 | user-visible API は不変、 audit records が CloudWatch Logs に出る |
| 4 | GCP / Azure adapter prototype、 1 つの cross-cloud demo target | 1 provider ずつ独立 PR |
| 5 | \`docs/architecture/cloud-action-intent.md\` で protocol 仕様を公開 | OSS user 向け参考実装 |

## Test plan

- [x] \`make harness\` — adr-self-contained / adr-must-be-html rule no findings (ADR-015 規約準拠)
- [x] ADR-017 を ADR-001〜016 と同じ HTML self-contained 形式で記述 (= Status / Tracking / Related / Context / Decision / Consequences / Alternatives / Open Questions / Relationship / Rollout)
- [ ] reviewer: Decision の D1-D6 が phase 1-5 の実装計画と整合していることを確認
- [ ] reviewer: Open Questions 8 件のうち、 Phase 1 着手前に決めるべきものを判別
- [ ] reviewer: Alternatives で考慮した SPIFFE / Token Exchange の position が誤解されていないか

## Regression 分析

- 本 PR は **ADR document の追加のみ**。 既存 CDK / Lambda / DDB / Cognito / API Gateway 構造に影響なし
- PR-#770 で導入した \`adr-self-contained\` / \`adr-must-be-html\` harness rule に違反しない範囲で書いた (= \`make harness\` no findings 確認済)
- Trust Bridge 実装は後続 phase 1-5 PR で段階的に追加
- ADR-002 (cross-account federation) の現行 wire は本 PR では変更しない (= Phase 2 で adapter としてラップする時に AWS 経路が adapter 経由になる)

## 物理影響

| 種別 | 対象 | 内容 |
|---|---|---|
| CREATE | \`docs/architecture/adr-017-cloud-action-intent-trust-bridge.html\` | ADR document 1 枚 |
| NO-OP | AWS CFn / Lambda / IAM / DDB / Cognito / API Gateway | 設定変更なし (= 後続 phase の作業範囲) |
| NO-OP | \`apps/*/dist/\` | frontend に修正なし |

## 関連

- Relates #795 (= 実装は Phase 1-5 PR 群で順次。 本 ADR は blueprint)
- ADR-002 (cross-account federation) / ADR-007 (outside-in) / ADR-010 (CLI-first) / ADR-015 (harness invariant) / ADR-016 (TenkaCloud Lite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)