### PR TITLE
feat(#778 Phase 4): TenkaCloud Lite CLI runner (scripts/tenkacloud-lite.ts + make lite-*)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ export JSII_DEPRECATED := quiet
         check-http-status check-template-ascii \
         env-check synth check-synth diff bootstrap \
         deploy deploy-control-plane deploy-bootstrap destroy \
-        deploy-battles destroy-battles
+        deploy-battles destroy-battles \
+        lite-up lite-down lite-status lite-portal-url lite-console-url
 
 help:
 	@awk '/^# =====/ {gsub(/^# ===== | =====$$/, ""); printf "\n%s\n", $$0} \
@@ -145,3 +146,14 @@ destroy-battles:
 	  exit 1; \
 	fi
 	@TEAM_SLUG="$(TEAM_SLUG)" bash scripts/destroy-battles.sh $(BATTLES)
+
+# ===== TenkaCloud Lite mode (Issue #778 ADR-016 Phase 4) =====
+# 「OSS / Product Hunt 向けに 1 コマンドで TenkaCloud を試す」体験を提供する CLI wrapper。
+# Lite stack は tenantId=local 固定で SBT / Pipeline / 動的 tenant 作成を持ち込まない (= ADR-016)。
+# 実 deploy 経路は Phase 5 で追加する `infrastructure/bin/tenkacloud-lite.ts` (= 専用 bin entry)
+# と組み合わせて完成する。 本ターゲットは CLI runner を委譲するのみ。
+lite-up:           ; bun run scripts/tenkacloud-lite.ts up
+lite-down:         ; bun run scripts/tenkacloud-lite.ts down
+lite-status:       ; bun run scripts/tenkacloud-lite.ts status
+lite-portal-url:   ; bun run scripts/tenkacloud-lite.ts portal-url
+lite-console-url:  ; bun run scripts/tenkacloud-lite.ts console-url

--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CliIO,
+  LITE_STACK_NAMES,
+  main,
+  type SpawnCaptureResult,
+} from "../../../scripts/tenkacloud-lite";
+
+/**
+ * Issue #778 ADR-016 Phase 4: TenkaCloud Lite CLI runner の挙動 pin。
+ *
+ * spawn 系を injectable にしてあるので、 AWS / CDK を実行せずに subcommand dispatch /
+ * help / unknown subcommand / output 読み取りを観測する。
+ */
+
+interface SpawnCall {
+  readonly cmd: string;
+  readonly args: readonly string[];
+  readonly mode: "inherit" | "capture";
+}
+
+function buildIO(opts: {
+  readonly inheritExitCode?: number;
+  readonly capture?: (cmd: string, args: readonly string[]) => SpawnCaptureResult;
+}): {
+  readonly io: CliIO;
+  readonly stdout: string[];
+  readonly stderr: string[];
+  readonly calls: SpawnCall[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls: SpawnCall[] = [];
+  const io: CliIO = {
+    stdout: (text) => {
+      stdout.push(text);
+    },
+    stderr: (text) => {
+      stderr.push(text);
+    },
+    spawnInherit: async (cmd, args) => {
+      calls.push({ cmd, args: [...args], mode: "inherit" });
+      return opts.inheritExitCode ?? 0;
+    },
+    spawnCapture: async (cmd, args) => {
+      calls.push({ cmd, args: [...args], mode: "capture" });
+      return opts.capture ? opts.capture(cmd, [...args]) : { code: 0, stdout: "", stderr: "" };
+    },
+  };
+  return { io, stdout, stderr, calls };
+}
+
+describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
+  it("引数なし / help / -h / --help でヘルプを出して exit 0 を返すべき", async () => {
+    for (const argv of [[], ["help"], ["-h"], ["--help"]]) {
+      const { io, stdout } = buildIO({});
+      const code = await main(argv, io);
+      expect(code).toBe(0);
+      const text = stdout.join("");
+      expect(text).toContain("tenkacloud lite");
+      expect(text).toContain("up");
+      expect(text).toContain("down");
+      expect(text).toContain("portal-url");
+      expect(text).toContain("console-url");
+      expect(text).toContain("status");
+    }
+  });
+
+  it("未知の subcommand では exit 1 + stderr にメッセージ + help を出すべき", async () => {
+    const { io, stdout, stderr } = buildIO({});
+    const code = await main(["frobnicate"], io);
+    expect(code).toBe(1);
+    expect(stderr.join("")).toContain("Unknown subcommand: frobnicate");
+    expect(stdout.join("")).toContain("使い方:");
+  });
+
+  it("up は cdk deploy を 1 回 inherit で呼び、 両 stack 名と --require-approval never を渡すべき", async () => {
+    const { io, calls } = buildIO({
+      inheritExitCode: 0,
+      capture: () => ({ code: 0, stdout: "https://example.cloudfront.net", stderr: "" }),
+    });
+    const code = await main(["up"], io);
+    expect(code).toBe(0);
+    const inheritCalls = calls.filter((c) => c.mode === "inherit");
+    expect(inheritCalls).toHaveLength(1);
+    const deployCall = inheritCalls[0];
+    expect(deployCall.cmd).toBe("bunx");
+    expect(deployCall.args).toContain("cdk");
+    expect(deployCall.args).toContain("deploy");
+    expect(deployCall.args).toContain(LITE_STACK_NAMES.app);
+    expect(deployCall.args).toContain(LITE_STACK_NAMES.problemDeploy);
+    expect(deployCall.args).toContain("--require-approval");
+    expect(deployCall.args).toContain("never");
+  });
+
+  it("up は cdk deploy が non-zero で落ちたら早期 return し AWS CLI を呼ばないべき", async () => {
+    const { io, calls } = buildIO({ inheritExitCode: 2 });
+    const code = await main(["up"], io);
+    expect(code).toBe(2);
+    expect(calls.filter((c) => c.cmd === "aws")).toHaveLength(0);
+  });
+
+  it("down は app stack を先に destroy → problem-deploy stack の順で呼ぶべき", async () => {
+    const { io, calls } = buildIO({ inheritExitCode: 0 });
+    const code = await main(["down"], io);
+    expect(code).toBe(0);
+    const destroyCalls = calls.filter((c) => c.args.includes("destroy"));
+    expect(destroyCalls).toHaveLength(2);
+    // 1 回目は app stack、 2 回目は problem-deploy stack の cross-stack 依存方向に合わせる。
+    expect(destroyCalls[0].args).toContain(LITE_STACK_NAMES.app);
+    expect(destroyCalls[1].args).toContain(LITE_STACK_NAMES.problemDeploy);
+    for (const call of destroyCalls) {
+      expect(call.args).toContain("--force");
+    }
+  });
+
+  it("down は 1 回目の destroy が落ちたら 2 回目を呼ばずに同じ exit code を返すべき", async () => {
+    const { io, calls } = buildIO({ inheritExitCode: 3 });
+    const code = await main(["down"], io);
+    expect(code).toBe(3);
+    expect(calls.filter((c) => c.args.includes("destroy"))).toHaveLength(1);
+  });
+
+  it("portal-url は問題 deploy stack の ParticipantPortalApiUrl output を describe-stacks で問い合わせるべき", async () => {
+    const { io, calls, stdout } = buildIO({
+      capture: () => ({ code: 0, stdout: "https://portal.example.com\n", stderr: "" }),
+    });
+    const code = await main(["portal-url"], io);
+    expect(code).toBe(0);
+    const awsCall = calls.find((c) => c.cmd === "aws");
+    expect(awsCall).toBeDefined();
+    expect(awsCall?.args).toContain("describe-stacks");
+    expect(awsCall?.args).toContain("--stack-name");
+    expect(awsCall?.args).toContain(LITE_STACK_NAMES.problemDeploy);
+    expect(awsCall?.args.join(" ")).toContain("ParticipantPortalApiUrl");
+    expect(stdout.join("")).toContain("https://portal.example.com");
+  });
+
+  it("console-url は AppPlane stack の ApplicationAdminConsoleUrl output を問い合わせるべき", async () => {
+    const { io, calls, stdout } = buildIO({
+      capture: () => ({ code: 0, stdout: "https://console.example.com\n", stderr: "" }),
+    });
+    const code = await main(["console-url"], io);
+    expect(code).toBe(0);
+    const awsCall = calls.find((c) => c.cmd === "aws");
+    expect(awsCall?.args).toContain(LITE_STACK_NAMES.app);
+    expect(awsCall?.args.join(" ")).toContain("ApplicationAdminConsoleUrl");
+    expect(stdout.join("")).toContain("https://console.example.com");
+  });
+
+  it("output が空文字なら not found を stderr に出して exit 1 を返すべき", async () => {
+    const { io, stderr } = buildIO({
+      capture: () => ({ code: 0, stdout: "  \n", stderr: "" }),
+    });
+    const code = await main(["portal-url"], io);
+    expect(code).toBe(1);
+    expect(stderr.join("")).toContain("not found");
+  });
+
+  it("describe-stacks が non-zero で落ちたら NOT_DEPLOYED として status に出すべき", async () => {
+    const { io, stdout } = buildIO({
+      capture: () => ({ code: 255, stdout: "", stderr: "Stack does not exist" }),
+    });
+    const code = await main(["status"], io);
+    expect(code).toBe(0);
+    const text = stdout.join("");
+    expect(text).toContain(LITE_STACK_NAMES.app);
+    expect(text).toContain(LITE_STACK_NAMES.problemDeploy);
+    // どちらの stack も NOT_DEPLOYED と報告される。
+    expect(text.match(/NOT_DEPLOYED/g)?.length).toBe(2);
+  });
+
+  it("status は describe-stacks 結果を 1 行ずつ標準出力に出すべき", async () => {
+    const { io, stdout } = buildIO({
+      capture: (_cmd, args) => {
+        const stackName = args[args.indexOf("--stack-name") + 1];
+        const status =
+          stackName === LITE_STACK_NAMES.app ? "CREATE_COMPLETE" : "UPDATE_IN_PROGRESS";
+        return { code: 0, stdout: `${status}\n`, stderr: "" };
+      },
+    });
+    const code = await main(["status"], io);
+    expect(code).toBe(0);
+    const text = stdout.join("");
+    expect(text).toContain("CREATE_COMPLETE");
+    expect(text).toContain("UPDATE_IN_PROGRESS");
+  });
+});

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env bun
+/**
+ * Issue #778 ADR-016 Phase 4: TenkaCloud Lite mode の CLI runner。
+ *
+ * SBT / Pipeline / 動的 tenant 作成のフル機能を持ち込まずに、 「TenkaCloud を試したい」
+ * 開発者が 1 コマンドで AWS account に最小 stack を deploy できる体験を提供する。
+ *
+ * 使い方:
+ *   bun run scripts/tenkacloud-lite.ts up          — Lite stack を deploy + URL を表示
+ *   bun run scripts/tenkacloud-lite.ts down        — Lite stack を destroy
+ *   bun run scripts/tenkacloud-lite.ts portal-url  — Participant Portal URL を表示
+ *   bun run scripts/tenkacloud-lite.ts console-url — Application Admin Console URL を表示
+ *   bun run scripts/tenkacloud-lite.ts status      — 両 stack の状態を表示
+ *
+ * 設計判断:
+ *   - `cdk deploy` / `cdk destroy` を spawn する形 (= AWS SDK で自前実装しない)。
+ *     CDK の deploy 進捗 UI を そのまま見せた方が初見者に親切。
+ *   - CFn outputs の読み取りは AWS CLI を spawn する (= bun の依存に
+ *     `@aws-sdk/client-cloudformation` を増やさない、 操作が単純な read のみ)。
+ *   - stack 名は固定 (`tenkacloud-lite` + `tenkacloud-lite-problem-deploy`)。
+ *     Lite は 1 deploy = 1 stack 集合の前提なので環境別の suffix は持たない。
+ *   - bin/infrastructure.ts は touch しない。 Lite stack の wiring は別 bin entry
+ *     (`infrastructure/bin/tenkacloud-lite.ts`、 Phase 5 で追加) が担う想定。
+ *     本 PR では CLI 単体の scaffold + Makefile target のみ。
+ *
+ * テスト容易性のため `main` を export し、 spawn 系を injectable にしている (= unit test
+ * から AWS や CDK を実行せずに subcommand dispatch / help / unknown を観測する)。
+ */
+
+import { spawn } from "node:child_process";
+
+export const LITE_STACK_NAMES = {
+  app: "tenkacloud-lite",
+  problemDeploy: "tenkacloud-lite-problem-deploy",
+} as const;
+
+const CDK_OPTS = ["--app", "bunx ts-node infrastructure/bin/tenkacloud-lite.ts"];
+
+export interface SpawnCaptureResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface CliIO {
+  readonly stdout: (text: string) => void;
+  readonly stderr: (text: string) => void;
+  readonly spawnInherit: (cmd: string, args: readonly string[]) => Promise<number>;
+  readonly spawnCapture: (cmd: string, args: readonly string[]) => Promise<SpawnCaptureResult>;
+}
+
+interface CommandSpec {
+  readonly help: string;
+  readonly run: (args: readonly string[], io: CliIO) => Promise<number>;
+}
+
+const COMMANDS: Record<string, CommandSpec> = {
+  up: {
+    help: "Lite stack 2 個 (= AppPlane + ProblemDeploy) を deploy し、 完了時に Console / Portal URL を表示する。",
+    run: cmdUp,
+  },
+  down: {
+    help: "Lite stack 2 個を destroy する。 RemovalPolicy=DESTROY が効いていれば S3 / DDB 含めて削除される。",
+    run: cmdDown,
+  },
+  "portal-url": {
+    help: "Participant Portal の CloudFront URL を CFn output から取得して標準出力する。",
+    run: (_args, io) =>
+      readOutput(LITE_STACK_NAMES.problemDeploy, "ParticipantPortalApiUrl", "", io),
+  },
+  "console-url": {
+    help: "Application Admin Console の CloudFront URL を CFn output から取得して標準出力する。",
+    run: (_args, io) => readOutput(LITE_STACK_NAMES.app, "ApplicationAdminConsoleUrl", "", io),
+  },
+  status: {
+    help: "両 stack の CFn StackStatus を 1 行で表示する。",
+    run: cmdStatus,
+  },
+};
+
+export async function main(argv: readonly string[], io: CliIO): Promise<number> {
+  const subcommand = argv[0];
+  if (!subcommand || subcommand === "-h" || subcommand === "--help" || subcommand === "help") {
+    printHelp(io);
+    return 0;
+  }
+  const spec = COMMANDS[subcommand];
+  if (!spec) {
+    io.stderr(`Unknown subcommand: ${subcommand}\n\n`);
+    printHelp(io);
+    return 1;
+  }
+  return spec.run(argv.slice(1), io);
+}
+
+function printHelp(io: CliIO): void {
+  io.stdout("tenkacloud lite — TenkaCloud Lite mode の CLI runner (Issue #778 Phase 4)\n\n");
+  io.stdout("使い方:\n");
+  io.stdout("  bun run scripts/tenkacloud-lite.ts <subcommand>\n");
+  io.stdout("  make lite-<subcommand>\n\n");
+  io.stdout("subcommand:\n");
+  for (const [name, spec] of Object.entries(COMMANDS)) {
+    io.stdout(`  ${name.padEnd(14)} ${spec.help}\n`);
+  }
+  io.stdout("\n");
+  io.stdout(
+    "Phase 4 scope (本 PR): CLI scaffold + Makefile target。 実 AWS deploy 経路は\n" +
+      "Phase 5 で追加する `infrastructure/bin/tenkacloud-lite.ts` (= bin entry) と組み合わせて完成する。\n",
+  );
+}
+
+async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
+  io.stdout("[lite] deploying 2 stacks (= AppPlane + ProblemDeploy)...\n");
+  const code = await io.spawnInherit("bunx", [
+    "cdk",
+    ...CDK_OPTS,
+    "deploy",
+    LITE_STACK_NAMES.problemDeploy,
+    LITE_STACK_NAMES.app,
+    "--require-approval",
+    "never",
+  ]);
+  if (code !== 0) {
+    io.stderr(`[lite] cdk deploy failed with exit code ${code}\n`);
+    return code;
+  }
+  io.stdout("\n[lite] deploy complete. URLs:\n");
+  await readOutput(
+    LITE_STACK_NAMES.app,
+    "ApplicationAdminConsoleUrl",
+    "  Application Admin Console: ",
+    io,
+  );
+  await readOutput(
+    LITE_STACK_NAMES.problemDeploy,
+    "ParticipantPortalApiUrl",
+    "  Participant Portal:        ",
+    io,
+  );
+  return 0;
+}
+
+async function cmdDown(_args: readonly string[], io: CliIO): Promise<number> {
+  io.stdout("[lite] destroying 2 stacks...\n");
+  // app stack を先に destroy (= cross-stack 参照 (DeployApi Lambda 等) の依存方向に合わせる)。
+  const code1 = await io.spawnInherit("bunx", [
+    "cdk",
+    ...CDK_OPTS,
+    "destroy",
+    LITE_STACK_NAMES.app,
+    "--force",
+  ]);
+  if (code1 !== 0) return code1;
+  return io.spawnInherit("bunx", [
+    "cdk",
+    ...CDK_OPTS,
+    "destroy",
+    LITE_STACK_NAMES.problemDeploy,
+    "--force",
+  ]);
+}
+
+async function cmdStatus(_args: readonly string[], io: CliIO): Promise<number> {
+  for (const stackName of [LITE_STACK_NAMES.app, LITE_STACK_NAMES.problemDeploy]) {
+    const status = await readStackStatus(stackName, io);
+    io.stdout(`${stackName.padEnd(40)} ${status}\n`);
+  }
+  return 0;
+}
+
+async function readOutput(
+  stackName: string,
+  outputKey: string,
+  prefix: string,
+  io: CliIO,
+): Promise<number> {
+  const value = await readStackOutput(stackName, outputKey, io);
+  if (value === undefined) {
+    io.stderr(`[lite] output ${outputKey} not found on stack ${stackName}\n`);
+    return 1;
+  }
+  io.stdout(`${prefix}${value}\n`);
+  return 0;
+}
+
+async function readStackOutput(
+  stackName: string,
+  outputKey: string,
+  io: CliIO,
+): Promise<string | undefined> {
+  const out = await io.spawnCapture("aws", [
+    "cloudformation",
+    "describe-stacks",
+    "--stack-name",
+    stackName,
+    "--query",
+    `Stacks[0].Outputs[?OutputKey=='${outputKey}'].OutputValue`,
+    "--output",
+    "text",
+  ]);
+  if (out.code !== 0) return undefined;
+  const trimmed = out.stdout.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function readStackStatus(stackName: string, io: CliIO): Promise<string> {
+  const out = await io.spawnCapture("aws", [
+    "cloudformation",
+    "describe-stacks",
+    "--stack-name",
+    stackName,
+    "--query",
+    "Stacks[0].StackStatus",
+    "--output",
+    "text",
+  ]);
+  if (out.code !== 0) return "NOT_DEPLOYED";
+  return out.stdout.trim() || "UNKNOWN";
+}
+
+export function defaultIO(): CliIO {
+  return {
+    stdout: (text) => process.stdout.write(text),
+    stderr: (text) => process.stderr.write(text),
+    spawnInherit: (cmd, args) =>
+      new Promise((resolveFn) => {
+        const proc = spawn(cmd, [...args], { stdio: "inherit" });
+        proc.on("close", (code) => resolveFn(code ?? 0));
+        proc.on("error", () => resolveFn(127));
+      }),
+    spawnCapture: (cmd, args) =>
+      new Promise((resolveFn) => {
+        const proc = spawn(cmd, [...args]);
+        let stdout = "";
+        let stderr = "";
+        proc.stdout.on("data", (chunk) => {
+          stdout += chunk.toString();
+        });
+        proc.stderr.on("data", (chunk) => {
+          stderr += chunk.toString();
+        });
+        proc.on("close", (code) => resolveFn({ code: code ?? 0, stdout, stderr }));
+        proc.on("error", () => resolveFn({ code: 127, stdout, stderr }));
+      }),
+  };
+}
+
+// Bun: import.meta.main === true のとき本ファイルが CLI として直接実行されている。
+// vitest 等から import された場合は main を呼ばない (= side effect-free entry)。
+if (import.meta.main) {
+  const exitCode = await main(process.argv.slice(2), defaultIO());
+  process.exit(exitCode);
+}


### PR DESCRIPTION
## Summary

ADR-016 Phase 4 として TenkaCloud Lite mode の CLI scaffold を導入する。 Phase 3 で
追加した `TenkaCloudLiteStack` (= tenantId=local 固定の自己完結 stack) を 1 コマンドで
deploy / destroy できる体験を整え、 OSS / Product Hunt 向けの「触りに来た人を迷わせない」
onboarding を実現する。

- `scripts/tenkacloud-lite.ts`: `up` / `down` / `status` / `portal-url` / `console-url` の 5 subcommand
- `Makefile`: `lite-up` / `lite-down` / `lite-status` / `lite-portal-url` / `lite-console-url` target
- `infrastructure/test/scripts/tenkacloud-lite.test.ts`: 11 test (subcommand dispatch / help / 順序 / output 読み取り / NOT_DEPLOYED 検出)

Relates #778

## 設計判断

- `cdk deploy` / `cdk destroy` を spawn する形 (= AWS SDK で自前実装しない)。 CDK の deploy 進捗 UI を そのまま見せた方が初見者に親切
- CFn output 読み取りは AWS CLI を spawn (= `@aws-sdk/client-cloudformation` を依存に増やさない、 操作が単純な read のみ)
- stack 名は固定 (`tenkacloud-lite` + `tenkacloud-lite-problem-deploy`)。 Lite は 1 deploy = 1 stack 集合の前提なので環境別 suffix は持たない
- spawn 系を `CliIO` interface に注入して unit test 可能にする (= AWS / CDK を実行せずに観測)

## Phase 4 scope と Phase 5 への引き継ぎ

本 PR は CLI scaffold + Makefile target + unit test の最小単位で観察可能な
increment (= `make lite-up` 起動時に help / dispatch が動く) を出荷する。 実 AWS
deploy 経路に必要な `infrastructure/bin/tenkacloud-lite.ts` (= Lite 専用 bin entry)
は Phase 5 で追加する。

## Regression 分析

- 既存 stack / handler / app に **触っていない** (= Phase 4 は新規 file 2 個 + Makefile 末尾 target 追加のみ)
- Makefile の `.PHONY` 追記と末尾セクション追加なので `make deploy` / `make destroy` などの既存 target 動作には影響なし
- CLI script は `import.meta.main` で自己実行を gate しており、 vitest 等から import されても side effect が出ない
- spawn 系の dependency injection は test fixture でしか使われない (= production は `defaultIO()` で従来通り `node:child_process` spawn)

## 物理影響

- CFn / S3 / IAM 影響: **NO-OP** (= IaC は一切 touch していない、 CLI から呼び出す `cdk deploy` 経路の bin entry は Phase 5 で追加)
- 新規 artifact: `scripts/tenkacloud-lite.ts` + `infrastructure/test/scripts/tenkacloud-lite.test.ts` + `Makefile` の lite-* target (= ローカル開発体験のみに影響)

## Test plan

- [x] `bun run --cwd infrastructure vitest run test/scripts/tenkacloud-lite.test.ts` (= 11 test pass)
- [x] `make before-commit` (= lint / typecheck /全 vitest / validate-problems / check-docs / cdk synth 全通過)
- [x] `bun run scripts/tenkacloud-lite.ts help` (= 5 subcommand の help が日本語で表示される)
- [x] `bun run scripts/tenkacloud-lite.ts unknown-cmd` (= stderr に `Unknown subcommand` + exit 1)
- [ ] Phase 5 で `infrastructure/bin/tenkacloud-lite.ts` を追加した後に `make lite-up ENV=development` で実 deploy を smoke (= 本 PR の scope 外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TenkaCloud Lite mode with simplified deployment management commands: `lite-up` (deploy), `lite-down` (remove), `lite-status` (check status), `lite-portal-url` (retrieve portal URL), and `lite-console-url` (retrieve console URL).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/798)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->