### PR TITLE
feat(#742 Phase 5): SCHEMA.json で全 5 builtin kind に hints を許容 ($defs.progressiveHints)

### DIFF
--- a/infrastructure/test/problems-schema-hints.test.ts
+++ b/infrastructure/test/problems-schema-hints.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import Ajv2020 from "ajv";
+import addFormats from "ajv-formats";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Issue #742 Phase 5: `hints` を全 5 builtin scoring kind で受け入れることを
+ * SCHEMA.json レイヤーでも pin する (= Phase 5 までは scoring-metadata.ts parser
+ * 側のみ拡張されていて、 metadata.json 直書きの hints は SCHEMA で剥奪されていた)。
+ *
+ * 本テストは Ajv で SCHEMA.json をそのまま validate する (= validate-problems.ts
+ * と同じ検証経路)。 hints の v1 (string[]) / v2 (object[]) 混在パターンと、
+ * id 欠落 / penalty 負値 / 不明 property 等の reject も pin する。
+ */
+
+const SCHEMA_PATH = join(__dirname, "../../problems/SCHEMA.json");
+
+function createValidator(): ReturnType<Ajv2020["compile"]> {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+function baseProblem(scoring: unknown): Record<string, unknown> {
+  return {
+    id: "test-problem",
+    name: "テスト問題",
+    category: "Challenge",
+    status: "draft",
+    difficulty: 1,
+    estimatedDuration: "10 分",
+    shortDescription: "test",
+    description: "test",
+    tags: ["test"],
+    exposedPorts: [{ port: 80, name: "main" }],
+    learningGoals: ["test"],
+    cfnTemplate: "template.yaml",
+    scoring,
+  };
+}
+
+describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべき", () => {
+  const validate = createValidator();
+  const validV2Hint = { id: "hint-1", content: "first hint", penalty: 10 } as const;
+  const validV1Hint = "legacy string hint";
+
+  it("kind=flag で hints (v2) を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "flag",
+        flagOutputKey: "Flag",
+        points: 100,
+        hints: [validV2Hint, validV1Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("kind=uptime (legacy) で hints を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "uptime",
+        endpoints: [{ outputKey: "BaseUrl", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 10,
+        hints: [validV1Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("kind=uptime-flat で hints を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 10,
+        hints: [validV2Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("kind=uptime-multi で hints を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "uptime-multi",
+        probedSlots: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsAllOk: 100,
+        hints: [validV2Hint, validV1Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("kind=phased-polling で hints を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "phased-polling",
+        intervalMinutes: 1,
+        probe: { metaPath: "/meta", scorePath: "/score" },
+        platformRules: { ec2: { points: 100 } },
+        hints: [validV2Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+
+  it("kind=attack-detection で hints を受け入れるべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "attack-detection",
+        statsOutputKey: "AttackCount",
+        pointsPerAttack: 10,
+        hints: [validV2Hint],
+      }),
+    );
+    expect(validate.errors).toBeNull();
+    expect(ok).toBe(true);
+  });
+});
+
+describe("[#742 Phase 5] SCHEMA.json: hints の不正 shape を reject すべき", () => {
+  const validate = createValidator();
+
+  it("hints 要素から `id` が欠落していたら reject すべき (= v2 object の required)", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "flag",
+        flagOutputKey: "Flag",
+        points: 100,
+        hints: [{ content: "missing id", penalty: 0 }],
+      }),
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("hints[].penalty が負値なら reject すべき (= minimum 0)", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 10,
+        hints: [{ id: "h1", content: "negative penalty", penalty: -5 }],
+      }),
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("hints[] に object 内 unknown property があったら reject すべき (= additionalProperties false)", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "attack-detection",
+        statsOutputKey: "AttackCount",
+        pointsPerAttack: 10,
+        hints: [{ id: "h1", content: "extra", penalty: 0, extra: "nope" }],
+      }),
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("hints が array でなければ reject すべき", () => {
+    const ok = validate(
+      baseProblem({
+        kind: "flag",
+        flagOutputKey: "Flag",
+        points: 100,
+        hints: "not-an-array",
+      }),
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -3,6 +3,43 @@
   "$id": "https://tenkacloud.example/schemas/problem-metadata.json",
   "title": "TenkaCloud Problem Metadata",
   "description": "1 つの問題ディレクトリ (problems/<category>/<id>/) に置く metadata.json の構造を定義する。frontend カタログ表示と backend deploy パイプラインの両方が参照する正本。ADR-012 Phase 2 で thick metadata DSL に拡張済み (endpoints / phases / disruptions / dashboard.slots / scoring.kind 5 種)。Phase 3 で platform 側の generic scoring dispatcher が新 kind を読み始めるまでの間、旧 scoring.kind (flag/uptime) も legacy alias として valid。",
+  "$defs": {
+    "progressiveHints": {
+      "type": "array",
+      "description": "競技者画面に表示するヒント。 Issue #742 Phase 1: v1 (string) と v2 (ProgressiveHint object) の混在を許容する (= 後方互換)。 v2 で `penalty` を指定すると reveal 時にその値が `points` から減算される (= Phase 5 で全 5 builtin kind 共通)。",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "[Legacy v1] テキスト 1 行 (= penalty 0 で reveal される hint)。 parser が `{id: \"hint-N\", content, penalty: 0}` に正規化する。"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "content", "penalty"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Stable identifier (= DDB `hintsRevealed` key、 metadata 順序変更で reveal 記録が drift しないため)。"
+              },
+              "content": {
+                "type": "string",
+                "minLength": 1,
+                "description": "表示テキスト (markdown 可)。"
+              },
+              "penalty": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Reveal すると `points` (= flag) / `pointsPerSuccess` (= uptime 系) / `pointsAllOk` (= uptime-multi) / 累計 score (= phased-polling / attack-detection) から減算される値。 0 は減点無し。"
+              }
+            },
+            "description": "[v2] Progressive hint (id + content + penalty)。"
+          }
+        ]
+      }
+    }
+  },
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -217,41 +254,7 @@
               "minimum": 1,
               "description": "正解時の獲得ポイント (1 deploy につき 1 回まで加算)。"
             },
-            "hints": {
-              "type": "array",
-              "description": "競技者画面に表示するヒント。Issue #742 Phase 1: v1 (string) と v2 (ProgressiveHint object) の混在を許容する (= 後方互換)。 v2 で `penalty` を指定すると reveal 時にその値が `points` から減算される (= Phase 2 以降で API/DDB/UI を追加予定)。",
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "description": "[Legacy v1] テキスト 1 行 (= penalty 0 で reveal される hint)。 parser が `{id: \"hint-N\", content, penalty: 0}` に正規化する。"
-                  },
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": ["id", "content", "penalty"],
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "Stable identifier (= 将来 DDB の `hintsRevealed` key で使う、 metadata 順序変更で reveal 記録が drift しないため)。"
-                      },
-                      "content": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "表示テキスト (markdown 可)。"
-                      },
-                      "penalty": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "description": "Reveal すると `points` から減算される値。 0 は減点無し。 Phase 2 で API/DDB/UI 追加時に実 deduction する。"
-                      }
-                    },
-                    "description": "[v2] Progressive hint (id + content + penalty)。"
-                  }
-                ]
-              }
-            }
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=flag (= Challenge 1 回提出形式)。example: hello-world は SSM Parameter 値を当てて +100 pt。"
         },
@@ -294,7 +297,8 @@
               "type": "integer",
               "minimum": 1,
               "description": "1 回の health check 成功あたりの獲得ポイント。"
-            }
+            },
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=uptime (legacy)。 Phase 2 transition 期間中の互換用。 新規問題は kind=uptime-flat を使うこと。"
         },
@@ -346,7 +350,8 @@
               "type": "integer",
               "minimum": 1,
               "description": "1 endpoint 成功あたりの獲得ポイント (= デフォルト値)。endpoints[].pointsPerSuccess で個別上書き可。"
-            }
+            },
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=uptime-flat。example: hello-world-battle (FrontendUrl + ApiUrl を独立に probe)。"
         },
@@ -390,7 +395,8 @@
             "failurePenalty": {
               "type": "integer",
               "description": "1 つでも fail が混ざった時の加点 (通常 0 または負値)。省略時 0。"
-            }
+            },
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=uptime-multi。example: security-battle-royale (frontend + api 同時生存中だけ加点)。"
         },
@@ -487,7 +493,8 @@
                   }
                 }
               }
-            }
+            },
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=phased-polling。example: microservice-migration-battle (EC2 vs Lambda/ECS/App Runner の hosting platform 分類 + 60 分劣化 + 90 分 legacy 切替)。"
         },
@@ -527,7 +534,8 @@
                   }
                 }
               }
-            }
+            },
+            "hints": { "$ref": "#/$defs/progressiveHints" }
           },
           "description": "kind=attack-detection。example: security-battle-royale の攻撃検知部 (= 防御側が WAF/IAM で塞ぐと検知数が頭打ちする設計)。"
         }


### PR DESCRIPTION
## Summary

Phase 5 で `scoring-metadata.ts` parser は全 5 kind (flag / uptime / uptime-flat /
uptime-multi / phased-polling / attack-detection) に `hints?: ProgressiveHint[]`
を共通拡張したが、 `problems/SCHEMA.json` は kind=flag だけに hints を許容しており、
他 4 kind の `metadata.json` に hints を直書きすると `validate-problems` が reject
していた (= 内部 drift)。 本 PR でこれを解消する。

Relates #742

## 変更

- `problems/SCHEMA.json`:
  - `$defs.progressiveHints` を root に定義 (= v1 string / v2 object oneOf + `additionalProperties: false` + `penalty: minimum 0`)
  - 5 kind branch すべてが `{ "$ref": "#/$defs/progressiveHints" }` で参照
  - flag branch の既存 inline hints も `$ref` に差し替え (= 単一定義に統一)
- `infrastructure/test/problems-schema-hints.test.ts`: Ajv で SCHEMA.json を直接 validate する 10 test
  - 5 kind それぞれが hints を accept することを pin
  - id 欠落 / penalty 負値 / 不明 property / 非配列を reject することを pin

## Regression 分析

- 既存 metadata.json (4 件) は すべて validate に通る (= `make validate-problems` 確認済み)
- flag kind の hints shape は inline → `$ref` に変えたが、 構造は完全に同一 (= 既存挙動と互換)
- 新規 `$defs` ブランチを root の "type": "object" より前に挿入したが、 Ajv は draft-07 で `$defs` を解決可能

## 物理影響

- CFn / IaC: **NO-OP**
- artifact: SCHEMA.json (= metadata 検証時のみ参照) + 新規 test 1 file

## Test plan

- [x] `make validate-problems` (= 既存 4 metadata.json すべて通る)
- [x] `make harness` (= no findings)
- [x] `cd infrastructure && bun run vitest run test/problems-schema-hints.test.ts` (= 10 test pass)
- [x] 新規問題で `kind=uptime-flat` + `hints` を書いた場合に validate-problems が通ることを test で pin
- [x] 不正 hints (id 欠落 / penalty < 0 等) は SCHEMA 層で reject されることを test で pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)