### PR TITLE
feat(#795 Phase 1): packages/trust-bridge skeleton (CloudActionIntent + JWS + TTL/nonce/audit)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -151,6 +151,18 @@
         "react": "^19.0.0",
       },
     },
+    "packages/trust-bridge": {
+      "name": "@TenkaCloud/trust-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.23.8",
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.5",
+      },
+    },
   },
   "packages": {
     "@TenkaCloud/admin-console": ["@TenkaCloud/admin-console@workspace:apps/admin-console"],
@@ -160,6 +172,8 @@
     "@TenkaCloud/infrastructure": ["@TenkaCloud/infrastructure@workspace:infrastructure"],
 
     "@TenkaCloud/participant-portal": ["@TenkaCloud/participant-portal@workspace:apps/participant-portal"],
+
+    "@TenkaCloud/trust-bridge": ["@TenkaCloud/trust-bridge@workspace:packages/trust-bridge"],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "scripts": {
     "build": "bun run --filter @TenkaCloud/infrastructure build && bun run --filter @TenkaCloud/admin-console build && bun run --filter @TenkaCloud/application-admin-console build && bun run --filter @TenkaCloud/participant-portal build",
-    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck",
+    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
-    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test",
+    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test",
     "validate:problems": "bun run scripts/validate-problems.ts",
     "build:problems-index": "bun run scripts/build-problem-index.ts",
     "check:problems-index": "bun run scripts/build-problem-index.ts --check",

--- a/packages/trust-bridge/package.json
+++ b/packages/trust-bridge/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@TenkaCloud/trust-bridge",
+  "version": "0.1.0",
+  "description": "Cross-cloud authority transfer library (= signed CloudActionIntent → short-lived provider-native credentials). Phase 1: schema + canonical serialization + JWS sign/verify + TTL + nonce hook + audit (#795 / ADR-017).",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/trust-bridge/src/audit.ts
+++ b/packages/trust-bridge/src/audit.ts
@@ -1,0 +1,89 @@
+import type { CloudActionIntent } from "./schema.js";
+import type { IntentVerifyOutcome } from "./verify.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 1: audit record helper。
+ *
+ * 「すべての decision に audit を残す」 原則 (= ADR-017 D5) を Phase 1 から
+ * pin する。 出力 schema は CloudActionAuditRecord (= ADR-017 で書いた shape)。
+ * 失敗系も audit に記録する (= attacker が token を投げ込んで何が起きた
+ * かを後から再現可能にする)。
+ */
+
+export interface CloudActionAuditRecord {
+  readonly requestId: string;
+  readonly tenantId: string;
+  readonly eventId?: string;
+  readonly teamId?: string;
+  readonly problemId?: string;
+  readonly deploymentId?: string;
+  readonly targetId?: string;
+  readonly provider: string;
+  readonly action: string;
+  readonly decision: "allow" | "deny" | "needs_approval";
+  readonly denialReason?: string;
+  readonly issuedCredentialExpiresAt?: string;
+  readonly policyVersion?: string;
+  readonly createdAt: string;
+}
+
+export interface AuditInput {
+  readonly outcome: IntentVerifyOutcome;
+  /** verify が成功し policy が allow を返したときの credential 失効時刻 (= AWS の AssumeRole 終了時刻等)。 */
+  readonly issuedCredentialExpiresAt?: string;
+  readonly policyVersion?: string;
+  readonly now?: () => Date;
+  /** verify は OK だが上位 policy が deny / needs_approval を返したときの decision 上書き。 */
+  readonly overrideDecision?: "deny" | "needs_approval";
+  readonly overrideReason?: string;
+}
+
+/**
+ * 失敗系の intent (= JWS / schema invalid) でも、 token 内の見えた情報から audit を作る。
+ * Phase 1 では JWS payload を再 decode しない (= verify 経路で得た intent or
+ * fail だけを使う)。 fail 系は requestId/tenantId 等が不明なので "unknown" を埋める。
+ */
+export function buildAuditRecord(input: AuditInput): CloudActionAuditRecord {
+  const createdAt = (input.now ?? (() => new Date()))().toISOString();
+  if (input.outcome.ok) {
+    return buildAllowOrOverride(input.outcome.intent, input, createdAt);
+  }
+  return {
+    requestId: "unknown",
+    tenantId: "unknown",
+    provider: "unknown",
+    action: "unknown",
+    decision: "deny",
+    denialReason: input.outcome.reason,
+    createdAt,
+  };
+}
+
+function buildAllowOrOverride(
+  intent: CloudActionIntent,
+  input: AuditInput,
+  createdAt: string,
+): CloudActionAuditRecord {
+  const decision: CloudActionAuditRecord["decision"] = input.overrideDecision ?? "allow";
+  const record: CloudActionAuditRecord = {
+    requestId: intent.requestId,
+    tenantId: intent.source.tenantId,
+    provider: intent.target.provider,
+    action: intent.action.type,
+    decision,
+    createdAt,
+    ...(intent.source.eventId === undefined ? {} : { eventId: intent.source.eventId }),
+    ...(intent.source.teamId === undefined ? {} : { teamId: intent.source.teamId }),
+    ...(intent.source.problemId === undefined ? {} : { problemId: intent.source.problemId }),
+    ...(intent.source.deploymentId === undefined
+      ? {}
+      : { deploymentId: intent.source.deploymentId }),
+    ...(intent.source.targetId === undefined ? {} : { targetId: intent.source.targetId }),
+    ...(input.issuedCredentialExpiresAt === undefined
+      ? {}
+      : { issuedCredentialExpiresAt: input.issuedCredentialExpiresAt }),
+    ...(input.policyVersion === undefined ? {} : { policyVersion: input.policyVersion }),
+    ...(input.overrideReason === undefined ? {} : { denialReason: input.overrideReason }),
+  };
+  return record;
+}

--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @TenkaCloud/trust-bridge — Issue #795 / ADR-017 Phase 1 public surface。
+ *
+ * 「クレデンシャルを越境させず、 署名された CloudActionIntent を越境させ、
+ *  検証側で短命 provider-native authority に交換する」 protocol の基盤層。
+ *
+ * Phase 1 出荷範囲:
+ *   - CloudActionIntent schema (zod)
+ *   - canonical JSON serialization
+ *   - JWS HS256 sign / verify
+ *   - TTL / notBefore 検証
+ *   - nonce hook 抽象
+ *   - audit record helper
+ *
+ * Phase 2 以降:
+ *   - AwsAssumeRoleExchange (= 既存 ExternalId flow を本 abstraction に migrate)
+ *   - Deploy API への internal integration
+ *   - GCP / Azure adapter prototype
+ *   - protocol 文書 (= docs/architecture/cloud-action-intent.html)
+ */
+
+export type { AuditInput, CloudActionAuditRecord } from "./audit.js";
+export { buildAuditRecord } from "./audit.js";
+export type {
+  JwsHeader,
+  SignOptions,
+  VerifyFailureReason,
+  VerifyOptions,
+  VerifyOutcome,
+} from "./jws.js";
+export { signIntent, verifySignature } from "./jws.js";
+export type { CloudActionIntent, VerifiedCloudActionIntent } from "./schema.js";
+export {
+  brandVerified,
+  CloudActionIntentSchema,
+  canonicalize,
+  INTENT_VERSION,
+  parseCloudActionIntent,
+} from "./schema.js";
+export type {
+  IntentVerifyError,
+  IntentVerifyFailureReason,
+  IntentVerifyOk,
+  IntentVerifyOptions,
+  IntentVerifyOutcome,
+  NonceStore,
+} from "./verify.js";
+export { verifyIntent } from "./verify.js";

--- a/packages/trust-bridge/src/jws.ts
+++ b/packages/trust-bridge/src/jws.ts
@@ -1,0 +1,145 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { type CloudActionIntent, canonicalize } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 1: minimal JWS compact serialization for
+ * CloudActionIntent。
+ *
+ * Phase 1 では HS256 (HMAC-SHA256) のみ実装する。 これは:
+ *  - 鍵管理を持ち込まず unit test 可能にする最小形 (= 共有 secret 1 個)
+ *  - JWS spec (RFC 7515) compact 形式の payload encoding / signature 検証
+ *    ロジックを pin する
+ *  - Phase 2 で AWS adapter を入れるときに ES256 / RS256 を追加できる
+ *    interface 形 (= sign/verify が alg を switch する余地)
+ *
+ * production 移行時の方針:
+ *  - KMS / Cloud HSM 経由の非対称鍵 (ES256 / RS256) に差し替える
+ *  - 共有 secret HS256 は internal tooling と test 限定で残す
+ *  - 本 module は node:crypto のみ依存 (= 追加 supply chain 負担なし、 ADR-017
+ *    Phase 1 の "no custom crypto" 原則は createHmac を OpenSSL bindings として
+ *    使うことで満たす、 JWS framing は spec 準拠の単純な base64url 連結のみ)
+ */
+
+const ALG_HS256 = "HS256" as const;
+type Alg = typeof ALG_HS256;
+
+export interface JwsHeader {
+  readonly alg: Alg;
+  readonly typ: "JWS";
+  readonly kid?: string;
+}
+
+export interface SignOptions {
+  readonly secret: Uint8Array;
+  readonly kid?: string;
+}
+
+export interface VerifyOptions {
+  readonly resolveSecret: (header: JwsHeader) => Uint8Array | undefined;
+}
+
+export type VerifyOutcome =
+  | { readonly ok: true; readonly intent: CloudActionIntent; readonly header: JwsHeader }
+  | { readonly ok: false; readonly reason: VerifyFailureReason };
+
+export type VerifyFailureReason =
+  | "malformed-token"
+  | "unknown-algorithm"
+  | "secret-not-resolved"
+  | "signature-mismatch"
+  | "payload-parse-failed"
+  | "payload-schema-invalid";
+
+function base64urlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64urlDecode(text: string): Uint8Array {
+  const padded = text.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  return new Uint8Array(Buffer.from(padded + pad, "base64"));
+}
+
+function hmacSha256(secret: Uint8Array, signingInput: string): Uint8Array {
+  const mac = createHmac("sha256", secret);
+  mac.update(signingInput);
+  return new Uint8Array(mac.digest());
+}
+
+/**
+ * Issue #795 / ADR-017 Phase 1: CloudActionIntent → JWS compact serialization。
+ *
+ * payload は canonicalize() の出力 (= sorted-key JSON) を使う。 検証側で
+ * 同じ payload を再現するためには parse → re-canonicalize が必要だが、
+ * Phase 1 では「sender が作った確定 bytes をそのまま JWS payload に
+ * 載せる」 ことを優先する (= MAC は bytes に対して計算される)。
+ */
+export function signIntent(intent: CloudActionIntent, options: SignOptions): string {
+  const header: JwsHeader = {
+    alg: ALG_HS256,
+    typ: "JWS",
+    ...(options.kid === undefined ? {} : { kid: options.kid }),
+  };
+  const headerB64 = base64urlEncode(new TextEncoder().encode(JSON.stringify(header)));
+  const payloadCanonical = canonicalize(intent);
+  const payloadB64 = base64urlEncode(new TextEncoder().encode(payloadCanonical));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = hmacSha256(options.secret, signingInput);
+  const signatureB64 = base64urlEncode(signature);
+  return `${signingInput}.${signatureB64}`;
+}
+
+/**
+ * Issue #795 / ADR-017 Phase 1: verify JWS compact token → CloudActionIntent。
+ *
+ * TTL 検証 / nonce 検証 / policy 評価 は本 module の責務ではない (= layer 分離)。
+ * 上位の `verifyIntent` (`./verify.ts`) が TTL / nonce / audit を組み合わせる。
+ */
+export function verifySignature(token: string, options: VerifyOptions): VerifyOutcome {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return { ok: false, reason: "malformed-token" };
+  }
+  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+  let header: JwsHeader;
+  try {
+    const headerJson = new TextDecoder().decode(base64urlDecode(headerB64));
+    const parsed = JSON.parse(headerJson) as JwsHeader;
+    if (parsed.typ !== "JWS") {
+      return { ok: false, reason: "malformed-token" };
+    }
+    header = parsed;
+  } catch {
+    return { ok: false, reason: "malformed-token" };
+  }
+
+  if (header.alg !== ALG_HS256) {
+    return { ok: false, reason: "unknown-algorithm" };
+  }
+
+  const secret = options.resolveSecret(header);
+  if (!secret) {
+    return { ok: false, reason: "secret-not-resolved" };
+  }
+
+  const expected = hmacSha256(secret, `${headerB64}.${payloadB64}`);
+  const provided = base64urlDecode(signatureB64);
+  if (expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+    return { ok: false, reason: "signature-mismatch" };
+  }
+
+  let intent: CloudActionIntent;
+  try {
+    const payloadJson = new TextDecoder().decode(base64urlDecode(payloadB64));
+    intent = JSON.parse(payloadJson) as CloudActionIntent;
+  } catch {
+    return { ok: false, reason: "payload-parse-failed" };
+  }
+
+  return { ok: true, intent, header };
+}

--- a/packages/trust-bridge/src/schema.ts
+++ b/packages/trust-bridge/src/schema.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+
+/**
+ * Issue #795 / ADR-017 Phase 1: CloudActionIntent schema。
+ *
+ * 「クレデンシャルを越境させず、 署名された意図 (intent) を越境させ、
+ * 検証側で短命 provider-native authority に交換する」 protocol の
+ * 入口データ構造。 TenkaCloud の domain (tenant / event / team / problem
+ * / deployment / target) を first-class claim として持ち込み、
+ * generic credential broker と差別化する。
+ *
+ * Phase 1 では schema + canonical serialization + JWS sign/verify までを
+ * 出荷する。 Phase 2 で AWS AssumeRole adapter を hook の先に繋ぐ。
+ *
+ * 設計判断:
+ *   - canonical serialization は key の lexicographic sort で実現する
+ *     (= JCS RFC 8785 の subset、 number は Number.prototype.toString 任せ)。
+ *     確定的 byte 表現が JWS payload に入る → 検証側でも同じ payload を
+ *     再現できる。
+ *   - validate() は zod を使う (= TenkaCloud 内既存 dep、 追加 supply chain
+ *     負担なし)。 `.brand<>` で型を nominal にし、 unvalidated 値が
+ *     intent として混入する事故を防ぐ。
+ *   - version field は literal 固定 (`tenkacloud.cloud-action-intent.v1`)。
+ *     将来 v2 を出すときに oneOf で discriminate する余地を残す。
+ */
+
+export const INTENT_VERSION = "tenkacloud.cloud-action-intent.v1" as const;
+
+const ProviderEnum = z.enum(["aws", "azure", "gcp", "cloudflare"]);
+const ActionTypeEnum = z.enum(["deploy", "destroy", "inspect", "collectOutputs", "verifyTrust"]);
+const EngineEnum = z.enum(["cloudformation", "terraform", "bicep", "pulumi", "script"]);
+
+const SourceSchema = z
+  .object({
+    system: z.literal("tenkacloud"),
+    tenantId: z.string().min(1),
+    eventId: z.string().min(1).optional(),
+    teamId: z.string().min(1).optional(),
+    problemId: z.string().min(1).optional(),
+    deploymentId: z.string().min(1).optional(),
+    targetId: z.string().min(1).optional(),
+    workloadId: z.string().min(1),
+  })
+  .strict();
+
+const TargetSchema = z
+  .object({
+    provider: ProviderEnum,
+    providerAccountRef: z.string().min(1),
+    region: z.string().min(1).optional(),
+    resourceScope: z.string().min(1).optional(),
+  })
+  .strict();
+
+const ActionSchema = z
+  .object({
+    type: ActionTypeEnum,
+    engine: EngineEnum,
+    entry: z.string().min(1).optional(),
+    requestedScopes: z.array(z.string().min(1)).readonly(),
+  })
+  .strict();
+
+const ConstraintsSchema = z
+  .object({
+    ttlSeconds: z.number().int().min(1).max(3600),
+    notBefore: z.string().datetime().optional(),
+    expiresAt: z.string().datetime(),
+    maxEstimatedCostUsd: z.number().nonnegative().optional(),
+    allowPrivilegeEscalation: z.boolean(),
+  })
+  .strict();
+
+export const CloudActionIntentSchema = z
+  .object({
+    version: z.literal(INTENT_VERSION),
+    requestId: z.string().min(1),
+    nonce: z.string().min(1),
+    source: SourceSchema,
+    target: TargetSchema,
+    action: ActionSchema,
+    constraints: ConstraintsSchema,
+  })
+  .strict();
+
+export type CloudActionIntent = z.infer<typeof CloudActionIntentSchema>;
+
+/**
+ * Issue #795 / ADR-017: 検証済み intent を nominal type で表現。 unvalidated
+ * 入力が intent として通る事故 (= confused deputy の入口) を型で防ぐ。
+ */
+export type VerifiedCloudActionIntent = CloudActionIntent & { readonly __verified: true };
+
+export function brandVerified(intent: CloudActionIntent): VerifiedCloudActionIntent {
+  return intent as VerifiedCloudActionIntent;
+}
+
+/**
+ * Issue #795 / ADR-017 Phase 1: canonical JSON serialization。
+ *
+ * 確定的 byte 表現を作るため key を lexicographic sort し、 array は順序を
+ * 保ったまま recurse する。 number / string / boolean / null は
+ * JSON.stringify と同じ表現を使う (= JCS の subset、 1.0 / 1e0 等の number
+ * 表記差は TS が Number.prototype.toString に統一済みなので問題なし)。
+ *
+ * 用途: JWS payload の決定的 bytes を作って sign / verify を通すこと、
+ * audit log の hashing を再現可能にすること。
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalize(v)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const body = entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",");
+  return `{${body}}`;
+}
+
+/**
+ * Phase 1: parse + validate。 安全な entry point。 zod が refine しない field は
+ * SafeParseError として戻る (= 詳細 path 付き)。
+ */
+export function parseCloudActionIntent(
+  raw: unknown,
+):
+  | { readonly ok: true; readonly intent: CloudActionIntent }
+  | { readonly ok: false; readonly issues: readonly string[] } {
+  const parsed = CloudActionIntentSchema.safeParse(raw);
+  if (parsed.success) {
+    return { ok: true, intent: parsed.data };
+  }
+  return {
+    ok: false,
+    issues: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`),
+  };
+}

--- a/packages/trust-bridge/src/verify.ts
+++ b/packages/trust-bridge/src/verify.ts
@@ -1,0 +1,120 @@
+import { type VerifyOptions, type VerifyOutcome, verifySignature } from "./jws.js";
+import type { CloudActionIntent, VerifiedCloudActionIntent } from "./schema.js";
+import { brandVerified, parseCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 1: 上位 verify entrypoint。
+ *
+ * JWS 検証 → schema 検証 → TTL 検証 → nonce hook 評価 を順に実施し、
+ * 失敗した最初の reason を 1 つ返す。 audit record は本 entry の戻り値から
+ * `auditRecord.ts` が組み立てる (= 失敗系も audit に残す方針)。
+ *
+ * TTL 検証は constraints.expiresAt と constraints.notBefore を `now` と
+ * 比較する (= 単純 string ISO 比較は時刻順に動かないので Date.parse 経由)。
+ *
+ * nonce hook は caller が DDB / Redis 等のバックエンドを差し込める。 Phase 1
+ * では「同じ nonce を 2 度 verify できない」 ことを caller 責任で担保する
+ * 抽象だけ提供する (= no built-in storage)。
+ */
+
+export interface NonceStore {
+  /**
+   * 同じ nonce を 2 度受理しないために caller が実装する hook。
+   * - 戻り値が `"accepted"` なら verify 続行
+   * - 戻り値が `"replay"` なら verify 失敗 (= replay attack)
+   *
+   * Phase 1 の expectation: store は intent 全体ではなく `(requestId, nonce, expiresAt)`
+   * を idempotency key として記録する。 TTL すぎたら GC する (= DDB TTL 等)。
+   */
+  recordNonce(intent: CloudActionIntent): Promise<"accepted" | "replay">;
+}
+
+export type IntentVerifyFailureReason =
+  | "jws-malformed"
+  | "jws-unknown-algorithm"
+  | "jws-secret-not-resolved"
+  | "jws-signature-mismatch"
+  | "jws-payload-parse-failed"
+  | "schema-invalid"
+  | "not-yet-valid"
+  | "expired"
+  | "nonce-replay";
+
+export interface IntentVerifyOk {
+  readonly ok: true;
+  readonly intent: VerifiedCloudActionIntent;
+}
+
+export interface IntentVerifyError {
+  readonly ok: false;
+  readonly reason: IntentVerifyFailureReason;
+  readonly details?: readonly string[];
+}
+
+export type IntentVerifyOutcome = IntentVerifyOk | IntentVerifyError;
+
+export interface IntentVerifyOptions extends VerifyOptions {
+  readonly nonceStore?: NonceStore;
+  readonly now?: () => Date;
+}
+
+function mapJwsReason(reason: VerifyOutcome & { ok: false }): IntentVerifyFailureReason {
+  switch (reason.reason) {
+    case "malformed-token":
+      return "jws-malformed";
+    case "unknown-algorithm":
+      return "jws-unknown-algorithm";
+    case "secret-not-resolved":
+      return "jws-secret-not-resolved";
+    case "signature-mismatch":
+      return "jws-signature-mismatch";
+    case "payload-parse-failed":
+      return "jws-payload-parse-failed";
+    case "payload-schema-invalid":
+      return "schema-invalid";
+  }
+}
+
+export async function verifyIntent(
+  token: string,
+  options: IntentVerifyOptions,
+): Promise<IntentVerifyOutcome> {
+  const jwsOutcome = verifySignature(token, options);
+  if (!jwsOutcome.ok) {
+    return { ok: false, reason: mapJwsReason(jwsOutcome) };
+  }
+
+  const schemaOutcome = parseCloudActionIntent(jwsOutcome.intent);
+  if (!schemaOutcome.ok) {
+    return { ok: false, reason: "schema-invalid", details: schemaOutcome.issues };
+  }
+
+  const intent = schemaOutcome.intent;
+  const now = (options.now ?? (() => new Date()))();
+  const expiresAt = new Date(intent.constraints.expiresAt);
+  if (Number.isNaN(expiresAt.getTime())) {
+    // datetime() で schema が弾く想定だが防御的に。
+    return { ok: false, reason: "schema-invalid", details: ["constraints.expiresAt"] };
+  }
+  if (expiresAt.getTime() <= now.getTime()) {
+    return { ok: false, reason: "expired" };
+  }
+  if (intent.constraints.notBefore) {
+    const nbf = new Date(intent.constraints.notBefore);
+    if (Number.isNaN(nbf.getTime())) {
+      return { ok: false, reason: "schema-invalid", details: ["constraints.notBefore"] };
+    }
+    if (now.getTime() < nbf.getTime()) {
+      return { ok: false, reason: "not-yet-valid" };
+    }
+  }
+
+  if (options.nonceStore) {
+    const outcome = await options.nonceStore.recordNonce(intent);
+    if (outcome === "replay") {
+      return { ok: false, reason: "nonce-replay" };
+    }
+  }
+
+  return { ok: true, intent: brandVerified(intent) };
+}

--- a/packages/trust-bridge/test/audit.test.ts
+++ b/packages/trust-bridge/test/audit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildAuditRecord } from "../src/audit.js";
+import { brandVerified, type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+function makeIntent(): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-audit-1",
+    nonce: "nonce-audit-1",
+    source: {
+      system: "tenkacloud",
+      tenantId: "tenant-a",
+      eventId: "event-001",
+      teamId: "team-alpha",
+      problemId: "hello-world",
+      deploymentId: "deploy-9",
+      workloadId: "deploy-worker",
+    },
+    target: { provider: "aws", providerAccountRef: "111111111111" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cfn:CreateStack"],
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T22:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+  };
+}
+
+describe("buildAuditRecord (#795 Phase 1)", () => {
+  const fixedNow = () => new Date("2026-05-15T19:30:00.000Z");
+
+  it("verify 成功 + override 無しなら decision=allow で intent の domain field を埋めるべき", () => {
+    const intent = makeIntent();
+    const record = buildAuditRecord({
+      outcome: { ok: true, intent: brandVerified(intent) },
+      issuedCredentialExpiresAt: "2026-05-15T19:45:00.000Z",
+      policyVersion: "policy-v1",
+      now: fixedNow,
+    });
+    expect(record).toEqual({
+      requestId: "req-audit-1",
+      tenantId: "tenant-a",
+      eventId: "event-001",
+      teamId: "team-alpha",
+      problemId: "hello-world",
+      deploymentId: "deploy-9",
+      provider: "aws",
+      action: "deploy",
+      decision: "allow",
+      issuedCredentialExpiresAt: "2026-05-15T19:45:00.000Z",
+      policyVersion: "policy-v1",
+      createdAt: "2026-05-15T19:30:00.000Z",
+    });
+  });
+
+  it("override で deny を指定したら decision が deny になり denialReason も載るべき", () => {
+    const intent = makeIntent();
+    const record = buildAuditRecord({
+      outcome: { ok: true, intent: brandVerified(intent) },
+      overrideDecision: "deny",
+      overrideReason: "policy:scope-too-broad",
+      now: fixedNow,
+    });
+    expect(record.decision).toBe("deny");
+    expect(record.denialReason).toBe("policy:scope-too-broad");
+  });
+
+  it("verify 失敗系は decision=deny + denialReason=reason で unknown を埋めるべき", () => {
+    const record = buildAuditRecord({
+      outcome: { ok: false, reason: "expired" },
+      now: fixedNow,
+    });
+    expect(record).toEqual({
+      requestId: "unknown",
+      tenantId: "unknown",
+      provider: "unknown",
+      action: "unknown",
+      decision: "deny",
+      denialReason: "expired",
+      createdAt: "2026-05-15T19:30:00.000Z",
+    });
+  });
+
+  it("schema 無効系も deny + denialReason=schema-invalid で audit に残るべき", () => {
+    const record = buildAuditRecord({
+      outcome: { ok: false, reason: "schema-invalid", details: ["constraints.ttlSeconds"] },
+      now: fixedNow,
+    });
+    expect(record.decision).toBe("deny");
+    expect(record.denialReason).toBe("schema-invalid");
+  });
+
+  it("source の optional field が無い intent では audit にも入らないべき (= clean serialization)", () => {
+    const intent = makeIntent();
+    const lean: CloudActionIntent = {
+      ...intent,
+      source: { system: "tenkacloud", tenantId: "t-2", workloadId: "w-2" },
+    };
+    const record = buildAuditRecord({
+      outcome: { ok: true, intent: brandVerified(lean) },
+      now: fixedNow,
+    });
+    expect(record).toEqual({
+      requestId: "req-audit-1",
+      tenantId: "t-2",
+      provider: "aws",
+      action: "deploy",
+      decision: "allow",
+      createdAt: "2026-05-15T19:30:00.000Z",
+    });
+  });
+});

--- a/packages/trust-bridge/test/jws.test.ts
+++ b/packages/trust-bridge/test/jws.test.ts
@@ -1,0 +1,87 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { signIntent, verifySignature } from "../src/jws.js";
+import { type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+function intent(): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-101",
+    nonce: "nonce-jws-1",
+    source: { system: "tenkacloud", tenantId: "t-1", workloadId: "w-1" },
+    target: { provider: "aws", providerAccountRef: "111111111111" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cfn:CreateStack"],
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T18:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+  };
+}
+
+describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
+  it("正しい secret で署名 → 検証が成功し、 元 intent を取り出せるべき", () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const result = verifySignature(token, { resolveSecret: () => secret });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.intent.requestId).toBe("req-101");
+      expect(result.header.alg).toBe("HS256");
+    }
+  });
+
+  it("token 形式が壊れていたら malformed-token を返すべき", () => {
+    const result = verifySignature("not.a.token.extra", {
+      resolveSecret: () => new Uint8Array(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed-token");
+  });
+
+  it("secret が resolve できなければ secret-not-resolved を返すべき", () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const result = verifySignature(token, { resolveSecret: () => undefined });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("secret-not-resolved");
+  });
+
+  it("異なる secret で検証すると signature-mismatch を返すべき", () => {
+    const signer = randomBytes(32);
+    const verifier = randomBytes(32);
+    const token = signIntent(intent(), { secret: signer });
+    const result = verifySignature(token, { resolveSecret: () => verifier });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature-mismatch");
+  });
+
+  it("不明 alg の header を持つ token は unknown-algorithm を返すべき", () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const [, payload, sig] = token.split(".");
+    // header だけ書き換えて再送 (= signature は壊れるが、 そもそも alg check が先)
+    const fakeHeader = Buffer.from(JSON.stringify({ alg: "none", typ: "JWS" })).toString(
+      "base64url",
+    );
+    const tampered = `${fakeHeader}.${payload}.${sig}`;
+    const result = verifySignature(tampered, { resolveSecret: () => secret });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("unknown-algorithm");
+  });
+
+  it("kid が options で渡されたら header に乗り、 resolveSecret に渡るべき", () => {
+    const k1 = randomBytes(32);
+    const k2 = randomBytes(32);
+    const token = signIntent(intent(), { secret: k1, kid: "key-1" });
+    const result = verifySignature(token, {
+      resolveSecret: (h: { kid?: string }) => (h.kid === "key-1" ? k1 : k2),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.header.kid).toBe("key-1");
+  });
+});

--- a/packages/trust-bridge/test/schema.test.ts
+++ b/packages/trust-bridge/test/schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CloudActionIntent,
+  canonicalize,
+  INTENT_VERSION,
+  parseCloudActionIntent,
+} from "../src/schema.js";
+
+function validIntent(overrides: Partial<CloudActionIntent> = {}): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-001",
+    nonce: "nonce-abc",
+    source: {
+      system: "tenkacloud",
+      tenantId: "tenant-xyz",
+      workloadId: "deploy-worker-lambda",
+    },
+    target: {
+      provider: "aws",
+      providerAccountRef: "123456789012",
+      region: "ap-northeast-1",
+    },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cloudformation:CreateStack"],
+    },
+    constraints: {
+      ttlSeconds: 900,
+      expiresAt: "2026-05-15T17:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("CloudActionIntentSchema (#795 Phase 1)", () => {
+  it("正常な intent は parse 成功して original を返すべき", () => {
+    const result = parseCloudActionIntent(validIntent());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.intent.version).toBe(INTENT_VERSION);
+      expect(result.intent.target.provider).toBe("aws");
+    }
+  });
+
+  it("未知の version は reject すべき (= 将来の v2 で discriminate するため)", () => {
+    const bad = { ...validIntent(), version: "tenkacloud.cloud-action-intent.v2" };
+    const result = parseCloudActionIntent(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.join(" ")).toContain("version");
+    }
+  });
+
+  it("provider が enum 外なら reject すべき", () => {
+    const bad = validIntent();
+    const result = parseCloudActionIntent({
+      ...bad,
+      target: { ...bad.target, provider: "ibm" as unknown as "aws" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("ttlSeconds が 0 以下なら reject すべき (= 即失効 intent の禁止)", () => {
+    const bad = validIntent();
+    const result = parseCloudActionIntent({
+      ...bad,
+      constraints: { ...bad.constraints, ttlSeconds: 0 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("ttlSeconds が 3600 を超えたら reject すべき (= short-TTL 原則の機械強制)", () => {
+    const bad = validIntent();
+    const result = parseCloudActionIntent({
+      ...bad,
+      constraints: { ...bad.constraints, ttlSeconds: 4000 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("expiresAt が ISO datetime 形式でなければ reject すべき", () => {
+    const bad = validIntent();
+    const result = parseCloudActionIntent({
+      ...bad,
+      constraints: { ...bad.constraints, expiresAt: "not-a-date" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("schema 外の property があれば reject すべき (= strict mode で confused deputy 防御)", () => {
+    const result = parseCloudActionIntent({
+      ...validIntent(),
+      somethingExtra: "should-be-rejected",
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("canonicalize (#795 Phase 1)", () => {
+  it("同じ object literal は順序が違っても同じ byte に正規化されるべき", () => {
+    const a = canonicalize({ b: 1, a: 2 });
+    const b = canonicalize({ a: 2, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":2,"b":1}');
+  });
+
+  it("array の要素順は preserve されるべき (= 意図的順序を破壊しない)", () => {
+    expect(canonicalize([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("undefined property は drop されるべき (= optional field の有無で hash 不変)", () => {
+    expect(canonicalize({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  it("null は preserve されるべき (= explicit null と undefined の意味差を保つ)", () => {
+    expect(canonicalize({ a: null })).toBe('{"a":null}');
+  });
+
+  it("nested object も再帰的に sort されるべき", () => {
+    const a = canonicalize({ outer: { z: 1, a: 2 }, alpha: 1 });
+    const b = canonicalize({ alpha: 1, outer: { a: 2, z: 1 } });
+    expect(a).toBe(b);
+  });
+});

--- a/packages/trust-bridge/test/verify.test.ts
+++ b/packages/trust-bridge/test/verify.test.ts
@@ -1,0 +1,134 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { signIntent } from "../src/jws.js";
+import { type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+import { type NonceStore, verifyIntent } from "../src/verify.js";
+
+function intent(overrides: Partial<CloudActionIntent["constraints"]> = {}): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-v-1",
+    nonce: `nonce-${Math.random()}`,
+    source: { system: "tenkacloud", tenantId: "t-1", workloadId: "w-1" },
+    target: { provider: "aws", providerAccountRef: "111111111111" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cfn:CreateStack"],
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+      ...overrides,
+    },
+  };
+}
+
+describe("verifyIntent (#795 Phase 1)", () => {
+  it("有効 token + future expiresAt + nonce 未使用なら ok=true でブランド型を返すべき", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.intent.requestId).toBe("req-v-1");
+    }
+  });
+
+  it("expiresAt が now より過去なら expired を返すべき", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent({ expiresAt: "2026-05-15T10:00:00.000Z" }), { secret });
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T12:00:00.000Z"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+
+  it("notBefore が now より未来なら not-yet-valid を返すべき", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(
+      intent({
+        notBefore: "2026-05-15T21:00:00.000Z",
+        expiresAt: "2026-05-15T22:00:00.000Z",
+      }),
+      { secret },
+    );
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T20:00:00.000Z"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not-yet-valid");
+  });
+
+  it("nonce store が replay を返すと nonce-replay を返すべき (= replay attack 防御)", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const replayStore: NonceStore = {
+      recordNonce: async () => "replay",
+    };
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      nonceStore: replayStore,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("nonce-replay");
+  });
+
+  it("nonce store が accepted を返すと verify は通るべき", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    let recorded = 0;
+    const store: NonceStore = {
+      recordNonce: async () => {
+        recorded += 1;
+        return "accepted";
+      },
+    };
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      nonceStore: store,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(true);
+    expect(recorded).toBe(1);
+  });
+
+  it("schema 違反な payload (= 不要 property 混入) は schema-invalid を返すべき", async () => {
+    const secret = randomBytes(32);
+    // 直接 invalid payload を sign したいので、 schema を bypass して任意 object を渡す。
+    const badPayload = {
+      ...intent(),
+      somethingExtra: "boom",
+    } as unknown as CloudActionIntent;
+    const token = signIntent(badPayload, { secret });
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("schema-invalid");
+      expect(result.details?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("signature が改ざんされていたら jws-signature-mismatch を返すべき", async () => {
+    const signer = randomBytes(32);
+    const verifier = randomBytes(32);
+    const token = signIntent(intent(), { secret: signer });
+    const result = await verifyIntent(token, {
+      resolveSecret: () => verifier,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-signature-mismatch");
+  });
+});

--- a/packages/trust-bridge/tsconfig.json
+++ b/packages/trust-bridge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["es2022"],
+    "outDir": "./dist",
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Issue #795 / ADR-017 Phase 1 として `packages/trust-bridge` を新設する。
「クレデンシャルを越境させず、 署名された CloudActionIntent を越境させ、
検証側で短命 provider-native authority に交換する」 protocol の基盤層 (= ADR-017)。

Relates #795

## Phase 1 scope (本 PR)

- `src/schema.ts`: CloudActionIntent (zod strict、 `version` literal `tenkacloud.cloud-action-intent.v1`) + `canonicalize()` (= sorted-key JSON、 確定的 byte 表現) + `parseCloudActionIntent()` + `VerifiedCloudActionIntent` brand
- `src/jws.ts`: HS256 sign / `verifySignature` (`node:crypto.createHmac` + `timingSafeEqual`)、 base64url 符号化、 alg / kid / signature reasons
- `src/verify.ts`: 上位 `verifyIntent` (= JWS → schema → TTL → nonce hook) + `NonceStore` 抽象 + `IntentVerifyOutcome` (= ok | reason 列挙)
- `src/audit.ts`: `buildAuditRecord()` (= allow / deny / needs_approval、 失敗系も unknown 埋めて audit に残す)
- `src/index.ts`: public surface (= 上記 type + function を re-export)

### tests (vitest, 30 件)

- **schema**: strict mode で extra property reject / version literal pin / TTL minimum=1 maximum=3600 / provider enum / expiresAt datetime 形式
- **canonicalize**: key sort 不変 / array 順序 preserve / undefined drop / null preserve / nested recurse
- **jws**: roundtrip OK / malformed / unknown alg / secret-not-resolved / signature-mismatch / kid 引き渡し
- **verify**: TTL expired / notBefore not-yet-valid / nonce-replay / accepted path / schema-invalid (= extra property を sign しても reject) / signature mismatch
- **audit**: allow path / override deny / verify 失敗系 / lean source の clean serialization

## 設計判断

- **HS256 のみ**: Phase 1 では「鍵管理を持ち込まず unit test 可能な最小形」 を優先。 Phase 2 で AWS adapter を入れるときに ES256 / RS256 を追加する hook 形 (alg switch の余地は interface に残してある)
- **No new crypto dependency**: `node:crypto` のみ依存。 JWS framing は spec (RFC 7515) 準拠の単純な base64url 連結のみ (= 「no custom cryptography」 原則は createHmac を OpenSSL bindings として使うことで satisfy)
- **No new package install hooks**: `make audit-deps` で baseline 83 packages のまま (= zod は既存 dep)
- **brand type で confused deputy 防御**: `VerifiedCloudActionIntent` は `CloudActionIntent & { __verified: true }`。 unvalidated 値が intent として通る事故を型で防ぐ
- **canonical serialization**: JCS RFC 8785 の subset (= key の lexicographic sort + array 順序 preserve + undefined drop)。 確定的 byte が JWS payload に入る → 検証側で再現可能
- **TenkaCloud domain field を first-class claim 化**: source.{tenantId/eventId/teamId/problemId/deploymentId/targetId/workloadId} を schema 上の必須 / optional field として持つ (= generic credential broker と差別化)

## 非 scope (= Phase 1 で意図的に出荷しない)

- Provider exchange (= AwsAssumeRoleExchange は Phase 2)
- Deploy API integration (= Phase 3)
- GCP / Azure adapter prototype (= Phase 4)
- protocol 文書 `docs/architecture/cloud-action-intent.html` (= Phase 5)
- 組み込み policy engine (= hook のみ、 OPA / Cedar 等は外で)

## Regression 分析

- 既存 deploy API / Lambda handler / CDK stack に **触っていない** (= packages/trust-bridge は新規 directory)
- root `package.json` の typecheck / test script に `@TenkaCloud/trust-bridge` を追加したが、 既存 4 workspace の動作には影響なし
- `bun.lock` は trust-bridge の dev deps (vitest / typescript / @types/node — すべて既存 root devDep のサブセット) で update
- supply chain: `make audit-deps` は 83 packages のまま (= 新規 lifecycle script を持つ package は無し)

## 物理影響

- CFn / IaC: **NO-OP** (= Phase 1 は library skeleton のみ、 Lambda bundling 経路にも入らない)
- 新規 artifact: `packages/trust-bridge/` (10 files: src 5 + test 4 + tsconfig)
- 既存 artifact 変更: `package.json` の scripts に trust-bridge typecheck/test 追加 + `bun.lock`

## Test plan

- [x] `cd packages/trust-bridge && bunx vitest run` (= 30 test pass)
- [x] `cd packages/trust-bridge && bunx tsc --noEmit` (= clean)
- [x] `make test` (= infrastructure 897 + admin-console 116 + application-admin-console 191 + participant-portal 146 + trust-bridge 30 すべて pass)
- [x] `make harness` (= no findings)
- [x] `make before-commit` (= lint + test + validate-problems + check-docs + check-http-status + check-template-ascii + audit-deps + check-synth すべて通過)
- [ ] Phase 2 で AwsAssumeRoleExchange を hook の先に繋いだ後の integration test (= 本 PR scope 外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)