### PR TITLE
fix(deploy): describe-stack-handler に input shape diagnostic logging を追加

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -2,7 +2,7 @@ import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-clo
 import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import type { Credentials } from "@aws-sdk/client-sts";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
-import { logDeployTrace, warnDeployTrace } from "../shared/trace-log.js";
+import { errorDeployTrace, logDeployTrace, warnDeployTrace } from "../shared/trace-log.js";
 
 export interface DescribeStackStateMachineInput {
   readonly detail?: {
@@ -118,11 +118,46 @@ async function assumeRoleWithExternalId(
   return assertCompleteCredentials(assumeOut.Credentials);
 }
 
+/**
+ * Issue (regression 調査): Step Functions 経由で渡される `input.detail.jobId`
+ * が undefined で fail するケースが 1 回観測された (= ジョブ ID は DDB row に
+ * 入っているのに、 Lambda が受け取った payload では `detail` が無いか jobId
+ * が抜けている)。 原因確定のため、 必須 field validation 前に input の構造を
+ * 1 行 JSON で trace log する。 `tenantId` / `namePrefix` 等の non-secret な
+ * shape 情報のみを残し、 PII / secret は含めない (= credential / external id
+ * は input に乗らない、 SSM parameter name のみ)。
+ *
+ * 用途: 次回 regression 再現時に CloudWatch Logs Insights で
+ *   filter event = "deploy.describe-stack.input-received"
+ * を引けば実 payload 構造が見える。 原因が確定したらこの trace は残してもよい
+ * (= structural log は long-term observability に有用)。
+ */
+function logInputShape(input: DescribeStackStateMachineInput): void {
+  const detail = input.detail;
+  errorDeployTrace("deploy.describe-stack.input-received", {
+    hasDetail: detail !== undefined && detail !== null,
+    hasJobId: typeof detail?.jobId === "string" && detail.jobId.length > 0,
+    hasNamePrefix: typeof detail?.namePrefix === "string" && detail.namePrefix.length > 0,
+    hasRegion: typeof detail?.region === "string" && detail.region.length > 0,
+    hasTenantId: typeof detail?.tenantId === "string" && detail.tenantId.length > 0,
+    hasCompetitorRoleArn:
+      typeof detail?.competitorRoleArn === "string" && detail.competitorRoleArn.length > 0,
+    hasExternalIdParameterName:
+      typeof detail?.externalIdParameterName === "string" &&
+      detail.externalIdParameterName.length > 0,
+    detailKeys: detail && typeof detail === "object" ? Object.keys(detail).join(",") : "",
+    topLevelKeys: Object.keys(input as Record<string, unknown>).join(","),
+  });
+}
+
 export async function describeStackForDeployment(
   input: DescribeStackStateMachineInput,
   deps: DescribeStackDeps,
 ) {
   const detail = input.detail ?? {};
+  if (typeof detail.jobId !== "string" || detail.jobId.length === 0) {
+    logInputShape(input);
+  }
   const jobId = requireString(detail.jobId, "detail.jobId");
   const correlationId = detail.correlationId || jobId;
   const stackName = requireString(detail.namePrefix, "detail.namePrefix");

--- a/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
+++ b/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
@@ -48,6 +48,60 @@ function deps(options: { externalId?: string } = {}) {
   };
 }
 
+describe("describeStackForDeployment input-shape diagnostics (regression #?)", () => {
+  it("detail.jobId が undefined のとき deploy.describe-stack.input-received を error level で emit し、 既存の missing required field エラーを保つべき", async () => {
+    const { deps: d } = deps();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(
+        describeStackForDeployment({ detail: { namePrefix: "x", region: "ap-northeast-1" } }, d),
+      ).rejects.toThrow("missing required field: detail.jobId");
+      const calls = errSpy.mock.calls.map((c) => String(c[0]));
+      const traceCall = calls.find((c) => c.includes("deploy.describe-stack.input-received"));
+      expect(traceCall).toBeDefined();
+      // shape の non-secret な field のみが出ること (= jobId 自体は出ない)。
+      expect(traceCall).toContain('"hasDetail":true');
+      expect(traceCall).toContain('"hasJobId":false');
+      expect(traceCall).toContain('"hasNamePrefix":true');
+      expect(traceCall).toContain('"hasRegion":true');
+      expect(traceCall).toContain('"detailKeys":"namePrefix,region"');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("detail 自体が undefined のときも shape log を emit して missing required field を保つべき", async () => {
+    const { deps: d } = deps();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(describeStackForDeployment({}, d)).rejects.toThrow(
+        "missing required field: detail.jobId",
+      );
+      const calls = errSpy.mock.calls.map((c) => String(c[0]));
+      const traceCall = calls.find((c) => c.includes("deploy.describe-stack.input-received"));
+      expect(traceCall).toBeDefined();
+      expect(traceCall).toContain('"hasDetail":false');
+      expect(traceCall).toContain('"hasJobId":false');
+      expect(traceCall).toContain('"detailKeys":""');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("正常 path (= jobId / namePrefix / region 全部揃う) では shape log を出さないべき", async () => {
+    const { deps: d } = deps();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await describeStackForDeployment(input, d);
+      const calls = errSpy.mock.calls.map((c) => String(c[0]));
+      const traceCall = calls.find((c) => c.includes("deploy.describe-stack.input-received"));
+      expect(traceCall).toBeUndefined();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
 describe("describeStackForDeployment", () => {
   it("competitorRoleArn がある場合は ExternalId 付き AssumeRole 後に DescribeStacks すべき", async () => {
     const { deps: d, ssmSend, stsSend, cfnSend, cfnClient } = deps();


### PR DESCRIPTION
## Summary

regression 調査用の防御的ロギング。 本番で次のエラーが観測された:

```
{"errorType":"Error","errorMessage":"missing required field: detail.jobId",
 "trace":["Error: missing required field: detail.jobId",
  " at requireString (/lib/problem-deploy/handlers/describe-stack-handler/index.ts:28:11)",
  " at describeStackForDeployment (/lib/problem-deploy/handlers/describe-stack-handler/index.ts:118:17)",
  ...]}
```

Job ID: `01KRN6SCJHZ0W9174J2ZH3JJPF`、 「Deploy failed for sample」 / `hello-world` (= 添付スクリーンショット)。

## 原因の現状

`deploy.ts → publishProblemEvent → EventBridge → DeployCreateRule → SfnStateMachine → DescribeStack` の経路を全部追跡したが、 `$.detail.jobId` が欠落する経路が **ソース上では見当たらない**:

- `deploy.ts:172-188` は `jobId: item.jobId` (= `ulid()`) を必ず詰める
- `events.ts:118-130` は `Detail: JSON.stringify(args.detail)` でそのまま乗せる
- `deploy-event-rule.ts` の `SfnStateMachine` は `input` 未指定 → EventBridge は event 全体を State Machine に渡す
- State Machine は `MarkInProgress` で `$.detail.jobId` を読んで成功している (= 失敗してたら別 error)
- `DescribeStack` task は `payload: TaskInput.fromJsonPathAt("$")` で `$` 全体を Lambda に渡す
- `cdk synth` 出力でも `EventBridge Rule` の Target は `{Arn, Id, RoleArn}` のみで `Input` / `InputPath` / `InputTransformer` 一切無い

つまり reproducer が現状の最新コードでは特定できない (= deploy 済 Lambda / State Machine と source が drift している可能性、 または racing condition の可能性)。

## 本 PR の対処

`describeStackForDeployment` の `requireString(detail.jobId, ...)` 直前に **input structural shape を 1 行 JSON で error-level trace log に出す**。 次回の同じ失敗で CloudWatch Logs Insights で

```
filter event = "deploy.describe-stack.input-received"
```

を引けば、 Lambda が受け取った実 payload の shape (= 各 field の有無 + detail / topLevel keys) が確定できる。

## 機微情報の取り扱い

非 secret な shape 情報のみ log に出る:
- `hasJobId` / `hasNamePrefix` / `hasRegion` / `hasTenantId` / `hasCompetitorRoleArn` / `hasExternalIdParameterName` — boolean のみ
- `detailKeys` / `topLevelKeys` — key 名のみ
- credential / external id 値、 role ARN 本体、 jobId 値 自体は **lo** しない

(= ulid jobId は機微ではないが、 contract 上 secrets と同列扱い)。

## test

- 既存 5 件 → 8 件 (新規 3 件)
- jobId 欠落で shape log を emit し missing required field error を保つ
- detail 自体が欠落でも同様に動く
- 正常 path では shape log を出さない (= no-emit を pin)

## Regression 分析

- 正常 path には影響なし (= shape log は失敗時のみ emit、 test で pin)
- `errorDeployTrace` は既存 helper の追加 import (= side effect なし)
- Lambda runtime / IAM / state machine 構造に変更なし

## 物理影響

- UPDATE: `tenkacloud-problem-deploy-DescribeStack*` Lambda bundle (= esbuild 出力が +6 行程度)
- NO-OP: CFn resource graph / IAM / DDB / EventBridge / Step Functions

## Test plan

- [x] `bun run vitest run test/problem-deploy/describe-stack-handler.test.ts` (= 8 test pass)
- [x] `make harness` (= no findings)
- [x] `make before-commit` (= 全 gate 通過)
- [ ] 本 PR merge + 再 deploy 後、 同じ失敗が再現したら CloudWatch で `deploy.describe-stack.input-received` を引いて shape を確定する
- [ ] 原因確定後、 本 trace を long-term observability として残すか撤去するか判断する

🤖 Generated with [Claude Code](https://claude.com/claude-code)