### PR TITLE
feat(#795 Phase 2): AwsAssumeRoleExchange adapter (verified intent → AWS STS credentials)

### DIFF
--- a/packages/trust-bridge/src/aws-assume-role.ts
+++ b/packages/trust-bridge/src/aws-assume-role.ts
@@ -1,0 +1,207 @@
+import {
+  type ExchangeContext,
+  ExchangeError,
+  type ProviderCredential,
+  type ProviderTokenExchange,
+} from "./provider.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 2: AwsAssumeRoleExchange adapter。
+ *
+ * Phase 1 で sign / verify した CloudActionIntent を、 AWS STS の AssumeRole
+ * 呼び出しに変換する layer。 既存 TenkaCloud の competitor account flow
+ * (= ADR-002 cross-account federation、 ExternalId 必須) を本抽象に乗せる。
+ *
+ * 設計判断:
+ *   - STS client は inject 可能にする (= test では fake、 production では
+ *     @aws-sdk/client-sts の AssumeRoleCommand を渡す)。 本 package に
+ *     `@aws-sdk/client-sts` を hard dep しない (= consumer 側で持ち込む、
+ *     これにより trust-bridge は provider client universe から独立を保つ)。
+ *   - ExternalId は context.externalId で渡す。 ADR-002 の「必ず ExternalId
+ *     を要求」 原則を強制 (= 渡されていなければ context-missing で fail)。
+ *   - RoleArn は context.roleArn で渡す (= providerAccountRef は ID 検証用、
+ *     RoleArn は具体的な ARN)。
+ *   - session policy は intent.action.requestedScopes から組み立てる
+ *     (= Effect=Allow + Resource="*" の minimal policy)。
+ *   - DurationSeconds は intent.constraints.ttlSeconds をそのまま転写。
+ *     STS の最低 limit (= 900 sec) と最大 limit (= 3600 sec) は spec の
+ *     1〜3600 範囲と整合済み。
+ */
+
+export interface AwsCredential extends ProviderCredential {
+  readonly provider: "aws";
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+  readonly assumedRoleArn: string;
+  readonly externalId: string;
+}
+
+/**
+ * STS の `AssumeRoleCommand` を呼び出す抽象。 production では
+ * `@aws-sdk/client-sts` の `STSClient.send(new AssumeRoleCommand(input))` を
+ * wrap する関数を渡す。 test では fake を渡す。
+ */
+export interface StsAssumeRoleClient {
+  assumeRole(input: AssumeRoleInput): Promise<AssumeRoleOutput>;
+}
+
+export interface AssumeRoleInput {
+  readonly RoleArn: string;
+  readonly RoleSessionName: string;
+  readonly ExternalId: string;
+  readonly DurationSeconds: number;
+  /** AWS session policy JSON (= 最終 effective permission)。 */
+  readonly Policy?: string;
+  /** 構造化 tag (= ABAC / audit 用)。 */
+  readonly Tags?: readonly { readonly Key: string; readonly Value: string }[];
+}
+
+export interface AssumeRoleOutput {
+  readonly Credentials: {
+    readonly AccessKeyId: string;
+    readonly SecretAccessKey: string;
+    readonly SessionToken: string;
+    readonly Expiration: Date | string;
+  };
+  readonly AssumedRoleUser: {
+    readonly Arn: string;
+  };
+}
+
+export interface AwsExchangeContext extends ExchangeContext {
+  readonly roleArn: string;
+  readonly externalId: string;
+  readonly roleSessionName?: string;
+}
+
+export interface AwsAssumeRoleExchangeOptions {
+  readonly sts: StsAssumeRoleClient;
+  readonly now?: () => Date;
+}
+
+export class AwsAssumeRoleExchange implements ProviderTokenExchange<AwsCredential> {
+  readonly provider = "aws" as const;
+  private readonly sts: StsAssumeRoleClient;
+  private readonly now: () => Date;
+
+  constructor(options: AwsAssumeRoleExchangeOptions) {
+    this.sts = options.sts;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async exchange(
+    intent: VerifiedCloudActionIntent,
+    context: ExchangeContext,
+  ): Promise<AwsCredential> {
+    if (intent.target.provider !== "aws") {
+      throw new ExchangeError(
+        "provider-mismatch",
+        `intent target provider is ${intent.target.provider}, not aws`,
+      );
+    }
+
+    const awsContext = context as AwsExchangeContext;
+    if (!awsContext.roleArn || awsContext.roleArn.length === 0) {
+      throw new ExchangeError("context-missing", "AwsExchangeContext.roleArn is required");
+    }
+    if (!awsContext.externalId || awsContext.externalId.length === 0) {
+      throw new ExchangeError(
+        "context-missing",
+        "AwsExchangeContext.externalId is required (= ADR-002 で必須化)",
+      );
+    }
+
+    const duration = intent.constraints.ttlSeconds;
+    if (duration < 900) {
+      // STS AssumeRole の最小 DurationSeconds は 900 (= 15 min)。 spec 上限は
+      // 3600 で揃えているが、 下限は STS 側で 900。 intent が短すぎる場合は
+      // 900 に切り上げる代わりに ttl-exceeded-provider-limit で fail (= 静かに
+      // 値を曲げない、 ADR-017 D1 の "explicit failure" 原則)。
+      throw new ExchangeError(
+        "ttl-exceeded-provider-limit",
+        `STS AssumeRole requires DurationSeconds >= 900, got ${duration}`,
+      );
+    }
+
+    const policy = this.buildSessionPolicy(intent);
+    const sessionName = (awsContext.roleSessionName ?? buildSessionName(intent)).slice(0, 64);
+    const issuedAt = this.now();
+
+    let output: AssumeRoleOutput;
+    try {
+      output = await this.sts.assumeRole({
+        RoleArn: awsContext.roleArn,
+        RoleSessionName: sessionName,
+        ExternalId: awsContext.externalId,
+        DurationSeconds: duration,
+        Policy: policy,
+        Tags: buildSessionTags(intent),
+      });
+    } catch (err) {
+      throw new ExchangeError("provider-api-error", "AssumeRole failed", err);
+    }
+
+    const expiresAt =
+      output.Credentials.Expiration instanceof Date
+        ? output.Credentials.Expiration.toISOString()
+        : new Date(output.Credentials.Expiration).toISOString();
+
+    return {
+      provider: "aws",
+      accessKeyId: output.Credentials.AccessKeyId,
+      secretAccessKey: output.Credentials.SecretAccessKey,
+      sessionToken: output.Credentials.SessionToken,
+      assumedRoleArn: output.AssumedRoleUser.Arn,
+      externalId: awsContext.externalId,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt,
+      forRequestId: intent.requestId,
+    };
+  }
+
+  private buildSessionPolicy(intent: VerifiedCloudActionIntent): string | undefined {
+    if (intent.action.requestedScopes.length === 0) {
+      return undefined;
+    }
+    return JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [...intent.action.requestedScopes],
+          Resource: "*",
+        },
+      ],
+    });
+  }
+}
+
+function buildSessionName(intent: VerifiedCloudActionIntent): string {
+  const parts = [
+    "tenkacloud",
+    intent.source.tenantId,
+    intent.source.teamId,
+    intent.requestId,
+  ].filter((p): p is string => Boolean(p));
+  return parts.join("-").replace(/[^A-Za-z0-9_=,.@-]/g, "_");
+}
+
+function buildSessionTags(
+  intent: VerifiedCloudActionIntent,
+): readonly { readonly Key: string; readonly Value: string }[] {
+  const tags: { readonly Key: string; readonly Value: string }[] = [
+    { Key: "tenkacloud:tenantId", Value: intent.source.tenantId },
+    { Key: "tenkacloud:workloadId", Value: intent.source.workloadId },
+    { Key: "tenkacloud:requestId", Value: intent.requestId },
+    { Key: "tenkacloud:action", Value: intent.action.type },
+  ];
+  if (intent.source.eventId) tags.push({ Key: "tenkacloud:eventId", Value: intent.source.eventId });
+  if (intent.source.teamId) tags.push({ Key: "tenkacloud:teamId", Value: intent.source.teamId });
+  if (intent.source.problemId)
+    tags.push({ Key: "tenkacloud:problemId", Value: intent.source.problemId });
+  if (intent.source.deploymentId)
+    tags.push({ Key: "tenkacloud:deploymentId", Value: intent.source.deploymentId });
+  return tags;
+}

--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -22,6 +22,15 @@
 export type { AuditInput, CloudActionAuditRecord } from "./audit.js";
 export { buildAuditRecord } from "./audit.js";
 export type {
+  AssumeRoleInput,
+  AssumeRoleOutput,
+  AwsAssumeRoleExchangeOptions,
+  AwsCredential,
+  AwsExchangeContext,
+  StsAssumeRoleClient,
+} from "./aws-assume-role.js";
+export { AwsAssumeRoleExchange } from "./aws-assume-role.js";
+export type {
   JwsHeader,
   SignOptions,
   VerifyFailureReason,
@@ -29,6 +38,15 @@ export type {
   VerifyOutcome,
 } from "./jws.js";
 export { signIntent, verifySignature } from "./jws.js";
+
+export type {
+  ExchangeContext,
+  ExchangeFailureReason,
+  ProviderCredential,
+  ProviderId,
+  ProviderTokenExchange,
+} from "./provider.js";
+export { ExchangeError } from "./provider.js";
 export type { CloudActionIntent, VerifiedCloudActionIntent } from "./schema.js";
 export {
   brandVerified,

--- a/packages/trust-bridge/src/provider.ts
+++ b/packages/trust-bridge/src/provider.ts
@@ -1,0 +1,61 @@
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 2: ProviderTokenExchange interface。
+ *
+ * 「verified intent → short-lived provider-native credential」 への変換を
+ * 抽象化する。 implementation は provider 別の adapter (Phase 2 で AWS、
+ * Phase 4 で GCP / Azure) が満たす。
+ *
+ * 重要な責務:
+ *   - intent.target.provider が adapter の provider と一致することを確認
+ *   - intent.constraints.ttlSeconds を provider-native lifetime に転写
+ *   - intent.action.requestedScopes を provider-native scope (= AWS session
+ *     policy / GCP role / Azure RBAC) に転写
+ *   - intent.source.* の context を provider call の context (= ExternalId /
+ *     session tags / audience claim) に転写
+ */
+
+export type ProviderId = "aws" | "azure" | "gcp" | "cloudflare";
+
+export interface ExchangeContext {
+  /**
+   * adapter 側が provider への call に追加で必要な context (= AWS STS の
+   * ExternalId 等)。 keys / values は adapter ごとに自由。
+   */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Phase 2: 短命 credential の minimum 共通 shape。 adapter 別の追加 field は
+ * adapter 側の concrete type で extend する (= 構造的 subtype)。
+ */
+export interface ProviderCredential {
+  readonly provider: ProviderId;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  /** adapter が intent をエコーするとき (= deploy 側で audit に使う)。 */
+  readonly forRequestId: string;
+}
+
+export interface ProviderTokenExchange<C extends ProviderCredential = ProviderCredential> {
+  readonly provider: ProviderId;
+  exchange(intent: VerifiedCloudActionIntent, context: ExchangeContext): Promise<C>;
+}
+
+export type ExchangeFailureReason =
+  | "provider-mismatch"
+  | "context-missing"
+  | "provider-api-error"
+  | "ttl-exceeded-provider-limit";
+
+export class ExchangeError extends Error {
+  readonly reason: ExchangeFailureReason;
+  readonly underlying?: unknown;
+  constructor(reason: ExchangeFailureReason, message: string, underlying?: unknown) {
+    super(message);
+    this.name = "ExchangeError";
+    this.reason = reason;
+    this.underlying = underlying;
+  }
+}

--- a/packages/trust-bridge/test/aws-assume-role.test.ts
+++ b/packages/trust-bridge/test/aws-assume-role.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AssumeRoleInput,
+  type AssumeRoleOutput,
+  AwsAssumeRoleExchange,
+  type StsAssumeRoleClient,
+} from "../src/aws-assume-role.js";
+import { ExchangeError } from "../src/provider.js";
+import {
+  brandVerified,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  type VerifiedCloudActionIntent,
+} from "../src/schema.js";
+
+function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudActionIntent {
+  const intent: CloudActionIntent = {
+    version: INTENT_VERSION,
+    requestId: "req-aws-1",
+    nonce: "nonce-aws-1",
+    source: {
+      system: "tenkacloud",
+      tenantId: "tenant-a",
+      teamId: "team-alpha",
+      problemId: "hello-world",
+      deploymentId: "deploy-9",
+      workloadId: "deploy-worker",
+    },
+    target: { provider: "aws", providerAccountRef: "123456789012" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cloudformation:CreateStack", "cloudformation:DescribeStacks"],
+    },
+    constraints: {
+      ttlSeconds: 1800,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+  return brandVerified(intent);
+}
+
+function makeStub(
+  output: Partial<AssumeRoleOutput> = {},
+  capture?: (input: AssumeRoleInput) => void,
+): StsAssumeRoleClient {
+  return {
+    assumeRole: async (input: AssumeRoleInput) => {
+      capture?.(input);
+      return {
+        Credentials: {
+          AccessKeyId: output.Credentials?.AccessKeyId ?? "ASIA-test",
+          SecretAccessKey: output.Credentials?.SecretAccessKey ?? "secret",
+          SessionToken: output.Credentials?.SessionToken ?? "token",
+          Expiration: output.Credentials?.Expiration ?? new Date("2026-05-15T20:30:00.000Z"),
+        },
+        AssumedRoleUser: {
+          Arn: output.AssumedRoleUser?.Arn ?? "arn:aws:sts::123456789012:assumed-role/X/Y",
+        },
+      };
+    },
+  };
+}
+
+describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
+  it("provider が aws でない intent では provider-mismatch を投げるべき", async () => {
+    const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
+    const intent = makeIntent({
+      target: { provider: "gcp", providerAccountRef: "my-project" },
+    });
+    await expect(
+      ex.exchange(intent, { roleArn: "arn:aws:iam::1:role/x", externalId: "abc" }),
+    ).rejects.toMatchObject({ reason: "provider-mismatch" });
+  });
+
+  it("context.roleArn が無いと context-missing を投げるべき", async () => {
+    const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
+    await expect(
+      ex.exchange(makeIntent(), { externalId: "ext-1" } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("context.externalId が無いと context-missing を投げるべき (= ADR-002 必須化)", async () => {
+    const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
+    await expect(
+      ex.exchange(makeIntent(), { roleArn: "arn:aws:iam::1:role/x" } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("ttlSeconds が STS 最小 900 未満なら ttl-exceeded-provider-limit を投げるべき", async () => {
+    const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
+    const intent = makeIntent();
+    const short: CloudActionIntent = {
+      ...intent,
+      constraints: { ...intent.constraints, ttlSeconds: 600 },
+    };
+    await expect(
+      ex.exchange(brandVerified(short), {
+        roleArn: "arn:aws:iam::1:role/x",
+        externalId: "ext-1",
+      }),
+    ).rejects.toMatchObject({ reason: "ttl-exceeded-provider-limit" });
+  });
+
+  it("STS が throw したら provider-api-error に wrap するべき (= underlying 保持)", async () => {
+    const failingSts: StsAssumeRoleClient = {
+      assumeRole: async () => {
+        throw new Error("STS unreachable");
+      },
+    };
+    const ex = new AwsAssumeRoleExchange({ sts: failingSts });
+    try {
+      await ex.exchange(makeIntent(), {
+        roleArn: "arn:aws:iam::1:role/x",
+        externalId: "ext-1",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExchangeError);
+      const ee = err as ExchangeError;
+      expect(ee.reason).toBe("provider-api-error");
+      expect((ee.underlying as Error).message).toBe("STS unreachable");
+    }
+  });
+
+  it("成功 path で AssumeRoleCommand input に DurationSeconds / ExternalId / Policy / Tags を正しく載せるべき", async () => {
+    let captured: AssumeRoleInput | undefined;
+    const sts = makeStub({}, (input) => {
+      captured = input;
+    });
+    const ex = new AwsAssumeRoleExchange({ sts });
+    const result = await ex.exchange(makeIntent(), {
+      roleArn: "arn:aws:iam::1:role/x",
+      externalId: "ext-secret",
+    });
+    expect(captured).toBeDefined();
+    expect(captured?.RoleArn).toBe("arn:aws:iam::1:role/x");
+    expect(captured?.ExternalId).toBe("ext-secret");
+    expect(captured?.DurationSeconds).toBe(1800);
+    expect(captured?.Policy).toContain('"Effect":"Allow"');
+    expect(captured?.Policy).toContain("cloudformation:CreateStack");
+    expect(captured?.Policy).toContain("cloudformation:DescribeStacks");
+    const tags = captured?.Tags ?? [];
+    expect(tags.find((t) => t.Key === "tenkacloud:tenantId")?.Value).toBe("tenant-a");
+    expect(tags.find((t) => t.Key === "tenkacloud:teamId")?.Value).toBe("team-alpha");
+    expect(tags.find((t) => t.Key === "tenkacloud:requestId")?.Value).toBe("req-aws-1");
+    expect(result.provider).toBe("aws");
+    expect(result.forRequestId).toBe("req-aws-1");
+    expect(result.externalId).toBe("ext-secret");
+  });
+
+  it("RoleSessionName は default で intent claim から組み立て、 64 文字 cap されるべき", async () => {
+    let captured: AssumeRoleInput | undefined;
+    const sts = makeStub({}, (input) => {
+      captured = input;
+    });
+    const ex = new AwsAssumeRoleExchange({ sts });
+    const intent = makeIntent({
+      requestId: "req-very-long-id-that-keeps-going-and-going-and-going",
+      source: {
+        system: "tenkacloud",
+        tenantId: "tenant-with-long-id",
+        teamId: "team-with-long-id",
+        workloadId: "w-1",
+      },
+    });
+    await ex.exchange(intent, { roleArn: "arn:aws:iam::1:role/x", externalId: "ext-1" });
+    expect(captured?.RoleSessionName.length).toBeLessThanOrEqual(64);
+  });
+
+  it("requestedScopes が空なら Policy 省略されるべき (= default = role policy のみ)", async () => {
+    let captured: AssumeRoleInput | undefined;
+    const sts = makeStub({}, (input) => {
+      captured = input;
+    });
+    const ex = new AwsAssumeRoleExchange({ sts });
+    const intent = makeIntent();
+    const noScopes: CloudActionIntent = {
+      ...intent,
+      action: { ...intent.action, requestedScopes: [] },
+    };
+    await ex.exchange(brandVerified(noScopes), {
+      roleArn: "arn:aws:iam::1:role/x",
+      externalId: "ext-1",
+    });
+    expect(captured?.Policy).toBeUndefined();
+  });
+
+  it("Expiration が string で返ってきても ISO に正規化されるべき", async () => {
+    const sts: StsAssumeRoleClient = {
+      assumeRole: async () => ({
+        Credentials: {
+          AccessKeyId: "K",
+          SecretAccessKey: "S",
+          SessionToken: "T",
+          Expiration: "2026-05-15T22:00:00Z",
+        },
+        AssumedRoleUser: { Arn: "arn:aws:sts::1:assumed-role/x/y" },
+      }),
+    };
+    const ex = new AwsAssumeRoleExchange({ sts });
+    const result = await ex.exchange(makeIntent(), {
+      roleArn: "arn:aws:iam::1:role/x",
+      externalId: "ext-1",
+    });
+    expect(result.expiresAt).toBe("2026-05-15T22:00:00.000Z");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 (PR #800、 merged) で sign/verify した CloudActionIntent を AWS STS
AssumeRole 呼び出しに変換する adapter を追加する。 既存 TenkaCloud の
competitor account flow (= ADR-002、 ExternalId 必須) を `ProviderTokenExchange`
抽象に乗せる第一歩。

Relates #795

## scope

- `src/provider.ts`: `ProviderTokenExchange<C>` + `ProviderCredential` + `ExchangeError`
- `src/aws-assume-role.ts`: `AwsAssumeRoleExchange` class
  - `StsAssumeRoleClient` を inject 可能 (= `@aws-sdk/client-sts` を hard dep にしない)
  - ExternalId 必須化を `context-missing` で機械強制 (= ADR-002 不可侵)
  - `intent.action.requestedScopes` を session policy (Effect=Allow、 Resource=`"*"`) に翻訳
  - `intent.source.*` を STS Tags (`tenkacloud:tenantId` 等) に転写
  - `DurationSeconds = intent.constraints.ttlSeconds`、 STS 最小 900 を割ったら明示 fail
  - `RoleSessionName` は intent claim から組み立て 64 文字 cap
- `test/aws-assume-role.test.ts`: 9 test (provider mismatch / context missing × 2 / ttl too short / STS error wrap / 成功 path / session name cap / Policy 省略 / Expiration ISO 正規化)

## 設計判断

- **`@aws-sdk/client-sts` を依存に追加しない**: `StsAssumeRoleClient` interface 経由で consumer が好きな client を渡す
- **静かに値を曲げない**: ttl が STS limit を割ったら切り上げず明示 fail (= ADR-017 D1 「explicit failure」)
- **session policy の Resource=`"*"`**: scope 制限は requestedScopes の Action 集合のみ
- **session tags は ABAC ready**

## Test plan

- [x] `cd packages/trust-bridge && bunx vitest run` (= 39 test pass、 Phase 1 30 + Phase 2 9)
- [x] `cd packages/trust-bridge && bunx tsc --noEmit` (= clean)
- [x] `make before-commit` (= 全 gate 通過)

## 物理影響

- CFn / IaC: **NO-OP** (= adapter library のみ)
- 新規 artifact: 3 file (provider.ts / aws-assume-role.ts / aws-assume-role.test.ts) + 1 file 変更 (index.ts に re-export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)