### PR TITLE
feat(#795 Phase 4): GCP / Azure adapter prototypes (WIF + FIC)

### DIFF
--- a/packages/trust-bridge/src/azure-federated-credential.ts
+++ b/packages/trust-bridge/src/azure-federated-credential.ts
@@ -1,0 +1,147 @@
+import {
+  type ExchangeContext,
+  ExchangeError,
+  type ProviderCredential,
+  type ProviderTokenExchange,
+} from "./provider.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 4: AzureFederatedCredentialExchange adapter (prototype)。
+ *
+ * Azure の Federated Identity Credential (FIC) は OIDC JWT を Azure AD token
+ * exchange に使い、 user-assigned managed identity の access token を取得する
+ * 仕組み (= GitHub Actions / Terraform Cloud 等で広く使われる)。
+ *
+ * TenkaCloud の場合:
+ *   1. CloudActionIntent (= JWS) を verify
+ *   2. JWS / JWT を `client_assertion` として Azure AD `/oauth2/v2.0/token` に POST
+ *      (`grant_type=client_credentials`, `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`)
+ *   3. 戻ってきた access token を Azure ARM API call に使う
+ *
+ * Phase 4 では `oauth2TokenEndpoint` を呼ぶ HTTP client を inject 可能にする
+ * (= `@azure/identity` を hard dep にしない)。 実 Azure subscription smoke は
+ * Phase 4 末で別 PR で行う。
+ *
+ * 既知の Open Question (ADR-017 OQ#1):
+ *   - Azure AD の client_assertion は RFC 7523 JWT を期待する。 本 prototype の
+ *     `toClientAssertion` hook は caller に JWT 変換責任を委ねる (= AWS / GCP と
+ *     対称な設計)。 trust-bridge 側で JWT claim 変換 utility を提供するかは
+ *     Phase 4 末で判断。
+ */
+
+export interface AzureCredential extends ProviderCredential {
+  readonly provider: "azure";
+  readonly accessToken: string;
+  readonly tokenType: "Bearer";
+  /** managed identity client ID (= app registration object ID)。 */
+  readonly clientId: string;
+}
+
+/**
+ * Azure AD `/oauth2/v2.0/token` を呼ぶ最小抽象。 production では fetch() を wrap、
+ * test では fake を渡す。
+ */
+export interface AzureTokenEndpointClient {
+  exchangeAssertion(input: AzureTokenExchangeInput): Promise<AzureTokenExchangeOutput>;
+}
+
+export interface AzureTokenExchangeInput {
+  readonly tenantId: string;
+  readonly clientId: string;
+  readonly clientAssertion: string;
+  readonly scope: string;
+}
+
+export interface AzureTokenExchangeOutput {
+  readonly access_token: string;
+  readonly token_type: "Bearer";
+  readonly expires_in: number;
+}
+
+export interface AzureExchangeContext extends ExchangeContext {
+  /** Azure AD tenant GUID (= directory ID)。 */
+  readonly azureTenantId: string;
+  /** managed identity の app registration client ID。 */
+  readonly clientId: string;
+  /** 取得 access token の scope (例: `https://management.azure.com/.default`)。 */
+  readonly scope: string;
+}
+
+export interface AzureAdapterOptions {
+  readonly tokenClient: AzureTokenEndpointClient;
+  readonly now?: () => Date;
+  /**
+   * Phase 4: intent → JWT (RFC 7523) 変換は caller 責任。 trust-bridge 内で
+   * JWT claim を組み立てるための utility を提供するかは Phase 4 末で判断。
+   */
+  readonly toClientAssertion: (intent: VerifiedCloudActionIntent) => string;
+}
+
+export class AzureFederatedCredentialExchange implements ProviderTokenExchange<AzureCredential> {
+  readonly provider = "azure" as const;
+  private readonly tokenClient: AzureTokenEndpointClient;
+  private readonly now: () => Date;
+  private readonly toClientAssertion: (intent: VerifiedCloudActionIntent) => string;
+
+  constructor(options: AzureAdapterOptions) {
+    this.tokenClient = options.tokenClient;
+    this.now = options.now ?? (() => new Date());
+    this.toClientAssertion = options.toClientAssertion;
+  }
+
+  async exchange(
+    intent: VerifiedCloudActionIntent,
+    context: ExchangeContext,
+  ): Promise<AzureCredential> {
+    if (intent.target.provider !== "azure") {
+      throw new ExchangeError(
+        "provider-mismatch",
+        `intent target provider is ${intent.target.provider}, not azure`,
+      );
+    }
+
+    const azureContext = context as AzureExchangeContext;
+    if (!azureContext.azureTenantId || azureContext.azureTenantId.length === 0) {
+      throw new ExchangeError("context-missing", "AzureExchangeContext.azureTenantId is required");
+    }
+    if (!azureContext.clientId || azureContext.clientId.length === 0) {
+      throw new ExchangeError("context-missing", "AzureExchangeContext.clientId is required");
+    }
+    if (!azureContext.scope || azureContext.scope.length === 0) {
+      throw new ExchangeError("context-missing", "AzureExchangeContext.scope is required");
+    }
+
+    const assertion = this.toClientAssertion(intent);
+    const issuedAt = this.now();
+
+    let output: AzureTokenExchangeOutput;
+    try {
+      output = await this.tokenClient.exchangeAssertion({
+        tenantId: azureContext.azureTenantId,
+        clientId: azureContext.clientId,
+        clientAssertion: assertion,
+        scope: azureContext.scope,
+      });
+    } catch (err) {
+      throw new ExchangeError(
+        "provider-api-error",
+        "Azure AD oauth2/v2.0/token exchange failed",
+        err,
+      );
+    }
+
+    // Azure AD は `expires_in` (= seconds) を返す。 ISO datetime に正規化する。
+    const expiresAt = new Date(issuedAt.getTime() + output.expires_in * 1000).toISOString();
+
+    return {
+      provider: "azure",
+      accessToken: output.access_token,
+      tokenType: output.token_type,
+      clientId: azureContext.clientId,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt,
+      forRequestId: intent.requestId,
+    };
+  }
+}

--- a/packages/trust-bridge/src/gcp-workload-identity.ts
+++ b/packages/trust-bridge/src/gcp-workload-identity.ts
@@ -1,0 +1,194 @@
+import {
+  type ExchangeContext,
+  ExchangeError,
+  type ProviderCredential,
+  type ProviderTokenExchange,
+} from "./provider.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #795 / ADR-017 Phase 4: GcpWorkloadIdentityFederationExchange adapter (prototype)。
+ *
+ * Google Cloud の Workload Identity Federation (WIF) は OIDC / SAML token を
+ * GCP service account の short-lived access token に交換する仕組み。 TenkaCloud
+ * の場合は次の 3 段:
+ *
+ *   1. CloudActionIntent (= JWS, HS256) を verify
+ *   2. JWS を re-sign せず、 そのまま GCP STS の `audience` field に乗せる形で
+ *      WIF pool に submit (= GCP STS API)
+ *   3. 戻ってきた federated token を `iamcredentials.googleapis.com` の
+ *      `generateAccessToken` API で service account の OAuth2 access token に
+ *      exchange
+ *
+ * Phase 4 では (2) と (3) を呼ぶ HTTP client を inject 可能にする (= @google-cloud
+ * 系 SDK を hard dep にしない、 prototype scope を最小化する)。 実 GCP account
+ * smoke は Phase 4 末で別 PR で行う。
+ *
+ * 既知の Open Question (ADR-017 OQ#1):
+ *   - CloudActionIntent を JWT として直接 GCP STS に渡すべきか、 JWS で包んだ
+ *     canonical JSON を audience に乗せるか。 GCP STS は JWT を期待するため、
+ *     Phase 4 末で intent → JWT claim 変換 layer を追加するか、 JWS のまま
+ *     allowAudiences として WIF pool に登録するかを決める。 本 prototype は
+ *     後者 (= JWS そのまま) を想定した interface 形。
+ */
+
+export interface GcpCredential extends ProviderCredential {
+  readonly provider: "gcp";
+  readonly accessToken: string;
+  readonly serviceAccountEmail: string;
+  /** GCP STS から受け取った federated token (= service account の generateAccessToken に渡す中間 token)。 */
+  readonly federatedToken: string;
+}
+
+/**
+ * GCP STS API + iamcredentials API を呼ぶ最小抽象。 production では
+ * `@google-cloud/iam-credentials` を wrap、 test では fake を渡す。
+ */
+export interface GcpStsClient {
+  /**
+   * GCP STS `https://sts.googleapis.com/v1/token` 相当。 OIDC token (= 本 adapter
+   * では trust-bridge の JWS) を federated token に交換する。
+   */
+  exchangeToken(input: GcpStsExchangeInput): Promise<GcpStsExchangeOutput>;
+  /**
+   * IAM Credentials API `iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{email}:generateAccessToken`。
+   * federated token を service account の OAuth2 access token に交換する。
+   */
+  generateServiceAccountToken(
+    input: GenerateServiceAccountTokenInput,
+  ): Promise<GenerateServiceAccountTokenOutput>;
+}
+
+export interface GcpStsExchangeInput {
+  readonly audience: string;
+  readonly subjectToken: string;
+  readonly subjectTokenType: string;
+  readonly scope: string;
+}
+
+export interface GcpStsExchangeOutput {
+  readonly access_token: string;
+  readonly expires_in: number;
+}
+
+export interface GenerateServiceAccountTokenInput {
+  readonly serviceAccountEmail: string;
+  readonly federatedToken: string;
+  readonly lifetimeSeconds: number;
+  readonly scopes: readonly string[];
+}
+
+export interface GenerateServiceAccountTokenOutput {
+  readonly accessToken: string;
+  readonly expireTime: string;
+}
+
+export interface GcpExchangeContext extends ExchangeContext {
+  /** WIF pool の audience URL (例: `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/tenkacloud/providers/cdk`)。 */
+  readonly wifAudience: string;
+  /** federated token を再 exchange する対象 service account email。 */
+  readonly serviceAccountEmail: string;
+  /** 取得 access token に付与する OAuth2 scopes (例: `["https://www.googleapis.com/auth/cloud-platform"]`)。 */
+  readonly oauthScopes: readonly string[];
+  /** subject token format。 default `urn:ietf:params:oauth:token-type:jwt`。 */
+  readonly subjectTokenType?: string;
+}
+
+export interface GcpAdapterOptions {
+  readonly stsClient: GcpStsClient;
+  readonly now?: () => Date;
+  /**
+   * Phase 4: caller が intent → JWS token を再構成する責任を持つ (= verify 経路で
+   * decode した intent から token 本体を保てない場合があるため)。 sign 関数を
+   * inject することで、 caller の鍵で sign し直す経路にも、 元 token を保持して
+   * pass-through する経路にも、 どちらも対応する。
+   */
+  readonly toSubjectToken: (intent: VerifiedCloudActionIntent) => string;
+}
+
+export class GcpWorkloadIdentityFederationExchange implements ProviderTokenExchange<GcpCredential> {
+  readonly provider = "gcp" as const;
+  private readonly stsClient: GcpStsClient;
+  private readonly now: () => Date;
+  private readonly toSubjectToken: (intent: VerifiedCloudActionIntent) => string;
+
+  constructor(options: GcpAdapterOptions) {
+    this.stsClient = options.stsClient;
+    this.now = options.now ?? (() => new Date());
+    this.toSubjectToken = options.toSubjectToken;
+  }
+
+  async exchange(
+    intent: VerifiedCloudActionIntent,
+    context: ExchangeContext,
+  ): Promise<GcpCredential> {
+    if (intent.target.provider !== "gcp") {
+      throw new ExchangeError(
+        "provider-mismatch",
+        `intent target provider is ${intent.target.provider}, not gcp`,
+      );
+    }
+
+    const gcpContext = context as GcpExchangeContext;
+    if (!gcpContext.wifAudience || gcpContext.wifAudience.length === 0) {
+      throw new ExchangeError("context-missing", "GcpExchangeContext.wifAudience is required");
+    }
+    if (!gcpContext.serviceAccountEmail || gcpContext.serviceAccountEmail.length === 0) {
+      throw new ExchangeError(
+        "context-missing",
+        "GcpExchangeContext.serviceAccountEmail is required",
+      );
+    }
+    if (!gcpContext.oauthScopes || gcpContext.oauthScopes.length === 0) {
+      throw new ExchangeError(
+        "context-missing",
+        "GcpExchangeContext.oauthScopes must contain at least 1 scope",
+      );
+    }
+
+    // GCP STS は token lifetime を直接受け取らない (= WIF pool 側で固定)。 intent
+    // の ttlSeconds は次段 generateAccessToken の lifetime に転写する。
+    const lifetimeSeconds = intent.constraints.ttlSeconds;
+
+    const subjectToken = this.toSubjectToken(intent);
+    const issuedAt = this.now();
+
+    let federatedOut: GcpStsExchangeOutput;
+    try {
+      federatedOut = await this.stsClient.exchangeToken({
+        audience: gcpContext.wifAudience,
+        subjectToken,
+        subjectTokenType: gcpContext.subjectTokenType ?? "urn:ietf:params:oauth:token-type:jwt",
+        scope: gcpContext.oauthScopes.join(" "),
+      });
+    } catch (err) {
+      throw new ExchangeError("provider-api-error", "GCP STS exchangeToken failed", err);
+    }
+
+    let saOut: GenerateServiceAccountTokenOutput;
+    try {
+      saOut = await this.stsClient.generateServiceAccountToken({
+        serviceAccountEmail: gcpContext.serviceAccountEmail,
+        federatedToken: federatedOut.access_token,
+        lifetimeSeconds,
+        scopes: gcpContext.oauthScopes,
+      });
+    } catch (err) {
+      throw new ExchangeError(
+        "provider-api-error",
+        "GCP iamcredentials.generateServiceAccountToken failed",
+        err,
+      );
+    }
+
+    return {
+      provider: "gcp",
+      accessToken: saOut.accessToken,
+      serviceAccountEmail: gcpContext.serviceAccountEmail,
+      federatedToken: federatedOut.access_token,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: saOut.expireTime,
+      forRequestId: intent.requestId,
+    };
+  }
+}

--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -30,6 +30,28 @@ export type {
   StsAssumeRoleClient,
 } from "./aws-assume-role.js";
 export { AwsAssumeRoleExchange } from "./aws-assume-role.js";
+
+export type {
+  AzureAdapterOptions,
+  AzureCredential,
+  AzureExchangeContext,
+  AzureTokenEndpointClient,
+  AzureTokenExchangeInput,
+  AzureTokenExchangeOutput,
+} from "./azure-federated-credential.js";
+export { AzureFederatedCredentialExchange } from "./azure-federated-credential.js";
+
+export type {
+  GcpAdapterOptions,
+  GcpCredential,
+  GcpExchangeContext,
+  GcpStsClient,
+  GcpStsExchangeInput,
+  GcpStsExchangeOutput,
+  GenerateServiceAccountTokenInput,
+  GenerateServiceAccountTokenOutput,
+} from "./gcp-workload-identity.js";
+export { GcpWorkloadIdentityFederationExchange } from "./gcp-workload-identity.js";
 export type {
   JwsHeader,
   SignOptions,

--- a/packages/trust-bridge/test/azure-federated-credential.test.ts
+++ b/packages/trust-bridge/test/azure-federated-credential.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  AzureFederatedCredentialExchange,
+  type AzureTokenEndpointClient,
+  type AzureTokenExchangeInput,
+} from "../src/azure-federated-credential.js";
+import { ExchangeError } from "../src/provider.js";
+import {
+  brandVerified,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  type VerifiedCloudActionIntent,
+} from "../src/schema.js";
+
+function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudActionIntent {
+  return brandVerified({
+    version: INTENT_VERSION,
+    requestId: "req-azure-1",
+    nonce: "nonce-azure-1",
+    source: { system: "tenkacloud", tenantId: "tenant-y", workloadId: "w-1" },
+    target: { provider: "azure", providerAccountRef: "00000000-0000-0000-0000-000000000001" },
+    action: {
+      type: "deploy",
+      engine: "bicep",
+      requestedScopes: ["microsoft.compute/virtualmachines/write"],
+    },
+    constraints: {
+      ttlSeconds: 1200,
+      expiresAt: "2026-05-16T00:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  });
+}
+
+function makeStub(capture?: (input: AzureTokenExchangeInput) => void): AzureTokenEndpointClient {
+  return {
+    exchangeAssertion: async (input) => {
+      capture?.(input);
+      return {
+        access_token: "eyJ-az-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      };
+    },
+  };
+}
+
+describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
+  it("provider が azure でない intent では provider-mismatch を投げるべき", async () => {
+    const ex = new AzureFederatedCredentialExchange({
+      tokenClient: makeStub(),
+      toClientAssertion: () => "jwt",
+    });
+    const intent = makeIntent({
+      target: { provider: "aws", providerAccountRef: "111111111111" },
+    });
+    await expect(
+      ex.exchange(intent, {
+        azureTenantId: "tid",
+        clientId: "cid",
+        scope: "https://management.azure.com/.default",
+      }),
+    ).rejects.toMatchObject({ reason: "provider-mismatch" });
+  });
+
+  it("azureTenantId が無いと context-missing を投げるべき", async () => {
+    const ex = new AzureFederatedCredentialExchange({
+      tokenClient: makeStub(),
+      toClientAssertion: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        clientId: "cid",
+        scope: "https://management.azure.com/.default",
+      } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("clientId / scope が無くても context-missing を投げるべき", async () => {
+    const ex = new AzureFederatedCredentialExchange({
+      tokenClient: makeStub(),
+      toClientAssertion: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        azureTenantId: "tid",
+        clientId: "",
+        scope: "x",
+      } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+    await expect(
+      ex.exchange(makeIntent(), {
+        azureTenantId: "tid",
+        clientId: "cid",
+        scope: "",
+      } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("成功 path で AzureAD endpoint に client_assertion / scope を渡し expires_in を ISO に正規化すべき", async () => {
+    let captured: AzureTokenExchangeInput | undefined;
+    const fixedNow = new Date("2026-05-15T22:00:00.000Z");
+    const ex = new AzureFederatedCredentialExchange({
+      tokenClient: makeStub((i) => {
+        captured = i;
+      }),
+      now: () => fixedNow,
+      toClientAssertion: (intent) => `assertion-for-${intent.requestId}`,
+    });
+    const result = await ex.exchange(makeIntent(), {
+      azureTenantId: "00000000-tenant-0000-0000-000000000000",
+      clientId: "11111111-app-id",
+      scope: "https://management.azure.com/.default",
+    });
+    expect(captured?.tenantId).toBe("00000000-tenant-0000-0000-000000000000");
+    expect(captured?.clientId).toBe("11111111-app-id");
+    expect(captured?.clientAssertion).toBe("assertion-for-req-azure-1");
+    expect(captured?.scope).toBe("https://management.azure.com/.default");
+    expect(result.provider).toBe("azure");
+    expect(result.accessToken).toBe("eyJ-az-access-token");
+    expect(result.tokenType).toBe("Bearer");
+    expect(result.clientId).toBe("11111111-app-id");
+    // issuedAt=22:00、 expires_in=3600 → expiresAt=23:00
+    expect(result.expiresAt).toBe("2026-05-15T23:00:00.000Z");
+    expect(result.forRequestId).toBe("req-azure-1");
+  });
+
+  it("Azure AD endpoint が throw したら provider-api-error に wrap するべき", async () => {
+    const ex = new AzureFederatedCredentialExchange({
+      tokenClient: {
+        exchangeAssertion: async () => {
+          throw new Error("AADSTS70021");
+        },
+      },
+      toClientAssertion: () => "jwt",
+    });
+    try {
+      await ex.exchange(makeIntent(), {
+        azureTenantId: "tid",
+        clientId: "cid",
+        scope: "scope",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExchangeError);
+      const ee = err as ExchangeError;
+      expect(ee.reason).toBe("provider-api-error");
+      expect((ee.underlying as Error).message).toBe("AADSTS70021");
+    }
+  });
+});

--- a/packages/trust-bridge/test/gcp-workload-identity.test.ts
+++ b/packages/trust-bridge/test/gcp-workload-identity.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  type GcpStsClient,
+  type GcpStsExchangeInput,
+  GcpWorkloadIdentityFederationExchange,
+  type GenerateServiceAccountTokenInput,
+} from "../src/gcp-workload-identity.js";
+import { ExchangeError } from "../src/provider.js";
+import {
+  brandVerified,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  type VerifiedCloudActionIntent,
+} from "../src/schema.js";
+
+function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudActionIntent {
+  return brandVerified({
+    version: INTENT_VERSION,
+    requestId: "req-gcp-1",
+    nonce: "nonce-gcp-1",
+    source: { system: "tenkacloud", tenantId: "tenant-x", workloadId: "w-1" },
+    target: { provider: "gcp", providerAccountRef: "my-gcp-project" },
+    action: {
+      type: "deploy",
+      engine: "terraform",
+      requestedScopes: ["compute.instances.create"],
+    },
+    constraints: {
+      ttlSeconds: 1800,
+      expiresAt: "2026-05-16T00:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  });
+}
+
+function makeStubClient(captures?: {
+  onExchange?: (input: GcpStsExchangeInput) => void;
+  onGenerate?: (input: GenerateServiceAccountTokenInput) => void;
+}): GcpStsClient {
+  return {
+    exchangeToken: async (input) => {
+      captures?.onExchange?.(input);
+      return { access_token: "federated-token-xyz", expires_in: 3600 };
+    },
+    generateServiceAccountToken: async (input) => {
+      captures?.onGenerate?.(input);
+      return {
+        accessToken: "ya29.SA-access-token",
+        expireTime: "2026-05-16T00:30:00.000Z",
+      };
+    },
+  };
+}
+
+describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () => {
+  it("provider が gcp でない intent では provider-mismatch を投げるべき", async () => {
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: makeStubClient(),
+      toSubjectToken: () => "jwt-placeholder",
+    });
+    const intent = makeIntent({
+      target: { provider: "aws", providerAccountRef: "123456789012" },
+    });
+    await expect(
+      ex.exchange(intent, {
+        wifAudience: "audience",
+        serviceAccountEmail: "sa@x.iam.gserviceaccount.com",
+        oauthScopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      }),
+    ).rejects.toMatchObject({ reason: "provider-mismatch" });
+  });
+
+  it("wifAudience が無いと context-missing を投げるべき", async () => {
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: makeStubClient(),
+      toSubjectToken: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        serviceAccountEmail: "sa@x.iam.gserviceaccount.com",
+        oauthScopes: ["scope"],
+      } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("oauthScopes が空配列なら context-missing を投げるべき", async () => {
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: makeStubClient(),
+      toSubjectToken: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        wifAudience: "//iam.googleapis.com/projects/123/...",
+        serviceAccountEmail: "sa@x.iam.gserviceaccount.com",
+        oauthScopes: [],
+      }),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("成功 path で GCP STS → IAM Credentials を順次呼び credential を返すべき", async () => {
+    let exchangeIn: GcpStsExchangeInput | undefined;
+    let generateIn: GenerateServiceAccountTokenInput | undefined;
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: makeStubClient({
+        onExchange: (i) => {
+          exchangeIn = i;
+        },
+        onGenerate: (i) => {
+          generateIn = i;
+        },
+      }),
+      toSubjectToken: (intent) => `subject-token-for-${intent.requestId}`,
+    });
+    const result = await ex.exchange(makeIntent(), {
+      wifAudience:
+        "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/p/providers/cdk",
+      serviceAccountEmail: "deploy-sa@tenkacloud.iam.gserviceaccount.com",
+      oauthScopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    });
+
+    expect(exchangeIn?.audience).toContain("workloadIdentityPools/p");
+    expect(exchangeIn?.subjectToken).toBe("subject-token-for-req-gcp-1");
+    expect(exchangeIn?.subjectTokenType).toBe("urn:ietf:params:oauth:token-type:jwt");
+    expect(exchangeIn?.scope).toBe("https://www.googleapis.com/auth/cloud-platform");
+    expect(generateIn?.federatedToken).toBe("federated-token-xyz");
+    expect(generateIn?.serviceAccountEmail).toBe("deploy-sa@tenkacloud.iam.gserviceaccount.com");
+    expect(generateIn?.lifetimeSeconds).toBe(1800);
+    expect(result.provider).toBe("gcp");
+    expect(result.accessToken).toBe("ya29.SA-access-token");
+    expect(result.federatedToken).toBe("federated-token-xyz");
+    expect(result.forRequestId).toBe("req-gcp-1");
+  });
+
+  it("GCP STS が throw したら provider-api-error に wrap するべき", async () => {
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: {
+        exchangeToken: async () => {
+          throw new Error("GCP STS 5xx");
+        },
+        generateServiceAccountToken: async () => {
+          throw new Error("should not reach");
+        },
+      },
+      toSubjectToken: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        wifAudience: "audience",
+        serviceAccountEmail: "sa@x.iam.gserviceaccount.com",
+        oauthScopes: ["s"],
+      }),
+    ).rejects.toBeInstanceOf(ExchangeError);
+  });
+
+  it("IAM credentials API が throw したら provider-api-error に wrap し federated step は完了済であるべき", async () => {
+    let federatedReached = false;
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: {
+        exchangeToken: async () => {
+          federatedReached = true;
+          return { access_token: "f-tok", expires_in: 3600 };
+        },
+        generateServiceAccountToken: async () => {
+          throw new Error("IAM API 403");
+        },
+      },
+      toSubjectToken: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        wifAudience: "a",
+        serviceAccountEmail: "sa@x.iam.gserviceaccount.com",
+        oauthScopes: ["s"],
+      }),
+    ).rejects.toMatchObject({ reason: "provider-api-error" });
+    expect(federatedReached).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 (PR #804) で AWS adapter を入れた `ProviderTokenExchange` 抽象に GCP
(WIF) と Azure (FIC) を加える prototype。 Issue #795 Phase 4 の "Add
GcpWorkloadIdentityFederationExchange prototype" + "Add
AzureFederatedCredentialExchange prototype" を満たす。

> **Stacked PR**: 内容的には `feat/795-trust-bridge-phase2-aws` (= PR #804) に
> 積み上げる diff だが、 GitHub のグラフ制約で base=main で開いている。 PR #804
> merge 後に conflict 無く main に rebase される。 Review 順は #804 → 本 PR。

Relates #795

## scope

- `src/gcp-workload-identity.ts`: `GcpWorkloadIdentityFederationExchange`
  - GCP STS `exchangeToken` + `iamcredentials.generateAccessToken` の 2 段 API を抽象化
  - subject token (JWS/JWT) の組み立ては caller の `toSubjectToken` hook 責任
  - context: `wifAudience` / `serviceAccountEmail` / `oauthScopes`
  - lifetime は `intent.constraints.ttlSeconds` を `generateAccessToken` に転写
- `src/azure-federated-credential.ts`: `AzureFederatedCredentialExchange`
  - Azure AD `/oauth2/v2.0/token` の `client_credentials` + `jwt-bearer` 形式
  - `client_assertion` (= RFC 7523 JWT) の組み立ては caller の `toClientAssertion` hook 責任
  - context: `azureTenantId` / `clientId` / `scope`
  - `expires_in` (sec) → ISO datetime に正規化
- `src/index.ts`: 両 adapter を public export に追加
- tests: GCP 6 件 + Azure 5 件 = 11 件追加。 Phase 1 30 + Phase 2 9 + Phase 4 11 = **計 50 件 pass**

## 設計判断

- **`@google-cloud/iam-credentials` / `@azure/identity` を hard dep にしない**: `GcpStsClient` / `AzureTokenEndpointClient` interface 経由で consumer が好きな client を渡す
- **subject token / client_assertion の組み立ては caller hook**: trust-bridge 側で JWT 変換 utility を提供するかは Phase 4 末で判断 (= ADR-017 OQ#1)
- **失敗 reason は AWS adapter と共通**: provider-mismatch / context-missing / provider-api-error / ttl-exceeded-provider-limit

## Phase 4 完了に向けて残る item

- [ ] "Build one cross-cloud proof-of-concept target" — 実 GCP / Azure account での smoke test。 PoC scope なので個別 follow-up

## Regression 分析

- Phase 1 / Phase 2 既存 API には触らず、 新規 export を追加のみ
- trust-bridge は依然として provider SDK に依存しない (= audit-deps baseline 不変)

## 物理影響

- CFn / IaC: **NO-OP** (= library のみ)
- 新規 artifact: 4 file (2 src + 2 test) + 1 file 変更 (index.ts)

## Test plan

- [x] `cd packages/trust-bridge && bunx vitest run` (= 50 test pass)
- [x] `cd packages/trust-bridge && bunx tsc --noEmit` (= clean)
- [x] `make before-commit` (= 全 gate 通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)