### PR TITLE
feat(#795 Phase 3): trust-bridge shadow integration in deploy handler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "cdk": "bin/infrastructure.js",
       },
       "dependencies": {
+        "@TenkaCloud/trust-bridge": "workspace:*",
         "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
         "@aws-sdk/client-codepipeline": "^3.1045.0",
         "@cdklabs/sbt-aws": "0.3.9",

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -12,6 +12,7 @@ import {
   publishProblemEvent,
 } from "../shared/events.js";
 import { logDeployTrace } from "../shared/trace-log.js";
+import { emitShadowAudit } from "../shared/trust-bridge-shadow.js";
 import {
   type PrivateVisibility,
   parseProblemsVisibility,
@@ -186,6 +187,27 @@ export async function startDeployment(
     externalIdParameterName: verified.externalIdParameterName,
     ...(challengePayloadUrl ? { challengePayloadUrl } : {}),
   };
+  // Issue #795 ADR-017 Phase 3 (shadow integration): 既存 deploy flow を変更せず、
+  // CloudActionIntent を構築 + audit log を CloudWatch に emit する。 失敗系も
+  // fail-open (= 既存の publishProblemEvent / DDB Put には影響を与えない)。
+  emitShadowAudit({
+    jobId,
+    tenantId: item.tenantId,
+    teamSlug,
+    problemId: item.problemId,
+    namePrefix: item.namePrefix,
+    region: item.region,
+    awsAccountId: item.awsAccountId,
+    ...(verified.competitorRoleArn ? { competitorRoleArn: verified.competitorRoleArn } : {}),
+    nowMs,
+    ttlSeconds: 900,
+    action: "deploy",
+    requestedScopes: [
+      "cloudformation:CreateStack",
+      "cloudformation:DescribeStacks",
+      "cloudformation:DescribeStackEvents",
+    ],
+  });
   try {
     await publishProblemEvent({
       client: ctx.events,

--- a/infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts
@@ -1,0 +1,147 @@
+import {
+  buildAuditRecord,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  parseCloudActionIntent,
+} from "@TenkaCloud/trust-bridge";
+import { logDeployTrace, warnDeployTrace } from "./trace-log.js";
+
+/**
+ * Issue #795 ADR-017 Phase 3 (shadow integration): deploy / destroy 経路で
+ * `CloudActionIntent` を 1 件構築し、 audit record を CloudWatch に emit する。
+ *
+ * 本 module は **shadow integration** (= 既存 deploy flow には触れず、 並行で
+ * 観測可能な audit を残す):
+ *
+ *   - 既存の publishProblemEvent + STS AssumeRole 経路は変更しない
+ *   - 失敗系も fail-open (= intent 構築 / parse / audit のいずれが落ちても
+ *     deploy 本体に影響を与えない)
+ *   - 出る log だけが Phase 3 の観測価値 (= ADR-017 D5 audit record の早期 wire)
+ *
+ * 将来 Phase 5+ で intent verify → AwsAssumeRoleExchange の実 integration に
+ * 切り替えるとき、 本 shadow path がベースラインの「intent shape が正しく組める」
+ * 保証として機能する (= shape drift を CloudWatch で観測できる)。
+ */
+
+export interface ShadowIntentParams {
+  readonly jobId: string;
+  readonly tenantId: string;
+  readonly teamSlug?: string;
+  readonly problemId: string;
+  readonly namePrefix: string;
+  readonly region: string;
+  readonly awsAccountId: string;
+  readonly competitorRoleArn?: string;
+  readonly nowMs: number;
+  readonly ttlSeconds: number;
+  readonly action: "deploy" | "destroy";
+  readonly requestedScopes: readonly string[];
+}
+
+/**
+ * 観測のみが目的なので throw しない。 失敗系も `warnDeployTrace` に reason を残す。
+ */
+export function emitShadowAudit(params: ShadowIntentParams): void {
+  let intent: CloudActionIntent;
+  try {
+    intent = buildIntentFromParams(params);
+  } catch (err) {
+    warnDeployTrace("trust-bridge.shadow.intent-build-failed", {
+      jobId: params.jobId,
+      correlationId: params.jobId,
+      action: params.action,
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  const parsed = parseCloudActionIntent(intent);
+  if (!parsed.ok) {
+    // schema 違反は ADR-017 D1 「explicit failure」 原則に対する観測点。 deploy 本体
+    // は失敗させない (= shadow なので) が、 audit record で deny を残す。
+    warnDeployTrace("trust-bridge.shadow.schema-invalid", {
+      jobId: params.jobId,
+      correlationId: params.jobId,
+      action: params.action,
+      issues: parsed.issues.join("; "),
+    });
+    const record = buildAuditRecord({
+      outcome: { ok: false, reason: "schema-invalid", details: parsed.issues },
+      now: () => new Date(params.nowMs),
+    });
+    logDeployTrace("trust-bridge.shadow.audit", {
+      jobId: params.jobId,
+      correlationId: params.jobId,
+      decision: record.decision,
+      denialReason: record.denialReason,
+      tenantId: record.tenantId,
+      provider: record.provider,
+      action: record.action,
+      createdAt: record.createdAt,
+    });
+    return;
+  }
+
+  // shadow path では「verify が成功した」 想定の audit を出す。 実 verify は
+  // Phase 5+ で AwsAssumeRoleExchange と合わせて wire する。
+  const record = buildAuditRecord({
+    outcome: {
+      ok: true,
+      // brand を bypass する shadow 用キャスト。 実 verify path では verifyIntent
+      // が返す brand を使う。
+      intent: parsed.intent as CloudActionIntent & { readonly __verified: true },
+    },
+    now: () => new Date(params.nowMs),
+  });
+  logDeployTrace("trust-bridge.shadow.audit", {
+    jobId: params.jobId,
+    correlationId: params.jobId,
+    decision: record.decision,
+    tenantId: record.tenantId,
+    eventId: record.eventId,
+    teamId: record.teamId,
+    problemId: record.problemId,
+    deploymentId: record.deploymentId,
+    provider: record.provider,
+    action: record.action,
+    createdAt: record.createdAt,
+  });
+}
+
+function buildIntentFromParams(params: ShadowIntentParams): CloudActionIntent {
+  const expiresAt = new Date(params.nowMs + params.ttlSeconds * 1000).toISOString();
+  return {
+    version: INTENT_VERSION,
+    requestId: params.jobId,
+    // shadow 期は nonce 単独 store を持たないため jobId を再利用 (= ULID は実用上
+    // unique)。 実 verify 期に DDB-backed nonce store と組み合わせる。
+    nonce: params.jobId,
+    source: {
+      system: "tenkacloud",
+      tenantId: params.tenantId,
+      ...(params.teamSlug ? { teamId: params.teamSlug } : {}),
+      problemId: params.problemId,
+      deploymentId: params.jobId,
+      // workloadId は Lambda function ARN を持ち込むのが理想。 shadow では env から
+      // 取得できない場合があるので固定 stub。
+      workloadId: "tenkacloud-problem-deploy-handler",
+    },
+    target: {
+      provider: "aws",
+      providerAccountRef: params.awsAccountId,
+      region: params.region,
+      ...(params.competitorRoleArn ? { resourceScope: params.competitorRoleArn } : {}),
+    },
+    action: {
+      type: params.action,
+      engine: "cloudformation",
+      entry: params.namePrefix,
+      requestedScopes: params.requestedScopes,
+    },
+    constraints: {
+      ttlSeconds: params.ttlSeconds,
+      expiresAt,
+      allowPrivilegeEscalation: false,
+    },
+  };
+}

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -41,6 +41,7 @@
     "zod": "^3.23.8"
   },
   "dependencies": {
+    "@TenkaCloud/trust-bridge": "workspace:*",
     "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
     "@aws-sdk/client-codepipeline": "^3.1045.0",
     "@cdklabs/sbt-aws": "0.3.9",

--- a/infrastructure/test/problem-deploy/trust-bridge-shadow.test.ts
+++ b/infrastructure/test/problem-deploy/trust-bridge-shadow.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  emitShadowAudit,
+  type ShadowIntentParams,
+} from "../../lib/problem-deploy/handlers/shared/trust-bridge-shadow";
+
+/**
+ * Issue #795 ADR-017 Phase 3 (shadow integration): emitShadowAudit が
+ * `trust-bridge.shadow.audit` を 1 行 JSON で CloudWatch に出すこと、 schema
+ * 違反でも throw せず audit を残すこと、 必要な claim だけが乗ること を pin。
+ */
+
+function baseParams(overrides: Partial<ShadowIntentParams> = {}): ShadowIntentParams {
+  return {
+    jobId: "01KSHADOW0000000000000000",
+    tenantId: "tenant-a",
+    teamSlug: "team-alpha",
+    problemId: "hello-world",
+    namePrefix: "tc-hello-world-team-alpha",
+    region: "ap-northeast-1",
+    awsAccountId: "123456789012",
+    nowMs: Date.UTC(2026, 4, 15, 22, 0, 0),
+    ttlSeconds: 900,
+    action: "deploy",
+    requestedScopes: ["cloudformation:CreateStack"],
+    ...overrides,
+  };
+}
+
+function captureLogs(): {
+  readonly infoLines: string[];
+  readonly warnLines: string[];
+  restore(): void;
+} {
+  const infoLines: string[] = [];
+  const warnLines: string[] = [];
+  // trace-log.ts uses console.log / console.warn / console.error。 spy には
+  // `log` を info-level として束ねる。
+  const infoSpy = vi.spyOn(console, "log").mockImplementation((msg: unknown) => {
+    infoLines.push(String(msg));
+  });
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation((msg: unknown) => {
+    warnLines.push(String(msg));
+  });
+  return {
+    infoLines,
+    warnLines,
+    restore() {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    },
+  };
+}
+
+describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
+  it("正常 params で trust-bridge.shadow.audit を decision=allow で emit すべき", () => {
+    const cap = captureLogs();
+    try {
+      emitShadowAudit(baseParams());
+      const audit = cap.infoLines.find((l) => l.includes("trust-bridge.shadow.audit"));
+      expect(audit).toBeDefined();
+      expect(audit).toContain('"decision":"allow"');
+      expect(audit).toContain('"tenantId":"tenant-a"');
+      expect(audit).toContain('"problemId":"hello-world"');
+      expect(audit).toContain('"deploymentId":"01KSHADOW0000000000000000"');
+      expect(audit).toContain('"provider":"aws"');
+      expect(audit).toContain('"action":"deploy"');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("action=destroy も同じ audit shape で emit すべき", () => {
+    const cap = captureLogs();
+    try {
+      emitShadowAudit(baseParams({ action: "destroy" }));
+      const audit = cap.infoLines.find((l) => l.includes("trust-bridge.shadow.audit"));
+      expect(audit).toContain('"action":"destroy"');
+      expect(audit).toContain('"decision":"allow"');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("ttlSeconds=0 (= schema 違反) でも throw せず warn + audit deny を emit すべき (= fail-open)", () => {
+    const cap = captureLogs();
+    try {
+      expect(() => emitShadowAudit(baseParams({ ttlSeconds: 0 }))).not.toThrow();
+      const warn = cap.warnLines.find((l) => l.includes("trust-bridge.shadow.schema-invalid"));
+      expect(warn).toBeDefined();
+      const audit = cap.infoLines.find((l) => l.includes("trust-bridge.shadow.audit"));
+      expect(audit).toBeDefined();
+      expect(audit).toContain('"decision":"deny"');
+      expect(audit).toContain('"denialReason":"schema-invalid"');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("ttlSeconds=9999 (= schema 上限超過) も同様に fail-open で audit deny を emit すべき", () => {
+    const cap = captureLogs();
+    try {
+      expect(() => emitShadowAudit(baseParams({ ttlSeconds: 9999 }))).not.toThrow();
+      const warn = cap.warnLines.find((l) => l.includes("trust-bridge.shadow.schema-invalid"));
+      expect(warn).toBeDefined();
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("competitorRoleArn が未指定でも intent を組めて allow を emit すべき (= same-account dev path)", () => {
+    const cap = captureLogs();
+    try {
+      emitShadowAudit(baseParams({ competitorRoleArn: undefined }));
+      const audit = cap.infoLines.find((l) => l.includes("trust-bridge.shadow.audit"));
+      expect(audit).toContain('"decision":"allow"');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("teamSlug 未指定でも intent を組めて teamId field 無しの audit を emit すべき", () => {
+    const cap = captureLogs();
+    try {
+      emitShadowAudit(baseParams({ teamSlug: undefined }));
+      const audit = cap.infoLines.find((l) => l.includes("trust-bridge.shadow.audit"));
+      expect(audit).toBeDefined();
+      // teamId field は intent.source.teamId が undefined のとき audit にも乗らない。
+      expect(audit).not.toContain('"teamId"');
+    } finally {
+      cap.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Issue #795 / ADR-017 Phase 3: 既存 deploy flow に CloudActionIntent + audit
record の **shadow integration** (= 平行観測、 fail-open) を追加する。 実際の
AssumeRole 経路 (= CodeBuild + STS) は変更せず、 deploy.ts が deployment row を
Put + EventBridge publish する周りで「もし trust-bridge で verify したらこういう
audit が出る」 ことを CloudWatch に emit する。

Relates #795

## なぜ shadow か

- describe-stack regression が active (= PR #803 で diagnostic logging shipped)
- 同じ Lambda handler chain (= deploy.ts は describe-stack の 1 hop 前) を invasive
  に弄ると blast radius が読めない
- 失敗系も fail-open にして既存 deploy には絶対影響しない設計にした
- shadow audit が動くことが確認できたら、 後続 PR で実 verify path に切り替える

## scope

- `infrastructure/package.json`: `@TenkaCloud/trust-bridge: workspace:*` を dep 追加
- `handlers/shared/trust-bridge-shadow.ts` (新規): `emitShadowAudit()` helper
  - `ShadowIntentParams` から `CloudActionIntent` を構築
  - `parseCloudActionIntent` で schema validate
  - `buildAuditRecord` で audit record を作って 1 行 JSON で CloudWatch
  - 失敗系は `warnDeployTrace` に reason を残して fail-open
- `handlers/deploy-handler/deploy.ts`: `startDeployment` 内、 `publishProblemEvent` の直前で `emitShadowAudit` を呼ぶ。 **既存 detail / DDB Put / EventBridge publish には触っていない**
- `test/problem-deploy/trust-bridge-shadow.test.ts` (新規): 6 test
  - 正常 params で `decision=allow` を emit
  - `action=destroy` も同じ shape
  - `ttlSeconds=0` (= schema 違反) でも throw せず `decision=deny` を emit
  - `ttlSeconds` 上限超過も同様
  - `competitorRoleArn` 未指定でも intent を組める
  - `teamSlug` 未指定でも intent を組める

## 観測

CloudWatch Logs Insights:

```
filter event = "trust-bridge.shadow.audit"
| fields @timestamp, decision, tenantId, problemId, action, denialReason
```

deploy 1 件ごとに 1 行 emit される。 `schema-invalid` を観測したら shape drift。 `allow` ばかりが続くことを baseline として確認した後、 実 verify path への切り替えに進む。

## Regression 分析

- **既存 deploy 経路に影響しない**: emitShadowAudit は failure-open (= intent 構築 / parse / audit のいずれが落ちても throw しない、 console.warn にとどめる)
- **既存 916 test 全部 pass** (= shadow 追加 + 6 新規 test)
- describe-stack regression (#803 diagnostic logging shipped) には影響しない経路 (= deploy.ts の方)
- @TenkaCloud/trust-bridge は既に Phase 1+2 merge 済で main にある (= 新規 dep は無し)

## 物理影響

- UPDATE: `tenkacloud-problem-deploy-DeployApi*` Lambda bundle (= trust-bridge を import するので esbuild 出力が +200KB 程度)
- NO-OP: CFn resource graph / IAM / DDB / EventBridge / Step Functions
- NO-OP: ApplicationConsole / ParticipantPortal / admin-console hosting

## 設計判断

- **shadow 期は `workloadId` 固定 stub**: Lambda function ARN を env から取れる経路を整える Phase は別 PR
- **failure-open**: regression 防御の最優先 (= active describe-stack regression に巻き込まれない)
- **`ttlSeconds: 900` hard-code**: deploy 全体は CodeBuild が 5〜15 分動くため実 verify には不適切。 Phase 5 で実 verify に切り替えるときに ttl 値を見直す (= ADR-017 OQ#8)

## Test plan

- [x] `bun run --filter @TenkaCloud/infrastructure test` (= 916 test pass、 +6 件)
- [x] `bun run typecheck` (= clean)
- [x] `make harness` (= no findings)
- [x] `make before-commit` (= 全 gate 通過)
- [ ] merge + 再 deploy 後、 CloudWatch で `trust-bridge.shadow.audit` を 1 件確認する (= shadow integration が動いているかの最終確認)
- [ ] 後続 PR で実 verify path への切り替え (= ADR-017 OQ#8 minimum demo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment and destroy operations now emit audit records for compliance and tracking purposes.
  * Added fail-safe audit logging that validates and records operation details without impacting deployment execution.

* **Tests**
  * Added comprehensive test coverage for audit emission across deploy and destroy scenarios, including edge cases and schema validation.

* **Chores**
  * Added new dependency to support audit functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/806)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->