### PR TITLE
feat(#778 Phase 5): infrastructure/bin/tenkacloud-lite.ts CDK app entry

### DIFF
--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import * as cdk from "aws-cdk-lib";
+import { resolveAppConfig } from "../lib/app-config";
+import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms";
+import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
+import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
+import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
+import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite";
+
+/**
+ * Issue #778 ADR-016 Phase 5: TenkaCloud Lite mode の CDK app entry point。
+ *
+ * SBT / Pipeline / 動的 tenant 作成のフル機能を持ち込まず、 tenantId="local" 固定で
+ * ApplicationAdminConsole + ProblemDeploy backend だけを deploy する経路。
+ * `make lite-up` (= `scripts/tenkacloud-lite.ts`) から呼ばれる。
+ *
+ * 配線:
+ *   1. ProblemDeployBackendStack を eventBusArn=undefined で作る (= local
+ *      EventBus に倒す、 ADR-016 Phase 2)
+ *   2. TenkaCloudLiteStack を作って ProblemDeploy stack の Lambda refs を渡す
+ *
+ * config 解決は Full mode と同じ `resolveAppConfig` を使う (= env / .env /
+ * problems 列挙)。 Lite 固有の調整は本ファイル内で配線レイヤだけ:
+ *   - ControlPlane / BootstrapTemplate / TenantTemplate / Pipeline /
+ *     AdminConsoleInsight は作らない (= Lite mode の出発点)
+ *   - AdminConsoleHosting (= System Admin SPA) も作らない (= Lite は Tenant
+ *     Admin Console + Participant Portal の 2 画面で完結)
+ */
+
+const app = new cdk.App();
+const config = resolveAppConfig({ env: process.env, binDir: __dirname });
+
+cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(config.kmsPendingWindowInDays));
+cdk.Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
+
+// Issue #778 ADR-016 Phase 2 / PR-#791: eventBusArn 省略で local bus 自動作成。
+const problemDeployBackend = new ProblemDeployBackendStack(app, "tenkacloud-lite-problem-deploy", {
+  ...config.stackEnv,
+  // eventBusArn は **明示的に渡さない** (= Lite では ControlPlane 不在のため)
+  sourceBucketName: config.s3SourceBucket,
+  sourceObjectKey: config.sourceZip,
+  problemsCatalog: config.problems.catalog as Readonly<Record<string, string>>,
+  problemsScoring: config.problems.scoring as Readonly<Record<string, unknown>>,
+  problemsEndpoints: config.problems.endpoints as Readonly<Record<string, unknown>>,
+  problemsPhases: (config.problems.phases ?? {}) as Readonly<Record<string, unknown>>,
+  problemsVisibility: (config.problems.visibility ?? {}) as Readonly<Record<string, "private">>,
+  // Lite では participant portal を runtime-config "default-dev-mock" で立てる
+  // (= portal Lambda + S3+CloudFront を持ち込む)。 frontend は backend mode で動く。
+  participantPortal: { runtimeConfig: "default-dev-mock" },
+  deployConcurrentBuildLimit: config.deployConcurrentBuildLimit,
+  environmentName: config.environment,
+});
+cdk.Aspects.of(problemDeployBackend).add(
+  new DynamoDbLowCapacity(config.dynamoReadCapacity, config.dynamoWriteCapacity),
+);
+
+// AppPlaneCore (= tenantId="local" 固定) を抱える Lite stack。 ProblemDeploy stack
+// の Lambda refs を cross-stack で渡す (= 既存 Full mode の TenantTemplateStack
+// と同 pattern)。
+const liteStack = new TenkaCloudLiteStack(app, "tenkacloud-lite", {
+  ...config.stackEnv,
+  environment: config.environment,
+  deployApiLambda: problemDeployBackend.deployApiLambda,
+  eventApiLambda: problemDeployBackend.eventApiLambda,
+  competitorAccountsApiLambda: problemDeployBackend.competitorAccountsApiLambda,
+  ...(problemDeployBackend.participantPortalUrl
+    ? { participantPortalUrl: problemDeployBackend.participantPortalUrl }
+    : {}),
+});
+cdk.Aspects.of(liteStack).add(
+  new DynamoDbLowCapacity(config.dynamoReadCapacity, config.dynamoWriteCapacity),
+);
+liteStack.addDependency(problemDeployBackend);

--- a/infrastructure/test/tenkacloud-lite-bin.test.ts
+++ b/infrastructure/test/tenkacloud-lite-bin.test.ts
@@ -1,0 +1,127 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms";
+import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
+import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
+import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
+import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite";
+
+/**
+ * Issue #778 ADR-016 Phase 5: bin/tenkacloud-lite.ts は `make lite-up` から
+ * `cdk deploy` で呼ばれる app entry。 ここでは entry の配線を **直接 reproducer
+ * する** (= bin file を import すると `new cdk.App()` の副作用が起きるため、
+ * 同等の wiring を test 内で再構築して assertion を pin する)。
+ *
+ * 重要な invariant:
+ *   - tenkacloud-lite-problem-deploy + tenkacloud-lite の 2 stack だけが立つ
+ *   - ControlPlane / BootstrapTemplate / TenantTemplate / Pipeline /
+ *     AdminConsoleInsight / AdminConsoleHosting は 一切 作らない
+ *   - Lite stack は ProblemDeploy stack に depend する (= cross-stack import)
+ *   - eventBusArn 省略で local EventBus が 1 つ作られる (= Phase 2 PR-#791)
+ *   - TenantId="local" 固定 (= CfnOutput)
+ */
+
+function buildLiteApp(): cdk.App {
+  const app = new cdk.App();
+  cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(7));
+  cdk.Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
+
+  const stackEnv = {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  } as const;
+
+  const problemDeployBackend = new ProblemDeployBackendStack(
+    app,
+    "tenkacloud-lite-problem-deploy",
+    {
+      ...stackEnv,
+      sourceBucketName: "serverless-saas-placeholder",
+      sourceObjectKey: "source.zip",
+      problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
+      problemsScoring: {},
+      problemsEndpoints: {},
+      problemsPhases: {},
+      problemsVisibility: {},
+      participantPortal: { runtimeConfig: "default-dev-mock" },
+      environmentName: "development",
+    },
+  );
+  cdk.Aspects.of(problemDeployBackend).add(new DynamoDbLowCapacity(1, 1));
+
+  const liteStack = new TenkaCloudLiteStack(app, "tenkacloud-lite", {
+    ...stackEnv,
+    environment: "development",
+    deployApiLambda: problemDeployBackend.deployApiLambda,
+    eventApiLambda: problemDeployBackend.eventApiLambda,
+    competitorAccountsApiLambda: problemDeployBackend.competitorAccountsApiLambda,
+    ...(problemDeployBackend.participantPortalUrl
+      ? { participantPortalUrl: problemDeployBackend.participantPortalUrl }
+      : {}),
+  });
+  cdk.Aspects.of(liteStack).add(new DynamoDbLowCapacity(1, 1));
+  liteStack.addDependency(problemDeployBackend);
+
+  return app;
+}
+
+describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
+  it("`tenkacloud-lite-problem-deploy` + `tenkacloud-lite` の 2 stack だけが synth されるべき", () => {
+    const app = buildLiteApp();
+    const assembly = app.synth();
+    const liteStacks = assembly.stacks.filter((s) => s.stackName.startsWith("tenkacloud-"));
+    const names = liteStacks.map((s) => s.stackName).sort();
+    expect(names).toEqual(["tenkacloud-lite", "tenkacloud-lite-problem-deploy"]);
+  }, 30_000);
+
+  it("ProblemDeployBackend (Lite mode) は eventBusArn 省略で local EventBus を 1 つ作るべき", () => {
+    const app = buildLiteApp();
+    const problemDeployStack = app.node
+      .findAll()
+      .find((c) => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite-problem-deploy");
+    expect(problemDeployStack).toBeDefined();
+    const template = Template.fromStack(problemDeployStack as cdk.Stack);
+    template.resourceCountIs("AWS::Events::EventBus", 1);
+  }, 30_000);
+
+  it("Lite stack 側は AppPlaneCore (= UserPool + REST API + CloudFront) を 1 セット作るべき", () => {
+    const app = buildLiteApp();
+    const liteStack = app.node
+      .findAll()
+      .find((c) => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite");
+    expect(liteStack).toBeDefined();
+    const template = Template.fromStack(liteStack as cdk.Stack);
+    template.resourceCountIs("AWS::Cognito::UserPool", 1);
+    template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
+    template.resourceCountIs("AWS::CloudFront::Distribution", 1);
+  }, 30_000);
+
+  it("Lite stack は ControlPlane / Tenant-Pipeline / Bootstrap / AdminConsoleInsight を持ち込まないべき", () => {
+    const app = buildLiteApp();
+    const assembly = app.synth();
+    const stackNames = assembly.stacks.map((s) => s.stackName);
+    for (const forbidden of [
+      "tenkacloud-control-plane",
+      "tenkacloud-bootstrap",
+      "tenkacloud-admin-console-insight",
+      "tenkacloud-admin-console-hosting",
+    ]) {
+      expect(stackNames).not.toContain(forbidden);
+    }
+    // ServerlessSaaSPipeline (= CodePipeline) も作らない。
+    const allTemplates = assembly.stacks.map((s) => Template.fromJSON(s.template));
+    for (const template of allTemplates) {
+      template.resourceCountIs("AWS::CodePipeline::Pipeline", 0);
+    }
+  }, 30_000);
+
+  it("Lite stack は ProblemDeploy stack に明示的に depend するべき (= cross-stack Lambda ref)", () => {
+    const app = buildLiteApp();
+    const liteStack = app.node
+      .findAll()
+      .find((c): c is cdk.Stack => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite");
+    expect(liteStack).toBeDefined();
+    const deps = liteStack?.dependencies.map((d) => d.stackName) ?? [];
+    expect(deps).toContain("tenkacloud-lite-problem-deploy");
+  }, 30_000);
+});

--- a/infrastructure/test/tenkacloud-lite-bin.test.ts
+++ b/infrastructure/test/tenkacloud-lite-bin.test.ts
@@ -31,6 +31,12 @@ function buildLiteApp(): cdk.App {
     env: { account: "123456789012", region: "ap-northeast-1" },
   } as const;
 
+  // 注: 既存 test 規約 (= problem-deploy-backend-stack.test.ts の `synthParticipantPortalLambdaOnly`)
+  // と同じ理由で `participantPortal` を test では渡さない (= CI で `apps/participant-portal/dist`
+  // asset が無いと CDK BucketDeployment が CannotFindAsset で fail する)。 bin entry 本体は
+  // `participantPortal: { runtimeConfig: "default-dev-mock" }` を渡すが、 wiring (= stack 数 /
+  // EventBus / AppPlaneCore / 禁止 stack 排除 / deps) の verification には participant portal
+  // は不要。 実 deploy 時 (= `make lite-up`) は frontend build 後に走るので dist は存在する。
   const problemDeployBackend = new ProblemDeployBackendStack(
     app,
     "tenkacloud-lite-problem-deploy",
@@ -43,7 +49,6 @@ function buildLiteApp(): cdk.App {
       problemsEndpoints: {},
       problemsPhases: {},
       problemsVisibility: {},
-      participantPortal: { runtimeConfig: "default-dev-mock" },
       environmentName: "development",
     },
   );


### PR DESCRIPTION
## Summary

ADR-016 Phase 5 の残作業 (= Lite mode 専用 CDK bin entry) を追加する。 既存の
Phase 3 (TenkaCloudLiteStack) と Phase 2 (ProblemDeployBackendStack.eventBusArn
optional) を組み合わせて、 Phase 4 で追加した `make lite-up` から実 AWS
deploy が走るようにする。

Relates #778

## scope

- `infrastructure/bin/tenkacloud-lite.ts` (新規): app entry
  - `resolveAppConfig` で `.env` / problems 解決 (= Full mode と同 path)
  - `ProblemDeployBackendStack` を `eventBusArn` 省略で作る (= local EventBus に倒す、 Phase 2 PR-#791)
  - `TenkaCloudLiteStack` に `deployApiLambda` / `eventApiLambda` / `competitorAccountsApiLambda` / `participantPortalUrl` を渡す
  - **作らない**: ControlPlane / BootstrapTemplate / TenantTemplate / Pipeline / AdminConsoleInsight / AdminConsoleHosting (= Lite mode の定義)
- `infrastructure/test/tenkacloud-lite-bin.test.ts` (新規): 5 test
  - 2 stack だけが synth される (= `tenkacloud-lite` + `tenkacloud-lite-problem-deploy`)
  - Lite mode ProblemDeploy stack は local EventBus を 1 つ持つ
  - Lite stack は AppPlaneCore (UserPool + REST API + CloudFront) を 1 セット持つ
  - 禁止 stack (ControlPlane / Bootstrap / AdminConsoleInsight / Pipeline) が無い
  - Lite stack は ProblemDeploy stack に depend する

## 設計判断

- **bin file は app composition のみ**: env / config 解決は `resolveAppConfig` (= Full mode と同 pure function) を再利用。 重複させない
- **deps を明示**: `liteStack.addDependency(problemDeployBackend)` で cross-stack Lambda ref を CFn 依存関係に変換
- **`DynamoDbLowCapacity` Aspect は両 stack に適用**: Free Tier 1/1 PROVISIONED 原則を Lite でも保つ (= CLAUDE.md 禁止事項)

## 全 Phase 完了状態

| Phase | PR | 状態 |
|---|---|---|
| Phase 1 (AppPlaneCore 抽出) | #789 | merged |
| Phase 2 (eventBusArn optional) | #791 | merged |
| Phase 3 (TenkaCloudLiteStack) | #796 | merged |
| Phase 4 (CLI runner) | #798 | merged |
| **Phase 5 (bin entry)** | **本 PR** | open |
| Phase 5 partial (README) | #801 | open |

本 PR merge で `make lite-up` が end-to-end で動く (= `cdk deploy --app` 経路が完成)。 サンプル問題 smoke test は user が実 AWS account で確認する。

## Regression 分析

- 既存 stack / Lambda には触っていない (= 新規 file 2 個のみ)
- Lite mode の new stack 名 `tenkacloud-lite` / `tenkacloud-lite-problem-deploy` は Full mode の `tenkacloud-problem-deploy` 等と名前空間が分離している
- 既存 test 916 件 + 新 5 件 = 計 921 件 すべて pass
- `make harness` no findings

## 物理影響

- CFn / IaC: **NO-OP for Full mode** (= bin/infrastructure.ts は変更なし、 Full mode deploy 経路に影響なし)
- Lite mode: 本 PR で初めて bin entry が成立 (= 今まで stack code はあったが entry が無く synth できなかった)

## Test plan

- [x] `bun run vitest run test/tenkacloud-lite-bin.test.ts` (= 5 test pass、 30s timeout)
- [x] `bun run --filter @TenkaCloud/infrastructure test` (= 全 921 test pass)
- [x] `bun run typecheck` (= clean)
- [x] `make harness` (= no findings)
- [x] `make before-commit` (= 全 gate 通過)
- [ ] merge 後、 user が `make lite-up` で実 AWS account に deploy を smoke
- [ ] sample problem (= hello-world) を Lite mode で deploy → portal に表示まで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)