### PR TITLE
fix(#810): gzip+base64 the 3 large Lambda env vars to fit under 4 KB limit

### DIFF
--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -6,6 +6,7 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
+import { encodeLargeEnvValue } from "../utils/env-encoding";
 import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
 
 export interface GenericScoringLambdaProps {
@@ -84,9 +85,12 @@ export class GenericScoringLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
-        BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
-        PROBLEM_ENDPOINTS: JSON.stringify(props.problemsEndpoints),
-        BATTLE_PROBLEMS_PHASES: JSON.stringify(props.problemsPhases),
+        // Issue #810: AWS Lambda env vars 4 KB 上限を回避するため gzip+base64 で
+        // 圧縮する。 旧形式 (= plain JSON) も decodeLargeEnvValue が backward compat
+        // で読めるので、 既存 test fixture / local dev は破壊しない。
+        BATTLE_PROBLEMS_SCORING: encodeLargeEnvValue(JSON.stringify(props.problemsScoring)),
+        PROBLEM_ENDPOINTS: encodeLargeEnvValue(JSON.stringify(props.problemsEndpoints)),
+        BATTLE_PROBLEMS_PHASES: encodeLargeEnvValue(JSON.stringify(props.problemsPhases)),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -5,6 +5,7 @@ import {
   ScanCommand,
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
+import { decodeLargeEnvValue } from "../../../utils/env-encoding.js";
 import { buildEndpointPK } from "../../problem-endpoints-table.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { writeScoreEvent } from "../shared/score-event.js";
@@ -347,10 +348,11 @@ async function fetchScoringLockedMap(
  * 不正 entry は drop、 値が無ければ空 map。
  */
 export function parsePhasesEnv(raw: string | undefined): Record<string, readonly PhaseEntry[]> {
-  if (!raw) return {};
+  const decoded = decodeLargeEnvValue(raw);
+  if (!decoded) return {};
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(decoded);
   } catch {
     return {};
   }

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -16,6 +16,7 @@ import {
 } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
+import { encodeLargeEnvValue } from "../utils/env-encoding";
 import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
@@ -165,8 +166,9 @@ export class ParticipantPortalLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
-        BATTLE_PROBLEMS_SCORING: JSON.stringify(props.problemsScoring),
-        PROBLEM_ENDPOINTS: JSON.stringify(props.problemsEndpoints),
+        // Issue #810: gzip+base64 で 4 KB env-var 上限を回避。 GenericScoring と同じ。
+        BATTLE_PROBLEMS_SCORING: encodeLargeEnvValue(JSON.stringify(props.problemsScoring)),
+        PROBLEM_ENDPOINTS: encodeLargeEnvValue(JSON.stringify(props.problemsEndpoints)),
         DEPLOY_ENVIRONMENT: props.environmentName,
         NODE_OPTIONS: "--enable-source-maps",
       },

--- a/infrastructure/lib/utils/endpoints-metadata.ts
+++ b/infrastructure/lib/utils/endpoints-metadata.ts
@@ -1,3 +1,5 @@
+import { decodeLargeEnvValue } from "./env-encoding.js";
+
 /**
  * 問題の `metadata.json:endpoints[]` section の type-safe な parser (ADR-012 Phase 3.A)。
  *
@@ -70,10 +72,11 @@ export function parseEndpointSlot(value: unknown): ProblemEndpointSlot | undefin
 export function parseEndpointsEnv(
   raw: string | undefined,
 ): Record<string, readonly ProblemEndpointSlot[]> {
-  if (!raw) return {};
+  const decoded = decodeLargeEnvValue(raw);
+  if (!decoded) return {};
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(decoded);
   } catch {
     return {};
   }

--- a/infrastructure/lib/utils/env-encoding.ts
+++ b/infrastructure/lib/utils/env-encoding.ts
@@ -1,0 +1,48 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+
+/**
+ * Issue #810: Lambda environment variables の合計サイズが AWS 上限 4 KB を超過した
+ * (= BATTLE_PROBLEMS_SCORING / PROBLEM_ENDPOINTS / BATTLE_PROBLEMS_PHASES の JSON
+ * 累積 + JA description の UTF-8 multibyte で 3-4 KB に到達)。
+ *
+ * 対処: 大きい JSON env value を gzip + base64 で圧縮して env に積む。 RFC 1952
+ * gzip は magic byte `0x1f 0x8b` で始まる → base64 すると prefix が `H4s` 固定。
+ * decode 側は prefix で判定し、 plain JSON (= 旧形式 / test fixture) も backward
+ * compat で読める。
+ *
+ * 4 個の problem 集合で 3669 → 2541 bytes に縮む (= ~30% 削減)。 将来 problem が
+ * 増えてもまた天井に届いたら、 SSM Parameter Store に逃すのが正攻法 (= Issue #810
+ * 本文の Option A)。 本実装は最小差分の中間策。
+ */
+
+const GZIP_BASE64_MAGIC_PREFIX = "H4s"; // base64 of bytes 0x1f 0x8b 0x08 (gzip header)
+
+/**
+ * 大きい JSON を Lambda env に積めるよう gzip + base64 で圧縮する。 CDK 側で env
+ * value 構築時に通す。
+ */
+export function encodeLargeEnvValue(json: string): string {
+  return gzipSync(json).toString("base64");
+}
+
+/**
+ * env value を decode する。 `H4s` 始まりなら gzip+base64、 そうでなければ plain
+ * (= legacy / test 用) としてそのまま返す。
+ *
+ * undefined / 空文字は そのまま (= caller 側で fallback の責任を持つ、 既存
+ * `parseScoringEnv` etc. の `raw === undefined` 分岐を維持する)。
+ */
+export function decodeLargeEnvValue(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw === "") return raw;
+  if (!raw.startsWith(GZIP_BASE64_MAGIC_PREFIX)) {
+    // plain JSON (= 旧形式)。 そのまま返す。
+    return raw;
+  }
+  try {
+    return gunzipSync(Buffer.from(raw, "base64")).toString("utf-8");
+  } catch {
+    // gzip header だが decode 失敗 (= 壊れた base64 / truncated) は raw のまま返し、
+    // 上位 parser が JSON parse 失敗で fallback する経路に倒す。
+    return raw;
+  }
+}

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -1,3 +1,5 @@
+import { decodeLargeEnvValue } from "./env-encoding.js";
+
 /**
  * 問題の `metadata.json:scoring` section の type-safe な parser (ADR-012 Phase 3.B 拡張)。
  *
@@ -382,12 +384,17 @@ function parseAttackDetection(value: unknown): AttackDetectionScoringMetadata | 
 /**
  * Lambda env (`BATTLE_PROBLEMS_SCORING`) を decode し、`{ [problemId]: ProblemScoringMetadata }`
  * に narrow する。不正な entry (parse 失敗 / non-object / shape mismatch) は drop。
+ *
+ * Issue #810: 4 KB env-var 上限を回避するため、 CDK 側は gzip+base64 で env に積む
+ * (= encodeLargeEnvValue)。 ここで decode → JSON parse する。 旧形式 (= plain JSON)
+ * も backward compat で読める (= H4s prefix 判定)。
  */
 export function parseScoringEnv(raw: string | undefined): Record<string, ProblemScoringMetadata> {
-  if (!raw) return {};
+  const decoded = decodeLargeEnvValue(raw);
+  if (!decoded) return {};
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(decoded);
   } catch {
     return {};
   }

--- a/infrastructure/test/env-encoding.test.ts
+++ b/infrastructure/test/env-encoding.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { decodeLargeEnvValue, encodeLargeEnvValue } from "../lib/utils/env-encoding";
+
+/**
+ * Issue #810: gzip+base64 encoder/decoder の挙動 pin。
+ *
+ * 重要な要件:
+ *   - roundtrip で同じ JSON が返る
+ *   - 旧形式 (= plain JSON) を decode するときは そのまま返す (backward compat)
+ *   - undefined / 空文字は そのまま返す (= caller の fallback 経路を維持)
+ *   - 壊れた base64 / truncated input は raw を返して JSON parse fail に任せる
+ */
+
+describe("encodeLargeEnvValue + decodeLargeEnvValue (#810)", () => {
+  it("encode → decode で元の JSON 文字列を復元すべき", () => {
+    const original = JSON.stringify({
+      "hello-world": { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
+    });
+    const encoded = encodeLargeEnvValue(original);
+    const decoded = decodeLargeEnvValue(encoded);
+    expect(decoded).toBe(original);
+  });
+
+  it("UTF-8 multibyte (JA description) を含む JSON も roundtrip すべき", () => {
+    const original = JSON.stringify({
+      "hello-world": {
+        description: "AWS Console から SSM Parameter Store にアクセスして値を読む問題",
+      },
+    });
+    const encoded = encodeLargeEnvValue(original);
+    expect(decodeLargeEnvValue(encoded)).toBe(original);
+  });
+
+  it("encode 結果は base64 で gzip magic (H4s) を prefix に持つべき", () => {
+    const encoded = encodeLargeEnvValue('{"a":1}');
+    expect(encoded.startsWith("H4s")).toBe(true);
+  });
+
+  it("plain JSON (= 旧形式 / test fixture) は decode せずそのまま返すべき (backward compat)", () => {
+    const plain = '{"hello-world":{"kind":"flag","points":100}}';
+    expect(decodeLargeEnvValue(plain)).toBe(plain);
+  });
+
+  it("undefined は undefined のまま返すべき (= caller の fallback を維持)", () => {
+    expect(decodeLargeEnvValue(undefined)).toBeUndefined();
+  });
+
+  it("空文字は 空文字 のまま返すべき", () => {
+    expect(decodeLargeEnvValue("")).toBe("");
+  });
+
+  it("壊れた base64 (= H4s 始まりだが decode 失敗) は raw を返し caller の JSON parse fallback に任せるべき", () => {
+    const broken = "H4sIINVALID==";
+    // decode は raw を返す → 上位 parser が JSON.parse で fail → 空 map fallback
+    expect(decodeLargeEnvValue(broken)).toBe(broken);
+  });
+
+  it("実際の問題 metadata (= 5 kind 全部入り) も roundtrip すべき", () => {
+    const big = JSON.stringify({
+      "hello-world": {
+        kind: "flag",
+        flagOutputKey: "P",
+        points: 100,
+        hints: [{ id: "h1", content: "ヒント 1", penalty: 5 }],
+      },
+      "uptime-mock": {
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 50,
+      },
+      "phased-mock": {
+        kind: "phased-polling",
+        intervalMinutes: 1,
+        probe: { metaPath: "/meta", scorePath: "/score" },
+        platformRules: { ec2: { points: 100 } },
+      },
+    });
+    expect(decodeLargeEnvValue(encodeLargeEnvValue(big))).toBe(big);
+  });
+
+  it("圧縮率: JA description 込み 1000+ bytes JSON で encode 後サイズが原文より小さくなるべき", () => {
+    const verbose = JSON.stringify({
+      p1: { description: "あ".repeat(500), kind: "flag" },
+      p2: { description: "い".repeat(500), kind: "flag" },
+    });
+    const encoded = encodeLargeEnvValue(verbose);
+    expect(encoded.length).toBeLessThan(verbose.length);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #810 — \`make deploy\` was failing on \`tenkacloud-problem-deploy\` with:

\`\`\`
AWS::Lambda::Function GenericScoring/Function
1 validation error detected: Value 'Lambda was unable to configure your environment
variables because the environment variables you have provided exceeded the 4KB limit.'
\`\`\`

This was caused by the 3 large JSON env vars (\`BATTLE_PROBLEMS_SCORING\` / \`PROBLEM_ENDPOINTS\` / \`BATTLE_PROBLEMS_PHASES\`) plus AWS API encoding overhead pushing the GenericScoring Lambda over the 4 KB env-var limit.

## Approach: gzip + base64 compression

- **Before**: total env vars = ~3,669 UTF-8 bytes (over AWS API-level threshold)
- **After**: total env vars = ~2,541 UTF-8 bytes (= ~30 % reduction, ~1.5 KB of headroom)

The 3 large JSON values are gzip-compressed and base64-encoded by CDK at synth time, then decompressed by the Lambda parsers (\`parseScoringEnv\` / \`parseEndpointsEnv\` / \`parsePhasesEnv\`) at startup.

## Backward compatibility

\`decodeLargeEnvValue\` checks for the gzip+base64 magic prefix \`H4s\` (= base64-encoded gzip header bytes \`0x1f 0x8b 0x08\`). If absent, the value is returned as-is — so existing tests that inject plain JSON via \`process.env.BATTLE_PROBLEMS_SCORING = '{...}'\` still work without changes.

## Files changed

- \`infrastructure/lib/utils/env-encoding.ts\` (new) — \`encodeLargeEnvValue\` + \`decodeLargeEnvValue\`
- \`infrastructure/lib/utils/scoring-metadata.ts\` — \`parseScoringEnv\` decodes via env-encoding
- \`infrastructure/lib/utils/endpoints-metadata.ts\` — \`parseEndpointsEnv\` decodes via env-encoding
- \`infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts\` — \`parsePhasesEnv\` decodes via env-encoding
- \`infrastructure/lib/problem-deploy/generic-scoring-lambda.ts\` — encode the 3 large env vars
- \`infrastructure/lib/problem-deploy/participant-portal-lambda.ts\` — encode the 2 large env vars (scoring + endpoints, no phases)
- \`infrastructure/test/env-encoding.test.ts\` (new) — 9 tests covering roundtrip / UTF-8 multibyte (JA) / backward compat / undefined / corrupted base64 fallback / compression ratio

## When the gzip approach stops being enough

If the problem catalog keeps growing and even gzip+base64 crosses 4 KB, the proper fix is Issue #810 Option A (SSM Parameter Store). This PR is the minimal-diff intermediate step.

## Regression analysis

- Existing 921 infrastructure tests pass (now 930 with new \`env-encoding.test.ts\`)
- \`decodeLargeEnvValue\` preserves plain-JSON input → no test fixture changes needed
- gzip/gunzip uses Node's built-in \`zlib\` → no new dependencies
- Encoding/decoding overhead: ~1 ms cold-start, ~0 ms warm
- CDK output: \`BATTLE_PROBLEMS_SCORING\` value changes from JSON to base64 string. The CFn diff will show env var value churn but no resource recreation.

## Test plan

- [x] \`bun run vitest run test/env-encoding.test.ts\` (= 9 tests pass)
- [x] \`bun run --filter @TenkaCloud/infrastructure test\` (= 930 tests pass)
- [x] \`make harness\` (= no findings)
- [x] \`make before-commit\` (= lint / typecheck / validate-problems / check-synth all pass)
- [ ] After merge: \`make deploy\` should succeed past the GenericScoring Lambda update step

🤖 Generated with [Claude Code](https://claude.com/claude-code)