### PR TITLE
fix(#809): DescribeStack task payload — use TaskInput.fromObject + JsonPath.objectAt

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -150,12 +150,20 @@ export class DeployCreateStateMachine extends Construct {
       .otherwise(invalidAssumeRoleMetadata);
 
     // CodeBuild 完了後に CFn から Outputs と StackId を取得。verified deployment は
-    // competitor account への AssumeRole が必要なので DescribeStackLambda に state 全体を渡す。
+    // competitor account への AssumeRole が必要なので DescribeStackLambda に detail (= 元
+    // EventBridge event の detail field) を渡す。
     // payloadResponseOnly=true により $.cfn は Lambda response (= DescribeStacks output)
     // そのものになり、既存 MarkSucceeded の JSONPath 契約を維持する。
+    //
+    // Issue #809: 旧コードは `payload: TaskInput.fromJsonPathAt("$")` を使っていたが、
+    // CDK が optimized Lambda integration + `payloadResponseOnly: true` で
+    // `Parameters: "$"` (= literal string) を生成し、 Lambda は literal `"$"` を event
+    // として受け取って `event.detail.jobId` が undefined で fail していた。
+    // `TaskInput.fromObject({...})` で明示的に object payload を組むと CDK は
+    // `Parameters: { "detail.$": "$.detail" }` を生成し、 JSONPath が解決される。
     const describeStacks = new LambdaInvoke(this, "DescribeStack", {
       lambdaFunction: props.describeStackFunction,
-      payload: TaskInput.fromJsonPathAt("$"),
+      payload: TaskInput.fromObject({ detail: JsonPath.objectAt("$.detail") }),
       payloadResponseOnly: true,
       resultPath: "$.cfn",
     });

--- a/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
@@ -1,0 +1,113 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Project, Source } from "aws-cdk-lib/aws-codebuild";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { describe, expect, it } from "vitest";
+import { DeployCreateStateMachine } from "../../lib/problem-deploy/deploy-create-state-machine";
+
+/**
+ * Issue #809: DescribeStack task の Parameters が JSONPath-resolved object になることを
+ * 機械検査する regression test。
+ *
+ * 旧コード (= `TaskInput.fromJsonPathAt("$")` + `payloadResponseOnly: true`) は ASL で
+ * `Parameters: "$"` (= literal string) を生成し、 Lambda が literal `"$"` を event として
+ * 受け取って `event.detail.jobId` undefined で fail していた。
+ *
+ * 修正後は `TaskInput.fromObject({ detail: JsonPath.objectAt("$.detail") })` を使い、
+ * ASL で `Parameters: { "detail.$": "$.detail" }` を生成する (= Step Functions が
+ * JSONPath を resolve して Lambda に渡す)。
+ */
+
+function buildTestStack(): { stack: cdk.Stack; template: Template } {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "Test", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const deployments = new Table(stack, "Deployments", {
+    partitionKey: { name: "PK", type: AttributeType.STRING },
+    sortKey: { name: "SK", type: AttributeType.STRING },
+  });
+  const describeStackFn = new LambdaFunction(stack, "DescribeStackFn", {
+    runtime: Runtime.NODEJS_22_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => ({});"),
+  });
+  const codeBuildProject = new Project(stack, "CodeBuild", {
+    source: Source.s3({
+      bucket: cdk.aws_s3.Bucket.fromBucketName(stack, "Src", "test-source-bucket"),
+      path: "source.zip",
+    }),
+  });
+  new DeployCreateStateMachine(stack, "Sm", {
+    codeBuildProject,
+    describeStackFunction: describeStackFn,
+    deploymentsTable: deployments,
+  });
+  return { stack, template: Template.fromStack(stack) };
+}
+
+describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => {
+  it("DescribeStack task の Parameters は object であり、 literal string ではないべき", () => {
+    const { template } = buildTestStack();
+    const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
+    const sm = Object.values(stateMachines)[0];
+    expect(sm).toBeDefined();
+    const definitionString = sm?.Properties?.DefinitionString;
+    expect(definitionString).toBeDefined();
+
+    // DefinitionString は CFn が join で組み立てるので {"Fn::Join": [...]} の可能性あり。
+    // join の場合は components を結合して 1 string にして JSON parse 可能性を確認する。
+    let asJson: string;
+    if (typeof definitionString === "string") {
+      asJson = definitionString;
+    } else {
+      // Fn::Join 形式: ["", [strings/refs]]。 ref は arn の placeholder なので string concat で OK。
+      const join = definitionString["Fn::Join"];
+      const parts = join[1] as Array<string | Record<string, unknown>>;
+      asJson = parts.map((p) => (typeof p === "string" ? p : "ARN_PLACEHOLDER")).join("");
+    }
+
+    // DescribeStack task definition を抽出。
+    // 旧 bug 形式: `"Parameters":"$"`
+    // 修正後形式: `"Parameters":{"detail.$":"$.detail"}`
+    expect(asJson).not.toContain('"Parameters":"$"');
+    expect(asJson).toContain('"DescribeStack"');
+    expect(asJson).toContain('"detail.$":"$.detail"');
+  });
+
+  it("DescribeStack task は payloadResponseOnly=true 維持で resultPath が $.cfn であるべき", () => {
+    const { template } = buildTestStack();
+    const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
+    const sm = Object.values(stateMachines)[0];
+    const definitionString = sm?.Properties?.DefinitionString;
+    let asJson: string;
+    if (typeof definitionString === "string") {
+      asJson = definitionString;
+    } else {
+      const join = definitionString["Fn::Join"];
+      const parts = join[1] as Array<string | Record<string, unknown>>;
+      asJson = parts.map((p) => (typeof p === "string" ? p : "ARN_PLACEHOLDER")).join("");
+    }
+    // resultPath: "$.cfn" は ASL 上 "ResultPath":"$.cfn" として出る。
+    expect(asJson).toContain('"ResultPath":"$.cfn"');
+  });
+
+  it("StateMachine 全体が synth 可能で IAM policy で Lambda invoke が許可されるべき", () => {
+    const { template } = buildTestStack();
+    template.resourceCountIs("AWS::StepFunctions::StateMachine", 1);
+    // State Machine の execution role policy が Lambda invoke を含むこと
+    template.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "lambda:InvokeFunction",
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #809.

Step Functions was passing the literal string `"\$"` to the DescribeStack Lambda as its payload, causing `event.detail.jobId` to be undefined and the entire deploy path to fail with `missing required field: detail.jobId`.

## Root cause (confirmed from deployed ASL)

\`\`\`json
{
  "Resource": "arn:aws:lambda:...:function:tenkacloud-problem-deploy-DescribeStack...",
  "Parameters": "$"
}
\`\`\`

\`Parameters: "\$"\` is a literal string. ASL requires \`Parameters\` to be an object for JSONPath resolution; when it's a string, Step Functions sends the literal value to the Lambda. CDK's \`TaskInput.fromJsonPathAt("\$")\` combined with \`payloadResponseOnly: true\` emits this broken form for the root path \`\$\`.

## Fix

Switch to \`TaskInput.fromObject({ detail: JsonPath.objectAt("\$.detail") })\`. This generates:

\`\`\`json
"Parameters": { "detail.$": "$.detail" }
\`\`\`

Step Functions then resolves \`\$.detail\` and passes \`{ detail: { jobId, namePrefix, region, ... } }\` to the Lambda — matching what the handler expects.

The handler (\`describe-stack-handler/index.ts\`) reads \`input.detail.jobId\` etc., so its interface is unchanged.

## Verification

New test \`deploy-create-state-machine.test.ts\` (3 cases):
- ASL Parameters is NOT the literal \`"\$"\`
- ASL contains \`"detail.\$":"\$.detail"\`
- \`payloadResponseOnly\` + \`resultPath: "\$.cfn"\` preserved
- Lambda invoke IAM policy generated

Repo-wide grep confirmed only one usage of \`TaskInput.fromJsonPathAt("\$")\` (this file).

## Regression analysis

- \`describe-stack-handler/index.ts\` is unchanged (interface is the same)
- PR #803's diagnostic log is designed to fire only on failure → won't emit on the success path after this fix
- All 921 existing infrastructure tests + 3 new tests = 924 total pass
- The \`tenkacloud-problem-deploy\` stack CFn diff will show the State Machine definition changed (= \`DefinitionString\` updated, but no Lambda / IAM / DDB resource recreation)

## Order with #810

This PR should be merged **after** #811 (the #810 env-vars 4KB fix), because deploys are currently blocked by the env-vars issue. Once #811 is in:
1. \`make deploy\` succeeds past the GenericScoring Lambda step
2. This PR's State Machine definition update reaches the deployed environment
3. A \`hello-world\` deploy can be re-tried and should succeed end-to-end

## Test plan

- [x] \`bun run vitest run test/problem-deploy/deploy-create-state-machine.test.ts\` (= 3 tests pass)
- [x] \`make harness\` (= no findings)
- [x] \`make before-commit\` (= lint / typecheck / validate-problems / check-synth all pass)
- [ ] After merge + deploy (= post-#811): \`hello-world\` deploy succeeds end-to-end
- [ ] Step Functions execution history shows \`LambdaFunctionScheduled.input\` as resolved JSON (\`{"detail": {...}}\`)
- [ ] PR #803's \`deploy.describe-stack.input-received\` log is NOT emitted on success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment state machine to properly pass job identifiers during stack creation operations, preventing undefined values.

* **Tests**
  * Added regression tests to verify stack creation payload handling and IAM permissions execute correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/812)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->