### PR TITLE
fix(portal): hide deploy status + show solved/unsolved state (#821 #822)

### DIFF
--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -77,8 +77,16 @@ function TeamScorePanel({ view }: { view: ParticipantTeamView }) {
           },
           { label: t("home.score_problem_count"), value: String(view.problems.length) },
           {
+            // Issue #821 / #822: 旧 \"deploy COMPLETE\" カウントから 「正解した問題数」 に
+            // 変更する。 flag 問題は flagSubmitted=true、 非 flag (Battle) は score>0 を
+            // 「解いた」 と扱う (= スコアを稼げてれば貢献あり)。
             label: t("home.score_completed_count"),
-            value: String(view.problems.filter((p) => p.status === "COMPLETE").length),
+            value: String(
+              view.problems.filter((p) => {
+                if (p.scoring?.kind === "flag") return p.scoring.flagSubmitted === true;
+                return p.score > 0;
+              }).length,
+            ),
           },
         ]}
       />

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -14,7 +14,6 @@ import StatusIndicator, {
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import {
-  type DeploymentStatus,
   getConsoleSigninUrl,
   type ParticipantProblemView,
   type ParticipantScoringInfo,
@@ -26,14 +25,43 @@ import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 import { categoryOf } from "../lib/category";
 
-const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
-  PENDING: "pending",
-  IN_PROGRESS: "in-progress",
-  COMPLETE: "success",
-  FAILED: "error",
-  DELETING: "in-progress",
-  DELETED: "stopped",
-};
+/**
+ * Issue #821 / #822: 競技者向けの 「解答状態」 (= 解けた / 解けてない) を可視化する。
+ *
+ * 旧 UI は `DeploymentStatus` (PENDING / IN_PROGRESS / COMPLETE / FAILED) を表示
+ * していたが、 これは 「deploy 進行状態」 であり競技者にとっては無関係。 競技者は
+ * 「flag 提出が成功したか」 / 「Battle が進行中か」 が知りたい。
+ *
+ * Challenge (flag):
+ *   - deploy 失敗 → \"デプロイ失敗\" (error)
+ *   - deploy 中    → \"準備中\" (in-progress)
+ *   - 未提出      → \"未解答\" (pending)
+ *   - 提出済 (正解) → \"クリア\" (success) + 獲得 pt を score 列で表示
+ *
+ * Battle (uptime / phased-polling / attack-detection):
+ *   - deploy 失敗 → \"デプロイ失敗\" (error)
+ *   - deploy 中    → \"準備中\" (in-progress)
+ *   - それ以外    → \"挑戦中\" (info) — Battle は 「解く」 ものでなく継続採点
+ *
+ * `applicationStatus.overall` は別 section で詳細化 (= 既存挙動を維持)。
+ */
+function renderSubmissionState(problem: ParticipantProblemView): {
+  readonly type: StatusIndicatorProps.Type;
+  readonly label: string;
+} {
+  if (problem.status === "FAILED") return { type: "error", label: "デプロイ失敗" };
+  if (problem.status === "DELETED") return { type: "stopped", label: "終了" };
+  if (problem.status === "PENDING" || problem.status === "IN_PROGRESS") {
+    return { type: "in-progress", label: "準備中" };
+  }
+  // status === COMPLETE / DELETING
+  if (problem.scoring?.kind === "flag") {
+    if (problem.scoring.flagSubmitted) return { type: "success", label: "クリア" };
+    return { type: "pending", label: "未解答" };
+  }
+  // Battle 系 (= uptime / phased-polling / attack-detection)。 採点は別 section で表示。
+  return { type: "info", label: "挑戦中" };
+}
 
 type CategoryFilter = "all" | "battle" | "challenge";
 
@@ -169,13 +197,14 @@ export function QuestsPage({ config }: { config: AppConfig }) {
           ),
           sections: [
             {
-              id: "status",
-              header: t("quests.status_env_header"),
-              content: (problem) => (
-                <StatusIndicator type={STATUS_TYPE[problem.status]}>
-                  {t(`quests.status_label.${problem.status}`)}
-                </StatusIndicator>
-              ),
+              // Issue #821 / #822: 「deploy 進行状況」 ではなく 「解答状態」 を出す
+              // (= COMPLETE / FAILED 等の internal deploy term を競技者に見せない)。
+              id: "submission",
+              header: "解答状態",
+              content: (problem) => {
+                const s = renderSubmissionState(problem);
+                return <StatusIndicator type={s.type}>{s.label}</StatusIndicator>;
+              },
             },
             {
               id: "score",

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -123,12 +123,13 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
               </Header>
             }
           >
+            {/* Issue #821: deploy status (= COMPLETE 等) は競技者には無関係なので
+                出さない。 AWS Account ID + Region で足りる。 */}
             <KeyValuePairs
-              columns={3}
+              columns={2}
               items={[
                 { label: "AWS Account", value: <code>{problem.awsAccountId}</code> },
                 { label: "Region", value: problem.region },
-                { label: "Status", value: problem.status },
               ]}
             />
           </Container>


### PR DESCRIPTION
Closes #821, Closes #822.

## scope

- Quests: 旧 "Environment status: COMPLETE" を 「解答状態」 (未解答/クリア/挑戦中/デプロイ失敗/準備中) に置換
- Home: "Completed" カウンタを 「正解した問題数」 (flag=flagSubmitted、 非flag=score>0) に変更
- SSO Credentials: "Status" 列削除

## test plan

- [x] make harness (no findings)
- [x] participant-portal test 146 件 pass
- [x] biome / typecheck clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Improved problem completion tracking to use scoring-based criteria (flag submission and battle scores) instead of deployment status.
  * Redesigned submission state display in quests to show whether problems are cleared or submitted.
  * Simplified console-login problem details to display only AWS Account and Region information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/823)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->