### PR TITLE
fix(deploy-ux): CFn Deploy phase stuck on In Progress after CREATE_COMPLETE (#818)

### DIFF
--- a/apps/application-admin-console/src/lib/deploy-phases.ts
+++ b/apps/application-admin-console/src/lib/deploy-phases.ts
@@ -35,13 +35,46 @@ export interface DeployPhase {
 
 const COMPLETE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["COMPLETE", "FAILED", "DELETED"]);
 
+/**
+ * Issue #818: stackStatus (= 現在の stack 状態) を権威 source として優先する。
+ * 旧 \`eventsToPhaseStatus\` は CFn event history の **過去** \`*_IN_PROGRESS\` event
+ * も拾うため、 stack が CREATE_COMPLETE になっても in-progress のままになる bug が
+ * あった。
+ */
+function stackStatusToPhaseStatus(stackStatus: string | undefined): PhaseStatus | undefined {
+  if (!stackStatus) return undefined;
+  if (stackStatus === "CREATE_COMPLETE") return "complete";
+  if (stackStatus === "UPDATE_COMPLETE") return "complete";
+  if (stackStatus === "IMPORT_COMPLETE") return "complete";
+  if (stackStatus.endsWith("_FAILED")) return "failed";
+  if (stackStatus === "ROLLBACK_COMPLETE") return "failed";
+  if (stackStatus === "UPDATE_ROLLBACK_COMPLETE") return "failed";
+  if (stackStatus === "IMPORT_ROLLBACK_COMPLETE") return "failed";
+  if (stackStatus.startsWith("DELETE_")) return "skipped";
+  if (stackStatus.endsWith("_IN_PROGRESS")) return "in-progress";
+  return undefined;
+}
+
+/**
+ * Issue #818: LogicalId ごとに最新 event だけを判定対象にする (= 過去の
+ * IN_PROGRESS が COMPLETE で superseded されている状態を正しく扱う)。 旧
+ * \`events.some(IN_PROGRESS)\` は history 全体を拾って永遠に in-progress を
+ * 返していた。
+ */
 function eventsToPhaseStatus(events: readonly StackProgressEvent[]): PhaseStatus {
   if (events.length === 0) return "pending";
-  const hasFailed = events.some((e) => e.resourceStatus.endsWith("_FAILED"));
+  const latestByLogicalId = new Map<string, StackProgressEvent>();
+  for (const e of events) {
+    const cur = latestByLogicalId.get(e.logicalResourceId);
+    if (!cur || cur.timestamp < e.timestamp) {
+      latestByLogicalId.set(e.logicalResourceId, e);
+    }
+  }
+  const latest = Array.from(latestByLogicalId.values());
+  const hasFailed = latest.some((e) => e.resourceStatus.endsWith("_FAILED"));
   if (hasFailed) return "failed";
-  const hasInProgress = events.some((e) => e.resourceStatus.endsWith("_IN_PROGRESS"));
+  const hasInProgress = latest.some((e) => e.resourceStatus.endsWith("_IN_PROGRESS"));
   if (hasInProgress) return "in-progress";
-  // すべて `_COMPLETE` で終わる前提 (= rollback 系は `_FAILED` で拾われている)。
   return "complete";
 }
 
@@ -93,7 +126,12 @@ export function derivePhases(
   // CFn 未割当 (= events 空 + status=PENDING/IN_PROGRESS) は Pending。
   // status=FAILED かつ events 空 → 上の Building で Failed を消化したので CFn 側は Pending のまま。
   let cfnStatus: PhaseStatus;
-  if (events.length === 0) {
+  // Issue #818: 優先順位 (1) stackStatus が権威 (2) event history (= LogicalId 別最新)
+  // (3) status + 観測有無の組み合わせ
+  const fromStackStatus = stackStatusToPhaseStatus(stackProgress?.stackStatus);
+  if (fromStackStatus !== undefined) {
+    cfnStatus = fromStackStatus;
+  } else if (events.length === 0) {
     if (status === "COMPLETE") cfnStatus = "complete";
     else if (status === "FAILED") cfnStatus = "pending";
     else if (status === "DELETING" || status === "DELETED") cfnStatus = "skipped";

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -142,6 +142,75 @@ describe("derivePhases", () => {
     const phases = derivePhases({ ...baseDeployment, status: "DELETED" }, progressAllComplete);
     expect(pick(phases, "complete").status).toBe("skipped");
   });
+
+  // #818 regression: past CREATE_IN_PROGRESS event が history に残っていても、
+  // stack 自体は CREATE_COMPLETE に到達しているなら cfn-deploy phase は complete。
+  it("stackStatus=CREATE_COMPLETE のとき過去 IN_PROGRESS event があっても complete にすべき (#818)", () => {
+    const stuck: StackProgress = {
+      ...emptyProgress,
+      stackStatus: "CREATE_COMPLETE",
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_IN_PROGRESS",
+        },
+        {
+          timestamp: "2026-05-11T01:09:10.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_COMPLETE",
+        },
+      ],
+    };
+    const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, stuck);
+    expect(pick(phases, "cfn-deploy").status).toBe("complete");
+  });
+
+  it("stackStatus 未指定でも LogicalId 別最新 event を見て complete を返すべき (#818)", () => {
+    // stackStatus 取得失敗の fallback path。 同 LogicalId に IN_PROGRESS と
+    // COMPLETE 両方あるとき、 最新 (= COMPLETE) を採用する。
+    const fallback: StackProgress = {
+      ...emptyProgress,
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_IN_PROGRESS",
+        },
+        {
+          timestamp: "2026-05-11T01:09:10.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_COMPLETE",
+        },
+      ],
+    };
+    const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, fallback);
+    expect(pick(phases, "cfn-deploy").status).toBe("complete");
+  });
+
+  it("stackStatus=ROLLBACK_COMPLETE は failed にすべき (#818)", () => {
+    const rolledBack: StackProgress = {
+      ...emptyProgress,
+      stackStatus: "ROLLBACK_COMPLETE",
+      events: [],
+    };
+    const phases = derivePhases({ ...baseDeployment, status: "FAILED" }, rolledBack);
+    expect(pick(phases, "cfn-deploy").status).toBe("failed");
+  });
+
+  it("stackStatus=CREATE_IN_PROGRESS は in-progress にすべき (#818)", () => {
+    const inProgress: StackProgress = {
+      ...emptyProgress,
+      stackStatus: "CREATE_IN_PROGRESS",
+      events: progressWithCreateInProgress.events,
+    };
+    const phases = derivePhases({ ...baseDeployment, status: "IN_PROGRESS" }, inProgress);
+    expect(pick(phases, "cfn-deploy").status).toBe("in-progress");
+  });
 });
 
 describe("deploySummaryTitle", () => {


### PR DESCRIPTION
Closes #818.

旧 `events.some(endsWith("_IN_PROGRESS"))` が past event も拾う bug を直す。

- stackProgress.stackStatus を権威 source として優先
- fallback で LogicalId 別最新 event のみ判定
- 既存 11 + 新 4 test all pass