### PR TITLE
fix(problems/hello-world): add SSM/CFn list perms to ParticipantViewerRole (#820)

### DIFF
--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -68,8 +68,21 @@ describe("problem template ParticipantViewerRole (#744)", () => {
       expect(role).toContain(`AWS: !Sub "arn:aws:iam::\${TenkaCloudAccountId}:root"`);
       expect(role).toContain("sts:ExternalId: !Ref ExternalId");
       expect(role).toContain("PolicyName: ProblemSpecific");
-      expect(role).not.toContain('Resource: "*"');
-      expect(role).not.toContain("Resource: '*'");
+      // Issue #820: \`Resource: \"*\"\` is permitted ONLY when paired with a
+      // List* / Describe-all Sid (AWS list-only APIs cannot be resource-scoped).
+      // Any \`Resource: \"*\"\` outside such a Sid indicates overprovisioning.
+      // Split by \`- Sid:\` markers to scope the search to each statement.
+      const statements = role.split(/^\s+- Sid: /m).slice(1);
+      for (const stmt of statements) {
+        const sid = stmt.split(/\s/, 1)[0] ?? "";
+        const hasWildcard = stmt.includes('Resource: "*"') || stmt.includes("Resource: '*'");
+        if (hasWildcard) {
+          expect(
+            /^(List|Describe)/.test(sid),
+            `Sid \"${sid}\" uses Resource:\"*\" — only allowed for List*/Describe-all read APIs`,
+          ).toBe(true);
+        }
+      }
       expect(template).toContain("ParticipantViewerRoleArn:");
       expect(template).toContain("Value: !GetAtt ParticipantViewerRole.Arn");
 

--- a/problems/challenges/hello-world/template.yaml
+++ b/problems/challenges/hello-world/template.yaml
@@ -52,12 +52,34 @@ Resources:
                 Effect: Allow
                 Action:
                   - ssm:GetParameter
+                  - ssm:GetParameters
                 Resource: !Sub "arn:aws:ssm:*:*:parameter/${NamePrefix}/*"
+              # Issue #820: AWS Console SSM Parameter Store list view requires
+              # DescribeParameters / GetParametersByPath (list APIs cannot be
+              # resource-scoped, but the Console filters by path so the user only
+              # sees their own problem's parameters).
+              - Sid: ListSsmParametersForConsole
+                Effect: Allow
+                Action:
+                  - ssm:DescribeParameters
+                  - ssm:GetParametersByPath
+                Resource: "*"
               - Sid: DescribeOwnStack
                 Effect: Allow
                 Action:
                   - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackResources
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:GetTemplate
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${NamePrefix}/*"
+              # Issue #820: required for CFn Console stack list view
+              # (ListStacks cannot be resource-scoped). List-only, no impact on
+              # the solution path (reading the SSM Parameter value).
+              - Sid: ListCfnStacksForConsole
+                Effect: Allow
+                Action:
+                  - cloudformation:ListStacks
+                Resource: "*"
 
   HelloParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
Closes #820 (hello-world only).

## Changes
- ssm:DescribeParameters / GetParametersByPath / GetParameters (list APIs need Resource:"*")
- cloudformation:ListStacks (= list-only, Resource:"*")
- cloudformation:DescribeStackResources / DescribeStackEvents / GetTemplate (own stack scope)

Test guardrail updated to permit Resource:"*" only on List*/Describe* Sid (= overprovisioning detector). 932 + new = passing.

Battles (security/microservice/hello-world-battle) follow-up in separate PR.