### PR TITLE
fix(auth): revoke Cognito session on sign-out (#833)

### DIFF
--- a/apps/admin-console/src/auth/AuthProvider.tsx
+++ b/apps/admin-console/src/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import type { AppConfig } from "../config";
-import { beginLogin, clearTokens, loadStoredTokens, type TokenSet } from "./cognito";
+import { beginLogin, beginLogout, loadStoredTokens, type TokenSet } from "./cognito";
 
 interface AuthState {
   tokens: TokenSet | null;
@@ -29,8 +29,11 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
         void beginLogin(config);
       },
       logout: () => {
-        clearTokens();
+        // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
+        // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
+        // で Cognito 側 cookie が残り silent re-login していた)。
         setTokensState(null);
+        void beginLogout(config);
       },
       setTokens: (t) => setTokensState(t),
     }),

--- a/apps/admin-console/src/auth/cognito.test.ts
+++ b/apps/admin-console/src/auth/cognito.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../config";
+import { beginLogout } from "./cognito";
+
+/**
+ * Issue #833: サインアウト時に Cognito Hosted UI session が revoke されず、
+ * 再 sign-in で Cognito を経由せず画面に入れてしまう問題の回帰防止テスト。
+ */
+
+const TOKENS_KEY = "TenkaCloud.tokens";
+
+const CONFIG: AppConfig = {
+  cognitoDomain: "https://example-domain.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "client-abc",
+  redirectUri: "https://admin.example.com/callback",
+  apiBaseUrl: "https://api.example.com",
+  scope: "openid email profile",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "ap-northeast-1",
+  awsAccountId: "000000000000",
+  adminInsightApiUrl: "",
+};
+
+function storeTokens(refreshToken: string | undefined) {
+  sessionStorage.setItem(
+    TOKENS_KEY,
+    JSON.stringify({
+      idToken: "id.jwt",
+      accessToken: "access.jwt",
+      refreshToken,
+      expiresAt: Date.now() + 60_000,
+    }),
+  );
+}
+
+describe("beginLogout (Issue #833)", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let assignSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    assignSpy = vi.fn();
+    // window.location.assign は jsdom では default に既存実装があるので spy で上書き
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refresh token を /oauth2/revoke に POST してから sessionStorage を clear すべき", async () => {
+    storeTokens("refresh.jwt");
+
+    await beginLogout(CONFIG);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(`${CONFIG.cognitoDomain}/oauth2/revoke`);
+    expect(init?.method).toBe("POST");
+    const body = init?.body as URLSearchParams;
+    expect(body.get("token")).toBe("refresh.jwt");
+    expect(body.get("client_id")).toBe(CONFIG.cognitoClientId);
+    expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
+  });
+
+  it("refresh token が無いときは /oauth2/revoke を呼ばずに redirect すべき", async () => {
+    storeTokens(undefined);
+
+    await beginLogout(CONFIG);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("/logout に client_id と logout_uri を付けて redirect すべき", async () => {
+    storeTokens("refresh.jwt");
+
+    await beginLogout(CONFIG);
+
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    const redirectedTo = new URL(assignSpy.mock.calls[0][0] as string);
+    expect(redirectedTo.origin + redirectedTo.pathname).toBe(`${CONFIG.cognitoDomain}/logout`);
+    expect(redirectedTo.searchParams.get("client_id")).toBe(CONFIG.cognitoClientId);
+    // UserPoolClient の sign-out URLs に揃える: redirectUri の origin + "/login"
+    expect(redirectedTo.searchParams.get("logout_uri")).toBe("https://admin.example.com/login");
+  });
+
+  it("/oauth2/revoke が失敗しても redirect は実行されるべき (= revoke failure で sign-out が止まらない)", async () => {
+    storeTokens("refresh.jwt");
+    fetchSpy.mockRejectedValueOnce(new Error("network down"));
+
+    await beginLogout(CONFIG);
+
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
+  });
+});

--- a/apps/admin-console/src/auth/cognito.ts
+++ b/apps/admin-console/src/auth/cognito.ts
@@ -104,3 +104,50 @@ export function clearTokens(): void {
   sessionStorage.removeItem(VERIFIER_KEY);
   sessionStorage.removeItem(STATE_KEY);
 }
+
+/**
+ * Issue #833: Cognito Hosted UI session (= cookie) を revoke してから redirect する。
+ *
+ * 旧 logout は `clearTokens()` (= sessionStorage) のみで、 Cognito 側の session cookie
+ * は browser に残ったまま。 次に `beginLogin` で /oauth2/authorize に redirect すると、
+ * Cognito が既存 cookie で silent re-login させ、 Hosted UI を経由せずに画面に戻って
+ * しまっていた。
+ *
+ * 修正:
+ *   1. refresh token があれば `/oauth2/revoke` で server-side revoke
+ *   2. sessionStorage を clearTokens
+ *   3. `/logout?client_id=...&logout_uri=...` に redirect し Cognito cookie を破棄
+ *
+ * `logout_uri` は UserPoolClient の sign-out URLs に登録されている origin に
+ * redirect する (= 多くの環境で `<redirectUri origin>/login` を登録済)。
+ */
+export async function beginLogout(config: AppConfig): Promise<void> {
+  // (1) refresh token の server-side revoke (= best-effort、 失敗しても続行)
+  const stored = loadStoredTokens();
+  if (stored?.refreshToken) {
+    try {
+      await fetch(`${config.cognitoDomain}/oauth2/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: stored.refreshToken,
+          client_id: config.cognitoClientId,
+        }),
+      });
+    } catch {
+      // revoke endpoint 失敗は production session 残留にしかつながらない (= 致命的でない)
+      // ので silently 続ける。 logout redirect で Cognito cookie は消える。
+    }
+  }
+  // (2) local 側 token を確実に破棄
+  clearTokens();
+  // (3) Hosted UI cookie を破棄するため `/logout` に redirect。 logout_uri は
+  //     UserPoolClient の `Allowed sign-out URLs` に含まれている origin に揃える。
+  const logoutUrl = new URL(`${config.cognitoDomain}/logout`);
+  logoutUrl.searchParams.set("client_id", config.cognitoClientId);
+  // redirectUri の origin + "/login" を logout 後の戻り先にする (= 既存 PKCE callback
+  // と同 origin、 UserPoolClient の sign-out URL 設定と整合)。
+  const callbackOrigin = new URL(config.redirectUri).origin;
+  logoutUrl.searchParams.set("logout_uri", `${callbackOrigin}/login`);
+  window.location.assign(logoutUrl.toString());
+}

--- a/apps/application-admin-console/src/auth/AuthProvider.tsx
+++ b/apps/application-admin-console/src/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import type { AppConfig } from "../config";
-import { beginLogin, clearTokens, loadStoredTokens, type TokenSet } from "./cognito";
+import { beginLogin, beginLogout, loadStoredTokens, type TokenSet } from "./cognito";
 
 interface AuthState {
   tokens: TokenSet | null;
@@ -29,8 +29,11 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
         void beginLogin(config);
       },
       logout: () => {
-        clearTokens();
+        // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
+        // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
+        // で Cognito 側 cookie が残り silent re-login していた)。
         setTokensState(null);
+        void beginLogout(config);
       },
       setTokens: (t) => setTokensState(t),
     }),

--- a/apps/application-admin-console/src/auth/cognito.test.ts
+++ b/apps/application-admin-console/src/auth/cognito.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../config";
+import { beginLogout } from "./cognito";
+
+/**
+ * Issue #833: サインアウト時に Cognito Hosted UI session が revoke されず、
+ * 再 sign-in で Cognito を経由せず画面に入れてしまう問題の回帰防止テスト。
+ */
+
+const TOKENS_KEY = "TenkaCloud.tokens";
+
+const CONFIG: AppConfig = {
+  cognitoDomain: "https://tenant-domain.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "tenant-client",
+  redirectUri: "https://app.example.com/callback",
+  scope: "openid email profile",
+  tenantId: "01HZZ",
+  tenantName: "Acme",
+  apiBaseUrl: "https://api.example.com",
+};
+
+function storeTokens(refreshToken: string | undefined) {
+  sessionStorage.setItem(
+    TOKENS_KEY,
+    JSON.stringify({
+      idToken: "id.jwt",
+      accessToken: "access.jwt",
+      refreshToken,
+      expiresAt: Date.now() + 60_000,
+    }),
+  );
+}
+
+describe("beginLogout (Issue #833)", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let assignSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refresh token を /oauth2/revoke に POST してから sessionStorage を clear すべき", async () => {
+    storeTokens("refresh.jwt");
+
+    await beginLogout(CONFIG);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(`${CONFIG.cognitoDomain}/oauth2/revoke`);
+    expect(init?.method).toBe("POST");
+    const body = init?.body as URLSearchParams;
+    expect(body.get("token")).toBe("refresh.jwt");
+    expect(body.get("client_id")).toBe(CONFIG.cognitoClientId);
+    expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
+  });
+
+  it("refresh token が無いときは /oauth2/revoke を呼ばずに redirect すべき", async () => {
+    storeTokens(undefined);
+
+    await beginLogout(CONFIG);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("/logout に client_id と logout_uri を付けて redirect すべき", async () => {
+    storeTokens("refresh.jwt");
+
+    await beginLogout(CONFIG);
+
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    const redirectedTo = new URL(assignSpy.mock.calls[0][0] as string);
+    expect(redirectedTo.origin + redirectedTo.pathname).toBe(`${CONFIG.cognitoDomain}/logout`);
+    expect(redirectedTo.searchParams.get("client_id")).toBe(CONFIG.cognitoClientId);
+    expect(redirectedTo.searchParams.get("logout_uri")).toBe("https://app.example.com/login");
+  });
+
+  it("/oauth2/revoke が失敗しても redirect は実行されるべき (= revoke failure で sign-out が止まらない)", async () => {
+    storeTokens("refresh.jwt");
+    fetchSpy.mockRejectedValueOnce(new Error("network down"));
+
+    await beginLogout(CONFIG);
+
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
+  });
+});

--- a/apps/application-admin-console/src/auth/cognito.ts
+++ b/apps/application-admin-console/src/auth/cognito.ts
@@ -110,3 +110,50 @@ export function clearTokens(): void {
   sessionStorage.removeItem(VERIFIER_KEY);
   sessionStorage.removeItem(STATE_KEY);
 }
+
+/**
+ * Issue #833: Cognito Hosted UI session (= cookie) を revoke してから redirect する。
+ *
+ * 旧 logout は `clearTokens()` (= sessionStorage) のみで、 Cognito 側の session cookie
+ * は browser に残ったまま。 次に `beginLogin` で /oauth2/authorize に redirect すると、
+ * Cognito が既存 cookie で silent re-login させ、 Hosted UI を経由せずに画面に戻って
+ * しまっていた。
+ *
+ * 修正:
+ *   1. refresh token があれば `/oauth2/revoke` で server-side revoke
+ *   2. sessionStorage を clearTokens
+ *   3. `/logout?client_id=...&logout_uri=...` に redirect し Cognito cookie を破棄
+ *
+ * `logout_uri` は UserPoolClient の sign-out URLs に登録されている origin に
+ * redirect する (= 多くの環境で `<redirectUri origin>/login` を登録済)。
+ */
+export async function beginLogout(config: AppConfig): Promise<void> {
+  // (1) refresh token の server-side revoke (= best-effort、 失敗しても続行)
+  const stored = loadStoredTokens();
+  if (stored?.refreshToken) {
+    try {
+      await fetch(`${config.cognitoDomain}/oauth2/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: stored.refreshToken,
+          client_id: config.cognitoClientId,
+        }),
+      });
+    } catch {
+      // revoke endpoint 失敗は production session 残留にしかつながらない (= 致命的でない)
+      // ので silently 続ける。 logout redirect で Cognito cookie は消える。
+    }
+  }
+  // (2) local 側 token を確実に破棄
+  clearTokens();
+  // (3) Hosted UI cookie を破棄するため `/logout` に redirect。 logout_uri は
+  //     UserPoolClient の `Allowed sign-out URLs` に含まれている origin に揃える。
+  const logoutUrl = new URL(`${config.cognitoDomain}/logout`);
+  logoutUrl.searchParams.set("client_id", config.cognitoClientId);
+  // redirectUri の origin + "/login" を logout 後の戻り先にする (= 既存 PKCE callback
+  // と同 origin、 UserPoolClient の sign-out URL 設定と整合)。
+  const callbackOrigin = new URL(config.redirectUri).origin;
+  logoutUrl.searchParams.set("logout_uri", `${callbackOrigin}/login`);
+  window.location.assign(logoutUrl.toString());
+}


### PR DESCRIPTION
## Summary

- `admin-console` / `application-admin-console` の sign-out が **local sessionStorage の clear のみ** で Cognito 側 session cookie / refresh token を残していた。 再 sign-in 時に `/oauth2/authorize` が既存 cookie で silent re-login させ、 Hosted UI を経由せず画面に入れていた (Issue #833)。
- `beginLogout(config)` を新規追加し、 (1) refresh token を `/oauth2/revoke` で server-side revoke → (2) sessionStorage を clear → (3) `/logout?client_id=...&logout_uri=<origin>/login` に redirect する。 これで Cognito Hosted UI cookie が破棄される。
- 両 SPA に同実装を入れ、 4 件ずつのテストで挙動を pin。

## Test plan

- [x] `make harness` — invariant 違反 0
- [x] `make before-commit` — lint / typecheck / test / validate-problems すべて green
- [x] 新規 unit test `apps/admin-console/src/auth/cognito.test.ts` (4 cases) green
- [x] 新規 unit test `apps/application-admin-console/src/auth/cognito.test.ts` (4 cases) green
- [ ] 手動: deploy 後に "サインアウト" → 再 sign-in で必ず Cognito Hosted UI が出ること
- [ ] 手動: 別 tab で同じ session を開いていても refresh token revoke 後に使えないこと

## Regression 分析

- 既存 `clearTokens()` は内部 helper として残置 (= `beginLogout` 内部 / `completeLogin` callback / token expiry path から呼ばれる)。 export も維持しているので外部 import の breakage 無し。
- `logout()` の挙動が「sessionStorage clear → 同画面に留まる」から「sessionStorage clear → Cognito `/logout` に redirect」に変わる。 redirect 先 (`<redirectUri origin>/login`) は両 SPA で既に Cognito UserPoolClient の `Allowed sign-out URLs` に登録済みなので production / dev とも追加 deploy 不要。
- `/oauth2/revoke` が失敗しても (network / endpoint 障害) `/logout` redirect は実行される (= sign-out が止まらない)。 best-effort セマンティクスをテストで pin。
- `participant-portal` は teamLoginKey 経路 (= OAuth ではない) なので Cognito 由来の revoke は不要。 既存 `clearSession()` が localStorage を確実に clear しており影響なし。

## 物理影響

- `apps/admin-console/dist/*` — NO-OP for CFn、 SPA バンドル内のロジック変更のみ (S3 sync で新 dist が反映)
- `apps/application-admin-console/dist/*` — 同上
- インフラ (CDK / Cognito UserPoolClient / IAM) — NO-OP

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logout flow to fully clear Cognito sessions server-side, ensuring complete session termination across all admin consoles.

* **Tests**
  * Added comprehensive test coverage for updated logout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/841)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->