### PR TITLE
fix(cleanup): delete orphan ExternalId SSM parameters on destroy

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -151,6 +151,27 @@ for orphan_lg in "/aws/vendedlogs/states/StepFunctionLogging"; do
   fi
 done
 
+# SSM Parameter Store の per-tenant ExternalId (= `/{env}/tenants/{tenantId}/external-id`)
+# は competitor-accounts handler が runtime で `PutParameterCommand` で書き込む (= CFn 管理外)
+# ため `cdk destroy` で消えない (= make destroy 後にも SecureString が残骸として残る)。
+# orphan API key と同じ pattern で env scope (`/${ENV}/tenants/`) を走査し削除する。
+# 対象は SecureString だが describe-parameters は `Type=SecureString` 自体を返さない
+# ので filter は不要、 命名規約 (`ends_with(Name, '/external-id')`) で同定する。
+log "scanning for orphan SSM parameters (per-tenant ExternalId SecureStrings)..."
+ORPHAN_PARAMS=$(aws ssm describe-parameters \
+  --parameter-filters "Key=Name,Option=BeginsWith,Values=/${ENV}/tenants/" \
+  --query "Parameters[?ends_with(Name, '/external-id')].Name" \
+  --output text 2>/dev/null || true)
+if [ -n "${ORPHAN_PARAMS}" ]; then
+  for param_name in ${ORPHAN_PARAMS}; do
+    log "  deleting orphan SSM parameter ${param_name}"
+    aws ssm delete-parameter --name "${param_name}" 2>/dev/null \
+      || log "    skip (already gone or in-use)"
+  done
+else
+  log "  no orphan SSM parameters found"
+fi
+
 log "scanning for orphan API Keys (server-Basic / Stand / Premi / Plati or tenkacloud-* tier keys)..."
 ORPHAN_KEY_IDS=$(aws apigateway get-api-keys --query \
   "items[?starts_with(name, 'server-Basic-') || starts_with(name, 'server-Stand-') || starts_with(name, 'server-Premi-') || starts_with(name, 'server-Plati-') || contains(name, '-basic-tier-key-') || contains(name, '-standard-tier-key-') || contains(name, '-premium-tier-key-') || contains(name, '-platinum-tier-key-')].id" \


### PR DESCRIPTION
## Summary

- `make destroy` 後にも SSM Parameter Store 上で `/{env}/tenants/{tenantId}/external-id` (SecureString) が残ったままだった。
- 原因: `competitor-accounts` handler が runtime で `PutParameterCommand` を使ってこのパラメータを直接書き込む (= CFn 管理外)。 `cdk destroy --all` は CFn stack 内のリソースしか消さないので、 ハンドラが SDK 経由で作った SSM パラメータは to orphan のまま残る。
- 既存の orphan API Key / LogGroup 掃除と同じ pattern で `aws ssm describe-parameters --parameter-filters Key=Name,Option=BeginsWith,Values=/${ENV}/tenants/` を走査し、 `ends_with(Name, '/external-id')` で同定して `aws ssm delete-parameter` で削除する。 idempotent (= 不在 / delete 失敗時は log だけ出して続行)。

## 物理影響

- `scripts/cleanup.sh` — UPDATE (21 行追加)。 destroy フローに SSM スキャン + delete を追加。
- ランタイム / インフラ — NO-OP (= スクリプト追記のみ、 deploy 経路には触らない)
- 既存 deploy 環境 — 次回 `make destroy` 実行時に orphan SecureString が削除される

## Regression 分析

- スキャンスコープを `/\${ENV}/tenants/` BeginsWith に絞っているので、 他用途 (`/cdk-bootstrap/...`、 third-party project の SSM パラメータ等) は touch しない。
- `ends_with(Name, '/external-id')` で path 末端を確認するので、 偶然 `/development/tenants/...` 配下に別目的のパラメータが入っていても巻き込まない (= 命名規約は `external-id-store.ts` で唯一 `/external-id` だけ)。
- delete 失敗時 (`in-use` / IAM 不足) は `log "skip"` でスクリプト全体は続行する。 partial cleanup でも他の orphan 掃除 (API Key 等) は走る。

## Test plan

- [x] `make harness` — invariant 違反 0
- [x] `make before-commit` — lint / typecheck / test / validate-problems すべて green
- [x] `shellcheck scripts/cleanup.sh` — 既存 warnings のみ、 新規追加なし
- [ ] 手動: `make destroy ENV=development` 後に `aws ssm describe-parameters --parameter-filters Key=Name,Option=BeginsWith,Values=/development/tenants/` が空であること
- [ ] 手動: 全 SSM 削除済みの状態で `make destroy` を再実行しても error にならないこと (= 冪等性確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)