### PR TITLE
fix(auth): drop unknown-tenant silent fallback (#843)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,11 @@ Battle (リアルタイム対戦) と Challenge (個別演習) の問題を、 �
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Built with CDK](https://img.shields.io/badge/Built%20with-AWS%20CDK-orange)](https://aws.amazon.com/cdk/)
 [![SBT](https://img.shields.io/badge/SBT-0.3.9-blue)](https://github.com/awslabs/sbt-aws)
+![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/susumutomita/TenkaCloud)
+![GitHub top language](https://img.shields.io/github/languages/top/susumutomita/TenkaCloud)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/susumutomita/TenkaCloud)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/susumutomita/TenkaCloud)
+![GitHub repo size](https://img.shields.io/github/repo-size/susumutomita/TenkaCloud)
 
 🌐 [English](./README.md) · [日本語](./README.ja.md)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Battle (real-time) and Challenge (self-paced) problems deployed straight to each
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Built with CDK](https://img.shields.io/badge/Built%20with-AWS%20CDK-orange)](https://aws.amazon.com/cdk/)
 [![SBT](https://img.shields.io/badge/SBT-0.3.9-blue)](https://github.com/awslabs/sbt-aws)
+![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/susumutomita/TenkaCloud)
+![GitHub top language](https://img.shields.io/github/languages/top/susumutomita/TenkaCloud)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/susumutomita/TenkaCloud)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/susumutomita/TenkaCloud)
+![GitHub repo size](https://img.shields.io/github/repo-size/susumutomita/TenkaCloud)
 
 🌐 [English](./README.md) · [日本語](./README.ja.md)
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -13,19 +13,22 @@ export function extractTenantIdFromClaims(claims: JwtClaims | undefined): string
 }
 
 /**
- * Issue #686 (revisit): 旧 fail-closed (= JWT claim 欠落で `MissingTenantClaimError` throw)
- * は Cognito UserPoolClient の readAttributes 設定漏れで `custom:tenantId` が id_token に
- * 載らない既存 tenant に対し GET /events が全部 500 になる regression を引き起こした
- * (PR-697 deploy 後の事故報告)。
+ * Issue #843: JWT に `custom:tenantId` が無く `DEFAULT_TENANT_ID` env も無い request は
+ * 401 で **fail-closed**。 旧 silent fallback (`"unknown-tenant"` 文字列) は SSM /
+ * DDB / EventBridge に bogus 行を量産する原因だったため削除した。
  *
- * 暫定 rollback: silent fallback `"unknown-tenant"` に戻す。 別途、
- *  (a) tenant-template/identity-provider.ts の UserPoolClient `readAttributes` に
- *      `custom:tenantId` を明示追加 (= JWT に確実に乗せる)
- *  (b) frontend が `tenantId === "unknown-tenant"` を 「(自動検出中)」 で表示する band-aid
- * の 2 経路で正解に近づける (= 別 PR)。
+ * 旧 fail-closed を一旦 rollback した理由 (Cognito UserPoolClient `readAttributes` に
+ * `custom:tenantId` が無く id_token に claim が載らなかった既存 tenant の regression、
+ * PR-697 rollback) は Issue #686 で解消済み:
+ *  - `tenant-template/identity-provider.ts` の `readAttributes` が `custom:tenantId`
+ *    `userRole` / `apiKey` / `tenantTier` / `tenantName` を明示 (= JWT に確実に乗る)
+ *  - `provision-tenant.sh` が `admin-create-user` 時に `custom:tenantId` を必ず set
+ *  - 3 handler (deploy / event / competitor-accounts) の `onError` で
+ *    `MissingTenantClaimError` → 401 `missing_tenant_claim` を返す配線が完備
  *
- * `MissingTenantClaimError` class は handler 側 onError 配線が既に残っているため、
- * type 互換のために残置 (= 将来 fail-closed 復帰時に再利用可能)。
+ * `DEFAULT_TENANT_ID` env は test 環境 (= `app.request()` で JWT を bypass する unit
+ * test) と TenkaCloud Lite の dev override 用にのみ残す。 prod では env を渡さない
+ * ので、 JWT claim 欠落は **必ず** 401 になる。
  */
 export class MissingTenantClaimError extends Error {
   constructor() {
@@ -36,14 +39,14 @@ export class MissingTenantClaimError extends Error {
   }
 }
 
-const FALLBACK_TENANT_ID = "unknown-tenant";
-
 export function resolveTenantId(c: Context): string {
   const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
   const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
   const fromJwt = extractTenantIdFromClaims(claims);
   if (fromJwt) return fromJwt;
-  return process.env.DEFAULT_TENANT_ID ?? FALLBACK_TENANT_ID;
+  const fromEnv = process.env.DEFAULT_TENANT_ID;
+  if (fromEnv) return fromEnv;
+  throw new MissingTenantClaimError();
 }
 
 /**

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -300,7 +300,7 @@ describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id", () 
       expect(parsed.event).toBe("competitor-accounts.rotate");
       expect(parsed.awsAccountId).toBe("222222222222");
       expect(parsed.rotatedAt).toBe("2026-05-12T00:00:00.000Z");
-      // tenantId / rotatedBy は test 環境では JWT 解決 fallback (= "unknown-tenant" / "unknown") を取る。
+      // tenantId は test の `DEFAULT_TENANT_ID` env (= "tenant-test")、 rotatedBy は JWT 不在で "unknown" fallback。
       expect(typeof parsed.tenantId).toBe("string");
       expect(typeof parsed.rotatedBy).toBe("string");
     } finally {

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   extractTenantIdFromClaims,
+  MissingTenantClaimError,
   resolveTenantId,
 } from "../../lib/problem-deploy/handlers/deploy-handler/auth";
 
@@ -63,10 +64,10 @@ describe("resolveTenantId", () => {
     expect(resolveTenantId(c)).toBe("tenant-from-env");
   });
 
-  it("env も無ければ unknown-tenant に倒すべき (= silent fallback、 PR-697 rollback)", () => {
+  it("env も無ければ MissingTenantClaimError を throw すべき (= Issue #843 fail-closed)", () => {
     delete process.env.DEFAULT_TENANT_ID;
     const c = buildCtx();
-    expect(resolveTenantId(c)).toBe("unknown-tenant");
+    expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
   });
 
   it("requestContext が存在しない (Function URL ops 経路) なら env にフォールバック", () => {


### PR DESCRIPTION
## Summary

- `resolveTenantId` の silent fallback (`FALLBACK_TENANT_ID = "unknown-tenant"`) を削除して **fail-closed** に戻す。 JWT `custom:tenantId` claim も `DEFAULT_TENANT_ID` env も無い場合は `MissingTenantClaimError` を throw、 3 handler の onError 配線で 401 `missing_tenant_claim` が返る (= 既存配線、 追加不要)。
- 副次として README.ja.md に repo activity / 言語 / size バッジを追加 (= 別 commit、 同 PR にまとめて取り込み)。

## Why this is safe now

旧 fail-closed を rollback した理由 (Cognito UserPoolClient `readAttributes` に `custom:tenantId` が無く既存 tenant の id_token に claim が載らない PR-697 regression) は Issue #686 で完全 fix 済み:

- `infrastructure/lib/tenant-template/identity-provider.ts:239-244` — `readAttributes` に `custom:tenantId` / `userRole` / `apiKey` / `tenantTier` / `tenantName` を明示
- `scripts/provision-tenant.sh:99` — `admin-create-user` 時に `custom:tenantId` を必ず set
- `infrastructure/lib/problem-deploy/handlers/{deploy,event,competitor-accounts}-handler/index.ts` — `app.onError` で `MissingTenantClaimError` → 401 `missing_tenant_claim`

つまり今は **コードの 1 定数 (`FALLBACK_TENANT_ID`) だけが、 古い band-aid の残骸として残っていた**。 これを除去すれば SSM / DDB / EventBridge に bogus `tenantId="unknown-tenant"` 行が書き込まれることが無くなる。

## Test plan

- [x] `make harness` — invariant 違反 0
- [x] `make before-commit` — lint / typecheck / test / validate-problems すべて green (= 934 tests)
- [x] `deploy-auth.test.ts` の "env も無ければ unknown-tenant に倒すべき" を "MissingTenantClaimError を throw すべき" に flip
- [ ] 手動: tenant-admin で sign-in → `GET /admin/competitor-accounts` が 200 を返す (= JWT claim 経路が壊れない)
- [ ] 手動: JWT 無しで `POST /admin/competitor-accounts` を叩くと 401 `missing_tenant_claim` が返る (= 旧 path で `unknown-tenant` が SSM に書かれない)

## Regression 分析

- `DEFAULT_TENANT_ID` env は **test (= `app.request()` で JWT bypass) と TenkaCloud Lite の dev override 用** に残す。 `event-api-lambda.ts:82` / `deploy-api-lambda.ts:80` は `props.defaultTenantId` が渡されたときだけ env を注入する spread 形式で、 prod では undefined。 prod 経路は env 無し → fail-closed が必ず発火。
- `competitor-accounts-routes.test.ts` / `deploy-handler-routes.test.ts` などの route テストは `beforeAll` で `DEFAULT_TENANT_ID = "tenant-test"` を入れているので、 throw に振り替わらず従来通り通る。
- `competitor-accounts-routes.test.ts:303` の stale コメント (= "test 環境では unknown-tenant fallback") を修正。
- prod で `unknown-tenant` 文字列に依存する code path / 監視 alert は無い (`grep "unknown-tenant"` 結果は本 PR 削除箇所 + 削除済 test 1 行のみ)。

## 物理影響

- `infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts` — UPDATE (`FALLBACK_TENANT_ID` 削除 + `resolveTenantId` を fail-closed 化、 docblock 更新)
- `infrastructure/test/problem-deploy/deploy-auth.test.ts` — UPDATE (`unknown-tenant` 期待を `toThrow(MissingTenantClaimError)` に flip + import 追加)
- `infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts` — UPDATE (stale コメント修正のみ、 assertion 変化なし)
- `README.ja.md` — UPDATE (バッジ 5 個追加、 別 commit)
- インフラ (CDK / Lambda env) — NO-OP (= スキーマ / IAM / Lambda 環境変数の差分なし)

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request validation to return 401 errors when tenant claims are missing or no default tenant is configured, replacing previous silent fallback behavior

* **Tests**
  * Updated test coverage to verify new validation behavior for missing tenant claims

* **Documentation**
  * Added GitHub Shields badges to README displaying repository metrics
  * Enhanced internal documentation on tenant claim handling logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->