### PR TITLE
fix(EventCreate): friendly 401 message for verified accounts dropdown (#815)

### DIFF
--- a/apps/application-admin-console/src/lib/competitor-accounts-filter.test.ts
+++ b/apps/application-admin-console/src/lib/competitor-accounts-filter.test.ts
@@ -1,0 +1,78 @@
+import { StatusCodes } from "http-status-codes";
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../api/client";
+import {
+  filterVerifiedAccounts,
+  formatCompetitorAccountsLoadError,
+} from "./competitor-accounts-filter";
+
+describe("filterVerifiedAccounts (Issue #671)", () => {
+  it("null は空配列を返すべき", () => {
+    expect(filterVerifiedAccounts(null)).toEqual([]);
+  });
+
+  it("verified=true のみ通すべき", () => {
+    const accounts = [
+      {
+        awsAccountId: "111111111111",
+        region: "ap-northeast-1",
+        competitorRoleName: "Role",
+        verified: true,
+        createdAt: "",
+        updatedAt: "",
+      },
+      {
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "Role",
+        verified: false,
+        createdAt: "",
+        updatedAt: "",
+      },
+    ];
+    expect(filterVerifiedAccounts(accounts).map((a) => a.awsAccountId)).toEqual(["111111111111"]);
+  });
+
+  it('verified が string "true" / number 1 の truthy 値も通すべき (= ABI 揺れ対策)', () => {
+    const accounts = [
+      {
+        awsAccountId: "111111111111",
+        region: "ap-northeast-1",
+        competitorRoleName: "Role",
+        verified: "true" as unknown as boolean,
+        createdAt: "",
+        updatedAt: "",
+      },
+      {
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "Role",
+        verified: 1 as unknown as boolean,
+        createdAt: "",
+        updatedAt: "",
+      },
+    ];
+    expect(filterVerifiedAccounts(accounts).length).toBe(2);
+  });
+});
+
+describe("formatCompetitorAccountsLoadError (Issue #815)", () => {
+  it("ApiError 401 は friendly 再ログインメッセージに flip すべき", () => {
+    const msg = formatCompetitorAccountsLoadError(
+      new ApiError(StatusCodes.UNAUTHORIZED, "missing_tenant_claim"),
+    );
+    expect(msg).toMatch(/再ログイン/);
+  });
+
+  it("ApiError 500 等の他 status は raw message を返すべき (= dev debug)", () => {
+    const msg = formatCompetitorAccountsLoadError(
+      new ApiError(StatusCodes.INTERNAL_SERVER_ERROR, "DynamoDB throttle"),
+    );
+    expect(msg).toContain("DynamoDB throttle");
+  });
+
+  it("Error 以外 (= 文字列 / null 等) は String() で safe stringify すべき", () => {
+    expect(formatCompetitorAccountsLoadError("plain string")).toBe("plain string");
+    expect(formatCompetitorAccountsLoadError(null)).toBe("null");
+  });
+});

--- a/apps/application-admin-console/src/lib/competitor-accounts-filter.ts
+++ b/apps/application-admin-console/src/lib/competitor-accounts-filter.ts
@@ -1,3 +1,5 @@
+import { StatusCodes } from "http-status-codes";
+import { ApiError } from "../api/client";
 import type { CompetitorAccountSummary } from "../api/competitor-accounts-client";
 
 /**
@@ -12,4 +14,20 @@ export function filterVerifiedAccounts(
 ): readonly CompetitorAccountSummary[] {
   if (!accounts) return [];
   return accounts.filter((a) => Boolean(a.verified));
+}
+
+/**
+ * Issue #815: EventCreate / CompetitorAccounts ページの `listCompetitorAccounts`
+ * 失敗時に operator が次の一手を判断しやすい文言を返す。
+ *
+ * - 401 (= JWT claim 不在 / token 失効) → 「再ログインしてください」 (= PR-#844 で
+ *   `unknown-tenant` silent fallback が消えたので、 claim 欠落 token は **必ず 401**)
+ * - その他 → raw message を出す (= 開発時のデバッグに必要、 backend message 抑制は別 Issue)
+ */
+export function formatCompetitorAccountsLoadError(err: unknown): string {
+  if (err instanceof ApiError && err.status === StatusCodes.UNAUTHORIZED) {
+    return "セッションが切れているか、 JWT に tenantId claim がありません。 サインアウトして再ログインしてください (= 再ログイン後も再現するときは System Admin に連絡)。";
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
 }

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -23,7 +23,10 @@ import { createEvent } from "../api/events-client";
 import type { AppConfig } from "../config";
 import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
 import { listProblemSummaries } from "../data/problems";
-import { filterVerifiedAccounts } from "../lib/competitor-accounts-filter";
+import {
+  filterVerifiedAccounts,
+  formatCompetitorAccountsLoadError,
+} from "../lib/competitor-accounts-filter";
 
 const NAME_MAX = 120;
 // MUST match infrastructure/lib/problem-deploy/handlers/event-handler/types.ts (zod schema)。
@@ -112,7 +115,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
       const res = await listCompetitorAccounts(apiClient as ApiClient);
       setCompetitorAccounts(res.items);
     } catch (err) {
-      setAccountsLoadError(err instanceof Error ? err.message : String(err));
+      // Issue #815: 401 は friendly な「再ログインしてください」 に flip。 silent 空配列で
+      // operator が次の一手を見失う UX を防ぐ (= 旧 unknown-tenant fallback の置き換え)。
+      setAccountsLoadError(formatCompetitorAccountsLoadError(err));
     } finally {
       setAccountsLoading(false);
     }


### PR DESCRIPTION
## Summary

- 旧 \`unknown-tenant\` silent fallback が PR-#844 で消えたので、 tenant API は JWT claim 欠落時に **必ず 401** を返す。 EventCreate dropdown は \`ApiError.message\` を raw 表示していたため 「API 401: missing_tenant_claim」 の生メッセージが出て operator が次の一手を見失っていた。
- 401 のみ 「セッションが切れているか tenantId claim がありません。 サインアウトして再ログインしてください」 に flip する helper \`formatCompetitorAccountsLoadError\` を \`competitor-accounts-filter.ts\` に追加し、 EventCreate の catch から使う。 他 status (= 500 等) は dev debug のため raw message を維持。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green
- [x] 新規 unit test (3 case): 401 → 友好文言 / 500 → raw / 非 Error → safe stringify
- [ ] 手動: tenant 用 JWT を invalidate した状態で EventCreate を開くと、 dropdown 領域に 「再ログインしてください」 alert が出る
- [ ] 手動: account 0 件のときは既存の \`showNoVerifiedAccountsHint\` が出る (= 触っていない)

## Regression 分析

- 既存 export \`filterVerifiedAccounts\` の signature / 挙動は変えていない。
- 新規 helper \`formatCompetitorAccountsLoadError\` は EventCreate のみで使う。 CompetitorAccounts ページ自体の error 表示は別 Issue で扱う (= 当面 raw message のまま、 開発時 friendly)。
- \`status === StatusCodes.UNAUTHORIZED\` の判定で \`http-status-codes\` の enum を使う (= CLAUDE.md 規約: magic number 禁止)。

## 物理影響

- \`apps/application-admin-console/src/lib/competitor-accounts-filter.ts\` — UPDATE (= helper 1 個追加)
- \`apps/application-admin-console/src/lib/competitor-accounts-filter.test.ts\` — CREATE
- \`apps/application-admin-console/src/pages/EventCreate.tsx\` — UPDATE (= catch 1 行 + import 1 行)
- インフラ — NO-OP

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)