### PR TITLE
fix(home): hide UUID tenantId from welcome, prompt re-login on missing tenantName (#830)

### DIFF
--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -27,7 +27,10 @@
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — Tenant admin console",
     "open_catalog": "Open problem catalog",
-    "welcome": "Welcome, {displayName}"
+    "welcome": "Welcome, {displayName}",
+    "welcome_fallback_name": "Tenant",
+    "tenant_name_missing_header": "Tenant name is missing from your JWT",
+    "tenant_name_missing_body": "Sign out and sign back in. If the issue persists, ask the System Admin to set the custom:tenantName attribute on your Cognito user."
   },
   "event_list": {
     "header": "Events",

--- a/apps/application-admin-console/src/i18n/locales/es.json
+++ b/apps/application-admin-console/src/i18n/locales/es.json
@@ -27,7 +27,10 @@
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — Consola de administración del tenant",
     "open_catalog": "Abrir catálogo de problemas",
-    "welcome": "Bienvenido, {displayName}"
+    "welcome": "Bienvenido, {displayName}",
+    "welcome_fallback_name": "Tenant",
+    "tenant_name_missing_header": "Falta el nombre del tenant en tu JWT",
+    "tenant_name_missing_body": "Cierre sesión y vuelva a iniciar sesión. Si el problema persiste, solicite al administrador del sistema que configure el atributo custom:tenantName en su usuario de Cognito."
   },
   "event_list": {
     "header": "Eventos",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -27,7 +27,10 @@
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — テナント管理コンソール",
     "open_catalog": "問題カタログを開く",
-    "welcome": "ようこそ、{displayName} さん"
+    "welcome": "ようこそ、{displayName} さん",
+    "welcome_fallback_name": "テナント",
+    "tenant_name_missing_header": "テナント名が JWT に含まれていません",
+    "tenant_name_missing_body": "一度サインアウトして再ログインしてください。 解消しない場合は System Admin に連絡し、 テナント名を Cognito user の custom:tenantName 属性に設定してもらってください。"
   },
   "event_list": {
     "header": "Event 一覧",

--- a/apps/application-admin-console/src/i18n/locales/zh.json
+++ b/apps/application-admin-console/src/i18n/locales/zh.json
@@ -27,7 +27,10 @@
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — 租户管理控制台",
     "open_catalog": "打开题目目录",
-    "welcome": "欢迎, {displayName}"
+    "welcome": "欢迎, {displayName}",
+    "welcome_fallback_name": "租户",
+    "tenant_name_missing_header": "JWT 中缺少租户名",
+    "tenant_name_missing_body": "请退出并重新登录。 如问题持续,请联系系统管理员,将您 Cognito 用户的 custom:tenantName 属性设置为正确的租户名。"
   },
   "event_list": {
     "header": "Event 列表",

--- a/apps/application-admin-console/src/lib/tenant-display.test.ts
+++ b/apps/application-admin-console/src/lib/tenant-display.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveTenantDisplayName } from "./tenant-display";
+
+describe("resolveTenantDisplayName (Issue #830)", () => {
+  it("custom:tenantName が非空文字列なら そのまま返すべき", () => {
+    const res = resolveTenantDisplayName({ "custom:tenantName": "Acme" });
+    expect(res).toEqual({ displayName: "Acme", fromFallback: false });
+  });
+
+  it("前後の空白は trim すべき (= Cognito attribute の trailing space 揺れ対策)", () => {
+    const res = resolveTenantDisplayName({ "custom:tenantName": "  Acme  " });
+    expect(res.displayName).toBe("Acme");
+    expect(res.fromFallback).toBe(false);
+  });
+
+  it("custom:tenantName が undefined なら displayName=null + fromFallback=true", () => {
+    const res = resolveTenantDisplayName({});
+    expect(res).toEqual({ displayName: null, fromFallback: true });
+  });
+
+  it("custom:tenantName が空文字 / 空白のみなら fromFallback=true (= UUID-like tenantId を welcome に出さない)", () => {
+    expect(resolveTenantDisplayName({ "custom:tenantName": "" })).toEqual({
+      displayName: null,
+      fromFallback: true,
+    });
+    expect(resolveTenantDisplayName({ "custom:tenantName": "   " })).toEqual({
+      displayName: null,
+      fromFallback: true,
+    });
+  });
+
+  it("claims 自体が null (= 未認証 / token decode 失敗) なら fromFallback=true", () => {
+    expect(resolveTenantDisplayName(null)).toEqual({ displayName: null, fromFallback: true });
+  });
+
+  it("UUID v4 形状の tenantId が tenantName 欠落時に welcome に漏れないこと (= 主要回帰防止)", () => {
+    const claims = {
+      "custom:tenantId": "3f01a734-9652-4065-a391-fa1b4d45ae26",
+      "custom:tenantName": undefined,
+    };
+    expect(resolveTenantDisplayName(claims).displayName).toBeNull();
+  });
+});

--- a/apps/application-admin-console/src/lib/tenant-display.ts
+++ b/apps/application-admin-console/src/lib/tenant-display.ts
@@ -1,0 +1,27 @@
+import type { IdTokenClaims } from "../auth/claims";
+
+/**
+ * Issue #830: JWT id_token から Home ヘッダ用の display name を解決する。
+ *
+ * 旧 logic は `tenantName ?? tenantId ?? "(unknown tenant)"` で、 `custom:tenantName`
+ * が無いと `custom:tenantId` (= SBT が生成する UUID v4) が welcome 文に露出して
+ * 「ようこそ、3f01a734-9652-4065-... さん」 のような UX 事故になっていた。
+ *
+ * 本 helper は **welcome 文に UUID を出さない** ことを保証する:
+ *   - tenantName があれば そのまま返す
+ *   - tenantName が空 / 未設定なら fallback (= caller が i18n 化する placeholder) を
+ *     使うことを `fromFallback: true` で伝える
+ *
+ * tenantId 自体は 「テナント情報」 panel で別途表示するので、 welcome 文側で重複
+ * 表示する必要はない (= panel に raw 値があれば operator は識別できる)。
+ */
+export function resolveTenantDisplayName(claims: IdTokenClaims | null): {
+  readonly displayName: string | null;
+  readonly fromFallback: boolean;
+} {
+  const tenantName = claims?.["custom:tenantName"]?.trim();
+  if (tenantName && tenantName.length > 0) {
+    return { displayName: tenantName, fromFallback: false };
+  }
+  return { displayName: null, fromFallback: true };
+}

--- a/apps/application-admin-console/src/pages/Home.tsx
+++ b/apps/application-admin-console/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import Alert from "@cloudscape-design/components/alert";
 import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
@@ -11,6 +12,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { decodeIdToken } from "../auth/claims";
 import { listProblemSummaries } from "../data/problems";
 import { useT } from "../i18n";
+import { resolveTenantDisplayName } from "../lib/tenant-display";
 
 // #542: 初回 operator 向けの onboarding section を dismiss 可能にするための localStorage key。
 // 2 回目以降の visit では「次のアクション」 section を出さず、画面上半分を進行中 Event 一覧
@@ -56,7 +58,11 @@ export function HomePage() {
   const tenantId = claims?.["custom:tenantId"];
   const tenantTier = claims?.["custom:tenantTier"];
   // Issue #831: userEmail は TopNav 右上に移動済。 Home page で参照しない。
-  const displayName = tenantName ?? tenantId ?? "(unknown tenant)";
+  // Issue #830: welcome 文に UUID を出さない。 tenantName が無いときは fallback (= "テナント")
+  // を使い、 raw tenantId は 「テナント情報」 panel 側でのみ表示する。
+  const { displayName: resolvedName, fromFallback: tenantNameMissing } =
+    resolveTenantDisplayName(claims);
+  const displayName = resolvedName ?? t("home.welcome_fallback_name");
 
   const problems = listProblemSummaries();
   const totalCount = problems.length;
@@ -79,6 +85,12 @@ export function HomePage() {
       >
         {t("home.welcome", { displayName })}
       </Header>
+
+      {tenantNameMissing && (
+        <Alert type="warning" header={t("home.tenant_name_missing_header")}>
+          {t("home.tenant_name_missing_body")}
+        </Alert>
+      )}
 
       <Container header={<Header variant="h2">問題カタログ</Header>}>
         <ColumnLayout columns={4} variant="text-grid">

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -82,16 +82,20 @@ describe("App", () => {
       ).toBeInTheDocument();
     });
 
-    it("custom:tenantName が無いときは custom:tenantId に fallback するべき", async () => {
+    it("custom:tenantName が無いときは fallback プレースホルダ (= UUID-like tenantId を welcome に出さない、 Issue #830)", async () => {
       loginAs({
         email: "admin@example.com",
-        "custom:tenantId": "t-acme",
+        "custom:tenantId": "3f01a734-9652-4065-a391-fa1b4d45ae26",
         "custom:tenantTier": "BASIC",
       });
       renderApp("/");
+      // welcome 文に UUID が漏れず、 fallback (= "テナント") に倒れる
       expect(
-        await screen.findByRole("heading", { level: 1, name: /t-acme さん/ }),
+        await screen.findByRole("heading", { level: 1, name: /テナント さん/ }),
       ).toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /3f01a734/ })).toBeNull();
+      // tenantName 欠落の Alert が表示される (= operator に再ログインを促す)
+      expect(screen.getByText(/テナント名が JWT に含まれていません/)).toBeInTheDocument();
     });
 
     it("config.tenantName の placeholder ('Shared Pooled Tenant') を画面に出してはいけない", async () => {


### PR DESCRIPTION
## Summary

- Home の welcome 文が \`tenantName ?? tenantId ?? "(unknown tenant)"\` で fallback していたため、 SBT が発行する UUID v4 形式の tenantId が welcome 文 (= 「ようこそ、 3f01a734-9652-4065-a391-fa1b4d45ae26 さん」) に表面化していた。
- \`resolveTenantDisplayName(claims)\` helper を新規 \`lib/tenant-display.ts\` に切り出し、 tenantName が無い場合は \`displayName=null + fromFallback=true\` を返す。 Home.tsx は welcome に i18n placeholder ("テナント" / "Tenant" / "租户") を出し、 raw UUID を漏らさない。
- \`fromFallback=true\` のときは Alert で "テナント名が JWT に含まれていません。 一度サインアウトして再ログインしてください。" を表示し、 operator を回復経路に誘導する。 4 言語の locale に文言追加。
- tenantId 自体は 「テナント情報」 panel で従来通り表示 (= 識別用途は維持)。

## Why is this the right fix layer

infra 側 (readAttributes / provision-tenant.sh) は Issue #748 で既に \`custom:tenantName\` を取り込み済:

- \`infrastructure/lib/tenant-template/identity-provider.ts:244\` — readAttributes に \`tenantName\` 含む
- \`scripts/provision-tenant.sh:99\` — admin-create-user で \`custom:tenantName\` を set
- 同 script 行 86-94 — 既存 user は \`admin-update-user-attributes\` で backfill

つまり 「fresh user は正しく tenantName を持つ」 「pre-#748 既存 user は再 provisioning + サインアウト/サインインで claim 更新」 の状態。 残った欠陥は frontend が 「JWT に claim が無い」 状況で UUID を fallback として表示してしまうこと。 本 PR は **その frontend の degraded display を直す** ことに閉じる。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green (= 205 tests)
- [x] 新規 \`tenant-display.test.ts\` (6 cases): 正常 / trim / undefined / 空文字 / claims=null / UUID 漏れ防止 (= 主要回帰防止)
- [x] 既存 \`App.test.tsx\` の "tenantName が無いときは tenantId に fallback" テストを新仕様に flip
- [ ] 手動: tenant admin で sign-in (tenantName set 済) → 「ようこそ、{tenantName} さん」 が出る
- [ ] 手動: tenantName 欠落の user で sign-in → 「ようこそ、テナント さん」 + 警告 Alert が出る、 UUID は welcome に出ない
- [ ] 手動: 4 言語 (ja / en / es / zh) で fallback 文言が翻訳されている

## Regression 分析

- 既存 user で \`custom:tenantName\` が正しく入っている経路は **挙動変化なし** (= welcome 文に そのまま tenantName を出す path はそのまま)。
- 既存 user で \`custom:tenantName\` が無い経路は: UUID が welcome に出る → fallback テキスト + 警告 Alert に変わる。 backward-incompat だが UX 改善。
- 「テナント情報」 panel の \`KeyValue "テナント名"\` は触っていない (= 旧来通り \`tenantName ?? "(未設定)"\`)。
- i18n: 4 言語すべてに 3 keys (\`welcome_fallback_name\` / \`tenant_name_missing_header\` / \`tenant_name_missing_body\`) を同時追加。 \`home\` namespace の key set 整合性テスト (= App.test.tsx 系) を破らない。

## 物理影響

- \`apps/application-admin-console/src/lib/tenant-display.ts\` — CREATE
- \`apps/application-admin-console/src/lib/tenant-display.test.ts\` — CREATE
- \`apps/application-admin-console/src/pages/Home.tsx\` — UPDATE (import + welcome / Alert wiring)
- \`apps/application-admin-console/src/i18n/locales/{ja,en,es,zh}.json\` — UPDATE (= 3 keys × 4 言語追加)
- \`apps/application-admin-console/test/App.test.tsx\` — UPDATE (fallback test を新仕様に)
- インフラ / backend — NO-OP

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)