### PR TITLE
fix(reconciler): rescue stuck DELETING deployments so Event TEARDOWN → ARCHIVED (#828)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
@@ -49,11 +49,61 @@ export interface ReconcileEventStatusesContext {
   readonly deploymentsTableName: string;
 }
 
-async function queryDeploymentStatusesForEvent(
+/**
+ * Issue #828: DELETING のまま 30 分以上停滞している deployment 行を 「stuck」 とみなして
+ * reconciler が FAILED に倒すための閾値。 30 分は CodeBuild + CFn DeleteStack の最遅成功
+ * パス (= CloudFront / Route53 等の slow-delete + retry) より長く取った余裕値。
+ *
+ * 想定する stuck の原因:
+ *   - bulk-delete が `status=DELETING` を書いた後、 publish chunk が失敗 (= EventBridge
+ *     PutEvents が partial fail) して State Machine が起動しなかった
+ *   - State Machine が起動したが Mark{Deleted,Failed} に到達せずに timeout (= 60 min 上限)
+ *   - 競技者が AWS Console で stack を手動削除 → CFn DeleteStack が "stack does not exist"
+ *     で 404 → State Machine の catch path が走らず、 silent に放置 (= 既知 issue B)
+ *
+ * いずれも結果として Event TEARDOWN が ARCHIVED に進まない。 本 reconciler は次 tick で
+ * 全 stuck 行を FAILED に倒し、 既存 `resolveEventStatusTransition` が FAILED を terminal
+ * 扱いするため自然に ARCHIVED に遷移する。
+ */
+const STUCK_DELETING_THRESHOLD_MS = 30 * 60 * 1000;
+
+/**
+ * Project field set for the reconciler:
+ *   - `status`: 必須 (= 既存 `resolveEventStatusTransition` の入力)
+ *   - `PK`: rescue UpdateItem を打つときに要る (= Issue #828 stuck DELETING rescue 経路)。
+ *     pre-#828 の旧 row や、 古い fixtures では projection されていない可能性があるので optional。
+ *   - `updatedAt`: stuck 判定の閾値比較 (= Issue #828)。 未設定行は rescue skip (= safe default)。
+ */
+interface DeploymentReconcilerRow {
+  readonly PK?: string;
+  readonly status: string;
+  readonly updatedAt?: string;
+}
+
+/**
+ * Issue #828: `DELETING` 行が TEARDOWN scope で stuck (= threshold 超え) か判定する pure helper。
+ * test で時刻入力を制御するため、 reconcileEventStatuses 本体と rescueStuckDeletingDeployments
+ * の両方から呼び出される。
+ */
+export function isStuckDeletingForTeardown(
+  eventStatus: string,
+  row: DeploymentReconcilerRow,
+  nowMs: number,
+  thresholdMs: number = STUCK_DELETING_THRESHOLD_MS,
+): boolean {
+  if (eventStatus !== "TEARDOWN") return false;
+  if (row.status !== "DELETING") return false;
+  if (!Number.isFinite(nowMs)) return false;
+  const updatedAtMs = row.updatedAt ? Date.parse(row.updatedAt) : Number.NaN;
+  if (!Number.isFinite(updatedAtMs)) return false;
+  return nowMs - updatedAtMs >= thresholdMs;
+}
+
+async function queryDeploymentRowsForEvent(
   ctx: ReconcileEventStatusesContext,
   event: { tenantId: string; eventId: string },
-): Promise<string[]> {
-  const statuses: string[] = [];
+): Promise<DeploymentReconcilerRow[]> {
+  const rows: DeploymentReconcilerRow[] = [];
   let exclusiveStartKey: Record<string, unknown> | undefined;
 
   do {
@@ -63,7 +113,7 @@ async function queryDeploymentStatusesForEvent(
         IndexName: "GSI1",
         KeyConditionExpression: "GSI1PK = :pk",
         FilterExpression: "eventId = :ev",
-        ProjectionExpression: "#status",
+        ProjectionExpression: "PK, #status, updatedAt",
         ExpressionAttributeNames: { "#status": "status" },
         ExpressionAttributeValues: {
           ":pk": `TENANT#${event.tenantId}`,
@@ -73,15 +123,75 @@ async function queryDeploymentStatusesForEvent(
       }),
     );
 
-    statuses.push(
-      ...(depsOut.Items ?? [])
-        .map((d) => String((d as { status?: string }).status ?? ""))
-        .filter((s) => s.length > 0),
-    );
+    for (const item of depsOut.Items ?? []) {
+      const cast = item as { PK?: string; status?: string; updatedAt?: string };
+      if (!cast.status) continue;
+      rows.push({ PK: cast.PK, status: cast.status, updatedAt: cast.updatedAt });
+    }
     exclusiveStartKey = depsOut.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
 
-  return statuses;
+  return rows;
+}
+
+/**
+ * Issue #828: `status=DELETING` 行が `STUCK_DELETING_THRESHOLD_MS` 以上更新されていなければ、
+ * conditional UpdateItem で `status=FAILED` に倒す。 race 防止のため `status=DELETING` 一致時のみ
+ * 書く (= State Machine が同時に MarkDeleted/MarkFailed したら CCF で skip)。
+ *
+ * 「rescue した行数」 を返す。 caller が log / next-tick の判断に使える。
+ */
+export async function rescueStuckDeletingDeployments(
+  ctx: ReconcileEventStatusesContext,
+  rows: readonly DeploymentReconcilerRow[],
+  nowMs: number,
+  thresholdMs: number = STUCK_DELETING_THRESHOLD_MS,
+): Promise<number> {
+  let rescued = 0;
+  await Promise.all(
+    rows.map(async (row) => {
+      if (row.status !== "DELETING") return;
+      if (!row.PK) return; // projection 漏れ (= 旧 fixture) は rescue skip
+      const updatedAtMs = row.updatedAt ? Date.parse(row.updatedAt) : Number.NaN;
+      if (!Number.isFinite(updatedAtMs)) return;
+      if (nowMs - updatedAtMs < thresholdMs) return;
+      try {
+        await ctx.ddb.send(
+          new UpdateCommand({
+            TableName: ctx.deploymentsTableName,
+            Key: { PK: row.PK, SK: "META" },
+            UpdateExpression:
+              "SET #status = :failed, updatedAt = :now, #reason = :reason REMOVE GSI2PK, GSI2SK",
+            ConditionExpression: "#status = :deleting",
+            ExpressionAttributeNames: {
+              "#status": "status",
+              "#reason": "failureReason",
+            },
+            ExpressionAttributeValues: {
+              ":deleting": "DELETING",
+              ":failed": "FAILED",
+              ":now": new Date(nowMs).toISOString(),
+              ":reason": `reconciler: stuck DELETING > ${Math.floor(thresholdMs / 60_000)} min, treating as FAILED to unblock Event TEARDOWN (#828)`,
+            },
+          }),
+        );
+        rescued += 1;
+        console.warn("[generic-scoring] rescued stuck DELETING deployment", {
+          PK: row.PK,
+          staleForMs: nowMs - updatedAtMs,
+        });
+      } catch (err) {
+        const code = (err as { name?: string })?.name ?? "";
+        // CCF = 並行 MarkDeleted / MarkFailed が先に勝った。 次 tick で再評価されるのでこの tick は skip。
+        if (code === "ConditionalCheckFailedException") return;
+        console.warn("[generic-scoring] stuck-DELETING rescue failed", {
+          PK: row.PK,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }),
+  );
+  return rescued;
 }
 
 /**
@@ -121,15 +231,29 @@ export async function reconcileEventStatuses(
       status?: string;
     }>;
 
+    const nowMs = Date.parse(nowIso);
     await Promise.all(
       items.map(async (event) => {
         if (!event.tenantId || !event.eventId || !event.status || !event.PK) return;
+        // narrow optional から required へ (= 以降 closure 内では string 確定)
+        const eventStatus: string = event.status;
         // 子 deployments を GSI1 (TENANT#) で query → eventId filter 後の全 page を集約。
-        const depStatuses = await queryDeploymentStatusesForEvent(ctx, {
+        const depRows = await queryDeploymentRowsForEvent(ctx, {
           tenantId: event.tenantId,
           eventId: event.eventId,
         });
-        const next = resolveEventStatusTransition(event.status, depStatuses);
+        // Issue #828: TEARDOWN で `DELETING` 行が `STUCK_DELETING_THRESHOLD_MS` 以上停滞していれば
+        // FAILED に倒す (= bulk-delete publish chunk 失敗 / State Machine 未起動 / 競技者の手動 stack
+        // 削除で silent path に倒れた orphan 行を救済し、 ARCHIVED 自動遷移を解錠する)。
+        // DDB Update は side-effect で発火、 同 tick の transition 判定には rescue 後の値を
+        // 想定した `adjustedStatuses` を使う (= 次 tick を待たずに同 tick で ARCHIVED 化可能)。
+        if (eventStatus === "TEARDOWN" && Number.isFinite(nowMs)) {
+          await rescueStuckDeletingDeployments(ctx, depRows, nowMs);
+        }
+        const adjustedStatuses = depRows.map((r) =>
+          isStuckDeletingForTeardown(eventStatus, r, nowMs) ? "FAILED" : r.status,
+        );
+        const next = resolveEventStatusTransition(eventStatus, adjustedStatuses);
         if (!next) return;
 
         try {
@@ -144,7 +268,7 @@ export async function reconcileEventStatuses(
               ExpressionAttributeNames: { "#status": "status" },
               ExpressionAttributeValues: {
                 ":tenant": event.tenantId,
-                ":current": event.status,
+                ":current": eventStatus,
                 ":next": next,
                 ":now": nowIso,
               },
@@ -152,7 +276,7 @@ export async function reconcileEventStatuses(
           );
           console.log("[generic-scoring] Event status auto-transition", {
             eventId: event.eventId,
-            from: event.status,
+            from: eventStatus,
             to: next,
           });
         } catch (err) {

--- a/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  isStuckDeletingForTeardown,
   type ReconcileEventStatusesContext,
   reconcileEventStatuses,
+  rescueStuckDeletingDeployments,
   resolveEventStatusTransition,
 } from "../../lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler";
 
@@ -256,6 +258,130 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
       GSI1PK: "TENANT#tenant-acme",
       GSI1SK: "cursor",
     });
+  });
+
+  // Issue #828: stuck DELETING rescue path の test
+  it("TEARDOWN で `DELETING` が 30 min 以上停滞していたら FAILED に rescue + ARCHIVED に遷移すべき", async () => {
+    const now = "2026-05-15T01:00:00.000Z";
+    const stale = "2026-05-15T00:25:00.000Z"; // 35 min 前 (= threshold 30 min を超過)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "EVENT#EV-STUCK", tenantId: "tenant-acme", eventId: "EV-STUCK", status: "TEARDOWN" },
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "DEPLOYMENT#FRESH", status: "DELETED", updatedAt: now },
+        { PK: "DEPLOYMENT#STUCK", status: "DELETING", updatedAt: stale },
+      ],
+    });
+    // rescue UpdateItem (= stuck row を FAILED に倒す)
+    ddbSend.mockResolvedValueOnce({});
+    // event Update (= TEARDOWN → ARCHIVED)
+    ddbSend.mockResolvedValueOnce({});
+
+    await reconcileEventStatuses(ctx, now);
+
+    expect(ddbSend).toHaveBeenCalledTimes(4);
+    const rescueCmd = ddbSend.mock.calls[2]?.[0] as {
+      input: {
+        TableName: string;
+        Key: Record<string, string>;
+        ExpressionAttributeValues: Record<string, string>;
+        ConditionExpression: string;
+      };
+    };
+    expect(rescueCmd.input.TableName).toBe("TestDeployments");
+    expect(rescueCmd.input.Key).toEqual({ PK: "DEPLOYMENT#STUCK", SK: "META" });
+    expect(rescueCmd.input.ExpressionAttributeValues[":failed"]).toBe("FAILED");
+    expect(rescueCmd.input.ExpressionAttributeValues[":deleting"]).toBe("DELETING");
+    expect(rescueCmd.input.ConditionExpression).toContain("#status = :deleting");
+    const eventUpdate = ddbSend.mock.calls[3]?.[0] as {
+      input: { ExpressionAttributeValues: Record<string, string> };
+    };
+    expect(eventUpdate.input.ExpressionAttributeValues[":next"]).toBe("ARCHIVED");
+  });
+
+  it("TEARDOWN でも `DELETING` が threshold 未満 (= まだ削除中) なら rescue も ARCHIVED 遷移も発火させないべき", async () => {
+    const now = "2026-05-15T01:00:00.000Z";
+    const recent = "2026-05-15T00:50:00.000Z"; // 10 min 前 (= threshold 未満)
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "EVENT#EV-FRESH", tenantId: "tenant-acme", eventId: "EV-FRESH", status: "TEARDOWN" },
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { PK: "DEPLOYMENT#A", status: "DELETED", updatedAt: now },
+        { PK: "DEPLOYMENT#B", status: "DELETING", updatedAt: recent },
+      ],
+    });
+
+    await reconcileEventStatuses(ctx, now);
+
+    // Scan + Query のみで Update は無し (= rescue も transition も skip)
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("`isStuckDeletingForTeardown` pure logic は eventStatus / status / threshold を組み合わせて判定すべき", () => {
+    const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
+    const stale = "2026-05-15T00:00:00.000Z"; // 60 min 前
+    const recent = "2026-05-15T00:55:00.000Z"; // 5 min 前
+    // 該当
+    expect(
+      isStuckDeletingForTeardown("TEARDOWN", { status: "DELETING", updatedAt: stale }, nowMs),
+    ).toBe(true);
+    // eventStatus が TEARDOWN 以外
+    expect(
+      isStuckDeletingForTeardown("DEPLOYING", { status: "DELETING", updatedAt: stale }, nowMs),
+    ).toBe(false);
+    // status が DELETING 以外
+    expect(
+      isStuckDeletingForTeardown("TEARDOWN", { status: "DELETED", updatedAt: stale }, nowMs),
+    ).toBe(false);
+    // updatedAt が threshold 未満
+    expect(
+      isStuckDeletingForTeardown("TEARDOWN", { status: "DELETING", updatedAt: recent }, nowMs),
+    ).toBe(false);
+    // updatedAt 未設定 (= 旧 row) は safe default で false
+    expect(isStuckDeletingForTeardown("TEARDOWN", { status: "DELETING" }, nowMs)).toBe(false);
+    // nowMs が NaN なら false (= 異常入力で副作用を出さない)
+    expect(
+      isStuckDeletingForTeardown("TEARDOWN", { status: "DELETING", updatedAt: stale }, Number.NaN),
+    ).toBe(false);
+  });
+
+  it("`rescueStuckDeletingDeployments` は PK 欠落行を rescue skip すべき (= projection 漏れ safety)", async () => {
+    const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
+    await rescueStuckDeletingDeployments(
+      ctx,
+      [{ status: "DELETING", updatedAt: "2026-05-15T00:00:00.000Z" }],
+      nowMs,
+    );
+    // PK 無しは silent skip (= UpdateItem 発火しない)
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("`rescueStuckDeletingDeployments` の UpdateItem CCF (= 並行 MarkDeleted/MarkFailed) は silent skip すべき", async () => {
+    const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
+    ddbSend.mockImplementationOnce(async () => {
+      const err: Error & { name?: string } = new Error("conditional check failed");
+      err.name = "ConditionalCheckFailedException";
+      throw err;
+    });
+    await expect(
+      rescueStuckDeletingDeployments(
+        ctx,
+        [
+          {
+            PK: "DEPLOYMENT#X",
+            status: "DELETING",
+            updatedAt: "2026-05-15T00:00:00.000Z",
+          },
+        ],
+        nowMs,
+      ),
+    ).resolves.toBe(0);
   });
 
   it("Event filter は DEPLOYING または TEARDOWN のみであるべき (= READY / ENDED は触らない)", async () => {


### PR DESCRIPTION
## Summary

- 1-min tick の \`event-reconciler.ts\` が、 子 deployment 行が \`DELETING\` のまま 30 分以上停滞している TEARDOWN Event を \`ARCHIVED\` に進められず、 画面に "deployment 削除中..." が固まる問題 (Issue #828) を rescue 経路で解錠する。
- 停滞の主要原因 (= bulk-delete publish chunk 失敗で State Machine 未起動 / State Machine 60 min timeout / 競技者の stack 手動削除で CFn DeleteStack が 404 → catch path 不発) いずれにも reconciler 側で対処する設計。
- \`rescueStuckDeletingDeployments\` 新規追加: \`status=DELETING\` + \`updatedAt\` が threshold (= 30 min) 超えの行を **conditional UpdateItem** で \`FAILED\` に倒す。 race の CCF は silent skip、 失敗理由は \`failureReason\` 列に "reconciler: stuck DELETING > 30 min" で監査可能。
- \`isStuckDeletingForTeardown\` pure helper を切り出し、 同 tick 内の transition 判定にも反映 (= 次 tick を待たずに同 tick で \`TEARDOWN → ARCHIVED\` 化可能)。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green (= 938 tests)
- [x] 既存 18 tests (= \`resolveEventStatusTransition\` / 基本 reconciler) は signature 互換で通過
- [x] 新規 5 tests: stuck rescue + archive 一気通貫 / threshold 未満は触らない / pure helper 6 case / PK 欠落 skip / CCF silent skip
- [ ] 手動: 競技者 account 側で stack 全削除 + bulk-delete publish 1 chunk fail で stuck 状態を作り、 31 min 待つと自動で ARCHIVED に進むこと
- [ ] 手動: 30 min 未満は触られず、 既存 "Force ARCHIVED" rescue button は引き続き機能すること

## Regression 分析

- 既存 \`resolveEventStatusTransition\` の signature / 挙動は不変。 旧来通り \`DELETED/FAILED\` 全揃いで \`ARCHIVED\`。
- \`queryDeploymentStatusesForEvent\` → \`queryDeploymentRowsForEvent\` に rename + projection 拡張 (PK + updatedAt 追加)。 旧 fixture は PK / updatedAt 不在でも \`status\` のみで動く (= 既存 17 tests grain 互換)。
- rescue は **TEARDOWN scope** のみ。 DEPLOYING で stuck の場合は対象外 (= 別の semantic で対処すべき、 本 PR では touch しない)。
- rescue UpdateItem は conditional (\`status=DELETING\`) なので、 State Machine が同時に MarkDeleted/MarkFailed した場合は CCF で skip → 並行安全。
- threshold 30 min は CodeBuild + CFn DeleteStack の最遅成功 path (= CloudFront / Route53 slow-delete + retry) より長い余裕値。 将来必要なら \`STUCK_DELETING_THRESHOLD_MS\` 定数を per-env tuning する。
- operator の "Force ARCHIVED" rescue button は touch しない (= 最終手段として残す方針)。

## 物理影響

- \`infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts\` — UPDATE (= +112 行: rescue 関数 + pure helper + projection 拡張)
- \`infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts\` — UPDATE (= 既存 18 → 23 tests、 +5 case 追加)
- generic-scoring-handler Lambda — runtime 挙動変化: TEARDOWN Event 毎の tick で stuck rescue を 1 phase 追加。 ddb は \`grantReadWriteData\` 済 (\`generic-scoring-lambda.ts:106\`) で IAM 変更不要
- CFn / インフラ — NO-OP

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)