### PR TITLE
fix(scoring): penalize wrong-flag submissions to prevent brute force (#817)

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -106,7 +106,11 @@ export interface ParticipantTeamView {
 export type SubmitFlagOutcome =
   | { kind: "ok"; scoreDelta: number; totalScore: number }
   | { kind: "already_scored"; totalScore: number }
-  | { kind: "wrong" };
+  /**
+   * Issue #817: 不正解。 問題 metadata に `wrongAnswerPenalty` が設定されていれば
+   * `scoreDelta` は負数 (= 減点)。 設定されていなければ 0。 wrongCount は累計試行回数。
+   */
+  | { kind: "wrong"; scoreDelta: number; totalScore: number; wrongCount: number };
 
 export class PortalValidationError extends Error {
   constructor(public readonly errorCode: string) {

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -244,8 +244,23 @@ function FlagSubmissionPanel({
         </Alert>
       )}
       {outcome?.kind === "wrong" && (
-        <Alert type="warning" header="不正解">
-          値を確認して再度提出してください。
+        <Alert
+          type="warning"
+          header={
+            outcome.scoreDelta < 0
+              ? `不正解 (${outcome.scoreDelta} pt) — 累計 ${outcome.totalScore} pt`
+              : "不正解"
+          }
+        >
+          {outcome.scoreDelta < 0 ? (
+            <>
+              これまで {outcome.wrongCount} 回 不正解です。 値を確認して再度提出してください。
+              ペナルティは不正解 1 回あたり {-outcome.scoreDelta} pt で、 累計スコアは 0 pt
+              未満になりません。
+            </>
+          ) : (
+            <>値を確認して再度提出してください。</>
+          )}
         </Alert>
       )}
       {outcome?.kind === "already_scored" && (

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -129,6 +129,11 @@ export interface DeploymentItem {
    */
   flagSubmitted?: boolean;
   /**
+   * Issue #817: Challenge (flag) で不正解 submit を受けた累計回数。 0 default。
+   * `wrongAnswerPenalty > 0` の問題で 1 不正解ごとに ADD 1 + score 減算する経路で使う。
+   */
+  wrongAnswerCount?: number;
+  /**
    * 直近の health check で endpoint ごとに probe した結果の JSON 文字列。
    * shape: `{ [outputKey]: { ok, checkedAt, since? } }`。
    * `since` は ok=false が続いている開始時刻 (= attack を検知した時刻)。

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -8,7 +8,12 @@ import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 export type SubmitFlagOutcome =
   | { kind: "ok"; scoreDelta: number; totalScore: number }
   | { kind: "already_scored"; totalScore: number }
-  | { kind: "wrong" }
+  /**
+   * Issue #817: 不正解。 wrongAnswerPenalty が問題 metadata で正の整数で設定されていれば
+   * score を減算する (= brute-force 対策、 team score は 0 で clamp)。 旧来の wrong (= 0 pt) は
+   * `scoreDelta: 0, totalScore: <変化なし>` で互換維持。
+   */
+  | { kind: "wrong"; scoreDelta: number; totalScore: number; wrongCount: number }
   | { kind: "not_flag_problem" }
   | { kind: "no_outputs" }
   | { kind: "scoring_locked" }
@@ -85,7 +90,73 @@ export async function submitFlag(
   const expected = outputs[scoring.flagOutputKey];
   if (typeof expected !== "string") return { kind: "no_outputs" };
 
-  if (!flagMatches(submittedFlag, expected)) return { kind: "wrong" };
+  if (!flagMatches(submittedFlag, expected)) {
+    // Issue #817: wrongAnswerPenalty が設定されていれば不正解時に score を減算 + wrongAnswerCount を ADD。
+    // - penalty が 0 / 未設定なら旧挙動 (= UpdateItem 発火せず、 scoreDelta=0、 score 変化なし) を維持
+    //   (= Free Tier 1 WCU/sec の DynamoDbLowCapacity 制約下で不要 write を出さない)
+    // - penalty > 0 なら conditional Update (flagSubmitted ≠ true 一致時のみ) で減点 + count
+    // - score は出口で 0 未満を clamp (= UI 期待を守る、 内部値の clamp は別 PR)
+    const penalty = scoring.wrongAnswerPenalty ?? 0;
+    if (penalty === 0) {
+      // 旧来挙動互換: UI 用に scoreDelta=0、 score / wrongCount は現状値 fallback。
+      return {
+        kind: "wrong",
+        scoreDelta: 0,
+        totalScore: Math.max(0, Number(item.score ?? 0)),
+        wrongCount: Number(item.wrongAnswerCount ?? 0),
+      };
+    }
+    const wrongNow = new Date().toISOString();
+    try {
+      const updated = await shared.ddb.send(
+        new UpdateCommand({
+          TableName: shared.tableName,
+          Key: { PK: item.PK, SK: "META" },
+          UpdateExpression: "ADD wrongAnswerCount :one, score :neg SET updatedAt = :now",
+          // race / 正解済との同時提出を防ぐ: flagSubmitted は false / 未設定のみ減点。
+          ConditionExpression: "attribute_not_exists(flagSubmitted) OR flagSubmitted = :false",
+          ExpressionAttributeValues: {
+            ":one": 1,
+            ":neg": -penalty,
+            ":false": false,
+            ":now": wrongNow,
+          },
+          ReturnValues: "ALL_NEW",
+        }),
+      );
+      const attrs = updated.Attributes as
+        | { score?: unknown; wrongAnswerCount?: unknown }
+        | undefined;
+      const rawScore = Number(attrs?.score ?? 0);
+      const totalScore = rawScore < 0 ? 0 : rawScore;
+      const wrongCount = Number(attrs?.wrongAnswerCount ?? 1);
+      if (item.jobId) {
+        // 不正解 audit event は score delta=-penalty で score_event に追記する (= 正解の "flag" と
+        // 対称な "flag-wrong" として lock-out UI / 監査の証跡に使う)。
+        await writeScoreEvent(
+          shared.ddb,
+          shared.tableName,
+          {
+            jobId: item.jobId,
+            problemId: item.problemId,
+            teamId: item.teamId,
+            eventId: item.eventId,
+            expiresAt: item.expiresAt ?? 0,
+          },
+          "flag-wrong",
+          -penalty,
+          wrongNow,
+        );
+      }
+      return { kind: "wrong", scoreDelta: -penalty, totalScore, wrongCount };
+    } catch (err) {
+      // flagSubmitted=true との race (= 正解と不正解が同時) は wrong 扱いを諦めて already_scored を返す。
+      if ((err as { name?: string })?.name === "ConditionalCheckFailedException") {
+        return { kind: "already_scored", totalScore: Number(item.score ?? 0) };
+      }
+      throw err;
+    }
+  }
 
   // ConditionExpression で flagSubmitted=true への 2 重加算を防ぐ。レース勝者だけが
   // 加点される。

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -26,23 +26,25 @@ export interface ScoreEventItem {
    * イベント発生源。
    * - `uptime`: HealthCheck の probe で全 endpoint OK
    * - `flag`: 競技者の flag 提出が正解
+   * - `flag-wrong`: 競技者の flag 提出が不正解で wrongAnswerPenalty が減点された (Issue #817)
    * - `attack-detected`: HealthCheck で `lastResult: ok → fail` 遷移を検知 (ADR-005 D2-A、
    *   Battle Portal の Attack Statistics / History で使う)
    */
-  source: "uptime" | "flag" | "attack-detected";
+  source: "uptime" | "flag" | "flag-wrong" | "attack-detected";
   /**
    * 加算ポイント。`uptime` = scoring.pointsPerSuccess、`flag` = scoring.points、
-   * `attack-detected` = 0 (= イベント marker のみ、score 加算なし)。
+   * `flag-wrong` = -wrongAnswerPenalty (= 減点、 負数)、 `attack-detected` = 0 (= イベント marker のみ)。
    */
   points: number;
   /**
    * 結果。
    * - `ok`: `uptime` で全 endpoint OK or `flag` で正解
+   * - `wrong`: `flag-wrong` (= 不正解で減点、 Issue #817)
    * - `down`: `attack-detected` (= 攻撃が刺さって uptime が落ちた)
    *
    * Phase 2 以前の event 行は `"ok"` のみ書かれているので backward compatible。
    */
-  result: "ok" | "down";
+  result: "ok" | "wrong" | "down";
   occurredAt: string;
   /** 親 deployment の TTL を継承。0 なら無期限 (旧 deployment 互換)。 */
   expiresAt: number;
@@ -73,7 +75,7 @@ export async function writeScoreEvent(
     eventId: parent.eventId,
     source,
     points,
-    result: source === "attack-detected" ? "down" : "ok",
+    result: source === "attack-detected" ? "down" : source === "flag-wrong" ? "wrong" : "ok",
     occurredAt,
     expiresAt: Number(parent.expiresAt ?? 0),
   };

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -39,6 +39,11 @@ export interface FlagScoringMetadata {
   readonly kind: "flag";
   readonly flagOutputKey: string;
   readonly points: number;
+  /**
+   * Issue #817: 不正解 1 回ごとに score から減算する値 (= brute-force 対策)。
+   * 未設定 / 0 は減点無し (= 既存問題と後方互換)。 team score は 0 未満にならず clamp。
+   */
+  readonly wrongAnswerPenalty?: number;
   readonly hints?: readonly ProgressiveHint[];
 }
 
@@ -160,13 +165,29 @@ export function parseScoringMetadata(value: unknown): ProblemScoringMetadata | u
 }
 
 function parseFlag(value: unknown): FlagScoringMetadata | undefined {
-  const f = value as { flagOutputKey?: unknown; points?: unknown; hints?: unknown };
+  const f = value as {
+    flagOutputKey?: unknown;
+    points?: unknown;
+    wrongAnswerPenalty?: unknown;
+    hints?: unknown;
+  };
   if (typeof f.flagOutputKey !== "string") return undefined;
   if (typeof f.points !== "number" || !Number.isFinite(f.points) || f.points <= 0) return undefined;
+  // Issue #817: wrongAnswerPenalty は optional。 不正な値 (= 負 / 非整数 / 非数値) は undefined に
+  // clamp して fallback (= "no penalty" として安全側に倒す、 metadata typo で減点暴走を防ぐ)。
+  const penaltyRaw = f.wrongAnswerPenalty;
+  const wrongAnswerPenalty =
+    typeof penaltyRaw === "number" &&
+    Number.isFinite(penaltyRaw) &&
+    penaltyRaw >= 0 &&
+    Number.isInteger(penaltyRaw)
+      ? penaltyRaw
+      : undefined;
   return {
     kind: "flag",
     flagOutputKey: f.flagOutputKey,
     points: f.points,
+    wrongAnswerPenalty,
     hints: parseHints(f.hints),
   };
 }

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -95,11 +95,76 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "no_outputs" });
   });
 
-  it("submitted flag が expected と一致しなければ wrong を返すべき (UpdateItem 呼ばない)", async () => {
-    ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+  it("submitted flag が expected と一致しなければ wrong + scoreDelta=0 を返すべき (penalty 未設定なら UpdateItem 呼ばない)", async () => {
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 25, wrongAnswerCount: 3 })] });
     const out = await submitFlag(shared, flagScoring, "KEY", "hello-world", "wrong-answer");
-    expect(out).toEqual({ kind: "wrong" });
-    expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、Update なし
+    // Issue #817: penalty=0 / 未設定の場合は scoreDelta=0、 既存 wrongCount を返す互換挙動。
+    expect(out).toEqual({ kind: "wrong", scoreDelta: 0, totalScore: 25, wrongCount: 3 });
+    expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、Update なし (= Free Tier WCU 節約)
+  });
+
+  it("Issue #817: wrongAnswerPenalty > 0 で不正解なら score を減算 + wrongAnswerCount を ADD すべき", async () => {
+    const penaltyScoring: Record<string, ProblemScoringMetadata> = {
+      "hello-world": {
+        kind: "flag",
+        flagOutputKey: "ParameterValue",
+        points: 100,
+        wrongAnswerPenalty: 10,
+      },
+    };
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 30, wrongAnswerCount: 2 })] });
+    // UpdateItem 後の Attributes (= score=30-10=20、 wrongAnswerCount=2+1=3)
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 20, wrongAnswerCount: 3 } });
+    // writeScoreEvent (= PutItem) の mock
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await submitFlag(shared, penaltyScoring, "KEY", "hello-world", "wrong-answer");
+
+    expect(out).toEqual({ kind: "wrong", scoreDelta: -10, totalScore: 20, wrongCount: 3 });
+    expect(ddbSend).toHaveBeenCalledTimes(3); // Query + UpdateItem + score event Put
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    expect(updateCmd.input.UpdateExpression).toContain("ADD wrongAnswerCount :one, score :neg");
+    expect(updateCmd.input.ExpressionAttributeValues?.[":neg"]).toBe(-10);
+    expect(updateCmd.input.ConditionExpression).toContain("attribute_not_exists(flagSubmitted)");
+  });
+
+  it("Issue #817: penalty で score が負数になっても totalScore は 0 で clamp して返すべき", async () => {
+    const penaltyScoring: Record<string, ProblemScoringMetadata> = {
+      "hello-world": {
+        kind: "flag",
+        flagOutputKey: "ParameterValue",
+        points: 100,
+        wrongAnswerPenalty: 50,
+      },
+    };
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 10, wrongAnswerCount: 0 })] });
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: -40, wrongAnswerCount: 1 } });
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await submitFlag(shared, penaltyScoring, "KEY", "hello-world", "wrong-answer");
+
+    expect(out).toEqual({ kind: "wrong", scoreDelta: -50, totalScore: 0, wrongCount: 1 });
+  });
+
+  it("Issue #817: penalty 経路で flagSubmitted=true との race (= CCF) は already_scored に倒すべき", async () => {
+    const penaltyScoring: Record<string, ProblemScoringMetadata> = {
+      "hello-world": {
+        kind: "flag",
+        flagOutputKey: "ParameterValue",
+        points: 100,
+        wrongAnswerPenalty: 10,
+      },
+    };
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] });
+    ddbSend.mockImplementationOnce(async () => {
+      const err: Error & { name?: string } = new Error("conditional check failed");
+      err.name = "ConditionalCheckFailedException";
+      throw err;
+    });
+
+    const out = await submitFlag(shared, penaltyScoring, "KEY", "hello-world", "wrong-answer");
+
+    expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
   });
 
   it("正解なら ADD score :pts SET flagSubmitted=true で UpdateItem し ok を返すべき", async () => {

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -254,9 +254,14 @@
               "minimum": 1,
               "description": "正解時の獲得ポイント (1 deploy につき 1 回まで加算)。"
             },
+            "wrongAnswerPenalty": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "[Issue #817] 不正解 1 回ごとに score から減算する値 (= brute-force 対策)。 0 は減点無し (default)。 team score は 0 未満にならない (= clamp)。"
+            },
             "hints": { "$ref": "#/$defs/progressiveHints" }
           },
-          "description": "kind=flag (= Challenge 1 回提出形式)。example: hello-world は SSM Parameter 値を当てて +100 pt。"
+          "description": "kind=flag (= Challenge 1 回提出形式)。example: hello-world は SSM Parameter 値を当てて +100 pt。 wrongAnswerPenalty を設定すると不正解 1 回ごとに減点する (= brute-force 防止)。"
         },
         {
           "type": "object",


### PR DESCRIPTION
## Summary

- Challenge (\`scoring.kind=flag\`) で **不正解 submit のペナルティが 0** だったため、 競技者が flag 値を総当りで提出可能だった (Issue #817、 hello-world 等の短い flag 空間で現実的な攻撃)。
- \`metadata.json\` schema に optional \`wrongAnswerPenalty: integer >= 0\` を追加。 backend \`submitFlag\` handler を不正解時に conditional Update (= flagSubmitted ≠ true 一致時のみ \`ADD wrongAnswerCount :one, score :neg\`) で減点 + count 累積させる。 不正解 audit event を \`source: "flag-wrong"\` / \`result: "wrong"\` で score_event に追記して監査可能にする。
- UI (participant-portal \`ProblemPanel.tsx\`) で 「不正解 (-N pt) — 累計 X pt / これまで N 回 不正解」 + 「累計スコアは 0 pt 未満になりません」 を明示。 既存の Alert は \`penalty=0\` 時は表示変えず後方互換。

## Why this design

- **penalty=0 / 未設定はゼロコスト**: DynamoDbLowCapacity Aspect で 1 WCU/sec に絞られている Free Tier 制約下、 旧来挙動と同じく Update を発火させない (= 旧テスト 18 件は signature 互換で通過、 wrong は 1 RCU の Query のみ)。
- **penalty > 0 は audit-trail 込み**: 加点と対称な \`score_event\` 行を追記 (= operator が brute-force 監視 / 採点異議申し立て対応に使える)。
- **lock-out (= wrongAnswerMaxAttempts) は Phase 2**: 本 PR では \`wrongAnswerCount\` を DDB に persist する基盤までを整える。 lock-out UI / input 無効化 / 解説表示は別 Issue で扱う。
- **0 で clamp は出口のみ**: backend では \`ADD score :neg\` で negative 値も入りうるが、 UI 用 \`totalScore\` は \`Math.max(0, ...)\` で 0 clamp。 内部値の clamp (= ADD ではなく conditional SET) は別 Issue。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green (= 12 submit-flag tests + 既存 18 reconciler)
- [x] schema test (\`problems/SCHEMA.json\`) で既存 4 metadata.json はそのまま valid (= wrongAnswerPenalty 未設定でも通る)
- [x] backend unit test 4 case 追加: penalty=0 / penalty>0 で減点 + count / 0 clamp / CCF race → already_scored
- [ ] 手動: \`metadata.json\` の hello-world に \`wrongAnswerPenalty: 10\` を入れて 5 回不正解 → score=-50 → 0 clamp で 0 pt 表示、 audit 行 5 件確認
- [ ] 手動: 既存問題 (penalty 未設定) は提出時に 「不正解」 のみ表示 (= 既存 UX 維持)

## Regression 分析

- \`SubmitFlagOutcome\` の \`wrong\` arm を widen (= \`{kind: "wrong"}\` → \`{kind: "wrong", scoreDelta, totalScore, wrongCount}\`)。 既存 client (= participant-portal) は \`outcome.kind === "wrong"\` のみ判定していたので破壊性なし、 新 field は optional で UI が読む。
- \`DeploymentItem.wrongAnswerCount\` は optional 追加。 既存 row には field 無し → \`Number(item.wrongAnswerCount ?? 0) === 0\` で safe default。
- \`ScoreEventItem.source\` に \`"flag-wrong"\` / result に \`"wrong"\` を追加。 既存 reader (= Battle Portal の Attack Statistics 等) は \`"attack-detected"\` / \`"flag"\` の判定で switch しているので 新 source を未知扱いするだけ (= silent ignore = safe)。
- \`metadata.json\` schema の \`wrongAnswerPenalty\` は optional integer >= 0。 既存 4 metadata.json は未設定で valid のまま。
- DynamoDbLowCapacity (= 1 WCU/sec 強制) との整合: penalty=0 は Update 発火しないので既存問題で write 増加なし。 penalty>0 の問題のみ 1 wrong submit ごとに 1 Update + 1 Put (= score_event)。

## 物理影響

- \`problems/SCHEMA.json\` — UPDATE (= \`wrongAnswerPenalty\` field 追加)
- \`infrastructure/lib/utils/scoring-metadata.ts\` — UPDATE (\`FlagScoringMetadata\` + \`parseFlag\`)
- \`infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts\` — UPDATE (wrong path に penalty 経路追加)
- \`infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts\` — UPDATE (\`wrongAnswerCount\` optional 追加)
- \`infrastructure/lib/problem-deploy/handlers/shared/score-event.ts\` — UPDATE (\`flag-wrong\` source + \`wrong\` result 追加)
- \`infrastructure/test/problem-deploy/submit-flag.test.ts\` — UPDATE (旧 wrong test を flip + 4 新 case)
- \`apps/participant-portal/src/api/portal-client.ts\` — UPDATE (\`SubmitFlagOutcome\` widen)
- \`apps/participant-portal/src/components/ProblemPanel.tsx\` — UPDATE (不正解 Alert に減点情報)
- インフラ — NO-OP

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)