### PR TITLE
fix(catalog): search + category/status/difficulty/tag filters with clickable tag badges (#834 #835)

### DIFF
--- a/apps/application-admin-console/src/lib/problem-filter.test.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { ProblemSummary } from "../data/problems";
+import {
+  collectTagFacets,
+  EMPTY_FILTER_CRITERIA,
+  filterProblems,
+  isFilterActive,
+  toggleTagFilter,
+} from "./problem-filter";
+
+const sample = (over: Partial<ProblemSummary> = {}): ProblemSummary => ({
+  id: "hello-world",
+  name: "Hello World",
+  category: "Challenge",
+  status: "ready",
+  shortDescription: "SSM Parameter 値を当てる flag 問題",
+  difficulty: 1,
+  estimatedDuration: "30 分",
+  tags: ["sample", "challenge", "ssm", "flag"],
+  ...over,
+});
+
+describe("filterProblems (Issue #834)", () => {
+  const problems: readonly ProblemSummary[] = [
+    sample({ id: "p1", name: "Hello World", category: "Challenge", tags: ["sample", "flag"] }),
+    sample({
+      id: "p2",
+      name: "Battle Royale",
+      category: "Battle",
+      status: "draft",
+      difficulty: 4,
+      tags: ["battle", "uptime", "ec2"],
+    }),
+    sample({
+      id: "p3",
+      name: "Microservice Migration",
+      category: "Battle",
+      difficulty: 5,
+      tags: ["battle", "migration", "ec2", "lambda"],
+    }),
+  ];
+
+  it("空 criteria は全件返すべき", () => {
+    expect(filterProblems(problems, EMPTY_FILTER_CRITERIA)).toHaveLength(3);
+  });
+
+  it("search が name に substring match すれば残るべき (case-insensitive)", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "BATTLE" });
+    expect(res.map((p) => p.id)).toEqual(["p2", "p3"]);
+  });
+
+  it("search は shortDescription / tags も走査すべき", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "migration" });
+    expect(res.map((p) => p.id)).toEqual(["p3"]);
+  });
+
+  it("category filter が 1 つ指定されたら AND 条件で絞るべき", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, categories: ["Battle"] });
+    expect(res.map((p) => p.id)).toEqual(["p2", "p3"]);
+  });
+
+  it("status filter で draft のみ残すべき", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, statuses: ["draft"] });
+    expect(res.map((p) => p.id)).toEqual(["p2"]);
+  });
+
+  it("difficulty multi-select で複数 level を OR で残すべき", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      difficulties: [1, 5],
+    });
+    expect(res.map((p) => p.id)).toEqual(["p1", "p3"]);
+  });
+
+  it("tag filter mode=or は いずれか含む 行を残すべき", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      tags: ["lambda", "flag"],
+      tagMatchMode: "or",
+    });
+    expect(res.map((p) => p.id)).toEqual(["p1", "p3"]);
+  });
+
+  it("tag filter mode=and は 全て含む 行のみ残すべき", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      tags: ["ec2", "lambda"],
+      tagMatchMode: "and",
+    });
+    expect(res.map((p) => p.id)).toEqual(["p3"]);
+  });
+
+  it("複数 filter は AND で組み合わさるべき", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      search: "battle",
+      categories: ["Battle"],
+      difficulties: [5],
+    });
+    expect(res.map((p) => p.id)).toEqual(["p3"]);
+  });
+
+  it("0 hit になっても空配列を返す (= UI 側で empty state)", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "nonexistent" });
+    expect(res).toEqual([]);
+  });
+});
+
+describe("isFilterActive", () => {
+  it("空 criteria は active=false", () => {
+    expect(isFilterActive(EMPTY_FILTER_CRITERIA)).toBe(false);
+  });
+
+  it("search 1 文字でも active=true", () => {
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, search: "x" })).toBe(true);
+  });
+
+  it("各 filter の少なくとも 1 つが non-empty なら active", () => {
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, categories: ["Battle"] })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, tags: ["sample"] })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, difficulties: [1] })).toBe(true);
+  });
+
+  it("search が空白のみは active=false (= trim 比較)", () => {
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, search: "   " })).toBe(false);
+  });
+});
+
+describe("collectTagFacets", () => {
+  it("出現頻度の降順 + タイは alphabetical で sort すべき", () => {
+    const problems = [
+      sample({ id: "p1", tags: ["a", "b", "c"] }),
+      sample({ id: "p2", tags: ["a", "b"] }),
+      sample({ id: "p3", tags: ["a"] }),
+    ];
+    const facets = collectTagFacets(problems);
+    expect(facets).toEqual([
+      { tag: "a", count: 3 },
+      { tag: "b", count: 2 },
+      { tag: "c", count: 1 },
+    ]);
+  });
+
+  it("空配列なら空 facets", () => {
+    expect(collectTagFacets([])).toEqual([]);
+  });
+});
+
+describe("toggleTagFilter (Issue #835)", () => {
+  it("空 → 1 タグ click でそのタグ 1 件のみ active", () => {
+    const next = toggleTagFilter(EMPTY_FILTER_CRITERIA, "sample");
+    expect(next.tags).toEqual(["sample"]);
+  });
+
+  it("既に同タグ 1 件のみ active → 同タグ click で clear (toggle)", () => {
+    const start = { ...EMPTY_FILTER_CRITERIA, tags: ["sample"] };
+    const next = toggleTagFilter(start, "sample");
+    expect(next.tags).toEqual([]);
+  });
+
+  it("別タグが active なら 「そのタグだけで絞り込み」 に切り替わるべき (= 単 click は全面切替)", () => {
+    const start = { ...EMPTY_FILTER_CRITERIA, tags: ["sample"] };
+    const next = toggleTagFilter(start, "battle");
+    expect(next.tags).toEqual(["battle"]);
+  });
+
+  it("他 filter (search / category 等) は維持すべき", () => {
+    const start = {
+      ...EMPTY_FILTER_CRITERIA,
+      search: "x",
+      categories: ["Battle"] as const,
+      tags: ["sample"],
+    };
+    const next = toggleTagFilter(start, "flag");
+    expect(next.search).toBe("x");
+    expect(next.categories).toEqual(["Battle"]);
+    expect(next.tags).toEqual(["flag"]);
+  });
+});

--- a/apps/application-admin-console/src/lib/problem-filter.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.ts
@@ -1,0 +1,117 @@
+import type { ProblemCategory, ProblemStatus, ProblemSummary } from "../data/problems";
+
+/**
+ * Issue #834 / #835: 問題カタログ page の filter / search を pure logic 化。
+ *
+ * 設計指針:
+ *  - **pure function**: side-effect なし。 React state 側で memoize して使う。
+ *  - **union semantic**: 各 filter (search / category / status / difficulty / tag) は **AND**。
+ *    tag だけ 「複数 tag 選択時に OR vs AND」 を caller が選べるよう `tagMatchMode` を取る。
+ *  - **search**: `name` / `shortDescription` / `tags` (kebab-case の文字列) を **substring** で
+ *    case-insensitive に走査。 旧 catalog の 4 問題程度なら正規表現は使わない (= 過剰)。
+ */
+
+export type DifficultyLevel = 1 | 2 | 3 | 4 | 5;
+export type TagMatchMode = "or" | "and";
+
+export interface ProblemFilterCriteria {
+  /** 全文検索 (= name / shortDescription / tags を substring match)。 空文字 = no-op。 */
+  readonly search: string;
+  /** カテゴリ filter。 空配列 = 全カテゴリ表示。 */
+  readonly categories: readonly ProblemCategory[];
+  /** 公開状態 filter。 空配列 = 全状態表示。 */
+  readonly statuses: readonly ProblemStatus[];
+  /** 難易度 multi-select。 空配列 = 全難易度表示。 */
+  readonly difficulties: readonly DifficultyLevel[];
+  /** タグ multi-select。 空配列 = タグ filter なし。 */
+  readonly tags: readonly string[];
+  /** タグが複数選択されたときの結合 (default OR、 "absolutely include" は AND)。 */
+  readonly tagMatchMode: TagMatchMode;
+}
+
+export const EMPTY_FILTER_CRITERIA: ProblemFilterCriteria = {
+  search: "",
+  categories: [],
+  statuses: [],
+  difficulties: [],
+  tags: [],
+  tagMatchMode: "or",
+};
+
+export function isFilterActive(c: ProblemFilterCriteria): boolean {
+  return (
+    c.search.trim().length > 0 ||
+    c.categories.length > 0 ||
+    c.statuses.length > 0 ||
+    c.difficulties.length > 0 ||
+    c.tags.length > 0
+  );
+}
+
+function matchesSearch(problem: ProblemSummary, needle: string): boolean {
+  if (needle.length === 0) return true;
+  const haystack = [problem.name, problem.shortDescription, ...problem.tags]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+function matchesTags(
+  problemTags: readonly string[],
+  selectedTags: readonly string[],
+  mode: TagMatchMode,
+): boolean {
+  if (selectedTags.length === 0) return true;
+  if (mode === "and") return selectedTags.every((t) => problemTags.includes(t));
+  return selectedTags.some((t) => problemTags.includes(t));
+}
+
+export function filterProblems(
+  problems: readonly ProblemSummary[],
+  criteria: ProblemFilterCriteria,
+): readonly ProblemSummary[] {
+  const needle = criteria.search.trim().toLowerCase();
+  return problems.filter((p) => {
+    if (!matchesSearch(p, needle)) return false;
+    if (criteria.categories.length > 0 && !criteria.categories.includes(p.category)) return false;
+    if (criteria.statuses.length > 0 && !criteria.statuses.includes(p.status)) return false;
+    if (criteria.difficulties.length > 0 && !criteria.difficulties.includes(p.difficulty)) {
+      return false;
+    }
+    if (!matchesTags(p.tags, criteria.tags, criteria.tagMatchMode)) return false;
+    return true;
+  });
+}
+
+/**
+ * カタログ全体から union された tag 一覧を返す (= multi-select 候補 + count badge)。
+ * 出現頻度の降順 → タイ時は alphabetical で安定 sort。
+ */
+export function collectTagFacets(
+  problems: readonly ProblemSummary[],
+): readonly { tag: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const p of problems) {
+    for (const tag of p.tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+/**
+ * Issue #835: 1 タグ click → そのタグだけ active な criteria を作る。
+ * 既に同じタグ 1 件のみ active なら 「 clear 」 とみなして空に戻す (= toggle)。
+ */
+export function toggleTagFilter(
+  criteria: ProblemFilterCriteria,
+  tag: string,
+): ProblemFilterCriteria {
+  const isOnlyThisTag = criteria.tags.length === 1 && criteria.tags[0] === tag;
+  if (isOnlyThisTag) return { ...criteria, tags: [] };
+  // 単 click は「そのタグだけで絞り込み」 (= filter 全面切替)。
+  // 累積 add したいケースは header の multi-select UI を使う想定。
+  return { ...criteria, tags: [tag] };
+}

--- a/apps/application-admin-console/src/pages/Problems.tsx
+++ b/apps/application-admin-console/src/pages/Problems.tsx
@@ -1,11 +1,27 @@
 import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
 import Link from "@cloudscape-design/components/link";
+import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
+import SegmentedControl, {
+  type SegmentedControlProps,
+} from "@cloudscape-design/components/segmented-control";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { listProblemSummaries, type ProblemSummary } from "../data/problems";
+import {
+  collectTagFacets,
+  type DifficultyLevel,
+  EMPTY_FILTER_CRITERIA,
+  filterProblems,
+  isFilterActive,
+  type ProblemFilterCriteria,
+  toggleTagFilter,
+} from "../lib/problem-filter";
 
 const DIFFICULTY_LABEL: Record<ProblemSummary["difficulty"], string> = {
   1: "入門",
@@ -27,25 +43,160 @@ const STATUS_LABEL: Record<ProblemSummary["status"], string> = {
   deprecated: "停止予定",
 };
 
+const CATEGORY_SEGMENTS: SegmentedControlProps.Option[] = [
+  { id: "all", text: "全て" },
+  { id: "Battle", text: "Battle" },
+  { id: "Challenge", text: "Challenge" },
+];
+
+const STATUS_SEGMENTS: SegmentedControlProps.Option[] = [
+  { id: "all", text: "全て" },
+  { id: "ready", text: "公開中" },
+  { id: "draft", text: "下書き" },
+  { id: "deprecated", text: "停止予定" },
+];
+
+const DIFFICULTY_LEVELS: DifficultyLevel[] = [1, 2, 3, 4, 5];
+
 /**
  * 問題一覧ページ。Cloudscape Cards で 1 件ずつカード表示する。
  * クリックすると /problems/:id へ遷移して詳細 + Deploy ボタン。
+ *
+ * Issue #834 / #835: 検索 box / category / status / 難易度 / タグ filter を提供。
+ * tag badge は click で 「そのタグだけで絞り込み」 (= toggle、 同タグ 2 回 click で解除)。
  */
 export function ProblemsPage() {
   const navigate = useNavigate();
   const problems = listProblemSummaries();
+  const [criteria, setCriteria] = useState<ProblemFilterCriteria>(EMPTY_FILTER_CRITERIA);
+
+  const filtered = useMemo(() => filterProblems(problems, criteria), [problems, criteria]);
+  const tagFacets = useMemo(() => collectTagFacets(problems), [problems]);
+  const tagOptions: MultiselectProps.Option[] = useMemo(
+    () => tagFacets.map((f) => ({ value: f.tag, label: f.tag, description: `${f.count} 件` })),
+    [tagFacets],
+  );
+  const tagSelected: MultiselectProps.Option[] = useMemo(
+    () => criteria.tags.map((t) => ({ value: t, label: t })),
+    [criteria.tags],
+  );
+  const difficultyOptions: MultiselectProps.Option[] = useMemo(
+    () =>
+      DIFFICULTY_LEVELS.map((d) => ({
+        value: String(d),
+        label: `${d} (${DIFFICULTY_LABEL[d]})`,
+      })),
+    [],
+  );
+  const difficultySelected: MultiselectProps.Option[] = useMemo(
+    () => criteria.difficulties.map((d) => ({ value: String(d), label: `${d}` })),
+    [criteria.difficulties],
+  );
 
   return (
     <SpaceBetween size="l">
       <Header
         variant="h1"
-        description="競技アカウントへデプロイ可能な問題の一覧。デプロイすると参加者にプレイ環境が払い出されます。"
+        description="競技アカウントへデプロイ可能な問題の一覧。 検索 / カテゴリ / 状態 / 難易度 / タグで絞り込みできます。"
+        counter={
+          isFilterActive(criteria)
+            ? `(${filtered.length} / ${problems.length})`
+            : `(${problems.length})`
+        }
+        actions={
+          isFilterActive(criteria) && (
+            <Button onClick={() => setCriteria(EMPTY_FILTER_CRITERIA)}>絞り込み解除</Button>
+          )
+        }
       >
         問題カタログ
       </Header>
 
+      <SpaceBetween size="s">
+        <Input
+          type="search"
+          value={criteria.search}
+          placeholder="問題名 / 説明 / タグから検索 (substring, 大文字小文字無視)"
+          onChange={({ detail }) => setCriteria((prev) => ({ ...prev, search: detail.value }))}
+        />
+        <SpaceBetween direction="horizontal" size="s">
+          <SegmentedControl
+            selectedId={criteria.categories.length === 1 ? criteria.categories[0] : "all"}
+            options={CATEGORY_SEGMENTS}
+            label="カテゴリ"
+            onChange={({ detail }) =>
+              setCriteria((prev) => ({
+                ...prev,
+                categories:
+                  detail.selectedId === "all"
+                    ? []
+                    : [detail.selectedId as ProblemSummary["category"]],
+              }))
+            }
+          />
+          <SegmentedControl
+            selectedId={criteria.statuses.length === 1 ? criteria.statuses[0] : "all"}
+            options={STATUS_SEGMENTS}
+            label="公開状態"
+            onChange={({ detail }) =>
+              setCriteria((prev) => ({
+                ...prev,
+                statuses:
+                  detail.selectedId === "all"
+                    ? []
+                    : [detail.selectedId as ProblemSummary["status"]],
+              }))
+            }
+          />
+        </SpaceBetween>
+        <SpaceBetween direction="horizontal" size="s">
+          <Multiselect
+            placeholder="難易度を選択"
+            options={difficultyOptions}
+            selectedOptions={difficultySelected}
+            tokenLimit={5}
+            onChange={({ detail }) =>
+              setCriteria((prev) => ({
+                ...prev,
+                difficulties: detail.selectedOptions
+                  .map((o) => Number(o.value))
+                  .filter((n): n is DifficultyLevel =>
+                    DIFFICULTY_LEVELS.includes(n as DifficultyLevel),
+                  ),
+              }))
+            }
+          />
+          <Multiselect
+            placeholder={`タグを選択 (${criteria.tagMatchMode === "and" ? "全て含む" : "いずれか含む"})`}
+            options={tagOptions}
+            selectedOptions={tagSelected}
+            tokenLimit={10}
+            onChange={({ detail }) =>
+              setCriteria((prev) => ({
+                ...prev,
+                tags: detail.selectedOptions
+                  .map((o) => o.value)
+                  .filter((v): v is string => typeof v === "string"),
+              }))
+            }
+          />
+          {criteria.tags.length > 1 && (
+            <Button
+              onClick={() =>
+                setCriteria((prev) => ({
+                  ...prev,
+                  tagMatchMode: prev.tagMatchMode === "and" ? "or" : "and",
+                }))
+              }
+            >
+              タグ結合: {criteria.tagMatchMode === "and" ? "AND (全て含む)" : "OR (いずれか含む)"}
+            </Button>
+          )}
+        </SpaceBetween>
+      </SpaceBetween>
+
       <Cards
-        items={[...problems]}
+        items={[...filtered]}
         cardDefinition={{
           header: (item) => (
             <Link
@@ -80,9 +231,21 @@ export function ProblemsPage() {
               header: "タグ",
               content: (item) => (
                 <SpaceBetween direction="horizontal" size="xxs">
-                  {item.tags.map((t) => (
-                    <Badge key={t}>{t}</Badge>
-                  ))}
+                  {item.tags.map((tag) => {
+                    const isActive = criteria.tags.includes(tag);
+                    return (
+                      <Button
+                        key={tag}
+                        variant={isActive ? "primary" : "inline-link"}
+                        onClick={() => setCriteria((prev) => toggleTagFilter(prev, tag))}
+                        ariaLabel={
+                          isActive ? `タグ ${tag} の絞り込みを解除` : `タグ ${tag} で絞り込む`
+                        }
+                      >
+                        {tag}
+                      </Button>
+                    );
+                  })}
                 </SpaceBetween>
               ),
             },
@@ -91,7 +254,14 @@ export function ProblemsPage() {
         cardsPerRow={[{ cards: 1 }, { minWidth: 700, cards: 2 }]}
         empty={
           <Box textAlign="center" color="inherit" padding="xxl">
-            問題がまだ登録されていません。
+            {isFilterActive(criteria) ? (
+              <SpaceBetween size="s">
+                <Box variant="p">条件に一致する問題はありません。</Box>
+                <Button onClick={() => setCriteria(EMPTY_FILTER_CRITERIA)}>絞り込み解除</Button>
+              </SpaceBetween>
+            ) : (
+              "問題がまだ登録されていません。"
+            )}
           </Box>
         }
       />


### PR DESCRIPTION
## Summary

- 問題カタログ page に **検索 / カテゴリ / 公開状態 / 難易度 / タグ** の 5 種類の絞り込みを実装 (Issue #834)。 タグ badge を click 可能にして 「そのタグ 1 件のみ active / 再 click で clear」 の toggle 挙動を追加 (Issue #835)。
- pure logic を \`lib/problem-filter.ts\` に分離。 20 unit tests で挙動 pin (= filter combinations / facet sort / toggle / search case-insensitive)。

## Behavior

- **検索 box**: name / shortDescription / tags を substring match、 case-insensitive。
- **カテゴリ filter** (SegmentedControl): \`全て / Battle / Challenge\`。
- **公開状態 filter** (SegmentedControl): \`全て / 公開中 / 下書き / 停止予定\`。
- **難易度 filter** (Multiselect): 1〜5 を multi-select。
- **タグ filter** (Multiselect): 全カタログから union された tag に count badge を付け、 出現頻度の降順 + タイは alphabetical で sort。 タグ複数選択時は OR/AND 切替 button。
- **タグ badge** (= 各カード内): click → そのタグ 1 件のみ active へ flip (= 累積 add したいときは header multi-select を使う設計)。 同タグ再 click で clear。
- **counter**: header に \`(filtered / total)\` 表示。 1 つでも filter active なら 「絞り込み解除」 button が出る。
- **empty state**: 0 hit のときは 「条件に一致する問題はありません + 絞り込み解除 button」、 元々 0 件のときは旧来通り 「問題がまだ登録されていません」。

## Out of scope (= Phase 2)

- URL params 反映 (shareable link)。 issue acceptance に挙がっているが、 React Router state を URL に sync する仕組み (= useSearchParams) は別 PR で扱う。
- カタログサイズが数十問を超えたときの virtual list / index pre-build (= 現状 4 問では不要)。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green
- [x] 新規 unit test 20 件: filter 各種 / AND組合 / facet sort / toggle 挙動 / search case-insensitive / empty 0 hit
- [ ] 手動: 検索 "battle" で Battle 系のみ残ること
- [ ] 手動: 難易度 5 + Battle category で microservice-migration-battle だけ残ること
- [ ] 手動: タグ "ec2" の badge click → \`tags: ["ec2"]\` で絞り込みされ、 同 badge 再 click で解除
- [ ] 手動: 0 hit empty state の 「絞り込み解除」 button が機能する

## Regression 分析

- 既存 \`ProblemSummary\` interface / \`listProblemSummaries\` は変更なし。 タグ display 変化のみ (Badge → Button)。
- タグ badge を Button にしたことで a11y は改善 (= ariaLabel 付き、 keyboard accessible)。 旧 Badge の見た目は維持 (variant=\`inline-link\`、 active 時 \`primary\`)。
- filter 空状態 (= 初期 / 絞り込み解除後) は元の \`listProblemSummaries()\` 全件を返す → 既存挙動を維持。

## 物理影響

- \`apps/application-admin-console/src/lib/problem-filter.ts\` — CREATE (= pure logic)
- \`apps/application-admin-console/src/lib/problem-filter.test.ts\` — CREATE (= 20 cases)
- \`apps/application-admin-console/src/pages/Problems.tsx\` — UPDATE (= filter UI 配線)
- インフラ / backend — NO-OP

Closes #834
Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)