### PR TITLE
fix(admin-console): split Jobs page into Provisioning / Deprovisioning tabs (#814)

### DIFF
--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -87,7 +87,13 @@
     "col_start_time": "Started",
     "col_elapsed": "Elapsed",
     "col_last_update": "Last update",
-    "open_console_aria": "Open execution {executionId} in AWS Console"
+    "open_console_aria": "Open execution {executionId} in AWS Console",
+    "tab_provisioning": "Provisioning",
+    "tab_deprovisioning": "Deprovisioning",
+    "deprovisioning_phase1_header": "Integration into this console is planned in Phase 2",
+    "deprovisioning_phase1_body": "Tenant deletion (deprovisioning) runs through the SBT BashJobRunner Step Functions state machine. The admin-insight Lambda currently only knows about the CodePipeline, so for now please inspect deprovisioning executions from the AWS Console > Step Functions list and filter state machines that contain 'deprovisioning' in their name.",
+    "deprovisioning_open_console": "Open Step Functions in AWS Console",
+    "deprovisioning_open_console_aria": "Open AWS Step Functions console (state machine list) in a new tab"
   },
   "tenant_events": {
     "missing_tenant_id": "tenantId is required.",

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -87,7 +87,13 @@
     "col_start_time": "Inicio",
     "col_elapsed": "Tiempo transcurrido",
     "col_last_update": "Última actualización",
-    "open_console_aria": "Abrir la ejecución {executionId} en la consola de AWS"
+    "open_console_aria": "Abrir la ejecución {executionId} en la consola de AWS",
+    "tab_provisioning": "Provisioning",
+    "tab_deprovisioning": "Deprovisioning",
+    "deprovisioning_phase1_header": "La integración en esta consola está prevista en Phase 2",
+    "deprovisioning_phase1_body": "La eliminación de tenants (deprovisioning) se ejecuta a través de la state machine de Step Functions del BashJobRunner de SBT. Por ahora, el Lambda admin-insight solo conoce el CodePipeline; revisa las ejecuciones de deprovisioning desde la consola AWS > Step Functions y filtra las state machines cuyo nombre contiene 'deprovisioning'.",
+    "deprovisioning_open_console": "Abrir Step Functions en la consola AWS",
+    "deprovisioning_open_console_aria": "Abrir la consola de AWS Step Functions (lista de state machines) en una nueva pestaña"
   },
   "tenant_events": {
     "missing_tenant_id": "Falta el tenantId.",

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -87,7 +87,13 @@
     "col_start_time": "開始時刻",
     "col_elapsed": "経過時間",
     "col_last_update": "最終更新",
-    "open_console_aria": "Execution {executionId} を AWS Console で開く"
+    "open_console_aria": "Execution {executionId} を AWS Console で開く",
+    "tab_provisioning": "Provisioning",
+    "tab_deprovisioning": "Deprovisioning",
+    "deprovisioning_phase1_header": "Phase 2 で本コンソールに統合予定です",
+    "deprovisioning_phase1_body": "テナント削除 (deprovisioning) は SBT BashJobRunner の Step Functions State Machine 経由で動作します。 現状 admin-insight Lambda は CodePipeline 専用で SFN を扱わないため、 当面は AWS Console > Step Functions で 'deprovisioning' を含むステートマシンの execution 履歴を確認してください。",
+    "deprovisioning_open_console": "AWS Console で Step Functions を開く",
+    "deprovisioning_open_console_aria": "AWS Step Functions コンソール (ステートマシン一覧) を新しいタブで開く"
   },
   "tenant_events": {
     "missing_tenant_id": "tenantId が指定されていません。",

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -87,7 +87,13 @@
     "col_start_time": "开始时间",
     "col_elapsed": "耗时",
     "col_last_update": "最后更新",
-    "open_console_aria": "在 AWS 控制台打开 execution {executionId}"
+    "open_console_aria": "在 AWS 控制台打开 execution {executionId}",
+    "tab_provisioning": "Provisioning",
+    "tab_deprovisioning": "Deprovisioning",
+    "deprovisioning_phase1_header": "计划在 Phase 2 集成到本控制台",
+    "deprovisioning_phase1_body": "租户删除 (deprovisioning) 通过 SBT BashJobRunner 的 Step Functions State Machine 执行。 当前 admin-insight Lambda 仅识别 CodePipeline,暂时请前往 AWS 控制台 > Step Functions,以 'deprovisioning' 关键字筛选 State Machine 来查看执行历史。",
+    "deprovisioning_open_console": "在 AWS 控制台打开 Step Functions",
+    "deprovisioning_open_console_aria": "在新标签页中打开 AWS Step Functions 控制台 (State Machine 列表)"
   },
   "tenant_events": {
     "missing_tenant_id": "未指定 tenantId。",

--- a/apps/admin-console/src/pages/Jobs.tsx
+++ b/apps/admin-console/src/pages/Jobs.tsx
@@ -3,9 +3,11 @@ import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
+import Tabs from "@cloudscape-design/components/tabs";
 import { StatusCodes } from "http-status-codes";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -167,12 +169,8 @@ export function JobsPage({ config }: { config: AppConfig }) {
     );
   }
 
-  return (
-    <SpaceBetween size="l">
-      <Header variant="h1" description={t("jobs_page.description")}>
-        {t("jobs_page.header")}
-      </Header>
-
+  const provisioningContent = (
+    <SpaceBetween size="m">
       {error && (
         <Alert
           type="error"
@@ -190,7 +188,7 @@ export function JobsPage({ config }: { config: AppConfig }) {
         </Box>
       ) : (
         <Table<PipelineExecutionItem>
-          variant="container"
+          variant="embedded"
           items={[...(items ?? [])]}
           trackBy="executionId"
           empty={
@@ -201,6 +199,65 @@ export function JobsPage({ config }: { config: AppConfig }) {
           columnDefinitions={columns}
         />
       )}
+    </SpaceBetween>
+  );
+
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1" description={t("jobs_page.description")}>
+        {t("jobs_page.header")}
+      </Header>
+
+      <Tabs
+        tabs={[
+          {
+            id: "provisioning",
+            label: t("jobs_page.tab_provisioning"),
+            content: provisioningContent,
+          },
+          {
+            id: "deprovisioning",
+            label: t("jobs_page.tab_deprovisioning"),
+            content: <DeprovisioningJobsTab awsRegion={config.awsRegion} />,
+          },
+        ]}
+      />
+    </SpaceBetween>
+  );
+}
+
+/**
+ * Issue #814: Deprovisioning Jobs (= SBT BashJobRunner の `deprovisioningJobRunner` が動かす
+ * Step Functions State Machine の execution 履歴) を表示するタブ。
+ *
+ * Phase 1 (本 PR): 既存 admin-insight Lambda は \`tenkacloud-saas-pipeline\` CodePipeline 専用で、
+ * Step Functions ListExecutions に対する route が未配線。 そのため operator を AWS Console
+ * の Step Functions list (= "deprovisioning" を含むステートマシンで絞り込み可能) に誘導する。
+ *
+ * Phase 2 (= 別 PR): admin-insight Lambda に \`GET /admin/insight/state-machine-executions\`
+ * route を追加し、 deprovisioningJobRunner.stateMachine.stateMachineArn を env 経由で渡して
+ * SFN ListExecutions を呼ぶ。 当 tab 内に Provisioning tab と同じ Table を表示する。
+ */
+function DeprovisioningJobsTab({ awsRegion }: { awsRegion: string }) {
+  const t = useT();
+  // 「Step Functions コンソールを開く」 deep link。 awsRegion が空文字 (= dev fallback)
+  // の場合は ap-northeast-1 を仮置きする (= 本 link は production 用途、 dev では押せても無効)。
+  const region = awsRegion || "ap-northeast-1";
+  const sfnListUrl = `https://${region}.console.aws.amazon.com/states/home?region=${region}#/statemachines`;
+  return (
+    <SpaceBetween size="m">
+      <Alert type="info" header={t("jobs_page.deprovisioning_phase1_header")}>
+        {t("jobs_page.deprovisioning_phase1_body")}
+      </Alert>
+      <Box>
+        <Link
+          external
+          href={sfnListUrl}
+          ariaLabel={t("jobs_page.deprovisioning_open_console_aria")}
+        >
+          {t("jobs_page.deprovisioning_open_console")}
+        </Link>
+      </Box>
     </SpaceBetween>
   );
 }


### PR DESCRIPTION
## Summary

- admin-console の Jobs page を 2 tabs (Provisioning / Deprovisioning) 構造に変更 (Issue #814)。 既存 Provisioning 表示は touch せず、 新規 Deprovisioning tab を追加して operator が tenant 削除の進行を可視化できるようにする。
- Phase 1 (本 PR): Deprovisioning tab は **AWS Console > Step Functions** への deep link を出す Alert + Link を表示。 admin-insight Lambda が現状 CodePipeline 専用なので、 SBT BashJobRunner の State Machine execution 履歴は AWS Console から確認する誘導文付き。
- Phase 2 (= 別 issue / 別 PR): \`AdminConsoleInsightStack\` で \`deprovisioningJobRunner.stateMachine.stateMachineArn\` を Lambda env に渡し、 \`GET /admin/insight/state-machine-executions\` route を追加して同 tab 内に Table 表示する。 CDK 担当範囲のため本 PR は frontend に閉じる。

## Why split now even with Phase 2 pending

operator は現状 「tenant 削除した」 → 「削除完了したか分からない」 → 「AWS Console のどこを見ればいいのか分からない」 で詰む。 Phase 1 だけでも 「Step Functions の deprovisioning State Machine を見ればいい」 という Discovery を Console 上で完結させる価値がある。 Phase 2 で本格 integration するまでの bridge。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green (= 120 admin-console tests)
- [x] i18n 4 言語 (ja / en / es / zh) で 5 新 keys 追加、 既存テスト 「key set 整合性」 を壊さない
- [ ] 手動: Provisioning tab で既存通り pipeline execution 一覧が出る
- [ ] 手動: Deprovisioning tab で deep link が新タブで AWS Step Functions list を開く
- [ ] 手動: 4 言語で文言が切り替わる

## Regression 分析

- 既存 Provisioning 表示の Table / polling / 列定義 / aria-label は全て不変。 \`SpaceBetween > Table\` を \`Tabs > tab > SpaceBetween > Table\` に内側に 1 階層下げただけ。
- Table の \`variant\` を \`container\` → \`embedded\` に変更 (= Tabs 内で 2 重 container を避けるため、 Cloudscape 標準パターン)。
- \`config.awsRegion\` が空文字 (= dev fallback) でも deep link は \`ap-northeast-1\` を仮置きする (= production では runtime-config 経由で正しい region が来る、 dev では押せても無効で safe)。

## 物理影響

- \`apps/admin-console/src/pages/Jobs.tsx\` — UPDATE (= Tabs 構造化 + DeprovisioningJobsTab 追加)
- \`apps/admin-console/src/i18n/locales/{ja,en,es,zh}.json\` — UPDATE (= 5 keys × 4 言語)
- インフラ / backend — NO-OP (= Phase 2 で AdminConsoleInsightStack 側に Step Functions wiring を追加する別 PR を立てる)

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)