### PR TITLE
fix(portal): add post-competition cleanup panel + enhanced template README (#840)

### DIFF
--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -134,6 +134,84 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
             />
           </Container>
         ))}
+
+      {view && view.problems.length > 0 && (
+        <PostCompetitionCleanupPanel
+          firstAccount={view.problems[0]?.awsAccountId}
+          firstRegion={view.problems[0]?.region}
+        />
+      )}
     </SpaceBetween>
+  );
+}
+
+/**
+ * Issue #840: 競技終了後の片付け案内。 競技者 AWS Account には `tenkacloud-competitor-bootstrap`
+ * stack (= TenkaCloud 運営側が AssumeRole するための IAM Role) が残り続けるので、 競技を終えたら
+ * 競技者自身が CFn DeleteStack することで TenkaCloud 側からの AssumeRole 経路を即時撤回できる。
+ *
+ * Phase 1 (本 PR): doc + AWS Console deep link を出す。 portal から cross-account で
+ * cleanup する経路は backend 側の追加実装が必要なため Phase 2 で扱う (= 別 PR、 CDK 担当範囲)。
+ */
+function PostCompetitionCleanupPanel({
+  firstAccount,
+  firstRegion,
+}: {
+  firstAccount: string | undefined;
+  firstRegion: string | undefined;
+}) {
+  const region = firstRegion || "ap-northeast-1";
+  // AWS Console deep link to CloudFormation の stack detail page (= 競技者 account にログイン中なら直接遷移可)。
+  const consoleUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks?filteringText=tenkacloud-competitor-bootstrap`;
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description="競技を終えたら IAM Role を撤回して TenkaCloud からの AssumeRole 経路を閉じます。"
+        >
+          競技後の環境片付け
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <Box variant="p">
+          competition 中に作成した <code>tenkacloud-competitor-bootstrap</code> stack (= IAM Role)
+          は、 競技後も AWS Account に残ります。 残ったままだと TenkaCloud 運営側からの AssumeRole
+          が 有効なままなので、 競技を終えたら次のいずれかの方法で削除してください。
+        </Box>
+        <Box variant="h4">方法 A: CLI で 1 行削除</Box>
+        <Box variant="code">
+          aws cloudformation delete-stack --stack-name tenkacloud-competitor-bootstrap
+        </Box>
+        <Box variant="h4">方法 B: AWS Console から削除</Box>
+        <Button
+          variant="normal"
+          iconName="external"
+          href={consoleUrl}
+          target="_blank"
+          ariaLabel="競技者 AWS Account の CloudFormation スタック一覧を新しいタブで開く"
+        >
+          CloudFormation スタック一覧を開く
+        </Button>
+        <Alert type="info">
+          {firstAccount && (
+            <>
+              対象 Account: <code>{firstAccount}</code> / Region: <code>{region}</code>。
+            </>
+          )}
+          stack を削除すると Role も同時に消え、 以降 TenkaCloud 側からの AssumeRole は即時 deny
+          されます。 AWS Console での手動 delete も同じ効果です。 詳しい手順とセキュリティ前提は{" "}
+          <a
+            href="https://github.com/susumutomita/TenkaCloud/blob/main/infrastructure/templates/README.md#%E6%92%A4%E5%9B%9E--%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%A2%E3%83%83%E3%83%97"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            infrastructure/templates/README.md
+          </a>{" "}
+          を参照してください。
+        </Alert>
+      </SpaceBetween>
+    </Container>
   );
 }

--- a/infrastructure/templates/README.md
+++ b/infrastructure/templates/README.md
@@ -62,9 +62,35 @@ TenkaCloud 側はこの ARN と ExternalId を用いて AssumeRole し、問題 
 
 このスタックを削除すると Role も消える ⇒ TenkaCloud からの AssumeRole が即時に拒否される。
 
+#### 競技後の片付け (推奨)
+
+競技を終えたら、 必ず stack を削除してください。 残したままにすると TenkaCloud
+運営側が AssumeRole 可能な状態が継続します (= 攻撃面 + コスト両面でクリーンに
+保つため)。
+
+##### 方法 A: CLI で 1 行削除 (推奨)
+
 ```bash
 aws cloudformation delete-stack --stack-name tenkacloud-competitor-bootstrap
+# 削除完了を待つ場合 (option):
+aws cloudformation wait stack-delete-complete --stack-name tenkacloud-competitor-bootstrap
 ```
+
+##### 方法 B: AWS Console から削除
+
+1. AWS Console > CloudFormation > スタック一覧
+2. `tenkacloud-competitor-bootstrap` を選択
+3. 「削除」→「スタックの削除」を確認
+
+Console / CLI どちらの経路でも結果は同じ (= IAM Role が即時消える)。 Issue #840 は
+Participant Portal 側に「環境を片付ける」button を追加して同操作を 1-click 化する
+予定ですが、 現状は上記いずれかを競技者ご自身で実行してください。
+
+#### 即時撤回 (競技中の trust 取り消し)
+
+万が一 External ID が漏れた場合などは、 競技中でも上記コマンドで stack を削除して
+trust を即時撤回できます。 削除後はあらためて生成した External ID で再 deploy
+すれば trust が復旧します。
 
 ### セキュリティ上の前提
 


### PR DESCRIPTION
## Summary

- 競技者 AWS Account に残る \`tenkacloud-competitor-bootstrap\` stack (= IAM Role) を削除する UI 導線と doc が無く、 競技後も TenkaCloud 運営側から AssumeRole 可能な状態が放置されていた問題 (Issue #840) を Phase 1 で解決する。
- Participant Portal \`SsoCredentials\` page に \`PostCompetitionCleanupPanel\` を追加: CLI 1-liner + AWS Console deep link (= 競技者 account の region に合わせた CFn stack list、 \`tenkacloud-competitor-bootstrap\` filter 付き) + 対象 Account / Region を inline 表示。
- \`infrastructure/templates/README.md\` の 「撤回 / クリーンアップ」 section を拡張: 「競技後の片付け (推奨)」 と 「即時撤回 (= security incident 時)」 を分離 + 方法 A (CLI) / 方法 B (AWS Console) を明示。

## Phase 2 scope (= 別 PR / CDK 担当範囲)

portal 内で 1-click 削除を実現する場合、 backend に次が要る:
- participant-handler Lambda に \`cloudformation:DeleteStack\` 権限
- 競技者 account に AssumeRole するための trust policy / Role-name 配線
- 「これは取り返しの付かない操作」 確認 modal を portal に追加

本 PR は **frontend + doc のみ** に閉じる (= CDK / IAM / Lambda 変更なし)。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems すべて green
- [ ] 手動: SsoCredentials page を開くと最下部に 「競技後の環境片付け」 Container が表示される
- [ ] 手動: 「CloudFormation スタック一覧を開く」 button で competitor account の region に合わせた deep link が新タブで開く
- [ ] 手動: CLI 1-liner をコピー → 競技者 account で実行 → stack 削除完了

## Regression 分析

- 既存 SsoCredentials page の挙動 (= AWS Console federation login button per deployment) は touch しない。 cleanup panel は \`view.problems.length > 0\` のときだけ末尾に表示する追加 Container。
- doc 更新は markdownlint / textlint いずれも pass。 既存 「撤回 / クリーンアップ」 section の CLI 例は残置 (= 旧来 deep link で参照されている可能性に配慮)。

## 物理影響

- \`apps/participant-portal/src/pages/SsoCredentials.tsx\` — UPDATE (= cleanup panel 追加)
- \`infrastructure/templates/README.md\` — UPDATE (= 「競技後の片付け」 / 「即時撤回」 sub-section 追加)
- インフラ / backend — NO-OP

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)