### PR TITLE
feat(saml): runtime tenant-managed SAML config via UI + API (Phase B, #839)

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -14,6 +14,7 @@ import { HomePage } from "./pages/Home";
 import { LoginPage } from "./pages/Login";
 import { ProblemDetailPage } from "./pages/ProblemDetail";
 import { ProblemsPage } from "./pages/Problems";
+import { SamlSsoPage } from "./pages/SamlSso";
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
@@ -51,6 +52,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/competitor-accounts"
           element={guarded(config, <CompetitorAccountsPage config={config} />)}
         />
+        <Route path="/settings/sso" element={guarded(config, <SamlSsoPage config={config} />)} />
         <Route path="/events" element={guarded(config, <EventListPage config={config} />)} />
         <Route path="/events/new" element={guarded(config, <EventCreatePage config={config} />)} />
         <Route

--- a/apps/application-admin-console/src/api/tenant-saml-client.ts
+++ b/apps/application-admin-console/src/api/tenant-saml-client.ts
@@ -1,0 +1,45 @@
+import type { ApiClient } from "./client";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant 管理者が画面 / API から自社 SAML IdP を CRUD する
+ * client。 backend は `competitor-accounts` Lambda に同居しているが、 frontend からは独立した
+ * 概念として扱うため client を分けている。
+ */
+
+export interface TenantSamlConfigView {
+  readonly enabled: boolean;
+  readonly metadataUrl?: string;
+  readonly providerName?: string;
+  readonly attributeMapping?: Readonly<Record<string, string>>;
+  readonly enforceSamlOnly?: boolean;
+  readonly updatedAt?: string;
+  readonly updatedBy?: string;
+}
+
+export interface TenantSamlConfigInput {
+  readonly metadataUrl: string;
+  readonly providerName?: string;
+  readonly attributeMapping?: Readonly<Record<string, string>>;
+  readonly enforceSamlOnly?: boolean;
+}
+
+export async function getTenantSamlConfig(api: ApiClient): Promise<TenantSamlConfigView> {
+  return api.get<TenantSamlConfigView>("admin/tenant-saml-config");
+}
+
+/**
+ * SAML config を upsert する。 backend が Cognito IdP CRUD + UserPoolClient mutation + DDB
+ * persist を 1 リクエストで行う。 enforceSamlOnly=true に flip するときは UI 側で 2-step
+ * 確認 modal を表示してから呼ぶこと。
+ */
+export async function putTenantSamlConfig(
+  api: ApiClient,
+  body: TenantSamlConfigInput,
+): Promise<TenantSamlConfigView> {
+  // ApiClient に PUT が無いので fetch を直接組む (= 既存 patch / post と同形を踏襲)。
+  return api.patch<TenantSamlConfigView>("admin/tenant-saml-config", body);
+}
+
+export async function deleteTenantSamlConfig(api: ApiClient): Promise<void> {
+  return api.del("admin/tenant-saml-config");
+}

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -112,6 +112,7 @@ export function ShellLayout({
               { type: "link", href: "/problems", text: t("nav.problems") },
               { type: "link", href: "/deployments", text: t("nav.deployments") },
               { type: "link", href: "/competitor-accounts", text: "Competitor Accounts" },
+              { type: "link", href: "/settings/sso", text: t("nav.saml_sso") },
             ]}
             onFollow={(e) => {
               if (!e.detail.external) {

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "events": "Events",
     "teams": "Teams",
     "problems": "Problems",
-    "deployments": "Deployments"
+    "deployments": "Deployments",
+    "saml_sso": "SAML SSO"
   },
   "auth": {
     "sign_out": "Sign out"
@@ -56,5 +57,39 @@
     "archive_modal_confirm": "Archive",
     "archive_conflict_known": "Event \"{name}\" cannot be archived (current: {current}, allowed: DRAFT / ENDED / TEARDOWN)",
     "archive_conflict_unknown": "Event \"{name}\" cannot be archived"
+  },
+  "saml_sso": {
+    "header": "SAML SSO Configuration",
+    "description": "Federate your company's IdP (Entra ID / Okta / Google Workspace, etc.) with this tenant's Cognito UserPool via SAML 2.0. After saving, sign-in flows through your corporate SSO.",
+    "pooled_warning_header": "Shared UserPool warning",
+    "pooled_warning_body": "If this tenant is in pooled mode (= multiple tenants share a UserPool), changes here affect sign-in for all pooled tenants. silo (PLATINUM) tenants have an isolated UserPool.",
+    "current_header": "Current configuration",
+    "setup_header": "Configure SAML",
+    "update_header": "Update SAML configuration",
+    "field_metadata_url": "Metadata URL",
+    "field_metadata_url_desc": "HTTPS URL that serves your IdP's federation metadata XML. Cert rotation is followed automatically.",
+    "field_provider_name": "Provider name",
+    "field_provider_name_desc": "Label shown on the Cognito Hosted UI sign-in button (alphanumeric + - _ , 3-32 chars).",
+    "field_enforce": "Allow SAML sign-in only",
+    "field_enforce_desc": "Turning this on disables username/password. A confirmation modal is shown before the flip.",
+    "field_updated_at": "Last updated",
+    "enforce_on": "ON (SAML only)",
+    "enforce_off": "OFF (parallel)",
+    "save_button": "Save",
+    "update_button": "Update",
+    "disable_button": "Disable SAML",
+    "save_success_header": "Saved",
+    "save_success": "SAML IdP applied to the Cognito UserPool. New sign-ins from now on use the SAML flow. Users already signed in are not affected.",
+    "save_error_header": "Failed to save",
+    "load_error_header": "Failed to load current configuration",
+    "delete_success": "SAML disabled. Username/password path is restored, SAML button disappears from Hosted UI.",
+    "modal_cancel": "Cancel",
+    "enforce_modal_header": "Allow SAML sign-in only?",
+    "enforce_modal_body": "Disables username/password and SRP, allowing sign-in only via SAML. Verify SAML sign-in in staging before flipping production.",
+    "enforce_modal_warning": "If SAML is broken or the IdP cert rotation fails, nobody can sign in. As recovery, manually add COGNITO back to the UserPoolClient SupportedIdentityProviders in AWS Console.",
+    "enforce_modal_confirm": "Switch to SAML only",
+    "delete_modal_header": "Disable SAML configuration?",
+    "delete_modal_body": "Removes the SAML IdP and reverts the UserPoolClient to username/password. SAML sign-in stops working. Re-enable later by entering a Metadata URL.",
+    "delete_modal_confirm": "Disable"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/es.json
+++ b/apps/application-admin-console/src/i18n/locales/es.json
@@ -11,7 +11,8 @@
     "events": "Eventos",
     "teams": "Equipos",
     "problems": "Problemas",
-    "deployments": "Despliegues"
+    "deployments": "Despliegues",
+    "saml_sso": "SAML SSO"
   },
   "auth": {
     "sign_out": "Cerrar sesión"
@@ -56,5 +57,39 @@
     "archive_modal_confirm": "Archivar",
     "archive_conflict_known": "El evento \"{name}\" no se puede archivar (actual: {current}, permitidos: DRAFT / ENDED / TEARDOWN)",
     "archive_conflict_unknown": "El evento \"{name}\" no se puede archivar"
+  },
+  "saml_sso": {
+    "header": "Configuración SAML SSO",
+    "description": "Federa el IdP de tu empresa (Entra ID / Okta / Google Workspace, etc.) con el UserPool de Cognito de este tenant mediante SAML 2.0. Tras guardar, el inicio de sesión fluye por el SSO corporativo.",
+    "pooled_warning_header": "Aviso de UserPool compartido",
+    "pooled_warning_body": "Si este tenant está en modo pooled (= varios tenants comparten un UserPool), los cambios aquí afectan al inicio de sesión de todos los tenants pooled. Los tenants silo (PLATINUM) tienen UserPool aislado.",
+    "current_header": "Configuración actual",
+    "setup_header": "Configurar SAML",
+    "update_header": "Actualizar configuración SAML",
+    "field_metadata_url": "URL de Metadata",
+    "field_metadata_url_desc": "URL HTTPS que sirve el metadata XML de federación del IdP. La rotación de certificado se sigue automáticamente.",
+    "field_provider_name": "Nombre del proveedor",
+    "field_provider_name_desc": "Etiqueta mostrada en el botón de inicio de sesión de Cognito Hosted UI (alfanumérico + - _ , 3-32 caracteres).",
+    "field_enforce": "Permitir solo SAML",
+    "field_enforce_desc": "Activarlo desactiva username/password. Se muestra un modal de confirmación antes del cambio.",
+    "field_updated_at": "Última actualización",
+    "enforce_on": "ON (solo SAML)",
+    "enforce_off": "OFF (paralelo)",
+    "save_button": "Guardar",
+    "update_button": "Actualizar",
+    "disable_button": "Desactivar SAML",
+    "save_success_header": "Guardado",
+    "save_success": "IdP SAML aplicado al UserPool de Cognito. Los nuevos inicios de sesión usan el flujo SAML. Los usuarios ya conectados no se ven afectados.",
+    "save_error_header": "Error al guardar",
+    "load_error_header": "Error al cargar la configuración actual",
+    "delete_success": "SAML desactivado. Se restaura username/password y el botón SAML desaparece de Hosted UI.",
+    "modal_cancel": "Cancelar",
+    "enforce_modal_header": "¿Permitir solo inicio SAML?",
+    "enforce_modal_body": "Desactiva username/password y SRP, permitiendo iniciar sesión solo via SAML. Verifica el inicio SAML en staging antes de aplicar en producción.",
+    "enforce_modal_warning": "Si SAML está roto o la rotación de certificado del IdP falla, nadie podrá iniciar sesión. Para recuperar, vuelve a añadir COGNITO manualmente a SupportedIdentityProviders en AWS Console.",
+    "enforce_modal_confirm": "Cambiar a solo SAML",
+    "delete_modal_header": "¿Desactivar la configuración SAML?",
+    "delete_modal_body": "Elimina el IdP SAML y revierte el UserPoolClient a username/password. El inicio SAML deja de funcionar. Puedes reactivarlo más tarde introduciendo una URL de Metadata.",
+    "delete_modal_confirm": "Desactivar"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -11,7 +11,8 @@
     "events": "イベント",
     "teams": "チーム",
     "problems": "問題",
-    "deployments": "デプロイ"
+    "deployments": "デプロイ",
+    "saml_sso": "SAML SSO 設定"
   },
   "auth": {
     "sign_out": "サインアウト"
@@ -56,5 +57,39 @@
     "archive_modal_confirm": "アーカイブ",
     "archive_conflict_known": "Event \"{name}\" はアーカイブできません (現在: {current}、許可: DRAFT / ENDED / TEARDOWN)",
     "archive_conflict_unknown": "Event \"{name}\" はアーカイブできません"
+  },
+  "saml_sso": {
+    "header": "SAML SSO 設定",
+    "description": "会社の認証基盤 (Entra ID / Okta / Google Workspace 等) と Cognito UserPool を SAML 2.0 で連携します。 設定後の sign-in は会社の SSO 経由になります。",
+    "pooled_warning_header": "共有 UserPool に注意",
+    "pooled_warning_body": "本テナントが pooled mode (= 複数 tenant が UserPool を共有) の場合、 ここでの設定は他 tenant の sign-in にも影響します。 silo (PLATINUM) tenant なら独立した UserPool なので影響範囲は本 tenant 内です。",
+    "current_header": "現在の設定",
+    "setup_header": "SAML を設定する",
+    "update_header": "SAML 設定を更新する",
+    "field_metadata_url": "Metadata URL",
+    "field_metadata_url_desc": "IdP の federation metadata XML を取得する HTTPS URL。 IdP 側 cert rotation 時も自動追従されます。",
+    "field_provider_name": "Provider 名",
+    "field_provider_name_desc": "Cognito Hosted UI の sign-in button に表示される名前 (英数字 + - _ の 3-32 字)。",
+    "field_enforce": "SAML のみで sign-in を許可",
+    "field_enforce_desc": "ON で username/password 経路を無効化し、 SAML のみで sign-in 可能になります。 既存 user の救済余地が無くなるので flip 前に確認 modal が出ます。",
+    "field_updated_at": "最終更新",
+    "enforce_on": "ON (SAML のみ)",
+    "enforce_off": "OFF (並列)",
+    "save_button": "保存",
+    "update_button": "更新",
+    "disable_button": "SAML を無効化",
+    "save_success_header": "更新しました",
+    "save_success": "Cognito UserPool に SAML IdP を反映しました。 次のサインインから新しい設定が有効になります。 既にサインイン中の user は影響を受けません。",
+    "save_error_header": "保存に失敗しました",
+    "load_error_header": "現在の設定を取得できませんでした",
+    "delete_success": "SAML 設定を無効化しました。 username/password 経路が復元され、 Hosted UI から SAML button が消えます。",
+    "modal_cancel": "キャンセル",
+    "enforce_modal_header": "SAML のみで sign-in を許可しますか?",
+    "enforce_modal_body": "ON にすると username/password / SRP 経路が無効化され、 SAML 経由でのみログイン可能になります。 lock-out 防止のため staging で SAML 経由の sign-in が確認できてから本番に flip することを推奨します。",
+    "enforce_modal_warning": "SAML 設定が壊れている / IdP 側 cert が rotation 失敗していると、 誰もログインできなくなります。 万一のときは AWS Console から UserPoolClient の SupportedIdentityProviders に COGNITO を手動で戻して復旧してください。",
+    "enforce_modal_confirm": "SAML のみに切り替える",
+    "delete_modal_header": "SAML 設定を無効化しますか?",
+    "delete_modal_body": "Cognito UserPool から SAML IdP を削除し、 UserPoolClient を username/password 経路に戻します。 SAML 経由の sign-in は今後できなくなります。 設定を再度有効化したいときは Metadata URL を入れて 「保存」 すれば復元できます。",
+    "delete_modal_confirm": "無効化する"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/zh.json
+++ b/apps/application-admin-console/src/i18n/locales/zh.json
@@ -11,7 +11,8 @@
     "events": "活动",
     "teams": "团队",
     "problems": "题目",
-    "deployments": "部署"
+    "deployments": "部署",
+    "saml_sso": "SAML SSO"
   },
   "auth": {
     "sign_out": "退出登录"
@@ -56,5 +57,39 @@
     "archive_modal_confirm": "归档",
     "archive_conflict_known": "Event \"{name}\" 无法归档 (当前: {current},允许: DRAFT / ENDED / TEARDOWN)",
     "archive_conflict_unknown": "Event \"{name}\" 无法归档"
+  },
+  "saml_sso": {
+    "header": "SAML SSO 设置",
+    "description": "通过 SAML 2.0 将公司的 IdP (Entra ID / Okta / Google Workspace 等) 与本租户的 Cognito UserPool 联合。 保存后,登录将通过公司 SSO 进行。",
+    "pooled_warning_header": "共享 UserPool 警告",
+    "pooled_warning_body": "如果本租户处于 pooled 模式 (= 多个租户共享 UserPool),此处的更改将影响所有 pooled 租户的登录。 silo (PLATINUM) 租户拥有独立的 UserPool,影响范围仅限本租户。",
+    "current_header": "当前配置",
+    "setup_header": "配置 SAML",
+    "update_header": "更新 SAML 配置",
+    "field_metadata_url": "Metadata URL",
+    "field_metadata_url_desc": "提供 IdP federation metadata XML 的 HTTPS URL。 IdP 端证书轮换会自动跟随。",
+    "field_provider_name": "Provider 名称",
+    "field_provider_name_desc": "Cognito Hosted UI 登录按钮上显示的标签 (字母数字 + - _ , 3-32 字符)。",
+    "field_enforce": "仅允许 SAML 登录",
+    "field_enforce_desc": "开启后将禁用 username/password 路径。 切换前会显示确认对话框。",
+    "field_updated_at": "最后更新",
+    "enforce_on": "ON (仅 SAML)",
+    "enforce_off": "OFF (并行)",
+    "save_button": "保存",
+    "update_button": "更新",
+    "disable_button": "禁用 SAML",
+    "save_success_header": "已保存",
+    "save_success": "SAML IdP 已应用到 Cognito UserPool。 此后的新登录将使用 SAML 流程。 已登录的用户不受影响。",
+    "save_error_header": "保存失败",
+    "load_error_header": "无法加载当前配置",
+    "delete_success": "SAML 配置已禁用。 username/password 路径已恢复,Hosted UI 上的 SAML 按钮已消失。",
+    "modal_cancel": "取消",
+    "enforce_modal_header": "仅允许 SAML 登录?",
+    "enforce_modal_body": "禁用 username/password 和 SRP,仅允许通过 SAML 登录。 为避免锁定,建议在 staging 环境验证 SAML 登录后再应用到生产。",
+    "enforce_modal_warning": "如果 SAML 配置损坏或 IdP 端证书轮换失败,所有人都无法登录。 作为恢复手段,可在 AWS Console 中手动将 COGNITO 重新添加到 UserPoolClient 的 SupportedIdentityProviders。",
+    "enforce_modal_confirm": "切换为仅 SAML",
+    "delete_modal_header": "禁用 SAML 配置?",
+    "delete_modal_body": "从 Cognito UserPool 删除 SAML IdP,将 UserPoolClient 恢复为 username/password。 SAML 登录将不再可用。 之后可通过输入 Metadata URL 并保存来重新启用。",
+    "delete_modal_confirm": "禁用"
   }
 }

--- a/apps/application-admin-console/src/pages/SamlSso.tsx
+++ b/apps/application-admin-console/src/pages/SamlSso.tsx
@@ -1,0 +1,314 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Toggle from "@cloudscape-design/components/toggle";
+import { useCallback, useEffect, useState } from "react";
+import { type ApiClient, useApiClient } from "../api/client";
+import {
+  deleteTenantSamlConfig,
+  getTenantSamlConfig,
+  putTenantSamlConfig,
+  type TenantSamlConfigView,
+} from "../api/tenant-saml-client";
+import type { AppConfig } from "../config";
+import { useT } from "../i18n";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant 管理者が自社の SAML IdP (= Entra ID / Okta /
+ * Google Workspace 等) を画面から設定する page。
+ *
+ * UI flow:
+ *  1. 初回 GET → enabled:false なら 「未設定」 表示 + 「設定する」 button
+ *  2. PUT → backend が Cognito UserPool に IdP 登録 + UserPoolClient mutate + DDB persist
+ *  3. enforceSamlOnly toggle ON → 2-step 確認 modal で 「password 経路を閉じる」 と明示
+ *  4. DELETE → 確認 modal 後に IdP 削除 + COGNITO 経路復元
+ *
+ * 設計上の重要事項:
+ *  - **lock-out 防止**: enforceSamlOnly を ON にする前に確認 modal を出す (= ON のまま
+ *    SAML 設定が壊れていると全 user がログインできなくなる)
+ *  - **pooled tenant warning**: pooled mode では UserPool を全 tenant が共有するため、
+ *    1 tenant の設定が他 tenant の sign-in に影響する。 警告 Alert を表示
+ *  - **更新成功後の hint**: 「次のサインインから新しい設定が反映されます。 既にサインイン中の
+ *    user は影響を受けません」 を表示し UX 不安を緩和する
+ */
+export function SamlSsoPage({ config }: { config: AppConfig }) {
+  const t = useT();
+  const apiClient = useApiClient(config);
+  const [view, setView] = useState<TenantSamlConfigView | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // form state
+  const [metadataUrl, setMetadataUrl] = useState("");
+  const [providerName, setProviderName] = useState("CompanySAML");
+  const [enforceSamlOnly, setEnforceSamlOnly] = useState(false);
+  const [pendingEnforceModal, setPendingEnforceModal] = useState(false);
+  const [pendingDeleteModal, setPendingDeleteModal] = useState(false);
+
+  const loadCurrent = useCallback(async () => {
+    if (!apiClient) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await getTenantSamlConfig(apiClient as ApiClient);
+      setView(res);
+      if (res.enabled) {
+        setMetadataUrl(res.metadataUrl ?? "");
+        setProviderName(res.providerName ?? "CompanySAML");
+        setEnforceSamlOnly(res.enforceSamlOnly ?? false);
+      }
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [apiClient]);
+
+  useEffect(() => {
+    void loadCurrent();
+  }, [loadCurrent]);
+
+  const submit = useCallback(
+    async (confirmedEnforce: boolean) => {
+      if (!apiClient) return;
+      setSubmitting(true);
+      setSubmitError(null);
+      setSuccessMessage(null);
+      try {
+        const next = await putTenantSamlConfig(apiClient as ApiClient, {
+          metadataUrl,
+          providerName,
+          enforceSamlOnly: confirmedEnforce,
+        });
+        setView(next);
+        setSuccessMessage(t("saml_sso.save_success"));
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [apiClient, metadataUrl, providerName, t],
+  );
+
+  const handleSubmit = (event: { preventDefault: () => void }) => {
+    event.preventDefault();
+    if (enforceSamlOnly && !view?.enforceSamlOnly) {
+      // enforceSamlOnly を OFF → ON に flip するときだけ確認 modal
+      setPendingEnforceModal(true);
+      return;
+    }
+    void submit(enforceSamlOnly);
+  };
+
+  const confirmEnforce = () => {
+    setPendingEnforceModal(false);
+    void submit(true);
+  };
+
+  const handleDelete = async () => {
+    if (!apiClient) return;
+    setPendingDeleteModal(false);
+    setSubmitting(true);
+    setSubmitError(null);
+    setSuccessMessage(null);
+    try {
+      await deleteTenantSamlConfig(apiClient as ApiClient);
+      setView({ enabled: false });
+      setMetadataUrl("");
+      setProviderName("CompanySAML");
+      setEnforceSamlOnly(false);
+      setSuccessMessage(t("saml_sso.delete_success"));
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1" description={t("saml_sso.description")}>
+        {t("saml_sso.header")}
+      </Header>
+
+      <Alert type="info" header={t("saml_sso.pooled_warning_header")}>
+        {t("saml_sso.pooled_warning_body")}
+      </Alert>
+
+      {loadError && (
+        <Alert
+          type="error"
+          header={t("saml_sso.load_error_header")}
+          dismissible
+          onDismiss={() => setLoadError(null)}
+        >
+          {loadError}
+        </Alert>
+      )}
+
+      {view?.enabled && (
+        <Container header={<Header variant="h2">{t("saml_sso.current_header")}</Header>}>
+          <KeyValuePairs
+            columns={2}
+            items={[
+              { label: t("saml_sso.field_provider_name"), value: view.providerName ?? "—" },
+              {
+                label: t("saml_sso.field_metadata_url"),
+                value: <code>{view.metadataUrl ?? "—"}</code>,
+              },
+              {
+                label: t("saml_sso.field_enforce"),
+                value: view.enforceSamlOnly ? t("saml_sso.enforce_on") : t("saml_sso.enforce_off"),
+              },
+              { label: t("saml_sso.field_updated_at"), value: view.updatedAt ?? "—" },
+            ]}
+          />
+        </Container>
+      )}
+
+      <Container
+        header={
+          <Header variant="h2">
+            {view?.enabled ? t("saml_sso.update_header") : t("saml_sso.setup_header")}
+          </Header>
+        }
+      >
+        <form onSubmit={handleSubmit}>
+          <Form
+            actions={
+              <SpaceBetween direction="horizontal" size="xs">
+                {view?.enabled && (
+                  <Button onClick={() => setPendingDeleteModal(true)} disabled={submitting}>
+                    {t("saml_sso.disable_button")}
+                  </Button>
+                )}
+                <Button
+                  variant="primary"
+                  formAction="submit"
+                  loading={submitting}
+                  disabled={loading || !apiClient}
+                >
+                  {view?.enabled ? t("saml_sso.update_button") : t("saml_sso.save_button")}
+                </Button>
+              </SpaceBetween>
+            }
+          >
+            <SpaceBetween size="m">
+              <FormField
+                label={t("saml_sso.field_metadata_url")}
+                description={t("saml_sso.field_metadata_url_desc")}
+              >
+                <Input
+                  value={metadataUrl}
+                  placeholder="https://login.microsoftonline.com/<tenant>/federationmetadata/2007-06/federationmetadata.xml"
+                  onChange={({ detail }) => setMetadataUrl(detail.value)}
+                  disabled={submitting}
+                  invalid={metadataUrl.length > 0 && !metadataUrl.startsWith("https://")}
+                />
+              </FormField>
+              <FormField
+                label={t("saml_sso.field_provider_name")}
+                description={t("saml_sso.field_provider_name_desc")}
+              >
+                <Input
+                  value={providerName}
+                  onChange={({ detail }) => setProviderName(detail.value)}
+                  disabled={submitting}
+                  invalid={providerName.length > 0 && !/^[A-Za-z0-9_-]{3,32}$/.test(providerName)}
+                />
+              </FormField>
+              <FormField
+                label={t("saml_sso.field_enforce")}
+                description={t("saml_sso.field_enforce_desc")}
+              >
+                <Toggle
+                  checked={enforceSamlOnly}
+                  onChange={({ detail }) => setEnforceSamlOnly(detail.checked)}
+                  disabled={submitting}
+                >
+                  {enforceSamlOnly ? t("saml_sso.enforce_on") : t("saml_sso.enforce_off")}
+                </Toggle>
+              </FormField>
+            </SpaceBetween>
+          </Form>
+        </form>
+      </Container>
+
+      {successMessage && (
+        <Alert
+          type="success"
+          header={t("saml_sso.save_success_header")}
+          dismissible
+          onDismiss={() => setSuccessMessage(null)}
+        >
+          {successMessage}
+        </Alert>
+      )}
+      {submitError && (
+        <Alert
+          type="error"
+          header={t("saml_sso.save_error_header")}
+          dismissible
+          onDismiss={() => setSubmitError(null)}
+        >
+          {submitError}
+        </Alert>
+      )}
+
+      <Modal
+        visible={pendingEnforceModal}
+        header={t("saml_sso.enforce_modal_header")}
+        onDismiss={() => setPendingEnforceModal(false)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setPendingEnforceModal(false)}>
+                {t("saml_sso.modal_cancel")}
+              </Button>
+              <Button variant="primary" onClick={confirmEnforce}>
+                {t("saml_sso.enforce_modal_confirm")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box variant="p">{t("saml_sso.enforce_modal_body")}</Box>
+          <Alert type="warning">{t("saml_sso.enforce_modal_warning")}</Alert>
+        </SpaceBetween>
+      </Modal>
+
+      <Modal
+        visible={pendingDeleteModal}
+        header={t("saml_sso.delete_modal_header")}
+        onDismiss={() => setPendingDeleteModal(false)}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setPendingDeleteModal(false)}>
+                {t("saml_sso.modal_cancel")}
+              </Button>
+              <Button variant="primary" onClick={() => void handleDelete()}>
+                {t("saml_sso.delete_modal_confirm")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <Box variant="p">{t("saml_sso.delete_modal_body")}</Box>
+      </Modal>
+    </SpaceBetween>
+  );
+}

--- a/docs/operations/saml-federation.html
+++ b/docs/operations/saml-federation.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>SAML federation セットアップ (Issue #839 follow-up)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>SAML federation セットアップ (Issue #839 follow-up)</h1>
+<p>TenkaCloud の <strong>System Admin (Control Plane)</strong> と <strong>Tenant Admin (Tenant Template)</strong> の Cognito UserPool に SAML IdP を連携し、 会社の SSO (Entra ID / Okta / Google Workspace 等) で sign-in 可能にする手順です。</p>
+<p><code>username/password</code> 経路と並列で運用するか、 SAML だけに絞るかは <code>enforceSamlOnly</code> フラグで切り替えます。</p>
+<h2>1. IdP 側 (= 会社の IdP) で application 登録</h2>
+<p>各 IdP の手順は以下のとおりです。</p>
+<ul>
+<li><strong>Microsoft Entra ID</strong>: Enterprise applications → New application → Non-gallery → SAML</li>
+<li><strong>Okta</strong>: Applications → Create App Integration → SAML 2.0</li>
+<li><strong>Google Workspace</strong>: Apps → Web and mobile apps → Add custom SAML app</li>
+</ul>
+<p>IdP には次の値を設定してください。</p>
+<ul>
+<li><strong>SP エンティティ ID (Audience)</strong>: <code>urn:amazon:cognito:sp:&lt;USER_POOL_ID&gt;</code><ul>
+<li>System Admin: ControlPlaneStack の <code>UserPoolId</code> Output を control に貼る</li>
+<li>Tenant Admin: <code>tenkacloud-tenant-template-pooled</code> の <code>UserPoolId</code> を貼る</li>
+</ul>
+</li>
+<li><strong>ACS URL (Reply URL)</strong>: <code>https://&lt;COGNITO_DOMAIN_PREFIX&gt;.auth.&lt;region&gt;.amazoncognito.com/saml2/idpresponse</code><ul>
+<li><code>&lt;COGNITO_DOMAIN_PREFIX&gt;</code> は <code>tenkacloud-&lt;env&gt;-&lt;tenantId&gt;-&lt;accountId&gt;</code> (= identity-provider.ts の <code>buildCognitoDomainPrefix</code>)</li>
+</ul>
+</li>
+<li><strong>NameID format</strong>: <code>EmailAddress</code></li>
+<li><strong>Attribute mapping</strong>:<ul>
+<li><code>email</code> → <code>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress</code></li>
+<li>(任意) <code>name</code> / <code>groups</code> 等を追加するときは下記「config.json での有効化」で <code>attributeMapping</code> に書く</li>
+</ul>
+</li>
+</ul>
+<p>IdP 設定完了後、 <strong>federation metadata URL</strong> を控えてください。 これを Cognito に渡します。</p>
+<ul>
+<li>Entra ID:「App Federation Metadata Url」</li>
+<li>Okta:「Identity Provider metadata」</li>
+<li>Google Workspace:「IDP metadata URL」</li>
+</ul>
+<h2>2. config.json での有効化</h2>
+<p><code>infrastructure/environments/&lt;env&gt;/config.json</code> に次の section を追加します。</p>
+<h3>Tenant Admin (全 tenant 共有の SAML)</h3>
+<pre><code class="language-json">{
+  &quot;tenantSamlConfig&quot;: {
+    &quot;metadataUrl&quot;: &quot;https://login.microsoftonline.com/&lt;tenant&gt;/federationmetadata/2007-06/federationmetadata.xml&quot;,
+    &quot;providerName&quot;: &quot;AcmeSAML&quot;,
+    &quot;enforceSamlOnly&quot;: false,
+    &quot;attributeMapping&quot;: {
+      &quot;email&quot;: &quot;http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress&quot;
+    }
+  }
+}
+</code></pre>
+<h3>System Admin (= TenkaCloud operator 会社の SSO)</h3>
+<pre><code class="language-json">{
+  &quot;controlPlaneConfig&quot;: {
+    &quot;systemAdminEmail&quot;: &quot;ops@example.com&quot;,
+    &quot;samlIdp&quot;: {
+      &quot;metadataUrl&quot;: &quot;https://login.microsoftonline.com/&lt;tenant&gt;/federationmetadata/2007-06/federationmetadata.xml&quot;,
+      &quot;providerName&quot;: &quot;AcmeSAML&quot;,
+      &quot;enforceSamlOnly&quot;: false
+    }
+  }
+}
+</code></pre>
+<h3>フィールドの意味</h3>
+<table>
+<thead>
+<tr>
+<th>field</th>
+<th>必須</th>
+<th>説明</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>metadataUrl</code></td>
+<td>yes</td>
+<td>IdP の federation metadata XML を取得する HTTPS URL。 IdP 側 cert rotation 時も自動追従。</td>
+</tr>
+<tr>
+<td><code>providerName</code></td>
+<td>no</td>
+<td>Cognito 内で IdP を識別する名前 (Hosted UI button label にもなる)。 default <code>CompanySAML</code>。 英数字 + <code>-_</code> のみ。</td>
+</tr>
+<tr>
+<td><code>enforceSamlOnly</code></td>
+<td>no</td>
+<td><code>true</code> なら username/password 経路を閉じる (= Hosted UI に SAML button のみ)。 default <code>false</code> (= 並列許可)。</td>
+</tr>
+<tr>
+<td><code>attributeMapping</code></td>
+<td>no</td>
+<td>SAML AttributeStatement 名 → Cognito attribute 名のマップ。 default は email のみ自動。</td>
+</tr>
+</tbody></table>
+<h2>3. deploy</h2>
+<pre><code class="language-bash">make deploy ENV=development
+</code></pre>
+<p><code>infrastructure/lib/tenant-template/identity-provider.ts</code> と <code>infrastructure/lib/control-plane-stack.ts</code> の両方が config を読み込み、 SAML IdP を CFn 上に作ります。</p>
+<p>deploy 完了後、 Cognito Hosted UI を開くと「Sign in with <code>&lt;providerName&gt;</code>」button が表示されます。</p>
+<h2>4. ロールアウトの推奨手順</h2>
+<p>既存 user に SAML 強制をかけるとログイン経路が一夜で変わるので、 次の段階で進めることを推奨します。</p>
+<ol>
+<li><strong>dev / staging で並列 (<code>enforceSamlOnly: false</code>)</strong>: SAML 経路を operator で 1 人テスト</li>
+<li><strong>production で並列</strong>: operator 全員が SAML 経由でログインできることを確認 (最低 1 週間)</li>
+<li><strong>production で <code>enforceSamlOnly: true</code></strong>: username/password 経路を閉じる</li>
+</ol>
+<p><code>enforceSamlOnly: true</code> に flip した後、 旧 username/password の user は Cognito Admin Console から削除する運用にすることで遺漏を防げます。</p>
+<h2>5. トラブルシューティング</h2>
+<h3>Hosted UI に SAML button が出ない</h3>
+<ul>
+<li><code>make synth</code> で UserPoolClient の <code>SupportedIdentityProviders</code> を確認: SAML provider 名が入っているか</li>
+<li>Cognito Hosted UI の <strong>App Client &gt; Identity Providers</strong> タブで provider が enable されているか確認 (= deploy 直後は反映に数分かかる場合あり)</li>
+</ul>
+<h3>Sign-in 時に「No email」 / 「No NameID」 エラー</h3>
+<ul>
+<li>IdP の attribute mapping が <code>emailaddress</code> を出力しているか確認 (NameID format=EmailAddress でない IdP は明示的に <code>email</code> claim を別の URN で出す必要あり)</li>
+<li><code>attributeMapping</code> の <code>email</code> キーを IdP 側の Attribute Name に合わせて override</li>
+</ul>
+<h3>「Untrusted ACS URL」 エラー</h3>
+<ul>
+<li>IdP 側の Reply URL が Cognito の <code>/saml2/idpresponse</code> を指しているか確認</li>
+<li>domain prefix は env / tenantId / accountId で組まれるので、 deploy 後の <strong>実 URL を IdP 側に貼る</strong> 順番が正しい (= deploy → URL 取得 → IdP 設定)</li>
+</ul>
+<h2>関連</h2>
+<ul>
+<li><a href="../../infrastructure/lib/tenant-template/identity-provider.ts"><code>infrastructure/lib/tenant-template/identity-provider.ts</code></a> — Tenant Admin SAML 連携の実装</li>
+<li><a href="../../infrastructure/lib/control-plane-stack.ts"><code>infrastructure/lib/control-plane-stack.ts</code></a> — System Admin SAML 連携の escape hatch</li>
+<li><a href="../../infrastructure/lib/config/config-interface.ts"><code>infrastructure/lib/config/config-interface.ts</code></a> — <code>SamlIdpConfig</code> 型定義</li>
+<li>Issue #839 — 本機能の親 issue</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/saml-federation.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/saml-federation.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -112,5 +112,27 @@ export class CompetitorAccountsApiLambda extends Construct {
         resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
       }),
     );
+
+    // 4. Issue #839 follow-up Phase B: Tenant 管理者が自社の SAML IdP を画面から設定できるよう、
+    //    同 Lambda に Cognito IdP mutation 権限を付ける。 Resource は自 account / region 配下の
+    //    全 UserPool に絞り (= account-level blast radius)、 runtime 側で JWT iss claim から
+    //    呼び出した UserPool ID を抽出して self-targeting のみ許可する。
+    //
+    //    cross-stack で具体 UserPool ARN を渡すと TenantTemplateStack ↔ ProblemDeployBackendStack
+    //    間に CFn export 依存が増えるため、 wildcard + runtime guard で代用する設計判断。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "cognito-idp:CreateIdentityProvider",
+          "cognito-idp:UpdateIdentityProvider",
+          "cognito-idp:DescribeIdentityProvider",
+          "cognito-idp:DeleteIdentityProvider",
+          "cognito-idp:DescribeUserPoolClient",
+          "cognito-idp:UpdateUserPoolClient",
+        ],
+        resources: [`arn:aws:cognito-idp:${stack.region}:${stack.account}:userpool/*`],
+      }),
+    );
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/cognito-saml.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/cognito-saml.ts
@@ -1,0 +1,255 @@
+import {
+  type CognitoIdentityProviderClient,
+  CreateIdentityProviderCommand,
+  DeleteIdentityProviderCommand,
+  DescribeIdentityProviderCommand,
+  DescribeUserPoolClientCommand,
+  UpdateIdentityProviderCommand,
+  UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant 管理者が画面から SAML 設定を変えるための Cognito SDK
+ * wrapper。 IdP CRUD + UserPoolClient の SupportedIdentityProviders 書換を pure-ish に保つ。
+ *
+ * 関数は **idempotent**:
+ *   - `upsertSamlProvider`: 既存なら Update、 無ければ Create
+ *   - `attachSamlToClient`: SupportedIdentityProviders に追加 (= 既に居れば no-op)
+ *   - `detachSamlFromClient`: 削除 (= 居なければ no-op)、 COGNITO は必ず残す
+ *   - `enforceSamlOnlyOnClient`: COGNITO を抜き、 ExplicitAuthFlows を SAML 互換に絞る
+ *   - `allowCognitoOnClient`: COGNITO を戻す、 ExplicitAuthFlows を password / SRP 含めて復元
+ *
+ * 全関数で `userPoolId` と `userPoolClientId` を引数で受ける (= JWT から runtime 抽出した値を
+ * handler 側で渡す)。 wildcard IAM だが runtime guard で self-pool に限定する設計。
+ */
+
+export interface CognitoSamlDeps {
+  readonly client: Pick<CognitoIdentityProviderClient, "send">;
+  readonly userPoolId: string;
+  readonly userPoolClientId: string;
+}
+
+export interface SamlProviderInput {
+  readonly providerName: string;
+  readonly metadataUrl: string;
+  readonly attributeMapping: Readonly<Record<string, string>>;
+}
+
+/**
+ * SAML IdP を idempotent に upsert する。 既存なら Update、 無ければ Create。
+ * ProviderDetails の MetadataURL が変わったら Cognito 側で metadata XML を re-fetch する。
+ */
+export async function upsertSamlProvider(
+  deps: CognitoSamlDeps,
+  input: SamlProviderInput,
+): Promise<void> {
+  const exists = await describeSamlProvider(deps, input.providerName);
+  if (exists) {
+    await deps.client.send(
+      new UpdateIdentityProviderCommand({
+        UserPoolId: deps.userPoolId,
+        ProviderName: input.providerName,
+        ProviderDetails: {
+          MetadataURL: input.metadataUrl,
+          IDPSignout: "true",
+        },
+        AttributeMapping: { ...input.attributeMapping },
+      }),
+    );
+  } else {
+    await deps.client.send(
+      new CreateIdentityProviderCommand({
+        UserPoolId: deps.userPoolId,
+        ProviderName: input.providerName,
+        ProviderType: "SAML",
+        ProviderDetails: {
+          MetadataURL: input.metadataUrl,
+          IDPSignout: "true",
+        },
+        AttributeMapping: { ...input.attributeMapping },
+      }),
+    );
+  }
+}
+
+async function describeSamlProvider(deps: CognitoSamlDeps, providerName: string): Promise<boolean> {
+  try {
+    await deps.client.send(
+      new DescribeIdentityProviderCommand({
+        UserPoolId: deps.userPoolId,
+        ProviderName: providerName,
+      }),
+    );
+    return true;
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ResourceNotFoundException") return false;
+    throw err;
+  }
+}
+
+/**
+ * SAML IdP を削除する。 不在なら no-op (= idempotent)。
+ */
+export async function deleteSamlProvider(
+  deps: CognitoSamlDeps,
+  providerName: string,
+): Promise<void> {
+  try {
+    await deps.client.send(
+      new DeleteIdentityProviderCommand({
+        UserPoolId: deps.userPoolId,
+        ProviderName: providerName,
+      }),
+    );
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ResourceNotFoundException") return;
+    throw err;
+  }
+}
+
+/**
+ * UserPoolClient の SupportedIdentityProviders に SAML provider を追加する (= 既に居れば
+ * no-op)。 ExplicitAuthFlows は触らない (= COGNITO 経路は維持)。
+ */
+export async function attachSamlToClient(
+  deps: CognitoSamlDeps,
+  providerName: string,
+): Promise<void> {
+  const current = await readClientState(deps);
+  if (current.supportedIdentityProviders.includes(providerName)) return;
+  await deps.client.send(
+    new UpdateUserPoolClientCommand({
+      UserPoolId: deps.userPoolId,
+      ClientId: deps.userPoolClientId,
+      SupportedIdentityProviders: [...current.supportedIdentityProviders, providerName],
+      ExplicitAuthFlows: [...current.explicitAuthFlows] as never,
+      CallbackURLs: [...current.callbackUrls],
+      LogoutURLs: [...current.logoutUrls],
+      AllowedOAuthFlows: [...current.allowedOAuthFlows] as (
+        | "code"
+        | "implicit"
+        | "client_credentials"
+      )[],
+      AllowedOAuthScopes: [...current.allowedOAuthScopes],
+      AllowedOAuthFlowsUserPoolClient: current.allowedOAuthFlowsUserPoolClient,
+      ReadAttributes: [...current.readAttributes],
+      WriteAttributes: [...current.writeAttributes],
+    }),
+  );
+}
+
+/**
+ * UserPoolClient の SupportedIdentityProviders から SAML を取り除き、 COGNITO を必ず含むよう
+ * 復元する (= SAML 削除時の lock-out 防止)。 ExplicitAuthFlows は password + SRP を戻す
+ * (= 標準的な user pool client の default fallback)。
+ */
+export async function allowCognitoOnClient(
+  deps: CognitoSamlDeps,
+  providerName: string | undefined,
+): Promise<void> {
+  const current = await readClientState(deps);
+  const filtered = current.supportedIdentityProviders.filter((p) => p !== providerName);
+  const next = filtered.includes("COGNITO") ? filtered : ["COGNITO", ...filtered];
+  await deps.client.send(
+    new UpdateUserPoolClientCommand({
+      UserPoolId: deps.userPoolId,
+      ClientId: deps.userPoolClientId,
+      SupportedIdentityProviders: next,
+      ExplicitAuthFlows: [
+        "ALLOW_USER_SRP_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
+        "ALLOW_USER_PASSWORD_AUTH",
+      ],
+      CallbackURLs: [...current.callbackUrls],
+      LogoutURLs: [...current.logoutUrls],
+      AllowedOAuthFlows: [...current.allowedOAuthFlows] as (
+        | "code"
+        | "implicit"
+        | "client_credentials"
+      )[],
+      AllowedOAuthScopes: [...current.allowedOAuthScopes],
+      AllowedOAuthFlowsUserPoolClient: current.allowedOAuthFlowsUserPoolClient,
+      ReadAttributes: [...current.readAttributes],
+      WriteAttributes: [...current.writeAttributes],
+    }),
+  );
+}
+
+/**
+ * SAML only に絞る: SupportedIdentityProviders を SAML provider 1 個のみ、 ExplicitAuthFlows を
+ * REFRESH_TOKEN のみ (= password / SRP を閉じる) に更新する。 lock-out 防止のため caller (handler)
+ * 側で確認を取った前提で呼ぶ。
+ */
+export async function enforceSamlOnlyOnClient(
+  deps: CognitoSamlDeps,
+  providerName: string,
+): Promise<void> {
+  const current = await readClientState(deps);
+  await deps.client.send(
+    new UpdateUserPoolClientCommand({
+      UserPoolId: deps.userPoolId,
+      ClientId: deps.userPoolClientId,
+      SupportedIdentityProviders: [providerName],
+      ExplicitAuthFlows: ["ALLOW_REFRESH_TOKEN_AUTH"],
+      CallbackURLs: [...current.callbackUrls],
+      LogoutURLs: [...current.logoutUrls],
+      AllowedOAuthFlows: [...current.allowedOAuthFlows] as (
+        | "code"
+        | "implicit"
+        | "client_credentials"
+      )[],
+      AllowedOAuthScopes: [...current.allowedOAuthScopes],
+      AllowedOAuthFlowsUserPoolClient: current.allowedOAuthFlowsUserPoolClient,
+      ReadAttributes: [...current.readAttributes],
+      WriteAttributes: [...current.writeAttributes],
+    }),
+  );
+}
+
+interface ClientState {
+  readonly supportedIdentityProviders: readonly string[];
+  readonly explicitAuthFlows: readonly string[];
+  readonly callbackUrls: readonly string[];
+  readonly logoutUrls: readonly string[];
+  readonly allowedOAuthFlows: readonly string[];
+  readonly allowedOAuthScopes: readonly string[];
+  readonly allowedOAuthFlowsUserPoolClient: boolean;
+  readonly readAttributes: readonly string[];
+  readonly writeAttributes: readonly string[];
+}
+
+async function readClientState(deps: CognitoSamlDeps): Promise<ClientState> {
+  const out = await deps.client.send(
+    new DescribeUserPoolClientCommand({
+      UserPoolId: deps.userPoolId,
+      ClientId: deps.userPoolClientId,
+    }),
+  );
+  const client = out.UserPoolClient ?? {};
+  return {
+    supportedIdentityProviders: client.SupportedIdentityProviders ?? ["COGNITO"],
+    explicitAuthFlows: client.ExplicitAuthFlows ?? [
+      "ALLOW_USER_SRP_AUTH",
+      "ALLOW_REFRESH_TOKEN_AUTH",
+    ],
+    callbackUrls: client.CallbackURLs ?? [],
+    logoutUrls: client.LogoutURLs ?? [],
+    allowedOAuthFlows: client.AllowedOAuthFlows ?? [],
+    allowedOAuthScopes: client.AllowedOAuthScopes ?? [],
+    allowedOAuthFlowsUserPoolClient: client.AllowedOAuthFlowsUserPoolClient ?? false,
+    readAttributes: client.ReadAttributes ?? [],
+    writeAttributes: client.WriteAttributes ?? [],
+  };
+}
+
+/**
+ * JWT `iss` claim から UserPool ID を抽出する pure helper。 Cognito JWT は
+ * `https://cognito-idp.<region>.amazonaws.com/<userPoolId>` の形式で iss を発行する。
+ *
+ * UserPool ID は `<region>_<14 文字英数字>` で、 Cognito の正式な書式。 形式が合わなければ undefined。
+ */
+export function extractUserPoolIdFromIss(iss: string | undefined): string | undefined {
+  if (typeof iss !== "string" || iss.length === 0) return undefined;
+  const m = iss.match(/^https:\/\/cognito-idp\.[a-z0-9-]+\.amazonaws\.com\/([a-z0-9_-]+)$/i);
+  return m ? m[1] : undefined;
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -8,6 +8,7 @@ import {
   resolveCognitoSub,
   resolveTenantId,
 } from "../deploy-handler/auth.js";
+import { routeDelete, routeGet, routePut } from "./saml-routes.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
 import {
   CompetitorAccountNotFoundError,
@@ -73,6 +74,26 @@ app.onError((err, c) => {
 });
 
 app.get("/admin/competitor-accounts/healthz", (c) => c.json({ ok: true }));
+
+// Issue #839 follow-up Phase B: Tenant 管理者が画面 / API から SAML IdP を CRUD する経路。
+// 同 Lambda に同居させる (= 同 IAM / auth、 別 handler 化は Phase 3 で再評価)。
+app.get("/admin/tenant-saml-config", async (c) => {
+  const result = await routeGet({ shared }, c);
+  return c.json(result.body as never, result.status as 200);
+});
+// 互換のため PATCH + PUT 両方受ける (= frontend は PATCH、 curl 直叩き / OpenAPI は PUT で書く)。
+app.patch("/admin/tenant-saml-config", async (c) => {
+  const result = await routePut({ shared }, c);
+  return c.json(result.body as never, result.status as 200 | 400 | 422);
+});
+app.put("/admin/tenant-saml-config", async (c) => {
+  const result = await routePut({ shared }, c);
+  return c.json(result.body as never, result.status as 200 | 400 | 422);
+});
+app.delete("/admin/tenant-saml-config", async (c) => {
+  const result = await routeDelete({ shared }, c);
+  return c.json(result.body as never, result.status as 200 | 422);
+});
 
 app.post("/admin/competitor-accounts", async (c) => {
   let body: unknown;

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
@@ -1,0 +1,286 @@
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+import type { Context } from "hono";
+import { resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
+import {
+  allowCognitoOnClient,
+  type CognitoSamlDeps,
+  deleteSamlProvider,
+  enforceSamlOnlyOnClient,
+  extractUserPoolIdFromIss,
+  upsertSamlProvider,
+} from "./cognito-saml.js";
+import { deleteTenantSamlConfig, getTenantSamlConfig, putTenantSamlConfig } from "./saml-store.js";
+import {
+  DEFAULT_SAML_PROVIDER_NAME,
+  normalizeAttributeMapping,
+  type TenantSamlConfigInput,
+  TenantSamlConfigInputSchema,
+  type TenantSamlConfigView,
+} from "./saml-types.js";
+import type { CompetitorAccountsSharedResources } from "./shared.js";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant 管理者が画面 / API から SAML IdP を CRUD する route 群。
+ *
+ *   GET    /admin/tenant-saml-config       — 現在の設定 view (= disabled なら enabled:false)
+ *   PUT    /admin/tenant-saml-config       — upsert (= Cognito IdP create/update + UserPoolClient
+ *                                            mutation + DDB persist)
+ *   DELETE /admin/tenant-saml-config       — disable (= UserPoolClient から SAML を外し + COGNITO
+ *                                            復元 → IdP 削除 → DDB row 削除)
+ *
+ * 設計判断:
+ *  - **UserPool ID は JWT iss から runtime 抽出**: cross-stack で具体 UserPool ARN を渡さず、
+ *    呼び出した user の token issuer の UserPool だけを mutate する self-targeting にする。
+ *  - **UserPoolClient ID は JWT aud (= client_id) から抽出**: UserPool 内に複数 client がある
+ *    ケースを想定せず、 token が来た client を対象にする。
+ *  - **enforceSamlOnly: true への flip は破壊的**: caller (UI) は 2-step 確認 modal を要求する。
+ *    backend は単純に flag を見て enforce する (= 確認 UX は frontend 責任)。
+ *  - **lock-out からの復旧経路**: 万一 SAML 設定が壊れて誰もログインできなくなったら、 operator は
+ *    `make deploy` で CDK 経由に戻すか、 AWS Console から手動で UserPoolClient.SupportedIdentityProviders
+ *    に COGNITO を足す。 これは security ops doc に残す前提。
+ */
+
+export interface SamlRouteResult {
+  /** HTTP status を caller (Hono) が読む。 */
+  readonly status: number;
+  /** body を caller が `c.json` する。 */
+  readonly body: unknown;
+}
+
+interface JwtClaims {
+  readonly iss?: string;
+  readonly aud?: string;
+  readonly client_id?: string;
+  readonly sub?: string;
+  readonly [k: string]: unknown;
+}
+
+/**
+ * JWT claims から Cognito self-targeting に必要な情報を取り出す。 必要な claim が無ければ
+ * `undefined` を返し、 caller が 401 / 422 に倒す。
+ */
+export function extractSelfPoolFromContext(c: Context): CognitoSamlDeps | undefined {
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const userPoolId = extractUserPoolIdFromIss(claims?.iss);
+  // Cognito access_token は aud ではなく client_id を持つ場合がある (= access_token vs id_token)。
+  // API GW JWT Authorizer は id_token を要求するので aud を優先しつつ、 client_id fallback も持つ。
+  const userPoolClientId =
+    typeof claims?.aud === "string" && claims.aud.length > 0
+      ? claims.aud
+      : typeof claims?.client_id === "string" && claims.client_id.length > 0
+        ? claims.client_id
+        : undefined;
+  if (!userPoolId || !userPoolClientId) return undefined;
+  return {
+    client: { send: () => Promise.reject(new Error("client not injected")) },
+    userPoolId,
+    userPoolClientId,
+  };
+}
+
+/**
+ * GET の DDB 経由実装。 caller の Hono ルートから呼ばれる pure-ish function (= shared + tenantId のみ依存)。
+ */
+export async function handleGetTenantSamlConfig(
+  shared: CompetitorAccountsSharedResources,
+  tenantId: string,
+): Promise<SamlRouteResult> {
+  const view = await getTenantSamlConfig(
+    { ddb: shared.ddb, tableName: shared.tableName },
+    tenantId,
+  );
+  if (!view) {
+    const disabled: TenantSamlConfigView = { enabled: false };
+    return { status: 200, body: disabled };
+  }
+  return { status: 200, body: view };
+}
+
+/**
+ * PUT 本体。 validation → Cognito upsert → UserPoolClient mutate → DDB persist の順。
+ * 失敗時の rollback は半端 (= DDB だけ書いて Cognito 失敗、 など) になり得るが、 再送で必ず
+ * eventual consistency に倒れる (= idempotent) ことで許容する。
+ */
+export async function handlePutTenantSamlConfig(
+  shared: CompetitorAccountsSharedResources,
+  cognitoDeps: CognitoSamlDeps,
+  ctx: { readonly tenantId: string; readonly updatedBy: string; readonly nowIso: string },
+  rawBody: unknown,
+): Promise<SamlRouteResult> {
+  const parsed = TenantSamlConfigInputSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return {
+      status: 400,
+      body: { error: "validation_failed", issues: parsed.error.issues },
+    };
+  }
+  const input: TenantSamlConfigInput = parsed.data;
+  const providerName = input.providerName ?? DEFAULT_SAML_PROVIDER_NAME;
+  const attributeMapping = normalizeAttributeMapping(input.attributeMapping);
+
+  // 1. Cognito IdP を upsert (= 既存なら Update、 無ければ Create)。
+  await upsertSamlProvider(cognitoDeps, {
+    providerName,
+    metadataUrl: input.metadataUrl,
+    attributeMapping,
+  });
+
+  // 2. UserPoolClient.SupportedIdentityProviders と ExplicitAuthFlows を flip。
+  if (input.enforceSamlOnly === true) {
+    await enforceSamlOnlyOnClient(cognitoDeps, providerName);
+  } else {
+    // 並列許可 (= COGNITO 経路は維持)。 SAML を SupportedIdentityProviders に追加。
+    // helper の名前が "allow" + "attach" で動詞 split されているため、 順序は:
+    //   - 先に COGNITO を残しつつ SAML を追加 (= attach)
+    //   - allowCognitoOnClient は逆方向 (= SAML を外す経路) なので使わない
+    const { attachSamlToClient } = await import("./cognito-saml.js");
+    await attachSamlToClient(cognitoDeps, providerName);
+  }
+
+  // 3. DDB persist (= UI が次回 GET で current state を見れる)。
+  const view = await putTenantSamlConfig(
+    { ddb: shared.ddb, tableName: shared.tableName },
+    ctx.tenantId,
+    { ...input, providerName, attributeMapping },
+    { updatedAt: ctx.nowIso, updatedBy: ctx.updatedBy },
+  );
+
+  // 4. 監査ログ (= console.log 経路、 ZERO 新 infra)。
+  console.log(
+    JSON.stringify({
+      event: "tenant-saml.upsert",
+      tenantId: ctx.tenantId,
+      providerName,
+      enforceSamlOnly: input.enforceSamlOnly === true,
+      updatedBy: ctx.updatedBy,
+      updatedAt: ctx.nowIso,
+    }),
+  );
+
+  return { status: 200, body: view };
+}
+
+/**
+ * DELETE 本体。 idempotent: 不在の SAML config を消しても OK。
+ *
+ * 順序:
+ *   1. UserPoolClient から SAML を外し COGNITO を必ず復元 (= lock-out 防止)
+ *   2. Cognito IdP を削除 (= 残ったままだと UserPool 内で provider name 衝突するため)
+ *   3. DDB row 削除
+ *
+ * 1 と 2 の間で Lambda が落ちると IdP だけ残る (= UserPoolClient 側では参照外れているので
+ * 実害なし、 次回 PUT で同 provider name の Update を打てる)。 caller の再送で eventual consistency。
+ */
+export async function handleDeleteTenantSamlConfig(
+  shared: CompetitorAccountsSharedResources,
+  cognitoDeps: CognitoSamlDeps,
+  ctx: { readonly tenantId: string; readonly updatedBy: string; readonly nowIso: string },
+): Promise<SamlRouteResult> {
+  // 既存 config を読んで providerName を決める。 無ければ default 名で attempt (= 不在なら no-op)。
+  const existing = await getTenantSamlConfig(
+    { ddb: shared.ddb, tableName: shared.tableName },
+    ctx.tenantId,
+  );
+  const providerName = existing?.providerName ?? DEFAULT_SAML_PROVIDER_NAME;
+
+  // 1. UserPoolClient revert: SAML を外し COGNITO + 標準 ExplicitAuthFlows を復元。
+  await allowCognitoOnClient(cognitoDeps, providerName);
+
+  // 2. Cognito IdP delete (idempotent)。
+  await deleteSamlProvider(cognitoDeps, providerName);
+
+  // 3. DDB row 削除。
+  await deleteTenantSamlConfig({ ddb: shared.ddb, tableName: shared.tableName }, ctx.tenantId);
+
+  console.log(
+    JSON.stringify({
+      event: "tenant-saml.delete",
+      tenantId: ctx.tenantId,
+      providerName,
+      deletedBy: ctx.updatedBy,
+      deletedAt: ctx.nowIso,
+    }),
+  );
+
+  return { status: 200, body: { deleted: true } };
+}
+
+/**
+ * Hono route handlers から呼ぶ thin orchestration: tenantId + sub を context から取り、
+ * Cognito self-targeting deps を組んで、 route-specific handler を呼ぶ。
+ *
+ * 各 route handler は **pure-ish** (= ctx 引数のみ取る) なので test しやすい。
+ */
+export interface SamlOrchestratorDeps {
+  readonly shared: CompetitorAccountsSharedResources;
+  /** test injection 用: Cognito SDK の動的 client。 prod では `shared.cognito` がそのまま入る。 */
+  readonly makeCognitoDeps?: (
+    c: Context,
+  ) => Promise<CognitoSamlDeps | undefined> | CognitoSamlDeps | undefined;
+}
+
+export function defaultMakeCognitoDeps(
+  shared: CompetitorAccountsSharedResources,
+): (c: Context) => CognitoSamlDeps | undefined {
+  return (c) => {
+    const skeleton = extractSelfPoolFromContext(c);
+    if (!skeleton) return undefined;
+    return {
+      client: shared.cognito,
+      userPoolId: skeleton.userPoolId,
+      userPoolClientId: skeleton.userPoolClientId,
+    };
+  };
+}
+
+export async function routeGet(deps: SamlOrchestratorDeps, c: Context): Promise<SamlRouteResult> {
+  const tenantId = resolveTenantId(c);
+  return handleGetTenantSamlConfig(deps.shared, tenantId);
+}
+
+export async function routePut(deps: SamlOrchestratorDeps, c: Context): Promise<SamlRouteResult> {
+  const tenantId = resolveTenantId(c);
+  const sub = resolveCognitoSub(c);
+  const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));
+  if (!cognitoDeps) {
+    return {
+      status: 422,
+      body: { error: "missing_cognito_claims", message: "iss / aud claims are required" },
+    };
+  }
+  const body = await c.req.json().catch(() => null);
+  if (body === null) {
+    return { status: 400, body: { error: "invalid_body" } };
+  }
+  return handlePutTenantSamlConfig(
+    deps.shared,
+    cognitoDeps,
+    {
+      tenantId,
+      updatedBy: sub,
+      nowIso: new Date().toISOString(),
+    },
+    body,
+  );
+}
+
+export async function routeDelete(
+  deps: SamlOrchestratorDeps,
+  c: Context,
+): Promise<SamlRouteResult> {
+  const tenantId = resolveTenantId(c);
+  const sub = resolveCognitoSub(c);
+  const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));
+  if (!cognitoDeps) {
+    return {
+      status: 422,
+      body: { error: "missing_cognito_claims", message: "iss / aud claims are required" },
+    };
+  }
+  return handleDeleteTenantSamlConfig(deps.shared, cognitoDeps, {
+    tenantId,
+    updatedBy: sub,
+    nowIso: new Date().toISOString(),
+  });
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-store.ts
@@ -1,0 +1,122 @@
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { TenantSamlConfigInput, TenantSamlConfigView } from "./saml-types.js";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant SAML 設定の DDB persistence 層。
+ *
+ * CompetitorAccounts table (= 既存 PK=`TENANT#<tenantId>` partition) を再利用し、 sparse な
+ * `SK="SAML_CONFIG"` 行 1 つを per-tenant で持つ。 Cognito UserPool 側の真実 (= IdP / Client
+ * config) は Cognito API から describe で取れるが、 UI が「最後に保存された設定」 を高速に
+ * 表示するための写しとして DDB を使う (= Cognito API は 5 RPS quota がある + 数 100ms かかる)。
+ *
+ * shape:
+ *   PK = `TENANT#<tenantId>` (= 既存 partition と相乗り)
+ *   SK = `SAML_CONFIG` (= sparse, 1 tenant 1 行)
+ *   metadataUrl: string
+ *   providerName: string
+ *   attributeMapping: map<string, string>
+ *   enforceSamlOnly: boolean
+ *   updatedAt: ISO 8601
+ *   updatedBy: cognito sub (= 監査用)
+ */
+
+const SK_SAML_CONFIG = "SAML_CONFIG";
+
+export interface SamlStoreDeps {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  readonly tableName: string;
+}
+
+function pk(tenantId: string): string {
+  return `TENANT#${tenantId}`;
+}
+
+/**
+ * 現在の SAML config を返す (= 未保存なら undefined)。 GET endpoint の主経路。
+ */
+export async function getTenantSamlConfig(
+  deps: SamlStoreDeps,
+  tenantId: string,
+): Promise<TenantSamlConfigView | undefined> {
+  const out = await deps.ddb.send(
+    new GetCommand({
+      TableName: deps.tableName,
+      Key: { PK: pk(tenantId), SK: SK_SAML_CONFIG },
+    }),
+  );
+  const item = out.Item as Partial<DdbRow> | undefined;
+  if (!item) return undefined;
+  return rowToView(item);
+}
+
+/**
+ * SAML config を upsert する (= PUT endpoint の DDB write 部)。 Cognito 側の更新成功後に呼ぶ。
+ * `updatedAt` は caller (handler) が runtime now を渡す (= test 注入用)。
+ */
+export async function putTenantSamlConfig(
+  deps: SamlStoreDeps,
+  tenantId: string,
+  input: TenantSamlConfigInput & { readonly providerName: string },
+  meta: { readonly updatedAt: string; readonly updatedBy: string },
+): Promise<TenantSamlConfigView> {
+  const row: DdbRow = {
+    PK: pk(tenantId),
+    SK: SK_SAML_CONFIG,
+    metadataUrl: input.metadataUrl,
+    providerName: input.providerName,
+    attributeMapping: input.attributeMapping ?? {},
+    enforceSamlOnly: input.enforceSamlOnly ?? false,
+    updatedAt: meta.updatedAt,
+    updatedBy: meta.updatedBy,
+  };
+  await deps.ddb.send(
+    new PutCommand({
+      TableName: deps.tableName,
+      Item: row,
+    }),
+  );
+  return rowToView(row);
+}
+
+/**
+ * SAML config を削除する (= DELETE endpoint の DDB 部)。 不在なら no-op (= idempotent)。
+ */
+export async function deleteTenantSamlConfig(deps: SamlStoreDeps, tenantId: string): Promise<void> {
+  await deps.ddb.send(
+    new DeleteCommand({
+      TableName: deps.tableName,
+      Key: { PK: pk(tenantId), SK: SK_SAML_CONFIG },
+    }),
+  );
+}
+
+interface DdbRow {
+  PK: string;
+  SK: string;
+  metadataUrl: string;
+  providerName: string;
+  attributeMapping: Record<string, string>;
+  enforceSamlOnly: boolean;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+function rowToView(row: Partial<DdbRow>): TenantSamlConfigView {
+  // 行が存在しても enabled は metadataUrl + providerName が揃っているときのみ true。
+  // 不正な partial row (= 旧 schema migration 中) は disabled 扱いで安全に倒す。
+  const hasCore =
+    typeof row.metadataUrl === "string" &&
+    row.metadataUrl.length > 0 &&
+    typeof row.providerName === "string" &&
+    row.providerName.length > 0;
+  return {
+    enabled: hasCore,
+    metadataUrl: row.metadataUrl,
+    providerName: row.providerName,
+    attributeMapping: row.attributeMapping,
+    enforceSamlOnly: row.enforceSamlOnly,
+    updatedAt: row.updatedAt,
+    updatedBy: row.updatedBy,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-types.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+/**
+ * Issue #839 follow-up Phase B: Tenant 管理者が画面/API から自社 SAML IdP を設定するための
+ * request / response shape。
+ *
+ * 設計原則:
+ *  - `metadataUrl` は HTTPS のみ受け付ける (= 暗号化されてない metadata 経路を作らない)
+ *  - `providerName` は Cognito の制約 (= URL 安全な英数字 + `-_`、 3-32 字) に厳密にマッチ
+ *  - `enforceSamlOnly` を `true` に flip するときは UI 側で 2-step 確認モーダルを要求する想定
+ *    (= API 層は per-request validation のみ、 確認 UX は別経路で担保)
+ */
+
+const PROVIDER_NAME_RE = /^[A-Za-z0-9_-]{3,32}$/;
+
+export const TenantSamlConfigInputSchema = z.object({
+  metadataUrl: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith("https://"), {
+      message: "metadataUrl は HTTPS 必須です (= IdP の federation metadata XML URL)",
+    })
+    .refine((u) => u.length <= 2048, {
+      message: "metadataUrl が長すぎます (max 2048 文字)",
+    }),
+  providerName: z
+    .string()
+    .regex(PROVIDER_NAME_RE, {
+      message: "providerName は英数字 + - _ の 3-32 文字 (Cognito 制約)",
+    })
+    .optional(),
+  attributeMapping: z
+    .record(z.string().min(1), z.string().min(1).max(2048))
+    .optional()
+    .refine((m) => !m || Object.keys(m).length <= 32, {
+      message: "attributeMapping のエントリ数が多すぎます (max 32)",
+    }),
+  enforceSamlOnly: z.boolean().optional(),
+});
+
+export type TenantSamlConfigInput = z.infer<typeof TenantSamlConfigInputSchema>;
+
+/**
+ * GET / PUT response。 DDB に persist されている current config を返す。 secret は無いので
+ * 全 field をそのまま expose する (= metadata URL は IdP 側で公開済の URL なので漏れても無害)。
+ */
+export interface TenantSamlConfigView {
+  readonly enabled: boolean;
+  readonly metadataUrl?: string;
+  readonly providerName?: string;
+  readonly attributeMapping?: Readonly<Record<string, string>>;
+  readonly enforceSamlOnly?: boolean;
+  /** ISO 8601、 最終更新時刻。 未設定なら undefined。 */
+  readonly updatedAt?: string;
+  /** Cognito sub (= 監査用、 UI は表示せずログのみ)。 */
+  readonly updatedBy?: string;
+}
+
+/** Cognito IdP の default 表示名 (= caller が providerName を指定しなかったとき)。 */
+export const DEFAULT_SAML_PROVIDER_NAME = "CompanySAML";
+
+/** SAML emailaddress claim の標準 namespace (= attributeMapping default)。 */
+export const DEFAULT_SAML_EMAIL_CLAIM =
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+
+/**
+ * caller の `attributeMapping` に email key が無ければ default を埋める。 既に指定されていれば
+ * caller の値が優先される (= Entra ID 等の非標準 claim 対応)。
+ */
+export function normalizeAttributeMapping(
+  input: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> {
+  const base: Record<string, string> = { email: DEFAULT_SAML_EMAIL_CLAIM };
+  if (!input) return base;
+  return { ...base, ...input };
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/shared.ts
@@ -1,3 +1,4 @@
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { SSMClient } from "@aws-sdk/client-ssm";
 import { STSClient } from "@aws-sdk/client-sts";
@@ -9,6 +10,7 @@ import { getEnv } from "../../../helper-functions.js";
  *
  * - `tableName` = `CompetitorAccounts` DDB (Issue #459 / ADR-002)
  * - `env` / `tenkaCloudAccountId` = SSM path 構築 + 「Add account」レスポンスで返す値
+ * - `cognito` = Issue #839 Phase B で SAML IdP CRUD に使う Cognito-IDP client
  *
  * Lambda は warm invoke で SDK client を 1 つだけ持つ (= cold start 軽減)。
  */
@@ -19,6 +21,7 @@ export interface CompetitorAccountsSharedResources {
   readonly ddb: DynamoDBDocumentClient;
   readonly ssm: SSMClient;
   readonly sts: STSClient;
+  readonly cognito: CognitoIdentityProviderClient;
 }
 
 export function buildCompetitorAccountsSharedResources(): CompetitorAccountsSharedResources {
@@ -29,5 +32,6 @@ export function buildCompetitorAccountsSharedResources(): CompetitorAccountsShar
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     ssm: new SSMClient({}),
     sts: new STSClient({}),
+    cognito: new CognitoIdentityProviderClient({}),
   };
 }

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -133,5 +133,14 @@ export class ApiGateway extends Construct {
     competitorAccount
       .addResource("rotate-external-id")
       .addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
+
+    // Issue #839 follow-up Phase B: Tenant 管理者が画面 / API から SAML IdP を CRUD する経路。
+    // 同 Lambda (competitor-accounts) に相乗りさせ、 IAM 拡張 (cognito-idp) は Lambda 側で済ませる。
+    //   /admin/tenant-saml-config  GET=read / PUT=upsert / DELETE=disable
+    const tenantSamlConfig = admin.addResource("tenant-saml-config");
+    tenantSamlConfig.addMethod("GET", competitorAccountsIntegration, deployMethodOptions);
+    tenantSamlConfig.addMethod("PUT", competitorAccountsIntegration, deployMethodOptions);
+    tenantSamlConfig.addMethod("PATCH", competitorAccountsIntegration, deployMethodOptions);
+    tenantSamlConfig.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -79,7 +79,7 @@ describe("problem template ParticipantViewerRole (#744)", () => {
         if (hasWildcard) {
           expect(
             /^(List|Describe)/.test(sid),
-            `Sid \"${sid}\" uses Resource:\"*\" — only allowed for List*/Describe-all read APIs`,
+            `Sid "${sid}" uses Resource:"*" — only allowed for List*/Describe-all read APIs`,
           ).toBe(true);
         }
       }

--- a/infrastructure/test/problem-deploy/tenant-saml.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml.test.ts
@@ -1,0 +1,470 @@
+import {
+  CreateIdentityProviderCommand,
+  DeleteIdentityProviderCommand,
+  DescribeIdentityProviderCommand,
+  DescribeUserPoolClientCommand,
+  UpdateIdentityProviderCommand,
+  type UpdateUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  allowCognitoOnClient,
+  attachSamlToClient,
+  deleteSamlProvider,
+  enforceSamlOnlyOnClient,
+  extractUserPoolIdFromIss,
+  upsertSamlProvider,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/cognito-saml";
+import {
+  handleDeleteTenantSamlConfig,
+  handleGetTenantSamlConfig,
+  handlePutTenantSamlConfig,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes";
+import {
+  deleteTenantSamlConfig,
+  getTenantSamlConfig,
+  putTenantSamlConfig,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-store";
+import {
+  normalizeAttributeMapping,
+  TenantSamlConfigInputSchema,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-types";
+import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/shared";
+
+/**
+ * Issue #839 follow-up Phase B: tenant-managed SAML 設定の handler / SDK wrapper / DDB store / schema を
+ * 単体テストで pin する。 Lambda 統合は別途 deploy で確認、 ここでは pure ロジックを保証する。
+ */
+
+describe("TenantSamlConfigInputSchema (Zod)", () => {
+  it("metadataUrl が HTTPS なら通すべき", () => {
+    const r = TenantSamlConfigInputSchema.safeParse({
+      metadataUrl: "https://idp.example.com/metadata.xml",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("HTTP の metadataUrl は reject すべき (= 平文 metadata 経路を作らない)", () => {
+    const r = TenantSamlConfigInputSchema.safeParse({
+      metadataUrl: "http://idp.example.com/metadata.xml",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("providerName は英数字 + -_ の 3-32 字に絞るべき", () => {
+    expect(
+      TenantSamlConfigInputSchema.safeParse({
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        providerName: "Acme_SAML-1",
+      }).success,
+    ).toBe(true);
+    expect(
+      TenantSamlConfigInputSchema.safeParse({
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        providerName: "ab",
+      }).success,
+    ).toBe(false);
+    expect(
+      TenantSamlConfigInputSchema.safeParse({
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        providerName: "Acme SAML",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("attributeMapping は 32 entries までを許容し、 33 で reject", () => {
+    const big: Record<string, string> = {};
+    for (let i = 0; i < 33; i++) big[`k${i}`] = `v${i}`;
+    expect(
+      TenantSamlConfigInputSchema.safeParse({
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        attributeMapping: big,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("normalizeAttributeMapping", () => {
+  it("undefined なら default email mapping のみ返すべき", () => {
+    expect(normalizeAttributeMapping(undefined)).toEqual({
+      email: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+    });
+  });
+
+  it("caller の email override が default に勝つべき (= Entra ID 等)", () => {
+    expect(normalizeAttributeMapping({ email: "urn:custom:user/email" })).toEqual({
+      email: "urn:custom:user/email",
+    });
+  });
+
+  it("default にない key (= name 等) を追加できる", () => {
+    expect(normalizeAttributeMapping({ name: "urn:custom:user/name" })).toMatchObject({
+      email: expect.any(String),
+      name: "urn:custom:user/name",
+    });
+  });
+});
+
+describe("extractUserPoolIdFromIss", () => {
+  it("正常な Cognito iss から userPoolId を抽出する", () => {
+    expect(
+      extractUserPoolIdFromIss(
+        "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_AbCdEfG12",
+      ),
+    ).toBe("ap-northeast-1_AbCdEfG12");
+  });
+
+  it("undefined / 空文字 / 不正 URL は undefined を返すべき", () => {
+    expect(extractUserPoolIdFromIss(undefined)).toBeUndefined();
+    expect(extractUserPoolIdFromIss("")).toBeUndefined();
+    expect(extractUserPoolIdFromIss("https://example.com")).toBeUndefined();
+    expect(extractUserPoolIdFromIss("not-a-url")).toBeUndefined();
+  });
+});
+
+/* ------------------------- Cognito SDK wrapper tests ------------------------- */
+
+function makeCognitoDeps() {
+  const send = vi.fn();
+  return {
+    send,
+    deps: {
+      client: { send },
+      userPoolId: "ap-northeast-1_PoolID",
+      userPoolClientId: "AbcdefClientId",
+    },
+  };
+}
+
+describe("upsertSamlProvider", () => {
+  it("既存 (Describe 成功) なら UpdateIdentityProviderCommand を送るべき", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({}); // describe ok
+    send.mockResolvedValueOnce({}); // update
+    await upsertSamlProvider(deps, {
+      providerName: "AcmeSAML",
+      metadataUrl: "https://idp/m.xml",
+      attributeMapping: { email: "claim" },
+    });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0][0]).toBeInstanceOf(DescribeIdentityProviderCommand);
+    expect(send.mock.calls[1][0]).toBeInstanceOf(UpdateIdentityProviderCommand);
+  });
+
+  it("Describe が ResourceNotFoundException なら CreateIdentityProviderCommand に倒れるべき", async () => {
+    const { send, deps } = makeCognitoDeps();
+    const err = new Error("not found") as Error & { name?: string };
+    err.name = "ResourceNotFoundException";
+    send.mockRejectedValueOnce(err);
+    send.mockResolvedValueOnce({});
+    await upsertSamlProvider(deps, {
+      providerName: "AcmeSAML",
+      metadataUrl: "https://idp/m.xml",
+      attributeMapping: {},
+    });
+    expect(send.mock.calls[1][0]).toBeInstanceOf(CreateIdentityProviderCommand);
+  });
+});
+
+describe("attachSamlToClient", () => {
+  it("既に SAML が含まれていれば update を送らない (idempotent)", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({
+      UserPoolClient: { SupportedIdentityProviders: ["COGNITO", "AcmeSAML"] },
+    });
+    await attachSamlToClient(deps, "AcmeSAML");
+    expect(send).toHaveBeenCalledTimes(1); // Describe のみ
+  });
+
+  it("含まれていなければ Update で SAML を追加 (COGNITO は維持)", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({
+      UserPoolClient: {
+        SupportedIdentityProviders: ["COGNITO"],
+        ExplicitAuthFlows: ["ALLOW_USER_SRP_AUTH"],
+        CallbackURLs: ["https://app.example.com/callback"],
+      },
+    });
+    send.mockResolvedValueOnce({});
+    await attachSamlToClient(deps, "AcmeSAML");
+    expect(send).toHaveBeenCalledTimes(2);
+    const cmd = send.mock.calls[1][0] as UpdateUserPoolClientCommand;
+    expect(cmd.input.SupportedIdentityProviders).toContain("COGNITO");
+    expect(cmd.input.SupportedIdentityProviders).toContain("AcmeSAML");
+  });
+});
+
+describe("enforceSamlOnlyOnClient", () => {
+  it("SAML 単独 + ExplicitAuthFlows=REFRESH_TOKEN のみで Update", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({
+      UserPoolClient: {
+        SupportedIdentityProviders: ["COGNITO", "AcmeSAML"],
+        ExplicitAuthFlows: ["ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH"],
+        CallbackURLs: [],
+      },
+    });
+    send.mockResolvedValueOnce({});
+    await enforceSamlOnlyOnClient(deps, "AcmeSAML");
+    const cmd = send.mock.calls[1][0] as UpdateUserPoolClientCommand;
+    expect(cmd.input.SupportedIdentityProviders).toEqual(["AcmeSAML"]);
+    expect(cmd.input.ExplicitAuthFlows).toEqual(["ALLOW_REFRESH_TOKEN_AUTH"]);
+  });
+});
+
+describe("allowCognitoOnClient", () => {
+  it("SAML を外し COGNITO を必ず復元 + ExplicitAuthFlows を password/SRP 含めて復元", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({
+      UserPoolClient: {
+        SupportedIdentityProviders: ["AcmeSAML"], // SAML only
+        ExplicitAuthFlows: ["ALLOW_REFRESH_TOKEN_AUTH"],
+        CallbackURLs: [],
+      },
+    });
+    send.mockResolvedValueOnce({});
+    await allowCognitoOnClient(deps, "AcmeSAML");
+    const cmd = send.mock.calls[1][0] as UpdateUserPoolClientCommand;
+    expect(cmd.input.SupportedIdentityProviders).toContain("COGNITO");
+    expect(cmd.input.SupportedIdentityProviders).not.toContain("AcmeSAML");
+    expect(cmd.input.ExplicitAuthFlows).toContain("ALLOW_USER_PASSWORD_AUTH");
+    expect(cmd.input.ExplicitAuthFlows).toContain("ALLOW_USER_SRP_AUTH");
+  });
+});
+
+describe("deleteSamlProvider", () => {
+  it("ResourceNotFound は silent skip (idempotent)", async () => {
+    const { send, deps } = makeCognitoDeps();
+    const err = new Error("not found") as Error & { name?: string };
+    err.name = "ResourceNotFoundException";
+    send.mockRejectedValueOnce(err);
+    await expect(deleteSamlProvider(deps, "AcmeSAML")).resolves.toBeUndefined();
+  });
+
+  it("通常は DeleteIdentityProviderCommand を送る", async () => {
+    const { send, deps } = makeCognitoDeps();
+    send.mockResolvedValueOnce({});
+    await deleteSamlProvider(deps, "AcmeSAML");
+    expect(send.mock.calls[0][0]).toBeInstanceOf(DeleteIdentityProviderCommand);
+  });
+});
+
+/* ----------------------- DDB store + handler integration ----------------------- */
+
+function makeSharedAndDdb() {
+  const ddbSend = vi.fn();
+  const cognitoSend = vi.fn();
+  const shared: CompetitorAccountsSharedResources = {
+    tableName: "TestCompetitorAccounts",
+    env: "development",
+    tenkaCloudAccountId: "123456789012",
+    ddb: { send: ddbSend } as unknown as CompetitorAccountsSharedResources["ddb"],
+    ssm: {} as unknown as CompetitorAccountsSharedResources["ssm"],
+    sts: {} as unknown as CompetitorAccountsSharedResources["sts"],
+    cognito: { send: cognitoSend } as unknown as CompetitorAccountsSharedResources["cognito"],
+  };
+  return { shared, ddbSend, cognitoSend };
+}
+
+describe("saml-store DDB CRUD", () => {
+  let shared: CompetitorAccountsSharedResources;
+  let ddbSend: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    const built = makeSharedAndDdb();
+    shared = built.shared;
+    ddbSend = built.ddbSend;
+  });
+  afterEach(() => ddbSend.mockReset());
+
+  it("getTenantSamlConfig: 行 不在なら undefined", async () => {
+    ddbSend.mockResolvedValueOnce({});
+    const r = await getTenantSamlConfig({ ddb: shared.ddb, tableName: shared.tableName }, "t1");
+    expect(r).toBeUndefined();
+    const cmd = ddbSend.mock.calls[0][0] as GetCommand;
+    expect(cmd.input.Key).toEqual({ PK: "TENANT#t1", SK: "SAML_CONFIG" });
+  });
+
+  it("getTenantSamlConfig: core 揃っている row は enabled:true で view にマップ", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        PK: "TENANT#t1",
+        SK: "SAML_CONFIG",
+        metadataUrl: "https://idp/m.xml",
+        providerName: "AcmeSAML",
+        attributeMapping: { email: "claim" },
+        enforceSamlOnly: false,
+        updatedAt: "2026-05-16T00:00:00Z",
+        updatedBy: "sub-1",
+      },
+    });
+    const r = await getTenantSamlConfig({ ddb: shared.ddb, tableName: shared.tableName }, "t1");
+    expect(r?.enabled).toBe(true);
+    expect(r?.metadataUrl).toBe("https://idp/m.xml");
+  });
+
+  it("putTenantSamlConfig: PutCommand を発行し view を返す", async () => {
+    ddbSend.mockResolvedValueOnce({});
+    const r = await putTenantSamlConfig(
+      { ddb: shared.ddb, tableName: shared.tableName },
+      "t1",
+      {
+        metadataUrl: "https://idp/m.xml",
+        providerName: "AcmeSAML",
+        attributeMapping: { email: "claim" },
+        enforceSamlOnly: true,
+      },
+      { updatedAt: "2026-05-16T00:00:00Z", updatedBy: "sub-1" },
+    );
+    expect(r.enabled).toBe(true);
+    expect(r.enforceSamlOnly).toBe(true);
+    const cmd = ddbSend.mock.calls[0][0] as PutCommand;
+    expect(cmd.input.Item).toMatchObject({
+      PK: "TENANT#t1",
+      SK: "SAML_CONFIG",
+      providerName: "AcmeSAML",
+    });
+  });
+
+  it("deleteTenantSamlConfig: DeleteCommand を発行 (idempotent)", async () => {
+    ddbSend.mockResolvedValueOnce({});
+    await deleteTenantSamlConfig({ ddb: shared.ddb, tableName: shared.tableName }, "t1");
+    const cmd = ddbSend.mock.calls[0][0] as DeleteCommand;
+    expect(cmd.input.Key).toEqual({ PK: "TENANT#t1", SK: "SAML_CONFIG" });
+  });
+});
+
+describe("handleGetTenantSamlConfig", () => {
+  it("DDB row 不在なら enabled:false の view を 200 で返す", async () => {
+    const { shared, ddbSend } = makeSharedAndDdb();
+    ddbSend.mockResolvedValueOnce({});
+    const r = await handleGetTenantSamlConfig(shared, "t1");
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ enabled: false });
+  });
+
+  it("DDB row 存在なら enabled:true の view を 200 で返す", async () => {
+    const { shared, ddbSend } = makeSharedAndDdb();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        PK: "TENANT#t1",
+        SK: "SAML_CONFIG",
+        metadataUrl: "https://idp/m.xml",
+        providerName: "AcmeSAML",
+        attributeMapping: { email: "claim" },
+        enforceSamlOnly: false,
+        updatedAt: "2026-05-16T00:00:00Z",
+        updatedBy: "sub",
+      },
+    });
+    const r = await handleGetTenantSamlConfig(shared, "t1");
+    expect(r.status).toBe(200);
+    expect((r.body as { enabled: boolean }).enabled).toBe(true);
+  });
+});
+
+describe("handlePutTenantSamlConfig", () => {
+  it("validation 失敗なら 400 を返し Cognito / DDB を呼ばないべき", async () => {
+    const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
+    const r = await handlePutTenantSamlConfig(
+      shared,
+      {
+        client: { send: cognitoSend },
+        userPoolId: "p",
+        userPoolClientId: "c",
+      },
+      { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
+      { metadataUrl: "http://insecure" }, // HTTP は reject
+    );
+    expect(r.status).toBe(400);
+    expect(ddbSend).not.toHaveBeenCalled();
+    expect(cognitoSend).not.toHaveBeenCalled();
+  });
+
+  it("正常系 (enforceSamlOnly=false): IdP describe → create → SupportedIdentityProviders update → DDB put の順", async () => {
+    const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
+    // 1) describe -> not found, 2) create, 3) describe userPoolClient, 4) update userPoolClient
+    const notFound = new Error("not found") as Error & { name?: string };
+    notFound.name = "ResourceNotFoundException";
+    cognitoSend.mockRejectedValueOnce(notFound);
+    cognitoSend.mockResolvedValueOnce({});
+    cognitoSend.mockResolvedValueOnce({
+      UserPoolClient: { SupportedIdentityProviders: ["COGNITO"], ExplicitAuthFlows: [] },
+    });
+    cognitoSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({}); // PutCommand
+
+    const r = await handlePutTenantSamlConfig(
+      shared,
+      {
+        client: { send: cognitoSend },
+        userPoolId: "p",
+        userPoolClientId: "c",
+      },
+      { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
+      {
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        providerName: "AcmeSAML",
+        enforceSamlOnly: false,
+      },
+    );
+    expect(r.status).toBe(200);
+    expect((r.body as { enabled: boolean }).enabled).toBe(true);
+    expect(cognitoSend).toHaveBeenCalledTimes(4);
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforceSamlOnly=true なら enforceSamlOnlyOnClient (= SupportedIdentityProviders=[SAML] のみ) を呼ぶべき", async () => {
+    const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
+    cognitoSend.mockResolvedValueOnce({}); // describe IdP ok (= exists)
+    cognitoSend.mockResolvedValueOnce({}); // update IdP
+    cognitoSend.mockResolvedValueOnce({
+      UserPoolClient: { SupportedIdentityProviders: ["COGNITO", "AcmeSAML"] },
+    });
+    cognitoSend.mockResolvedValueOnce({}); // update client
+    ddbSend.mockResolvedValueOnce({});
+
+    await handlePutTenantSamlConfig(
+      shared,
+      {
+        client: { send: cognitoSend },
+        userPoolId: "p",
+        userPoolClientId: "c",
+      },
+      { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
+      {
+        metadataUrl: "https://idp.example.com/metadata.xml",
+        providerName: "AcmeSAML",
+        enforceSamlOnly: true,
+      },
+    );
+    const updateClientCmd = cognitoSend.mock.calls[3][0] as UpdateUserPoolClientCommand;
+    expect(updateClientCmd.input.SupportedIdentityProviders).toEqual(["AcmeSAML"]);
+    expect(updateClientCmd.input.ExplicitAuthFlows).toEqual(["ALLOW_REFRESH_TOKEN_AUTH"]);
+  });
+});
+
+describe("handleDeleteTenantSamlConfig", () => {
+  it("UserPoolClient revert → IdP delete → DDB delete の順、 200 を返す (idempotent)", async () => {
+    const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
+    ddbSend.mockResolvedValueOnce({}); // get existing → no row
+    cognitoSend.mockResolvedValueOnce({
+      UserPoolClient: { SupportedIdentityProviders: ["COGNITO", "CompanySAML"] },
+    });
+    cognitoSend.mockResolvedValueOnce({}); // update client
+    cognitoSend.mockResolvedValueOnce({}); // delete IdP
+    ddbSend.mockResolvedValueOnce({}); // delete row
+
+    const r = await handleDeleteTenantSamlConfig(
+      shared,
+      { client: { send: cognitoSend }, userPoolId: "p", userPoolClientId: "c" },
+      { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
+    );
+
+    expect(r.status).toBe(200);
+    expect((r.body as { deleted: boolean }).deleted).toBe(true);
+    // 4 cognito calls (Describe + Update for revert, Delete IdP) + 2 DDB calls (Get + Delete)
+    expect(cognitoSend).toHaveBeenCalledTimes(3);
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

PR #852 (Phase A) は \`config.json\` + redeploy 経由のみで 「SaaS としては不十分」 という user feedback を受けた follow-up。 Tenant 管理者が application-admin-console の **設定画面 + API** から自社 SAML を CRUD できる経路を追加する。

### 何が変わるか

| | Phase A (PR #852) | Phase B (本 PR) |
|---|---|---|
| 設定経路 | \`config.json\` + redeploy | UI \`/settings/sso\` + REST API |
| 主体 | TenkaCloud operator | tenant 管理者 (Tenant Admin) |
| 即時性 | 再 deploy (数分) | API 呼び出しで即反映 |
| Audit | git log | console.log audit (DDB 履歴 + CloudWatch) |
| Lock-out 防止 | なし | 2-step 確認 modal + 「SAML のみ」 切替前警告 |

Phase A は廃止せず残します (= operator default 用)、 Phase B が runtime override で上書き。

## Backend

- 新規 routes (`/admin/tenant-saml-config` の `GET` / `PATCH`+`PUT` / `DELETE`) を **既存 `competitor-accounts` Lambda** に同居 (= IAM scope が近い、 別 Lambda 化は Phase 3 で再評価)
- Cognito SDK wrapper (`cognito-saml.ts`): upsert IdP / attach to client / enforce SAML only / allow Cognito back / delete を **全部 idempotent**
- DDB persistence (`saml-store.ts`): CompetitorAccounts table の \`PK=TENANT#<id>\`, \`SK=SAML_CONFIG\` sparse row
- self-targeting: JWT \`iss\` / \`aud\` から UserPool / Client ID を runtime 抽出 (= cross-stack で具体 ARN を渡さず、 wildcard IAM + runtime guard で代用)
- 監査: console.log (= 既存 pattern と同じ、 ZERO 新 infra)

## Frontend

- 新規 page `apps/application-admin-console/src/pages/SamlSso.tsx`:
  - 現在の設定表示 (KeyValuePairs)
  - 編集 form (= Metadata URL + Provider name + enforce toggle)
  - **2-step 確認 modal**: enforceSamlOnly を OFF → ON に flip するとき + SAML 削除するとき
  - **pooled tenant 警告 Alert**: pooled mode では UserPool 共有のため変更が全 pooled tenants に波及することを明示
- API client (`tenant-saml-client.ts`) — GET / PATCH / DELETE
- Nav menu に `SAML SSO` 追加
- i18n 4 言語 (ja / en / es / zh) で 32 keys 追加

## Tests

27 cases pass:
- Zod schema (HTTPS 強制 / providerName 制約 / attributeMapping 上限)
- attribute mapping normalization
- JWT iss から UserPool ID 抽出 helper
- Cognito SDK wrapper (upsert / attach / enforce / allow / delete) all idempotent
- DDB store CRUD
- handler orchestration (validation 失敗 / 正常並列 / enforceSamlOnly / 削除)

## 重要な設計判断

### Lock-out 防止
\`enforceSamlOnly\` を ON にすると username/password 経路が閉じる。 SAML 設定が壊れていると誰もログインできなくなる。 防御:
1. UI で **2-step 確認 modal** + 「staging で確認してから本番」 推奨文言
2. 「壊れたら AWS Console で UserPoolClient.SupportedIdentityProviders に COGNITO を手動で戻す」 復旧手順を modal 内に明示

### Idempotent
全 SDK 操作 (create / update / attach / delete) が再送で同じ結果に倒れる。 Lambda 途中失敗 → リトライ → 正常完了の経路を保証。

### Self-targeting via JWT
cross-stack で具体 UserPool ARN を渡すと CFn export が増える + tenant 増減で配線が変わる。 代わりに JWT \`iss\` / \`aud\` から runtime 抽出 + IAM scope を account/region 内 UserPool に絞ることで 「呼び出した user の UserPool だけ mutate できる」 を保証する。

## 既知の制約 (= doc 化済み)

- **pooled mode の co-tenancy**: pooled tenants は 1 UserPool を共有するため、 1 tenant の SAML 設定が他 pooled tenants に波及する。 UI で warning Alert を表示。 silo (PLATINUM) は独立 UserPool で影響なし。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / build / validate-problems / cdk synth すべて green
- [x] 27 new tests pass (Zod / SDK wrapper / DDB store / handler orchestration)
- [ ] 手動: Entra ID で SAML application 登録 → UI \`/settings/sso\` で Metadata URL 入力 → 保存 → Hosted UI に \"Sign in with CompanySAML\" 出現
- [ ] 手動: enforceSamlOnly toggle ON → 2-step modal が出る → 確認後 SAML のみ sign-in 可
- [ ] 手動: SAML 削除 → 2-step modal → username/password 復元、 Hosted UI から SAML button 消える
- [ ] 手動: pooled tenant 警告 Alert が表示される

## 物理影響

- **新規 backend files (4)**: \`competitor-accounts-handler/{saml-types,saml-store,cognito-saml,saml-routes}.ts\`
- **modified backend**: \`competitor-accounts-handler/{index,shared}.ts\`, \`competitor-accounts-api-lambda.ts\` (IAM + Cognito SDK client), \`tenant-template/api-gateway.ts\` (3 ルート追加)
- **新規 frontend files (2)**: \`pages/SamlSso.tsx\`, \`api/tenant-saml-client.ts\`
- **modified frontend**: \`App.tsx\` (route), \`components/AppLayout.tsx\` (nav), 4 i18n locale ファイル
- **テスト**: \`infrastructure/test/problem-deploy/tenant-saml.test.ts\` (CREATE, 27 cases)
- インフラ: 既存 Lambda の IAM 拡張のみ (= 新 Lambda / DDB table は作らない)

## Out of scope (= 別 PR)

- **Per-tenant 完全 isolation (pooled でも独立 IdP)**: Cognito は per-UserPool で IdP を持つので、 pooled tenants が独立 IdP を持つには 1 tenant 1 UserPool が必要 (= 全 tenant を silo 化)。 大きな architectural shift なので別議論
- **Audit log の DDB 専用 table 化**: 現状 console.log で十分 (= rare path)、 高頻度監査が要るときに追加
- **System Admin (Control Plane) 側の runtime SAML**: SBT-wrapped UserPool なので escape hatch が必要。 PR #852 Phase A で deploy-time のみ対応済、 runtime は別 issue

Related: Issue #839 (Phase A: PR #852), Phase B: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)