### PR TITLE
fix(auth): enforce TenantAdmin role on tenant API routes + Codecov integration (#854)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,12 @@ jobs:
       - name: Build
         run: |
           make build
+
+      # 3rd-party action は tag (mutable) ではなく commit SHA (immutable) で pin する
+      # (= supply-chain attack 防御、 maintainer / attacker が tag を移動できなくする)。 v5.5.4 SHA。
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Codecov 側 outage で CI 全体を落とさない。 coverage 計測は補助、 必須でない。
+          fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install:
 install_ci:    ; bun install --frozen-lockfile --ignore-scripts
 build:         ; bun run build
 typecheck:     ; bun run typecheck
-test:          ; bun run test
+test:          ; bun run test --coverage
 validate-problems: ; bun run validate:problems
 build-problems-index: ; bun run build:problems-index
 check-problems-index: ; bun run check:problems-index

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,7 @@ Battle (リアルタイム対戦) と Challenge (個別演習) の問題を、 �
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Built with CDK](https://img.shields.io/badge/Built%20with-AWS%20CDK-orange)](https://aws.amazon.com/cdk/)
 [![SBT](https://img.shields.io/badge/SBT-0.3.9-blue)](https://github.com/awslabs/sbt-aws)
+[![codecov](https://codecov.io/gh/susumutomita/TenkaCloud/graph/badge.svg?token=WfleGvJor9)](https://codecov.io/gh/susumutomita/TenkaCloud)
 ![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/susumutomita/TenkaCloud)
 ![GitHub top language](https://img.shields.io/github/languages/top/susumutomita/TenkaCloud)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/susumutomita/TenkaCloud)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Battle (real-time) and Challenge (self-paced) problems deployed straight to each
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Built with CDK](https://img.shields.io/badge/Built%20with-AWS%20CDK-orange)](https://aws.amazon.com/cdk/)
 [![SBT](https://img.shields.io/badge/SBT-0.3.9-blue)](https://github.com/awslabs/sbt-aws)
+[![codecov](https://codecov.io/gh/susumutomita/TenkaCloud/graph/badge.svg?token=WfleGvJor9)](https://codecov.io/gh/susumutomita/TenkaCloud)
 ![GitHub last commit (by committer)](https://img.shields.io/github/last-commit/susumutomita/TenkaCloud)
 ![GitHub top language](https://img.shields.io/github/languages/top/susumutomita/TenkaCloud)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/susumutomita/TenkaCloud)

--- a/apps/admin-console/test/cognito.test.ts
+++ b/apps/admin-console/test/cognito.test.ts
@@ -57,7 +57,11 @@ describe("completeLogin", () => {
 
   describe("PKCE verifier が session に無いとき", () => {
     it("エラーを投げるべき", async () => {
-      await expect(completeLogin(config, "code")).rejects.toThrow(/PKCE verifier missing/);
+      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression あり
+      // (空文字判定に倒れる)。 `toMatchObject` で error.message を robust に照合する。
+      await expect(completeLogin(config, "code")).rejects.toMatchObject({
+        message: expect.stringContaining("PKCE verifier missing"),
+      });
     });
   });
 
@@ -113,7 +117,10 @@ describe("completeLogin", () => {
           .mockResolvedValue(new Response("invalid_grant", { status: 400, statusText: "Bad" })),
       );
 
-      await expect(completeLogin(config, "bad")).rejects.toThrow(/400.*invalid_grant/);
+      // Issue #873: regex assertion regression を回避するため toMatchObject で照合。
+      await expect(completeLogin(config, "bad")).rejects.toMatchObject({
+        message: expect.stringMatching(/400.*invalid_grant/),
+      });
     });
   });
 });

--- a/apps/admin-console/test/insight.test.ts
+++ b/apps/admin-console/test/insight.test.ts
@@ -74,8 +74,9 @@ describe("fetchTenantsInsightSummary", () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(JSON.stringify({ error: "internal" }), { status: 500 }),
     );
-    await expect(fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"])).rejects.toThrow(
-      /500/,
+    // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` regression を回避。
+    await expect(fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"])).rejects.toMatchObject(
+      { message: expect.stringContaining("500") },
     );
   });
 });

--- a/apps/admin-console/test/tenants.test.ts
+++ b/apps/admin-console/test/tenants.test.ts
@@ -111,9 +111,10 @@ describe("createTenant", () => {
       const { api, post } = buildApiMock();
       post.mockRejectedValueOnce(new Error("API 500"));
 
+      // Issue #873: vitest 4.x で `.rejects.toThrow(string)` regression を回避。
       await expect(
         createTenant(api, { tenantName: "X", email: "a@b.com", tier: "basic" }),
-      ).rejects.toThrow("API 500");
+      ).rejects.toMatchObject({ message: "API 500" });
     });
   });
 });

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -60,7 +60,10 @@ describe("createApiClient", () => {
       const api = createApiClient(config.apiBaseUrl, "TOKEN");
 
       await expect(api.get("apps")).rejects.toBeInstanceOf(ApiError);
-      await expect(api.get("apps")).rejects.toThrow(/403.*forbidden/);
+      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` regression を回避。
+      await expect(api.get("apps")).rejects.toMatchObject({
+        message: expect.stringMatching(/403.*forbidden/),
+      });
     });
   });
 

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -59,7 +59,10 @@ describe("completeLogin", () => {
 
   describe("PKCE verifier が session に無いとき", () => {
     it("エラーを投げるべき", async () => {
-      await expect(completeLogin(config, "code")).rejects.toThrow(/PKCE verifier missing/);
+      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression を回避。
+      await expect(completeLogin(config, "code")).rejects.toMatchObject({
+        message: expect.stringContaining("PKCE verifier missing"),
+      });
     });
   });
 
@@ -115,7 +118,10 @@ describe("completeLogin", () => {
           .mockResolvedValue(new Response("invalid_grant", { status: 400, statusText: "Bad" })),
       );
 
-      await expect(completeLogin(config, "bad")).rejects.toThrow(/400.*invalid_grant/);
+      // Issue #873: regex regression を回避。
+      await expect(completeLogin(config, "bad")).rejects.toMatchObject({
+        message: expect.stringMatching(/400.*invalid_grant/),
+      });
     });
   });
 });

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -78,7 +78,10 @@ describe("getPortalMe", () => {
       vi.fn().mockImplementation(() => Promise.resolve(new Response("ddb down", { status: 500 }))),
     );
     await expect(getPortalMe("https://x", KEY)).rejects.toBeInstanceOf(PortalNetworkError);
-    await expect(getPortalMe("https://x", KEY)).rejects.toThrow(/500.*ddb down/);
+    // Issue #873: regex regression を回避。
+    await expect(getPortalMe("https://x", KEY)).rejects.toMatchObject({
+      message: expect.stringMatching(/500.*ddb down/),
+    });
   });
 
   it("AbortSignal を fetch に伝播するべき", async () => {

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -47,7 +47,10 @@ describe("AuthProvider", () => {
   it("空白のみのキーを渡したら throw、session は変わらないべき", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
-      await expect(result.current.login("   ")).rejects.toThrow(/チームログインキー/);
+      // Issue #873: vitest 4.x `.rejects.toThrow(/regex/)` regression を回避。
+      await expect(result.current.login("   ")).rejects.toMatchObject({
+        message: expect.stringContaining("チームログインキー"),
+      });
     });
     expect(result.current.session).toBeNull();
   });
@@ -117,9 +120,10 @@ describe("AuthProvider", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
     const { result } = renderAuth(prodConfig);
     await act(async () => {
-      await expect(result.current.login("AbCdEfGhIjKlMnOpQrStUvWx")).rejects.toThrow(
-        /チームログインキーが無効/,
-      );
+      // Issue #873: regex regression を回避。
+      await expect(result.current.login("AbCdEfGhIjKlMnOpQrStUvWx")).rejects.toMatchObject({
+        message: expect.stringContaining("チームログインキーが無効"),
+      });
     });
     expect(result.current.session).toBeNull();
   });

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
         "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
+        "@vitest/coverage-v8": "^4.1.6",
         "husky": "^9.1.4",
         "markdownlint-cli2": "^0.21.0",
         "marked": "^18.0.3",
@@ -316,13 +317,15 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
-    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
 
@@ -454,7 +457,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@keyv/bigmap": ["@keyv/bigmap@1.3.0", "", { "dependencies": { "hashery": "^1.2.0", "hookified": "^1.13.0" }, "peerDependencies": { "keyv": "^5.5.4" } }, "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg=="],
 
@@ -762,6 +765,8 @@
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.6", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.6", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.6", "vitest": "4.1.6" }, "optionalPeers": ["@vitest/browser"] }, "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
@@ -774,7 +779,7 @@
 
     "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+    "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -811,6 +816,8 @@
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "assign-symbols": ["assign-symbols@1.0.0", "", {}, "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
@@ -1138,6 +1145,8 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
@@ -1256,13 +1265,19 @@
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
     "japanese-numerals-to-number": ["japanese-numerals-to-number@1.0.2", "", {}, "sha512-rgs/V7G8Gfy8Z4XtnVBYXzWMAb9oUWp1pDdRmwHmh0hcjcy1kOu+DOpC5rwoHUAN4TqANwb7WD6z5W2v7v7PQQ=="],
 
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1317,6 +1332,10 @@
     "lz-string": ["lz-string@1.5.0", "", { "bin": "bin/bin.js" }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
@@ -1976,9 +1995,13 @@
 
     "@aws-sdk/client-s3/@smithy/core": ["@smithy/core@3.24.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@cdklabs/sbt-aws/@aws-cdk/aws-lambda-python-alpha": ["@aws-cdk/aws-lambda-python-alpha@2.114.1-alpha.0", "", { "peerDependencies": { "aws-cdk-lib": "^2.114.1", "constructs": "^10.0.0" } }, "sha512-ozpcGNBrNjfrEOkTC8gpTJu9g1PCKV62NNGV3kE3hOkqjphss9ytwKjIfUIvS+yjqy8D8/BHM0btJKrNur0RoQ=="],
 
     "@cloudscape-design/component-toolkit/weekstart": ["weekstart@2.0.0", "", {}, "sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@smithy/hash-blob-browser/@smithy/core": ["@smithy/core@3.24.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g=="],
 
@@ -1997,6 +2020,16 @@
     "@textlint/linter-formatter/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@textlint/markdown-to-ast/unified": ["unified@9.2.2", "", { "dependencies": { "bail": "^1.0.0", "extend": "^3.0.0", "is-buffer": "^2.0.0", "is-plain-obj": "^2.0.0", "trough": "^1.0.0", "vfile": "^4.0.0" } }, "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ=="],
+
+    "@vitest/coverage-v8/vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
+
+    "@vitest/expect/@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "@vitest/runner/@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
@@ -2021,6 +2054,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "kuromoji/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "mdast-util-footnote/micromark": ["micromark@2.11.4", "", { "dependencies": { "debug": "^4.0.0", "parse-entities": "^2.0.0" } }, "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA=="],
 
@@ -2092,6 +2127,8 @@
 
     "textlint-rule-preset-jtf-style/textlint-rule-prh": ["textlint-rule-prh@6.1.0", "", { "dependencies": { "@babel/parser": "^7.27.0", "prh": "^5.4.4", "textlint-rule-helper": "^2.3.1" } }, "sha512-KrchADHw1/LZ/tAQ2XwL/XdUhunKCvlNmwgp+6hdyzuWX7uojOkDdJWWV0KAN4XWsK6Te5w/SZcYwQ7X6i3B0A=="],
 
+    "textlint-rule-prh/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
     "textlint-rule-spellcheck-tech-word/textlint-rule-helper": ["textlint-rule-helper@1.2.0", "", { "dependencies": { "unist-util-visit": "^1.1.0" } }, "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ=="],
 
     "textlint-tester/@textlint/feature-flag": ["@textlint/feature-flag@13.4.1", "", {}, "sha512-qY8gKUf30XtzWMTkwYeKytCo6KPx6milpz8YZhuRsEPjT/5iNdakJp5USWDQWDrwbQf7RbRncQdU+LX5JbM9YA=="],
@@ -2108,6 +2145,8 @@
 
     "vfile/is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
 
+    "vitest/@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.11.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
@@ -2123,6 +2162,18 @@
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@textlint/markdown-to-ast/unified/is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/runner": ["@vitest/runner@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/snapshot": ["@vitest/snapshot@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
+
+    "@vitest/coverage-v8/vitest/@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -2166,6 +2217,8 @@
 
     "micromark-extension-gfm/micromark/parse-entities": ["parse-entities@2.0.0", "", { "dependencies": { "character-entities": "^1.0.0", "character-entities-legacy": "^1.0.0", "character-reference-invalid": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0", "is-hexadecimal": "^1.0.0" } }, "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="],
 
+    "parse-json/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "prh/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -2181,6 +2234,10 @@
     "textlint-rule-ja-unnatural-alphabet/@textlint/regexp-string-matcher/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "textlint-rule-no-exclamation-question-mark/@textlint/regexp-string-matcher/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "textlint-rule-preset-jtf-style/textlint-rule-prh/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "textlint-rule-prh/@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "textlint-rule-spellcheck-tech-word/textlint-rule-helper/unist-util-visit": ["unist-util-visit@1.4.1", "", { "dependencies": { "unist-util-visit-parents": "^2.0.0" } }, "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw=="],
 
@@ -2283,6 +2340,8 @@
     "micromark-extension-gfm/micromark/parse-entities/is-decimal": ["is-decimal@1.0.4", "", {}, "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="],
 
     "micromark-extension-gfm/micromark/parse-entities/is-hexadecimal": ["is-hexadecimal@1.0.4", "", {}, "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="],
+
+    "textlint-rule-preset-jtf-style/textlint-rule-prh/@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "textlint-rule-spellcheck-tech-word/textlint-rule-helper/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@2.1.2", "", { "dependencies": { "unist-util-is": "^3.0.0" } }, "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g=="],
 

--- a/docs/operations/saml-federation.html
+++ b/docs/operations/saml-federation.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>SAML federation セットアップ (Issue #839 follow-up)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>SAML federation セットアップ (Issue #839 follow-up)</h1>
+<p>TenkaCloud の <strong>System Admin (Control Plane)</strong> と <strong>Tenant Admin (Tenant Template)</strong> の Cognito UserPool に SAML IdP を連携し、 会社の SSO (Entra ID / Okta / Google Workspace 等) で sign-in 可能にする手順です。</p>
+<p><code>username/password</code> 経路と並列で運用するか、 SAML だけに絞るかは <code>enforceSamlOnly</code> フラグで切り替えます。</p>
+<h2>1. IdP 側 (= 会社の IdP) で application 登録</h2>
+<p>各 IdP の手順は以下のとおりです。</p>
+<ul>
+<li><strong>Microsoft Entra ID</strong>: Enterprise applications → New application → Non-gallery → SAML</li>
+<li><strong>Okta</strong>: Applications → Create App Integration → SAML 2.0</li>
+<li><strong>Google Workspace</strong>: Apps → Web and mobile apps → Add custom SAML app</li>
+</ul>
+<p>IdP には次の値を設定してください。</p>
+<ul>
+<li><strong>SP エンティティ ID (Audience)</strong>: <code>urn:amazon:cognito:sp:&lt;USER_POOL_ID&gt;</code><ul>
+<li>System Admin: ControlPlaneStack の <code>UserPoolId</code> Output を control に貼る</li>
+<li>Tenant Admin: <code>tenkacloud-tenant-template-pooled</code> の <code>UserPoolId</code> を貼る</li>
+</ul>
+</li>
+<li><strong>ACS URL (Reply URL)</strong>: <code>https://&lt;COGNITO_DOMAIN_PREFIX&gt;.auth.&lt;region&gt;.amazoncognito.com/saml2/idpresponse</code><ul>
+<li><code>&lt;COGNITO_DOMAIN_PREFIX&gt;</code> は <code>tenkacloud-&lt;env&gt;-&lt;tenantId&gt;-&lt;accountId&gt;</code> (= identity-provider.ts の <code>buildCognitoDomainPrefix</code>)</li>
+</ul>
+</li>
+<li><strong>NameID format</strong>: <code>EmailAddress</code></li>
+<li><strong>Attribute mapping</strong>:<ul>
+<li><code>email</code> → <code>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress</code></li>
+<li>(任意) <code>name</code> / <code>groups</code> 等を追加するときは下記「config.json での有効化」で <code>attributeMapping</code> に書く</li>
+</ul>
+</li>
+</ul>
+<p>IdP 設定完了後、 <strong>federation metadata URL</strong> を控えてください。 これを Cognito に渡します。</p>
+<ul>
+<li>Entra ID:「App Federation Metadata Url」</li>
+<li>Okta:「Identity Provider metadata」</li>
+<li>Google Workspace:「IDP metadata URL」</li>
+</ul>
+<h2>2. config.json での有効化</h2>
+<p><code>infrastructure/environments/&lt;env&gt;/config.json</code> に次の section を追加します。</p>
+<h3>Tenant Admin (全 tenant 共有の SAML)</h3>
+<pre><code class="language-json">{
+  &quot;tenantSamlConfig&quot;: {
+    &quot;metadataUrl&quot;: &quot;https://login.microsoftonline.com/&lt;tenant&gt;/federationmetadata/2007-06/federationmetadata.xml&quot;,
+    &quot;providerName&quot;: &quot;AcmeSAML&quot;,
+    &quot;enforceSamlOnly&quot;: false,
+    &quot;attributeMapping&quot;: {
+      &quot;email&quot;: &quot;http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress&quot;
+    }
+  }
+}
+</code></pre>
+<h3>System Admin (= TenkaCloud operator 会社の SSO)</h3>
+<pre><code class="language-json">{
+  &quot;controlPlaneConfig&quot;: {
+    &quot;systemAdminEmail&quot;: &quot;ops@example.com&quot;,
+    &quot;samlIdp&quot;: {
+      &quot;metadataUrl&quot;: &quot;https://login.microsoftonline.com/&lt;tenant&gt;/federationmetadata/2007-06/federationmetadata.xml&quot;,
+      &quot;providerName&quot;: &quot;AcmeSAML&quot;,
+      &quot;enforceSamlOnly&quot;: false
+    }
+  }
+}
+</code></pre>
+<h3>フィールドの意味</h3>
+<table>
+<thead>
+<tr>
+<th>field</th>
+<th>必須</th>
+<th>説明</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>metadataUrl</code></td>
+<td>yes</td>
+<td>IdP の federation metadata XML を取得する HTTPS URL。 IdP 側 cert rotation 時も自動追従。</td>
+</tr>
+<tr>
+<td><code>providerName</code></td>
+<td>no</td>
+<td>Cognito 内で IdP を識別する名前 (Hosted UI button label にもなる)。 default <code>CompanySAML</code>。 英数字 + <code>-_</code> のみ。</td>
+</tr>
+<tr>
+<td><code>enforceSamlOnly</code></td>
+<td>no</td>
+<td><code>true</code> なら username/password 経路を閉じる (= Hosted UI に SAML button のみ)。 default <code>false</code> (= 並列許可)。</td>
+</tr>
+<tr>
+<td><code>attributeMapping</code></td>
+<td>no</td>
+<td>SAML AttributeStatement 名 → Cognito attribute 名のマップ。 default は email のみ自動。</td>
+</tr>
+</tbody></table>
+<h2>3. deploy</h2>
+<pre><code class="language-bash">make deploy ENV=development
+</code></pre>
+<p><code>infrastructure/lib/tenant-template/identity-provider.ts</code> と <code>infrastructure/lib/control-plane-stack.ts</code> の両方が config を読み込み、 SAML IdP を CFn 上に作ります。</p>
+<p>deploy 完了後、 Cognito Hosted UI を開くと「Sign in with <code>&lt;providerName&gt;</code>」button が表示されます。</p>
+<h2>4. ロールアウトの推奨手順</h2>
+<p>既存 user に SAML 強制をかけるとログイン経路が一夜で変わるので、 次の段階で進めることを推奨します。</p>
+<ol>
+<li><strong>dev / staging で並列 (<code>enforceSamlOnly: false</code>)</strong>: SAML 経路を operator で 1 人テスト</li>
+<li><strong>production で並列</strong>: operator 全員が SAML 経由でログインできることを確認 (最低 1 週間)</li>
+<li><strong>production で <code>enforceSamlOnly: true</code></strong>: username/password 経路を閉じる</li>
+</ol>
+<p><code>enforceSamlOnly: true</code> に flip した後、 旧 username/password の user は Cognito Admin Console から削除する運用にすることで遺漏を防げます。</p>
+<h2>5. トラブルシューティング</h2>
+<h3>Hosted UI に SAML button が出ない</h3>
+<ul>
+<li><code>make synth</code> で UserPoolClient の <code>SupportedIdentityProviders</code> を確認: SAML provider 名が入っているか</li>
+<li>Cognito Hosted UI の <strong>App Client &gt; Identity Providers</strong> タブで provider が enable されているか確認 (= deploy 直後は反映に数分かかる場合あり)</li>
+</ul>
+<h3>Sign-in 時に「No email」 / 「No NameID」 エラー</h3>
+<ul>
+<li>IdP の attribute mapping が <code>emailaddress</code> を出力しているか確認 (NameID format=EmailAddress でない IdP は明示的に <code>email</code> claim を別の URN で出す必要あり)</li>
+<li><code>attributeMapping</code> の <code>email</code> キーを IdP 側の Attribute Name に合わせて override</li>
+</ul>
+<h3>「Untrusted ACS URL」 エラー</h3>
+<ul>
+<li>IdP 側の Reply URL が Cognito の <code>/saml2/idpresponse</code> を指しているか確認</li>
+<li>domain prefix は env / tenantId / accountId で組まれるので、 deploy 後の <strong>実 URL を IdP 側に貼る</strong> 順番が正しい (= deploy → URL 取得 → IdP 設定)</li>
+</ul>
+<h2>関連</h2>
+<ul>
+<li><a href="../../infrastructure/lib/tenant-template/identity-provider.ts"><code>infrastructure/lib/tenant-template/identity-provider.ts</code></a> — Tenant Admin SAML 連携の実装</li>
+<li><a href="../../infrastructure/lib/control-plane-stack.ts"><code>infrastructure/lib/control-plane-stack.ts</code></a> — System Admin SAML 連携の escape hatch</li>
+<li><a href="../../infrastructure/lib/config/config-interface.ts"><code>infrastructure/lib/config/config-interface.ts</code></a> — <code>SamlIdpConfig</code> 型定義</li>
+<li>Issue #839 — 本機能の親 issue</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/saml-federation.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/saml-federation.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -4,7 +4,9 @@ import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import {
+  ForbiddenRoleError,
   MissingTenantClaimError,
+  requireTenantAdmin,
   resolveCognitoSub,
   resolveTenantId,
 } from "../deploy-handler/auth.js";
@@ -64,12 +66,37 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
+  // Issue #854: role 不一致は 403。 actualRole / requiredRoles は body には出さない
+  // (= attacker に attack surface を教えない、 audit log にだけ残す)。
+  if (err instanceof ForbiddenRoleError) {
+    console.warn("[competitor-accounts] forbidden role", {
+      path: c.req.path,
+      actualRole: err.actualRole,
+      requiredRoles: err.requiredRoles,
+    });
+    return c.json(
+      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      StatusCodes.FORBIDDEN,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[competitor-accounts] uncaught handler error", {
     path: c.req.path,
     message,
   });
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+// Issue #854: `/admin/*` 全 route で TenantAdmin role を要求する middleware。
+// healthz だけは認証無しで通したいので path 比較で skip する (= 認証は API Gateway Cognito
+// authorizer で既に通っているが、 healthz は role check 自体を skip する設計)。
+// 個別 handler 内で再度 `requireTenantAdmin(c)` を呼ぶ必要は無い (= middleware が gate)。
+app.use("/admin/*", async (c, next) => {
+  if (c.req.path.endsWith("/healthz")) {
+    return next();
+  }
+  requireTenantAdmin(c);
+  return next();
 });
 
 app.get("/admin/competitor-accounts/healthz", (c) => c.json({ ok: true }));

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts
@@ -60,3 +60,65 @@ export function resolveCognitoSub(c: Context): string {
   const sub = claims?.sub;
   return typeof sub === "string" && sub.length > 0 ? sub : "unknown";
 }
+
+/**
+ * Issue #854: TenantAdmin / SystemAdmin の role enforcement。
+ *
+ * 旧コードは Cognito JWT authorizer (= 署名 + expiry 検証) を通った request を 「TenantAdmin
+ * 認可済」 と comment で書いていたが、 実態は **誰でも (= tenant 内の一般 user / monitor bot 等)
+ * destructive 操作ができる** 状態だった。 \`custom:userRole\` claim を見て role check しないと
+ * \`/admin/*\` route + destructive event route が tenant 内の誰でも実行できてしまう。
+ *
+ * `provision-tenant.sh` は admin-create-user で **TenantAdmin** を set する (= line 99)。
+ * 将来別 role (= 例 TenantViewer / Auditor) を増やすなら、 allowedRoles を caller で渡す形に
+ * 拡張する想定。
+ *
+ * `DEFAULT_USER_ROLE` env (= test / local override 用) を持ち、 unit test (= app.request で
+ * JWT bypass) が role check を pass できるようにする。 prod では env を渡さない。
+ */
+export class ForbiddenRoleError extends Error {
+  constructor(
+    public readonly actualRole: string | undefined,
+    public readonly requiredRoles: readonly string[],
+  ) {
+    super(
+      `role "${actualRole ?? "(none)"}" is not authorized to perform this action (required: ${requiredRoles.join(", ")})`,
+    );
+    this.name = "ForbiddenRoleError";
+  }
+}
+
+const TENANT_ADMIN_ROLE = "TenantAdmin";
+
+export function extractUserRoleFromClaims(claims: JwtClaims | undefined): string | undefined {
+  if (!claims) return undefined;
+  const raw = claims["custom:userRole"];
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * `custom:userRole` claim を取り出す。 JWT 不在経路 (= test) では env fallback。
+ */
+export function resolveUserRole(c: Context): string | undefined {
+  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
+  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const fromJwt = extractUserRoleFromClaims(claims);
+  if (fromJwt) return fromJwt;
+  const fromEnv = process.env.DEFAULT_USER_ROLE;
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/**
+ * `custom:userRole === "TenantAdmin"` を要求する。 不一致 / 不在なら `ForbiddenRoleError`
+ * を throw。 handler 側 onError で 403 にマップする。
+ *
+ * caller (handler) は \`/admin/*\` route と destructive event route の 1 行目で呼ぶ。
+ */
+export function requireTenantAdmin(c: Context): void {
+  const role = resolveUserRole(c);
+  if (role !== TENANT_ADMIN_ROLE) {
+    throw new ForbiddenRoleError(role, [TENANT_ADMIN_ROLE]);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -12,7 +12,12 @@ import {
   HTTP_NOT_FOUND,
   HTTP_OK,
 } from "../shared/http-status.js";
-import { MissingTenantClaimError, resolveTenantId } from "./auth.js";
+import {
+  ForbiddenRoleError,
+  MissingTenantClaimError,
+  requireTenantAdmin,
+  resolveTenantId,
+} from "./auth.js";
 import { requestTeardown } from "./delete.js";
 import {
   buildContext,
@@ -91,9 +96,33 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
+  // Issue #854: role 不一致は 403、 detail は body に出さず log のみ。
+  if (err instanceof ForbiddenRoleError) {
+    console.warn("[deploy] forbidden role", {
+      path: c.req.path,
+      actualRole: err.actualRole,
+      requiredRoles: err.requiredRoles,
+    });
+    return c.json(
+      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      StatusCodes.FORBIDDEN,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[deploy] uncaught handler error", { path: c.req.path, message });
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+// Issue #854: deploy / list 全 route で TenantAdmin role を要求 (= 一般 user / monitor bot に
+// destructive 操作を許さない、 GET 経路でも tenant 配下の全 deployment が見えるので admin scope)。
+// healthz だけ skip。 path prefix が無い (= "/problems/*" / "/deployments/*" 両方) ので
+// `app.use("*", ...)` で全 route を gate、 healthz は path 比較で skip する。
+app.use("*", async (c, next) => {
+  if (c.req.path === "/healthz" || c.req.path.endsWith("/healthz")) {
+    return next();
+  }
+  requireTenantAdmin(c);
+  return next();
 });
 
 app.get("/healthz", (c) => c.json({ ok: true }));

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -4,7 +4,9 @@ import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import {
+  ForbiddenRoleError,
   MissingTenantClaimError,
+  requireTenantAdmin,
   resolveCognitoSub,
   resolveTenantId,
 } from "../deploy-handler/auth.js";
@@ -89,9 +91,32 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
+  // Issue #854: role 不一致は 403、 detail は body に出さず log のみ。
+  if (err instanceof ForbiddenRoleError) {
+    console.warn("[events] forbidden role", {
+      path: c.req.path,
+      actualRole: err.actualRole,
+      requiredRoles: err.requiredRoles,
+    });
+    return c.json(
+      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      StatusCodes.FORBIDDEN,
+    );
+  }
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[events] uncaught handler error", { path: c.req.path, message });
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+});
+
+// Issue #854: 全 /events/* route で TenantAdmin role を要求 (= 一般 user / monitor bot に
+// destructive 操作を許さない、 read 経路でも teamLoginKey が response に含まれるので admin scope)。
+// healthz だけ skip。
+app.use("/events/*", async (c, next) => {
+  if (c.req.path.endsWith("/healthz")) {
+    return next();
+  }
+  requireTenantAdmin(c);
+  return next();
 });
 
 app.get("/events/healthz", (c) => c.json({ ok: true }));

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -1,11 +1,13 @@
 import { StatusCodes } from "http-status-codes";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // #686: `resolveTenantId` は JWT claim 欠落で MissingTenantClaimError を throw する。
 // route tests は `app.request()` で JWT を bypass するため、 dev override env で tenantId を
 // inject する。 prod では Cognito JWT が必ず claim を載せる前提なのでこの env は使わない。
 beforeAll(() => {
   process.env.DEFAULT_TENANT_ID = "tenant-test";
+  // Issue #854: handler middleware が TenantAdmin role を要求するので test 環境では env で inject。
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
 });
 
 const mocks = vi.hoisted(() => ({
@@ -349,5 +351,35 @@ describe("DELETE /admin/competitor-accounts/:awsAccountId", () => {
       method: "DELETE",
     });
     expect(res.status).toBe(StatusCodes.NOT_FOUND);
+  });
+});
+
+/* ---- Issue #854: /admin/* middleware enforces TenantAdmin role ---- */
+
+describe("/admin/* middleware (Issue #854)", () => {
+  const originalRole = process.env.DEFAULT_USER_ROLE;
+  afterEach(() => {
+    if (originalRole === undefined) delete process.env.DEFAULT_USER_ROLE;
+    else process.env.DEFAULT_USER_ROLE = originalRole;
+  });
+
+  it("role 不一致 (= TenantUser) なら 403 forbidden_role を返すべき", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantUser";
+    const res = await app.request("/admin/competitor-accounts", { method: "GET" });
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("forbidden_role");
+  });
+
+  it("role claim 不在 (= JWT 経由なし) なら 403", async () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const res = await app.request("/admin/competitor-accounts", { method: "GET" });
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+  });
+
+  it("healthz は role check skip して 200 を返すべき", async () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const res = await app.request("/admin/competitor-accounts/healthz", { method: "GET" });
+    expect(res.status).toBe(StatusCodes.OK);
   });
 });

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -2,8 +2,12 @@ import type { Context } from "hono";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   extractTenantIdFromClaims,
+  extractUserRoleFromClaims,
+  ForbiddenRoleError,
   MissingTenantClaimError,
+  requireTenantAdmin,
   resolveTenantId,
+  resolveUserRole,
 } from "../../lib/problem-deploy/handlers/deploy-handler/auth";
 
 describe("extractTenantIdFromClaims", () => {
@@ -74,5 +78,90 @@ describe("resolveTenantId", () => {
     process.env.DEFAULT_TENANT_ID = "tenant-from-env";
     const c = { env: {} } as unknown as Context;
     expect(resolveTenantId(c)).toBe("tenant-from-env");
+  });
+});
+
+/* ---- Issue #854: TenantAdmin role enforcement ---- */
+
+describe("extractUserRoleFromClaims (Issue #854)", () => {
+  it("custom:userRole が文字列なら trim して返すべき", () => {
+    expect(extractUserRoleFromClaims({ "custom:userRole": "TenantAdmin" })).toBe("TenantAdmin");
+    expect(extractUserRoleFromClaims({ "custom:userRole": "  TenantAdmin  " })).toBe("TenantAdmin");
+  });
+
+  it("不在 / 空 / 非 string は undefined", () => {
+    expect(extractUserRoleFromClaims({})).toBeUndefined();
+    expect(extractUserRoleFromClaims({ "custom:userRole": "" })).toBeUndefined();
+    expect(extractUserRoleFromClaims({ "custom:userRole": 42 })).toBeUndefined();
+    expect(extractUserRoleFromClaims(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveUserRole (Issue #854)", () => {
+  const original = process.env.DEFAULT_USER_ROLE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.DEFAULT_USER_ROLE;
+    else process.env.DEFAULT_USER_ROLE = original;
+  });
+
+  it("JWT claim が居れば優先するべき", () => {
+    process.env.DEFAULT_USER_ROLE = "from-env";
+    const c = buildCtx({ "custom:userRole": "TenantAdmin" });
+    expect(resolveUserRole(c)).toBe("TenantAdmin");
+  });
+
+  it("JWT claim が無ければ DEFAULT_USER_ROLE env を返すべき", () => {
+    process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+    expect(resolveUserRole(buildCtx())).toBe("TenantAdmin");
+  });
+
+  it("env も無ければ undefined を返すべき", () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    expect(resolveUserRole(buildCtx())).toBeUndefined();
+  });
+});
+
+describe("requireTenantAdmin (Issue #854)", () => {
+  const original = process.env.DEFAULT_USER_ROLE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.DEFAULT_USER_ROLE;
+    else process.env.DEFAULT_USER_ROLE = original;
+  });
+
+  it("TenantAdmin role なら throw せずに pass", () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const c = buildCtx({ "custom:userRole": "TenantAdmin" });
+    expect(() => requireTenantAdmin(c)).not.toThrow();
+  });
+
+  it("他 role (= TenantUser / Auditor 等) なら ForbiddenRoleError を throw", () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const c = buildCtx({ "custom:userRole": "TenantUser" });
+    expect(() => requireTenantAdmin(c)).toThrow(ForbiddenRoleError);
+  });
+
+  it("role claim 不在 / env も無いなら ForbiddenRoleError を throw (= fail-closed)", () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const c = buildCtx();
+    expect(() => requireTenantAdmin(c)).toThrow(ForbiddenRoleError);
+  });
+
+  it("DEFAULT_USER_ROLE=TenantAdmin env で JWT 不在経路 (= test bypass) は pass", () => {
+    process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+    expect(() => requireTenantAdmin(buildCtx())).not.toThrow();
+  });
+
+  it("ForbiddenRoleError は actualRole / requiredRoles を保持する (= audit log 用)", () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const c = buildCtx({ "custom:userRole": "TenantUser" });
+    try {
+      requireTenantAdmin(c);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ForbiddenRoleError);
+      const forbidden = err as ForbiddenRoleError;
+      expect(forbidden.actualRole).toBe("TenantUser");
+      expect(forbidden.requiredRoles).toEqual(["TenantAdmin"]);
+    }
   });
 });

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -4,6 +4,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 // tenantId を inject する。 prod では Cognito JWT が必ず claim を載せる前提。
 beforeAll(() => {
   process.env.DEFAULT_TENANT_ID = "tenant-test";
+  // Issue #854: handler middleware が TenantAdmin role を要求するので test 環境では env で inject。
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
 });
 
 const mocks = vi.hoisted(() => ({

--- a/infrastructure/test/problem-deploy/handler-error-cors.test.ts
+++ b/infrastructure/test/problem-deploy/handler-error-cors.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Issue #854: handler middleware が TenantAdmin role を要求するので test 環境では env で inject。
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
 
 /**
  * #559 defensive layer の test (PR-570 review 指摘で書き直し)。

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
     "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
+    "@vitest/coverage-v8": "^4.1.6",
     "husky": "^9.1.4",
     "markdownlint-cli2": "^0.21.0",
     "marked": "^18.0.3",


### PR DESCRIPTION
## Summary

### Security fix (Issue #854): TenantAdmin role enforcement

API Gateway Cognito JWT authorizer は署名 + expiry 検証のみで、 \`custom:userRole\` claim による role check が無く、 tenant 内の **誰でも** /admin/* + destructive event route + 全 deploy route が実行できる状態だった (Critical security issue)。

実装:
- \`auth.ts\` に \`requireTenantAdmin(c)\` helper + \`ForbiddenRoleError\` 追加
- 3 handler に Hono middleware で全 route gate (healthz だけ bypass)
- ForbiddenRoleError → 403 forbidden_role に map、 attack surface 情報は body に出さず log のみ
- 8 cases for pure helper + 3 cases for /admin/* middleware

### Codecov integration (user 追加 + SHA pin)

- root \`package.json\` に \`@vitest/coverage-v8\` (user 設定)
- \`Makefile\` の \`make test\` に \`--coverage\` flag (user 設定)
- \`.github/workflows/ci.yml\` の codecov-action を **commit SHA pin** に置換 (= supply chain 防御):
  \`codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4\`
- \`fail_ci_if_error: false\` で Codecov outage が CI を落とさない

### Pre-existing test failure workaround (Issue #873)

\`make test --coverage\` 経由で表面化した vitest 4.x の \`.rejects.toThrow(/regex/)\` 照合 regression を \`.rejects.toMatchObject({ message: ... })\` 方式に書き換え。 7 ファイル / 8 case 修正。 根本対応 (= vitest version alignment) は別 PR で行う (Issue #873)。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / 952+ tests / build / cdk synth すべて green
- [x] requireTenantAdmin pure helper 8 cases + /admin/* middleware 3 cases
- [ ] 手動: TenantUser role JWT で /admin/competitor-accounts → 403 forbidden_role
- [ ] 手動: TenantAdmin role JWT で /admin/competitor-accounts → 200
- [ ] 手動: healthz は role なしでも 200

## Regression 分析

- backend は middleware で全 /admin / /events / deploy route を gate するため、 既存 frontend (= TenantAdmin role の JWT で叩く) は影響なし
- monitor bot / 一般 user (= 仮にいた場合) は 403 を受ける (= intended security fix)
- healthz は role check skip、 monitoring 経路は維持
- test fixture (= \`DEFAULT_USER_ROLE=TenantAdmin\` env) を beforeAll で inject、 全 953 tests pass

## 物理影響

- \`infrastructure/lib/problem-deploy/handlers/{competitor-accounts,event,deploy}-handler/index.ts\` — middleware + onError 追加
- \`infrastructure/lib/problem-deploy/handlers/deploy-handler/auth.ts\` — requireTenantAdmin / ForbiddenRoleError 追加
- \`infrastructure/test/problem-deploy/deploy-auth.test.ts\` + \`competitor-accounts-routes.test.ts\` + \`deploy-handler-routes.test.ts\` + \`handler-error-cors.test.ts\` — DEFAULT_USER_ROLE inject + 11 new cases
- \`.github/workflows/ci.yml\` + \`Makefile\` + \`package.json\` — Codecov integration (user changes + SHA pin)
- 7 test files — Issue #873 workaround
- インフラ — NO-OP (= IAM 変更なし、 Lambda の挙動のみ強化)

Closes #854
Relates #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAML federation documentation for System Admin and Tenant Admin user pools (Entra ID, Okta, Google Workspace).
  * Implemented tenant admin role enforcement for admin endpoints.
  * Integrated coverage reporting to Codecov with badge display in project README.

* **Bug Fixes**
  * Fixed test assertions for improved reliability with test framework compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->