### PR TITLE
fix(security): add CloudFront security headers (CSP / HSTS / X-Frame-Options) to 3 distributions (#855)

### DIFF
--- a/apps/admin-console/test/cognito.test.ts
+++ b/apps/admin-console/test/cognito.test.ts
@@ -57,8 +57,7 @@ describe("completeLogin", () => {
 
   describe("PKCE verifier が session に無いとき", () => {
     it("エラーを投げるべき", async () => {
-      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression あり
-      // (空文字判定に倒れる)。 `toMatchObject` で error.message を robust に照合する。
+      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression あり。
       await expect(completeLogin(config, "code")).rejects.toMatchObject({
         message: expect.stringContaining("PKCE verifier missing"),
       });
@@ -117,7 +116,7 @@ describe("completeLogin", () => {
           .mockResolvedValue(new Response("invalid_grant", { status: 400, statusText: "Bad" })),
       );
 
-      // Issue #873: regex assertion regression を回避するため toMatchObject で照合。
+      // Issue #873: regex regression を回避。
       await expect(completeLogin(config, "bad")).rejects.toMatchObject({
         message: expect.stringMatching(/400.*invalid_grant/),
       });

--- a/apps/admin-console/test/insight.test.ts
+++ b/apps/admin-console/test/insight.test.ts
@@ -74,7 +74,7 @@ describe("fetchTenantsInsightSummary", () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(JSON.stringify({ error: "internal" }), { status: 500 }),
     );
-    // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` regression を回避。
+    // Issue #873: regex regression を回避。
     await expect(fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"])).rejects.toMatchObject(
       { message: expect.stringContaining("500") },
     );

--- a/apps/admin-console/test/tenants.test.ts
+++ b/apps/admin-console/test/tenants.test.ts
@@ -111,7 +111,7 @@ describe("createTenant", () => {
       const { api, post } = buildApiMock();
       post.mockRejectedValueOnce(new Error("API 500"));
 
-      // Issue #873: vitest 4.x で `.rejects.toThrow(string)` regression を回避。
+      // Issue #873: vitest 4.x `.rejects.toThrow(string)` regression を回避。
       await expect(
         createTenant(api, { tenantName: "X", email: "a@b.com", tier: "basic" }),
       ).rejects.toMatchObject({ message: "API 500" });

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -60,7 +60,7 @@ describe("createApiClient", () => {
       const api = createApiClient(config.apiBaseUrl, "TOKEN");
 
       await expect(api.get("apps")).rejects.toBeInstanceOf(ApiError);
-      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` regression を回避。
+      // Issue #873: regex regression を回避。
       await expect(api.get("apps")).rejects.toMatchObject({
         message: expect.stringMatching(/403.*forbidden/),
       });

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -59,7 +59,7 @@ describe("completeLogin", () => {
 
   describe("PKCE verifier が session に無いとき", () => {
     it("エラーを投げるべき", async () => {
-      // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression を回避。
+      // Issue #873: regex regression を回避。
       await expect(completeLogin(config, "code")).rejects.toMatchObject({
         message: expect.stringContaining("PKCE verifier missing"),
       });

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -47,7 +47,7 @@ describe("AuthProvider", () => {
   it("空白のみのキーを渡したら throw、session は変わらないべき", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
-      // Issue #873: vitest 4.x `.rejects.toThrow(/regex/)` regression を回避。
+      // Issue #873: regex regression を回避。
       await expect(result.current.login("   ")).rejects.toMatchObject({
         message: expect.stringContaining("チームログインキー"),
       });

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -11,6 +11,7 @@ import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
+import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers";
 
 export interface AdminConsoleHostingStackProps extends cdk.StackProps {
   /** Control Plane API Gateway URL (末尾スラッシュ無し) */
@@ -88,10 +89,19 @@ export class AdminConsoleHostingStack extends cdk.Stack {
     const oai = new OriginAccessIdentity(this, "OAI");
     bucket.grantRead(oai);
 
+    // Issue #855: CloudFront に security headers (HSTS / CSP / X-Frame-Options 等) を強制。
+    // admin-console は Control Plane API (= props.apiUrl) と SBT Cognito (= props.cognitoDomain)
+    // に connect する。 form-action は Cognito Hosted UI への sign-in form 投稿で使う。
+    const securityHeaders = buildSecurityHeadersPolicy(this, "SecurityHeaders", {
+      connectSrcAllowedOrigins: [props.apiUrl, props.cognitoDomain],
+      formActionAllowedOrigins: [props.cognitoDomain],
+    });
+
     const distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: new S3Origin(bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        responseHeadersPolicy: securityHeaders,
       },
       defaultRootObject: "index.html",
       httpVersion: HttpVersion.HTTP2,

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -11,6 +11,7 @@ import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
+import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers";
 
 export type ParticipantPortalMode = "dev-mock" | "backend";
 
@@ -61,10 +62,21 @@ export class ParticipantPortalHosting extends Construct {
     const oai = new OriginAccessIdentity(this, "OAI");
     this.bucket.grantRead(oai);
 
+    // Issue #855: CloudFront に security headers を強制。 participant-portal は teamLoginKey 経路
+    // (= bearer token 専用) で外部 Cognito は使わないが、 backend API (= Lambda Function URL)
+    // への connect は許可する必要がある。 form-action は teamLoginKey login の form 投稿で同 origin。
+    const securityHeaders = buildSecurityHeadersPolicy(this, "SecurityHeaders", {
+      connectSrcAllowedOrigins: [
+        "https://*.lambda-url.*.on.aws",
+        "https://*.execute-api.*.amazonaws.com",
+      ],
+    });
+
     this.distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: new S3Origin(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        responseHeadersPolicy: securityHeaders,
       },
       defaultRootObject: "index.html",
       httpVersion: HttpVersion.HTTP2,

--- a/infrastructure/lib/security/cloudfront-headers.ts
+++ b/infrastructure/lib/security/cloudfront-headers.ts
@@ -1,0 +1,110 @@
+import { Duration } from "aws-cdk-lib";
+import {
+  HeadersFrameOption,
+  HeadersReferrerPolicy,
+  ResponseHeadersPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import type { Construct } from "constructs";
+
+/**
+ * Issue #855: 3 SPA (admin-console / application-admin-console / participant-portal) の
+ * CloudFront Distribution に適用する security headers の正本 helper。
+ *
+ * 適用される headers:
+ *   - Strict-Transport-Security: max-age=63072000; includeSubDomains; preload (= HSTS、 downgrade 防御)
+ *   - X-Frame-Options: DENY (= clickjacking 防御、 CSP frame-ancestors と二重防御)
+ *   - X-Content-Type-Options: nosniff (= MIME sniffing XSS 防御)
+ *   - Referrer-Policy: strict-origin-when-cross-origin (= cross-origin referrer leak 防御)
+ *   - Content-Security-Policy: SPA ごとに connect-src を override する (= Cognito / API GW 経路)
+ *
+ * CSP 設計 (= 最小許容):
+ *   - default-src 'self' (= 同 origin のみ)
+ *   - script-src 'self' (= 'unsafe-inline' / 'unsafe-eval' なし、 Vite bundle が出すモジュール JS のみ)
+ *   - style-src 'self' 'unsafe-inline' (= Cloudscape Design System が inline style を注入する制約、
+ *     hash / nonce 化は Phase 2 で別 issue)
+ *   - img-src 'self' data: (= Cloudscape の base64 inline icon)
+ *   - font-src 'self' data: (= 同上)
+ *   - connect-src は SPA ごとに override (= caller が apiOrigins / cognitoDomain を渡す)
+ *   - frame-ancestors 'none' (= clickjacking 防御、 X-Frame-Options より厳格)
+ *   - form-action 'self' (= 同 origin の form submit のみ、 phishing 経路を狭める)
+ *   - base-uri 'self' (= <base> tag 操作による URL hijack 防御)
+ *
+ * 既知制約:
+ *   - Cloudscape の inline style を 'unsafe-inline' で許容している。 厳格化は別 issue
+ *   - script-src nonce 化は Vite 4.x で SSR 経路が無いと困難、 別 issue
+ */
+export interface SecurityHeadersOptions {
+  /**
+   * CSP connect-src で許可する外部 origin (= SPA から fetch する API + auth)。 \`'self'\` は自動付与
+   * されるので caller は同 origin を含めない。 例:
+   *   - \`["https://*.amazoncognito.com", "https://*.execute-api.ap-northeast-1.amazonaws.com"]\`
+   */
+  readonly connectSrcAllowedOrigins?: readonly string[];
+  /**
+   * CSP form-action で許可する外部 origin (= Cognito Hosted UI の sign-in form 経路)。
+   * 通常は Cognito domain を含める。
+   */
+  readonly formActionAllowedOrigins?: readonly string[];
+  /**
+   * dev mode で \`unsafe-eval\` を許可するか (= Vite HMR が dev で eval を使う場合)。
+   * production では必ず false にする。 default false。
+   */
+  readonly allowUnsafeEval?: boolean;
+}
+
+/**
+ * 共通 ResponseHeadersPolicy を作る。 3 hosting stack から同 helper を呼ぶ。
+ * scope / id は CDK convention に従い caller が決める (= per-stack で unique にする)。
+ */
+export function buildSecurityHeadersPolicy(
+  scope: Construct,
+  id: string,
+  opts: SecurityHeadersOptions = {},
+): ResponseHeadersPolicy {
+  const csp = buildContentSecurityPolicy(opts);
+  return new ResponseHeadersPolicy(scope, id, {
+    securityHeadersBehavior: {
+      strictTransportSecurity: {
+        accessControlMaxAge: Duration.days(730),
+        includeSubdomains: true,
+        preload: true,
+        override: true,
+      },
+      contentTypeOptions: { override: true },
+      frameOptions: {
+        frameOption: HeadersFrameOption.DENY,
+        override: true,
+      },
+      referrerPolicy: {
+        referrerPolicy: HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+        override: true,
+      },
+      contentSecurityPolicy: {
+        contentSecurityPolicy: csp,
+        override: true,
+      },
+    },
+  });
+}
+
+/**
+ * CSP 文字列を組み立てる pure helper。 test しやすい (= options で挙動が決まる)。
+ */
+export function buildContentSecurityPolicy(opts: SecurityHeadersOptions = {}): string {
+  const connectSrc = ["'self'", ...(opts.connectSrcAllowedOrigins ?? [])];
+  const formAction = ["'self'", ...(opts.formActionAllowedOrigins ?? [])];
+  const scriptSrc = opts.allowUnsafeEval ? ["'self'", "'unsafe-eval'"] : ["'self'"];
+  const directives: readonly string[] = [
+    "default-src 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    `connect-src ${connectSrc.join(" ")}`,
+    `form-action ${formAction.join(" ")}`,
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+  ];
+  return directives.join("; ");
+}

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -11,6 +11,7 @@ import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
+import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers";
 
 interface ApplicationAdminConsoleHostingProps {
   /** TenantTemplateStack を識別するためのテナント ID。pooled の場合は "pooled" */
@@ -101,10 +102,23 @@ export class ApplicationAdminConsoleHosting extends Construct {
     const oai = new OriginAccessIdentity(this, "OAI");
     this.bucket.grantRead(oai);
 
+    // Issue #855: CloudFront に security headers を強制。 application-admin-console は tenant
+    // 別の API GW + Cognito UserPool 経路に connect するが、 具体 URL は per-tenant で動的に決まる
+    // (= runtime-config.json 経由)。 CSP connect-src / form-action は AWS の domain wildcard で
+    // 許容する (= 厳格化は別 issue、 全 tenant で共通のため individual URL の追加配線は別途検討)。
+    const securityHeaders = buildSecurityHeadersPolicy(this, "SecurityHeaders", {
+      connectSrcAllowedOrigins: [
+        "https://*.amazoncognito.com",
+        "https://*.execute-api.*.amazonaws.com",
+      ],
+      formActionAllowedOrigins: ["https://*.amazoncognito.com"],
+    });
+
     this.distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: new S3Origin(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        responseHeadersPolicy: securityHeaders,
       },
       defaultRootObject: "index.html",
       httpVersion: HttpVersion.HTTP2,

--- a/infrastructure/test/security/cloudfront-headers.test.ts
+++ b/infrastructure/test/security/cloudfront-headers.test.ts
@@ -1,0 +1,143 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import {
+  buildContentSecurityPolicy,
+  buildSecurityHeadersPolicy,
+} from "../../lib/security/cloudfront-headers";
+
+/**
+ * Issue #855: CloudFront security headers helper の pin。 CSP の各 directive、 5 つの
+ * security header が ResponseHeadersPolicy に乗ることを CFn synth で確認する。
+ */
+
+describe("buildContentSecurityPolicy (pure helper)", () => {
+  it("default で 9 directive を持ち、 connect-src / form-action は 'self' のみ", () => {
+    const csp = buildContentSecurityPolicy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).toContain("font-src 'self' data:");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+  });
+
+  it("connectSrcAllowedOrigins を 'self' に追加するべき", () => {
+    const csp = buildContentSecurityPolicy({
+      connectSrcAllowedOrigins: ["https://api.example.com", "https://auth.example.com"],
+    });
+    expect(csp).toContain("connect-src 'self' https://api.example.com https://auth.example.com");
+  });
+
+  it("formActionAllowedOrigins を 'self' に追加するべき", () => {
+    const csp = buildContentSecurityPolicy({
+      formActionAllowedOrigins: ["https://auth.example.com"],
+    });
+    expect(csp).toContain("form-action 'self' https://auth.example.com");
+  });
+
+  it("allowUnsafeEval=true なら script-src に 'unsafe-eval' を入れる (= dev only)", () => {
+    const csp = buildContentSecurityPolicy({ allowUnsafeEval: true });
+    expect(csp).toContain("script-src 'self' 'unsafe-eval'");
+  });
+
+  it("allowUnsafeEval が指定されない / false なら 'unsafe-eval' を含めない (= prod default 安全側)", () => {
+    expect(buildContentSecurityPolicy()).not.toContain("'unsafe-eval'");
+    expect(buildContentSecurityPolicy({ allowUnsafeEval: false })).not.toContain("'unsafe-eval'");
+  });
+
+  it("frame-ancestors 'none' が含まれる (= clickjacking 防御の主経路)", () => {
+    expect(buildContentSecurityPolicy()).toContain("frame-ancestors 'none'");
+  });
+});
+
+describe("buildSecurityHeadersPolicy (CDK ResponseHeadersPolicy synth)", () => {
+  function synth(): Template {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    buildSecurityHeadersPolicy(stack, "TestPolicy", {
+      connectSrcAllowedOrigins: ["https://api.example.com"],
+      formActionAllowedOrigins: ["https://auth.example.com"],
+    });
+    return Template.fromStack(stack);
+  }
+
+  it("ResponseHeadersPolicy を 1 個作る", () => {
+    synth().resourceCountIs("AWS::CloudFront::ResponseHeadersPolicy", 1);
+  });
+
+  it("HSTS / Frame Options / Content Type / Referrer / CSP の 5 header が含まれる", () => {
+    const template = synth();
+    const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
+    const config = Object.values(policies)[0]?.Properties?.ResponseHeadersPolicyConfig as {
+      SecurityHeadersConfig?: {
+        StrictTransportSecurity?: unknown;
+        FrameOptions?: unknown;
+        ContentTypeOptions?: unknown;
+        ReferrerPolicy?: unknown;
+        ContentSecurityPolicy?: { ContentSecurityPolicy?: string };
+      };
+    };
+    const sec = config?.SecurityHeadersConfig ?? {};
+    expect(sec.StrictTransportSecurity).toBeDefined();
+    expect(sec.FrameOptions).toBeDefined();
+    expect(sec.ContentTypeOptions).toBeDefined();
+    expect(sec.ReferrerPolicy).toBeDefined();
+    expect(sec.ContentSecurityPolicy?.ContentSecurityPolicy).toContain("default-src 'self'");
+    expect(sec.ContentSecurityPolicy?.ContentSecurityPolicy).toContain(
+      "connect-src 'self' https://api.example.com",
+    );
+  });
+
+  it("HSTS の max-age が 63072000 秒 (= 2 年) で includeSubdomains + preload", () => {
+    const template = synth();
+    const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
+    const hsts = (
+      Object.values(policies)[0]?.Properties as {
+        ResponseHeadersPolicyConfig: {
+          SecurityHeadersConfig: {
+            StrictTransportSecurity: {
+              AccessControlMaxAgeSec: number;
+              IncludeSubdomains: boolean;
+              Preload: boolean;
+            };
+          };
+        };
+      }
+    ).ResponseHeadersPolicyConfig.SecurityHeadersConfig.StrictTransportSecurity;
+    expect(hsts.AccessControlMaxAgeSec).toBe(63072000);
+    expect(hsts.IncludeSubdomains).toBe(true);
+    expect(hsts.Preload).toBe(true);
+  });
+
+  it("FrameOptions は DENY (= clickjacking 防御)", () => {
+    const template = synth();
+    const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
+    const fo = (
+      Object.values(policies)[0]?.Properties as {
+        ResponseHeadersPolicyConfig: {
+          SecurityHeadersConfig: { FrameOptions: { FrameOption: string } };
+        };
+      }
+    ).ResponseHeadersPolicyConfig.SecurityHeadersConfig.FrameOptions;
+    expect(fo.FrameOption).toBe("DENY");
+  });
+
+  it("ReferrerPolicy は strict-origin-when-cross-origin", () => {
+    const template = synth();
+    const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
+    const rp = (
+      Object.values(policies)[0]?.Properties as {
+        ResponseHeadersPolicyConfig: {
+          SecurityHeadersConfig: { ReferrerPolicy: { ReferrerPolicy: string } };
+        };
+      }
+    ).ResponseHeadersPolicyConfig.SecurityHeadersConfig.ReferrerPolicy;
+    expect(rp.ReferrerPolicy).toBe("strict-origin-when-cross-origin");
+  });
+});


### PR DESCRIPTION
## Summary

3 CloudFront Distribution (admin-console / application-admin-console / participant-portal) すべてに **共通 ResponseHeadersPolicy** を適用する (Issue #855)。 旧来 \`responseHeadersPolicy\` 未設定で、 以下の security header が全 HTTP response に付かない状態だった。

| Header | 防御対象 |
| --- | --- |
| Strict-Transport-Security | downgrade attack / MITM |
| Content-Security-Policy | XSS / data exfil |
| X-Frame-Options DENY | clickjacking |
| X-Content-Type-Options nosniff | MIME sniffing XSS |
| Referrer-Policy strict-origin-when-cross-origin | cross-origin referrer leak |

## CSP design (= 最小許容)

- \`default-src 'self'\`
- \`script-src 'self'\` (= \`'unsafe-inline'\` / \`'unsafe-eval'\` なし)
- \`style-src 'self' 'unsafe-inline'\` (= Cloudscape Design System が inline style を注入、 nonce 化は別 issue)
- \`img-src 'self' data:\`, \`font-src 'self' data:\` (= Cloudscape の base64 inline icons)
- \`connect-src\`: SPA ごとに override
  - admin-console: Control Plane apiUrl + Cognito domain (= 具体 URL)
  - application-admin-console: \`*.amazoncognito.com\` / \`*.execute-api.*.amazonaws.com\` (= per-tenant 動的、 wildcard)
  - participant-portal: \`*.lambda-url.*.on.aws\` / API GW wildcard
- \`form-action 'self'\` + Cognito domain (= sign-in form 投稿)
- \`base-uri 'self'\` (= \`<base>\` tag による URL hijack 防御)
- \`frame-ancestors 'none'\` (= clickjacking 主防御、 X-Frame-Options と二重)
- \`object-src 'none'\` (= Flash 等 plugin の禁止)

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / test / build / cdk synth すべて green
- [x] \`buildContentSecurityPolicy\` pure helper の 6 cases (default / connectSrc / formAction / unsafe-eval / 安全側 default)
- [x] \`buildSecurityHeadersPolicy\` CDK synth の 5 cases (= ResponseHeadersPolicy 出力 + 5 header 確認)
- [ ] 手動: \`curl -I https://<admin-console>.cloudfront.net/\` で 5 header が全部出る
- [ ] 手動: CSP で SPA が壊れないこと (= sign-in / API call / Cloudscape render 確認)

## Regression 分析

- CSP の \`script-src 'self'\` は \`'unsafe-inline'\` なし。 Vite bundle は module JS で出るので影響なし。 既存 inline script があれば壊れるが、 監査時 0 件確認済。
- \`style-src\` に \`'unsafe-inline'\` を含めるのは Cloudscape の constraint (= 既存 UI を壊さないため)。 nonce 化は別 issue で hardening。
- HSTS は 2 年 + preload。 deploy 後の rollback が困難 (= preload list から外す要求が必要)。 dev / staging で確認後 production に flip する運用を推奨。

## Out of scope (= 別 issue)

- nonce-based CSP (= \`'unsafe-inline'\` 排除) — Cloudscape の inline style を制御する仕組みが必要
- SPA 別の connect-src 厳格化 (= wildcard を具体 URL に絞る) — runtime URL を CDK 時点で知る配線が要る
- Lambda@Edge による header 動的注入 — overhead 大、 現状の static header で十分

## 物理影響

- \`infrastructure/lib/security/cloudfront-headers.ts\` — CREATE (= 共通 helper)
- \`infrastructure/lib/admin-console-hosting.ts\` — UPDATE (Distribution に responseHeadersPolicy)
- \`infrastructure/lib/tenant-template/application-admin-console-hosting.ts\` — UPDATE (同上)
- \`infrastructure/lib/problem-deploy/participant-portal-hosting.ts\` — UPDATE (同上)
- \`infrastructure/test/security/cloudfront-headers.test.ts\` — CREATE (= 11 cases)
- 5 test files — Issue #873 workaround (= #854 と並行のため再適用)
- インフラ: 各 CloudFront stack に \`AWS::CloudFront::ResponseHeadersPolicy\` リソース追加

Closes #855
Relates #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)