### PR TITLE
fix(auth): OAuth flow hardening — disable implicit grant + fail-closed state + prod localhost callbacks (#861)

### DIFF
--- a/apps/admin-console/src/auth/cognito.ts
+++ b/apps/admin-console/src/auth/cognito.ts
@@ -39,9 +39,13 @@ export async function completeLogin(
   const verifier = sessionStorage.getItem(VERIFIER_KEY);
   if (!verifier) throw new Error("PKCE verifier missing (session lost before callback)");
 
+  // Issue #861: state check は **fail-closed**。 旧コードは expectedState が null のとき check
+  // を skip していたため、 attacker が victim の sessionStorage を clear してから callback URL を
+  // 送り付けると state validation を bypass できた。 sessionStorage に state が無い時点で
+  // beginLogin() を再走行しないと到達不能経路なので、 不在は CSRF / session 切れの signal。
   const expectedState = sessionStorage.getItem(STATE_KEY);
-  if (expectedState && returnedState !== expectedState) {
-    throw new Error("OAuth state mismatch (possible CSRF attempt)");
+  if (!expectedState || returnedState !== expectedState) {
+    throw new Error("OAuth state mismatch or missing (possible CSRF attempt or session lost)");
   }
 
   const body = new URLSearchParams({

--- a/apps/admin-console/test/cognito.test.ts
+++ b/apps/admin-console/test/cognito.test.ts
@@ -68,6 +68,8 @@ describe("completeLogin", () => {
     let tokens: TokenSet;
     beforeEach(async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      // Issue #861: state validation が fail-closed になったので、 valid な state を inject。
+      sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(
@@ -82,7 +84,7 @@ describe("completeLogin", () => {
           ),
         ),
       );
-      tokens = await completeLogin(config, "code");
+      tokens = await completeLogin(config, "code", "STATE-OK");
     });
 
     it("id_token を TokenSet.idToken に入れるべき", () => {
@@ -109,6 +111,8 @@ describe("completeLogin", () => {
   describe("Cognito が 4xx を返したとき", () => {
     it("ステータスと detail を含むエラーを投げるべき", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      // Issue #861: state validation 経由で state を渡す。
+      sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
       vi.stubGlobal(
         "fetch",
         vi
@@ -116,9 +120,36 @@ describe("completeLogin", () => {
           .mockResolvedValue(new Response("invalid_grant", { status: 400, statusText: "Bad" })),
       );
 
-      // Issue #873: regex regression を回避。
-      await expect(completeLogin(config, "bad")).rejects.toMatchObject({
+      // Issue #861 + #873: state validation 経由で state を渡しつつ、 vitest 4.x regex
+      // regression を回避するため toMatchObject で message を照合する。
+      await expect(completeLogin(config, "bad", "STATE-OK")).rejects.toMatchObject({
         message: expect.stringMatching(/400.*invalid_grant/),
+      });
+    });
+  });
+
+  describe("Issue #861: state validation fail-closed", () => {
+    it("returnedState 不一致は throw", async () => {
+      sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
+      await expect(completeLogin(config, "code", "ATTACKER-STATE")).rejects.toMatchObject({
+        message: expect.stringContaining("OAuth state mismatch"),
+      });
+    });
+
+    it("sessionStorage に state が無いとき (= session clear / CSRF 経路) も throw", async () => {
+      sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      // STATE_KEY を入れない
+      await expect(completeLogin(config, "code", "ATTACKER-STATE")).rejects.toMatchObject({
+        message: expect.stringContaining("OAuth state mismatch"),
+      });
+    });
+
+    it("returnedState 未指定でも throw (= 旧 silent skip の bypass を塞ぐ)", async () => {
+      sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
+      await expect(completeLogin(config, "code")).rejects.toMatchObject({
+        message: expect.stringContaining("OAuth state mismatch"),
       });
     });
   });

--- a/apps/application-admin-console/src/auth/cognito.ts
+++ b/apps/application-admin-console/src/auth/cognito.ts
@@ -45,9 +45,11 @@ export async function completeLogin(
   const verifier = sessionStorage.getItem(VERIFIER_KEY);
   if (!verifier) throw new Error("PKCE verifier missing (session lost before callback)");
 
+  // Issue #861: state check を fail-closed に。 不在 (= session 切れ / sessionStorage clear)
+  // を CSRF / phishing 経路の signal として throw する。
   const expectedState = sessionStorage.getItem(STATE_KEY);
-  if (expectedState && returnedState !== expectedState) {
-    throw new Error("OAuth state mismatch (possible CSRF attempt)");
+  if (!expectedState || returnedState !== expectedState) {
+    throw new Error("OAuth state mismatch or missing (possible CSRF attempt or session lost)");
   }
 
   const body = new URLSearchParams({

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -70,6 +70,8 @@ describe("completeLogin", () => {
     let tokens: TokenSet;
     beforeEach(async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      // Issue #861: state validation fail-closed
+      sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(
@@ -84,7 +86,7 @@ describe("completeLogin", () => {
           ),
         ),
       );
-      tokens = await completeLogin(config, "code");
+      tokens = await completeLogin(config, "code", "STATE-OK");
     });
 
     it("id_token を TokenSet.idToken に入れるべき", () => {
@@ -111,6 +113,7 @@ describe("completeLogin", () => {
   describe("Cognito が 4xx を返したとき", () => {
     it("ステータスと detail を含むエラーを投げるべき", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
       vi.stubGlobal(
         "fetch",
         vi
@@ -118,9 +121,25 @@ describe("completeLogin", () => {
           .mockResolvedValue(new Response("invalid_grant", { status: 400, statusText: "Bad" })),
       );
 
-      // Issue #873: regex regression を回避。
-      await expect(completeLogin(config, "bad")).rejects.toMatchObject({
+      await expect(completeLogin(config, "bad", "STATE-OK")).rejects.toMatchObject({
         message: expect.stringMatching(/400.*invalid_grant/),
+      });
+    });
+  });
+
+  describe("Issue #861: state validation fail-closed", () => {
+    it("returnedState 不一致は throw", async () => {
+      sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
+      await expect(completeLogin(config, "code", "ATTACKER")).rejects.toMatchObject({
+        message: expect.stringContaining("OAuth state mismatch"),
+      });
+    });
+
+    it("session に state が無いと throw (= 旧 silent skip を塞ぐ)", async () => {
+      sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
+      await expect(completeLogin(config, "code", "ATTACKER")).rejects.toMatchObject({
+        message: expect.stringContaining("OAuth state mismatch"),
       });
     });
   });

--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -86,19 +86,24 @@ export class ControlPlaneStack extends cdk.Stack {
     });
 
     // SBT 内蔵 UserPoolUserClient の callbackUrls を escape hatch で上書きして
-    // localhost 多ポート + CloudFront URL + ref デフォルトの 'http://localhost' を許可する。
+    // CloudFront URL を許可する。
+    // Issue #861: production では localhost callback URL を含めない (= phishing 経路で
+    // localhost dev tool に redirect される攻撃面を縮減)。 dev / staging は維持。
+    const isProduction = process.env.CDK_PARAM_ENVIRONMENT === "production";
     const userClient = cognitoAuth.node.findChild("UserPoolUserClient") as UserPoolClient;
     const cfnUserClient = userClient.node.defaultChild as CfnUserPoolClient;
-    cfnUserClient.addPropertyOverride("CallbackURLs", [
-      "http://localhost",
-      ...LOCALHOST_CALLBACK_URLS,
-      ...extraCallbackUrls,
-    ]);
-    cfnUserClient.addPropertyOverride("LogoutURLs", [
-      "http://localhost",
-      ...LOCALHOST_LOGOUT_URLS,
-      ...extraLogoutUrls,
-    ]);
+    cfnUserClient.addPropertyOverride(
+      "CallbackURLs",
+      isProduction
+        ? [...extraCallbackUrls]
+        : ["http://localhost", ...LOCALHOST_CALLBACK_URLS, ...extraCallbackUrls],
+    );
+    cfnUserClient.addPropertyOverride(
+      "LogoutURLs",
+      isProduction
+        ? [...extraLogoutUrls]
+        : ["http://localhost", ...LOCALHOST_LOGOUT_URLS, ...extraLogoutUrls],
+    );
 
     // Issue #653: SBT default の SystemAdmin 招待メール本文は `http://localhost` を
     // 埋めてしまうため、 admin-console origin に書き換える。 Phase 1 deploy 時は

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -143,6 +143,22 @@ interface IdentityProviderProps {
  * env / tenantId / accountId のいずれかが空文字 (synth-only context など) のときは
  * placeholder で synth が通るようにフォールバックする。
  */
+/**
+ * Issue #861: production では localhost callback URL を含めない (= phishing 経路で localhost
+ * dev tool に redirect される攻撃面を縮減)。 development / staging では dev 経路を維持。
+ *
+ * pure function、 input が同じなら output 不変。 test も容易。
+ */
+export function buildAllowedRedirectUrls(
+  primaryUrl: string,
+  environment: string,
+  devUrl: string,
+): readonly string[] {
+  const env = environment.toLowerCase();
+  if (env === "production") return [primaryUrl];
+  return [primaryUrl, devUrl];
+}
+
 function buildCognitoDomainPrefix(
   environment: string,
   tenantId: string,
@@ -286,14 +302,29 @@ export class IdentityProvider extends Construct {
         ],
         flows: {
           authorizationCodeGrant: true,
-          implicitCodeGrant: true,
+          // Issue #861: Implicit Grant は OAuth 2.0 で legacy 認定 (RFC 8252 / OAuth 2.1 で廃止)。
+          // token を URL fragment で渡し browser history / referrer / log に残るため漏れリスクあり。
+          // PKCE + Authorization Code Grant のみで OK なので無効化する。
+          implicitCodeGrant: false,
         },
+        // Issue #861: localhost callback URL は production では Allowed list に含めない。
+        // attacker が phishing 経路で localhost (= dev tooling) への redirect を試みるリスクを
+        // 下げる。 dev / staging では引き続き許容して \`make dev\` で application-admin-console を
+        // localhost:5174 で立てたデバッグ経路を壊さない。
         callbackUrls: [
-          `${props.applicationAdminConsoleUrl}/callback`,
-          // dev (apps/application-admin-console を make dev で立てる場合)
-          "http://localhost:5174/callback",
+          ...buildAllowedRedirectUrls(
+            `${props.applicationAdminConsoleUrl}/callback`,
+            props.environment,
+            "http://localhost:5174/callback",
+          ),
         ],
-        logoutUrls: [`${props.applicationAdminConsoleUrl}/`, "http://localhost:5174/"],
+        logoutUrls: [
+          ...buildAllowedRedirectUrls(
+            `${props.applicationAdminConsoleUrl}/`,
+            props.environment,
+            "http://localhost:5174/",
+          ),
+        ],
       },
     });
     if (samlProvider) {

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { describe, expect, it } from "vitest";
 import type { SamlIdpConfig } from "../lib/config/config-interface";
 import {
+  buildAllowedRedirectUrls,
   buildSupportedIdentityProviders,
   IdentityProvider,
 } from "../lib/tenant-template/identity-provider";
@@ -325,5 +326,93 @@ describe("buildSupportedIdentityProviders (pure helper)", () => {
   it("cognito=false / saml 無し (= 想定外 input) は COGNITO fallback (= safe default)", () => {
     const r = buildSupportedIdentityProviders({ cognito: false });
     expect(r.map((p) => p.name)).toEqual(["COGNITO"]);
+  });
+});
+
+describe("buildAllowedRedirectUrls (Issue #861)", () => {
+  it("development では primary + dev localhost を返すべき", () => {
+    expect(
+      buildAllowedRedirectUrls(
+        "https://app.example.com/callback",
+        "development",
+        "http://localhost:5174/callback",
+      ),
+    ).toEqual(["https://app.example.com/callback", "http://localhost:5174/callback"]);
+  });
+
+  it("staging も localhost を含めて debug 経路を維持", () => {
+    expect(
+      buildAllowedRedirectUrls(
+        "https://app.example.com/callback",
+        "staging",
+        "http://localhost:5174/callback",
+      ),
+    ).toEqual(["https://app.example.com/callback", "http://localhost:5174/callback"]);
+  });
+
+  it("production は localhost を含めない (= phishing 経路の attack surface 縮減)", () => {
+    expect(
+      buildAllowedRedirectUrls(
+        "https://app.example.com/callback",
+        "production",
+        "http://localhost:5174/callback",
+      ),
+    ).toEqual(["https://app.example.com/callback"]);
+  });
+
+  it("environment の casing は無視 (= Production / PRODUCTION も同等)", () => {
+    expect(
+      buildAllowedRedirectUrls("https://app.example.com/", "PRODUCTION", "http://localhost:5174/"),
+    ).toEqual(["https://app.example.com/"]);
+  });
+});
+
+describe("OAuth flow hardening (Issue #861)", () => {
+  function synthFor(environment: string): Template {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    new IdentityProvider(stack, "Identity", {
+      tenantId: "tenant-1",
+      environment,
+      applicationAdminConsoleUrl: "https://app.example.com",
+    });
+    return Template.fromStack(stack);
+  }
+
+  it("UserPoolClient で implicitCodeGrant が無効 (= ALLOW_FLOWS に implicit が含まれない)", () => {
+    const template = synthFor("development");
+    template.hasResourceProperties(
+      "AWS::Cognito::UserPoolClient",
+      Match.objectLike({
+        AllowedOAuthFlows: Match.arrayWith(["code"]),
+      }),
+    );
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const flows = (Object.values(clients)[0]?.Properties?.AllowedOAuthFlows ?? []) as string[];
+    expect(flows).not.toContain("implicit");
+  });
+
+  it("production env では CallbackURLs に localhost が含まれないべき", () => {
+    const template = synthFor("production");
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const callbacks = (Object.values(clients)[0]?.Properties?.CallbackURLs ?? []) as string[];
+    expect(callbacks).toEqual(["https://app.example.com/callback"]);
+    expect(callbacks).not.toContain("http://localhost:5174/callback");
+  });
+
+  it("development env では CallbackURLs に localhost が含まれる (= dev 経路維持)", () => {
+    const template = synthFor("development");
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const callbacks = (Object.values(clients)[0]?.Properties?.CallbackURLs ?? []) as string[];
+    expect(callbacks).toContain("http://localhost:5174/callback");
+  });
+
+  it("production env では LogoutURLs に localhost が含まれない", () => {
+    const template = synthFor("production");
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const logouts = (Object.values(clients)[0]?.Properties?.LogoutURLs ?? []) as string[];
+    expect(logouts).toEqual(["https://app.example.com/"]);
   });
 });


### PR DESCRIPTION
## Summary

3 つの OAuth セキュリティ改善 (Issue #861):

### 1. Implicit Code Grant 無効化

\`identity-provider.ts\` で \`implicitCodeGrant: true\` を \`false\` に。 PKCE + Authorization Code Grant で十分、 Implicit は OAuth 2.0 で legacy (RFC 8252 / OAuth 2.1 で廃止) で token を URL fragment で渡すため漏れリスクあり。

### 2. State validation fail-closed

\`apps/{admin-console,application-admin-console}/src/auth/cognito.ts\` の \`completeLogin\` で sessionStorage の expectedState が null のとき state check が **skip** される regression を fix。 attacker が victim の sessionStorage を 1 度 clear してから phishing callback URL を踏ませる攻撃経路を塞ぐ。

\`if (expectedState && returnedState !== expectedState) throw\` → \`if (!expectedState || returnedState !== expectedState) throw\` に変更。

### 3. localhost callback URL を production で除外

\`buildAllowedRedirectUrls(primary, env, devUrl)\` pure helper を切り出し、 \`environment === "production"\` のとき localhost を除外。 dev / staging は維持。 tenant template + control plane の両方に適用。

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / 全 tests / build / cdk synth すべて green
- [x] \`buildAllowedRedirectUrls\` 4 cases (dev / staging / production / casing)
- [x] CDK synth: production env で localhost が CallbackURLs / LogoutURLs に含まれないことを pin
- [x] state validation 3 new cases (mismatch / 不在 / 未指定)
- [ ] 手動: production deploy 後 \`http://localhost:5174/callback\` への OAuth redirect が Cognito で reject される
- [ ] 手動: dev env では localhost callback が引き続き動作

## Regression 分析

- 既存 \`completeLogin\` 呼び出しの test 7 件で state validation 経路を bypass していた。 STATE_KEY + returnedState を inject する形に書き換え (= 同 PR で対応、 既存テスト signature 変更)。
- production deploy 後 dev tooling を localhost で立てると admin-console / app-admin-console の login が動かない。 これは intended (= production 環境では CloudFront URL 経由運用が前提)。
- ControlPlane の \`LOCALHOST_*\` 定数は環境変数 \`CDK_PARAM_ENVIRONMENT\` で gating。 未設定 (= 旧来 dev) では従来通り localhost 許容。

## 物理影響

- \`infrastructure/lib/tenant-template/identity-provider.ts\` — implicitCodeGrant false + env-aware callback URLs + buildAllowedRedirectUrls helper
- \`infrastructure/lib/control-plane-stack.ts\` — production で localhost callback / logout URLs を除外
- \`apps/admin-console/src/auth/cognito.ts\` — state fail-closed
- \`apps/application-admin-console/src/auth/cognito.ts\` — 同上
- \`infrastructure/test/identity-provider.test.ts\` — 4 helper + 4 synth-level cases (= 8 new cases)
- \`apps/{admin-console,application-admin-console}/test/*/cognito.test.ts\` — STATE_KEY setup + state 不在 cases

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)