### PR TITLE
fix(security): tighten API Gateway CORS from allowOrigins:[*] to specific origins (#860)

### DIFF
--- a/infrastructure/lib/app-plane-core/app-plane-core.ts
+++ b/infrastructure/lib/app-plane-core/app-plane-core.ts
@@ -124,6 +124,9 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
       apiKeyId: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.platinum.keyId),
       value: props.apiKeyConfig.ssmLookup(props.apiKeyConfig.ssmParameterNames.platinum.value),
     },
+    // Issue #860: CORS allowOrigins を application-admin-console URL に絞る。
+    applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
+    environment: props.environment,
   });
 
   applicationAdminConsoleHosting.deployRuntimeConfig({

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -38,6 +38,17 @@ interface ApiGatewayProps {
   apiKeyStandardTier: CustomApiKey;
   apiKeyPremiumTier: CustomApiKey;
   apiKeyPlatinumTier: CustomApiKey;
+  /**
+   * Issue #860: CORS \`allowOrigins\` に乗せる application-admin-console の CloudFront URL。
+   * 旧コードは \`["*"]\` だったが、 phishing 経路で attacker サイトから fetch される攻撃面が
+   * 残るため、 同 tenant の SPA origin のみ許可する。 未指定なら dev fallback (= localhost のみ)。
+   */
+  applicationAdminConsoleUrl?: string;
+  /**
+   * Issue #860: environment 名 (development / staging / production)。 production のみ
+   * localhost を CORS allowOrigins から除外する (= phishing 経路で localhost への redirect を弾く)。
+   */
+  environment?: string;
 }
 
 /**
@@ -55,9 +66,25 @@ export class ApiGateway extends Construct {
   constructor(scope: Construct, id: string, props: ApiGatewayProps) {
     super(scope, id);
 
+    // Issue #860: CORS allowOrigins を `["*"]` から具体 origin に絞る (= phishing サイトから
+    // 任意 origin で fetch される攻撃面を縮減)。 application-admin-console URL + dev localhost。
+    // localhost は production env では除外する (= prod 環境の operator が dev tooling 経由で
+    // 本番 API を叩く経路を塞ぐ)。
+    const isProduction = (props.environment ?? "").toLowerCase() === "production";
+    const allowOrigins: string[] = [];
+    if (props.applicationAdminConsoleUrl) {
+      allowOrigins.push(props.applicationAdminConsoleUrl);
+    }
+    if (!isProduction) {
+      allowOrigins.push("http://localhost:5174");
+    }
+    if (allowOrigins.length === 0) {
+      // synth-only / dev-fallback で URL が解決できないときは安全側に localhost のみ。
+      allowOrigins.push("http://localhost:5174");
+    }
     this.restApi = new RestApi(this, `TenantAPI-${props.tenantId}`, {
       defaultCorsPreflightOptions: {
-        allowOrigins: ["*"],
+        allowOrigins,
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
         allowHeaders: ["Content-Type", "Authorization"],
       },


### PR DESCRIPTION
## Summary

旧 tenant-template API GW の \`defaultCorsPreflightOptions: { allowOrigins: ["*"] }\` を **application-admin-console の CloudFront URL + dev localhost** に絞る (Issue #860)。

旧設定:
\`\`\`ts
defaultCorsPreflightOptions: {
  allowOrigins: ["*"],   // ← phishing サイトから fetch される攻撃面
  ...
}
\`\`\`

新設定 (= env-aware):
\`\`\`ts
allowOrigins: [
  applicationAdminConsoleUrl,             // 同 tenant SPA
  ...(isProduction ? [] : ["http://localhost:5174"]),  // dev / staging のみ
]
\`\`\`

## Threat model

- JWT は Authorization header で送るため CORS は browser 側の defense in depth
- \`allowOrigins: ["*"]\` + \`allowHeaders: ["Authorization"]\` で attacker サイトの JS が victim の token (= 別 tab の SPA から盗む) を使って tenant API を叩く CSRF 風経路を許容していた
- 同 origin (= 同じ CloudFront URL) からのみ fetch 許可する形に絞ると、 attacker サイトの fetch は browser が block する

## Test plan

- [x] \`make harness\` — invariant 違反 0
- [x] \`make before-commit\` — lint / typecheck / 全 tests / build / cdk synth すべて green
- [ ] 手動: production deploy 後 \`curl -i -X OPTIONS -H "Origin: https://attacker.example.com" <api>\` で CORS preflight が deny されること
- [ ] 手動: 同 origin (CloudFront URL) からの fetch は通る

## Regression 分析

- application-admin-console (= 正規 client) は CloudFront URL から fetch するので CORS pass
- dev で \`make dev\` から \`http://localhost:5174\` で立てた場合も pass (= localhost を allowOrigins に含む non-production)
- ControlPlane API は別構成 (= 既に \`extraCorsOrigins\` で env-aware) で影響なし

## 物理影響

- \`infrastructure/lib/tenant-template/api-gateway.ts\` — props + CORS allowOrigins ロジック
- \`infrastructure/lib/app-plane-core/app-plane-core.ts\` — applicationAdminConsoleUrl + environment 渡し
- インフラ: 既存 API GW resource の CORS preflight 設定変更 (= IAM / Lambda 変更なし、 deploy で反映)

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)