### PR TITLE
fix(security): disable Lambda source maps in prod + no-cache runtime-config.json

### DIFF
--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -9,7 +9,7 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
-import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
 
 export interface AdminConsoleHostingStackProps extends cdk.StackProps {
@@ -168,12 +168,15 @@ export class AdminConsoleHostingStack extends cdk.Stack {
       // #718: 競技者向け bootstrap template の public S3 URL (CFn TemplateURL 経由 fetch 用)
       competitorBootstrapTemplateUrl: this.competitorBootstrapTemplateUrl,
     };
+    // Issue #867: runtime-config.json は **絶対にキャッシュさせない** (= CloudFront edge で
+    // tenant 間混線するリスク + deploy 後 1 時間反映されない問題を避けるため)。
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [Source.jsonData("runtime-config.json", runtimeConfig)],
       destinationBucket: bucket,
       distribution,
       distributionPaths: ["/runtime-config.json"],
       prune: false,
+      cacheControl: [CacheControl.noStore(), CacheControl.noCache(), CacheControl.mustRevalidate()],
     });
 
     new cdk.CfnOutput(this, "AdminConsoleUrl", {

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -5,7 +5,11 @@ import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 
 export interface AdminInsightApiLambdaProps {
   /**
@@ -64,7 +68,7 @@ export class AdminInsightApiLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -5,7 +5,11 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface CompetitorAccountsApiLambdaProps {
@@ -59,7 +63,7 @@ export class CompetitorAccountsApiLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -7,7 +7,11 @@ import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import { grantChallengePayloadRead } from "../utils/iam-helpers.js";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DeployApiLambdaProps {
@@ -87,7 +91,7 @@ export class DeployApiLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
+++ b/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
@@ -4,7 +4,11 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DescribeStackLambdaProps {
@@ -35,7 +39,7 @@ export class DescribeStackLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -5,7 +5,11 @@ import type { IEventBus } from "aws-cdk-lib/aws-events";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 
 export interface EventApiLambdaProps {
   readonly eventsTable: Table;
@@ -86,7 +90,7 @@ export class EventApiLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
+++ b/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
@@ -7,7 +7,11 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 
 export interface ExternalIdAuditLambdaProps {
   /** `CompetitorAccounts` DDB table (rotatedAt / createdAt を読み取る)。 */
@@ -59,7 +63,7 @@ export class ExternalIdAuditLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -7,7 +7,11 @@ import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import { encodeLargeEnvValue } from "../utils/env-encoding";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 
 export interface GenericScoringLambdaProps {
   readonly deploymentsTable: ITable;
@@ -96,7 +100,7 @@ export class GenericScoringLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -9,7 +9,7 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
-import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
 
 export type ParticipantPortalMode = "dev-mock" | "backend";
@@ -89,6 +89,8 @@ export class ParticipantPortalHosting extends Construct {
   }
 
   deployRuntimeConfig(config: ParticipantPortalRuntimeConfig): void {
+    // Issue #867: runtime-config.json は CloudFront / browser キャッシュさせない。
+    // event 切替 / mode 切替時に古い設定が残ると participant 全員の画面が壊れる。
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [
         Source.jsonData("runtime-config.json", {
@@ -102,6 +104,7 @@ export class ParticipantPortalHosting extends Construct {
       distribution: this.distribution,
       distributionPaths: ["/runtime-config.json"],
       prune: false,
+      cacheControl: [CacheControl.noStore(), CacheControl.noCache(), CacheControl.mustRevalidate()],
     });
   }
 }

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -17,7 +17,11 @@ import {
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import { encodeLargeEnvValue } from "../utils/env-encoding";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface ParticipantPortalLambdaProps {
@@ -175,7 +179,7 @@ export class ParticipantPortalLambda extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
+++ b/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
@@ -6,7 +6,11 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { LAMBDA_NODEJS_BUNDLING_TARGET, LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
 
 export interface TenantStatusReconcilerProps {
   /**
@@ -51,7 +55,7 @@ export class TenantStatusReconciler extends Construct {
       bundling: {
         minify: true,
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
-        sourceMap: true,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
       },
     });

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -9,7 +9,7 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
-import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
 
 interface ApplicationAdminConsoleHostingProps {
@@ -165,12 +165,15 @@ export class ApplicationAdminConsoleHosting extends Construct {
         ? { competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl }
         : {}),
     };
+    // Issue #867: runtime-config.json は CloudFront cache 無効化。 pooled tenants 共有 CDN
+    // でも tenant 別 config を返すため cache はリスク (= 設定混線)。
     new BucketDeployment(this, "RuntimeConfigDeployment", {
       sources: [Source.jsonData("runtime-config.json", data)],
       destinationBucket: this.bucket,
       distribution: this.distribution,
       distributionPaths: ["/runtime-config.json"],
       prune: false,
+      cacheControl: [CacheControl.noStore(), CacheControl.noCache(), CacheControl.mustRevalidate()],
     });
   }
 }

--- a/infrastructure/lib/utils/lambda-runtime.ts
+++ b/infrastructure/lib/utils/lambda-runtime.ts
@@ -5,3 +5,14 @@ export const LAMBDA_NODEJS_RUNTIME = Runtime.NODEJS_22_X;
 
 /** esbuild `target` aligned with `LAMBDA_NODEJS_RUNTIME`. */
 export const LAMBDA_NODEJS_BUNDLING_TARGET = "node22" as const;
+
+/**
+ * Issue #866: Lambda bundle に `.js.map` を含めるかの env-aware フラグ。
+ * production では source map を含めないことで、 万一 Lambda artifact が漏れたときに
+ * .ts source code (= 内部 logic / IAM / 構造) が復元できるリスクを下げる。
+ *
+ * `dev` / `staging` では debug 経路 (= CloudWatch Logs の stack trace を読む) を維持するため
+ * source map 有効。 環境変数 `CDK_PARAM_ENVIRONMENT` で判定する。
+ */
+export const LAMBDA_SOURCE_MAP_ENABLED =
+  (process.env.CDK_PARAM_ENVIRONMENT ?? "").toLowerCase() !== "production";


### PR DESCRIPTION
## Summary

- **#866 (Medium)**: production Lambda artifacts に `.js.map` を含めない env-aware flag (`LAMBDA_SOURCE_MAP_ENABLED`) を導入。 万一 Lambda zip が漏れても `.ts` source / IAM 構造を復元されにくくする。
- **#867 (Low)**: 全 SPA hosting (admin-console / application-admin-console / participant-portal) の `runtime-config.json` に `Cache-Control: no-store, no-cache, must-revalidate` を付与。 CloudFront edge / browser キャッシュで tenant 間設定混線 / deploy 後 1 時間反映されない問題を防ぐ。

Closes #866
Closes #867

## Regression 分析

- `LAMBDA_SOURCE_MAP_ENABLED` は `CDK_PARAM_ENVIRONMENT` (環境変数) で判定。 \`production\` 以外 (= dev / staging / 空) は従来通り `sourceMap: true` を維持 → CloudWatch stack trace の debug 経路は不変。
- 9 Lambda 構成 (admin-insight / tenant-status-reconciler / problem-deploy 系 7 件) の bundling option のみ変更。 IAM / runtime / env は touch しない。
- `runtime-config.json` 以外の S3 オブジェクト (= immutable dist asset) の cache 動作は変更なし。
- production 環境で初回 `runtime-config.json` GET が CloudFront cache miss になるが、 1 アクセス / セッションで終わるため負荷増は微小。

## 物理影響

- **UPDATE**: 9 Lambda function (bundle config の `sourceMap` フラグが env-aware)
- **UPDATE**: 3 `Custom::CDKBucketDeployment` (`runtime-config.json` の S3 metadata に `Cache-Control` 追加)
- **NO-OP** (dev / staging): production 以外では source map / cache 動作いずれも変化なし
- **NO-OP** (production): Lambda artifact が \`.js.map\` を含まなくなる → zip size 縮小 + cold start 微減 (副次効果)

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — lint / typecheck / test / validate-problems / cdk synth 全通過
- [ ] dev 環境で \`runtime-config.json\` を curl して \`Cache-Control: no-store\` を確認
- [ ] production 経路 (= \`CDK_PARAM_ENVIRONMENT=production\`) で \`cdk synth\` し Lambda bundling の sourceMap が無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)