### PR TITLE
fix(security): grace fallback in verifyCompetitorAccount on rotate race

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/verify.ts
@@ -1,5 +1,5 @@
 import { AssumeRoleCommand, type STSClient } from "@aws-sdk/client-sts";
-import { getExternalId } from "../shared/external-id-store.js";
+import { getExternalIdByVersion, getExternalIdWithVersion } from "../shared/external-id-store.js";
 import type { CompetitorAccountsSharedResources } from "./shared.js";
 import {
   CompetitorAccountNotFoundError,
@@ -37,6 +37,29 @@ const SANITY_CHECK_SESSION_NAME = "TenkaCloud-CompetitorAccount-Verify";
 const MIN_ASSUME_ROLE_SESSION_SECONDS = 900;
 
 /**
+ * Issue #856: rotate 直後の race で AssumeRole が AccessDenied / ExternalIdMismatch を返した
+ * とき、 1 generation 前の ExternalId で 1 回だけ retry する。
+ *
+ * race scenario:
+ *   1. operator が rotate を叩く → SSM v=N+1 へ
+ *   2. verify が `$LATEST` から v=N+1 を読む
+ *   3. competitor 側 Trust Policy は v=N (まだ反映していない)
+ *   4. AssumeRole fails (= ExternalId mismatch)
+ *   5. v=N を fallback で読み直して 1 回だけ retry → 成功すれば pass
+ *
+ * version <= 1 のとき fallback 不可。 100 version cap で auto-drop 済の場合も undefined。
+ */
+const ASSUME_ROLE_FALLBACK_ERROR_NAMES = new Set([
+  "AccessDenied",
+  "AccessDeniedException",
+  "Forbidden",
+]);
+
+function shouldRetryWithPreviousVersion(errorName: string): boolean {
+  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(errorName);
+}
+
+/**
  * `(tenantId, awsAccountId)` の競技者 IAM Role に対して STS AssumeRole を 1 度だけ発行し
  * (= ExternalId 付き、最短 15 分 session)、成功なら DDB の `verified=true` を立てる。
  *
@@ -54,16 +77,20 @@ export async function verifyCompetitorAccount(
   ctx: VerifyCompetitorAccountContext,
 ): Promise<CompetitorAccountSummary> {
   // DDB Get と SSM GetParameter は互いに独立 (= tenantId / awsAccountId が確定済) なので並列発火。
-  const [account, externalId] = await Promise.all([
+  // Issue #856: rotate 直後の race を吸収するため version 番号も取得する。
+  const externalIdDeps = { ssm: shared.ssm, env: shared.env };
+  const [account, externalIdWithVersion] = await Promise.all([
     getCompetitorAccount(shared, ctx.tenantId, ctx.awsAccountId),
-    getExternalId({ ssm: shared.ssm, env: shared.env }, ctx.tenantId),
+    getExternalIdWithVersion(externalIdDeps, ctx.tenantId),
   ]);
   if (!account) throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
-  if (!externalId) throw new ExternalIdMissingError(ctx.tenantId);
+  if (!externalIdWithVersion) throw new ExternalIdMissingError(ctx.tenantId);
 
   const roleArn = `arn:aws:iam::${ctx.awsAccountId}:role/${account.competitorRoleName}`;
-  try {
-    await (shared.sts as STSClient).send(
+  const sts = shared.sts as STSClient;
+
+  const tryAssumeRole = async (externalId: string): Promise<void> => {
+    await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
         RoleSessionName: SANITY_CHECK_SESSION_NAME,
@@ -71,14 +98,39 @@ export async function verifyCompetitorAccount(
         DurationSeconds: MIN_ASSUME_ROLE_SESSION_SECONDS,
       }),
     );
+  };
+
+  try {
+    await tryAssumeRole(externalIdWithVersion.value);
   } catch (err) {
-    const underlyingErrorName = err instanceof Error ? err.name : "Unknown";
-    const underlyingMessage = err instanceof Error ? err.message : String(err);
-    throw new AssumeRoleSanityCheckFailedError(
-      ctx.awsAccountId,
-      underlyingErrorName,
-      underlyingMessage,
-    );
+    const errorName = err instanceof Error ? err.name : "Unknown";
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // Issue #856: rotate race grace fallback。 1 generation 前の ExternalId を 1 回だけ retry。
+    if (shouldRetryWithPreviousVersion(errorName) && externalIdWithVersion.version > 1) {
+      const previousExternalId = await getExternalIdByVersion(
+        externalIdDeps,
+        ctx.tenantId,
+        externalIdWithVersion.version - 1,
+      );
+      if (previousExternalId) {
+        try {
+          await tryAssumeRole(previousExternalId);
+          // grace fallback 成功: 旧 version で AssumeRole が通ったので verify 完了扱い。
+          return markCompetitorAccountVerified(shared, {
+            tenantId: ctx.tenantId,
+            awsAccountId: ctx.awsAccountId,
+            verifiedAt: new Date(ctx.nowMs).toISOString(),
+          });
+        } catch (retryErr) {
+          const retryName = retryErr instanceof Error ? retryErr.name : "Unknown";
+          const retryMessage = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          throw new AssumeRoleSanityCheckFailedError(ctx.awsAccountId, retryName, retryMessage);
+        }
+      }
+    }
+
+    throw new AssumeRoleSanityCheckFailedError(ctx.awsAccountId, errorName, errorMessage);
   }
 
   return markCompetitorAccountVerified(shared, {

--- a/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
@@ -48,7 +48,7 @@ describe("verifyCompetitorAccount", () => {
       },
     });
     // 2. SSM.Get で ExternalId
-    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc", Version: 1 } });
     // 3. STS.AssumeRole 成功
     stsSend.mockResolvedValueOnce({});
     // 4. DDB.Update で verified=true
@@ -88,7 +88,7 @@ describe("verifyCompetitorAccount", () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     // DDB Get + SSM GetParameter は Promise.all で並列発火されるので両方 mock 必要
     ddbSend.mockResolvedValueOnce({}); // not found
-    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc", Version: 1 } });
 
     await expect(
       verifyCompetitorAccount(shared, {
@@ -140,7 +140,7 @@ describe("verifyCompetitorAccount", () => {
         updatedAt: "2026-01-01T00:00:00.000Z",
       },
     });
-    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc" } });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-abc", Version: 1 } });
     stsSend.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "AccessDenied" }));
 
     const thrown = await verifyCompetitorAccount(shared, {
@@ -156,5 +156,114 @@ describe("verifyCompetitorAccount", () => {
 
     // verify 失敗時は DDB.Update は呼ばれない (= verified=false のまま残る)
     expect(ddbSend.mock.calls.length).toBe(1);
+  });
+
+  it("#856: AssumeRole が AccessDenied + version > 1 のとき 1 generation 前の ExternalId で retry して成功すべき (rotate race grace)", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    // 1st SSM: $LATEST = v=3 (rotate 直後の新値)
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-new", Version: 3 } });
+    // 1st STS AssumeRole: AccessDenied (competitor 側 Trust Policy がまだ v=2 を期待している)
+    stsSend.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "AccessDenied" }));
+    // 2nd SSM: version=2 (= 3-1) を fetch
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-old", Version: 2 } });
+    // 2nd STS AssumeRole: 旧 ExternalId で成功
+    stsSend.mockResolvedValueOnce({});
+    // markVerified の DDB.Update
+    ddbSend.mockResolvedValueOnce({
+      Attributes: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        verified: true,
+        verifiedAt: new Date(NOW_MS).toISOString(),
+      },
+    });
+
+    const out = await verifyCompetitorAccount(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      nowMs: NOW_MS,
+    });
+
+    expect(out.verified).toBe(true);
+    expect(stsSend.mock.calls).toHaveLength(2);
+    const firstStsCmd = stsSend.mock.calls[0]?.[0] as AssumeRoleCommand;
+    const secondStsCmd = stsSend.mock.calls[1]?.[0] as AssumeRoleCommand;
+    expect(firstStsCmd.input.ExternalId).toBe("external-id-new");
+    expect(secondStsCmd.input.ExternalId).toBe("external-id-old");
+  });
+
+  it("#856: version=1 のときは fallback せず即失敗するべき (= rotate 未経験 / Trust Policy 真の不整合)", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-init", Version: 1 } });
+    stsSend.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "AccessDenied" }));
+
+    await expect(
+      verifyCompetitorAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(AssumeRoleSanityCheckFailedError);
+
+    // STS は 1 度のみ (= fallback retry なし)
+    expect(stsSend.mock.calls).toHaveLength(1);
+    // SSM も 1 度のみ (= getExternalIdByVersion を呼ばない)
+    expect(ssmSend.mock.calls).toHaveLength(1);
+  });
+
+  it("#856: fallback 経路でも 2 回目が失敗したら AssumeRoleSanityCheckFailedError を 2 回目の error 名で投げる", async () => {
+    const { shared, ddbSend, ssmSend, stsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-new", Version: 3 } });
+    stsSend.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "AccessDenied" }));
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "external-id-old", Version: 2 } });
+    stsSend.mockRejectedValueOnce(
+      Object.assign(new Error("malformed"), { name: "ValidationError" }),
+    );
+
+    const thrown = await verifyCompetitorAccount(shared, {
+      tenantId: "tenant-acme",
+      awsAccountId: "222222222222",
+      nowMs: NOW_MS,
+    }).then(
+      () => null,
+      (e) => e as unknown,
+    );
+    expect(thrown).toBeInstanceOf(AssumeRoleSanityCheckFailedError);
+    expect((thrown as AssumeRoleSanityCheckFailedError).underlyingErrorName).toBe(
+      "ValidationError",
+    );
   });
 });


### PR DESCRIPTION
## Summary

rotate 直後の race window で AssumeRole が AccessDenied になるケースを救済する
grace fallback を \`verifyCompetitorAccount\` に追加 (#856 Symptom 2)。

- \`getExternalId\` → \`getExternalIdWithVersion\` に切り替え (= version 番号も取得)
- AssumeRole が AccessDenied / AccessDeniedException / Forbidden で失敗したとき:
  - version > 1 なら 1 generation 前 (= version - 1) を \`getExternalIdByVersion\` で取得
  - 旧 ExternalId で 1 回だけ retry
  - 成功なら verified=true を立てる
  - 2 回目も失敗したら従来通り \`AssumeRoleSanityCheckFailedError\` を投げる
- version <= 1 のとき fallback せず即失敗 (= rotate 未経験 = 真の Trust Policy 不整合)

Relates #856

## Race scenario (Symptom 2)

1. operator が rotate を叩く → SSM v=N+1 へ
2. verify が \`\$LATEST\` から v=N+1 を読む
3. competitor 側 Trust Policy は v=N を期待 (= 反映が遅れている)
4. AssumeRole fails (= ExternalId mismatch)
5. 旧版 v=N を fallback で読み直して 1 回だけ retry → 成功すれば pass

## Out of scope

\`infrastructure/templates/competitor-bootstrap.yaml\` の Trust Policy 明示化
(= \`Symptom 1: Trust Policy 強制不足\`) は infrastructure templates の change で
user 担当領域のため本 PR では着手しない。 別 issue で追跡可能 (= #856 を partial close せず
backlink のみ残す)。

## Regression 分析

- 既存 happy path (= 1 回目 AssumeRole 成功): 従来通り、 fallback 経路は走らない
- 既存 AccessDenied (version=1 / rotate 未経験): 従来通り即失敗
- 既存 ParameterNotFound: 従来通り \`ExternalIdMissingError\`
- 新たに version > 1 + AccessDenied で旧版 retry の経路を追加 (= 3 つの新規 test ケース)

## 物理影響

- **UPDATE**: \`competitor-accounts-api\` Lambda bundle (verify.ts のロジック変更)
- **NO-OP**: DDB / SSM / IAM / API Gateway は変更なし
- **副次効果**: rotate 直後に同期 verify が 1 度だけ余計に SSM GetParameter を発行する (= cap 1)

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1006 tests pass
- [x] 新規 3 test ケース (grace fallback / version=1 即失敗 / 2 回目失敗) を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of competitor account verification by adding retry logic for temporary access failures (Issue `#856`).

* **Tests**
  * Added comprehensive test coverage for competitor account verification retry behavior under various failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->