### PR TITLE
fix(security): strip ARN/credentials from logs + coarsen rotate audit timing

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -225,13 +225,17 @@ app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c
     // 「いつ・どの operator (Cognito sub) が・どの (tenant, account) を rotate したか」を
     // 後追いできる。DDB の専用 audit table を作らない代わりに log を正本にする
     // (= ZERO 新 infra、operator 監査は infrequent なので Logs Insights で十分)。
+    //
+    // Issue #864: timing 分析で attack window を絞られないように `rotatedAt` を分単位に
+    // 粗化する (= ISO8601 の秒以下を 00 に切り詰め)。 audit 用途では分単位で十分。
+    const rotatedAtCoarse = response.rotatedAt.replace(/:\d{2}\.\d+Z$/, ":00.000Z");
     console.log(
       JSON.stringify({
         event: "competitor-accounts.rotate",
         tenantId,
         awsAccountId,
         rotatedBy,
-        rotatedAt: response.rotatedAt,
+        rotatedAt: rotatedAtCoarse,
       }),
     );
     return c.json(response, StatusCodes.OK);

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -128,13 +128,14 @@ export async function getConsoleSigninUrl(
     return { kind: "not_ready" };
   }
   if (!shared.ssm || !shared.env) {
-    console.error("[sso] ExternalId store is not configured", { jobId, tenantId });
+    // Issue #864: tenantId / ARN は CloudWatch Logs に残さない (= 情報漏洩面の縮小)。
+    console.error("[sso] ExternalId store is not configured", { jobId });
     return { kind: "assume_role_failed", reason: "ExternalId store is not configured" };
   }
 
   const tenantExternalId = await getExternalId({ ssm: shared.ssm, env: shared.env }, tenantId);
   if (!tenantExternalId) {
-    console.error("[sso] tenant ExternalId missing", { jobId, tenantId });
+    console.error("[sso] tenant ExternalId missing", { jobId });
     return { kind: "assume_role_failed", reason: "Tenant ExternalId missing" };
   }
 
@@ -152,10 +153,9 @@ export async function getConsoleSigninUrl(
     );
     const competitorCredentials = toSdkCredentials(competitorSession.Credentials);
     if (!competitorCredentials) {
-      console.error("[sso] CompetitorDeployRole AssumeRole returned empty Credentials", {
-        competitorRoleArn,
-        jobId,
-      });
+      // Issue #864: ARN を log に出さない。 jobId のみで CloudWatch Logs Insights から
+      // deployment item に join できる (= ARN は item 側から後追い参照可能、 log 側に重複させない)。
+      console.error("[sso] CompetitorDeployRole AssumeRole returned empty Credentials", { jobId });
       return { kind: "assume_role_failed", reason: "Credentials field empty" };
     }
     const innerSts = new STSClient({ credentials: competitorCredentials });
@@ -168,21 +168,15 @@ export async function getConsoleSigninUrl(
       }),
     );
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    console.error("[sso] AssumeRole failed", {
-      competitorRoleArn,
-      participantRoleArn,
-      jobId,
-      reason,
-    });
-    return { kind: "assume_role_failed", reason };
+    // Issue #864: ARN / message を log に残さず、 error 種別 (= class name) のみで切り分け可能にする。
+    // operator は jobId で deployment item を引いて ARN を確認できる (= 別経路で参照可能)。
+    const errorName = err instanceof Error ? err.name : "Unknown";
+    console.error("[sso] AssumeRole failed", { jobId, errorName });
+    return { kind: "assume_role_failed", reason: errorName };
   }
   const creds = session.Credentials;
   if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-    console.error("[sso] ParticipantViewerRole AssumeRole returned empty Credentials", {
-      participantRoleArn,
-      jobId,
-    });
+    console.error("[sso] ParticipantViewerRole AssumeRole returned empty Credentials", { jobId });
     return { kind: "assume_role_failed", reason: "Credentials field empty" };
   }
 

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -302,9 +302,42 @@ describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id", () 
       expect(parsed.event).toBe("competitor-accounts.rotate");
       expect(parsed.awsAccountId).toBe("222222222222");
       expect(parsed.rotatedAt).toBe("2026-05-12T00:00:00.000Z");
+      // Issue #864: rotatedAt は audit log では分単位に粗化する (= timing 分析を困難に)。
+      // 秒 .000 でちょうど minute-aligned なので、 :SS.SSS は :00.000 のまま。
+      expect((parsed.rotatedAt as string).endsWith(":00.000Z")).toBe(true);
       // tenantId は test の `DEFAULT_TENANT_ID` env (= "tenant-test")、 rotatedBy は JWT 不在で "unknown" fallback。
       expect(typeof parsed.tenantId).toBe("string");
       expect(typeof parsed.rotatedBy).toBe("string");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("#864: rotatedAt の秒以下は audit log で分単位に粗化する (timing 分析対策)", async () => {
+    mocks.rotateExternalIdForAccount.mockResolvedValueOnce({
+      awsAccountId: "222222222222",
+      region: "ap-northeast-1",
+      competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+      verified: true,
+      verifiedAt: "2026-05-11T00:00:00.000Z",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-12T08:42:37.123Z",
+      rotatedAt: "2026-05-12T08:42:37.123Z",
+      externalId: "new-rotated-id",
+      tenkaCloudAccountId: "111111111111",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
+        method: "POST",
+      });
+      expect(res.status).toBe(StatusCodes.OK);
+      const auditLine = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .find((line) => line.includes("competitor-accounts.rotate"));
+      const parsed = JSON.parse(auditLine ?? "{}") as Record<string, unknown>;
+      // 秒以下を 00.000 に切り詰めた値を期待 (attacker に rotate timing の精細解像度を渡さない)。
+      expect(parsed.rotatedAt).toBe("2026-05-12T08:42:00.000Z");
     } finally {
       logSpy.mockRestore();
     }

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -257,15 +257,18 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "federation_endpoint_failed", status: 500 });
   });
 
-  it("STS AssumeRole が throw したら assume_role_failed + reason を返すべき (#705)", async () => {
+  it("STS AssumeRole が throw したら assume_role_failed + reason (error name) を返すべき (#705, #864)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
-    stsSend.mockRejectedValueOnce(new Error("AccessDenied: role not assumable"));
+    // Issue #864: reason は error.name (= 種別) のみを返す。 message / ARN は log に残さない。
+    stsSend.mockRejectedValueOnce(
+      Object.assign(new Error("role not assumable"), { name: "AccessDenied" }),
+    );
 
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
     expect(result.kind).toBe("assume_role_failed");
     if (result.kind === "assume_role_failed") {
-      expect(result.reason).toMatch(/AccessDenied/);
+      expect(result.reason).toBe("AccessDenied");
     }
   });
 


### PR DESCRIPTION
## Summary

Issue #864 の 4 symptom のうち本 PR では 2 件を fix:

- **Symptom 2 — ARN / IAM in error logs**: \`participant-handler/sso.ts\` の 5 つの
  console.error から competitorRoleArn / participantRoleArn / tenantId を除去。 jobId のみ
  残し、 operator は jobId で deployment item を引いて ARN を後追い参照する経路に倒す。
  AssumeRole 例外時の reason は \`error.message\` → \`error.name\` に絞り、 内部情報の
  exposure を最小化。
- **Symptom 4 — Rotation audit timing**: \`competitor-accounts-handler/index.ts\` の rotate
  audit log で \`rotatedAt\` を分単位に粗化 (= \`HH:MM:00.000Z\`)。 timing 分析で attack
  window を絞られないようにする。

Relates #864

## Out of scope

- **Symptom 1 — Federation URL credentials**: AWS \`signin.aws.amazon.com/federation\` が
  GET + Session= query 必須 (AWS 仕様)。 POST body に変更不可。 Lambda → AWS signin は
  HTTPS 直接で proxy / log 通過しないので、 現状でも実害なし。 別 ADR で追跡する余地。
- **Symptom 3 — API error body leak**: backend ハンドラはすでに 500 で generic
  \`{ error: \"internal_error\" }\` を返している (= 内部 detail を leak していない)。
  application-admin-console の client.ts 側で operator が見る detail は意図的に backend が
  返している情報のみ。 operator UX を壊さないため別 PR で server レスポンス監査と並行検討。

## Regression 分析

- sso.ts: 既存挙動 (= 各 not_ready/assume_role_failed kind) は維持。 error log の field のみ
  縮小。 既存テスト 1 件 (\`stsSend\` の \`Error.message\` を \`reason\` に渡していた) を更新し、
  代わりに \`error.name\` (= AccessDenied 等) を assert。
- competitor-accounts-handler: rotate response body の \`rotatedAt\` (= API レスポンス) は
  従来通り精細な ISO timestamp を返す (= operator UI の表示精度を維持)。 audit log のみ粗化。

## 物理影響

- **UPDATE**: participant Lambda + competitor-accounts-api Lambda bundle (ロジック内
  log 文字列のみ)
- **NO-OP**: API レスポンス body / DDB / SSM / IAM / API Gateway は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1012 tests pass
- [x] \`sso.ts\` の error 経路テストを更新 (\`reason\` が \`error.name\` を返す assertion)
- [x] rotate audit log の分単位粗化 assertion を追加 (新 test ケース 1 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)