### PR TITLE
fix(security): tighten submit-flag rate limit to WRITE_VERY_LOW (3 burst / 6 RPM)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -131,6 +131,9 @@ app.patch("/portal/me", (c) =>
   ),
 );
 
+// Issue #870: submit-flag は brute force の標的になりうるため WRITE_VERY_LOW で更に絞る
+// (= 3 burst / 6 RPM = 1 attempt / 10s)。 旧 WRITE_LOW (= 12 RPM) 適用時は 1 team / day で
+// 17,000 attempts 可能だった。 hint reveal / teamName 編集など他の write は WRITE_LOW のまま。
 app.post("/portal/me/submit-flag", (c) =>
   withBearerAuth(
     c,
@@ -153,7 +156,7 @@ app.post("/portal/me/submit-flag", (c) =>
       if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
       return c.json(outcome, HTTP_OK);
     },
-    RATE_LIMITS.WRITE_LOW,
+    RATE_LIMITS.WRITE_VERY_LOW,
   ),
 );
 

--- a/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
@@ -90,12 +90,17 @@ export function createRateLimiter(clock: RateLimiterClock = defaultClock) {
  *
  *   - READ_HIGH: notification polling (= 5s 間隔) を 12 RPS burst で許容、 sustained 2 RPS
  *   - READ_MID: leaderboard / score-events (= 60s 間隔) を 30 RPS burst で許容
- *   - WRITE_LOW: submit-flag / endpoint override (= 人手の write) を 5 RPS burst、 1 RPS sustained
+ *   - WRITE_LOW: 人手の write (= teamName / hint reveal) を 10 burst / 12 RPM で絞る
+ *   - WRITE_VERY_LOW: brute force 標的になりうる write (= submit-flag) を 3 burst / 6 RPM
+ *     (= 1 attempt / 10s sustained) で更に絞る。 Issue #870: 旧 WRITE_LOW 適用時は
+ *     1 team / day で 17,000 attempts 可能だった。 6 RPM なら 1 day = 8,640 attempts、
+ *     2 day = 17k と倍以上の遅延を強制でき、 短時間 brute force 経路を実質遮断する。
  */
 export const RATE_LIMITS = {
   READ_HIGH: { capacity: 60, refillPerSec: 2 } as const satisfies RateLimitConfig,
   READ_MID: { capacity: 60, refillPerSec: 1 } as const satisfies RateLimitConfig,
   WRITE_LOW: { capacity: 10, refillPerSec: 0.2 } as const satisfies RateLimitConfig,
+  WRITE_VERY_LOW: { capacity: 3, refillPerSec: 0.1 } as const satisfies RateLimitConfig,
 };
 
 /** Lambda module-scope singleton (warm invoke で共有)。 */

--- a/infrastructure/test/problem-deploy/rate-limiter.test.ts
+++ b/infrastructure/test/problem-deploy/rate-limiter.test.ts
@@ -86,9 +86,14 @@ describe("createRateLimiter", () => {
     expect(limiter.take("k", config).allowed).toBe(true);
   });
 
-  it("RATE_LIMITS.WRITE_LOW は 10 burst / 0.2 RPS (= 12 RPM) であるべき (= submit-flag 設計値)", () => {
+  it("RATE_LIMITS.WRITE_LOW は 10 burst / 0.2 RPS (= 12 RPM) であるべき (= 人手 write 一般)", () => {
     expect(RATE_LIMITS.WRITE_LOW.capacity).toBe(10);
     expect(RATE_LIMITS.WRITE_LOW.refillPerSec).toBe(0.2);
+  });
+
+  it("Issue #870: RATE_LIMITS.WRITE_VERY_LOW は 3 burst / 0.1 RPS (= 6 RPM) であるべき (= submit-flag brute force 抑制)", () => {
+    expect(RATE_LIMITS.WRITE_VERY_LOW.capacity).toBe(3);
+    expect(RATE_LIMITS.WRITE_VERY_LOW.refillPerSec).toBe(0.1);
   });
 
   it("RATE_LIMITS.READ_HIGH は 60 burst / 2 RPS であるべき (= 5s polling 阻害しない)", () => {


### PR DESCRIPTION
## Summary

Issue #870: flag 提出経路の brute force feasibility を下げるため、
\`/portal/me/submit-flag\` の rate limit を旧 \`WRITE_LOW\` (= 10 burst / 12 RPM) から
新設 \`WRITE_VERY_LOW\` (= 3 burst / 6 RPM = 1 attempt / 10s sustained) に強化。

- 旧設定: 1 team / day で **17,000 attempts** 可能 → hello-world 系の短い flag は brute force 可
- 新設定: 1 day = 8,640 attempts、 2 day = 17k → 倍以上の遅延を強制
- hint reveal / teamName 編集など他の write は WRITE_LOW のまま (= 人手 UX を阻害しない)

Relates #870

## Out of scope (= 別 PR / Phase 2)

- \`wrongAnswerCount\` based lockout (= \`>= wrongAnswerMaxAttempts\` で 429)
- \`metadata.json\` への \`wrongAnswerMaxAttempts\` schema 追加
- UI 側の 「残り N 回」 表示 / lockout hint

これらは PR #848 で \`wrongAnswerCount\` の DDB persistence は wired 済だが、 上記 3 点は
metadata 拡張 + DDB GSI 設計 + frontend wire を伴う大きな変更で本 PR の scope を超える。
issue は本 PR では partial close せず backlink のみ残し、 Phase 2 で完全 close する。

## Regression 分析

- 既存 \`WRITE_LOW\` の他経路 (= \`PATCH /portal/me\` / hint reveal) は変更なし
- 既存 \`participantRateLimiter\` (= module-scope singleton) も変更なし
- \`RATE_LIMITS.WRITE_VERY_LOW\` の新規 const 追加 + 1 endpoint 適用のみ
- normal 競技者 (= 1 attempt / 数 minutes) には体感差なし

## 物理影響

- **UPDATE**: participant Lambda bundle (定数 1 行 + endpoint 1 行)
- **NO-OP**: DDB / IAM / API Gateway は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1012 tests pass
- [x] 新規 test: \`RATE_LIMITS.WRITE_VERY_LOW\` の capacity / refillPerSec assertion 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate limiting on the flag submission endpoint with stricter throttling to better protect against brute-force attacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->