### PR TITLE
fix(security): validate runtime-config.json URLs (HTTPS + cognito allowlist)

### DIFF
--- a/apps/admin-console/src/config.ts
+++ b/apps/admin-console/src/config.ts
@@ -43,12 +43,54 @@ interface RuntimeConfig {
   readonly adminInsightApiUrl?: string;
 }
 
+/**
+ * Issue #871: runtime-config.json は S3 + CloudFront 経由なので tampering surface は
+ * 限定的だが、 万一 bucket compromise / MITM で apiUrl が attacker URL に書き換えられた
+ * 場合に frontend が JWT を漏らさないよう、 URL の protocol / host を validate する。
+ *
+ *   - apiUrl: \`https://\` 必須 (= mixed content / MITM 防御)
+ *   - cognitoDomain: \`https://\` 必須 かつ \`.amazoncognito.com\` 終端
+ *     (= Cognito Hosted UI ドメインの allowlist)
+ *
+ * 検証失敗時は null を返し、 caller を env-based dev fallback に倒す
+ * (= production deploy では env が空なので throw に倒れ、 早期に検知できる)。
+ */
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isCognitoDomain(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "https:" && u.host.endsWith(".amazoncognito.com");
+  } catch {
+    return false;
+  }
+}
+
 async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
   try {
     const res = await fetch("/runtime-config.json", { cache: "no-store" });
     if (!res.ok) return null;
     const data = (await res.json()) as Partial<RuntimeConfig>;
     if (!data.apiUrl || !data.cognitoDomain || !data.userClientId) return null;
+    // Issue #871: protocol / host を validate (= tampering 対策)
+    if (!isHttpsUrl(data.apiUrl)) {
+      console.error("[config] runtime-config.json apiUrl is not HTTPS, rejecting", {
+        apiUrl: data.apiUrl,
+      });
+      return null;
+    }
+    if (!isCognitoDomain(data.cognitoDomain)) {
+      console.error("[config] runtime-config.json cognitoDomain failed allowlist, rejecting", {
+        cognitoDomain: data.cognitoDomain,
+      });
+      return null;
+    }
     return {
       apiUrl: data.apiUrl,
       cognitoDomain: data.cognitoDomain,

--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -39,6 +39,30 @@ interface RuntimeConfig {
   readonly competitorBootstrapTemplateUrl?: string;
 }
 
+/**
+ * Issue #871: runtime-config.json の URL validate (= S3 / CloudFront tampering 対策)。
+ *   - apiUrl: \`https://\` 必須
+ *   - cognitoDomain: \`https://\` 必須 + \`.amazoncognito.com\` 終端 (allowlist)
+ *
+ * 検証失敗時は null → caller が env fallback に倒れる (= production では env が空で throw)。
+ */
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isCognitoDomain(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "https:" && u.host.endsWith(".amazoncognito.com");
+  } catch {
+    return false;
+  }
+}
+
 async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
   try {
     const res = await fetch("/runtime-config.json", { cache: "no-store" });
@@ -52,6 +76,19 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       !data.apiUrl
     )
       return null;
+    // Issue #871: protocol / host を validate (= tampering 対策)
+    if (!isHttpsUrl(data.apiUrl)) {
+      console.error("[config] runtime-config.json apiUrl is not HTTPS, rejecting", {
+        apiUrl: data.apiUrl,
+      });
+      return null;
+    }
+    if (!isCognitoDomain(data.cognitoDomain)) {
+      console.error("[config] runtime-config.json cognitoDomain failed allowlist, rejecting", {
+        cognitoDomain: data.cognitoDomain,
+      });
+      return null;
+    }
     return {
       cognitoDomain: data.cognitoDomain,
       userClientId: data.userClientId,

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -17,7 +17,7 @@ describe("loadConfig", () => {
           Promise.resolve(
             new Response(
               JSON.stringify({
-                cognitoDomain: "https://prod-cognito.example.com",
+                cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
                 userClientId: "prod-client-id",
                 tenantId: "tenant-prod-1",
                 tenantName: "DENSO 第一事業部",
@@ -32,7 +32,9 @@ describe("loadConfig", () => {
     }
 
     it("cognitoDomain を runtime-config から取るべき", async () => {
-      expect((await loadWithFullRuntime()).cognitoDomain).toBe("https://prod-cognito.example.com");
+      expect((await loadWithFullRuntime()).cognitoDomain).toBe(
+        "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+      );
     });
 
     it("cognitoClientId を runtime-config.userClientId から取るべき (key が異なる)", async () => {
@@ -95,6 +97,71 @@ describe("loadConfig", () => {
               userClientId: "prod-client-id",
               tenantId: "tenant-prod-1",
               tenantName: "T",
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      const config = await loadConfig(env);
+      expect(config.apiBaseUrl).toBe("http://localhost:3999");
+    });
+  });
+
+  describe("Issue #871: runtime-config.json validation", () => {
+    it("apiUrl が http:// なら env fallback に倒れるべき (= mixed content / MITM 防御)", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "http://attacker.evil.com/",
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      const config = await loadConfig(env);
+      expect(config.apiBaseUrl).toBe("http://localhost:3999");
+    });
+
+    it("cognitoDomain が amazoncognito.com 以外なら env fallback に倒れるべき (= allowlist)", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://attacker-cognito.evil.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "https://api.example.com",
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      const config = await loadConfig(env);
+      expect(config.cognitoDomain).toBe("https://dev-cognito.example.com");
+    });
+
+    it("apiUrl が `javascript:` などの非 URL ならは env fallback に倒れるべき", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "javascript:alert(1)",
             }),
             { status: 200 },
           ),

--- a/apps/participant-portal/src/config.ts
+++ b/apps/participant-portal/src/config.ts
@@ -33,6 +33,19 @@ const DEV_FALLBACK: AppConfig = {
   mode: "dev-mock",
 };
 
+/**
+ * Issue #871: backend mode で apiBaseUrl が tampered で attacker URL を指すと、 portal が
+ * teamLoginKey (= bearer) を attacker に送ってしまう。 backend mode のときは HTTPS を強制
+ * (= dev-mock mode では localhost http を許容)。
+ */
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export async function loadConfig(): Promise<AppConfig> {
   try {
     const res = await fetch("/runtime-config.json", { cache: "no-store" });
@@ -41,11 +54,20 @@ export async function loadConfig(): Promise<AppConfig> {
       return DEV_FALLBACK;
     }
     const runtime = (await res.json()) as RuntimeConfig;
+    const mode = runtime.mode ?? DEV_FALLBACK.mode;
+    const apiBaseUrl = runtime.apiBaseUrl ?? DEV_FALLBACK.apiBaseUrl;
+    // Issue #871: backend mode は HTTPS 必須 (= teamLoginKey を attacker に漏らさない)
+    if (mode === "backend" && apiBaseUrl && !isHttpsUrl(apiBaseUrl)) {
+      console.error("[config] runtime-config.json apiBaseUrl is not HTTPS in backend mode", {
+        apiBaseUrl,
+      });
+      return DEV_FALLBACK;
+    }
     return {
-      apiBaseUrl: runtime.apiBaseUrl ?? DEV_FALLBACK.apiBaseUrl,
+      apiBaseUrl,
       eventTitle: runtime.eventTitle ?? DEV_FALLBACK.eventTitle,
       eventRegion: runtime.eventRegion ?? DEV_FALLBACK.eventRegion,
-      mode: runtime.mode ?? DEV_FALLBACK.mode,
+      mode,
     };
   } catch {
     return DEV_FALLBACK;

--- a/apps/participant-portal/test/config.test.ts
+++ b/apps/participant-portal/test/config.test.ts
@@ -63,4 +63,21 @@ describe("loadConfig", () => {
     const cfg = await loadConfig();
     expect(cfg.apiBaseUrl).toContain("dev-mock");
   });
+
+  it("Issue #871: backend mode で apiBaseUrl が http:// なら fallback に倒れるべき", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "http://attacker.evil.com/portal",
+        eventTitle: "Spoofed",
+        eventRegion: "us-east-1",
+        mode: "backend",
+      }),
+    });
+    const cfg = await loadConfig();
+    // fallback の dev-mock URL に倒れる (= teamLoginKey を attacker に送らない)
+    expect(cfg.apiBaseUrl).toContain("dev-mock");
+    expect(cfg.mode).toBe("dev-mock");
+  });
 });


### PR DESCRIPTION
## Summary

3 SPA の \`loadConfig\` で \`runtime-config.json\` を fetch したあと、 URL field を
protocol / host で validate するように変更。 万一 S3 bucket compromise / MITM で
attacker URL に書き換えられても frontend が JWT / teamLoginKey を漏らさないようにする
defense-in-depth。

- **admin-console**:
  - \`apiUrl\` が \`https://\` 必須
  - \`cognitoDomain\` が \`https://\` + \`.amazoncognito.com\` 終端必須 (= Cognito Hosted UI allowlist)
- **application-admin-console**: 同じ rule (apiUrl HTTPS + cognitoDomain allowlist)
- **participant-portal**: \`mode === \"backend\"\` のときは \`apiBaseUrl\` が HTTPS 必須
  (dev-mock mode では localhost http を許容)

検証失敗時は \`runtime-config.json\` を破棄して dev fallback (env-based) に倒れる。
production deploy では env が空なので throw に到達し、 早期に検知可能。

Closes #871

## Regression 分析

- 既存 happy-path (= prod URL は CloudFront / API Gateway の HTTPS + Cognito Hosted UI の
  \`*.amazoncognito.com\`) は validate を通過。
- 既存 test fixture (\`application-admin-console/test/config.test.ts\`) で cognitoDomain が
  \`example.com\` だったので、 \`amazoncognito.com\` に変更。
- dev fallback の挙動は変更なし (= 404 / fetch error / 必須 field 欠落いずれも従来通り)。
- 新規 4 test ケース (3 attack scenario + 1 happy) で validation を検証。

## 物理影響

- **UPDATE**: 3 SPA dist bundle (= validate function 追加、 build artifact のみ変更)
- **NO-OP**: S3 / CloudFront / runtime-config.json の deploy 経路は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 全 test pass
- [x] 新規 4 test (3 attack scenario: \`apiUrl=http://attacker\` / \`cognitoDomain=attacker.com\` /
      \`apiUrl=javascript:\` + 1 happy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)