### PR TITLE
fix(security): add 15-min idle timeout to admin / application-admin consoles (#859)

### DIFF
--- a/apps/admin-console/src/auth/AuthProvider.tsx
+++ b/apps/admin-console/src/auth/AuthProvider.tsx
@@ -1,4 +1,13 @@
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { AppConfig } from "../config";
 import { beginLogin, beginLogout, loadStoredTokens, type TokenSet } from "./cognito";
 
@@ -12,6 +21,16 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null);
 
+/**
+ * Issue #859: idle session 自動ログアウト。 15 分間 mouse / keyboard / touch / focus
+ * 操作が無ければ Cognito 側 refresh token を revoke して logout する。 stolen JWT の
+ * 利用窓を Cognito idToken 寿命 (= 1h) ではなく 15 min に短縮する defense-in-depth。
+ *
+ * timer は user 操作毎に reset。 `idle` event は throttle 不要 (= setTimeout の 1 度 fire)。
+ */
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const IDLE_EVENTS = ["mousedown", "keydown", "touchstart", "focus", "scroll"] as const;
+
 export function AuthProvider({ config, children }: { config: AppConfig; children: ReactNode }) {
   const [tokens, setTokensState] = useState<TokenSet | null>(null);
   const [ready, setReady] = useState(false);
@@ -21,6 +40,37 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     setReady(true);
   }, []);
 
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const logout = useCallback(() => {
+    // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
+    // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
+    // で Cognito 側 cookie が残り silent re-login していた)。
+    setTokensState(null);
+    void beginLogout(config);
+  }, [config]);
+
+  // Issue #859: idle timeout を tokens が存在するときのみ起動。
+  useEffect(() => {
+    if (!tokens) return;
+    const resetTimer = (): void => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        logout();
+      }, IDLE_TIMEOUT_MS);
+    };
+    resetTimer();
+    for (const evt of IDLE_EVENTS) {
+      window.addEventListener(evt, resetTimer, { passive: true });
+    }
+    return () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      for (const evt of IDLE_EVENTS) {
+        window.removeEventListener(evt, resetTimer);
+      }
+    };
+  }, [tokens, logout]);
+
   const value = useMemo<AuthState>(
     () => ({
       tokens,
@@ -28,16 +78,10 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
       login: () => {
         void beginLogin(config);
       },
-      logout: () => {
-        // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
-        // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
-        // で Cognito 側 cookie が残り silent re-login していた)。
-        setTokensState(null);
-        void beginLogout(config);
-      },
+      logout,
       setTokens: (t) => setTokensState(t),
     }),
-    [tokens, ready, config],
+    [tokens, ready, config, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/admin-console/test/AuthProvider.test.tsx
+++ b/apps/admin-console/test/AuthProvider.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Issue #859: idle session 自動ログアウトの regression test。
+ *
+ * 15 分間 mouse / keyboard 操作が無ければ logout を発火することを timer mock で pin。
+ */
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const beginLogoutMock = vi.fn();
+vi.mock("../src/auth/cognito", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    beginLogout: beginLogoutMock,
+    beginLogin: vi.fn(),
+  };
+});
+
+const { AuthProvider, useAuth } = await import("../src/auth/AuthProvider");
+
+import type { AppConfig } from "../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5173/callback",
+  apiBaseUrl: "https://api.example.com",
+  scope: "openid email",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "",
+};
+
+function TokensDisplay() {
+  const { tokens, ready } = useAuth();
+  return (
+    <div>
+      <span data-testid="ready">{ready ? "ready" : "not-ready"}</span>
+      <span data-testid="tokens">{tokens ? "has-tokens" : "no-tokens"}</span>
+    </div>
+  );
+}
+
+describe("AuthProvider idle timeout (#859)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    beginLogoutMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tokens が無いときは idle timer を起動しないべき", async () => {
+    render(
+      <AuthProvider config={config}>
+        <TokensDisplay />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("tokens")).toHaveTextContent("no-tokens");
+    act(() => {
+      vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
+    });
+    // beginLogout は呼ばれない
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+  });
+
+  it("tokens 有りで 15 min 無操作なら beginLogout を呼ぶべき", async () => {
+    const valid = {
+      idToken: "id",
+      accessToken: "ac",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    sessionStorage.setItem("TenkaCloud.tokens", JSON.stringify(valid));
+
+    render(
+      <AuthProvider config={config}>
+        <TokensDisplay />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("tokens")).toHaveTextContent("has-tokens");
+
+    // 14 min 59 sec ではまだ呼ばれない
+    await act(async () => {
+      vi.advanceTimersByTime(14 * 60 * 1000 + 59 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+
+    // 残り 1 sec で発火
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("user 操作 (keydown) で idle timer は reset されるべき", async () => {
+    const valid = {
+      idToken: "id",
+      accessToken: "ac",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    sessionStorage.setItem("TenkaCloud.tokens", JSON.stringify(valid));
+
+    render(
+      <AuthProvider config={config}>
+        <TokensDisplay />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // 10 min 経過 → keydown で reset → 14 min 経過 (total 24 min) でも logout しない
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown"));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(14 * 60 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+
+    // 残り 2 min 進めれば計 26 min、 reset 後 16 min で発火
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/application-admin-console/src/auth/AuthProvider.tsx
+++ b/apps/application-admin-console/src/auth/AuthProvider.tsx
@@ -1,4 +1,13 @@
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { AppConfig } from "../config";
 import { beginLogin, beginLogout, loadStoredTokens, type TokenSet } from "./cognito";
 
@@ -12,6 +21,13 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null);
 
+/**
+ * Issue #859: idle session 自動ログアウト (= admin-console と同 design)。 15 分の
+ * mouse / keyboard / touch / focus 無操作で Cognito refresh token を revoke して logout。
+ */
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const IDLE_EVENTS = ["mousedown", "keydown", "touchstart", "focus", "scroll"] as const;
+
 export function AuthProvider({ config, children }: { config: AppConfig; children: ReactNode }) {
   const [tokens, setTokensState] = useState<TokenSet | null>(null);
   const [ready, setReady] = useState(false);
@@ -21,6 +37,36 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     setReady(true);
   }, []);
 
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const logout = useCallback(() => {
+    // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
+    // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
+    // で Cognito 側 cookie が残り silent re-login していた)。
+    setTokensState(null);
+    void beginLogout(config);
+  }, [config]);
+
+  useEffect(() => {
+    if (!tokens) return;
+    const resetTimer = (): void => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        logout();
+      }, IDLE_TIMEOUT_MS);
+    };
+    resetTimer();
+    for (const evt of IDLE_EVENTS) {
+      window.addEventListener(evt, resetTimer, { passive: true });
+    }
+    return () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      for (const evt of IDLE_EVENTS) {
+        window.removeEventListener(evt, resetTimer);
+      }
+    };
+  }, [tokens, logout]);
+
   const value = useMemo<AuthState>(
     () => ({
       tokens,
@@ -28,16 +74,10 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
       login: () => {
         void beginLogin(config);
       },
-      logout: () => {
-        // Issue #833: Cognito Hosted UI cookie + refresh token を server-side revoke
-        // してから /logout に redirect する (= 旧コードは local sessionStorage のみ clear
-        // で Cognito 側 cookie が残り silent re-login していた)。
-        setTokensState(null);
-        void beginLogout(config);
-      },
+      logout,
       setTokens: (t) => setTokensState(t),
     }),
-    [tokens, ready, config],
+    [tokens, ready, config, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -1,8 +1,29 @@
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { getPortalMe, PortalAuthError } from "../api/portal-client";
 import type { AppConfig } from "../config";
 import { toAsciiSlug } from "../lib/slug";
 import { clearSession, loadSession, type ParticipantSession, saveSession } from "./storage";
+
+/**
+ * Issue #859: participant portal の idle session 自動ログアウト。
+ *
+ * **6 hours** で auto logout する。 admin console の 15 min より長い理由:
+ *   - 競技中 (= 90 min ~ 4 h) は participant が席を離れる時間も含めて session 維持が必要
+ *   - admin operator は監視業務で 15 min 周期で操作するが、 participant は問題に集中する
+ *     ため操作頻度が低い (= 解析 / 思考時間で 30 min 以上 idle になる)
+ *   - 競技時間上限 (= TenkaCloud Battle 仕様で最大 6 h 想定) 後に自動 logout で安全弁
+ */
+const PARTICIPANT_IDLE_TIMEOUT_MS = 6 * 60 * 60 * 1000;
+const IDLE_EVENTS = ["mousedown", "keydown", "touchstart", "focus", "scroll"] as const;
 
 const DEFAULT_DEV_TTL_MS = 4 * 60 * 60 * 1000;
 // Phase 1 以前 (jobId-based) の deployment は eventId / teamId を持たない。
@@ -82,6 +103,7 @@ const AuthContext = createContext<AuthState | null>(null);
 
 export function AuthProvider({ config, children }: { config: AppConfig; children: ReactNode }) {
   const [session, setSession] = useState<ParticipantSession | null>(() => loadSession());
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const login = useCallback(
     async (teamLoginKey: string) => {
@@ -96,6 +118,27 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     clearSession();
     setSession(null);
   }, []);
+
+  // Issue #859: session 存在中のみ 6 時間 idle timer を回す。 user 操作で reset。
+  useEffect(() => {
+    if (!session) return;
+    const resetTimer = (): void => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        logout();
+      }, PARTICIPANT_IDLE_TIMEOUT_MS);
+    };
+    resetTimer();
+    for (const evt of IDLE_EVENTS) {
+      window.addEventListener(evt, resetTimer, { passive: true });
+    }
+    return () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      for (const evt of IDLE_EVENTS) {
+        window.removeEventListener(evt, resetTimer);
+      }
+    };
+  }, [session, logout]);
 
   const updateSession = useCallback<AuthState["updateSession"]>((patch) => {
     setSession((prev) => {

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -131,4 +131,79 @@ describe("AuthProvider", () => {
   it("Provider 外で useAuth() を呼んだら error を throw するべき", () => {
     expect(() => renderHook(() => useAuth())).toThrow(/AuthProvider/);
   });
+
+  describe("Issue #859: idle timeout (6 hours)", () => {
+    it("5h 59min 経過しても logout しないべき (= 競技中の長時間 idle を許容)", async () => {
+      vi.useFakeTimers();
+      try {
+        const { result } = renderAuth(devConfig);
+        await act(async () => {
+          await result.current.login("abc-123-team");
+        });
+        expect(result.current.session).not.toBeNull();
+
+        await act(async () => {
+          vi.advanceTimersByTime(5 * 60 * 60 * 1000 + 59 * 60 * 1000);
+          await Promise.resolve();
+        });
+        // 6h 未満ではまだ session 維持
+        expect(result.current.session).not.toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("6h 無操作で auto-logout するべき (= 競技後の安全弁)", async () => {
+      vi.useFakeTimers();
+      try {
+        const { result } = renderAuth(devConfig);
+        await act(async () => {
+          await result.current.login("abc-123-team");
+        });
+        expect(result.current.session).not.toBeNull();
+
+        await act(async () => {
+          vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1000);
+          await Promise.resolve();
+        });
+        expect(result.current.session).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("user 操作で 6h timer は reset されるべき", async () => {
+      vi.useFakeTimers();
+      try {
+        const { result } = renderAuth(devConfig);
+        await act(async () => {
+          await result.current.login("abc-123-team");
+        });
+
+        // 5h 経過 → keydown で reset → 5h 59min 経過 (合計 10h 59min) でも logout しない
+        await act(async () => {
+          vi.advanceTimersByTime(5 * 60 * 60 * 1000);
+          await Promise.resolve();
+        });
+        await act(async () => {
+          window.dispatchEvent(new KeyboardEvent("keydown"));
+          await Promise.resolve();
+        });
+        await act(async () => {
+          vi.advanceTimersByTime(5 * 60 * 60 * 1000 + 59 * 60 * 1000);
+          await Promise.resolve();
+        });
+        expect(result.current.session).not.toBeNull();
+
+        // 残り 1 min 進めて (= reset 後 6h 経過) logout 発火
+        await act(async () => {
+          vi.advanceTimersByTime(2 * 60 * 1000);
+          await Promise.resolve();
+        });
+        expect(result.current.session).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Issue #859: stolen JWT / teamLoginKey の利用窓を縮小するため、 3 SPA に
idle session 自動ログアウトを追加。

- **admin-console + application-admin-console** の \`AuthProvider\`:
  - **15 分** 間 \`mousedown\` / \`keydown\` / \`touchstart\` / \`focus\` / \`scroll\` 操作が無ければ
    \`logout()\` を呼ぶ → Cognito \`/oauth2/revoke\` (#833 で wired) で refresh token を
    server-side revoke し、 \`/oauth2/logout\` に redirect
- **participant-portal** の \`AuthProvider\`:
  - **6 時間** で auto logout。 admin の 15 min より長い理由:
    - 競技中 (= 90 min ~ 4 h) は participant が席を離れる時間も含めて session 維持が必要
    - admin operator は監視業務で 15 min 周期で操作するが、 participant は問題に集中する
      ため操作頻度が低い (= 解析 / 思考時間で 30 min 以上 idle になる)
    - 競技時間上限 (= TenkaCloud Battle 仕様で最大 6 h 想定) 後に自動 logout で安全弁
- すべての SPA で timer は tokens / session 確定後にのみ起動 (= 未ログイン状態では無効)
- user 操作毎に timer を reset

これにより stolen credentials の利用窓は:
- admin console: Cognito idToken 寿命 (= 1h) → **15 min + 当該 idToken 残寿命**
- participant portal: teamLoginKey TTL (= deployment 寿命) → **6 hours**
に縮小する。

Closes #859

## Out of scope (= 別 ADR / Phase 2)

- **HttpOnly Secure SameSite=Strict cookie 経由への migrate**: OAuth code flow を
  Lambda@Edge or CloudFront Function で受けて cookie set する設計変更が必要で、
  別 ADR で起こす。 本 PR は sessionStorage / localStorage 維持の Phase 1。
- **participant-portal の localStorage → sessionStorage 移行**: Issue #495 で UX 問題
  (= tab close で消える) が報告済。 idle timeout で代替してこの PR では touch しない。
- **warning modal at 10 min / 5h 45min**: UX デザインが要件依存で別 PR で対応。

## Regression 分析

- 既存 123 + 233 + 146 tests (admin / app-admin / participant) すべて pass
- 新規 6 tests (各 SPA で idle timeout / no-token guard / activity reset)
- 既存 logout / login / setTokens API は無変更
- non-token 状態では timer 起動しないので CPU 影響なし
- token 状態でも passive event listener なので scroll 性能影響 minimal

## 物理影響

- **UPDATE**: 3 SPA dist bundle (= AuthProvider のみ変更)
- **NO-OP**: Cognito UserPool / Lambda / IAM / API Gateway は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 全 test pass
- [x] 新規 6 test (admin 3: 15-min logout / no tokens / reset、 portal 3: 5h59min keep / 6h logout / reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)