### PR TITLE
fix(security): unwrap IPv6-mapped IPv4 + IMDS expanded form in SSRF blocklist (#863)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
+++ b/infrastructure/lib/problem-deploy/handlers/problem-endpoints-handler/endpoints.ts
@@ -92,15 +92,51 @@ export type PutOverrideOutcome =
 // SSRF defense-in-depth blocklist (Phase 3.B fetcher で DNS-rebinding-safe な
 // resolve-then-connect を実装するまでの暫定)。 host は IPv6 bracket を剥がし lowercase
 // 化した bare form に正規化してから lookup する。
+//
+// Issue #863: IPv6-mapped IPv4 (`::ffff:169.254.169.254`) や IPv4 short form
+// (`0xa9.0xfe.0xa9.0xfe`) で blocklist を bypass される攻撃を防ぐため、 host を
+// normalize してから check。 私設 IP (RFC 1918 等) は Battle 参加者の AWS endpoint 登録で
+// 必要なため intentional に許容する (= issue 内 design 判断)。
 const SSRF_BLOCKED_HOSTS = new Set([
   "169.254.169.254", // AWS / Azure IMDS v4
-  "fd00:ec2::254", // AWS IMDS v6
+  "fd00:ec2::254", // AWS IMDS v6 (canonical)
+  "fd00:ec2:0:0:0:0:0:254", // AWS IMDS v6 (expanded)
   "metadata.google.internal", // GCE metadata
   "metadata",
   "127.0.0.1",
+  "0.0.0.0",
   "::1",
+  "0:0:0:0:0:0:0:1", // ::1 expanded
   "localhost",
 ]);
+
+/**
+ * Issue #863: IPv6-mapped IPv4 (`::ffff:a.b.c.d` / `::ffff:AABB:CCDD`) を unwrap して
+ * IPv4 dotted string を返す。 IPv4 native や IPv6 non-mapped はそのまま返す。
+ *
+ * 例:
+ *   `::ffff:169.254.169.254` → `169.254.169.254`
+ *   `::ffff:a9fe:a9fe`        → `169.254.169.254`
+ *   `127.0.0.1`               → `127.0.0.1`
+ */
+function unwrapIPv6MappedIPv4(host: string): string {
+  const lower = host.toLowerCase();
+  // dotted form: ::ffff:X.X.X.X
+  const dotted = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return dotted[1];
+  // hex form: ::ffff:AABB:CCDD → IPv4
+  const hex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hex) {
+    const high = parseInt(hex[1], 16);
+    const low = parseInt(hex[2], 16);
+    if (high <= 0xffff && low <= 0xffff) {
+      return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(".");
+    }
+  }
+  return host;
+}
+
+export const __testing_unwrapIPv6MappedIPv4 = unwrapIPv6MappedIPv4;
 
 /**
  * 競技者向け URL validation。`https?://...` のみ許容、 private IP / VPC 内 endpoint は許容
@@ -115,7 +151,9 @@ function isValidOverrideUrl(value: unknown): value is string {
     const u = new URL(trimmed);
     if (u.protocol !== "http:" && u.protocol !== "https:") return false;
     // Node の `URL.hostname` は IPv6 で `[::1]` のように bracket を含む。 lookup 前に strip。
-    const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    const rawHost = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    // Issue #863: IPv6-mapped IPv4 で blocklist を bypass されないよう unwrap してから check。
+    const host = unwrapIPv6MappedIPv4(rawHost);
     return !SSRF_BLOCKED_HOSTS.has(host);
   } catch {
     return false;

--- a/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
@@ -224,13 +224,20 @@ describe("upsertProblemEndpointOverride", () => {
 
   // SSRF defense-in-depth: metadata service / loopback literal を write 時に拒否する。
   // Phase 3.B fetcher で DNS-rebinding-safe resolve-then-connect を行うまでの blocklist。
+  // Issue #863: IPv6-mapped IPv4 / IMDS v6 expanded form bypass を追加検証。
   it.each([
     ["AWS IMDS v4", "http://169.254.169.254/latest/meta-data/iam/security-credentials/"],
     ["AWS IMDS v6", "http://[fd00:ec2::254]/latest/meta-data/"],
+    ["AWS IMDS v6 expanded", "http://[fd00:ec2:0:0:0:0:0:254]/latest/meta-data/"],
     ["GCE metadata", "http://metadata.google.internal/computeMetadata/v1/"],
     ["loopback IPv4", "http://127.0.0.1:9001/admin"],
+    ["loopback all-zero IPv4", "http://0.0.0.0:9001/admin"],
     ["loopback IPv6", "http://[::1]/"],
+    ["loopback IPv6 expanded", "http://[0:0:0:0:0:0:0:1]/"],
     ["localhost literal", "http://localhost/"],
+    ["IPv6-mapped IMDS (dotted)", "http://[::ffff:169.254.169.254]/latest/meta-data/"],
+    ["IPv6-mapped IMDS (hex)", "http://[::ffff:a9fe:a9fe]/latest/meta-data/"],
+    ["IPv6-mapped loopback", "http://[::ffff:127.0.0.1]/admin"],
   ])("SSRF blocklist: %s host は invalid_url を返すべき", async (_, url) => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn();


### PR DESCRIPTION
## Summary

Issue #863 の 4 symptom のうち、 blocklist bypass の入口を 2 件 fix:

- **Symptom 2 — IPv6-mapped IPv4 bypass**: \`::ffff:169.254.169.254\` / \`::ffff:a9fe:a9fe\`
  などで attacker が IPv6 representation 経由で IMDS / loopback に到達できる経路を塞ぐ。
  hostname を \`unwrapIPv6MappedIPv4\` で IPv4 dotted form に正規化してから blocklist check。
- **IMDS v6 expanded form** (\`fd00:ec2:0:0:0:0:0:254\`) も blocklist 追加。 IPv6 spec で
  cannonical の \`fd00:ec2::254\` と semantically 同じだが、 string compare では別物として
  bypass される。
- **all-zero IPv4** (\`0.0.0.0\`) も blocklist 追加 (= 一部 OS で loopback として接続される)。

Closes #863

## Out of scope (= Phase 2 / Phase 3)

- **Symptom 1 — DNS rebinding**: TTL=0 で 1st query (= validation 用) と 2nd query (= Lambda
  fetch) で別 IP を返す攻撃。 resolve-then-connect pattern (= Node.js \`dns.lookup\` +
  http custom agent) で実装する必要があり、 大きな構造変更で別 PR で扱う。
- **Symptom 3 — Private IP ranges (RFC 1918)**: Battle 参加者が自分の AWS VPC 内 endpoint を
  登録するため intentional に許容している (= issue 内の design 判断と整合)。
- **Symptom 4 — VPC isolation**: Lambda を private subnet + NAT Gateway 配置にする infra
  構造変更で、 user 担当の CDK 変更。

## Regression 分析

- 既存 6 SSRF blocklist test すべて pass + 新規 5 test (IPv6-mapped / expanded form variants)
- 公開 endpoint (= public IP / private VPC) は従来通り通過
- IPv6-mapped IPv4 の正常 use case (= \`::ffff:8.8.8.8\` で外部に出る) は dotted form に
  unwrap された結果 \`8.8.8.8\` (= public) で通過する

## 物理影響

- **UPDATE**: deploy-api Lambda bundle (= 1 helper func 追加 + blocklist 追加 entries)
- **NO-OP**: DDB / IAM / API Gateway / Lambda runtime は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1022 test pass
- [x] 新規 5 test (IPv6-mapped IMDS / loopback / expanded form / all-zero IPv4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)