### PR TITLE
feat(operator): Red Team Disruption Injection Phase A — backend API + audit DDB

### DIFF
--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -44,6 +44,8 @@ const problemDeployBackend = new ProblemDeployBackendStack(app, "tenkacloud-lite
   problemsEndpoints: config.problems.endpoints as Readonly<Record<string, unknown>>,
   problemsPhases: (config.problems.phases ?? {}) as Readonly<Record<string, unknown>>,
   problemsVisibility: (config.problems.visibility ?? {}) as Readonly<Record<string, "private">>,
+  // Issue #888: Lite mode でも problemsDisruptions を Lambda env に渡す。
+  problemsDisruptions: (config.problems.disruptions ?? {}) as Readonly<Record<string, unknown>>,
   // Lite では participant portal を runtime-config "default-dev-mock" で立てる
   // (= portal Lambda + S3+CloudFront を持ち込む)。 frontend は backend mode で動く。
   participantPortal: { runtimeConfig: "default-dev-mock" },

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -7,6 +7,7 @@ import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participa
 import { loadConfig } from "../utils/config-loader";
 import {
   discoverProblemsCatalog,
+  discoverProblemsDisruptions,
   discoverProblemsEndpoints,
   discoverProblemsPhases,
   discoverProblemsScoring,
@@ -170,6 +171,7 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
           endpoints: discoverProblemsEndpoints(problemsRoot),
           phases: discoverProblemsPhases(problemsRoot),
           visibility: discoverProblemsVisibility(problemsRoot),
+          disruptions: discoverProblemsDisruptions(problemsRoot),
         } satisfies ProblemsCatalogBundle);
 
   const challengePayloadBucketName = env.CDK_PARAM_CHALLENGE_PAYLOAD_BUCKET || undefined;

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -107,6 +107,8 @@ export interface ProblemsCatalogBundle {
   readonly endpoints: unknown;
   readonly phases: unknown;
   readonly visibility: unknown;
+  /** Issue #888: per-problem `disruptions[]` 宣言。 未宣言の問題はキー無し。 */
+  readonly disruptions: unknown;
 }
 
 export interface AdminConsoleHostingInputs {

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -59,6 +59,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       problemsEndpoints: config.problems.endpoints as ProblemDeployBackendEndpoints,
       problemsPhases: config.problems.phases as ProblemDeployBackendPhases,
       problemsVisibility: config.problems.visibility as ProblemDeployBackendVisibility,
+      // Issue #888: per-problem `disruptions[]` を Lambda env に injection
+      problemsDisruptions: config.problems.disruptions as Readonly<Record<string, unknown>>,
       ...(config.challengePayloadBucketName
         ? { challengePayloadBucketName: config.challengePayloadBucketName }
         : {}),

--- a/infrastructure/lib/problem-deploy/disruptions-table.ts
+++ b/infrastructure/lib/problem-deploy/disruptions-table.ts
@@ -1,0 +1,49 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * Issue #888: Red Team Disruption Injection の audit log を保存する DynamoDB テーブル。
+ *
+ * Schema:
+ *   PK: EVENT#<eventId>            tenantId / eventId は GSI1PK で参照する
+ *   SK: AUDIT#<firedAt>#<auditId>  ULID で append-only
+ *
+ * 主な属性:
+ *   auditId / tenantId / eventId / problemId / disruptionId / firedBy (= Cognito sub)
+ *   / firedAt (ISO8601) / scope / targetTeamIds[] / parameters / requestId / expiresAt
+ *
+ * GSI1 (= requestId Idempotency lookup):
+ *   PK: REQUEST#<requestId>
+ *   SK: METADATA  (1 requestId につき 1 row)
+ *
+ * Capacity / lifecycle:
+ *   provisioned 1/1 (DynamoDbLowCapacity Aspect が均す)。 audit 用途で QPS 極小、
+ *   Free Tier 内に収める。 削除方針: RETAIN (= stack 削除で history を失わない)。
+ *   TTL は expiresAt 属性で 7 日 (operator が長期保管したい場合は exporter で別 sink へ)。
+ */
+export class DisruptionsTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+      timeToLiveAttribute: "expiresAt",
+    });
+
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI1",
+      partitionKey: { name: "GSI1PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -35,6 +35,15 @@ export interface EventApiLambdaProps {
    */
   readonly problemsCatalog: Readonly<Record<string, string>>;
   /**
+   * Issue #888: Red Team Disruption Injection の audit + idempotency 用 DDB table。
+   */
+  readonly disruptionsTable: Table;
+  /**
+   * Issue #888: problem metadata.json の `disruptions[]` 宣言。 Lambda runtime で
+   * `(problemId, disruptionId)` lookup に使う。
+   */
+  readonly problemsDisruptions: Readonly<Record<string, readonly unknown[]>>;
+  /**
    * tenantId として handler に渡す `DEFAULT_TENANT_ID` env (DeployApi と同じ fallback)。
    * Cognito JWT 結線後は JWT claim から取る。
    */
@@ -85,6 +94,9 @@ export class EventApiLambda extends Construct {
         // #686: legacy "unknown-tenant" fallback は削除 (= JWT claim 欠落時は handler が 401)
         ...(props.defaultTenantId ? { DEFAULT_TENANT_ID: props.defaultTenantId } : {}),
         BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
+        // Issue #888: disruption fire / catalog / audit Lambda 経路で参照
+        DISRUPTIONS_TABLE_NAME: props.disruptionsTable.tableName,
+        BATTLE_PROBLEMS_DISRUPTIONS: JSON.stringify(props.problemsDisruptions),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -105,5 +117,8 @@ export class EventApiLambda extends Construct {
     // RW を付与しない (= 最小権限)。
     props.competitorAccountsTable.grantReadData(this.fn);
     props.eventBus.grantPutEventsTo(this.fn);
+    // Issue #888: disruption audit + idempotency 用に RW、 EventBus PutEvents は既存付与で十分
+    // (= disruption fire でも同 bus に publish するため)。
+    props.disruptionsTable.grantReadWriteData(this.fn);
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
@@ -1,0 +1,350 @@
+/**
+ * Issue #888 Phase A: Red Team Disruption Fire の business logic。
+ *
+ * 流れ:
+ *   1. problemId / disruptionId を problemsDisruptions catalog で解決
+ *   2. parameters を operatorEditable allow-list で fold (= 不正 key を reject)
+ *   3. scope に応じて targetTeamIds を解決 (= all / team / random-n)
+ *   4. requestId Idempotency lookup (= GSI1 で `REQUEST#<id>` を引く)
+ *   5. EventBridge に detail-type=<disruption.eventDetailType> で N team 分 publish
+ *   6. DDB に 1 audit row + 1 idempotency row を書く
+ *
+ * cross-account publish (= 競技者アカウントへの forward) は Phase B で追加する。
+ * 本 Phase A では同 account の event bus に publish するに留め、 audit + Logs Insights で
+ * 観察可能にする。
+ */
+
+import { randomInt } from "node:crypto";
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
+import { GetCommand, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+import { logDeployTrace } from "../shared/trace-log.js";
+import type {
+  DisruptionAuditRow,
+  DisruptionFireInput,
+  DisruptionFireOutcome,
+  DisruptionFireResult,
+} from "./disruption-types.js";
+import type { EventSharedResources } from "./shared.js";
+import type { TeamItem } from "./types.js";
+
+const EVENT_SOURCE = "tenkacloud.disruptions";
+const AUDIT_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MAX_AFFECTED_TEAMS = 200;
+
+/**
+ * `targetTeamIds` の subset selection。 scope=all なら全件、 scope=team は input そのまま、
+ * scope=random-n は crypto-grade Fisher-Yates で randomCount 件抽選。
+ */
+function resolveTargetTeams(
+  scope: DisruptionFireInput["scope"],
+  allTeams: readonly TeamItem[],
+  input: DisruptionFireInput,
+): readonly string[] {
+  if (scope === "all") {
+    return allTeams.map((t) => t.teamId);
+  }
+  if (scope === "team") {
+    const ids = new Set(allTeams.map((t) => t.teamId));
+    return input.targetTeamIds.filter((id) => ids.has(id));
+  }
+  // scope === "random-n"
+  const n = Math.min(Math.max(input.randomCount ?? 1, 1), allTeams.length);
+  const pool = allTeams.map((t) => t.teamId);
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = randomInt(0, i + 1);
+    const tmp = pool[i] as string;
+    pool[i] = pool[j] as string;
+    pool[j] = tmp;
+  }
+  return pool.slice(0, n);
+}
+
+/**
+ * Phase A の fire 実装。 caller (handler/index.ts) が JWT 認可 + tenantId scoping を済ませた
+ * 前提で呼ぶ。 cross-tenant fire 防止は handler 側で `event.tenantId === ctx.tenantId` を
+ * assert する責務。
+ */
+export async function fireDisruption(
+  shared: EventSharedResources,
+  input: DisruptionFireInput,
+): Promise<DisruptionFireOutcome> {
+  // 1. catalog lookup
+  const catalog = shared.problemsDisruptions[input.problemId];
+  if (!catalog) return { kind: "unknown_problem" };
+  const declaration = catalog.find((d) => d.id === input.disruptionId);
+  if (!declaration) return { kind: "unknown_disruption" };
+
+  // 2. parameters allow-list 検証 (= operatorEditable に無い key を reject)
+  const allow = new Set(declaration.operatorEditable ?? []);
+  for (const key of Object.keys(input.parameters)) {
+    if (!allow.has(key)) {
+      return {
+        kind: "invalid_parameters",
+        reason: `parameter '${key}' is not in operatorEditable allow-list`,
+      };
+    }
+  }
+  const mergedParameters: Record<string, unknown> = {
+    ...(declaration.parameters ?? {}),
+    ...input.parameters,
+  };
+
+  // 3. Idempotency: requestId 既存 → 前回結果を返す
+  const idempotencyKey = `REQUEST#${input.tenantId}#${input.requestId}`;
+  const prior = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.disruptionsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      ExpressionAttributeValues: { ":pk": idempotencyKey },
+      Limit: 1,
+    }),
+  );
+  const priorItem = prior.Items?.[0] as Partial<DisruptionAuditRow> | undefined;
+  if (priorItem?.auditId) {
+    return {
+      kind: "duplicate",
+      result: {
+        auditId: priorItem.auditId,
+        firedAt: priorItem.firedAt ?? new Date(input.nowMs).toISOString(),
+        affectedTeamIds: priorItem.targetTeamIds ?? [],
+      },
+    };
+  }
+
+  // 4. event 配下 team 一覧を取得 (= scope 解決の母集団)
+  const allTeams = await listTeamsByEvent(shared, input.eventId);
+  if (allTeams.length === 0) return { kind: "no_targets" };
+
+  const affected = resolveTargetTeams(input.scope, allTeams, input);
+  if (affected.length === 0) return { kind: "no_targets" };
+  if (affected.length > MAX_AFFECTED_TEAMS) {
+    return { kind: "invalid_scope", reason: `too many target teams: ${affected.length}` };
+  }
+
+  const auditId = ulid();
+  const firedAt = new Date(input.nowMs).toISOString();
+  const result: DisruptionFireResult = { auditId, firedAt, affectedTeamIds: affected };
+
+  // 5. EventBridge publish: 1 PutEvents = 10 entries 上限。 chunk 分割で全 affected を流す。
+  await publishEntries(shared, input, declaration.eventDetailType, affected, firedAt);
+
+  // 6. DDB audit + idempotency row を 2 PutItem で書く (= TransactWrite だと 25 row 制限が
+  //    別 audit 経路と相互作用するため Phase A では 2 separate PutItem)。
+  const expiresAt = Math.floor(input.nowMs / 1000) + AUDIT_TTL_SECONDS;
+  const auditRow: DisruptionAuditRow = {
+    auditId,
+    tenantId: input.tenantId,
+    eventId: input.eventId,
+    problemId: input.problemId,
+    disruptionId: input.disruptionId,
+    firedBy: input.firedBy,
+    firedAt,
+    scope: input.scope,
+    targetTeamIds: affected,
+    parameters: mergedParameters,
+    requestId: input.requestId,
+    expiresAt,
+  };
+  try {
+    await shared.ddb.send(
+      new PutCommand({
+        TableName: shared.disruptionsTableName,
+        Item: {
+          PK: `EVENT#${input.eventId}`,
+          SK: `AUDIT#${firedAt}#${auditId}`,
+          GSI1PK: `TENANT#${input.tenantId}`,
+          GSI1SK: `AUDIT#${firedAt}#${auditId}`,
+          ...auditRow,
+        },
+        // append-only: 同 SK の上書きを防ぐ (= 万一 ULID collision でも reject)
+        ConditionExpression: "attribute_not_exists(SK)",
+      }),
+    );
+    await shared.ddb.send(
+      new PutCommand({
+        TableName: shared.disruptionsTableName,
+        Item: {
+          PK: idempotencyKey,
+          SK: "METADATA",
+          GSI1PK: idempotencyKey,
+          GSI1SK: "METADATA",
+          ...auditRow,
+        },
+        // requestId 重複は手前の Query 段で吸収するが、 並列 fire の race を condition で守る
+        ConditionExpression: "attribute_not_exists(PK)",
+      }),
+    );
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      // race で先勝されたらこちらは duplicate 扱いに倒す (= idempotent return)。
+      return { kind: "duplicate", result };
+    }
+    throw err;
+  }
+
+  logDeployTrace("disruption.fire", {
+    auditId,
+    eventId: input.eventId,
+    problemId: input.problemId,
+    disruptionId: input.disruptionId,
+    scope: input.scope,
+    affectedCount: affected.length,
+  });
+
+  return { kind: "ok", result };
+}
+
+async function listTeamsByEvent(
+  shared: EventSharedResources,
+  eventId: string,
+): Promise<readonly TeamItem[]> {
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.teamsTableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :tprefix)",
+      ExpressionAttributeValues: { ":pk": `EVENT#${eventId}`, ":tprefix": "TEAM#" },
+    }),
+  );
+  return (out.Items ?? []) as TeamItem[];
+}
+
+async function publishEntries(
+  shared: EventSharedResources,
+  input: DisruptionFireInput,
+  detailType: string,
+  affectedTeamIds: readonly string[],
+  firedAt: string,
+): Promise<void> {
+  const entries: PutEventsRequestEntry[] = affectedTeamIds.map((teamId) => ({
+    Source: EVENT_SOURCE,
+    DetailType: detailType,
+    EventBusName: shared.eventBusName,
+    Detail: JSON.stringify({
+      disruptionId: input.disruptionId,
+      eventId: input.eventId,
+      problemId: input.problemId,
+      tenantId: input.tenantId,
+      teamId,
+      parameters: input.parameters,
+      requestId: input.requestId,
+      firedAt,
+    }),
+  }));
+  const BATCH = 10;
+  for (let i = 0; i < entries.length; i += BATCH) {
+    const chunk = entries.slice(i, i + BATCH);
+    await shared.events.send(new PutEventsCommand({ Entries: chunk }));
+  }
+}
+
+/**
+ * Issue #888 FR-4: audit log の page query。 cursor-based pagination。
+ */
+export async function listDisruptionAudit(
+  shared: EventSharedResources,
+  eventId: string,
+  options: { limit?: number; cursor?: string } = {},
+): Promise<{ items: DisruptionAuditRow[]; nextCursor?: string }> {
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+  const exclusiveStartKey = options.cursor ? decodeCursor(options.cursor) : undefined;
+  const out = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.disruptionsTableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :ap)",
+      ExpressionAttributeValues: { ":pk": `EVENT#${eventId}`, ":ap": "AUDIT#" },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+  const items: DisruptionAuditRow[] = (out.Items ?? []).map((raw) => {
+    const r = raw as Partial<DisruptionAuditRow> & Record<string, unknown>;
+    return {
+      auditId: String(r.auditId ?? ""),
+      tenantId: String(r.tenantId ?? ""),
+      eventId: String(r.eventId ?? ""),
+      problemId: String(r.problemId ?? ""),
+      disruptionId: String(r.disruptionId ?? ""),
+      firedBy: String(r.firedBy ?? ""),
+      firedAt: String(r.firedAt ?? ""),
+      scope: (r.scope ?? "team") as DisruptionAuditRow["scope"],
+      targetTeamIds: Array.isArray(r.targetTeamIds)
+        ? (r.targetTeamIds as string[])
+        : ([] as readonly string[]),
+      parameters: (r.parameters && typeof r.parameters === "object"
+        ? r.parameters
+        : {}) as Readonly<Record<string, unknown>>,
+      requestId: String(r.requestId ?? ""),
+      expiresAt: Number(r.expiresAt ?? 0),
+    };
+  });
+  return {
+    items,
+    ...(out.LastEvaluatedKey
+      ? { nextCursor: encodeCursor(out.LastEvaluatedKey as Record<string, unknown>) }
+      : {}),
+  };
+}
+
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), "utf8").toString("base64url");
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> | undefined {
+  if (cursor.length > 512) return undefined;
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const allow = new Set(["PK", "SK", "GSI1PK", "GSI1SK"]);
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!allow.has(k)) return undefined;
+      if (typeof v !== "string" || v.length === 0 || v.length > 256) return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Issue #888 FR-2: 該当 event に deploy された problem の disruption catalog を返す。
+ *
+ * event item から problems[] を引き、 problemId 毎に problemsDisruptions catalog を merge。
+ * publicHint=false の disruption も TenantAdmin 向けには返す (= operator view が前提)。
+ */
+export async function listDisruptionCatalog(
+  shared: EventSharedResources,
+  eventId: string,
+): Promise<{
+  entries: Array<{
+    problemId: string;
+    disruption: (typeof shared.problemsDisruptions)[string][number];
+  }>;
+}> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+    }),
+  );
+  const event = out.Item as { problems?: Array<{ problemId: string }> } | undefined;
+  const problemIds = Array.isArray(event?.problems)
+    ? event.problems.map((p) => p.problemId).filter((p): p is string => typeof p === "string")
+    : [];
+  const entries: Array<{
+    problemId: string;
+    disruption: (typeof shared.problemsDisruptions)[string][number];
+  }> = [];
+  for (const problemId of problemIds) {
+    const cat = shared.problemsDisruptions[problemId];
+    if (!cat) continue;
+    for (const d of cat) {
+      entries.push({ problemId, disruption: d });
+    }
+  }
+  return { entries };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
@@ -1,13 +1,20 @@
 /**
  * Issue #888 Phase A: Red Team Disruption Fire の business logic。
  *
- * 流れ:
+ * 流れ (= race-safe ordering、 PR #889 review fix 後):
  *   1. problemId / disruptionId を problemsDisruptions catalog で解決
  *   2. parameters を operatorEditable allow-list で fold (= 不正 key を reject)
- *   3. scope に応じて targetTeamIds を解決 (= all / team / random-n)
- *   4. requestId Idempotency lookup (= GSI1 で `REQUEST#<id>` を引く)
- *   5. EventBridge に detail-type=<disruption.eventDetailType> で N team 分 publish
- *   6. DDB に 1 audit row + 1 idempotency row を書く
+ *   3. event 配下 team 一覧を取得し scope=all/team/random-n を解決 (= 母集団)
+ *   4. **Idempotency claim (= REQUEST# row を conditional Put で奪取)**:
+ *      - 成功 → こちらが winner、 publish + audit に進む
+ *      - CCF + 既存 row 有 → duplicate、 前回 result を返す
+ *      - CCF + race winner の row 未到達 → 短時間 sleep + 再 Get
+ *   5. EventBridge publish (= FailedEntryCount > 0 で throw)
+ *   6. AUDIT# row を Put
+ *
+ * 旧設計 (= 先 Query → publish → 後 Put) には race 窓があり、 同 requestId の 2 件が
+ * 両方 publish に進めてしまう問題があったため、 publish の **前** に conditional Put で
+ * 排他を取る形に書き換えた (PR #889 critical review)。
  *
  * cross-account publish (= 競技者アカウントへの forward) は Phase B で追加する。
  * 本 Phase A では同 account の event bus に publish するに留め、 audit + Logs Insights で
@@ -15,6 +22,7 @@
  */
 
 import { randomInt } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
 import { GetCommand, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
@@ -32,10 +40,12 @@ import type { TeamItem } from "./types.js";
 const EVENT_SOURCE = "tenkacloud.disruptions";
 const AUDIT_TTL_SECONDS = 7 * 24 * 60 * 60;
 const MAX_AFFECTED_TEAMS = 200;
+const DUPLICATE_RESOLVE_RETRY_MS = 200;
+const DUPLICATE_RESOLVE_RETRIES = 3;
 
 /**
- * `targetTeamIds` の subset selection。 scope=all なら全件、 scope=team は input そのまま、
- * scope=random-n は crypto-grade Fisher-Yates で randomCount 件抽選。
+ * `targetTeamIds` の subset selection。 scope=all なら全件、 scope=team は dedupe して
+ * 既存 team との intersection、 scope=random-n は crypto-grade Fisher-Yates で抽選。
  */
 function resolveTargetTeams(
   scope: DisruptionFireInput["scope"],
@@ -46,8 +56,16 @@ function resolveTargetTeams(
     return allTeams.map((t) => t.teamId);
   }
   if (scope === "team") {
-    const ids = new Set(allTeams.map((t) => t.teamId));
-    return input.targetTeamIds.filter((id) => ids.has(id));
+    // PR #889 review: input.targetTeamIds が同 id 重複を含む可能性があるため Set で dedupe。
+    const validIds = new Set(allTeams.map((t) => t.teamId));
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const id of input.targetTeamIds) {
+      if (!validIds.has(id) || seen.has(id)) continue;
+      seen.add(id);
+      result.push(id);
+    }
+    return result;
   }
   // scope === "random-n"
   const n = Math.min(Math.max(input.randomCount ?? 1, 1), allTeams.length);
@@ -59,6 +77,77 @@ function resolveTargetTeams(
     pool[j] = tmp;
   }
   return pool.slice(0, n);
+}
+
+/**
+ * PR #889 review: race-safe idempotency claim。 REQUEST# row を conditional Put で
+ * 奪取し、 失敗時は同 row を Get して duplicate result を返す。
+ *
+ * loser 側で row の DDB 反映 (= 強い整合性ありの Get) を即時参照できる前提だが、 万一
+ * eventual な race で row 未到達のケースに備え、 短時間 sleep + 再 Get で 1 度だけ retry。
+ */
+async function tryClaimIdempotency(
+  shared: EventSharedResources,
+  input: DisruptionFireInput,
+  draft: DisruptionAuditRow,
+): Promise<{ kind: "claimed" } | { kind: "duplicate"; row: DisruptionAuditRow }> {
+  const idempotencyKey = `REQUEST#${input.tenantId}#${input.requestId}`;
+  try {
+    await shared.ddb.send(
+      new PutCommand({
+        TableName: shared.disruptionsTableName,
+        Item: {
+          PK: idempotencyKey,
+          SK: "METADATA",
+          GSI1PK: idempotencyKey,
+          GSI1SK: "METADATA",
+          ...draft,
+        },
+        ConditionExpression: "attribute_not_exists(PK)",
+      }),
+    );
+    return { kind: "claimed" };
+  } catch (err) {
+    if (!(err instanceof ConditionalCheckFailedException)) throw err;
+  }
+  // loser: 既存 row を Get で取り直し、 duplicate を返す
+  for (let attempt = 0; attempt <= DUPLICATE_RESOLVE_RETRIES; attempt++) {
+    const out = await shared.ddb.send(
+      new GetCommand({
+        TableName: shared.disruptionsTableName,
+        Key: { PK: idempotencyKey, SK: "METADATA" },
+        ConsistentRead: true,
+      }),
+    );
+    const item = out.Item as Partial<DisruptionAuditRow> | undefined;
+    if (item?.auditId) {
+      return {
+        kind: "duplicate",
+        row: {
+          auditId: item.auditId,
+          tenantId: String(item.tenantId ?? input.tenantId),
+          eventId: String(item.eventId ?? input.eventId),
+          problemId: String(item.problemId ?? input.problemId),
+          disruptionId: String(item.disruptionId ?? input.disruptionId),
+          firedBy: String(item.firedBy ?? input.firedBy),
+          firedAt: String(item.firedAt ?? new Date(input.nowMs).toISOString()),
+          scope: (item.scope ?? input.scope) as DisruptionFireInput["scope"],
+          targetTeamIds: Array.isArray(item.targetTeamIds) ? (item.targetTeamIds as string[]) : [],
+          parameters: (item.parameters && typeof item.parameters === "object"
+            ? item.parameters
+            : {}) as Readonly<Record<string, unknown>>,
+          requestId: String(item.requestId ?? input.requestId),
+          expiresAt: Number(item.expiresAt ?? 0),
+        },
+      };
+    }
+    if (attempt < DUPLICATE_RESOLVE_RETRIES) await sleep(DUPLICATE_RESOLVE_RETRY_MS);
+  }
+  // race winner が item 書き込み前に死んだ等の極端ケース: 自分が claim を取り直すために throw
+  throw new Error(
+    `disruption fire idempotency claim failed for requestId=${input.requestId}: ` +
+      "conditional check failed but no prior row visible after retries",
+  );
 }
 
 /**
@@ -91,33 +180,9 @@ export async function fireDisruption(
     ...input.parameters,
   };
 
-  // 3. Idempotency: requestId 既存 → 前回結果を返す
-  const idempotencyKey = `REQUEST#${input.tenantId}#${input.requestId}`;
-  const prior = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.disruptionsTableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      ExpressionAttributeValues: { ":pk": idempotencyKey },
-      Limit: 1,
-    }),
-  );
-  const priorItem = prior.Items?.[0] as Partial<DisruptionAuditRow> | undefined;
-  if (priorItem?.auditId) {
-    return {
-      kind: "duplicate",
-      result: {
-        auditId: priorItem.auditId,
-        firedAt: priorItem.firedAt ?? new Date(input.nowMs).toISOString(),
-        affectedTeamIds: priorItem.targetTeamIds ?? [],
-      },
-    };
-  }
-
-  // 4. event 配下 team 一覧を取得 (= scope 解決の母集団)
+  // 3. event 配下 team 一覧 → scope 解決
   const allTeams = await listTeamsByEvent(shared, input.eventId);
   if (allTeams.length === 0) return { kind: "no_targets" };
-
   const affected = resolveTargetTeams(input.scope, allTeams, input);
   if (affected.length === 0) return { kind: "no_targets" };
   if (affected.length > MAX_AFFECTED_TEAMS) {
@@ -126,15 +191,8 @@ export async function fireDisruption(
 
   const auditId = ulid();
   const firedAt = new Date(input.nowMs).toISOString();
-  const result: DisruptionFireResult = { auditId, firedAt, affectedTeamIds: affected };
-
-  // 5. EventBridge publish: 1 PutEvents = 10 entries 上限。 chunk 分割で全 affected を流す。
-  await publishEntries(shared, input, declaration.eventDetailType, affected, firedAt);
-
-  // 6. DDB audit + idempotency row を 2 PutItem で書く (= TransactWrite だと 25 row 制限が
-  //    別 audit 経路と相互作用するため Phase A では 2 separate PutItem)。
   const expiresAt = Math.floor(input.nowMs / 1000) + AUDIT_TTL_SECONDS;
-  const auditRow: DisruptionAuditRow = {
+  const draft: DisruptionAuditRow = {
     auditId,
     tenantId: input.tenantId,
     eventId: input.eventId,
@@ -148,42 +206,45 @@ export async function fireDisruption(
     requestId: input.requestId,
     expiresAt,
   };
-  try {
-    await shared.ddb.send(
-      new PutCommand({
-        TableName: shared.disruptionsTableName,
-        Item: {
-          PK: `EVENT#${input.eventId}`,
-          SK: `AUDIT#${firedAt}#${auditId}`,
-          GSI1PK: `TENANT#${input.tenantId}`,
-          GSI1SK: `AUDIT#${firedAt}#${auditId}`,
-          ...auditRow,
-        },
-        // append-only: 同 SK の上書きを防ぐ (= 万一 ULID collision でも reject)
-        ConditionExpression: "attribute_not_exists(SK)",
-      }),
-    );
-    await shared.ddb.send(
-      new PutCommand({
-        TableName: shared.disruptionsTableName,
-        Item: {
-          PK: idempotencyKey,
-          SK: "METADATA",
-          GSI1PK: idempotencyKey,
-          GSI1SK: "METADATA",
-          ...auditRow,
-        },
-        // requestId 重複は手前の Query 段で吸収するが、 並列 fire の race を condition で守る
-        ConditionExpression: "attribute_not_exists(PK)",
-      }),
-    );
-  } catch (err) {
-    if (err instanceof ConditionalCheckFailedException) {
-      // race で先勝されたらこちらは duplicate 扱いに倒す (= idempotent return)。
-      return { kind: "duplicate", result };
-    }
-    throw err;
+
+  // 4. Idempotency claim (= publish 前に排他を取る、 race-safe な順序)
+  const claim = await tryClaimIdempotency(shared, input, draft);
+  if (claim.kind === "duplicate") {
+    return {
+      kind: "duplicate",
+      result: {
+        auditId: claim.row.auditId,
+        firedAt: claim.row.firedAt,
+        affectedTeamIds: claim.row.targetTeamIds,
+      },
+    };
   }
+
+  // 5. EventBridge publish (= FailedEntryCount > 0 で throw、 audit 整合性確保)
+  await publishEntries(
+    shared,
+    input,
+    declaration.eventDetailType,
+    affected,
+    firedAt,
+    mergedParameters,
+  );
+
+  // 6. AUDIT# row を Put (= append-only audit log)
+  await shared.ddb.send(
+    new PutCommand({
+      TableName: shared.disruptionsTableName,
+      Item: {
+        PK: `EVENT#${input.eventId}`,
+        SK: `AUDIT#${firedAt}#${auditId}`,
+        GSI1PK: `TENANT#${input.tenantId}`,
+        GSI1SK: `AUDIT#${firedAt}#${auditId}`,
+        ...draft,
+      },
+      // 同 SK の上書きを防ぐ (= 万一 ULID collision でも reject)
+      ConditionExpression: "attribute_not_exists(SK)",
+    }),
+  );
 
   logDeployTrace("disruption.fire", {
     auditId,
@@ -194,7 +255,10 @@ export async function fireDisruption(
     affectedCount: affected.length,
   });
 
-  return { kind: "ok", result };
+  return {
+    kind: "ok",
+    result: { auditId, firedAt, affectedTeamIds: affected } satisfies DisruptionFireResult,
+  };
 }
 
 async function listTeamsByEvent(
@@ -217,7 +281,10 @@ async function publishEntries(
   detailType: string,
   affectedTeamIds: readonly string[],
   firedAt: string,
+  mergedParameters: Readonly<Record<string, unknown>>,
 ): Promise<void> {
+  // PR #889 review: publish 内容は audit に書く mergedParameters と一致させる
+  // (= 旧コードは input.parameters のみで base parameters を欠いていた)。
   const entries: PutEventsRequestEntry[] = affectedTeamIds.map((teamId) => ({
     Source: EVENT_SOURCE,
     DetailType: detailType,
@@ -228,16 +295,58 @@ async function publishEntries(
       problemId: input.problemId,
       tenantId: input.tenantId,
       teamId,
-      parameters: input.parameters,
+      parameters: mergedParameters,
       requestId: input.requestId,
       firedAt,
     }),
   }));
   const BATCH = 10;
+  const failureDetails: Array<{ entryIndex: number; errorCode: string; errorMessage: string }> = [];
   for (let i = 0; i < entries.length; i += BATCH) {
     const chunk = entries.slice(i, i + BATCH);
-    await shared.events.send(new PutEventsCommand({ Entries: chunk }));
+    const resp = await shared.events.send(new PutEventsCommand({ Entries: chunk }));
+    // PR #889 review: PutEvents は HTTP 200 でも entry 単位の失敗を返す。 FailedEntryCount を
+    // 必ず確認し、 失敗があれば throw して audit 行を書かないようにする (= 整合性確保)。
+    if ((resp.FailedEntryCount ?? 0) > 0) {
+      for (const [idx, e] of (resp.Entries ?? []).entries()) {
+        if (e.ErrorCode) {
+          failureDetails.push({
+            entryIndex: i + idx,
+            errorCode: e.ErrorCode,
+            errorMessage: e.ErrorMessage ?? "",
+          });
+        }
+      }
+    }
   }
+  if (failureDetails.length > 0) {
+    throw new Error(
+      `disruption publish partial failure: ${failureDetails
+        .map((f) => `entry[${f.entryIndex}]=${f.errorCode}`)
+        .join(", ")}`,
+    );
+  }
+}
+
+/**
+ * PR #889 review: tenant ownership check。 catalog / audit / fire の各 endpoint で
+ * 呼び出し前に event.tenantId === callerTenantId を確認するための shared helper。
+ *
+ * not found / tenant mismatch のどちらも `false` を返す (= info leak 防止のため区別しない)。
+ */
+export async function isEventOwnedByTenant(
+  shared: EventSharedResources,
+  eventId: string,
+  tenantId: string,
+): Promise<boolean> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.eventsTableName,
+      Key: { PK: `EVENT#${eventId}`, SK: "META" },
+    }),
+  );
+  const item = out.Item as { tenantId?: string } | undefined;
+  return !!item && item.tenantId === tenantId;
 }
 
 /**
@@ -315,6 +424,8 @@ function decodeCursor(cursor: string): Record<string, unknown> | undefined {
  *
  * event item から problems[] を引き、 problemId 毎に problemsDisruptions catalog を merge。
  * publicHint=false の disruption も TenantAdmin 向けには返す (= operator view が前提)。
+ *
+ * PR #889 review: 呼び出し側 (handler/index.ts) で tenantId 一致を確認した上で呼ぶ前提。
  */
 export async function listDisruptionCatalog(
   shared: EventSharedResources,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Issue #888: Red Team Disruption Injection の API / store の共通 type 定義。
+ */
+
+import type { ProblemDisruptionEntry } from "../../../utils/discover-problems-catalog";
+
+/** Fire API の request scope。 */
+export type DisruptionFireScope = "team" | "all" | "random-n";
+
+/** Fire API の入力。 caller (handler) で zod / 手動 validate 済を渡す前提。 */
+export interface DisruptionFireInput {
+  readonly tenantId: string;
+  readonly eventId: string;
+  readonly problemId: string;
+  readonly disruptionId: string;
+  /** operatorEditable allow-list 通過後の parameters。 base parameters と merge 済。 */
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly scope: DisruptionFireScope;
+  /** scope=team のみ意味を持つ。 他 scope では空配列。 */
+  readonly targetTeamIds: readonly string[];
+  /** scope=random-n のみ意味を持つ。 1 以上。 */
+  readonly randomCount?: number;
+  /** Client 生成の idempotency key。 */
+  readonly requestId: string;
+  /** Cognito sub。 audit log の firedBy に書く。 */
+  readonly firedBy: string;
+  /** 現在時刻 (ms)。 test で差し替え可能にする。 */
+  readonly nowMs: number;
+}
+
+export interface DisruptionFireResult {
+  readonly auditId: string;
+  readonly firedAt: string;
+  readonly affectedTeamIds: readonly string[];
+}
+
+export type DisruptionFireOutcome =
+  | { kind: "ok"; result: DisruptionFireResult }
+  | { kind: "duplicate"; result: DisruptionFireResult }
+  | { kind: "unknown_disruption" }
+  | { kind: "unknown_problem" }
+  | { kind: "invalid_parameters"; reason: string }
+  | { kind: "invalid_scope"; reason: string }
+  | { kind: "no_targets" };
+
+export interface DisruptionAuditRow {
+  readonly auditId: string;
+  readonly tenantId: string;
+  readonly eventId: string;
+  readonly problemId: string;
+  readonly disruptionId: string;
+  readonly firedBy: string;
+  readonly firedAt: string;
+  readonly scope: DisruptionFireScope;
+  readonly targetTeamIds: readonly string[];
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly requestId: string;
+  readonly expiresAt: number;
+}
+
+export interface DisruptionCatalogEntry extends ProblemDisruptionEntry {
+  readonly problemId: string;
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -26,8 +26,12 @@ import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
 import { createNotification } from "./create-notification.js";
-import { fireDisruption, listDisruptionAudit, listDisruptionCatalog } from "./disruption-fire.js";
-import type { DisruptionFireScope } from "./disruption-types.js";
+import {
+  fireDisruption,
+  isEventOwnedByTenant,
+  listDisruptionAudit,
+  listDisruptionCatalog,
+} from "./disruption-fire.js";
 import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
 import { lockScoring, unlockScoring } from "./lock-scoring.js";
@@ -36,6 +40,7 @@ import { buildEventSharedResources } from "./shared.js";
 import {
   BulkDeployRequestSchema,
   CreateEventRequestSchema,
+  DisruptionFireRequestSchema,
   ScheduleEventRequestSchema,
 } from "./types.js";
 
@@ -461,6 +466,10 @@ app.get("/events/:eventId/disruptions", async (c) => {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
   }
   try {
+    // PR #889 review: 他 tenant の event を obscured ID で覗くのを防ぐため tenant ownership 必須
+    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
+      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    }
     const out = await listDisruptionCatalog(shared, eventId);
     return c.json(out, HTTP_OK);
   } catch (err) {
@@ -480,6 +489,10 @@ app.get("/events/:eventId/disruptions/audit", async (c) => {
   if (!parsed) return c.json({ error: "invalid_limit" }, HTTP_BAD_REQUEST);
   const cursor = c.req.query("cursor");
   try {
+    // PR #889 review: 他 tenant の audit log を覗かれないよう tenant ownership 必須
+    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
+      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    }
     const out = await listDisruptionAudit(shared, eventId, {
       limit: parsed.limit,
       cursor,
@@ -497,54 +510,33 @@ app.post("/events/:eventId/disruptions/fire", async (c) => {
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
   }
-  const body = (await c.req.json().catch(() => null)) as {
-    disruptionId?: unknown;
-    problemId?: unknown;
-    parameters?: unknown;
-    scope?: unknown;
-    targetTeamIds?: unknown;
-    randomCount?: unknown;
-    requestId?: unknown;
-  } | null;
-  if (!body) return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  if (typeof body.disruptionId !== "string" || body.disruptionId.length === 0) {
-    return c.json({ error: "invalid_disruption_id" }, HTTP_BAD_REQUEST);
-  }
-  if (typeof body.problemId !== "string" || body.problemId.length === 0) {
-    return c.json({ error: "invalid_problem_id" }, HTTP_BAD_REQUEST);
-  }
-  if (
-    typeof body.requestId !== "string" ||
-    body.requestId.length < 8 ||
-    body.requestId.length > 128
-  ) {
-    return c.json({ error: "invalid_request_id" }, HTTP_BAD_REQUEST);
-  }
-  const scope = body.scope;
-  if (scope !== "all" && scope !== "team" && scope !== "random-n") {
-    return c.json({ error: "invalid_scope" }, HTTP_BAD_REQUEST);
-  }
-  const targetTeamIds =
-    Array.isArray(body.targetTeamIds) && scope === "team"
-      ? body.targetTeamIds.filter((id): id is string => typeof id === "string")
-      : [];
-  const randomCount =
-    scope === "random-n" && typeof body.randomCount === "number" ? body.randomCount : undefined;
-  const parameters =
-    body.parameters && typeof body.parameters === "object" && !Array.isArray(body.parameters)
-      ? (body.parameters as Record<string, unknown>)
-      : {};
+  let body: unknown;
   try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
+  }
+  // PR #889 review: 既存 route と整合する Zod parse に統一 (= cross-field 制約も含めて検証)
+  const parsed = DisruptionFireRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
+  }
+  const req = parsed.data;
+  try {
+    // PR #889 review: 他 tenant の event に fire できないよう ownership 必須
+    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
+      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+    }
     const outcome = await fireDisruption(shared, {
       tenantId: resolveTenantId(c),
       eventId,
-      problemId: body.problemId,
-      disruptionId: body.disruptionId,
-      parameters,
-      scope: scope as DisruptionFireScope,
-      targetTeamIds,
-      ...(randomCount !== undefined ? { randomCount } : {}),
-      requestId: body.requestId,
+      problemId: req.problemId,
+      disruptionId: req.disruptionId,
+      parameters: req.parameters ?? {},
+      scope: req.scope,
+      targetTeamIds: req.targetTeamIds ?? [],
+      ...(req.randomCount !== undefined ? { randomCount: req.randomCount } : {}),
+      requestId: req.requestId,
       firedBy: resolveCognitoSub(c),
       nowMs: Date.now(),
     });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -26,6 +26,8 @@ import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
 import { createNotification } from "./create-notification.js";
+import { fireDisruption, listDisruptionAudit, listDisruptionCatalog } from "./disruption-fire.js";
+import type { DisruptionFireScope } from "./disruption-types.js";
 import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
 import { lockScoring, unlockScoring } from "./lock-scoring.js";
@@ -445,6 +447,122 @@ app.post("/events/:eventId/deploy", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[events] bulkDeployEvent failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+// Issue #888 Phase A: Red Team Disruption Injection
+//   GET    /events/:eventId/disruptions          — event 内 disruption catalog
+//   GET    /events/:eventId/disruptions/audit    — 発火履歴 (pagination)
+//   POST   /events/:eventId/disruptions/fire     — disruption を fire
+app.get("/events/:eventId/disruptions", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
+  }
+  try {
+    const out = await listDisruptionCatalog(shared, eventId);
+    return c.json(out, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[disruptions] catalog failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.get("/events/:eventId/disruptions/audit", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
+  }
+  const limitRaw = c.req.query("limit");
+  const parsed = parseLimit(limitRaw);
+  if (!parsed) return c.json({ error: "invalid_limit" }, HTTP_BAD_REQUEST);
+  const cursor = c.req.query("cursor");
+  try {
+    const out = await listDisruptionAudit(shared, eventId, {
+      limit: parsed.limit,
+      cursor,
+    });
+    return c.json(out, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[disruptions] audit list failed", { eventId, message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  }
+});
+
+app.post("/events/:eventId/disruptions/fire", async (c) => {
+  const eventId = c.req.param("eventId");
+  if (!eventId || !EVENT_ID_RE.test(eventId)) {
+    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
+  }
+  const body = (await c.req.json().catch(() => null)) as {
+    disruptionId?: unknown;
+    problemId?: unknown;
+    parameters?: unknown;
+    scope?: unknown;
+    targetTeamIds?: unknown;
+    randomCount?: unknown;
+    requestId?: unknown;
+  } | null;
+  if (!body) return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
+  if (typeof body.disruptionId !== "string" || body.disruptionId.length === 0) {
+    return c.json({ error: "invalid_disruption_id" }, HTTP_BAD_REQUEST);
+  }
+  if (typeof body.problemId !== "string" || body.problemId.length === 0) {
+    return c.json({ error: "invalid_problem_id" }, HTTP_BAD_REQUEST);
+  }
+  if (
+    typeof body.requestId !== "string" ||
+    body.requestId.length < 8 ||
+    body.requestId.length > 128
+  ) {
+    return c.json({ error: "invalid_request_id" }, HTTP_BAD_REQUEST);
+  }
+  const scope = body.scope;
+  if (scope !== "all" && scope !== "team" && scope !== "random-n") {
+    return c.json({ error: "invalid_scope" }, HTTP_BAD_REQUEST);
+  }
+  const targetTeamIds =
+    Array.isArray(body.targetTeamIds) && scope === "team"
+      ? body.targetTeamIds.filter((id): id is string => typeof id === "string")
+      : [];
+  const randomCount =
+    scope === "random-n" && typeof body.randomCount === "number" ? body.randomCount : undefined;
+  const parameters =
+    body.parameters && typeof body.parameters === "object" && !Array.isArray(body.parameters)
+      ? (body.parameters as Record<string, unknown>)
+      : {};
+  try {
+    const outcome = await fireDisruption(shared, {
+      tenantId: resolveTenantId(c),
+      eventId,
+      problemId: body.problemId,
+      disruptionId: body.disruptionId,
+      parameters,
+      scope: scope as DisruptionFireScope,
+      targetTeamIds,
+      ...(randomCount !== undefined ? { randomCount } : {}),
+      requestId: body.requestId,
+      firedBy: resolveCognitoSub(c),
+      nowMs: Date.now(),
+    });
+    if (outcome.kind === "ok") return c.json(outcome.result, HTTP_CREATED);
+    if (outcome.kind === "duplicate") return c.json(outcome.result, HTTP_OK);
+    if (outcome.kind === "unknown_problem")
+      return c.json({ error: "unknown_problem" }, HTTP_BAD_REQUEST);
+    if (outcome.kind === "unknown_disruption")
+      return c.json({ error: "unknown_disruption" }, HTTP_BAD_REQUEST);
+    if (outcome.kind === "invalid_parameters")
+      return c.json({ error: "invalid_parameters", message: outcome.reason }, HTTP_BAD_REQUEST);
+    if (outcome.kind === "invalid_scope")
+      return c.json({ error: "invalid_scope", message: outcome.reason }, HTTP_BAD_REQUEST);
+    if (outcome.kind === "no_targets") return c.json({ error: "no_targets" }, HTTP_CONFLICT);
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[disruptions] fire failed", { eventId, message });
     return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -2,6 +2,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import type { ProblemDisruptionEntry } from "../../../utils/discover-problems-catalog.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
 
@@ -23,11 +24,15 @@ export interface EventSharedResources {
   readonly teamsTableName: string;
   readonly deploymentsTableName: string;
   readonly competitorAccountsTableName: string;
+  /** Issue #888: disruption audit + idempotency 用 DDB table。 deploy 時に env で wire。 */
+  readonly disruptionsTableName: string;
   readonly eventBusName: string;
   readonly env: string;
   readonly ddb: DynamoDBDocumentClient;
   readonly events: EventBridgeClient;
   readonly problemsCatalog: Readonly<Record<string, string>>;
+  /** Issue #888: problem metadata.json の `disruptions[]` 宣言 (problemId 毎)。 */
+  readonly problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>;
 }
 
 export function buildEventSharedResources(): EventSharedResources {
@@ -36,12 +41,26 @@ export function buildEventSharedResources(): EventSharedResources {
     teamsTableName: getEnv("TEAMS_TABLE_NAME"),
     deploymentsTableName: getEnv("DEPLOYMENTS_TABLE_NAME"),
     competitorAccountsTableName: getEnv("COMPETITOR_ACCOUNTS_TABLE_NAME"),
+    disruptionsTableName: getEnv("DISRUPTIONS_TABLE_NAME"),
     eventBusName: getEnv("DEPLOY_EVENT_BUS_NAME"),
     env: getEnv("DEPLOY_ENVIRONMENT"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     events: new EventBridgeClient({}),
     problemsCatalog: parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG),
+    problemsDisruptions: parseProblemsDisruptions(process.env.BATTLE_PROBLEMS_DISRUPTIONS),
   };
+}
+
+function parseProblemsDisruptions(
+  raw: string | undefined,
+): Readonly<Record<string, readonly ProblemDisruptionEntry[]>> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, ProblemDisruptionEntry[]>;
+    return parsed;
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -293,3 +293,38 @@ export const BulkDeployRequestSchema = z
     path: ["forceRedeploy"],
   });
 export type BulkDeployRequest = z.infer<typeof BulkDeployRequestSchema>;
+
+/**
+ * Issue #888 FR-1 + PR #889 review: Red Team Disruption Fire request の Zod schema。
+ *
+ * `scope` ごとに必須 / 禁止 field が異なるため refine で cross-field 制約を表現する。
+ * `randomCount` は integer + finite を要求 (= NaN / Infinity / 小数を reject)。
+ */
+export const DisruptionFireRequestSchema = z
+  .object({
+    disruptionId: z.string().min(1).max(64),
+    problemId: z.string().min(1).max(128),
+    parameters: z.record(z.unknown()).optional(),
+    scope: z.enum(["all", "team", "random-n"]),
+    targetTeamIds: z.array(z.string().min(1).max(128)).max(200).optional(),
+    randomCount: z.number().int().finite().min(1).max(200).optional(),
+    requestId: z.string().min(8).max(128),
+  })
+  .strict()
+  .refine((v) => v.scope !== "team" || (v.targetTeamIds && v.targetTeamIds.length > 0), {
+    message: "targetTeamIds is required when scope is 'team'",
+    path: ["targetTeamIds"],
+  })
+  .refine((v) => v.scope !== "random-n" || v.randomCount !== undefined, {
+    message: "randomCount is required when scope is 'random-n'",
+    path: ["randomCount"],
+  })
+  .refine((v) => v.scope === "team" || !v.targetTeamIds || v.targetTeamIds.length === 0, {
+    message: "targetTeamIds is only valid for scope='team'",
+    path: ["targetTeamIds"],
+  })
+  .refine((v) => v.scope === "random-n" || v.randomCount === undefined, {
+    message: "randomCount is only valid for scope='random-n'",
+    path: ["randomCount"],
+  });
+export type DisruptionFireRequest = z.infer<typeof DisruptionFireRequestSchema>;

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -14,6 +14,7 @@ import { DeployDeleteStateMachine } from "./deploy-delete-state-machine";
 import { DeployDeleteEventRule, DeployEventRule } from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
 import { DescribeStackLambda } from "./describe-stack-lambda";
+import { DisruptionsTable } from "./disruptions-table";
 import { EventApiLambda } from "./event-api-lambda";
 import { EventsTable } from "./events-table";
 import { ExternalIdAuditLambda } from "./external-id-audit-lambda";
@@ -77,6 +78,12 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * 等が `phases` を持たないので) で受ける。
    */
   readonly problemsPhases?: Readonly<Record<string, unknown>>;
+  /**
+   * Issue #888: `problemId → disruptions[]` の map。 `discoverProblemsDisruptions` で
+   * metadata.json から自動収集。 Red Team Disruption Injection の fire API が
+   * `(problemId, disruptionId)` の declaration lookup に参照する。 未宣言の問題はキーが無い。
+   */
+  readonly problemsDisruptions?: Readonly<Record<string, unknown>>;
   /**
    * ADR-008 Phase 3 (Issue #642): `problemId → "private"` の map。
    * `discoverProblemsVisibility` で metadata.json から自動収集。 空 map なら全 public 扱い (dormant)。
@@ -194,6 +201,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     const competitorAccounts = new CompetitorAccountsTable(this, "CompetitorAccounts");
     this.competitorAccountsTable = competitorAccounts.table;
     this.problemEndpointsTable = endpoints.table;
+    // Issue #888: Red Team Disruption Injection の audit log + idempotency
+    const disruptions = new DisruptionsTable(this, "Disruptions");
     // Issue #778 ADR-016 Phase 2: eventBusArn が渡されていれば既存の SBT bus を import、
     // 渡されていなければ Lite mode と判定して local EventBus を新規に作る。 後者では Step
     // Functions Rule も local bus にぶら下がるため、 cross-stack 依存が増えない。
@@ -232,6 +241,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsCatalog: props.problemsCatalog,
       defaultTenantId: props.defaultTenantId,
       environmentName: props.environmentName,
+      // Issue #888: disruption fire / audit / catalog で参照
+      disruptionsTable: disruptions.table,
+      problemsDisruptions: (props.problemsDisruptions ?? {}) as Readonly<
+        Record<string, readonly unknown[]>
+      >,
     });
     this.eventApiLambda = eventApi.fn;
 

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -142,6 +142,15 @@ export class ApiGateway extends Construct {
     lockScoring.addMethod("POST", eventIntegration, deployMethodOptions);
     lockScoring.addMethod("DELETE", eventIntegration, deployMethodOptions);
 
+    // Issue #888 Phase A: Red Team Disruption Injection
+    //   /events/{eventId}/disruptions          GET  = catalog
+    //   /events/{eventId}/disruptions/audit    GET  = 発火履歴 (pagination)
+    //   /events/{eventId}/disruptions/fire     POST = disruption を fire
+    const disruptions = event.addResource("disruptions");
+    disruptions.addMethod("GET", eventIntegration, deployMethodOptions);
+    disruptions.addResource("audit").addMethod("GET", eventIntegration, deployMethodOptions);
+    disruptions.addResource("fire").addMethod("POST", eventIntegration, deployMethodOptions);
+
     // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + verify
     //   /admin/competitor-accounts                                     POST=register, GET=list
     //   /admin/competitor-accounts/{awsAccountId}                      DELETE=remove (last row なら SSM 鍵も掃除)

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -214,7 +214,8 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
           operatorEditable: v.operatorEditable.filter((s): s is string => typeof s === "string"),
         }
       : {}),
-    ...(v.parameters && typeof v.parameters === "object"
+    // PR #889 review: typeof [] === "object" のため array が漏れる。 Record/object のみ許容。
+    ...(v.parameters && typeof v.parameters === "object" && !Array.isArray(v.parameters)
       ? { parameters: v.parameters as Record<string, unknown> }
       : {}),
     ...(typeof v.publicHint === "boolean" ? { publicHint: v.publicHint } : {}),

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -146,6 +146,81 @@ export function discoverProblemsVisibility(problemsRoot: string): Record<string,
   return result;
 }
 
+/**
+ * Issue #888: 各 problem metadata.json から `disruptions[]` 宣言を抽出する。
+ *
+ * Lambda runtime に渡す形は `{ [problemId]: ProblemDisruptionEntry[] }`。 fire API が
+ * `(problemId, disruptionId)` の組で declaration を引き、 `operatorEditable` allow-list /
+ * `eventDetailType` などを参照する。
+ *
+ * `disruptions` を持たない問題はキーごと出さない (= env var を最小化)。
+ */
+export interface ProblemDisruptionEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly eventDetailType: string;
+  readonly description?: string;
+  readonly defaultAfterMinutes?: number;
+  readonly operatorEditable?: readonly string[];
+  readonly parameters?: Readonly<Record<string, unknown>>;
+  readonly publicHint?: boolean;
+}
+
+export function discoverProblemsDisruptions(
+  problemsRoot: string,
+): Record<string, readonly ProblemDisruptionEntry[]> {
+  const result: Record<string, readonly ProblemDisruptionEntry[]> = {};
+  for (const meta of iterateProblemsMetadata(problemsRoot)) {
+    if (!Array.isArray(meta.disruptions)) continue;
+    const entries: ProblemDisruptionEntry[] = [];
+    for (const raw of meta.disruptions) {
+      const entry = parseDisruptionEntry(raw);
+      if (entry) entries.push(entry);
+    }
+    if (entries.length > 0) result[meta.id] = entries;
+  }
+  return result;
+}
+
+function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as {
+    id?: unknown;
+    name?: unknown;
+    eventDetailType?: unknown;
+    description?: unknown;
+    defaultAfterMinutes?: unknown;
+    operatorEditable?: unknown;
+    parameters?: unknown;
+    publicHint?: unknown;
+  };
+  if (
+    typeof v.id !== "string" ||
+    typeof v.name !== "string" ||
+    typeof v.eventDetailType !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    id: v.id,
+    name: v.name,
+    eventDetailType: v.eventDetailType,
+    ...(typeof v.description === "string" ? { description: v.description } : {}),
+    ...(typeof v.defaultAfterMinutes === "number"
+      ? { defaultAfterMinutes: v.defaultAfterMinutes }
+      : {}),
+    ...(Array.isArray(v.operatorEditable)
+      ? {
+          operatorEditable: v.operatorEditable.filter((s): s is string => typeof s === "string"),
+        }
+      : {}),
+    ...(v.parameters && typeof v.parameters === "object"
+      ? { parameters: v.parameters as Record<string, unknown> }
+      : {}),
+    ...(typeof v.publicHint === "boolean" ? { publicHint: v.publicHint } : {}),
+  };
+}
+
 interface ProblemMetadataEntry {
   id: string;
   category: string;
@@ -154,6 +229,7 @@ interface ProblemMetadataEntry {
   endpoints: unknown;
   phases: unknown;
   visibility: unknown;
+  disruptions: unknown;
 }
 
 function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetadataEntry> {
@@ -178,6 +254,7 @@ function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetada
           endpoints?: unknown;
           phases?: unknown;
           visibility?: unknown;
+          disruptions?: unknown;
         };
         if (typeof meta.id !== "string" || meta.id.length === 0) {
           console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
@@ -191,6 +268,7 @@ function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetada
           endpoints: meta.endpoints,
           phases: meta.phases,
           visibility: meta.visibility,
+          disruptions: meta.disruptions,
         };
       } catch (err) {
         console.warn(

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -26,11 +26,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints の 5 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / Disruptions の 6 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
       // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts、
-      // ADR-012 Phase 3.A で ProblemEndpoints。
-      // 5 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 5);
+      // ADR-012 Phase 3.A で ProblemEndpoints、 Issue #888 で Disruptions (Red Team audit + idempotency)。
+      // 6 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 6);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({

--- a/infrastructure/test/problem-deploy/disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-fire.test.ts
@@ -1,8 +1,10 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import type { PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { GetCommand, PutCommand, type QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fireDisruption,
+  isEventOwnedByTenant,
   listDisruptionAudit,
   listDisruptionCatalog,
 } from "../../lib/problem-deploy/handlers/event-handler/disruption-fire";
@@ -78,104 +80,118 @@ describe("fireDisruption (#888)", () => {
     expect(out.kind).toBe("invalid_parameters");
   });
 
-  it("scope=all で全 team を target にし EventBridge + audit に書くべき", async () => {
+  it("scope=all で全 team を target にし、 idempotency Put → EventBridge → audit Put の順", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
-    // 1. idempotency Query (空)
-    ddbSend.mockResolvedValueOnce({ Items: [] });
-    // 2. team list query
+    // 1. team list query
     ddbSend.mockResolvedValueOnce({
-      Items: [
-        { teamId: "T1", PK: "EVENT#X", SK: "TEAM#T1" },
-        { teamId: "T2", PK: "EVENT#X", SK: "TEAM#T2" },
-      ],
+      Items: [{ teamId: "T1" }, { teamId: "T2" }],
     });
-    // 3. PutEvents
-    eventsSend.mockResolvedValueOnce({});
-    // 4. audit PutItem
+    // 2. idempotency Put (claim)
     ddbSend.mockResolvedValueOnce({});
-    // 5. idempotency PutItem
+    // 3. PutEvents
+    eventsSend.mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [{}, {}] });
+    // 4. audit Put
     ddbSend.mockResolvedValueOnce({});
 
     const out = await fireDisruption(shared, baseInput());
     expect(out.kind).toBe("ok");
     if (out.kind !== "ok") return;
     expect(out.result.affectedTeamIds).toEqual(["T1", "T2"]);
-    // PutEvents 1 call (2 entries)
     const evCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
     expect(evCmd.input.Entries).toHaveLength(2);
     expect(evCmd.input.Entries?.[0]?.DetailType).toBe("RedTeamRouterThrottleFired");
+    // PR #889 review: publish detail も mergedParameters を載せる
+    const detail = JSON.parse(evCmd.input.Entries?.[0]?.Detail ?? "{}");
+    expect(detail.parameters).toMatchObject({ throttleRps: 5, durationSec: 60 });
   });
 
-  it("scope=team で targetTeamIds の subset のみに publish", async () => {
+  it("scope=team で targetTeamIds dedupe + subset", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({ Items: [] });
     ddbSend.mockResolvedValueOnce({
       Items: [{ teamId: "T1" }, { teamId: "T2" }, { teamId: "T3" }],
     });
-    eventsSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({}); // idempotency Put
+    eventsSend.mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [{}] });
+    ddbSend.mockResolvedValueOnce({}); // audit Put
 
     const out = await fireDisruption(
       shared,
-      baseInput({ scope: "team", targetTeamIds: ["T2", "T999"] }),
+      baseInput({ scope: "team", targetTeamIds: ["T2", "T2", "T999"] }),
     );
     expect(out.kind).toBe("ok");
     if (out.kind !== "ok") return;
-    // T999 は team 一覧に無いので除外、 T2 のみ残る
+    // dedupe + existence filter で T2 だけ残る
     expect(out.result.affectedTeamIds).toEqual(["T2"]);
   });
 
-  it("idempotency: 同 requestId の 2 度目は duplicate + 前回 result を返す", async () => {
+  it("idempotency: claim Put が CCF → duplicate を返す (race-safe)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
-    // 1st: idempotency Query が prior row を返す
+    ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] }); // team list
+    // idempotency Put が ConditionalCheckFailed
+    const ccf = new ConditionalCheckFailedException({
+      message: "exists",
+      $metadata: {},
+    });
+    ddbSend.mockRejectedValueOnce(ccf);
+    // 既存 row を Get で取得
     ddbSend.mockResolvedValueOnce({
-      Items: [
-        {
-          auditId: "01HPRIOR",
-          firedAt: "2026-01-01T00:00:00.000Z",
-          targetTeamIds: ["T1"],
-        },
-      ],
+      Item: {
+        auditId: "01HPRIOR",
+        firedAt: "2026-01-01T00:00:00.000Z",
+        targetTeamIds: ["T1"],
+        scope: "all",
+      },
     });
 
     const out = await fireDisruption(shared, baseInput());
     expect(out.kind).toBe("duplicate");
     if (out.kind !== "duplicate") return;
     expect(out.result.auditId).toBe("01HPRIOR");
-    // EventBridge は呼ばれない (= side effect 重複防止)
     expect(eventsSend).not.toHaveBeenCalled();
-    // DDB Put も呼ばれない
-    const puts = ddbSend.mock.calls.filter((c) => c[0] instanceof PutCommand);
-    expect(puts).toHaveLength(0);
   });
 
   it("no_targets を返すべき (event 配下に team 不在)", async () => {
     const { shared, ddbSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({ Items: [] });
-    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({ Items: [] }); // team list 空
     const out = await fireDisruption(shared, baseInput());
     expect(out.kind).toBe("no_targets");
   });
 
-  it("audit row に parameters / firedBy / scope / requestId が書かれる", async () => {
+  it("PutEvents で FailedEntryCount > 0 なら throw して audit row を書かないべき", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
-    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] }); // team list
+    ddbSend.mockResolvedValueOnce({}); // idempotency Put
+    eventsSend.mockResolvedValueOnce({
+      FailedEntryCount: 1,
+      Entries: [{ ErrorCode: "InternalFailure", ErrorMessage: "transient" }],
+    });
+
+    await expect(fireDisruption(shared, baseInput())).rejects.toThrow(/partial failure/);
+    // audit Put は呼ばれない
+    const puts = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is PutCommand => c instanceof PutCommand);
+    // idempotency Put 1 件のみ (= audit は走らない)
+    expect(puts).toHaveLength(1);
+  });
+
+  it("audit row に mergedParameters / firedBy / scope / requestId が書かれる", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] });
-    eventsSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({});
-    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({}); // idempotency Put
+    eventsSend.mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [{}] });
+    ddbSend.mockResolvedValueOnce({}); // audit Put
 
     await fireDisruption(shared, baseInput({ parameters: { throttleRps: 10 } }));
     const putCmds = ddbSend.mock.calls
       .map((c) => c[0])
       .filter((c): c is PutCommand => c instanceof PutCommand);
     expect(putCmds).toHaveLength(2);
-    const auditItem = putCmds[0]?.input.Item;
+    // 1st = idempotency, 2nd = audit
+    const auditItem = putCmds[1]?.input.Item;
     expect(auditItem?.firedBy).toBe("cognito-sub-1");
     expect(auditItem?.requestId).toBe("req-12345678");
     expect(auditItem?.scope).toBe("all");
-    // base parameters と merge されている (throttleRps を override + durationSec は base から継承)
     expect(auditItem?.parameters).toMatchObject({ throttleRps: 10, durationSec: 60 });
   });
 });
@@ -226,7 +242,28 @@ describe("listDisruptionCatalog (#888)", () => {
     expect(out.entries).toHaveLength(1);
     expect(out.entries[0]?.problemId).toBe("battle-1");
     expect(out.entries[0]?.disruption.id).toBe("router-throttle");
-    // unknown-problem は problemsDisruptions に無いので skip
     expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
+  });
+});
+
+describe("isEventOwnedByTenant (#888 PR #889)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("event item が存在し tenantId 一致なら true", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: { tenantId: "tenant-acme" } });
+    expect(await isEventOwnedByTenant(shared, "EV1", "tenant-acme")).toBe(true);
+  });
+
+  it("tenantId 不一致なら false (= 他 tenant の event を覗かせない)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: { tenantId: "tenant-other" } });
+    expect(await isEventOwnedByTenant(shared, "EV1", "tenant-acme")).toBe(false);
+  });
+
+  it("event 不在なら false", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+    expect(await isEventOwnedByTenant(shared, "EV1", "tenant-acme")).toBe(false);
   });
 });

--- a/infrastructure/test/problem-deploy/disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-fire.test.ts
@@ -1,0 +1,232 @@
+import type { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { GetCommand, PutCommand, type QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireDisruption,
+  listDisruptionAudit,
+  listDisruptionCatalog,
+} from "../../lib/problem-deploy/handlers/event-handler/disruption-fire";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+const NOW_MS = 1_700_000_000_000;
+
+function buildShared(): {
+  shared: EventSharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  eventsSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const eventsSend = vi.fn();
+  const shared: EventSharedResources = {
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    disruptionsTableName: "TestDisruptions",
+    eventBusName: "test-bus",
+    env: "development",
+    ddb: { send: ddbSend } as unknown as EventSharedResources["ddb"],
+    events: { send: eventsSend } as unknown as EventSharedResources["events"],
+    problemsCatalog: { "battle-1": "problems/battles/battle-1" },
+    problemsDisruptions: {
+      "battle-1": [
+        {
+          id: "router-throttle",
+          name: "Throttle test",
+          eventDetailType: "RedTeamRouterThrottleFired",
+          operatorEditable: ["throttleRps", "durationSec"],
+          parameters: { throttleRps: 5, durationSec: 60 },
+        },
+      ],
+    },
+  };
+  return { shared, ddbSend, eventsSend };
+}
+
+const baseInput = (over: Partial<Parameters<typeof fireDisruption>[1]> = {}) => ({
+  tenantId: "tenant-acme",
+  eventId: "01HZX0K3M3K9ZQHB3MRQHBA1B2",
+  problemId: "battle-1",
+  disruptionId: "router-throttle",
+  parameters: {},
+  scope: "all" as const,
+  targetTeamIds: [],
+  requestId: "req-12345678",
+  firedBy: "cognito-sub-1",
+  nowMs: NOW_MS,
+  ...over,
+});
+
+describe("fireDisruption (#888)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("unknown_problem を返すべき (problemsDisruptions に entry が無い)", async () => {
+    const { shared } = buildShared();
+    const out = await fireDisruption(shared, baseInput({ problemId: "unknown" }));
+    expect(out.kind).toBe("unknown_problem");
+  });
+
+  it("unknown_disruption を返すべき (disruptionId が catalog に無い)", async () => {
+    const { shared } = buildShared();
+    const out = await fireDisruption(shared, baseInput({ disruptionId: "nope" }));
+    expect(out.kind).toBe("unknown_disruption");
+  });
+
+  it("invalid_parameters を返すべき (operatorEditable allow-list 外の key)", async () => {
+    const { shared } = buildShared();
+    const out = await fireDisruption(shared, baseInput({ parameters: { evilKey: "exfil" } }));
+    expect(out.kind).toBe("invalid_parameters");
+  });
+
+  it("scope=all で全 team を target にし EventBridge + audit に書くべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    // 1. idempotency Query (空)
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    // 2. team list query
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        { teamId: "T1", PK: "EVENT#X", SK: "TEAM#T1" },
+        { teamId: "T2", PK: "EVENT#X", SK: "TEAM#T2" },
+      ],
+    });
+    // 3. PutEvents
+    eventsSend.mockResolvedValueOnce({});
+    // 4. audit PutItem
+    ddbSend.mockResolvedValueOnce({});
+    // 5. idempotency PutItem
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await fireDisruption(shared, baseInput());
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.result.affectedTeamIds).toEqual(["T1", "T2"]);
+    // PutEvents 1 call (2 entries)
+    const evCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(evCmd.input.Entries).toHaveLength(2);
+    expect(evCmd.input.Entries?.[0]?.DetailType).toBe("RedTeamRouterThrottleFired");
+  });
+
+  it("scope=team で targetTeamIds の subset のみに publish", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ teamId: "T1" }, { teamId: "T2" }, { teamId: "T3" }],
+    });
+    eventsSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+
+    const out = await fireDisruption(
+      shared,
+      baseInput({ scope: "team", targetTeamIds: ["T2", "T999"] }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    // T999 は team 一覧に無いので除外、 T2 のみ残る
+    expect(out.result.affectedTeamIds).toEqual(["T2"]);
+  });
+
+  it("idempotency: 同 requestId の 2 度目は duplicate + 前回 result を返す", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    // 1st: idempotency Query が prior row を返す
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          auditId: "01HPRIOR",
+          firedAt: "2026-01-01T00:00:00.000Z",
+          targetTeamIds: ["T1"],
+        },
+      ],
+    });
+
+    const out = await fireDisruption(shared, baseInput());
+    expect(out.kind).toBe("duplicate");
+    if (out.kind !== "duplicate") return;
+    expect(out.result.auditId).toBe("01HPRIOR");
+    // EventBridge は呼ばれない (= side effect 重複防止)
+    expect(eventsSend).not.toHaveBeenCalled();
+    // DDB Put も呼ばれない
+    const puts = ddbSend.mock.calls.filter((c) => c[0] instanceof PutCommand);
+    expect(puts).toHaveLength(0);
+  });
+
+  it("no_targets を返すべき (event 配下に team 不在)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await fireDisruption(shared, baseInput());
+    expect(out.kind).toBe("no_targets");
+  });
+
+  it("audit row に parameters / firedBy / scope / requestId が書かれる", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] });
+    eventsSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+    ddbSend.mockResolvedValueOnce({});
+
+    await fireDisruption(shared, baseInput({ parameters: { throttleRps: 10 } }));
+    const putCmds = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is PutCommand => c instanceof PutCommand);
+    expect(putCmds).toHaveLength(2);
+    const auditItem = putCmds[0]?.input.Item;
+    expect(auditItem?.firedBy).toBe("cognito-sub-1");
+    expect(auditItem?.requestId).toBe("req-12345678");
+    expect(auditItem?.scope).toBe("all");
+    // base parameters と merge されている (throttleRps を override + durationSec は base から継承)
+    expect(auditItem?.parameters).toMatchObject({ throttleRps: 10, durationSec: 60 });
+  });
+});
+
+describe("listDisruptionAudit (#888)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("event 直下の AUDIT# row のみを返し、 ScanIndexForward=false で時系列降順", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          auditId: "A1",
+          tenantId: "tenant-acme",
+          eventId: "EV1",
+          problemId: "battle-1",
+          disruptionId: "router-throttle",
+          firedBy: "op-1",
+          firedAt: "2026-05-12T00:00:00.000Z",
+          scope: "all",
+          targetTeamIds: ["T1"],
+          parameters: { throttleRps: 5 },
+          requestId: "r1",
+          expiresAt: 1_700_000_000,
+        },
+      ],
+    });
+    const out = await listDisruptionAudit(shared, "EV1");
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]?.auditId).toBe("A1");
+    const qry = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(qry.input.ScanIndexForward).toBe(false);
+    expect(qry.input.ExpressionAttributeValues?.[":ap"]).toBe("AUDIT#");
+  });
+});
+
+describe("listDisruptionCatalog (#888)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("event の problems[] に該当する disruption のみを catalog に出すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        problems: [{ problemId: "battle-1" }, { problemId: "unknown-problem" }],
+      },
+    });
+    const out = await listDisruptionCatalog(shared, "EV1");
+    expect(out.entries).toHaveLength(1);
+    expect(out.entries[0]?.problemId).toBe("battle-1");
+    expect(out.entries[0]?.disruption.id).toBe("router-throttle");
+    // unknown-problem は problemsDisruptions に無いので skip
+    expect(ddbSend.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
+  });
+});


### PR DESCRIPTION
Closes #888 Phase A (= backend; admin-console UI と cross-account publish は別 PR で対応)

## Summary

Operator が任意のタイミングで battle 問題の disruption を fire できる横断機能の Phase A。
problem metadata.json の \`disruptions[]\` 宣言を catalog として読み、 API 経由で event スコープで
fire + audit + EventBridge publish を担う。

### 追加した経路 (FR-1 / FR-2 / FR-4)

- \`GET    /events/{eventId}/disruptions\`        — 該当 event の disruption catalog
- \`GET    /events/{eventId}/disruptions/audit\`  — 発火履歴 (cursor pagination)
- \`POST   /events/{eventId}/disruptions/fire\`   — disruption を fire

### 実装ポイント

- 新 DDB table \`Disruptions\` (PROVISIONED 1/1、 TTL 7 日、 RETAIN)
  - PK=EVENT#<eventId> / SK=AUDIT#<firedAt>#<auditId> で append-only audit
  - GSI1: PK=REQUEST#<tenantId>#<requestId> で idempotency lookup
- \`parameters\` は disruption.operatorEditable allow-list でホワイトリスト fold
- \`scope\`: \`all\` / \`team\` / \`random-n\` (= crypto-grade Fisher-Yates 抽選)
- EventBridge publish は同 account の DEPLOY_EVENT_BUS に detail-type =
  \`disruption.eventDetailType\` で N team 分 (= MAX_AFFECTED_TEAMS=200)
- Idempotency: 同 requestId 2 度目は前回 result を返し、 EventBridge / DDB Put は skip
- 認可: 既存 \`/events/*\` middleware で TenantAdmin 必須

## Out of scope (= 別 PR)

- **FR-3 cross-account publish**: 競技者アカウントへの forward は ExternalId / Trust Bridge
  経由で行う必要があり、 別 PR で wiring
- **FR-5 admin-console UI**: Disruption Control panel を EventDetail に追加するのは別 PR
- **FR-8 Rate limit**: 1 event 60 RPM の rate limiter wiring は別 PR
- **FR-6 SystemAdmin cross-tenant**: 横断観察権限の整理は別 issue

## Regression 分析

- 既存 1027 test + 新規 11 test (= 9 fireDisruption + 1 listDisruptionAudit + 1 listDisruptionCatalog)
  すべて pass
- \`problem-deploy-backend-stack.test.ts\` で table count 5 → 6 に更新
- TenantTemplateStack に 3 新規 route を生やしたため、 既存 tenant 配下 deploy で再 deploy が必要

## 物理影響

- **CREATE**: DDB table \`Disruptions\` (= 1 RCU / 1 WCU PROVISIONED + GSI1 1/1)
- **UPDATE**: EventApi Lambda bundle (= 3 route + handler logic 追加)
- **UPDATE**: TenantTemplateStack の API Gateway (= 3 endpoint + COGNITO authorizer)
- **NO-OP**: 既存 event / deployment / team route は変更なし

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1038 test pass + cdk synth OK
- [x] 11 新規 test (fire happy / unknown / invalid / dup / no-targets / scope=team / audit row / list / catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added Red Team Disruption Injection capability with three new API endpoints: view disruption catalog, audit injection history, and fire disruptions
  - Supports multiple targeting scopes: all teams, specific teams, or random team selection
  - Audit logging with idempotency protection ensures injection requests are tracked and prevent duplicate execution
  - Configurable per-problem disruptions with parameter validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->