### PR TITLE
fix(security): block ExternalId rotate on unverified competitor accounts (#868)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -14,6 +14,7 @@ import { routeDelete, routeGet, routePut } from "./saml-routes.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
 import {
   CompetitorAccountNotFoundError,
+  CompetitorAccountNotVerifiedError,
   createCompetitorAccount,
   DuplicateCompetitorAccountError,
   deleteCompetitorAccount,
@@ -242,6 +243,11 @@ app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c
   } catch (err) {
     if (err instanceof CompetitorAccountNotFoundError) {
       return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+    }
+    // Issue #868: verified=false な row への rotate は 409 + 明示メッセージで operator に
+    // 「先に verify を成功させて」 と返す。 attacker spoof 経路に鍵を回さない。
+    if (err instanceof CompetitorAccountNotVerifiedError) {
+      return c.json({ error: "not_verified" }, StatusCodes.CONFLICT);
     }
     if (err instanceof ExternalIdMissingForRotationError) {
       return c.json({ error: "external_id_missing" }, StatusCodes.CONFLICT);

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/store.ts
@@ -50,6 +50,21 @@ export class CompetitorAccountNotFoundError extends Error {
   }
 }
 
+/**
+ * Issue #868: register 直後 / verify 未完了 (verified=false) の row に対する operation を
+ * 拒否するエラー。 `POST /verify` で AssumeRole sanity check が成功するまで、 deploy /
+ * rotate などの downstream operation を gate する。
+ */
+export class CompetitorAccountNotVerifiedError extends Error {
+  constructor(public readonly awsAccountId: string) {
+    super(
+      `competitor account ${awsAccountId} is registered but not yet verified; ` +
+        "call POST /admin/competitor-accounts/{awsAccountId}/verify first",
+    );
+    this.name = "CompetitorAccountNotVerifiedError";
+  }
+}
+
 export interface CreateCompetitorAccountContext {
   readonly tenantId: string;
   readonly nowMs: number;
@@ -264,6 +279,11 @@ export async function rotateExternalIdForAccount(
     }),
   );
   if (!existing.Item) throw new CompetitorAccountNotFoundError(ctx.awsAccountId);
+  // Issue #868: verified=false な行に対する rotate は禁止 (= ownership 未確認の account に
+  // 鍵を回す経路で attacker spoof が成立しないように、 verify を必須前提にする)。
+  if (existing.Item.verified !== true) {
+    throw new CompetitorAccountNotVerifiedError(ctx.awsAccountId);
+  }
 
   // 2. 現 ExternalId 存在確認 (= 鍵が完全消失している tenant に対する rotate は誤操作のサイン)。
   const currentExternalId = await getExternalId(

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -34,6 +34,12 @@ const mocks = vi.hoisted(() => ({
       this.name = "ExternalIdMissingForRotationError";
     }
   },
+  CompetitorAccountNotVerifiedError: class extends Error {
+    constructor(public readonly awsAccountId: string) {
+      super("not verified");
+      this.name = "CompetitorAccountNotVerifiedError";
+    }
+  },
   AssumeRoleSanityCheckFailedError: class extends Error {
     constructor(
       public readonly awsAccountId: string,
@@ -70,6 +76,7 @@ vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/store", (
   rotateExternalIdForAccount: mocks.rotateExternalIdForAccount,
   DuplicateCompetitorAccountError: mocks.DuplicateCompetitorAccountError,
   CompetitorAccountNotFoundError: mocks.CompetitorAccountNotFoundError,
+  CompetitorAccountNotVerifiedError: mocks.CompetitorAccountNotVerifiedError,
   ExternalIdMissingForRotationError: mocks.ExternalIdMissingForRotationError,
 }));
 
@@ -264,6 +271,18 @@ describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id", () 
     expect(res.status).toBe(StatusCodes.CONFLICT);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.error).toBe("external_id_missing");
+  });
+
+  it("Issue #868: verified=false な row への rotate は 409 (not_verified) を返すべき", async () => {
+    mocks.rotateExternalIdForAccount.mockRejectedValueOnce(
+      new mocks.CompetitorAccountNotVerifiedError("222222222222"),
+    );
+    const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
+      method: "POST",
+    });
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("not_verified");
   });
 
   it("awsAccountId が 12 桁でないと 400", async () => {

--- a/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/shared";
 import {
   CompetitorAccountNotFoundError,
+  CompetitorAccountNotVerifiedError,
   createCompetitorAccount,
   DuplicateCompetitorAccountError,
   deleteCompetitorAccount,
@@ -405,5 +406,35 @@ describe("rotateExternalIdForAccount", () => {
 
     // SSM Get 1 度のみ、Put は呼ばない
     expect(ssmSend.mock.calls.length).toBe(1);
+  });
+
+  it("Issue #868: verified=false な row への rotate は CompetitorAccountNotVerifiedError を投げ SSM Put しないべき", async () => {
+    const { shared, ddbSend, ssmSend } = buildShared();
+    // verified=false な row
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        PK: "TENANT#tenant-acme",
+        SK: "ACCOUNT#222222222222",
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        region: "ap-northeast-1",
+        competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+        verified: false,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+      },
+    });
+
+    await expect(
+      rotateExternalIdForAccount(shared, {
+        tenantId: "tenant-acme",
+        awsAccountId: "222222222222",
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBeInstanceOf(CompetitorAccountNotVerifiedError);
+
+    // DDB Get 1 度のみ。SSM は touch しない (= unverified row に対して鍵を回さない)
+    expect(ddbSend.mock.calls.length).toBe(1);
+    expect(ssmSend.mock.calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #868

## Summary

Issue #868: register endpoint で作る row は \`verified=false\` 初期値、 \`POST /verify\` で
STS AssumeRole sanity check (= ownership proof) を通った時のみ \`verified=true\` に
昇格する設計。 deploy / bulk-deploy 経路は \`resolveVerifiedCompetitorAccount\` で
verified=true gate を既に持っているが、 \`rotate-external-id\` だけが gate されていなかった
ため、 attacker が register 直後の unverified row に対して鍵 rotation を強制できる経路を塞ぐ。

### 修正点

- \`rotateExternalIdForAccount\` で row 存在確認後に \`verified !== true\` を check し、
  新規 \`CompetitorAccountNotVerifiedError\` を throw
- handler は 409 + \`{ error: \"not_verified\" }\` を返し、 operator に
  \`POST /verify\` を先に実行することを促す
- SSM rotate は呼ばない (= unverified row には鍵を回さない)

## 既存実装の確認

Issue acceptance に対する現状:

- [x] register endpoint が \`unverified\` row のみ作る ← \`createCompetitorAccount\`
      が \`verified: false\` で初期化済
- [x] verify endpoint が必須経路 ← \`resolveVerifiedCompetitorAccount\` が
      bulk-deploy / single deploy / delete で gate
- [x] PoC: 他社 AWS account ID を register しても verify で AccessDenied になる ←
      verify は STS AssumeRole を発行するので、 attacker が ExternalId を知らなければ失敗
- [x] **rotate の verified gate** ← 本 PR で追加

## Regression 分析

- 既存 1043 test pass + 新規 2 test (store rotate not-verified + route 409 not_verified)
- verified=true な row への rotate は従来通り (= regression なし)
- 新規 error はモック側に追加するだけ

## 物理影響

- **UPDATE**: competitor-accounts-api Lambda bundle (= ロジック内 verified check 追加)
- **NO-OP**: DDB / IAM / API Gateway は変更なし

## Out of scope (= 別 Issue / Phase)

- Phase 2 strong ownership proof (= operator が CompetitorBootstrapStack を deploy し
  stack output を register に渡す経路) は別 PR。 本 PR は **verify 必須化** で TOFU 経路を
  実用上閉じるに留める

## Test plan

- [x] \`make harness\` — invariant 違反 0 件
- [x] \`make before-commit\` — 1044 test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)