### PR TITLE
fix(lite): make lite-up loader を ts-node から tsx に切替

### DIFF
--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -34,7 +34,10 @@ export const LITE_STACK_NAMES = {
   problemDeploy: "tenkacloud-lite-problem-deploy",
 } as const;
 
-const CDK_OPTS = ["--app", "bunx ts-node infrastructure/bin/tenkacloud-lite.ts"];
+// cdk.json と同じ tsx loader を使う。 ts-node は `./foo.js` → `./foo.ts` の
+// extension rewrite を CommonJS 文脈で解決できず、 `endpoints-metadata.ts` 等の
+// ESM-style import (`./env-encoding.js`) で MODULE_NOT_FOUND になる。
+const CDK_OPTS = ["--app", "bunx tsx infrastructure/bin/tenkacloud-lite.ts"];
 
 export interface SpawnCaptureResult {
   readonly code: number;


### PR DESCRIPTION
## Summary

- \`make lite-up\` が起動時に \`Cannot find module './env-encoding.js'\` で落ちる regression を修正
- root cause: \`scripts/tenkacloud-lite.ts:37\` の \`--app \"bunx ts-node ...\"\` は ts-node の CommonJS 文脈で \`./foo.js\` → \`./foo.ts\` の extension rewrite を解決できず、 \`infrastructure/lib/utils/endpoints-metadata.ts:1\` の \`import { decodeLargeEnvValue } from \"./env-encoding.js\";\` のような ESM-style import で \`MODULE_NOT_FOUND\` になる
- \`cdk.json\` (= 本来の \`bin/infrastructure.ts\` 経路) は \`bunx tsx\` を使って同じ import 解決を通せる。 lite mode も \`tsx\` に揃える

## Regression 分析

- 影響: \`make lite-up\` / \`lite-down\` / \`lite-status\` / \`lite-portal-url\` / \`lite-console-url\` の **5 target すべて** が \`MODULE_NOT_FOUND\` で落ちていた (= CLI subcommand を 1 つ呼ぶたびに同じエラー)
- 既存テスト (\`infrastructure/test/scripts/tenkacloud-lite.test.ts:87\`) は \`cmd === \"bunx\"\` と \`args\` の一部のみ assertion しており、 loader (\`ts-node\` vs \`tsx\`) の literal は検査していなかった → regression を CI で検出できなかった
- 既存テスト 23/23 すべて pass (= 本変更で test behavior は変わらない)
- 別経路の標準 \`make deploy\` (= \`cdk.json\` 経由) は \`tsx\` を使うため影響なし

## 物理影響

- **NO-OP** (CFn / 成果物に変更なし): \`scripts/tenkacloud-lite.ts\` の \`--app\` 引数文字列のみの変更。 stack 構築は \`cdk\` 起動引数の loader 選択だけが変わる。 CFn template / IAM Role / Lambda / S3 等の生成物は同一

## Test plan

- [x] \`bun run test\` (\`infrastructure/test/scripts/tenkacloud-lite.test.ts\` を含む 23 件 pass)
- [x] \`make lite-up\` が CDK app の起動 (= asset bundling) まで到達することを確認
- [x] \`make harness\` (architecture invariant) green

## References

- \`scripts/tenkacloud-lite.ts:37\` — 修正対象
- \`infrastructure/lib/utils/endpoints-metadata.ts:1\` — 引き金となった ESM-style import
- \`infrastructure/cdk.json:1\` — \`tsx\` を使う既存の reference 実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build infrastructure tooling configuration to enhance reliability of the application initialization process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->