### PR TITLE
fix(#903): tenant 招待メールを英語のみに統一 (4 言語混在を廃止)

### DIFF
--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -10,99 +10,33 @@ const COGNITO_USERNAME = "{username}";
 const COGNITO_TEMP_PASSWORD = "{####}";
 
 /**
- * #529 i18n + #660: 1 通の招待メールに 4 言語 (JA / EN / ES / ZH) を順に並べる + Gmail 等で
- * 単一改行が space に re-flow される問題を回避するため、 各 field を `\n\n` (paragraph
- * break) で区切る。
+ * Issue #903: 招待メール文面を英語のみに統一する (= 旧 4 言語混在は Gmail で改行が collapse
+ * して読めなくなる問題があった)。 Control Plane の System Admin 招待 (Issue #714) と同じ
+ * 方針。 各 field を `\n\n` (paragraph break) で区切り、 Gmail / Outlook で改行が保たれる
+ * よう整形する。
  *
- * Cognito の `InviteMessageTemplate` は **UserPool あたり 1 言語**しか保持できない (= 4 言語
- * 同梱で送る理由)、 かつ Cognito default 送信は **plain text** で HTML タグが literal text
- * になる (= Option A: HTML 化 は SES verified identity が必要で infra 影響大、 ここでは
- * Option B: plain text 整形強化 を採用)。
- *
- * Phase 2 で `custom:locale` 属性 + CustomMessage Lambda Trigger + SES への移行を予定。
+ * Cognito `InviteMessageTemplate` は **UserPool あたり 1 言語**しか保持できないので、
+ * 多言語化が必要なら `custom:locale` 属性 + CustomMessage Lambda Trigger + SES への移行が
+ * 必要 (= 別 issue)。 当面は SaaS の lingua franca = 英語のみ。
  */
 function buildInviteEmailBody(consoleUrl: string): string {
-  const divider = "═══════════════════════════════════════════";
-  const sections: readonly string[] = [
-    // --- 日本語 ---
-    [
-      "▼ 日本語",
-      "",
-      "ようこそ TenkaCloud Battle / Challenge へ。",
-      "",
-      "テナント管理コンソールへサインインするための一時アカウントを発行しました。",
-      "",
-      `■ ユーザー名: ${COGNITO_USERNAME}`,
-      "",
-      `■ 一時パスワード: ${COGNITO_TEMP_PASSWORD}`,
-      "",
-      `■ サインイン URL: ${consoleUrl}`,
-      "",
-      "初回サインイン時に新しいパスワードを設定してください。 競技イベント (Event) の作成 / 競技者向け Portal URL の払い出しは、 テナント管理コンソールから操作できます。",
-    ].join("\n"),
-
-    // --- English ---
-    [
-      "▼ English",
-      "",
-      "Welcome to TenkaCloud Battle / Challenge.",
-      "",
-      "A temporary account has been issued so you can sign in to the Tenant Admin Console.",
-      "",
-      `■ Username: ${COGNITO_USERNAME}`,
-      "",
-      `■ Temporary password: ${COGNITO_TEMP_PASSWORD}`,
-      "",
-      `■ Sign-in URL: ${consoleUrl}`,
-      "",
-      "Set a new password on first sign-in. From the Tenant Admin Console you can create competition Events and hand out Participant Portal URLs.",
-    ].join("\n"),
-
-    // --- Español ---
-    [
-      "▼ Español",
-      "",
-      "Bienvenido a TenkaCloud Battle / Challenge.",
-      "",
-      "Se ha emitido una cuenta temporal para iniciar sesión en la consola de administración de inquilinos.",
-      "",
-      `■ Usuario: ${COGNITO_USERNAME}`,
-      "",
-      `■ Contraseña temporal: ${COGNITO_TEMP_PASSWORD}`,
-      "",
-      `■ URL de inicio de sesión: ${consoleUrl}`,
-      "",
-      "Establezca una nueva contraseña al iniciar sesión por primera vez. Desde la consola puede crear eventos de competición y emitir URLs del portal para los participantes.",
-    ].join("\n"),
-
-    // --- 中文 (简体) ---
-    [
-      "▼ 中文 (简体)",
-      "",
-      "欢迎使用 TenkaCloud Battle / Challenge。",
-      "",
-      "已为您颁发临时账号,用于登录租户管理控制台。",
-      "",
-      `■ 用户名: ${COGNITO_USERNAME}`,
-      "",
-      `■ 临时密码: ${COGNITO_TEMP_PASSWORD}`,
-      "",
-      `■ 登录地址: ${consoleUrl}`,
-      "",
-      "首次登录时请设置新密码。 在租户管理控制台中,您可以创建比赛活动 (Event) 并发放参赛者门户 URL。",
-    ].join("\n"),
-  ];
-
-  const footer = [
-    "If this email looks unfamiliar, please discard it.",
-    "本メールに心当たりがない場合は破棄してください。",
-    "Si este correo no le resulta familiar, descártelo.",
-    "如果您不认识此邮件,请忽略。",
+  return [
+    "Welcome to TenkaCloud Battle / Challenge.",
     "",
-    "-- TenkaCloud Operations / 運営 / Operaciones / 运营",
+    "A temporary account has been issued so you can sign in to the Tenant Admin Console.",
+    "",
+    `Username: ${COGNITO_USERNAME}`,
+    "",
+    `Temporary password: ${COGNITO_TEMP_PASSWORD}`,
+    "",
+    `Sign-in URL: ${consoleUrl}`,
+    "",
+    "Set a new password on first sign-in. From the Tenant Admin Console you can create competition Events and hand out Participant Portal URLs.",
+    "",
+    "If this email looks unfamiliar, please discard it.",
+    "",
+    "-- TenkaCloud Operations",
   ].join("\n");
-
-  return [...sections, footer].join(`\n\n${divider}\n\n`);
 }
 
 interface IdentityProviderProps {
@@ -193,16 +127,14 @@ export class IdentityProvider extends Construct {
   constructor(scope: Construct, id: string, props: IdentityProviderProps) {
     super(scope, id);
 
-    // #529: tenant admin 招待 — 4 言語の multilingual body (JA / EN / ES / ZH) を 1 通に並べる。
-    // Cognito は UserPool ごとに 1 template しか持てないため、locale 別配信は CustomMessage
-    // Lambda Trigger が要る (Phase 2)。MVP は 4 言語並列で各 operator が読める段落を選ぶ。
+    // Issue #903: tenant admin 招待は英語のみ (Control Plane #714 と同方針)。 旧 4 言語混在
+    // は Gmail で改行が collapse して読めない問題があった。 多言語化が必要なら CustomMessage
+    // Lambda Trigger + SES への移行 (= 別 issue) で対応する。
     this.tenantUserPool = new aws_cognito.UserPool(this, "tenantUserPool", {
       autoVerify: { email: true },
       accountRecovery: aws_cognito.AccountRecovery.EMAIL_ONLY,
       userInvitation: {
-        // 多言語 subject (= mail client preview で言語識別できるよう全部入り)
-        emailSubject:
-          "[TenkaCloud] テナント管理コンソール招待 / Tenant Admin Invitation / Invitación / 租户管理控制台邀请",
+        emailSubject: "[TenkaCloud] Tenant Admin Invitation",
         emailBody: buildInviteEmailBody(props.applicationAdminConsoleUrl),
         // Cognito CFn は `InviteMessageTemplate` 設定時に SMSMessage も整合性チェックする
         // (aws-cdk#30315 系の挙動)。SMS は使わないが空にできないため最短形を入れる。

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -134,22 +134,24 @@ describe("IdentityProvider", () => {
       expect(readAttrs).toContain("custom:tenantName");
     });
 
-    it("#529 i18n: 招待メール body に JA / EN / ES / ZH 4 言語が含まれ console URL + placeholder も embed されるべき", () => {
+    it("Issue #903: 招待メール subject は英語のみであるべき (4 言語混在を廃止)", () => {
       const consoleUrl = "https://d123abc.cloudfront.net";
       const { template } = synth("tenant-1", consoleUrl);
-      // Subject は 4 言語並列 (mail client preview での言語識別用)
       template.hasResourceProperties(
         "AWS::Cognito::UserPool",
         Match.objectLike({
           AdminCreateUserConfig: Match.objectLike({
             InviteMessageTemplate: Match.objectLike({
-              EmailSubject: Match.stringLikeRegexp(
-                "テナント管理コンソール招待.*Tenant Admin Invitation",
-              ),
+              EmailSubject: "[TenkaCloud] Tenant Admin Invitation",
             }),
           }),
         }),
       );
+    });
+
+    it("Issue #903: 招待メール body は英語のみで、 console URL + Cognito placeholder を含むべき", () => {
+      const consoleUrl = "https://d123abc.cloudfront.net";
+      const { template } = synth("tenant-1", consoleUrl);
       const userPool = Object.values(template.findResources("AWS::Cognito::UserPool"))[0];
       const body =
         (
@@ -157,20 +159,25 @@ describe("IdentityProvider", () => {
             AdminCreateUserConfig?: { InviteMessageTemplate?: { EmailMessage?: string } };
           }
         )?.AdminCreateUserConfig?.InviteMessageTemplate?.EmailMessage ?? "";
-      // 4 言語の greeting (= operator がどの言語でも 1 段落見つけられる)
-      expect(body).toContain("ようこそ TenkaCloud"); // JA
-      expect(body).toContain("Welcome to TenkaCloud"); // EN
-      expect(body).toContain("Bienvenido a TenkaCloud"); // ES
-      expect(body).toContain("欢迎使用 TenkaCloud"); // ZH
+      // 英語 greeting + 各 field
+      expect(body).toContain("Welcome to TenkaCloud");
+      expect(body).toContain("Username:");
+      expect(body).toContain("Temporary password:");
+      expect(body).toContain("Sign-in URL:");
+      // 旧 4 言語混在の痕跡が無いこと (= regression 防止)
+      expect(body).not.toContain("ようこそ TenkaCloud");
+      expect(body).not.toContain("Bienvenido a TenkaCloud");
+      expect(body).not.toContain("欢迎使用 TenkaCloud");
+      expect(body).not.toContain("▼");
       // Cognito placeholder と console URL
       expect(body).toContain("{username}");
       expect(body).toContain("{####}");
       expect(body).toContain(consoleUrl);
     });
 
-    it("#660: 各 field (ユーザー名 / 一時パスワード / URL) が paragraph break (= 二重改行) で区切られるべき", () => {
+    it("Issue #903: 各 field (Username / Temporary password / Sign-in URL) が paragraph break (= 二重改行) で区切られるべき", () => {
       // Gmail / Outlook は単一改行を space に re-flow するので、 fields は \n\n で区切らないと
-      // 1 行に潰れて読めなくなる (= PR-582 で起きた regression)。
+      // 1 行に潰れて読めなくなる (= PR-582 で起きた regression、 Issue #903 でも継続維持)。
       const consoleUrl = "https://d123abc.cloudfront.net";
       const { template } = synth("tenant-1", consoleUrl);
       const userPool = Object.values(template.findResources("AWS::Cognito::UserPool"))[0];
@@ -180,17 +187,9 @@ describe("IdentityProvider", () => {
             AdminCreateUserConfig?: { InviteMessageTemplate?: { EmailMessage?: string } };
           }
         )?.AdminCreateUserConfig?.InviteMessageTemplate?.EmailMessage ?? "";
-      // 各 field の前後に \n\n がある (= paragraph break)
-      expect(body).toMatch(/\n\n■ ユーザー名: \{username\}\n\n/);
-      expect(body).toMatch(/\n\n■ 一時パスワード: \{####\}\n\n/);
-      expect(body).toMatch(/\n\n■ Username: \{username\}\n\n/);
-      // 言語間の divider が存在する (= 視覚的セクション区切り)
-      expect(body).toContain("═══");
-      // 言語 prefix が各セクション冒頭にある (= 受信者が読める段落をすぐ見つけられる)
-      expect(body).toContain("▼ 日本語");
-      expect(body).toContain("▼ English");
-      expect(body).toContain("▼ Español");
-      expect(body).toContain("▼ 中文 (简体)");
+      expect(body).toMatch(/\n\nUsername: \{username\}\n\n/);
+      expect(body).toMatch(/\n\nTemporary password: \{####\}\n\n/);
+      expect(body).toMatch(/\n\nSign-in URL: /);
     });
 
     it("#529: SMS message も InviteMessageTemplate 整合のため Cognito placeholder 込みで置かれるべき", () => {


### PR DESCRIPTION
Closes #903

## Summary

Tenant Admin 招待メール (Cognito 経由) の文面が 4 言語 (JA / EN / ES / ZH) を 1 通に並べる形になっており、 Gmail で改行が collapse して読めない問題があった。 Control Plane System Admin 招待 (Issue #714) と同様に英語のみへ統一する。

## 変更

- \`infrastructure/lib/tenant-template/identity-provider.ts:buildInviteEmailBody()\` を英語単独へ
- subject も \`[TenkaCloud] Tenant Admin Invitation\` 単独へ
- test を英語のみに更新 + regression 防止 (4 言語混在 marker が body に出ない assertion)

## Regression 分析

- 既存 tenant のメール文面が変わる → 招待された Application Admin が受け取るメールの見た目が変わる (UX のみ、 機能は同じ)
- Cognito UserPool template は redeploy で更新される。 既送信メールは影響なし
- 多言語版が将来必要なら CustomMessage Lambda Trigger + SES + \`custom:locale\` 属性 (= 別 issue) で対応する。 現状は SaaS の lingua franca = 英語

## 物理影響

- **UPDATE** (CFn): tenant template stack の \`AWS::Cognito::UserPool\` の \`AdminCreateUserConfig.InviteMessageTemplate.EmailSubject\` / \`EmailMessage\` が更新される
- **NO-OP**: stack 構成 / IAM / 他リソースは変更なし

## Test plan

- [x] \`bun run test test/identity-provider.test.ts\`: 33 件 pass
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: lint + test + cdk synth 全 green

## References

- Issue #714 / commit \`aa39833\` — Control Plane System Admin 招待を英語化した先例
- Issue #660 — paragraph break (\\n\\n) regression の元 (本 PR でも継続維持)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tenant admin invitation emails simplified to English-only format with improved readability. Email structure now uses paragraph-based layout for better presentation, replacing previous multi-language composition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->