### PR TITLE
feat(#899): API reference を Scalar で配信 (admin-console /api-docs.html)

### DIFF
--- a/apps/admin-console/public/api-docs.html
+++ b/apps/admin-console/public/api-docs.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TenkaCloud API — Reference</title>
+    <link rel="icon" href="data:," />
+    <style>
+      html, body { margin: 0; padding: 0; height: 100%; background: #0d1117; }
+      #scalar { height: 100%; }
+    </style>
+  </head>
+  <body>
+    <!--
+      Issue #899: Scalar による interactive API reference。
+      OpenAPI spec は同 origin の /openapi.json から読み込む (= S3 static)。
+      Scalar bundle は CDN から読み込む (no build step、 SPA bundle に混ぜない)。
+      auto-generation from Hono routes は follow-up (= 別 PR)。
+    -->
+    <script
+      id="api-reference"
+      data-url="/openapi.json"
+      data-configuration='{"theme":"deepSpace","layout":"modern","hideDownloadButton":false,"showSidebar":true}'
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>

--- a/apps/admin-console/public/openapi.json
+++ b/apps/admin-console/public/openapi.json
@@ -1,0 +1,289 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "TenkaCloud Control Plane + AdminInsight API",
+    "version": "0.1.0",
+    "description": "TenkaCloud SaaS の System Admin 向け REST API。 Cognito ID token (Bearer) で認証する。 endpoint は admin-console UI からも叩けるが、 同じ API を CI / 自動化 / 外部 dashboard から直接利用するための spec。",
+    "contact": {
+      "name": "TenkaCloud Operations",
+      "url": "https://github.com/susumutomita/TenkaCloud"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": [
+    {
+      "url": "{controlPlaneUrl}",
+      "description": "Control Plane API Gateway (= runtime-config.json の apiUrl)",
+      "variables": {
+        "controlPlaneUrl": {
+          "default": "https://example.execute-api.ap-northeast-1.amazonaws.com/prod",
+          "description": "deploy 後の admin-console runtime-config.json から取得"
+        }
+      }
+    },
+    {
+      "url": "{adminInsightUrl}",
+      "description": "AdminInsight API Gateway (= runtime-config.json の adminInsightApiUrl)",
+      "variables": {
+        "adminInsightUrl": {
+          "default": "https://example.execute-api.ap-northeast-1.amazonaws.com",
+          "description": "deploy 後の admin-console runtime-config.json から取得"
+        }
+      }
+    }
+  ],
+  "security": [{ "cognitoIdToken": [] }],
+  "paths": {
+    "/tenants": {
+      "get": {
+        "summary": "List tenants",
+        "description": "SBT ControlPlane の `GET /tenants`。 System Admin のみ。 全 tenant を返す (pagination は SBT 仕様に依存)。",
+        "tags": ["Tenants"],
+        "responses": {
+          "200": {
+            "description": "Tenants found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Tenant" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      },
+      "post": {
+        "summary": "Create tenant",
+        "description": "SBT ControlPlane の `POST /tenants`。 EventBridge `onboardingRequest` event を発火して per-tenant pipeline を起動する。 PLATINUM tier のみ silo stack が立つ。",
+        "tags": ["Tenants"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["tenantName", "email", "tier"],
+                "properties": {
+                  "tenantName": { "type": "string", "example": "ACME 株式会社" },
+                  "email": { "type": "string", "format": "email", "example": "admin@acme.example" },
+                  "tier": { "type": "string", "enum": ["basic", "advanced", "platinum"] },
+                  "tenantStatus": { "type": "string", "default": "In progress" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tenant created (= onboarding 開始)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/Tenant" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/tenants/{tenantId}": {
+      "delete": {
+        "summary": "Deprovision tenant",
+        "description": "SBT ControlPlane の `DELETE /tenants/{tenantId}`。 EventBridge `offboardingRequest` event を発火、 isActive=false に倒し silo stack を destroy する。",
+        "tags": ["Tenants"],
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "tenant の ULID または \"pooled\""
+          }
+        ],
+        "responses": {
+          "200": { "description": "Tenant deprovision started" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/admin/insight/tenants/summary": {
+      "get": {
+        "summary": "Tenants insight summary",
+        "description": "tenant 一覧 page で deploy aggregate (activeDeploys / failedDeploys) を表示するための endpoint。 `tenantIds` query で対象を絞れる。 System Admin (= `cognito:groups` に SystemAdmin が必要)。",
+        "tags": ["AdminInsight"],
+        "parameters": [
+          {
+            "name": "tenantIds",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "comma-separated tenant ID (例: t-1,t-2,t-3)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-tenant deploy aggregate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TenantInsightSummary" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/admin/insight/pipeline-executions": {
+      "get": {
+        "summary": "Recent CodePipeline executions",
+        "description": "`tenkacloud-saas-pipeline` の execution 履歴を取得する。 admin-console の \"Provisioning Jobs\" page が 60s polling で叩く。",
+        "tags": ["AdminInsight"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline executions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pipelineName": { "type": "string" },
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PipelineExecution" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "cognitoIdToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Cognito ID token (= application-admin-console の AuthProvider が発行する idToken)。 `Authorization: Bearer <token>` で送る。"
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Bearer token が無いか invalid",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "SystemAdmin group ではない",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "対象リソースが存在しない",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Tenant": {
+        "type": "object",
+        "properties": {
+          "tenantId": { "type": "string", "example": "01HX..." },
+          "tenantName": { "type": "string", "example": "ACME 株式会社" },
+          "email": { "type": "string", "format": "email" },
+          "tier": { "type": "string", "enum": ["basic", "advanced", "platinum"] },
+          "tenantStatus": { "type": "string", "example": "In progress" },
+          "isActive": { "type": "boolean", "default": true }
+        }
+      },
+      "TenantInsightSummary": {
+        "type": "object",
+        "properties": {
+          "tenantId": { "type": "string" },
+          "activeDeploys": { "type": "integer", "minimum": 0 },
+          "failedDeploys": { "type": "integer", "minimum": 0 },
+          "totalEvents": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "PipelineExecution": {
+        "type": "object",
+        "properties": {
+          "executionId": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": [
+              "InProgress",
+              "Succeeded",
+              "Failed",
+              "Cancelled",
+              "Stopped",
+              "Stopping",
+              "Superseded"
+            ]
+          },
+          "startTimeIso": { "type": "string", "format": "date-time" },
+          "lastUpdateTimeIso": { "type": "string", "format": "date-time" },
+          "consoleUrl": { "type": "string", "format": "uri" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string", "description": "error code (= snake_case)" }
+        }
+      }
+    }
+  },
+  "tags": [
+    { "name": "Tenants", "description": "SBT ControlPlane が提供する tenant CRUD" },
+    { "name": "AdminInsight", "description": "tenant 横断の集計 / drill-down endpoint (= ADR-011)" }
+  ]
+}

--- a/apps/admin-console/src/components/AppLayout.tsx
+++ b/apps/admin-console/src/components/AppLayout.tsx
@@ -64,6 +64,15 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/tenants", text: t("nav.tenants") },
               { type: "link", href: "/tenants/new", text: t("nav.tenants_new") },
               { type: "link", href: "/jobs", text: t("nav.jobs") },
+              { type: "divider" },
+              // Issue #899: Scalar による API reference。 同 origin の static file (public/api-docs.html)
+              // へ external link。 SPA route と分離 (= API spec を SPA bundle に混ぜない)。
+              {
+                type: "link",
+                href: "/api-docs.html",
+                text: t("nav.api_docs"),
+                external: true,
+              },
             ]}
             onFollow={(e) => {
               if (!e.detail.external) {

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -10,7 +10,8 @@
     "menu": "Admin menu",
     "tenants": "Tenants",
     "tenants_new": "Create tenant",
-    "jobs": "Provisioning Jobs"
+    "jobs": "Provisioning Jobs",
+    "api_docs": "API Reference ↗"
   },
   "auth": {
     "sign_out": "Sign out"

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -10,7 +10,8 @@
     "menu": "Menú de administración",
     "tenants": "Tenants",
     "tenants_new": "Crear tenant",
-    "jobs": "Trabajos de aprovisionamiento"
+    "jobs": "Trabajos de aprovisionamiento",
+    "api_docs": "Referencia de API ↗"
   },
   "auth": {
     "sign_out": "Cerrar sesión"

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -10,7 +10,8 @@
     "menu": "管理メニュー",
     "tenants": "テナント一覧",
     "tenants_new": "テナント作成",
-    "jobs": "プロビジョニング Jobs"
+    "jobs": "プロビジョニング Jobs",
+    "api_docs": "API リファレンス ↗"
   },
   "auth": {
     "sign_out": "サインアウト"

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -10,7 +10,8 @@
     "menu": "管理菜单",
     "tenants": "租户列表",
     "tenants_new": "创建租户",
-    "jobs": "配置作业"
+    "jobs": "配置作业",
+    "api_docs": "API 参考 ↗"
   },
   "auth": {
     "sign_out": "退出登录"

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -89,16 +89,18 @@ export class AdminConsoleHostingStack extends cdk.Stack {
     const oai = new OriginAccessIdentity(this, "OAI");
     bucket.grantRead(oai);
 
-    // Issue #855 + #896: CloudFront に security headers (HSTS / CSP / X-Frame-Options 等) を強制。
-    // admin-console は次の 3 経路に fetch する。 すべて allow-list に列挙する (= 漏れは
-    // ブラウザの \"Refused to connect by CSP\" を発生させ Provisioning Jobs 等を壊す):
+    // Issue #855 + #896 + #899: CloudFront に security headers (HSTS / CSP / X-Frame-Options 等)
+    // を強制。 admin-console は次の経路に fetch する:
     //   - props.apiUrl              : Control Plane API GW (= tenant CRUD)
     //   - props.cognitoDomain       : Cognito OAuth (/oauth2/token /authorize /revoke /logout)
     //   - props.adminInsightApiUrl  : AdminInsight API GW (= Provisioning Jobs / TenantDrillDown)
+    //   - cdn.jsdelivr.net          : Issue #899 — Scalar API reference を CDN から読み込む
+    //                                 (public/api-docs.html、 SPA bundle に混ぜない方針)
     // form-action は Cognito Hosted UI への sign-in form 投稿で使う。
     const securityHeaders = buildSecurityHeadersPolicy(this, "SecurityHeaders", {
       connectSrcAllowedOrigins: [props.apiUrl, props.cognitoDomain, props.adminInsightApiUrl],
       formActionAllowedOrigins: [props.cognitoDomain],
+      additionalScriptSrcs: ["https://cdn.jsdelivr.net"],
     });
 
     const distribution = new Distribution(this, "Distribution", {

--- a/infrastructure/lib/security/cloudfront-headers.ts
+++ b/infrastructure/lib/security/cloudfront-headers.ts
@@ -50,6 +50,12 @@ export interface SecurityHeadersOptions {
    * production では必ず false にする。 default false。
    */
   readonly allowUnsafeEval?: boolean;
+  /**
+   * Issue #899: SPA 内で外部 CDN 由来の script を読み込む場合の追加 allow-list。
+   * 例: API reference (Scalar) を CDN から読み込むときの \`https://cdn.jsdelivr.net\`。
+   * 同時に \`style-src\` にも追加 (Scalar が inline 風 CSS を出すため一部 CDN style も必要)。
+   */
+  readonly additionalScriptSrcs?: readonly string[];
 }
 
 /**
@@ -91,13 +97,17 @@ export function buildSecurityHeadersPolicy(
  * CSP 文字列を組み立てる pure helper。 test しやすい (= options で挙動が決まる)。
  */
 export function buildContentSecurityPolicy(opts: SecurityHeadersOptions = {}): string {
-  const connectSrc = ["'self'", ...(opts.connectSrcAllowedOrigins ?? [])];
+  const additionalScripts = opts.additionalScriptSrcs ?? [];
+  const connectSrc = ["'self'", ...(opts.connectSrcAllowedOrigins ?? []), ...additionalScripts];
   const formAction = ["'self'", ...(opts.formActionAllowedOrigins ?? [])];
-  const scriptSrc = opts.allowUnsafeEval ? ["'self'", "'unsafe-eval'"] : ["'self'"];
+  const scriptSrc = opts.allowUnsafeEval
+    ? ["'self'", "'unsafe-eval'", ...additionalScripts]
+    : ["'self'", ...additionalScripts];
+  const styleSrc = ["'self'", "'unsafe-inline'", ...additionalScripts];
   const directives: readonly string[] = [
     "default-src 'self'",
     `script-src ${scriptSrc.join(" ")}`,
-    "style-src 'self' 'unsafe-inline'",
+    `style-src ${styleSrc.join(" ")}`,
     "img-src 'self' data:",
     "font-src 'self' data:",
     `connect-src ${connectSrc.join(" ")}`,

--- a/infrastructure/test/security/cloudfront-headers.test.ts
+++ b/infrastructure/test/security/cloudfront-headers.test.ts
@@ -54,6 +54,15 @@ describe("buildContentSecurityPolicy (pure helper)", () => {
   it("frame-ancestors 'none' が含まれる (= clickjacking 防御の主経路)", () => {
     expect(buildContentSecurityPolicy()).toContain("frame-ancestors 'none'");
   });
+
+  it("Issue #899: additionalScriptSrcs を script-src / style-src / connect-src に追加するべき", () => {
+    const csp = buildContentSecurityPolicy({
+      additionalScriptSrcs: ["https://cdn.jsdelivr.net"],
+    });
+    expect(csp).toContain("script-src 'self' https://cdn.jsdelivr.net");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net");
+    expect(csp).toContain("connect-src 'self' https://cdn.jsdelivr.net");
+  });
 });
 
 describe("buildSecurityHeadersPolicy (CDK ResponseHeadersPolicy synth)", () => {


### PR DESCRIPTION
Closes #899

## Summary

ユーザーから \"API docs リンクが無いから API を自動化で叩く方法が分からない\" + \"度肝を抜くモダンな画面で\" の要望。 **Scalar** (Open Source、 最新の OpenAPI viewer) を採用、 admin-console から external link で配信する。

## 何が見られるか

- admin-console nav に \"API Reference ↗\" 追加
- リンク先 \`/api-docs.html\` で **Scalar Deep Space theme** の interactive viewer 表示
- 4 endpoint を文書化:
  - \`GET /tenants\` (Control Plane)
  - \`POST /tenants\` (Control Plane)
  - \`DELETE /tenants/{tenantId}\` (Control Plane)
  - \`GET /admin/insight/tenants/summary\` (AdminInsight)
  - \`GET /admin/insight/pipeline-executions\` (AdminInsight)
- 認証: Cognito ID token (Bearer)、 try-it-out 可能

## アーキテクチャ判断

- **PoC scope = hand-authored OpenAPI spec**: 自動生成 (zod-openapi from Hono routes) は drift を防ぐが、 PoC で完成型を見せたいので spec は手書き。 follow-up issue で route → spec 自動同期を入れる
- **Scalar bundle は CDN (cdn.jsdelivr.net) から**: SPA bundle に混ぜると admin-console の dist size が膨らむため、 API docs は別 page (= public/api-docs.html) で外部 script load。 CSP に \`https://cdn.jsdelivr.net\` を script-src / style-src / connect-src に追加 (Issue #855 セキュリティ headers の \`additionalScriptSrcs\` option で渡す)
- **同 origin で配信**: 別 CloudFront を立てない (= admin-console と同じ S3 + CloudFront)。 SystemAdmin が見られればよく、 public access も問題ない

## Regression 分析

- 新規 page + nav item の追加のみ、 既存 page 挙動は不変
- CSP に jsdelivr.net が増える → SPA bundle 内から jsdelivr の script を読み込めるようになる (本来は \`public/api-docs.html\` 以外では使わないが、 CSP は path 単位で分けられないため admin-console 全体で許可)
- security tradeoff: jsdelivr.net は信頼できる CDN だが supply chain 攻撃面が広がる。 mitigation として **Scalar の Subresource Integrity (SRI)** を follow-up で追加すべき
- 既存 \`buildContentSecurityPolicy\` 呼び出し元は \`additionalScriptSrcs\` を渡さなければ従来通り (= default で undefined / 配列展開で空)

## 物理影響

- **UPDATE** (CFn): \`AdminConsoleHostingStack\` の \`ResponseHeadersPolicy\` の CSP が更新
- **NEW** (S3 objects): \`api-docs.html\`、 \`openapi.json\` を S3 にアップロード
- **UPDATE** (S3 objects): admin-console の bundle (= nav 変更)

## Test plan

- [x] \`bun run test\` 全 workspace pass (= 126 件 admin-console、 1054 件 infrastructure)
- [x] cdk synth pass
- [x] make harness pass
- [ ] **手動確認**: deploy 後に admin-console nav から \"API Reference ↗\" をクリックして Scalar 画面が出ること、 spec が dark theme で render されること

## Follow-up issues

- Scalar bundle の **SRI 化** (supply chain 攻撃面の縮減)
- **zod-openapi での auto-generation** (Hono route と spec の drift 防止)
- **AdminInsight 以外の API** (problem-deploy / tenant API / participant-portal API) の spec 追加
- application-admin-console / participant-portal 側にも同経路で API docs を追加

## References

- Issue #899 — API docs リンクが無い + Scalar / Swagger / Redoc どれかの user 質問
- Scalar OSS: <https://github.com/scalar/scalar>
- CSP `additionalScriptSrcs` は本 PR で初めて使われる新 option (= 既存 CSP 設計の最小拡張)