### PR TITLE
feat(#895): Phase 2.A — CFn stack tagging foundation for Distributed Map

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -88,6 +88,13 @@ export class DeployCreateStateMachine extends Construct {
     // Phase 2.2 (Issue #459): AssumeRole metadata は 2 fields が両方あるときだけ
     // CodeBuild env に渡す。Step Functions の optional path 直接参照は field 欠落時に
     // States.Runtime で即死するため、Choice で cross-account / same-account を明示分岐する。
+    //
+    // Issue #895 Phase 2.A: ADR-001 §6 の stack tagging に必要な tenantId / jobId /
+    // batchId を CodeBuild env に渡す。 deploy-battles.sh が `cloudformation deploy --tags`
+    // に展開し、 operator が `cloudformation:ListStacks` + tag filter で batch を逆引き
+    // できるようにする。 batchId は bulk 発火 (= 同一 event で N×M 個の deploy を撒く
+    // ケース) で 1 batch を識別する。 単発 / authoring iteration では未指定 = jobId と
+    // 同値 fallback で扱う (= deploy-battles.sh 側で fallback)。
     const startCodeBuildSameAccount = new CodeBuildStartBuild(this, "StartDeployCodeBuild", {
       project: props.codeBuildProject,
       integrationPattern: IntegrationPattern.RUN_JOB,
@@ -97,6 +104,8 @@ export class DeployCreateStateMachine extends Construct {
         DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
         PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
         TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+        TENKACLOUD_TENANT_ID: { value: JsonPath.stringAt("$.detail.tenantId") },
+        TENKACLOUD_JOB_ID: { value: JsonPath.stringAt("$.detail.jobId") },
       },
       resultPath: "$.codebuild",
     });
@@ -113,6 +122,8 @@ export class DeployCreateStateMachine extends Construct {
           DEPLOY_REGION: { value: JsonPath.stringAt("$.detail.region") },
           PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
+          TENKACLOUD_TENANT_ID: { value: JsonPath.stringAt("$.detail.tenantId") },
+          TENKACLOUD_JOB_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           COMPETITOR_ROLE_ARN: {
             value: JsonPath.stringAt("$.detail.competitorRoleArn"),
           },

--- a/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
@@ -110,4 +110,29 @@ describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => 
       }),
     );
   });
+
+  // Issue #895 Phase 2.A: ADR-001 §6 の stack tagging に必要な tenantId / jobId を
+  // CodeBuild env に渡す経路の regression test。 これらが欠けると deploy-battles.sh が
+  // tag 値を \"unknown\" にして CFn → tenant 逆引きが効かなくなる。
+  it("Issue #895: CodeBuild env に TENKACLOUD_TENANT_ID / TENKACLOUD_JOB_ID が渡されるべき", () => {
+    const { template } = buildTestStack();
+    const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
+    const sm = Object.values(stateMachines)[0];
+    const definitionString = sm?.Properties?.DefinitionString;
+    let asJson: string;
+    if (typeof definitionString === "string") {
+      asJson = definitionString;
+    } else {
+      const join = definitionString["Fn::Join"];
+      const parts = join[1] as Array<string | Record<string, unknown>>;
+      asJson = parts.map((p) => (typeof p === "string" ? p : "ARN_PLACEHOLDER")).join("");
+    }
+    // ASL 上 EnvironmentVariablesOverride は `Name / Type / Value.$` 形式。
+    expect(asJson).toContain('"Name":"TENKACLOUD_TENANT_ID"');
+    expect(asJson).toContain('"Value.$":"$.detail.tenantId"');
+    expect(asJson).toContain('"Name":"TENKACLOUD_JOB_ID"');
+    // 既存 TENKACLOUD_CORRELATION_ID と PROBLEM_EXTERNAL_ID も維持されているべき (regression 防止)
+    expect(asJson).toContain('"Name":"TENKACLOUD_CORRELATION_ID"');
+    expect(asJson).toContain('"Name":"PROBLEM_EXTERNAL_ID"');
+  });
 });

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -191,6 +191,17 @@ deploy_one() {
   #   - stack が無ければ Create
   #   - stack があれば Update (差分が無ければ "No changes" で 0 終了)
   #   - --no-fail-on-empty-changeset で「差分無し」を成功扱いにする (rerun 時の運用上の都合)
+  #
+  # Issue #895 Phase 2.A (ADR-001 §6): stack カタログ用 tag を打つ。 operator が
+  # `cloudformation:ListStacks` / Resource Groups Tagging API で次の用途で逆引きできる:
+  #   - TenantId    : tenant 別の deploy 一覧
+  #   - JobId       : 1 deploy = 1 job、 retry / drill-down の identity
+  #   - BatchId     : bulk 発火 (= 同一 event の N×M 個 deploy) のグルーピング、
+  #                   未指定なら JobId と同値 fallback (= 単発 / authoring iteration)
+  # 既存 NamePrefix / Problem / TeamSlug / DeployedBy tag は維持する (旧 operator UI 互換)。
+  TENKACLOUD_TENANT_ID="${TENKACLOUD_TENANT_ID:-unknown}"
+  TENKACLOUD_JOB_ID="${TENKACLOUD_JOB_ID:-${TENKACLOUD_CORRELATION_ID:-unknown}}"
+  TENKACLOUD_BATCH_ID="${TENKACLOUD_BATCH_ID:-${TENKACLOUD_JOB_ID}}"
   if ! aws cloudformation deploy \
     --region "${AWS_REGION}" \
     --stack-name "${name_prefix}" \
@@ -201,7 +212,11 @@ deploy_one() {
     --tags \
       "TenkaCloud:NamePrefix=${name_prefix}" \
       "TenkaCloud:Problem=${problem_slug}" \
+      "TenkaCloud:ProblemId=${problem_slug}" \
       "TenkaCloud:TeamSlug=${TEAM_SLUG}" \
+      "TenkaCloud:TenantId=${TENKACLOUD_TENANT_ID}" \
+      "TenkaCloud:JobId=${TENKACLOUD_JOB_ID}" \
+      "TenkaCloud:BatchId=${TENKACLOUD_BATCH_ID}" \
       "TenkaCloud:DeployedBy=deploy-battles.sh"; then
     trace_log "deploy.cfn.deploy.failed" stackName "${name_prefix}" region "${AWS_REGION}" teamSlug "${TEAM_SLUG}" problemDir "${problem_dir}"
     echo "error: CloudFormation deploy failed for ${name_prefix}" >&2


### PR DESCRIPTION
Refs #895 (= phase 化、 残 phase は sub-issue で track)

## Summary

Issue #895 (ADR-001 Phase 2 Distributed Map 並列化) を **A〜E の 5 phase** に分けて着手。 本 PR は **Phase 2.A — stack tagging foundation** のみ。

ADR-001 §6 が要求する CFn stack の \`TenantId\` / \`JobId\` / \`BatchId\` Tag が欠けていた。 これが無いと:
- \`cloudformation:ListStacks\` + tag filter で tenant 別 deploy 逆引き不可
- bulk batch (= Phase 2 で導入する Distributed Map iteration) で 1 batch を識別する key 無し → retry API 実装不可
- cross-account で \`resource-groups:GetResources\` の tag filter で競技者 account の stack カタログ不可

本 phase はこの基盤だけを入れる。 後続 phase が必要とする dependency を作る。

## 変更

| file | 変更 |
|---|---|
| \`infrastructure/lib/problem-deploy/deploy-create-state-machine.ts\` | CodeBuild env に \`TENKACLOUD_TENANT_ID\` / \`TENKACLOUD_JOB_ID\` を追加 (same-account / cross-account 両分岐) |
| \`scripts/deploy-battles.sh\` | \`--tags\` に \`TenkaCloud:TenantId\` / \`:ProblemId\` / \`:JobId\` / \`:BatchId\` を追加。 既存 tag (\`NamePrefix\` / \`Problem\` / \`TeamSlug\` / \`DeployedBy\`) は維持 |
| \`infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts\` | ASL serialization で env vars が含まれることを assert (regression 防止) |

## 後続 phase (= 別 sub-issue / 別 PR)

| phase | scope | 規模 |
|---|---|---|
| **2.B** | \`DeployUpdateStateMachine\` / \`DeployDeleteStateMachine\` を新設 (ADR-001 §2) | 中 |
| **2.C** | \`POST /events/:id/deploy\` の fan-out を Distributed Map iterator に置換 (= API + bulk-deploy handler refactor) | 大 |
| **2.D** | \`POST /deployments/retry\` 失敗 item 再投入 API | 中 |
| **2.E** | cross-account の Resource Groups Tagging API への切替検討 (ADR-001 §6 (a)) | 小 (検討のみ) |

各 phase 用の sub-issue を本 PR とあわせて立てる予定。 親 #895 は全 phase の完了で close する。

## Regression 分析

- 既存挙動 (= 1 event → 1 CodeBuild → 1 CFn deploy → 1 stack) は不変
- 既存 stack tags (NamePrefix / Problem / TeamSlug / DeployedBy) は維持。 旧 operator UI / `cloudformation describe-stacks` 経由の 既存 query は 変わらず動作
- 既存 deploy (= タグ未付与の旧 stack) は本 PR の deploy 後の \`aws cloudformation deploy\` の冪等 update で **追加 tag が反映される**。 stack 自体は REPLACE されず、 in-place tag update
- env var 未注入の dev / local 実行は \`unknown\` fallback (= deploy-battles.sh で安全側に倒す)

## 物理影響

- **UPDATE** (CFn): \`tenkacloud-problem-deploy/DeployCreate/StateMachine\` の DefinitionString に env var 2 個追加
- **UPDATE** (runtime): 新規 deploy 実行 (= bash script) で stack に tag が 4 個追加 (= AWS CFn StackTags)
- **NO-OP**: Step Functions Role / IAM / Lambda は不変

## Test plan

- [x] \`bun run test\` 全 workspace pass (= 1627 件 total)
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: lint + cdk synth + audit-deps green

## References

- [ADR-001 §6 stack カタログ](../docs/architecture/adr-001-problem-deploy-crud.html) — Tag 要件の正本
- Issue #895 — 親 issue (= 残 phase の完了で close)