### PR TITLE
fix(scripts): provision-tenant.sh の "package.json not found" — 2 ヶ月物の regression を解消

### DIFF
--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -214,6 +214,10 @@ export function TenantListPage({ config }: { config: AppConfig }) {
               );
               if (!isInProgress(row.tenantStatus)) return badge;
               const progress = computeTenantProgress({ createdAt: row.createdAt, nowMs });
+              // createdAt 未取得 (= SBT が field を返さない、 fresh tenant の race) のとき
+              // \`progress.label === \"—\"\` が出る。 細い em dash が badge 下に \"_\" のように
+              // 見えて誤解を生むので、 そのときは badge のみ表示する。
+              if (progress.label === "—") return badge;
               const progressColor =
                 progress.severity === "danger"
                   ? "text-status-error"

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -31,4 +31,12 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
     expect(exportIdx).toBeGreaterThan(0);
     expect(deployIdx).toBeGreaterThan(exportIdx);
   });
+
+  // tenant provisioning / update CodeBuild job が `scripts/lib/install-node.sh:
+  // install_bun_from_package_manager` で CWD/`package.json` の `packageManager` field から
+  // Bun version を読む。 install.sh が staging root に `package.json` を copy していないと
+  // ENOENT で CodeBuild job が \"package.json not found\" で fail する (= 直近 regression)。
+  it("staging root に repo root `package.json` を copy すべき (= CodeBuild が packageManager を読む)", () => {
+    expect(source).toContain('cp "${TenkaCloud_ROOT}/package.json" "${STAGING}/package.json"');
+  });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,6 +86,11 @@ cp -R problems "${STAGING}/problems"
 # `.nvmrc` を staging root に同梱 (= source of truth、CodeBuild 内 provision/update-tenant.sh が
 # `nvm install $(cat .nvmrc)` で参照する)。repo root から copy。
 cp "${TenkaCloud_ROOT}/.nvmrc" "${STAGING}/.nvmrc"
+# repo root `package.json` を staging root に同梱。 CodeBuild 内
+# `scripts/lib/install-node.sh:install_bun_from_package_manager` が CWD/`package.json` の
+# `packageManager: "bun@<version>"` field から Bun version を読む。 無いと ENOENT で
+# tenant provisioning / update CodeBuild job が fail する (= "package.json not found")。
+cp "${TenkaCloud_ROOT}/package.json" "${STAGING}/package.json"
 # 旧 ref-arch では src/ を staging に含めていたが、#76 で
 # infrastructure/lib/tenant-pipeline/handlers/ に移動済 (cdk/ 配下に同梱されるので不要)。
 


### PR DESCRIPTION
## Symptom (= user report)

新規 tenant 作成すると admin-console の \"In progress\" のまま永久に進まない。 SBT BashJobRunner の CodeBuild Job を見ると次の error で fail:

\`\`\`
+ install_bun_from_package_manager
++ node -e ... readFileSync('package.json', 'utf8') ...
Error: ENOENT: no such file or directory, open 'package.json'
\`\`\`

application-admin-console に sign-in しても \`API 403: forbidden_role\` で Event 一覧が取れない (= provision-tenant.sh の \`admin-create-user\` が走らず TenantAdmin role を持つ user が作られていない、 二次症状)。

## Root cause

PR #775 (\`fix: use bunx for tenant pipeline cdk\`、 2 ヶ月前) で \`scripts/lib/install-node.sh:install_bun_from_package_manager\` を追加した際、 同関数が **CWD の \`package.json\`** から \`packageManager: \"bun@<version>\"\` field を読む実装になっていた。 しかし \`install.sh\` の staging logic は STAGING root に **root \`package.json\` を copy していなかった**。 source.zip 配下に \`package.json\` (= TenkaCloud monorepo root の) が存在しないので CodeBuild 内で常に ENOENT。

2 ヶ月間気付かれなかった理由: tenant pipeline CodeBuild は 1 度 build できれば cached image / cached node_modules で次回も成立する可能性 + 個別 tenant 作成 frequency が低かったため。

## Fix

\`scripts/install.sh\` の staging block に 1 行追加:

\`\`\`bash
cp \"\${TenkaCloud_ROOT}/package.json\" \"\${STAGING}/package.json\"
\`\`\`

これで source.zip の root に \`package.json\` が入り、 CodeBuild の \`install_bun_from_package_manager\` が \`packageManager: \"bun@1.3.11\"\` field を読めるようになる。

regression 再発防止のため \`infrastructure/test/install-script.test.ts\` に assertion を追加 (= \`source\` 文字列に \`cp "\${TenkaCloud_ROOT}/package.json"\` を含むこと)。

## Bonus fix: TenantList の \"_\" 表示 artifact

admin-console の TenantList で \"In progress\" badge の下に細い水色の \`_\` が見える件: \`computeTenantProgress\` が \`createdAt\` 未取得時に \`label: \"—\"\` (em dash) を返し、 \`<Box variant=\"small\">\` で render されると小さな水平線に見えていた。 label が \"—\" のときは badge だけ表示するよう gate。

## Regression / 二次影響の解消経路

1. 本 PR で install.sh 修正 + main merge
2. user が \`make deploy\` を再実行 → tenant pipeline の CodeBuild Project が更新 source.zip を読む
3. 既存 \"In progress\" tenant は **deprovision してから再 create** する必要あり (= CodeBuild Job が新 source.zip で走り、 admin-create-user が成功 → TenantAdmin role 付与 → 403 forbidden_role も解消)

## Test plan

- [x] \`bun run test test/install-script.test.ts\`: 3 件 pass (= 新 assertion + 既存 2 件)
- [x] \`bun run test\` admin-console: 126 件 pass
- [x] \`make before-commit\`: full green (= lint + test + cdk synth + audit-deps)
- [x] \`make harness\`: 0 findings

## References

- PR #775 — \`install_bun_from_package_manager\` を追加した元 PR (= 本 regression の trigger)
- CodeBuild error log (= user 提供):
\`\`\`
Error: ENOENT: no such file or directory, open 'package.json'
    at Object.readFileSync (node:fs:440:20)
\`\`\`