### PR TITLE
docs(#912): ADR-019 — cross-account stack catalog は platform DDB を真実源にする

### DIFF
--- a/docs/architecture/adr-019-cross-account-stack-catalog.html
+++ b/docs/architecture/adr-019-cross-account-stack-catalog.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-019: cross-account 問題 deploy stack のカタログ化 — Resource Groups Tagging API は採用せず、 platform DDB を single source of truth に据える</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .callout { padding: .8rem 1rem; border-left: 4px solid var(--c-warn); background: #fff8c5; border-radius: 3px; margin: 1rem 0; }
+  .callout.danger { border-color: var(--c-reject); background: #ffe9e9; }
+  .callout.info { border-color: var(--c-link); background: #ddf4ff; }
+</style>
+</head>
+<body>
+
+<h1>ADR-019: cross-account 問題 deploy stack のカタログ化 — Resource Groups Tagging API は採用せず、 platform DDB を single source of truth に据える</h1>
+
+<div class="meta">
+  <div><b>Status:</b><span class="badge accept">Accepted</span> 2026-05-17</div>
+  <div><b>Supersedes:</b> (なし)</div>
+  <div><b>Superseded-by:</b> (なし)</div>
+  <div><b>Related:</b> <a href="adr-001-problem-deploy-crud.html">ADR-001</a> §6 (stack カタログ 2 案)</div>
+</div>
+
+<h2>1. Context</h2>
+
+<p>ADR-001 §6 は \"operator が cross-account で deploy された問題 stack をどう逆引きするか\" に対して 2 案を提示していた:</p>
+
+<table>
+  <tr><th>案</th><th>方法</th><th>必要な要素</th></tr>
+  <tr>
+    <td>(a)</td>
+    <td>競技者 account に AssumeRole → <code>resource-groups:GetResources</code> (= Resource Groups Tagging API、 tag filter native 対応) を fan-out</td>
+    <td>competitor-bootstrap.yaml の IAM Role に <code>tag:GetResources</code> 追加、 platform 側 fan-out Lambda、 並列度 / RPS 制御</td>
+  </tr>
+  <tr>
+    <td>(b)</td>
+    <td><code>cloudformation:ListStacks</code> + client-side filter (= tag を取得してから絞る)</td>
+    <td>競技者 account に AssumeRole → <code>cloudformation:ListStacks</code> + <code>DescribeStacks</code> で tag を 1 stack ずつ取得</td>
+  </tr>
+</table>
+
+<p>ADR-001 は MVP 段階 (= 同一 account 内) で (b) を選択した。 Issue #912 (#895 Phase 2.E) は \"cross-account になったとき (a) に切替検討\" を要求していた。 Phase 2.A (PR #908) で stack に <code>TenkaCloud:TenantId</code> / <code>JobId</code> / <code>BatchId</code> tag が打たれるようになった今、 改めて (a) / (b) / 第 3 の案を評価する。</p>
+
+<h2>2. Decision</h2>
+
+<table>
+  <tr><th style="width:18%">decision</th><th>本 ADR の結論</th></tr>
+  <tr>
+    <td><b>D1</b></td>
+    <td><b>Resource Groups Tagging API (= 案 a) は採用しない</b>。 platform 側 DDB (= Deployments テーブル) を stack カタログの <b>single source of truth</b> として運用する。</td>
+  </tr>
+  <tr>
+    <td><b>D2</b></td>
+    <td>Phase 2.A で打った CFn tag (<code>TenkaCloud:TenantId</code> / <code>JobId</code> / <code>BatchId</code> / <code>ProblemId</code>) は <b>競技者 account 側の debug 補助</b> として残す (= operator が competitor account の console で stack を探すとき identify できる)。 platform 側の逆引き経路には依存しない。</td>
+  </tr>
+  <tr>
+    <td><b>D3</b></td>
+    <td>platform 側 DDB の \"stack 所在カタログ\" responsibility は <code>Deployments</code> テーブルが既に担っている (= <code>tenantId</code> / <code>jobId</code> / <code>stackId</code> / <code>region</code> / <code>awsAccountId</code> が row として書かれる)。 別 catalog テーブルを新設しない。</td>
+  </tr>
+  <tr>
+    <td><b>D4</b></td>
+    <td><b>re-evaluate trigger</b>: 次のいずれかが起きたら本 ADR を見直し:<br>
+      (a) platform DDB と competitor account 上 stack の <b>drift 検出</b> が要件化された (= operator が \"DDB には無いけど stack が残ってる\" 経路を発見したい場合)<br>
+      (b) Disruption / Red Team 系で \"competitor account 内の任意リソース (= stack 経由以外で作られたもの) を tag で全集計\" が必要になった<br>
+      (c) AWS が tag filter の cross-region / cross-account 集約 API を出した
+    </td>
+  </tr>
+</table>
+
+<h2>3. Resource Groups Tagging API を採用しない理由 (= D1 の根拠)</h2>
+
+<h3>3.1 platform は既に書いた deploy を全件知っている</h3>
+
+<p>競技者 account 上の stack は <b>全て platform 側の <code>POST /deployments</code> / Step Functions 経由</b>で作られる。 操作主が platform 自身なので、 <b>platform は何を deploy したか完璧に知っている</b>。 deploy ごとに <code>Deployments</code> DDB に row が書かれる (= jobId / tenantId / awsAccountId / region / stackId / status):</p>
+
+<pre>
+PK = "DEPLOYMENT#&lt;jobId&gt;"
+SK = "META"
+{
+  jobId, tenantId, awsAccountId, region,
+  stackId, status, createdAt, updatedAt, problemId, ...
+}
+</pre>
+
+<p>operator が \"tenant A の deploy 一覧が欲しい\" と問い合わせるとき、 <code>Deployments</code> を <code>tenantId</code> GSI で query するだけで完結。 競技者 account に AssumeRole する必要が無い。</p>
+
+<h3>3.2 Resource Groups Tagging API は <b>真実源として劣る</b></h3>
+
+<table>
+  <tr><th>観点</th><th>platform DDB (D1 採用)</th><th>Resource Groups Tagging API (案 a)</th></tr>
+  <tr>
+    <td>整合性</td>
+    <td>platform が write したものを read。 race / lag 無し</td>
+    <td>tag indexing は <b>eventual consistency (~3 分 lag)</b>。 stack 作成直後の query で見えない</td>
+  </tr>
+  <tr>
+    <td>cost</td>
+    <td>DDB query = 1 RCU / query (= 1/1 PROVISIONED で運用)</td>
+    <td>per-account AssumeRole + <code>GetResources</code> call、 API request charge + STS cost、 並列化で linear に増える</td>
+  </tr>
+  <tr>
+    <td>latency</td>
+    <td>~10 ms (= DDB 1 query)</td>
+    <td>~500 ms-数秒 (= AssumeRole + GetResources、 account 数で線形)</td>
+  </tr>
+  <tr>
+    <td>IAM 表面積</td>
+    <td>variant なし (= 既存の <code>dynamodb:Query</code> のみ)</td>
+    <td>competitor account 側 IAM Role に <code>tag:GetResources</code> 追加が必要 (= bootstrap.yaml mutation = 全競技者再 deploy)</td>
+  </tr>
+  <tr>
+    <td>失敗モード</td>
+    <td>DDB throttle / row 欠落 (= platform write 失敗)</td>
+    <td>AssumeRole 失敗 / GetResources rate limit / 競技者の Role 削除 / tag service 障害</td>
+  </tr>
+</table>
+
+<p>= 真実源として platform DDB が strictly 優位。</p>
+
+<h3>3.3 単独問題: \"platform DDB に無いけど stack が残っている\" drift</h3>
+
+<p>唯一の使い道は \"platform DDB と stack の drift 検出\" = orphan stack の発見。 これは:</p>
+
+<ul>
+  <li>頻度: 非常に低い (= deploy 経路を経由しない stack 作成は cross-account では原理上不可)</li>
+  <li>必要性: operator が手で competitor account console を見れば足りる (= 緊急対応の領域)</li>
+  <li>cost: 全競技者に対して定期 audit する場合、 上の表の cost を毎回払う</li>
+</ul>
+
+<p>= ROI が見合わない。 drift が問題化したら別途専用 audit Lambda を立てる (= 6 ヶ月後 review)。</p>
+
+<h2>4. CFn stack tag の役割 (= D2)</h2>
+
+<p>Phase 2.A で打った tag (= <code>TenkaCloud:TenantId</code> / <code>JobId</code> / <code>BatchId</code> / <code>ProblemId</code>) は本 ADR の D1 で <b>platform 側 query 経路として依存しない</b>。 では何のために打つか:</p>
+
+<ul>
+  <li><b>competitor 側 operator 補助</b>: 競技者が AWS console で自 account を見たとき、 stack tag から \"これが TenkaCloud platform から来たもの\" + \"自分の team / problem 識別子\" を即座に見られる</li>
+  <li><b>incident 時の AssumeRole なし audit</b>: platform DDB が完全 down のとき、 competitor 自身が console で全 TenkaCloud stack を tag filter で identify できる (= self-service)</li>
+  <li><b>billing tagging</b>: 競技者組織が AWS cost allocation tag を有効化していれば、 TenkaCloud 由来 stack の cost を分離できる</li>
+</ul>
+
+<p>= tag は <b>local debug / billing</b> 用途。 platform 側 query は DDB を見る。</p>
+
+<h2>5. Alternatives considered</h2>
+
+<h3>Alt-A: Resource Groups Tagging API を fan-out で集約 (= ADR-001 案 a)</h3>
+
+<p>本 ADR §3.2 で示した eventual consistency / cost / IAM 増加で却下。</p>
+
+<h3>Alt-B: <code>cloudformation:ListStacks</code> + client-side filter (= ADR-001 案 b 維持)</h3>
+
+<p>同一 account 時代の MVP 設計。 cross-account に拡張すると AssumeRole + ListStacks pagination で更に slow / cost。 採用しない。</p>
+
+<h3>Alt-C: 独立した <code>StacksCatalog</code> DDB テーブルを新設</h3>
+
+<p><code>Deployments</code> テーブルと別に <code>StacksCatalog</code> を立てる。 deploy / delete が両方を書く dual-write。 race / inconsistency の温床。 <code>Deployments</code> 1 本で同等情報を持っているので追加しない。</p>
+
+<h2>6. Implications</h2>
+
+<table>
+  <tr><th>影響</th><th>positive</th><th>negative</th></tr>
+  <tr>
+    <td>cost</td>
+    <td>DDB 1/1 PROVISIONED 維持。 cross-account API call 増加 0</td>
+    <td>—</td>
+  </tr>
+  <tr>
+    <td>operator UX</td>
+    <td>tenant 別 deploy 一覧が ~10 ms で返る (= DDB query)</td>
+    <td>orphan stack drift 検出は手動 fallback (= console)</td>
+  </tr>
+  <tr>
+    <td>IAM 表面積</td>
+    <td>competitor-bootstrap.yaml に <code>tag:GetResources</code> 追加不要 (= mutation 無し)</td>
+    <td>—</td>
+  </tr>
+  <tr>
+    <td>technical debt</td>
+    <td>追加 catalog テーブル / fan-out Lambda 不要</td>
+    <td>drift 監視を将来必要に応じて別 issue で実装</td>
+  </tr>
+</table>
+
+<h2>7. Follow-up</h2>
+
+<ul>
+  <li><b>drift audit Lambda</b> (= optional、 priority low): platform DDB と competitor account stack の drift を定期 scan する Lambda。 6 ヶ月後 review で要否判断</li>
+  <li><b>cost allocation tag</b>: 競技者組織向け doc に \"TenkaCloud から来た stack を billing 分離する方法\" を載せる (= AWS Cost Allocation Tag 機能の使い方)</li>
+  <li><b>ADR-001 §6 update</b>: 案 (a) / (b) のうち \"platform DDB を真実源、 tag は補助\" を正式採用と書く (= 本 ADR が ADR-001 §6 を上書き)</li>
+</ul>
+
+<h2>8. References</h2>
+
+<ul>
+  <li><a href="adr-001-problem-deploy-crud.html">ADR-001</a> §6 — cross-account stack カタログの 2 案を提示した元 ADR</li>
+  <li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/912">#912</a> — 本 ADR の trigger (= #895 Phase 2.E)</li>
+  <li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/895">#895</a> — 親 issue (= ADR-001 Phase 2)</li>
+  <li>PR <a href="https://github.com/susumutomita/TenkaCloud/pull/908">#908</a> — Phase 2.A で CFn stack tag を打つ実装</li>
+  <li><code>Deployments</code> DDB schema: <a href="../../infrastructure/lib/problem-deploy/deployments-table.ts"><code>infrastructure/lib/problem-deploy/deployments-table.ts</code></a></li>
+  <li>AWS Resource Groups Tagging API doc: <a href="https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/Welcome.html">resourcegroupstaggingapi</a></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #912

## Summary

Issue #912 (#895 Phase 2.E) は \"cross-account 問題 deploy stack のカタログ化に Resource Groups Tagging API を採用するか\" の検討を要求する architecture issue。 deliverable は **コード変更ではなく ADR**。 ADR-019 で結論を記録。

## 決定 (3 行)

| | |
|---|---|
| **D1** | Resource Groups Tagging API は **採用しない**。 platform DDB (\`Deployments\`) を single source of truth に据える |
| **D2** | Phase 2.A で打った CFn tag (TenantId / JobId / BatchId / ProblemId) は competitor 側 debug / billing 補助として残す |
| **D3** | drift 検出など conditional な要件が出てきたときに再評価 (= 6 ヶ月後 review) |

## なぜ採用しないか

| 観点 | DDB (D1) | GetResources API |
|---|---|---|
| 整合性 | platform が write → read。 race 無し | eventual consistency (~3 分 lag) |
| latency | ~10 ms | ~500 ms-数秒 (= AssumeRole + GetResources) |
| cost | 1 RCU / query | per-account AssumeRole + API request fee |
| IAM | 既存 \`dynamodb:Query\` のみ | competitor-bootstrap.yaml に \`tag:GetResources\` 追加が必要 |

つまり **真実源として DDB が strictly 優位**。 GetResources の唯一の使い道は \"platform DDB に無い orphan stack の drift 検出\" だが、 頻度低 + 緊急対応で人手 fallback で十分。

## 物理影響

- **NO-OP** (CFn / 成果物に変更なし): ADR docs only
- harness \`adr-must-be-html\` / \`adr-self-contained\` rule 準拠

## Test plan

- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green
- [x] ADR が OSS reader 向け self-contained (= chat 文脈 / TODO / metadata 無し)

## References

- ADR-001 §6 — 元の 2 案を提示した先行 ADR (= 本 ADR で上書き)
- Issue #912 — 本 PR で close
- Issue #895 — 親 issue (= Phase 2.A/B/C/D/E のうち 2.A/2.B/2.E 完了、 残 2.C/2.D)