### PR TITLE
fix(#916, 2 層目): CodeBuild の npm install を bun install に切替 + packages/ 同梱

### DIFF
--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -39,4 +39,12 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
   it("staging root に repo root `package.json` を copy すべき (= CodeBuild が packageManager を読む)", () => {
     expect(source).toContain('cp "${TenkaCloud_ROOT}/package.json" "${STAGING}/package.json"');
   });
+
+  // Issue #916 (2 層目): `infrastructure/package.json` は `@TenkaCloud/trust-bridge:
+  // workspace:*` で sibling workspace を参照する。 staging に `packages/` を同梱しないと
+  // bun が workspace を resolve できず `EUNSUPPORTEDPROTOCOL` (npm) /
+  // `package not found` (bun) で fail する。
+  it("staging root に `packages` directory を copy すべき (= workspace:* protocol の resolve)", () => {
+    expect(source).toContain('cp -R packages "${STAGING}/packages"');
+  });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,6 +91,13 @@ cp "${TenkaCloud_ROOT}/.nvmrc" "${STAGING}/.nvmrc"
 # `packageManager: "bun@<version>"` field から Bun version を読む。 無いと ENOENT で
 # tenant provisioning / update CodeBuild job が fail する (= "package.json not found")。
 cp "${TenkaCloud_ROOT}/package.json" "${STAGING}/package.json"
+# packages/ を staging root に同梱。 infrastructure/package.json (= cdk/package.json) は
+# `@TenkaCloud/trust-bridge: workspace:*` で sibling workspace を参照する。 CodeBuild の
+# bun install (= update-tenant.sh / provision-tenant.sh で npm install → bun install に
+# 切替済) が workspace を resolve できるよう同梱する。 無いと
+# `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"` で fail する (= 旧 npm install
+# 経路、 #916 の 2 層目 regression)。
+cp -R packages "${STAGING}/packages"
 # 旧 ref-arch では src/ を staging に含めていたが、#76 で
 # infrastructure/lib/tenant-pipeline/handlers/ に移動済 (cdk/ 配下に同梱されるので不要)。
 

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -37,7 +37,12 @@ source ./scripts/lib/install-node.sh
 install_node_from_nvmrc
 
 cd cdk
-npm install
+# Issue #916 (2 層目): `infrastructure/package.json` は `@TenkaCloud/trust-bridge:
+# workspace:*` で sibling workspace を参照する。 npm は `workspace:` protocol を理解せず
+# `EUNSUPPORTEDPROTOCOL` で fail するので bun install に切替。 staging root の monorepo
+# package.json (= install.sh が copy) と `packages/trust-bridge` (= install.sh が
+# 同梱) が揃った状態で bun が workspace resolve する。
+bun install
 
 # Parse tenant details from the input message from step function
 export CDK_PARAM_TENANT_ID=$tenantId

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -35,5 +35,10 @@ source ./scripts/lib/install-node.sh
 install_node_from_nvmrc
 
 cd cdk
-npm install
+# Issue #916 (2 層目): `infrastructure/package.json` は \`@TenkaCloud/trust-bridge:
+# workspace:*\` で sibling workspace を参照する。 npm は \`workspace:\` protocol を理解せず
+# \`EUNSUPPORTEDPROTOCOL\` で fail するので bun install に切替。 staging root の monorepo
+# package.json (= install.sh が copy) と \`packages/trust-bridge\` (= install.sh が
+# 同梱) が揃った状態で bun が workspace resolve する。
+bun install
 bunx cdk deploy "$STACK_NAME" --exclusively --require-approval never


### PR DESCRIPTION
Closes #916

## Symptom

PR #915 で install.sh の \`package.json\` 同梱漏れを fix した後、 **SBT BashJobRunner の CodeBuild Job が新たな error で fail**:

\`\`\`
+ cd cdk
+ npm install
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type \"workspace:\": workspace:*
\`\`\`

→ admin-create-user の \`custom:userRole=TenantAdmin\` 付与が走らず、 application-admin-console で 403 forbidden_role 継続。

## Root cause

\`infrastructure/package.json\` (= staging で cdk/) が \`@TenkaCloud/trust-bridge: workspace:*\` で sibling workspace を参照する。 SBT 生成の update-tenant.sh / provision-tenant.sh は \`cd cdk; npm install\` で installs を走らせるが、 **npm は \`workspace:\` protocol を理解しない**。

PR #915 (1 層目) で \`package.json\` 同梱を fix した先に隠れていた regression。

## Fix

| file | 変更 |
|---|---|
| \`scripts/install.sh\` | staging に \`packages/\` (= trust-bridge 含む) を同梱。 bun の workspace resolve に必要 |
| \`scripts/update-tenant.sh\` | \`cd cdk; npm install\` → \`cd cdk; bun install\` (= bun は workspace protocol 対応) |
| \`scripts/provision-tenant.sh\` | 同上 |
| \`infrastructure/test/install-script.test.ts\` | packages/ copy assertion 追加 (= regression 防止) |

bun は \`scripts/lib/install-node.sh:install_bun_from_package_manager\` が既に PATH に通している (= PR #915 で \`package.json\` を staging に置いて readable にした効果)。 切替対象の 2 script は同関数を \`source\` してから実行されるので、 \`bun\` command は available。

## Verification path (user)

1. PR merge を確認
2. \`make deploy\` 再実行 → 新 source.zip が S3 にアップロード (= packages/ 含む)
3. 既存 \"In progress\" tenant (test2 等) を deprovision
4. 新規 tenant 作成 → CodeBuild Job が完走 (= bun install で workspace 解決 → bunx cdk deploy → admin-create-user が走る)
5. 招待メール経由で sign-in → 403 forbidden_role 消える

## Regression 分析

- 旧 cdk/ 配下で \`npm install\` を試していた既存運用は **そもそも壊れていた** ので bun への切替で挙動改善のみ
- bun.lock は cdk/ に同梱されていないが、 root staging の monorepo package.json + packages/ から bun が自前で解決する
- 既存 \`npx cdk deploy\` 等の経路は \`bunx cdk deploy\` で動いていた (= bin 経路で bun は導入済)
- ローカル開発 (= host での \`make deploy\` Phase 1 等) は影響なし (= bun install を root で実行する flow に変更なし)

## 物理影響

- **UPDATE** (S3 object): source.zip に packages/ が追加で含まれる (~数 KB 増)
- CodeBuild の install 時間は npm install ≒ bun install で同等 (~30 秒、 bun のほうがやや速い)

## Test plan

- [x] \`bun run test test/install-script.test.ts\`: 4 件 pass (= packages/ assertion 追加)
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green

## References

- Issue #916 (本 PR で close、 verify path 完了次第)
- PR #915 — 1 層目の \`package.json\` 同梱漏れ fix (= 本 PR の prerequisite)
- CodeBuild log (= user 提供): \`npm error code EUNSUPPORTEDPROTOCOL\`