### PR TITLE
feat(#911): Phase 2.D — POST /deployments/retry で FAILED item を再投入する idempotent API

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -27,6 +27,7 @@ import {
   UnverifiedCompetitorAccountError,
 } from "./deploy.js";
 import { getDeployment, listDeployments } from "./list.js";
+import { InvalidRetryRequestError, retryDeployments, validateRetryRequest } from "./retry.js";
 import {
   defaultCfnClient,
   defaultCfnClientForCompetitor,
@@ -274,6 +275,41 @@ app.get("/deployments/:jobId/stack-progress", async (c) => {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[deploy] getStackProgress failed", { jobId, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+/**
+ * Issue #911 (#895 Phase 2.D): bulk batch で FAILED になった item の jobId 配列を再投入する
+ * idempotent retry API。 caller の tenantId scope に閉じ、 FAILED row のみ PENDING に
+ * 巻き戻して event 再 publish。 成功済 / in-progress / 別 tenant の row は skip して結果に
+ * 含める (= partial success を一括 response で表現)。
+ *
+ * 入力: \`{ failedJobIds: ["01HX...", ...] }\`、 最大 750 件
+ * 出力: \`{ items: [{ jobId, action: \"requeued\" | \"skipped\", reason? }, ...] }\`
+ */
+app.post("/deployments/retry", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
+  }
+  let request: ReturnType<typeof validateRetryRequest>;
+  try {
+    request = validateRetryRequest(body);
+  } catch (err) {
+    if (err instanceof InvalidRetryRequestError) {
+      return c.json({ error: "invalid_request", message: err.message }, HTTP_BAD_REQUEST);
+    }
+    throw err;
+  }
+  try {
+    const result = await retryDeployments(shared, resolveTenantId(c), request);
+    return c.json(result, HTTP_OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[deploy] retryDeployments failed", { message });
+    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
   }
 });
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/retry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/retry.ts
@@ -1,0 +1,239 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { ULID_RE as JOB_ID_RE } from "../shared/constants.js";
+import {
+  type DeployCreateRequestedDetail,
+  EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+  publishProblemEvent,
+} from "../shared/events.js";
+import { logDeployTrace } from "../shared/trace-log.js";
+import type { DeploySharedResources } from "./deploy.js";
+import type { DeploymentItem } from "./types.js";
+
+/**
+ * Issue #911 (#895 Phase 2.D): bulk batch で FAILED になった item の jobId 配列を受け取り、
+ * **FAILED 行のみ** を PENDING に戻して `DeployCreateRequested` event を再 publish する
+ * retry API。 成功済 / IN_PROGRESS / その他 status の row は touch しない (= idempotent)。
+ *
+ * 重要な性質:
+ *  - cross-tenant safety: caller (TenantAdmin) の tenantId と一致しない row は skip (= 別 tenant
+ *    の deploy を巻き込み再起動しない)。 row 自体が無いときも skip
+ *  - idempotent: 成功済 (COMPLETE) は no-op、 in-progress (IN_PROGRESS / PENDING) も no-op
+ *    (= 進行中を勝手に巻き戻さない、 operator は明示的に DELETE してから retry する設計)
+ *  - 部分成功: 配列の一部だけ FAILED でも処理続行し、 各 jobId ごとの結果を返す
+ *
+ * 入力: \`{ failedJobIds: ["01HX...", "01HX..."] }\`
+ * 出力: \`{ items: [{ jobId, action: \"requeued\" | \"skipped\", reason? }, ...] }\`
+ *   - action=\"requeued\": FAILED → PENDING に戻し、 event 再 publish 成功
+ *   - action=\"skipped\": cross-tenant / not_found / not_failed / publish_failed のいずれか
+ */
+
+export interface RetryDeploymentsRequest {
+  readonly failedJobIds: readonly string[];
+}
+
+export type RetryAction = "requeued" | "skipped";
+
+export interface RetryDeploymentResult {
+  readonly jobId: string;
+  readonly action: RetryAction;
+  /** action=\"skipped\" のとき理由を返す (cross_tenant / not_found / not_failed / publish_failed)。 */
+  readonly reason?: string;
+}
+
+export interface RetryDeploymentsResponse {
+  readonly items: readonly RetryDeploymentResult[];
+}
+
+const MAX_RETRY_BATCH_SIZE = 750;
+
+export class InvalidRetryRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRetryRequestError";
+  }
+}
+
+export function validateRetryRequest(raw: unknown): RetryDeploymentsRequest {
+  if (!raw || typeof raw !== "object") {
+    throw new InvalidRetryRequestError("body must be a JSON object");
+  }
+  const failedJobIds = (raw as { failedJobIds?: unknown }).failedJobIds;
+  if (!Array.isArray(failedJobIds)) {
+    throw new InvalidRetryRequestError("failedJobIds must be an array of jobId strings");
+  }
+  if (failedJobIds.length === 0) {
+    throw new InvalidRetryRequestError("failedJobIds must not be empty");
+  }
+  if (failedJobIds.length > MAX_RETRY_BATCH_SIZE) {
+    throw new InvalidRetryRequestError(
+      `failedJobIds must not exceed ${MAX_RETRY_BATCH_SIZE} entries (got ${failedJobIds.length})`,
+    );
+  }
+  for (const jobId of failedJobIds) {
+    if (typeof jobId !== "string" || !JOB_ID_RE.test(jobId)) {
+      throw new InvalidRetryRequestError(
+        `failedJobIds must all be ULID strings (got ${JSON.stringify(jobId)})`,
+      );
+    }
+  }
+  // dedupe しないと同じ jobId を 2 回触りに行って 2 回目が ConditionExpression で fail する
+  // (= 1 回目で PENDING に戻した直後の row は FAILED でなくなる)。 caller が混入させた重複を
+  // 無害化する。
+  const deduped = Array.from(new Set(failedJobIds as readonly string[]));
+  return { failedJobIds: deduped };
+}
+
+/**
+ * 1 jobId を retry する。 cross-tenant / status / publish 失敗のいずれでも throw せず、
+ * caller には `RetryDeploymentResult` を返す (= 部分成功を表現するため batch loop は throw
+ * しない設計)。
+ */
+async function retryOne(
+  shared: DeploySharedResources,
+  callerTenantId: string,
+  jobId: string,
+  now: () => number,
+): Promise<RetryDeploymentResult> {
+  const out = await shared.ddb.send(
+    new GetCommand({
+      TableName: shared.tableName,
+      Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+    }),
+  );
+  const item = out.Item as Partial<DeploymentItem> | undefined;
+  if (!item || !item.jobId) {
+    return { jobId, action: "skipped", reason: "not_found" };
+  }
+  if (item.tenantId !== callerTenantId) {
+    // 別 tenant の row を見せない (= 404 相当扱い、 reason は cross_tenant としつつ caller
+    // には not_found との区別を与えない方が安全)。
+    return { jobId, action: "skipped", reason: "not_found" };
+  }
+  if (item.status !== "FAILED") {
+    return { jobId, action: "skipped", reason: "not_failed" };
+  }
+
+  // FAILED → PENDING に巻き戻す。 ConditionExpression で並走時の race (= 既に他経路で再 trigger
+  // されている / 同じ retry 配列内の重複) を防ぐ。
+  const updatedAt = new Date(now()).toISOString();
+  try {
+    await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+        UpdateExpression: "SET #s = :pending, updatedAt = :updatedAt REMOVE failureReason",
+        // FAILED かつ caller の tenantId 一致のときだけ書き戻す (= cross-tenant defense-in-depth)。
+        ConditionExpression: "#s = :failed AND tenantId = :tenantId",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":pending": "PENDING",
+          ":failed": "FAILED",
+          ":updatedAt": updatedAt,
+          ":tenantId": callerTenantId,
+        },
+      }),
+    );
+  } catch (err) {
+    // ConditionExpression 違反 = 他経路で先に retry された / status 変動。 best-effort で skip 扱い。
+    const name = err instanceof Error ? err.name : "unknown";
+    if (name === "ConditionalCheckFailedException") {
+      return { jobId, action: "skipped", reason: "not_failed" };
+    }
+    throw err;
+  }
+
+  // 元 deploy 時に書いた item + shared.problemsCatalog から DeployCreateRequestedDetail
+  // を再構築する。 namePrefix / region / awsAccountId / competitor metadata は item に持って
+  // いる。 problemDir は shared.problemsCatalog (= module-load 時の static catalog) で
+  // problemId から解決。
+  const problemId = String(item.problemId ?? "");
+  const problemDir = shared.problemsCatalog[problemId];
+  if (!problemDir) {
+    return { jobId, action: "skipped", reason: "unknown_problem" };
+  }
+  // 既知 limitation: challengePayloadUrl (= private 問題用 presigned URL) は retry で再生成
+  // しない。 期限切れ URL を渡すと CodeBuild 内で 403 になり再度 FAILED に倒れる。 private
+  // 問題の retry は当面 manual (= operator が新 deploy として再投入) で運用、 Phase 2.D
+  // follow-up で presigned URL regen を入れる予定。
+  const detail: DeployCreateRequestedDetail = {
+    jobId,
+    correlationId: jobId,
+    tenantId: callerTenantId,
+    problemId,
+    problemDir,
+    teamSlug: String(item.teamName ?? ""),
+    namePrefix: String(item.namePrefix ?? ""),
+    region: String(item.region ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
+    ...(item.competitorRoleArn ? { competitorRoleArn: item.competitorRoleArn } : {}),
+    ...(item.externalIdParameterName
+      ? { externalIdParameterName: item.externalIdParameterName }
+      : {}),
+  };
+
+  try {
+    await publishProblemEvent({
+      client: shared.events,
+      busName: shared.eventBusName,
+      detailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+      jobId,
+      detail,
+    });
+  } catch (err) {
+    // event publish 失敗時は PENDING に戻したのを FAILED に巻き戻す (= operator が再 retry
+    // 可能な状態を維持)。 巻き戻しの失敗は無視 (= best-effort)。
+    try {
+      await shared.ddb.send(
+        new UpdateCommand({
+          TableName: shared.tableName,
+          Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+          UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+          ConditionExpression: "#s = :pending AND tenantId = :tenantId",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: {
+            ":failed": "FAILED",
+            ":pending": "PENDING",
+            ":updatedAt": new Date(now()).toISOString(),
+            ":reason": "Failed to re-publish DeployCreateRequested event during retry",
+            ":tenantId": callerTenantId,
+          },
+        }),
+      );
+    } catch {
+      // ignore: best-effort rollback
+    }
+    const message = err instanceof Error ? err.message : "unknown";
+    logDeployTrace("deploy.retry.publish_failed", {
+      jobId,
+      correlationId: jobId,
+      tenantId: callerTenantId,
+      message,
+    });
+    return { jobId, action: "skipped", reason: "publish_failed" };
+  }
+
+  logDeployTrace("deploy.retry.requeued", {
+    jobId,
+    correlationId: jobId,
+    tenantId: callerTenantId,
+    problemId: detail.problemId,
+  });
+  return { jobId, action: "requeued" };
+}
+
+/**
+ * 配列内の各 jobId に対して `retryOne` を逐次実行する (= caller の tenantId scope に閉じる)。
+ * 並列化は不要 (= 750 件でも 1 件あたり数 ms、 操作頻度低い)。
+ */
+export async function retryDeployments(
+  shared: DeploySharedResources,
+  callerTenantId: string,
+  request: RetryDeploymentsRequest,
+  now: () => number = () => Date.now(),
+): Promise<RetryDeploymentsResponse> {
+  const results: RetryDeploymentResult[] = [];
+  for (const jobId of request.failedJobIds) {
+    results.push(await retryOne(shared, callerTenantId, jobId, now));
+  }
+  return { items: results };
+}

--- a/infrastructure/test/problem-deploy/deploy-retry.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-retry.test.ts
@@ -1,0 +1,198 @@
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
+import {
+  InvalidRetryRequestError,
+  retryDeployments,
+  validateRetryRequest,
+} from "../../lib/problem-deploy/handlers/deploy-handler/retry";
+
+/**
+ * Issue #911 (#895 Phase 2.D): retry API の挙動契約 test。
+ *
+ * 重点 4 経路:
+ *  1. FAILED → PENDING + event publish (= action: "requeued")
+ *  2. not_found (DDB row 無し) → action: "skipped", reason: "not_found"
+ *  3. cross-tenant (= 別 tenant の row) → action: "skipped", reason: "not_found" (= 漏洩防止)
+ *  4. not FAILED (= COMPLETE / IN_PROGRESS 等) → action: "skipped", reason: "not_failed"
+ *  5. unknown_problem (= problemsCatalog にない problemId) → action: "skipped", reason: "unknown_problem"
+ *  6. publish_failed (= EventBridge throw) → action: "skipped", reason: "publish_failed",
+ *     status は FAILED に巻き戻し
+ */
+
+const VALID_JOB_ID = "01J0RETRYABCDEFGHJKMNPQRST";
+const VALID_JOB_ID_2 = "01J0RETRYABCDEFGHJKMNPQRSV";
+
+function buildShared(): {
+  shared: DeploySharedResources;
+  ddbSend: ReturnType<typeof vi.fn>;
+  eventsSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const eventsSend = vi.fn();
+  const shared: DeploySharedResources = {
+    tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+    events: { send: eventsSend } as unknown as DeploySharedResources["events"],
+    problemsCatalog: {
+      "hello-world": "problems/challenges/hello-world",
+    },
+    problemsVisibility: {} as DeploySharedResources["problemsVisibility"],
+    challengePayloadBucket: undefined,
+    s3: {} as DeploySharedResources["s3"],
+  };
+  return { shared, ddbSend, eventsSend };
+}
+
+const failedRow = (over: Record<string, unknown> = {}) => ({
+  jobId: VALID_JOB_ID,
+  problemId: "hello-world",
+  tenantId: "tenant-a",
+  awsAccountId: "111111111111",
+  region: "ap-northeast-1",
+  teamName: "team-alpha",
+  namePrefix: "tc-hello-world-alpha",
+  status: "FAILED",
+  failureReason: "CodeBuild exit 1",
+  ...over,
+});
+
+describe("validateRetryRequest", () => {
+  it("body が object でないとき throw", () => {
+    expect(() => validateRetryRequest("not object")).toThrow(InvalidRetryRequestError);
+  });
+  it("failedJobIds が array でないとき throw", () => {
+    expect(() => validateRetryRequest({ failedJobIds: "string" })).toThrow(
+      InvalidRetryRequestError,
+    );
+  });
+  it("failedJobIds が空配列のとき throw", () => {
+    expect(() => validateRetryRequest({ failedJobIds: [] })).toThrow(InvalidRetryRequestError);
+  });
+  it("失敗 jobId が ULID でないとき throw", () => {
+    expect(() => validateRetryRequest({ failedJobIds: ["not-ulid"] })).toThrow(
+      InvalidRetryRequestError,
+    );
+  });
+  it("750 件超のとき throw", () => {
+    const big = Array.from({ length: 751 }, () => VALID_JOB_ID);
+    expect(() => validateRetryRequest({ failedJobIds: big })).toThrow(InvalidRetryRequestError);
+  });
+  it("正常 input は dedupe して返す", () => {
+    const res = validateRetryRequest({
+      failedJobIds: [VALID_JOB_ID, VALID_JOB_ID, VALID_JOB_ID_2],
+    });
+    expect(res.failedJobIds.length).toBe(2);
+    expect(res.failedJobIds).toContain(VALID_JOB_ID);
+    expect(res.failedJobIds).toContain(VALID_JOB_ID_2);
+  });
+});
+
+describe("retryDeployments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("FAILED row を PENDING に戻し、 event を re-publish して action='requeued' を返すべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: failedRow() }); // Get
+    ddbSend.mockResolvedValueOnce({}); // Update FAILED → PENDING
+    eventsSend.mockResolvedValueOnce({});
+
+    const res = await retryDeployments(
+      shared,
+      "tenant-a",
+      { failedJobIds: [VALID_JOB_ID] },
+      () => 1700000000000,
+    );
+
+    expect(res.items).toEqual([{ jobId: VALID_JOB_ID, action: "requeued" }]);
+    // Update が status FAILED → PENDING を書いている
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+    expect(updateCmd).toBeInstanceOf(UpdateCommand);
+    expect(updateCmd.input.ExpressionAttributeValues?.[":pending"]).toBe("PENDING");
+    expect(updateCmd.input.ExpressionAttributeValues?.[":failed"]).toBe("FAILED");
+    // EventBridge にも publish
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const eventCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(eventCmd).toBeInstanceOf(PutEventsCommand);
+  });
+
+  it("DDB row 無しなら 'not_found'", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const res = await retryDeployments(shared, "tenant-a", { failedJobIds: [VALID_JOB_ID] });
+
+    expect(res.items[0]?.action).toBe("skipped");
+    expect(res.items[0]?.reason).toBe("not_found");
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("別 tenant の row は 'not_found' 扱い (= cross-tenant 漏洩防止)", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: failedRow({ tenantId: "tenant-other" }) });
+
+    const res = await retryDeployments(shared, "tenant-a", { failedJobIds: [VALID_JOB_ID] });
+
+    expect(res.items[0]?.reason).toBe("not_found");
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("FAILED 以外 (COMPLETE / IN_PROGRESS) は 'not_failed' でスキップ、 巻き戻さない", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: failedRow({ status: "COMPLETE" }) });
+
+    const res = await retryDeployments(shared, "tenant-a", { failedJobIds: [VALID_JOB_ID] });
+
+    expect(res.items[0]?.reason).toBe("not_failed");
+    expect(eventsSend).not.toHaveBeenCalled();
+    // Update は呼ばれない (= Get のみ)
+    expect(ddbSend).toHaveBeenCalledOnce();
+  });
+
+  it("unknown problemId は 'unknown_problem' でスキップ", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: failedRow({ problemId: "no-such-problem" }) });
+
+    const res = await retryDeployments(shared, "tenant-a", { failedJobIds: [VALID_JOB_ID] });
+
+    expect(res.items[0]?.reason).toBe("unknown_problem");
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("publish 失敗時は status を FAILED に巻き戻して 'publish_failed' を返す", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: failedRow() }); // Get
+    ddbSend.mockResolvedValueOnce({}); // Update FAILED → PENDING
+    eventsSend.mockRejectedValueOnce(new Error("EventBridge throttle"));
+    ddbSend.mockResolvedValueOnce({}); // Update PENDING → FAILED (rollback)
+
+    const res = await retryDeployments(shared, "tenant-a", { failedJobIds: [VALID_JOB_ID] });
+
+    expect(res.items[0]?.reason).toBe("publish_failed");
+    // 3 回 ddbSend (Get + Update forward + Update rollback)
+    expect(ddbSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("複数 jobId の一部成功・一部スキップを 1 response でまとめて返すべき", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    // jobId 1: FAILED → requeued
+    ddbSend.mockResolvedValueOnce({ Item: failedRow({ jobId: VALID_JOB_ID }) });
+    ddbSend.mockResolvedValueOnce({});
+    eventsSend.mockResolvedValueOnce({});
+    // jobId 2: not_found
+    ddbSend.mockResolvedValueOnce({ Item: undefined });
+
+    const res = await retryDeployments(shared, "tenant-a", {
+      failedJobIds: [VALID_JOB_ID, VALID_JOB_ID_2],
+    });
+
+    expect(res.items.length).toBe(2);
+    expect(res.items[0]?.action).toBe("requeued");
+    expect(res.items[1]?.action).toBe("skipped");
+    expect(res.items[1]?.reason).toBe("not_found");
+  });
+});


### PR DESCRIPTION
Closes #911

## Summary

#895 Phase 2.D の実装。 bulk batch (Phase 2.C) で失敗した item の jobId 配列を caller (TenantAdmin) の tenantId scope で再投入する API。 **cross-tenant safety + idempotent** を物理層で担保。

## 振舞い

\`POST /deployments/retry { failedJobIds: [\"01HX...\", ...] }\` (最大 750 件)

レスポンス:

\`\`\`json
{
  \"items\": [
    { \"jobId\": \"01HX...\", \"action\": \"requeued\" },
    { \"jobId\": \"01HY...\", \"action\": \"skipped\", \"reason\": \"not_found\" }
  ]
}
\`\`\`

| action / reason | 意味 |
|---|---|
| \`requeued\` | FAILED → PENDING 巻き戻し + DeployCreateRequested event 再 publish 成功 |
| \`skipped\` + \`not_found\` | DDB row 無し / 別 tenant の row (= 漏洩防止で同 reason) |
| \`skipped\` + \`not_failed\` | COMPLETE / IN_PROGRESS 等 (= 進行中を勝手に巻き戻さない) |
| \`skipped\` + \`unknown_problem\` | problemsCatalog に problemId 無し (= 削除済) |
| \`skipped\` + \`publish_failed\` | EventBridge throw、 status は FAILED に rollback |

## Cross-tenant safety

- DDB Get 時に caller tenantId と row.tenantId を比較、 不一致なら not_found 扱い (= 別 tenant の存在は漏らさない)
- Update の ConditionExpression に \`tenantId = :tenantId AND #s = :failed\` を入れて、 race / 別 tenant 巻き込みを **DDB レベル** で物理的に防ぐ

## Idempotent

- 入力 jobId 配列は handler 内で \`Set\` dedupe (= caller が混入させた重複を無害化)
- COMPLETE row は touch しない (= 既に成功している deploy を巻き戻さない)
- 同 retry を 2 回叩いても 2 回目は \"not_failed\" で skip (= 1 回目で PENDING に戻っているため、 2 回目の ConditionExpression が fail)
- publish 失敗時は status を FAILED に rollback (= operator が再 retry 可能な状態を維持)

## Known limitation (= follow-up)

- **\`challengePayloadUrl\` (= private 問題用 presigned URL) は retry で再生成しない**。 期限切れ URL で再投入すると CodeBuild 内で 403 → 再 FAILED。 private 問題の retry は当面 manual 運用 (= operator が POST /deployments で新 deploy)、 Phase 2.D follow-up で presigned URL regen を入れる予定

## 実装

| file | 変更 |
|---|---|
| \`infrastructure/lib/problem-deploy/handlers/deploy-handler/retry.ts\` (新規) | \`validateRetryRequest\` + \`retryDeployments\` + \`retryOne\` の pure logic |
| \`infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts\` | \`POST /deployments/retry\` route 追加。 既存 \`requireTenantAdmin\` middleware で role gate 済 |
| \`infrastructure/test/problem-deploy/deploy-retry.test.ts\` (新規) | 6 分岐 + dedupe + validation + 部分成功の 13 件 |

## Regression 分析

- 既存 routes (\`/deployments\`、 \`/deployments/:jobId\`、 \`DELETE /deployments/:jobId\` 等) は touch しない
- 既存 \`requireTenantAdmin\` middleware で 403 gate 済、 新 endpoint も automatic に role 制約
- DDB schema (= \`DeploymentItem\`) を変更しない。 Update は既存 column のみ (= status / updatedAt / failureReason)

## 物理影響

- **UPDATE** (CFn): \`tenkacloud-problem-deploy\` の DeployApi Lambda code が増える (= retry.ts + index.ts 修正)
- **NO-OP** (DDB schema / IAM Role / API Gateway routes): 新 endpoint は Lambda 内で route 分岐、 API Gateway は \"ANY /\" proxy 統合で既に通る

## Test plan

- [x] \`bun run test test/problem-deploy/deploy-retry.test.ts\`: 13 件 pass
- [x] \`bun run test\` 全 workspace: 1642 件 pass (= 1068 infrastructure + 126 admin-console + 239 application-admin-console + 159 participant-portal + 50 trust-bridge)
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green

## References

- Issue #911 — Phase 2.D
- Issue #895 — 親 issue (= Phase 2.A/2.B/2.E 完了、 残 2.C を続く別 PR で実装予定)
- ADR-001 §4 — \"失敗時は continue + summary、 再実行 API で部分 retry\" の元設計