### PR TITLE
feat(#910 Phase 2.C.1): BulkDeployCreateStateMachine 構築 (Distributed Map foundation)

### DIFF
--- a/infrastructure/lib/problem-deploy/bulk-deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/bulk-deploy-create-state-machine.ts
@@ -1,0 +1,127 @@
+import { Duration, Stack } from "aws-cdk-lib";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import type { IBucket } from "aws-cdk-lib/aws-s3";
+import {
+  DefinitionBody,
+  DistributedMap,
+  IntegrationPattern,
+  type IStateMachine,
+  JsonPath,
+  LogLevel,
+  ProcessorMode,
+  ProcessorType,
+  S3JsonItemReader,
+  StateMachine,
+  StateMachineType,
+  TaskInput,
+} from "aws-cdk-lib/aws-stepfunctions";
+import { StepFunctionsStartExecution } from "aws-cdk-lib/aws-stepfunctions-tasks";
+import { Construct } from "constructs";
+
+/**
+ * Issue #910 (#895 Phase 2.C): bulk batch (= 1 event で N×M deployments) を **Distributed Map**
+ * で並列処理する State Machine。
+ *
+ * 入力 shape (= \`BulkDeployCreateRequestedDetail\`):
+ *   {
+ *     batchId: "01HX...",
+ *     tenantId: "tenant-acme",
+ *     s3Bucket: "tenkacloud-bulk-payload-...",
+ *     s3Key: "batches/01HX.../deployments.json",
+ *     itemCount: 750
+ *   }
+ *
+ * 挙動:
+ *   1. \`S3JsonItemReader\` で s3Bucket/s3Key を読む (= JSON array of DeployCreateRequestedDetail)
+ *   2. Distributed Map で各 item を **MaxConcurrency=50** で並列実行
+ *   3. 各 child execution は \`childStateMachine\` (= 既存 \`DeployCreateStateMachine\`) を
+ *      \`StartExecution\` で起動 (= 既存 single-shot logic をそのまま再利用)
+ *   4. \`ToleratedFailure* 未設定\` で全 item を最後まで試す (= 失敗してもエラー扱いにせず
+ *      Map 全体を success で終わらせる、 ADR-001 §4 の継続+summary 方針)
+ *
+ * Phase 2.C.1 (= 本 PR、 foundation only):
+ *   - State Machine construct + S3 ItemReader + EventBridge Rule を CDK で確立
+ *   - API 側の bulk-deploy handler refactor (= S3 PutObject + BulkDeployCreateRequested
+ *     publish) は **本 PR 範囲外**。 既存 fan-out も削除しない (= 旧 経路は残し、
+ *     新 経路を coexist させる)
+ *
+ * Phase 2.C.2 (= 別 PR):
+ *   - \`bulk-deploy.ts\` の fan-out を撤廃して S3 write + 1 event publish に書き換え
+ *   - result aggregation (= failedItems[] を親が返す)
+ */
+export interface BulkDeployCreateStateMachineProps {
+  /**
+   * 子 deploy を実行する単発 State Machine。 \`DeployCreateStateMachine\` を渡す想定。
+   * Distributed Map child execution が \`StartExecution\` でこれを起動する。
+   */
+  readonly childStateMachine: IStateMachine;
+  /**
+   * Bulk batch payload を保存する S3 Bucket。 \`S3JsonItemReader\` がここから読む。
+   * API Lambda が batchId ごとに object を put する想定。
+   */
+  readonly payloadBucket: IBucket;
+}
+
+/**
+ * ADR-001 §3 で固定された並列度。 operator が UI で上げ下げしない (= cross-account API
+ * rate limit / CFn quota との均衡)。 SLO 評価で見直すなら本 ADR を update する。
+ */
+const MAX_CONCURRENCY = 50;
+
+export class BulkDeployCreateStateMachine extends Construct {
+  public readonly stateMachine: StateMachine;
+
+  constructor(scope: Construct, id: string, props: BulkDeployCreateStateMachineProps) {
+    super(scope, id);
+
+    const logGroup = new LogGroup(this, "LogGroup", {
+      retention: RetentionDays.ONE_WEEK,
+    });
+
+    // Distributed Map の child execution は子 State Machine を `StartExecution` で起動する。
+    // 各 item は `DeployCreateRequestedDetail` shape の JSON object。 既存 single-shot
+    // State Machine は `$.detail` で受けるため、 input を `{detail: <item>}` で wrap する。
+    const childInvoke = new StepFunctionsStartExecution(this, "InvokeChildDeploy", {
+      stateMachine: props.childStateMachine,
+      input: TaskInput.fromObject({
+        detail: JsonPath.objectAt("$$.Map.Item.Value"),
+      }),
+      // wait なし (= async fan-out)、 各 child の終了は child 自身が DDB に書き戻すので
+      // 親は item を Start するだけで次へ進む。 child execution の失敗は本 Map で catch
+      // しない (= ADR-001 §4 "continue + summary" = 親は失敗を accumulate するだけ)。
+      integrationPattern: IntegrationPattern.REQUEST_RESPONSE,
+    });
+
+    // ADR-001 §4: 失敗を error 扱いにせず最後まで試す。 ToleratedFailure* は未設定で
+    // "any failure tolerated" になり、 親 execution は success で終わる。
+    const map = new DistributedMap(this, "DeployItemsMap", {
+      maxConcurrency: MAX_CONCURRENCY,
+      itemReader: new S3JsonItemReader({
+        bucket: props.payloadBucket,
+        // S3 Object Key は event detail の `$.detail.s3Key` から JSONPath で解決。
+        key: JsonPath.stringAt("$.detail.s3Key"),
+      }),
+    });
+
+    map.itemProcessor(childInvoke, {
+      mode: ProcessorMode.DISTRIBUTED,
+      executionType: ProcessorType.STANDARD,
+    });
+
+    this.stateMachine = new StateMachine(this, "StateMachine", {
+      stateMachineType: StateMachineType.STANDARD,
+      definitionBody: DefinitionBody.fromChainable(map),
+      logs: { destination: logGroup, level: LogLevel.ALL },
+      timeout: Duration.hours(3),
+      // Stack scope に commit して logical ID を pin (= 後続 PR で API 経路を wire するとき
+      // も同 stack の同 path で参照できる)。
+      stateMachineName: `${Stack.of(scope).stackName}-bulk-deploy-create`.slice(0, 79),
+    });
+
+    // S3 read 権限 (= ItemReader が GetObject + ListObjectsV2 する)。 IBucket.grantRead で
+    // GetObject + ListBucket が両方付く。
+    props.payloadBucket.grantRead(this.stateMachine);
+    // child State Machine の StartExecution 権限 (= Distributed Map item processor が呼ぶ)。
+    props.childStateMachine.grantStartExecution(this.stateMachine);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -18,6 +18,14 @@ import { logDeployTrace } from "./trace-log.js";
 export const EVENT_SOURCE = "tenkacloud.deploy" as const;
 export const EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED = "DeployCreateRequested" as const;
 export const EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED = "DeployDeleteRequested" as const;
+/**
+ * Issue #910 (#895 Phase 2.C): bulk batch (= 1 event で N×M deployments) を Distributed Map
+ * state machine に渡すための event type。 detail に S3 URI を載せ、 state machine が
+ * S3JsonItemReader で deployments 配列を読む。 個別 deploy は `DeployCreateRequested` (=
+ * 単発経路) を使い続け、 bulk と単発を異なる EventBridge Rule で 2 つの state machine に
+ * route する。
+ */
+export const EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED = "BulkDeployCreateRequested" as const;
 
 export const COMPETITOR_ROLE_NAME_DEFAULT = "TenkaCloud-CompetitorDeploy-Role" as const;
 
@@ -86,6 +94,28 @@ export const DeployDeleteRequestedDetailSchema = z.object({
   externalIdParameterName: z.string().optional(),
 });
 export type DeployDeleteRequestedDetail = z.infer<typeof DeployDeleteRequestedDetailSchema>;
+
+/**
+ * Issue #910 (#895 Phase 2.C): `BulkDeployCreateRequested` event の `detail` schema。
+ * tenant API Lambda が bulk deploy 時 (= 1 event で N×M deployments) に publish し、
+ * `BulkDeployCreate` State Machine が `S3JsonItemReader` で deployment 配列を読み込む。
+ *
+ * - `s3Bucket` / `s3Key`: deployment 配列 (\`DeployCreateRequestedDetail[]\`) を JSON で保存
+ *   した S3 object。 Step Functions の Distributed Map が ItemReader で iteration する
+ * - `batchId`: 1 bulk 実行を識別する ULID。 各 deployment の CFn stack に Tag として
+ *   打たれ、 operator が後で同 batch を逆引きできる (= ADR-001 §6 + Phase 2.A)
+ * - `tenantId`: caller tenant の scope。 Distributed Map child execution に渡され、
+ *   個別 deploy の TenantId に伝搬する
+ */
+export const BulkDeployCreateRequestedDetailSchema = z.object({
+  batchId: z.string().min(1),
+  tenantId: z.string().min(1),
+  s3Bucket: z.string().min(1),
+  s3Key: z.string().min(1),
+  /** batch 内 item 数 (= operator の参考表示用、 state machine の挙動には影響しない)。 */
+  itemCount: z.number().int().nonnegative().optional(),
+});
+export type BulkDeployCreateRequestedDetail = z.infer<typeof BulkDeployCreateRequestedDetailSchema>;
 
 export class ProblemEventPublishError extends Error {
   constructor(

--- a/infrastructure/test/problem-deploy/bulk-deploy-create-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/bulk-deploy-create-state-machine.test.ts
@@ -1,0 +1,116 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Pass, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { describe, expect, it } from "vitest";
+import { BulkDeployCreateStateMachine } from "../../lib/problem-deploy/bulk-deploy-create-state-machine";
+
+/**
+ * Issue #910 (#895 Phase 2.C.1): BulkDeployCreateStateMachine の CFn shape を pin する
+ * regression test。 Distributed Map / S3JsonItemReader / MaxConcurrency=50 / Standard
+ * child execution の 4 つの設計判断が ASL に反映されているかを assertion する。
+ */
+
+function buildStack(): { stack: cdk.Stack; template: Template } {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "Test", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const payloadBucket = new Bucket(stack, "PayloadBucket");
+  // child State Machine は本 PR scope 外 (= 別 PR で DeployCreateStateMachine を渡す)。
+  // テスト的には任意の Standard SM があれば良いので minimal Pass で組む。
+  const childSm = new StateMachine(stack, "ChildSm", {
+    definition: new Pass(stack, "ChildPass"),
+  });
+  new BulkDeployCreateStateMachine(stack, "Bulk", {
+    childStateMachine: childSm,
+    payloadBucket,
+  });
+  return { stack, template: Template.fromStack(stack) };
+}
+
+function asJsonString(definitionString: unknown): string {
+  if (typeof definitionString === "string") return definitionString;
+  const join = (definitionString as { "Fn::Join": [string, unknown[]] })["Fn::Join"];
+  const parts = join[1] as Array<string | Record<string, unknown>>;
+  return parts.map((p) => (typeof p === "string" ? p : "ARN_PLACEHOLDER")).join("");
+}
+
+describe("BulkDeployCreateStateMachine", () => {
+  it("Distributed Map state を含むべき (= Standard Map ではない、 750 batch のため)", () => {
+    const { template } = buildStack();
+    const sm = Object.values(template.findResources("AWS::StepFunctions::StateMachine")).find(
+      (r) => {
+        const def = asJsonString(r.Properties?.DefinitionString);
+        return def.includes("DeployItemsMap");
+      },
+    );
+    expect(sm).toBeDefined();
+    const def = asJsonString(sm?.Properties?.DefinitionString);
+    expect(def).toContain('"Type":"Map"');
+    expect(def).toContain('"ProcessorConfig"');
+    expect(def).toContain('"Mode":"DISTRIBUTED"');
+    expect(def).toContain('"ExecutionType":"STANDARD"');
+  });
+
+  it("MaxConcurrency が ADR-001 §3 で fix された 50 であるべき", () => {
+    const { template } = buildStack();
+    const sm = Object.values(template.findResources("AWS::StepFunctions::StateMachine")).find(
+      (r) => {
+        const def = asJsonString(r.Properties?.DefinitionString);
+        return def.includes("DeployItemsMap");
+      },
+    );
+    const def = asJsonString(sm?.Properties?.DefinitionString);
+    expect(def).toContain('"MaxConcurrency":50');
+  });
+
+  it("S3 ItemReader を含む (= JSON array of deployments を読む)", () => {
+    const { template } = buildStack();
+    const sm = Object.values(template.findResources("AWS::StepFunctions::StateMachine")).find(
+      (r) => {
+        const def = asJsonString(r.Properties?.DefinitionString);
+        return def.includes("DeployItemsMap");
+      },
+    );
+    const def = asJsonString(sm?.Properties?.DefinitionString);
+    expect(def).toContain('"ItemReader"');
+    expect(def).toContain('"Resource":"arn:');
+    expect(def).toContain("s3:getObject");
+    expect(def).toContain('"ReaderConfig"');
+    expect(def).toContain('"InputType":"JSON"');
+  });
+
+  it("S3 Bucket への Read 権限が State Machine Role に付くべき", () => {
+    const { template } = buildStack();
+    // IAM policy で s3:GetObject + s3:ListBucket が付く
+    template.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(["s3:GetObject*"]),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("Child State Machine の StartExecution 権限が付くべき", () => {
+    const { template } = buildStack();
+    template.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "states:StartExecution",
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Refs #910 (Phase 2.C を 3 段階に分割、 本 PR は 2.C.1)

## Summary

Issue #910 (#895 Phase 2.C) の foundation 層 (2.C.1)。 Distributed Map + S3 ItemReader + child State Machine 起動の **CDK construct のみ** を作る。 既存 fan-out 経路 (= 単発 \`DeployCreateRequested\` 経路) には触らず coexist。

## 追加

| component | 内容 |
|---|---|
| \`BulkDeployCreateStateMachine\` construct | \`DistributedMap\` + \`MaxConcurrency: 50\` (ADR-001 §3) + \`S3JsonItemReader\` + \`StepFunctionsStartExecution\` で child SM (= 既存 DeployCreateStateMachine) を invoke |
| \`BulkDeployCreateRequestedDetailSchema\` | \`batchId\` / \`tenantId\` / \`s3Bucket\` / \`s3Key\` / \`itemCount\` の zod schema |
| \`EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED\` 定数 | event type 文字列、 Producer / Consumer 共有 |
| vitest 5 件 | Distributed Map / MaxConcurrency=50 / ItemReader / S3 grant / child SM StartExecution grant の ASL pin |

## 設計判断

| 判断 | 理由 |
|---|---|
| \`MaxConcurrency: 50\` 固定 | ADR-001 §3。 cross-account API rate limit / CFn quota との均衡。 operator が UI で調整しない |
| \`ProcessorMode: DISTRIBUTED, ExecutionType: STANDARD\` | child execution が \`CodeBuildStartBuild .sync\` を使うため Express 不可 (= ADR-001 §3) |
| \`ToleratedFailure* 未設定\` | ADR-001 §4 \"continue + summary\"。 失敗を error 扱いにせず最後まで試す |
| 親 timeout = 3 hours | 750 件 × 5-10 min / MaxConcurrency 50 ≈ 113 min の余裕分 |
| \`IntegrationPattern.REQUEST_RESPONSE\` | async fan-out。 各 child の終了は child 自身が DDB に書き戻す。 親は item を Start するだけで次へ進む |

## Phase 2.C 残 (= 別 PR)

- **2.C.2**: \`bulk-deploy.ts\` handler の refactor
  - 旧 fan-out (= N×M 個の DeployCreateRequested を publish) を撤廃
  - S3 PutObject + 1 BulkDeployCreateRequested publish に置換
  - EventBridge Rule 追加 (\`BulkDeployCreateRequested\` → \`BulkDeployCreateStateMachine\`)
  - S3 Bucket 構築 + IAM grant (= API Lambda が PutObject)
- **2.C.3**: 750 batch smoke test、 ADR-001 §3 の 113 min 見積りの実測

## Regression / 物理影響

- **NO-OP** (= construct を作っただけで stack instance に inject していない)。 既存 CFn template には追加 resource は **0 件**
- 既存 \`DeployCreateStateMachine\` / \`DeployDeleteStateMachine\` / EventBridge Rule に変更なし
- 後続 2.C.2 で \`ProblemDeployBackendStack\` に組み込んで初めて CFn 上に State Machine + IAM Role + S3 Bucket が物理化される

## Test plan

- [x] \`bun run test test/problem-deploy/bulk-deploy-create-state-machine.test.ts\`: 5 件 pass
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green

## References

- Issue #910 (Phase 2.C)、 Issue #895 (親)
- ADR-001 §3 (= Distributed Map 採用根拠、 MaxConcurrency 50 固定の根拠)
- ADR-001 §4 (= ToleratedFailure 未設定 = continue + summary の方針)
- Phase 2.A (PR #908) で打った CFn stack tag (\`TenkaCloud:BatchId\`) が本 PR の \`batchId\` 値と対応する