### PR TITLE
feat(#910 Phase 2.C.2.a): BulkDeployCreateStateMachine を ProblemDeployBackendStack に wire

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-event-rule.ts
+++ b/infrastructure/lib/problem-deploy/deploy-event-rule.ts
@@ -3,6 +3,7 @@ import { SfnStateMachine } from "aws-cdk-lib/aws-events-targets";
 import type { IStateMachine } from "aws-cdk-lib/aws-stepfunctions";
 import { Construct } from "constructs";
 import {
+  EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
   EVENT_SOURCE,
@@ -68,6 +69,36 @@ export class DeployDeleteEventRule extends Construct {
       eventPattern: {
         source: [EVENT_SOURCE],
         detailType: [EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED],
+      },
+      targets: [new SfnStateMachine(props.stateMachine)],
+    });
+  }
+}
+
+export interface BulkDeployCreateEventRuleProps {
+  readonly eventBus: IEventBus;
+  /** Rule の Target になる State Machine (= `BulkDeployCreateStateMachine`)。 */
+  readonly stateMachine: IStateMachine;
+}
+
+/**
+ * Issue #910 (#895 Phase 2.C): `BulkDeployCreateRequested` event を
+ * `BulkDeployCreateStateMachine` (= Distributed Map) にルーティングする EventBridge Rule。
+ * 単発 `DeployCreateRequested` は従来通り `DeployCreateStateMachine` に流れ、 同 EventBus
+ * 上で detail-type で route 分岐する。
+ */
+export class BulkDeployCreateEventRule extends Construct {
+  public readonly rule: Rule;
+
+  constructor(scope: Construct, id: string, props: BulkDeployCreateEventRuleProps) {
+    super(scope, id);
+
+    this.rule = new Rule(this, "Rule", {
+      eventBus: props.eventBus,
+      description: `Route ${EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED} events to BulkDeployCreateStateMachine`,
+      eventPattern: {
+        source: [EVENT_SOURCE],
+        detailType: [EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED],
       },
       targets: [new SfnStateMachine(props.stateMachine)],
     });

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -3,15 +3,20 @@ import { CfnOutput } from "aws-cdk-lib";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
-import { Bucket } from "aws-cdk-lib/aws-s3";
+import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
+import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine";
 import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda";
 import { CompetitorAccountsTable } from "./competitor-accounts-table";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine";
 import { DeployDeleteStateMachine } from "./deploy-delete-state-machine";
-import { DeployDeleteEventRule, DeployEventRule } from "./deploy-event-rule";
+import {
+  BulkDeployCreateEventRule,
+  DeployDeleteEventRule,
+  DeployEventRule,
+} from "./deploy-event-rule";
 import { DeploymentsTable } from "./deployments-table";
 import { DescribeStackLambda } from "./describe-stack-lambda";
 import { DisruptionsTable } from "./disruptions-table";
@@ -180,6 +185,16 @@ export class ProblemDeployBackendStack extends cdk.Stack {
   public readonly deployDeleteStateMachineArn: string;
   /** Problem deploy CodeBuild project name for CloudWatch metrics. */
   public readonly deployCodeBuildProjectName: string;
+  /**
+   * Issue #910 (#895 Phase 2.C): bulk batch deploy 用 Distributed Map State Machine ARN。
+   * 後続 PR (= 2.C.2.b) で API Lambda が `StartExecution` で起動する。
+   */
+  public readonly bulkDeployCreateStateMachineArn: string;
+  /**
+   * Issue #910: bulk batch payload S3 bucket。 後続 PR で API Lambda が deployment 配列を
+   * PutObject する。
+   */
+  public readonly bulkDeployPayloadBucketName: string;
 
   constructor(scope: Construct, id: string, props: ProblemDeployBackendStackProps) {
     super(scope, id, props);
@@ -299,6 +314,38 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       eventBus,
       stateMachine: deleteStateMachine.stateMachine,
     });
+
+    // Issue #910 (#895 Phase 2.C): bulk batch (= 750 deployments) を Distributed Map で
+    // 並列実行するための State Machine + S3 Bucket + EventBridge Rule。 Phase 2.C.2.a
+    // 段階では bulk-deploy.ts handler はまだこの経路を使わない (= 旧 fan-out が継続)。
+    // 後続 PR (2.C.2.b) で handler を S3 PutObject + 1 BulkDeployCreateRequested publish
+    // に切替える。
+    const bulkPayloadBucket = new Bucket(this, "BulkDeployPayloadBucket", {
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      // 旧 batch の object はもう不要なので 7 日で自動削除 (= cost / GC)。 retry API は
+      // jobId 単位で再投入する (= retry 経路で再 PutObject)、 batch object 自体は短命。
+      lifecycleRules: [
+        {
+          expiration: cdk.Duration.days(7),
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
+        },
+      ],
+    });
+    const bulkStateMachine = new BulkDeployCreateStateMachine(this, "BulkDeployCreate", {
+      childStateMachine: stateMachine.stateMachine,
+      payloadBucket: bulkPayloadBucket,
+    });
+    new BulkDeployCreateEventRule(this, "BulkDeployCreateRule", {
+      eventBus,
+      stateMachine: bulkStateMachine.stateMachine,
+    });
+    // outputs: handler refactor (= 2.C.2.b) で API Lambda が PutObject に使う。
+    this.bulkDeployPayloadBucketName = bulkPayloadBucket.bucketName;
+    this.bulkDeployCreateStateMachineArn = bulkStateMachine.stateMachine.stateMachineArn;
 
     // ADR-012 Phase 3.B: 1 分間隔の Generic Scoring Lambda (= 旧 HealthCheckLambda の後継)。
     // 2 つの責務を持つ:

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -152,8 +152,8 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("Step Functions State Machine + EventBridge Rule", () => {
-    it("Create / Delete の State Machine を 2 つ作るべき", () => {
-      tpl.resourceCountIs("AWS::StepFunctions::StateMachine", 2);
+    it("Create / Delete / BulkCreate の State Machine を 3 つ作るべき (Issue #910 Phase 2.C.2.a)", () => {
+      tpl.resourceCountIs("AWS::StepFunctions::StateMachine", 3);
     });
 
     it("Create State Machine は CodeBuild 起動前に PENDING → IN_PROGRESS の中間遷移を書くべき", () => {
@@ -247,12 +247,13 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(deleteStateMachine).toContain("MarkFailed");
     });
 
-    it("EventBridge Rule を Create / Delete / GenericScoring / ExternalIdAudit schedule で 4 つ持つべき", () => {
+    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule で 5 つ持つべき (Issue #910 Phase 2.C.2.a)", () => {
       // 旧 2 (Create / Delete state-machine event rules)
+      //   + BulkCreate (Issue #910 Phase 2.C: BulkDeployCreateRequested → Distributed Map)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)
       //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
-      // = 4。GenericScoring は scoring 問題が無い tenant でも reconcile 用に常時 instantiate される。
-      tpl.resourceCountIs("AWS::Events::Rule", 4);
+      // = 5。GenericScoring は scoring 問題が無い tenant でも reconcile 用に常時 instantiate される。
+      tpl.resourceCountIs("AWS::Events::Rule", 5);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({


### PR DESCRIPTION
Refs #910 (Phase 2.C を更に分割、 本 PR は 2.C.2.a)

## Summary

PR #921 で作った \`BulkDeployCreateStateMachine\` construct を実際の \`ProblemDeployBackendStack\` に組み込む。 これで CFn 上に State Machine + S3 Bucket + EventBridge Rule が物理化される。 Handler refactor (= 2.C.2.b) は別 PR。

## 変更

| 追加リソース | 用途 |
|---|---|
| \`BulkDeployPayloadBucket\` (S3) | bulk batch (= 750 deployments の JSON array) を payload 保存。 BLOCK_ALL public + SSE + 7 日 lifecycle expiration |
| \`BulkDeployCreate\` (Step Functions) | Distributed Map iterator + child = DeployCreateStateMachine |
| \`BulkDeployCreateRule\` (EventBridge Rule) | \`BulkDeployCreateRequested\` event → State Machine |

stack の public properties に \`bulkDeployCreateStateMachineArn\` / \`bulkDeployPayloadBucketName\` を追加 (= 後続 2.C.2.b で API Lambda が StartExecution + PutObject に使う)。

## CFn 物理影響

- **NEW** (3 リソース): S3 Bucket + Bucket Policy + AutoDelete Lambda + State Machine + Role + LogGroup + EventBridge Rule
- **NO-OP** (既存 deploy paths): DeployCreate / DeployDelete state machines、 既存 EventBridge Rules は完全 unchanged
- 既存 single-shot fan-out 経路 (= bulk-deploy.ts) は coexist で残り、 旧 deploy 動作は不変

## Test plan

- [x] \`bun run test\` 全 workspace: 1648 件 pass (= 1074 infrastructure + 126 admin-console + 239 application-admin-console + 159 participant-portal + 50 trust-bridge)
- [x] \`bun run test test/problem-deploy-backend-stack.test.ts\`: 34 件 pass (= 2 件の SM/Rule カウント assertion を更新)
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green

## Phase 2.C 残

- **2.C.2.b**: \`bulk-deploy.ts\` handler の refactor (= S3 PutObject + 1 event publish、 fan-out 撤廃、 IAM 追加、 env 注入)
- **2.C.3**: 750 batch smoke test (= ADR-001 §3 の 113 min 見積り実測)

## References

- PR #921 (Phase 2.C.1 foundation): 本 PR の prerequisite
- Issue #910 / Issue #895 (= 親)
- ADR-001 §3 (= Distributed Map 採用根拠)