### PR TITLE
feat(#910 Phase 2.C.2.b): bulk-deploy.ts handler に S3 PutObject + 1 event publish 経路 (feature flag 切替)

### DIFF
--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -4,6 +4,7 @@ import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import type { IEventBus } from "aws-cdk-lib/aws-events";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import type { IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
@@ -54,6 +55,17 @@ export interface EventApiLambdaProps {
    * Lambda と同じ env 名)。
    */
   readonly environmentName: string;
+  /**
+   * Issue #910 (#895 Phase 2.C): bulk batch payload を保存する S3 bucket。 未配線
+   * (= 旧 fan-out のみ) なら undefined。 wire 時に bulk-deploy.ts が PutObject で
+   * deployment 配列を書き、 1 BulkDeployCreateRequested event を publish する。
+   */
+  readonly bulkDeployPayloadBucket?: IBucket;
+  /**
+   * Issue #910: Distributed Map 経路への切替 flag。 "true" で bulk-deploy.ts が S3 PutObject
+   * + 1 event publish に切替。 未設定 / "false" は旧 fan-out 維持 (= rollback safety)。
+   */
+  readonly useBulkDistributedMap?: boolean;
 }
 
 /**
@@ -97,6 +109,10 @@ export class EventApiLambda extends Construct {
         // Issue #888: disruption fire / catalog / audit Lambda 経路で参照
         DISRUPTIONS_TABLE_NAME: props.disruptionsTable.tableName,
         BATTLE_PROBLEMS_DISRUPTIONS: JSON.stringify(props.problemsDisruptions),
+        // Issue #910 (#895 Phase 2.C.2.b): bulk batch payload S3 bucket + feature flag。
+        // bucket 未配線時は空文字、 flag は default false (= 旧 fan-out 維持)。
+        BULK_DEPLOY_PAYLOAD_BUCKET: props.bulkDeployPayloadBucket?.bucketName ?? "",
+        BULK_DEPLOY_VIA_DISTRIBUTED_MAP: props.useBulkDistributedMap ? "true" : "false",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -120,5 +136,11 @@ export class EventApiLambda extends Construct {
     // Issue #888: disruption audit + idempotency 用に RW、 EventBus PutEvents は既存付与で十分
     // (= disruption fire でも同 bus に publish するため)。
     props.disruptionsTable.grantReadWriteData(this.fn);
+    // Issue #910 (#895 Phase 2.C.2.b): bulk payload bucket への PutObject 権限。 bucket が
+    // 渡されたときのみ grant (= 未配線時の余分な IAM を避ける)。 useBulkDistributedMap が
+    // false でも grant を入れておくと、 flag を flip するだけで切替できる (= 段階移行)。
+    if (props.bulkDeployPayloadBucket) {
+      props.bulkDeployPayloadBucket.grantPut(this.fn);
+    }
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy.ts
@@ -1,4 +1,5 @@
 import { PutEventsCommand, type PutEventsRequestEntry } from "@aws-sdk/client-eventbridge";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import {
   GetCommand,
   QueryCommand,
@@ -15,6 +16,7 @@ import {
 } from "../shared/competitor-account-lookup.js";
 import {
   type DeployCreateRequestedDetail,
+  EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   EVENT_SOURCE,
 } from "../shared/events.js";
@@ -422,13 +424,41 @@ export async function bulkDeployEvent(
 
   const items = plan.map((p) => p.item);
 
-  // EventBridge PutEvents は 1 call 10 entries まで。chunk を Promise.all で並列発火。
-  // DDB row 作成後の publish 失敗は PENDING 放置にしない。失敗分だけ FAILED に倒せば
-  // operator が retryFailedOnly で復旧でき、duplicate deploy は既存 row として skip される。
+  // Issue #910 (#895 Phase 2.C.2.b): feature flag で publish 経路を分岐。
+  //   - true  → S3 PutObject + 1 BulkDeployCreateRequested → Distributed Map
+  //   - false → 旧 fan-out (= N×M 個の DeployCreateRequested を PutEvents、 default 維持)
+  // 切替の rollback safety:
+  //   - 旧 path は完全 untouched (= 切り戻し時 env を false にするだけ)
+  //   - 新 path で publish が失敗したら 既存 markPublishFailuresFailed で全 plan を
+  //     FAILED に倒して operator が retryFailedOnly で復旧する
+  const useDistributedMap =
+    shared.useBulkDistributedMap && shared.bulkDeployPayloadBucket.length > 0;
+
   const putChunks: Promise<PublishFailure[]>[] = [];
-  for (let i = 0; i < plan.length; i += PUT_EVENTS_BATCH) {
-    const chunk = plan.slice(i, i + PUT_EVENTS_BATCH);
-    putChunks.push(publishPlanChunk(shared, chunk));
+  if (useDistributedMap) {
+    // 新 path: deployment 配列を S3 に PutObject → 1 BulkDeployCreateRequested publish。
+    // batchId は eventId-tenantId-timestamp で衝突回避。 retry (= operator が同 event を
+    // 再叩き) でも別 batchId になり、 旧 batch の S3 object は lifecycle (7 日) で自動削除。
+    const batchId = ulid();
+    const details = plan.map(
+      (p) => JSON.parse(p.entry.Detail ?? "{}") as DeployCreateRequestedDetail,
+    );
+    putChunks.push(
+      publishViaDistributedMap(shared, {
+        batchId,
+        tenantId,
+        details,
+        eventId,
+      }),
+    );
+  } else {
+    // 旧 path: EventBridge PutEvents は 1 call 10 entries まで。chunk を Promise.all で並列発火。
+    // DDB row 作成後の publish 失敗は PENDING 放置にしない。失敗分だけ FAILED に倒せば
+    // operator が retryFailedOnly で復旧でき、duplicate deploy は既存 row として skip される。
+    for (let i = 0; i < plan.length; i += PUT_EVENTS_BATCH) {
+      const chunk = plan.slice(i, i + PUT_EVENTS_BATCH);
+      putChunks.push(publishPlanChunk(shared, chunk));
+    }
   }
 
   // Event status を DRAFT → DEPLOYING に倒す。operator が EventDetail の status badge で
@@ -481,6 +511,99 @@ export async function bulkDeployEvent(
 interface PublishFailure {
   readonly jobId: string;
   readonly reason: string;
+}
+
+/**
+ * Issue #910 (#895 Phase 2.C.2.b): Distributed Map 経路。 deployment 配列を S3 に PutObject
+ * (= 1 call で payload を整理)、 続いて 1 \`BulkDeployCreateRequested\` event を publish。
+ * Step Functions State Machine 側で \`S3JsonItemReader\` が読んで Distributed Map で N×M
+ * child execution を並列起動する (= PR #921 で構築済の foundation)。
+ *
+ * 失敗モード:
+ *   - S3 PutObject 失敗 → 全 plan を FAILED に倒す (= 旧 path の "1 event publish 失敗時
+ *     全件 FAILED" と同セマンティクス)
+ *   - PutEvents 失敗 → 同上
+ *   - State Machine 内 child 失敗 → 個別 deployment は child SM 内で FAILED に倒れる (=
+ *     既存 DeployCreateStateMachine の挙動)。 親 Map は ToleratedFailure 未設定で全 item
+ *     を最後まで試す
+ */
+async function publishViaDistributedMap(
+  shared: EventSharedResources,
+  args: {
+    readonly batchId: string;
+    readonly tenantId: string;
+    readonly eventId: string;
+    readonly details: readonly DeployCreateRequestedDetail[];
+  },
+): Promise<PublishFailure[]> {
+  const { batchId, tenantId, eventId, details } = args;
+  const s3Key = `batches/${batchId}/deployments.json`;
+  // S3 PutObject: payload = deployment 配列。 Distributed Map の S3JsonItemReader が
+  // この shape (= top-level array) を要求する。 Content-Type は明示しないと Step Functions
+  // 側で text/plain と誤認することがあるので application/json を強制。
+  try {
+    await shared.s3.send(
+      new PutObjectCommand({
+        Bucket: shared.bulkDeployPayloadBucket,
+        Key: s3Key,
+        Body: JSON.stringify(details),
+        ContentType: "application/json",
+        // 短命 + バケット自体に lifecycle (7 日) が掛かっているので追加 expires は不要。
+      }),
+    );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return details.map((d) => ({
+      jobId: d.jobId,
+      reason: `S3 PutObject failed for bulk payload: ${reason}`,
+    }));
+  }
+
+  // 1 BulkDeployCreateRequested event を publish。 EventBridge Rule (PR #922 で wire 済) が
+  // BulkDeployCreateStateMachine を起動する。 親 1 execution = 1 batch、 child は item 数分。
+  try {
+    const out = await shared.events.send(
+      new PutEventsCommand({
+        Entries: [
+          {
+            EventBusName: shared.eventBusName,
+            Source: EVENT_SOURCE,
+            DetailType: EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED,
+            Detail: JSON.stringify({
+              batchId,
+              tenantId,
+              s3Bucket: shared.bulkDeployPayloadBucket,
+              s3Key,
+              itemCount: details.length,
+            }),
+            Resources: [`tenkacloud:bulk-deploy:${batchId}`, `tenkacloud:event:${eventId}`],
+          },
+        ],
+      }),
+    );
+    if ((out.FailedEntryCount ?? 0) > 0) {
+      const reason = out.Entries?.[0]?.ErrorMessage ?? "EventBridge PutEvents failed";
+      return details.map((d) => ({
+        jobId: d.jobId,
+        reason: `BulkDeployCreateRequested publish failed: ${reason}`,
+      }));
+    }
+    logDeployTrace("bulk-deploy.distributed_map.published", {
+      correlationId: batchId,
+      tenantId,
+      eventId,
+      itemCount: details.length,
+      s3Bucket: shared.bulkDeployPayloadBucket,
+      s3Key,
+    });
+    return [];
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return details.map((d) => ({
+      jobId: d.jobId,
+      reason: `BulkDeployCreateRequested publish failed: ${reason}`,
+    }));
+  }
 }
 
 async function publishPlanChunk(

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import { S3Client } from "@aws-sdk/client-s3";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
 import type { ProblemDisruptionEntry } from "../../../utils/discover-problems-catalog.js";
@@ -30,9 +31,22 @@ export interface EventSharedResources {
   readonly env: string;
   readonly ddb: DynamoDBDocumentClient;
   readonly events: EventBridgeClient;
+  readonly s3: S3Client;
   readonly problemsCatalog: Readonly<Record<string, string>>;
   /** Issue #888: problem metadata.json の `disruptions[]` 宣言 (problemId 毎)。 */
   readonly problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>;
+  /**
+   * Issue #910 (#895 Phase 2.C): bulk batch を Distributed Map 経路で実行するときの
+   * S3 payload bucket。 未配線 (= 旧 fan-out 経路) なら空文字。
+   */
+  readonly bulkDeployPayloadBucket: string;
+  /**
+   * Issue #910: Distributed Map 経路を使うかどうかの feature flag (= env 由来)。
+   * "true" のとき S3 PutObject + 1 BulkDeployCreateRequested publish に切替。
+   * それ以外 (= "" / "false" / 未設定) なら旧 fan-out (= N×M 個の DeployCreateRequested
+   * publish) を維持する。 段階移行で rollback 可能にする。
+   */
+  readonly useBulkDistributedMap: boolean;
 }
 
 export function buildEventSharedResources(): EventSharedResources {
@@ -46,8 +60,12 @@ export function buildEventSharedResources(): EventSharedResources {
     env: getEnv("DEPLOY_ENVIRONMENT"),
     ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
     events: new EventBridgeClient({}),
+    s3: new S3Client({}),
     problemsCatalog: parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG),
     problemsDisruptions: parseProblemsDisruptions(process.env.BATTLE_PROBLEMS_DISRUPTIONS),
+    bulkDeployPayloadBucket: process.env.BULK_DEPLOY_PAYLOAD_BUCKET ?? "",
+    useBulkDistributedMap:
+      (process.env.BULK_DEPLOY_VIA_DISTRIBUTED_MAP ?? "").toLowerCase() === "true",
   };
 }
 

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -90,6 +90,13 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    */
   readonly problemsDisruptions?: Readonly<Record<string, unknown>>;
   /**
+   * Issue #910 (#895 Phase 2.C.2.b): bulk batch deploy を Distributed Map 経路で実行するか
+   * (= EventApiLambda の \`BULK_DEPLOY_VIA_DISTRIBUTED_MAP\` env で切替)。 default=false で
+   * 旧 fan-out 経路を維持し、 deploy 後に true に切替えて Distributed Map に移行する。
+   * rollback も flag を false に戻すだけ。
+   */
+  readonly useBulkDistributedMap?: boolean;
+  /**
    * ADR-008 Phase 3 (Issue #642): `problemId → "private"` の map。
    * `discoverProblemsVisibility` で metadata.json から自動収集。 空 map なら全 public 扱い (dormant)。
    */
@@ -244,6 +251,25 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     });
     this.deployApiLambda = deployApi.fn;
 
+    // Issue #910 (#895 Phase 2.C.2.b): bulk batch payload S3 bucket。 EventApiLambda の
+    // bulk-deploy handler が PutObject で deployment 配列を書く。 default では feature flag
+    // off で旧 fan-out 維持、 flag flip で Distributed Map 経路 (= 後段 BulkDeployCreateStateMachine)
+    // に切替。 bucket 自体は flag に関係なく作る (= flip だけで切替可能、 段階移行)。
+    const bulkPayloadBucket = new Bucket(this, "BulkDeployPayloadBucket", {
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      // 旧 batch の object はもう不要なので 7 日で自動削除 (= cost / GC)。
+      lifecycleRules: [
+        {
+          expiration: cdk.Duration.days(7),
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
+        },
+      ],
+    });
+
     // ADR-004 Phase 1+2a: Event / Team CRUD + Bulk Deploy/Teardown Lambda。
     // Phase 2a で deployment 行の作成 / status 更新 + EventBridge fan-out publish を担う。
     // Phase 2.2 (Issue #459): CompetitorAccounts table + env を渡して verified-only gate を有効化。
@@ -261,6 +287,9 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsDisruptions: (props.problemsDisruptions ?? {}) as Readonly<
         Record<string, readonly unknown[]>
       >,
+      // Issue #910 Phase 2.C.2.b: bulk batch payload bucket + feature flag。
+      bulkDeployPayloadBucket: bulkPayloadBucket,
+      useBulkDistributedMap: props.useBulkDistributedMap ?? false,
     });
     this.eventApiLambda = eventApi.fn;
 
@@ -315,26 +344,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       stateMachine: deleteStateMachine.stateMachine,
     });
 
-    // Issue #910 (#895 Phase 2.C): bulk batch (= 750 deployments) を Distributed Map で
-    // 並列実行するための State Machine + S3 Bucket + EventBridge Rule。 Phase 2.C.2.a
-    // 段階では bulk-deploy.ts handler はまだこの経路を使わない (= 旧 fan-out が継続)。
-    // 後続 PR (2.C.2.b) で handler を S3 PutObject + 1 BulkDeployCreateRequested publish
-    // に切替える。
-    const bulkPayloadBucket = new Bucket(this, "BulkDeployPayloadBucket", {
-      encryption: BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      // 旧 batch の object はもう不要なので 7 日で自動削除 (= cost / GC)。 retry API は
-      // jobId 単位で再投入する (= retry 経路で再 PutObject)、 batch object 自体は短命。
-      lifecycleRules: [
-        {
-          expiration: cdk.Duration.days(7),
-          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
-        },
-      ],
-    });
+    // Issue #910 (#895 Phase 2.C): Distributed Map state machine + EventBridge Rule。
+    // bulkPayloadBucket は上で EventApiLambda 用に先行生成済 (= bucket logical ID 維持)。
     const bulkStateMachine = new BulkDeployCreateStateMachine(this, "BulkDeployCreate", {
       childStateMachine: stateMachine.stateMachine,
       payloadBucket: bulkPayloadBucket,

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -761,4 +761,96 @@ describe("bulkDeployEvent", () => {
     );
     expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
+
+  // Issue #910 (#895 Phase 2.C.2.b): Distributed Map 経路の feature-flag 切替 test。
+  // useBulkDistributedMap=true + bulkDeployPayloadBucket 設定済のとき、 fan-out (= N×M
+  // 個の DeployCreateRequested publish) ではなく S3 PutObject + 1 BulkDeployCreateRequested
+  // publish に切替わるべき。
+  it("useBulkDistributedMap=true なら S3 PutObject + 1 BulkDeployCreateRequested に切替えるべき", async () => {
+    const s3Send = vi.fn().mockResolvedValue({});
+    const { shared, ddbSend, eventsSend } = buildShared({
+      s3: { send: s3Send } as unknown as EventSharedResources["s3"],
+      bulkDeployPayloadBucket: "test-bulk-bucket",
+      useBulkDistributedMap: true,
+    });
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+
+    // S3 PutObject が exactly 1 回。 batches/<batchId>/deployments.json に書く。
+    const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+    const s3Calls = s3Send.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is InstanceType<typeof PutObjectCommand> => c instanceof PutObjectCommand);
+    expect(s3Calls).toHaveLength(1);
+    expect(s3Calls[0]?.input.Bucket).toBe("test-bulk-bucket");
+    expect(s3Calls[0]?.input.Key).toMatch(/^batches\/[0-9A-Z]+\/deployments\.json$/);
+    expect(s3Calls[0]?.input.ContentType).toBe("application/json");
+    // S3 body は deployment 配列の JSON
+    const body = JSON.parse(String(s3Calls[0]?.input.Body ?? "[]"));
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body[0].jobId).toBeDefined();
+
+    // EventBridge は BulkDeployCreateRequested を **1 回だけ** publish (= fan-out 撤廃)。
+    const eventCalls = eventsSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is PutEventsCommand => c instanceof PutEventsCommand);
+    expect(eventCalls).toHaveLength(1);
+    expect(eventCalls[0]?.input.Entries?.[0]?.DetailType).toBe("BulkDeployCreateRequested");
+    const bulkDetail = JSON.parse(String(eventCalls[0]?.input.Entries?.[0]?.Detail ?? "{}"));
+    expect(bulkDetail.s3Bucket).toBe("test-bulk-bucket");
+    expect(bulkDetail.s3Key).toMatch(/^batches\/[0-9A-Z]+\/deployments\.json$/);
+    expect(bulkDetail.tenantId).toBe("tenant-acme");
+    expect(bulkDetail.itemCount).toBe(body.length);
+  });
+
+  it("useBulkDistributedMap=true でも S3 PutObject が失敗したら 全 plan を FAILED に倒すべき", async () => {
+    const s3Send = vi.fn().mockRejectedValue(new Error("S3 throttle"));
+    const { shared, ddbSend, eventsSend } = buildShared({
+      s3: { send: s3Send } as unknown as EventSharedResources["s3"],
+      bulkDeployPayloadBucket: "test-bulk-bucket",
+      useBulkDistributedMap: true,
+    });
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValue({});
+
+    await expect(bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS)).rejects.toThrow(
+      /S3 PutObject failed|PutEvents failed/,
+    );
+    // EventBridge は呼ばれない (= S3 失敗で早期中止)
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("useBulkDistributedMap=false なら旧 fan-out 経路を維持すべき (= rollback safety)", async () => {
+    const s3Send = vi.fn().mockResolvedValue({});
+    const { shared, ddbSend, eventsSend } = buildShared({
+      s3: { send: s3Send } as unknown as EventSharedResources["s3"],
+      bulkDeployPayloadBucket: "test-bulk-bucket",
+      useBulkDistributedMap: false, // 明示的に旧 path を使う
+    });
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockResolvedValue({});
+
+    await bulkDeployEvent(shared, "tenant-acme", "EV1", NOW_MS);
+
+    // S3 は触らない (= 旧 path)
+    expect(s3Send).not.toHaveBeenCalled();
+    // EventBridge は fan-out で複数 DeployCreateRequested を publish (= problems 2 × team 1 = 2 events)
+    const eventCalls = eventsSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is PutEventsCommand => c instanceof PutEventsCommand);
+    expect(eventCalls.length).toBeGreaterThan(0);
+    // 旧 path は DeployCreateRequested を publish (= BulkDeployCreateRequested ではない)
+    expect(eventCalls[0]?.input.Entries?.[0]?.DetailType).toBe("DeployCreateRequested");
+  });
 });


### PR DESCRIPTION
Refs #910 (Phase 2.C.2.b、 残 2.C.3 のみ)

## Summary

bulk-deploy.ts handler に **Distributed Map 経路** を追加。 feature flag \`BULK_DEPLOY_VIA_DISTRIBUTED_MAP\` で旧 fan-out (= N×M 個の event publish) と新 経路 (= S3 PutObject + 1 event publish) を切替える。 default = false で **runtime 挙動は不変**、 deploy 後に flag flip するだけで切替可能、 rollback も flip だけ。

## 経路の対比

| | 旧 path (default、 flag=false) | 新 path (flag=true) |
|---|---|---|
| EventBridge publish 数 | N×M (= deployments 数、 10-batch chunk) | **1** (= BulkDeployCreateRequested) |
| S3 PutObject | なし | 1 (= deployments.json) |
| 並列度の上限 | CodeBuild concurrent build quota (= region default 60) | **Distributed Map MaxConcurrency 50 で平準化** (ADR-001 §3) |
| 失敗時 | 旧 retry: \`markPublishFailuresFailed\` で 失敗分のみ FAILED | 全 plan を FAILED に倒して \`retryFailedOnly\` で復旧 (= PR #920 retry API と整合) |

## 切替 / rollback 手順

1. PR merge → CFn deploy で env \`BULK_DEPLOY_VIA_DISTRIBUTED_MAP=false\` で再 deploy (= 既存挙動不変)
2. operator が Lambda console で env を \`true\` に変更 (or CDK の \`useBulkDistributedMap: true\` で再 deploy)
3. 動作確認 (= 小 batch で 1 BulkDeployCreateRequested が publish される、 Distributed Map 親 execution が起動)
4. 問題があれば env を \`false\` に戻すだけ (= 旧 fan-out path が即座に復活)

## 変更ファイル

| layer | 変更 |
|---|---|
| handler | \`bulk-deploy.ts\` に \`publishViaDistributedMap\` + flag 切替 if 文 |
| shared | \`shared.ts\` に \`s3\` / \`bulkDeployPayloadBucket\` / \`useBulkDistributedMap\` 追加 |
| stack | \`BulkDeployPayloadBucket\` を EventApiLambda の前に move + 同 lambda に bucket + flag pass |
| lambda construct | \`event-api-lambda.ts\` に bucket prop + flag prop + env 注入 + \`grantPut\` |
| stack props | \`useBulkDistributedMap?: boolean\` で outermost CDK app から flag 注入可能 |
| tests | \`event-bulk-deploy.test.ts\` に 3 件追加 (= flag=true 切替 / S3 失敗 / flag=false rollback path) |

## Regression 分析

- **runtime 挙動は不変** (= default flag=false)
- 旧 fan-out path は完全 untouched (= 既存 27 件 test + 新 3 件 = 30 件 all pass)
- S3 PutObject 権限は flag に関係なく Lambda に付与 (= flip だけで切替できる必要)
- 旧 path 削除は **本 PR scope 外**。 1-2 週間 monitor して flag flip 経路が stable と判断したら別 PR で旧 path 撤廃

## 物理影響

- **NO-OP** (runtime): default flag=false で旧 path 維持
- **UPDATE** (CFn): EventApiLambda Role に \`s3:PutObject\` 追加 (= flag flip 準備)、 env 2 つ追加
- **MOVE** (CFn): \`BulkDeployPayloadBucket\` の construct path は logical ID 維持 (= Stack/BulkDeployPayloadBucket、 path 不変)

## Phase 2.C 残

- **2.C.3** (= 別 PR): 実環境で 750 batch smoke test。 flag flip して running event で deploy → ADR-001 §3 の 113 min 見積りを実測 → 結果を ADR-001 にフィードバック

## Test plan

- [x] \`bun run test\` 全 workspace: 1651 件 pass (= 1077 infrastructure + 126 admin-console + 239 application-admin-console + 159 participant-portal + 50 trust-bridge)
- [x] \`bun run test test/problem-deploy/event-bulk-deploy.test.ts\`: 30 件 pass (= 既存 27 + 新 3)
- [x] \`make harness\`: 0 findings
- [x] \`make before-commit\`: full green

## References

- PR #921 (= Phase 2.C.1 foundation): BulkDeployCreateStateMachine construct
- PR #922 (= Phase 2.C.2.a): stack に State Machine + EventBridge Rule wire
- PR #920 (= Phase 2.D): retry API、 失敗 jobId 再投入経路
- Issue #910 / Issue #895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk deployment capability with S3-backed payload distribution and distributed map pattern for improved deployment efficiency
  * Introduced feature flag configuration options for controlling bulk deployment behavior across deployment infrastructure

* **Tests**
  * Added comprehensive test coverage for bulk deployment distributed map scenarios, including success and error handling paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->