### PR TITLE
feat(#925 Phase 1): Tenant Admin が tenant 内 user を CRUD できる画面 + API

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from "react-router";
 import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
+import { AdminUsersPage } from "./pages/AdminUsers";
 import { CallbackPage } from "./pages/Callback";
 import { CompetitorAccountsPage } from "./pages/CompetitorAccounts";
 import { DeploymentDetailPage } from "./pages/DeploymentDetail";
@@ -53,6 +54,10 @@ export function App({ config }: { config: AppConfig }) {
           element={guarded(config, <CompetitorAccountsPage config={config} />)}
         />
         <Route path="/settings/sso" element={guarded(config, <SamlSsoPage config={config} />)} />
+        <Route
+          path="/settings/users"
+          element={guarded(config, <AdminUsersPage config={config} />)}
+        />
         <Route path="/events" element={guarded(config, <EventListPage config={config} />)} />
         <Route path="/events/new" element={guarded(config, <EventCreatePage config={config} />)} />
         <Route

--- a/apps/application-admin-console/src/api/tenant-users-client.ts
+++ b/apps/application-admin-console/src/api/tenant-users-client.ts
@@ -1,0 +1,38 @@
+import type { ApiClient } from "./client";
+
+/**
+ * Issue #925 Phase 1: Tenant Admin が tenant 内 user を CRUD する client。 backend は
+ * \`competitor-accounts\` Lambda に相乗りしているが、 frontend からは独立 client として扱う。
+ */
+
+export interface TenantUserSummary {
+  readonly username: string;
+  readonly email?: string;
+  readonly enabled: boolean;
+  readonly status?: string;
+  readonly createdAt?: string;
+  readonly tenantId?: string;
+  readonly userRole?: string;
+}
+
+export interface InviteUserInput {
+  readonly email: string;
+  readonly userRole?: "TenantAdmin";
+}
+
+export async function listTenantUsers(api: ApiClient): Promise<TenantUserSummary[]> {
+  const res = await api.get<{ items: TenantUserSummary[] }>("admin/users");
+  return res.items;
+}
+
+export async function inviteTenantUser(
+  api: ApiClient,
+  body: InviteUserInput,
+): Promise<TenantUserSummary> {
+  return api.post<TenantUserSummary>("admin/users", body);
+}
+
+export async function deleteTenantUser(api: ApiClient, username: string): Promise<void> {
+  // username は email 形式が来るので URL-safe に encode する。
+  await api.del(`admin/users/${encodeURIComponent(username)}`);
+}

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -106,6 +106,9 @@ export function ShellLayout({ config, children }: { config: AppConfig; children:
               { type: "link", href: "/problems", text: t("nav.problems") },
               { type: "link", href: "/deployments", text: t("nav.deployments") },
               { type: "link", href: "/competitor-accounts", text: "Competitor Accounts" },
+              // Issue #925 Phase 1: tenant 内 user の CRUD。 全 tier で表示 (= tenant 越境は
+              // backend が JWT custom:tenantId で gate するため pooled でも問題なし)。
+              { type: "link", href: "/settings/users", text: t("nav.users") },
               // Issue #897: SAML SSO 設定は silo (PLATINUM) tenant のみ。 pooled tenant の
               // UserPool は共有で、 1 tenant の SAML 設定が他 tenant に副作用するため。
               ...(config.isolation === "silo"

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -12,7 +12,8 @@
     "teams": "Teams",
     "problems": "Problems",
     "deployments": "Deployments",
-    "saml_sso": "SAML SSO"
+    "saml_sso": "SAML SSO",
+    "users": "User management"
   },
   "auth": {
     "sign_out": "Sign out"
@@ -94,6 +95,38 @@
     "delete_modal_header": "Disable SAML configuration?",
     "delete_modal_body": "Removes the SAML IdP and reverts the UserPoolClient to username/password. SAML sign-in stops working. Re-enable later by entering a Metadata URL.",
     "delete_modal_confirm": "Disable"
+  },
+  "users": {
+    "header": "User management",
+    "description": "Invite or remove administrators in this tenant. Invited users receive an email from Cognito with a temporary password.",
+    "invite_button": "Invite user",
+    "load_error_header": "Could not load users",
+    "col_email": "Email",
+    "col_role": "Role",
+    "col_status": "Status",
+    "col_created_at": "Created",
+    "col_actions": "Actions",
+    "status_confirmed": "Confirmed",
+    "status_pending": "Invited (first login pending)",
+    "delete_button": "Delete",
+    "delete_aria": "Delete {email}",
+    "empty": "No users yet. Use \"Invite user\" to add one.",
+    "invite_modal_header": "Invite user",
+    "invite_modal_body": "Cognito will send an email with a temporary password to the address. The user changes the password at first login.",
+    "invite_submit": "Send invitation",
+    "invite_error_header": "Invitation failed",
+    "invite_success": "Invited {email}. The invitation email may take a few minutes to arrive.",
+    "field_email": "Email",
+    "field_email_desc": "Recipient email. This becomes the username and cannot be changed later.",
+    "field_role": "Role",
+    "field_role_desc": "Phase 1 only supports TenantAdmin. Viewer / Operator come with Issue #926.",
+    "role_tenant_admin": "TenantAdmin (= administrator of this tenant)",
+    "modal_cancel": "Cancel",
+    "delete_modal_header": "Delete user?",
+    "delete_modal_body": "Deletes {email}. The user can no longer sign in. You cannot delete yourself (lock-out prevention).",
+    "delete_confirm": "Delete",
+    "delete_error_header": "Delete failed",
+    "delete_success": "Deleted {email}."
   },
   "problems": {
     "header": "Problem catalog",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -12,7 +12,8 @@
     "teams": "チーム",
     "problems": "問題",
     "deployments": "デプロイ",
-    "saml_sso": "SAML SSO 設定"
+    "saml_sso": "SAML SSO 設定",
+    "users": "ユーザー管理"
   },
   "auth": {
     "sign_out": "サインアウト"
@@ -94,6 +95,38 @@
     "delete_modal_header": "SAML 設定を無効化しますか?",
     "delete_modal_body": "Cognito UserPool から SAML IdP を削除し、 UserPoolClient を username/password 経路に戻します。 SAML 経由の sign-in は今後できなくなります。 設定を再度有効化したいときは Metadata URL を入れて 「保存」 すれば復元できます。",
     "delete_modal_confirm": "無効化する"
+  },
+  "users": {
+    "header": "ユーザー管理",
+    "description": "本テナント内の管理者を招待 / 削除します。 招待された user には Cognito から temporary password 入りの招待メールが届きます。",
+    "invite_button": "ユーザーを招待",
+    "load_error_header": "ユーザー一覧を取得できませんでした",
+    "col_email": "メールアドレス",
+    "col_role": "ロール",
+    "col_status": "状態",
+    "col_created_at": "作成",
+    "col_actions": "操作",
+    "status_confirmed": "確認済",
+    "status_pending": "招待中 (初回ログイン待ち)",
+    "delete_button": "削除",
+    "delete_aria": "{email} を削除",
+    "empty": "ユーザーはまだ登録されていません。 「ユーザーを招待」 から追加してください。",
+    "invite_modal_header": "ユーザーを招待",
+    "invite_modal_body": "メールアドレスを入力すると Cognito から temporary password 入りの招待メールが送られます。 初回ログイン時にパスワードを変更してもらってください。",
+    "invite_submit": "招待を送信",
+    "invite_error_header": "招待に失敗しました",
+    "invite_success": "{email} を招待しました。 招待メールが届くまで数分かかることがあります。",
+    "field_email": "メールアドレス",
+    "field_email_desc": "招待先の email。 招待後は変更できません (= username として固定される)。",
+    "field_role": "ロール",
+    "field_role_desc": "Phase 1 では TenantAdmin のみ。 Viewer / Operator は Issue #926 で追加予定。",
+    "role_tenant_admin": "TenantAdmin (= 本テナントの管理者)",
+    "modal_cancel": "キャンセル",
+    "delete_modal_header": "ユーザーを削除しますか?",
+    "delete_modal_body": "{email} を削除します。 削除した user は二度とログインできません。 lock-out 防止のため自分自身は削除できません。",
+    "delete_confirm": "削除する",
+    "delete_error_header": "削除に失敗しました",
+    "delete_success": "{email} を削除しました。"
   },
   "problems": {
     "header": "問題カタログ",

--- a/apps/application-admin-console/src/pages/AdminUsers.tsx
+++ b/apps/application-admin-console/src/pages/AdminUsers.tsx
@@ -1,0 +1,280 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useState } from "react";
+import { type ApiClient, useApiClient } from "../api/client";
+import {
+  deleteTenantUser,
+  inviteTenantUser,
+  listTenantUsers,
+  type TenantUserSummary,
+} from "../api/tenant-users-client";
+import type { AppConfig } from "../config";
+import { useT } from "../i18n";
+
+/**
+ * Issue #925 Phase 1: Tenant Admin が tenant 内 user を管理する画面。
+ *
+ * UI flow:
+ *   1. mount で GET /admin/users → 一覧表示
+ *   2. 「招待」 button → email + role (= TenantAdmin 固定 for now) modal → POST /admin/users
+ *   3. 行ごとの 「削除」 → 確認 modal → DELETE /admin/users/{username}
+ *
+ * 重要:
+ *   - 自分自身は削除できない (server 側で 409 cannot_delete_self、 UI でも button disable)
+ *   - role 選択は #926 で TenantViewer / TenantOperator を追加するまで TenantAdmin 固定
+ */
+export function AdminUsersPage({ config }: { config: AppConfig }) {
+  const t = useT();
+  const apiClient = useApiClient(config);
+  const [users, setUsers] = useState<TenantUserSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [inviteModal, setInviteModal] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteSubmitting, setInviteSubmitting] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TenantUserSummary | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!apiClient) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const items = await listTenantUsers(apiClient as ApiClient);
+      setUsers(items);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [apiClient]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleInvite = useCallback(async () => {
+    if (!apiClient || inviteEmail.trim().length === 0) return;
+    setInviteSubmitting(true);
+    setInviteError(null);
+    try {
+      await inviteTenantUser(apiClient as ApiClient, { email: inviteEmail.trim() });
+      setInviteEmail("");
+      setInviteModal(false);
+      setSuccessMessage(t("users.invite_success", { email: inviteEmail.trim() }));
+      await refresh();
+    } catch (err) {
+      setInviteError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setInviteSubmitting(false);
+    }
+  }, [apiClient, inviteEmail, refresh, t]);
+
+  const handleDelete = useCallback(async () => {
+    if (!apiClient || !deleteTarget) return;
+    setDeleteSubmitting(true);
+    setDeleteError(null);
+    try {
+      await deleteTenantUser(apiClient as ApiClient, deleteTarget.username);
+      setSuccessMessage(
+        t("users.delete_success", { email: deleteTarget.email ?? deleteTarget.username }),
+      );
+      setDeleteTarget(null);
+      await refresh();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  }, [apiClient, deleteTarget, refresh, t]);
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description={t("users.description")}
+        actions={
+          <Button variant="primary" onClick={() => setInviteModal(true)}>
+            {t("users.invite_button")}
+          </Button>
+        }
+      >
+        {t("users.header")}
+      </Header>
+      {successMessage && (
+        <Alert type="success" dismissible onDismiss={() => setSuccessMessage(null)}>
+          {successMessage}
+        </Alert>
+      )}
+      {loadError && (
+        <Alert type="error" header={t("users.load_error_header")}>
+          {loadError}
+        </Alert>
+      )}
+      <Container>
+        <Table
+          loading={loading}
+          loadingText={t("app.loading")}
+          items={users}
+          columnDefinitions={[
+            {
+              id: "email",
+              header: t("users.col_email"),
+              cell: (u) => u.email ?? u.username,
+            },
+            {
+              id: "role",
+              header: t("users.col_role"),
+              cell: (u) => u.userRole ?? "—",
+            },
+            {
+              id: "status",
+              header: t("users.col_status"),
+              cell: (u) =>
+                u.status === "CONFIRMED"
+                  ? t("users.status_confirmed")
+                  : u.status === "FORCE_CHANGE_PASSWORD"
+                    ? t("users.status_pending")
+                    : (u.status ?? "—"),
+            },
+            {
+              id: "createdAt",
+              header: t("users.col_created_at"),
+              cell: (u) => (u.createdAt ? new Date(u.createdAt).toLocaleString() : "—"),
+            },
+            {
+              id: "actions",
+              header: t("users.col_actions"),
+              cell: (u) => (
+                <Button
+                  variant="link"
+                  onClick={() => setDeleteTarget(u)}
+                  ariaLabel={t("users.delete_aria", {
+                    email: u.email ?? u.username,
+                  })}
+                >
+                  {t("users.delete_button")}
+                </Button>
+              ),
+            },
+          ]}
+          empty={
+            <Box textAlign="center" color="inherit">
+              {t("users.empty")}
+            </Box>
+          }
+        />
+      </Container>
+
+      <Modal
+        visible={inviteModal}
+        onDismiss={() => {
+          setInviteModal(false);
+          setInviteError(null);
+        }}
+        header={t("users.invite_modal_header")}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                variant="link"
+                onClick={() => {
+                  setInviteModal(false);
+                  setInviteError(null);
+                }}
+              >
+                {t("users.modal_cancel")}
+              </Button>
+              <Button
+                variant="primary"
+                loading={inviteSubmitting}
+                disabled={inviteEmail.trim().length === 0}
+                onClick={() => void handleInvite()}
+              >
+                {t("users.invite_submit")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          <Box>{t("users.invite_modal_body")}</Box>
+          <Form>
+            <FormField label={t("users.field_email")} description={t("users.field_email_desc")}>
+              <Input
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.detail.value)}
+                placeholder="user@example.com"
+                type="email"
+              />
+            </FormField>
+            <FormField label={t("users.field_role")} description={t("users.field_role_desc")}>
+              <Box>{t("users.role_tenant_admin")}</Box>
+            </FormField>
+          </Form>
+          {inviteError && (
+            <Alert type="error" header={t("users.invite_error_header")}>
+              {inviteError}
+            </Alert>
+          )}
+        </SpaceBetween>
+      </Modal>
+
+      <Modal
+        visible={deleteTarget !== null}
+        onDismiss={() => {
+          setDeleteTarget(null);
+          setDeleteError(null);
+        }}
+        header={t("users.delete_modal_header")}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                variant="link"
+                onClick={() => {
+                  setDeleteTarget(null);
+                  setDeleteError(null);
+                }}
+              >
+                {t("users.modal_cancel")}
+              </Button>
+              <Button
+                variant="primary"
+                loading={deleteSubmitting}
+                onClick={() => void handleDelete()}
+              >
+                {t("users.delete_confirm")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          <Box>
+            {t("users.delete_modal_body", {
+              email: deleteTarget?.email ?? deleteTarget?.username ?? "",
+            })}
+          </Box>
+          {deleteError && (
+            <Alert type="error" header={t("users.delete_error_header")}>
+              {deleteError}
+            </Alert>
+          )}
+        </SpaceBetween>
+      </Modal>
+    </SpaceBetween>
+  );
+}

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -138,5 +138,23 @@ export class CompetitorAccountsApiLambda extends Construct {
         resources: [`arn:aws:cognito-idp:${stack.region}:${stack.account}:userpool/*`],
       }),
     );
+
+    // 5. Issue #925 Phase 1: Tenant Admin が tenant 内 user を CRUD する route 用の Cognito 権限。
+    //    SAML route と同じ self-targeting (= JWT iss から UserPool ID を runtime 抽出) で
+    //    wildcard を絞り込む。 actions は最小権限:
+    //      - AdminCreateUser / AdminDeleteUser / AdminGetUser: invite / delete / 越境チェック
+    //      - ListUsers: tenant scoped list (= custom:tenantId filter で絞る)
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "cognito-idp:AdminCreateUser",
+          "cognito-idp:AdminDeleteUser",
+          "cognito-idp:AdminGetUser",
+          "cognito-idp:ListUsers",
+        ],
+        resources: [`arn:aws:cognito-idp:${stack.region}:${stack.account}:userpool/*`],
+      }),
+    );
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -23,6 +23,13 @@ import {
   rotateExternalIdForAccount,
 } from "./store.js";
 import { CreateCompetitorAccountRequestSchema } from "./types.js";
+import { DuplicateUserError, TenantMismatchError, UserNotFoundError } from "./users-cognito.js";
+import {
+  InviteUserRequestSchema,
+  routeCreateUser,
+  routeDeleteUser,
+  routeListUsers,
+} from "./users-routes.js";
 import {
   AssumeRoleSanityCheckFailedError,
   ExternalIdMissingError,
@@ -272,6 +279,71 @@ app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
     }
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[competitor-accounts] delete failed", { awsAccountId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// Issue #925 Phase 1: Tenant 内 user の CRUD。 `/admin/*` middleware で既に TenantAdmin role が
+// gate されているため、 各 handler では tenantId resolve のみ行う。 削除は self-delete 防止 +
+// tenant 越境チェック (AdminGetUser) → AdminDeleteUser。
+app.get("/admin/users", async (c) => {
+  const tenantId = resolveTenantId(c);
+  const result = await routeListUsers({ shared }, c, tenantId);
+  return c.json(result.body as never, result.status as 200 | 401);
+});
+
+app.post("/admin/users", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = InviteUserRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  const tenantId = resolveTenantId(c);
+  try {
+    const result = await routeCreateUser({ shared }, c, tenantId, parsed.data);
+    return c.json(result.body as never, result.status as 201 | 401);
+  } catch (err) {
+    if (err instanceof DuplicateUserError) {
+      return c.json({ error: "duplicate_user", email: err.email }, StatusCodes.CONFLICT);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] user create failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.delete("/admin/users/:username", async (c) => {
+  const username = c.req.param("username");
+  if (!username || username.length === 0) {
+    return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
+  }
+  const tenantId = resolveTenantId(c);
+  try {
+    const result = await routeDeleteUser({ shared }, c, tenantId, username);
+    return c.json(result.body as never, result.status as 200 | 401 | 409);
+  } catch (err) {
+    if (err instanceof UserNotFoundError) {
+      return c.json({ error: "not_found", username: err.username }, StatusCodes.NOT_FOUND);
+    }
+    if (err instanceof TenantMismatchError) {
+      // 越境試行は 404 で隠蔽 (= attacker に「存在するが他 tenant の user」と教えない)。
+      console.warn("[competitor-accounts] tenant mismatch on delete", {
+        username,
+        expected: err.expectedTenantId,
+        actual: err.actualTenantId,
+      });
+      return c.json({ error: "not_found", username }, StatusCodes.NOT_FOUND);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] user delete failed", { username, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
@@ -1,0 +1,200 @@
+import {
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminGetUserCommand,
+  type CognitoIdentityProviderClient,
+  DeliveryMediumType,
+  ListUsersCommand,
+  UserNotFoundException,
+  UsernameExistsException,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+/**
+ * Issue #925 Phase 1: Tenant Admin が画面から自 tenant の Cognito user を CRUD するための
+ * SDK wrapper。 self-targeting (= UserPoolId は handler 側で JWT iss から runtime 抽出)
+ * の pure-ish 関数群で書く。
+ *
+ *   listUsersByTenant: `custom:tenantId = <tenantId>` filter で ListUsers
+ *   createUser:        AdminCreateUser (email 招待 + 属性 set)
+ *   deleteUser:        AdminDeleteUser
+ *
+ * 競合動作:
+ *   - email 重複 → `UsernameExistsException` を `DuplicateUserError` に正規化
+ *   - 存在しない user の削除 → `UserNotFoundException` を `UserNotFoundError` に正規化
+ *
+ * tenant 越境防止:
+ *   - create 時の `custom:tenantId` は JWT から取った値で server 側が上書きする (= caller から body で
+ *     渡された tenantId を信頼しない)
+ *   - delete 前に AdminGetUser で `custom:tenantId === <jwt tenantId>` を確認する責務は **caller 側** に
+ *     持たせる (= 本 wrapper は AdminDelete を素直に呼ぶ pure 層)
+ */
+
+export interface CognitoUserClientDeps {
+  readonly client: Pick<CognitoIdentityProviderClient, "send">;
+  readonly userPoolId: string;
+}
+
+export interface CognitoUserSummary {
+  readonly username: string;
+  readonly email: string | undefined;
+  readonly enabled: boolean;
+  readonly status: string | undefined;
+  readonly createdAt: string | undefined;
+  readonly tenantId: string | undefined;
+  readonly userRole: string | undefined;
+}
+
+export class DuplicateUserError extends Error {
+  constructor(public readonly email: string) {
+    super(`user with email ${email} already exists`);
+    this.name = "DuplicateUserError";
+  }
+}
+
+export class UserNotFoundError extends Error {
+  constructor(public readonly username: string) {
+    super(`user ${username} not found`);
+    this.name = "UserNotFoundError";
+  }
+}
+
+export class TenantMismatchError extends Error {
+  constructor(
+    public readonly expectedTenantId: string,
+    public readonly actualTenantId: string | undefined,
+  ) {
+    super(`user belongs to tenant "${actualTenantId ?? "(none)"}" not "${expectedTenantId}"`);
+    this.name = "TenantMismatchError";
+  }
+}
+
+function pickAttr(
+  attrs: ReadonlyArray<{ Name?: string; Value?: string }> | undefined,
+  name: string,
+): string | undefined {
+  return attrs?.find((a) => a.Name === name)?.Value;
+}
+
+/**
+ * tenant 内の全 user を返す。 Cognito の \`ListUsersCommand\` filter は \`attr = "value"\` 形式
+ * のみ対応 (= prefix match の \`^=\` は string attr で、 custom: は完全一致 = だけ)。
+ * 1 page = 60 件 (Cognito 上限) を超える tenant は paginate。 Phase 1 は 60 件まで暗黙仮定 (=
+ * P0 は SPOF 解消が主目的、 paginate UI は follow-up)。
+ */
+export async function listUsersByTenant(
+  deps: CognitoUserClientDeps,
+  tenantId: string,
+): Promise<CognitoUserSummary[]> {
+  const out = await deps.client.send(
+    new ListUsersCommand({
+      UserPoolId: deps.userPoolId,
+      Filter: `"custom:tenantId" = "${tenantId}"`,
+      Limit: 60,
+    }),
+  );
+  return (out.Users ?? []).map((u) => ({
+    username: u.Username ?? "",
+    email: pickAttr(u.Attributes, "email"),
+    enabled: u.Enabled ?? false,
+    status: u.UserStatus,
+    createdAt: u.UserCreateDate?.toISOString(),
+    tenantId: pickAttr(u.Attributes, "custom:tenantId"),
+    userRole: pickAttr(u.Attributes, "custom:userRole"),
+  }));
+}
+
+export interface CreateUserInput {
+  readonly email: string;
+  readonly tenantId: string;
+  readonly userRole: string;
+  readonly tenantName: string | undefined;
+  readonly tenantTier: string | undefined;
+}
+
+export async function createUser(
+  deps: CognitoUserClientDeps,
+  input: CreateUserInput,
+): Promise<CognitoUserSummary> {
+  const attrs: { Name: string; Value: string }[] = [
+    { Name: "email", Value: input.email },
+    { Name: "email_verified", Value: "true" },
+    { Name: "custom:tenantId", Value: input.tenantId },
+    { Name: "custom:userRole", Value: input.userRole },
+  ];
+  if (input.tenantName) attrs.push({ Name: "custom:tenantName", Value: input.tenantName });
+  if (input.tenantTier) attrs.push({ Name: "custom:tenantTier", Value: input.tenantTier });
+
+  try {
+    const out = await deps.client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: input.email,
+        UserAttributes: attrs,
+        DesiredDeliveryMediums: [DeliveryMediumType.EMAIL],
+      }),
+    );
+    const u = out.User;
+    return {
+      username: u?.Username ?? input.email,
+      email: input.email,
+      enabled: u?.Enabled ?? true,
+      status: u?.UserStatus,
+      createdAt: u?.UserCreateDate?.toISOString(),
+      tenantId: input.tenantId,
+      userRole: input.userRole,
+    };
+  } catch (err) {
+    if (err instanceof UsernameExistsException) {
+      throw new DuplicateUserError(input.email);
+    }
+    throw err;
+  }
+}
+
+/**
+ * username (= Cognito の primary key、 email 招待の場合は email 文字列が入る) で削除。
+ * tenant 越境を防ぐため caller は事前に AdminGetUser で \`custom:tenantId\` 検証する。
+ */
+export async function deleteUser(deps: CognitoUserClientDeps, username: string): Promise<void> {
+  try {
+    await deps.client.send(
+      new AdminDeleteUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new UserNotFoundError(username);
+    }
+    throw err;
+  }
+}
+
+/**
+ * tenant 越境 check: username が JWT tenantId と同じ tenant に属するかを確認する。
+ * 不在なら \`UserNotFoundError\`、 別 tenant なら \`TenantMismatchError\`。
+ */
+export async function assertUserBelongsToTenant(
+  deps: CognitoUserClientDeps,
+  username: string,
+  expectedTenantId: string,
+): Promise<void> {
+  try {
+    const out = await deps.client.send(
+      new AdminGetUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+      }),
+    );
+    const actual = pickAttr(out.UserAttributes, "custom:tenantId");
+    if (actual !== expectedTenantId) {
+      throw new TenantMismatchError(expectedTenantId, actual);
+    }
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new UserNotFoundError(username);
+    }
+    throw err;
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-routes.ts
@@ -1,0 +1,136 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import { extractClaims } from "../deploy-handler/auth.js";
+import { extractUserPoolIdFromIss } from "./cognito-saml.js";
+import type { CompetitorAccountsSharedResources } from "./shared.js";
+import {
+  assertUserBelongsToTenant,
+  type CognitoUserClientDeps,
+  type CognitoUserSummary,
+  createUser,
+  deleteUser,
+  listUsersByTenant,
+} from "./users-cognito.js";
+
+/**
+ * Issue #925 Phase 1: Tenant Admin が tenant 内 user を CRUD する route 群。 既存
+ * \`competitor-accounts\` Lambda に同居 (= IAM / auth 共通、 Phase 2 で別 Lambda 化を再評価)。
+ *
+ *   GET    /admin/users                    — tenant 内 user list (custom:tenantId filter)
+ *   POST   /admin/users                    — invite (= AdminCreateUser、 email 招待 + 属性 set)
+ *   DELETE /admin/users/:username          — 削除 (= AdminGetUser で tenantId 検証 → AdminDeleteUser)
+ *
+ * 設計判断:
+ *   - **UserPool ID は JWT iss から runtime 抽出**: SAML routes と同パターン (= self-targeting)
+ *   - **custom:tenantId は server が JWT から上書き**: caller が body に書いた tenantId は信頼しない
+ *   - **role は当面 "TenantAdmin" のみ allow**: #926 で role enum 拡張するまで lock
+ *   - **自分自身の削除を許さない**: lock-out 回避 (= Cognito sub と削除対象 username の比較)
+ */
+
+export interface UsersRouteResult {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+const ALLOWED_ROLES = ["TenantAdmin"] as const;
+export const InviteUserRequestSchema = z.object({
+  email: z.string().email(),
+  userRole: z.enum(ALLOWED_ROLES).default("TenantAdmin"),
+});
+export type InviteUserRequest = z.infer<typeof InviteUserRequestSchema>;
+
+function extractSelfPoolFromContext(
+  c: Context,
+  shared: CompetitorAccountsSharedResources,
+): CognitoUserClientDeps | undefined {
+  const claims = extractClaims(c);
+  const userPoolId = extractUserPoolIdFromIss(claims?.iss as string | undefined);
+  if (!userPoolId) return undefined;
+  return { client: shared.cognito, userPoolId };
+}
+
+function extractTenantMetadata(c: Context): {
+  tenantName: string | undefined;
+  tenantTier: string | undefined;
+} {
+  const claims = extractClaims(c);
+  const tenantName = claims?.["custom:tenantName"];
+  const tenantTier = claims?.["custom:tenantTier"];
+  return {
+    tenantName: typeof tenantName === "string" ? tenantName : undefined,
+    tenantTier: typeof tenantTier === "string" ? tenantTier : undefined,
+  };
+}
+
+export interface UsersRouteDeps {
+  readonly shared: CompetitorAccountsSharedResources;
+}
+
+export async function routeListUsers(
+  deps: UsersRouteDeps,
+  c: Context,
+  tenantId: string,
+): Promise<UsersRouteResult> {
+  const pool = extractSelfPoolFromContext(c, deps.shared);
+  if (!pool) {
+    return {
+      status: 401,
+      body: { error: "user_pool_unresolved", message: "JWT iss から UserPool を抽出できません" },
+    };
+  }
+  const users = await listUsersByTenant(pool, tenantId);
+  return { status: 200, body: { items: users } };
+}
+
+export async function routeCreateUser(
+  deps: UsersRouteDeps,
+  c: Context,
+  tenantId: string,
+  request: InviteUserRequest,
+): Promise<UsersRouteResult> {
+  const pool = extractSelfPoolFromContext(c, deps.shared);
+  if (!pool) {
+    return {
+      status: 401,
+      body: { error: "user_pool_unresolved", message: "JWT iss から UserPool を抽出できません" },
+    };
+  }
+  const { tenantName, tenantTier } = extractTenantMetadata(c);
+  const summary: CognitoUserSummary = await createUser(pool, {
+    email: request.email,
+    tenantId,
+    userRole: request.userRole,
+    tenantName,
+    tenantTier,
+  });
+  return { status: 201, body: summary };
+}
+
+export async function routeDeleteUser(
+  deps: UsersRouteDeps,
+  c: Context,
+  tenantId: string,
+  username: string,
+): Promise<UsersRouteResult> {
+  const pool = extractSelfPoolFromContext(c, deps.shared);
+  if (!pool) {
+    return {
+      status: 401,
+      body: { error: "user_pool_unresolved", message: "JWT iss から UserPool を抽出できません" },
+    };
+  }
+  // lock-out 防止: caller 自身の username (= Cognito `cognito:username` claim) と削除対象が一致する
+  // request は拒否する。 sub での比較ではなく username で比較するのは、 AdminDelete の引数が
+  // username (= email alias 含む) で sub は受け付けないため。
+  const claims = extractClaims(c);
+  const callerUsername = claims?.["cognito:username"];
+  if (typeof callerUsername === "string" && callerUsername === username) {
+    return {
+      status: 409,
+      body: { error: "cannot_delete_self", message: "lock-out 防止のため自分自身は削除できません" },
+    };
+  }
+  await assertUserBelongsToTenant(pool, username, tenantId);
+  await deleteUser(pool, username);
+  return { status: 200, body: { deleted: true, username } };
+}

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -178,5 +178,17 @@ export class ApiGateway extends Construct {
     tenantSamlConfig.addMethod("PUT", competitorAccountsIntegration, deployMethodOptions);
     tenantSamlConfig.addMethod("PATCH", competitorAccountsIntegration, deployMethodOptions);
     tenantSamlConfig.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
+
+    // Issue #925 Phase 1: Tenant 内 user の CRUD (= 初期 admin だけでなく追加ユーザーを招待できる)。
+    // 同 Lambda (competitor-accounts) に相乗りさせ、 Cognito AdminCreate / AdminDelete / ListUsers
+    // 権限は Lambda 側で付与済。
+    //   /admin/users                 GET=list / POST=invite
+    //   /admin/users/{username}      DELETE=remove (tenant 越境 + self-delete 防止 server 側で)
+    const users = admin.addResource("users");
+    users.addMethod("GET", competitorAccountsIntegration, deployMethodOptions);
+    users.addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
+    users
+      .addResource("{username}")
+      .addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/tenant-users.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-users.test.ts
@@ -1,0 +1,241 @@
+import {
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminGetUserCommand,
+  ListUsersCommand,
+  UserNotFoundException,
+  UsernameExistsException,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CognitoUserClientDeps,
+  CognitoUserSummary,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito";
+import {
+  assertUserBelongsToTenant,
+  createUser,
+  DuplicateUserError,
+  deleteUser,
+  listUsersByTenant,
+  TenantMismatchError,
+  UserNotFoundError,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito";
+import { InviteUserRequestSchema } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes";
+
+/**
+ * Issue #925 Phase 1: Tenant user CRUD wrapper の単体テスト。 Cognito SDK は \`vi.fn\` でモック
+ * 化し、 入力 → SDK command の引数 + 戻り値の正規化を pin する。
+ */
+
+interface MockCognito {
+  client: { send: ReturnType<typeof vi.fn> };
+  userPoolId: string;
+}
+
+function mockClient(): MockCognito {
+  return {
+    client: { send: vi.fn() },
+    userPoolId: "ap-northeast-1_XXXXXXXXX",
+  };
+}
+
+describe("InviteUserRequestSchema", () => {
+  it("email が必須、 valid email なら通すべき", () => {
+    expect(InviteUserRequestSchema.safeParse({ email: "u@example.com" }).success).toBe(true);
+  });
+
+  it("invalid email は reject", () => {
+    expect(InviteUserRequestSchema.safeParse({ email: "not-an-email" }).success).toBe(false);
+    expect(InviteUserRequestSchema.safeParse({}).success).toBe(false);
+  });
+
+  it("userRole が未指定なら TenantAdmin が default で入るべき", () => {
+    const r = InviteUserRequestSchema.parse({ email: "u@example.com" });
+    expect(r.userRole).toBe("TenantAdmin");
+  });
+
+  it("未定義 role (= Auditor 等) は #926 で拡張するまで reject", () => {
+    expect(
+      InviteUserRequestSchema.safeParse({ email: "u@example.com", userRole: "Auditor" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("listUsersByTenant", () => {
+  let mock: MockCognito;
+  beforeEach(() => {
+    mock = mockClient();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("ListUsersCommand に custom:tenantId filter を渡すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({ Users: [] });
+    await listUsersByTenant(mock as CognitoUserClientDeps, "tenant-acme");
+    const cmd = mock.client.send.mock.calls[0]?.[0] as ListUsersCommand;
+    expect(cmd).toBeInstanceOf(ListUsersCommand);
+    expect(cmd.input.Filter).toBe('"custom:tenantId" = "tenant-acme"');
+    expect(cmd.input.UserPoolId).toBe(mock.userPoolId);
+  });
+
+  it("Cognito の Users[] を CognitoUserSummary[] に整形して返すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({
+      Users: [
+        {
+          Username: "alice@example.com",
+          Enabled: true,
+          UserStatus: "CONFIRMED",
+          UserCreateDate: new Date("2026-01-01T00:00:00Z"),
+          Attributes: [
+            { Name: "email", Value: "alice@example.com" },
+            { Name: "custom:tenantId", Value: "tenant-acme" },
+            { Name: "custom:userRole", Value: "TenantAdmin" },
+          ],
+        },
+      ],
+    });
+    const out: CognitoUserSummary[] = await listUsersByTenant(
+      mock as CognitoUserClientDeps,
+      "tenant-acme",
+    );
+    expect(out).toEqual([
+      {
+        username: "alice@example.com",
+        email: "alice@example.com",
+        enabled: true,
+        status: "CONFIRMED",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tenantId: "tenant-acme",
+        userRole: "TenantAdmin",
+      },
+    ]);
+  });
+
+  it("Users が undefined でも空配列を返すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({});
+    expect(await listUsersByTenant(mock as CognitoUserClientDeps, "tenant-acme")).toEqual([]);
+  });
+});
+
+describe("createUser", () => {
+  let mock: MockCognito;
+  beforeEach(() => {
+    mock = mockClient();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("AdminCreateUser に email + custom:tenantId + custom:userRole を渡すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({
+      User: {
+        Username: "bob@example.com",
+        Enabled: true,
+        UserStatus: "FORCE_CHANGE_PASSWORD",
+        UserCreateDate: new Date("2026-05-17T12:00:00Z"),
+      },
+    });
+    const out = await createUser(mock as CognitoUserClientDeps, {
+      email: "bob@example.com",
+      tenantId: "tenant-acme",
+      userRole: "TenantAdmin",
+      tenantName: "Acme",
+      tenantTier: "PREMIUM",
+    });
+    const cmd = mock.client.send.mock.calls[0]?.[0] as AdminCreateUserCommand;
+    expect(cmd).toBeInstanceOf(AdminCreateUserCommand);
+    expect(cmd.input.Username).toBe("bob@example.com");
+    expect(cmd.input.UserAttributes).toEqual(
+      expect.arrayContaining([
+        { Name: "email", Value: "bob@example.com" },
+        { Name: "email_verified", Value: "true" },
+        { Name: "custom:tenantId", Value: "tenant-acme" },
+        { Name: "custom:userRole", Value: "TenantAdmin" },
+        { Name: "custom:tenantName", Value: "Acme" },
+        { Name: "custom:tenantTier", Value: "PREMIUM" },
+      ]),
+    );
+    expect(cmd.input.DesiredDeliveryMediums).toEqual(["EMAIL"]);
+    expect(out.email).toBe("bob@example.com");
+    expect(out.tenantId).toBe("tenant-acme");
+    expect(out.status).toBe("FORCE_CHANGE_PASSWORD");
+  });
+
+  it("UsernameExistsException は DuplicateUserError に正規化すべき", async () => {
+    mock.client.send.mockRejectedValueOnce(
+      new UsernameExistsException({
+        message: "User account already exists",
+        $metadata: {},
+      }),
+    );
+    await expect(
+      createUser(mock as CognitoUserClientDeps, {
+        email: "dup@example.com",
+        tenantId: "tenant-acme",
+        userRole: "TenantAdmin",
+        tenantName: undefined,
+        tenantTier: undefined,
+      }),
+    ).rejects.toBeInstanceOf(DuplicateUserError);
+  });
+});
+
+describe("deleteUser", () => {
+  let mock: MockCognito;
+  beforeEach(() => {
+    mock = mockClient();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("AdminDeleteUserCommand を呼び、 username / UserPoolId を渡すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({});
+    await deleteUser(mock as CognitoUserClientDeps, "alice@example.com");
+    const cmd = mock.client.send.mock.calls[0]?.[0] as AdminDeleteUserCommand;
+    expect(cmd).toBeInstanceOf(AdminDeleteUserCommand);
+    expect(cmd.input.Username).toBe("alice@example.com");
+    expect(cmd.input.UserPoolId).toBe(mock.userPoolId);
+  });
+
+  it("UserNotFoundException は UserNotFoundError に正規化すべき", async () => {
+    mock.client.send.mockRejectedValueOnce(
+      new UserNotFoundException({ message: "User does not exist", $metadata: {} }),
+    );
+    await expect(
+      deleteUser(mock as CognitoUserClientDeps, "ghost@example.com"),
+    ).rejects.toBeInstanceOf(UserNotFoundError);
+  });
+});
+
+describe("assertUserBelongsToTenant (越境チェック)", () => {
+  let mock: MockCognito;
+  beforeEach(() => {
+    mock = mockClient();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("custom:tenantId が一致すれば throw しない", async () => {
+    mock.client.send.mockResolvedValueOnce({
+      UserAttributes: [{ Name: "custom:tenantId", Value: "tenant-acme" }],
+    });
+    await expect(
+      assertUserBelongsToTenant(mock as CognitoUserClientDeps, "alice@example.com", "tenant-acme"),
+    ).resolves.toBeUndefined();
+    const cmd = mock.client.send.mock.calls[0]?.[0] as AdminGetUserCommand;
+    expect(cmd).toBeInstanceOf(AdminGetUserCommand);
+  });
+
+  it("custom:tenantId が異なれば TenantMismatchError を throw すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({
+      UserAttributes: [{ Name: "custom:tenantId", Value: "tenant-other" }],
+    });
+    await expect(
+      assertUserBelongsToTenant(mock as CognitoUserClientDeps, "alice@example.com", "tenant-acme"),
+    ).rejects.toBeInstanceOf(TenantMismatchError);
+  });
+
+  it("UserNotFoundException は UserNotFoundError に正規化すべき", async () => {
+    mock.client.send.mockRejectedValueOnce(
+      new UserNotFoundException({ message: "User does not exist", $metadata: {} }),
+    );
+    await expect(
+      assertUserBelongsToTenant(mock as CognitoUserClientDeps, "ghost@example.com", "tenant-acme"),
+    ).rejects.toBeInstanceOf(UserNotFoundError);
+  });
+});


### PR DESCRIPTION
Closes #925 (Phase 1)

## Summary
- \`provision-tenant.sh admin-create-user\` で払い出された 1 ユーザーが SPOF だった問題を解消する。 Tenant Admin が画面から追加ユーザーを招待 / 削除できる。
- Backend は既存の **competitor-accounts Lambda に同居** (= IAM / auth 共通、 別 Lambda 化は Phase 3 で再評価)。
- Frontend は application-admin-console に \`/settings/users\` 画面を追加。

## Backend
- \`users-cognito.ts\` — Cognito SDK wrapper (AdminCreateUser / AdminDeleteUser / AdminGetUser / ListUsers)、 DuplicateUserError / UserNotFoundError / TenantMismatchError を正規化
- \`users-routes.ts\` — 3 route + Zod スキーマ。 JWT iss から UserPool runtime 抽出 (= SAML routes と同じ self-targeting)、 \`custom:tenantId\` は **server が JWT から上書き** (caller の body は信頼しない)、 当面 TenantAdmin role のみ allow
- \`index.ts\` — \`/admin/users\` (GET/POST) + \`/admin/users/:username\` (DELETE) を wire
  - DELETE は AdminGetUser で \`custom:tenantId\` 検証 → AdminDeleteUser (越境試行は **404 で隠蔽**)
  - 自分自身の削除は 409 \`cannot_delete_self\` (lock-out 防止、 \`cognito:username\` 比較)
- IAM (\`competitor-accounts-api-lambda.ts\`) — AdminCreateUser / AdminDeleteUser / AdminGetUser / ListUsers を userpool/* 範囲で grant

## Frontend
- \`/settings/users\` route + side-nav \`nav.users\` (全 tier 表示)
- \`AdminUsersPage\` — Cloudscape Table + 招待 modal + 削除確認 modal
- \`tenant-users-client.ts\` — list / invite / delete API client
- i18n ja / en に \`users.*\` セクション + \`nav.users\` 追加 (es / zh は en fallback)

## 物理影響
- **API Gateway**: tenant API に \`/admin/users\` (GET, POST) + \`/admin/users/{username}\` (DELETE) を 3 method 追加 (CREATE)
- **Lambda IAM**: competitor-accounts Lambda の role に Cognito 4 action を追加 (UPDATE)
- **Lambda artifact**: competitor-accounts handler bundle 更新 (UPDATE)
- **Frontend bundle**: AdminUsers page 1 chunk 追加 (UPDATE)
- CFn UPDATE は tenant-template stack (= API GW + IAM policy version 上がる)

## Regression 分析
- \`/admin/users\` は新規 path で既存 route と被らない (= 旧 SAML / competitor-accounts route に副作用無し)
- IAM 追加は ALLOW のみで既存権限を狭めない
- side-nav は \`{ type: \"link\", href: \"/settings/users\" }\` を既存配列に push するだけ (SAML silo-only guard とは独立)
- DELETE の越境試行 404 隠蔽は attacker probe を防ぐ (= 漏れる情報を最小化)
- 自己削除 409 は frontend に頼らず server で reject (= UI bypass されても gate)

## Test plan
- [x] \`make harness\`
- [x] \`make before-commit\` (lint / typecheck / 全 workspace test / build / cdk synth)
- [x] \`bun run vitest run test/problem-deploy/tenant-users.test.ts\` — 14 件 pass (= list filter + create attrs + delete + 越境 / self-delete)
- [x] application-admin-console test 239 件 pass (regression なし)
- [ ] deploy 後: /settings/users から招待 → email 受信 → 初回 password 変更 → ログイン確認、 越境試行 (curl で他 tenant の username を DELETE) が 404 を返すこと

## Phase 2 follow-up (= 本 PR 範囲外)
- System Admin Console (apps/admin-console) 側の system user 管理 — 別 PR
- role 拡張 (TenantViewer / TenantOperator) — #926 で扱う
- 招待メールの再送 endpoint (= \`AdminResendInvitationOrUpdateUserAttributes\`) — UX backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Users management page accessible from the admin console navigation, enabling tenant administrators to view, invite, and delete tenant users with intuitive modal dialogs for user actions.

* **Localization**
  * Added comprehensive user management text support in English and Japanese for the new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->