### PR TITLE
fix(#910): DistributedMap propertyIgnored warning を ack で実際に suppress する

### DIFF
--- a/infrastructure/lib/problem-deploy/bulk-deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/bulk-deploy-create-state-machine.ts
@@ -1,4 +1,4 @@
-import { Duration, Stack } from "aws-cdk-lib";
+import { Annotations, Duration, Stack } from "aws-cdk-lib";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { IBucket } from "aws-cdk-lib/aws-s3";
 import {
@@ -95,17 +95,17 @@ export class BulkDeployCreateStateMachine extends Construct {
     // ADR-001 §4: 失敗を error 扱いにせず最後まで試す。 ToleratedFailure* は未設定で
     // "any failure tolerated" になり、 親 execution は success で終わる。
     //
-    // CDK 2.252 の DistributedMap は inconsistent API:
-    //   - 新 API: \`mapExecutionType\` (= DistributedMap props、 ASL 出力で使われる)
-    //   - 旧 API: \`itemProcessor(processor, { executionType })\` (= ASL に影響しないが
-    //     validation がここを check する。 無いと synth error \"You must specify an
-    //     execution type for the distributed Map workflow\")
-    // 両方指定すると CDK が \"ProcessorConfig.executionType is ignored\" warning を出すが、
-    // 旧 API を消すと validation で fail するため両方指定する。 warning は informational
-    // (= ASL 上の挙動は \`mapExecutionType\` が支配的、 実行に影響なし) で受け入れる。
-    // CDK の \`Annotations.acknowledgeWarning\` は 2.252 で この warning タイプを suppress
-    // しないため、 cosmetic な log noise として残る。 upstream で API 整合される将来 CDK
-    // upgrade 時に旧 API を撤廃する。
+    // CDK 2.252 の DistributedMap には API duplication がある:
+    //   - 新 API: \`mapExecutionType\` (= DistributedMap props、 ASL 出力で実際に使われる)
+    //   - 旧 API: \`itemProcessor(processor, { executionType })\` (= MapBase.validateState で
+    //     "You must specify an execution type for the distributed Map workflow" 検査される。
+    //     ASL には反映されない (= DistributedMap.toStateJson が上書きで overwrite する))
+    // 両方を残さないと validation で fail する一方、 両方残すと CDK が synth 時に warning
+    // \`@aws-cdk/aws-stepfunctions:propertyIgnored\` を出す。 これは CDK の bug-shaped な
+    // 整合不全だが、 既知の suppress 方法がある:
+    // \`Annotations.of(map).acknowledgeWarning(id)\` を constructor で呼び、 後段の
+    // \`addWarningV2\` に「この警告は ack 済」 と覚えさせる (= core/annotations.js の
+    // \`Acknowledgements.has\` 経由で skip される)。
     const map = new DistributedMap(this, "DeployItemsMap", {
       maxConcurrency: MAX_CONCURRENCY,
       mapExecutionType: StateMachineType.STANDARD,
@@ -120,6 +120,14 @@ export class BulkDeployCreateStateMachine extends Construct {
       mode: ProcessorMode.DISTRIBUTED,
       executionType: ProcessorType.STANDARD,
     });
+
+    // 上記コメント参照: validation のために itemProcessor.executionType を残しつつ、
+    // CDK が出す \`propertyIgnored\` warning を ack で suppress する。 register 先は **親 scope** (= \`this\`)
+    // である必要がある。 CDK の \`Acknowledgements.searchPaths\` (core/annotations.js) は node path の
+    // 先頭からの prefix を末尾まで含めずに reverse して返す (= 自 path は含まれず、 ancestor だけ
+    // が match 対象になる) ため、 ack を child (= DistributedMap) に register しても child 自身の
+    // \`addWarningV2\` では検出されない。 親に register することで child へ伝播し suppress される。
+    Annotations.of(this).acknowledgeWarning("@aws-cdk/aws-stepfunctions:propertyIgnored");
 
     this.stateMachine = new StateMachine(this, "StateMachine", {
       stateMachineType: StateMachineType.STANDARD,


### PR DESCRIPTION
PR-927 のフォローアップ。 PR-927 で \`mapExecutionType\` を足したが、 CDK の cosmetic warning \`@aws-cdk/aws-stepfunctions:propertyIgnored\` が依然として synth で出ていた。

## Root cause

CDK \`core/annotations.js\` の \`Acknowledgements.searchPaths\` は node path の prefix のみを返し、 **path 自身を含めない**。 PR-927 当時の私の試行は \`Annotations.of(map).acknowledgeWarning(...)\` (= DistributedMap 自身に ack) を入れた前提だったが、 そもそも ack を入れていなかった (= comment で「 suppress しない」 と諦めていた)。 また \`Annotations.of(map)\` でも \`searchPaths\` の挙動上 self ack は効かない。

## Fix

\`Annotations.of(this).acknowledgeWarning("@aws-cdk/aws-stepfunctions:propertyIgnored")\` を **parent scope** (= 本 \`BulkDeployCreateStateMachine\` construct) に register する。 これで child (= DistributedMap) で \`addWarningV2\` が呼ばれた時に \`Acknowledgements.has\` の prefix-only 検索が parent ack を捕まえて suppress する。

\`itemProcessor.executionType\` は \`MapBase.validateState\` (\"You must specify an execution type for the distributed Map workflow\") が必須要求するため残す (= 削除すると synth error)。

## 物理影響
- **\`infrastructure/lib/problem-deploy/bulk-deploy-create-state-machine.ts\`** — UPDATE: \`Annotations\` import + ack call 追加 + comment 更新
- ASL 出力 / CFn 出力: **NO-OP** (= \`mapExecutionType\` は既に PR-927 で入っている、 本 PR は cosmetic warning suppress のみ)

## Regression 分析
- \`Annotations.acknowledgeWarning\` は metadata mutation のみで construct tree や ASL に影響しない
- 他の \`@aws-cdk/aws-stepfunctions:propertyIgnored\` warning (= 同 id の別 source) もあれば同様に suppress されるが、 現状 repo 内で他の DistributedMap は無い
- parent scope (\`this\` = BulkDeployCreateStateMachine) に register するので **子孫の他 construct** が将来同じ id の warning を出した場合も suppress される。 現実装上は DistributedMap のみが child なので影響範囲は本 map に閉じる

## Test plan
- [x] isolated \`cdk synth --output cdk.out.test2\` で \`propertyIgnored\` が出ないことを確認
- [x] \`make harness\`
- [x] \`make before-commit\` (= lint / typecheck / 全 workspace test / build / cdk synth)
- [ ] deploy 後の \`cdk synth\` で warning が再現しないことを最終確認 (= 「直ってない」 の解消)

Relates #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)