### PR TITLE
fix: CloudFront S3Origin deprecation warning を解消

### DIFF
--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -7,7 +7,7 @@ import {
   PriceClass,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
@@ -105,7 +105,10 @@ export class AdminConsoleHostingStack extends cdk.Stack {
 
     const distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
-        origin: new S3Origin(bucket, { originAccessIdentity: oai }),
+        // CDK 2.252+ で `S3Origin` は deprecated。 `S3BucketOrigin.withOriginAccessIdentity` は
+        // 既存 OAI を渡せる同等 API (= bucket policy + Signer 経路を変えずに移行可)。 OAC への
+        // 完全移行は別 PR で trade-off (= 既存 deploy stack の OAI を OAC に置換する操作) を含めて扱う。
+        origin: S3BucketOrigin.withOriginAccessIdentity(bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: securityHeaders,
       },

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -7,7 +7,7 @@ import {
   PriceClass,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
@@ -80,7 +80,7 @@ export class ParticipantPortalHosting extends Construct {
 
     this.distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
-        origin: new S3Origin(this.bucket, { originAccessIdentity: oai }),
+        origin: S3BucketOrigin.withOriginAccessIdentity(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: securityHeaders,
       },

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -7,7 +7,7 @@ import {
   PriceClass,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import { S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
@@ -128,7 +128,7 @@ export class ApplicationAdminConsoleHosting extends Construct {
 
     this.distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
-        origin: new S3Origin(this.bucket, { originAccessIdentity: oai }),
+        origin: S3BucketOrigin.withOriginAccessIdentity(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: securityHeaders,
       },


### PR DESCRIPTION
## Summary
CDK が出す \`aws-cloudfront-origins.S3Origin is deprecated\` warning を 3 hosting stack で
\`S3BucketOrigin.withOriginAccessIdentity\` に置換して suppress する。

PR-929 で StepFunctions \`propertyIgnored\` を ack 経路で消したのに続き、 synth 出力を更にクリーンに保つ。

## 物理影響
- **\`infrastructure/lib/admin-console-hosting.ts\`** — UPDATE: \`S3Origin\` → \`S3BucketOrigin.withOriginAccessIdentity\`
- **\`infrastructure/lib/tenant-template/application-admin-console-hosting.ts\`** — UPDATE: 同上
- **\`infrastructure/lib/problem-deploy/participant-portal-hosting.ts\`** — UPDATE: 同上
- CFn 出力 / runtime 挙動: **NO-OP** (= OAI を維持するため bucket policy / Signer 経路に変更なし、 CFn diff は実質ゼロ)

## Regression 分析
- \`S3BucketOrigin.withOriginAccessIdentity(bucket, { originAccessIdentity: oai })\` は旧 \`new S3Origin(bucket, { originAccessIdentity: oai })\` と同等の OAI signing を維持する。 CloudFront → S3 の origin request 経路 (= 認可 / cache key / origin headers) は不変。
- 既存 deployed distribution は CFn UPDATE 時に origin id が同じなので replace されない。
- OAC 完全移行 (\`withOriginAccessControl\`) は別 PR で扱う。 既存 OAI bucket policy の OAC 移行は signer の置換 + bucket policy 書換が含まれるため、 cosmetic な warning 解消とは scope を分けるべき。

## 残 warning (= 本 PR scope 外)
\`cdk synth\` に残る次の warning は SBT vendored code (\`@cdklabs/sbt-aws\`) 側の問題で、 本 repo の責務外:
- \`aws-cdk-lib.aws_cognito.UserPoolProps#advancedSecurityMode is deprecated\` — \`@cdklabs/sbt-aws/lib/control-plane/auth/cognito-auth.js\`
- \`aws-cdk-lib.aws_dynamodb.TableOptions#pointInTimeRecovery is deprecated\` — SBT の 4 internal tables

SBT upstream upgrade で同時に解消される想定。

## Test plan
- [x] isolated \`cdk synth\` で \`S3Origin\` の warning が出ないことを確認
- [x] \`make harness\`
- [x] \`make before-commit\`
- [ ] deploy 後の CloudFront origin 経路が変わっていないことを確認 (= 3 SPA とも index.html が 200 で返る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure hosting configurations to use current API standards for cloud resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->