### PR TITLE
fix(#925): ListUsers Filter は custom:* 非対応 — Lambda 側で tenantId 絞り込む

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
@@ -76,10 +76,22 @@ function pickAttr(
 }
 
 /**
- * tenant 内の全 user を返す。 Cognito の \`ListUsersCommand\` filter は \`attr = "value"\` 形式
- * のみ対応 (= prefix match の \`^=\` は string attr で、 custom: は完全一致 = だけ)。
- * 1 page = 60 件 (Cognito 上限) を超える tenant は paginate。 Phase 1 は 60 件まで暗黙仮定 (=
- * P0 は SPOF 解消が主目的、 paginate UI は follow-up)。
+ * tenant 内の全 user を返す。
+ *
+ * **Cognito ListUsers の Filter は custom:* 属性に対応していない** (= built-in attr のみ:
+ * username / email / phone_number / name / given_name / family_name / preferred_username /
+ * cognito:user_status / status / sub)。 \`"custom:tenantId" = "..."\` を渡すと
+ * \`InvalidParameterException\` で 500 になる。
+ *
+ * そのため:
+ *   1. UserPool の全 user を 1 ページ取得 (Limit 60)
+ *   2. Lambda 側で \`custom:tenantId === tenantId\` を絞り込む
+ *
+ * pooled tier (= 複数 tenant が UserPool を共有) では Lambda 側 filter が **正当性の必須条件** (=
+ * 何もしないと他 tenant の user が見える)。 silo tier (= PLATINUM) は UserPool が tenant 専用なので
+ * filter があっても無くても漏洩しないが、 統一のため常に適用する。
+ *
+ * 60 件超の tenant は paginate を追加する必要がある (= 本 Phase の暗黙仮定)。
  */
 export async function listUsersByTenant(
   deps: CognitoUserClientDeps,
@@ -88,19 +100,20 @@ export async function listUsersByTenant(
   const out = await deps.client.send(
     new ListUsersCommand({
       UserPoolId: deps.userPoolId,
-      Filter: `"custom:tenantId" = "${tenantId}"`,
       Limit: 60,
     }),
   );
-  return (out.Users ?? []).map((u) => ({
-    username: u.Username ?? "",
-    email: pickAttr(u.Attributes, "email"),
-    enabled: u.Enabled ?? false,
-    status: u.UserStatus,
-    createdAt: u.UserCreateDate?.toISOString(),
-    tenantId: pickAttr(u.Attributes, "custom:tenantId"),
-    userRole: pickAttr(u.Attributes, "custom:userRole"),
-  }));
+  return (out.Users ?? [])
+    .map((u) => ({
+      username: u.Username ?? "",
+      email: pickAttr(u.Attributes, "email"),
+      enabled: u.Enabled ?? false,
+      status: u.UserStatus,
+      createdAt: u.UserCreateDate?.toISOString(),
+      tenantId: pickAttr(u.Attributes, "custom:tenantId"),
+      userRole: pickAttr(u.Attributes, "custom:userRole"),
+    }))
+    .filter((u) => u.tenantId === tenantId);
 }
 
 export interface CreateUserInput {

--- a/infrastructure/test/problem-deploy/tenant-users.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-users.test.ts
@@ -80,13 +80,40 @@ describe("listUsersByTenant", () => {
   });
   afterEach(() => vi.clearAllMocks());
 
-  it("ListUsersCommand に custom:tenantId filter を渡すべき", async () => {
+  it("ListUsersCommand は Filter を **渡さない** べき (= Cognito 仕様: custom:* は filter 不可)", async () => {
     mock.client.send.mockResolvedValueOnce({ Users: [] });
     await listUsersByTenant(mock as CognitoUserClientDeps, "tenant-acme");
     const cmd = mock.client.send.mock.calls[0]?.[0] as ListUsersCommand;
     expect(cmd).toBeInstanceOf(ListUsersCommand);
-    expect(cmd.input.Filter).toBe('"custom:tenantId" = "tenant-acme"');
+    expect(cmd.input.Filter).toBeUndefined();
     expect(cmd.input.UserPoolId).toBe(mock.userPoolId);
+  });
+
+  it("Lambda 側で custom:tenantId が一致する user だけを返すべき (= pooled tier の越境防止)", async () => {
+    mock.client.send.mockResolvedValueOnce({
+      Users: [
+        {
+          Username: "alice@example.com",
+          Enabled: true,
+          UserStatus: "CONFIRMED",
+          Attributes: [{ Name: "custom:tenantId", Value: "tenant-acme" }],
+        },
+        {
+          Username: "bob@example.com",
+          Enabled: true,
+          UserStatus: "CONFIRMED",
+          Attributes: [{ Name: "custom:tenantId", Value: "tenant-other" }],
+        },
+        {
+          Username: "ghost@example.com",
+          Enabled: true,
+          UserStatus: "CONFIRMED",
+          Attributes: [],
+        },
+      ],
+    });
+    const out = await listUsersByTenant(mock as CognitoUserClientDeps, "tenant-acme");
+    expect(out.map((u) => u.username)).toEqual(["alice@example.com"]);
   });
 
   it("Cognito の Users[] を CognitoUserSummary[] に整形して返すべき", async () => {


### PR DESCRIPTION
## Root cause
\`Could not load users API 500: {\"error\":\"internal_error\"}\` の真因は Cognito \`ListUsersCommand\` の Filter に \`"custom:tenantId" = "..."\` を渡していたこと。

**AWS Cognito の \`ListUsers\` Filter は custom:* 属性を sub 対応していない**。 supported attribute は built-in (= \`username\` / \`email\` / \`phone_number\` / \`name\` / \`given_name\` / \`family_name\` / \`preferred_username\` / \`cognito:user_status\` / \`status\` / \`sub\`) のみ。 custom 属性を渡すと \`InvalidParameterException\` で 500 になる。

PR-928 で \`/admin/users\` を出した時のテストは Filter 文字列が組み立てられることだけ検証していたため、 deploy しないと気付けなかった (= 既存 test smell)。

## Fix
ListUsers から Filter を外し、 Lambda 側で \`custom:tenantId === tenantId\` を絞り込む。

pooled tier (= 複数 tenant が UserPool を共有) ではこの Lambda 側 filter が **正当性の必須条件** (= 何もしないと他 tenant の user が見える)。 silo tier (= PLATINUM) は UserPool 自体が tenant 専用なので filter があっても無くても情報漏洩しないが、 統一のため常に適用する。

## 物理影響
- **\`infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts\`** — UPDATE: ListUsersCommand から Filter param 削除 + Lambda 側 \`.filter()\`
- **\`infrastructure/test/problem-deploy/tenant-users.test.ts\`** — UPDATE: 「 Filter を渡さない 」 assertion + 「 Lambda 側で 越境 user を除外する 」 assertion を追加 (= regression pin)
- CFn / Lambda IAM: 変更なし、 Lambda bundle のみ更新

## Regression 分析
- ListUsers のレスポンスサイズが pooled tier で 増える (= 60 件まで、 全 tenant 分)。 Lambda 側で .filter() するので外向き response 件数は同じ
- pooled tier で UserPool が 60 件超になった時点で paginate 必要 (= 本 PR scope 外、 #925 Phase 2 で扱う)
- ListUsersCommand には \`Filter\` を渡さなくなった (= 既存 test の Filter assertion を 削除した版に更新)

## Test plan
- [x] \`bun run vitest run test/problem-deploy/tenant-users.test.ts\` — 16 件 pass (= 既存 14 + Filter 非渡し / Lambda filter 検証 各 1)
- [x] \`make harness\`
- [x] \`make before-commit\`
- [ ] deploy 後の確認: /settings/users が 200 で render する。 他 tenant の admin が居る pooled tier で他 tenant の user が混入しないこと

Closes #925 (Phase 1 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with retrieving filtered user lists in multi-tenant environments that was attempting to use an unsupported filtering method, improving reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->