### PR TITLE
fix: tighten participant Role permissions (#820 retract) + CodeBuild workspace fix (#916 L3)

### DIFF
--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -47,4 +47,12 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
   it("staging root に `packages` directory を copy すべき (= workspace:* protocol の resolve)", () => {
     expect(source).toContain('cp -R packages "${STAGING}/packages"');
   });
+
+  // Issue #916 (3 層目): repo root の workspaces 配列は `infrastructure` を含むが、 staging では
+  // SBT ref-arch 互換のため `cdk/` にリネームされる。 root package.json の workspaces を staging で
+  // も `cdk` に書き換えないと bun が CWD=cdk を workspace member と認識せず、
+  // `Workspace dependency "@TenkaCloud/trust-bridge" not found / Searched in "./*"` で fail する。
+  it("staging package.json の workspaces を `infrastructure` → `cdk` に書き換えるべき", () => {
+    expect(source).toContain("pkg['workspaces'] = [w if w != 'infrastructure' else 'cdk'");
+  });
 });

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -68,20 +68,20 @@ describe("problem template ParticipantViewerRole (#744)", () => {
       expect(role).toContain(`AWS: !Sub "arn:aws:iam::\${TenkaCloudAccountId}:root"`);
       expect(role).toContain("sts:ExternalId: !Ref ExternalId");
       expect(role).toContain("PolicyName: ProblemSpecific");
-      // Issue #820: \`Resource: \"*\"\` is permitted ONLY when paired with a
-      // List* / Describe-all Sid (AWS list-only APIs cannot be resource-scoped).
-      // Any \`Resource: \"*\"\` outside such a Sid indicates overprovisioning.
-      // Split by \`- Sid:\` markers to scope the search to each statement.
+      // Issue #820 撤回 / ADR-021: AWS JAM/GameDay 前提 — 参加者の IAM Role は
+      // **その問題の resource しか触れない** を IAM レベルで強制する。 旧 policy は
+      // \`ssm:DescribeParameters\` / \`ssm:GetParametersByPath\` / \`cloudformation:ListStacks\`
+      // を Resource:* で付与しており、 CLI 越しに platform / 他 tenant の Parameter Store と
+      // CFn stack の存在 / 値が見えていた (= security 事故レベル)。 list 系 IAM action は
+      // 一切付与しない。 Resource:"*" がどの statement にあっても test を fail させる。
       const statements = role.split(/^\s+- Sid: /m).slice(1);
       for (const stmt of statements) {
         const sid = stmt.split(/\s/, 1)[0] ?? "";
         const hasWildcard = stmt.includes('Resource: "*"') || stmt.includes("Resource: '*'");
-        if (hasWildcard) {
-          expect(
-            /^(List|Describe)/.test(sid),
-            `Sid "${sid}" uses Resource:"*" — only allowed for List*/Describe-all read APIs`,
-          ).toBe(true);
-        }
+        expect(
+          hasWildcard,
+          `Sid "${sid}" uses Resource:"*" — JAM/GameDay 前提では参加者 Role に list 系を付与しない方針 (#820 撤回)`,
+        ).toBe(false);
       }
       expect(template).toContain("ParticipantViewerRoleArn:");
       expect(template).toContain("Value: !GetAtt ParticipantViewerRole.Arn");

--- a/problems/challenges/hello-world/template.yaml
+++ b/problems/challenges/hello-world/template.yaml
@@ -48,22 +48,21 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
+              # Issue #820 retraction / ADR-021: JAM/GameDay baseline = participant IAM
+              # Role MUST only touch its own problem's resources. Previous policy
+              # granted ssm:DescribeParameters / ssm:GetParametersByPath /
+              # cloudformation:ListStacks at Resource:*, leaking other tenants' SSM
+              # parameter names and CFn stack metadata via CLI. List-style IAM actions
+              # are no longer granted (AWS Console list view stays empty by design;
+              # the participant portal provides deep links to specific resources).
               - Sid: ReadOwnSsmParameters
                 Effect: Allow
                 Action:
                   - ssm:GetParameter
                   - ssm:GetParameters
-                Resource: !Sub "arn:aws:ssm:*:*:parameter/${NamePrefix}/*"
-              # Issue #820: AWS Console SSM Parameter Store list view requires
-              # DescribeParameters / GetParametersByPath (list APIs cannot be
-              # resource-scoped, but the Console filters by path so the user only
-              # sees their own problem's parameters).
-              - Sid: ListSsmParametersForConsole
-                Effect: Allow
-                Action:
-                  - ssm:DescribeParameters
+                  # GetParametersByPath is resource-scopable via path-prefix ARN.
                   - ssm:GetParametersByPath
-                Resource: "*"
+                Resource: !Sub "arn:aws:ssm:*:*:parameter/${NamePrefix}/*"
               - Sid: DescribeOwnStack
                 Effect: Allow
                 Action:
@@ -72,14 +71,6 @@ Resources:
                   - cloudformation:DescribeStackEvents
                   - cloudformation:GetTemplate
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${NamePrefix}/*"
-              # Issue #820: required for CFn Console stack list view
-              # (ListStacks cannot be resource-scoped). List-only, no impact on
-              # the solution path (reading the SSM Parameter value).
-              - Sid: ListCfnStacksForConsole
-                Effect: Allow
-                Action:
-                  - cloudformation:ListStacks
-                Resource: "*"
 
   HelloParameter:
     Type: AWS::SSM::Parameter

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,12 +91,30 @@ cp "${TenkaCloud_ROOT}/.nvmrc" "${STAGING}/.nvmrc"
 # `packageManager: "bun@<version>"` field から Bun version を読む。 無いと ENOENT で
 # tenant provisioning / update CodeBuild job が fail する (= "package.json not found")。
 cp "${TenkaCloud_ROOT}/package.json" "${STAGING}/package.json"
-# packages/ を staging root に同梱。 infrastructure/package.json (= cdk/package.json) は
-# `@TenkaCloud/trust-bridge: workspace:*` で sibling workspace を参照する。 CodeBuild の
-# bun install (= update-tenant.sh / provision-tenant.sh で npm install → bun install に
-# 切替済) が workspace を resolve できるよう同梱する。 無いと
-# `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"` で fail する (= 旧 npm install
-# 経路、 #916 の 2 層目 regression)。
+# Issue #916 (3 層目): repo root の workspaces 宣言は `["infrastructure", "apps/*", "packages/*"]`
+# だが、 staging では SBT ref-arch 互換のため `infrastructure/` を `cdk/` にリネームしている (= 上の
+# `cp -R infrastructure "${STAGING}/cdk"`)。 結果 root package.json の workspaces 宣言と staging の
+# 実ディレクトリ名が乖離し、 CodeBuild の `cd cdk && bun install` で bun が `cdk` を workspace
+# member と認識せず、 `@TenkaCloud/trust-bridge: workspace:*` を `./*` (= cdk 内 siblings) で探して
+# fail する (= "Workspace dependency '@TenkaCloud/trust-bridge' not found / Searched in './*'")。
+#
+# 対策: staging root の package.json の workspaces 配列で `infrastructure` を `cdk` に置換する。
+# 他に staging 名と repo 名が乖離している workspace は無いので 1 置換で十分。 sed の in-place 編集は
+# BSD/GNU 互換に注意 (macOS は `sed -i ''`)。
+python3 -c "
+import json, sys
+p = '${STAGING}/package.json'
+with open(p, 'r') as f:
+    pkg = json.load(f)
+pkg['workspaces'] = [w if w != 'infrastructure' else 'cdk' for w in pkg.get('workspaces', [])]
+with open(p, 'w') as f:
+    json.dump(pkg, f, indent=2)
+"
+# packages/ を staging root に同梱。 cdk/package.json は \`@TenkaCloud/trust-bridge: workspace:*\` で
+# sibling workspace を参照する。 CodeBuild の bun install (= update-tenant.sh / provision-tenant.sh で
+# npm install → bun install に切替済) が workspace を resolve できるよう同梱する。 無いと
+# \`EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"\` で fail する (= 旧 npm install 経路、
+# #916 の 2 層目 regression)。
 cp -R packages "${STAGING}/packages"
 # 旧 ref-arch では src/ を staging に含めていたが、#76 で
 # infrastructure/lib/tenant-pipeline/handlers/ に移動済 (cdk/ 配下に同梱されるので不要)。


### PR DESCRIPTION
2 production blockers in one PR (both small, both urgent).

## #1: participant-viewer Role IAM tightening (security)
旧 policy が \`ssm:DescribeParameters\` / \`ssm:GetParametersByPath\` / \`cloudformation:ListStacks\` を Resource:* で付与しており、 参加者は CLI 越しに platform / 他 tenant / 他 team の SSM Parameter / CFn Stack を列挙 + 一部値を読めていた。 AWS JAM / GameDay 系の競技前提 (= 参加者は自問題の resource のみ触れる) を Issue #820 の compromise が壊していたため撤回。

- \`problems/challenges/hello-world/template.yaml\`: list 系 statement を削除、 \`GetParametersByPath\` は path-prefix で scope。
- \`problem-template-participant-viewer-role.test.ts\`: Resource:* が **どの statement にあっても** test を fail させるよう pin。

副作用: AWS Console の list view が空になる (= JAM/GameDay の正常な振舞い)。 参加者は portal の deep link で個別 resource に直行する。

ADR-021 (= 設計判断の正本化) は follow-up PR で別途。

## #2: CodeBuild の bun install workspace 解決 fix (#916 layer 3)
直近 build log:
\`\`\`
error: Workspace dependency '@TenkaCloud/trust-bridge' not found
Searched in './*'
\`\`\`

Root cause: repo root の workspaces 配列は \`["infrastructure", "apps/*", "packages/*"]\` だが、 install.sh は staging で \`infrastructure/\` を \`cdk/\` にリネーム (SBT ref-arch 互換)。 staging root の package.json も同じ書き換えが必要だったが抜けていた → bun が CWD=cdk を workspace member と認識せず、 \`workspace:*\` を local \`./*\` で resolve しようとして fail。

Fix: install.sh で staging package.json を python3 で書き換え、 workspaces 配列の \`infrastructure\` を \`cdk\` に置換してから zip に固める。 \`install-script.test.ts\` に regression pin 追加。

これで tenant provisioning / update CodeBuild が再び通る。

## 物理影響
- **\`problems/challenges/hello-world/template.yaml\`** — UPDATE: policy 削減 (security 効果あり、 deploy 後の Role policy version 上がる)
- **\`scripts/install.sh\`** — UPDATE: python3 1 block 挿入、 staging package.json の workspaces 書き換え
- **2 つの test ファイル** — UPDATE: regression pin

## Test plan
- [x] \`bun run vitest run test/install-script.test.ts test/problem-deploy/problem-template-participant-viewer-role.test.ts\` — 9 件 pass
- [x] \`make harness\` / \`make before-commit\` (lint / typecheck / 全 workspace test / build / cdk synth)
- [ ] deploy 後: CodeBuild tenant provisioning job が success、 参加者 Role で \`aws ssm describe-parameters\` が AccessDenied を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)