### PR TITLE
fix(#13)!: 競技開始前 / 終了後の flag 提出を gate で reject (critical correctness)

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -200,7 +200,22 @@ function FlagSubmissionPanel({
       }
     } catch (err) {
       if (err instanceof PortalValidationError) {
-        setSubmitError(`バリデーションエラー: ${err.errorCode}`);
+        // Issue #13 / scoring gate: 競技開始前 / 終了後 / lock の error code を
+        // 人間可読 message に変換 (= 「バリデーションエラー: scoring_not_started」 では何が
+        // 起きているか参加者に伝わらない)。
+        const friendly = (() => {
+          switch (err.errorCode) {
+            case "scoring_not_started":
+              return "競技はまだ開始していません。 運営の開始合図をお待ちください。";
+            case "scoring_ended":
+              return "競技は終了しました。 採点 gate は閉じています。";
+            case "scoring_locked":
+              return "採点が一時停止されています。 運営にお問い合わせください。";
+            default:
+              return `エラー: ${err.errorCode}`;
+          }
+        })();
+        setSubmitError(friendly);
       } else {
         setSubmitError(err instanceof Error ? err.message : String(err));
       }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -154,6 +154,10 @@ app.post("/portal/me/submit-flag", (c) =>
       if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
       if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
       if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
+      // Issue #13 / scoring gate: 競技開始前 / 終了後の提出は raw outcome を 409 で返し、
+      // UI で「競技開始までお待ちください」 / 「競技は終了しました」 の文言に分岐させる。
+      if (outcome.kind === "scoring_not_started") return respondError(c, "scoring_not_started");
+      if (outcome.kind === "scoring_ended") return respondError(c, "scoring_ended");
       return c.json(outcome, HTTP_OK);
     },
     RATE_LIMITS.WRITE_VERY_LOW,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -38,6 +38,9 @@ const ERROR_STATUS = {
   no_event: HTTP_NOT_FOUND,
   not_found: HTTP_NOT_FOUND,
   scoring_locked: HTTP_CONFLICT,
+  // Issue #13 / scoring gate: 競技開始前 / 終了後の提出。 409 (= 状態的に受け付けない)。
+  scoring_not_started: HTTP_CONFLICT,
+  scoring_ended: HTTP_CONFLICT,
   misconfigured: HTTP_INTERNAL_ERROR,
   // Issue #705: SSO の "misconfigured" を細分化 (= 原因切り分け可能に)。
   assume_role_failed: HTTP_INTERNAL_ERROR,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -17,33 +17,94 @@ export type SubmitFlagOutcome =
   | { kind: "not_flag_problem" }
   | { kind: "no_outputs" }
   | { kind: "scoring_locked" }
+  /**
+   * Issue #13 / scoring gate: 競技が開始前 (= Event.startsAt 未設定 / now < startsAt) または
+   * 終了後 (= now > endsAt) / status=ENDED|ARCHIVED の状態で flag 提出を受けない。
+   * 旧コードはこの gate が欠落しており、 deploy 直後から flag 提出で得点が入っていた (= JAM/GameDay
+   * 前提違反、 大会の公平性を完全に壊す)。
+   */
+  | { kind: "scoring_not_started"; startsAt?: string }
+  | { kind: "scoring_ended"; endsAt?: string }
   | { kind: "unauthorized" };
 
+interface EventGate {
+  readonly scoringLocked: boolean;
+  readonly startsAt: string | undefined;
+  readonly endsAt: string | undefined;
+  readonly status: string | undefined;
+}
+
 /**
- * #558: Event の scoringLocked flag を read-through で取得する。
- * - 行不在 / フィールド無し → false (= unlocked と同義)
- * - error → false (fail-open。lock が効かない方が「採点ストップ」より運用上マシ、健全な状態に戻る)
+ * Issue #13: Event の gate flags を read-through で取得する。 scoringLocked + startsAt + endsAt +
+ * status を 1 GetItem (= 1 RCU) でまとめて読む。 不在 / error は fail-closed で 「採点不可」 扱い
+ * (= old fail-open とは逆。 JAM/GameDay 前提では「採点しないより、 まずデータ取れなかったら
+ * 採点を止める」 が安全側)。
  */
-async function isEventScoringLocked(
+async function getEventGate(
   shared: ParticipantSharedResources,
   eventId: string,
-): Promise<boolean> {
+): Promise<EventGate | undefined> {
   try {
     const out = await shared.ddb.send(
       new GetCommand({
         TableName: shared.eventsTableName,
         Key: { PK: `EVENT#${eventId}`, SK: "META" },
-        ProjectionExpression: "scoringLocked",
+        ProjectionExpression: "scoringLocked, startsAt, endsAt, #s",
+        ExpressionAttributeNames: { "#s": "status" },
       }),
     );
-    return (out.Item as { scoringLocked?: boolean } | undefined)?.scoringLocked === true;
+    const item = out.Item as
+      | {
+          scoringLocked?: boolean;
+          startsAt?: string;
+          endsAt?: string;
+          status?: string;
+        }
+      | undefined;
+    if (!item) return undefined;
+    return {
+      scoringLocked: item.scoringLocked === true,
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      status: item.status,
+    };
   } catch (err) {
-    console.warn("[submit-flag] isEventScoringLocked failed (fail-open)", {
+    console.warn("[submit-flag] getEventGate failed", {
       eventId,
       message: err instanceof Error ? err.message : String(err),
     });
-    return false;
+    return undefined;
   }
+}
+
+/**
+ * Issue #13: scoring gate を評価する。 順序は次のとおり (= 上から先に該当した outcome を返す):
+ *   1. event 行が無い          → "scoring_not_started" (= 安全側)
+ *   2. status=ENDED / ARCHIVED → "scoring_ended"
+ *   3. startsAt 未設定         → "scoring_not_started"
+ *   4. now < startsAt          → "scoring_not_started"
+ *   5. endsAt 設定 + now > endsAt → "scoring_ended"
+ *   6. scoringLocked           → "scoring_locked"
+ *   7. それ以外                → undefined (= scoring active、 加点経路へ)
+ */
+function evaluateGate(gate: EventGate | undefined, nowMs: number): SubmitFlagOutcome | undefined {
+  if (!gate) return { kind: "scoring_not_started" };
+  if (gate.status === "ENDED" || gate.status === "ARCHIVED") {
+    return { kind: "scoring_ended", endsAt: gate.endsAt };
+  }
+  if (!gate.startsAt) return { kind: "scoring_not_started" };
+  const startMs = Date.parse(gate.startsAt);
+  if (Number.isFinite(startMs) && nowMs < startMs) {
+    return { kind: "scoring_not_started", startsAt: gate.startsAt };
+  }
+  if (gate.endsAt) {
+    const endMs = Date.parse(gate.endsAt);
+    if (Number.isFinite(endMs) && nowMs > endMs) {
+      return { kind: "scoring_ended", endsAt: gate.endsAt };
+    }
+  }
+  if (gate.scoringLocked) return { kind: "scoring_locked" };
+  return undefined;
 }
 
 /**
@@ -71,12 +132,14 @@ export async function submitFlag(
   const item = items.find((i) => i.problemId === problemId);
   if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
 
-  // #558: scoring lock check — Event 単位で lock されていたら加点経路を返さない
-  // (= 提出履歴は残さず、`scoring_locked` outcome で UI に伝える)。Event GET は 1 RCU、
-  // submit-flag は per-attempt の rare path なので read-through で十分。
+  // Issue #13 / scoring gate: 競技開始前 / 終了後 / lock 時は加点経路を返さない
+  // (= 提出履歴は残さず、 該当 outcome を UI に伝える)。 Event GET は 1 RCU、 submit-flag は
+  // per-attempt の rare path なので read-through で十分。 旧来 (#558) は scoringLocked
+  // のみ checked。 本 PR で startsAt / endsAt / status も追加し、 competition gate を完全化。
   if (typeof item.eventId === "string" && item.eventId.length > 0) {
-    const locked = await isEventScoringLocked(shared, item.eventId);
-    if (locked) return { kind: "scoring_locked" };
+    const gate = await getEventGate(shared, item.eventId);
+    const blocked = evaluateGate(gate, Date.now());
+    if (blocked) return blocked;
   }
 
   const scoring = scoringMap[item.problemId];

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -231,4 +231,130 @@ describe("submitFlag", () => {
     expect(queryCmd.input.IndexName).toBe("GSI2");
     expect(queryCmd.input.ExpressionAttributeValues).toEqual({ ":pk": "TEAMKEY#MYKEY" });
   });
+
+  // ---- Issue #13 / scoring gate (startsAt / endsAt / status) ----
+  // event-scoped deployment は EventMeta から gate flags を読んで、 競技開始前 / 終了後の
+  // 提出を加点経路に通さない。
+  describe("competition scoring gate (Issue #13)", () => {
+    const eventRow = sampleRow({ eventId: "EVT1", score: 0 });
+
+    it("Event 行が無い場合 fail-closed で scoring_not_started を返すべき", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({}); // EventMeta GetItem returns no Item
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out).toEqual({ kind: "scoring_not_started" });
+    });
+
+    it("startsAt 未設定 (READY だが時刻未指定) なら scoring_not_started を返すべき", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({ Item: { status: "READY" } });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out.kind).toBe("scoring_not_started");
+    });
+
+    it("now < startsAt なら scoring_not_started を返し startsAt を含めるべき", async () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({ Item: { status: "READY", startsAt: future } });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out).toEqual({ kind: "scoring_not_started", startsAt: future });
+    });
+
+    it("endsAt 設定 + now > endsAt なら scoring_ended を返すべき", async () => {
+      const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const before = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, endsAt: past },
+      });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out).toEqual({ kind: "scoring_ended", endsAt: past });
+    });
+
+    it("status=ENDED なら startsAt があっても scoring_ended を返すべき", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({ Item: { status: "ENDED", startsAt: before } });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out.kind).toBe("scoring_ended");
+    });
+
+    it("startsAt 過去 + endsAt 未来 + status=READY なら gate を通って ok 加点すべき", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, endsAt: future },
+      });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out.kind).toBe("ok");
+    });
+
+    it("scoringLocked=true は startsAt OK でも scoring_locked を返す (= 既存挙動)", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, scoringLocked: true },
+      });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out).toEqual({ kind: "scoring_locked" });
+    });
+
+    it("eventId 不在の row (= standalone deploy) では gate を skip して ok を返すべき (旧挙動互換)", async () => {
+      // event scope 無し → gate check しない → 即加点経路へ
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] }); // eventId 無し
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+      );
+      expect(out.kind).toBe("ok");
+    });
+  });
 });


### PR DESCRIPTION
## 致命的 correctness bug

submit-flag handler が \`Event.startsAt\` / \`endsAt\` / \`status\` を **全く check していなかった**。
結果として Event が READY (= deploy 完了したが startsAt 未設定) の状態でも参加者が flag を
提出して得点が入っていた (Image #37/#38 で報告: \`採点ステータス=未開始 / 開始時刻 (UTC)=未設定\` でも
100 pt 加算)。

JAM / GameDay 系競技の前提:
- 競技は admin が「開始時刻」 を設定するか「即座に開始」 で gate を開けて初めて採点開始
- それまで参加者は flag 提出しても **加点されない** (= 公平性の根本)
- endsAt を過ぎたら gate が閉じる。 ENDED / ARCHIVED でも閉じる

旧コードはこの基本前提を gate していなかった。

## Fix

\`submit-flag.ts\` に \`getEventGate\` + \`evaluateGate\` を追加し、 次の順で 評価:

| 順 | 条件 | 返り値 |
|---|---|---|
| 1 | EventMeta が引けない (= fail-closed) | scoring_not_started |
| 2 | status=ENDED \| ARCHIVED | scoring_ended |
| 3 | startsAt 未設定 | scoring_not_started |
| 4 | now < startsAt | scoring_not_started + startsAt |
| 5 | endsAt 設定 + now > endsAt | scoring_ended + endsAt |
| 6 | scoringLocked=true (= 既存 #558) | scoring_locked |
| 7 | 以上に該当しない | 加点経路 OK |

## 物理影響
- **\`infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts\`** — UPDATE: gate helpers + outcome 2 種類追加
- **\`infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts\`** — UPDATE: 新 outcome を respondError で 409 返却
- **\`infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts\`** — UPDATE: error code → HTTP_CONFLICT mapping
- **\`apps/participant-portal/src/components/ProblemPanel.tsx\`** — UPDATE: error code を人間可読 message に
- **\`infrastructure/test/problem-deploy/submit-flag.test.ts\`** — UPDATE: gate 7 case 追加 (= 計 20 件 pass)
- CFn 出力 / IAM / API GW: 変更なし。 Lambda bundle と SPA bundle のみ更新

## Regression 分析
- 旧 \`isEventScoringLocked\` は fail-**open** (= EventMeta 取れない時 false = unlocked 扱い)。 新 \`getEventGate\` は fail-**closed** (= 取れない時 scoring_not_started)。 JAM/GameDay 前提では取れないなら採点しない方が安全側
- standalone deploy (= eventId 不在の row) は gate 検査を skip し、 旧挙動を維持 (= smoke test / sample deploy / per-team manual deploy で使う経路)。 event-scoped deploy のみ gate 適用
- 既存 \`scoring_locked\` 経路は変更なし (= 順 #6 に格下げ。 startsAt OK + locked なら locked を返す)
- 追加 IAM: EventMeta GetItem (= 既存 IAM が許可済、 1 RCU/submit)

## Test plan
- [x] \`bun run vitest run test/problem-deploy/submit-flag.test.ts\` — 20 件 pass (= 既存 13 + gate 7)
- [x] \`make harness\` / \`make before-commit\` (flaky CDK synth test 2 件は isolated 実行で pass を確認、 changes と無関係)
- [ ] deploy 後: Event 作成 → deploy → 開始時刻 未設定で flag 提出 → 409 \`scoring_not_started\` が返る、 開始時刻設定後に提出 → ok 加点

## 関連
- Image #37/#38 で発見されたバグ (= 競技未開始でも score 100pt が入っていた状態)
- ADR-022 (= scoring gate 仕様の正本化) は follow-up PR

! BREAKING: API レスポンス outcome に新 kind 追加 (\`scoring_not_started\` / \`scoring_ended\`)。 既存 SDK client (= portal SPA) は 409 で wrap した PortalValidationError として既に handling 済なので互換。

🤖 Generated with [Claude Code](https://claude.com/claude-code)