### PR TITLE
feat(#1,#2,#3): 問題詳細画面から競技に不要な metadata を削除

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -1,7 +1,6 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
-import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
@@ -107,20 +106,15 @@ export function ProblemPanel({
             期待通り応答していない可能性があります。
           </Alert>
         )}
-        <ColumnLayout columns={2} variant="text-grid">
-          <KeyValuePairs
-            items={[
-              { label: "Region", value: problem.region },
-              { label: "Job ID", value: <code>{problem.jobId}</code> },
-            ]}
-          />
-          <KeyValuePairs
-            items={[
-              { label: "現在の score", value: `${problem.score} pt` },
-              { label: "最終加点", value: describeAgo(problem.lastScoredAt, now) },
-            ]}
-          />
-        </ColumnLayout>
+        {/* Audit #3: Job ID (= 内部 ULID) は競技者に見せない。 Region は AWS 多リージョン
+            の場合のみ意味があるが、 1 リージョン運用の現状では noise。 残すのは現在の score + 最終加点 */}
+        <KeyValuePairs
+          items={[
+            { label: "現在の score", value: `${problem.score} pt` },
+            { label: "最終加点", value: describeAgo(problem.lastScoredAt, now) },
+          ]}
+        />
+
         {Object.keys(problem.stackOutputs).length > 0 && (
           <Container header={<Header variant="h3">アクセス先 URL</Header>}>
             <KeyValuePairs

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -133,33 +133,30 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
 }
 
 /**
- * #550: 「問題情報」 section。metadata.json 由来の narrative を競技者目線で表示する。
+ * #550 + audit #1/#2: 「問題情報」 section。 metadata 由来 narrative を competition 目線で表示。
  * 内訳:
- *   - カテゴリ (Battle / Challenge) + 難易度 + 想定プレイ時間 + tags (基本情報 row)
- *   - 問題説明 (= `description`、改行保持の長文)
- *   - 学習目的 (= `learningGoals`、bullet list)
+ *   - カテゴリ (Battle / Challenge) + 難易度 (= 競技者の戦略決定に必要な 2 軸)
+ *   - 問題説明 (= description、 改行保持の長文)
  *
- * 表示しない field: `cfnTemplate` / `cfnParameters` / `exposedPorts` (= 競技者が見ても
- * 答えの hint にしかならない deploy 内部情報)。
- *
- * 「シナリオ」「達成条件」「参考資料」「Battle 用ヒント」は schema 拡張が要るため別 PR で
- * 対応 (= #550 issue 本文の段階的実装、schema 拡張は `problems/SCHEMA.json` + 既存 3 問の
- * metadata.json 全更新が要りスコープ大)。
+ * 表示しない field (audit table):
+ *   - 想定プレイ時間 → 大会 timing を競技者に漏らさない (audit #1)
+ *   - 学習目的 / 背景 / 世界観 → 出題意図のメタ情報、 競技中は不要 (audit #2)
+ *   - タグ → 一覧の category filter で十分、 詳細では noise
+ *   - cfnTemplate / cfnParameters / exposedPorts → deploy 内部情報
  */
 function ProblemInfoSection({
   metadata,
   narrative,
 }: {
   metadata: ProblemCatalogEntry;
-  narrative: {
-    readonly description: string;
-    readonly learningGoals: readonly string[];
-  };
+  narrative: { readonly description: string };
 }) {
+  // Audit table #1/#2: 想定プレイ時間 / 学習目的 / タグ は competition では出さない
+  // (= timing 漏洩 + 出題意図メタの暴露)。 残すのは カテゴリ + 難易度 + 問題説明 のみ。
   return (
     <Container header={<Header variant="h2">問題情報</Header>}>
       <SpaceBetween size="m">
-        <ColumnLayout columns={4} variant="text-grid">
+        <ColumnLayout columns={2} variant="text-grid">
           <InfoCell label="カテゴリ">
             <SpaceBetween direction="horizontal" size="xxs">
               <Badge color={metadata.category === "Battle" ? "red" : "blue"}>
@@ -170,22 +167,6 @@ function ProblemInfoSection({
             </SpaceBetween>
           </InfoCell>
           <InfoCell label="難易度">{DIFFICULTY_LABEL[metadata.difficulty]}</InfoCell>
-          <InfoCell label="想定プレイ時間">{metadata.estimatedDuration}</InfoCell>
-          <InfoCell label="タグ">
-            <SpaceBetween direction="horizontal" size="xxs">
-              {metadata.tags.length === 0 ? (
-                <Box variant="small" color="text-status-inactive">
-                  —
-                </Box>
-              ) : (
-                metadata.tags.map((t) => (
-                  <Badge key={t} color="grey">
-                    {t}
-                  </Badge>
-                ))
-              )}
-            </SpaceBetween>
-          </InfoCell>
         </ColumnLayout>
 
         <div>
@@ -199,17 +180,6 @@ function ProblemInfoSection({
             dangerouslySetInnerHTML={{ __html: renderMarkdownToSafeHtml(narrative.description) }}
           />
         </div>
-
-        {narrative.learningGoals.length > 0 && (
-          <div>
-            <Box variant="awsui-key-label">学習目的</Box>
-            <ul>
-              {narrative.learningGoals.map((g) => (
-                <li key={g}>{g}</li>
-              ))}
-            </ul>
-          </div>
-        )}
       </SpaceBetween>
     </Container>
   );


### PR DESCRIPTION
Audit table の #1 / #2 / #3 を 1 PR で。

## 削除する情報

| audit # | 場所 | 内容 | 理由 |
|---|---|---|---|
| #1 | 問題詳細「問題情報」 | 想定プレイ時間 | 大会 timing が漏れる |
| #2 | 問題詳細「問題情報」 | 学習目的 / タグ | 出題意図のメタ情報、 競技中は不要 |
| #3 | ProblemPanel (= 詳細下部) | Job ID / Region | Job ID は内部 ULID、 Region は 1 リージョン運用で noise |

## 残す情報
カテゴリ / 難易度 / 問題説明 / アクセス先 URL / flag 提出 / ヒント / (Battle: 採点 + timeline)。 これらは競技者が **解く / 状況把握する** のに必要な要素。

## 物理影響
- **\`apps/participant-portal/src/pages/ProblemDetail.tsx\`** — UPDATE: ProblemInfoSection を 4 列 → 2 列、 学習目的 セクション削除、 narrative 型から learningGoals 削除
- **\`apps/participant-portal/src/components/ProblemPanel.tsx\`** — UPDATE: ColumnLayout 削除、 KeyValuePairs を 1 個に圧縮
- backend / CFn: 変更なし

## Regression 分析
- backend ParticipantProblemView は変更せず、 frontend が出さない field を保持。 既存 cache / API contract に影響なし
- learningGoals は問題作者の self-doc 用 metadata として残るが、 portal では出さない (= admin / 問題作成ツール側で見られる経路は別途)

## Test plan
- [x] \`bun run typecheck\` — clean
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: 問題詳細を開いて 想定プレイ時間 / 学習目的 / タグ / Job ID / Region が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the problem panel display to show only the current score and when it was last scored
  * Refined the problem information section to focus on category, difficulty, and problem description, removing estimated play time and learning goals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->