### PR TITLE
feat(#5): SSO Credentials から 「競技後の環境片付け」 panel を削除

### DIFF
--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -135,83 +135,12 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
           </Container>
         ))}
 
-      {view && view.problems.length > 0 && (
-        <PostCompetitionCleanupPanel
-          firstAccount={view.problems[0]?.awsAccountId}
-          firstRegion={view.problems[0]?.region}
-        />
-      )}
+      {/* Audit table #5: 「競技後の環境片付け」 セクションは participant portal の責務ではない (=
+       *   admin が event 終了通知メールで案内するべき、 競技中に常時表示すべきでない)。 旧 #840
+       *   が PostCompetitionCleanupPanel をここに置いていたが competition の persona と
+       *   合わないため削除。 cleanup 手順自体は infrastructure/templates/README.md に残るので、
+       *   admin が event 終了時に competitors にメール文面でリンクを渡す運用にする (= Phase 2)。
+       */}
     </SpaceBetween>
-  );
-}
-
-/**
- * Issue #840: 競技終了後の片付け案内。 競技者 AWS Account には `tenkacloud-competitor-bootstrap`
- * stack (= TenkaCloud 運営側が AssumeRole するための IAM Role) が残り続けるので、 競技を終えたら
- * 競技者自身が CFn DeleteStack することで TenkaCloud 側からの AssumeRole 経路を即時撤回できる。
- *
- * Phase 1 (本 PR): doc + AWS Console deep link を出す。 portal から cross-account で
- * cleanup する経路は backend 側の追加実装が必要なため Phase 2 で扱う (= 別 PR、 CDK 担当範囲)。
- */
-function PostCompetitionCleanupPanel({
-  firstAccount,
-  firstRegion,
-}: {
-  firstAccount: string | undefined;
-  firstRegion: string | undefined;
-}) {
-  const region = firstRegion || "ap-northeast-1";
-  // AWS Console deep link to CloudFormation の stack detail page (= 競技者 account にログイン中なら直接遷移可)。
-  const consoleUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks?filteringText=tenkacloud-competitor-bootstrap`;
-  return (
-    <Container
-      header={
-        <Header
-          variant="h2"
-          description="競技を終えたら IAM Role を撤回して TenkaCloud からの AssumeRole 経路を閉じます。"
-        >
-          競技後の環境片付け
-        </Header>
-      }
-    >
-      <SpaceBetween size="m">
-        <Box variant="p">
-          competition 中に作成した <code>tenkacloud-competitor-bootstrap</code> stack (= IAM Role)
-          は、 競技後も AWS Account に残ります。 残ったままだと TenkaCloud 運営側からの AssumeRole
-          が 有効なままなので、 競技を終えたら次のいずれかの方法で削除してください。
-        </Box>
-        <Box variant="h4">方法 A: CLI で 1 行削除</Box>
-        <Box variant="code">
-          aws cloudformation delete-stack --stack-name tenkacloud-competitor-bootstrap
-        </Box>
-        <Box variant="h4">方法 B: AWS Console から削除</Box>
-        <Button
-          variant="normal"
-          iconName="external"
-          href={consoleUrl}
-          target="_blank"
-          ariaLabel="競技者 AWS Account の CloudFormation スタック一覧を新しいタブで開く"
-        >
-          CloudFormation スタック一覧を開く
-        </Button>
-        <Alert type="info">
-          {firstAccount && (
-            <>
-              対象 Account: <code>{firstAccount}</code> / Region: <code>{region}</code>。
-            </>
-          )}
-          stack を削除すると Role も同時に消え、 以降 TenkaCloud 側からの AssumeRole は即時 deny
-          されます。 AWS Console での手動 delete も同じ効果です。 詳しい手順とセキュリティ前提は{" "}
-          <a
-            href="https://github.com/susumutomita/TenkaCloud/blob/main/infrastructure/templates/README.md#%E6%92%A4%E5%9B%9E--%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%A2%E3%83%83%E3%83%97"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            infrastructure/templates/README.md
-          </a>{" "}
-          を参照してください。
-        </Alert>
-      </SpaceBetween>
-    </Container>
   );
 }


### PR DESCRIPTION
audit #5: participant portal の SSO Credentials に 「競技後の環境片付け」 (= delete-stack CLI + AWS Console deep link) が常時表示されていたが、 competition の persona に合わない (= 競技中の participant に片付け手順を出すのは noise、 admin が終了通知メールで案内するべき)。

panel コンポーネントごと削除。 cleanup 手順自体は \`infrastructure/templates/README.md\` に残るので、 application-admin-console 側の event 終了通知メール文面 (Phase 2) でリンクを渡す運用に移す。

## 物理影響
- **\`apps/participant-portal/src/pages/SsoCredentials.tsx\`** — UPDATE: PostCompetitionCleanupPanel コンポーネントと caller 削除 (= 60 行減)

## Regression 分析
- AWS Console deep link 経路は \`infrastructure/templates/README.md\` に同じ link が残るのでドキュメント側で参照可能
- 既存 SsoCredentials の上部 (= 使い方 alert / AWS Console を開く button per problem) は変更なし

## Test plan
- [x] \`bun run typecheck\` — clean
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: /tools/sso に 「競技後の環境片付け」 が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)