### PR TITLE
feat(#10,#11): Home を dashboard 化 + 長 username の truncate

### DIFF
--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -42,7 +42,10 @@
     "score_problem_count": "Problems",
     "score_completed_count": "Completed",
     "no_problems_header": "No problems",
-    "no_problems_body": "This team has no deployed problems. Please contact the operator."
+    "no_problems_body": "This team has no deployed problems. Please contact the operator.",
+    "quests_quick_link_header": "Take on the problems",
+    "quests_quick_link_body": "{count} problem(s) deployed. Open the Quests list to start.",
+    "quests_quick_link_button": "Open Quests"
   },
   "login": {
     "header": "TenkaCloud Participant Portal",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -42,7 +42,10 @@
     "score_problem_count": "問題数",
     "score_completed_count": "完了済",
     "no_problems_header": "問題がありません",
-    "no_problems_body": "このチームには deploy 済みの問題がありません。operator にお問い合わせください。"
+    "no_problems_body": "このチームには deploy 済みの問題がありません。operator にお問い合わせください。",
+    "quests_quick_link_header": "問題に挑戦",
+    "quests_quick_link_body": "{count} 問が deploy 済です。 問題一覧から挑戦してください。",
+    "quests_quick_link_button": "問題一覧を開く"
   },
   "login": {
     "header": "TenkaCloud Participant Portal",

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -1,25 +1,39 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useNavigate } from "react-router";
 import type { ParticipantTeamView } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
-import { ProblemPanel } from "../components/ProblemPanel";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 
+/**
+ * Audit table #11: 超長 username (= Cognito sub-derived 名等) が header 全幅を占有して
+ * layout を壊す問題への対策。 長すぎる名前は ~24 文字で truncate + "…" を付ける (Cloudscape
+ * の Box variant に text overflow control が無いため自前で行う)。 詳細は detail 画面 / プロファイル
+ * 画面で fullName を出す経路を別途用意する。
+ */
+const TEAM_NAME_MAX = 24;
+function truncateTeamName(name: string): string {
+  if (name.length <= TEAM_NAME_MAX) return name;
+  return `${name.slice(0, TEAM_NAME_MAX)}…`;
+}
+
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
-  const sessionToken = auth.session?.sessionToken ?? null;
   const isBackend = config.mode === "backend";
   const t = useT();
+  const navigate = useNavigate();
   // Polling は ShellLayout の TeamViewProvider で一括管理される (TopNav も同じデータを共有)。
-  const { view, error, refresh } = useTeamView();
+  const { view, error } = useTeamView();
 
-  const teamName = view?.team.teamName ?? auth.session?.teamName ?? "(unknown)";
+  const teamNameRaw = view?.team.teamName ?? auth.session?.teamName ?? "(unknown)";
+  const teamName = truncateTeamName(teamNameRaw);
 
   return (
     <SpaceBetween size="l">
@@ -40,15 +54,18 @@ export function HomePage({ config }: { config: AppConfig }) {
 
       {view && <TeamScorePanel view={view} />}
 
-      {view?.problems.map((problem) => (
-        <ProblemPanel
-          key={problem.jobId}
-          problem={problem}
-          apiBaseUrl={config.apiBaseUrl}
-          sessionToken={sessionToken ?? ""}
-          onScored={refresh}
-        />
-      ))}
+      {/* Audit table #10: ホームは dashboard。 問題詳細 (ProblemPanel) を embed しない (=
+       *  「一等地に何を出すか」 のティアリング、 問題の deep dive は /problems から)。 */}
+      {view && view.problems.length > 0 && (
+        <Container header={<Header variant="h2">{t("home.quests_quick_link_header")}</Header>}>
+          <SpaceBetween size="m">
+            <Box>{t("home.quests_quick_link_body", { count: view.problems.length })}</Box>
+            <Button variant="primary" onClick={() => navigate("/problems")}>
+              {t("home.quests_quick_link_button")}
+            </Button>
+          </SpaceBetween>
+        </Container>
+      )}
 
       {view && view.problems.length === 0 && (
         <Container header={<Header variant="h2">{t("home.no_problems_header")}</Header>}>


### PR DESCRIPTION
audit table #10 + #11 を 1 PR で。

## #10: Home から ProblemPanel embed を削除
旧 Home はチーム score panel の下に **全 problem の ProblemPanel** を縦に並べていた。 結果として 「ホームの一等地」 が問題詳細で埋まり、 dashboard としての俯瞰性が失われていた (= image #36 で hello-world の full info がホームに展開されている)。 ティアリング原則:
- ホーム = dashboard (= score + 残タスク 概観 + 詳細への導線)
- /problems (Quests) = カード一覧 (= 戦略決定)
- /problems/:jobId = 問題詳細 (= 解くため)

修正: 問題詳細 embed を削除し、 「問題に挑戦 → 問題一覧を開く」 quick link container に置き換え。

## #11: 超長 username の truncate
旧コードは header に \`{teamName} さん\` を生で展開していた。 username が長いと layout を破壊する (= image #36 の \"0123456789012...\" 文字列が画面幅を占有)。 24 文字超は \"…\" で truncate。 完全な username は profile / detail 画面 (= 将来追加) で見せる。

## 物理影響
- **\`apps/participant-portal/src/pages/Home.tsx\`** — UPDATE: ProblemPanel embed 削除 + truncateTeamName helper 追加 + quick link container
- **i18n ja/en** — UPDATE: \`quests_quick_link_*\` 3 keys 追加

## Regression 分析
- 問題詳細にアクセスする経路は維持: ホームの quick link button → /problems → カード click → /problems/:jobId
- 残タスク把握は score panel (= 完了済 count) + Quests の status filter (#9) で十分
- truncate は表示のみで data 自体は変更なし (= score / 採点 / その他 backend には影響無し)

## Test plan
- [x] \`bun run typecheck\` — clean
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: ホームに ProblemPanel が embed されないこと、 超長 username が \"…\" で切られること

🤖 Generated with [Claude Code](https://claude.com/claude-code)