### PR TITLE
feat(#8, ADR-020 Phase E): RoleSessionName に problemId + tenant UserPool MFA REQUIRED

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -185,10 +185,15 @@ export async function getConsoleSigninUrl(
       return { kind: "assume_role_failed", reason: "Credentials field empty" };
     }
     const innerSts = new STSClient({ credentials: competitorCredentials });
+    // Audit table #8: 旧 RoleSessionName は `participant-viewer-${jobId}` で generic だった (=
+    // AWS Console 上部 federation user 表示で問題名が分からない、 image #30 の指摘)。 problemId を
+    // 含めて `${problemId}-${jobId}` 形式に変更。 IAM の RoleSessionName 制約: 2-64 文字 / pattern
+    // `[\\w+=,.@-]+`。 problemId max ~30 文字 + '-' + ULID jobId 26 文字 = 最大 57 文字で収まる。
+    // problemId は metadata.json の id (= kebab-case slug) なので IAM 許容 pattern に合致する。
     session = await innerSts.send(
       new AssumeRoleCommand({
         RoleArn: participantRoleArn,
-        RoleSessionName: `participant-viewer-${jobId}`,
+        RoleSessionName: `${problemId}-${jobId}`,
         ExternalId: jobId,
         DurationSeconds: FEDERATION_SESSION_DURATION_SEC,
       }),

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -133,6 +133,25 @@ export class IdentityProvider extends Construct {
     this.tenantUserPool = new aws_cognito.UserPool(this, "tenantUserPool", {
       autoVerify: { email: true },
       accountRecovery: aws_cognito.AccountRecovery.EMAIL_ONLY,
+      // ADR-020 Phase E / audit MFA: tenant admin consoles は destructive 操作を扱う
+      // (= user 管理 / SAML / 削除 / IAM mutate)。 OPTIONAL では参加率に依存して未設定の admin が
+      // 攻撃面に残るため、 REQUIRED で全 admin に TOTP 設定を強制する。
+      //
+      // signInAliases に email を使う運用なので SMS は使わず TOTP のみ (= 国際 SMS の到達率不安定
+      // 問題 + コスト)。 SMS をオフにしたい場合は \`mfaSecondFactor.sms: false\`、 TOTP 必須なので
+      // \`otp: true\`。
+      //
+      // 既存 user 向けの grace period 対策:
+      //   - Cognito の REQUIRED mode は first sign-in 時に MFA 登録を促す flow (= ChallengeName=MFA_SETUP)。
+      //   - 既存 user は 次回 sign-in 時に MFA 設定 step を 通る必要があるが、 forced reset ではなく
+      //     associate-software-token → verify の自然な流れ。
+      //   - 既存 TenantAdmin が lock-out された場合の救済は SystemAdmin (= control plane 側) が
+      //     AdminResetUserPassword + 再招待で復旧可能。
+      mfa: aws_cognito.Mfa.REQUIRED,
+      mfaSecondFactor: {
+        sms: false,
+        otp: true,
+      },
       userInvitation: {
         emailSubject: "[TenkaCloud] Tenant Admin Invitation",
         emailBody: buildInviteEmailBody(props.applicationAdminConsoleUrl),

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -36,6 +36,19 @@ describe("IdentityProvider", () => {
       template.resourceCountIs("AWS::Cognito::UserPoolDomain", 1);
     });
 
+    it("ADR-020 Phase E: tenant UserPool は MFA REQUIRED + TOTP-only に設定するべき", () => {
+      const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
+      // MFA を REQUIRED にし、 SMS を無効化、 TOTP (SOFTWARE_TOKEN_MFA) のみ許可。
+      // destructive 操作を扱う tenant admin console の baseline (OPTIONAL は不可)。
+      template.hasResourceProperties(
+        "AWS::Cognito::UserPool",
+        Match.objectLike({
+          MfaConfiguration: "ON",
+          EnabledMfas: ["SOFTWARE_TOKEN_MFA"],
+        }),
+      );
+    });
+
     it("UserPoolDomain prefix は TenkaCloud-{env}-{tenantId}-{accountId} を lowercase 化して使うべき", () => {
       const { template } = synth("Tenant-ABC", "https://example.cloudfront.net", "Development");
       template.hasResourceProperties("AWS::Cognito::UserPoolDomain", {

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -245,7 +245,9 @@ describe("getConsoleSigninUrl", () => {
     const second = stsSend.mock.calls[1]?.[0] as AssumeRoleCommand;
     expect(second.input).toMatchObject({
       RoleArn: "arn:aws:iam::999999999999:role/tc-security-battle-royale-alpha-participant-viewer",
-      RoleSessionName: `participant-viewer-${VALID_JOB_ID}`,
+      // Audit #8: session name に problemId を含める (= AWS Console 上部の federated user 表示で
+      // 問題名が判別できるようにする、 image #30 の改善)。 `${problemId}-${jobId}` 形式。
+      RoleSessionName: `security-battle-royale-${VALID_JOB_ID}`,
       ExternalId: VALID_JOB_ID,
       DurationSeconds: 3600,
     });


### PR DESCRIPTION
2 件を 1 PR で。

## audit #8: RoleSessionName が generic で問題判別不可
旧 SSO は最終 AssumeRole の RoleSessionName を \`participant-viewer-<jobId>\` にしていた。 AWS Console 上部の federated user 表示で問題名が見えず、 「どの問題に federate しているか」 が judgement 不能だった (image #30 の指摘)。

修正: RoleSessionName を \`\${problemId}-\${jobId}\` に。
- IAM RoleSessionName 制約 (2-64 chars, \`[\\\w+=,.@-]+\`) に収まる
- problemId は kebab-case slug なので allowed pattern 合致

## ADR-020 Phase E: tenant UserPool に MFA REQUIRED
旧: tenant Cognito UserPool は MFA 未設定 (= OPTIONAL でもない)。 destructive 操作を扱う admin console (= user 管理 / SAML / 削除 / IAM mutate) で MFA 無しは security baseline 違反。

修正: \`tenant-template/identity-provider.ts\` の UserPool に:
- \`mfa: REQUIRED\`
- TOTP-only (\`SOFTWARE_TOKEN_MFA\`)、 SMS 無効 (= 国際 SMS の到達不安定 + コスト + SIM swap risk)

既存 user は次回 sign-in 時に MFA_SETUP challenge を通る。 lock-out 救済は SystemAdmin の AdminResetUserPassword + 再招待。

control-plane 側 (= SBT 管理 UserPool) は SBT 側責務なので本 PR では触らない。

## 物理影響
- **\`infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts\`** — UPDATE: RoleSessionName format
- **\`infrastructure/lib/tenant-template/identity-provider.ts\`** — UPDATE: UserPool に MfaConfiguration=ON + EnabledMfas=[SOFTWARE_TOKEN_MFA]
- **\`infrastructure/test/problem-deploy/participant-sso.test.ts\`** — UPDATE: 新 session name format pin
- **\`infrastructure/test/identity-provider.test.ts\`** — UPDATE: MFA 設定 pin

## Regression 分析
- MFA REQUIRED で既存 user は **次回 sign-in 時に MFA 設定 step が挟まる** (= breaking UX change だが、 security 上必要)
- federation 経路 (SAML) は IdP 側で MFA を持つので Cognito 側 REQUIRED と二重にはなる (= 一般的に IdP 側 MFA を持っていれば Cognito 側は SUPPRESS される実装が多い、 動作確認は deploy 後)
- SystemAdmin lock-out 救済経路 (= AdminResetUserPassword) は変更なし

## Test plan
- [x] vitest 58 件 pass (= identity-provider + participant-sso)
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: tenant admin 招待 → 初回 sign-in で TOTP 登録要求 → 成功
- [ ] AWS Console で federated user 表示が \`<problemId>-<jobId>\` 形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enforced TOTP-based multi-factor authentication for tenant admin consoles.

* **Improvements**
  * Enhanced session identification in federated user display with problem-specific identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->