### PR TITLE
feat(#17): 既存 user の role 変更機能 (PATCH /admin/users/:username)

### DIFF
--- a/apps/application-admin-console/src/api/tenant-users-client.ts
+++ b/apps/application-admin-console/src/api/tenant-users-client.ts
@@ -48,3 +48,18 @@ export async function deleteTenantUser(api: ApiClient, username: string): Promis
   // username は email 形式が来るので URL-safe に encode する。
   await api.del(`admin/users/${encodeURIComponent(username)}`);
 }
+
+/**
+ * Issue #17: 既存 user の role を変更する。 backend が AdminUpdateUserAttributes で
+ * \`custom:userRole\` を書き換える。 self-target は 409 cannot_change_own_role。
+ */
+export async function changeTenantUserRole(
+  api: ApiClient,
+  username: string,
+  userRole: TenantRole,
+): Promise<{ username: string; userRole: TenantRole }> {
+  return api.patch<{ username: string; userRole: TenantRole }>(
+    `admin/users/${encodeURIComponent(username)}`,
+    { userRole },
+  );
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -131,7 +131,14 @@
     "delete_modal_body": "Deletes {email}. The user can no longer sign in. You cannot delete yourself (lock-out prevention).",
     "delete_confirm": "Delete",
     "delete_error_header": "Delete failed",
-    "delete_success": "Deleted {email}."
+    "delete_success": "Deleted {email}.",
+    "role_change_button": "Change role",
+    "role_change_aria": "Change role of {email}",
+    "role_change_modal_header": "Change role?",
+    "role_change_modal_body": "Change the role of {email} (current: {current}) to the value selected below. The change takes effect immediately; the user will be authorised under the new role at next sign-in. You cannot change your own role (lock-out prevention).",
+    "role_change_confirm": "Change role",
+    "role_change_error_header": "Role change failed",
+    "role_change_success": "Changed role of {email} to {role}."
   },
   "problems": {
     "header": "Problem catalog",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -131,7 +131,14 @@
     "delete_modal_body": "{email} を削除します。 削除した user は二度とログインできません。 lock-out 防止のため自分自身は削除できません。",
     "delete_confirm": "削除する",
     "delete_error_header": "削除に失敗しました",
-    "delete_success": "{email} を削除しました。"
+    "delete_success": "{email} を削除しました。",
+    "role_change_button": "ロール変更",
+    "role_change_aria": "{email} のロールを変更",
+    "role_change_modal_header": "ロールを変更しますか?",
+    "role_change_modal_body": "{email} (現在: {current}) のロールを下のドロップダウンで選択した値に変更します。 変更は即時反映され、 次回ログイン時から新ロールで認可されます。 lock-out 防止のため自分自身のロールは変更できません。",
+    "role_change_confirm": "ロールを変更する",
+    "role_change_error_header": "ロール変更に失敗しました",
+    "role_change_success": "{email} のロールを {role} に変更しました。"
   },
   "problems": {
     "header": "問題カタログ",

--- a/apps/application-admin-console/src/pages/AdminUsers.tsx
+++ b/apps/application-admin-console/src/pages/AdminUsers.tsx
@@ -13,6 +13,7 @@ import Table from "@cloudscape-design/components/table";
 import { useCallback, useEffect, useState } from "react";
 import { type ApiClient, useApiClient } from "../api/client";
 import {
+  changeTenantUserRole,
   deleteTenantUser,
   inviteTenantUser,
   listTenantUsers,
@@ -51,6 +52,11 @@ export function AdminUsersPage({ config }: { config: AppConfig }) {
   const [deleteTarget, setDeleteTarget] = useState<TenantUserSummary | null>(null);
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  // Issue #17: role 変更 modal state。 selected role は user の現在 role を初期値にする。
+  const [roleChangeTarget, setRoleChangeTarget] = useState<TenantUserSummary | null>(null);
+  const [roleChangeNew, setRoleChangeNew] = useState<TenantRole>("TenantAdmin");
+  const [roleChangeSubmitting, setRoleChangeSubmitting] = useState(false);
+  const [roleChangeError, setRoleChangeError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!apiClient) return;
@@ -108,6 +114,28 @@ export function AdminUsersPage({ config }: { config: AppConfig }) {
       setDeleteSubmitting(false);
     }
   }, [apiClient, deleteTarget, refresh, t]);
+
+  // Issue #17: role 変更 submit。 server 側 (= AdminUpdateUserAttributes) で実 attribute を書き換え。
+  const handleRoleChange = useCallback(async () => {
+    if (!apiClient || !roleChangeTarget) return;
+    setRoleChangeSubmitting(true);
+    setRoleChangeError(null);
+    try {
+      await changeTenantUserRole(apiClient as ApiClient, roleChangeTarget.username, roleChangeNew);
+      setSuccessMessage(
+        t("users.role_change_success", {
+          email: roleChangeTarget.email ?? roleChangeTarget.username,
+          role: roleChangeNew,
+        }),
+      );
+      setRoleChangeTarget(null);
+      await refresh();
+    } catch (err) {
+      setRoleChangeError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRoleChangeSubmitting(false);
+    }
+  }, [apiClient, roleChangeTarget, roleChangeNew, refresh, t]);
 
   return (
     <SpaceBetween size="l">
@@ -167,15 +195,30 @@ export function AdminUsersPage({ config }: { config: AppConfig }) {
               id: "actions",
               header: t("users.col_actions"),
               cell: (u) => (
-                <Button
-                  variant="link"
-                  onClick={() => setDeleteTarget(u)}
-                  ariaLabel={t("users.delete_aria", {
-                    email: u.email ?? u.username,
-                  })}
-                >
-                  {t("users.delete_button")}
-                </Button>
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button
+                    variant="link"
+                    onClick={() => {
+                      setRoleChangeTarget(u);
+                      // 初期値は現在 role (= 未設定なら Viewer に倒す)
+                      setRoleChangeNew((u.userRole as TenantRole | undefined) ?? "TenantViewer");
+                    }}
+                    ariaLabel={t("users.role_change_aria", {
+                      email: u.email ?? u.username,
+                    })}
+                  >
+                    {t("users.role_change_button")}
+                  </Button>
+                  <Button
+                    variant="link"
+                    onClick={() => setDeleteTarget(u)}
+                    ariaLabel={t("users.delete_aria", {
+                      email: u.email ?? u.username,
+                    })}
+                  >
+                    {t("users.delete_button")}
+                  </Button>
+                </SpaceBetween>
               ),
             },
           ]}
@@ -296,6 +339,72 @@ export function AdminUsersPage({ config }: { config: AppConfig }) {
           {deleteError && (
             <Alert type="error" header={t("users.delete_error_header")}>
               {deleteError}
+            </Alert>
+          )}
+        </SpaceBetween>
+      </Modal>
+
+      {/* Issue #17: role 変更 modal。 select で新 role を選び confirm で PATCH。 */}
+      <Modal
+        visible={roleChangeTarget !== null}
+        onDismiss={() => {
+          setRoleChangeTarget(null);
+          setRoleChangeError(null);
+        }}
+        header={t("users.role_change_modal_header")}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                variant="link"
+                onClick={() => {
+                  setRoleChangeTarget(null);
+                  setRoleChangeError(null);
+                }}
+              >
+                {t("users.modal_cancel")}
+              </Button>
+              <Button
+                variant="primary"
+                loading={roleChangeSubmitting}
+                onClick={() => void handleRoleChange()}
+                disabled={roleChangeTarget?.userRole === roleChangeNew}
+              >
+                {t("users.role_change_confirm")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          <Box>
+            {t("users.role_change_modal_body", {
+              email: roleChangeTarget?.email ?? roleChangeTarget?.username ?? "",
+              current: roleChangeTarget?.userRole ?? "—",
+            })}
+          </Box>
+          <FormField label={t("users.field_role")} description={t("users.field_role_desc")}>
+            <Select
+              selectedOption={{
+                value: roleChangeNew,
+                label: t(`users.role_${roleChangeNew.replace("Tenant", "tenant_").toLowerCase()}`),
+              }}
+              onChange={(e) => {
+                if (e.detail.selectedOption.value)
+                  setRoleChangeNew(e.detail.selectedOption.value as TenantRole);
+              }}
+              options={TENANT_ROLE_OPTIONS.map((role) => ({
+                value: role,
+                label: t(`users.role_${role.replace("Tenant", "tenant_").toLowerCase()}`),
+                description: t(
+                  `users.role_${role.replace("Tenant", "tenant_").toLowerCase()}_desc`,
+                ),
+              }))}
+            />
+          </FormField>
+          {roleChangeError && (
+            <Alert type="error" header={t("users.role_change_error_header")}>
+              {roleChangeError}
             </Alert>
           )}
         </SpaceBetween>

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -151,6 +151,8 @@ export class CompetitorAccountsApiLambda extends Construct {
           "cognito-idp:AdminCreateUser",
           "cognito-idp:AdminDeleteUser",
           "cognito-idp:AdminGetUser",
+          // Issue #17: AdminUpdateUserAttributes で custom:userRole を書き換える経路。
+          "cognito-idp:AdminUpdateUserAttributes",
           "cognito-idp:ListUsers",
         ],
         resources: [`arn:aws:cognito-idp:${stack.region}:${stack.account}:userpool/*`],

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -25,7 +25,9 @@ import {
 import { CreateCompetitorAccountRequestSchema } from "./types.js";
 import { DuplicateUserError, TenantMismatchError, UserNotFoundError } from "./users-cognito.js";
 import {
+  ChangeRoleRequestSchema,
   InviteUserRequestSchema,
+  routeChangeUserRole,
   routeCreateUser,
   routeDeleteUser,
   routeListUsers,
@@ -344,6 +346,47 @@ app.delete("/admin/users/:username", async (c) => {
     }
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[competitor-accounts] user delete failed", { username, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// Issue #17: 既存 user の custom:userRole を変更する PATCH。 越境チェック + 自己変更禁止。
+app.patch("/admin/users/:username", async (c) => {
+  const username = c.req.param("username");
+  if (!username || username.length === 0) {
+    return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
+  }
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = ChangeRoleRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  const tenantId = resolveTenantId(c);
+  try {
+    const result = await routeChangeUserRole({ shared }, c, tenantId, username, parsed.data);
+    return c.json(result.body as never, result.status as 200 | 401 | 409);
+  } catch (err) {
+    if (err instanceof UserNotFoundError) {
+      return c.json({ error: "not_found", username: err.username }, StatusCodes.NOT_FOUND);
+    }
+    if (err instanceof TenantMismatchError) {
+      console.warn("[competitor-accounts] tenant mismatch on role change", {
+        username,
+        expected: err.expectedTenantId,
+        actual: err.actualTenantId,
+      });
+      return c.json({ error: "not_found", username }, StatusCodes.NOT_FOUND);
+    }
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[competitor-accounts] user role change failed", { username, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito.ts
@@ -2,6 +2,7 @@ import {
   AdminCreateUserCommand,
   AdminDeleteUserCommand,
   AdminGetUserCommand,
+  AdminUpdateUserAttributesCommand,
   type CognitoIdentityProviderClient,
   DeliveryMediumType,
   ListUsersCommand,
@@ -174,6 +175,31 @@ export async function deleteUser(deps: CognitoUserClientDeps, username: string):
       new AdminDeleteUserCommand({
         UserPoolId: deps.userPoolId,
         Username: username,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new UserNotFoundError(username);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Issue #17 (user role change): 既存 user の \`custom:userRole\` を書き換える。 caller は事前に
+ * \`assertUserBelongsToTenant\` で tenant 越境を防ぐこと。 不在なら \`UserNotFoundError\`。
+ */
+export async function updateUserRole(
+  deps: CognitoUserClientDeps,
+  username: string,
+  newRole: string,
+): Promise<void> {
+  try {
+    await deps.client.send(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+        UserAttributes: [{ Name: "custom:userRole", Value: newRole }],
       }),
     );
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/users-routes.ts
@@ -10,6 +10,7 @@ import {
   createUser,
   deleteUser,
   listUsersByTenant,
+  updateUserRole,
 } from "./users-cognito.js";
 
 /**
@@ -40,6 +41,15 @@ export const InviteUserRequestSchema = z.object({
   email: z.string().email(),
   userRole: z.enum(TENANT_ROLES).default("TenantAdmin"),
 });
+
+/**
+ * Issue #17 (user role change): 既存 user の role を変更する PATCH request の schema。
+ * 招待と同じく Zod enum で 3 role に絞り、 任意文字列の inject を防ぐ。
+ */
+export const ChangeRoleRequestSchema = z.object({
+  userRole: z.enum(TENANT_ROLES),
+});
+export type ChangeRoleRequest = z.infer<typeof ChangeRoleRequestSchema>;
 export type InviteUserRequest = z.infer<typeof InviteUserRequestSchema>;
 
 function extractSelfPoolFromContext(
@@ -107,6 +117,41 @@ export async function routeCreateUser(
     tenantTier,
   });
   return { status: 201, body: summary };
+}
+
+/**
+ * Issue #17: 既存 user の role を変更する PATCH。 越境チェック (AdminGetUser) → AdminUpdateUserAttributes。
+ * 自分自身の role 変更は **403 cannot_change_own_role** で reject (= 誤って Viewer 等に
+ * downgrade して lock-out するのを防ぐ)。
+ */
+export async function routeChangeUserRole(
+  deps: UsersRouteDeps,
+  c: Context,
+  tenantId: string,
+  username: string,
+  request: ChangeRoleRequest,
+): Promise<UsersRouteResult> {
+  const pool = extractSelfPoolFromContext(c, deps.shared);
+  if (!pool) {
+    return {
+      status: 401,
+      body: { error: "user_pool_unresolved", message: "JWT iss から UserPool を抽出できません" },
+    };
+  }
+  const claims = extractClaims(c);
+  const callerUsername = claims?.["cognito:username"];
+  if (typeof callerUsername === "string" && callerUsername === username) {
+    return {
+      status: 409,
+      body: {
+        error: "cannot_change_own_role",
+        message: "lock-out 防止のため自分自身の role は変更できません",
+      },
+    };
+  }
+  await assertUserBelongsToTenant(pool, username, tenantId);
+  await updateUserRole(pool, username, request.userRole);
+  return { status: 200, body: { username, userRole: request.userRole } };
 }
 
 export async function routeDeleteUser(

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -183,12 +183,12 @@ export class ApiGateway extends Construct {
     // 同 Lambda (competitor-accounts) に相乗りさせ、 Cognito AdminCreate / AdminDelete / ListUsers
     // 権限は Lambda 側で付与済。
     //   /admin/users                 GET=list / POST=invite
-    //   /admin/users/{username}      DELETE=remove (tenant 越境 + self-delete 防止 server 側で)
+    //   /admin/users/{username}      DELETE=remove / PATCH=change role (Issue #17)
     const users = admin.addResource("users");
     users.addMethod("GET", competitorAccountsIntegration, deployMethodOptions);
     users.addMethod("POST", competitorAccountsIntegration, deployMethodOptions);
-    users
-      .addResource("{username}")
-      .addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
+    const usersById = users.addResource("{username}");
+    usersById.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
+    usersById.addMethod("PATCH", competitorAccountsIntegration, deployMethodOptions);
   }
 }

--- a/infrastructure/test/problem-deploy/tenant-users.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-users.test.ts
@@ -2,6 +2,7 @@ import {
   AdminCreateUserCommand,
   AdminDeleteUserCommand,
   AdminGetUserCommand,
+  AdminUpdateUserAttributesCommand,
   ListUsersCommand,
   UserNotFoundException,
   UsernameExistsException,
@@ -19,8 +20,12 @@ import {
   listUsersByTenant,
   TenantMismatchError,
   UserNotFoundError,
+  updateUserRole,
 } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-cognito";
-import { InviteUserRequestSchema } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes";
+import {
+  ChangeRoleRequestSchema,
+  InviteUserRequestSchema,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes";
 
 /**
  * Issue #925 Phase 1: Tenant user CRUD wrapper の単体テスト。 Cognito SDK は \`vi.fn\` でモック
@@ -275,6 +280,50 @@ describe("assertUserBelongsToTenant (越境チェック)", () => {
     );
     await expect(
       assertUserBelongsToTenant(mock as CognitoUserClientDeps, "ghost@example.com", "tenant-acme"),
+    ).rejects.toBeInstanceOf(UserNotFoundError);
+  });
+});
+
+/* ---- Issue #17 (user role change) ---- */
+
+describe("ChangeRoleRequestSchema (Issue #17)", () => {
+  it("3 role を全て受け入れるべき", () => {
+    for (const role of ["TenantAdmin", "TenantOperator", "TenantViewer"] as const) {
+      expect(ChangeRoleRequestSchema.safeParse({ userRole: role }).success).toBe(true);
+    }
+  });
+
+  it("未定義 role (= Auditor / SystemAdmin / 自由文字列) は reject", () => {
+    expect(ChangeRoleRequestSchema.safeParse({ userRole: "Auditor" }).success).toBe(false);
+    expect(ChangeRoleRequestSchema.safeParse({ userRole: "SystemAdmin" }).success).toBe(false);
+    expect(ChangeRoleRequestSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("updateUserRole (Issue #17)", () => {
+  let mock: MockCognito;
+  beforeEach(() => {
+    mock = mockClient();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("AdminUpdateUserAttributes に custom:userRole を渡すべき", async () => {
+    mock.client.send.mockResolvedValueOnce({});
+    await updateUserRole(mock as CognitoUserClientDeps, "alice@example.com", "TenantOperator");
+    const cmd = mock.client.send.mock.calls[0]?.[0] as AdminUpdateUserAttributesCommand;
+    expect(cmd).toBeInstanceOf(AdminUpdateUserAttributesCommand);
+    expect(cmd.input.Username).toBe("alice@example.com");
+    expect(cmd.input.UserAttributes).toEqual([
+      { Name: "custom:userRole", Value: "TenantOperator" },
+    ]);
+  });
+
+  it("UserNotFoundException は UserNotFoundError に正規化すべき", async () => {
+    mock.client.send.mockRejectedValueOnce(
+      new UserNotFoundException({ message: "User does not exist", $metadata: {} }),
+    );
+    await expect(
+      updateUserRole(mock as CognitoUserClientDeps, "ghost@example.com", "TenantAdmin"),
     ).rejects.toBeInstanceOf(UserNotFoundError);
   });
 });


### PR DESCRIPTION
audit follow: User management 画面で role を 変更 する 経路 が無く、 招待時のミスを直せなかった (= image #43 で uiuiui.dvd@gmail.com を Viewer で招待した後、 Admin に昇格させる UI が無い)。

PATCH /admin/users/{username} を実装し、 「ロール変更」 button → 確認 modal + Select dropdown で実 attribute 書き換えできるようにする。

## 実装
1. **users-cognito.ts** \`updateUserRole\` (= AdminUpdateUserAttributes で \`custom:userRole\` 書き換え、 UserNotFoundError 正規化)
2. **users-routes.ts** \`routeChangeUserRole\`: tenant 越境チェック (= AdminGetUser) + self-change reject (= \`cannot_change_own_role\` 409) → \`updateUserRole\`
3. **ChangeRoleRequestSchema**: Zod enum で 3 role に絞る (= 任意文字列 inject 防御)
4. **index.ts** PATCH route。 越境試行は 404 隠蔽、 self-change は 409
5. **IAM**: \`cognito-idp:AdminUpdateUserAttributes\` を Lambda role に追加 (userpool/* scope)
6. **API Gateway**: \`/admin/users/{username}\` に PATCH method 追加
7. **frontend** \`changeTenantUserRole\` API client + AdminUsers の 「ロール変更」 link button + Select dropdown + 確認 modal
8. i18n ja/en に \`role_change_*\` 7 keys

## 物理影響
- Lambda IAM: 1 action 追加 (= AdminUpdateUserAttributes、 既存 cognito-idp policy block に追加)
- API Gateway: PATCH method 追加 (CFn UPDATE)
- Lambda artifact: 更新 (competitor-accounts handler)
- frontend bundle: AdminUsers.tsx 拡張

## Regression 分析
- 既存 invite / delete 経路は変更なし、 新 button が増えるだけ
- self-change 409 は server gate (= UI bypass されても reject)
- 越境試行は 404 隠蔽 (= attacker probe 防御、 delete と同じパターン)
- IAM 追加は ALLOW のみで既存権限を狭めない

## Test plan
- [x] vitest 20 件 pass (= ChangeRoleRequestSchema + updateUserRole 4 case 追加)
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: /settings/users → ロール変更 → modal で別 role 選択 → 一覧で更新確認
- [ ] 自分自身を選ぶと 409 cannot_change_own_role が出る
- [ ] 他 tenant の username を curl PATCH すると 404 not_found が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)