### PR TITLE
fix: logout で 'redirect_uri is not present' 失敗を解消

### DIFF
--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -269,11 +269,21 @@ export class IdentityProvider extends Construct {
             "http://localhost:5174/callback",
           ),
         ],
+        // frontend beginLogout は `logout_uri=<origin>/login` で /logout に redirect する
+        // (application-admin-console/src/auth/cognito.ts)。 Cognito は logout_uri が
+        // UserPoolClient の logoutUrls に登録されていないと `Required String parameter
+        // 'redirect_uri' is not present` で fail するので、 \`/login\` も含めて allow する。
+        // \`/\` は legacy 経路 (= 旧 frontend が `<origin>/` に飛ばしていた時の互換) として残す。
         logoutUrls: [
           ...buildAllowedRedirectUrls(
             `${props.applicationAdminConsoleUrl}/`,
             props.environment,
             "http://localhost:5174/",
+          ),
+          ...buildAllowedRedirectUrls(
+            `${props.applicationAdminConsoleUrl}/login`,
+            props.environment,
+            "http://localhost:5174/login",
           ),
         ],
       },

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -93,6 +93,19 @@ describe("IdentityProvider", () => {
       );
     });
 
+    it("UserPoolClient の logoutUrls に /login も含むべき (= beginLogout の logout_uri と一致)", () => {
+      const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
+      template.hasResourceProperties(
+        "AWS::Cognito::UserPoolClient",
+        Match.objectLike({
+          LogoutURLs: Match.arrayWith([
+            "https://d123abc.cloudfront.net/login",
+            "http://localhost:5174/login",
+          ]),
+        }),
+      );
+    });
+
     it("cognitoDomainUrl を property として公開すべき (https://{prefix}.auth.{region}.amazoncognito.com 形式)", () => {
       const { provider } = synth("tenant-1", "https://example.cloudfront.net");
       expect(provider.cognitoDomainUrl).toBe(
@@ -425,6 +438,7 @@ describe("OAuth flow hardening (Issue #861)", () => {
     const template = synthFor("production");
     const clients = template.findResources("AWS::Cognito::UserPoolClient");
     const logouts = (Object.values(clients)[0]?.Properties?.LogoutURLs ?? []) as string[];
-    expect(logouts).toEqual(["https://app.example.com/"]);
+    // \`/login\` も Cognito の logout_uri 一致用に追加されている (= production でも localhost 無し)。
+    expect(logouts).toEqual(["https://app.example.com/", "https://app.example.com/login"]);
   });
 });


### PR DESCRIPTION
application-admin-console の sign-out → Cognito Hosted UI \`/logout\` が image #49 のエラーで失敗していた:

\`\`\`
Required String parameter 'redirect_uri' is not present
\`\`\`

## Root cause
frontend (\`beginLogout\` in \`apps/application-admin-console/src/auth/cognito.ts\`) は \`/logout?client_id=X&logout_uri=<origin>/login\` で redirect していたが、 CDK \`UserPoolClient.logoutUrls\` には \`<origin>/\` (= 末尾スラッシュのみ) しか登録されていなかった。

Cognito は logout_uri が allow list に無いと \`redirect_uri\` parameter も探しに行く別経路に倒れ、 どちらも無いとこのエラーを返す。

## Fix
\`logoutUrls\` に \`<origin>/login\` (production / dev) と \`http://localhost:5174/login\` (dev) を追加。 既存 \`<origin>/\` は legacy 経路として残す (= 旧 frontend が \`/\` に飛ばしていた時の互換)。

## 物理影響
- UserPoolClient の \`LogoutURLs\` property が 2 entries 増える (= CFn UPDATE、 in-place)
- frontend / Lambda / IAM 変更なし

## Regression 分析
- 既存 \`<origin>/\` 経路は維持
- production env でも localhost は含めない (= Issue #861 ポリシー保持)
- 既存テスト 1 件を新 expectation に更新

## Test plan
- [x] vitest 35 件 pass
- [x] \`make harness\` / \`make before-commit\`
- [ ] deploy 後: tenant admin console から sign-out → /login に redirect、 エラー banner が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logout flow to properly redirect users to the login page after signing out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->