### PR TITLE
feat(#952): AWS Budgets で月次コスト爆発を 80% / 100% で alarm

### DIFF
--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -30,6 +30,13 @@ import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite";
 const app = new cdk.App();
 const config = resolveAppConfig({ env: process.env, binDir: __dirname });
 
+// Issue #952 / PR-957: cost allocation tag を App scope で全リソースに付与する。
+// SaaS mode (wire.ts) と同じ規則。 AWS Billing console で `Project` を Cost
+// Allocation Tag として activate すれば Budget / Cost Explorer で TenkaCloud
+// 分だけを抽出できる。
+cdk.Tags.of(app).add("Project", "TenkaCloud");
+cdk.Tags.of(app).add("Environment", config.environment);
+
 cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(config.kmsPendingWindowInDays));
 cdk.Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
 

--- a/infrastructure/environments/development/config.json
+++ b/infrastructure/environments/development/config.json
@@ -36,5 +36,6 @@
   },
   "kmsConfig": {
     "pendingWindowInDays": "${KMS_PENDING_WINDOW_DAYS:-7}"
-  }
+  },
+  "monthlyCostLimitUsd": "${MONTHLY_COST_LIMIT_USD:-50}"
 }

--- a/infrastructure/environments/production/config.json
+++ b/infrastructure/environments/production/config.json
@@ -24,5 +24,6 @@
   },
   "kmsConfig": {
     "pendingWindowInDays": "${KMS_PENDING_WINDOW_DAYS:-7}"
-  }
+  },
+  "monthlyCostLimitUsd": "${MONTHLY_COST_LIMIT_USD:-200}"
 }

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -197,9 +197,16 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
   const controlPlaneSamlConfig = config?.controlPlaneConfig?.samlIdp;
 
   // Issue #952 epic / cost guardrails
+  // schema (config-schema.json) は integer / 数値文字列 ("50") の双方を許容するため、
+  // ここでも `${MONTHLY_COST_LIMIT_USD:-50}` 経由で来た文字列を Number で正規化する。
+  const rawMonthlyCostLimit = config?.monthlyCostLimitUsd;
+  const parsedMonthlyCostLimit =
+    rawMonthlyCostLimit !== undefined && rawMonthlyCostLimit !== null
+      ? Number(rawMonthlyCostLimit)
+      : Number.NaN;
   const monthlyCostLimitUsd =
-    typeof config?.monthlyCostLimitUsd === "number" && config.monthlyCostLimitUsd > 0
-      ? config.monthlyCostLimitUsd
+    Number.isFinite(parsedMonthlyCostLimit) && parsedMonthlyCostLimit > 0
+      ? parsedMonthlyCostLimit
       : undefined;
   const budgetAlarmEmails =
     Array.isArray(config?.budgetAlarmEmails) && config.budgetAlarmEmails.length > 0

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -196,6 +196,16 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
   const tenantSamlConfig = config?.tenantSamlConfig;
   const controlPlaneSamlConfig = config?.controlPlaneConfig?.samlIdp;
 
+  // Issue #952 epic / cost guardrails
+  const monthlyCostLimitUsd =
+    typeof config?.monthlyCostLimitUsd === "number" && config.monthlyCostLimitUsd > 0
+      ? config.monthlyCostLimitUsd
+      : undefined;
+  const budgetAlarmEmails =
+    Array.isArray(config?.budgetAlarmEmails) && config.budgetAlarmEmails.length > 0
+      ? config.budgetAlarmEmails
+      : undefined;
+
   return {
     environment,
     isProductionLike,
@@ -234,6 +244,8 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     adminConsoleHostingInputs,
     tenantSamlConfig,
     controlPlaneSamlConfig,
+    monthlyCostLimitUsd,
+    budgetAlarmEmails,
   };
 }
 

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -99,6 +99,14 @@ export interface AppConfig {
    * hatch で IdP を付ける。
    */
   readonly controlPlaneSamlConfig: SamlIdpConfig | undefined;
+
+  /**
+   * Issue #952 epic / cost guardrails: AWS Budgets monthly limit (USD)。 未指定 / 0 なら
+   * budget を立てない (= 旧挙動互換)。 development: 50, production: 200 を推奨。
+   */
+  readonly monthlyCostLimitUsd: number | undefined;
+  /** Budget alarm 通知の追加 email 宛先 (systemAdminEmail は自動同梱)。 */
+  readonly budgetAlarmEmails: readonly string[] | undefined;
 }
 
 export interface ProblemsCatalogBundle {

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -26,6 +26,16 @@ import { TenantTemplateStack } from "../tenant-template/tenant-template-stack";
  * を発生させない) ことを invariant とする。
  */
 export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudAppHandles {
+  // Issue #952 / PR-957 user feedback: cost allocation tag を App scope で全リソースに
+  // 強制付与する。 名前 prefix 識別ではなく tag で resource ownership を表明することで:
+  //   - 同一 AWS account 内に他 workload があっても混ざらない (= cost / drift / cleanup 識別)
+  //   - AWS Budgets / Cost Explorer の `TagKeyValue` filter (= `user:Project$TenkaCloud`) で
+  //     TenkaCloud 分だけを抽出して予算管理できる
+  //   - user は AWS Billing console で 1 回 "Project" tag を "Cost Allocation Tag" として
+  //     activate する必要がある (= 既存リソースへの遡及反映には最大 24h)
+  cdk.Tags.of(app).add("Project", "TenkaCloud");
+  cdk.Tags.of(app).add("Environment", config.environment);
+
   // App scope Aspect: KMS Key 削除待機期間を `config.kmsPendingWindowInDays` に揃える。
   // SBT が内部生成する CodeBuild EncryptionKey 等も含む全 `AWS::KMS::Key` が対象。
   cdk.Aspects.of(app).add(new KmsKeyShortPendingWindow(config.kmsPendingWindowInDays));
@@ -230,6 +240,9 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       budgetNamePrefix: `tenkacloud-${config.environment}`,
       monthlyLimitUsd: config.monthlyCostLimitUsd,
       notificationEmails: allEmails,
+      // App scope の cdk.Tags.of(app).add("Project", "TenkaCloud") と整合させ、
+      // TenkaCloud で deploy したリソース分だけを集計対象にする。
+      costAllocationTags: { Project: ["TenkaCloud"] },
     });
   }
 

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -9,6 +9,7 @@ import { DynamoDbLowCapacity } from "../cdk-aspect/dynamodb-low-capacity";
 import { KmsKeyShortPendingWindow } from "../cdk-aspect/kms-key-short-pending-window";
 import { ControlPlaneStack } from "../control-plane-stack";
 import { ObservabilityStack } from "../observability/cloudwatch-dashboard-stack";
+import { CostBudget } from "../observability/cost-budget";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting";
 import { ProblemDeployBackendStack } from "../problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../tenant-pipeline/serverless-saas-pipeline";
@@ -217,6 +218,19 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
   observabilityStack.addDependency(bootstrapTemplateStack);
   observabilityStack.addDependency(tenantTemplateStack);
   observabilityStack.addDependency(serverlessSaaSPipeline);
+
+  // Issue #952 epic / cost guardrails: 月次 AWS Budget を立てる。 limit / alarm 通知先は config から。
+  // limit が 0 / 未指定なら budget は立てない (= legacy 互換)。
+  if (config.monthlyCostLimitUsd && config.monthlyCostLimitUsd > 0) {
+    const adminEmail = config.systemAdminEmail;
+    const extraEmails = config.budgetAlarmEmails ?? [];
+    const allEmails = adminEmail ? [adminEmail, ...extraEmails] : extraEmails;
+    new CostBudget(observabilityStack, "CostBudget", {
+      budgetNamePrefix: `tenkacloud-${config.environment}`,
+      monthlyLimitUsd: config.monthlyCostLimitUsd,
+      notificationEmails: allEmails,
+    });
+  }
 
   let adminConsoleHosting: AdminConsoleHostingStack | undefined;
   if (config.adminConsoleHostingInputs) {

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -224,7 +224,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
   if (config.monthlyCostLimitUsd && config.monthlyCostLimitUsd > 0) {
     const adminEmail = config.systemAdminEmail;
     const extraEmails = config.budgetAlarmEmails ?? [];
-    const allEmails = adminEmail ? [adminEmail, ...extraEmails] : extraEmails;
+    // adminEmail と extraEmails の重複を排して同一宛先への重複 subscription を防ぐ。
+    const allEmails = Array.from(new Set(adminEmail ? [adminEmail, ...extraEmails] : extraEmails));
     new CostBudget(observabilityStack, "CostBudget", {
       budgetNamePrefix: `tenkacloud-${config.environment}`,
       monthlyLimitUsd: config.monthlyCostLimitUsd,

--- a/infrastructure/lib/config/config-interface.ts
+++ b/infrastructure/lib/config/config-interface.ts
@@ -18,6 +18,17 @@ export interface Config {
    * + Hosted UI fallback。 per-tenant の独立 IdP は Phase 2 で onboarding 経由で扱う。
    */
   readonly tenantSamlConfig?: SamlIdpConfig;
+  /**
+   * Issue #952 epic / cost guardrails: AWS Budgets の monthly limit (USD)。
+   * 未指定 / 0 なら budget は立てない (= 旧挙動互換)。 development 50 / production 200 を
+   * config.json で指定するのを推奨。
+   */
+  readonly monthlyCostLimitUsd?: number;
+  /**
+   * Budget alarm 通知の追加 email 宛先。 systemAdminEmail は自動で含めるので、 追加 cc / oncall
+   * を渡すときに使う。
+   */
+  readonly budgetAlarmEmails?: readonly string[];
 }
 
 /**

--- a/infrastructure/lib/config/config-schema.json
+++ b/infrastructure/lib/config/config-schema.json
@@ -114,6 +114,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "kmsConfig": {
+      "type": "object",
+      "properties": {
+        "pendingWindowInDays": {
+          "anyOf": [
+            { "type": "integer", "minimum": 7, "maximum": 30 },
+            { "type": "string", "pattern": "^([7-9]|[12][0-9]|30)$" }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "monthlyCostLimitUsd": {
+      "anyOf": [{ "type": "integer", "minimum": 0 }, { "type": "string", "pattern": "^[0-9]+$" }]
+    },
+    "budgetAlarmEmails": {
+      "type": "array",
+      "items": { "type": "string", "format": "email" }
     }
   },
   "additionalProperties": false

--- a/infrastructure/lib/observability/cost-budget.ts
+++ b/infrastructure/lib/observability/cost-budget.ts
@@ -35,6 +35,15 @@ export interface CostBudgetProps {
    * 通知 threshold (%)。 default は [80, 100]。
    */
   readonly thresholdPercents?: readonly number[];
+  /**
+   * Cost allocation tag filter (= Budget が拾う tag key/value)。
+   * 例: \`{ Project: ["TenkaCloud"] }\` で App scope tag `Project=TenkaCloud` の付いたリソース
+   * だけを集計対象にする。 user は AWS Billing console で 「Project」 を Cost Allocation Tag
+   * として activate する必要がある (= 既存リソースへの遡及反映は最大 24h、 未 activate でも
+   * Budget 自体は壊れないが filter が効かず全アカウント費用が対象になる)。
+   * 未指定 (default) なら filter なし (= 全アカウント費用)。
+   */
+  readonly costAllocationTags?: Readonly<Record<string, readonly string[]>>;
 }
 
 /**
@@ -65,6 +74,17 @@ export class CostBudget extends Construct {
       // BudgetActions の SNS topic policy は AWS Budgets が自動で付ける (= 明示的 grant 不要)。
     ];
 
+    // Cost allocation tag filter を CfnBudget の costFilters に変換する。
+    //   - AWS Budgets は user-defined tag を `user:<Key>$<Value>` 形式の key で参照する
+    //   - 同一 key に複数 value (e.g. multiple Project values) を持たせるなら配列で羅列
+    //   - 未指定なら全リソースを集計 (= 既存挙動と互換、 ただし wire.ts default で
+    //     `Project=TenkaCloud` を渡す前提)
+    const tagFilters: Record<string, readonly string[]> = {};
+    for (const [tagKey, values] of Object.entries(props.costAllocationTags ?? {})) {
+      const filterKey = `user:${tagKey}`;
+      tagFilters[filterKey] = values.map((v) => `${tagKey}$${v}`);
+    }
+
     this.budget = new aws_budgets.CfnBudget(this, "MonthlyCostBudget", {
       budget: {
         budgetName: `${props.budgetNamePrefix}-monthly-cost`,
@@ -88,6 +108,8 @@ export class CostBudget extends Construct {
           useAmortized: false,
           useBlended: false,
         },
+        // Cost allocation tag を渡されたときだけ filter を入れる (= 未指定なら全アカウント費用)。
+        ...(Object.keys(tagFilters).length > 0 ? { costFilters: tagFilters } : {}),
       },
       notificationsWithSubscribers: thresholds.map((threshold) => ({
         notification: {

--- a/infrastructure/lib/observability/cost-budget.ts
+++ b/infrastructure/lib/observability/cost-budget.ts
@@ -1,0 +1,106 @@
+import { aws_budgets, aws_sns, aws_sns_subscriptions, Stack } from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+/**
+ * Issue #952 epic / cost guardrails: AWS Budgets で 月次コストの天井を設定し、 alarm
+ * threshold (80% / 100%) で SNS topic → email 通知する。 production / development の
+ * default を分けて、 user は config.json で override 可能。
+ *
+ * 目的:
+ *   - dev 環境で 検証用 deploy が放置されコスト爆発するのを早期検知する (= 80% で 1 回、
+ *     100% で 2 回目の通知)
+ *   - production で sudden spike (= 攻撃 / 設定ミス / runaway loop) に気付く
+ *   - AWS Free Tier 内で運用する前提を破った瞬間を operator に伝える
+ *
+ * AWS Budgets 自体は **コストゼロ** (= 月 2 件まで free、 SNS 通知も 1,000 通までは無料)。
+ * 設定するだけで作る価値あり。 阻止は出来ないが 「気付ける」 で十分な早期防御。
+ */
+
+export interface CostBudgetProps {
+  /**
+   * Budget の表示名 prefix。 default は \`tenkacloud-<env>\`。
+   * Budget Name は account 内 unique なので env 別に分ける。
+   */
+  readonly budgetNamePrefix: string;
+  /**
+   * monthly limit (USD)。 production: 200、 development: 50 を default 想定。 config.json で override。
+   */
+  readonly monthlyLimitUsd: number;
+  /**
+   * 通知先 email。 SNS topic を作って subscribe する。
+   * 未指定なら topic だけ作って subscription は別途 operator が AWS Console から追加する想定。
+   */
+  readonly notificationEmails?: readonly string[];
+  /**
+   * 通知 threshold (%)。 default は [80, 100]。
+   */
+  readonly thresholdPercents?: readonly number[];
+}
+
+/**
+ * AWS Budgets + SNS topic を立てる Construct。 stack を跨いで参照不要なので observability
+ * stack 配下に置く。 IAM は AWS Budgets が SNS publish を自動で持つので追加 grant 不要。
+ */
+export class CostBudget extends Construct {
+  public readonly topic: aws_sns.Topic;
+  public readonly budget: aws_budgets.CfnBudget;
+
+  constructor(scope: Construct, id: string, props: CostBudgetProps) {
+    super(scope, id);
+
+    const stack = Stack.of(this);
+    const thresholds = props.thresholdPercents ?? [80, 100];
+
+    this.topic = new aws_sns.Topic(this, "BudgetAlarmTopic", {
+      displayName: `${props.budgetNamePrefix} cost budget alarm`,
+    });
+    for (const email of props.notificationEmails ?? []) {
+      this.topic.addSubscription(new aws_sns_subscriptions.EmailSubscription(email));
+    }
+
+    const subscribers: aws_budgets.CfnBudget.SubscriberProperty[] = [
+      // SNS subscriber (= 通知本体)。 email は SNS subscription 側で配信。
+      { subscriptionType: "SNS", address: this.topic.topicArn },
+      // BudgetActions の SNS topic policy は AWS Budgets が自動で付ける (= 明示的 grant 不要)。
+    ];
+
+    this.budget = new aws_budgets.CfnBudget(this, "MonthlyCostBudget", {
+      budget: {
+        budgetName: `${props.budgetNamePrefix}-monthly-cost`,
+        budgetType: "COST",
+        timeUnit: "MONTHLY",
+        budgetLimit: {
+          amount: props.monthlyLimitUsd,
+          unit: "USD",
+        },
+        costTypes: {
+          // Free Tier 控除を含めた **実 課金額** で評価する (= 操作実感に近い)。
+          includeCredit: false,
+          includeDiscount: true,
+          includeOtherSubscription: true,
+          includeRecurring: true,
+          includeRefund: false,
+          includeSubscription: true,
+          includeSupport: false,
+          includeTax: true,
+          includeUpfront: false,
+          useAmortized: false,
+          useBlended: false,
+        },
+      },
+      notificationsWithSubscribers: thresholds.map((threshold) => ({
+        notification: {
+          notificationType: "ACTUAL",
+          comparisonOperator: "GREATER_THAN",
+          threshold,
+          thresholdType: "PERCENTAGE",
+        },
+        subscribers,
+      })),
+    });
+
+    // CfnBudget は account-scoped (= region 不問) だが、 SNS topic は region 限定。
+    // budget が複数 region に分散しないよう Stack.of(this).region 配下で 1 つだけ作る運用。
+    void stack;
+  }
+}

--- a/infrastructure/lib/observability/cost-budget.ts
+++ b/infrastructure/lib/observability/cost-budget.ts
@@ -54,7 +54,8 @@ export class CostBudget extends Construct {
     this.topic = new aws_sns.Topic(this, "BudgetAlarmTopic", {
       displayName: `${props.budgetNamePrefix} cost budget alarm`,
     });
-    for (const email of props.notificationEmails ?? []) {
+    // 重複 email で同じ宛先に 2 重 subscription を作らないように Set で一意化する。
+    for (const email of new Set(props.notificationEmails ?? [])) {
       this.topic.addSubscription(new aws_sns_subscriptions.EmailSubscription(email));
     }
 

--- a/infrastructure/test/app-config/resolve.test.ts
+++ b/infrastructure/test/app-config/resolve.test.ts
@@ -257,6 +257,22 @@ describe("resolveAppConfig", () => {
     expect(env.CDK_PARAM_IDP_NAME).toBe("COGNITO");
     expect(env.CDK_PARAM_SYSTEM_ADMIN_ROLE_NAME).toBe("SystemAdmin");
   });
+
+  // Issue #952 / PR-957 CodeRabbit follow-up: schema は `monthlyCostLimitUsd` に数値文字列を
+  // 許容する (`${MONTHLY_COST_LIMIT_USD:-50}` で `"50"` が JSON に入る) ため、 resolve は
+  // string を Number として扱う必要がある。 env override は process.env 直読みのため本
+  // test では config.json default (= "50") が正しく Number 化されることだけを pin する。
+  it("monthlyCostLimitUsd は config.json の string '50' を number 50 に正規化するべき", () => {
+    const cfg = resolveAppConfig({
+      env: baseEnv(),
+      binDir: BIN_DIR,
+      fs: fsAlwaysMissing,
+      dotenvConfig: noopDotenv,
+      discoverProblems: stubProblems,
+    });
+    expect(cfg.monthlyCostLimitUsd).toBe(50);
+    expect(typeof cfg.monthlyCostLimitUsd).toBe("number");
+  });
 });
 
 describe("resolveApiKeyValue", () => {

--- a/infrastructure/test/observability/cost-budget.test.ts
+++ b/infrastructure/test/observability/cost-budget.test.ts
@@ -82,4 +82,43 @@ describe("CostBudget", () => {
       | undefined;
     expect(notifications?.length).toBe(3);
   });
+
+  // Issue #952 / PR-957 user feedback: TenkaCloud リソースだけを集計するため、 user-defined
+  // cost allocation tag (= App scope `Project=TenkaCloud`) で filter を絞る経路を pin する。
+  it("costAllocationTags を渡すと CfnBudget の CostFilters に `user:<Key>$<Value>` 形式で入るべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: ["alarm@example.com"],
+      costAllocationTags: { Project: ["TenkaCloud"] },
+    });
+
+    const template = Template.fromStack(stack);
+    const budgetProps = template.findResources("AWS::Budgets::Budget");
+    const key = Object.keys(budgetProps)[0];
+    if (!key) throw new Error("budget resource not found");
+    const budgetSpec = budgetProps[key]?.Properties?.Budget as Record<string, unknown>;
+    const costFilters = budgetSpec?.CostFilters as Record<string, readonly string[]>;
+    expect(costFilters).toBeDefined();
+    expect(costFilters["user:Project"]).toEqual(["Project$TenkaCloud"]);
+  });
+
+  it("costAllocationTags 未指定なら CostFilters key 自体が無いべき (= 全アカウント費用が対象)", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: ["alarm@example.com"],
+    });
+
+    const template = Template.fromStack(stack);
+    const budgetProps = template.findResources("AWS::Budgets::Budget");
+    const key = Object.keys(budgetProps)[0];
+    if (!key) throw new Error("budget resource not found");
+    const budgetSpec = budgetProps[key]?.Properties?.Budget as Record<string, unknown>;
+    expect(budgetSpec?.CostFilters).toBeUndefined();
+  });
 });

--- a/infrastructure/test/observability/cost-budget.test.ts
+++ b/infrastructure/test/observability/cost-budget.test.ts
@@ -1,0 +1,85 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { CostBudget } from "../../lib/observability/cost-budget";
+
+/**
+ * Issue #952 / PR-957 CodeRabbit follow-up: CostBudget construct の振る舞いを pin する。
+ * 特に「同一 email を 2 回以上渡しても SNS Subscription は 1 つだけ作られる」 ことを保証する
+ * (= AWS 側で同じ宛先に 2 件の confirmation mail が飛ぶ事故を防ぐ)。
+ */
+
+describe("CostBudget", () => {
+  it("budget と SNS topic を作成し、 default 閾値 80% / 100% で 2 件の Notification を生成すべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: ["alarm@example.com"],
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::SNS::Topic", 1);
+    template.resourceCountIs("AWS::SNS::Subscription", 1);
+    template.hasResourceProperties("AWS::Budgets::Budget", {
+      Budget: { BudgetType: "COST", TimeUnit: "MONTHLY" },
+    });
+    // notificationsWithSubscribers が 2 件 (= 80% / 100%) 含まれる
+    const budgetProps = template.findResources("AWS::Budgets::Budget");
+    const key = Object.keys(budgetProps)[0];
+    if (!key) throw new Error("budget resource not found");
+    const notifications = budgetProps[key]?.Properties?.NotificationsWithSubscribers as
+      | Array<unknown>
+      | undefined;
+    expect(notifications).toBeDefined();
+    expect(notifications?.length).toBe(2);
+  });
+
+  it("notificationEmails に重複があっても SNS Subscription は 1 件にまとまるべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: ["alarm@example.com", "alarm@example.com", "alarm@example.com"],
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::SNS::Subscription", 1);
+  });
+
+  it("notificationEmails が空でも construct 自体は壊れず、 Subscription は 0 件すべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: [],
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::SNS::Topic", 1);
+    template.resourceCountIs("AWS::SNS::Subscription", 0);
+  });
+
+  it("thresholdPercents 上書きで Notification 数が変わるべき", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    new CostBudget(stack, "Budget", {
+      budgetNamePrefix: "tenkacloud-test",
+      monthlyLimitUsd: 50,
+      notificationEmails: ["alarm@example.com"],
+      thresholdPercents: [50, 80, 100],
+    });
+
+    const template = Template.fromStack(stack);
+    const budgetProps = template.findResources("AWS::Budgets::Budget");
+    const key = Object.keys(budgetProps)[0];
+    if (!key) throw new Error("budget resource not found");
+    const notifications = budgetProps[key]?.Properties?.NotificationsWithSubscribers as
+      | Array<unknown>
+      | undefined;
+    expect(notifications?.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

epic #952 (= 初見の人が独力でコンテストを開催できる SaaS) の sub: cost guardrails 層。 AWS Budgets で **月次コストが threshold (80% / 100%) を超えたら email alarm** する。 主犯は Lambda 暴走 / DDB autoscale ミス / 競技者問題の CFn 想定外リソース。 これを early signal で検知し、 ops が止められるようにする。

## 実装

- `infrastructure/lib/observability/cost-budget.ts` — 新規 \`CostBudget\` construct。 \`aws_budgets.CfnBudget\` + \`aws_sns.Topic\` を立て、 80% / 100% の threshold subscription に email を流す
- \`wire.ts\` — observability stack 配下で生成 (\`monthlyCostLimitUsd > 0\` のときだけ、 default は config に書く)
- AppConfig / Config: \`monthlyCostLimitUsd\` + \`budgetAlarmEmails\` を追加
- config-schema.json: \`kmsConfig\` + \`monthlyCostLimitUsd\` + \`budgetAlarmEmails\` を json schema に追加
- environments/development/config.json: default 50 USD
- environments/production/config.json: default 200 USD

## Regression 分析

- \`monthlyCostLimitUsd: 0\` のときは Budget を立てない (= 既存 user の deploy を壊さない)
- email 未設定でも SNS topic だけ立ち上がるので publish error にはならない
- AWS Budgets の Free Tier 内 (= 月 2 件 / SNS 通知 1000/月) で運用

## 物理影響

- CREATE: \`AWS::SNS::Topic\` (BudgetAlarmTopic), \`AWS::Budgets::Budget\` (MonthlyCostBudget)
- CREATE: \`AWS::SNS::Subscription\` × budgetAlarmEmails の数
- 既存 stack: NO-OP

Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional monthly cost limit configuration (dev default $50, prod default $200) and optional extra budget notification emails.
  * Automatically provisions a monthly cost budget when a positive limit is set; includes system admin and deduplicated recipient emails.
  * Default alert thresholds at 80% and 100%, configurable.

* **Config & Validation**
  * Schema and config types updated to validate new fields.

* **Tests**
  * Added unit tests for config normalization and budget/notification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->