### PR TITLE
feat(#952): apps/landing-page で Google Form waitlist + OSS 紹介

### DIFF
--- a/apps/landing-page/README.md
+++ b/apps/landing-page/README.md
@@ -1,0 +1,45 @@
+# @TenkaCloud/landing-page
+
+TenkaCloud の OSS ランディングページ。 主催者向けの製品紹介 + Google Form ウェイトリスト埋め込み + Participant Portal / Admin Console / GitHub への deep link。
+
+## ローカル開発
+
+```bash
+cd apps/landing-page
+bun run dev
+# → http://localhost:5176
+```
+
+並走ポート: admin-console 5173 / application-admin-console 5174 / participant-portal 5175 / landing-page **5176**。
+
+## Google Form を差し替える
+
+waitlist 用 Google Form の embed URL を 2 通りで注入できる。
+
+### dev (= ローカル)
+
+```bash
+# apps/landing-page/.env.local
+VITE_WAITLIST_FORM_URL=https://docs.google.com/forms/d/e/<FORM_ID>/viewform?embedded=true
+```
+
+### production (= CloudFront 配信)
+
+`runtime-config.json` を CloudFront 配下に配置し、 `waitlistFormUrl` を設定する。 同じ仕組みで Participant Portal / Admin Console の URL も差し替える。
+
+```json
+{
+  "waitlistFormUrl": "https://docs.google.com/forms/d/e/FORM_ID/viewform?embedded=true",
+  "participantPortalUrl": "https://portal.example.com",
+  "adminConsoleUrl": "https://admin.example.com",
+  "githubRepoUrl": "https://github.com/<owner>/TenkaCloud"
+}
+```
+
+未設定なら waitlist セクションは「Google Form 未設定」の Alert を出して動作する。
+
+## デザイン方針
+
+- **Cloudscape 一択** — 他 SPA (admin-console / application-admin-console / participant-portal) と同じデザイン言語で揃える
+- **single page** — `<a href="#waitlist">` 内部リンク。 react-router は使わない (= overkill)
+- **runtime-config.json で差し替え** — `apps/*/dist/` は static asset、 環境差分は runtime に注入する (`INVARIANT_APP_CODE_IS_UNMODIFIED`)

--- a/apps/landing-page/index.html
+++ b/apps/landing-page/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="TenkaCloud — AWS マルチテナント SaaS のクラウドコンペティション基盤。 GameDay / JAM 風の Battle と常設 Challenge を独力で開催できる、 OSS の競技プラットフォーム"
+    />
+    <title>TenkaCloud — Cloud Competition Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@TenkaCloud/landing-page",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "start": "vite preview",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@cloudscape-design/components": "^3.0.960",
+    "@cloudscape-design/global-styles": "^1.0.44",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react-swc": "^4.3.0",
+    "jsdom": "^25.0.1",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.2",
+    "vitest": "^4.1.6"
+  }
+}

--- a/apps/landing-page/src/App.tsx
+++ b/apps/landing-page/src/App.tsx
@@ -1,0 +1,216 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import Grid from "@cloudscape-design/components/grid";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import type { AppConfig } from "./config";
+
+export function App({ config }: { config: AppConfig }) {
+  return (
+    <Box padding={{ vertical: "xxl", horizontal: "l" }}>
+      <Box margin={{ bottom: "xxl" }}>
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            description="AWS マルチテナント SaaS のクラウドコンペティション基盤。 GameDay / JAM 風の Battle と常設 Challenge を、 主催者 1 人で独力で開催できる OSS プラットフォーム。"
+          >
+            TenkaCloud — Cloud Competition Platform
+          </Header>
+          <SpaceBetween size="xs" direction="horizontal">
+            {config.waitlistFormUrl ? (
+              <Button variant="primary" href="#waitlist">
+                ウェイトリストに登録
+              </Button>
+            ) : null}
+            <Button
+              variant="normal"
+              href={config.githubRepoUrl}
+              iconAlign="right"
+              iconName="external"
+            >
+              GitHub で見る
+            </Button>
+            {config.participantPortalUrl ? (
+              <Button
+                variant="link"
+                href={config.participantPortalUrl}
+                iconAlign="right"
+                iconName="external"
+              >
+                Participant Portal
+              </Button>
+            ) : null}
+            {config.adminConsoleUrl ? (
+              <Button
+                variant="link"
+                href={config.adminConsoleUrl}
+                iconAlign="right"
+                iconName="external"
+              >
+                System Admin Console
+              </Button>
+            ) : null}
+          </SpaceBetween>
+        </SpaceBetween>
+      </Box>
+
+      <Box margin={{ bottom: "xxl" }}>
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="主催者が抱える「インフラを書く」「採点を書く」「競技者環境を配る」の 3 重苦を、 platform 側に閉じ込めた"
+            >
+              なぜ TenkaCloud か
+            </Header>
+          }
+        >
+          <ColumnLayout columns={3} variant="text-grid">
+            <FeatureCard
+              title="問題は plugin、 platform は host"
+              body="問題 = metadata.json + CFn ペライチ + 任意の portal/dashboard。 採点関数は 5 種類の builtin kind から 1 つ宣言するだけ。 platform に問題固有のコードを書く必要は無い"
+            />
+            <FeatureCard
+              title="競技者環境を 1 click で配布"
+              body="主催者は問題を deploy するだけ。 競技者は IAM Role を assume してそのまま AWS Console を開ける。 EventBridge → Worker Lambda → CFn CreateStack まで自動"
+            />
+            <FeatureCard
+              title="コスト爆発を未然に防ぐ"
+              body="DynamoDB は 1 RCU / 1 WCU PROVISIONED 強制 (Free Tier 内)。 AWS Budgets で月次コストを 80% / 100% で email alarm。 Lambda 暴走を early signal で検知"
+            />
+            <FeatureCard
+              title="マルチテナント (= SaaS) と single-tenant"
+              body="SBT 0.3.9 (Software-as-a-Service Builder Toolkit) ベース。 BASIC / STANDARD / PREMIUM は pooled、 PLATINUM は silo stack。 個人開催なら single-tenant モードで起動"
+            />
+            <FeatureCard
+              title="認証はインフラ層で注入"
+              body="Cognito UserPool + Hosted UI + OAuth Code + PKCE。 アプリ側に AUTH_SKIP 的な bypass を書かない。 MFA TOTP は tenant UserPool で REQUIRED"
+            />
+            <FeatureCard
+              title="ADR で意思決定を正本化"
+              body="docs/architecture/adr-*.html に背景・判断・影響・代替案・移行方針を self-contained に。 architecture invariant は `make harness` で機械検査"
+            />
+          </ColumnLayout>
+        </Container>
+      </Box>
+
+      <Box margin={{ bottom: "xxl" }}>
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="主催者 (= 大会オペレーター) と競技者 (= participant) の 2 つの persona で完結する"
+            >
+              使い方
+            </Header>
+          }
+        >
+          <ColumnLayout columns={2}>
+            <Box>
+              <Header variant="h3">主催者として開催する</Header>
+              <Box variant="p">
+                <ol>
+                  <li>
+                    repo を clone して <code>make deploy ENV=production</code>
+                  </li>
+                  <li>System Admin Console から tenant (= 大会) を作成</li>
+                  <li>
+                    <code>/create-problem</code> で問題雛形を生成し、 metadata.json と template.yaml
+                    を編集
+                  </li>
+                  <li>競技者 (= team) を招待 (= login key を配布)</li>
+                </ol>
+              </Box>
+            </Box>
+            <Box>
+              <Header variant="h3">競技者として参加する</Header>
+              <Box variant="p">
+                <ol>
+                  <li>主催者から渡された login key で Participant Portal にログイン</li>
+                  <li>
+                    問題一覧から「これに挑戦」をクリック → 自分の AWS account に環境が deploy される
+                  </li>
+                  <li>AWS Console に federated user として直接サインインして調査・修復</li>
+                  <li>flag を提出 → scoring engine が builtin kind で自動採点</li>
+                </ol>
+              </Box>
+            </Box>
+          </ColumnLayout>
+        </Container>
+      </Box>
+
+      <Box id="waitlist" margin={{ bottom: "xxl" }}>
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="ベータ版の招待をご希望の方は、 Google Form にご記入ください (= 開催ご相談の方も歓迎)"
+            >
+              ウェイトリスト
+            </Header>
+          }
+        >
+          <WaitlistEmbed formUrl={config.waitlistFormUrl} />
+        </Container>
+      </Box>
+
+      <Box>
+        <Grid gridDefinition={[{ colspan: 12 }]}>
+          <Box variant="small" textAlign="center" color="text-body-secondary">
+            <SpaceBetween size="xs" direction="horizontal">
+              <Link href={config.githubRepoUrl} external>
+                GitHub
+              </Link>
+              <span>·</span>
+              <Link href={`${config.githubRepoUrl}/blob/main/LICENSE`} external>
+                MIT License
+              </Link>
+              <span>·</span>
+              <Link href={`${config.githubRepoUrl}/issues`} external>
+                Issues
+              </Link>
+            </SpaceBetween>
+          </Box>
+        </Grid>
+      </Box>
+    </Box>
+  );
+}
+
+function FeatureCard({ title, body }: { title: string; body: string }) {
+  return (
+    <Box>
+      <Header variant="h3">{title}</Header>
+      <Box variant="p">{body}</Box>
+    </Box>
+  );
+}
+
+function WaitlistEmbed({ formUrl }: { formUrl: string | null }) {
+  if (!formUrl) {
+    return (
+      <Alert type="info" header="Google Form 未設定" statusIconAriaLabel="info">
+        <Box variant="p">
+          ウェイトリスト用の Google Form がまだ設定されていません。 主催者は{" "}
+          <code>VITE_WAITLIST_FORM_URL</code> 環境変数 (dev) または <code>runtime-config.json</code>{" "}
+          の <code>waitlistFormUrl</code> (production) に embed URL を設定してください。
+        </Box>
+      </Alert>
+    );
+  }
+  return (
+    <iframe
+      src={formUrl}
+      title="TenkaCloud waitlist (Google Forms)"
+      width="100%"
+      height="800"
+      style={{ border: 0, maxWidth: "720px", display: "block", margin: "0 auto" }}
+    >
+      Loading...
+    </iframe>
+  );
+}

--- a/apps/landing-page/src/config.ts
+++ b/apps/landing-page/src/config.ts
@@ -1,0 +1,46 @@
+// runtime-config.json (= CloudFront 配下) で waitlist Google Form URL を注入する。
+// dev では vite env (VITE_WAITLIST_FORM_URL) も fallback として参照する。
+export interface AppConfig {
+  /**
+   * Google Form の埋め込み用 embed URL。
+   * `https://docs.google.com/forms/d/e/<formId>/viewform?embedded=true`
+   * 未設定なら waitlist セクションは「準備中」表示になる。
+   */
+  waitlistFormUrl: string | null;
+  /** Participant Portal の URL (= 既にコンテストに招待されている人の入口) */
+  participantPortalUrl: string | null;
+  /** System Admin Console の URL (= 主催者 sign-in) */
+  adminConsoleUrl: string | null;
+  /** GitHub repo URL (= OSS としての CTA) */
+  githubRepoUrl: string;
+}
+
+const DEFAULT_GITHUB_REPO_URL = "https://github.com/susumutomita/TenkaCloud";
+
+export async function loadConfig(): Promise<AppConfig> {
+  try {
+    const res = await fetch("/runtime-config.json", { cache: "no-store" });
+    if (res.ok) {
+      const json = (await res.json()) as Partial<AppConfig>;
+      return {
+        waitlistFormUrl: json.waitlistFormUrl ?? readEnvWaitlistUrl(),
+        participantPortalUrl: json.participantPortalUrl ?? null,
+        adminConsoleUrl: json.adminConsoleUrl ?? null,
+        githubRepoUrl: json.githubRepoUrl ?? DEFAULT_GITHUB_REPO_URL,
+      };
+    }
+  } catch {
+    // runtime-config.json が無い (= dev) ときは env fallback
+  }
+  return {
+    waitlistFormUrl: readEnvWaitlistUrl(),
+    participantPortalUrl: null,
+    adminConsoleUrl: null,
+    githubRepoUrl: DEFAULT_GITHUB_REPO_URL,
+  };
+}
+
+function readEnvWaitlistUrl(): string | null {
+  const url = import.meta.env.VITE_WAITLIST_FORM_URL;
+  return typeof url === "string" && url.length > 0 ? url : null;
+}

--- a/apps/landing-page/src/main.tsx
+++ b/apps/landing-page/src/main.tsx
@@ -1,0 +1,20 @@
+import "@cloudscape-design/global-styles/index.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import { loadConfig } from "./config";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root element missing from index.html");
+
+loadConfig()
+  .then((config) => {
+    createRoot(root).render(
+      <StrictMode>
+        <App config={config} />
+      </StrictMode>,
+    );
+  })
+  .catch((err: Error) => {
+    root.innerHTML = `<pre style="padding: 2rem; color: #a00; font-family: monospace;">Config load failed: ${err.message}</pre>`;
+  });

--- a/apps/landing-page/test/App.test.tsx
+++ b/apps/landing-page/test/App.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { App } from "../src/App";
+import type { AppConfig } from "../src/config";
+
+const baseConfig: AppConfig = {
+  waitlistFormUrl: null,
+  participantPortalUrl: null,
+  adminConsoleUrl: null,
+  githubRepoUrl: "https://github.com/example/repo",
+};
+
+describe("LandingPage App", () => {
+  it("ヒーロー見出しに TenkaCloud を表示するべき", () => {
+    render(<App config={baseConfig} />);
+    expect(screen.getByRole("heading", { level: 1, name: /TenkaCloud/ })).toBeInTheDocument();
+  });
+
+  it("Google Form 未設定なら waitlist セクションは案内 Alert を出すべき", () => {
+    render(<App config={baseConfig} />);
+    expect(screen.getByText(/Google Form 未設定/)).toBeInTheDocument();
+  });
+
+  it("Google Form URL が設定されていれば iframe を埋め込むべき", () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      waitlistFormUrl: "https://docs.google.com/forms/d/e/FORM_ID/viewform?embedded=true",
+    };
+    render(<App config={config} />);
+    const iframe = screen.getByTitle(/TenkaCloud waitlist/);
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.tagName.toLowerCase()).toBe("iframe");
+  });
+
+  it("waitlist CTA は formUrl が設定されているときだけ出すべき", () => {
+    const { rerender } = render(<App config={baseConfig} />);
+    expect(screen.queryByRole("link", { name: /ウェイトリストに登録/ })).toBeNull();
+    rerender(
+      <App
+        config={{
+          ...baseConfig,
+          waitlistFormUrl: "https://docs.google.com/forms/d/e/FORM_ID/viewform?embedded=true",
+        }}
+      />,
+    );
+    expect(screen.getByRole("link", { name: /ウェイトリストに登録/ })).toBeInTheDocument();
+  });
+});

--- a/apps/landing-page/test/setup.ts
+++ b/apps/landing-page/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/landing-page/tsconfig.json
+++ b/apps/landing-page/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/landing-page/vite.config.ts
+++ b/apps/landing-page/vite.config.ts
@@ -1,0 +1,34 @@
+import react from "@vitejs/plugin-react-swc";
+import { createLogger, defineConfig } from "vite";
+
+// 他 app と同じく Vite 7 の vite:react-swc deprecation warning を抑制する。
+const logger = createLogger();
+const originalWarn = logger.warn;
+logger.warn = (msg, opts) => {
+  if (msg.includes('"vite:react-swc"') && msg.includes("optimizeDeps.esbuildOptions")) return;
+  originalWarn(msg, opts);
+};
+
+export default defineConfig({
+  plugins: [react()],
+  customLogger: logger,
+  // admin-console (5173) / application-admin-console (5174) / participant-portal (5175) と並走できるよう別ポート。
+  server: { port: 5176 },
+  build: {
+    chunkSizeWarningLimit: 1200,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          cloudscape: ["@cloudscape-design/components", "@cloudscape-design/global-styles"],
+          react: ["react", "react-dom"],
+        },
+      },
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+    exclude: ["node_modules", "dist"],
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,27 @@
         "vitest": "^4.1.6",
       },
     },
+    "apps/landing-page": {
+      "name": "@TenkaCloud/landing-page",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cloudscape-design/components": "^3.0.960",
+        "@cloudscape-design/global-styles": "^1.0.44",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@types/react": "^19.0.2",
+        "@types/react-dom": "^19.0.2",
+        "@vitejs/plugin-react-swc": "^4.3.0",
+        "jsdom": "^25.0.1",
+        "typescript": "~5.9.3",
+        "vite": "^7.3.2",
+        "vitest": "^4.1.6",
+      },
+    },
     "apps/participant-portal": {
       "name": "@TenkaCloud/participant-portal",
       "version": "0.1.0",
@@ -173,6 +194,8 @@
     "@TenkaCloud/application-admin-console": ["@TenkaCloud/application-admin-console@workspace:apps/application-admin-console"],
 
     "@TenkaCloud/infrastructure": ["@TenkaCloud/infrastructure@workspace:infrastructure"],
+
+    "@TenkaCloud/landing-page": ["@TenkaCloud/landing-page@workspace:apps/landing-page"],
 
     "@TenkaCloud/participant-portal": ["@TenkaCloud/participant-portal@workspace:apps/participant-portal"],
 

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "bun run --filter @TenkaCloud/infrastructure build && bun run --filter @TenkaCloud/admin-console build && bun run --filter @TenkaCloud/application-admin-console build && bun run --filter @TenkaCloud/participant-portal build",
-    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
+    "build": "bun run --filter @TenkaCloud/infrastructure build && bun run --filter @TenkaCloud/admin-console build && bun run --filter @TenkaCloud/application-admin-console build && bun run --filter @TenkaCloud/participant-portal build && bun run --filter @TenkaCloud/landing-page build",
+    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/landing-page typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
-    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test",
+    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/landing-page test && bun run --filter @TenkaCloud/trust-bridge test",
     "validate:problems": "bun run scripts/validate-problems.ts",
     "build:problems-index": "bun run scripts/build-problem-index.ts",
     "check:problems-index": "bun run scripts/build-problem-index.ts --check",


### PR DESCRIPTION
## Summary

epic #952 (= 初見の人が独力でコンテストを開催できる SaaS) の sub: ランディングページ。 Vite + React 19 + Cloudscape の 4 つ目の SPA として \`apps/landing-page\` を新設し、 主催者向けの **製品紹介 + Google Form ウェイトリスト埋め込み + Participant Portal / Admin Console / GitHub への deep link** を提供する。

## 実装

- \`apps/landing-page/\` 新 workspace (port **5176**)
- \`src/App.tsx\` — hero + 6 feature cards + 使い方 (主催者 / 競技者 2 column) + waitlist iframe + footer。 Cloudscape 一択で他 SPA と同じデザイン言語
- \`src/config.ts\` — \`runtime-config.json\` で \`waitlistFormUrl\` / \`participantPortalUrl\` / \`adminConsoleUrl\` / \`githubRepoUrl\` を注入 (\`INVARIANT_APP_CODE_IS_UNMODIFIED\` に従い env 差分は runtime に閉じる)。 dev は \`VITE_WAITLIST_FORM_URL\` 環境変数で fallback
- \`test/App.test.tsx\` — 4 ケース (ヒーロー / 未設定 alert / iframe / CTA)
- root \`package.json\` — \`build\` / \`typecheck\` / \`test\` の filter chain に \`@TenkaCloud/landing-page\` を追加

## Regression 分析

- 既存 3 SPA (admin-console / application-admin-console / participant-portal) のコードには触れていない
- root \`package.json\` の filter chain 末尾 (= trust-bridge の前) に追加しただけ。 既存 build 順序は変わらない
- Google Form URL が未設定でも壊れない (= Alert で「準備中」表示)。 既存 user の deploy には影響なし
- port 5176 は他 SPA (5173/5174/5175) と並走可能

## 物理影響

- CREATE: \`apps/landing-page/\` ディレクトリ + 10 ファイル
- UPDATE: root \`package.json\` (build / typecheck / test scripts に 1 行ずつ追加)
- UPDATE: \`bun.lock\` (= 既存 cloudscape / react / vite に乗っかるだけ、 新規 dep なし)
- CFn / AWS 側: NO-OP (= CloudFront hosting stack は user 側で後付け予定)

## Test plan

- [x] `bun run --filter @TenkaCloud/landing-page test` — 4 passed
- [x] `bun run --filter @TenkaCloud/landing-page typecheck` — pass
- [x] `bun run --filter @TenkaCloud/landing-page build` — pass
- [x] `make harness` — no findings
- [x] `make before-commit` (= husky pre-commit hook 経由) — pass

## Next steps

- Google Form を作成し embed URL を \`runtime-config.json\` に注入 (= user 担当)
- landing-page を CloudFront で配信する infrastructure stack を追加 (= user 担当、 admin-console-hosting.ts と同型)

Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)