### PR TITLE
feat(#951): 問題 scaffold 5 種を SCHEMA validate-ready + hint v2 入りに

### DIFF
--- a/.claude/templates/problems/attack-detection/metadata.json
+++ b/.claude/templates/problems/attack-detection/metadata.json
@@ -9,7 +9,7 @@
   "estimatedDuration": "60〜90 分",
   "shortDescription": "攻撃検知 counter 差分で加点する attack-detection Battle skeleton。",
   "description": "competitor account 内の counter (= 攻撃検知件数、 SQLi 阻止件数、 SOC alert 件数 等) を CFn Output で露出し、 platform が 1 分毎に diff を取って加点する。\\n\\n典型用途: WAF 防御 / SOC monitoring / IDS 設定の効果を数値で評価したい問題。 counter 値は問題側 Lambda / CloudWatch metrics → SSM Parameter Store 経由で CFn Output に書く方式が一般的。",
-  "tags": ["__TAG__", "security"],
+  "tags": ["sample", "security"],
   "exposedPorts": [{ "port": 80, "name": "monitored-service" }],
   "learningGoals": ["__LEARNING_GOAL_1__"],
   "cfnTemplate": "template.yaml",

--- a/.claude/templates/problems/flag/metadata.json
+++ b/.claude/templates/problems/flag/metadata.json
@@ -7,16 +7,33 @@
   "visibility": "public",
   "difficulty": 2,
   "estimatedDuration": "30〜45 分",
-  "shortDescription": "1 行サマリ (~200 字) — どんな問題か。",
-  "description": "問題の長文説明。\\n\\n参加者が deploy 後に何をするか / どんな AWS リソースが立つか / 正解 flag はどこから取り出すかを書く。\\n\\nflag 型の典型: CFn template に SSM Parameter / Secrets Manager / 静的 Output で正解値を仕込み、 OutputKey を `scoring.flagOutputKey` で指す。 競技者は AWS Console / CLI で値を見つけ、 portal の flag form に提出する。",
-  "tags": ["__TAG__"],
-  "exposedPorts": [{ "port": 0, "name": "(no public endpoint)" }],
-  "learningGoals": ["__LEARNING_GOAL_1__", "__LEARNING_GOAL_2__"],
+  "shortDescription": "deploy 後に AWS Console / CLI で正解 flag を発見し portal に提出する Challenge (flag 採点)。",
+  "description": "本問題では deploy 直後に AWS リソース (例: SSM Parameter / Secrets Manager / S3 オブジェクト) が立ち上がります。 そのリソースのいずれかに正解 flag (`TC{...}` 形式) が仕込まれているので、 AWS Console / CLI から発見し、 portal の flag 提出フォームに submit してください。\\n\\n採点ロジック: scoring engine が `cfnTemplate` の Outputs から `scoring.flagOutputKey` で指定された値を読み取り、 提出値と一致比較します。 一致すれば `scoring.points` 点を加算します。 不正解は 0 点 (penalty なし)。 hint を表示すると hint ごとの `penalty` だけ最終得点から差し引かれます。\\n\\n想定経路: (1) deploy 後に payload を取得 → (2) Console / CLI で flag を発見 → (3) portal で提出。 hint は段階的に開示してください。",
+  "tags": ["sample", "challenge"],
+  "exposedPorts": [
+    { "port": 1, "name": "(no public endpoint — flag は SSM Parameter 等から取り出す)" }
+  ],
+  "learningGoals": [
+    "AWS Console / CLI でリソース属性を読み取る基本操作に慣れる",
+    "IAM の最小権限が与えられている状態で必要な情報だけを引き出す",
+    "問題文と CFn Outputs を突き合わせて 「採点対象の値」 を特定する"
+  ],
   "cfnTemplate": "template.yaml",
   "scoring": {
     "kind": "flag",
     "flagOutputKey": "FlagValue",
     "points": 100,
-    "hints": ["__HINT_1__ (任意、 portal の hint 欄に表示)"]
+    "hints": [
+      {
+        "id": "hint-1",
+        "content": "competitor IAM role には `ssm:GetParameter` が付与されています。 まず `aws ssm get-parameter --name /<NamePrefix>/flag` を試してみてください。",
+        "penalty": 10
+      },
+      {
+        "id": "hint-2",
+        "content": "flag は `TC{...}` の形式です。 SSM Parameter の `Value` をそのまま portal に提出してください。",
+        "penalty": 20
+      }
+    ]
   }
 }

--- a/.claude/templates/problems/flag/template.yaml
+++ b/.claude/templates/problems/flag/template.yaml
@@ -2,6 +2,8 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   TenkaCloud problem — __PROBLEM_ID__ (flag-kind Challenge).
   競技者が AWS Console / CLI で正解値を発見して portal に提出する Challenge 型の skeleton。
+  本 skeleton は SSM Parameter に flag を仕込む最小構成。 実問題では Secrets Manager / S3 /
+  Lambda Env 等に置き換え、 IAM scope を最小化してください。
 
 Parameters:
   NamePrefix:
@@ -12,19 +14,34 @@ Parameters:
     Description: "tc-{problemSlug}-{teamSlug} 形式の共通リソース prefix。"
 
 Resources:
-  # 例: SSM Parameter に正解 flag を仕込む。 競技者は ssm:GetParameter で取り出す等。
+  # 競技者が SSM GetParameter で flag を取り出す想定。
+  # 本格運用では Type: SecureString + KMS で暗号化することを検討してください。
   FlagParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub "/${NamePrefix}/flag"
       Type: String
       Value: "TC{__REPLACE_WITH_REAL_FLAG__}"
-      Description: "本問題の正解 flag (competitor が発見すべき値)。"
+      Description: "本問題の正解 flag。 metadata.scoring.flagOutputKey で指す Output が scoring engine の比較対象。"
+
+  # 任意: 競技者用 discovery hint。 「どこに何があるか」 のヒントを SSM Parameter として置く。
+  # metadata.scoring.hints[] と二重持ちになるが、 競技者が AWS CLI を素振りする練習材料になる。
+  # 不要なら削除して問題ありません。
+  HintParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${NamePrefix}/hints/discovery"
+      Type: String
+      Value: "Find a parameter named /<NamePrefix>/flag and submit its value."
+      Description: "競技者向け discovery hint (任意削除可)。"
 
 Outputs:
   FlagValue:
     Description: "scoring engine が submitted flag と一致比較する正解値 (= metadata.scoring.flagOutputKey で参照)。"
     Value: !GetAtt FlagParameter.Value
+  FlagParameterPath:
+    Description: "競技者が CLI で読み取る SSM Parameter の path (= 問題文に載せる用)。"
+    Value: !Ref FlagParameter
   NamePrefix:
     Description: "Deploy 時に渡された prefix (echo)。"
     Value: !Ref NamePrefix

--- a/.claude/templates/problems/phased-polling/metadata.json
+++ b/.claude/templates/problems/phased-polling/metadata.json
@@ -9,7 +9,7 @@
   "estimatedDuration": "90〜120 分",
   "shortDescription": "時間経過で rule が変わる phased-polling 採点の Battle skeleton。",
   "description": "競技時間中に複数 phase が自動進行する Battle 型。 phases[].afterMinutes で発火 offset を持ち、 phase ごとに `effect` で scoring engine の挙動を切り替える (= platform 加点分類 / scorePath override 等)。\\n\\n典型用途: マイクロサービス分割レース、 段階的負荷試験、 時系列的に変わる game rule。 phased-polling は probe 1 回ごとに platform 自己申告 (`/meta`) を読み platform 分類 (ec2/lambda/ecs/apprunner) で加点する。",
-  "tags": ["__TAG__"],
+  "tags": ["sample", "battle"],
   "exposedPorts": [{ "port": 80, "name": "service" }],
   "learningGoals": ["__LEARNING_GOAL_1__"],
   "cfnTemplate": "template.yaml",

--- a/.claude/templates/problems/uptime-flat/metadata.json
+++ b/.claude/templates/problems/uptime-flat/metadata.json
@@ -7,11 +7,19 @@
   "visibility": "public",
   "difficulty": 3,
   "estimatedDuration": "60〜90 分",
-  "shortDescription": "1 endpoint を稼働させ続けて defense する Battle 問題の skeleton (uptime-flat 採点)。",
-  "description": "deploy 後に 1 endpoint が払い出される。 1 分毎に platform が probe し、 200 OK ならポイント加算。 fail 時はゼロ加算 (penalty なし)。\\n\\n典型用途: 「最低限稼働する単一サービス」 を 1〜2 時間維持する Battle。 攻撃側 / 防御側のロール分けはしない最も簡単な uptime 採点。",
-  "tags": ["__TAG__"],
-  "exposedPorts": [{ "port": 80, "name": "service (HTTP)" }],
-  "learningGoals": ["__LEARNING_GOAL_1__"],
+  "shortDescription": "1〜N endpoint を稼働させ続けて defense する Battle 問題 (uptime-flat 採点)。",
+  "description": "deploy 直後に 1〜N の service endpoint が払い出されます。 platform 側 scoring engine が 1 分毎に各 endpoint を **独立に** probe し、 HTTP status が `expectStatus` (= 200) に該当すれば 1 回成功とみなし `pointsPerSuccess` 点を加算します。 N endpoint のうち M 個成功なら M × pointsPerSuccess の部分点が入る (= 全 ok でないと 0 の uptime-multi とは異なる)。\\n\\n典型用途: 「複数の microservice の生存を独立に評価する」 Battle。 1 endpoint だけでもよい (= 最も簡単な uptime 採点)。 service の作り込み次第で「自己破壊しないように起動 → 維持」「攻撃対象から守る」「DOS 耐性を上げる」 等の応用が可能。\\n\\n採点の癖: probe interval は最短 1 分。 短時間 outage でも 1 cycle まるごと 0 点になる。 攻撃 sequence は metadata の `disruptions[]` で時間軸を入れられる (= 何分目に何が起きるか)。",
+  "tags": ["sample", "battle"],
+  "exposedPorts": [
+    { "port": 80, "name": "service (HTTP)" },
+    { "port": 443, "name": "service (HTTPS、 任意)" }
+  ],
+  "learningGoals": [
+    "自分の AWS account に minimum viable web service を立てる",
+    "EC2 / Lambda / ECS / App Runner の何を選ぶかをコスト・運用性で判断する",
+    "Security Group / WAF / CloudFront で外部攻撃を緩和する",
+    "CloudWatch Logs で probe 失敗の root cause を読む"
+  ],
   "cfnTemplate": "template.yaml",
   "endpoints": [
     {
@@ -24,9 +32,19 @@
   ],
   "scoring": {
     "kind": "uptime-flat",
-    "intervalMinutes": 1,
-    "probe": { "path": "/", "expectStatus": [200] },
+    "endpoints": [{ "slot": "main", "path": "/", "expectStatus": [200] }],
     "pointsPerSuccess": 100,
-    "failurePenalty": 0
+    "hints": [
+      {
+        "id": "hint-1",
+        "content": "deploy 直後の URL は CFn Outputs.ServiceUrl で確認できます。 curl で叩いて 200 が返ることを最初に確認してください。",
+        "penalty": 5
+      },
+      {
+        "id": "hint-2",
+        "content": "Security Group の inbound を `0.0.0.0/0` に開放すると probe は通りますが攻撃も通ります。 Battle 系問題では platform 側 probe Lambda 専用の CIDR 許可も検討してください。",
+        "penalty": 15
+      }
+    ]
   }
 }

--- a/.claude/templates/problems/uptime-flat/template.yaml
+++ b/.claude/templates/problems/uptime-flat/template.yaml
@@ -1,7 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   TenkaCloud problem — __PROBLEM_ID__ (uptime-flat Battle).
-  1 endpoint を 1〜2 時間維持する Battle 型 skeleton。
+  1〜N endpoint を 1 分毎の probe で独立に評価する Battle 型 skeleton。
+  本 skeleton は SNS Topic だけの placeholder。 実問題では EC2 + nginx / Lambda + API GW /
+  ECS 等で実際の HTTP endpoint を立て、 ServiceUrl Output に URL を入れてください。
 
 Parameters:
   NamePrefix:
@@ -14,19 +16,25 @@ Parameters:
     Type: String
     Default: "0.0.0.0/0"
     AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
-    Description: "公開 port を許可する CIDR。"
+    Description: "公開 port を許可する CIDR。 Battle 問題では platform 側 probe 経路を限定したい場合に絞り込み可。"
 
 Resources:
-  # TODO: 競技者が維持する service の AWS リソースを定義 (例: EC2 + nginx、 Lambda + API GW、 ECS 等)
-  # ここでは最小構成として EC2 + UserData での nginx を例示。
-  PlaceholderService:
+  # TODO: 競技者が維持する service の AWS リソースをここで定義してください。
+  # 例:
+  #   - EC2 + UserData で nginx 起動 (= 簡単、 SSM Session Manager で操作練習)
+  #   - Lambda + API Gateway (= cold start に注意)
+  #   - ECS Fargate (= タスク数を 1 に固定して Free Tier 内に収める工夫)
+  #   - App Runner (= source からビルド、 minScale=1 でアイドル課金あり)
+  #
+  # 下記は最小 placeholder。 実 service に置き換えてください。
+  PlaceholderTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub "${NamePrefix}-placeholder"
 
 Outputs:
   ServiceUrl:
-    Description: "metadata.endpoints[0].default.key が指す URL。 platform scoring が probe する。"
+    Description: "metadata.endpoints[0].default.key が指す URL。 platform scoring が 1 分毎に probe する。"
     Value: "https://example.com/__REPLACE_WITH_REAL_URL__"
   NamePrefix:
     Description: "Deploy 時に渡された prefix (echo)。"

--- a/.claude/templates/problems/uptime-multi/metadata.json
+++ b/.claude/templates/problems/uptime-multi/metadata.json
@@ -9,7 +9,7 @@
   "estimatedDuration": "60〜90 分",
   "shortDescription": "N slot を全部生存させ続ける uptime-multi 採点の Battle skeleton。",
   "description": "deploy 後に複数 endpoint が払い出される。 1 分毎に platform が全 slot を probe し、 **全部 OK** なら pointsAllOk 加算、 1 つでも fail なら failurePenalty。\\n\\n典型用途: 「複数 service の同時稼働」 が必要な Battle (= microservice 監視 / 3-tier app 等)。 1 つでも倒すと点が伸びないため、 攻撃側に「どこを倒すか」 の戦略が出る。",
-  "tags": ["__TAG__"],
+  "tags": ["sample", "battle"],
   "exposedPorts": [
     { "port": 80, "name": "frontend (HTTP)" },
     { "port": 8080, "name": "api (HTTP)" }

--- a/infrastructure/test/scripts/scaffolds-validate.test.ts
+++ b/infrastructure/test/scripts/scaffolds-validate.test.ts
@@ -1,0 +1,74 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import Ajv2020 from "ajv";
+import addFormats from "ajv-formats";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Issue #951 sub #1: `.claude/templates/problems/<kind>/metadata.json` の 5 種 scaffold が
+ * `__PROBLEM_ID__` / `__PROBLEM_NAME__` を CLI が置換した後、 `problems/SCHEMA.json` に
+ * 通ることを保証する。
+ *
+ * `scripts/tenkacloud-problem.ts create` が安全に動く前提を守る。 scaffold は新規問題作者の
+ * 最初の入口なので、 invalid scaffold = onboarding 0 秒で詰む状態。 ここで pin する。
+ */
+
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
+const TEMPLATES_ROOT = join(REPO_ROOT, ".claude/templates/problems");
+const SCHEMA_PATH = join(REPO_ROOT, "problems/SCHEMA.json");
+
+function applyPlaceholders(content: string, problemId: string): string {
+  const titleCase = problemId
+    .split("-")
+    .map((s) => (s.length > 0 ? s[0]?.toUpperCase() + s.slice(1) : ""))
+    .join(" ");
+  return content.replaceAll("__PROBLEM_ID__", problemId).replaceAll("__PROBLEM_NAME__", titleCase);
+}
+
+function listKinds(): readonly string[] {
+  return readdirSync(TEMPLATES_ROOT)
+    .filter((entry) => {
+      const full = join(TEMPLATES_ROOT, entry);
+      try {
+        return statSync(full).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+describe("Problem scaffold templates", () => {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  const kinds = listKinds();
+
+  it("5 種の builtin kind の scaffold ディレクトリがすべて存在するべき", () => {
+    const expected = ["attack-detection", "flag", "phased-polling", "uptime-flat", "uptime-multi"];
+    expect(kinds).toEqual(expected);
+  });
+
+  for (const kind of kinds) {
+    it(`${kind}/metadata.json は CLI 置換後 SCHEMA.json に通るべき`, () => {
+      const raw = readFileSync(join(TEMPLATES_ROOT, kind, "metadata.json"), "utf8");
+      const substituted = applyPlaceholders(raw, "scaffold-smoke-test");
+      const json = JSON.parse(substituted);
+      const ok = validate(json);
+      if (!ok) {
+        const errors = (validate.errors ?? [])
+          .map((e) => `  ${e.instancePath} ${e.message}`)
+          .join("\n");
+        throw new Error(`scaffold ${kind} failed SCHEMA validation:\n${errors}`);
+      }
+      expect(ok).toBe(true);
+    });
+
+    it(`${kind}/template.yaml が存在するべき`, () => {
+      const path = join(TEMPLATES_ROOT, kind, "template.yaml");
+      expect(() => readFileSync(path, "utf8")).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

epic #952 / #951 sub #1: 新規問題作者が \`bun run scripts/tenkacloud-problem.ts create\` 直後に **\`make validate-problems\` で OK が返る完成度** に scaffold を引き上げる。

旧 scaffold は \`tags: ["__TAG__"]\` / \`port: 0\` で初手から SCHEMA 違反 (= onboarding 0 秒で詰む状態)。 これを **5 kind 全部で valid な「埋まった例」** に置き換える。

## 実装

| Kind | 変更 |
| --- | --- |
| \`flag/\` | tags kebab-case 化、 hints を v2 (\`{id, content, penalty}\`) で 2 段付与、 \`learningGoals\` / \`description\` を埋まった例に。 \`template.yaml\` に HintParameter + FlagParameterPath Output を追加し競技者の CLI 練習材料に |
| \`uptime-flat/\` | **旧 scaffold が誤って \`intervalMinutes\` / \`probe\` key (= SCHEMA に存在しない) を使っていたのを修正**。 正本の \`endpoints[]\` 形式 (\`{slot, path, expectStatus}\`) に。 hints v2 / learningGoals / exposedPorts を充実化。 \`template.yaml\` に EC2/Lambda/ECS/App Runner の選択肢コメント |
| \`attack-detection/\` | \`__TAG__\` placeholder を kebab-case 値 (\`["sample", "security"]\`) に差替 |
| \`uptime-multi/\` | 同上 (\`["sample", "battle"]\`) |
| \`phased-polling/\` | 同上 (\`["sample", "battle"]\`) |

**新規 regression test**: \`infrastructure/test/scripts/scaffolds-validate.test.ts\`
- 5 kind 全 scaffold が CLI placeholder 置換 (= \`__PROBLEM_ID__\` → 実 id) 後 \`problems/SCHEMA.json\` に通ることを pin
- 11 tests (5 kind × (metadata 検証 + template 存在) + 「5 kind 揃ってる」 guard)
- scaffold 起点で regression が出たら CI が止める

## Regression 分析

- **既存問題への影響なし**: 変更したのは \`.claude/templates/problems/\` 配下のみ。 \`problems/\` 配下の実問題 (= hello-world / hello-world-battle / security-battle-royale 等) には触れていない
- **\`uptime-flat\` scaffold の SCHEMA 修正**: 旧 scaffold で \`create\` した既存問題があれば、 そちらは引き続き旧形式で動作する (= scaffold は新規生成時のみ参照される)。 ただし作者が \`create\` 後に旧 scaffold をそのまま deploy しようとすると validate-problems で落ちていたはず (= 元々 invalid だった)
- **CLI 互換**: \`tenkacloud-problem.ts create <id> --kind <kind>\` の signature 変化なし

## 物理影響

- UPDATE: \`.claude/templates/problems/{flag,uptime-flat,attack-detection,uptime-multi,phased-polling}/metadata.json\` (= scaffold の中身、 dev 時のみ参照)
- UPDATE: \`.claude/templates/problems/{flag,uptime-flat}/template.yaml\` (= 同上)
- CREATE: \`infrastructure/test/scripts/scaffolds-validate.test.ts\` (= CI 増)
- CFn / AWS: NO-OP (= 設定ファイル変更のみ)

## Test plan

- [x] \`bun run --filter @TenkaCloud/infrastructure test -- scaffolds-validate\` — 11/11 passed
- [x] \`bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>\` を 5 kind 全部で実行 → \`make validate-problems\` がすべて OK
- [x] \`make harness\` — no findings
- [x] \`bun run lint:format\` — clean
- [x] \`make before-commit\` (= pre-commit hook 経由) — pass

## Next steps for #951

- [ ] sub #2: cfn-lint port を \`make validate-problems\` に統合 (CFn template の壊れを実 deploy 前に検出)
- [ ] sub #3: scoring dry-run CLI (uptime / phased / attack-detection を mock データで回す)
- [ ] sub #4: \`make deploy-problem <id>\` の差分 update path
- [ ] sub #5: admin-console に \`/problems/:problemId/health\` view

Relates #951 sub #1
Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)