### PR TITLE
feat(#951): scoring dry-run CLI (flag + uptime-flat 対応)

### DIFF
--- a/infrastructure/test/scripts/scoring-dry-run.test.ts
+++ b/infrastructure/test/scripts/scoring-dry-run.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { runDryRun } from "../../../scripts/tenkacloud-problem";
+
+/**
+ * Issue #951 sub #3: scoring dry-run CLI が local で正しく score を算出することを保証する。
+ * 既存問題 (hello-world / hello-world-battle / security-battle-royale) に対して、 各
+ * kind が想定通りの earned points を返すことを観察する。
+ */
+
+describe("scoring dry-run (#951 sub #3)", () => {
+  it("flag kind: 不正解で earned=0 すべき", () => {
+    const r = runDryRun({ problemId: "hello-world", submitted: "wrong" });
+    expect(r.ok).toBe(true);
+    expect(r.summary).toContain("不正解");
+    expect(r.summary).toContain("earned=0");
+  });
+
+  it("flag kind: hint 開示は penalty を引くべき (template に静的 Value が無いケースは expected null)", () => {
+    // hello-world は !Sub なので extractFlag は null を返す → submitted との一致は常に false
+    const r = runDryRun({ problemId: "hello-world", submitted: "anything", revealHints: 1 });
+    expect(r.ok).toBe(true);
+    const linesText = r.lines.join("\n");
+    expect(linesText).toContain("hintsRevealed:  1");
+  });
+
+  it("uptime-flat kind: 全 success cycles で `cycles × endpoints × pointsPerSuccess` 点", () => {
+    // hello-world-battle: 2 endpoints, 100 pt/success, failurePenalty=0
+    const r = runDryRun({ problemId: "hello-world-battle", cycles: 5, pattern: "sssss" });
+    expect(r.ok).toBe(true);
+    // 5 cycles × 2 endpoints × 100 pt = 1000
+    expect(r.summary).toContain("earned=1000");
+  });
+
+  it("uptime-flat kind: 部分 fail の cycles で earned が下がるべき", () => {
+    const r = runDryRun({ problemId: "hello-world-battle", cycles: 4, pattern: "ssff" });
+    expect(r.ok).toBe(true);
+    // 2 success cycles × 2 endpoints × 100 = 400 (failurePenalty=0)
+    expect(r.summary).toContain("earned=400");
+  });
+
+  it("uptime-flat kind: cycles=デフォルト=10 / pattern=デフォルト=all success", () => {
+    const r = runDryRun({ problemId: "hello-world-battle" });
+    expect(r.ok).toBe(true);
+    // 10 × 2 × 100 = 2000
+    expect(r.summary).toContain("earned=2000");
+  });
+
+  it("uptime-multi kind: 未対応として ok=true で「未対応」を含むべき", () => {
+    const r = runDryRun({ problemId: "security-battle-royale" });
+    expect(r.ok).toBe(true);
+    expect(r.summary).toContain("unsupported");
+  });
+
+  it("存在しない問題 id で ok=false を返すべき", () => {
+    const r = runDryRun({ problemId: "this-does-not-exist" });
+    expect(r.ok).toBe(false);
+    expect(r.summary).toContain("not found");
+  });
+});

--- a/scripts/tenkacloud-problem.ts
+++ b/scripts/tenkacloud-problem.ts
@@ -49,10 +49,18 @@ const KIND_TO_DEFAULT_CATEGORY: Record<Kind, "Battle" | "Challenge"> = {
 };
 
 interface CliArgs {
-  command: "create" | "validate" | "list-kinds" | "help";
+  command: "create" | "validate" | "list-kinds" | "dry-run" | "help";
   problemId?: string;
   kind?: Kind;
   category?: "Battle" | "Challenge";
+  /** dry-run --submitted <flag> (flag kind) */
+  submitted?: string;
+  /** dry-run --reveal-hints <count> (flag / uptime kinds) */
+  revealHints?: number;
+  /** dry-run --cycles <N> (uptime-flat kind) */
+  cycles?: number;
+  /** dry-run --pattern <s|f sequence> (uptime-flat kind, e.g. "ssfsf") */
+  pattern?: string;
 }
 
 function parseArgs(argv: readonly string[]): CliArgs {
@@ -61,8 +69,10 @@ function parseArgs(argv: readonly string[]): CliArgs {
   }
   const command = argv[0];
   if (command === "list-kinds") return { command };
-  if (command !== "create" && command !== "validate") {
-    throw new Error(`unknown command: ${command}. Try 'help', 'list-kinds', 'create', 'validate'.`);
+  if (command !== "create" && command !== "validate" && command !== "dry-run") {
+    throw new Error(
+      `unknown command: ${command}. Try 'help', 'list-kinds', 'create', 'validate', 'dry-run'.`,
+    );
   }
   const problemId = argv[1];
   if (!problemId) throw new Error(`${command} requires <problemId>`);
@@ -83,6 +93,30 @@ function parseArgs(argv: readonly string[]): CliArgs {
       }
       result.category = v;
       i += 1;
+    } else if (flag === "--submitted") {
+      result.submitted = argv[i + 1] ?? "";
+      i += 1;
+    } else if (flag === "--reveal-hints") {
+      const n = Number(argv[i + 1]);
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error("--reveal-hints must be a non-negative integer");
+      }
+      result.revealHints = n;
+      i += 1;
+    } else if (flag === "--cycles") {
+      const n = Number(argv[i + 1]);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error("--cycles must be a positive integer");
+      }
+      result.cycles = n;
+      i += 1;
+    } else if (flag === "--pattern") {
+      const v = argv[i + 1];
+      if (typeof v !== "string" || !/^[sf]+$/.test(v)) {
+        throw new Error("--pattern must be a non-empty string of 's' / 'f' (e.g. 'ssfsf')");
+      }
+      result.pattern = v;
+      i += 1;
     } else {
       throw new Error(`unknown flag: ${flag}`);
     }
@@ -96,6 +130,8 @@ function printHelp(): void {
 Usage:
   bun run scripts/tenkacloud-problem.ts create <id> --kind <kind> [--category Battle|Challenge]
   bun run scripts/tenkacloud-problem.ts validate <id>
+  bun run scripts/tenkacloud-problem.ts dry-run <id> [--submitted <flag>] [--reveal-hints N]
+                                                    [--cycles N] [--pattern <s|f sequence>]
   bun run scripts/tenkacloud-problem.ts list-kinds
 
 Available kinds:  ${KINDS.join(", ")}
@@ -104,6 +140,8 @@ Examples:
   bun run scripts/tenkacloud-problem.ts create my-battle --kind uptime-multi
   bun run scripts/tenkacloud-problem.ts create hello-flag --kind flag
   bun run scripts/tenkacloud-problem.ts validate microservice-migration-battle
+  bun run scripts/tenkacloud-problem.ts dry-run hello-world --submitted "actual-flag-value"
+  bun run scripts/tenkacloud-problem.ts dry-run hello-world-battle --cycles 60 --pattern "ssssffssssss"
 
 See also:
   docs/problems/AUTHORING.html  — 30 分 onboarding guide
@@ -285,6 +323,172 @@ export function runValidate(problemId: string): ValidateResult {
   return { ok: errors.length === 0, errors };
 }
 
+interface DryRunResult {
+  readonly ok: boolean;
+  readonly summary: string;
+  readonly lines: readonly string[];
+}
+
+/**
+ * 問題の `metadata.scoring` を読んで、 与えられた input に対する得点を local 計算する。
+ * 実 deploy 不要 (= scoring engine の Lambda 経路を回さない) で採点ロジックの妥当性を
+ * 確認できる。 #951 sub #3。
+ *
+ * 対応 kind:
+ *   - flag: --submitted <flag> + --reveal-hints <n>
+ *   - uptime-flat: --cycles <N> + --pattern <s/f...> + --reveal-hints <n>
+ *   - 他 kind: 「未対応」 を明示して exit 0 (= dry-run の存在自体は壊さない)
+ */
+export function runDryRun(args: {
+  problemId: string;
+  submitted?: string;
+  revealHints?: number;
+  cycles?: number;
+  pattern?: string;
+}): DryRunResult {
+  const dir = findProblemDir(args.problemId);
+  if (!dir) {
+    return {
+      ok: false,
+      summary: `Problem dir not found for id="${args.problemId}"`,
+      lines: [],
+    };
+  }
+  const metaPath = join(dir, "metadata.json");
+  if (!existsSync(metaPath)) {
+    return { ok: false, summary: "metadata.json not found", lines: [] };
+  }
+  const meta = JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>;
+  const scoring = (meta.scoring ?? {}) as Record<string, unknown>;
+  const kind = String(scoring.kind ?? "");
+  const lines: string[] = [];
+
+  if (kind === "flag") {
+    const expectedKey = scoring.flagOutputKey;
+    const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+    const templatePath = join(dir, cfnTemplate);
+    if (!existsSync(templatePath)) {
+      return { ok: false, summary: `template ${cfnTemplate} not found`, lines };
+    }
+    const yaml = readFileSync(templatePath, "utf8");
+    const expectedFlag = extractFlagFromTemplate(yaml, String(expectedKey));
+    const points = Number(scoring.points ?? 0);
+    const submitted = args.submitted ?? "";
+    const correct = expectedFlag !== null && submitted === expectedFlag;
+    const hintsRevealed = args.revealHints ?? 0;
+    const hints = Array.isArray(scoring.hints) ? scoring.hints : [];
+    let penaltyTotal = 0;
+    for (let i = 0; i < Math.min(hintsRevealed, hints.length); i += 1) {
+      const h = hints[i] as Record<string, unknown> | string;
+      const p = typeof h === "object" && h !== null ? Number(h.penalty ?? 0) : 0;
+      penaltyTotal += p;
+    }
+    const earned = correct ? Math.max(0, points - penaltyTotal) : 0;
+
+    lines.push(`kind:           flag`);
+    lines.push(`flagOutputKey:  ${String(expectedKey)}`);
+    lines.push(
+      `expectedFlag:   ${expectedFlag === null ? "(could not extract from template — set Value directly to test)" : expectedFlag}`,
+    );
+    lines.push(`submitted:      ${submitted || "(empty)"}`);
+    lines.push(`correct:        ${correct ? "yes" : "no"}`);
+    lines.push(`baseline:       ${points} pt`);
+    lines.push(`hintsRevealed:  ${hintsRevealed} (penalty -${penaltyTotal})`);
+    lines.push(`earned:         ${earned} pt`);
+
+    return {
+      ok: true,
+      summary: `flag dry-run: ${correct ? "正解" : "不正解"} → earned=${earned}`,
+      lines,
+    };
+  }
+
+  if (kind === "uptime-flat" || kind === "uptime") {
+    const pointsPerSuccess = Number(scoring.pointsPerSuccess ?? 0);
+    const failurePenalty = Number(scoring.failurePenalty ?? 0);
+    const endpointsInScoring = Array.isArray(scoring.endpoints) ? scoring.endpoints : [];
+    const endpointCount = endpointsInScoring.length;
+    if (endpointCount === 0) {
+      return {
+        ok: false,
+        summary: "uptime-flat metadata has no scoring.endpoints; cannot dry-run",
+        lines,
+      };
+    }
+
+    const cycles = args.cycles ?? 10;
+    const pattern = args.pattern ?? "s".repeat(cycles);
+    if (pattern.length !== cycles) {
+      lines.push(
+        `note: pattern length (${pattern.length}) !== cycles (${cycles}). Pattern を cycles に揃えるか、 cycles を pattern.length に合わせてください。`,
+      );
+    }
+
+    let score = 0;
+    let okCount = 0;
+    let failCount = 0;
+    for (let i = 0; i < cycles; i += 1) {
+      const sym = pattern[i % pattern.length];
+      if (sym === "s") {
+        score += pointsPerSuccess * endpointCount;
+        okCount += 1;
+      } else {
+        score -= failurePenalty * endpointCount;
+        failCount += 1;
+      }
+    }
+
+    const hintsRevealed = args.revealHints ?? 0;
+    const hints = Array.isArray(scoring.hints) ? scoring.hints : [];
+    let penaltyTotal = 0;
+    for (let i = 0; i < Math.min(hintsRevealed, hints.length); i += 1) {
+      const h = hints[i] as Record<string, unknown> | string;
+      const p = typeof h === "object" && h !== null ? Number(h.penalty ?? 0) : 0;
+      penaltyTotal += p;
+    }
+    const earned = Math.max(0, score - penaltyTotal);
+
+    lines.push(`kind:             ${kind}`);
+    lines.push(`endpoints:        ${endpointCount}`);
+    lines.push(`pointsPerSuccess: ${pointsPerSuccess}`);
+    lines.push(`failurePenalty:   ${failurePenalty}`);
+    lines.push(`cycles:           ${cycles}`);
+    lines.push(`pattern:          ${pattern} (s=success, f=fail)`);
+    lines.push(`okCycles:         ${okCount}`);
+    lines.push(`failCycles:       ${failCount}`);
+    lines.push(`subtotal:         ${score} pt`);
+    lines.push(`hintsRevealed:    ${hintsRevealed} (penalty -${penaltyTotal})`);
+    lines.push(`earned:           ${earned} pt`);
+
+    return {
+      ok: true,
+      summary: `${kind} dry-run: ${cycles} cycles → earned=${earned}`,
+      lines,
+    };
+  }
+
+  // 他 kind は未対応 (= ok=true で「未対応」 を明示)
+  lines.push(`kind="${kind}" の dry-run は未対応です。 #951 sub #3 で順次実装予定:`);
+  lines.push(`  - uptime-multi: --cycles N --pattern <ss|sf|fs|ff> (slot 数 2 想定)`);
+  lines.push(`  - phased-polling: phases[].afterMinutes ごとの rule 切替を simulate`);
+  lines.push(`  - attack-detection: counter delta から得点`);
+  return { ok: true, summary: `kind=${kind} dry-run unsupported`, lines };
+}
+
+/**
+ * CFn YAML から Output `key:` 配下の `Value:` を抽出する素朴 parser。
+ * `Value: "TC{...}"` / `Value: !GetAtt X.Value` の前者だけハンドルする。
+ * 後者は実 deploy しないと値が解決しないため null を返す。
+ */
+function extractFlagFromTemplate(yaml: string, key: string): string | null {
+  const re = new RegExp(`${key}:[\\s\\S]*?Value:\\s*("[^"\\n]+"|'[^'\\n]+'|[^\\n!]+)\\n`, "m");
+  const m = yaml.match(re);
+  if (!m || !m[1]) return null;
+  const raw = m[1].trim();
+  if (raw.startsWith("!")) return null;
+  return raw.replace(/^["']|["']$/g, "");
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   switch (args.command) {
@@ -317,6 +521,22 @@ async function main(): Promise<void> {
         for (const e of r.errors) console.error(`  - ${e}`);
         process.exit(1);
       }
+      return;
+    }
+    case "dry-run": {
+      const r = runDryRun({
+        problemId: args.problemId ?? "",
+        ...(args.submitted !== undefined ? { submitted: args.submitted } : {}),
+        ...(args.revealHints !== undefined ? { revealHints: args.revealHints } : {}),
+        ...(args.cycles !== undefined ? { cycles: args.cycles } : {}),
+        ...(args.pattern !== undefined ? { pattern: args.pattern } : {}),
+      });
+      if (!r.ok) {
+        console.error(`NG ${r.summary}`);
+        process.exit(1);
+      }
+      for (const line of r.lines) console.log(line);
+      console.log(`\nsummary: ${r.summary}`);
       return;
     }
     default: {


### PR DESCRIPTION
## Summary

epic #952 / #951 sub #3: **実 deploy せずに採点ロジックを local で確認可能に**。

問題作者が新規 scoring config を書いたとき、 旧来は実 AWS deploy + 実 probe (= 数分待ち) しないと「hint penalty 引きすぎ / 部分 fail でも score が伸びる / 想定外 pattern」 等の挙動を確認できなかった。 dry-run で mock 入力に対する得点を即座に計算できるようにする。

## 実装

新規 CLI subcommand: \`bun run scripts/tenkacloud-problem.ts dry-run <id> [...flags]\`

| Kind | サポート | flags |
| --- | --- | --- |
| \`flag\` | ✅ | \`--submitted <flag>\` \`--reveal-hints <n>\` |
| \`uptime-flat\` / \`uptime\` | ✅ | \`--cycles <N>\` \`--pattern <s/f sequence>\` \`--reveal-hints <n>\` |
| \`uptime-multi\` | ⏳ 未対応 (= ok=true で明示) | — |
| \`phased-polling\` | ⏳ 未対応 | — |
| \`attack-detection\` | ⏳ 未対応 | — |

flag kind:
- \`template.yaml\` Outputs から static Value を抽出 (= \`!Sub\` / \`!GetAtt\` 経由は null を返す → submitted との一致判定は常に false になる、 静的 Value のみ自動判定可能)
- hints v2 (= \`{id, content, penalty}\` object) の penalty を集計

uptime-flat / uptime kind:
- 累計 = endpoints 数 × \`pointsPerSuccess\` × 成功 cycle 数 - \`failurePenalty\` × 失敗 cycle 数
- pattern は \`s\` (success) / \`f\` (fail) の文字列で 1 文字 = 1 cycle
- 既定: \`cycles=10\`, \`pattern="ssssssssss"\` (= 全 success)

新規 test \`scoring-dry-run.test.ts\` (7 cases):
- flag 不正解 / hint reveal
- uptime-flat: 全 success / 部分 fail / 既定値
- 未対応 kind の挙動
- 存在しない問題 id の error 経路

## 使用例

\`\`\`bash
# flag 問題で「正しい flag」 を出した場合の earned を確認
bun run scripts/tenkacloud-problem.ts dry-run hello-world --submitted "TC{actual-flag}"

# uptime-flat で 60 cycle 中 6 cycle 連続 down した場合の earned を確認
bun run scripts/tenkacloud-problem.ts dry-run hello-world-battle --cycles 60 --pattern "ssssffssssssssssssssssssssssssssssssssssssssssssssssssssssss"
\`\`\`

## Regression 分析

- 既存 \`create\` / \`validate\` / \`list-kinds\` の signature / 挙動は不変
- 既存 problems の動作には影響なし (= dry-run は read-only)
- \`runDryRun()\` を export しているので他 script / test から再利用可能

## 物理影響

- UPDATE: \`scripts/tenkacloud-problem.ts\` (+ ~150 行)
- CREATE: \`infrastructure/test/scripts/scoring-dry-run.test.ts\` (7 tests)
- CFn / AWS: NO-OP

## Test plan

- [x] \`bun run --filter @TenkaCloud/infrastructure test -- scoring-dry-run\` — 7/7 passed
- [x] \`bun run scripts/tenkacloud-problem.ts dry-run hello-world --submitted "wrong"\` → earned=0
- [x] \`bun run scripts/tenkacloud-problem.ts dry-run hello-world-battle --cycles 10 --pattern "ssssffssss"\` → earned=1600
- [x] \`bun run scripts/tenkacloud-problem.ts dry-run security-battle-royale\` → "uptime-multi unsupported"
- [x] \`make harness\` — no findings
- [x] \`make before-commit\` (= pre-commit hook 経由) — pass

## Next steps for #951

- [ ] sub #3 extension: uptime-multi / phased-polling / attack-detection の dry-run
- [ ] sub #4: \`make deploy-problem <id>\` の差分 update path (= CodeBuild pipeline 経由でない直接更新、 user 担当)
- [ ] sub #5: admin-console \`/problems/:problemId/health\` view (= backend API + UI)

Relates #951 sub #3
Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)