### PR TITLE
feat(#952): AI 無人運用の足場 — read-only ops CLI + Codex CLI 併用ガイド

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,22 @@ CI (`.github/workflows/ci.yml`) は `make install_ci` → textlint → format ch
 
 加えて TenkaCloud 関係なく使える共通 skill (`/review`、`/security-review`、`/simplify`、`/init` 等) は Claude Code 本体側に同梱されている。
 
+## Codex CLI との併用 (= 総力戦)
+
+OpenAI の Codex CLI も本 repo を AGENTS.md (本ファイル) 経由で読み込める。 並列に走らせて作業分担する典型パターンは次の通り。
+
+- **Claude Code** が `apps/*` と `scripts/*` の実装を主導 (= 本ファイルの「役割分担」通り)
+- **Codex CLI** で別ブランチを切り、 cross-cutting concern (= naming refactor / dead code 削除 / 同型 helper の抽出) を並行で進める
+- 結果は別々の PR にし、 conflict は user (= 最終 reviewer) が手で潰す
+
+Codex CLI を起動する前に次を確認する。
+
+1. `make harness` が通る状態であること (= invariant 違反のある branch を渡さない)
+2. 作業範囲を本ファイルの「役割分担」と「禁止事項」に従わせること (= CDK を弄らせない / `rm` 等を実行させない)
+3. Codex の出力 PR にも `## Regression 分析` / `## 物理影響` セクションを書かせること
+
+Codex CLI 専用の skill / config は持たない (= AGENTS.md 1 つで両者をガイドする方針)。 Claude Code 側で `.claude/skills/*` を使う subcommand は Codex からは見えないので、 Codex には slash command (`/<skill>`) を要求しない普通の自然言語タスクを与えること。
+
 ## ブランチと PR
 
 - **マージ済みブランチに push しない**。PR を出す前に必ず `gh pr view --json state` で state を確認。`MERGED` / `CLOSED` なら新ブランチを切る。

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ export JSII_DEPRECATED := quiet
         env-check synth check-synth diff bootstrap \
         deploy deploy-control-plane deploy-bootstrap destroy \
         deploy-battles destroy-battles \
-        lite-up lite-down lite-status lite-portal-url lite-console-url
+        lite-up lite-down lite-status lite-portal-url lite-console-url \
+        ops-health
 
 help:
 	@awk '/^# =====/ {gsub(/^# ===== | =====$$/, ""); printf "\n%s\n", $$0} \
@@ -159,3 +160,9 @@ lite-down:         ; bun run scripts/tenkacloud-lite.ts down
 lite-status:       ; bun run scripts/tenkacloud-lite.ts status
 lite-portal-url:   ; bun run scripts/tenkacloud-lite.ts portal-url
 lite-console-url:  ; bun run scripts/tenkacloud-lite.ts console-url
+
+# ===== Ops observation (read-only CLI for AI / operator) =====
+# Issue #952: AI 無人運用の足場。 全 TenkaCloud stack の状態を 1 コマンドで観察する
+# read-only CLI。 exit code は 0=全 healthy / 1=in_progress あり / 2=failed あり。
+# 外部 cron / AI agent が spawn して platform 状態を判断する経路。
+ops-health:        ; bun run scripts/tenkacloud-ops.ts health

--- a/infrastructure/test/scripts/tenkacloud-ops.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-ops.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CliIO,
+  main,
+  runHealth,
+  type SpawnCaptureResult,
+} from "../../../scripts/tenkacloud-ops";
+
+/**
+ * Issue #952: tenkacloud-ops CLI の健全性 / 異常検出を pin する。
+ *
+ * AI 無人運用の足場として、 「全 stack 健全 / in-progress / failed」 の 3 状態を
+ * exit code で区別できることを確認する (= 0 / 1 / 2)。 これにより外部 cron / agent が
+ * stack 状態を 1 度の spawn で判断できる。
+ */
+
+function makeIO(spawnResults: SpawnCaptureResult[]): {
+  readonly io: CliIO;
+  readonly stdout: string[];
+  readonly stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let idx = 0;
+  const io: CliIO = {
+    stdout: (t) => stdout.push(t),
+    stderr: (t) => stderr.push(t),
+    spawnCapture: async () => spawnResults[idx++] ?? { code: 1, stdout: "", stderr: "no more" },
+  };
+  return { io, stdout, stderr };
+}
+
+describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
+  it("ヘルプ表示は exit 0 で usage を返すべき", async () => {
+    const { io, stdout } = makeIO([]);
+    const code = await main(["help"], io);
+    expect(code).toBe(0);
+    expect(stdout.join("")).toContain("tenkacloud ops");
+    expect(stdout.join("")).toContain("Usage:");
+  });
+
+  it("引数なしは help を表示するべき", async () => {
+    const { io, stdout } = makeIO([]);
+    const code = await main([], io);
+    expect(code).toBe(0);
+    expect(stdout.join("")).toContain("Usage:");
+  });
+
+  it("未知 subcommand は exit 1 でエラーメッセージを stderr に出すべき", async () => {
+    const { io, stderr } = makeIO([]);
+    const code = await main(["bogus-cmd"], io);
+    expect(code).toBe(1);
+    expect(stderr.join("")).toContain("unknown command");
+  });
+
+  it("health: 全 stack 健全なら exit 0 すべき", async () => {
+    const { io, stdout } = makeIO([
+      {
+        code: 0,
+        stdout: JSON.stringify({
+          StackSummaries: [
+            { StackName: "tenkacloud-control-plane", StackStatus: "CREATE_COMPLETE" },
+            { StackName: "tenkacloud-lite", StackStatus: "UPDATE_COMPLETE" },
+            { StackName: "tc-hello-world-demo-team", StackStatus: "CREATE_COMPLETE" },
+            { StackName: "other-stack", StackStatus: "CREATE_COMPLETE" },
+          ],
+        }),
+        stderr: "",
+      },
+    ]);
+    const code = await runHealth(io);
+    expect(code).toBe(0);
+    const out = stdout.join("");
+    expect(out).toContain("3 total");
+    expect(out).toContain("HEALTHY (3)");
+    expect(out).not.toContain("other-stack"); // prefix 違いは除外
+  });
+
+  it("health: in_progress の stack があれば exit 1 (= soft warning)", async () => {
+    const { io } = makeIO([
+      {
+        code: 0,
+        stdout: JSON.stringify({
+          StackSummaries: [
+            { StackName: "tenkacloud-control-plane", StackStatus: "CREATE_COMPLETE" },
+            { StackName: "tenkacloud-lite", StackStatus: "UPDATE_IN_PROGRESS" },
+          ],
+        }),
+        stderr: "",
+      },
+    ]);
+    const code = await runHealth(io);
+    expect(code).toBe(1);
+  });
+
+  it("health: ROLLBACK / FAILED があれば exit 2 (= hard fail)", async () => {
+    const { io } = makeIO([
+      {
+        code: 0,
+        stdout: JSON.stringify({
+          StackSummaries: [
+            { StackName: "tenkacloud-control-plane", StackStatus: "CREATE_COMPLETE" },
+            { StackName: "tenkacloud-lite", StackStatus: "ROLLBACK_COMPLETE" },
+          ],
+        }),
+        stderr: "",
+      },
+    ]);
+    const code = await runHealth(io);
+    expect(code).toBe(2);
+  });
+
+  it("health: TenkaCloud stack 0 件なら exit 0 でその旨表示", async () => {
+    const { io, stdout } = makeIO([
+      { code: 0, stdout: JSON.stringify({ StackSummaries: [] }), stderr: "" },
+    ]);
+    const code = await runHealth(io);
+    expect(code).toBe(0);
+    expect(stdout.join("")).toContain("no TenkaCloud stacks");
+  });
+
+  it("health: aws CLI が失敗したら non-zero で stderr に message", async () => {
+    const { io, stderr } = makeIO([{ code: 254, stdout: "", stderr: "credentials expired" }]);
+    const code = await runHealth(io);
+    expect(code).toBe(254);
+    expect(stderr.join("")).toContain("credentials expired");
+  });
+
+  it("health --region us-east-1 が aws CLI 引数に渡るべき", async () => {
+    let capturedArgs: readonly string[] | null = null;
+    const io: CliIO = {
+      stdout: () => {},
+      stderr: () => {},
+      spawnCapture: async (_cmd, args) => {
+        capturedArgs = args;
+        return { code: 0, stdout: JSON.stringify({ StackSummaries: [] }), stderr: "" };
+      },
+    };
+    await runHealth(io, "us-east-1");
+    expect(capturedArgs).not.toBeNull();
+    const argsString = (capturedArgs ?? []).join(" ");
+    expect(argsString).toContain("--region us-east-1");
+  });
+});

--- a/scripts/tenkacloud-ops.ts
+++ b/scripts/tenkacloud-ops.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Issue #952 (epic): TenkaCloud platform の operational state を 1 コマンドで観察する CLI。
+ *
+ * AI 無人運用の最初の一歩。 操作者 (= 大会主催) や AI agent が「いま platform は健全か」 を
+ * 知るための **read-only** subcommand 群。 mutate 操作 (deploy / destroy / rotate 等) は
+ * 既存の make target に閉じ込め、 本 CLI は観察に専念する (= 安全な automation 経路を作る)。
+ *
+ * Usage:
+ *   bun run scripts/tenkacloud-ops.ts health [--region <r>]
+ *   bun run scripts/tenkacloud-ops.ts help
+ *
+ * 設計判断:
+ *   - aws CLI を spawn (= AWS SDK の依存追加を避ける、 install.sh が aws CLI を要求済)
+ *   - test 容易性のため `runHealth` を export し spawnCapture を injectable に
+ *   - mutate 操作は持たない (= AI agent が誤って destroy する事故を避ける)
+ *
+ * 想定 stack 名 prefix:
+ *   - SaaS mode: serverless-saas-ref-arch-* / tenkacloud-control-plane / tenkacloud-* / tc-*
+ *   - Lite mode: tenkacloud-lite / tenkacloud-lite-problem-deploy
+ *   - Problem deploy: tc-{problemSlug}-{teamSlug}
+ */
+
+import { spawn } from "node:child_process";
+
+const HELP_TEXT = `tenkacloud ops — TenkaCloud platform observation CLI (read-only)
+
+Usage:
+  bun run scripts/tenkacloud-ops.ts health [--region <r>]
+  bun run scripts/tenkacloud-ops.ts help
+
+Subcommands:
+  health   全 TenkaCloud stack の CFn StackStatus を 1 行ずつ表示
+  help     このヘルプ
+
+Examples:
+  bun run scripts/tenkacloud-ops.ts health
+  bun run scripts/tenkacloud-ops.ts health --region us-east-1
+
+See also:
+  make lite-status   (= Lite mode 専用の status、 scripts/tenkacloud-lite.ts)
+`;
+
+export interface SpawnCaptureResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export type SpawnCapture = (cmd: string, args: readonly string[]) => Promise<SpawnCaptureResult>;
+
+export interface CliIO {
+  readonly stdout: (text: string) => void;
+  readonly stderr: (text: string) => void;
+  readonly spawnCapture: SpawnCapture;
+}
+
+const TENKACLOUD_STACK_PREFIXES = ["tenkacloud-", "serverless-saas-ref-arch-", "tc-"] as const;
+
+interface CfnStackSummary {
+  readonly StackName: string;
+  readonly StackStatus: string;
+  readonly LastUpdatedTime?: string;
+  readonly CreationTime?: string;
+}
+
+/**
+ * `aws cloudformation list-stacks` を spawn して TenkaCloud 関連 stack の status を集める。
+ *
+ * stack filter:
+ *   - DELETE_COMPLETE は除外 (= ノイズ)
+ *   - 名前 prefix が tenkacloud-* / serverless-saas-ref-arch-* / tc-* のいずれか
+ */
+export async function runHealth(io: CliIO, region?: string): Promise<number> {
+  const args = [
+    "cloudformation",
+    "list-stacks",
+    "--stack-status-filter",
+    "CREATE_IN_PROGRESS",
+    "CREATE_FAILED",
+    "CREATE_COMPLETE",
+    "ROLLBACK_IN_PROGRESS",
+    "ROLLBACK_FAILED",
+    "ROLLBACK_COMPLETE",
+    "DELETE_IN_PROGRESS",
+    "DELETE_FAILED",
+    "UPDATE_IN_PROGRESS",
+    "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+    "UPDATE_COMPLETE",
+    "UPDATE_ROLLBACK_IN_PROGRESS",
+    "UPDATE_ROLLBACK_FAILED",
+    "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+    "UPDATE_ROLLBACK_COMPLETE",
+    "REVIEW_IN_PROGRESS",
+    "IMPORT_IN_PROGRESS",
+    "IMPORT_COMPLETE",
+    "IMPORT_ROLLBACK_IN_PROGRESS",
+    "IMPORT_ROLLBACK_FAILED",
+    "IMPORT_ROLLBACK_COMPLETE",
+    "--output",
+    "json",
+  ];
+  if (region) {
+    args.push("--region", region);
+  }
+
+  const result = await io.spawnCapture("aws", args);
+  if (result.code !== 0) {
+    io.stderr(`aws cloudformation list-stacks failed (exit ${result.code}):\n${result.stderr}`);
+    return result.code === 0 ? 1 : result.code;
+  }
+
+  let parsed: { StackSummaries?: CfnStackSummary[] };
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (e) {
+    io.stderr(`failed to parse aws output: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+
+  const all = parsed.StackSummaries ?? [];
+  const ours = all.filter((s) => TENKACLOUD_STACK_PREFIXES.some((p) => s.StackName.startsWith(p)));
+
+  if (ours.length === 0) {
+    io.stdout("(no TenkaCloud stacks found)\n");
+    return 0;
+  }
+
+  // 状態ごとに健全 / 注意 / 異常を分類
+  const healthy: CfnStackSummary[] = [];
+  const inProgress: CfnStackSummary[] = [];
+  const failed: CfnStackSummary[] = [];
+
+  for (const s of ours) {
+    if (s.StackStatus.includes("FAILED") || s.StackStatus.includes("ROLLBACK")) {
+      failed.push(s);
+    } else if (s.StackStatus.includes("IN_PROGRESS")) {
+      inProgress.push(s);
+    } else {
+      healthy.push(s);
+    }
+  }
+
+  const widest = ours.reduce((m, s) => Math.max(m, s.StackName.length), 0);
+  const summarize = (label: string, list: readonly CfnStackSummary[]): void => {
+    if (list.length === 0) return;
+    io.stdout(`\n${label} (${list.length})\n`);
+    for (const s of list) {
+      io.stdout(`  ${s.StackName.padEnd(widest)}  ${s.StackStatus}\n`);
+    }
+  };
+
+  io.stdout(`TenkaCloud stacks: ${ours.length} total (region=${region ?? "default"})\n`);
+  summarize("FAILED / ROLLBACK", failed);
+  summarize("IN_PROGRESS", inProgress);
+  summarize("HEALTHY", healthy);
+
+  // exit code: failed 1 件以上で 2、 in_progress のみで 1、 すべて healthy で 0
+  if (failed.length > 0) return 2;
+  if (inProgress.length > 0) return 1;
+  return 0;
+}
+
+function defaultSpawnCapture(): SpawnCapture {
+  return (cmd: string, args: readonly string[]) =>
+    new Promise<SpawnCaptureResult>((resolveSpawn) => {
+      const child = spawn(cmd, args as string[], { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.on("close", (code: number | null) => {
+        resolveSpawn({ code: code ?? 0, stdout, stderr });
+      });
+      child.on("error", (err: Error) => {
+        resolveSpawn({ code: 127, stdout: "", stderr: err.message });
+      });
+    });
+}
+
+export async function main(argv: readonly string[], ioOverride?: Partial<CliIO>): Promise<number> {
+  const io: CliIO = {
+    stdout: (t) => process.stdout.write(t),
+    stderr: (t) => process.stderr.write(t),
+    spawnCapture: defaultSpawnCapture(),
+    ...ioOverride,
+  };
+
+  if (argv.length === 0 || argv[0] === "help" || argv[0] === "--help" || argv[0] === "-h") {
+    io.stdout(HELP_TEXT);
+    return 0;
+  }
+
+  const command = argv[0];
+  if (command !== "health") {
+    io.stderr(`unknown command: ${command}. Try 'help' or 'health'.\n`);
+    return 1;
+  }
+
+  let region: string | undefined;
+  for (let i = 1; i < argv.length; i += 1) {
+    if (argv[i] === "--region") {
+      region = argv[i + 1];
+      i += 1;
+    } else {
+      io.stderr(`unknown flag: ${argv[i]}\n`);
+      return 1;
+    }
+  }
+
+  return await runHealth(io, region);
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary

epic #952 のうち **AI 無人運用** と **Codex CLI 併用** の柱に着手。 mutate を持たない read-only ops CLI を 1 本立てて、 外部 cron や AI agent が「いま platform は健全か」 を exit code 1 つで判断できるようにする。

## 実装

### \`scripts/tenkacloud-ops.ts\` (新規 read-only CLI)

\`\`\`bash
bun run scripts/tenkacloud-ops.ts health [--region <r>]
# または
make ops-health
\`\`\`

- subcommand \`health\`: 全 TenkaCloud stack (prefix \`tenkacloud-*\` / \`serverless-saas-ref-arch-*\` / \`tc-*\`) の CFn StackStatus を 1 コマンドで観察
- 状態を 3 分類 (healthy / in_progress / failed-or-rollback)
- exit code: **0** = 全 healthy、 **1** = in_progress あり (soft warning)、 **2** = failed あり (hard fail)
- mutate 操作は持たない (= AI agent が誤って destroy する事故を避ける)
- \`aws\` CLI を spawn する形 (= install.sh が既に \`aws\` CLI を要求済、 AWS SDK 依存を増やさない)
- \`spawnCapture\` を injectable にして AWS を呼ばずに単体テスト可能

### \`AGENTS.md\` に「Codex CLI との併用」 section を追加

OpenAI Codex CLI が本 repo を AGENTS.md 経由で読み込める前提を明文化し、 Claude Code と並列で動かす際の **役割分担** と **Codex に渡してはいけない範囲** (= CDK / \`rm\`) を pin した。 Codex CLI 専用の config / skill は持たない (= AGENTS.md 1 本で両者をガイド、 設定の重複を避ける)。

### 新規 test \`tenkacloud-ops.test.ts\` (9 cases)

- ヘルプ / 未知 subcommand
- 全 healthy で exit 0、 in_progress で exit 1、 failed / rollback で exit 2
- TenkaCloud stack 0 件のときの guard
- aws CLI 失敗時の伝播
- \`--region\` flag が aws CLI 引数に渡る

## 設計判断

- ops CLI は purely read-only (= 観察に専念)。 mutate は既存 make target に閉じ込める。 AI 無人運用は「観察 → 報告 → user 承認 → make target 起動」 の loop で構成し、 CLI 1 本で勝手に変更させないアーキを優先
- Codex CLI 専用の config を作らない判断は「設定の重複が技術負債になる」 という観察に基づく。 AGENTS.md は両者の共通入口になる

## Regression 分析

- 既存 \`scripts/*\` / \`apps/*\` / CDK には触れない (= 純粋追加)
- ops CLI は read-only なので AWS 側に副作用なし
- 既存 make target の signature / 挙動は不変

## 物理影響

- CREATE: \`scripts/tenkacloud-ops.ts\` (= ~220 行)
- CREATE: \`infrastructure/test/scripts/tenkacloud-ops.test.ts\` (= 9 tests)
- UPDATE: \`Makefile\` (+ \`ops-health\` target、 .PHONY 拡張)
- UPDATE: \`AGENTS.md\` (+ Codex CLI 併用 section)
- CFn / AWS: NO-OP

## Test plan

- [x] \`bun run --filter @TenkaCloud/infrastructure test -- tenkacloud-ops\` — 9/9 passed
- [x] \`bun run scripts/tenkacloud-ops.ts help\` — usage 表示
- [x] \`make harness\` — no findings
- [x] \`make before-commit\` (= pre-commit hook 経由) — pass
- [ ] 実 AWS で \`make ops-health\` 実行 (= user 環境で確認)

Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)