### PR TITLE
docs(#956): persona × screen UX 行列を docs/ux/ に新規 doc 化

### DIFF
--- a/docs/ux/persona-screen-matrix.html
+++ b/docs/ux/persona-screen-matrix.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Persona × Screen UX matrix — TenkaCloud</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 1100px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 0.5rem 0.7rem; vertical-align: top; text-align: left; }
+  th { background: var(--c-bg-soft); font-weight: 600; }
+  .persona-competitor { background: #fff8e1; }
+  .persona-admin     { background: #e1f5fe; }
+  .persona-operator  { background: #f3e5f5; }
+  .persona-viewer    { background: #e8f5e9; }
+  .persona-system    { background: #fbe9e7; }
+  .primary { color: var(--c-ok); font-weight: 600; }
+  .secondary { color: var(--c-info); }
+  .nope { color: var(--c-muted); font-style: italic; }
+  .warn { color: var(--c-warn); font-weight: 600; }
+  .legend span { display: inline-block; padding: 2px 8px; margin-right: 8px; border-radius: 3px; font-size: 0.85rem; }
+  .badge-primary { background: #ddf4dd; color: var(--c-ok); }
+  .badge-secondary { background: #ddf0fb; color: var(--c-info); }
+  .badge-warn { background: #fff4d4; color: var(--c-warn); }
+  ul.compact { margin: 0.2rem 0 0.2rem 1.2rem; padding: 0; }
+  ul.compact li { margin: 0.1rem 0; }
+  .summary-card {
+    border: 1px solid var(--c-border); border-radius: 5px; padding: 0.8rem 1rem;
+    background: var(--c-bg-soft); margin: 0.8rem 0;
+  }
+  details summary { cursor: pointer; font-weight: 600; padding: 0.3rem 0; }
+  details[open] summary { color: var(--c-info); }
+  .meta { color: var(--c-muted); font-size: 0.85rem; }
+</style>
+</head>
+<body>
+
+<h1>Persona × Screen UX matrix</h1>
+
+<p class="meta">
+  Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/956">#956</a> Phase 1 ·
+  epic <a href="https://github.com/susumutomita/TenkaCloud/issues/952">#952</a> の柱「初見の人が動かせる」 を満たすための情報設計の正本。
+</p>
+
+<div class="summary-card">
+  <strong>このドキュメントが解く問題</strong>
+  <ul class="compact">
+    <li>直近の audit (image #29 / #32 / #33 / #34 / #35 / #36 / #43 / #45 / #50 等) で表面の UX を 1 件ずつ直してきたが、 <strong>画面ごとの IA (= 情報設計) を体系的に見直していない</strong>。</li>
+    <li>結果: 「どの persona が何を見るべきか」 が画面ごとに揺らぎ、 primary action が複数あったり、 不要情報が一等地を占有したりしている。</li>
+    <li>本 doc は <strong>persona × screen の行列</strong> を正本化し、 各画面の primary / secondary / non-target を 1 ページで判断できる base にする。</li>
+  </ul>
+</div>
+
+<h2>Persona 一覧</h2>
+
+<p class="legend">
+  <span class="badge-primary">primary</span>
+  <span class="badge-secondary">secondary</span>
+  <span class="badge-warn">non-target</span>
+  (= 画面の primary action がどの persona に向けられるべきかを示す)
+</p>
+
+<table>
+<thead>
+<tr><th>Persona</th><th>主役の状況</th><th>典型タスク</th><th>絶対に見せない情報</th></tr>
+</thead>
+<tbody>
+<tr class="persona-competitor">
+  <td><strong>競技者 (Participant)</strong></td>
+  <td>大会に参加するチーム代表 / メンバー。 自分のチームの問題と得点しか見えてはいけない</td>
+  <td>
+    <ul class="compact">
+      <li>問題に挑戦する</li>
+      <li>AWS Console に federated でサインインして調査</li>
+      <li>flag を提出する / hint を開く</li>
+      <li>スコアボードを見る</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>他チームの flag / 提出履歴</li>
+      <li>大会全体の運営情報 (= tenant 管理 / user 管理)</li>
+      <li>環境片付け / SSO 設定の管理 UI</li>
+      <li>Job ID / Region のような実装詳細 (= audit #3)</li>
+    </ul>
+  </td>
+</tr>
+<tr class="persona-admin">
+  <td><strong>TenantAdmin (大会主催)</strong></td>
+  <td>1 大会 = 1 tenant の運営者。 user 招待 / event 作成 / 問題 deploy 制御を握る</td>
+  <td>
+    <ul class="compact">
+      <li>競技者アカウント (login key) を発行 / 失効</li>
+      <li>event (= 開催単位) を作る / 公開 / 終了する</li>
+      <li>問題を tenant の catalog に追加する</li>
+      <li>運用中に SSO / role を rotate する</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>他 tenant の運営情報</li>
+      <li>SystemAdmin 操作 (= tenant 自体の作成 / 削除)</li>
+    </ul>
+  </td>
+</tr>
+<tr class="persona-operator">
+  <td><strong>TenantOperator (運営支援)</strong></td>
+  <td>大会中の現場オペレーター。 監視と即時対応に専念し、 構成変更権限を持たない</td>
+  <td>
+    <ul class="compact">
+      <li>deploy queue / 競技者の deploy 状況をモニタする</li>
+      <li>問題 health / probe / flag 提出履歴を観察する</li>
+      <li>不審な提出 (= brute-force) を見つけたら TenantAdmin にエスカレーション</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>user 作成 / 削除 / role 変更</li>
+      <li>event 作成 / 削除</li>
+      <li>SSO 設定変更</li>
+    </ul>
+  </td>
+</tr>
+<tr class="persona-viewer">
+  <td><strong>TenantViewer (観戦)</strong></td>
+  <td>スコアボード / 公開情報を見るだけの persona。 メンター / OBS / 来賓向け</td>
+  <td>
+    <ul class="compact">
+      <li>スコアボードを見る</li>
+      <li>公開 event の概要を見る</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>競技者個人情報 (= login key、 email)</li>
+      <li>運営情報 (= deploy / job 状態)</li>
+      <li>個別チームの flag 提出履歴</li>
+    </ul>
+  </td>
+</tr>
+<tr class="persona-system">
+  <td><strong>SystemAdmin (platform owner)</strong></td>
+  <td>TenkaCloud platform 自体の管理者 (= 大会開催者ではなく、 大会開催の場を作る人)</td>
+  <td>
+    <ul class="compact">
+      <li>tenant (= 大会) を作成 / 削除する</li>
+      <li>tenant ごとの tier を切り替える (BASIC / STANDARD / PREMIUM / PLATINUM)</li>
+      <li>platform 全体の cost / 障害 / 監査ログを見る</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>tenant 内部の競技進行 (= 個別 flag / 提出履歴) — tenant 越境は禁止</li>
+    </ul>
+  </td>
+</tr>
+</tbody>
+</table>
+
+<h2>Screen × Persona 行列</h2>
+
+<p>各画面で primary persona は 1 つだけにする (= primary action を 1 画面 1 つに収束)。 secondary persona は閲覧可能だが action は限定される。 non-target persona には URL アクセスがあっても 403 か redirect で弾く。</p>
+
+<table>
+<thead>
+<tr>
+  <th>Screen</th>
+  <th>競技者</th>
+  <th>TenantAdmin</th>
+  <th>TenantOperator</th>
+  <th>TenantViewer</th>
+  <th>SystemAdmin</th>
+  <th>Primary action (= 一等地に出すべきもの)</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+  <td><strong>Participant Portal / Home</strong></td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>「次に挑む問題」 のカード 1 枚 + 自チームの累計スコア</td>
+</tr>
+<tr>
+  <td><strong>Participant Portal / Quests (問題一覧)</strong></td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary (= preview)</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>未クリア問題のみ default 表示 (= フィルタ初期値) + クリア状態バッジ</td>
+</tr>
+<tr>
+  <td><strong>Participant Portal / ProblemDetail</strong></td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>「これに挑戦」 ボタン 1 つ + 問題説明。 学習目的 / 想定プレイ時間 / tag は **競技中は隠す** (= audit #1, #33)</td>
+</tr>
+<tr>
+  <td><strong>Participant Portal / SsoCredentials</strong></td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>federated console を開くボタン 1 つ。 「環境片付け」 panel は出さない (= audit #5)</td>
+</tr>
+<tr>
+  <td><strong>Participant Portal / Scoreboard</strong></td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary</td>
+  <td class="secondary">secondary</td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td>tenant 内の team ランキング + 自チーム位置 (= 競技者用)、 公開モードでは TenantViewer も同じ画面を共有</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / Home</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary (= 監視 widget だけ)</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>「今動いている event の状態」 + 競技者数 + 直近 deploy 失敗件数</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / Events</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary (read-only)</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>「新規 event を作成」 + 進行中 event の status / 終了予定時刻</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / Events/Create</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>step-wizard で 「日時 → 問題選択 → チーム招待 → 確認」 を一直線。 verified AWS account の Select は最初の競技者追加と同時に提示 (= audit #45 fix)</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / AdminUsers</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>user 一覧 + 「招待」 ボタン。 role 変更は inline (= audit #17)、 自分自身の role / delete はガード</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / CompetitorAccounts</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="secondary">secondary (= 一覧閲覧のみ)</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>verified 件数バッジ + 「ExternalId rotate」 (TenantAdmin のみ) + bootstrap CFn URL コピー</td>
+</tr>
+<tr>
+  <td><strong>Application Admin Console / Jobs (Deprovisioning)</strong></td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td class="primary">primary</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td>進行中 / 失敗の deprovisioning の table + 「失敗 stack の再 destroy」</td>
+</tr>
+<tr>
+  <td><strong>Admin Console / TenantList (= System Admin)</strong></td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td>tenant 一覧 + 「新規 tenant 作成」 + 各 tenant の tier badge</td>
+</tr>
+<tr>
+  <td><strong>Admin Console / Insights / Jobs</strong></td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="nope">—</td>
+  <td class="primary">primary</td>
+  <td>provisioning / deprovisioning の SFN executions table (= PR-#814 Phase 2)</td>
+</tr>
+
+</tbody>
+</table>
+
+<h2>情報のティアリング規約</h2>
+
+<p>1 画面を縦 3 層に分けて persona に対する情報密度を制御する。</p>
+
+<table>
+<thead>
+<tr><th>層</th><th>視認時間</th><th>載せるもの</th><th>載せないもの</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>一等地 (= Header / 上部 1 画面)</strong></td>
+  <td>~1 秒</td>
+  <td>
+    <ul class="compact">
+      <li>画面の primary action (= 1 つだけ)</li>
+      <li>summary metric (= 自チームの累計スコア、 進行中 event 数、 verified accounts 数)</li>
+      <li>「次の一歩」 への CTA (= Mario の右矢印)</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>tag / 学習目的 / Job ID / Region</li>
+      <li>運用 metadata (= correlationId、 deploy stack 名)</li>
+      <li>2 つ以上の同格 CTA</li>
+    </ul>
+  </td>
+</tr>
+<tr>
+  <td><strong>中段 (= Operational state)</strong></td>
+  <td>~5 秒</td>
+  <td>
+    <ul class="compact">
+      <li>進行中の状態 (= probe 結果 / deploy progress / 提出履歴 1 行)</li>
+      <li>「変化」 を可視化する小チャート (= 得点 time-series、 deploy queue depth)</li>
+    </ul>
+  </td>
+  <td>
+    <ul class="compact">
+      <li>全件 table (= scoll 必要なものは下段)</li>
+    </ul>
+  </td>
+</tr>
+<tr>
+  <td><strong>下段 (= 詳細 / metadata)</strong></td>
+  <td>scroll が必要</td>
+  <td>
+    <ul class="compact">
+      <li>全件 table、 metadata、 history</li>
+      <li>collapsible で初期は閉じる</li>
+    </ul>
+  </td>
+  <td>—</td>
+</tr>
+</tbody>
+</table>
+
+<h2>エラー / 空状態 UX 規約</h2>
+
+<h3>エラー</h3>
+
+<p>API エラーは <strong>技術的 message を競技者に見せない</strong>。 既存 <code>FriendlyErrorAlert</code> で次の 4 要素を満たす。</p>
+
+<ul class="compact">
+  <li><strong>何が起きたか</strong> (= 「環境を deploy できませんでした」)、 stack trace ではなく業務語彙で</li>
+  <li><strong>なぜ起きたか</strong> (= 「現在の AWS アカウントに deploy 権限が足りません」)、 推測でなく確定できる時だけ書く</li>
+  <li><strong>次に何をすればよいか</strong> (= 「TenantAdmin に ExternalId を rotate するよう依頼してください」)</li>
+  <li><strong>support 連絡先 / correlationId</strong> (= 下段に小さく)</li>
+</ul>
+
+<h3>空状態</h3>
+
+<p>0 件 = empty state はゴミ箱ではなく <strong>次の一歩への入口</strong>。 「データがありません」 ではなく「最初に何をすればよいか」 を出す。</p>
+
+<table>
+<thead>
+<tr><th>画面</th><th>0 件のとき出すもの</th></tr>
+</thead>
+<tbody>
+<tr><td>Quests (問題一覧)</td><td>「event がまだ始まっていません」 + event 開始予定時刻 + 「event 詳細を見る」 link</td></tr>
+<tr><td>Scoreboard</td><td>「まだ採点が始まっていません」 + 1 つ目の team が提出するまでの説明</td></tr>
+<tr><td>AdminUsers</td><td>「ユーザー未招待」 + 「最初のユーザーを招待」 primary button</td></tr>
+<tr><td>CompetitorAccounts</td><td>「verified AWS account が 0 件」 + bootstrap CFn template の copy ボタン + 1 step ガイド</td></tr>
+<tr><td>Jobs (Deprovisioning)</td><td>「すべて健全」 + 直近の deprovisioning 完了履歴 (= 健全さの証明)</td></tr>
+</tbody>
+</table>
+
+<h2>Cloudscape 使い方規約</h2>
+
+<p>全 SPA (admin-console / application-admin-console / participant-portal / landing-page) で Cloudscape Design System の使い方を揃える。</p>
+
+<ul class="compact">
+  <li><strong>Header variant</strong>: h1 はページ 1 つに 1 個。 「画面のタイトル」 と「primary action」 の組合せ。 description は 1 行で済ませる</li>
+  <li><strong>Container vs SpaceBetween</strong>: 関連情報は <code>Container</code> で boxing、 独立した section 間は <code>SpaceBetween size="l"</code>。 「box の中にさらに box」 は避ける</li>
+  <li><strong>Table vs Cards</strong>: 6 件以下 / 各行に 4 col 以下なら <code>Cards</code>、 それ以上は <code>Table</code></li>
+  <li><strong>Button variant</strong>: primary は 1 画面 1 つだけ。 ほかは normal / link。 destructive (= delete / destroy) は variant=normal + ConfirmModal を必須</li>
+  <li><strong>Modal</strong>: 編集系は inline (= Cards 内 SelectInput) を優先、 確認系のみ Modal</li>
+  <li><strong>Breakpoint</strong>: <code>ColumnLayout columns={3}</code> は mobile で 1 列に折り返る。 4 col 以上は明示的に grid で書く</li>
+</ul>
+
+<h2>Roadmap</h2>
+
+<table>
+<thead>
+<tr><th>Phase</th><th>scope</th><th>状態</th></tr>
+</thead>
+<tbody>
+<tr><td>Phase 1: 行列 doc 化</td><td>本ファイル (= persona-screen-matrix.html)</td><td><span class="primary">本 PR</span></td></tr>
+<tr><td>Phase 2: primary action 統一</td><td>各画面に 1 つだけ primary を残し、 secondary を normal / link に降格</td><td>未着手 (= 別 PR、 画面ごと)</td></tr>
+<tr><td>Phase 3: FriendlyErrorAlert / empty state library を全 SPA に展開</td><td>共有 component を <code>packages/portal-plugin-sdk</code> に bundle</td><td>未着手</td></tr>
+<tr><td>Phase 4: Cloudscape 使い方 ADR</td><td>本 doc を ADR-NNN として正式化、 機械検査ルール (= harness) を追加</td><td>未着手</td></tr>
+</tbody>
+</table>
+
+<h2>関連</h2>
+
+<ul class="compact">
+  <li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/956">#956</a> — 画面 UX 改善 epic</li>
+  <li>Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/952">#952</a> — 初見が独力で動かせる goal</li>
+  <li><a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> — 問題は plugin、 platform は host (= 競技者画面の dashboard.slots は問題側 plugin)</li>
+  <li><a href="https://cloudscape.design/components/">Cloudscape Design System</a></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

epic #952 / #956 **Phase 1**: 直近 audit (image #29 / #32-#36 / #43 / #45 / #50 等) で表面 UX を 1 件ずつ修正してきたが、 画面ごとの IA (= 情報設計) を体系的に見直していなかった。

本 PR は 5 persona (Participant / TenantAdmin / TenantOperator / TenantViewer / SystemAdmin) × 12 主要 screen の primary / secondary / non-target を **1 表で正本化** する。

## 実装

新規 \`docs/ux/persona-screen-matrix.html\`:

- **Persona 一覧** — 主役の状況 / 典型タスク / 絶対に見せない情報
- **Screen × Persona 行列** — 12 screen × 5 persona の primary action と一等地に出すべきもの
- **情報のティアリング規約** — 一等地 (1 秒) / 中段 (5 秒) / 下段 (scroll) に何を入れるか
- **エラー / 空状態 UX 規約** — \`FriendlyErrorAlert\` の 4 要素 (= 何が起きた / なぜ / 次に何をすればよいか / correlationId) + 空状態 = 「次の一歩への入口」
- **Cloudscape 使い方規約** — Header / Container / Table-vs-Cards / Button variant の使い分け
- **Roadmap** — Phase 1 = 本 PR / Phase 2 = primary action 統一 (画面ごとに別 PR) / Phase 3 = FriendlyErrorAlert を全 SPA 展開 / Phase 4 = ADR 化

## 設計判断

- **HTML 直書き** — ADR と同じ理由で表現力 (row span / color / class-based persona 配色) を保つ。 \`feedback_design_docs_html\` memory に沿う
- **\`docs/ux/\` を新設** — 既存の \`docs/operations/\` \`docs/problems/\` と並列、 設計知識の置き場を分離
- **機械検査ルール (= harness) は Phase 4 で追加** — 本 doc はまず reference として配布し、 検証可能な規約に絞り込んでから harness 化

## Regression 分析

- 既存コードに変更なし (= doc 追加のみ)
- 既存 audit 修正で出した動作は本 doc が正当化する形 (= 例: audit #1 / #3 / #33 で削除した「Job ID / 想定プレイ時間 / 学習目的」 は本 doc で「下段に格下げ」 として規約化される)
- 新規問題作者 / 新規 contributor が persona と画面の責務をすぐ参照できる

## 物理影響

- CREATE: \`docs/ux/persona-screen-matrix.html\` (= 441 行)
- CFn / AWS / コード: NO-OP

## Test plan

- [x] \`make harness\` — no findings
- [x] \`bun run lint:text\` — clean
- [x] \`make before-commit\` (= pre-commit hook 経由) — pass
- [ ] OSS reader が persona × screen の責務を 1 ページで把握できるか (= user レビューで確認)

## Next steps (= 別 PR で順次)

- [ ] Phase 2: 各画面の primary action を 1 つに統一 (Participant Portal / Home → Quests → ProblemDetail から)
- [ ] Phase 3: \`FriendlyErrorAlert\` を \`packages/portal-plugin-sdk\` に bundle して全 SPA で共有
- [ ] Phase 4: 本 doc を ADR-NNN として正本化、 \`make harness\` に Cloudscape 使い方 lint rule を追加

Relates #956 Phase 1
Relates #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)