### PR TITLE
feat(#948): middleware を route 単位の granular role check に置換 (ADR-020 Phase B.1)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -6,9 +6,11 @@ import { StatusCodes } from "http-status-codes";
 import {
   ForbiddenRoleError,
   MissingTenantClaimError,
-  requireTenantAdmin,
+  requireRole,
   resolveCognitoSub,
   resolveTenantId,
+  TENANT_ADMIN_ROLE,
+  TENANT_ROLES,
 } from "../deploy-handler/auth.js";
 import { routeDelete, routeGet, routePut } from "./saml-routes.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
@@ -77,16 +79,20 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
-  // Issue #854: role 不一致は 403。 actualRole / requiredRoles は body には出さない
-  // (= attacker に attack surface を教えない、 audit log にだけ残す)。
+  // Issue #854 / ADR-020 Phase B.1 (#948): role 不一致は 403、 actualRole / requiredRoles は
+  // body に出さず log にだけ残す (= attacker に attack surface を教えない)。
   if (err instanceof ForbiddenRoleError) {
     console.warn("[competitor-accounts] forbidden role", {
       path: c.req.path,
+      method: c.req.method,
       actualRole: err.actualRole,
       requiredRoles: err.requiredRoles,
     });
     return c.json(
-      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      {
+        error: "forbidden_role",
+        message: "あなたの tenant role ではこの操作を実行できません",
+      },
       StatusCodes.FORBIDDEN,
     );
   }
@@ -98,15 +104,18 @@ app.onError((err, c) => {
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
 });
 
-// Issue #854: `/admin/*` 全 route で TenantAdmin role を要求する middleware。
-// healthz だけは認証無しで通したいので path 比較で skip する (= 認証は API Gateway Cognito
-// authorizer で既に通っているが、 healthz は role check 自体を skip する設計)。
-// 個別 handler 内で再度 `requireTenantAdmin(c)` を呼ぶ必要は無い (= middleware が gate)。
+// ADR-020 Phase B.1 (#948): /admin/* は 「tenant 内の認証済 user」 (= Admin / Operator / Viewer
+// のいずれか) を要求する。 destructive 操作 (= POST / DELETE / PATCH) は各 route の 1 行目で
+// `requireRole(c, [TENANT_ADMIN_ROLE])` を呼んで Admin 限定にする。 GET 系のうち
+// `/admin/competitor-accounts` は 3 role 全部 pass (= EventCreate 画面 dropdown populate に
+// 必要、 Viewer も verified accounts を見る)。 SAML 設定 / user 管理 は GET も含めて Admin only
+// (= sensitive config / user 一覧)。
+// healthz は role check 自体を skip。
 app.use("/admin/*", async (c, next) => {
   if (c.req.path.endsWith("/healthz")) {
     return next();
   }
-  requireTenantAdmin(c);
+  requireRole(c, TENANT_ROLES);
   return next();
 });
 
@@ -114,25 +123,31 @@ app.get("/admin/competitor-accounts/healthz", (c) => c.json({ ok: true }));
 
 // Issue #839 follow-up Phase B: Tenant 管理者が画面 / API から SAML IdP を CRUD する経路。
 // 同 Lambda に同居させる (= 同 IAM / auth、 別 handler 化は Phase 3 で再評価)。
+// ADR-020 Phase B.1 (#948): SAML 設定は sensitive config なので GET も含めて Admin only。
 app.get("/admin/tenant-saml-config", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const result = await routeGet({ shared }, c);
   return c.json(result.body as never, result.status as 200);
 });
 // 互換のため PATCH + PUT 両方受ける (= frontend は PATCH、 curl 直叩き / OpenAPI は PUT で書く)。
 app.patch("/admin/tenant-saml-config", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const result = await routePut({ shared }, c);
   return c.json(result.body as never, result.status as 200 | 400 | 422);
 });
 app.put("/admin/tenant-saml-config", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const result = await routePut({ shared }, c);
   return c.json(result.body as never, result.status as 200 | 400 | 422);
 });
 app.delete("/admin/tenant-saml-config", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const result = await routeDelete({ shared }, c);
   return c.json(result.body as never, result.status as 200 | 422);
 });
 
 app.post("/admin/competitor-accounts", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   let body: unknown;
   try {
     body = await c.req.json();
@@ -182,6 +197,7 @@ app.get("/admin/competitor-accounts", async (c) => {
 });
 
 app.post("/admin/competitor-accounts/:awsAccountId/verify", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const awsAccountId = c.req.param("awsAccountId");
   if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
     return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
@@ -217,6 +233,7 @@ app.post("/admin/competitor-accounts/:awsAccountId/verify", async (c) => {
 });
 
 app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const awsAccountId = c.req.param("awsAccountId");
   if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
     return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
@@ -268,6 +285,7 @@ app.post("/admin/competitor-accounts/:awsAccountId/rotate-external-id", async (c
 });
 
 app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const awsAccountId = c.req.param("awsAccountId");
   if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
     return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
@@ -285,16 +303,18 @@ app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
   }
 });
 
-// Issue #925 Phase 1: Tenant 内 user の CRUD。 `/admin/*` middleware で既に TenantAdmin role が
-// gate されているため、 各 handler では tenantId resolve のみ行う。 削除は self-delete 防止 +
-// tenant 越境チェック (AdminGetUser) → AdminDeleteUser。
+// Issue #925 Phase 1 / ADR-020 Phase B.1 (#948): Tenant 内 user の CRUD は **GET も含めて
+// Admin only** (= user 一覧 / 招待 / 削除 / role 変更 はいずれも sensitive 操作)。
+// 削除は self-delete 防止 + tenant 越境チェック (AdminGetUser) → AdminDeleteUser。
 app.get("/admin/users", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const tenantId = resolveTenantId(c);
   const result = await routeListUsers({ shared }, c, tenantId);
   return c.json(result.body as never, result.status as 200 | 401);
 });
 
 app.post("/admin/users", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   let body: unknown;
   try {
     body = await c.req.json();
@@ -323,6 +343,7 @@ app.post("/admin/users", async (c) => {
 });
 
 app.delete("/admin/users/:username", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const username = c.req.param("username");
   if (!username || username.length === 0) {
     return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
@@ -352,6 +373,7 @@ app.delete("/admin/users/:username", async (c) => {
 
 // Issue #17: 既存 user の custom:userRole を変更する PATCH。 越境チェック + 自己変更禁止。
 app.patch("/admin/users/:username", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const username = c.req.param("username");
   if (!username || username.length === 0) {
     return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -15,8 +15,11 @@ import {
 import {
   ForbiddenRoleError,
   MissingTenantClaimError,
-  requireTenantAdmin,
+  requireRole,
   resolveTenantId,
+  TENANT_ADMIN_ROLE,
+  TENANT_OPERATOR_ROLE,
+  TENANT_ROLES,
 } from "./auth.js";
 import { requestTeardown } from "./delete.js";
 import {
@@ -97,15 +100,21 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
-  // Issue #854: role 不一致は 403、 detail は body に出さず log のみ。
+  // Issue #854 / ADR-020 Phase B.1 (#948): role 不一致は 403、 detail は body に出さず log のみ
+  // (= attacker に attack surface を教えない)。 frontend は error code "forbidden_role" を
+  // FriendlyErrorAlert にマップする。
   if (err instanceof ForbiddenRoleError) {
     console.warn("[deploy] forbidden role", {
       path: c.req.path,
+      method: c.req.method,
       actualRole: err.actualRole,
       requiredRoles: err.requiredRoles,
     });
     return c.json(
-      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      {
+        error: "forbidden_role",
+        message: "あなたの tenant role ではこの操作を実行できません",
+      },
       StatusCodes.FORBIDDEN,
     );
   }
@@ -114,21 +123,24 @@ app.onError((err, c) => {
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
 });
 
-// Issue #854: deploy / list 全 route で TenantAdmin role を要求 (= 一般 user / monitor bot に
-// destructive 操作を許さない、 GET 経路でも tenant 配下の全 deployment が見えるので admin scope)。
-// healthz だけ skip。 path prefix が無い (= "/problems/*" / "/deployments/*" 両方) ので
-// `app.use("*", ...)` で全 route を gate、 healthz は path 比較で skip する。
+// ADR-020 Phase B.1 (#948): blanket middleware は **「tenant 内のいずれかの role を持つ
+// 認証済 user」** であることだけ要求する (= Admin / Operator / Viewer のいずれか)。 各 route の
+// 1 行目で `requireRole(c, [...])` を呼び、 destructive 操作には Admin 限定 / mutate には
+// Admin + Operator のように **route 単位で** 絞り込む (= Viewer も dropdown populate のため
+// GET には pass、 旧 broken-glass 規律で 403 になっていた regression を解消)。
+// healthz は authn / authz どちらも skip (= API GW 側で auth bypass 設定)。
 app.use("*", async (c, next) => {
   if (c.req.path === "/healthz" || c.req.path.endsWith("/healthz")) {
     return next();
   }
-  requireTenantAdmin(c);
+  requireRole(c, TENANT_ROLES);
   return next();
 });
 
 app.get("/healthz", (c) => c.json({ ok: true }));
 
 app.post("/problems/:problemId/deploy", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const problemId = c.req.param("problemId");
   if (!problemId || !PROBLEM_ID_RE.test(problemId)) {
     return c.json({ error: "invalid_problem_id" }, HTTP_BAD_REQUEST);
@@ -288,6 +300,7 @@ app.get("/deployments/:jobId/stack-progress", async (c) => {
  * 出力: \`{ items: [{ jobId, action: \"requeued\" | \"skipped\", reason? }, ...] }\`
  */
 app.post("/deployments/retry", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   let body: unknown;
   try {
     body = await c.req.json();
@@ -314,6 +327,7 @@ app.post("/deployments/retry", async (c) => {
 });
 
 app.delete("/deployments/:jobId", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const jobId = c.req.param("jobId");
   if (!jobId || !JOB_ID_RE.test(jobId)) {
     return c.json({ error: "invalid_job_id" }, HTTP_BAD_REQUEST);

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -6,9 +6,12 @@ import { StatusCodes } from "http-status-codes";
 import {
   ForbiddenRoleError,
   MissingTenantClaimError,
-  requireTenantAdmin,
+  requireRole,
   resolveCognitoSub,
   resolveTenantId,
+  TENANT_ADMIN_ROLE,
+  TENANT_OPERATOR_ROLE,
+  TENANT_ROLES,
 } from "../deploy-handler/auth.js";
 import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
@@ -98,15 +101,19 @@ app.onError((err, c) => {
       StatusCodes.UNAUTHORIZED,
     );
   }
-  // Issue #854: role 不一致は 403、 detail は body に出さず log のみ。
+  // Issue #854 / ADR-020 Phase B.1 (#948): role 不一致は 403、 detail は body に出さず log のみ。
   if (err instanceof ForbiddenRoleError) {
     console.warn("[events] forbidden role", {
       path: c.req.path,
+      method: c.req.method,
       actualRole: err.actualRole,
       requiredRoles: err.requiredRoles,
     });
     return c.json(
-      { error: "forbidden_role", message: "this endpoint requires TenantAdmin role" },
+      {
+        error: "forbidden_role",
+        message: "あなたの tenant role ではこの操作を実行できません",
+      },
       StatusCodes.FORBIDDEN,
     );
   }
@@ -115,20 +122,23 @@ app.onError((err, c) => {
   return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
 });
 
-// Issue #854: 全 /events/* route で TenantAdmin role を要求 (= 一般 user / monitor bot に
-// destructive 操作を許さない、 read 経路でも teamLoginKey が response に含まれるので admin scope)。
-// healthz だけ skip。
+// ADR-020 Phase B.1 (#948): /events/* は 「tenant 内の認証済 user」 (= Admin / Operator /
+// Viewer のいずれか) を要求し、 destructive / mutate 操作は各 route の 1 行目で `requireRole(c,
+// [...])` を呼んで absolute に絞る。 GET 系 (= list / detail / disruption catalog / audit) は
+// 3 role 全部 OK (= Viewer も event 観覧可)。
+// healthz は skip。
 app.use("/events/*", async (c, next) => {
   if (c.req.path.endsWith("/healthz")) {
     return next();
   }
-  requireTenantAdmin(c);
+  requireRole(c, TENANT_ROLES);
   return next();
 });
 
 app.get("/events/healthz", (c) => c.json({ ok: true }));
 
 app.post("/events", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   let body: unknown;
   try {
     body = await c.req.json();
@@ -195,6 +205,7 @@ app.get("/events/:eventId", async (c) => {
 });
 
 app.patch("/events/:eventId/schedule", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -282,6 +293,7 @@ app.patch("/events/:eventId/schedule", async (c) => {
 });
 
 app.post("/events/:eventId/end", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -309,6 +321,7 @@ app.post("/events/:eventId/end", async (c) => {
 // idempotent: already locked / unlocked のときは 200 + body に現状を返す。
 // status=READY / ENDED のみ lockable (= 加点経路があり得る state)。
 app.post("/events/:eventId/lock-scoring", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -341,6 +354,7 @@ app.post("/events/:eventId/lock-scoring", async (c) => {
 });
 
 app.delete("/events/:eventId/lock-scoring", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -366,6 +380,7 @@ app.delete("/events/:eventId/lock-scoring", async (c) => {
 });
 
 app.post("/events/:eventId/notifications", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -401,6 +416,7 @@ app.post("/events/:eventId/notifications", async (c) => {
 });
 
 app.post("/events/:eventId/archive", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -420,6 +436,7 @@ app.post("/events/:eventId/archive", async (c) => {
 });
 
 app.post("/events/:eventId/deploy", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -506,6 +523,7 @@ app.get("/events/:eventId/disruptions/audit", async (c) => {
 });
 
 app.post("/events/:eventId/disruptions/fire", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
@@ -560,6 +578,7 @@ app.post("/events/:eventId/disruptions/fire", async (c) => {
 });
 
 app.delete("/events/:eventId", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
   const eventId = c.req.param("eventId");
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);

--- a/infrastructure/test/problem-deploy/role-gates.test.ts
+++ b/infrastructure/test/problem-deploy/role-gates.test.ts
@@ -1,0 +1,616 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ADR-020 Phase B.1 (#948): 3 handler (deploy / event / competitor-accounts) の
+ * route 単位 granular role gate を pin する test。
+ *
+ * 旧 broken-glass 規律 (= 全 route で TenantAdmin only) を、 次の matrix に置換した:
+ *
+ *   - GET (read) → Admin / Operator / Viewer 全部 OK
+ *   - POST / PATCH (mutate) → Admin + Operator
+ *   - DELETE / archive / lock-scoring (destructive) → Admin only
+ *   - admin (= SAML config / user 管理) → Admin only
+ *
+ * Viewer も dropdown populate のため `/admin/competitor-accounts` の GET には pass する
+ * (= EventCreate dropdown 空問題の解消、 issue 本文の persona mismatch fix)。
+ *
+ * test 経路は `app.request()` で JWT を bypass しているので、 各 test で
+ * `DEFAULT_USER_ROLE` env を切り替えて role 差を再現する。
+ */
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+});
+
+const originalRole = process.env.DEFAULT_USER_ROLE;
+afterEach(() => {
+  if (originalRole === undefined) delete process.env.DEFAULT_USER_ROLE;
+  else process.env.DEFAULT_USER_ROLE = originalRole;
+});
+
+const deployMocks = vi.hoisted(() => ({
+  startDeployment: vi.fn(),
+  listDeployments: vi.fn(),
+  getDeployment: vi.fn(),
+  requestTeardown: vi.fn(),
+  retryDeployments: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/deploy-handler/deploy")
+  >("../../lib/problem-deploy/handlers/deploy-handler/deploy");
+  return {
+    buildSharedResources: () => ({
+      tableName: "TestDeployments",
+      competitorAccountsTableName: "TestCompetitorAccounts",
+      env: "development",
+      eventBusName: "test-bus",
+      ddb: { send: vi.fn() },
+      events: { send: vi.fn() },
+    }),
+    buildContext: (shared: unknown, tenantId: string) => ({ ...(shared as object), tenantId }),
+    startDeployment: deployMocks.startDeployment,
+    UnknownProblemError: actual.UnknownProblemError,
+    UnverifiedCompetitorAccountError: actual.UnverifiedCompetitorAccountError,
+  };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/list", () => ({
+  listDeployments: deployMocks.listDeployments,
+  getDeployment: deployMocks.getDeployment,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
+  requestTeardown: deployMocks.requestTeardown,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/retry", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/deploy-handler/retry")
+  >("../../lib/problem-deploy/handlers/deploy-handler/retry");
+  return {
+    retryDeployments: deployMocks.retryDeployments,
+    validateRetryRequest: actual.validateRetryRequest,
+    InvalidRetryRequestError: actual.InvalidRetryRequestError,
+  };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/stack-progress", () => ({
+  getStackProgress: vi.fn(),
+  defaultCfnClient: vi.fn(),
+  defaultCfnClientForCompetitor: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listEvents: vi.fn(),
+  getEventDetail: vi.fn(),
+  createEvent: vi.fn(),
+  setEventSchedule: vi.fn(),
+  endEvent: vi.fn(),
+  lockScoring: vi.fn(),
+  unlockScoring: vi.fn(),
+  archiveEvent: vi.fn(),
+  bulkDeployEvent: vi.fn(),
+  bulkTeardownEvent: vi.fn(),
+  createNotification: vi.fn(),
+  fireDisruption: vi.fn(),
+  isEventOwnedByTenant: vi.fn(),
+  listDisruptionCatalog: vi.fn(),
+  listDisruptionAudit: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/event-handler/shared", () => ({
+  buildEventSharedResources: () => ({
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: vi.fn() },
+    events: { send: vi.fn() },
+    problemsCatalog: {},
+  }),
+  queryDeploymentsByEvent: vi.fn(),
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/list", () => ({
+  listEvents: eventMocks.listEvents,
+  getEventDetail: eventMocks.getEventDetail,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/create", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/event-handler/create")
+  >("../../lib/problem-deploy/handlers/event-handler/create");
+  return {
+    createEvent: eventMocks.createEvent,
+    DuplicateInternalSlugError: actual.DuplicateInternalSlugError,
+    DuplicateProblemIdError: actual.DuplicateProblemIdError,
+  };
+});
+vi.mock("../../lib/problem-deploy/handlers/event-handler/schedule", () => ({
+  setEventSchedule: eventMocks.setEventSchedule,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/end-event", () => ({
+  endEvent: eventMocks.endEvent,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/lock-scoring", () => ({
+  lockScoring: eventMocks.lockScoring,
+  unlockScoring: eventMocks.unlockScoring,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/archive", () => ({
+  archiveEvent: eventMocks.archiveEvent,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/bulk-deploy", () => ({
+  bulkDeployEvent: eventMocks.bulkDeployEvent,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/bulk-delete", () => ({
+  bulkTeardownEvent: eventMocks.bulkTeardownEvent,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/create-notification", () => ({
+  createNotification: eventMocks.createNotification,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/disruption-fire", () => ({
+  fireDisruption: eventMocks.fireDisruption,
+  isEventOwnedByTenant: eventMocks.isEventOwnedByTenant,
+  listDisruptionCatalog: eventMocks.listDisruptionCatalog,
+  listDisruptionAudit: eventMocks.listDisruptionAudit,
+}));
+
+const competitorMocks = vi.hoisted(() => ({
+  listCompetitorAccounts: vi.fn(),
+  createCompetitorAccount: vi.fn(),
+  deleteCompetitorAccount: vi.fn(),
+  rotateExternalIdForAccount: vi.fn(),
+  verifyCompetitorAccount: vi.fn(),
+  routeGet: vi.fn(),
+  routePut: vi.fn(),
+  routeDelete: vi.fn(),
+  routeListUsers: vi.fn(),
+  routeCreateUser: vi.fn(),
+  routeDeleteUser: vi.fn(),
+  routeChangeUserRole: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/shared", () => ({
+  buildCompetitorAccountsSharedResources: () => ({
+    tableName: "TestCompetitorAccounts",
+    ssmKeyPrefix: "/tenkacloud/test/competitor",
+    region: "ap-northeast-1",
+    ddb: { send: vi.fn() },
+    ssm: { send: vi.fn() },
+    sts: { send: vi.fn() },
+    cognito: { send: vi.fn() },
+    userPoolId: "test-pool",
+  }),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/store", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/competitor-accounts-handler/store")
+  >("../../lib/problem-deploy/handlers/competitor-accounts-handler/store");
+  return {
+    listCompetitorAccounts: competitorMocks.listCompetitorAccounts,
+    createCompetitorAccount: competitorMocks.createCompetitorAccount,
+    deleteCompetitorAccount: competitorMocks.deleteCompetitorAccount,
+    rotateExternalIdForAccount: competitorMocks.rotateExternalIdForAccount,
+    DuplicateCompetitorAccountError: actual.DuplicateCompetitorAccountError,
+    CompetitorAccountNotFoundError: actual.CompetitorAccountNotFoundError,
+    CompetitorAccountNotVerifiedError: actual.CompetitorAccountNotVerifiedError,
+    ExternalIdMissingForRotationError: actual.ExternalIdMissingForRotationError,
+  };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify")
+  >("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify");
+  return {
+    verifyCompetitorAccount: competitorMocks.verifyCompetitorAccount,
+    ExternalIdMissingError: actual.ExternalIdMissingError,
+    AssumeRoleSanityCheckFailedError: actual.AssumeRoleSanityCheckFailedError,
+  };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes", () => ({
+  routeGet: competitorMocks.routeGet,
+  routePut: competitorMocks.routePut,
+  routeDelete: competitorMocks.routeDelete,
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes")
+  >("../../lib/problem-deploy/handlers/competitor-accounts-handler/users-routes");
+  return {
+    InviteUserRequestSchema: actual.InviteUserRequestSchema,
+    ChangeRoleRequestSchema: actual.ChangeRoleRequestSchema,
+    routeListUsers: competitorMocks.routeListUsers,
+    routeCreateUser: competitorMocks.routeCreateUser,
+    routeDeleteUser: competitorMocks.routeDeleteUser,
+    routeChangeUserRole: competitorMocks.routeChangeUserRole,
+  };
+});
+
+const { app: deployApp } = await import("../../lib/problem-deploy/handlers/deploy-handler/index");
+const { app: eventApp } = await import("../../lib/problem-deploy/handlers/event-handler/index");
+const { app: competitorApp } = await import(
+  "../../lib/problem-deploy/handlers/competitor-accounts-handler/index"
+);
+
+const ULID = "01H8XGJWBWBAQ4N6RZHM4S2KMV";
+const PROBLEM = "security-battle-royale";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // happy-path stubs so that pass-through routes reach the handler body without throwing
+  deployMocks.startDeployment.mockResolvedValue({ jobId: ULID });
+  deployMocks.listDeployments.mockResolvedValue({ items: [] });
+  deployMocks.getDeployment.mockResolvedValue({ jobId: ULID, status: "IN_PROGRESS" });
+  deployMocks.requestTeardown.mockResolvedValue({ kind: "already_deleted" });
+  deployMocks.retryDeployments.mockResolvedValue({ items: [] });
+
+  eventMocks.listEvents.mockResolvedValue({ items: [] });
+  eventMocks.getEventDetail.mockResolvedValue({ id: ULID });
+  eventMocks.createEvent.mockResolvedValue({ id: ULID });
+  eventMocks.setEventSchedule.mockResolvedValue({ kind: "no_op" });
+  eventMocks.endEvent.mockResolvedValue({ kind: "not_found" });
+  eventMocks.lockScoring.mockResolvedValue({ kind: "not_found" });
+  eventMocks.unlockScoring.mockResolvedValue({ kind: "not_found" });
+  eventMocks.archiveEvent.mockResolvedValue({ kind: "not_found" });
+  eventMocks.bulkDeployEvent.mockResolvedValue({ kind: "not_found" });
+  eventMocks.bulkTeardownEvent.mockResolvedValue({ kind: "not_found" });
+  eventMocks.createNotification.mockResolvedValue({ kind: "not_found" });
+  eventMocks.fireDisruption.mockResolvedValue({ kind: "unknown_problem" });
+  eventMocks.isEventOwnedByTenant.mockResolvedValue(true);
+  eventMocks.listDisruptionCatalog.mockResolvedValue({ items: [] });
+  eventMocks.listDisruptionAudit.mockResolvedValue({ items: [] });
+
+  competitorMocks.listCompetitorAccounts.mockResolvedValue([]);
+  competitorMocks.createCompetitorAccount.mockResolvedValue({ awsAccountId: "123456789012" });
+  competitorMocks.deleteCompetitorAccount.mockResolvedValue(undefined);
+  competitorMocks.rotateExternalIdForAccount.mockResolvedValue({
+    awsAccountId: "123456789012",
+    rotatedAt: "2026-01-01T00:00:00.000Z",
+  });
+  competitorMocks.verifyCompetitorAccount.mockResolvedValue({ awsAccountId: "123456789012" });
+  competitorMocks.routeGet.mockResolvedValue({ status: 200, body: {} });
+  competitorMocks.routePut.mockResolvedValue({ status: 200, body: {} });
+  competitorMocks.routeDelete.mockResolvedValue({ status: 200, body: {} });
+  competitorMocks.routeListUsers.mockResolvedValue({ status: 200, body: { items: [] } });
+  competitorMocks.routeCreateUser.mockResolvedValue({ status: 201, body: {} });
+  competitorMocks.routeDeleteUser.mockResolvedValue({ status: 200, body: {} });
+  competitorMocks.routeChangeUserRole.mockResolvedValue({ status: 200, body: {} });
+});
+
+async function expectForbidden(res: Response): Promise<void> {
+  expect(res.status).toBe(403);
+  const body = (await res.json()) as { error?: string };
+  expect(body.error).toBe("forbidden_role");
+}
+
+async function expectNotForbidden(res: Response): Promise<void> {
+  expect(res.status).not.toBe(403);
+}
+
+describe("ADR-020 Phase B.1 (#948): deploy-handler route role gates", () => {
+  describe("TenantViewer (= read-only)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantViewer";
+    });
+
+    it("GET /problems/:id/deployments は 200 を返すべき (= dropdown populate のため Viewer も pass)", async () => {
+      const res = await deployApp.request(`/problems/${PROBLEM}/deployments`);
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /deployments/:jobId は pass するべき", async () => {
+      const res = await deployApp.request(`/deployments/${ULID}`);
+      await expectNotForbidden(res);
+    });
+
+    it("POST /problems/:id/deploy は 403 forbidden_role になるべき", async () => {
+      const res = await deployApp.request(`/problems/${PROBLEM}/deploy`, {
+        method: "POST",
+        body: JSON.stringify({
+          region: "ap-northeast-1",
+          awsAccountId: "123456789012",
+          teamName: "T",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("POST /deployments/retry は 403 になるべき", async () => {
+      const res = await deployApp.request("/deployments/retry", {
+        method: "POST",
+        body: JSON.stringify({ failedJobIds: [ULID] }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("DELETE /deployments/:jobId は 403 になるべき", async () => {
+      const res = await deployApp.request(`/deployments/${ULID}`, { method: "DELETE" });
+      await expectForbidden(res);
+    });
+  });
+
+  describe("TenantOperator (= mutate OK + destructive OK)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantOperator";
+    });
+
+    it("POST /problems/:id/deploy は pass する (= mutate 可)", async () => {
+      const res = await deployApp.request(`/problems/${PROBLEM}/deploy`, {
+        method: "POST",
+        body: JSON.stringify({
+          region: "ap-northeast-1",
+          awsAccountId: "123456789012",
+          teamName: "T",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectNotForbidden(res);
+    });
+
+    it("DELETE /deployments/:jobId は pass する (= 個別 teardown は Operator も可)", async () => {
+      const res = await deployApp.request(`/deployments/${ULID}`, { method: "DELETE" });
+      await expectNotForbidden(res);
+    });
+  });
+
+  describe("TenantAdmin (= everything OK)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+    });
+
+    it("DELETE /deployments/:jobId は pass", async () => {
+      const res = await deployApp.request(`/deployments/${ULID}`, { method: "DELETE" });
+      await expectNotForbidden(res);
+    });
+  });
+
+  describe("unknown role (= claim 不在)", () => {
+    beforeEach(() => {
+      delete process.env.DEFAULT_USER_ROLE;
+    });
+
+    it("GET は 403 になる (= 認証済 user として扱われない、 fail-closed)", async () => {
+      const res = await deployApp.request(`/problems/${PROBLEM}/deployments`);
+      await expectForbidden(res);
+    });
+  });
+});
+
+describe("ADR-020 Phase B.1 (#948): event-handler route role gates", () => {
+  describe("TenantViewer", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantViewer";
+    });
+
+    it("GET /events は 200 (= 観覧 OK)", async () => {
+      const res = await eventApp.request("/events");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /events/:id は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}`);
+      await expectNotForbidden(res);
+    });
+
+    it("GET /events/:id/disruptions は pass (= disruption catalog 観覧)", async () => {
+      const res = await eventApp.request(`/events/${ULID}/disruptions`);
+      await expectNotForbidden(res);
+    });
+
+    it("POST /events は 403 (= 作成は Admin/Operator)", async () => {
+      const res = await eventApp.request("/events", {
+        method: "POST",
+        body: JSON.stringify({
+          internalSlug: "x",
+          displayName: "X",
+          competitorAccounts: [{ awsAccountId: "123456789012", teamName: "T" }],
+          problemIds: ["security-battle-royale"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("PATCH /events/:id/schedule は 403", async () => {
+      const res = await eventApp.request(`/events/${ULID}/schedule`, {
+        method: "PATCH",
+        body: JSON.stringify({ startNow: true }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("DELETE /events/:id は 403", async () => {
+      const res = await eventApp.request(`/events/${ULID}`, { method: "DELETE" });
+      await expectForbidden(res);
+    });
+
+    it("POST /events/:id/archive は 403", async () => {
+      const res = await eventApp.request(`/events/${ULID}/archive`, { method: "POST" });
+      await expectForbidden(res);
+    });
+
+    it("POST /events/:id/lock-scoring は 403", async () => {
+      const res = await eventApp.request(`/events/${ULID}/lock-scoring`, { method: "POST" });
+      await expectForbidden(res);
+    });
+  });
+
+  describe("TenantOperator (= mutate OK, destructive NG)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantOperator";
+    });
+
+    it("POST /events は pass (= Operator も event 作成 OK)", async () => {
+      const res = await eventApp.request("/events", {
+        method: "POST",
+        body: JSON.stringify({
+          internalSlug: "x",
+          displayName: "X",
+          competitorAccounts: [{ awsAccountId: "123456789012", teamName: "T" }],
+          problemIds: ["security-battle-royale"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectNotForbidden(res);
+    });
+
+    it("POST /events/:id/deploy (bulk) は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}/deploy`, {
+        method: "POST",
+        body: "",
+      });
+      await expectNotForbidden(res);
+    });
+
+    it("POST /events/:id/disruptions/fire は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}/disruptions/fire`, {
+        method: "POST",
+        body: JSON.stringify({
+          problemId: "security-battle-royale",
+          disruptionId: "test-disruption",
+          requestId: ULID,
+          scope: "single",
+          targetTeamIds: ["t1"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectNotForbidden(res);
+    });
+
+    it("DELETE /events/:id は 403 (= destructive bulk teardown は Admin のみ)", async () => {
+      const res = await eventApp.request(`/events/${ULID}`, { method: "DELETE" });
+      await expectForbidden(res);
+    });
+
+    it("POST /events/:id/archive は 403 (= archive は Admin のみ)", async () => {
+      const res = await eventApp.request(`/events/${ULID}/archive`, { method: "POST" });
+      await expectForbidden(res);
+    });
+
+    it("POST /events/:id/lock-scoring は 403 (= scoring lock は Admin のみ)", async () => {
+      const res = await eventApp.request(`/events/${ULID}/lock-scoring`, { method: "POST" });
+      await expectForbidden(res);
+    });
+  });
+
+  describe("TenantAdmin (= everything OK)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+    });
+
+    it("DELETE /events/:id は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}`, { method: "DELETE" });
+      await expectNotForbidden(res);
+    });
+
+    it("POST /events/:id/archive は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}/archive`, { method: "POST" });
+      await expectNotForbidden(res);
+    });
+
+    it("POST /events/:id/lock-scoring は pass", async () => {
+      const res = await eventApp.request(`/events/${ULID}/lock-scoring`, { method: "POST" });
+      await expectNotForbidden(res);
+    });
+  });
+});
+
+describe("ADR-020 Phase B.1 (#948): competitor-accounts-handler route role gates", () => {
+  describe("TenantViewer (= dropdown populate のため list には pass)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantViewer";
+    });
+
+    it("GET /admin/competitor-accounts は 200 (= EventCreate dropdown 用)", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts");
+      expect(res.status).toBe(200);
+    });
+
+    it("POST /admin/competitor-accounts は 403 (= 新規登録は Admin)", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts", {
+        method: "POST",
+        body: JSON.stringify({ awsAccountId: "123456789012", teamName: "T" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("DELETE /admin/competitor-accounts/:id は 403", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts/123456789012", {
+        method: "DELETE",
+      });
+      await expectForbidden(res);
+    });
+
+    it("GET /admin/tenant-saml-config は 403 (= SAML 設定は Admin)", async () => {
+      const res = await competitorApp.request("/admin/tenant-saml-config");
+      await expectForbidden(res);
+    });
+
+    it("GET /admin/users は 403 (= user 一覧は Admin)", async () => {
+      const res = await competitorApp.request("/admin/users");
+      await expectForbidden(res);
+    });
+  });
+
+  describe("TenantOperator", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantOperator";
+    });
+
+    it("GET /admin/competitor-accounts は pass (= Operator も dropdown 使う)", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts");
+      await expectNotForbidden(res);
+    });
+
+    it("POST /admin/competitor-accounts は 403 (= Admin 限定)", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts", {
+        method: "POST",
+        body: JSON.stringify({ awsAccountId: "123456789012", teamName: "T" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectForbidden(res);
+    });
+
+    it("DELETE /admin/users/:username は 403 (= user 削除は Admin)", async () => {
+      const res = await competitorApp.request("/admin/users/alice", { method: "DELETE" });
+      await expectForbidden(res);
+    });
+  });
+
+  describe("TenantAdmin (= everything OK)", () => {
+    beforeEach(() => {
+      process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+    });
+
+    it("POST /admin/competitor-accounts は pass", async () => {
+      const res = await competitorApp.request("/admin/competitor-accounts", {
+        method: "POST",
+        body: JSON.stringify({ awsAccountId: "123456789012", teamName: "T" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectNotForbidden(res);
+    });
+
+    it("GET /admin/users は pass", async () => {
+      const res = await competitorApp.request("/admin/users");
+      expect(res.status).toBe(200);
+    });
+
+    it("PATCH /admin/users/:username は pass", async () => {
+      const res = await competitorApp.request("/admin/users/alice", {
+        method: "PATCH",
+        body: JSON.stringify({ role: "TenantViewer" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      await expectNotForbidden(res);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

旧 broken-glass 規律 (= 3 handler の全 route で TenantAdmin only) を、 ADR-020 が規定する **3 role × HTTP method** の matrix に置換する。 これで Operator / Viewer を招待した tenant の persona mismatch (= EventCreate dropdown 空問題、 #948 本文 image 由来) を解消する。

## Role × Route matrix

| handler | route | required role |
| --- | --- | --- |
| **deploy** | GET /problems/:id/deployments, GET /deployments, GET /deployments/:jobId, GET /deployments/:jobId/stack-progress | Admin / Operator / Viewer |
| **deploy** | POST /problems/:id/deploy, POST /deployments/retry, DELETE /deployments/:jobId | Admin / Operator |
| **events** | GET /events, GET /events/:id, GET /events/:id/disruptions, GET /events/:id/disruptions/audit | Admin / Operator / Viewer |
| **events** | POST /events, PATCH /events/:id/schedule, POST /events/:id/end, POST /events/:id/deploy, POST /events/:id/notifications, POST /events/:id/disruptions/fire | Admin / Operator |
| **events** | DELETE /events/:id, POST /events/:id/archive, POST/DELETE /events/:id/lock-scoring | Admin |
| **competitor-accounts** | GET /admin/competitor-accounts | Admin / Operator / Viewer (= dropdown populate) |
| **competitor-accounts** | POST/DELETE /admin/competitor-accounts*, /admin/tenant-saml-config (all), /admin/users* (all incl. GET) | Admin |

## 実装

- 3 handler の `app.use(... requireTenantAdmin)` を `requireRole(c, TENANT_ROLES)` (= 認証済 tenant user) に緩め、 各 route の 1 行目で granular な `requireRole(c, [...])` を呼ぶ
- forbidden_role の error message を 「あなたの tenant role ではこの操作を実行できません」 に変更 (= 旧 message 「TenantAdmin role が必要」 は granular 化後 misleading)
- frontend は引き続き error code \`forbidden_role\` を FriendlyErrorAlert で扱える

## test

- 新 \`infrastructure/test/problem-deploy/role-gates.test.ts\` で 37 case の matrix を pin
- 既存 handler test (= deploy-handler-routes / event-* / competitor-accounts-routes / handler-error-cors) は \`DEFAULT_USER_ROLE = \"TenantAdmin\"\` のまま regression 0
- 全 1202 件 infra test green

## Regression 分析

- 旧 caller (= TenantAdmin ログイン) は引き続き全 route pass (= 1202 件 既存 test green)
- 新 caller (= Viewer / Operator ログイン) は dropdown / list 系で 200 を受け取れるようになり、 EventCreate UX 問題が解消
- destructive 経路 (= 削除 / archive / lock-scoring / SAML config / user 管理) は Admin のみ pass で fail-closed を維持
- claim 不在 / unknown role は引き続き 403 (= ForbiddenRoleError throw)
- API contract: 旧 \"forbidden_role\" error code は維持、 message text のみ変更 (= frontend が code で分岐していれば影響なし)

## 物理影響

- UPDATE: 3 handler index.ts (各 +~10 行) + 1 新 test file (~440 行)
- CFn / Cognito / IAM: NO-OP (= role enforcement は app layer のみ、 Cognito 側 \`custom:userRole\` claim 構成は ADR-020 Phase B の PR-931 で既に整備済)
- audit-deps: baseline 影響なし

## Test plan

- [x] \`make harness\` — no findings
- [x] \`make typecheck\` — 全 workspace clean
- [x] \`make test\` — 1202 件 (= 既存 1165 + 新 37) 通過
- [x] \`make before-commit\` — lint / test / validate-problems / audit-deps / cdk synth 全通過

Closes #948
Relates ADR-020 / PR-931 (= Phase B 基盤に乗る Phase B.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced role-based access control across admin operations for stricter authorization enforcement.
  * Improved error responses when access is denied, now with clearer messaging.

* **Tests**
  * Added comprehensive test suite validating authorization controls across admin endpoints to ensure proper access restrictions based on user roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->