### PR TITLE
fix(#947): hello-world に hint penalty + wrongAnswerPenalty を実装

### DIFF
--- a/problems/challenges/hello-world/metadata.json
+++ b/problems/challenges/hello-world/metadata.json
@@ -50,9 +50,18 @@
     "kind": "flag",
     "flagOutputKey": "ParameterValue",
     "points": 100,
+    "wrongAnswerPenalty": 5,
     "hints": [
-      "AWS Console (SSM Parameter Store) または `aws ssm get-parameter --name /{NamePrefix}/hello` で値を読み出してください",
-      "値は `Hello from tc-...` の形式で、Stack 名 prefix を含みます"
+      {
+        "id": "hint-1",
+        "content": "AWS Console (SSM Parameter Store) または `aws ssm get-parameter --name /{NamePrefix}/hello` で値を読み出してください",
+        "penalty": 10
+      },
+      {
+        "id": "hint-2",
+        "content": "値は `Hello from tc-...` の形式で、Stack 名 prefix を含みます (= NamePrefix の値そのもの)",
+        "penalty": 20
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Issue #947: portal に 「ヒント (0 / 2 公開済)」 + 「公開すると -0 pt」 と表示されるが、 metadata.json の \`hints[]\` が legacy v1 (string) 形式で penalty=0 に正規化されるため、 hint reveal の **減点体験そのものを sample で確認できない** 状態だった。

hello-world は scoring engine + deploy chain の end-to-end smoke test を兼ねる sample 問題 (ADR-012)。 hint penalty が動く挙動を sample で観察できなければ、 他問題で hint feature を使う運営が動作確認できない。

## 実装

\`problems/challenges/hello-world/metadata.json\` scoring block:

- v1 string × 2 → v2 ProgressiveHint object × 2 に変換
  - hint-1 (soft hint, AWS Console/CLI 経路): penalty=10
  - hint-2 (near-answer, 値フォーマット): penalty=20
- \`wrongAnswerPenalty\`=5 を追加 (= brute-force discourager、 issue #817 で導入された field)

Penalty が累積した場合の例: hint 2 段階 reveal + 不正解 1 回 = 100 - 10 - 20 - 5 = 65 pt。 clamp により 0 未満にはならない。

## Regression 分析

- SCHEMA validation: \`make validate-problems\` 通過 (= v2 ProgressiveHint object は SCHEMA 許容形式)
- v1 (string) の他 hint を持つ問題 (= microservice-migration-battle / security-battle-royale / hello-world-battle) は無改修、 backward 互換維持
- scoring engine (\`infrastructure/lib/utils/scoring-metadata.ts\`) は v1 / v2 両方を normalize するため pipeline 影響なし

## 物理影響

- UPDATE: \`problems/challenges/hello-world/metadata.json\` のみ (= 数行)
- CFn / AWS: NO-OP (= 問題 template.yaml は不変)
- portal hint reveal UI は metadata を runtime fetch で読むので portal バイナリ rebuild 不要 (= deploy 後すぐ反映)

## Test plan

- [x] \`make validate-problems\` — 4 件 metadata 全 valid
- [x] \`make harness\` — no findings
- [x] \`make before-commit\` — lint / typecheck / test / build / audit-deps / cdk synth 全通過

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)