### PR TITLE
fix(#946): federation destination を smart に選び SSM list view AccessDenied を回避

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -37,6 +37,35 @@ const AWS_REGION_RE = /^[a-z]{2,3}-[a-z]+-\d{1,2}$/;
 const NAME_PREFIX_RE = /^[a-z][a-z0-9-]{0,127}$/;
 const IAM_ROLE_ARN_RE = /^arn:aws:iam::\d{12}:role\/[A-Za-z0-9+=,.@_/-]+$/;
 
+/**
+ * Issue #946: AWS Console federation destination として SSM Parameter detail を埋めるとき、
+ * Parameter 名は URL に直接挿入される (= `/systems-manager/parameters/<urlencoded>/description`)。
+ * 攻撃者が namePrefix を改竄して `#`/`?`/`/` 等の特殊文字を入れることで Destination を曲げる
+ * 経路を塞ぐため、 strict pattern を再 validate する (= 先頭 `/` 必須 + 英数 / `.` / `_` / `-` / `/` のみ)。
+ */
+const SSM_PARAM_NAME_RE = /^\/[A-Za-z0-9._\-/]{1,1023}$/;
+
+/**
+ * Issue #946: stack outputs から destination を決定する pure function (= testable に切り出し)。
+ *
+ * - `ssmParameterName` が strict regex に合致するなら SSM Parameter detail URL (= list view を
+ *   経由しないため `ssm:DescribeParameters` 不要)
+ * - そうでなければ CFn stacks 画面 (= multi-resource 問題で Resources tab から辿る前提)
+ *
+ * caller は `region` / `namePrefix` を事前 validate 済 (= URL injection 防御済) で渡す責務を負う。
+ */
+export function buildConsoleDestination(args: {
+  readonly region: string;
+  readonly namePrefix: string;
+  readonly ssmParameterName: string | undefined;
+}): string {
+  const { region, namePrefix, ssmParameterName } = args;
+  if (ssmParameterName && SSM_PARAM_NAME_RE.test(ssmParameterName)) {
+    return `https://${region}.console.aws.amazon.com/systems-manager/parameters/${encodeURIComponent(ssmParameterName)}/description?region=${encodeURIComponent(region)}`;
+  }
+  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(region)}#/stacks?filteringText=${encodeURIComponent(namePrefix)}`;
+}
+
 const sts = new STSClient({});
 
 type StsCredentialShape = {
@@ -240,9 +269,16 @@ export async function getConsoleSigninUrl(
     return { kind: "federation_token_malformed" };
   }
 
-  // CloudFormation スタック画面に直接遷移するための destination URL。
-  // 自分の deployment の namePrefix で stacks フィルタ済の view にする。
-  const destination = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(region)}#/stacks?filteringText=${encodeURIComponent(deployment.namePrefix)}`;
+  // Issue #946: stack outputs に `ParameterName` があれば SSM Parameter detail page に直接遷移
+  // させる (= AWS Console SSM Parameter Store の list view を経由しないため
+  // ssm:DescribeParameters 不要、 JAM/GameDay baseline IAM (PR-933 / ADR-021) と整合)。
+  // それ以外は従来通り CFn stacks 画面 (= multi-resource 問題で Resources tab 経由)。
+  const ssmParameterNameRaw = parsedOutputs.ParameterName;
+  const destination = buildConsoleDestination({
+    region,
+    namePrefix: deployment.namePrefix,
+    ssmParameterName: typeof ssmParameterNameRaw === "string" ? ssmParameterNameRaw : undefined,
+  });
   const loginUrl = `${FEDERATION_ENDPOINT}?Action=login&Issuer=${encodeURIComponent(TENKACLOUD_ISSUER)}&Destination=${encodeURIComponent(destination)}&SigninToken=${encodeURIComponent(tokenJson.SigninToken)}`;
 
   return { kind: "ok", loginUrl };

--- a/infrastructure/test/problem-deploy/sso-console-destination.test.ts
+++ b/infrastructure/test/problem-deploy/sso-console-destination.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildConsoleDestination } from "../../lib/problem-deploy/handlers/participant-handler/sso";
+
+/**
+ * Issue #946: AWS Console federation destination の選択ロジックを pin する。
+ *
+ * 旧挙動: 常に CFn stacks 画面 (= 全 stack list を namePrefix で filter) を destination にしていた。
+ * その後 user が SSM Parameter Store サイドバーをクリックすると list view 経由で `ssm:DescribeParameters`
+ * AccessDenied になる経路があった (= JAM/GameDay baseline IAM では list 権限を与えない、 PR-933)。
+ *
+ * 新挙動: stack outputs に `ParameterName` (= SSM Parameter のフルパス) があれば SSM Parameter detail
+ * page に直接遷移させる (= list view を経由しないので IAM 不変で動く)。
+ */
+
+const REGION = "ap-northeast-1";
+const NAME_PREFIX = "tc-hello-world-team-3";
+
+describe("buildConsoleDestination (#946)", () => {
+  it("ssmParameterName 未指定なら CFn stacks 画面を返すべき (= 旧挙動 / multi-resource 問題用)", () => {
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: undefined,
+    });
+    expect(url).toBe(
+      "https://ap-northeast-1.console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks?filteringText=tc-hello-world-team-3",
+    );
+  });
+
+  it("ssmParameterName が有効なら SSM Parameter detail URL を返すべき (= deep link、 list view 不要)", () => {
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: "/tc-hello-world-team-3/hello",
+    });
+    expect(url).toBe(
+      "https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/%2Ftc-hello-world-team-3%2Fhello/description?region=ap-northeast-1",
+    );
+  });
+
+  it("ssmParameterName に許可外文字 (= `#` / `?`) を含むなら CFn fallback すべき (= URL injection 防御)", () => {
+    const malicious = "/tc#injection?query";
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: malicious,
+    });
+    // CFn 画面 (= fallback)
+    expect(url).toContain("/cloudformation/home");
+    expect(url).not.toContain(encodeURIComponent(malicious));
+  });
+
+  it("ssmParameterName が `/` で始まらないなら CFn fallback すべき", () => {
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: "no-leading-slash",
+    });
+    expect(url).toContain("/cloudformation/home");
+  });
+
+  it("ssmParameterName が空文字なら CFn fallback すべき", () => {
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: "",
+    });
+    expect(url).toContain("/cloudformation/home");
+  });
+
+  it("path 内に `.` / `_` / `-` は許容 (= IAM Parameter naming に合う)", () => {
+    const valid = "/tc-x_y.z/sub-key";
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: valid,
+    });
+    expect(url).toContain("/systems-manager/parameters/");
+    expect(url).toContain(encodeURIComponent(valid));
+  });
+
+  it("region は URL-encode される (= defense-in-depth、 region は事前 RE validate 済の前提)", () => {
+    const url = buildConsoleDestination({
+      region: "us-east-1",
+      namePrefix: "x",
+      ssmParameterName: undefined,
+    });
+    expect(url).toContain("region=us-east-1");
+  });
+
+  it("ssmParameterName が 1023 文字を超えるなら CFn fallback (= URL 長制限の defensive)", () => {
+    const tooLong = `/${"a".repeat(1024)}`;
+    const url = buildConsoleDestination({
+      region: REGION,
+      namePrefix: NAME_PREFIX,
+      ssmParameterName: tooLong,
+    });
+    expect(url).toContain("/cloudformation/home");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #946: PR-933 (ADR-021 / JAM/GameDay baseline) で参加者 Role から \`ssm:DescribeParameters\` を削除した結果、 portal 経由で AWS Console に federation login した後 SSM Parameter Store サイドバーに飛ぶと list view が AccessDenied で表示不能。 競技者は CLI で \`aws ssm get-parameter\` を叩けば値を取れるが、 web UI からは進めず onboarding が止まる (= hello-world 体験を阻害、 image #46)。

## 実装

\`sso.ts\` の federation destination 構築を smart に変更:

- stack outputs に \`ParameterName\` (= SSM Parameter フルパス) があれば、 destination として **SSM Parameter detail page** を直接渡す (\`/systems-manager/parameters/<URL-encoded path>/description\`)。 List view を経由しないため \`ssm:DescribeParameters\` 不要
- 旧挙動 (= CFn stacks 画面、 namePrefix で filter) は EC2 / Lambda / multi-resource 問題用に維持。 SSM Parameter が outputs に無い場合は fallback

destination 構築を pure function \`buildConsoleDestination\` に切り出し、 unit test 可能に。 \`SSM_PARAM_NAME_RE\` で 先頭 \`/\` 必須 + 英数 / \`.\` / \`_\` / \`-\` / \`/\` のみ許容の strict pattern を再 validate (= attacker が \`#\`/\`?\` を埋めて Destination を曲げる経路を塞ぐ)。

## test

新 \`infrastructure/test/problem-deploy/sso-console-destination.test.ts\` で 8 case:

- \`ssmParameterName\` 未指定 → CFn fallback
- 有効な path → SSM detail URL
- 許可外文字 (= \`#\` / \`?\`) → CFn fallback (URL injection 防御)
- 先頭 \`/\` 無し / 空 / 1023 文字超え → CFn fallback
- \`.\` / \`_\` / \`-\` を含む path は許容

## 解決案の選定 (= 議論候補との対応)

| 候補 | 採用? | 理由 |
| --- | --- | --- |
| A: portal が console signin URL に Destination で SSM parameter detail URL を埋め込む | ✓ | 本 PR が実装 |
| B: portal のリンクを \`/systems-manager/parameters/{name}/description\` 形式に変える | ✓ | A と同じ実装で達成 |
| C: \`ssm:DescribeParameters\` を Condition で path-prefix scope して付与 | ✗ | AWS Console SPA は Cognito Console 仕様で path-prefix Condition を効かせられない (= 全 path を見ようとするので path 単位の deny にならない、 検証保留) |

## Regression 分析

- 既存 multi-resource 問題 (= security-battle-royale / microservice-migration-battle) は \`ParameterName\` を outputs に持たないため CFn fallback で旧挙動と同じ
- hello-world / hello-world-battle のような SSM-only 問題は detail page に直接遷移し、 list view AccessDenied 回避
- URL injection 防御は strict regex で多層化 (= namePrefix / region は既存 RE、 ssmParameterName は新 RE、 encodeURIComponent で final escape)
- 1202 件の既存 infra test 全 green、 新 8 test 追加

## 物理影響

- UPDATE: \`sso.ts\` (+30 行 destination logic + 切り出し)
- NEW test (= 90 行)
- CFn / IAM: NO-OP (= 参加者 Role policy は不変、 destination URL のみ変更)
- portal frontend: 影響なし (= 受け取った loginUrl を新 tab で開くだけ)

## Test plan

- [x] \`make harness\` — no findings
- [x] \`make typecheck\` — clean
- [x] \`bunx vitest run test/problem-deploy/sso-console-destination.test.ts\` — 8 passed
- [x] \`make before-commit\` — 全通過

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)