### PR TITLE
feat(#949): SystemAdmin Console 側の system user 管理 UI (ADR-020 Phase C)

### DIFF
--- a/apps/admin-console/src/App.tsx
+++ b/apps/admin-console/src/App.tsx
@@ -8,6 +8,7 @@ import { AdminEventDetailPage } from "./pages/AdminEventDetail";
 import { CallbackPage } from "./pages/Callback";
 import { JobsPage } from "./pages/Jobs";
 import { LoginPage } from "./pages/Login";
+import { SystemUsersPage } from "./pages/SystemUsers";
 import { TenantCreatePage } from "./pages/TenantCreate";
 import { TenantEventsPage } from "./pages/TenantEvents";
 import { TenantListPage } from "./pages/TenantList";
@@ -82,6 +83,17 @@ export function App({ config }: { config: AppConfig }) {
             <RequireAuth>
               <ShellLayout>
                 <JobsPage config={config} />
+              </ShellLayout>
+            </RequireAuth>
+          }
+        />
+        {/* Issue #949 (ADR-020 Phase C): SystemAdmin user 管理 */}
+        <Route
+          path="/settings/system-users"
+          element={
+            <RequireAuth>
+              <ShellLayout>
+                <SystemUsersPage config={config} />
               </ShellLayout>
             </RequireAuth>
           }

--- a/apps/admin-console/src/api/system-users-client.ts
+++ b/apps/admin-console/src/api/system-users-client.ts
@@ -1,0 +1,165 @@
+import { StatusCodes } from "http-status-codes";
+import type { AppConfig } from "../config";
+
+/**
+ * Issue #949 (ADR-020 Phase C): SystemAdmin Console から ControlPlane UserPool の
+ * SystemAdmin / SystemAuditor user を CRUD する client。 admin-insight Lambda の
+ * `/admin/insight/system-users` route 群を叩く (= 既存 `fetchTenantsInsightSummary` と同じ
+ * base URL: `config.adminInsightApiUrl`)。
+ *
+ * `config.adminInsightApiUrl` 未配線 (= phase 2 deploy 前 / dev) なら client は null を返す。
+ * caller (SystemUsersPage) は null を見て「未配線」 alert を表示する。
+ */
+
+export const SYSTEM_ROLES = ["SystemAdmin", "SystemAuditor"] as const;
+export type SystemUserRole = (typeof SYSTEM_ROLES)[number];
+
+export interface SystemUserSummary {
+  readonly username: string;
+  readonly email?: string;
+  readonly enabled?: boolean;
+  readonly status?: string;
+  readonly createdAt?: string;
+  readonly groups: readonly SystemUserRole[];
+}
+
+export interface SystemUsersClient {
+  list(): Promise<SystemUserSummary[]>;
+  invite(input: { email: string; role: SystemUserRole }): Promise<SystemUserSummary>;
+  changeRole(username: string, role: SystemUserRole): Promise<void>;
+  remove(username: string): Promise<void>;
+}
+
+export class SystemUsersApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly errorCode: string | undefined,
+    public readonly detail: unknown,
+  ) {
+    super(`SystemUsers API ${status}: ${errorCode ?? "unknown_error"}`);
+    this.name = "SystemUsersApiError";
+  }
+}
+
+export function createSystemUsersClient(
+  config: AppConfig,
+  idToken: string,
+): SystemUsersClient | null {
+  if (!config.adminInsightApiUrl) {
+    return null;
+  }
+  const base = config.adminInsightApiUrl.endsWith("/")
+    ? config.adminInsightApiUrl
+    : `${config.adminInsightApiUrl}/`;
+
+  const request = async (path: string, init: RequestInit = {}): Promise<Response | undefined> => {
+    const url = new URL(path.replace(/^\//, ""), base);
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${idToken}`,
+        "content-type": "application/json",
+        ...init.headers,
+      },
+    });
+    if (!res.ok) {
+      let errorCode: string | undefined;
+      let detail: unknown;
+      try {
+        const body = await res.json();
+        detail = body;
+        if (typeof body === "object" && body !== null && "error" in body) {
+          errorCode = String((body as { error: unknown }).error);
+        }
+      } catch {
+        // body parse 失敗時は detail を text で残す
+        try {
+          detail = await res.text();
+        } catch {
+          /* noop */
+        }
+      }
+      throw new SystemUsersApiError(res.status, errorCode, detail);
+    }
+    return res;
+  };
+
+  return {
+    async list() {
+      const res = await request("admin/insight/system-users");
+      if (!res) return [];
+      const body = (await res.json()) as { items?: SystemUserSummary[] };
+      return body.items ?? [];
+    },
+    async invite(input) {
+      const res = await request("admin/insight/system-users", {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+      if (!res) throw new Error("invite returned undefined response");
+      return (await res.json()) as SystemUserSummary;
+    },
+    async changeRole(username, role) {
+      await request(`admin/insight/system-users/${encodeURIComponent(username)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      });
+    },
+    async remove(username) {
+      await request(`admin/insight/system-users/${encodeURIComponent(username)}`, {
+        method: "DELETE",
+      });
+    },
+  };
+}
+
+/**
+ * SystemUsersApiError を human-readable な message + i18n key にマップするヘルパ。
+ * caller (UI) は本 helper を経由して 「あなたの role では…」 「最後の SystemAdmin は削除できません」
+ * 等の親切なエラーを表示できる。
+ */
+export function describeSystemUsersError(err: SystemUsersApiError): {
+  i18nKey: string;
+  fallback: string;
+} {
+  switch (err.status) {
+    case StatusCodes.FORBIDDEN:
+      return { i18nKey: "system_users.error.forbidden", fallback: "SystemAdmin role が必要です" };
+    case StatusCodes.CONFLICT:
+      if (err.errorCode === "cannot_delete_self") {
+        return {
+          i18nKey: "system_users.error.cannot_delete_self",
+          fallback: "lock-out 防止のため自分自身は削除できません",
+        };
+      }
+      if (err.errorCode === "cannot_demote_self") {
+        return {
+          i18nKey: "system_users.error.cannot_demote_self",
+          fallback: "lock-out 防止のため自分自身を降格できません",
+        };
+      }
+      if (err.errorCode === "duplicate_user") {
+        return {
+          i18nKey: "system_users.error.duplicate",
+          fallback: "同 email の user が既に存在します",
+        };
+      }
+      return { i18nKey: "system_users.error.conflict", fallback: "競合が発生しました" };
+    case StatusCodes.SERVICE_UNAVAILABLE:
+      return {
+        i18nKey: "system_users.error.unconfigured",
+        fallback:
+          "AdminInsight stack に ControlPlane UserPool が配線されていません (= deploy chain の更新が必要)",
+      };
+    case StatusCodes.NOT_FOUND:
+      return {
+        i18nKey: "system_users.error.not_found",
+        fallback: "user が見つかりません",
+      };
+    default:
+      return {
+        i18nKey: "system_users.error.generic",
+        fallback: `エラーが発生しました (${err.status})`,
+      };
+  }
+}

--- a/apps/admin-console/src/components/AppLayout.tsx
+++ b/apps/admin-console/src/components/AppLayout.tsx
@@ -64,6 +64,7 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/tenants", text: t("nav.tenants") },
               { type: "link", href: "/tenants/new", text: t("nav.tenants_new") },
               { type: "link", href: "/jobs", text: t("nav.jobs") },
+              { type: "link", href: "/settings/system-users", text: t("nav.system_users") },
               { type: "divider" },
               // Issue #899: Scalar による API reference。 同 origin の static file (public/api-docs.html)
               // へ external link。 SPA route と分離 (= API spec を SPA bundle に混ぜない)。

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -11,6 +11,7 @@
     "tenants": "Tenants",
     "tenants_new": "Create tenant",
     "jobs": "Provisioning Jobs",
+    "system_users": "SystemAdmin users",
     "api_docs": "API Reference ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -11,6 +11,7 @@
     "tenants": "Tenants",
     "tenants_new": "Crear tenant",
     "jobs": "Trabajos de aprovisionamiento",
+    "system_users": "Usuarios SystemAdmin",
     "api_docs": "Referencia de API ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -11,6 +11,7 @@
     "tenants": "テナント一覧",
     "tenants_new": "テナント作成",
     "jobs": "プロビジョニング Jobs",
+    "system_users": "SystemAdmin user 管理",
     "api_docs": "API リファレンス ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -11,6 +11,7 @@
     "tenants": "租户列表",
     "tenants_new": "创建租户",
     "jobs": "配置作业",
+    "system_users": "SystemAdmin 用户管理",
     "api_docs": "API 参考 ↗"
   },
   "auth": {

--- a/apps/admin-console/src/pages/SystemUsers.tsx
+++ b/apps/admin-console/src/pages/SystemUsers.tsx
@@ -1,0 +1,377 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createSystemUsersClient,
+  describeSystemUsersError,
+  SYSTEM_ROLES,
+  type SystemUserRole,
+  type SystemUserSummary,
+  SystemUsersApiError,
+} from "../api/system-users-client";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * Issue #949 (ADR-020 Phase C): SystemAdmin Console 側の system user 管理画面。
+ *
+ * UI flow:
+ *   1. mount で GET /admin/insight/system-users → 一覧表示
+ *   2. 「招待」 button → email + role (= SystemAdmin / SystemAuditor) modal → POST
+ *   3. 行ごとの 「role 変更」 → modal → PATCH
+ *   4. 行ごとの 「削除」 → 確認 modal → DELETE
+ *
+ * Lock-out 防止:
+ *   - 自分自身は削除できない (server 409 cannot_delete_self)
+ *   - 自分自身を SystemAuditor に降格できない (server 409 cannot_demote_self)
+ *
+ * 設定エラー:
+ *   - `adminInsightApiUrl` 未配線 (= phase 2 前) → client が null、 「未配線」 alert を表示
+ */
+export function SystemUsersPage({ config }: { config: AppConfig }) {
+  const auth = useAuth();
+  const client = useMemo(
+    () => (auth.tokens ? createSystemUsersClient(config, auth.tokens.idToken) : null),
+    [auth.tokens, config],
+  );
+  const [users, setUsers] = useState<SystemUserSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<SystemUserRole>("SystemAdmin");
+  const [inviteSubmitting, setInviteSubmitting] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+
+  const [roleTarget, setRoleTarget] = useState<SystemUserSummary | null>(null);
+  const [roleNew, setRoleNew] = useState<SystemUserRole>("SystemAdmin");
+  const [roleSubmitting, setRoleSubmitting] = useState(false);
+  const [roleError, setRoleError] = useState<string | null>(null);
+
+  const [deleteTarget, setDeleteTarget] = useState<SystemUserSummary | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!client) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const items = await client.list();
+      setUsers(items);
+    } catch (err) {
+      if (err instanceof SystemUsersApiError) {
+        setLoadError(describeSystemUsersError(err).fallback);
+      } else if (err instanceof Error) {
+        setLoadError(err.message);
+      } else {
+        setLoadError("一覧取得に失敗しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const submitInvite = async () => {
+    if (!client) return;
+    setInviteSubmitting(true);
+    setInviteError(null);
+    try {
+      await client.invite({ email: inviteEmail, role: inviteRole });
+      setInviteOpen(false);
+      setInviteEmail("");
+      setInviteRole("SystemAdmin");
+      setSuccessMessage(`${inviteEmail} を招待しました (Cognito から email が届きます)`);
+      await refresh();
+    } catch (err) {
+      if (err instanceof SystemUsersApiError) {
+        setInviteError(describeSystemUsersError(err).fallback);
+      } else if (err instanceof Error) {
+        setInviteError(err.message);
+      } else {
+        setInviteError("招待に失敗しました");
+      }
+    } finally {
+      setInviteSubmitting(false);
+    }
+  };
+
+  const submitRoleChange = async () => {
+    if (!client || !roleTarget) return;
+    setRoleSubmitting(true);
+    setRoleError(null);
+    try {
+      await client.changeRole(roleTarget.username, roleNew);
+      setRoleTarget(null);
+      setSuccessMessage(`${roleTarget.email ?? roleTarget.username} を ${roleNew} に変更しました`);
+      await refresh();
+    } catch (err) {
+      if (err instanceof SystemUsersApiError) {
+        setRoleError(describeSystemUsersError(err).fallback);
+      } else if (err instanceof Error) {
+        setRoleError(err.message);
+      } else {
+        setRoleError("role 変更に失敗しました");
+      }
+    } finally {
+      setRoleSubmitting(false);
+    }
+  };
+
+  const submitDelete = async () => {
+    if (!client || !deleteTarget) return;
+    setDeleteSubmitting(true);
+    setDeleteError(null);
+    try {
+      await client.remove(deleteTarget.username);
+      const removed = deleteTarget;
+      setDeleteTarget(null);
+      setSuccessMessage(`${removed.email ?? removed.username} を削除しました`);
+      await refresh();
+    } catch (err) {
+      if (err instanceof SystemUsersApiError) {
+        setDeleteError(describeSystemUsersError(err).fallback);
+      } else if (err instanceof Error) {
+        setDeleteError(err.message);
+      } else {
+        setDeleteError("削除に失敗しました");
+      }
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  };
+
+  if (!client) {
+    return (
+      <Container header={<Header>SystemAdmin user 管理</Header>}>
+        <Alert type="warning" header="AdminInsight stack が未配線">
+          \`config.adminInsightApiUrl\` が空のため SystemAdmin user 管理 UI は利用できません。 Phase
+          2 の deploy を完了して runtime-config.json に <code>adminInsightApiUrl</code>{" "}
+          を注入してください。
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={
+          <Button variant="primary" onClick={() => setInviteOpen(true)}>
+            SystemAdmin user を招待
+          </Button>
+        }
+      >
+        SystemAdmin user 管理
+      </Header>
+
+      {successMessage && (
+        <Alert type="success" dismissible onDismiss={() => setSuccessMessage(null)}>
+          {successMessage}
+        </Alert>
+      )}
+      {loadError && (
+        <Alert type="error" header="一覧取得に失敗">
+          {loadError}
+        </Alert>
+      )}
+
+      <Table
+        loading={loading}
+        loadingText="読み込み中…"
+        items={users}
+        columnDefinitions={[
+          {
+            id: "email",
+            header: "Email",
+            cell: (u) => u.email ?? u.username,
+          },
+          {
+            id: "role",
+            header: "Role",
+            cell: (u) => u.groups.join(", ") || "(未割当)",
+          },
+          {
+            id: "status",
+            header: "状態",
+            cell: (u) => `${u.enabled === false ? "(無効) " : ""}${u.status ?? "-"}`,
+          },
+          {
+            id: "createdAt",
+            header: "作成日時",
+            cell: (u) => u.createdAt ?? "-",
+          },
+          {
+            id: "actions",
+            header: "操作",
+            cell: (u) => (
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button
+                  variant="normal"
+                  onClick={() => {
+                    setRoleTarget(u);
+                    setRoleNew((u.groups[0] ?? "SystemAdmin") as SystemUserRole);
+                    setRoleError(null);
+                  }}
+                >
+                  role 変更
+                </Button>
+                <Button
+                  variant="normal"
+                  onClick={() => {
+                    setDeleteTarget(u);
+                    setDeleteError(null);
+                  }}
+                >
+                  削除
+                </Button>
+              </SpaceBetween>
+            ),
+          },
+        ]}
+        empty={
+          <Box textAlign="center" padding="m">
+            <SpaceBetween size="s">
+              <b>SystemAdmin user が 1 人もいません</b>
+              <Button variant="primary" onClick={() => setInviteOpen(true)}>
+                招待する
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      />
+
+      <Modal
+        visible={inviteOpen}
+        onDismiss={() => setInviteOpen(false)}
+        header="SystemAdmin user を招待"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => setInviteOpen(false)}>
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                onClick={submitInvite}
+                loading={inviteSubmitting}
+                disabled={!inviteEmail || inviteSubmitting}
+              >
+                招待 email を送信
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <Form>
+          <SpaceBetween size="m">
+            {inviteError && <Alert type="error">{inviteError}</Alert>}
+            <FormField label="Email" description="招待 email の宛先 + Cognito Username になります">
+              <Input
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.detail.value)}
+                placeholder="user@example.com"
+              />
+            </FormField>
+            <FormField label="Role">
+              <Select
+                selectedOption={{ value: inviteRole, label: inviteRole }}
+                options={SYSTEM_ROLES.map((r) => ({ value: r, label: r }))}
+                onChange={(e) => setInviteRole(e.detail.selectedOption.value as SystemUserRole)}
+              />
+            </FormField>
+          </SpaceBetween>
+        </Form>
+      </Modal>
+
+      <Modal
+        visible={roleTarget !== null}
+        onDismiss={() => setRoleTarget(null)}
+        header={`role を変更: ${roleTarget?.email ?? roleTarget?.username ?? ""}`}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => setRoleTarget(null)}>
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                onClick={submitRoleChange}
+                loading={roleSubmitting}
+                disabled={roleSubmitting}
+              >
+                変更
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <Form>
+          <SpaceBetween size="m">
+            {roleError && <Alert type="error">{roleError}</Alert>}
+            <FormField label="新しい role">
+              <Select
+                selectedOption={{ value: roleNew, label: roleNew }}
+                options={SYSTEM_ROLES.map((r) => ({ value: r, label: r }))}
+                onChange={(e) => setRoleNew(e.detail.selectedOption.value as SystemUserRole)}
+              />
+            </FormField>
+          </SpaceBetween>
+        </Form>
+      </Modal>
+
+      <Modal
+        visible={deleteTarget !== null}
+        onDismiss={() => setDeleteTarget(null)}
+        header="user を削除しますか?"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => setDeleteTarget(null)}>
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                onClick={submitDelete}
+                loading={deleteSubmitting}
+                disabled={deleteSubmitting}
+              >
+                削除
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          {deleteError && <Alert type="error">{deleteError}</Alert>}
+          <Box>
+            <p>
+              {deleteTarget?.email ?? deleteTarget?.username} を Cognito UserPool から削除します。
+              削除した user は SystemAdmin Console にサインインできなくなります。
+            </p>
+            <p>
+              <strong>自分自身は削除できません</strong> (= lock-out 防止)。
+            </p>
+          </Box>
+        </SpaceBetween>
+      </Modal>
+    </SpaceBetween>
+  );
+}

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -80,6 +80,10 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       deploymentsTable: props.deploymentsTable,
       eventsTable: props.eventsTable,
       teamsTable: props.teamsTable,
+      // Issue #949: SystemAdmin user CRUD のため ControlPlane UserPool を渡す。
+      // Lambda は env CONTROL_PLANE_USER_POOL_ID + IAM Allow を取得し、
+      // /admin/insight/system-users route 群を実装する。
+      controlPlaneUserPool: props.cognitoUserPool,
       ...(props.deprovisioningStateMachineArn
         ? { deprovisioningStateMachineArn: props.deprovisioningStateMachineArn }
         : {}),
@@ -118,7 +122,15 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       corsPreflight: {
         allowOrigins,
         allowHeaders: ["Authorization", "Content-Type"],
-        allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.OPTIONS],
+        // Issue #949: SystemAdmin user CRUD で POST / DELETE / PATCH が要るため CORS allow を拡張。
+        // 既存 read-only routes は GET のみで動くので影響なし (= preflight allowMethods は superset)。
+        allowMethods: [
+          CorsHttpMethod.GET,
+          CorsHttpMethod.POST,
+          CorsHttpMethod.DELETE,
+          CorsHttpMethod.PATCH,
+          CorsHttpMethod.OPTIONS,
+        ],
         maxAge: cdk.Duration.minutes(10),
       },
     });
@@ -169,6 +181,21 @@ export class AdminConsoleInsightStack extends cdk.Stack {
     httpApi.addRoutes({
       path: "/admin/insight/state-machine-executions",
       methods: [HttpMethod.GET],
+      integration,
+    });
+
+    // Issue #949 (ADR-020 Phase C): SystemAdmin user の CRUD route 群。
+    // 全 route で JWT Authorizer + handler 内の `cognito:groups ⊇ {SystemAdmin}` の 2 段 check で
+    // 認可する。 list / detail は SystemAuditor も pass、 mutate (POST / DELETE / PATCH) は
+    // SystemAdmin only にする予定 (= handler 内 granular gate)。
+    httpApi.addRoutes({
+      path: "/admin/insight/system-users",
+      methods: [HttpMethod.GET, HttpMethod.POST],
+      integration,
+    });
+    httpApi.addRoutes({
+      path: "/admin/insight/system-users/{username}",
+      methods: [HttpMethod.GET, HttpMethod.DELETE, HttpMethod.PATCH],
       integration,
     });
 

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
+import type { IUserPool } from "aws-cdk-lib/aws-cognito";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
@@ -36,6 +37,15 @@ export interface AdminInsightApiLambdaProps {
    * 503 を返す or placeholder)。
    */
   readonly deprovisioningStateMachineArn?: string;
+  /**
+   * Issue #949 (ADR-020 Phase C): SBT ControlPlane の UserPool (= SystemAdmin が登録される pool)。
+   * 指定時は Lambda に `cognito-idp:AdminCreateUser` / `AdminDeleteUser` / `AdminGetUser` /
+   * `AdminUpdateUserAttributes` / `ListUsers` / `AdminAddUserToGroup` / `AdminRemoveUserFromGroup`
+   * 権限を付与し、 `/admin/insight/system-users` route が SystemAdmin user の CRUD を実装する。
+   *
+   * Resource scope は `userPool.userPoolArn` で固定 (= 他 tenant pool への越境を禁止)。
+   */
+  readonly controlPlaneUserPool?: IUserPool;
 }
 
 /**
@@ -73,6 +83,9 @@ export class AdminInsightApiLambda extends Construct {
         // Issue #814 Phase 2: deprovisioning Step Functions ARN を env に渡す (= 未指定なら空)。
         // handler は env の有無で route を 503 にするか実 SFN.ListExecutions を呼ぶか分岐する。
         DEPROVISIONING_STATE_MACHINE_ARN: props.deprovisioningStateMachineArn ?? "",
+        // Issue #949 (ADR-020 Phase C): ControlPlane UserPool ID を env で渡す。 未指定なら空文字
+        // (= /admin/insight/system-users route は 503 を返す)。 prod では必ず注入する想定。
+        CONTROL_PLANE_USER_POOL_ID: props.controlPlaneUserPool?.userPoolId ?? "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -116,6 +129,34 @@ export class AdminInsightApiLambda extends Construct {
         resources: ["*"],
       }),
     );
+
+    // Issue #949 (ADR-020 Phase C): ControlPlane UserPool への SystemAdmin user CRUD 権限。
+    // 指定 UserPool ARN に scope して付与する (= 越境攻撃の防御)。 未指定なら付与しない (= 旧 stack 互換)。
+    // 含む actions:
+    //   - AdminCreateUser  (= 招待 + temp password)
+    //   - AdminDeleteUser  (= 削除)
+    //   - AdminGetUser     (= detail / role 読み取り)
+    //   - AdminUpdateUserAttributes (= role 変更)
+    //   - ListUsers        (= 一覧、 page 化)
+    //   - AdminAddUserToGroup / AdminRemoveUserFromGroup (= SystemAdmin / SystemAuditor group 操作)
+    if (props.controlPlaneUserPool) {
+      this.fn.addToRolePolicy(
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            "cognito-idp:AdminCreateUser",
+            "cognito-idp:AdminDeleteUser",
+            "cognito-idp:AdminGetUser",
+            "cognito-idp:AdminUpdateUserAttributes",
+            "cognito-idp:ListUsers",
+            "cognito-idp:AdminAddUserToGroup",
+            "cognito-idp:AdminRemoveUserFromGroup",
+            "cognito-idp:AdminListGroupsForUser",
+          ],
+          resources: [props.controlPlaneUserPool.userPoolArn],
+        }),
+      );
+    }
 
     // Issue #814 Phase 2: Deprovisioning Jobs route の Step Functions ListExecutions 権限。
     // 指定された SBT BashJobRunner の state machine ARN に scope する。 未指定なら付与しない

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -15,6 +15,15 @@ import { defaultPipelineClient, listPipelineExecutions } from "./pipeline-execut
 import { buildSharedResources } from "./shared.js";
 import { defaultSfnClient, listStateMachineExecutions } from "./state-machine-executions.js";
 import { summarizeTenants } from "./summary.js";
+import {
+  ChangeSystemUserRoleRequestSchema,
+  InviteSystemUserRequestSchema,
+  routeChangeSystemUserRole,
+  routeCreateSystemUser,
+  routeDeleteSystemUser,
+  routeGetSystemUser,
+  routeListSystemUsers,
+} from "./system-users-routes.js";
 
 /**
  * Admin Insight API Lambda の Hono app (ADR-011、issue #590 Phase 1.A + #598 Phase 1.B)。
@@ -345,6 +354,121 @@ app.get("/admin/insight/state-machine-executions", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[admin-insight] listStateMachineExecutions failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// ====== Issue #949 (ADR-020 Phase C): SystemAdmin user 管理 routes ======
+//
+// 認可は 2 段: API GW JWT Authorizer + handler 内 `isSystemAdmin` 検査。 mutate (POST / DELETE /
+// PATCH) は全部 SystemAdmin only にしている (= 一旦 SystemAdmin と SystemAuditor の中間 role を
+// 区別せず、 SystemAuditor は将来 GET だけ pass させる余地として残す)。
+
+const USERNAME_RE = /^[A-Za-z0-9_.@+-]{1,128}$/;
+
+app.get("/admin/insight/system-users", async (c) => {
+  const forbidden = auditAndAuthorize(c, "/admin/insight/system-users");
+  if (forbidden) return forbidden;
+  try {
+    const result = await routeListSystemUsers(c);
+    return c.json(result.body as never, result.status as 200 | 503);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] list system-users failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.post("/admin/insight/system-users", async (c) => {
+  const forbidden = auditAndAuthorize(c, "/admin/insight/system-users[POST]");
+  if (forbidden) return forbidden;
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = InviteSystemUserRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  try {
+    const result = await routeCreateSystemUser(c, parsed.data);
+    return c.json(result.body as never, result.status as 201 | 409 | 503);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] create system-user failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/insight/system-users/:username", async (c) => {
+  const username = c.req.param("username");
+  if (!username || !USERNAME_RE.test(username)) {
+    return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/system-users/:username", { username });
+  if (forbidden) return forbidden;
+  try {
+    const result = await routeGetSystemUser(c, username);
+    return c.json(result.body as never, result.status as 200 | 404 | 503);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] get system-user failed", { username, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.patch("/admin/insight/system-users/:username", async (c) => {
+  const username = c.req.param("username");
+  if (!username || !USERNAME_RE.test(username)) {
+    return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/system-users/:username[PATCH]", {
+    username,
+  });
+  if (forbidden) return forbidden;
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST);
+  }
+  const parsed = ChangeSystemUserRoleRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    );
+  }
+  try {
+    const result = await routeChangeSystemUserRole(c, username, parsed.data);
+    return c.json(result.body as never, result.status as 200 | 404 | 409 | 503);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] change system-user role failed", { username, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.delete("/admin/insight/system-users/:username", async (c) => {
+  const username = c.req.param("username");
+  if (!username || !USERNAME_RE.test(username)) {
+    return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
+  }
+  const forbidden = auditAndAuthorize(c, "/admin/insight/system-users/:username[DELETE]", {
+    username,
+  });
+  if (forbidden) return forbidden;
+  try {
+    const result = await routeDeleteSystemUser(c, username);
+    return c.json(result.body as never, result.status as 200 | 404 | 409 | 503);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] delete system-user failed", { username, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/system-users-cognito.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/system-users-cognito.ts
@@ -1,0 +1,297 @@
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminGetUserCommand,
+  AdminListGroupsForUserCommand,
+  AdminRemoveUserFromGroupCommand,
+  type CognitoIdentityProviderClient,
+  DeliveryMediumType,
+  ListUsersInGroupCommand,
+  UserNotFoundException,
+  UsernameExistsException,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+/**
+ * Issue #949 (ADR-020 Phase C): SystemAdmin Console (= `apps/admin-console`) 側の
+ * SystemAdmin user CRUD 用 Cognito wrapper。 tenant 側の `users-cognito.ts` と shape は同じだが、
+ * 違いは:
+ *
+ *   - 識別軸が **Cognito group** (= `SystemAdmin` / `SystemAuditor`) であり `custom:tenantId` ではない
+ *     → list は `ListUsersInGroup(group="SystemAdmin")` を使う
+ *     → create は `AdminCreateUser` の後に `AdminAddUserToGroup` で group を付ける
+ *     → role 変更は group の add / remove 操作
+ *   - UserPool は固定 (= ControlPlane の UserPool ID を env から取る)。 tenant 側のような
+ *     JWT iss から runtime 抽出 (= self-targeting) ではない
+ *
+ * 競合動作:
+ *   - email 重複 → `UsernameExistsException` を `DuplicateSystemUserError` に正規化
+ *   - 存在しない user の操作 → `UserNotFoundException` を `SystemUserNotFoundError` に正規化
+ *
+ * 越境防止:
+ *   - 本 wrapper は単一 ControlPlane UserPool 内に閉じている (= tenant 越境 risk なし)
+ *   - self-delete 防止は caller layer (route) で sub / username 比較
+ */
+
+export const SYSTEM_ADMIN_GROUP = "SystemAdmin";
+export const SYSTEM_AUDITOR_GROUP = "SystemAuditor";
+export const SYSTEM_GROUPS = [SYSTEM_ADMIN_GROUP, SYSTEM_AUDITOR_GROUP] as const;
+export type SystemUserRole = (typeof SYSTEM_GROUPS)[number];
+
+export interface SystemUserClientDeps {
+  readonly client: Pick<CognitoIdentityProviderClient, "send">;
+  readonly userPoolId: string;
+}
+
+export interface SystemUserSummary {
+  readonly username: string;
+  readonly email: string | undefined;
+  readonly enabled: boolean;
+  readonly status: string | undefined;
+  readonly createdAt: string | undefined;
+  /** ユーザーが属する全 system group (= `SystemAdmin` / `SystemAuditor`)。 通常 1 つ。 */
+  readonly groups: readonly SystemUserRole[];
+}
+
+export class DuplicateSystemUserError extends Error {
+  constructor(public readonly email: string) {
+    super(`SystemAdmin user with email ${email} already exists`);
+    this.name = "DuplicateSystemUserError";
+  }
+}
+
+export class SystemUserNotFoundError extends Error {
+  constructor(public readonly username: string) {
+    super(`SystemAdmin user ${username} not found`);
+    this.name = "SystemUserNotFoundError";
+  }
+}
+
+function pickAttr(
+  attrs: ReadonlyArray<{ Name?: string; Value?: string }> | undefined,
+  name: string,
+): string | undefined {
+  return attrs?.find((a) => a.Name === name)?.Value;
+}
+
+/**
+ * SystemAdmin / SystemAuditor 各 group の user を 1 ページ取得して合算する (= 重複 dedupe)。
+ * 60 件超は paginate を別途追加する (= Phase 1 は cap 内の想定)。
+ */
+export async function listSystemUsers(deps: SystemUserClientDeps): Promise<SystemUserSummary[]> {
+  const seenByUsername = new Map<string, SystemUserSummary>();
+  for (const group of SYSTEM_GROUPS) {
+    const out = await deps.client.send(
+      new ListUsersInGroupCommand({
+        UserPoolId: deps.userPoolId,
+        GroupName: group,
+        Limit: 60,
+      }),
+    );
+    for (const u of out.Users ?? []) {
+      const username = u.Username ?? "";
+      if (!username) continue;
+      const existing = seenByUsername.get(username);
+      const groups: SystemUserRole[] = existing ? [...existing.groups] : [];
+      if (!groups.includes(group)) groups.push(group);
+      seenByUsername.set(username, {
+        username,
+        email: pickAttr(u.Attributes, "email"),
+        enabled: u.Enabled ?? false,
+        status: u.UserStatus,
+        createdAt: u.UserCreateDate?.toISOString(),
+        groups,
+      });
+    }
+  }
+  return Array.from(seenByUsername.values()).sort((a, b) =>
+    (a.email ?? a.username).localeCompare(b.email ?? b.username),
+  );
+}
+
+export interface CreateSystemUserInput {
+  readonly email: string;
+  readonly role: SystemUserRole;
+}
+
+export async function createSystemUser(
+  deps: SystemUserClientDeps,
+  input: CreateSystemUserInput,
+): Promise<SystemUserSummary> {
+  const attrs: { Name: string; Value: string }[] = [
+    { Name: "email", Value: input.email },
+    { Name: "email_verified", Value: "true" },
+  ];
+  let createdUsername: string;
+  let createdAt: string | undefined;
+  let status: string | undefined;
+  let enabled = true;
+  try {
+    const out = await deps.client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: input.email,
+        UserAttributes: attrs,
+        DesiredDeliveryMediums: [DeliveryMediumType.EMAIL],
+      }),
+    );
+    createdUsername = out.User?.Username ?? input.email;
+    createdAt = out.User?.UserCreateDate?.toISOString();
+    status = out.User?.UserStatus;
+    enabled = out.User?.Enabled ?? true;
+  } catch (err) {
+    if (err instanceof UsernameExistsException) {
+      throw new DuplicateSystemUserError(input.email);
+    }
+    throw err;
+  }
+  // AdminCreateUser 直後に group 追加。 失敗時は user が group 無し状態で残るので、 best-effort
+  // で AdminDeleteUser で巻き戻す (= idempotent な再 invite を許容)。
+  try {
+    await deps.client.send(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: deps.userPoolId,
+        Username: createdUsername,
+        GroupName: input.role,
+      }),
+    );
+  } catch (err) {
+    try {
+      await deps.client.send(
+        new AdminDeleteUserCommand({
+          UserPoolId: deps.userPoolId,
+          Username: createdUsername,
+        }),
+      );
+    } catch {
+      // 巻き戻しの失敗は log のみ。 caller に元 throw を伝える方が優先。
+      console.error("[system-users] rollback delete failed", { username: createdUsername });
+    }
+    throw err;
+  }
+  return {
+    username: createdUsername,
+    email: input.email,
+    enabled,
+    status,
+    createdAt,
+    groups: [input.role],
+  };
+}
+
+export async function deleteSystemUser(
+  deps: SystemUserClientDeps,
+  username: string,
+): Promise<void> {
+  try {
+    await deps.client.send(
+      new AdminDeleteUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new SystemUserNotFoundError(username);
+    }
+    throw err;
+  }
+}
+
+/**
+ * 既存 user の role を変更する (= group remove + add)。 newRole が現状と同じなら no-op。
+ * 不在なら `SystemUserNotFoundError`。
+ */
+export async function updateSystemUserRole(
+  deps: SystemUserClientDeps,
+  username: string,
+  newRole: SystemUserRole,
+): Promise<void> {
+  let currentGroups: readonly string[];
+  try {
+    const out = (await deps.client.send(
+      new AdminListGroupsForUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+        Limit: 60,
+      }),
+    )) as { Groups?: { GroupName?: string }[] };
+    currentGroups = (out.Groups ?? []).map((g) => g.GroupName ?? "").filter(Boolean);
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new SystemUserNotFoundError(username);
+    }
+    throw err;
+  }
+  for (const g of currentGroups) {
+    if ((SYSTEM_GROUPS as readonly string[]).includes(g) && g !== newRole) {
+      await deps.client.send(
+        new AdminRemoveUserFromGroupCommand({
+          UserPoolId: deps.userPoolId,
+          Username: username,
+          GroupName: g,
+        }),
+      );
+    }
+  }
+  if (!currentGroups.includes(newRole)) {
+    await deps.client.send(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+        GroupName: newRole,
+      }),
+    );
+  }
+}
+
+/**
+ * 単一 system user を取得する (= detail view 用)。 不在なら `SystemUserNotFoundError`。
+ *
+ * AdminGetUser の response 型は `Pick<...>` で void 化されているため、 ad-hoc cast で field を引く
+ * (= 既存 admin-insight handlers と同パターン)。
+ */
+export async function getSystemUser(
+  deps: SystemUserClientDeps,
+  username: string,
+): Promise<SystemUserSummary> {
+  let userRaw: unknown;
+  try {
+    userRaw = await deps.client.send(
+      new AdminGetUserCommand({
+        UserPoolId: deps.userPoolId,
+        Username: username,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new SystemUserNotFoundError(username);
+    }
+    throw err;
+  }
+  const groupsOut = (await deps.client.send(
+    new AdminListGroupsForUserCommand({
+      UserPoolId: deps.userPoolId,
+      Username: username,
+      Limit: 60,
+    }),
+  )) as { Groups?: { GroupName?: string }[] };
+  const groups = (groupsOut.Groups ?? [])
+    .map((g) => g.GroupName ?? "")
+    .filter((g): g is SystemUserRole => (SYSTEM_GROUPS as readonly string[]).includes(g));
+  const u = userRaw as {
+    Username?: string;
+    UserAttributes?: { Name?: string; Value?: string }[];
+    UserCreateDate?: Date;
+    UserStatus?: string;
+    Enabled?: boolean;
+  };
+  return {
+    username: u.Username ?? username,
+    email: pickAttr(u.UserAttributes, "email"),
+    enabled: u.Enabled ?? false,
+    status: u.UserStatus,
+    createdAt: u.UserCreateDate?.toISOString(),
+    groups,
+  };
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/system-users-routes.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/system-users-routes.ts
@@ -1,0 +1,199 @@
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import type { Context } from "hono";
+import { z } from "zod";
+import { resolveCognitoSub } from "./auth.js";
+import {
+  createSystemUser,
+  DuplicateSystemUserError,
+  deleteSystemUser,
+  getSystemUser,
+  listSystemUsers,
+  SYSTEM_ADMIN_GROUP,
+  SYSTEM_AUDITOR_GROUP,
+  SYSTEM_GROUPS,
+  type SystemUserClientDeps,
+  SystemUserNotFoundError,
+  updateSystemUserRole,
+} from "./system-users-cognito.js";
+
+/**
+ * Issue #949 (ADR-020 Phase C): SystemAdmin Console 側の system user 管理 route 群。
+ *
+ *   GET    /admin/insight/system-users               — 一覧 (SystemAdmin + SystemAuditor 合算)
+ *   POST   /admin/insight/system-users               — invite (email + role)
+ *   GET    /admin/insight/system-users/:username     — detail
+ *   PATCH  /admin/insight/system-users/:username     — role 変更 (group remove + add)
+ *   DELETE /admin/insight/system-users/:username     — 削除 (self-delete 防止)
+ *
+ * Auth:
+ *   - 1 段目: API Gateway HTTP API JWT Authorizer (ControlPlane UserPool)
+ *   - 2 段目: handler 内で `cognito:groups ⊇ {SystemAdmin}` を検査 (= `isSystemAdmin` 既存 helper)
+ *
+ * Lock-out 防止:
+ *   - 自分自身の削除 / role downgrade を 409 で拒否 (= sub / username 比較)
+ *   - SystemAdmin が 0 人になる shutdown は本 Phase では検査しない (= 後続 Phase で 「最低 1 人残す」
+ *     ルールを追加する余地。 まずは self-action のみ防御)
+ */
+
+export interface SystemUsersRouteResult {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+export const InviteSystemUserRequestSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(SYSTEM_GROUPS),
+});
+
+export const ChangeSystemUserRoleRequestSchema = z.object({
+  role: z.enum(SYSTEM_GROUPS),
+});
+
+export type InviteSystemUserRequest = z.infer<typeof InviteSystemUserRequestSchema>;
+export type ChangeSystemUserRoleRequest = z.infer<typeof ChangeSystemUserRoleRequestSchema>;
+
+/**
+ * Lambda 全体で module-scope に作る Cognito client (= warm invoke で connection pool 再利用)。
+ * `CONTROL_PLANE_USER_POOL_ID` env が空なら handler が 503 を返すので、 client 自体は常に
+ * 作っておく (= 起動 fail-fast を避ける)。
+ */
+const cognitoClient = new CognitoIdentityProviderClient({});
+
+function resolveSystemUserPool(): SystemUserClientDeps | undefined {
+  const userPoolId = process.env.CONTROL_PLANE_USER_POOL_ID;
+  if (!userPoolId || userPoolId.length === 0) return undefined;
+  return { client: cognitoClient, userPoolId };
+}
+
+function notConfigured(): SystemUsersRouteResult {
+  return {
+    status: 503,
+    body: {
+      error: "control_plane_user_pool_unconfigured",
+      message: "CONTROL_PLANE_USER_POOL_ID env が未設定です (= stack 配線漏れ)",
+    },
+  };
+}
+
+export async function routeListSystemUsers(c: Context): Promise<SystemUsersRouteResult> {
+  const pool = resolveSystemUserPool();
+  if (!pool) return notConfigured();
+  const items = await listSystemUsers(pool);
+  return { status: 200, body: { items } };
+}
+
+export async function routeGetSystemUser(
+  _c: Context,
+  username: string,
+): Promise<SystemUsersRouteResult> {
+  const pool = resolveSystemUserPool();
+  if (!pool) return notConfigured();
+  try {
+    const user = await getSystemUser(pool, username);
+    return { status: 200, body: user };
+  } catch (err) {
+    if (err instanceof SystemUserNotFoundError) {
+      return { status: 404, body: { error: "not_found", username } };
+    }
+    throw err;
+  }
+}
+
+export async function routeCreateSystemUser(
+  _c: Context,
+  request: InviteSystemUserRequest,
+): Promise<SystemUsersRouteResult> {
+  const pool = resolveSystemUserPool();
+  if (!pool) return notConfigured();
+  try {
+    const user = await createSystemUser(pool, request);
+    return { status: 201, body: user };
+  } catch (err) {
+    if (err instanceof DuplicateSystemUserError) {
+      return { status: 409, body: { error: "duplicate_user", email: err.email } };
+    }
+    throw err;
+  }
+}
+
+export async function routeChangeSystemUserRole(
+  c: Context,
+  username: string,
+  request: ChangeSystemUserRoleRequest,
+): Promise<SystemUsersRouteResult> {
+  const pool = resolveSystemUserPool();
+  if (!pool) return notConfigured();
+  // Lock-out 防止: 自分自身を SystemAuditor に降格する経路を拒否する (= write 権限を失う)。
+  // sub では username に変換できないので、 まず getSystemUser で検証 user の email を取り、
+  // それと caller の email claim を比較する。 簡素化のため username 同値比較を採用 (= AdminCreateUser
+  // で Username=email を使う本 stack の規約に依存)。
+  const callerSub = resolveCognitoSub(c);
+  if (callerSub === username || isSameAsCaller(c, username)) {
+    if (request.role === SYSTEM_AUDITOR_GROUP) {
+      return {
+        status: 409,
+        body: {
+          error: "cannot_demote_self",
+          message: "lock-out 防止のため自分自身を SystemAuditor に降格できません",
+        },
+      };
+    }
+  }
+  try {
+    await updateSystemUserRole(pool, username, request.role);
+    return { status: 200, body: { username, role: request.role } };
+  } catch (err) {
+    if (err instanceof SystemUserNotFoundError) {
+      return { status: 404, body: { error: "not_found", username } };
+    }
+    throw err;
+  }
+}
+
+export async function routeDeleteSystemUser(
+  c: Context,
+  username: string,
+): Promise<SystemUsersRouteResult> {
+  const pool = resolveSystemUserPool();
+  if (!pool) return notConfigured();
+  const callerSub = resolveCognitoSub(c);
+  if (callerSub === username || isSameAsCaller(c, username)) {
+    return {
+      status: 409,
+      body: { error: "cannot_delete_self", message: "lock-out 防止のため自分自身は削除できません" },
+    };
+  }
+  try {
+    await deleteSystemUser(pool, username);
+    return { status: 200, body: { deleted: true, username } };
+  } catch (err) {
+    if (err instanceof SystemUserNotFoundError) {
+      return { status: 404, body: { error: "not_found", username } };
+    }
+    throw err;
+  }
+}
+
+/**
+ * JWT claims から caller の username (= Cognito `cognito:username` claim、 通常 email) を取って
+ * target username と一致するか判定する。 sub だけでは Cognito Username にならない (= AdminCreateUser
+ * で Username=email を使う本 stack の規約) ため、 sub と username 両方を見る defense-in-depth。
+ */
+function isSameAsCaller(c: Context, username: string): boolean {
+  const event = (c.env as { event?: { requestContext?: { authorizer?: unknown } } } | undefined)
+    ?.event;
+  const authorizer = event?.requestContext?.authorizer as
+    | { jwt?: { claims?: Record<string, unknown> }; claims?: Record<string, unknown> }
+    | undefined;
+  const claims = authorizer?.jwt?.claims ?? authorizer?.claims;
+  if (!claims) return false;
+  const callerUsername = claims["cognito:username"];
+  if (typeof callerUsername === "string" && callerUsername === username) return true;
+  const callerEmail = claims["email"];
+  return typeof callerEmail === "string" && callerEmail === username;
+}
+
+export {
+  SYSTEM_ADMIN_GROUP as SYSTEM_ADMIN_ROLE_VALUE,
+  SYSTEM_AUDITOR_GROUP as SYSTEM_AUDITOR_ROLE_VALUE,
+};

--- a/infrastructure/test/admin-insight/system-users-routes.test.ts
+++ b/infrastructure/test/admin-insight/system-users-routes.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #949 (ADR-020 Phase C): admin-insight Lambda の /admin/insight/system-users
+ * route 群が SystemAdmin 認可 + CRUD shape を満たすことを pin する。
+ *
+ * 既存 admin-insight-routes.test.ts と同じ mock 戦略:
+ *   - shared 構築 / Cognito wrapper は vi.mock で stub
+ *   - JWT claim は `event.requestContext.authorizer.jwt.claims` 経由で inject
+ */
+
+const ORIGINAL_USER_POOL = process.env.CONTROL_PLANE_USER_POOL_ID;
+beforeEach(() => {
+  // 各 test 開始時に env を test-pool に固定 (= 「未設定で 503」 だけ test 内で削除する)
+  process.env.CONTROL_PLANE_USER_POOL_ID = "test-pool";
+});
+afterEach(() => {
+  if (ORIGINAL_USER_POOL === undefined) delete process.env.CONTROL_PLANE_USER_POOL_ID;
+  else process.env.CONTROL_PLANE_USER_POOL_ID = ORIGINAL_USER_POOL;
+});
+
+const mocks = vi.hoisted(() => ({
+  listSystemUsers: vi.fn(),
+  createSystemUser: vi.fn(),
+  deleteSystemUser: vi.fn(),
+  updateSystemUserRole: vi.fn(),
+  getSystemUser: vi.fn(),
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/shared", () => ({
+  buildSharedResources: () => ({
+    deploymentsTableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    ddb: { send: vi.fn() },
+  }),
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/summary", () => ({
+  summarizeTenants: vi.fn(),
+}));
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/events", () => ({
+  listEventsForTenant: vi.fn(),
+  getEventDetailForTenant: vi.fn(),
+}));
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/deployments", () => ({
+  getDeploymentForTenant: vi.fn(),
+  getStackProgressForTenant: vi.fn(),
+  defaultCfnClient: () => undefined,
+}));
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/pipeline-executions", () => ({
+  listPipelineExecutions: vi.fn(),
+  defaultPipelineClient: () => undefined,
+}));
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/state-machine-executions", () => ({
+  listStateMachineExecutions: vi.fn(),
+  defaultSfnClient: () => undefined,
+}));
+
+vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito")
+  >("../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito");
+  return {
+    SYSTEM_ADMIN_GROUP: actual.SYSTEM_ADMIN_GROUP,
+    SYSTEM_AUDITOR_GROUP: actual.SYSTEM_AUDITOR_GROUP,
+    SYSTEM_GROUPS: actual.SYSTEM_GROUPS,
+    DuplicateSystemUserError: actual.DuplicateSystemUserError,
+    SystemUserNotFoundError: actual.SystemUserNotFoundError,
+    listSystemUsers: mocks.listSystemUsers,
+    createSystemUser: mocks.createSystemUser,
+    deleteSystemUser: mocks.deleteSystemUser,
+    updateSystemUserRole: mocks.updateSystemUserRole,
+    getSystemUser: mocks.getSystemUser,
+  };
+});
+
+const { app } = await import("../../lib/admin-insight/handlers/admin-insight-handler/index");
+
+function withClaims(claims: Record<string, unknown>) {
+  return {
+    requestContext: {
+      authorizer: { jwt: { claims } },
+    },
+  };
+}
+
+const systemAdminClaims = {
+  "custom:userRole": "SystemAdmin",
+  sub: "admin-sub-1",
+  "cognito:username": "admin@example.com",
+  email: "admin@example.com",
+};
+const tenantAdminClaims = {
+  "custom:userRole": "TenantAdmin",
+  sub: "tenant-1",
+};
+
+describe("ADR-020 Phase C / #949: GET /admin/insight/system-users", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SystemAdmin claim があれば 200 + items を返すべき", async () => {
+    mocks.listSystemUsers.mockResolvedValueOnce([
+      { username: "u1@example.com", email: "u1@example.com", groups: ["SystemAdmin"] },
+    ]);
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {},
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items.length).toBe(1);
+  });
+
+  it("TenantAdmin claim は 403 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {},
+      { event: withClaims(tenantAdminClaims) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("CONTROL_PLANE_USER_POOL_ID 未設定なら 503 を返すべき", async () => {
+    delete process.env.CONTROL_PLANE_USER_POOL_ID;
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {},
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("control_plane_user_pool_unconfigured");
+  });
+});
+
+describe("ADR-020 Phase C / #949: POST /admin/insight/system-users", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("有効 body なら 201 を返すべき", async () => {
+    mocks.createSystemUser.mockResolvedValueOnce({
+      username: "new@example.com",
+      email: "new@example.com",
+      groups: ["SystemAdmin"],
+    });
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "SystemAdmin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("無効 email は 400 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "not-an-email", role: "SystemAdmin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("無効 role は 400 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "Bogus" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("Duplicate email は 409 を返すべき", async () => {
+    const { DuplicateSystemUserError } = await import(
+      "../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito"
+    );
+    mocks.createSystemUser.mockRejectedValueOnce(new DuplicateSystemUserError("new@example.com"));
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "SystemAdmin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("TenantAdmin claim は 403", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "SystemAdmin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(tenantAdminClaims) },
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("ADR-020 Phase C / #949: GET /admin/insight/system-users/:username", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("存在するなら 200 + detail を返すべき", async () => {
+    mocks.getSystemUser.mockResolvedValueOnce({
+      username: "u1@example.com",
+      email: "u1@example.com",
+      groups: ["SystemAdmin"],
+    });
+    const res = await app.request(
+      "/admin/insight/system-users/u1@example.com",
+      {},
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("存在しないなら 404", async () => {
+    const { SystemUserNotFoundError } = await import(
+      "../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito"
+    );
+    mocks.getSystemUser.mockRejectedValueOnce(new SystemUserNotFoundError("u1@example.com"));
+    const res = await app.request(
+      "/admin/insight/system-users/u1@example.com",
+      {},
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("無効 username (= 不正文字含む) は 400", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/<bad>",
+      {},
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("ADR-020 Phase C / #949: PATCH /admin/insight/system-users/:username", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("role 変更が 200 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/other@example.com",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "SystemAuditor" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("自分自身を SystemAuditor に降格しようとすると 409 cannot_demote_self", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/admin@example.com",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "SystemAuditor" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("cannot_demote_self");
+  });
+
+  it("存在しない user は 404", async () => {
+    const { SystemUserNotFoundError } = await import(
+      "../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito"
+    );
+    mocks.updateSystemUserRole.mockRejectedValueOnce(
+      new SystemUserNotFoundError("ghost@example.com"),
+    );
+    const res = await app.request(
+      "/admin/insight/system-users/ghost@example.com",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "SystemAdmin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("ADR-020 Phase C / #949: DELETE /admin/insight/system-users/:username", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("他人の削除は 200 を返すべき", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/other@example.com",
+      { method: "DELETE" },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("自分自身の削除は 409 cannot_delete_self", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/admin@example.com",
+      { method: "DELETE" },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("cannot_delete_self");
+  });
+
+  it("存在しない user は 404", async () => {
+    const { SystemUserNotFoundError } = await import(
+      "../../lib/admin-insight/handlers/admin-insight-handler/system-users-cognito"
+    );
+    mocks.deleteSystemUser.mockRejectedValueOnce(new SystemUserNotFoundError("ghost@example.com"));
+    const res = await app.request(
+      "/admin/insight/system-users/ghost@example.com",
+      { method: "DELETE" },
+      { event: withClaims(systemAdminClaims) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("TenantAdmin claim は 403", async () => {
+    const res = await app.request(
+      "/admin/insight/system-users/other@example.com",
+      { method: "DELETE" },
+      { event: withClaims(tenantAdminClaims) },
+    );
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

SBT ControlPlane の SystemAdmin / SystemAuditor user を SystemAdmin Console から **招待 / 一覧 / role 変更 / 削除** する経路を追加する。

旧状態: SBT 初期 deploy で払い出される 1 アカウントのみ SystemAdmin で、 2 人目以降を増やすには Cognito Console を直接触る必要があった (= SPOF、 #925 で指摘されていた問題の SystemAdmin 側未着手分)。

## 構成 (= 3 stage)

### Stage 1: CDK + IAM (\`infrastructure/lib/admin-insight/\`)

- \`AdminInsightApiLambda\` に prop \`controlPlaneUserPool\` を追加
- env \`CONTROL_PLANE_USER_POOL_ID\` を注入
- IAM: \`cognito-idp:Admin{Create,Delete,Get,UpdateAttributes,ListGroupsFor}User\` / \`ListUsers\` / \`Admin{Add,Remove}UserFromGroup\` を指定 UserPool ARN に scope して付与
- HTTP API に \`/admin/insight/system-users[/:username]\` route を追加 (GET / POST / DELETE / PATCH)
- CORS allowMethods を拡張 (= POST / DELETE / PATCH を追加)

### Stage 2: backend handler

- 新 \`system-users-cognito.ts\`: SDK wrapper (list / create / delete / role-change / get)
- 新 \`system-users-routes.ts\`: 503 (未配線) / 409 (lock-out 防止) / 404 (不在) を整理
- \`index.ts\` に 5 routes 配線、 既存 \`auditAndAuthorize\` で SystemAdmin claim 2 段目 check
- Lock-out 防止:
  - 自分自身を SystemAuditor に降格 → 409 \`cannot_demote_self\`
  - 自分自身の削除 → 409 \`cannot_delete_self\`

### Stage 3: frontend (\`apps/admin-console/\`)

- 新 \`api/system-users-client.ts\`: error code → human-readable message map
- 新 \`pages/SystemUsers.tsx\`: list / 招待 / role 変更 / 削除 modal、 \`adminInsightApiUrl\` 未配線時は alert 誘導
- \`App.tsx\` に \`/settings/system-users\` route 配線
- \`AppLayout.tsx\` SideNavigation に entry 追加
- 4 locale (ja / en / es / zh) に \`nav.system_users\` 追加

## test

新 \`infrastructure/test/admin-insight/system-users-routes.test.ts\` (18 case):

- GET / POST / GET-detail / PATCH / DELETE 各 route で SystemAdmin pass / TenantAdmin 403 を pin
- POST: 無効 email / 無効 role / Duplicate (409)
- DELETE / PATCH: self-target で \`cannot_delete_self\` / \`cannot_demote_self\`
- env 未配線時の 503
- 不在 user の 404

## Regression 分析

- 既存 admin-insight routes (= summary / drill-down / pipeline / sfn) は無改修
- CORS allowMethods 拡張は preflight allow なので既存 GET 経路に影響なし
- IAM 付与は新 prop が指定された時のみ (= 未指定なら旧挙動 / 旧 stack 互換)
- Lambda env 未設定でも起動可能 (= route だけ 503 を返す)
- 1236 件 infra test 全 green、 新 18 test 追加

## 物理影響

- UPDATE: \`AdminInsightApiLambda\` / \`AdminConsoleInsightStack\` (CDK / IAM / CORS / routes)
- NEW backend file: \`system-users-{cognito,routes}.ts\`, \`system-users-routes.test.ts\`
- NEW frontend file: \`system-users-client.ts\`, \`SystemUsers.tsx\`
- UPDATE frontend: \`App.tsx\` (+1 route), \`AppLayout.tsx\` (+1 nav entry), 4 locale.json (+1 key)
- CFn / Cognito: UPDATE — admin-insight Lambda IAM Policy + env + HTTP API route 追加 (= deploy 必要、 SystemAdmin user は SBT が group 払い出し済の前提)

## Test plan

- [x] \`make harness\` — no findings
- [x] \`make typecheck\` — clean
- [x] \`make test\` — 1236 infra + 126 admin-console 全通過
- [x] \`make before-commit\` — 全 gate 通過

Closes #949 (= ADR-020 Phase C)
Relates ADR-020 / #925 (= original SPOF issue で SystemAdmin 側が未着手だった分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added system users management interface to admin console.
  * Administrators can list, invite, manage roles, and delete system users.

* **Internationalization**
  * Added translations for English, Spanish, Japanese, and Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->