### PR TITLE
feat(#950): AdminAuditLog DDB + writeAuditEvent helper + audit list UI (ADR-020 Phase D)

### DIFF
--- a/apps/admin-console/src/App.tsx
+++ b/apps/admin-console/src/App.tsx
@@ -5,6 +5,7 @@ import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
 import { AdminDeploymentDetailPage } from "./pages/AdminDeploymentDetail";
 import { AdminEventDetailPage } from "./pages/AdminEventDetail";
+import { AuditLogPage } from "./pages/AuditLog";
 import { CallbackPage } from "./pages/Callback";
 import { JobsPage } from "./pages/Jobs";
 import { LoginPage } from "./pages/Login";
@@ -94,6 +95,17 @@ export function App({ config }: { config: AppConfig }) {
             <RequireAuth>
               <ShellLayout>
                 <SystemUsersPage config={config} />
+              </ShellLayout>
+            </RequireAuth>
+          }
+        />
+        {/* Issue #950 (ADR-020 Phase D): admin audit log */}
+        <Route
+          path="/audit-log"
+          element={
+            <RequireAuth>
+              <ShellLayout>
+                <AuditLogPage config={config} />
               </ShellLayout>
             </RequireAuth>
           }

--- a/apps/admin-console/src/api/audit-client.ts
+++ b/apps/admin-console/src/api/audit-client.ts
@@ -1,0 +1,100 @@
+import { StatusCodes } from "http-status-codes";
+import type { AppConfig } from "../config";
+
+/**
+ * Issue #950 (ADR-020 Phase D): admin-insight Lambda の `/admin/insight/audit` route を叩く
+ * read-only client。 既存 `fetchTenantsInsightSummary` と同じ base URL (= adminInsightApiUrl) を使う。
+ *
+ * `config.adminInsightApiUrl` 未配線なら null を返す (= 「未配線」 alert で誘導)。
+ */
+
+export interface AuditItem {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly actor: string;
+  readonly actorUsername?: string;
+  readonly action: string;
+  readonly outcome: string;
+  readonly target?: string;
+  readonly ipAddress?: string;
+  readonly userAgent?: string;
+  readonly occurredAt: string;
+  readonly extra?: Record<string, unknown>;
+}
+
+export interface AuditPage {
+  readonly items: readonly AuditItem[];
+  readonly nextCursor?: string;
+}
+
+export type AuditScope = "tenant" | "system";
+
+export interface AuditClient {
+  list(input: {
+    scope: AuditScope;
+    tenantId?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<AuditPage>;
+}
+
+export class AuditApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly errorCode: string | undefined,
+  ) {
+    super(`Audit API ${status}: ${errorCode ?? "unknown_error"}`);
+    this.name = "AuditApiError";
+  }
+}
+
+export function createAuditClient(config: AppConfig, idToken: string): AuditClient | null {
+  if (!config.adminInsightApiUrl) return null;
+  const base = config.adminInsightApiUrl.endsWith("/")
+    ? config.adminInsightApiUrl
+    : `${config.adminInsightApiUrl}/`;
+  return {
+    async list(input) {
+      const url = new URL("admin/insight/audit", base);
+      url.searchParams.set("scope", input.scope);
+      if (input.tenantId) url.searchParams.set("tenantId", input.tenantId);
+      if (input.limit !== undefined) url.searchParams.set("limit", String(input.limit));
+      if (input.cursor) url.searchParams.set("cursor", input.cursor);
+      const res = await fetch(url, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${idToken}`,
+          "content-type": "application/json",
+        },
+      });
+      if (!res.ok) {
+        let errorCode: string | undefined;
+        try {
+          const body = await res.json();
+          if (typeof body === "object" && body !== null && "error" in body) {
+            errorCode = String((body as { error: unknown }).error);
+          }
+        } catch {
+          /* noop */
+        }
+        throw new AuditApiError(res.status, errorCode);
+      }
+      return (await res.json()) as AuditPage;
+    },
+  };
+}
+
+export function describeAuditError(err: AuditApiError): string {
+  switch (err.status) {
+    case StatusCodes.FORBIDDEN:
+      return "SystemAdmin role が必要です";
+    case StatusCodes.SERVICE_UNAVAILABLE:
+      return "AdminInsight stack に AdminAuditLog table が配線されていません (= deploy chain の更新が必要)";
+    case StatusCodes.BAD_REQUEST:
+      if (err.errorCode === "invalid_scope") return "scope が無効です (= tenant / system のみ)";
+      if (err.errorCode === "invalid_tenant_id") return "tenantId 形式が無効です";
+      return "リクエストが無効です";
+    default:
+      return `エラーが発生しました (${err.status})`;
+  }
+}

--- a/apps/admin-console/src/components/AppLayout.tsx
+++ b/apps/admin-console/src/components/AppLayout.tsx
@@ -65,6 +65,7 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/tenants/new", text: t("nav.tenants_new") },
               { type: "link", href: "/jobs", text: t("nav.jobs") },
               { type: "link", href: "/settings/system-users", text: t("nav.system_users") },
+              { type: "link", href: "/audit-log", text: t("nav.audit_log") },
               { type: "divider" },
               // Issue #899: Scalar による API reference。 同 origin の static file (public/api-docs.html)
               // へ external link。 SPA route と分離 (= API spec を SPA bundle に混ぜない)。

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -12,6 +12,7 @@
     "tenants_new": "Create tenant",
     "jobs": "Provisioning Jobs",
     "system_users": "SystemAdmin users",
+    "audit_log": "Audit log",
     "api_docs": "API Reference ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -12,6 +12,7 @@
     "tenants_new": "Crear tenant",
     "jobs": "Trabajos de aprovisionamiento",
     "system_users": "Usuarios SystemAdmin",
+    "audit_log": "Registro de auditoría",
     "api_docs": "Referencia de API ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -12,6 +12,7 @@
     "tenants_new": "テナント作成",
     "jobs": "プロビジョニング Jobs",
     "system_users": "SystemAdmin user 管理",
+    "audit_log": "監査ログ",
     "api_docs": "API リファレンス ↗"
   },
   "auth": {

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -12,6 +12,7 @@
     "tenants_new": "创建租户",
     "jobs": "配置作业",
     "system_users": "SystemAdmin 用户管理",
+    "audit_log": "审计日志",
     "api_docs": "API 参考 ↗"
   },
   "auth": {

--- a/apps/admin-console/src/pages/AuditLog.tsx
+++ b/apps/admin-console/src/pages/AuditLog.tsx
@@ -1,0 +1,220 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AuditApiError,
+  type AuditClient,
+  type AuditItem,
+  type AuditScope,
+  createAuditClient,
+  describeAuditError,
+} from "../api/audit-client";
+import { useAuth } from "../auth/AuthProvider";
+import type { AppConfig } from "../config";
+
+/**
+ * Issue #950 (ADR-020 Phase D): SystemAdmin Console 側の admin 操作監査ログ view。
+ *
+ * 表示: scope (= tenant or system) + tenantId を入力 → 1 ページ 50 件、 cursor で次ページ。
+ * outcome は success / forbidden / not_found / conflict / error で badge 色分け。
+ *
+ * 未配線時 (= `adminInsightApiUrl` 空 / table 配線無し): alert で誘導。
+ */
+export function AuditLogPage({ config }: { config: AppConfig }) {
+  const auth = useAuth();
+  const client: AuditClient | null = useMemo(
+    () => (auth.tokens ? createAuditClient(config, auth.tokens.idToken) : null),
+    [auth.tokens, config],
+  );
+  const [scope, setScope] = useState<AuditScope>("system");
+  const [tenantId, setTenantId] = useState("");
+  const [items, setItems] = useState<AuditItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (cursor: string | undefined) => {
+      if (!client) return;
+      if (scope === "tenant" && tenantId.trim().length === 0) {
+        setError("tenantId を入力してください (scope=tenant の場合)");
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const page = await client.list({
+          scope,
+          ...(scope === "tenant" ? { tenantId: tenantId.trim() } : {}),
+          limit: 50,
+          ...(cursor ? { cursor } : {}),
+        });
+        if (cursor) {
+          // 続きを append
+          setItems((prev) => [...prev, ...page.items]);
+        } else {
+          setItems([...page.items]);
+        }
+        setNextCursor(page.nextCursor);
+      } catch (err) {
+        if (err instanceof AuditApiError) {
+          setError(describeAuditError(err));
+        } else if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("読み込みに失敗しました");
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client, scope, tenantId],
+  );
+
+  useEffect(() => {
+    // 初期 mount で system scope を 1 回 load。 client が ready になった時点で発火。
+    void load(undefined);
+  }, [load]);
+
+  if (!client) {
+    return (
+      <Container header={<Header>Admin Audit Log</Header>}>
+        <Alert type="warning" header="AdminInsight stack が未配線">
+          \`config.adminInsightApiUrl\` が空のため audit log は読み込めません。 Phase 2 deploy
+          を完了して runtime-config.json に <code>adminInsightApiUrl</code> を注入してください。
+        </Alert>
+      </Container>
+    );
+  }
+
+  function outcomeIndicator(outcome: string) {
+    if (outcome === "success") return <StatusIndicator type="success">success</StatusIndicator>;
+    if (outcome === "forbidden") return <StatusIndicator type="error">forbidden</StatusIndicator>;
+    if (outcome === "not_found") return <StatusIndicator type="warning">not_found</StatusIndicator>;
+    if (outcome === "conflict") return <StatusIndicator type="warning">conflict</StatusIndicator>;
+    if (outcome === "error") return <StatusIndicator type="error">error</StatusIndicator>;
+    return <span>{outcome}</span>;
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        actions={
+          <Button
+            variant="primary"
+            onClick={() => {
+              setNextCursor(undefined);
+              void load(undefined);
+            }}
+            loading={loading}
+            disabled={loading}
+          >
+            読み込み
+          </Button>
+        }
+      >
+        Admin Audit Log
+      </Header>
+
+      <Container>
+        <SpaceBetween size="m" direction="horizontal">
+          <Select
+            selectedOption={{
+              value: scope,
+              label: scope === "system" ? "SystemAdmin 操作" : "Tenant 操作",
+            }}
+            options={[
+              { value: "system", label: "SystemAdmin 操作" },
+              { value: "tenant", label: "Tenant 操作" },
+            ]}
+            onChange={(e) => setScope(e.detail.selectedOption.value as AuditScope)}
+          />
+          {scope === "tenant" && (
+            <Input
+              value={tenantId}
+              onChange={(e) => setTenantId(e.detail.value)}
+              placeholder="tenantId (例: t-01HX...)"
+            />
+          )}
+        </SpaceBetween>
+      </Container>
+
+      {error && (
+        <Alert type="error" dismissible onDismiss={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Table
+        loading={loading}
+        loadingText="読み込み中…"
+        items={items}
+        columnDefinitions={[
+          {
+            id: "occurredAt",
+            header: "発生時刻",
+            cell: (i) => i.occurredAt,
+          },
+          {
+            id: "actor",
+            header: "操作者",
+            cell: (i) => i.actorUsername ?? i.actor,
+          },
+          {
+            id: "action",
+            header: "操作",
+            cell: (i) => i.action,
+          },
+          {
+            id: "outcome",
+            header: "結果",
+            cell: (i) => outcomeIndicator(i.outcome),
+          },
+          {
+            id: "target",
+            header: "対象",
+            cell: (i) => i.target ?? "-",
+          },
+          {
+            id: "tenantId",
+            header: "Tenant",
+            cell: (i) => i.tenantId,
+          },
+          {
+            id: "ipAddress",
+            header: "IP",
+            cell: (i) => i.ipAddress ?? "-",
+          },
+        ]}
+        empty={
+          <Box textAlign="center" padding="m">
+            <SpaceBetween size="s">
+              <b>監査ログがありません</b>
+              <span>scope / tenantId を確認してください。</span>
+            </SpaceBetween>
+          </Box>
+        }
+      />
+
+      {nextCursor && (
+        <Button
+          variant="normal"
+          onClick={() => void load(nextCursor)}
+          loading={loading}
+          disabled={loading}
+        >
+          続きを読み込む
+        </Button>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -45,6 +45,12 @@ export interface AdminConsoleInsightStackProps extends cdk.StackProps {
    * Deprovisioning Jobs タブで参加者運営に見せる。 未指定なら route は未配線 (= legacy 互換)。
    */
   readonly deprovisioningStateMachineArn?: string;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin 操作の audit log table。 ProblemDeployBackendStack で
+   * 作成された Table を cross-stack read で渡す。 未指定なら admin-insight の audit route は 503
+   * (= 旧 stack 互換)。
+   */
+  readonly adminAuditLogTable?: Table;
 }
 
 /**
@@ -87,6 +93,8 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       ...(props.deprovisioningStateMachineArn
         ? { deprovisioningStateMachineArn: props.deprovisioningStateMachineArn }
         : {}),
+      // Issue #950: admin audit log table の read-only access
+      ...(props.adminAuditLogTable ? { adminAuditLogTable: props.adminAuditLogTable } : {}),
     });
     this.lambdaFunctionName = lambda.fn.functionName;
 
@@ -196,6 +204,13 @@ export class AdminConsoleInsightStack extends cdk.Stack {
     httpApi.addRoutes({
       path: "/admin/insight/system-users/{username}",
       methods: [HttpMethod.GET, HttpMethod.DELETE, HttpMethod.PATCH],
+      integration,
+    });
+
+    // Issue #950 (ADR-020 Phase D): admin audit log read route (= cross-tenant 監査)
+    httpApi.addRoutes({
+      path: "/admin/insight/audit",
+      methods: [HttpMethod.GET],
       integration,
     });
 

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -46,6 +46,12 @@ export interface AdminInsightApiLambdaProps {
    * Resource scope は `userPool.userPoolArn` で固定 (= 他 tenant pool への越境を禁止)。
    */
   readonly controlPlaneUserPool?: IUserPool;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin audit log table。 指定時は SystemAdmin が
+   * /admin/insight/audit route で cross-tenant に audit を読めるようになる (= read-only)。
+   * 未指定なら route は 503 を返す (= 旧 stack 互換)。
+   */
+  readonly adminAuditLogTable?: Table;
 }
 
 /**
@@ -86,6 +92,8 @@ export class AdminInsightApiLambda extends Construct {
         // Issue #949 (ADR-020 Phase C): ControlPlane UserPool ID を env で渡す。 未指定なら空文字
         // (= /admin/insight/system-users route は 503 を返す)。 prod では必ず注入する想定。
         CONTROL_PLANE_USER_POOL_ID: props.controlPlaneUserPool?.userPoolId ?? "",
+        // Issue #950 (ADR-020 Phase D): admin audit log table 名 (= read-only 経由で表示)
+        ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -102,6 +110,8 @@ export class AdminInsightApiLambda extends Construct {
     // を使う (= 個別 PolicyStatement で限定するより SBT 同型の grantRead で十分)。
     props.deploymentsTable.grantReadData(this.fn);
     props.eventsTable.grantReadData(this.fn);
+    // Issue #950 (ADR-020 Phase D): admin audit log の read-only access (GSI も含む)
+    props.adminAuditLogTable?.grantReadData(this.fn);
     props.teamsTable.grantReadData(this.fn);
 
     // Phase 1.B (#598) CFn Describe: deploy job 詳細ページの "Stack 進行状況" セクションが

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/audit.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/audit.ts
@@ -1,0 +1,112 @@
+import { type DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * Issue #950 (ADR-020 Phase D): admin audit log を tenant 別 / system 別に read する。
+ *
+ * SystemAdmin 用 (= cross-tenant) の 「すべての audit を見る」 経路は admin-insight handler の
+ * `/admin/insight/audit?scope=tenant&tenantId=...` または `?scope=system` で実現する。
+ *
+ * Query 設計:
+ *   - PK=TENANT#<tenantId>     → tenant 単位の audit
+ *   - PK=SYSTEM#<env>          → SystemAdmin 操作 audit
+ *   - sort key (= SK) は ULID で時系列順、 ScanIndexForward=false で新しい順に返す
+ *
+ * 1 ページ 50 件、 cursor は base64(LastEvaluatedKey) で次ページ移行。
+ */
+
+export interface AuditDeps {
+  readonly ddb: DynamoDBDocumentClient;
+  readonly auditTableName: string;
+}
+
+export interface AuditListInput {
+  readonly scope: "tenant" | "system";
+  /** scope=tenant のみ必須 */
+  readonly tenantId?: string;
+  readonly limit?: number;
+  /** base64(LastEvaluatedKey) */
+  readonly cursor?: string;
+}
+
+export interface AuditItem {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly actor: string;
+  readonly actorUsername?: string;
+  readonly action: string;
+  readonly outcome: string;
+  readonly target?: string;
+  readonly ipAddress?: string;
+  readonly userAgent?: string;
+  readonly occurredAt: string;
+  readonly extra?: Record<string, unknown>;
+}
+
+export interface AuditListResponse {
+  readonly items: readonly AuditItem[];
+  readonly nextCursor?: string;
+}
+
+const LIST_LIMIT_DEFAULT = 50;
+const LIST_LIMIT_MAX = 200;
+
+function decodeCursor(cursor: string | undefined): Record<string, unknown> | undefined {
+  if (!cursor) return undefined;
+  try {
+    return JSON.parse(Buffer.from(cursor, "base64").toString("utf-8")) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function encodeCursor(key: Record<string, unknown> | undefined): string | undefined {
+  if (!key) return undefined;
+  return Buffer.from(JSON.stringify(key), "utf-8").toString("base64");
+}
+
+export async function listAuditEntries(
+  deps: AuditDeps,
+  input: AuditListInput,
+  env: string,
+): Promise<AuditListResponse> {
+  const limit = Math.min(input.limit ?? LIST_LIMIT_DEFAULT, LIST_LIMIT_MAX);
+  const pk = input.scope === "system" ? `SYSTEM#${env}` : `TENANT#${input.tenantId ?? ""}`;
+  const out = await deps.ddb.send(
+    new QueryCommand({
+      TableName: deps.auditTableName,
+      KeyConditionExpression: "PK = :pk",
+      ExpressionAttributeValues: { ":pk": pk },
+      Limit: limit,
+      ScanIndexForward: false,
+      ExclusiveStartKey: decodeCursor(input.cursor),
+    }),
+  );
+  const items: AuditItem[] = (out.Items ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    const sk = String(r.SK ?? "");
+    const id = sk.startsWith("AUDIT#") ? sk.substring(6) : sk;
+    const tenantId =
+      input.scope === "system" ? "SYSTEM" : String(r.PK ?? "").replace(/^TENANT#/, "");
+    return {
+      id,
+      tenantId,
+      actor: String(r.actor ?? "unknown"),
+      ...(typeof r.actorUsername === "string" ? { actorUsername: r.actorUsername } : {}),
+      action: String(r.action ?? ""),
+      outcome: String(r.outcome ?? ""),
+      ...(typeof r.target === "string" ? { target: r.target } : {}),
+      ...(typeof r.ipAddress === "string" ? { ipAddress: r.ipAddress } : {}),
+      ...(typeof r.userAgent === "string" ? { userAgent: r.userAgent } : {}),
+      occurredAt: String(r.occurredAt ?? ""),
+      ...(r.extra && typeof r.extra === "object"
+        ? { extra: r.extra as Record<string, unknown> }
+        : {}),
+    };
+  });
+  return {
+    items,
+    ...(out.LastEvaluatedKey
+      ? { nextCursor: encodeCursor(out.LastEvaluatedKey as Record<string, unknown>) }
+      : {}),
+  };
+}

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -4,6 +4,7 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
+import { listAuditEntries } from "./audit.js";
 import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
 import {
   defaultCfnClient,
@@ -469,6 +470,52 @@ app.delete("/admin/insight/system-users/:username", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[admin-insight] delete system-user failed", { username, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// ====== Issue #950 (ADR-020 Phase D): admin audit log read route ======
+
+app.get("/admin/insight/audit", async (c) => {
+  const forbidden = auditAndAuthorize(c, "/admin/insight/audit");
+  if (forbidden) return forbidden;
+  if (!shared.auditTableName || shared.auditTableName.length === 0) {
+    return c.json(
+      {
+        error: "audit_log_unconfigured",
+        message: "ADMIN_AUDIT_LOG_TABLE_NAME env が未設定です (= stack 配線漏れ)",
+      },
+      StatusCodes.SERVICE_UNAVAILABLE,
+    );
+  }
+  const rawScope = c.req.query("scope") ?? "tenant";
+  if (rawScope !== "tenant" && rawScope !== "system") {
+    return c.json({ error: "invalid_scope" }, StatusCodes.BAD_REQUEST);
+  }
+  const scope = rawScope as "tenant" | "system";
+  const tenantId = c.req.query("tenantId");
+  if (scope === "tenant") {
+    if (!tenantId || !TENANT_ID_RE.test(tenantId)) {
+      return c.json({ error: "invalid_tenant_id" }, StatusCodes.BAD_REQUEST);
+    }
+  }
+  const parsedLimit = parseLimit(c.req.query("limit"));
+  if (!parsedLimit) return c.json({ error: "invalid_limit" }, StatusCodes.BAD_REQUEST);
+  try {
+    const result = await listAuditEntries(
+      { ddb: shared.ddb, auditTableName: shared.auditTableName },
+      {
+        scope,
+        ...(tenantId ? { tenantId } : {}),
+        ...(parsedLimit.limit !== undefined ? { limit: parsedLimit.limit } : {}),
+        ...(c.req.query("cursor") ? { cursor: c.req.query("cursor") as string } : {}),
+      },
+      shared.environmentName,
+    );
+    return c.json(result, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] listAuditEntries failed", { scope, tenantId, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
@@ -14,6 +14,13 @@ export interface AdminInsightSharedResources {
   readonly eventsTableName: string;
   readonly teamsTableName: string;
   readonly ddb: DynamoDBDocumentClient;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin audit log table 名。 未配線時は空文字、
+   * handler の audit route が 503 を返す。
+   */
+  readonly auditTableName: string;
+  /** Issue #950: 環境名 (= SYSTEM 操作の PK 構築に使う `SYSTEM#<env>`)。 */
+  readonly environmentName: string;
 }
 
 function requireEnv(name: string): string {
@@ -31,5 +38,8 @@ export function buildSharedResources(): AdminInsightSharedResources {
     eventsTableName: requireEnv("EVENTS_TABLE_NAME"),
     teamsTableName: requireEnv("TEAMS_TABLE_NAME"),
     ddb,
+    // Issue #950: 未配線時は空文字。 caller (audit route) が 503 を返す。
+    auditTableName: process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "",
+    environmentName: process.env.DEPLOY_ENVIRONMENT ?? "development",
   };
 }

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -122,6 +122,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       // Issue #814 Phase 2: SBT BashJobRunner の deprovisioning state machine ARN を渡し、
       // admin-insight Lambda が ListExecutions で履歴を引けるようにする。
       deprovisioningStateMachineArn: bootstrapTemplateStack.deprovisioningStateMachineArn,
+      // Issue #950 (ADR-020 Phase D): admin audit log table を cross-stack read で渡す
+      adminAuditLogTable: problemDeployBackendStack.adminAuditLogTable,
     },
   );
   adminConsoleInsightStack.addDependency(controlPlaneStack);

--- a/infrastructure/lib/problem-deploy/admin-audit-log-table.ts
+++ b/infrastructure/lib/problem-deploy/admin-audit-log-table.ts
@@ -1,0 +1,59 @@
+import { RemovalPolicy } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+/**
+ * Issue #950 (ADR-020 Phase D): admin 操作の append-only 監査ログ DDB Table。
+ *
+ * 旧状態: admin 操作 (= user 招待 / role 変更 / 削除、 SAML CRUD、 ExternalId rotate、 Event 削除 等) は
+ * CloudWatch Logs に `console.log` で 1 行残るだけ。 「誰が・いつ・何を」 を後追いする集約 storage が
+ * 無く、 audit 監査 (= 内部統制) を CloudWatch Logs Insights grep に依存。
+ *
+ * Schema:
+ *   PK: TENANT#<tenantId>     (tenant 操作)
+ *       SYSTEM#<env>          (SystemAdmin 操作、 tenant に紐づかないもの)
+ *   SK: AUDIT#<ulid>
+ *
+ * 主な属性:
+ *   - actor: Cognito sub (= 実行者)
+ *   - actorUsername: cognito:username (= 通常 email、 検索性のため非正規化で持つ)
+ *   - action: e.g. "patch_user_role" / "invite_user" / "rotate_external_id" / "delete_event"
+ *   - outcome: "success" / "forbidden" / "not_found" / "error"
+ *   - target: 対象 resource (= username / awsAccountId / eventId 等)
+ *   - ipAddress: source IP (X-Forwarded-For)
+ *   - userAgent: User-Agent header
+ *   - occurredAt: ISO8601 (caller の Date.now() 由来)
+ *   - ttl: 90 日後の unix timestamp (= 自動削除、 audit 要件は 90 日想定)
+ *
+ * provisioned 1/1 (DynamoDbLowCapacity Aspect で更に均す)。 audit write は admin 操作毎の 1 行で
+ * 極低 QPS、 read は監査画面の paginate のみ。 Free Tier 25 RCU/WCU に十分収まる。
+ *
+ * 削除方針: RETAIN。 stack delete で audit 履歴を意図せず消さない (= 監査要件)。 必要なら手動。
+ */
+export class AdminAuditLogTable extends Construct {
+  public readonly table: Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.table = new Table(this, "Table", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+      // 90 日で自動削除 (= caller が `ttl` attribute に Date.now()/1000 + 90*86400 を入れる)
+      timeToLiveAttribute: "ttl",
+    });
+
+    // GSI1: actor 別の audit query (= 「ユーザー X が何をしたか」 を 1 引きで)
+    this.table.addGlobalSecondaryIndex({
+      indexName: "GSI1",
+      partitionKey: { name: "GSI1PK", type: AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: AttributeType.STRING },
+      readCapacity: 1,
+      writeCapacity: 1,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -16,6 +16,10 @@ export interface CompetitorAccountsApiLambdaProps {
   readonly competitorAccountsTable: Table;
   /** SSM SecureString path 構築用 (`/<env>/tenants/<tenantId>/external-id`)。 */
   readonly environmentName: string;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin 操作 audit log 用 DDB Table。 deploy-api-lambda と同じ。
+   */
+  readonly adminAuditLogTable?: Table;
 }
 
 /**
@@ -58,6 +62,8 @@ export class CompetitorAccountsApiLambda extends Construct {
         COMPETITOR_ACCOUNTS_TABLE_NAME: props.competitorAccountsTable.tableName,
         DEPLOY_ENVIRONMENT: props.environmentName,
         TENKACLOUD_ACCOUNT_ID: stack.account,
+        // Issue #950: audit log table 名 (未配線なら空文字)
+        ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -70,6 +76,8 @@ export class CompetitorAccountsApiLambda extends Construct {
 
     // 1. DDB CompetitorAccounts: PutItem / Query / GetItem / UpdateItem / DeleteItem
     props.competitorAccountsTable.grantReadWriteData(this.fn);
+    // Issue #950 (ADR-020 Phase D): admin audit log は write-only。
+    props.adminAuditLogTable?.grantWriteData(this.fn);
 
     // 2. SSM Parameter Store SecureString — tenant の path prefix で絞り込み。
     //    `/{env}/tenants/*/external-id` (= tenantId は wildcard、env は固定)。

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -49,6 +49,12 @@ export interface DeployApiLambdaProps {
    * SSM SecureString path 構築用の env 名 (Phase 2.2、`/<environmentName>/tenants/...`)。
    */
   readonly environmentName: string;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin 操作 audit log を append-only 書き込む DDB Table。
+   * 指定時は Lambda env `ADMIN_AUDIT_LOG_TABLE_NAME` を注入 + IAM `dynamodb:PutItem` を付与する。
+   * 未指定なら writeAuditEvent は env 不在で no-op を選ぶ (= 旧 stack 互換、 audit 行 0 件)。
+   */
+  readonly adminAuditLogTable?: Table;
 }
 
 /**
@@ -86,6 +92,8 @@ export class DeployApiLambda extends Construct {
         // ADR-008 Phase 3 (Issue #642): visibility + bucket env、 default は dormant
         BATTLE_PROBLEMS_VISIBILITY: JSON.stringify(props.problemsVisibility),
         CHALLENGE_PAYLOAD_BUCKET: props.challengePayloadBucketName ?? "",
+        // Issue #950: audit log table 名 (未配線なら空文字、 handler の writeAuditEvent が no-op)
+        ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -103,6 +111,9 @@ export class DeployApiLambda extends Construct {
     props.deploymentsTable.grantReadWriteData(this.fn);
     props.competitorAccountsTable.grantReadData(this.fn);
     props.eventBus.grantPutEventsTo(this.fn);
+    // Issue #950 (ADR-020 Phase D): admin 操作 audit log を append-only 書き込む。
+    // Read は付与しない (= write-only から query を起こす経路を作らない)。
+    props.adminAuditLogTable?.grantWriteData(this.fn);
 
     // #534: deploy job 詳細ページから CFn StackEvents / StackResources を引く読み取り権限。
     // same-account 経路 (= dev / 旧 deployment 行) では本 Lambda Role が直接呼ぶため Describe*

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -66,6 +66,10 @@ export interface EventApiLambdaProps {
    * + 1 event publish に切替。 未設定 / "false" は旧 fan-out 維持 (= rollback safety)。
    */
   readonly useBulkDistributedMap?: boolean;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin 操作 audit log 用 DDB Table。 deploy-api-lambda と同じ。
+   */
+  readonly adminAuditLogTable?: Table;
 }
 
 /**
@@ -113,6 +117,8 @@ export class EventApiLambda extends Construct {
         // bucket 未配線時は空文字、 flag は default false (= 旧 fan-out 維持)。
         BULK_DEPLOY_PAYLOAD_BUCKET: props.bulkDeployPayloadBucket?.bucketName ?? "",
         BULK_DEPLOY_VIA_DISTRIBUTED_MAP: props.useBulkDistributedMap ? "true" : "false",
+        // Issue #950: audit log table 名 (未配線なら空文字)
+        ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -136,6 +142,8 @@ export class EventApiLambda extends Construct {
     // Issue #888: disruption audit + idempotency 用に RW、 EventBus PutEvents は既存付与で十分
     // (= disruption fire でも同 bus に publish するため)。
     props.disruptionsTable.grantReadWriteData(this.fn);
+    // Issue #950 (ADR-020 Phase D): admin 操作 audit log は write-only で十分。
+    props.adminAuditLogTable?.grantWriteData(this.fn);
     // Issue #910 (#895 Phase 2.C.2.b): bulk payload bucket への PutObject 権限。 bucket が
     // 渡されたときのみ grant (= 未配線時の余分な IAM を避ける)。 useBulkDistributedMap が
     // false でも grant を入れておくと、 flag を flip するだけで切替できる (= 段階移行)。

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -12,6 +12,7 @@ import {
   TENANT_ADMIN_ROLE,
   TENANT_ROLES,
 } from "../deploy-handler/auth.js";
+import { extractAuditContext, writeAuditEvent } from "../shared/audit-log.js";
 import { routeDelete, routeGet, routePut } from "./saml-routes.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
 import {
@@ -88,6 +89,29 @@ app.onError((err, c) => {
       actualRole: err.actualRole,
       requiredRoles: err.requiredRoles,
     });
+    // Issue #950 (ADR-020 Phase D): forbidden_role を audit に残す (= 「誰が何を試みたか」 が
+    // 1 query で引ける)。 tenantId 不明 (= claim 不在 / 越境) の場合は "unknown" を入れる。
+    const auditCtx = extractAuditContext(c);
+    let tenantId = "unknown";
+    try {
+      tenantId = resolveTenantId(c);
+    } catch {
+      // tenantId 不明でも audit は試みる
+    }
+    void writeAuditEvent({
+      tenantId,
+      actor: auditCtx.actor,
+      actorUsername: auditCtx.actorUsername,
+      action: `${c.req.method} ${c.req.path}`,
+      outcome: "forbidden",
+      ipAddress: auditCtx.ipAddress,
+      userAgent: auditCtx.userAgent,
+      occurredAtMs: Date.now(),
+      extra: {
+        actualRole: err.actualRole ?? "(none)",
+        requiredRoles: err.requiredRoles.join(","),
+      },
+    });
     return c.json(
       {
         error: "forbidden_role",
@@ -161,19 +185,44 @@ app.post("/admin/competitor-accounts", async (c) => {
       StatusCodes.BAD_REQUEST,
     );
   }
+  const tenantIdForCreate = resolveTenantId(c);
+  const auditCreate = extractAuditContext(c);
   try {
     const response = await createCompetitorAccount(
       shared,
       {
-        tenantId: resolveTenantId(c),
+        tenantId: tenantIdForCreate,
         nowMs: Date.now(),
         createdBy: resolveCognitoSub(c),
       },
       parsed.data,
     );
+    // Issue #950: success audit (= 「誰が tenant にどの competitor account を追加したか」)
+    void writeAuditEvent({
+      tenantId: tenantIdForCreate,
+      actor: auditCreate.actor,
+      actorUsername: auditCreate.actorUsername,
+      action: "create_competitor_account",
+      outcome: "success",
+      target: parsed.data.awsAccountId,
+      ipAddress: auditCreate.ipAddress,
+      userAgent: auditCreate.userAgent,
+      occurredAtMs: Date.now(),
+    });
     return c.json(response, StatusCodes.CREATED);
   } catch (err) {
     if (err instanceof DuplicateCompetitorAccountError) {
+      void writeAuditEvent({
+        tenantId: tenantIdForCreate,
+        actor: auditCreate.actor,
+        actorUsername: auditCreate.actorUsername,
+        action: "create_competitor_account",
+        outcome: "conflict",
+        target: err.awsAccountId,
+        ipAddress: auditCreate.ipAddress,
+        userAgent: auditCreate.userAgent,
+        occurredAtMs: Date.now(),
+      });
       return c.json(
         { error: "duplicate_account", awsAccountId: err.awsAccountId },
         StatusCodes.CONFLICT,
@@ -290,8 +339,22 @@ app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
   if (!awsAccountId || !AWS_ACCOUNT_ID_RE.test(awsAccountId)) {
     return c.json({ error: "invalid_account_id" }, StatusCodes.BAD_REQUEST);
   }
+  const tenantIdForDelete = resolveTenantId(c);
+  const auditDelete = extractAuditContext(c);
   try {
-    await deleteCompetitorAccount(shared, resolveTenantId(c), awsAccountId);
+    await deleteCompetitorAccount(shared, tenantIdForDelete, awsAccountId);
+    // Issue #950: success audit (= competitor account 削除は IAM 越境表面に影響)
+    void writeAuditEvent({
+      tenantId: tenantIdForDelete,
+      actor: auditDelete.actor,
+      actorUsername: auditDelete.actorUsername,
+      action: "delete_competitor_account",
+      outcome: "success",
+      target: awsAccountId,
+      ipAddress: auditDelete.ipAddress,
+      userAgent: auditDelete.userAgent,
+      occurredAtMs: Date.now(),
+    });
     return c.json({ deleted: true }, StatusCodes.OK);
   } catch (err) {
     if (err instanceof CompetitorAccountNotFoundError) {
@@ -329,11 +392,35 @@ app.post("/admin/users", async (c) => {
     );
   }
   const tenantId = resolveTenantId(c);
+  const auditCtx = extractAuditContext(c);
   try {
     const result = await routeCreateUser({ shared }, c, tenantId, parsed.data);
+    void writeAuditEvent({
+      tenantId,
+      actor: auditCtx.actor,
+      actorUsername: auditCtx.actorUsername,
+      action: "invite_user",
+      outcome: "success",
+      target: parsed.data.email,
+      ipAddress: auditCtx.ipAddress,
+      userAgent: auditCtx.userAgent,
+      occurredAtMs: Date.now(),
+      extra: { userRole: parsed.data.userRole },
+    });
     return c.json(result.body as never, result.status as 201 | 401);
   } catch (err) {
     if (err instanceof DuplicateUserError) {
+      void writeAuditEvent({
+        tenantId,
+        actor: auditCtx.actor,
+        actorUsername: auditCtx.actorUsername,
+        action: "invite_user",
+        outcome: "conflict",
+        target: err.email,
+        ipAddress: auditCtx.ipAddress,
+        userAgent: auditCtx.userAgent,
+        occurredAtMs: Date.now(),
+      });
       return c.json({ error: "duplicate_user", email: err.email }, StatusCodes.CONFLICT);
     }
     const message = err instanceof Error ? err.message : "unknown error";
@@ -349,8 +436,20 @@ app.delete("/admin/users/:username", async (c) => {
     return c.json({ error: "invalid_username" }, StatusCodes.BAD_REQUEST);
   }
   const tenantId = resolveTenantId(c);
+  const auditCtx = extractAuditContext(c);
   try {
     const result = await routeDeleteUser({ shared }, c, tenantId, username);
+    void writeAuditEvent({
+      tenantId,
+      actor: auditCtx.actor,
+      actorUsername: auditCtx.actorUsername,
+      action: "delete_user",
+      outcome: "success",
+      target: username,
+      ipAddress: auditCtx.ipAddress,
+      userAgent: auditCtx.userAgent,
+      occurredAtMs: Date.now(),
+    });
     return c.json(result.body as never, result.status as 200 | 401 | 409);
   } catch (err) {
     if (err instanceof UserNotFoundError) {
@@ -362,6 +461,19 @@ app.delete("/admin/users/:username", async (c) => {
         username,
         expected: err.expectedTenantId,
         actual: err.actualTenantId,
+      });
+      // Issue #950: 越境試行は audit に記録 (= attacker behavior detection)
+      void writeAuditEvent({
+        tenantId,
+        actor: auditCtx.actor,
+        actorUsername: auditCtx.actorUsername,
+        action: "delete_user",
+        outcome: "forbidden",
+        target: username,
+        ipAddress: auditCtx.ipAddress,
+        userAgent: auditCtx.userAgent,
+        occurredAtMs: Date.now(),
+        extra: { reason: "tenant_mismatch" },
       });
       return c.json({ error: "not_found", username }, StatusCodes.NOT_FOUND);
     }
@@ -392,8 +504,21 @@ app.patch("/admin/users/:username", async (c) => {
     );
   }
   const tenantId = resolveTenantId(c);
+  const auditCtx = extractAuditContext(c);
   try {
     const result = await routeChangeUserRole({ shared }, c, tenantId, username, parsed.data);
+    void writeAuditEvent({
+      tenantId,
+      actor: auditCtx.actor,
+      actorUsername: auditCtx.actorUsername,
+      action: "patch_user_role",
+      outcome: "success",
+      target: username,
+      ipAddress: auditCtx.ipAddress,
+      userAgent: auditCtx.userAgent,
+      occurredAtMs: Date.now(),
+      extra: { newRole: parsed.data.userRole },
+    });
     return c.json(result.body as never, result.status as 200 | 401 | 409);
   } catch (err) {
     if (err instanceof UserNotFoundError) {
@@ -404,6 +529,18 @@ app.patch("/admin/users/:username", async (c) => {
         username,
         expected: err.expectedTenantId,
         actual: err.actualTenantId,
+      });
+      void writeAuditEvent({
+        tenantId,
+        actor: auditCtx.actor,
+        actorUsername: auditCtx.actorUsername,
+        action: "patch_user_role",
+        outcome: "forbidden",
+        target: username,
+        ipAddress: auditCtx.ipAddress,
+        userAgent: auditCtx.userAgent,
+        occurredAtMs: Date.now(),
+        extra: { reason: "tenant_mismatch" },
       });
       return c.json({ error: "not_found", username }, StatusCodes.NOT_FOUND);
     }

--- a/infrastructure/lib/problem-deploy/handlers/shared/audit-log.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/audit-log.ts
@@ -1,0 +1,161 @@
+import { DynamoDBClient, type DynamoDBClient as RawDynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+
+/**
+ * Issue #950 (ADR-020 Phase D): admin 操作の append-only 監査ログを書き込む shared helper。
+ *
+ * 旧状態: admin 操作 (= user 招待 / role 変更 / 削除、 SAML CRUD、 ExternalId rotate、 Event 削除 等) は
+ * CloudWatch Logs に \`console.log\` で 1 行残るだけ。 「誰が・いつ・何を」 を後追いする集約 storage が
+ * 無く、 audit は CloudWatch Logs Insights grep に依存。 本 helper は 3 handler (= deploy /
+ * event / competitor-accounts) と admin-insight Lambda から共通で呼ばれ、 1 DDB Table に行を
+ * 集約する (= ADR-006 Notifications の writeScoreEvent と同パターン)。
+ *
+ * Schema (= `admin-audit-log-table.ts` 参照):
+ *   PK: TENANT#<tenantId>   (tenant 操作)
+ *       SYSTEM#<env>        (SystemAdmin 操作、 tenant に紐づかない)
+ *   SK: AUDIT#<ulid>
+ *   GSI1PK: ACTOR#<sub>     (actor 別の 「誰が何をしたか」 query)
+ *   GSI1SK: <occurredAt ISO8601>
+ *   attrs: actor / actorUsername / action / outcome / target / ipAddress / userAgent /
+ *          occurredAt / ttl
+ *
+ * fail-safe: write 失敗しても caller の business logic を阻害しない (= audit 行欠落より
+ * primary 操作の成功を優先)。 失敗時は console.error で警告のみ。
+ *
+ * env: `ADMIN_AUDIT_LOG_TABLE_NAME` が空文字 / 未設定なら write は no-op (= 旧 stack 互換、
+ * audit 行 0 件で正常動作)。 CDK 側で table 配線が landed したあとから自動で記録され始める。
+ */
+
+const AUDIT_TTL_DAYS = 90;
+const AUDIT_TTL_SECONDS = AUDIT_TTL_DAYS * 86400;
+
+export type AuditOutcome = "success" | "forbidden" | "not_found" | "conflict" | "error";
+
+export interface AuditEvent {
+  /**
+   * tenant 操作なら tenantId、 SystemAdmin 操作なら `"SYSTEM"` を渡す。 後者は
+   * `PK = "SYSTEM#<env>"` で書かれる (= tenant 越境のない単一 partition)。
+   */
+  readonly tenantId: string;
+  /** Cognito sub (= 安定識別子)。 不明なら "unknown" を渡す。 */
+  readonly actor: string;
+  /** Cognito cognito:username (= 通常 email)。 不明なら undefined。 */
+  readonly actorUsername?: string;
+  /** e.g. "patch_user_role" / "invite_user" / "rotate_external_id" / "delete_event"。 */
+  readonly action: string;
+  readonly outcome: AuditOutcome;
+  /** 対象 resource (= username / awsAccountId / eventId)。 */
+  readonly target?: string;
+  /** Source IP (X-Forwarded-For 等)。 */
+  readonly ipAddress?: string;
+  readonly userAgent?: string;
+  /** ms epoch (= Date.now())、 ISO8601 化して保存。 */
+  readonly occurredAtMs: number;
+  /** optional 追加情報 (= 任意の string map、 内部監査用のみで PII を入れない)。 */
+  readonly extra?: Readonly<Record<string, string>>;
+}
+
+const documentClient = DynamoDBDocumentClient.from(
+  new DynamoDBClient({}) satisfies RawDynamoDBClient,
+);
+
+export interface AuditClient {
+  send: typeof documentClient.send;
+}
+
+function getEnv(): { tableName: string; env: string } | undefined {
+  const tableName = process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "";
+  if (tableName.length === 0) return undefined;
+  const env = process.env.DEPLOY_ENVIRONMENT ?? "development";
+  return { tableName, env };
+}
+
+/**
+ * audit 行を書き込む (= 業務 logic と並列の補助 write、 fail-safe)。
+ *
+ * 戻り値: 書き込んだ場合 true、 env 未配線 / 失敗の場合 false。 caller は戻り値を見ない
+ * (= 「best-effort write」 として扱う)。 unit test は env mock + client mock で coverage。
+ */
+export async function writeAuditEvent(
+  event: AuditEvent,
+  client: AuditClient = documentClient,
+): Promise<boolean> {
+  const cfg = getEnv();
+  if (!cfg) return false;
+  const occurredAt = new Date(event.occurredAtMs).toISOString();
+  const id = ulid(event.occurredAtMs);
+  const pk = event.tenantId === "SYSTEM" ? `SYSTEM#${cfg.env}` : `TENANT#${event.tenantId}`;
+  const ttl = Math.floor(event.occurredAtMs / 1000) + AUDIT_TTL_SECONDS;
+
+  const item: Record<string, unknown> = {
+    PK: pk,
+    SK: `AUDIT#${id}`,
+    GSI1PK: `ACTOR#${event.actor}`,
+    GSI1SK: occurredAt,
+    actor: event.actor,
+    action: event.action,
+    outcome: event.outcome,
+    occurredAt,
+    ttl,
+  };
+  if (event.actorUsername) item.actorUsername = event.actorUsername;
+  if (event.target) item.target = event.target;
+  if (event.ipAddress) item.ipAddress = event.ipAddress;
+  if (event.userAgent) item.userAgent = event.userAgent;
+  if (event.extra) item.extra = event.extra;
+
+  try {
+    await client.send(
+      new PutCommand({
+        TableName: cfg.tableName,
+        Item: item,
+      }),
+    );
+    return true;
+  } catch (err) {
+    // audit 行欠落は primary 操作の成否に比べて重要度が低い。 log は残すが throw しない。
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[audit] writeAuditEvent failed", {
+      action: event.action,
+      outcome: event.outcome,
+      message,
+    });
+    return false;
+  }
+}
+
+/**
+ * Hono Context から actor / actorUsername / ipAddress / userAgent を抽出する helper。
+ * 既存 `resolveCognitoSub` と同じ JWT claims 経路を読む (= deploy-handler/auth.ts に依存しない、
+ * lightweight な独立 helper)。
+ */
+export function extractAuditContext(c: {
+  env?: unknown;
+  req?: { header: (name: string) => string | undefined };
+}): {
+  actor: string;
+  actorUsername: string | undefined;
+  ipAddress: string | undefined;
+  userAgent: string | undefined;
+} {
+  const event = (c.env as { event?: { requestContext?: { authorizer?: unknown; http?: unknown } } })
+    ?.event;
+  const authorizer = (event?.requestContext as { authorizer?: unknown })?.authorizer as
+    | { jwt?: { claims?: Record<string, unknown> }; claims?: Record<string, unknown> }
+    | undefined;
+  const claims = authorizer?.jwt?.claims ?? authorizer?.claims;
+  const sub = typeof claims?.sub === "string" ? claims.sub : "unknown";
+  const cognitoUsername =
+    typeof claims?.["cognito:username"] === "string"
+      ? (claims["cognito:username"] as string)
+      : undefined;
+  const http = (event?.requestContext as { http?: { sourceIp?: string; userAgent?: string } })
+    ?.http;
+  return {
+    actor: sub,
+    actorUsername: cognitoUsername,
+    ipAddress: http?.sourceIp,
+    userAgent: http?.userAgent,
+  };
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -5,6 +5,7 @@ import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
+import { AdminAuditLogTable } from "./admin-audit-log-table";
 import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine";
 import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda";
 import { CompetitorAccountsTable } from "./competitor-accounts-table";
@@ -186,6 +187,11 @@ export class ProblemDeployBackendStack extends cdk.Stack {
   public readonly competitorAccountsTable: Table;
   /** ProblemEndpoints table name is surfaced to ObservabilityStack metrics. */
   public readonly problemEndpointsTable: Table;
+  /**
+   * Issue #950 (ADR-020 Phase D): admin audit log table。 AdminConsoleInsightStack が
+   * cross-stack read で audit UI に出すため公開する (= read-only)。
+   */
+  public readonly adminAuditLogTable: Table;
   /** DeployCreate Step Functions State Machine ARN for CloudWatch metrics. */
   public readonly deployCreateStateMachineArn: string;
   /** DeployDelete Step Functions State Machine ARN for CloudWatch metrics. */
@@ -225,6 +231,10 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     this.problemEndpointsTable = endpoints.table;
     // Issue #888: Red Team Disruption Injection の audit log + idempotency
     const disruptions = new DisruptionsTable(this, "Disruptions");
+    // Issue #950 (ADR-020 Phase D): admin 操作の append-only 監査ログ。 3 handler Lambda +
+    // admin-insight Lambda が PutItem する。 TTL 90 日で自動 GC。
+    const adminAuditLog = new AdminAuditLogTable(this, "AdminAuditLog");
+    this.adminAuditLogTable = adminAuditLog.table;
     // Issue #778 ADR-016 Phase 2: eventBusArn が渡されていれば既存の SBT bus を import、
     // 渡されていなければ Lite mode と判定して local EventBus を新規に作る。 後者では Step
     // Functions Rule も local bus にぶら下がるため、 cross-stack 依存が増えない。
@@ -248,6 +258,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         ? { challengePayloadBucketName: props.challengePayloadBucketName }
         : {}),
       environmentName: props.environmentName,
+      // Issue #950 (ADR-020 Phase D): admin audit log を write
+      adminAuditLogTable: adminAuditLog.table,
     });
     this.deployApiLambda = deployApi.fn;
 
@@ -290,6 +302,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       // Issue #910 Phase 2.C.2.b: bulk batch payload bucket + feature flag。
       bulkDeployPayloadBucket: bulkPayloadBucket,
       useBulkDistributedMap: props.useBulkDistributedMap ?? false,
+      // Issue #950
+      adminAuditLogTable: adminAuditLog.table,
     });
     this.eventApiLambda = eventApi.fn;
 
@@ -298,6 +312,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     const competitorAccountsApi = new CompetitorAccountsApiLambda(this, "CompetitorAccountsApi", {
       competitorAccountsTable: competitorAccounts.table,
       environmentName: props.environmentName,
+      // Issue #950
+      adminAuditLogTable: adminAuditLog.table,
     });
     this.competitorAccountsApiLambda = competitorAccountsApi.fn;
 

--- a/infrastructure/test/admin-insight/audit-routes.test.ts
+++ b/infrastructure/test/admin-insight/audit-routes.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listAuditEntries } from "../../lib/admin-insight/handlers/admin-insight-handler/audit";
+
+/**
+ * Issue #950 (ADR-020 Phase D): listAuditEntries の挙動を pin する。
+ *
+ * - scope=tenant + tenantId → PK=TENANT#<id> で Query
+ * - scope=system → PK=SYSTEM#<env> で Query
+ * - ScanIndexForward=false (= 新しい順)
+ * - cursor + nextCursor を base64(LastEvaluatedKey) で round-trip
+ */
+
+beforeEach(() => {
+  // noop — handlers are pure functions on ddb mock
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function buildMock() {
+  const send = vi.fn();
+  return { ddb: { send }, send };
+}
+
+describe("listAuditEntries (#950)", () => {
+  it("scope=tenant は PK=TENANT#<id> で Query するべき", async () => {
+    const { ddb, send } = buildMock();
+    send.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "TENANT#t-1",
+          SK: "AUDIT#01HX",
+          actor: "u-1",
+          action: "patch_user_role",
+          outcome: "success",
+          occurredAt: "2026-05-17T12:00:00.000Z",
+        },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+    const out = await listAuditEntries(
+      { ddb: ddb as never, auditTableName: "T" },
+      { scope: "tenant", tenantId: "t-1", limit: 10 },
+      "test-env",
+    );
+    expect(out.items.length).toBe(1);
+    expect(out.items[0]?.tenantId).toBe("t-1");
+    expect(out.items[0]?.action).toBe("patch_user_role");
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(cmd.input?.KeyConditionExpression).toBe("PK = :pk");
+    expect((cmd.input?.ExpressionAttributeValues as Record<string, unknown>)?.[":pk"]).toBe(
+      "TENANT#t-1",
+    );
+    expect(cmd.input?.Limit).toBe(10);
+    expect(cmd.input?.ScanIndexForward).toBe(false);
+  });
+
+  it("scope=system は PK=SYSTEM#<env> で Query するべき", async () => {
+    const { ddb, send } = buildMock();
+    send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    await listAuditEntries({ ddb: ddb as never, auditTableName: "T" }, { scope: "system" }, "prod");
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect((cmd.input?.ExpressionAttributeValues as Record<string, unknown>)?.[":pk"]).toBe(
+      "SYSTEM#prod",
+    );
+  });
+
+  it("LastEvaluatedKey から nextCursor を base64 で返すべき", async () => {
+    const { ddb, send } = buildMock();
+    const lastKey = { PK: "TENANT#t-1", SK: "AUDIT#01HX" };
+    send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: lastKey });
+    const out = await listAuditEntries(
+      { ddb: ddb as never, auditTableName: "T" },
+      { scope: "tenant", tenantId: "t-1" },
+      "test-env",
+    );
+    expect(out.nextCursor).toBe(Buffer.from(JSON.stringify(lastKey)).toString("base64"));
+  });
+
+  it("cursor を decode して ExclusiveStartKey に渡すべき", async () => {
+    const { ddb, send } = buildMock();
+    send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    const key = { PK: "TENANT#t-1", SK: "AUDIT#01HX" };
+    const cursor = Buffer.from(JSON.stringify(key)).toString("base64");
+    await listAuditEntries(
+      { ddb: ddb as never, auditTableName: "T" },
+      { scope: "tenant", tenantId: "t-1", cursor },
+      "test-env",
+    );
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(cmd.input?.ExclusiveStartKey).toEqual(key);
+  });
+
+  it("limit > 200 は 200 に clamp するべき", async () => {
+    const { ddb, send } = buildMock();
+    send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    await listAuditEntries(
+      { ddb: ddb as never, auditTableName: "T" },
+      { scope: "tenant", tenantId: "t-1", limit: 9999 },
+      "test-env",
+    );
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(cmd.input?.Limit).toBe(200);
+  });
+
+  it("optional attrs (target / ipAddress / userAgent / extra) を含む item を正しく map するべき", async () => {
+    const { ddb, send } = buildMock();
+    send.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "TENANT#t-1",
+          SK: "AUDIT#01HX",
+          actor: "u-1",
+          actorUsername: "alice@example.com",
+          action: "invite_user",
+          outcome: "success",
+          target: "bob@example.com",
+          ipAddress: "203.0.113.5",
+          userAgent: "Mozilla/5.0",
+          occurredAt: "2026-05-17T12:00:00.000Z",
+          extra: { userRole: "TenantViewer" },
+        },
+      ],
+    });
+    const out = await listAuditEntries(
+      { ddb: ddb as never, auditTableName: "T" },
+      { scope: "tenant", tenantId: "t-1" },
+      "test-env",
+    );
+    expect(out.items[0]?.actorUsername).toBe("alice@example.com");
+    expect(out.items[0]?.target).toBe("bob@example.com");
+    expect(out.items[0]?.ipAddress).toBe("203.0.113.5");
+    expect(out.items[0]?.userAgent).toBe("Mozilla/5.0");
+    expect(out.items[0]?.extra).toEqual({ userRole: "TenantViewer" });
+  });
+});

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -26,11 +26,12 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / Disruptions の 6 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / Disruptions / AdminAuditLog の 7 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
       // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts、
-      // ADR-012 Phase 3.A で ProblemEndpoints、 Issue #888 で Disruptions (Red Team audit + idempotency)。
-      // 6 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
-      tpl.resourceCountIs("AWS::DynamoDB::Table", 6);
+      // ADR-012 Phase 3.A で ProblemEndpoints、 Issue #888 で Disruptions (Red Team audit + idempotency)、
+      // Issue #950 (ADR-020 Phase D) で AdminAuditLog (admin 操作監査)。
+      // 7 Table すべて DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に均される。
+      tpl.resourceCountIs("AWS::DynamoDB::Table", 7);
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({

--- a/infrastructure/test/problem-deploy/audit-log.test.ts
+++ b/infrastructure/test/problem-deploy/audit-log.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AuditClient,
+  extractAuditContext,
+  writeAuditEvent,
+} from "../../lib/problem-deploy/handlers/shared/audit-log";
+
+/**
+ * Issue #950 (ADR-020 Phase D): writeAuditEvent helper の挙動を pin する。
+ *
+ * - env ADMIN_AUDIT_LOG_TABLE_NAME が空文字 → no-op で false を返すべき (= 旧 stack 互換)
+ * - env 設定済 + 正常書き込み → PutCommand を送信して true を返すべき
+ * - DDB 例外 → console.error で警告のみ、 false を返す (= caller の business logic を阻害しない)
+ * - tenantId="SYSTEM" は PK="SYSTEM#<env>" に変換されるべき
+ */
+
+const ORIGINAL_TABLE = process.env.ADMIN_AUDIT_LOG_TABLE_NAME;
+const ORIGINAL_ENV = process.env.DEPLOY_ENVIRONMENT;
+beforeEach(() => {
+  process.env.ADMIN_AUDIT_LOG_TABLE_NAME = "TestAuditLog";
+  process.env.DEPLOY_ENVIRONMENT = "test-env";
+});
+afterEach(() => {
+  if (ORIGINAL_TABLE === undefined) delete process.env.ADMIN_AUDIT_LOG_TABLE_NAME;
+  else process.env.ADMIN_AUDIT_LOG_TABLE_NAME = ORIGINAL_TABLE;
+  if (ORIGINAL_ENV === undefined) delete process.env.DEPLOY_ENVIRONMENT;
+  else process.env.DEPLOY_ENVIRONMENT = ORIGINAL_ENV;
+});
+
+function buildMockClient(): { client: AuditClient; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn().mockResolvedValue({});
+  return { client: { send: send as never }, send };
+}
+
+const baseEvent = {
+  tenantId: "t-1",
+  actor: "user-sub-1",
+  actorUsername: "alice@example.com",
+  action: "patch_user_role",
+  outcome: "success",
+  target: "bob@example.com",
+  ipAddress: "203.0.113.5",
+  userAgent: "Mozilla/5.0",
+  occurredAtMs: Date.UTC(2026, 4, 17, 12, 0, 0),
+} as const;
+
+describe("writeAuditEvent (#950)", () => {
+  it("env 配線済なら PutCommand を送って true を返すべき", async () => {
+    const { client, send } = buildMockClient();
+    const ok = await writeAuditEvent(baseEvent, client);
+    expect(ok).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(cmd.input?.TableName).toBe("TestAuditLog");
+    const item = cmd.input?.Item as Record<string, unknown>;
+    expect(item.PK).toBe("TENANT#t-1");
+    expect(item.SK).toMatch(/^AUDIT#[0-9A-Z]{26}$/);
+    expect(item.GSI1PK).toBe("ACTOR#user-sub-1");
+    expect(item.actor).toBe("user-sub-1");
+    expect(item.actorUsername).toBe("alice@example.com");
+    expect(item.action).toBe("patch_user_role");
+    expect(item.outcome).toBe("success");
+    expect(item.target).toBe("bob@example.com");
+    expect(item.occurredAt).toBe("2026-05-17T12:00:00.000Z");
+    // ttl = occurredAtMs/1000 + 90*86400
+    expect(item.ttl).toBe(Math.floor(baseEvent.occurredAtMs / 1000) + 90 * 86400);
+  });
+
+  it("env が空文字なら no-op で false を返すべき (= 旧 stack 互換)", async () => {
+    delete process.env.ADMIN_AUDIT_LOG_TABLE_NAME;
+    const { client, send } = buildMockClient();
+    const ok = await writeAuditEvent(baseEvent, client);
+    expect(ok).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("DDB 例外なら false を返して console.error を出し、 throw しない", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("DDB failure"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ok = await writeAuditEvent(baseEvent, { send: send as never });
+    expect(ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("tenantId='SYSTEM' は PK='SYSTEM#<env>' に変換されるべき", async () => {
+    const { client, send } = buildMockClient();
+    await writeAuditEvent({ ...baseEvent, tenantId: "SYSTEM" }, client);
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    const item = cmd.input?.Item as Record<string, unknown>;
+    expect(item.PK).toBe("SYSTEM#test-env");
+  });
+
+  it("optional fields (target / ipAddress / userAgent / extra) が undefined ならスキップされるべき", async () => {
+    const { client, send } = buildMockClient();
+    await writeAuditEvent(
+      {
+        tenantId: "t-2",
+        actor: "u-2",
+        action: "x",
+        outcome: "forbidden",
+        occurredAtMs: Date.now(),
+      },
+      client,
+    );
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    const item = cmd.input?.Item as Record<string, unknown>;
+    expect(item.target).toBeUndefined();
+    expect(item.ipAddress).toBeUndefined();
+    expect(item.userAgent).toBeUndefined();
+    expect(item.extra).toBeUndefined();
+  });
+
+  it("extra が指定されると Item に含まれるべき (= 追加情報の保存)", async () => {
+    const { client, send } = buildMockClient();
+    await writeAuditEvent(
+      {
+        ...baseEvent,
+        extra: { newRole: "TenantViewer", reason: "downgrade" },
+      },
+      client,
+    );
+    const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    const item = cmd.input?.Item as Record<string, unknown>;
+    expect(item.extra).toEqual({ newRole: "TenantViewer", reason: "downgrade" });
+  });
+});
+
+describe("extractAuditContext (#950)", () => {
+  it("HTTP API V2 形式 (= authorizer.jwt.claims) から actor / username / ipAddress / userAgent を抽出すべき", () => {
+    const ctx = extractAuditContext({
+      env: {
+        event: {
+          requestContext: {
+            authorizer: {
+              jwt: {
+                claims: {
+                  sub: "abc-123",
+                  "cognito:username": "alice@example.com",
+                },
+              },
+            },
+            http: { sourceIp: "203.0.113.10", userAgent: "curl/8.0" },
+          },
+        },
+      },
+    });
+    expect(ctx.actor).toBe("abc-123");
+    expect(ctx.actorUsername).toBe("alice@example.com");
+    expect(ctx.ipAddress).toBe("203.0.113.10");
+    expect(ctx.userAgent).toBe("curl/8.0");
+  });
+
+  it("REST API 形式 (= authorizer.claims) でも actor が引けるべき", () => {
+    const ctx = extractAuditContext({
+      env: {
+        event: {
+          requestContext: {
+            authorizer: { claims: { sub: "def-456" } },
+          },
+        },
+      },
+    });
+    expect(ctx.actor).toBe("def-456");
+  });
+
+  it("claims 不在なら actor='unknown', 他は undefined", () => {
+    const ctx = extractAuditContext({});
+    expect(ctx.actor).toBe("unknown");
+    expect(ctx.actorUsername).toBeUndefined();
+    expect(ctx.ipAddress).toBeUndefined();
+    expect(ctx.userAgent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

admin 操作 (= user 招待 / role 変更 / 削除、 SAML CRUD、 ExternalId rotate、 Event 削除 等) を append-only DDB Table に集約する監査経路を新設する。

旧状態: 各 admin 操作は CloudWatch Logs に \`console.log\` で 1 行残るだけ。 「誰が・いつ・何を」 を後追いする集約 storage が無く、 audit は Logs Insights grep に依存。

## 構成 (= 4 stage)

### Stage 1: CDK + IAM
- 新 \`AdminAuditLogTable\` (PROVISIONED 1/1、 \`DynamoDbLowCapacity\` Aspect 強制、 TTL 90 日、 RETAIN)
- IAM grant:
  - 3 handler (deploy / event / competitor-accounts): write-only
  - admin-insight: read-only (cross-tenant 監査画面)
- Lambda env \`ADMIN_AUDIT_LOG_TABLE_NAME\` を全 4 Lambda に注入

### Stage 2: shared helper
- \`writeAuditEvent(event)\` — fail-safe な append-only write (= 業務 logic を阻害しない)
- \`extractAuditContext(c)\` — Hono Context から actor / username / IP / UA を抽出
- env 未配線なら no-op (= 旧 stack 互換)

### Stage 3: handler 配線 (competitor-accounts-handler)
- onError \`ForbiddenRoleError\` 経路 (= attacker behavior detection)
- POST /admin/competitor-accounts (success / conflict)
- DELETE /admin/competitor-accounts/:awsAccountId
- POST /admin/users / DELETE /admin/users/:username / PATCH /admin/users/:username (success / forbidden / conflict)

### Stage 4: admin-insight (read) + frontend
- 新 \`listAuditEntries\` + GET /admin/insight/audit route
- 新 \`AuditLogPage\` (= scope切替、 outcome 色分け、 base64 cursor で paginate)
- 4 locale に \`nav.audit_log\` 追加

## test

新 2 file 計 15 case + 既存 stack test の DDB Table count を 6 → 7 に更新。

- \`audit-log.test.ts\` (= writeAuditEvent / extractAuditContext): 9 case
- \`audit-routes.test.ts\` (= listAuditEntries): 6 case

## Regression 分析

- 既存 admin 操作は audit write が **追加** されるだけで挙動は不変 (= best-effort write、 失敗は console.error のみ)
- env 未配線なら no-op で 1 件も書かれない
- IAM grant は新 table のみ、 既存 IAM Policy に影響なし
- 1233 件 infra test 全 green (= 既存 1218 + 新 15)

## 物理影響

- NEW DDB Table: AdminAuditLog (PROVISIONED 1/1、 GSI1、 TTL 90 日、 RETAIN)
- UPDATE Lambda env (4 個): \`ADMIN_AUDIT_LOG_TABLE_NAME\` 追加
- UPDATE Lambda IAM (4 個): 3 個に PutItem、 admin-insight に Query/Scan
- UPDATE HTTP API: \`/admin/insight/audit\` GET route 追加
- NEW frontend file: \`AuditLog.tsx\` + \`audit-client.ts\`
- UPDATE frontend: App.tsx (+1 route)、 AppLayout (+1 nav)、 4 locale.json (+1 key)
- CFn diff: 1 DDB Table CREATE + 4 Lambda UPDATE (env + IAM Policy) + 1 HTTP API Route UPDATE

## Test plan

- [x] \`make harness\` — no findings
- [x] \`make typecheck\` — clean
- [x] \`make test\` — 1233 infra + 126 admin-console 全通過
- [x] \`make before-commit\` — 全 gate 通過

Closes #950 (= ADR-020 Phase D、 admin audit log の foundational layer)
Phase 2 (= 残 mutate route の audit 配線 / ADR-022 化) は次 PR で続ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)