### PR TITLE
feat(#951 sub-1+2): CFn ref check script + scaffold metadata の learningGoals 実例化

### DIFF
--- a/.claude/templates/problems/attack-detection/metadata.json
+++ b/.claude/templates/problems/attack-detection/metadata.json
@@ -11,7 +11,11 @@
   "description": "competitor account 内の counter (= 攻撃検知件数、 SQLi 阻止件数、 SOC alert 件数 等) を CFn Output で露出し、 platform が 1 分毎に diff を取って加点する。\\n\\n典型用途: WAF 防御 / SOC monitoring / IDS 設定の効果を数値で評価したい問題。 counter 値は問題側 Lambda / CloudWatch metrics → SSM Parameter Store 経由で CFn Output に書く方式が一般的。",
   "tags": ["sample", "security"],
   "exposedPorts": [{ "port": 80, "name": "monitored-service" }],
-  "learningGoals": ["__LEARNING_GOAL_1__"],
+  "learningGoals": [
+    "AWS WAF / SOC monitoring / IDS の検知ルールを書き、 攻撃 packet を確実に阻止する",
+    "CloudWatch Metric → SSM Parameter Store → CFn Output 経由で 「自分が検知した数」 を 1 分 1 度 publish する経路を実装する",
+    "false-positive を抑えつつ阻止件数を最大化する trade-off を観察する"
+  ],
   "cfnTemplate": "template.yaml",
   "endpoints": [
     {

--- a/.claude/templates/problems/phased-polling/metadata.json
+++ b/.claude/templates/problems/phased-polling/metadata.json
@@ -11,7 +11,11 @@
   "description": "競技時間中に複数 phase が自動進行する Battle 型。 phases[].afterMinutes で発火 offset を持ち、 phase ごとに `effect` で scoring engine の挙動を切り替える (= platform 加点分類 / scorePath override 等)。\\n\\n典型用途: マイクロサービス分割レース、 段階的負荷試験、 時系列的に変わる game rule。 phased-polling は probe 1 回ごとに platform 自己申告 (`/meta`) を読み platform 分類 (ec2/lambda/ecs/apprunner) で加点する。",
   "tags": ["sample", "battle"],
   "exposedPorts": [{ "port": 80, "name": "service" }],
-  "learningGoals": ["__LEARNING_GOAL_1__"],
+  "learningGoals": [
+    "EC2 / Lambda / ECS / App Runner の 4 platform に同一 service を移行し、 各 platform の特性を体験する",
+    "phase 切替時に意図した加点 effect が乗るよう /meta を更新する自己申告 endpoint を実装する",
+    "段階的進行で運用優先度 (= まず動かす / 次に最適化) を切り替える判断練習"
+  ],
   "cfnTemplate": "template.yaml",
   "endpoints": [
     {

--- a/.claude/templates/problems/uptime-multi/metadata.json
+++ b/.claude/templates/problems/uptime-multi/metadata.json
@@ -14,7 +14,11 @@
     { "port": 80, "name": "frontend (HTTP)" },
     { "port": 8080, "name": "api (HTTP)" }
   ],
-  "learningGoals": ["__LEARNING_GOAL_1__"],
+  "learningGoals": [
+    "複数 microservice を並列に稼働させ続け、 1 つの障害が全体スコアを 0 に落とす設計問題を体験する",
+    "障害発生時の優先度判断 (= どの slot を先に復旧するか) を 1 分単位で迫られる situational awareness",
+    "frontend / api / db など層別 service 依存を解消する 「分離設計」 を実装で示す"
+  ],
   "cfnTemplate": "template.yaml",
   "endpoints": [
     {

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export JSII_DEPRECATED := quiet
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
-        check-http-status check-template-ascii check-template-security \
+        check-http-status check-template-ascii check-template-security check-template-cfn-refs \
         env-check env-check-lite synth check-synth diff bootstrap \
         deploy deploy-saas deploy-control-plane deploy-bootstrap destroy destroy-saas \
         deploy-battles destroy-battles \
@@ -46,9 +46,11 @@ check-http-status: ; bun run scripts/check-http-magic-numbers.ts
 check-template-ascii: ; bun run scripts/check-template-ascii.ts
 # Issue #869: 問題 template.yaml の pre-deploy security scan (= IAM wildcard / SG open / S3 public / KMS rotation)
 check-template-security: ; bun run scripts/check-template-security.ts
+# Issue #951 sub-2: 問題 template.yaml の構造的整合性 (= !Ref / !GetAtt が declared resource を指す)
+check-template-cfn-refs: ; bun run scripts/check-template-cfn-refs.ts
 audit-deps:    ; bun run audit:dependencies
-check:         install lint test validate-problems check-problems-index check-docs check-http-status check-template-ascii check-template-security audit-deps check-synth
-before-commit: lint test validate-problems check-problems-index check-docs check-http-status check-template-ascii check-template-security audit-deps check-synth
+check:         install lint test validate-problems check-problems-index check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs audit-deps check-synth
+before-commit: lint test validate-problems check-problems-index check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs audit-deps check-synth
 
 # `cdk synth` が通ることを保証 (= ts-node / tsx の module resolution、 stack 構築の type error
 # 等を本番 deploy 前にキャッチ)。 Makefile placeholder env で全 stack を synth するので AWS 認証は不要。

--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -1,0 +1,95 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * Issue #951 sub #2: `scripts/check-template-cfn-refs.ts` の挙動を pin する。
+ *
+ * 直接 main を呼ばずに、 同 script の helper 関数を import して unit test する設計が望ましいが、
+ * 現状 `main()` のみ export していないので、 child process で script 全体を実行して exit code +
+ * stdout/stderr で検証する。 これにより、 後で helper を export 化したとき test を壊さずに済む
+ * (= 公開 contract = 「exit code + 出力」 を pin する)。
+ *
+ * test 戦略:
+ *   - 一時ディレクトリに problems/<category>/<id>/template.yaml を仕込んで script を回す
+ *   - script は `problems/` 直下を絶対 path で見るため、 PROBLEMS_DIR を env で上書き...は本実装には
+ *     無いので、 「 既存 problem template (= main repo の 4 個) を抜けるかどうか」 だけ smoke test
+ */
+
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
+
+describe("check-template-cfn-refs script (#951 sub-2)", () => {
+  it("既存 4 問題 template は全 pass するべき (= smoke test)", () => {
+    const result = spawnSync("bun", ["run", "scripts/check-template-cfn-refs.ts"], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK:");
+    expect(result.stdout).toContain("4 template(s)");
+  });
+});
+
+/**
+ * helper 関数の export 化を待たずに、 検出ロジックの unit test を持ちたい部分は
+ * inline で同等のロジックを再現する (= regression を script 側で起こしたら同じ正規表現に
+ * 戻すかどうかを review で議論できるよう、 期待挙動を doc 化する目的)。
+ */
+describe("check-template-cfn-refs detection patterns (= 期待挙動 doc)", () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), "tc-cfn-refs-test-"));
+  const tmpProblem = join(tmpDir, "problems/challenges/test-problem");
+  beforeEach(() => {
+    mkdirSync(tmpProblem, { recursive: true });
+  });
+  afterEach(() => {
+    try {
+      rmSync(tmpProblem, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("Resources / Parameters / pseudo を分けて parse できること (= shape 確認)", () => {
+    const yaml = `AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  NamePrefix:
+    Type: String
+  TenkaCloudAccountId:
+    Type: String
+Resources:
+  HelloParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/\${NamePrefix}/hello"
+      Type: String
+      Value: !Sub "Hello from \${NamePrefix}"
+  ParticipantViewerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "\${NamePrefix}-participant-viewer"
+Outputs:
+  ParticipantViewerRoleArn:
+    Value: !GetAtt ParticipantViewerRole.Arn
+`;
+    // 単純 parse: line に \`^  HelloParameter:\` 等が含まれることを確認する。
+    expect(yaml).toContain("HelloParameter:");
+    expect(yaml).toContain("ParticipantViewerRole:");
+    expect(yaml).toContain("ParticipantViewerRoleArn:");
+  });
+
+  it("`!Ref UnknownResource` を unresolve として検出する (= pattern doc)", () => {
+    // 本物の script を回さなくても、 unresolved-ref を投げ込むテンプレが具体的にどう失敗するかを
+    // doc 化する目的の test。 実 script 走行は前段の smoke test で。
+    const yaml = `Resources:
+  Foo:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Ref BogusResource
+`;
+    const re = /!Ref\s+([A-Za-z][A-Za-z0-9:_]*)/g;
+    const refs = [...yaml.matchAll(re)].map((m) => m[1]);
+    expect(refs).toContain("BogusResource");
+  });
+});

--- a/scripts/check-template-cfn-refs.ts
+++ b/scripts/check-template-cfn-refs.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env bun
+/**
+ * Issue #951 sub #2: 問題 template.yaml の構造的整合性チェック (cfn-lint port lite)。
+ *
+ * 旧状態: `make validate-problems` は metadata.json の SCHEMA 検証 + cross-ref
+ * (= scoring.flagOutputKey ↔ Outputs / endpoints[].default.key ↔ Outputs) のみ。
+ * CFn template 内部の `!Ref` / `!GetAtt` が未宣言の resource を指していても deploy 時まで
+ * 気付けず、 問題作成者の開発サイクルが (= edit → make deploy 5-10 分 → 失敗) で長い。
+ *
+ * 本 script は問題テンプレートに限定した軽量 cfn-lint:
+ *
+ *   - `!Ref <name>` / `Fn::Ref: <name>` が `Resources.<name>` か `Parameters.<name>` か
+ *     pseudo parameter (= `AWS::*`) に解決できるか
+ *   - `!GetAtt <Resource>.<Attr>` の `<Resource>` 部分が `Resources` に declared か
+ *   - `!Sub "${VarName}"` 内の `${...}` 参照が同様に解決できるか
+ *   - 必須 Resource 規約: 全 problem template で `ParticipantViewerRole` (= AWS::IAM::Role) と
+ *     その Outputs `ParticipantViewerRoleArn` (= ADR-002 Phase 2.1) が宣言されているか
+ *
+ * 検出されたら exit 1。 `make validate-problems` の後段で呼ぶ。
+ *
+ * Python cfn-lint 同等の網羅性は持たない (= 意図的に小さく、 deploy 前に検出すべき
+ * top 80% を狙う)。 IAM policy 細部や resource type 別 attribute は AWS 側 deploy 時に
+ * 任せる。
+ */
+
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+
+interface Finding {
+  readonly templatePath: string;
+  readonly rule: string;
+  readonly detail: string;
+}
+
+/**
+ * AWS pseudo parameters。 `!Ref` で参照可能だが Resources / Parameters には declared されない。
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html
+ */
+const PSEUDO_PARAMETERS = new Set([
+  "AWS::AccountId",
+  "AWS::NotificationARNs",
+  "AWS::NoValue",
+  "AWS::Partition",
+  "AWS::Region",
+  "AWS::StackId",
+  "AWS::StackName",
+  "AWS::URLSuffix",
+]);
+
+/**
+ * 必須宣言の resource 名 + Outputs key (= ADR-002 Phase 2.1)。 sso.ts が
+ * ParticipantViewerRoleArn を読むため、 全 problem template で declare 必須。
+ */
+const REQUIRED_RESOURCE_NAMES = ["ParticipantViewerRole"] as const;
+const REQUIRED_OUTPUT_KEYS = ["ParticipantViewerRoleArn"] as const;
+
+/**
+ * YAML を line-by-line で section 別に分割する単純な parser。 完全な YAML AST は使わない (= 短文・
+ * tab/空白 mix の防御に弱い既存 YAML library 依存を避ける)。 各 section の resource / parameter / output
+ * 名は `^  <Name>:` (= 2-space indent) で declare されているという CFn 慣例を前提に抽出する。
+ */
+function parseSections(yaml: string): {
+  resources: Set<string>;
+  parameters: Set<string>;
+  outputs: Set<string>;
+} {
+  const lines = yaml.split(/\r?\n/);
+  const resources = new Set<string>();
+  const parameters = new Set<string>();
+  const outputs = new Set<string>();
+  let currentSection: "resources" | "parameters" | "outputs" | null = null;
+
+  for (const line of lines) {
+    // Top-level section header (= `Resources:` / `Parameters:` / `Outputs:` at column 0)
+    if (/^Resources:\s*$/.test(line)) {
+      currentSection = "resources";
+      continue;
+    }
+    if (/^Parameters:\s*$/.test(line)) {
+      currentSection = "parameters";
+      continue;
+    }
+    if (/^Outputs:\s*$/.test(line)) {
+      currentSection = "outputs";
+      continue;
+    }
+    // 次の top-level section に入ったら終了 (= column 0 の `<Section>:` で抜ける)
+    if (/^[A-Za-z]/.test(line) && line.endsWith(":")) {
+      currentSection = null;
+      continue;
+    }
+    if (!currentSection) continue;
+    // Section 内の `  <Name>:` (= 2-space indent + identifier + `:`) を拾う
+    const m = line.match(/^ {2}([A-Za-z][A-Za-z0-9]*):\s*$/);
+    if (!m?.[1]) continue;
+    const name = m[1];
+    if (currentSection === "resources") resources.add(name);
+    if (currentSection === "parameters") parameters.add(name);
+    if (currentSection === "outputs") outputs.add(name);
+  }
+  return { resources, parameters, outputs };
+}
+
+/**
+ * `!Ref <name>` / `Ref: <name>` を YAML テキストから抽出する。 `<name>` は英数 + `_` のみ。
+ */
+function collectRefs(yaml: string): string[] {
+  const refs: string[] = [];
+  // !Ref shortform
+  for (const m of yaml.matchAll(/!Ref\s+([A-Za-z][A-Za-z0-9:_]*)/g)) {
+    if (m[1]) refs.push(m[1]);
+  }
+  // Long form `Ref: <Name>` (= JSON-shape の Fn::Ref)
+  for (const m of yaml.matchAll(/^\s*Ref:\s+([A-Za-z][A-Za-z0-9:_]*)\s*$/gm)) {
+    if (m[1]) refs.push(m[1]);
+  }
+  return refs;
+}
+
+/**
+ * `!GetAtt <Resource>.<Attr>` から resource 部分を抽出する。
+ * 関数形 (`Fn::GetAtt: [Resource, Attr]`) も対応するが、 主に short form のみ検出。
+ */
+function collectGetAttResources(yaml: string): string[] {
+  const out: string[] = [];
+  for (const m of yaml.matchAll(/!GetAtt\s+([A-Za-z][A-Za-z0-9]*)\.([A-Za-z][A-Za-z0-9.]*)/g)) {
+    if (m[1]) out.push(m[1]);
+  }
+  // Long form: Fn::GetAtt: [ Resource, Attr ]
+  for (const m of yaml.matchAll(/Fn::GetAtt:\s*\[\s*([A-Za-z][A-Za-z0-9]*)\s*,/g)) {
+    if (m[1]) out.push(m[1]);
+  }
+  return out;
+}
+
+/**
+ * `!Sub "${VarName}"` 内の `${...}` 参照を抽出する。 `${VarName}` (= Ref) / `${Resource.Attr}` (= GetAtt) / `${!Literal}` (= escape) を区別する。
+ */
+function collectSubRefs(yaml: string): { refs: string[]; getAtts: string[] } {
+  const refs: string[] = [];
+  const getAtts: string[] = [];
+  // `!Sub "..."` または `Fn::Sub:` の右辺を行ごとに拾う簡易版。 multi-line "|" Sub も含めて検出
+  // しやすいよう、 `${...}` を yaml 全体から拾い、 `!Sub` line context は問わない (= false-positive
+  // のリスクはあるが、 problem template の安全側 default として ${...} が出現したら必ず Ref / GetAtt
+  // と扱う方が漏れにくい)。
+  const re = /\$\{([^}]+)\}/g;
+  for (const m of yaml.matchAll(re)) {
+    const expr = m[1];
+    if (!expr) continue;
+    if (expr.startsWith("!")) continue; // ${!Literal} は escape、 reference でない
+    if (expr.includes(".")) {
+      const head = expr.split(".")[0];
+      if (head) getAtts.push(head);
+    } else {
+      refs.push(expr);
+    }
+  }
+  return { refs, getAtts };
+}
+
+function checkTemplate(templatePath: string): Finding[] {
+  const findings: Finding[] = [];
+  const yaml = readFileSync(templatePath, "utf8");
+  const { resources, parameters, outputs } = parseSections(yaml);
+
+  // 必須 Resource / Output (= ADR-002 Phase 2.1)
+  for (const required of REQUIRED_RESOURCE_NAMES) {
+    if (!resources.has(required)) {
+      findings.push({
+        templatePath,
+        rule: "required-resource-missing",
+        detail: `Resources.${required} is required (= ADR-002 Phase 2.1: 全 problem template で参加者 federation 用 Role を宣言する)`,
+      });
+    }
+  }
+  for (const required of REQUIRED_OUTPUT_KEYS) {
+    if (!outputs.has(required)) {
+      findings.push({
+        templatePath,
+        rule: "required-output-missing",
+        detail: `Outputs.${required} is required (= sso.ts handler が読む key)`,
+      });
+    }
+  }
+
+  // !Ref / Ref: の resolve
+  const directRefs = collectRefs(yaml);
+  const subRefs = collectSubRefs(yaml);
+  const allRefs = [...directRefs, ...subRefs.refs];
+  for (const ref of allRefs) {
+    if (PSEUDO_PARAMETERS.has(ref)) continue;
+    if (resources.has(ref) || parameters.has(ref)) continue;
+    findings.push({
+      templatePath,
+      rule: "unresolved-ref",
+      detail: `Ref: ${ref} — not declared in Resources / Parameters / pseudo`,
+    });
+  }
+
+  // !GetAtt の resource 部分
+  const getAttResources = [...collectGetAttResources(yaml), ...subRefs.getAtts];
+  for (const r of getAttResources) {
+    if (PSEUDO_PARAMETERS.has(r)) continue;
+    if (resources.has(r) || parameters.has(r)) continue;
+    findings.push({
+      templatePath,
+      rule: "unresolved-getatt-resource",
+      detail: `GetAtt ${r}.* — resource not declared`,
+    });
+  }
+
+  return findings;
+}
+
+function findTemplates(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry === "template.yaml" || entry === "template.yml") out.push(full);
+    }
+  };
+  walk(PROBLEMS_DIR);
+  return out;
+}
+
+function main(): void {
+  const templates = findTemplates();
+  if (templates.length === 0) {
+    console.log("No template.yaml found under problems/.");
+    return;
+  }
+  const allFindings: Finding[] = [];
+  for (const tpl of templates) {
+    allFindings.push(...checkTemplate(tpl));
+  }
+  if (allFindings.length === 0) {
+    console.log(
+      `OK: ${templates.length} template(s) スキャン、 CFn ref / 必須 resource 違反 0 件 (= !Ref / !GetAtt 解決済、 ParticipantViewerRole 宣言済)`,
+    );
+    return;
+  }
+  for (const f of allFindings) {
+    const rel = relative(REPO_ROOT, f.templatePath);
+    console.error(`NG ${rel} [${f.rule}] ${f.detail}`);
+  }
+  console.error(`\n${allFindings.length} finding(s) across ${templates.length} template(s)`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Issue #951 epic (= 問題作成体験の改善) の sub-task 2 件を 1 PR に統合:

### Sub-2: CFn template structural check (= cfn-lint port lite)

旧状態: \`make validate-problems\` は metadata.json の SCHEMA + cross-ref のみ。 CFn template 内部の \`!Ref\` / \`!GetAtt\` が未宣言の resource を指していても deploy 時まで気付けず、 問題作成者の edit → deploy (5-10 分) → 失敗 サイクルが長かった。

新 \`scripts/check-template-cfn-refs.ts\`:

- \`!Ref <name>\` / \`Ref:\` の resolve (= Resources / Parameters / pseudo \`AWS::*\`)
- \`!GetAtt <Resource>.<Attr>\` の resource 部分
- \`!Sub \"\${VarName}\"\` 内の \`\${...}\` 参照
- 必須 Resource 規約: \`ParticipantViewerRole\` + Output \`ParticipantViewerRoleArn\` (= ADR-002 Phase 2.1)

Python cfn-lint 等の外部依存は持ち込まず、 line-by-line + regex の軽量 parser で problem template の top 80% を local 検出する (= 既存 \`check-template-security.ts\` と同パターン)。

Makefile に \`check-template-cfn-refs\` target 追加、 \`make before-commit\` / \`make check\` に組み込み。

### Sub-1: scaffold metadata learningGoals の実例化

旧状態: \`.claude/templates/problems/<kind>/metadata.json\` の attack-detection / phased-polling / uptime-multi が \`learningGoals: [\"__LEARNING_GOAL_1__\"]\` placeholder のまま。 \`tenkacloud problem create\` 直後の作者が schema valid な雛形を得られても 「何を学ぶ問題か」 が空。

3 種それぞれに 3 件ずつ実例 learning goal を埋め込む。

## test

- 新 \`check-template-cfn-refs.test.ts\` (3 case): 既存 4 問題テンプレ全 pass の smoke test + parse / detection pattern doc
- 既存 \`scaffolds-validate.test.ts\` (11 case) も passing

## Regression 分析

- 新 CFn ref check は **追加** check で、 既存 problem template に違反なし (= 4 件 OK)
- scaffold metadata の learningGoals 変更は SCHEMA valid な配列の中身のみ、 frontend display 以外への影響なし
- Makefile 追加 target は CI で自動実行

## 物理影響

- NEW script + test
- UPDATE \`Makefile\` (+1 target、 before-commit / check に追加)
- UPDATE 3 scaffold metadata.json (= placeholder → 実例 3 件ずつ)
- CFn / AWS: NO-OP

## Test plan

- [x] \`make before-commit\` — 全 gate 通過 (= lint / typecheck / test / validate-problems / cfn-refs / audit-deps / cdk synth)
- [x] \`make validate-problems\` — 4 件 metadata 全 valid
- [x] \`bun run scripts/check-template-cfn-refs.ts\` — 0 finding
- [x] scaffold create test (= scaffolds-validate.test.ts) 11 件 pass

Closes #951 sub-1 (scaffold polish) + sub-2 (CFn ref check)
Remaining (= sub-3 scoring dry-run / sub-4 hot-reload / sub-5 admin debug UI) は別 PR で続ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)