### PR TITLE
feat(#956 Phase 3 + #951 sub-3): friendly-error map 拡張 + scoring dry-run の残 3 kind 実装

### DIFF
--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -86,6 +86,53 @@ const KNOWN_ERRORS: Readonly<Record<string, FriendlyError>> = {
     title: "AWS Federation token の response 形式が不正です",
     hint: "AWS 側 spec 変更の可能性 (= AWS support 確認推奨)",
   },
+  // Issue #948 (ADR-020 Phase B.1): route 単位 granular role gate で返す
+  forbidden_role: {
+    title: "この操作にはより高い tenant role が必要です",
+    hint: "あなたの role では実行できません。 TenantAdmin に依頼してください",
+    possibleCauses: [
+      "TenantViewer / TenantOperator として招待されている (= destructive 操作は TenantAdmin のみ)",
+      "招待後に role が変更されたが、 token が古いまま (= 再ログインで token を更新)",
+    ],
+  },
+  // Issue #17 / ADR-020 Phase B: 自分自身の role 変更を禁止 (= lock-out 防止)
+  cannot_change_own_role: {
+    title: "自分自身の role は変更できません",
+    hint: "lock-out 防止のため、 自分の role 変更は別の TenantAdmin に依頼してください",
+  },
+  // Issue #925 Phase 1: 自分自身の削除を禁止
+  cannot_delete_self: {
+    title: "自分自身は削除できません",
+    hint: "lock-out 防止のため、 自分自身は削除できません。 別の管理者に依頼してください",
+  },
+  // Issue #950 (ADR-020 Phase D): admin audit 監査ログ table 未配線
+  audit_log_unconfigured: {
+    title: "監査ログ Table が未配線です",
+    hint: "AdminInsight stack に AdminAuditLog Table が deploy されていません",
+    possibleCauses: [
+      "Phase 2 deploy が未完了 (= make deploy 実行が必要)",
+      "古い stack 世代から upgrade していない (= deploy chain の更新で解消)",
+    ],
+  },
+  // Issue #949 / ADR-020 Phase C: ControlPlane UserPool 未配線
+  control_plane_user_pool_unconfigured: {
+    title: "ControlPlane UserPool が未配線です",
+    hint: "AdminInsight stack に ControlPlane の UserPool ID が渡されていません",
+    possibleCauses: [
+      "Phase 2 deploy が未完了 (= make deploy 実行が必要)",
+      "古い stack 世代から upgrade していない",
+    ],
+  },
+  // 既存 + 新規 ともに duplicate
+  duplicate_user: {
+    title: "同 email の user が既に存在します",
+    hint: "別の email address を指定するか、 既存 user の role を変更してください",
+  },
+  // tenant_mismatch (server は 404 not_found に隠蔽するが log で識別)
+  missing_tenant_claim: {
+    title: "tenant 識別子が JWT にありません",
+    hint: "再ログインして token を更新してください (= tenant 招待 email を経由)",
+  },
 };
 
 /**

--- a/apps/application-admin-console/test/lib/friendly-error.test.ts
+++ b/apps/application-admin-console/test/lib/friendly-error.test.ts
@@ -51,4 +51,57 @@ describe("toFriendlyError", () => {
     const fe = toFriendlyError("plain string");
     expect(fe.title).toBe("plain string");
   });
+
+  // Issue #948 (ADR-020 Phase B.1): granular role gate で返る forbidden_role
+  it("forbidden_role を friendly title に展開すべき (= #948)", () => {
+    const err = new ApiError(
+      403,
+      '{"error":"forbidden_role","message":"あなたの tenant role ではこの操作を実行できません"}',
+    );
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/より高い tenant role/);
+    expect(fe.hint).toMatch(/TenantAdmin に依頼/);
+    expect(fe.possibleCauses?.length).toBeGreaterThan(0);
+  });
+
+  // Issue #17 lock-out 防止 (= 自己 role 変更禁止)
+  it("cannot_change_own_role を friendly title に展開すべき", () => {
+    const err = new ApiError(409, '{"error":"cannot_change_own_role"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/自分自身の role/);
+  });
+
+  // Issue #925 lock-out 防止 (= 自己 delete 禁止)
+  it("cannot_delete_self を friendly title に展開すべき", () => {
+    const err = new ApiError(409, '{"error":"cannot_delete_self"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/自分自身は削除/);
+  });
+
+  // Issue #950 (ADR-020 Phase D): audit table 未配線
+  it("audit_log_unconfigured を friendly title に展開すべき (= #950)", () => {
+    const err = new ApiError(503, '{"error":"audit_log_unconfigured"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/監査ログ.*未配線/);
+    expect(fe.possibleCauses?.length).toBeGreaterThan(0);
+  });
+
+  // Issue #949 (ADR-020 Phase C): ControlPlane UserPool 未配線
+  it("control_plane_user_pool_unconfigured を friendly title に展開すべき (= #949)", () => {
+    const err = new ApiError(503, '{"error":"control_plane_user_pool_unconfigured"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/ControlPlane UserPool.*未配線/);
+  });
+
+  it("missing_tenant_claim を friendly title に展開すべき", () => {
+    const err = new ApiError(401, '{"error":"missing_tenant_claim"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/tenant 識別子/);
+  });
+
+  it("duplicate_user を friendly title に展開すべき", () => {
+    const err = new ApiError(409, '{"error":"duplicate_user","email":"alice@example.com"}');
+    const fe = toFriendlyError(err);
+    expect(fe.title).toMatch(/同 email/);
+  });
 });


### PR DESCRIPTION
## Summary

2 つの sub-task を 1 PR にまとめる (= どちらも小規模 file edit、 別 file)。

### Part 1: #956 Phase 3 — friendly-error map 拡張

旧来 UI に raw JSON \`{\"error\":\"forbidden_role\",...}\` が出ていた 7 件の backend error code を friendly-error mapping に追加し、 operator が UI で 「あなたの role では…」 「監査ログ未配線」 等の親切な message を直接読めるようにする。

| code | 由来 | 表示 |
| --- | --- | --- |
| \`forbidden_role\` | PR #973 / #948 | 「より高い tenant role が必要」 + 「TenantAdmin に依頼」 |
| \`cannot_change_own_role\` | Issue #17 | lock-out 防止メッセージ |
| \`cannot_delete_self\` | Issue #925 | lock-out 防止メッセージ |
| \`audit_log_unconfigured\` | PR #978 / #950 | 「監査ログ Table が未配線」 |
| \`control_plane_user_pool_unconfigured\` | PR #977 / #949 | 「ControlPlane UserPool が未配線」 |
| \`duplicate_user\` | tenant/system users | 「同 email の user が既に存在」 |
| \`missing_tenant_claim\` | JWT claim 不在 | 「tenant 識別子が JWT にない」 |

### Part 2: #951 sub-3 — scoring dry-run の残 3 kind 実装

旧状態: \`bun run scripts/tenkacloud-problem.ts dry-run <id>\` は flag / uptime-flat のみサポート。 他 3 kind は 「未対応」 メッセージで、 問題作成者が phased-polling / attack-detection / uptime-multi の採点ロジックを local で検証できなかった。

- **uptime-multi**: \`--pattern <s/f...>\` で全 slot OK / 1 つでも fail を simulate
- **phased-polling**: \`--pattern <e/l/c/a per cycle>\` で platform 別 cycle を simulate。 phases[].afterMinutes から degraded 遷移を計算
- **attack-detection**: \`--pattern <digit per cycle>\` で counter increment を simulate

\`--pattern\` の文字種を拡張 (= s/f → [a-z0-9])。

## test

- friendly-error.test.ts: 7 case 追加 (= 旧 8 → 14 case)
- scoring-dry-run.test.ts: 4 case 追加 (= 旧 7 → 11 case)

## Regression 分析

- KNOWN_ERRORS object に key 追加のみ、 既存 mapping 不変
- 既存 flag / uptime-flat dry-run は無改修
- \`--pattern\` validation 拡張は文字検査のみで業務 logic に影響なし

## 物理影響

- UPDATE: \`apps/application-admin-console/src/lib/friendly-error.ts\` (+~50 行)
- UPDATE: \`scripts/tenkacloud-problem.ts\` (+~120 行)
- UPDATE: 2 test files (+~110 行)
- CFn / AWS: NO-OP

## Test plan

- [x] \`make before-commit\` 全 gate 通過
- [x] friendly-error 14 case pass
- [x] scoring-dry-run 11 case pass

Closes #956 Phase 3 (= step 1) + #951 sub-3 (= dry-run 拡張)

🤖 Generated with [Claude Code](https://claude.com/claude-code)