### PR TITLE
feat(#951 sub-5): inspect CLI subcommand で metadata + template + cross-ref を 1 引きで dump

### DIFF
--- a/infrastructure/test/scripts/inspect-problem.test.ts
+++ b/infrastructure/test/scripts/inspect-problem.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { runInspect } from "../../../scripts/tenkacloud-problem";
+
+/**
+ * Issue #951 sub #5: `tenkacloud-problem.ts inspect <id>` の挙動を pin する。
+ * 既存 4 問題で正しく metadata + template + cross-ref を dump できることを確認。
+ */
+
+describe("runInspect (#951 sub #5)", () => {
+  it("hello-world: flag kind の scoring + template Outputs + cross-ref OK を含むべき", () => {
+    const r = runInspect({ problemId: "hello-world" });
+    expect(r.ok).toBe(true);
+    const text = r.lines.join("\n");
+    expect(text).toContain("=== Problem hello-world ===");
+    expect(text).toContain("kind:             flag");
+    expect(text).toContain("flagOutputKey:    ParameterValue");
+    expect(text).toContain("Resources:  ParticipantViewerRole, HelloParameter");
+    expect(text).toContain(
+      "Outputs:    ParameterName, ParameterValue, NamePrefix, ParticipantViewerRoleArn",
+    );
+    expect(text).toContain("Cross-ref:  OK");
+  });
+
+  it("hello-world-battle: uptime-flat の endpoint registry を含むべき", () => {
+    const r = runInspect({ problemId: "hello-world-battle" });
+    expect(r.ok).toBe(true);
+    const text = r.lines.join("\n");
+    expect(text).toContain("Endpoint registry");
+    expect(text).toContain("slot=frontend");
+    expect(text).toContain("slot=api");
+  });
+
+  it("microservice-migration-battle: portal slots + phases + disruptions を含むべき", () => {
+    const r = runInspect({ problemId: "microservice-migration-battle" });
+    expect(r.ok).toBe(true);
+    const text = r.lines.join("\n");
+    expect(text).toContain("Portal slots");
+    expect(text).toContain("RegistrationPanel");
+    expect(text).toContain("StatusPanel");
+    // 表示形式: ファイル存在 OK / 必須 PVR resource declared
+    expect(text).toContain("(OK)");
+  });
+
+  it("security-battle-royale: uptime-multi の probedSlots を含むべき", () => {
+    const r = runInspect({ problemId: "security-battle-royale" });
+    expect(r.ok).toBe(true);
+    const text = r.lines.join("\n");
+    expect(text).toContain("kind:             uptime-multi");
+    expect(text).toContain("probedSlots:");
+  });
+
+  it("存在しない problemId は ok=false を返すべき", () => {
+    const r = runInspect({ problemId: "does-not-exist-12345" });
+    expect(r.ok).toBe(false);
+    expect(r.summary).toContain("not found");
+  });
+});

--- a/scripts/tenkacloud-problem.ts
+++ b/scripts/tenkacloud-problem.ts
@@ -50,7 +50,7 @@ const KIND_TO_DEFAULT_CATEGORY: Record<Kind, "Battle" | "Challenge"> = {
 };
 
 interface CliArgs {
-  command: "create" | "validate" | "list-kinds" | "dry-run" | "help" | "interactive";
+  command: "create" | "validate" | "list-kinds" | "dry-run" | "inspect" | "help" | "interactive";
   problemId?: string;
   kind?: Kind;
   category?: "Battle" | "Challenge";
@@ -73,9 +73,14 @@ function parseArgs(argv: readonly string[]): CliArgs {
   // Issue #954: interactive mode は引数なしで起動する `tenkacloud problem interactive` か、
   // `tenkacloud problem create` (= problemId / kind 省略時) のどちらでも入れる。
   if (command === "interactive") return { command };
-  if (command !== "create" && command !== "validate" && command !== "dry-run") {
+  if (
+    command !== "create" &&
+    command !== "validate" &&
+    command !== "dry-run" &&
+    command !== "inspect"
+  ) {
     throw new Error(
-      `unknown command: ${command}. Try 'help', 'list-kinds', 'create', 'validate', 'dry-run', 'interactive'.`,
+      `unknown command: ${command}. Try 'help', 'list-kinds', 'create', 'validate', 'dry-run', 'inspect', 'interactive'.`,
     );
   }
   const problemId = argv[1];
@@ -142,6 +147,7 @@ Usage:
   bun run scripts/tenkacloud-problem.ts validate <id>
   bun run scripts/tenkacloud-problem.ts dry-run <id> [--submitted <flag>] [--reveal-hints N]
                                                     [--cycles N] [--pattern <s|f sequence>]
+  bun run scripts/tenkacloud-problem.ts inspect <id>  # metadata + template の全体 dump (= author debug)
   bun run scripts/tenkacloud-problem.ts list-kinds
 
 Available kinds:  ${KINDS.join(", ")}
@@ -153,6 +159,7 @@ Examples:
   bun run scripts/tenkacloud-problem.ts validate microservice-migration-battle
   bun run scripts/tenkacloud-problem.ts dry-run hello-world --submitted "actual-flag-value"
   bun run scripts/tenkacloud-problem.ts dry-run hello-world-battle --cycles 60 --pattern "ssssffssssss"
+  bun run scripts/tenkacloud-problem.ts inspect hello-world
 
 See also:
   docs/problems/AUTHORING.html  — 30 分 onboarding guide
@@ -646,6 +653,244 @@ export function runDryRun(args: {
  * `Value: "TC{...}"` / `Value: !GetAtt X.Value` の前者だけハンドルする。
  * 後者は実 deploy しないと値が解決しないため null を返す。
  */
+/**
+ * Issue #951 sub #5: problem author 向け debug inspector。
+ *
+ * 旧状態: 問題作成者が 「scoring engine が自分の問題をどう読んでいるか」 を確認するには
+ * metadata.json / template.yaml / portal/ を別々に grep する必要があった。 採点が想定通り動かない
+ * とき、 どこで詰まっているか切り分けるのに時間が掛かる (= 「scoring kind は flag だが flagOutputKey
+ * が typo で template Outputs に無い」 のような bug を deploy 前に発見する経路が無い)。
+ *
+ * 本 inspect subcommand は metadata + template + portal slot を resolve し、 1 引きで dump する:
+ *
+ *   - metadata.json から id / kind / scoring / endpoints / phases / disruptions / dashboard.slots
+ *   - template.yaml から Resources / Parameters / Outputs の一覧 + 必須 ParticipantViewerRole 検査
+ *   - scoring engine が読む key (= flagOutputKey / statsOutputKey / endpoints[].default.key) と
+ *     Outputs の cross-ref を一覧表示
+ *   - portal/ ディレクトリの slot file (= dashboard.slots で declared された tsx) の存在確認
+ *
+ * `make validate-problems` と違って 「正しいか」 ではなく 「何が見えているか」 を吐く。 author の
+ * mental model 確認用。
+ */
+export interface InspectResult {
+  readonly ok: boolean;
+  readonly summary: string;
+  readonly lines: readonly string[];
+}
+
+export function runInspect(args: { problemId: string }): InspectResult {
+  const dir = findProblemDir(args.problemId);
+  if (!dir) {
+    return { ok: false, summary: `Problem dir not found for id="${args.problemId}"`, lines: [] };
+  }
+  const metaPath = join(dir, "metadata.json");
+  if (!existsSync(metaPath)) {
+    return { ok: false, summary: "metadata.json not found", lines: [] };
+  }
+  const meta = JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>;
+  const lines: string[] = [];
+
+  lines.push(`=== Problem ${args.problemId} ===`);
+  lines.push(`directory:        ${dir.replace(REPO_ROOT, "")}`);
+  lines.push(`name:             ${String(meta.name ?? "(none)")}`);
+  lines.push(`category:         ${String(meta.category ?? "(none)")}`);
+  lines.push(`status:           ${String(meta.status ?? "(none)")}`);
+  lines.push(`visibility:       ${String(meta.visibility ?? "public")}`);
+  lines.push(`difficulty:       ${String(meta.difficulty ?? "(none)")}`);
+  lines.push(`estimatedDuration: ${String(meta.estimatedDuration ?? "(none)")}`);
+  lines.push("");
+
+  // scoring
+  const scoring = (meta.scoring ?? {}) as Record<string, unknown>;
+  const kind = String(scoring.kind ?? "");
+  lines.push(`--- Scoring engine view ---`);
+  lines.push(`kind:             ${kind || "(none)"}`);
+  if (kind === "flag") {
+    lines.push(`flagOutputKey:    ${String(scoring.flagOutputKey ?? "(missing)")}`);
+    lines.push(`points:           ${String(scoring.points ?? "(missing)")}`);
+    if (scoring.wrongAnswerPenalty)
+      lines.push(`wrongAnswerPenalty: ${String(scoring.wrongAnswerPenalty)}`);
+  } else if (kind === "uptime-flat" || kind === "uptime") {
+    const eps = Array.isArray(scoring.endpoints) ? scoring.endpoints : [];
+    lines.push(`endpoints:        ${eps.length}`);
+    for (const ep of eps as Array<Record<string, unknown>>) {
+      lines.push(
+        `                  - slot=${String(ep.slot ?? "?")} path=${String(ep.path ?? "?")} expect=${JSON.stringify(ep.expectStatus ?? [])}`,
+      );
+    }
+    lines.push(`pointsPerSuccess: ${String(scoring.pointsPerSuccess ?? "(missing)")}`);
+    if (scoring.failurePenalty !== undefined)
+      lines.push(`failurePenalty:   ${String(scoring.failurePenalty)}`);
+  } else if (kind === "uptime-multi") {
+    const slots = Array.isArray(scoring.probedSlots) ? scoring.probedSlots : [];
+    lines.push(`probedSlots:      ${slots.length} (= 全部 OK で加点)`);
+    for (const s of slots as Array<Record<string, unknown>>) {
+      lines.push(
+        `                  - slot=${String(s.slot ?? "?")} path=${String(s.path ?? "?")} expect=${JSON.stringify(s.expectStatus ?? [])}`,
+      );
+    }
+    lines.push(`pointsAllOk:      ${String(scoring.pointsAllOk ?? "(missing)")}`);
+    lines.push(`failurePenalty:   ${String(scoring.failurePenalty ?? "0")}`);
+  } else if (kind === "phased-polling") {
+    lines.push(`intervalMinutes:  ${String(scoring.intervalMinutes ?? "(missing)")}`);
+    const platforms = scoring.platformRules as Record<string, unknown> | undefined;
+    lines.push(`platformRules:    ${platforms ? Object.keys(platforms).join(", ") : "(missing)"}`);
+    const probe = scoring.probe as Record<string, unknown> | undefined;
+    lines.push(
+      `probe paths:      meta=${String(probe?.metaPath ?? "?")} score=${String(probe?.scorePath ?? "?")}`,
+    );
+  } else if (kind === "attack-detection") {
+    lines.push(`statsOutputKey:   ${String(scoring.statsOutputKey ?? "(missing)")}`);
+    lines.push(`pointsPerAttack:  ${String(scoring.pointsPerAttack ?? "(missing)")}`);
+  }
+  // hints (= 全 kind)
+  const hints = Array.isArray(scoring.hints) ? scoring.hints : [];
+  if (hints.length > 0) {
+    lines.push(`hints:            ${hints.length} 件`);
+    hints.forEach((h, i) => {
+      if (typeof h === "string") {
+        lines.push(`                  [${i + 1}] (legacy v1, penalty=0) ${h.slice(0, 60)}…`);
+      } else if (h && typeof h === "object") {
+        const ho = h as Record<string, unknown>;
+        lines.push(
+          `                  [${i + 1}] id=${String(ho.id)} penalty=${String(ho.penalty)} content="${String(ho.content).slice(0, 50)}…"`,
+        );
+      }
+    });
+  }
+  lines.push("");
+
+  // endpoints (= metadata.endpoints、 scoring.endpoints とは別軸の registry)
+  const endpoints = Array.isArray(meta.endpoints) ? meta.endpoints : [];
+  if (endpoints.length > 0) {
+    lines.push(`--- Endpoint registry (= metadata.endpoints) ---`);
+    for (const ep of endpoints as Array<Record<string, unknown>>) {
+      const def = ep.default as Record<string, unknown> | undefined;
+      lines.push(
+        `  slot=${String(ep.slot)} default-from=${String(def?.from ?? "?")} default-key=${String(def?.key ?? "?")} overridable=${String(ep.overridable ?? false)}`,
+      );
+    }
+    lines.push("");
+  }
+
+  // phases
+  const phases = Array.isArray(meta.phases) ? meta.phases : [];
+  if (phases.length > 0) {
+    lines.push(`--- Phases ---`);
+    for (const ph of phases as Array<Record<string, unknown>>) {
+      lines.push(
+        `  name=${String(ph.name)} afterMinutes=${String(ph.afterMinutes ?? "?")} effect=${JSON.stringify(ph.effect ?? {})}`,
+      );
+    }
+    lines.push("");
+  }
+
+  // disruptions
+  const disruptions = Array.isArray(meta.disruptions) ? meta.disruptions : [];
+  if (disruptions.length > 0) {
+    lines.push(`--- Disruptions ---`);
+    for (const d of disruptions as Array<Record<string, unknown>>) {
+      lines.push(
+        `  id=${String(d.id)} name=${String(d.name)} default=${String(d.defaultAfterMinutes ?? "?")}min`,
+      );
+    }
+    lines.push("");
+  }
+
+  // dashboard.slots
+  const dashboard = meta.dashboard as Record<string, unknown> | undefined;
+  const slots = dashboard?.slots as Record<string, unknown> | undefined;
+  if (slots) {
+    lines.push(`--- Portal slots ---`);
+    for (const [slot, file] of Object.entries(slots)) {
+      const physical = join(dir, String(file));
+      const exists = existsSync(physical);
+      lines.push(`  ${slot}: ${String(file)} ${exists ? "(OK)" : "(MISSING!)"}`);
+    }
+    lines.push("");
+  }
+
+  // template.yaml の inspection (= check-template-cfn-refs と同 line-by-line parser)
+  const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+  const templatePath = join(dir, cfnTemplate);
+  if (existsSync(templatePath)) {
+    const yaml = readFileSync(templatePath, "utf8");
+    lines.push(`--- Template (${cfnTemplate}) ---`);
+    const yamlLines = yaml.split(/\r?\n/);
+    const resourceNames: string[] = [];
+    const outputNames: string[] = [];
+    const parameterNames: string[] = [];
+    let section: "resources" | "parameters" | "outputs" | null = null;
+    for (const line of yamlLines) {
+      if (/^Resources:\s*$/.test(line)) {
+        section = "resources";
+        continue;
+      }
+      if (/^Parameters:\s*$/.test(line)) {
+        section = "parameters";
+        continue;
+      }
+      if (/^Outputs:\s*$/.test(line)) {
+        section = "outputs";
+        continue;
+      }
+      if (/^[A-Za-z]/.test(line) && line.endsWith(":")) {
+        section = null;
+        continue;
+      }
+      if (!section) continue;
+      const m = line.match(/^ {2}([A-Za-z][A-Za-z0-9]*):\s*$/);
+      if (!m?.[1]) continue;
+      if (section === "resources") resourceNames.push(m[1]);
+      else if (section === "outputs") outputNames.push(m[1]);
+      else if (section === "parameters") parameterNames.push(m[1]);
+    }
+    lines.push(`  Parameters: ${parameterNames.join(", ") || "(none)"}`);
+    lines.push(`  Resources:  ${resourceNames.join(", ") || "(none)"}`);
+    lines.push(`  Outputs:    ${outputNames.join(", ") || "(none)"}`);
+
+    // Cross-ref check (= 各 key が Outputs に存在するか + 必須 ParticipantViewerRole 等)
+    const crossRefIssues: string[] = [];
+    if (kind === "flag") {
+      const k = String(scoring.flagOutputKey ?? "");
+      if (k && !outputNames.includes(k)) crossRefIssues.push(`flagOutputKey="${k}" not in Outputs`);
+    }
+    if (kind === "attack-detection") {
+      const k = String(scoring.statsOutputKey ?? "");
+      if (k && !outputNames.includes(k))
+        crossRefIssues.push(`statsOutputKey="${k}" not in Outputs`);
+    }
+    for (const ep of endpoints as Array<Record<string, unknown>>) {
+      const def = ep.default as Record<string, unknown> | undefined;
+      if (
+        def?.from === "cfn-output" &&
+        typeof def.key === "string" &&
+        !outputNames.includes(def.key)
+      ) {
+        crossRefIssues.push(
+          `endpoints[slot=${String(ep.slot)}].default.key="${def.key}" not in Outputs`,
+        );
+      }
+    }
+    if (!resourceNames.includes("ParticipantViewerRole")) {
+      crossRefIssues.push("ParticipantViewerRole resource not declared (= ADR-002 Phase 2.1)");
+    }
+    if (!outputNames.includes("ParticipantViewerRoleArn")) {
+      crossRefIssues.push("ParticipantViewerRoleArn output not declared (= sso.ts が読む)");
+    }
+    if (crossRefIssues.length > 0) {
+      lines.push(`  Cross-ref issues:`);
+      for (const issue of crossRefIssues) lines.push(`    ✗ ${issue}`);
+    } else {
+      lines.push(`  Cross-ref:  OK (= all scoring / endpoint keys resolve to Outputs)`);
+    }
+  } else {
+    lines.push(`  Template "${cfnTemplate}" NOT FOUND`);
+  }
+
+  return { ok: true, summary: `inspect ${args.problemId} (kind=${kind})`, lines };
+}
+
 function extractFlagFromTemplate(yaml: string, key: string): string | null {
   const re = new RegExp(`${key}:[\\s\\S]*?Value:\\s*("[^"\\n]+"|'[^'\\n]+'|[^\\n!]+)\\n`, "m");
   const m = yaml.match(re);
@@ -716,6 +961,15 @@ async function main(): Promise<void> {
       }
       for (const line of r.lines) console.log(line);
       console.log(`\nsummary: ${r.summary}`);
+      return;
+    }
+    case "inspect": {
+      const r = runInspect({ problemId: args.problemId ?? "" });
+      if (!r.ok) {
+        console.error(`NG ${r.summary}`);
+        process.exit(1);
+      }
+      for (const line of r.lines) console.log(line);
       return;
     }
     default: {


### PR DESCRIPTION
## Summary

Issue #951 sub #5 (= 問題作成者向け debug 可視化) の CLI 版を追加。

旧状態: 問題作成者が 「scoring engine が自分の問題をどう読んでいるか」 を確認するには metadata.json / template.yaml / portal/ を別々に grep する必要があり、 採点が想定通り動かないときの切り分けに時間が掛かった。 元 issue 案では admin-console に \`/problems/:problemId/health\` view を追加する形だったが、 まずは CLI で同等の情報を見られるようにする (= author の mental model 確認用)。

## inspect 出力例 (hello-world)

\`\`\`
=== Problem hello-world ===
directory:        /problems/challenges/hello-world
name:             Hello World (Sample)
...
--- Scoring engine view ---
kind:             flag
flagOutputKey:    ParameterValue
points:           100
wrongAnswerPenalty: 5
hints:            2 件
                  [1] id=hint-1 penalty=10 content="..."

--- Template (template.yaml) ---
  Parameters: NamePrefix, TenkaCloudAccountId, ExternalId
  Resources:  ParticipantViewerRole, HelloParameter
  Outputs:    ParameterName, ParameterValue, NamePrefix, ParticipantViewerRoleArn
  Cross-ref:  OK (= all scoring / endpoint keys resolve to Outputs)
\`\`\`

## 実装

- \`scripts/tenkacloud-problem.ts inspect <id>\` を追加 (= \`runInspect(args)\` export)
- scoring engine view (= 5 kind 別に整形表示)
- endpoint registry / phases / disruptions / portal slots (= 物理 file 存在 check)
- template parser を check-template-cfn-refs と同パターンの line-by-line に揃え、 Parameters / Resources / Outputs を抽出。 cross-ref に scoring key 解決 + 必須 PVR resource 検査

## test

新 \`inspect-problem.test.ts\` (5 case): 既存 4 問題 (= flag / uptime-flat / uptime-multi / phased-polling) と存在しない id

## Regression 分析

- 既存 5 subcommand (create / validate / dry-run / interactive / list-kinds) は無改修
- 新 inspect は read-only、 必ず exit 0
- cross-ref issue が見つかっても exit 1 にはしない (= author の見える化が目的、 invariant 違反は \`make validate-problems\` + \`check-template-cfn-refs\` の責務)

## #951 epic 進捗 update

- ✅ sub-1: scaffold metadata polish (PR #979)
- ✅ sub-2: CFn ref check (PR #979)
- ✅ sub-3: scoring dry-run extension (PR #981)
- ⏭ sub-4: problem hot-reload — 別 PR 必要
- ✅ sub-5: 本 PR

## 物理影響

- UPDATE \`scripts/tenkacloud-problem.ts\` (+~200 行)
- NEW \`inspect-problem.test.ts\` (+~60 行)
- CFn / AWS: NO-OP

Closes #951 sub-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)