### PR TITLE
feat(#952): Free Tier breach 検知 CloudWatch Alarm を CostBudget と並列で wire

### DIFF
--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -10,6 +10,7 @@ import { KmsKeyShortPendingWindow } from "../cdk-aspect/kms-key-short-pending-wi
 import { ControlPlaneStack } from "../control-plane-stack";
 import { ObservabilityStack } from "../observability/cloudwatch-dashboard-stack";
 import { CostBudget } from "../observability/cost-budget";
+import { FreeTierAlarms } from "../observability/free-tier-alarms";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting";
 import { ProblemDeployBackendStack } from "../problem-deploy/problem-deploy-backend-stack";
 import { ServerlessSaaSPipeline } from "../tenant-pipeline/serverless-saas-pipeline";
@@ -238,13 +239,37 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
     const extraEmails = config.budgetAlarmEmails ?? [];
     // adminEmail と extraEmails の重複を排して同一宛先への重複 subscription を防ぐ。
     const allEmails = Array.from(new Set(adminEmail ? [adminEmail, ...extraEmails] : extraEmails));
-    new CostBudget(observabilityStack, "CostBudget", {
+    const budget = new CostBudget(observabilityStack, "CostBudget", {
       budgetNamePrefix: `tenkacloud-${config.environment}`,
       monthlyLimitUsd: config.monthlyCostLimitUsd,
       notificationEmails: allEmails,
       // App scope の cdk.Tags.of(app).add("Project", "TenkaCloud") と整合させ、
       // TenkaCloud で deploy したリソース分だけを集計対象にする。
       costAllocationTags: { Project: ["TenkaCloud"] },
+    });
+    // Issue #952 cost guardrails: Free Tier breach 検知 alarm を CostBudget と同じ SNS topic に
+    // wire する。 budget alarm (= 24-48h 遅延) を補完する resource-usage 即時 alarm。
+    new FreeTierAlarms(observabilityStack, "FreeTierAlarms", {
+      notificationTopic: budget.topic,
+      lambdaFunctionNames: [
+        problemDeployBackendStack.deployApiLambda.functionName,
+        problemDeployBackendStack.eventApiLambda.functionName,
+        adminConsoleInsightStack.lambdaFunctionName,
+        problemDeployBackendStack.competitorAccountsApiLambda.functionName,
+        problemDeployBackendStack.externalIdAuditLambda.functionName,
+        problemDeployBackendStack.genericScoringLambda.functionName,
+        ...(problemDeployBackendStack.participantPortalLambda
+          ? [problemDeployBackendStack.participantPortalLambda.functionName]
+          : []),
+      ],
+      dynamoDbTableNames: [
+        problemDeployBackendStack.deploymentsTable.tableName,
+        problemDeployBackendStack.eventsTable.tableName,
+        problemDeployBackendStack.teamsTable.tableName,
+        problemDeployBackendStack.competitorAccountsTable.tableName,
+        problemDeployBackendStack.problemEndpointsTable.tableName,
+        bootstrapTemplateStack.tenantMappingTable.tableName,
+      ],
     });
   }
 

--- a/infrastructure/lib/observability/cloudwatch-dashboard-stack.ts
+++ b/infrastructure/lib/observability/cloudwatch-dashboard-stack.ts
@@ -77,6 +77,12 @@ export class ObservabilityStack extends cdk.Stack {
     dashboard.addWidgets(this.ddbCapacityWidget(props), this.ddbThrottleWidget(props));
     dashboard.addWidgets(this.lambdaCriticalWidget(props), this.lambdaHelperWidget(props));
     dashboard.addWidgets(this.apiGatewayTrafficWidget(props), this.apiGatewayLatencyWidget(props));
+
+    // Issue #952 cost guardrails: Free Tier breach 検知 CloudWatch Alarms は wire.ts 側で
+    // CostBudget の SNS topic を共有しつつ FreeTierAlarms construct を 直接 attach する。
+    // ObservabilityStack 内で完結させない理由: CostBudget も同じ topic に publish する必要が
+    // あり、 topic を 1 つだけ作る owner として CostBudget が適切 (= wire.ts で CostBudget →
+    // FreeTierAlarms の順に作って参照させる)。
   }
 
   private dashboardName(environment?: string): string {

--- a/infrastructure/lib/observability/free-tier-alarms.ts
+++ b/infrastructure/lib/observability/free-tier-alarms.ts
@@ -1,0 +1,140 @@
+import { Duration } from "aws-cdk-lib";
+import {
+  Alarm,
+  ComparisonOperator,
+  Metric,
+  TreatMissingData,
+  Unit,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import type { ITopic } from "aws-cdk-lib/aws-sns";
+import { Construct } from "constructs";
+
+/**
+ * Issue #952 epic / コスト爆発防止: AWS Free Tier breach 検知 CloudWatch Alarms。
+ *
+ * 旧状態: `CostBudget` construct で月次 USD 上限 alarm は持つ (= AWS Budgets)。 これは
+ * **金額 base** の遅延 alarm (= 24-48h 遅れ)、 spike を即座に検知できない。 sudden traffic
+ * (= 攻撃 / runaway loop / 設定ミス) は数時間で Free Tier を吹き飛ばす。
+ *
+ * 本 construct は **resource usage base** の即時 alarm を立てる:
+ *
+ *   - Lambda: 月次 invocations が Free Tier の 80% (= 800k req) に達したら alarm
+ *   - DynamoDB: 月次 ConsumedReadCapacityUnits / WriteCapacityUnits が Free Tier (= 25 RCU/WCU)
+ *     を超過したら alarm (= DynamoDbLowCapacity Aspect で 1/1 PROVISIONED に強制してあるので
+ *     通常超過しないが、 hand-edit / future stack 追加で破られた場合の defense-in-depth)
+ *
+ * 各 alarm は SNS topic に publish。 caller (= ObservabilityStack) は CostBudget と同じ
+ * topic を渡す想定 (= operator email に統一)。
+ *
+ * 設計:
+ *   - Alarm 自体は **無料** (= AWS CloudWatch Standard alarm 10 個までは Free Tier 内)
+ *   - SNS 通知は 1,000 件まで free
+ *   - 集計 period は 1 日 (= 月次 cap の 1/30) で計算、 80% 閾値を sum で判定
+ */
+
+export interface FreeTierAlarmsProps {
+  /** 通知先 SNS topic (= CostBudget と共有を推奨)。 */
+  readonly notificationTopic: ITopic;
+  /**
+   * monitor 対象の Lambda function 名一覧。 各 function に対して invocations alarm を立てる。
+   * 全部の合計を 1 つの alarm にする方が安いが、 どの function が暴走したかが見えないので
+   * 個別に立てる (= alarm が 10 個を超える環境では `aggregateLambda=true` に切替予定)。
+   */
+  readonly lambdaFunctionNames: readonly string[];
+  /**
+   * monitor 対象の DDB Table 名一覧。 ConsumedReadCapacityUnits / WriteCapacityUnits を見る。
+   */
+  readonly dynamoDbTableNames: readonly string[];
+  /**
+   * Lambda 月次 invocation Free Tier (= 1M req)、 80% を default 閾値とする。
+   * 日次に分割すると 800,000 / 30 ≒ 26,666 inv/day。 1 alarm 期間 = 1 day。
+   */
+  readonly lambdaDailyInvocationThreshold?: number;
+  /**
+   * DDB Free Tier (= 25 RCU/WCU per Table) の超過検知。 PROVISIONED 1/1 を強制している
+   * (DynamoDbLowCapacity Aspect) ので通常 1 RCU * 86400 sec/day = 86,400 が日次理論上限、
+   * 余裕を 100,000 にする。
+   */
+  readonly dynamoDbDailyConsumedThreshold?: number;
+}
+
+const DEFAULT_LAMBDA_DAILY_INVOCATIONS = 26_666; // 800k/month / 30 days
+const DEFAULT_DDB_DAILY_CONSUMED = 100_000;
+
+export class FreeTierAlarms extends Construct {
+  public readonly lambdaAlarms: readonly Alarm[];
+  public readonly dynamoDbAlarms: readonly Alarm[];
+
+  constructor(scope: Construct, id: string, props: FreeTierAlarmsProps) {
+    super(scope, id);
+    const lambdaThreshold =
+      props.lambdaDailyInvocationThreshold ?? DEFAULT_LAMBDA_DAILY_INVOCATIONS;
+    const ddbThreshold = props.dynamoDbDailyConsumedThreshold ?? DEFAULT_DDB_DAILY_CONSUMED;
+    const action = new SnsAction(props.notificationTopic);
+
+    this.lambdaAlarms = props.lambdaFunctionNames.map((fnName, idx) => {
+      const alarm = new Alarm(this, `LambdaInvocations${sanitize(fnName)}${idx}`, {
+        alarmName: `tenkacloud-freetier-lambda-${fnName}`,
+        alarmDescription: `Lambda ${fnName} の日次 invocations が ${lambdaThreshold} を超過 (= Free Tier 80% 相当)`,
+        metric: new Metric({
+          namespace: "AWS/Lambda",
+          metricName: "Invocations",
+          dimensionsMap: { FunctionName: fnName },
+          statistic: "Sum",
+          period: Duration.days(1),
+          unit: Unit.COUNT,
+        }),
+        threshold: lambdaThreshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+      alarm.addAlarmAction(action);
+      return alarm;
+    });
+
+    this.dynamoDbAlarms = props.dynamoDbTableNames.flatMap((tableName, idx) => {
+      const readAlarm = new Alarm(this, `DdbReadCapacity${sanitize(tableName)}${idx}`, {
+        alarmName: `tenkacloud-freetier-ddb-read-${tableName}`,
+        alarmDescription: `DDB ${tableName} の日次 ConsumedReadCapacityUnits が ${ddbThreshold} を超過`,
+        metric: new Metric({
+          namespace: "AWS/DynamoDB",
+          metricName: "ConsumedReadCapacityUnits",
+          dimensionsMap: { TableName: tableName },
+          statistic: "Sum",
+          period: Duration.days(1),
+          unit: Unit.COUNT,
+        }),
+        threshold: ddbThreshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+      readAlarm.addAlarmAction(action);
+      const writeAlarm = new Alarm(this, `DdbWriteCapacity${sanitize(tableName)}${idx}`, {
+        alarmName: `tenkacloud-freetier-ddb-write-${tableName}`,
+        alarmDescription: `DDB ${tableName} の日次 ConsumedWriteCapacityUnits が ${ddbThreshold} を超過`,
+        metric: new Metric({
+          namespace: "AWS/DynamoDB",
+          metricName: "ConsumedWriteCapacityUnits",
+          dimensionsMap: { TableName: tableName },
+          statistic: "Sum",
+          period: Duration.days(1),
+          unit: Unit.COUNT,
+        }),
+        threshold: ddbThreshold,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+      writeAlarm.addAlarmAction(action);
+      return [readAlarm, writeAlarm];
+    });
+  }
+}
+
+/** Alarm logical ID に英数字以外を入れられないので safe ID に変換する。 */
+function sanitize(s: string): string {
+  return s.replace(/[^A-Za-z0-9]/g, "");
+}

--- a/infrastructure/test/observability/free-tier-alarms.test.ts
+++ b/infrastructure/test/observability/free-tier-alarms.test.ts
@@ -1,0 +1,118 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { describe, expect, it } from "vitest";
+import { FreeTierAlarms } from "../../lib/observability/free-tier-alarms";
+
+/**
+ * Issue #952 cost guardrails: FreeTierAlarms construct の CFn synth を pin する。
+ *
+ * - Lambda 1 件あたり 1 個の Alarm
+ * - DDB Table 1 件あたり Read / Write 2 個の Alarm
+ * - 各 Alarm に SNS topic action が wire される
+ * - Lambda の threshold は default 26666 (= 800k/month / 30 days、 Free Tier 80%)
+ * - DDB の threshold は default 100000 (= 1 RCU * 86400 sec + 余裕)
+ */
+
+function buildStack() {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const topic = new Topic(stack, "Topic");
+  return { app, stack, topic };
+}
+
+describe("FreeTierAlarms (#952 cost guardrails)", () => {
+  it("Lambda 2 個 + DDB 1 個なら計 4 個の Alarm を生成すべき", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: ["fn-a", "fn-b"],
+      dynamoDbTableNames: ["table-x"],
+    });
+    const tpl = Template.fromStack(stack);
+    // 2 Lambda alarms + 1 DDB (read+write) = 4
+    tpl.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+  });
+
+  it("Lambda alarm の threshold は default 26666、 metric namespace=AWS/Lambda", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: ["fn-a"],
+      dynamoDbTableNames: [],
+    });
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/Lambda",
+      MetricName: "Invocations",
+      Threshold: 26666,
+      Statistic: "Sum",
+    });
+  });
+
+  it("DDB Read Capacity Alarm の threshold default は 100000", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: [],
+      dynamoDbTableNames: ["table-x"],
+    });
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/DynamoDB",
+      MetricName: "ConsumedReadCapacityUnits",
+      Threshold: 100000,
+    });
+    tpl.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/DynamoDB",
+      MetricName: "ConsumedWriteCapacityUnits",
+      Threshold: 100000,
+    });
+  });
+
+  it("各 Alarm は SNS topic action を持つべき", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: ["fn-a"],
+      dynamoDbTableNames: [],
+    });
+    const tpl = Template.fromStack(stack);
+    const alarms = tpl.findResources("AWS::CloudWatch::Alarm");
+    const first = Object.values(alarms)[0];
+    expect(first?.Properties?.AlarmActions).toBeDefined();
+    expect(Array.isArray(first?.Properties?.AlarmActions)).toBe(true);
+  });
+
+  it("override threshold が反映されるべき", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: ["fn-a"],
+      dynamoDbTableNames: ["table-x"],
+      lambdaDailyInvocationThreshold: 5000,
+      dynamoDbDailyConsumedThreshold: 50000,
+    });
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/Lambda",
+      Threshold: 5000,
+    });
+    tpl.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      Namespace: "AWS/DynamoDB",
+      Threshold: 50000,
+    });
+  });
+
+  it("英数以外を含む resource 名 (= dot / hyphen) でも logical ID 衝突しないべき", () => {
+    const { stack, topic } = buildStack();
+    new FreeTierAlarms(stack, "Alarms", {
+      notificationTopic: topic,
+      lambdaFunctionNames: ["fn-a.b", "fn-a-b"],
+      dynamoDbTableNames: [],
+    });
+    const tpl = Template.fromStack(stack);
+    // 2 Lambda alarms (= sanitize で衝突しない logical ID)
+    tpl.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #952 epic / 軸 #8 (= コスト爆発防止) の追加層。 旧来 \`CostBudget\` (AWS Budgets) は **金額 base** の月次 alarm のみで、 spike を即座に検知できない (= 24-48h 遅延)。 sudden traffic は数時間で Free Tier を吹き飛ばすので、 resource-usage base の即時 alarm を加える。

## 実装

新 \`FreeTierAlarms\` construct:

- **Lambda**: 月次 invocations Free Tier 80% (= 800k req) 相当の日次 26,666 を超過したら alarm (= 7 Lambda 別個に立てて 「どれが暴走したか」 が見える)
- **DynamoDB**: 月次 ConsumedRead/WriteCapacityUnits が Free Tier (= 25 RCU/WCU) 由来の日次 100,000 を超過したら alarm (= 6 Table × Read/Write で 12 alarm)
- 各 alarm は CostBudget と同じ SNS topic に publish (= operator email に統一)

\`wire.ts\` で \`monthlyCostLimitUsd > 0\` のとき CostBudget と並列で attach。 budget 24-48h 遅延 alarm と Free Tier breach 即時 alarm が同 channel に届く。

## test

新 \`free-tier-alarms.test.ts\` (= 6 case): alarm count / threshold default + override / SNS action / logical ID 衝突回避。

## Regression 分析

- 既存 \`CostBudget\` 無改修、 \`ObservabilityStack\` も Phase 1 dashboard-only 設計を維持
- \`monthlyCostLimitUsd\` 未指定なら旧挙動 (= FreeTierAlarms も作らない)
- CloudWatch alarm は Free Tier 10 個まで free、 計 19 alarm で ~$1/月 (= 極小)

## 物理影響

- NEW: \`free-tier-alarms.ts\` + test
- UPDATE: \`wire.ts\` で CostBudget の隣に FreeTierAlarms attach
- CFn diff: ~19 \`AWS::CloudWatch::Alarm\` 追加 (monthlyCostLimit > 0 のとき)

Closes #952 軸 #8 (= cost guardrails resource-usage 層追加)
Relates ADR-021

🤖 Generated with [Claude Code](https://claude.com/claude-code)