### PR TITLE
fix(#1005): ヒント開封も event scoring gate を通す (競技公平性)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/event-gate.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/event-gate.ts
@@ -1,0 +1,100 @@
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import type { ParticipantSharedResources } from "./shared.js";
+
+/**
+ * Issue #1005 / Issue #13: event の scoring gate を participant routes 間で共有する。
+ *
+ * 旧来 submit-flag だけが gate を見ていたが、 hint reveal も同じ gate に従う必要がある
+ * (= 開始前 / 終了後に hint を開封して penalty を accrue させない、 競技の公平性)。
+ *
+ * 本モジュールは:
+ *   - `getEventGate(eventId)` で event 行から gate fields を 1 GetItem で取得
+ *   - `evaluateGate(gate, now)` で fail-closed に 「採点経路を続けてよい」 か判定
+ *
+ * 採点経路を block するべき場合は kind + 補助情報を返す。 通せるなら `undefined`。
+ * 旧 submit-flag に閉じていた gate を、 reveal-hint からも同関数で呼べる shape にする。
+ */
+
+export type GateBlock =
+  | { kind: "scoring_not_started"; startsAt?: string }
+  | { kind: "scoring_ended"; endsAt?: string }
+  | { kind: "scoring_locked" };
+
+export interface EventGate {
+  readonly scoringLocked: boolean;
+  readonly startsAt: string | undefined;
+  readonly endsAt: string | undefined;
+  readonly status: string | undefined;
+}
+
+/**
+ * Event 行の gate fields (scoringLocked / startsAt / endsAt / status) を 1 GetItem で取得。
+ * 不在 / DDB error は fail-closed (= undefined 返却、 evaluateGate 側で
+ * scoring_not_started に変換) で安全側に倒す。
+ */
+export async function getEventGate(
+  shared: ParticipantSharedResources,
+  eventId: string,
+): Promise<EventGate | undefined> {
+  try {
+    const out = await shared.ddb.send(
+      new GetCommand({
+        TableName: shared.eventsTableName,
+        Key: { PK: `EVENT#${eventId}`, SK: "META" },
+        ProjectionExpression: "scoringLocked, startsAt, endsAt, #s",
+        ExpressionAttributeNames: { "#s": "status" },
+      }),
+    );
+    const item = out.Item as
+      | {
+          scoringLocked?: boolean;
+          startsAt?: string;
+          endsAt?: string;
+          status?: string;
+        }
+      | undefined;
+    if (!item) return undefined;
+    return {
+      scoringLocked: item.scoringLocked === true,
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      status: item.status,
+    };
+  } catch (err) {
+    console.warn("[event-gate] getEventGate failed", {
+      eventId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Gate 評価。 順序 (= 上から先に該当した kind を返す):
+ *   1. gate 不在 (= event 行なし)        → scoring_not_started
+ *   2. status=ENDED / ARCHIVED           → scoring_ended
+ *   3. startsAt 未設定                   → scoring_not_started
+ *   4. now < startsAt                    → scoring_not_started
+ *   5. endsAt 設定 + now > endsAt        → scoring_ended
+ *   6. scoringLocked                     → scoring_locked
+ *   7. それ以外                          → undefined (= 採点可能)
+ */
+export function evaluateGate(gate: EventGate | undefined, nowMs: number): GateBlock | undefined {
+  if (!gate) return { kind: "scoring_not_started" };
+  if (gate.status === "ENDED" || gate.status === "ARCHIVED") {
+    return { kind: "scoring_ended", endsAt: gate.endsAt };
+  }
+  if (!gate.startsAt) return { kind: "scoring_not_started" };
+  const startMs = Date.parse(gate.startsAt);
+  if (Number.isFinite(startMs) && nowMs < startMs) {
+    return { kind: "scoring_not_started", startsAt: gate.startsAt };
+  }
+  if (gate.endsAt) {
+    const endMs = Date.parse(gate.endsAt);
+    if (Number.isFinite(endMs) && nowMs > endMs) {
+      return { kind: "scoring_ended", endsAt: gate.endsAt };
+    }
+  }
+  if (gate.scoringLocked) return { kind: "scoring_locked" };
+  return undefined;
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -184,6 +184,10 @@ app.post("/portal/me/problems/:problemId/hints/:hintId/reveal", (c) =>
       if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
       if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
       if (outcome.kind === "unknown_hint") return respondError(c, "unknown_hint");
+      // Issue #1005: scoring gate failures are the same 409 family as submit-flag.
+      if (outcome.kind === "scoring_not_started") return respondError(c, "scoring_not_started");
+      if (outcome.kind === "scoring_ended") return respondError(c, "scoring_ended");
+      if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
       // ok / already_revealed どちらも 200 で content + score を返す (= idempotent UX)。
       return c.json(outcome, HTTP_OK);
     },

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
@@ -1,6 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import { parseHintRevealedAttribute } from "../shared/hint-reveal.js";
+import { evaluateGate, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
@@ -23,7 +24,15 @@ export type RevealHintOutcome =
   | { kind: "already_revealed"; content: string; penaltyApplied: number; totalScore: number }
   | { kind: "unauthorized" }
   | { kind: "not_flag_problem" }
-  | { kind: "unknown_hint" };
+  | { kind: "unknown_hint" }
+  /**
+   * Issue #1005: 競技開始前 / 終了後 / scoringLocked 状態でヒント開封を block する。
+   * submit-flag と同じ gate を共有 (event-gate.ts)。 旧来 reveal-hint は gate を見ず、
+   * 開始前に開けて -penalty が accrue する公平性破壊バグがあった。
+   */
+  | { kind: "scoring_not_started"; startsAt?: string }
+  | { kind: "scoring_ended"; endsAt?: string }
+  | { kind: "scoring_locked" };
 
 export async function revealHint(
   shared: ParticipantSharedResources,
@@ -37,6 +46,14 @@ export async function revealHint(
 
   const item = items.find((i) => i.problemId === problemId);
   if (!item?.PK || !item.problemId) return { kind: "unauthorized" };
+
+  // Issue #1005: ヒント開封も submit-flag と同じ scoring gate を通す。
+  // 開始前 / 終了後 / scoringLocked では penalty を accrue させない (= 公平性)。
+  if (typeof item.eventId === "string" && item.eventId.length > 0) {
+    const gate = await getEventGate(shared, item.eventId);
+    const blocked = evaluateGate(gate, Date.now());
+    if (blocked) return blocked;
+  }
 
   const scoring = scoringMap[item.problemId];
   // Phase 3 は flag kind 限定で hints をサポート (= Phase 5 で他 4 kind に拡張)。

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,8 +1,9 @@
-import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import { flagMatches } from "../generic-scoring-handler/kinds/flag.js";
 import { parseStackOutputs } from "../shared/cfn-status.js";
 import { writeScoreEvent } from "../shared/score-event.js";
+import { evaluateGate, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 export type SubmitFlagOutcome =
@@ -26,86 +27,6 @@ export type SubmitFlagOutcome =
   | { kind: "scoring_not_started"; startsAt?: string }
   | { kind: "scoring_ended"; endsAt?: string }
   | { kind: "unauthorized" };
-
-interface EventGate {
-  readonly scoringLocked: boolean;
-  readonly startsAt: string | undefined;
-  readonly endsAt: string | undefined;
-  readonly status: string | undefined;
-}
-
-/**
- * Issue #13: Event の gate flags を read-through で取得する。 scoringLocked + startsAt + endsAt +
- * status を 1 GetItem (= 1 RCU) でまとめて読む。 不在 / error は fail-closed で 「採点不可」 扱い
- * (= old fail-open とは逆。 JAM/GameDay 前提では「採点しないより、 まずデータ取れなかったら
- * 採点を止める」 が安全側)。
- */
-async function getEventGate(
-  shared: ParticipantSharedResources,
-  eventId: string,
-): Promise<EventGate | undefined> {
-  try {
-    const out = await shared.ddb.send(
-      new GetCommand({
-        TableName: shared.eventsTableName,
-        Key: { PK: `EVENT#${eventId}`, SK: "META" },
-        ProjectionExpression: "scoringLocked, startsAt, endsAt, #s",
-        ExpressionAttributeNames: { "#s": "status" },
-      }),
-    );
-    const item = out.Item as
-      | {
-          scoringLocked?: boolean;
-          startsAt?: string;
-          endsAt?: string;
-          status?: string;
-        }
-      | undefined;
-    if (!item) return undefined;
-    return {
-      scoringLocked: item.scoringLocked === true,
-      startsAt: item.startsAt,
-      endsAt: item.endsAt,
-      status: item.status,
-    };
-  } catch (err) {
-    console.warn("[submit-flag] getEventGate failed", {
-      eventId,
-      message: err instanceof Error ? err.message : String(err),
-    });
-    return undefined;
-  }
-}
-
-/**
- * Issue #13: scoring gate を評価する。 順序は次のとおり (= 上から先に該当した outcome を返す):
- *   1. event 行が無い          → "scoring_not_started" (= 安全側)
- *   2. status=ENDED / ARCHIVED → "scoring_ended"
- *   3. startsAt 未設定         → "scoring_not_started"
- *   4. now < startsAt          → "scoring_not_started"
- *   5. endsAt 設定 + now > endsAt → "scoring_ended"
- *   6. scoringLocked           → "scoring_locked"
- *   7. それ以外                → undefined (= scoring active、 加点経路へ)
- */
-function evaluateGate(gate: EventGate | undefined, nowMs: number): SubmitFlagOutcome | undefined {
-  if (!gate) return { kind: "scoring_not_started" };
-  if (gate.status === "ENDED" || gate.status === "ARCHIVED") {
-    return { kind: "scoring_ended", endsAt: gate.endsAt };
-  }
-  if (!gate.startsAt) return { kind: "scoring_not_started" };
-  const startMs = Date.parse(gate.startsAt);
-  if (Number.isFinite(startMs) && nowMs < startMs) {
-    return { kind: "scoring_not_started", startsAt: gate.startsAt };
-  }
-  if (gate.endsAt) {
-    const endMs = Date.parse(gate.endsAt);
-    if (Number.isFinite(endMs) && nowMs > endMs) {
-      return { kind: "scoring_ended", endsAt: gate.endsAt };
-    }
-  }
-  if (gate.scoringLocked) return { kind: "scoring_locked" };
-  return undefined;
-}
 
 /**
  * teamLoginKey で team の全 deployment 行を引き、`problemId` 一致する行に対し flag を

--- a/infrastructure/test/problem-deploy/reveal-hint.test.ts
+++ b/infrastructure/test/problem-deploy/reveal-hint.test.ts
@@ -188,4 +188,86 @@ describe("revealHint (#742 Phase 3)", () => {
       revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1"),
     ).rejects.toThrow(/DDB throttle/);
   });
+
+  // ---- Issue #1005 / scoring gate (= submit-flag と同じ gate を hint reveal でも通す) ----
+  describe("competition scoring gate (Issue #1005)", () => {
+    const eventRow = sampleRow({ eventId: "EVT1", score: 0 });
+
+    it("Event 行が無いときは fail-closed で scoring_not_started を返し UpdateItem を呼ばないべき", async () => {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({}); // EventMeta GetItem returns no Item
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("scoring_not_started");
+      // hintsRevealed の Update は走らない (= penalty が accrue しない)
+      expect(ddbSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("now < startsAt なら scoring_not_started を返し startsAt を含めるべき", async () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({ Item: { status: "READY", startsAt: future } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out).toEqual({ kind: "scoring_not_started", startsAt: future });
+    });
+
+    it("endsAt 設定 + now > endsAt なら scoring_ended を返すべき", async () => {
+      const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const before = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, endsAt: past },
+      });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out).toEqual({ kind: "scoring_ended", endsAt: past });
+    });
+
+    it("status=ENDED なら startsAt があっても scoring_ended を返すべき", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({ Item: { status: "ENDED", startsAt: before } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("scoring_ended");
+    });
+
+    it("scoringLocked=true は startsAt OK でも scoring_locked を返すべき", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, scoringLocked: true },
+      });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("scoring_locked");
+    });
+
+    it("startsAt 過去 + endsAt 未来 + status=READY なら gate を通って ok で penalty を deduct すべき", async () => {
+      const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
+      ddbSend.mockResolvedValueOnce({
+        Item: { status: "READY", startsAt: before, endsAt: future },
+      });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: -10 } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("ok");
+      if (out.kind !== "ok") return;
+      expect(out.penaltyApplied).toBe(10);
+    });
+
+    it("eventId が item に無い legacy row は gate check を skip して旧挙動で reveal すべき", async () => {
+      // = team の row に eventId が無いケース (= non-event-scoped、 historical)
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] }); // no eventId
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 90 } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("ok");
+      // EventMeta の Get は呼ばない (= 2 calls: query + update のみ)
+      expect(ddbSend).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- ヒント開封は scoring gate (= startsAt / endsAt / status / scoringLocked) を見ておらず、 競技開始前に hint を開いて -30 pt が accrue する **公平性破壊バグ** だった (= Flag 提出は gate 通っていたので非対称)
- gate logic (\`getEventGate\` + \`evaluateGate\`) を submit-flag.ts から抽出した \`event-gate.ts\` に共通化し、 reveal-hint.ts でも呼ぶ
- \`RevealHintOutcome\` に \`scoring_not_started\` / \`scoring_ended\` / \`scoring_locked\` を追加、 route handler で 409 にマップ

## Test plan

- [x] \`cd infrastructure && bunx vitest run\`: 113 file / **1278 tests** 全 passed
- [x] reveal-hint.test.ts に 7 件 (= gate describe block) を追加、 含めて 16 tests pass
- [x] submit-flag.test.ts 既存 21 tests pass (= 抽出後の non-regression)
- [x] \`bun run --filter @TenkaCloud/infrastructure typecheck\`: clean
- [x] \`make harness\`: no findings

## Regression 分析

- submit-flag の gate logic は 1:1 で move (= body 差分は import のみ → 挙動 100% 互換)
- 既存 \`reveal-hint\` の non-event-scoped (= item.eventId 不在) item は gate を skip し旧挙動維持
- 新規 「ヒントが scoring_not_started で開けない」 は **仕様変更** (= 旧挙動が bug)
- Penalty が accrue してしまった既存 score の reset は **本 PR では行わない** (別 issue で migration script)
- UI 側で button を grey out する追加対応は別 PR (= まずは backend 正しさを優先)

## 物理影響

- CFn: **NO-OP** (= Lambda handler コードのみ)
- DDB read 増: hint reveal で EventMeta GetItem +1 回 / 操作 (= 1 RCU/操作)。 rare path なので PROVISIONED 1 RCU/sec で吸収
- Lambda code size: 微増 (= 1 ファイル 89 行追加)
- 認可 / IAM: NO-OP (= 同 DDB を既に GetItem する権限を持つ)

Closes #1005