### PR TITLE
fix(#998): EventCreate の Teams / Region dropdown を expandToViewport で見切れ解消

### DIFF
--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -434,6 +434,11 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                             invalid={
                               t.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(t.awsAccountId)
                             }
+                            // Issue #998: option (alias + region + role) が table cell 幅を
+                            // 超えると text が見切れる。 expandToViewport で portal に逃がして
+                            // 横幅自由・全文表示にする。
+                            expandToViewport
+                            filteringType="auto"
                           />
                           {selectedAccount && (
                             <Box variant="small" color="text-status-inactive">
@@ -493,6 +498,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                               defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
                             })
                           }
+                          // Issue #998: region 名 (= 「アジアパシフィック (東京)」 等) が table cell
+                          // の幅を超えるので portal に逃がす。
+                          expandToViewport
                         />
                       ),
                     },


### PR DESCRIPTION
## Summary

AWS Account ID (verified) dropdown と Region dropdown の option が table cell 幅を超えて見切れる問題 (screenshot 報告: "ap-northeast-1/TenkaCloud-CompetitorDeploy-Role" の途中で切断)。 \`expandToViewport={true}\` を付けて option を portal に逃がし、 横幅自由に展開。 AWS Account の方は \`filteringType="auto"\` で typeahead 検索も有効化。

## Test plan

- [x] bun --filter @TenkaCloud/application-admin-console test: **246 tests passed**
- [x] bun --filter @TenkaCloud/application-admin-console typecheck: clean

## Regression 分析

- expandToViewport は Cloudscape 標準 prop で副作用なし (= portal の描画位置だけ変える)
- filteringType="auto" は option 多い時 typeahead を有効化、 1 option のケースは挙動変わらず

## 物理影響

- CFn: **NO-OP**
- frontend のみ、 既存 import の prop 追加 2 件

Closes #998