### PR TITLE
feat(#1002): Score events に累計 score 折れ線グラフ + 加点/減点 UI 拡張

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -228,14 +228,16 @@ export async function updateTeamName(
 }
 
 /**
- * Phase 3: 自チームの加点履歴 (時系列降順)。flag 提出と uptime probe 成功の両方を含む。
+ * Phase 3: 自チームのスコア変動履歴 (時系列降順)。
+ * Issue #1001: flag 提出 / uptime probe 成功に加え、 ヒント開封 / 不正解 flag の
+ * 減点行も含む。 source / points の符号で 「加点 / 減点」 を区別する。
  */
 export interface ScoreEventView {
   readonly jobId: string;
   readonly problemId: string;
-  readonly source: "uptime" | "flag";
+  readonly source: "uptime" | "flag" | "flag-wrong" | "hint";
   readonly points: number;
-  readonly result: "ok";
+  readonly result: "ok" | "wrong";
   readonly occurredAt: string;
 }
 

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -3,10 +3,11 @@ import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
+import LineChart from "@cloudscape-design/components/line-chart";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   getScoreEvents,
   PortalAuthError,
@@ -20,21 +21,59 @@ import { describeAgo, formatOccurredAtTooltip } from "../lib/format";
 // Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/user で過多)。
 const POLL_INTERVAL_MS = 30_000;
 
+/**
+ * Issue #1001: 加点 / 減点を区別するラベル + 色。
+ * - uptime / flag : 加点系 (green / blue)
+ * - flag-wrong / hint : 減点系 (red / grey)
+ */
 const SOURCE_LABEL: Record<ScoreEventView["source"], string> = {
   uptime: "Battle (uptime)",
   flag: "Challenge (flag)",
+  "flag-wrong": "不正解 flag",
+  hint: "ヒント開封",
 };
 
 const SOURCE_COLOR: Record<ScoreEventView["source"], "blue" | "green" | "grey" | "red"> = {
   uptime: "green",
   flag: "blue",
+  "flag-wrong": "red",
+  hint: "grey",
 };
 
 /**
- * 自チームの加点履歴 (sidebar 「Score events」)。新しい順 100 件まで表示。
+ * Issue #1002: 累計 score を時系列に並べる data point を作る。 entries は新しい順なので
+ * reverse して古い順にしてから累積加算する。
+ */
+interface ChartPoint {
+  readonly x: Date;
+  readonly y: number;
+}
+
+function buildCumulativeSeries(entries: readonly ScoreEventView[]): readonly ChartPoint[] {
+  if (entries.length === 0) return [];
+  const oldestFirst = [...entries].sort((a, b) =>
+    a.occurredAt < b.occurredAt ? -1 : a.occurredAt > b.occurredAt ? 1 : 0,
+  );
+  const points: ChartPoint[] = [];
+  let cumulative = 0;
+  for (const e of oldestFirst) {
+    cumulative += e.points;
+    const ts = Date.parse(e.occurredAt);
+    if (!Number.isFinite(ts)) continue;
+    points.push({ x: new Date(ts), y: cumulative });
+  }
+  return points;
+}
+
+/**
+ * 自チームのスコア変動履歴 (sidebar 「Score events」)。新しい順 100 件まで表示。
  *
- * データ source は `getScoreEvents` を 5 秒間隔で polling。HealthCheck (uptime 成功) と
- * 競技者の flag 提出 (正解) の両方を merge 済。
+ * データ source は `getScoreEvents` を 30 秒間隔で polling。HealthCheck (uptime 成功) /
+ * 競技者の flag 提出 (正解) / ヒント開封による減点 / 不正解 flag による減点を merge 済。
+ *
+ * Issue #1002: 上部に累計 score の折れ線グラフを追加 (Cloudscape LineChart)。
+ * X 軸 = wall-clock 時刻、 Y 軸 = cumulative score。 hover で 1 point の詳細 (時刻 +
+ * cumulative score) を tooltip。
  */
 export function ScoreEventsPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
@@ -74,11 +113,13 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
     };
   }, [isBackend, sessionToken, tick]);
 
+  const series = useMemo(() => (data ? buildCumulativeSeries(data.entries) : []), [data]);
+
   return (
     <SpaceBetween size="l">
       <Header
         variant="h1"
-        description={`自チームの加点履歴 (${POLL_INTERVAL_MS / 1000} 秒ごと自動更新、新しい順 100 件まで)`}
+        description={`自チームのスコア変動履歴 (${POLL_INTERVAL_MS / 1000} 秒ごと自動更新、新しい順 100 件まで)`}
       >
         Score events
       </Header>
@@ -98,6 +139,43 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
         <Box textAlign="center" padding="l">
           <Spinner /> 状態を取得中…
         </Box>
+      )}
+
+      {data && series.length > 0 && (
+        <Container header={<Header variant="h2">累計 score 推移</Header>}>
+          <LineChart
+            series={[
+              {
+                title: "累計 score",
+                type: "line",
+                data: series.map((p) => ({ x: p.x, y: p.y })),
+              },
+            ]}
+            xDomain={
+              series.length > 0
+                ? [series[0]?.x ?? new Date(), series[series.length - 1]?.x ?? new Date()]
+                : undefined
+            }
+            xScaleType="time"
+            xTitle="時刻"
+            yTitle="累計 score"
+            height={240}
+            i18nStrings={{
+              xTickFormatter: (d) =>
+                new Date(d).toLocaleTimeString("ja-JP", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  second: "2-digit",
+                }),
+            }}
+            empty={
+              <Box textAlign="center" padding="m" color="text-status-inactive">
+                データなし
+              </Box>
+            }
+            ariaLabel="累計 score の時系列"
+          />
+        </Container>
       )}
 
       {data && (
@@ -132,21 +210,27 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
               },
               {
                 id: "points",
-                header: "加点",
-                cell: (e) => (
-                  <Box variant="strong" color="text-status-success">
-                    +{e.points} pt
-                  </Box>
-                ),
+                header: "変動",
+                // Issue #1001: 負の数は赤、 正の数は緑で 「±N pt」 を表示。
+                cell: (e) =>
+                  e.points >= 0 ? (
+                    <Box variant="strong" color="text-status-success">
+                      +{e.points} pt
+                    </Box>
+                  ) : (
+                    <Box variant="strong" color="text-status-error">
+                      {e.points} pt
+                    </Box>
+                  ),
                 width: 100,
               },
             ]}
             empty={
               <Box textAlign="center" padding="l">
-                <Box variant="strong">まだ加点履歴がありません</Box>
+                <Box variant="strong">まだスコア変動履歴がありません</Box>
                 <Box variant="small" color="text-status-inactive" padding={{ top: "s" }}>
-                  競技開始後、HealthCheck の uptime 成功や flag
-                  提出で加点されると履歴がここに並びます。
+                  競技開始後、HealthCheck の uptime 成功 / flag 提出 /
+                  ヒント開封などでスコアが動くと履歴がここに並びます。
                 </Box>
               </Box>
             }


### PR DESCRIPTION
## Summary

- Score events page の上部に **Cloudscape LineChart** で累計 score 時系列を可視化 (#1002)
- 同時に PR-1007 で backend 拡張済 (= hint / flag-wrong 減点を返す) を **frontend に反映**: ScoreEventView union を拡張、 表の 「加点」 → 「変動」、 負の数を赤 / 正の数を緑で表示

## Test plan

- [x] bun --filter @TenkaCloud/participant-portal test: 17 file / **159 tests** passed
- [x] bun --filter @TenkaCloud/participant-portal typecheck: clean

## Regression 分析

- 既存 entries (= uptime/flag のみ) は描画変わらず
- SOURCE_LABEL/SOURCE_COLOR は TypeScript 網羅性で未知 source が出ても compile-time error
- LineChart は data 0 件のとき render しない

## 物理影響

- CFn: **NO-OP**
- frontend のみ、 LineChart import で bundle +N KB

Closes #1002