### PR TITLE
fix(#993): Codecov に全 workspace の coverage を上げる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,13 @@ jobs:
         run: |
           make typecheck
 
-      - name: Run tests
+      # Issue #993: 旧 `make test` (= `bun run test --coverage`) は && chain の末尾 workspace
+      # にしか --coverage が渡らず、 codecov に上がる coverage が trust-bridge だけだった。
+      # `test-coverage` target は各 workspace の `test:coverage` script を順に叩き、
+      # 各 workspace 配下に `coverage/lcov.info` を生成する → codecov-action が拾う。
+      - name: Run tests with coverage
         run: |
-          make test
+          make test-coverage
 
       - name: Build
         run: |
@@ -79,3 +83,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           # Codecov 側 outage で CI 全体を落とさない。 coverage 計測は補助、 必須でない。
           fail_ci_if_error: false
+          # 各 workspace の coverage/lcov.info を明示的に拾う (= auto-discover に依存しない)。
+          files: ./infrastructure/coverage/lcov.info,./apps/admin-console/coverage/lcov.info,./apps/application-admin-console/coverage/lcov.info,./apps/participant-portal/coverage/lcov.info,./packages/trust-bridge/coverage/lcov.info

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ install:
 install_ci:    ; bun install --frozen-lockfile --ignore-scripts
 build:         ; bun run build
 typecheck:     ; bun run typecheck
-test:          ; bun run test --coverage
+test:          ; bun run test
+test-coverage: ; bun run test:coverage
 validate-problems: ; bun run validate:problems
 build-problems-index: ; bun run build:problems-index
 check-problems-index: ; bun run check:problems-index

--- a/apps/admin-console/package.json
+++ b/apps/admin-console/package.json
@@ -9,7 +9,8 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='**/*.test.ts*'"
   },
   "dependencies": {
     "@cloudscape-design/components": "^3.0.1297",

--- a/apps/application-admin-console/package.json
+++ b/apps/application-admin-console/package.json
@@ -9,7 +9,8 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='**/*.test.ts*'"
   },
   "dependencies": {
     "@cloudscape-design/components": "^3.0.1297",

--- a/apps/participant-portal/package.json
+++ b/apps/participant-portal/package.json
@@ -9,7 +9,8 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='**/*.test.ts*'"
   },
   "dependencies": {
     "@cloudscape-design/components": "^3.0.1297",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -10,6 +10,7 @@
     "watch": "tsc -w",
     "synth": "cdk synth -c environment=${ENV:-development}",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='cdk.out/**' --coverage.exclude='**/*.test.ts' --coverage.exclude='test/**'",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
     "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test",
+    "test:coverage": "bun run --filter @TenkaCloud/infrastructure test:coverage && bun run --filter @TenkaCloud/admin-console test:coverage && bun run --filter @TenkaCloud/application-admin-console test:coverage && bun run --filter @TenkaCloud/participant-portal test:coverage && bun run --filter @TenkaCloud/trust-bridge test:coverage",
     "validate:problems": "bun run scripts/validate-problems.ts",
     "build:problems-index": "bun run scripts/build-problem-index.ts",
     "check:problems-index": "bun run scripts/build-problem-index.ts --check",

--- a/packages/trust-bridge/package.json
+++ b/packages/trust-bridge/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='**/*.test.ts'"
   },
   "dependencies": {
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary

Codecov "No coverage reports found" を解消。 原因は root の \`bun run test --coverage\` が \`&&\` chain 末尾 (= trust-bridge) にしか --coverage を渡さなかったこと。 全 workspace に \`test:coverage\` script を追加し、 CI で順次実行 → codecov-action に各 lcov.info を明示的に渡す。

- 各 workspace package.json: \`test:coverage\` を CLI flag (= lcov + reportsDirectory + exclude) で追加
- root package.json: \`test:coverage\` chain
- Makefile: \`test\` から --coverage を外し、 \`test-coverage\` target を新設
- CI workflow: \`make test-coverage\` を呼ぶ + codecov-action に \`files:\` で 5 workspace の lcov を明示

## Test plan

- [x] bun --filter @TenkaCloud/trust-bridge test:coverage: lcov.info 生成、 92.78% statements
- [ ] CI で Codecov ダッシュボードに 5 workspace 分の coverage が表示されることを確認 (post-merge)

## Regression 分析

- local dev \`make test\` は --coverage が外れて高速化 (= 旧挙動だと末尾 1 workspace だけ instrument、 効果薄)
- CI 時間 +N% (v8 instrument ~10% overhead)
- vitest.config.ts は変更しない (= CLAUDE.md 「設定ファイルの直接変更禁止」 を尊重、 CLI flag で同等)

## 物理影響

- CFn: **NO-OP**
- CI: 各 workspace 配下に \`coverage/\` が出力される (= .gitignore で除外済)

Closes #993