### PR TITLE
feat(#1006): scoring gate 409 に startsAt / endsAt を含めて 「あと N 分」 UI を出す

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -136,6 +136,25 @@ export class PortalNetworkError extends Error {
   }
 }
 
+/**
+ * Issue #1006: scoring gate (= 競技開始前 / 終了後) で 409 が返った時に、 startsAt / endsAt を
+ * 取り出して UI が 「競技開始まで N 分」 「競技は X 終了しました」 を出せるようにする。
+ *
+ * backend は { error: "scoring_not_started"|"scoring_ended", startsAt?, endsAt? } を返す。
+ * 旧来 frontend は PortalNetworkError として string で受け取り、 ユーザーに JSON が見える
+ * 不親切 UX だった。
+ */
+export class PortalScoringGateError extends Error {
+  constructor(
+    public readonly kind: "scoring_not_started" | "scoring_ended" | "scoring_locked",
+    public readonly startsAt?: string,
+    public readonly endsAt?: string,
+  ) {
+    super(`Portal scoring gate: ${kind}`);
+    this.name = "PortalScoringGateError";
+  }
+}
+
 function buildPortalUrl(apiBaseUrl: string, path: string): URL {
   const base = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
   return new URL(path, base);
@@ -185,7 +204,19 @@ async function portalFetch<T>(
     throw new PortalValidationError(body.error ?? "invalid_request");
   }
   if (res.status === StatusCodes.CONFLICT && options.throwOn409) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    const body = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      startsAt?: string;
+      endsAt?: string;
+    };
+    // Issue #1006: scoring gate 系の 409 は startsAt / endsAt を持つ専用 error にする。
+    if (
+      body.error === "scoring_not_started" ||
+      body.error === "scoring_ended" ||
+      body.error === "scoring_locked"
+    ) {
+      throw new PortalScoringGateError(body.error, body.startsAt, body.endsAt);
+    }
     throw new PortalValidationError(body.error ?? "conflict");
   }
   if (!res.ok) {
@@ -421,6 +452,9 @@ export async function revealHint(
     {
       method: "POST",
       throwOn400: true,
+      // Issue #1006: 409 scoring_not_started / scoring_ended / scoring_locked を
+      // PortalScoringGateError として throw (= UI が startsAt 文言を出せる)。
+      throwOn409: true,
       signal,
     },
   )) as RevealHintResponse;
@@ -440,6 +474,9 @@ export async function submitFlag(
     method: "POST",
     body: { problemId, flag },
     throwOn400: true,
+    // Issue #1006: 409 scoring_not_started / scoring_ended / scoring_locked を
+    // PortalScoringGateError として throw (= UI が startsAt 文言を出せる)。
+    throwOn409: true,
     signal,
   })) as SubmitFlagOutcome;
 }

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -17,6 +17,7 @@ import {
   type DeploymentStatus,
   type ParticipantHintView,
   type ParticipantProblemView,
+  PortalScoringGateError,
   PortalValidationError,
   revealHint,
   type SubmitFlagOutcome,
@@ -45,6 +46,36 @@ const SCORING_KIND_LABEL: Record<string, string> = {
 };
 
 const FALLBACK_KIND_LABEL = "(未設定)";
+
+/**
+ * Issue #1006: scoring gate (= 競技開始前 / 終了後 / 一時停止) のエラーを 「いつ開始 / 終了か」
+ * を添えた人間可読 message に変換する。 backend が startsAt / endsAt を返すようになったので、
+ * UI 側で 「あと N 分」 を計算して表示する。
+ */
+function describeScoringGate(err: PortalScoringGateError, now: Date = new Date()): string {
+  if (err.kind === "scoring_not_started") {
+    if (!err.startsAt) {
+      return "競技はまだ開始していません。 運営の開始合図をお待ちください。";
+    }
+    const startsAt = new Date(err.startsAt);
+    if (Number.isNaN(startsAt.getTime())) {
+      return "競技はまだ開始していません。";
+    }
+    const diffMs = startsAt.getTime() - now.getTime();
+    if (diffMs <= 0) {
+      return `競技開始時刻は ${startsAt.toLocaleString()} です (= 既に経過)。 反映に時差がある場合があります。`;
+    }
+    const minutes = Math.ceil(diffMs / 60_000);
+    return `競技開始まで約 ${minutes} 分です (開始予定: ${startsAt.toLocaleString()})。 開始までお待ちください。`;
+  }
+  if (err.kind === "scoring_ended") {
+    if (!err.endsAt) return "競技は終了しました。 採点 gate は閉じています。";
+    const endsAt = new Date(err.endsAt);
+    if (Number.isNaN(endsAt.getTime())) return "競技は終了しました。";
+    return `競技は終了しました (終了: ${endsAt.toLocaleString()})。 採点 gate は閉じています。`;
+  }
+  return "採点が一時停止されています。 運営にお問い合わせください。";
+}
 
 /** uptime kind で `lastScoredAt` がこの閾値より古ければ「停滞」表示。 */
 const STALE_THRESHOLD_MS = 2 * 60 * 1000;
@@ -195,23 +226,12 @@ function FlagSubmissionPanel({
         await onScored();
       }
     } catch (err) {
-      if (err instanceof PortalValidationError) {
-        // Issue #13 / scoring gate: 競技開始前 / 終了後 / lock の error code を
-        // 人間可読 message に変換 (= 「バリデーションエラー: scoring_not_started」 では何が
-        // 起きているか参加者に伝わらない)。
-        const friendly = (() => {
-          switch (err.errorCode) {
-            case "scoring_not_started":
-              return "競技はまだ開始していません。 運営の開始合図をお待ちください。";
-            case "scoring_ended":
-              return "競技は終了しました。 採点 gate は閉じています。";
-            case "scoring_locked":
-              return "採点が一時停止されています。 運営にお問い合わせください。";
-            default:
-              return `エラー: ${err.errorCode}`;
-          }
-        })();
-        setSubmitError(friendly);
+      // Issue #1006: scoring gate は startsAt / endsAt を含む専用 error。 「あと N 分」 を表示。
+      if (err instanceof PortalScoringGateError) {
+        setSubmitError(describeScoringGate(err));
+      } else if (err instanceof PortalValidationError) {
+        // 旧 path (= backend 古い / 別 error code) の fallback。
+        setSubmitError(`エラー: ${err.errorCode}`);
       } else {
         setSubmitError(err instanceof Error ? err.message : String(err));
       }
@@ -330,7 +350,10 @@ function HintsPanel({
       await revealHint(apiBaseUrl, sessionToken, problemId, hintId);
       await onRevealed();
     } catch (err) {
-      if (err instanceof PortalValidationError) {
+      // Issue #1006: hint reveal も scoring gate (= 競技開始前は開けない) の友好的 message を出す。
+      if (err instanceof PortalScoringGateError) {
+        setRevealError(describeScoringGate(err));
+      } else if (err instanceof PortalValidationError) {
         setRevealError(`バリデーションエラー: ${err.errorCode}`);
       } else {
         setRevealError(err instanceof Error ? err.message : String(err));

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -154,10 +154,14 @@ app.post("/portal/me/submit-flag", (c) =>
       if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
       if (outcome.kind === "no_outputs") return respondError(c, "no_outputs");
       if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
-      // Issue #13 / scoring gate: 競技開始前 / 終了後の提出は raw outcome を 409 で返し、
-      // UI で「競技開始までお待ちください」 / 「競技は終了しました」 の文言に分岐させる。
-      if (outcome.kind === "scoring_not_started") return respondError(c, "scoring_not_started");
-      if (outcome.kind === "scoring_ended") return respondError(c, "scoring_ended");
+      // Issue #13 / #1006: scoring gate failures に startsAt / endsAt を含めて返す。
+      // UI で 「競技開始まで N 分」 / 「競技は X 終了しました」 を出せるようにする。
+      if (outcome.kind === "scoring_not_started") {
+        return respondError(c, "scoring_not_started", { startsAt: outcome.startsAt });
+      }
+      if (outcome.kind === "scoring_ended") {
+        return respondError(c, "scoring_ended", { endsAt: outcome.endsAt });
+      }
       return c.json(outcome, HTTP_OK);
     },
     RATE_LIMITS.WRITE_VERY_LOW,
@@ -184,9 +188,13 @@ app.post("/portal/me/problems/:problemId/hints/:hintId/reveal", (c) =>
       if (outcome.kind === "unauthorized") return respondError(c, "unauthorized");
       if (outcome.kind === "not_flag_problem") return respondError(c, "not_flag_problem");
       if (outcome.kind === "unknown_hint") return respondError(c, "unknown_hint");
-      // Issue #1005: scoring gate failures are the same 409 family as submit-flag.
-      if (outcome.kind === "scoring_not_started") return respondError(c, "scoring_not_started");
-      if (outcome.kind === "scoring_ended") return respondError(c, "scoring_ended");
+      // Issue #1005 / #1006: scoring gate failures with startsAt / endsAt context.
+      if (outcome.kind === "scoring_not_started") {
+        return respondError(c, "scoring_not_started", { startsAt: outcome.startsAt });
+      }
+      if (outcome.kind === "scoring_ended") {
+        return respondError(c, "scoring_ended", { endsAt: outcome.endsAt });
+      }
       if (outcome.kind === "scoring_locked") return respondError(c, "scoring_locked");
       // ok / already_revealed どちらも 200 で content + score を返す (= idempotent UX)。
       return c.json(outcome, HTTP_OK);

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -57,7 +57,17 @@ const ERROR_STATUS = {
 
 export type ErrorKind = keyof typeof ERROR_STATUS;
 
-export function respondError(c: Context, kind: ErrorKind) {
+export function respondError(
+  c: Context,
+  kind: ErrorKind,
+  extras?: Readonly<Record<string, unknown>>,
+) {
+  // Issue #1006: scoring_not_started / scoring_ended では startsAt / endsAt を body に含めて
+  // UI が 「競技開始まで N 分」 等の親切な文言を出せるようにする。 旧来は { error: kind } のみで
+  // ユーザーが 「いつ始まるのか」 分からず迷子になっていた。
+  if (extras && Object.keys(extras).length > 0) {
+    return c.json({ error: kind, ...extras }, ERROR_STATUS[kind]);
+  }
   return c.json({ error: kind }, ERROR_STATUS[kind]);
 }
 


### PR DESCRIPTION
## Summary

「スケジュールで event を開催しても答えを提出できない」 報告に対して、 backend gate は正しく
動いていることを確認し、 「いつ開始 / 終わるかを UI に伝える」 形で UX を直す。

- backend: respondError に extras を追加、 scoring_not_started / scoring_ended に
  startsAt / endsAt を body に含めて返す (= 409 のまま)
- frontend: PortalScoringGateError class を新設、 portalFetch で 409 を専用 throw、
  ProblemPanel の describeScoringGate(err) で 「競技開始まで約 N 分です (開始予定: HH:MM)」
  のような人間可読 message を生成

## Test plan

- [x] bun --filter @TenkaCloud/infrastructure test: **1278 tests** passed
- [x] bun --filter @TenkaCloud/participant-portal test: **159 tests** passed
- [x] typecheck both clean

## Regression 分析

- 旧 PortalValidationError fallback 経路は維持 (= backend 古い deploy との互換)
- backend body shape は super-set 拡張 (= 旧 client は body の追加 field を無視)
- PortalScoringGateError は新 class、 既存 catch (PortalValidationError) は throw されない場合の挙動を残す

## 物理影響

- CFn: **NO-OP**
- backend: route-helpers + 2 route handler だけ、 既存 mock test は body 追加で動作維持

Closes #1006