### PR TITLE
docs(#995): SystemAdmin email 変更動線を UI で案内 (Cognito Username 仕様の不変性)

### DIFF
--- a/apps/admin-console/src/pages/SystemUsers.tsx
+++ b/apps/admin-console/src/pages/SystemUsers.tsx
@@ -182,6 +182,17 @@ export function SystemUsersPage({ config }: { config: AppConfig }) {
         SystemAdmin user 管理
       </Header>
 
+      {/* Issue #995: email = Cognito Username なので 「email 変更」 は技術的に不可。
+       *   行き先がよく分からないユーザーに、 ここで明示する (= 「変更ボタンが無い」 を
+       *   操作的にカバー)。 */}
+      <Alert type="info" header="Email を変更したい場合">
+        SystemAdmin user の email は Cognito Username に紐付いているため変更できません (= AWS
+        Cognito の仕様)。 新しい email で SystemAdmin を 1 人 「招待」 してログイン確認した後、 旧
+        user の 「削除」 を実行してください (= 自分自身を削除する経路は server 側 409 で block
+        されるので、 別 SystemAdmin から削除依頼を出すか、 一時的に別 SystemAdmin を
+        立てて操作してください)。
+      </Alert>
+
       {successMessage && (
         <Alert type="success" dismissible onDismiss={() => setSuccessMessage(null)}>
           {successMessage}


### PR DESCRIPTION
## Summary

「SystemAdmin の email を変更できない」 報告に対して、 Cognito UserPool で Username=email を採用している以上技術的に不可な制約を、 UI 上に **明示的な動線** として書く。 招待 → ログイン確認 → 旧 user 削除のワークフローを 1 alert に集約。

## Test plan

- [x] bun --filter @TenkaCloud/admin-console test: 13 file / **126 tests** passed
- [x] bun --filter @TenkaCloud/admin-console typecheck: clean

## Regression 分析

- header 直下に Alert 1 つ追加するのみ
- 既存招待 / role 変更 / 削除動線は無変更
- 「自分自身は削除できない」 制約の文言は既存 server message と一致

## 物理影響

- CFn: **NO-OP**
- frontend のみ、 bundle 影響なし

Closes #995