### PR TITLE
fix(#987): admin-insight Lambda の IAM policy に cognito-idp:ListUsersInGroup を追加

### DIFF
--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -147,7 +147,10 @@ export class AdminInsightApiLambda extends Construct {
     //   - AdminDeleteUser  (= 削除)
     //   - AdminGetUser     (= detail / role 読み取り)
     //   - AdminUpdateUserAttributes (= role 変更)
-    //   - ListUsers        (= 一覧、 page 化)
+    //   - ListUsers        (= 全 user 一覧、 旧 phase 用に維持)
+    //   - ListUsersInGroup (= Issue #987: SystemAdmin / SystemAuditor 別の一覧、
+    //     handler は ListUsersInGroupCommand を使っているのに本 action が欠落していて 500 で
+    //     fail していた)
     //   - AdminAddUserToGroup / AdminRemoveUserFromGroup (= SystemAdmin / SystemAuditor group 操作)
     if (props.controlPlaneUserPool) {
       this.fn.addToRolePolicy(
@@ -159,6 +162,7 @@ export class AdminInsightApiLambda extends Construct {
             "cognito-idp:AdminGetUser",
             "cognito-idp:AdminUpdateUserAttributes",
             "cognito-idp:ListUsers",
+            "cognito-idp:ListUsersInGroup",
             "cognito-idp:AdminAddUserToGroup",
             "cognito-idp:AdminRemoveUserFromGroup",
             "cognito-idp:AdminListGroupsForUser",


### PR DESCRIPTION
## Summary

SystemAdmin Console > SystemAdmin users 一覧の 500 (= image #53) の root cause を fix。

- handler は \`ListUsersInGroupCommand\` を呼ぶが、 admin-insight Lambda の IAM role に
  \`cognito-idp:ListUsersInGroup\` が無く AccessDenied で 500 になっていた
- IAM policy に **1 行追加**: \`cognito-idp:ListUsersInGroup\`
- 同じ ControlPlane UserPool ARN への scope は維持

## Test plan

- [x] bun --filter @TenkaCloud/infrastructure test: 113 file / **1278 tests** passed
- [ ] 再 deploy 後に SystemAdmin Console で 200 (= 既存 user が一覧表示) を確認 (post-merge)

## Regression 分析

- Lambda role の actions が 1 つ増えるだけ、 同 UserPool ARN scope 維持
- 既存 ListUsers / AdminGetUser etc は影響なし
- 越境攻撃面: ListUsersInGroup の読み取り範囲は ListUsers のサブセット (= group filter
  追加版)、 セキュリティ広がりなし

## 物理影響

- CFn: **UPDATE** admin-insight Lambda IAM role (= addToRolePolicy 1 action 追加)
- 既存 deploy では再 deploy 必須 (= deploy 後に 200 で返る)

Closes #987