### PR TITLE
feat(#1003): SSO loginUrl 構成要素長の structured log を追加 (AWS 400 診断補助)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -281,5 +281,24 @@ export async function getConsoleSigninUrl(
   });
   const loginUrl = `${FEDERATION_ENDPOINT}?Action=login&Issuer=${encodeURIComponent(TENKACLOUD_ISSUER)}&Destination=${encodeURIComponent(destination)}&SigninToken=${encodeURIComponent(tokenJson.SigninToken)}`;
 
+  // Issue #1003: AWS Console "400 Bad Request" を発見した時の診断補助。 loginUrl は
+  // typical 1800-2400 文字。 一部 proxy / ブラウザは長い URL を勝手に truncate するので、
+  // 上限を 4096 で警告 + 構成要素長を log に残す (= 「token が破損していたのか URL が長すぎたのか」 を
+  // CloudWatch Logs Insights で切り分け可能にする)。
+  const componentLengths = {
+    issuer: TENKACLOUD_ISSUER.length,
+    destination: destination.length,
+    signinTokenRaw: tokenJson.SigninToken.length,
+    encodedSigninToken: encodeURIComponent(tokenJson.SigninToken).length,
+    total: loginUrl.length,
+  };
+  if (loginUrl.length > 4096) {
+    console.warn("[sso] loginUrl exceeds 4096 chars (may be truncated by proxies)", {
+      jobId,
+      ...componentLengths,
+    });
+  }
+  logDeployTrace("portal.sso.ok", { jobId, problemId, ...componentLengths });
+
   return { kind: "ok", loginUrl };
 }


### PR DESCRIPTION
## Summary

ユーザーが participant-portal の 「AWS Console を開く」 経由で AWS 400 Bad Request を遭遇する報告 (#1003)。 AWS 側の generic 400 page で根本原因が分からないので、 sso.ts の最終 loginUrl 直後に **構成要素長の structured log** を出して CloudWatch Logs Insights で diagnosis 可能にする。

**注**: 本 PR は診断補助のみで root-cause fix ではない。 deploy 後の log で 「URL 長すぎ」 / 「Issuer フィールド長異常」 / 「SigninToken 短すぎ」 を切り分けて、 後続 PR で本格 fix する。

## Test plan

- [x] bun --filter @TenkaCloud/infrastructure test: 113 file / **1278 tests** passed (sso.test.ts 既存 8 件 pass)

## Regression 分析

- logDeployTrace は既存 11 箇所と同形式、 副作用なし
- 戻り値 shape 不変

## 物理影響

- CFn: **NO-OP**
- CloudWatch Logs 量: SSO 1 操作 = +1 log line (rare path)

Relates #1003 (= 診断補助、 issue は open のまま fix PR を待つ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSO login diagnostics with warnings when login URLs exceed maximum length limits, displaying component details to identify potential truncation issues.
  * Added structured logging for successful SSO operations to improve troubleshooting and monitoring capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->