### PR TITLE
fix(#993): lcov.info の SF: パスを workspace prefix で補正 (Codecov 表示空問題)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
     "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test",
-    "test:coverage": "bun run --filter @TenkaCloud/infrastructure test:coverage && bun run --filter @TenkaCloud/admin-console test:coverage && bun run --filter @TenkaCloud/application-admin-console test:coverage && bun run --filter @TenkaCloud/participant-portal test:coverage && bun run --filter @TenkaCloud/trust-bridge test:coverage",
+    "test:coverage": "bun run --filter @TenkaCloud/infrastructure test:coverage && bun run --filter @TenkaCloud/admin-console test:coverage && bun run --filter @TenkaCloud/application-admin-console test:coverage && bun run --filter @TenkaCloud/participant-portal test:coverage && bun run --filter @TenkaCloud/trust-bridge test:coverage && bun run scripts/fix-coverage-paths.ts",
     "validate:problems": "bun run scripts/validate-problems.ts",
     "build:problems-index": "bun run scripts/build-problem-index.ts",
     "check:problems-index": "bun run scripts/build-problem-index.ts --check",

--- a/scripts/fix-coverage-paths.ts
+++ b/scripts/fix-coverage-paths.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * Issue #993: Codecov 上の coverage が空になる問題への post-process。
+ *
+ * vitest --coverage が生成する `apps/<x>/coverage/lcov.info` の SF: 行は
+ * **workspace-root 相対** (= `SF:src/foo.ts`) で書かれる。 Codecov はこの SF を
+ * repo root から見ようとして file が見つからず、 全行 0% 計算になっていた。
+ *
+ * 本 script は各 workspace の lcov.info を読み、 `SF:` 行を workspace dir で prefix する。
+ * 例: `apps/admin-console/coverage/lcov.info` の `SF:src/api/foo.ts`
+ *   → `SF:apps/admin-console/src/api/foo.ts`
+ *
+ * 同様の処理は本来 vitest config の `coverage.processFile` などで吸収できるが、
+ * CLAUDE.md の 「設定ファイル直接変更禁止」 と整合させるため CLI 後段で処理する。
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const WORKSPACES = [
+  "infrastructure",
+  "apps/admin-console",
+  "apps/application-admin-console",
+  "apps/participant-portal",
+  "packages/trust-bridge",
+] as const;
+
+let fixed = 0;
+let skipped = 0;
+for (const ws of WORKSPACES) {
+  const path = resolve(process.cwd(), ws, "coverage/lcov.info");
+  if (!existsSync(path)) {
+    console.log(`  skip: ${ws}/coverage/lcov.info (not found)`);
+    skipped++;
+    continue;
+  }
+  const content = readFileSync(path, "utf8");
+  // SF: が既に "apps/" / "infrastructure/" / "packages/" で始まっている場合は skip
+  // (= 二重 prefix 防止、 idempotent)
+  if (/^SF:(apps|infrastructure|packages)\//m.test(content)) {
+    console.log(`  skip: ${ws}/coverage/lcov.info (already prefixed)`);
+    skipped++;
+    continue;
+  }
+  const updated = content.replace(/^SF:/gm, `SF:${ws}/`);
+  writeFileSync(path, updated, "utf8");
+  console.log(`  fix:  ${ws}/coverage/lcov.info`);
+  fixed++;
+}
+
+console.log(`fix-coverage-paths: ${fixed} fixed, ${skipped} skipped`);


### PR DESCRIPTION
## Summary

PR-1011 で全 workspace の coverage upload は通っているのに Codecov dashboard が空のまま (= 「やっぱり上がっていない」 報告)。 root cause: lcov.info の \`SF:\` 行が **workspace-root 相対** (例: \`SF:src/api/foo.ts\`) で書かれていて、 Codecov が repo root から解決できず source not found 扱いで集計が 0% になっていた。

scripts/fix-coverage-paths.ts を post-process として追加し、 各 workspace の lcov.info の \`SF:\` 行を workspace prefix で書き換える (= idempotent)。

## Test plan

- [x] 手動 smoke: \`bun run --filter @TenkaCloud/admin-console test:coverage && bun run scripts/fix-coverage-paths.ts\` で \`SF:src/api/admin-drill-down.ts\` → \`SF:apps/admin-console/src/api/admin-drill-down.ts\` に書き換わることを確認
- [x] 二度実行しても idempotent (= 既存 prefix を検出して skip)
- [ ] CI で Codecov に coverage が表示されることを確認 (post-merge)

## Regression 分析

- PR-1011 の test:coverage 配線は維持、 末尾 1 script を追加
- vitest.config.ts は無変更 (CLAUDE.md 「設定ファイル直接変更禁止」 と整合)
- local dev \`make test\` は影響なし

## 物理影響

- CFn: **NO-OP**
- CI: 数 ms の sed-like 処理を追加

#993 の fix follow-up (= PR-1011 で bug)