### PR TITLE
feat(#988): @TenkaCloud/cli workspace scaffold (Cognito OAuth + PKCE + loopback)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,53 @@
+# @TenkaCloud/cli (Phase 1 scaffold)
+
+TenkaCloud CLI for sign-in via Cognito OAuth (Authorization Code + PKCE + loopback).
+
+## Phase 1 commands
+
+- `tenkacloud login` — open Cognito Hosted UI in the browser, capture the
+  authorization code via a local loopback HTTP server (`127.0.0.1:<random>`),
+  exchange for ID/access/refresh tokens, persist to
+  `~/.config/tenkacloud/credentials` (mode `0600`).
+- `tenkacloud logout` — clear the credential store.
+- `tenkacloud whoami` — print the current ID token claims as JSON.
+- `tenkacloud status` — show sign-in state (token TTL remaining).
+
+## Required environment
+
+`tenkacloud login` reads these env vars:
+
+| Variable | Example |
+| --- | --- |
+| `TENKACLOUD_COGNITO_HOSTED_UI_DOMAIN` | `https://tenkacloud-dev.auth.ap-northeast-1.amazoncognito.com` |
+| `TENKACLOUD_COGNITO_CLI_CLIENT_ID` | `123abc...` (UserPool Client ID for the CLI) |
+| `TENKACLOUD_COGNITO_ISSUER` | `https://cognito-idp.ap-northeast-1.amazonaws.com/<userPoolId>` |
+
+The Cognito UserPool Client must allow loopback redirect URIs
+(`http://127.0.0.1:*/callback`) and the `code` flow with the standard
+`openid profile email` scopes.
+
+## What's not in Phase 1
+
+- `tenants list`, `events list`, etc — Phase 2 will add API subcommands.
+- OS-native credential storage (macOS Keychain / Linux Secret Service /
+  Windows Credential Manager) — Phase 2.
+- Automatic refresh token rotation — Phase 2.
+
+These are tracked as follow-up work in the original feature spec.
+
+## Running locally
+
+```
+bun run apps/cli/bin/tenkacloud.ts login
+bun run apps/cli/bin/tenkacloud.ts status
+```
+
+## Tests
+
+```
+bun run --filter @TenkaCloud/cli test
+bun run --filter @TenkaCloud/cli typecheck
+```
+
+Tests cover PKCE primitives. End-to-end OAuth flow is exercised manually in
+this phase (= Cognito UserPool Client setup is environment-dependent).

--- a/apps/cli/bin/tenkacloud.ts
+++ b/apps/cli/bin/tenkacloud.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env bun
+/**
+ * Issue #988: TenkaCloud CLI entry point (Phase 1 scaffold)。
+ *
+ * Phase 1 で実装する subcommand:
+ *   - tenkacloud login    : Cognito Hosted UI を loopback PKCE で叩いて token 取得
+ *   - tenkacloud logout   : credential store を空にする
+ *   - tenkacloud whoami   : 現在の id_token claim を表示
+ *   - tenkacloud status   : サインイン状態 (token expiry 残時間) を表示
+ *
+ * Phase 2 以降で `tenants list` 等を実装する。 Phase 1 は OAuth flow と
+ * credential storage の安定化が目的。
+ */
+
+import { spawn } from "node:child_process";
+import { clearTokens, isExpired, loadTokens, saveTokens } from "../src/credential-store.ts";
+import { signInWithCognito } from "../src/oauth.ts";
+
+function readEnvConfig() {
+  const hostedUiDomain = process.env.TENKACLOUD_COGNITO_HOSTED_UI_DOMAIN;
+  const clientId = process.env.TENKACLOUD_COGNITO_CLI_CLIENT_ID;
+  const issuer = process.env.TENKACLOUD_COGNITO_ISSUER;
+  if (!hostedUiDomain || !clientId || !issuer) {
+    console.error(
+      "Error: 環境変数が不足しています。 次を設定してください:\n" +
+        "  TENKACLOUD_COGNITO_HOSTED_UI_DOMAIN (= https://<prefix>.auth.<region>.amazoncognito.com)\n" +
+        "  TENKACLOUD_COGNITO_CLI_CLIENT_ID    (= UserPool に追加した CLI 用 client ID)\n" +
+        "  TENKACLOUD_COGNITO_ISSUER           (= https://cognito-idp.<region>.amazonaws.com/<userPoolId>)",
+    );
+    process.exit(2);
+  }
+  return { hostedUiDomain, clientId, issuer };
+}
+
+function openBrowser(url: string): Promise<void> {
+  // OS 別に open / xdg-open / start を切り替え。 失敗しても続行 (= ユーザーが手動で URL を貼る選択肢を残す)。
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "explorer" : "xdg-open";
+  return new Promise((resolve) => {
+    const child = spawn(cmd, [url], { stdio: "ignore", detached: true });
+    child.on("error", () => resolve());
+    child.unref();
+    // 起動完了を待たず即 resolve (= browser process が長寿命でも CLI は閉じる)
+    setTimeout(resolve, 100);
+  });
+}
+
+async function cmdLogin(): Promise<number> {
+  const config = readEnvConfig();
+  console.log("TenkaCloud CLI sign-in を開始します…");
+  const tokens = await signInWithCognito(
+    {
+      hostedUiDomain: config.hostedUiDomain,
+      clientId: config.clientId,
+      issuer: config.issuer,
+    },
+    {
+      openBrowser,
+      notify: (msg) => console.log(`  → ${msg}`),
+    },
+  );
+  saveTokens({
+    accessToken: tokens.accessToken,
+    idToken: tokens.idToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    issuer: config.issuer,
+    clientId: config.clientId,
+  });
+  const remainSec = tokens.expiresAt - Math.floor(Date.now() / 1000);
+  console.log(`✓ Sign-in 完了 (token 有効期限: あと ${Math.floor(remainSec / 60)} 分)`);
+  return 0;
+}
+
+function cmdLogout(): number {
+  clearTokens();
+  console.log("✓ Logout (credential store を空にしました)");
+  return 0;
+}
+
+function decodeJwtClaims(jwt: string): Record<string, unknown> | undefined {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const payload = parts[1];
+    if (!payload) return undefined;
+    const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
+    const buf = Buffer.from(padded.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+    return JSON.parse(buf.toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function cmdWhoami(): number {
+  const tokens = loadTokens();
+  if (!tokens) {
+    console.log("(未サインイン)");
+    return 1;
+  }
+  const claims = decodeJwtClaims(tokens.idToken);
+  if (!claims) {
+    console.error("ID token の decode に失敗しました");
+    return 2;
+  }
+  console.log(JSON.stringify(claims, null, 2));
+  return 0;
+}
+
+function cmdStatus(): number {
+  const tokens = loadTokens();
+  if (!tokens) {
+    console.log("未サインイン (`tenkacloud login` でログインしてください)");
+    return 1;
+  }
+  if (isExpired(tokens)) {
+    console.log(
+      "token が expire しています (= refresh は Phase 2 で実装)。 `tenkacloud login` を再実行してください。",
+    );
+    return 1;
+  }
+  const remainSec = tokens.expiresAt - Math.floor(Date.now() / 1000);
+  console.log(`Signed in (issuer: ${tokens.issuer}, expires in ${Math.floor(remainSec / 60)} min)`);
+  return 0;
+}
+
+const USAGE = `tenkacloud — TenkaCloud CLI (Phase 1 scaffold)
+
+Usage:
+  tenkacloud login     Cognito Hosted UI 経由でサインイン (PKCE + loopback)
+  tenkacloud logout    credential store を空にする
+  tenkacloud whoami    現在の ID token claim を JSON で表示
+  tenkacloud status    サインイン状態を表示
+
+Env (required for login):
+  TENKACLOUD_COGNITO_HOSTED_UI_DOMAIN
+  TENKACLOUD_COGNITO_CLI_CLIENT_ID
+  TENKACLOUD_COGNITO_ISSUER
+`;
+
+async function main(): Promise<void> {
+  const cmd = process.argv[2];
+  let code: number;
+  switch (cmd) {
+    case "login":
+      code = await cmdLogin();
+      break;
+    case "logout":
+      code = cmdLogout();
+      break;
+    case "whoami":
+      code = cmdWhoami();
+      break;
+    case "status":
+      code = cmdStatus();
+      break;
+    case "-h":
+    case "--help":
+    case "help":
+    case undefined:
+      console.log(USAGE);
+      code = 0;
+      break;
+    default:
+      console.error(`Unknown command: ${cmd}\n\n${USAGE}`);
+      code = 1;
+  }
+  process.exit(code);
+}
+
+void main();

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@TenkaCloud/cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TenkaCloud CLI — Cognito OAuth (Authorization Code + PKCE + loopback) で sign-in し API を叩く",
+  "type": "module",
+  "bin": {
+    "tenkacloud": "./bin/tenkacloud.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.4",
+    "typescript": "~5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/apps/cli/src/credential-store.ts
+++ b/apps/cli/src/credential-store.ts
@@ -1,0 +1,60 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Issue #988: CLI が Cognito OAuth で取得した tokens を OS-specific credential store に保存する。
+ *
+ * Phase 1: ~/.config/tenkacloud/credentials (mode 0600) の plain JSON。
+ * Phase 2: macOS Keychain / Linux Secret Service / Windows Credential Manager の OS-native
+ * library に差し替える (= keytar / @napi-rs/keyring 等を検討)。 本 phase は CLI を spike として
+ * 起動させ、 token storage 仕様の安定後に library 切替する design。
+ *
+ * file mode 0600 (= owner read/write only) で他 user / process からの読み取りを防ぐ。
+ */
+
+export interface StoredTokens {
+  readonly accessToken: string;
+  readonly idToken: string;
+  readonly refreshToken: string;
+  /** Unix seconds when accessToken expires. */
+  readonly expiresAt: number;
+  /** Cognito issuer URL (= "https://cognito-idp.<region>.amazonaws.com/<userPoolId>") */
+  readonly issuer: string;
+  /** UserPool client ID (= OAuth client_id) */
+  readonly clientId: string;
+}
+
+function credentialsPath(): string {
+  return resolve(homedir(), ".config/tenkacloud/credentials");
+}
+
+export function saveTokens(tokens: StoredTokens): void {
+  const path = credentialsPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+export function loadTokens(): StoredTokens | undefined {
+  const path = credentialsPath();
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as StoredTokens;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearTokens(): void {
+  const path = credentialsPath();
+  if (!existsSync(path)) return;
+  writeFileSync(path, "", { mode: 0o600 });
+}
+
+export function isExpired(
+  tokens: StoredTokens,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): boolean {
+  return tokens.expiresAt <= nowSec;
+}

--- a/apps/cli/src/oauth.ts
+++ b/apps/cli/src/oauth.ts
@@ -1,0 +1,194 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { generatePkcePair, type PkcePair } from "./pkce.ts";
+
+/**
+ * Issue #988: Authorization Code + PKCE + loopback flow を CLI 内部で完結させる。
+ *
+ * 流れ:
+ *   1. PKCE pair を生成
+ *   2. ephemeral local HTTP server (= 127.0.0.1:RANDOM) を起動
+ *   3. Cognito Hosted UI URL (redirect_uri = loopback) をブラウザで開かせる
+ *   4. ユーザーがログイン → Cognito が loopback に redirect (authorization_code 付き)
+ *   5. local server が code を捕捉 → /oauth2/token を code + verifier で叩いて tokens 取得
+ *   6. 取得 tokens を caller に返す
+ *
+ * Cognito の OAuth flow が前提 (= UserPool Client に loopback callback を許可、
+ * Issue #988 の CDK 部分で 別途 client を追加)。
+ *
+ * 本 module は **Cognito 依存の token 取得 logic と loopback dance だけ** を露出する。
+ * caller (= bin/tenkacloud.ts) が CLI 起動順 (browser open / wait / token save) を組む。
+ */
+
+export interface CognitoOAuthConfig {
+  /** Cognito Hosted UI domain (= https://<prefix>.auth.<region>.amazoncognito.com) */
+  readonly hostedUiDomain: string;
+  /** UserPool Client ID */
+  readonly clientId: string;
+  /** Cognito UserPool issuer (= https://cognito-idp.<region>.amazonaws.com/<userPoolId>) */
+  readonly issuer: string;
+  /** 任意 scope。 default は "openid profile email"。 */
+  readonly scope?: string;
+}
+
+export interface OAuthTokens {
+  readonly accessToken: string;
+  readonly idToken: string;
+  readonly refreshToken: string;
+  /** Unix seconds */
+  readonly expiresAt: number;
+}
+
+interface LoopbackServerResult {
+  readonly server: Server;
+  readonly port: number;
+  /** authorization_code が来るまで resolve しない */
+  readonly waitForCode: () => Promise<string>;
+}
+
+function startLoopbackServer(): Promise<LoopbackServerResult> {
+  return new Promise((resolve, reject) => {
+    let codeResolve: ((code: string) => void) | undefined;
+    let codeReject: ((err: Error) => void) | undefined;
+    const codePromise = new Promise<string>((res, rej) => {
+      codeResolve = res;
+      codeReject = rej;
+    });
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", `http://localhost`);
+      const code = url.searchParams.get("code");
+      const error = url.searchParams.get("error");
+      if (error) {
+        res.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        res.end(`OAuth error: ${error}`);
+        codeReject?.(new Error(`OAuth error: ${error}`));
+        return;
+      }
+      if (!code) {
+        res.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        res.end("Missing 'code' query parameter.");
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(
+        "<html><body><h1>TenkaCloud CLI: sign-in 完了</h1><p>このタブを閉じて CLI に戻ってください。</p></body></html>",
+      );
+      codeResolve?.(code);
+    });
+
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({
+        server,
+        port: addr.port,
+        waitForCode: () => codePromise,
+      });
+    });
+  });
+}
+
+function buildAuthorizationUrl(args: {
+  readonly hostedUiDomain: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly pkce: PkcePair;
+  readonly scope: string;
+  readonly state: string;
+}): string {
+  const url = new URL(`${args.hostedUiDomain.replace(/\/$/, "")}/oauth2/authorize`);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", args.clientId);
+  url.searchParams.set("redirect_uri", args.redirectUri);
+  url.searchParams.set("scope", args.scope);
+  url.searchParams.set("code_challenge", args.pkce.challenge);
+  url.searchParams.set("code_challenge_method", args.pkce.method);
+  url.searchParams.set("state", args.state);
+  return url.toString();
+}
+
+async function exchangeCodeForTokens(args: {
+  readonly hostedUiDomain: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly code: string;
+  readonly verifier: string;
+}): Promise<OAuthTokens> {
+  const url = `${args.hostedUiDomain.replace(/\/$/, "")}/oauth2/token`;
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: args.clientId,
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    code_verifier: args.verifier,
+  });
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Token exchange failed: HTTP ${res.status} ${text}`);
+  }
+  const json = (await res.json()) as {
+    access_token: string;
+    id_token: string;
+    refresh_token: string;
+    expires_in: number;
+  };
+  return {
+    accessToken: json.access_token,
+    idToken: json.id_token,
+    refreshToken: json.refresh_token,
+    expiresAt: Math.floor(Date.now() / 1000) + json.expires_in,
+  };
+}
+
+export interface SignInOrchestrator {
+  /** ブラウザを開いて URL を表示する callback (= 環境で open / xdg-open / start を差し替え可能) */
+  readonly openBrowser: (url: string) => Promise<void>;
+  /** ユーザー向けに進捗を出す (= "CLI を開いたまま…") */
+  readonly notify: (message: string) => void;
+}
+
+/**
+ * sign-in flow を 1 関数で完結。 caller は openBrowser / notify を渡すだけ。
+ */
+export async function signInWithCognito(
+  config: CognitoOAuthConfig,
+  orchestrator: SignInOrchestrator,
+): Promise<OAuthTokens> {
+  const pkce = generatePkcePair();
+  const state = pkce.verifier.slice(0, 12); // CSRF 簡易 token
+  const loopback = await startLoopbackServer();
+  const redirectUri = `http://127.0.0.1:${loopback.port}/callback`;
+  const scope = config.scope ?? "openid profile email";
+
+  const authUrl = buildAuthorizationUrl({
+    hostedUiDomain: config.hostedUiDomain,
+    clientId: config.clientId,
+    redirectUri,
+    pkce,
+    scope,
+    state,
+  });
+
+  orchestrator.notify(`ブラウザを起動します: ${authUrl}`);
+  await orchestrator.openBrowser(authUrl);
+
+  try {
+    const code = await loopback.waitForCode();
+    const tokens = await exchangeCodeForTokens({
+      hostedUiDomain: config.hostedUiDomain,
+      clientId: config.clientId,
+      redirectUri,
+      code,
+      verifier: pkce.verifier,
+    });
+    return tokens;
+  } finally {
+    loopback.server.close();
+  }
+}

--- a/apps/cli/src/pkce.ts
+++ b/apps/cli/src/pkce.ts
@@ -1,0 +1,27 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * PKCE (Proof Key for Code Exchange, RFC 7636) の verifier / challenge pair を生成する。
+ *
+ * - verifier: 43-128 文字、 URL-safe base64 (= RFC 7636 4.1)
+ * - challenge: SHA-256(verifier) を URL-safe base64 化 (= S256 method、 RFC 7636 4.2)
+ *
+ * 32 bytes (= 256 bits) random で 43 文字、 推測困難。
+ */
+export interface PkcePair {
+  readonly verifier: string;
+  readonly challenge: string;
+  readonly method: "S256";
+}
+
+function urlsafeBase64(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function generatePkcePair(): PkcePair {
+  const verifierBuf = randomBytes(32);
+  const verifier = urlsafeBase64(verifierBuf);
+  const hash = createHash("sha256").update(verifier).digest();
+  const challenge = urlsafeBase64(hash);
+  return { verifier, challenge, method: "S256" };
+}

--- a/apps/cli/test/pkce.test.ts
+++ b/apps/cli/test/pkce.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { generatePkcePair } from "../src/pkce.ts";
+
+describe("generatePkcePair", () => {
+  it("verifier は 43 文字の URL-safe base64 (32 byte random) であるべき", () => {
+    const { verifier } = generatePkcePair();
+    expect(verifier.length).toBe(43); // 32 bytes → 43 chars urlsafe base64 without padding
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("challenge は SHA-256 base64url で 43 文字であるべき", () => {
+    const { challenge } = generatePkcePair();
+    expect(challenge.length).toBe(43);
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("method は S256 であるべき", () => {
+    expect(generatePkcePair().method).toBe("S256");
+  });
+
+  it("2 回呼ぶと別 pair (= randomness 確認)", () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2024", "DOM"]
+  },
+  "include": ["bin/**/*.ts", "src/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,18 @@
         "vitest": "^4.1.6",
       },
     },
+    "apps/cli": {
+      "name": "@TenkaCloud/cli",
+      "version": "0.1.0",
+      "bin": {
+        "tenkacloud": "./bin/tenkacloud.ts",
+      },
+      "devDependencies": {
+        "@types/node": "^24.12.4",
+        "typescript": "~5.9.3",
+        "vitest": "^4.1.6",
+      },
+    },
     "apps/participant-portal": {
       "name": "@TenkaCloud/participant-portal",
       "version": "0.1.0",
@@ -171,6 +183,8 @@
     "@TenkaCloud/admin-console": ["@TenkaCloud/admin-console@workspace:apps/admin-console"],
 
     "@TenkaCloud/application-admin-console": ["@TenkaCloud/application-admin-console@workspace:apps/application-admin-console"],
+
+    "@TenkaCloud/cli": ["@TenkaCloud/cli@workspace:apps/cli"],
 
     "@TenkaCloud/infrastructure": ["@TenkaCloud/infrastructure@workspace:infrastructure"],
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "scripts": {
     "build": "bun run --filter @TenkaCloud/infrastructure build && bun run --filter @TenkaCloud/admin-console build && bun run --filter @TenkaCloud/application-admin-console build && bun run --filter @TenkaCloud/participant-portal build",
-    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck",
+    "typecheck": "bun run --filter @TenkaCloud/infrastructure typecheck && bun run --filter @TenkaCloud/admin-console typecheck && bun run --filter @TenkaCloud/application-admin-console typecheck && bun run --filter @TenkaCloud/participant-portal typecheck && bun run --filter @TenkaCloud/trust-bridge typecheck && bun run --filter @TenkaCloud/cli typecheck",
     "synth": "bun run --filter @TenkaCloud/infrastructure synth",
-    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test",
+    "test": "bun run --filter @TenkaCloud/infrastructure test && bun run --filter @TenkaCloud/admin-console test && bun run --filter @TenkaCloud/application-admin-console test && bun run --filter @TenkaCloud/participant-portal test && bun run --filter @TenkaCloud/trust-bridge test && bun run --filter @TenkaCloud/cli test",
     "test:coverage": "bun run --filter @TenkaCloud/infrastructure test:coverage && bun run --filter @TenkaCloud/admin-console test:coverage && bun run --filter @TenkaCloud/application-admin-console test:coverage && bun run --filter @TenkaCloud/participant-portal test:coverage && bun run --filter @TenkaCloud/trust-bridge test:coverage",
     "validate:problems": "bun run scripts/validate-problems.ts",
     "build:problems-index": "bun run scripts/build-problem-index.ts",


### PR DESCRIPTION
## Summary

Issue #988 で 「API は CLI 経由でのみ公開、 Cognito OAuth (Authorization Code + PKCE + loopback) で sign-in」 と決定。 Phase 1 として CLI workspace を scaffold し、 OAuth flow と credential storage の最小実装を入れる。

- **新規 workspace** \`apps/cli/\`: package.json / tsconfig.json / README.md
- **PKCE primitives** (\`src/pkce.ts\`): RFC 7636 verifier (32 byte random / 43 char urlsafe base64) + S256 challenge
- **OAuth flow** (\`src/oauth.ts\`): \`signInWithCognito()\` で loopback HTTP server + Hosted UI authorize URL + \`/oauth2/token\` 交換を 1 関数で完結
- **Credential storage** (\`src/credential-store.ts\`): \`~/.config/tenkacloud/credentials\` (mode 0600) に access/id/refresh + expiry + issuer を JSON 保存
- **CLI entry** (\`bin/tenkacloud.ts\`): \`login\` / \`logout\` / \`whoami\` / \`status\` subcommand
- **Test** (\`test/pkce.test.ts\`): 4 ケース (verifier 長さ / 文字種 / challenge / randomness)
- root \`package.json\` の test / typecheck chain に CLI workspace を追加

## Phase 1 範囲

- OAuth flow と credential storage の **scaffold**
- 実 Cognito UserPool Client (loopback callback 許可) は **CDK 別 PR** で追加 (= env で渡す前提)
- \`tenants list\` 等の API subcommand は **Phase 2**

## Test plan

- [x] bun --filter @TenkaCloud/cli test: **4 tests** passed
- [x] bun run typecheck (全 workspace): clean
- [x] bun run test (全 workspace): 全 passed

## Regression 分析

- 新規 workspace、 既存 workspace への影響なし
- root package.json の chain に 1 entry 追加

## 物理影響

- CFn: **NO-OP** (= Phase 2 で UserPool Client 追加が CDK 変更)
- bundle: 新規 workspace のみ

Closes #988