### PR TITLE
docs(#1023): define launch funnel and LP activation strategy

### DIFF
--- a/docs/product/launch-funnel.md
+++ b/docs/product/launch-funnel.md
@@ -1,0 +1,165 @@
+# TenkaCloud Launch Funnel
+
+Related: #1023
+
+## Why
+
+TenkaCloud already has deep platform architecture and a working OSS footprint, but first-time visitors still need to read and infer the value before they can feel it.
+
+The launch funnel should move from:
+
+```text
+Read → Understand → Imagine
+```
+
+to:
+
+```text
+See → Try → Understand
+```
+
+The first external audience should not be asked to understand the whole platform up front. They should reach a visible cloud competition experience quickly.
+
+## Primary audience for the first launch
+
+Optimize the landing page for one buyer/user first:
+
+> Teams that need to turn internal cloud training into hands-on exercises.
+
+Secondary audiences can remain visible, but they should not compete with the hero message:
+
+- SRE / incident response drills
+- Security training
+- AWS partner enablement
+- Community hackathons
+- Hiring skill checks
+- Schools and bootcamps
+
+## Hero positioning
+
+Current broad positioning:
+
+```text
+Cloud skill is measured in the wild.
+Compete on real AWS — build it, defend it, optimize it.
+```
+
+Sharper launch positioning:
+
+```text
+Turn internal cloud training into hands-on exercises in minutes.
+AWS GameDay-style experiences with automated environment provisioning, scoring, and reusable scenarios.
+```
+
+Japanese candidate:
+
+```text
+社内クラウド研修を、5分で実戦演習に。
+AWS GameDay のような演習を OSS で。
+環境払い出し、スコアリング、問題管理を自動化します。
+```
+
+## First CTA
+
+The first CTA should prefer a fast product experience over source-code reading.
+
+Recommended CTA order:
+
+1. Try in 3 minutes
+2. View on GitHub
+
+Until a hosted demo exists, the CTA can point to the most guided path available:
+
+- `problems/hello-world`
+- a static demo page
+- a demo video
+- a local quickstart
+
+## Activation funnel
+
+Track these events once analytics is introduced:
+
+```text
+landing_view
+  ↓
+hero_try_clicked
+  ↓
+demo_started
+  ↓
+challenge_completed
+  ↓
+problem_authoring_started
+  ↓
+problem_created
+```
+
+## Success criteria
+
+### Visitor activation
+
+- A new visitor can understand the product category in 5 seconds.
+- A new visitor can start a visible demo in 3 minutes.
+- A new visitor can complete the first challenge in 5 minutes.
+
+### Problem author activation
+
+- A new problem author can create a minimal problem in 30 minutes.
+- The authoring path includes validation, local preview, and packaging checks.
+
+### Community sharing
+
+- A 30-second demo video exists.
+- The LP can be shared without requiring readers to inspect the repository first.
+- The README and LP point to the same first experience.
+
+## Suggested implementation phases
+
+### Phase 1: LP copy and CTA
+
+- Replace the hero with the sharper internal-training message.
+- Reorder CTA buttons so the first action is a guided trial.
+- Keep GitHub as a secondary CTA.
+- Add a short `For training teams` section above the generic audience section.
+
+### Phase 2: no-AWS demo path
+
+- Add a static `hello-world` demo path that does not require an AWS account.
+- Simulate score changes and challenge completion.
+- Make the demo good enough for a 30-second video.
+
+### Phase 3: guided problem authoring
+
+- Add a `create-tenkacloud-problem` style scaffold command or equivalent script.
+- Provide one minimal metadata file, one deployable asset, and one scoring probe.
+- Add validation errors that explain what to fix.
+
+### Phase 4: signed achievement model
+
+Do not start with NFT or on-chain credentials.
+
+Start with:
+
+```text
+signed result JSON
+  ↓
+public profile / shareable certificate
+  ↓
+W3C Verifiable Credential
+  ↓
+optional on-chain proof
+```
+
+This keeps the product focused on proof of skill rather than speculative tokens.
+
+## Non-goals for the first launch
+
+Avoid adding these before first community feedback:
+
+- Multi-cloud support
+- Marketplace mechanics
+- NFT issuance
+- Full credential graph
+- Enterprise SSO polish
+- Complex tournament formats
+
+The next milestone is not feature breadth. It is a first experience that makes people say, "I understand this. I want to run one."

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,1046 +3,443 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>TenkaCloud — クラウド競技を、もっとシンプルに。</title>
-<meta name="description" content="TenkaCloud は本物の AWS で構築・防御・コスト最適化を競う、オープンソースのクラウド競技基盤。Battle / Challenge を 1 イベントに混ぜて使える、Apache 2.0 の SaaS。" />
-<!--
-  Issue #952 / PR-958 follow-up: ウェイトリストの Google Form URL は本 meta tag を
-  書き換えるだけで差し替え可能。 GitHub Pages 配信 (= 静的 HTML) なので env 注入は
-  使わず、 deployer が直接編集する運用。 値が空 / placeholder のままなら waitlist
-  section は 「準備中」 alert に降格する。
-  Embedded URL format: `https://docs.google.com/forms/d/e/<FORM_ID>/viewform?embedded=true`
--->
-<meta name="tenkacloud:waitlist-form-url" content="" />
-<meta property="og:title" content="TenkaCloud — クラウド競技を、もっとシンプルに。" />
-<meta property="og:description" content="本物の AWS で競う、オープンソースのクラウド競技基盤。Battle / Challenge を 1 イベントに混ぜて使える。Apache 2.0。" />
+<title>TenkaCloud — 社内クラウド研修を、5分で実戦演習に。</title>
+<meta name="description" content="TenkaCloud は AWS GameDay のようなクラウド実戦演習を OSS として運営できる基盤です。環境払い出し、スコアリング、問題管理を自動化します。" />
+<meta property="og:title" content="TenkaCloud — 社内クラウド研修を、5分で実戦演習に。" />
+<meta property="og:description" content="AWS GameDay のような演習を OSS で。環境払い出し、スコアリング、問題管理を自動化。" />
 <meta property="og:type" content="website" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+JP:wght@300;400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Noto+Sans+JP:wght@300;400;500;700;800&family=JetBrains+Mono:wght@400;500&display=swap" />
 <style>
 :root {
-  --ink:        #1d1d1f;
-  --ink-2:      #424245;
-  --ink-3:      #6e6e73;
-  --ink-4:      #86868b;
-  --line:       #d2d2d7;
-  --line-soft:  #e8e8ed;
-  --paper:      #ffffff;
-  --paper-2:    #fbfbfd;
-  --paper-3:    #f5f5f7;
-
+  --ink: #171717;
+  --ink-2: #3f3f46;
+  --ink-3: #71717a;
+  --line: #e4e4e7;
+  --paper: #ffffff;
+  --paper-2: #fafafa;
+  --paper-3: #f4f4f5;
+  --accent: #0f172a;
+  --blue: #0066cc;
+  --green: #15803d;
+  --red: #b91c1c;
+  --w: 1080px;
   --font-sans: "Inter", "Noto Sans JP", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
-
-  --w: 980px;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-
 * { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
 body {
+  margin: 0;
   font-family: var(--font-sans);
   color: var(--ink);
   background: var(--paper);
   -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-weight: 400;
-  line-height: 1.5;
-}
-
-.wrap { max-width: var(--w); margin: 0 auto; padding: 0 22px; }
-
-/* ============== NAV ============== */
-.nav {
-  position: sticky; top: 0; z-index: 50;
-  background: rgba(255,255,255,0.72);
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
-  border-bottom: 1px solid rgba(0,0,0,0.06);
-  height: 48px;
-}
-.nav .wrap {
-  height: 100%;
-  display: flex; align-items: center; justify-content: space-between;
-  max-width: 1024px;
-}
-.nav .brand {
-  font-weight: 500; font-size: 19px; letter-spacing: -0.02em;
-  color: var(--ink);
-}
-.nav-links { display: flex; gap: 28px; font-size: 12px; }
-.nav-links a { color: var(--ink-2); text-decoration: none; cursor: pointer; }
-.nav-links a:hover { color: var(--ink); }
-.nav-right { display: flex; align-items: center; gap: 18px; font-size: 12px; }
-.nav-right .lang { color: var(--ink-3); cursor: pointer; background: none; border: none; padding: 0; font: inherit; }
-.nav-right .lang.on { color: var(--ink); font-weight: 500; }
-.nav-right .sep { color: var(--line); }
-
-/* ============== TYPE ============== */
-h1, h2, h3, h4 { font-weight: 600; letter-spacing: -0.025em; margin: 0; color: var(--ink); }
-p { margin: 0; }
-
-.eyebrow {
-  font-size: 14px; font-weight: 500;
-  color: var(--ink-3); margin-bottom: 6px;
-}
-
-/* ============== HERO ============== */
-.hero { text-align: center; padding: 96px 22px 24px; }
-.hero h1 {
-  font-size: clamp(48px, 7vw, 80px);
-  font-weight: 600;
-  letter-spacing: -0.035em;
-  line-height: 1.05;
-  max-width: 880px;
-  margin: 0 auto 18px;
-  text-wrap: balance;
-}
-.hero h1 em { font-style: normal; font-weight: 600; color: var(--ink-3); }
-.hero .sub {
-  font-size: clamp(20px, 2.2vw, 26px);
-  line-height: 1.32;
-  color: var(--ink-2);
-  max-width: 720px;
-  margin: 0 auto;
-  font-weight: 400;
-  letter-spacing: -0.01em;
-  text-wrap: balance;
-}
-.hero .cta-row {
-  display: flex; gap: 22px; justify-content: center;
-  margin-top: 28px; font-size: 17px;
-}
-.hero .cta-row a {
-  color: #0066cc; text-decoration: none;
-  display: inline-flex; align-items: center; gap: 4px;
-}
-.hero .cta-row a:hover { text-decoration: underline; }
-
-.hero-visual { margin: 56px auto 0; max-width: 1024px; padding: 0 22px; }
-
-/* device-like glass card showing the product */
-.product-card {
-  position: relative;
-  background: var(--paper-3);
-  border-radius: 28px;
-  padding: 56px 48px;
-  overflow: hidden;
-}
-.product-card .inner {
-  position: relative;
-  background: var(--paper);
-  border-radius: 18px;
-  box-shadow: 0 1px 0 rgba(0,0,0,0.04), 0 20px 60px -20px rgba(0,0,0,0.18);
-  overflow: hidden;
-  border: 1px solid var(--line-soft);
-}
-.product-card .toolbar {
-  display: flex; align-items: center; gap: 8px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--line-soft);
-  background: var(--paper-2);
-}
-.product-card .toolbar .dot { width: 12px; height: 12px; border-radius: 50%; background: var(--line); }
-.product-card .toolbar .url {
-  margin-left: auto; margin-right: auto;
-  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
-}
-.product-card .body { display: grid; grid-template-columns: 220px 1fr; min-height: 360px; }
-.product-card .sidebar {
-  border-right: 1px solid var(--line-soft);
-  padding: 20px 16px; background: var(--paper-2);
-}
-.product-card .sidebar .group {
-  font-size: 10px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--ink-4); margin: 14px 8px 6px;
-}
-.product-card .sidebar a {
-  display: flex; align-items: center; gap: 10px;
-  padding: 7px 10px; border-radius: 6px;
-  font-size: 13px; color: var(--ink-2); text-decoration: none;
-}
-.product-card .sidebar a.on { background: var(--paper-3); color: var(--ink); font-weight: 500; }
-.product-card .sidebar a .b { width: 6px; height: 6px; border-radius: 50%; background: var(--line); }
-.product-card .sidebar a.battle .b { background: #ff453a; }
-.product-card .sidebar a.challenge .b { background: #30b766; }
-
-.product-card .main { padding: 24px 28px; }
-.product-card .main h3 { font-size: 20px; margin-bottom: 4px; }
-.product-card .main .breadcrumb { font-size: 12px; color: var(--ink-3); margin-bottom: 18px; }
-.product-card .main .row {
-  display: grid; grid-template-columns: 1fr 80px 80px 80px;
-  align-items: center;
-  padding: 14px 0;
-  border-top: 1px solid var(--line-soft);
-  font-size: 13px;
-}
-.product-card .main .row:last-child { border-bottom: 1px solid var(--line-soft); }
-.product-card .main .row .name { font-weight: 500; color: var(--ink); }
-.product-card .main .row .id { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); margin-top: 2px; display: block; }
-.product-card .main .row .tag {
-  font-size: 10px; padding: 2px 8px; border-radius: 999px;
-  display: inline-block; font-weight: 500;
-}
-.product-card .main .row .tag.battle { background: rgba(255,69,58,0.1); color: #b8261d; }
-.product-card .main .row .tag.challenge { background: rgba(48,183,102,0.1); color: #1d7a44; }
-.product-card .main .row .stars { display: inline-flex; gap: 2px; }
-.product-card .main .row .stars i { width: 6px; height: 6px; border-radius: 1px; background: var(--line); display: inline-block; }
-.product-card .main .row .stars i.on { background: var(--ink); }
-.product-card .main .row .pts { font-family: var(--font-mono); font-size: 12px; color: var(--ink-2); text-align: right; }
-
-/* ============== SECTIONS ============== */
-section { padding: 120px 22px; }
-section.alt { background: var(--paper-3); }
-section .wrap { max-width: var(--w); }
-section h2 {
-  font-size: clamp(34px, 4.4vw, 56px);
-  font-weight: 600; letter-spacing: -0.03em;
-  line-height: 1.08; max-width: 760px; margin: 0 0 16px;
-  text-wrap: balance;
-}
-section .lead {
-  font-size: clamp(18px, 1.6vw, 21px);
-  color: var(--ink-2); max-width: 640px;
-  line-height: 1.45; margin: 0 0 56px;
-}
-
-/* ============== TWO-UP FEATURE ============== */
-.twoup { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-.tile {
-  background: var(--paper-3); border-radius: 22px; padding: 44px;
-  min-height: 460px; display: flex; flex-direction: column;
-}
-.tile .kicker { font-size: 13px; color: var(--ink-3); font-weight: 500; margin-bottom: 10px; }
-.tile h3 {
-  font-size: 32px; font-weight: 600; letter-spacing: -0.025em;
-  line-height: 1.1; margin-bottom: 12px; text-wrap: balance;
-}
-.tile p { font-size: 16px; line-height: 1.5; color: var(--ink-2); max-width: 340px; }
-.tile .demo { margin-top: auto; }
-
-.demo-scoreboard {
-  background: var(--paper);
-  border: 1px solid var(--line-soft);
-  border-radius: 14px; overflow: hidden;
-}
-.demo-scoreboard .head {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--line-soft);
-  font-size: 11px; color: var(--ink-3);
-  font-family: var(--font-mono);
-}
-.demo-scoreboard .head .live { display: inline-flex; align-items: center; gap: 6px; color: #b8261d; }
-.demo-scoreboard .head .live .d {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: #ff453a; animation: ping 1.6s infinite;
-}
-@keyframes ping { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
-.demo-scoreboard .row {
-  display: grid; grid-template-columns: 24px 1fr 80px;
-  align-items: center; padding: 12px 16px;
-  border-top: 1px solid var(--line-soft); font-size: 13px;
-}
-.demo-scoreboard .row:first-child { border-top: none; }
-.demo-scoreboard .row .rank { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); }
-.demo-scoreboard .row.lead .rank { color: var(--ink); font-weight: 700; }
-.demo-scoreboard .row .name { font-family: var(--font-mono); font-size: 12px; color: var(--ink-2); }
-.demo-scoreboard .row.lead .name { color: var(--ink); font-weight: 500; }
-.demo-scoreboard .row .pts { text-align: right; font-family: var(--font-mono); font-weight: 500; color: var(--ink); }
-
-.demo-flag {
-  background: var(--paper); border: 1px solid var(--line-soft);
-  border-radius: 14px; padding: 20px;
-}
-.demo-flag .label {
-  font-family: var(--font-mono); font-size: 10px;
-  letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--ink-3); margin-bottom: 8px;
-}
-.demo-flag .input {
-  height: 38px; border: 1px solid var(--line); border-radius: 8px;
-  padding: 0 12px; display: flex; align-items: center;
-  font-family: var(--font-mono); font-size: 12px; color: var(--ink);
-  margin-bottom: 12px; background: var(--paper);
-}
-.demo-flag .input .cursor {
-  width: 1px; height: 14px; background: var(--ink); margin-left: 2px;
-  animation: cursor 1s steps(2) infinite;
-}
-@keyframes cursor { 50% { opacity: 0; } }
-.demo-flag .submit {
-  display: inline-flex; align-items: center; gap: 8px;
-  height: 32px; padding: 0 14px;
-  background: var(--ink); color: var(--paper);
-  border-radius: 999px; font-size: 12px; font-weight: 500; border: none;
-}
-.demo-flag .points { margin-top: 14px; font-size: 12px; color: var(--ink-3); font-family: var(--font-mono); }
-.demo-flag .points b { color: var(--ink); font-weight: 600; }
-
-/* ============== AUDIENCE 3-up ============== */
-.aud {
-  display: grid; grid-template-columns: repeat(3, 1fr);
-  gap: 1px; background: var(--line-soft);
-  border-top: 1px solid var(--line-soft);
-  border-bottom: 1px solid var(--line-soft);
-}
-.aud .col {
-  background: var(--paper);
-  padding: 48px 36px;
-  display: flex; flex-direction: column;
-  min-height: 320px;
-}
-.aud .col .role {
-  font-size: 12px; color: var(--ink-3); font-weight: 500;
-  font-family: var(--font-mono);
-  letter-spacing: 0.04em; text-transform: uppercase;
-  margin-bottom: 22px;
-}
-.aud .col h3 {
-  font-size: 26px; line-height: 1.15; font-weight: 600;
-  letter-spacing: -0.02em; margin-bottom: 10px; text-wrap: balance;
-}
-.aud .col p { font-size: 15px; line-height: 1.5; color: var(--ink-2); margin: 0; flex: 1; }
-.aud .col .more { margin-top: 24px; font-size: 13px; color: #0066cc; text-decoration: none; }
-.aud .col .more:hover { text-decoration: underline; }
-
-/* ============== STEPS ============== */
-.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; }
-.step .n {
-  font-size: 12px; font-weight: 500; color: var(--ink-3);
-  margin-bottom: 14px; font-family: var(--font-mono);
-}
-.step h4 {
-  font-size: 22px; font-weight: 600;
-  letter-spacing: -0.02em; margin-bottom: 10px;
-}
-.step p { font-size: 15px; line-height: 1.5; color: var(--ink-2); margin: 0; }
-.step .code {
-  margin-top: 16px;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--ink-2);
-  background: var(--paper);
-  border: 1px solid var(--line-soft);
-  border-radius: 8px;
-  padding: 10px 12px;
-  display: block;
-  overflow-x: auto;
-  white-space: nowrap;
   line-height: 1.6;
 }
-
-/* ============== TRUST ============== */
-.trust { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; align-items: center; }
-.trust .copy h2 { font-size: clamp(30px, 3.8vw, 44px); margin-bottom: 16px; }
-.trust ul { list-style: none; padding: 0; margin: 24px 0 0; display: grid; gap: 14px; }
-.trust ul li {
-  display: grid; grid-template-columns: 18px 1fr; gap: 14px;
-  font-size: 15px; line-height: 1.5; color: var(--ink-2);
+a { color: inherit; }
+.wrap { max-width: var(--w); margin: 0 auto; padding: 0 24px; }
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  height: 56px;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+  background: rgba(255,255,255,0.82);
+  backdrop-filter: blur(18px) saturate(160%);
 }
-.trust ul li::before {
-  content: "";
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--ink); margin-top: 8px;
+.nav .wrap { height: 100%; display: flex; align-items: center; justify-content: space-between; }
+.brand { font-size: 18px; font-weight: 700; letter-spacing: -0.03em; }
+.nav-links { display: flex; gap: 22px; align-items: center; font-size: 13px; color: var(--ink-2); }
+.nav-links a { text-decoration: none; }
+.nav-links a:hover { color: var(--ink); }
+.langs { display: flex; gap: 6px; align-items: center; }
+.langs button {
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink-3);
+  border-radius: 999px;
+  padding: 5px 9px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
 }
-.trust ul li b { color: var(--ink); font-weight: 600; }
-
-.flow { background: var(--paper); border: 1px solid var(--line-soft); border-radius: 18px; padding: 28px; }
-.flow .node {
-  background: var(--paper-2); border: 1px solid var(--line-soft);
-  border-radius: 10px; padding: 14px 16px;
-  font-family: var(--font-mono); font-size: 12px; color: var(--ink);
-  display: flex; justify-content: space-between; align-items: center;
-}
-.flow .node .tag { font-size: 10px; color: var(--ink-3); }
-.flow .arr {
-  display: flex; align-items: center; gap: 10px; padding: 10px 16px;
-  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
-}
-.flow .arr .line { flex: 1; height: 1px; background: var(--line); position: relative; }
-.flow .arr .line::after {
-  content: ""; position: absolute; right: 0; top: -3px;
-  width: 0; height: 0;
-  border-left: 6px solid var(--line);
-  border-top: 3.5px solid transparent;
-  border-bottom: 3.5px solid transparent;
-}
-.flow .sub { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-top: 4px; }
-.flow .sub .leaf {
-  background: var(--paper-2); border: 1px solid var(--line-soft);
-  border-radius: 8px; padding: 10px 12px;
-  font-family: var(--font-mono); font-size: 11px;
+.langs button.on { color: var(--paper); background: var(--accent); border-color: var(--accent); }
+.hero { padding: 104px 0 64px; text-align: center; }
+.kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
   color: var(--ink-2);
-  display: flex; flex-direction: column; gap: 4px;
-}
-.flow .sub .leaf .ok { color: #1d7a44; font-size: 10px; }
-
-/* ============== STATS ============== */
-.stats {
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  border-top: 1px solid var(--line-soft);
-  border-bottom: 1px solid var(--line-soft);
-}
-.stat { padding: 56px 24px 56px 0; border-right: 1px solid var(--line-soft); }
-.stat:last-child { border-right: none; }
-.stat .n {
-  font-size: clamp(40px, 4.4vw, 64px);
-  font-weight: 600; letter-spacing: -0.04em;
-  line-height: 1; color: var(--ink); margin-bottom: 8px;
-}
-.stat .n .u { font-size: 0.55em; color: var(--ink-3); margin-left: 2px; font-weight: 500; }
-.stat .l { font-size: 13px; color: var(--ink-3); max-width: 200px; line-height: 1.45; }
-
-/* ============== ENTERPRISE CTA ============== */
-.ent-cta {
-  background: var(--ink); color: var(--paper);
-  border-radius: 28px; padding: 80px 56px; text-align: center;
-}
-.ent-cta .eyebrow { color: rgba(255,255,255,0.55); margin-bottom: 12px; }
-.ent-cta h2 {
-  color: var(--paper);
-  font-size: clamp(34px, 4.6vw, 56px);
-  font-weight: 600; letter-spacing: -0.03em;
-  margin: 0 auto 16px; max-width: 680px; text-wrap: balance;
-}
-.ent-cta p {
-  color: rgba(255,255,255,0.7);
-  font-size: 18px; max-width: 540px;
-  margin: 0 auto 36px; line-height: 1.5;
-}
-.ent-cta .btns { display: inline-flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
-.ent-cta .btn-primary {
-  height: 46px; padding: 0 26px;
-  background: var(--paper); color: var(--ink);
   border-radius: 999px;
-  font-size: 15px; font-weight: 500; border: none; cursor: pointer;
-  text-decoration: none;
-  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 24px;
 }
-.ent-cta .btn-ghost {
-  height: 46px; padding: 0 26px;
-  background: transparent; color: var(--paper);
+.kicker::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+}
+h1 {
+  font-size: clamp(44px, 7vw, 84px);
+  line-height: 1.04;
+  letter-spacing: -0.055em;
+  max-width: 930px;
+  margin: 0 auto 22px;
+}
+h1 em { color: var(--ink-3); font-style: normal; }
+.sub {
+  font-size: clamp(18px, 2.1vw, 25px);
+  line-height: 1.45;
+  color: var(--ink-2);
+  max-width: 760px;
+  margin: 0 auto;
+  letter-spacing: -0.015em;
+}
+.cta-row {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 34px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 46px;
+  padding: 0 22px;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.3);
-  font-size: 15px; font-weight: 500;
   text-decoration: none;
-  display: inline-flex; align-items: center; gap: 6px;
+  font-weight: 600;
+  font-size: 15px;
 }
-
-/* ============== FOOTER ============== */
-footer { padding: 56px 22px 32px; background: var(--paper-3); color: var(--ink-3); }
-footer .wrap {
-  display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr;
-  gap: 40px; max-width: 1024px;
+.btn.primary { background: var(--accent); color: var(--paper); }
+.btn.secondary { border: 1px solid var(--line); color: var(--ink); background: var(--paper); }
+.btn.link { color: var(--blue); padding-left: 8px; padding-right: 8px; }
+.hero-card {
+  margin: 64px auto 0;
+  max-width: 980px;
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: linear-gradient(180deg, #fff, var(--paper-2));
+  box-shadow: 0 24px 80px rgba(15,23,42,0.10);
+  overflow: hidden;
+  text-align: left;
 }
-footer h5 { font-size: 12px; font-weight: 600; color: var(--ink); margin: 0 0 12px; }
-footer a { display: block; color: var(--ink-3); text-decoration: none; font-size: 12px; padding: 4px 0; }
-footer a:hover { color: var(--ink); text-decoration: underline; }
-footer .brand { font-size: 19px; font-weight: 500; letter-spacing: -0.02em; color: var(--ink); margin-bottom: 8px; }
-footer .tag { font-size: 12px; color: var(--ink-3); line-height: 1.5; max-width: 280px; }
-footer .legal {
-  grid-column: 1 / -1;
-  margin-top: 24px; padding-top: 24px;
+.window-bar {
+  height: 44px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  background: var(--paper-2);
+}
+.dot { width: 11px; height: 11px; border-radius: 50%; background: #d4d4d8; }
+.window-url { margin-left: auto; margin-right: auto; font-family: var(--font-mono); font-size: 12px; color: var(--ink-3); }
+.dashboard { display: grid; grid-template-columns: 260px 1fr; min-height: 410px; }
+.side { border-right: 1px solid var(--line); background: var(--paper-2); padding: 22px 18px; }
+.side-label { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.08em; margin: 14px 8px 8px; }
+.side-item { display: flex; align-items: center; gap: 10px; border-radius: 10px; padding: 10px; font-size: 14px; color: var(--ink-2); }
+.side-item.on { background: var(--paper); color: var(--ink); font-weight: 700; box-shadow: 0 1px 0 rgba(0,0,0,0.04); }
+.pill-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--line); }
+.pill-dot.red { background: var(--red); }
+.pill-dot.green { background: var(--green); }
+.main { padding: 28px; }
+.breadcrumb { font-family: var(--font-mono); color: var(--ink-3); font-size: 12px; margin-bottom: 8px; }
+.panel-title { display: flex; justify-content: space-between; align-items: end; gap: 16px; margin-bottom: 22px; }
+.panel-title h2 { font-size: 26px; letter-spacing: -0.035em; margin: 0; }
+.live { font-family: var(--font-mono); color: var(--red); font-size: 12px; }
+.problem-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 0;
   border-top: 1px solid var(--line);
-  display: flex; justify-content: space-between;
-  font-size: 11px; color: var(--ink-4);
 }
-
-/* ============== RESPONSIVE ============== */
+.problem-row:last-child { border-bottom: 1px solid var(--line); }
+.problem-name { font-weight: 700; }
+.problem-id { font-family: var(--font-mono); font-size: 12px; color: var(--ink-3); margin-top: 3px; }
+.badge { border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 700; }
+.badge.battle { background: #fee2e2; color: var(--red); }
+.badge.challenge { background: #dcfce7; color: var(--green); }
+.points { font-family: var(--font-mono); font-size: 13px; color: var(--ink-2); min-width: 82px; text-align: right; }
+section { padding: 92px 0; }
+section.alt { background: var(--paper-3); }
+.section-head { max-width: 760px; margin-bottom: 44px; }
+.eyebrow { color: var(--ink-3); font-weight: 700; font-size: 13px; margin-bottom: 8px; }
+h2.section-title { font-size: clamp(32px, 4.5vw, 58px); line-height: 1.08; letter-spacing: -0.045em; margin: 0 0 14px; }
+.lead { color: var(--ink-2); font-size: 19px; margin: 0; }
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.card {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  padding: 28px;
+  min-height: 260px;
+}
+.card h3 { font-size: 24px; line-height: 1.18; letter-spacing: -0.025em; margin: 0 0 12px; }
+.card p { color: var(--ink-2); margin: 0; }
+.card .num { font-family: var(--font-mono); font-size: 12px; color: var(--ink-3); margin-bottom: 22px; }
+.flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 24px; overflow: hidden; }
+.flow-step { background: var(--paper); padding: 30px 24px; }
+.flow-step .n { font-family: var(--font-mono); color: var(--ink-3); font-size: 12px; margin-bottom: 16px; }
+.flow-step h3 { margin: 0 0 8px; font-size: 20px; letter-spacing: -0.02em; }
+.flow-step p { margin: 0; color: var(--ink-2); font-size: 15px; }
+.code-card {
+  border: 1px solid var(--line);
+  background: #0f172a;
+  color: #e5e7eb;
+  border-radius: 22px;
+  padding: 28px;
+  font-family: var(--font-mono);
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.8;
+}
+.code-card .muted { color: #94a3b8; }
+.cta-panel {
+  background: var(--accent);
+  color: var(--paper);
+  border-radius: 30px;
+  padding: 64px 34px;
+  text-align: center;
+}
+.cta-panel h2 { color: var(--paper); max-width: 760px; margin: 0 auto 16px; }
+.cta-panel p { color: rgba(255,255,255,0.72); max-width: 680px; margin: 0 auto 28px; font-size: 18px; }
+.cta-panel .btn.primary { background: var(--paper); color: var(--accent); }
+.cta-panel .btn.secondary { border-color: rgba(255,255,255,0.25); color: var(--paper); background: transparent; }
+footer { border-top: 1px solid var(--line); padding: 40px 0; background: var(--paper-2); color: var(--ink-3); font-size: 13px; }
+footer .wrap { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; }
+footer a { color: var(--ink-2); text-decoration: none; margin-left: 16px; }
+footer a:hover { text-decoration: underline; }
 @media (max-width: 860px) {
-  .twoup, .steps, .aud, .trust, .stats { grid-template-columns: 1fr; }
-  .stats { gap: 1px; background: var(--line-soft); border: none; }
-  .stat { border-right: none; background: var(--paper); padding: 32px 22px; }
-  .product-card { padding: 24px; }
-  .product-card .body { grid-template-columns: 1fr; }
-  .product-card .sidebar { display: none; }
-  .product-card .main .row { grid-template-columns: 1fr auto; }
-  .product-card .main .row > :nth-child(3),
-  .product-card .main .row > :nth-child(4) { display: none; }
-  .ent-cta { padding: 56px 28px; border-radius: 18px; }
-  footer .wrap { grid-template-columns: 1fr 1fr; }
-  section { padding: 80px 22px; }
+  .nav-links { display: none; }
+  .dashboard { grid-template-columns: 1fr; }
+  .side { display: none; }
+  .grid-3, .flow { grid-template-columns: 1fr; }
+  .hero { padding-top: 72px; }
+  .hero-card { margin-top: 42px; }
+  .panel-title { align-items: start; flex-direction: column; }
+  .problem-row { grid-template-columns: 1fr; gap: 8px; }
+  .points { text-align: left; }
 }
 </style>
 </head>
 <body>
-
 <nav class="nav">
   <div class="wrap">
     <div class="brand">TenkaCloud</div>
     <div class="nav-links">
-      <a href="#modes" data-i18n="nav.product">プロダクト</a>
-      <a href="#onboard" data-i18n="nav.problems">問題</a>
-      <a href="https://github.com/susumutomita/TenkaCloud#readme" target="_blank" rel="noopener noreferrer" data-i18n="nav.docs">ドキュメント</a>
-      <a href="#waitlist" data-i18n="nav.waitlist">ウェイトリスト</a>
-      <a href="#contact" data-i18n="nav.contact">お問い合わせ</a>
-      <a href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer" data-i18n="nav.github">GitHub</a>
+      <a href="#why" data-i18n="nav.why">なぜ</a>
+      <a href="#flow" data-i18n="nav.flow">体験</a>
+      <a href="#author" data-i18n="nav.author">問題作成</a>
+      <a href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer">GitHub</a>
     </div>
-    <div class="nav-right">
-      <button class="lang on" data-lang="ja" type="button">JA</button>
-      <span class="sep">·</span>
-      <button class="lang" data-lang="en" type="button">EN</button>
+    <div class="langs">
+      <button class="on" data-lang="ja" type="button">JA</button>
+      <button data-lang="en" type="button">EN</button>
     </div>
   </div>
 </nav>
 
-<section class="hero">
-  <h1>
-    <span data-i18n="hero.h1a">クラウドの実力は、</span><em data-i18n="hero.h1b">実戦でしか測れない。</em>
-  </h1>
-  <p class="sub" data-i18n="hero.sub">AWS の実環境で、構築・防御・コスト最適化を競う。誰でも使える、オープンソースのアリーナ。</p>
-  <div class="cta-row">
-    <a href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer">
-      <span data-i18n="hero.cta1">GitHub を見る</span> ›
-    </a>
-    <a href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer">
-      <span data-i18n="hero.cta2">デモを見る</span> ›
-    </a>
-  </div>
+<main>
+  <section class="hero">
+    <div class="wrap">
+      <div class="kicker" data-i18n="hero.kicker">AWS GameDay-style OSS platform</div>
+      <h1><span data-i18n="hero.h1a">社内クラウド研修を、</span><em data-i18n="hero.h1b">5分で実戦演習に。</em></h1>
+      <p class="sub" data-i18n="hero.sub">AWS GameDay のような演習を OSS で。環境払い出し、スコアリング、問題管理を自動化します。</p>
+      <div class="cta-row">
+        <a class="btn primary" href="#flow"><span data-i18n="hero.cta.try">3分で試す</span> ›</a>
+        <a class="btn secondary" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="hero.cta.github">GitHubを見る</span> ›</a>
+        <a class="btn link" href="https://github.com/susumutomita/TenkaCloud/issues/1023" target="_blank" rel="noopener noreferrer"><span data-i18n="hero.cta.issue">改善Issue</span> ›</a>
+      </div>
 
-  <div class="hero-visual">
-    <div class="product-card">
-      <div class="inner">
-        <div class="toolbar">
+      <div class="hero-card" aria-label="TenkaCloud product preview">
+        <div class="window-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="url">portal.tenkacloud.dev / problems</span>
+          <span class="window-url">portal.tenkacloud.dev / demo / hello-world-battle</span>
         </div>
-        <div class="body">
-          <div class="sidebar">
-            <div class="group">Workspace</div>
-            <a class="on"><span class="b battle"></span><span data-i18n="product.sidebar.0">問題</span></a>
-            <a><span class="b"></span><span data-i18n="product.sidebar.1">リーダーボード</span></a>
-            <a><span class="b"></span><span data-i18n="product.sidebar.2">イベント</span></a>
-            <a><span class="b"></span><span data-i18n="product.sidebar.3">ドキュメント</span></a>
-            <div class="group">Categories</div>
-            <a class="battle"><span class="b battle"></span>Battle</a>
-            <a class="challenge"><span class="b challenge"></span>Challenge</a>
-          </div>
+        <div class="dashboard">
+          <aside class="side">
+            <div class="side-label">Workspace</div>
+            <div class="side-item on"><span class="pill-dot red"></span><span data-i18n="preview.nav.problem">問題</span></div>
+            <div class="side-item"><span class="pill-dot green"></span><span data-i18n="preview.nav.score">スコア</span></div>
+            <div class="side-item"><span class="pill-dot"></span><span data-i18n="preview.nav.event">イベント</span></div>
+            <div class="side-label">Activation</div>
+            <div class="side-item"><span class="pill-dot green"></span><span data-i18n="preview.nav.try">Try in 3 min</span></div>
+          </aside>
           <div class="main">
-            <div class="breadcrumb" data-i18n="product.breadcrumb">Workspace · open-arena · Season 01</div>
-            <h3 data-i18n="product.title">問題カタログ</h3>
-            <div style="margin-top:14px;" id="product-rows"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="alt" id="modes">
-  <div class="wrap">
-    <div class="eyebrow" data-i18n="modes.eyebrow">2 つのモード</div>
-    <h2 data-i18n="modes.h2">対戦か、演習か。両方か。</h2>
-    <p class="lead" data-i18n="modes.lead">リアルタイムの Battle と、じっくり解く Challenge。1 つのイベントに混ぜて使える。</p>
-    <div class="twoup">
-      <div class="tile">
-        <div class="kicker" data-i18n="modes.battle.kicker">Battle</div>
-        <h3 data-i18n="modes.battle.h">Battle.</h3>
-        <p data-i18n="modes.battle.p">稼働率で競う、リアルタイム対戦。毎分のヘルスチェックを生き残ったチームが、勝つ。</p>
-        <div class="demo">
-          <div class="demo-scoreboard">
-            <div class="head">
-              <span>SECURITY BATTLE ROYALE</span>
-              <span class="live"><span class="d"></span><span data-i18n="modes.battle.live">ROUND 03 · LIVE</span></span>
+            <div class="breadcrumb">Workspace · open-arena · Season 01</div>
+            <div class="panel-title">
+              <h2 data-i18n="preview.title">最初の演習を開始</h2>
+              <span class="live">LIVE · demo-ready</span>
             </div>
-            <div id="scoreboard-rows"></div>
+            <div class="problem-row">
+              <div><div class="problem-name">Hello World Battle</div><div class="problem-id">problems/battle/hello-world-battle</div></div>
+              <span class="badge battle">Battle</span>
+              <span class="points">400 pts</span>
+            </div>
+            <div class="problem-row">
+              <div><div class="problem-name">IAM Escape Room</div><div class="problem-id">problems/challenge/iam-escape-room</div></div>
+              <span class="badge challenge">Challenge</span>
+              <span class="points">800 pts</span>
+            </div>
+            <div class="problem-row">
+              <div><div class="problem-name">Security Battle Royale</div><div class="problem-id">problems/battle/security-battle-royale</div></div>
+              <span class="badge battle">Battle</span>
+              <span class="points">1,200 pts</span>
+            </div>
           </div>
         </div>
       </div>
-      <div class="tile">
-        <div class="kicker" data-i18n="modes.challenge.kicker">Challenge</div>
-        <h3 data-i18n="modes.challenge.h">Challenge.</h3>
-        <p data-i18n="modes.challenge.p">問題を解き、フラグを提出する。AWS の一つひとつのサービスを、ひとつずつ理解していく。</p>
-        <div class="demo">
-          <div class="demo-flag">
-            <div class="label">Flag</div>
-            <div class="input"><span data-i18n="modes.challenge.input">Hello from tc-iam-…</span><span class="cursor"></span></div>
-            <button class="submit" type="button">Submit ›</button>
-            <div class="points">+<b>800 pts</b> · iam-escape-room</div>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section>
-  <div class="wrap">
-    <div class="eyebrow" data-i18n="aud.eyebrow">誰のための</div>
-    <h2 data-i18n="aud.h2">出る人にも、開く人にも。</h2>
-    <p class="lead" data-i18n="aud.lead">個人のエンジニアから、勉強会の主催者、教育の現場まで。AWS コンソールを開かずに、競技は始まる。</p>
-  </div>
-  <div class="aud">
-    <div class="col">
-      <div class="role" data-i18n="aud.a.role">エンジニア</div>
-      <h3 data-i18n="aud.a.h">実戦で、腕を上げる。</h3>
-      <p data-i18n="aud.a.p">本物の AWS で問題を解き、ランクを上げる。成果は履歴に残せる、技術の足跡になる。</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="aud.a.more">参加者ポータル</span> ›</a>
+  <section id="why" class="alt">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="eyebrow" data-i18n="why.eyebrow">Why now</div>
+        <h2 class="section-title" data-i18n="why.title">座学では、クラウド運用の勘所は身につかない。</h2>
+        <p class="lead" data-i18n="why.lead">TenkaCloud は、研修・ハッカソン・インシデント演習を「実環境で動く問題」として再利用できる形にします。</p>
+      </div>
+      <div class="grid-3">
+        <div class="card"><div class="num">01</div><h3 data-i18n="why.a.h">準備が重い</h3><p data-i18n="why.a.p">参加者ごとのAWS環境、権限、スコアリングを毎回手作業で作ると、運営負荷が高すぎます。</p></div>
+        <div class="card"><div class="num">02</div><h3 data-i18n="why.b.h">成果が見えない</h3><p data-i18n="why.b.p">講義を受けたことではなく、実際に直せた・守れた・最適化できたことを可視化します。</p></div>
+        <div class="card"><div class="num">03</div><h3 data-i18n="why.c.h">問題が資産化しない</h3><p data-i18n="why.c.p">一度作った演習を、問題パッケージとして再利用・共有・改善できるようにします。</p></div>
+      </div>
     </div>
-    <div class="col">
-      <div class="role" data-i18n="aud.b.role">イベント主催</div>
-      <h3 data-i18n="aud.b.h">GameDay を、1 画面で。</h3>
-      <p data-i18n="aud.b.p">競技者ごとの環境を自動で配ってまわす。準備に費やしていた一週間が、半日で終わる。</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="aud.b.more">運営ガイド</span> ›</a>
-    </div>
-    <div class="col">
-      <div class="role" data-i18n="aud.c.role">学校・コミュニティ</div>
-      <h3 data-i18n="aud.c.h">AWS を、教材にする。</h3>
-      <p data-i18n="aud.c.p">授業や勉強会で、本物の AWS を題材にできる。問題はオープン。新しい問題の提案も歓迎します。</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/problems/README.md" target="_blank" rel="noopener noreferrer"><span data-i18n="aud.c.more">問題を作る</span> ›</a>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="alt" id="onboard">
-  <div class="wrap">
-    <div class="eyebrow" data-i18n="onboard.eyebrow">オンボーディング</div>
-    <h2 data-i18n="onboard.h2">AWS との接続は、3 ステップ。</h2>
-    <p class="lead" data-i18n="onboard.lead">「自分のアカウントに何をされるか」をなくす設計。最小権限の AssumeRole 一本だけで、すべてが動く。</p>
-    <div class="steps">
-      <div class="step">
-        <div class="n">01</div>
-        <h4 data-i18n="onboard.s1.h">テンプレートを、1 度だけ。</h4>
-        <p data-i18n="onboard.s1.p">CloudFormation を自分のアカウントに 1 回デプロイ。それで IAM Role が用意される。</p>
-        <div class="code"><div>$ aws cloudformation create-stack \</div><div>&nbsp;&nbsp;&nbsp;&nbsp;--stack-name tenka-bootstrap \</div><div>&nbsp;&nbsp;&nbsp;&nbsp;--template-url https://…</div></div>
-      </div>
-      <div class="step">
-        <div class="n">02</div>
-        <h4 data-i18n="onboard.s2.h">ExternalId で、固く守る。</h4>
-        <p data-i18n="onboard.s2.p">TenkaCloud は固有の ExternalId 付きでしか、その Role を引き受けられない。Role ARN だけでは入れない。</p>
-        <div class="code"><div>Principal: tenkacloud-control-plane</div><div>Condition:</div><div>&nbsp;&nbsp;sts:ExternalId: TC-EXT-•••</div></div>
-      </div>
-      <div class="step">
-        <div class="n">03</div>
-        <h4 data-i18n="onboard.s3.h">ポータルから、競技へ。</h4>
-        <p data-i18n="onboard.s3.p">ログインすれば、問題環境が自動で立ち上がる。エンドポイントと点数は、その瞬間から見える。</p>
-        <div class="code"><div>$ open https://portal.tenkacloud.dev</div><div>→ <span data-i18n="onboard.s3.line2">問題が割り当てられました</span></div><div>→ Frontend URL: https://t1…</div></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="wrap">
-    <div class="trust">
-      <div class="copy">
-        <div class="eyebrow" data-i18n="trust.eyebrow">セキュリティ</div>
-        <h2 data-i18n="trust.h2">あなたの AWS は、ずっとあなたのもの。</h2>
-        <ul id="trust-bullets"></ul>
+  <section id="flow">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="eyebrow" data-i18n="flow.eyebrow">First experience</div>
+        <h2 class="section-title" data-i18n="flow.title">見る、試す、理解する。</h2>
+        <p class="lead" data-i18n="flow.lead">初回体験はコードを読む前に価値が伝わることを重視します。最初のゴールは5分以内に演習を開始できることです。</p>
       </div>
       <div class="flow">
-        <div class="node">
-          <span>TenkaCloud · Control Plane</span>
-          <span class="tag">SaaS</span>
-        </div>
-        <div class="arr">
-          <span>AssumeRole + ExternalId</span>
-          <span class="line"></span>
-        </div>
-        <div class="sub">
-          <div class="leaf"><span>acct-a</span><span class="ok">● deployed</span></div>
-          <div class="leaf"><span>acct-b</span><span class="ok">● deployed</span></div>
-          <div class="leaf"><span>acct-c</span><span class="ok">● deployed</span></div>
+        <div class="flow-step"><div class="n">01</div><h3 data-i18n="flow.s1.h">LPを見る</h3><p data-i18n="flow.s1.p">対象はまず社内クラウド研修チーム。用途を絞って、5秒で価値を伝えます。</p></div>
+        <div class="flow-step"><div class="n">02</div><h3 data-i18n="flow.s2.h">3分デモ</h3><p data-i18n="flow.s2.p">hello-world battle を、AWS不要でも体験できる導線にします。</p></div>
+        <div class="flow-step"><div class="n">03</div><h3 data-i18n="flow.s3.h">スコアを見る</h3><p data-i18n="flow.s3.p">競技の面白さを、動くスコアとリーダーボードで即座に見せます。</p></div>
+        <div class="flow-step"><div class="n">04</div><h3 data-i18n="flow.s4.h">自分で作る</h3><p data-i18n="flow.s4.p">30分で最小問題を追加できる authoring path に接続します。</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="author" class="alt">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="eyebrow" data-i18n="author.eyebrow">Problem authoring</div>
+        <h2 class="section-title" data-i18n="author.title">問題を増やせることが、TenkaCloudのスケール要因。</h2>
+        <p class="lead" data-i18n="author.lead">プラットフォームの価値は問題資産で増えます。初見の人が迷わず問題を追加できる導線を最優先にします。</p>
+      </div>
+      <div class="code-card">
+        <div><span class="muted"># target authoring experience</span></div>
+        <div>$ npx create-tenkacloud-problem my-first-battle</div>
+        <div>$ cd my-first-battle</div>
+        <div>$ tenkacloud problem validate</div>
+        <div>$ tenkacloud problem preview</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <div class="cta-panel">
+        <h2 class="section-title" data-i18n="cta.title">まずは、仲間内で1回走らせる。</h2>
+        <p data-i18n="cta.p">完成したら大規模ローンチではなく、AWSに詳しい仲間・コミュニティ・研修担当に限定して流し、反応を見るのが最短です。</p>
+        <div class="cta-row">
+          <a class="btn primary" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="cta.github">GitHubを見る</span> ›</a>
+          <a class="btn secondary" href="https://github.com/susumutomita/TenkaCloud/issues/1023" target="_blank" rel="noopener noreferrer"><span data-i18n="cta.issue">Issue #1023</span> ›</a>
         </div>
       </div>
     </div>
-  </div>
-</section>
-
-<section class="alt">
-  <div class="wrap">
-    <div class="stats" id="stats-grid"></div>
-  </div>
-</section>
-
-<section id="waitlist">
-  <div class="wrap">
-    <div class="ent-cta">
-      <div class="eyebrow" data-i18n="waitlist.eyebrow">ベータの招待を受け取る</div>
-      <h2 data-i18n="waitlist.h2">ウェイトリストに登録する。</h2>
-      <p data-i18n="waitlist.p">公開アリーナの招待 / 開催ご相談の連絡先を残しておくと、 準備が整い次第お知らせします。 OSS なので料金はありません。</p>
-      <div id="waitlist-embed">
-        <noscript data-i18n="waitlist.noscript">JavaScript を有効にすると登録フォームが表示されます。</noscript>
-      </div>
-      <div class="btns" id="waitlist-fallback" hidden>
-        <a class="btn-primary" href="#" id="waitlist-fallback-link" target="_blank" rel="noopener noreferrer"><span data-i18n="waitlist.fallback">フォームを開く</span> ›</a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="contact">
-  <div class="wrap">
-    <div class="ent-cta">
-      <div class="eyebrow" data-i18n="ent.eyebrow">もし、こんな使い方をしたいなら</div>
-      <h2 data-i18n="ent.h2">クローズドな会場で、走らせたい人へ。</h2>
-      <p data-i18n="ent.p">社内勉強会、学校の授業、クローズドなインシデントレスポンス演習 — 公開アリーナで難しい使い方を考えているなら、相談してください。OSS なので料金はありません。</p>
-      <div class="btns">
-        <a class="btn-primary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="ent.cta1">お問い合わせ</span> ›</a>
-        <a class="btn-ghost" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="ent.cta2">GitHub を見る</span> ›</a>
-      </div>
-    </div>
-  </div>
-</section>
+  </section>
+</main>
 
 <footer>
   <div class="wrap">
-    <div>
-      <div class="brand">TenkaCloud</div>
-      <div class="tag" data-i18n="footer.tag">AWS の実環境で競う、オープンソースのクラウド競技基盤。Apache 2.0。</div>
-    </div>
-    <div>
-      <h5>Product</h5>
-      <a href="#modes" data-i18n="footer.p0">概要</a>
-      <a href="https://github.com/susumutomita/TenkaCloud/tree/main/problems" target="_blank" rel="noopener noreferrer" data-i18n="footer.p1">問題カタログ</a>
-      <a data-i18n="footer.p2">参加者ポータル</a>
-      <a data-i18n="footer.p3">運営コンソール</a>
-    </div>
-    <div>
-      <h5>Resources</h5>
-      <a href="https://github.com/susumutomita/TenkaCloud#readme" target="_blank" rel="noopener noreferrer" data-i18n="footer.r0">ドキュメント</a>
-      <a href="https://github.com/susumutomita/TenkaCloud/tree/main/docs/architecture" target="_blank" rel="noopener noreferrer" data-i18n="footer.r1">アーキテクチャ</a>
-      <a href="https://github.com/susumutomita/TenkaCloud/releases" target="_blank" rel="noopener noreferrer" data-i18n="footer.r2">Changelog</a>
-    </div>
-    <div>
-      <h5>Community</h5>
+    <span>© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0</span>
+    <span>
       <a href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
       <a href="https://github.com/susumutomita/TenkaCloud/issues" target="_blank" rel="noopener noreferrer">Issues</a>
-      <a href="https://github.com/susumutomita/TenkaCloud/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">Contribute</a>
-    </div>
-    <div class="legal">
-      <span data-i18n="footer.legal">© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0</span>
-      <span>v0.2.0 · ja · en</span>
-    </div>
+    </span>
   </div>
 </footer>
 
 <script>
 (function(){
   "use strict";
-
   var I18N = {
     ja: {
-      "nav.product": "プロダクト",
-      "nav.problems": "問題",
-      "nav.docs": "ドキュメント",
-      "nav.waitlist": "ウェイトリスト",
-      "nav.contact": "お問い合わせ",
-      "nav.github": "GitHub",
-
-      "hero.h1a": "クラウドの実力は、",
-      "hero.h1b": "実戦でしか測れない。",
-      "hero.sub": "AWS の実環境で、構築・防御・コスト最適化を競う。誰でも使える、オープンソースのアリーナ。",
-      "hero.cta1": "GitHub を見る",
-      "hero.cta2": "デモを見る",
-
-      "product.title": "問題カタログ",
-      "product.breadcrumb": "Workspace · open-arena · Season 01",
-      "product.sidebar.0": "問題",
-      "product.sidebar.1": "リーダーボード",
-      "product.sidebar.2": "イベント",
-      "product.sidebar.3": "ドキュメント",
-
-      "modes.eyebrow": "2 つのモード",
-      "modes.h2": "対戦か、演習か。両方か。",
-      "modes.lead": "リアルタイムの Battle と、じっくり解く Challenge。1 つのイベントに混ぜて使える。",
-      "modes.battle.kicker": "Battle",
-      "modes.battle.h": "Battle.",
-      "modes.battle.p": "稼働率で競う、リアルタイム対戦。毎分のヘルスチェックを生き残ったチームが、勝つ。",
-      "modes.battle.live": "ROUND 03 · LIVE",
-      "modes.challenge.kicker": "Challenge",
-      "modes.challenge.h": "Challenge.",
-      "modes.challenge.p": "問題を解き、フラグを提出する。AWS の一つひとつのサービスを、ひとつずつ理解していく。",
-      "modes.challenge.input": "Hello from tc-iam-…",
-
-      "aud.eyebrow": "誰のための",
-      "aud.h2": "出る人にも、開く人にも。",
-      "aud.lead": "個人のエンジニアから、勉強会の主催者、教育の現場まで。AWS コンソールを開かずに、競技は始まる。",
-      "aud.a.role": "エンジニア",
-      "aud.a.h": "実戦で、腕を上げる。",
-      "aud.a.p": "本物の AWS で問題を解き、ランクを上げる。成果は履歴に残せる、技術の足跡になる。",
-      "aud.a.more": "参加者ポータル",
-      "aud.b.role": "イベント主催",
-      "aud.b.h": "GameDay を、1 画面で。",
-      "aud.b.p": "競技者ごとの環境を自動で配ってまわす。準備に費やしていた一週間が、半日で終わる。",
-      "aud.b.more": "運営ガイド",
-      "aud.c.role": "学校・コミュニティ",
-      "aud.c.h": "AWS を、教材にする。",
-      "aud.c.p": "授業や勉強会で、本物の AWS を題材にできる。問題はオープン。新しい問題の提案も歓迎します。",
-      "aud.c.more": "問題を作る",
-
-      "onboard.eyebrow": "オンボーディング",
-      "onboard.h2": "AWS との接続は、3 ステップ。",
-      "onboard.lead": "「自分のアカウントに何をされるか」をなくす設計。最小権限の AssumeRole 一本だけで、すべてが動く。",
-      "onboard.s1.h": "テンプレートを、1 度だけ。",
-      "onboard.s1.p": "CloudFormation を自分のアカウントに 1 回デプロイ。それで IAM Role が用意される。",
-      "onboard.s2.h": "ExternalId で、固く守る。",
-      "onboard.s2.p": "TenkaCloud は固有の ExternalId 付きでしか、その Role を引き受けられない。Role ARN だけでは入れない。",
-      "onboard.s3.h": "ポータルから、競技へ。",
-      "onboard.s3.p": "ログインすれば、問題環境が自動で立ち上がる。エンドポイントと点数は、その瞬間から見える。",
-      "onboard.s3.line2": "問題が割り当てられました",
-
-      "trust.eyebrow": "セキュリティ",
-      "trust.h2": "あなたの AWS は、ずっとあなたのもの。",
-      "trust.bullets": [
-        ["クロスアカウント AssumeRole + ExternalId。", "競技者アカウントへの操作は、すべて固有 ExternalId 付き。Role ARN を知っているだけでは、何もできない。"],
-        ["撤収は、いつでも自分の手で。", "ポータルから 1 クリックでスタックごと削除。リソースの取り残しも、想定外の請求もない。"],
-        ["コードは全部、GitHub にある。", "Lambda、Step Functions、IaC。何が動いているか、自分の目で読める。Apache License 2.0。"],
-        ["Free Tier の中で、走り続ける。", "DynamoDB は 1 RCU / 1 WCU 固定。アイドル中の課金は、ゼロ。"]
-      ],
-
-      "stats": [
-        { n: "100", u: "+",   l: "公開済みの問題。3 カテゴリ・5 難易度。" },
-        { n: "3",   u: "min", l: "競技者アカウントへの平均デプロイ時間。" },
-        { n: "0",   u: "$/h", l: "アイドル時の運用コスト。" },
-        { n: "100", u: "%",   l: "OSS / Apache 2.0。すべて読める。" }
-      ],
-
-      "waitlist.eyebrow": "ベータの招待を受け取る",
-      "waitlist.h2": "ウェイトリストに登録する。",
-      "waitlist.p": "公開アリーナの招待 / 開催ご相談の連絡先を残しておくと、 準備が整い次第お知らせします。 OSS なので料金はありません。",
-      "waitlist.noscript": "JavaScript を有効にすると登録フォームが表示されます。",
-      "waitlist.fallback": "フォームを開く",
-      "waitlist.unconfigured": "ウェイトリストはまもなく公開予定です。",
-
-      "ent.eyebrow": "もし、こんな使い方をしたいなら",
-      "ent.h2": "クローズドな会場で、走らせたい人へ。",
-      "ent.p": "社内勉強会、学校の授業、クローズドなインシデントレスポンス演習 — 公開アリーナで難しい使い方を考えているなら、相談してください。OSS なので料金はありません。",
-      "ent.cta1": "お問い合わせ",
-      "ent.cta2": "GitHub を見る",
-
-      "footer.tag": "AWS の実環境で競う、オープンソースのクラウド競技基盤。Apache 2.0。",
-      "footer.p0": "概要", "footer.p1": "問題カタログ", "footer.p2": "参加者ポータル", "footer.p3": "運営コンソール",
-      "footer.r0": "ドキュメント", "footer.r1": "アーキテクチャ", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0"
+      "nav.why": "なぜ", "nav.flow": "体験", "nav.author": "問題作成",
+      "hero.kicker": "AWS GameDay-style OSS platform",
+      "hero.h1a": "社内クラウド研修を、", "hero.h1b": "5分で実戦演習に。",
+      "hero.sub": "AWS GameDay のような演習を OSS で。環境払い出し、スコアリング、問題管理を自動化します。",
+      "hero.cta.try": "3分で試す", "hero.cta.github": "GitHubを見る", "hero.cta.issue": "改善Issue",
+      "preview.nav.problem": "問題", "preview.nav.score": "スコア", "preview.nav.event": "イベント", "preview.nav.try": "Try in 3 min", "preview.title": "最初の演習を開始",
+      "why.eyebrow": "Why now", "why.title": "座学では、クラウド運用の勘所は身につかない。", "why.lead": "TenkaCloud は、研修・ハッカソン・インシデント演習を「実環境で動く問題」として再利用できる形にします。",
+      "why.a.h": "準備が重い", "why.a.p": "参加者ごとのAWS環境、権限、スコアリングを毎回手作業で作ると、運営負荷が高すぎます。",
+      "why.b.h": "成果が見えない", "why.b.p": "講義を受けたことではなく、実際に直せた・守れた・最適化できたことを可視化します。",
+      "why.c.h": "問題が資産化しない", "why.c.p": "一度作った演習を、問題パッケージとして再利用・共有・改善できるようにします。",
+      "flow.eyebrow": "First experience", "flow.title": "見る、試す、理解する。", "flow.lead": "初回体験はコードを読む前に価値が伝わることを重視します。最初のゴールは5分以内に演習を開始できることです。",
+      "flow.s1.h": "LPを見る", "flow.s1.p": "対象はまず社内クラウド研修チーム。用途を絞って、5秒で価値を伝えます。",
+      "flow.s2.h": "3分デモ", "flow.s2.p": "hello-world battle を、AWS不要でも体験できる導線にします。",
+      "flow.s3.h": "スコアを見る", "flow.s3.p": "競技の面白さを、動くスコアとリーダーボードで即座に見せます。",
+      "flow.s4.h": "自分で作る", "flow.s4.p": "30分で最小問題を追加できる authoring path に接続します。",
+      "author.eyebrow": "Problem authoring", "author.title": "問題を増やせることが、TenkaCloudのスケール要因。", "author.lead": "プラットフォームの価値は問題資産で増えます。初見の人が迷わず問題を追加できる導線を最優先にします。",
+      "cta.title": "まずは、仲間内で1回走らせる。", "cta.p": "完成したら大規模ローンチではなく、AWSに詳しい仲間・コミュニティ・研修担当に限定して流し、反応を見るのが最短です。", "cta.github": "GitHubを見る", "cta.issue": "Issue #1023"
     },
     en: {
-      "nav.product": "Product",
-      "nav.problems": "Problems",
-      "nav.docs": "Docs",
-      "nav.waitlist": "Waitlist",
-      "nav.contact": "Contact",
-      "nav.github": "GitHub",
-
-      "hero.h1a": "Cloud skill ",
-      "hero.h1b": "is measured in the wild.",
-      "hero.sub": "Compete on real AWS — build it, defend it, optimize it. An open-source arena, free for anyone to use.",
-      "hero.cta1": "View on GitHub",
-      "hero.cta2": "Watch the demo",
-
-      "product.title": "Problem catalog",
-      "product.breadcrumb": "Workspace · open-arena · Season 01",
-      "product.sidebar.0": "Problems",
-      "product.sidebar.1": "Leaderboard",
-      "product.sidebar.2": "Events",
-      "product.sidebar.3": "Docs",
-
-      "modes.eyebrow": "Two modes",
-      "modes.h2": "Live battles. Solo challenges. Or both.",
-      "modes.lead": "Real-time Battles and patient Challenges, in a single event if you want.",
-      "modes.battle.kicker": "Battle",
-      "modes.battle.h": "Battle.",
-      "modes.battle.p": "Uptime, in real time. A health check probes every team every minute — the last one standing wins.",
-      "modes.battle.live": "ROUND 03 · LIVE",
-      "modes.challenge.kicker": "Challenge",
-      "modes.challenge.h": "Challenge.",
-      "modes.challenge.p": "Solve the problem, submit the flag, earn the points. Learn one AWS service at a time, in depth.",
-      "modes.challenge.input": "Hello from tc-iam-…",
-
-      "aud.eyebrow": "Who it's for",
-      "aud.h2": "For the people who play. And the people who host.",
-      "aud.lead": "Solo engineers, meetup organizers, classrooms. Run an event, or join one — without ever opening the AWS Console.",
-      "aud.a.role": "Engineers",
-      "aud.a.h": "Sharpen on the real thing.",
-      "aud.a.p": "Solve problems on real AWS, climb the rank, earn badges your résumé can prove.",
-      "aud.a.more": "Participant portal",
-      "aud.b.role": "Organizers",
-      "aud.b.h": "Run a GameDay from one screen.",
-      "aud.b.p": "Every team's environment, provisioned automatically. The week of prep collapses to an afternoon.",
-      "aud.b.more": "Operator guide",
-      "aud.c.role": "Schools & community",
-      "aud.c.h": "Teach with real AWS.",
-      "aud.c.p": "Use real AWS as a textbook. Every problem is open — and new ones are welcome from anyone.",
-      "aud.c.more": "Author a problem",
-
-      "onboard.eyebrow": "Onboarding",
-      "onboard.h2": "Connect AWS in three steps.",
-      "onboard.lead": "We designed away the \"what's it going to do in my account?\" question. One least-privilege AssumeRole — nothing more, nothing less.",
-      "onboard.s1.h": "Deploy the bootstrap, once.",
-      "onboard.s1.p": "One CloudFormation template, deployed once into your account. An IAM Role is provisioned for us.",
-      "onboard.s2.h": "Locked with ExternalId.",
-      "onboard.s2.p": "TenkaCloud can only AssumeRole with a unique ExternalId. A leaked Role ARN gets you nowhere.",
-      "onboard.s3.h": "Compete from the portal.",
-      "onboard.s3.p": "Log in. Your problem stack deploys itself. Endpoints and scores are live the moment you land.",
-      "onboard.s3.line2": "Problem assigned",
-
-      "trust.eyebrow": "Security",
-      "trust.h2": "Your AWS account, still yours.",
-      "trust.bullets": [
-        ["Cross-account AssumeRole + ExternalId.", "Every call into a player account carries a unique ExternalId. Knowing the Role ARN gets an attacker nothing."],
-        ["Tear it down whenever, yourself.", "One click in the portal removes the stack. No orphans, no surprise charges."],
-        ["The code is on GitHub.", "Lambdas, Step Functions, the IaC — read what runs, line by line. Apache License 2.0."],
-        ["Runs inside Free Tier.", "DynamoDB pinned at 1 RCU / 1 WCU. Idle cost is zero."]
-      ],
-
-      "stats": [
-        { n: "100", u: "+",   l: "Public problems. 3 categories, 5 difficulty tiers." },
-        { n: "3",   u: "min", l: "Average deploy time into a player account." },
-        { n: "0",   u: "$/h", l: "Operating cost while idle." },
-        { n: "100", u: "%",   l: "Open source. Apache 2.0. End to end." }
-      ],
-
-      "waitlist.eyebrow": "Get an invite to the beta",
-      "waitlist.h2": "Join the waitlist.",
-      "waitlist.p": "Leave your email for the public arena invite or to discuss hosting your own event. We'll reach out when we're ready. OSS — no fee.",
-      "waitlist.noscript": "Enable JavaScript to see the signup form.",
-      "waitlist.fallback": "Open the form",
-      "waitlist.unconfigured": "The waitlist will be open soon.",
-
-      "ent.eyebrow": "If you need it private",
-      "ent.h2": "Running it in a closed setting?",
-      "ent.p": "Internal study groups, classroom courses, closed-door incident-response drills — anything the public arena can't easily host. Reach out. It's OSS; there's no fee.",
-      "ent.cta1": "Get in touch",
-      "ent.cta2": "View on GitHub",
-
-      "footer.tag": "An open-source cloud-competition platform that runs on real AWS. Apache 2.0.",
-      "footer.p0": "Overview", "footer.p1": "Problems", "footer.p2": "Participant portal", "footer.p3": "Operator console",
-      "footer.r0": "Docs", "footer.r1": "Architecture", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0"
+      "nav.why": "Why", "nav.flow": "Experience", "nav.author": "Authoring",
+      "hero.kicker": "AWS GameDay-style OSS platform",
+      "hero.h1a": "Turn cloud training ", "hero.h1b": "into hands-on drills in minutes.",
+      "hero.sub": "Run AWS GameDay-style exercises as open source. Automate environment provisioning, scoring, and reusable problem management.",
+      "hero.cta.try": "Try in 3 minutes", "hero.cta.github": "View on GitHub", "hero.cta.issue": "Improvement issue",
+      "preview.nav.problem": "Problems", "preview.nav.score": "Scores", "preview.nav.event": "Events", "preview.nav.try": "Try in 3 min", "preview.title": "Start the first exercise",
+      "why.eyebrow": "Why now", "why.title": "Slides do not build cloud operations instinct.", "why.lead": "TenkaCloud turns training, hackathons, and incident drills into reusable problems that run in real environments.",
+      "why.a.h": "Setup is heavy", "why.a.p": "Creating AWS environments, permissions, and scoring for every participant by hand makes events too expensive to run repeatedly.",
+      "why.b.h": "Outcomes are invisible", "why.b.p": "Measure what people actually fixed, defended, and optimized—not just whether they attended a lecture.",
+      "why.c.h": "Problems do not compound", "why.c.p": "Turn each exercise into a reusable package that can be shared, improved, and run again.",
+      "flow.eyebrow": "First experience", "flow.title": "See it. Try it. Understand it.", "flow.lead": "The first experience should deliver value before asking people to read the source. The first milestone is starting an exercise within five minutes.",
+      "flow.s1.h": "Visit the LP", "flow.s1.p": "Start with internal cloud training teams. Narrow the message so the value lands in five seconds.",
+      "flow.s2.h": "Three-minute demo", "flow.s2.p": "Make hello-world battle testable even without an AWS account.",
+      "flow.s3.h": "Watch the score", "flow.s3.p": "Show the fun immediately through a moving scoreboard and leaderboard.",
+      "flow.s4.h": "Author your own", "flow.s4.p": "Connect the demo to a path where a new author can add a minimal problem in thirty minutes.",
+      "author.eyebrow": "Problem authoring", "author.title": "Problem supply is the scale engine.", "author.lead": "The platform becomes more valuable as reusable problems accumulate. Make first-time authoring obvious.",
+      "cta.title": "Run it once with a small circle first.", "cta.p": "Before a broad launch, share it with AWS-fluent friends, communities, and training owners. Watch where they lean in.", "cta.github": "View on GitHub", "cta.issue": "Issue #1023"
     }
   };
-
-  var PRODUCT_ROWS = [
-    { cat: "Battle",    id: "security-battle-royale", name: { ja: "Security Battle Royale", en: "Security Battle Royale" }, diff: 3, pts: "1,200 pts" },
-    { cat: "Challenge", id: "iam-escape-room",        name: { ja: "IAM Escape Room",        en: "IAM Escape Room"        }, diff: 4, pts: "  800 pts" },
-    { cat: "Challenge", id: "cost-optimizer",         name: { ja: "Cost Optimizer",         en: "Cost Optimizer"         }, diff: 2, pts: "  400 pts" },
-    { cat: "Battle",    id: "lambda-cold-war",        name: { ja: "Lambda Cold War",        en: "Lambda Cold War"        }, diff: 4, pts: "1,000 pts" }
-  ];
-
-  function renderProductRows(lang) {
-    var html = PRODUCT_ROWS.map(function (r) {
-      var stars = [1,2,3,4,5].map(function (i) {
-        return '<i class="' + (i <= r.diff ? 'on' : '') + '"></i>';
-      }).join('');
-      var tagClass = r.cat === "Battle" ? "battle" : "challenge";
-      return '<div class="row">'
-        + '<div><div class="name">' + r.name[lang] + '</div><span class="id">' + r.id + '</span></div>'
-        + '<span class="tag ' + tagClass + '">' + r.cat + '</span>'
-        + '<span class="stars">' + stars + '</span>'
-        + '<span class="pts">' + r.pts + '</span>'
-        + '</div>';
-    }).join('');
-    document.getElementById("product-rows").innerHTML = html;
-  }
-
-  function renderTrustBullets(lang) {
-    var bullets = I18N[lang]["trust.bullets"];
-    var html = bullets.map(function (entry) {
-      return '<li><span><b>' + entry[0] + '</b> ' + entry[1] + '</span></li>';
-    }).join('');
-    document.getElementById("trust-bullets").innerHTML = html;
-  }
-
-  function renderStats(lang) {
-    var stats = I18N[lang]["stats"];
-    var html = stats.map(function (s) {
-      return '<div class="stat">'
-        + '<div class="n">' + s.n + '<span class="u">' + s.u + '</span></div>'
-        + '<div class="l">' + s.l + '</div>'
-        + '</div>';
-    }).join('');
-    document.getElementById("stats-grid").innerHTML = html;
-  }
-
-  var SCORE_BASE = [
-    { name: "team-shogun",    pts: 8420 },
-    { name: "team-honnoji",   pts: 7990 },
-    { name: "team-sekigahara", pts: 7710 },
-    { name: "team-osaka",     pts: 6420 }
-  ];
-
-  function renderScoreboard(tick) {
-    var html = SCORE_BASE.map(function (r, i) {
-      var pts = r.pts + (tick * (4 - i) * 7);
-      var leadCls = i === 0 ? " lead" : "";
-      return '<div class="row' + leadCls + '">'
-        + '<span class="rank">' + (i + 1) + '</span>'
-        + '<span class="name">' + r.name + '</span>'
-        + '<span class="pts">' + pts.toLocaleString() + '</span>'
-        + '</div>';
-    }).join('');
-    document.getElementById("scoreboard-rows").innerHTML = html;
-  }
 
   function applyLang(lang) {
     document.documentElement.lang = lang;
     var dict = I18N[lang];
     document.querySelectorAll("[data-i18n]").forEach(function (el) {
       var key = el.getAttribute("data-i18n");
-      if (dict[key] != null) el.textContent = dict[key];
+      if (dict[key]) el.textContent = dict[key];
     });
-    document.querySelectorAll(".nav-right .lang").forEach(function (btn) {
+    document.querySelectorAll("[data-lang]").forEach(function (btn) {
       btn.classList.toggle("on", btn.getAttribute("data-lang") === lang);
     });
-    renderProductRows(lang);
-    renderTrustBullets(lang);
-    renderStats(lang);
-    renderWaitlist(lang);
   }
 
-  /**
-   * Issue #952: Google Form の waitlist 埋め込み。 form URL は <meta name="tenkacloud:waitlist-form-url">
-   * から読む。 値が空 / placeholder のままなら waitlist section を「準備中」アラートに降格する。
-   * Google Forms の embed URL は `https://docs.google.com/forms/d/e/<FORM_ID>/viewform?embedded=true`。
-   */
-  function renderWaitlist(lang) {
-    var meta = document.querySelector('meta[name="tenkacloud:waitlist-form-url"]');
-    var url = (meta && meta.getAttribute("content") || "").trim();
-    var embed = document.getElementById("waitlist-embed");
-    var fallback = document.getElementById("waitlist-fallback");
-    var link = document.getElementById("waitlist-fallback-link");
-    if (!embed) return;
-    if (!url || url.indexOf("docs.google.com/forms") === -1) {
-      embed.innerHTML = '<p class="sub" style="margin-top:18px;">' + I18N[lang]["waitlist.unconfigured"] + '</p>';
-      if (fallback) fallback.hidden = true;
-      return;
-    }
-    // iframe を 1 回だけ inject (= lang 切替で再描画しない)。
-    if (!embed.querySelector("iframe")) {
-      var iframe = document.createElement("iframe");
-      iframe.src = url;
-      iframe.width = "100%";
-      iframe.height = "740";
-      iframe.frameBorder = "0";
-      iframe.marginHeight = "0";
-      iframe.marginWidth = "0";
-      iframe.setAttribute("title", "TenkaCloud waitlist (Google Forms)");
-      iframe.style.border = "0";
-      iframe.style.maxWidth = "720px";
-      iframe.style.display = "block";
-      iframe.style.margin = "24px auto 0";
-      embed.appendChild(iframe);
-    }
-    if (link && fallback) {
-      link.href = url;
-      fallback.hidden = false;
-    }
-  }
-
-  document.querySelectorAll(".nav-right .lang").forEach(function (btn) {
-    btn.addEventListener("click", function () {
-      applyLang(btn.getAttribute("data-lang"));
-    });
+  document.querySelectorAll("[data-lang]").forEach(function (btn) {
+    btn.addEventListener("click", function () { applyLang(btn.getAttribute("data-lang")); });
   });
 
   applyLang("ja");
-
-  var tick = 0;
-  renderScoreboard(tick);
-  setInterval(function () { tick += 1; renderScoreboard(tick); }, 1500);
 })();
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
Implements the product-side thinking from Issue #1023.

What this PR adds:

- Launch funnel definition
- Hero repositioning proposal
- First CTA strategy
- Activation metrics
- Demo-first flow
- Guided problem authoring plan
- Skill proof roadmap (signed credentials before blockchain)
- Explicit non-goals to avoid feature drift

This intentionally focuses on product activation before implementation details.

Follow-up PR:
- Apply LP hero copy updates in landing/index.html
- Add guided 3-minute demo path

Relates #1023