### PR TITLE
fix(scripts): install.sh の TENKACLOUD_ROOT typo を修正 (deploy-saas Phase 2 fail)

### DIFF
--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -67,4 +67,14 @@ describe("scripts/install.sh Phase 3 (#716)", () => {
     expect(source).not.toContain('cp -R packages "${STAGING}/packages"');
     expect(source).not.toContain('cp -R problems "${STAGING}/problems"');
   });
+
+  // prepare-source-bundle.sh は `set -euo pipefail` で `-u` を有効化しており、 install.sh が
+  // それを source した時点で unbound variable は実行時エラーになる。 過去に install.sh の
+  // 後段 `cd` で `${TenkaCloud_ROOT}` (PascalCase 表記) と書かれていて Phase 2 で
+  // 「TenkaCloud_ROOT: unbound variable」 で deploy が止まった。 typo regression を pin する。
+  it("install.sh の repo root 変数は **全大文字** TENKACLOUD_ROOT で統一すべき (= PascalCase 禁止)", () => {
+    expect(source).not.toMatch(/\$\{TenkaCloud_ROOT[}:]/);
+    expect(source).not.toMatch(/\$\{TenkaCloud_Root[}:]/);
+    expect(source).toMatch(/\$\{TENKACLOUD_ROOT[}:]/);
+  });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,8 +38,9 @@ source "${SCRIPT_DIR}/prepare-source-bundle.sh"
 # eventTitle はオプション (default は "TenkaCloud Battle")。
 export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL="true"
 
-# TenkaCloud_ROOT は prepare-source-bundle.sh が cd する。 install.sh の後段は
-# infrastructure/ 配下で動作するため戻す。
+# TENKACLOUD_ROOT は prepare-source-bundle.sh が export する。 install.sh の後段は
+# infrastructure/ 配下で動作するため戻す。 source 経由で set -u が継承されるので、
+# 以降の cd でも変数名は **全大文字** に揃える (= typo は unbound variable で fail する)。
 cd "${TENKACLOUD_ROOT}/infrastructure"
 
 # JSII_DEPRECATED=quiet: SBT 内部の aws-cdk-lib deprecation warning を抑制 (CFT には影響なし)
@@ -88,7 +89,7 @@ echo "  Cognito Domain: ${COGNITO_DOMAIN}"
 
 # admin-console を host で build。URL は build に焼かない (runtime-config.json 経由で
 # CDK が CloudFront に配置する)。dev ローカル開発では .env.local が効くので触らない。
-cd "${TenkaCloud_ROOT}/apps/admin-console"
+cd "${TENKACLOUD_ROOT}/apps/admin-console"
 echo "  apps/admin-console: bun install + vite build (URL 非依存)"
 bun install
 bun run build
@@ -131,7 +132,7 @@ echo "  AdminInsight API URL: ${ADMIN_INSIGHT_API_URL}"
 
 # AdminConsoleHostingStack deploy: backend outputs を CDK_PARAM_* env に渡す
 # (stack が runtime-config.json に書いて S3 に配置する)
-cd "${TenkaCloud_ROOT}/infrastructure"
+cd "${TENKACLOUD_ROOT}/infrastructure"
 export CDK_PARAM_CONTROL_PLANE_API_URL="${API_URL}"
 export CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN="${COGNITO_DOMAIN}"
 export CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID="${CLIENT_ID}"


### PR DESCRIPTION
## Summary

- `scripts/install.sh` Phase 2 で `TenkaCloud_ROOT: unbound variable` エラーになり deploy-saas が止まっていた問題を修正
- `prepare-source-bundle.sh` の `set -euo pipefail` が `source` 経由で install.sh に伝播 → install.sh 後段の `cd "${TenkaCloud_ROOT}/..."` (PascalCase = typo) が unbound variable で fail
- 正しい変数名は **全大文字** `TENKACLOUD_ROOT` (= prepare-source-bundle.sh が export する名前)
- 回帰防止に `infrastructure/test/install-script.test.ts` で PascalCase 禁止 + 全大文字必須を assertion で pin

## 根本原因

```bash
# scripts/prepare-source-bundle.sh:23
set -euo pipefail   # ← -u が有効
TENKACLOUD_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"  # ← export する変数名

# scripts/install.sh:35
source "${SCRIPT_DIR}/prepare-source-bundle.sh"  # ← set -u が install.sh に伝播

# scripts/install.sh:91 (修正前、 typo)
cd "${TenkaCloud_ROOT}/apps/admin-console"  # ← unbound variable で fail
```

コミット fb4cb2a3 (`fix(lite): source.zip 自動準備で make deploy の CodeBuild エラーを解消 #985`) で `set -u` 入りの prepare-source-bundle.sh が登場し、 install.sh の latent typo が露見した形。

## 修正範囲

- `scripts/install.sh:91, 134, 41` の `TenkaCloud_ROOT` → `TENKACLOUD_ROOT`
- `infrastructure/test/install-script.test.ts` に regression test 追加 (PascalCase 禁止 / 全大文字必須)

## Test plan

- [x] `make harness` clean
- [x] `bun test test/install-script.test.ts` (7 pass、 1 件新規追加で 6→7)
- [x] `make before-commit` 通過
- [x] `bash -n scripts/install.sh` 構文 OK
- [ ] `make deploy-saas` の Phase 2 が再度通ることを確認 (= user 環境で再 deploy)

## Regression 分析

- **影響範囲**: SaaS mode (`make deploy-saas`) のみ。 Lite mode (`make deploy`) は別 entry point (`scripts/tenkacloud-lite.ts`) で本 typo を踏まない
- **壊しうる挙動**: 変数名の修正のみ。 install.sh 内の `cd` 先 path は同一 (= apps/admin-console / infrastructure)、 ふるまい変更なし
- **既存テスト**: 6 件 → 7 件に増えるのみ、 既存 assertion は不変

## 物理影響

- **CFn / 成果物**: NO-OP (= shell script + test 修正のみ、 CDK synth 結果に差分なし)
- **CI**: NO-OP (= 既存 lint / test に乗っているだけ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized environment variable naming in the installation script to prevent configuration errors.

* **Tests**
  * Added regression test to verify environment variable naming consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->