### PR TITLE
fix(participant-portal): EventsTable に GetItem grant (Event 採点中 flag 提出 reject 修正)

### DIFF
--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -105,12 +105,17 @@ export class ParticipantPortalLambda extends Construct {
             }),
           ],
         }),
-        // ADR-006 Notifications: Events table の partition Query 権限のみ。
+        // ADR-006 Notifications: Events table の partition Query 権限 + 単一行 GetItem。
+        // GetItem は Issue #1005 で導入された event-gate.ts (= submit-flag / hint reveal
+        // が共有する scoring gate) が PK=EVENT#<id> / SK=META 1 行を `dynamodb:GetItem` で
+        // 引くために必要。 grant が漏れていると AccessDenied で getEventGate が undefined を
+        // 返し、 fail-closed で `scoring_not_started` に倒れて Event は採点中なのに flag 提出
+        // が「競技はまだ開始していません」 で reject されていた。
         // 書き込みは event-handler / health-check 側に閉じる (= participant は read-only)。
         EventsRead: new PolicyDocument({
           statements: [
             new PolicyStatement({
-              actions: ["dynamodb:Query"],
+              actions: ["dynamodb:Query", "dynamodb:GetItem"],
               resources: [props.eventsTable.tableArn],
             }),
           ],

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -504,10 +504,15 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 
-  it("ParticipantPortal Lambda の IAM Role に Events table の dynamodb:Query を付与するべき", () => {
-    // ADR-006: GET /portal/me/notifications が Events table を Query する。
-    // 配線が無いと AccessDenied で 500 になる。Role 直貼りの inline policy なので
-    // `AWS::IAM::Role` の Policies 配列を見る。
+  it("ParticipantPortal Lambda の IAM Role に Events table の dynamodb:Query + GetItem を付与するべき", () => {
+    // ADR-006: GET /portal/me/notifications が Events table を Query する (= partition 単位)。
+    // Issue #1005: submit-flag / hint reveal が共有する event-gate.ts が PK=EVENT#<id> /
+    // SK=META を `dynamodb:GetItem` で 1 行引く (= scoring gate)。 grant が漏れていると
+    // AccessDenied で getEventGate が undefined を返し、 fail-closed で `scoring_not_started`
+    // に倒れ 「Event 採点中なのに flag 提出が reject される」 不整合になる (= 実 deploy で
+    // 観測した regression、 CloudWatch logs `[event-gate] getEventGate failed AccessDenied`)。
+    // 配線が無いと AccessDenied で 500 / 提出 reject になる。 Role 直貼りの inline policy
+    // なので `AWS::IAM::Role` の Policies 配列を見る。
     tpl.hasResourceProperties(
       "AWS::IAM::Role",
       Match.objectLike({
@@ -517,7 +522,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
             PolicyDocument: Match.objectLike({
               Statement: Match.arrayWith([
                 Match.objectLike({
-                  Action: "dynamodb:Query",
+                  Action: Match.arrayWith(["dynamodb:Query", "dynamodb:GetItem"]),
                   Effect: "Allow",
                 }),
               ]),


### PR DESCRIPTION
## Summary

ParticipantPortalLambda の IAM policy で EventsTable に対する `dynamodb:GetItem` 権限が抜けており、 event-gate.ts (= submit-flag / hint reveal の scoring gate) が AccessDenied で落ちて 「Event は採点中なのに flag 提出が **競技はまだ開始していません** で reject される」 不整合が発生していた。 1 line の IAM 追加で解消。

## 根本原因

Issue #1005 で `event-gate.ts` を導入したとき、 submit-flag / hint reveal 両方が gate を読むよう refactor された。 そのとき gate query は \`Query (partition 単位)\` → \`GetItem (PK=EVENT#<id> / SK=META 1 行)\` に変わったが、 ParticipantPortalLambda の inline policy `EventsRead` は `dynamodb:Query` のまま放置されていた。

CloudWatch logs (実 deploy 環境、 2026-05-18 9:41 UTC):

```
WARN [event-gate] getEventGate failed {
  eventId: '01KRWFT60ST6HG5THAADQKZH3P',
  message: '...is not authorized to perform: dynamodb:GetItem on resource:
    arn:aws:dynamodb:ap-northeast-1:...:table/tenkacloud-problem-deploy-EventsTable...
    because no identity-based policy allows the dynamodb:GetItem action'
}
```

`getEventGate` は IAM 失敗時 fail-closed で `undefined` を返し (`event-gate.ts:67-69`)、 `evaluateGate(undefined)` は `{ kind: "scoring_not_started" }` に倒れる (`event-gate.ts:83`)。 結果:

- Admin Console (Event 概要): status=READY / 採点ステータス=採点中
- Participant Portal (flag 提出): 「競技はまだ開始していません。 運営の開始合図をお待ちください。」 で reject

の plane 間 state 乖離が露見していた。

## 修正

- `infrastructure/lib/problem-deploy/participant-portal-lambda.ts`:
  `EventsRead` inline policy の actions に `dynamodb:GetItem` を追加。 リソース範囲は変えず (= 同じ EventsTable のみ)
- `infrastructure/test/problem-deploy-backend-stack.test.ts`:
  既存の `Action: "dynamodb:Query"` 単独 assertion を `Action: Match.arrayWith(["dynamodb:Query", "dynamodb:GetItem"])` に強化。 root cause (= event-gate.ts は GetItem を呼ぶ) を docblock に固定して再発防止

## Test plan

- [x] `bun run test infrastructure/test/problem-deploy-backend-stack.test.ts` 34 件 pass
- [x] `make harness` clean
- [x] `make before-commit` 通過
- [ ] `make deploy-saas` で stack update → CloudWatch logs の `[event-gate] getEventGate failed` warning 消失を確認
- [ ] Participant Portal で hello-world flag 提出 → 採点される / 「競技はまだ開始していません」 が出ないことを確認

## Regression 分析

- **影響範囲**: ParticipantPortalLambda の IAM のみ。 他 Lambda / API Gateway / DDB schema には触らない
- **壊しうる挙動**: 既存 `dynamodb:Query` 経路 (= ADR-006 Notifications) は actions array に Query を残しているので不変
- **既存テスト**: 1 件の assertion を強化、 他 33 件は不変

## 物理影響

- **CFn**: `tenkacloud-problem-deploy` stack の `ParticipantPortalLambdaRole` の inline policy `EventsRead` を **UPDATE** (= Statement.Action を string → string[2] に変更)
- **Lambda 再 deploy**: なし (= 環境変数 / bundle 変更なし)
- **DDB**: NO-OP (= 同 EventsTable に対する read 権限を 1 action 追加するだけ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)