### PR TITLE
fix(tenant-pipeline): update-tenant.sh の並列 race を wait_for_stack_idle で解消

### DIFF
--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -27,8 +27,10 @@ describe("tenant lifecycle scripts", () => {
     expect(readRepoFile("scripts/provision-tenant.sh")).toContain(
       'bunx cdk deploy "$STACK_NAME" --require-approval never',
     );
-    expect(readRepoFile("scripts/update-tenant.sh")).toContain(
-      'bunx cdk deploy "$STACK_NAME" --exclusively --require-approval never',
+    // update-tenant.sh は `${STACK_NAME}` (braces) で wait_for_stack_idle と一致させている。
+    // 形が違う provision-tenant / deprovision-tenant は他で test 済。
+    expect(readRepoFile("scripts/update-tenant.sh")).toMatch(
+      /bunx cdk deploy "\$\{?STACK_NAME\}?" --exclusively --require-approval never/,
     );
     expect(readRepoFile("scripts/deprovision-tenant.sh")).toContain(
       'bunx cdk destroy "$STACK_NAME" --force',
@@ -71,5 +73,22 @@ describe("tenant lifecycle scripts", () => {
 
     expect(miseToml).toContain(`node = "${nodeMajor}"`);
     expect(miseToml).toContain(`bun = "${bunVersion}"`);
+  });
+
+  // SBT の Step Functions provisioning は pooled stack へ並列 deploy を試みるため、
+  // cdk deploy 前に stack を idle まで poll しないと次の 2 種で fail する:
+  //   1. Cannot delete ChangeSet in status CREATE_IN_PROGRESS
+  //   2. Stack ... is in UPDATE_IN_PROGRESS state and can not be updated
+  // 実 deploy 環境 (2026-05-18 CodeBuild logs) で 3 連続 fail を観測したので regression
+  // pin する。
+  it("update-tenant.sh は cdk deploy 直前に wait_for_stack_idle で stack を poll すべき", () => {
+    const script = readRepoFile("scripts/update-tenant.sh");
+    expect(script).toContain("wait_for_stack_idle()");
+    expect(script).toContain('wait_for_stack_idle "${STACK_NAME}"');
+    // poll は cdk deploy より **前** に呼ばれていること (= race を防ぐ順序)
+    const waitIdx = script.indexOf('wait_for_stack_idle "${STACK_NAME}"');
+    const deployIdx = script.indexOf("bunx cdk deploy");
+    expect(waitIdx).toBeGreaterThan(0);
+    expect(deployIdx).toBeGreaterThan(waitIdx);
   });
 });

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -41,4 +41,42 @@ cd cdk
 # package.json (= install.sh が copy) と \`packages/trust-bridge\` (= install.sh が
 # 同梱) が揃った状態で bun が workspace resolve する。
 bun install
-bunx cdk deploy "$STACK_NAME" --exclusively --require-approval never
+
+# SBT の Step Functions provisioning が同 pooled stack へ並列 deploy を試みると CDK が
+# race し、 後続 build が次の 2 種の failure を起こす:
+#   1. Cannot delete ChangeSet in status CREATE_IN_PROGRESS (= 先行 build の ChangeSet
+#      がまだ作成中で、 後続が削除できない)
+#   2. Stack ... is in UPDATE_IN_PROGRESS state and can not be updated (= 先行 deploy が
+#      ChangeSet を execute 中で、 stack が次の update を受け付けない)
+# cdk deploy 直前に stack を idle 状態 (= *_COMPLETE / *_FAILED 等の terminal) まで poll
+# する。 stack が存在しない初回 create は MISSING 扱いで即 return (= cdk deploy が作る)。
+wait_for_stack_idle() {
+  local stack="$1"
+  local max_wait=900  # 15 min: 既存 CFn deploy の典型最長 (= LambdaFunction + UserPool 等)
+  local waited=0
+  while [ "${waited}" -lt "${max_wait}" ]; do
+    local status
+    status=$(aws cloudformation describe-stacks --stack-name "${stack}" \
+      --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "MISSING")
+    case "${status}" in
+      MISSING)
+        echo "[wait_for_stack_idle] stack ${stack} not yet created (= 初回 cdk deploy で作成される)"
+        return 0
+        ;;
+      *_IN_PROGRESS)
+        echo "[wait_for_stack_idle] stack ${stack} busy (status=${status}), 15s 後 retry (累計 ${waited}s)"
+        sleep 15
+        waited=$((waited + 15))
+        ;;
+      *)
+        echo "[wait_for_stack_idle] stack ${stack} idle (status=${status})"
+        return 0
+        ;;
+    esac
+  done
+  echo "[wait_for_stack_idle] ERROR: stack ${stack} が ${max_wait}s 経っても busy。 並列 provisioning 同士の競合を operator が手動で解消してください"
+  return 1
+}
+
+wait_for_stack_idle "${STACK_NAME}"
+bunx cdk deploy "${STACK_NAME}" --exclusively --require-approval never


### PR DESCRIPTION
## Summary

SBT Step Functions が pooled stack へ並列 deploy を試みて発生していた CodeBuild の連続 fail を、 cdk deploy 直前の stack idle poll で解消する。

## 観測 (実 deploy 環境、 2026-05-18 ap-northeast-1)

`tenkacloud-development-saas-deployment-machine` Step Functions が `CdkCodeBuildProject98C8CAB8-xov9Jrjnx5df` を 3 回連続 trigger し、 全て FAILED:

| Build ID | 時刻 | エラー |
|---|---|---|
| `e51ab3aa-…` | 18:07-18:09 | `Cannot delete ChangeSet in status CREATE_IN_PROGRESS` |
| `7aeb9d77-…` | 19:23-19:25 | 同上 |
| `67c187f0-…` | 19:33-19:35 | `Stack ... is in UPDATE_IN_PROGRESS state and can not be updated` |

どちらも root cause は **同 pooled stack へ並列 deploy を試みている race condition**:
- CDK は ChangeSet 名を `cdk-deploy-change-set` 固定で再利用するので、 並列 invocation が同名 ChangeSet を作ろうとして衝突
- 先行が ChangeSet を execute 中なら stack が `UPDATE_IN_PROGRESS` で、 後続は ChangeSet 作成自体不可

## 修正

`scripts/update-tenant.sh` (= 全 tenant pipeline の CodeBuild BuildSpec に literal で bake される source) に `wait_for_stack_idle()` を追加。 cdk deploy 直前に target stack の `StackStatus` を 15 秒間隔で poll し、 `*_IN_PROGRESS` の間は wait、 terminal (`*_COMPLETE` / `*_FAILED` / `MISSING`) になったら return。 最大 15 分まで待ち、 それでも busy なら明示 fail (= silent retry より operator 通知優先)。

```bash
wait_for_stack_idle() {
  local stack="$1"
  local max_wait=900
  local waited=0
  while [ "${waited}" -lt "${max_wait}" ]; do
    local status
    status=$(aws cloudformation describe-stacks --stack-name "${stack}" \
      --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "MISSING")
    case "${status}" in
      MISSING) return 0 ;;     # 初回 cdk deploy が作る
      *_IN_PROGRESS) sleep 15; waited=$((waited + 15)) ;;
      *) return 0 ;;            # terminal
    esac
  done
  return 1
}

wait_for_stack_idle "${STACK_NAME}"
bunx cdk deploy "${STACK_NAME}" --exclusively --require-approval never
```

## Test plan

- [x] `bash -n scripts/update-tenant.sh` 構文 OK
- [x] `bun run test test/tenant-pipeline/tenant-lifecycle-scripts.test.ts` 7 pass (= 既存 6 件 + regression pin 1 件)
- [x] `make harness` clean
- [x] `cdk synth` で synth 経路への影響なし
- [ ] PR merge 後、 `make deploy-saas` で `tenkacloud-saas-pipeline` を redeploy (= BuildSpec を CodeBuild に反映)。 以降の CodeBuild trigger で race が消えることを確認

## Regression 分析

- **影響範囲**: `update-tenant.sh` のみ。 `provision-tenant.sh` (= 初回 silo create) と `deprovision-tenant.sh` (= 削除) は対象外
- **壊しうる挙動**: 初回 stack 作成は MISSING で即 return、 既存挙動不変
- **タイムアウト**: 既存 deploy が 15 分超 hang する場合のみ後続が return 1 で fail。 silent retry より明示通知の方が運用上望ましい
- **既存テスト**: 6 件 → 7 件、 1 件 (`bunx cdk deploy` 引数 form) を regex にゆるめて `${STACK_NAME}` form を許容

## 物理影響

- **CFn**: `tenkacloud-saas-pipeline` stack の `CdkCodeBuildProject*` の `BuildSpec` を **UPDATE** (= bash script literal が CFn template に埋め込まれているため synth で diff)
- **CodeBuild runtime / IAM**: NO-OP (= `aws cloudformation describe-stacks` は CodeBuild の既存 service role が持っている権限の範囲)
- **deploy 必要**: merge 後 `make deploy-saas` (または `bunx cdk deploy tenkacloud-saas-pipeline`) で BuildSpec を CodeBuild に反映
- **stuck ChangeSet / stack の解消**: 本 PR は将来の race を防ぐが、 既に stuck 状態のものは operator 側で `aws cloudformation delete-change-set` / `aws cloudformation cancel-update-stack` で解消するか、 自然終端を待つ必要あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tenant update process with infrastructure readiness verification before deployment to prevent race conditions during concurrent provisioning operations.

* **Tests**
  * Expanded test coverage to verify infrastructure readiness checks execute before deployment commands and properly handle both new stack creation and existing stack update scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->