### PR TITLE
fix(tenant-pipeline): provision-tenant.sh の PLATINUM 大文字依存 + bootstrap URL 欠落を修正

### DIFF
--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -104,4 +104,36 @@ describe("tenant lifecycle scripts", () => {
     expect(waitIdx).toBeGreaterThan(0);
     expect(deployIdx).toBeGreaterThan(waitIdx);
   });
+
+  // Issue #1029 follow-up: tier は admin-console から大文字 / 小文字どちらでも渡ってくる
+  // 可能性がある。 provision-tenant.sh が `[[ $TIER == "PLATINUM" ]]` で大文字比較する前に
+  // 必ず uppercase 正規化する。 忘れると小文字 "platinum" が silo 分岐に入らず pooled に
+  // 倒れて UI で「Open ↗ (pooled)」 表示になる (= 2026-05-18 testsilo regression)。
+  it("provision-tenant.sh は TIER を大文字に正規化してから PLATINUM 判定すべき", () => {
+    const script = readRepoFile("scripts/provision-tenant.sh");
+    // TIER 環境変数が tr で大文字化されてから export されること
+    expect(script).toMatch(/export TIER=\$\(echo "\$tier" \| tr '\[:lower:\]' '\[:upper:\]'\)/);
+    // 比較は大文字 PLATINUM (= 正規化後の形)
+    expect(script).toContain('[[ $TIER == "PLATINUM" ]]');
+    // 正規化 (= tr) は **silo 分岐の `if [[ $TIER == "PLATINUM" ]]; then` を含む block** より
+    // 前に来ること。 docblock 内の参照と区別するため、 `if [[` を伴う block 開始行で比較する。
+    const normalizeIdx = script.indexOf("tr '[:lower:]' '[:upper:]'");
+    const branchIdx = script.indexOf('if [[ $TIER == "PLATINUM" ]]; then');
+    expect(normalizeIdx).toBeGreaterThan(0);
+    expect(branchIdx).toBeGreaterThan(normalizeIdx);
+  });
+
+  // Issue #1029 follow-up: 初回 provisioning でも admin-console-hosting の
+  // CompetitorBootstrapTemplateUrl を CFn output から読んで cdk deploy 時に env に流す。
+  // 忘れると pooled tenant の runtime-config に bootstrap URL が空のまま焼かれ、
+  // 競技者 Launch Stack で CFn が「TemplateURL must be a supported URL」 で reject する
+  // (= raw.githubusercontent.com fallback では deploy 不可、 2026-05-18 観測)。
+  it("provision-tenant.sh は admin-console-hosting の CompetitorBootstrapTemplateUrl を CFn output から export すべき", () => {
+    const script = readRepoFile("scripts/provision-tenant.sh");
+    expect(script).toMatch(
+      /CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=\$\(aws cloudformation describe-stacks/,
+    );
+    expect(script).toContain('--stack-name "tenkacloud-admin-console-hosting"');
+    expect(script).toMatch(/CompetitorBootstrapTemplateUrl/);
+  });
 });

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -49,8 +49,25 @@ export CDK_PARAM_TENANT_ID=$tenantId
 # admin-console から POST /tenants 時に渡された tenantName。runtime-config.json
 # 経由で application-admin-console の画面表示に使う (#48)。
 export CDK_PARAM_TENANT_NAME=$tenantName
-export TIER=$tier
+# Issue #1029 follow-up: tier は admin-console から大文字 (PLATINUM) で渡ってくる場合と
+# 小文字 (platinum) で渡ってくる場合の両方を扱うため、 比較する前に大文字に正規化する。
+# 小文字のまま `[[ $TIER == "PLATINUM" ]]` を通すと silo 分岐に入らず pooled に倒れ、
+# admin-console UI の Application Console column が「Open ↗ (pooled)」 と表示される
+# bug が観測された (2026-05-18 testsilo tenant)。
+export TIER=$(echo "$tier" | tr '[:lower:]' '[:upper:]')
 export TENANT_ADMIN_EMAIL=$email
+
+# Issue #1029 follow-up: admin-console-hosting stack の CompetitorBootstrapTemplateUrl
+# output (= public S3 URL) を CodeBuild 側で読み直して cdk deploy の synth に流す。
+# pooled stack の runtime-config.json に bootstrap URL が空のまま焼かれると、
+# 競技者の Launch Stack deeplink で CFn が「TemplateURL must be a supported URL」 で
+# reject する (= raw.githubusercontent.com fallback では deploy 不可)。 stack 不在は
+# 空文字 fallback (= 初回 install と同じく frontend が GitHub raw fallback に倒れる)。
+export CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=$(aws cloudformation describe-stacks \
+  --stack-name "tenkacloud-admin-console-hosting" \
+  --query "Stacks[0].Outputs[?starts_with(OutputKey,'CompetitorBootstrapTemplateUrl')].OutputValue" \
+  --output text 2>/dev/null || echo "")
+echo "CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL: ${CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
 
 # Define variables
 TENANT_ADMIN_USERNAME="tenant-admin-$CDK_PARAM_TENANT_ID"


### PR DESCRIPTION
## Summary

`make deploy-saas` 後の実 deploy 環境で 2 つの bug を観測:

1. **PLATINUM tier の tenant が silo にならず pooled として表示** (= testsilo)
2. **pooled tenant の Launch Stack deeplink で CFn が「TemplateURL must be a supported URL」 で reject**

両方とも `scripts/provision-tenant.sh` の bug。

## bug 1: PLATINUM 判定が大文字依存

```bash
if [[ $TIER == "PLATINUM" ]]; then          # ← 大文字依存
  STACK_NAME="tenkacloud-tenant-template-$CDK_PARAM_TENANT_ID"
  bun cdk deploy "$STACK_NAME"
fi
```

admin-console から `tier=platinum` (小文字) が来ると silo 分岐に入らず pooled stack を deploy 対象とし、 admin-console UI で「Open ↗ (pooled)」 表示になっていた (= 2026-05-18 testsilo 観測)。

`deprovision-tenant.sh` は既に `shopt -s nocasematch` で case-insensitive 化されていたが、 provision-tenant.sh には同等処理が無かった。

**修正**: `export TIER=$(echo "$tier" | tr '[:lower:]' '[:upper:]')` で TIER を export 前に大文字正規化する (= 内部全 reference 大文字統一)。

## bug 2: pooled stack の bootstrap URL が空のまま焼かれる

PR-#1030 で `install.sh` から pooled stack の deploy を撤去した結果、 pooled stack の lifecycle は SBT pipeline (= CodeBuild) のみが触る。 `update-tenant.sh` には admin-console-hosting の `CompetitorBootstrapTemplateUrl` を CFn output から export する処理を入れたが、 `provision-tenant.sh` には入れ忘れていた。

結果として **初回 provisioning** で pooled stack の runtime-config.json に bootstrap URL が空文字で焼かれ、 application-admin-console が GitHub raw URL fallback を使って Launch Stack deeplink を組み立て、 CFn が次の error で reject:

> TemplateURL must be a supported URL.

**修正**: `provision-tenant.sh` に `update-tenant.sh` と同じ CFn output 読み出し + env export を追加。 stack 不在 (= 初回 install の race) は空文字 fallback。

## Test plan

- [x] `bun run test test/tenant-pipeline/tenant-lifecycle-scripts.test.ts` 10 件 pass (= 既存 8 件 + 新 2 件 regression pin)
- [x] `make harness` clean
- [x] `bash -n scripts/provision-tenant.sh` 構文 OK
- [ ] 実 deploy で platinum tenant 作成 → silo stack が deploy され UI で「Open ↗」 (silo) になることを確認
- [ ] 実 deploy で pooled tenant 作成 → runtime-config に bootstrap URL が焼かれ、 Launch Stack deeplink で CFn が template を読み込めることを確認

## Regression 分析

- **影響範囲**: provision-tenant.sh のみ
- **壊しうる挙動**: TIER の大文字正規化により Cognito user attribute `custom:tenantTier` も大文字で書かれる。 既存 attribute (= 旧 deploy で小文字書き込まれた分) は変わらない、 新規 tenant は uppercase。 frontend の tier 判定は既に大文字想定 (= `tier === 'PLATINUM'`) なので互換性あり
- **既存テスト**: 8 件 → 10 件、 既存 assertion は不変

## 物理影響

- **CFn**: `tenkacloud-saas-pipeline` stack の `CdkCodeBuildProject*` の BuildSpec を **UPDATE** (= provision-tenant.sh literal が CFn template に焼き込まれているため synth で diff)
- **deploy 必要**: merge 後 `make deploy-saas` で saas-pipeline を redeploy
- **既存 tenant への影響**: NO-OP (= 既 deploy 済 tenant の TIER attribute / stack 配置は触らない、 本 PR は次以降の provisioning に効く)

## 関連

- PR-#1030: install.sh から pooled stack の deploy を撤去 + update-tenant.sh に bootstrap URL export 追加。 本 PR は同じ修正を **provision-tenant.sh** にも適用 (= 入れ忘れ修正)
- PR-#1032: sign-out fix + API Reference 削除 (= 並行 review)
- Issue #1031: install.sh を upstream 同形の `cdk deploy --all` 1 発に refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed tier value handling in provisioning script to normalize input case, ensuring consistent tier comparisons and proper configuration routing

**New Features**
- Tenant provisioning now retrieves and exports competitor bootstrap template URL from infrastructure configuration for enhanced deployment flexibility

**Tests**
- Added regression tests verifying tier normalization behavior and bootstrap template URL retrieval from stack outputs during tenant lifecycle provisioning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->