### PR TITLE
feat(admin-console): TenantList の Deleted tenant を default で hide + toggle 追加

### DIFF
--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -60,7 +60,8 @@
     "deprovision_modal_header": "Deprovision this tenant?",
     "deprovision_modal_cancel": "Cancel",
     "deprovision_modal_confirm": "Confirm",
-    "deprovision_modal_body": "Deprovisioning {tenantName} ({tenantId}). Its CloudFormation stack and DynamoDB records will be removed."
+    "deprovision_modal_body": "Deprovisioning {tenantName} ({tenantId}). Its CloudFormation stack and DynamoDB records will be removed.",
+    "show_deprovisioned_toggle": "Show deleted ({count})"
   },
   "tenant_create": {
     "header": "Create tenant",

--- a/apps/admin-console/src/i18n/locales/es.json
+++ b/apps/admin-console/src/i18n/locales/es.json
@@ -60,7 +60,8 @@
     "deprovision_modal_header": "¿Deprovisionar este tenant?",
     "deprovision_modal_cancel": "Cancelar",
     "deprovision_modal_confirm": "Confirmar",
-    "deprovision_modal_body": "Se deprovisionará {tenantName} ({tenantId}). Se eliminarán su stack de CloudFormation y los registros de DynamoDB."
+    "deprovision_modal_body": "Se deprovisionará {tenantName} ({tenantId}). Se eliminarán su stack de CloudFormation y los registros de DynamoDB.",
+    "show_deprovisioned_toggle": "Mostrar eliminados ({count})"
   },
   "tenant_create": {
     "header": "Crear tenant",

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -60,7 +60,8 @@
     "deprovision_modal_header": "テナントを deprovision しますか？",
     "deprovision_modal_cancel": "キャンセル",
     "deprovision_modal_confirm": "実行",
-    "deprovision_modal_body": "{tenantName} ({tenantId}) を deprovision します。関連する CloudFormation スタックと DynamoDB レコードが削除されます。"
+    "deprovision_modal_body": "{tenantName} ({tenantId}) を deprovision します。関連する CloudFormation スタックと DynamoDB レコードが削除されます。",
+    "show_deprovisioned_toggle": "削除済を表示 ({count} 件)"
   },
   "tenant_create": {
     "header": "テナント作成",

--- a/apps/admin-console/src/i18n/locales/zh.json
+++ b/apps/admin-console/src/i18n/locales/zh.json
@@ -60,7 +60,8 @@
     "deprovision_modal_header": "是否对该租户执行 deprovision?",
     "deprovision_modal_cancel": "取消",
     "deprovision_modal_confirm": "确认",
-    "deprovision_modal_body": "将对 {tenantName} ({tenantId}) 执行 deprovision。相关的 CloudFormation 堆栈和 DynamoDB 记录将被删除。"
+    "deprovision_modal_body": "将对 {tenantName} ({tenantId}) 执行 deprovision。相关的 CloudFormation 堆栈和 DynamoDB 记录将被删除。",
+    "show_deprovisioned_toggle": "显示已删除 ({count})"
   },
   "tenant_create": {
     "header": "创建租户",

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -8,7 +8,8 @@ import Modal from "@cloudscape-design/components/modal";
 import Popover from "@cloudscape-design/components/popover";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import { useCallback, useEffect, useState } from "react";
+import Toggle from "@cloudscape-design/components/toggle";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
 import {
@@ -68,6 +69,9 @@ export function TenantListPage({ config }: { config: AppConfig }) {
   const [tenants, setTenants] = useState<Tenant[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingDeprovision, setPendingDeprovision] = useState<Tenant | null>(null);
+  // 2026-05-18 user feedback: 削除済 (= Deleted / Deprovisioned / isActive=false) tenant が
+  // 一覧に蓄積し続けて操作対象を見つけにくくなる。 default は非表示、 toggle で表示切替。
+  const [showDeprovisioned, setShowDeprovisioned] = useState(false);
   // #657: "In progress" の経過時間表示用 wall clock。 60 秒ごとに更新し severity 再評価。
   const [nowMs, setNowMs] = useState(() => Date.now());
   // ADR-011 #590 Phase 1.A: tenantId → 集計 の lookup。
@@ -140,6 +144,17 @@ export function TenantListPage({ config }: { config: AppConfig }) {
   };
 
   const deprovisionedLabel = t("tenant_list.deprovisioned");
+
+  // 削除済 tenant の filter。 default は隠す、 toggle が ON なら全件表示。
+  const deprovisionedCount = useMemo(
+    () => (tenants ?? []).filter(isDeprovisioned).length,
+    [tenants],
+  );
+  const visibleTenants = useMemo(() => {
+    const all = tenants ?? [];
+    return showDeprovisioned ? all : all.filter((row) => !isDeprovisioned(row));
+  }, [tenants, showDeprovisioned]);
+
   return (
     <SpaceBetween size="l">
       <Header
@@ -164,11 +179,22 @@ export function TenantListPage({ config }: { config: AppConfig }) {
         </Alert>
       )}
 
+      {deprovisionedCount > 0 && (
+        <Toggle
+          checked={showDeprovisioned}
+          onChange={({ detail }) => setShowDeprovisioned(detail.checked)}
+        >
+          {interpolate(t("tenant_list.show_deprovisioned_toggle"), {
+            count: String(deprovisionedCount),
+          })}
+        </Toggle>
+      )}
+
       <Table
         variant="container"
         loading={tenants === null && error === null}
         loadingText={t("tenant_list.loading")}
-        items={tenants ?? []}
+        items={visibleTenants}
         trackBy="tenantId"
         empty={
           <Box textAlign="center" color="inherit">


### PR DESCRIPTION
## Summary

実 deploy 環境 (2026-05-18) で観測した user feedback: tenant 作成 → 削除を繰り返すと、 admin-console の Tenants 一覧に Deleted (= Deprovisioned / isActive=false) tenant が蓄積し続け、 active な操作対象を探すのが困難になる。

修正: **default で Deleted を hide**、 必要なら toggle で表示切替。

## 仕様

| 状態 | 表示 |
|---|---|
| Deleted tenant が 0 件 | toggle 非表示、 active のみ |
| Deleted tenant が 1 件以上 | toggle 「削除済を表示 (N 件)」 が現れる。 OFF (default) で active のみ、 ON で全件 |

フィルタは既存の `isDeprovisioned()` を再利用 (= "Deleted" / "deprovisioned" / isActive=false judge)。

## i18n

4 locale に `tenant_list.show_deprovisioned_toggle` を追加 (ja / en / es / zh)。

## Test plan

- [x] `bun run test apps/admin-console/` 9 file 98 件 pass
- [x] `make harness` clean
- [x] typecheck clean
- [ ] 実 deploy 検証: Deleted tenant が default で隠れる + toggle で表示できる

## Regression 分析

- **影響範囲**: admin-console の TenantList page のみ
- **壊しうる挙動**: なし。 削除済を見たい場合は toggle で expose 可能 (= 情報は隠さない、 ノイズだけ減らす)
- **既存テスト**: 98 件全て pass

## 物理影響

- **CFn**: NO-OP (= frontend dist のみ)
- **CloudFront**: admin-console dist **UPDATE** (= `make deploy-saas` で BucketDeployment が新 dist を S3 に sync)
- **Lambda / DDB / Cognito**: NO-OP

🤖 Generated with [Claude Code](https://claude.com/claude-code)