### PR TITLE
fix(lite): cdk binary path を hoist 先 (= node_modules root) に修正 (exit 127 解消)

### DIFF
--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -92,8 +92,10 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     const deployCall = inheritCalls[1];
     // 2026-05-18 user feedback「bunx 禁止」 + 「Script not found 'cdk'」 regression
     // (= PR-#1030 で bunx → bun に置換した結果、 repo root に "cdk" script が無く Bun
-    // が fail) 対策: cdk binary を infrastructure/node_modules/.bin から直接 spawn する。
-    expect(deployCall.cmd).toBe("./infrastructure/node_modules/.bin/cdk");
+    // が fail) 対策: cdk binary を repo root の hoist 先から直接 spawn する。
+    // `./infrastructure/node_modules/.bin/cdk` は workspace の hoist で broken symlink
+    // になっており exit 127 で fail する (= user 観測)。
+    expect(deployCall.cmd).toBe("./node_modules/aws-cdk/bin/cdk");
     expect(deployCall.args).toContain("deploy");
     expect(deployCall.args).toContain(LITE_STACK_NAMES.app);
     expect(deployCall.args).toContain(LITE_STACK_NAMES.problemDeploy);

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -34,15 +34,18 @@ export const LITE_STACK_NAMES = {
   problemDeploy: "tenkacloud-lite-problem-deploy",
 } as const;
 
-// cdk + tsx を repo root から呼ぶため、 infrastructure/node_modules/.bin の binary を
-// 絶対 path で指定する (= workspace の hoist 場所によらず確実)。
+// cdk + tsx を repo root から呼ぶ。 monorepo workspace で aws-cdk / tsx は **repo root**
+// の node_modules に hoist されるため、 `infrastructure/node_modules/.bin/cdk` は broken
+// symlink (= 2026-05-18 user 観測、 exit 127)。 実 binary path:
+//   - aws-cdk: `./node_modules/aws-cdk/bin/cdk`  (= shebang `#!/usr/bin/env node`、 直接実行可能)
+//   - tsx:     `./node_modules/.bin/tsx`         (= root .bin に symlink あり)
 //
-// `bun cdk ...` は Bun の script lookup が package.json scripts に "cdk" が無いと
-// `Script not found "cdk"` で fail する (= 2026-05-18 user 観測、 `make destroy` で再現)。
-// `bunx cdk` は user 方針「bunx 禁止」 で使えない。 binary を直 spawn することで Bun
-// の script lookup を経由せず、 PATH / cwd 依存も無い。
-const CDK_BIN = "./infrastructure/node_modules/.bin/cdk";
-const TSX_BIN = "./infrastructure/node_modules/.bin/tsx";
+// `bun cdk ...` は Bun の script lookup が repo root package.json に "cdk" が無いと
+// `Script not found "cdk"` で fail (= PR-#1030 で bunx → bun 置換した regression)。
+// `bunx cdk` は user 方針「bunx 禁止」 で使えない。 binary を直 spawn することで Bun の
+// script lookup を経由せず、 PATH / cwd 依存も無い。
+const CDK_BIN = "./node_modules/aws-cdk/bin/cdk";
+const TSX_BIN = "./node_modules/.bin/tsx";
 const CDK_OPTS = ["--app", `${TSX_BIN} infrastructure/bin/tenkacloud-lite.ts`];
 
 export interface SpawnCaptureResult {


### PR DESCRIPTION
## Summary

PR-#1039 で `./infrastructure/node_modules/.bin/cdk` を指定したが、 user 環境では **broken symlink** で `exit 127` (= command not found) が出た:

```
❯ make destroy
bun run scripts/tenkacloud-lite.ts down
[lite] destroying 2 stacks...
make: *** [destroy] Error 127
```

monorepo workspace で `aws-cdk` package は **repo root の node_modules に hoist** されるため、 `infrastructure/node_modules/.bin/cdk` は `../aws-cdk/bin/cdk` を指す symlink が dangling になる。

## 調査結果

2026-05-18 user 環境:
- `./infrastructure/node_modules/.bin/cdk` → broken symlink to `../aws-cdk/bin/cdk`
- `./node_modules/aws-cdk/bin/cdk` → **存在** (= 実 binary、 shebang `#!/usr/bin/env node`)
- `./node_modules/.bin/tsx` → **存在** (= symlink to `../tsx/dist/cli.mjs`)

```bash
$ ./node_modules/aws-cdk/bin/cdk --version
2.1122.0 (build c8f270c)
$ ./node_modules/.bin/tsx --version
tsx v4.22.1 / node v24.14.1
```

## 修正

`scripts/tenkacloud-lite.ts` の binary path を repo root の hoist 先に変更:

```diff
-const CDK_BIN = "./infrastructure/node_modules/.bin/cdk";
-const TSX_BIN = "./infrastructure/node_modules/.bin/tsx";
+const CDK_BIN = "./node_modules/aws-cdk/bin/cdk";
+const TSX_BIN = "./node_modules/.bin/tsx";
```

aws-cdk は `.bin` 経由ではなく直接 binary path を指す (= repo root には aws-cdk の `.bin` symlink が無い workspace 配置のため)。 tsx は repo root の `.bin` に symlink あり。

## Test plan

- [x] `bun run test test/scripts/tenkacloud-lite.test.ts` 16 件 pass
- [x] 直接実行 sanity check: cdk 2.1122.0, tsx v4.22.1 確認
- [ ] 実環境で `make destroy` 完走

## Regression 分析

- **影響範囲**: scripts/tenkacloud-lite.ts + test (= path 文字列 2 行)
- **壊しうる挙動**: なし。 hoist 先を直接指すので workspace 配置が変わらない限り deterministic
- **既存テスト**: 16 件 pass、 assertion 更新

## 物理影響

- **CFn / Lambda / DDB**: NO-OP
- **deploy 必要**: なし

## 関連

- PR-#1039 (merged): 同 issue を一度直そうとしたが path 選択を誤った。 本 PR で path を修正
- 完全に独立した path の問題 (= bun script lookup の方は前 PR で解決済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)