### PR TITLE
fix(cdk): cdk.json の app を bun run script 経由に (= PLATINUM silo provisioning fail 解消)

### DIFF
--- a/infrastructure/cdk.json
+++ b/infrastructure/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "bun tsx bin/infrastructure.ts",
+  "app": "bun run _synth-app",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -14,7 +14,8 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "_synth-app": "tsx bin/infrastructure.ts"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.1048.0",


### PR DESCRIPTION
## Summary

PR-#1030 で `bunx tsx` → `bun tsx` に置換した結果、 `infrastructure/cdk.json` の app entry が CodeBuild 環境で `Script not found "esbuild"` で fail し、 SBT pipeline の PLATINUM silo provisioning が中断していた (= 2026-05-18 観測、 Issue #1038 P0)。

PR-#1040 で `scripts/tenkacloud-lite.ts` の方は binary 直接 spawn で解決済。 本 PR は同じ regression を **`infrastructure/cdk.json`** にも適用する (= こちらは CDK CLI が cwd を infrastructure/ にする経路なので別アプローチ)。

## 修正

- `infrastructure/package.json` に `"_synth-app": "tsx bin/infrastructure.ts"` を追加 (= underscore prefix で internal 利用を明示)
- `infrastructure/cdk.json` の `"app"` を `"bun run _synth-app"` に変更

`bun run _synth-app` は Bun が package.json scripts を lookup → "tsx ..." を shell context で実行 → tsx は PATH (= node_modules/.bin) から resolve される。 user 方針「bunx 禁止」 にも準拠。

## Test plan

- [x] `bun run _synth-app` から synth が開始 (= tsx 呼び出し成功、 Docker bundling error は別問題)
- [x] `make harness` clean
- [ ] 実 deploy で SBT pipeline / PLATINUM provisioning が完走、 silo stack `tenkacloud-tenant-template-<id>` が作成され UI で「Open ↗」 (silo) 表示

## Regression 分析

- **影響範囲**: cdk.json + package.json のみ
- **壊しうる挙動**: なし
- **既存テスト**: 影響なし

## 物理影響

- **CFn**: `tenkacloud-saas-pipeline` の `CdkCodeBuildProject*` BuildSpec / asset bundle に同梱される cdk.json + package.json が **UPDATE**
- **deploy 必要**: merge 後 `make deploy-saas` で saas-pipeline を redeploy + 全 stack refresh

## 関連

- PR-#1040 (merged): scripts/tenkacloud-lite.ts 側の同 regression を解決
- Issue #1038 P0: PLATINUM tenant が silo にならない / tenant admin user 未作成 → 本 PR で根本解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)