### PR TITLE
feat(participant-portal): 競技開始前は ProblemDetail を lock (= 種明かし防止 P0 #2)

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -93,6 +93,20 @@ export interface ParticipantProblemView {
  * 設計判断: per-endpoint health (どの endpoint が落ちているか) は participant API には
  * 出さない。Battle のゲーム性 = 「なぜ壊れているかを防御側自身が調査して回復する」。
  */
+/**
+ * Issue #1038 P0 #2: 競技開始前 / 終了 / 一時停止 の gate 状態を backend が
+ * 計算して返す (= participant-handler `/portal/me`)。
+ *
+ * frontend は `kind: "scoring_not_started"` のとき ProblemDetail page を lock screen
+ * (= 「競技開始前です」 表示) に切り替える。 backend 側で fail-closed を担保するので
+ * eventId 不在 / gate 取得失敗時も "scoring_not_started" が返り、 不正アクセスを防ぐ。
+ */
+export type ParticipantEventGate =
+  | { readonly kind: "ok" }
+  | { readonly kind: "scoring_not_started"; readonly startsAt?: string }
+  | { readonly kind: "scoring_ended"; readonly endsAt?: string }
+  | { readonly kind: "scoring_locked" };
+
 export interface ParticipantTeamView {
   readonly team: {
     readonly teamName: string;
@@ -101,6 +115,8 @@ export interface ParticipantTeamView {
     readonly teamId?: string;
   };
   readonly problems: readonly ParticipantProblemView[];
+  /** Issue #1038 P0 #2: event gate (= 競技開始前 / 終了 / lock 中) status。 */
+  readonly eventGate?: ParticipantEventGate;
 }
 
 export type SubmitFlagOutcome =

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -108,12 +108,9 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       {/* #550: 競技者向けに problem の narrative を 1 section にまとめる。
        *   metadata 不在 (= 旧 problem 等) は section ごと skip。
        *   Issue #1038 P0 #2: scoring_not_started のときは render しない (= lock)。 */}
-      {problem &&
-        metadata &&
-        narrative &&
-        view?.eventGate?.kind !== "scoring_not_started" && (
-          <ProblemInfoSection metadata={metadata} narrative={narrative} />
-        )}
+      {problem && metadata && narrative && view?.eventGate?.kind !== "scoring_not_started" && (
+        <ProblemInfoSection metadata={metadata} narrative={narrative} />
+      )}
       {/* 2026-05-18 user feedback: 「攻撃時刻を相手に予告する Red Team は存在しない」
        *   「種明かしをした おばけやしき はつまらない」
        *   ADR-012 Phase 4 / Issue #607 の `TimelinePredictSection` (= 残時間 countdown +
@@ -139,12 +136,12 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
         metadata &&
         metadata.endpoints.length > 0 &&
         view?.eventGate?.kind !== "scoring_not_started" && (
-        <EndpointOverrideForm
-          apiBaseUrl={config.apiBaseUrl}
-          teamLoginKey={sessionToken ?? ""}
-          problemId={problem.problemId}
-        />
-      )}
+          <EndpointOverrideForm
+            apiBaseUrl={config.apiBaseUrl}
+            teamLoginKey={sessionToken ?? ""}
+            problemId={problem.problemId}
+          />
+        )}
 
       {/* ADR-012 Phase 5: problem 側 portal plugin (= metadata.dashboard.slots で宣言) を
        *   render する。 該当 slot が無い問題は section 全体が render されない。 */}

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -85,11 +85,35 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       )}
       {!problem && !view && !error && <Box>状態を取得中…</Box>}
 
-      {/* #550: 競技者向けに problem の narrative を 1 section にまとめる。
-       *   metadata 不在 (= 旧 problem 等) は section ごと skip。 */}
-      {problem && metadata && narrative && (
-        <ProblemInfoSection metadata={metadata} narrative={narrative} />
+      {/* Issue #1038 P0 #2: 競技開始前は問題詳細 / hints へのアクセスを **完全に lock**。
+       *   backend (= participant-handler) から eventGate が scoring_not_started で返ってきた
+       *   とき、 problem detail の代わりに lock screen を表示する。 backend 側で fail-closed
+       *   が担保されているため、 eventId 不在 / gate 取得失敗時も同じく lock 表示になる。
+       *   競技公平性 (= 開始前に hints / 問題文を読んで準備するのを防ぐ) のため必須。 */}
+      {problem && view?.eventGate?.kind === "scoring_not_started" && (
+        <Alert type="info" header="競技開始前です">
+          <Box variant="p">
+            この問題は <strong>競技開始時刻まで lock</strong> されています。 開始までは問題詳細
+            ・ヒント・flag 提出経路にアクセスできません。 運営の開始合図をお待ちください。
+            {view.eventGate.startsAt && (
+              <>
+                <br />
+                開始予定: <code>{new Date(view.eventGate.startsAt).toLocaleString()}</code>
+              </>
+            )}
+          </Box>
+        </Alert>
       )}
+
+      {/* #550: 競技者向けに problem の narrative を 1 section にまとめる。
+       *   metadata 不在 (= 旧 problem 等) は section ごと skip。
+       *   Issue #1038 P0 #2: scoring_not_started のときは render しない (= lock)。 */}
+      {problem &&
+        metadata &&
+        narrative &&
+        view?.eventGate?.kind !== "scoring_not_started" && (
+          <ProblemInfoSection metadata={metadata} narrative={narrative} />
+        )}
       {/* 2026-05-18 user feedback: 「攻撃時刻を相手に予告する Red Team は存在しない」
        *   「種明かしをした おばけやしき はつまらない」
        *   ADR-012 Phase 4 / Issue #607 の `TimelinePredictSection` (= 残時間 countdown +
@@ -98,7 +122,8 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
        *   Event 管理画面) で再利用する可能性があるため file は維持、 participant portal の
        *   ProblemDetail からのみ撤去する。 */}
 
-      {problem && (
+      {/* Issue #1038 P0 #2: ProblemPanel (= flag 提出 / hint reveal の UI 本体) も lock。 */}
+      {problem && view?.eventGate?.kind !== "scoring_not_started" && (
         <ProblemPanel
           problem={problem}
           apiBaseUrl={config.apiBaseUrl}
@@ -108,8 +133,12 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
       )}
 
       {/* Issue #607 ADR-012 Phase 3.A UI: endpoints[] が宣言された Battle 問題で override 登録
-       *   form を表示。 endpoints 空 / 不在の問題 (= flag-only Challenge 等) は内部で skip。 */}
-      {problem && metadata && metadata.endpoints.length > 0 && (
+       *   form を表示。 endpoints 空 / 不在の問題 (= flag-only Challenge 等) は内部で skip。
+       *   Issue #1038 P0 #2: scoring_not_started のときは render しない (= lock)。 */}
+      {problem &&
+        metadata &&
+        metadata.endpoints.length > 0 &&
+        view?.eventGate?.kind !== "scoring_not_started" && (
         <EndpointOverrideForm
           apiBaseUrl={config.apiBaseUrl}
           teamLoginKey={sessionToken ?? ""}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -4,6 +4,7 @@ import { parseStackOutputs } from "../shared/cfn-status.js";
 import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
 import { parseEndpointsHealth } from "../shared/endpoints-health.js";
 import { parseHintRevealedAttribute } from "../shared/hint-reveal.js";
+import { evaluateGate, type GateBlock, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 /**
@@ -117,6 +118,21 @@ export interface ParticipantTeamView {
     readonly teamId?: string;
   };
   readonly problems: readonly ParticipantProblemView[];
+  /**
+   * Issue #1038 P0 #2: 競技開始前 / 終了 / 一時停止 の gate 状態。 frontend が
+   * ProblemDetail page にロック画面を出すために使う (= competitor が競技開始前に問題詳細
+   * や hints を覗き見るのを防ぐ)。
+   *
+   * - `{ kind: "ok" }` = gate 通過、 通常表示
+   * - `{ kind: "scoring_not_started", startsAt? }` = 競技開始前、 ProblemDetail を隠す
+   * - `{ kind: "scoring_ended", endsAt? }` = 競技終了後、 ProblemDetail は閲覧可能だが
+   *   提出 / hint reveal は backend gate で reject される (= 既存挙動と同等)
+   * - `{ kind: "scoring_locked" }` = 一時 lock、 提出 / hint reveal は同様に reject
+   *
+   * eventId 不在 / gate 取得失敗時は **fail-closed** で scoring_not_started 扱い
+   * (= 安全側に倒す)。
+   */
+  readonly eventGate?: GateBlock | { readonly kind: "ok" };
 }
 
 /**
@@ -268,13 +284,28 @@ function toApplicationStatus(item: Partial<DeploymentItem>): ApplicationStatus {
  *
  * GSI2 は eventually consistent。直近に rotate / 削除された teamLoginKey は最大
  * 数百ms 程度認証が通る可能性があるが、TTL ベースの teardown と整合する許容範囲。
+ *
+ * Issue #1038 P0 #2: team view に **eventGate** (= 競技開始前 / 終了 / 一時停止 の judge)
+ * を含める。 frontend が ProblemDetail page にロック画面を出すために使う (= competitor が
+ * 競技開始前に問題詳細 / hints を覗き見るのを防ぐ)。 gate 取得 fail (= eventId 不在 /
+ * IAM 失敗) は fail-closed で `kind: "scoring_not_started"` 扱い (= 安全側に倒す)。
  */
 export async function lookupTeamByLoginKey(
   shared: ParticipantSharedResources,
   teamLoginKey: string,
 ): Promise<ParticipantTeamView | undefined> {
   const items = await queryTeamItems(shared, teamLoginKey);
-  return buildTeamView(items, shared.problemsScoring);
+  const view = buildTeamView(items, shared.problemsScoring);
+  if (!view) return undefined;
+
+  // eventGate を取得して team view に注入。 eventId 不在は gate 不明 → fail-closed。
+  const eventId = view.team.eventId;
+  if (eventId) {
+    const gate = await getEventGate(shared, eventId);
+    const block = evaluateGate(gate, Date.now());
+    return { ...view, eventGate: block ?? { kind: "ok" } };
+  }
+  return { ...view, eventGate: { kind: "scoring_not_started" } };
 }
 
 /**

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -210,7 +210,7 @@ async function ensureTenantAdminUser(email: string, io: CliIO): Promise<number> 
   }
   // `https://<prefix>.auth.<region>.amazoncognito.com` から prefix を抽出。
   const match = domainUrl.match(/^https?:\/\/([^.]+)\.auth\./);
-  if (!match || !match[1]) {
+  if (!match?.[1]) {
     io.stderr(`[lite] failed to parse CognitoDomainUrl: ${domainUrl}\n`);
     return 1;
   }

--- a/scripts/tenkacloud-problem.ts
+++ b/scripts/tenkacloud-problem.ts
@@ -1060,7 +1060,7 @@ export function runInspect(args: { problemId: string }): InspectResult {
 function extractFlagFromTemplate(yaml: string, key: string): string | null {
   const re = new RegExp(`${key}:[\\s\\S]*?Value:\\s*("[^"\\n]+"|'[^'\\n]+'|[^\\n!]+)\\n`, "m");
   const m = yaml.match(re);
-  if (!m || !m[1]) return null;
+  if (!m?.[1]) return null;
   const raw = m[1].trim();
   if (raw.startsWith("!")) return null;
   return raw.replace(/^["']|["']$/g, "");


### PR DESCRIPTION
## Summary

2026-05-18 user feedback「競技開始前に問題の詳細まで飛べてしまう。 問題のロック機能が動いていない」 を解消。

backend が `eventGate` を team view response (= `GET /portal/me`) に含めるよう拡張し、 frontend は `scoring_not_started` のとき ProblemDetail page を **完全 lock screen** に切替える。

## 修正

### Backend (= `infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts`)

- `ParticipantTeamView` に `eventGate?: GateBlock | { kind: "ok" }` field を追加
- `lookupTeamByLoginKey` が team view 構築後に既存 `getEventGate` + `evaluateGate` を呼び、 結果を team view に inject
- **fail-closed**: eventId 不在 / gate 取得失敗時は `scoring_not_started` 扱い (= 不正アクセス防止)

### Frontend (= `apps/participant-portal/src/`)

- `api/portal-client.ts`: `ParticipantEventGate` type + `ParticipantTeamView.eventGate` を export
- `pages/ProblemDetail.tsx`: `eventGate.kind === "scoring_not_started"` のとき:
  - `ProblemInfoSection` (= 問題説明) を render しない
  - `ProblemPanel` (= flag 提出 / hint reveal UI) を render しない
  - `EndpointOverrideForm` を render しない
  - 代わりに 「競技開始前です」 Alert を表示 (= startsAt が backend にあれば日時表示)

## Test plan

- [x] `bun run test apps/participant-portal/` 16 file 150 件 pass
- [x] `bunx tsc --noEmit` clean
- [x] `make harness` clean
- [ ] 実 deploy で確認: 競技開始前は問題詳細 page が lock 表示、 開始後に通常表示

## Regression 分析

- **影響範囲**: participant-handler/lookup.ts + portal-client.ts + ProblemDetail.tsx
- **壊しうる挙動**: 既存 deploy で eventGate は undefined → frontend の判定は通常表示 (= 後方互換、 段階導入可能)
- **既存テスト**: 150 件 pass、 新 gate path は実 deploy で検証

## 物理影響

- **CFn**: ParticipantPortalLambda bundle が **UPDATE** (= lookup.ts に import 追加)
- **DDB / Lambda IAM**: NO-OP (= PR-#1026 で grant 済の `dynamodb:GetItem` を再利用)
- **deploy 必要**: merge 後 `make deploy-saas`

## 関連

- Issue #1038 P0 #2: 問題ロック未動作 → 本 PR で解決
- PR-#1026: ParticipantPortalLambda に `dynamodb:GetItem` 権限を grant (= 既 merge 済、 本 PR の前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Problem details are now locked until the competition officially starts
  * Users see an informational alert with the scheduled start time when attempting to access problems before the competition begins

* **Chores**
  * Code improvements and optimizations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->