### PR TITLE
fix(participant-handler): hint reveal で score event 履歴を書く (P1 #8)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
@@ -1,6 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { ProblemScoringMetadata } from "../../../utils/scoring-metadata.js";
 import { parseHintRevealedAttribute } from "../shared/hint-reveal.js";
+import { writeScoreEvent } from "../shared/score-event.js";
 import { evaluateGate, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
@@ -110,6 +111,36 @@ export async function revealHint(
       }),
     );
     const totalScore = Number((updated.Attributes as { score?: unknown })?.score ?? -hint.penalty);
+
+    // Issue #1038 P1 #8: hint 開封の score event を履歴に書く (= 旧来 score だけ ADD して
+    // score event 行を作らず、 portal の Score events ページが「-30pt なのに履歴 0 件」 と
+    // 表示する不整合を起こしていた)。 best-effort で書き、 失敗時は log のみ (= 親 score
+    // の整合性は ADD で既に成立、 履歴の loss だけ受容、 既存 writeScoreEvent と同方針)。
+    if (hint.penalty !== 0) {
+      try {
+        await writeScoreEvent(
+          shared.ddb,
+          shared.tableName,
+          {
+            jobId: String(item.jobId ?? ""),
+            problemId: item.problemId,
+            ...(typeof item.teamId === "string" ? { teamId: item.teamId } : {}),
+            ...(typeof item.eventId === "string" ? { eventId: item.eventId } : {}),
+            expiresAt: Number(item.expiresAt ?? 0),
+          },
+          "hint",
+          -hint.penalty,
+          now,
+        );
+      } catch (err) {
+        console.warn("[reveal-hint] writeScoreEvent failed (best-effort)", {
+          jobId: item.jobId,
+          hintId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     return {
       kind: "ok",
       content: hint.content,

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -29,16 +29,20 @@ export interface ScoreEventItem {
    * - `flag-wrong`: 競技者の flag 提出が不正解で wrongAnswerPenalty が減点された (Issue #817)
    * - `attack-detected`: HealthCheck で `lastResult: ok → fail` 遷移を検知 (ADR-005 D2-A、
    *   Battle Portal の Attack Statistics / History で使う)
+   * - `hint`: 競技者がヒントを開封し penalty が deduct された (Issue #1038 P1 #8、 2026-05-18)。
+   *   旧来 hint reveal は score を直 ADD するだけで score event 履歴に出ず、 「-30 pt なのに
+   *   履歴 0 件」 表示の不整合になっていた。
    */
-  source: "uptime" | "flag" | "flag-wrong" | "attack-detected";
+  source: "uptime" | "flag" | "flag-wrong" | "attack-detected" | "hint";
   /**
    * 加算ポイント。`uptime` = scoring.pointsPerSuccess、`flag` = scoring.points、
-   * `flag-wrong` = -wrongAnswerPenalty (= 減点、 負数)、 `attack-detected` = 0 (= イベント marker のみ)。
+   * `flag-wrong` = -wrongAnswerPenalty (= 減点、 負数)、 `attack-detected` = 0 (= イベント marker のみ)、
+   * `hint` = -hint.penalty (= 減点、 負数)。
    */
   points: number;
   /**
    * 結果。
-   * - `ok`: `uptime` で全 endpoint OK or `flag` で正解
+   * - `ok`: `uptime` で全 endpoint OK or `flag` で正解 or `hint` 開封成功
    * - `wrong`: `flag-wrong` (= 不正解で減点、 Issue #817)
    * - `down`: `attack-detected` (= 攻撃が刺さって uptime が落ちた)
    *

--- a/infrastructure/test/problem-deploy/reveal-hint.test.ts
+++ b/infrastructure/test/problem-deploy/reveal-hint.test.ts
@@ -264,10 +264,12 @@ describe("revealHint (#742 Phase 3)", () => {
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] }); // no eventId
       ddbSend.mockResolvedValueOnce({ Attributes: { score: 90 } });
+      // Issue #1038 P1 #8: hint reveal の score event 履歴書き込み (= 3 つ目の DDB call)。
+      ddbSend.mockResolvedValueOnce({});
       const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
       expect(out.kind).toBe("ok");
-      // EventMeta の Get は呼ばない (= 2 calls: query + update のみ)
-      expect(ddbSend).toHaveBeenCalledTimes(2);
+      // EventMeta の Get は呼ばない、 score event の Put は呼ぶ (= 3 calls: query + update + score-event Put)
+      expect(ddbSend).toHaveBeenCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

2026-05-18 user feedback (= Image #9): 「ヒント開封のスコアが score events 履歴に出ない」。 旧来 reveal-hint handler は score を直 ADD するだけで score event 行を書いておらず、 portal の Score events page で「-30 pt なのに履歴 0 件」 表示の不整合を起こしていた。

## 修正

### Backend

- `shared/score-event.ts`: `ScoreEventItem.source` の union に `"hint"` を追加
- `participant-handler/reveal-hint.ts`: DDB UpdateCommand 成功後に `writeScoreEvent(..., "hint", -hint.penalty, now)` を呼ぶ
  - `hint.penalty === 0` のときは skip (= score 変動なしで履歴 noise を作らない)
  - best-effort: writeScoreEvent 失敗時は log のみ (= 既存 writeScoreEvent と同方針)

### Frontend (= 既存準備済)

- `ScoreEventView.source` には既に `"hint"` が含まれていた (= Issue #1001)
- `ScoreEvents.tsx` の `SOURCE_LABEL` / `SOURCE_COLOR` にも「ヒント開封」 ラベル + grey 色 が定義済

frontend は **準備済**、 backend が writeScoreEvent を呼んでいなかったのが原因。 本 PR で backend を整合させる。

## Test plan

- [x] `bun run test test/problem-deploy/reveal-hint.test.ts` 17 件 pass
- [x] `bun run test infrastructure/` 1200 件 pass
- [x] `make harness` clean
- [ ] 実 deploy でヒント開封 → Score events page に「ヒント開封 -30pt」 表示

## Regression 分析

- **影響範囲**: reveal-hint.ts + score-event.ts
- **壊しうる挙動**: なし
- **既存テスト**: 1200 件 pass

## 物理影響

- **CFn**: ParticipantPortalLambda bundle が UPDATE
- **DDB IAM**: NO-OP (= 既存 PutItem 権限を再利用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)