### PR TITLE
feat(#1038): READY event を endsAt 経過で自動 ENDED 遷移 (P0 #3)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/event-reconciler.ts
@@ -17,10 +17,13 @@ import { QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb"
  *
  * - `DEPLOYING`: 子 deployment が **全て terminal** (`COMPLETE` / `FAILED`) → `READY`。
  *   1 件でも進行中 (`PENDING` / `IN_PROGRESS`) があれば `undefined` (= 触らない)。
+ * - `READY`: `endsAt` が現在時刻を過ぎていたら → `ENDED` (Issue #1038 P0 #3、 2026-05-18)。
+ *   user 観測「終了時刻を過ぎたのにイベントが終わらない」 を解消するため、 endsAt 経過後の
+ *   1 分以内に自動 ENDED 遷移する。 endsAt 不在の event は無期限なので `undefined`。
  * - `TEARDOWN`: 子 deployment が **全て終端** (`DELETED` / `FAILED`) → `ARCHIVED`。
  *   `DELETING` が残っていれば `undefined`。
  * - 子 deployment 0 件: `undefined` (= bulk-deploy/bulk-delete 前の race state、触らない)。
- * - その他 status (`DRAFT` / `READY` / `ENDED` / `ARCHIVED`): caller でフィルタ済前提だが
+ * - その他 status (`DRAFT` / `ENDED` / `ARCHIVED`): caller でフィルタ済前提だが
  *   defense-in-depth で `undefined`。
  *
  * `FAILED` を terminal に含む理由: deploy が失敗した行も「これ以上進行しない」状態なので
@@ -30,7 +33,18 @@ import { QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb"
 export function resolveEventStatusTransition(
   eventStatus: string,
   deploymentStatuses: readonly string[],
-): "READY" | "ARCHIVED" | undefined {
+  context?: { readonly endsAt?: string; readonly nowMs?: number },
+): "READY" | "ENDED" | "ARCHIVED" | undefined {
+  if (eventStatus === "READY") {
+    // Issue #1038 P0 #3: endsAt 経過で自動 ENDED 遷移。 deployment status は不要 (= 採点 gate は
+    // event-gate.ts が endsAt から既に judge している)。
+    const endsAt = context?.endsAt;
+    const nowMs = context?.nowMs;
+    if (!endsAt || nowMs === undefined) return undefined;
+    const endsAtMs = Date.parse(endsAt);
+    if (!Number.isFinite(endsAtMs)) return undefined;
+    return nowMs >= endsAtMs ? "ENDED" : undefined;
+  }
   if (deploymentStatuses.length === 0) return undefined;
   if (eventStatus === "DEPLOYING") {
     const allTerminal = deploymentStatuses.every((s) => s === "COMPLETE" || s === "FAILED");
@@ -195,8 +209,11 @@ export async function rescueStuckDeletingDeployments(
 }
 
 /**
- * Events table を scan して `DEPLOYING` / `TEARDOWN` 状態の Event について、
- * 子 deployment 集約 status を見て `READY` / `ARCHIVED` に遷移させる (#557 #539)。
+ * Events table を scan して `DEPLOYING` / `READY` / `TEARDOWN` 状態の Event について
+ * 自動遷移を判定 (#557 #539 / Issue #1038 P0 #3):
+ *   - `DEPLOYING`: 子 deployment 全 terminal → `READY`
+ *   - `READY` + `endsAt` 経過 → `ENDED`
+ *   - `TEARDOWN`: 子 deployment 全 終端 → `ARCHIVED`
  *
  * 各 Event の判定は **並列**: 1 件遅い tenant が他を block しない。Update が CCF
  * (= operator 手動遷移などの race) で失敗した行は silent skip (= 次の tick で再評価)。
@@ -213,11 +230,12 @@ export async function reconcileEventStatuses(
     const out = await ctx.ddb.send(
       new ScanCommand({
         TableName: ctx.eventsTableName,
-        ProjectionExpression: "PK, tenantId, eventId, #status",
+        ProjectionExpression: "PK, tenantId, eventId, #status, endsAt",
         ExpressionAttributeNames: { "#status": "status" },
-        FilterExpression: "#status = :deploying OR #status = :teardown",
+        FilterExpression: "#status = :deploying OR #status = :ready OR #status = :teardown",
         ExpressionAttributeValues: {
           ":deploying": "DEPLOYING",
+          ":ready": "READY",
           ":teardown": "TEARDOWN",
         },
         Limit: 100,
@@ -229,67 +247,115 @@ export async function reconcileEventStatuses(
       tenantId?: string;
       eventId?: string;
       status?: string;
+      endsAt?: string;
     }>;
 
     const nowMs = Date.parse(nowIso);
-    await Promise.all(
-      items.map(async (event) => {
-        if (!event.tenantId || !event.eventId || !event.status || !event.PK) return;
-        // narrow optional から required へ (= 以降 closure 内では string 確定)
-        const eventStatus: string = event.status;
-        // 子 deployments を GSI1 (TENANT#) で query → eventId filter 後の全 page を集約。
-        const depRows = await queryDeploymentRowsForEvent(ctx, {
-          tenantId: event.tenantId,
-          eventId: event.eventId,
-        });
-        // Issue #828: TEARDOWN で `DELETING` 行が `STUCK_DELETING_THRESHOLD_MS` 以上停滞していれば
-        // FAILED に倒す (= bulk-delete publish chunk 失敗 / State Machine 未起動 / 競技者の手動 stack
-        // 削除で silent path に倒れた orphan 行を救済し、 ARCHIVED 自動遷移を解錠する)。
-        // DDB Update は side-effect で発火、 同 tick の transition 判定には rescue 後の値を
-        // 想定した `adjustedStatuses` を使う (= 次 tick を待たずに同 tick で ARCHIVED 化可能)。
-        if (eventStatus === "TEARDOWN" && Number.isFinite(nowMs)) {
-          await rescueStuckDeletingDeployments(ctx, depRows, nowMs);
-        }
-        const adjustedStatuses = depRows.map((r) =>
-          isStuckDeletingForTeardown(eventStatus, r, nowMs) ? "FAILED" : r.status,
-        );
-        const next = resolveEventStatusTransition(eventStatus, adjustedStatuses);
-        if (!next) return;
-
-        try {
-          await ctx.ddb.send(
-            new UpdateCommand({
-              TableName: ctx.eventsTableName,
-              Key: { PK: event.PK, SK: "META" },
-              UpdateExpression: "SET #status = :next, updatedAt = :now",
-              // race 防止: 期待 current status と一致しているときのみ更新 (= operator が
-              // 手動 archive / 再 deploy で先に動かしてたら CCF で skip)。
-              ConditionExpression: "tenantId = :tenant AND #status = :current",
-              ExpressionAttributeNames: { "#status": "status" },
-              ExpressionAttributeValues: {
-                ":tenant": event.tenantId,
-                ":current": eventStatus,
-                ":next": next,
-                ":now": nowIso,
-              },
-            }),
-          );
-          console.log("[generic-scoring] Event status auto-transition", {
-            eventId: event.eventId,
-            from: eventStatus,
-            to: next,
-          });
-        } catch (err) {
-          const code = (err as { name?: string })?.name ?? "";
-          if (code === "ConditionalCheckFailedException") return;
-          console.warn("[generic-scoring] Event status update failed", {
-            eventId: event.eventId,
-            message: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }),
-    );
+    await Promise.all(items.map((event) => reconcileSingleEvent(ctx, event, nowIso, nowMs)));
 
     exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
+}
+
+async function reconcileSingleEvent(
+  ctx: ReconcileEventStatusesContext,
+  event: {
+    readonly PK?: string;
+    readonly tenantId?: string;
+    readonly eventId?: string;
+    readonly status?: string;
+    readonly endsAt?: string;
+  },
+  nowIso: string,
+  nowMs: number,
+): Promise<void> {
+  if (!event.tenantId || !event.eventId || !event.status || !event.PK) return;
+  const eventStatus: string = event.status;
+
+  // Issue #1038 P0 #3: READY → ENDED は deployment row を見る必要が無い (= endsAt のみで判定)。
+  // 子 deployment を query しないことで RCU / Lambda 時間を節約。
+  if (eventStatus === "READY") {
+    const next = resolveEventStatusTransition(eventStatus, [], { endsAt: event.endsAt, nowMs });
+    if (!next) return;
+    await applyEventStatusTransition(ctx, {
+      PK: event.PK,
+      tenantId: event.tenantId,
+      eventId: event.eventId,
+      from: eventStatus,
+      to: next,
+      nowIso,
+    });
+    return;
+  }
+
+  // 子 deployments を GSI1 (TENANT#) で query → eventId filter 後の全 page を集約。
+  const depRows = await queryDeploymentRowsForEvent(ctx, {
+    tenantId: event.tenantId,
+    eventId: event.eventId,
+  });
+  // Issue #828: TEARDOWN で `DELETING` 行が `STUCK_DELETING_THRESHOLD_MS` 以上停滞していれば
+  // FAILED に倒す (= bulk-delete publish chunk 失敗 / State Machine 未起動 / 競技者の手動 stack
+  // 削除で silent path に倒れた orphan 行を救済し、 ARCHIVED 自動遷移を解錠する)。
+  // DDB Update は side-effect で発火、 同 tick の transition 判定には rescue 後の値を
+  // 想定した `adjustedStatuses` を使う (= 次 tick を待たずに同 tick で ARCHIVED 化可能)。
+  if (eventStatus === "TEARDOWN" && Number.isFinite(nowMs)) {
+    await rescueStuckDeletingDeployments(ctx, depRows, nowMs);
+  }
+  const adjustedStatuses = depRows.map((r) =>
+    isStuckDeletingForTeardown(eventStatus, r, nowMs) ? "FAILED" : r.status,
+  );
+  const next = resolveEventStatusTransition(eventStatus, adjustedStatuses);
+  if (!next) return;
+  await applyEventStatusTransition(ctx, {
+    PK: event.PK,
+    tenantId: event.tenantId,
+    eventId: event.eventId,
+    from: eventStatus,
+    to: next,
+    nowIso,
+  });
+}
+
+async function applyEventStatusTransition(
+  ctx: ReconcileEventStatusesContext,
+  args: {
+    readonly PK: string;
+    readonly tenantId: string;
+    readonly eventId: string;
+    readonly from: string;
+    readonly to: "READY" | "ENDED" | "ARCHIVED";
+    readonly nowIso: string;
+  },
+): Promise<void> {
+  try {
+    await ctx.ddb.send(
+      new UpdateCommand({
+        TableName: ctx.eventsTableName,
+        Key: { PK: args.PK, SK: "META" },
+        UpdateExpression: "SET #status = :next, updatedAt = :now",
+        // race 防止: 期待 current status と一致しているときのみ更新 (= operator が
+        // 手動 archive / 再 deploy で先に動かしてたら CCF で skip)。
+        ConditionExpression: "tenantId = :tenant AND #status = :current",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":tenant": args.tenantId,
+          ":current": args.from,
+          ":next": args.to,
+          ":now": args.nowIso,
+        },
+      }),
+    );
+    console.log("[generic-scoring] Event status auto-transition", {
+      eventId: args.eventId,
+      from: args.from,
+      to: args.to,
+    });
+  } catch (err) {
+    const code = (err as { name?: string })?.name ?? "";
+    if (code === "ConditionalCheckFailedException") return;
+    console.warn("[generic-scoring] Event status update failed", {
+      eventId: args.eventId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
 }

--- a/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
@@ -52,11 +52,46 @@ describe("resolveEventStatusTransition (#557 #539 pure logic)", () => {
     expect(resolveEventStatusTransition("TEARDOWN", [])).toBeUndefined();
   });
 
-  it("対象外 status (DRAFT / READY / ENDED / ARCHIVED) は defense-in-depth で undefined を返すべき", () => {
+  it("対象外 status (DRAFT / ENDED / ARCHIVED) は defense-in-depth で undefined を返すべき", () => {
     expect(resolveEventStatusTransition("DRAFT", ["COMPLETE"])).toBeUndefined();
-    expect(resolveEventStatusTransition("READY", ["COMPLETE"])).toBeUndefined();
     expect(resolveEventStatusTransition("ENDED", ["DELETED"])).toBeUndefined();
     expect(resolveEventStatusTransition("ARCHIVED", ["DELETED"])).toBeUndefined();
+  });
+
+  // Issue #1038 P0 #3: READY + endsAt 経過の自動 ENDED 遷移
+  it("READY + endsAt が現在時刻を過ぎていたら ENDED に遷移すべき", () => {
+    const endsAt = "2026-05-15T00:00:00.000Z";
+    const nowMs = Date.parse("2026-05-15T00:00:01.000Z");
+    expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBe("ENDED");
+  });
+
+  it("READY + endsAt がちょうど現在時刻なら ENDED に遷移すべき (= 境界包含)", () => {
+    const endsAt = "2026-05-15T00:00:00.000Z";
+    const nowMs = Date.parse(endsAt);
+    expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBe("ENDED");
+  });
+
+  it("READY + endsAt がまだ未来なら undefined を返すべき (= 触らない)", () => {
+    const endsAt = "2026-05-15T01:00:00.000Z";
+    const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
+    expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBeUndefined();
+  });
+
+  it("READY + endsAt 不在なら undefined を返すべき (= 無期限 event は触らない)", () => {
+    const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
+    expect(resolveEventStatusTransition("READY", [], { nowMs })).toBeUndefined();
+  });
+
+  it("READY + 不正な endsAt (parse 不能) なら undefined を返すべき", () => {
+    const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
+    expect(
+      resolveEventStatusTransition("READY", [], { endsAt: "not-a-date", nowMs }),
+    ).toBeUndefined();
+  });
+
+  it("READY + context 未指定なら undefined を返すべき (= 旧 caller の互換)", () => {
+    expect(resolveEventStatusTransition("READY", [])).toBeUndefined();
+    expect(resolveEventStatusTransition("READY", ["COMPLETE"])).toBeUndefined();
   });
 });
 
@@ -384,17 +419,91 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     ).resolves.toBe(0);
   });
 
-  it("Event filter は DEPLOYING または TEARDOWN のみであるべき (= READY / ENDED は触らない)", async () => {
+  it("Event filter は DEPLOYING / READY / TEARDOWN 対象であるべき (= ENDED / ARCHIVED は触らない)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
     await reconcileEventStatuses(ctx, NOW_ISO);
     const scanCmd = ddbSend.mock.calls[0]?.[0] as {
       input: {
+        ProjectionExpression: string;
         FilterExpression: string;
         ExpressionAttributeValues: Record<string, string>;
       };
     };
-    expect(scanCmd.input.FilterExpression).toBe("#status = :deploying OR #status = :teardown");
+    expect(scanCmd.input.FilterExpression).toBe(
+      "#status = :deploying OR #status = :ready OR #status = :teardown",
+    );
     expect(scanCmd.input.ExpressionAttributeValues[":deploying"]).toBe("DEPLOYING");
+    expect(scanCmd.input.ExpressionAttributeValues[":ready"]).toBe("READY");
     expect(scanCmd.input.ExpressionAttributeValues[":teardown"]).toBe("TEARDOWN");
+    // Issue #1038 P0 #3: READY → ENDED 判定に endsAt が要るので projection に含める
+    expect(scanCmd.input.ProjectionExpression).toContain("endsAt");
+  });
+
+  // Issue #1038 P0 #3: READY + endsAt 経過で自動 ENDED 遷移
+  it("READY で endsAt が現在時刻を過ぎていたら Update で ENDED に遷移すべき (= deployment 行は query しない)", async () => {
+    const now = "2026-05-15T01:00:00.000Z";
+    const pastEnd = "2026-05-15T00:30:00.000Z";
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "EVENT#EV-DUE",
+          tenantId: "tenant-acme",
+          eventId: "EV-DUE",
+          status: "READY",
+          endsAt: pastEnd,
+        },
+      ],
+    });
+    // READY 経路は deployment Query を skip し、 直接 Update に進む。
+    ddbSend.mockResolvedValueOnce({});
+
+    await reconcileEventStatuses(ctx, now);
+
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+    const updateCmd = ddbSend.mock.calls[1]?.[0] as {
+      input: {
+        UpdateExpression: string;
+        ConditionExpression: string;
+        ExpressionAttributeValues: Record<string, string>;
+      };
+    };
+    expect(updateCmd.input.ExpressionAttributeValues[":next"]).toBe("ENDED");
+    expect(updateCmd.input.ExpressionAttributeValues[":current"]).toBe("READY");
+    expect(updateCmd.input.ConditionExpression).toContain("#status = :current");
+  });
+
+  it("READY で endsAt がまだ未来なら Update を発行しないべき", async () => {
+    const now = "2026-05-15T00:00:00.000Z";
+    const future = "2026-05-15T01:00:00.000Z";
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "EVENT#EV-LIVE",
+          tenantId: "tenant-acme",
+          eventId: "EV-LIVE",
+          status: "READY",
+          endsAt: future,
+        },
+      ],
+    });
+
+    await reconcileEventStatuses(ctx, now);
+    expect(ddbSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("READY で endsAt 不在 (= 無期限 event) なら Update も Query も発行しないべき", async () => {
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "EVENT#EV-OPEN",
+          tenantId: "tenant-acme",
+          eventId: "EV-OPEN",
+          status: "READY",
+        },
+      ],
+    });
+
+    await reconcileEventStatuses(ctx, NOW_ISO);
+    expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Issue #1038 P0 #3 (= user 報告「終了時刻を過ぎたのにイベントが終わらない、 バックグラウンドの採点は止まったようには見える」)。 operator が `end-event` API を手動で叩かなくても endsAt を過ぎた `READY` event を **自動的に ENDED** に倒す。
- 生 reconciler tick (1 min) で `endsAt <= now` の `READY` event を Scan で拾い、 status のみ conditional Update で `ENDED` に遷移させる (= 子 deployment row の更新は行わない、 採点 gate `event-gate.ts` は既に endsAt から judge しているので status 更新だけで participant portal / scoreboard の表示は一致する)。
- pure 関数 `resolveEventStatusTransition` に `context?: { endsAt, nowMs }` を追加、 既存 caller (= DEPLOYING / TEARDOWN 経路) は context 不要なので backward compatible。
- `reconcileEventStatuses` の per-event 処理を `reconcileSingleEvent` ヘルパに extract、 status update は `applyEventStatusTransition` に集約。 結果として元 closure の cognitive complexity が 16→14 に下がり、 既存 lint baseline を新規違反させない。

## Test plan

- [x] `infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts` — 32 tests pass
  - `resolveEventStatusTransition` 単体: READY + endsAt 経過 / 境界 / 未来 / 不在 / 不正 / context 無し の 6 case
  - `reconcileEventStatuses` DDB mock: READY → ENDED 遷移、 endsAt 未来時 Update 抑止、 endsAt 不在時 Query/Update 抑止
  - 既存 Scan FilterExpression / ProjectionExpression assertion を `endsAt` + `:ready` 含む形に更新
- [x] `make harness` — 0 findings
- [x] `make before-commit` — lint / typecheck / 全 workspace vitest / template scans / cdk synth 全 pass

## Regression 分析

| 壊しうる箇所 | 仕組み的に守られる根拠 |
|---|---|
| 既存 DEPLOYING → READY 遷移 | `resolveEventStatusTransition(eventStatus, depStatuses)` (= context なし) は完全に旧パスを維持。 reconciler 経路も `reconcileSingleEvent` に切り出した後 if-branch で同じ順序で実行 |
| 既存 TEARDOWN → ARCHIVED 遷移 (+ #828 stuck DELETING rescue) | rescue + adjustedStatuses + transition 判定の 3-stage 順序が変わらない (= ヘルパ抽出で並び替えていない)。 既存 `rescueStuckDeletingDeployments` / `isStuckDeletingForTeardown` test も pass |
| operator が `endEvent` API を手動で叩いた競合 | event Update は `ConditionExpression: tenantId AND #status = :current` (= 期待状態 READY) で CCF safety。 operator が先に `ENDED` に倒していれば自動遷移は silent skip |
| `endsAt` 不在の event (= 無期限) | `resolveEventStatusTransition` が `undefined` を返すので Scan で拾われても何もしない |
| `endsAt` が不正な文字列の event | `Date.parse` で NaN → `Number.isFinite` ガードで `undefined`。 操作中の事故 (= 旧 fixture / migration 漏れ) は安全側に倒れる |
| Lambda 内処理時間 | READY event は子 deployment Query を **skip** するため、 既存 1-tick 当たり RCU は減る方向。 Scan filter 条件が 1 つ増えただけ |

## 物理影響

- **NO-OP**: CFn / IAM / Lambda Layer / DynamoDB schema は変更なし
- **UPDATE**: `generic-scoring-handler` Lambda の関数コード (= reconciler 内部関数のみ)
- **REPLACE**: なし
- **DELETE**: なし
- **CREATE**: なし

Closes #1038 partial — P0 #3 (= 終了時刻 auto-transition) のみ。 残 backlog (P1 #6 / P1 #7 / P2 #10) は別 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)