### PR TITLE
fix(participant-handler): score-events に hint/flag-wrong 行を含める (P1 #8 follow-up)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/score-events.ts
@@ -4,13 +4,22 @@ import { DELETED_LIKE_STATUSES } from "../shared/constants.js";
 import type { ScoreEventItem } from "../shared/score-event.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
-/** participant 向けに公開する score event 1 行 (内部 PK/SK 等は出さない)。 */
+/**
+ * participant 向けに公開する score event 1 行 (内部 PK/SK 等は出さない)。
+ *
+ * Issue #1038 P1 #8 follow-up: hint reveal (= PR-1043) / 不正解 flag (Issue #817 で書き込み済)
+ * は score を確かに動かすが、 旧 toView が `"uptime"` / `"flag"` のみ通過させていたため履歴に
+ * 出てこなかった (= user 観測「ヒントひらいたときのスコアが score events 履歴に出ない」)。
+ * `score-event.ts` の writer 側 union は既に `"uptime" | "flag" | "flag-wrong" | "hint" |
+ * "attack-detected"` を持つ。 そのうち competitor の累計 score に影響する 4 種を公開する
+ * (= `attack-detected` は marker 用、 frontend にスコア行として並べない)。
+ */
 export interface ScoreEventView {
   readonly jobId: string;
   readonly problemId: string;
-  readonly source: "uptime" | "flag";
+  readonly source: "uptime" | "flag" | "flag-wrong" | "hint";
   readonly points: number;
-  readonly result: "ok";
+  readonly result: "ok" | "wrong";
   readonly occurredAt: string;
 }
 
@@ -94,19 +103,30 @@ export async function listScoreEvents(
   return { kind: "ok", response: { entries } };
 }
 
-/** ScoreEventItem (DDB row) → ScoreEventView (公開 shape)。不正な行は undefined。 */
+/**
+ * ScoreEventItem (DDB row) → ScoreEventView (公開 shape)。不正な行は undefined。
+ *
+ * Issue #1038 P1 #8 follow-up: 加点系 (`uptime` / `flag`) に加え減点系 (`flag-wrong` /
+ * `hint`) も公開する。 `attack-detected` (= marker 用 result=down 行) は participant の
+ * 累計 score に影響しないので score event 履歴には載せない (= 別 endpoint `battle-attacks`)。
+ */
+const ALLOWED_SOURCES = new Set<ScoreEventView["source"]>(["uptime", "flag", "flag-wrong", "hint"]);
+const ALLOWED_RESULTS = new Set<ScoreEventView["result"]>(["ok", "wrong"]);
+
 function toView(item: Partial<ScoreEventItem>): ScoreEventView | undefined {
   if (typeof item.jobId !== "string") return undefined;
   if (typeof item.problemId !== "string") return undefined;
-  if (item.source !== "uptime" && item.source !== "flag") return undefined;
-  if (item.result !== "ok") return undefined;
+  if (typeof item.source !== "string") return undefined;
+  if (!ALLOWED_SOURCES.has(item.source as ScoreEventView["source"])) return undefined;
+  if (typeof item.result !== "string") return undefined;
+  if (!ALLOWED_RESULTS.has(item.result as ScoreEventView["result"])) return undefined;
   if (typeof item.occurredAt !== "string") return undefined;
   return {
     jobId: item.jobId,
     problemId: item.problemId,
-    source: item.source,
+    source: item.source as ScoreEventView["source"],
     points: Number(item.points ?? 0),
-    result: item.result,
+    result: item.result as ScoreEventView["result"],
     occurredAt: item.occurredAt,
   };
 }

--- a/infrastructure/test/problem-deploy/participant-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/participant-score-events.test.ts
@@ -140,6 +140,76 @@ describe("listScoreEvents", () => {
     }
   });
 
+  // Issue #1038 P1 #8 follow-up: 旧 toView は uptime/flag のみ通したため、 PR-1043 で書き
+  // 込まれる hint 行と Issue #817 で書き込まれる flag-wrong 行が participant の Score events
+  // 履歴に表示されなかった。 4 source 全て (= uptime / flag / flag-wrong / hint) を含める。
+  it("hint reveal の減点行 (source=hint, result=ok, points=-30) を履歴に含めるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({
+          source: "hint",
+          points: -30,
+          result: "ok",
+          occurredAt: "2026-05-18T10:00:00.000Z",
+        }),
+      ],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(1);
+      expect(out.response.entries[0]).toMatchObject({
+        source: "hint",
+        points: -30,
+        result: "ok",
+      });
+    }
+  });
+
+  it("不正解 flag の減点行 (source=flag-wrong, result=wrong, points=-10) を履歴に含めるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({
+          source: "flag-wrong",
+          points: -10,
+          result: "wrong",
+          occurredAt: "2026-05-18T11:00:00.000Z",
+        }),
+      ],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(1);
+      expect(out.response.entries[0]).toMatchObject({
+        source: "flag-wrong",
+        points: -10,
+        result: "wrong",
+      });
+    }
+  });
+
+  it("attack-detected (marker 用、 result=down) は participant 履歴に出さないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [meta()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        event({ source: "attack-detected", points: 0, result: "down" }),
+        event({ source: "uptime", points: 5, result: "ok" }),
+      ],
+    });
+    const out = await listScoreEvents(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.response.entries).toHaveLength(1);
+      expect(out.response.entries[0]?.source).toBe("uptime");
+    }
+  });
+
   it("attack-detected が 1 page 目を埋め尽くしても次 page を読んで scoring 行を回収する", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });


### PR DESCRIPTION
## Summary

- PR-1043 (#1038 P1 #8) で `reveal-hint` handler が hint reveal 時に score event 行を DDB に書き込むようになったが、 read path の `toView` フィルタが `uptime` / `flag` のみ通していたため履歴に出ない (= user 観測「ヒントひらいたときのスコアが score events 履歴に出ない」 の未解決部分)。
- `score-events.ts` の `toView` を `ALLOWED_SOURCES` / `ALLOWED_RESULTS` Set 経由で 4 source (= `uptime` / `flag` / `flag-wrong` / `hint`) + 2 result (= `ok` / `wrong`) を許可する形に拡張。
- 公開 `ScoreEventView` interface の `source` / `result` union を frontend (`apps/participant-portal/src/api/portal-client.ts`) と一致させた (= frontend は既にこの shape を期待していた)。
- `attack-detected` (= marker 用 `result=down`) は participant の累計 score に影響しないので従来通り score events 履歴には出さない (= 別 endpoint `/portal/me/battle-attacks` で扱う)。

## Test plan

- [x] `bun run vitest run test/problem-deploy/participant-score-events.test.ts` — 10 tests pass
  - 新規 3 case: hint 減点行 / flag-wrong 減点行 / attack-detected marker 除外
  - 既存 7 case (= 正常系 / unauthorized / 全 DELETED / limit truncate / 不正行除外 / page beyond markers / operator 情報非漏洩) は変更なし pass
- [x] `make harness` clean
- [x] `make before-commit` lint / typecheck / 全 workspace vitest / cdk synth 全 pass

## Regression 分析

| 壊しうる箇所 | 仕組み的に守られる根拠 |
|---|---|
| 既存 uptime / flag 行の表示 | `ALLOWED_SOURCES` / `ALLOWED_RESULTS` で同じ pair を引き続き通過させる |
| `attack-detected` marker が score 履歴に紛れ込む | `ALLOWED_SOURCES` に含めない / `result=down` も `ALLOWED_RESULTS` に含めないので二重 reject |
| operator 内部情報 (= teamId / eventId / tenantId / expiresAt) の漏洩 | 既存 test「operator 情報非漏洩」 で assertion 済、 toView の output shape は変更なし |
| Frontend 側の SOURCE_LABEL / SOURCE_COLOR | `apps/participant-portal/src/pages/ScoreEvents.tsx` は既に 4 source 分のラベル/色を定義済 (= 旧 PR で frontend のみ先行更新済み)、 backend が追従した形 |

## 物理影響

- **UPDATE**: ParticipantPortal Lambda bundle (= `score-events.ts` の filter ロジック更新)
- **NO-OP**: CFn / IAM / DynamoDB / API Gateway / EventBridge

Closes #1038 partial — P1 #8 backend read path 補完 (= PR-1043 + 本 PR で履歴表示が end-to-end で機能)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoring events now comprehensively track hint usage and incorrect flag submission attempts, in addition to uptime and successful attempts
  * Score events now distinguish between successful and unsuccessful outcomes for enhanced performance visibility
  * Participants' complete interaction history is now captured for more detailed performance insights

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->