### PR TITLE
feat(#1038): Event 詳細画面に全 team の score event 推移 panel を追加 (P1 #7)

### DIFF
--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -61,6 +61,26 @@ export interface EventDeploymentSummary {
   status: EventDeploymentStatus;
 }
 
+/**
+ * Issue #1038 P1 #7: operator 側 Event 詳細画面で全 team の score event 推移を可視化する。
+ * `?withScoreEvents=true` を付けた `getEvent` でのみ含まれる (default は undefined)。
+ */
+export interface TeamScoreEventView {
+  jobId: string;
+  problemId: string;
+  source: "uptime" | "flag" | "flag-wrong" | "hint";
+  points: number;
+  result: "ok" | "wrong";
+  occurredAt: string;
+}
+
+export interface TeamScoreEvents {
+  teamId: string;
+  teamName: string;
+  /** occurredAt 昇順 (= chart の cumulative 計算に向く)。 */
+  events: readonly TeamScoreEventView[];
+}
+
 export interface EventDetail extends EventSummary {
   teams: readonly TeamSummary[];
   problems: readonly EventProblemTarget[];
@@ -69,6 +89,8 @@ export interface EventDetail extends EventSummary {
    * 旧 jobId-based deployment は eventId が無いので含まれない。
    */
   deploymentsByProblem: Readonly<Record<string, readonly EventDeploymentSummary[]>>;
+  /** Issue #1038 P1 #7: opt-in で全 team の累計 score event timeline を含む。 */
+  scoreEventsByTeam?: readonly TeamScoreEvents[];
 }
 
 export interface CreateEventTeamInput {
@@ -113,8 +135,15 @@ export async function listEvents(
   return api.get<EventListResponse>(qs ? `events?${qs}` : "events");
 }
 
-export async function getEvent(api: ApiClient, eventId: string): Promise<EventDetail> {
-  return api.get<EventDetail>(`events/${encodeURIComponent(eventId)}`);
+export async function getEvent(
+  api: ApiClient,
+  eventId: string,
+  options: { readonly withScoreEvents?: boolean } = {},
+): Promise<EventDetail> {
+  const path = `events/${encodeURIComponent(eventId)}${
+    options.withScoreEvents ? "?withScoreEvents=true" : ""
+  }`;
+  return api.get<EventDetail>(path);
 }
 
 export async function createEvent(

--- a/apps/application-admin-console/src/components/TeamScoreEventsPanel.tsx
+++ b/apps/application-admin-console/src/components/TeamScoreEventsPanel.tsx
@@ -1,0 +1,110 @@
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import LineChart from "@cloudscape-design/components/line-chart";
+import { useMemo } from "react";
+import type { TeamScoreEvents } from "../api/events-client";
+
+/**
+ * Issue #1038 P1 #7: operator (= tenant admin) 視点で全 team の score event 推移を一覧する panel。
+ *
+ * 旧 EventDetail には「どの team がいつ加点 / 減点したか」 を一目で見るビューが無かった。
+ * `EventDetail.scoreEventsByTeam` (= ?withScoreEvents=true 経由で fetch) を multi-series
+ * LineChart で render する。 全 team を categorical palette で描画 (= participant 側 chart と
+ * 違って operator は自分の team が無いため特定 team の強調はしない)。
+ *
+ * Cloudscape の LineChart は内部で凡例 + 系列 toggle を持つので、 chart 自体に dropdown は
+ * 追加しない (= 凡例 click で 1 系列のみ visible にできる)。
+ */
+const PALETTE = [
+  "#0972d3",
+  "#037f0c",
+  "#8d6cab",
+  "#e07700",
+  "#a44b8c",
+  "#5b6770",
+  "#b80f5a",
+  "#6f4e37",
+  "#0a8c8a",
+  "#cc4a00",
+];
+
+interface SeriesPoint {
+  readonly x: Date;
+  readonly y: number;
+}
+
+function buildCumulative(team: TeamScoreEvents): readonly SeriesPoint[] {
+  const points: SeriesPoint[] = [];
+  let cum = 0;
+  for (const e of team.events) {
+    cum += e.points;
+    const ts = Date.parse(e.occurredAt);
+    if (!Number.isFinite(ts)) continue;
+    points.push({ x: new Date(ts), y: cum });
+  }
+  return points;
+}
+
+export function TeamScoreEventsPanel({ teams }: { teams: readonly TeamScoreEvents[] }) {
+  const view = useMemo(() => {
+    const series = teams.map((team, idx) => ({
+      title: team.teamName || team.teamId,
+      type: "line" as const,
+      data: buildCumulative(team).map((p) => ({ x: p.x, y: p.y })),
+      valueFormatter: (v: number) => `${v} pt`,
+      color: PALETTE[idx % PALETTE.length] ?? "#5b6770",
+    }));
+    const allTs = series.flatMap((s) => s.data.map((d) => d.x.getTime()));
+    const minX = allTs.length > 0 ? new Date(Math.min(...allTs)) : new Date();
+    const maxX = allTs.length > 0 ? new Date(Math.max(...allTs)) : new Date();
+    const allY = series.flatMap((s) => s.data.map((d) => d.y));
+    const minY = allY.length > 0 ? Math.min(0, ...allY) : 0;
+    const maxY = allY.length > 0 ? Math.max(10, ...allY) : 10;
+    return { series, minX, maxX, minY, maxY };
+  }, [teams]);
+
+  const totalEvents = teams.reduce((s, t) => s + t.events.length, 0);
+
+  if (totalEvents === 0) {
+    return (
+      <Container header={<Header variant="h2">全チーム スコア推移</Header>}>
+        <Box color="text-status-inactive">
+          まだスコア変動の履歴がありません。 flag 提出や Battle uptime / hint
+          開封などで記録されます。
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`全 ${teams.length} チームの累計 score 推移 (凡例 click で系列の表示 / 非表示を切替)`}
+        >
+          全チーム スコア推移
+        </Header>
+      }
+    >
+      <LineChart
+        series={view.series}
+        xDomain={[view.minX, view.maxX]}
+        yDomain={[view.minY, view.maxY]}
+        xScaleType="time"
+        i18nStrings={{
+          xTickFormatter: (d: Date) =>
+            d.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }),
+          yTickFormatter: (n: number) => `${n}`,
+        }}
+        height={320}
+        xTitle="時刻"
+        yTitle="累計スコア (pt)"
+        ariaLabel="全チームの累計スコア推移"
+        empty={<Box color="text-status-inactive">データなし</Box>}
+        noMatch={<Box color="text-status-inactive">範囲内にデータなし</Box>}
+      />
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -36,6 +36,7 @@ import {
   unlockEventScoring,
 } from "../api/events-client";
 import { SendNotificationModal } from "../components/SendNotificationModal";
+import { TeamScoreEventsPanel } from "../components/TeamScoreEventsPanel";
 import type { AppConfig } from "../config";
 import { computeEventWizardState, WIZARD_STEPS } from "../lib/event-wizard";
 
@@ -189,7 +190,9 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
   const refresh = useCallback(async () => {
     if (!apiClient || !eventIdValid || !eventId) return;
     try {
-      const d = await getEvent(apiClient, eventId);
+      // Issue #1038 P1 #7: operator が「どのチームがいつ加点 / 減点したか」 を一目で
+      // 把握できるよう、 Event 詳細取得で全 team の score event timeline も同時に fetch する。
+      const d = await getEvent(apiClient, eventId, { withScoreEvents: true });
       setDetail(d);
       setError(null);
     } catch (err) {
@@ -855,6 +858,8 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
           />
         </Container>
       )}
+
+      {detail?.scoreEventsByTeam && <TeamScoreEventsPanel teams={detail.scoreEventsByTeam} />}
 
       {detail && (
         <Container header={<Header variant="h2">参加者向け配布</Header>}>

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -193,8 +193,11 @@ app.get("/events/:eventId", async (c) => {
   if (!eventId || !EVENT_ID_RE.test(eventId)) {
     return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
   }
+  // Issue #1038 P1 #7: opt-in で全 team の累計 score event timeline を返す。
+  // default (= "true" 以外) は scoreEventsByTeam を省き、 既存 caller を素通り。
+  const withScoreEvents = c.req.query("withScoreEvents") === "true";
   try {
-    const detail = await getEventDetail(shared, resolveTenantId(c), eventId);
+    const detail = await getEventDetail(shared, resolveTenantId(c), eventId, { withScoreEvents });
     if (!detail) return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
     return c.json(detail, HTTP_OK);
   } catch (err) {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -1,5 +1,6 @@
 import { GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import type { EventSharedResources } from "./shared.js";
+import { collectTeamScoreEvents, type DeploymentRefForScoreEvents } from "./team-score-events.js";
 import type {
   EventDeploymentSummary,
   EventDetail,
@@ -108,11 +109,16 @@ export async function listEvents(
  *
  * teams[].teamLoginKey は **詳細経路でのみ露出** (operator が hand-off に使うため)。
  * 一覧経路 (`listEvents`) では teams 自体を返さない。
+ *
+ * Issue #1038 P1 #7: `opts.withScoreEvents=true` のとき全 team の累計 score event timeline を
+ * `scoreEventsByTeam` に含める。 default (= false) は従来挙動を維持 (= 余分な DDB query を
+ * 発生させない、 既存 caller への影響なし)。
  */
 export async function getEventDetail(
   shared: EventSharedResources,
   tenantId: string,
   eventId: string,
+  opts: { readonly withScoreEvents?: boolean } = {},
 ): Promise<EventDetail | undefined> {
   // Event Get と Teams Query は依存関係なし → 並列発火でラウンドトリップを 1 回分節約。
   // Event / Teams / Deployments を並列発火。Deployments は競技者が PATCH /portal/me で
@@ -144,7 +150,9 @@ export async function getEventDetail(
         ExpressionAttributeValues: { ":pk": `TENANT#${tenantId}` },
         // problemId / jobId / status は per-problem deploy 状況を組み立てるのに必要。
         // displayTeamName は既存の teams[].displayName 上書き用。
-        ProjectionExpression: "teamId, eventId, displayTeamName, problemId, jobId, #s",
+        // PK / teamName は Issue #1038 P1 #7 で per-team score events を引くために追加 projection。
+        ProjectionExpression:
+          "PK, teamId, eventId, displayTeamName, teamName, problemId, jobId, #s",
         ExpressionAttributeNames: { "#s": "status" },
       }),
     ),
@@ -154,41 +162,8 @@ export async function getEventDetail(
   if (event.tenantId !== tenantId) return undefined;
 
   const teamItems = (teamsOut.Items ?? []) as Partial<TeamItem>[];
-
-  // teamId → displayTeamName の最新値 map を作る。同じ team の N 行のうち、operator
-  // 起動時には全て同じ値で埋まる (update.ts が Promise.all で全行を更新するため)。
-  // 念のため最後に拾った非空文字列を採用 (=「設定済」優先)。
-  const displayNameByTeamId = new Map<string, string>();
-  // problemId → deployment summary[]。本 event の deployment のみ集める。
-  const deploymentsByProblem: Record<string, EventDeploymentSummary[]> = {};
-  for (const d of deploymentsOut.Items ?? []) {
-    const row = d as {
-      teamId?: unknown;
-      eventId?: unknown;
-      displayTeamName?: unknown;
-      problemId?: unknown;
-      jobId?: unknown;
-      status?: unknown;
-    };
-    if (row.eventId !== eventId) continue;
-    if (typeof row.teamId === "string" && typeof row.displayTeamName === "string") {
-      if (row.displayTeamName.length > 0) {
-        displayNameByTeamId.set(row.teamId, row.displayTeamName);
-      }
-    }
-    if (
-      typeof row.problemId !== "string" ||
-      typeof row.jobId !== "string" ||
-      typeof row.teamId !== "string"
-    ) {
-      continue;
-    }
-    const status = parseDeploymentStatus(row.status);
-    if (!status) continue;
-    const list = deploymentsByProblem[row.problemId] ?? [];
-    list.push({ jobId: row.jobId, teamId: row.teamId, status });
-    deploymentsByProblem[row.problemId] = list;
-  }
+  const { displayNameByTeamId, deploymentsByProblem, deploymentRefs } =
+    aggregateDeploymentsForEvent(deploymentsOut.Items ?? [], eventId);
 
   const teams: TeamSummary[] = teamItems.map((t) => {
     const teamId = String(t.teamId ?? "");
@@ -205,11 +180,78 @@ export async function getEventDetail(
     };
   });
 
+  const scoreEventsByTeam = opts.withScoreEvents
+    ? await collectTeamScoreEvents(shared, {
+        deployments: deploymentRefs,
+        displayNameByTeamId,
+      })
+    : undefined;
+
   const summary = toSummary(event);
   return {
     ...summary,
     problems: Array.isArray(event.problems) ? (event.problems as EventDetail["problems"]) : [],
     teams,
     deploymentsByProblem,
+    ...(scoreEventsByTeam !== undefined ? { scoreEventsByTeam } : {}),
   };
+}
+
+/**
+ * Deployment rows を 3 つの view (= displayName / deploymentsByProblem / deploymentRefs) に
+ * 同時集約する pure helper。 `getEventDetail` の cognitive complexity を抑えるために
+ * 切り出した。 同一 row を 3 view に流すので 1 pass で済む。
+ */
+function aggregateDeploymentsForEvent(
+  items: readonly Record<string, unknown>[],
+  eventId: string,
+): {
+  displayNameByTeamId: Map<string, string>;
+  deploymentsByProblem: Record<string, EventDeploymentSummary[]>;
+  deploymentRefs: DeploymentRefForScoreEvents[];
+} {
+  const displayNameByTeamId = new Map<string, string>();
+  const deploymentsByProblem: Record<string, EventDeploymentSummary[]> = {};
+  const deploymentRefs: DeploymentRefForScoreEvents[] = [];
+  for (const d of items) {
+    if (d.eventId !== eventId) continue;
+    captureDisplayName(d, displayNameByTeamId);
+    captureDeploymentRef(d, deploymentRefs);
+    captureDeploymentSummary(d, deploymentsByProblem);
+  }
+  return { displayNameByTeamId, deploymentsByProblem, deploymentRefs };
+}
+
+function captureDisplayName(d: Record<string, unknown>, byTeamId: Map<string, string>): void {
+  if (typeof d.teamId !== "string") return;
+  if (typeof d.displayTeamName !== "string") return;
+  if (d.displayTeamName.length === 0) return;
+  byTeamId.set(d.teamId, d.displayTeamName);
+}
+
+function captureDeploymentRef(
+  d: Record<string, unknown>,
+  refs: DeploymentRefForScoreEvents[],
+): void {
+  if (typeof d.PK !== "string") return;
+  if (typeof d.teamId !== "string") return;
+  refs.push({
+    PK: d.PK,
+    teamId: d.teamId,
+    teamName: typeof d.teamName === "string" ? d.teamName : undefined,
+  });
+}
+
+function captureDeploymentSummary(
+  d: Record<string, unknown>,
+  byProblem: Record<string, EventDeploymentSummary[]>,
+): void {
+  if (typeof d.problemId !== "string") return;
+  if (typeof d.jobId !== "string") return;
+  if (typeof d.teamId !== "string") return;
+  const status = parseDeploymentStatus(d.status);
+  if (!status) return;
+  const list = byProblem[d.problemId] ?? [];
+  list.push({ jobId: d.jobId, teamId: d.teamId, status });
+  byProblem[d.problemId] = list;
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/team-score-events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/team-score-events.ts
@@ -1,0 +1,132 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { ScoreEventItem } from "../shared/score-event.js";
+import type { EventSharedResources } from "./shared.js";
+import type { TeamScoreEvents, TeamScoreEventView } from "./types.js";
+
+/**
+ * Issue #1038 P1 #7: operator (= tenant admin) 視点で同 event の全 team の score event timeline
+ * を 1 回でまとめて取得する。 participant 側 `/portal/leaderboard/score-events` (PR-1048) と
+ * 同 shape で、 違いは認可境界 (= bearer ではなく tenant API GW + Cognito JWT 経由)。
+ *
+ * Deployments table の per-PK partition (= 1 deployment 1 partition) を並列 query。
+ * 1 team あたり最大 200 events で打ち止め、 各 deployment 最大 3 page まで読む。 MVP 規模
+ * (= 10 teams × 5 problems = 50 deployments) で 1 request あたり 50〜150 query、 30s polling
+ * 想定で許容範囲。
+ *
+ * `deployments` は `getEventDetail` が既に GSI1 で fetch している rows を再利用して渡す
+ * (= 同じ table を 2 回読みに行かない)。
+ */
+const PER_TEAM_LIMIT = 200;
+const MAX_PAGES_PER_DEPLOYMENT = 3;
+
+export interface DeploymentRefForScoreEvents {
+  readonly PK: string;
+  readonly teamId: string;
+  readonly teamName?: string;
+}
+
+/**
+ * 全 team の score event timeline を構築する。 teams[] (= EventDetail.teams) を渡して
+ * 表示順 / displayName を継承する。 teamId 不明な deployment は捨てる (= safety)。
+ */
+export async function collectTeamScoreEvents(
+  shared: Pick<EventSharedResources, "ddb" | "deploymentsTableName">,
+  args: {
+    readonly deployments: readonly DeploymentRefForScoreEvents[];
+    readonly displayNameByTeamId: ReadonlyMap<string, string>;
+  },
+): Promise<TeamScoreEvents[]> {
+  // teamId → { teamName, deploymentPKs[] }
+  const byTeam = new Map<string, { teamName: string; deploymentPKs: string[] }>();
+  for (const d of args.deployments) {
+    if (!d.PK || !d.teamId) continue;
+    let bucket = byTeam.get(d.teamId);
+    if (!bucket) {
+      bucket = {
+        teamName: args.displayNameByTeamId.get(d.teamId) ?? d.teamName ?? d.teamId,
+        deploymentPKs: [],
+      };
+      byTeam.set(d.teamId, bucket);
+    }
+    bucket.deploymentPKs.push(d.PK);
+  }
+
+  const teams: TeamScoreEvents[] = await Promise.all(
+    [...byTeam.entries()].map(async ([teamId, meta]) => {
+      const collected = await collectEventsForDeployments(shared, meta.deploymentPKs);
+      collected.sort((a, b) =>
+        a.occurredAt < b.occurredAt ? -1 : a.occurredAt > b.occurredAt ? 1 : 0,
+      );
+      return {
+        teamId,
+        teamName: meta.teamName,
+        events: collected.slice(0, PER_TEAM_LIMIT),
+      };
+    }),
+  );
+
+  // teamId 昇順で安定化 (= leaderboard と違って operator 視点は team 順序が「総合 score 順」 で
+  // なくても良いが、 重複描画や順序のブレを避けるため teamId をキーに昇順 sort)。
+  teams.sort((a, b) => a.teamId.localeCompare(b.teamId));
+
+  return teams;
+}
+
+async function collectEventsForDeployments(
+  shared: Pick<EventSharedResources, "ddb" | "deploymentsTableName">,
+  deploymentPKs: readonly string[],
+): Promise<TeamScoreEventView[]> {
+  const collected: TeamScoreEventView[] = [];
+  await Promise.all(
+    deploymentPKs.map(async (pk) => {
+      let exclusiveStart: Record<string, unknown> | undefined;
+      let pages = 0;
+      while (pages < MAX_PAGES_PER_DEPLOYMENT && collected.length < PER_TEAM_LIMIT) {
+        const out = await shared.ddb.send(
+          new QueryCommand({
+            TableName: shared.deploymentsTableName,
+            KeyConditionExpression: "PK = :pk AND begins_with(SK, :evpfx)",
+            ExpressionAttributeValues: { ":pk": pk, ":evpfx": "EVENT#" },
+            ScanIndexForward: false,
+            Limit: PER_TEAM_LIMIT,
+            ExclusiveStartKey: exclusiveStart,
+          }),
+        );
+        for (const it of (out.Items ?? []) as Partial<ScoreEventItem>[]) {
+          const v = toView(it);
+          if (v) collected.push(v);
+        }
+        exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+        pages++;
+        if (!exclusiveStart) break;
+      }
+    }),
+  );
+  return collected;
+}
+
+const ALLOWED_SOURCES = new Set<TeamScoreEventView["source"]>([
+  "uptime",
+  "flag",
+  "flag-wrong",
+  "hint",
+]);
+const ALLOWED_RESULTS = new Set<TeamScoreEventView["result"]>(["ok", "wrong"]);
+
+function toView(item: Partial<ScoreEventItem>): TeamScoreEventView | undefined {
+  if (typeof item.jobId !== "string") return undefined;
+  if (typeof item.problemId !== "string") return undefined;
+  if (typeof item.source !== "string") return undefined;
+  if (!ALLOWED_SOURCES.has(item.source as TeamScoreEventView["source"])) return undefined;
+  if (typeof item.result !== "string") return undefined;
+  if (!ALLOWED_RESULTS.has(item.result as TeamScoreEventView["result"])) return undefined;
+  if (typeof item.occurredAt !== "string") return undefined;
+  return {
+    jobId: item.jobId,
+    problemId: item.problemId,
+    source: item.source as TeamScoreEventView["source"],
+    points: Number(item.points ?? 0),
+    result: item.result as TeamScoreEventView["result"],
+    occurredAt: item.occurredAt,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -249,6 +249,33 @@ export const EventDeploymentSummarySchema = z.object({
 });
 export type EventDeploymentSummary = z.infer<typeof EventDeploymentSummarySchema>;
 
+/**
+ * Issue #1038 P1 #7: operator が Event 詳細画面で全 team の score event 推移を一目で
+ * 把握できるよう、 EventDetail に optional な team-grouped score events を含める。
+ *
+ * 公開 source は 4 種 (= uptime / flag / flag-wrong / hint)。 marker 用 `attack-detected`
+ * (= result=down) は累計 score に影響しないので除外。 leaderboard 合計と chart 累積を一致
+ * させる目的で、 participant 側 chart endpoint (= `/portal/leaderboard/score-events`) と
+ * 同じ shape にする。
+ */
+export const TeamScoreEventViewSchema = z.object({
+  jobId: z.string(),
+  problemId: z.string(),
+  source: z.enum(["uptime", "flag", "flag-wrong", "hint"]),
+  points: z.number(),
+  result: z.enum(["ok", "wrong"]),
+  occurredAt: z.string(),
+});
+export type TeamScoreEventView = z.infer<typeof TeamScoreEventViewSchema>;
+
+export const TeamScoreEventsSchema = z.object({
+  teamId: z.string(),
+  teamName: z.string(),
+  /** occurredAt 昇順 (= chart の cumulative 計算に向く順序)。 */
+  events: z.array(TeamScoreEventViewSchema),
+});
+export type TeamScoreEvents = z.infer<typeof TeamScoreEventsSchema>;
+
 export const EventDetailSchema = EventSummarySchema.extend({
   problems: z.array(EventProblemTargetSchema),
   teams: z.array(TeamSummarySchema),
@@ -257,6 +284,12 @@ export const EventDetailSchema = EventSummarySchema.extend({
    * 旧 jobId-based deployment は eventId が無いので含まれない。
    */
   deploymentsByProblem: z.record(z.string(), z.array(EventDeploymentSummarySchema)),
+  /**
+   * Issue #1038 P1 #7: 全 team の累計 score event timeline。 `?withScoreEvents=true` 経由で
+   * のみ含まれる (= default は undefined で従来挙動を維持、 余分な DDB query を発生させない)。
+   * teams[] と同じ順序 (= teamId 昇順) で並べる。
+   */
+  scoreEventsByTeam: z.array(TeamScoreEventsSchema).optional(),
 });
 export type EventDetail = z.infer<typeof EventDetailSchema>;
 

--- a/infrastructure/test/problem-deploy/team-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/team-score-events.test.ts
@@ -1,0 +1,188 @@
+import type { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { collectTeamScoreEvents } from "../../lib/problem-deploy/handlers/event-handler/team-score-events";
+
+/**
+ * Issue #1038 P1 #7: operator (= tenant admin) 視点で同 event の全 team の score event
+ * timeline をまとめて構築する pure-ish helper の test。 DDB は mock。
+ */
+
+function buildShared(): {
+  shared: { ddb: { send: ReturnType<typeof vi.fn> }; deploymentsTableName: string };
+  ddbSend: ReturnType<typeof vi.fn>;
+} {
+  const ddbSend = vi.fn();
+  const shared = {
+    ddb: { send: ddbSend },
+    deploymentsTableName: "TestDeployments",
+  };
+  return { shared, ddbSend };
+}
+
+const ev = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#J1",
+  SK: "EVENT#2026-05-08T10:00:00.000Z#01HX",
+  jobId: "J1",
+  problemId: "p1",
+  source: "uptime",
+  points: 5,
+  result: "ok",
+  occurredAt: "2026-05-08T10:00:00.000Z",
+  ...over,
+});
+
+describe("collectTeamScoreEvents", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("複数 team の events を group + occurredAt 昇順で返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    // TEAM_A J1 と TEAM_B J2 — Promise.all なので mock 順は両方発火
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        ev({ occurredAt: "2026-05-08T10:01:00.000Z", points: 5 }),
+        ev({ occurredAt: "2026-05-08T10:00:00.000Z", points: 5 }),
+      ],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        ev({
+          PK: "DEPLOYMENT#J2",
+          jobId: "J2",
+          occurredAt: "2026-05-08T10:00:30.000Z",
+          source: "flag",
+          points: 100,
+        }),
+      ],
+    });
+
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [
+        { PK: "DEPLOYMENT#J1", teamId: "TEAM_A", teamName: "team-a" },
+        { PK: "DEPLOYMENT#J2", teamId: "TEAM_B", teamName: "team-b" },
+      ],
+      displayNameByTeamId: new Map([
+        ["TEAM_A", "Alpha"],
+        ["TEAM_B", "Bravo"],
+      ]),
+    });
+
+    // teamId 昇順 sort
+    expect(teams.map((t) => t.teamId)).toEqual(["TEAM_A", "TEAM_B"]);
+    // displayNameByTeamId を優先
+    expect(teams[0]?.teamName).toBe("Alpha");
+    expect(teams[1]?.teamName).toBe("Bravo");
+    // events 昇順
+    expect(teams[0]?.events.map((e) => e.occurredAt)).toEqual([
+      "2026-05-08T10:00:00.000Z",
+      "2026-05-08T10:01:00.000Z",
+    ]);
+    expect(teams[1]?.events[0]?.source).toBe("flag");
+  });
+
+  it("hint / flag-wrong / uptime / flag を含め、 attack-detected を除外するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        ev({ source: "uptime", points: 5, result: "ok" }),
+        ev({ source: "flag", points: 100, result: "ok" }),
+        ev({ source: "hint", points: -30, result: "ok" }),
+        ev({ source: "flag-wrong", points: -10, result: "wrong" }),
+        ev({ source: "attack-detected", points: 0, result: "down" }),
+      ],
+    });
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [{ PK: "DEPLOYMENT#J1", teamId: "TEAM_A" }],
+      displayNameByTeamId: new Map(),
+    });
+    expect(teams[0]?.events).toHaveLength(4);
+    const total = teams[0]?.events.reduce((s, e) => s + e.points, 0);
+    expect(total).toBe(65); // 5 + 100 - 30 - 10
+  });
+
+  it("displayName 不在 / teamName 不在ならば teamId を fallback として使うべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [ev()] });
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [{ PK: "DEPLOYMENT#J1", teamId: "TEAM_X" }],
+      displayNameByTeamId: new Map(),
+    });
+    expect(teams[0]?.teamName).toBe("TEAM_X");
+  });
+
+  it("EVENT# query は ScanIndexForward=false + PK + EVENT# prefix で発火するべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [ev()] });
+    await collectTeamScoreEvents(shared, {
+      deployments: [{ PK: "DEPLOYMENT#J1", teamId: "TEAM_A" }],
+      displayNameByTeamId: new Map(),
+    });
+    const cmd = ddbSend.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd.input.ScanIndexForward).toBe(false);
+    expect(cmd.input.KeyConditionExpression).toContain("begins_with(SK, :evpfx)");
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("DEPLOYMENT#J1");
+    expect(cmd.input.ExpressionAttributeValues?.[":evpfx"]).toBe("EVENT#");
+  });
+
+  it("1 team が複数 deployment / page をまたぐ場合の集約", async () => {
+    const { shared, ddbSend } = buildShared();
+    // J1 page1 (LastEvaluatedKey 付き) → J1 page2 → J2 page1
+    ddbSend.mockResolvedValueOnce({
+      Items: [ev({ occurredAt: "2026-05-08T10:00:00.000Z" })],
+      LastEvaluatedKey: { PK: "DEPLOYMENT#J1", SK: "EVENT#x" },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [ev({ occurredAt: "2026-05-08T10:01:00.000Z" })],
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [ev({ PK: "DEPLOYMENT#J2", jobId: "J2", occurredAt: "2026-05-08T10:02:00.000Z" })],
+    });
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [
+        { PK: "DEPLOYMENT#J1", teamId: "TEAM_A" },
+        { PK: "DEPLOYMENT#J2", teamId: "TEAM_A" },
+      ],
+      displayNameByTeamId: new Map(),
+    });
+    expect(teams).toHaveLength(1);
+    expect(teams[0]?.events.map((e) => e.occurredAt)).toEqual([
+      "2026-05-08T10:00:00.000Z",
+      "2026-05-08T10:01:00.000Z",
+      "2026-05-08T10:02:00.000Z",
+    ]);
+  });
+
+  it("空 deployments なら空 teams を返すべき (= DDB 呼び出しなし)", async () => {
+    const { shared, ddbSend } = buildShared();
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [],
+      displayNameByTeamId: new Map(),
+    });
+    expect(teams).toHaveLength(0);
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("operator 内部情報 (PK / SK / expiresAt) を出力に含めないべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        ev({
+          PK: "DEPLOYMENT#LEAK_PK_SENTINEL",
+          SK: "EVENT#LEAK_SK_SENTINEL",
+          tenantId: "LEAK_TENANT_SENTINEL",
+          expiresAt: 1_700_000_000_001,
+          GSI2PK: "TEAMKEY#LEAK_KEY_SENTINEL",
+        }),
+      ],
+    });
+    const teams = await collectTeamScoreEvents(shared, {
+      deployments: [{ PK: "DEPLOYMENT#LEAK_PK_SENTINEL", teamId: "TEAM_A" }],
+      displayNameByTeamId: new Map(),
+    });
+    const json = JSON.stringify(teams);
+    expect(json).not.toContain("LEAK_PK_SENTINEL");
+    expect(json).not.toContain("LEAK_SK_SENTINEL");
+    expect(json).not.toContain("LEAK_TENANT_SENTINEL");
+    expect(json).not.toContain("LEAK_KEY_SENTINEL");
+    expect(json).not.toContain("1700000000001");
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #1038 P1 #7 (= user 観測「スコアイベントは Application のイベント管理画面で出てこないとだめ、 つまり全チームのスコアの獲得状況を見えないと競技になりません」)。 operator が Event 詳細画面で 「どのチームがいつ加点 / 減点したか」 を一覧できる multi-series chart panel を追加。
- API GW resource を増やさない方針 (= CDK 配線は user 領域なので app 側で完結) のため、 既存 `GET /events/:eventId` に `?withScoreEvents=true` を opt-in 追加して同 endpoint で score events を返す。 default (= 既存 caller) は scoreEventsByTeam 不在で従来挙動を完全に維持。
- 新 backend module: `event-handler/team-score-events.ts` (+ 7 tests)
- 新 frontend component: `TeamScoreEventsPanel.tsx` (Cloudscape LineChart, multi-series, 凡例 click で系列 toggle)
- `getEventDetail` の per-row 集約を `aggregateDeploymentsForEvent` ヘルパに extract (= cognitive complexity 抑制、 既存 contract 不変)

## Test plan

- [x] 7 backend tests (= `test/problem-deploy/team-score-events.test.ts`)
  - 複数 team の events を group + occurredAt 昇順、 displayName 優先 / teamId fallback
  - source filter: uptime / flag / flag-wrong / hint allow / attack-detected 除外
  - EVENT# query の ScanIndexForward=false + PK + EVENT# prefix で発火
  - 複数 deployment × 複数 page の集約 (= 1 team が複数 PK に跨る場合)
  - 空 deployments の早期 return (= DDB call 0 件)
  - operator 内部情報 (PK / SK / tenantId / expiresAt / GSI2PK) の非漏洩
- [x] 既存 821 backend tests pass / 246 application-admin-console tests pass
- [x] `make harness` clean / `make before-commit` 全 pass (= synth + bundling 含む)

## Regression 分析

| 壊しうる箇所 | 仕組み的に守られる根拠 |
|---|---|
| 既存 `GET /events/:eventId` (= 旧 EventDetail 経路) | `withScoreEvents` default false で従来挙動を完全に維持、 余分な DDB query を発生させない |
| `getEventDetail` の deploymentsByProblem / displayNameByTeamId | `aggregateDeploymentsForEvent` ヘルパに 1 pass の集約 logic を extract、 入出力 contract は不変。 既存 821 件 pass で固定 |
| Frontend 既存 EventDetail panel | TeamScoreEventsPanel は `scoreEventsByTeam` が ある時のみ render、 既存 panel の位置 / 挙動には影響なし |
| participant 側 `/portal/leaderboard/score-events` (PR-1048) | 別 Lambda / 別 route なので影響なし。 score event semantics (= 4 source allow / marker 除外) は揃えてあり累計が一致 |
| Lambda 内処理時間 | opt-in なので default 経路は変化なし。 opt-in 経路は N teams × M deployments × 1-3 page = MVP 規模 (< 150 query / request)、 polling 30s 想定で許容 |
| Information disclosure | tenant scope (= JWT 経由) の認可で、 score event の公開 shape は participant 公開と同 (= internal PK / SK / expiresAt / login key 等を含まない)、 test sentinel で非漏洩 assertion 済 |

## 物理影響

- **UPDATE**: EventApi Lambda bundle (= 新 module + 拡張 route)、 application-admin-console SPA dist (= 新 panel + 新型)
- **NO-OP**: CFn / IAM (= 既存 Deployments table grantReadWriteData を再利用、 新 GSI / 新 route 不要)、 API GW resource、 EventBridge

## 残 backlog

Closes #1038 partial — P1 #7 のみ。 P2 #10 (= ParticipantViewerRole IAM) と P2 #13 (= Participant Portal URL injection、 wire.ts) は `infrastructure/templates/` / `app-wiring/` のインフラ層なので user 担当 ([[feedback-infra-user-owns]])。

🤖 Generated with [Claude Code](https://claude.com/claude-code)