### PR TITLE
fix(#1038): Participant Portal URL を pooled/silo runtime-config に再注入 (P2 #13)

### DIFF
--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -76,6 +76,26 @@ describe("tenant lifecycle scripts", () => {
     expect(script).toMatch(/CompetitorBootstrapTemplateUrl/);
   });
 
+  // Issue #1038 P2 #13: SBT pipeline (CodeBuild) が pooled / silo stack を synth するとき
+  // `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` を持っていないと、 `enableParticipantPortal=false`
+  // に倒れて `problemDeployBackendStack.participantPortalUrl` が undefined になり、 pooled
+  // stack の runtime-config に `participantPortalUrl` が **silent に消える**。 install.sh と
+  // 同じ default を CodeBuild にも入れて regression を防ぐ。
+  it("update-tenant.sh は CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき", () => {
+    const script = readRepoFile("scripts/update-tenant.sh");
+    expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
+  });
+
+  it("provision-tenant.sh は CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき", () => {
+    const script = readRepoFile("scripts/provision-tenant.sh");
+    expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
+  });
+
+  it("install.sh も CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき (= 3 script 同期)", () => {
+    const script = readRepoFile("scripts/install.sh");
+    expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
+  });
+
   it("mise の Node/Bun runtime は repo の正本 version と一致すべき", () => {
     const packageJson = JSON.parse(readRepoFile("package.json")) as {
       packageManager?: string;

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -69,6 +69,14 @@ export CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=$(aws cloudformation describe
   --output text 2>/dev/null || echo "")
 echo "CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL: ${CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
 
+# Issue #1038 P2 #13: install.sh と同じ default を入れて、 SBT pipeline (CodeBuild) が pooled /
+# silo stack を synth したときに `enableParticipantPortal=false` に regress するのを防ぐ。
+# これが無いと `problemDeployBackendStack.participantPortalUrl` が undefined になり、
+# pooled stack の runtime-config に `participantPortalUrl` が焼かれない (= user 観測
+# 「Application Console に Participant Portal URL 未注入」)。
+export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL="true"
+echo "CDK_PARAM_ENABLE_PARTICIPANT_PORTAL: ${CDK_PARAM_ENABLE_PARTICIPANT_PORTAL}"
+
 # Define variables
 TENANT_ADMIN_USERNAME="tenant-admin-$CDK_PARAM_TENANT_ID"
 STACK_NAME="tenkacloud-tenant-template-pooled"

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -36,6 +36,16 @@ VERSIONS=$(aws s3api list-object-versions --bucket "$CDK_PARAM_S3_BUCKET_NAME" -
 export CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')
 echo "CDK_PARAM_COMMIT_ID: ${CDK_PARAM_COMMIT_ID}"
 
+# Issue #1038 P2 #13: install.sh は `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` で synth するため、
+# `problemDeployBackendStack` は `participantPortalUrl` を CfnOutput し、 pooled stack の
+# runtime-config に cross-stack ref として焼かれる。 一方 SBT pipeline (CodeBuild) はこの env を
+# 持たないため synth 時に `enableParticipantPortal=false` に倒れ、 pooled stack を update する
+# たびに runtime-config から `participantPortalUrl` が **silent に消える** (= user 観測
+# 「participantPortalUrl 未注入」)。 install.sh と同じ default を CodeBuild にも入れて、
+# tenant provisioning / update での regression を防ぐ。
+export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL="true"
+echo "CDK_PARAM_ENABLE_PARTICIPANT_PORTAL: ${CDK_PARAM_ENABLE_PARTICIPANT_PORTAL}"
+
 aws s3api get-object --bucket "$CDK_PARAM_S3_BUCKET_NAME" --key "$CDK_SOURCE_NAME" --version-id "$CDK_PARAM_COMMIT_ID" "$CDK_SOURCE_NAME" 2>&1
 # `-o`: 既存ファイルを silent overwrite (CodeBuild の workspace 再利用で残ったファイルに対し、
 # prompt が出ると stdin EOF で `[N]one` 扱い → 展開不完全 → 後段で silent fail するのを防ぐ)。


### PR DESCRIPTION
## Summary

- Issue #1038 P2 #13 (= user 観測「Application Console に Participant Portal URL 未注入」)。 install.sh で `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` を export しているが、 SBT pipeline (CodeBuild) が pooled / silo stack を update するとき、 `update-tenant.sh` / `provision-tenant.sh` にこの env が無いため synth 時に `enableParticipantPortal=false` に regress し、 `problemDeployBackendStack.participantPortalUrl` が undefined になる。
- その結果 pooled stack の `runtime-config.json` に `participantPortalUrl` が **silent に消える** — tenant provisioning / update が走るたびに値が落ちる挙動だった。
- 3 script (install / update-tenant / provision-tenant) で `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true` を揃える。 regression 防止のため `tenant-lifecycle-scripts.test.ts` で 3 script 全てを assert。

## Test plan

- [x] 13 script tests pass (= 既存 10 + 新 3 で 3 script 同期を pin)
- [x] `make harness` clean / `make before-commit` 全 pass (= synth + bundling 含む)

## Regression 分析

| 壊しうる箇所 | 仕組み的に守られる根拠 |
|---|---|
| 既存 install.sh 経路 | 既存 export 行は touch していない、 新規 export は idempotent (= 同 value を 2 箇所で立てる) |
| pooled tenant の既存 runtime-config | 新規 deploy で URL が **追加** される方向、 既存 runtime-config から何かが消えるわけではない |
| silo (PLATINUM) tenant | provision-tenant.sh が PLATINUM 分岐で cdk deploy する直前に env を立てる、 silo の runtime-config にも URL が焼かれる |
| `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=false` を意図的に立てた deploy | 本 commit で 3 script が常に true を上書きするので false 経路は消える。 ただし本 repo の deploy 用途では false に倒したいケースは観測されていない (= 設定として常に true 想定) |

## 物理影響

- **UPDATE**: 次の `update-tenant.sh` / `provision-tenant.sh` 実行時に pooled / silo stack の `runtime-config.json` に `participantPortalUrl` が **再注入** される (= 既存 deploy では未注入だった field が増える)
- **NO-OP**: CFn resource 構造、 IAM、 DynamoDB / API GW / EventBridge

Closes #1038 partial — P2 #13 のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)