### PR TITLE
fix(#1035): Control Plane Cognito UserPool に MFA 必須を強制

### DIFF
--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -12,6 +12,11 @@ import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { Construct } from "constructs";
 import type { SamlIdpConfig } from "./config/config-interface";
 import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "./control-plane/invite-message";
+import {
+  SYSTEM_ADMIN_ENABLED_MFAS,
+  SYSTEM_ADMIN_MFA_CONFIGURATION,
+  SYSTEM_ADMIN_PASSWORD_POLICY,
+} from "./control-plane/mfa-policy";
 
 interface ControlPlaneStackProps extends cdk.StackProps {
   systemAdminEmail: string;
@@ -118,6 +123,16 @@ export class ControlPlaneStack extends cdk.Stack {
       "AdminCreateUserConfig.InviteMessageTemplate.EmailMessage",
       buildInviteEmailBody(adminConsoleOrigin),
     );
+
+    // Issue #1035: SystemAdmin は SaaS 全 tenant 横断の権限を持つので MFA 必須化 + 強 password。
+    // SBT 0.3.9 が UserPool を内部生成するため escape hatch で CFn property を上書きする。
+    // TenantAdmin 側 (= tenant-template/identity-provider.ts) は ADR-020 Phase E で同 baseline 適用済み。
+    // TOTP only (= SMS は SNS コスト + 国際到達率不安定で避ける)。
+    cfnUserPool.addPropertyOverride("MfaConfiguration", SYSTEM_ADMIN_MFA_CONFIGURATION);
+    cfnUserPool.addPropertyOverride("EnabledMfas", [...SYSTEM_ADMIN_ENABLED_MFAS]);
+    cfnUserPool.addPropertyOverride("Policies.PasswordPolicy", {
+      ...SYSTEM_ADMIN_PASSWORD_POLICY,
+    });
 
     const eventBus = EventBus.fromEventBusArn(this, "eventBus", controlPlane.eventManager.busArn);
 

--- a/infrastructure/lib/control-plane/mfa-policy.ts
+++ b/infrastructure/lib/control-plane/mfa-policy.ts
@@ -1,0 +1,24 @@
+/**
+ * Issue #1035: Control Plane (= SystemAdmin) の Cognito UserPool に MFA を強制するための
+ * CFn property 値を pin する。 SBT 0.3.9 が UserPool を内部生成するため、
+ * `control-plane-stack.ts` が escape hatch (`addPropertyOverride`) でこれらを上書きする。
+ *
+ * SMS は使わず TOTP 単独 (= SOFTWARE_TOKEN_MFA)。 国際 SMS の到達率不安定 + SNS コストを避ける。
+ * tenant-template/identity-provider.ts (= TenantAdmin 側、 ADR-020 Phase E で既設) と同方針。
+ *
+ * password policy も同時に強化する。 SBT default (= 8 文字 / lower+upper+number+symbol) を
+ * 12 文字に引き上げ、 SystemAdmin が SaaS 全体の権限を持つ前提に合わせる。
+ */
+
+export const SYSTEM_ADMIN_MFA_CONFIGURATION = "ON" as const;
+
+export const SYSTEM_ADMIN_ENABLED_MFAS = ["SOFTWARE_TOKEN_MFA"] as const;
+
+export const SYSTEM_ADMIN_PASSWORD_POLICY = {
+  MinimumLength: 12,
+  RequireLowercase: true,
+  RequireNumbers: true,
+  RequireSymbols: true,
+  RequireUppercase: true,
+  TemporaryPasswordValidityDays: 7,
+} as const;

--- a/infrastructure/test/control-plane/mfa-policy.test.ts
+++ b/infrastructure/test/control-plane/mfa-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  SYSTEM_ADMIN_ENABLED_MFAS,
+  SYSTEM_ADMIN_MFA_CONFIGURATION,
+  SYSTEM_ADMIN_PASSWORD_POLICY,
+} from "../../lib/control-plane/mfa-policy";
+
+/**
+ * Issue #1035: SystemAdmin の MFA / password policy が緩む方向に書き換えられないよう値を pin する。
+ * ここの定数値は control-plane-stack.ts が SBT 内蔵 UserPool に escape hatch で flush している。
+ *
+ * tenant-template/identity-provider.ts (TenantAdmin 側、 ADR-020 Phase E) と同方針 — TOTP only /
+ * SMS なし / 12 文字以上 / 4 種混在 を baseline とする。
+ */
+describe("SystemAdmin の Cognito UserPool MFA / password policy (Issue #1035)", () => {
+  it("MFA は REQUIRED (= ON) に強制すべき", () => {
+    expect(SYSTEM_ADMIN_MFA_CONFIGURATION).toBe("ON");
+  });
+
+  it("第二要素は TOTP (SOFTWARE_TOKEN_MFA) のみとし SMS は許可しないべき", () => {
+    expect(SYSTEM_ADMIN_ENABLED_MFAS).toEqual(["SOFTWARE_TOKEN_MFA"]);
+    expect(SYSTEM_ADMIN_ENABLED_MFAS).not.toContain("SMS_MFA");
+  });
+
+  it("password 最小長は 12 文字以上であるべき (SBT default 8 文字を上書き)", () => {
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.MinimumLength).toBeGreaterThanOrEqual(12);
+  });
+
+  it("password は lower / upper / number / symbol の 4 種を必須にすべき", () => {
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireLowercase).toBe(true);
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireUppercase).toBe(true);
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireNumbers).toBe(true);
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireSymbols).toBe(true);
+  });
+
+  it("一時パスワード有効期間は 7 日以内に制限すべき (= 招待後の総当たり面を縮減)", () => {
+    expect(SYSTEM_ADMIN_PASSWORD_POLICY.TemporaryPasswordValidityDays).toBeLessThanOrEqual(7);
+  });
+});


### PR DESCRIPTION
## Summary

- `ControlPlaneStack` の SBT 内蔵 UserPool に escape hatch (`addPropertyOverride`) で `MfaConfiguration: "ON"` / `EnabledMfas: ["SOFTWARE_TOKEN_MFA"]` / 12 文字 password policy を flush。username + password 1 要素で SystemAdmin が sign-in できる状態を解消。
- 設定値は `infrastructure/lib/control-plane/mfa-policy.ts` に pure constants として切り出し、`infrastructure/test/control-plane/mfa-policy.test.ts` で OFF / SMS / 短 password への退行を回帰防止 (5 ケース)。
- TenantAdmin 側 (`tenant-template/identity-provider.ts:150-154`) は ADR-020 Phase E で既に同 baseline 適用済み。本 PR で両 Plane の baseline が揃う。

Closes #1035

## なぜ pure constants + unit test なのか

`ControlPlaneStack` は SBT が内部で Python Lambda を Docker build するため、 `Template.fromStack` 経由の直接 synth assertion は CI / ローカルで Docker を要求する (`infrastructure/test/helpers.ts:7-8` に既存方針として明記)。 そこで MFA 設定値を pure constants module に分離し、 そこを unit test で pin する三段構成にした。 `identity-provider.test.ts:39-50` の TenantAdmin 側 invariant と対になる形。

## Regression 分析

- **既存 SystemAdmin user**: 次回 sign-in 時に Cognito Hosted UI が `MFA_SETUP` challenge を返し、 Authenticator app で TOTP 登録を促す。 1 回 setup すれば以降は通常通り。 lock-out 時の救済は AWS Console から `AdminResetUserPassword` + 再招待。
- **新規 user 招待**: 初回 sign-in (temp password → 新 password) の後に MFA setup wizard が挟まる。 既存の招待メール本文 (Issue #714 で英語化) は変更なし。
- **password policy 強化 (8 → 12 字 + 4 種混在)**: 既存 user の現 password が 12 字未満でも sign-in 自体は許可される (Cognito の policy は **新規 / 変更時のみ** 検査)。 次回 password reset 時に再設定が要る。
- **既存 escape hatch との相互作用**: 同一 `cfnUserPool` インスタンスに対する複数 `addPropertyOverride` は独立。 `AdminCreateUserConfig.InviteMessageTemplate.*` の上書き (Issue #714) は温存。
- **SAML IdP 経路 (Issue #839)**: `enforceSamlOnly` 時は Cognito password flow を `ExplicitAuthFlows: ["ALLOW_REFRESH_TOKEN_AUTH"]` で閉じているので Cognito MFA は要求されない (= IdP 側の MFA が効く)。 並列モードでは Cognito 経路に MFA が課される。
- **AdminConsoleInsight stack の JWT Authorizer**: `cognitoUserPool` / `cognitoUserClientId` の export 値 (= UserPool ID / Client ID) は不変なので兄弟 stack 側参照は壊れない。

## 物理影響

| Resource | Change | Type |
|---|---|---|
| `AWS::Cognito::UserPool` (SBT-managed, in `ControlPlaneStack`) | `MfaConfiguration`, `EnabledMfas`, `Policies.PasswordPolicy` の 3 property を追加 | UPDATE (in-place、 UserPool replace 無し) |
| `infrastructure/lib/control-plane/mfa-policy.ts` | 新規 | CREATE (CFn 影響なし、 build asset のみ) |
| `infrastructure/test/control-plane/mfa-policy.test.ts` | 新規 | CREATE (test only) |

CFn 上は UserPool の in-place UPDATE で `UserPoolId` は不変。 兄弟 stack の export 参照 (AdminConsoleInsight 等) は壊れない。

## スコープ外

- WebAuthn / Passkey (= Cognito で対応可だが本 issue では TOTP MFA を最低要件)
- TenantViewer / TenantOperator role の MFA 強制 (= 別 issue、 まず admin role 2 種を強制化)
- SMS MFA (= 国際到達率不安定 + SNS コストで TOTP only baseline)
- IP allowlist / VPN-only access (= 別 layer、 CloudFront viewer policy)

## Test plan

- [x] `infrastructure/test/control-plane/mfa-policy.test.ts` (5 ケース、 vitest green)
- [x] `make harness` clean (architecture invariant 違反なし)
- [x] `make before-commit` clean (lint / typecheck / test / validate-problems / cdk synth)
- [ ] **deploy 後の手動確認** (= user): Cognito Hosted UI で SystemAdmin sign-in 時に MFA setup wizard が出ること、 既存 user は 2 段目で TOTP code が要求されること
- [ ] **deploy 後の手動確認** (= user): AWS Console > Cognito > UserPool で `MFA: Required (Software token only)` 表示、 Password policy が 12 文字 + 4 種混在になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SystemAdmin accounts now require multi-factor authentication (MFA) via TOTP software tokens
  * Enhanced password policy with minimum 12-character requirement, mandatory uppercase/lowercase/numbers/symbols, and 7-day temporary password validity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->