### PR TITLE
fix(#1054): Rotate ExternalId button を verified=false で disable する

### DIFF
--- a/apps/application-admin-console/src/lib/competitor-account-actions.test.ts
+++ b/apps/application-admin-console/src/lib/competitor-account-actions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateRotateButtonGuard,
+  ROTATE_DISABLED_REASON_NOT_VERIFIED,
+  ROTATE_DISABLED_REASON_VERIFY_IN_FLIGHT,
+} from "./competitor-account-actions";
+
+/**
+ * Issue #1054: Competitor Accounts 画面の Rotate ExternalId button guard を pin する。
+ * backend (#868) の 409 not_verified guard と UI が乖離しないよう、 不変条件を test で固定する。
+ */
+describe("evaluateRotateButtonGuard (Issue #1054)", () => {
+  it("verified=false の row では Rotate ExternalId button が disabled であるべき", () => {
+    const result = evaluateRotateButtonGuard({ verified: false, verifyInFlight: null });
+    expect(result.disabled).toBe(true);
+    expect(result.reason).toBe(ROTATE_DISABLED_REASON_NOT_VERIFIED);
+  });
+
+  it("verified=true の row では Rotate ExternalId button が enabled であるべき", () => {
+    const result = evaluateRotateButtonGuard({ verified: true, verifyInFlight: null });
+    expect(result.disabled).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("verifyInFlight が進行中は verified=true でも Rotate button が disabled であるべき", () => {
+    const result = evaluateRotateButtonGuard({
+      verified: true,
+      verifyInFlight: "123456789012",
+    });
+    expect(result.disabled).toBe(true);
+    expect(result.reason).toBe(ROTATE_DISABLED_REASON_VERIFY_IN_FLIGHT);
+  });
+
+  it("not_verified と verify in-flight が同時に成立するときは not_verified を優先して説明すべき", () => {
+    // operator が unverified row を verify 中に他 row の rotate を試した経路。
+    // 「先に Verify を成功させて」 の方が本質的な原因なのでそちらを表示する。
+    const result = evaluateRotateButtonGuard({
+      verified: false,
+      verifyInFlight: "123456789012",
+    });
+    expect(result.disabled).toBe(true);
+    expect(result.reason).toBe(ROTATE_DISABLED_REASON_NOT_VERIFIED);
+  });
+});

--- a/apps/application-admin-console/src/lib/competitor-account-actions.ts
+++ b/apps/application-admin-console/src/lib/competitor-account-actions.ts
@@ -1,0 +1,35 @@
+/**
+ * Issue #1054: Competitor Accounts 画面の row 単位 button guard。
+ *
+ * backend (`competitor-accounts-handler/index.ts:313-317`, Issue #868) は verified=false な row
+ * への Rotate ExternalId を 409 not_verified で reject する。 UI が状態に追従していないと、
+ * operator は button を click してから 409 を画面で見るハマり方をする。 ここを pure function に
+ * 切り出して、 JSX 側で `disabled` の引数として渡し、 同時に unit test で挙動を pin する。
+ */
+
+export interface RotateButtonGuardInput {
+  readonly verified: boolean;
+  /** 同画面で進行中の verify があれば awsAccountId、 無ければ null。 */
+  readonly verifyInFlight: string | null;
+}
+
+export const ROTATE_DISABLED_REASON_NOT_VERIFIED =
+  "先に Verify を成功させてから Rotate してください。";
+export const ROTATE_DISABLED_REASON_VERIFY_IN_FLIGHT =
+  "Verify 中は Rotate できません。 完了を待ってください。";
+
+export interface RotateButtonGuardResult {
+  readonly disabled: boolean;
+  /** disabled=true のときに HTML `title` 属性 / Popover content として表示する文言。 */
+  readonly reason: string | undefined;
+}
+
+export function evaluateRotateButtonGuard(input: RotateButtonGuardInput): RotateButtonGuardResult {
+  if (!input.verified) {
+    return { disabled: true, reason: ROTATE_DISABLED_REASON_NOT_VERIFIED };
+  }
+  if (input.verifyInFlight !== null) {
+    return { disabled: true, reason: ROTATE_DISABLED_REASON_VERIFY_IN_FLIGHT };
+  }
+  return { disabled: false, reason: undefined };
+}

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -26,6 +26,7 @@ import {
 import { CopyableField } from "../components/CopyableField";
 import { FriendlyErrorAlert } from "../components/FriendlyErrorAlert";
 import type { AppConfig } from "../config";
+import { evaluateRotateButtonGuard } from "../lib/competitor-account-actions";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
@@ -178,14 +179,28 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
             >
               {item.verified ? "再 Verify" : "Verify"}
             </Button>
-            <Button
-              variant="normal"
-              iconName="refresh"
-              onClick={() => setRotateTarget(item)}
-              data-testid={`rotate-${item.awsAccountId}`}
-            >
-              Rotate ExternalId
-            </Button>
+            {(() => {
+              // Issue #1054: backend (#868) は verified=false への rotate を 409 で reject する。
+              // UI 側で row 状態に応じて button を disable し、 native title で理由を hover hint
+              // として出す (= Cloudscape Popover は click trigger で disabled button に乗らない)。
+              const guard = evaluateRotateButtonGuard({
+                verified: item.verified,
+                verifyInFlight,
+              });
+              return (
+                <span title={guard.reason}>
+                  <Button
+                    variant="normal"
+                    iconName="refresh"
+                    disabled={guard.disabled}
+                    onClick={() => setRotateTarget(item)}
+                    data-testid={`rotate-${item.awsAccountId}`}
+                  >
+                    Rotate ExternalId
+                  </Button>
+                </span>
+              );
+            })()}
             <Button
               variant="normal"
               iconName="upload"


### PR DESCRIPTION
## Summary

- `apps/application-admin-console/src/pages/CompetitorAccounts.tsx` の Rotate ExternalId button に `disabled={!item.verified || verifyInFlight !== null}` を適用。 native `<span title="...">` で disabled 理由を hover hint として出す。
- guard logic は pure function (`evaluateRotateButtonGuard` in `lib/competitor-account-actions.ts`) に切り出し、 unit test で 4 ケースを pin。
- backend handler は変更しない (= Issue #868 の 409 not_verified guard は **設計通り正しい**、 UI が状態に追従していなかっただけ)。

Closes #1054

## Regression 分析

- **verified=true の正常 rotate flow**: 既存と同じ enabled、 click で modal 遷移
- **verifyInFlight 中の rotate**: 元々 backend は受け付ける (= 別 row への rotate なので) が、 verify 結果が rotate 後の新 externalId に乗らないため UX 上不自然。 今回 disable に倒す (= 既存 user flow を壊す変更ではあるが、 fail-fast の方向)
- **既存 backend 409 path**: 残る (= manual 直叩き / 旧 frontend からの retry の safety net)
- **Cloudscape `<span>` wrapping**: Button の click event は span を通って bubble up するため、 disabled 時に親 onClick が誤発火する経路はなし
- **Update bootstrap button / 削除 button**: 触らない (= 別 root cause、 #1053 で対処)
- **Popover を使わなかった理由**: Cloudscape `Popover` は click trigger で、 disabled button では click event が発火しない。 hover hint には native `title` 属性が適合

## 物理影響

- frontend bundle のみ変更
- CFn / IAM / DDB / Lambda: 0 件 (= NO-OP)
- 新規 file: `lib/competitor-account-actions.ts` + `.test.ts`

## Test plan

- [x] `apps/application-admin-console/src/lib/competitor-account-actions.test.ts` (4 ケース) green
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / test / cdk synth)
- [ ] **deploy 後の手動確認** (= user): unverified row の Rotate button が disabled、 hover で 「先に Verify を成功させてから Rotate してください」 が表示されること、 verified row の Rotate は従来通り動くこと

## スコープ外

- Update bootstrap button の guard (= 別 root cause、 #1053 で URL 修正)
- Bootstrap URL 未注入時の警告 banner (= #1055)
- backend handler 変更 (= 設計通り)

🤖 Generated with [Claude Code](https://claude.com/claude-code)