### PR TITLE
fix(#1055): competitorBootstrapTemplateUrl 未注入時に警告 banner を表示

### DIFF
--- a/apps/application-admin-console/src/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isBootstrapUrlMissing } from "./competitor-bootstrap";
+
+/**
+ * Issue #1055: runtime-config の `competitorBootstrapTemplateUrl` 未注入判定を pin する。
+ * UI 側はこの判定を使って CompetitorAccounts 画面に警告 banner を出す。
+ */
+describe("isBootstrapUrlMissing (Issue #1055)", () => {
+  it("undefined は missing として扱うべき", () => {
+    expect(isBootstrapUrlMissing(undefined)).toBe(true);
+  });
+
+  it("空文字列は missing として扱うべき", () => {
+    expect(isBootstrapUrlMissing("")).toBe(true);
+  });
+
+  it("S3 URL が注入されていれば missing ではないべき", () => {
+    expect(
+      isBootstrapUrlMissing(
+        "https://tenkacloud-bootstrap-123.s3.ap-northeast-1.amazonaws.com/competitor-bootstrap.yaml",
+      ),
+    ).toBe(false);
+  });
+
+  it("GitHub raw URL (= 旧 fallback) も missing 扱いはしない (= 値が入っている時点で operator 配線済の判定)", () => {
+    // fallback URL も「URL が注入されている」 扱いにする (= 警告は出さない)。
+    // raw URL 自体が CFn で reject される問題は #1053 で別途解決される。
+    expect(
+      isBootstrapUrlMissing(
+        "https://raw.githubusercontent.com/susumutomita/TenkaCloud/main/infrastructure/templates/competitor-bootstrap.yaml",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/application-admin-console/src/lib/competitor-bootstrap.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.ts
@@ -36,6 +36,20 @@ function resolveTemplateUrl(templateUrl: string | undefined): string {
     : COMPETITOR_BOOTSTRAP_TEMPLATE_URL_FALLBACK;
 }
 
+/**
+ * Issue #1055: runtime-config に `competitorBootstrapTemplateUrl` が注入されているか判定する。
+ * 空 / undefined のとき、 CompetitorAccounts 画面の Launch / Update Stack リンクは GitHub raw
+ * fallback を返し、 AWS CFn console が「TemplateURL must be a supported URL」 で reject する。
+ * UI 側は本 helper で検出して事前警告 banner を表示する (= operator が壊れたリンクを送る前に
+ * 気付く)。
+ *
+ * #1053 の CDK refactor (= ProblemDeployBackendStack に hosting 移管) 完了で常に注入される
+ * ようになれば、 本 helper + 警告 banner は dead code として撤去できる。
+ */
+export function isBootstrapUrlMissing(templateUrl: string | undefined): boolean {
+  return !templateUrl || templateUrl.length === 0;
+}
+
 export interface LaunchStackUrlInput {
   readonly tenkaCloudAccountId: string;
   readonly externalId: string;

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -32,6 +32,7 @@ import {
   buildUpdatePayload,
   buildUpdateStackUrl,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
+  isBootstrapUrlMissing,
 } from "../lib/competitor-bootstrap";
 import { type FriendlyError, toFriendlyError } from "../lib/friendly-error";
 import { computeRotationAge, ROTATION_AGE_WARNING_DAYS } from "../lib/rotation-age";
@@ -225,6 +226,18 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
       >
         Competitor Accounts
       </Header>
+
+      {/* Issue #1055: runtime-config に competitorBootstrapTemplateUrl が注入されていないと
+          Launch / Update Stack リンクが GitHub raw URL fallback を返し、 AWS CFn console で
+          「TemplateURL must be a supported URL」 で reject される。 操作前に operator へ事前告知。
+          根治は #1053 で hosting を ProblemDeployBackendStack に移管したのち本 banner は撤去予定。 */}
+      {isBootstrapUrlMissing(config.competitorBootstrapTemplateUrl) && (
+        <Alert type="warning" header="Bootstrap template URL が未注入です">
+          runtime-config の <code>competitorBootstrapTemplateUrl</code> が空のため、 Launch / Update
+          Stack リンクは AWS CloudFormation 側で reject されます。 deploy 経路の
+          設定を管理者にご確認ください (= 参考: #1053)。
+        </Alert>
+      )}
 
       {error && <FriendlyErrorAlert error={error} />}
 


### PR DESCRIPTION
## Summary

- `apps/application-admin-console/src/lib/competitor-bootstrap.ts` に pure helper `isBootstrapUrlMissing` を追加 (4 ケース unit test 付き)
- `CompetitorAccounts` 画面の Header 直下に Cloudscape `Alert type="warning"` を条件付きで表示。 deploy 経路の設定不備を operator が click 前に気付ける
- 既存 Launch / Update button は **disable しない** (= dev 経路 / 手動 download は引き続き有効、 banner で事前告知のみ)
- 根治は #1053 (hosting を ProblemDeployBackendStack に移管) の方で対処。 本 PR は移管完了までの操作前ガード

Closes #1055

## Regression 分析

- **URL 注入済の SaaS deploy**: 既存挙動と完全に同じ (= banner は条件不成立で render されない)
- **URL 未注入 (= Lite mode / 未 deploy dev)**: 新規 banner が表示されるのみ。 button click は今まで通り進める (= GitHub raw URL に飛ぶ、 CFn 側で reject される挙動は #1053 完了まで残る)
- **既存 test**: `competitor-accounts-filter.test.ts` / `i18n.test.tsx` 等は影響なし。 新 helper のみ test 対象
- **`COMPETITOR_BOOTSTRAP_TEMPLATE_URL_FALLBACK` (= raw github const)**: 削除しない (= #1053 完了後の follow-up issue で撤去予定)
- **Alert の dismissable**: false (= default)。 operator が誤って閉じて見落とすリスクを抑制

## 物理影響

- frontend bundle のみ変更
- CFn / IAM / DDB / Lambda: 0 件 (= NO-OP)
- 新規 file: `lib/competitor-bootstrap.test.ts`

## Test plan

- [x] `apps/application-admin-console/src/lib/competitor-bootstrap.test.ts` (4 ケース) green
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / test / cdk synth)
- [ ] **deploy 後の手動確認** (= user): Lite mode で deploy した application-admin-console > Competitor Accounts 画面で警告 banner が表示されること。 SaaS Phase 3 完了後の deploy では banner が出ないこと

## スコープ外

- raw github fallback URL の削除 → #1053 完了後の follow-up
- CFn TemplateURL 経路自体の修正 → #1053
- Rotate button の disable → #1054 (= 別 PR で対処済 PR #1058)

🤖 Generated with [Claude Code](https://claude.com/claude-code)