### PR TITLE
fix(#1053): competitor-bootstrap.yaml hosting を ProblemDeployBackendStack に移管

### DIFF
--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -86,6 +86,8 @@ const liteStack = new TenkaCloudLiteStack(app, stackId("tenkacloud-lite"), {
   deployApiLambda: problemDeployBackend.deployApiLambda,
   eventApiLambda: problemDeployBackend.eventApiLambda,
   competitorAccountsApiLambda: problemDeployBackend.competitorAccountsApiLambda,
+  // Issue #1053: ProblemDeployBackendStack に移管した hosting の URL を cross-stack ref で渡す。
+  competitorBootstrapTemplateUrl: problemDeployBackend.competitorBootstrapTemplateUrl,
   ...(problemDeployBackend.participantPortalUrl
     ? { participantPortalUrl: problemDeployBackend.participantPortalUrl }
     : {}),

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -12,6 +12,9 @@ import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3"
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
 import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers";
+// Issue #1053: 旧来本 stack 内に同居していた competitor-bootstrap.yaml の S3 hosting は
+// ProblemDeployBackendStack 配下の CompetitorBootstrapHosting に移管した。 本 stack は
+// その出力 URL を props で受け取って runtime-config.json に焼き込むだけ。
 
 export interface AdminConsoleHostingStackProps extends cdk.StackProps {
   /** Control Plane API Gateway URL (末尾スラッシュ無し) */
@@ -48,6 +51,13 @@ export interface AdminConsoleHostingStackProps extends cdk.StackProps {
    * (= phase 2 初回 deploy の race 状態でも UI が壊れない安全装置)。
    */
   readonly adminInsightApiUrl: string;
+  /**
+   * Issue #1053: 競技者向け CFn bootstrap template (`competitor-bootstrap.yaml`) の S3 URL。
+   * `ProblemDeployBackendStack.competitorBootstrapTemplateUrl` を cross-stack ref で受け取る。
+   * runtime-config.json に焼き込まれ、 admin-console の Competitor Accounts 画面が CFn Quick
+   * Create / Update Stack deeplink の TemplateURL に埋める。
+   */
+  readonly competitorBootstrapTemplateUrl: string;
 }
 
 /**
@@ -67,13 +77,6 @@ export interface AdminConsoleHostingStackProps extends cdk.StackProps {
  */
 export class AdminConsoleHostingStack extends cdk.Stack {
   public readonly distributionDomainName: string;
-  /**
-   * #718: CFn `TemplateURL` は S3 / SSM の URL しか受け付けない (raw.githubusercontent.com は
-   * reject)。 競技者の Quick-create / Update Stack 経路で fetch される
-   * `competitor-bootstrap.yaml` の S3 public URL。 admin-console の runtime-config.json に
-   * 注入され、 frontend の `buildLaunchStackUrl` / `buildUpdateStackUrl` が consumer。
-   */
-  public readonly competitorBootstrapTemplateUrl: string;
 
   constructor(scope: Construct, id: string, props: AdminConsoleHostingStackProps) {
     super(scope, id, props);
@@ -121,46 +124,6 @@ export class AdminConsoleHostingStack extends cdk.Stack {
 
     this.distributionDomainName = distribution.distributionDomainName;
 
-    // #718: 競技者向け CFn template の public S3 host。 CFn `TemplateURL` は S3 URL のみ
-    // 許容するため、 GitHub raw URL の代わりに本 bucket の virtual-hosted style URL を返す。
-    // template 自体は既に public repo に置いてあり secret は含まないので、 public-read ACL
-    // は OK (= content は GitHub と冗長な複製)。 admin-console の runtime-config 経由で
-    // frontend に渡し、 Quick-create / Update Stack deeplink の templateURL に埋める。
-    const templateBucket = new Bucket(this, "CompetitorBootstrapTemplateBucket", {
-      encryption: BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-      // public-read を明示的に許可するため BlockPublicAccess を全 OFF にする。 BucketPolicy
-      // / ACL を後段で `publicReadAccess: true` で付与する。 同 stack 内の SiteBucket は
-      // BLOCK_ALL のまま (= 別 bucket 分離 + 1 bucket = 1 用途で混在を避ける)。
-      blockPublicAccess: new BlockPublicAccess({
-        blockPublicAcls: false,
-        blockPublicPolicy: false,
-        ignorePublicAcls: false,
-        restrictPublicBuckets: false,
-      }),
-      publicReadAccess: true,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-    });
-
-    // CompetitorAccounts modal の Launch Stack / Update Stack で参照される yaml を S3 へ sync。
-    // ローカル checkout の最新 yaml を deploy 時に upload するため、 GitHub raw と異なり
-    // PR 後の merge → 再 deploy で competitor 側にも反映される。
-    new BucketDeployment(this, "CompetitorBootstrapTemplateDeployment", {
-      sources: [
-        Source.asset(path.join(__dirname, "..", "templates"), {
-          // テンプレ単一 file のみ upload (= templates/ ディレクトリ内の README 等は不要)
-          exclude: ["*", "!competitor-bootstrap.yaml"],
-        }),
-      ],
-      destinationBucket: templateBucket,
-      prune: false,
-    });
-
-    // virtual-hosted style S3 URL (= CFn TemplateURL が要求する形式)。 region は明示的に
-    // path に含める。 同 stack 配下の bucketName は CFn deploy 時に動的解決される。
-    this.competitorBootstrapTemplateUrl = `https://${templateBucket.bucketName}.s3.${cdk.Stack.of(this).region}.amazonaws.com/competitor-bootstrap.yaml`;
-
     // 1) dist/ をアップロード (URL 非依存の静的ファイル)
     const distDir = path.join(__dirname, "..", "..", "apps", "admin-console", "dist");
     new BucketDeployment(this, "SiteDeployment", {
@@ -182,8 +145,10 @@ export class AdminConsoleHostingStack extends cdk.Stack {
       awsAccountId: props.awsAccountId,
       // ADR-011 #590 Phase 1.A
       adminInsightApiUrl: props.adminInsightApiUrl.replace(/\/$/, ""),
-      // #718: 競技者向け bootstrap template の public S3 URL (CFn TemplateURL 経由 fetch 用)
-      competitorBootstrapTemplateUrl: this.competitorBootstrapTemplateUrl,
+      // Issue #1053: 競技者向け bootstrap template の public S3 URL (= ProblemDeployBackendStack
+      // 配下 CompetitorBootstrapHosting の cross-stack ref)。 CFn TemplateURL は S3 URL のみ受け
+      // 付けるため、 frontend は本値を Quick-create / Update Stack deeplink に埋める。
+      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
     };
     // Issue #867: runtime-config.json は **絶対にキャッシュさせない** (= CloudFront edge で
     // tenant 間混線するリスク + deploy 後 1 時間反映されない問題を避けるため)。
@@ -200,12 +165,6 @@ export class AdminConsoleHostingStack extends cdk.Stack {
       value: `https://${distribution.distributionDomainName}`,
       description:
         "admin-console の CloudFront URL。ControlPlaneStack の CDK_PARAM_ADMIN_CONSOLE_ORIGIN に設定して再 deploy することで Cognito callback + CORS に追加される",
-    });
-
-    new cdk.CfnOutput(this, "CompetitorBootstrapTemplateUrl", {
-      value: this.competitorBootstrapTemplateUrl,
-      description:
-        "Competitor 用 bootstrap CFn テンプレート (= competitor-bootstrap.yaml) の S3 public URL。Quick-create / Update Stack deeplink の TemplateURL に渡す。",
     });
   }
 }

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -186,7 +186,8 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
   }
 
   const adminConsoleOriginForCors = env.CDK_PARAM_ADMIN_CONSOLE_ORIGIN;
-  const competitorBootstrapTemplateUrlEnv = env.CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL;
+  // Issue #1053: 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance は廃止。
+  // hosting を ProblemDeployBackendStack に移管し、 consumer は cross-stack ref で URL を受ける。
 
   const adminConsoleHostingInputs = buildHostingInputs(env);
 
@@ -247,7 +248,6 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     challengePayloadBucketName,
     deployConcurrentBuildLimit,
     adminConsoleOriginForCors,
-    competitorBootstrapTemplateUrlEnv,
     adminConsoleHostingInputs,
     tenantSamlConfig,
     controlPlaneSamlConfig,

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -82,8 +82,9 @@ export interface AppConfig {
   /** AdminConsoleInsight の CORS allow-list 用 origin。 phase 2 deploy 時に install.sh が export する。 */
   readonly adminConsoleOriginForCors: string | undefined;
 
-  /** 競技者向け bootstrap template の S3 URL (phase 3 で install.sh が export して inject)。 */
-  readonly competitorBootstrapTemplateUrlEnv: string | undefined;
+  // Issue #1053: 旧 `competitorBootstrapTemplateUrlEnv` (= `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL`)
+  // は廃止。 ProblemDeployBackendStack に hosting を移管したため、 consumer は cross-stack ref で
+  // URL を受ける (= Phase 3 env-var dance が不要になる)。
 
   /** Phase 2 hosting stack を立てるための 3 つの env (全部揃ったときだけ deploy する)。 */
   readonly adminConsoleHostingInputs: AdminConsoleHostingInputs | undefined;

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -172,7 +172,9 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       eventApiLambda: problemDeployBackendStack.eventApiLambda,
       competitorAccountsApiLambda: problemDeployBackendStack.competitorAccountsApiLambda,
       participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
-      competitorBootstrapTemplateUrl: config.competitorBootstrapTemplateUrlEnv,
+      // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 cross-stack ref で
+      // URL を受ける。 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance は廃止。
+      competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
       samlConfig: config.tenantSamlConfig,
     },
   );
@@ -319,8 +321,12 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
         awsRegion: config.awsRegion,
         awsAccountId: config.awsAccountId,
         adminInsightApiUrl: config.adminConsoleHostingInputs.adminInsightApiUrl,
+        // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 cross-stack ref で
+        // URL を受ける。 Phase 1 から runtime-config.json に正しい S3 URL が焼かれる。
+        competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
       },
     );
+    adminConsoleHosting.addDependency(problemDeployBackendStack);
     cdk.Aspects.of(adminConsoleHosting).add(new DestroyPolicySetter());
   }
 

--- a/infrastructure/lib/problem-deploy/competitor-bootstrap-hosting.ts
+++ b/infrastructure/lib/problem-deploy/competitor-bootstrap-hosting.ts
@@ -1,0 +1,62 @@
+import * as path from "node:path";
+import * as cdk from "aws-cdk-lib";
+import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+
+/**
+ * Issue #1053: 競技者向け CFn bootstrap template (`competitor-bootstrap.yaml`) の public S3 host。
+ *
+ * 旧実装は `AdminConsoleHostingStack` (= System Admin SPA hosting、 SaaS-only stack) 内に同居
+ * していたため、 Lite mode (= AdminConsoleHosting を deploy しない) では template が S3 に
+ * 置かれず、 frontend は GitHub raw URL fallback (= CFn が `TemplateURL must be a supported URL`
+ * で reject) を使うしかなかった。 SaaS mode でも 3-phase env-var dance に依存していて
+ * Phase 3 失敗時には fragile。
+ *
+ * 本 construct を `ProblemDeployBackendStack` (= Lite / SaaS 両モードが無条件で deploy)
+ * 内に置き、 owner を 「問題 deploy 機構の asset」 という正しい責務に揃える。 consumer
+ * (AdminConsoleHosting / ApplicationAdminConsoleHosting) は cross-stack ref で URL を import。
+ *
+ * yaml 自体は公開 repo にあり secret は含まないため public-read で OK (= GitHub raw との冗長複製)。
+ * deploy 毎に最新 checkout の yaml が S3 に sync される (= GitHub raw と異なり、 merge 後の
+ * 再 deploy が無くても CFn console 経路は最新を引く)。
+ */
+export class CompetitorBootstrapHosting extends Construct {
+  /**
+   * `competitor-bootstrap.yaml` の S3 virtual-hosted style URL (= CFn `TemplateURL` 要件)。
+   * region を明示的に path に含め、 bucketName は deploy 時に動的解決される。 同 stack 配下の
+   * consumer は CFn token として扱う、 cross-stack consumer は CfnOutput / public readonly で
+   * 受け取る。
+   */
+  public readonly templateUrl: string;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const templateBucket = new Bucket(this, "Bucket", {
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      blockPublicAccess: new BlockPublicAccess({
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false,
+      }),
+      publicReadAccess: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    new BucketDeployment(this, "Deployment", {
+      sources: [
+        Source.asset(path.join(__dirname, "..", "..", "templates"), {
+          exclude: ["*", "!competitor-bootstrap.yaml"],
+        }),
+      ],
+      destinationBucket: templateBucket,
+      prune: false,
+    });
+
+    this.templateUrl = `https://${templateBucket.bucketName}.s3.${cdk.Stack.of(this).region}.amazonaws.com/competitor-bootstrap.yaml`;
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -9,6 +9,7 @@ import { AdminAuditLogTable } from "./admin-audit-log-table";
 import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine";
 import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda";
 import { CompetitorAccountsTable } from "./competitor-accounts-table";
+import { CompetitorBootstrapHosting } from "./competitor-bootstrap-hosting";
 import { DeployApiLambda } from "./deploy-api-lambda";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine";
@@ -192,6 +193,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
    * cross-stack read で audit UI に出すため公開する (= read-only)。
    */
   public readonly adminAuditLogTable: Table;
+  /**
+   * Issue #1053: 競技者向け CFn bootstrap template (`competitor-bootstrap.yaml`) の S3 public
+   * URL。 旧実装は `AdminConsoleHostingStack` に同居していたが、 Lite mode で deploy されない
+   * 構造的問題があったため、 両モードが無条件で deploy する本 stack へ移管した。 consumer は
+   * `AdminConsoleHostingStack` (SaaS) と `TenantTemplateStack` / `TenkaCloudLiteStack` 経由の
+   * `ApplicationAdminConsoleHosting` で、 cross-stack ref で受け取る。
+   */
+  public readonly competitorBootstrapTemplateUrl: string;
   /** DeployCreate Step Functions State Machine ARN for CloudWatch metrics. */
   public readonly deployCreateStateMachineArn: string;
   /** DeployDelete Step Functions State Machine ARN for CloudWatch metrics. */
@@ -235,6 +244,19 @@ export class ProblemDeployBackendStack extends cdk.Stack {
     // admin-insight Lambda が PutItem する。 TTL 90 日で自動 GC。
     const adminAuditLog = new AdminAuditLogTable(this, "AdminAuditLog");
     this.adminAuditLogTable = adminAuditLog.table;
+
+    // Issue #1053: 競技者向け CFn bootstrap template の S3 hosting を本 stack に持つ。
+    // 旧 AdminConsoleHostingStack から移管 (= Lite / SaaS 両モード対応 + 3-phase env-var dance 解消)。
+    const competitorBootstrapHosting = new CompetitorBootstrapHosting(
+      this,
+      "CompetitorBootstrapHosting",
+    );
+    this.competitorBootstrapTemplateUrl = competitorBootstrapHosting.templateUrl;
+    new CfnOutput(this, "CompetitorBootstrapTemplateUrl", {
+      value: this.competitorBootstrapTemplateUrl,
+      description:
+        "Competitor 用 bootstrap CFn テンプレート (= competitor-bootstrap.yaml) の S3 public URL。Quick-create / Update Stack deeplink の TemplateURL に渡す。",
+    });
     // Issue #778 ADR-016 Phase 2: eventBusArn が渡されていれば既存の SBT bus を import、
     // 渡されていなければ Lite mode と判定して local EventBus を新規に作る。 後者では Step
     // Functions Rule も local bus にぶら下がるため、 cross-stack 依存が増えない。

--- a/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
+++ b/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
@@ -36,6 +36,12 @@ export interface TenkaCloudLiteStackProps extends StackProps {
   /** Participant Portal の CloudFront URL (= application-admin-console の runtime-config に注入)。 */
   readonly participantPortalUrl?: string;
   /**
+   * Issue #1053: 競技者向け CFn bootstrap template (`competitor-bootstrap.yaml`) の S3 URL。
+   * `ProblemDeployBackendStack.competitorBootstrapTemplateUrl` を cross-stack ref で受け取り、
+   * `buildAppPlaneCore` 経由で `ApplicationAdminConsoleHosting` の runtime-config に焼く。
+   */
+  readonly competitorBootstrapTemplateUrl: string;
+  /**
    * Issue #839 follow-up: Lite mode 1 tenant 用 SAML IdP 連携。 未設定なら従来通り
    * Cognito username/password。 wire.ts が `Config.tenantSamlConfig` をそのまま渡す。
    */
@@ -80,6 +86,7 @@ export class TenkaCloudLiteStack extends Stack {
       eventApiLambda: props.eventApiLambda,
       competitorAccountsApiLambda: props.competitorAccountsApiLambda,
       participantPortalUrl: props.participantPortalUrl,
+      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
       apiKeyConfig: {
         ssmParameterNames: {
           basic: { keyId: `${liteApiKeyPlaceholder}-basic-id`, value: liteApiKeyPlaceholder },

--- a/infrastructure/test/admin-console-hosting.test.ts
+++ b/infrastructure/test/admin-console-hosting.test.ts
@@ -35,6 +35,8 @@ function synth(): Template {
     awsRegion: "ap-northeast-1",
     awsAccountId: "123456789012",
     adminInsightApiUrl: "https://insight.example.com",
+    competitorBootstrapTemplateUrl:
+      "https://tenkacloud-source.s3.ap-northeast-1.amazonaws.com/competitor-bootstrap.yaml",
   });
   return Template.fromStack(stack);
 }

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -324,6 +324,34 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["ProblemEndpointsTableName"]));
     });
+
+    it("Issue #1053: CompetitorBootstrapTemplateUrl を Output として持つべき", () => {
+      // hosting を AdminConsoleHostingStack から移管したため、 本 stack が出力 owner。
+      // SaaS の AdminConsoleHosting と Lite / SaaS の ApplicationAdminConsoleHosting が
+      // cross-stack ref で受け取る。
+      const outputs = tpl.findOutputs("*");
+      expect(Object.keys(outputs)).toEqual(
+        expect.arrayContaining(["CompetitorBootstrapTemplateUrl"]),
+      );
+    });
+  });
+
+  describe("Issue #1053: CompetitorBootstrapHosting (公開 S3 hosting)", () => {
+    it("public-read な S3 bucket を 1 つ追加で作るべき (= 旧 AdminConsoleHostingStack から移管)", () => {
+      // ParticipantPortal 等で別 bucket もあるため count assert は避け、 public-read 設定の
+      // ある bucket が存在することで pin。
+      tpl.hasResourceProperties(
+        "AWS::S3::Bucket",
+        Match.objectLike({
+          PublicAccessBlockConfiguration: Match.objectLike({
+            BlockPublicAcls: false,
+            BlockPublicPolicy: false,
+            IgnorePublicAcls: false,
+            RestrictPublicBuckets: false,
+          }),
+        }),
+      );
+    });
   });
 
   describe("legacy 経路の廃止", () => {

--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -63,17 +63,12 @@ describe("tenant lifecycle scripts", () => {
     expect(nodeMajor).toBeGreaterThanOrEqual(22);
   });
 
-  // Issue #1029 / PR-1028 follow-up: install.sh が pooled stack を deploy しなくなったため、
-  // CodeBuild 側で competitorBootstrapTemplateUrl を CFn output から読み直す必要がある。
-  // 忘れると pooled tenant の application-admin-console runtime-config に bootstrap URL が
-  // 空のまま焼かれ、 競技者の Launch Stack deeplink が動かなくなる。 regression pin。
-  it("update-tenant.sh は admin-console-hosting の CompetitorBootstrapTemplateUrl を CFn output から export すべき", () => {
+  // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 update-tenant.sh / provision-tenant.sh
+  // は `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` を env で渡さない (= cross-stack ref に置換)。
+  // 旧 env-var 経路が誤って復活しないよう regression pin する。
+  it("update-tenant.sh は CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL を env-var inject しないべき (#1053)", () => {
     const script = readRepoFile("scripts/update-tenant.sh");
-    expect(script).toMatch(
-      /CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=\$\(aws cloudformation describe-stacks/,
-    );
-    expect(script).toContain('--stack-name "tenkacloud-admin-console-hosting"');
-    expect(script).toMatch(/CompetitorBootstrapTemplateUrl/);
+    expect(script).not.toMatch(/export\s+CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=/);
   });
 
   // Issue #1038 P2 #13: SBT pipeline (CodeBuild) が pooled / silo stack を synth するとき
@@ -143,17 +138,10 @@ describe("tenant lifecycle scripts", () => {
     expect(branchIdx).toBeGreaterThan(normalizeIdx);
   });
 
-  // Issue #1029 follow-up: 初回 provisioning でも admin-console-hosting の
-  // CompetitorBootstrapTemplateUrl を CFn output から読んで cdk deploy 時に env に流す。
-  // 忘れると pooled tenant の runtime-config に bootstrap URL が空のまま焼かれ、
-  // 競技者 Launch Stack で CFn が「TemplateURL must be a supported URL」 で reject する
-  // (= raw.githubusercontent.com fallback では deploy 不可、 2026-05-18 観測)。
-  it("provision-tenant.sh は admin-console-hosting の CompetitorBootstrapTemplateUrl を CFn output から export すべき", () => {
+  // Issue #1053: 初回 provisioning でも env-var inject は不要 (= ProblemDeployBackendStack
+  // から cross-stack ref で URL が引かれる)。 旧経路が誤って復活しないよう regression pin。
+  it("provision-tenant.sh は CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL を env-var inject しないべき (#1053)", () => {
     const script = readRepoFile("scripts/provision-tenant.sh");
-    expect(script).toMatch(
-      /CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=\$\(aws cloudformation describe-stacks/,
-    );
-    expect(script).toContain('--stack-name "tenkacloud-admin-console-hosting"');
-    expect(script).toMatch(/CompetitorBootstrapTemplateUrl/);
+    expect(script).not.toMatch(/export\s+CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=/);
   });
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,17 +175,9 @@ echo "=============================================="
 ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
 export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"
 echo "  CloudFront URL: ${ADMIN_CONSOLE_URL}"
-# #718: AdminConsoleHostingStack の CompetitorBootstrapTemplateUrl output を取得し、
-# tenant-template-pooled に env 経由で再 inject する。 これにより application-admin-console の
-# runtime-config.json に S3 URL が埋まり、 Launch Stack / Update Stack の CFn TemplateURL が
-# S3 URL になる (= 旧 GitHub raw は CFn が reject していた)。
-COMPETITOR_BOOTSTRAP_TEMPLATE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'CompetitorBootstrapTemplateUrl')].OutputValue" --output text)
-export CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL="${COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
-echo "  Competitor bootstrap template URL: ${COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
-# Issue #1029 / PR-1028 follow-up: pooled stack は SBT pipeline (CodeBuild) で update する
-# 設計なので install.sh では deploy しない。 CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL が
-# pooled stack に伝播するのは、 次の tenant event で CodeBuild が走ったとき
-# (update-tenant.sh が同 CFn output を読んで env に流す、 別 commit で対応)。
+# Issue #1053: 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` の env-var inject は廃止。
+# hosting を ProblemDeployBackendStack に移管したので、 Phase 1 完了時点で cross-stack ref
+# 経由で runtime-config.json に正しい S3 URL が焼かれる (= Phase 3 の dance が不要)。
 bun cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight --require-approval never
 
 # ============================================================================

--- a/scripts/provision-tenant.sh
+++ b/scripts/provision-tenant.sh
@@ -57,17 +57,9 @@ export CDK_PARAM_TENANT_NAME=$tenantName
 export TIER=$(echo "$tier" | tr '[:lower:]' '[:upper:]')
 export TENANT_ADMIN_EMAIL=$email
 
-# Issue #1029 follow-up: admin-console-hosting stack の CompetitorBootstrapTemplateUrl
-# output (= public S3 URL) を CodeBuild 側で読み直して cdk deploy の synth に流す。
-# pooled stack の runtime-config.json に bootstrap URL が空のまま焼かれると、
-# 競技者の Launch Stack deeplink で CFn が「TemplateURL must be a supported URL」 で
-# reject する (= raw.githubusercontent.com fallback では deploy 不可)。 stack 不在は
-# 空文字 fallback (= 初回 install と同じく frontend が GitHub raw fallback に倒れる)。
-export CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=$(aws cloudformation describe-stacks \
-  --stack-name "tenkacloud-admin-console-hosting" \
-  --query "Stacks[0].Outputs[?starts_with(OutputKey,'CompetitorBootstrapTemplateUrl')].OutputValue" \
-  --output text 2>/dev/null || echo "")
-echo "CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL: ${CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
+# Issue #1053: hosting を ProblemDeployBackendStack に移管したので、 env-var で
+# CompetitorBootstrapTemplateUrl を inject する経路は不要。 pooled / silo stack は cross-stack
+# ref で `tenkacloud-problem-deploy` から URL を import する (= synth が CFn 上で解決)。
 
 # Issue #1038 P2 #13: install.sh と同じ default を入れて、 SBT pipeline (CodeBuild) が pooled /
 # silo stack を synth したときに `enableParticipantPortal=false` に regress するのを防ぐ。

--- a/scripts/update-tenant.sh
+++ b/scripts/update-tenant.sh
@@ -21,16 +21,9 @@ export CDK_PARAM_S3_BUCKET_NAME="tenkacloud-source-${ACCOUNT_ID}-${REGION}"
 echo "CDK_PARAM_S3_BUCKET_NAME: ${CDK_PARAM_S3_BUCKET_NAME}"
 export CDK_SOURCE_NAME="source.zip"
 
-# Issue #1029 / PR-1028 follow-up: install.sh が pooled stack を deploy しなくなったため
-# (= SBT pipeline 一本化)、 admin-console-hosting stack の CompetitorBootstrapTemplateUrl
-# output を CodeBuild 側で読み直して、 cdk deploy 時の synth に流す。 これを忘れると
-# pooled stack の application-admin-console runtime-config に bootstrap URL が空のまま
-# 焼かれ、 競技者の Launch Stack deeplink が動かなくなる。 stack 不在は空文字 fallback。
-export CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=$(aws cloudformation describe-stacks \
-  --stack-name "tenkacloud-admin-console-hosting" \
-  --query "Stacks[0].Outputs[?starts_with(OutputKey,'CompetitorBootstrapTemplateUrl')].OutputValue" \
-  --output text 2>/dev/null || echo "")
-echo "CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL: ${CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL}"
+# Issue #1053: hosting を ProblemDeployBackendStack に移管したので、 env-var で
+# CompetitorBootstrapTemplateUrl を inject する経路は不要。 pooled stack は cross-stack ref で
+# `tenkacloud-problem-deploy` から URL を import する (= synth が CFn 上で解決)。
 
 VERSIONS=$(aws s3api list-object-versions --bucket "$CDK_PARAM_S3_BUCKET_NAME" --prefix "$CDK_SOURCE_NAME" --query 'Versions[?IsLatest==`true`].{VersionId:VersionId}' --output text 2>&1)
 export CDK_PARAM_COMMIT_ID=$(echo "$VERSIONS" | awk 'NR==1{print $1}')


### PR DESCRIPTION
## Summary

- 新規 `infrastructure/lib/problem-deploy/competitor-bootstrap-hosting.ts` 構築 (= public S3 bucket + BucketDeployment、 旧 `admin-console-hosting.ts:129-162` を移管)
- `ProblemDeployBackendStack` が internal instantiate し、 public readonly `competitorBootstrapTemplateUrl` + CfnOutput で URL を expose
- `AdminConsoleHostingStack` から bucket / deployment / URL 構築 / 旧 output を削除し、 URL を props 受け取りに変更
- `wire.ts` (SaaS) / `bin/tenkacloud-lite.ts` + `tenkacloud-lite-stack.ts` (Lite) で `problemDeployBackendStack.competitorBootstrapTemplateUrl` を CFn token で渡す cross-stack ref に統一
- 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance を撤去 (`app-config/resolve.ts` + `types.ts`、 `install.sh` Phase 3、 `update-tenant.sh` / `provision-tenant.sh` から)

Closes #1053

## なぜ設計バグだったか

`competitor-bootstrap.yaml` は **問題 deploy 機構が要求する asset** で、 Lite / SaaS 両モードが使う。 しかし旧実装は SaaS-only な `AdminConsoleHostingStack` 内に同居していたため:

| Mode | 症状 |
|---|---|
| Lite (`make deploy`) | `AdminConsoleHostingStack` 未 deploy → yaml が S3 に置かれない → frontend は GitHub raw fallback → CFn console が `TemplateURL must be a supported URL` で reject (Image #15 #17) |
| SaaS (`make deploy-saas`) | Phase 3 の `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var inject に失敗すると同症状。 update-tenant.sh / provision-tenant.sh で重複定義 |

両モードが無条件で deploy する `ProblemDeployBackendStack` が owner であるべき (= 責務整合)。 移管後は cross-stack ref で Phase 1 完了時点から URL が runtime-config に焼かれる。

## Regression 分析

- **既存 SaaS deploy の cdk diff**: `AdminConsoleHostingStack` 配下の `CompetitorBootstrapTemplateBucket` / `CompetitorBootstrapTemplateDeployment` / `CompetitorBootstrapTemplateUrl` Output が **DELETE**、 `ProblemDeployBackendStack` 配下に同等の resource が **CREATE**。 bucket は `removalPolicy: DESTROY + autoDeleteObjects: true` なので CFn 上で消える (= operator の手 cleanup 不要)
- **既存 SaaS frontend**: `runtime-config.json` の `competitorBootstrapTemplateUrl` 値が新 bucket の virtual-hosted URL に切り替わる。 CloudFront cache は no-store (Issue #867) なのでブラウザ次 fetch で即反映
- **既存 Lite deploy**: 元から動いていなかったので regression なし。 本 PR で初めて Launch / Update Stack リンクが S3 URL になり成立する
- **`CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env**: 削除。 旧 export 経路を持つ CI / scripts (= install.sh Phase 3、 update-tenant.sh、 provision-tenant.sh) からも除去
- **`competitorBootstrapTemplateUrlEnv` field**: `AppConfig` / `resolveAppConfig` から削除 (= dead code)
- **AdminConsoleHostingStack.cognitoUserPool 等の cross-stack ref**: 不変
- **AdminConsoleHostingStack の `addDependency(problemDeployBackendStack)`**: 新規追加 (= cross-stack ref が CFn 上で解決されるための依存)
- **`#1055` の警告 banner**: 同 PR の URL 注入によって、 通常 deploy では空文字にならなくなる (= banner は事実上 dev / 設定不備でのみ表示)。 #1055 の banner 自体は撤去せず残す (= dev 経路 safeguard)

## 物理影響

| Resource | Mode | Change |
|---|---|---|
| `AWS::S3::Bucket` (CompetitorBootstrap host bucket) | SaaS | DELETE (旧 AdminConsoleHostingStack 内) + CREATE (新 ProblemDeployBackendStack 内) = **REPLACE** (= 名前は CFn 自動採番、 内容は同一 yaml) |
| 同上 | Lite | **CREATE** (= 今まで存在しなかった) |
| `AWS::S3::BucketPolicy` (PublicRead) | 両モード | REPLACE / CREATE |
| BucketDeployment 関連 Lambda + CloudFront invalidation | 両モード | REPLACE / CREATE |
| `AWS::CloudFormation::Output: CompetitorBootstrapTemplateUrl` | SaaS | 所属 stack が AdminConsoleHostingStack → ProblemDeployBackendStack に移動 |
| AdminConsoleHostingStack `runtime-config.json` | SaaS | UPDATE (`competitorBootstrapTemplateUrl` が新 bucket の virtual-hosted URL に変わる) |
| ApplicationAdminConsoleHosting `runtime-config.json` | Lite + SaaS | UPDATE (Lite は空 → 値あり、 SaaS は新 URL) |
| CFn / IAM / DDB / Lambda の他 stack | - | 0 件 (= NO-OP) |

## Test plan

- [x] `infrastructure/test/problem-deploy-backend-stack.test.ts` に new output + public-read bucket assert 追加 (50/50 green)
- [x] `infrastructure/test/admin-console-hosting.test.ts` の synth props に `competitorBootstrapTemplateUrl` 追加 (3/3 green)
- [x] `infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts` を新 cross-stack ref 方針に合わせて regression pin 書き換え (= 旧 env-var inject が誤って復活しないこと)
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / 1248 vitest cases / cdk synth)
- [ ] **deploy 後の手動確認** (= user): Lite mode と SaaS mode の両方で application-admin-console > Competitor Accounts > 「アカウントを追加」 → Quick-create リンクが S3 URL を返し、 CFn console で reject されないこと
- [ ] **deploy 後の手動確認** (= user): `tenkacloud-admin-console-hosting` stack の cdk diff で旧 bucket が **DELETE** されること、 `tenkacloud-problem-deploy` stack で同等の bucket が **CREATE** されること

## スコープ外

- `apps/application-admin-console/src/lib/competitor-bootstrap.ts:25` の `COMPETITOR_BOOTSTRAP_TEMPLATE_URL_FALLBACK` 削除 → 本 PR merge 後 follow-up issue で扱う (= dev 用 safeguard として一旦残す)
- `#1055` の警告 banner 撤去 → 同上、 follow-up
- AdminConsoleHostingStack 自体の SaaS-only 性は不変 (= System Admin SPA hosting の責務はそのまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)