### PR TITLE
fix(#1034): SBT tenant onboarding/offboarding event を SystemAdmin audit に集約

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/system-audit-writer/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/system-audit-writer/index.ts
@@ -1,0 +1,116 @@
+import type { EventBridgeEvent } from "aws-lambda";
+import { writeAuditEvent } from "../shared/audit-log.js";
+
+/**
+ * Issue #1034: SBT Control Plane が発する tenant onboarding / offboarding events を audit
+ * (= `PK=SYSTEM#<env>`) に集約する EventBridge listener。
+ *
+ * 旧状態: SystemAdmin による tenant 作成 / 削除は SBT 経由なので、 App Plane Lambda の
+ * `writeAuditEvent` は呼ばれず、 `audit-log` page の SystemAdmin scope は常に 0 件だった
+ * (= 「監査ログがありません」 表示)。 本 handler が SBT EventBridge bus を listen し、
+ * onboarding* / offboarding* の 6 detailType を SYSTEM scope audit に書き戻す。
+ *
+ * actor:
+ *   SBT event の detail に Cognito identity が乗っていれば優先 (= `sub` / `cognitoUsername`)。
+ *   無ければ "sbt-control-plane" を識別子に置く (= 「SBT 経由の自動 / 不明 actor」 として
+ *   区別可能)。
+ *
+ * fail-safe:
+ *   writeAuditEvent は env 未配線で no-op、 書込失敗で false を返す。 lambda が error を
+ *   throw すると EventBridge が再 deliver を試みるため、 catch して swallow (= audit 行 1 件
+ *   欠落より event bus の retry storm を避ける)。
+ */
+
+interface SbtTenantEventDetail {
+  readonly tenantId?: string;
+  readonly tenantName?: string;
+  readonly tier?: string;
+  /** SBT が actor を載せている場合の path 候補。 環境次第で位置が違うので複数 fallback。 */
+  readonly sub?: string;
+  readonly cognitoUsername?: string;
+  readonly username?: string;
+  readonly actor?: string;
+}
+
+const SBT_DETAIL_TYPE_TO_ACTION: Readonly<Record<string, { action: string; outcome: string }>> = {
+  onboardingRequest: { action: "tenant_create_requested", outcome: "success" },
+  onboardingSuccess: { action: "tenant_create_succeeded", outcome: "success" },
+  onboardingFailure: { action: "tenant_create_failed", outcome: "error" },
+  offboardingRequest: { action: "tenant_delete_requested", outcome: "success" },
+  offboardingSuccess: { action: "tenant_delete_succeeded", outcome: "success" },
+  offboardingFailure: { action: "tenant_delete_failed", outcome: "error" },
+};
+
+export type SbtTenantEventDetailType = keyof typeof SBT_DETAIL_TYPE_TO_ACTION;
+
+const FALLBACK_ACTOR = "sbt-control-plane";
+
+export function resolveActor(detail: SbtTenantEventDetail): {
+  actor: string;
+  actorUsername?: string;
+} {
+  const actor = detail.sub ?? detail.actor ?? FALLBACK_ACTOR;
+  const actorUsername = detail.cognitoUsername ?? detail.username;
+  return actorUsername ? { actor, actorUsername } : { actor };
+}
+
+export function mapEventToAudit(event: EventBridgeEvent<string, SbtTenantEventDetail>): {
+  tenantId: string;
+  action: string;
+  outcome: "success" | "error";
+  target: string | undefined;
+  actor: string;
+  actorUsername: string | undefined;
+  occurredAtMs: number;
+  extra: Record<string, string>;
+} | null {
+  const mapping = SBT_DETAIL_TYPE_TO_ACTION[event["detail-type"]];
+  if (!mapping) return null;
+  const { actor, actorUsername } = resolveActor(event.detail);
+  const occurredAtMs = event.time ? new Date(event.time).getTime() : Date.now();
+  const extra: Record<string, string> = {};
+  if (event.detail.tier) extra.tier = event.detail.tier;
+  if (event.detail.tenantName) extra.tenantName = event.detail.tenantName;
+  return {
+    tenantId: "SYSTEM",
+    action: mapping.action,
+    outcome: mapping.outcome === "error" ? "error" : "success",
+    target: event.detail.tenantId,
+    actor,
+    actorUsername,
+    occurredAtMs,
+    extra,
+  };
+}
+
+export async function handler(
+  event: EventBridgeEvent<string, SbtTenantEventDetail>,
+): Promise<void> {
+  const row = mapEventToAudit(event);
+  if (!row) {
+    console.warn("[system-audit-writer] unknown detail-type, skipping", {
+      detailType: event["detail-type"],
+    });
+    return;
+  }
+  try {
+    await writeAuditEvent({
+      tenantId: row.tenantId,
+      actor: row.actor,
+      ...(row.actorUsername ? { actorUsername: row.actorUsername } : {}),
+      action: row.action,
+      outcome: row.outcome,
+      ...(row.target ? { target: row.target } : {}),
+      occurredAtMs: row.occurredAtMs,
+      ...(Object.keys(row.extra).length > 0 ? { extra: row.extra } : {}),
+    });
+  } catch (err) {
+    // EventBridge retry storm を避けるため throw しない (= [[feedback-question-premise-before-patching]]
+    // の fail-safe pattern と同方針、 writeAuditEvent 自体も内部で fail-safe だが念のため二重防御)。
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[system-audit-writer] write failed (swallowed)", {
+      detailType: event["detail-type"],
+      message,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -32,6 +32,7 @@ import {
 } from "./participant-portal-hosting";
 import { ParticipantPortalLambda } from "./participant-portal-lambda";
 import { ProblemEndpointsTable } from "./problem-endpoints-table";
+import { SystemAuditWriterLambda } from "./system-audit-writer-lambda";
 import { TeamsTable } from "./teams-table";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
@@ -243,6 +244,17 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       : new EventBus(this, "LocalEventBus", {
           eventBusName: `tenkacloud-problem-deploy-local-${cdk.Stack.of(this).stackName}`,
         });
+
+    // Issue #1034: SBT Control Plane が発する onboarding* / offboarding* event を audit に集約。
+    // SystemAdmin の tenant CRUD は SBT 経由なので App Plane Lambda が走らず、 audit-log page の
+    // SystemAdmin scope が常に空になっていた。 本 listener が SBT bus 上の 6 detailType を catch して
+    // `PK=SYSTEM#<env>` 行を書く。 Lite mode (= ControlPlane 不在) では local bus にぶら下がるが、
+    // SBT events も流れて来ない (= 副作用なし) ため idle で安全。
+    new SystemAuditWriterLambda(this, "SystemAuditWriter", {
+      eventBus,
+      adminAuditLogTable: adminAuditLog.table,
+      environmentName: props.environmentName,
+    });
 
     // tenant API から invoke される Lambda。validation + DDB Put + EventBridge PutEvents のみ。
     // Phase 2.2 (Issue #459): CompetitorAccounts table + env を渡して verified-only gate を有効化。

--- a/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
+++ b/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
@@ -1,0 +1,85 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { Table } from "aws-cdk-lib/aws-dynamodb";
+import { type IEventBus, Rule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime";
+
+export interface SystemAuditWriterLambdaProps {
+  /** SBT ControlPlane が払い出す共通 EventBus。 */
+  readonly eventBus: IEventBus;
+  /** ADR-020 Phase D の admin audit log table (= `PK=SYSTEM#<env>` で行を書く)。 */
+  readonly adminAuditLogTable: Table;
+  /** `SYSTEM#<env>` の env suffix (= writeAuditEvent が `DEPLOY_ENVIRONMENT` を読む)。 */
+  readonly environmentName: string;
+}
+
+/**
+ * Issue #1034: SBT Control Plane の tenant onboarding / offboarding イベントを listen し、
+ * `AdminAuditLog` table の SYSTEM 区画 (= `PK=SYSTEM#<env>`) に行を書き戻す Lambda + Rule。
+ *
+ * 旧状態: SystemAdmin の tenant CRUD は SBT 経由なので App Plane Lambda は走らず、 audit-log
+ * page の SystemAdmin scope は常に 0 件だった。 本 construct が SBT EventBridge bus を listen
+ * し、 onboardingRequest / onboardingSuccess / onboardingFailure / offboarding* の 6 detailType
+ * を SYSTEM scope audit に集約する (= 「誰がいつ tenant を作成 / 削除した」 が UI で読める)。
+ *
+ * fail-safe: Lambda が throw すると EventBridge は最大 24h 再 deliver を試みる。 audit 1 行
+ * 欠落 < retry storm のコストなので handler は catch して swallow する (= writeAuditEvent も
+ * 内部で fail-safe)。
+ */
+export class SystemAuditWriterLambda extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly rule: Rule;
+
+  constructor(scope: Construct, id: string, props: SystemAuditWriterLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(__dirname, "handlers/system-audit-writer/index.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(10),
+      memorySize: 256,
+      environment: {
+        ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: LAMBDA_NODEJS_BUNDLING_TARGET,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
+        externalModules: [],
+      },
+    });
+
+    props.adminAuditLogTable.grantWriteData(this.fn);
+
+    // SBT `DetailType` enum (= event-manager.d.ts) のうち audit に意味があるものを listen。
+    // user / api-key 系の SBT events は別 issue で扱う (本 issue は tenant CRUD に絞る)。
+    this.rule = new Rule(this, "Rule", {
+      eventBus: props.eventBus,
+      description:
+        "Route SBT tenant onboarding/offboarding events to SystemAuditWriter Lambda (Issue #1034)",
+      eventPattern: {
+        detailType: [
+          "onboardingRequest",
+          "onboardingSuccess",
+          "onboardingFailure",
+          "offboardingRequest",
+          "offboardingSuccess",
+          "offboardingFailure",
+        ],
+      },
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -248,13 +248,14 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(deleteStateMachine).toContain("MarkFailed");
     });
 
-    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule で 5 つ持つべき (Issue #910 Phase 2.C.2.a)", () => {
+    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) で 6 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + BulkCreate (Issue #910 Phase 2.C: BulkDeployCreateRequested → Distributed Map)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)
       //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
       // = 5。GenericScoring は scoring 問題が無い tenant でも reconcile 用に常時 instantiate される。
-      tpl.resourceCountIs("AWS::Events::Rule", 5);
+      // 旧 5 + Issue #1034 SystemAuditWriter rule (= SBT onboarding/offboarding listener)
+      tpl.resourceCountIs("AWS::Events::Rule", 6);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -323,6 +324,43 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
     it("ADR-012 Phase 3.A: ProblemEndpointsTableName を Output として持つべき", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["ProblemEndpointsTableName"]));
+    });
+  });
+
+  describe("Issue #1034: SystemAuditWriter Lambda + EventBridge Rule", () => {
+    it("SBT onboarding/offboarding の 6 detailType を listen する EventBridge Rule を持つべき", () => {
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          EventPattern: Match.objectLike({
+            "detail-type": Match.arrayWith([
+              "onboardingRequest",
+              "onboardingSuccess",
+              "onboardingFailure",
+              "offboardingRequest",
+              "offboardingSuccess",
+              "offboardingFailure",
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("SystemAuditWriter Lambda は DEPLOY_ENVIRONMENT + ADMIN_AUDIT_LOG_TABLE_NAME env を持つべき", () => {
+      // env が無いと writeAuditEvent が no-op になり、 audit が書かれない silent failure に戻る。
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs22.x",
+          Architectures: ["arm64"],
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              ADMIN_AUDIT_LOG_TABLE_NAME: Match.anyValue(),
+              DEPLOY_ENVIRONMENT: "development",
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/infrastructure/test/problem-deploy/system-audit-writer.test.ts
+++ b/infrastructure/test/problem-deploy/system-audit-writer.test.ts
@@ -1,0 +1,112 @@
+import type { EventBridgeEvent } from "aws-lambda";
+import { describe, expect, it } from "vitest";
+import {
+  mapEventToAudit,
+  resolveActor,
+  type SbtTenantEventDetailType,
+} from "../../lib/problem-deploy/handlers/system-audit-writer";
+
+/**
+ * Issue #1034: SBT tenant onboarding/offboarding event → audit row 変換の pure logic を pin する。
+ * Lambda 全体は IAM / EventBridge Rule との配線が要るので CDK test 側で synth assertion する。
+ */
+function buildEvent(
+  detailType: SbtTenantEventDetailType,
+  detail: Record<string, unknown> = {},
+  time = "2026-05-19T09:00:00.000Z",
+): EventBridgeEvent<string, Record<string, unknown>> {
+  return {
+    version: "0",
+    id: "evt-1",
+    "detail-type": detailType,
+    source: "sbt-control-plane-api",
+    account: "123456789012",
+    time,
+    region: "ap-northeast-1",
+    resources: [],
+    detail,
+  };
+}
+
+describe("system-audit-writer (Issue #1034)", () => {
+  describe("mapEventToAudit", () => {
+    it("onboardingRequest を tenant_create_requested + success として SYSTEM scope に書くべき", () => {
+      const event = buildEvent("onboardingRequest", { tenantId: "t-01", tier: "STANDARD" });
+      const row = mapEventToAudit(event);
+      expect(row).not.toBeNull();
+      expect(row?.tenantId).toBe("SYSTEM");
+      expect(row?.action).toBe("tenant_create_requested");
+      expect(row?.outcome).toBe("success");
+      expect(row?.target).toBe("t-01");
+      expect(row?.extra.tier).toBe("STANDARD");
+    });
+
+    it("onboardingFailure は outcome=error に倒すべき", () => {
+      const row = mapEventToAudit(buildEvent("onboardingFailure", { tenantId: "t-02" }));
+      expect(row?.outcome).toBe("error");
+      expect(row?.action).toBe("tenant_create_failed");
+    });
+
+    it("offboardingRequest は tenant_delete_requested を返すべき", () => {
+      const row = mapEventToAudit(buildEvent("offboardingRequest", { tenantId: "t-03" }));
+      expect(row?.action).toBe("tenant_delete_requested");
+      expect(row?.outcome).toBe("success");
+    });
+
+    it("offboardingSuccess は tenant_delete_succeeded を返すべき", () => {
+      const row = mapEventToAudit(buildEvent("offboardingSuccess", { tenantId: "t-03" }));
+      expect(row?.action).toBe("tenant_delete_succeeded");
+    });
+
+    it("offboardingFailure は outcome=error に倒すべき", () => {
+      const row = mapEventToAudit(buildEvent("offboardingFailure", { tenantId: "t-03" }));
+      expect(row?.outcome).toBe("error");
+      expect(row?.action).toBe("tenant_delete_failed");
+    });
+
+    it("未知の detail-type は null を返して skip すべき", () => {
+      const row = mapEventToAudit(
+        buildEvent("unknownEvent" as SbtTenantEventDetailType, { tenantId: "t-x" }),
+      );
+      expect(row).toBeNull();
+    });
+
+    it("event.time から occurredAtMs を抽出すべき (= EventBridge が記録した実発生時刻を保持)", () => {
+      const row = mapEventToAudit(
+        buildEvent("onboardingSuccess", { tenantId: "t-04" }, "2026-04-01T12:34:56.000Z"),
+      );
+      expect(row?.occurredAtMs).toBe(new Date("2026-04-01T12:34:56.000Z").getTime());
+    });
+
+    it("tenantName / tier がある時は extra に含めるべき", () => {
+      const row = mapEventToAudit(
+        buildEvent("onboardingSuccess", { tenantId: "t-05", tenantName: "Acme", tier: "PLATINUM" }),
+      );
+      expect(row?.extra).toEqual({ tenantName: "Acme", tier: "PLATINUM" });
+    });
+  });
+
+  describe("resolveActor", () => {
+    it("detail.sub があれば優先すべき (= Cognito 安定識別子)", () => {
+      expect(resolveActor({ sub: "cog-sub-1", cognitoUsername: "alice@example" })).toEqual({
+        actor: "cog-sub-1",
+        actorUsername: "alice@example",
+      });
+    });
+
+    it("detail.sub が無ければ actor field を見るべき", () => {
+      expect(resolveActor({ actor: "fallback-actor" })).toEqual({ actor: "fallback-actor" });
+    });
+
+    it("いずれも無ければ sbt-control-plane を fallback とすべき", () => {
+      expect(resolveActor({})).toEqual({ actor: "sbt-control-plane" });
+    });
+
+    it("cognitoUsername と username の両方があれば cognitoUsername を優先すべき", () => {
+      expect(resolveActor({ sub: "s", cognitoUsername: "a", username: "b" })).toEqual({
+        actor: "s",
+        actorUsername: "a",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 新規 `infrastructure/lib/problem-deploy/handlers/system-audit-writer/index.ts` (= pure mapping + fail-safe handler、 11 unit test ケースで pin)
- 新規 `infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts` (= Lambda + EventBridge Rule construct)
- `ProblemDeployBackendStack` で instantiate して SBT EventBridge bus 上の onboarding* / offboarding* 6 detailType を listen
- handler は `writeAuditEvent({ tenantId: "SYSTEM", ... })` で `PK=SYSTEM#<env>` 行を書く

Closes #1034

## Root cause (= issue 仮説 1 が確定)

`AdminAuditLog` table の SYSTEM 区画 (= `PK=SYSTEM#<env>`) には **writer が存在しなかった**。 SystemAdmin による tenant CRUD は SBT Control Plane Lambda 経由なので、 App Plane の `writeAuditEvent` (= competitor-accounts / deploy / event handler 配下) は走らない。 結果、 admin-console の audit-log page で scope=SystemAdmin を選んでも 「監査ログがありません」 が表示されていた。

仮説 2 / 3 / 4 は調査済 (= 否定):
- (2) table empty は (1) の結果
- (3) PK prefix は read / write 両側で `SYSTEM#<env>` で一致 (`audit.ts:73` + `audit-log.ts:88`)
- (4) `ADMIN_AUDIT_LOG_TABLE_NAME` env は admin-insight / 3 App Plane Lambda すべてに wire 済

## 実装の選択

| 案 | 採否 | 理由 |
|---|---|---|
| EventBridge listener Lambda (本 PR) | ✅ | SBT が emit する `onboardingRequest` etc. を passive に catch するだけで SBT 内部に touch しない。 既存 `DeployEventRule` / `ExternalIdAuditLambda` と同 pattern |
| SBT Control Plane Lambda を fork して writeAuditEvent を埋める | ❌ | SBT version up に追随しづらい、 vendored copy で divergence リスク |
| TenantMappingTable を schedule scan で diff | ❌ | actor 情報 (= 誰がやった) が一切残らない |

## actor 識別

SBT event detail に Cognito identity (`sub` / `cognitoUsername`) があれば優先、 無ければ `"sbt-control-plane"` fallback (= 「SBT 経由で actor 不明」 として明示的に区別)。 SBT の `OnboardingService` が将来 actor を event payload に乗せれば自動で正しい値が入る (= handler 側 forward-compatible)。

## Regression 分析

- **Lite mode (= eventBusArn=undefined)**: local EventBus にぶら下がるが、 SBT events もそこに流れないため idle (= 副作用なし)
- **SaaS mode**: SBT が既に publish する event を catch するだけ。 SBT 側変更ゼロ
- **既存 `DeployEventRule` / `ExternalIdAudit` rule**: 不変。 新 rule が追加されただけ
- **`AdminAuditLog` table の既存 tenant scope 行**: 不変。 新 row は `PK=SYSTEM#<env>`、 既存 `PK=TENANT#<tenantId>` 行と区画が分離
- **EventBridge retry**: handler は throw しない (= fail-safe、 24h retry storm を防ぐ)。 失敗時は `console.error` のみ
- **既存 audit-log page の tenant scope**: 完全に不変。 SystemAdmin scope のみ初めて行が表示される
- **既存 `EventBusWatcherRule` (`control-plane-stack.ts:125`)**: 同 bus 上の別 rule、 互いに独立して fire
- **SBT version up**: 6 detailType は SBT public API として stable (= `DetailType` enum で公開)。 future-proof

## 物理影響

| Resource | Change |
|---|---|
| `AWS::Lambda::Function` (SystemAuditWriter) | CREATE |
| `AWS::IAM::Role` + Policy (Lambda execution role) | CREATE (DDB PutItem on AdminAuditLog + CloudWatch Logs のみ) |
| `AWS::Events::Rule` (新規 listener) | CREATE (event count 5 → 6) |
| `AWS::Lambda::Permission` (EventBridge invoke) | CREATE |
| `AWS::CloudWatch::LogGroup` (Lambda) | CREATE (= NodejsFunction default) |
| `AWS::DynamoDB::Table` (AdminAuditLog) | NO-OP (= 既存 table 共有) |
| 他 stack | 0 件 (= NO-OP) |

## Test plan

- [x] `infrastructure/test/problem-deploy/system-audit-writer.test.ts` (11 ケース、 pure mapping logic を pin)
- [x] `infrastructure/test/problem-deploy-backend-stack.test.ts` (= 6 detailType event pattern + env 配線、 rule count 6)
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / 1248 vitest cases / cdk synth)
- [ ] **deploy 後の手動確認** (= user): admin-console から SystemAdmin として tenant 作成 / 削除 → audit-log page > SystemAdmin scope で `tenant_create_requested` / `tenant_create_succeeded` / `tenant_delete_requested` / `tenant_delete_succeeded` 行が表示されること
- [ ] **deploy 後の手動確認** (= user): `aws dynamodb query --table-name <AdminAuditLog> --key-condition-expression "PK = :pk" --expression-attribute-values '{":pk":{"S":"SYSTEM#development"}}'` で行が読めること
- [ ] **deploy 後の手動確認** (= user): actor 列 — SBT が sub を流していれば Cognito sub、 そうでなければ `"sbt-control-plane"` が表示されること

## スコープ外

- SystemAdmin 以外の SBT detailType (= user / api-key 系) の audit → 別 issue
- audit log の TTL / 保持期間変更 → ADR-020 の別 phase
- actor 詳細化のための SBT Control Plane Lambda fork → 必要に応じて別 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)