### PR TITLE
fix(#1029): CodeBuild FAILED event を AdminAuditLog に記録 (silent failure 観測)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/system-audit-writer/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/system-audit-writer/index.ts
@@ -45,6 +45,14 @@ export type SbtTenantEventDetailType = keyof typeof SBT_DETAIL_TYPE_TO_ACTION;
 
 const FALLBACK_ACTOR = "sbt-control-plane";
 
+/**
+ * Issue #1029: CodeBuild の Build State Change event (= AWS default bus 経由) を別 actor で
+ * 区別する。 SBT pipeline の Step Functions が CodeBuild FAILED を SUCCEEDED で報告する
+ * silent failure に対する観測性 fix として、 FAILED build を audit log に記録する。
+ */
+const CODEBUILD_DETAIL_TYPE = "CodeBuild Build State Change";
+const CODEBUILD_ACTOR = "codebuild";
+
 export function resolveActor(detail: SbtTenantEventDetail): {
   actor: string;
   actorUsername?: string;
@@ -54,28 +62,44 @@ export function resolveActor(detail: SbtTenantEventDetail): {
   return actorUsername ? { actor, actorUsername } : { actor };
 }
 
-export function mapEventToAudit(event: EventBridgeEvent<string, SbtTenantEventDetail>): {
-  tenantId: string;
-  action: string;
-  outcome: "success" | "error";
-  target: string | undefined;
-  actor: string;
-  actorUsername: string | undefined;
-  occurredAtMs: number;
-  extra: Record<string, string>;
-} | null {
+interface CodeBuildStateChangeDetail {
+  readonly "build-status"?: string;
+  readonly "project-name"?: string;
+  readonly "build-id"?: string;
+  readonly region?: string;
+}
+
+export interface MappedAuditRow {
+  readonly tenantId: string;
+  readonly action: string;
+  readonly outcome: "success" | "error";
+  readonly target: string | undefined;
+  readonly actor: string;
+  readonly actorUsername: string | undefined;
+  readonly occurredAtMs: number;
+  readonly extra: Record<string, string>;
+}
+
+export function mapEventToAudit(
+  event: EventBridgeEvent<string, SbtTenantEventDetail | CodeBuildStateChangeDetail>,
+): MappedAuditRow | null {
+  // Issue #1029: CodeBuild Build State Change で build-status=FAILED のものを audit に記録する。
+  if (event["detail-type"] === CODEBUILD_DETAIL_TYPE) {
+    return mapCodeBuildEvent(event as EventBridgeEvent<string, CodeBuildStateChangeDetail>);
+  }
+  const tenantDetail = event.detail as SbtTenantEventDetail;
   const mapping = SBT_DETAIL_TYPE_TO_ACTION[event["detail-type"]];
   if (!mapping) return null;
-  const { actor, actorUsername } = resolveActor(event.detail);
+  const { actor, actorUsername } = resolveActor(tenantDetail);
   const occurredAtMs = event.time ? new Date(event.time).getTime() : Date.now();
   const extra: Record<string, string> = {};
-  if (event.detail.tier) extra.tier = event.detail.tier;
-  if (event.detail.tenantName) extra.tenantName = event.detail.tenantName;
+  if (tenantDetail.tier) extra.tier = tenantDetail.tier;
+  if (tenantDetail.tenantName) extra.tenantName = tenantDetail.tenantName;
   return {
     tenantId: "SYSTEM",
     action: mapping.action,
     outcome: mapping.outcome === "error" ? "error" : "success",
-    target: event.detail.tenantId,
+    target: tenantDetail.tenantId,
     actor,
     actorUsername,
     occurredAtMs,
@@ -83,12 +107,41 @@ export function mapEventToAudit(event: EventBridgeEvent<string, SbtTenantEventDe
   };
 }
 
+/**
+ * Issue #1029: CodeBuild Build State Change event の FAILED / FAULT / STOPPED / TIMED_OUT を
+ * audit に書く。 SUCCEEDED は noise が多いので skip (= 1 deploy で 1 件出ても観測価値が薄い)。
+ * SBT pipeline + 本 stack の DeployCodeBuild の両 project が catch される (= 副次的に問題 deploy
+ * の失敗も audit に上がる、 silent failure の網羅性が上がる)。
+ */
+function mapCodeBuildEvent(
+  event: EventBridgeEvent<string, CodeBuildStateChangeDetail>,
+): MappedAuditRow | null {
+  const buildStatus = event.detail["build-status"];
+  if (!buildStatus || buildStatus === "SUCCEEDED" || buildStatus === "IN_PROGRESS") {
+    return null;
+  }
+  const occurredAtMs = event.time ? new Date(event.time).getTime() : Date.now();
+  const extra: Record<string, string> = { buildStatus };
+  if (event.detail["build-id"]) extra.buildId = event.detail["build-id"];
+  if (event.detail.region) extra.region = event.detail.region;
+  return {
+    tenantId: "SYSTEM",
+    action: "codebuild_failed",
+    outcome: "error",
+    target: event.detail["project-name"],
+    actor: CODEBUILD_ACTOR,
+    actorUsername: undefined,
+    occurredAtMs,
+    extra,
+  };
+}
+
 export async function handler(
-  event: EventBridgeEvent<string, SbtTenantEventDetail>,
+  event: EventBridgeEvent<string, SbtTenantEventDetail | CodeBuildStateChangeDetail>,
 ): Promise<void> {
   const row = mapEventToAudit(event);
   if (!row) {
-    console.warn("[system-audit-writer] unknown detail-type, skipping", {
+    console.warn("[system-audit-writer] unknown / non-audit-worthy event, skipping", {
       detailType: event["detail-type"],
     });
     return;

--- a/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
+++ b/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
@@ -37,6 +37,12 @@ export interface SystemAuditWriterLambdaProps {
 export class SystemAuditWriterLambda extends Construct {
   public readonly fn: NodejsFunction;
   public readonly rule: Rule;
+  /**
+   * Issue #1029: CodeBuild Build State Change event (= aws.codebuild source) を listen する
+   * 別 rule。 default event bus にぶら下がるため `rule` (SBT bus) とは分離した EventBridge
+   * Rule 構築になる。
+   */
+  public readonly codeBuildFailureRule: Rule;
 
   constructor(scope: Construct, id: string, props: SystemAuditWriterLambdaProps) {
     super(scope, id);
@@ -78,6 +84,25 @@ export class SystemAuditWriterLambda extends Construct {
           "offboardingSuccess",
           "offboardingFailure",
         ],
+      },
+      targets: [new LambdaFunction(this.fn)],
+    });
+
+    // Issue #1029: CodeBuild Build State Change event は AWS service event なので **default
+    // event bus** に流れる (= SBT bus とは別 bus)。 SBT pipeline の Step Functions が CodeBuild
+    // FAILED を SUCCEEDED と取り違える silent failure に対する observability fix として、 build-status
+    // が SUCCEEDED 以外 (= FAILED / FAULT / STOPPED / TIMED_OUT 等) の event を audit に書く。
+    // project-name filter は意図的に外して account 全域を catch (= SBT が自動採番する project
+    // 名 prefix が version で変わるリスク回避、 不要 noise は handler 側 outcome=error で識別可)。
+    this.codeBuildFailureRule = new Rule(this, "CodeBuildFailureRule", {
+      description:
+        "Route CodeBuild FAILED / FAULT / STOPPED / TIMED_OUT events to SystemAuditWriter Lambda (Issue #1029)",
+      eventPattern: {
+        source: ["aws.codebuild"],
+        detailType: ["CodeBuild Build State Change"],
+        detail: {
+          "build-status": ["FAILED", "FAULT", "STOPPED", "TIMED_OUT"],
+        },
       },
       targets: [new LambdaFunction(this.fn)],
     });

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -248,14 +248,14 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(deleteStateMachine).toContain("MarkFailed");
     });
 
-    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) で 6 つ持つべき", () => {
+    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) / CodeBuildFailure (Issue #1029) で 7 つ持つべき", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + BulkCreate (Issue #910 Phase 2.C: BulkDeployCreateRequested → Distributed Map)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)
       //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
       // = 5。GenericScoring は scoring 問題が無い tenant でも reconcile 用に常時 instantiate される。
-      // 旧 5 + Issue #1034 SystemAuditWriter rule (= SBT onboarding/offboarding listener)
-      tpl.resourceCountIs("AWS::Events::Rule", 6);
+      // 旧 5 + Issue #1034 SystemAuditWriter (SBT bus) + Issue #1029 CodeBuildFailure (default bus)
+      tpl.resourceCountIs("AWS::Events::Rule", 7);
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -385,6 +385,21 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
             Variables: Match.objectLike({
               ADMIN_AUDIT_LOG_TABLE_NAME: Match.anyValue(),
               DEPLOY_ENVIRONMENT: "development",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("Issue #1029: CodeBuild FAILED / FAULT / STOPPED / TIMED_OUT event を catch する Rule を持つべき", () => {
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({
+          EventPattern: Match.objectLike({
+            source: ["aws.codebuild"],
+            "detail-type": ["CodeBuild Build State Change"],
+            detail: Match.objectLike({
+              "build-status": Match.arrayWith(["FAILED", "FAULT", "STOPPED", "TIMED_OUT"]),
             }),
           }),
         }),

--- a/infrastructure/test/problem-deploy/system-audit-writer.test.ts
+++ b/infrastructure/test/problem-deploy/system-audit-writer.test.ts
@@ -86,6 +86,63 @@ describe("system-audit-writer (Issue #1034)", () => {
     });
   });
 
+  describe("CodeBuild Build State Change (Issue #1029)", () => {
+    function buildCodeBuildEvent(
+      buildStatus: string,
+      projectName = "tenkacloud-development-deploy-codebuild",
+    ) {
+      return {
+        version: "0",
+        id: "evt-cb-1",
+        "detail-type": "CodeBuild Build State Change",
+        source: "aws.codebuild",
+        account: "123456789012",
+        time: "2026-05-19T10:00:00.000Z",
+        region: "ap-northeast-1",
+        resources: [],
+        detail: {
+          "build-status": buildStatus,
+          "project-name": projectName,
+          "build-id": `arn:aws:codebuild:ap-northeast-1:123456789012:build/${projectName}:abc`,
+          region: "ap-northeast-1",
+        },
+      } as const;
+    }
+
+    it("FAILED build は codebuild_failed + outcome=error として SYSTEM scope に書くべき", () => {
+      const row = mapEventToAudit(buildCodeBuildEvent("FAILED"));
+      expect(row).not.toBeNull();
+      expect(row?.tenantId).toBe("SYSTEM");
+      expect(row?.action).toBe("codebuild_failed");
+      expect(row?.outcome).toBe("error");
+      expect(row?.target).toBe("tenkacloud-development-deploy-codebuild");
+      expect(row?.actor).toBe("codebuild");
+      expect(row?.extra.buildStatus).toBe("FAILED");
+    });
+
+    it("FAULT / STOPPED / TIMED_OUT も audit に書くべき (= silent failure 網羅)", () => {
+      for (const status of ["FAULT", "STOPPED", "TIMED_OUT"]) {
+        const row = mapEventToAudit(buildCodeBuildEvent(status));
+        expect(row).not.toBeNull();
+        expect(row?.outcome).toBe("error");
+        expect(row?.extra.buildStatus).toBe(status);
+      }
+    });
+
+    it("SUCCEEDED build は audit に書かないべき (= noise 抑制、 silent failure の対象外)", () => {
+      expect(mapEventToAudit(buildCodeBuildEvent("SUCCEEDED"))).toBeNull();
+    });
+
+    it("IN_PROGRESS build も audit に書かないべき (= mid-flight 状態)", () => {
+      expect(mapEventToAudit(buildCodeBuildEvent("IN_PROGRESS"))).toBeNull();
+    });
+
+    it("build-id があれば extra.buildId に保存すべき (= CloudWatch Logs deep link 用)", () => {
+      const row = mapEventToAudit(buildCodeBuildEvent("FAILED"));
+      expect(row?.extra.buildId).toMatch(/build\//);
+    });
+  });
+
   describe("resolveActor", () => {
     it("detail.sub があれば優先すべき (= Cognito 安定識別子)", () => {
       expect(resolveActor({ sub: "cog-sub-1", cognitoUsername: "alice@example" })).toEqual({


### PR DESCRIPTION
## Summary

- 既存 `SystemAuditWriterLambda` (Issue #1034) に CodeBuild Build State Change event の rule を追加
- FAILED / FAULT / STOPPED / TIMED_OUT を `action="codebuild_failed"` の audit 行 (`PK=SYSTEM#<env>`) として記録
- admin-console > audit-log page の SystemAdmin scope でそのまま観測可能 (= 別 UI 不要)
- SBT pipeline CodeBuild + 本 stack DeployCodeBuild の両方を catch する (= silent failure 網羅性 ↑)

Closes #1029

## なぜ alarm ではなく AdminAuditLog 統合か

Issue 本文の修正候補 (3) は CloudWatch alarm。 候補 (1) (2) は SBT 0.3.9 の API 制約で困難 (= BashJobRunner / state machine の Catch policy 上書きは vendoring が必要)。 (3) を採用しつつ、 SNS topic / 別 dashboard を増やさず **既に operator が見る AdminAuditLog page** に統合した:

- 単一 observability surface に集約 (= 「監査ログがありません」 → 「codebuild_failed 行が並ぶ」 で即発見)
- Issue #1034 で landed した SystemAuditWriterLambda を流用 (= 新 Lambda 不要、 1 file の handler 拡張で済む)
- audit 行は TTL 90 日で自動 GC (= alarm より storage friendly)

## 物理影響

| Resource | Change |
|---|---|
| `AWS::Events::Rule` (CodeBuildFailureRule, default bus) | CREATE |
| `AWS::Lambda::Permission` (EventBridge invoke) | CREATE |
| 既存 `SystemAuditWriterLambda` | UPDATE (= handler extended、 同 NodejsFunction を bundling) |
| 他 stack / IAM / DDB / SBT 内部 | 0 件 (= NO-OP) |

## Regression 分析

- **既存 SBT tenant audit (Issue #1034)**: 完全不変。 SBT bus 上の rule は touch せず、 default bus に別 rule を追加するだけ
- **CodeBuild SUCCEEDED event**: 明示的に skip (= `mapCodeBuildEvent` で SUCCEEDED / IN_PROGRESS を null return)。 audit に SUCCEEDED が並ばないので noise なし
- **handler の throw 経路**: 既存通り swallow (= EventBridge 24h retry storm 回避)
- **EventBridge cross-bus**: default bus と SBT bus は独立 → 各 rule は別 bus にぶら下がるが、 target Lambda は同じ → 単一 Lambda invocation で audit 行 1 件
- **account 全域 CodeBuild noise**: project-name filter は外したが、 SUCCEEDED filter で日常 build はほぼ skip。 別 project の本気失敗のみが audit に上がる (= operator にとって有用情報)
- **deploy job 失敗 (DeployCodeBuild)**: 副次的に audit に上がる → operator が「deploy が失敗した」 を audit-log page で気付ける (= 別 issue 観測点としても有用)

## Test plan

- [x] `infrastructure/test/problem-deploy/system-audit-writer.test.ts` (= +5 ケース、 計 16 ケース green)
- [x] `infrastructure/test/problem-deploy-backend-stack.test.ts` (= rule count 7、 event pattern pin)
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / 1255+ vitest cases / cdk synth)
- [ ] **deploy 後の手動確認** (= user): SBT tenant pipeline が CodeBuild FAILED を吸って ExecutionSucceeded で締めるシナリオを再現 (= 並列 race 等) → admin-console audit-log SystemAdmin scope に `codebuild_failed` 行が表示されること

## スコープ外

- 根本原因 (= SBT state machine の Catch policy) の修正 → 別 issue (SBT vendoring / upstream PR)
- CloudWatch dashboard 追加 → 別 issue (本 PR で AdminAuditLog 経路に統合済なので不要かもしれない)
- 採点系 (problem deploy) の Step Functions silent failure → 別 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded system audit to capture CodeBuild build failures (failed, fault, stopped, timed out states).
  * Added EventBridge rule to automatically route CodeBuild Build State Change events to audit system.
  * Successful builds and in-progress states excluded from audit logs for clarity.

* **Tests**
  * Added comprehensive test coverage for CodeBuild audit event mapping and filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->