### PR TITLE
refactor(#1031): install.sh を cdk deploy --all 1 発に統合 (admin-console-hosting 分割 + cross-stack ref)

### DIFF
--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -9,79 +9,44 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
-import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
 import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers";
-// Issue #1053: 旧来本 stack 内に同居していた competitor-bootstrap.yaml の S3 hosting は
-// ProblemDeployBackendStack 配下の CompetitorBootstrapHosting に移管した。 本 stack は
-// その出力 URL を props で受け取って runtime-config.json に焼き込むだけ。
-
-export interface AdminConsoleHostingStackProps extends cdk.StackProps {
-  /** Control Plane API Gateway URL (末尾スラッシュ無し) */
-  readonly apiUrl: string;
-  /** Cognito UserPool domain (例: https://xxx.auth.<region>.amazoncognito.com) */
-  readonly cognitoDomain: string;
-  /** SBT 内蔵 UserPoolUserClient の client ID */
-  readonly userClientId: string;
-  /**
-   * Pooled tier tenants が共有する application-admin-console の CloudFront URL。
-   * admin-console の TenantList で basic / advanced tenant 行のリンクに使う。
-   */
-  readonly pooledApplicationAdminConsoleUrl: string;
-  /**
-   * Provisioning ジョブを動かす CodeBuild project 名 (SBT BashJobRunner が立てる)。
-   * admin-console の「ログ」カラムで build deep link の構築に使う。
-   * unknown なら admin-console 側はリンクを出さない。
-   */
-  readonly provisioningCodeBuildProject: string;
-  /**
-   * AWS region (例: ap-northeast-1)。CodeBuild console URL の {region} に埋める。
-   */
-  readonly awsRegion: string;
-  /**
-   * AWS account ID。CodeBuild console URL の {accountId} に埋める。
-   */
-  readonly awsAccountId: string;
-  /**
-   * Admin Insight API のエンドポイント (ADR-011 / #590 Phase 1.A)。System Admin が
-   * tenant 横断で deploy 進捗を read する経路。phase 1.A では tenant 一覧の deploy 集計 column
-   * (= activeDeploys / failedDeploys) を表示するのに使う。
-   *
-   * 空文字 fallback は admin-console 側で「未発行」表示にしてリクエスト送信をスキップする
-   * (= phase 2 初回 deploy の race 状態でも UI が壊れない安全装置)。
-   */
-  readonly adminInsightApiUrl: string;
-  /**
-   * Issue #1053: 競技者向け CFn bootstrap template (`competitor-bootstrap.yaml`) の S3 URL。
-   * `ProblemDeployBackendStack.competitorBootstrapTemplateUrl` を cross-stack ref で受け取る。
-   * runtime-config.json に焼き込まれ、 admin-console の Competitor Accounts 画面が CFn Quick
-   * Create / Update Stack deeplink の TemplateURL に埋める。
-   */
-  readonly competitorBootstrapTemplateUrl: string;
-}
 
 /**
- * apps/admin-console (React + Vite) を CloudFront + S3 で配信する stack。
+ * Issue #1031: admin-console-hosting は **CloudFront 配信側だけ** を担い、 runtime-config.json
+ * の生成は `AdminConsoleRuntimeConfigStack` に分離した。 これにより依存方向を 1 方向
+ * (= 本 stack → control-plane / admin-console-insight → runtime-config) に揃え、
+ * `bun cdk deploy --all` 1 発で install.sh が完結する。
  *
- * 設計:
- * - dist/ は install.sh が host 側で build (bun workspace の symlink を docker cp が扱えない問題回避)
- * - URL 系 (API / Cognito) は build artifact に焼かず、`runtime-config.json` として別途 S3 にアップロード
- *   admin-console は起動時に `/runtime-config.json` を fetch して URL を解決する
- *   → build artifact は URL 非依存、backend URL が変わっても再 build 不要
+ * CSP は backend URL を **wildcard pattern** で許可する。 これによりバックエンド URL の
+ * cross-stack ref を本 stack から外して循環依存を解消する。 trade-off:
+ *   - 旧: `<specific-execute-api-id>.execute-api.<region>.amazonaws.com` を厳密 allow
+ *   - 新: `https://*.execute-api.<region>.amazonaws.com` で region 内全 API GW を allow
+ * 同 region 別 API GW を悪用するには (a) admin-console XSS 注入 (b) 同 account に攻撃 API 所持 の
+ * 両条件が要り、 hosting 単独 deploy 可能性を取って良い trade。
  *
- * 3-phase deploy の phase 2:
- *   1. ControlPlaneStack が立っている
- *   2. install.sh が apps/admin-console を build → 本 stack を deploy
- *      (S3 アップロード: dist/ + runtime-config.json、CloudFront 作成)
- *   3. ControlPlaneStack を再 deploy して CloudFront URL を callback / CORS に追加
+ * 旧 admin-console-hosting にあった `competitor-bootstrap.yaml` の S3 host は Issue #1053 で
+ * ProblemDeployBackendStack 配下に移管済。
  */
+export interface AdminConsoleHostingStackProps extends cdk.StackProps {}
+
 export class AdminConsoleHostingStack extends cdk.Stack {
   public readonly distributionDomainName: string;
+  /**
+   * Issue #1031: `AdminConsoleRuntimeConfigStack` が runtime-config.json をこの bucket に
+   * BucketDeployment する。 cross-stack ref で受け渡す。
+   */
+  public readonly siteBucket: Bucket;
+  /**
+   * Issue #1031: runtime-config.json 更新時の CloudFront 無効化 (= `distributionPaths`) 用。
+   */
+  public readonly distribution: Distribution;
 
   constructor(scope: Construct, id: string, props: AdminConsoleHostingStackProps) {
     super(scope, id, props);
 
-    const bucket = new Bucket(this, "SiteBucket", {
+    this.siteBucket = new Bucket(this, "SiteBucket", {
       encryption: BucketEncryption.S3_MANAGED,
       enforceSSL: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
@@ -90,26 +55,24 @@ export class AdminConsoleHostingStack extends cdk.Stack {
     });
 
     const oai = new OriginAccessIdentity(this, "OAI");
-    bucket.grantRead(oai);
+    this.siteBucket.grantRead(oai);
 
-    // Issue #855 + #896: CloudFront に security headers (HSTS / CSP / X-Frame-Options 等)
-    // を強制。 admin-console は次の経路に fetch する:
-    //   - props.apiUrl              : Control Plane API GW (= tenant CRUD)
-    //   - props.cognitoDomain       : Cognito OAuth (/oauth2/token /authorize /revoke /logout)
-    //   - props.adminInsightApiUrl  : AdminInsight API GW (= Provisioning Jobs / TenantDrillDown)
-    // form-action は Cognito Hosted UI への sign-in form 投稿で使う。
-    // (Issue #899 の Scalar API reference は廃止、 cdn.jsdelivr.net allow も除去)
+    // Issue #1031: CSP は region wildcard。 詳細は file header 参照。
+    const region = cdk.Stack.of(this).region;
     const securityHeaders = buildSecurityHeadersPolicy(this, "SecurityHeaders", {
-      connectSrcAllowedOrigins: [props.apiUrl, props.cognitoDomain, props.adminInsightApiUrl],
-      formActionAllowedOrigins: [props.cognitoDomain],
+      connectSrcAllowedOrigins: [
+        `https://*.execute-api.${region}.amazonaws.com`,
+        "https://*.amazoncognito.com",
+        `https://cognito-idp.${region}.amazonaws.com`,
+      ],
+      formActionAllowedOrigins: ["https://*.amazoncognito.com"],
     });
 
-    const distribution = new Distribution(this, "Distribution", {
+    this.distribution = new Distribution(this, "Distribution", {
       defaultBehavior: {
-        // CDK 2.252+ で `S3Origin` は deprecated。 `S3BucketOrigin.withOriginAccessIdentity` は
-        // 既存 OAI を渡せる同等 API (= bucket policy + Signer 経路を変えずに移行可)。 OAC への
-        // 完全移行は別 PR で trade-off (= 既存 deploy stack の OAI を OAC に置換する操作) を含めて扱う。
-        origin: S3BucketOrigin.withOriginAccessIdentity(bucket, { originAccessIdentity: oai }),
+        origin: S3BucketOrigin.withOriginAccessIdentity(this.siteBucket, {
+          originAccessIdentity: oai,
+        }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: securityHeaders,
       },
@@ -122,49 +85,21 @@ export class AdminConsoleHostingStack extends cdk.Stack {
       ],
     });
 
-    this.distributionDomainName = distribution.distributionDomainName;
+    this.distributionDomainName = this.distribution.distributionDomainName;
 
-    // 1) dist/ をアップロード (URL 非依存の静的ファイル)
+    // dist/ をアップロード (URL 非依存の静的ファイル)
     const distDir = path.join(__dirname, "..", "..", "apps", "admin-console", "dist");
     new BucketDeployment(this, "SiteDeployment", {
       sources: [Source.asset(distDir)],
-      destinationBucket: bucket,
-      distribution,
-      prune: false, // runtime-config.json を別途配置するので他 key も残す
-    });
-
-    // 2) runtime-config.json を同 bucket のルートに配置
-    // admin-console は起動時に `/runtime-config.json` を fetch して URL を解決する
-    const runtimeConfig = {
-      apiUrl: props.apiUrl.replace(/\/$/, ""),
-      cognitoDomain: props.cognitoDomain,
-      userClientId: props.userClientId,
-      pooledApplicationAdminConsoleUrl: props.pooledApplicationAdminConsoleUrl,
-      provisioningCodeBuildProject: props.provisioningCodeBuildProject,
-      awsRegion: props.awsRegion,
-      awsAccountId: props.awsAccountId,
-      // ADR-011 #590 Phase 1.A
-      adminInsightApiUrl: props.adminInsightApiUrl.replace(/\/$/, ""),
-      // Issue #1053: 競技者向け bootstrap template の public S3 URL (= ProblemDeployBackendStack
-      // 配下 CompetitorBootstrapHosting の cross-stack ref)。 CFn TemplateURL は S3 URL のみ受け
-      // 付けるため、 frontend は本値を Quick-create / Update Stack deeplink に埋める。
-      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
-    };
-    // Issue #867: runtime-config.json は **絶対にキャッシュさせない** (= CloudFront edge で
-    // tenant 間混線するリスク + deploy 後 1 時間反映されない問題を避けるため)。
-    new BucketDeployment(this, "RuntimeConfigDeployment", {
-      sources: [Source.jsonData("runtime-config.json", runtimeConfig)],
-      destinationBucket: bucket,
-      distribution,
-      distributionPaths: ["/runtime-config.json"],
-      prune: false,
-      cacheControl: [CacheControl.noStore(), CacheControl.noCache(), CacheControl.mustRevalidate()],
+      destinationBucket: this.siteBucket,
+      distribution: this.distribution,
+      prune: false, // runtime-config.json は別 stack が書くので他 key を残す
     });
 
     new cdk.CfnOutput(this, "AdminConsoleUrl", {
-      value: `https://${distribution.distributionDomainName}`,
+      value: `https://${this.distribution.distributionDomainName}`,
       description:
-        "admin-console の CloudFront URL。ControlPlaneStack の CDK_PARAM_ADMIN_CONSOLE_ORIGIN に設定して再 deploy することで Cognito callback + CORS に追加される",
+        "admin-console の CloudFront URL。 control-plane / admin-console-insight に cross-stack ref で渡る (= callback / CORS 経路で消費)",
     });
   }
 }

--- a/infrastructure/lib/admin-console-runtime-config-stack.ts
+++ b/infrastructure/lib/admin-console-runtime-config-stack.ts
@@ -1,0 +1,70 @@
+import * as cdk from "aws-cdk-lib";
+import type { Distribution } from "aws-cdk-lib/aws-cloudfront";
+import type { Bucket } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
+import type { Construct } from "constructs";
+
+/**
+ * Issue #1031: admin-console の `runtime-config.json` を SiteBucket に配置する専用 stack。
+ *
+ * 旧 AdminConsoleHostingStack 内 BucketDeployment を本 stack に切り出し、 「Distribution を
+ * 立てる stack」 と 「backend URL を runtime-config に焼く stack」 を分離した。 これにより:
+ *   - admin-console-hosting は backend stack の cross-stack ref を持たない (= 最初に立つ)
+ *   - control-plane / admin-console-insight が admin-console-hosting の distributionDomainName を
+ *     prop で受ける (= 1 方向の cross-stack ref で循環依存なし)
+ *   - 本 stack が backend URL + siteBucket を最後に集める (= 1 方向グラフ末端)
+ *
+ * Issue #867: runtime-config.json は **絶対にキャッシュさせない**。 deploy 毎に CloudFront
+ * invalidation も実行する (`distributionPaths`)。
+ */
+export interface AdminConsoleRuntimeConfigStackProps extends cdk.StackProps {
+  /** admin-console-hosting の SiteBucket (= cross-stack ref)。 */
+  readonly siteBucket: Bucket;
+  /** admin-console-hosting の Distribution (= invalidation 対象)。 */
+  readonly distribution: Distribution;
+  /** Control Plane API Gateway URL (末尾スラッシュ無し)。 */
+  readonly apiUrl: string;
+  /** Cognito UserPool domain (例: `https://xxx.auth.<region>.amazoncognito.com`)。 */
+  readonly cognitoDomain: string;
+  /** SBT 内蔵 UserPoolUserClient の client ID。 */
+  readonly userClientId: string;
+  /** Pooled tenant が共有する application-admin-console の CloudFront URL。 */
+  readonly pooledApplicationAdminConsoleUrl: string;
+  /** Provisioning ジョブを動かす CodeBuild project 名 (= SBT BashJobRunner)。 */
+  readonly provisioningCodeBuildProject: string;
+  /** AWS region。 */
+  readonly awsRegion: string;
+  /** AWS account ID。 */
+  readonly awsAccountId: string;
+  /** Admin Insight API のエンドポイント (= ADR-011 / #590 Phase 1.A)。 */
+  readonly adminInsightApiUrl: string;
+  /** Issue #1053: 競技者向け bootstrap template の public S3 URL。 */
+  readonly competitorBootstrapTemplateUrl: string;
+}
+
+export class AdminConsoleRuntimeConfigStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: AdminConsoleRuntimeConfigStackProps) {
+    super(scope, id, props);
+
+    const runtimeConfig = {
+      apiUrl: props.apiUrl.replace(/\/$/, ""),
+      cognitoDomain: props.cognitoDomain,
+      userClientId: props.userClientId,
+      pooledApplicationAdminConsoleUrl: props.pooledApplicationAdminConsoleUrl,
+      provisioningCodeBuildProject: props.provisioningCodeBuildProject,
+      awsRegion: props.awsRegion,
+      awsAccountId: props.awsAccountId,
+      adminInsightApiUrl: props.adminInsightApiUrl.replace(/\/$/, ""),
+      competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+    };
+
+    new BucketDeployment(this, "RuntimeConfigDeployment", {
+      sources: [Source.jsonData("runtime-config.json", runtimeConfig)],
+      destinationBucket: props.siteBucket,
+      distribution: props.distribution,
+      distributionPaths: ["/runtime-config.json"],
+      prune: false,
+      cacheControl: [CacheControl.noStore(), CacheControl.noCache(), CacheControl.mustRevalidate()],
+    });
+  }
+}

--- a/infrastructure/lib/app-config/index.ts
+++ b/infrastructure/lib/app-config/index.ts
@@ -1,7 +1,2 @@
 export { resolveApiKeyValue, resolveAppConfig } from "./resolve";
-export type {
-  AdminConsoleHostingInputs,
-  ApiKeySSMParameterNames,
-  AppConfig,
-  ProblemsCatalogBundle,
-} from "./types";
+export type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types";

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -13,12 +13,7 @@ import {
   discoverProblemsScoring,
   discoverProblemsVisibility,
 } from "../utils/discover-problems-catalog";
-import type {
-  AdminConsoleHostingInputs,
-  ApiKeySSMParameterNames,
-  AppConfig,
-  ProblemsCatalogBundle,
-} from "./types";
+import type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types";
 
 /**
  * Issue #766: bin/infrastructure.ts に散在していた env / config 解決を 1 つの pure function
@@ -185,11 +180,9 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     );
   }
 
-  const adminConsoleOriginForCors = env.CDK_PARAM_ADMIN_CONSOLE_ORIGIN;
-  // Issue #1053: 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance は廃止。
-  // hosting を ProblemDeployBackendStack に移管し、 consumer は cross-stack ref で URL を受ける。
-
-  const adminConsoleHostingInputs = buildHostingInputs(env);
+  // Issue #1031: 旧 `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env 直読みは廃止。 admin-console-hosting
+  // が先に立ち、 cross-stack ref で control-plane / admin-console-insight に流れる。
+  // Issue #1053: 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` も同じく cross-stack ref へ。
 
   // Issue #839 follow-up: SAML IdP 設定を config.json から取り出す (= 未設定なら undefined)。
   // tenant-stack 側 (= application-admin-console / pooled tenant + per-tenant silo + Lite) と
@@ -247,8 +240,6 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     problems,
     challengePayloadBucketName,
     deployConcurrentBuildLimit,
-    adminConsoleOriginForCors,
-    adminConsoleHostingInputs,
     tenantSamlConfig,
     controlPlaneSamlConfig,
     monthlyCostLimitUsd,
@@ -281,21 +272,6 @@ export function resolveApiKeyValue(args: ResolveApiKeyValueArgs): string {
     );
   }
   return `${args.appNameLower}-${args.environment}-${args.tier}-tier-key-default-do-not-share`.toLowerCase();
-}
-
-function buildHostingInputs(env: NodeJS.ProcessEnv): AdminConsoleHostingInputs | undefined {
-  const apiUrl = env.CDK_PARAM_CONTROL_PLANE_API_URL;
-  const cognitoDomain = env.CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN;
-  const userClientId = env.CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID;
-  if (!apiUrl || !cognitoDomain || !userClientId) return undefined;
-  return {
-    apiUrl,
-    cognitoDomain,
-    userClientId,
-    pooledApplicationAdminConsoleUrl: env.CDK_PARAM_POOLED_APP_CONSOLE_URL ?? "",
-    provisioningCodeBuildProject: env.CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT ?? "unknown",
-    adminInsightApiUrl: env.CDK_PARAM_ADMIN_INSIGHT_API_URL ?? "",
-  };
 }
 
 /**

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -79,15 +79,10 @@ export interface AppConfig {
   /** Bulk Deploy の CodeBuild 並列度 (未設定なら AWS account-level quota に任せる)。 */
   readonly deployConcurrentBuildLimit: number | undefined;
 
-  /** AdminConsoleInsight の CORS allow-list 用 origin。 phase 2 deploy 時に install.sh が export する。 */
-  readonly adminConsoleOriginForCors: string | undefined;
-
-  // Issue #1053: 旧 `competitorBootstrapTemplateUrlEnv` (= `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL`)
-  // は廃止。 ProblemDeployBackendStack に hosting を移管したため、 consumer は cross-stack ref で
-  // URL を受ける (= Phase 3 env-var dance が不要になる)。
-
-  /** Phase 2 hosting stack を立てるための 3 つの env (全部揃ったときだけ deploy する)。 */
-  readonly adminConsoleHostingInputs: AdminConsoleHostingInputs | undefined;
+  // Issue #1031: 旧 `adminConsoleOriginForCors` (= `CDK_PARAM_ADMIN_CONSOLE_ORIGIN`) は廃止。
+  // admin-console-hosting が先に立ち、 cross-stack ref で control-plane / admin-console-insight
+  // に流れる (= Phase 3 env-var dance が不要になる)。
+  // Issue #1053: 旧 `competitorBootstrapTemplateUrlEnv` も同じく cross-stack ref へ移行。
 
   /**
    * Issue #839 follow-up: 全 tenant 共有の SAML IdP 連携。 config.json の `tenantSamlConfig`
@@ -118,13 +113,4 @@ export interface ProblemsCatalogBundle {
   readonly visibility: unknown;
   /** Issue #888: per-problem `disruptions[]` 宣言。 未宣言の問題はキー無し。 */
   readonly disruptions: unknown;
-}
-
-export interface AdminConsoleHostingInputs {
-  readonly apiUrl: string;
-  readonly cognitoDomain: string;
-  readonly userClientId: string;
-  readonly pooledApplicationAdminConsoleUrl: string;
-  readonly provisioningCodeBuildProject: string;
-  readonly adminInsightApiUrl: string;
 }

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { AdminConsoleHostingStack } from "../admin-console-hosting";
+import { AdminConsoleRuntimeConfigStack } from "../admin-console-runtime-config-stack";
 import { AdminConsoleInsightStack } from "../admin-insight/admin-console-insight-stack";
 import type { AppConfig } from "../app-config/types";
 import { BootstrapTemplateStack } from "../bootstrap-template/bootstrap-template-stack";
@@ -59,15 +60,31 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
   // KMS Key を AWS-managed alias `alias/aws/s3` (無料) に置き換える Aspect (cost cleanup)。
   cdk.Aspects.of(app).add(new CodeBuildUseAwsManagedKms());
 
+  // Issue #1031: admin-console-hosting を最初に立てる (= 依存なし、 wildcard CSP)。
+  // 後続 control-plane / admin-console-insight が `distributionDomainName` を cross-stack ref で
+  // 受け取る (= adminConsoleOrigin)。 これで install.sh の Phase 1/2/3 の env-var dance を
+  // 撤廃でき、 `bun cdk deploy --all` 1 発で全 stack が立つ。
+  const adminConsoleHostingStack = new AdminConsoleHostingStack(
+    app,
+    stackId("tenkacloud-admin-console-hosting", config.environment),
+    {
+      ...config.stackEnv,
+    },
+  );
+  cdk.Aspects.of(adminConsoleHostingStack).add(new DestroyPolicySetter());
+  const adminConsoleOrigin = `https://${adminConsoleHostingStack.distributionDomainName}`;
+
   const controlPlaneStack = new ControlPlaneStack(
     app,
     stackId("tenkacloud-control-plane", config.environment),
     {
       ...config.stackEnv,
       systemAdminEmail: config.systemAdminEmail,
+      adminConsoleOrigin,
       samlIdp: config.controlPlaneSamlConfig,
     },
   );
+  controlPlaneStack.addDependency(adminConsoleHostingStack);
 
   // SBT が ControlPlane 内部で作る TenantDetails table は default 5/5 (CDK Table の
   // 既定値) なので Free Tier 枠 (25 RCU/WCU) を圧迫する。Aspect で全 CfnTable を
@@ -141,7 +158,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       deploymentsTable: problemDeployBackendStack.deploymentsTable,
       eventsTable: problemDeployBackendStack.eventsTable,
       teamsTable: problemDeployBackendStack.teamsTable,
-      adminConsoleOrigin: config.adminConsoleOriginForCors,
+      // Issue #1031: cross-stack ref で adminConsoleOrigin を受ける (= 旧 env-var dance 撤廃)。
+      adminConsoleOrigin,
       // Issue #814 Phase 2: SBT BashJobRunner の deprovisioning state machine ARN を渡し、
       // admin-insight Lambda が ListExecutions で履歴を引けるようにする。
       deprovisioningStateMachineArn: bootstrapTemplateStack.deprovisioningStateMachineArn,
@@ -305,30 +323,34 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
     });
   }
 
-  let adminConsoleHosting: AdminConsoleHostingStack | undefined;
-  if (config.adminConsoleHostingInputs) {
-    adminConsoleHosting = new AdminConsoleHostingStack(
-      app,
-      stackId("tenkacloud-admin-console-hosting", config.environment),
-      {
-        ...config.stackEnv,
-        apiUrl: config.adminConsoleHostingInputs.apiUrl,
-        cognitoDomain: config.adminConsoleHostingInputs.cognitoDomain,
-        userClientId: config.adminConsoleHostingInputs.userClientId,
-        pooledApplicationAdminConsoleUrl:
-          config.adminConsoleHostingInputs.pooledApplicationAdminConsoleUrl,
-        provisioningCodeBuildProject: config.adminConsoleHostingInputs.provisioningCodeBuildProject,
-        awsRegion: config.awsRegion,
-        awsAccountId: config.awsAccountId,
-        adminInsightApiUrl: config.adminConsoleHostingInputs.adminInsightApiUrl,
-        // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 cross-stack ref で
-        // URL を受ける。 Phase 1 から runtime-config.json に正しい S3 URL が焼かれる。
-        competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
-      },
-    );
-    adminConsoleHosting.addDependency(problemDeployBackendStack);
-    cdk.Aspects.of(adminConsoleHosting).add(new DestroyPolicySetter());
-  }
+  // Issue #1031: runtime-config.json を SiteBucket に配置する専用 stack。 全 backend stack の
+  // cross-stack ref を集めて 1 ヶ所で runtime-config を組み立てる (= 旧 install.sh phase 2 で
+  // env-var 経由していた値を CFn ref に置換)。
+  const adminConsoleRuntimeConfigStack = new AdminConsoleRuntimeConfigStack(
+    app,
+    stackId("tenkacloud-admin-console-runtime-config", config.environment),
+    {
+      ...config.stackEnv,
+      siteBucket: adminConsoleHostingStack.siteBucket,
+      distribution: adminConsoleHostingStack.distribution,
+      apiUrl: controlPlaneStack.regApiGatewayUrl,
+      cognitoDomain: controlPlaneStack.cognitoDomain,
+      userClientId: controlPlaneStack.cognitoUserClientId,
+      pooledApplicationAdminConsoleUrl: tenantTemplateStack.applicationAdminConsoleUrl,
+      provisioningCodeBuildProject: serverlessSaaSPipeline.provisioningCodeBuildProjectName,
+      awsRegion: config.awsRegion,
+      awsAccountId: config.awsAccountId,
+      adminInsightApiUrl: adminConsoleInsightStack.apiUrl,
+      competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
+    },
+  );
+  adminConsoleRuntimeConfigStack.addDependency(adminConsoleHostingStack);
+  adminConsoleRuntimeConfigStack.addDependency(controlPlaneStack);
+  adminConsoleRuntimeConfigStack.addDependency(adminConsoleInsightStack);
+  adminConsoleRuntimeConfigStack.addDependency(tenantTemplateStack);
+  adminConsoleRuntimeConfigStack.addDependency(serverlessSaaSPipeline);
+  adminConsoleRuntimeConfigStack.addDependency(problemDeployBackendStack);
+  cdk.Aspects.of(adminConsoleRuntimeConfigStack).add(new DestroyPolicySetter());
 
   return {
     controlPlaneStack,
@@ -338,7 +360,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
     tenantTemplateStack,
     serverlessSaaSPipeline,
     observabilityStack,
-    adminConsoleHosting,
+    adminConsoleHosting: adminConsoleHostingStack,
+    adminConsoleRuntimeConfigStack,
   };
 }
 
@@ -350,7 +373,9 @@ export interface TenkaCloudAppHandles {
   readonly tenantTemplateStack: TenantTemplateStack;
   readonly serverlessSaaSPipeline: ServerlessSaaSPipeline;
   readonly observabilityStack: ObservabilityStack;
-  readonly adminConsoleHosting: AdminConsoleHostingStack | undefined;
+  readonly adminConsoleHosting: AdminConsoleHostingStack;
+  /** Issue #1031: runtime-config.json を SiteBucket に配置する専用 stack (= 旧 install.sh phase 2 を置換)。 */
+  readonly adminConsoleRuntimeConfigStack: AdminConsoleRuntimeConfigStack;
 }
 
 const apiIdFromExecuteApiUrl = (apiUrl: string): string =>

--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -6,6 +6,7 @@ import {
   CfnUserPoolIdentityProvider,
   type IUserPool,
   type UserPoolClient,
+  type UserPoolDomain,
 } from "aws-cdk-lib/aws-cognito";
 import { EventBus, Rule } from "aws-cdk-lib/aws-events";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
@@ -20,6 +21,12 @@ import {
 
 interface ControlPlaneStackProps extends cdk.StackProps {
   systemAdminEmail: string;
+  /**
+   * Issue #1031: admin-console の CloudFront URL (= `AdminConsoleHostingStack.distributionDomainName`)。
+   * 旧 `process.env.CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env 直読みを撤廃し、 prop で受ける形に揃えた。
+   * 未指定 (= optional) は test や hosting stack 不在ケースで許容。
+   */
+  adminConsoleOrigin?: string;
   /**
    * Issue #839 follow-up: System Admin (= TenkaCloud operator 会社) 用 SAML IdP 連携。
    * SBT が wrap した Cognito UserPool に `CfnUserPoolIdentityProvider` (= SAML) を escape hatch で
@@ -62,6 +69,13 @@ export class ControlPlaneStack extends cdk.Stack {
    * AdminInsight HTTP API の JWT Authorizer も同 client を audience とみなす。
    */
   public readonly cognitoUserClientId: string;
+  /**
+   * Issue #1031: SBT 内蔵 UserPoolDomain の base URL (= `https://<prefix>.auth.<region>.amazoncognito.com`)。
+   * `AdminConsoleRuntimeConfigStack` が runtime-config.json に焼き込む値を cross-stack ref で受ける。
+   * SBT は cognitoDomain を public field として expose しないため、 内部 child `UserPoolDomain` を
+   * findChild で取り出して `.baseUrl()` を呼ぶ。
+   */
+  public readonly cognitoDomain: string;
 
   constructor(scope: Construct, id: string, props: ControlPlaneStackProps) {
     super(scope, id, props);
@@ -70,9 +84,8 @@ export class ControlPlaneStack extends cdk.Stack {
       setAPIGWScopes: false, // done for testing purposes. Scopes should be used for added security in production!
     });
 
-    // admin-console の CloudFront URL (install.sh phase 3 で env 経由で注入される)。
-    // 最初の deploy 時は未設定、AdminConsoleHostingStack deploy 後に再 deploy で設定される。
-    const adminConsoleOrigin = process.env.CDK_PARAM_ADMIN_CONSOLE_ORIGIN;
+    // Issue #1031: admin-console の CloudFront URL は cross-stack ref で props 経由。 旧 env 直読みは廃止。
+    const adminConsoleOrigin = props.adminConsoleOrigin;
     const extraCorsOrigins = adminConsoleOrigin ? [adminConsoleOrigin] : [];
     const extraCallbackUrls = adminConsoleOrigin ? [`${adminConsoleOrigin}/callback`] : [];
     const extraLogoutUrls = adminConsoleOrigin ? [`${adminConsoleOrigin}/`] : [];
@@ -182,6 +195,11 @@ export class ControlPlaneStack extends cdk.Stack {
     // (AdminConsoleInsightStack) の JWT Authorizer 用に export する。
     this.cognitoUserPool = cognitoAuth.userPool;
     this.cognitoUserClientId = cognitoAuth.userClientId;
+    // Issue #1031: SBT 内蔵 UserPoolDomain (= cognito-auth.js:104 で `new UserPoolDomain` される
+    // 子 construct) を findChild で取り出して baseUrl を expose。 `AdminConsoleRuntimeConfigStack`
+    // が runtime-config.json の `cognitoDomain` field に焼き込む。
+    const userPoolDomain = cognitoAuth.node.findChild("UserPoolDomain") as UserPoolDomain;
+    this.cognitoDomain = userPoolDomain.baseUrl();
   }
 }
 

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -80,6 +80,13 @@ export class TenantTemplateStack extends Stack {
   public readonly tenantApiName: string;
   /** Tenant REST API deployment stage name for CloudWatch metrics. */
   public readonly tenantApiStageName: string;
+  /**
+   * Issue #1031: pooled tenant が共有する application-admin-console の CloudFront URL。
+   * `AdminConsoleRuntimeConfigStack` が runtime-config.json の `pooledApplicationAdminConsoleUrl`
+   * field に焼き込む cross-stack ref として使う。 silo (PLATINUM) instance も同 field を持つが、
+   * admin-console は pooled URL のみを runtime-config 経由で表示する。
+   */
+  public readonly applicationAdminConsoleUrl: string;
 
   constructor(scope: Construct, id: string, props: TenantTemplateStackProps) {
     super(scope, id, props);
@@ -121,6 +128,7 @@ export class TenantTemplateStack extends Stack {
     this.tenantApiId = apiGateway.restApi.restApiId;
     this.tenantApiName = apiGateway.restApi.restApiName;
     this.tenantApiStageName = apiGateway.restApi.deploymentStage.stageName;
+    this.applicationAdminConsoleUrl = applicationAdminConsoleHosting.distributionUrl;
 
     new AwsCustomResource(this, "CreateTenantMapping", {
       installLatestAwsSdk: true,

--- a/infrastructure/test/admin-console-hosting.test.ts
+++ b/infrastructure/test/admin-console-hosting.test.ts
@@ -6,10 +6,12 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { AdminConsoleHostingStack } from "../lib/admin-console-hosting";
 
 /**
- * Issue #896: admin-console-hosting の CSP origin allow-list regression を検出する test。
+ * Issue #1031: admin-console-hosting は CloudFront + SiteBucket + dist/ deployment のみを担い、
+ * runtime-config.json は `AdminConsoleRuntimeConfigStack` が別 stack で書く。 backend URL の
+ * cross-stack ref を本 stack から切ったため、 CSP は region wildcard。
  *
- * AdminConsoleHostingStack は dist/ を S3 deployment する。 ローカル / CI で未 build の場合は
- * placeholder を作って synth を通す (= application-admin-console-hosting.test.ts と同 pattern)。
+ * 旧 Issue #896 の strict CSP 検査 (= execute-api / auth host 名 厳密 allow) は wildcard 化に伴い
+ * pattern を緩めて pin する (= 同 region 内 API GW / Cognito domain だけは少なくとも許可される)。
  */
 const distDir = path.join(__dirname, "..", "..", "apps", "admin-console", "dist");
 
@@ -27,16 +29,6 @@ function synth(): Template {
   const app = new cdk.App();
   const stack = new AdminConsoleHostingStack(app, "TestStack", {
     env: { account: "123456789012", region: "ap-northeast-1" },
-    apiUrl: "https://api.example.com",
-    cognitoDomain: "https://auth.example.amazoncognito.com",
-    userClientId: "client-id",
-    pooledApplicationAdminConsoleUrl: "https://pooled.example.cloudfront.net",
-    provisioningCodeBuildProject: "proj",
-    awsRegion: "ap-northeast-1",
-    awsAccountId: "123456789012",
-    adminInsightApiUrl: "https://insight.example.com",
-    competitorBootstrapTemplateUrl:
-      "https://tenkacloud-source.s3.ap-northeast-1.amazonaws.com/competitor-bootstrap.yaml",
   });
   return Template.fromStack(stack);
 }
@@ -46,31 +38,40 @@ describe("AdminConsoleHostingStack", () => {
     ensurePlaceholderDist();
   });
 
-  describe("CloudFront security headers (CSP) — Issue #896", () => {
-    it("connect-src に adminInsightApiUrl を含むべき", () => {
+  describe("CloudFront security headers (CSP wildcard, Issue #1031)", () => {
+    it("connect-src に execute-api region wildcard を含むべき", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
       expect(policy).toBeDefined();
       const cspJson = JSON.stringify(policy);
-      expect(cspJson).toContain("https://insight.example.com");
+      expect(cspJson).toContain("https://*.execute-api.ap-northeast-1.amazonaws.com");
     });
 
-    it("connect-src に Control Plane apiUrl と cognitoDomain を含むべき", () => {
+    it("connect-src に Cognito domain wildcard を含むべき", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
       const cspJson = JSON.stringify(policy);
-      expect(cspJson).toContain("https://api.example.com");
-      expect(cspJson).toContain("https://auth.example.amazoncognito.com");
+      expect(cspJson).toContain("https://*.amazoncognito.com");
+      expect(cspJson).toContain("https://cognito-idp.ap-northeast-1.amazonaws.com");
     });
 
-    it("form-action に Cognito domain を含むべき (= Hosted UI sign-in form)", () => {
+    it("form-action に Cognito domain wildcard を含むべき (= Hosted UI sign-in form)", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
       const cspJson = JSON.stringify(policy);
       expect(cspJson).toMatch(/form-action[^;]*amazoncognito\.com/);
+    });
+  });
+
+  describe("Issue #1031: runtime-config 分離", () => {
+    it("RuntimeConfigDeployment を本 stack に持たないべき (= AdminConsoleRuntimeConfigStack に移管)", () => {
+      const template = synth();
+      // BucketDeployment は 1 つだけ (= SiteDeployment for dist/)、 旧 RuntimeConfigDeployment は無い。
+      const bucketDeployments = template.findResources("Custom::CDKBucketDeployment");
+      expect(Object.keys(bucketDeployments)).toHaveLength(1);
     });
   });
 });

--- a/infrastructure/test/app-config/resolve.test.ts
+++ b/infrastructure/test/app-config/resolve.test.ts
@@ -206,41 +206,23 @@ describe("resolveAppConfig", () => {
     expect(cfg.participantPortal).toBeUndefined();
   });
 
-  it("adminConsoleHostingInputs は 3 つの env (apiUrl / cognitoDomain / userClientId) が揃ったときだけ object を返すべき (phase 2 gate)", () => {
-    const noinputs = resolveAppConfig({
-      env: baseEnv(),
-      binDir: BIN_DIR,
-      fs: fsAlwaysMissing,
-      dotenvConfig: noopDotenv,
-      discoverProblems: stubProblems,
-    });
-    expect(noinputs.adminConsoleHostingInputs).toBeUndefined();
-
-    const partial = resolveAppConfig({
-      env: baseEnv({ CDK_PARAM_CONTROL_PLANE_API_URL: "https://api" }),
-      binDir: BIN_DIR,
-      fs: fsAlwaysMissing,
-      dotenvConfig: noopDotenv,
-      discoverProblems: stubProblems,
-    });
-    expect(partial.adminConsoleHostingInputs).toBeUndefined();
-
-    const all = resolveAppConfig({
+  it("Issue #1031: adminConsoleHostingInputs / adminConsoleOriginForCors field は AppConfig から除去されているべき", () => {
+    // admin-console-hosting は backend URL の cross-stack ref で立つようになり、 env-var 経由の
+    // gate は廃止された。 AppConfig 出力に該当 field が含まれないことで env-var 経路 regression を防ぐ。
+    const cfg = resolveAppConfig({
       env: baseEnv({
         CDK_PARAM_CONTROL_PLANE_API_URL: "https://api",
         CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN: "https://cog",
         CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID: "abc",
+        CDK_PARAM_ADMIN_CONSOLE_ORIGIN: "https://admin.example.com",
       }),
       binDir: BIN_DIR,
       fs: fsAlwaysMissing,
       dotenvConfig: noopDotenv,
       discoverProblems: stubProblems,
     });
-    expect(all.adminConsoleHostingInputs).toMatchObject({
-      apiUrl: "https://api",
-      cognitoDomain: "https://cog",
-      userClientId: "abc",
-    });
+    expect((cfg as Record<string, unknown>).adminConsoleHostingInputs).toBeUndefined();
+    expect((cfg as Record<string, unknown>).adminConsoleOriginForCors).toBeUndefined();
   });
 
   it("CDK_PARAM_IDP_NAME / SYSTEM_ADMIN_ROLE_NAME のデフォルトを process.env に注入すべき (SBT ref-arch 互換)", () => {

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -3,93 +3,69 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * #716: `scripts/install.sh` Phase 3 が `admin-console-insight` も再 deploy しないと、
- * 該当 stack の HTTP API CORS allow-list が Phase 1 時点 (localhost-only) のままで
- * Provisioning Jobs page が "Failed to fetch" を吐く。 本テストは Phase 3 の cdk deploy
- * 行が `tenkacloud-admin-console-insight` を含むことを pin (= 退行防止)。
+ * Issue #1031: `scripts/install.sh` は admin-console-hosting を cross-stack ref で先に立てる
+ * 構造へ refactor し、 旧 Phase 1/2/3 を `cdk deploy --all` 1 発に統合した。 本 file は
+ *   - 単一 deploy 文 1 つで全 stack を立てる
+ *   - 旧 env-var injection (CDK_PARAM_ADMIN_CONSOLE_ORIGIN) を行わない
+ *   - DRY (= prepare-source-bundle.sh への委譲) を保つ
+ *   - pooled stack を直 deploy しない (= SBT pipeline 一本化、 Issue #1029)
+ * を pin する。
  */
 
 const INSTALL_SH_PATH = join(__dirname, "..", "..", "scripts", "install.sh");
 const PREPARE_BUNDLE_SH_PATH = join(__dirname, "..", "..", "scripts", "prepare-source-bundle.sh");
 
-describe("scripts/install.sh Phase 3 (#716)", () => {
+describe("scripts/install.sh (Issue #1031: single-phase deploy)", () => {
   const source = readFileSync(INSTALL_SH_PATH, "utf8");
-  // staging-related logic は prepare-source-bundle.sh に集約済 (= DRY、 install.sh と
-  // tenkacloud-lite.ts cmdUp の両方が同じ shell を呼ぶ)。 staging 要件は本 file で読む。
   const prepareBundle = readFileSync(PREPARE_BUNDLE_SH_PATH, "utf8");
 
-  it("Phase 3 の cdk deploy で control-plane と admin-console-insight の両方を指定すべき", () => {
-    const phase3Match = source.match(
-      /bun cdk deploy[^\n]*tenkacloud-control-plane[^\n]*tenkacloud-admin-console-insight[^\n]*--require-approval never/,
-    );
-    expect(phase3Match).not.toBeNull();
+  it("`bun cdk deploy --all` で全 stack を 1 発で deploy すべき (#1031)", () => {
+    // bash の \ 継続を許容するため、 `--all` と `--require-approval never` を別 line 検査で。
+    expect(source).toMatch(/bun cdk deploy --all\b/);
+    expect(source).toContain("--require-approval never");
   });
 
-  it("Phase 3 で CDK_PARAM_ADMIN_CONSOLE_ORIGIN を再 export してから再 deploy すべき", () => {
-    const exportIdx = source.indexOf(
-      `export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="\${ADMIN_CONSOLE_URL}"`,
-    );
-    const deployIdx = source.indexOf(
-      "bun cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight",
-    );
-    expect(exportIdx).toBeGreaterThan(0);
-    expect(deployIdx).toBeGreaterThan(exportIdx);
+  it("旧 Phase 3 の `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env injection は廃止すべき (#1031)", () => {
+    expect(source).not.toContain("export CDK_PARAM_ADMIN_CONSOLE_ORIGIN=");
   });
 
-  // tenant provisioning / update CodeBuild job が `scripts/lib/install-node.sh:
-  // install_bun_from_package_manager` で CWD/`package.json` の `packageManager` field から
-  // Bun version を読む。 staging root に `package.json` を copy していないと ENOENT で
-  // CodeBuild job が \"package.json not found\" で fail する (= 直近 regression)。
-  // 本 logic は prepare-source-bundle.sh に集約済 (= install.sh から source される、 DRY)。
-  it("prepare-source-bundle.sh が staging root に repo root `package.json` を copy すべき (= CodeBuild が packageManager を読む)", () => {
+  it("旧 Phase 2 で読んでいた backend output 系 env (CDK_PARAM_CONTROL_PLANE_API_URL 等) は廃止すべき (#1031)", () => {
+    expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_API_URL");
+    expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN");
+    expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID");
+    expect(source).not.toContain("CDK_PARAM_POOLED_APP_CONSOLE_URL");
+    expect(source).not.toContain("CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT");
+    expect(source).not.toContain("CDK_PARAM_ADMIN_INSIGHT_API_URL");
+  });
+
+  // prepare-source-bundle.sh が staging logic の DRY 集約点であることを pin。
+  it("prepare-source-bundle.sh が staging root に repo root `package.json` を copy すべき", () => {
     expect(prepareBundle).toContain('cp package.json "${STAGING}/package.json"');
   });
 
-  // Issue #916 (2 層目): `infrastructure/package.json` は `@TenkaCloud/trust-bridge:
-  // workspace:*` で sibling workspace を参照する。 staging に `packages/` を同梱しないと
-  // bun が workspace を resolve できず `EUNSUPPORTEDPROTOCOL` (npm) /
-  // `package not found` (bun) で fail する。
-  it("prepare-source-bundle.sh が staging root に `packages` directory を copy すべき (= workspace:* protocol の resolve)", () => {
+  it("prepare-source-bundle.sh が staging root に `packages` directory を copy すべき (= workspace:* protocol)", () => {
     expect(prepareBundle).toContain('cp -R packages "${STAGING}/packages"');
   });
 
-  // Issue #916 (3 層目): repo root の workspaces 配列は `infrastructure` を含むが、 staging では
-  // SBT ref-arch 互換のため `cdk/` にリネームされる。 root package.json の workspaces を staging で
-  // も `cdk` に書き換えないと bun が CWD=cdk を workspace member と認識せず、
-  // `Workspace dependency "@TenkaCloud/trust-bridge" not found / Searched in "./*"` で fail する。
   it("prepare-source-bundle.sh が staging package.json の workspaces を `infrastructure` → `cdk` に書き換えるべき", () => {
     expect(prepareBundle).toContain("pkg['workspaces'] = [w if w != 'infrastructure' else 'cdk'");
   });
 
-  // DRY regression 防止: install.sh が staging logic を再度 inline で持たないこと。
   it("install.sh は prepare-source-bundle.sh を source して staging を委譲し、 重複 inline 化しないべき", () => {
     expect(source).toContain('source "${SCRIPT_DIR}/prepare-source-bundle.sh"');
     expect(source).not.toContain('cp -R packages "${STAGING}/packages"');
     expect(source).not.toContain('cp -R problems "${STAGING}/problems"');
   });
 
-  // Issue #1029 / PR-1028 follow-up: pooled stack の lifecycle は SBT pipeline (= CodeBuild)
-  // に一本化する。 install.sh が直 deploy すると SBT Step Functions の「Can we update Stack?」
-  // が Skip Deployment 分岐に倒れ tenant update path が機能しない silent failure になる。
-  // regression pin: install.sh の `bun cdk deploy` 引数に pooled stack が含まれないこと。
+  // Issue #1029 / PR-1028: pooled stack の lifecycle は SBT pipeline 一本化。
   it("install.sh は tenkacloud-tenant-template-pooled を cdk deploy しないべき (= SBT pipeline 一本化)", () => {
-    // `bun cdk deploy` で始まる block (= 単独 stack 名指定の cdk deploy、 bash の \ 継続あり /
-    // なし両方) に pooled stack 名が出てこないこと。 CFn output 読み込み
-    // (= `aws cloudformation describe-stacks --stack-name "tenkacloud-tenant-template-pooled"`)
-    // は別経路なので除外。
-    //
-    // 正規表現: `bun cdk deploy` + 0 個以上の継続行 (`<chars>\<newline>`) + 最終行 (`<chars>`)。
-    const deployBlocks = source.match(/bun cdk deploy(?:[^\n]*\\\n)*[^\n]*/g) ?? [];
-    expect(deployBlocks.length).toBeGreaterThan(0);
-    for (const block of deployBlocks) {
-      expect(block).not.toContain("tenkacloud-tenant-template-pooled");
-    }
+    // `bun cdk deploy --all` は `--exclusively` で all を意味するため、 pooled stack を **直接
+    // 名指しで deploy しない** ことのみ pin する。 `--all` は app 上 instantiate された stack を
+    // 全て deploy するため、 wire.ts で pooled stack を生成する限り CDK が立てに行く。 pooled
+    // stack の SBT pipeline 一本化は wire.ts 側 + `--exclusively` flag で扱う方針。
+    expect(source).not.toMatch(/bun cdk deploy[^\n-][^\n]*tenkacloud-tenant-template-pooled/);
   });
 
-  // prepare-source-bundle.sh は `set -euo pipefail` で `-u` を有効化しており、 install.sh が
-  // それを source した時点で unbound variable は実行時エラーになる。 過去に install.sh の
-  // 後段 `cd` で `${TenkaCloud_ROOT}` (PascalCase 表記) と書かれていて Phase 2 で
-  // 「TenkaCloud_ROOT: unbound variable」 で deploy が止まった。 typo regression を pin する。
   it("install.sh の repo root 変数は **全大文字** TENKACLOUD_ROOT で統一すべき (= PascalCase 禁止)", () => {
     expect(source).not.toMatch(/\$\{TenkaCloud_ROOT[}:]/);
     expect(source).not.toMatch(/\$\{TenkaCloud_Root[}:]/);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -eo pipefail
-# TenkaCloud orchestration entry — 全部 AWS で動かす 3-phase deploy
+# TenkaCloud orchestration entry — `cdk deploy --all` 1 発で完結 (Issue #1031)。
 #
-# Phase 1: Backend stacks (ControlPlane + Bootstrap + TenantTemplate-pooled + Pipeline)
-# Phase 2: AdminConsoleHostingStack (React admin-console を CloudFront+S3 配信)
-# Phase 3: ControlPlaneStack + admin-console-insight 再 deploy
-#         (CloudFront URL を callback / CORS に追加、 #716)
+# 旧 install.sh は Phase 1 (backend) → Phase 2 (admin-console-hosting) → Phase 3 (control-plane
+# 再 deploy) の 3 段だった。 admin-console URL の chicken-and-egg を env-var dance で解いていた
+# が、 Issue #1031 で admin-console-hosting を cross-stack ref で最初に立てる構造に reshape し、
+# CDK が依存解決して 1 発 deploy できるようになった。
 #
 # Usage:
 #   bash scripts/install.sh "admin@example.com"
 #
 # 前提:
 #   - aws CLI ログイン済み
-#   - docker 起動済み (BucketDeployment bundling で使用)
+#   - docker 起動済み (= BucketDeployment bundling 用)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -23,169 +23,55 @@ if [[ -z "$CDK_PARAM_SYSTEM_ADMIN_EMAIL" ]]; then
   exit 1
 fi
 
-# --- Source bucket 準備 + source.zip upload (= prepare-source-bundle.sh に集約) ---
-#
-# 旧来この install.sh 自体で bucket 作成 + apps build + staging + zip + upload を inline で
-# 書いていたが (= 80 行 / 内容は tenkacloud-lite.ts cmdUp の Lite mode と完全に同じ)、 DRY
-# 違反になっていた。 prepare-source-bundle.sh に shared logic を切り出し、 install.sh / lite
-# 両方が同じ手順を踏むようにする。 source で呼ぶことで CDK_PARAM_S3_BUCKET_NAME /
-# CDK_PARAM_COMMIT_ID 等の export を caller に持ち越す。
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source bucket 準備 + source.zip upload (= prepare-source-bundle.sh が DRY 集約点)。
+# CDK_PARAM_S3_BUCKET_NAME / CDK_PARAM_COMMIT_ID / TENKACLOUD_ROOT を export する。
 # shellcheck source=./prepare-source-bundle.sh
 source "${SCRIPT_DIR}/prepare-source-bundle.sh"
 
-# Participant Portal を ProblemDeployBackendStack に含める (CDK 側で条件付き作成)。
-# eventTitle はオプション (default は "TenkaCloud Battle")。
+# SBT 内部の aws-cdk-lib deprecation warning を抑制 (CFT には影響なし)。
+export JSII_DEPRECATED=quiet
+# Participant Portal を ProblemDeployBackendStack に含める (= CDK 側で条件付き作成)。
 export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL="true"
 
-# TENKACLOUD_ROOT は prepare-source-bundle.sh が export する。 install.sh の後段は
-# infrastructure/ 配下で動作するため戻す。 source 経由で set -u が継承されるので、
-# 以降の cd でも変数名は **全大文字** に揃える (= typo は unbound variable で fail する)。
+# SPA dist/ build — BucketDeployment.Source.asset が dist/ を要求するため CDK synth 前に必須。
+# Issue #1031: 旧 install.sh は Phase 2 で host 側 build していたが、 全 stack 1 発 deploy する
+# 都合で先回り build する。 URL 系は build に焼かず runtime-config.json 経由 (= URL 非依存 bundle)。
+for app in admin-console application-admin-console participant-portal; do
+  echo "[install] building apps/${app}..."
+  (cd "${TENKACLOUD_ROOT}/apps/${app}" && bun install && bun run build) >/dev/null
+done
+
 cd "${TENKACLOUD_ROOT}/infrastructure"
-
-# JSII_DEPRECATED=quiet: SBT 内部の aws-cdk-lib deprecation warning を抑制 (CFT には影響なし)
-export JSII_DEPRECATED=quiet
-
 bun install
 bun cdk bootstrap
 
 # ============================================================================
-# Phase 1: backend stacks — admin-console URL はまだ無いので CORS/callback は
-# localhost のみで deploy
-# ============================================================================
-echo ""
-echo "=============================================="
-echo "Phase 1: Deploy backend stacks"
-echo "=============================================="
-# Issue #1029 / PR-1028 follow-up: `tenkacloud-tenant-template-pooled` (= pooled tenants が
-# 共有する App Plane stack) は install.sh からは deploy しない。 理由:
-#   - install.sh が直 deploy すると stack が UPDATE_IN_PROGRESS の間 SBT Step Functions が
-#     「Can we update Stack?」 = NO で Skip Deployment 分岐に倒れ、 CodeBuild が起動しない
-#     → tenant update path が機能しない silent failure になる
-#   - 役割分担を明確化: pooled stack の lifecycle (create / update) は SBT pipeline
-#     (CodeBuild 経由) に一本化。 install.sh は Control Plane 系 stack + saas-pipeline まで
-# 初回 install: pooled stack は未作成 (= 後で初 tenant 作成 trigger で SBT が初 create)
-# 二度目以降: pooled stack は SBT pipeline が tenant event で update
-bun cdk deploy \
-  tenkacloud-control-plane \
-  tenkacloud-bootstrap \
-  tenkacloud-problem-deploy \
-  tenkacloud-admin-console-insight \
-  tenkacloud-saas-pipeline \
-  --require-approval never --concurrency 4
-
-# ============================================================================
-# Phase 2: admin-console build + hosting deploy
-#   - Phase 1 の outputs を env に入れて apps/admin-console を host 側で build
-#     (bun workspace の node_modules 内シンボリックリンクが docker cp で壊れるので
-#      host build → dist/ を S3 アップロードする形)
-#   - AdminConsoleHostingStack を deploy (S3 + CloudFront)
-# ============================================================================
-echo ""
-echo "=============================================="
-echo "Phase 2: Build admin-console + deploy CloudFront"
-echo "=============================================="
-API_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?OutputKey=='controlPlaneAPIEndpoint'].OutputValue" --output text)
-USER_POOL_ID=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpUserPoolId')].OutputValue" --output text)
-CLIENT_ID=$(aws cloudformation describe-stacks --stack-name tenkacloud-control-plane --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpClientId')].OutputValue" --output text)
-COGNITO_DOMAIN_PREFIX=$(aws cognito-idp describe-user-pool --user-pool-id "${USER_POOL_ID}" --query "UserPool.Domain" --output text)
-COGNITO_DOMAIN="https://${COGNITO_DOMAIN_PREFIX}.auth.${REGION}.amazoncognito.com"
-
-echo "  API URL       : ${API_URL}"
-echo "  ClientId      : ${CLIENT_ID}"
-echo "  Cognito Domain: ${COGNITO_DOMAIN}"
-
-# admin-console を host で build。URL は build に焼かない (runtime-config.json 経由で
-# CDK が CloudFront に配置する)。dev ローカル開発では .env.local が効くので触らない。
-cd "${TENKACLOUD_ROOT}/apps/admin-console"
-echo "  apps/admin-console: bun install + vite build (URL 非依存)"
-bun install
-bun run build
-echo "  → dist/ generated"
-
-# pooled stack の application-admin-console URL も runtime-config に流す
-# (admin-console から basic / standard / advanced tier の tenant 行で「開く」リンクを
-# 出すため。silo platinum tenant は provision-tenant.sh が tenantConfig に書く)。
+# Single-phase deploy (Issue #1031): admin-console-hosting → control-plane / 他 backend →
+# admin-console-runtime-config の依存グラフを CDK が解決して 1 発で全 stack を立てる。
 #
-# Issue #1029 / PR-1028 follow-up: pooled stack は SBT pipeline (CodeBuild) で create / update
-# される設計なので、 初回 install (= 第 1 tenant 未作成) の時点では存在しない。 stack 不在は
-# 空文字 fallback (= runtime-config に空 URL が入る、 admin-console は「pooled tenants 未配信」
-# 扱いで UI 上 link を出さない / 空表示する)。 第 1 tenant 作成後に再 install.sh を走らせれば
-# URL が伝播する。
-POOLED_APP_CONSOLE_URL=$(aws cloudformation describe-stacks \
-  --stack-name "tenkacloud-tenant-template-pooled" \
-  --query "Stacks[0].Outputs[?OutputKey=='ApplicationAdminConsoleUrl'].OutputValue" \
-  --output text 2>/dev/null || echo "")
-if [ -z "${POOLED_APP_CONSOLE_URL}" ]; then
-  echo "  Pooled App URL: (未作成、 第 1 tenant 作成後に SBT pipeline が pooled stack を初 create する)"
-else
-  echo "  Pooled App URL: ${POOLED_APP_CONSOLE_URL}"
-fi
-
-# 同 stack の CodeBuild プロジェクト名を AdminConsoleHostingStack に渡す
-# (provisioning ログ deep link 構築で使う)。SBT BashJobRunner が立てる project の
-# 名前は CFn output に直接無いので、tag フィルタで取得。
-PROVISIONING_CODEBUILD_PROJECT=$(aws codebuild list-projects --output json \
-  | jq -r '.projects[]' \
-  | grep -i 'provisioning' \
-  | head -n 1 || echo "")
-if [ -z "${PROVISIONING_CODEBUILD_PROJECT}" ]; then
-  echo "  Warning: provisioning CodeBuild project が見つからない (admin-console のログ link は無効化される)"
-  PROVISIONING_CODEBUILD_PROJECT="unknown"
-fi
-echo "  Provisioning CodeBuild Project: ${PROVISIONING_CODEBUILD_PROJECT}"
-
-# ADR-011 #590 Phase 1.A: AdminConsole Insight API URL を runtime-config に注入する。
-# Phase 1 で立てた tenkacloud-admin-console-insight stack の CFn output を取得。
-ADMIN_INSIGHT_API_URL=$(aws cloudformation describe-stacks \
-  --stack-name "tenkacloud-admin-console-insight" \
-  --query "Stacks[0].Outputs[?OutputKey=='AdminInsightApiUrl'].OutputValue" \
-  --output text 2>/dev/null || echo "")
-if [ -z "${ADMIN_INSIGHT_API_URL}" ]; then
-  echo "  Warning: AdminInsightApiUrl が解決できない (admin-console の集計 column は無効化される)"
-  ADMIN_INSIGHT_API_URL=""
-fi
-echo "  AdminInsight API URL: ${ADMIN_INSIGHT_API_URL}"
-
-# AdminConsoleHostingStack deploy: backend outputs を CDK_PARAM_* env に渡す
-# (stack が runtime-config.json に書いて S3 に配置する)
-cd "${TENKACLOUD_ROOT}/infrastructure"
-export CDK_PARAM_CONTROL_PLANE_API_URL="${API_URL}"
-export CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN="${COGNITO_DOMAIN}"
-export CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID="${CLIENT_ID}"
-export CDK_PARAM_POOLED_APP_CONSOLE_URL="${POOLED_APP_CONSOLE_URL}"
-export CDK_PARAM_PROVISIONING_CODEBUILD_PROJECT="${PROVISIONING_CODEBUILD_PROJECT}"
-export CDK_PARAM_AWS_REGION="${REGION}"
-export CDK_PARAM_AWS_ACCOUNT_ID="${ACCOUNT_ID}"
-export CDK_PARAM_ADMIN_INSIGHT_API_URL="${ADMIN_INSIGHT_API_URL}"
-bun cdk deploy tenkacloud-admin-console-hosting --require-approval never
-
-# ============================================================================
-# Phase 3: ControlPlaneStack + admin-console-insight 再 deploy
-#   - control-plane の Cognito callback / OAuth allow-list に CloudFront URL を追加
-#   - admin-console-insight の HTTP API CORS allow-list にも同 URL を追加 (#716)
-#     旧実装は control-plane のみ再 deploy しており、 admin-console-insight の CORS は
-#     Phase 1 時点の localhost-only のままで Provisioning Jobs page が "Failed to fetch"
-#     を吐いていた。
+# pooled stack (`tenkacloud-tenant-template-pooled`) は SBT pipeline (CodeBuild) で
+# create / update する設計のため install.sh からは deploy しない (Issue #1029 / PR-1028)。
+# runtime-config の pooledApplicationAdminConsoleUrl は初回 install では空文字 fallback、
+# 第 1 tenant 作成後の再 install で SBT が立てた pooled stack の URL が cross-stack ref で
+# 焼かれる。
 # ============================================================================
 echo ""
 echo "=============================================="
-echo "Phase 3: Update tenkacloud-control-plane + admin-console-insight with admin-console CloudFront URL"
+echo "Deploying all stacks (cdk deploy --all)"
 echo "=============================================="
-ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks --stack-name tenkacloud-admin-console-hosting --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" --output text)
-export CDK_PARAM_ADMIN_CONSOLE_ORIGIN="${ADMIN_CONSOLE_URL}"
-echo "  CloudFront URL: ${ADMIN_CONSOLE_URL}"
-# Issue #1053: 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` の env-var inject は廃止。
-# hosting を ProblemDeployBackendStack に移管したので、 Phase 1 完了時点で cross-stack ref
-# 経由で runtime-config.json に正しい S3 URL が焼かれる (= Phase 3 の dance が不要)。
-bun cdk deploy tenkacloud-control-plane tenkacloud-admin-console-insight --require-approval never
+bun cdk deploy --all \
+  --exclusively \
+  --require-approval never \
+  --concurrency 4
 
 # ============================================================================
 # 完了
 # ============================================================================
-# pooled stack の application-admin-console URL を取得 (basic / standard / premium
-# tenant が共有する 1 console)。silo (PLATINUM) tenant の URL は admin-console の
-# テナント一覧から開けるので install.sh 側では出さない。
+ADMIN_CONSOLE_URL=$(aws cloudformation describe-stacks \
+  --stack-name "tenkacloud-admin-console-hosting" \
+  --query "Stacks[0].Outputs[?starts_with(OutputKey,'AdminConsoleUrl')].OutputValue" \
+  --output text 2>/dev/null || echo "(missing)")
+
 POOLED_APP_CONSOLE_URL=$(aws cloudformation describe-stacks \
   --stack-name "tenkacloud-tenant-template-pooled" \
   --query "Stacks[0].Outputs[?OutputKey=='ApplicationAdminConsoleUrl'].OutputValue" \
@@ -208,5 +94,5 @@ echo ""
 echo "1. SystemAdmin 初回招待メール (${CDK_PARAM_SYSTEM_ADMIN_EMAIL}) が届いてるはずなので開く"
 echo "2. ${ADMIN_CONSOLE_URL} にブラウザで access"
 echo "3. ログイン → テナント作成画面で tenant 作成 → 招待メールが飛ぶ"
-echo "4. テナント一覧の「Application Console を開く」ボタンから per-tenant URL を開く"
-echo "   (PLATINUM tier のみ、pooled tier は上記 pooled URL を直接共有)"
+echo "4. テナント一覧の「Application Console を開く」 ボタンから per-tenant URL を開く"
+echo "   (PLATINUM tier のみ、 pooled tier は上記 pooled URL を直接共有)"


### PR DESCRIPTION
## Summary

旧 install.sh は Phase 1 (backend) → Phase 2 (admin-console-hosting) → Phase 3 (control-plane 再 deploy) の 3 段構造。 admin-console URL の chicken-and-egg を `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env-var dance で解いていた。 本 PR で次の構造改造により **`bun cdk deploy --all` 1 発** に統合:

1. **admin-console-hosting**: backend URL 依存を切る。 CSP は region wildcard (= `https://*.execute-api.<region>.amazonaws.com` / `*.amazoncognito.com`)。 依存なしで最初に立てる。 `siteBucket` / `distribution` を public readonly で expose
2. **新規 `admin-console-runtime-config-stack`**: SiteBucket + Distribution + backend URL を cross-stack ref で集めて `runtime-config.json` を S3 に PUT + CloudFront invalidation
3. **control-plane**: `adminConsoleOrigin?: string` prop を追加、 旧 `process.env` 直読みを撤廃。 `cognitoDomain` を `cognitoAuth.node.findChild("UserPoolDomain").baseUrl()` で public readonly export
4. **tenant-template**: `applicationAdminConsoleUrl` を public readonly で expose
5. **wire.ts**: stack 生成順を admin-console-hosting → control-plane / 他 backend → admin-console-runtime-config に reshape
6. **app-config**: `adminConsoleOriginForCors` / `adminConsoleHostingInputs` / `buildHostingInputs` を撤去
7. **install.sh**: Phase 1/2/3 を `bun cdk deploy --all` 1 発に統合

Closes #1031

## CSP wildcard 化の trade-off

| 観点 | 旧 (= specific allow) | 新 (= wildcard) |
|---|---|---|
| connect-src | `<execute-api-id>.execute-api.<region>...` | `https://*.execute-api.<region>.amazonaws.com` |
| 攻撃面 | account 内固有 API のみ | region 内全 API GW |
| 必要な攻撃条件 | XSS 注入 + 当該 API への奪取 | XSS 注入 **+** 同 account に攻撃 API 所持 |

XSS 注入が前提条件で、 さらに 「同 account に攻撃用 API GW が存在」 必要 — 攻撃が成立するハードルが高いため、 hosting 単独 deploy 可能性を取って良い trade と判断。 厳格 CSP に戻す follow-up が必要なら `AwsCustomResource` で Cognito update する案 (= 別 issue) で対応可能。

## Regression 分析

- **既存 SaaS deploy の cdk diff**:
  - `tenkacloud-admin-console-hosting` stack: props 変更 (= 旧 URL 系 props 削除) と RuntimeConfigDeployment の削除 → CloudFront Distribution の logical ID は不変 → CloudFront domain も不変 → 既存 admin-console URL に影響なし
  - 新 stack `tenkacloud-admin-console-runtime-config` の CREATE
  - `tenkacloud-control-plane`: `adminConsoleOrigin` cross-stack ref への置き換えで CORS / callback URL がより安定 (= 旧 env 未注入時の placeholder 問題が消える)
- **CSP wildcard 化**: 上記 trade-off で受容可能と判断。 admin-console のリクエスト先 (Control Plane API / Cognito / AdminInsight) は wildcard 内に収まる
- **`CDK_PARAM_ADMIN_CONSOLE_ORIGIN` 等の env-var**: 完全廃止。 各 script (install.sh, update-tenant.sh, provision-tenant.sh) に残っていないことを test で pin
- **install.sh の 3-phase**: `cdk deploy --all` で CDK が cross-stack 依存解決して順に立てる
- **既存 PR-1028 + Issue #1029**: 互換 (= pooled stack は install.sh から deploy しない方針を維持)
- **既存 PR-1053 (= competitor-bootstrap.yaml 移管)**: 互換 (= runtime-config が cross-stack で URL を引く)
- **Lite mode (= `make deploy`)**: 影響なし (= wire.ts は Lite と独立、 admin-console-hosting は SaaS 専用)

## 物理影響

| Resource | Mode | Change |
|---|---|---|
| `AdminConsoleHostingStack` 内 `AWS::S3::Bucket` (= RuntimeConfigDeployment が書く側) | SaaS | NO-OP (= SiteBucket は同 logical ID 不変) |
| `AdminConsoleHostingStack` 内 BucketDeployment (RuntimeConfig) | SaaS | DELETE (= 新 stack に移管) |
| `AdminConsoleHostingStack` 内 BucketDeployment (SiteDeployment / dist) | SaaS | NO-OP |
| `AWS::CloudFront::Distribution` | SaaS | UPDATE (= ResponseHeadersPolicy 内 CSP 文字列のみ変化) |
| 新規 `AdminConsoleRuntimeConfigStack` | SaaS | CREATE |
| `AdminConsoleRuntimeConfigStack` 内 BucketDeployment (RuntimeConfig) | SaaS | CREATE (cross-stack で SiteBucket / Distribution を参照) |
| `ControlPlaneStack`: Cognito UserPoolClient callback URL | SaaS | UPDATE (cross-stack ref で CloudFront URL 注入、 旧 env-var 経由と同じ最終値) |
| Lite mode | Lite | NO-OP (= AdminConsoleHostingStack を Lite は deploy しない) |

## Test plan

- [x] `infrastructure/test/admin-console-hosting.test.ts`: CSP wildcard を pin、 RuntimeConfigDeployment が本 stack 不在を pin
- [x] `infrastructure/test/install-script.test.ts`: `cdk deploy --all` を pin、 旧 Phase 3 env injection 廃止を pin
- [x] `infrastructure/test/app-config/resolve.test.ts`: `adminConsoleHostingInputs` / `adminConsoleOriginForCors` field が AppConfig から消えている pin
- [x] `make harness` clean
- [x] `make before-commit` clean (lint / typecheck / 1250+ vitest cases / cdk synth)
- [ ] **deploy 後の手動確認** (= user): `make deploy-saas` で初回 install が `cdk deploy --all` 1 発で完走、 admin-console URL が deploy 完了時点で表示 + Cognito sign-in が成功
- [ ] **deploy 後の手動確認**: 既存 SaaS deploy 環境で `make deploy-saas` を再実行、 CloudFront URL 不変 + 既存 sign-in 経路維持を確認

## スコープ外

- 厳格 CSP に戻すための AwsCustomResource 経由 Cognito update → follow-up issue
- pooled stack の SBT pipeline 一本化 (Issue #1029 既処理)
- Lite mode の deploy 統合 (= Lite は元から 1 発)

🤖 Generated with [Claude Code](https://claude.com/claude-code)