### PR TITLE
fix(#1065): ExternalId rotate 後の Launch Stack を抑止 + Update bootstrap 経路を全廃

### DIFF
--- a/apps/application-admin-console/src/lib/competitor-bootstrap.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.ts
@@ -79,34 +79,12 @@ export function buildLaunchStackUrl(input: LaunchStackUrlInput): string {
 }
 
 /**
- * #706: 既存 `tenkacloud-competitor-bootstrap` stack を **同 template の最新版** で update する
- * deeplink を組み立てる。 PR-694 のような IAM 追加を反映するため operator が競技者に共有する用途。
- *
- * AWS CFn console の Update Stack 経路は `#/stacks/update/template` で、 `stackName` 指定 +
- * `templateURL` 指定で 「Replace current template」 で update する。 既存 Parameter 値は競技者の
- * CFn console 側で **Use existing value** が default になるため operator が externalId 等の
- * 秘密値を再送する必要は無い。 SSO ログイン後 → 確認画面で diff を見せた上で 1 click で update できる。
- *
- * `region` は operator がレコードから渡す (= 別 region に bootstrap が無い前提)。
- */
-export interface UpdateStackUrlInput {
-  readonly region?: string;
-  /** #718: CFn TemplateURL 用の S3 URL。 undefined / 空文字なら GitHub raw fallback。 */
-  readonly templateUrl?: string;
-}
-
-export function buildUpdateStackUrl(input: UpdateStackUrlInput = {}): string {
-  const region = input.region ?? DEFAULT_REGION;
-  const params = new URLSearchParams({
-    stackName: DEFAULT_STACK_NAME,
-    templateURL: resolveTemplateUrl(input.templateUrl),
-  });
-  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/update/template?${params.toString()}`;
-}
-
-/**
  * 「すべてコピー」 button が clipboard に書き込む 1 つの整形済 string。
  * 競技者の作業手順 (= Slack / メールでそのまま送れる) を含む。
+ *
+ * 旧 `buildUpdateStackUrl` / `buildUpdatePayload` (= bootstrap stack の Update Stack deeplink 生成)
+ * は仕様簡素化のため廃止 (= ExternalId rotate は新値を operator が共有し、 競技者が CFn console
+ * で Parameter を手動更新する経路に統一)。
  */
 export function buildShareablePayload(input: LaunchStackUrlInput): string {
   return [
@@ -123,30 +101,5 @@ export function buildShareablePayload(input: LaunchStackUrlInput): string {
     `   ${buildLaunchStackUrl(input)}`,
     "",
     "完了後 operator にこの mail / msg を返信、 operator が「Verify」 で確認します。",
-  ].join("\n");
-}
-
-/**
- * #706: 既存 bootstrap stack を最新 template で update してもらう案内 payload。
- * PR-694 (Lambda IAM 追加) のような新 IAM を反映する用途。 競技者に Slack / メールで送る。
- *
- * 既存 stack の Parameter 値は CFn console 側で「Use existing value」 が default になるので、
- * 秘密値 (= ExternalId) を再送する必要は無い (= 公開 URL のみ含める)。
- */
-export function buildUpdatePayload(input: UpdateStackUrlInput = {}): string {
-  return [
-    "TenkaCloud Competitor Bootstrap — 既存 stack の update のお願い",
-    "",
-    "deploy chain に新しい IAM (例: Lambda Function 操作) が追加されたため、 既に deploy 済の",
-    "`tenkacloud-competitor-bootstrap` stack を最新 template に update してください。",
-    "",
-    "update 手順 (= 1 click):",
-    "1. 競技者 AWS account にログイン (= 既存と同じ)",
-    "2. 下記 Update Stack リンクを開く (= 既存 stack の Replace current template 画面に直行):",
-    `   ${buildUpdateStackUrl(input)}`,
-    "3. Parameter 画面は「Use existing value」 のまま (= 秘密値 ExternalId は既存のまま再利用)。",
-    "4. 確認画面で diff (= 追加 IAM Statement 等) を確認して Update。",
-    "",
-    "完了後 operator にこの mail / msg を返信、 operator が「Verify」 で再確認します。",
   ].join("\n");
 }

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -30,8 +30,6 @@ import { evaluateRotateButtonGuard } from "../lib/competitor-account-actions";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
-  buildUpdatePayload,
-  buildUpdateStackUrl,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
   isBootstrapUrlMissing,
 } from "../lib/competitor-bootstrap";
@@ -60,11 +58,15 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
   const [verifyInFlight, setVerifyInFlight] = useState<string | null>(null);
   const [deleteInFlight, setDeleteInFlight] = useState(false);
   const [rotateInFlight, setRotateInFlight] = useState(false);
+  // 旧 issue: rotate 後の Launch Stack click が `AlreadyExistsException` で fail していた
+  // (= bootstrap stack は initial create で既に存在、 rotate は Parameter 変更のみ)。 mode で
+  // 区別して rotate 時は Launch Stack を隠し、 「競技者に新 ExternalId を渡して Parameter
+  // を手動更新してもらう」 経路に倒す。 `BootstrapUpdateModal` 経路は廃止 (= 仕様簡素化)。
   const [showSecret, setShowSecret] = useState<
-    CreateCompetitorAccountResponse | RotateExternalIdResponse | null
+    | { mode: "create"; details: CreateCompetitorAccountResponse }
+    | { mode: "rotate"; details: RotateExternalIdResponse }
+    | null
   >(null);
-  // #706: 既存 bootstrap stack の update 案内 modal (= row の「Update bootstrap」 button から開く)。
-  const [updateTarget, setUpdateTarget] = useState<CompetitorAccountSummary | null>(null);
 
   const reload = useCallback(async () => {
     if (!apiClient) return;
@@ -117,7 +119,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
     try {
       const res = await rotateExternalId(apiClient, rotateTarget.awsAccountId);
       setRotateTarget(null);
-      setShowSecret(res);
+      setShowSecret({ mode: "rotate", details: res });
       await reload();
     } catch (err) {
       setError(toFriendlyError(err));
@@ -202,14 +204,6 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
                 </span>
               );
             })()}
-            <Button
-              variant="normal"
-              iconName="upload"
-              onClick={() => setUpdateTarget(item)}
-              data-testid={`update-bootstrap-${item.awsAccountId}`}
-            >
-              Update bootstrap
-            </Button>
             <Button variant="link" onClick={() => setDeleteTarget(item)}>
               削除
             </Button>
@@ -272,13 +266,13 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         onDismiss={() => setAddModalVisible(false)}
         onSuccess={(res) => {
           setAddModalVisible(false);
-          setShowSecret(res);
+          setShowSecret({ mode: "create", details: res });
           void reload();
         }}
       />
 
       <SecretRevealModal
-        details={showSecret}
+        secret={showSecret}
         onDismiss={() => setShowSecret(null)}
         templateUrl={config.competitorBootstrapTemplateUrl}
       />
@@ -308,12 +302,6 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
           鍵漏洩リスク削減)。
         </p>
       </Modal>
-
-      <BootstrapUpdateModal
-        target={updateTarget}
-        onDismiss={() => setUpdateTarget(null)}
-        templateUrl={config.competitorBootstrapTemplateUrl}
-      />
 
       <Modal
         visible={rotateTarget !== null}
@@ -497,21 +485,29 @@ function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountMo
 }
 
 interface SecretRevealModalProps {
-  details: CreateCompetitorAccountResponse | RotateExternalIdResponse | null;
+  secret:
+    | { mode: "create"; details: CreateCompetitorAccountResponse }
+    | { mode: "rotate"; details: RotateExternalIdResponse }
+    | null;
   onDismiss: () => void;
-  /** #718: runtime-config 由来の public S3 URL (= CFn TemplateURL に渡す)。未注入なら GitHub raw fallback。 */
+  /** runtime-config 由来の public S3 URL (= CFn TemplateURL に渡す)。 未注入なら fallback。 */
   templateUrl?: string;
 }
 
-function SecretRevealModal({ details, onDismiss, templateUrl }: SecretRevealModalProps) {
+/**
+ * 競技者と共有する ExternalId 等の secret を提示する modal。
+ *
+ * mode="create" (= initial bootstrap): Launch Stack (= Quick Create deeplink) で 1 click deploy 可能。
+ *   bootstrap stack 不在なので Quick Create が正常に通る。
+ * mode="rotate" (= ExternalId rotate): Launch Stack は出さない。 bootstrap stack は既に存在するため
+ *   Quick Create は AlreadyExistsException で fail する。 operator は新 ExternalId を競技者に共有し、
+ *   競技者側で CloudFormation console から `tenkacloud-competitor-bootstrap` stack の Parameter を手動
+ *   更新する経路を取る (= 仕様簡素化、 旧 BootstrapUpdateModal / Update Stack deeplink 経路は廃止)。
+ */
+function SecretRevealModal({ secret, onDismiss, templateUrl }: SecretRevealModalProps) {
   const [allCopied, setAllCopied] = useState(false);
-  if (!details) return null;
-  const launchStackUrl = buildLaunchStackUrl({
-    tenkaCloudAccountId: details.tenkaCloudAccountId,
-    externalId: details.externalId,
-    competitorRoleName: details.competitorRoleName,
-    templateUrl,
-  });
+  if (!secret) return null;
+  const { mode, details } = secret;
   const effectiveTemplateUrl =
     templateUrl && templateUrl.length > 0 ? templateUrl : COMPETITOR_BOOTSTRAP_TEMPLATE_URL;
   const payload = buildShareablePayload({
@@ -529,7 +525,7 @@ function SecretRevealModal({ details, onDismiss, templateUrl }: SecretRevealModa
     <Modal
       visible
       onDismiss={onDismiss}
-      header="競技者に共有する情報"
+      header={mode === "create" ? "競技者に共有する情報" : "新 ExternalId を共有"}
       footer={
         <Box float="right">
           <Button variant="primary" onClick={onDismiss}>
@@ -540,41 +536,61 @@ function SecretRevealModal({ details, onDismiss, templateUrl }: SecretRevealModa
     >
       <SpaceBetween size="m">
         <Alert type="warning" header="この画面でのみ ExternalId を確認できます">
-          ExternalId は SecureString として保存されており、閉じると再表示できません。
+          ExternalId は SecureString として保存されており、 閉じると再表示できません。
           競技者に渡すコピーは <strong>今</strong> 取ってください。
         </Alert>
+        {mode === "create" ? (
+          <SpaceBetween size="s">
+            <Header variant="h3">推奨: Launch Stack 1 click deploy</Header>
+            <Button
+              variant="primary"
+              href={buildLaunchStackUrl({
+                tenkaCloudAccountId: details.tenkaCloudAccountId,
+                externalId: details.externalId,
+                competitorRoleName: details.competitorRoleName,
+                templateUrl,
+              })}
+              target="_blank"
+              iconName="external"
+              iconAlign="right"
+            >
+              Launch Stack (Quick-create deeplink)
+            </Button>
+            <Box variant="small" color="text-status-inactive">
+              CFn create-stack 画面に直行し、 Parameter 3 値は pre-fill 済です。
+            </Box>
+          </SpaceBetween>
+        ) : (
+          <Alert type="info" header="競技者側で Parameter を手動更新します">
+            bootstrap stack は既に存在するため Quick Create は使えません (= AlreadyExistsException
+            になる)。 競技者の AWS console で <code>tenkacloud-competitor-bootstrap</code> stack
+            を開き、 「Update」 → 「Use current template」 → Parameter <code>ExternalId</code>{" "}
+            に下記の新値を入力 → 「Update stack」 してもらう経路で進めてください。
+          </Alert>
+        )}
         <SpaceBetween size="s">
-          <Header variant="h3">推奨: Launch Stack 1 click deploy</Header>
-          <Button
-            variant="primary"
-            href={launchStackUrl}
-            target="_blank"
-            iconName="external"
-            iconAlign="right"
-          >
-            Launch Stack (Quick-create deeplink)
-          </Button>
-          <Box variant="small" color="text-status-inactive">
-            CFn create-stack 画面に直行し、Parameter 3 値は pre-fill 済です。
-          </Box>
-        </SpaceBetween>
-        <SpaceBetween size="s">
-          <Header variant="h3">競技者に共有する情報</Header>
+          <Header variant="h3">{mode === "create" ? "競技者に共有する情報" : "コピー用"}</Header>
           <Button
             iconName={allCopied ? "status-positive" : "copy"}
             onClick={() => void onCopyAll()}
           >
-            {allCopied ? "コピーしました" : "すべて (3 値 + 手順 + Launch Stack URL) をコピー"}
+            {allCopied
+              ? "コピーしました"
+              : mode === "create"
+                ? "すべて (3 値 + 手順 + Launch Stack URL) をコピー"
+                : "新 ExternalId + 手順をコピー"}
           </Button>
         </SpaceBetween>
-        <div>
-          <Box variant="awsui-key-label">次のステップ — 競技者向け</Box>
-          <ol>
-            <li>Launch Stack を開いて bootstrap stack を作成する</li>
-            <li>deploy 完了後、 この画面の「Verify」 button で接続確認する</li>
-          </ol>
-        </div>
-        <ExpandableSection headerText="手動 deploy の詳細" variant="container">
+        {mode === "create" && (
+          <div>
+            <Box variant="awsui-key-label">次のステップ — 競技者向け</Box>
+            <ol>
+              <li>Launch Stack を開いて bootstrap stack を作成する</li>
+              <li>deploy 完了後、 この画面の「Verify」 button で接続確認する</li>
+            </ol>
+          </div>
+        )}
+        <ExpandableSection headerText="手動 deploy / update の詳細" variant="container">
           <SpaceBetween size="m">
             <ColumnLayout columns={1} variant="text-grid">
               <div>
@@ -606,88 +622,12 @@ function SecretRevealModal({ details, onDismiss, templateUrl }: SecretRevealModa
               </div>
             </ColumnLayout>
             <Box variant="small" color="text-status-inactive">
-              上記 3 値を Parameter として CloudFormation create-stack でも deploy できます。
+              {mode === "create"
+                ? "上記 3 値を Parameter として CloudFormation create-stack でも deploy できます。"
+                : "既存 stack の Parameter ExternalId だけを上記新値に更新してもらえば OK です (= 他の Parameter は変更不要)。"}
             </Box>
           </SpaceBetween>
         </ExpandableSection>
-      </SpaceBetween>
-    </Modal>
-  );
-}
-
-interface BootstrapUpdateModalProps {
-  target: CompetitorAccountSummary | null;
-  onDismiss: () => void;
-  /** #718: runtime-config 由来の public S3 URL (= CFn TemplateURL に渡す)。未注入なら GitHub raw fallback。 */
-  templateUrl?: string;
-}
-
-/**
- * #706: 既存 bootstrap stack の update 案内 modal。
- *
- * PR-694 (Lambda IAM 追加) のように deploy chain 側で IAM が増えると、 競技者の
- * `tenkacloud-competitor-bootstrap` stack を最新 template で update してもらわないと
- * 「lambda:GetFunction AccessDenied」 等で deploy が失敗する。
- *
- * 本 modal は秘密値 (ExternalId) を含まないので、 既存 row から呼べる (= row には
- * externalId が無い)。 競技者の CFn console で Parameter は default で existing value 再利用される。
- */
-function BootstrapUpdateModal({ target, onDismiss, templateUrl }: BootstrapUpdateModalProps) {
-  const [copied, setCopied] = useState(false);
-  if (!target) return null;
-  const updateUrl = buildUpdateStackUrl({ region: target.region, templateUrl });
-  const payload = buildUpdatePayload({ region: target.region, templateUrl });
-  const onCopy = async () => {
-    await navigator.clipboard.writeText(payload);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-  return (
-    <Modal
-      visible
-      onDismiss={onDismiss}
-      header="bootstrap stack の update を依頼"
-      footer={
-        <Box float="right">
-          <Button variant="primary" onClick={onDismiss}>
-            閉じる
-          </Button>
-        </Box>
-      }
-    >
-      <SpaceBetween size="m">
-        <Alert type="info" header="新しい IAM 反映には bootstrap stack の update が必要です">
-          deploy chain 側で IAM (例: Lambda 操作権限) が追加された場合、 competitor 側で
-          <code>tenkacloud-competitor-bootstrap</code> stack を最新 template に update して
-          もらう必要があります。 ExternalId 等の秘密値は競技者の既存 stack で再利用されるため、
-          operator から再送する必要はありません。
-        </Alert>
-        <Box>
-          <Button
-            variant="primary"
-            iconName={copied ? "status-positive" : "copy"}
-            onClick={() => void onCopy()}
-            data-testid="copy-update-payload"
-          >
-            {copied ? "コピーしました" : "update 依頼テキストをコピー (Slack / メール用)"}
-          </Button>
-        </Box>
-        <div>
-          <Box variant="awsui-key-label">Update Stack URL (= 競技者がワンクリックで開く)</Box>
-          <CopyableField value={updateUrl} ariaLabel="Copy Update Stack URL" />
-        </div>
-        <div>
-          <Box variant="awsui-key-label">最新 template (= レビュー用 raw URL)</Box>
-          <CopyableField
-            value={COMPETITOR_BOOTSTRAP_TEMPLATE_URL}
-            ariaLabel="Copy bootstrap template URL"
-          />
-        </div>
-        <Box variant="small" color="text-status-inactive">
-          競技者は SSO ログイン後、 Replace current template 画面に直行します。 Parameter 値は 「Use
-          existing value」 (= default) のままで OK。 confirm 画面で IAM diff (例: lambda:GetFunction
-          追加) を確認して Update。
-        </Box>
       </SpaceBetween>
     </Modal>
   );

--- a/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   buildLaunchStackUrl,
   buildShareablePayload,
-  buildUpdatePayload,
-  buildUpdateStackUrl,
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
 } from "../../src/lib/competitor-bootstrap";
 
@@ -73,48 +71,5 @@ describe("COMPETITOR_BOOTSTRAP_TEMPLATE_URL", () => {
     expect(COMPETITOR_BOOTSTRAP_TEMPLATE_URL).toMatch(
       /^https:\/\/raw\.githubusercontent\.com\/.+\/competitor-bootstrap\.yaml$/,
     );
-  });
-});
-
-describe("buildUpdateStackUrl (#706)", () => {
-  it("Update Stack 経路 (#/stacks/update/template) を指すべき", () => {
-    const url = buildUpdateStackUrl();
-    expect(url).toContain("#/stacks/update/template");
-    expect(url).toContain("https://ap-northeast-1.console.aws.amazon.com/cloudformation/home");
-  });
-
-  it("templateURL + stackName を pre-fill し、 秘密値 Parameter は含まないべき (= existing 値再利用)", () => {
-    const decoded = decodeURIComponent(buildUpdateStackUrl());
-    expect(decoded).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
-    expect(decoded).toContain("stackName=tenkacloud-competitor-bootstrap");
-    // 秘密値 (ExternalId) を URL に含めない、 既存 stack の Parameter を Use existing で再利用する
-    expect(decoded).not.toContain("param_ExternalId");
-    expect(decoded).not.toContain("param_TenkaCloudAccountId");
-    expect(decoded).not.toContain("param_RoleName");
-  });
-
-  it("region を上書きできるべき", () => {
-    const url = buildUpdateStackUrl({ region: "us-east-1" });
-    expect(url).toContain("https://us-east-1.console.aws.amazon.com/");
-    expect(url).toContain("region=us-east-1");
-  });
-});
-
-describe("buildUpdatePayload (#706)", () => {
-  it("Update Stack URL と「update のお願い」 文言を含むべき", () => {
-    const payload = buildUpdatePayload();
-    expect(payload).toContain(buildUpdateStackUrl());
-    expect(payload).toContain("update");
-    expect(payload).toContain("既存");
-  });
-
-  it("Quick-create URL (= 新規 create 経路) は含まれないべき (= update 専用)", () => {
-    expect(buildUpdatePayload()).not.toContain("quickcreate");
-  });
-
-  it("秘密値 (ExternalId / TenkaCloudAccountId) は含まないべき (= 公開 URL のみ)", () => {
-    const payload = buildUpdatePayload();
-    expect(payload).not.toContain("ExternalId:");
-    expect(payload).not.toContain("123456789012");
   });
 });

--- a/apps/application-admin-console/test/pages/CompetitorAccounts.rotate.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.rotate.test.tsx
@@ -114,37 +114,26 @@ describe("CompetitorAccountsPage rotate flow (Issue #596 / Phase 3.1)", () => {
     await waitFor(() => expect(mocks.listCompetitorAccounts).toHaveBeenCalledTimes(2));
   });
 
-  it("Reveal modal は Launch Stack を primary action として先頭に表示すべき", async () => {
+  it("Reveal modal (rotate mode) は Launch Stack を表示しないべき (= bootstrap stack 既存で AlreadyExistsException 防止)", async () => {
     await rotateAndRevealExternalId();
 
-    const launchStackText = await screen.findByText("Launch Stack (Quick-create deeplink)");
-    const launchStackLink = launchStackText.closest("a");
-    expect(launchStackLink).toBeInTheDocument();
+    // rotate mode では Launch Stack button は出さない (bootstrap stack は既に存在するため)。
+    expect(screen.queryByText("Launch Stack (Quick-create deeplink)")).not.toBeInTheDocument();
 
-    const launchHref = launchStackLink?.getAttribute("href") ?? "";
-    expect(launchHref).toContain(
-      "https://ap-northeast-1.console.aws.amazon.com/cloudformation/home",
-    );
-    expect(launchHref).toContain("#/stacks/quickcreate");
-    expect(decodeURIComponent(launchHref)).toContain("param_TenkaCloudAccountId=111111111111");
-    expect(decodeURIComponent(launchHref)).toContain("param_ExternalId=new-rotated-secret-value");
-    expect(decodeURIComponent(launchHref)).toContain(
-      "param_RoleName=TenkaCloud-CompetitorDeploy-Role",
-    );
+    // 代わりに 「競技者側で Parameter を手動更新」 の Alert を表示する
+    expect(screen.getByText(/競技者側で Parameter を手動更新します/)).toBeInTheDocument();
 
-    const copyAllButton = screen.getByRole("button", {
-      name: /すべて \(3 値 \+ 手順 \+ Launch Stack URL\) をコピー/,
+    const copyButton = screen.getByRole("button", {
+      name: /新 ExternalId \+ 手順をコピー/,
     });
-    expect(
-      launchStackText.compareDocumentPosition(copyAllButton) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+    expect(copyButton).toBeInTheDocument();
   });
 
-  it("Reveal modal は手動 deploy の 3 値を折りたたみ section に表示すべき", async () => {
+  it("Reveal modal は手動 deploy / update の 3 値を折りたたみ section に表示すべき", async () => {
     await rotateAndRevealExternalId();
 
     const manualDeployToggle = await screen.findByRole("button", {
-      name: /手動 deploy の詳細/,
+      name: /手動 deploy \/ update の詳細/,
     });
     expect(manualDeployToggle).toHaveAttribute("aria-expanded", "false");
 


### PR DESCRIPTION
## Summary

- \`SecretRevealModal\` に \`mode: \"create\" | \"rotate\"\` を導入。 **rotate mode では Launch Stack button を非表示**にし、 「競技者側で Parameter を手動更新します」 の案内 Alert + copy 経路のみを表示。 bootstrap stack 既存による \`AlreadyExistsException\` を回避
- row level の **「Update bootstrap」 button を削除**
- \`BootstrapUpdateModal\` component を削除
- \`lib/competitor-bootstrap.ts\` から \`buildUpdateStackUrl\` / \`buildUpdatePayload\` / \`UpdateStackUrlInput\` を削除 (= dead code)
- 関連 test 修正 (rotate flow + Update bootstrap)

Closes #1065

## なぜ Update bootstrap 経路ごと廃止か

旧 PR-#706 で導入された Update Stack deeplink は 「deploy chain に IAM 追加があったとき bootstrap stack を最新 template で update してもらう」 用途だった。 ただし:

- ExternalId rotate も同じ 「Parameter 値更新」 の操作。 別 UI 経路を持つ理由がない
- 競技者側の CFn console は手動 Update が直感的 (= modal で操作手順を案内するだけで十分)
- 「Update bootstrap」 row button は initial state の操作が verified=false / rotate と混在し、 認知負荷が高い

割り切って **「rotate も新 IAM 反映も、 競技者が CFn console から Parameter / template を手動更新」** に統一する方が仕様がシンプル。

## Regression 分析

- **既存 create flow (= 初回 bootstrap deploy)**: 不変。 Launch Stack を primary action として残す
- **既存 rotate flow**: Launch Stack click → \`AlreadyExistsException\` の壊れた経路を撤去 → 手動 update 案内に置換
- **既存 「Update bootstrap」 button の利用**: PR-#706 後の運用で実利用があったなら影響あり。 ただし button click 後の modal は壊れていた (= 旧 \`buildUpdateStackUrl\` が空文字 fallback で動作不安定だった可能性)。 仕様簡素化を優先
- **既存 test**: 旧 「Launch Stack を primary action として表示すべき」 / 「手動 deploy の詳細」 を rotate mode 用に書き換え

## 物理影響

- frontend bundle のみ変更
- CFn / IAM / DDB / Lambda / S3: 0 件 (= NO-OP)

## Test plan

- [x] \`apps/application-admin-console/test/pages/CompetitorAccounts.rotate.test.tsx\` 5 ケース green (= Launch Stack 非表示 / 手動更新 Alert / copy button / ExpandableSection / rotation age)
- [x] \`apps/application-admin-console/test/lib/competitor-bootstrap.test.ts\` 8 ケース green (= Launch / Shareable / fallback URL)
- [x] \`make harness\` clean
- [x] \`make before-commit\` clean (lint / typecheck / 1245+ vitest cases / cdk synth)
- [ ] **deploy 後の手動確認** (= user): Competitor Accounts で verified=true な row に対し Rotate ExternalId 実行 → modal で Launch Stack button が出ないこと、 「競技者側で Parameter を手動更新します」 Alert が表示されること、 新 ExternalId の値が copy 可能であること

## スコープ外

- SAML SSO 設定の廃止 → #1066
- Event 作成後 deploy modal → #1067
- Deploy status reload button → #1068
- hello-world ParticipantViewerRole に SSM 権限追加 → #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined competitor account credential management by consolidating the credential reveal workflow into a single unified modal experience.
  * Enhanced modal interface to display context-specific guidance and instructions based on credential operation type (creation vs. rotation).
  * Simplified and clarified manual deployment documentation with operation-specific procedural details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->