### PR TITLE
feat(#1068): EventDetail の Deploy 進捗に手動 reload button を追加

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -191,6 +191,10 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
 
   const eventIdValid = !!eventId && EVENT_ID_RE.test(eventId);
 
+  // Issue #1068: deploy status の手動 reload button 用 in-flight flag。 自動 polling が
+  // 止まる (= tab background / network 一時切断 / backend hang) ケースの fallback 経路。
+  const [manualRefreshInFlight, setManualRefreshInFlight] = useState(false);
+
   const refresh = useCallback(async () => {
     if (!apiClient || !eventIdValid || !eventId) return;
     try {
@@ -203,6 +207,16 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       setError(err instanceof Error ? err.message : String(err));
     }
   }, [apiClient, eventId, eventIdValid]);
+
+  const manualRefresh = useCallback(async () => {
+    if (manualRefreshInFlight) return;
+    setManualRefreshInFlight(true);
+    try {
+      await refresh();
+    } finally {
+      setManualRefreshInFlight(false);
+    }
+  }, [manualRefreshInFlight, refresh]);
 
   useEffect(() => {
     void refresh();
@@ -671,6 +685,18 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             <Header
               variant="h2"
               description={`${totalDeployCount} 件中 完了 ${completeCount} / 進行中 ${inFlightCount}${failedCount > 0 ? ` / 失敗 ${failedCount}` : ""}`}
+              actions={
+                // Issue #1068: 自動 polling が止まった時の fallback として手動 reload を提供。
+                <Button
+                  iconName="refresh"
+                  loading={manualRefreshInFlight}
+                  onClick={() => void manualRefresh()}
+                  ariaLabel="Deploy status を再読み込み"
+                  data-testid="deploy-status-reload"
+                >
+                  再読み込み
+                </Button>
+              }
             >
               Deploy 進捗
             </Header>


### PR DESCRIPTION
## Summary

- Deploy 進捗 section header に **手動 reload button** を追加 (= 自動 polling 停止時の fallback)
- click で既存 \`refresh\` callback を再実行、 spinner / disable 制御
- 自動 polling 経路は不変

Closes #1068

## ユースケース

自動 polling が止まるケース:
- ブラウザ tab を background にして戻ったとき (= throttling で polling delay)
- 一時的な network 切断後 polling が再開しない
- backend が長時間 IN_PROGRESS のまま (= reload で 確認したい)

## 物理影響

- frontend のみ、 既存 API 経路を再呼び出しするだけ。 CFn / IAM / DDB / Lambda 0 件

## Test plan

- [x] \`make harness\` clean
- [x] \`make before-commit\` clean
- [ ] **手動確認** (= user): EventDetail で Deploy 進捗 section header の 「再読み込み」 button click → spinner 表示 → status が latest に更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)