### PR TITLE
feat(#1071): EventDetail にチームランキング table を追加

### DIFF
--- a/apps/application-admin-console/src/components/TeamRankingPanel.tsx
+++ b/apps/application-admin-console/src/components/TeamRankingPanel.tsx
@@ -1,0 +1,116 @@
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Table from "@cloudscape-design/components/table";
+import { useMemo } from "react";
+import type { TeamScoreEvents } from "../api/events-client";
+
+/**
+ * Issue #1071: EventDetail 用チームランキング table。
+ *
+ * `scoreEventsByTeam` の events[] を team 毎に合計し、 累計 score 降順で sort して順位を出す。
+ * 同点は最終 update が早い方を上位 (= 早く到達した方が有利、 一般的な競技 tie-break)。
+ *
+ * 既存 \`TeamScoreEventsPanel\` (= 時系列 chart) と同 data source。 backend 追加なし。
+ * polling で自動更新される。
+ */
+
+interface RankingRow {
+  rank: number;
+  teamId: string;
+  teamName: string;
+  totalScore: number;
+  lastUpdateMs: number | undefined;
+}
+
+export function computeRanking(teams: readonly TeamScoreEvents[]): readonly RankingRow[] {
+  const aggregated = teams.map((t) => {
+    const total = t.events.reduce((acc, e) => acc + e.points, 0);
+    const lastUpdate =
+      t.events.length > 0
+        ? Math.max(...t.events.map((e) => new Date(e.occurredAt).getTime()))
+        : undefined;
+    return {
+      teamId: t.teamId,
+      teamName: t.teamName,
+      totalScore: total,
+      lastUpdateMs: lastUpdate,
+    };
+  });
+  const sorted = [...aggregated].sort((a, b) => {
+    if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore;
+    // 同点は 最終 update が早い (= 小さい ms) を上位。 update 無しは最下位扱い。
+    const aLast = a.lastUpdateMs ?? Number.POSITIVE_INFINITY;
+    const bLast = b.lastUpdateMs ?? Number.POSITIVE_INFINITY;
+    return aLast - bLast;
+  });
+  // 同点は同順位 (= 標準的な競技 ranking)。
+  let prevScore: number | null = null;
+  let prevRank = 0;
+  return sorted.map((row, idx) => {
+    const rank = prevScore !== null && row.totalScore === prevScore ? prevRank : idx + 1;
+    prevScore = row.totalScore;
+    prevRank = rank;
+    return { rank, ...row };
+  });
+}
+
+function formatLastUpdate(ms: number | undefined): string {
+  if (ms === undefined) return "—";
+  const d = new Date(ms);
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+}
+
+export function TeamRankingPanel({ teams }: { teams: readonly TeamScoreEvents[] }) {
+  const rows = useMemo(() => computeRanking(teams), [teams]);
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description="累計 score 降順で sort。 同点は最終 update が早い方を上位 (= 標準 tie-break)"
+        >
+          現在の順位 ({rows.length} チーム)
+        </Header>
+      }
+    >
+      <Table
+        variant="embedded"
+        items={[...rows]}
+        columnDefinitions={[
+          {
+            id: "rank",
+            header: "順位",
+            cell: (r) =>
+              r.rank === 1 ? (
+                <Badge color="green">1</Badge>
+              ) : r.rank <= 3 ? (
+                <Badge color="blue">{r.rank}</Badge>
+              ) : (
+                <Box variant="strong">{r.rank}</Box>
+              ),
+          },
+          { id: "name", header: "チーム名", cell: (r) => <code>{r.teamName}</code> },
+          {
+            id: "score",
+            header: "累計 score",
+            cell: (r) => <Box variant="strong">{r.totalScore} pt</Box>,
+          },
+          {
+            id: "lastUpdate",
+            header: "最終 update",
+            cell: (r) => (
+              <Box variant="small" color="text-status-inactive">
+                {formatLastUpdate(r.lastUpdateMs)}
+              </Box>
+            ),
+          },
+        ]}
+      />
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -37,6 +37,7 @@ import {
   unlockEventScoring,
 } from "../api/events-client";
 import { SendNotificationModal } from "../components/SendNotificationModal";
+import { TeamRankingPanel } from "../components/TeamRankingPanel";
 import { TeamScoreEventsPanel } from "../components/TeamScoreEventsPanel";
 import type { AppConfig } from "../config";
 import { computeEventWizardState, WIZARD_STEPS } from "../lib/event-wizard";
@@ -918,6 +919,9 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
       )}
 
       {detail?.scoreEventsByTeam && <TeamScoreEventsPanel teams={detail.scoreEventsByTeam} />}
+
+      {/* Issue #1071: 現在の順位 table。 score 推移 chart と同 data source、 backend 不要。 */}
+      {detail?.scoreEventsByTeam && <TeamRankingPanel teams={detail.scoreEventsByTeam} />}
 
       {detail && (
         <Container header={<Header variant="h2">参加者向け配布</Header>}>

--- a/apps/application-admin-console/test/components/TeamRankingPanel.test.tsx
+++ b/apps/application-admin-console/test/components/TeamRankingPanel.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { TeamScoreEvents } from "../../src/api/events-client";
+import { computeRanking } from "../../src/components/TeamRankingPanel";
+
+/**
+ * Issue #1071: チーム順位計算の pure logic を pin。 events.points の合計を team 別に取り、
+ * 降順 sort + 標準 tie-break (= 最終 update 早い方が上位) + 同点同順位を保証する。
+ */
+function team(
+  teamId: string,
+  teamName: string,
+  events: ReadonlyArray<{ points: number; occurredAt: string }>,
+): TeamScoreEvents {
+  return {
+    teamId,
+    teamName,
+    events: events.map((e, i) => ({
+      jobId: `${teamId}-${i}`,
+      problemId: "hello-world",
+      source: "uptime",
+      points: e.points,
+      result: "ok",
+      occurredAt: e.occurredAt,
+    })),
+  };
+}
+
+describe("computeRanking (Issue #1071)", () => {
+  it("score 降順で順位を割り当てるべき", () => {
+    const rows = computeRanking([
+      team("t-1", "alpha", [{ points: 100, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+      team("t-2", "beta", [{ points: 300, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+      team("t-3", "gamma", [{ points: 200, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+    ]);
+    expect(rows.map((r) => [r.rank, r.teamName])).toEqual([
+      [1, "beta"],
+      [2, "gamma"],
+      [3, "alpha"],
+    ]);
+  });
+
+  it("同点は最終 update が早い方を上位とすべき (= 標準 tie-break)", () => {
+    const rows = computeRanking([
+      team("t-1", "later", [{ points: 100, occurredAt: "2026-05-19T10:05:00.000Z" }]),
+      team("t-2", "earlier", [{ points: 100, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+    ]);
+    expect(rows[0].teamName).toBe("earlier");
+    expect(rows[1].teamName).toBe("later");
+  });
+
+  it("同点は同順位を割り当てるべき (= 1, 1, 3 のように skip)", () => {
+    const rows = computeRanking([
+      team("t-1", "a", [{ points: 200, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+      team("t-2", "b", [{ points: 200, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+      team("t-3", "c", [{ points: 100, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+    ]);
+    expect(rows.map((r) => r.rank)).toEqual([1, 1, 3]);
+  });
+
+  it("events 0 件の team も 0 pt で順位に含めるべき", () => {
+    const rows = computeRanking([
+      team("t-1", "no-events", []),
+      team("t-2", "scored", [{ points: 50, occurredAt: "2026-05-19T10:00:00.000Z" }]),
+    ]);
+    expect(rows.map((r) => [r.rank, r.teamName, r.totalScore])).toEqual([
+      [1, "scored", 50],
+      [2, "no-events", 0],
+    ]);
+  });
+
+  it("複数 events を合計すべき", () => {
+    const rows = computeRanking([
+      team("t-1", "multi", [
+        { points: 30, occurredAt: "2026-05-19T10:00:00.000Z" },
+        { points: 50, occurredAt: "2026-05-19T10:05:00.000Z" },
+        { points: -10, occurredAt: "2026-05-19T10:10:00.000Z" },
+      ]),
+    ]);
+    expect(rows[0].totalScore).toBe(70);
+  });
+});


### PR DESCRIPTION
## Summary

- 新 \`TeamRankingPanel\` component で 「現在の順位」 table を表示 (= score 推移 chart の下)
- \`scoreEventsByTeam\` を re-use、 backend 追加なし
- 累計 score 降順 + 最終 update 早い方上位 + 同点同順位
- 上位 3 位を色付き Badge で強調
- \`computeRanking\` pure function を 5 ケース unit test で pin

Closes #1071

## 物理影響

- frontend のみ、 既存 polling 経路を再利用。 CFn / IAM / DDB / Lambda 0 件

## Test plan

- [x] \`make harness\` clean
- [x] \`make before-commit\` clean
- [ ] **手動確認** (= user): score event が発生した event で EventDetail を開き、 順位 table の score 降順 sort と Badge 色分けを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)