### PR TITLE
fix(#1095): Event 終了で scoring auto-lock + badge を status/lock aware に

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -828,7 +828,7 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
             </Field>
           </ColumnLayout>
           <Box margin={{ top: "m" }}>
-            <Field label="採点ステータス">{scoringBadge(detail.startsAt)}</Field>
+            <Field label="採点ステータス">{scoringBadge(detail)}</Field>
           </Box>
           {/* Issue #1038 P1 #9 follow-up: scoreboard freeze 分数 (= 終了 N 分前から順位非公開) */}
           <Box margin={{ top: "m" }}>
@@ -1286,12 +1286,23 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
 }
 
 /**
- * Event の採点状況バッジ。3 分岐: 未設定 / 開始予定 / 採点中。
- * 時刻判定は新しいレンダ時の `Date.now()` を使うので polling refresh で自然に更新される。
+ * Event の採点状況バッジ。 #1095: status / scoringLocked / 時刻の優先順位で分岐。
+ *   1. scoringLocked → 「採点 lock 中」 (red)
+ *   2. status === ENDED → 「終了」 (grey)
+ *   3. status === ARCHIVED / TEARDOWN → 「終了」 (grey)
+ *   4. !startsAt → 「未開始」 (grey)
+ *   5. startsAt 未到達 → 「開始予定」 (blue)
+ *   6. それ以外 → 「採点中」 (green)
  */
-function scoringBadge(startsAt: string | undefined) {
-  if (!startsAt) return <Badge color="grey">未開始</Badge>;
-  if (new Date(startsAt).getTime() > Date.now()) return <Badge color="blue">開始予定</Badge>;
+function scoringBadge(detail: Pick<EventDetail, "startsAt" | "status" | "scoringLocked">) {
+  if (detail.scoringLocked === true) return <Badge color="red">採点 lock 中</Badge>;
+  if (detail.status === "ENDED" || detail.status === "ARCHIVED" || detail.status === "TEARDOWN") {
+    return <Badge color="grey">終了</Badge>;
+  }
+  if (!detail.startsAt) return <Badge color="grey">未開始</Badge>;
+  if (new Date(detail.startsAt).getTime() > Date.now()) {
+    return <Badge color="blue">開始予定</Badge>;
+  }
   return <Badge color="green">採点中</Badge>;
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/end-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/end-event.ts
@@ -26,6 +26,12 @@ export type EndEventOutcome =
  *   - `DRAFT` / `DEPLOYING`: まだ動いていないので無意味
  *   - `TEARDOWN` / `ARCHIVED`: 既に teardown 済 → 終了は redundant
  *   - `ENDED`: 二重操作防止
+ *
+ * Issue #1095: ENDED 遷移と同時に `scoringLocked = true` も atomic に立てる。
+ * 旧設計では scoringLocked は status と orthogonal な軸として保持していたが、
+ * 「event 終了したのに 採点中 badge のまま」 という UX bug が出ていた。 ENDED は
+ * 採点を継続する意味が無いので auto-lock を default にする。 READY 中の表彰
+ * フェーズ用 manual lock (= lockEventScoring) は別経路で残るので柔軟性は保たれる。
  */
 export async function endEvent(
   shared: EventSharedResources,
@@ -41,7 +47,12 @@ export async function endEvent(
       new UpdateCommand({
         TableName: shared.eventsTableName,
         Key: { PK: `EVENT#${eventId}`, SK: "META" },
-        UpdateExpression: "SET #s = :ended, endsAt = :now, updatedAt = :now",
+        // #1095: ENDED 遷移と同時に scoringLocked / scoringLockedAt / scoringLockedBy を
+        //        立てる (= 採点 gate 自動 lock)。 既に手動 lock 済 (scoringLocked=true) の
+        //        event を ENDED にする場合は ConditionExpression が ready のみ許可なので
+        //        通らず、 副作用なし。
+        UpdateExpression:
+          "SET #s = :ended, endsAt = :now, updatedAt = :now, scoringLocked = :true, scoringLockedAt = :now, scoringLockedBy = :system",
         // tenant 跨ぎ防止 + status=READY のみ許可
         ConditionExpression: "tenantId = :tenantId AND #s = :ready",
         ExpressionAttributeNames: { "#s": "status" },
@@ -50,6 +61,8 @@ export async function endEvent(
           ":ready": "READY",
           ":now": now,
           ":tenantId": tenantId,
+          ":true": true,
+          ":system": "system:end-event",
         },
         ReturnValues: "ALL_NEW",
       }),

--- a/infrastructure/test/problem-deploy/event-end.test.ts
+++ b/infrastructure/test/problem-deploy/event-end.test.ts
@@ -66,6 +66,13 @@ describe("endEvent", () => {
     expect(eventUpd.input.ExpressionAttributeValues?.[":ready"]).toBe("READY");
     expect(eventUpd.input.ExpressionAttributeValues?.[":ended"]).toBe("ENDED");
     expect(eventUpd.input.ExpressionAttributeValues?.[":now"]).toBe(NOW_ISO);
+    // #1095: ENDED 遷移と同時に scoringLocked = true / scoringLockedAt = now /
+    //        scoringLockedBy = "system:end-event" が立つ
+    expect(eventUpd.input.ExpressionAttributeValues?.[":true"]).toBe(true);
+    expect(eventUpd.input.ExpressionAttributeValues?.[":system"]).toBe("system:end-event");
+    expect(eventUpd.input.UpdateExpression).toContain("scoringLocked = :true");
+    expect(eventUpd.input.UpdateExpression).toContain("scoringLockedAt = :now");
+    expect(eventUpd.input.UpdateExpression).toContain("scoringLockedBy = :system");
 
     // Deployments query は GSI1 = TENANT# + FilterExpression eventId 一致 (cross-event 漏洩防止)
     const queryCmd = ddbSend.mock.calls[1]?.[0] as QueryCommand;


### PR DESCRIPTION
## Summary

- \`endEvent\` handler の UpdateExpression に \`scoringLocked = true\` / \`scoringLockedAt = now\` / \`scoringLockedBy = "system:end-event"\` を atomic に追加
- \`scoringBadge\` を \`startsAt\` 単一引数 → \`detail\` 全体に変え、 \`status\` / \`scoringLocked\` / 時刻の優先順位で 「採点 lock 中」 / 「終了」 / 「未開始」 / 「開始予定」 / 「採点中」 を出し分け
- 既存 test (\`event-end.test.ts\`) に scoringLocked 関連 assertion を追加

## Why

「Event を終了」 button を押しても 採点ステータス badge が 「採点中」 のまま、 主催者は別途 「採点を lock」 button を手動で押す必要があり直感に反していた。 ENDED は採点を継続する意味が無いので auto-lock を default にする。

READY 中の表彰フェーズ用 manual lock (= \`lockEventScoring\`) は別経路で残るので運用柔軟性は維持される。

## Regression 分析

- ENDED 遷移の ConditionExpression は status=READY のみ許可、 既存 ENDED 行への二重 lock は通らない
- HealthCheck / submit-flag は既に \`eventEndsAt\` を見て probe / 加点 skip 済 → scoringLocked との二重防御になるだけで regression 無し
- \`scoringBadge\` の signature 変更で呼び出し側 1 箇所 (EventDetail.tsx:831) を追従

## 物理影響

- \`infrastructure/lib/problem-deploy/handlers/event-handler/end-event.ts\`: UPDATE (UpdateExpression 拡張)
- \`infrastructure/test/problem-deploy/event-end.test.ts\`: UPDATE (assertion 追加)
- \`apps/application-admin-console/src/pages/EventDetail.tsx\`: UPDATE (scoringBadge 書き換え + 呼び出し追従)
- CFn: NO-OP (handler は同じ Lambda、 DDB schema 変更無し)

## Test plan

- [x] make harness
- [x] make before-commit pass
- [x] event-end.test.ts 7 test pass
- [ ] manual: Event を ENDED に遷移 → 「終了」 badge / SCORING LOCKED が同時に表示される

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events automatically lock scoring when transitioning to ended state, preventing subsequent score modifications
  * Scoring status badge enhanced to display lock state and event lifecycle information

* **Tests**
  * Test suite updated to verify automatic scoring lock behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->