### PR TITLE
fix(#1094): hello-world に AWS Console deep link Output 追加 + Portal URL 判定

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -152,10 +152,17 @@ export function ProblemPanel({
             <KeyValuePairs
               items={Object.entries(problem.stackOutputs).map(([label, value]) => ({
                 label,
-                value: (
+                // #1094: URL (= http(s)://) のときだけ click 可能リンクにする。 ARN / SSM
+                //   parameter name / NamePrefix 等の非 URL output を a href で wrap すると
+                //   broken link になるので plain code 表示に倒す。 「ParameterConsoleUrl」
+                //   のような deep link を問題 author が emit すれば click で AWS Console
+                //   直接遷移 (ssm:DescribeParameters 不要、 ADR-021 と整合)。
+                value: /^https?:\/\//i.test(value) ? (
                   <a href={value} target="_blank" rel="noreferrer noopener">
                     <code>{value}</code>
                   </a>
+                ) : (
+                  <code>{value}</code>
                 ),
               }))}
             />

--- a/infrastructure/test/scripts/inspect-problem.test.ts
+++ b/infrastructure/test/scripts/inspect-problem.test.ts
@@ -16,7 +16,7 @@ describe("runInspect (#951 sub #5)", () => {
     expect(text).toContain("flagOutputKey:    ParameterValue");
     expect(text).toContain("Resources:  ParticipantViewerRole, HelloParameter");
     expect(text).toContain(
-      "Outputs:    ParameterName, ParameterValue, NamePrefix, ParticipantViewerRoleArn",
+      "Outputs:    ParameterName, ParameterValue, ParameterConsoleUrl, NamePrefix, ParticipantViewerRoleArn",
     );
     expect(text).toContain("Cross-ref:  OK");
   });

--- a/problems/challenges/hello-world/template.yaml
+++ b/problems/challenges/hello-world/template.yaml
@@ -88,6 +88,15 @@ Outputs:
   ParameterValue:
     Description: SSM Parameter value (echoed in Outputs for smoke test verification).
     Value: !Sub "Hello from ${NamePrefix}"
+  # Issue #1094: AWS Console deep link to the specific parameter detail page.
+  # competitors click this from the Participant Portal and land directly on
+  # the parameter view (= ssm:GetParameter, no DescribeParameters required).
+  # The top-level Parameter Store list view requires ssm:DescribeParameters
+  # which the participant-viewer Role intentionally lacks (ADR-021, no cross-
+  # tenant leak), so the deep link is the supported solve path.
+  ParameterConsoleUrl:
+    Description: AWS Console deep link to the Parameter Store entry (no DescribeParameters needed).
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/parameters/%2F${NamePrefix}%2Fhello/description?region=${AWS::Region}"
   NamePrefix:
     Description: Common resource prefix that this stack used.
     Value: !Ref NamePrefix


### PR DESCRIPTION
## Summary

- hello-world template の Outputs に \`ParameterConsoleUrl\` を追加 (= AWS Console SSM Parameter detail 画面への deep link)
- ProblemPanel の stackOutputs 描画で URL 判定 (\`/^https?:\/\//\`) を行い、 URL output のみリンク化、 非 URL output は plain code 表示
- inspect-problem.test.ts の Outputs assertion を新出力名に追従

## Why

過去 #1069 / ADR-021 で 「participant-viewer Role は own problem's resources のみ」 と決め \`ssm:DescribeParameters\` を意図的に付けていなかった。 結果として AWS Console の SSM Parameter Store top-level list 画面 (= DescribeParameters 必須) に federated login すると 403 で sample 問題が解けない状態だった。

問題側 template が deep link を emit し、 Portal が それを click 可能にする経路で、 IAM を緩めずに solve できるようになる。

## Regression 分析

- participant-viewer IAM は無変更 (ADR-021 維持、 cross-tenant leak 無し)
- URL output (\`http(s)://...\`) のリンク化は維持 → 既存の API 系問題 (= BaseUrl emit) は壊れない
- 非 URL output (ARN / NamePrefix / SSM 名) の broken link は plain code に直る = 改善方向
- 既存 hello-world deploy 済 stack は cdk deploy で UPDATE-NO-INTERRUPT (Output 1 行追加)

## 物理影響

- \`problems/challenges/hello-world/template.yaml\`: **UPDATE** (Output 1 行追加)
- \`apps/participant-portal/src/components/ProblemPanel.tsx\`: **UPDATE** (URL 判定)
- \`infrastructure/test/scripts/inspect-problem.test.ts\`: **UPDATE** (assertion 追従)
- CFn: hello-world stack に Output 追加のみ

## Test plan

- [x] make harness
- [x] make before-commit pass
- [ ] manual: 既存 hello-world を redeploy し、 Portal の 「アクセス先 URL」 から ParameterConsoleUrl を click → 直接 SSM parameter 詳細が開く

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)