### PR TITLE
fix(#1096): 「Failed to fetch」 を URL + method 込みの ApiError に変換

### DIFF
--- a/apps/application-admin-console/src/api/client.ts
+++ b/apps/application-admin-console/src/api/client.ts
@@ -21,14 +21,28 @@ export function createApiClient(baseUrl: string, idToken: string): ApiClient {
 
   const request = async (path: string, init: RequestInit = {}): Promise<Response> => {
     const url = new URL(path.replace(/^\//, ""), base);
-    const res = await fetch(url, {
-      ...init,
-      headers: {
-        authorization: `Bearer ${idToken}`,
-        "content-type": "application/json",
-        ...init.headers,
-      },
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${idToken}`,
+          "content-type": "application/json",
+          ...init.headers,
+        },
+      });
+    } catch (err) {
+      // Issue #1096: 「Failed to fetch」 (= fetch が TypeError を throw する CORS
+      // preflight 失敗 / network unreachable / API 不在 等) を ApiError に正規化し、
+      // 上位 UI で 「ネットワーク経路エラー」 として region / API URL / 推奨手順を
+      // 含む operator-friendly message に変換できるようにする。 status=0 を sentinel
+      // にして上位 friendly-error mapping から判別する。
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new ApiError(
+        0,
+        `Network error: ${detail} (URL: ${url.toString()}, method: ${init.method ?? "GET"})`,
+      );
+    }
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
       throw new ApiError(res.status, detail || res.statusText);


### PR DESCRIPTION
## Summary

\`apps/application-admin-console/src/api/client.ts\` の \`request()\` で fetch を try/catch し、 TypeError (= 「Failed to fetch」) を \`ApiError(0, ...)\` に正規化。 message に URL + method + 元 error message を含める。

## Why

ENDED + SCORING LOCKED event の Delete button などで 「Failed to fetch」 だけが出ていたが、 URL / method 不明で operator が debug できなかった。 fetch が throw する TypeError は CORS preflight 失敗 / network unreachable / Lambda cold start 等の様々な原因で発生するため、 まず operator が 「どの URL に何 method で叩いた結果失敗したか」 を 1 query で確認できる経路を作る。

これは sym 緩和であり真の root cause (= CORS / Lambda 配備状態 / 経路) を fix するものではないが、 #1096 のような bug 報告の debug が容易になる。

## Regression 分析

- ApiError signature は無変更 (status / message のみ)
- 4xx/5xx 経路は無変更 (= 既存テスト pass)
- 動作変更は 「fetch が throw した場合のみ」、 caller は新たに status=0 を観測する。 既存 caller は status を switch していないため backward compatible
- application-admin-console vitest 235 pass

## 物理影響

- \`apps/application-admin-console/src/api/client.ts\`: **UPDATE**
- CFn: **NO-OP**

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)