### PR TITLE
refactor(#1108): problem metadata から es / zh を削除 (= ja + en のみ)

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -129,13 +129,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
     });
 
-    it("locale='zh' の override が宣言されていれば中文を返すべき (hello-world)", () => {
-      const m = requireProblemMetadata("hello-world");
-      const r = resolveLocalizedNarrative(m, "zh");
-      expect(r.name).toContain("示例");
-    });
-
-    it("全 4 既存問題が en / es / zh の翻訳を持つべき (Phase 5.A + 5.C 完了)", () => {
+    it("全 4 既存問題が en の翻訳を持つべき (#1108 で ja+en のみサポート)", () => {
       for (const id of [
         "hello-world",
         "hello-world-battle",
@@ -144,8 +138,6 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       ]) {
         const m = findProblemMetadata(id);
         expect(m?.i18n?.en?.name).toBeTruthy();
-        expect(m?.i18n?.es?.name).toBeTruthy();
-        expect(m?.i18n?.zh?.name).toBeTruthy();
         expect(m?.i18n?.en?.learningGoals?.length ?? 0).toBeGreaterThan(0);
       }
     });
@@ -154,12 +146,6 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       const m = requireProblemMetadata("security-battle-royale");
       const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Attack\/defend/);
-    });
-
-    it("locale='es' で security-battle-royale もスペイン語翻訳を返すべき", () => {
-      const m = requireProblemMetadata("security-battle-royale");
-      const r = resolveLocalizedNarrative(m, "es");
-      expect(r.shortDescription).toMatch(/Ataca\/defiende/);
     });
   });
 });

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -138,17 +138,15 @@ interface ProblemMetadata {
   dashboard?: {
     slots?: Record<string, string>;
   };
-  /** ADR Issue #583 Phase 5: 競技者向け field の locale override。 ja 自体は top-level が正本。 */
+  /** ADR Issue #583 Phase 5 / #1108: 競技者向け field の locale override。 ja 自体は top-level が正本。 サポート対象は en のみ。 */
   i18n?: {
     en?: ProblemI18nOverride;
-    es?: ProblemI18nOverride;
-    zh?: ProblemI18nOverride;
   };
 }
 
 /**
  * Issue #583 Phase 5: 1 locale 分の override。 各 field 省略時は ja (= top-level の値) に fallback。
- * portal の locale switcher (= "ja" / "en" / "es" / "zh") と対応。
+ * portal の locale switcher (= "ja" / "en") と対応。
  */
 export interface ProblemI18nOverride {
   readonly name?: string;
@@ -246,16 +244,17 @@ export function findProblemMetadata(problemId: string): ProblemCatalogEntry | un
 }
 
 /**
- * Issue #583 Phase 5: locale を適用した narrative view を返す。 fallback chain:
- *   1. 指定 locale (= en/es/zh) の override
+ * Issue #583 Phase 5 / #1108: locale を適用した narrative view を返す。 fallback chain:
+ *   1. 指定 locale (= en) の override
  *   2. top-level (= ja の正本)
  *
  * locale="ja" / metadata.i18n 不在 / 該当 field 不在は静かに ja を返す。 caller (= ProblemDetail
  * の useI18n から locale を取って呼ぶ) は常に non-undefined string を受け取る。
+ * 注: SUPPORTED_LOCALES は ja+en のみ (#1108 で es / zh は廃止)。
  */
 export function resolveLocalizedNarrative(
   entry: ProblemCatalogEntry,
-  locale: "ja" | "en" | "es" | "zh",
+  locale: "ja" | "en",
 ): {
   readonly name: string;
   readonly shortDescription: string;

--- a/problems/SCHEMA.json
+++ b/problems/SCHEMA.json
@@ -144,29 +144,9 @@
     "i18n": {
       "type": "object",
       "additionalProperties": false,
-      "description": "[Issue #583 Phase 5] 競技者向け field の英語 / スペイン語 / 中国語訳。 default 言語 (= 日本語) の文字列は top-level の `name` / `shortDescription` / `description` / `learningGoals` 等にそのまま入れる。 本 field に locale 別の override を入れると portal の locale switcher で動的切替される (= locale fallback chain: 指定言語 → ja → top-level)。 ja 自体は本 field に **含めない** (= top-level が正本、 重複を防ぐ)。",
+      "description": "[Issue #583 Phase 5 / #1108] 競技者向け field の英語訳。 default 言語 (= 日本語) の文字列は top-level の `name` / `shortDescription` / `description` / `learningGoals` 等にそのまま入れる。 本 field に locale 別の override を入れると portal の locale switcher で動的切替される (= locale fallback chain: en → ja → top-level)。 ja 自体は本 field に **含めない** (= top-level が正本、 重複を防ぐ)。 サポート対象 locale は ja + en のみ (= #1108 で es / zh は廃止)。",
       "properties": {
         "en": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": { "type": "string" },
-            "shortDescription": { "type": "string" },
-            "description": { "type": "string" },
-            "learningGoals": { "type": "array", "items": { "type": "string", "minLength": 1 } }
-          }
-        },
-        "es": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": { "type": "string" },
-            "shortDescription": { "type": "string" },
-            "description": { "type": "string" },
-            "learningGoals": { "type": "array", "items": { "type": "string", "minLength": 1 } }
-          }
-        },
-        "zh": {
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/problems/battles/hello-world-battle/metadata.json
+++ b/problems/battles/hello-world-battle/metadata.json
@@ -11,8 +11,14 @@
   "description": "Battle uptime scoring の動作確認用 sample。\n\nDeploy すると競技者の AWS アカウントに次が作られる:\n  - 専用 VPC (10.99.0.0/16) + 公開 subnet + IGW\n  - EC2 t3.micro (Amazon Linux 2023, Public IP)\n    - nginx (port 80) で frontend ページを serve\n    - python3 http.server (port 8080) で `/healthz` API を serve\n\nHealth Check Lambda が 1 分ごとに FrontendUrl + ApiUrl を probe し、両方が 200 を返せば +100 pt 加算。どちらかが落ちている / 改ざんされていれば lastResult=fail として加算停止。\n\n## 攻撃 / 防御 (Battle 形式の体験)\n\n- **攻撃側** が同じ EC2 / Security Group を弄って frontend や API を停止すると、防御側のスコアが止まる\n- **防御側** は SSM Session Manager で SSH 不要で接続し、サービスを復旧する\n- いずれの操作も 1 EC2 内で完結するので、cross-tenant 影響なし (= 自テナント内の競技として安全)\n\n## コスト\n\n- EC2 t3.micro: AWS Free Tier 750 hr/月 (12 ヶ月) 内\n- VPC / IGW / SG: 無料\n- 競技 1 回 (~30 分) のコストは Free Tier 範囲ならゼロ",
   "tags": ["sample", "battle", "uptime", "ec2", "nginx"],
   "exposedPorts": [
-    { "port": 80, "name": "frontend (nginx)" },
-    { "port": 8080, "name": "api (python http.server)" }
+    {
+      "port": 80,
+      "name": "frontend (nginx)"
+    },
+    {
+      "port": 8080,
+      "name": "api (python http.server)"
+    }
   ],
   "learningGoals": [
     "TenkaCloud の Battle uptime scoring engine が実 endpoint で動くことを確認する",
@@ -31,39 +37,25 @@
         "Experience a minimal web stack (EC2 + nginx + Python) receiving health-check probes",
         "Practice connecting via SSM Session Manager without SSH to start/stop the service"
       ]
-    },
-    "es": {
-      "name": "Hello World Battle (Muestra)",
-      "shortDescription": "Muestra mínima de Battle con scoring de uptime. Ejecuta nginx (frontend) + Python (API) en EC2 y, mientras ambos devuelven 200, suma +100 cada minuto.",
-      "description": "Muestra mínima para verificar el scoring de uptime en formato Battle.\n\nAl desplegar se crea en la cuenta AWS del competidor:\n  - VPC dedicada (10.99.0.0/16) + subnet pública + IGW\n  - EC2 t3.micro (Amazon Linux 2023, IP pública)\n    - nginx (puerto 80) sirviendo la página frontend\n    - python3 http.server (puerto 8080) sirviendo la API `/healthz`\n\nHealth Check Lambda hace probes a FrontendUrl + ApiUrl cada minuto y otorga +100 pt cuando ambos devuelven 200. Si alguno falla o es manipulado, lastResult=fail y la puntuación se detiene.\n\n## Ataque / defensa (experiencia Battle)\n\n- **Atacantes** pueden manipular el EC2 / Security Group compartido para tumbar frontend o API, congelando la puntuación del defensor.\n- **Defensores** se conectan vía SSM Session Manager (sin SSH) para restaurar el servicio.\n- Todas las operaciones quedan dentro de una EC2, sin impacto cross-tenant (= seguro dentro del scoring self-tenant).\n\n## Coste\n\n- EC2 t3.micro: dentro del AWS Free Tier 750 hr/mes (12 meses)\n- VPC / IGW / SG: gratis\n- Coste por sesión de 30 min: cero dentro del Free Tier",
-      "learningGoals": [
-        "Verificar que el motor de scoring de uptime Battle de TenkaCloud funciona contra endpoints reales",
-        "Experimentar un stack web mínimo (EC2 + nginx + Python) recibiendo probes de health-check",
-        "Practicar la conexión vía SSM Session Manager sin SSH para iniciar/detener el servicio"
-      ]
-    },
-    "zh": {
-      "name": "Hello World Battle (示例)",
-      "shortDescription": "Battle uptime 评分的最小示例。在 EC2 上启动 nginx (frontend) + Python (API),只要两者都返回 200,每分钟 +100 分。",
-      "description": "Battle uptime 评分的最小示例。\n\n部署后在参赛者的 AWS 账户中创建:\n  - 专用 VPC (10.99.0.0/16) + 公共子网 + IGW\n  - EC2 t3.micro (Amazon Linux 2023, 公网 IP)\n    - nginx (端口 80) 提供 frontend 页面\n    - python3 http.server (端口 8080) 提供 `/healthz` API\n\nHealth Check Lambda 每分钟 probe FrontendUrl + ApiUrl,两者都返回 200 时加 +100 分。任何一方宕机或被篡改,lastResult=fail 且评分停止。\n\n## 攻击 / 防御 (Battle 体验)\n\n- **攻击方** 可篡改共享 EC2 / Security Group,使 frontend 或 API 宕机,冻结防御方评分。\n- **防御方** 通过 SSM Session Manager (无需 SSH) 连接以恢复服务。\n- 所有操作在 1 EC2 内完成,无 cross-tenant 影响 (= 在自租户内安全评分)。\n\n## 成本\n\n- EC2 t3.micro: 在 AWS Free Tier 750 小时/月 (12 个月) 范围内\n- VPC / IGW / SG: 免费\n- 单次 30 分钟会话成本: 在 Free Tier 范围内为零",
-      "learningGoals": [
-        "验证 TenkaCloud 的 Battle uptime 评分引擎能针对真实 endpoint 工作",
-        "体验最小 web 栈 (EC2 + nginx + Python) 接收健康检查 probe 的流程",
-        "练习通过 SSM Session Manager 无需 SSH 连接以启动 / 停止服务"
-      ]
     }
   },
   "endpoints": [
     {
       "slot": "frontend",
-      "default": { "from": "cfn-output", "key": "FrontendUrl" },
+      "default": {
+        "from": "cfn-output",
+        "key": "FrontendUrl"
+      },
       "overridable": false,
       "label": "Frontend (nginx)",
       "description": "EC2 上の nginx (port 80)。 防御側が落とすとスコア停止。"
     },
     {
       "slot": "api",
-      "default": { "from": "cfn-output", "key": "ApiUrl" },
+      "default": {
+        "from": "cfn-output",
+        "key": "ApiUrl"
+      },
       "overridable": false,
       "label": "API (python http.server)",
       "description": "EC2 上の python http.server (port 8080)。 `/healthz` で 200 を返す。"
@@ -72,8 +64,16 @@
   "scoring": {
     "kind": "uptime",
     "endpoints": [
-      { "outputKey": "FrontendUrl", "path": "/", "expectStatus": [200] },
-      { "outputKey": "ApiUrl", "path": "/healthz", "expectStatus": [200] }
+      {
+        "outputKey": "FrontendUrl",
+        "path": "/",
+        "expectStatus": [200]
+      },
+      {
+        "outputKey": "ApiUrl",
+        "path": "/healthz",
+        "expectStatus": [200]
+      }
     ],
     "pointsPerSuccess": 100
   }

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -10,7 +10,12 @@
   "shortDescription": "EC2 1 台に同居する 3 サービス (users / orders / catalog) を Lambda + API Gateway / ECS Fargate / App Runner の 3 種ホスティングに分割するレース。",
   "description": "EC2 1 台に同居する 3 サービス (users / orders / catalog) のモノリスを、競技時間内に Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner の 3 種類の異なるホスティングへマイクロサービスとして分割していく Battle。\n\nDeploy 完了後、各チームには EC2 上で動くモノリスのベース URL が払い出される。3 つのスコア対象エンドポイント (`/users/score` / `/orders/score` / `/catalog/score`) を運営側スコアエンジンが 1 分毎に polling し、レスポンスに応じてポイントを加減算する。\n\n## 学習目的\n\n- モノリスからマイクロサービスへの段階的移行 (strangler fig パターン) を実体験する\n- Lambda function / managed container (App Runner) / orchestrated container (ECS Fargate) の 3 段階を比較する\n- どのサービスから分離すべきかをスコア最大化の観点で判断する\n- コード内に意図的に仕込まれた「遅延コードパス」を読み解いて取り除く\n\n## アーキテクチャ (Phase 1 = この PR の deploy 範囲)\n\n```\n┌─────────────── EC2 (t3.small) ───────────────┐\n│  nginx :80  →  /users/* → users:3001           │\n│              →  /orders/* → orders:3002        │\n│              →  /catalog/* → catalog:3003      │\n│         docker compose で 3 サービス + nginx │\n└──────────────────────────────────────────────┘\n         ↑ Score Engine が 1 分毎 polling\n```\n\n各サービスは Node.js 20 + Hono の最小 HTTP サーバーで、`GET /meta` (= platform 自己申告) と `GET /score` を公開する。Dockerfile は Lambda / App Runner / ECS Fargate のいずれにもそのまま乗せ替え可能。\n\n## 採点ルール (Phase 2 で score engine を実装)\n\n| 状態                                       | 1 check あたり |\n| ------------------------------------------ | -------------- |\n| 未登録 / 200 以外 / timeout                | -100           |\n| EC2 上のレスポンス (劣化前)                | +100           |\n| EC2 上のレスポンス (劣化後 = 開始 60 分後) | +10            |\n| Lambda + API GW にホスティング済           | +1,000         |\n| ECS Fargate にホスティング済               | +1,000         |\n| App Runner にホスティング済                | +1,000         |\n| 3 サービス全て分離完了                     | +5,000 (1 回)  |\n\n## フェーズタイムライン\n\n- 0 分: deploy 完了 → 競技開始\n- 60 分: EC2 劣化 (`tc qdisc` 注入予定 / Phase 2)\n- 90 分: スコアエンジンが `/score` → `/score?legacy=true` へ切替 → 各サービスコードに仕込まれた遅延コードパスを取り除いて再デプロイする必要あり\n\n## 制約 / 既知の制限\n\n- 遅延コードパス (`?legacy=true` で 2 秒 sleep) は本リポジトリ内で公開されているため、ADR-008 (= 問題実装の private repo 化) が ship するまで仕掛けは事前に読まれる可能性がある。Phase 2 ship までに ADR-008 を解決する。\n- Phase 1 では score engine / endpoint 登録 UI / EC2 劣化 cron / フェーズ進行 logic は未実装 (= Phase 2 / Phase 3 で追加)。",
   "tags": ["microservices", "migration", "lambda", "ecs", "apprunner", "ec2", "docker"],
-  "exposedPorts": [{ "port": 80, "name": "nginx reverse proxy (users / orders / catalog)" }],
+  "exposedPorts": [
+    {
+      "port": 80,
+      "name": "nginx reverse proxy (users / orders / catalog)"
+    }
+  ],
   "learningGoals": [
     "モノリスから 3 ホスティング (Lambda / ECS Fargate / App Runner) へのマイクロサービス分割を体験する",
     "サーバレス / マネージドコンテナ / オーケストレーションのトレードオフを実機で比較する",
@@ -30,48 +35,38 @@
         "Judge migration priority under EC2 degradation and legacy-codepath constraints",
         "Find and remove the intentionally-planted slow code paths"
       ]
-    },
-    "es": {
-      "name": "Microservice Migration Battle",
-      "shortDescription": "Carrera para dividir un monolito de 3 servicios (users / orders / catalog) en EC2 a hospedajes Lambda + API Gateway / ECS Fargate / App Runner.",
-      "description": "Battle donde los equipos dividen un monolito de 3 servicios (users / orders / catalog) en un solo EC2 a 3 plataformas de hospedaje diferentes — Lambda + API Gateway, Amazon ECS (Fargate), y AWS App Runner — dentro del tiempo de competición.\n\nTras el despliegue, cada equipo recibe la URL base del monolito en EC2. El motor de puntuación del operador hace polling de los 3 endpoints de puntuación (`/users/score` / `/orders/score` / `/catalog/score`) cada minuto y suma / resta puntos según las respuestas.\n\n## Objetivos de aprendizaje\n\n- Experimentar la migración progresiva monolito → microservicios (patrón strangler fig)\n- Comparar Lambda function / managed container (App Runner) / orchestrated container (ECS Fargate)\n- Decidir qué servicio dividir primero para maximizar puntuación\n- Encontrar y eliminar el slow code path intencionalmente plantado",
-      "learningGoals": [
-        "Experimentar la división de un monolito en 3 hospedajes (Lambda / ECS Fargate / App Runner)",
-        "Comparar tradeoffs de serverless / contenedores gestionados / orquestación en infraestructura real",
-        "Juzgar la prioridad de migración bajo restricciones de degradación de EC2 y legacy-codepath",
-        "Encontrar y eliminar slow code paths plantados intencionalmente"
-      ]
-    },
-    "zh": {
-      "name": "Microservice Migration Battle (微服务迁移大战)",
-      "shortDescription": "在 EC2 上共存的 3 个服务 (users / orders / catalog) 拆分到 Lambda + API Gateway / ECS Fargate / App Runner 的 3 种托管的竞赛。",
-      "description": "在竞赛时间内,将 EC2 上共存的 3 个服务 (users / orders / catalog) 单体拆分到 Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner 三种不同托管的 Battle 题目。\n\n部署完成后,每个团队会获得 EC2 上运行的单体的基础 URL。运营方评分引擎每分钟 polling 3 个评分端点 (`/users/score` / `/orders/score` / `/catalog/score`),根据响应加减分。\n\n## 学习目标\n\n- 实践单体到微服务的逐步迁移 (strangler fig 模式)\n- 对比 Lambda function / managed container (App Runner) / orchestrated container (ECS Fargate)\n- 从评分最大化的角度判断应优先拆分哪个服务\n- 解读并移除代码中故意植入的「慢速代码路径」",
-      "learningGoals": [
-        "体验单体到 3 种托管 (Lambda / ECS Fargate / App Runner) 的微服务拆分",
-        "在真实基础设施上比较 serverless / 托管容器 / orchestration 的权衡",
-        "在 EC2 劣化和 legacy code path 约束下判断迁移优先级",
-        "解读并移除故意植入的慢速代码路径"
-      ]
     }
   },
   "endpoints": [
     {
       "slot": "users",
-      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/users" },
+      "default": {
+        "from": "cfn-output",
+        "key": "BaseUrl",
+        "appendPath": "/users"
+      },
       "overridable": true,
       "label": "Users service",
       "description": "初期は EC2 上の nginx reverse proxy 経由。 Lambda / ECS / App Runner に切り出したら override で登録する。"
     },
     {
       "slot": "orders",
-      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/orders" },
+      "default": {
+        "from": "cfn-output",
+        "key": "BaseUrl",
+        "appendPath": "/orders"
+      },
       "overridable": true,
       "label": "Orders service",
       "description": "初期は EC2 上の nginx reverse proxy 経由。 移行先の新 endpoint を override で登録。"
     },
     {
       "slot": "catalog",
-      "default": { "from": "cfn-output", "key": "BaseUrl", "appendPath": "/catalog" },
+      "default": {
+        "from": "cfn-output",
+        "key": "BaseUrl",
+        "appendPath": "/catalog"
+      },
       "overridable": true,
       "label": "Catalog service",
       "description": "初期は EC2 上の nginx reverse proxy 経由。 移行先の新 endpoint を override で登録。"
@@ -80,15 +75,32 @@
   "scoring": {
     "kind": "phased-polling",
     "intervalMinutes": 1,
-    "probe": { "metaPath": "/meta", "scorePath": "/score" },
+    "probe": {
+      "metaPath": "/meta",
+      "scorePath": "/score"
+    },
     "platformRules": {
-      "ec2": { "points": 100, "degradedPoints": 10 },
-      "lambda": { "points": 1000 },
-      "ecs": { "points": 1000 },
-      "apprunner": { "points": 1000 }
+      "ec2": {
+        "points": 100,
+        "degradedPoints": 10
+      },
+      "lambda": {
+        "points": 1000
+      },
+      "ecs": {
+        "points": 1000
+      },
+      "apprunner": {
+        "points": 1000
+      }
     },
     "failurePenalty": -100,
-    "responsePenalties": [{ "if": "responseTimeMs > 1500", "points": -10 }],
+    "responsePenalties": [
+      {
+        "if": "responseTimeMs > 1500",
+        "points": -10
+      }
+    ],
     "bonuses": [
       {
         "kind": "all-slots-on-platforms",
@@ -102,13 +114,17 @@
     {
       "name": "degraded",
       "afterMinutes": 60,
-      "effect": { "switchPlatformToDegraded": ["ec2"] },
+      "effect": {
+        "switchPlatformToDegraded": ["ec2"]
+      },
       "description": "EC2 上の劣化フェーズ。 EC2 hosting platform の加点が degradedPoints (= 10) に切り替わる。"
     },
     {
       "name": "legacy",
       "afterMinutes": 90,
-      "effect": { "scorePathOverride": "/score?legacy=true" },
+      "effect": {
+        "scorePathOverride": "/score?legacy=true"
+      },
       "description": "Legacy code path フェーズ。 各サービスに仕込まれた遅延 code path を取り除く必要が出る。"
     }
   ],
@@ -119,7 +135,10 @@
       "eventDetailType": "DegradedDisruptionFired",
       "defaultAfterMinutes": 60,
       "operatorEditable": ["afterMinutes"],
-      "parameters": { "delayMs": 200, "device": "eth0" },
+      "parameters": {
+        "delayMs": 200,
+        "device": "eth0"
+      },
       "description": "deploy 後 60 分 (default) の self-triggered Scheduler が EC2 の eth0 に `tc qdisc add ... netem delay 200ms` を注入する。 phases[0]=degraded と同時刻で発火し、 score engine 側の degradedPoints 切替と組み合わさって accumulated latency による減点が始まる。 operator は deploy 時に afterMinutes を上書き可能 (CFn parameter `DegradedAfterMinutes`)。"
     }
   ],

--- a/problems/battles/security-battle-royale/metadata.json
+++ b/problems/battles/security-battle-royale/metadata.json
@@ -11,8 +11,14 @@
   "description": "ECサイト風の Web アプリ「Unicorn.Rentals」を題材に、SQL injection / リモートコード実行 / SSRF / IMDS 露出を含む複数の脆弱性が仕込まれた状態でデプロイされる。\n\n競技参加者は次のいずれかのロールでプレイする。\n  - **攻撃側**: 他チームの公開エンドポイントを巡回し、得点リソースを奪取する。\n  - **防御側**: 自チームのアプリを継続稼働させたまま、脆弱性を順次塞いでいく。\n\nデプロイ単位は EC2 1 台 + Docker 構成 (mysql / Flask api / nginx frontend)。デプロイ完了後、参加者には Frontend URL と API URL が払い出される。",
   "tags": ["security", "web", "sql-injection", "rce", "ssrf"],
   "exposedPorts": [
-    { "port": 80, "name": "frontend (nginx)" },
-    { "port": 8080, "name": "api (Flask)" }
+    {
+      "port": 80,
+      "name": "frontend (nginx)"
+    },
+    {
+      "port": 8080,
+      "name": "api (Flask)"
+    }
   ],
   "learningGoals": [
     "意図的な SQL injection / RCE / SSRF を発見・修正する一連の手順を体験する",
@@ -33,39 +39,25 @@
         "Understand the EC2 IMDS / IAM Role exposure path and best practices to close it",
         "Experience the attacker / defender tradeoff (keep availability while hardening)"
       ]
-    },
-    "es": {
-      "name": "Security Battle Royale",
-      "shortDescription": "Ataca/defiende una app web deliberadamente vulnerable en la cuenta del competidor. Gana el último equipo en pie.",
-      "description": "Una web app estilo e-commerce, 'Unicorn.Rentals', se despliega con vulnerabilidades intencionales: SQL injection, RCE, SSRF y exposición de IMDS.\n\nLos competidores juegan uno de estos roles:\n  - **Atacantes**: Recorren los endpoints públicos de otros equipos para capturar recursos de puntuación.\n  - **Defensores**: Mantienen su propia app funcionando mientras parchean progresivamente las vulnerabilidades.\n\nUnidad de despliegue: 1 EC2 + Docker (mysql / Flask api / nginx frontend). Tras el despliegue, los participantes reciben Frontend URL y API URL.",
-      "learningGoals": [
-        "Recorrer el flujo de descubrir y parchear SQL injection / RCE / SSRF intencionales",
-        "Entender la ruta de exposición de EC2 IMDS / IAM Role y las mejores prácticas para cerrarla",
-        "Experimentar el tradeoff atacante / defensor (mantener disponibilidad mientras se endurece)"
-      ]
-    },
-    "zh": {
-      "name": "Security Battle Royale (安全大逃杀)",
-      "shortDescription": "在参赛账户上攻击 / 防御故意植入漏洞的 Web 应用,最后存活的团队获胜。",
-      "description": "一个电商风格的 Web 应用 'Unicorn.Rentals' 部署时故意植入 SQL 注入、远程代码执行、SSRF、IMDS 暴露等多个漏洞。\n\n参赛者扮演以下角色之一:\n  - **攻击方**: 巡视其他团队的公开 endpoint,夺取得分资源。\n  - **防御方**: 在保持自己应用持续运行的同时,逐步堵住漏洞。\n\n部署单元: EC2 1 台 + Docker (mysql / Flask api / nginx frontend)。部署完成后,参与者会获得 Frontend URL 和 API URL。",
-      "learningGoals": [
-        "体验发现并修复故意植入的 SQL 注入 / RCE / SSRF 的完整流程",
-        "理解 EC2 IMDS / IAM Role 的暴露路径,以及关闭它的最佳实践",
-        "体验竞赛中同居的攻击者与防御者的权衡 (保持可用性的同时进行加固)"
-      ]
     }
   },
   "endpoints": [
     {
       "slot": "frontend",
-      "default": { "from": "cfn-output", "key": "FrontendUrl" },
+      "default": {
+        "from": "cfn-output",
+        "key": "FrontendUrl"
+      },
       "overridable": true,
       "label": "Frontend (nginx)",
       "description": "競技者が公開する商品ページ。 防御側は WAF / CDN を被せて override 可能。"
     },
     {
       "slot": "api",
-      "default": { "from": "cfn-output", "key": "ApiUrl" },
+      "default": {
+        "from": "cfn-output",
+        "key": "ApiUrl"
+      },
       "overridable": true,
       "label": "API (Flask)",
       "description": "JSON API endpoint。 SQL injection 等の標的。"
@@ -74,8 +66,16 @@
   "scoring": {
     "kind": "uptime-multi",
     "probedSlots": [
-      { "slot": "frontend", "path": "/", "expectStatus": [200] },
-      { "slot": "api", "path": "/healthz", "expectStatus": [200] }
+      {
+        "slot": "frontend",
+        "path": "/",
+        "expectStatus": [200]
+      },
+      {
+        "slot": "api",
+        "path": "/healthz",
+        "expectStatus": [200]
+      }
     ],
     "pointsAllOk": 100,
     "failurePenalty": 0

--- a/problems/challenges/hello-world/metadata.json
+++ b/problems/challenges/hello-world/metadata.json
@@ -10,7 +10,12 @@
   "shortDescription": "新人 SRE のあなた、 まずは加藤さんが残した SSM Parameter の挨拶を読んで Portal に貼り付けて。 100 点。",
   "description": "天下クラウド株式会社へようこそ。 あなたは今日が入社初日。 前任 SRE の加藤さんが先週 突然 退職し、 production には謎の SSM Parameter が 1 つ残されている。\n\n佐々木 CTO 曰く、 「動作確認のために残したと思う、 たぶん」。 詳細は不明。 Slack の DM 履歴を遡っても何も出てこない。 Notion の引継ぎ書には 「SSM の hello 見といて」 とだけ書いてある。\n\nあなたのミッション: AWS Console または CLI で SSM Parameter Store にアクセスし、 `/{NamePrefix}/hello` の値を読んで Participant Portal の入力欄に貼り付ける。 一致すれば +100 pt。\n\n背景: この問題は scoring engine + deploy chain の sanity-check 用 (= 加藤さんが本当にそう言ったかは別として、 そういう設計になっている)。 SSM Standard tier の Parameter 1 つだけなので AWS コストはゼロ。\n\n世界観: [`docs/lore/world.html`](../../../docs/lore/world.html) — TenkaCloud / 加藤さん / 佐々木 CTO の物語設定。",
   "tags": ["sample", "challenge", "flag", "ssm"],
-  "exposedPorts": [{ "port": 1, "name": "(no public endpoint — SSM Parameter only, port unused)" }],
+  "exposedPorts": [
+    {
+      "port": 1,
+      "name": "(no public endpoint — SSM Parameter only, port unused)"
+    }
+  ],
   "learningGoals": [
     "AWS Console / CLI で SSM Parameter Store の値を読み出す経路を体験する",
     "TenkaCloud の deploy → flag 提出 → 加点 経路が end-to-end で動くことを確認する"
@@ -25,24 +30,6 @@
       "learningGoals": [
         "Experience reading a value from SSM Parameter Store via AWS Console / CLI",
         "Verify that TenkaCloud's deploy → flag-submission → score pipeline works end-to-end"
-      ]
-    },
-    "es": {
-      "name": "Hello World (Muestra)",
-      "shortDescription": "Muestra mínima de Challenge con envío de flag. Lee un valor del SSM Parameter Store y envíalo para obtener 100 puntos.",
-      "description": "Muestra mínima del formato Challenge con envío de flag.\n\nAl desplegar se crea un único SSM Parameter `/{NamePrefix}/hello` en la cuenta AWS del competidor. El valor sigue el formato `Hello from {NamePrefix}`. Los competidores leen el parámetro desde AWS Console / CLI, pegan el valor en el campo de envío del Participant Portal y ganan +100 puntos si coincide.\n\nCoste cero (SSM Standard tier, sin EC2 / VPC / endpoint público). Útil para verificar el flujo de autoría de problemas + motor de puntuación.",
-      "learningGoals": [
-        "Experimentar la lectura de un valor desde SSM Parameter Store vía AWS Console / CLI",
-        "Verificar que la cadena de despliegue → envío de flag → puntuación de TenkaCloud funciona end-to-end"
-      ]
-    },
-    "zh": {
-      "name": "Hello World (示例)",
-      "shortDescription": "Challenge / flag 提交格式的最小示例。读取 SSM Parameter Store 中写入的值并提交即可获得 100 分。",
-      "description": "Challenge / flag 提交格式的最小示例。\n\n部署后会在参赛者的 AWS 账户中创建一个 SSM Parameter `/{NamePrefix}/hello`。其值的格式为 `Hello from {NamePrefix}`。参赛者通过 AWS Console / CLI 读取该参数,将值粘贴到 Participant Portal 的输入框中提交,若匹配则获得 +100 分。\n\n成本为零 (SSM 标准层,无 EC2 / VPC / 公开端点)。用于验证问题创作 + 评分引擎的可用性。",
-      "learningGoals": [
-        "体验通过 AWS Console / CLI 从 SSM Parameter Store 读取值的路径",
-        "验证 TenkaCloud 的 deploy → flag 提交 → 加分 路径 end-to-end 工作正常"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- 4 \`problems/*/*/metadata.json\` (hello-world / hello-world-battle / security-battle-royale / microservice-migration-battle) から \`i18n.es\` と \`i18n.zh\` block を削除
- \`problems/SCHEMA.json\` から \`i18n.properties.es\` / \`i18n.properties.zh\` を drop し description で 「SUPPORTED_LOCALES = ja + en」 を明記
- \`apps/participant-portal/src/data/problems.ts\`: \`ProblemMetadata.i18n\` 型 + \`resolveLocalizedNarrative\` の \`locale\` 引数を \`\"ja\" | \"en\"\` に narrow
- 関連 test を更新: \`locale='zh'\` / \`locale='es'\` の検証 2 件を削除、 全 4 問題が en 翻訳を持つかの check はそのまま保持
- biome のフォーマット (= 配列の inline 化) も同 PR に含む

Relates #1108

## Regression 分析

- SUPPORTED_LOCALES (= \`[\"ja\", \"en\"]\`) は既存。 portal locale switcher の選択肢は変わらない
- 4 metadata.json の en block + ja top-level は維持 → 既存 portal UI で en/ja 切替が引き続き動作
- \`resolveLocalizedNarrative\` の signature を狭めたが、 caller (= portal \`ProblemDetail\`) は \`useI18n().locale: \"ja\" | \"en\"\` を渡すので型エラーなし
- 148 portal tests pass (= 旧 150 から es/zh 専用 test 2 件削除分)

## 物理影響

- CFn / Lambda 成果物: NO-OP
- problems/SCHEMA.json: \`make validate-problems\` で schema check 通過確認済
- bundle size: portal の build-time metadata import 量が ~30% 減 (= es/zh の長文 description が消えた、 全 4 問題で ~6 KB)

## 補足

- 旧 es / zh 翻訳は git history に残るため、 将来再導入する場合は restore 可能 (= 削除ではなく shrinkage)

## Test plan

- [x] make harness
- [x] make before-commit (= validate-problems / typecheck / portal tests pass)
- [ ] CI green
- [ ] portal locale=en で 4 問題の名前 / 説明が英語表示
- [ ] portal locale=ja で 4 問題の名前 / 説明が日本語表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)