### PR TITLE
docs: remove README comparison table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,18 +131,6 @@ Schema: [`problems/SCHEMA.json`](./problems/SCHEMA.json) · onboarding guide: [`
 
 ADR 全索引は [`docs/architecture/`](./docs/architecture/) に置く。
 
-## 他プラットフォームとの比較
-
-| | TenkaCloud | AWS GameDay | CTFd | Hack The Box |
-|---|---|---|---|---|
-| 競技者の AWS account に deploy | ✅ | ✅ | ❌ | ❌ |
-| OSS / セルフホスト可 | ✅ | ❌ | ✅ | ❌ |
-| マルチテナント SaaS 層 | ✅ | N/A | ❌ | ❌ |
-| リアルタイム PvP (Battle) | ✅ | ✅ | ❌ | 部分的 |
-| Free Tier 親和 | ✅ | ❌ | ✅ | N/A |
-| Plugin 型問題 | ✅ | ❌ | ✅ | ❌ |
-| Trust Bridge (クラウド横断権限) | ✅ | ❌ | ❌ | ❌ |
-
 ## コントリビューション
 
 [CONTRIBUTING.md](./CONTRIBUTING.md) を参照。 概要は次の通り。

--- a/README.md
+++ b/README.md
@@ -127,18 +127,6 @@ Start here:
 
 Full ADR index lives under [`docs/architecture/`](./docs/architecture/).
 
-## Comparison
-
-| | TenkaCloud | AWS GameDay | CTFd | Hack The Box |
-|---|---|---|---|---|
-| Deploys to participant's own AWS | ✅ | ✅ | ❌ | ❌ |
-| OSS / self-hostable | ✅ | ❌ | ✅ | ❌ |
-| Multi-tenant SaaS layer | ✅ | N/A | ❌ | ❌ |
-| Real-time PvP (Battle) | ✅ | ✅ | ❌ | Partial |
-| Free Tier compatible | ✅ | ❌ | ✅ | N/A |
-| Plugin-style problems | ✅ | ❌ | ✅ | ❌ |
-| Trust Bridge (cross-cloud authority) | ✅ | ❌ | ❌ | ❌ |
-
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). In short:


### PR DESCRIPTION
## Summary

Relates #1124

- Remove the competitor/platform comparison table from `README.md`
- Remove the same comparison section from `README.ja.md`

## Regression 分析

- Scope is documentation-only: no application code, scripts, infrastructure, generated assets, or problem metadata changed.
- README flow remains intact: Architecture now leads directly into Contributing in both English and Japanese.
- Search verified that the removed README comparison headings and competitor names no longer remain in the two README files.
- Manual review / security-review / simplify: no runtime behavior, secrets, IAM, deploy path, or user-facing app code is touched; the change only deletes an outdated comparison surface.

## 物理影響

- DELETE: `README.md` Comparison section
- DELETE: `README.ja.md` 他プラットフォームとの比較 section
- NO-OP: CloudFormation / CDK resources
- NO-OP: Lambda / frontend build artifacts
- NO-OP: database schema / DynamoDB data

## Test plan

- `make tech-debt`
- `make harness`
- `make lint-md`
- `make lint-text`
- `make before-commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Removed the platform comparison table section from README documentation in both English and Japanese versions. The documentation structure has been simplified, with the Contributing section now directly following the architecture and ADR index for a more streamlined user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->