### PR TITLE
docs: document scripts lifecycle inventory

### DIFF
--- a/docs/operations/scripts.html
+++ b/docs/operations/scripts.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Scripts lifecycle inventory</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Scripts lifecycle inventory</h1>
+<p>This document is the source of truth for files under <code>scripts/</code>. It answers
+which files are product surface, CI checks, CodeBuild runtime glue, local
+operator tools, archived migrations, or data files.</p>
+<p>New files under <code>scripts/</code> must add a row here in the same PR. If a script has
+no current caller, mark it <code>candidate-for-removal</code> instead of leaving ownership
+implicit.</p>
+<h2>Status taxonomy</h2>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>active-product</code></td>
+<td>User-facing CLI or product runtime path.</td>
+</tr>
+<tr>
+<td><code>active-ci</code></td>
+<td>CI / pre-commit / validation gate.</td>
+</tr>
+<tr>
+<td><code>active-codebuild</code></td>
+<td>Runtime script executed inside CodeBuild or SBT pipeline jobs.</td>
+</tr>
+<tr>
+<td><code>active-local-ops</code></td>
+<td>Operator tool for local deploy, teardown, smoke, or observation.</td>
+</tr>
+<tr>
+<td><code>active-helper</code></td>
+<td>Sourced or imported by another script; do not run directly.</td>
+</tr>
+<tr>
+<td><code>active-data</code></td>
+<td>Data file consumed by an active script.</td>
+</tr>
+<tr>
+<td><code>archived-migration</code></td>
+<td>One-shot migration retained for historical recovery only.</td>
+</tr>
+<tr>
+<td><code>candidate-for-removal</code></td>
+<td>No active caller found; remove in a dedicated PR after confirmation.</td>
+</tr>
+</tbody></table>
+<h2>Inventory</h2>
+<table>
+<thead>
+<tr>
+<th>Script</th>
+<th>Status</th>
+<th>Called by</th>
+<th>Runtime context</th>
+<th>Safe to run locally</th>
+<th>Owner area</th>
+<th>Remove after</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>scripts/audit-baseline.json</code></td>
+<td><code>active-data</code></td>
+<td><code>scripts/audit-dependencies.ts</code></td>
+<td>CI / local audit</td>
+<td>No direct run</td>
+<td>supply-chain security</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/audit-dependencies.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>package.json</code> <code>audit:dependencies</code>; <code>make audit-deps</code>; CI</td>
+<td>local / CI</td>
+<td>Yes, read-only unless <code>--update</code></td>
+<td>supply-chain security</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/build-docs.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>make build-docs</code>; <code>make check-docs</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes</td>
+<td>docs</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/build-problem-index.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>package.json</code> <code>build:problems-index</code> / <code>check:problems-index</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes</td>
+<td>problem catalog</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/check-http-magic-numbers.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>make check-http-status</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes, read-only</td>
+<td>code quality</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/check-template-ascii.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>make check-template-ascii</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes, read-only</td>
+<td>problem template safety</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/check-template-cfn-refs.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>make check-template-cfn-refs</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes, read-only</td>
+<td>problem template safety</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/check-template-security.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>make check-template-security</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes, read-only</td>
+<td>problem template safety</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/cleanup.sh</code></td>
+<td><code>active-local-ops</code></td>
+<td><code>make destroy-saas</code></td>
+<td>local operator</td>
+<td>Risky: deletes SaaS stacks and buckets</td>
+<td>SaaS teardown</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/delete-battles.sh</code></td>
+<td><code>active-codebuild</code></td>
+<td>Problem deploy CodeBuild delete path; <code>docs/api/tenant.openapi.yaml</code>; <code>docs/operations/deploy-trace.md</code></td>
+<td>CodeBuild / local recovery</td>
+<td>Risky: deletes a named CFn stack</td>
+<td>problem deploy</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/deploy-battles.sh</code></td>
+<td><code>active-codebuild</code></td>
+<td>Problem deploy CodeBuild create path; <code>make deploy-battles</code>; <code>docs/api/tenant.openapi.yaml</code></td>
+<td>CodeBuild / local smoke</td>
+<td>Yes with AWS target account configured</td>
+<td>problem deploy</td>
+<td>Rename candidate only; no removal planned</td>
+</tr>
+<tr>
+<td><code>scripts/deprovision-tenant.sh</code></td>
+<td><code>active-codebuild</code></td>
+<td>SBT tenant offboarding pipeline</td>
+<td>CodeBuild</td>
+<td>No direct local run</td>
+<td>tenant lifecycle</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/destroy-battles.sh</code></td>
+<td><code>active-local-ops</code></td>
+<td><code>make destroy-battles</code></td>
+<td>local smoke teardown</td>
+<td>Risky: deletes problem stacks by derived name</td>
+<td>problem deploy smoke</td>
+<td>Rename candidate only; no removal planned</td>
+</tr>
+<tr>
+<td><code>scripts/fix-coverage-paths.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>package.json</code> <code>test:coverage</code>; CI coverage upload path</td>
+<td>local / CI</td>
+<td>Yes, rewrites coverage files only</td>
+<td>coverage</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/install.sh</code></td>
+<td><code>active-local-ops</code></td>
+<td><code>make deploy-saas</code>; README / CLAUDE deploy docs</td>
+<td>local operator</td>
+<td>Risky: deploys SaaS stacks and uploads source bundle</td>
+<td>SaaS deploy</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/lib/battles-common.sh</code></td>
+<td><code>active-helper</code></td>
+<td><code>deploy-battles.sh</code>; <code>delete-battles.sh</code>; <code>destroy-battles.sh</code></td>
+<td>sourced shell helper</td>
+<td>No direct run</td>
+<td>problem deploy</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/lib/install-node.sh</code></td>
+<td><code>active-helper</code></td>
+<td><code>provision-tenant.sh</code>; <code>update-tenant.sh</code>; <code>deprovision-tenant.sh</code></td>
+<td>CodeBuild bootstrap</td>
+<td>No direct run</td>
+<td>tenant lifecycle</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/migrate-tier-premium-to-platinum.sh</code></td>
+<td><code>archived-migration</code> / <code>candidate-for-removal</code></td>
+<td>Manual only; no active Makefile / CI caller</td>
+<td>local operator migration</td>
+<td>Risky: mutates tenant DDB rows; use <code>--dry-run</code> first</td>
+<td>historical migration</td>
+<td>Remove after confirming no pre-PR-56 tenants remain in supported environments</td>
+</tr>
+<tr>
+<td><code>scripts/prepare-source-bundle.sh</code></td>
+<td><code>active-local-ops</code></td>
+<td><code>install.sh</code>; <code>tenkacloud-lite.ts</code>; infrastructure tests</td>
+<td>local operator</td>
+<td>Yes with AWS env configured; creates/updates source bucket</td>
+<td>deploy packaging</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/print-source-bundle-lifecycle.ts</code></td>
+<td><code>active-helper</code></td>
+<td><code>prepare-source-bundle.sh</code></td>
+<td>local deploy packaging</td>
+<td>Yes, read-only stdout emitter</td>
+<td>deploy packaging</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/provision-tenant.sh</code></td>
+<td><code>active-codebuild</code></td>
+<td>SBT tenant onboarding pipeline</td>
+<td>CodeBuild</td>
+<td>No direct local run</td>
+<td>tenant lifecycle</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/tenkacloud-lite.ts</code></td>
+<td><code>active-product</code></td>
+<td><code>make deploy</code>; <code>make destroy</code>; <code>make lite-*</code>; README / CLAUDE deploy docs</td>
+<td>local operator CLI</td>
+<td>Risky for <code>up</code> / <code>down</code>; read-only for status / URL commands</td>
+<td>Lite mode</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/tenkacloud-ops.ts</code></td>
+<td><code>active-product</code></td>
+<td><code>make ops-health</code>; direct operator use</td>
+<td>local operator CLI</td>
+<td>Yes, read-only AWS observation</td>
+<td>operations</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/tenkacloud-problem.ts</code></td>
+<td><code>active-product</code></td>
+<td>README / AGENTS problem authoring docs; infrastructure tests</td>
+<td>local authoring CLI</td>
+<td>Yes; <code>create</code> writes under <code>problems/</code></td>
+<td>problem authoring</td>
+<td>Split tracked separately by #1113 / #1114</td>
+</tr>
+<tr>
+<td><code>scripts/update-tenant.sh</code></td>
+<td><code>active-codebuild</code></td>
+<td>SBT tenant update pipeline</td>
+<td>CodeBuild</td>
+<td>No direct local run</td>
+<td>tenant lifecycle</td>
+<td>-</td>
+</tr>
+<tr>
+<td><code>scripts/validate-problems.ts</code></td>
+<td><code>active-ci</code></td>
+<td><code>package.json</code> <code>validate:problems</code>; <code>make validate-problems</code>; <code>make before-commit</code></td>
+<td>local / pre-commit</td>
+<td>Yes, read-only</td>
+<td>problem authoring</td>
+<td>-</td>
+</tr>
+</tbody></table>
+<h2>Explicitly retained migration</h2>
+<p><code>scripts/migrate-tier-premium-to-platinum.sh</code> is intentionally kept in place
+for now. It has no Makefile, CI, or CodeBuild caller and should not be treated
+as active product surface. The script documents the historical <code>premium</code> to
+<code>platinum</code> tenant tier rename and includes a <code>--dry-run</code> mode, so it remains a
+manual recovery tool until supported environments are known to have no legacy
+tenant rows.</p>
+<p>Do not move or delete it in mixed refactor PRs. A dedicated cleanup PR may
+remove it after:</p>
+<ol>
+<li>caller search still shows no active automation path,</li>
+<li>supported environments have no <code>tier=&quot;premium&quot;</code> tenant rows, and</li>
+<li>the PR body lists the operational confirmation used for removal.</li>
+</ol>
+<h2>Rename candidates</h2>
+<p><code>deploy-battles.sh</code> and <code>destroy-battles.sh</code> still carry early Battle-only
+names, but they are active paths for generic problem CloudFormation stacks.
+They should not be removed. Any rename must be a separate PR because it touches
+Makefile targets, CodeBuild commands, docs, tests, and operator habits.</p>
+<p><code>delete-battles.sh</code> is also historically named, but it is the active CodeBuild
+delete path. Treat it as product runtime until a dedicated rename PR updates all
+callers.</p>
+
+<div class="doc-source">Source: <code>docs/operations/scripts.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/scripts.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/scripts.md
+++ b/docs/operations/scripts.md
@@ -1,0 +1,80 @@
+# Scripts lifecycle inventory
+
+This document is the source of truth for files under `scripts/`. It answers
+which files are product surface, CI checks, CodeBuild runtime glue, local
+operator tools, archived migrations, or data files.
+
+New files under `scripts/` must add a row here in the same PR. If a script has
+no current caller, mark it `candidate-for-removal` instead of leaving ownership
+implicit.
+
+## Status taxonomy
+
+| Status | Meaning |
+|---|---|
+| `active-product` | User-facing CLI or product runtime path. |
+| `active-ci` | CI / pre-commit / validation gate. |
+| `active-codebuild` | Runtime script executed inside CodeBuild or SBT pipeline jobs. |
+| `active-local-ops` | Operator tool for local deploy, teardown, smoke, or observation. |
+| `active-helper` | Sourced or imported by another script; do not run directly. |
+| `active-data` | Data file consumed by an active script. |
+| `archived-migration` | One-shot migration retained for historical recovery only. |
+| `candidate-for-removal` | No active caller found; remove in a dedicated PR after confirmation. |
+
+## Inventory
+
+| Script | Status | Called by | Runtime context | Safe to run locally | Owner area | Remove after |
+|---|---|---|---|---|---|---|
+| `scripts/audit-baseline.json` | `active-data` | `scripts/audit-dependencies.ts` | CI / local audit | No direct run | supply-chain security | - |
+| `scripts/audit-dependencies.ts` | `active-ci` | `package.json` `audit:dependencies`; `make audit-deps`; CI | local / CI | Yes, read-only unless `--update` | supply-chain security | - |
+| `scripts/build-docs.ts` | `active-ci` | `make build-docs`; `make check-docs`; `make before-commit` | local / pre-commit | Yes | docs | - |
+| `scripts/build-problem-index.ts` | `active-ci` | `package.json` `build:problems-index` / `check:problems-index`; `make before-commit` | local / pre-commit | Yes | problem catalog | - |
+| `scripts/check-http-magic-numbers.ts` | `active-ci` | `make check-http-status`; `make before-commit` | local / pre-commit | Yes, read-only | code quality | - |
+| `scripts/check-template-ascii.ts` | `active-ci` | `make check-template-ascii`; `make before-commit` | local / pre-commit | Yes, read-only | problem template safety | - |
+| `scripts/check-template-cfn-refs.ts` | `active-ci` | `make check-template-cfn-refs`; `make before-commit` | local / pre-commit | Yes, read-only | problem template safety | - |
+| `scripts/check-template-security.ts` | `active-ci` | `make check-template-security`; `make before-commit` | local / pre-commit | Yes, read-only | problem template safety | - |
+| `scripts/cleanup.sh` | `active-local-ops` | `make destroy-saas` | local operator | Risky: deletes SaaS stacks and buckets | SaaS teardown | - |
+| `scripts/delete-battles.sh` | `active-codebuild` | Problem deploy CodeBuild delete path; `docs/api/tenant.openapi.yaml`; `docs/operations/deploy-trace.md` | CodeBuild / local recovery | Risky: deletes a named CFn stack | problem deploy | - |
+| `scripts/deploy-battles.sh` | `active-codebuild` | Problem deploy CodeBuild create path; `make deploy-battles`; `docs/api/tenant.openapi.yaml` | CodeBuild / local smoke | Yes with AWS target account configured | problem deploy | Rename candidate only; no removal planned |
+| `scripts/deprovision-tenant.sh` | `active-codebuild` | SBT tenant offboarding pipeline | CodeBuild | No direct local run | tenant lifecycle | - |
+| `scripts/destroy-battles.sh` | `active-local-ops` | `make destroy-battles` | local smoke teardown | Risky: deletes problem stacks by derived name | problem deploy smoke | Rename candidate only; no removal planned |
+| `scripts/fix-coverage-paths.ts` | `active-ci` | `package.json` `test:coverage`; CI coverage upload path | local / CI | Yes, rewrites coverage files only | coverage | - |
+| `scripts/install.sh` | `active-local-ops` | `make deploy-saas`; README / CLAUDE deploy docs | local operator | Risky: deploys SaaS stacks and uploads source bundle | SaaS deploy | - |
+| `scripts/lib/battles-common.sh` | `active-helper` | `deploy-battles.sh`; `delete-battles.sh`; `destroy-battles.sh` | sourced shell helper | No direct run | problem deploy | - |
+| `scripts/lib/install-node.sh` | `active-helper` | `provision-tenant.sh`; `update-tenant.sh`; `deprovision-tenant.sh` | CodeBuild bootstrap | No direct run | tenant lifecycle | - |
+| `scripts/migrate-tier-premium-to-platinum.sh` | `archived-migration` / `candidate-for-removal` | Manual only; no active Makefile / CI caller | local operator migration | Risky: mutates tenant DDB rows; use `--dry-run` first | historical migration | Remove after confirming no pre-PR-56 tenants remain in supported environments |
+| `scripts/prepare-source-bundle.sh` | `active-local-ops` | `install.sh`; `tenkacloud-lite.ts`; infrastructure tests | local operator | Yes with AWS env configured; creates/updates source bucket | deploy packaging | - |
+| `scripts/print-source-bundle-lifecycle.ts` | `active-helper` | `prepare-source-bundle.sh` | local deploy packaging | Yes, read-only stdout emitter | deploy packaging | - |
+| `scripts/provision-tenant.sh` | `active-codebuild` | SBT tenant onboarding pipeline | CodeBuild | No direct local run | tenant lifecycle | - |
+| `scripts/tenkacloud-lite.ts` | `active-product` | `make deploy`; `make destroy`; `make lite-*`; README / CLAUDE deploy docs | local operator CLI | Risky for `up` / `down`; read-only for status / URL commands | Lite mode | - |
+| `scripts/tenkacloud-ops.ts` | `active-product` | `make ops-health`; direct operator use | local operator CLI | Yes, read-only AWS observation | operations | - |
+| `scripts/tenkacloud-problem.ts` | `active-product` | README / AGENTS problem authoring docs; infrastructure tests | local authoring CLI | Yes; `create` writes under `problems/` | problem authoring | Split tracked separately by #1113 / #1114 |
+| `scripts/update-tenant.sh` | `active-codebuild` | SBT tenant update pipeline | CodeBuild | No direct local run | tenant lifecycle | - |
+| `scripts/validate-problems.ts` | `active-ci` | `package.json` `validate:problems`; `make validate-problems`; `make before-commit` | local / pre-commit | Yes, read-only | problem authoring | - |
+
+## Explicitly retained migration
+
+`scripts/migrate-tier-premium-to-platinum.sh` is intentionally kept in place
+for now. It has no Makefile, CI, or CodeBuild caller and should not be treated
+as active product surface. The script documents the historical `premium` to
+`platinum` tenant tier rename and includes a `--dry-run` mode, so it remains a
+manual recovery tool until supported environments are known to have no legacy
+tenant rows.
+
+Do not move or delete it in mixed refactor PRs. A dedicated cleanup PR may
+remove it after:
+
+1. caller search still shows no active automation path,
+2. supported environments have no `tier="premium"` tenant rows, and
+3. the PR body lists the operational confirmation used for removal.
+
+## Rename candidates
+
+`deploy-battles.sh` and `destroy-battles.sh` still carry early Battle-only
+names, but they are active paths for generic problem CloudFormation stacks.
+They should not be removed. Any rename must be a separate PR because it touches
+Makefile targets, CodeBuild commands, docs, tests, and operator habits.
+
+`delete-battles.sh` is also historically named, but it is the active CodeBuild
+delete path. Treat it as product runtime until a dedicated rename PR updates all
+callers.


### PR DESCRIPTION
## Summary

Closes #1125

- Add `docs/operations/scripts.md` as the lifecycle inventory for every file under `scripts/`
- Generate `docs/operations/scripts.html` from the markdown source
- Mark active product, CI, CodeBuild, helper, data, local-ops, archived migration, and candidate-for-removal statuses
- Explicitly retain `scripts/migrate-tier-premium-to-platinum.sh` as an archived migration / candidate-for-removal instead of moving or deleting it in this PR

## Regression 分析

- Documentation-only change: no script path, Makefile target, CI workflow, infrastructure code, or runtime behavior changed.
- Every current file from `rg --files scripts` is listed in the inventory; a caller or candidate-for-removal status is documented for each row.
- One-shot migration handling is explicit: the historical tier migration remains in place and is not treated as active product surface.
- Generated HTML was rebuilt through the existing docs pipeline and verified with `make check-docs`.

## 物理影響

- CREATE: `docs/operations/scripts.md`
- CREATE: `docs/operations/scripts.html`
- NO-OP: `scripts/*` file paths and behavior
- NO-OP: Makefile / CI references
- NO-OP: CloudFormation / CDK resources
- NO-OP: Lambda / frontend build artifacts
- NO-OP: database schema / DynamoDB data

## Test plan

- `make build-docs`
- `make lint-md`
- `make lint-text`
- `make check-docs`
- `make harness`
- `make before-commit`
