### PR TITLE
refactor: add event handler route helpers

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -13,7 +13,6 @@ import {
   TENANT_OPERATOR_ROLE,
   TENANT_ROLES,
 } from "../deploy-handler/auth.js";
-import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
 import {
   HTTP_ACCEPTED,
   HTTP_BAD_REQUEST,
@@ -29,15 +28,18 @@ import { bulkTeardownEvent } from "./bulk-delete.js";
 import { bulkDeployEvent } from "./bulk-deploy.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "./create.js";
 import { createNotification } from "./create-notification.js";
-import {
-  fireDisruption,
-  isEventOwnedByTenant,
-  listDisruptionAudit,
-  listDisruptionCatalog,
-} from "./disruption-fire.js";
+import { fireDisruption, listDisruptionAudit, listDisruptionCatalog } from "./disruption-fire.js";
 import { endEvent } from "./end-event.js";
 import { getEventDetail, listEvents } from "./list.js";
 import { lockScoring, unlockScoring } from "./lock-scoring.js";
+import {
+  handleRouteError,
+  parseJsonBody,
+  parseOptionalJsonBody,
+  requireEventOwnership,
+  withEventId,
+  withJsonBody,
+} from "./route-helpers.js";
 import { setEventSchedule } from "./schedule.js";
 import { buildEventSharedResources } from "./shared.js";
 import {
@@ -137,39 +139,34 @@ app.use("/events/*", async (c, next) => {
 
 app.get("/events/healthz", (c) => c.json({ ok: true }));
 
-app.post("/events", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-
-  const parsed = CreateEventRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
-  }
-
-  try {
-    const response = await createEvent(
-      shared,
-      { tenantId: resolveTenantId(c), nowMs: Date.now() },
-      parsed.data,
-    );
-    return c.json(response, HTTP_CREATED);
-  } catch (err) {
-    if (err instanceof DuplicateInternalSlugError) {
-      return c.json({ error: "duplicate_internal_slug", slug: err.slug }, HTTP_BAD_REQUEST);
-    }
-    if (err instanceof DuplicateProblemIdError) {
-      return c.json({ error: "duplicate_problem_id", problemId: err.problemId }, HTTP_BAD_REQUEST);
-    }
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] createEvent failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events",
+  withJsonBody(
+    CreateEventRequestSchema,
+    async ({ c, body }) => {
+      try {
+        const response = await createEvent(
+          shared,
+          { tenantId: resolveTenantId(c), nowMs: Date.now() },
+          body,
+        );
+        return c.json(response, HTTP_CREATED);
+      } catch (err) {
+        if (err instanceof DuplicateInternalSlugError) {
+          return c.json({ error: "duplicate_internal_slug", slug: err.slug }, HTTP_BAD_REQUEST);
+        }
+        if (err instanceof DuplicateProblemIdError) {
+          return c.json(
+            { error: "duplicate_problem_id", problemId: err.problemId },
+            HTTP_BAD_REQUEST,
+          );
+        }
+        return handleRouteError(c, "[events] createEvent failed", {}, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
 app.get("/events", async (c) => {
   const parsedLimit = parseLimit(c.req.query("limit"));
@@ -182,421 +179,371 @@ app.get("/events", async (c) => {
     });
     return c.json(response, HTTP_OK);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] listEvents failed", { message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+    return handleRouteError(c, "[events] listEvents failed", {}, err);
   }
 });
 
-app.get("/events/:eventId", async (c) => {
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  // Issue #1038 P1 #7: opt-in で全 team の累計 score event timeline を返す。
-  // default (= "true" 以外) は scoreEventsByTeam を省き、 既存 caller を素通り。
-  const withScoreEvents = c.req.query("withScoreEvents") === "true";
-  try {
-    const detail = await getEventDetail(shared, resolveTenantId(c), eventId, { withScoreEvents });
-    if (!detail) return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    return c.json(detail, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] getEventDetail failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.get(
+  "/events/:eventId",
+  withEventId(async ({ c, eventId }) => {
+    // Issue #1038 P1 #7: opt-in で全 team の累計 score event timeline を返す。
+    // default (= "true" 以外) は scoreEventsByTeam を省き、 既存 caller を素通り。
+    const withScoreEvents = c.req.query("withScoreEvents") === "true";
+    try {
+      const detail = await getEventDetail(shared, resolveTenantId(c), eventId, {
+        withScoreEvents,
+      });
+      if (!detail) return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+      return c.json(detail, HTTP_OK);
+    } catch (err) {
+      return handleRouteError(c, "[events] getEventDetail failed", { eventId }, err);
+    }
+  }),
+);
 
-app.patch("/events/:eventId/schedule", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-  const parsed = ScheduleEventRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
-  }
-  const nowMs = Date.now();
-  // `startNow: true` は server now を ISO8601 化して startsAt に解決 (= 即座に開始)。
-  // #536: endsAt も同 endpoint で受け、predictive scheduling を可能に。
-  const resolvedStartsAt = parsed.data.startNow
-    ? new Date(nowMs).toISOString()
-    : parsed.data.startsAt;
-  const resolvedEndsAt = parsed.data.endsAt;
-  try {
-    const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, {
-      startsAt: resolvedStartsAt,
-      endsAt: resolvedEndsAt,
-      scoreboardFreezeMinutes: parsed.data.scoreboardFreezeMinutes,
-      nowMs,
-    });
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    if (outcome.kind === "past_starts_at") {
-      // #537: 過去 startsAt を frontend が迂回した場合の防御線。SLACK (= 60s) より過去なら
-      // 「即座に開始」 button を使うべきなので reject。
-      return c.json(
-        {
-          error: "past_starts_at",
-          message:
-            "startsAt が過去の時刻です。「即座に開始」 button を使うか、未来の時刻を指定してください。",
-          startsAt: outcome.startsAt,
-          serverNow: new Date(outcome.nowMs).toISOString(),
-        },
-        HTTP_BAD_REQUEST,
-      );
-    }
-    if (outcome.kind === "past_ends_at") {
-      // #536: 過去 endsAt を弾く。「Event を終了」 button (= 即終了) は別 endpoint なので、
-      // 本 schedule API には未来の endsAt のみ来る想定。
-      return c.json(
-        {
-          error: "past_ends_at",
-          message:
-            "endsAt が過去の時刻です。「Event を終了」 button (= 即時) を使うか、未来の時刻を指定してください。",
-          endsAt: outcome.endsAt,
-          serverNow: new Date(outcome.nowMs).toISOString(),
-        },
-        HTTP_BAD_REQUEST,
-      );
-    }
-    if (outcome.kind === "ends_before_starts") {
-      // #536: 競技時間 0 以下を弾く。
-      return c.json(
-        {
-          error: "ends_before_starts",
-          message: "endsAt は startsAt より後の時刻を指定してください。",
-          startsAt: outcome.startsAt,
-          endsAt: outcome.endsAt,
-        },
-        HTTP_BAD_REQUEST,
-      );
-    }
-    if (outcome.kind === "no_op") {
-      return c.json({ error: "no_op", message: "更新対象が指定されていません" }, HTTP_BAD_REQUEST);
-    }
-    return c.json(
-      {
-        startsAt: outcome.startsAt,
-        endsAt: outcome.endsAt,
-        updatedDeployments: outcome.updatedDeployments,
-      },
-      HTTP_OK,
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] setEventSchedule failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.patch(
+  "/events/:eventId/schedule",
+  withEventId(
+    async ({ c, eventId }) => {
+      const parsed = await parseJsonBody(c, ScheduleEventRequestSchema);
+      if (!parsed.ok) return parsed.response;
+      const nowMs = Date.now();
+      // `startNow: true` は server now を ISO8601 化して startsAt に解決 (= 即座に開始)。
+      // #536: endsAt も同 endpoint で受け、predictive scheduling を可能に。
+      const resolvedStartsAt = parsed.data.startNow
+        ? new Date(nowMs).toISOString()
+        : parsed.data.startsAt;
+      const resolvedEndsAt = parsed.data.endsAt;
+      try {
+        const outcome = await setEventSchedule(shared, resolveTenantId(c), eventId, {
+          startsAt: resolvedStartsAt,
+          endsAt: resolvedEndsAt,
+          scoreboardFreezeMinutes: parsed.data.scoreboardFreezeMinutes,
+          nowMs,
+        });
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        if (outcome.kind === "past_starts_at") {
+          // #537: 過去 startsAt を frontend が迂回した場合の防御線。SLACK (= 60s) より過去なら
+          // 「即座に開始」 button を使うべきなので reject。
+          return c.json(
+            {
+              error: "past_starts_at",
+              message:
+                "startsAt が過去の時刻です。「即座に開始」 button を使うか、未来の時刻を指定してください。",
+              startsAt: outcome.startsAt,
+              serverNow: new Date(outcome.nowMs).toISOString(),
+            },
+            HTTP_BAD_REQUEST,
+          );
+        }
+        if (outcome.kind === "past_ends_at") {
+          // #536: 過去 endsAt を弾く。「Event を終了」 button (= 即終了) は別 endpoint なので、
+          // 本 schedule API には未来の endsAt のみ来る想定。
+          return c.json(
+            {
+              error: "past_ends_at",
+              message:
+                "endsAt が過去の時刻です。「Event を終了」 button (= 即時) を使うか、未来の時刻を指定してください。",
+              endsAt: outcome.endsAt,
+              serverNow: new Date(outcome.nowMs).toISOString(),
+            },
+            HTTP_BAD_REQUEST,
+          );
+        }
+        if (outcome.kind === "ends_before_starts") {
+          // #536: 競技時間 0 以下を弾く。
+          return c.json(
+            {
+              error: "ends_before_starts",
+              message: "endsAt は startsAt より後の時刻を指定してください。",
+              startsAt: outcome.startsAt,
+              endsAt: outcome.endsAt,
+            },
+            HTTP_BAD_REQUEST,
+          );
+        }
+        if (outcome.kind === "no_op") {
+          return c.json(
+            { error: "no_op", message: "更新対象が指定されていません" },
+            HTTP_BAD_REQUEST,
+          );
+        }
+        return c.json(
+          {
+            startsAt: outcome.startsAt,
+            endsAt: outcome.endsAt,
+            updatedDeployments: outcome.updatedDeployments,
+          },
+          HTTP_OK,
+        );
+      } catch (err) {
+        return handleRouteError(c, "[events] setEventSchedule failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
-app.post("/events/:eventId/end", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await endEvent(shared, resolveTenantId(c), eventId, Date.now());
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    if (outcome.kind === "not_endable") {
-      return c.json({ error: "not_endable", currentStatus: outcome.status }, HTTP_CONFLICT);
-    }
-    return c.json(
-      { endsAt: outcome.endsAt, updatedDeployments: outcome.updatedDeployments },
-      HTTP_OK,
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] endEvent failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/end",
+  withEventId(
+    async ({ c, eventId }) => {
+      try {
+        const outcome = await endEvent(shared, resolveTenantId(c), eventId, Date.now());
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        if (outcome.kind === "not_endable") {
+          return c.json({ error: "not_endable", currentStatus: outcome.status }, HTTP_CONFLICT);
+        }
+        return c.json(
+          { endsAt: outcome.endsAt, updatedDeployments: outcome.updatedDeployments },
+          HTTP_OK,
+        );
+      } catch (err) {
+        return handleRouteError(c, "[events] endEvent failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
 // #558: scoring lock — operator が表彰フェーズで採点を凍結 / 解除する。
 //   - POST  /events/:eventId/lock-scoring : 採点 lock (scoringLocked=true)
 //   - DELETE /events/:eventId/lock-scoring : 採点 unlock (scoringLocked を REMOVE)
 // idempotent: already locked / unlocked のときは 200 + body に現状を返す。
 // status=READY / ENDED のみ lockable (= 加点経路があり得る state)。
-app.post("/events/:eventId/lock-scoring", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await lockScoring(
-      shared,
-      resolveTenantId(c),
-      eventId,
-      resolveCognitoSub(c),
-      Date.now(),
-    );
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    if (outcome.kind === "not_lockable") {
-      return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
-    }
-    return c.json(
-      {
-        scoringLocked: outcome.scoringLocked,
-        scoringLockedAt: outcome.kind === "ok" ? outcome.scoringLockedAt : undefined,
-        idempotent: outcome.kind === "already",
-      },
-      HTTP_OK,
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] lockScoring failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/lock-scoring",
+  withEventId(
+    async ({ c, eventId }) => {
+      try {
+        const outcome = await lockScoring(
+          shared,
+          resolveTenantId(c),
+          eventId,
+          resolveCognitoSub(c),
+          Date.now(),
+        );
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        if (outcome.kind === "not_lockable") {
+          return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
+        }
+        return c.json(
+          {
+            scoringLocked: outcome.scoringLocked,
+            scoringLockedAt: outcome.kind === "ok" ? outcome.scoringLockedAt : undefined,
+            idempotent: outcome.kind === "already",
+          },
+          HTTP_OK,
+        );
+      } catch (err) {
+        return handleRouteError(c, "[events] lockScoring failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE] },
+  ),
+);
 
-app.delete("/events/:eventId/lock-scoring", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await unlockScoring(shared, resolveTenantId(c), eventId, Date.now());
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    if (outcome.kind === "not_lockable") {
-      return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
-    }
-    return c.json(
-      {
-        scoringLocked: outcome.scoringLocked,
-        idempotent: outcome.kind === "already",
-      },
-      HTTP_OK,
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] unlockScoring failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.delete(
+  "/events/:eventId/lock-scoring",
+  withEventId(
+    async ({ c, eventId }) => {
+      try {
+        const outcome = await unlockScoring(shared, resolveTenantId(c), eventId, Date.now());
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        if (outcome.kind === "not_lockable") {
+          return c.json({ error: "not_lockable", currentStatus: outcome.status }, HTTP_CONFLICT);
+        }
+        return c.json(
+          {
+            scoringLocked: outcome.scoringLocked,
+            idempotent: outcome.kind === "already",
+          },
+          HTTP_OK,
+        );
+      } catch (err) {
+        return handleRouteError(c, "[events] unlockScoring failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE] },
+  ),
+);
 
-app.post("/events/:eventId/notifications", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-  const parsed = NotificationCreateRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await createNotification(
-      shared,
-      resolveTenantId(c),
-      eventId,
-      resolveCognitoSub(c),
-      parsed.data,
-    );
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    return c.json(
-      { notificationId: outcome.notificationId, occurredAt: outcome.occurredAt },
-      HTTP_CREATED,
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] createNotification failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/notifications",
+  withEventId(
+    async ({ c, eventId }) => {
+      const parsed = await parseJsonBody(c, NotificationCreateRequestSchema);
+      if (!parsed.ok) return parsed.response;
+      try {
+        const outcome = await createNotification(
+          shared,
+          resolveTenantId(c),
+          eventId,
+          resolveCognitoSub(c),
+          parsed.data,
+        );
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        return c.json(
+          { notificationId: outcome.notificationId, occurredAt: outcome.occurredAt },
+          HTTP_CREATED,
+        );
+      } catch (err) {
+        return handleRouteError(c, "[events] createNotification failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
-app.post("/events/:eventId/archive", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await archiveEvent(shared, resolveTenantId(c), eventId, Date.now());
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    if (outcome.kind === "not_archivable") {
-      return c.json({ error: "not_archivable", currentStatus: outcome.status }, HTTP_CONFLICT);
-    }
-    return c.json({ archivedAt: outcome.archivedAt }, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] archiveEvent failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/archive",
+  withEventId(
+    async ({ c, eventId }) => {
+      try {
+        const outcome = await archiveEvent(shared, resolveTenantId(c), eventId, Date.now());
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        if (outcome.kind === "not_archivable") {
+          return c.json({ error: "not_archivable", currentStatus: outcome.status }, HTTP_CONFLICT);
+        }
+        return c.json({ archivedAt: outcome.archivedAt }, HTTP_OK);
+      } catch (err) {
+        return handleRouteError(c, "[events] archiveEvent failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE] },
+  ),
+);
 
-app.post("/events/:eventId/deploy", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  // #555: body は opt-in。空 body は bulk-all 扱い (= 後方互換)。値が来た場合だけ
-  // validate (= retryFailedOnly / teamIds / problemIds の filter として使う)。
-  let body: unknown = {};
-  const raw = await c.req.text().catch(() => "");
-  if (raw.length > 0) {
-    try {
-      body = JSON.parse(raw);
-    } catch {
-      return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-    }
-  }
-  const parsed = BulkDeployRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await bulkDeployEvent(
-      shared,
-      resolveTenantId(c),
-      eventId,
-      Date.now(),
-      parsed.data,
-    );
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    return c.json(outcome.result, HTTP_ACCEPTED);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] bulkDeployEvent failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/deploy",
+  withEventId(
+    async ({ c, eventId }) => {
+      // #555: body は opt-in。空 body は bulk-all 扱い (= 後方互換)。値が来た場合だけ
+      // validate (= retryFailedOnly / teamIds / problemIds の filter として使う)。
+      const parsed = await parseOptionalJsonBody(c, BulkDeployRequestSchema);
+      if (!parsed.ok) return parsed.response;
+      try {
+        const outcome = await bulkDeployEvent(
+          shared,
+          resolveTenantId(c),
+          eventId,
+          Date.now(),
+          parsed.data,
+        );
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        return c.json(outcome.result, HTTP_ACCEPTED);
+      } catch (err) {
+        return handleRouteError(c, "[events] bulkDeployEvent failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
 // Issue #888 Phase A: Red Team Disruption Injection
 //   GET    /events/:eventId/disruptions          — event 内 disruption catalog
 //   GET    /events/:eventId/disruptions/audit    — 発火履歴 (pagination)
 //   POST   /events/:eventId/disruptions/fire     — disruption を fire
-app.get("/events/:eventId/disruptions", async (c) => {
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    // PR #889 review: 他 tenant の event を obscured ID で覗くのを防ぐため tenant ownership 必須
-    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
-      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+app.get(
+  "/events/:eventId/disruptions",
+  withEventId(async ({ c, eventId }) => {
+    try {
+      // PR #889 review: 他 tenant の event を obscured ID で覗くのを防ぐため tenant ownership 必須
+      const tenantId = resolveTenantId(c);
+      const ownershipError = await requireEventOwnership({ c, shared, eventId, tenantId });
+      if (ownershipError) return ownershipError;
+      const out = await listDisruptionCatalog(shared, eventId);
+      return c.json(out, HTTP_OK);
+    } catch (err) {
+      return handleRouteError(c, "[disruptions] catalog failed", { eventId }, err);
     }
-    const out = await listDisruptionCatalog(shared, eventId);
-    return c.json(out, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[disruptions] catalog failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+  }),
+);
 
-app.get("/events/:eventId/disruptions/audit", async (c) => {
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  const limitRaw = c.req.query("limit");
-  const parsed = parseLimit(limitRaw);
-  if (!parsed) return c.json({ error: "invalid_limit" }, HTTP_BAD_REQUEST);
-  const cursor = c.req.query("cursor");
-  try {
-    // PR #889 review: 他 tenant の audit log を覗かれないよう tenant ownership 必須
-    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
-      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+app.get(
+  "/events/:eventId/disruptions/audit",
+  withEventId(async ({ c, eventId }) => {
+    const limitRaw = c.req.query("limit");
+    const parsed = parseLimit(limitRaw);
+    if (!parsed) return c.json({ error: "invalid_limit" }, HTTP_BAD_REQUEST);
+    const cursor = c.req.query("cursor");
+    try {
+      // PR #889 review: 他 tenant の audit log を覗かれないよう tenant ownership 必須
+      const tenantId = resolveTenantId(c);
+      const ownershipError = await requireEventOwnership({ c, shared, eventId, tenantId });
+      if (ownershipError) return ownershipError;
+      const out = await listDisruptionAudit(shared, eventId, {
+        limit: parsed.limit,
+        cursor,
+      });
+      return c.json(out, HTTP_OK);
+    } catch (err) {
+      return handleRouteError(c, "[disruptions] audit list failed", { eventId }, err);
     }
-    const out = await listDisruptionAudit(shared, eventId, {
-      limit: parsed.limit,
-      cursor,
-    });
-    return c.json(out, HTTP_OK);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[disruptions] audit list failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+  }),
+);
 
-app.post("/events/:eventId/disruptions/fire", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "invalid_body" }, HTTP_BAD_REQUEST);
-  }
-  // PR #889 review: 既存 route と整合する Zod parse に統一 (= cross-field 制約も含めて検証)
-  const parsed = DisruptionFireRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "validation_failed", issues: parsed.error.issues }, HTTP_BAD_REQUEST);
-  }
-  const req = parsed.data;
-  try {
-    // PR #889 review: 他 tenant の event に fire できないよう ownership 必須
-    if (!(await isEventOwnedByTenant(shared, eventId, resolveTenantId(c)))) {
-      return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    }
-    const outcome = await fireDisruption(shared, {
-      tenantId: resolveTenantId(c),
-      eventId,
-      problemId: req.problemId,
-      disruptionId: req.disruptionId,
-      parameters: req.parameters ?? {},
-      scope: req.scope,
-      targetTeamIds: req.targetTeamIds ?? [],
-      ...(req.randomCount !== undefined ? { randomCount: req.randomCount } : {}),
-      requestId: req.requestId,
-      firedBy: resolveCognitoSub(c),
-      nowMs: Date.now(),
-    });
-    if (outcome.kind === "ok") return c.json(outcome.result, HTTP_CREATED);
-    if (outcome.kind === "duplicate") return c.json(outcome.result, HTTP_OK);
-    if (outcome.kind === "unknown_problem")
-      return c.json({ error: "unknown_problem" }, HTTP_BAD_REQUEST);
-    if (outcome.kind === "unknown_disruption")
-      return c.json({ error: "unknown_disruption" }, HTTP_BAD_REQUEST);
-    if (outcome.kind === "invalid_parameters")
-      return c.json({ error: "invalid_parameters", message: outcome.reason }, HTTP_BAD_REQUEST);
-    if (outcome.kind === "invalid_scope")
-      return c.json({ error: "invalid_scope", message: outcome.reason }, HTTP_BAD_REQUEST);
-    if (outcome.kind === "no_targets") return c.json({ error: "no_targets" }, HTTP_CONFLICT);
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[disruptions] fire failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.post(
+  "/events/:eventId/disruptions/fire",
+  withEventId(
+    async ({ c, eventId }) => {
+      // PR #889 review: 既存 route と整合する Zod parse に統一 (= cross-field 制約も含めて検証)
+      const parsed = await parseJsonBody(c, DisruptionFireRequestSchema);
+      if (!parsed.ok) return parsed.response;
+      const req = parsed.data;
+      try {
+        // PR #889 review: 他 tenant の event に fire できないよう ownership 必須
+        const tenantId = resolveTenantId(c);
+        const ownershipError = await requireEventOwnership({ c, shared, eventId, tenantId });
+        if (ownershipError) return ownershipError;
+        const outcome = await fireDisruption(shared, {
+          tenantId,
+          eventId,
+          problemId: req.problemId,
+          disruptionId: req.disruptionId,
+          parameters: req.parameters ?? {},
+          scope: req.scope,
+          targetTeamIds: req.targetTeamIds ?? [],
+          ...(req.randomCount !== undefined ? { randomCount: req.randomCount } : {}),
+          requestId: req.requestId,
+          firedBy: resolveCognitoSub(c),
+          nowMs: Date.now(),
+        });
+        if (outcome.kind === "ok") return c.json(outcome.result, HTTP_CREATED);
+        if (outcome.kind === "duplicate") return c.json(outcome.result, HTTP_OK);
+        if (outcome.kind === "unknown_problem")
+          return c.json({ error: "unknown_problem" }, HTTP_BAD_REQUEST);
+        if (outcome.kind === "unknown_disruption")
+          return c.json({ error: "unknown_disruption" }, HTTP_BAD_REQUEST);
+        if (outcome.kind === "invalid_parameters")
+          return c.json({ error: "invalid_parameters", message: outcome.reason }, HTTP_BAD_REQUEST);
+        if (outcome.kind === "invalid_scope")
+          return c.json({ error: "invalid_scope", message: outcome.reason }, HTTP_BAD_REQUEST);
+        if (outcome.kind === "no_targets") return c.json({ error: "no_targets" }, HTTP_CONFLICT);
+        return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
+      } catch (err) {
+        return handleRouteError(c, "[disruptions] fire failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE, TENANT_OPERATOR_ROLE] },
+  ),
+);
 
-app.delete("/events/:eventId", async (c) => {
-  requireRole(c, [TENANT_ADMIN_ROLE]);
-  const eventId = c.req.param("eventId");
-  if (!eventId || !EVENT_ID_RE.test(eventId)) {
-    return c.json({ error: "invalid_event_id" }, HTTP_BAD_REQUEST);
-  }
-  try {
-    const outcome = await bulkTeardownEvent(shared, resolveTenantId(c), eventId, Date.now());
-    if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
-    return c.json(outcome.result, HTTP_ACCEPTED);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    console.error("[events] bulkTeardownEvent failed", { eventId, message });
-    return c.json({ error: "internal_error" }, HTTP_INTERNAL_ERROR);
-  }
-});
+app.delete(
+  "/events/:eventId",
+  withEventId(
+    async ({ c, eventId }) => {
+      try {
+        const outcome = await bulkTeardownEvent(shared, resolveTenantId(c), eventId, Date.now());
+        if (outcome.kind === "not_found") return c.json({ error: "not_found" }, HTTP_NOT_FOUND);
+        return c.json(outcome.result, HTTP_ACCEPTED);
+      } catch (err) {
+        return handleRouteError(c, "[events] bulkTeardownEvent failed", { eventId }, err);
+      }
+    },
+    { roles: [TENANT_ADMIN_ROLE] },
+  ),
+);
 
 export const handler = handle(app) as (
   event: LambdaEvent,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/route-helpers.ts
@@ -1,0 +1,133 @@
+import type { Context, Handler } from "hono";
+import { StatusCodes } from "http-status-codes";
+import type { z } from "zod";
+import { requireRole } from "../deploy-handler/auth.js";
+import { ULID_RE as EVENT_ID_RE } from "../shared/constants.js";
+import { isEventOwnedByTenant } from "./disruption-fire.js";
+import type { EventSharedResources } from "./shared.js";
+
+type RouteResult = Response | Promise<Response>;
+
+interface RouteContext {
+  readonly c: Context;
+}
+
+interface EventRouteContext extends RouteContext {
+  readonly eventId: string;
+}
+
+interface JsonRouteContext<TBody> extends RouteContext {
+  readonly body: TBody;
+}
+
+interface RouteOptions {
+  readonly roles?: readonly string[];
+}
+
+type ParseResult<TBody> =
+  | { readonly ok: true; readonly data: TBody }
+  | { readonly ok: false; readonly response: Response };
+
+export function withEventId(
+  handler: (ctx: EventRouteContext) => RouteResult,
+  options: RouteOptions = {},
+): Handler {
+  return (c) => {
+    applyRouteRole(c, options);
+    const parsed = parseEventId(c);
+    if (!parsed.ok) return parsed.response;
+    return handler({ c, eventId: parsed.data });
+  };
+}
+
+export function withJsonBody<TSchema extends z.ZodType>(
+  schema: TSchema,
+  handler: (ctx: JsonRouteContext<z.infer<TSchema>>) => RouteResult,
+  options: RouteOptions = {},
+): Handler {
+  return async (c) => {
+    applyRouteRole(c, options);
+    const parsed = await parseJsonBody(c, schema);
+    if (!parsed.ok) return parsed.response;
+    return handler({ c, body: parsed.data });
+  };
+}
+
+export async function parseJsonBody<TSchema extends z.ZodType>(
+  c: Context,
+  schema: TSchema,
+): Promise<ParseResult<z.infer<TSchema>>> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return { ok: false, response: c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST) };
+  }
+  return parseSchemaBody(c, schema, body);
+}
+
+export async function parseOptionalJsonBody<TSchema extends z.ZodType>(
+  c: Context,
+  schema: TSchema,
+): Promise<ParseResult<z.infer<TSchema>>> {
+  let body: unknown = {};
+  const raw = await c.req.text().catch(() => "");
+  if (raw.length > 0) {
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      return { ok: false, response: c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST) };
+    }
+  }
+  return parseSchemaBody(c, schema, body);
+}
+
+export function handleRouteError(
+  c: Context,
+  logMessage: string,
+  fields: Record<string, unknown>,
+  err: unknown,
+): Response {
+  const message = err instanceof Error ? err.message : "unknown error";
+  console.error(logMessage, { ...fields, message });
+  return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+}
+
+export async function requireEventOwnership(args: {
+  readonly c: Context;
+  readonly shared: EventSharedResources;
+  readonly eventId: string;
+  readonly tenantId: string;
+}): Promise<Response | undefined> {
+  const { c, shared, eventId, tenantId } = args;
+  if (await isEventOwnedByTenant(shared, eventId, tenantId)) return undefined;
+  return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+}
+
+function applyRouteRole(c: Context, options: RouteOptions): void {
+  if (options.roles) requireRole(c, options.roles);
+}
+
+function parseEventId(c: Context): ParseResult<string> {
+  const eventId = c.req.param("eventId");
+  if (eventId && EVENT_ID_RE.test(eventId)) {
+    return { ok: true, data: eventId };
+  }
+  return { ok: false, response: c.json({ error: "invalid_event_id" }, StatusCodes.BAD_REQUEST) };
+}
+
+function parseSchemaBody<TSchema extends z.ZodType>(
+  c: Context,
+  schema: TSchema,
+  body: unknown,
+): ParseResult<z.infer<TSchema>> {
+  const parsed = schema.safeParse(body);
+  if (parsed.success) return { ok: true, data: parsed.data };
+  return {
+    ok: false,
+    response: c.json(
+      { error: "validation_failed", issues: parsed.error.issues },
+      StatusCodes.BAD_REQUEST,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- Closes #1117
- Closes #1130
- Add event-handler route helpers for event ID validation, JSON body parsing, shared error logging, and tenant ownership checks.
- Replace repeated route boilerplate in the Event API while preserving existing response bodies, status codes, role gates, and tenant claim resolution order.

## Test plan
- `./node_modules/.bin/vitest run infrastructure/test/problem-deploy/role-gates.test.ts infrastructure/test/problem-deploy/handler-error-cors.test.ts infrastructure/test/problem-deploy/event-create.test.ts infrastructure/test/problem-deploy/event-schedule.test.ts infrastructure/test/problem-deploy/event-end.test.ts infrastructure/test/problem-deploy/event-lock-scoring.test.ts infrastructure/test/problem-deploy/event-create-notification.test.ts infrastructure/test/problem-deploy/event-archive.test.ts infrastructure/test/problem-deploy/event-bulk-deploy.test.ts infrastructure/test/problem-deploy/event-bulk-delete.test.ts infrastructure/test/problem-deploy/disruption-fire.test.ts`
- `bun run --filter @TenkaCloud/infrastructure typecheck`
- `bun biome check infrastructure/lib/problem-deploy/handlers/event-handler/index.ts infrastructure/lib/problem-deploy/handlers/event-handler/route-helpers.ts`
- `make harness`
- `make before-commit`
- `/review`: no findings
- `/security-review`: no findings
- `/simplify`: no findings

## Regression 分析
- Route behavior is intended to be unchanged: role checks, eventId validation, JSON parsing, Zod validation, and tenant ownership checks still happen in the same effective order as before.
- `resolveTenantId(c)` remains inside the existing route try/catch paths so missing-tenant/error handling does not shift as part of the helper extraction.
- Focused Event API tests plus full before-commit coverage passed locally.

## 物理影響
- No CDK, IAM, CloudFormation, DynamoDB schema, EventBridge, or deployment topology changes.
- Lambda bundle code changes only; no new dependencies and no runtime infrastructure resource impact.
