### PR TITLE
feat(trust-bridge): add mock cloud adapter

### DIFF
--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -60,6 +60,14 @@ export type {
   VerifyOutcome,
 } from "./jws.js";
 export { signIntent, verifySignature } from "./jws.js";
+export type {
+  MockCloudAdapterOptions,
+  MockCloudCredential,
+  MockCloudExchangeContext,
+  MockDeploymentSignal,
+  MockDeploymentSignalStatus,
+} from "./mock-cloud-adapter.js";
+export { MockCloudAdapter } from "./mock-cloud-adapter.js";
 
 export type {
   ExchangeContext,

--- a/packages/trust-bridge/src/mock-cloud-adapter.ts
+++ b/packages/trust-bridge/src/mock-cloud-adapter.ts
@@ -1,0 +1,109 @@
+import {
+  type ExchangeContext,
+  ExchangeError,
+  type ProviderCredential,
+  type ProviderId,
+  type ProviderTokenExchange,
+} from "./provider.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+export type MockDeploymentSignalStatus = "SUCCEEDED";
+
+export interface MockDeploymentSignal {
+  readonly status: MockDeploymentSignalStatus;
+  readonly actionType: VerifiedCloudActionIntent["action"]["type"];
+  readonly engine: VerifiedCloudActionIntent["action"]["engine"];
+  readonly requestId: string;
+  readonly traceLabel?: string;
+}
+
+export interface MockCloudCredential extends ProviderCredential {
+  readonly mode: "mock";
+  readonly accountRef: string;
+  readonly region?: string;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+  readonly requestedScopes: readonly string[];
+  readonly deploymentSignal: MockDeploymentSignal;
+}
+
+export interface MockCloudAdapterOptions {
+  /**
+   * The provider this mock adapter stands in for. Mock mode is an execution mode,
+   * not a new provider id, so the intent target provider remains aws/gcp/etc.
+   */
+  readonly provider?: ProviderId;
+  readonly maxTtlSeconds?: number;
+  readonly now?: () => Date;
+}
+
+export interface MockCloudExchangeContext extends ExchangeContext {
+  readonly traceLabel?: string;
+}
+
+/**
+ * #1122: offline/local demo adapter for trust-bridge.
+ *
+ * This adapter never calls a cloud provider. It validates the same provider
+ * boundary as production adapters and returns deterministic, clearly fake
+ * credentials plus an immediate success signal that callers can use to drive
+ * frontend-only or LocalStack-adjacent demos.
+ */
+export class MockCloudAdapter implements ProviderTokenExchange<MockCloudCredential> {
+  readonly provider: ProviderId;
+  private readonly maxTtlSeconds: number;
+  private readonly now: () => Date;
+
+  constructor(options: MockCloudAdapterOptions = {}) {
+    this.provider = options.provider ?? "aws";
+    this.maxTtlSeconds = options.maxTtlSeconds ?? 3600;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async exchange(
+    intent: VerifiedCloudActionIntent,
+    context: ExchangeContext,
+  ): Promise<MockCloudCredential> {
+    if (intent.target.provider !== this.provider) {
+      throw new ExchangeError(
+        "provider-mismatch",
+        `intent target provider is ${intent.target.provider}, not ${this.provider}`,
+      );
+    }
+    if (intent.constraints.ttlSeconds > this.maxTtlSeconds) {
+      throw new ExchangeError(
+        "ttl-exceeded-provider-limit",
+        `MockCloudAdapter maxTtlSeconds is ${this.maxTtlSeconds}, got ${intent.constraints.ttlSeconds}`,
+      );
+    }
+
+    const issuedAt = this.now();
+    const expiresAt = new Date(issuedAt.getTime() + intent.constraints.ttlSeconds * 1000);
+    const mockContext = context as MockCloudExchangeContext;
+    return {
+      provider: this.provider,
+      mode: "mock",
+      accountRef: intent.target.providerAccountRef,
+      region: intent.target.region,
+      accessKeyId: `MOCK-${sanitizeTokenPart(intent.requestId)}`,
+      secretAccessKey: "mock-secret-not-valid-for-cloud-provider",
+      sessionToken: `mock-session-${sanitizeTokenPart(intent.nonce)}`,
+      requestedScopes: [...intent.action.requestedScopes],
+      deploymentSignal: {
+        status: "SUCCEEDED",
+        actionType: intent.action.type,
+        engine: intent.action.engine,
+        requestId: intent.requestId,
+        ...(mockContext.traceLabel ? { traceLabel: mockContext.traceLabel } : {}),
+      },
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      forRequestId: intent.requestId,
+    };
+  }
+}
+
+function sanitizeTokenPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
+}

--- a/packages/trust-bridge/test/mock-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/mock-cloud-adapter.test.ts
@@ -52,6 +52,9 @@ describe("MockCloudAdapter (#1122)", () => {
     expect(credential.forRequestId).toBe("req-mock-1");
     expect(credential.accountRef).toBe("123456789012");
     expect(credential.region).toBe("ap-northeast-1");
+    expect(credential.accessKeyId).toBe("MOCK-req-mock-1");
+    expect(credential.secretAccessKey).toBe("mock-secret-not-valid-for-cloud-provider");
+    expect(credential.sessionToken).toBe("mock-session-nonce-mock-1");
     expect(credential.deploymentSignal).toEqual({
       status: "SUCCEEDED",
       actionType: "deploy",

--- a/packages/trust-bridge/test/mock-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/mock-cloud-adapter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { MockCloudAdapter } from "../src/mock-cloud-adapter.js";
+import { ExchangeError } from "../src/provider.js";
+import {
+  brandVerified,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  type VerifiedCloudActionIntent,
+} from "../src/schema.js";
+
+function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudActionIntent {
+  const intent: CloudActionIntent = {
+    version: INTENT_VERSION,
+    requestId: "req-mock-1",
+    nonce: "nonce-mock-1",
+    source: {
+      system: "tenkacloud",
+      tenantId: "tenant-a",
+      teamId: "team-alpha",
+      problemId: "hello-world",
+      deploymentId: "deploy-9",
+      workloadId: "deploy-worker",
+    },
+    target: { provider: "aws", providerAccountRef: "123456789012", region: "ap-northeast-1" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cloudformation:CreateStack"],
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+  return brandVerified(intent);
+}
+
+describe("MockCloudAdapter (#1122)", () => {
+  it("実 provider API を呼ばず擬似 credential と成功 signal を返すべき", async () => {
+    const adapter = new MockCloudAdapter({
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+
+    const credential = await adapter.exchange(makeIntent(), {});
+
+    expect(credential.provider).toBe("aws");
+    expect(credential.mode).toBe("mock");
+    expect(credential.issuedAt).toBe("2026-05-15T19:00:00.000Z");
+    expect(credential.expiresAt).toBe("2026-05-15T19:10:00.000Z");
+    expect(credential.forRequestId).toBe("req-mock-1");
+    expect(credential.accountRef).toBe("123456789012");
+    expect(credential.region).toBe("ap-northeast-1");
+    expect(credential.deploymentSignal).toEqual({
+      status: "SUCCEEDED",
+      actionType: "deploy",
+      engine: "cloudformation",
+      requestId: "req-mock-1",
+    });
+  });
+
+  it("target provider が adapter provider と違う場合は provider-mismatch を投げるべき", async () => {
+    const adapter = new MockCloudAdapter({ provider: "gcp" });
+    await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
+      reason: "provider-mismatch",
+    });
+  });
+
+  it("ttlSeconds は options.maxTtlSeconds を超えると ttl-exceeded-provider-limit を投げるべき", async () => {
+    const adapter = new MockCloudAdapter({ maxTtlSeconds: 300 });
+    await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
+      reason: "ttl-exceeded-provider-limit",
+    });
+  });
+
+  it("context の traceLabel を signal に引き継ぐべき", async () => {
+    const adapter = new MockCloudAdapter();
+    const credential = await adapter.exchange(makeIntent(), { traceLabel: "offline-demo" });
+    expect(credential.deploymentSignal.traceLabel).toBe("offline-demo");
+  });
+
+  it("ExchangeError として扱えるべき", async () => {
+    const adapter = new MockCloudAdapter({ provider: "azure" });
+    try {
+      await adapter.exchange(makeIntent(), {});
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExchangeError);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MockCloudAdapter` to `@TenkaCloud/trust-bridge` for offline/local demo flows without calling real provider APIs.
- Return deterministic fake credentials plus an immediate `SUCCEEDED` deployment signal while preserving provider and TTL boundary checks.
- Export the adapter and add unit coverage for success, provider mismatch, TTL limit, trace label propagation, and `ExchangeError` behavior.

Relates #1122

## Test plan

- `bun biome check packages/trust-bridge/src/mock-cloud-adapter.ts packages/trust-bridge/src/index.ts packages/trust-bridge/test/mock-cloud-adapter.test.ts`
- `bun run --filter @TenkaCloud/trust-bridge typecheck`
- `bun run --filter @TenkaCloud/trust-bridge test -- mock-cloud-adapter`
- `make harness`
- `make before-commit`
- manual `/review`
- manual `/security-review`
- manual `/simplify`

## Regression 分析

- Existing production provider exchanges are untouched; the new adapter is opt-in and only exported from the package public surface.
- The adapter keeps the same provider target boundary and rejects mismatched providers, so mock mode does not become a generic auth bypass.
- TTL is capped by `maxTtlSeconds`, with deterministic `now` injection only for tests and local/demo orchestration.

## 物理影響

- No CDK, IAM, CloudFormation, or runtime environment changes.
- No real AWS/GCP/Azure API calls are introduced.
- Returned credentials are explicitly fake and unsuitable for real provider access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for offline cloud credential exchange testing with built-in provider validation and token expiration limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->