### PR TITLE
docs: add community launch validation plan

### DIFF
--- a/docs/go-to-market/community-first-launch.html
+++ b/docs/go-to-market/community-first-launch.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Community-First Launch Validation</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Community-First Launch Validation</h1>
+<p>TenkaCloud should validate buyer intent with a small community-first release before broad OSS promotion. The launch goal is not to maximize stars, likes, or Product Hunt ranking. The goal is to discover who immediately understands the value, who has budget authority, and which use case creates a concrete request for a demo, introduction, or internal trial.</p>
+<p>This document is the operating checklist for issue #1133.</p>
+<h2>Hypothesis</h2>
+<p>The most likely early adopters are:</p>
+<ol>
+<li>CCoE and internal platform leaders who need realistic cloud enablement.</li>
+<li>Training and enablement owners who run hands-on AWS learning programs.</li>
+<li>AWS partners and SI organizations that package workshops for customers.</li>
+<li>SRE and security exercise owners who run incident drills or GameDays.</li>
+<li>Engineering communities that want cloud competitions without heavy setup.</li>
+</ol>
+<p>The validation order should favor people who can name a concrete event, team, or buying process over people who only react positively to the project.</p>
+<h2>Release Package</h2>
+<p>Prepare these assets before broad promotion:</p>
+<table>
+<thead>
+<tr>
+<th>Asset</th>
+<th>Purpose</th>
+<th>Done when</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>30-60 second GIF</td>
+<td>Shows the complete value loop: create event, deploy problem, participant starts solving.</td>
+<td>A viewer can understand the product without reading the README.</td>
+</tr>
+<tr>
+<td>5 minute setup flow</td>
+<td>Removes the &quot;looks too heavy&quot; objection.</td>
+<td>A fresh evaluator can reach a local or Lite mode demo in one short sitting.</td>
+</tr>
+<tr>
+<td>Lite mode demo</td>
+<td>Enables evaluation without committing to a full tenant deployment.</td>
+<td>The demo can be shared with a training owner or community organizer.</td>
+</tr>
+<tr>
+<td>One-page architecture visual</td>
+<td>Builds confidence for technical buyers.</td>
+<td>It explains control plane, tenant plane, and competitor AWS account boundaries on one page.</td>
+</tr>
+<tr>
+<td>Persona ask</td>
+<td>Turns reactions into demand signals.</td>
+<td>Every outreach message asks which use case the recipient would use this for.</td>
+</tr>
+</tbody></table>
+<p>The standard ask is:</p>
+<pre><code class="language-text">What would you use this for?
+
+- training
+- hiring
+- GameDay
+- incident drills
+- cloud competitions
+</code></pre>
+<h2>Outreach Sequence</h2>
+<p>Use small batches so message wording can improve between rounds.</p>
+<table>
+<thead>
+<tr>
+<th>Round</th>
+<th>Audience</th>
+<th align="right">Sample size</th>
+<th>Question to answer</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td>Known AWS builders, community organizers, and training operators</td>
+<td align="right">10-15 people</td>
+<td>Which use case is understood fastest?</td>
+</tr>
+<tr>
+<td>2</td>
+<td>CCoE, platform, SRE, and security enablement leaders</td>
+<td align="right">10-20 people</td>
+<td>Who asks for a demo or internal trial?</td>
+</tr>
+<tr>
+<td>3</td>
+<td>AWS partners and SI workshop owners</td>
+<td align="right">10-20 people</td>
+<td>Is there a service-package or customer-workshop angle?</td>
+</tr>
+<tr>
+<td>4</td>
+<td>Public OSS channels</td>
+<td align="right">Small public post</td>
+<td>Does broader interest match the private signal, or only produce shallow engagement?</td>
+</tr>
+</tbody></table>
+<p>Do not scale the launch until at least one audience produces a concrete next step.</p>
+<h2>Signal Log</h2>
+<p>Record every conversation with these fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Contact type</td>
+<td>CCoE, training, partner, SRE/security, community, other.</td>
+</tr>
+<tr>
+<td>Use case selected</td>
+<td>Training, hiring, GameDay, incident drills, cloud competitions, other.</td>
+</tr>
+<tr>
+<td>Strength</td>
+<td>Passive interest, shared with others, demo requested, manager intro, pricing question, internal trial request.</td>
+</tr>
+<tr>
+<td>Objection</td>
+<td>Setup weight, security model, AWS account requirement, cost, unclear use case, missing content.</td>
+</tr>
+<tr>
+<td>Follow-up</td>
+<td>No action, send demo, schedule call, prepare internal pilot, introduce buyer.</td>
+</tr>
+</tbody></table>
+<p>Strong signals are:</p>
+<ul>
+<li>Demo requests.</li>
+<li>Introductions to managers or budget owners.</li>
+<li>&quot;Can we use this internally?&quot;</li>
+<li>&quot;Can you run this for us?&quot;</li>
+<li>Pricing, procurement, or event date questions.</li>
+</ul>
+<p>Weak signals are:</p>
+<ul>
+<li>Stars, likes, reposts, and vague encouragement without a next step.</li>
+<li>Feedback from people who cannot name a concrete event or team.</li>
+<li>Interest that only appears when the setup is assumed to be free and fully hosted.</li>
+</ul>
+<h2>Message Test</h2>
+<p>Test three message angles before choosing public positioning.</p>
+<table>
+<thead>
+<tr>
+<th>Angle</th>
+<th>Example</th>
+<th>Winning signal</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Cloud enablement</td>
+<td>&quot;Run realistic AWS training without building a custom workshop platform.&quot;</td>
+<td>Training owners ask for content format, duration, and participant limits.</td>
+</tr>
+<tr>
+<td>GameDay operations</td>
+<td>&quot;Launch and score cloud challenges with tenant isolation and participant AWS accounts.&quot;</td>
+<td>SRE/security teams ask about incident-drill workflows.</td>
+</tr>
+<tr>
+<td>Partner workshop kit</td>
+<td>&quot;Package reusable cloud competition environments for customer workshops.&quot;</td>
+<td>Partners ask whether they can reuse or white-label events.</td>
+</tr>
+</tbody></table>
+<p>Retire any angle that produces compliments but no demo request, buyer intro, or event-specific follow-up.</p>
+<h2>Decision Gate</h2>
+<p>Proceed to broader OSS promotion only when at least two of these are true:</p>
+<ul>
+<li>Three or more demo requests from the same audience class.</li>
+<li>One buyer or budget owner asks for an internal pilot.</li>
+<li>One AWS partner or SI asks how to package it for customers.</li>
+<li>One community organizer commits to running a small event.</li>
+<li>Objections are specific enough to prioritize product work.</li>
+</ul>
+<p>If none of these happen, do not optimize the landing page or public launch. Revise the audience, message, or Lite demo first.</p>
+<h2>PR Checklist</h2>
+<p>For launch-readiness PRs related to this plan, include:</p>
+<ul>
+<li>The asset or experiment being added.</li>
+<li>The intended audience.</li>
+<li>The demand signal it is meant to test.</li>
+<li>The success and stop criteria.</li>
+<li>The expected physical impact, including whether the change is docs-only, app-only, or infrastructure-affecting.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/go-to-market/community-first-launch.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/go-to-market/community-first-launch.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/go-to-market/community-first-launch.md
+++ b/docs/go-to-market/community-first-launch.md
@@ -1,0 +1,114 @@
+# Community-First Launch Validation
+
+TenkaCloud should validate buyer intent with a small community-first release before broad OSS promotion. The launch goal is not to maximize stars, likes, or Product Hunt ranking. The goal is to discover who immediately understands the value, who has budget authority, and which use case creates a concrete request for a demo, introduction, or internal trial.
+
+This document is the operating checklist for issue #1133.
+
+## Hypothesis
+
+The most likely early adopters are:
+
+1. CCoE and internal platform leaders who need realistic cloud enablement.
+2. Training and enablement owners who run hands-on AWS learning programs.
+3. AWS partners and SI organizations that package workshops for customers.
+4. SRE and security exercise owners who run incident drills or GameDays.
+5. Engineering communities that want cloud competitions without heavy setup.
+
+The validation order should favor people who can name a concrete event, team, or buying process over people who only react positively to the project.
+
+## Release Package
+
+Prepare these assets before broad promotion:
+
+| Asset | Purpose | Done when |
+| --- | --- | --- |
+| 30-60 second GIF | Shows the complete value loop: create event, deploy problem, participant starts solving. | A viewer can understand the product without reading the README. |
+| 5 minute setup flow | Removes the "looks too heavy" objection. | A fresh evaluator can reach a local or Lite mode demo in one short sitting. |
+| Lite mode demo | Enables evaluation without committing to a full tenant deployment. | The demo can be shared with a training owner or community organizer. |
+| One-page architecture visual | Builds confidence for technical buyers. | It explains control plane, tenant plane, and competitor AWS account boundaries on one page. |
+| Persona ask | Turns reactions into demand signals. | Every outreach message asks which use case the recipient would use this for. |
+
+The standard ask is:
+
+```text
+What would you use this for?
+
+- training
+- hiring
+- GameDay
+- incident drills
+- cloud competitions
+```
+
+## Outreach Sequence
+
+Use small batches so message wording can improve between rounds.
+
+| Round | Audience | Sample size | Question to answer |
+| --- | --- | ---: | --- |
+| 1 | Known AWS builders, community organizers, and training operators | 10-15 people | Which use case is understood fastest? |
+| 2 | CCoE, platform, SRE, and security enablement leaders | 10-20 people | Who asks for a demo or internal trial? |
+| 3 | AWS partners and SI workshop owners | 10-20 people | Is there a service-package or customer-workshop angle? |
+| 4 | Public OSS channels | Small public post | Does broader interest match the private signal, or only produce shallow engagement? |
+
+Do not scale the launch until at least one audience produces a concrete next step.
+
+## Signal Log
+
+Record every conversation with these fields:
+
+| Field | Meaning |
+| --- | --- |
+| Contact type | CCoE, training, partner, SRE/security, community, other. |
+| Use case selected | Training, hiring, GameDay, incident drills, cloud competitions, other. |
+| Strength | Passive interest, shared with others, demo requested, manager intro, pricing question, internal trial request. |
+| Objection | Setup weight, security model, AWS account requirement, cost, unclear use case, missing content. |
+| Follow-up | No action, send demo, schedule call, prepare internal pilot, introduce buyer. |
+
+Strong signals are:
+
+- Demo requests.
+- Introductions to managers or budget owners.
+- "Can we use this internally?"
+- "Can you run this for us?"
+- Pricing, procurement, or event date questions.
+
+Weak signals are:
+
+- Stars, likes, reposts, and vague encouragement without a next step.
+- Feedback from people who cannot name a concrete event or team.
+- Interest that only appears when the setup is assumed to be free and fully hosted.
+
+## Message Test
+
+Test three message angles before choosing public positioning.
+
+| Angle | Example | Winning signal |
+| --- | --- | --- |
+| Cloud enablement | "Run realistic AWS training without building a custom workshop platform." | Training owners ask for content format, duration, and participant limits. |
+| GameDay operations | "Launch and score cloud challenges with tenant isolation and participant AWS accounts." | SRE/security teams ask about incident-drill workflows. |
+| Partner workshop kit | "Package reusable cloud competition environments for customer workshops." | Partners ask whether they can reuse or white-label events. |
+
+Retire any angle that produces compliments but no demo request, buyer intro, or event-specific follow-up.
+
+## Decision Gate
+
+Proceed to broader OSS promotion only when at least two of these are true:
+
+- Three or more demo requests from the same audience class.
+- One buyer or budget owner asks for an internal pilot.
+- One AWS partner or SI asks how to package it for customers.
+- One community organizer commits to running a small event.
+- Objections are specific enough to prioritize product work.
+
+If none of these happen, do not optimize the landing page or public launch. Revise the audience, message, or Lite demo first.
+
+## PR Checklist
+
+For launch-readiness PRs related to this plan, include:
+
+- The asset or experiment being added.
+- The intended audience.
+- The demand signal it is meant to test.
+- The success and stop criteria.
+- The expected physical impact, including whether the change is docs-only, app-only, or infrastructure-affecting.


### PR DESCRIPTION
## Summary

- Add a community-first GTM validation plan for TenkaCloud before broad OSS promotion.
- Capture the hypothesized early adopter personas, launch asset checklist, outreach sequence, signal log, message tests, and decision gate.
- Generate the companion HTML document via `scripts/build-docs.ts`.

Closes #1133

## Test plan

- `bun run lint:md -- docs/go-to-market/community-first-launch.md`
- `bun run scripts/build-docs.ts --check`
- `make harness`
- `make before-commit`
- manual `/review`
- manual `/security-review`
- manual `/simplify`

## Regression 分析

- Docs-only change; no application, package, infrastructure, or runtime behavior changes.
- The generated HTML is checked by `scripts/build-docs.ts --check`, so markdown and rendered docs remain synchronized.
- The plan intentionally treats stars/likes as weak signals and records buyer-intent signals that can be inspected later.

## 物理影響

- CREATE: `docs/go-to-market/community-first-launch.md`
- CREATE: `docs/go-to-market/community-first-launch.html`
- UPDATE/REPLACE/DELETE: none
- Infrastructure impact: NO-OP
- Runtime impact: NO-OP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive community-first launch validation guide, including operating checklists for hypothesis testing, release package assembly, outreach sequencing, conversation tracking, message positioning validation, promotion decision criteria, and launch readiness requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->