### PR TITLE
feat(portal): show deploy progress terminal

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -62,6 +62,19 @@ export interface ApplicationStatus {
   readonly checkedAt?: string;
 }
 
+export interface DeploymentLogEntry {
+  readonly id: string;
+  readonly timestamp: string;
+  readonly source: "deployment";
+  readonly level: "info" | "success" | "warning" | "error";
+  readonly message: string;
+}
+
+export interface DeploymentLogView {
+  readonly cursor: string;
+  readonly entries: readonly DeploymentLogEntry[];
+}
+
 /**
  * Phase 2c: 1 problem 単位の view (= team の N 問題のうち 1 つ)。
  */
@@ -79,6 +92,7 @@ export interface ParticipantProblemView {
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  readonly deployLog: DeploymentLogView;
   /** Issue #607: deploy 開始時刻 (DDB.createdAt の echo)。 portal の phase countdown が
    *  metadata.phases / disruptions の afterMinutes との差で残時間を計算する。 deploy 中の
    *  PENDING / IN_PROGRESS でも present。 */

--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -101,6 +101,7 @@ function viewIsUnchanged(prev: ParticipantTeamView | null, next: ParticipantTeam
       p.lastResult !== n.lastResult ||
       p.scoring?.flagSubmitted !== n.scoring?.flagSubmitted ||
       p.failureReason !== n.failureReason ||
+      p.deployLog?.cursor !== n.deployLog?.cursor ||
       JSON.stringify(p.stackOutputs) !== JSON.stringify(n.stackOutputs)
     ) {
       return false;

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import type * as React from "react";
+import { describe, expect, it } from "vitest";
+import type { ParticipantProblemView } from "../api/portal-client";
+import { I18nProvider } from "../i18n";
+import { ProblemPanel } from "./ProblemPanel";
+
+function withI18n(node: React.ReactNode) {
+  window.localStorage.setItem("tenkacloud.portal.locale", "ja");
+  return <I18nProvider>{node}</I18nProvider>;
+}
+
+const baseProblem: ParticipantProblemView = {
+  jobId: "JOB1",
+  problemId: "hello-world",
+  region: "ap-northeast-1",
+  awsAccountId: "999999999999",
+  status: "IN_PROGRESS",
+  stackOutputs: {},
+  expiresAt: 1_700_000_000,
+  score: 0,
+  deployLog: {
+    cursor: "2026-05-04T15:02:00.000Z",
+    entries: [
+      {
+        id: "queued",
+        timestamp: "2026-05-04T15:00:00.000Z",
+        source: "deployment",
+        level: "info",
+        message: "Deployment job was queued.",
+      },
+      {
+        id: "cfn",
+        timestamp: "2026-05-04T15:02:00.000Z",
+        source: "deployment",
+        level: "info",
+        message: "CloudFormation stack creation is in progress.",
+      },
+    ],
+  },
+};
+
+describe("ProblemPanel deploy terminal", () => {
+  it("deployLog の terminal 行を表示すべき", () => {
+    render(
+      withI18n(
+        <ProblemPanel
+          problem={baseProblem}
+          apiBaseUrl="https://api.example.com"
+          sessionToken="team-key"
+          onScored={async () => undefined}
+        />,
+      ),
+    );
+
+    expect(screen.getByLabelText("デプロイ terminal")).toBeInTheDocument();
+    expect(screen.getByText("Deployment job was queued.")).toBeInTheDocument();
+    expect(screen.getByText("CloudFormation stack creation is in progress.")).toBeInTheDocument();
+  });
+});

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -14,6 +14,7 @@ import StatusIndicator, {
 } from "@cloudscape-design/components/status-indicator";
 import { useState } from "react";
 import {
+  type DeploymentLogEntry,
   type DeploymentStatus,
   type ParticipantHintView,
   type ParticipantProblemView,
@@ -87,6 +88,13 @@ const STALE_THRESHOLD_MS = 2 * 60 * 1000;
 // Lambda invocation コスト抑制のため 30 秒 (= 旧 5 秒は 12 req/min/user で過多)。
 const POLL_INTERVAL_MS = 30_000;
 
+const DEPLOY_LOG_LEVEL_COLOR: Record<DeploymentLogEntry["level"], string> = {
+  info: "#9bd3ff",
+  success: "#9dffb0",
+  warning: "#ffd27d",
+  error: "#ff9b9b",
+};
+
 /**
  * 1 problem 単位の詳細パネル。Home (= 全 problem を縦並べ) と ProblemDetail
  * (= 1 problem 専用ページ) の両方から使う共通 component。
@@ -154,6 +162,13 @@ export function ProblemPanel({
           ]}
         />
 
+        {problem.deployLog?.entries.length > 0 && (
+          <DeployTerminal
+            entries={problem.deployLog.entries}
+            title={t("problem_panel.deploy_log_header")}
+          />
+        )}
+
         {Object.keys(problem.stackOutputs).length > 0 && (
           <Container header={<Header variant="h3">{t("problem_panel.outputs_header")}</Header>}>
             <KeyValuePairs
@@ -194,6 +209,53 @@ export function ProblemPanel({
       </SpaceBetween>
     </Container>
   );
+}
+
+function DeployTerminal({
+  entries,
+  title,
+}: {
+  entries: readonly DeploymentLogEntry[];
+  title: string;
+}) {
+  return (
+    <section aria-label={title}>
+      <Box variant="h3">{title}</Box>
+      <div
+        style={{
+          marginTop: 8,
+          maxHeight: 240,
+          overflowY: "auto",
+          borderRadius: 6,
+          background: "#0f1419",
+          color: "#d5dde5",
+          padding: "12px 14px",
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace",
+          fontSize: 13,
+          lineHeight: 1.55,
+        }}
+      >
+        {entries.map((entry) => (
+          <div key={entry.id} style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+            <span style={{ color: "#8796a5" }}>{formatTerminalTime(entry.timestamp)}</span>{" "}
+            <span style={{ color: DEPLOY_LOG_LEVEL_COLOR[entry.level] }}>[{entry.level}]</span>{" "}
+            <span>{entry.message}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function formatTerminalTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "--:--:--";
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 function FlagSubmissionPanel({

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -237,6 +237,7 @@
     "stale_body": "{ago} since last scoring. Something in your service may not be responding as expected.",
     "current_score_label": "Current score",
     "last_scored_label": "Last scored",
+    "deploy_log_header": "Deployment terminal",
     "outputs_header": "Access URLs",
     "auto_refresh_note": "Auto-refreshing every {seconds} s.",
     "celebrate_header": "🏆 Cleared +{points} pt",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -237,6 +237,7 @@
     "stale_body": "直近の採点から {ago} 経過。 サービスのどこかが期待通り応答していない可能性があります。",
     "current_score_label": "現在の score",
     "last_scored_label": "最終加点",
+    "deploy_log_header": "デプロイ terminal",
     "outputs_header": "アクセス先 URL",
     "auto_refresh_note": "{seconds} 秒ごとに自動更新します。",
     "celebrate_header": "🏆 クリア済み +{points} pt",

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -82,6 +82,23 @@ export interface ApplicationStatus {
   readonly checkedAt?: string;
 }
 
+export interface DeploymentLogEntry {
+  readonly id: string;
+  readonly timestamp: string;
+  readonly source: "deployment";
+  readonly level: "info" | "success" | "warning" | "error";
+  readonly message: string;
+}
+
+export interface DeploymentLogView {
+  /**
+   * `/portal/me` polling で差分判定するための cursor。現状は DDB row の updatedAt を使い、
+   * CloudWatch Logs 直読を後続で足す場合は nextToken に差し替え可能な shape にしておく。
+   */
+  readonly cursor: string;
+  readonly entries: readonly DeploymentLogEntry[];
+}
+
 export type ParticipantProblemView = Pick<
   DeploymentItem,
   "jobId" | "problemId" | "region" | "expiresAt" | "awsAccountId"
@@ -93,6 +110,7 @@ export type ParticipantProblemView = Pick<
   readonly lastScoredAt?: string;
   readonly lastResult?: "ok" | "fail";
   readonly scoring?: ParticipantScoringInfo;
+  readonly deployLog: DeploymentLogView;
   /** ADR-012 Phase 4 / Issue #607: deploy 開始時刻 (= DDB.createdAt の echo)。 portal の phase
    *  countdown timeline (= metadata.phases[].afterMinutes の経過判定) に使う。 deploy 中の
    *  PENDING / IN_PROGRESS でも present (= job 生成時刻)。 */
@@ -171,6 +189,7 @@ export function toProblemView(
     lastScoredAt: typeof item.lastScoredAt === "string" ? item.lastScoredAt : undefined,
     lastResult: item.lastResult,
     scoring: scoring ? toScoringInfo(scoring, item) : undefined,
+    deployLog: toDeploymentLog(item, status),
     // Issue #607: deploy 開始時刻 (DDB.createdAt) を echo。 portal の phase countdown が
     // metadata.phases[].afterMinutes との差で「+N 分まであと M 分」を計算する。
     createdAt: typeof item.createdAt === "string" ? item.createdAt : undefined,
@@ -179,6 +198,78 @@ export function toProblemView(
     // attack-detection / flag では undefined (= probe しない kind)。
     applicationStatus: isUptimeKind(scoring?.kind) ? toApplicationStatus(item) : undefined,
   };
+}
+
+function toDeploymentLog(
+  item: Partial<DeploymentItem>,
+  status: DeploymentStatus,
+): DeploymentLogView {
+  const createdAt = typeof item.createdAt === "string" ? item.createdAt : "";
+  const updatedAt = typeof item.updatedAt === "string" ? item.updatedAt : createdAt;
+  const hasBuildId = hasNonEmptyString(item.buildId);
+  const hasStackId = hasNonEmptyString(item.stackId);
+  const entries: DeploymentLogEntry[] = [];
+
+  const push = (
+    message: string,
+    level: DeploymentLogEntry["level"] = "info",
+    at: string | undefined = createdAt,
+  ) => {
+    entries.push({
+      id: `${resolveLogTimestamp(at, updatedAt, createdAt)}:${entries.length}`,
+      timestamp: resolveLogTimestamp(at, updatedAt, createdAt),
+      source: "deployment",
+      level,
+      message,
+    });
+  };
+
+  push("Deployment job was queued.", "info", createdAt);
+
+  if (hasBuildId) {
+    push("Build runner started.", "info", updatedAt);
+  } else if (status === "PENDING") {
+    push("Waiting for build runner.", "info", updatedAt);
+  }
+
+  if (hasStackId) {
+    push(...describeStackLog(status), updatedAt);
+  }
+
+  if (status === "COMPLETE") {
+    push("Deployment completed.", "success", updatedAt);
+  } else if (status === "FAILED") {
+    const reason =
+      typeof item.failureReason === "string" && item.failureReason.length > 0
+        ? `: ${item.failureReason}`
+        : ".";
+    push(`Deployment failed${reason}`, "error", updatedAt);
+  } else if (status === "IN_PROGRESS") {
+    push("Deployment is still running.", "info", updatedAt);
+  }
+
+  return {
+    cursor: updatedAt || createdAt || status,
+    entries,
+  };
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function resolveLogTimestamp(
+  value: string | undefined,
+  updatedAt: string,
+  createdAt: string,
+): string {
+  return value || updatedAt || createdAt;
+}
+
+function describeStackLog(status: DeploymentStatus): [string, DeploymentLogEntry["level"]] {
+  if (status === "COMPLETE") return ["CloudFormation stack completed.", "success"];
+  if (status === "FAILED") return ["CloudFormation reported a failure.", "error"];
+  return ["CloudFormation stack creation is in progress.", "info"];
 }
 
 function isUptimeKind(kind: string | undefined): boolean {

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -99,6 +99,53 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.createdAt).toBe("2026-05-04T15:00:00.000Z");
   });
 
+  it("deployLog は DDB の進捗から競技者向け terminal 行を返すべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          status: "IN_PROGRESS",
+          buildId: "DeployCodeBuild:abc123",
+          stackId:
+            "arn:aws:cloudformation:ap-northeast-1:999999999999:stack/tc-secret-team/stack-id",
+          updatedAt: "2026-05-04T15:02:00.000Z",
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    const log = view?.problems[0]?.deployLog;
+    expect(log?.cursor).toBe("2026-05-04T15:02:00.000Z");
+    expect(log?.entries.map((entry) => entry.message)).toEqual([
+      "Deployment job was queued.",
+      "Build runner started.",
+      "CloudFormation stack creation is in progress.",
+      "Deployment is still running.",
+    ]);
+    expect(JSON.stringify(log)).not.toContain("DeployCodeBuild:abc123");
+    expect(JSON.stringify(log)).not.toContain("tc-secret-team");
+  });
+
+  it("deployLog は失敗理由を terminal 行に含めるべき", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        sampleRow({
+          status: "FAILED",
+          failureReason: "CREATE_FAILED: VPC limit",
+          updatedAt: "2026-05-04T15:03:00.000Z",
+        }),
+      ],
+    });
+
+    const view = await lookupTeamByLoginKey(shared, "KEY1");
+    expect(view?.problems[0]?.deployLog.entries.at(-1)).toMatchObject({
+      level: "error",
+      message: "Deployment failed: CREATE_FAILED: VPC limit",
+      source: "deployment",
+    });
+  });
+
   it("Phase 2a 経由の eventId / teamId 列が team に伝播するべき", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Add a sanitized `deployLog` to participant problem views from existing deployment row state.
- Render a terminal-style deployment progress panel in Participant Portal and refresh when the log cursor changes.
- Keep raw CodeBuild build IDs and CloudFormation stack IDs out of participant responses.

Relates #1120

## Test plan
- `make harness`
- `make before-commit`

## Regression 分析
- `/portal/me` gains a small `deployLog` object per problem; existing fields and auth behavior are unchanged.
- Polling equality now includes `deployLog.cursor`, so deploy progress updates are not dropped when status remains unchanged.
- No new dependency or package lifecycle script was added.

## 物理影響
- No CDK, IAM, DynamoDB table, or AWS permission changes.
- Participant Lambda payload grows by a few short deployment progress entries per problem.
- Direct CloudWatch Logs / CodeBuild streaming still needs the user-owned IAM/API follow-up described in #1120.