### PR TITLE
docs: add ADR-022 — inter-team coordination plugin contract

### DIFF
--- a/docs/architecture/adr-022-inter-team-coordination-plugin.html
+++ b/docs/architecture/adr-022-inter-team-coordination-plugin.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-022: Inter-team coordination plugin contract</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft { background: #ddf4ff; color: var(--c-link); }
+  .badge.reject { background: #ffe5e5; color: var(--c-reject); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-022: Inter-team coordination plugin contract</h1>
+  <p><em>Battle 問題が宣言する他チーム interaction primitive を platform が dispatch する plugin 契約</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge draft">Draft</span> 2026-05-20</div>
+    <div><b>Related:</b>
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin, platform = host)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>Battle 問題はリアルタイム対戦である以上、 何らかの形で <strong>他チームとの interaction</strong> を仕込まないと「複数 team が同じ event に参加している」 だけで実際の競争にならない。 一方、 TenkaCloud で既に存在する / 検討されている Battle 問題を並べると、 必要な inter-team interaction の primitive (= 一次プリミティブ) は問題ごとに大きく違う。</p>
+
+<table>
+<thead>
+<tr><th>問題</th><th>想定 inter-team primitive</th><th>例</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td>microservice-migration-battle</td>
+  <td>service router</td>
+  <td>team A が公開した service URL を team B が直接 call する route 登録 (= 他チームのアウトプットを部分参照)</td>
+</tr>
+<tr>
+  <td>security-battle-royale</td>
+  <td>alliance</td>
+  <td>team どうしの相互合意による「同盟」 関係。 同盟内は攻撃しない / 互いを助ける</td>
+</tr>
+<tr>
+  <td>stackstack (#1137)</td>
+  <td>TBD (= 本 ADR ship 後に declare)</td>
+  <td>当初 「共有組織リソース queue (SSO Proxy 2 slot 先着 / Security Review 待ち行列)」 を想定したが、 tenant 境界を越える shared resource registry の security 設計の難度が現 platform の整備状況と釣り合わないため <strong>明示却下</strong>。 stackstack の inter-team primitive は本 ADR 上で別の (= tenant 境界を越えない) 形に置き換える</td>
+</tr>
+</tbody>
+</table>
+
+<p>共通項は 「team どうしの interaction を介する小さな共有状態 + 状態を mutate する operation 集合 + 各 team への投影」 の 3 点であり、 具体的な primitive (router / alliance / queue / partition / etc.) は完全に問題依存である。</p>
+
+<p>現状の platform は inter-team coordination のプリミティブを <strong>一つも</strong> 持たない (= per-team deployment + per-team scoring engine のみ)。 仮にどれか 1 つ (例: shared resource pool) を platform 側に hardcode で実装すると、 他の問題タイプ (router / alliance) に汎用化できず、 1 問題に最適化された platform 機能が他 問題の足を引っ張る。</p>
+</section>
+
+<section>
+<h2>Goals</h2>
+
+<ol>
+<li><strong>問題ごとに独自の inter-team primitive を declare できる</strong>: metadata DSL の一部として 「この問題はこういう inter-team coordination を持つ」 と宣言できる</li>
+<li><strong>platform は primitive を一つも hardcode しない</strong>: platform 側 code は dispatcher 1 つだけを持ち、 中身の意思決定は plugin に委譲する (= ADR-012 同型)</li>
+<li><strong>tenant 境界を越えない</strong>: shared state は <em>per-tenant per-event</em> scope に閉じる。 cross-tenant data flow は作らない。 security 監査範囲は問題 plugin code + 1 個の per-tenant per-event DDB row に閉じる</li>
+<li><strong>fallback safe</strong>: 既存問題は <code>interTeamCoordination</code> field 未宣言で動く (= inter-team interaction 無しの Battle として既存挙動を維持)</li>
+<li><strong>plugin code は問題リポジトリ同梱</strong>: <code>problems/&lt;category&gt;/&lt;id&gt;/coordination/</code> に書く (= ADR-012 で portal slots を <code>problems/&lt;...&gt;/portal/</code> に同梱したのと同じ局所性)</li>
+<li><strong>operator が runtime に scope を見られる</strong>: 競技中に application-admin-console から coordination state を観察 / debug できる</li>
+</ol>
+</section>
+
+<section>
+<h2>Decision (= 仮)</h2>
+
+<h3>D1: metadata に <code>interTeamCoordination</code> field を追加</h3>
+
+<p>SCHEMA を拡張し、 問題が次のように coordination plugin を宣言する。</p>
+
+<pre>"interTeamCoordination": {
+  "module": "coordination/router.ts",
+  "kind": "router",
+  "summary": "team が公開する service URL を register / lookup する router。"
+}</pre>
+
+<p><code>module</code> は問題ディレクトリ相対 path、 <code>kind</code> は問題 author が付ける free-form なラベル (catalog / debug 表示用、 platform は意味解釈しない)、 <code>summary</code> は 1 行説明 (portal 表示用)。 field 自体は optional。 省略すると inter-team interaction 無しの Battle として動く (= goal #4 fallback)。</p>
+
+<h3>D2: Plugin contract = TypeScript interface (state machine + 3 hooks)</h3>
+
+<p>plugin module は次の interface を default export する。 platform 側 SDK は <code>@TenkaCloud/coordination-plugin-sdk</code> として型と util を提供する。</p>
+
+<pre>// problems/&lt;category&gt;/&lt;id&gt;/coordination/router.ts
+import type { CoordinationPlugin } from "@TenkaCloud/coordination-plugin-sdk";
+
+interface RouterState {
+  readonly routes: Record&lt;string /* teamId */, string /* serviceUrl */&gt;;
+}
+
+type RouterOp =
+  | { kind: "register"; serviceUrl: string }
+  | { kind: "unregister" };
+
+const plugin: CoordinationPlugin&lt;RouterState, RouterOp&gt; = {
+  initialState(_ctx) {
+    return { routes: {} };
+  },
+
+  validateOp(state, teamId, op) {
+    if (op.kind === "register" &amp;&amp; !op.serviceUrl.startsWith("https://")) {
+      return { ok: false, error: "must_be_https" };
+    }
+    return { ok: true };
+  },
+
+  applyOp(state, teamId, op) {
+    if (op.kind === "register") {
+      return {
+        ...state,
+        routes: { ...state.routes, [teamId]: op.serviceUrl },
+      };
+    }
+    const { [teamId]: _, ...rest } = state.routes;
+    return { ...state, routes: rest };
+  },
+
+  // 各 team が portal で見える view (= 他 team の URL 一覧を return する等)
+  projectForTeam(state, teamId) {
+    return { otherRoutes: state.routes };
+  },
+};
+
+export default plugin;</pre>
+
+<p>5 つの hook は state machine の必要最小:</p>
+
+<ul>
+<li><code>initialState(ctx)</code>: event 開始時の初期 state</li>
+<li><code>validateOp(state, teamId, op)</code>: operation を受理可能か判定 (= rate limit / 入力検証 / 競技 phase 制約)</li>
+<li><code>applyOp(state, teamId, op)</code>: state を変える pure function (= 副作用なし)</li>
+<li><code>tick?(state, eventNowMs)</code>: scoring engine が tick ごとに呼ぶ optional hook (= 経過時間で alliance 解消等)</li>
+<li><code>projectForTeam(state, teamId)</code>: その team の portal に渡す projection (= 他 team の機密を漏らさない投影)</li>
+</ul>
+
+<h3>D3: 状態保存は per-tenant per-event DDB row</h3>
+
+<p>tenant 境界を越えない (= goal #3)。 platform は新規 DDB table <code>EventCoordinationState</code> を追加し、 partition key = <code>tenantId#eventId</code>、 sort key = なし、 attribute は <code>state: Map</code> + <code>updatedAt</code> + <code>version</code> (= optimistic locking)。 既存 ADR-012 の per-team scoring state とは完全に分離 (= 1 event につき 1 row、 N teams 共有)。 <code>DynamoDbLowCapacity</code> aspect で 1 RCU / 1 WCU に強制 (= cost 0 原則)。</p>
+
+<h3>D4: operation 提出経路は portal API + scoring tick の 2 系統</h3>
+
+<table>
+<thead>
+<tr><th>経路</th><th>誰が trigger</th><th>使用</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><code>POST /portal/me/coordination/&lt;eventId&gt;</code></td>
+  <td>競技者 (= team key 認証)</td>
+  <td>register / propose-alliance 等、 team が能動的に呼ぶ operation</td>
+</tr>
+<tr>
+  <td><code>tick(state, eventNowMs)</code></td>
+  <td>scoring engine (= 1 分ごとの polling tick と同期)</td>
+  <td>経過時間で alliance 期限切れ / queue front 進行 / 等の自動進行</td>
+</tr>
+</tbody>
+</table>
+
+<p>portal API 側は body の Zod 検証 + plugin の <code>validateOp</code> を通したあと、 DDB の optimistic locking で <code>applyOp</code> 結果を書き込む。 conflict 時は <code>409</code> を返し、 portal は退避リトライ。</p>
+
+<h3>D5: per-team projection が見える場所</h3>
+
+<p>各 team の <code>/portal/me</code> response に <code>coordination: PluginProjection</code> field を追加。 plugin の <code>projectForTeam(state, teamId)</code> 結果がそのまま入る。 portal の <code>dashboard.slots</code> で問題が独自 UI を render する (= router なら他 team の URL 表、 alliance なら同盟関係 graph、 等)。 portal 標準 UI は coordination state を直接 render しない (= 問題依存 UI を platform が知る必要がない)。</p>
+
+<h3>D6: platform 側 dispatcher Lambda の責務</h3>
+
+<p>新規 Lambda <code>CoordinationDispatcherFunction</code>:</p>
+
+<ul>
+<li>portal API <code>POST /portal/me/coordination/&lt;eventId&gt;</code> の backend</li>
+<li>plugin module を S3 (= ADR-008 で problems を payload 配信する経路) から fetch + bun runtime で load</li>
+<li><code>validateOp</code> → <code>applyOp</code> → DDB write の sequence を実行</li>
+<li>scoring tick で <code>tick</code> を呼ぶ (= 同 Lambda の別 entrypoint)</li>
+<li>plugin の <code>projectForTeam</code> を participant lookup から call する経路を export</li>
+</ul>
+
+<p>plugin code は bun の <code>import()</code> で動的 load。 sandbox は別 isolate を立てない (= cost と複雑度のため)。 plugin の bug は当該 event のみに影響し、 platform 全体には波及しない (= optimistic locking + DDB write failure で停止する)。</p>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>得るもの</h3>
+
+<ul>
+<li>各問題が完全に自由な inter-team primitive を持てる (= microservice-migration の router / security-battle-royale の alliance / stackstack の TBD primitive を同じ contract 上に乗せられる)</li>
+<li>platform は coordination の意味解釈を一切しない (= ADR-012 の thick metadata DSL と同じ抽象化)</li>
+<li>tenant 境界を越えないので security 監査範囲は問題 plugin code + 1 DDB row に閉じる (= cross-tenant data flow を audit する必要なし)</li>
+<li>fallback で coordination 未宣言の問題 (= 既存 4 問題 + Challenge 系) は影響を受けない</li>
+</ul>
+
+<h3>失うもの / コスト</h3>
+
+<ul>
+<li>plugin SDK の version 互換管理が必要 (= TypeScript interface の breaking change で全問題が壊れうる)</li>
+<li>plugin が bug を持つと当該 event の coordination が機能不全に陥る (= scoring の core 経路は影響しないが、 inter-team interaction だけが落ちる)</li>
+<li>新規 DDB table + 新規 Lambda + 新規 portal route の運用コストが platform に増える (= 既存問題は使わない reseurces だが maintenance は必要)</li>
+<li>plugin code の sandbox を持たないので、 problem author の信頼境界 = platform operator の信頼境界 (= 既存 ADR-012 の <code>portal/*.tsx</code> と同じ前提)</li>
+</ul>
+</section>
+
+<section>
+<h2>Alternatives considered</h2>
+
+<h3>A1: 1 つの primitive を platform に hardcode <span class="badge reject">却下</span></h3>
+
+<p>例えば shared resource pool だけを platform に組み込み、 全問題に強制する。 microservice-migration / security-battle-royale / stackstack のいずれにも fit せず、 1 問題に最適化された platform 機能が他問題の足を引っ張る。 ADR-012 で確立した 「問題 = plugin、 platform = host」 原則に反する。</p>
+
+<h3>A2: tenant 横断 shared resource registry <span class="badge reject">却下</span></h3>
+
+<p>stackstack の当初構想にあった 「SSO Proxy 2 slot 先着 / Security Review 待ち行列 / Claude API quota」 のような cross-tenant shared state を platform 側で持つ。 検討の結果、 security 設計の難度 (= cross-tenant authorization model / rate limiting / data isolation / audit trail) が現 platform の整備状況と釣り合わないため明示却下した。 tenant 境界を越えない別 primitive (= 本 ADR の D3 = per-tenant per-event scope) で代替する。</p>
+
+<h3>A3: 各問題が独自 Lambda + DDB を CFn 側で deploy <span class="badge reject">却下</span></h3>
+
+<p>問題 <code>template.yaml</code> 側に inter-team coordination 用 Lambda + DDB を入れる。 deploy が競技者 account に走るため cross-team write が原理的に不可能 (= team A の deployment が team B の deployment に直接 write できない)。 platform 側 plane でしか shared state を持てない。</p>
+
+<h3>A4: GraphQL / RPC service を platform 側に立てて問題が consume <span class="badge reject">却下</span></h3>
+
+<p>汎用 RPC service を platform が提供し、 問題側はその client として coordination を実装する。 plugin contract と比べて (1) platform code が問題依存 schema を持ち込む、 (2) operator から見て debugging surface が増える、 (3) 問題 author の学習コストが上がる、 のため却下。 plugin contract の方が局所性が高い。</p>
+</section>
+
+<section>
+<h2>Migration</h2>
+
+<h3>Phase 1: SDK + dispatcher + DSL ship</h3>
+
+<ul>
+<li><code>@TenkaCloud/coordination-plugin-sdk</code> パッケージ作成 (= TypeScript types + util)</li>
+<li><code>problems/SCHEMA.json</code> に <code>interTeamCoordination</code> optional field 追加</li>
+<li><code>CoordinationDispatcherFunction</code> Lambda + <code>EventCoordinationState</code> DDB table を <code>infrastructure/lib/problem-deploy/</code> に追加</li>
+<li>portal API <code>POST /portal/me/coordination/&lt;eventId&gt;</code> 追加</li>
+<li><code>/portal/me</code> response に <code>coordination</code> projection 入れる</li>
+</ul>
+
+<h3>Phase 2: 既存 problem の onboarding</h3>
+
+<ul>
+<li>microservice-migration-battle: <code>coordination/router.ts</code> を書いて他 team service URL の register / lookup を提供 (= 現状の hypothetical を実装に変換)</li>
+<li>security-battle-royale: <code>coordination/alliance.ts</code> を書いて propose / accept / dissolve の alliance state machine を提供</li>
+<li>hello-world-battle: 未宣言のまま (= goal #4 fallback で従来挙動維持)</li>
+</ul>
+
+<h3>Phase 3: stackstack の inter-team primitive を declare</h3>
+
+<p>stackstack (#1137) の Phase 2 として、 tenant 境界を越えない形の inter-team primitive を <code>coordination/&lt;something&gt;.ts</code> で declare する。 候補 (= ADR ship 時点では未確定):</p>
+
+<ul>
+<li><strong>review-queue</strong> per-tenant per-event の Security Review 待ち行列 (= 同じ tenant 内の他チームと枠を奪い合うが、 cross-tenant ではない)</li>
+<li><strong>shared-incident-board</strong> 同 tenant 内の他チーム incident 状況の公開 board (= 「あのチームも .env 流出があった」 を見せる)</li>
+<li><strong>blueprint-trade</strong> hardening 完了済 slot の blueprint を他 team に共有 / 受領する trade 機構</li>
+</ul>
+
+<p>選定は stackstack 自体の game design 判断であり、 本 ADR の scope 外。</p>
+</section>
+
+<section>
+<h2>Open questions</h2>
+
+<ul>
+<li>plugin module の依存解決: 問題 author が npm package を import したい場合の取り扱い (= 現状の <code>portal/*.tsx</code> と同様、 peer dep に閉じる方針か?)</li>
+<li>plugin の動的 reload: event 進行中に plugin code を patch できるべきか? (= 初期実装は不可、 event 終了まで固定で良いか確認)</li>
+<li>DDB row size: <code>state</code> attribute の上限 (DynamoDB の 400KB) を超える coordination が必要な問題が出てきた場合の split 戦略</li>
+<li>operator debug UI: application-admin-console に coordination state inspector を立てる範囲</li>
+<li>plugin error の血液型: plugin throw を <code>4xx</code> (= 競技者向け) と <code>5xx</code> (= operator alert) のどちらに分類するかの基準</li>
+</ul>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- 新規 ADR `docs/architecture/adr-022-inter-team-coordination-plugin.html` を追加。
- Battle 問題ごとに異なる他チーム interaction primitive (router / alliance / queue / 他) を problem 側 plugin で declare、 platform は dispatcher 1 つだけで意味解釈しない contract を定義。 ADR-012 で確立した 「問題 = plugin、 platform = host」 原則の延長。
- 却下した代替: tenant 横断 shared resource registry (= security 設計の難度が現 platform の整備状況と釣り合わないため明示却下)。 inter-team state は per-tenant per-event scope に閉じる。

## 中核 decision

| ID | 決定 |
|----|------|
| D1 | metadata に `interTeamCoordination` field (optional) を追加 |
| D2 | Plugin contract = TypeScript interface (`initialState` / `validateOp` / `applyOp` / `tick?` / `projectForTeam`) を default export |
| D3 | 状態保存は per-tenant per-event 1 DDB row (= 1 RCU/1 WCU、 `DynamoDbLowCapacity` aspect 強制) |
| D4 | operation 提出経路: portal API `POST /portal/me/coordination/<eventId>` + scoring tick の 2 系統 |
| D5 | per-team projection は `/portal/me` response の `coordination` field に入る |
| D6 | platform 側 `CoordinationDispatcherFunction` Lambda が plugin module を動的 load + DDB optimistic locking で applyOp 結果を書く |

## Migration

- **Phase 1**: SDK + dispatcher Lambda + DDB table + portal route の ship
- **Phase 2**: 既存 battle (microservice-migration-battle / security-battle-royale) の inter-team primitive を declare
- **Phase 3**: stackstack (#1137) の inter-team primitive を declare (= 候補は review-queue / shared-incident-board / blueprint-trade、 game design 判断)

## Test plan

- `make harness` → no findings (= `adr-must-be-html` / `adr-self-contained` 含む全 invariant clear)
- `make before-commit` → lint / typecheck / vitest / build / build-docs check / template ASCII / template security / CFn refs / audit-deps / cdk synth すべて OK
- ADR 単独で読めることを確認 (= chat 文脈 / 順次反映 metadata / role 分担を残していない)

## Regression 分析

- ドキュメント追加のみ。 application / infrastructure / problems / scripts には触っていない。
- 既存 ADR への text 変更なし (リンクは <a href> で <code>./adr-012-problem-plugin-architecture.html</code> を 1 件参照するだけ)。
- 既存問題 / 既存 scoring engine / 既存 portal の挙動には一切影響しない。
- ADR 本文の decision は **draft** status であり、 実装 PR は別途。 本 PR で platform の挙動は変わらない。

## 物理影響

- **CREATE**: `docs/architecture/adr-022-inter-team-coordination-plugin.html` (1 ファイル、 307 行)
- **UPDATE / REPLACE / DELETE**: なし
- **CFn / AWS deploy 影響**: なし (= docs-only)
- **CI / CD 影響**: なし (= `.github/workflows/ci.yml` 不変)
- **dependency 影響**: なし
- **Runtime impact**: NO-OP

Relates #1137 (StackStack Phase 2 = ADR-022 ship 後に inter-team primitive を declare する)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)