### PR TITLE
feat(portal): surface offline cloud mode

### DIFF
--- a/apps/participant-portal/public/.gitignore
+++ b/apps/participant-portal/public/.gitignore
@@ -1,0 +1,1 @@
+runtime-config.json

--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -1,3 +1,4 @@
+import Alert from "@cloudscape-design/components/alert";
 import AppLayout from "@cloudscape-design/components/app-layout";
 import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
@@ -23,6 +24,25 @@ const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
   ja: "日本語",
   en: "English",
 };
+
+function OfflineCloudModeAlert({ config }: { config: AppConfig }) {
+  const { t } = useI18n();
+  if (config.cloudMode === "real") return null;
+  if (config.cloudMode === "localstack") {
+    return (
+      <Alert type="warning" header={t("app.localstack_cloud_header")}>
+        {t("app.localstack_cloud_body", {
+          endpoint: config.localstackEndpoint ?? t("app.localstack_endpoint_missing"),
+        })}
+      </Alert>
+    );
+  }
+  return (
+    <Alert type="info" header={t("app.mock_cloud_header")}>
+      {t("app.mock_cloud_body")}
+    </Alert>
+  );
+}
 
 /**
  * Participant Portal の shell。AWS GameDay の参考画面に倣って TopNavigation +
@@ -190,6 +210,7 @@ function ShellInner({ config, children }: { config: AppConfig; children: ReactNo
         }
         content={
           <SpaceBetween size="m">
+            <OfflineCloudModeAlert config={config} />
             {auth.session === null ? (
               <Box variant="strong" color="text-status-warning">
                 {t("app.no_session")}

--- a/apps/participant-portal/src/config.ts
+++ b/apps/participant-portal/src/config.ts
@@ -9,14 +9,19 @@
  * `mode` は backend 連携モード。`"dev-mock"` はフロント単体動作 (mock auth が有効)。
  *   `"backend"` は本物の backend API を呼ぶ。runtime-config の値が優先、なければ
  *   fallback で `"dev-mock"` 扱い。
+ * `cloudMode` は実際に問題環境を作る provider execution mode。frontend はこれを見て
+ * offline/mock/localstack の警告 UI を出すが、認証 skip には使わない。
  */
 export type AppMode = "dev-mock" | "backend";
+export type CloudMode = "real" | "mock" | "localstack";
 
 export interface AppConfig {
   readonly apiBaseUrl: string;
   readonly eventTitle: string;
   readonly eventRegion: string;
   readonly mode: AppMode;
+  readonly cloudMode: CloudMode;
+  readonly localstackEndpoint?: string;
 }
 
 interface RuntimeConfig {
@@ -24,6 +29,8 @@ interface RuntimeConfig {
   readonly eventTitle?: string;
   readonly eventRegion?: string;
   readonly mode?: AppMode;
+  readonly cloudMode?: CloudMode;
+  readonly localstackEndpoint?: string;
 }
 
 const DEV_FALLBACK: AppConfig = {
@@ -31,6 +38,7 @@ const DEV_FALLBACK: AppConfig = {
   eventTitle: "TenkaCloud Battle (dev mock)",
   eventRegion: "ap-northeast-1",
   mode: "dev-mock",
+  cloudMode: "mock",
 };
 
 /**
@@ -46,6 +54,28 @@ function isHttpsUrl(value: string): boolean {
   }
 }
 
+function isCloudMode(value: unknown): value is CloudMode {
+  return value === "real" || value === "mock" || value === "localstack";
+}
+
+function defaultCloudMode(mode: AppMode): CloudMode {
+  return mode === "backend" ? "real" : "mock";
+}
+
+function normalizeLocalstackEndpoint(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  try {
+    const url = new URL(value);
+    const allowedHost =
+      url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+    const allowedProtocol = url.protocol === "http:" || url.protocol === "https:";
+    if (!allowedHost || !allowedProtocol) return undefined;
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
 export async function loadConfig(): Promise<AppConfig> {
   try {
     const res = await fetch("/runtime-config.json", { cache: "no-store" });
@@ -55,6 +85,7 @@ export async function loadConfig(): Promise<AppConfig> {
     }
     const runtime = (await res.json()) as RuntimeConfig;
     const mode = runtime.mode ?? DEV_FALLBACK.mode;
+    const cloudMode = isCloudMode(runtime.cloudMode) ? runtime.cloudMode : defaultCloudMode(mode);
     const apiBaseUrl = runtime.apiBaseUrl ?? DEV_FALLBACK.apiBaseUrl;
     // Issue #871: backend mode は HTTPS 必須 (= teamLoginKey を attacker に漏らさない)
     if (mode === "backend" && apiBaseUrl && !isHttpsUrl(apiBaseUrl)) {
@@ -68,6 +99,11 @@ export async function loadConfig(): Promise<AppConfig> {
       eventTitle: runtime.eventTitle ?? DEV_FALLBACK.eventTitle,
       eventRegion: runtime.eventRegion ?? DEV_FALLBACK.eventRegion,
       mode,
+      cloudMode,
+      localstackEndpoint:
+        cloudMode === "localstack"
+          ? normalizeLocalstackEndpoint(runtime.localstackEndpoint)
+          : undefined,
     };
   } catch {
     return DEV_FALLBACK;

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -6,7 +6,11 @@
     "title": "TenkaCloud Participant Portal",
     "loading": "Loading…",
     "no_session": "No active session. Please sign in again.",
-    "dev_mock_alert": "Running in dev-mock mode. To connect to a real backend, set runtime-config mode to backend.",
+    "mock_cloud_header": "Mock cloud mode",
+    "mock_cloud_body": "This event is using a local mock cloud adapter. No real AWS resources are created.",
+    "localstack_cloud_header": "LocalStack cloud mode",
+    "localstack_cloud_body": "This event is configured for LocalStack at {endpoint}. Real AWS resources are not used.",
+    "localstack_endpoint_missing": "endpoint not configured",
     "fetch_status_failed": "Failed to fetch status"
   },
   "nav": {

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -6,7 +6,11 @@
     "title": "TenkaCloud 競技者ポータル",
     "loading": "状態を取得中…",
     "no_session": "セッションがありません。再ログインしてください。",
-    "dev_mock_alert": "dev-mock モードで動作中です。実 backend と接続するには runtime-config の mode を backend に設定してください。",
+    "mock_cloud_header": "Mock cloud mode",
+    "mock_cloud_body": "このイベントは local mock cloud adapter で動作しています。実 AWS リソースは作成されません。",
+    "localstack_cloud_header": "LocalStack cloud mode",
+    "localstack_cloud_body": "このイベントは LocalStack ({endpoint}) 向けに設定されています。実 AWS リソースは使われません。",
+    "localstack_endpoint_missing": "endpoint 未設定",
     "fetch_status_failed": "状態の取得に失敗しました"
   },
   "nav": {

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -46,7 +46,6 @@ export function HomePage({ config }: { config: AppConfig }) {
         {t("home.welcome", { teamName })}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {error && (
         <Alert type="error" header={t("app.fetch_status_failed")}>
           {error}

--- a/apps/participant-portal/src/pages/Notifications.tsx
+++ b/apps/participant-portal/src/pages/Notifications.tsx
@@ -51,7 +51,6 @@ export function NotificationsPage({ config }: { config: AppConfig }) {
         {t("notifications.header")}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {notificationsError && (
         <Alert type="error" header={t("notifications.fetch_failed")}>
           {notificationsError}

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -168,7 +168,6 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         {t("quests.header")}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {error && (
         <Alert type="error" header={t("app.fetch_status_failed")}>
           {error}

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -106,7 +106,6 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
         {t("score_events.title")}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {error && (
         <Alert type="error" header={t("app.fetch_status_failed")}>
           {error}

--- a/apps/participant-portal/src/pages/Scoreboard.tsx
+++ b/apps/participant-portal/src/pages/Scoreboard.tsx
@@ -32,7 +32,6 @@ export function ScoreboardPage({ config }: { config: AppConfig }) {
         {t("scoreboard.title")}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {leaderboardError && (
         <Alert type="error" header={t("app.fetch_status_failed")}>
           {leaderboardError}

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -58,7 +58,6 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
         {t("sso_credentials.title")}
       </Header>
 
-      {!isBackend && <Alert type="info">{t("app.dev_mock_alert")}</Alert>}
       {error && (
         <Alert type="error" header={t("app.fetch_status_failed")}>
           {error}

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -11,6 +11,7 @@ const config: AppConfig = {
   eventTitle: "TenkaCloud Battle (test)",
   eventRegion: "ap-northeast-1",
   mode: "dev-mock",
+  cloudMode: "mock",
 };
 
 function renderApp(initialPath: string) {
@@ -72,6 +73,7 @@ describe("App", () => {
       expect(
         await screen.findByRole("heading", { level: 1, name: /ようこそ/ }),
       ).toBeInTheDocument();
+      expect(screen.getByText("Mock cloud mode")).toBeInTheDocument();
     });
   });
 

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -73,7 +73,7 @@ describe("App", () => {
       expect(
         await screen.findByRole("heading", { level: 1, name: /ようこそ/ }),
       ).toBeInTheDocument();
-      expect(screen.getByText("Mock cloud mode")).toBeInTheDocument();
+      expect(screen.getByText(/実 AWS リソースは作成されません/)).toBeInTheDocument();
     });
   });
 

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -8,6 +8,7 @@ const devConfig: AppConfig = {
   eventTitle: "Test Event",
   eventRegion: "ap-northeast-1",
   mode: "dev-mock",
+  cloudMode: "mock",
 };
 
 const prodConfig: AppConfig = {
@@ -15,6 +16,7 @@ const prodConfig: AppConfig = {
   eventTitle: "Test Event",
   eventRegion: "ap-northeast-1",
   mode: "backend",
+  cloudMode: "real",
 };
 
 const renderAuth = (config: AppConfig) =>

--- a/apps/participant-portal/test/config.test.ts
+++ b/apps/participant-portal/test/config.test.ts
@@ -25,6 +25,7 @@ describe("loadConfig", () => {
     expect(cfg.eventTitle).toBe("Real Event");
     expect(cfg.eventRegion).toBe("us-east-1");
     expect(cfg.mode).toBe("backend");
+    expect(cfg.cloudMode).toBe("real");
   });
 
   it("mode が runtime-config に無いときは fallback の dev-mock になるべき", async () => {
@@ -34,6 +35,40 @@ describe("loadConfig", () => {
     });
     const cfg = await loadConfig();
     expect(cfg.mode).toBe("dev-mock");
+    expect(cfg.cloudMode).toBe("mock");
+  });
+
+  it("cloudMode=localstack の runtime-config を読み込むべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        eventTitle: "Offline Event",
+        eventRegion: "ap-northeast-1",
+        mode: "backend",
+        cloudMode: "localstack",
+        localstackEndpoint: "http://localhost:4566/",
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.mode).toBe("backend");
+    expect(cfg.cloudMode).toBe("localstack");
+    expect(cfg.localstackEndpoint).toBe("http://localhost:4566");
+  });
+
+  it("localstackEndpoint が localhost 以外なら表示用 endpoint として採用しないべき", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        mode: "backend",
+        cloudMode: "localstack",
+        localstackEndpoint: "https://example.com:4566",
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.cloudMode).toBe("localstack");
+    expect(cfg.localstackEndpoint).toBeUndefined();
   });
 
   it("一部キー欠落でも fallback で埋めるべき", async () => {
@@ -79,5 +114,6 @@ describe("loadConfig", () => {
     // fallback の dev-mock URL に倒れる (= teamLoginKey を attacker に送らない)
     expect(cfg.apiBaseUrl).toContain("dev-mock");
     expect(cfg.mode).toBe("dev-mock");
+    expect(cfg.cloudMode).toBe("mock");
   });
 });

--- a/scripts/participant-portal-runtime-config.ts
+++ b/scripts/participant-portal-runtime-config.ts
@@ -138,8 +138,10 @@ function defaultPortalMode(cloudMode: CloudMode): AppMode {
 
 function buildRuntimeConfig(options: Options): RuntimeConfig {
   const mode = options.portalMode ?? defaultPortalMode(options.cloudMode);
-  const apiBaseUrl =
-    options.apiBaseUrl ?? (mode === "backend" ? "" : "http://localhost:3199/dev-mock");
+  if (mode === "backend" && (!options.apiBaseUrl || options.apiBaseUrl.trim().length === 0)) {
+    throw new Error("--api-base-url is required when participant portal runs in backend mode");
+  }
+  const apiBaseUrl = options.apiBaseUrl ?? "http://localhost:3199/dev-mock";
   return {
     apiBaseUrl,
     eventTitle: options.eventTitle,

--- a/scripts/participant-portal-runtime-config.ts
+++ b/scripts/participant-portal-runtime-config.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+type AppMode = "dev-mock" | "backend";
+type CloudMode = "real" | "mock" | "localstack";
+
+interface RuntimeConfig {
+  readonly apiBaseUrl: string;
+  readonly eventTitle: string;
+  readonly eventRegion: string;
+  readonly mode: AppMode;
+  readonly cloudMode: CloudMode;
+  readonly localstackEndpoint?: string;
+}
+
+interface Options {
+  readonly cloudMode: CloudMode;
+  readonly portalMode?: AppMode;
+  readonly apiBaseUrl?: string;
+  readonly eventTitle: string;
+  readonly eventRegion: string;
+  readonly localstackEndpoint?: string;
+  readonly out: string;
+  readonly print: boolean;
+}
+
+interface MutableOptions {
+  cloudMode?: CloudMode;
+  portalMode?: AppMode;
+  apiBaseUrl?: string;
+  eventTitle: string;
+  eventRegion: string;
+  localstackEndpoint?: string;
+  out: string;
+  print: boolean;
+}
+
+const DEFAULT_OUT = "apps/participant-portal/public/runtime-config.json";
+
+function usage(): string {
+  return [
+    "Usage: bun run scripts/participant-portal-runtime-config.ts --cloud-mode <mock|localstack|real> [options]",
+    "",
+    "Options:",
+    "  --portal-mode <dev-mock|backend>       Participant Portal API mode",
+    "  --api-base-url <url>                   Portal backend base URL",
+    "  --event-title <title>                  Event title",
+    "  --event-region <region>                Display region",
+    "  --localstack-endpoint <url>             LocalStack endpoint (localstack mode)",
+    "  --out <path>                           Output path",
+    "  --print                                Print JSON instead of writing",
+  ].join("\n");
+}
+
+function requireValue(argv: readonly string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseCloudMode(value: string): CloudMode {
+  if (value === "real" || value === "mock" || value === "localstack") return value;
+  throw new Error(`Invalid --cloud-mode: ${value}`);
+}
+
+function parseAppMode(value: string): AppMode {
+  if (value === "dev-mock" || value === "backend") return value;
+  throw new Error(`Invalid --portal-mode: ${value}`);
+}
+
+const VALUE_HANDLERS: Record<string, (state: MutableOptions, value: string) => void> = {
+  "--cloud-mode": (state, value) => {
+    state.cloudMode = parseCloudMode(value);
+  },
+  "--portal-mode": (state, value) => {
+    state.portalMode = parseAppMode(value);
+  },
+  "--api-base-url": (state, value) => {
+    state.apiBaseUrl = value.replace(/\/$/, "");
+  },
+  "--event-title": (state, value) => {
+    state.eventTitle = value;
+  },
+  "--event-region": (state, value) => {
+    state.eventRegion = value;
+  },
+  "--localstack-endpoint": (state, value) => {
+    state.localstackEndpoint = value.replace(/\/$/, "");
+  },
+  "--out": (state, value) => {
+    state.out = value;
+  },
+};
+
+function parseArgs(argv: readonly string[]): Options {
+  const state: MutableOptions = {
+    eventTitle: "TenkaCloud Battle (offline)",
+    eventRegion: "ap-northeast-1",
+    out: DEFAULT_OUT,
+    print: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--print") {
+      state.print = true;
+      continue;
+    }
+    const handler = VALUE_HANDLERS[arg];
+    if (!handler) throw new Error(`Unknown argument: ${arg}`);
+    handler(state, requireValue(argv, i, arg));
+    i++;
+  }
+
+  const cloudMode = state.cloudMode;
+  if (!cloudMode) throw new Error("--cloud-mode is required");
+  return {
+    cloudMode,
+    portalMode: state.portalMode,
+    apiBaseUrl: state.apiBaseUrl,
+    eventTitle: state.eventTitle,
+    eventRegion: state.eventRegion,
+    localstackEndpoint: state.localstackEndpoint,
+    out: state.out,
+    print: state.print,
+  };
+}
+
+function defaultPortalMode(cloudMode: CloudMode): AppMode {
+  return cloudMode === "real" ? "backend" : "dev-mock";
+}
+
+function buildRuntimeConfig(options: Options): RuntimeConfig {
+  const mode = options.portalMode ?? defaultPortalMode(options.cloudMode);
+  const apiBaseUrl =
+    options.apiBaseUrl ?? (mode === "backend" ? "" : "http://localhost:3199/dev-mock");
+  return {
+    apiBaseUrl,
+    eventTitle: options.eventTitle,
+    eventRegion: options.eventRegion,
+    mode,
+    cloudMode: options.cloudMode,
+    ...(options.cloudMode === "localstack"
+      ? { localstackEndpoint: options.localstackEndpoint ?? "http://localhost:4566" }
+      : {}),
+  };
+}
+
+function main(): void {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const json = `${JSON.stringify(buildRuntimeConfig(options), null, 2)}\n`;
+    if (options.print) {
+      process.stdout.write(json);
+      return;
+    }
+    const out = resolve(options.out);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, json, "utf8");
+    console.log(`Wrote ${out}`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    console.error(usage());
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Extend participant portal runtime config with `cloudMode: real | mock | localstack` and an optional LocalStack endpoint.
- Centralize the offline/mock warning in the portal shell so participants can see when no real AWS resources are used.
- Add `scripts/participant-portal-runtime-config.ts` to generate local mock/localstack runtime-config.json for offline demos.

## Test plan
- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`
- `bun run scripts/participant-portal-runtime-config.ts --cloud-mode mock --print`
- Browser check: local participant portal with generated LocalStack runtime-config shows `LocalStack cloud mode` after mock login.

## Regression 分析
- Auth behavior is unchanged: `cloudMode` is display/runtime metadata only and does not enable auth skip.
- Backend mode still rejects non-HTTPS `apiBaseUrl`, so teamLoginKey is not sent to arbitrary HTTP endpoints.
- Existing per-page dev-mock notices were replaced by one shell-level notice to avoid duplicate alerts.
- LocalStack endpoint is only displayed when it is localhost/127.0.0.1/[::1].

## 物理影響
- CREATE: local helper script `scripts/participant-portal-runtime-config.ts` and `apps/participant-portal/public/.gitignore`.
- UPDATE: participant portal runtime-config parsing, shell notice, i18n, and tests.
- NO-OP: no CDK, IAM, CloudFormation, or AWS resource changes in this PR.

Relates #1122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud environment mode selection (Real, Mock, or LocalStack) with a visible status indicator in the main app layout
  * Added LocalStack endpoint configuration support for local development and testing

* **Improvements**
  * Consolidated environment status messaging to the app layout for a cleaner experience across all pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->