### PR TITLE
refactor(app-admin): remove unused shell code

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -22,10 +22,10 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-function guarded(config: AppConfig, element: React.ReactNode) {
+function guarded(element: React.ReactNode) {
   return (
     <RequireAuth>
-      <ShellLayout config={config}>{element}</ShellLayout>
+      <ShellLayout>{element}</ShellLayout>
     </RequireAuth>
   );
 }
@@ -36,27 +36,24 @@ export function App({ config }: { config: AppConfig }) {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/callback" element={<CallbackPage config={config} />} />
-        <Route path="/" element={guarded(config, <HomePage />)} />
-        <Route path="/problems" element={guarded(config, <ProblemsPage />)} />
+        <Route path="/" element={guarded(<HomePage />)} />
+        <Route path="/problems" element={guarded(<ProblemsPage />)} />
         <Route
           path="/problems/:problemId"
-          element={guarded(config, <ProblemDetailPage config={config} />)}
+          element={guarded(<ProblemDetailPage config={config} />)}
         />
-        <Route path="/deployments" element={guarded(config, <DeploymentsPage config={config} />)} />
+        <Route path="/deployments" element={guarded(<DeploymentsPage config={config} />)} />
         <Route
           path="/deployments/:jobId"
-          element={guarded(config, <DeploymentDetailPage config={config} />)}
+          element={guarded(<DeploymentDetailPage config={config} />)}
         />
         <Route
           path="/competitor-accounts"
-          element={guarded(config, <CompetitorAccountsPage config={config} />)}
+          element={guarded(<CompetitorAccountsPage config={config} />)}
         />
-        <Route path="/events" element={guarded(config, <EventListPage config={config} />)} />
-        <Route path="/events/new" element={guarded(config, <EventCreatePage config={config} />)} />
-        <Route
-          path="/events/:eventId"
-          element={guarded(config, <EventDetailPage config={config} />)}
-        />
+        <Route path="/events" element={guarded(<EventListPage config={config} />)} />
+        <Route path="/events/new" element={guarded(<EventCreatePage config={config} />)} />
+        <Route path="/events/:eventId" element={guarded(<EventDetailPage config={config} />)} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </AuthProvider>

--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -7,7 +7,6 @@ import type { ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import { decodeIdToken } from "../auth/claims";
-import type { AppConfig } from "../config";
 import { type LocaleCode, SUPPORTED_LOCALES, useI18n } from "../i18n";
 
 /** Issue #583 Phase 1.C: locale switcher display 名 map (= 各 locale.json と同期)。 */
@@ -24,7 +23,7 @@ const LOCALE_NAME: Record<LocaleCode, string> = {
  * placeholder のまま漏れるので、ここでは表示しない。Home ページ側で JWT custom 属性
  * (custom:tenantId / 将来 custom:tenantName) からユーザの所属テナントを描画する。
  */
-export function ShellLayout({ config, children }: { config: AppConfig; children: ReactNode }) {
+export function ShellLayout({ children }: { children: ReactNode }) {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -37,7 +37,6 @@ import {
   type DeployPhase,
   deploySummaryTitle,
   derivePhases,
-  formatLogTimestamp,
   type LogLine,
   type PhaseStatus,
 } from "../lib/deploy-phases";

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -39,7 +39,6 @@ const TEAMS_MIN = 1;
 const TEAMS_MAX = 99;
 const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
 const INITIAL_TEAM_COUNT = 3;
-const NO_VERIFIED_ACCOUNTS_HELPER = "No verified accounts available. Add one first.";
 
 const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
   value: r.code,


### PR DESCRIPTION
## Summary

- Remove an unused `ShellLayout` `config` prop and simplify its internal caller.
- Remove unused `formatLogTimestamp` import from deployment detail.
- Remove unused `NO_VERIFIED_ACCOUNTS_HELPER` constant from event creation.
- Relates #1124

## Deleted Code Checklist

- DELETE: `ShellLayout` unused `config` prop and `AppConfig` import.
- DELETE: redundant `guarded(config, ...)` argument in application admin routing.
- DELETE: unused `formatLogTimestamp` import.
- DELETE: unused `NO_VERIFIED_ACCOUNTS_HELPER` constant.

## Test plan

- `make tech-debt` (`OK tech-debt analyzer is not configured for this repository yet`)
- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage bun run --filter @TenkaCloud/application-admin-console test`
- `bun run --filter @TenkaCloud/application-admin-console typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`

## Regression 分析

- No user-facing route, label, API call, or state transition changed; this removes values that were already unused by the application.
- Application admin console tests cover the touched routing shell and event/deployment pages; the full repository before-commit gate also passed.
- Biome unused-code warnings decreased from 76 to 73 during the local sweep.

## 物理影響

- CREATE: none.
- UPDATE: TypeScript source only in `apps/application-admin-console`.
- REPLACE: none.
- DELETE: unused code only; no runtime resources.
- NO-OP: AWS/CDK/IAM/CloudFormation templates are untouched.
