### PR TITLE
refactor(admin): simplify audit log loading

### DIFF
--- a/apps/admin-console/src/pages/AuditLog.tsx
+++ b/apps/admin-console/src/pages/AuditLog.tsx
@@ -21,6 +21,45 @@ import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 
+const AUDIT_PAGE_LIMIT = 50;
+
+type AuditListInput = Parameters<AuditClient["list"]>[0];
+type TFn = (key: string, params?: Readonly<Record<string, string | number>>) => string;
+
+export function validateAuditLoadInput(scope: AuditScope, tenantId: string, t: TFn): string | null {
+  if (scope === "tenant" && tenantId.trim().length === 0) {
+    return t("audit_log.tenant_id_required");
+  }
+  return null;
+}
+
+export function buildAuditListInput(
+  scope: AuditScope,
+  tenantId: string,
+  cursor: string | undefined,
+): AuditListInput {
+  return {
+    scope,
+    ...(scope === "tenant" ? { tenantId: tenantId.trim() } : {}),
+    limit: AUDIT_PAGE_LIMIT,
+    ...(cursor ? { cursor } : {}),
+  };
+}
+
+export function mergeAuditItems(
+  previousItems: readonly AuditItem[],
+  pageItems: readonly AuditItem[],
+  cursor: string | undefined,
+): AuditItem[] {
+  return cursor ? [...previousItems, ...pageItems] : [...pageItems];
+}
+
+export function describeAuditLoadError(err: unknown, t: TFn): string {
+  if (err instanceof AuditApiError) return describeAuditError(err);
+  if (err instanceof Error) return err.message;
+  return t("audit_log.fetch_failed");
+}
+
 /**
  * Issue #950 (ADR-020 Phase D): SystemAdmin Console 側の admin 操作監査ログ view。
  *
@@ -46,34 +85,19 @@ export function AuditLogPage({ config }: { config: AppConfig }) {
   const load = useCallback(
     async (cursor: string | undefined) => {
       if (!client) return;
-      if (scope === "tenant" && tenantId.trim().length === 0) {
-        setError(t("audit_log.tenant_id_required"));
+      const validationError = validateAuditLoadInput(scope, tenantId, t);
+      if (validationError) {
+        setError(validationError);
         return;
       }
       setLoading(true);
       setError(null);
       try {
-        const page = await client.list({
-          scope,
-          ...(scope === "tenant" ? { tenantId: tenantId.trim() } : {}),
-          limit: 50,
-          ...(cursor ? { cursor } : {}),
-        });
-        if (cursor) {
-          // 続きを append
-          setItems((prev) => [...prev, ...page.items]);
-        } else {
-          setItems([...page.items]);
-        }
+        const page = await client.list(buildAuditListInput(scope, tenantId, cursor));
+        setItems((prev) => mergeAuditItems(prev, page.items, cursor));
         setNextCursor(page.nextCursor);
       } catch (err) {
-        if (err instanceof AuditApiError) {
-          setError(describeAuditError(err));
-        } else if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError(t("audit_log.fetch_failed"));
-        }
+        setError(describeAuditLoadError(err, t));
       } finally {
         setLoading(false);
       }

--- a/apps/admin-console/test/audit-log.test.ts
+++ b/apps/admin-console/test/audit-log.test.ts
@@ -1,0 +1,62 @@
+import { StatusCodes } from "http-status-codes";
+import { describe, expect, it } from "vitest";
+import { AuditApiError } from "../src/api/audit-client";
+import {
+  buildAuditListInput,
+  describeAuditLoadError,
+  mergeAuditItems,
+  validateAuditLoadInput,
+} from "../src/pages/AuditLog";
+
+const t = (key: string) => `t:${key}`;
+
+const firstItem = {
+  id: "audit-1",
+  tenantId: "tenant-a",
+  actor: "admin",
+  action: "CreateTenant",
+  outcome: "success",
+  occurredAt: "2026-05-20T10:00:00.000Z",
+};
+
+const secondItem = {
+  id: "audit-2",
+  tenantId: "tenant-a",
+  actor: "admin",
+  action: "DeleteTenant",
+  outcome: "forbidden",
+  occurredAt: "2026-05-20T10:01:00.000Z",
+};
+
+describe("AuditLog helpers", () => {
+  it("tenant scope で tenantId が空なら validation error を返すべき", () => {
+    expect(validateAuditLoadInput("tenant", "  ", t)).toBe("t:audit_log.tenant_id_required");
+    expect(validateAuditLoadInput("system", "  ", t)).toBeNull();
+  });
+
+  it("Audit API list input は tenantId を trim し cursor を必要時だけ含めるべき", () => {
+    expect(buildAuditListInput("tenant", " tenant-a ", "next")).toEqual({
+      scope: "tenant",
+      tenantId: "tenant-a",
+      limit: 50,
+      cursor: "next",
+    });
+    expect(buildAuditListInput("system", " tenant-a ", undefined)).toEqual({
+      scope: "system",
+      limit: 50,
+    });
+  });
+
+  it("cursor ありなら audit items を append し cursor 無しなら差し替えるべき", () => {
+    expect(mergeAuditItems([firstItem], [secondItem], "next")).toEqual([firstItem, secondItem]);
+    expect(mergeAuditItems([firstItem], [secondItem], undefined)).toEqual([secondItem]);
+  });
+
+  it("Audit API error と unknown error を表示文言に変換すべき", () => {
+    expect(describeAuditLoadError(new AuditApiError(StatusCodes.FORBIDDEN, undefined), t)).toBe(
+      "SystemAdmin role が必要です",
+    );
+    expect(describeAuditLoadError(new Error("network failed"), t)).toBe("network failed");
+    expect(describeAuditLoadError("bad", t)).toBe("t:audit_log.fetch_failed");
+  });
+});


### PR DESCRIPTION
## Summary

- Split `AuditLogPage` load logic into focused helpers for validation, request construction, item merge, and error mapping.
- Add unit coverage for those helpers so the refactor has a direct safety net.
- Relates #1124

## Refactor Checklist

- UPDATE: `apps/admin-console/src/pages/AuditLog.tsx` load callback is simplified.
- CREATE: `apps/admin-console/test/audit-log.test.ts` covers extracted helper behavior.
- DELETE: none.

## Test plan

- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage bun run --filter @TenkaCloud/admin-console test -- audit-log`
- `bun run --filter @TenkaCloud/admin-console typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`

## Regression 分析

- No endpoint, auth flow, route, or UI label changed; this only moves existing `AuditLogPage` load branches into pure helpers.
- Helper tests cover tenant validation, cursor/tenant request construction, append-vs-replace behavior, and error text mapping.
- Biome complexity warning for `apps/admin-console/src/pages/AuditLog.tsx` is removed on this branch.

## 物理影響

- CREATE: no AWS resources.
- UPDATE: admin-console TypeScript source and unit tests only.
- REPLACE: none.
- DELETE: none.
- NO-OP: CDK/IAM/CloudFormation/templates are untouched.
