### PR TITLE
refactor(portal): simplify score timeline loading

### DIFF
--- a/apps/participant-portal/src/components/ScoreTimelineChart.test.ts
+++ b/apps/participant-portal/src/components/ScoreTimelineChart.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { TeamScoreEvents } from "../api/portal-client";
+import { buildCumulativePoints, toScoreTimelineLoadError } from "./ScoreTimelineChart";
+
+describe("ScoreTimelineChart helpers", () => {
+  it("score events を累積 point に変換し invalid timestamp は除外すべき", () => {
+    const team: TeamScoreEvents = {
+      teamId: "team-a",
+      teamName: "Team A",
+      isMyTeam: true,
+      events: [
+        {
+          jobId: "job-1",
+          problemId: "p1",
+          source: "flag",
+          points: 10,
+          result: "ok",
+          occurredAt: "2026-05-20T10:00:00.000Z",
+        },
+        {
+          jobId: "job-2",
+          problemId: "p2",
+          source: "hint",
+          points: -2,
+          result: "ok",
+          occurredAt: "bad timestamp",
+        },
+        {
+          jobId: "job-3",
+          problemId: "p3",
+          source: "uptime",
+          points: 5,
+          result: "ok",
+          occurredAt: "2026-05-20T10:01:00.000Z",
+        },
+      ],
+    };
+
+    const points = buildCumulativePoints(team);
+
+    expect(points).toHaveLength(2);
+    expect(points.map((p) => p.y)).toEqual([10, 13]);
+    expect(points[0]?.x.toISOString()).toBe("2026-05-20T10:00:00.000Z");
+  });
+
+  it("AbortError は skip、それ以外は error message に変換すべき", () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+
+    expect(toScoreTimelineLoadError(abort)).toEqual({ kind: "skip" });
+    expect(toScoreTimelineLoadError(new Error("network failed"))).toEqual({
+      kind: "error",
+      message: "network failed",
+    });
+    expect(toScoreTimelineLoadError("bad")).toEqual({ kind: "error", message: "bad" });
+  });
+});

--- a/apps/participant-portal/src/components/ScoreTimelineChart.tsx
+++ b/apps/participant-portal/src/components/ScoreTimelineChart.tsx
@@ -38,11 +38,16 @@ interface SeriesPoint {
   readonly y: number;
 }
 
+type ScoreTimelineLoadResult =
+  | { readonly kind: "ok"; readonly data: LeaderboardScoreEventsResponse }
+  | { readonly kind: "skip" }
+  | { readonly kind: "error"; readonly message: string };
+
 /**
  * 1 team の event 列 (= occurredAt 昇順前提) を 累計スコア の data point 列に変換する。
  * 競技開始からの累積遷移を見たいので 0 origin から積み上げる。
  */
-function buildCumulativePoints(team: TeamScoreEvents): readonly SeriesPoint[] {
+export function buildCumulativePoints(team: TeamScoreEvents): readonly SeriesPoint[] {
   const points: SeriesPoint[] = [];
   let cum = 0;
   for (const e of team.events) {
@@ -52,6 +57,26 @@ function buildCumulativePoints(team: TeamScoreEvents): readonly SeriesPoint[] {
     points.push({ x: new Date(ts), y: cum });
   }
   return points;
+}
+
+export function toScoreTimelineLoadError(err: unknown): ScoreTimelineLoadResult {
+  if (err instanceof Error && err.name === "AbortError") return { kind: "skip" };
+  return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+}
+
+async function fetchScoreTimelineData(
+  apiBaseUrl: string,
+  sessionToken: string,
+  signal: AbortSignal,
+): Promise<ScoreTimelineLoadResult> {
+  if (!sessionToken) return { kind: "skip" };
+  try {
+    const data = await getLeaderboardScoreEvents(apiBaseUrl, sessionToken, signal);
+    if (!data) return { kind: "skip" };
+    return { kind: "ok", data };
+  } catch (err) {
+    return toScoreTimelineLoadError(err);
+  }
 }
 
 export function ScoreTimelineChart({
@@ -70,18 +95,14 @@ export function ScoreTimelineChart({
     let mounted = true;
     const controller = new AbortController();
     const fetchOnce = async () => {
-      if (!sessionToken) return;
-      try {
-        const res = await getLeaderboardScoreEvents(apiBaseUrl, sessionToken, controller.signal);
-        if (mounted) {
-          setData(res);
-          setError(null);
-        }
-      } catch (err) {
-        if (!mounted) return;
-        if (err instanceof Error && err.name === "AbortError") return;
-        setError(err instanceof Error ? err.message : String(err));
+      const result = await fetchScoreTimelineData(apiBaseUrl, sessionToken, controller.signal);
+      if (!mounted || result.kind === "skip") return;
+      if (result.kind === "error") {
+        setError(result.message);
+        return;
       }
+      setData(result.data);
+      setError(null);
     };
     void fetchOnce();
     const interval = setInterval(fetchOnce, POLL_INTERVAL_MS);


### PR DESCRIPTION
## Summary

- Split `ScoreTimelineChart` polling result handling into small helpers.
- Add unit coverage for cumulative score point building and abort/error classification.
- Relates #1124

## Refactor Checklist

- UPDATE: `apps/participant-portal/src/components/ScoreTimelineChart.tsx` fetch/polling branch handling.
- CREATE: `apps/participant-portal/src/components/ScoreTimelineChart.test.ts`.
- DELETE: none.

## Test plan

- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage bun run --filter @TenkaCloud/participant-portal test -- ScoreTimelineChart`
- `bun run --filter @TenkaCloud/participant-portal typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`

## Regression 分析

- The chart still calls the same `/portal/leaderboard/score-events` client and keeps the same 30s polling cadence.
- Abort handling remains a no-op path; non-abort failures still surface as the existing error message state.
- Tests now cover cumulative score behavior, invalid timestamp filtering, and AbortError vs real error classification.
- Biome complexity warning for `ScoreTimelineChart` fetch handling is removed on this branch.

## 物理影響

- CREATE: no AWS resources.
- UPDATE: participant-portal TypeScript source and unit tests only.
- REPLACE: none.
- DELETE: none.
- NO-OP: CDK/IAM/CloudFormation/templates are untouched.
