### PR TITLE
feat(portal): support auto-delete lifecycle status

### DIFF
--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -44,17 +44,21 @@ export type DeploymentStatus =
   | "COMPLETE"
   | "FAILED"
   | "DELETING"
-  | "DELETED";
+  | "DELETED"
+  | "EXPIRED"
+  | "AUTO_DELETED";
 
 export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
   "COMPLETE",
   "FAILED",
   "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
 ]);
 
 export const DEPLOYMENT_STATUS_INDICATOR: Record<
   DeploymentStatus,
-  "pending" | "in-progress" | "success" | "error" | "stopped"
+  "pending" | "in-progress" | "success" | "error" | "stopped" | "warning"
 > = {
   PENDING: "pending",
   IN_PROGRESS: "in-progress",
@@ -62,6 +66,8 @@ export const DEPLOYMENT_STATUS_INDICATOR: Record<
   FAILED: "error",
   DELETING: "in-progress",
   DELETED: "stopped",
+  EXPIRED: "warning",
+  AUTO_DELETED: "stopped",
 };
 
 export interface DeployRequestBody {

--- a/apps/application-admin-console/src/api/events-client.ts
+++ b/apps/application-admin-console/src/api/events-client.ts
@@ -58,7 +58,9 @@ export type EventDeploymentStatus =
   | "COMPLETE"
   | "FAILED"
   | "DELETING"
-  | "DELETED";
+  | "DELETED"
+  | "EXPIRED"
+  | "AUTO_DELETED";
 
 export interface EventDeploymentSummary {
   jobId: string;

--- a/apps/application-admin-console/src/components/event-detail/shared.tsx
+++ b/apps/application-admin-console/src/components/event-detail/shared.tsx
@@ -18,6 +18,8 @@ const DEPLOY_STATUS_COLOR: Record<EventDeploymentStatus, "blue" | "green" | "gre
   FAILED: "red",
   DELETING: "grey",
   DELETED: "grey",
+  EXPIRED: "red",
+  AUTO_DELETED: "grey",
 };
 
 export const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"> = {
@@ -45,10 +47,12 @@ export function renderProblemDeployStatus(
     );
   }
   const total = deployments.length;
-  const complete = deployments.filter((d) => d.status === "COMPLETE").length;
-  const failed = deployments.filter((d) => d.status === "FAILED").length;
+  const complete = deployments.filter(
+    (d) => d.status === "COMPLETE" || d.status === "AUTO_DELETED",
+  ).length;
+  const failed = deployments.filter((d) => d.status === "FAILED" || d.status === "EXPIRED").length;
   const inFlight = deployments.filter(
-    (d) => d.status === "PENDING" || d.status === "IN_PROGRESS",
+    (d) => d.status === "PENDING" || d.status === "IN_PROGRESS" || d.status === "DELETING",
   ).length;
   return (
     <SpaceBetween direction="horizontal" size="xs" alignItems="center">

--- a/apps/application-admin-console/src/lib/deploy-phases.ts
+++ b/apps/application-admin-console/src/lib/deploy-phases.ts
@@ -33,7 +33,13 @@ export interface DeployPhase {
   readonly note?: string;
 }
 
-const COMPLETE_STATUSES: ReadonlySet<DeploymentStatus> = new Set(["COMPLETE", "FAILED", "DELETED"]);
+const COMPLETE_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+  "COMPLETE",
+  "FAILED",
+  "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
+]);
 
 /**
  * Issue #818: stackStatus (= 現在の stack 状態) を権威 source として優先する。
@@ -102,7 +108,7 @@ export function derivePhases(
   // - status=FAILED かつ CFn 進行が観測されていない → Build で Failed (= CodeBuild 失敗)
   // - status=IN_PROGRESS かつ CFn 未観測 → In Progress
   // - status=PENDING → Pending
-  // - status=COMPLETE / DELETING / DELETED → Complete (terminal)
+  // - status=COMPLETE / DELETING / DELETED / EXPIRED / AUTO_DELETED → Complete (terminal)
   let buildingStatus: PhaseStatus;
   if (hasObservedCfn) {
     buildingStatus = "complete";
@@ -113,7 +119,7 @@ export function derivePhases(
   } else if (status === "FAILED") {
     buildingStatus = "failed";
   } else {
-    // COMPLETE / DELETING / DELETED — CFn が観測できなくても build は通っていた。
+    // terminal statuses — CFn が観測できなくても build は通っていた。
     buildingStatus = "complete";
   }
   const building: DeployPhase = {
@@ -134,7 +140,13 @@ export function derivePhases(
   } else if (events.length === 0) {
     if (status === "COMPLETE") cfnStatus = "complete";
     else if (status === "FAILED") cfnStatus = "pending";
-    else if (status === "DELETING" || status === "DELETED") cfnStatus = "skipped";
+    else if (
+      status === "DELETING" ||
+      status === "DELETED" ||
+      status === "EXPIRED" ||
+      status === "AUTO_DELETED"
+    )
+      cfnStatus = "skipped";
     else cfnStatus = "pending";
   } else {
     cfnStatus = eventsToPhaseStatus(events);
@@ -159,6 +171,8 @@ export function derivePhases(
   else if (status === "FAILED") finalStatus = "failed";
   else if (status === "DELETING") finalStatus = "in-progress";
   else if (status === "DELETED") finalStatus = "skipped";
+  else if (status === "EXPIRED") finalStatus = "failed";
+  else if (status === "AUTO_DELETED") finalStatus = "skipped";
   else if (COMPLETE_STATUSES.has(status)) finalStatus = "complete";
   else finalStatus = "pending";
   const complete: DeployPhase = {
@@ -188,6 +202,10 @@ export function deploySummaryTitle(deployment: DeploymentSummary): string {
       return `Tearing down ${label}`;
     case "DELETED":
       return `Deploy removed for ${label}`;
+    case "EXPIRED":
+      return `Deploy expired for ${label}`;
+    case "AUTO_DELETED":
+      return `Deploy auto-deleted for ${label}`;
     default:
       return `Deploy for ${label}`;
   }

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -41,9 +41,15 @@ function summarizeDeployments(detail: EventDetail): DeploymentCounts {
     (acc, list) => {
       for (const deployment of list) {
         acc.totalDeployCount += 1;
-        if (deployment.status === "COMPLETE") acc.completeCount += 1;
-        if (deployment.status === "FAILED") acc.failedCount += 1;
-        if (deployment.status === "PENDING" || deployment.status === "IN_PROGRESS") {
+        if (deployment.status === "COMPLETE" || deployment.status === "AUTO_DELETED") {
+          acc.completeCount += 1;
+        }
+        if (deployment.status === "FAILED" || deployment.status === "EXPIRED") acc.failedCount += 1;
+        if (
+          deployment.status === "PENDING" ||
+          deployment.status === "IN_PROGRESS" ||
+          deployment.status === "DELETING"
+        ) {
           acc.inFlightCount += 1;
         }
       }

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -133,10 +133,12 @@ describe("listDeployments", () => {
 });
 
 describe("TERMINAL_STATUSES", () => {
-  it("COMPLETE / FAILED / DELETED を含むべき (poll 停止条件)", () => {
+  it("terminal status を含むべき (poll 停止条件)", () => {
     expect(TERMINAL_STATUSES.has("COMPLETE")).toBe(true);
     expect(TERMINAL_STATUSES.has("FAILED")).toBe(true);
     expect(TERMINAL_STATUSES.has("DELETED")).toBe(true);
+    expect(TERMINAL_STATUSES.has("EXPIRED")).toBe(true);
+    expect(TERMINAL_STATUSES.has("AUTO_DELETED")).toBe(true);
   });
 
   it("PENDING / IN_PROGRESS / DELETING は含まないべき", () => {

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -143,6 +143,16 @@ describe("derivePhases", () => {
     expect(pick(phases, "complete").status).toBe("skipped");
   });
 
+  it("status=EXPIRED / AUTO_DELETED のとき自動削除 lifecycle として表示すべき", () => {
+    const expired = derivePhases({ ...baseDeployment, status: "EXPIRED" }, emptyProgress);
+    expect(pick(expired, "cfn-deploy").status).toBe("skipped");
+    expect(pick(expired, "complete").status).toBe("failed");
+
+    const autoDeleted = derivePhases({ ...baseDeployment, status: "AUTO_DELETED" }, emptyProgress);
+    expect(pick(autoDeleted, "cfn-deploy").status).toBe("skipped");
+    expect(pick(autoDeleted, "complete").status).toBe("skipped");
+  });
+
   // #818 regression: past CREATE_IN_PROGRESS event が history に残っていても、
   // stack 自体は CREATE_COMPLETE に到達しているなら cfn-deploy phase は complete。
   it("stackStatus=CREATE_COMPLETE のとき過去 IN_PROGRESS event があっても complete にすべき (#818)", () => {
@@ -219,6 +229,13 @@ describe("deploySummaryTitle", () => {
   });
   it("FAILED のとき failed を含むべき", () => {
     expect(deploySummaryTitle({ ...baseDeployment, status: "FAILED" })).toMatch(/failed/);
+  });
+
+  it("EXPIRED / AUTO_DELETED のとき lifecycle label を含むべき", () => {
+    expect(deploySummaryTitle({ ...baseDeployment, status: "EXPIRED" })).toMatch(/expired/);
+    expect(deploySummaryTitle({ ...baseDeployment, status: "AUTO_DELETED" })).toMatch(
+      /auto-deleted/,
+    );
   });
 });
 

--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -6,12 +6,16 @@ export type DeploymentStatus =
   | "COMPLETE"
   | "FAILED"
   | "DELETING"
-  | "DELETED";
+  | "DELETED"
+  | "EXPIRED"
+  | "AUTO_DELETED";
 
 export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
   "COMPLETE",
   "FAILED",
   "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
 ]);
 
 /**

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -82,4 +82,19 @@ describe("ProblemPanel deploy terminal", () => {
     expect(screen.getByText(/14/)).toBeInTheDocument();
     expect(screen.getByText(/teardown/)).toBeInTheDocument();
   });
+
+  it("AUTO_DELETED status を停止済みとして表示すべき", () => {
+    render(
+      withI18n(
+        <ProblemPanel
+          problem={{ ...baseProblem, status: "AUTO_DELETED" }}
+          apiBaseUrl="https://api.example.com"
+          sessionToken="team-key"
+          onScored={async () => undefined}
+        />,
+      ),
+    );
+
+    expect(screen.getByText(/Auto-deleted|自動削除済み/)).toBeInTheDocument();
+  });
 });

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -36,6 +36,8 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
   FAILED: "error",
   DELETING: "in-progress",
   DELETED: "stopped",
+  EXPIRED: "warning",
+  AUTO_DELETED: "stopped",
 };
 
 const SCORING_KIND_KEY: Record<string, string> = {
@@ -182,7 +184,9 @@ export function ProblemPanel({
           variant="h2"
           description={`${kindLabel} / ${problem.score} pt`}
           actions={
-            <StatusIndicator type={STATUS_TYPE[problem.status]}>{problem.status}</StatusIndicator>
+            <StatusIndicator type={STATUS_TYPE[problem.status]}>
+              {t(`quests.status_label.${problem.status}`)}
+            </StatusIndicator>
           }
         >
           {problem.problemId}

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -117,7 +117,9 @@
       "COMPLETE": "Running",
       "FAILED": "Failed to start",
       "DELETING": "Stopping",
-      "DELETED": "Stopped"
+      "DELETED": "Stopped",
+      "EXPIRED": "Expired",
+      "AUTO_DELETED": "Auto-deleted"
     },
     "submission_failed": "Deploy failed",
     "submission_finished": "Finished",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -117,7 +117,9 @@
       "COMPLETE": "起動中",
       "FAILED": "起動失敗",
       "DELETING": "停止中",
-      "DELETED": "停止済"
+      "DELETED": "停止済",
+      "EXPIRED": "期限切れ",
+      "AUTO_DELETED": "自動削除済み"
     },
     "submission_failed": "デプロイ失敗",
     "submission_finished": "終了",

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -35,10 +35,18 @@ function renderSubmissionState(
   readonly label: string;
 } {
   if (problem.status === "FAILED") return { type: "error", label: t("quests.submission_failed") };
-  if (problem.status === "DELETED")
-    return { type: "stopped", label: t("quests.submission_finished") };
-  if (problem.status === "PENDING" || problem.status === "IN_PROGRESS") {
-    return { type: "in-progress", label: t("quests.submission_preparing") };
+  if (problem.status === "EXPIRED") {
+    return { type: "warning", label: t("quests.status_label.EXPIRED") };
+  }
+  if (problem.status === "DELETED" || problem.status === "AUTO_DELETED") {
+    return { type: "stopped", label: t(`quests.status_label.${problem.status}`) };
+  }
+  if (
+    problem.status === "PENDING" ||
+    problem.status === "IN_PROGRESS" ||
+    problem.status === "DELETING"
+  ) {
+    return { type: "in-progress", label: t(`quests.status_label.${problem.status}`) };
   }
   if (problem.scoring?.kind === "flag") {
     if (problem.scoring.flagSubmitted)

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -14,6 +14,8 @@ export const DeploymentStatusSchema = z.enum([
   "FAILED",
   "DELETING",
   "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
 ]);
 export type DeploymentStatus = z.infer<typeof DeploymentStatusSchema>;
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -17,6 +17,8 @@ const DEPLOYMENT_STATUS_VALUES = [
   "FAILED",
   "DELETING",
   "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
 ] as const;
 type DeploymentStatus = (typeof DEPLOYMENT_STATUS_VALUES)[number];
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -268,7 +268,16 @@ export type TeamSummary = z.infer<typeof TeamSummarySchema>;
 export const EventDeploymentSummarySchema = z.object({
   jobId: z.string(),
   teamId: z.string(),
-  status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETE", "FAILED", "DELETING", "DELETED"]),
+  status: z.enum([
+    "PENDING",
+    "IN_PROGRESS",
+    "COMPLETE",
+    "FAILED",
+    "DELETING",
+    "DELETED",
+    "EXPIRED",
+    "AUTO_DELETED",
+  ]),
 });
 export type EventDeploymentSummary = z.infer<typeof EventDeploymentSummarySchema>;
 

--- a/infrastructure/lib/problem-deploy/handlers/shared/constants.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/constants.ts
@@ -14,4 +14,6 @@ export const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 export const DELETED_LIKE_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
   "DELETING",
   "DELETED",
+  "EXPIRED",
+  "AUTO_DELETED",
 ]);

--- a/infrastructure/test/problem-deploy/deployment-status.test.ts
+++ b/infrastructure/test/problem-deploy/deployment-status.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { DeploymentStatusSchema } from "../../lib/problem-deploy/handlers/deploy-handler/types";
+import { DELETED_LIKE_STATUSES } from "../../lib/problem-deploy/handlers/shared/constants";
+
+describe("DeploymentStatusSchema", () => {
+  it("auto-delete lifecycle status を許可すべき", () => {
+    expect(DeploymentStatusSchema.parse("EXPIRED")).toBe("EXPIRED");
+    expect(DeploymentStatusSchema.parse("AUTO_DELETED")).toBe("AUTO_DELETED");
+  });
+
+  it("EXPIRED / AUTO_DELETED は削除済み扱いにすべき", () => {
+    expect(DELETED_LIKE_STATUSES.has("EXPIRED")).toBe(true);
+    expect(DELETED_LIKE_STATUSES.has("AUTO_DELETED")).toBe(true);
+  });
+});

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -232,6 +232,7 @@ describe("getEventDetail", () => {
         { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J1", status: "COMPLETE" },
         { teamId: "T1", eventId: "EV1", problemId: "p1", jobId: "J2", status: "FAILED" },
         { teamId: "T1", eventId: "EV1", problemId: "p2", jobId: "J3", status: "IN_PROGRESS" },
+        { teamId: "T1", eventId: "EV1", problemId: "p2", jobId: "J4", status: "AUTO_DELETED" },
         // 別 event の deployment は除外されるべき
         { teamId: "T1", eventId: "EV-OTHER", problemId: "p1", jobId: "J-LEAK", status: "COMPLETE" },
       ],
@@ -239,7 +240,7 @@ describe("getEventDetail", () => {
 
     const out = await getEventDetail(shared, "tenant-acme", "EV1");
     expect(out?.deploymentsByProblem.p1).toHaveLength(2);
-    expect(out?.deploymentsByProblem.p2).toHaveLength(1);
+    expect(out?.deploymentsByProblem.p2).toHaveLength(2);
     expect(out?.deploymentsByProblem.p1?.[0]).toMatchObject({
       jobId: "J1",
       teamId: "T1",
@@ -248,6 +249,10 @@ describe("getEventDetail", () => {
     expect(out?.deploymentsByProblem.p2?.[0]).toMatchObject({
       jobId: "J3",
       status: "IN_PROGRESS",
+    });
+    expect(out?.deploymentsByProblem.p2?.[1]).toMatchObject({
+      jobId: "J4",
+      status: "AUTO_DELETED",
     });
     // 別 event の jobId が漏れないこと
     expect(JSON.stringify(out?.deploymentsByProblem)).not.toContain("J-LEAK");

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -144,8 +144,8 @@ describe("setDisplayTeamName", () => {
     expect(out.kind).toBe("unauthorized");
   });
 
-  it("team の全行が DELETING / DELETED なら unauthorized (UpdateItem しない)", async () => {
-    for (const status of ["DELETING", "DELETED"]) {
+  it("team の全行が削除済み扱い status なら unauthorized (UpdateItem しない)", async () => {
+    for (const status of ["DELETING", "DELETED", "EXPIRED", "AUTO_DELETED"]) {
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status })] });
       const out = await setDisplayTeamName(shared, "KEY1", "Alpha");


### PR DESCRIPTION
## Summary
- Add EXPIRED and AUTO_DELETED to deployment DTO/status parsing and deleted-like authorization handling.
- Surface the lifecycle statuses in application admin and participant portal UI, including progress summaries, phase labels, Quests cards, and localized status labels.
- Add regression tests for backend status acceptance, event detail summaries, participant update denial, deploy phases, and participant status display.

Relates #1121

## Test plan
- bun run --filter @TenkaCloud/infrastructure test -- deployment-status participant-update event-list
- bun run --filter @TenkaCloud/infrastructure typecheck
- NODE_OPTIONS=--no-experimental-webstorage bun run --filter @TenkaCloud/application-admin-console test -- EventDetail deploy-client deploy-phases
- bun run --filter @TenkaCloud/application-admin-console typecheck
- NODE_OPTIONS=--no-experimental-webstorage bun run --filter @TenkaCloud/participant-portal test -- ProblemPanel
- bun run --filter @TenkaCloud/participant-portal typecheck
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit

## Regression 分析
- Existing deployment statuses keep their previous terminal and in-flight behavior.
- EXPIRED and AUTO_DELETED are treated as terminal/deleted-like so participant update paths do not keep accepting stale deployment rows.
- Event detail and portal views no longer leave auto-delete lifecycle rows as unfinished progress.
- This PR does not implement the actual scheduler or delete executor; those remain infra/IAM owned.

## 物理影響
- No CDK, IAM, CloudFormation template, or AWS resource changes.
- TypeScript handler DTO/schema and SPA UI/test changes only.