### PR TITLE
feat(trust-bridge): add localstack cloud adapter

### DIFF
--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -18,10 +18,8 @@
     "_synth-app": "tsx bin/infrastructure.ts"
   },
   "devDependencies": {
-    "@aws-sdk/client-codebuild": "^3.1048.0",
     "@aws-sdk/client-cloudformation": "^3.1048.0",
     "@aws-sdk/client-cloudwatch": "^3.1048.0",
-    "@aws-sdk/client-cloudwatch-logs": "^3.1048.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1048.0",
     "@aws-sdk/client-dynamodb": "^3.1048.0",
     "@aws-sdk/client-eventbridge": "^3.1048.0",
@@ -47,7 +45,9 @@
   "dependencies": {
     "@TenkaCloud/trust-bridge": "workspace:*",
     "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
+    "@aws-sdk/client-codebuild": "^3.1048.0",
     "@aws-sdk/client-codepipeline": "^3.1048.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1048.0",
     "@aws-sdk/client-sfn": "^3.1048.0",
     "@cdklabs/sbt-aws": "0.3.9",
     "ajv": "8.18.0",

--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -61,6 +61,12 @@ export type {
 } from "./jws.js";
 export { signIntent, verifySignature } from "./jws.js";
 export type {
+  LocalStackCloudAdapterOptions,
+  LocalStackCredential,
+  LocalStackExchangeContext,
+} from "./localstack-cloud-adapter.js";
+export { LocalStackCloudAdapter } from "./localstack-cloud-adapter.js";
+export type {
   MockCloudAdapterOptions,
   MockCloudCredential,
   MockCloudExchangeContext,

--- a/packages/trust-bridge/src/localstack-cloud-adapter.ts
+++ b/packages/trust-bridge/src/localstack-cloud-adapter.ts
@@ -1,0 +1,126 @@
+import {
+  type ExchangeContext,
+  ExchangeError,
+  type ProviderCredential,
+  type ProviderTokenExchange,
+} from "./provider.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+const DEFAULT_LOCALSTACK_ENDPOINT = "http://localhost:4566";
+
+export interface LocalStackCredential extends ProviderCredential {
+  readonly provider: "aws";
+  readonly mode: "localstack";
+  readonly endpointUrl: string;
+  readonly accountRef: string;
+  readonly region: string;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken: string;
+  readonly requestedScopes: readonly string[];
+  readonly traceLabel?: string;
+}
+
+export interface LocalStackCloudAdapterOptions {
+  readonly endpointUrl?: string;
+  readonly region?: string;
+  readonly maxTtlSeconds?: number;
+  readonly now?: () => Date;
+  readonly credentials?: {
+    readonly accessKeyId: string;
+    readonly secretAccessKey: string;
+    readonly sessionToken?: string;
+  };
+}
+
+export interface LocalStackExchangeContext extends ExchangeContext {
+  readonly endpointUrl?: string;
+  readonly traceLabel?: string;
+}
+
+/**
+ * This adapter does not call AWS or LocalStack. It validates the intent boundary
+ * and returns endpoint-aware AWS-shaped credentials that consumers can pass to
+ * SDK clients configured with the returned `endpointUrl`.
+ */
+export class LocalStackCloudAdapter implements ProviderTokenExchange<LocalStackCredential> {
+  readonly provider = "aws" as const;
+  private readonly endpointUrl: string;
+  private readonly region?: string;
+  private readonly maxTtlSeconds: number;
+  private readonly now: () => Date;
+  private readonly credentials: LocalStackCloudAdapterOptions["credentials"];
+
+  constructor(options: LocalStackCloudAdapterOptions = {}) {
+    this.endpointUrl = normalizeLocalStackEndpoint(
+      options.endpointUrl ?? DEFAULT_LOCALSTACK_ENDPOINT,
+    );
+    this.region = options.region;
+    this.maxTtlSeconds = options.maxTtlSeconds ?? 3600;
+    this.now = options.now ?? (() => new Date());
+    this.credentials = options.credentials;
+  }
+
+  async exchange(
+    intent: VerifiedCloudActionIntent,
+    context: ExchangeContext,
+  ): Promise<LocalStackCredential> {
+    if (intent.target.provider !== "aws") {
+      throw new ExchangeError(
+        "provider-mismatch",
+        `intent target provider is ${intent.target.provider}, not aws`,
+      );
+    }
+    if (intent.constraints.ttlSeconds > this.maxTtlSeconds) {
+      throw new ExchangeError(
+        "ttl-exceeded-provider-limit",
+        `LocalStackCloudAdapter maxTtlSeconds is ${this.maxTtlSeconds}, got ${intent.constraints.ttlSeconds}`,
+      );
+    }
+
+    const localContext = context as LocalStackExchangeContext;
+    const endpointUrl = normalizeLocalStackEndpoint(localContext.endpointUrl ?? this.endpointUrl);
+    const issuedAt = this.now();
+    const expiresAt = new Date(issuedAt.getTime() + intent.constraints.ttlSeconds * 1000);
+    const tokenPart = sanitizeTokenPart(intent.requestId);
+
+    return {
+      provider: "aws",
+      mode: "localstack",
+      endpointUrl,
+      accountRef: intent.target.providerAccountRef,
+      region: intent.target.region ?? this.region ?? "ap-northeast-1",
+      accessKeyId: this.credentials?.accessKeyId ?? "test",
+      secretAccessKey: this.credentials?.secretAccessKey ?? "test",
+      sessionToken: this.credentials?.sessionToken ?? `localstack-session-${tokenPart}`,
+      requestedScopes: [...intent.action.requestedScopes],
+      ...(localContext.traceLabel ? { traceLabel: localContext.traceLabel } : {}),
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      forRequestId: intent.requestId,
+    };
+  }
+}
+
+function normalizeLocalStackEndpoint(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (err) {
+    throw new ExchangeError("context-missing", `invalid LocalStack endpoint URL: ${value}`, err);
+  }
+  const allowedProtocol = url.protocol === "http:" || url.protocol === "https:";
+  const host = url.hostname.toLowerCase();
+  const allowedHost = host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+  if (!allowedProtocol || !allowedHost) {
+    throw new ExchangeError(
+      "context-missing",
+      `LocalStack endpoint must be http(s) localhost/127.0.0.1/[::1], got ${url.origin}`,
+    );
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function sanitizeTokenPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
+}

--- a/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { LocalStackCloudAdapter } from "../src/localstack-cloud-adapter.js";
+import { ExchangeError } from "../src/provider.js";
+import {
+  brandVerified,
+  type CloudActionIntent,
+  INTENT_VERSION,
+  type VerifiedCloudActionIntent,
+} from "../src/schema.js";
+
+function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudActionIntent {
+  const intent: CloudActionIntent = {
+    version: INTENT_VERSION,
+    requestId: "req-localstack-1",
+    nonce: "nonce-localstack-1",
+    source: {
+      system: "tenkacloud",
+      tenantId: "tenant-a",
+      teamId: "team-alpha",
+      problemId: "hello-world",
+      deploymentId: "deploy-9",
+      workloadId: "deploy-worker",
+    },
+    target: { provider: "aws", providerAccountRef: "000000000000", region: "ap-northeast-1" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cloudformation:CreateStack", "cloudformation:DescribeStacks"],
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+  return brandVerified(intent);
+}
+
+describe("LocalStackCloudAdapter (#1122)", () => {
+  it("localhost endpoint 付きの AWS 形 credential を返すべき", async () => {
+    const adapter = new LocalStackCloudAdapter({
+      endpointUrl: "http://localhost:4566/",
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+
+    const credential = await adapter.exchange(makeIntent(), { traceLabel: "offline-demo" });
+
+    expect(credential.provider).toBe("aws");
+    expect(credential.mode).toBe("localstack");
+    expect(credential.endpointUrl).toBe("http://localhost:4566");
+    expect(credential.issuedAt).toBe("2026-05-15T19:00:00.000Z");
+    expect(credential.expiresAt).toBe("2026-05-15T19:10:00.000Z");
+    expect(credential.forRequestId).toBe("req-localstack-1");
+    expect(credential.accountRef).toBe("000000000000");
+    expect(credential.region).toBe("ap-northeast-1");
+    expect(credential.accessKeyId).toBe("test");
+    expect(credential.secretAccessKey).toBe("test");
+    expect(credential.sessionToken).toBe("localstack-session-req-localstack-1");
+    expect(credential.requestedScopes).toEqual([
+      "cloudformation:CreateStack",
+      "cloudformation:DescribeStacks",
+    ]);
+    expect(credential.traceLabel).toBe("offline-demo");
+  });
+
+  it("context endpointUrl で adapter default endpoint を上書きすべき", async () => {
+    const adapter = new LocalStackCloudAdapter({ endpointUrl: "http://localhost:4566" });
+
+    const credential = await adapter.exchange(makeIntent(), {
+      endpointUrl: "http://127.0.0.1:4567",
+    });
+
+    expect(credential.endpointUrl).toBe("http://127.0.0.1:4567");
+  });
+
+  it("target provider が aws 以外なら provider-mismatch を投げるべき", async () => {
+    const adapter = new LocalStackCloudAdapter();
+    await expect(
+      adapter.exchange(
+        makeIntent({ target: { provider: "gcp", providerAccountRef: "gcp-dev" } }),
+        {},
+      ),
+    ).rejects.toMatchObject({ reason: "provider-mismatch" });
+  });
+
+  it("localhost 以外の endpoint は拒否すべき", async () => {
+    const adapter = new LocalStackCloudAdapter();
+    await expect(
+      adapter.exchange(makeIntent(), { endpointUrl: "https://localstack.example.com" }),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
+  it("ttlSeconds は options.maxTtlSeconds を超えると ttl-exceeded-provider-limit を投げるべき", async () => {
+    const adapter = new LocalStackCloudAdapter({ maxTtlSeconds: 300 });
+    await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
+      reason: "ttl-exceeded-provider-limit",
+    });
+  });
+
+  it("ExchangeError として扱えるべき", async () => {
+    try {
+      new LocalStackCloudAdapter({ endpointUrl: "ftp://localhost:4566" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExchangeError);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `LocalStackCloudAdapter` to `@TenkaCloud/trust-bridge` for endpoint-aware offline AWS credentials without calling real providers.
- Export the adapter and cover endpoint validation, provider mismatch, TTL limits, and `ExchangeError` behavior with unit tests.
- Move CodeBuild and CloudWatch Logs SDK clients to infrastructure runtime dependencies so deploy-log Lambda bundling resolves after PR-1141.

Relates #1122
Relates #1120

## Test plan
- `bun run --filter @TenkaCloud/trust-bridge test -- localstack-cloud-adapter`
- `bun run --filter @TenkaCloud/trust-bridge typecheck`
- `bun biome check packages/trust-bridge/src/localstack-cloud-adapter.ts packages/trust-bridge/src/index.ts packages/trust-bridge/test/localstack-cloud-adapter.test.ts`
- `bun run --filter @TenkaCloud/infrastructure test -- participant-deploy-logs problem-endpoints-routes problem-deploy-backend-stack`
- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`

## Regression 分析
- Production provider adapters are unchanged; the LocalStack adapter is opt-in through the trust-bridge package export.
- LocalStack endpoints are restricted to http(s) localhost, 127.0.0.1, and [::1] to avoid credential forwarding to arbitrary hosts.
- The returned AWS-shaped credentials are fake local credentials; consumers still need to explicitly wire SDK clients to the returned endpointUrl.
- The dependency classification change adds no new packages or lifecycle hooks; `audit-dependencies` reported no baseline drift.

## 物理影響
- CREATE: trust-bridge LocalStack adapter and unit tests.
- UPDATE: trust-bridge exports and infrastructure package runtime dependency classification.
- NO-OP: CDK stacks, IAM policies, CloudFormation templates, and AWS resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LocalStack cloud adapter for credential exchange, enabling integration with LocalStack environments
  * Exported new credential provider types for extended platform support

* **Tests**
  * Added test suite for LocalStack adapter covering credential generation, endpoint validation, and error scenarios

* **Chores**
  * Reorganized AWS SDK package dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->