### PR TITLE
fix(portal): validate offline runtime config generation

### DIFF
--- a/infrastructure/test/scripts/participant-portal-runtime-config.test.ts
+++ b/infrastructure/test/scripts/participant-portal-runtime-config.test.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
+const SCRIPT = join(REPO_ROOT, "scripts/participant-portal-runtime-config.ts");
+const tempDirs: string[] = [];
+
+function runConfig(args: readonly string[]): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync("bun", ["run", SCRIPT, ...args], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err) {
+    const failed = err as { stdout?: Buffer; stderr?: Buffer; status?: number };
+    return {
+      stdout: failed.stdout?.toString("utf8") ?? "",
+      stderr: failed.stderr?.toString("utf8") ?? "",
+      status: failed.status ?? 1,
+    };
+  }
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("participant-portal-runtime-config (#1122)", () => {
+  it("mock mode の runtime-config を標準出力に生成すべき", () => {
+    const result = runConfig(["--cloud-mode", "mock", "--print"]);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout);
+
+    expect(json).toMatchObject({
+      apiBaseUrl: "http://localhost:3199/dev-mock",
+      eventTitle: "TenkaCloud Battle (offline)",
+      eventRegion: "ap-northeast-1",
+      mode: "dev-mock",
+      cloudMode: "mock",
+    });
+    expect(json.localstackEndpoint).toBeUndefined();
+  });
+
+  it("localstack mode は localhost endpoint を正規化して出力すべき", () => {
+    const result = runConfig([
+      "--cloud-mode",
+      "localstack",
+      "--localstack-endpoint",
+      "http://localhost:4566/",
+      "--print",
+    ]);
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout);
+
+    expect(json.mode).toBe("dev-mock");
+    expect(json.cloudMode).toBe("localstack");
+    expect(json.localstackEndpoint).toBe("http://localhost:4566");
+  });
+
+  it("localstack mode は localhost 以外の endpoint を拒否すべき", () => {
+    const result = runConfig([
+      "--cloud-mode",
+      "localstack",
+      "--localstack-endpoint",
+      "https://localstack.example.com",
+      "--print",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("LocalStack endpoint must be http(s) localhost");
+  });
+
+  it("backend mode は HTTPS の apiBaseUrl だけを受け付けるべき", () => {
+    const ok = runConfig([
+      "--cloud-mode",
+      "real",
+      "--portal-mode",
+      "backend",
+      "--api-base-url",
+      "https://api.example.com/portal/",
+      "--print",
+    ]);
+    expect(ok.status).toBe(0);
+    expect(JSON.parse(ok.stdout).apiBaseUrl).toBe("https://api.example.com/portal");
+
+    const ng = runConfig([
+      "--cloud-mode",
+      "real",
+      "--portal-mode",
+      "backend",
+      "--api-base-url",
+      "http://api.example.com/portal",
+      "--print",
+    ]);
+    expect(ng.status).not.toBe(0);
+    expect(ng.stderr).toContain("--api-base-url must be HTTPS");
+  });
+
+  it("--out 指定時は runtime-config.json を書き出すべき", () => {
+    const dir = mkdtempSync(join(tmpdir(), "tc-runtime-config-"));
+    tempDirs.push(dir);
+    const out = join(dir, "runtime-config.json");
+
+    const result = runConfig(["--cloud-mode", "mock", "--out", out]);
+    expect(result.status).toBe(0);
+
+    const json = JSON.parse(readFileSync(out, "utf8"));
+    expect(json.cloudMode).toBe("mock");
+  });
+});

--- a/scripts/participant-portal-runtime-config.ts
+++ b/scripts/participant-portal-runtime-config.ts
@@ -136,12 +136,46 @@ function defaultPortalMode(cloudMode: CloudMode): AppMode {
   return cloudMode === "real" ? "backend" : "dev-mock";
 }
 
+function normalizeLocalstackEndpoint(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (err) {
+    throw new Error(`Invalid LocalStack endpoint URL: ${value}`, { cause: err });
+  }
+  const allowedHost =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  const allowedProtocol = url.protocol === "http:" || url.protocol === "https:";
+  if (!allowedHost || !allowedProtocol) {
+    throw new Error(
+      `LocalStack endpoint must be http(s) localhost/127.0.0.1/[::1], got ${url.origin}`,
+    );
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function normalizeApiBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (err) {
+    throw new Error(`Invalid --api-base-url: ${value}`, { cause: err });
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("--api-base-url must be HTTPS when participant portal runs in backend mode");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
 function buildRuntimeConfig(options: Options): RuntimeConfig {
   const mode = options.portalMode ?? defaultPortalMode(options.cloudMode);
   if (mode === "backend" && (!options.apiBaseUrl || options.apiBaseUrl.trim().length === 0)) {
     throw new Error("--api-base-url is required when participant portal runs in backend mode");
   }
-  const apiBaseUrl = options.apiBaseUrl ?? "http://localhost:3199/dev-mock";
+  const apiBaseUrl =
+    mode === "backend"
+      ? normalizeApiBaseUrl(options.apiBaseUrl ?? "")
+      : (options.apiBaseUrl ?? "http://localhost:3199/dev-mock");
   return {
     apiBaseUrl,
     eventTitle: options.eventTitle,
@@ -149,7 +183,11 @@ function buildRuntimeConfig(options: Options): RuntimeConfig {
     mode,
     cloudMode: options.cloudMode,
     ...(options.cloudMode === "localstack"
-      ? { localstackEndpoint: options.localstackEndpoint ?? "http://localhost:4566" }
+      ? {
+          localstackEndpoint: normalizeLocalstackEndpoint(
+            options.localstackEndpoint ?? "http://localhost:4566",
+          ),
+        }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary
- Add CLI coverage for participant portal runtime-config generation in mock, LocalStack, backend, and --out modes.
- Reject non-local LocalStack endpoints when generating localstack runtime-config.
- Reject non-HTTPS backend apiBaseUrl so generated config matches participant portal runtime safety rules.

Relates #1122

## Test plan
- bun biome check scripts/participant-portal-runtime-config.ts infrastructure/test/scripts/participant-portal-runtime-config.test.ts
- bun run --filter @TenkaCloud/infrastructure test -- participant-portal-runtime-config
- bun run scripts/participant-portal-runtime-config.ts --cloud-mode localstack --localstack-endpoint http://localhost:4566/ --print
- bun run typecheck
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit

## Regression 分析
- Real backend mode now fails fast for HTTP apiBaseUrl, matching app-side loadConfig protection against teamLoginKey leakage.
- LocalStack mode remains localhost-only; arbitrary remote endpoints cannot be written into runtime-config as LocalStack.
- Mock mode output and default LocalStack localhost output stay unchanged except trailing slash normalization.
- CLI writes only the requested runtime-config file when --out is used.

## 物理影響
- UPDATE: scripts/participant-portal-runtime-config.ts.
- CREATE: infrastructure/test/scripts/participant-portal-runtime-config.test.ts.
- NO-OP: CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.