### PR TITLE
refactor(admin): simplify stack output parsing

### DIFF
--- a/apps/application-admin-console/src/api/deploy-client.ts
+++ b/apps/application-admin-console/src/api/deploy-client.ts
@@ -14,25 +14,39 @@ export const JOB_ID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
  */
 export function parseStackOutputs(json: string | undefined): Record<string, string> {
   if (!json) return {};
-  let parsed: unknown;
+  const parsed = parseJson(json);
+  if (!isObjectLike(parsed)) return {};
+  return Array.isArray(parsed)
+    ? stackOutputArrayToRecord(parsed)
+    : stackOutputMapToRecord(parsed as Record<string, unknown>);
+}
+
+function parseJson(json: string): unknown {
   try {
-    parsed = JSON.parse(json);
+    return JSON.parse(json);
   } catch {
-    return {};
+    return undefined;
   }
-  if (!parsed || typeof parsed !== "object") return {};
+}
+
+function isObjectLike(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+function stackOutputArrayToRecord(entries: readonly unknown[]): Record<string, string> {
   const out: Record<string, string> = {};
-  if (Array.isArray(parsed)) {
-    for (const entry of parsed) {
-      if (entry && typeof entry === "object") {
-        const k = (entry as { OutputKey?: unknown }).OutputKey;
-        const v = (entry as { OutputValue?: unknown }).OutputValue;
-        if (typeof k === "string" && typeof v === "string") out[k] = v;
-      }
-    }
-    return out;
+  for (const entry of entries) {
+    if (!isObjectLike(entry)) continue;
+    const k = (entry as { OutputKey?: unknown }).OutputKey;
+    const v = (entry as { OutputValue?: unknown }).OutputValue;
+    if (typeof k === "string" && typeof v === "string") out[k] = v;
   }
-  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+  return out;
+}
+
+function stackOutputMapToRecord(entries: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(entries)) {
     if (typeof v === "string") out[k] = v;
   }
   return out;

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -6,6 +6,7 @@ import {
   getDeployment,
   getStackProgress,
   listDeployments,
+  parseStackOutputs,
   startDeployment,
   statusToIndicator,
   TERMINAL_STATUSES,
@@ -115,6 +116,38 @@ describe("getDeployment", () => {
     });
     await getDeployment(client, "01H");
     expect(calls[0]).toEqual({ path: "/deployments/01H", method: "GET" });
+  });
+});
+
+describe("parseStackOutputs", () => {
+  it("map 形式の stackOutputs から string 値だけを取り出すべき", () => {
+    expect(
+      parseStackOutputs(
+        JSON.stringify({
+          FrontendUrl: "https://app.example.com",
+          Port: 443,
+          Empty: null,
+        }),
+      ),
+    ).toEqual({ FrontendUrl: "https://app.example.com" });
+  });
+
+  it("CloudFormation Output 配列形式から OutputKey/OutputValue を取り出すべき", () => {
+    expect(
+      parseStackOutputs(
+        JSON.stringify([
+          { OutputKey: "FrontendUrl", OutputValue: "https://app.example.com" },
+          { OutputKey: "IgnoredNumber", OutputValue: 123 },
+          { OutputKey: 456, OutputValue: "ignored" },
+        ]),
+      ),
+    ).toEqual({ FrontendUrl: "https://app.example.com" });
+  });
+
+  it("壊れた JSON や非 object は空 map にすべき", () => {
+    expect(parseStackOutputs(undefined)).toEqual({});
+    expect(parseStackOutputs("{bad json")).toEqual({});
+    expect(parseStackOutputs(JSON.stringify("not-object"))).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary
- Split application-admin-console stackOutputs parsing into small helpers for JSON parsing, map outputs, and CloudFormation Output array outputs.
- Add focused tests for map-form outputs, CloudFormation array-form outputs, and invalid JSON/non-object fallback behavior.
- Reduce the Biome cognitive-complexity backlog by removing the parseStackOutputs warning.

Relates #1124

## Test plan
- bun biome check apps/application-admin-console/src/api/deploy-client.ts apps/application-admin-console/test/api/deploy-client.test.ts
- bun run --filter @TenkaCloud/application-admin-console test -- deploy-client
- bun run --filter @TenkaCloud/application-admin-console typecheck
- bun biome check apps scripts --diagnostic-level=warn (23 warnings after this change; parseStackOutputs warning removed)
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit

## Regression 分析
- The parser still returns an empty object for missing input, malformed JSON, and non-object JSON.
- Map-form stackOutputs still keeps only string values, so numeric/null values remain hidden from operator UI.
- CloudFormation Output array form still keeps only string key/value pairs.
- No API path, HTTP behavior, auth behavior, deployment behavior, or rendered layout is changed.

## 物理影響
- UPDATE: apps/application-admin-console/src/api/deploy-client.ts.
- UPDATE: apps/application-admin-console/test/api/deploy-client.test.ts.
- NO-OP: backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.