### PR TITLE
refactor(admin): simplify event create team state

### DIFF
--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -77,6 +77,53 @@ interface TeamRow {
   awsAccountId: string;
 }
 
+interface TeamValidation {
+  readonly allSlugsValid: boolean;
+  readonly allAccountsValid: boolean;
+  readonly hasDuplicateSlug: boolean;
+}
+
+export function resizeTeamRows(prev: TeamRow[], next: number): TeamRow[] {
+  if (next === prev.length) return prev;
+  if (next < prev.length) return prev.slice(0, Math.max(next, 0));
+  const additions = Array.from({ length: next - prev.length }, (_, i) => ({
+    internalSlug: `team-${prev.length + i + 1}`,
+    awsAccountId: "",
+  }));
+  return [...prev, ...additions];
+}
+
+export function validateTeamRows(teamRows: readonly TeamRow[]): TeamValidation {
+  let allSlugsValid = true;
+  let allAccountsValid = true;
+  const slugs = new Set<string>();
+  let hasDuplicateSlug = false;
+  for (const t of teamRows) {
+    if (!SLUG_RE.test(t.internalSlug)) allSlugsValid = false;
+    if (!ACCOUNT_ID_RE.test(t.awsAccountId)) allAccountsValid = false;
+    if (slugs.has(t.internalSlug)) hasDuplicateSlug = true;
+    else slugs.add(t.internalSlug);
+  }
+  return { allSlugsValid, allAccountsValid, hasDuplicateSlug };
+}
+
+export function parseTeamCountInput(value: string): number | undefined {
+  const next = Number.parseInt(value.replace(/\D/g, "").slice(0, TEAM_COUNT_INPUT_MAX_LEN), 10);
+  return Number.isFinite(next) ? Math.max(0, Math.min(TEAMS_MAX, next)) : undefined;
+}
+
+function getNameErrorText(t: ReturnType<typeof useT>, name: string, nameInvalid: boolean) {
+  return nameInvalid && name.length > 0
+    ? t("event_create.name_invalid", { max: NAME_MAX })
+    : undefined;
+}
+
+function getTeamCountErrorText(t: ReturnType<typeof useT>, teamCountInvalid: boolean) {
+  return teamCountInvalid
+    ? t("event_create.team_count_invalid", { min: TEAMS_MIN, max: TEAMS_MAX })
+    : undefined;
+}
+
 /**
  * Event 作成 form。
  *
@@ -170,15 +217,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   /** チーム数の Input 変更で teamRows を伸縮。同数なら same-reference を返して
    *  無駄な再 render を防ぐ。減るとき末尾捨て、増えるとき新 row 追加。 */
   const handleTeamCountChange = (next: number) => {
-    setTeamRows((prev) => {
-      if (next === prev.length) return prev;
-      if (next < prev.length) return prev.slice(0, Math.max(next, 0));
-      const additions = Array.from({ length: next - prev.length }, (_, i) => ({
-        internalSlug: `team-${prev.length + i + 1}`,
-        awsAccountId: "",
-      }));
-      return [...prev, ...additions];
-    });
+    setTeamRows((prev) => resizeTeamRows(prev, next));
   };
 
   const updateTeamRow = (idx: number, patch: Partial<TeamRow>) => {
@@ -211,19 +250,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
 
   // teamRows ベースの validation を 1 pass に集約 (= 4 つ .every() / IIFE を回す代わり)。
   // teamRows 変更時のみ再評価され、render path の負担を減らす。
-  const teamValidation = useMemo(() => {
-    let allSlugsValid = true;
-    let allAccountsValid = true;
-    const slugs = new Set<string>();
-    let hasDuplicateSlug = false;
-    for (const t of teamRows) {
-      if (!SLUG_RE.test(t.internalSlug)) allSlugsValid = false;
-      if (!ACCOUNT_ID_RE.test(t.awsAccountId)) allAccountsValid = false;
-      if (slugs.has(t.internalSlug)) hasDuplicateSlug = true;
-      else slugs.add(t.internalSlug);
-    }
-    return { allSlugsValid, allAccountsValid, hasDuplicateSlug };
-  }, [teamRows]);
+  const teamValidation = useMemo(() => validateTeamRows(teamRows), [teamRows]);
   // Table の items に渡す配列を teamRows ベースで memo 化。Cloudscape Table は items の
   // shallow identity で再 render 判定するので、毎 render 新 array を渡すと無駄に重い
   // (= 99 行 × 2 column の Input が全部 reconcile される)。
@@ -314,11 +341,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
               <FormField
                 label={t("event_create.name_label")}
                 description={t("event_create.name_placeholder_example")}
-                errorText={
-                  nameInvalid && name.length > 0
-                    ? t("event_create.name_invalid", { max: NAME_MAX })
-                    : undefined
-                }
+                errorText={getNameErrorText(t, name, nameInvalid)}
               >
                 <Input
                   value={name}
@@ -332,23 +355,15 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                   min: TEAMS_MIN,
                   max: TEAMS_MAX,
                 })}
-                errorText={
-                  teamCountInvalid
-                    ? t("event_create.team_count_invalid", { min: TEAMS_MIN, max: TEAMS_MAX })
-                    : undefined
-                }
+                errorText={getTeamCountErrorText(t, teamCountInvalid)}
               >
                 <Input
                   type="number"
                   inputMode="numeric"
                   value={String(teamRows.length)}
                   onChange={({ detail }) => {
-                    const next = Number.parseInt(
-                      detail.value.replace(/\D/g, "").slice(0, TEAM_COUNT_INPUT_MAX_LEN),
-                      10,
-                    );
-                    if (Number.isFinite(next))
-                      handleTeamCountChange(Math.max(0, Math.min(TEAMS_MAX, next)));
+                    const next = parseTeamCountInput(detail.value);
+                    if (next !== undefined) handleTeamCountChange(next);
                   }}
                   invalid={teamCountInvalid}
                 />

--- a/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
+++ b/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { parseTeamCountInput, resizeTeamRows, validateTeamRows } from "../../src/pages/EventCreate";
+
+describe("resizeTeamRows", () => {
+  it("同じ team 数なら同じ配列参照を返すべき", () => {
+    const rows = [{ internalSlug: "team-1", awsAccountId: "111111111111" }];
+
+    expect(resizeTeamRows(rows, 1)).toBe(rows);
+  });
+
+  it("team 数を減らすと末尾の row を捨てるべき", () => {
+    expect(
+      resizeTeamRows(
+        [
+          { internalSlug: "team-1", awsAccountId: "111111111111" },
+          { internalSlug: "team-2", awsAccountId: "222222222222" },
+        ],
+        1,
+      ),
+    ).toEqual([{ internalSlug: "team-1", awsAccountId: "111111111111" }]);
+  });
+
+  it("team 数を増やすと既存 row を保持して空の新 row を追加すべき", () => {
+    expect(resizeTeamRows([{ internalSlug: "team-1", awsAccountId: "111111111111" }], 3)).toEqual([
+      { internalSlug: "team-1", awsAccountId: "111111111111" },
+      { internalSlug: "team-2", awsAccountId: "" },
+      { internalSlug: "team-3", awsAccountId: "" },
+    ]);
+  });
+
+  it("負数は 0 件として扱うべき", () => {
+    expect(resizeTeamRows([{ internalSlug: "team-1", awsAccountId: "111111111111" }], -1)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("validateTeamRows", () => {
+  it("slug/account が全て有効で重複がなければ valid を返すべき", () => {
+    expect(
+      validateTeamRows([
+        { internalSlug: "team-1", awsAccountId: "111111111111" },
+        { internalSlug: "team-2", awsAccountId: "222222222222" },
+      ]),
+    ).toEqual({
+      allSlugsValid: true,
+      allAccountsValid: true,
+      hasDuplicateSlug: false,
+    });
+  });
+
+  it("不正 slug/account と重複 slug を検出すべき", () => {
+    expect(
+      validateTeamRows([
+        { internalSlug: "Team_1", awsAccountId: "111" },
+        { internalSlug: "Team_1", awsAccountId: "222222222222" },
+      ]),
+    ).toEqual({
+      allSlugsValid: false,
+      allAccountsValid: false,
+      hasDuplicateSlug: true,
+    });
+  });
+});
+
+describe("parseTeamCountInput", () => {
+  it("数字だけを取り出して上限まで clamp すべき", () => {
+    expect(parseTeamCountInput("abc12345")).toBe(99);
+  });
+
+  it("空文字や数字なし入力は undefined にすべき", () => {
+    expect(parseTeamCountInput("")).toBeUndefined();
+    expect(parseTeamCountInput("abc")).toBeUndefined();
+  });
+
+  it("0 は 0 のまま返すべき", () => {
+    expect(parseTeamCountInput("0")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract EventCreate team row resizing, team row validation, and team-count parsing into focused helpers.
- Add unit tests for row resizing, validation, and numeric input parsing edge cases.
- Remove the EventCreatePage Biome cognitive-complexity warning without changing the form behavior.

Relates #1124

## Test plan
- bun biome check apps/application-admin-console/src/pages/EventCreate.tsx apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
- bun run --filter @TenkaCloud/application-admin-console test -- EventCreate.team-rows
- bun run --filter @TenkaCloud/application-admin-console typecheck
- bun biome check apps scripts --diagnostic-level=warn (EventCreatePage warning removed)
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit

## Regression 分析
- Team count resizing preserves same-reference behavior for unchanged counts, truncates from the tail, and appends the same default team-N rows as before.
- Slug/account validation still uses the same regexes and duplicate slug detection, now covered directly by unit tests.
- Team count input still strips non-digits, limits input length, clamps to the existing maximum, and leaves non-numeric input unchanged.
- Event creation API payloads, navigation, bulk deploy prompt behavior, auth, and backend contracts are unchanged.

## 物理影響
- UPDATE: apps/application-admin-console/src/pages/EventCreate.tsx.
- CREATE: apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts.
- NO-OP: backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.