### PR TITLE
refactor(admin): simplify notification submit state

### DIFF
--- a/apps/application-admin-console/src/components/SendNotificationModal.tsx
+++ b/apps/application-admin-console/src/components/SendNotificationModal.tsx
@@ -16,6 +16,26 @@ import { useT } from "../i18n";
 const TITLE_MAX = 120;
 const BODY_MAX = 2000;
 
+interface NotificationDraft {
+  readonly title: string;
+  readonly body: string;
+}
+
+export function isNotificationDraftValid(draft: NotificationDraft): boolean {
+  return (
+    draft.title.length > 0 &&
+    draft.title.length <= TITLE_MAX &&
+    draft.body.length > 0 &&
+    draft.body.length <= BODY_MAX
+  );
+}
+
+export function formatNotificationSubmitError(err: unknown): string {
+  if (err instanceof ApiError) return `${err.status}: ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 /**
  * Operator → competitor notification modal (ADR-006 D6).
  */
@@ -63,9 +83,7 @@ export function SendNotificationModal({
   };
 
   const handleSubmit = async () => {
-    if (!apiClient) return;
-    if (title.length === 0 || title.length > TITLE_MAX) return;
-    if (body.length === 0 || body.length > BODY_MAX) return;
+    if (!apiClient || !isNotificationDraftValid({ title, body })) return;
     setInFlight(true);
     setError(null);
     try {
@@ -73,13 +91,7 @@ export function SendNotificationModal({
       reset();
       onSuccess();
     } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? `${err.status}: ${err.message}`
-          : err instanceof Error
-            ? err.message
-            : String(err);
-      setError(message);
+      setError(formatNotificationSubmitError(err));
     } finally {
       setInFlight(false);
     }
@@ -87,13 +99,7 @@ export function SendNotificationModal({
 
   const titleInvalid = title.length > TITLE_MAX;
   const bodyInvalid = body.length > BODY_MAX;
-  const submitDisabled =
-    !apiClient ||
-    inFlight ||
-    title.length === 0 ||
-    body.length === 0 ||
-    titleInvalid ||
-    bodyInvalid;
+  const submitDisabled = !apiClient || inFlight || !isNotificationDraftValid({ title, body });
 
   return (
     <Modal

--- a/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
+++ b/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
@@ -37,8 +37,10 @@ const config: AppConfig = {
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
 
-const { SendNotificationModal } = await import("../../src/components/SendNotificationModal");
+const { formatNotificationSubmitError, isNotificationDraftValid, SendNotificationModal } =
+  await import("../../src/components/SendNotificationModal");
 const { I18nProvider } = await import("../../src/i18n");
+const { ApiError } = await import("../../src/api/client");
 
 function withI18n(node: React.ReactNode) {
   return <I18nProvider>{node}</I18nProvider>;
@@ -159,5 +161,28 @@ describe("SendNotificationModal", () => {
     fireEvent.change(screen.getByLabelText("本文"), { target: { value: "b" } });
     expect(screen.getByText(/120 文字以内/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+  });
+});
+
+describe("SendNotificationModal helpers", () => {
+  it("title / body が制限内で非空なら submit 可能にすべき", () => {
+    expect(isNotificationDraftValid({ title: "T", body: "B" })).toBe(true);
+  });
+
+  it("title / body が空または上限超過なら submit 不可にすべき", () => {
+    expect(isNotificationDraftValid({ title: "", body: "B" })).toBe(false);
+    expect(isNotificationDraftValid({ title: "T", body: "" })).toBe(false);
+    expect(isNotificationDraftValid({ title: "a".repeat(121), body: "B" })).toBe(false);
+    expect(isNotificationDraftValid({ title: "T", body: "b".repeat(2001) })).toBe(false);
+  });
+
+  it("ApiError は status 付き message に整形すべき", () => {
+    expect(formatNotificationSubmitError(new ApiError(403, "forbidden"))).toBe(
+      "403: API 403: forbidden",
+    );
+  });
+
+  it("Error 以外も string 化すべき", () => {
+    expect(formatNotificationSubmitError("failed")).toBe("failed");
   });
 });


### PR DESCRIPTION
## Summary
- Extract SendNotificationModal draft validation into a focused helper shared by submit and disabled-state checks.
- Extract notification submit error formatting into a focused helper.
- Add unit coverage for valid/invalid notification drafts and error message formatting.
- Remove the SendNotificationModal handleSubmit Biome cognitive-complexity warning without changing modal behavior.

Relates #1124

## Test plan
- bun biome check apps/application-admin-console/src/components/SendNotificationModal.tsx apps/application-admin-console/test/components/SendNotificationModal.test.tsx
- bun run --filter @TenkaCloud/application-admin-console test -- SendNotificationModal
- bun run --filter @TenkaCloud/application-admin-console typecheck
- bun biome check apps scripts --diagnostic-level=warn (SendNotificationModal warning removed)
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit

## Regression 分析
- Submit remains blocked when the API client is unavailable, while a request is in flight, or title/body is empty or over the existing limits.
- Successful sends still call createNotification with the same eventId, title, body, and severity payload, then reset and call onSuccess.
- ApiError, Error, and non-Error failure messages preserve the previous displayed strings.
- No API route, auth, i18n key, backend contract, or rendered modal layout is changed.

## 物理影響
- UPDATE: apps/application-admin-console/src/components/SendNotificationModal.tsx.
- UPDATE: apps/application-admin-console/test/components/SendNotificationModal.test.tsx.
- NO-OP: backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.