### PR TITLE
refactor(portal): simplify team setup submit state

### DIFF
--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -25,6 +25,34 @@ const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
   en: "English",
 };
 
+interface TeamNameDraft {
+  readonly trimmed: string;
+  readonly invalid: boolean;
+}
+
+interface TeamNameSubmitState extends TeamNameDraft {
+  readonly sessionToken?: string;
+  readonly submitting: boolean;
+}
+
+export function describeTeamNameDraft(teamName: string): TeamNameDraft {
+  const trimmed = teamName.trim();
+  return {
+    trimmed,
+    invalid: teamName.length > 0 && !TEAM_NAME_RE.test(trimmed),
+  };
+}
+
+export function canSubmitTeamName(state: TeamNameSubmitState): boolean {
+  return !!state.sessionToken && state.trimmed.length > 0 && !state.invalid && !state.submitting;
+}
+
+export function formatTeamSetupSubmitError(err: unknown, validationMessage: string): string {
+  if (err instanceof PortalValidationError) return validationMessage;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 /**
  * 競技者がログイン直後に通る team name 入力ページ。 `PATCH /portal/me` でサーバ側
  * `displayTeamName` を設定し、 AuthProvider のセッションを更新して `/` に戻る。
@@ -45,16 +73,23 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const trimmed = teamName.trim();
-  const invalid = teamName.length > 0 && !TEAM_NAME_RE.test(trimmed);
-  const canSubmit = !!auth.session?.sessionToken && trimmed.length > 0 && !invalid && !submitting;
+  const draft = describeTeamNameDraft(teamName);
+  const canSubmit = canSubmitTeamName({
+    ...draft,
+    sessionToken: auth.session?.sessionToken,
+    submitting,
+  });
 
   const handleSubmit = async () => {
     if (!canSubmit || !auth.session) return;
     setSubmitting(true);
     setError(null);
     try {
-      const view = await updateTeamName(config.apiBaseUrl, auth.session.sessionToken, trimmed);
+      const view = await updateTeamName(
+        config.apiBaseUrl,
+        auth.session.sessionToken,
+        draft.trimmed,
+      );
       auth.updateSession({
         teamName: view.team.teamName,
         teamNameSetByCompetitor: view.team.teamNameSetByCompetitor,
@@ -66,11 +101,7 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
         navigate("/login");
         return;
       }
-      if (err instanceof PortalValidationError) {
-        setError(t("team_setup.validation_failed"));
-      } else {
-        setError(err instanceof Error ? err.message : String(err));
-      }
+      setError(formatTeamSetupSubmitError(err, t("team_setup.validation_failed")));
     } finally {
       setSubmitting(false);
     }
@@ -120,14 +151,14 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
                 label={t("team_setup.field_label")}
                 description={t("team_setup.field_description")}
                 constraintText={t("team_setup.field_constraint")}
-                errorText={invalid ? t("team_setup.field_invalid_format") : undefined}
+                errorText={draft.invalid ? t("team_setup.field_invalid_format") : undefined}
               >
                 <Input
                   value={teamName}
                   placeholder={t("team_setup.field_placeholder")}
                   disabled={submitting}
                   onChange={({ detail }) => setTeamName(detail.value)}
-                  invalid={invalid}
+                  invalid={draft.invalid}
                 />
               </FormField>
               <Button

--- a/apps/participant-portal/test/pages/TeamSetup.test.ts
+++ b/apps/participant-portal/test/pages/TeamSetup.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { PortalValidationError } from "../../src/api/portal-client";
+import {
+  canSubmitTeamName,
+  describeTeamNameDraft,
+  formatTeamSetupSubmitError,
+} from "../../src/pages/TeamSetup";
+
+describe("TeamSetup helpers", () => {
+  it("team name を trim し、有効な入力を判定すべき", () => {
+    expect(describeTeamNameDraft("  Team Alpha  ")).toEqual({
+      trimmed: "Team Alpha",
+      invalid: false,
+    });
+  });
+
+  it("不正文字を含む team name を invalid にすべき", () => {
+    expect(describeTeamNameDraft("Team!")).toEqual({
+      trimmed: "Team!",
+      invalid: true,
+    });
+  });
+
+  it("sessionToken があり非空かつ valid で送信中でなければ submit 可能にすべき", () => {
+    expect(
+      canSubmitTeamName({
+        sessionToken: "session-token",
+        trimmed: "Team Alpha",
+        invalid: false,
+        submitting: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("sessionToken 不在 / 空 / invalid / submitting は submit 不可にすべき", () => {
+    expect(
+      canSubmitTeamName({
+        sessionToken: undefined,
+        trimmed: "Team Alpha",
+        invalid: false,
+        submitting: false,
+      }),
+    ).toBe(false);
+    expect(
+      canSubmitTeamName({
+        sessionToken: "session-token",
+        trimmed: "",
+        invalid: false,
+        submitting: false,
+      }),
+    ).toBe(false);
+    expect(
+      canSubmitTeamName({
+        sessionToken: "session-token",
+        trimmed: "Team!",
+        invalid: true,
+        submitting: false,
+      }),
+    ).toBe(false);
+    expect(
+      canSubmitTeamName({
+        sessionToken: "session-token",
+        trimmed: "Team Alpha",
+        invalid: false,
+        submitting: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("validation error は i18n 済み message に整形すべき", () => {
+    expect(
+      formatTeamSetupSubmitError(new PortalValidationError("invalid"), "validation failed"),
+    ).toBe("validation failed");
+  });
+
+  it("Error 以外も string 化すべき", () => {
+    expect(formatTeamSetupSubmitError("boom", "validation failed")).toBe("boom");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract TeamSetup team-name draft validation and submit eligibility into focused helpers.
- Extract non-auth submit error formatting into a focused helper.
- Add unit coverage for valid/invalid team names, submit eligibility, and error formatting.
- Remove the TeamSetup handleSubmit Biome cognitive-complexity warning without changing page behavior.

Relates #1124

## Test plan
- bun biome check apps/participant-portal/src/pages/TeamSetup.tsx apps/participant-portal/test/pages/TeamSetup.test.ts
- bun run --filter @TenkaCloud/participant-portal test -- TeamSetup
- bun run --filter @TenkaCloud/participant-portal typecheck
- bun biome check apps scripts --diagnostic-level=warn (TeamSetup warning removed; remaining warnings are existing unrelated complexity items)
- bun install --frozen-lockfile --ignore-scripts
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit
- Manual /review: scoped helper extraction keeps the same branch conditions and updateTeamName payload.
- Manual /security-review: no auth/session/token handling changes beyond reusing the existing sessionToken guard.
- Manual /simplify: helper extraction removes inline conditional complexity without adding cross-module abstractions.

## Regression 分析
- Team name trimming and regex validation use the same 1-40 char rule as before.
- Submit remains blocked without a session token, with empty trimmed input, invalid input, or while submitting.
- PortalAuthError still logs out and redirects to /login; PortalValidationError still shows the i18n validation message; other errors still show Error.message/String(err).
- updateTeamName still sends the trimmed team name and updates session/navigates on success.

## 物理影響
- UPDATE: apps/participant-portal/src/pages/TeamSetup.tsx.
- CREATE: apps/participant-portal/test/pages/TeamSetup.test.ts.
- NO-OP: backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.
