### PR TITLE
fix(infrastructure): bypass Lambda env 4KB limit via esbuild define

### DIFF
--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -6,7 +6,6 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { encodeLargeEnvValue } from "../utils/env-encoding";
 import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
@@ -89,12 +88,6 @@ export class GenericScoringLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
-        // Issue #810: AWS Lambda env vars 4 KB 上限を回避するため gzip+base64 で
-        // 圧縮する。 旧形式 (= plain JSON) も decodeLargeEnvValue が backward compat
-        // で読めるので、 既存 test fixture / local dev は破壊しない。
-        BATTLE_PROBLEMS_SCORING: encodeLargeEnvValue(JSON.stringify(props.problemsScoring)),
-        PROBLEM_ENDPOINTS: encodeLargeEnvValue(JSON.stringify(props.problemsEndpoints)),
-        BATTLE_PROBLEMS_PHASES: encodeLargeEnvValue(JSON.stringify(props.problemsPhases)),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -102,6 +95,20 @@ export class GenericScoringLambda extends Construct {
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
         sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
+        // problem catalog (scoring / endpoints / phases) を bundle 時に literal 置換する。
+        // 旧 #810 の gzip+base64 env var は問題が増えるたび 4 KB 上限に張り付き、
+        // stackstack 追加で deploy 不可になった。 esbuild define で
+        // process.env.X を build 時に固定 JSON 文字列にし env を 0 化する。
+        // tests は process.env 経由で fixture を注入するので影響なし。
+        define: {
+          "process.env.BATTLE_PROBLEMS_SCORING": JSON.stringify(
+            JSON.stringify(props.problemsScoring),
+          ),
+          "process.env.PROBLEM_ENDPOINTS": JSON.stringify(JSON.stringify(props.problemsEndpoints)),
+          "process.env.BATTLE_PROBLEMS_PHASES": JSON.stringify(
+            JSON.stringify(props.problemsPhases),
+          ),
+        },
       },
     });
 

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -16,7 +16,6 @@ import {
 } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
-import { encodeLargeEnvValue } from "../utils/env-encoding";
 import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
@@ -175,9 +174,6 @@ export class ParticipantPortalLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
-        // Issue #810: gzip+base64 で 4 KB env-var 上限を回避。 GenericScoring と同じ。
-        BATTLE_PROBLEMS_SCORING: encodeLargeEnvValue(JSON.stringify(props.problemsScoring)),
-        PROBLEM_ENDPOINTS: encodeLargeEnvValue(JSON.stringify(props.problemsEndpoints)),
         DEPLOY_ENVIRONMENT: props.environmentName,
         NODE_OPTIONS: "--enable-source-maps",
       },
@@ -186,6 +182,15 @@ export class ParticipantPortalLambda extends Construct {
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
         sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
+        // Issue #1158: 旧 #810 の gzip+base64 env 圧縮では問題追加で 4 KB を再度超える。
+        // esbuild define で build 時に literal 置換し env を 0 化する。 handler は
+        // process.env を読む既存コードのまま (= build 後に literal JSON が埋まる)。
+        define: {
+          "process.env.BATTLE_PROBLEMS_SCORING": JSON.stringify(
+            JSON.stringify(props.problemsScoring),
+          ),
+          "process.env.PROBLEM_ENDPOINTS": JSON.stringify(JSON.stringify(props.problemsEndpoints)),
+        },
       },
     });
 

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -290,26 +290,28 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("GenericScoring Lambda が PROBLEM_ENDPOINTS_TABLE_NAME / BATTLE_PROBLEMS_PHASES env を持つべき", () => {
-      // ADR-012 Phase 3.B: 旧 HealthCheck Lambda は scoring 設定のみ持っていたが、
-      // GenericScoring は Endpoint registry (Phase 3.A) と Phase 定義 (Phase 3.B) を併せて受ける。
-      tpl.hasResourceProperties(
-        "AWS::Lambda::Function",
-        Match.objectLike({
-          Runtime: "nodejs22.x",
-          Architectures: ["arm64"],
-          Environment: Match.objectLike({
-            Variables: Match.objectLike({
-              DEPLOYMENTS_TABLE_NAME: Match.anyValue(),
-              EVENTS_TABLE_NAME: Match.anyValue(),
-              PROBLEM_ENDPOINTS_TABLE_NAME: Match.anyValue(),
-              BATTLE_PROBLEMS_SCORING: Match.anyValue(),
-              PROBLEM_ENDPOINTS: Match.anyValue(),
-              BATTLE_PROBLEMS_PHASES: Match.anyValue(),
-            }),
-          }),
-        }),
+    it("GenericScoring Lambda が table name env を持ち catalog env は持たないべき", () => {
+      // Issue #1158: BATTLE_PROBLEMS_SCORING / PROBLEM_ENDPOINTS / BATTLE_PROBLEMS_PHASES は
+      // env vars 4 KB 上限を回避するため esbuild bundling.define で build 時 literal 置換し、
+      // Lambda env からは取り除いている。 catalog 配線は handler の `process.env.X` 読み取りが
+      // build 時に literal JSON に固定され、 runtime IO 0 で動く。
+      const functions = tpl.findResources("AWS::Lambda::Function");
+      const genericScoring = Object.entries(functions).find(
+        ([name]) => name.includes("GenericScoring") && name.includes("Function"),
       );
+      expect(genericScoring).toBeDefined();
+      const vars =
+        (
+          genericScoring?.[1] as {
+            Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+          }
+        )?.Properties?.Environment?.Variables ?? {};
+      expect(vars.DEPLOYMENTS_TABLE_NAME).toBeDefined();
+      expect(vars.EVENTS_TABLE_NAME).toBeDefined();
+      expect(vars.PROBLEM_ENDPOINTS_TABLE_NAME).toBeDefined();
+      expect(vars.BATTLE_PROBLEMS_SCORING).toBeUndefined();
+      expect(vars.PROBLEM_ENDPOINTS).toBeUndefined();
+      expect(vars.BATTLE_PROBLEMS_PHASES).toBeUndefined();
     });
   });
 
@@ -614,18 +616,32 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 
-  it("ADR-012 Phase 3.A: environment に PROBLEM_ENDPOINTS_TABLE_NAME + PROBLEM_ENDPOINTS を持つべき", () => {
+  it("ADR-012 Phase 3.A: environment に PROBLEM_ENDPOINTS_TABLE_NAME を持ち catalog env は持たないべき", () => {
+    // Issue #1158: PROBLEM_ENDPOINTS / BATTLE_PROBLEMS_SCORING は env 4 KB 上限回避のため
+    // esbuild bundling.define で build 時 literal 置換し、 Lambda env からは取り除いている。
     tpl.hasResourceProperties(
       "AWS::Lambda::Function",
       Match.objectLike({
         Environment: Match.objectLike({
           Variables: Match.objectLike({
             PROBLEM_ENDPOINTS_TABLE_NAME: Match.anyValue(),
-            PROBLEM_ENDPOINTS: Match.anyValue(),
           }),
         }),
       }),
     );
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const participantPortal = Object.entries(functions).find(
+      ([name]) => name.includes("ParticipantPortal") && name.includes("Function"),
+    );
+    expect(participantPortal).toBeDefined();
+    const vars =
+      (
+        participantPortal?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    expect(vars.PROBLEM_ENDPOINTS).toBeUndefined();
+    expect(vars.BATTLE_PROBLEMS_SCORING).toBeUndefined();
   });
 
   it("AWS Console SSO 用に DEPLOY_ENVIRONMENT を持つべき", () => {


### PR DESCRIPTION
## Summary

- `generic-scoring-lambda` と `participant-portal-lambda` が `BATTLE_PROBLEMS_SCORING` / `PROBLEM_ENDPOINTS` / `BATTLE_PROBLEMS_PHASES` を gzip+base64 env (#810) で持っていた合計が 4 KB 上限を再度超え、 `make deploy` が CREATE_FAILED していた (#1158)。
- `bundling.define` で esbuild が build 時に `process.env.X` を literal JSON 文字列に置換する → Lambda env から 3 つの大 vars を撤去。 handler は `process.env` を読む既存実装のまま (= build 後に literal が埋まる)。
- env-var assertion 2 件を「これらは env に存在しないこと」に inverted (= bundling.define で literal 化された旨をコメントで明示)。

Closes #1158
Relates #810

## Test plan

- `cd infrastructure && bun run typecheck`
- `bun run --filter @TenkaCloud/infrastructure test` (= 1283 tests pass)
- `make harness` (= no findings)
- `CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make synth ENV=development` (= 9 stacks synth OK)
- `make before-commit` (= lint / format / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth すべて OK)
- bundle 内 literal 注入確認: `grep -o 'stackstack' .../asset.*/index.js` → 3 件 (= scoring + endpoints + phases 各 1)。
- synth CFn 内 GenericScoring Lambda env: `DEPLOYMENTS_TABLE_NAME` / `EVENTS_TABLE_NAME` / `PROBLEM_ENDPOINTS_TABLE_NAME` / `NODE_OPTIONS` の 4 つのみ (= 旧 7 → 4)。

## Regression 分析

- **handler の input shape は不変**: `parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING)` 等の呼び出しは build 時に `parseScoringEnv("{\"hello-world\":{...}}")` に展開される。 同関数は `decodeLargeEnvValue` で plain JSON も backward-compat 処理するため挙動 unchanged。
- **test fixture**: vitest は esbuild bundle を経由せず TS を直接実行するので、 `process.env.X = JSON.stringify(...)` で fixture 注入する既存テストは影響なし (= 1283 件すべて pass)。
- **Lambda bundle サイズ**: catalog JSON が raw で埋まるため +6-7 KB。 Lambda の 250 MB 上限に対し無視できる増分。
- **`encodeLargeEnvValue` import**: 2 stack から削除。 `env-encoding.ts` の関数本体は test fixture で plain JSON 経路を維持するため残置 (= follow-up で dead code 削除候補)。
- **採点 / portal の runtime 動作**: env vars 削減のみで logic 不変。 既存の score event / endpoint resolution / phase switch の挙動は完全に保たれる (= 1283 件 pass)。
- **#1141 で追加した CodeBuild + CloudWatch Logs deps**: 影響なし (= 別 lambda の bundling、 そもそも本 PR が触る generic-scoring / participant-portal とは別資源)。

## 物理影響

- **CREATE**: なし。
- **UPDATE**:
  - `infrastructure/lib/problem-deploy/generic-scoring-lambda.ts` (env 3 行削除 + bundling.define 追加 + import 整理)
  - `infrastructure/lib/problem-deploy/participant-portal-lambda.ts` (同上、 ただし phases 不要なので 2 vars)
  - `infrastructure/test/problem-deploy-backend-stack.test.ts` (env 存在 assertion → env 不在 assertion 2 件)
- **REPLACE**:
  - `AWS::Lambda::Function` (GenericScoring / ParticipantPortal) の `Environment.Variables` が縮小 → CFn update で in-place env 変更。 関数自体の REPLACE は不要。
- **DELETE**: なし。
- **NO-OP**: 採点 / portal の runtime 挙動、 IAM ロール、 DDB / SQS / EventBridge 構成、 他 stack はすべて不変。
- **CFn diff サイズ**: 2 Lambda Function resource の `Environment.Variables` のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)