### PR TITLE
refactor(portal): split portal fetch handling

### DIFF
--- a/apps/participant-portal/src/api/portal-client.ts
+++ b/apps/participant-portal/src/api/portal-client.ts
@@ -215,6 +215,59 @@ interface PortalFetchOptions {
   readonly returnUndefinedOn404?: boolean;
 }
 
+interface PortalErrorBody {
+  readonly error?: string;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+}
+
+function applyPortalQuery(url: URL, query?: Readonly<Record<string, string>>): void {
+  if (!query) return;
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+}
+
+function buildPortalFetchInit(teamLoginKey: string, options: PortalFetchOptions): RequestInit {
+  const headers: Record<string, string> = { authorization: `Bearer ${teamLoginKey}` };
+  const hasBody = options.body !== undefined;
+  if (hasBody) headers["content-type"] = "application/json";
+  return {
+    method: options.method ?? "GET",
+    headers,
+    body: hasBody ? JSON.stringify(options.body) : undefined,
+    signal: options.signal,
+  };
+}
+
+async function readPortalErrorBody(res: Response): Promise<PortalErrorBody> {
+  return (await res.json().catch(() => ({}))) as PortalErrorBody;
+}
+
+function isScoringGateError(
+  error: string | undefined,
+): error is "scoring_not_started" | "scoring_ended" | "scoring_locked" {
+  return error === "scoring_not_started" || error === "scoring_ended" || error === "scoring_locked";
+}
+
+async function throwPortalErrorResponse(res: Response, options: PortalFetchOptions): Promise<void> {
+  if (res.status === StatusCodes.UNAUTHORIZED) throw new PortalAuthError();
+  if (res.status === StatusCodes.BAD_REQUEST && options.throwOn400) {
+    const body = await readPortalErrorBody(res);
+    throw new PortalValidationError(body.error ?? "invalid_request");
+  }
+  if (res.status === StatusCodes.CONFLICT && options.throwOn409) {
+    const body = await readPortalErrorBody(res);
+    // Issue #1006: scoring gate 系の 409 は startsAt / endsAt を持つ専用 error にする。
+    if (isScoringGateError(body.error)) {
+      throw new PortalScoringGateError(body.error, body.startsAt, body.endsAt);
+    }
+    throw new PortalValidationError(body.error ?? "conflict");
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PortalNetworkError(res.status, body);
+  }
+}
+
 /**
  * Portal API 共通 fetch。401→PortalAuthError / !ok→PortalNetworkError は全 endpoint
  * 共通なので 1 箇所に集約。400 (validation) と 404 (no-content) は opt-in。
@@ -226,45 +279,10 @@ async function portalFetch<T>(
   options: PortalFetchOptions = {},
 ): Promise<T | undefined> {
   const url = buildPortalUrl(apiBaseUrl, path);
-  if (options.query) {
-    for (const [k, v] of Object.entries(options.query)) url.searchParams.set(k, v);
-  }
-  const headers: Record<string, string> = { authorization: `Bearer ${teamLoginKey}` };
-  const hasBody = options.body !== undefined;
-  if (hasBody) headers["content-type"] = "application/json";
-
-  const res = await fetch(url, {
-    method: options.method ?? "GET",
-    headers,
-    body: hasBody ? JSON.stringify(options.body) : undefined,
-    signal: options.signal,
-  });
-  if (res.status === StatusCodes.UNAUTHORIZED) throw new PortalAuthError();
+  applyPortalQuery(url, options.query);
+  const res = await fetch(url, buildPortalFetchInit(teamLoginKey, options));
   if (res.status === StatusCodes.NOT_FOUND && options.returnUndefinedOn404) return undefined;
-  if (res.status === StatusCodes.BAD_REQUEST && options.throwOn400) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new PortalValidationError(body.error ?? "invalid_request");
-  }
-  if (res.status === StatusCodes.CONFLICT && options.throwOn409) {
-    const body = (await res.json().catch(() => ({}))) as {
-      error?: string;
-      startsAt?: string;
-      endsAt?: string;
-    };
-    // Issue #1006: scoring gate 系の 409 は startsAt / endsAt を持つ専用 error にする。
-    if (
-      body.error === "scoring_not_started" ||
-      body.error === "scoring_ended" ||
-      body.error === "scoring_locked"
-    ) {
-      throw new PortalScoringGateError(body.error, body.startsAt, body.endsAt);
-    }
-    throw new PortalValidationError(body.error ?? "conflict");
-  }
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new PortalNetworkError(res.status, body);
-  }
+  await throwPortalErrorResponse(res, options);
   return (await res.json()) as T;
 }
 

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -7,8 +7,10 @@ import {
   listProblemEndpoints,
   PortalAuthError,
   PortalNetworkError,
+  PortalScoringGateError,
   PortalValidationError,
   putProblemEndpointOverride,
+  submitFlag,
   TERMINAL_STATUSES,
 } from "../../src/api/portal-client";
 
@@ -314,6 +316,38 @@ describe("putProblemEndpointOverride", () => {
     await expect(
       putProblemEndpointOverride("https://x", KEY, "p1", "fixed-slot", "https://x.com"),
     ).rejects.toBeInstanceOf(PortalValidationError);
+  });
+});
+
+describe("submitFlag", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("409 scoring_not_started は PortalScoringGateError として startsAt を保持すべき", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: "scoring_not_started",
+              startsAt: "2026-05-21T10:00:00.000Z",
+            }),
+            {
+              status: 409,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expect(submitFlag("https://x", KEY, "hello-world", "FLAG{demo}")).rejects.toMatchObject({
+      kind: "scoring_not_started",
+      startsAt: "2026-05-21T10:00:00.000Z",
+    });
+    await expect(submitFlag("https://x", KEY, "hello-world", "FLAG{demo}")).rejects.toBeInstanceOf(
+      PortalScoringGateError,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Split portalFetch URL/query/init construction and response error handling into focused helpers.
- Keep 401 / opt-in 400 / opt-in 404 / opt-in 409 / generic !ok behavior unchanged.
- Add regression coverage for submitFlag 409 scoring_not_started preserving PortalScoringGateError startsAt metadata.
- Remove the portalFetch Biome cognitive-complexity warning without changing API client behavior.

Relates #1124

## Test plan
- bun biome check apps/participant-portal/src/api/portal-client.ts apps/participant-portal/test/api/portal-client.test.ts --diagnostic-level=warn --max-diagnostics=30
- bun run --filter @TenkaCloud/participant-portal test -- portal-client
- bun run --filter @TenkaCloud/participant-portal typecheck
- bun biome check apps scripts --diagnostic-level=warn --max-diagnostics=80 (portalFetch warning removed; remaining warnings are unrelated existing items / open PR overlap)
- bun install --frozen-lockfile --ignore-scripts
- make harness
- NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit
- Manual /review: helper extraction preserves fetch method/header/body/signal construction and error mapping order.
- Manual /security-review: Authorization header behavior is unchanged; no token persistence or logging added.
- Manual /simplify: portalFetch now orchestrates helpers instead of owning every branch inline.

## Regression 分析
- Bearer header, JSON body content-type, method default, AbortSignal propagation, and query serialization are unchanged.
- 401 still throws PortalAuthError; opt-in 404 still returns undefined before generic error handling.
- opt-in 400 still throws PortalValidationError with response error or invalid_request fallback.
- opt-in 409 still maps scoring_not_started / scoring_ended / scoring_locked to PortalScoringGateError and other conflicts to PortalValidationError.
- generic non-ok responses still throw PortalNetworkError with status and response text.

## 物理影響
- UPDATE: apps/participant-portal/src/api/portal-client.ts.
- UPDATE: apps/participant-portal/test/api/portal-client.test.ts.
- NO-OP: React UI components, backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.
