### PR TITLE
chore(infrastructure): add .js extension to relative imports (#1153 PR-A)

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
-import { resolveAppConfig } from "../lib/app-config";
-import { buildTenkaCloudApp } from "../lib/app-wiring";
+import { resolveAppConfig } from "../lib/app-config/index.js";
+import { buildTenkaCloudApp } from "../lib/app-wiring/index.js";
 
 /**
  * TenkaCloud CDK app の composition root。

--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
-import { resolveAppConfig } from "../lib/app-config";
-import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms";
-import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity";
-import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window";
-import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
-import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite";
+import { resolveAppConfig } from "../lib/app-config/index.js";
+import { CodeBuildUseAwsManagedKms } from "../lib/cdk-aspect/codebuild-use-aws-managed-kms.js";
+import { DynamoDbLowCapacity } from "../lib/cdk-aspect/dynamodb-low-capacity.js";
+import { KmsKeyShortPendingWindow } from "../lib/cdk-aspect/kms-key-short-pending-window.js";
+import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack.js";
+import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite/index.js";
 
 /**
  * Issue #778 ADR-016 Phase 5: TenkaCloud Lite mode の CDK app entry point。

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -11,7 +11,7 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
-import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers";
+import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers.js";
 
 /**
  * Issue #1031: admin-console-hosting は **CloudFront 配信側だけ** を担い、 runtime-config.json

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -6,7 +6,7 @@ import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations
 import type { IUserPool } from "aws-cdk-lib/aws-cognito";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import type { Construct } from "constructs";
-import { AdminInsightApiLambda } from "./admin-insight-api-lambda";
+import { AdminInsightApiLambda } from "./admin-insight-api-lambda.js";
 
 export interface AdminConsoleInsightStackProps extends cdk.StackProps {
   /**

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -10,7 +10,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface AdminInsightApiLambdaProps {
   /**

--- a/infrastructure/lib/app-config/index.ts
+++ b/infrastructure/lib/app-config/index.ts
@@ -1,2 +1,2 @@
-export { resolveApiKeyValue, resolveAppConfig } from "./resolve";
-export type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types";
+export { resolveApiKeyValue, resolveAppConfig } from "./resolve.js";
+export type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types.js";

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -2,9 +2,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { BillingMode } from "aws-cdk-lib/aws-dynamodb";
 import * as dotenv from "dotenv";
-import { getEnv } from "../helper-functions";
-import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting";
-import { loadConfig } from "../utils/config-loader";
+import { getEnv } from "../helper-functions.js";
+import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
+import { loadConfig } from "../utils/config-loader.js";
 import {
   discoverProblemsCatalog,
   discoverProblemsDisruptions,
@@ -12,8 +12,8 @@ import {
   discoverProblemsPhases,
   discoverProblemsScoring,
   discoverProblemsVisibility,
-} from "../utils/discover-problems-catalog";
-import type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types";
+} from "../utils/discover-problems-catalog.js";
+import type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "./types.js";
 
 /**
  * Issue #766: bin/infrastructure.ts に散在していた env / config 解決を 1 つの pure function

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -1,6 +1,6 @@
 import type { BillingMode } from "aws-cdk-lib/aws-dynamodb";
-import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
-import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting";
+import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
+import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
 
 export type { ApiKeySSMParameterNames };
 

--- a/infrastructure/lib/app-plane-core/app-plane-core.ts
+++ b/infrastructure/lib/app-plane-core/app-plane-core.ts
@@ -1,9 +1,9 @@
 import type { Stack } from "aws-cdk-lib";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
-import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
-import { ApiGateway } from "../tenant-template/api-gateway";
-import { ApplicationAdminConsoleHosting } from "../tenant-template/application-admin-console-hosting";
-import { IdentityProvider } from "../tenant-template/identity-provider";
+import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
+import { ApiGateway } from "../tenant-template/api-gateway.js";
+import { ApplicationAdminConsoleHosting } from "../tenant-template/application-admin-console-hosting.js";
+import { IdentityProvider } from "../tenant-template/identity-provider.js";
 
 /**
  * Issue #778 ADR-016 Phase 1: TenantTemplateStack から共通 App Plane コア構成を抽出する。

--- a/infrastructure/lib/app-plane-core/index.ts
+++ b/infrastructure/lib/app-plane-core/index.ts
@@ -2,5 +2,5 @@ export type {
   AppPlaneCoreApiKeyConfig,
   AppPlaneCoreHandles,
   AppPlaneCoreProps,
-} from "./app-plane-core";
-export { buildAppPlaneCore } from "./app-plane-core";
+} from "./app-plane-core.js";
+export { buildAppPlaneCore } from "./app-plane-core.js";

--- a/infrastructure/lib/app-wiring/index.ts
+++ b/infrastructure/lib/app-wiring/index.ts
@@ -1,2 +1,2 @@
-export type { TenkaCloudAppHandles } from "./wire";
-export { buildTenkaCloudApp } from "./wire";
+export type { TenkaCloudAppHandles } from "./wire.js";
+export { buildTenkaCloudApp } from "./wire.js";

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -1,21 +1,21 @@
 import * as cdk from "aws-cdk-lib";
-import { AdminConsoleHostingStack } from "../admin-console-hosting";
-import { AdminConsoleRuntimeConfigStack } from "../admin-console-runtime-config-stack";
-import { AdminConsoleInsightStack } from "../admin-insight/admin-console-insight-stack";
-import type { AppConfig } from "../app-config/types";
-import { BootstrapTemplateStack } from "../bootstrap-template/bootstrap-template-stack";
-import { CodeBuildUseAwsManagedKms } from "../cdk-aspect/codebuild-use-aws-managed-kms";
-import { DestroyPolicySetter } from "../cdk-aspect/destroy-policy-setter";
-import { DynamoDbLowCapacity } from "../cdk-aspect/dynamodb-low-capacity";
-import { KmsKeyShortPendingWindow } from "../cdk-aspect/kms-key-short-pending-window";
-import { ControlPlaneStack } from "../control-plane-stack";
-import { ObservabilityStack } from "../observability/cloudwatch-dashboard-stack";
-import { CostBudget } from "../observability/cost-budget";
-import { FreeTierAlarms } from "../observability/free-tier-alarms";
-import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting";
-import { ProblemDeployBackendStack } from "../problem-deploy/problem-deploy-backend-stack";
-import { ServerlessSaaSPipeline } from "../tenant-pipeline/serverless-saas-pipeline";
-import { TenantTemplateStack } from "../tenant-template/tenant-template-stack";
+import { AdminConsoleHostingStack } from "../admin-console-hosting.js";
+import { AdminConsoleRuntimeConfigStack } from "../admin-console-runtime-config-stack.js";
+import { AdminConsoleInsightStack } from "../admin-insight/admin-console-insight-stack.js";
+import type { AppConfig } from "../app-config/types.js";
+import { BootstrapTemplateStack } from "../bootstrap-template/bootstrap-template-stack.js";
+import { CodeBuildUseAwsManagedKms } from "../cdk-aspect/codebuild-use-aws-managed-kms.js";
+import { DestroyPolicySetter } from "../cdk-aspect/destroy-policy-setter.js";
+import { DynamoDbLowCapacity } from "../cdk-aspect/dynamodb-low-capacity.js";
+import { KmsKeyShortPendingWindow } from "../cdk-aspect/kms-key-short-pending-window.js";
+import { ControlPlaneStack } from "../control-plane-stack.js";
+import { ObservabilityStack } from "../observability/cloudwatch-dashboard-stack.js";
+import { CostBudget } from "../observability/cost-budget.js";
+import { FreeTierAlarms } from "../observability/free-tier-alarms.js";
+import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
+import { ProblemDeployBackendStack } from "../problem-deploy/problem-deploy-backend-stack.js";
+import { ServerlessSaaSPipeline } from "../tenant-pipeline/serverless-saas-pipeline.js";
+import { TenantTemplateStack } from "../tenant-template/tenant-template-stack.js";
 
 /**
  * Issue #766: TenkaCloud の全 stack 配線を 1 つの pure function に集約する。

--- a/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
+++ b/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
@@ -11,9 +11,9 @@ import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import { PolicyDocument } from "aws-cdk-lib/aws-iam";
 import type { Construct } from "constructs";
-import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
-import { TenantStatusReconciler } from "../tenant-status-reconciler/tenant-status-reconciler";
-import { TenantApiKey } from "./tenant-api-key";
+import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
+import { TenantStatusReconciler } from "../tenant-status-reconciler/tenant-status-reconciler.js";
+import { TenantApiKey } from "./tenant-api-key.js";
 
 interface BootstrapTemplateStackProps extends StackProps {
   apiKeySSMParameterNames: ApiKeySSMParameterNames;

--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -10,12 +10,12 @@ import type {
 import { EventBus, Rule } from "aws-cdk-lib/aws-events";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import type { Construct } from "constructs";
-import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "./control-plane/invite-message";
+import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "./control-plane/invite-message.js";
 import {
   SYSTEM_ADMIN_ENABLED_MFAS,
   SYSTEM_ADMIN_MFA_CONFIGURATION,
   SYSTEM_ADMIN_PASSWORD_POLICY,
-} from "./control-plane/mfa-policy";
+} from "./control-plane/mfa-policy.js";
 
 interface ControlPlaneStackProps extends cdk.StackProps {
   systemAdminEmail: string;

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -9,7 +9,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface CompetitorAccountsApiLambdaProps {

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -11,7 +11,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DeployApiLambdaProps {

--- a/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-create-state-machine.ts
@@ -22,7 +22,7 @@ import {
   LambdaInvoke,
 } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { Construct } from "constructs";
-import { deploymentKey, stateEnteredTime } from "./state-machine-helpers";
+import { deploymentKey, stateEnteredTime } from "./state-machine-helpers.js";
 
 export interface DeployCreateStateMachineProps {
   /** 実体の deploy を担う CodeBuild Project (= `scripts/deploy-battles.sh` を実行)。 */

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -19,7 +19,7 @@ import {
   DynamoUpdateItem,
 } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { Construct } from "constructs";
-import { deploymentKey, stateEnteredTime } from "./state-machine-helpers";
+import { deploymentKey, stateEnteredTime } from "./state-machine-helpers.js";
 
 export interface DeployDeleteStateMachineProps {
   /**

--- a/infrastructure/lib/problem-deploy/deploy-event-rule.ts
+++ b/infrastructure/lib/problem-deploy/deploy-event-rule.ts
@@ -7,7 +7,7 @@ import {
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
   EVENT_SOURCE,
-} from "./handlers/shared/events";
+} from "./handlers/shared/events.js";
 
 export interface DeployEventRuleProps {
   /** SBT ControlPlane が払い出す共通 EventBus。 */

--- a/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
+++ b/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
@@ -8,7 +8,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface DescribeStackLambdaProps {

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -10,7 +10,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface EventApiLambdaProps {
   readonly eventsTable: Table;

--- a/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
+++ b/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
@@ -11,7 +11,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface ExternalIdAuditLambdaProps {
   /** `CompetitorAccounts` DDB table (rotatedAt / createdAt を読み取る)。 */

--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -10,7 +10,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface GenericScoringLambdaProps {
   readonly deploymentsTable: ITable;

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
@@ -2,7 +2,7 @@
  * Issue #888: Red Team Disruption Injection の API / store の共通 type 定義。
  */
 
-import type { ProblemDisruptionEntry } from "../../../utils/discover-problems-catalog";
+import type { ProblemDisruptionEntry } from "../../../utils/discover-problems-catalog.js";
 
 /** Fire API の request scope。 */
 export type DisruptionFireScope = "team" | "all" | "random-n";

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -11,7 +11,7 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
-import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers";
+import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers.js";
 
 export type ParticipantPortalMode = "dev-mock" | "backend";
 

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -20,7 +20,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 
 export interface ParticipantPortalLambdaProps {

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -5,36 +5,36 @@ import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
-import { AdminAuditLogTable } from "./admin-audit-log-table";
-import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine";
-import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda";
-import { CompetitorAccountsTable } from "./competitor-accounts-table";
-import { CompetitorBootstrapHosting } from "./competitor-bootstrap-hosting";
-import { DeployApiLambda } from "./deploy-api-lambda";
-import { DeployCodeBuildProject } from "./deploy-codebuild-project";
-import { DeployCreateStateMachine } from "./deploy-create-state-machine";
-import { DeployDeleteStateMachine } from "./deploy-delete-state-machine";
+import { AdminAuditLogTable } from "./admin-audit-log-table.js";
+import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine.js";
+import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda.js";
+import { CompetitorAccountsTable } from "./competitor-accounts-table.js";
+import { CompetitorBootstrapHosting } from "./competitor-bootstrap-hosting.js";
+import { DeployApiLambda } from "./deploy-api-lambda.js";
+import { DeployCodeBuildProject } from "./deploy-codebuild-project.js";
+import { DeployCreateStateMachine } from "./deploy-create-state-machine.js";
+import { DeployDeleteStateMachine } from "./deploy-delete-state-machine.js";
 import {
   BulkDeployCreateEventRule,
   DeployDeleteEventRule,
   DeployEventRule,
-} from "./deploy-event-rule";
-import { DeploymentsTable } from "./deployments-table";
-import { DescribeStackLambda } from "./describe-stack-lambda";
-import { DisruptionsTable } from "./disruptions-table";
-import { EventApiLambda } from "./event-api-lambda";
-import { EventsTable } from "./events-table";
-import { ExternalIdAuditLambda } from "./external-id-audit-lambda";
-import { GenericScoringLambda } from "./generic-scoring-lambda";
+} from "./deploy-event-rule.js";
+import { DeploymentsTable } from "./deployments-table.js";
+import { DescribeStackLambda } from "./describe-stack-lambda.js";
+import { DisruptionsTable } from "./disruptions-table.js";
+import { EventApiLambda } from "./event-api-lambda.js";
+import { EventsTable } from "./events-table.js";
+import { ExternalIdAuditLambda } from "./external-id-audit-lambda.js";
+import { GenericScoringLambda } from "./generic-scoring-lambda.js";
 import {
   DEFAULT_DEV_MOCK_RUNTIME_CONFIG,
   ParticipantPortalHosting,
   type ParticipantPortalRuntimeConfig,
-} from "./participant-portal-hosting";
-import { ParticipantPortalLambda } from "./participant-portal-lambda";
-import { ProblemEndpointsTable } from "./problem-endpoints-table";
-import { SystemAuditWriterLambda } from "./system-audit-writer-lambda";
-import { TeamsTable } from "./teams-table";
+} from "./participant-portal-hosting.js";
+import { ParticipantPortalLambda } from "./participant-portal-lambda.js";
+import { ProblemEndpointsTable } from "./problem-endpoints-table.js";
+import { SystemAuditWriterLambda } from "./system-audit-writer-lambda.js";
+import { TeamsTable } from "./teams-table.js";
 
 export interface ProblemDeployBackendStackProps extends cdk.StackProps {
   /**

--- a/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
+++ b/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
@@ -10,7 +10,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface SystemAuditWriterLambdaProps {
   /** SBT ControlPlane が払い出す共通 EventBus。 */

--- a/infrastructure/lib/source-bundle/lifecycle-policy.ts
+++ b/infrastructure/lib/source-bundle/lifecycle-policy.ts
@@ -1,4 +1,4 @@
-import type { SourceBundleConfig } from "../config/config-interface";
+import type { SourceBundleConfig } from "../config/config-interface.js";
 
 /**
  * Issue #1056: deploy artifact (= `source.zip`) bucket の lifecycle policy。

--- a/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
+++ b/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
@@ -10,7 +10,7 @@ import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
-} from "../utils/lambda-runtime";
+} from "../utils/lambda-runtime.js";
 
 export interface TenantStatusReconcilerProps {
   /**

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -7,8 +7,8 @@ import {
 import type { IUserPool } from "aws-cdk-lib/aws-cognito";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import type { CustomApiKey } from "../interfaces/custom-api-key";
-import type { IdentityDetails } from "../interfaces/identity-details";
+import type { CustomApiKey } from "../interfaces/custom-api-key.js";
+import type { IdentityDetails } from "../interfaces/identity-details.js";
 
 interface ApiGatewayProps {
   tenantId: string;

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -11,7 +11,7 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
-import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers";
+import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers.js";
 
 interface ApplicationAdminConsoleHostingProps {
   /** TenantTemplateStack を識別するためのテナント ID。pooled の場合は "pooled" */

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -1,6 +1,6 @@
 import { aws_cognito, Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import type { IdentityDetails } from "../interfaces/identity-details";
+import type { IdentityDetails } from "../interfaces/identity-details.js";
 
 // Cognito InviteMessageTemplate の placeholder。{username} は admin-create-user 時に
 // 指定したユーザー名、{####} は Cognito 自動生成の一時パスワードに置換される。

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -8,8 +8,8 @@ import {
   PhysicalResourceId,
 } from "aws-cdk-lib/custom-resources";
 import type { Construct } from "constructs";
-import { buildAppPlaneCore } from "../app-plane-core";
-import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names";
+import { buildAppPlaneCore } from "../app-plane-core/index.js";
+import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
 
 interface TenantTemplateStackProps extends StackProps {
   stageName: string;

--- a/infrastructure/lib/tenkacloud-lite/index.ts
+++ b/infrastructure/lib/tenkacloud-lite/index.ts
@@ -1,2 +1,2 @@
-export type { TenkaCloudLiteStackProps } from "./tenkacloud-lite-stack";
-export { TenkaCloudLiteStack } from "./tenkacloud-lite-stack";
+export type { TenkaCloudLiteStackProps } from "./tenkacloud-lite-stack.js";
+export { TenkaCloudLiteStack } from "./tenkacloud-lite-stack.js";

--- a/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
+++ b/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
@@ -1,7 +1,7 @@
 import { CfnOutput, Stack, type StackProps } from "aws-cdk-lib";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import type { Construct } from "constructs";
-import { buildAppPlaneCore } from "../app-plane-core";
+import { buildAppPlaneCore } from "../app-plane-core/index.js";
 
 /**
  * Issue #778 ADR-016 Phase 3: TenkaCloud Lite mode の専用 stack。

--- a/infrastructure/lib/utils/config-loader.ts
+++ b/infrastructure/lib/utils/config-loader.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import type { Logger } from "winston";
-import type { Config } from "../config/config-interface";
+import type { Config } from "../config/config-interface.js";
 
 export interface ExpandOptions {
   /**

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { type ProblemEndpointSlot, parseEndpointSlot } from "./endpoints-metadata";
-import { type ProblemScoringMetadata, parseScoringMetadata } from "./scoring-metadata";
+import { type ProblemEndpointSlot, parseEndpointSlot } from "./endpoints-metadata.js";
+import { type ProblemScoringMetadata, parseScoringMetadata } from "./scoring-metadata.js";
 
 export type { ProblemEndpointSlot, ProblemScoringMetadata };
 


### PR DESCRIPTION
## Summary

- ESM 統一 (#1153) の前段として、 `infrastructure/lib` + `bin` の 38 ファイルにある拡張子無し relative import 99 箇所に `.js` 拡張子を機械的に付与する。
- CommonJS NodeNext モードでも `.js` 付き path は auto-resolve できるため、 本 PR 単独では behavior change なし (= 既に `handlers/` が同じ pattern で動作中、 既存 CI が無修正で pass)。
- 本 PR が landed したら **#1153 PR-B** (= `"type": "module"` + `__dirname` → `import.meta.dirname` + `require` → `import` + Ajv ESM interop fix) が小さい atomic diff になる。

Relates #1153

## Test plan

- `bun run --filter @TenkaCloud/infrastructure typecheck` (= 0 errors)
- `bun run --filter @TenkaCloud/infrastructure test` (= 1283 tests pass)
- `make harness` (= no findings)
- `CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make synth ENV=development` (= 9 stacks synth OK)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth すべて OK)

## Regression 分析

- **runtime 動作**: CommonJS NodeNext モードでは `import x from "./foo.js"` と `import x from "./foo"` は同じ resolver path (= `./foo.ts` → `./foo.js` 出力) を辿る。 esbuild bundling (= NodejsFunction) も両 path を受ける。 `handlers/` 配下が PR 以前から `.js` を使っていた実績。
- **生成 CFn / Lambda bundle**: synth 出力は完全に identical (= ファイル内容のみ source 表記変更、 tsc / esbuild の output は不変)。
- **test fixtures**: `test/` ディレクトリは tsconfig の `exclude` 対象で TypeScript の check 範囲外。 vitest は relative path resolution が permissive で `.js` 有無どちらでも動く。 本 PR は test/ に touch しない。
- **import path 表記の見方**: `import x from "./foo.js"` は **TypeScript 側で `./foo.ts` を意図**している (= NodeNext / Node16 module resolution の規約)。 build 後の `.js` extension に合わせて TS source でも `.js` と書く。 これは TypeScript の official guidance (https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext)。
- **directory barrel imports**: `./app-plane-core` (= directory) は `./app-plane-core/index.js` に展開、 `./app-plane-core.ts` (= sibling file) は `./app-plane-core.js` に展開。 `lib/app-plane-core/index.ts` の sibling import (= `./app-plane-core.js`) は誤って `./app-plane-core/index.js` に書き換わらないよう手動修正。

## 物理影響

- **CREATE**: なし。
- **UPDATE**: `infrastructure/lib/**/*.ts` + `infrastructure/bin/*.ts` の 38 ファイル。 各ファイルの relative import に `.js` 付与のみ (= total 99 lines changed, 99 insertions / 99 deletions = 純粋な置換)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース・CFn・IAM・DDB schema は完全に不変。
- **CI / CD 影響**: なし。 CI は既存通り `make install_ci` → typecheck → test → build で pass。
- **dependency 影響**: なし。 package.json / bun.lock / audit-baseline.json は無修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)