### PR TITLE
refactor(portal): split team view refresh decisions

### DIFF
--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -154,6 +154,51 @@ function leaderboardIsUnchanged(
   return true;
 }
 
+export type PortalMeRefreshDecision =
+  | { readonly kind: "view"; readonly view: ParticipantTeamView; readonly stopPolling: boolean }
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "auth-error" };
+
+export type LeaderboardRefreshDecision =
+  | { readonly kind: "leaderboard"; readonly leaderboard: LeaderboardResponse }
+  | { readonly kind: "no-event" }
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "auth-error" };
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function shouldStopProblemPolling(view: ParticipantTeamView): boolean {
+  return view.problems.every((p) => p.status === "FAILED" || p.status === "DELETED");
+}
+
+export function toPortalMeRefreshDecision(
+  result: PromiseSettledResult<ParticipantTeamView>,
+): PortalMeRefreshDecision {
+  if (result.status === "fulfilled") {
+    return {
+      kind: "view",
+      view: result.value,
+      stopPolling: shouldStopProblemPolling(result.value),
+    };
+  }
+  if (result.reason instanceof PortalAuthError) return { kind: "auth-error" };
+  return { kind: "error", message: errorMessage(result.reason) };
+}
+
+export function toLeaderboardRefreshDecision(
+  result: PromiseSettledResult<LeaderboardResponse | undefined>,
+): LeaderboardRefreshDecision {
+  if (result.status === "fulfilled") {
+    return result.value === undefined
+      ? { kind: "no-event" }
+      : { kind: "leaderboard", leaderboard: result.value };
+  }
+  if (result.reason instanceof PortalAuthError) return { kind: "auth-error" };
+  return { kind: "error", message: errorMessage(result.reason) };
+}
+
 /**
  * Authenticated 領域 (`ShellLayout`) の中で 1 度だけ動く polling を提供する Context。
  *
@@ -185,6 +230,43 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
   const [lastSeenAt, setLastSeenAt] = useState<string | null>(() => loadLastSeenAt(eventIdForKey));
   const stopPollingRef = useRef(false);
 
+  const applyPortalMeDecision = useCallback(
+    (decision: PortalMeRefreshDecision): boolean => {
+      if (decision.kind === "auth-error") {
+        auth.logout();
+        return false;
+      }
+      if (decision.kind === "error") {
+        setError(decision.message);
+        return true;
+      }
+      setView((prev) => (viewIsUnchanged(prev, decision.view) ? prev : decision.view));
+      setError(null);
+      if (decision.stopPolling) stopPollingRef.current = true;
+      return true;
+    },
+    [auth],
+  );
+
+  const applyLeaderboardDecision = useCallback((decision: LeaderboardRefreshDecision): void => {
+    if (decision.kind === "auth-error") return;
+    if (decision.kind === "error") {
+      setLeaderboardError(decision.message);
+      return;
+    }
+    if (decision.kind === "no-event") {
+      // 404 = Phase 1 以前の旧 deployment (eventId 無し) → leaderboard 不能
+      setLeaderboardNoEvent(true);
+      setLeaderboard(null);
+    } else {
+      setLeaderboardNoEvent(false);
+      setLeaderboard((prev) =>
+        leaderboardIsUnchanged(prev, decision.leaderboard) ? prev : decision.leaderboard,
+      );
+    }
+    setLeaderboardError(null);
+  }, []);
+
   /** 5 秒 tick: `/portal/me` + `/portal/leaderboard`。Notifications は別系統。 */
   const refresh = useCallback(async () => {
     if (!isBackend || !sessionToken) return;
@@ -193,41 +275,9 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
       getLeaderboard(config.apiBaseUrl, sessionToken),
     ]);
 
-    if (meResult.status === "fulfilled") {
-      const next = meResult.value;
-      setView((prev) => (viewIsUnchanged(prev, next) ? prev : next));
-      setError(null);
-      if (next.problems.every((p) => p.status === "FAILED" || p.status === "DELETED")) {
-        stopPollingRef.current = true;
-      }
-    } else {
-      const err = meResult.reason;
-      if (err instanceof PortalAuthError) {
-        auth.logout();
-        return;
-      }
-      setError(err instanceof Error ? err.message : String(err));
-    }
-
-    if (leaderboardResult.status === "fulfilled") {
-      const next = leaderboardResult.value;
-      if (next === undefined) {
-        // 404 = Phase 1 以前の旧 deployment (eventId 無し) → leaderboard 不能
-        setLeaderboardNoEvent(true);
-        setLeaderboard(null);
-      } else {
-        setLeaderboardNoEvent(false);
-        setLeaderboard((prev) => (leaderboardIsUnchanged(prev, next) ? prev : next));
-      }
-      setLeaderboardError(null);
-    } else {
-      const err = leaderboardResult.reason;
-      // Auth エラーは meResult 側で処理済 (= 同じ token を使っているので)
-      if (!(err instanceof PortalAuthError)) {
-        setLeaderboardError(err instanceof Error ? err.message : String(err));
-      }
-    }
-  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
+    if (!applyPortalMeDecision(toPortalMeRefreshDecision(meResult))) return;
+    applyLeaderboardDecision(toLeaderboardRefreshDecision(leaderboardResult));
+  }, [isBackend, sessionToken, config.apiBaseUrl, applyPortalMeDecision, applyLeaderboardDecision]);
 
   /** 60 秒 tick: `/portal/me/notifications` 専用。Events table の RCU を守る。 */
   const refreshNotifications = useCallback(async () => {

--- a/apps/participant-portal/test/auth/TeamViewProvider.test.ts
+++ b/apps/participant-portal/test/auth/TeamViewProvider.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { type ParticipantTeamView, PortalAuthError } from "../../src/api/portal-client";
+import {
+  toLeaderboardRefreshDecision,
+  toPortalMeRefreshDecision,
+} from "../../src/auth/TeamViewProvider";
+
+function teamView(statuses: readonly ParticipantTeamView["problems"][number]["status"][]) {
+  return {
+    team: {
+      teamName: "Blue",
+      teamNameSetByCompetitor: true,
+    },
+    problems: statuses.map((status, index) => ({
+      jobId: `job-${index}`,
+      problemId: `problem-${index}`,
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+      status,
+      stackOutputs: {},
+      expiresAt: 0,
+      score: 0,
+      deployLog: { cursor: "0", entries: [] },
+    })),
+  } satisfies ParticipantTeamView;
+}
+
+describe("TeamViewProvider refresh decisions", () => {
+  it("portal/me 成功時は view と polling 停止判定を返すべき", () => {
+    const active = teamView(["COMPLETE", "FAILED"]);
+    expect(toPortalMeRefreshDecision({ status: "fulfilled", value: active })).toEqual({
+      kind: "view",
+      view: active,
+      stopPolling: false,
+    });
+
+    const terminal = teamView(["FAILED", "DELETED"]);
+    expect(toPortalMeRefreshDecision({ status: "fulfilled", value: terminal })).toEqual({
+      kind: "view",
+      view: terminal,
+      stopPolling: true,
+    });
+  });
+
+  it("portal/me の認証エラーは logout 判定にすべき", () => {
+    expect(
+      toPortalMeRefreshDecision({ status: "rejected", reason: new PortalAuthError() }),
+    ).toEqual({
+      kind: "auth-error",
+    });
+  });
+
+  it("portal/me の通常エラーは message に変換すべき", () => {
+    expect(toPortalMeRefreshDecision({ status: "rejected", reason: new Error("boom") })).toEqual({
+      kind: "error",
+      message: "boom",
+    });
+    expect(toPortalMeRefreshDecision({ status: "rejected", reason: "plain" })).toEqual({
+      kind: "error",
+      message: "plain",
+    });
+  });
+
+  it("leaderboard 成功時は no-event と通常更新を区別すべき", () => {
+    expect(toLeaderboardRefreshDecision({ status: "fulfilled", value: undefined })).toEqual({
+      kind: "no-event",
+    });
+
+    const leaderboard = { eventId: "event-1", entries: [] };
+    expect(toLeaderboardRefreshDecision({ status: "fulfilled", value: leaderboard })).toEqual({
+      kind: "leaderboard",
+      leaderboard,
+    });
+  });
+
+  it("leaderboard の認証エラーは無視し通常エラーだけ message に変換すべき", () => {
+    expect(
+      toLeaderboardRefreshDecision({ status: "rejected", reason: new PortalAuthError() }),
+    ).toEqual({
+      kind: "auth-error",
+    });
+    expect(
+      toLeaderboardRefreshDecision({ status: "rejected", reason: new Error("leaderboard down") }),
+    ).toEqual({
+      kind: "error",
+      message: "leaderboard down",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `/portal/me` and leaderboard all-settled result handling into explicit refresh decision helpers.
- Keep React state updates and logout side effects inside `TeamViewProvider`, while thinning the polling callback.
- Add helper coverage for view updates, terminal polling stop, no-event leaderboard, auth errors, and ordinary errors.
- Remove the `TeamViewProvider.refresh` Biome cognitive-complexity warning without changing polling behavior.

Relates #1124

## Test plan
- `bun biome check apps/participant-portal/src/auth/TeamViewProvider.tsx apps/participant-portal/test/auth/TeamViewProvider.test.ts --diagnostic-level=warn --max-diagnostics=40`
- `bun run --filter @TenkaCloud/participant-portal test -- TeamViewProvider`
- `bun run --filter @TenkaCloud/participant-portal typecheck`
- `bun install --frozen-lockfile --ignore-scripts`
- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`
- Manual /review: branch was rebased onto latest `origin/main`; the callback still runs `/portal/me` and `/portal/leaderboard` together and preserves the existing early logout path.
- Manual /security-review: token handling and logout conditions are unchanged; helper exports only classify existing in-memory results.
- Manual /simplify: refresh result branching is centralized and covered directly, leaving the polling callback as orchestration.

## Regression 分析
- `/portal/me` success still updates `view`, clears `error`, and stops problem polling only when all problems are `FAILED` or `DELETED`.
- `/portal/me` `PortalAuthError` still calls `logout()` and returns before leaderboard handling.
- `/portal/me` non-auth errors still populate `error` with the thrown message/string.
- Leaderboard 404/undefined still sets `leaderboardNoEvent` and clears the leaderboard.
- Leaderboard success still preserves the no-op render optimization through `leaderboardIsUnchanged`.
- Leaderboard auth errors remain ignored because `/portal/me` owns the shared-token logout path.
- Notifications polling and mark-seen behavior are untouched.

## 物理影響
- UPDATE: `apps/participant-portal/src/auth/TeamViewProvider.tsx`.
- CREATE: `apps/participant-portal/test/auth/TeamViewProvider.test.ts`.
- NO-OP: backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.
