### PR TITLE
refactor(portal): split app layout utilities

### DIFF
--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ import TopNavigation, {
 } from "@cloudscape-design/components/top-navigation";
 import { type ReactNode, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router";
+import type { LeaderboardResponse, ParticipantTeamView } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import { TeamViewProvider, useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
@@ -24,6 +25,88 @@ const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
   ja: "日本語",
   en: "English",
 };
+
+type Translate = (key: string) => string;
+
+export function isSupportedLocaleId(id: string): id is LocaleCode {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(id);
+}
+
+export function formatTopNavScore(
+  mode: AppConfig["mode"],
+  view: ParticipantTeamView | null,
+): string {
+  if (mode !== "backend") return "—";
+  if (!view) return "…";
+  const totalScore = view.problems.reduce((sum, p) => sum + p.score, 0);
+  return `${totalScore} pt`;
+}
+
+export function formatTopNavRank(
+  mode: AppConfig["mode"],
+  leaderboard: LeaderboardResponse | null,
+  leaderboardNoEvent: boolean,
+): string {
+  if (mode !== "backend" || leaderboardNoEvent) return "—";
+  const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
+  const totalEntries = leaderboard?.entries.length;
+  return myEntry && totalEntries ? `${myEntry.rank}/${totalEntries}` : "…";
+}
+
+function buildLocaleUtility(
+  locale: LocaleCode,
+  setLocale: (locale: LocaleCode) => void,
+  t: Translate,
+): TopNavigationProps.Utility {
+  return {
+    type: "menu-dropdown",
+    iconName: "globe",
+    ariaLabel: t("switcher.aria_label"),
+    text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
+    items: SUPPORTED_LOCALES.map((code) => ({
+      id: code,
+      text: LOCALE_DICTIONARIES_NAME[code] ?? code,
+    })),
+    onItemClick: ({ detail }) => {
+      if (isSupportedLocaleId(detail.id)) setLocale(detail.id);
+    },
+  };
+}
+
+function buildScoreRankUtility(
+  score: string,
+  rank: string,
+  navigate: (href: string) => void,
+): TopNavigationProps.Utility {
+  return {
+    type: "button",
+    text: `Score: ${score}  /  Rank: ${rank}`,
+    iconName: "status-positive",
+    onClick: () => {
+      navigate("/scoreboard");
+    },
+  };
+}
+
+function buildProfileUtility(
+  teamName: string,
+  logout: () => void,
+  navigate: (href: string) => void,
+  t: Translate,
+): TopNavigationProps.Utility {
+  return {
+    type: "menu-dropdown",
+    text: teamName,
+    iconName: "user-profile",
+    items: [{ id: "logout", text: t("nav.sign_out") }],
+    onItemClick: ({ detail }) => {
+      if (detail.id === "logout") {
+        logout();
+        navigate("/login");
+      }
+    },
+  };
+}
 
 function OfflineCloudModeAlert({ config }: { config: AppConfig }) {
   const { t } = useI18n();
@@ -109,66 +192,21 @@ function ShellInner({ config, children }: { config: AppConfig; children: ReactNo
   const utilities = useMemo<TopNavigationProps.Utility[]>(() => {
     // Issue #583 Phase 1.A: locale switcher utility は session 有無に依存しない (= ログイン
     // 前 / login page でも切替可能)。
-    const localeUtility: TopNavigationProps.Utility = {
-      type: "menu-dropdown",
-      iconName: "globe",
-      ariaLabel: t("switcher.aria_label"),
-      text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
-      items: SUPPORTED_LOCALES.map((code) => ({
-        id: code,
-        text: LOCALE_DICTIONARIES_NAME[code] ?? code,
-      })),
-      onItemClick: ({ detail }) => {
-        if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
-          setLocale(detail.id as LocaleCode);
-        }
-      },
-    };
+    const localeUtility = buildLocaleUtility(locale, setLocale, t);
     if (!auth.session) return [localeUtility];
     // Score: backend mode のときだけ実値、未取得なら "…"、dev-mock なら "—"。
-    const totalScore = teamView.view
-      ? teamView.view.problems.reduce((sum, p) => sum + p.score, 0)
-      : null;
-    const score =
-      config.mode === "backend" ? (totalScore !== null ? `${totalScore} pt` : "…") : "—";
+    const score = formatTopNavScore(config.mode, teamView.view);
     // Rank: leaderboard.entries.find(isMyTeam) の rank / 全 entries 数。
     // Phase 1 以前 (eventId 無し) は leaderboardNoEvent → "—"、未取得は "…"。
-    const myEntry = teamView.leaderboard?.entries.find((e) => e.isMyTeam);
-    const totalEntries = teamView.leaderboard?.entries.length;
-    const rank =
-      config.mode !== "backend"
-        ? "—"
-        : teamView.leaderboardNoEvent
-          ? "—"
-          : myEntry && totalEntries
-            ? `${myEntry.rank}/${totalEntries}`
-            : "…";
+    const rank = formatTopNavRank(config.mode, teamView.leaderboard, teamView.leaderboardNoEvent);
     return [
       localeUtility,
       // #547: 旧 `menu-dropdown` + 空 items は chevron で展開できそうに見えて何も出ない
       // という UX bug。Score / Rank の click は scoreboard ページへの遷移が自然なので
       // `type: "button"` + onClick で /scoreboard に飛ばす (= dropdown の意図不明
       // affordance を排除)。
-      {
-        type: "button",
-        text: `Score: ${score}  /  Rank: ${rank}`,
-        iconName: "status-positive",
-        onClick: () => {
-          navigate("/scoreboard");
-        },
-      },
-      {
-        type: "menu-dropdown",
-        text: auth.session.teamName,
-        iconName: "user-profile",
-        items: [{ id: "logout", text: t("nav.sign_out") }],
-        onItemClick: ({ detail }) => {
-          if (detail.id === "logout") {
-            auth.logout();
-            navigate("/login");
-          }
-        },
-      },
+      buildScoreRankUtility(score, rank, navigate),
+      buildProfileUtility(auth.session.teamName, auth.logout, navigate, t),
     ];
   }, [
     auth.session,

--- a/apps/participant-portal/test/components/AppLayout.test.ts
+++ b/apps/participant-portal/test/components/AppLayout.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { LeaderboardResponse, ParticipantTeamView } from "../../src/api/portal-client";
+import {
+  formatTopNavRank,
+  formatTopNavScore,
+  isSupportedLocaleId,
+} from "../../src/components/AppLayout";
+
+function teamView(scores: readonly number[]) {
+  return {
+    team: {
+      teamName: "Blue",
+      teamNameSetByCompetitor: true,
+    },
+    problems: scores.map((score, index) => ({
+      jobId: `job-${index}`,
+      problemId: `problem-${index}`,
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+      status: "COMPLETE",
+      stackOutputs: {},
+      expiresAt: 0,
+      score,
+      deployLog: { cursor: "0", entries: [] },
+    })),
+  } satisfies ParticipantTeamView;
+}
+
+function leaderboard(entries: LeaderboardResponse["entries"]) {
+  return {
+    eventId: "event-1",
+    entries,
+  } satisfies LeaderboardResponse;
+}
+
+describe("AppLayout top navigation helpers", () => {
+  it("backend mode では取得済み score を合算表示すべき", () => {
+    expect(formatTopNavScore("backend", teamView([10, 15, -3]))).toBe("22 pt");
+  });
+
+  it("backend 未取得または mock mode では score fallback を表示すべき", () => {
+    expect(formatTopNavScore("backend", null)).toBe("…");
+    expect(formatTopNavScore("dev-mock", teamView([10]))).toBe("—");
+  });
+
+  it("backend mode では自チーム rank と総チーム数を表示すべき", () => {
+    expect(
+      formatTopNavRank(
+        "backend",
+        leaderboard([
+          {
+            rank: 1,
+            teamId: "team-a",
+            teamName: "Blue",
+            score: 100,
+            completedProblems: 1,
+            totalProblems: 2,
+            isMyTeam: true,
+          },
+          {
+            rank: 2,
+            teamId: "team-b",
+            teamName: "Red",
+            score: 80,
+            completedProblems: 1,
+            totalProblems: 2,
+            isMyTeam: false,
+          },
+        ]),
+        false,
+      ),
+    ).toBe("1/2");
+  });
+
+  it("rank が取得不能な場合は状態に応じた fallback を表示すべき", () => {
+    expect(formatTopNavRank("dev-mock", null, false)).toBe("—");
+    expect(formatTopNavRank("backend", null, true)).toBe("—");
+    expect(formatTopNavRank("backend", null, false)).toBe("…");
+    expect(formatTopNavRank("backend", leaderboard([]), false)).toBe("…");
+  });
+
+  it("対応 locale id だけを受け入れるべき", () => {
+    expect(isSupportedLocaleId("ja")).toBe(true);
+    expect(isSupportedLocaleId("en")).toBe(true);
+    expect(isSupportedLocaleId("fr")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract top-navigation score, rank, and locale-id decisions into small helpers.
- Move locale, score/rank, and profile utility construction out of the `ShellInner` `useMemo` body.
- Add helper coverage for score aggregation, rank fallback behavior, and supported locale IDs.
- Remove the `AppLayout` top-navigation Biome cognitive-complexity warning without changing navigation behavior.

Relates #1124

## Test plan
- `bun biome check apps/participant-portal/src/components/AppLayout.tsx apps/participant-portal/test/components/AppLayout.test.ts --diagnostic-level=warn --max-diagnostics=40`
- `bun run --filter @TenkaCloud/participant-portal test -- AppLayout`
- `bun run --filter @TenkaCloud/participant-portal typecheck`
- `bun install --frozen-lockfile --ignore-scripts`
- `make harness`
- `NODE_OPTIONS=--no-experimental-webstorage CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make before-commit`
- Manual /review: helper extraction preserves the existing locale switch, scoreboard navigation, and logout navigation callbacks.
- Manual /security-review: no auth token/session storage behavior changed; logout remains behind the same menu item id.
- Manual /simplify: display formatting and utility object creation are centralized, leaving `ShellInner` focused on layout composition.

## Regression 分析
- Locale switcher remains visible without a session and still accepts only supported locale IDs.
- Backend score still sums all problem scores and shows `…` before `/portal/me` loads.
- Non-backend score and rank still render `—`.
- Rank still uses the current team entry and total leaderboard entries, with `—` for no-event and `…` for not-yet-loaded/no own entry.
- Score/Rank button still navigates to `/scoreboard`.
- Profile menu still signs out and navigates to `/login` only for the `logout` item.
- Side navigation and offline cloud alerts are untouched.

## 物理影響
- UPDATE: `apps/participant-portal/src/components/AppLayout.tsx`.
- CREATE: `apps/participant-portal/test/components/AppLayout.test.ts`.
- NO-OP: API clients, backend handlers, CDK stacks, IAM policies, CloudFormation templates, package manifests, lockfiles, generated docs, and AWS resources.
- DELETE: none.
