### PR TITLE
chore(infrastructure): flip to ESM ("type": "module") (#1153 PR-B)

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -19,7 +19,7 @@ const app = new cdk.App();
 
 const config = resolveAppConfig({
   env: process.env,
-  binDir: __dirname,
+  binDir: import.meta.dirname,
 });
 
 buildTenkaCloudApp(app, config);

--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -28,7 +28,7 @@ import { TenkaCloudLiteStack } from "../lib/tenkacloud-lite/index.js";
  */
 
 const app = new cdk.App();
-const config = resolveAppConfig({ env: process.env, binDir: __dirname });
+const config = resolveAppConfig({ env: process.env, binDir: import.meta.dirname });
 
 /**
  * Issue #992: 同 AWS account に複数 env を deploy できるよう stack ID に env suffix を付ける。

--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -88,7 +88,7 @@ export class AdminConsoleHostingStack extends cdk.Stack {
     this.distributionDomainName = this.distribution.distributionDomainName;
 
     // dist/ をアップロード (URL 非依存の静的ファイル)
-    const distDir = path.join(__dirname, "..", "..", "apps", "admin-console", "dist");
+    const distDir = path.join(import.meta.dirname, "..", "..", "apps", "admin-console", "dist");
     new BucketDeployment(this, "SiteDeployment", {
       sources: [Source.asset(distDir)],
       destinationBucket: this.siteBucket,

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -76,7 +76,7 @@ export class AdminInsightApiLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/admin-insight-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/admin-insight-handler/index.ts"),
       handler: "handler",
       // Per-tenant Query を Promise.all で並列発火するので、tenant 数 100 件 × DDB 往復 ~50ms
       // ≒ 5s が最大。安全側で 15s。

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -29,7 +29,7 @@ import type { ApiKeySSMParameterNames, AppConfig, ProblemsCatalogBundle } from "
  */
 export interface ResolveAppConfigInput {
   readonly env: NodeJS.ProcessEnv;
-  /** `bin/infrastructure.ts` の __dirname (= `infrastructure/bin`)。 .env / config.json の base path 解決に使う。 */
+  /** `bin/infrastructure.ts` の import.meta.dirname (= `infrastructure/bin`)。 .env / config.json の base path 解決に使う。 */
   readonly binDir: string;
   /**
    * テストから filesystem 読みを差し替えるための optional hook。 既定では実 dotenv / fs。

--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -53,7 +53,7 @@ export class CompetitorAccountsApiLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/competitor-accounts-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/competitor-accounts-handler/index.ts"),
       handler: "handler",
       // verify endpoint は STS AssumeRole 1 回 (= ~1s) + DDB Update なので 10s で十分。
       timeout: Duration.seconds(15),

--- a/infrastructure/lib/problem-deploy/competitor-bootstrap-hosting.ts
+++ b/infrastructure/lib/problem-deploy/competitor-bootstrap-hosting.ts
@@ -49,7 +49,7 @@ export class CompetitorBootstrapHosting extends Construct {
 
     new BucketDeployment(this, "Deployment", {
       sources: [
-        Source.asset(path.join(__dirname, "..", "..", "templates"), {
+        Source.asset(path.join(import.meta.dirname, "..", "..", "templates"), {
           exclude: ["*", "!competitor-bootstrap.yaml"],
         }),
       ],

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -76,7 +76,7 @@ export class DeployApiLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/deploy-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/deploy-handler/index.ts"),
       handler: "handler",
       timeout: Duration.seconds(15),
       memorySize: 256,

--- a/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
+++ b/infrastructure/lib/problem-deploy/describe-stack-lambda.ts
@@ -29,7 +29,7 @@ export class DescribeStackLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/describe-stack-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/describe-stack-handler/index.ts"),
       handler: "handler",
       timeout: Duration.seconds(30),
       memorySize: 256,

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -91,7 +91,7 @@ export class EventApiLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/event-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/event-handler/index.ts"),
       handler: "handler",
       // Bulk teardown は teams × problems 全行を Update + chunk publish するので
       // teams=25 × problems=30 = 750 行で 30 秒前後を見込む。Phase 3 で Distributed

--- a/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
+++ b/infrastructure/lib/problem-deploy/external-id-audit-lambda.ts
@@ -50,7 +50,7 @@ export class ExternalIdAuditLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/external-id-audit-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/external-id-audit-handler/index.ts"),
       handler: "handler",
       // DDB Scan + PutMetricData 1 回。MVP 規模で 5s 以内に終わる想定だが余裕で 60s。
       timeout: Duration.seconds(60),

--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -75,7 +75,7 @@ export class GenericScoringLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/generic-scoring-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/generic-scoring-handler/index.ts"),
       handler: "handler",
       timeout: Duration.minutes(2),
       // #746: 旧 256MB だと cold start で OOM + init timeout が頻発し採点 Lambda が

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -96,7 +96,15 @@ export class ParticipantPortalHosting extends Construct {
     this.distributionDomainName = this.distribution.distributionDomainName;
     this.distributionUrl = `https://${this.distribution.distributionDomainName}`;
 
-    const distDir = path.join(__dirname, "..", "..", "..", "apps", "participant-portal", "dist");
+    const distDir = path.join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "apps",
+      "participant-portal",
+      "dist",
+    );
     new BucketDeployment(this, "SiteDeployment", {
       sources: [Source.asset(distDir)],
       destinationBucket: this.bucket,

--- a/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-lambda.ts
@@ -162,7 +162,7 @@ export class ParticipantPortalLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/participant-handler/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/participant-handler/index.ts"),
       handler: "handler",
       timeout: Duration.seconds(10),
       // Issue #672: bundle が 33MB と巨大 (= AWS SDK / Hono / zod 等が含まれる) で

--- a/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
+++ b/infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts
@@ -50,7 +50,7 @@ export class SystemAuditWriterLambda extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/system-audit-writer/index.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/system-audit-writer/index.ts"),
       handler: "handler",
       timeout: Duration.seconds(10),
       memorySize: 256,

--- a/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
+++ b/infrastructure/lib/tenant-pipeline/serverless-saas-pipeline.ts
@@ -17,7 +17,10 @@ import * as stepfunctions from "aws-cdk-lib/aws-stepfunctions";
 import type { Construct } from "constructs";
 
 const DEPLOYMENT_STATE_MACHINE_NAME_SUFFIX = "saas-deployment-machine";
-const TENANT_UPDATE_SCRIPT_PATH = path.join(__dirname, "../../../scripts/update-tenant.sh");
+const TENANT_UPDATE_SCRIPT_PATH = path.join(
+  import.meta.dirname,
+  "../../../scripts/update-tenant.sh",
+);
 const TENANT_PIPELINE_LAMBDA_RUNTIME = lambda.Runtime.PYTHON_3_14;
 const TENANT_PIPELINE_CODEBUILD_IMAGE_ID = "aws/codebuild/standard:8.0";
 const TENANT_PIPELINE_CODEBUILD_NODE_VERSION = 24;
@@ -74,7 +77,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
     });
     // Lambda handler のソースは Construct と co-locate (handlers/)。旧 ref-arch では
     // リポジトリルート src/ にあったが #76 で整理した。
-    const handlersPath = path.join(__dirname, "handlers");
+    const handlersPath = path.join(import.meta.dirname, "handlers");
     const lambdaFunctionPrep = new lambda.Function(this, "prep-deploy", {
       handler: "lambda-prepare-deploy.lambda_handler",
       runtime: TENANT_PIPELINE_LAMBDA_RUNTIME,
@@ -296,7 +299,7 @@ export class ServerlessSaaSPipeline extends cdk.Stack {
       },
     });
 
-    const filePath = require("node:path").join(__dirname, "deployemntstatemachine.asl.json");
+    const filePath = path.join(import.meta.dirname, "deployemntstatemachine.asl.json");
     const file = fs.readFileSync(filePath);
 
     new stepfunctions.CfnStateMachine(this, "DeploymentCfnStateMachine", {

--- a/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
+++ b/infrastructure/lib/tenant-status-reconciler/tenant-status-reconciler.ts
@@ -44,7 +44,7 @@ export class TenantStatusReconciler extends Construct {
     this.fn = new NodejsFunction(this, "Function", {
       runtime: LAMBDA_NODEJS_RUNTIME,
       architecture: Architecture.ARM_64,
-      entry: path.resolve(__dirname, "handlers/handler.ts"),
+      entry: path.resolve(import.meta.dirname, "handlers/handler.ts"),
       handler: "handler",
       timeout: Duration.seconds(60),
       memorySize: 256,

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -150,7 +150,7 @@ export class ApplicationAdminConsoleHosting extends Construct {
     // CodeBuild 実行時 (silo stack) は STAGING/apps/application-admin-console/dist。
     // どちらも install.sh が事前に build + 配置する。
     const distDir = path.join(
-      __dirname,
+      import.meta.dirname,
       "..",
       "..",
       "..",

--- a/infrastructure/lib/utils/config-loader.ts
+++ b/infrastructure/lib/utils/config-loader.ts
@@ -1,9 +1,18 @@
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
+import { Ajv } from "ajv";
+import type { FormatsPlugin } from "ajv-formats";
 import type { Logger } from "winston";
 import type { Config } from "../config/config-interface.js";
+
+// ajv-formats 3 は CJS `export default formatsPlugin` で publish。 ESM
+// (= `"type": "module"`) では tsc が default import の値を namespace 扱いするため
+// callable として呼べない。 `createRequire(import.meta.url)` で CJS resolver から
+// runtime 関数を取り出し、型は named export の `FormatsPlugin` interface を当てる
+// (= `Plugin<Opts>` を継承する callable interface)。
+const require = createRequire(import.meta.url);
+const addFormats = require("ajv-formats").default as FormatsPlugin;
 
 export interface ExpandOptions {
   /**
@@ -126,7 +135,7 @@ export function loadConfig(envName: string, baseDir: string): Config | undefined
  * Validate a Config object against the JSON Schema.
  */
 export function validateConfig(config: Config, logger: Logger): void {
-  const schemaPath = path.resolve(__dirname, "../config/config-schema.json");
+  const schemaPath = path.resolve(import.meta.dirname, "../config/config-schema.json");
   let schemaContent: string;
   try {
     schemaContent = fs.readFileSync(schemaPath, "utf-8");

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@TenkaCloud/infrastructure",
   "version": "0.1.0",
+  "type": "module",
   "bin": {
     "cdk": "bin/infrastructure.js"
   },


### PR DESCRIPTION
## Summary

- `infrastructure` package を CommonJS hybrid 状態から純 ESM に切替え (#1153 PR-B)。
- PR-A (#1162) で全 relative import に `.js` 拡張子を付与済の前提で、 本 PR は以下の atomic な flip を入れる:
  1. `infrastructure/package.json` に `"type": "module"` 追加
  2. `infrastructure/lib + bin` の `__dirname` (= 19 ファイル / 21 箇所) を `import.meta.dirname` に置換
  3. `serverless-saas-pipeline.ts:299` の inline `require(\"node:path\")` を既存 top-level `import path` から呼ぶ形に統合
  4. `config-loader.ts` の Ajv import を ESM/CJS interop 対応 (= named `import { Ajv } from \"ajv\"` と ajv-formats の `createRequire` workaround)

これで `apps/*` (= 4 SPA) と `infrastructure` が全て ESM (`\"type\": \"module\"`) で整合する。 tsconfig の `module: NodeNext` + import path に `.js` 拡張子の流儀が一致 (= 旧来は ESM 流儀のコードを CJS package で動かす hybrid だった)。

Closes #1153

## Test plan

- `cd infrastructure && bun run typecheck` (= 0 errors)
- `bun run --filter @TenkaCloud/infrastructure test` (= 1283 tests pass)
- `make harness` (= no findings)
- `CDK_PARAM_SYSTEM_ADMIN_EMAIL=admin@example.com make synth ENV=development` (= 9 stacks synth OK)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth すべて OK)

## Regression 分析

- **runtime 動作 (= CDK synth)**: Node 22 + ESM module で `import.meta.dirname` が Node 20.11+ から GA で利用可能 (= 本 repo は Node 22)。 `path.join(import.meta.dirname, ...)` の output は旧 `path.join(__dirname, ...)` と同 string (= `bin/infrastructure.ts` / `lib/**/*.ts` の compiled JS の解決 path が一致)。
- **CDK Function asset (= `NodejsFunction({ entry: path.resolve(import.meta.dirname, \"handlers/...\") })`)**: entry の絶対 path を esbuild に渡す挙動は不変。 esbuild は entry が pre-resolved fully-qualified path のため `\"type\": \"module\"` の影響を受けず handler bundle を生成する。
- **inline runtime require の置換** (`serverless-saas-pipeline.ts:299`): `require(\"node:path\")` を消し、 既存 top-level `import * as path from \"node:path\"` から呼ぶ形に統合。 結果 path は完全同一。
- **Ajv 8 interop**: Ajv 8 / ajv-formats 3 は CJS `export = X` で publish。 ESM `\"type\": \"module\"` では tsc が default import を namespace 扱いし ctor / function として呼べないため:
  - Ajv: named export `import { Ajv } from \"ajv\"` で class 直接取得 (= tsc OK / runtime OK)
  - ajv-formats: `createRequire(import.meta.url)` で CJS resolver から runtime 関数を取り、 型は named `FormatsPlugin` interface を当てる
  - runtime 挙動は不変 (= Ajv constructor 呼び出しと addFormats(ajv) plugin 呼び出しが従来通り走る)
- **vitest test fixtures**: `test/` ディレクトリは tsconfig の `exclude` 対象で tsc の check 範囲外。 vitest は relative path resolution が permissive で `.js` 拡張子有無どちらでも動く。 既存 fixture は process.env / mock パターンで影響なし (= 1283 tests pass)。
- **生成 CFn / Lambda bundle / DDB schema**: 完全に identical。 synth 出力 cdk.out の `.template.json` は本 PR 前後で diff なし (= module type は infra source layer の表記、 CDK output は不変)。
- **bin entry `infrastructure.js`**: tsc が compile した `.js` は ESM 出力 (= `import { ... } from \".../index.js\"` のまま)。 `cdk` CLI が node で実行する経路は Node 22 ESM resolver が処理。

## 物理影響

- **CREATE**: なし。
- **UPDATE**: `infrastructure/package.json` (\"type\": \"module\" 追加) + `infrastructure/lib/**/*.ts` + `infrastructure/bin/*.ts` の 20 ファイル (= __dirname 置換 + require 整理 + Ajv interop)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース・CFn・IAM・DDB schema・Lambda runtime 動作はすべて identical。
- **CI / CD 影響**: なし。 CI は既存通り `make install_ci` → typecheck → test → build で pass。
- **dependency 影響**: なし。 package.json deps / bun.lock / audit-baseline.json は無修正 (\"type\" field 追加のみ)。
- **\"type\": \"module\" の波及**: `apps/*` は既に \"type\": \"module\"。 root package.json は \"type\" 未設定 (= CJS default、 scripts/ 配下が tsx 経由実行のため触らない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)