### PR TITLE
refactor(scripts): split tenkacloud-ops runHealth into helpers

### DIFF
--- a/infrastructure/test/scripts/tenkacloud-ops.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-ops.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildListStacksArgs,
+  type CfnStackSummary,
   type CliIO,
+  classifyStacks,
+  computeHealthExitCode,
+  filterTenkaCloudStacks,
   main,
+  parseStackSummariesJson,
   runHealth,
   type SpawnCaptureResult,
 } from "../../../scripts/tenkacloud-ops";
@@ -140,5 +146,102 @@ describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
     expect(capturedArgs).not.toBeNull();
     const argsString = (capturedArgs ?? []).join(" ");
     expect(argsString).toContain("--region us-east-1");
+  });
+});
+
+describe("runHealth helpers", () => {
+  it("buildListStacksArgs: region 未指定なら --region を付けず status filter は完全に揃うべき", () => {
+    const args = buildListStacksArgs();
+    expect(args).toContain("cloudformation");
+    expect(args).toContain("list-stacks");
+    expect(args).toContain("--stack-status-filter");
+    expect(args).toContain("CREATE_COMPLETE");
+    expect(args).toContain("ROLLBACK_FAILED");
+    expect(args).toContain("UPDATE_ROLLBACK_COMPLETE");
+    expect(args).toContain("IMPORT_ROLLBACK_COMPLETE");
+    expect(args).toContain("--output");
+    expect(args).toContain("json");
+    expect(args).not.toContain("--region");
+  });
+
+  it("buildListStacksArgs: region 指定で --region <r> を末尾に追加すべき", () => {
+    const args = buildListStacksArgs("ap-northeast-1");
+    expect(args[args.length - 2]).toBe("--region");
+    expect(args[args.length - 1]).toBe("ap-northeast-1");
+  });
+
+  it("parseStackSummariesJson: 正常 JSON は StackSummaries を返すべき", () => {
+    const out = parseStackSummariesJson(
+      JSON.stringify({
+        StackSummaries: [{ StackName: "tenkacloud-x", StackStatus: "CREATE_COMPLETE" }],
+      }),
+    );
+    expect(out).toEqual({
+      ok: true,
+      stacks: [{ StackName: "tenkacloud-x", StackStatus: "CREATE_COMPLETE" }],
+    });
+  });
+
+  it("parseStackSummariesJson: StackSummaries 不在は空配列を返すべき", () => {
+    expect(parseStackSummariesJson("{}")).toEqual({ ok: true, stacks: [] });
+  });
+
+  it("parseStackSummariesJson: 壊れた JSON は error を返すべき", () => {
+    const out = parseStackSummariesJson("not json");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toMatch(/.+/);
+  });
+
+  it("filterTenkaCloudStacks: 既知 prefix の stack だけを残すべき", () => {
+    const all: readonly CfnStackSummary[] = [
+      { StackName: "tenkacloud-control-plane", StackStatus: "CREATE_COMPLETE" },
+      { StackName: "serverless-saas-ref-arch-pooled", StackStatus: "CREATE_COMPLETE" },
+      { StackName: "tc-stackstack-team1", StackStatus: "CREATE_COMPLETE" },
+      { StackName: "unrelated-stack", StackStatus: "CREATE_COMPLETE" },
+    ];
+    const ours = filterTenkaCloudStacks(all);
+    expect(ours.map((s) => s.StackName)).toEqual([
+      "tenkacloud-control-plane",
+      "serverless-saas-ref-arch-pooled",
+      "tc-stackstack-team1",
+    ]);
+  });
+
+  it("classifyStacks: FAILED / ROLLBACK / IN_PROGRESS / その他で 3 bucket に振り分けるべき", () => {
+    const buckets = classifyStacks([
+      { StackName: "a", StackStatus: "CREATE_COMPLETE" },
+      { StackName: "b", StackStatus: "CREATE_FAILED" },
+      { StackName: "c", StackStatus: "UPDATE_ROLLBACK_COMPLETE" },
+      { StackName: "d", StackStatus: "UPDATE_IN_PROGRESS" },
+      { StackName: "e", StackStatus: "UPDATE_COMPLETE" },
+    ]);
+    expect(buckets.healthy.map((s) => s.StackName)).toEqual(["a", "e"]);
+    expect(buckets.inProgress.map((s) => s.StackName)).toEqual(["d"]);
+    expect(buckets.failed.map((s) => s.StackName)).toEqual(["b", "c"]);
+  });
+
+  it("computeHealthExitCode: failed>0 で 2、 in_progress のみで 1、 healthy のみで 0", () => {
+    expect(computeHealthExitCode({ healthy: [], inProgress: [], failed: [] })).toBe(0);
+    expect(
+      computeHealthExitCode({
+        healthy: [{ StackName: "a", StackStatus: "CREATE_COMPLETE" }],
+        inProgress: [],
+        failed: [],
+      }),
+    ).toBe(0);
+    expect(
+      computeHealthExitCode({
+        healthy: [],
+        inProgress: [{ StackName: "a", StackStatus: "CREATE_IN_PROGRESS" }],
+        failed: [],
+      }),
+    ).toBe(1);
+    expect(
+      computeHealthExitCode({
+        healthy: [],
+        inProgress: [{ StackName: "a", StackStatus: "CREATE_IN_PROGRESS" }],
+        failed: [{ StackName: "b", StackStatus: "CREATE_FAILED" }],
+      }),
+    ).toBe(2);
   });
 });

--- a/scripts/tenkacloud-ops.ts
+++ b/scripts/tenkacloud-ops.ts
@@ -57,11 +57,114 @@ export interface CliIO {
 
 const TENKACLOUD_STACK_PREFIXES = ["tenkacloud-", "serverless-saas-ref-arch-", "tc-"] as const;
 
-interface CfnStackSummary {
+const CFN_STACK_STATUS_FILTER = [
+  "CREATE_IN_PROGRESS",
+  "CREATE_FAILED",
+  "CREATE_COMPLETE",
+  "ROLLBACK_IN_PROGRESS",
+  "ROLLBACK_FAILED",
+  "ROLLBACK_COMPLETE",
+  "DELETE_IN_PROGRESS",
+  "DELETE_FAILED",
+  "UPDATE_IN_PROGRESS",
+  "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+  "UPDATE_COMPLETE",
+  "UPDATE_ROLLBACK_IN_PROGRESS",
+  "UPDATE_ROLLBACK_FAILED",
+  "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+  "UPDATE_ROLLBACK_COMPLETE",
+  "REVIEW_IN_PROGRESS",
+  "IMPORT_IN_PROGRESS",
+  "IMPORT_COMPLETE",
+  "IMPORT_ROLLBACK_IN_PROGRESS",
+  "IMPORT_ROLLBACK_FAILED",
+  "IMPORT_ROLLBACK_COMPLETE",
+] as const;
+
+export interface CfnStackSummary {
   readonly StackName: string;
   readonly StackStatus: string;
   readonly LastUpdatedTime?: string;
   readonly CreationTime?: string;
+}
+
+export interface StackHealthBuckets {
+  readonly healthy: readonly CfnStackSummary[];
+  readonly inProgress: readonly CfnStackSummary[];
+  readonly failed: readonly CfnStackSummary[];
+}
+
+export function buildListStacksArgs(region?: string): readonly string[] {
+  const args: string[] = [
+    "cloudformation",
+    "list-stacks",
+    "--stack-status-filter",
+    ...CFN_STACK_STATUS_FILTER,
+    "--output",
+    "json",
+  ];
+  if (region) args.push("--region", region);
+  return args;
+}
+
+export function parseStackSummariesJson(
+  stdout: string,
+): { ok: true; stacks: readonly CfnStackSummary[] } | { ok: false; error: string } {
+  try {
+    const parsed = JSON.parse(stdout) as { StackSummaries?: CfnStackSummary[] };
+    return { ok: true, stacks: parsed.StackSummaries ?? [] };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export function filterTenkaCloudStacks(
+  stacks: readonly CfnStackSummary[],
+): readonly CfnStackSummary[] {
+  return stacks.filter((s) => TENKACLOUD_STACK_PREFIXES.some((p) => s.StackName.startsWith(p)));
+}
+
+export function classifyStacks(stacks: readonly CfnStackSummary[]): StackHealthBuckets {
+  const healthy: CfnStackSummary[] = [];
+  const inProgress: CfnStackSummary[] = [];
+  const failed: CfnStackSummary[] = [];
+  for (const s of stacks) {
+    if (s.StackStatus.includes("FAILED") || s.StackStatus.includes("ROLLBACK")) {
+      failed.push(s);
+    } else if (s.StackStatus.includes("IN_PROGRESS")) {
+      inProgress.push(s);
+    } else {
+      healthy.push(s);
+    }
+  }
+  return { healthy, inProgress, failed };
+}
+
+// exit code: failed 1 件以上で 2、 in_progress のみで 1、 すべて healthy で 0
+export function computeHealthExitCode(buckets: StackHealthBuckets): 0 | 1 | 2 {
+  if (buckets.failed.length > 0) return 2;
+  if (buckets.inProgress.length > 0) return 1;
+  return 0;
+}
+
+function printHealthSummary(
+  io: CliIO,
+  ours: readonly CfnStackSummary[],
+  buckets: StackHealthBuckets,
+  region: string | undefined,
+): void {
+  const widest = ours.reduce((m, s) => Math.max(m, s.StackName.length), 0);
+  const summarize = (label: string, list: readonly CfnStackSummary[]): void => {
+    if (list.length === 0) return;
+    io.stdout(`\n${label} (${list.length})\n`);
+    for (const s of list) {
+      io.stdout(`  ${s.StackName.padEnd(widest)}  ${s.StackStatus}\n`);
+    }
+  };
+  io.stdout(`TenkaCloud stacks: ${ours.length} total (region=${region ?? "default"})\n`);
+  summarize("FAILED / ROLLBACK", buckets.failed);
+  summarize("IN_PROGRESS", buckets.inProgress);
+  summarize("HEALTHY", buckets.healthy);
 }
 
 /**
@@ -72,93 +175,24 @@ interface CfnStackSummary {
  *   - 名前 prefix が tenkacloud-* / serverless-saas-ref-arch-* / tc-* のいずれか
  */
 export async function runHealth(io: CliIO, region?: string): Promise<number> {
-  const args = [
-    "cloudformation",
-    "list-stacks",
-    "--stack-status-filter",
-    "CREATE_IN_PROGRESS",
-    "CREATE_FAILED",
-    "CREATE_COMPLETE",
-    "ROLLBACK_IN_PROGRESS",
-    "ROLLBACK_FAILED",
-    "ROLLBACK_COMPLETE",
-    "DELETE_IN_PROGRESS",
-    "DELETE_FAILED",
-    "UPDATE_IN_PROGRESS",
-    "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-    "UPDATE_COMPLETE",
-    "UPDATE_ROLLBACK_IN_PROGRESS",
-    "UPDATE_ROLLBACK_FAILED",
-    "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-    "UPDATE_ROLLBACK_COMPLETE",
-    "REVIEW_IN_PROGRESS",
-    "IMPORT_IN_PROGRESS",
-    "IMPORT_COMPLETE",
-    "IMPORT_ROLLBACK_IN_PROGRESS",
-    "IMPORT_ROLLBACK_FAILED",
-    "IMPORT_ROLLBACK_COMPLETE",
-    "--output",
-    "json",
-  ];
-  if (region) {
-    args.push("--region", region);
-  }
-
-  const result = await io.spawnCapture("aws", args);
+  const result = await io.spawnCapture("aws", buildListStacksArgs(region));
   if (result.code !== 0) {
     io.stderr(`aws cloudformation list-stacks failed (exit ${result.code}):\n${result.stderr}`);
     return result.code === 0 ? 1 : result.code;
   }
-
-  let parsed: { StackSummaries?: CfnStackSummary[] };
-  try {
-    parsed = JSON.parse(result.stdout);
-  } catch (e) {
-    io.stderr(`failed to parse aws output: ${e instanceof Error ? e.message : String(e)}`);
+  const parsed = parseStackSummariesJson(result.stdout);
+  if (!parsed.ok) {
+    io.stderr(`failed to parse aws output: ${parsed.error}`);
     return 1;
   }
-
-  const all = parsed.StackSummaries ?? [];
-  const ours = all.filter((s) => TENKACLOUD_STACK_PREFIXES.some((p) => s.StackName.startsWith(p)));
-
+  const ours = filterTenkaCloudStacks(parsed.stacks);
   if (ours.length === 0) {
     io.stdout("(no TenkaCloud stacks found)\n");
     return 0;
   }
-
-  // 状態ごとに健全 / 注意 / 異常を分類
-  const healthy: CfnStackSummary[] = [];
-  const inProgress: CfnStackSummary[] = [];
-  const failed: CfnStackSummary[] = [];
-
-  for (const s of ours) {
-    if (s.StackStatus.includes("FAILED") || s.StackStatus.includes("ROLLBACK")) {
-      failed.push(s);
-    } else if (s.StackStatus.includes("IN_PROGRESS")) {
-      inProgress.push(s);
-    } else {
-      healthy.push(s);
-    }
-  }
-
-  const widest = ours.reduce((m, s) => Math.max(m, s.StackName.length), 0);
-  const summarize = (label: string, list: readonly CfnStackSummary[]): void => {
-    if (list.length === 0) return;
-    io.stdout(`\n${label} (${list.length})\n`);
-    for (const s of list) {
-      io.stdout(`  ${s.StackName.padEnd(widest)}  ${s.StackStatus}\n`);
-    }
-  };
-
-  io.stdout(`TenkaCloud stacks: ${ours.length} total (region=${region ?? "default"})\n`);
-  summarize("FAILED / ROLLBACK", failed);
-  summarize("IN_PROGRESS", inProgress);
-  summarize("HEALTHY", healthy);
-
-  // exit code: failed 1 件以上で 2、 in_progress のみで 1、 すべて healthy で 0
-  if (failed.length > 0) return 2;
-  if (inProgress.length > 0) return 1;
-  return 0;
+  const buckets = classifyStacks(ours);
+  printHealthSummary(io, ours, buckets, region);
+  return computeHealthExitCode(buckets);
 }
 
 function defaultSpawnCapture(): SpawnCapture {


### PR DESCRIPTION
## Summary

- `scripts/tenkacloud-ops.ts:74` の `runHealth` は cognitive complexity 19 (= biome max 15 超過)。 spawn / JSON parse / filter / classify / exit code / 出力整形を 1 関数で抱えていた。
- 純粋関数を 5 つ抽出して責務を分離:
  - `buildListStacksArgs(region?)` — aws CLI 引数組み立て
  - `parseStackSummariesJson(stdout)` — JSON parse + `StackSummaries` 取り出し
  - `filterTenkaCloudStacks(stacks)` — `TENKACLOUD_STACK_PREFIXES` での filter
  - `classifyStacks(stacks)` — `FAILED` / `IN_PROGRESS` / `HEALTHY` 振り分け
  - `computeHealthExitCode(buckets)` — `0` / `1` / `2` mapping
- 各 helper に test を追加 (= 8 新規 it ブロック)。 既存 9 件の integration test は無修正で pass。
- `CFN_STACK_STATUS_FILTER` を const 化して `runHealth` 本体から退避。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/infrastructure test -- tenkacloud-ops` (= 17 tests pass、 旧 9 + 新 8)
- `bunx biome check scripts/tenkacloud-ops.ts` (= complexity warning 解消)
- `make harness` (= no findings)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth すべて OK)

## Regression 分析

- **runHealth の振る舞いは完全に保存**: spawn → parse → filter → classify → print → exit code の流れは不変。 入力 stdout が同じなら出力 stdout / stderr / exit code は完全に identical。
- **JSON parse 失敗時の挙動**: 旧コードは `try/catch` で `failed to parse aws output: <message>` を stderr に出して 1 を返す。 新コードは `parseStackSummariesJson(stdout)` が `{ ok: false, error }` を返し、 呼び出し側で同じ message + 1 を返す。 既存 test `health: aws CLI が失敗したら non-zero で stderr に message` でカバー継続。
- **`StackSummaries` 不在**: 旧 `parsed.StackSummaries ?? []` を helper 内に移動し挙動同一。
- **classifyStacks の case 順**: 旧コードと同じ条件順 (`FAILED` / `ROLLBACK` を最優先、 次に `IN_PROGRESS`、 残りを `HEALTHY`)。 `classifyStacks` test で `UPDATE_ROLLBACK_COMPLETE` → failed bucket に入ること、 `UPDATE_IN_PROGRESS` → inProgress bucket に入ること、 `UPDATE_COMPLETE` → healthy bucket を確認。
- **`computeHealthExitCode` 優先順**: failed > 0 で 2、 in_progress のみで 1、 残りで 0。 既存 integration test (`exit 0` / `exit 1` / `exit 2` 3 ケース) + helper test 4 ケースでカバー。
- **buildListStacksArgs**: 22 個の status filter を const に外出し。 region 指定なしなら `--region` を出さない既存挙動を helper test で固定。

## 物理影響

- **CREATE**: なし。
- **UPDATE**:
  - `scripts/tenkacloud-ops.ts` (= runHealth 内ロジックを 5 helper + 1 print helper に分解、 const `CFN_STACK_STATUS_FILTER` 追加、 `CfnStackSummary` を export 化、 新 type `StackHealthBuckets` を export 化)
  - `infrastructure/test/scripts/tenkacloud-ops.test.ts` (= 新 helper の test 8 件追加、 既存 9 件 unchanged)
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / CFn / IAM / DDB schema 不変。 観察可能な動作不変。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)