### PR TITLE
refactor(scripts): split check-template-cfn-refs parser + checker helpers

### DIFF
--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -3,6 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  collectGetAttResources,
+  collectRefs,
+  collectSubRefs,
+  parseSections,
+} from "../../../scripts/check-template-cfn-refs";
 
 /**
  * Issue #951 sub #2: `scripts/check-template-cfn-refs.ts` の挙動を pin する。
@@ -91,5 +97,78 @@ Outputs:
     const re = /!Ref\s+([A-Za-z][A-Za-z0-9:_]*)/g;
     const refs = [...yaml.matchAll(re)].map((m) => m[1]);
     expect(refs).toContain("BogusResource");
+  });
+});
+
+describe("check-template-cfn-refs unit (= 抽出した helper の挙動を pin)", () => {
+  it("parseSections: Resources / Parameters / Outputs を分離して name を集めるべき", () => {
+    const yaml = `AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  NamePrefix:
+    Type: String
+  ExternalId:
+    Type: String
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+  Bucket:
+    Type: AWS::S3::Bucket
+Outputs:
+  RoleArn:
+    Value: !GetAtt Role.Arn
+`;
+    const sections = parseSections(yaml);
+    expect([...sections.parameters].sort()).toEqual(["ExternalId", "NamePrefix"]);
+    expect([...sections.resources].sort()).toEqual(["Bucket", "Role"]);
+    expect([...sections.outputs].sort()).toEqual(["RoleArn"]);
+  });
+
+  it("parseSections: 他の top-level section (Conditions 等) に入ったら currentSection を抜けるべき", () => {
+    const yaml = `Resources:
+  A:
+    Type: AWS::Foo
+Conditions:
+  IsProd: !Equals [a, b]
+Resources:
+  B:
+    Type: AWS::Bar
+`;
+    const sections = parseSections(yaml);
+    expect([...sections.resources].sort()).toEqual(["A", "B"]);
+  });
+
+  it("collectRefs: !Ref shortform と Ref: longform の両方を拾うべき", () => {
+    const yaml = `Resources:
+  A:
+    Properties:
+      Name: !Ref NamePrefix
+      Tag:
+        Ref: ExternalId
+`;
+    expect(collectRefs(yaml).sort()).toEqual(["ExternalId", "NamePrefix"]);
+  });
+
+  it("collectGetAttResources: !GetAtt と Fn::GetAtt の両方を拾うべき", () => {
+    const yaml = `Resources:
+  Out:
+    Value: !GetAtt Role.Arn
+  Other:
+    Value:
+      Fn::GetAtt: [ Bucket, Arn ]
+`;
+    expect(collectGetAttResources(yaml).sort()).toEqual(["Bucket", "Role"]);
+  });
+
+  it("collectSubRefs: \\${Var} は ref、 \\${X.Y} は getAtt、 \\${!Literal} は無視すべき", () => {
+    const yaml = `Foo: !Sub "\${NamePrefix}-suffix"
+Bar: !Sub "arn:\${AWS::Partition}:s3:::bucket"
+Baz: !Sub "arn:s3:::\${Role.Arn}"
+Esc: !Sub "literal \${!NotAVariable}"
+`;
+    const out = collectSubRefs(yaml);
+    expect(out.refs.sort()).toEqual(["AWS::Partition", "NamePrefix"]);
+    expect(out.getAtts).toEqual(["Role"]);
+    expect(out.refs).not.toContain("NotAVariable");
+    expect(out.getAtts).not.toContain("NotAVariable");
   });
 });

--- a/scripts/check-template-cfn-refs.ts
+++ b/scripts/check-template-cfn-refs.ts
@@ -58,6 +58,32 @@ const PSEUDO_PARAMETERS = new Set([
 const REQUIRED_RESOURCE_NAMES = ["ParticipantViewerRole"] as const;
 const REQUIRED_OUTPUT_KEYS = ["ParticipantViewerRoleArn"] as const;
 
+type CfnSection = "resources" | "parameters" | "outputs";
+
+const SECTION_HEADER_RE: Record<CfnSection, RegExp> = {
+  resources: /^Resources:\s*$/,
+  parameters: /^Parameters:\s*$/,
+  outputs: /^Outputs:\s*$/,
+};
+const OTHER_TOP_LEVEL_SECTION_RE = /^[A-Za-z][^:]*:\s*$/;
+const INDENTED_NAME_RE = /^ {2}([A-Za-z][A-Za-z0-9]*):\s*$/;
+
+/**
+ * `Resources:` / `Parameters:` / `Outputs:` のいずれか、 または他の top-level section header
+ * (= 既知 section を抜ける合図) を 1 行から検出する。
+ *
+ * - 該当 section に入る場合: そのキー
+ * - 他の top-level に入る場合: "exit" (= currentSection を null に倒す)
+ * - section header でない (= 内容行) 場合: null
+ */
+function detectSectionHeader(line: string): CfnSection | "exit" | null {
+  for (const section of ["resources", "parameters", "outputs"] as const) {
+    if (SECTION_HEADER_RE[section].test(line)) return section;
+  }
+  if (OTHER_TOP_LEVEL_SECTION_RE.test(line)) return "exit";
+  return null;
+}
+
 /**
  * YAML を line-by-line で section 別に分割する単純な parser。 完全な YAML AST は使わない (= 短文・
  * tab/空白 mix の防御に弱い既存 YAML library 依存を避ける)。 各 section の resource / parameter / output
@@ -68,41 +94,28 @@ function parseSections(yaml: string): {
   parameters: Set<string>;
   outputs: Set<string>;
 } {
-  const lines = yaml.split(/\r?\n/);
-  const resources = new Set<string>();
-  const parameters = new Set<string>();
-  const outputs = new Set<string>();
-  let currentSection: "resources" | "parameters" | "outputs" | null = null;
+  const buckets: Record<CfnSection, Set<string>> = {
+    resources: new Set<string>(),
+    parameters: new Set<string>(),
+    outputs: new Set<string>(),
+  };
+  let currentSection: CfnSection | null = null;
 
-  for (const line of lines) {
-    // Top-level section header (= `Resources:` / `Parameters:` / `Outputs:` at column 0)
-    if (/^Resources:\s*$/.test(line)) {
-      currentSection = "resources";
-      continue;
-    }
-    if (/^Parameters:\s*$/.test(line)) {
-      currentSection = "parameters";
-      continue;
-    }
-    if (/^Outputs:\s*$/.test(line)) {
-      currentSection = "outputs";
-      continue;
-    }
-    // 次の top-level section に入ったら終了 (= column 0 の `<Section>:` で抜ける)
-    if (/^[A-Za-z]/.test(line) && line.endsWith(":")) {
+  for (const line of yaml.split(/\r?\n/)) {
+    const header = detectSectionHeader(line);
+    if (header === "exit") {
       currentSection = null;
       continue;
     }
+    if (header) {
+      currentSection = header;
+      continue;
+    }
     if (!currentSection) continue;
-    // Section 内の `  <Name>:` (= 2-space indent + identifier + `:`) を拾う
-    const m = line.match(/^ {2}([A-Za-z][A-Za-z0-9]*):\s*$/);
-    if (!m?.[1]) continue;
-    const name = m[1];
-    if (currentSection === "resources") resources.add(name);
-    if (currentSection === "parameters") parameters.add(name);
-    if (currentSection === "outputs") outputs.add(name);
+    const name = INDENTED_NAME_RE.exec(line)?.[1];
+    if (name) buckets[currentSection].add(name);
   }
-  return { resources, parameters, outputs };
+  return buckets;
 }
 
 /**
@@ -162,36 +175,39 @@ function collectSubRefs(yaml: string): { refs: string[]; getAtts: string[] } {
   return { refs, getAtts };
 }
 
-function checkTemplate(templatePath: string): Finding[] {
+function checkRequiredDeclarations(
+  templatePath: string,
+  resources: Set<string>,
+  outputs: Set<string>,
+): Finding[] {
   const findings: Finding[] = [];
-  const yaml = readFileSync(templatePath, "utf8");
-  const { resources, parameters, outputs } = parseSections(yaml);
-
-  // 必須 Resource / Output (= ADR-002 Phase 2.1)
   for (const required of REQUIRED_RESOURCE_NAMES) {
-    if (!resources.has(required)) {
-      findings.push({
-        templatePath,
-        rule: "required-resource-missing",
-        detail: `Resources.${required} is required (= ADR-002 Phase 2.1: 全 problem template で参加者 federation 用 Role を宣言する)`,
-      });
-    }
+    if (resources.has(required)) continue;
+    findings.push({
+      templatePath,
+      rule: "required-resource-missing",
+      detail: `Resources.${required} is required (= ADR-002 Phase 2.1: 全 problem template で参加者 federation 用 Role を宣言する)`,
+    });
   }
   for (const required of REQUIRED_OUTPUT_KEYS) {
-    if (!outputs.has(required)) {
-      findings.push({
-        templatePath,
-        rule: "required-output-missing",
-        detail: `Outputs.${required} is required (= sso.ts handler が読む key)`,
-      });
-    }
+    if (outputs.has(required)) continue;
+    findings.push({
+      templatePath,
+      rule: "required-output-missing",
+      detail: `Outputs.${required} is required (= sso.ts handler が読む key)`,
+    });
   }
+  return findings;
+}
 
-  // !Ref / Ref: の resolve
-  const directRefs = collectRefs(yaml);
-  const subRefs = collectSubRefs(yaml);
-  const allRefs = [...directRefs, ...subRefs.refs];
-  for (const ref of allRefs) {
+function checkUnresolvedRefs(
+  templatePath: string,
+  refs: readonly string[],
+  resources: Set<string>,
+  parameters: Set<string>,
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const ref of refs) {
     if (PSEUDO_PARAMETERS.has(ref)) continue;
     if (resources.has(ref) || parameters.has(ref)) continue;
     findings.push({
@@ -200,9 +216,16 @@ function checkTemplate(templatePath: string): Finding[] {
       detail: `Ref: ${ref} — not declared in Resources / Parameters / pseudo`,
     });
   }
+  return findings;
+}
 
-  // !GetAtt の resource 部分
-  const getAttResources = [...collectGetAttResources(yaml), ...subRefs.getAtts];
+function checkUnresolvedGetAttResources(
+  templatePath: string,
+  getAttResources: readonly string[],
+  resources: Set<string>,
+  parameters: Set<string>,
+): Finding[] {
+  const findings: Finding[] = [];
   for (const r of getAttResources) {
     if (PSEUDO_PARAMETERS.has(r)) continue;
     if (resources.has(r) || parameters.has(r)) continue;
@@ -212,8 +235,31 @@ function checkTemplate(templatePath: string): Finding[] {
       detail: `GetAtt ${r}.* — resource not declared`,
     });
   }
-
   return findings;
+}
+
+export type { Finding };
+export { collectGetAttResources, collectRefs, collectSubRefs, parseSections };
+
+export function checkTemplate(templatePath: string): Finding[] {
+  const yaml = readFileSync(templatePath, "utf8");
+  const { resources, parameters, outputs } = parseSections(yaml);
+  const subRefs = collectSubRefs(yaml);
+  return [
+    ...checkRequiredDeclarations(templatePath, resources, outputs),
+    ...checkUnresolvedRefs(
+      templatePath,
+      [...collectRefs(yaml), ...subRefs.refs],
+      resources,
+      parameters,
+    ),
+    ...checkUnresolvedGetAttResources(
+      templatePath,
+      [...collectGetAttResources(yaml), ...subRefs.getAtts],
+      resources,
+      parameters,
+    ),
+  ];
 }
 
 function findTemplates(): string[] {
@@ -254,4 +300,4 @@ function main(): void {
   process.exit(1);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

- `scripts/check-template-cfn-refs.ts` の `parseSections` (= cognitive complexity 20) と `checkTemplate` (= 18) が biome max 15 超過。
- 純粋関数を 4 つ抽出 + section header 検出を helper 化:
  - `detectSectionHeader(line)` — section header / "exit" / 非 header の 3 値判定
  - `checkRequiredDeclarations(templatePath, resources, outputs)` — `ParticipantViewerRole` / `ParticipantViewerRoleArn` 必須宣言
  - `checkUnresolvedRefs(templatePath, refs, resources, parameters)` — `!Ref` / `Ref:` の resolve
  - `checkUnresolvedGetAttResources(templatePath, getAttResources, resources, parameters)` — `!GetAtt` の resource resolve
- `parseSections` は `detectSectionHeader` を使い state machine が flat に。 `checkTemplate` は 3 helper を compose するだけ。
- 新たに `parseSections` / `collectRefs` / `collectGetAttResources` / `collectSubRefs` を export 化し unit test を 5 件追加。 既存 2 件の smoke test は無修正で pass。
- `import.meta.main` で `main()` 実行を guard し、 test が import しても script が副作用で動かないようにした。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/infrastructure test -- check-template-cfn-refs` (= 8 tests pass: 旧 3 + 新 5)
- `bunx biome check scripts/check-template-cfn-refs.ts` (= 2 complexity warnings 解消)
- `make harness` (= no findings)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / template security / **CFn refs**: 5 template OK / audit-deps / cdk synth すべて OK)

## Regression 分析

- **`parseSections` の挙動**: state machine の構造を保持。 `Resources:` / `Parameters:` / `Outputs:` の header 検出 + 他 top-level section で抜ける挙動を pin する unit test を追加 (= `Conditions:` を挟んで `Resources:` が再開する case 含む)。
- **`checkTemplate` の挙動**: 旧コードでは findings を 1 つの配列に for-loop で push、 新コードでは 3 つの pure helper の return を spread で結合。 順序は同一 (= required declarations → refs → getAtts)。
- **`detectSectionHeader` の追加**: 3 セクションの regex chain + その他 top-level の判定を 1 関数に集約。 旧コードと意味的に等価。
- **`import.meta.main` guard**: bun / node ESM の標準。 `bun run scripts/check-template-cfn-refs.ts` で実行されたときは `main()` を呼ぶ、 import されたときは呼ばない。 既存 spawn-based smoke test は影響なし (= 子 process では `import.meta.main === true`)。
- **export 追加**: `parseSections` / `collectRefs` / `collectGetAttResources` / `collectSubRefs` / `Finding` 型を export。 既存 caller は無 (= script は CLI から `bun run` で呼ばれていたのみ)、 新規 import path が現れただけ。
- **生成 CFn / runtime 挙動**: 完全に identical (= 本 script は静的検証ツールで AWS resource を作らない)。

## 物理影響

- **CREATE**: なし。
- **UPDATE**:
  - `scripts/check-template-cfn-refs.ts` (= parseSections / checkTemplate を refactor、 4 helper 抽出、 4 関数 + 1 型を export、 `import.meta.main` guard 追加)
  - `infrastructure/test/scripts/check-template-cfn-refs.test.ts` (= 新 helper の unit test 5 件追加、 既存 3 件 unchanged)
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / CFn / IAM 不変。 観察可能な script 挙動不変 (= 同じ exit code / 同じ stdout / stderr message)。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests verifying CloudFormation template reference validation, including resource and parameter reference capture, attribute getter handling, and variable substitution patterns.

* **Refactor**
  * Improved internal template validation tooling with enhanced modularity and testability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->