### PR TITLE
refactor(scripts): split check-template-security IAM + SG helpers

### DIFF
--- a/infrastructure/test/scripts/check-template-security.test.ts
+++ b/infrastructure/test/scripts/check-template-security.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  findIamActionWildcardFindings,
+  findIamResourceWildcardFindings,
+  findSgOpenNonWebFinding,
+} from "../../../scripts/check-template-security";
+
+/**
+ * Issue #869 / #1124: pre-deploy security scanner の helper を pin する。
+ *
+ * `checkIamWildcards` / `checkSgIngress` から抽出した pure helper を直接 unit-test し、
+ * 「危険パターンを正しく拾う」 「allowlist で誤検出しない」 という規約を docs / regression
+ * の両面で固定する。
+ */
+
+const PATH = "problems/test/template.yaml";
+
+describe("check-template-security helpers (#869 + #1124)", () => {
+  describe("findIamActionWildcardFindings", () => {
+    it('Action: "*" を 1 件以上含むなら finding を返すべき', () => {
+      const findings = findIamActionWildcardFindings(PATH, "Resources.A.Properties", ["*"]);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("iam-action-wildcard");
+    });
+
+    it('Action 配列に "*" が無ければ 0 件にすべき', () => {
+      expect(findIamActionWildcardFindings(PATH, "loc", ["s3:GetObject", "s3:PutObject"])).toEqual(
+        [],
+      );
+    });
+
+    it('複数の "*" は複数 finding として返すべき (= 同 statement 内重複も検出)', () => {
+      expect(findIamActionWildcardFindings(PATH, "loc", ["*", "*", "s3:GetObject"])).toHaveLength(
+        2,
+      );
+    });
+  });
+
+  describe("findIamResourceWildcardFindings", () => {
+    it('Resource: "*" + allowlist 外の action なら finding を返すべき', () => {
+      const findings = findIamResourceWildcardFindings(PATH, "loc", ["*"], ["s3:DeleteObject"]);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("iam-resource-wildcard");
+      expect(findings[0]?.detail).toContain("s3:DeleteObject");
+    });
+
+    it('Resource: "*" + allowlist 内 action だけなら finding を返さないべき', () => {
+      const findings = findIamResourceWildcardFindings(
+        PATH,
+        "loc",
+        ["*"],
+        ["ec2:DescribeRegions", "sts:GetCallerIdentity"],
+      );
+      expect(findings).toEqual([]);
+    });
+
+    it('Resource: "*" が無ければ 0 件にすべき (= scoped ARN は OK)', () => {
+      expect(
+        findIamResourceWildcardFindings(
+          PATH,
+          "loc",
+          ["arn:aws:s3:::my-bucket/*"],
+          ["s3:GetObject"],
+        ),
+      ).toEqual([]);
+    });
+
+    it('Resource: "*" + action 空配列なら finding を返すべき (= allowlist 判定不能)', () => {
+      const findings = findIamResourceWildcardFindings(PATH, "loc", ["*"], []);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.detail).toContain("Resource");
+    });
+  });
+
+  describe("findSgOpenNonWebFinding", () => {
+    it("0.0.0.0/0 から 80/443 以外への ingress は finding を返すべき", () => {
+      const finding = findSgOpenNonWebFinding(PATH, "Sg", 0, {
+        CidrIp: "0.0.0.0/0",
+        FromPort: 22,
+      });
+      expect(finding?.rule).toBe("sg-open-non-web");
+      expect(finding?.detail).toContain("port 22");
+    });
+
+    it("0.0.0.0/0 + 80 / 443 は finding を返さないべき (= 競技 web は OK)", () => {
+      expect(
+        findSgOpenNonWebFinding(PATH, "Sg", 0, { CidrIp: "0.0.0.0/0", FromPort: 80 }),
+      ).toBeUndefined();
+      expect(
+        findSgOpenNonWebFinding(PATH, "Sg", 0, { CidrIp: "0.0.0.0/0", FromPort: 443 }),
+      ).toBeUndefined();
+    });
+
+    it("CidrIp が 0.0.0.0/0 でないなら finding を返さないべき", () => {
+      expect(
+        findSgOpenNonWebFinding(PATH, "Sg", 0, { CidrIp: "10.0.0.0/8", FromPort: 22 }),
+      ).toBeUndefined();
+    });
+
+    it("FromPort が string でも number に変換して判定すべき", () => {
+      const finding = findSgOpenNonWebFinding(PATH, "Sg", 1, {
+        CidrIp: "0.0.0.0/0",
+        FromPort: "22",
+      });
+      expect(finding?.location).toBe("Resources.Sg.Properties.SecurityGroupIngress[1]");
+    });
+  });
+});

--- a/scripts/check-template-security.ts
+++ b/scripts/check-template-security.ts
@@ -110,65 +110,98 @@ function visit(
   }
 }
 
+function toArrayField(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value === undefined) return [];
+  return [value];
+}
+
+export function findIamActionWildcardFindings(
+  templatePath: string,
+  loc: string,
+  actions: readonly unknown[],
+): Finding[] {
+  return actions
+    .filter((a) => a === "*")
+    .map(() => ({
+      templatePath,
+      rule: "iam-action-wildcard",
+      location: loc,
+      detail: `Action "*" is a full-admin grant; scope to specific service actions`,
+    }));
+}
+
+export function findIamResourceWildcardFindings(
+  templatePath: string,
+  loc: string,
+  resources: readonly unknown[],
+  actions: readonly unknown[],
+): Finding[] {
+  if (!resources.includes("*")) return [];
+  const actionList = actions.map((a) => (typeof a === "string" ? a : "")).filter(Boolean);
+  const allRequireStar =
+    actionList.length > 0 && actionList.every((a) => RESOURCE_STAR_OK_ACTIONS.has(a));
+  if (allRequireStar) return [];
+  return [
+    {
+      templatePath,
+      rule: "iam-resource-wildcard",
+      location: loc,
+      detail: `Resource "*" with actions [${actionList.join(", ")}] is broader than required. Scope to specific ARNs, or add the action to RESOURCE_STAR_OK_ACTIONS allowlist if AWS API requires "*".`,
+    },
+  ];
+}
+
 function checkIamWildcards(template: unknown, results: Finding[], templatePath: string): void {
   visit(template, "", (loc, node) => {
     if (!isPlainObject(node)) return;
     // Action / Resource は IAM Statement entry の field。 Statement に近い文脈のみ拾う。
     if (!("Action" in node) && !("Resource" in node)) return;
-    const action = node.Action;
-    const actions = Array.isArray(action) ? action : action !== undefined ? [action] : [];
-    for (const a of actions) {
-      if (a === "*") {
-        results.push({
-          templatePath,
-          rule: "iam-action-wildcard",
-          location: loc,
-          detail: `Action "*" is a full-admin grant; scope to specific service actions`,
-        });
-      }
-    }
-    const resource = node.Resource;
-    const resources = Array.isArray(resource) ? resource : resource !== undefined ? [resource] : [];
-    // Resource: "*" の場合、 Action が AWS-side で require "*" な read-only API のみで構成
-    // されているなら許容。 1 つでも require "*" 外があれば警告。
-    if (resources.includes("*")) {
-      const actionList = actions.map((a) => (typeof a === "string" ? a : "")).filter(Boolean);
-      const allRequireStar =
-        actionList.length > 0 && actionList.every((a) => RESOURCE_STAR_OK_ACTIONS.has(a));
-      if (!allRequireStar) {
-        results.push({
-          templatePath,
-          rule: "iam-resource-wildcard",
-          location: loc,
-          detail: `Resource "*" with actions [${actionList.join(", ")}] is broader than required. Scope to specific ARNs, or add the action to RESOURCE_STAR_OK_ACTIONS allowlist if AWS API requires "*".`,
-        });
-      }
-    }
+    const actions = toArrayField(node.Action);
+    const resources = toArrayField(node.Resource);
+    results.push(...findIamActionWildcardFindings(templatePath, loc, actions));
+    results.push(...findIamResourceWildcardFindings(templatePath, loc, resources, actions));
   });
 }
 
-function checkSgIngress(template: unknown, results: Finding[], templatePath: string): void {
+function* iterateResourcesOfType(
+  template: unknown,
+  type: string,
+): Generator<[name: string, props: Record<string, unknown> | undefined]> {
   const resources =
     isPlainObject(template) && isPlainObject(template.Resources) ? template.Resources : {};
   for (const [name, res] of Object.entries(resources)) {
     if (!isPlainObject(res)) continue;
-    if (res.Type !== "AWS::EC2::SecurityGroup") continue;
-    const props = isPlainObject(res.Properties) ? res.Properties : undefined;
-    const ingress =
-      props && Array.isArray(props.SecurityGroupIngress) ? props.SecurityGroupIngress : [];
+    if (res.Type !== type) continue;
+    yield [name, isPlainObject(res.Properties) ? res.Properties : undefined];
+  }
+}
+
+export function findSgOpenNonWebFinding(
+  templatePath: string,
+  sgName: string,
+  index: number,
+  rule: Record<string, unknown>,
+): Finding | undefined {
+  const cidr = rule.CidrIp;
+  const fromPort = typeof rule.FromPort === "number" ? rule.FromPort : Number(rule.FromPort);
+  if (cidr !== "0.0.0.0/0" || WEB_PORTS.has(fromPort)) return undefined;
+  return {
+    templatePath,
+    rule: "sg-open-non-web",
+    location: `Resources.${sgName}.Properties.SecurityGroupIngress[${index}]`,
+    detail: `0.0.0.0/0 ingress to port ${fromPort} (= non-web). Scope to specific CIDR or restrict to 80/443.`,
+  };
+}
+
+function checkSgIngress(template: unknown, results: Finding[], templatePath: string): void {
+  for (const [name, props] of iterateResourcesOfType(template, "AWS::EC2::SecurityGroup")) {
+    const ingress = Array.isArray(props?.SecurityGroupIngress) ? props.SecurityGroupIngress : [];
     for (let i = 0; i < ingress.length; i++) {
       const rule = ingress[i];
       if (!isPlainObject(rule)) continue;
-      const cidr = rule.CidrIp;
-      const fromPort = typeof rule.FromPort === "number" ? rule.FromPort : Number(rule.FromPort);
-      if (cidr === "0.0.0.0/0" && !WEB_PORTS.has(fromPort)) {
-        results.push({
-          templatePath,
-          rule: "sg-open-non-web",
-          location: `Resources.${name}.Properties.SecurityGroupIngress[${i}]`,
-          detail: `0.0.0.0/0 ingress to port ${fromPort} (= non-web). Scope to specific CIDR or restrict to 80/443.`,
-        });
-      }
+      const finding = findSgOpenNonWebFinding(templatePath, name, i, rule);
+      if (finding) results.push(finding);
     }
   }
 }
@@ -297,4 +330,4 @@ function main(): void {
   process.exit(1);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

- `scripts/check-template-security.ts` の `checkIamWildcards` (cognitive complexity 26) と `checkSgIngress` (24) が biome max 15 超過。
- 純粋関数 3 + iteration helper 1 を抽出して責務を分離:
  - `toArrayField(value)` — field 値を array に正規化
  - `findIamActionWildcardFindings(path, loc, actions)` — `Action: \"*\"` 検出
  - `findIamResourceWildcardFindings(path, loc, resources, actions)` — `Resource: \"*\"` + allowlist 判定
  - `iterateResourcesOfType(template, type)` — `Resources.<Type>` の generator
  - `findSgOpenNonWebFinding(path, sgName, idx, rule)` — `0.0.0.0/0` ingress 検出
- `checkIamWildcards` は visit() callback 内で 2 helper を呼ぶだけになり、 `checkSgIngress` は `iterateResourcesOfType` を使い nested for が flat に。
- 3 helper を export 化し unit test を 11 件追加 (= 既存 helper test 無、 全 新規)。
- `import.meta.main` で `main()` を guard し、 test が import しても script が副作用で動かないようにした。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/infrastructure test -- check-template-security` (= 11 tests pass、 全 新規)
- `bunx biome check scripts/check-template-security.ts` (= 2 complexity warnings 解消)
- `make harness` (= no findings)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / **template security**: 5 template OK / CFn refs / audit-deps / cdk synth すべて OK)

## Regression 分析

- **`checkIamWildcards` の挙動**: 旧コードは visit() callback 内で Action / Resource を順に処理し、 1 つの \`Action: \"*\"\` で 1 finding、 \`Resource: \"*\"\` + 非 allowlist action で 1 finding を push。 新コードでは同じ判定を 2 pure helper に切り出し、 callback は単に results に concat するだけ。 statement 内の重複 `\"*\"` も同じく N 件 finding を返すことを test で固定。
- **`checkSgIngress` の挙動**: 旧コードは Resources を全走査し `Type === \"AWS::EC2::SecurityGroup\"` を filter してから ingress を走査。 新コードは `iterateResourcesOfType(template, \"AWS::EC2::SecurityGroup\")` で同じ filter を一段引き上げただけ。 0.0.0.0/0 + 非 web port の finding は `findSgOpenNonWebFinding` に切り出し、 既存挙動を pin する test を追加 (= web port 80/443 は通過、 string FromPort も number に変換)。
- **export 追加**: 3 helper を export。 既存 caller 無 (= script は CLI から `bun run` で呼ばれていたのみ)。
- **`import.meta.main` guard**: bun / node ESM の標準。 子 process で実行されると `true`、 import されると `false`。 既存 `bun run scripts/check-template-security.ts` 経路は影響なし。
- **scan 検出結果**: 既存 5 template での scan 結果が PR 前後で identical (= `OK: 5 template(s) スキャン、 危険パターン 0 件`)。 同 finding 順序・同 detail 文字列が出ることを before-commit で確認。
- **AWS リソース / runtime 挙動**: 完全に identical (= 本 script は静的検証ツール)。

## 物理影響

- **CREATE**: `infrastructure/test/scripts/check-template-security.test.ts` (= 11 件の helper unit test)。
- **UPDATE**: `scripts/check-template-security.ts` (= 4 helper + 1 generator 抽出、 3 helper を export、 `import.meta.main` guard 追加、 既存 visit() / scanTemplate 動作不変)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / CFn / IAM 不変。 観察可能な script 挙動不変 (= 同じ exit code / 同じ stdout / stderr message)。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)