### PR TITLE
refactor(scripts): split audit-dependencies iteration helpers

### DIFF
--- a/scripts/audit-dependencies.ts
+++ b/scripts/audit-dependencies.ts
@@ -72,25 +72,49 @@ function safeIsDirectory(path: string): boolean {
   }
 }
 
-function scanNodeModules(rootNodeModules: string): readonly Finding[] {
-  if (!existsSync(rootNodeModules)) return [];
-  const findings: Finding[] = [];
+interface PackageDirEntry {
+  readonly pkgDir: string;
+  readonly expectedName: string;
+}
+
+/**
+ * `@scope/` ディレクトリ配下の packages を列挙する。 metadata dir / non-dir は skip。
+ */
+function* iterateScopedPackageDirs(
+  scopeDir: string,
+  scopeName: string,
+): Generator<PackageDirEntry> {
+  for (const scoped of readdirSync(scopeDir)) {
+    if (scoped.startsWith(".")) continue;
+    const pkgPath = join(scopeDir, scoped);
+    if (!safeIsDirectory(pkgPath)) continue;
+    yield { pkgDir: pkgPath, expectedName: `${scopeName}/${scoped}` };
+  }
+}
+
+/**
+ * `node_modules/<pkg>` または `node_modules/@scope/<pkg>` の package dir を順に列挙する。
+ * `.` で始まる metadata dir (= `.bin` / `.cache` 等) や non-directory entry は skip。
+ */
+function* iterateInstalledPackageDirs(rootNodeModules: string): Generator<PackageDirEntry> {
+  if (!existsSync(rootNodeModules)) return;
   for (const entry of readdirSync(rootNodeModules)) {
     if (entry.startsWith(".")) continue;
     const entryPath = join(rootNodeModules, entry);
     if (!safeIsDirectory(entryPath)) continue;
     if (entry.startsWith("@")) {
-      for (const scoped of readdirSync(entryPath)) {
-        if (scoped.startsWith(".")) continue;
-        const pkgPath = join(entryPath, scoped);
-        if (!safeIsDirectory(pkgPath)) continue;
-        const f = inspectPackage(pkgPath, `${entry}/${scoped}`);
-        if (f) findings.push(f);
-      }
+      yield* iterateScopedPackageDirs(entryPath, entry);
     } else {
-      const f = inspectPackage(entryPath, entry);
-      if (f) findings.push(f);
+      yield { pkgDir: entryPath, expectedName: entry };
     }
+  }
+}
+
+function scanNodeModules(rootNodeModules: string): readonly Finding[] {
+  const findings: Finding[] = [];
+  for (const { pkgDir, expectedName } of iterateInstalledPackageDirs(rootNodeModules)) {
+    const f = inspectPackage(pkgDir, expectedName);
+    if (f) findings.push(f);
   }
   return findings;
 }
@@ -134,26 +158,48 @@ function readRootPackage(): PackageJson {
   }
 }
 
+/**
+ * `<wsPath>/package.json` を読み name を返す。 存在 / parse 失敗時は undefined。
+ */
+function readPackageNameAt(wsPath: string): string | undefined {
+  const pkgJson = join(wsPath, "package.json");
+  if (!existsSync(pkgJson)) return undefined;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJson, "utf8")) as PackageJson;
+    return pkg.name;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * apps/* / packages/* / infrastructure の各 workspace package dir を列挙する。
+ * `infrastructure` だけは 1 package、 残り 2 つは subdir ごとに 1 package。
+ */
+function* iterateWorkspacePackageDirs(): Generator<string> {
+  const groups: readonly { readonly dir: string; readonly singlePackage: boolean }[] = [
+    { dir: "apps", singlePackage: false },
+    { dir: "packages", singlePackage: false },
+    { dir: "infrastructure", singlePackage: true },
+  ];
+  for (const { dir, singlePackage } of groups) {
+    const base = join(REPO_ROOT, dir);
+    if (!existsSync(base) || statSync(base).isFile()) continue;
+    if (singlePackage) {
+      yield base;
+      continue;
+    }
+    for (const entry of readdirSync(base)) yield join(base, entry);
+  }
+}
+
 function listWorkspacePackages(): readonly string[] {
   const names: string[] = [];
   const root = readRootPackage();
   if (root.name) names.push(root.name);
-  for (const dir of ["apps", "packages", "infrastructure"]) {
-    const base = join(REPO_ROOT, dir);
-    if (!existsSync(base)) continue;
-    if (statSync(base).isFile()) continue;
-    const entries = dir === "infrastructure" ? ["."] : readdirSync(base);
-    for (const entry of entries) {
-      const wsPath = dir === "infrastructure" ? base : join(base, entry);
-      const pkgJson = join(wsPath, "package.json");
-      if (!existsSync(pkgJson)) continue;
-      try {
-        const pkg = JSON.parse(readFileSync(pkgJson, "utf8")) as PackageJson;
-        if (pkg.name) names.push(pkg.name);
-      } catch {
-        // ignore
-      }
-    }
+  for (const wsPath of iterateWorkspacePackageDirs()) {
+    const name = readPackageNameAt(wsPath);
+    if (name) names.push(name);
   }
   return names;
 }


### PR DESCRIPTION
## Summary

- `scripts/audit-dependencies.ts` の `scanNodeModules` (cognitive complexity 27) と `listWorkspacePackages` (22) が biome max 15 超過。
- 純粋 generator + helper を 3 つ抽出して責務分離:
  - `iterateScopedPackageDirs(scopeDir, scopeName)` — `@scope/<pkg>` の subdir 列挙
  - `iterateInstalledPackageDirs(rootNodeModules)` — flat + @scope 統合 generator
  - `readPackageNameAt(wsPath)` — workspace `package.json` から name 抽出
  - `iterateWorkspacePackageDirs()` — apps / packages / infrastructure 統合
- `scanNodeModules` / `listWorkspacePackages` はそれぞれ generator を for-of で回すだけになり、 nested branching が消える。
- 内部 helper のみで public API (= `runAudit` / `AuditOutcome`) は不変。 既存 7 件の test が無修正で pass。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/infrastructure test -- audit-dependencies` (= 7 tests pass、 既存 fake node_modules integration test を継続)
- `bunx biome check scripts/audit-dependencies.ts` (= 2 complexity warnings 解消)
- `make harness` (= no findings)
- `make before-commit` (= lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / **audit-deps** / cdk synth すべて OK)

## Regression 分析

- **`scanNodeModules` の挙動**: 旧コードは flat package と `@scope/<pkg>` を 1 関数内で分岐 (= if-else) で処理し、 各々 `inspectPackage` を呼んで Finding を集めていた。 新コードは `iterateInstalledPackageDirs` generator が同じ 2 経路を統一して `{ pkgDir, expectedName }` を yield、 呼び出し側はそれを for-of で回すだけ。 `inspectPackage` 呼び出し回数 / 引数 / 順序すべて identical。
- **`listWorkspacePackages` の挙動**: 旧コードは `apps` / `packages` (= subdir 列挙) と `infrastructure` (= 単 package) を if 分岐していた。 新コードは `iterateWorkspacePackageDirs` generator が `{ dir, singlePackage }` table をループし同じ列挙順を yield。 root package.json の name を先頭に追加する挙動も保持。
- **`@scope/<pkg>` の追加分割**: cognitive complexity を更に下げるため `iterateScopedPackageDirs` を分離。 セマンティクスは旧コードと同一 (= `.` 始まり skip / non-dir skip / `${scope}/${name}` 形式の expectedName)。
- **public API**: `runAudit` / `AuditOutcome` / `BaselineSnapshot` / `Finding` / `DiffResult` 全 unchanged。 既存 fake node_modules integration test 7 件が無修正で pass。
- **production node_modules scan 結果**: `OK 0 package(s) with install-time lifecycle scripts. No new packages or hooks vs baseline.` (= PR 前後で identical)。
- **AWS リソース / runtime 挙動**: 完全に identical (= 本 script は CI 中の静的監査ツール)。

## 物理影響

- **CREATE**: なし。
- **UPDATE**: `scripts/audit-dependencies.ts` (= 2 既存関数を helper + generator に分解、 public API 不変)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / CFn / IAM / baseline.json 不変。 観察可能な script 挙動不変 (= 同じ exit code / 同じ stdout / stderr message)。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)