### PR TITLE
refactor(admin): split toFriendlyError ApiError branch

### DIFF
--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -173,30 +173,28 @@ function extractErrorCode(envelope: BackendErrorEnvelope): string | null {
  * - 未知の code でも、 raw JSON は drop して title だけ表示
  * - HTTP status code は title に併記 (= 422 / 500 / 等を operator が判別可能に)
  */
+function fromBackendEnvelope(status: number, envelope: BackendErrorEnvelope): FriendlyError {
+  const code = extractErrorCode(envelope);
+  if (code && KNOWN_ERRORS[code]) return KNOWN_ERRORS[code];
+  const msg = typeof envelope.message === "string" ? envelope.message : undefined;
+  const codeOrMsg = code ?? msg;
+  return {
+    title: codeOrMsg ? `エラー (${status}) — ${codeOrMsg}` : `エラー (${status})`,
+    hint: code && msg ? msg : undefined,
+  };
+}
+
+function fromApiError(err: ApiError): FriendlyError {
+  const envelope = extractBackendEnvelope(err.message);
+  if (envelope) return fromBackendEnvelope(err.status, envelope);
+  return {
+    title: `エラー (${err.status})`,
+    hint: err.message.replace(/^API \d+:\s*/, "").trim() || undefined,
+  };
+}
+
 export function toFriendlyError(err: unknown): FriendlyError {
-  if (err instanceof ApiError) {
-    const envelope = extractBackendEnvelope(err.message);
-    if (envelope) {
-      const code = extractErrorCode(envelope);
-      if (code && KNOWN_ERRORS[code]) {
-        return KNOWN_ERRORS[code];
-      }
-      // title に code (or message) を併記、 hint には message が code と異なる時のみ詰める
-      // (= title と hint で同じ文字列を表示しないため)。
-      const msg = typeof envelope.message === "string" ? envelope.message : undefined;
-      const codeOrMsg = code ?? msg;
-      return {
-        title: codeOrMsg ? `エラー (${err.status}) — ${codeOrMsg}` : `エラー (${err.status})`,
-        hint: code && msg ? msg : undefined,
-      };
-    }
-    return {
-      title: `エラー (${err.status})`,
-      hint: err.message.replace(/^API \d+:\s*/, "").trim() || undefined,
-    };
-  }
-  if (err instanceof Error) {
-    return { title: err.message };
-  }
+  if (err instanceof ApiError) return fromApiError(err);
+  if (err instanceof Error) return { title: err.message };
   return { title: String(err) };
 }


### PR DESCRIPTION
## Summary

- `apps/application-admin-console/src/lib/friendly-error.ts` の `toFriendlyError` が cognitive complexity 20 で biome max 15 超過。
- ApiError 分岐内の envelope handling を 2 helper に切り出し、 メイン関数は 3 分岐 (= ApiError / Error / unknown) の dispatch のみ:
  - `fromBackendEnvelope(status, envelope)` — `KNOWN_ERRORS` lookup + title/hint 構築
  - `fromApiError(err)` — envelope 有無で 2 経路を 1 関数に集約
- 既存 14 件の test が無修正で pass。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/application-admin-console test -- friendly-error` (= 14 tests pass)
- `bunx biome check apps/application-admin-console/src/lib/friendly-error.ts` (= complexity warning 解消)
- `make before-commit` (= lint / typecheck / test / build (= cdk synth) / audit-deps すべて OK)

## Regression 分析

- **`toFriendlyError` の output**: 旧コードと同じ 4 経路を保持: (a) ApiError + envelope + KNOWN code → KNOWN_ERRORS から (b) ApiError + envelope + 未知 code → \`エラー (status) — code\` + hint=msg (c) ApiError + envelope なし → \`エラー (status)\` + hint=cleaned message (d) Error / unknown → message のまま。 全 4 経路を既存 14 test が網羅。
- **BackendErrorEnvelope type 保持**: `fromBackendEnvelope` の引数型を `BackendErrorEnvelope` のまま保ち、 caller の `Record<string, unknown>` への暗黙 cast を避ける (= tsc error TS2345 回避)。
- **observable behavior**: 全ての error → UI 表示 mapping は完全に identical。

## 物理影響

- **CREATE**: なし。
- **UPDATE**: `apps/application-admin-console/src/lib/friendly-error.ts` (= toFriendlyError を 2 helper に分解)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / CFn / IAM / runtime 動作 / UI 表示すべて不変。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)