### PR TITLE
refactor(admin): extract describeArchiveError from EventList

### DIFF
--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -98,6 +98,24 @@ function buildColumns(ctx: ColumnContext): TableProps.ColumnDefinition<EventSumm
   ];
 }
 
+type TFn = (key: string) => string;
+
+/**
+ * Archive 失敗時の error を user 向け文字列に整形する。 409 は CFn の `currentStatus` から
+ * 「DRAFT で archive できない」 「READY のままで archive できない」 等の文脈付き message を
+ * 出す。 それ以外は generic な Error message を流す。
+ */
+export function describeArchiveError(err: unknown, name: string, t: TFn): string {
+  if (err instanceof ApiError && err.status === StatusCodes.CONFLICT) {
+    const match = err.message.match(/"currentStatus"\s*:\s*"([A-Z_]+)"/);
+    const current = match?.[1];
+    return current
+      ? interpolate(t("event_list.archive_conflict_known"), { name, current })
+      : interpolate(t("event_list.archive_conflict_unknown"), { name });
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function EventListPage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
   const navigate = useNavigate();
@@ -157,17 +175,7 @@ export function EventListPage({ config }: { config: AppConfig }) {
       await archive(apiClient, target.eventId);
       await fetchOnce();
     } catch (err) {
-      if (err instanceof ApiError && err.status === StatusCodes.CONFLICT) {
-        const match = err.message.match(/"currentStatus"\s*:\s*"([A-Z_]+)"/);
-        const current = match?.[1];
-        setError(
-          current
-            ? interpolate(t("event_list.archive_conflict_known"), { name: target.name, current })
-            : interpolate(t("event_list.archive_conflict_unknown"), { name: target.name }),
-        );
-      } else {
-        setError(err instanceof Error ? err.message : String(err));
-      }
+      setError(describeArchiveError(err, target.name, t));
     } finally {
       setArchivingId(null);
     }


### PR DESCRIPTION
## Summary

- `handleArchiveConfirm` (cognitive complexity 19) が biome max 15 超過。
- 409 currentStatus 抽出 + i18n message 整形を `describeArchiveError(err, name, t)` helper に切り出し、 主体は archive + setError 制御のみに。 helper を export 化。

Relates #1124

## Test plan

- `bun run --filter @TenkaCloud/application-admin-console test -- EventList` (= 既存 test 無修正で pass)
- `bunx biome check apps/application-admin-console/src/pages/EventList.tsx` (= complexity 解消)
- `make before-commit` (= lint / typecheck / test / build / cdk synth すべて OK)

## Regression 分析

- **挙動完全保存**: 409 currentStatus 抽出 / archive_conflict_known / archive_conflict_unknown / generic Error message の 4 経路を helper に集約。 既存 EventList integration test (archive 系) が無修正で pass。
- **export 追加**: `describeArchiveError` を export し将来別 EventList sibling で再利用可能に。

## 物理影響

- **CREATE**: なし。
- **UPDATE**: `apps/application-admin-console/src/pages/EventList.tsx` (= describeArchiveError helper を抽出、 handleArchiveConfirm を簡素化)。
- **REPLACE / DELETE / NO-OP**: なし。 AWS リソース / runtime / UI 動作不変。
- **CI / CD 影響**: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)