### PR TITLE
docs: translate AGENTS.md / CLAUDE.md / CONTRIBUTING.md to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,133 +1,133 @@
 # AGENTS.md — TenkaCloud
 
-AI エージェント (Claude Code, Codex CLI 等) 向けのガイド。プロダクト全体の正本は @CLAUDE.md。本ファイルは「エージェントとして動くときに守る運用ルール」だけに絞る。
+Guide for AI agents (Claude Code, Codex CLI, etc.). The source of truth for the product as a whole is @CLAUDE.md. This file is scoped to the operational rules an agent should follow while it is acting.
 
-## 役割分担
+## Role split
 
-- **インフラ (CDK / SBT / IAM / `infrastructure/templates/`) はユーザーが書く**。CDK スタック、IAM ポリシー、CFn テンプレートはユーザー判断で進める。提案は OK だが勝手に編集しない。
-- **アプリ (`apps/*`、`scripts/*` の orchestration、`problems/*`) はエージェントが進める**。テストを書き、`make before-commit` を通し、PR を出すところまで一気通貫で。
-- 不明点はまず repo を読む (`git log`, `git diff main...HEAD`, 関連 stack の test)。それでも判断つかないときだけユーザーに問う。
+- **Infrastructure (CDK / SBT / IAM / `infrastructure/templates/`) is the user's responsibility.** CDK stacks, IAM policies, and CFn templates are the user's call. Proposals are fine; do not edit them on your own initiative.
+- **Application code (`apps/*`, `scripts/*` orchestration, `problems/*`) is the agent's responsibility.** Write tests, get `make before-commit` green, and follow it through to a PR end-to-end.
+- When something is unclear, read the repo first (`git log`, `git diff main...HEAD`, related stack tests). Only ask the user when even that is not enough.
 
-## 一気通貫で動く
+## Run end-to-end
 
-中間で「次に進めていいですか？」と止まらない。タスクが完了するまで連続で進めて、最後に結果だけ報告する。途中で軌道修正があれば次の発話で受け取る。
+Don't pause to ask "should I continue?" in the middle. Run continuously until the task is done, then report the result. Course corrections come back in the next message.
 
-次の例外を除く。
+The exceptions are:
 
-- 破壊的操作 (`rm -rf`、`git reset --hard`、強制 push、`make destroy`、本番への deploy)
-- 共有環境への push / PR 作成 / Slack 投稿等の外部副作用
-- シークレット (.env, AWS credentials) を扱う操作
+- Destructive operations (`rm -rf`, `git reset --hard`, force push, `make destroy`, production deploys)
+- Side effects on shared environments — pushing to PR / Slack / external services
+- Anything that touches secrets (`.env`, AWS credentials)
 
-これらは確認を取る。
+For those, ask first.
 
-## 品質ゲート
+## Quality gates
 
-PR 作成前に **この順序で** 通すこと。
+Run the following **in this order** before opening a PR.
 
 ```bash
-make harness         # architecture invariant チェック (docs/architecture/harness.md)
+make harness         # architecture invariant check (docs/architecture/harness.md)
 make before-commit   # lint (markdownlint + textlint + biome) / typecheck / test / validate-problems
-/review              # コードレビュー
-/security-review     # セキュリティレビュー
-/simplify            # 重複・複雑度・効率の最終チェック
+/review              # code review
+/security-review     # security review
+/simplify            # final pass for duplication, complexity, and efficiency
 ```
 
-何か落ちたらコードを直す。設定ファイル (`biome.json`, `vitest.config.ts`, `tsconfig.json`) を直接いじって誤魔化さない。
+If something fails, fix the code. Don't paper over it by editing config files (`biome.json`, `vitest.config.ts`, `tsconfig.json`).
 
-`make harness` が落ちる場合は `docs/architecture/harness.md` の invariant ID と照らし合わせる。harness 自体のテストは `make harness-test`、ハーネスのルールロジックは `.claude/harness/src/architecture.ts` と `tech-debt.ts`。
+If `make harness` fails, cross-reference the invariant ID with `docs/architecture/harness.md`. The harness's own unit tests are `make harness-test`, and the rule logic lives in `.claude/harness/src/architecture.ts` and `tech-debt.ts`.
 
-CI (`.github/workflows/ci.yml`) は `make install_ci` → textlint → format check → typecheck → test → build。ローカル `make before-commit` が通れば CI は通る前提。
+CI (`.github/workflows/ci.yml`) runs `make install_ci` → textlint → format check → typecheck → test → build. If `make before-commit` passes locally, CI passes — that's the contract.
 
-## 利用可能な skills
+## Available skills
 
-`/<skill>` で起動する。実体は `.claude/skills/<skill>/SKILL.md`。
+Invoke as `/<skill>`. Implementations live in `.claude/skills/<skill>/SKILL.md`.
 
-| skill              | 用途                                                                  |
-| ------------------ | --------------------------------------------------------------------- |
-| `/harness`         | `make harness` を走らせて invariant 違反を検出                       |
-| `/tech-debt`       | `make tech-debt` で技術的負債バックログを生成                         |
-| `/create-problem`  | `problems/<category>/<id>/` を `metadata.json` + `template.yaml` で雛形生成 |
-| `/spec`            | Open Web Docs (MDN) スタイルの技術仕様書を書く                       |
+| skill              | Purpose                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `/harness`         | Run `make harness` to detect invariant violations                                       |
+| `/tech-debt`       | Run `make tech-debt` to generate the tech-debt backlog                                  |
+| `/create-problem`  | Scaffold `problems/<category>/<id>/` with the `metadata.json` + `template.yaml` convention |
+| `/spec`            | Write a technical specification in the Open Web Docs (MDN) style                       |
 
-加えて TenkaCloud 関係なく使える共通 skill (`/review`、`/security-review`、`/simplify`、`/init` 等) は Claude Code 本体側に同梱されている。
+In addition, the common skills (`/review`, `/security-review`, `/simplify`, `/init`, etc.) that ship with Claude Code itself are also available; they are not TenkaCloud-specific.
 
-## Codex CLI との併用 (= 総力戦)
+## Working alongside Codex CLI ("total war" mode)
 
-OpenAI の Codex CLI も本 repo を AGENTS.md (本ファイル) 経由で読み込める。 並列に走らせて作業分担する典型パターンは次の通り。
+OpenAI's Codex CLI can also load this repo through this AGENTS.md file. The typical pattern for parallelizing work is:
 
-- **Claude Code** が `apps/*` と `scripts/*` の実装を主導 (= 本ファイルの「役割分担」通り)
-- **Codex CLI** で別ブランチを切り、 cross-cutting concern (= naming refactor / dead code 削除 / 同型 helper の抽出) を並行で進める
-- 結果は別々の PR にし、 conflict は user (= 最終 reviewer) が手で潰す
+- **Claude Code** drives the `apps/*` and `scripts/*` implementation (matches the role split above).
+- **Codex CLI** runs on a separate branch and tackles cross-cutting concerns (naming refactors, dead code removal, helper extraction, etc.) in parallel.
+- Each agent ships its own PR. Conflicts are reconciled by the user (the final reviewer).
 
-Codex CLI を起動する前に次を確認する。
+Before launching Codex CLI, check the following:
 
-1. `make harness` が通る状態であること (= invariant 違反のある branch を渡さない)
-2. 作業範囲を本ファイルの「役割分担」と「禁止事項」に従わせること (= CDK を弄らせない / `rm` 等を実行させない)
-3. Codex の出力 PR にも `## Regression 分析` / `## 物理影響` セクションを書かせること
+1. `make harness` passes (don't hand it a branch with invariant violations)
+2. The work scope respects this file's role split and prohibitions (no CDK edits, no `rm`, etc.)
+3. Codex's PR body must also include the `## Regression analysis` / `## Physical impact` sections
 
-Codex CLI 専用の skill / config は持たない (= AGENTS.md 1 つで両者をガイドする方針)。 Claude Code 側で `.claude/skills/*` を使う subcommand は Codex からは見えないので、 Codex には slash command (`/<skill>`) を要求しない普通の自然言語タスクを与えること。
+We do not maintain Codex CLI-specific skills or config — AGENTS.md alone guides both agents. The `.claude/skills/*` slash commands on the Claude Code side are invisible from Codex, so give Codex plain natural-language tasks that don't require `/<skill>` invocations.
 
-## ブランチと PR
+## Branches and PRs
 
-- **マージ済みブランチに push しない**。PR を出す前に必ず `gh pr view --json state` で state を確認。`MERGED` / `CLOSED` なら新ブランチを切る。
-- 小さな意味単位で PR を分ける。`feat(...)` `fix(...)` `refactor(...)` `docs(...)` `test(...)` `chore(...)` のいずれか (Conventional Commits)。
-- PR タイトルは 70 文字以内。本文に Summary + Test plan を書く。
-- Issue 引用は GitHub の auto-close keyword に揃える:
-  - **解決して閉じる** = `Closes #553` / `Fixes #553` / `Resolves #553` (= merge 時に GitHub が auto-close)
-  - **関連だが閉じない (= partial fix / backlink)** = `Relates #553` または非 keyword 位置で `#553` を書く
-  - **PR 同士の参照** = `PR-565` のように番号 prefix
-  - 旧ルール (= `(#N)` の括弧で auto-close 抑止) は誤解だった。`Closes` などの keyword が無ければ `#N` 単独で auto-close されない (= backlink のみ作る)。
+- **Don't push to a branch whose PR is already merged.** Always confirm state with `gh pr view --json state` before opening a new PR; if it is `MERGED` / `CLOSED`, cut a new branch.
+- Split PRs into small, meaningful units. Title must be one of `feat(...)` `fix(...)` `refactor(...)` `docs(...)` `test(...)` `chore(...)` (Conventional Commits).
+- PR titles are under 70 characters. Put Summary + Test plan in the body.
+- Issue references must align with GitHub's auto-close keywords:
+  - **Close on merge** = `Closes #553` / `Fixes #553` / `Resolves #553` (GitHub auto-closes at merge time)
+  - **Related but doesn't close** (partial fix / backlink) = `Relates #553`, or mention `#553` in a non-keyword position
+  - **PR-to-PR references** = use a `PR-565`-style number prefix
+  - The old rule of wrapping `(#N)` to suppress auto-close was a misunderstanding. Without a keyword like `Closes`, a bare `#N` does **not** auto-close — it just makes a backlink.
 
-## ADR 規約
+## ADR conventions
 
-- ADR は `docs/architecture/adr-*.html` で書く。Markdown の新規 ADR は作らない。row span / color / SVG / collapsible など、HTML の表現力を使って設計判断を正本化する。
-- ADR は self-contained に書く。chat 文脈、順次反映 metadata、`Claude が提案` / `user 担当` のような会話内の役割分担、未確定 TODO を残さない。OSS readers が ADR 単体で背景・判断・影響を理解できることを基準にする。
-- 機械検査は `make harness` の `adr-must-be-html` / `adr-self-contained` rule が担う。既存違反は `.claude/harness/baselines/adr-self-contained.json` で baseline 化し、新規 regression だけを落とす。
+- ADRs live in `docs/architecture/adr-*.html`. Don't create new ADRs in Markdown. Use HTML's expressive features (row spans, color, SVG, collapsible) to make design decisions the source of truth.
+- ADRs must be self-contained. Don't leave chat context, rolling-update metadata, role-split notes like `Claude proposes` / `user owns`, or unresolved TODOs. The benchmark is "an OSS reader can understand background, decision, and impact from this ADR alone."
+- Machine checks live in `make harness` as the `adr-must-be-html` / `adr-self-contained` rules. Existing violations are baselined at `.claude/harness/baselines/adr-self-contained.json` so only new regressions fail.
 
-## コーディング規約
+## Coding rules
 
-- **HTTP status code は `StatusCodes.*` (`http-status-codes` library) を使う**。`c.json(body, 200)` / `res.status === 401` のような数値リテラル直書きは禁止。意図 (200 vs 202、400 vs 409 等) を name で明示し、grep / lint で意味検索を可能にする。
+- **HTTP status codes use `StatusCodes.*` (`http-status-codes` library).** Numeric literals such as `c.json(body, 200)` / `res.status === 401` are forbidden. Names make intent explicit (200 vs 202, 400 vs 409, etc.) and let you grep / lint by meaning.
   - backend: `import { StatusCodes } from "http-status-codes"; return c.json(body, StatusCodes.OK);`
   - frontend: `if (res.status === StatusCodes.UNAUTHORIZED) ...`
-  - legacy alias (`HTTP_OK` 等、`infrastructure/lib/problem-deploy/handlers/shared/http-status.ts`) は deprecated。新規コードでは使わない
+  - The legacy aliases (`HTTP_OK` etc. in `infrastructure/lib/problem-deploy/handlers/shared/http-status.ts`) are deprecated. Don't use them in new code.
 
-## 禁止事項
+## Prohibited
 
-- `npx` → `bunx` または `nlx`
-- `rm` (環境破壊リスク) → `git rm`
-- HTTP status code の数値リテラル直書き — `StatusCodes.*` を使う
-- モック / スタブで握り潰す fallback / 空配列を返して見せかける処理
-- 設定ファイル (`biome.json`, `vitest.config.*`, `tsconfig.json`) の直接編集
-- DynamoDB の on-demand (`PAY_PER_REQUEST`) 化 — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED 強制
-- SSE / WebSocket の新規導入 — Lambda 運用と整合する **polling** で書く
-  - 状態反映の polling 削減は [ADR-014](./docs/architecture/adr-014-eventbridge-driven-state-reconciliation.html) に従い EventBridge 駆動で補完する。frontend polling 方針は維持する
-- シークレットのコミット (`infrastructure/environments/<env>/.env`、AWS credentials)
-- `package.json` の `trustedDependencies` への追加を独断で行わない — supply chain attack の入口になる
+- `npx` → use `bunx` or `nlx`
+- `rm` (risk of nuking the environment) → use `git rm`
+- HTTP status code numeric literals — use `StatusCodes.*`
+- Silent fallbacks via mocks / stubs / empty-array returns
+- Direct edits to config files (`biome.json`, `vitest.config.*`, `tsconfig.json`)
+- On-demand (`PAY_PER_REQUEST`) DynamoDB — the `DynamoDbLowCapacity` Aspect enforces 1/1 PROVISIONED
+- Introducing SSE / WebSocket — write **polling** so it aligns with the Lambda operational model
+  - To reduce polling pressure, supplement with EventBridge-driven reconciliation per [ADR-014](./docs/architecture/adr-014-eventbridge-driven-state-reconciliation.html). The frontend polling policy stays.
+- Committing secrets (`infrastructure/environments/<env>/.env`, AWS credentials)
+- Adding packages to `package.json` `trustedDependencies` on your own — that's a supply chain attack vector
 
-## Supply Chain Security (mini Shai-Hulud 第二波 2026-05 対策)
+## Supply chain security (mini Shai-Hulud 2nd wave, 2026-05)
 
-参考: [blog.flatt.tech/entry/mini_shai_hulud_2nd](https://blog.flatt.tech/entry/mini_shai_hulud_2nd)
+Reference: [blog.flatt.tech/entry/mini_shai_hulud_2nd](https://blog.flatt.tech/entry/mini_shai_hulud_2nd)
 
-防御層は次の 4 段で構成する。
+The four defense layers are:
 
-1. **Bun の `trustedDependencies` モデル**: Bun は transitive dep の lifecycle script を default で実行しない。 root `package.json` の `trustedDependencies` 配列が allowlist (現状空)
-2. **`.npmrc`**: 万一 contributor が npm / yarn / pnpm を使っても自動 fallback で防御するため `ignore-scripts=true` + `min-release-age=168h` (= 7 日 quarantine) を入れる
-3. **CI 監査** (`make audit-deps`): `scripts/audit-dependencies.ts` が `node_modules` 配下を scan し、 lifecycle script (= preinstall / install / postinstall / preprepare / prepare / postprepare) を持つ package を `scripts/audit-baseline.json` と diff。 新規追加 / 既存 dep の hook 追加で CI を fail させる
-4. **CI の `--ignore-scripts` install + Safe Chain**: `make install_ci` は `bun install --frozen-lockfile --ignore-scripts`、 さらに Aikido Safe Chain で悪意 package を検出する
+1. **Bun's `trustedDependencies` model**: Bun does not run transitive lifecycle scripts by default. The root `package.json` `trustedDependencies` array is the allowlist (currently empty).
+2. **`.npmrc`**: To protect contributors who fall back to npm / yarn / pnpm, set `ignore-scripts=true` + `min-release-age=168h` (7-day quarantine).
+3. **CI audit** (`make audit-deps`): `scripts/audit-dependencies.ts` scans under `node_modules`, diffs packages with lifecycle scripts (preinstall / install / postinstall / preprepare / prepare / postprepare) against `scripts/audit-baseline.json`, and fails CI on any new addition or any new hook on an existing dep.
+4. **`--ignore-scripts` install + Safe Chain in CI**: `make install_ci` runs `bun install --frozen-lockfile --ignore-scripts`, plus Aikido Safe Chain to detect malicious packages.
 
-### baseline を更新するとき
+### Updating the baseline
 
-dependency を新規追加 / 更新したとき lifecycle script を持つ新 package が baseline に増えることがある。 次の手順で更新する。
+When adding / updating a dependency, a new package with lifecycle scripts may end up in the baseline. Procedure:
 
-1. 該当 package の `package.json` 内 lifecycle script を実際に読み、 不審な動作 (= curl / wget / OS 識別 / 環境変数 exfil / ファイル書き込み / プロセス spawn) がないことを目視確認
-2. `bun run scripts/audit-dependencies.ts --update` で `scripts/audit-baseline.json` を更新
-3. PR body に「baseline 更新の理由 + 確認した script の要約」を書く
+1. Read the package's `package.json` lifecycle scripts by eye and verify there is no suspicious behavior (`curl` / `wget` / OS detection / env-var exfil / file writes / process spawn)
+2. Run `bun run scripts/audit-dependencies.ts --update` to refresh `scripts/audit-baseline.json`
+3. Document in the PR body the reason for the baseline change and a summary of the scripts you reviewed
 
-特に不審な script (= remote download / OS-level persistence / curl piped to sh) を見たら baseline に入れず PR を停止して報告すること。
+If you see something genuinely suspicious (remote download / OS-level persistence / `curl | sh`), do **not** add it to the baseline — stop the PR and report.
 
 ## TDD
 
-テストを先に書く。テストタイトルは日本語「〜すべき」形式。
+Write tests first. Test titles use the English `should ...` pattern.
 
 ```typescript
 import { Template } from "aws-cdk-lib/assertions";
@@ -135,7 +135,7 @@ import { describe, expect, it } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 
 describe("AdminConsoleHostingStack", () => {
-  it("CloudFront distribution に runtime-config.json が配置されるべき", () => {
+  it("should place runtime-config.json on the CloudFront distribution", () => {
     const app = new App();
     const stack = new AdminConsoleHostingStack(app, "Test", { /* ... */ });
     const template = Template.fromStack(stack);
@@ -144,61 +144,61 @@ describe("AdminConsoleHostingStack", () => {
 });
 ```
 
-CDK の test では `Template.fromStack(stack)` で生成 CFn を assertion する。Lambda handler のユニットテストは `vi.mock` で AWS SDK clients をモックする。
+In CDK tests, assert against the generated CFn via `Template.fromStack(stack)`. For Lambda handler unit tests, mock the AWS SDK clients with `vi.mock`.
 
-## ディレクトリ早見
+## Directory cheat sheet
 
 ```
 apps/
   admin-console/                   # System Admin (Cognito Hosted UI / OAuth Code+PKCE)
   application-admin-console/       # Tenant Admin (per-tenant Application Plane)
-  participant-portal/              # 競技者ポータル (per-team login key)
+  participant-portal/              # Competitor portal (per-team login key)
 infrastructure/
-  bin/infrastructure.ts            # 全 stack の配線
+  bin/infrastructure.ts            # Wiring for every stack
   lib/control-plane-stack.ts       # SBT ControlPlane
   lib/bootstrap-template/          # TenantMappingTable
-  lib/tenant-template/             # 1 tenant の API + Cognito + ApplicationConsole
-  lib/tenant-pipeline/             # CodePipeline 経由の per-tenant provisioning
-  lib/problem-deploy/              # 競技者 AWS への問題 deploy backend
-  lib/admin-console-hosting.ts     # admin-console S3+CloudFront 配信
+  lib/tenant-template/             # One tenant's API + Cognito + ApplicationConsole
+  lib/tenant-pipeline/             # Per-tenant provisioning via CodePipeline
+  lib/problem-deploy/              # Problem deployment backend into competitor AWS
+  lib/admin-console-hosting.ts     # admin-console S3 + CloudFront hosting
   lib/cdk-aspect/                  # DynamoDbLowCapacity / DestroyPolicySetter
   environments/<env>/              # config.json + .env
-  templates/competitor-bootstrap.yaml  # 競技者アカウントで流す IAM Role
+  templates/competitor-bootstrap.yaml  # IAM Role to roll out in the competitor account
 scripts/
-  install.sh                       # 3-phase deploy のオーケストレーション
-  cleanup.sh                       # 冪等な teardown
-  provision-tenant.sh              # CodeBuild から呼ばれる per-tenant deploy
-  deprovision-tenant.sh            # tenant 削除
-problems/<category>/<id>/          # metadata.json + template.yaml が正本
+  install.sh                       # 3-phase deploy orchestration
+  cleanup.sh                       # Idempotent teardown
+  provision-tenant.sh              # Per-tenant deploy invoked from CodeBuild
+  deprovision-tenant.sh            # Tenant teardown
+problems/<category>/<id>/          # metadata.json + template.yaml are the source of truth
 ```
 
-## クロスプレーン契約 (壊さない)
+## Cross-plane contracts (do not break)
 
-- **EventBridge bus** は `ControlPlaneStack` が払い出し、`bin/infrastructure.ts` が他 stack に ARN を渡す。新 stack を追加するときも同じ bus を使う。
-- **Tenant 作成イベント** (`onboardingRequest`) は `ServerlessSaaSPipeline` が拾って per-tenant stack を deploy する。BASIC / STANDARD / PREMIUM は pooled stack を共有、PLATINUM のみ silo stack を立てる。
-- **DeployRequested イベント** は `ProblemDeployBackendStack` の Worker Lambda が拾い、tenant の ExternalId で競技者アカウントに AssumeRole → CFn CreateStack する。**ExternalId は必ず要求** (省略不可)。
-- **Frontend の URL** は `runtime-config.json` (CloudFront 配下) 経由で注入される。`apps/*/src/config.ts` に `loadConfig()` がある。新しい URL を追加するときは hosting stack の env と config.ts の interface を両方更新する。
+- **EventBridge bus** is provisioned by `ControlPlaneStack`; `bin/infrastructure.ts` hands the ARN to every other stack. New stacks must use the same bus.
+- **Tenant creation event** (`onboardingRequest`) is picked up by `ServerlessSaaSPipeline`, which deploys the per-tenant stack. BASIC / STANDARD / PREMIUM share the pooled stack; only PLATINUM gets a silo stack.
+- **DeployRequested event** is picked up by the `ProblemDeployBackendStack` Worker Lambda, which AssumeRoles into the competitor account using the tenant's ExternalId and runs CFn CreateStack. **`ExternalId` is always required** (no omission allowed).
+- **Frontend URLs** are injected through `runtime-config.json` (served under CloudFront). `apps/*/src/config.ts` has a `loadConfig()`. When you add a new URL, update both the hosting stack env and the `config.ts` interface.
 
-## Problem Authoring (ADR-012)
+## Problem authoring (ADR-012)
 
-新しい問題を追加するときの正本は次の 3 点です。
+The three sources of truth when adding a problem are:
 
-- **正本 schema**: [`problems/SCHEMA.json`](./problems/SCHEMA.json) — `metadata.json` の JSON Schema
-- **30 分 onboarding guide**: [`docs/problems/AUTHORING.html`](./docs/problems/AUTHORING.html) — step-by-step + 5 kind の決定木 + 実例 4 問
-- **Claude Code skill**: `.claude/skills/create-problem/SKILL.md` — `/create-problem` で起動、要件ヒアリング → 雛形生成 → metadata 編集まで誘導
+- **Schema source of truth**: [`problems/SCHEMA.json`](./problems/SCHEMA.json) — JSON Schema for `metadata.json`
+- **30-minute onboarding guide**: [`docs/problems/AUTHORING.html`](./docs/problems/AUTHORING.html) — step-by-step + 5-kind decision tree + 4 worked examples
+- **Claude Code skill**: `.claude/skills/create-problem/SKILL.md` — invoked as `/create-problem`; walks through requirements gathering → scaffold generation → metadata editing
 
-問題は **3-asset model** (ADR-012):
+Problems use the **3-asset model** (ADR-012):
 
 ```
 problems/<category>/<id>/
-├── metadata.json    # catalog 表示 + scoring engine + portal plugin 配線の正本
-├── template.yaml    # CFn ペライチ (deploy 本体、 競技者 account に直接 deploy)
-└── portal/          # 任意 (= dashboard.slots で宣言した tsx)
+├── metadata.json    # Source of truth for catalog display + scoring engine + portal plugin wiring
+├── template.yaml    # A single-page CFn (the deploy body, deployed straight into the competitor account)
+└── portal/          # Optional (.tsx files declared in dashboard.slots)
 ```
 
-採点は 5 種の builtin kind (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) を 1 問題 1 つ宣言する。 platform 側 generic scoring Lambda (= ADR-012 Phase 3) が dispatch する。 問題固有の scoring code を platform に書かない。
+Scoring uses one of five built-in kinds (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) — one per problem. The platform's generic scoring Lambda (ADR-012 Phase 3) dispatches them. Don't put problem-specific scoring code into the platform.
 
-雛形生成 CLI を備えています。
+A scaffolding CLI is available:
 
 ```bash
 bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>
@@ -206,15 +206,15 @@ bun run scripts/tenkacloud-problem.ts validate <id>
 bun run scripts/tenkacloud-problem.ts list-kinds
 ```
 
-雛形 templates: `.claude/templates/problems/<kind>/` に 5 kind 分 (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`)。
+Scaffold templates live under `.claude/templates/problems/<kind>/` — one per kind (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`).
 
-## 参照
+## References
 
-- @CLAUDE.md — プロダクト全体・アーキテクチャ・コマンド一覧
-- [`docs/architecture/harness.md`](./docs/architecture/harness.md) — invariant + PR Discipline の正本
-- [`docs/architecture/adr-012-problem-plugin-architecture.html`](./docs/architecture/adr-012-problem-plugin-architecture.html) — 問題 = plugin、 platform = host の設計
-- [`docs/problems/AUTHORING.html`](./docs/problems/AUTHORING.html) — 問題作成 30 分 onboarding
-- [`infrastructure/templates/README.md`](./infrastructure/templates/README.md) — 競技者アカウント側のセットアップ
-- [`problems/README.md`](./problems/README.md) — 問題追加の手順とスキーマ
-- `apps/<app>/README.md` — 各 SPA のローカル開発手順
-- [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — CI が走らせるコマンド
+- @CLAUDE.md — full product overview, architecture, command list
+- [`docs/architecture/harness.md`](./docs/architecture/harness.md) — source of truth for invariants + PR Discipline
+- [`docs/architecture/adr-012-problem-plugin-architecture.html`](./docs/architecture/adr-012-problem-plugin-architecture.html) — problem = plugin, platform = host design
+- [`docs/problems/AUTHORING.html`](./docs/problems/AUTHORING.html) — 30-minute problem authoring onboarding
+- [`infrastructure/templates/README.md`](./infrastructure/templates/README.md) — competitor-side setup
+- [`problems/README.md`](./problems/README.md) — problem authoring steps + schema
+- `apps/<app>/README.md` — local development steps per SPA
+- [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — what CI runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,241 +1,240 @@
 # TenkaCloud
 
-AWS マルチテナント SaaS のクラウドコンペティション基盤。問題は **Battle**（リアルタイム対戦）と **Challenge**（個別演習・常設チャレンジ）の 2 カテゴリで配信する (旧称 GameDay / JAM)。SBT (`@cdklabs/sbt-aws` 0.3.9) を土台に、Control Plane / Application Plane / 競技者 AWS アカウントへの問題 deploy をまるごと CDK で持つ。
+A multi-tenant SaaS cloud competition platform on AWS. Problems are delivered in two categories: **Battle** (real-time, head-to-head) and **Challenge** (self-paced, evergreen) — formerly known as GameDay / JAM. Built on top of SBT (`@cdklabs/sbt-aws` 0.3.9), with the Control Plane, Application Plane, and per-competitor problem deployment all expressed in CDK.
 
-## アーキテクチャ
+## Architecture
 
 ```
 TenkaCloud/
-├── apps/                                    # Vite + React 19 + Cloudscape の SPA 群
-│   ├── admin-console/                       # System Admin 用 Control Plane UI (dev :5173)
-│   ├── application-admin-console/           # Tenant Admin 用 Application Plane UI (dev :5174)
-│   └── participant-portal/                  # 競技者向けポータル (dev :5175)
-├── infrastructure/                          # CDK (SBT 0.3.9) — 全 backend は Lambda
-│   ├── bin/infrastructure.ts                # Stack 配線のエントリ
+├── apps/                                    # Vite + React 19 + Cloudscape SPAs
+│   ├── admin-console/                       # System Admin (Control Plane UI, dev :5173)
+│   ├── application-admin-console/           # Tenant Admin (Application Plane UI, dev :5174)
+│   └── participant-portal/                  # Competitor portal (dev :5175)
+├── infrastructure/                          # CDK (SBT 0.3.9) — every backend is a Lambda
+│   ├── bin/infrastructure.ts                # Stack wiring entry point
 │   ├── lib/
 │   │   ├── control-plane-stack.ts           # SBT ControlPlane (Cognito + EventBridge + API)
-│   │   ├── bootstrap-template/              # Tenant pipeline 用 bootstrap (TenantMappingTable)
-│   │   ├── tenant-template/                 # 1 tenant 分の API + Cognito + ApplicationConsole hosting
-│   │   ├── tenant-pipeline/                 # CodePipeline 経由の per-tenant provisioning
-│   │   ├── problem-deploy/                  # 競技者 AWS への問題 deploy (DDB + Worker Lambda + API)
-│   │   ├── admin-console-hosting.ts         # admin-console を S3+CloudFront 配信
+│   │   ├── bootstrap-template/              # Tenant pipeline bootstrap (TenantMappingTable)
+│   │   ├── tenant-template/                 # One tenant's API + Cognito + ApplicationConsole hosting
+│   │   ├── tenant-pipeline/                 # Per-tenant provisioning via CodePipeline
+│   │   ├── problem-deploy/                  # Problem deployment into competitor AWS (DDB + Worker Lambda + API)
+│   │   ├── admin-console-hosting.ts         # admin-console served via S3 + CloudFront
 │   │   ├── cdk-aspect/                      # DynamoDbLowCapacity / DestroyPolicySetter
 │   │   ├── config/                          # config.json schema + interface
 │   │   └── utils/                           # config-loader, iam-helpers
-│   ├── environments/<env>/{config.json,.env}# 環境別設定。.env で ${VAR:-default} を注入
-│   └── templates/competitor-bootstrap.yaml  # 競技者アカウント側で 1 回流す IAM Role
-├── scripts/                                 # install.sh / cleanup.sh / provision-tenant.sh 等
-├── problems/<category>/<id>/                # 1 ディレクトリ 1 問題 (metadata.json + template.yaml)
-└── .github/workflows/ci.yml                 # PR で lint / typecheck / test / build
+│   ├── environments/<env>/{config.json,.env}# Per-environment config; .env injects ${VAR:-default}
+│   └── templates/competitor-bootstrap.yaml  # One-time IAM Role rolled out in the competitor account
+├── scripts/                                 # install.sh / cleanup.sh / provision-tenant.sh, etc.
+├── problems/<category>/<id>/                # One directory per problem (metadata.json + template.yaml)
+└── .github/workflows/ci.yml                 # PR-time lint / typecheck / test / build
 ```
 
-### Plane 配置
+### Plane layout
 
-- **Control Plane** (`ControlPlaneStack`) — SBT 内蔵の Cognito UserPool + System Admin + Tenant CRUD API + EventBridge bus。`admin-console` がフロント。
-- **Application Plane (pooled)** — `serverless-saas-ref-arch-tenant-template-pooled` として Phase 1 で 1 つ立つ。BASIC / STANDARD / PREMIUM tier の tenant が共有する `application-admin-console` を 1 CloudFront URL で配信。
-- **Application Plane (silo)** — PLATINUM tier の tenant 作成イベントで `ServerlessSaaSPipeline` が CodeBuild を起動し、tenant 専用の `serverless-saas-ref-arch-tenant-template-<tenantId>` を deploy。
-- **Problem deploy backend** (`ProblemDeployBackendStack`) — Deployments DDB + Cognito JWT 認可付き HTTP API + Worker Lambda。EventBridge から `DeployRequested` を拾い、tenant の ExternalId で競技者アカウントへ AssumeRole → CFn CreateStack。
-- **Participant Portal** — 競技者が自チームの問題エンドポイント・スコアを見るアプリ。`ProblemDeployBackendStack` から S3+CloudFront でホスティング (有効化は `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true`)。
+- **Control Plane** (`ControlPlaneStack`) — SBT-bundled Cognito UserPool + System Admin + Tenant CRUD API + EventBridge bus. `admin-console` is the front end.
+- **Application Plane (pooled)** — One `serverless-saas-ref-arch-tenant-template-pooled` instance stands up during Phase 1. BASIC / STANDARD / PREMIUM tenants share a single `application-admin-console` URL behind CloudFront.
+- **Application Plane (silo)** — On PLATINUM tier tenant creation, `ServerlessSaaSPipeline` kicks off CodeBuild and deploys a dedicated `serverless-saas-ref-arch-tenant-template-<tenantId>` for that tenant.
+- **Problem deploy backend** (`ProblemDeployBackendStack`) — Deployments DDB + Cognito JWT-authenticated HTTP API + Worker Lambda. EventBridge `DeployRequested` is picked up, the worker AssumeRoles into the competitor account using the tenant's ExternalId, then CFn CreateStack runs there.
+- **Participant Portal** — App where each competitor sees their team's problem endpoints and scores. Hosted on S3 + CloudFront from `ProblemDeployBackendStack` (enable via `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true`).
 
-### Plane 越しの通信
+### Cross-plane communication
 
-EventBridge bus (Control Plane が払い出し、ARN を `bin/infrastructure.ts` で他 stack に渡す) を経由する。フロントエンドは runtime-config.json + Cognito JWT で各 API を叩く。
+Goes through the EventBridge bus (Control Plane provisions it; `bin/infrastructure.ts` hands the ARN to other stacks). The frontend hits each API using `runtime-config.json` + Cognito JWT.
 
-### データ分離
+### Data isolation
 
-DynamoDB シングルテーブル設計はしない。stack ごとに専用テーブル (TenantMappingTable / Deployments / Apps 等) を持ち、テナント分離は `TenantId` キー or stack 自体の分離で行う。**全テーブルは PROVISIONED 1 RCU / 1 WCU を Aspect (`DynamoDbLowCapacity`) で強制** — Free Tier 25 RCU/WCU 内に収めるため。
+We don't use a single-table DynamoDB design. Each stack owns its own tables (TenantMappingTable / Deployments / Apps / etc.), and tenant isolation is enforced via the `TenantId` partition key or by stack separation. **Every table is forced to PROVISIONED 1 RCU / 1 WCU by a CDK Aspect (`DynamoDbLowCapacity`)** so the whole platform fits inside the AWS Free Tier 25 RCU/WCU budget.
 
-## コマンド
+## Commands
 
-| コマンド                | 用途                                                        |
-| ----------------------- | ----------------------------------------------------------- |
-| `make install`          | 全 workspace の依存をインストール (bun)                     |
-| `make build`            | 全 workspace を build (`infrastructure` → 3 SPA)            |
-| `make typecheck`        | 全 workspace の `tsc --noEmit`                              |
-| `make test`             | 全 workspace の vitest                                      |
-| `make lint`             | markdownlint + textlint + biome                             |
-| `make fix`              | 上記の自動修正版 (`make format` でも可)                     |
-| `make validate-problems`| `problems/**/metadata.json` を `problems/SCHEMA.json` で検証|
-| `make check`            | install + lint + test + validate-problems                   |
-| `make before-commit`    | lint + test + validate-problems (PR 前の必須ゲート)         |
-| `make synth`            | `cdk synth` (デフォルト `ENV=development`)                  |
-| `make diff`             | `cdk diff --all`                                            |
-| `make bootstrap`        | `cdk bootstrap`                                             |
-| `make deploy`           | **Lite mode** (= single-tenant) を deploy。 `bin/tenkacloud-lite.ts` 経由で AppPlaneCore + Participant Portal を立てる (#955) |
-| `make deploy-saas`      | **SaaS mode** (= multi-tenant) を deploy。 `scripts/install.sh` を起動 (3-phase deploy、 SBT ControlPlane を立てる) |
-| `make destroy`          | Lite mode を destroy (= `make lite-down`)                   |
-| `make destroy-saas`     | SaaS mode を destroy (`scripts/cleanup.sh` で全 stack + S3 を冪等に破棄) |
-| `make harness`          | architecture invariant チェック (`docs/architecture/harness.md`) |
-| `make harness-test`     | harness 自体のユニットテスト (`.claude/harness/`)           |
-| `make tech-debt`        | 技術的負債スキャン (test smell / 結合 / 責務漏れ)           |
-| `make help`             | Makefile の全ターゲット一覧                                 |
+| Command                 | Purpose                                                                  |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `make install`          | Install dependencies for every workspace (bun)                           |
+| `make build`            | Build every workspace (`infrastructure` → 3 SPAs)                        |
+| `make typecheck`        | `tsc --noEmit` across every workspace                                    |
+| `make test`             | `vitest` across every workspace                                          |
+| `make lint`             | markdownlint + textlint + biome                                          |
+| `make fix`              | Auto-fix variant of the above (`make format` works too)                  |
+| `make validate-problems`| Validate `problems/**/metadata.json` against `problems/SCHEMA.json`      |
+| `make check`            | install + lint + test + validate-problems                                |
+| `make before-commit`    | lint + test + validate-problems (required gate before opening a PR)      |
+| `make synth`            | `cdk synth` (defaults to `ENV=development`)                              |
+| `make diff`             | `cdk diff --all`                                                         |
+| `make bootstrap`        | `cdk bootstrap`                                                          |
+| `make deploy`           | **Lite mode** (single-tenant) deploy. Stands up AppPlaneCore + Participant Portal via `bin/tenkacloud-lite.ts` (#955) |
+| `make deploy-saas`      | **SaaS mode** (multi-tenant) deploy. Runs `scripts/install.sh` (3-phase deploy, stands up SBT ControlPlane) |
+| `make destroy`          | Tear down Lite mode (`make lite-down`)                                   |
+| `make destroy-saas`     | Tear down SaaS mode (`scripts/cleanup.sh` idempotently removes every stack + S3) |
+| `make harness`          | Architecture invariant check (`docs/architecture/harness.md`)            |
+| `make harness-test`     | Unit tests for the harness itself (`.claude/harness/`)                   |
+| `make tech-debt`        | Tech-debt scan (test smell / coupling / responsibility gaps)             |
+| `make help`             | List every Makefile target                                               |
 
-環境切替は `make deploy ENV=production` のように `ENV` 変数で行う。`infrastructure/environments/<env>/.env` を読み込み、無ければ `make env-check` (SaaS mode) / `make env-check-lite` (Lite mode、 SYSTEM_ADMIN_EMAIL 不要) がエラーで止める。
+Switch environments with `make deploy ENV=production` and similar. It loads `infrastructure/environments/<env>/.env`; if missing, `make env-check` (SaaS mode) / `make env-check-lite` (Lite mode, no `SYSTEM_ADMIN_EMAIL` required) fail with an error.
 
-## アーキテクチャ Invariants
+## Architecture invariants
 
-`docs/architecture/harness.md` に固定済み。`make harness` が `.claude/harness/bin/architecture.ts` で staged ファイルを検査して逸脱を error で報告する。
+Codified in `docs/architecture/harness.md`. `make harness` runs `.claude/harness/bin/architecture.ts` against staged files and reports deviations as errors.
 
-| ID                                                    | 概要                                                                            |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `INVARIANT_CONTROL_PLANE_USES_SBT`                    | Control Plane は `@cdklabs/sbt-aws` の ControlPlane construct に乗せる         |
-| `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`| Control Plane は tenant manager。tenant runtime を持ち込まない                  |
-| `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER`           | テナント分離はインフラ層 (DDB PK / stack 分離) で実現。アプリに tenant ロジックを書かない |
-| `INVARIANT_APP_CODE_IS_UNMODIFIED`                    | `apps/*/dist/` は tenant 共有。差分は `runtime-config.json` 経由で注入する       |
-| `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`              | 認証はインフラ層で注入。アプリに `AUTH_SKIP` 的なバイパスを書かない              |
-| `INVARIANT_PR_SHIPS_WORKING_INCREMENT`                | PR 単体で観察可能な機能が動く。scaffolding-only PR は禁止                        |
-| `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`              | コード変更とテストを同じ PR に含める。既存テストでカバー時は body で明示         |
-| `INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED`         | PR body に `## Regression 分析` セクションで壊しうる挙動を列挙する              |
-| `INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED`             | PR body に `## 物理影響` セクションで CFn / 成果物の差分を CREATE/UPDATE/REPLACE/DELETE/NO-OP で列挙 |
-| `ONE_PASS_LOCAL`                                      | ローカルで tenant 作成 → application console → 問題 deploy → participant join がブラウザ 1 回で通る |
-| `ONE_PASS_AWS`                                        | `make deploy-saas` (= SaaS mode) 1 発で 3-phase が通り、SystemAdmin 招待 → tenant 作成 → 問題 deploy → 競技者ログインまで一気通貫 |
+| ID                                                    | Summary                                                                            |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `INVARIANT_CONTROL_PLANE_USES_SBT`                    | The Control Plane must sit on top of the `@cdklabs/sbt-aws` ControlPlane construct |
+| `INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`| The Control Plane is the tenant manager. Tenant runtime must not live there       |
+| `INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER`           | Tenant isolation lives in the infra layer (DDB PK / stack separation). No tenant logic in the app |
+| `INVARIANT_APP_CODE_IS_UNMODIFIED`                    | `apps/*/dist/` is shared across tenants. Differences must flow through `runtime-config.json` |
+| `INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`              | Auth is injected at the infra layer. Don't add `AUTH_SKIP`-style bypasses to the app |
+| `INVARIANT_PR_SHIPS_WORKING_INCREMENT`                | Every PR ships an observable, working slice. Scaffolding-only PRs are not allowed  |
+| `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`              | Code and tests change in the same PR. If existing tests already cover it, say so in the PR body |
+| `INVARIANT_PR_REGRESSION_ANALYSIS_DOCUMENTED`         | PR body must include a `## Regression analysis` section listing what could break    |
+| `INVARIANT_PR_PHYSICAL_IMPACT_DOCUMENTED`             | PR body must include a `## Physical impact` section labeling CFn / artifact diffs as CREATE/UPDATE/REPLACE/DELETE/NO-OP |
+| `ONE_PASS_LOCAL`                                      | Locally, tenant creation → application console → problem deploy → participant join all flow in a single browser pass |
+| `ONE_PASS_AWS`                                        | `make deploy-saas` (SaaS mode) runs all three phases end-to-end: SystemAdmin invite → tenant creation → problem deploy → competitor login |
 
-加えて次の Enforcement Rules を機械検査する。
+We also machine-check the following enforcement rules:
 
-- `secrets-manager-forbidden` — `@aws-sdk/client-secrets-manager` 禁止 (SSM Parameter Store SecureString を使う、コスト 0 原則)
-- `handler-must-not-call-fetch` — `lib/handlers/` で `fetch(` 直接呼び出し禁止 (Service / Repository に閉じ込める)
-- `adr-must-be-html` — ADR は `docs/architecture/adr-*.html` で書く。Markdown ADR は禁止
-- `adr-self-contained` — ADR に chat 文脈 / 順次反映 metadata / AI agent との役割分担メモを残さない
+- `secrets-manager-forbidden` — `@aws-sdk/client-secrets-manager` is forbidden (use SSM Parameter Store SecureString — cost-zero principle)
+- `handler-must-not-call-fetch` — `lib/handlers/` must not call `fetch(` directly (keep it inside Service / Repository)
+- `adr-must-be-html` — ADRs live in `docs/architecture/adr-*.html`. Markdown ADRs are forbidden
+- `adr-self-contained` — ADRs must not retain chat context, rolling-update metadata, or notes about which AI agent owns what
 
-## 開発フロー
+## Development flow
 
-### ADR 規約
+### ADR conventions
 
-ADR は `docs/architecture/adr-*.html` を正本とし、Markdown では書かない。row span / color / SVG / collapsible など、設計判断を読みやすくする HTML の表現力を使う。
+ADRs are authored in `docs/architecture/adr-*.html` as the source of truth; we do not write them in Markdown. Use HTML's expressive features (row spans, color, SVG, collapsible sections, etc.) to make design decisions easier to read.
 
-ADR は OSS readers 向けに self-contained に書く。chat 文脈、順次反映 metadata、`Claude が提案` / `user 担当` のような会話内の役割分担、未確定 TODO は残さない。背景、判断、影響、代替案、移行方針を、その ADR 単体で読める形にする。
+ADRs must be self-contained for OSS readers. Do not leave chat context, rolling-update metadata, role-split notes such as `Claude proposes` / `user owns`, or unresolved TODOs. Write the background, decision, impact, alternatives, and migration plan so each ADR is understandable on its own.
 
-### ゲート (PR 作成前)
+### Gates (before opening a PR)
 
-1. `make harness` — architecture invariant 違反が 0 件であること
-2. `make before-commit` — lint / typecheck / test / build / validate-problems がすべて通ること
-3. `/review` — コードレビュー
-4. `/security-review` — セキュリティレビュー
-5. `/simplify` — 重複・複雑度・無駄なコードの最終チェック
+1. `make harness` — zero architecture invariant violations
+2. `make before-commit` — lint / typecheck / test / build / validate-problems must all pass
+3. `/review` — code review
+4. `/security-review` — security review
+5. `/simplify` — final pass for duplication, complexity, and wasted code
 
-すべて通るまで未完了。失敗したら原因を特定してコードを修正する（`biome.json` / `vitest.config.ts` 等の設定ファイルを直接いじらない）。
+You are not done until they all pass. If something fails, find the root cause and fix the code (don't edit `biome.json` / `vitest.config.ts` / etc. to mask it).
 
-### 利用可能な skills
+### Available skills
 
-`.claude/skills/` 配下に置いてある。`/<skill-name>` で起動する。
+Live under `.claude/skills/` and are invoked as `/<skill-name>`.
 
-| skill              | 用途                                                                        |
-| ------------------ | --------------------------------------------------------------------------- |
-| `/harness`         | `make harness` を走らせて architecture invariant 違反を検出                 |
-| `/tech-debt`       | `make tech-debt` で技術的負債バックログを生成（assertion-roulette / 結合 / fallback 検出） |
-| `/create-problem`  | `problems/<category>/<id>/` を `metadata.json` + `template.yaml` 規約で雛形生成 |
-| `/spec`            | Open Web Docs (MDN) スタイルの技術仕様書を書く                              |
+| skill              | Purpose                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `/harness`         | Run `make harness` to detect architecture invariant violations                          |
+| `/tech-debt`       | Run `make tech-debt` to generate the tech-debt backlog (assertion roulette / coupling / fallback detection) |
+| `/create-problem`  | Scaffold `problems/<category>/<id>/` with the `metadata.json` + `template.yaml` convention |
+| `/spec`            | Write a technical specification in the Open Web Docs (MDN) style                       |
 
 ### TDD
 
-テストを先に書く。テストタイトルは日本語「〜すべき」形式。Vitest は workspace ごとに独立 (`infrastructure/vitest.config.ts`、各 SPA の `vite.config.ts`)。
+Write tests first. Test titles use the English `should ...` pattern. Vitest runs per workspace (`infrastructure/vitest.config.ts`, plus each SPA's `vite.config.ts`).
 
 ```typescript
 describe("AdminConsoleHostingStack", () => {
-  it("CloudFront distribution に runtime-config.json が配置されるべき", () => {
+  it("should place runtime-config.json on the CloudFront distribution", () => {
     // ...
   });
 });
 ```
 
-### Issue 引用ルール
+### Issue reference rules
 
-GitHub の auto-close keyword は **括弧なし** で書く。
+Use GitHub's auto-close keywords **without parentheses**.
 
-- **解決して issue を閉じる** = `Closes #553` / `Fixes #553` / `Resolves #553` (= merge 時に auto-close)
-- **関連だが閉じない (= partial fix / 単なる backlink)** = `Relates #553` または本文中で `#553` を非 keyword 位置で言及
-- **PR 同士の参照** = `PR-565` のように番号 prefix で書く (issue 番号と区別)
+- **Closes the issue on merge** = `Closes #553` / `Fixes #553` / `Resolves #553` (auto-closes on merge)
+- **Related but does not close** (partial fix / pure backlink) = `Relates #553`, or mention `#553` in a non-keyword position
+- **PR-to-PR references** = write `PR-565` with a number prefix to distinguish from issue numbers
 
-旧ルール (= `(#N)` の括弧で囲って auto-close を抑止) は仕様誤解だった。`Closes` などの
-keyword が無ければ `#N` 単独でも auto-close されない (= backlink のみ作る)。
+The old rule of wrapping `(#N)` in parentheses to suppress auto-close was a misunderstanding of the spec. Without a keyword like `Closes`, a bare `#N` does **not** trigger auto-close — it only creates a backlink.
 
-### HTTP status code は magic number 禁止
+### HTTP status codes: no magic numbers
 
-`c.json(body, 500)` のような数値リテラル直書きは禁止です。`http-status-codes` の `StatusCodes` enum を使ってください。
+Writing numeric literals like `c.json(body, 500)` is forbidden. Use the `StatusCodes` enum from `http-status-codes`.
 
 ```ts
 import { StatusCodes } from "http-status-codes";
 
-return c.json({ ok: true }, StatusCodes.OK);                    // ✅
+return c.json({ ok: true }, StatusCodes.OK);                         // ✅
 return c.json({ error: "..." }, StatusCodes.INTERNAL_SERVER_ERROR);  // ✅
-return c.json({ ok: true }, 200);                               // ❌ magic number
+return c.json({ ok: true }, 200);                                    // ❌ magic number
 ```
 
-フロントエンドの fetch response 判定も同様です。
+The frontend response checks follow the same rule.
 
 ```ts
 if (res.status === StatusCodes.UNAUTHORIZED) throw new PortalAuthError();  // ✅
 if (res.status === 401) throw new PortalAuthError();                       // ❌
 ```
 
-旧来の `HTTP_OK` / `HTTP_INTERNAL_ERROR` は `infrastructure/lib/problem-deploy/handlers/shared/http-status.ts` に deprecated alias として残ります。新規コードでは使いません。値は `StatusCodes.*` から派生するため、library 更新で自動追従します。
+The legacy aliases (`HTTP_OK` / `HTTP_INTERNAL_ERROR` etc. in `infrastructure/lib/problem-deploy/handlers/shared/http-status.ts`) remain as deprecated re-exports. Don't use them in new code. They are derived from `StatusCodes.*`, so library updates flow through automatically.
 
-## 禁止事項
+## Prohibited
 
-- **`npx` 禁止** → `bunx` または `nlx` を使う
-- **`rm` コマンド禁止** → ファイル削除は `git rm` 経由で扱う
-- **HTTP status code の数値リテラル直書き禁止** — `StatusCodes.*` (`http-status-codes` library) を使う
-- **モック / スタブで握り潰す fallback 禁止** — 失敗するなら明示的に失敗させる
-- **DynamoDB を on-demand (PAY_PER_REQUEST) で立てない** — `DynamoDbLowCapacity` Aspect で 1/1 PROVISIONED に強制している。これを破る変更は CFn 出力で必ず引っかかる
-- **設定ファイル (`biome.json`, 各 `vitest.config.ts`, `tsconfig.json`) の直接変更禁止** — コード側を修正する
-- **シークレット (`.env`, AWS credentials) のコミット禁止** — `.gitignore` で除外、`infrastructure/environments/<env>/.env.example` だけコミット
+- **No `npx`** → use `bunx` or `nlx`
+- **No `rm`** → delete files through `git rm`
+- **No HTTP status code literals** — use `StatusCodes.*` (`http-status-codes` library)
+- **No silent fallbacks via mocks / stubs** — if it fails, fail loudly
+- **No on-demand DynamoDB (PAY_PER_REQUEST)** — the `DynamoDbLowCapacity` Aspect enforces 1/1 PROVISIONED; any change that breaks this will show up in the CFn output
+- **No direct edits to config files (`biome.json`, each `vitest.config.ts`, `tsconfig.json`)** — fix the code instead
+- **No committed secrets (`.env`, AWS credentials)** — they are excluded by `.gitignore`; only `infrastructure/environments/<env>/.env.example` is committed
 
-## セキュリティ
+## Security
 
-- ユーザー入力 / 外部 API 境界では Zod でバリデーション
-- 認証バイパスを実装しない (本 repo には AUTH_SKIP は無い、Cognito JWT を必ず通す)
-- `innerHTML` / `eval` / `dangerouslySetInnerHTML` 不使用
-- 競技者アカウントへの AssumeRole は **必ず ExternalId** を要求 (`CDK_PARAM_DEPLOY_EXTERNAL_ID`)
-- `infrastructure/templates/competitor-bootstrap.yaml` の IAM Role は最小権限 (CFn CreateStack + 問題テンプレートが触る AWS サービス分のみ)
-- 依存パッケージは Renovate / dependabot で更新、CI は Safe Chain で malicious package を検出
+- Validate user input / external API boundaries with Zod
+- Do not implement auth bypasses (this repo has no `AUTH_SKIP`; every request goes through Cognito JWT)
+- No `innerHTML` / `eval` / `dangerouslySetInnerHTML`
+- AssumeRole into competitor accounts **always requires `ExternalId`** (`CDK_PARAM_DEPLOY_EXTERNAL_ID`)
+- The IAM Role in `infrastructure/templates/competitor-bootstrap.yaml` is least-privilege (only CFn CreateStack + whatever AWS services each problem template touches)
+- Dependencies are updated by Renovate / Dependabot; CI uses Safe Chain to detect malicious packages
 
-### Supply Chain Security (mini Shai-Hulud 第二波対策、参考 [blog.flatt.tech/entry/mini_shai_hulud_2nd](https://blog.flatt.tech/entry/mini_shai_hulud_2nd))
+### Supply chain security (mini Shai-Hulud 2nd-wave mitigation, see [blog.flatt.tech/entry/mini_shai_hulud_2nd](https://blog.flatt.tech/entry/mini_shai_hulud_2nd))
 
-`prepare` / `postinstall` 等の transitive dep lifecycle script を悪用した credential exfil 系攻撃に対する 4 層防御です。
+A four-layer defense against credential-exfil attacks that abuse `prepare` / `postinstall` and other transitive lifecycle scripts.
 
-1. **Bun `trustedDependencies`**: Bun は default で transitive lifecycle script を block (= secure-by-default)。`package.json` の `trustedDependencies` 配列が明示 allowlist (現状空)。
-2. **`.npmrc`**: `ignore-scripts=true` + `min-release-age=168h` (= 7 日 quarantine、 npm 11+)。 contributor が npm / yarn / pnpm を使っても自動防御。
-3. **CI 監査** `make audit-deps` (`scripts/audit-dependencies.ts`): `node_modules` を scan し lifecycle script を持つ package を `scripts/audit-baseline.json` と diff、 新規追加 / 既存 dep の hook 追加で fail。
-4. **CI install policy** `make install_ci`: `bun install --frozen-lockfile --ignore-scripts` + Aikido Safe Chain による悪意 package 検出。
+1. **Bun `trustedDependencies`**: Bun blocks transitive lifecycle scripts by default (secure by default). The `trustedDependencies` array in `package.json` is the explicit allowlist (currently empty).
+2. **`.npmrc`**: `ignore-scripts=true` + `min-release-age=168h` (7-day quarantine, npm 11+). Even if a contributor uses npm / yarn / pnpm, the protection is automatic.
+3. **CI audit** `make audit-deps` (`scripts/audit-dependencies.ts`): Scans `node_modules`, diffs packages with lifecycle scripts against `scripts/audit-baseline.json`, and fails on any new addition or new hook on an existing dep.
+4. **CI install policy** `make install_ci`: `bun install --frozen-lockfile --ignore-scripts` + Aikido Safe Chain malicious package detection.
 
-`trustedDependencies` への package 追加は単独 PR で行い、 該当 script の中身を目視確認 + PR body で要約してください (= 不審な curl / wget / OS persistence / 環境変数 exfil があれば baseline に入れず報告)。
+Add packages to `trustedDependencies` in a stand-alone PR. Manually verify the script contents and summarize them in the PR body (if you see suspicious `curl` / `wget` / OS persistence / env-var exfil, do not add to the baseline — report it instead).
 
-## 技術スタック
+## Tech stack
 
-| レイヤー         | 技術                                                                  |
+| Layer            | Tech                                                                  |
 | ---------------- | --------------------------------------------------------------------- |
-| フロントエンド   | Vite 7, React 19, react-router 7, Cloudscape Design System            |
-| バックエンド     | AWS Lambda (Node.js / Hono on Lambda), API Gateway HTTP API           |
+| Frontend         | Vite 7, React 19, react-router 7, Cloudscape Design System            |
+| Backend          | AWS Lambda (Node.js / Hono on Lambda), API Gateway HTTP API           |
 | IaC              | AWS CDK 2 + `@cdklabs/sbt-aws` 0.3.9, cdk-nag                         |
-| 認証             | AWS Cognito (Hosted UI + OAuth Code + PKCE)                           |
-| データ           | DynamoDB (PROVISIONED 1/1 強制)                                       |
-| イベント         | EventBridge (cross-plane: tenant 作成 / DeployRequested / DeployCompleted) |
-| テスト           | Vitest                                                                |
+| Auth             | AWS Cognito (Hosted UI + OAuth Code + PKCE)                           |
+| Data             | DynamoDB (forced PROVISIONED 1/1)                                     |
+| Events           | EventBridge (cross-plane: tenant creation / DeployRequested / DeployCompleted) |
+| Tests            | Vitest                                                                |
 | Lint / Format    | Biome (TS), markdownlint-cli2 + textlint (Markdown)                   |
-| パッケージ管理   | Bun 1.3.11 (workspaces: `infrastructure` + `apps/*`)                  |
+| Package manager  | Bun 1.3.11 (workspaces: `infrastructure` + `apps/*`)                  |
 | CI               | GitHub Actions (`.github/workflows/ci.yml`)                           |
 
-## デプロイの流れ
+## Deploy flow
 
-### Lite mode (= デフォルト、 `make deploy`)
+### Lite mode (default, `make deploy`)
 
-Issue #955 で `make deploy` のデフォルトを single-tenant Lite mode に切替えた。 SBT ControlPlane / tenant pipeline / SystemAdmin 招待を全て省き、 `bin/tenkacloud-lite.ts` 経由で AppPlaneCore (`tenantId="local"`) + ProblemDeployBackend (= Participant Portal) の 2 stack だけを deploy する。 主催者 1 人 1 大会の最短経路 (= 約 10 分)。 teardown は `make destroy` (= `make lite-down`)。
+Issue #955 switched the default for `make deploy` to single-tenant Lite mode. It skips the SBT ControlPlane / tenant pipeline / SystemAdmin invitation entirely and deploys just two stacks via `bin/tenkacloud-lite.ts`: AppPlaneCore (`tenantId="local"`) + ProblemDeployBackend (Participant Portal). It is the shortest path for "one organizer running one event" (about 10 minutes). Teardown is `make destroy` (`make lite-down`).
 
-### SaaS mode (= opt-in、 `make deploy-saas`)
+### SaaS mode (opt-in, `make deploy-saas`)
 
-複数 tenant / pooled tier (BASIC/STANDARD/PREMIUM) / silo tier (PLATINUM) / SystemAdmin 招待を含む本格運用は SaaS mode を使う。 `make deploy-saas` (= `scripts/install.sh`) は次の 3 フェーズで動く。
+For full multi-tenant operation — pooled tiers (BASIC / STANDARD / PREMIUM), silo tier (PLATINUM), and SystemAdmin invitations — use SaaS mode. `make deploy-saas` (`scripts/install.sh`) runs three phases.
 
-1. **Phase 1**: `ControlPlaneStack` + `serverless-saas-ref-arch-bootstrap-stack` + `serverless-saas-ref-arch-tenant-template-pooled` + `ServerlessSaaSPipeline` を deploy。CORS/callback は localhost のみ。
-2. **Phase 2**: Phase 1 の outputs を runtime-config 用 env に入れて `apps/admin-console` を host で build → `AdminConsoleHostingStack` (S3 + CloudFront) を deploy。
-3. **Phase 3**: CloudFront URL を `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` に入れて `ControlPlaneStack` を再 deploy → callback / CORS を更新。
+1. **Phase 1**: Deploy `ControlPlaneStack` + `serverless-saas-ref-arch-bootstrap-stack` + `serverless-saas-ref-arch-tenant-template-pooled` + `ServerlessSaaSPipeline`. CORS/callback is localhost only at this point.
+2. **Phase 2**: Feed Phase 1 outputs into runtime-config env, host-build `apps/admin-console`, then deploy `AdminConsoleHostingStack` (S3 + CloudFront).
+3. **Phase 3**: Put the CloudFront URL into `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` and redeploy `ControlPlaneStack` to update callback / CORS.
 
-teardown は `make destroy-saas` (= `scripts/cleanup.sh`)。途中失敗状態 / 部分削除済み状態からも冪等に動くよう書かれている。
+Teardown is `make destroy-saas` (`scripts/cleanup.sh`). It is written to be idempotent from any partial-failure / partial-delete state.
 
-## ポインター
+## Pointers
 
-- **アーキテクチャ正本**: [`docs/architecture/harness.md`](./docs/architecture/harness.md) — invariant + PR Discipline
-- **デザインシステム**: [Cloudscape](https://cloudscape.design/components/) — UI コンポーネントは原則ここから選ぶ
-- **問題作成**: [`problems/README.md`](./problems/README.md) (metadata.json スキーマ + template.yaml 規約) — `/create-problem` で雛形生成
-- **競技者側セットアップ**: [`infrastructure/templates/README.md`](./infrastructure/templates/README.md)
-- **エージェント向けガイド**: @AGENTS.md
-- **コントリビューション**: @CONTRIBUTING.md
+- **Architecture source of truth**: [`docs/architecture/harness.md`](./docs/architecture/harness.md) — invariants + PR Discipline
+- **Design system**: [Cloudscape](https://cloudscape.design/components/) — pick UI components from here as a default
+- **Problem authoring**: [`problems/README.md`](./problems/README.md) (metadata.json schema + template.yaml conventions) — scaffold with `/create-problem`
+- **Competitor-side setup**: [`infrastructure/templates/README.md`](./infrastructure/templates/README.md)
+- **Agent guide**: @AGENTS.md
+- **Contributing**: @CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ make start
 1. Pick an issue (`good first issue` / `help wanted`) or a starter task from
    [ROADMAP.md](./ROADMAP.md#good-first-issue-candidates)
 2. Create a branch: `git checkout -b feat/your-feature`
-3. Write tests first (TDD). Test titles use the Japanese pattern `〜すべき` — match this style for consistency with the existing suite.
+3. Write tests first (TDD). Test titles use the English `should ...` pattern — match this style for consistency with the existing suite.
 4. Run `make before-commit` (lint / format / typecheck / tests / build)
 5. Open a PR (title under 70 characters, Conventional Commits)
 


### PR DESCRIPTION
## Summary

- Convert the agent + product guides from Japanese to English so the repo is approachable to a global OSS audience.
- Preserve all technical content verbatim: file paths, commands, ADR / invariant IDs, issue references, code blocks.
- Update the TDD convention from the Japanese `〜すべき` pattern to the English `should ...` pattern. The bulk rename of 189 existing test files ships in a follow-up PR.

## Test plan

- `make harness` (no findings)
- `make before-commit` (lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth all OK)
- Manual diff review — section structure / table rows / IDs unchanged

## Regression analysis

- **No runtime change**: AGENTS.md / CLAUDE.md / CONTRIBUTING.md are not loaded by any code path. They are read by humans / AI agents only.
- **Markdown lint**: same heading hierarchy, same code-block language tags, same link targets.
- **harness `adr-self-contained` rule**: not affected — it targets `docs/architecture/adr-*.html`, not these top-level guides.
- **CLAUDE.md TDD section** now specifies the English `should ...` test convention. Existing Japanese test titles still run (Vitest doesn't care about the natural language). The follow-up PR will bulk-rename them.
- **`make harness` / `make before-commit`**: both pass on this branch.

## Physical impact

- **CREATE**: none.
- **UPDATE**: `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` (prose translation only; technical content preserved).
- **REPLACE / DELETE / NO-OP**: none. No AWS resources / CFn / IAM / DDB schema touched.
- **CI / CD impact**: none.

## Follow-up

A separate PR will rename `〜すべき` → `should ...` across the 189 existing test files so test titles align with the new convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)