### PR TITLE
fix(portal): stop leaking spoiler description to competitor portal

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -22,15 +22,16 @@ function requireProblemMetadata(problemId: string): ProblemCatalogEntry {
 }
 
 describe("findProblemMetadata (Portal build-time catalog #550)", () => {
-  it("hello-world (Challenge sample) が引けて narrative field を含むべき", () => {
+  it("should expose competitor-safe narrative fields (no description) for hello-world", () => {
     const m = findProblemMetadata("hello-world");
     expect(m).toBeDefined();
     expect(m?.category).toBe("Challenge");
     expect(m?.name).toBe("Hello World (Sample)");
     // narrative field が空でない (= competitor 向け表示が実質中身ありで動く)
-    expect(m?.description.length).toBeGreaterThan(0);
-    expect(m?.learningGoals.length).toBeGreaterThan(0);
     expect(m?.shortDescription.length).toBeGreaterThan(0);
+    expect(m?.learningGoals.length).toBeGreaterThan(0);
+    // fairness contract: description (= 採点ルール等のネタバレを含む長文) は portal に embed しない
+    expect((m as unknown as { description?: string })?.description).toBeUndefined();
   });
 
   it("hello-world-battle (Battle uptime sample) が引けて category=Battle であるべき", () => {
@@ -43,18 +44,21 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(findProblemMetadata("does-not-exist")).toBeUndefined();
   });
 
-  it("Portal は deploy 内部情報 (cfnTemplate 等) を expose しないべき (#550 設計判断)", () => {
+  it("should not expose deploy internals or spoiler description (#550 + fairness contract)", () => {
     const m = findProblemMetadata("hello-world");
     expect(m).toBeDefined();
-    // 答えの hint になりうる deploy 内部情報は Portal の型に含めない
+    // 答えの hint になりうる deploy 内部情報 + ネタバレ長文は Portal bundle に出さない
     // (= JSON.stringify でも漏らさない)
     const json = JSON.stringify(m);
     expect(json).not.toContain("cfnTemplate");
     expect(json).not.toContain("cfnParameters");
+    expect(json).not.toContain('"description"');
   });
 
-  // ADR-012 Phase 4: phases / disruptions を portal が予告 panel に出すための data shape pin。
-  it("microservice-migration-battle で phases / disruptions が露出されるべき (ADR-012 Phase 4)", () => {
+  // ADR-012 Phase 4 + fairness contract: portal は author が `publicHint: true` で
+  // 明示宣言した phase / disruption だけを予告 panel に出す。 microservice-migration-battle は
+  // 全 phase / disruption に publicHint: true を立てているので全部見える。
+  it("should expose phases / disruptions for microservice-migration-battle (all publicHint: true)", () => {
     const m = findProblemMetadata("microservice-migration-battle");
     expect(m).toBeDefined();
     expect(m?.phases.length).toBeGreaterThanOrEqual(2);
@@ -62,6 +66,15 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     expect(m?.disruptions.length).toBeGreaterThanOrEqual(1);
     expect(m?.disruptions[0]?.id).toBe("ec2-latency-injection");
     expect(m?.disruptions[0]?.defaultAfterMinutes).toBe(60);
+  });
+
+  // fairness contract: publicHint: true が無い phase / disruption は portal bundle に embed されない。
+  // stackstack の phases / disruptions は publicHint が無いので 0 件露出が期待値。
+  it("should drop phases / disruptions without publicHint: true (fairness contract)", () => {
+    const m = findProblemMetadata("stackstack");
+    expect(m).toBeDefined();
+    expect(m?.phases).toEqual([]);
+    expect(m?.disruptions).toEqual([]);
   });
 
   it("phases / disruptions に operator 内部 field (effect / parameters / eventDetailType) を露出しないべき", () => {
@@ -112,21 +125,21 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
 
   // Issue #583 Phase 5: i18n override の locale fallback chain。
   describe("resolveLocalizedNarrative (Phase 5)", () => {
-    it("locale='ja' なら top-level の値をそのまま返すべき", () => {
+    it("should return top-level values for locale='ja'", () => {
       const m = requireProblemMetadata("hello-world");
       const r = resolveLocalizedNarrative(m, "ja");
       expect(r.name).toBe("Hello World (Sample)");
-      // Issue #816: narrative re-write で description が変わったので tone-of-voice の
-      // 代表的な substring (= 加藤さん) で検証する。
-      expect(r.description).toContain("加藤さん");
+      expect(r.shortDescription.length).toBeGreaterThan(0);
+      expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
     });
 
-    it("locale='en' の override が宣言されていれば英語を返すべき (hello-world)", () => {
+    it("should return en override fields when locale='en' (hello-world)", () => {
       const m = requireProblemMetadata("hello-world");
       const r = resolveLocalizedNarrative(m, "en");
       expect(r.shortDescription).toMatch(/Minimal Challenge/);
-      expect(r.description).toMatch(/Deploying creates a single SSM Parameter/);
       expect(r.learningGoals.length).toBeGreaterThanOrEqual(2);
+      // fairness contract: description は narrative の戻り値型から削除済
+      expect((r as unknown as { description?: string }).description).toBeUndefined();
     });
 
     it("全 4 既存問題が en の翻訳を持つべき (#1108 で ja+en のみサポート)", () => {

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -65,6 +65,16 @@ export interface ProblemEndpointEntry {
 /**
  * Portal で表示する問題メタ情報。`cfnTemplate` / `cfnParameters` 等の deploy 内部情報は
  * 含めない (= 答えのヒントを意図せず露出させないため)。
+ *
+ * **fairness contract**:
+ * - `description` (= 採点ルール / hardened state / 段階詳細などのネタバレを含む長文) は
+ *   admin / authoring view 専用で portal には決して embed しない。 portal では
+ *   `shortDescription` のみ。
+ * - `phases` / `disruptions` は `publicHint === true` で著者が明示宣言したエントリだけを
+ *   portal に流す (= 予告 UI / countdown 用)。 internal の `effect` / `parameters` /
+ *   `operatorEditable` 等の採点 trigger 詳細は portal に流さない。
+ * - これらは build-time (= `metadataToEntry`) で narrowing し、 portal bundle そのものに
+ *   ネタバレ JSON が残らない。 DevTools 越しの inspection でも漏れない。
  */
 export interface ProblemCatalogEntry {
   readonly id: string;
@@ -76,22 +86,19 @@ export interface ProblemCatalogEntry {
   readonly difficulty: 1 | 2 | 3 | 4 | 5;
   readonly estimatedDuration: string;
   readonly shortDescription: string;
-  readonly description: string;
   readonly learningGoals: readonly string[];
   readonly tags: readonly string[];
   /** ADR-012 Phase 2: endpoint slot 宣言 (= portal plugin の default URL 組立に使う)。 */
   readonly endpoints: readonly ProblemEndpointEntry[];
-  /** ADR-012 Phase 4: 段階制の予告 (= afterMinutes で portal が countdown / status pill 表示)。 */
+  /** ADR-012 Phase 4: 段階制の予告 (= afterMinutes で portal が countdown / status pill 表示)。 `publicHint: true` のみ。 */
   readonly phases: readonly ProblemPhaseEntry[];
-  /** ADR-012 Phase 4: 「妨害」予告 (= template.yaml-bundled self-triggered Scheduler)。 */
+  /** ADR-012 Phase 4: 「妨害」予告 (= template.yaml-bundled self-triggered Scheduler)。 `publicHint: true` のみ。 */
   readonly disruptions: readonly ProblemDisruptionEntry[];
   /** ADR-012 Phase 5: dashboard.slots[slotName] = portal/<file>.tsx 相対 path の map。 */
   readonly dashboardSlots?: ProblemDashboardSlots;
-  /** Issue #583 Phase 5: 競技者向け field の locale override (en / es / zh)。 ja は top-level。 */
+  /** Issue #583 Phase 5: 競技者向け field の locale override (en のみ、 #1108 で es / zh は廃止)。 ja は top-level。 */
   readonly i18n?: {
     readonly en?: ProblemI18nOverride;
-    readonly es?: ProblemI18nOverride;
-    readonly zh?: ProblemI18nOverride;
   };
 }
 
@@ -147,11 +154,13 @@ interface ProblemMetadata {
 /**
  * Issue #583 Phase 5: 1 locale 分の override。 各 field 省略時は ja (= top-level の値) に fallback。
  * portal の locale switcher (= "ja" / "en") と対応。
+ *
+ * fairness contract: `description` (= ネタバレ長文) は portal に embed しないため、
+ * locale override も `name` / `shortDescription` / `learningGoals` のみ受け付ける。
  */
 export interface ProblemI18nOverride {
   readonly name?: string;
   readonly shortDescription?: string;
-  readonly description?: string;
   readonly learningGoals?: readonly string[];
 }
 
@@ -172,11 +181,18 @@ function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return out;
 }
 
+/**
+ * Build-time narrowing for portal-side problem catalog.
+ *
+ * **fairness contract** (= bundle に embed しても DevTools で漏れて困るものは入れない):
+ *   - `description` は admin/authoring 専用なので drop (= portal は `shortDescription` だけ表示する)
+ *   - `phases` / `disruptions` は `publicHint === true` で著者が明示宣言した entry のみ通す。
+ *     `effect` / `parameters` / `operatorEditable` / `eventDetailType` 等の内部 trigger 詳細も全 drop
+ *   - i18n.en も同じ contract で `description` を drop
+ */
 function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
   const dashboardSlots = metadata.dashboard?.slots;
-  // 競技者向けには operator 内部 field (= effect / parameters / operatorEditable /
-  // eventDetailType 等の採点 / trigger internals) を全部隠す。 1 箇所に narrowing を集約
-  // して props-builder 等での re-implement を防ぐ。
+  const publicI18n = sanitizeI18n(metadata.i18n);
   return {
     id: metadata.id,
     name: metadata.name,
@@ -187,7 +203,6 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
     difficulty: metadata.difficulty,
     estimatedDuration: metadata.estimatedDuration,
     shortDescription: metadata.shortDescription,
-    description: metadata.description,
     learningGoals: metadata.learningGoals,
     tags: metadata.tags,
     endpoints:
@@ -202,31 +217,52 @@ function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry {
         ...omitUndefined({ label: ep.label, description: ep.description }),
       })) ?? [],
     phases:
-      metadata.phases?.map(
-        (p) =>
-          omitUndefined({
-            name: p.name,
-            afterMinutes: p.afterMinutes,
-            description: p.description,
-            publicHint: p.publicHint,
-          }) as ProblemPhaseEntry,
-      ) ?? [],
+      metadata.phases
+        ?.filter((p) => p.publicHint === true)
+        .map(
+          (p) =>
+            omitUndefined({
+              name: p.name,
+              afterMinutes: p.afterMinutes,
+              description: p.description,
+              publicHint: true,
+            }) as ProblemPhaseEntry,
+        ) ?? [],
     disruptions:
-      metadata.disruptions?.map(
-        (d) =>
-          omitUndefined({
-            id: d.id,
-            name: d.name,
-            defaultAfterMinutes: d.defaultAfterMinutes,
-            description: d.description,
-            publicHint: d.publicHint,
-          }) as ProblemDisruptionEntry,
-      ) ?? [],
+      metadata.disruptions
+        ?.filter((d) => d.publicHint === true)
+        .map(
+          (d) =>
+            omitUndefined({
+              id: d.id,
+              name: d.name,
+              defaultAfterMinutes: d.defaultAfterMinutes,
+              description: d.description,
+              publicHint: true,
+            }) as ProblemDisruptionEntry,
+        ) ?? [],
     ...(dashboardSlots && Object.keys(dashboardSlots).length > 0
       ? { dashboardSlots: dashboardSlots as ProblemDashboardSlots }
       : {}),
-    ...(metadata.i18n && Object.keys(metadata.i18n).length > 0 ? { i18n: metadata.i18n } : {}),
+    ...(publicI18n ? { i18n: publicI18n } : {}),
   };
+}
+
+/**
+ * i18n override から portal 用 field のみ取り出す (= description は drop)。 全 locale entry が
+ * 空 (= override field が無い) なら undefined を返し、 catalog entry の i18n field 自体を省略する。
+ */
+function sanitizeI18n(raw: ProblemMetadata["i18n"]): ProblemCatalogEntry["i18n"] | undefined {
+  if (!raw) return undefined;
+  const en = raw.en
+    ? omitUndefined({
+        name: raw.en.name,
+        shortDescription: raw.en.shortDescription,
+        learningGoals: raw.en.learningGoals,
+      })
+    : undefined;
+  if (!en || Object.keys(en).length === 0) return undefined;
+  return { en: en as ProblemI18nOverride };
 }
 
 const PROBLEM_CATALOG: readonly ProblemCatalogEntry[] = Object.values(metadataModules)
@@ -258,14 +294,12 @@ export function resolveLocalizedNarrative(
 ): {
   readonly name: string;
   readonly shortDescription: string;
-  readonly description: string;
   readonly learningGoals: readonly string[];
 } {
   if (locale === "ja" || !entry.i18n) {
     return {
       name: entry.name,
       shortDescription: entry.shortDescription,
-      description: entry.description,
       learningGoals: entry.learningGoals,
     };
   }
@@ -274,14 +308,12 @@ export function resolveLocalizedNarrative(
     return {
       name: entry.name,
       shortDescription: entry.shortDescription,
-      description: entry.description,
       learningGoals: entry.learningGoals,
     };
   }
   return {
     name: override.name ?? entry.name,
     shortDescription: override.shortDescription ?? entry.shortDescription,
-    description: override.description ?? entry.description,
     learningGoals: override.learningGoals ?? entry.learningGoals,
   };
 }

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -20,7 +20,6 @@ import {
   resolveLocalizedNarrative,
 } from "../data/problems";
 import { useI18n, useT } from "../i18n";
-import { renderMarkdownToSafeHtml } from "../lib/markdown";
 import { PortalPluginSlots } from "../plugins/PortalPluginSlots";
 
 const DIFFICULTY_KEY: Record<ProblemCatalogEntry["difficulty"], string> = {
@@ -245,7 +244,7 @@ function ProblemInfoSection({
   t,
 }: {
   metadata: ProblemCatalogEntry;
-  narrative: { readonly description: string };
+  narrative: { readonly shortDescription: string };
   t: (key: string, params?: Readonly<Record<string, string | number>>) => string;
 }) {
   // Audit table #1/#2: 想定プレイ時間 / 学習目的 / タグ は competition では出さない
@@ -272,14 +271,12 @@ function ProblemInfoSection({
 
         <div>
           <Box variant="awsui-key-label">{t("problem_detail.info_description_label")}</Box>
-          {/* Issue #661: metadata.json の description は markdown source。 marked → DOMPurify
-           *   で sanitize した HTML を render する。 ADR-008 で community contributor 経由の
-           *   metadata 受け入れを想定して必ず XSS sanitize を通す。 */}
-          <div
-            className="problem-description-markdown"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify sanitized in renderMarkdownToSafeHtml
-            dangerouslySetInnerHTML={{ __html: renderMarkdownToSafeHtml(narrative.description) }}
-          />
+          {/* fairness contract (#1124 follow-up): metadata.description は採点ルール /
+           *   hardened state / 段階詳細 などのネタバレを含むので portal には embed しない。
+           *   競技者向けの 1 行サマリ (= shortDescription) のみ表示する。 admin / authoring
+           *   view 用の長文は apps/application-admin-console / docs/problems/AUTHORING.html
+           *   を参照。 */}
+          <Box variant="p">{narrative.shortDescription}</Box>
         </div>
       </SpaceBetween>
     </Container>

--- a/problems/battles/microservice-migration-battle/metadata.json
+++ b/problems/battles/microservice-migration-battle/metadata.json
@@ -117,7 +117,8 @@
       "effect": {
         "switchPlatformToDegraded": ["ec2"]
       },
-      "description": "EC2 上の劣化フェーズ。 EC2 hosting platform の加点が degradedPoints (= 10) に切り替わる。"
+      "description": "EC2 hosting で稼働を続けているとスコア加算が degraded 値に切り替わる予告フェーズ。",
+      "publicHint": true
     },
     {
       "name": "legacy",
@@ -125,7 +126,8 @@
       "effect": {
         "scorePathOverride": "/score?legacy=true"
       },
-      "description": "Legacy code path フェーズ。 各サービスに仕込まれた遅延 code path を取り除く必要が出る。"
+      "description": "スコア engine が `/score?legacy=true` に切替わる予告フェーズ。",
+      "publicHint": true
     }
   ],
   "disruptions": [
@@ -139,7 +141,8 @@
         "delayMs": 200,
         "device": "eth0"
       },
-      "description": "deploy 後 60 分 (default) の self-triggered Scheduler が EC2 の eth0 に `tc qdisc add ... netem delay 200ms` を注入する。 phases[0]=degraded と同時刻で発火し、 score engine 側の degradedPoints 切替と組み合わさって accumulated latency による減点が始まる。 operator は deploy 時に afterMinutes を上書き可能 (CFn parameter `DegradedAfterMinutes`)。"
+      "description": "deploy 後 60 分 (default) で EC2 のネットワーク遅延が増加する予告。",
+      "publicHint": true
     }
   ],
   "dashboard": {


### PR DESCRIPTION
## Summary

- Competitor が見るべきでない問題の長文 description (採点ルール表 / phase の内部 effect 説明 / 学習目的の hint) が participant-portal の build bundle に embed されていた。 Application admin 画面でだけ見えるべき素材が競技者側に出ていた。 user 報告: 「ようはこのテキストは Application 管理画面で見えるのはいいのだけど競技者側で見えちゃだめだよ」
- `ProblemCatalogEntry` / `ProblemI18nOverride` から `description` を完全削除し、 portal は `shortDescription` + `learningGoals` + 予告 panel だけを出す fairness contract に変える。 JSON.stringify でも漏れない (= `should not expose deploy internals or spoiler description` で pin)
- `phases` / `disruptions` は author が明示 `publicHint: true` を立てたものだけ portal に通す。 既存の microservice-migration-battle (= 時間軸が UX 上の予告になっている問題) は 2 phases + 1 disruption とも `publicHint: true` を立て、 description を spoiler-free な予告文 (= mechanism や復旧手段に触れない) に rewrite。 stackstack のような publicHint なしの問題は portal 上で空配列に落ちる (= 既存実装通り author opt-in)

## Regression 分析

- `ProblemDetail.tsx` で長文 description (markdown) が消える。 portal UI 上で問題の `shortDescription` + `learningGoals` + `phases` (publicHint:true のみ) で運用する。 これが今回の意図 (= 競技者は短い予告だけ見て、 採点ルールや内部仕掛けには触れない)
- 既存 5 問題で portal の `i18n.en.description` にも触らない構成 (= `sanitizeI18n` が strip する) なので翻訳の欠落は無い
- `microservice-migration-battle` の `phases[*].description` / `disruptions[*].description` を spoiler-free 文に rewrite。 metadata 自体は application admin 側ではフル description を引き続き表示できる (= 露出経路が違うので影響なし)
- `resolveLocalizedNarrative` の戻り値型からも `description` を削除。 portal 内で description を読む callsite は他に無いことを grep 済

## 物理影響

- CFn: NO-OP (= portal bundle のソース変更のみ。 stack 差分なし)
- 成果物: participant-portal の dist bundle で問題 description が消える (= competitor fairness 改善)。 metadata.json は 1 件 (microservice-migration-battle) で phases/disruptions に `publicHint: true` を 3 個追加 + description を spoiler-free に rewrite

## Test plan

- [x] `bun run --filter @TenkaCloud/participant-portal test` (186 tests pass, 含む新規 fairness pin)
- [x] `make harness` (architecture invariant findings = 0)
- [x] `make before-commit` (lint / typecheck / test / validate-problems / template-security / cdk synth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified problem detail view to display short descriptions instead of full narrative text.
  * Refined visibility of phases and disruptions based on public configuration settings.
  * Updated internationalization support to focus on essential problem information.

* **Tests**
  * Updated test coverage for problem metadata visibility and localization handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->