### PR TITLE
fix(admin): drop dead Health Check phase + granular progress bar

### DIFF
--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -372,7 +372,6 @@
     "phase_building_description": "CodeBuild assembles the CFn to deploy the problem template to the competitor account.",
     "phase_building_link": "Open CodeBuild / CloudFormation logs in AWS Console",
     "phase_building_url_unavailable": "CodeBuild console URL is not yet available.",
-    "phase_health_skipped": "Skipped",
     "label_final_status": "Final status",
     "label_last_updated": "Last updated",
     "label_failure_reason": "Failure reason",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -372,7 +372,6 @@
     "phase_building_description": "CodeBuild が問題テンプレートを競技者アカウントへ deploy するための CFn を組み立てます。",
     "phase_building_link": "Open CodeBuild / CloudFormation logs in AWS Console",
     "phase_building_url_unavailable": "CodeBuild console URL is not yet available.",
-    "phase_health_skipped": "Skipped",
     "label_final_status": "Final status",
     "label_last_updated": "Last updated",
     "label_failure_reason": "Failure reason",

--- a/apps/application-admin-console/src/lib/deploy-phases.ts
+++ b/apps/application-admin-console/src/lib/deploy-phases.ts
@@ -1,5 +1,5 @@
 /**
- * DeploymentDetail を Netlify 風の 5 phase に変換するロジック。
+ * DeploymentDetail を Netlify 風の 4 phase に変換するロジック。
  *
  * 既存の backend を変えずに、`DeploymentSummary` + `StackProgress` だけから派生する。
  * Phase の status は次の順で決まる:
@@ -8,8 +8,7 @@
  *      Complete、まだなら IN_PROGRESS は In Progress、FAILED + 観測なし は Failed。
  *   3. CloudFormation Deploy — events を見て判定。すべて `_COMPLETE` なら Complete、
  *      `_FAILED` を含めば Failed、`_IN_PROGRESS` を含めば In Progress、空なら Pending。
- *   4. Health Check — placeholder。常に Skipped (= 将来の Lambda 連携枠)。
- *   5. Complete / Teardown — deployment.status を素直に反映。
+ *   4. Complete / Teardown — deployment.status を素直に反映。
  *
  * Backend を変えない frontend-only の派生なので、ここに集約することで View 側を薄く保つ。
  */
@@ -23,7 +22,7 @@ import type {
 
 export type PhaseStatus = "complete" | "in-progress" | "failed" | "skipped" | "pending";
 
-export type PhaseId = "enqueued" | "building" | "cfn-deploy" | "health-check" | "complete";
+export type PhaseId = "enqueued" | "building" | "cfn-deploy" | "complete";
 
 export interface DeployPhase {
   readonly id: PhaseId;
@@ -154,8 +153,12 @@ export function deriveFinalStatus(status: DeploymentStatus): PhaseStatus {
 }
 
 /**
- * 5 phase 派生のコア関数。`stackProgress` は未取得 (= null) を許容する:
+ * 4 phase 派生のコア関数。`stackProgress` は未取得 (= null) を許容する:
  * その場合 `Building` / `CloudFormation Deploy` は status だけから推定する。
+ *
+ * 旧 5 phase に居た Health Check は ADR-012 Phase 3.B で GenericScoringLambda に
+ * 置き換わり (= deploy-time の health check 連携枠としては復活しない設計) のため、
+ * 永続 Skipped な dead UI を消した。
  */
 export function derivePhases(
   deployment: DeploymentSummary,
@@ -172,12 +175,6 @@ export function derivePhases(
       id: "cfn-deploy",
       name: "CloudFormation Deploy",
       status: deriveCfnDeployStatus(status, stackProgress),
-    },
-    {
-      id: "health-check",
-      name: "Health Check",
-      status: "skipped",
-      note: "Skipped — will be wired to HealthCheck Lambda in a future iteration",
     },
     { id: "complete", name: "Complete / Teardown", status: deriveFinalStatus(status) },
   ];
@@ -293,15 +290,13 @@ function phaseBodyLines(
       return buildingPhaseLines(stackProgress);
     case "cfn-deploy":
       return cfnDeployPhaseLines(stackProgress);
-    case "health-check":
-      return [{ header: false, text: phase.note ?? "Skipped" }];
     case "complete":
       return completePhaseLines(deployment);
   }
 }
 
 /**
- * 5 phase を 1 本の terminal log に展開する。phase ヘッダ行 + events 行を順に並べる。
+ * 4 phase を 1 本の terminal log に展開する。phase ヘッダ行 + events 行を順に並べる。
  */
 export function buildTerminalLog(
   deployment: DeploymentSummary,

--- a/apps/application-admin-console/src/lib/deploy-progress.ts
+++ b/apps/application-admin-console/src/lib/deploy-progress.ts
@@ -1,0 +1,39 @@
+import type { DeploymentStatus } from "../api/deploy-client";
+
+/**
+ * 1 件の deployment が「 何 % 進んだか」 の重み。
+ *
+ * EventDetail 画面の全体プログレスバーは旧実装で `(完了数 / 総数) * 100` だった
+ * (= 1 件運用なら 0 % か 100 % の 2 値で動かない)。 ここで status 別の中間重みを
+ * 与えることで、 1 件運用でも PENDING (5 %) → IN_PROGRESS (50 %) → DELETING (80 %)
+ * → terminal (100 %) と段階的に進む。
+ *
+ * 値は粗いが「 動いてる感」 を出すための UX 指標で、 厳密な物理進捗ではない
+ * (= 厳密に出すには backend で CFn event count / build phase % が必要)。
+ */
+export function deploymentProgressWeight(status: DeploymentStatus): number {
+  switch (status) {
+    case "PENDING":
+      return 5;
+    case "IN_PROGRESS":
+      return 50;
+    case "DELETING":
+      return 80;
+    case "COMPLETE":
+    case "FAILED":
+    case "DELETED":
+    case "EXPIRED":
+    case "AUTO_DELETED":
+      return 100;
+  }
+}
+
+/**
+ * 複数 deployment 全体の進捗 % を返す。
+ * 0 件のときは 0 を返す (= ProgressBar 非表示は呼び出し側で判定)。
+ */
+export function aggregateDeployProgressPercent(statuses: readonly DeploymentStatus[]): number {
+  if (statuses.length === 0) return 0;
+  const totalWeight = statuses.reduce((sum, s) => sum + deploymentProgressWeight(s), 0);
+  return Math.round(totalWeight / statuses.length);
+}

--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -469,12 +469,6 @@ function PhaseBody(props: {
           t={t}
         />
       );
-    case "health-check":
-      return (
-        <Box variant="p" color="text-status-info">
-          {phase.note ?? t("deployment_detail.phase_health_skipped")}
-        </Box>
-      );
     case "complete":
       return (
         <KeyValuePairs

--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -5,6 +5,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { type ApiClient, useApiClient } from "../api/client";
+import type { DeploymentStatus } from "../api/deploy-client";
 import { EVENT_ID_RE, type EventDetail } from "../api/events-client";
 import { DeployProgressPanel } from "../components/event-detail/DeployProgressPanel";
 import { EventDangerZone } from "../components/event-detail/EventDangerZone";
@@ -22,6 +23,7 @@ import type { AppConfig } from "../config";
 import { useEventDetail } from "../hooks/useEventDetail";
 import { useEventOperations, validateEndsAtInput } from "../hooks/useEventOperations";
 import { useT } from "../i18n";
+import { aggregateDeployProgressPercent } from "../lib/deploy-progress";
 import { computeEventWizardState, type WizardState } from "../lib/event-wizard";
 
 type EventOperations = ReturnType<typeof useEventOperations>;
@@ -37,10 +39,12 @@ interface DeploymentCounts {
 }
 
 function summarizeDeployments(detail: EventDetail): DeploymentCounts {
+  const statuses: DeploymentStatus[] = [];
   const counts = Object.values(detail.deploymentsByProblem).reduce(
     (acc, list) => {
       for (const deployment of list) {
         acc.totalDeployCount += 1;
+        statuses.push(deployment.status);
         if (deployment.status === "COMPLETE" || deployment.status === "AUTO_DELETED") {
           acc.completeCount += 1;
         }
@@ -61,8 +65,7 @@ function summarizeDeployments(detail: EventDetail): DeploymentCounts {
   return {
     ...counts,
     allDoneCount,
-    deployProgressPercent:
-      counts.totalDeployCount > 0 ? Math.round((allDoneCount / counts.totalDeployCount) * 100) : 0,
+    deployProgressPercent: aggregateDeployProgressPercent(statuses),
   };
 }
 

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -88,20 +88,19 @@ const progressWithFailed: StackProgress = {
 };
 
 describe("derivePhases", () => {
-  it("should show all 5 phases as Complete (or Skipped) when status=COMPLETE", () => {
+  it("should show all 4 phases as Complete when status=COMPLETE", () => {
     const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
-    expect(phases.map((p) => p.id)).toEqual([
-      "enqueued",
-      "building",
-      "cfn-deploy",
-      "health-check",
-      "complete",
-    ]);
+    expect(phases.map((p) => p.id)).toEqual(["enqueued", "building", "cfn-deploy", "complete"]);
     expect(phases[0].status).toBe("complete"); // Enqueued
     expect(phases[1].status).toBe("complete"); // Building
     expect(phases[2].status).toBe("complete"); // CFn Deploy
-    expect(phases[3].status).toBe("skipped"); // Health Check (placeholder)
-    expect(phases[4].status).toBe("complete"); // Final
+    expect(phases[3].status).toBe("complete"); // Final
+  });
+
+  it("should not include the dead Health Check placeholder phase", () => {
+    const phases = derivePhases({ ...baseDeployment, status: "COMPLETE" }, progressAllComplete);
+    expect(phases.map((p) => p.id)).not.toContain("health-check");
+    expect(phases.every((p) => p.status !== "skipped" || p.id === "complete")).toBe(true);
   });
 
   it("should show CloudFormation Deploy phase as Failed when status=FAILED with CFn progress", () => {
@@ -131,9 +130,9 @@ describe("derivePhases", () => {
     expect(pick(phases, "cfn-deploy").status).toBe("pending");
   });
 
-  it("should still generate 5 phases when stackProgress=null", () => {
+  it("should still generate 4 phases when stackProgress=null", () => {
     const phases = derivePhases({ ...baseDeployment, status: "PENDING" }, null);
-    expect(phases).toHaveLength(5);
+    expect(phases).toHaveLength(4);
     expect(phases[1].status).toBe("pending"); // building pending
     expect(phases[2].status).toBe("pending"); // cfn pending
   });
@@ -252,7 +251,6 @@ describe("buildTerminalLog", () => {
       "> Enqueued [complete]",
       "> Building [complete]",
       "> CloudFormation Deploy [complete]",
-      "> Health Check [skipped]",
       "> Complete / Teardown [complete]",
     ]);
     // CFn event lines should include logicalResourceId.

--- a/apps/application-admin-console/test/lib/deploy-progress.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-progress.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateDeployProgressPercent,
+  deploymentProgressWeight,
+} from "../../src/lib/deploy-progress";
+
+describe("deploymentProgressWeight", () => {
+  it("should return 5% for a freshly queued PENDING deployment", () => {
+    expect(deploymentProgressWeight("PENDING")).toBe(5);
+  });
+
+  it("should return 50% for a mid-flight IN_PROGRESS deployment", () => {
+    expect(deploymentProgressWeight("IN_PROGRESS")).toBe(50);
+  });
+
+  it("should return 80% for a DELETING deployment (mostly torn down)", () => {
+    expect(deploymentProgressWeight("DELETING")).toBe(80);
+  });
+
+  it("should return 100% for every terminal status", () => {
+    for (const s of ["COMPLETE", "FAILED", "DELETED", "EXPIRED", "AUTO_DELETED"] as const) {
+      expect(deploymentProgressWeight(s)).toBe(100);
+    }
+  });
+});
+
+describe("aggregateDeployProgressPercent", () => {
+  it("should return 0 when no deployments exist", () => {
+    expect(aggregateDeployProgressPercent([])).toBe(0);
+  });
+
+  it("should reflect single-deployment mid-flight progress (not 0/100 binary) — fixes user-reported binary progress bar", () => {
+    expect(aggregateDeployProgressPercent(["PENDING"])).toBe(5);
+    expect(aggregateDeployProgressPercent(["IN_PROGRESS"])).toBe(50);
+    expect(aggregateDeployProgressPercent(["DELETING"])).toBe(80);
+    expect(aggregateDeployProgressPercent(["COMPLETE"])).toBe(100);
+  });
+
+  it("should average per-deployment weights when multiple deployments mix states", () => {
+    // 2 done + 2 mid-flight = (100 + 100 + 50 + 50) / 4 = 75
+    expect(
+      aggregateDeployProgressPercent(["COMPLETE", "COMPLETE", "IN_PROGRESS", "IN_PROGRESS"]),
+    ).toBe(75);
+    // 1 queued + 1 in-flight + 1 done = (5 + 50 + 100) / 3 ≈ 52
+    expect(aggregateDeployProgressPercent(["PENDING", "IN_PROGRESS", "COMPLETE"])).toBe(52);
+  });
+
+  it("should return 100 when every deployment is terminal", () => {
+    expect(aggregateDeployProgressPercent(["COMPLETE", "FAILED", "AUTO_DELETED"])).toBe(100);
+  });
+});

--- a/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
@@ -114,12 +114,13 @@ describe("DeploymentDetailPage (Netlify-style phase + log view)", () => {
     await waitFor(() => expect(mocks.getDeployment).toHaveBeenCalled());
     await screen.findByTestId("phase-enqueued");
 
-    // all 5 phases should be displayed
-    for (const id of ["enqueued", "building", "cfn-deploy", "health-check", "complete"]) {
+    // all 4 phases should be displayed (the legacy Health Check placeholder is gone)
+    for (const id of ["enqueued", "building", "cfn-deploy", "complete"]) {
       expect(screen.getByTestId(`phase-${id}`)).toBeInTheDocument();
     }
+    expect(screen.queryByTestId("phase-health-check")).toBeNull();
 
-    // それぞれの phase に Complete または Skipped status が出る
+    // each phase should show Complete status
     const enqueued = within(screen.getByTestId("phase-enqueued"));
     expect(enqueued.getByText("Complete")).toBeInTheDocument();
 
@@ -128,9 +129,6 @@ describe("DeploymentDetailPage (Netlify-style phase + log view)", () => {
 
     const cfn = within(screen.getByTestId("phase-cfn-deploy"));
     expect(cfn.getByText("Complete")).toBeInTheDocument();
-
-    const health = within(screen.getByTestId("phase-health-check"));
-    expect(health.getByText("Skipped")).toBeInTheDocument();
 
     const completePhase = within(screen.getByTestId("phase-complete"));
     expect(completePhase.getByText("Complete")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

User reported 2 deploy-progress UX issues in `application-admin-console`:

1. **Health Check phase forever Skipped** — phase #4 was a placeholder for "future HealthCheck Lambda wiring" that never materialized. ADR-012 Phase 3.B replaced the original HealthCheckLambda with GenericScoringLambda (= scoring engine, not a deploy-time health check), so the placeholder has no road to being wired. Removed the dead `health-check` phase entirely. Timeline goes from 5 phases to 4: `Enqueued → Building → CloudFormation Deploy → Complete / Teardown`.

2. **EventDetail progress bar binary** — old formula `(complete + failed) / total * 100` only flipped when a deployment hit a terminal status. For single-deployment events the bar was permanently 0% or 100%. User: 「プログレスバーの意味がない」. Introduced `aggregateDeployProgressPercent` that weights each deployment by status (PENDING 5% / IN_PROGRESS 50% / DELETING 80% / terminal 100%). A single-deploy event now reads ~5 → 50 → 100 as it progresses.

## Regression analysis

- `PhaseId` union loses `"health-check"`. TypeScript exhaustiveness in `phaseBodyLines` / `DeploymentDetail` switch arms guarantees other call sites are covered (= typecheck verifies).
- i18n key `phase_health_skipped` (ja/en) removed — grep confirmed no other usage.
- DeploymentDetail page test now asserts exactly 4 phase test-ids + that `phase-health-check` is absent — pins against accidental re-introduction.
- Progress weights are intentionally coarse UX heuristics, not physical CFn progress. Tests pin the curve (`PENDING=5 / IN_PROGRESS=50 / DELETING=80 / terminal=100`) so future status-enum additions can't silently regress to binary.
- No backend / API contract change. `EventDetail` consumes the same `DeploymentSummary[]` it always has.

## Physical impact

- CFn: NO-OP (frontend-only)
- Artifacts: `application-admin-console` bundle drops the Health Check phase card + its skipped-status label; EventDetail progress bar % is now derived from per-deployment status weighting

## Test plan

- [x] `bun run --filter @TenkaCloud/application-admin-console test` — 262 tests pass, including 8 new deploy-progress tests + revised phase tests
- [x] `make harness` — 0 errors (1 pre-existing `file-too-large` warning on DeploymentDetail.tsx, unrelated)
- [x] `make before-commit` — lint / typecheck / test / validate-problems / cdk synth all green
- [ ] Manual UI verification deferred — user has live deploy in progress, can confirm the bar now moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)