### PR TITLE
docs(problems): add per-problem README in JA + EN for 5 sample problems

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -24,9 +24,17 @@ references/**
 # spellcheck-tech-word の日本語側 dictionary) の対象外。 プロジェクトは
 # OSS 配布で英語を正本としているため、 README / CONTRIBUTING / apps/*/README は
 # 全て英語固定 (#1087)。
+# problems/<category>/<id>/README.en.md は問題ごとの英語 README (= 同階層の
+# README.md が日本語 narrative、 README.en.md が英訳)。 spellcheck-tech-word が
+# 英文中の "session" を "セッション" に書き換えるなど誤検出するため除外する。
 README.md
 CONTRIBUTING.md
 apps/*/README.md
+# 問題ディレクトリ直下の README は JA narrative + EN AWS 製品名 (Session Manager / Parameter Store /
+# Auto Scaling 等) を多用する。 spellcheck-tech-word が AWS 公式の英語製品名を
+# "セッション" 等のカタカナに書き換える誤検出を起こすため、 JA / EN とも除外する。
+problems/**/README.md
+problems/**/README.en.md
 
 # 外部 spec の vendor 翻訳。 textlint の社内 style rule (= 句点 / 接続詞 / 曖昧表現)
 # を当てると原典の意図がずれる。

--- a/problems/battles/hello-world-battle/README.en.md
+++ b/problems/battles/hello-world-battle/README.en.md
@@ -1,0 +1,64 @@
+# Hello World Battle (Sample)
+
+> 日本語版: [README.md](./README.md)
+
+The **minimal sample** for Battle uptime scoring. Deploys nginx (frontend) and Python `http.server` (api) on a single EC2 instance; a 1-minute health probe awards +100 points per cycle while both endpoints return 200.
+
+| Field          | Value                                  |
+| -------------- | -------------------------------------- |
+| Category       | Battle (real-time PvP)                 |
+| Difficulty     | 1 / 5 (beginner)                       |
+| Estimated time | 30 min                                 |
+| status         | `ready`                                |
+| Scoring        | `uptime` (`pointsPerSuccess`: 100)     |
+
+## What you do
+
+As the new SRE on duty, defend the two endpoints (`FrontendUrl` / `ApiUrl`) deployed at start, and restore service via SSM Session Manager whenever attackers knock something down. A probe runs every minute; +100 pt accrues only on cycles where both endpoints return 200.
+
+- **Attackers** tamper with the shared EC2 / Security Group to bring frontend or API down (e.g. `systemctl stop nginx`).
+- **Defenders** connect via SSM Session Manager (no SSH) and restart the service.
+
+All operations stay inside one EC2, so there is no cross-tenant impact.
+
+## What gets deployed
+
+```
+┌─────── EC2 t3.micro (Amazon Linux 2023, public IP) ───────┐
+│  nginx          :80   → /  (FrontendUrl)                  │
+│  python3 http.server :8080 → /healthz (ApiUrl)            │
+└────────────────────────────────────────────────────────────┘
+       ▲
+       │ Health Check Lambda probes every 1 minute
+       │ Both 200 → +100 pt / cycle
+```
+
+- Dedicated VPC (`10.99.0.0/16`) + public subnet + IGW
+- InstanceRole for SSM Session Manager (`AmazonSSMManagedInstanceCore`)
+- `ParticipantViewerRole` (read-only role competitors AssumeRole into for AWS Console)
+
+## Scoring
+
+| State                                                | Per cycle (1 min) |
+| ---------------------------------------------------- | ----------------- |
+| `FrontendUrl /` and `ApiUrl /healthz` both return 200 | +100 pt           |
+| Either is non-200 / times out                        | 0 pt              |
+
+See the `scoring` field in [`metadata.json`](./metadata.json) for the full spec.
+
+## Cost
+
+- EC2 t3.micro: within AWS Free Tier (750 hr/month for 12 months)
+- VPC / IGW / SG: free
+- One ~30-minute session is zero-cost while inside the Free Tier.
+
+## Learning goals
+
+- Confirm that TenkaCloud's Battle uptime scoring engine works against real endpoints.
+- Experience a minimal EC2 + nginx + Python web stack receiving health-check probes.
+- Practice connecting via SSM Session Manager without SSH to start / stop services.
+
+## Related files
+
+- [`metadata.json`](./metadata.json) — problem metadata (source of truth for UI / scoring engine)
+- [`template.yaml`](./template.yaml) — one-page CFn template deployed into the competitor account

--- a/problems/battles/hello-world-battle/README.md
+++ b/problems/battles/hello-world-battle/README.md
@@ -1,0 +1,64 @@
+# Hello World Battle (Sample)
+
+> English version: [README.en.md](./README.en.md)
+
+Battle uptime scoring の **最小 sample** 問題。 EC2 1 台に nginx (frontend) と Python http.server (api) を起動し、 1 分ごとの health probe で両方が 200 を返す間スコアが +100 加算される。
+
+| 項目         | 値                                       |
+| ------------ | ---------------------------------------- |
+| カテゴリ     | Battle (リアルタイム対戦)                |
+| 難易度       | 1 / 5 (入門)                             |
+| 想定時間     | 30 分                                    |
+| status       | `ready`                                  |
+| 採点方式     | `uptime` (`pointsPerSuccess`: 100)       |
+
+## 何をする問題か
+
+新人 SRE のあなたは、 deploy 直後の 2 つの endpoint (`FrontendUrl` / `ApiUrl`) が落ちないように守りながら、 攻撃側の妨害で stop されたサービスを SSM Session Manager で復旧する。 1 分ごとに probe が走り、 両方が 200 を返すサイクルだけ +100 pt が加算される。
+
+- **攻撃側**: 同じ EC2 / Security Group を弄って frontend や API を止める (例: `systemctl stop nginx`)
+- **防御側**: SSM Session Manager で SSH 不要に入り、 サービスを再起動する
+
+全操作は 1 EC2 内で完結するため cross-tenant 影響なし。
+
+## デプロイされるもの
+
+```
+┌─────── EC2 t3.micro (Amazon Linux 2023, Public IP) ───────┐
+│  nginx          :80   → /  (FrontendUrl)                  │
+│  python3 http.server :8080 → /healthz (ApiUrl)            │
+└────────────────────────────────────────────────────────────┘
+       ▲
+       │ 1 分ごとに Health Check Lambda が probe
+       │ 両方 200 → +100 pt / cycle
+```
+
+- 専用 VPC (`10.99.0.0/16`) + 公開 subnet + IGW
+- SSM Session Manager 用 InstanceRole (`AmazonSSMManagedInstanceCore`)
+- `ParticipantViewerRole` (競技者が AWS Console を読み取り専用で AssumeRole する用)
+
+## 採点
+
+| 状態                                            | 1 cycle (1 分) |
+| ----------------------------------------------- | -------------- |
+| `FrontendUrl /` と `ApiUrl /healthz` が両方 200 | +100 pt        |
+| いずれかが 200 以外 / timeout                   | 0 pt           |
+
+詳細は [`metadata.json`](./metadata.json) の `scoring` フィールド参照。
+
+## コスト
+
+- EC2 t3.micro: AWS Free Tier 750 時間/月 (12 ヶ月) 内
+- VPC / IGW / SG: 無料
+- 1 セッション (~30 分) は Free Tier 範囲ならゼロ円
+
+## 学習目的
+
+- TenkaCloud の Battle uptime scoring engine が実 endpoint で動くことを確認する
+- EC2 + nginx + Python の最小 web stack で health probe を受ける流れを体験する
+- SSM Session Manager で SSH 不要に接続し、 サービスを start / stop する操作を覚える
+
+## 関連ファイル
+
+- [`metadata.json`](./metadata.json) — 問題メタデータ (UI / scoring engine 正本)
+- [`template.yaml`](./template.yaml) — CFn ペライチ (competitor account に deploy する本体)

--- a/problems/battles/microservice-migration-battle/README.en.md
+++ b/problems/battles/microservice-migration-battle/README.en.md
@@ -1,0 +1,167 @@
+# Microservice Migration Battle
+
+> 日本語版: [README.md](./README.md)
+>
+> **Status: Phase 1 (draft)** — Phase 1 only ships the monolith problem files (3 services co-tenant on a single EC2). The score engine / registration UI / EC2 degradation cron / phase progression are added in Phase 2 / Phase 3 (= follow-ups to issue #572).
+
+A Battle problem in which a monolith of three services (`users` / `orders` / `catalog`) co-tenant on a single EC2 must be split out, during a 90–120 minute event, into three different hosting environments: **Lambda + API Gateway**, **Amazon ECS (Fargate)**, and **AWS App Runner**.
+
+## Overview
+
+- Category: Battle (real-time PvP)
+- Difficulty: 4 / 5
+- Estimated time: 90 – 120 min
+- Learning goals:
+  - Experience an incremental monolith → microservices migration (strangler fig pattern).
+  - Compare the spectrum of Lambda function / managed container / orchestrated container on real infrastructure.
+  - Decide which service to extract first under a score-degradation constraint.
+  - Read the code and remove an intentionally-injected slow code path (`?legacy=true`).
+
+## Architecture
+
+### Initial state (right after deploy / what Phase 1 ships)
+
+```text
+┌─────────────── EC2 (t3.small, Amazon Linux 2023) ───────────────┐
+│                                                                  │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                       │
+│  │  users   │  │  orders  │  │ catalog  │  ← co-tenant via       │
+│  │  :3001   │  │  :3002   │  │  :3003   │     docker compose     │
+│  └──────────┘  └──────────┘  └──────────┘                       │
+│         ▲             ▲             ▲                            │
+│         └─────────────┴─────────────┘                            │
+│                       │                                          │
+│  ┌────────────────────────────────────────────┐                  │
+│  │  nginx :80  →  /users/*   /orders/*        │                  │
+│  │             →  /catalog/*                  │                  │
+│  └────────────────────────────────────────────┘                  │
+└──────────────────────────────────────────────────────────────────┘
+                       ▲
+                       │ Score Engine polls every 1 minute
+                       │ (implemented in Phase 2)
+                       │ /users/score, /orders/score, /catalog/score
+```
+
+### Target end-state (= what a fully-split competitor produces)
+
+```text
+                ┌────────── Lambda + API Gateway ───────────┐
+                │  /users   → handler (Hono on Lambda)        │
+                └─────────────────────────────────────────────┘
+
+                ┌────────── ECS Fargate Service ─────────────┐
+                │  /orders  → ALB → Fargate Task (container)  │
+                └─────────────────────────────────────────────┘
+
+                ┌────────── AWS App Runner ──────────────────┐
+                │  /catalog → App Runner Service (container)  │
+                └─────────────────────────────────────────────┘
+```
+
+> Which service goes to which hosting target is up to the competitor. With 3! = 6 combinations, the assignment becomes each team's strategic call.
+
+## Service spec
+
+All three services are isomorphic (Hono on Node.js 20; only port and service name differ).
+
+| service   | port | self-reported platform (`/meta`) | handlers                       |
+| --------- | ---- | -------------------------------- | ------------------------------ |
+| `users`   | 3001 | `ec2`                            | `/meta`, `/score`, `/healthz`  |
+| `orders`  | 3002 | `ec2`                            | same as above                  |
+| `catalog` | 3003 | `ec2`                            | same as above                  |
+
+### Endpoints
+
+Common HTTP routes:
+
+- `GET /meta` → `{ "service": "<name>", "platform": "ec2" | "lambda" | "ecs" | "apprunner", "version": "1.0.0" }`
+- `GET /score` → `{ "score": <int> }` (fast path, ~5ms)
+- `GET /score?legacy=true` → same shape, but with an intentional **2-second sleep** (= late-game gimmick; in Phase 2 the score engine switches to this)
+- `GET /healthz` → `{ "ok": true, "service": "<name>" }`
+
+### Local development
+
+```bash
+cd problems/battles/microservice-migration-battle/services
+docker compose up --build
+curl http://localhost/users/score
+curl http://localhost/orders/score
+curl http://localhost/catalog/score
+```
+
+## Scoring rules (spec for the Phase 2 score engine)
+
+| State                                          | Per check | Per hour |
+| ---------------------------------------------- | --------- | -------- |
+| Unregistered / non-200 / timeout               | -100      | -6,000   |
+| EC2 response (pre-degradation)                 | +100      | +6,000   |
+| EC2 response (post-degradation)                | +10       | +600     |
+| Hosted on Lambda + API GW                      | +1,000    | +60,000  |
+| Hosted on ECS Fargate                          | +1,000    | +60,000  |
+| Hosted on App Runner                           | +1,000    | +60,000  |
+| All 3 services fully separated                 | +5,000 (one-time bundle bonus) |        |
+| Slow-endpoint response (>1.5s)                 | +10       | +600     |
+
+Hosting is identified by the `platform` field returned from `GET /meta` as self-reporting (a Phase 1 design choice).
+
+## Phase timeline
+
+| Time       | Phase              | What happens                                                                                |
+| ---------- | ------------------ | -------------------------------------------------------------------------------------------- |
+| 0 min      | start              | EC2 deploy complete / 3 services up / `BaseUrl` issued                                       |
+| 60 min     | EC2 degradation    | `tc qdisc` injects latency (Phase 2) → EC2 award drops from +100 to +10                      |
+| 90 min     | legacy switch      | Score Engine switches `/score` → `/score?legacy=true` → the slow path becomes visible        |
+| 90–120 min | rewrite + redeploy | Read the code, remove the `legacy` branch, redeploy to each hosting target                   |
+
+## Hints: minimum deploy for each hosting target
+
+> In every case you can reuse this repo's `services/<name>/Dockerfile` as-is.
+
+### Lambda + API Gateway
+
+1. Wrap Hono with the `hono/aws-lambda` adapter (export the handler).
+2. Bundle with `npm install -g esbuild`, or run a container image with `npx tsx`.
+3. `aws lambda create-function --package-type Image --code ImageUri=<ECR URI>` to create the function.
+4. In API Gateway HTTP API, point the integration target to the Lambda function.
+5. Set the env var `PLATFORM=lambda`.
+
+### ECS Fargate
+
+1. `docker build -t <ECR URI>:latest services/orders` → ECR push.
+2. Task Definition (CPU 256 / Memory 512, container port 3002, `PLATFORM=ecs`).
+3. ECS Cluster + Service (1 task), register against the ALB Target Group (port 3002).
+4. Forward `/orders/*` to the Target Group via an ALB Listener Rule.
+
+### App Runner
+
+1. `docker build -t <ECR URI>:latest services/catalog` → ECR push.
+2. Create an App Runner Service (Source = ECR, port 3003, `PLATFORM=apprunner`).
+3. Register the issued App Runner URL directly as the endpoint.
+
+> Minimum IaC examples per target will land under `services/iac-examples/` in Phase 2.
+
+## Retrospective (= why all three hosting flavors at once)
+
+| Axis             | Lambda + API GW          | ECS Fargate                       | App Runner                          |
+| ---------------- | ------------------------ | --------------------------------- | ----------------------------------- |
+| Unit             | function (event-driven)  | container + cluster management    | container (managed)                 |
+| Scale            | per-request, cold start  | per-task (Auto Scaling Group)     | per-request, auto                   |
+| Setup overhead   | light (one HTTP API)     | heavy (VPC / ALB / Service / TaskDef) | medium (one URL, no VPC)        |
+| Main takeaway    | event-driven, async      | orchestration, persistence, network | managed container, source deploy   |
+
+The intent is to let competitors experience the spectrum Lambda (function) ↔ App Runner (managed container) ↔ ECS (orchestrated container) in a single competition.
+
+## Not shipped in Phase 1 (= follow-up PRs)
+
+- The score engine (1-minute polling Lambda + EventBridge Scheduler).
+- DDB table for the registration endpoint.
+- Phase progression (`degradationMinutes` / `legacySwitchMinutes`).
+- EC2 degradation cron (`tc qdisc`).
+- The 3-slot endpoint registration UI in `participant-portal`.
+- The phase-timeline card in the Battle Portal.
+
+These will be implemented in Phase 2 / Phase 3 follow-up issues.
+
+## Known limitations
+
+- The slow code path (2-second sleep on `?legacy=true`) is publicly visible in this repo. Until ADR-008 (= moving problem implementations to a private repo, issue #574) ships, the gimmick can be read in advance.

--- a/problems/battles/microservice-migration-battle/README.md
+++ b/problems/battles/microservice-migration-battle/README.md
@@ -1,5 +1,7 @@
 # Microservice Migration Battle
 
+> English version: [README.en.md](./README.en.md)
+>
 > **Status: Phase 1 (draft)** — Phase 1 では EC2 上のモノリス問題ファイル一式のみを出荷する。スコアエンジン / 登録 UI / EC2 劣化 cron / フェーズ進行ロジックは Phase 2 / Phase 3 で追加される (= issue #572 のフォローアップ)。
 
 EC2 1 台に同居する 3 サービス (`users` / `orders` / `catalog`) のモノリスを、競技時間 90〜120 分の間に **Lambda + API Gateway / Amazon ECS (Fargate) / AWS App Runner** の 3 種類の異なるホスティングへマイクロサービスとして分割していく Battle 問題。

--- a/problems/battles/security-battle-royale/README.en.md
+++ b/problems/battles/security-battle-royale/README.en.md
@@ -1,0 +1,83 @@
+# Security Battle Royale
+
+> 日本語版: [README.md](./README.md)
+
+A Battle around an e-commerce-style web app, "Unicorn.Rentals," deliberately seeded with vulnerabilities. Players take attacker or defender roles: attackers sweep other teams' public endpoints to capture scoring resources, defenders patch holes without taking the app offline. SQL injection / RCE / SSRF / IMDS exposure coexist by design.
+
+| Field          | Value                                  |
+| -------------- | -------------------------------------- |
+| Category       | Battle (real-time PvP)                 |
+| Difficulty     | 3 / 5                                  |
+| Estimated time | 60–90 min                              |
+| status         | `draft`                                |
+| Scoring        | `uptime-multi` (`pointsAllOk`: 100)    |
+
+## What you do
+
+- **Attackers** sweep other teams' `FrontendUrl` / `ApiUrl` and exploit the seeded SQLi / RCE / SSRF / IMDS exposure to steal scoring resources.
+- **Defenders** patch vulnerabilities **without shutting the app down**. Killing the service technically protects you, but the uptime probe stops paying out.
+
+That trade-off (= harden while staying available) is the core of the problem.
+
+## What gets deployed
+
+```
+┌── single EC2 (Amazon Linux 2023, t3.small) docker-compose ──┐
+│                                                              │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                    │
+│  │  nginx   │  │  Flask   │  │  mysql   │                    │
+│  │  :80     │  │  :8080   │  │  :3306   │                    │
+│  └──────────┘  └──────────┘  └──────────┘                    │
+│       │              │              │                        │
+│  FrontendUrl     ApiUrl         (private)                    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Dedicated VPC + public subnet + IGW
+- Public ports: 80 (frontend) / 8080 (api); restrictable via `AllowedCidr`
+- `DbPassword` is a CFn parameter (NoEcho); the deploy chain generates it from `__RANDOM_PASSWORD__`
+
+## Scoring
+
+Every minute, both endpoints are probed; if both return 200, +100 pt.
+
+| State                                                  | Per cycle |
+| ------------------------------------------------------ | --------- |
+| `FrontendUrl /` and `ApiUrl /healthz` both return 200  | +100 pt   |
+| Either non-200 / times out                             | 0 pt      |
+
+See the `scoring` field in [`metadata.json`](./metadata.json) for the full spec.
+
+## Local development
+
+```bash
+cd problems/battles/security-battle-royale/local
+docker compose up --build
+# frontend: http://localhost:80
+# api:      http://localhost:8080/healthz
+```
+
+`local/docker-compose.yaml` + `local/mysql-init.sql` reproduce the same 3-container stack as production. `api/api.py` and `frontend/index.html` contain the vulnerabilities themselves.
+
+## Seeded vulnerabilities (= spoilers)
+
+- **SQL injection** — raw string concatenation in `api.py` search queries.
+- **RCE** — `eval` / shell-out style helpers behind a debug endpoint.
+- **SSRF** — a helper endpoint that fetches an arbitrary URL.
+- **IMDS exposure** — IMDSv1 enabled; chained with SSRF, IAM Role credentials can be exfiltrated.
+
+> Until ADR-008 (= moving problem implementations to a private repo, issue #574) ships, these can be read ahead in the public repo.
+
+## Learning goals
+
+- Walk through the workflow of discovering and patching intentional SQL injection / RCE / SSRF.
+- Understand the EC2 IMDS / IAM Role exposure path and the best practices to close it.
+- Experience the attacker / defender trade-off (keep availability while hardening) in real time.
+
+## Related files
+
+- [`metadata.json`](./metadata.json) — problem metadata
+- [`template.yaml`](./template.yaml) — one-page CFn template deployed into the competitor account
+- [`api/api.py`](./api/api.py) — Flask API (where the vulnerabilities live)
+- [`frontend/index.html`](./frontend/index.html) — static page served by nginx
+- [`local/docker-compose.yaml`](./local/docker-compose.yaml) — local reproduction

--- a/problems/battles/security-battle-royale/README.md
+++ b/problems/battles/security-battle-royale/README.md
@@ -1,0 +1,83 @@
+# Security Battle Royale
+
+> English version: [README.en.md](./README.en.md)
+
+意図的に脆弱性を仕込んだ EC サイト風 Web アプリ「Unicorn.Rentals」を、 攻撃側と防御側に分かれて競う Battle。 SQL injection / RCE / SSRF / IMDS 露出が同居した状態でデプロイされ、 防御側はサービスを止めずに塞ぐ、 攻撃側は他チームの公開エンドポイントを巡回して得点リソースを奪う。
+
+| 項目         | 値                                          |
+| ------------ | ------------------------------------------- |
+| カテゴリ     | Battle (リアルタイム対戦)                   |
+| 難易度       | 3 / 5                                       |
+| 想定時間     | 60〜90 分                                   |
+| status       | `draft`                                     |
+| 採点方式     | `uptime-multi` (`pointsAllOk`: 100)         |
+
+## 何をする問題か
+
+- **攻撃側**: 他チームの `FrontendUrl` / `ApiUrl` を巡回し、 仕込まれた SQLi / RCE / SSRF / IMDS 露出を突いて得点を奪う。
+- **防御側**: 自チームのアプリを **動かしたまま** 脆弱性を順次塞ぐ。 アプリを止めれば確かに守れるが、 uptime probe が落ちて加点も止まる。
+
+このトレードオフ (= 可用性を保ちつつ守る) が問題の核。
+
+## デプロイされるもの
+
+```
+┌── EC2 1 台 (Amazon Linux 2023, t3.small) docker-compose ──┐
+│                                                            │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                  │
+│  │  nginx   │  │  Flask   │  │  mysql   │                  │
+│  │  :80     │  │  :8080   │  │  :3306   │                  │
+│  └──────────┘  └──────────┘  └──────────┘                  │
+│       │              │              │                      │
+│  FrontendUrl     ApiUrl         (private)                  │
+└────────────────────────────────────────────────────────────┘
+```
+
+- 専用 VPC + 公開 subnet + IGW
+- 公開ポート: 80 (frontend) / 8080 (api)、 `AllowedCidr` で絞れる
+- `DbPassword` は CFn parameter (NoEcho)、 deploy chain が `__RANDOM_PASSWORD__` で生成
+
+## 採点
+
+1 分ごとに 2 endpoint を probe し、 両方 200 で +100 pt。
+
+| 状態                                                    | 1 cycle |
+| ------------------------------------------------------- | ------- |
+| `FrontendUrl /` と `ApiUrl /healthz` が両方 200          | +100 pt |
+| いずれかが 200 以外 / timeout                           | 0 pt    |
+
+詳細は [`metadata.json`](./metadata.json) の `scoring` フィールド参照。
+
+## ローカル開発
+
+```bash
+cd problems/battles/security-battle-royale/local
+docker compose up --build
+# frontend: http://localhost:80
+# api:      http://localhost:8080/healthz
+```
+
+`local/docker-compose.yaml` + `local/mysql-init.sql` で本番と同じ 3 コンテナ構成を再現できる。 `api/api.py` と `frontend/index.html` が脆弱性を含む本体。
+
+## 含まれる脆弱性 (= 仕込みネタバレ注意)
+
+- **SQL injection** — `api.py` の検索クエリで raw 文字列連結
+- **RCE** — debug endpoint に `eval` / shell-out 系
+- **SSRF** — 任意 URL の取得を試せる helper endpoint
+- **IMDS exposure** — IMDSv1 enabled、 SSRF と組み合わせて IAM Role の credential が抜ける
+
+> ADR-008 (= 問題実装の private repo 化、 issue #574) が ship するまで、 仕掛けは事前に読まれる可能性がある。
+
+## 学習目的
+
+- 意図的な SQL injection / RCE / SSRF を発見・修正する一連の手順を体験する
+- EC2 IMDS / IAM Role の露出経路と、 それを塞ぐベストプラクティスを理解する
+- 競技中に同居する攻撃者と防御者のトレードオフ (可用性を保ちつつ守る) を体験する
+
+## 関連ファイル
+
+- [`metadata.json`](./metadata.json) — 問題メタデータ
+- [`template.yaml`](./template.yaml) — CFn ペライチ (competitor account に deploy する本体)
+- [`api/api.py`](./api/api.py) — Flask API (脆弱性本体)
+- [`frontend/index.html`](./frontend/index.html) — nginx が serve する静的ページ
+- [`local/docker-compose.yaml`](./local/docker-compose.yaml) — ローカル再現用

--- a/problems/battles/stackstack/README.en.md
+++ b/problems/battles/stackstack/README.en.md
@@ -1,0 +1,86 @@
+# StackStack — AI to Production Last Mile
+
+> 日本語版: [README.md](./README.md)
+
+A Battle that gamifies the **AI → Production last mile** in an era where anyone can generate apps with AI. It is neither a coding race nor a CTF; it is a contest of Platform Team operational quality — shipping fast AND safely AND under governance.
+
+| Field          | Value                                                                                              |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| Category       | Battle (real-time PvP)                                                                             |
+| Difficulty     | 4 / 5                                                                                              |
+| Estimated time | 90–120 min                                                                                         |
+| status         | `draft`                                                                                            |
+| Scoring        | `phased-polling` (EC2 = 100pt / managed = 1,000pt / all-slot managed bonus = +5,000pt one-time)    |
+
+## What you do
+
+Players act as the Platform Team for a company with 100 internal AI Builders pushing out fragile apps. Each app must be hardened across 5 control axes (Security / Network / Rate / Audit / UX availability). Score is composite, not just speed: it depends on the balance across all 5 axes plus the team's response to random organizational events (CEO demanding a 5000-person demo, Legal finding PII, .env leaks, Claude committing secrets).
+
+## 5 control axes (= 5 endpoint slots)
+
+| slot      | axis                                | initial state                       | hardened state                                  |
+| --------- | ----------------------------------- | ----------------------------------- | ----------------------------------------------- |
+| `auth`    | Authentication / Authorization      | naive Basic auth on EC2 (`ec2`)     | Cognito / SSO via managed runtime               |
+| `network` | Network controls (S3 / WAF / IAM)   | Public S3 + wildcard IAM (`ec2`)    | OAC + scoped IAM via managed runtime            |
+| `rate`    | Rate limit / DoS protection         | unthrottled Flask (`ec2`)           | API GW throttle / Lambda concurrency cap        |
+| `audit`   | Logging / Compliance                | stdout only (`ec2`)                 | CloudTrail + Athena + WORM bucket               |
+| `ux`      | User-facing availability            | single EC2 (`ec2`)                  | Multi-AZ + ALB + Auto Scaling                   |
+
+Each slot self-reports its hosting platform via `/meta`. The initial deploy puts all five on EC2 (low score: 100 pt/cycle/slot). Hardening = re-hosting to Lambda + API GW / ECS Fargate / App Runner — which inherently brings managed security defaults — and registering the new URL via the portal override. Once `/meta` returns `"lambda" | "ecs" | "apprunner"`, the slot's payout jumps to 1,000 pt/cycle.
+
+## Time-based phases
+
+| Time   | phase              | What happens                                                                                                |
+| ------ | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| 0 min  | start              | All slots naive on EC2 (≈ 500 pt/min baseline)                                                              |
+| 30 min | production-ramp    | `ux` slot degrades to `degradedPoints` (10 pt) if still on EC2 (CEO 5000-user demo pressure)                |
+| 60 min | compliance-audit   | `audit` slot degrades to `degradedPoints` if still on EC2 (Legal review pressure)                           |
+| 90 min | incident-response  | All slots switch to `/score?legacy=true`, requiring redeploy without the legacy path the AI Builder injected |
+
+## Random org events (disruptions)
+
+Operator-fired catalog:
+
+| id                    | name                              | Effect                                                  |
+| --------------------- | --------------------------------- | ------------------------------------------------------- |
+| `ceo-5000-users`      | CEO demands a 5000-user demo      | -500 pt/cycle while `ux` slot stays on EC2              |
+| `mfa-mandate`         | Security Team mandates MFA        | `auth` on `ec2` for >10 min → disqualified              |
+| `legal-pii-found`     | Legal finds PII                   | -500 pt/cycle while `audit` slot is on EC2              |
+| `env-credential-leak` | `.env` leaks                      | `auth` slot returns 503 for 5 minutes (failurePenalty)  |
+| `ai-committed-secret` | Claude commits a secret           | `network` + `audit` both return 503 for 3 minutes       |
+
+## All-managed bonus
+
+If every one of the 5 slots is hosted on `lambda` / `ecs` / `apprunner`, **+5,000 pt one-time bonus** ("production-ready" certification). One slot left on EC2 disqualifies the bonus.
+
+## Scope: Phase 1 vs Phase 2
+
+### Phase 1 (= this problem today)
+
+- ✅ Individual-team hardening mechanics via the existing `phased-polling` engine.
+- ✅ Disruption catalog declared via `disruptions[]` (operator-fired).
+- ✅ 5-axis subscore display via `dashboard.slots/StatusPanel.tsx`.
+
+### Phase 2 (= requires platform extension; separate ADR / PR)
+
+- **Inter-team coordination plugin** (ADR-022): inter-team primitives vary by problem (microservice-migration's service router / security-battle-royale's alliances / etc.). Rather than hardcoding one mechanism into the platform, ADR-022 defines a plugin contract where problems declare the primitive and the platform dispatches. StackStack's specific inter-team primitive will be declared after ADR-022 lands.
+- **AI Agent / platform usage status**: player-triggered platform actions from the portal. Requires an extension to the portal plugin SDK.
+
+### Explicitly rejected
+
+- **Tenant-spanning shared resource registry** (SSO Proxy 2 slots first-come / Security Review queue / Claude API quota): the security design exceeds the current platform's maturity, so it is removed from the Phase 2 plan. Replaced by an inter-team primitive that stays inside tenant boundaries via ADR-022.
+
+Phase 1 alone is enough to experience the StackStack core (5 axes + random events + phased timeline).
+
+## Learning goals
+
+- Practice the judgment and ordering required to take an AI-generated app to production across 5 control axes.
+- Understand how migrating to managed runtimes (Lambda / ECS / App Runner) auto-bootstraps hardening defaults.
+- Train Platform Team decision-making under random organizational events (CEO demand / Legal audit / .env leak).
+- Articulate the boundary between Phase 2 (inter-team coordination plugin = ADR-022) and Phase 1 (individual-team hardening) as an ADR.
+
+## Related files
+
+- [`metadata.json`](./metadata.json) — problem metadata (source of truth for slots / scoring / phases / disruptions)
+- [`template.yaml`](./template.yaml) — one-page CFn template
+- [`portal/StatusPanel.tsx`](./portal/StatusPanel.tsx) — dashboard plugin that surfaces the 5-axis subscore + phase + disruption state

--- a/problems/battles/stackstack/README.md
+++ b/problems/battles/stackstack/README.md
@@ -1,0 +1,88 @@
+# StackStack — AI → Production ラストワンマイル
+
+> English version: [README.en.md](./README.en.md)
+
+生成 AI で誰でもアプリを作れる時代の **AI → Production ラストワンマイル** を競技化する Battle。 コードを書く速さでも CTF でもなく、 Platform Team として「速く・安全に・統制下で」社内公開する能力を競う。
+
+| 項目         | 値                                                                                                  |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| カテゴリ     | Battle (リアルタイム対戦)                                                                           |
+| 難易度       | 4 / 5                                                                                               |
+| 想定時間     | 90〜120 分                                                                                          |
+| status       | `draft`                                                                                             |
+| 採点方式     | `phased-polling` (EC2 = 100pt / managed = 1,000pt / 全 slot managed bonus = +5,000pt one-time)      |
+
+## 何をする問題か
+
+参加者は企業の Platform Team として、 社内 100 人の AI Builder が量産する脆弱なアプリを 5 つの統制軸 (Security / Network / Rate / Audit / UX availability) で本番品質に持ち上げる。 単純な速度競争ではなく、 5 軸の総合バランス + ランダム組織イベント (CEO 5000 人デモ要求 / Legal の PII 指摘 / .env 流出 / AI が秘密鍵を commit 等) への対応で勝敗が決まる。
+
+## 5 つの統制軸 (= 5 endpoint slot)
+
+| slot      | 統制軸                                  | 初期状態                              | hardened 状態                                  |
+| --------- | --------------------------------------- | ------------------------------------- | ---------------------------------------------- |
+| `auth`    | Authentication / Authorization          | EC2 上の naive Basic auth (`ec2`)     | Cognito / SSO 統合 (Lambda+API GW / App Runner / ECS) |
+| `network` | Network controls (S3 / WAF / IAM)       | Public S3 + wildcard IAM (`ec2`)      | Origin Access Control + scoped IAM (managed)   |
+| `rate`    | Rate limit / DoS protection             | 無制限の Flask (`ec2`)                | API GW throttle / Lambda concurrency (managed) |
+| `audit`   | Logging / Compliance                    | 標準出力のみ (`ec2`)                  | CloudTrail + Athena + WORM bucket (managed)    |
+| `ux`      | User-facing availability                | EC2 1 台 (`ec2`)                      | Multi-AZ + ALB + Auto Scaling (managed)        |
+
+各 slot は `/meta` で hosting platform を自己申告する。 deploy 直後は全 slot が `"ec2"` を返し低スコア (100 pt/cycle/slot)。 Lambda+API GW / ECS Fargate / App Runner に切り出して endpoint を override 登録すると `/meta` が `"lambda" | "ecs" | "apprunner"` を返し、 加点が 1,000 pt/cycle/slot にジャンプする。
+
+## 時間進行 (phases)
+
+| 時刻       | phase                | 内容                                                                                                  |
+| ---------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
+| 0 分       | start                | 全 slot が EC2 上に naive deploy (~500 pt/min ベース)                                                 |
+| 30 分      | production-ramp      | `ux` slot が EC2 のままだと degradedPoints (10 pt) に劣化 (= CEO 5000 人デモに間に合わなかった状態)   |
+| 60 分      | compliance-audit     | `audit` slot が EC2 のままだと degradedPoints (= Legal 監査に間に合わなかった状態)                    |
+| 90 分      | incident-response    | 全 slot で `/score?legacy=true` に切替。 AI Builder が混入させた legacy path を取り除いて再 deploy が必要 |
+
+## ランダム組織イベント (disruptions)
+
+operator が任意タイミングで fire できる。
+
+| id                    | name                              | 影響                                              |
+| --------------------- | --------------------------------- | ------------------------------------------------- |
+| `ceo-5000-users`      | CEO が明日 5000 人デモを要求      | `ux` slot が EC2 上にある間 -500 pt/cycle         |
+| `mfa-mandate`         | Security Team が MFA 必須化       | `auth` slot が ec2 のまま 10 分超 → 失格扱い      |
+| `legal-pii-found`     | Legal が PII 検出                 | `audit` slot が ec2 のまま -500 pt/cycle          |
+| `env-credential-leak` | .env 流出                         | `auth` slot を 5 分間 503 (= failurePenalty 連発) |
+| `ai-committed-secret` | Claude が秘密鍵を Git commit      | `network` + `audit` の 2 slot を 3 分間 503        |
+
+## 全 4 platform 移行ボーナス
+
+全 5 slot が `lambda` / `ecs` / `apprunner` のいずれかにホスティング済みなら **+5,000 pt one-time bonus** (`"production-ready"` 認定)。 ec2 が 1 つでも残っていれば bonus は付かない。
+
+## Phase 1 / Phase 2 スコープ
+
+### Phase 1 (= 本 problem の現状)
+
+- ✅ 個別チームの「naive AI アプリを 5 軸でハードニングする」mechanics は phased-polling kind の既存 engine で動く
+- ✅ ランダム組織イベント catalog は `disruptions[]` で宣言済み (operator fire)
+- ✅ 5 軸 subscore display は `dashboard.slots/StatusPanel.tsx`
+
+### Phase 2 (= platform 拡張が必要)
+
+以下は今日の platform にプリミティブが無く、 別 ADR / 別 PR で扱う。
+
+- **inter-team coordination plugin** (ADR-022): 問題ごとに他チーム interaction の primitive が違う (microservice-migration の service router / security-battle-royale の同盟 / その他)。 platform にこの coordination 機構を 1 つ hardcode せず、 問題が宣言した primitive を platform が dispatch する plugin 契約を ADR-022 で定義する。 StackStack の inter-team primitive は ADR-022 ship 後に declare する。
+- **AI Agent 利用 / Platform 利用ステータス**: 競技者 portal から trigger する操作系。 portal plugin SDK の拡張が必要。
+
+### やらないこと (= 明示却下)
+
+- **tenant 横断 shared resource registry** (SSO Proxy 2 slot 先着 / Security Review 待ち行列 / Claude API quota): security 設計の難度が現 platform の整備状況と釣り合わないため Phase 2 計画から外す。
+
+Phase 1 だけでも StackStack の中核 (5 軸 + ランダムイベント + 時間進行) は体験できる。
+
+## 学習目的
+
+- AI で量産されたアプリを 5 つの統制軸 (auth / network / rate / audit / ux) で本番化する判断と順序付けを体験する
+- managed services (Lambda / ECS / App Runner) への移行が hardening をどう自動で底上げするかを理解する
+- ランダム組織イベント (CEO 要求 / Legal 監査 / .env 流出) の発火下で優先度を再評価する Platform Team の意思決定を訓練する
+- Phase 2 (inter-team coordination plugin = ADR-022) と Phase 1 (個別チームの hardening) の境界を見極め、 platform 拡張要求を ADR として言語化する
+
+## 関連ファイル
+
+- [`metadata.json`](./metadata.json) — 問題メタデータ (5 slot / scoring / phases / disruptions 正本)
+- [`template.yaml`](./template.yaml) — CFn ペライチ
+- [`portal/StatusPanel.tsx`](./portal/StatusPanel.tsx) — 5 軸 subscore + phase + disruption を表示する dashboard plugin

--- a/problems/challenges/hello-world/README.en.md
+++ b/problems/challenges/hello-world/README.en.md
@@ -1,0 +1,71 @@
+# Hello World (Sample)
+
+> 日本語版: [README.md](./README.md)
+
+The **minimal sample** for Challenge / flag submission. Read a value from SSM Parameter Store, paste it into the Participant Portal, and earn +100 pt. Use it as a sanity check for the deploy → flag-submit → score path end-to-end.
+
+| Field          | Value                                                       |
+| -------------- | ----------------------------------------------------------- |
+| Category       | Challenge (self-paced)                                      |
+| Difficulty     | 1 / 5 (beginner)                                            |
+| Estimated time | 1 min                                                       |
+| status         | `ready`                                                     |
+| Scoring        | `flag` (`points`: 100, `wrongAnswerPenalty`: 5)             |
+
+## Story
+
+Welcome to TenkaCloud Inc. Today is your first day. Your predecessor SRE, Kato-san, abruptly resigned last week and left a single mysterious SSM Parameter in production.
+
+Sasaki-san, the CTO, says: "I think he left it for smoke testing... probably." Details unknown. Searching Slack DMs turns up nothing. The Notion handover note just says: "look at SSM `hello`."
+
+Your mission: open AWS Console or CLI, read the value at `/{NamePrefix}/hello`, and paste it into the Participant Portal flag-submission box. Correct match → +100 pt.
+
+The canonical worldbuilding lives in [`docs/lore/world.html`](../../../docs/lore/world.html).
+
+## What gets deployed
+
+- `AWS::SSM::Parameter` (`/{NamePrefix}/hello`, Standard tier, value `Hello from {NamePrefix}`)
+- `ParticipantViewerRole` — IAM Role competitors AssumeRole into for read-only AWS Console access
+  - `ssm:GetParameter` / `GetParameters` / `GetParametersByPath` scoped **only to their own prefix**
+  - `cloudformation:DescribeStacks` etc. scoped **only to their own stack**
+  - Cannot peek at other tenants' parameters / stacks (ADR-021)
+
+No EC2 / VPC / public endpoint is created. SSM Standard tier is free.
+
+## How to solve
+
+```bash
+# Via CLI
+aws ssm get-parameter --name /{NamePrefix}/hello --query Parameter.Value --output text
+# → "Hello from {NamePrefix}"
+```
+
+Or click through to the Parameter Store detail page in AWS Console — the deep link is published as the `ParameterConsoleUrl` output in [`template.yaml`](./template.yaml) and exposed to competitors via the Participant Portal.
+
+> The Parameter Store **list** page in Console requires `ssm:DescribeParameters`, which `ParticipantViewerRole` intentionally lacks to prevent cross-tenant leakage (ADR-021). Listing from the console is deliberately blocked, so use the deep link from the Portal.
+
+Paste the value into the Participant Portal flag submission box and submit. Correct → +100 pt. Wrong → -5 pt.
+
+## Hints (cost score if used)
+
+| hint   | Content                                                                                                            | Penalty |
+| ------ | ------------------------------------------------------------------------------------------------------------------ | ------- |
+| hint-1 | Read the value via AWS Console (SSM Parameter Store) or `aws ssm get-parameter --name /{NamePrefix}/hello`.        | -10     |
+| hint-2 | The value follows the form `Hello from tc-...` and includes the stack-name prefix (= the value of NamePrefix).     | -20     |
+
+## Scoring
+
+| State                         | Score |
+| ----------------------------- | ----- |
+| Correct (= value matches)     | +100  |
+| Wrong                         | -5    |
+
+## Learning goals
+
+- Experience reading a value from SSM Parameter Store via AWS Console / CLI.
+- Verify that TenkaCloud's deploy → flag-submit → score pipeline works end-to-end.
+
+## Related files
+
+- [`metadata.json`](./metadata.json) — problem metadata
+- [`template.yaml`](./template.yaml) — one-page CFn template (SSM Parameter + a scoped IAM Role only)

--- a/problems/challenges/hello-world/README.md
+++ b/problems/challenges/hello-world/README.md
@@ -1,0 +1,71 @@
+# Hello World (Sample)
+
+> English version: [README.en.md](./README.en.md)
+
+Challenge / flag-submission の **最小 sample** 問題。 SSM Parameter Store の値を読み取って Participant Portal に貼り付けると +100 pt。 deploy → flag 提出 → 加点経路を end-to-end で確認する用途。
+
+| 項目         | 値                                                            |
+| ------------ | ------------------------------------------------------------- |
+| カテゴリ     | Challenge (個別演習)                                          |
+| 難易度       | 1 / 5 (入門)                                                  |
+| 想定時間     | 1 分                                                          |
+| status       | `ready`                                                       |
+| 採点方式     | `flag` (`points`: 100, `wrongAnswerPenalty`: 5)               |
+
+## ストーリー
+
+天下クラウド株式会社へようこそ。 あなたは今日が入社初日。 前任 SRE の加藤さんが先週突然退職し、 production には謎の SSM Parameter が 1 つ残されている。
+
+佐々木 CTO 曰く、「動作確認のために残したやつ、 たぶん」。 詳細は不明。 Slack の DM 履歴を遡っても何も出てこない。 Notion の引継ぎ書には「SSM の hello 見といて」とだけ書いてある。
+
+あなたのミッション: AWS Console または CLI で SSM Parameter Store にアクセスし、 `/{NamePrefix}/hello` の値を読んで Participant Portal の入力欄に貼り付ける。 一致すれば +100 pt。
+
+世界観の正本は [`docs/lore/world.html`](../../../docs/lore/world.html) を参照。
+
+## デプロイされるもの
+
+- `AWS::SSM::Parameter` (`/{NamePrefix}/hello`、 Standard tier、 値は `Hello from {NamePrefix}`)
+- `ParticipantViewerRole` — 競技者が AWS Console で読み取り専用 AssumeRole するための IAM Role
+  - `ssm:GetParameter` / `GetParameters` / `GetParametersByPath` を **自分の prefix だけ** に scope
+  - `cloudformation:DescribeStacks` etc. を **自分の stack だけ** に scope
+  - 他テナントの parameter / stack を覗けない (ADR-021)
+
+EC2 / VPC / 公開エンドポイントは作らない。 SSM Standard tier は料金ゼロ。
+
+## 解き方
+
+```bash
+# CLI で読む場合
+aws ssm get-parameter --name /{NamePrefix}/hello --query Parameter.Value --output text
+# → "Hello from {NamePrefix}"
+```
+
+または AWS Console の Parameter Store 詳細ページ ([`ParameterConsoleUrl` の Output](./template.yaml)) を Participant Portal から click-through すると直接 deep link で開ける。
+
+> Console の Parameter Store **一覧** ページは `ssm:DescribeParameters` が必要で、 cross-tenant leak を防ぐため `ParticipantViewerRole` には付与していない (ADR-021)。 一覧から探す解き方は意図的に塞いであるので、 Portal の deep link を使う。
+
+値を Participant Portal の Flag 提出欄に貼り付けて submit → 一致すれば +100 pt。 間違えると -5 pt のペナルティ。
+
+## ヒント (利用すると減点)
+
+| hint   | 内容                                                                                  | 減点  |
+| ------ | ------------------------------------------------------------------------------------- | ----- |
+| hint-1 | AWS Console (SSM Parameter Store) または `aws ssm get-parameter --name /{NamePrefix}/hello` で値を読み出してください | -10   |
+| hint-2 | 値は `Hello from tc-...` の形式で、 Stack 名 prefix を含みます (= NamePrefix の値そのもの) | -20   |
+
+## 採点
+
+| 状態                            | 得点  |
+| ------------------------------- | ----- |
+| 正答 (= 値が一致)               | +100  |
+| 誤答                            | -5    |
+
+## 学習目的
+
+- AWS Console / CLI で SSM Parameter Store の値を読み出す経路を体験する
+- TenkaCloud の deploy → flag 提出 → 加点経路が end-to-end で動くことを確認する
+
+## 関連ファイル
+
+- [`metadata.json`](./metadata.json) — 問題メタデータ
+- [`template.yaml`](./template.yaml) — CFn ペライチ (SSM Parameter + 限定 IAM Role のみ)


### PR DESCRIPTION
## Summary

- 5 つの sample 問題 (`hello-world-battle` / `microservice-migration-battle` / `security-battle-royale` / `stackstack` / `challenges/hello-world`) それぞれに JA `README.md` と EN `README.en.md` を追加。
- 構成: 概要 → デプロイされるもの (ASCII 図) → 採点 → ローカル開発 (該当時) → 学習目的 → 関連ファイル。 冒頭に対訳へのクロスリンク (`> English version:` / `> 日本語版:`)。
- 既存の `microservice-migration-battle/README.md` (JA) はそのまま残し、 EN mirror として `README.en.md` を追加 + クロスリンク 1 行を冒頭に挿入。

## なぜ

`metadata.json` は scoring engine / catalog 表示の正本だが、 OSS reader が repo を眺めたときに「この問題は何を解くのか」が一目でわかる人間可読サマリが欠けていた。 1 問題 = 2 README (JA + EN) の規約を入れることで、 日本語話者にも英語話者にも導線を一本化する。

## .textlintignore の更新

問題ディレクトリ直下の README は JA narrative の中に AWS 公式英語製品名 (`Session Manager` / `Parameter Store` / `Auto Scaling` 等) が頻出する。 `spellcheck-tech-word` rule が `Session` → `セッション` のようにカタカナへ書き換える誤検出を起こすため、 既存の root `README.md` / `apps/*/README.md` と同じ扱いで `problems/**/README.md` + `problems/**/README.en.md` を `.textlintignore` に追加。 metadata.json の description 文も同じ表記なので、 整合性も保たれる。

## Regression analysis

- **runtime 影響**: なし (ドキュメント追加のみ)。 scoring engine / deploy pipeline / portal / admin console いずれも README を読まない。
- **catalog 表示**: 影響なし。 frontend は `problems/index.json` (= `metadata.json` を集約) を読むのみで、 `README.md` は表示対象外。
- **textlint coverage の縮小**: `problems/**/README*.md` が CI lint から外れる。 ただし JA narrative + EN AWS 製品名の混在を想定した妥当な除外で、 既存の root `README.md` / `apps/*/README.md` と同じ方針 (#1087)。 lint されない代わりに markdownlint は CI で引き続き走る。
- **新規 README にリンク切れの可能性**: 全 README が `metadata.json` / `template.yaml` / (該当する) ローカル開発ファイルへの相対リンクを含むが、 全て同一問題ディレクトリ内の既存ファイル。 リンク切れなし。

## Physical impact

- CFn template / IAM / runtime artifact: **NO-OP** (1 行も触っていない)。
- ドキュメント追加: **CREATE** × 9 files (`README.md` × 4 + `README.en.md` × 5)、 **UPDATE** × 2 files (`microservice-migration-battle/README.md` 冒頭クロスリンク 1 行追加 + `.textlintignore` に 4 行追加)。

## Test plan

- [x] `make harness` — invariant 違反 0
- [x] `make before-commit` — markdownlint + textlint + biome + typecheck + vitest + `validate:problems` + `check:problems-index` + cdk synth まで全 green
- [x] 各 README 内のリンクパス手動確認 (`metadata.json` / `template.yaml` / `services/` / `portal/` / `local/` / `api/` / `frontend/` がそれぞれ実在)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation for five new challenges and battles, including Hello World Challenge, Hello World Battle, Microservice Migration Battle, Security Battle Royale, and StackStack Battle, detailing gameplay mechanics, deployment architecture, and learning objectives.
  * Provided bilingual documentation with English and Japanese versions for all new challenges and battles.

* **Chores**
  * Updated documentation linting configuration to properly handle localized content across English and Japanese documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->