### PR TITLE
refactor(problems): drop unused CFn perms + refresh catalog README

### DIFF
--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -7,17 +7,11 @@ const REPO_ROOT = resolve(__dirname, "../../..");
 const TEMPLATES = [
   {
     path: "problems/challenges/hello-world/template.yaml",
-    actions: ["ssm:GetParameter", "cloudformation:DescribeStacks"],
+    actions: ["ssm:GetParameter"],
   },
   {
     path: "problems/battles/hello-world-battle/template.yaml",
-    actions: [
-      "ec2:Describe*",
-      "ssm:StartSession",
-      "ssm:TerminateSession",
-      "cloudformation:DescribeStacks",
-      "logs:FilterLogEvents",
-    ],
+    actions: ["ec2:Describe*", "ssm:StartSession", "ssm:TerminateSession", "logs:FilterLogEvents"],
   },
   {
     path: "problems/battles/security-battle-royale/template.yaml",

--- a/problems/README.en.md
+++ b/problems/README.en.md
@@ -1,0 +1,210 @@
+# TenkaCloud Problem Catalog
+
+> 日本語版: [README.md](./README.md)
+
+Problems shipped on TenkaCloud (**Battle** / **Challenge**) follow a one-directory-per-problem convention. Whatever lives under `problems/` is the source of truth for the catalog.
+
+Problems are treated as **plugins** per ADR-012: each problem ships in 3–4 assets (`metadata.json` + `template.yaml` + optional `portal/` slots + optional `services/` implementation). The platform side (`infrastructure/lib/problem-deploy/`) is a generic dispatcher that drives scoring / portal / disruptions purely from metadata. Problem-specific code stays inside the problem directory.
+
+For a cross-cutting view of shipped problems + ideas, see [`docs/gallery.md`](../docs/gallery.md). For a 30-minute "author a new problem" onboarding, see [`docs/problems/AUTHORING.html`](../docs/problems/AUTHORING.html).
+
+## Directory layout
+
+```
+problems/
+├── battles/                       # Battle (real-time, head-to-head)
+│   ├── hello-world-battle/
+│   ├── microservice-migration-battle/
+│   ├── security-battle-royale/
+│   └── stackstack/
+├── challenges/                    # Challenge (self-paced, evergreen)
+│   └── hello-world/
+├── SCHEMA.json                    # JSON Schema (draft-07) — source of truth for metadata.json
+├── index.json                     # Catalog built from every metadata.json (= `make build-problems-index`)
+└── README.md                      # This file (Japanese)
+```
+
+A single problem directory is made up of the following four assets (ADR-012).
+
+| Asset                       | Required | Purpose                                                                                          |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `metadata.json`             | ✓        | Source of truth for catalog UI + scoring engine + portal plugin wiring.                          |
+| `README.md` / `README.en.md` | ✓       | Problem detail page (story / solve path / learning goals). i18n: ja + en only.                   |
+| `template.yaml`             | ✓        | A single-page CFn template (the deploy body). Pushed into the competitor account via `create-stack`. |
+| `portal/<slot>.tsx`         | -        | Problem-specific participant portal UI, referenced from `dashboard.slots`.                       |
+| `services/`                 | -        | Problem-specific implementation (docker-compose / Lambda code / etc; pulled by EC2 UserData).    |
+
+## Categories
+
+| Category    | Nature                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| `Battle`    | Real-time, head-to-head. Multiple teams deploy at once and earn points via uptime / defense / phase progression. |
+| `Challenge` | Self-paced, evergreen. Always open; the typical shape is "1 deploy = 1 flag submission".            |
+
+The two are not strictly separated — they share metadata, scoring engine, and portal. A Battle problem can embed CTF-style sub-quests, and `metadata.category` tells them apart.
+
+## metadata.json
+
+The source of truth is [`SCHEMA.json`](./SCHEMA.json). Both the frontend catalog and the backend deploy pipeline read it.
+
+### Required keys
+
+| Key                 | Purpose                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `id`                | Lowercase kebab-case ID. Matches the directory name. Also goes into the CFn stack name prefix.           |
+| `name`              | Human-readable display name (any language).                                                              |
+| `category`          | `Battle` or `Challenge`.                                                                                 |
+| `status`            | `ready` / `draft` / `deprecated`.                                                                        |
+| `visibility`        | `public` / `private`. Private problems show up only in the admin console.                                |
+| `difficulty`        | 1 (beginner) – 5 (expert).                                                                               |
+| `estimatedDuration` | Estimated playtime, e.g. `60–90 min`.                                                                    |
+| `shortDescription`  | One-line summary used on catalog cards.                                                                  |
+| `description`       | Long-form detail page text (newlines OK).                                                                |
+| `tags`              | kebab-case search / filter tags.                                                                         |
+| `exposedPorts`      | Array of `{port, name}` for endpoints exposed to competitors after deploy. Use a single placeholder entry if there are no public endpoints. |
+| `learningGoals`     | Bullet list of learning goals.                                                                           |
+| `cfnTemplate`       | Relative path to the CFn template in the same directory (typically `template.yaml`).                     |
+
+### Optional keys (ADR-012 thick metadata DSL)
+
+| Key              | Purpose                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `i18n.en`        | English overrides for `name` / `shortDescription` / `description` / `learningGoals`. ja stays at top-level; en lives here. Supported locales are **ja + en only** (#1108). |
+| `scoring`        | Declares one of 5 builtin kinds (see below). Omit to disable scoring entirely (deploy-only problem).         |
+| `endpoints`      | Endpoint registry for uptime / phased-polling kinds (`slot` / `outputKey` / `path`).                          |
+| `phases`         | For `phased-polling`. Stages in `afterMinutes` order where score rule or endpoint binding flips over time.    |
+| `disruptions`    | In-Battle disruption events. Triggers: `after-deploy` / `team-score-above` / `phase-entered`.                 |
+| `dashboard.slots`| Slots for problem-specific React components (`portal/<slot>.tsx`) injected into the participant portal.       |
+| `cfnParameters`  | Hints for CFn parameters the operator inputs at deploy time.                                                  |
+
+### Scoring kinds
+
+One kind per problem. The platform's generic dispatcher (ADR-012 Phase 3) reads `scoring.kind` and dispatches accordingly.
+
+| Kind                | Summary                                                                                                          | Example                                |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `flag`              | Challenge-style. One submission per deploy; compare submitted flag with the CFn Output named in `flagOutputKey`. | `hello-world`                          |
+| `uptime-flat`       | Probe 1–N endpoints independently; award points for each endpoint that returns OK (partial uptime still earns).   | `hello-world-battle`                   |
+| `uptime-multi`      | Probe N endpoints; award `pointsAllOk` only when *all* are OK. A single failure → 0 + `failurePenalty`.           | `security-battle-royale`               |
+| `phased-polling`    | Polling kind with rules that flip over time. Combine with `phases[]` to express progressive degradation / hosting switches. | `microservice-migration-battle` / `stackstack` |
+| `attack-detection`  | Read an attack counter shipped with the problem stack (CFn Output / SSM Parameter / CW metric) and award based on detection count. | (defense side of `security-battle-royale`) |
+
+The legacy `uptime` kind is an alias for `uptime-flat`. New problems should use `uptime-flat`.
+
+### Hints (progressive, shared by all 5 kinds)
+
+`scoring.hints[]` accepts `{id, content, penalty}` entries. Each reveal in the portal deducts `penalty` from `points` (flag) / `pointsPerSuccess` (uptime kinds) / cumulative score (phased-polling / attack-detection) — Issue #742 Phase 5.
+
+## template.yaml
+
+A single-page CloudFormation template. **This one file** is pushed into the competitor account on deploy — no S3 upload, no nested stacks.
+
+### Required parameters
+
+So the deploy pipeline can invoke every problem template with the same arguments, every template supports these.
+
+| Parameter             | Required | Purpose                                                                                                |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `NamePrefix`          | ✓        | `tc-{problemSlug}-{teamSlug}` resource prefix. Goes on every resource name / tag.                       |
+| `TenkaCloudAccountId` | ✓        | TenkaCloud operator AWS account ID (12 digits). Goes into the `ParticipantViewerRole` trust policy.     |
+| `ExternalId`          | ✓        | ExternalId (= jobId) used when AssumeRoling into `ParticipantViewerRole`. Injected by the deploy chain. |
+| `AllowedCidr`         | -        | CIDR allowed to access public ports (default `0.0.0.0/0`).                                              |
+| Problem-specific params | -      | `DbPassword` / `InstanceType` / etc — free to add per problem.                                          |
+
+### Required resources
+
+| Resource                  | Purpose                                                                                                                |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `ParticipantViewerRole`   | Read-only IAM Role that competitors AssumeRole into from AWS Console / CLI. Role name is fixed at `${NamePrefix}-participant-viewer`. Trust is `TenkaCloudAccountId:root` + `sts:ExternalId == ExternalId`. Per the ADR-021 baseline, "the Role must only be able to touch resources belonging to this problem". |
+
+The policy requirements for `ParticipantViewerRole` are machine-checked by [`infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts`](../infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts) — `Resource: "*"` is only allowed under a tag-based Condition or via the metadata-only / self-identity API allowlist.
+
+### Naming convention (avoiding collisions)
+
+We assume multiple teams' stacks coexist in the same (Account, Region). Prefix every resource name / tag / group name with `${NamePrefix}`.
+
+```yaml
+Resources:
+  MyVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
+```
+
+Add the `TenkaCloud:NamePrefix` tag to every resource a competitor can see — this is what makes the tag-based Condition (`aws:ResourceTag/TenkaCloud:NamePrefix`) on `ParticipantViewerRole` work.
+
+### Required Outputs
+
+At minimum, the UI / operator / scoring dispatcher reads these.
+
+| Output                       | Purpose                                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `NamePrefix`                 | Echo of the deploy-time parameter (debug aid for the operator).                                        |
+| `ParticipantViewerRoleArn`   | `!GetAtt ParticipantViewerRole.Arn`. AssumeRoled by the portal's one-click AWS Console federation.     |
+| Participant-facing endpoint URLs | `FrontendUrl` / `ApiUrl` etc (uptime / phased-polling kinds). Referenced from `endpoints[].outputKey`. |
+| The key named in `flagOutputKey` | Only when `scoring.kind = flag`. This is the value competitors paste into the portal.              |
+
+## Adding a new problem
+
+The scaffolding CLI is the shortest path. Templates exist for each of the 5 kinds under `.claude/templates/problems/<kind>/`.
+
+```bash
+# 1. Generate scaffold (Battle uptime-flat example)
+bun run scripts/tenkacloud-problem.ts create my-new-problem --kind uptime-flat
+
+# 2. Edit metadata.json and template.yaml
+
+# 3. Validate
+bun run scripts/tenkacloud-problem.ts validate my-new-problem
+make validate-problems
+
+# 4. (Optional) Smoke deploy
+aws cloudformation deploy \
+  --template-file problems/battles/my-new-problem/template.yaml \
+  --stack-name tc-my-new-problem-test \
+  --parameter-overrides NamePrefix=tc-my-new-problem-test TenkaCloudAccountId=<id> ExternalId=<jobId>
+```
+
+| Subcommand                                         | Purpose                                                                          |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `tenkacloud-problem.ts list-kinds`                 | List available scoring kinds and their scaffolds.                                |
+| `tenkacloud-problem.ts create <id> --kind <kind>`  | Generate scaffold (metadata.json + template.yaml + README skeleton).             |
+| `tenkacloud-problem.ts validate <id>`              | SCHEMA + cross-ref check (e.g. `endpoints[].outputKey` exists in CFn Outputs).   |
+| `tenkacloud-problem.ts inspect <id>`               | Dump metadata + template + cross-ref in one screen (design review aid).         |
+
+Inside Claude Code, the `/create-problem` skill walks you through requirements → scaffold generation → metadata editing.
+
+## Catalog build pipeline
+
+After adding / editing a problem, the following checks make CI green. `make before-commit` runs them locally.
+
+| Step                                  | What it checks                                                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `make validate-problems`              | Validate every `metadata.json` against `SCHEMA.json`.                                                              |
+| `make check-problems-index`           | Verify `index.json` matches the current metadata.json set (drift detection). Rebuild via `make build-problems-index`. |
+| `make check-template-ascii`           | Templates stay within ASCII + Latin-1 (safe IAM Description characters).                                           |
+| `make check-template-security`        | Scan for dangerous patterns in IAM / Security Group / S3 / KMS (e.g. `Action: "*"` + `Resource: "*"`).             |
+| `make check-template-cfn-refs`        | Verify `!Ref` / `!GetAtt` reference integrity + presence of the required `ParticipantViewerRole`.                  |
+
+`index.json` is injected at build time into the three SPAs (`apps/admin-console` / `apps/application-admin-console` / `apps/participant-portal`), making `metadata.json` the single source of truth for catalog display.
+
+## i18n
+
+Supported locales: **ja + en only** (Issue #1108 deprecated es / zh).
+
+- Japanese (default): put `name` / `shortDescription` / `description` / `learningGoals` at the top level of `metadata.json`.
+- English: put overrides in `metadata.json` → `i18n.en` and add `README.en.md` next to `README.md`.
+
+If a problem has no English override (= no `i18n.en`), switching the portal's locale switcher to `en` falls back to the Japanese default.
+
+## Related docs
+
+- [`SCHEMA.json`](./SCHEMA.json) — JSON Schema for `metadata.json` (source of truth)
+- [`docs/problems/AUTHORING.html`](../docs/problems/AUTHORING.html) — 30-minute onboarding (5-kind decision tree + 4 worked examples)
+- [`docs/architecture/adr-012-problem-plugin-architecture.html`](../docs/architecture/adr-012-problem-plugin-architecture.html) — 3-asset model + thick metadata DSL + generic scoring dispatcher
+- [`infrastructure/templates/README.md`](../infrastructure/templates/README.md) — Competitor-account setup
+- [`docs/gallery.md`](../docs/gallery.md) — Cross-cutting catalog of shipped + planned problems

--- a/problems/README.md
+++ b/problems/README.md
@@ -1,76 +1,127 @@
 # TenkaCloud 問題カタログ
 
-TenkaCloud で配信する問題 (Battle / Challenge) は 1 ディレクトリ 1 問題の規約で管理する。
-リポジトリの `problems/` 配下を見れば、現在カタログに載っている全問題が分かるのが正本。
+> English version: [README.en.md](./README.en.md)
 
-実装済み問題と次に作る候補を横断して眺めたい場合は
-[`docs/gallery.md`](../docs/gallery.md) を参照。
+TenkaCloud で配信する問題 (**Battle** / **Challenge**) は 1 ディレクトリ 1 問題の規約で管理する。 `problems/` 配下を見れば、 現在カタログに載っている全問題が分かるのが正本。
+
+問題は ADR-012 の **plugin architecture** で扱う: 1 問題は `metadata.json` + `template.yaml` + 任意の `portal/` slot + 任意の `services/` 実装の 3 〜 4 アセットで完結する。 platform 側 (= `infrastructure/lib/problem-deploy/`) は generic dispatcher として metadata だけを見て scoring / portal / disruption を捌く。 問題固有のコードは問題ディレクトリの中に閉じる。
+
+実装済み問題と次に作る候補を横断して眺めたい場合は [`docs/gallery.md`](../docs/gallery.md)、 30 分でゼロから 1 問書く手順は [`docs/problems/AUTHORING.html`](../docs/problems/AUTHORING.html) を参照。
 
 ## ディレクトリ構造
 
 ```
 problems/
-  <category>/                     # gameday / jam / ...
-    <problem-id>/                 # kebab-case の問題 ID (= ディレクトリ名)
-      metadata.json               # 問題メタデータ (UI / カタログ正本)
-      template.yaml               # CFn ペライチ (deploy 本体)
-      api/, frontend/, local/     # 任意の問題実装ファイル
-      ...
-  SCHEMA.json                     # metadata.json の JSON Schema (draft-07)
-  README.md                       # このファイル
+├── battles/                       # Battle (リアルタイム対戦)
+│   ├── hello-world-battle/
+│   ├── microservice-migration-battle/
+│   ├── security-battle-royale/
+│   └── stackstack/
+├── challenges/                    # Challenge (個別演習)
+│   └── hello-world/
+├── SCHEMA.json                    # metadata.json の JSON Schema (draft-07、正本)
+├── index.json                     # 全 metadata から build した catalog 一覧 (= make build-problems-index で生成)
+└── README.md                      # このファイル
 ```
 
-1 つの問題ディレクトリは **`metadata.json` と `template.yaml`** の 2 つだけあれば成立する。
-追加の `api/` や `frontend/` 等は問題実装の都合で置く。
+1 つの問題ディレクトリは次の 4 アセットで構成する (ADR-012)。
 
-## 必須ファイル
+| アセット                | 必須 | 用途                                                                          |
+| ----------------------- | ---- | ----------------------------------------------------------------------------- |
+| `metadata.json`         | ○    | UI カタログ表示 + scoring engine + portal plugin の正本。                       |
+| `README.md` / `README.en.md` | ○    | 問題詳細 (ストーリー / 解き方 / 学習目的)。 i18n は ja + en の 2 言語。       |
+| `template.yaml`         | ○    | CFn ペライチ (deploy 本体)。 競技アカウントに `aws cloudformation create-stack` で展開される。 |
+| `portal/<slot>.tsx`     | -    | 問題固有の participant portal UI (`dashboard.slots` から参照)。               |
+| `services/`             | -    | 問題固有の実装 (docker-compose / Lambda code 等。 EC2 UserData から fetch)。  |
 
-### `metadata.json`
+## カテゴリ
 
-[`SCHEMA.json`](./SCHEMA.json) で形式を定義する。frontend のカタログ表示と backend の deploy
-パイプラインの両方が参照する正本。記述例は
-[`gameday/security-battle-royale/metadata.json`](./gameday/security-battle-royale/metadata.json)
-を参照。
+| カテゴリ    | 性質                                                                       |
+| ----------- | -------------------------------------------------------------------------- |
+| `Battle`    | リアルタイム対戦。 1 イベントで複数チームが同時 deploy、 uptime / 防御 / phase 進行で得点。 |
+| `Challenge` | 個別演習。 evergreen で常時開かれている、 1 deploy = 1 flag 提出が典型。   |
 
-主なキーは次の通りです。
+両者は分離せず、 metadata `category` で識別する。 Battle 内に CTF 風の sub-quest を持たせる構成も可。
 
-| キー                | 用途                                                                      |
-| ------------------- | ------------------------------------------------------------------------- |
-| `id`                | kebab-case 英小文字 ID。ディレクトリ名と一致させる。CFn stack 名にも入る。 |
-| `name`              | UI 表示名 (人間可読、日本語可)。                                          |
-| `category`          | `Battle` (リアルタイム対戦) または `Challenge` (個別演習)。               |
-| `status`            | `ready` / `draft` / `deprecated`。                                        |
-| `difficulty`        | 1 (入門) 〜 5 (エキスパート)。                                            |
-| `estimatedDuration` | 想定プレイ時間 (例: `60〜90 分`)。                                        |
-| `shortDescription`  | カード表示用の 1 行サマリ。                                               |
-| `description`       | 詳細ページの長文 (改行 OK)。                                              |
-| `tags`              | 検索 / フィルタリング用 kebab-case タグ。                                 |
-| `exposedPorts`      | deploy 後に参加者へ払い出されるポート (`{port, name}` の配列)。           |
-| `learningGoals`     | 想定学習目的の箇条書き。                                                  |
-| `cfnTemplate`       | 同ディレクトリ内 CFn テンプレートへの相対パス。                           |
+## metadata.json
 
-### `template.yaml`
+JSON Schema は [`SCHEMA.json`](./SCHEMA.json) が正本。 frontend カタログと backend deploy パイプラインの両方が参照する。
 
-CloudFormation テンプレート。「ペライチ」とし、deploy 時には**このファイル単独**を競技アカウントの
-CFn にアップロードして展開する。
+### 必須キー
 
-#### 必須パラメータ
+| キー                | 用途                                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `id`                | kebab-case 英小文字 ID。 ディレクトリ名と一致させる。 CFn stack 名 prefix にも入る。              |
+| `name`              | UI 表示名 (人間可読、 日本語 OK)。                                                                |
+| `category`          | `Battle` または `Challenge`。                                                                     |
+| `status`            | `ready` / `draft` / `deprecated`。                                                                |
+| `visibility`        | `public` / `private`。 private は admin console のみで見える。                                    |
+| `difficulty`        | 1 (入門) 〜 5 (エキスパート)。                                                                    |
+| `estimatedDuration` | 想定プレイ時間 (例: `60〜90 分`)。                                                                |
+| `shortDescription`  | カード表示用の 1 行サマリ。                                                                       |
+| `description`       | 詳細ページの長文 (改行 OK)。                                                                      |
+| `tags`              | 検索 / フィルタ用 kebab-case タグ。                                                               |
+| `exposedPorts`      | deploy 後に参加者へ払い出されるポート (`{port, name}` の配列)。 公開エンドポイント無しなら 1 要素 placeholder。 |
+| `learningGoals`     | 想定学習目的の箇条書き。                                                                          |
+| `cfnTemplate`       | 同ディレクトリ内 CFn テンプレートへの相対パス (通常 `template.yaml`)。                            |
 
-deploy パイプラインがすべての問題テンプレートに対して同じ引数で起動できるよう、
-次のパラメータをサポートします。
+### 任意キー (ADR-012 thick metadata DSL)
 
-| パラメータ        | 必須 | 用途                                                                            |
-| ----------------- | ---- | ------------------------------------------------------------------------------- |
-| `NamePrefix`      | ○    | `tc-{problemSlug}-{teamSlug}` 形式の共通リソース prefix。全リソース名に冠する。 |
-| `AllowedCidr`     | -    | 公開ポートを許可する CIDR (default `0.0.0.0/0`)。                               |
-| 問題固有パラメータ | -    | `DbPassword` 等。問題ごとに自由に追加してよい。                                 |
+| キー             | 用途                                                                                                 |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `i18n.en`        | 英語訳 (`name` / `shortDescription` / `description` / `learningGoals`)。 ja は top-level、 en はここに。 サポート locale は **ja + en のみ** (#1108)。 |
+| `scoring`        | 5 種 builtin kind から 1 つを宣言 (= 後述)。 省略すると scoring 無効 (= deploy のみ)。               |
+| `endpoints`      | uptime / phased-polling 系で probe する endpoint の宣言 (`slot` / `outputKey` / `path`)。            |
+| `phases`         | `phased-polling` 用。 時間経過で score rule や endpoint binding が切り替わる段階を `afterMinutes` 昇順で宣言。 |
+| `disruptions`    | Battle 中に発火する妨害イベント (`after-deploy` / `team-score-above` / `phase-entered` トリガー)。 |
+| `dashboard.slots`| participant portal に差し込む問題固有 React component (`portal/<slot>.tsx`) のスロット定義。       |
+| `cfnParameters`  | deploy 時に operator が入力する CFn パラメータの hint。                                              |
 
-#### 命名規約 (衝突回避)
+### scoring kinds
 
-同一 (Account, Region) に複数チームの問題スタックが共存する運用を想定する。
-すべてのリソース名 / タグ / グループ名等は `${NamePrefix}` を冠する。
+1 問題につき 1 kind。 platform 側の generic dispatcher (ADR-012 Phase 3) が読み分ける。
 
-例えば次のように記述します。
+| kind                | 概要                                                                                                   | 例                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `flag`              | Challenge 型。 1 deploy 1 回提出、 `flagOutputKey` (CFn Output) と submitted flag を一致比較。         | `hello-world`                     |
+| `uptime-flat`       | 1 〜 N endpoint を独立に probe。 成功した endpoint 分だけ加点 (= 部分稼働でも稼ぐ)。                   | `hello-world-battle`              |
+| `uptime-multi`      | N endpoint を probe、 全 OK の時だけ `pointsAllOk`。 1 つでも fail なら 0 点 + `failurePenalty`。      | `security-battle-royale`          |
+| `phased-polling`    | 時間経過で score rule が切り替わる polling 型。 `phases[]` と組み合わせて段階的劣化 / hosting 切替を表現。 | `microservice-migration-battle` / `stackstack` |
+| `attack-detection`  | 問題 stack に同梱した attack counter (CFn Output / SSM Parameter / CW metric 等) から検知数で加点。   | (`security-battle-royale` の防御側)|
+
+旧 `uptime` は `uptime-flat` の legacy alias。 新規問題は `uptime-flat` を使う。
+
+### Hints (progressive、 5 kind 共通)
+
+`scoring.hints[]` に `{id, content, penalty}` を並べると、 portal で reveal するごとに `points` (flag) / `pointsPerSuccess` (uptime 系) / 累計 score (phased-polling / attack-detection) から減算される (Issue #742 Phase 5)。
+
+## template.yaml
+
+CloudFormation テンプレート。 ペライチで、 **このファイル単独**を競技アカウントに展開する (= S3 アップロードや nested stack は不要)。
+
+### 必須パラメータ
+
+deploy パイプラインがすべての問題テンプレートを同じ引数で起動できるよう、 次のパラメータをサポートする。
+
+| パラメータ            | 必須 | 用途                                                                                              |
+| --------------------- | ---- | ------------------------------------------------------------------------------------------------- |
+| `NamePrefix`          | ○    | `tc-{problemSlug}-{teamSlug}` 形式の共通リソース prefix。 全リソース名 / タグに冠する。           |
+| `TenkaCloudAccountId` | ○    | TenkaCloud 運営アカウント ID (12 桁)。 `ParticipantViewerRole` の trust に入る。                  |
+| `ExternalId`          | ○    | `ParticipantViewerRole` AssumeRole 用の ExternalId (jobId)。 deploy chain が自動注入する。        |
+| `AllowedCidr`         | -    | 公開ポートを許可する CIDR (default `0.0.0.0/0`)。                                                 |
+| 問題固有パラメータ    | -    | `DbPassword` / `InstanceType` 等、 問題ごとに自由に追加してよい。                                 |
+
+### 必須リソース
+
+| リソース                  | 用途                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ParticipantViewerRole`   | 競技者が AWS Console / CLI で AssumeRole する読み取り専用 IAM Role。 `${NamePrefix}-participant-viewer` の名前固定。 trust は `TenkaCloudAccountId:root` + `sts:ExternalId == ExternalId`。 ADR-021 に従い「自分の問題のリソースしか触れない」 IAM。 |
+
+`ParticipantViewerRole` の policy 要件は [`infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts`](../infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts) で機械検証される (= `Resource: "*"` は tag-based Condition または metadata-only / self-identity API allowlist 必須)。
+
+### 命名規約 (衝突回避)
+
+同一 (Account, Region) に複数チームのスタックが共存する運用を想定する。 全リソース名 / タグ / グループ名は `${NamePrefix}` を冠する。
 
 ```yaml
 Resources:
@@ -80,40 +131,80 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub "${NamePrefix}-vpc"
+        - Key: TenkaCloud:NamePrefix
+          Value: !Ref NamePrefix
 ```
 
-#### 出力 (Outputs)
+`TenkaCloud:NamePrefix` タグは `ParticipantViewerRole` の tag-based Condition (`aws:ResourceTag/TenkaCloud:NamePrefix`) を成立させるために、 競技者が見るすべてのリソースに付与する。
 
-UI / 運営側で扱いやすいよう、最低でも次の Output を含めます。
+### 必須 Output
 
-- `FrontendUrl` / `ApiUrl` 等、参加者向けエンドポイント URL
-- `InstanceId` 等、運営側のデバッグ用識別子
-- `NamePrefix` (deploy 時の引数 echo)
+UI / 運営側 / scoring dispatcher が読むため、 次の Output を最低限含める。
+
+| Output                       | 用途                                                                                              |
+| ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| `NamePrefix`                 | deploy 時の引数 echo (operator デバッグ用)。                                                      |
+| `ParticipantViewerRoleArn`   | `!GetAtt ParticipantViewerRole.Arn`。 portal の AWS Console ワンクリック login で AssumeRole される。 |
+| 参加者向けエンドポイント URL | `FrontendUrl` / `ApiUrl` 等 (uptime / phased-polling 系)。 `endpoints[].outputKey` から参照される。 |
+| `flagOutputKey` で指定した値 | scoring kind=flag のみ。 競技者が portal に貼り付ける値が出る。                                    |
 
 ## 新しい問題を追加する手順
 
-1. `problems/<category>/<id>/` ディレクトリを作る (kebab-case)。
-2. [`SCHEMA.json`](./SCHEMA.json) に従って `metadata.json` を書く。
-3. `template.yaml` を書く (上記 NamePrefix 規約に沿う)。
-4. docker-compose や言語ランタイム等を伴う問題では `api/` / `frontend/` / `local/` 配下に実装ファイルを置く。
-5. `bun run validate:problems` (※今後追加) でメタデータの形式チェックを通す。
-6. 動作確認: `aws cloudformation deploy --template-file template.yaml --stack-name tc-<id>-test --parameter-overrides NamePrefix=tc-<id>-test ...`
+scaffolding CLI を使うのが最短経路。 5 種の kind それぞれに雛形がある (`.claude/templates/problems/<kind>/`)。
 
-## frontend カタログとの連携 (今後)
+```bash
+# 1. 雛形を生成 (Battle uptime-flat の例)
+bun run scripts/tenkacloud-problem.ts create my-new-problem --kind uptime-flat
 
-現状 frontend (`apps/application-admin-console/src/data/problems.ts`) は問題カタログを静的リテラルで
-持っている。今後 build 時に `problems/**/metadata.json` をスキャンして frontend に注入する仕組みを
-入れ、`metadata.json` を正本とする (TODO)。
+# 2. metadata.json と template.yaml を編集
 
-## ロードマップ (本 PR の範囲外)
+# 3. validate
+bun run scripts/tenkacloud-problem.ts validate my-new-problem
+make validate-problems
 
-以下は metadata.json 規約の上に積む後続の仕事。現状は枠組みだけ提示。
+# 4. (任意) 動作確認
+aws cloudformation deploy \
+  --template-file problems/battles/my-new-problem/template.yaml \
+  --stack-name tc-my-new-problem-test \
+  --parameter-overrides NamePrefix=tc-my-new-problem-test TenkaCloudAccountId=<id> ExternalId=<jobId>
+```
 
-- **participant ポータル**: チームログインキーで認証し、自チームに deploy された問題への
-  click-through 一覧 + 競技状況を見せる別アプリ。
-- **scoreboard**: Battle / Challenge 両モード共通の得点 backend (DDB + 集計 Lambda)。
-- **Challenge ダッシュボード**: 線グラフ + 得点ヒストリー + リアルタイム得点。
-- **Battle 演出 / disruption イベント**: 競技中に妨害やシチュエーションチェンジを差し込む
-  仕組み + ペナルティ / 得点の可視化。
-- **deploy backend**: form 入力を受け取り、CFn テンプレートを competitor account の
-  CloudFormation に展開する Lambda + cross-account AssumeRole + ステータス追跡。
+| サブコマンド                                       | 用途                                                              |
+| -------------------------------------------------- | ----------------------------------------------------------------- |
+| `tenkacloud-problem.ts list-kinds`                 | 利用可能な scoring kind と雛形を一覧。                              |
+| `tenkacloud-problem.ts create <id> --kind <kind>`  | 雛形生成 (metadata.json + template.yaml + README skeleton)。       |
+| `tenkacloud-problem.ts validate <id>`              | SCHEMA + cross-ref (endpoints の outputKey が CFn に存在するか等)。 |
+| `tenkacloud-problem.ts inspect <id>`               | metadata + template + cross-ref を 1 画面に dump (= 設計レビュー用)。 |
+
+Claude Code から使う場合は `/create-problem` skill が要件聞き取り → 雛形生成 → metadata 編集まで walk through する。
+
+## カタログ生成パイプライン
+
+問題追加 / 編集後、 次のチェックを通すと CI が緑になる (= `make before-commit` が走らせる)。
+
+| step                                  | 内容                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `make validate-problems`              | `metadata.json` を `SCHEMA.json` で検証。                                                         |
+| `make check-problems-index`           | `index.json` が `metadata.json` 群と一致するか check (drift 検知)。 編集後に `make build-problems-index` で再生成。 |
+| `make check-template-ascii`           | template.yaml が ASCII + Latin-1 範囲内か (IAM Description の安全性)。                            |
+| `make check-template-security`        | IAM / Security Group / S3 / KMS の危険パターン scan (例: `Action: "*"` + `Resource: "*"`)。       |
+| `make check-template-cfn-refs`        | `!Ref` / `!GetAtt` の reference 整合 + `ParticipantViewerRole` 宣言の存在検証。                   |
+
+`index.json` は `apps/admin-console` / `apps/application-admin-console` / `apps/participant-portal` の 3 SPA に build 時注入される (= metadata.json が UI 表示の正本)。
+
+## i18n
+
+サポート locale は **ja + en の 2 言語のみ** (Issue #1108 で es / zh は廃止)。
+
+- 日本語 (default): top-level の `name` / `shortDescription` / `description` / `learningGoals` にそのまま入れる。
+- 英語: `metadata.json` の `i18n.en` に override + `README.en.md` を同ディレクトリに置く。
+
+英語版が無い問題 (= `i18n.en` 未設定) は portal の locale switcher を `en` に切り替えると default (ja) にフォールバックする。
+
+## 関連ドキュメント
+
+- [`SCHEMA.json`](./SCHEMA.json) — metadata.json JSON Schema (正本)
+- [`docs/problems/AUTHORING.html`](../docs/problems/AUTHORING.html) — 30 分で 1 問書く onboarding (5 kind 決定木 + 4 worked example)
+- [`docs/architecture/adr-012-problem-plugin-architecture.html`](../docs/architecture/adr-012-problem-plugin-architecture.html) — 3-asset model + thick metadata DSL + generic scoring dispatcher の設計
+- [`infrastructure/templates/README.md`](../infrastructure/templates/README.md) — 競技者側 (competitor account) のセットアップ
+- [`docs/gallery.md`](../docs/gallery.md) — 実装済み問題と次の候補を眺めるカタログ

--- a/problems/battles/hello-world-battle/template.yaml
+++ b/problems/battles/hello-world-battle/template.yaml
@@ -180,11 +180,6 @@ Resources:
                 Action:
                   - ssm:TerminateSession
                 Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:session/${NamePrefix}*"
-              - Sid: DescribeOwnStack
-                Effect: Allow
-                Action:
-                  - cloudformation:DescribeStacks
-                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${NamePrefix}/*"
               - Sid: FilterOwnLambdaLogs
                 Effect: Allow
                 Action:

--- a/problems/challenges/hello-world/README.en.md
+++ b/problems/challenges/hello-world/README.en.md
@@ -27,8 +27,7 @@ The canonical worldbuilding lives in [`docs/lore/world.html`](../../../docs/lore
 - `AWS::SSM::Parameter` (`/{NamePrefix}/hello`, Standard tier, value `Hello from {NamePrefix}`)
 - `ParticipantViewerRole` — IAM Role competitors AssumeRole into for read-only AWS Console access
   - `ssm:GetParameter` / `GetParameters` / `GetParametersByPath` scoped **only to their own prefix**
-  - `cloudformation:DescribeStacks` etc. scoped **only to their own stack**
-  - Cannot peek at other tenants' parameters / stacks (ADR-021)
+  - SSM read only (= cannot peek at other tenants' parameters, ADR-021)
 
 No EC2 / VPC / public endpoint is created. SSM Standard tier is free.
 
@@ -40,9 +39,9 @@ aws ssm get-parameter --name /{NamePrefix}/hello --query Parameter.Value --outpu
 # → "Hello from {NamePrefix}"
 ```
 
-Or click through to the Parameter Store detail page in AWS Console — the deep link is published as the `ParameterConsoleUrl` output in [`template.yaml`](./template.yaml) and exposed to competitors via the Participant Portal.
+Or open the `ParameterConsoleUrl` output (= region-scoped AWS Console home) from the Participant Portal and navigate to SSM Parameter Store yourself. Type the parameter name (`ParameterName` output) into Parameter Store search, or read it via the CLI.
 
-> The Parameter Store **list** page in Console requires `ssm:DescribeParameters`, which `ParticipantViewerRole` intentionally lacks to prevent cross-tenant leakage (ADR-021). Listing from the console is deliberately blocked, so use the deep link from the Portal.
+> The Parameter Store **list** page in Console requires `ssm:DescribeParameters`, which `ParticipantViewerRole` intentionally lacks to prevent cross-tenant leakage (ADR-021). Listing from the console is deliberately blocked, so the CLI path (`aws ssm get-parameter --name ...`) is the recommended solve.
 
 Paste the value into the Participant Portal flag submission box and submit. Correct → +100 pt. Wrong → -5 pt.
 

--- a/problems/challenges/hello-world/README.md
+++ b/problems/challenges/hello-world/README.md
@@ -27,8 +27,7 @@ Challenge / flag-submission の **最小 sample** 問題。 SSM Parameter Store 
 - `AWS::SSM::Parameter` (`/{NamePrefix}/hello`、 Standard tier、 値は `Hello from {NamePrefix}`)
 - `ParticipantViewerRole` — 競技者が AWS Console で読み取り専用 AssumeRole するための IAM Role
   - `ssm:GetParameter` / `GetParameters` / `GetParametersByPath` を **自分の prefix だけ** に scope
-  - `cloudformation:DescribeStacks` etc. を **自分の stack だけ** に scope
-  - 他テナントの parameter / stack を覗けない (ADR-021)
+  - SSM 読み取り権限のみ (= 他テナントの parameter は覗けない、 ADR-021)
 
 EC2 / VPC / 公開エンドポイントは作らない。 SSM Standard tier は料金ゼロ。
 
@@ -40,9 +39,9 @@ aws ssm get-parameter --name /{NamePrefix}/hello --query Parameter.Value --outpu
 # → "Hello from {NamePrefix}"
 ```
 
-または AWS Console の Parameter Store 詳細ページ ([`ParameterConsoleUrl` の Output](./template.yaml)) を Participant Portal から click-through すると直接 deep link で開ける。
+または Participant Portal の `ParameterConsoleUrl` (= region-scoped AWS Console home) から飛んで、 自分で SSM Parameter Store に navigate する。 パラメータ名 (`ParameterName` Output) を直接入力するか、 CLI 経由で読み出すかの 2 択。
 
-> Console の Parameter Store **一覧** ページは `ssm:DescribeParameters` が必要で、 cross-tenant leak を防ぐため `ParticipantViewerRole` には付与していない (ADR-021)。 一覧から探す解き方は意図的に塞いであるので、 Portal の deep link を使う。
+> Console の Parameter Store **一覧** ページは `ssm:DescribeParameters` が必要で、 cross-tenant leak を防ぐため `ParticipantViewerRole` には付与していない (ADR-021)。 一覧から探す解き方は意図的に塞いであるので、 CLI で名前指定 (`aws ssm get-parameter --name ...`) が推奨経路。
 
 値を Participant Portal の Flag 提出欄に貼り付けて submit → 一致すれば +100 pt。 間違えると -5 pt のペナルティ。
 

--- a/problems/challenges/hello-world/template.yaml
+++ b/problems/challenges/hello-world/template.yaml
@@ -63,14 +63,6 @@ Resources:
                   # GetParametersByPath is resource-scopable via path-prefix ARN.
                   - ssm:GetParametersByPath
                 Resource: !Sub "arn:aws:ssm:*:*:parameter/${NamePrefix}/*"
-              - Sid: DescribeOwnStack
-                Effect: Allow
-                Action:
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeStackResources
-                  - cloudformation:DescribeStackEvents
-                  - cloudformation:GetTemplate
-                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${NamePrefix}/*"
 
   HelloParameter:
     Type: AWS::SSM::Parameter
@@ -88,15 +80,15 @@ Outputs:
   ParameterValue:
     Description: SSM Parameter value (echoed in Outputs for smoke test verification).
     Value: !Sub "Hello from ${NamePrefix}"
-  # Issue #1094: AWS Console deep link to the specific parameter detail page.
-  # competitors click this from the Participant Portal and land directly on
-  # the parameter view (= ssm:GetParameter, no DescribeParameters required).
-  # The top-level Parameter Store list view requires ssm:DescribeParameters
-  # which the participant-viewer Role intentionally lacks (ADR-021, no cross-
-  # tenant leak), so the deep link is the supported solve path.
+  # AWS Console home (region-scoped). Competitors land here and navigate to
+  # SSM Parameter Store themselves -- this is a learning problem, not a
+  # spoon-fed deep link. The Parameter Store list view stays empty by design
+  # (ADR-021: participant Role lacks ssm:DescribeParameters), so the intended
+  # solve path is CLI (`aws ssm get-parameter --name /<NamePrefix>/hello`) or
+  # typing the parameter name in Console directly.
   ParameterConsoleUrl:
-    Description: AWS Console deep link to the Parameter Store entry (no DescribeParameters needed).
-    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/parameters/%2F${NamePrefix}%2Fhello/description?region=${AWS::Region}"
+    Description: AWS Console home (region-scoped). Navigate to SSM Parameter Store from here.
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/console/home?region=${AWS::Region}#"
   NamePrefix:
     Description: Common resource prefix that this stack used.
     Value: !Ref NamePrefix


### PR DESCRIPTION
## Summary

- **Sample problem IAM minimization**: drop `cloudformation:Describe*` actions from `ParticipantViewerRole` in the two sample problems (`challenges/hello-world` and `battles/hello-world-battle`). These problems don't actually use CFn read on the participant side — stack outputs already flow into the portal, so the perm was pure surface area. Also flip the `ParameterConsoleUrl` output in `hello-world` from an SSM Parameter detail deep link to the region-scoped AWS Console home, so the solve path stays "navigate / CLI" rather than spoon-fed.
- **`problems/README.md` rewrite**: bring it up to current reality. The previous version still mentioned the legacy `gameday / jam` directory layout, marked `validate:problems` as "future", and listed a "roadmap (out of scope)" section whose items (participant portal, scoreboard, disruptions, deploy backend, metadata-driven catalog injection) are all shipped. Document ADR-012 plugin architecture, 3-asset model, thick metadata DSL, 5 scoring kinds, scaffolding CLI (`scripts/tenkacloud-problem.ts`), and the catalog build pipeline (`make validate-problems` / `check-problems-index` / `check-template-*`).
- **Add `problems/README.en.md`**: English counterpart, matching the per-problem `README.md` + `README.en.md` ja/en convention shipped in #1180.

## Regression analysis

What could break:

- **Existing deployed stacks**: `make deploy-saas` does not redeploy participant problem stacks automatically — each tenant's competitor stacks are deployed on demand by the deploy chain. Already-deployed stacks of `hello-world` / `hello-world-battle` keep their old `ParticipantViewerRole` policy until a tenant re-deploys the problem. New deploys get the slimmer policy. No incompatible Output is removed (`ParameterConsoleUrl` keeps the same name; only the URL value changes).
- **Participant portal URL display**: `ProblemPanel.tsx` renders any `http(s)://` stackOutput as a clickable link (`#1094`). With `ParameterConsoleUrl` now pointing at Console home, the click takes competitors to the AWS Console landing page (login wall, then home). The SSO one-click federation in `sso.ts` is unchanged and still deep-links to the SSM Parameter detail page when `ParameterName` is in stack outputs (`#946`), so the federated path is unaffected.
- **`problem-template-participant-viewer-role.test.ts`**: the `cloudformation:DescribeStacks` expectation for `hello-world` and `hello-world-battle` is removed in this PR. The other three problems (`security-battle-royale`, `microservice-migration-battle`, `stackstack`) still expect their existing actions — unchanged.
- **README link integrity**: removed reference to a non-existent `adr-021-participant-iam-baseline.html` (the real `adr-021` covers dependency major bumps; the "ADR-021" mentioned in test comments is a working name). No other ADR / file references were removed.
- **i18n / locale switcher**: documented that supported locales are ja + en only (#1108). No behavioral change.
- **No CFn schema / scoring kind / SCHEMA.json change** — pure docs + IAM trim.

## Physical impact

| Resource                                                                  | Change                                                                                                                              |
| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| `problems/challenges/hello-world/template.yaml` — `ParticipantViewerRole` | **UPDATE** (inline policy: drop `DescribeOwnStack` statement with 4 CFn actions). IAM Role itself is not replaced.                  |
| `problems/challenges/hello-world/template.yaml` — `ParameterConsoleUrl` Output | **UPDATE** (Output value flips to Console home URL; Output key unchanged).                                                          |
| `problems/battles/hello-world-battle/template.yaml` — `ParticipantViewerRole` | **UPDATE** (inline policy: drop `DescribeOwnStack` statement with `cloudformation:DescribeStacks`).                                 |
| `problems/README.md`                                                      | **UPDATE** (full rewrite — content drift, no API change).                                                                            |
| `problems/README.en.md`                                                   | **CREATE** (new file; English counterpart).                                                                                          |
| `problems/challenges/hello-world/README.{md,en.md}`                       | **UPDATE** (sync with template policy + Output changes).                                                                             |
| `infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts` | **UPDATE** (drop `cloudformation:DescribeStacks` from expected-actions for the two samples).                                         |
| Deployed CFn stacks (any tenant)                                          | **NO-OP** until next deploy. Re-deploy of these two sample problems will apply the trimmed policy + new Output value.                |
| All other problem templates / stacks                                      | **NO-OP**.                                                                                                                           |

## Test plan

- [x] `make harness` — 0 findings
- [x] `make before-commit` — passes (lint-md / lint-text / biome format / vitest / validate-problems / check-problems-index / check-template-{ascii,security,cfn-refs} / audit-deps / cdk synth)
- [x] Affected unit tests pass:
  - [x] `infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts` (still asserts the IAM baseline for all 4 problem templates; updated expectations for the two samples)
  - [x] `infrastructure/test/problem-deploy/sso-console-destination.test.ts` (unchanged; the SSO federation deep link is still pinned via `buildConsoleDestination` and unaffected by this change)
  - [x] `infrastructure/test/scripts/inspect-problem.test.ts` (`ParameterConsoleUrl` output key still listed; only the URL value changed)
- [ ] Manual: after re-deploying `hello-world` in a Lite-mode environment, verify the participant portal shows `ParameterConsoleUrl` pointing at Console home and that `aws ssm get-parameter --name /<NamePrefix>/hello` still resolves via the trimmed `ParticipantViewerRole`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)