### PR TITLE
feat(deploy): route all problems through S3 payload when bucket is bound (Phase 4a-A)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -148,24 +148,24 @@ export async function startDeployment(
     }),
   );
 
-  // ADR-008 Phase 3: private 問題 + bucket bind 済なら S3 から 15min TTL presigned URL を
-  // 発行。 CodeBuild の deploy-battles.sh が CHALLENGE_PAYLOAD_URL を fetch して zip 展開する。
-  const privateBucket = resolveChallengePayloadBucket({
+  // ADR-003 Phase 4a (problem catalog split): bucket が bound されていれば
+  // visibility に関わらず S3 経路で payload を渡す (= 旧 ADR-008 Phase 3 の private
+  // 限定経路を全問題に拡張)。 bucket 未 bound のときは従来の source.zip 同梱経路で fallback。
+  const payloadBucket = resolveChallengePayloadBucket({
     problemId: request.problemId,
-    visibility: ctx.problemsVisibility,
     bucketName: ctx.challengePayloadBucket,
   });
   let challengePayloadUrl: string | undefined;
-  if (privateBucket) {
+  if (payloadBucket) {
     if (!ctx.s3) {
       throw new Error(
-        "deploy-handler: private problem requires S3 client but ctx.s3 is undefined. " +
+        "deploy-handler: challenge payload bucket is set but ctx.s3 is undefined. " +
           "Check CDK wiring for CHALLENGE_PAYLOAD_BUCKET + S3Client.",
       );
     }
     challengePayloadUrl = await generateChallengePayloadUrl({
       s3: ctx.s3,
-      bucketName: privateBucket,
+      bucketName: payloadBucket,
       problemId: request.problemId,
     });
   }

--- a/infrastructure/lib/problem-deploy/handlers/shared/visibility.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/visibility.ts
@@ -32,15 +32,19 @@ export function parseProblemsVisibility(
 }
 
 /**
- * private 問題 + bucket 両方揃ったとき bucket 名を返す。 dormant なら undefined。
- * 呼び出し側で truthy check 1 つで分岐できる + 型が narrow される。
+ * ADR-003 Phase 4a (problem catalog split): bucketName が set されていれば、 problemId の
+ * visibility に関わらず S3 経路を使う。 旧挙動 (= private 問題だけ S3、 public は source.zip
+ * 同梱) は repo split 前の transition 用で、 split 完了後は全問題が ChallengePayloadStack
+ * + TenkaCloudChallenge repo の publish workflow で S3 に publish される設計。
+ *
+ * `visibility` 引数 / `parseProblemsVisibility` 自体は metadata catalog で
+ * `private` 表示用に保持 (= operator UI / admin console で「答え非公開」マーカーを出す)。
+ * deploy 経路 (= CHALLENGE_PAYLOAD_URL の発行可否) では visibility は参照しない。
  */
 export function resolveChallengePayloadBucket(args: {
   readonly problemId: string;
-  readonly visibility: Readonly<Record<string, PrivateVisibility>> | undefined;
   readonly bucketName: string | undefined;
 }): string | undefined {
   if (!args.bucketName) return undefined;
-  if (args.visibility?.[args.problemId] !== PROBLEM_VISIBILITY_PRIVATE) return undefined;
   return args.bucketName;
 }

--- a/infrastructure/test/problem-deploy/deploy-handler.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler.test.ts
@@ -220,9 +220,10 @@ describe("startDeployment", () => {
     expect(detail.externalIdParameterName).toBe("/development/tenants/tenant-acme/external-id");
   });
 
-  // ADR-008 Phase 3 (Issue #642): visibility / bucket env が dormant なら presigned URL を発行しない (= default)
-  describe("Issue #642: private 問題の presigned URL 発行", () => {
-    it("visibility 空のとき detail.challengePayloadUrl は undefined (= default 互換)", async () => {
+  // ADR-003 Phase 4a (problem catalog split): bucket が bind されているとき、 visibility に
+  // 関わらず全問題が S3 経路で deploy される (= 旧 ADR-008 Phase 3 の private 限定経路を全問題に拡張)。
+  describe("ADR-003 Phase 4a: catalog split deploy routing", () => {
+    it("bucket 未 bound のとき detail.challengePayloadUrl は undefined (= source.zip fallback)", async () => {
       const { ctx, eventsSend } = buildContext();
       await startDeployment(ctx, sampleRequest());
       const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
@@ -231,18 +232,20 @@ describe("startDeployment", () => {
       expect(detail.challengePayloadUrl).toBeUndefined();
     });
 
-    it("bucket 未設定のとき private 問題でも presigned URL を発行しない (= dormant)", async () => {
+    it("bucket bound + visibility=public でも S3 から presigned URL を発行する (= catalog split)", async () => {
       const { ctx, eventsSend } = buildContext({
-        problemsVisibility: { "security-battle-royale": "private" },
-        // challengePayloadBucket は undefined のまま
+        challengePayloadBucket: "tc-challenges-test",
+        s3: {} as DeployContext["s3"],
       });
-      await startDeployment(ctx, sampleRequest());
+      await startDeployment(ctx, sampleRequest({ problemId: "security-battle-royale" }));
       const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
       const detail = JSON.parse(cmd.input.Entries?.[0]?.Detail ?? "{}");
-      expect(detail.challengePayloadUrl).toBeUndefined();
+      expect(typeof detail.challengePayloadUrl).toBe("string");
+      expect(detail.challengePayloadUrl).toContain("tc-challenges-test");
+      expect(detail.challengePayloadUrl).toContain("security-battle-royale/latest.zip");
     });
 
-    it("should pack a presigned URL into detail when a private problem has a bucket configured and an S3 client", async () => {
+    it("bucket bound + visibility=private でも S3 から presigned URL を発行する (= 旧 ADR-008 互換)", async () => {
       const { ctx, eventsSend } = buildContext({
         problemsVisibility: { "security-battle-royale": "private" },
         challengePayloadBucket: "tc-challenges-test",
@@ -252,29 +255,17 @@ describe("startDeployment", () => {
       const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
       const detail = JSON.parse(cmd.input.Entries?.[0]?.Detail ?? "{}");
       expect(typeof detail.challengePayloadUrl).toBe("string");
-      expect(detail.challengePayloadUrl).toContain("tc-challenges-test");
       expect(detail.challengePayloadUrl).toContain("security-battle-royale/latest.zip");
     });
 
-    it("public 問題は private map に無いので bucket 設定があっても presigned URL を発行しない", async () => {
-      const { ctx, eventsSend } = buildContext({
-        problemsVisibility: { "some-other-private-problem": "private" },
-        challengePayloadBucket: "tc-challenges-test",
-        s3: {} as DeployContext["s3"],
-      });
-      await startDeployment(ctx, sampleRequest({ problemId: "security-battle-royale" }));
-      const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
-      const detail = JSON.parse(cmd.input.Entries?.[0]?.Detail ?? "{}");
-      expect(detail.challengePayloadUrl).toBeUndefined();
-    });
-
-    it("should throw an error for private problems with a bucket but no s3 client injected", async () => {
+    it("should throw when the bucket is bound but the S3 client is not injected", async () => {
       const { ctx } = buildContext({
-        problemsVisibility: { "security-battle-royale": "private" },
         challengePayloadBucket: "tc-challenges-test",
         s3: undefined,
       });
-      await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(/S3 client/);
+      await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(
+        /challenge payload bucket/,
+      );
     });
   });
 });

--- a/infrastructure/test/problem-deploy/visibility.test.ts
+++ b/infrastructure/test/problem-deploy/visibility.test.ts
@@ -37,42 +37,26 @@ describe("parseProblemsVisibility (Issue #642)", () => {
   });
 });
 
-describe("resolveChallengePayloadBucket (Issue #642)", () => {
-  it("bucketName 未設定なら undefined (= dormant)", () => {
+describe("resolveChallengePayloadBucket (ADR-003 Phase 4a)", () => {
+  it("should return undefined when bucketName is unset (= source.zip fallback)", () => {
     expect(
       resolveChallengePayloadBucket({
-        problemId: "secret-problem",
-        visibility: { "secret-problem": "private" },
+        problemId: "any-problem",
         bucketName: undefined,
       }),
     ).toBeUndefined();
   });
 
-  it("bucketName あっても visibility に該当 id が無ければ undefined", () => {
+  it("should return the bucket name regardless of visibility once bucketName is bound (= catalog split mode)", () => {
     expect(
       resolveChallengePayloadBucket({
         problemId: "public-problem",
-        visibility: { "secret-problem": "private" },
         bucketName: "tc-challenges-test",
       }),
-    ).toBeUndefined();
-  });
-
-  it("should safely return undefined when visibility is undefined", () => {
+    ).toBe("tc-challenges-test");
     expect(
       resolveChallengePayloadBucket({
-        problemId: "any-problem",
-        visibility: undefined,
-        bucketName: "tc-challenges-test",
-      }),
-    ).toBeUndefined();
-  });
-
-  it("should return the bucket name when bucketName + visibility are both set", () => {
-    expect(
-      resolveChallengePayloadBucket({
-        problemId: "secret-problem",
-        visibility: { "secret-problem": "private" },
+        problemId: "private-problem",
         bucketName: "tc-challenges-test",
       }),
     ).toBe("tc-challenges-test");


### PR DESCRIPTION
## Summary

Generalize the ADR-008 Phase 3 (Issue #642) private-only S3 fetch path to **all problems** once the ChallengePayloadStack bucket is bound. After Phase 2 (#1184) deploys the bucket and TenkaCloudChallenge's publish.yml uploads zips, this PR makes the deploy-handler emit a presigned URL for every deploy regardless of the problem's \`metadata.visibility\`.

This is the routing change that unlocks **Phase 4a-B** (= deleting \`problems/{template.yaml, portal, services}\` from this repo). With this PR alone the source.zip fallback path still works when the bucket is not bound, so existing environments stay unaffected until they choose to wire up Phase 2's stack.

### Changes

- \`resolveChallengePayloadBucket\` (\`infrastructure/lib/problem-deploy/handlers/shared/visibility.ts\`): drop the visibility check; key off \`bucketName\` alone.
- \`deploy.ts\`: rename \`privateBucket\` → \`payloadBucket\` and update the missing-S3-client error message to \`"challenge payload bucket"\`. The actual routing flow is otherwise unchanged.
- \`parseProblemsVisibility\` and the \`visibility\` env / config field stay around for catalog UI (= "answer-suppressed" marker in admin console).
- Test rewrites:
  - \`visibility.test.ts\`: collapse 4 cases into 2 (bound vs unbound; visibility no longer participates in deploy routing).
  - \`deploy-handler.test.ts\`: replace the Issue #642 block with 4 catalog-split-mode cases:
    1. source.zip fallback when bucket is unbound.
    2. presigned URL when bucket is bound + visibility=public.
    3. presigned URL when bucket is bound + visibility=private (= legacy compat).
    4. throw when bucket is bound but s3 client is missing.

### What this PR does NOT do

- **Doesn't remove anything from \`problems/\`.** That comes in **Phase 4a-B**, after Phase 2 stack is deployed, secrets are bound in TenkaCloudChallenge, and publish.yml has successfully produced \`s3://tc-challenges-<env>/<id>/latest.zip\` for all 5 problems.
- Doesn't change \`scripts/deploy-battles.sh\` — it already honors \`CHALLENGE_PAYLOAD_URL\` (= \`resolve_problem_dir\` switches between local-path and presigned URL download).

## Regression analysis

- **Environments where \`challengePayloadBucketName\` is NOT bound**: behavior unchanged. \`payloadBucket\` is \`undefined\` and \`challengePayloadUrl\` stays \`undefined\`, so \`deploy-battles.sh\` falls back to the local-path (source.zip) flow.
- **Environments where the bucket IS bound (= Phase 2 deployed)**: deploy-handler will now generate a presigned URL for every problem. If \`s3://<bucket>/<id>/latest.zip\` does not exist (= publish.yml hasn't run for that problem yet), \`deploy-battles.sh\` will fail with a curl error. The mitigation is to verify all 5 problems are present in S3 (= push a no-op commit to TenkaCloudChallenge's main, or run \`workflow_dispatch\` on publish.yml with \`workflow_dispatch.target_environment=development\`) **before binding the bucket**.
- **Legacy \`BATTLE_PROBLEMS_VISIBILITY\` env**: still parsed and propagated to Lambdas as before; only the deploy routing stops consulting it. Catalog UI that surfaces "this problem is private" still gets the same data.
- **Existing \`visibility.test.ts\` / \`deploy-handler.test.ts\` semantics**: 4 cases per file updated 1:1. No new behavior modeled outside of test coverage.

## Physical impact

| Resource | Change |
| --- | --- |
| \`visibility.ts\` \`resolveChallengePayloadBucket\` | **UPDATE** (drop visibility arg; key off bucketName only) |
| \`deploy.ts\` private-bucket branch | **UPDATE** (rename + caller passes 2 args instead of 3) |
| \`visibility.test.ts\` | **UPDATE** (4 cases → 2) |
| \`deploy-handler.test.ts\` Issue #642 block | **UPDATE** (4 cases → 4, all Phase 4a-A semantics) |
| Deployed CFn stacks | **NO-OP** until \`challengePayloadBucketName\` is bound in an environment |
| Once bound (Phase 2 stack deployed + secret bind) | **BEHAVIOR CHANGE** (= all deploys route through S3) |

## Test plan

- [x] \`make harness\` — no findings
- [x] \`make before-commit\` — passes
- [x] Affected unit tests pass (\`visibility.test.ts\`, \`deploy-handler.test.ts\`)
- [ ] Manual after merge (= ordered with Phase 2 + TenkaCloudChallenge follow-ups):
  1. Deploy Phase 2 stack: \`make deploy ENV=development\` → capture \`tc-challenges-development\` bucket + publish Role ARN.
  2. In TenkaCloudChallenge repo: bind \`AWS_CHALLENGE_PUBLISH_ROLE_ARN\` secret. Trigger \`publish.yml\` via \`workflow_dispatch(target_environment=development)\` to seed all 5 problems' \`latest.zip\` into the bucket.
  3. Verify \`aws s3 ls s3://tc-challenges-development/\` lists 5 problem IDs.
  4. Smoke deploy 1 problem from a tenant. Check Step Functions exec → CodeBuild log shows \`Downloading private challenge payload to /tmp/...\` followed by successful CFn deploy.
  5. Only after all 5 problems land successfully via S3, open the **Phase 4a-B PR** (\`problems/{template.yaml, portal, services}\` deletion + source.zip stripping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)