### PR TITLE
docs: add contributor onboarding (overview / module map / glossary / map)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,16 @@ make install
 make start
 ```
 
+## Where to start (under 15 minutes)
+
+For first-time contributors, read in this order:
+
+1. [`docs/architecture/OVERVIEW.md`](./docs/architecture/OVERVIEW.md) — what TenkaCloud is, the 4 planes, why Lite vs SaaS exists
+2. [`CONTRIBUTOR_MAP.md`](./CONTRIBUTOR_MAP.md) — pick the recipe matching your goal (new problem / Lambda bug / admin UI / etc)
+3. [`docs/architecture/GLOSSARY.md`](./docs/architecture/GLOSSARY.md) — definitions for AppPlane / ControlPlane / TrustBridge / ParticipantViewerRole / etc
+
+For directory-level "where is X" lookups, [`docs/architecture/MODULE_MAP.md`](./docs/architecture/MODULE_MAP.md) is the index.
+
 ## Development flow
 
 1. Pick an issue (`good first issue` / `help wanted`) or a starter task from

--- a/CONTRIBUTOR_MAP.md
+++ b/CONTRIBUTOR_MAP.md
@@ -1,0 +1,269 @@
+# TenkaCloud Contributor Map
+
+> "I want to do X. Where do I read and where do I edit?" navigation guide. For the architectural narrative, read [`docs/architecture/OVERVIEW.md`](./docs/architecture/OVERVIEW.md) first. For directory-level "where is X" lookups, see [`docs/architecture/MODULE_MAP.md`](./docs/architecture/MODULE_MAP.md). For term definitions, see [`docs/architecture/GLOSSARY.md`](./docs/architecture/GLOSSARY.md).
+
+This document is intentionally **task-oriented**. Each section starts with a concrete goal and lists what to read, what to edit, and what gates to clear.
+
+---
+
+## First-time setup (15 minutes)
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud
+cd TenkaCloud
+make install
+make help                    # see every workflow target
+```
+
+Then read in this order:
+
+1. [`CLAUDE.md`](./CLAUDE.md) — project rules + commands + prohibitions
+2. [`docs/architecture/OVERVIEW.md`](./docs/architecture/OVERVIEW.md) — the 10-minute architectural picture
+3. [`docs/architecture/GLOSSARY.md`](./docs/architecture/GLOSSARY.md) — definitions for terms you'll hit immediately
+4. The ADR for whichever subsystem you're touching ([`docs/architecture/adr-*.html`](./docs/architecture))
+
+Before opening a PR, run the gates in this order:
+
+```bash
+make harness          # architecture invariants (see docs/architecture/harness.md)
+make before-commit    # lint / typecheck / vitest / validate-problems / template checks / synth
+```
+
+Both must be green. If something fails, fix the code; do not edit `biome.json` / `vitest.config.ts` / `tsconfig.json` to mask it (= explicit prohibition in CLAUDE.md).
+
+---
+
+## "I want to add a new problem"
+
+**Read**:
+
+- [`problems/CATALOG.md`](./problems/CATALOG.md) (or `.en.md`) — catalog repo's authoring narrative
+- [`docs/architecture/adr-012-problem-plugin-architecture.html`](./docs/architecture/adr-012-problem-plugin-architecture.html) — the plugin contract
+- [`docs/problems/AUTHORING.html`](./docs/problems/AUTHORING.html) — 30-minute scaffolding walkthrough
+
+**Edit**:
+
+- The `problems/` submodule is the catalog repo [TenkaCloudChallenge](https://github.com/susumutomita/TenkaCloudChallenge). Commit your `metadata.json` + `template.yaml` + optional `portal/` / `services/` **there**, not in the platform repo.
+- Generate the scaffold via `bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>` or invoke the `/create-problem` Claude Code skill.
+
+**After the catalog repo merges your PR**:
+
+A maintainer of this platform repo bumps the submodule pointer:
+
+```bash
+git submodule update --remote problems
+git add problems
+git commit -m "chore(catalog): bump TenkaCloudChallenge to <sha>"
+```
+
+The next `make deploy` picks up your new problem automatically.
+
+**Gates**:
+
+- Catalog repo runs `bun run validate` on PR (= ajv schema + cross-ref check).
+- Platform repo runs `make validate-problems` on the same metadata after the submodule pointer is bumped.
+
+---
+
+## "I want to fix a Lambda bug"
+
+**Read**:
+
+- [`docs/architecture/MODULE_MAP.md`](./docs/architecture/MODULE_MAP.md) — find the right handler under `infrastructure/lib/problem-deploy/handlers/`
+- Most handlers carry an issue number in their comments (e.g., `// Issue #862`); read that issue for context.
+
+**Edit**:
+
+- The handler file under `infrastructure/lib/problem-deploy/handlers/<role>/`.
+- Add or update a test under `infrastructure/test/problem-deploy/` ([`INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`](./docs/architecture/harness.md)).
+
+**Constraints**:
+
+- HTTP status codes: use `StatusCodes` from `http-status-codes`, never numeric literals (= AGENTS.md rule).
+- Handlers must not call `fetch(` directly — push HTTP calls down to Service / Repository (= harness rule).
+- Auth: every Lambda goes through Cognito JWT. No `AUTH_SKIP`.
+
+**Gates**:
+
+- `make before-commit` runs vitest with coverage.
+- `make harness` checks the no-`fetch`-in-handlers and HTTP-status-code rules.
+
+---
+
+## "I want to add a new admin UI feature"
+
+**Read**:
+
+- [`apps/admin-console/README.md`](./apps/admin-console/README.md) and the screenshot folder.
+- ADR-020 (authorization model) — what System Admin can and can't see.
+- [Cloudscape Design System](https://cloudscape.design/components/) — pick UI components from here as the default.
+
+**Edit**:
+
+- `apps/admin-console/src/` for SystemAdmin UI, `apps/application-admin-console/src/` for Tenant Admin UI.
+- If the feature needs a new backend route, add the route under the appropriate handler in `infrastructure/lib/`.
+- `runtime-config.json` flow: if you introduce a new backend URL, update the hosting stack env AND `apps/<app>/src/config.ts` `loadConfig()`.
+
+**Constraints**:
+
+- No tenant logic in app code ([`INVARIANT_APP_CODE_IS_UNMODIFIED`](./docs/architecture/harness.md)). `apps/*/dist/` is shared across tenants; differences flow through `runtime-config.json`.
+- Polling only ([AGENTS.md prohibition](./AGENTS.md#prohibited)). No SSE / WebSocket. Supplement with EventBridge-driven reconciliation per [ADR-014](./docs/architecture/adr-014-eventbridge-driven-state-reconciliation.html).
+
+**Gates**:
+
+- Per-app `vitest`. CI runs them via `make test-coverage`.
+- Visual smoke: `make start` boots all SPAs on ports 5173/5174/5175.
+
+---
+
+## "I want to add a Battle disruption"
+
+**Read**:
+
+- [ADR-013](./docs/architecture/adr-013-disruption-phase2-condition-triggered.html) — disruption phase 2 (condition-triggered) design
+- [`SCHEMA.json`](./problems/SCHEMA.json) `disruptions[]` field — declare in metadata
+- `infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts` — the firing handler
+
+**Edit**:
+
+- In the catalog repo (submodule): add `disruptions[]` to your problem's `metadata.json` with a `trigger.kind` (`after-deploy` / `team-score-above` / `phase-entered`).
+- If the trigger logic doesn't exist yet (= rare; the 3 above cover most needs), add a new trigger kind in `disruption-fire.ts` + a unit test.
+
+**Gates**: same as Lambda bug fix.
+
+---
+
+## "I want to write a new ADR"
+
+**Read**:
+
+- Existing ADRs under [`docs/architecture/adr-*.html`](./docs/architecture) for style reference. Pick an ADR close to your topic and skim it.
+- The `adr-must-be-html` and `adr-self-contained` rules in [`docs/architecture/harness.md`](./docs/architecture/harness.md).
+
+**Edit**:
+
+- Create `docs/architecture/adr-NNN-<kebab-slug>.html`. Number = next unused. **Do not** create ADRs in Markdown — harness will fail.
+- Write background / decision / impact / alternatives / migration plan. Use HTML's expressive features (row spans, color, SVG, collapsible sections). Each ADR is OSS-readable in isolation.
+
+**Constraints**:
+
+- ADRs must be **self-contained**. Do not leave chat context, rolling-update metadata, role-split notes like `Claude proposes / user owns`, or unresolved TODOs.
+- If you cite another ADR, link to it explicitly.
+
+**Gates**: `make harness` validates the ADR contract. Existing violations are baselined at `.claude/harness/baselines/adr-self-contained.json` so only new regressions fail.
+
+---
+
+## "I want to change CDK / IAM / a CFn template"
+
+**This is the user's territory** (= [AGENTS.md role-split](./AGENTS.md#role-split)). If you are an AI agent: propose, don't act. Write a PR description with the diff and let the user decide.
+
+If you are the user (or have explicit authorization):
+
+**Read**:
+
+- The relevant stack under `infrastructure/lib/`.
+- Aspects under `infrastructure/lib/cdk-aspect/` — they enforce cross-cutting policies (DDB low-capacity, KMS pending window, etc).
+- ADRs about IAM (ADR-002, ADR-009, ADR-017 for TrustBridge).
+
+**Edit**:
+
+- The CDK stack. Add or update unit tests under `infrastructure/test/` with `Template.fromStack(stack)` assertions.
+- If you add a new cross-cutting policy, add a new Aspect and apply it in `app-wiring/wire.ts`.
+
+**Constraints**:
+
+- AssumeRole into competitor accounts **always requires `ExternalId`**. No exceptions.
+- DynamoDB: PROVISIONED 1/1 only. PAY_PER_REQUEST is forbidden (Aspect will override).
+- No `npx` (= use `bunx` or `nlx`). No `rm` (= use `git rm`).
+
+**Gates**:
+
+- `cdk synth` runs in `make before-commit` to catch CFn generation errors.
+- `make harness` + cdk-nag rules in CI.
+
+---
+
+## "I want to update a CLI command"
+
+**Read**:
+
+- [`apps/cli/README.md`](./apps/cli/README.md) — Phase 1 OAuth scaffold.
+- ADR-010 (api-first-cli-mcp) — the operator API-first model.
+
+**Edit**:
+
+- `apps/cli/bin/tenkacloud.ts` for the subcommand router.
+- `apps/cli/src/` for OAuth / API calls.
+- Add a vitest case under `apps/cli/test/`.
+
+**Constraints**:
+
+- CLI subcommands should be machine-friendly: `--json` flag, explicit exit codes, idempotency where applicable. This makes them usable by AI agents and automation.
+
+**Gates**: `bun run --filter @TenkaCloud/cli test` + `make before-commit`.
+
+---
+
+## "I want to investigate a production incident"
+
+**Read**:
+
+- `docs/operations/` — runbooks (HTML).
+- The relevant Lambda's CloudWatch Log Group. Most Lambdas emit structured logs prefixed with `[<role>]` and tagged with `jobId` / `tenantId` for correlation.
+- The TrustBridge shadow audit log (Issue #795 / ADR-017) for cross-account actions.
+
+**No code change unless rolling out a fix.** Document findings in a follow-up issue.
+
+---
+
+## "I want to update CI / lint / format config"
+
+Avoid this unless absolutely necessary. CLAUDE.md explicitly forbids editing `biome.json` / `vitest.config.ts` / `tsconfig.json` to mask code failures. The correct path is almost always to fix the code.
+
+Legitimate config edits:
+
+- Adding a new package to `package.json` `trustedDependencies` — **always a stand-alone PR** with manual script verification in the PR body (= supply-chain hardening; AGENTS.md "Supply chain security").
+- Adjusting CI workflow steps for new infrastructure (e.g., a new submodule, a new check). Document the rationale in the commit.
+- Bumping `biome` or other locked tool versions — run `biome migrate` and document.
+
+**Gates**: full `make before-commit` + CI green.
+
+---
+
+## "I want to scope out a brand-new subsystem"
+
+You probably want an ADR first. See "I want to write a new ADR" above.
+
+For inspiration, look at how recent large changes were proposed:
+
+- ADR-012 (problem plugin architecture) — set up the plugin contract for problems
+- ADR-016 (TenkaCloud Lite) — split the deploy mode in two
+- ADR-017 (TrustBridge) — added a new cross-cutting audit layer
+- ADR-022 (inter-team coordination plugin) — extended the plugin model for Battle interactions
+
+Open a draft PR with just the ADR. Iterate on the design before writing implementation code.
+
+---
+
+## Common surprises
+
+| Surprise                                                                 | What's happening                                                                                  |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| "I edited a problem and `make deploy` doesn't pick it up"                | Problems live in the `problems/` **submodule**. Bump the pointer or edit in the catalog repo.     |
+| "`make deploy` is fast, why does the docs mention 3 phases?"              | `make deploy` is **Lite mode** (= 2 stacks). 3-phase install is `make deploy-saas` only.          |
+| "Why is DynamoDB so slow on my new table?"                                 | The `DynamoDbLowCapacity` Aspect forces 1 RCU / 1 WCU. Override only with a justified config bump. |
+| "Cognito UserPool keeps getting recreated"                                 | The DestroyPolicySetter Aspect sets `RemovalPolicy.DESTROY` for dev. Production envs override.   |
+| "CI fails on a problem I didn't touch"                                     | Submodule pointer drift. Run `git submodule update --init --recursive`.                           |
+| "ADR-NNN is mentioned in code but the file doesn't exist"                  | Several ADR numbers were tentatively reserved during design; check open issues for the real ADR.  |
+| "The `_legacy/` dir is gone but Git log still references it"              | Phase 1 of the catalog split (= TenkaCloudChallenge#3) deleted it. History is intact via Git log. |
+| "I see TrustBridge mentioned but the code doesn't block anything"          | TrustBridge is in **shadow mode** by design. Phase 2 of ADR-017 flips it to enforcement.          |
+
+---
+
+## Who to ask
+
+- Architecture / design decisions → open an issue with the `discussion` label
+- Bugs → open an issue with a repro + the relevant Lambda log excerpt
+- Security → see [SECURITY.md](./SECURITY.md). Do not file public issues for sensitive disclosures.
+- General questions → [GitHub Discussions](https://github.com/susumutomita/TenkaCloud/discussions)

--- a/README.md
+++ b/README.md
@@ -132,10 +132,16 @@ Core planes:
 
 Start with these architecture docs:
 
-- [ADR-012: Problem plugin architecture](./docs/architecture/adr-012-problem-plugin-architecture.html)
-- [ADR-016: TenkaCloud Lite mode](./docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html)
-- [ADR-017: Cloud Action Intent / Trust Bridge](./docs/architecture/adr-017-cloud-action-intent-trust-bridge.html)
-- [Cloud Action Intent protocol spec](./docs/architecture/cloud-action-intent.html)
+- **For first-time contributors** (10-min reads):
+  - [`docs/architecture/OVERVIEW.md`](./docs/architecture/OVERVIEW.md) — full architectural narrative
+  - [`CONTRIBUTOR_MAP.md`](./CONTRIBUTOR_MAP.md) — "I want to do X" navigation
+  - [`docs/architecture/MODULE_MAP.md`](./docs/architecture/MODULE_MAP.md) — "where is X" directory map
+  - [`docs/architecture/GLOSSARY.md`](./docs/architecture/GLOSSARY.md) — term definitions with ADR back-links
+- **Decision rationales (ADRs)**:
+  - [ADR-012: Problem plugin architecture](./docs/architecture/adr-012-problem-plugin-architecture.html)
+  - [ADR-016: TenkaCloud Lite mode](./docs/architecture/adr-016-tenkacloud-lite-app-plane-core.html)
+  - [ADR-017: Cloud Action Intent / Trust Bridge](./docs/architecture/adr-017-cloud-action-intent-trust-bridge.html)
+  - [Cloud Action Intent protocol spec](./docs/architecture/cloud-action-intent.html)
 
 ## Full Deployment
 

--- a/docs/architecture/GLOSSARY.html
+++ b/docs/architecture/GLOSSARY.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Glossary</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud Glossary</h1>
+<blockquote>
+<p>Definitions of recurring terms in TenkaCloud. Each entry says <strong>what it is</strong>, <strong>where it lives in code</strong>, and <strong>which ADR introduced or governs it</strong>. For the narrative, see <a href="./OVERVIEW.md">OVERVIEW.md</a>. For directory ownership, see <a href="./MODULE_MAP.md">MODULE_MAP.md</a>.</p>
+</blockquote>
+<p>Sorted alphabetically. Acronyms are spelled out on first reference.</p>
+<hr>
+<h2>AppPlane / Application Plane</h2>
+<p>The per-tenant runtime that hosts a tenant&#39;s own Cognito UserPool, API Gateway HTTP API, and <code>application-admin-console</code> SPA. Two tier shapes:</p>
+<ul>
+<li><strong>Pooled</strong> — BASIC / STANDARD / PREMIUM tiers share a single CDK stack (<code>serverless-saas-ref-arch-tenant-template-pooled</code>). One Cognito UserPool, one API, one SPA serve all pooled tenants.</li>
+<li><strong>Silo</strong> — PLATINUM tier gets its own stack (<code>serverless-saas-ref-arch-tenant-template-&lt;tenantId&gt;</code>) deployed via the per-tenant <code>ServerlessSaaSPipeline</code>.</li>
+</ul>
+<p>Distinct from Control Plane (= tenant manager). The Application Plane runs <em>tenant business logic</em>; it doesn&#39;t manage tenants. Defined by invariant <a href="./harness.md"><code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code></a>.</p>
+<p><strong>Code</strong>: <code>infrastructure/lib/tenant-template/</code>, <code>apps/application-admin-console/</code>.</p>
+<hr>
+<h2>Battle vs Challenge</h2>
+<p>Two problem categories that share scoring engine, portal, and metadata DSL but differ in cadence.</p>
+<ul>
+<li><strong>Battle</strong>: real-time, head-to-head. Multiple teams deploy concurrently and earn points from uptime / defense / phase progression.</li>
+<li><strong>Challenge</strong>: self-paced, evergreen. Always open. One deploy = one flag submission is typical.</li>
+</ul>
+<p>Distinguished by <code>metadata.category</code> (= <code>&quot;Battle&quot;</code> or <code>&quot;Challenge&quot;</code>). Battle and Challenge are not strict silos — a Battle problem may embed CTF-style sub-quests inside the same metadata. See <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>.</p>
+<p><strong>Code</strong>: <code>problems/battles/&lt;id&gt;/</code>, <code>problems/challenges/&lt;id&gt;/</code> (= inside the submodule).</p>
+<hr>
+<h2>ChallengePayloadStack</h2>
+<p>A CDK stack (<code>infrastructure/lib/challenge-payload/challenge-payload-stack.ts</code>) that materializes the S3 bucket + GitHub OIDC IAM Role used by an external &quot;additional problems&quot; repo. Currently <strong>dormant</strong> — no repo binds its <code>AWS_CHALLENGE_PUBLISH_ROLE_ARN</code> secret yet. Reserved for a future private/answer repo that does not want to ship via the OSS <code>problems/</code> submodule.</p>
+<p>Introduced by <a href="./adr-003-problem-catalog-ddb.html">ADR-008</a> Phase 3 + Phase 4 (the bucket is the Phase 3 piece; the OIDC Role is the Phase 4 piece). The deploy-handler path that consumes its presigned URLs (= <code>resolveChallengePayloadBucket</code> → <code>CHALLENGE_PAYLOAD_URL</code> env into <code>deploy-battles.sh</code>) is also live but only fires when the bucket env is bound.</p>
+<hr>
+<h2>CHALLENGE_PAYLOAD_URL</h2>
+<p>The env var that <code>deploy-handler</code> injects into a CodeBuild execution when a problem&#39;s payload should be fetched from S3 instead of read from the local <code>problems/</code> directory. When set, <code>scripts/deploy-battles.sh</code>&#39;s <code>resolve_problem_dir</code> downloads + unzips the URL into <code>/tmp/...</code> and substitutes that path before running <code>aws cloudformation deploy</code>. When unset, the script uses the in-repo <code>problems/&lt;category&gt;/&lt;id&gt;/</code> path directly (= source.zip bundled).</p>
+<p><strong>Code</strong>: <code>infrastructure/lib/problem-deploy/handlers/deploy-handler/presigned-url.ts</code>, <code>scripts/deploy-battles.sh</code>.</p>
+<hr>
+<h2>CloudActionIntent</h2>
+<p>A structured, pre-flight audit record emitted by <code>deploy-handler</code> (and other &quot;dangerous&quot; Lambdas) before any AssumeRole / CFn / DDB-mutating operation. It captures who is acting (<code>tenantId</code>, <code>teamSlug</code>), what action (<code>deploy</code> / <code>delete</code> / etc), and which AWS API scopes are requested. Currently emitted <em>shadow-only</em> (= the operation still proceeds; the record is for forensic audit). Phase 2/3 of <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> will flip high-risk intents to require explicit operator approval.</p>
+<p><strong>Code</strong>: <code>packages/trust-bridge/</code>, <code>infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts</code>.</p>
+<hr>
+<h2>Competitor account</h2>
+<p>The AWS account owned by a <strong>team</strong> (= competitor). Problem stacks are CFn-deployed <em>into</em> this account, not into the platform account. The competitor pre-deploys <a href="../../infrastructure/templates/competitor-bootstrap.yaml"><code>infrastructure/templates/competitor-bootstrap.yaml</code></a> which creates an IAM Role with a trust policy requiring <code>ExternalId</code>. The platform&#39;s Worker Lambda then <code>sts:AssumeRole</code>s into that account using the per-tenant ExternalId stored in SSM.</p>
+<p>This is the most security-sensitive boundary in the system. ExternalId is <strong>always required</strong> (no exceptions) and is verified at every AssumeRole call. The Role&#39;s permissions are the minimum needed to run that specific problem&#39;s <code>template.yaml</code>.</p>
+<hr>
+<h2>Control Plane</h2>
+<p>The tenant manager. Built on top of SBT&#39;s <code>ControlPlane</code> construct (<a href="./harness.md"><code>INVARIANT_CONTROL_PLANE_USES_SBT</code></a>). Provides: System Admin Cognito UserPool, Tenant CRUD HTTP API, EventBridge bus, <code>admin-console</code> SPA. Does NOT run tenant business logic (<a href="./harness.md"><code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code></a>).</p>
+<p><strong>Code</strong>: <code>infrastructure/lib/control-plane-stack.ts</code>, <code>apps/admin-console/</code>.</p>
+<hr>
+<h2>deploy chain</h2>
+<p>The end-to-end sequence that starts when an operator clicks &quot;Deploy&quot; in <code>application-admin-console</code> and ends when CFn finishes inside the competitor account.</p>
+<pre><code>HTTP POST → deploy-handler (DDB Put + EventBridge Publish)
+         → EventBridge DeployRequested
+         → Step Functions DeployCreateStateMachine
+         → CodeBuild (scripts/deploy-battles.sh) → aws cloudformation deploy
+         → CFn (in competitor account) → CREATE_COMPLETE
+         → generic-scoring-handler picks up and starts polling
+</code></pre>
+<p><strong>Code</strong>: <code>infrastructure/lib/problem-deploy/{deploy-api-lambda,deploy-event-rule,deploy-codebuild-project,deploy-create-state-machine}.ts</code>.</p>
+<hr>
+<h2>Disruption</h2>
+<p>A scheduled or condition-triggered event that fires <em>during</em> a Battle to inject a complication (attack, hosting outage, score handicap). Declared in <code>metadata.disruptions[]</code> with a <code>trigger.kind</code> (<code>after-deploy</code> / <code>team-score-above</code> / <code>phase-entered</code>). The dispatcher Lambda subscribes to EventBridge and invokes a per-problem <code>disruption-fire</code> handler.</p>
+<p>See <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a>. Code: <code>infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts</code>.</p>
+<hr>
+<h2>EventBridge bus</h2>
+<p>The single cross-plane communication channel, owned by the Control Plane stack. Every other stack receives the bus ARN at synth time. Recurring detail types:</p>
+<table>
+<thead>
+<tr>
+<th>Detail Type</th>
+<th>Producer</th>
+<th>Consumer</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>onboardingRequest</code></td>
+<td>SBT ControlPlane (tenant create)</td>
+<td><code>ServerlessSaaSPipeline</code> (PLATINUM silo deploy)</td>
+</tr>
+<tr>
+<td><code>DeployRequested</code></td>
+<td><code>deploy-handler</code></td>
+<td><code>event-handler</code> (= triggers CodeBuild via Step Functions)</td>
+</tr>
+<tr>
+<td><code>DeployCompleted</code></td>
+<td><code>event-handler</code></td>
+<td><code>generic-scoring-handler</code> (starts polling)</td>
+</tr>
+<tr>
+<td><code>ScoreUpdated</code></td>
+<td><code>generic-scoring-handler</code></td>
+<td><code>participant-portal-lambda</code> (live score push)</td>
+</tr>
+<tr>
+<td><code>DisruptionFire</code></td>
+<td>EventBridge scheduled rule</td>
+<td><code>event-handler/disruption-fire</code></td>
+</tr>
+</tbody></table>
+<p>No SSE / WebSocket. Frontend uses polling (= matches Lambda operational model). <a href="./adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> supplements polling with EventBridge-driven reconciliation.</p>
+<hr>
+<h2>ExternalId</h2>
+<p>Per-tenant secret (ULID) stored in SSM SecureString that gates AssumeRole into the competitor account. The competitor sets it when deploying <code>competitor-bootstrap.yaml</code>; the platform stores it in SSM after verification (<code>competitor-accounts-handler/verify.ts</code>). Every subsequent AssumeRole call passes it. Without ExternalId match, AssumeRole fails — this is the <em>only</em> thing preventing cross-tenant deployments if the platform&#39;s IAM Role identity were ever compromised.</p>
+<hr>
+<h2>Generic scoring dispatcher</h2>
+<p>The platform-side Lambda (<code>generic-scoring-handler/</code>) that reads <code>metadata.scoring.kind</code> from each deploy and routes to one of 5 builtin handlers:</p>
+<table>
+<thead>
+<tr>
+<th><code>kind</code></th>
+<th>Handler</th>
+<th>Use case</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>flag</code></td>
+<td><code>kinds/flag.ts</code></td>
+<td>Challenge: one submission, exact-match a CFn Output</td>
+</tr>
+<tr>
+<td><code>uptime-flat</code></td>
+<td><code>kinds/uptime-flat.ts</code></td>
+<td>Battle: poll N endpoints independently, +pt per OK</td>
+</tr>
+<tr>
+<td><code>uptime-multi</code></td>
+<td><code>kinds/uptime-multi.ts</code></td>
+<td>Battle: all-or-nothing, points only when all N OK</td>
+</tr>
+<tr>
+<td><code>phased-polling</code></td>
+<td><code>kinds/phased-polling.ts</code></td>
+<td>Battle: score rule changes by <code>phases[]</code> time</td>
+</tr>
+<tr>
+<td><code>attack-detection</code></td>
+<td><code>kinds/attack-detection.ts</code></td>
+<td>Battle: read attack counter, +pt per detection</td>
+</tr>
+</tbody></table>
+<p>The point is: <strong>scoring code lives in the platform</strong>, not in the problem. A new problem author picks a kind; they don&#39;t add new scoring code. ADR-012 governs this contract.</p>
+<hr>
+<h2>Lite mode</h2>
+<p>The default deploy mode. <code>make deploy</code> (= <code>bun run scripts/tenkacloud-lite.ts up</code>) brings up exactly two stacks (AppPlaneCore + ProblemDeployBackend) with a single hardcoded <code>tenantId=&quot;local&quot;</code>. Skips SBT ControlPlane, tenant pipeline, and the SystemAdmin invitation flow. Use case: one organizer running one event. Boots in ~10 min.</p>
+<p>Opposite of SaaS mode (<code>make deploy-saas</code>). See Issue #955 and <a href="./adr-016-tenkacloud-lite-app-plane-core.html">ADR-016</a>.</p>
+<hr>
+<h2>NamePrefix</h2>
+<p>The <code>tc-{problemSlug}-{teamSlug}</code> prefix injected as a CFn parameter into every problem template. Used to scope all resource names, tags, and IAM trust conditions when multiple teams&#39; stacks coexist in the same competitor (account, region). The deploy chain auto-generates this from <code>metadata.id</code> + <code>team.name</code> slugified.</p>
+<hr>
+<h2>ParticipantViewerRole</h2>
+<p>A required IAM Role inside every problem&#39;s <code>template.yaml</code> (= <a href="./harness.md"><code>INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE</code></a> is partially enforced via <code>problem-template-participant-viewer-role.test.ts</code>). The portal AssumeRoles into it via the Console federation flow (= one-click &quot;open in AWS Console&quot; button), giving the competitor read-only access to <em>their own</em> problem resources via tag-based IAM conditions.</p>
+<p>The baseline policy must restrict <code>Resource: &quot;*&quot;</code> to either a tag-based Condition (<code>aws:ResourceTag/TenkaCloud:NamePrefix</code>) or a small allowlist of metadata-only / self-identity API SIDs (<code>ConsoleEc2Metadata</code>, <code>ConsoleSelfIdentity</code>). Cross-tenant resource leak is the threat model. Test enforces this via <code>RESOURCE_STAR_OK_SIDS</code>.</p>
+<p><strong>Code</strong>: <code>infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts</code> (the AssumeRole caller), <code>problems/**/template.yaml</code> (the resource itself).</p>
+<hr>
+<h2>Plugin (problem-as-plugin)</h2>
+<p>The architectural pattern from ADR-012: a problem ships <strong>content + UI slot + scoring metadata</strong> to a generic platform host. The platform doesn&#39;t know what <code>microservice-migration-battle</code> <em>is</em>; it only knows how to read its <code>metadata.json</code>, deploy its <code>template.yaml</code>, mount its <code>portal/&lt;slot&gt;.tsx</code> into the participant portal, and poll its endpoints per the metadata.</p>
+<p>Three-asset model (+ optional fourth): <code>metadata.json</code> (required) + <code>template.yaml</code> (required) + <code>README.md</code> / <code>README.en.md</code> (required) + <code>portal/</code> (optional UI) + <code>services/</code> (optional in-stack code).</p>
+<hr>
+<h2>Pooled vs Silo</h2>
+<p>The two SaaS tenant isolation models, both supported in SaaS mode.</p>
+<ul>
+<li><strong>Pooled</strong> — BASIC / STANDARD / PREMIUM tenants share one CDK stack. Cheaper, faster onboarding.</li>
+<li><strong>Silo</strong> — PLATINUM tenants each get their own stack via <code>ServerlessSaaSPipeline</code>. Stronger isolation, higher cost.</li>
+</ul>
+<p>Lite mode is implicitly pooled (= one tenant, one stack). See <a href="./adr-018-pooled-userpool-saml-isolation.html">ADR-018</a>.</p>
+<hr>
+<h2>Problem (catalog item)</h2>
+<p>A single directory inside the <code>problems/</code> submodule that the platform can deploy as one unit. Composed of metadata + a CFn template + optional portal/services code. The &quot;problems repo&quot; is <a href="https://github.com/susumutomita/TenkaCloudChallenge">TenkaCloudChallenge</a>.</p>
+<p>See &quot;Plugin&quot; for the architectural framing and &quot;Battle vs Challenge&quot; for the two category shapes.</p>
+<hr>
+<h2>SaaS mode</h2>
+<p>The opt-in multi-tenant deploy mode. <code>make deploy-saas</code> runs <code>scripts/install.sh</code> to do a 3-phase install: (1) ControlPlane + bootstrap + pooled tenant template + per-tenant pipeline, (2) host-build admin-console + deploy <code>AdminConsoleHostingStack</code>, (3) re-deploy ControlPlane with the CloudFront URL to fix callback / CORS. Use case: multi-organizer SaaS.</p>
+<p>Opposite of Lite mode.</p>
+<hr>
+<h2>Scoring kind</h2>
+<p>See &quot;Generic scoring dispatcher&quot; — one of 5 builtin handlers chosen by <code>metadata.scoring.kind</code>. Adding a new kind = a platform-side PR (new file in <code>kinds/</code>), not a problem-side change.</p>
+<hr>
+<h2>source.zip</h2>
+<p>The packaging artifact uploaded to S3 (<code>s3://tenkacloud-source-&lt;account&gt;-&lt;region&gt;/source.zip</code>) by <code>scripts/prepare-source-bundle.sh</code>. Contains the repo + the <code>problems/</code> submodule contents + per-app <code>dist/</code>. CodeBuild pulls this every time it runs <code>scripts/deploy-battles.sh</code>. Re-running <code>prepare-source-bundle.sh</code> is how an operator pushes a problem update without redeploying any Lambda.</p>
+<hr>
+<h2>SystemAdmin</h2>
+<p>The Cognito user role in the Control Plane UserPool. Created via email invitation during <code>make deploy-saas</code> (env <code>SYSTEM_ADMIN_EMAIL</code>). In Lite mode there is no SystemAdmin — the single tenant is hardcoded and the admin console is the only auth boundary.</p>
+<hr>
+<h2>TenantId</h2>
+<p>The string that scopes every per-tenant resource. In Lite mode it is hardcoded to <code>&quot;local&quot;</code>. In SaaS mode it is <code>&quot;pooled&quot;</code> for pooled-tier tenants or a ULID for silo (PLATINUM) tenants. Used as the DDB partition key on every per-tenant table and as the EventBridge detail field for cross-plane routing.</p>
+<hr>
+<h2>TenkaCloudChallenge</h2>
+<p>The catalog repo: <a href="https://github.com/susumutomita/TenkaCloudChallenge">https://github.com/susumutomita/TenkaCloudChallenge</a>. Mounted as a Git submodule at <code>problems/</code> in this repo. Holds the actual problem content (battles + challenges) while the platform repo holds the host that deploys/scores them. The split is the physical manifestation of ADR-012 + ADR-008.</p>
+<hr>
+<h2>Tier</h2>
+<p>The pricing tier a tenant belongs to: BASIC / STANDARD / PREMIUM / PLATINUM. The first three are pooled; PLATINUM is silo. Determined at tenant-create time and stored on <code>TenantDetails</code>. The pipeline decides pooled vs silo based on tier.</p>
+<hr>
+<h2>TrustBridge</h2>
+<p>The audit-and-eventually-approval layer for risky cross-account actions. See &quot;CloudActionIntent&quot; above for the implementation handle and <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> for the full design. The name comes from the role it plays: a logged bridge between the platform&#39;s identity and the competitor&#39;s account, where every crossing is recorded and (in future phases) gated.</p>
+<p><strong>Code</strong>: <code>packages/trust-bridge/</code>, <code>infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts</code>.</p>
+<hr>
+<h2>visibility</h2>
+<p>A metadata field (<code>metadata.visibility</code>) on each problem. <code>&quot;public&quot;</code> problems ship via the OSS <code>problems/</code> submodule (= source.zip route). <code>&quot;private&quot;</code> problems would ship via a separate answer repo using the dormant ChallengePayloadStack S3 route. Currently all problems in the catalog repo are <code>&quot;public&quot;</code>. The <code>parseProblemsVisibility</code> helper remains in the codebase to support the private route when an answer repo gets set up.</p>
+<hr>
+<h2>Pointer-only entries (= things you&#39;ll see in the codebase but that have their own canonical docs)</h2>
+<table>
+<thead>
+<tr>
+<th>Term</th>
+<th>Where it&#39;s defined</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>ADR (Architecture Decision Record)</td>
+<td><code>docs/architecture/adr-*.html</code> (HTML by convention; markdown ADRs are forbidden by harness rule)</td>
+</tr>
+<tr>
+<td>Cloudscape Design System</td>
+<td><a href="https://cloudscape.design/components/">https://cloudscape.design/components/</a> — picked as the SPA UI library default</td>
+</tr>
+<tr>
+<td>CDK Aspect</td>
+<td><code>infrastructure/lib/cdk-aspect/</code> — see MODULE_MAP for the active Aspects</td>
+</tr>
+<tr>
+<td>SBT (SaaS Builder Toolkit)</td>
+<td><code>@cdklabs/sbt-aws</code> 0.3.9 — provides <code>ControlPlane</code> construct + tenant onboarding events</td>
+</tr>
+<tr>
+<td>Mini Shai-Hulud (2nd wave)</td>
+<td>Supply-chain attack pattern. Mitigation: see CLAUDE.md / AGENTS.md &quot;Supply chain security&quot;</td>
+</tr>
+<tr>
+<td>Conventional Commits</td>
+<td><a href="https://www.conventionalcommits.org/">https://www.conventionalcommits.org/</a> — PR title format requirement</td>
+</tr>
+</tbody></table>
+
+<div class="doc-source">Source: <code>docs/architecture/GLOSSARY.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/architecture/GLOSSARY.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -1,0 +1,256 @@
+# TenkaCloud Glossary
+
+> Definitions of recurring terms in TenkaCloud. Each entry says **what it is**, **where it lives in code**, and **which ADR introduced or governs it**. For the narrative, see [OVERVIEW.md](./OVERVIEW.md). For directory ownership, see [MODULE_MAP.md](./MODULE_MAP.md).
+
+Sorted alphabetically. Acronyms are spelled out on first reference.
+
+---
+
+## AppPlane / Application Plane
+
+The per-tenant runtime that hosts a tenant's own Cognito UserPool, API Gateway HTTP API, and `application-admin-console` SPA. Two tier shapes:
+
+- **Pooled** — BASIC / STANDARD / PREMIUM tiers share a single CDK stack (`serverless-saas-ref-arch-tenant-template-pooled`). One Cognito UserPool, one API, one SPA serve all pooled tenants.
+- **Silo** — PLATINUM tier gets its own stack (`serverless-saas-ref-arch-tenant-template-<tenantId>`) deployed via the per-tenant `ServerlessSaaSPipeline`.
+
+Distinct from Control Plane (= tenant manager). The Application Plane runs *tenant business logic*; it doesn't manage tenants. Defined by invariant [`INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`](./harness.md).
+
+**Code**: `infrastructure/lib/tenant-template/`, `apps/application-admin-console/`.
+
+---
+
+## Battle vs Challenge
+
+Two problem categories that share scoring engine, portal, and metadata DSL but differ in cadence.
+
+- **Battle**: real-time, head-to-head. Multiple teams deploy concurrently and earn points from uptime / defense / phase progression.
+- **Challenge**: self-paced, evergreen. Always open. One deploy = one flag submission is typical.
+
+Distinguished by `metadata.category` (= `"Battle"` or `"Challenge"`). Battle and Challenge are not strict silos — a Battle problem may embed CTF-style sub-quests inside the same metadata. See [ADR-012](./adr-012-problem-plugin-architecture.html).
+
+**Code**: `problems/battles/<id>/`, `problems/challenges/<id>/` (= inside the submodule).
+
+---
+
+## ChallengePayloadStack
+
+A CDK stack (`infrastructure/lib/challenge-payload/challenge-payload-stack.ts`) that materializes the S3 bucket + GitHub OIDC IAM Role used by an external "additional problems" repo. Currently **dormant** — no repo binds its `AWS_CHALLENGE_PUBLISH_ROLE_ARN` secret yet. Reserved for a future private/answer repo that does not want to ship via the OSS `problems/` submodule.
+
+Introduced by [ADR-008](./adr-003-problem-catalog-ddb.html) Phase 3 + Phase 4 (the bucket is the Phase 3 piece; the OIDC Role is the Phase 4 piece). The deploy-handler path that consumes its presigned URLs (= `resolveChallengePayloadBucket` → `CHALLENGE_PAYLOAD_URL` env into `deploy-battles.sh`) is also live but only fires when the bucket env is bound.
+
+---
+
+## CHALLENGE_PAYLOAD_URL
+
+The env var that `deploy-handler` injects into a CodeBuild execution when a problem's payload should be fetched from S3 instead of read from the local `problems/` directory. When set, `scripts/deploy-battles.sh`'s `resolve_problem_dir` downloads + unzips the URL into `/tmp/...` and substitutes that path before running `aws cloudformation deploy`. When unset, the script uses the in-repo `problems/<category>/<id>/` path directly (= source.zip bundled).
+
+**Code**: `infrastructure/lib/problem-deploy/handlers/deploy-handler/presigned-url.ts`, `scripts/deploy-battles.sh`.
+
+---
+
+## CloudActionIntent
+
+A structured, pre-flight audit record emitted by `deploy-handler` (and other "dangerous" Lambdas) before any AssumeRole / CFn / DDB-mutating operation. It captures who is acting (`tenantId`, `teamSlug`), what action (`deploy` / `delete` / etc), and which AWS API scopes are requested. Currently emitted *shadow-only* (= the operation still proceeds; the record is for forensic audit). Phase 2/3 of [ADR-017](./adr-017-cloud-action-intent-trust-bridge.html) will flip high-risk intents to require explicit operator approval.
+
+**Code**: `packages/trust-bridge/`, `infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts`.
+
+---
+
+## Competitor account
+
+The AWS account owned by a **team** (= competitor). Problem stacks are CFn-deployed *into* this account, not into the platform account. The competitor pre-deploys [`infrastructure/templates/competitor-bootstrap.yaml`](../../infrastructure/templates/competitor-bootstrap.yaml) which creates an IAM Role with a trust policy requiring `ExternalId`. The platform's Worker Lambda then `sts:AssumeRole`s into that account using the per-tenant ExternalId stored in SSM.
+
+This is the most security-sensitive boundary in the system. ExternalId is **always required** (no exceptions) and is verified at every AssumeRole call. The Role's permissions are the minimum needed to run that specific problem's `template.yaml`.
+
+---
+
+## Control Plane
+
+The tenant manager. Built on top of SBT's `ControlPlane` construct ([`INVARIANT_CONTROL_PLANE_USES_SBT`](./harness.md)). Provides: System Admin Cognito UserPool, Tenant CRUD HTTP API, EventBridge bus, `admin-console` SPA. Does NOT run tenant business logic ([`INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`](./harness.md)).
+
+**Code**: `infrastructure/lib/control-plane-stack.ts`, `apps/admin-console/`.
+
+---
+
+## deploy chain
+
+The end-to-end sequence that starts when an operator clicks "Deploy" in `application-admin-console` and ends when CFn finishes inside the competitor account.
+
+```
+HTTP POST → deploy-handler (DDB Put + EventBridge Publish)
+         → EventBridge DeployRequested
+         → Step Functions DeployCreateStateMachine
+         → CodeBuild (scripts/deploy-battles.sh) → aws cloudformation deploy
+         → CFn (in competitor account) → CREATE_COMPLETE
+         → generic-scoring-handler picks up and starts polling
+```
+
+**Code**: `infrastructure/lib/problem-deploy/{deploy-api-lambda,deploy-event-rule,deploy-codebuild-project,deploy-create-state-machine}.ts`.
+
+---
+
+## Disruption
+
+A scheduled or condition-triggered event that fires *during* a Battle to inject a complication (attack, hosting outage, score handicap). Declared in `metadata.disruptions[]` with a `trigger.kind` (`after-deploy` / `team-score-above` / `phase-entered`). The dispatcher Lambda subscribes to EventBridge and invokes a per-problem `disruption-fire` handler.
+
+See [ADR-013](./adr-013-disruption-phase2-condition-triggered.html). Code: `infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts`.
+
+---
+
+## EventBridge bus
+
+The single cross-plane communication channel, owned by the Control Plane stack. Every other stack receives the bus ARN at synth time. Recurring detail types:
+
+| Detail Type            | Producer                       | Consumer                                          |
+| ---------------------- | ------------------------------ | ------------------------------------------------- |
+| `onboardingRequest`    | SBT ControlPlane (tenant create) | `ServerlessSaaSPipeline` (PLATINUM silo deploy)  |
+| `DeployRequested`      | `deploy-handler`               | `event-handler` (= triggers CodeBuild via Step Functions) |
+| `DeployCompleted`      | `event-handler`                | `generic-scoring-handler` (starts polling)        |
+| `ScoreUpdated`         | `generic-scoring-handler`      | `participant-portal-lambda` (live score push)     |
+| `DisruptionFire`       | EventBridge scheduled rule     | `event-handler/disruption-fire`                   |
+
+No SSE / WebSocket. Frontend uses polling (= matches Lambda operational model). [ADR-014](./adr-014-eventbridge-driven-state-reconciliation.html) supplements polling with EventBridge-driven reconciliation.
+
+---
+
+## ExternalId
+
+Per-tenant secret (ULID) stored in SSM SecureString that gates AssumeRole into the competitor account. The competitor sets it when deploying `competitor-bootstrap.yaml`; the platform stores it in SSM after verification (`competitor-accounts-handler/verify.ts`). Every subsequent AssumeRole call passes it. Without ExternalId match, AssumeRole fails — this is the *only* thing preventing cross-tenant deployments if the platform's IAM Role identity were ever compromised.
+
+---
+
+## Generic scoring dispatcher
+
+The platform-side Lambda (`generic-scoring-handler/`) that reads `metadata.scoring.kind` from each deploy and routes to one of 5 builtin handlers:
+
+| `kind`                | Handler                                | Use case                                          |
+| --------------------- | -------------------------------------- | ------------------------------------------------- |
+| `flag`                | `kinds/flag.ts`                        | Challenge: one submission, exact-match a CFn Output |
+| `uptime-flat`         | `kinds/uptime-flat.ts`                 | Battle: poll N endpoints independently, +pt per OK |
+| `uptime-multi`        | `kinds/uptime-multi.ts`                | Battle: all-or-nothing, points only when all N OK   |
+| `phased-polling`      | `kinds/phased-polling.ts`              | Battle: score rule changes by `phases[]` time       |
+| `attack-detection`    | `kinds/attack-detection.ts`            | Battle: read attack counter, +pt per detection      |
+
+The point is: **scoring code lives in the platform**, not in the problem. A new problem author picks a kind; they don't add new scoring code. ADR-012 governs this contract.
+
+---
+
+## Lite mode
+
+The default deploy mode. `make deploy` (= `bun run scripts/tenkacloud-lite.ts up`) brings up exactly two stacks (AppPlaneCore + ProblemDeployBackend) with a single hardcoded `tenantId="local"`. Skips SBT ControlPlane, tenant pipeline, and the SystemAdmin invitation flow. Use case: one organizer running one event. Boots in ~10 min.
+
+Opposite of SaaS mode (`make deploy-saas`). See Issue #955 and [ADR-016](./adr-016-tenkacloud-lite-app-plane-core.html).
+
+---
+
+## NamePrefix
+
+The `tc-{problemSlug}-{teamSlug}` prefix injected as a CFn parameter into every problem template. Used to scope all resource names, tags, and IAM trust conditions when multiple teams' stacks coexist in the same competitor (account, region). The deploy chain auto-generates this from `metadata.id` + `team.name` slugified.
+
+---
+
+## ParticipantViewerRole
+
+A required IAM Role inside every problem's `template.yaml` (= [`INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`](./harness.md) is partially enforced via `problem-template-participant-viewer-role.test.ts`). The portal AssumeRoles into it via the Console federation flow (= one-click "open in AWS Console" button), giving the competitor read-only access to *their own* problem resources via tag-based IAM conditions.
+
+The baseline policy must restrict `Resource: "*"` to either a tag-based Condition (`aws:ResourceTag/TenkaCloud:NamePrefix`) or a small allowlist of metadata-only / self-identity API SIDs (`ConsoleEc2Metadata`, `ConsoleSelfIdentity`). Cross-tenant resource leak is the threat model. Test enforces this via `RESOURCE_STAR_OK_SIDS`.
+
+**Code**: `infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts` (the AssumeRole caller), `problems/**/template.yaml` (the resource itself).
+
+---
+
+## Plugin (problem-as-plugin)
+
+The architectural pattern from ADR-012: a problem ships **content + UI slot + scoring metadata** to a generic platform host. The platform doesn't know what `microservice-migration-battle` *is*; it only knows how to read its `metadata.json`, deploy its `template.yaml`, mount its `portal/<slot>.tsx` into the participant portal, and poll its endpoints per the metadata.
+
+Three-asset model (+ optional fourth): `metadata.json` (required) + `template.yaml` (required) + `README.md` / `README.en.md` (required) + `portal/` (optional UI) + `services/` (optional in-stack code).
+
+---
+
+## Pooled vs Silo
+
+The two SaaS tenant isolation models, both supported in SaaS mode.
+
+- **Pooled** — BASIC / STANDARD / PREMIUM tenants share one CDK stack. Cheaper, faster onboarding.
+- **Silo** — PLATINUM tenants each get their own stack via `ServerlessSaaSPipeline`. Stronger isolation, higher cost.
+
+Lite mode is implicitly pooled (= one tenant, one stack). See [ADR-018](./adr-018-pooled-userpool-saml-isolation.html).
+
+---
+
+## Problem (catalog item)
+
+A single directory inside the `problems/` submodule that the platform can deploy as one unit. Composed of metadata + a CFn template + optional portal/services code. The "problems repo" is [TenkaCloudChallenge](https://github.com/susumutomita/TenkaCloudChallenge).
+
+See "Plugin" for the architectural framing and "Battle vs Challenge" for the two category shapes.
+
+---
+
+## SaaS mode
+
+The opt-in multi-tenant deploy mode. `make deploy-saas` runs `scripts/install.sh` to do a 3-phase install: (1) ControlPlane + bootstrap + pooled tenant template + per-tenant pipeline, (2) host-build admin-console + deploy `AdminConsoleHostingStack`, (3) re-deploy ControlPlane with the CloudFront URL to fix callback / CORS. Use case: multi-organizer SaaS.
+
+Opposite of Lite mode.
+
+---
+
+## Scoring kind
+
+See "Generic scoring dispatcher" — one of 5 builtin handlers chosen by `metadata.scoring.kind`. Adding a new kind = a platform-side PR (new file in `kinds/`), not a problem-side change.
+
+---
+
+## source.zip
+
+The packaging artifact uploaded to S3 (`s3://tenkacloud-source-<account>-<region>/source.zip`) by `scripts/prepare-source-bundle.sh`. Contains the repo + the `problems/` submodule contents + per-app `dist/`. CodeBuild pulls this every time it runs `scripts/deploy-battles.sh`. Re-running `prepare-source-bundle.sh` is how an operator pushes a problem update without redeploying any Lambda.
+
+---
+
+## SystemAdmin
+
+The Cognito user role in the Control Plane UserPool. Created via email invitation during `make deploy-saas` (env `SYSTEM_ADMIN_EMAIL`). In Lite mode there is no SystemAdmin — the single tenant is hardcoded and the admin console is the only auth boundary.
+
+---
+
+## TenantId
+
+The string that scopes every per-tenant resource. In Lite mode it is hardcoded to `"local"`. In SaaS mode it is `"pooled"` for pooled-tier tenants or a ULID for silo (PLATINUM) tenants. Used as the DDB partition key on every per-tenant table and as the EventBridge detail field for cross-plane routing.
+
+---
+
+## TenkaCloudChallenge
+
+The catalog repo: <https://github.com/susumutomita/TenkaCloudChallenge>. Mounted as a Git submodule at `problems/` in this repo. Holds the actual problem content (battles + challenges) while the platform repo holds the host that deploys/scores them. The split is the physical manifestation of ADR-012 + ADR-008.
+
+---
+
+## Tier
+
+The pricing tier a tenant belongs to: BASIC / STANDARD / PREMIUM / PLATINUM. The first three are pooled; PLATINUM is silo. Determined at tenant-create time and stored on `TenantDetails`. The pipeline decides pooled vs silo based on tier.
+
+---
+
+## TrustBridge
+
+The audit-and-eventually-approval layer for risky cross-account actions. See "CloudActionIntent" above for the implementation handle and [ADR-017](./adr-017-cloud-action-intent-trust-bridge.html) for the full design. The name comes from the role it plays: a logged bridge between the platform's identity and the competitor's account, where every crossing is recorded and (in future phases) gated.
+
+**Code**: `packages/trust-bridge/`, `infrastructure/lib/problem-deploy/handlers/shared/trust-bridge-shadow.ts`.
+
+---
+
+## visibility
+
+A metadata field (`metadata.visibility`) on each problem. `"public"` problems ship via the OSS `problems/` submodule (= source.zip route). `"private"` problems would ship via a separate answer repo using the dormant ChallengePayloadStack S3 route. Currently all problems in the catalog repo are `"public"`. The `parseProblemsVisibility` helper remains in the codebase to support the private route when an answer repo gets set up.
+
+---
+
+## Pointer-only entries (= things you'll see in the codebase but that have their own canonical docs)
+
+| Term                                  | Where it's defined                                                                              |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| ADR (Architecture Decision Record)    | `docs/architecture/adr-*.html` (HTML by convention; markdown ADRs are forbidden by harness rule) |
+| Cloudscape Design System              | <https://cloudscape.design/components/> — picked as the SPA UI library default                  |
+| CDK Aspect                            | `infrastructure/lib/cdk-aspect/` — see MODULE_MAP for the active Aspects                        |
+| SBT (SaaS Builder Toolkit)            | `@cdklabs/sbt-aws` 0.3.9 — provides `ControlPlane` construct + tenant onboarding events         |
+| Mini Shai-Hulud (2nd wave)            | Supply-chain attack pattern. Mitigation: see CLAUDE.md / AGENTS.md "Supply chain security"      |
+| Conventional Commits                  | <https://www.conventionalcommits.org/> — PR title format requirement                            |

--- a/docs/architecture/MODULE_MAP.html
+++ b/docs/architecture/MODULE_MAP.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Module Map</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud Module Map</h1>
+<blockquote>
+<p>&quot;Where does X live?&quot; reference. For the 10-minute architectural narrative, read <a href="./OVERVIEW.md">OVERVIEW.md</a> first. For term definitions, see <a href="./GLOSSARY.md">GLOSSARY.md</a>. For &quot;I want to do X, where do I edit?&quot; recipes, see <a href="../../CONTRIBUTOR_MAP.md">CONTRIBUTOR_MAP.md</a>.</p>
+</blockquote>
+<p>This document maps directories to <strong>who owns them</strong>, <strong>what they&#39;re responsible for</strong>, and <strong>what the main entry point is</strong>. It does not describe decisions — those live in ADRs (<code>adr-*.html</code> in this directory).</p>
+<h2>Top-level layout</h2>
+<pre><code>TenkaCloud/
+├── apps/                       # Vite + React 19 + Cloudscape SPAs + CLI
+├── infrastructure/             # CDK (SBT 0.3.9) — every backend is a Lambda
+├── scripts/                    # Orchestration: install / cleanup / deploy / etc
+├── packages/                   # Cross-app shared TypeScript packages
+├── problems/                   # ← git submodule of TenkaCloudChallenge (catalog)
+├── docs/                       # ADRs, harness rules, architecture narratives
+├── landing/                    # Static OSS landing page (CloudFront)
+├── Makefile                    # Single entry point for every workflow
+├── CLAUDE.md / AGENTS.md       # Project rules (humans + AI agents)
+├── CONTRIBUTOR_MAP.md          # &quot;I want to do X&quot; navigation
+├── ROADMAP.md / SECURITY.md
+└── biome.json / package.json / mise.toml
+</code></pre>
+<h2><code>apps/*</code></h2>
+<p>User-facing SPAs and the CLI. All built with Vite + Bun. Each loads <code>runtime-config.json</code> from S3 at boot to learn its backend URL (= per-tenant). No tenant logic in app code — that&#39;s an invariant (<a href="./harness.md"><code>INVARIANT_APP_CODE_IS_UNMODIFIED</code></a>).</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Audience</th>
+<th>Backend it talks to</th>
+<th>Dev port</th>
+<th>Entry point</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>apps/admin-console/</code></td>
+<td>System Admin (organizer ops)</td>
+<td>Control Plane API (SBT)</td>
+<td>5173</td>
+<td><code>src/main.tsx</code></td>
+</tr>
+<tr>
+<td><code>apps/application-admin-console/</code></td>
+<td>Tenant Admin</td>
+<td>per-tenant Application Plane API</td>
+<td>5174</td>
+<td><code>src/main.tsx</code></td>
+</tr>
+<tr>
+<td><code>apps/participant-portal/</code></td>
+<td>Competitor</td>
+<td>Problem Deploy Backend (participant routes)</td>
+<td>5175</td>
+<td><code>src/main.tsx</code></td>
+</tr>
+<tr>
+<td><code>apps/cli/</code></td>
+<td>Operator / AI agent</td>
+<td>Cognito Hosted UI + Control Plane API (Phase 2 WIP)</td>
+<td>n/a</td>
+<td><code>bin/tenkacloud.ts</code></td>
+</tr>
+<tr>
+<td><code>apps/landing-page/</code></td>
+<td>OSS visitor</td>
+<td>(static)</td>
+<td>n/a</td>
+<td><code>index.html</code></td>
+</tr>
+</tbody></table>
+<h2><code>infrastructure/lib/</code></h2>
+<p>CDK stacks and Lambda handlers. <strong>This directory is the user&#39;s responsibility</strong> (<a href="../../AGENTS.md">AGENTS.md role-split</a>). AI agents propose; the user reviews and decides on infra changes.</p>
+<h3>Stack-level entries (one CDK stack per file)</h3>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Stack name (development)</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>control-plane-stack.ts</code></td>
+<td><code>tenkacloud-control-plane</code></td>
+<td>SBT ControlPlane + EventBridge bus + Tenant CRUD API</td>
+</tr>
+<tr>
+<td><code>admin-console-hosting.ts</code></td>
+<td><code>tenkacloud-admin-console-hosting</code></td>
+<td>admin-console SPA on S3 + CloudFront</td>
+</tr>
+<tr>
+<td><code>admin-console-runtime-config-stack.ts</code></td>
+<td><code>tenkacloud-admin-console-runtime-config</code></td>
+<td>Writes <code>runtime-config.json</code> into the SPA bucket post-deploy</td>
+</tr>
+<tr>
+<td><code>admin-insight/admin-console-insight-stack.ts</code></td>
+<td><code>tenkacloud-admin-insight</code></td>
+<td>System Admin observability + audit log API</td>
+</tr>
+<tr>
+<td><code>bootstrap-template/bootstrap-template-stack.ts</code></td>
+<td><code>serverless-saas-ref-arch-bootstrap</code></td>
+<td>TenantMappingTable + deprovisioning Step Functions</td>
+</tr>
+<tr>
+<td><code>tenant-template/tenant-template-stack.ts</code></td>
+<td><code>serverless-saas-ref-arch-tenant-template-*</code></td>
+<td>Per-tenant API + Cognito + application-admin-console hosting</td>
+</tr>
+<tr>
+<td><code>tenant-pipeline/serverless-saas-pipeline.ts</code></td>
+<td><code>ServerlessSaaSPipeline</code></td>
+<td>PLATINUM-tier silo deploy via CodePipeline</td>
+</tr>
+<tr>
+<td><code>problem-deploy/problem-deploy-backend-stack.ts</code></td>
+<td><code>tenkacloud-problem-deploy</code></td>
+<td>Deployments DDB + Worker Lambda + Participant Portal hosting + CodeBuild deploy executor</td>
+</tr>
+<tr>
+<td><code>challenge-payload/challenge-payload-stack.ts</code></td>
+<td><code>tenkacloud-challenge-payload</code></td>
+<td>S3 bucket + GitHub OIDC IAM Role (= dormant; for future &quot;additional problems&quot; repo)</td>
+</tr>
+<tr>
+<td><code>tenkacloud-lite/*</code> (under <code>app-plane-core</code>)</td>
+<td><code>tenkacloud-lite-*</code></td>
+<td>Lite-mode-specific entries (Cognito + AppPlaneCore wiring without SBT)</td>
+</tr>
+<tr>
+<td><code>observability/cloudwatch-dashboard-stack.ts</code></td>
+<td><code>tenkacloud-observability</code></td>
+<td>CW Dashboard + Cost Budget + Free Tier Alarms</td>
+</tr>
+</tbody></table>
+<h3>Lambda handlers (inside <code>problem-deploy/handlers/</code>)</h3>
+<p>All Lambdas use Hono on Lambda + Cognito JWT auth. Validation with Zod at the boundary; no <code>AUTH_SKIP</code> anywhere.</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Lambda role</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>handlers/deploy-handler/</code></td>
+<td><code>POST /deployments</code> etc. Emits <code>DeployRequested</code> event after DDB Put.</td>
+</tr>
+<tr>
+<td><code>handlers/event-handler/</code></td>
+<td>EventBridge consumer for <code>DeployRequested</code> / disruption fires / bulk-delete / schedule</td>
+</tr>
+<tr>
+<td><code>handlers/generic-scoring-handler/</code></td>
+<td>Dispatches by <code>metadata.scoring.kind</code> to one of 5 builtin handlers (<code>kinds/*.ts</code>)</td>
+</tr>
+<tr>
+<td><code>handlers/participant-handler/</code></td>
+<td>Competitor-facing API: list deployments, submit flag, request Console SSO URL (<code>sso.ts</code>)</td>
+</tr>
+<tr>
+<td><code>handlers/competitor-accounts-handler/</code></td>
+<td>Verify-and-store competitor&#39;s AWS account + region + ExternalId</td>
+</tr>
+<tr>
+<td><code>handlers/admin-audit-handler/</code></td>
+<td>Read-side for the admin audit log (ADR-020 Phase D)</td>
+</tr>
+<tr>
+<td><code>handlers/event-api-handler/</code></td>
+<td>CRUD for organizer events</td>
+</tr>
+<tr>
+<td><code>handlers/shared/</code></td>
+<td>catalog parser, visibility resolver, ExternalId store, CFn status helpers, trust-bridge shadow</td>
+</tr>
+</tbody></table>
+<h3>Cross-cutting Aspects (<code>infrastructure/lib/cdk-aspect/</code>)</h3>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>dynamodb-low-capacity.ts</code></td>
+<td>Forces all DDB tables to PROVISIONED 1 RCU / 1 WCU (Free Tier guard)</td>
+</tr>
+<tr>
+<td><code>destroy-policy-setter.ts</code></td>
+<td>Sets <code>RemovalPolicy.DESTROY</code> on most resources for dev tear-down</td>
+</tr>
+<tr>
+<td><code>kms-key-short-pending-window.ts</code></td>
+<td>Trims KMS key deletion window to dev-friendly 7 days</td>
+</tr>
+<tr>
+<td><code>codebuild-use-aws-managed-kms.ts</code></td>
+<td>Replaces customer-managed KMS key on CodeBuild artifacts with <code>alias/aws/s3</code></td>
+</tr>
+</tbody></table>
+<h3>App composition</h3>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>infrastructure/bin/infrastructure.ts</code></td>
+<td>CDK app entry point. Delegates to <code>app-wiring</code>.</td>
+</tr>
+<tr>
+<td><code>infrastructure/lib/app-config/</code></td>
+<td>Resolves env vars + <code>environments/&lt;env&gt;/{config.json,.env}</code> into <code>AppConfig</code>. Pure function.</td>
+</tr>
+<tr>
+<td><code>infrastructure/lib/app-wiring/</code></td>
+<td><code>buildTenkaCloudApp(app, config)</code> — instantiates every stack in the right order with dependencies.</td>
+</tr>
+<tr>
+<td><code>infrastructure/lib/config/</code></td>
+<td><code>Config</code> TypeScript interface + JSON Schema for <code>config.json</code> validation.</td>
+</tr>
+</tbody></table>
+<h2><code>scripts/</code></h2>
+<table>
+<thead>
+<tr>
+<th>Script</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>install.sh</code></td>
+<td>SaaS mode 3-phase install (<code>make deploy-saas</code>). Sources <code>prepare-source-bundle.sh</code>.</td>
+</tr>
+<tr>
+<td><code>cleanup.sh</code></td>
+<td>Idempotent teardown of every SaaS stack + S3 buckets.</td>
+</tr>
+<tr>
+<td><code>prepare-source-bundle.sh</code></td>
+<td>Builds <code>source.zip</code> for CodeBuild. Initializes the <code>problems/</code> submodule first.</td>
+</tr>
+<tr>
+<td><code>deploy-battles.sh</code></td>
+<td>Run inside CodeBuild. <code>aws cloudformation deploy</code> against the competitor account.</td>
+</tr>
+<tr>
+<td><code>delete-battles.sh</code> / <code>destroy-battles.sh</code></td>
+<td>Mirror for stack teardown.</td>
+</tr>
+<tr>
+<td><code>provision-tenant.sh</code> / <code>deprovision-tenant.sh</code></td>
+<td>Per-tenant CodeBuild scripts for the SaaS tenant pipeline.</td>
+</tr>
+<tr>
+<td><code>update-tenant.sh</code></td>
+<td>Push a new source.zip + redeploy a single tenant&#39;s stack.</td>
+</tr>
+<tr>
+<td><code>tenkacloud-lite.ts</code></td>
+<td><code>make deploy</code> (Lite mode). Brings up AppPlaneCore + ProblemDeployBackend without SBT.</td>
+</tr>
+<tr>
+<td><code>tenkacloud-ops.ts</code></td>
+<td>One-off operator tasks (e.g., promote tenant tier).</td>
+</tr>
+<tr>
+<td><code>tenkacloud-problem.ts</code></td>
+<td>Local problem scaffolding CLI (<code>create / validate / inspect / list-kinds</code>). Wraps <code>problem-cli/</code>.</td>
+</tr>
+<tr>
+<td><code>validate-problems.ts</code></td>
+<td>Runs <code>metadata.json</code> schema + cross-ref checks (used by <code>make validate-problems</code>).</td>
+</tr>
+<tr>
+<td><code>build-problem-index.ts</code></td>
+<td>Generates <code>problems/index.json</code> from all <code>metadata.json</code> files (catalog repo owns this now).</td>
+</tr>
+<tr>
+<td><code>check-template-*.ts</code></td>
+<td>CFn template static checks (ASCII safety / security patterns / <code>!Ref</code> integrity).</td>
+</tr>
+<tr>
+<td><code>audit-dependencies.ts</code></td>
+<td>Supply-chain audit: diffs lifecycle scripts vs <code>audit-baseline.json</code>.</td>
+</tr>
+<tr>
+<td><code>migrate-tier-premium-to-platinum.sh</code></td>
+<td>One-off data migration (one-shot script kept for history).</td>
+</tr>
+</tbody></table>
+<h2><code>packages/</code></h2>
+<p>Cross-app shared TypeScript libraries. Published only inside the monorepo (bun workspaces).</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>packages/trust-bridge/</code></td>
+<td>TrustBridge primitives (ADR-017): CloudActionIntent shape, shadow audit emitter, structured log helpers. Used by both deploy-handler and admin-audit.</td>
+</tr>
+<tr>
+<td><code>packages/portal-plugin-sdk/</code></td>
+<td>Public types for <code>problems/&lt;id&gt;/portal/*.tsx</code> slot components. Catalog-side authors import these.</td>
+</tr>
+</tbody></table>
+<h2><code>problems/</code></h2>
+<p>Git submodule of <a href="https://github.com/susumutomita/TenkaCloudChallenge">TenkaCloudChallenge</a>. Layout inside (= catalog repo&#39;s repo root):</p>
+<pre><code>battles/&lt;id&gt;/                  metadata.json + template.yaml + optional portal/ services/
+challenges/&lt;id&gt;/               same
+SCHEMA.json                    JSON Schema for metadata.json (= contract with platform)
+index.json                     Catalog index built from all metadata
+scripts/validate-problems.ts   Catalog-side validator (catalog CI uses this)
+</code></pre>
+<p>To bump the submodule pointer: <code>git submodule update --remote problems &amp;&amp; git add problems &amp;&amp; git commit</code>.</p>
+<h2><code>docs/</code></h2>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Audience</th>
+<th>Format</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>docs/architecture/adr-*.html</code></td>
+<td>Anyone making design decisions</td>
+<td>HTML (= ADR convention; see <a href="./harness.md"><code>adr-must-be-html</code></a> rule)</td>
+</tr>
+<tr>
+<td><code>docs/architecture/harness.md</code></td>
+<td>Anyone editing CDK</td>
+<td>Markdown (machine-checked invariants)</td>
+</tr>
+<tr>
+<td><code>docs/architecture/OVERVIEW.md</code></td>
+<td>First-time contributor</td>
+<td>Markdown (this doc set)</td>
+</tr>
+<tr>
+<td><code>docs/architecture/MODULE_MAP.md</code></td>
+<td>&quot;Where is X?&quot; lookups</td>
+<td>Markdown (this doc set)</td>
+</tr>
+<tr>
+<td><code>docs/architecture/GLOSSARY.md</code></td>
+<td>Term definitions</td>
+<td>Markdown (this doc set)</td>
+</tr>
+<tr>
+<td><code>docs/problems/AUTHORING.html</code></td>
+<td>Problem author</td>
+<td>HTML (30-min onboarding)</td>
+</tr>
+<tr>
+<td><code>docs/operations/</code></td>
+<td>Operator on-call</td>
+<td>HTML</td>
+</tr>
+<tr>
+<td><code>docs/lore/world.html</code></td>
+<td>Problem worldbuilding</td>
+<td>HTML</td>
+</tr>
+<tr>
+<td><code>docs/api/</code></td>
+<td>Backend API consumers</td>
+<td>HTML</td>
+</tr>
+<tr>
+<td><code>docs/gallery.{md,html}</code></td>
+<td>Problem catalog viewer</td>
+<td>both</td>
+</tr>
+<tr>
+<td><code>docs/ux/</code>, <code>docs/go-to-market/</code>, <code>docs/requirements/</code></td>
+<td>Background context</td>
+<td>HTML</td>
+</tr>
+</tbody></table>
+<h2>Build / CI / lint</h2>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>Makefile</code></td>
+<td>Single entry point. All workflows go through <code>make &lt;target&gt;</code>. Run <code>make help</code> for the full list.</td>
+</tr>
+<tr>
+<td><code>package.json</code> (root)</td>
+<td>bun workspaces, lint scripts (<code>lint:md</code>, <code>lint:text</code>, <code>lint:format</code>), shared dev deps.</td>
+</tr>
+<tr>
+<td><code>infrastructure/package.json</code></td>
+<td>CDK deps + per-stack vitest cases.</td>
+</tr>
+<tr>
+<td><code>apps/*/package.json</code></td>
+<td>Per-app Vite + React deps + per-app vitest.</td>
+</tr>
+<tr>
+<td><code>.github/workflows/ci.yml</code></td>
+<td>PR-time gate: install_ci + audit-deps + lint_text + format_check + typecheck + test-coverage + build.</td>
+</tr>
+<tr>
+<td><code>.claude/harness/</code></td>
+<td>Architecture invariant harness + tech-debt scanner. Source rules: <code>src/architecture.ts</code>, <code>src/tech-debt.ts</code>.</td>
+</tr>
+<tr>
+<td><code>biome.json</code></td>
+<td>Lint / format config. <code>files.includes</code> excludes the <code>problems/</code> submodule.</td>
+</tr>
+<tr>
+<td><code>.textlintignore</code></td>
+<td>Excludes vendor docs + the <code>problems/</code> submodule from Japanese style linting.</td>
+</tr>
+</tbody></table>
+<h2><code>infrastructure/templates/</code></h2>
+<p>CFn templates rolled out <strong>into the competitor&#39;s AWS account</strong> (not the platform account).</p>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>competitor-bootstrap.yaml</code></td>
+<td>One-time IAM Role + trust policy (= ExternalId required) the competitor deploys before joining.</td>
+</tr>
+<tr>
+<td><code>README.md</code></td>
+<td>Competitor-side setup instructions.</td>
+</tr>
+</tbody></table>
+
+<div class="doc-source">Source: <code>docs/architecture/MODULE_MAP.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/architecture/MODULE_MAP.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/architecture/MODULE_MAP.md
+++ b/docs/architecture/MODULE_MAP.md
@@ -1,0 +1,169 @@
+# TenkaCloud Module Map
+
+> "Where does X live?" reference. For the 10-minute architectural narrative, read [OVERVIEW.md](./OVERVIEW.md) first. For term definitions, see [GLOSSARY.md](./GLOSSARY.md). For "I want to do X, where do I edit?" recipes, see [CONTRIBUTOR_MAP.md](../../CONTRIBUTOR_MAP.md).
+
+This document maps directories to **who owns them**, **what they're responsible for**, and **what the main entry point is**. It does not describe decisions — those live in ADRs (`adr-*.html` in this directory).
+
+## Top-level layout
+
+```
+TenkaCloud/
+├── apps/                       # Vite + React 19 + Cloudscape SPAs + CLI
+├── infrastructure/             # CDK (SBT 0.3.9) — every backend is a Lambda
+├── scripts/                    # Orchestration: install / cleanup / deploy / etc
+├── packages/                   # Cross-app shared TypeScript packages
+├── problems/                   # ← git submodule of TenkaCloudChallenge (catalog)
+├── docs/                       # ADRs, harness rules, architecture narratives
+├── landing/                    # Static OSS landing page (CloudFront)
+├── Makefile                    # Single entry point for every workflow
+├── CLAUDE.md / AGENTS.md       # Project rules (humans + AI agents)
+├── CONTRIBUTOR_MAP.md          # "I want to do X" navigation
+├── ROADMAP.md / SECURITY.md
+└── biome.json / package.json / mise.toml
+```
+
+## `apps/*`
+
+User-facing SPAs and the CLI. All built with Vite + Bun. Each loads `runtime-config.json` from S3 at boot to learn its backend URL (= per-tenant). No tenant logic in app code — that's an invariant ([`INVARIANT_APP_CODE_IS_UNMODIFIED`](./harness.md)).
+
+| Path                              | Audience                     | Backend it talks to                                   | Dev port | Entry point                              |
+| --------------------------------- | ---------------------------- | ----------------------------------------------------- | -------- | ---------------------------------------- |
+| `apps/admin-console/`             | System Admin (organizer ops) | Control Plane API (SBT)                               | 5173     | `src/main.tsx`                           |
+| `apps/application-admin-console/` | Tenant Admin                 | per-tenant Application Plane API                      | 5174     | `src/main.tsx`                           |
+| `apps/participant-portal/`        | Competitor                   | Problem Deploy Backend (participant routes)           | 5175     | `src/main.tsx`                           |
+| `apps/cli/`                       | Operator / AI agent          | Cognito Hosted UI + Control Plane API (Phase 2 WIP)   | n/a      | `bin/tenkacloud.ts`                      |
+| `apps/landing-page/`              | OSS visitor                  | (static)                                              | n/a      | `index.html`                             |
+
+## `infrastructure/lib/`
+
+CDK stacks and Lambda handlers. **This directory is the user's responsibility** ([AGENTS.md role-split](../../AGENTS.md)). AI agents propose; the user reviews and decides on infra changes.
+
+### Stack-level entries (one CDK stack per file)
+
+| Path                                                                  | Stack name (development)              | Purpose                                                                                  |
+| --------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `control-plane-stack.ts`                                              | `tenkacloud-control-plane`            | SBT ControlPlane + EventBridge bus + Tenant CRUD API                                     |
+| `admin-console-hosting.ts`                                            | `tenkacloud-admin-console-hosting`    | admin-console SPA on S3 + CloudFront                                                     |
+| `admin-console-runtime-config-stack.ts`                               | `tenkacloud-admin-console-runtime-config` | Writes `runtime-config.json` into the SPA bucket post-deploy                           |
+| `admin-insight/admin-console-insight-stack.ts`                        | `tenkacloud-admin-insight`            | System Admin observability + audit log API                                               |
+| `bootstrap-template/bootstrap-template-stack.ts`                      | `serverless-saas-ref-arch-bootstrap`  | TenantMappingTable + deprovisioning Step Functions                                       |
+| `tenant-template/tenant-template-stack.ts`                            | `serverless-saas-ref-arch-tenant-template-*` | Per-tenant API + Cognito + application-admin-console hosting                       |
+| `tenant-pipeline/serverless-saas-pipeline.ts`                         | `ServerlessSaaSPipeline`              | PLATINUM-tier silo deploy via CodePipeline                                               |
+| `problem-deploy/problem-deploy-backend-stack.ts`                      | `tenkacloud-problem-deploy`           | Deployments DDB + Worker Lambda + Participant Portal hosting + CodeBuild deploy executor |
+| `challenge-payload/challenge-payload-stack.ts`                        | `tenkacloud-challenge-payload`        | S3 bucket + GitHub OIDC IAM Role (= dormant; for future "additional problems" repo)      |
+| `tenkacloud-lite/*` (under `app-plane-core`)                          | `tenkacloud-lite-*`                   | Lite-mode-specific entries (Cognito + AppPlaneCore wiring without SBT)                   |
+| `observability/cloudwatch-dashboard-stack.ts`                         | `tenkacloud-observability`            | CW Dashboard + Cost Budget + Free Tier Alarms                                            |
+
+### Lambda handlers (inside `problem-deploy/handlers/`)
+
+All Lambdas use Hono on Lambda + Cognito JWT auth. Validation with Zod at the boundary; no `AUTH_SKIP` anywhere.
+
+| Path                                  | Lambda role                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `handlers/deploy-handler/`            | `POST /deployments` etc. Emits `DeployRequested` event after DDB Put.                            |
+| `handlers/event-handler/`             | EventBridge consumer for `DeployRequested` / disruption fires / bulk-delete / schedule           |
+| `handlers/generic-scoring-handler/`   | Dispatches by `metadata.scoring.kind` to one of 5 builtin handlers (`kinds/*.ts`)                |
+| `handlers/participant-handler/`       | Competitor-facing API: list deployments, submit flag, request Console SSO URL (`sso.ts`)        |
+| `handlers/competitor-accounts-handler/` | Verify-and-store competitor's AWS account + region + ExternalId                                |
+| `handlers/admin-audit-handler/`       | Read-side for the admin audit log (ADR-020 Phase D)                                              |
+| `handlers/event-api-handler/`         | CRUD for organizer events                                                                        |
+| `handlers/shared/`                    | catalog parser, visibility resolver, ExternalId store, CFn status helpers, trust-bridge shadow   |
+
+### Cross-cutting Aspects (`infrastructure/lib/cdk-aspect/`)
+
+| File                                  | Effect                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `dynamodb-low-capacity.ts`            | Forces all DDB tables to PROVISIONED 1 RCU / 1 WCU (Free Tier guard)                            |
+| `destroy-policy-setter.ts`            | Sets `RemovalPolicy.DESTROY` on most resources for dev tear-down                                |
+| `kms-key-short-pending-window.ts`     | Trims KMS key deletion window to dev-friendly 7 days                                            |
+| `codebuild-use-aws-managed-kms.ts`    | Replaces customer-managed KMS key on CodeBuild artifacts with `alias/aws/s3`                    |
+
+### App composition
+
+| Path                                 | Role                                                                                                |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `infrastructure/bin/infrastructure.ts` | CDK app entry point. Delegates to `app-wiring`.                                                   |
+| `infrastructure/lib/app-config/`     | Resolves env vars + `environments/<env>/{config.json,.env}` into `AppConfig`. Pure function.        |
+| `infrastructure/lib/app-wiring/`     | `buildTenkaCloudApp(app, config)` — instantiates every stack in the right order with dependencies.  |
+| `infrastructure/lib/config/`         | `Config` TypeScript interface + JSON Schema for `config.json` validation.                           |
+
+## `scripts/`
+
+| Script                                | Purpose                                                                                      |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `install.sh`                          | SaaS mode 3-phase install (`make deploy-saas`). Sources `prepare-source-bundle.sh`.          |
+| `cleanup.sh`                          | Idempotent teardown of every SaaS stack + S3 buckets.                                        |
+| `prepare-source-bundle.sh`            | Builds `source.zip` for CodeBuild. Initializes the `problems/` submodule first.              |
+| `deploy-battles.sh`                   | Run inside CodeBuild. `aws cloudformation deploy` against the competitor account.            |
+| `delete-battles.sh` / `destroy-battles.sh` | Mirror for stack teardown.                                                              |
+| `provision-tenant.sh` / `deprovision-tenant.sh` | Per-tenant CodeBuild scripts for the SaaS tenant pipeline.                          |
+| `update-tenant.sh`                    | Push a new source.zip + redeploy a single tenant's stack.                                    |
+| `tenkacloud-lite.ts`                  | `make deploy` (Lite mode). Brings up AppPlaneCore + ProblemDeployBackend without SBT.        |
+| `tenkacloud-ops.ts`                   | One-off operator tasks (e.g., promote tenant tier).                                          |
+| `tenkacloud-problem.ts`               | Local problem scaffolding CLI (`create / validate / inspect / list-kinds`). Wraps `problem-cli/`. |
+| `validate-problems.ts`                | Runs `metadata.json` schema + cross-ref checks (used by `make validate-problems`).           |
+| `build-problem-index.ts`              | Generates `problems/index.json` from all `metadata.json` files (catalog repo owns this now). |
+| `check-template-*.ts`                 | CFn template static checks (ASCII safety / security patterns / `!Ref` integrity).            |
+| `audit-dependencies.ts`               | Supply-chain audit: diffs lifecycle scripts vs `audit-baseline.json`.                        |
+| `migrate-tier-premium-to-platinum.sh` | One-off data migration (one-shot script kept for history).                                   |
+
+## `packages/`
+
+Cross-app shared TypeScript libraries. Published only inside the monorepo (bun workspaces).
+
+| Path                                | Purpose                                                                                        |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `packages/trust-bridge/`            | TrustBridge primitives (ADR-017): CloudActionIntent shape, shadow audit emitter, structured log helpers. Used by both deploy-handler and admin-audit. |
+| `packages/portal-plugin-sdk/`       | Public types for `problems/<id>/portal/*.tsx` slot components. Catalog-side authors import these. |
+
+## `problems/`
+
+Git submodule of [TenkaCloudChallenge](https://github.com/susumutomita/TenkaCloudChallenge). Layout inside (= catalog repo's repo root):
+
+```
+battles/<id>/                  metadata.json + template.yaml + optional portal/ services/
+challenges/<id>/               same
+SCHEMA.json                    JSON Schema for metadata.json (= contract with platform)
+index.json                     Catalog index built from all metadata
+scripts/validate-problems.ts   Catalog-side validator (catalog CI uses this)
+```
+
+To bump the submodule pointer: `git submodule update --remote problems && git add problems && git commit`.
+
+## `docs/`
+
+| Path                                | Audience              | Format             |
+| ----------------------------------- | --------------------- | ------------------ |
+| `docs/architecture/adr-*.html`      | Anyone making design decisions | HTML (= ADR convention; see [`adr-must-be-html`](./harness.md) rule) |
+| `docs/architecture/harness.md`      | Anyone editing CDK    | Markdown (machine-checked invariants) |
+| `docs/architecture/OVERVIEW.md`     | First-time contributor | Markdown (this doc set) |
+| `docs/architecture/MODULE_MAP.md`   | "Where is X?" lookups | Markdown (this doc set) |
+| `docs/architecture/GLOSSARY.md`     | Term definitions       | Markdown (this doc set) |
+| `docs/problems/AUTHORING.html`      | Problem author        | HTML (30-min onboarding) |
+| `docs/operations/`                  | Operator on-call       | HTML |
+| `docs/lore/world.html`              | Problem worldbuilding  | HTML |
+| `docs/api/`                         | Backend API consumers  | HTML |
+| `docs/gallery.{md,html}`            | Problem catalog viewer | both |
+| `docs/ux/`, `docs/go-to-market/`, `docs/requirements/` | Background context | HTML |
+
+## Build / CI / lint
+
+| Path                                | Role                                                                                                |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Makefile`                          | Single entry point. All workflows go through `make <target>`. Run `make help` for the full list.    |
+| `package.json` (root)               | bun workspaces, lint scripts (`lint:md`, `lint:text`, `lint:format`), shared dev deps.              |
+| `infrastructure/package.json`       | CDK deps + per-stack vitest cases.                                                                  |
+| `apps/*/package.json`               | Per-app Vite + React deps + per-app vitest.                                                         |
+| `.github/workflows/ci.yml`          | PR-time gate: install_ci + audit-deps + lint_text + format_check + typecheck + test-coverage + build. |
+| `.claude/harness/`                  | Architecture invariant harness + tech-debt scanner. Source rules: `src/architecture.ts`, `src/tech-debt.ts`. |
+| `biome.json`                        | Lint / format config. `files.includes` excludes the `problems/` submodule.                          |
+| `.textlintignore`                   | Excludes vendor docs + the `problems/` submodule from Japanese style linting.                       |
+
+## `infrastructure/templates/`
+
+CFn templates rolled out **into the competitor's AWS account** (not the platform account).
+
+| File                                | Purpose                                                                                          |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `competitor-bootstrap.yaml`         | One-time IAM Role + trust policy (= ExternalId required) the competitor deploys before joining. |
+| `README.md`                         | Competitor-side setup instructions.                                                              |

--- a/docs/architecture/OVERVIEW.html
+++ b/docs/architecture/OVERVIEW.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Architecture Overview</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud Architecture Overview</h1>
+<blockquote>
+<p>10-minute read for first-time contributors. For the &quot;what to do&quot; perspective, jump to <a href="../../CONTRIBUTOR_MAP.md">CONTRIBUTOR_MAP.md</a>. For module-level &quot;where is X&quot; lookups, see <a href="./MODULE_MAP.md">MODULE_MAP.md</a>. For term definitions with ADR back-links, see <a href="./GLOSSARY.md">GLOSSARY.md</a>. Decisions and their rationales live in <a href="."><code>adr-*.html</code></a> — this document does <strong>not</strong> duplicate ADR content.</p>
+</blockquote>
+<p>TenkaCloud is a multi-tenant SaaS cloud-competition platform on AWS. Operators (&quot;organizers&quot;) run events. Each event hosts teams of competitors who deploy AWS CFn stacks into their own AWS accounts under controlled supervision, and earn points based on the resulting state (flag submission, endpoint uptime, attack detection, etc).</p>
+<h2>The two deploy modes</h2>
+<p>The codebase ships <strong>two</strong> deploy entry points. They share the same Lambdas and 5 problem-scoring kinds. They differ in how many tenants they support and how much SBT machinery they bring up.</p>
+<pre><code>┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│   make deploy        →     Lite mode                                         │
+│   (default)               • single tenantId=&quot;local&quot;                          │
+│                           • 2 stacks: AppPlaneCore + ProblemDeployBackend    │
+│                           • ~10 min boot                                     │
+│                           • use case: 1 organizer, 1 event, fastest path     │
+│                                                                              │
+│   make deploy-saas   →     SaaS mode                                         │
+│                           • SBT ControlPlane (pooled + silo tiers)           │
+│                           • 5+ stacks (control plane, bootstrap, tenant      │
+│                             template, pipeline, problem-deploy, admin UIs)   │
+│                           • 3-phase install (control plane → admin UI →      │
+│                             callback wiring)                                 │
+│                           • use case: multi-organizer SaaS                   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+</code></pre>
+<p>Same code, two entry points. Lite mode is the <strong>default</strong> because most events are one-organizer / one-event. SaaS mode kicks in when an organizer wants tier-based pooled vs siloed tenant isolation. The Lite vs SaaS choice is hidden behind <code>make deploy</code> vs <code>make deploy-saas</code>; everything downstream of &quot;a tenant exists&quot; is identical.</p>
+<h2>The four planes</h2>
+<p>Once the platform is up, runtime traffic flows across four planes that talk through an EventBridge bus.</p>
+<pre><code>┌──────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Control Plane                       │    │  Application Plane               │
+│  • SBT ControlPlane construct        │    │  • per-tenant Cognito + API + UI │
+│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/STANDARD/       │
+│  • Tenant CRUD HTTP API              │    │    PREMIUM tiers) or silo        │
+│  • admin-console UI                  │    │    (PLATINUM tier)               │
+│  • EventBridge bus owner             │    │  • application-admin-console UI  │
+└────────────────┬─────────────────────┘    └────────────────┬─────────────────┘
+                 │                                            │
+                 │              EventBridge bus               │
+                 │ ◄────────────────────────────────────────► │
+                 │     (onboardingRequest, DeployRequested,   │
+                 │      DeployCompleted, ScoreUpdated, …)     │
+                 │                                            │
+┌────────────────┴─────────────────────┐    ┌────────────────┴─────────────────┐
+│  Problem Deploy Backend              │    │  Participant Portal              │
+│  • Deployments DDB + Worker Lambda   │    │  • per-team UI                   │
+│  • AssumeRole into competitor AWS    │    │  • flag submission / endpoints   │
+│  • CFn CreateStack per team          │    │  • Console SSO one-click login   │
+│  • generic scoring dispatcher        │    │    (federation → AssumeRole)     │
+│  • Step Functions for retry / delete │    │  • disruption display            │
+└──────────────────────────────────────┘    └──────────────────────────────────┘
+</code></pre>
+<ul>
+<li><strong>Control Plane</strong> is the <em>tenant manager</em>. It does NOT host tenant runtime (= <a href="./harness.md"><code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code></a>). It only knows &quot;tenant X exists, tier=Y&quot;.</li>
+<li><strong>Application Plane</strong> is the per-tenant runtime. Pooled tiers share one CDK stack, PLATINUM gets its own stack via the per-tenant pipeline.</li>
+<li><strong>Problem Deploy Backend</strong> is the dangerous bit: it AssumeRoles into competitors&#39; AWS accounts and runs CFn there. Every AssumeRole call requires <code>ExternalId</code> (<a href="../../infrastructure/templates/competitor-bootstrap.yaml">no exception, ever</a>).</li>
+<li><strong>Participant Portal</strong> is the public-facing per-team app. Competitors log in with a team key (no AWS account required from them) and click through to AWS Console via the federation flow in <code>sso.ts</code>.</li>
+</ul>
+<p>These four planes are not microservices in the cloud-native sense — they&#39;re CDK stack boundaries within a single AWS account. The point of the separation is <strong>deployment + IAM isolation</strong>, not network isolation.</p>
+<h2>TrustBridge: why one extra hop exists</h2>
+<p>When a deploy is requested, it crosses the most dangerous IAM boundary in the system: the platform&#39;s AWS account (where Lambdas run) → the <strong>competitor&#39;s</strong> AWS account (where the actual problem stack gets created). To make this auditable and to give the operator a &quot;veto&quot; point before the action runs, every deploy goes through <strong>TrustBridge</strong> (ADR-017).</p>
+<pre><code>Operator clicks &quot;Deploy&quot;
+       │
+       ▼
+deploy-handler Lambda emits a CloudActionIntent (shadow audit)
+       │
+       ▼
+TrustBridge logs the intent BEFORE AssumeRole happens
+       │
+       ▼
+Worker Lambda AssumeRoles into competitor account using tenant&#39;s ExternalId
+       │
+       ▼
+CFn CreateStack runs inside the competitor account with that problem&#39;s template
+</code></pre>
+<p>TrustBridge is currently in <em>shadow</em> mode: it emits structured audit logs without blocking. Phase 2/3 plans (ADR-017) flip it to enforcement, where high-risk actions require operator confirmation. The shadow mode is intentional — it lets us collect baseline data before adding friction.</p>
+<h2>Problems = plugins</h2>
+<p>Problem templates do not live in this repo. They live in <a href="https://github.com/susumutomita/TenkaCloudChallenge">TenkaCloudChallenge</a>, mounted as a Git submodule at <code>problems/</code>. The platform side is a generic <em>host</em> that knows how to deploy a CFn template, poll endpoints for uptime, count attacks, etc; the catalog repo brings the actual content (ADR-012).</p>
+<pre><code>[TenkaCloudChallenge repo]                    [This (platform) repo]
+problems/                                     problems/                          ← git submodule pointer
+  battles/&lt;id&gt;/                               infrastructure/lib/problem-deploy/ ← the generic host
+    metadata.json    ← scoring + UI wiring      handlers/deploy-handler/         ← deploy chain
+    template.yaml    ← CFn payload              handlers/generic-scoring-handler/← 5 builtin kinds
+    portal/&lt;slot&gt;.tsx← optional UI slot         handlers/participant-handler/    ← portal API
+    services/...     ← optional payload code
+</code></pre>
+<p>A new problem = a PR to the catalog repo + a <code>git submodule update --remote problems</code> bump here. No platform Lambda code changes. The host validates the metadata against <code>SCHEMA.json</code> (= source of truth for the contract between platform and catalog), then dispatches scoring based on <code>scoring.kind</code>.</p>
+<p>There&#39;s a second, dormant path for content that shouldn&#39;t ship via OSS submodule: <code>ChallengePayloadStack</code> (ADR-008 Phase 3) provides an S3 + GitHub OIDC route where a private &quot;answer&quot; repo can publish per-problem zips and the deploy-handler fetches them via presigned URL. It&#39;s available but currently no repo binds the secret.</p>
+<h2>Data isolation</h2>
+<p>There is <strong>no</strong> single-table DDB design in this repo. Each stack owns its own tables (TenantMappingTable / Deployments / Apps / CompetitorAccounts / Events / Teams / Disruptions / etc), and tenant isolation is enforced via either the <code>TenantId</code> partition key or by stack separation.</p>
+<p>Every DDB table is forced to PROVISIONED 1 RCU / 1 WCU by a CDK Aspect (<a href="../../infrastructure/lib/cdk-aspect/dynamodb-low-capacity.ts"><code>DynamoDbLowCapacity</code></a>) so the whole platform stays inside the AWS Free Tier 25 RCU/WCU budget. PAY_PER_REQUEST is explicitly forbidden — the Aspect will quietly override it.</p>
+<h2>What&#39;s intentionally NOT in this overview</h2>
+<ul>
+<li><strong>Specific scoring kinds</strong> — see <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> and the catalog repo&#39;s <code>SCHEMA.json</code>.</li>
+<li><strong>Auth model details</strong> — see <a href="./adr-020-authorization-model.html">ADR-020</a>.</li>
+<li><strong>Per-tenant pipeline mechanics</strong> — see <a href="./adr-018-pooled-userpool-saml-isolation.html">ADR-018</a> + <code>serverless-saas-pipeline.ts</code>.</li>
+<li><strong>TrustBridge enforcement details</strong> — see <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a>.</li>
+<li><strong>Disruption phase 2 (condition-triggered)</strong> — see <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a>.</li>
+</ul>
+<p>All ADRs live alongside this file under <code>docs/architecture/adr-*.html</code>.</p>
+
+<div class="doc-source">Source: <code>docs/architecture/OVERVIEW.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/architecture/OVERVIEW.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,0 +1,123 @@
+# TenkaCloud Architecture Overview
+
+> 10-minute read for first-time contributors. For the "what to do" perspective, jump to [CONTRIBUTOR_MAP.md](../../CONTRIBUTOR_MAP.md). For module-level "where is X" lookups, see [MODULE_MAP.md](./MODULE_MAP.md). For term definitions with ADR back-links, see [GLOSSARY.md](./GLOSSARY.md). Decisions and their rationales live in [`adr-*.html`](.) — this document does **not** duplicate ADR content.
+
+TenkaCloud is a multi-tenant SaaS cloud-competition platform on AWS. Operators ("organizers") run events. Each event hosts teams of competitors who deploy AWS CFn stacks into their own AWS accounts under controlled supervision, and earn points based on the resulting state (flag submission, endpoint uptime, attack detection, etc).
+
+## The two deploy modes
+
+The codebase ships **two** deploy entry points. They share the same Lambdas and 5 problem-scoring kinds. They differ in how many tenants they support and how much SBT machinery they bring up.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│   make deploy        →     Lite mode                                         │
+│   (default)               • single tenantId="local"                          │
+│                           • 2 stacks: AppPlaneCore + ProblemDeployBackend    │
+│                           • ~10 min boot                                     │
+│                           • use case: 1 organizer, 1 event, fastest path     │
+│                                                                              │
+│   make deploy-saas   →     SaaS mode                                         │
+│                           • SBT ControlPlane (pooled + silo tiers)           │
+│                           • 5+ stacks (control plane, bootstrap, tenant      │
+│                             template, pipeline, problem-deploy, admin UIs)   │
+│                           • 3-phase install (control plane → admin UI →      │
+│                             callback wiring)                                 │
+│                           • use case: multi-organizer SaaS                   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Same code, two entry points. Lite mode is the **default** because most events are one-organizer / one-event. SaaS mode kicks in when an organizer wants tier-based pooled vs siloed tenant isolation. The Lite vs SaaS choice is hidden behind `make deploy` vs `make deploy-saas`; everything downstream of "a tenant exists" is identical.
+
+## The four planes
+
+Once the platform is up, runtime traffic flows across four planes that talk through an EventBridge bus.
+
+```
+┌──────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Control Plane                       │    │  Application Plane               │
+│  • SBT ControlPlane construct        │    │  • per-tenant Cognito + API + UI │
+│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/STANDARD/       │
+│  • Tenant CRUD HTTP API              │    │    PREMIUM tiers) or silo        │
+│  • admin-console UI                  │    │    (PLATINUM tier)               │
+│  • EventBridge bus owner             │    │  • application-admin-console UI  │
+└────────────────┬─────────────────────┘    └────────────────┬─────────────────┘
+                 │                                            │
+                 │              EventBridge bus               │
+                 │ ◄────────────────────────────────────────► │
+                 │     (onboardingRequest, DeployRequested,   │
+                 │      DeployCompleted, ScoreUpdated, …)     │
+                 │                                            │
+┌────────────────┴─────────────────────┐    ┌────────────────┴─────────────────┐
+│  Problem Deploy Backend              │    │  Participant Portal              │
+│  • Deployments DDB + Worker Lambda   │    │  • per-team UI                   │
+│  • AssumeRole into competitor AWS    │    │  • flag submission / endpoints   │
+│  • CFn CreateStack per team          │    │  • Console SSO one-click login   │
+│  • generic scoring dispatcher        │    │    (federation → AssumeRole)     │
+│  • Step Functions for retry / delete │    │  • disruption display            │
+└──────────────────────────────────────┘    └──────────────────────────────────┘
+```
+
+- **Control Plane** is the *tenant manager*. It does NOT host tenant runtime (= [`INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`](./harness.md)). It only knows "tenant X exists, tier=Y".
+- **Application Plane** is the per-tenant runtime. Pooled tiers share one CDK stack, PLATINUM gets its own stack via the per-tenant pipeline.
+- **Problem Deploy Backend** is the dangerous bit: it AssumeRoles into competitors' AWS accounts and runs CFn there. Every AssumeRole call requires `ExternalId` ([no exception, ever](../../infrastructure/templates/competitor-bootstrap.yaml)).
+- **Participant Portal** is the public-facing per-team app. Competitors log in with a team key (no AWS account required from them) and click through to AWS Console via the federation flow in `sso.ts`.
+
+These four planes are not microservices in the cloud-native sense — they're CDK stack boundaries within a single AWS account. The point of the separation is **deployment + IAM isolation**, not network isolation.
+
+## TrustBridge: why one extra hop exists
+
+When a deploy is requested, it crosses the most dangerous IAM boundary in the system: the platform's AWS account (where Lambdas run) → the **competitor's** AWS account (where the actual problem stack gets created). To make this auditable and to give the operator a "veto" point before the action runs, every deploy goes through **TrustBridge** (ADR-017).
+
+```
+Operator clicks "Deploy"
+       │
+       ▼
+deploy-handler Lambda emits a CloudActionIntent (shadow audit)
+       │
+       ▼
+TrustBridge logs the intent BEFORE AssumeRole happens
+       │
+       ▼
+Worker Lambda AssumeRoles into competitor account using tenant's ExternalId
+       │
+       ▼
+CFn CreateStack runs inside the competitor account with that problem's template
+```
+
+TrustBridge is currently in *shadow* mode: it emits structured audit logs without blocking. Phase 2/3 plans (ADR-017) flip it to enforcement, where high-risk actions require operator confirmation. The shadow mode is intentional — it lets us collect baseline data before adding friction.
+
+## Problems = plugins
+
+Problem templates do not live in this repo. They live in [TenkaCloudChallenge](https://github.com/susumutomita/TenkaCloudChallenge), mounted as a Git submodule at `problems/`. The platform side is a generic *host* that knows how to deploy a CFn template, poll endpoints for uptime, count attacks, etc; the catalog repo brings the actual content (ADR-012).
+
+```
+[TenkaCloudChallenge repo]                    [This (platform) repo]
+problems/                                     problems/                          ← git submodule pointer
+  battles/<id>/                               infrastructure/lib/problem-deploy/ ← the generic host
+    metadata.json    ← scoring + UI wiring      handlers/deploy-handler/         ← deploy chain
+    template.yaml    ← CFn payload              handlers/generic-scoring-handler/← 5 builtin kinds
+    portal/<slot>.tsx← optional UI slot         handlers/participant-handler/    ← portal API
+    services/...     ← optional payload code
+```
+
+A new problem = a PR to the catalog repo + a `git submodule update --remote problems` bump here. No platform Lambda code changes. The host validates the metadata against `SCHEMA.json` (= source of truth for the contract between platform and catalog), then dispatches scoring based on `scoring.kind`.
+
+There's a second, dormant path for content that shouldn't ship via OSS submodule: `ChallengePayloadStack` (ADR-008 Phase 3) provides an S3 + GitHub OIDC route where a private "answer" repo can publish per-problem zips and the deploy-handler fetches them via presigned URL. It's available but currently no repo binds the secret.
+
+## Data isolation
+
+There is **no** single-table DDB design in this repo. Each stack owns its own tables (TenantMappingTable / Deployments / Apps / CompetitorAccounts / Events / Teams / Disruptions / etc), and tenant isolation is enforced via either the `TenantId` partition key or by stack separation.
+
+Every DDB table is forced to PROVISIONED 1 RCU / 1 WCU by a CDK Aspect ([`DynamoDbLowCapacity`](../../infrastructure/lib/cdk-aspect/dynamodb-low-capacity.ts)) so the whole platform stays inside the AWS Free Tier 25 RCU/WCU budget. PAY_PER_REQUEST is explicitly forbidden — the Aspect will quietly override it.
+
+## What's intentionally NOT in this overview
+
+- **Specific scoring kinds** — see [ADR-012](./adr-012-problem-plugin-architecture.html) and the catalog repo's `SCHEMA.json`.
+- **Auth model details** — see [ADR-020](./adr-020-authorization-model.html).
+- **Per-tenant pipeline mechanics** — see [ADR-018](./adr-018-pooled-userpool-saml-isolation.html) + `serverless-saas-pipeline.ts`.
+- **TrustBridge enforcement details** — see [ADR-017](./adr-017-cloud-action-intent-trust-bridge.html).
+- **Disruption phase 2 (condition-triggered)** — see [ADR-013](./adr-013-disruption-phase2-condition-triggered.html).
+
+All ADRs live alongside this file under `docs/architecture/adr-*.html`.


### PR DESCRIPTION
Closes #1183.

## Summary

Adds 4 documents targeting first-time contributors so the architecture can be understood in **under 15 minutes**, satisfying #1183's acceptance criteria.

| File | Purpose |
| ---- | ------- |
| `docs/architecture/OVERVIEW.md` | 10-min architectural narrative. The two deploy modes (Lite vs SaaS), the four planes (Control / Application / Problem Deploy / Participant Portal), TrustBridge's "why one extra hop", and the problems-as-plugins model. Back-links to ADRs for rationale (= does **not** duplicate ADR content, per #1183 notes). |
| `docs/architecture/MODULE_MAP.md` | "Where is X" directory map. `apps/`, `infrastructure/lib/` (stack-level entries + Lambda handlers + CDK Aspects + app composition), `scripts/`, `packages/`, `problems/` submodule, `docs/`, build/CI. |
| `docs/architecture/GLOSSARY.md` | Definitions of recurring terms (AppPlane, ControlPlane, TrustBridge, ParticipantViewerRole, ChallengePayloadStack, source.zip, scoring kind, Lite/SaaS, Pooled/Silo, etc) with code locations and ADR back-links. |
| `CONTRIBUTOR_MAP.md` | Task-oriented navigation. Each section starts with a concrete goal ("I want to add a new problem", "I want to fix a Lambda bug", etc) and lists what to read, what to edit, and which gates to clear. Includes a "common surprises" table for gotchas. |

Plus wiring updates so people actually find these docs:

- `README.md` "Architecture" section: lists the 4 new docs above the ADR list, framed as "for first-time contributors".
- `CONTRIBUTING.md`: new "Where to start (under 15 minutes)" section placed before the development flow.

HTML mirrors of `OVERVIEW`, `MODULE_MAP`, and `GLOSSARY` are also committed (= `make build-docs` outputs) so the rendered docs site stays in sync. `CONTRIBUTOR_MAP.md` stays Markdown-only since it lives at the repo root for fastest discovery on GitHub.

## Why now

This PR ships immediately after the platform's largest recent structural changes (catalog physical split into TenkaCloudChallenge submodule, ChallengePayloadStack added). Documenting now is much higher-value than waiting — the model is fresh and not yet drifting.

## Regression analysis

- Pure docs PR. No code, no Lambdas, no CDK.
- `make harness` no findings.
- `make before-commit` passes (textlint auto-fix flipped a few "git" → "Git" in the new docs; `make build-docs` regenerated the HTML mirrors).
- README + CONTRIBUTING changes are additive — no existing sections deleted, only links added.
- No invariant changes. No ADR additions (= the issue explicitly asks to avoid ADR duplication; these 4 docs are *navigation aids*, not decisions).

## Physical impact

| Resource | Change |
| --- | --- |
| `docs/architecture/OVERVIEW.{md,html}` | **CREATE** |
| `docs/architecture/MODULE_MAP.{md,html}` | **CREATE** |
| `docs/architecture/GLOSSARY.{md,html}` | **CREATE** |
| `CONTRIBUTOR_MAP.md` (repo root) | **CREATE** |
| `README.md` | **UPDATE** (+5 lines of cross-links in the Architecture section) |
| `CONTRIBUTING.md` | **UPDATE** (+8 lines for "Where to start") |
| Deployed CFn stacks | **NO-OP** |
| AWS resources | **NO-OP** |
| `infrastructure/` `apps/` `scripts/` | **NO-OP** |

## Test plan

- [x] `make harness` — no findings
- [x] `make before-commit` — passes (lint / textlint / vitest / validate-problems / template checks / audit-deps / cdk synth)
- [ ] Manual smoke: walk a non-maintainer through OVERVIEW + GLOSSARY + CONTRIBUTOR_MAP and verify they can answer:
  1. What's the difference between Lite and SaaS?
  2. What does TrustBridge do?
  3. Where do I add a new problem?
  4. What does ParticipantViewerRole guard against?

  Target: 10-15 minutes total per #1183 acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)