### PR TITLE
refactor(sso): pin AWS Console destination to home

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts
@@ -38,32 +38,16 @@ const NAME_PREFIX_RE = /^[a-z][a-z0-9-]{0,127}$/;
 const IAM_ROLE_ARN_RE = /^arn:aws:iam::\d{12}:role\/[A-Za-z0-9+=,.@_/-]+$/;
 
 /**
- * Issue #946: AWS Console federation destination として SSM Parameter detail を埋めるとき、
- * Parameter 名は URL に直接挿入される (= `/systems-manager/parameters/<urlencoded>/description`)。
- * 攻撃者が namePrefix を改竄して `#`/`?`/`/` 等の特殊文字を入れることで Destination を曲げる
- * 経路を塞ぐため、 strict pattern を再 validate する (= 先頭 `/` 必須 + 英数 / `.` / `_` / `-` / `/` のみ)。
- */
-const SSM_PARAM_NAME_RE = /^\/[A-Za-z0-9._\-/]{1,1023}$/;
-
-/**
- * Issue #946: stack outputs から destination を決定する pure function (= testable に切り出し)。
+ * AWS Console の federation destination は home 画面に固定する。 SSM / CFn の deep link は
+ * サービス固有の list view を経由して `Describe*` を要求するため、 JAM/GameDay baseline IAM
+ * (PR-933 / ADR-021) と相性が悪い。 home から競技者自身が必要なサービスへ遷移する方が
+ * fail-safe (= 問題側の IAM スコープに依らない)。
  *
- * - `ssmParameterName` が strict regex に合致するなら SSM Parameter detail URL (= list view を
- *   経由しないため `ssm:DescribeParameters` 不要)
- * - そうでなければ CFn stacks 画面 (= multi-resource 問題で Resources tab から辿る前提)
- *
- * caller は `region` / `namePrefix` を事前 validate 済 (= URL injection 防御済) で渡す責務を負う。
+ * caller は `region` を事前 validate 済 (= URL injection 防御済) で渡す責務を負う。
  */
-export function buildConsoleDestination(args: {
-  readonly region: string;
-  readonly namePrefix: string;
-  readonly ssmParameterName: string | undefined;
-}): string {
-  const { region, namePrefix, ssmParameterName } = args;
-  if (ssmParameterName && SSM_PARAM_NAME_RE.test(ssmParameterName)) {
-    return `https://${region}.console.aws.amazon.com/systems-manager/parameters/${encodeURIComponent(ssmParameterName)}/description?region=${encodeURIComponent(region)}`;
-  }
-  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(region)}#/stacks?filteringText=${encodeURIComponent(namePrefix)}`;
+export function buildConsoleDestination(args: { readonly region: string }): string {
+  const { region } = args;
+  return `https://${region}.console.aws.amazon.com/console/home?region=${encodeURIComponent(region)}`;
 }
 
 const sts = new STSClient({});
@@ -120,16 +104,7 @@ export async function getConsoleSigninUrl(
   const signinToken = await fetchSigninToken(jobId, credentials);
   if (typeof signinToken !== "string") return signinToken;
 
-  // Issue #946: stack outputs に `ParameterName` があれば SSM Parameter detail page に直接遷移
-  // させる (= AWS Console SSM Parameter Store の list view を経由しないため
-  // ssm:DescribeParameters 不要、 JAM/GameDay baseline IAM (PR-933 / ADR-021) と整合)。
-  // それ以外は従来通り CFn stacks 画面 (= multi-resource 問題で Resources tab 経由)。
-  const ssmParameterNameRaw = ready.parsedOutputs.ParameterName;
-  const destination = buildConsoleDestination({
-    region: ready.region,
-    namePrefix: ready.namePrefix,
-    ssmParameterName: typeof ssmParameterNameRaw === "string" ? ssmParameterNameRaw : undefined,
-  });
+  const destination = buildConsoleDestination({ region: ready.region });
   const loginUrl = `${FEDERATION_ENDPOINT}?Action=login&Issuer=${encodeURIComponent(TENKACLOUD_ISSUER)}&Destination=${encodeURIComponent(destination)}&SigninToken=${encodeURIComponent(signinToken)}`;
 
   // Issue #1003: AWS Console "400 Bad Request" を発見した時の診断補助。 loginUrl は

--- a/infrastructure/test/problem-deploy/participant-sso.test.ts
+++ b/infrastructure/test/problem-deploy/participant-sso.test.ts
@@ -188,9 +188,12 @@ describe("getConsoleSigninUrl", () => {
     expect(result.loginUrl).toContain("https://signin.aws.amazon.com/federation");
     expect(result.loginUrl).toContain("Action=login");
     expect(result.loginUrl).toContain("SigninToken=SIGNIN_TOKEN_VALUE");
-    expect(result.loginUrl).toContain("cloudformation");
-    // 競技者の namePrefix で stacks フィルタを掛ける
-    expect(result.loginUrl).toContain(encodeURIComponent("tc-security-battle-royale-alpha"));
+    // destination は問題のデプロイリージョン (= ready.region) の AWS Console home に固定
+    expect(result.loginUrl).toContain(
+      encodeURIComponent(
+        "https://ap-northeast-1.console.aws.amazon.com/console/home?region=ap-northeast-1",
+      ),
+    );
 
     // #747: getSigninToken request URL に SessionDuration param が含まれてはいけない
     // (AssumeRole 由来 credentials では federation endpoint が 400 を返すため)。

--- a/infrastructure/test/problem-deploy/sso-console-destination.test.ts
+++ b/infrastructure/test/problem-deploy/sso-console-destination.test.ts
@@ -2,99 +2,28 @@ import { describe, expect, it } from "vitest";
 import { buildConsoleDestination } from "../../lib/problem-deploy/handlers/participant-handler/sso";
 
 /**
- * Issue #946: AWS Console federation destination の選択ロジックを pin する。
- *
- * 旧挙動: 常に CFn stacks 画面 (= 全 stack list を namePrefix で filter) を destination にしていた。
- * その後 user が SSM Parameter Store サイドバーをクリックすると list view 経由で `ssm:DescribeParameters`
- * AccessDenied になる経路があった (= JAM/GameDay baseline IAM では list 権限を与えない、 PR-933)。
- *
- * 新挙動: stack outputs に `ParameterName` (= SSM Parameter のフルパス) があれば SSM Parameter detail
- * page に直接遷移させる (= list view を経由しないので IAM 不変で動く)。
+ * AWS Console federation destination は home に固定する (= サービス固有 deep link を避け、
+ * 問題側 IAM スコープに依らない fail-safe な遷移先にする)。 SSM/CFn deep link 経路は
+ * Issue #946 でいったん導入したが、 home に倒すことで list view 起因の AccessDenied 経路を
+ * 根本的に塞ぐ。
  */
 
-const REGION = "ap-northeast-1";
-const NAME_PREFIX = "tc-hello-world-team-3";
-
-describe("buildConsoleDestination (#946)", () => {
-  it("should return the CFn stacks screen when ssmParameterName is unspecified (legacy behavior / multi-resource problems)", () => {
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: undefined,
-    });
+describe("buildConsoleDestination", () => {
+  it("should return the AWS Console home URL for the given region", () => {
+    const url = buildConsoleDestination({ region: "ap-northeast-1" });
     expect(url).toBe(
-      "https://ap-northeast-1.console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks?filteringText=tc-hello-world-team-3",
+      "https://ap-northeast-1.console.aws.amazon.com/console/home?region=ap-northeast-1",
     );
   });
 
-  it("should return the SSM Parameter detail URL when ssmParameterName is valid (deep link, no list view)", () => {
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: "/tc-hello-world-team-3/hello",
-    });
-    expect(url).toBe(
-      "https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/%2Ftc-hello-world-team-3%2Fhello/description?region=ap-northeast-1",
-    );
+  it("should encode the region in the query string (defense-in-depth)", () => {
+    const url = buildConsoleDestination({ region: "us-east-1" });
+    expect(url).toBe("https://us-east-1.console.aws.amazon.com/console/home?region=us-east-1");
   });
 
-  it("should fall back to CFn when ssmParameterName contains disallowed characters (`#` / `?`) (URL injection guard)", () => {
-    const malicious = "/tc#injection?query";
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: malicious,
-    });
-    // CFn 画面 (= fallback)
-    expect(url).toContain("/cloudformation/home");
-    expect(url).not.toContain(encodeURIComponent(malicious));
-  });
-
-  it("should fall back to CFn when ssmParameterName does not start with `/`", () => {
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: "no-leading-slash",
-    });
-    expect(url).toContain("/cloudformation/home");
-  });
-
-  it("should fall back to CFn when ssmParameterName is empty", () => {
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: "",
-    });
-    expect(url).toContain("/cloudformation/home");
-  });
-
-  it("path 内に `.` / `_` / `-` は許容 (= IAM Parameter naming に合う)", () => {
-    const valid = "/tc-x_y.z/sub-key";
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: valid,
-    });
-    expect(url).toContain("/systems-manager/parameters/");
-    expect(url).toContain(encodeURIComponent(valid));
-  });
-
-  it("region は URL-encode される (= defense-in-depth、 region は事前 RE validate 済の前提)", () => {
-    const url = buildConsoleDestination({
-      region: "us-east-1",
-      namePrefix: "x",
-      ssmParameterName: undefined,
-    });
-    expect(url).toContain("region=us-east-1");
-  });
-
-  it("ssmParameterName が 1023 文字を超えるなら CFn fallback (= URL 長制限の defensive)", () => {
-    const tooLong = `/${"a".repeat(1024)}`;
-    const url = buildConsoleDestination({
-      region: REGION,
-      namePrefix: NAME_PREFIX,
-      ssmParameterName: tooLong,
-    });
-    expect(url).toContain("/cloudformation/home");
+  it("should never reference service-specific consoles (SSM / CFn)", () => {
+    const url = buildConsoleDestination({ region: "ap-northeast-1" });
+    expect(url).not.toContain("/systems-manager/");
+    expect(url).not.toContain("/cloudformation/");
   });
 });


### PR DESCRIPTION
## Summary

- 競技者 portal の **SSO Credentials** ボタンから開く AWS Console federation destination を SSM Parameter detail / CFn stacks 画面の deep link ではなく **console home** に固定 (`https://${region}.console.aws.amazon.com/console/home?region=${region}`)
- region は deploy 時に validate 済の `ready.region` を継続使用 → 東京デプロイ問題は `ap-northeast-1.console.aws.amazon.com/console/home` が開く
- 不要になった `SSM_PARAM_NAME_RE` regex と SSM/CFn 分岐ロジックを削除し、 `buildConsoleDestination` を `region` だけ受け取る pure function に簡素化

## Why

サービス固有 deep link は SSM list view 等を経由するため `Describe*` を要求し、 JAM/GameDay baseline IAM (PR-933 / ADR-021) と相性が悪く AccessDenied になる経路があった (Issue #946 で SSM deep link 対応を入れたが、 home 固定の方が問題側 IAM スコープに依らず fail-safe)。 home から競技者がサイドバー経由で必要なサービスへ遷移する運用に統一する。

## Test plan

- [x] `make before-commit` (lint / typecheck / test / build / validate-problems)
- [x] `bun run test test/problem-deploy/participant-sso.test.ts test/problem-deploy/sso-console-destination.test.ts` (27 passed)
- [ ] 手動: 競技者ポータルで SSO Credentials ボタン → AWS Console home が開く + region クエリが deploy region と一致する

## Regression analysis

- caller の `getConsoleSigninUrl` は `buildConsoleDestination` への引数を `region` のみに簡素化。 ほかに `buildConsoleDestination` を呼ぶ箇所は無し
- federation `Action=login` URL の `Destination` query param が変わるだけ。 SigninToken / 2-stage AssumeRole / `ExternalId` の流れは無変更 → 認証経路は影響なし
- 旧 deep link (SSM Parameter detail / CFn stacks) を利用していた問題は home からサイドバー経由で代替可能。 ParticipantViewerRole の IAM スコープ自体は無変更なので、 home → SSM / CFn の遷移は従来どおり機能する
- Issue #946 で導入した SSM `ParameterName` stack output の生成側 (`tc-hello-world` 等) には触っていない → 競技者向け catalog の `outputs` 表示でリンクされる経路は維持

## Physical impact

- **NO-OP infra**: CDK stack / IAM / DDB に変化なし
- **UPDATE**: `ProblemDeployBackendStack` の Lambda handler bundle (sso handler)
- ParticipantViewerRole / CompetitorDeployRole は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)