### PR TITLE
refactor(participant-portal): collapse deploy terminal, suppress auto-delete info

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -78,7 +78,7 @@ describe("ProblemPanel deploy terminal", () => {
       ),
     );
 
-    expect(screen.getByLabelText(/Deployment terminal|デプロイ terminal/)).toBeInTheDocument();
+    expect(screen.getByText(/Deployment terminal|デプロイ terminal/)).toBeInTheDocument();
     expect(screen.getByText("Deployment job was queued.")).toBeInTheDocument();
     expect(screen.getByText("CloudFormation stack creation is in progress.")).toBeInTheDocument();
   });

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -1,6 +1,7 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
+import ExpandableSection from "@cloudscape-design/components/expandable-section";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
@@ -71,19 +72,14 @@ function useNowMs(intervalMs: number): number {
 
 function describeRemainingUntilAutoDelete(t: ProblemPanelT, diffMs: number): string {
   const totalMinutes = Math.max(1, Math.ceil(diffMs / 60_000));
-  if (totalMinutes < 60) {
-    return t("problem_panel.auto_delete_remaining_minutes", { minutes: totalMinutes });
-  }
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return t("problem_panel.auto_delete_remaining_hours", { hours, minutes });
+  return t("problem_panel.auto_delete_remaining_minutes", { minutes: totalMinutes });
 }
 
 function buildAutoDeleteNotice(
   t: ProblemPanelT,
   expiresAt: number,
   nowMs: number,
-): { readonly type: "info" | "warning"; readonly body: string } | undefined {
+): { readonly type: "warning"; readonly body: string } | undefined {
   if (!Number.isFinite(expiresAt) || expiresAt <= 0) return undefined;
   const expiresAtMs = expiresAt * 1000;
   const expiresAtLabel = new Date(expiresAtMs).toLocaleString();
@@ -94,17 +90,14 @@ function buildAutoDeleteNotice(
       body: t("problem_panel.auto_delete_expired_body", { expiresAt: expiresAtLabel }),
     };
   }
-  const remaining = describeRemainingUntilAutoDelete(t, diffMs);
   if (diffMs <= AUTO_DELETE_SOON_THRESHOLD_MS) {
+    const remaining = describeRemainingUntilAutoDelete(t, diffMs);
     return {
       type: "warning",
       body: t("problem_panel.auto_delete_soon_body", { remaining, expiresAt: expiresAtLabel }),
     };
   }
-  return {
-    type: "info",
-    body: t("problem_panel.auto_delete_body", { remaining, expiresAt: expiresAtLabel }),
-  };
+  return undefined;
 }
 
 function useLiveDeployLog({
@@ -197,7 +190,7 @@ function ProblemPanelAlerts({
 }: {
   problem: ParticipantProblemView;
   isStale: boolean;
-  autoDeleteNotice?: { readonly type: "info" | "warning"; readonly body: string };
+  autoDeleteNotice?: { readonly type: "warning"; readonly body: string };
   now: number;
   t: ProblemPanelT;
 }) {
@@ -288,6 +281,7 @@ export function ProblemPanel({
           <DeployTerminal
             entries={displayedDeployLog.entries}
             title={t("problem_panel.deploy_log_header")}
+            defaultExpanded={!TERMINAL_STATUSES.has(problem.status)}
           />
         )}
 
@@ -358,16 +352,16 @@ function classifyCodeBuildLog(message: string): DeploymentLogEntry["level"] {
 function DeployTerminal({
   entries,
   title,
+  defaultExpanded,
 }: {
   entries: readonly DeploymentLogEntry[];
   title: string;
+  defaultExpanded: boolean;
 }) {
   return (
-    <section aria-label={title}>
-      <Box variant="h3">{title}</Box>
+    <ExpandableSection headerText={title} defaultExpanded={defaultExpanded}>
       <div
         style={{
-          marginTop: 8,
           maxHeight: 240,
           overflowY: "auto",
           borderRadius: 6,
@@ -388,7 +382,7 @@ function DeployTerminal({
           </div>
         ))}
       </div>
-    </section>
+    </ExpandableSection>
   );
 }
 

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -243,8 +243,6 @@
     "stale_body": "{ago} since last scoring. Something in your service may not be responding as expected.",
     "auto_delete_header": "Auto-delete scheduled",
     "auto_delete_remaining_minutes": "{minutes} min",
-    "auto_delete_remaining_hours": "{hours} h {minutes} min",
-    "auto_delete_body": "This sandbox is scheduled for automatic deletion in about {remaining} ({expiresAt}).",
     "auto_delete_soon_body": "Automatic deletion is approaching: about {remaining} remaining ({expiresAt}). Save anything you still need before teardown starts.",
     "auto_delete_expired_body": "The automatic deletion time has passed ({expiresAt}). Teardown may already be running or queued.",
     "current_score_label": "Current score",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -243,8 +243,6 @@
     "stale_body": "直近の採点から {ago} 経過。 サービスのどこかが期待通り応答していない可能性があります。",
     "auto_delete_header": "自動削除予定",
     "auto_delete_remaining_minutes": "{minutes} 分",
-    "auto_delete_remaining_hours": "{hours} 時間 {minutes} 分",
-    "auto_delete_body": "この sandbox は約 {remaining} 後に自動削除される予定です ({expiresAt})。",
     "auto_delete_soon_body": "自動削除が近づいています。残り約 {remaining} です ({expiresAt})。teardown 開始前に必要な内容を退避してください。",
     "auto_delete_expired_body": "自動削除予定時刻を過ぎています ({expiresAt})。teardown が既に実行中または待機中の可能性があります。",
     "current_score_label": "現在の score",


### PR DESCRIPTION
## Summary

- 競技者画面の **デプロイ terminal** を Cloudscape `ExpandableSection` で折りたためるようにする。 進行中 (PENDING / IN_PROGRESS) のみ default 展開、 終了 (COMPLETE / FAILED) は default 折りたたみで score / outputs に視線を集中
- **自動削除予定 (info アラート)** の表示を抑制。 残り 15 分以下の "soon" warning と 既に過ぎている "expired" warning は事故防止のため引き続き表示
- 不要になった i18n key (`auto_delete_body`, `auto_delete_remaining_hours`) と `describeRemainingUntilAutoDelete` の hours 分岐を削除

## Why

- デプロイ完了後の terminal は最終 4 行 (queued → started → completed) で固定されており、 競技者の操作対象ではない (= noise)。 必要なら開ける状態にしておけば十分
- "約 167 時間 後に自動削除" のような長期 info はほぼ恒常表示になり、 hello-world のような短時間問題では特に冗長。 切迫した警告 (15 min 以下 / 期限切れ) のみに絞る方が信号として強い

## Test plan

- [x] `make before-commit` (lint / typecheck / test / build / validate-problems)
- [x] `bun run --filter @TenkaCloud/participant-portal test` (8 passed)
- [ ] 手動: IN_PROGRESS 中は terminal が展開、 COMPLETE 後は折りたたまれ、 ヘッダクリックで開閉できる
- [ ] 手動: 期限まで >15 min は info アラート無し、 <=15 min で warning が出る

## Regression analysis

- `useNowMs` / `now` は `isStaleProblem` と `describeAgo` で引き続き使用 → setInterval は維持
- 既存テスト "should display the remaining time until auto-delete based on expiresAt" は 14 分残 (soon 経路) で warning を出す前提なので継続パス
- DeployTerminal の外側 `<section aria-label>` を削除したのは ExpandableSection header と aria 名が重複していたため (= `getByLabelText` で多重ヒットしていた)。 アクセス名は ExpandableSection の header text 経由で引き続き取得可能
- 削除した i18n key は他箇所で参照されていないことを grep で確認済

## Physical impact

- **NO-OP infra**: CDK / IAM / DDB に変更なし
- **UPDATE**: `apps/participant-portal/dist/` bundle (= ProblemPanel コード + ja/en locale JSON)
- 競技者向け UI のみが変化、 API / 認証 / scoring は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)