### PR TITLE
feat(participant-portal): allow changing team name after initial setup

### DIFF
--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -88,6 +88,38 @@ function buildScoreRankUtility(
   };
 }
 
+/**
+ * Issue #1191: profile dropdown のメニュー項目を再利用可能な pure function で組む
+ * (= unit test で項目構成を pin)。 競技者は「チーム名を変更」「サインアウト」の 2 つを
+ * 選べる。
+ */
+export function buildProfileMenuItems(
+  t: Translate,
+): readonly { readonly id: string; readonly text: string }[] {
+  return [
+    { id: "change_team_name", text: t("nav.change_team_name") },
+    { id: "logout", text: t("nav.sign_out") },
+  ];
+}
+
+/**
+ * profile dropdown の item click handler。 `id` ごとに副作用を分岐する pure
+ * dispatcher (unit test 可能)。
+ */
+export function handleProfileMenuClick(
+  id: string,
+  deps: { readonly logout: () => void; readonly navigate: (href: string) => void },
+): void {
+  if (id === "change_team_name") {
+    deps.navigate("/setup");
+    return;
+  }
+  if (id === "logout") {
+    deps.logout();
+    deps.navigate("/login");
+  }
+}
+
 function buildProfileUtility(
   teamName: string,
   logout: () => void,
@@ -98,13 +130,8 @@ function buildProfileUtility(
     type: "menu-dropdown",
     text: teamName,
     iconName: "user-profile",
-    items: [{ id: "logout", text: t("nav.sign_out") }],
-    onItemClick: ({ detail }) => {
-      if (detail.id === "logout") {
-        logout();
-        navigate("/login");
-      }
-    },
+    items: buildProfileMenuItems(t),
+    onItemClick: ({ detail }) => handleProfileMenuClick(detail.id, { logout, navigate }),
   };
 }
 

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -25,6 +25,7 @@
     "scoreboard": "Scoreboard",
     "score_events": "Score events",
     "sso_credentials": "SSO Credentials",
+    "change_team_name": "Change team name",
     "sign_out": "Sign out"
   },
   "switcher": {
@@ -71,12 +72,16 @@
   "team_setup": {
     "title": "Choose your team name",
     "description": "Enter the name to call your team during this event",
+    "edit_title": "Change team name",
+    "edit_description": "Update the name shown on the scoreboard and your profile. Other members of your team will see the new name too.",
     "field_label": "Team name",
     "field_description": "Shown on your profile and the scoreboard. You can change it later.",
     "field_placeholder": "e.g. Our team",
     "field_constraint": "1–40 chars, alphanumeric / space / _ / - / Japanese",
     "field_invalid_format": "Invalid format",
     "submit_button": "Start with this name",
+    "edit_submit_button": "Save",
+    "cancel_button": "Cancel",
     "submit_failed_header": "Failed to save team name",
     "validation_failed": "Invalid team name format. Use 1–40 chars: alphanumeric, space, _, -, or Japanese characters only."
   },

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -25,6 +25,7 @@
     "scoreboard": "スコアボード",
     "score_events": "スコアイベント",
     "sso_credentials": "SSO 資格情報",
+    "change_team_name": "チーム名を変更",
     "sign_out": "サインアウト"
   },
   "switcher": {
@@ -71,12 +72,16 @@
   "team_setup": {
     "title": "チーム名を決めよう",
     "description": "このイベント中にあなたのチームを呼ぶ名前を入力してください",
+    "edit_title": "チーム名を変更",
+    "edit_description": "スコアボードやプロフィールに表示される名前を更新します。 チームメンバーの表示にも反映されます。",
     "field_label": "チーム名",
     "field_description": "プロフィールやスコアボードに表示される名前。 後から変更できます。",
     "field_placeholder": "例: わたしたちのチーム",
     "field_constraint": "1〜40 文字、 英数字 / 半角スペース / _ / - / 日本語",
     "field_invalid_format": "形式が無効です",
     "submit_button": "この名前で始める",
+    "edit_submit_button": "保存",
+    "cancel_button": "キャンセル",
     "submit_failed_header": "チーム名を保存できませんでした",
     "validation_failed": "チーム名の形式が無効です。 1〜40 文字、 英数字 / 半角スペース / _ / - / 日本語のみ。"
   },

--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -69,7 +69,10 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const t = useT();
   const { locale, setLocale } = useI18n();
-  const [teamName, setTeamName] = useState("");
+  // Issue #1191: 既に teamName を設定済の競技者が dropdown 経由でこのページを開く
+  // ケースが edit mode。 初期表示の入力欄に現在の名前を埋めておく + Cancel で `/` に戻る。
+  const isEditMode = auth.session?.teamNameSetByCompetitor === true;
+  const [teamName, setTeamName] = useState(isEditMode ? (auth.session?.teamName ?? "") : "");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -135,8 +138,11 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
       <Box padding="l" textAlign="center">
         <Container
           header={
-            <Header variant="h1" description={t("team_setup.description")}>
-              {t("team_setup.title")}
+            <Header
+              variant="h1"
+              description={t(isEditMode ? "team_setup.edit_description" : "team_setup.description")}
+            >
+              {t(isEditMode ? "team_setup.edit_title" : "team_setup.title")}
             </Header>
           }
         >
@@ -161,14 +167,21 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
                   invalid={draft.invalid}
                 />
               </FormField>
-              <Button
-                variant="primary"
-                loading={submitting}
-                disabled={!canSubmit}
-                onClick={handleSubmit}
-              >
-                {t("team_setup.submit_button")}
-              </Button>
+              <SpaceBetween size="xs" direction="horizontal">
+                <Button
+                  variant="primary"
+                  loading={submitting}
+                  disabled={!canSubmit}
+                  onClick={handleSubmit}
+                >
+                  {t(isEditMode ? "team_setup.edit_submit_button" : "team_setup.submit_button")}
+                </Button>
+                {isEditMode && (
+                  <Button variant="link" disabled={submitting} onClick={() => navigate("/")}>
+                    {t("team_setup.cancel_button")}
+                  </Button>
+                )}
+              </SpaceBetween>
             </SpaceBetween>
           </Form>
         </Container>

--- a/apps/participant-portal/test/components/AppLayout.test.ts
+++ b/apps/participant-portal/test/components/AppLayout.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { LeaderboardResponse, ParticipantTeamView } from "../../src/api/portal-client";
 import {
+  buildProfileMenuItems,
   formatTopNavRank,
   formatTopNavScore,
+  handleProfileMenuClick,
   isSupportedLocaleId,
 } from "../../src/components/AppLayout";
 
@@ -83,5 +85,39 @@ describe("AppLayout top navigation helpers", () => {
     expect(isSupportedLocaleId("ja")).toBe(true);
     expect(isSupportedLocaleId("en")).toBe(true);
     expect(isSupportedLocaleId("fr")).toBe(false);
+  });
+});
+
+describe("profile dropdown menu (Issue #1191)", () => {
+  it("should list change_team_name before logout so the destructive action is visually last", () => {
+    const items = buildProfileMenuItems((key) => `<${key}>`);
+    expect(items).toEqual([
+      { id: "change_team_name", text: "<nav.change_team_name>" },
+      { id: "logout", text: "<nav.sign_out>" },
+    ]);
+  });
+
+  it("should navigate to /setup when the change_team_name item is clicked", () => {
+    const logout = vi.fn();
+    const navigate = vi.fn();
+    handleProfileMenuClick("change_team_name", { logout, navigate });
+    expect(navigate).toHaveBeenCalledWith("/setup");
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it("should logout and navigate to /login when the logout item is clicked", () => {
+    const logout = vi.fn();
+    const navigate = vi.fn();
+    handleProfileMenuClick("logout", { logout, navigate });
+    expect(logout).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith("/login");
+  });
+
+  it("should ignore unknown menu item ids without side effects", () => {
+    const logout = vi.fn();
+    const navigate = vi.fn();
+    handleProfileMenuClick("does-not-exist", { logout, navigate });
+    expect(logout).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1191

Issue #1191 の Option B (= いつでも変更可能 + UI 露出) を実装。 競技者が初回設定後でも、 TopNavigation の profile dropdown から team name を編集できるようにする。

- TopNavigation の profile dropdown に **「チーム名を変更」** 項目を追加 (= サインアウトの上、 destructive を視覚的に末尾に置く)
- 既存 `TeamSetupPage` を **edit mode** 対応に拡張: 現在の team name を入力欄に prefill、 ヘッダ / 送信ボタン文言を edit_* に差し替え、 Cancel で `/` に戻る
- 初回設定フロー (`teamNameSetByCompetitor=false`) は文言 / Cancel ともに従来どおり (= 初回は cancel 不可、 default placeholder)

i18n:
- `nav.change_team_name` を ja / en に追加
- `team_setup.edit_title` / `edit_description` / `edit_submit_button` / `cancel_button` を ja / en に追加

副次的に、 既存 en.json の `team_setup.field_description: "You can change it later"` という UX promise が実装と一致するようになった (= 旧文言は dead promise だった)。

## Why

Issue #1191 の「team name 未設定で複数競技者がアクセスすると後勝ち」 問題に対し、 backend の overwrite 動作はそのままに、 **UI 露出で silent loss を防ぐ** 設計。 上書きされた競技者は dropdown 経由でいつでも再編集できるため、 race による silent loss が「team の合意で運用するだけ」 の状態に降格する。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / test / build / validate-problems all pass)
- [x] `bun run --filter @TenkaCloud/participant-portal test` (190 / 190 pass、 dropdown handler 用 unit test を追加済)
- [ ] 手動: 初回ログイン → TeamSetup でチーム名設定 → home に遷移
- [ ] 手動: 設定済セッションで TopNavigation team dropdown → 「チーム名を変更」 → 入力欄に現在名が prefill、 編集して保存で home に戻る
- [ ] 手動: 編集ページで Cancel → home に戻る (= 副作用なし)

## Regression analysis

- **backend は無変更**: `setDisplayTeamName` は既に overwrite 許容、 `PATCH /portal/me` の挙動も同じ。 Issue #1191 の「後勝ち」自体は仕様として受容 (UI 経由で再編集可能になったため silent loss にはならない)
- 初回設定フローは入力欄が `""` で始まる挙動を維持 (= `isEditMode` は `teamNameSetByCompetitor` 厳密 true で判定)。 既存 dev-mock モード (`teamNameSetByCompetitor=true` を初期セッションに入れている) では従来どおり `/setup` に到達しないので影響なし
- profile dropdown の click handler を pure dispatcher (`handleProfileMenuClick`) に切り出した。 既存 `id === "logout"` の挙動は完全に同等 → ログアウト動線に regression なし
- 新規 i18n key は 5 つ (ja / en どちらにも追加済)、 既存 key は無変更

## Physical impact

- **NO-OP infra**: CDK / IAM / DDB / Lambda に変更なし
- **UPDATE**: `apps/participant-portal/dist/` bundle のみ (AppLayout + TeamSetup + ja/en locale JSON)
- backend API surface は無変更 (`PATCH /portal/me` を引き続き利用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)