### PR TITLE
feat(scripts): add check-template-cli-access for ParticipantViewerRole managed policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export JSII_DEPRECATED := quiet
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
-        check-http-status check-template-ascii check-template-security check-template-cfn-refs \
+        check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-cli-access \
         env-check env-check-lite synth check-synth diff bootstrap \
         deploy deploy-saas deploy-control-plane deploy-bootstrap destroy destroy-saas \
         deploy-battles destroy-battles \
@@ -49,6 +49,13 @@ check-template-ascii: ; bun run scripts/check-template-ascii.ts
 check-template-security: ; bun run scripts/check-template-security.ts
 # Issue #951 sub-2: 問題 template.yaml の構造的整合性 (= !Ref / !GetAtt が declared resource を指す)
 check-template-cfn-refs: ; bun run scripts/check-template-cfn-refs.ts
+# ParticipantViewerRole に Console federation 後の CLI / CloudShell access に必要な
+# AWS managed policy (AWSSignInLocalDevelopmentAccess + AWSCloudShellFullAccess) が
+# attach されているか検証。 未 attach だと Console login は成功するのに CLI / CloudShell が
+# 静かに失敗するため、 問題作成者が同じ落とし穴を踏まないよう merge 前に弾く。
+# 現状は既存 5 テンプレが未対応なので standalone target のみ。 TenkaCloudChallenge 側で
+# templates を更新してから before-commit / check に組み込む (follow-up PR で wire)。
+check-template-cli-access: ; bun run scripts/check-template-cli-access.ts
 audit-deps:    ; bun run audit:dependencies
 # `check-problems-index` は submodule (= TenkaCloudChallenge) 側 catalog CI に責任を移譲した
 # ため、 本体 before-commit / check からは外す。 platform 側 build:problems-index を走らせると

--- a/infrastructure/test/scripts/check-template-cli-access.test.ts
+++ b/infrastructure/test/scripts/check-template-cli-access.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractParticipantViewerBlock,
+  findMissingRequiredPolicies,
+} from "../../../scripts/check-template-cli-access";
+
+/**
+ * `scripts/check-template-cli-access.ts` の挙動を pin する unit test。
+ *
+ * 公開 contract:
+ *   - `extractParticipantViewerBlock` は ParticipantViewerRole の properties block を
+ *     文字列で切り出す (= 次の top-level Resource / section に当たった所で打ち切る)
+ *   - `findMissingRequiredPolicies` は AWSSignInLocalDevelopmentAccess /
+ *     AWSCloudShellFullAccess のうち block 中に出現しないものを返す
+ */
+
+describe("extractParticipantViewerBlock", () => {
+  it("should return the ParticipantViewerRole properties block until the next top-level Resource", () => {
+    const yaml = [
+      "Resources:",
+      "  ParticipantViewerRole:",
+      "    Type: AWS::IAM::Role",
+      "    Properties:",
+      "      RoleName: foo",
+      "  OtherResource:",
+      "    Type: AWS::S3::Bucket",
+    ].join("\n");
+    const block = extractParticipantViewerBlock(yaml);
+    expect(block).toBeDefined();
+    expect(block).toContain("ParticipantViewerRole:");
+    expect(block).toContain("RoleName: foo");
+    expect(block).not.toContain("OtherResource");
+  });
+
+  it("should stop at the next top-level section (e.g. Outputs)", () => {
+    const yaml = [
+      "Resources:",
+      "  ParticipantViewerRole:",
+      "    Type: AWS::IAM::Role",
+      "    Properties:",
+      "      RoleName: foo",
+      "Outputs:",
+      "  Arn: !GetAtt ParticipantViewerRole.Arn",
+    ].join("\n");
+    const block = extractParticipantViewerBlock(yaml);
+    expect(block).toContain("RoleName: foo");
+    expect(block).not.toContain("Outputs:");
+  });
+
+  it("should return undefined when the role is missing", () => {
+    const yaml = "Resources:\n  OnlyOtherRole:\n    Type: AWS::IAM::Role\n";
+    expect(extractParticipantViewerBlock(yaml)).toBeUndefined();
+  });
+});
+
+describe("findMissingRequiredPolicies", () => {
+  it("should report both policies missing when block has no ManagedPolicyArns", () => {
+    const block = [
+      "  ParticipantViewerRole:",
+      "    Type: AWS::IAM::Role",
+      "    Properties:",
+      "      RoleName: foo",
+    ].join("\n");
+    const missing = findMissingRequiredPolicies(block);
+    expect(missing.map((m) => m.arnSuffix)).toEqual([
+      ":policy/AWSSignInLocalDevelopmentAccess",
+      ":policy/AWSCloudShellFullAccess",
+    ]);
+  });
+
+  it("should report only CloudShell missing when SignIn is attached but CloudShell is not", () => {
+    const block = [
+      "  ParticipantViewerRole:",
+      "    Properties:",
+      "      ManagedPolicyArns:",
+      "        - arn:aws:iam::aws:policy/AWSSignInLocalDevelopmentAccess",
+    ].join("\n");
+    const missing = findMissingRequiredPolicies(block);
+    expect(missing.map((m) => m.arnSuffix)).toEqual([":policy/AWSCloudShellFullAccess"]);
+  });
+
+  it("should report no missing when both policies are attached", () => {
+    const block = [
+      "  ParticipantViewerRole:",
+      "    Properties:",
+      "      ManagedPolicyArns:",
+      "        - arn:aws:iam::aws:policy/AWSSignInLocalDevelopmentAccess",
+      "        - arn:aws:iam::aws:policy/AWSCloudShellFullAccess",
+    ].join("\n");
+    expect(findMissingRequiredPolicies(block)).toEqual([]);
+  });
+
+  it("should accept !Sub style ARN strings (suffix-based matching)", () => {
+    const block = [
+      "  ParticipantViewerRole:",
+      "    Properties:",
+      "      ManagedPolicyArns:",
+      '        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSSignInLocalDevelopmentAccess"',
+      '        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSCloudShellFullAccess"',
+    ].join("\n");
+    expect(findMissingRequiredPolicies(block)).toEqual([]);
+  });
+});

--- a/scripts/check-template-cli-access.ts
+++ b/scripts/check-template-cli-access.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+/**
+ * 問題 template.yaml の `ParticipantViewerRole` が、 競技者が AWS Console から
+ * シームレスに環境を触るために必要な AWS managed policy を attach しているか
+ * 確認する。
+ *
+ * 必須 managed policy:
+ *   - `AWSSignInLocalDevelopmentAccess` — Console federation セッションを CLI
+ *      (`aws` コマンド) に持ち出すために必要。 これが無いと Console login は
+ *      成功するが、 ターミナルに切り替えた瞬間に静かに reject される
+ *   - `AWSCloudShellFullAccess` — Console 内 CloudShell の起動権限。 これが
+ *      無いと CloudShell タブで 「環境を作成できません」 エラーになる。
+ *      CloudShell は federated role 直下で動くため、 ここで attach すれば
+ *      CloudShell 内のコマンドは ParticipantViewerRole として実行される
+ *      (= 別途 sts:AssumeRole 不要)
+ *
+ * 背景: 競技者は AWS Console 画面では 「ログインできた」 と認識する一方で、
+ * CLI / CloudShell に切り替えた瞬間に静かに失敗するため、 切り分けが難しい。
+ * 問題作成側で template を書くたびに同じ落とし穴を踏むので、 platform 側で
+ * 機械チェックして 「これを attach してください」 と即フィードバックする。
+ *
+ * 出典:
+ *   https://docs.aws.amazon.com/signin/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-SignInLocalDevelopmentAccess
+ *   https://docs.aws.amazon.com/cloudshell/latest/userguide/sec-auth-with-identities.html
+ *
+ * 検出ルール:
+ *   - 全 problem template に対して `^  ParticipantViewerRole:` から次の
+ *     top-level Resource 宣言までを 1 block として切り出す
+ *   - block 内に literal ARN suffix
+ *     `:policy/AWSSignInLocalDevelopmentAccess` および
+ *     `:policy/AWSCloudShellFullAccess` の両方を含まなければ NG
+ *   - `!Sub "arn:...AWSCloudShellFullAccess"` 等の変則表記も
+ *     文字列レベルで拾えるよう、 suffix で許容する
+ *
+ * `make validate-problems` の後段で呼ぶ。 fail-fast (exit 1) で問題作成者の
+ * 早い段階で気付かせる。
+ */
+
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+
+interface RequiredPolicy {
+  readonly arnSuffix: string;
+  readonly purpose: string;
+  readonly docUrl: string;
+}
+
+const REQUIRED_POLICIES: readonly RequiredPolicy[] = [
+  {
+    arnSuffix: ":policy/AWSSignInLocalDevelopmentAccess",
+    purpose: "Console federation 後の CLI (`aws` コマンド) access",
+    docUrl:
+      "https://docs.aws.amazon.com/signin/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-SignInLocalDevelopmentAccess",
+  },
+  {
+    arnSuffix: ":policy/AWSCloudShellFullAccess",
+    purpose: "Console 内 CloudShell 起動 + 内部での AWS API 操作",
+    docUrl: "https://docs.aws.amazon.com/cloudshell/latest/userguide/sec-auth-with-identities.html",
+  },
+];
+
+interface Finding {
+  readonly templatePath: string;
+  readonly missing: readonly RequiredPolicy[];
+}
+
+/**
+ * `^  ParticipantViewerRole:` の block を切り出す。 block 終端は
+ * 次の同インデント (2 spaces) の resource 宣言、 もしくは次の top-level section。
+ *
+ * YAML loader を使わないのは check-template-cfn-refs.ts と整合させるため
+ * (= ! tag を含む CFn 拡張形を loader 非依存で扱う)。
+ */
+export function extractParticipantViewerBlock(yaml: string): string | undefined {
+  const lines = yaml.split("\n");
+  let start: number | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === "  ParticipantViewerRole:") {
+      start = i;
+      break;
+    }
+  }
+  if (start === undefined) return undefined;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // 次の Resource (= 2-space indent + Name:) または top-level section に当たったら終端
+    if (/^  [A-Za-z][A-Za-z0-9]*:\s*$/.test(line)) {
+      end = i;
+      break;
+    }
+    if (/^[A-Za-z][A-Za-z0-9]*:\s*$/.test(line)) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+export function findMissingRequiredPolicies(block: string): readonly RequiredPolicy[] {
+  return REQUIRED_POLICIES.filter((p) => !block.includes(p.arnSuffix));
+}
+
+export function checkTemplate(templatePath: string): Finding[] {
+  const yaml = readFileSync(templatePath, "utf8");
+  const block = extractParticipantViewerBlock(yaml);
+  if (block === undefined) {
+    // check-template-cfn-refs が ParticipantViewerRole 必須宣言を別途検証している
+    // ので、 ここで二重検出はしない (= 該当 role が無いテンプレートは skip)。
+    return [];
+  }
+  const missing = findMissingRequiredPolicies(block);
+  if (missing.length === 0) return [];
+  return [{ templatePath, missing }];
+}
+
+function findTemplates(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry === "template.yaml" || entry === "template.yml") out.push(full);
+    }
+  };
+  walk(PROBLEMS_DIR);
+  return out;
+}
+
+function main(): void {
+  const templates = findTemplates();
+  if (templates.length === 0) {
+    console.log("No template.yaml found under problems/.");
+    return;
+  }
+  const allFindings: Finding[] = [];
+  for (const tpl of templates) {
+    allFindings.push(...checkTemplate(tpl));
+  }
+  if (allFindings.length === 0) {
+    console.log(
+      `OK: ${templates.length} template(s) スキャン、` +
+        " ParticipantViewerRole は CLI / CloudShell access に必要な managed policy を全て attach 済",
+    );
+    return;
+  }
+  for (const f of allFindings) {
+    const rel = relative(REPO_ROOT, f.templatePath);
+    for (const m of f.missing) {
+      console.error(`NG ${rel}: ${m.arnSuffix.slice(1)} 未 attach (= ${m.purpose})`);
+    }
+  }
+  console.error("");
+  console.error("修正方法: ParticipantViewerRole の Properties に以下を追加してください:");
+  console.error("");
+  console.error("  Properties:");
+  console.error("    ManagedPolicyArns:");
+  for (const p of REQUIRED_POLICIES) {
+    console.error(`      - arn:aws:iam::aws:policy${p.arnSuffix.slice(":policy".length)}`);
+  }
+  console.error("");
+  console.error("参考:");
+  for (const p of REQUIRED_POLICIES) {
+    console.error(`  - ${p.docUrl}`);
+  }
+  process.exit(1);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

問題作成側がよく踏む落とし穴 (= AWS Console で federation login は成功するのに、 CLI / CloudShell に切り替えた瞬間に静かに失敗する) を、 platform 側で merge 前に弾くための機械チェックを追加。

検出ルール:
- 全 `problems/**/template.yaml` の `ParticipantViewerRole` block を切り出し、 以下 2 つの AWS managed policy が attach されているか suffix match で検証
  - **`AWSSignInLocalDevelopmentAccess`** — Console federation セッションを CLI (`aws` コマンド) に持ち出すために必要 ([AWS doc](https://docs.aws.amazon.com/signin/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-SignInLocalDevelopmentAccess))
  - **`AWSCloudShellFullAccess`** — Console 内 CloudShell 起動 + 内部での AWS API 操作に必要 ([AWS doc](https://docs.aws.amazon.com/cloudshell/latest/userguide/sec-auth-with-identities.html))
- `!Sub \"arn:\${AWS::Partition}:iam::aws:policy/...\"` などの変則表記も suffix match で許容
- どちらか 1 つでも欠けたら NG。 修正手順 + AWS doc URL を stderr に表示してフィードバック

実行例:

```bash
$ make check-template-cli-access
NG problems/challenges/hello-world/template.yaml: policy/AWSSignInLocalDevelopmentAccess 未 attach (= Console federation 後の CLI (\`aws\` コマンド) access)
NG problems/challenges/hello-world/template.yaml: policy/AWSCloudShellFullAccess 未 attach (= Console 内 CloudShell 起動 + 内部での AWS API 操作)
...

修正方法: ParticipantViewerRole の Properties に以下を追加してください:

  Properties:
    ManagedPolicyArns:
      - arn:aws:iam::aws:policy/AWSSignInLocalDevelopmentAccess
      - arn:aws:iam::aws:policy/AWSCloudShellFullAccess
```

## Why

ベースの SSO Credentials 機能 (Issue #705) は STS AssumeRole → federation 経由で AWS Console 1-click login を提供している。 ところが competitor が Console 内で CloudShell を開く、 または federation session を CLI に持ち出すには role 側に追加の AWS managed policy が必要で、 未 attach だと:

- Console: タブは開くが \"環境を作成できません\" でエラー (= CloudShell)
- CLI: federation の \"Get IAM role credentials\" 経路が SignIn 側で reject

→ 競技者は 「ログインできた」 と認識する一方で、 一歩進んだ瞬間に静かに失敗するため切り分けが難しい。 問題作成者も 「自分の template で何を attach すべきか」 のドキュメントが散らばっていて毎回踏む。

platform 側の機械チェックで merge 前に弾けば、 「これを attach してください」 と即フィードバックでき、 問題作成側が困らなくなる。

## Scope of this PR

- ✅ `scripts/check-template-cli-access.ts` を追加
- ✅ `make check-template-cli-access` standalone target を追加
- ✅ `infrastructure/test/scripts/check-template-cli-access.test.ts` で 7 件の unit test を追加 (block 抽出 / suffix match / `!Sub` 形式 等)
- ⛔ **`before-commit` / `check` への組み込みは見送り** (現状 5 テンプレ全てが未 attach のため、 wire すると即座に gate が落ちて作業不能になる)

= 今 PR は \"検出器を用意するだけ\" の最小単位。 ここから follow-up:

## Follow-up

1. **TenkaCloudChallenge 側 PR**: 全 problem template (hello-world / hello-world-battle / security-battle-royale / microservice-migration-battle / stackstack) の `ParticipantViewerRole` に `AWSSignInLocalDevelopmentAccess` + `AWSCloudShellFullAccess` を追加
2. submodule pointer を bump (= TenkaCloud 本体側 PR)
3. follow-up PR でこの check を `before-commit` / `check` に組み込む (= 以降 problem 追加時の自動 gate になる)

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / test / build / validate-problems all pass)
- [x] `bun run --filter @TenkaCloud/infrastructure test test/scripts/check-template-cli-access.test.ts` (7 passed)
- [x] `make check-template-cli-access` が現状の 5 テンプレで 10 件 finding を出すこと (= 2 policy × 5 template) を手動確認

## Regression analysis

- standalone target のみで `before-commit` / `check` には組み込んでいない → 既存 CI pipeline / pre-commit hook の挙動は無変化
- `extractParticipantViewerBlock` は 2-space indent の YAML を想定。 CFn template の慣例 (= cfn-lint / sam build 経由でも 2-space) に依存しているが、 既存 5 テンプレすべてこの indent なので問題は無い
- suffix match は 「他のリソースの Sid やコメントに `AWSCloudShellFullAccess` 文字列が混入していた場合」 false-negative になりうるが、 実用上稀

## Physical impact

- NO-OP infra (CDK / IAM / DDB に変更なし)
- 新 script + 単体テスト + Makefile target 追加のみ
- `before-commit` / `check` の出力は無変化

🤖 Generated with [Claude Code](https://claude.com/claude-code)