### PR TITLE
feat(application-admin-console): EventCreate wizard が problem metadata の defaultRegion を初期値に使う

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -22,6 +22,12 @@ export interface ProblemSummary {
   /** 想定プレイ時間 */
   estimatedDuration: string;
   tags: readonly string[];
+  /**
+   * Issue #1201: 問題作成者が宣言する推奨 deploy 先 region。 EventCreate wizard が
+   * 各問題行の region 初期値として採用する。 未宣言なら従来通り
+   * `DEFAULT_AWS_REGION` にフォールバック。 operator は wizard で override 可能。
+   */
+  defaultRegion?: string;
 }
 
 export interface ProblemDetail extends ProblemSummary {
@@ -53,6 +59,8 @@ interface ProblemMetadata {
   learningGoals: string[];
   cfnTemplate: string;
   cfnParameters?: Record<string, string>;
+  /** Issue #1201: 問題作成者宣言の推奨 region。 wizard が初期値に使う。 */
+  defaultRegion?: string;
 }
 
 // `import.meta.glob` で repo root の `problems/*/*/metadata.json` を build 時 / HMR 時に
@@ -76,6 +84,7 @@ function metadataToDetail(metadata: ProblemMetadata): ProblemDetail {
     description: metadata.description,
     exposedPorts: metadata.exposedPorts,
     learningGoals: metadata.learningGoals,
+    ...(metadata.defaultRegion ? { defaultRegion: metadata.defaultRegion } : {}),
   };
 }
 
@@ -98,5 +107,6 @@ export function listProblemSummaries(): readonly ProblemSummary[] {
     difficulty: p.difficulty,
     estimatedDuration: p.estimatedDuration,
     tags: p.tags,
+    ...(p.defaultRegion ? { defaultRegion: p.defaultRegion } : {}),
   }));
 }

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -83,6 +83,22 @@ interface TeamValidation {
   readonly hasDuplicateSlug: boolean;
 }
 
+/**
+ * Issue #1201: 問題行の初期 region を決める純関数。
+ *
+ * - 問題 metadata に `defaultRegion` が宣言されていればそれを採用
+ * - 未宣言なら `globalDefault` (= 通常 `DEFAULT_AWS_REGION.code`) にフォールバック
+ *
+ * 「全 event が ap-northeast-1 に集中して quota 上限に到達する」 問題を、 問題側
+ * (= 動作確認済 region を一番よく知っている人) の宣言で散らすための仕掛け。
+ */
+export function resolveInitialRegion(
+  metaDefaultRegion: string | undefined,
+  globalDefault: string,
+): string {
+  return metaDefaultRegion ?? globalDefault;
+}
+
 export function resizeTeamRows(prev: TeamRow[], next: number): TeamRow[] {
   if (next === prev.length) return prev;
   if (next < prev.length) return prev.slice(0, Math.max(next, 0));
@@ -238,7 +254,10 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
           return {
             problemId: opt.value,
             problemName: meta?.name ?? opt.value,
-            defaultRegion: DEFAULT_AWS_REGION.code,
+            // Issue #1201: 問題 metadata の defaultRegion を初期値に採用 (= 全 event
+            // が ap-northeast-1 に集中するのを防ぐ)。 未宣言なら従来通り
+            // DEFAULT_AWS_REGION にフォールバック。 operator は wizard で override 可能。
+            defaultRegion: meta?.defaultRegion ?? DEFAULT_AWS_REGION.code,
           };
         });
     });

--- a/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
+++ b/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseTeamCountInput, resizeTeamRows, validateTeamRows } from "../../src/pages/EventCreate";
+import {
+  parseTeamCountInput,
+  resizeTeamRows,
+  resolveInitialRegion,
+  validateTeamRows,
+} from "../../src/pages/EventCreate";
 
 describe("resizeTeamRows", () => {
   it("should return the same array reference when team count is unchanged", () => {
@@ -75,5 +80,21 @@ describe("parseTeamCountInput", () => {
 
   it("should return 0 as-is for input '0'", () => {
     expect(parseTeamCountInput("0")).toBe(0);
+  });
+});
+
+describe("resolveInitialRegion (Issue #1201)", () => {
+  it("should prefer the problem metadata defaultRegion when declared", () => {
+    expect(resolveInitialRegion("us-east-1", "ap-northeast-1")).toBe("us-east-1");
+  });
+
+  it("should fall back to the global default when the problem does not declare one", () => {
+    expect(resolveInitialRegion(undefined, "ap-northeast-1")).toBe("ap-northeast-1");
+  });
+
+  it("should treat empty string as declared (= the operator can author it intentionally to force the global default off)", () => {
+    // 仕様: 空文字は宣言済として扱う (= 後で metadata validator が拒否すべき)。 ここでは
+    // 純関数の動作を pin するだけ。
+    expect(resolveInitialRegion("", "ap-northeast-1")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

Relates #1201 (Phase 1).

全 event が `ap-northeast-1` (= wizard のグローバル default) に集中して service quota 上限に到達する問題への 1 段目の対策。 問題作成側 (= 動作確認済 region を最もよく知っている人) が `metadata.json` で推奨 region を declare できるようにし、 wizard はそれを問題行の region 初期値として採用する。

実装:
- `ProblemMetadata` / `ProblemSummary` / `ProblemDetail` に optional `defaultRegion` フィールドを追加
- `metadataToDetail` / `listProblemSummaries` で carry-through
- `EventCreate` wizard の `onProblemsChange` で問題行追加時の region 初期値を `meta.defaultRegion ?? DEFAULT_AWS_REGION.code` に変更
- 純関数 `resolveInitialRegion` として切り出し unit test (3 ケース) で動作を pin
- operator は wizard で従来どおり override 可能 (= 同問題でも team 別に region 散らしたいケース対応)

## Phase 2 (= 別 PR / 別 repo)

- `problems/SCHEMA.json` (TenkaCloudChallenge submodule) に `defaultRegion` / `supportedRegions` を declare し、 metadata validator で整合性 check
- 既存 5 問題の metadata.json に `defaultRegion` を実際に書く (= operator が手で選んでいた値を問題側に移管)
- 100 名規模 (Issue #1196) 時に向けて `supportedRegions` の round-robin 分散 (Phase 3 候補)

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / test / build / validate-problems)
- [x] `bun run --filter @TenkaCloud/application-admin-console test test/pages/EventCreate.team-rows.test.ts` (12 / 12 pass)
- [ ] 手動: EventCreate wizard で問題を追加 → `defaultRegion` 宣言済の問題はその region が region picker の初期値に
- [ ] 手動: `defaultRegion` 未宣言の問題は従来通り `DEFAULT_AWS_REGION` (ap-northeast-1) が初期値に

## Regression analysis

- `defaultRegion` 未宣言の既存 5 問題は従来どおり `DEFAULT_AWS_REGION.code` にフォールバック → 動作変化なし
- `ProblemMetadata.defaultRegion` は optional なので SCHEMA.json を bump する前に Phase 1 が単独 merge できる
- `resolveInitialRegion` の動作を 3 ケース (declared / undefined / 空文字) で pin

## Physical impact

- **NO-OP infra**: CDK / IAM / DDB に変更なし
- **UPDATE**: `apps/application-admin-console/dist/` bundle (= problems.ts + EventCreate.tsx)
- API surface / DDB schema / Lambda は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)