### PR TITLE
feat(participant-portal): add inter-team event dispatch primitive

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/cast-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/cast-event.ts
@@ -1,0 +1,243 @@
+import { PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { ulid } from "ulid";
+import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import { DELETED_LIKE_STATUSES, ULID_RE } from "../shared/constants.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+
+/**
+ * 「Battle 中のイベント注入 + チーム間 interactive 交流」 の platform-side dispatch primitive。
+ *
+ * 既存設計メモ ([[feedback_inter_team_coordination_plugin]]):
+ *   - inter-team interaction の semantics (= alliance / attack / shared queue / etc.) は
+ *     問題ごとに異なるので、 platform に hardcode せず dispatch だけ提供する
+ *   - 問題側 plugin が portal で polling して inbox を読み、 問題固有の UI / scoring に
+ *     繋ぎ込む
+ *
+ * 通信モデル ([[feedback_polling_over_sse]]): SSE / WebSocket を使わず polling。 Lambda
+ * 運用 / 既存 portal の polling 周期 (30s) に乗せる。
+ *
+ * 物理: Deployments テーブル (= 既存) に `INBOX#<isoTs>#<ulid>` SK pattern を増やすだけ
+ * なので CDK / IAM 変更不要。 PK は recipient deployment の `DEPLOYMENT#<jobId>`。
+ * 7 日 TTL で自然消滅させる (= Issue #1200 と整合)。
+ *
+ * 注意 — 本 primitive は per-deployment 直接送信のみ。 以下は scope 外:
+ *   - operator → competitor (= Issue #888 Phase B、 別件)
+ *   - event broadcast (= 全 team 同報、 別件)
+ *   - cross-account forward (= 競技者 AWS 内 Lambda が直接読む経路、 別件)
+ */
+
+const INBOX_SK_PREFIX = "INBOX#";
+const INBOX_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MAX_PAYLOAD_BYTES = 4 * 1024;
+const KIND_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+export interface InboxEvent {
+  readonly eventId: string;
+  readonly fromTeamId: string;
+  readonly fromJobId: string;
+  readonly kind: string;
+  readonly payload: unknown;
+  readonly occurredAt: string;
+}
+
+export type CastEventOutcome =
+  | { kind: "ok"; eventId: string; occurredAt: string }
+  | { kind: "unauthorized" }
+  | { kind: "invalid_jobid" }
+  | { kind: "invalid_kind" }
+  | { kind: "invalid_payload" }
+  | { kind: "target_not_found" }
+  | { kind: "cross_event_forbidden" }
+  | { kind: "not_ready" };
+
+export type InboxReadOutcome =
+  | { kind: "ok"; events: readonly InboxEvent[] }
+  | { kind: "unauthorized" }
+  | { kind: "invalid_jobid" }
+  | { kind: "invalid_since_ms" };
+
+/** 受信側 inbox query の sinceMs 上限。 RCU 暴発防止 (= 24h 分以上は遡れない)。 */
+export const INBOX_SINCE_MS_MAX = 24 * 60 * 60 * 1000;
+
+interface CastEventInput {
+  readonly targetJobId: string;
+  readonly kind: string;
+  readonly payload: unknown;
+}
+
+/**
+ * sender team の所有 deployment 一覧から自分の「 active な代表行 」 を選び、
+ * sender 同定情報 (eventId / teamId / jobId) を返す。 deleted / pending は不可。
+ */
+function pickSenderContext(
+  items: readonly Partial<DeploymentItem>[],
+): { eventId: string; teamId: string; jobId: string } | undefined {
+  for (const item of items) {
+    const status = (item.status ?? "PENDING") as DeploymentStatus;
+    if (DELETED_LIKE_STATUSES.has(status)) continue;
+    if (status === "PENDING" || status === "IN_PROGRESS") continue;
+    const eventId = typeof item.eventId === "string" ? item.eventId : undefined;
+    const teamId = typeof item.teamId === "string" ? item.teamId : undefined;
+    const jobId = typeof item.jobId === "string" ? item.jobId : undefined;
+    if (eventId && teamId && jobId) return { eventId, teamId, jobId };
+  }
+  return undefined;
+}
+
+/**
+ * Caller の所有 deployment 一覧から、 与えられた jobId 行を返す (= 認可済 lookup)。
+ */
+function findOwnedDeployment(
+  items: readonly Partial<DeploymentItem>[],
+  jobId: string,
+): Partial<DeploymentItem> | undefined {
+  return items.find((i) => i.jobId === jobId);
+}
+
+export function validateKind(raw: unknown): raw is string {
+  return typeof raw === "string" && KIND_RE.test(raw);
+}
+
+export function validatePayload(raw: unknown): boolean {
+  if (raw === null || raw === undefined) return true;
+  if (typeof raw !== "object") return false;
+  try {
+    const json = JSON.stringify(raw);
+    return Buffer.byteLength(json, "utf8") <= MAX_PAYLOAD_BYTES;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Team A → 指定 jobId に inbox event を 1 件追加する。
+ *
+ * 認可:
+ *   - caller の teamLoginKey で deployment 群を引き、 active な代表行から `eventId` を取得
+ *   - target jobId の deployment を別途 query して `eventId` を比較
+ *   - 同 event 内であれば許可、 違うなら `cross_event_forbidden`
+ *
+ * 副作用: target deployment の PK の partition に `INBOX#<isoTs>#<ulid>` 行を Put。
+ * TTL は 7 日 (= 自然消滅、 retention 議論 #1200 と整合)。
+ */
+export async function castEvent(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  input: CastEventInput,
+): Promise<CastEventOutcome> {
+  if (!ULID_RE.test(input.targetJobId)) return { kind: "invalid_jobid" };
+  if (!validateKind(input.kind)) return { kind: "invalid_kind" };
+  if (!validatePayload(input.payload)) return { kind: "invalid_payload" };
+
+  const myItems = await queryTeamItems(shared, teamLoginKey);
+  if (myItems.length === 0) return { kind: "unauthorized" };
+  const sender = pickSenderContext(myItems);
+  if (!sender) return { kind: "not_ready" };
+
+  const targetRows = await shared.ddb.send(
+    new QueryCommand({
+      TableName: shared.tableName,
+      KeyConditionExpression: "PK = :pk AND SK = :sk",
+      ExpressionAttributeValues: {
+        ":pk": `DEPLOYMENT#${input.targetJobId}`,
+        ":sk": "META",
+      },
+    }),
+  );
+  const target = (targetRows.Items?.[0] ?? undefined) as Partial<DeploymentItem> | undefined;
+  if (!target) return { kind: "target_not_found" };
+  const targetStatus = (target.status ?? "PENDING") as DeploymentStatus;
+  if (DELETED_LIKE_STATUSES.has(targetStatus)) return { kind: "target_not_found" };
+  const targetEventId = typeof target.eventId === "string" ? target.eventId : undefined;
+  if (!targetEventId) return { kind: "target_not_found" };
+  if (targetEventId !== sender.eventId) return { kind: "cross_event_forbidden" };
+
+  const occurredAt = new Date().toISOString();
+  const inboxId = ulid();
+  const ttl = Math.floor(Date.now() / 1000) + INBOX_TTL_SECONDS;
+  await shared.ddb.send(
+    new PutCommand({
+      TableName: shared.tableName,
+      Item: {
+        PK: `DEPLOYMENT#${input.targetJobId}`,
+        SK: `${INBOX_SK_PREFIX}${occurredAt}#${inboxId}`,
+        eventId: sender.eventId,
+        fromTeamId: sender.teamId,
+        fromJobId: sender.jobId,
+        kind: input.kind,
+        payload: input.payload ?? {},
+        occurredAt,
+        ttl,
+      },
+    }),
+  );
+  return { kind: "ok", eventId: inboxId, occurredAt };
+}
+
+/**
+ * 自分の指定 jobId の inbox から、 `sinceMs` (epoch ms) 以降の event を時系列降順で返す。
+ * 認可は teamLoginKey + jobId 所有チェック。
+ */
+export async function readInbox(
+  shared: ParticipantSharedResources,
+  teamLoginKey: string,
+  jobIdRaw: string,
+  sinceMsRaw: number,
+  nowMs: number = Date.now(),
+): Promise<InboxReadOutcome> {
+  if (!ULID_RE.test(jobIdRaw)) return { kind: "invalid_jobid" };
+  if (
+    !Number.isInteger(sinceMsRaw) ||
+    sinceMsRaw < 0 ||
+    sinceMsRaw > nowMs ||
+    nowMs - sinceMsRaw > INBOX_SINCE_MS_MAX
+  ) {
+    return { kind: "invalid_since_ms" };
+  }
+
+  const myItems = await queryTeamItems(shared, teamLoginKey);
+  if (myItems.length === 0) return { kind: "unauthorized" };
+  const owned = findOwnedDeployment(myItems, jobIdRaw);
+  if (!owned) return { kind: "unauthorized" };
+
+  const sinceIso = new Date(sinceMsRaw).toISOString();
+  const skStart = `${INBOX_SK_PREFIX}${sinceIso}`;
+  const skEnd = `${INBOX_SK_PREFIX}~`;
+
+  const events: InboxEvent[] = [];
+  let exclusiveStart: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.tableName,
+        KeyConditionExpression: "PK = :pk AND SK BETWEEN :sk_start AND :sk_end",
+        ExpressionAttributeValues: {
+          ":pk": `DEPLOYMENT#${jobIdRaw}`,
+          ":sk_start": skStart,
+          ":sk_end": skEnd,
+        },
+        ScanIndexForward: false,
+        ExclusiveStartKey: exclusiveStart,
+      }),
+    );
+    for (const item of (out.Items ?? []) as Record<string, unknown>[]) {
+      const eventId = typeof item.eventId === "string" ? item.eventId : "";
+      const fromTeamId = typeof item.fromTeamId === "string" ? item.fromTeamId : "";
+      const fromJobId = typeof item.fromJobId === "string" ? item.fromJobId : "";
+      const kind = typeof item.kind === "string" ? item.kind : "";
+      const occurredAt = typeof item.occurredAt === "string" ? item.occurredAt : "";
+      if (!eventId || !fromTeamId || !fromJobId || !kind || !occurredAt) continue;
+      events.push({
+        eventId,
+        fromTeamId,
+        fromJobId,
+        kind,
+        payload: item.payload,
+        occurredAt,
+      });
+    }
+    exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStart);
+
+  return { kind: "ok", events };
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -11,6 +11,7 @@ import { ULID_RE as JOB_ID_RE, PROBLEM_ID_RE } from "../shared/constants.js";
 import { HTTP_OK } from "../shared/http-status.js";
 import { RATE_LIMITS } from "../shared/rate-limiter.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
+import { castEvent, INBOX_SINCE_MS_MAX, readInbox } from "./cast-event.js";
 import {
   defaultDeployLogDeps,
   getParticipantDeployLogs,
@@ -90,6 +91,52 @@ app.get("/portal/me/notifications", (c) =>
       const limit = limitRaw === undefined ? NOTIFICATIONS_DEFAULT_LIMIT : Number(limitRaw);
       const outcome = await listNotifications(shared, token, limit);
       if (outcome.kind === "ok") return c.json(outcome.response, StatusCodes.OK);
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.READ_HIGH,
+  ),
+);
+
+// Inter-team event dispatch primitive (= platform は dispatch だけ、 semantics は問題側 plugin)。
+// 詳細は cast-event.ts の JSDoc を参照。
+app.post("/portal/me/cast-event", (c) =>
+  withBearerAuth(
+    c,
+    "cast-event",
+    async (token) => {
+      const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+      if (body === null) return respondError(c, "invalid_body");
+      const targetJobId = typeof body.targetJobId === "string" ? body.targetJobId : "";
+      const kindStr = typeof body.kind === "string" ? body.kind : "";
+      const outcome = await castEvent(shared, token, {
+        targetJobId,
+        kind: kindStr,
+        payload: body.payload,
+      });
+      if (outcome.kind === "ok") {
+        return c.json({ eventId: outcome.eventId, occurredAt: outcome.occurredAt }, StatusCodes.OK);
+      }
+      return respondError(c, outcome.kind);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
+);
+
+app.get("/portal/me/event-inbox", (c) =>
+  withBearerAuth(
+    c,
+    "event-inbox",
+    async (token) => {
+      const jobId = c.req.query("jobId");
+      if (!jobId) return respondError(c, "missing_jobid");
+      const sinceMsRaw = c.req.query("sinceMs");
+      // 既定は INBOX_SINCE_MS_MAX (= 24h 分まで) を遡る。 frontend が空で叩いても reasonable。
+      const sinceMs =
+        sinceMsRaw === undefined
+          ? Math.max(Date.now() - INBOX_SINCE_MS_MAX, 0)
+          : Number(sinceMsRaw);
+      const outcome = await readInbox(shared, token, jobId, sinceMs);
+      if (outcome.kind === "ok") return c.json({ events: outcome.events }, StatusCodes.OK);
       return respondError(c, outcome.kind);
     },
     RATE_LIMITS.READ_HIGH,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -53,6 +53,12 @@ const ERROR_STATUS = {
   slot_not_overridable: HTTP_CONFLICT,
   invalid_url: HTTP_BAD_REQUEST,
   invalid_slot: HTTP_BAD_REQUEST,
+  // Inter-team event dispatch primitive (cast-event.ts)
+  invalid_kind: HTTP_BAD_REQUEST,
+  invalid_payload: HTTP_BAD_REQUEST,
+  invalid_since_ms: HTTP_BAD_REQUEST,
+  target_not_found: HTTP_NOT_FOUND,
+  cross_event_forbidden: HTTP_CONFLICT,
 } as const;
 
 export type ErrorKind = keyof typeof ERROR_STATUS;

--- a/infrastructure/test/problem-deploy/participant-cast-event.test.ts
+++ b/infrastructure/test/problem-deploy/participant-cast-event.test.ts
@@ -1,0 +1,301 @@
+import { PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  castEvent,
+  INBOX_SINCE_MS_MAX,
+  readInbox,
+  validateKind,
+  validatePayload,
+} from "../../lib/problem-deploy/handlers/participant-handler/cast-event";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
+
+/**
+ * Inter-team event dispatch primitive の挙動を pin する unit test。
+ * 認可 (同 event 縛り) / 入力 validation / DDB Put / DDB Query 結果整形を網羅する。
+ */
+
+const SENDER_JOB = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const TARGET_JOB = "01HZX0K3M3K9ZQHB3MRQHBA1B3";
+const TEAM_KEY = "SENDER_KEY";
+const EVENT_ID = "01HZX0E000000000000000000Z";
+const NOW_MS = new Date("2026-05-21T12:00:00.000Z").getTime();
+
+function buildShared(): { shared: ParticipantSharedResources; ddbSend: ReturnType<typeof vi.fn> } {
+  const ddbSend = vi.fn();
+  const shared: ParticipantSharedResources = {
+    tableName: "TestDeployments",
+    eventsTableName: "TestEvents",
+    endpointsTableName: "",
+    ddb: { send: ddbSend } as unknown as ParticipantSharedResources["ddb"],
+    problemsScoring: {},
+    problemsEndpoints: {},
+  };
+  return { shared, ddbSend };
+}
+
+const senderRow = (over: Record<string, unknown> = {}) => ({
+  PK: `DEPLOYMENT#${SENDER_JOB}`,
+  SK: "META",
+  GSI2PK: `TEAMKEY#${TEAM_KEY}`,
+  jobId: SENDER_JOB,
+  teamId: "team-alpha",
+  eventId: EVENT_ID,
+  status: "COMPLETE",
+  ...over,
+});
+
+const targetMetaRow = (over: Record<string, unknown> = {}) => ({
+  PK: `DEPLOYMENT#${TARGET_JOB}`,
+  SK: "META",
+  jobId: TARGET_JOB,
+  teamId: "team-beta",
+  eventId: EVENT_ID,
+  status: "COMPLETE",
+  ...over,
+});
+
+describe("validateKind", () => {
+  it("should accept lowercase kebab-case kinds", () => {
+    expect(validateKind("attack-launch")).toBe(true);
+    expect(validateKind("a")).toBe(true);
+  });
+
+  it("should reject UPPERCASE / spaces / leading-digit / non-string", () => {
+    expect(validateKind("Attack-Launch")).toBe(false);
+    expect(validateKind("attack launch")).toBe(false);
+    expect(validateKind("1invalid")).toBe(false);
+    expect(validateKind(42)).toBe(false);
+    expect(validateKind(undefined)).toBe(false);
+  });
+
+  it("should reject kinds longer than 64 chars", () => {
+    expect(validateKind("a".repeat(65))).toBe(false);
+    expect(validateKind("a".repeat(64))).toBe(true);
+  });
+});
+
+describe("validatePayload", () => {
+  it("should accept undefined / null / objects up to 4 KB", () => {
+    expect(validatePayload(undefined)).toBe(true);
+    expect(validatePayload(null)).toBe(true);
+    expect(validatePayload({ foo: "bar" })).toBe(true);
+  });
+
+  it("should reject primitives that are not null", () => {
+    expect(validatePayload("string")).toBe(false);
+    expect(validatePayload(123)).toBe(false);
+  });
+
+  it("should reject payloads larger than 4 KB", () => {
+    const big = { blob: "x".repeat(5_000) };
+    expect(validatePayload(big)).toBe(false);
+  });
+});
+
+describe("castEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return invalid_jobid for non-ULID targetJobId", async () => {
+    const { shared } = buildShared();
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: "not-ulid",
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "invalid_jobid" });
+  });
+
+  it("should return invalid_kind for malformed kind", async () => {
+    const { shared } = buildShared();
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "BAD KIND",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "invalid_kind" });
+  });
+
+  it("should return invalid_payload when payload exceeds 4 KB", async () => {
+    const { shared } = buildShared();
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: { blob: "x".repeat(5_000) },
+    });
+    expect(out).toEqual({ kind: "invalid_payload" });
+  });
+
+  it("should return unauthorized when caller's teamLoginKey has no deployments", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "unauthorized" });
+  });
+
+  it("should return not_ready when sender has only PENDING / IN_PROGRESS deployments", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow({ status: "PENDING" })] });
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "not_ready" });
+  });
+
+  it("should return target_not_found when target deployment does not exist", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "target_not_found" });
+  });
+
+  it("should return target_not_found when target deployment is DELETED", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    ddbSend.mockResolvedValueOnce({ Items: [targetMetaRow({ status: "DELETED" })] });
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "target_not_found" });
+  });
+
+  it("should return cross_event_forbidden when target is in a different event", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [targetMetaRow({ eventId: "01HZX0E000000000000000DIFF" })],
+    });
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack",
+      payload: {},
+    });
+    expect(out).toEqual({ kind: "cross_event_forbidden" });
+  });
+
+  it("should Put an INBOX# row on the target deployment partition with ttl + sender context (= happy path)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    ddbSend.mockResolvedValueOnce({ Items: [targetMetaRow()] });
+    ddbSend.mockResolvedValueOnce({});
+    const out = await castEvent(shared, TEAM_KEY, {
+      targetJobId: TARGET_JOB,
+      kind: "attack-launch",
+      payload: { damage: 30 },
+    });
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.eventId).toMatch(/^[0-9A-Z]{26}$/);
+    expect(out.occurredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+    const putCall = ddbSend.mock.calls.find(([cmd]) => cmd instanceof PutCommand);
+    expect(putCall).toBeDefined();
+    const input = (putCall?.[0] as PutCommand).input as {
+      TableName: string;
+      Item: Record<string, unknown>;
+    };
+    expect(input.TableName).toBe("TestDeployments");
+    expect(input.Item.PK).toBe(`DEPLOYMENT#${TARGET_JOB}`);
+    expect((input.Item.SK as string).startsWith("INBOX#")).toBe(true);
+    expect(input.Item.fromTeamId).toBe("team-alpha");
+    expect(input.Item.fromJobId).toBe(SENDER_JOB);
+    expect(input.Item.eventId).toBe(EVENT_ID);
+    expect(input.Item.kind).toBe("attack-launch");
+    expect(input.Item.payload).toEqual({ damage: 30 });
+    expect(typeof input.Item.ttl).toBe("number");
+    // TTL は ~7 日 + 現在時刻、 6.5 日 < ttl < 7.5 日 で許容
+    const ttlSec = input.Item.ttl as number;
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(ttlSec).toBeGreaterThan(nowSec + 6 * 24 * 60 * 60);
+    expect(ttlSec).toBeLessThan(nowSec + 8 * 24 * 60 * 60);
+  });
+});
+
+describe("readInbox", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return invalid_jobid for non-ULID jobId", async () => {
+    const { shared } = buildShared();
+    const out = await readInbox(shared, TEAM_KEY, "not-ulid", 0, NOW_MS);
+    expect(out).toEqual({ kind: "invalid_jobid" });
+  });
+
+  it("should return invalid_since_ms for negative / future / too-old / non-integer sinceMs", async () => {
+    const { shared } = buildShared();
+    expect((await readInbox(shared, TEAM_KEY, SENDER_JOB, -1, NOW_MS)).kind).toBe(
+      "invalid_since_ms",
+    );
+    expect((await readInbox(shared, TEAM_KEY, SENDER_JOB, NOW_MS + 1, NOW_MS)).kind).toBe(
+      "invalid_since_ms",
+    );
+    expect(
+      (await readInbox(shared, TEAM_KEY, SENDER_JOB, NOW_MS - INBOX_SINCE_MS_MAX - 1, NOW_MS)).kind,
+    ).toBe("invalid_since_ms");
+    expect((await readInbox(shared, TEAM_KEY, SENDER_JOB, 1.5, NOW_MS)).kind).toBe(
+      "invalid_since_ms",
+    );
+  });
+
+  it("should return unauthorized when jobId is not owned by the team", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    const out = await readInbox(shared, TEAM_KEY, TARGET_JOB, NOW_MS - 60_000, NOW_MS);
+    expect(out).toEqual({ kind: "unauthorized" });
+  });
+
+  it("should return ok with events sorted newest first (= DDB Query with ScanIndexForward=false)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [senderRow()] });
+    ddbSend.mockResolvedValueOnce({
+      Items: [
+        {
+          PK: `DEPLOYMENT#${SENDER_JOB}`,
+          SK: "INBOX#2026-05-21T12:01:00.000Z#01J",
+          eventId: EVENT_ID,
+          fromTeamId: "team-beta",
+          fromJobId: TARGET_JOB,
+          kind: "attack-launch",
+          payload: { damage: 30 },
+          occurredAt: "2026-05-21T12:01:00.000Z",
+        },
+        {
+          PK: `DEPLOYMENT#${SENDER_JOB}`,
+          SK: "INBOX#2026-05-21T12:00:30.000Z#01H",
+          eventId: EVENT_ID,
+          fromTeamId: "team-gamma",
+          fromJobId: "01HZX0K3M3K9ZQHB3MRQHBA1B4",
+          kind: "alliance-propose",
+          payload: { duration: 60 },
+          occurredAt: "2026-05-21T12:00:30.000Z",
+        },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+    const out = await readInbox(shared, TEAM_KEY, SENDER_JOB, NOW_MS - 5 * 60_000, NOW_MS);
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+    expect(out.events.length).toBe(2);
+    expect(out.events[0]?.kind).toBe("attack-launch");
+    expect(out.events[1]?.kind).toBe("alliance-propose");
+
+    const queryCall = ddbSend.mock.calls[1];
+    const input = (queryCall?.[0] as QueryCommand).input as {
+      ScanIndexForward?: boolean;
+      ExpressionAttributeValues?: Record<string, string>;
+    };
+    expect(input.ScanIndexForward).toBe(false);
+    expect(input.ExpressionAttributeValues?.[":pk"]).toBe(`DEPLOYMENT#${SENDER_JOB}`);
+  });
+});


### PR DESCRIPTION
## Summary

Platform-side minimum viable primitive for **inter-team interactive 交流** ([[feedback_inter_team_coordination_plugin]] と整合: 「semantics は問題ごとに異なるので、 platform に hardcode せず dispatch だけ提供」)。

既存 Deployments テーブルに `INBOX#<isoTs>#<ulid>` SK pattern を載せるだけなので **CDK / IAM 変更不要**。

新 API:

```
POST /portal/me/cast-event
  body: { targetJobId, kind, payload }
  rate limit: WRITE_LOW (= 10 burst / 0.2 RPS)

GET /portal/me/event-inbox?jobId=&sinceMs=
  rate limit: READ_HIGH (= 60 burst / 2 RPS)
```

## Design

- 認可: caller の teamLoginKey で deployment 群を引き、 active 行から sender 同定 (eventId / teamId / jobId)。 target deployment の `eventId` と一致しなければ `cross_event_forbidden`
- TTL: 7 日 (Issue #1200 retention と整合)
- polling-based ([[feedback_polling_over_sse]] と整合、 SSE / WebSocket 使わず)
- `kind` は kebab-case opaque string、 `payload` は 4 KB 上限 JSON。 platform は中身を解釈せず、 problem plugin が semantics を実装

## Scope (今 PR)

- ✅ per-deployment 直接送信
- ✅ recipient inbox の polling 取得
- ⛔ event broadcast (= 全 team 同報) は未実装、 後付け可能
- ⛔ operator cast (= Issue #888 Phase B / disruption cross-account forward) は scope 外、 同じ INBOX# pattern で別 endpoint から書き込めば再利用可能
- ⛔ cross-account forward (= 競技者 AWS 内 Lambda が直接読む) は別件

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit`
- [x] 単体テスト 14 件で挙動を pin: validateKind / validatePayload / castEvent (7 ケース、 認可 + validation + happy path) / readInbox (4 ケース、 認可 + sinceMs validation + Sort 順)
- [ ] 手動: 問題 plugin から `fetch('/portal/me/cast-event', ...)` で送信、 受信側 plugin が `/portal/me/event-inbox` polling で読めること

## Regression analysis

- 既存 routes / data に触れていない (= 新ファイル + index.ts に 2 routes 追加のみ)
- Deployments テーブルの新 SK prefix `INBOX#` は existing Query (`SK=META` / `SK BETWEEN EVENT#... AND EVENT#~`) の key condition 範囲外なので既存読み出しに silently 混入しない
- 既存 IAM policy (= Deployments への CRUD) で新 endpoint をカバー済

## Physical impact

- **NO-OP infra**: CDK / IAM / DDB schema 変更なし
- **UPDATE**: ProblemDeployBackendStack の Lambda handler bundle (participant-handler)

## Follow-up

- 問題側 plugin に利用例 (= 攻撃通知 UI / 同盟提案モーダル) を別 PR で実装
- operator cast = 同 INBOX# pattern を event-handler 側から書く別 endpoint で
- event broadcast = `targetJobId` 省略時に event 内 deployment へ fan-out する mode を後付け

Relates: [[feedback_inter_team_coordination_plugin]]、 Issue #888 (operator disruption Phase B)、 Issue #1196 (scaling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)