### PR TITLE
feat(application-admin-console): EventCreate wizard が supportedRegions で region picker を絞る + validator 追加

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -28,6 +28,13 @@ export interface ProblemSummary {
    * `DEFAULT_AWS_REGION` にフォールバック。 operator は wizard で override 可能。
    */
   defaultRegion?: string;
+  /**
+   * Issue #1201 Phase 2: 動作確認済の region 集合。 宣言された場合、 EventCreate
+   * wizard の region picker はこの集合だけを選択肢として出す (= 動かない region への
+   * misconfig 予防)。 `defaultRegion` はこの集合に含まれていることを validator が保証。
+   * 未宣言なら全 AWS region から選べる (= 後方互換)。
+   */
+  supportedRegions?: readonly string[];
 }
 
 export interface ProblemDetail extends ProblemSummary {
@@ -61,6 +68,8 @@ interface ProblemMetadata {
   cfnParameters?: Record<string, string>;
   /** Issue #1201: 問題作成者宣言の推奨 region。 wizard が初期値に使う。 */
   defaultRegion?: string;
+  /** Issue #1201 Phase 2: 動作確認済 region 集合。 wizard が picker の選択肢を絞る。 */
+  supportedRegions?: string[];
 }
 
 // `import.meta.glob` で repo root の `problems/*/*/metadata.json` を build 時 / HMR 時に
@@ -85,6 +94,9 @@ function metadataToDetail(metadata: ProblemMetadata): ProblemDetail {
     exposedPorts: metadata.exposedPorts,
     learningGoals: metadata.learningGoals,
     ...(metadata.defaultRegion ? { defaultRegion: metadata.defaultRegion } : {}),
+    ...(metadata.supportedRegions && metadata.supportedRegions.length > 0
+      ? { supportedRegions: metadata.supportedRegions }
+      : {}),
   };
 }
 
@@ -108,5 +120,6 @@ export function listProblemSummaries(): readonly ProblemSummary[] {
     estimatedDuration: p.estimatedDuration,
     tags: p.tags,
     ...(p.defaultRegion ? { defaultRegion: p.defaultRegion } : {}),
+    ...(p.supportedRegions ? { supportedRegions: p.supportedRegions } : {}),
   }));
 }

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -66,6 +66,27 @@ interface ProblemRow {
   problemId: string;
   problemName: string;
   defaultRegion: string;
+  /** Issue #1201 Phase 2: 問題が動作確認済 region 集合。 wizard picker の選択肢を絞る。 */
+  supportedRegions?: readonly string[];
+}
+
+/**
+ * Issue #1201 Phase 2: region picker の選択肢を `supportedRegions` で絞る純関数。
+ *
+ * - `supportedRegions` が undefined / 空 → 全 region (= 後方互換)
+ * - 宣言されていれば、 集合と AWS_REGIONS の intersection で picker を構築
+ * - 未知 region code (= AWS_REGIONS に無い文字列) は無視 (= UI に壊れた option を出さない)
+ */
+export function resolveRegionOptions(
+  supportedRegions: readonly string[] | undefined,
+  baseOptions: readonly SelectProps.Option[],
+): readonly SelectProps.Option[] {
+  if (!supportedRegions || supportedRegions.length === 0) return baseOptions;
+  const allowed = new Set(supportedRegions);
+  const intersection = baseOptions.filter((o) => o.value && allowed.has(o.value));
+  // 宣言が無効 (= AWS_REGIONS と 1 件もマッチしない) のときは base に倒す。
+  // ここで空配列を返すと wizard が壊れるので fail-safe。
+  return intersection.length > 0 ? intersection : baseOptions;
 }
 
 /**
@@ -258,6 +279,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
             // が ap-northeast-1 に集中するのを防ぐ)。 未宣言なら従来通り
             // DEFAULT_AWS_REGION にフォールバック。 operator は wizard で override 可能。
             defaultRegion: meta?.defaultRegion ?? DEFAULT_AWS_REGION.code,
+            ...(meta?.supportedRegions ? { supportedRegions: meta.supportedRegions } : {}),
           };
         });
     });
@@ -559,21 +581,23 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
                     {
                       id: "region",
                       header: t("event_create.col_region"),
-                      cell: (r) => (
-                        <Select
-                          selectedOption={
-                            REGION_OPTIONS.find((o) => o.value === r.defaultRegion) ??
-                            REGION_OPTIONS[0]
-                          }
-                          options={REGION_OPTIONS}
-                          onChange={({ detail }) =>
-                            updateProblemRow(r.problemId, {
-                              defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
-                            })
-                          }
-                          expandToViewport
-                        />
-                      ),
+                      cell: (r) => {
+                        const options = resolveRegionOptions(r.supportedRegions, REGION_OPTIONS);
+                        return (
+                          <Select
+                            selectedOption={
+                              options.find((o) => o.value === r.defaultRegion) ?? options[0]
+                            }
+                            options={[...options]}
+                            onChange={({ detail }) =>
+                              updateProblemRow(r.problemId, {
+                                defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
+                              })
+                            }
+                            expandToViewport
+                          />
+                        );
+                      },
                     },
                   ]}
                 />

--- a/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
+++ b/apps/application-admin-console/test/pages/EventCreate.team-rows.test.ts
@@ -3,6 +3,7 @@ import {
   parseTeamCountInput,
   resizeTeamRows,
   resolveInitialRegion,
+  resolveRegionOptions,
   validateTeamRows,
 } from "../../src/pages/EventCreate";
 
@@ -96,5 +97,36 @@ describe("resolveInitialRegion (Issue #1201)", () => {
     // 仕様: 空文字は宣言済として扱う (= 後で metadata validator が拒否すべき)。 ここでは
     // 純関数の動作を pin するだけ。
     expect(resolveInitialRegion("", "ap-northeast-1")).toBe("");
+  });
+});
+
+describe("resolveRegionOptions (Issue #1201 Phase 2)", () => {
+  const base = [
+    { value: "ap-northeast-1", label: "Tokyo" },
+    { value: "us-east-1", label: "N. Virginia" },
+    { value: "us-west-2", label: "Oregon" },
+  ];
+
+  it("should return all base options when supportedRegions is undefined (backward compatible)", () => {
+    expect(resolveRegionOptions(undefined, base)).toBe(base);
+  });
+
+  it("should return all base options when supportedRegions is empty array", () => {
+    expect(resolveRegionOptions([], base)).toBe(base);
+  });
+
+  it("should restrict to intersection of supportedRegions and base options", () => {
+    const out = resolveRegionOptions(["us-east-1", "us-west-2"], base);
+    expect(out.map((o) => o.value)).toEqual(["us-east-1", "us-west-2"]);
+  });
+
+  it("should ignore unknown region codes not in base", () => {
+    const out = resolveRegionOptions(["us-east-1", "made-up-region"], base);
+    expect(out.map((o) => o.value)).toEqual(["us-east-1"]);
+  });
+
+  it("should fall back to base when supportedRegions has no intersection (= author misconfig)", () => {
+    // wizard が空 picker で固まるのを防ぐ fail-safe。 metadata validator は別途で hard-error。
+    expect(resolveRegionOptions(["made-up-only"], base)).toBe(base);
   });
 });

--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -56,25 +56,19 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
   });
 
   // ADR-012 Phase 4 + fairness contract: portal は author が `publicHint: true` で
-  // 明示宣言した phase / disruption だけを予告 panel に出す。 microservice-migration-battle は
-  // 全 phase / disruption に publicHint: true を立てているので全部見える。
-  it("should expose phases / disruptions for microservice-migration-battle (all publicHint: true)", () => {
-    const m = findProblemMetadata("microservice-migration-battle");
-    expect(m).toBeDefined();
-    expect(m?.phases.length).toBeGreaterThanOrEqual(2);
-    expect(m?.phases.map((p) => p.name)).toEqual(expect.arrayContaining(["degraded", "legacy"]));
-    expect(m?.disruptions.length).toBeGreaterThanOrEqual(1);
-    expect(m?.disruptions[0]?.id).toBe("ec2-latency-injection");
-    expect(m?.disruptions[0]?.defaultAfterMinutes).toBe(60);
-  });
-
-  // fairness contract: publicHint: true が無い phase / disruption は portal bundle に embed されない。
-  // stackstack の phases / disruptions は publicHint が無いので 0 件露出が期待値。
+  // 明示宣言した phase / disruption だけを予告 panel に出す。 現状の全 problem は
+  // publicHint: false (or 未宣言) なので competitor 視点では 0 件露出が期待値。
+  // (= 過去 microservice-migration-battle は publicHint: true で showcase されていたが、
+  //  catalog 側 metadata の方針変更で false に倒された)。
   it("should drop phases / disruptions without publicHint: true (fairness contract)", () => {
-    const m = findProblemMetadata("stackstack");
-    expect(m).toBeDefined();
-    expect(m?.phases).toEqual([]);
-    expect(m?.disruptions).toEqual([]);
+    for (const id of ["stackstack", "microservice-migration-battle"]) {
+      const m = findProblemMetadata(id);
+      expect(m, `${id} should be in catalog`).toBeDefined();
+      expect(m?.phases, `${id} phases should be hidden when publicHint != true`).toEqual([]);
+      expect(m?.disruptions, `${id} disruptions should be hidden when publicHint != true`).toEqual(
+        [],
+      );
+    }
   });
 
   it("phases / disruptions に operator 内部 field (effect / parameters / eventDetailType) を露出しないべき", () => {

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/cast-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/cast-event.ts
@@ -65,6 +65,22 @@ interface CastEventInput {
   readonly payload: unknown;
 }
 
+function isActiveDeployment(item: Partial<DeploymentItem>): boolean {
+  const status = (item.status ?? "PENDING") as DeploymentStatus;
+  if (DELETED_LIKE_STATUSES.has(status)) return false;
+  if (status === "PENDING" || status === "IN_PROGRESS") return false;
+  return true;
+}
+
+function toSenderContext(
+  item: Partial<DeploymentItem>,
+): { eventId: string; teamId: string; jobId: string } | undefined {
+  if (typeof item.eventId !== "string") return undefined;
+  if (typeof item.teamId !== "string") return undefined;
+  if (typeof item.jobId !== "string") return undefined;
+  return { eventId: item.eventId, teamId: item.teamId, jobId: item.jobId };
+}
+
 /**
  * sender team の所有 deployment 一覧から自分の「 active な代表行 」 を選び、
  * sender 同定情報 (eventId / teamId / jobId) を返す。 deleted / pending は不可。
@@ -73,13 +89,9 @@ function pickSenderContext(
   items: readonly Partial<DeploymentItem>[],
 ): { eventId: string; teamId: string; jobId: string } | undefined {
   for (const item of items) {
-    const status = (item.status ?? "PENDING") as DeploymentStatus;
-    if (DELETED_LIKE_STATUSES.has(status)) continue;
-    if (status === "PENDING" || status === "IN_PROGRESS") continue;
-    const eventId = typeof item.eventId === "string" ? item.eventId : undefined;
-    const teamId = typeof item.teamId === "string" ? item.teamId : undefined;
-    const jobId = typeof item.jobId === "string" ? item.jobId : undefined;
-    if (eventId && teamId && jobId) return { eventId, teamId, jobId };
+    if (!isActiveDeployment(item)) continue;
+    const ctx = toSenderContext(item);
+    if (ctx) return ctx;
   }
   return undefined;
 }
@@ -174,6 +186,56 @@ export async function castEvent(
   return { kind: "ok", eventId: inboxId, occurredAt };
 }
 
+function isValidSinceMs(sinceMs: number, nowMs: number): boolean {
+  if (!Number.isInteger(sinceMs)) return false;
+  if (sinceMs < 0) return false;
+  if (sinceMs > nowMs) return false;
+  if (nowMs - sinceMs > INBOX_SINCE_MS_MAX) return false;
+  return true;
+}
+
+function toInboxEvent(item: Record<string, unknown>): InboxEvent | undefined {
+  const eventId = typeof item.eventId === "string" ? item.eventId : "";
+  const fromTeamId = typeof item.fromTeamId === "string" ? item.fromTeamId : "";
+  const fromJobId = typeof item.fromJobId === "string" ? item.fromJobId : "";
+  const kind = typeof item.kind === "string" ? item.kind : "";
+  const occurredAt = typeof item.occurredAt === "string" ? item.occurredAt : "";
+  if (!eventId || !fromTeamId || !fromJobId || !kind || !occurredAt) return undefined;
+  return { eventId, fromTeamId, fromJobId, kind, payload: item.payload, occurredAt };
+}
+
+async function queryInboxRows(
+  shared: ParticipantSharedResources,
+  jobId: string,
+  sinceMs: number,
+): Promise<readonly Record<string, unknown>[]> {
+  const sinceIso = new Date(sinceMs).toISOString();
+  const skStart = `${INBOX_SK_PREFIX}${sinceIso}`;
+  const skEnd = `${INBOX_SK_PREFIX}~`;
+  const rows: Record<string, unknown>[] = [];
+  let exclusiveStart: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.tableName,
+        KeyConditionExpression: "PK = :pk AND SK BETWEEN :sk_start AND :sk_end",
+        ExpressionAttributeValues: {
+          ":pk": `DEPLOYMENT#${jobId}`,
+          ":sk_start": skStart,
+          ":sk_end": skEnd,
+        },
+        ScanIndexForward: false,
+        ExclusiveStartKey: exclusiveStart,
+      }),
+    );
+    for (const item of (out.Items ?? []) as Record<string, unknown>[]) {
+      rows.push(item);
+    }
+    exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStart);
+  return rows;
+}
+
 /**
  * 自分の指定 jobId の inbox から、 `sinceMs` (epoch ms) 以降の event を時系列降順で返す。
  * 認可は teamLoginKey + jobId 所有チェック。
@@ -186,58 +248,17 @@ export async function readInbox(
   nowMs: number = Date.now(),
 ): Promise<InboxReadOutcome> {
   if (!ULID_RE.test(jobIdRaw)) return { kind: "invalid_jobid" };
-  if (
-    !Number.isInteger(sinceMsRaw) ||
-    sinceMsRaw < 0 ||
-    sinceMsRaw > nowMs ||
-    nowMs - sinceMsRaw > INBOX_SINCE_MS_MAX
-  ) {
-    return { kind: "invalid_since_ms" };
-  }
+  if (!isValidSinceMs(sinceMsRaw, nowMs)) return { kind: "invalid_since_ms" };
 
   const myItems = await queryTeamItems(shared, teamLoginKey);
   if (myItems.length === 0) return { kind: "unauthorized" };
-  const owned = findOwnedDeployment(myItems, jobIdRaw);
-  if (!owned) return { kind: "unauthorized" };
+  if (!findOwnedDeployment(myItems, jobIdRaw)) return { kind: "unauthorized" };
 
-  const sinceIso = new Date(sinceMsRaw).toISOString();
-  const skStart = `${INBOX_SK_PREFIX}${sinceIso}`;
-  const skEnd = `${INBOX_SK_PREFIX}~`;
-
+  const rows = await queryInboxRows(shared, jobIdRaw, sinceMsRaw);
   const events: InboxEvent[] = [];
-  let exclusiveStart: Record<string, unknown> | undefined;
-  do {
-    const out = await shared.ddb.send(
-      new QueryCommand({
-        TableName: shared.tableName,
-        KeyConditionExpression: "PK = :pk AND SK BETWEEN :sk_start AND :sk_end",
-        ExpressionAttributeValues: {
-          ":pk": `DEPLOYMENT#${jobIdRaw}`,
-          ":sk_start": skStart,
-          ":sk_end": skEnd,
-        },
-        ScanIndexForward: false,
-        ExclusiveStartKey: exclusiveStart,
-      }),
-    );
-    for (const item of (out.Items ?? []) as Record<string, unknown>[]) {
-      const eventId = typeof item.eventId === "string" ? item.eventId : "";
-      const fromTeamId = typeof item.fromTeamId === "string" ? item.fromTeamId : "";
-      const fromJobId = typeof item.fromJobId === "string" ? item.fromJobId : "";
-      const kind = typeof item.kind === "string" ? item.kind : "";
-      const occurredAt = typeof item.occurredAt === "string" ? item.occurredAt : "";
-      if (!eventId || !fromTeamId || !fromJobId || !kind || !occurredAt) continue;
-      events.push({
-        eventId,
-        fromTeamId,
-        fromJobId,
-        kind,
-        payload: item.payload,
-        occurredAt,
-      });
-    }
-    exclusiveStart = out.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (exclusiveStart);
-
+  for (const row of rows) {
+    const ev = toInboxEvent(row);
+    if (ev) events.push(ev);
+  }
   return { kind: "ok", events };
 }

--- a/infrastructure/test/problem-deploy-backend-stack.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test.ts
@@ -22,6 +22,21 @@ function synthDefault(): Template {
   return Template.fromStack(stack);
 }
 
+function synthWithDeployConcurrentBuildLimit(): Template {
+  const app = new cdk.App();
+  const stack = new ProblemDeployBackendStack(app, "TestStackWithLimit", {
+    eventBusArn: "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus",
+    sourceBucketName: "test-source-bucket",
+    sourceObjectKey: "source.zip",
+    problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
+    problemsScoring: {},
+    problemsEndpoints: {},
+    deployConcurrentBuildLimit: 200,
+    environmentName: "development",
+  });
+  return Template.fromStack(stack);
+}
+
 describe("ProblemDeployBackendStack (MVP-1)", () => {
   const tpl = synthDefault();
 
@@ -130,26 +145,16 @@ describe("ProblemDeployBackendStack (MVP-1)", () => {
   });
 
   describe("CodeBuild Project concurrent build limit (#538)", () => {
-    // synth が 5 個の NodejsFunction (= esbuild bundling) を走らせるため、default 5s では足りない。
-    // 共有 fixture (`tpl = synthDefault()`) と別 props を渡すので別 instance での synth が必要。
+    // 共有 fixture (`tpl = synthDefault()`) と別 props を渡すので別 instance で synth する。
+    // bundling が長い環境でも assertion timeout に巻き込まれないよう collection 時に fixture 化する。
+    const limited = synthWithDeployConcurrentBuildLimit();
+
     it("should reflect `deployConcurrentBuildLimit: 200` in the CFn property", () => {
-      const app = new cdk.App();
-      const stack = new ProblemDeployBackendStack(app, "TestStackWithLimit", {
-        eventBusArn: "arn:aws:events:ap-northeast-1:123456789012:event-bus/test-bus",
-        sourceBucketName: "test-source-bucket",
-        sourceObjectKey: "source.zip",
-        problemsCatalog: { "hello-world": "problems/challenges/hello-world" },
-        problemsScoring: {},
-        problemsEndpoints: {},
-        deployConcurrentBuildLimit: 200,
-        environmentName: "development",
-      });
-      const limited = Template.fromStack(stack);
       limited.hasResourceProperties(
         "AWS::CodeBuild::Project",
         Match.objectLike({ ConcurrentBuildLimit: 200 }),
       );
-    }, 30_000);
+    });
   });
 
   describe("Step Functions State Machine + EventBridge Rule", () => {

--- a/infrastructure/test/problem-deploy/participant-cast-event.test.ts
+++ b/infrastructure/test/problem-deploy/participant-cast-event.test.ts
@@ -1,4 +1,4 @@
-import { PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { PutCommand, type QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   castEvent,

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -64,6 +64,10 @@ const RESOURCE_STAR_OK_SIDS = new Set([
   "ConsoleEc2Metadata",
   // self-identity (= sts:GetCallerIdentity は呼び出し元 token を返すだけ)
   "ConsoleSelfIdentity",
+  // Issue #1198 (#1208 follow-up): CloudShell launch action は session 用 per-team
+  // dedicated AWS account に閉じる (= 他 tenant の cloudshell に触れない)。
+  // Resource-level scope は CloudShell API が持たないため、 Resource:"*" 必須。
+  "OpenCloudShellSession",
 ]);
 
 describe("problem template ParticipantViewerRole (#744)", () => {

--- a/infrastructure/test/scripts/check-template-cli-access.test.ts
+++ b/infrastructure/test/scripts/check-template-cli-access.test.ts
@@ -95,7 +95,9 @@ describe("findMissingRequiredPolicies", () => {
       "  ParticipantViewerRole:",
       "    Properties:",
       "      ManagedPolicyArns:",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub の literal を pin する意図
       '        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSSignInLocalDevelopmentAccess"',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub の literal を pin する意図
       '        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSCloudShellFullAccess"',
     ].join("\n");
     expect(findMissingRequiredPolicies(block)).toEqual([]);

--- a/infrastructure/test/scripts/check-template-security.test.ts
+++ b/infrastructure/test/scripts/check-template-security.test.ts
@@ -54,6 +54,24 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       expect(findings).toEqual([]);
     });
 
+    it('should allow the CloudShell participant baseline on Resource: "*"', () => {
+      const findings = findIamResourceWildcardFindings(
+        PATH,
+        "loc",
+        ["*"],
+        [
+          "cloudshell:CreateEnvironment",
+          "cloudshell:CreateSession",
+          "cloudshell:GetEnvironmentStatus",
+          "cloudshell:StartEnvironment",
+          "cloudshell:StopEnvironment",
+          "cloudshell:DeleteEnvironment",
+          "cloudshell:PutCredentials",
+        ],
+      );
+      expect(findings).toEqual([]);
+    });
+
     it('should return 0 findings when Resource: "*" is absent (scoped ARNs are OK)', () => {
       expect(
         findIamResourceWildcardFindings(

--- a/infrastructure/test/scripts/validate-problems-region.test.ts
+++ b/infrastructure/test/scripts/validate-problems-region.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { checkRegionConsistency } from "../../../scripts/validate-problems";
+
+/**
+ * Issue #1201 Phase 2: `checkRegionConsistency` の動作を pin する unit test。
+ *
+ * Validator は `defaultRegion` / `supportedRegions` が宣言された場合のみ動き、
+ * 未宣言なら no-op (= 後方互換) であることを保証する。
+ */
+
+describe("checkRegionConsistency", () => {
+  it("should be a no-op when neither defaultRegion nor supportedRegions is declared", () => {
+    expect(checkRegionConsistency({})).toEqual([]);
+  });
+
+  it("should accept defaultRegion alone with a valid AWS region format", () => {
+    expect(checkRegionConsistency({ defaultRegion: "ap-northeast-1" })).toEqual([]);
+  });
+
+  it("should reject defaultRegion with a non-AWS-region string", () => {
+    const errors = checkRegionConsistency({ defaultRegion: "not-a-region" });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("defaultRegion");
+    expect(errors[0]).toContain("not-a-region");
+  });
+
+  it("should accept supportedRegions alone with valid region codes", () => {
+    expect(checkRegionConsistency({ supportedRegions: ["us-east-1", "us-west-2"] })).toEqual([]);
+  });
+
+  it("should reject an empty supportedRegions array (= declared but useless)", () => {
+    const errors = checkRegionConsistency({ supportedRegions: [] });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("supportedRegions");
+  });
+
+  it("should reject supportedRegions with non-region values", () => {
+    const errors = checkRegionConsistency({ supportedRegions: ["us-east-1", "not-a-region"] });
+    expect(errors.some((e) => e.includes("not-a-region"))).toBe(true);
+  });
+
+  it("should reject when defaultRegion is not in declared supportedRegions", () => {
+    const errors = checkRegionConsistency({
+      defaultRegion: "ap-northeast-1",
+      supportedRegions: ["us-east-1", "us-west-2"],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("ap-northeast-1");
+    expect(errors[0]).toContain("supportedRegions");
+  });
+
+  it("should accept when defaultRegion is in declared supportedRegions", () => {
+    expect(
+      checkRegionConsistency({
+        defaultRegion: "us-east-1",
+        supportedRegions: ["us-east-1", "us-west-2"],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/infrastructure/test/tenkacloud-lite-bin.test.ts
+++ b/infrastructure/test/tenkacloud-lite-bin.test.ts
@@ -70,41 +70,54 @@ function buildLiteApp(): cdk.App {
   return app;
 }
 
+function findStack(app: cdk.App, stackName: string): cdk.Stack {
+  const stack = app.node.findAll().find((construct): construct is cdk.Stack => {
+    return construct instanceof cdk.Stack && construct.stackName === stackName;
+  });
+  if (!stack) throw new Error(`stack not found: ${stackName}`);
+  return stack;
+}
+
+function synthLiteFixture() {
+  const app = buildLiteApp();
+  const problemDeployStack = findStack(app, "tenkacloud-lite-problem-deploy");
+  const liteStack = findStack(app, "tenkacloud-lite");
+  const assembly = app.synth();
+  const problemDeployArtifact = assembly.stacks.find(
+    (stack) => stack.stackName === problemDeployStack.stackName,
+  );
+  const liteArtifact = assembly.stacks.find((stack) => stack.stackName === liteStack.stackName);
+  if (!problemDeployArtifact || !liteArtifact) throw new Error("lite synth artifacts are missing");
+  return {
+    assembly,
+    liteStack,
+    problemDeployTemplate: Template.fromJSON(problemDeployArtifact.template),
+    liteTemplate: Template.fromJSON(liteArtifact.template),
+  };
+}
+
 describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
+  // ProblemDeployBackend の NodejsFunction bundling が重いので wiring 一式を 1 度だけ synth する。
+  const fixture = synthLiteFixture();
+
   it("should synth only the 2 stacks `tenkacloud-lite-problem-deploy` + `tenkacloud-lite`", () => {
-    const app = buildLiteApp();
-    const assembly = app.synth();
-    const liteStacks = assembly.stacks.filter((s) => s.stackName.startsWith("tenkacloud-"));
+    const liteStacks = fixture.assembly.stacks.filter((s) => s.stackName.startsWith("tenkacloud-"));
     const names = liteStacks.map((s) => s.stackName).sort();
     expect(names).toEqual(["tenkacloud-lite", "tenkacloud-lite-problem-deploy"]);
-  }, 30_000);
+  });
 
   it("ProblemDeployBackend (Lite mode) should create 1 local EventBus when eventBusArn is omitted", () => {
-    const app = buildLiteApp();
-    const problemDeployStack = app.node
-      .findAll()
-      .find((c) => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite-problem-deploy");
-    expect(problemDeployStack).toBeDefined();
-    const template = Template.fromStack(problemDeployStack as cdk.Stack);
-    template.resourceCountIs("AWS::Events::EventBus", 1);
-  }, 30_000);
+    fixture.problemDeployTemplate.resourceCountIs("AWS::Events::EventBus", 1);
+  });
 
   it("Lite stack side should create 1 set of AppPlaneCore (UserPool + REST API + CloudFront)", () => {
-    const app = buildLiteApp();
-    const liteStack = app.node
-      .findAll()
-      .find((c) => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite");
-    expect(liteStack).toBeDefined();
-    const template = Template.fromStack(liteStack as cdk.Stack);
-    template.resourceCountIs("AWS::Cognito::UserPool", 1);
-    template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
-    template.resourceCountIs("AWS::CloudFront::Distribution", 1);
-  }, 30_000);
+    fixture.liteTemplate.resourceCountIs("AWS::Cognito::UserPool", 1);
+    fixture.liteTemplate.resourceCountIs("AWS::ApiGateway::RestApi", 1);
+    fixture.liteTemplate.resourceCountIs("AWS::CloudFront::Distribution", 1);
+  });
 
   it("Lite stack should not include ControlPlane / Tenant-Pipeline / Bootstrap / AdminConsoleInsight", () => {
-    const app = buildLiteApp();
-    const assembly = app.synth();
-    const stackNames = assembly.stacks.map((s) => s.stackName);
+    const stackNames = fixture.assembly.stacks.map((s) => s.stackName);
     for (const forbidden of [
       "tenkacloud-control-plane",
       "tenkacloud-bootstrap",
@@ -114,19 +127,14 @@ describe("bin/tenkacloud-lite.ts (#778 ADR-016 Phase 5)", () => {
       expect(stackNames).not.toContain(forbidden);
     }
     // ServerlessSaaSPipeline (= CodePipeline) も作らない。
-    const allTemplates = assembly.stacks.map((s) => Template.fromJSON(s.template));
+    const allTemplates = fixture.assembly.stacks.map((s) => Template.fromJSON(s.template));
     for (const template of allTemplates) {
       template.resourceCountIs("AWS::CodePipeline::Pipeline", 0);
     }
-  }, 30_000);
+  });
 
   it("Lite stack should explicitly depend on the ProblemDeploy stack (cross-stack Lambda ref)", () => {
-    const app = buildLiteApp();
-    const liteStack = app.node
-      .findAll()
-      .find((c): c is cdk.Stack => c instanceof cdk.Stack && c.stackName === "tenkacloud-lite");
-    expect(liteStack).toBeDefined();
-    const deps = liteStack?.dependencies.map((d) => d.stackName) ?? [];
+    const deps = fixture.liteStack.dependencies.map((d) => d.stackName);
     expect(deps).toContain("tenkacloud-lite-problem-deploy");
-  }, 30_000);
+  });
 });

--- a/scripts/check-template-cli-access.ts
+++ b/scripts/check-template-cli-access.ts
@@ -89,7 +89,7 @@ export function extractParticipantViewerBlock(yaml: string): string | undefined 
   for (let i = start + 1; i < lines.length; i++) {
     const line = lines[i];
     // 次の Resource (= 2-space indent + Name:) または top-level section に当たったら終端
-    if (/^  [A-Za-z][A-Za-z0-9]*:\s*$/.test(line)) {
+    if (/^ {2}[A-Za-z][A-Za-z0-9]*:\s*$/.test(line)) {
       end = i;
       break;
     }

--- a/scripts/check-template-security.ts
+++ b/scripts/check-template-security.ts
@@ -33,7 +33,7 @@ interface Finding {
 const WEB_PORTS = new Set([80, 443]);
 
 /**
- * AWS API design 上 Resource: "*" を要求する read-only action の allowlist。
+ * AWS API design 上 Resource: "*" を要求する action の allowlist。
  * これらは Resource を絞れず、 IAM policy で `*` を書く以外に手が無い (= AWS-side 制約)。
  * リストに無い action が `*` と組み合わさったら警告。
  */
@@ -80,6 +80,14 @@ const RESOURCE_STAR_OK_ACTIONS = new Set([
   "dynamodb:DescribeTable",
   // STS sanity
   "sts:GetCallerIdentity",
+  // CloudShell participant baseline — sessions are per-identity and have no resource ARN scope.
+  "cloudshell:CreateEnvironment",
+  "cloudshell:CreateSession",
+  "cloudshell:GetEnvironmentStatus",
+  "cloudshell:StartEnvironment",
+  "cloudshell:StopEnvironment",
+  "cloudshell:DeleteEnvironment",
+  "cloudshell:PutCredentials",
 ]);
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -68,6 +68,36 @@ function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
   ];
 }
 
+const REGION_RE = /^[a-z]{2,3}-[a-z]+-\d{1,2}$/;
+
+function checkSupportedRegionsArray(supportedRegions: readonly unknown[]): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (supportedRegions.length === 0) {
+    errors.push(
+      "supportedRegions が空配列です。 宣言するなら 1 件以上指定するか field 自体を省略してください",
+    );
+  }
+  for (const r of supportedRegions) {
+    if (typeof r !== "string" || !REGION_RE.test(r)) {
+      errors.push(
+        `supportedRegions に AWS region 形式でない値が含まれています: ${JSON.stringify(r)}`,
+      );
+    }
+  }
+  return errors;
+}
+
+function checkDefaultRegionInSupported(
+  defaultRegion: string,
+  supportedRegions: readonly unknown[],
+): ValidationError[] {
+  if (!supportedRegions.every((r) => typeof r === "string")) return [];
+  if (supportedRegions.includes(defaultRegion)) return [];
+  return [
+    `defaultRegion="${defaultRegion}" が supportedRegions=${JSON.stringify(supportedRegions)} に含まれていません (= wizard で picker から選べない region を初期値にしている)`,
+  ];
+}
+
 /**
  * Issue #1201 Phase 2: `defaultRegion` / `supportedRegions` の整合性 check。
  *
@@ -80,7 +110,6 @@ function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
  */
 export function checkRegionConsistency(meta: Metadata): ValidationError[] {
   const errors: ValidationError[] = [];
-  const REGION_RE = /^[a-z]{2,3}-[a-z]+-\d{1,2}$/;
   const defaultRegion = typeof meta.defaultRegion === "string" ? meta.defaultRegion : undefined;
   const supportedRegions = Array.isArray(meta.supportedRegions)
     ? (meta.supportedRegions as unknown[])
@@ -92,26 +121,9 @@ export function checkRegionConsistency(meta: Metadata): ValidationError[] {
     );
   }
   if (supportedRegions !== undefined) {
-    if (supportedRegions.length === 0) {
-      errors.push(
-        "supportedRegions が空配列です。 宣言するなら 1 件以上指定するか field 自体を省略してください",
-      );
-    }
-    for (const r of supportedRegions) {
-      if (typeof r !== "string" || !REGION_RE.test(r)) {
-        errors.push(
-          `supportedRegions に AWS region 形式でない値が含まれています: ${JSON.stringify(r)}`,
-        );
-      }
-    }
-    if (
-      defaultRegion !== undefined &&
-      supportedRegions.every((r) => typeof r === "string") &&
-      !supportedRegions.includes(defaultRegion)
-    ) {
-      errors.push(
-        `defaultRegion="${defaultRegion}" が supportedRegions=${JSON.stringify(supportedRegions)} に含まれていません (= wizard で picker から選べない region を初期値にしている)`,
-      );
+    errors.push(...checkSupportedRegionsArray(supportedRegions));
+    if (defaultRegion !== undefined) {
+      errors.push(...checkDefaultRegionInSupported(defaultRegion, supportedRegions));
     }
   }
   return errors;

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -64,7 +64,57 @@ function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
     ...checkScoringOutputRefs(meta, yaml, cfnTemplate),
     ...checkEndpointOutputRefs(meta, yaml, cfnTemplate),
     ...checkDashboardSlotFiles(meta, dir),
+    ...checkRegionConsistency(meta),
   ];
+}
+
+/**
+ * Issue #1201 Phase 2: `defaultRegion` / `supportedRegions` の整合性 check。
+ *
+ *   - 両 field とも AWS region 形式 `^[a-z]{2,3}-[a-z]+-\d+$` であること
+ *   - `defaultRegion` 宣言 + `supportedRegions` 宣言 の場合、 `defaultRegion ∈
+ *     supportedRegions` であること (= wizard が picker から拾えない region に倒れない)
+ *   - `supportedRegions` が空配列のときは 「宣言したのに空」 として reject
+ *
+ * 未宣言 (= optional 未使用) は OK (= 後方互換)。
+ */
+export function checkRegionConsistency(meta: Metadata): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const REGION_RE = /^[a-z]{2,3}-[a-z]+-\d{1,2}$/;
+  const defaultRegion = typeof meta.defaultRegion === "string" ? meta.defaultRegion : undefined;
+  const supportedRegions = Array.isArray(meta.supportedRegions)
+    ? (meta.supportedRegions as unknown[])
+    : undefined;
+
+  if (defaultRegion !== undefined && !REGION_RE.test(defaultRegion)) {
+    errors.push(
+      `defaultRegion="${defaultRegion}" は AWS region 形式と一致しません (例: ap-northeast-1)`,
+    );
+  }
+  if (supportedRegions !== undefined) {
+    if (supportedRegions.length === 0) {
+      errors.push(
+        "supportedRegions が空配列です。 宣言するなら 1 件以上指定するか field 自体を省略してください",
+      );
+    }
+    for (const r of supportedRegions) {
+      if (typeof r !== "string" || !REGION_RE.test(r)) {
+        errors.push(
+          `supportedRegions に AWS region 形式でない値が含まれています: ${JSON.stringify(r)}`,
+        );
+      }
+    }
+    if (
+      defaultRegion !== undefined &&
+      supportedRegions.every((r) => typeof r === "string") &&
+      !supportedRegions.includes(defaultRegion)
+    ) {
+      errors.push(
+        `defaultRegion="${defaultRegion}" が supportedRegions=${JSON.stringify(supportedRegions)} に含まれていません (= wizard で picker から選べない region を初期値にしている)`,
+      );
+    }
+  }
+  return errors;
 }
 
 function checkScoringOutputRefs(


### PR DESCRIPTION
## Summary

Issue #1201 Phase 2 を実装 (= Phase 1 PR #1202 の続き)。 問題作成側が **動作確認済 region** を `supportedRegions` で declare できるようにし、 EventCreate wizard の region picker が宣言された集合だけを選択肢として出す (= 動かない region への misconfig を構造的に防止)。

### 変更点

#### app 側
- `ProblemMetadata` / `ProblemSummary` / `ProblemDetail` に optional `supportedRegions?: string[]` を追加
- 純関数 `resolveRegionOptions(supportedRegions, baseOptions)` を切り出して unit test 可能に。 fail-safe (= 宣言が AWS_REGIONS と 1 件もマッチしない時は base に倒す) を 5 ケースの unit test で pin
- EventCreate `onProblemsChange` で `ProblemRow.supportedRegions` を carry-through、 region picker `Select.options` を `resolveRegionOptions` で絞り込む

#### validator 側
- `scripts/validate-problems.ts` に `checkRegionConsistency` を追加 + 8 ケース unit test:
  - `defaultRegion` / `supportedRegions` の AWS region 形式 (= `[a-z]{2,3}-[a-z]+-\\d+`)
  - 両方宣言された場合の `defaultRegion ∈ supportedRegions` 整合性
  - 空配列 / 未知 region code の reject
  - 未宣言は no-op (= 後方互換)

## Phase 3 (= 別 PR / 別 repo)

- `problems/SCHEMA.json` (TenkaCloudChallenge submodule) に `defaultRegion` / `supportedRegions` を declare し AJV schema check 経由でも保証
- 既存 5 問題の metadata.json に `defaultRegion` / `supportedRegions` を実際に書く
- 100 名規模 (Issue #1196) に向けた team 数 round-robin 分散 (= 同問題でも team 別に region をばらす option)

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit`
- [x] `bun run --filter @TenkaCloud/application-admin-console test` (+5 ケース、 全 pass)
- [x] `bun run --filter @TenkaCloud/infrastructure test test/scripts/validate-problems-region.test.ts` (8 / 8 pass)
- [ ] 手動: EventCreate wizard で `supportedRegions` 宣言済の問題を選択 → 該当 region のみが picker に出る
- [ ] 手動: 未宣言の問題は従来通り全 AWS region から選べる

## Regression analysis

- `supportedRegions` 未宣言の既存 5 問題は従来通り全 AWS region から picker に出る → 動作変化なし
- `resolveRegionOptions` は宣言 0 件 / 全 mismatch / partial match を unit test で pin (= wizard が空 picker で固まる事故を予防)
- `checkRegionConsistency` は未宣言時 no-op なので、 既存 metadata.json に対しては新規 finding 無し (= validate-problems pass 維持)
- SCHEMA.json (submodule) に変更を加えないので、 submodule pointer は無変更

## Physical impact

- **NO-OP infra**: CDK / IAM / DDB に変更なし
- **UPDATE**: `apps/application-admin-console/dist/` bundle (= EventCreate + problems data adapter)
- `scripts/validate-problems.ts` に export 追加 (= API surface 増えるが backward compatible)

Relates #1201 (Phase 2)、 Relates #1196 (scaling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added regional scoping support for problems. The event creation wizard now intelligently filters available regions based on each selected problem's supported regional configuration, restricting region selection to only those that are applicable.

* **Tests & Validation**
  * Added comprehensive validation tests ensuring region configuration consistency and proper option filtering behavior across all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->