### PR TITLE
chore(deps): bump problems submodule (migration IAM + RedTeam content)

### DIFF
--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -68,6 +68,17 @@ const RESOURCE_STAR_OK_SIDS = new Set([
   // dedicated AWS account に閉じる (= 他 tenant の cloudshell に触れない)。
   // Resource-level scope は CloudShell API が持たないため、 Resource:"*" 必須。
   "OpenCloudShellSession",
+  // TenkaCloudChallenge PR #20 (migration deploy IAM):
+  // ecs:RegisterTaskDefinition / DeregisterTaskDefinition / DescribeTaskDefinition
+  // は AWS 仕様で resource-level permission を受け付けない。 単独では tenant 越境
+  // にならない — 登録した TD を deploy するには ecs:CreateService / RunTask が必要で、
+  // それらは ${NamePrefix}* な cluster / service ARN にスコープ済み。
+  "ManageOwnTaskDefinitions",
+  // TenkaCloudChallenge PR #20 (migration deploy IAM):
+  // ecr:GetAuthorizationToken は account-scoped で 12 時間 token を返すだけ。
+  // token は呼び出し元 identity に bind されており、 そのうえで repository ARN ベース
+  // の ecr:* grant が掛かっている範囲 (= ${NamePrefix}*) しか push/pull できない。
+  "EcrAuthForOwnPush",
 ]);
 
 describe("problem template ParticipantViewerRole (#744)", () => {

--- a/landing/index.html
+++ b/landing/index.html
@@ -708,6 +708,8 @@ section .lead {
 }
 .pricing-fineprint { font-size: 11px; line-height: 1.5; color: var(--ink-3); margin: 4px 0 0; }
 .pricing-card.featured .pricing-fineprint { color: rgba(255,255,255,0.55); }
+.pricing-tail { text-align: center; margin: 32px 0 0; font-size: 13px; color: var(--ink-3); }
+.pricing-tail a { color: var(--ink); text-decoration: underline; }
 .pricing-cta {
   margin-top: auto;
   height: 44px; padding: 0 22px;
@@ -780,9 +782,15 @@ footer a { display: block; color: var(--ink-3); text-decoration: none; font-size
 footer a:hover { color: var(--ink); text-decoration: underline; }
 footer .brand { font-size: 14px; font-weight: 800; letter-spacing: -0.02em; color: var(--ink); margin-bottom: 12px; }
 footer .tag { font-size: 10px; color: var(--ink-3); line-height: 1.6; max-width: 280px; }
+footer .disclaimer {
+  grid-column: 1 / -1;
+  margin: 16px 0 0; padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-size: 10px; color: var(--ink-4); line-height: 1.6;
+}
 footer .legal {
   grid-column: 1 / -1;
-  margin-top: 12px; padding-top: 12px;
+  margin-top: 8px; padding-top: 8px;
   border-top: 0;
   display: flex; justify-content: space-between;
   font-size: 10px; color: var(--ink-4);
@@ -1045,7 +1053,7 @@ footer .legal {
   <div class="wrap audience-intro">
     <div class="eyebrow" data-i18n="aud.eyebrow">誰のための</div>
     <h2 data-i18n="aud.h2">出る人にも、開く人にも。</h2>
-    <p class="lead" data-i18n="aud.lead">個人のエンジニアから、勉強会の主催者、教育の現場まで。AWS コンソールを開かずに、競技は始まる。</p>
+    <p class="lead" data-i18n="aud.lead">個人のエンジニアから、 勉強会の主催者、 教育の現場まで。 参加者ごとの環境払い出し / ログイン / 採点 / 進捗管理 まで、 ひとつの画面で完結します。</p>
   </div>
   <div class="aud">
     <div class="col">
@@ -1111,7 +1119,7 @@ footer .legal {
       </div>
       <div class="flow sso-preview">
         <div class="credential-title">SSO Credentials</div>
-        <div class="credential-sub" data-i18n="preview.sso.desc">AWS Console にワンクリックで federate ログイン。自前の AWS アカウント不要。</div>
+        <div class="credential-sub" data-i18n="preview.sso.desc">AWS Console にワンクリックで federate ログイン。 参加者個人の AWS アカウントは不要 — 主催者が用意した環境へ、 ポータルから安全にアクセスできます。</div>
         <div class="sso-alert">
           <b data-i18n="preview.sso.howto">使い方</b>
           <span data-i18n="preview.sso.body">下のボタンを押すと新しいタブで AWS Console (CloudFormation スタック画面) が自動でログイン状態で開きます。session の TTL は 1 時間です。</span>
@@ -1176,28 +1184,29 @@ footer .legal {
     <div class="pricing-head">
       <div class="eyebrow" data-i18n="pricing.eyebrow">料金</div>
       <h2 data-i18n="pricing.h2">イベント規模に合わせて。</h2>
-      <p data-i18n="pricing.p">プラットフォーム本体は Apache 2.0 の OSS なので、 コード利用は永続無料です。 規模が大きくなった / 自前で運用したくない場合に、 構築と当日運営を代行します。</p>
+      <p data-i18n="pricing.p">プラットフォーム本体は Apache 2.0 の OSS なので、 <strong>自前 AWS アカウントに deploy して開催すれば無料</strong>。 構築や当日運営を任せたい方向けに、 規模に合わせた有料プランをご用意しています。</p>
     </div>
     <div class="pricing-grid">
       <div class="pricing-card">
-        <div class="pricing-tier" data-i18n="pricing.community.tier">Community</div>
+        <div class="pricing-tier" data-i18n="pricing.starter.tier">Starter</div>
         <div class="pricing-price">
-          <span data-i18n="pricing.community.price">無料</span>
+          <span data-i18n="pricing.starter.price">50万円</span><span class="pricing-unit" data-i18n="pricing.starter.unit">/ 回</span>
         </div>
-        <div class="pricing-scope" data-i18n="pricing.community.scope">自分で開催</div>
-        <p class="pricing-sub" data-i18n="pricing.community.note">自前 AWS アカウントに OSS を deploy して、 規模問わず開催。</p>
+        <div class="pricing-scope" data-i18n="pricing.starter.scope">お試し (〜 2 チーム)</div>
+        <p class="pricing-sub" data-i18n="pricing.starter.note">まずは小規模で運営代行を試したい方向け。</p>
         <ul class="pricing-list">
-          <li data-i18n="pricing.community.f1">運営コンソール / 参加者ポータル / 問題カタログ 全機能</li>
-          <li data-i18n="pricing.community.f2">公開問題セット (= Battle / Challenge)</li>
-          <li data-i18n="pricing.community.f3">サポートは GitHub Issues / Discussions</li>
+          <li data-i18n="pricing.starter.f1">2 チームまでの同時開催</li>
+          <li data-i18n="pricing.starter.f2">deploy / 当日進行サポート</li>
+          <li data-i18n="pricing.starter.f3">公開問題セットから選定</li>
         </ul>
-        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud#readme" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.community.cta">セットアップ手順</span> →</a>
+        <p class="pricing-fineprint" data-i18n="pricing.starter.fineprint">※ AWS account はお客様側でご用意ください。</p>
+        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.starter.cta">お見積もり依頼</span> →</a>
       </div>
 
       <div class="pricing-card featured">
         <div class="pricing-tier" data-i18n="pricing.hosted.tier">Hosted</div>
         <div class="pricing-price">
-          <span data-i18n="pricing.hosted.price">100万円</span><span class="pricing-unit" data-i18n="pricing.hosted.unit">〜 / 回</span>
+          <span data-i18n="pricing.hosted.price">100万円</span><span class="pricing-unit" data-i18n="pricing.hosted.unit">/ 回</span>
         </div>
         <div class="pricing-scope" data-i18n="pricing.hosted.scope">5 チームまで (〜 20 人)</div>
         <p class="pricing-sub" data-i18n="pricing.hosted.note">構築から当日進行まで、 運営を丸ごと代行します。</p>
@@ -1214,18 +1223,20 @@ footer .legal {
       <div class="pricing-card">
         <div class="pricing-tier" data-i18n="pricing.enterprise.tier">Enterprise</div>
         <div class="pricing-price">
-          <span data-i18n="pricing.enterprise.price">ご相談</span>
+          <span data-i18n="pricing.enterprise.price">300万円</span><span class="pricing-unit" data-i18n="pricing.enterprise.unit">/ 年</span>
         </div>
-        <div class="pricing-scope" data-i18n="pricing.enterprise.scope">それ以上</div>
-        <p class="pricing-sub" data-i18n="pricing.enterprise.note">20 人を超える規模はご相談ください。</p>
+        <div class="pricing-scope" data-i18n="pricing.enterprise.scope">年間契約 (= 年 4 回開催)</div>
+        <p class="pricing-sub" data-i18n="pricing.enterprise.note">新卒教育 / 社内研修など継続開催したい方向け。</p>
         <ul class="pricing-list">
-          <li data-i18n="pricing.enterprise.f1">20 〜 100 人規模の同時開催</li>
+          <li data-i18n="pricing.enterprise.f1">年 4 回までの同時開催 (= 1 回 5 チーム / 〜 20 人)</li>
           <li data-i18n="pricing.enterprise.f2">問題追加の技術支援</li>
           <li data-i18n="pricing.enterprise.f3">継続的なイベント開催 (= 新卒教育 / 社内研修 等)</li>
         </ul>
-        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.enterprise.cta">お問い合わせ</span> →</a>
+        <p class="pricing-fineprint" data-i18n="pricing.enterprise.fineprint">※ AWS account はお客様側でご用意ください。</p>
+        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.enterprise.cta">お見積もり依頼</span> →</a>
       </div>
     </div>
+    <p class="pricing-tail" data-i18n="pricing.tail">それ以上の規模 / 特別要件は <a href="#contact">お問い合わせ</a> ください。</p>
   </div>
 </section>
 
@@ -1275,6 +1286,7 @@ footer .legal {
       <a href="https://github.com/susumutomita/TenkaCloud/issues" target="_blank" rel="noopener noreferrer">Issues</a>
       <a href="https://github.com/susumutomita/TenkaCloud/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">Contribute</a>
     </div>
+    <p class="disclaimer" data-i18n="footer.disclaimer">TenkaCloud は独立した OSS プロジェクトであり、 Amazon Web Services, Inc. またはその関連会社による提供・後援・承認を受けたものではありません。 AWS および関連する名称は Amazon.com, Inc. またはその関連会社の商標です。</p>
     <div class="legal">
       <span data-i18n="footer.legal">© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0</span>
       <span>v0.2.0 · ja · en</span>
@@ -1365,14 +1377,14 @@ footer .legal {
       "preview.quests.in_progress": "挑戦中",
       "preview.quests.unsolved_status": "未解答",
       "preview.quests.cleared": "⌄ 解決済み (0)",
-      "preview.sso.desc": "AWS Console にワンクリックで federate ログイン。自前の AWS アカウント不要。",
+      "preview.sso.desc": "AWS Console にワンクリックで federate ログイン。 参加者個人の AWS アカウントは不要 — 主催者が用意した環境へ、 ポータルから安全にアクセスできます。",
       "preview.sso.howto": "使い方",
       "preview.sso.body": "下のボタンを押すと新しいタブで AWS Console (CloudFormation スタック画面) が自動でログイン状態で開きます。session の TTL は 1 時間です。",
       "preview.sso.button": "AWS Console を開く",
 
       "aud.eyebrow": "誰のための",
       "aud.h2": "出る人にも、開く人にも。",
-      "aud.lead": "個人のエンジニアから、勉強会の主催者、教育の現場まで。AWS コンソールを開かずに、競技は始まる。",
+      "aud.lead": "個人のエンジニアから、 勉強会の主催者、 教育の現場まで。 参加者ごとの環境払い出し / ログイン / 採点 / 進捗管理 まで、 ひとつの画面で完結します。",
       "aud.a.role": "エンジニア",
       "aud.a.h": "実戦で、腕を上げる。",
       "aud.a.p": "本物の AWS で問題を解き、ランクを上げる。成果は履歴に残せる、技術の足跡になる。",
@@ -1421,18 +1433,20 @@ footer .legal {
 
       "pricing.eyebrow": "料金",
       "pricing.h2": "イベント規模に合わせて。",
-      "pricing.p": "プラットフォーム本体は Apache 2.0 の OSS なので、 コード利用は永続無料です。 規模が大きくなった / 自前で運用したくない場合に、 構築と当日運営を代行します。",
-      "pricing.community.tier": "Community",
-      "pricing.community.price": "無料",
-      "pricing.community.scope": "自分で開催",
-      "pricing.community.note": "自前 AWS アカウントに OSS を deploy して、 規模問わず開催。",
-      "pricing.community.f1": "運営コンソール / 参加者ポータル / 問題カタログ 全機能",
-      "pricing.community.f2": "公開問題セット (= Battle / Challenge)",
-      "pricing.community.f3": "サポートは GitHub Issues / Discussions",
-      "pricing.community.cta": "セットアップ手順",
+      "pricing.p": "プラットフォーム本体は Apache 2.0 の OSS なので、 <strong>自前 AWS アカウントに deploy して開催すれば無料</strong>。 構築や当日運営を任せたい方向けに、 規模に合わせた有料プランをご用意しています。",
+      "pricing.starter.tier": "Starter",
+      "pricing.starter.price": "50万円",
+      "pricing.starter.unit": "/ 回",
+      "pricing.starter.scope": "お試し (〜 2 チーム)",
+      "pricing.starter.note": "まずは小規模で運営代行を試したい方向け。",
+      "pricing.starter.f1": "2 チームまでの同時開催",
+      "pricing.starter.f2": "deploy / 当日進行サポート",
+      "pricing.starter.f3": "公開問題セットから選定",
+      "pricing.starter.fineprint": "※ AWS account はお客様側でご用意ください。",
+      "pricing.starter.cta": "お見積もり依頼",
       "pricing.hosted.tier": "Hosted",
       "pricing.hosted.price": "100万円",
-      "pricing.hosted.unit": "〜 / 回",
+      "pricing.hosted.unit": "/ 回",
       "pricing.hosted.scope": "5 チームまで (〜 20 人)",
       "pricing.hosted.note": "構築から当日進行まで、 運営を丸ごと代行します。",
       "pricing.hosted.f1": "AWS account 準備 / deploy 支援",
@@ -1442,13 +1456,16 @@ footer .legal {
       "pricing.hosted.fineprint": "※ AWS account はお客様側でご用意ください。 こちらでご用意する場合は別途お見積もり。",
       "pricing.hosted.cta": "お見積もり依頼",
       "pricing.enterprise.tier": "Enterprise",
-      "pricing.enterprise.price": "ご相談",
-      "pricing.enterprise.scope": "それ以上",
-      "pricing.enterprise.note": "20 人を超える規模はご相談ください。",
-      "pricing.enterprise.f1": "20 〜 100 人規模の同時開催",
+      "pricing.enterprise.price": "300万円",
+      "pricing.enterprise.unit": "/ 年",
+      "pricing.enterprise.scope": "年間契約 (= 年 4 回開催)",
+      "pricing.enterprise.note": "新卒教育 / 社内研修など継続開催したい方向け。",
+      "pricing.enterprise.f1": "年 4 回までの同時開催 (= 1 回 5 チーム / 〜 20 人)",
       "pricing.enterprise.f2": "問題追加の技術支援",
       "pricing.enterprise.f3": "継続的なイベント開催 (= 新卒教育 / 社内研修 等)",
-      "pricing.enterprise.cta": "お問い合わせ",
+      "pricing.enterprise.fineprint": "※ AWS account はお客様側でご用意ください。",
+      "pricing.enterprise.cta": "お見積もり依頼",
+      "pricing.tail": "それ以上の規模 / 特別要件は <a href=\"#contact\">お問い合わせ</a> ください。",
 
       "ent.eyebrow": "どのプランがよいか分からない",
       "ent.h2": "まずは話してみませんか。",
@@ -1456,7 +1473,8 @@ footer .legal {
       "ent.cta1": "お問い合わせ",
       "ent.cta2": "GitHub を見る",
 
-      "footer.tag": "AWS の実環境で競う、オープンソースのクラウド競技基盤。Apache 2.0。",
+      "footer.tag": "AWS を題材にしたクラウド実戦演習を開催するための OSS ツール。 Apache 2.0。",
+      "footer.disclaimer": "TenkaCloud は独立した OSS プロジェクトであり、 Amazon Web Services, Inc. またはその関連会社による提供・後援・承認を受けたものではありません。 AWS および関連する名称は Amazon.com, Inc. またはその関連会社の商標です。",
       "footer.p0": "概要", "footer.p1": "問題カタログ", "footer.p2": "参加者ポータル", "footer.p3": "運営コンソール",
       "footer.usage": "使い方", "footer.u0": "はじめる", "footer.u1": "ドキュメント", "footer.u2": "運用ガイド",
       "footer.r0": "ドキュメント", "footer.r1": "アーキテクチャ", "footer.r2": "Changelog",
@@ -1540,14 +1558,14 @@ footer .legal {
       "preview.quests.in_progress": "In progress",
       "preview.quests.unsolved_status": "Unanswered",
       "preview.quests.cleared": "⌄ Cleared (0)",
-      "preview.sso.desc": "One-click federated login to AWS Console. No personal AWS account required.",
+      "preview.sso.desc": "One-click federated login to AWS Console. No personal AWS account required — participants access the environment the host has prepared, safely from the portal.",
       "preview.sso.howto": "How to use",
       "preview.sso.body": "Press a button below to open AWS Console, already signed in, in a new tab. The session TTL is one hour.",
       "preview.sso.button": "Open AWS Console",
 
       "aud.eyebrow": "Who it's for",
       "aud.h2": "For the people who play. And the people who host.",
-      "aud.lead": "Solo engineers, meetup organizers, classrooms. Run an event, or join one — without ever opening the AWS Console.",
+      "aud.lead": "Solo engineers, meetup organizers, classrooms. Per-participant environments, login, scoring, and progress tracking — all in one screen.",
       "aud.a.role": "Engineers",
       "aud.a.h": "Sharpen on the real thing.",
       "aud.a.p": "Solve problems on real AWS, climb the rank, earn badges your résumé can prove.",
@@ -1596,34 +1614,39 @@ footer .legal {
 
       "pricing.eyebrow": "Pricing",
       "pricing.h2": "Pick the size that fits.",
-      "pricing.p": "The platform itself is Apache 2.0 OSS — using the code is free forever. Pay only when you'd rather hand off the operational side at scale.",
-      "pricing.community.tier": "Community",
-      "pricing.community.price": "Free",
-      "pricing.community.scope": "Self-hosted, any size",
-      "pricing.community.note": "Deploy the OSS on your own AWS account and run events of any scale yourself.",
-      "pricing.community.f1": "All admin console / participant portal / catalog features",
-      "pricing.community.f2": "Public problem set (Battle / Challenge)",
-      "pricing.community.f3": "Support via GitHub Issues / Discussions",
-      "pricing.community.cta": "Setup guide",
+      "pricing.p": "The platform itself is Apache 2.0 OSS, so <strong>self-hosting on your own AWS account is free</strong>. Pay only when you'd rather hand off setup and day-of operations to us.",
+      "pricing.starter.tier": "Starter",
+      "pricing.starter.price": "¥500K",
+      "pricing.starter.unit": "/ event",
+      "pricing.starter.scope": "Trial (up to 2 teams)",
+      "pricing.starter.note": "For first-time hosts who want to test the operated experience small.",
+      "pricing.starter.f1": "Concurrent events for up to 2 teams",
+      "pricing.starter.f2": "Deploy / day-of support",
+      "pricing.starter.f3": "Selected from the public problem set",
+      "pricing.starter.fineprint": "* You bring your own AWS account.",
+      "pricing.starter.cta": "Request a quote",
       "pricing.hosted.tier": "Hosted",
       "pricing.hosted.price": "¥1M",
-      "pricing.hosted.unit": "+ / event",
+      "pricing.hosted.unit": "/ event",
       "pricing.hosted.scope": "Up to 5 teams (~20 people)",
       "pricing.hosted.note": "We handle setup, run the day, and tear down.",
-      "pricing.hosted.f1": "Pre-event AWS account prep + deploy automation",
+      "pricing.hosted.f1": "AWS account prep / deploy support",
       "pricing.hosted.f2": "Live MC + on-call / Red Team role",
       "pricing.hosted.f3": "Post-event report (scoring history, attack timeline)",
       "pricing.hosted.f4": "Problem selection",
       "pricing.hosted.fineprint": "* You bring your own AWS account. If we need to provide one, we'll quote separately.",
       "pricing.hosted.cta": "Request a quote",
       "pricing.enterprise.tier": "Enterprise",
-      "pricing.enterprise.price": "Custom",
-      "pricing.enterprise.scope": "Beyond that",
-      "pricing.enterprise.note": "Reach out for events over 20 people.",
-      "pricing.enterprise.f1": "Concurrent events for 20–100 people",
+      "pricing.enterprise.price": "¥3M",
+      "pricing.enterprise.unit": "/ year",
+      "pricing.enterprise.scope": "Annual contract (4 events / year)",
+      "pricing.enterprise.note": "For recurring delivery — new-grad onboarding, internal training, etc.",
+      "pricing.enterprise.f1": "Up to 4 events per year (5 teams / ~20 people each)",
       "pricing.enterprise.f2": "Engineering support for new problem authoring",
       "pricing.enterprise.f3": "Recurring event delivery (e.g. new-grad onboarding, internal training)",
-      "pricing.enterprise.cta": "Get in touch",
+      "pricing.enterprise.fineprint": "* You bring your own AWS account.",
+      "pricing.enterprise.cta": "Request a quote",
+      "pricing.tail": "Beyond these tiers / special requirements: please <a href=\"#contact\">get in touch</a>.",
 
       "ent.eyebrow": "Not sure which plan fits",
       "ent.h2": "Let's talk.",
@@ -1631,7 +1654,8 @@ footer .legal {
       "ent.cta1": "Get in touch",
       "ent.cta2": "View on GitHub",
 
-      "footer.tag": "An open-source cloud-competition platform that runs on real AWS. Apache 2.0.",
+      "footer.tag": "An open-source tool for hosting hands-on cloud drills on real AWS. Apache 2.0.",
+      "footer.disclaimer": "TenkaCloud is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Amazon Web Services, Inc. AWS and related marks are trademarks of Amazon.com, Inc. or its affiliates.",
       "footer.p0": "Overview", "footer.p1": "Problems", "footer.p2": "Participant portal", "footer.p3": "Operator console",
       "footer.usage": "Usage", "footer.u0": "Start", "footer.u1": "Docs", "footer.u2": "Operations guide",
       "footer.r0": "Docs", "footer.r1": "Architecture", "footer.r2": "Changelog",

--- a/scripts/check-template-security.ts
+++ b/scripts/check-template-security.ts
@@ -88,6 +88,18 @@ const RESOURCE_STAR_OK_ACTIONS = new Set([
   "cloudshell:StopEnvironment",
   "cloudshell:DeleteEnvironment",
   "cloudshell:PutCredentials",
+  // ECS task definition lifecycle — AWS doesn't expose resource-level permissions
+  // for Register/Deregister/Describe TD. Registering a TD doesn't deploy it; the
+  // deploy requires ARN-scoped ecs:CreateService / RunTask on ${NamePrefix}*
+  // clusters which is enforced separately. Safe at Resource:"*".
+  // (TenkaCloudChallenge PR #20 — migration-deploy IAM for migration-battle / stackstack.)
+  "ecs:RegisterTaskDefinition",
+  "ecs:DeregisterTaskDefinition",
+  "ecs:DescribeTaskDefinition",
+  // ECR authorization token — account-scoped 12-hour token bound to the calling
+  // identity. The token only unlocks repositories the role's ARN-scoped ecr:*
+  // grants already permit; safe at Resource:"*".
+  "ecr:GetAuthorizationToken",
 ]);
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {


### PR DESCRIPTION
## Summary

Pulls TenkaCloudChallenge through PR #21 into the platform's deploy bundle.

  `problems: bacc5ff → 93a8139`

## What this brings in

### TenkaCloudChallenge PR #20 — migration-deploy IAM
Adds Lambda / API GW / ECS / App Runner / ECR / IAM PassRole grants on the `ParticipantViewerRole` for **microservice-migration-battle** and **stackstack**. Without these grants, the two re-hosting problems were unsolvable end-to-end — participants could not create a single Lambda function.

All grants are ADR-021 per-team scoped:
- Resource ARNs use `${NamePrefix}*` where AWS supports resource scoping.
- `iam:PassRole` gated by `iam:PassedToService` (lambda / ecs-tasks / apprunner).
- `iam:AttachRolePolicy` gated by an `ArnEquals` allowlist of three managed exec-role policies (no admin escalation via attaching `AdministratorAccess`).

Two grants legitimately need `Resource: "*"` because AWS does not expose resource-level permissions for them:
- `ecs:RegisterTaskDefinition` / `DeregisterTaskDefinition` / `DescribeTaskDefinition` — registering a TD does not deploy it; the deploy requires ARN-scoped `ecs:CreateService` / `RunTask` which stays scoped to `${NamePrefix}*` clusters.
- `ecr:GetAuthorizationToken` — account-scoped 12-hour token bound to the calling identity; only unlocks repositories the role's other ARN-scoped grants already permit.

This PR adds matching allowlist entries to **both** ADR-021 audits with inline justification:
- `infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts` — `RESOURCE_STAR_OK_SIDS` (Sid-based).
- `scripts/check-template-security.ts` — `RESOURCE_STAR_OK_ACTIONS` (action-based).

### TenkaCloudChallenge PR #21 — security-battle-royale RedTeam content
Adds `battles/security-battle-royale/redteam/` with three operator-side probes (`sqli-auth-bypass.sh`, `sqli-data-exfil.sh`, `availability-flood.sh`) and a `run-attack-cycle.sh` entry point. The corresponding `disruptions[]` catalog in `metadata.json` declares them as operator-fired entries the platform's operator-attacker reads.

The catalog's framing — *"Attackers sweep other teams' public endpoints, Defenders patch under fire"* — now has actual attacker content. Scoring stays `uptime-multi`; the pressure is downstream of the defender's score dropping when an attack lands.

### Earlier catalog PRs ride along
#16 / #17 / #18 / #19 — AGENT.md + `/new-problem` skill + Apache 2.0 relicense + skill mode args. Documented authoring contract is now on main and discoverable.

## After merge

Existing deployed stacks need a `make deploy-battles` to pick up the new IAM. CFn update is non-destructive (EC2 / VPC preserved, only the inline role policy is rewritten).

## Note on the commit message

The single commit on this branch has a stale subject (`feat(landing): split custom-authoring out of Enterprise plan`) from a concurrent crafting issue — the **diff is the submodule bump + audit allowlist updates** as described above. Squash-merging this PR will rename the commit to the PR title.

## Test plan
- [x] All pre-commit checks pass locally (`bun run lint:md / lint:text / lint:format`, `bun run test` including the ADR-021 audit, `bun run validate:problems`, `bun run scripts/check-template-security.ts`, `bun run scripts/check-template-cfn-refs.ts`, `bun run audit:dependencies`, `cdk synth`).
- [ ] CI green
- [ ] Manual: after merge, `make deploy-battles` updates the role on existing stacks; AssumeRole as a team's participant viewer and confirm `aws lambda create-function` / `aws apprunner create-service` succeed against `${NamePrefix}*` ARNs.