### PR TITLE
feat(deploy-handler): 7-day TTL refresh on terminal status (Closes #1200)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -1,5 +1,6 @@
 import { GetCommand, UpdateCommand, type UpdateCommandInput } from "@aws-sdk/lib-dynamodb";
 import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
+import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
   type DeployDeleteRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
@@ -59,7 +60,7 @@ export async function requestTeardown(
   }
 
   const updatedAt = new Date(nowMs).toISOString();
-  const transition = await transitionTeardownToDeleting(shared, tenantId, jobId, updatedAt);
+  const transition = await transitionTeardownToDeleting(shared, tenantId, jobId, updatedAt, nowMs);
   if (transition) return transition;
 
   // Phase 2.2 (Issue #459): delete も cross-account 化。verified=true 行が見つかった
@@ -105,10 +106,11 @@ async function transitionTeardownToDeleting(
   tenantId: string,
   jobId: string,
   updatedAt: string,
+  nowMs: number,
 ): Promise<Extract<TeardownOutcome, { kind: "race" }> | undefined> {
   try {
     await shared.ddb.send(
-      new UpdateCommand(buildTeardownUpdate(shared, tenantId, jobId, updatedAt)),
+      new UpdateCommand(buildTeardownUpdate(shared, tenantId, jobId, updatedAt, nowMs)),
     );
     return undefined;
   } catch (err) {
@@ -124,11 +126,15 @@ function buildTeardownUpdate(
   tenantId: string,
   jobId: string,
   updatedAt: string,
+  nowMs: number,
 ): UpdateCommandInput {
   return {
     TableName: shared.tableName,
     Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
-    UpdateExpression: "SET #s = :deleting, updatedAt = :updatedAt",
+    // Issue #1200: DELETING に遷移したタイミングで expiresAt を 7 日 retention に refresh する
+    // (= teardown が成功して DELETED に最終遷移するまでに competition session TTL (8h) が
+    // 切れて DDB から消える事故を防ぐ。 DELETING 中の audit trail を保護する)。
+    UpdateExpression: "SET #s = :deleting, updatedAt = :updatedAt, expiresAt = :expiresAt",
     ConditionExpression: "tenantId = :tenantId AND #s IN (:p, :i, :c, :f)",
     ExpressionAttributeNames: { "#s": "status" },
     ExpressionAttributeValues: {
@@ -139,6 +145,7 @@ function buildTeardownUpdate(
       ":i": "IN_PROGRESS",
       ":c": "COMPLETE",
       ":f": "FAILED",
+      ":expiresAt": deploymentTerminalExpiresAt(nowMs),
     },
   };
 }
@@ -175,7 +182,9 @@ async function compensateFailedTeardownPublish(
       new UpdateCommand({
         TableName: shared.tableName,
         Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
-        UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+        // Issue #1200: FAILED 化のタイミングで expiresAt を 7 日 retention に refresh。
+        UpdateExpression:
+          "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason, expiresAt = :expiresAt",
         ConditionExpression: "tenantId = :tenantId AND #s = :deleting",
         ExpressionAttributeNames: { "#s": "status" },
         ExpressionAttributeValues: {
@@ -184,6 +193,7 @@ async function compensateFailedTeardownPublish(
           ":updatedAt": new Date(nowMs).toISOString(),
           ":reason": "Failed to publish DeployDeleteRequested event",
           ":tenantId": tenantId,
+          ":expiresAt": deploymentTerminalExpiresAt(nowMs),
         },
       }),
     );

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -6,6 +6,7 @@ import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
 import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
+import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
   type DeployCreateRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
@@ -222,7 +223,10 @@ export async function startDeployment(
         new UpdateCommand({
           TableName: ctx.tableName,
           Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
-          UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+          // Issue #1200: FAILED terminal 化のタイミングで expiresAt を 7 日 retention に
+          // refresh する (= 旧来 create 時の 8h session TTL を上書きし、 audit 履歴を 7 日残す)。
+          UpdateExpression:
+            "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason, expiresAt = :expiresAt",
           // #872: compensation 経路に tenantId condition (= 直前 PutItem 自身が item.tenantId を
           // 書いているので transitively 一致するが、 write レベルで明示する defense-in-depth)。
           ConditionExpression: "tenantId = :tenantId AND #s = :pending",
@@ -233,6 +237,7 @@ export async function startDeployment(
             ":updatedAt": new Date(ctx.now()).toISOString(),
             ":reason": "Failed to publish DeployCreateRequested event",
             ":tenantId": item.tenantId,
+            ":expiresAt": deploymentTerminalExpiresAt(ctx.now()),
           },
         }),
       );

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/retry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/retry.ts
@@ -1,5 +1,6 @@
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { ULID_RE as JOB_ID_RE } from "../shared/constants.js";
+import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
   type DeployCreateRequestedDetail,
   EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
@@ -234,7 +235,9 @@ async function compensateRetryPublishFailure(
       new UpdateCommand({
         TableName: shared.tableName,
         Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
-        UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+        // Issue #1200: FAILED terminal 化のタイミングで expiresAt を 7 日 retention に refresh。
+        UpdateExpression:
+          "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason, expiresAt = :expiresAt",
         ConditionExpression: "#s = :pending AND tenantId = :tenantId",
         ExpressionAttributeNames: { "#s": "status" },
         ExpressionAttributeValues: {
@@ -243,6 +246,7 @@ async function compensateRetryPublishFailure(
           ":updatedAt": new Date(now()).toISOString(),
           ":reason": "Failed to re-publish DeployCreateRequested event during retry",
           ":tenantId": tenantId,
+          ":expiresAt": deploymentTerminalExpiresAt(now()),
         },
       }),
     );

--- a/infrastructure/lib/problem-deploy/handlers/shared/deployment-retention.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/deployment-retention.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #1200: Deployments テーブルの retention 設計。
+ *
+ * 旧来:
+ *   - `deploy-handler/deploy.ts` が create 時に `expiresAt = now + 8h` (= competition
+ *     session TTL) を SET していた。
+ *   - 8 時間後に DDB TTL が行を sweep するため、 翌日には audit 履歴が全部消える。
+ *   - operator が deploy 失敗の事後解析や 「先週の event のレビュー」 をしようとしても
+ *     行が無い、 という UX 問題があった。
+ *
+ * 新 (= 本 helper の役割):
+ *   - **terminal 化** (= COMPLETE / FAILED / DELETED / DELETING / EXPIRED / AUTO_DELETED)
+ *     した時点で `expiresAt = now + 7 days` に refresh する。
+ *   - これにより 「terminal 化してから 7 日間は audit 履歴が残る」 を保証。
+ *   - terminal でない (= PENDING / IN_PROGRESS) は短い session TTL のまま (= 競技中の
+ *     行が放置されて長期肥大化するのを防ぐ)。
+ *
+ * DDB TTL feature でバックグラウンド sweep されるため、 Lambda / Cron は不要 (= cost-zero
+ * 原則に整合)。 厳密 7 日 + α (= DDB の挙動上 数時間遅延あり、 規約上 OK)。
+ *
+ * 注意:
+ *   - Step Functions 側で `Items.UpdateItem` を発行する terminal transition (= CFn 完了
+ *     を polling して COMPLETE / DELETED を書く path) は本 helper を呼ばない CDK 領域。
+ *     現状は create 時の `expiresAt = now + 7d` (= bulk-deploy.ts) が retention 役を
+ *     兼ねており、 大半の deploy が 24h 以内に terminal 化することから 約 6-7 日 の
+ *     post-terminal retention を実効で得ている。 厳密に 「terminal 化から 7 日」 に
+ *     合わせたい場合は CDK の state machine 末端タスクで `expiresAt` を SET する step を
+ *     入れる (= follow-up、 user 領域)。
+ */
+const DEPLOYMENT_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * terminal status に遷移した行に SET すべき `expiresAt` (= DDB TTL attribute 値、 epoch
+ * seconds) を返す。 呼び元の UpdateItemCommand の UpdateExpression に
+ * `, expiresAt = :expiresAt` を追加し、 ExpressionAttributeValues で本値を渡す。
+ */
+export function deploymentTerminalExpiresAt(nowMs: number): number {
+  return Math.floor((nowMs + DEPLOYMENT_TERMINAL_RETENTION_MS) / 1000);
+}

--- a/infrastructure/test/problem-deploy/deployment-retention.test.ts
+++ b/infrastructure/test/problem-deploy/deployment-retention.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { deploymentTerminalExpiresAt } from "../../lib/problem-deploy/handlers/shared/deployment-retention.js";
+
+/**
+ * Issue #1200: Deployments 行が terminal 化したタイミングで `expiresAt` を 7 日先に
+ * refresh する helper のテスト。 caller (= deploy-handler/{deploy,retry,delete}.ts) が
+ * UpdateItemCommand の `:expiresAt` slot に本値を渡す前提。
+ */
+
+describe("deploymentTerminalExpiresAt", () => {
+  it("should return epoch-seconds 7 days ahead of given nowMs", () => {
+    const nowMs = Date.parse("2026-05-22T19:00:00Z");
+    const expected = Math.floor((nowMs + 7 * 24 * 60 * 60 * 1000) / 1000);
+    expect(deploymentTerminalExpiresAt(nowMs)).toBe(expected);
+  });
+
+  it("should produce an epoch-seconds value (= not milliseconds)", () => {
+    const nowMs = Date.parse("2026-05-22T19:00:00Z");
+    const result = deploymentTerminalExpiresAt(nowMs);
+    // epoch seconds for 2026-05-22 is around 1.7e9, milliseconds would be 1.7e12.
+    expect(result).toBeLessThan(2_000_000_000);
+    expect(result).toBeGreaterThan(1_500_000_000);
+  });
+
+  it("should be monotonic in nowMs (= later now → later expiry)", () => {
+    const t1 = Date.parse("2026-05-22T19:00:00Z");
+    const t2 = t1 + 60 * 1000;
+    expect(deploymentTerminalExpiresAt(t2)).toBeGreaterThan(deploymentTerminalExpiresAt(t1));
+  });
+});


### PR DESCRIPTION
## Summary

Issue #1200 「Deployments 履歴を 7 日 retention で linear growth を止める」 の実装。 旧来 `deploy-handler/deploy.ts` が create 時に `expiresAt = now + 8h` を SET していたため、 8 時間後に DDB TTL が行を sweep し、 翌日には audit 履歴が消えていた。 terminal 化のタイミングで 7 日 retention に refresh する。

## 変更

### `infrastructure/lib/problem-deploy/handlers/shared/deployment-retention.ts` (新規)
- `deploymentTerminalExpiresAt(nowMs)`: 7 日先の epoch-seconds を返す helper。
- 7 日 = `7 * 24 * 60 * 60 * 1000` ms。

### `infrastructure/lib/problem-deploy/handlers/deploy-handler/`
- `deploy.ts`: FAILED 補償 path (= EventBridge publish 失敗時) で `expiresAt` を refresh。
- `retry.ts`: FAILED 補償 path (= retry の再 publish 失敗時) で `expiresAt` を refresh。
- `delete.ts`:
  - `transitionTeardownToDeleting` で DELETING 遷移と同時に `expiresAt` を refresh (= teardown 中に 8h TTL で消える事故を防ぐ)。
  - FAILED 補償 path でも refresh。

### Test
- `infrastructure/test/problem-deploy/deployment-retention.test.ts`: helper 3 case (値範囲 / epoch-seconds 単位 / monotonic 性) — 3/3 pass。
- 既存 deploy / retry / delete テストはシグネチャ拡張部分のみで動作変更なし → 全 pass 維持。

## Step Functions 側について

CFn polling 経由で COMPLETE / DELETED に最終遷移する path は **CDK の state machine 領域** で、 本 PR では触らない。 大半の deploy は 24h 以内に terminal 化するため、 SF 側でも create 時の `expiresAt = now + 7d` (= bulk-deploy.ts) が retention 役を兼ねており、 約 6-7 日 の post-terminal retention を実効で得ている。 厳密に 「terminal 化から 7 日」 にしたい場合は SF 末端タスクに `expiresAt = now + 7d` を SET する step を追加 (follow-up、 user 領域)。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / test 全 pass)
- [x] `deployment-retention.test.ts` (3/3 pass)
- [x] 既存 deploy / retry / delete テスト全 pass
- [ ] 手動: FAILED 遷移後 7 日経過 + 数時間後に DDB から該当行が消える (= DDB TTL の挙動)

## Regression analysis

- 既存の 8h session TTL は **PENDING / IN_PROGRESS で放置された行が 8 時間で消える** という用途を維持。 競技中の行が長期残らない原則は維持。
- terminal 化 した行の `expiresAt` を最大 7 日先まで延長 → DDB TTL の sweep 時刻が後ろにずれる。 monitoring / cost への影響は無視できるレベル (= 1 イベント 100 名 x 5 問 = 500 行 / 7 日)。
- `transitionTeardownToDeleting` のシグネチャに `nowMs` を追加。 同 file 内 caller のみのため、 影響範囲はクローズ。

## Physical impact

- **NO-OP infra**: CDK 変更なし、 DDB schema 変更なし (= `timeToLiveAttribute: "expiresAt"` は既に設定済)、 IAM policy 変更なし。
- **UPDATE Lambda**: `deploy-handler` Lambda の bundle に helper 1 ファイル + 4 caller の UpdateExpression 1 句追加 (= サイズ影響 < 1 KB)。

## Related

問題側 `metadata.json` schema 拡張 (defaultRegion / supportedRegions、 Closes #1201) は別 PR (susumutomita/TenkaCloudChallenge#22) で submodule 側に提出済。

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)