### PR TITLE
feat(portal+landing): playable mock + 50/150/600 pricing + Pages auto-rebuild

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,11 @@ on:
     branches: [main]
     paths:
       - 'landing/**'
+      # 「モックで試す」 動線で配信する participant-portal が rebuild 対象なので、
+      # apps/participant-portal/** の変更でも Pages を再 deploy する。 さもないと
+      # portal demo の fixtures / UI 変更が landing 経由でしか反映されない (= PR #1217
+      # で score events fixture / mock info UX が live に反映されなかった原因)。
+      - 'apps/participant-portal/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/apps/participant-portal/src/auth/dev-mock-fixtures.ts
+++ b/apps/participant-portal/src/auth/dev-mock-fixtures.ts
@@ -44,13 +44,14 @@ export const DEV_MOCK_TEAM_VIEW: ParticipantTeamView = {
         WebsiteEndpoint: "https://demo-tenkacloud-static.s3-website-ap-northeast-1.amazonaws.com/",
       },
       expiresAt: DEPLOY_EXPIRES_AT,
-      score: 800,
-      lastScoredAt: "2026-05-22T13:38:11Z",
-      lastResult: "ok",
+      // 未提出状態でデモを始める (= LP visitor が submit ボタンを押すまでの体験を作る)。
+      // flag が正解になったあとの体験は FlagSubmissionPanel が local state で celebration を
+      // 出すので、 view 側の更新は必須ではない。
+      score: 0,
       scoring: {
         kind: "flag",
         points: 800,
-        flagSubmitted: true,
+        flagSubmitted: false,
       },
       deployLog: { cursor: "", entries: [] },
       createdAt: "2026-05-22T13:00:00Z",

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -224,11 +224,14 @@ export function ProblemPanel({
   apiBaseUrl,
   sessionToken,
   onScored,
+  isMock = false,
 }: {
   problem: ParticipantProblemView;
   apiBaseUrl: string;
   sessionToken: string;
   onScored: () => Promise<void>;
+  /** dev-mock mode: backend を呼ばず submit を local で評価する (= LP 「モックで試す」 用)。 */
+  isMock?: boolean;
 }) {
   const t = useT();
   const now = useNowMs(COUNTDOWN_REFRESH_MS);
@@ -315,6 +318,7 @@ export function ProblemPanel({
             points={flagScoring.points ?? 0}
             hints={flagScoring.hints ?? []}
             onScored={onScored}
+            isMock={isMock}
           />
         )}
         {shouldShowAutoRefreshNote(problem.status) && (

--- a/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
+++ b/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
@@ -29,6 +29,7 @@ export function FlagSubmissionPanel({
   points,
   hints,
   onScored,
+  isMock = false,
 }: {
   apiBaseUrl: string;
   sessionToken: string;
@@ -37,14 +38,24 @@ export function FlagSubmissionPanel({
   points: number;
   hints: readonly ParticipantHintView[];
   onScored: () => Promise<void>;
+  /**
+   * dev-mock mode (= LP の 「モックで試す」 動線)。 true のとき submit を backend に投げず、
+   * local state で 「正解 → celebration」 「不正解 → 減点 + リトライ」 を再現する。
+   * 本物の AWS 環境は無いので flag の中身は問わず、 任意 1 文字以上の入力で OK とする。
+   */
+  isMock?: boolean;
 }) {
   const t = useT();
   const [flag, setFlag] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // dev-mock では submit 後の view refetch が空振りするので、 「celebration を出した
+  // 後は同じ panel で 提出済み 表示にしない」 (= 再度 submit form を出さない) ために
+  // local flag を保持する。
+  const [mockCleared, setMockCleared] = useState(false);
 
-  if (flagSubmitted) {
+  if (flagSubmitted || mockCleared) {
     // audit #6: 既出提出 (= reload した後の表示)。 「事務的 提出済み」 ではなく祝祭的 message。
     return (
       <Alert type="success" header={t("problem_panel.celebrate_header", { points })}>
@@ -60,9 +71,12 @@ export function FlagSubmissionPanel({
     setSubmitError(null);
     setOutcome(null);
     try {
-      const result = await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
+      const result = isMock
+        ? simulateMockFlagSubmit(flag, points)
+        : await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
       setOutcome(result);
-      if (shouldRefreshAfterFlagSubmit(result)) await onScored();
+      if (result.kind === "ok") setMockCleared(true);
+      if (!isMock && shouldRefreshAfterFlagSubmit(result)) await onScored();
     } catch (err) {
       setSubmitError(formatProblemPanelActionError(t, err, "problem_panel.submit_error_prefix"));
     } finally {
@@ -89,11 +103,18 @@ export function FlagSubmissionPanel({
             </Button>
           }
         >
-          <FormField label={t("problem_panel.flag_field_label")}>
+          <FormField
+            label={t("problem_panel.flag_field_label")}
+            description={isMock ? t("problem_panel.flag_mock_hint") : undefined}
+          >
             <Input
               value={flag}
               onChange={(e) => setFlag(e.detail.value)}
-              placeholder={t("problem_panel.flag_placeholder")}
+              placeholder={
+                isMock
+                  ? t("problem_panel.flag_mock_placeholder")
+                  : t("problem_panel.flag_placeholder")
+              }
               disabled={submitting}
             />
           </FormField>
@@ -140,6 +161,47 @@ export function FlagSubmissionPanel({
       )}
     </SpaceBetween>
   );
+}
+
+/**
+ * dev-mock 用 mock flag 検証。 LP visitor が submit 体験を試せるよう、 固定の
+ * 「正解」 文字列 `tenkacloudsample` (case-insensitive、 部分一致) のときに celebration を
+ * 出し、 それ以外は不正解 (= 減点 + リトライ) にする。 placeholder で答えを示唆する。
+ */
+export const MOCK_CORRECT_FLAG = "tenkacloudsample";
+
+/**
+ * Easter eggs. ふざけて submit してくれた visitor へのリワード (= 全部 正解扱い)。
+ *  - `42`               : The Hitchhiker's Guide to the Galaxy
+ *  - `claude`           : 開発で使ってる AI agent への nod
+ *  - `kaizen`           : 改善 = 日本語の karma
+ *  - `tenkadev`         : 開発者専用 dev wink
+ *  - `konnichiwa`       : ja LP visitor 向け hello
+ *  - `tenka`            : 部分マッチで通したいゆるさ
+ */
+const MOCK_EASTER_EGGS: readonly string[] = [
+  "42",
+  "claude",
+  "kaizen",
+  "tenkadev",
+  "konnichiwa",
+  "tenka",
+];
+
+function simulateMockFlagSubmit(flag: string, points: number): SubmitFlagOutcome {
+  const trimmed = flag.trim().toLowerCase();
+  if (trimmed.length === 0) {
+    return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
+  }
+  // `tenkacloudsample` を含むか、 逆に `tenkacloudsample` が入力を含むときも OK
+  // (= ユーザが `tenkacloud` だけ入れても通る、 typo に少し寛容)。
+  if (trimmed.includes(MOCK_CORRECT_FLAG) || MOCK_CORRECT_FLAG.includes(trimmed)) {
+    return { kind: "ok", scoreDelta: points, totalScore: points };
+  }
+  if (MOCK_EASTER_EGGS.some((egg) => trimmed === egg)) {
+    return { kind: "ok", scoreDelta: points, totalScore: points };
+  }
+  return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
 }
 
 function canSubmitFlag(flag: string, submitting: boolean): boolean {

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -67,7 +67,11 @@
     "info_body": "Enter the team-level login key shared by your operator. Per-individual accounts are not created.",
     "field_label": "Team login key",
     "field_description": "Short-lived key issued by the operator at problem deploy time",
-    "field_placeholder": "Key distributed to your team"
+    "field_placeholder": "Key distributed to your team",
+    "mock_info_header": "Demo mode — any string works to sign in",
+    "mock_info_body": "In a real event you would enter the short-lived team login key issued by the operator. This demo has no backend, so anything you type signs you in as a fixed \"Demo Team\" and lets you explore the portal.",
+    "mock_field_description": "Any string is fine for the demo (e.g. demo / abc / aaa). Because there is no backend, the value is not sent to any AWS environment and is only kept in localStorage.",
+    "mock_field_placeholder": "e.g. demo (anything works)"
   },
   "team_setup": {
     "title": "Choose your team name",
@@ -285,6 +289,8 @@
     "submit_button": "Submit flag (+{points} pt)",
     "flag_field_label": "Flag (Stack Output value)",
     "flag_placeholder": "Enter value",
+    "flag_mock_placeholder": "e.g. tenkacloudsample",
+    "flag_mock_hint": "Demo mode — type `tenkacloudsample` to feel the correct-answer celebration (partial matches work too; Easter eggs like `claude` / `42` also count).",
     "ok_alert_header": "🎉 Correct!  +{delta} pt",
     "ok_alert_body": "Congratulations. Your total score is {total} pt.",
     "wrong_with_penalty_header": "Wrong ({delta} pt) — total {total} pt",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -67,7 +67,11 @@
     "info_body": "運営から共有されたチーム単位のログインキーを入力してください。個人ごとのアカウントは作成されません。",
     "field_label": "チームログインキー",
     "field_description": "問題 deploy 時に運営が発行する短命キー",
-    "field_placeholder": "チームに配布されたキー"
+    "field_placeholder": "チームに配布されたキー",
+    "mock_info_header": "これはデモモードです — 任意の文字列でサインインできます",
+    "mock_info_body": "本番のイベントでは、 運営が発行するチームログインキー (= 短命キー) を入力します。 このデモでは backend が無いため、 何でも入力してサインインすれば、 固定の「Demo Team」 として portal の各画面を確認できます。",
+    "mock_field_description": "デモ用なので、 任意の文字列を入れてください (例: demo / abc / aaa)。 backend を経由しないため、 値は AWS 環境にも localStorage 以外にも保存されません。",
+    "mock_field_placeholder": "例: demo (何でも OK)"
   },
   "team_setup": {
     "title": "チーム名を決めよう",
@@ -285,6 +289,8 @@
     "submit_button": "Flag 提出 (+{points} pt)",
     "flag_field_label": "Flag (Stack Output 値)",
     "flag_placeholder": "値を入力",
+    "flag_mock_placeholder": "例: tenkacloudsample",
+    "flag_mock_hint": "デモモードです — `tenkacloudsample` と入力すると正解の体験が出ます (= 部分一致でも OK。 `claude` / `42` 等の Easter egg もあります)。",
     "ok_alert_header": "🎉 正解！  +{delta} pt",
     "ok_alert_body": "おめでとうございます。 合計スコアは {total} pt です。",
     "wrong_with_penalty_header": "不正解 ({delta} pt) — 累計 {total} pt",

--- a/apps/participant-portal/src/pages/Login.tsx
+++ b/apps/participant-portal/src/pages/Login.tsx
@@ -29,6 +29,10 @@ export function LoginPage({ config }: { config: AppConfig }) {
   const [teamLoginKey, setTeamLoginKey] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // LP 「モックで試す」 動線では backend が存在せず login key 文字列 が任意 (= 競技
+  // 主催者が発行する短命キーは無い)。 ユーザーに 「何を入れればいいか分からない」 と
+  // 思わせないために info banner / placeholder / description を dev-mock 用に出し分ける。
+  const isMock = config.mode !== "backend";
 
   // 既ログイン状態で /login に来た場合は home に redirect (= 別 key 黙々上書き防止)。
   // ready=false の間は loadSession の結果待ちで何も決められないので render を保留。
@@ -80,15 +84,25 @@ export function LoginPage({ config }: { config: AppConfig }) {
                 {error}
               </Alert>
             )}
-            <Alert type="info" header={t("login.info_header")}>
-              {t("login.info_body")}
+            <Alert
+              type="info"
+              header={isMock ? t("login.mock_info_header") : t("login.info_header")}
+            >
+              {isMock ? t("login.mock_info_body") : t("login.info_body")}
             </Alert>
-            <FormField label={t("login.field_label")} description={t("login.field_description")}>
+            <FormField
+              label={t("login.field_label")}
+              description={
+                isMock ? t("login.mock_field_description") : t("login.field_description")
+              }
+            >
               <Input
                 value={teamLoginKey}
-                type="password"
+                type={isMock ? "text" : "password"}
                 onChange={({ detail }) => setTeamLoginKey(detail.value)}
-                placeholder={t("login.field_placeholder")}
+                placeholder={
+                  isMock ? t("login.mock_field_placeholder") : t("login.field_placeholder")
+                }
                 disabled={submitting}
               />
             </FormField>

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -149,6 +149,7 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
           apiBaseUrl={config.apiBaseUrl}
           sessionToken={sessionToken ?? ""}
           onScored={refresh}
+          isMock={config.mode !== "backend"}
         />
       )}
 

--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -88,6 +88,17 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
     setSubmitting(true);
     setError(null);
     try {
+      // dev-mock mode: backend が無いので 直接 session を更新する (= localStorage に永続化、
+      // `auth.updateSession` が saveSession を呼ぶ)。 backend mode と同じ UX (= submit 後
+      // home に navigate) を保ち、 「Failed to fetch」 赤エラーを回避する。
+      if (config.mode !== "backend") {
+        auth.updateSession({
+          teamName: draft.trimmed,
+          teamNameSetByCompetitor: true,
+        });
+        navigate("/");
+        return;
+      }
       const view = await updateTeamName(
         config.apiBaseUrl,
         auth.session.sessionToken,

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -62,7 +62,7 @@ describe("App", () => {
       const user = userEvent.setup();
       renderApp("/login");
 
-      const input = screen.getByPlaceholderText("チームに配布されたキー");
+      const input = screen.getByPlaceholderText("例: demo (何でも OK)");
       await user.type(input, "ABCDEF1234");
 
       const button = await screen.findByRole("button", { name: "サインイン" });
@@ -82,7 +82,7 @@ describe("App", () => {
       const user = userEvent.setup();
       // 1 度ログインして session を作る
       const { unmount } = renderApp("/login");
-      const input = screen.getByPlaceholderText("チームに配布されたキー");
+      const input = screen.getByPlaceholderText("例: demo (何でも OK)");
       await user.type(input, "TEAM-A-KEY");
       await user.click(await screen.findByRole("button", { name: "サインイン" }));
       await screen.findByRole("heading", { level: 1, name: /ようこそ/ });

--- a/landing/index.html
+++ b/landing/index.html
@@ -1240,7 +1240,7 @@ footer .legal {
       <div class="pricing-card featured">
         <div class="pricing-tier" data-i18n="pricing.hosted.tier">Hosted</div>
         <div class="pricing-price">
-          <span data-i18n="pricing.hosted.price">100万円</span><span class="pricing-unit" data-i18n="pricing.hosted.unit">/ 回</span>
+          <span data-i18n="pricing.hosted.price">150万円</span><span class="pricing-unit" data-i18n="pricing.hosted.unit">/ 回</span>
         </div>
         <div class="pricing-scope" data-i18n="pricing.hosted.scope">5 チームまで (〜 20 人)</div>
         <p class="pricing-sub" data-i18n="pricing.hosted.note">構築から当日進行まで、 運営を丸ごと代行します。</p>
@@ -1257,14 +1257,14 @@ footer .legal {
       <div class="pricing-card">
         <div class="pricing-tier" data-i18n="pricing.enterprise.tier">Annual Arena</div>
         <div class="pricing-price">
-          <span data-i18n="pricing.enterprise.price">600万円</span><span class="pricing-unit" data-i18n="pricing.enterprise.unit">〜 / 年</span>
+          <span data-i18n="pricing.enterprise.price">600万円</span><span class="pricing-unit" data-i18n="pricing.enterprise.unit">/ 年</span>
         </div>
         <div class="pricing-scope" data-i18n="pricing.enterprise.scope">年間契約 (= 「社内の演習基盤」 として継続運用)</div>
         <p class="pricing-sub" data-i18n="pricing.enterprise.note">新卒教育 / 内製化推進 / CCoE プログラムなど、 単発でなく <strong>常設の演習場</strong> として運用したい組織向け。</p>
         <ul class="pricing-list">
           <li data-i18n="pricing.enterprise.f1">複数開催 (= 年 4 回、 部門別 / 期別)</li>
-          <li data-i18n="pricing.enterprise.f2">問題セットの roadmap 提案 + facilitator 向け運営手順</li>
-          <li data-i18n="pricing.enterprise.f3">事後レポーティング (= 採点履歴 / 受講者進捗 / 攻撃可視化)</li>
+          <li data-i18n="pricing.enterprise.f2">公開問題カタログから 入門 → 中級 → 上級 の learning path 提案 + facilitator 運営手順書テンプレート</li>
+          <li data-i18n="pricing.enterprise.f3">事後レポート PDF (= portal の採点履歴 / チーム別進捗 / 攻撃可視化 を整理、 1 イベント 1 部)</li>
         </ul>
         <p class="pricing-fineprint" data-i18n="pricing.enterprise.fineprint">※ 規模 / 内容に応じて見積もり。 AWS account はお客様側でご用意ください。</p>
         <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.enterprise.cta">プログラム相談</span> →</a>
@@ -1479,7 +1479,7 @@ footer .legal {
       "pricing.starter.fineprint": "※ AWS account はお客様側でご用意ください。",
       "pricing.starter.cta": "お見積もり依頼",
       "pricing.hosted.tier": "Hosted",
-      "pricing.hosted.price": "100万円",
+      "pricing.hosted.price": "150万円",
       "pricing.hosted.unit": "/ 回",
       "pricing.hosted.scope": "1 回 5 チーム (〜 20 人) まで",
       "pricing.hosted.note": "構築から当日進行まで、 単発イベントを 丸ごと運営代行します。",
@@ -1491,12 +1491,12 @@ footer .legal {
       "pricing.hosted.cta": "お見積もり依頼",
       "pricing.enterprise.tier": "Annual Arena",
       "pricing.enterprise.price": "600万円",
-      "pricing.enterprise.unit": "〜 / 年",
+      "pricing.enterprise.unit": "/ 年",
       "pricing.enterprise.scope": "年間契約 (= 「社内の演習基盤」 として継続運用)",
       "pricing.enterprise.note": "新卒教育 / 内製化推進 / CCoE プログラムなど、 単発でなく <strong>常設の演習場</strong> として運用したい組織向け。",
       "pricing.enterprise.f1": "複数開催 (= 年 4 回、 部門別 / 期別)",
-      "pricing.enterprise.f2": "問題セットの roadmap 提案 + facilitator 向け運営手順",
-      "pricing.enterprise.f3": "事後レポーティング (= 採点履歴 / 受講者進捗 / 攻撃可視化)",
+      "pricing.enterprise.f2": "公開問題カタログから 入門 → 中級 → 上級 の learning path 提案 + facilitator 運営手順書テンプレート",
+      "pricing.enterprise.f3": "事後レポート PDF (= portal の採点履歴 / チーム別進捗 / 攻撃可視化 を整理、 1 イベント 1 部)",
       "pricing.enterprise.fineprint": "※ 規模 / 内容に応じて見積もり。 AWS account はお客様側でご用意ください。",
       "pricing.enterprise.cta": "プログラム相談",
       "pricing.tail": "<strong>カスタム問題の追加開発</strong>は要件定義から実装まで通常の受託開発と同じスコープになるため、 別途お見積もりします。 それ以上の規模 / 特別要件も含めて、 <a href=\"#contact\">お問い合わせ</a> ください。",
@@ -1660,7 +1660,7 @@ footer .legal {
       "pricing.starter.fineprint": "* You bring your own AWS account.",
       "pricing.starter.cta": "Request a quote",
       "pricing.hosted.tier": "Hosted Event",
-      "pricing.hosted.price": "¥1M",
+      "pricing.hosted.price": "¥1.5M",
       "pricing.hosted.unit": "/ event",
       "pricing.hosted.scope": "Up to 5 teams / ~20 participants per event",
       "pricing.hosted.note": "We handle setup, run the day, and tear down — one full event, operated.",
@@ -1672,12 +1672,12 @@ footer .legal {
       "pricing.hosted.cta": "Request a quote",
       "pricing.enterprise.tier": "Annual Arena",
       "pricing.enterprise.price": "¥6M",
-      "pricing.enterprise.unit": "+ / year",
+      "pricing.enterprise.unit": "/ year",
       "pricing.enterprise.scope": "Annual contract — your <strong>internal cloud arena</strong>",
       "pricing.enterprise.note": "For organizations running new-grad onboarding, CCoE programs, or platform enablement <strong>as a recurring program</strong>, not a one-off event.",
       "pricing.enterprise.f1": "Up to 4 events per year (by department / cohort)",
-      "pricing.enterprise.f2": "Problem-set roadmap + facilitator enablement materials",
-      "pricing.enterprise.f3": "Program reporting (scoring history, learner progress, attack visibility)",
+      "pricing.enterprise.f2": "Beginner → intermediate → advanced learning path proposal from the public problem catalog + facilitator playbook template",
+      "pricing.enterprise.f3": "Post-event PDF report (= scoring history, team progress, and attack timeline pulled from the portal — one PDF per event)",
       "pricing.enterprise.fineprint": "* Quoted by scope and scale. You bring your own AWS account.",
       "pricing.enterprise.cta": "Talk about a program",
       "pricing.tail": "<strong>Custom problem authoring</strong> follows the same scope as regular software development (requirements → implementation), so we quote it separately. <a href=\"#contact\">Get in touch</a> for that and for anything beyond these tiers.",


### PR DESCRIPTION
## Summary

利用者フィードバックへの 5 件まとめ対応:

1. **CRITICAL**: Pages workflow が `apps/participant-portal/**` を trigger していない (= portal 変更が live に反映されない原因)
2. Pricing **50 / 150 / 600** + features を deliverable-honest に
3. Login 画面 dev-mock guidance (= 「何入れればいい?」 問い合わせを防ぐ)
4. Team name 変更を dev-mock で local 保存に (= 「Failed to fetch」 赤 alert を消す)
5. **Flag submit を interactive に** (= `tenkacloudsample` で celebration + Easter eggs)

## 詳細

### 1. Pages workflow trigger fix

PR #1217 で portal 側の fixture / mock UX を入れたが、 Pages workflow の `paths` が `landing/**` だけだったため portal-demo は古いまま。 `apps/participant-portal/**` も paths に追加し、 portal 変更で都度 rebuild。

### 2. Pricing 50 / 150 / 600 + features honest

| Tier | ja 価格 | en 価格 |
|---|---|---|
| Starter | 50 万円 / 回 | ¥500K / event |
| Hosted Event | **150 万円 / 回** (旧 100) | **¥1.5M / event** (旧 ¥1M) |
| Annual Arena | 600 万円 / 年 (`/ 年` 旧 `〜/年`) | ¥6M / year (`/ year` 旧 `+ / year`) |

**Anchor story**: 「4 × Hosted (150) = 600 と同額。 年間で買えば問題 roadmap + facilitator 資料 + 進捗 reporting が無料で付く」

Features を **deliverable-honest** に:
- 旧 「問題セットの roadmap 提案 + facilitator 向け運営手順」 → 「公開問題カタログから 入門 → 中級 → 上級 の learning path 提案 + facilitator 運営手順書テンプレート」
- 旧 「事後レポーティング (= 採点履歴 / 受講者進捗 / 攻撃可視化)」 → 「事後レポート PDF (= portal の採点履歴 / チーム別進捗 / 攻撃可視化 を整理、 1 イベント 1 部)」

scope を 「公開 catalog 内 ordering / PDF 1 部」 に物理的に限定 → 暴走リクエスト防止。

### 3. Login dev-mock guidance

`config.mode !== "backend"` のとき:
- info banner: 「Demo mode — any string works to sign in」
- placeholder: 「例: demo (何でも OK)」
- description: 「任意の文字列を入れてください。 backend には送られず localStorage だけに保存」
- input type: `password` → `text`

### 4. Team name 変更 dev-mock 対応

`updateTeamName` を呼ばず、 直接 `auth.updateSession({teamName, teamNameSetByCompetitor:true})` で localStorage 保存。 同じ UX (= submit → home navigate)、 「Failed to fetch」 赤 alert 解消。

### 5. Flag submit interactive

fixture を **`flagSubmitted: false / score: 0`** で開始 → submit form が出る。

`FlagSubmissionPanel` に `isMock?: boolean` prop 追加 (= ProblemDetail → ProblemPanel → FlagSubmissionPanel で propagate)。 `isMock` のとき `simulateMockFlagSubmit()`:
- **`tenkacloudsample`** を含む / 含まれる → 正解 (= CelebrationOverlay 紙吹雪 + +800 pt)
- **Easter eggs** (`42` / `claude` / `kaizen` / `tenkadev` / `konnichiwa` / `tenka`) も正解
- それ以外 → 不正解 (= -10 pt、 リトライ可)

placeholder + description で答えを示唆: 「デモモードです — `tenkacloudsample` と入力すると正解の体験が出ます (= 部分一致でも OK。 `claude` / `42` 等の Easter egg もあります)。」

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / 195 portal test 全 pass、 既存 placeholder 期待値を mock 版に追従)
- [ ] 手動 (= Pages merge 後): portal-demo を開いて
  - login info が dev-mock 用 / placeholder 「例: demo (何でも OK)」
  - home: Score / Rank に fixture 値
  - score events: chart + 8 events table
  - problem detail: submit 画面表示 + `tenkacloudsample` で celebration、 `wrong` で不正解
  - team name 変更: 「Failed to fetch」 が出ない
  - SSO Console open: 赤 → info 「モックモードでは開けません」
  - CLI credentials 折り畳み: 発行 button の代わりに info

## Regression analysis

- production (= backend mode) では `isMock` / `mockBlocked` 分岐が dead code (= `if (isBackend) return` ガード + optional prop default false)
- App.test.tsx の placeholder 期待文字列 1 件 (= 4 occurrence) を mock 版に追従
- Pages workflow paths 追加で portal 変更ごとに rebuild → artifact 内容変わらず、 起動頻度のみ増加

## Physical impact

- NO-OP infra
- UPDATE participant-portal Lambda bundle (= dev-mock 分岐 < 6 KB、 backend mode では dead code)
- UPDATE `landing/index.html` (pricing 3 値 + features 表現 + i18n 同期)
- UPDATE `.github/workflows/pages.yml` (paths 追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)