### PR TITLE
docs(landing): drop 「常設の演習場」 framing + fix CTA Japanese 「お見積もりを依頼」

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1092,8 +1092,8 @@ footer .legal {
   <div class="aud">
     <div class="col">
       <div class="role" data-i18n="aud.a.role">CCoE / クラウド人材育成</div>
-      <h3 data-i18n="aud.a.h">研修を、常設の演習場へ。</h3>
-      <p data-i18n="aud.a.p">新卒オンボーディング / 内製化推進 / 部門横断の継続的な AWS 演習を、 同じプラットフォーム上で繰り返し開催できる。 単発ハンズオンから 「社内の演習基盤」 へ。</p>
+      <h3 data-i18n="aud.a.h">研修イベントを、 年に複数回。</h3>
+      <p data-i18n="aud.a.p">新卒オンボーディング / 内製化推進 / 部門横断の AWS 演習を、 同じプラットフォームで 年に複数回 開催できる。 単発ハンズオンから 計画的な 年間プログラム へ。</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="aud.a.more">導入のご相談</span> ›</a>
     </div>
     <div class="col">
@@ -1234,7 +1234,7 @@ footer .legal {
           <li data-i18n="pricing.starter.f3">公開問題セットから選定</li>
         </ul>
         <p class="pricing-fineprint" data-i18n="pricing.starter.fineprint">※ AWS account はお客様側でご用意ください。</p>
-        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.starter.cta">お見積もり依頼</span> →</a>
+        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.starter.cta">お見積もりを依頼</span> →</a>
       </div>
 
       <div class="pricing-card featured">
@@ -1251,7 +1251,7 @@ footer .legal {
           <li data-i18n="pricing.hosted.f4">問題セットの選定</li>
         </ul>
         <p class="pricing-fineprint" data-i18n="pricing.hosted.fineprint">※ AWS account はお客様側でご用意ください。 こちらでご用意する場合は別途お見積もり。</p>
-        <a class="pricing-cta primary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.hosted.cta">お見積もり依頼</span> →</a>
+        <a class="pricing-cta primary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.hosted.cta">お見積もりを依頼</span> →</a>
       </div>
 
       <div class="pricing-card">
@@ -1259,15 +1259,15 @@ footer .legal {
         <div class="pricing-price">
           <span data-i18n="pricing.enterprise.price">600万円</span><span class="pricing-unit" data-i18n="pricing.enterprise.unit">/ 年</span>
         </div>
-        <div class="pricing-scope" data-i18n="pricing.enterprise.scope">年間契約 (= 「社内の演習基盤」 として継続運用)</div>
-        <p class="pricing-sub" data-i18n="pricing.enterprise.note">新卒教育 / 内製化推進 / CCoE プログラムなど、 単発でなく <strong>常設の演習場</strong> として運用したい組織向け。</p>
+        <div class="pricing-scope" data-i18n="pricing.enterprise.scope">年間契約 (= 年 4 回のイベント開催を代行)</div>
+        <p class="pricing-sub" data-i18n="pricing.enterprise.note">新卒教育 / 内製化推進 / CCoE プログラムなど、 同じプラットフォームで <strong>年 4 回イベントを開催したい</strong> 組織向け。</p>
         <ul class="pricing-list">
           <li data-i18n="pricing.enterprise.f1">複数開催 (= 年 4 回、 部門別 / 期別)</li>
           <li data-i18n="pricing.enterprise.f2">公開問題カタログから 入門 → 中級 → 上級 の learning path 提案 + facilitator 運営手順書テンプレート</li>
           <li data-i18n="pricing.enterprise.f3">事後レポート PDF (= portal の採点履歴 / チーム別進捗 / 攻撃可視化 を整理、 1 イベント 1 部)</li>
         </ul>
         <p class="pricing-fineprint" data-i18n="pricing.enterprise.fineprint">※ 規模 / 内容に応じて見積もり。 AWS account はお客様側でご用意ください。</p>
-        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.enterprise.cta">プログラム相談</span> →</a>
+        <a class="pricing-cta secondary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="pricing.enterprise.cta">プログラムについて相談</span> →</a>
       </div>
     </div>
     <p class="pricing-tail" data-i18n="pricing.tail"><strong>カスタム問題の追加開発</strong>は要件定義から実装まで通常の受託開発と同じスコープになるため、 別途お見積もりします。 それ以上の規模 / 特別要件も含めて、 <a href="#contact">お問い合わせ</a> ください。</p>
@@ -1420,8 +1420,8 @@ footer .legal {
       "aud.h2": "クラウド実戦力を、組織で育てる。",
       "aud.lead": "クラウド人材育成 (= CCoE) / Platform / SRE / Security 部門が、 イベント基盤を自前で作らずに ハンズオン AWS 演習 を開催 / 運営できます。 環境払い出し / ログイン / 採点 / 進捗管理 まで、 ひとつの画面で完結。",
       "aud.a.role": "CCoE / クラウド人材育成",
-      "aud.a.h": "研修を、常設の演習場へ。",
-      "aud.a.p": "新卒オンボーディング / 内製化推進 / 部門横断の継続的な AWS 演習を、 同じプラットフォーム上で繰り返し開催できる。 単発ハンズオンから 「社内の演習基盤」 へ。",
+      "aud.a.h": "研修イベントを、 年に複数回。",
+      "aud.a.p": "新卒オンボーディング / 内製化推進 / 部門横断の AWS 演習を、 同じプラットフォームで 年に複数回 開催できる。 単発ハンズオンから 計画的な 年間プログラム へ。",
       "aud.a.more": "導入のご相談",
       "aud.b.role": "Platform / SRE",
       "aud.b.h": "演習設計を、 1 画面で。",
@@ -1466,7 +1466,7 @@ footer .legal {
       "extend.cta2": "new-problem skill",
 
       "pricing.eyebrow": "料金",
-      "pricing.h2": "単発イベントから、 常設の演習場へ。",
+      "pricing.h2": "単発イベントから、 年間プログラムへ。",
       "pricing.p": "プラットフォーム本体は Apache 2.0 の OSS なので、 <strong>自前 AWS アカウントに deploy して開催すれば無料</strong>。 構築や当日運営を任せたい / 継続開催したい方向けに、 規模に合わせた有料プランをご用意しています。",
       "pricing.starter.tier": "Starter",
       "pricing.starter.price": "50万円",
@@ -1477,7 +1477,7 @@ footer .legal {
       "pricing.starter.f2": "deploy / 当日進行サポート",
       "pricing.starter.f3": "公開問題セットから選定",
       "pricing.starter.fineprint": "※ AWS account はお客様側でご用意ください。",
-      "pricing.starter.cta": "お見積もり依頼",
+      "pricing.starter.cta": "お見積もりを依頼",
       "pricing.hosted.tier": "Hosted",
       "pricing.hosted.price": "150万円",
       "pricing.hosted.unit": "/ 回",
@@ -1488,17 +1488,17 @@ footer .legal {
       "pricing.hosted.f3": "事後の振り返りレポート (= 採点履歴 / 攻撃可視化)",
       "pricing.hosted.f4": "問題セットの選定",
       "pricing.hosted.fineprint": "※ AWS account はお客様側でご用意ください。 こちらでご用意する場合は別途お見積もり。",
-      "pricing.hosted.cta": "お見積もり依頼",
+      "pricing.hosted.cta": "お見積もりを依頼",
       "pricing.enterprise.tier": "Annual Arena",
       "pricing.enterprise.price": "600万円",
       "pricing.enterprise.unit": "/ 年",
-      "pricing.enterprise.scope": "年間契約 (= 「社内の演習基盤」 として継続運用)",
-      "pricing.enterprise.note": "新卒教育 / 内製化推進 / CCoE プログラムなど、 単発でなく <strong>常設の演習場</strong> として運用したい組織向け。",
+      "pricing.enterprise.scope": "年間契約 (= 年 4 回のイベント開催を代行)",
+      "pricing.enterprise.note": "新卒教育 / 内製化推進 / CCoE プログラムなど、 同じプラットフォームで <strong>年 4 回イベントを開催したい</strong> 組織向け。",
       "pricing.enterprise.f1": "複数開催 (= 年 4 回、 部門別 / 期別)",
       "pricing.enterprise.f2": "公開問題カタログから 入門 → 中級 → 上級 の learning path 提案 + facilitator 運営手順書テンプレート",
       "pricing.enterprise.f3": "事後レポート PDF (= portal の採点履歴 / チーム別進捗 / 攻撃可視化 を整理、 1 イベント 1 部)",
       "pricing.enterprise.fineprint": "※ 規模 / 内容に応じて見積もり。 AWS account はお客様側でご用意ください。",
-      "pricing.enterprise.cta": "プログラム相談",
+      "pricing.enterprise.cta": "プログラムについて相談",
       "pricing.tail": "<strong>カスタム問題の追加開発</strong>は要件定義から実装まで通常の受託開発と同じスコープになるため、 別途お見積もりします。 それ以上の規模 / 特別要件も含めて、 <a href=\"#contact\">お問い合わせ</a> ください。",
 
       "ent.eyebrow": "どのプランがよいか分からない",
@@ -1601,8 +1601,8 @@ footer .legal {
       "aud.h2": "Build cloud capability across the org.",
       "aud.lead": "For Cloud Enablement (CCoE), Platform / SRE, and Security teams that need hands-on AWS training — without rebuilding the event platform. Environment provisioning, login, scoring, and progress tracking — all in one screen.",
       "aud.a.role": "Cloud Enablement / CCoE",
-      "aud.a.h": "Turn training into a recurring arena.",
-      "aud.a.p": "New-grad onboarding, internalization programs, cross-team AWS drills — all running on the same platform, repeatedly. Move from one-off workshops to <strong>a reusable internal cloud arena</strong>.",
+      "aud.a.h": "Run training events multiple times a year.",
+      "aud.a.p": "New-grad onboarding, internalization programs, cross-team AWS drills — run them multiple times a year on the same platform. Move from one-off workshops to a planned annual program.",
       "aud.a.more": "Talk to us",
       "aud.b.role": "Platform / SRE",
       "aud.b.h": "Design drills from one screen.",
@@ -1647,7 +1647,7 @@ footer .legal {
       "extend.cta2": "new-problem skill",
 
       "pricing.eyebrow": "Pricing",
-      "pricing.h2": "Start small. Turn it into a recurring cloud arena.",
+      "pricing.h2": "Start small. Move to a yearly program.",
       "pricing.p": "The platform itself is Apache 2.0 OSS, so <strong>self-hosting on your own AWS account is free</strong>. Pay only when you want setup, day-of operations, or a multi-event program run for you.",
       "pricing.starter.tier": "Starter",
       "pricing.starter.price": "¥500K",
@@ -1673,8 +1673,8 @@ footer .legal {
       "pricing.enterprise.tier": "Annual Arena",
       "pricing.enterprise.price": "¥6M",
       "pricing.enterprise.unit": "/ year",
-      "pricing.enterprise.scope": "Annual contract — your <strong>internal cloud arena</strong>",
-      "pricing.enterprise.note": "For organizations running new-grad onboarding, CCoE programs, or platform enablement <strong>as a recurring program</strong>, not a one-off event.",
+      "pricing.enterprise.scope": "Annual contract — 4 operated events per year",
+      "pricing.enterprise.note": "For organizations that want to run <strong>4 events per year</strong> on the same platform — new-grad onboarding, CCoE programs, or platform enablement.",
       "pricing.enterprise.f1": "Up to 4 events per year (by department / cohort)",
       "pricing.enterprise.f2": "Beginner → intermediate → advanced learning path proposal from the public problem catalog + facilitator playbook template",
       "pricing.enterprise.f3": "Post-event PDF report (= scoring history, team progress, and attack timeline pulled from the portal — one PDF per event)",


### PR DESCRIPTION
## Summary

利用者フィードバック (= PR #1220 merge 後の追加レビュー):

1. **「常設の演習場」 framing はミスリード** (= 「常設しちゃうと運用だれするの?」 という運用責任の不安を呼ぶ)。 「年 4 回のイベント開催」 という具体・有限 framing にすべき
2. **「お見積もり依頼」 は名詞並びで日本語が不自然** → 「お見積もりを依頼」 (= 助詞 「を」 を入れる)

## 変更

### 「常設の演習場」 framing 撤回 (ja + en 同期)

| 場所 | 旧 | 新 |
|---|---|---|
| aud.a.h (ja) | 研修を、 **常設の演習場**へ。 | 研修イベントを、 **年に複数回**。 |
| aud.a.p (ja) | 単発ハンズオンから 「**社内の演習基盤**」 へ。 | 単発ハンズオンから **計画的な年間プログラム**へ。 |
| pricing.h2 (ja) | 単発イベントから、 **常設の演習場**へ。 | 単発イベントから、 **年間プログラム**へ。 |
| pricing.enterprise.scope (ja) | 年間契約 (= 「社内の演習基盤」 として **継続運用**) | 年間契約 (= **年 4 回のイベント開催を代行**) |
| pricing.enterprise.note (ja) | 単発でなく **常設の演習場** として運用したい組織向け | 同じプラットフォームで **年 4 回イベントを開催したい** 組織向け |
| aud.a.h (en) | Turn training into a **recurring arena**. | Run training events **multiple times a year**. |
| aud.a.p (en) | …Move from one-off workshops to **a reusable internal cloud arena**. | …Move from one-off workshops to **a planned annual program**. |
| pricing.h2 (en) | Start small. Turn it into a **recurring cloud arena**. | Start small. **Move to a yearly program**. |
| pricing.enterprise.scope (en) | Annual contract — your **internal cloud arena** | Annual contract — **4 operated events per year** |
| pricing.enterprise.note (en) | …**as a recurring program**, not a one-off event. | …want to run **4 events per year** on the same platform. |

### 日本語 CTA 修正

| key | 旧 | 新 |
|---|---|---|
| pricing.starter.cta | お見積もり**依頼** | お見積もり**を**依頼 |
| pricing.hosted.cta | お見積もり**依頼** | お見積もり**を**依頼 |
| pricing.enterprise.cta | プログラム**相談** | プログラム**について**相談 |

en の "Request a quote" / "Talk about a program" は既に自然な英語なので変更なし。

## なぜ重要か

「常設」 は 「我々がずっと運用する」 暗黙的責任を顧客に想起させ、 商談で 「運用は誰がやるの?」 「sustained support は?」 という 別売の SaaS / 維持管理サブスク を求められる入り口になる。 我々の deliverable は **「年 4 回のイベント代行 + 1 イベント 1 部の PDF レポート」** と物理的に有限なので、 表現も合わせる。

「お見積もり依頼」 は名詞並びで CTA ボタンとして自然さに欠ける。 助詞 「を」 を入れた 「お見積もりを依頼」 がよりナチュラル。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / 195 portal test 全 pass)
- [ ] 手動: ja / en 切替 で 全 「常設」 phrasing が消えていることを確認

## Regression analysis

- 文言変更のみ、 機能変更なし
- i18n key の構造変更なし → JavaScript applyLang() は無修正で動作
- Pages workflow は PR #1220 で `apps/participant-portal/**` に拡張済 → 本 PR は `landing/**` のみ触るので landing 経由で自動再 deploy

## Physical impact

- NO-OP infra
- UPDATE `landing/index.html` (= ja + en 文言の表現変更 のみ、 構造変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)