### PR TITLE
feat(landing): commercial-release minimum — legal pages + contact form + mobile

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -771,6 +771,34 @@ section .lead {
   display: inline-flex; align-items: center; gap: 6px;
 }
 
+/* ============== CONTACT FORM ============== */
+.contact-form {
+  max-width: 680px; margin: 32px auto 0; display: flex; flex-direction: column; gap: 18px;
+  text-align: left; color: var(--paper);
+}
+.contact-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.contact-field { display: flex; flex-direction: column; gap: 6px; }
+.contact-label { font-size: 12px; font-weight: 700; color: rgba(255,255,255,0.78); }
+.contact-label em { color: #ff8b6b; font-style: normal; }
+.contact-field input,
+.contact-field select,
+.contact-field textarea {
+  background: rgba(255,255,255,0.06); color: var(--paper);
+  border: 1px solid rgba(255,255,255,0.2); border-radius: 8px;
+  padding: 10px 12px; font: inherit; font-size: 14px; line-height: 1.5;
+  width: 100%;
+}
+.contact-field input:focus,
+.contact-field select:focus,
+.contact-field textarea:focus {
+  outline: 2px solid rgba(255,255,255,0.4); outline-offset: 1px;
+}
+.contact-fineprint { font-size: 11px; color: rgba(255,255,255,0.58); margin: 0; line-height: 1.6; }
+.contact-fineprint a { color: rgba(255,255,255,0.86); text-decoration: underline; }
+.contact-feedback { margin: 4px 0 0; padding: 10px 14px; border-radius: 8px; font-size: 13px; }
+.contact-feedback.success { background: rgba(76,175,80,0.18); color: #c6f3cb; }
+.contact-feedback.error { background: rgba(252,77,117,0.18); color: #ffd3dd; }
+
 /* ============== FOOTER ============== */
 footer { padding: 28px 0 24px; background: var(--paper-3); color: var(--ink-3); }
 footer .wrap {
@@ -792,9 +820,12 @@ footer .legal {
   grid-column: 1 / -1;
   margin-top: 8px; padding-top: 8px;
   border-top: 0;
-  display: flex; justify-content: space-between;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px 16px;
   font-size: 10px; color: var(--ink-4);
 }
+footer .legal a { color: var(--ink-3); text-decoration: none; }
+footer .legal a:hover { text-decoration: underline; }
+footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; }
 
 /* ============== RESPONSIVE ============== */
 @media (max-width: 980px) {
@@ -838,6 +869,18 @@ footer .legal {
   footer .legal { flex-direction: column; align-items: flex-start; gap: 4px; }
   /* section の縦 padding を mobile で詰める */
   section { padding: 36px 0; }
+  /* Contact form 2col → 1col stack */
+  .contact-row { grid-template-columns: 1fr; gap: 12px; }
+  .contact-form { gap: 14px; }
+  .contact-field input, .contact-field select, .contact-field textarea { font-size: 16px; }
+  /* iOS Safari の input zoom 防止に 16px を維持 */
+  /* ent-cta inner padding を mobile で詰める */
+  .ent-cta { padding: 28px 22px; }
+  .ent-cta h2 { font-size: clamp(22px, 6vw, 30px); }
+  /* hero CTA を横並びから縦並びへ (= タッチターゲット拡大) */
+  .hero .cta-row a { width: 100%; justify-content: center; padding: 10px 16px; }
+  /* nav-right brand 隠す (= ロゴはあるので冗長) */
+  .nav-brand-sub { display: none; }
 }
 @media (max-width: 420px) {
   /* 最小幅 (iPhone SE 等) で最後の調整 — 横スクロール / 文字溢れ 防止 */
@@ -1280,11 +1323,50 @@ footer .legal {
       <div class="eyebrow" data-i18n="ent.eyebrow">どのプランがよいか分からない</div>
       <h2 data-i18n="ent.h2">まずは話してみませんか。</h2>
       <p data-i18n="ent.p">クラウド人材育成プログラム、 内製化推進、 継続的な AWS 演習 — 規模 / 期間 / 参加者像を聞いた上で、 適切なプランを一緒に決めます。</p>
+    </div>
+    <form id="contact-form" class="contact-form" onsubmit="return submitContactForm(event);">
+      <div class="contact-row">
+        <label class="contact-field">
+          <span class="contact-label" data-i18n="contact.field_name">お名前 <em>*</em></span>
+          <input type="text" name="name" required maxlength="80" autocomplete="name" />
+        </label>
+        <label class="contact-field">
+          <span class="contact-label" data-i18n="contact.field_company">所属組織</span>
+          <input type="text" name="company" maxlength="120" autocomplete="organization" />
+        </label>
+      </div>
+      <div class="contact-row">
+        <label class="contact-field">
+          <span class="contact-label" data-i18n="contact.field_email">メールアドレス <em>*</em></span>
+          <input type="email" name="email" required maxlength="120" autocomplete="email" />
+        </label>
+        <label class="contact-field">
+          <span class="contact-label" data-i18n="contact.field_plan">興味のあるプラン</span>
+          <select name="plan">
+            <option value="" data-i18n="contact.plan_unknown">未定 / 相談したい</option>
+            <option value="starter">Starter (50万円 / 回)</option>
+            <option value="hosted">Hosted Event (150万円 / 回)</option>
+            <option value="annual">Annual Arena (600万円 / 年)</option>
+            <option value="oss" data-i18n="contact.plan_oss">OSS 自己ホストの相談</option>
+            <option value="other" data-i18n="contact.plan_other">その他 / カスタム</option>
+          </select>
+        </label>
+      </div>
+      <label class="contact-field">
+        <span class="contact-label" data-i18n="contact.field_scale">想定規模 / 開催時期</span>
+        <input type="text" name="scale" maxlength="120" placeholder="例: 20 人 / 2026 年 Q3" />
+      </label>
+      <label class="contact-field">
+        <span class="contact-label" data-i18n="contact.field_message">メッセージ</span>
+        <textarea name="message" rows="4" maxlength="2000" data-i18n-attr-placeholder="contact.field_message_placeholder" placeholder="解決したい課題、 参加者の技術レベル、 過去の研修の振り返り 等、 何でもお書きください。"></textarea>
+      </label>
+      <p class="contact-fineprint" data-i18n="contact.fineprint">送信先: TenkaCloud 運営 (富田進)。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href="./privacy.html">プライバシーポリシー</a>)。</p>
       <div class="btns">
-        <a class="btn-primary" href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer"><span data-i18n="ent.cta1">お問い合わせ</span> →</a>
+        <button class="btn-primary" type="submit"><span data-i18n="contact.submit">送信する</span> →</button>
         <a class="btn-ghost" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="ent.cta2">GitHub を見る</span> →</a>
       </div>
-    </div>
+      <p id="contact-feedback" class="contact-feedback" hidden></p>
+    </form>
   </div>
 </section>
 
@@ -1323,6 +1405,11 @@ footer .legal {
     <p class="disclaimer" data-i18n="footer.disclaimer">TenkaCloud は独立した OSS プロジェクトであり、 Amazon Web Services, Inc. またはその関連会社による提供・後援・承認を受けたものではありません。 AWS および関連する名称は Amazon.com, Inc. またはその関連会社の商標です。</p>
     <div class="legal">
       <span data-i18n="footer.legal">© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0</span>
+      <span class="footer-legal-links">
+        <a href="./privacy.html"><span data-i18n="footer.privacy">プライバシーポリシー</span></a> ·
+        <a href="./terms.html"><span data-i18n="footer.terms">利用規約</span></a> ·
+        <a href="./legal.html"><span data-i18n="footer.tokushoho">特定商取引法に基づく表記</span></a>
+      </span>
       <span>v0.2.0 · ja · en</span>
     </div>
   </div>
@@ -1506,13 +1593,28 @@ footer .legal {
       "ent.p": "クラウド人材育成プログラム、 内製化推進、 継続的な AWS 演習 — 規模 / 期間 / 参加者像を聞いた上で、 適切なプランを一緒に決めます。",
       "ent.cta1": "お問い合わせ",
       "ent.cta2": "GitHub を見る",
+      "contact.field_name": "お名前 *",
+      "contact.field_company": "所属組織",
+      "contact.field_email": "メールアドレス *",
+      "contact.field_plan": "興味のあるプラン",
+      "contact.plan_unknown": "未定 / 相談したい",
+      "contact.plan_oss": "OSS 自己ホストの相談",
+      "contact.plan_other": "その他 / カスタム",
+      "contact.field_scale": "想定規模 / 開催時期",
+      "contact.field_message": "メッセージ",
+      "contact.field_message_placeholder": "解決したい課題、 参加者の技術レベル、 過去の研修の振り返り 等、 何でもお書きください。",
+      "contact.fineprint": "送信先: TenkaCloud 運営 (富田進)。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href=\"./privacy.html\">プライバシーポリシー</a>)。",
+      "contact.submit": "送信する",
 
       "footer.tag": "AWS を題材にしたクラウド実戦演習を開催するための OSS ツール。 Apache 2.0。",
       "footer.disclaimer": "TenkaCloud は独立した OSS プロジェクトであり、 Amazon Web Services, Inc. またはその関連会社による提供・後援・承認を受けたものではありません。 AWS および関連する名称は Amazon.com, Inc. またはその関連会社の商標です。",
       "footer.p0": "概要", "footer.p1": "問題カタログ", "footer.p2": "参加者ポータル", "footer.p3": "運営コンソール",
       "footer.usage": "使い方", "footer.u0": "はじめる", "footer.u1": "ドキュメント", "footer.u2": "運用ガイド",
       "footer.r0": "ドキュメント", "footer.r1": "アーキテクチャ", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0"
+      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0",
+      "footer.privacy": "プライバシーポリシー",
+      "footer.terms": "利用規約",
+      "footer.tokushoho": "特定商取引法に基づく表記"
     },
     en: {
       "nav.product": "Product",
@@ -1687,13 +1789,28 @@ footer .legal {
       "ent.p": "Cloud enablement programs, internal onboarding, recurring AWS drills — share your scale, cadence, and audience, and we'll figure out the right setup together.",
       "ent.cta1": "Get in touch",
       "ent.cta2": "View on GitHub",
+      "contact.field_name": "Name *",
+      "contact.field_company": "Organization",
+      "contact.field_email": "Email *",
+      "contact.field_plan": "Plan you're interested in",
+      "contact.plan_unknown": "Not sure / let's talk",
+      "contact.plan_oss": "OSS self-host help",
+      "contact.plan_other": "Other / custom",
+      "contact.field_scale": "Expected scale / timing",
+      "contact.field_message": "Message",
+      "contact.field_message_placeholder": "Tell us the problem you're trying to solve, your participants' technical level, lessons from past trainings — anything that helps.",
+      "contact.fineprint": "Sent to: TenkaCloud (Susumu Tomita). Your input is used only for replying and quoting (see <a href=\"./privacy.html\">Privacy Policy</a>).",
+      "contact.submit": "Send",
 
       "footer.tag": "An open-source tool for hosting hands-on cloud drills on real AWS. Apache 2.0.",
       "footer.disclaimer": "TenkaCloud is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Amazon Web Services, Inc. AWS and related marks are trademarks of Amazon.com, Inc. or its affiliates.",
       "footer.p0": "Overview", "footer.p1": "Problems", "footer.p2": "Participant portal", "footer.p3": "Operator console",
       "footer.usage": "Usage", "footer.u0": "Start", "footer.u1": "Docs", "footer.u2": "Operations guide",
       "footer.r0": "Docs", "footer.r1": "Architecture", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0"
+      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0",
+      "footer.privacy": "Privacy Policy",
+      "footer.terms": "Terms of Service",
+      "footer.tokushoho": "Business identification (Japan TokushoHo)"
     }
   };
 
@@ -1840,6 +1957,69 @@ footer .legal {
   var tick = 0;
   renderScoreboard(tick);
   setInterval(function () { tick += 1; renderScoreboard(tick); }, 1500);
+
+  // Contact form submission. backend が無いので 入力内容を mailto: URL に組み立てて
+  // ユーザーの mail client を開く (= GitHub Pages の static site にできる最小実装)。
+  // 将来 backend (= Lambda Function URL) を立てたら fetch に差し替え。
+  window.submitContactForm = function (event) {
+    event.preventDefault();
+    var form = event.target;
+    var data = new FormData(form);
+    var name = String(data.get("name") || "").trim();
+    var email = String(data.get("email") || "").trim();
+    var company = String(data.get("company") || "").trim();
+    var plan = String(data.get("plan") || "").trim();
+    var scale = String(data.get("scale") || "").trim();
+    var message = String(data.get("message") || "").trim();
+    var feedback = document.getElementById("contact-feedback");
+    if (!name || !email) {
+      feedback.hidden = false;
+      feedback.className = "contact-feedback error";
+      feedback.textContent = "お名前とメールアドレスは必須です。";
+      return false;
+    }
+    var lines = [
+      "TenkaCloud お問い合わせ",
+      "",
+      "お名前: " + name,
+      "所属組織: " + (company || "(未記入)"),
+      "メールアドレス: " + email,
+      "興味のあるプラン: " + (plan || "(未指定)"),
+      "想定規模 / 開催時期: " + (scale || "(未記入)"),
+      "",
+      "メッセージ:",
+      message || "(なし)",
+      "",
+      "---",
+      "送信元: " + window.location.href,
+    ];
+    var body = encodeURIComponent(lines.join("\n"));
+    var subject = encodeURIComponent("[TenkaCloud] " + (plan || "お問い合わせ") + " — " + name);
+    // mailto: で運営者の窓口に飛ばす。 アドレスは GitHub プロフィール経由でも辿れる
+    // 公開窓口を使う想定 (= privacy.html / legal.html では 「請求があった場合に開示」
+    // を明示しているので、 ここでは GitHub Discussions URL にフォールバックする選択肢
+    // も保持)。
+    var primary = "mailto:oyster880+tenkacloud@gmail.com?subject=" + subject + "&body=" + body;
+    var discussionUrl =
+      "https://github.com/susumutomita/TenkaCloud/discussions/new?category=general&body=" + body;
+
+    // ユーザーの環境で mailto: が開けない (= web mail のみ) ケースに備え、 1.5 秒後に
+    // 「mailto が起動しなければ GitHub Discussions で送信」 リンクを提示する。
+    var w = window.open(primary, "_self");
+    feedback.hidden = false;
+    feedback.className = "contact-feedback success";
+    feedback.innerHTML =
+      "メーラーを起動しました。 もし開かない場合は、 こちらの " +
+      '<a href="' +
+      discussionUrl +
+      '" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline">' +
+      "GitHub Discussions から送信</a> もご利用いただけます。 ご連絡お待ちしています。";
+    if (!w) {
+      // mailto: opener が拒否された (= popup blocker)。 location.href fallback。
+      window.location.href = primary;
+    }
+    return false;
+  };
 })();
 </script>
 

--- a/landing/legal.html
+++ b/landing/legal.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>特定商取引法に基づく表記 — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/legal.html" />
+<style>
+:root { --bg:#fafafa; --paper:#fff; --ink:#0b0e14; --ink-2:#2d343d; --ink-3:#5b6470; --line:#d8dde4; --accent:#0066cc; }
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+table { width: 100%; border-collapse: collapse; margin: 16px 0 32px; font-size: 14px; }
+th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--ink); font-weight: 600; width: 32%; background: #f3f4f6; }
+td { color: var(--ink-2); }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+  table { font-size: 13px; }
+  th, td { padding: 10px 12px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <a class="back" href="./">← ホームへ戻る</a>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>特定商取引法に基づく表記</h1>
+  <p class="lede">特定商取引に関する法律 第 11 条 に基づく事業者情報の表示。</p>
+  <p class="meta">最終更新: 2026-05-23</p>
+
+  <table>
+    <tr>
+      <th>販売事業者</th>
+      <td>富田進 (Susumu Tomita)</td>
+    </tr>
+    <tr>
+      <th>運営責任者</th>
+      <td>富田進</td>
+    </tr>
+    <tr>
+      <th>所在地</th>
+      <td>請求があった場合に遅滞なく開示します。 <a href="./#contact">お問い合わせ</a>よりご連絡ください。</td>
+    </tr>
+    <tr>
+      <th>連絡先</th>
+      <td><a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> または LP <a href="./#contact">お問い合わせフォーム</a> よりご連絡ください。</td>
+    </tr>
+    <tr>
+      <th>販売価格</th>
+      <td>
+        各プランの価格は <a href="./#pricing">トップページの料金セクション</a> に表示しています。 すべて税別表示です。
+        <ul>
+          <li>Starter: 50 万円 / 回</li>
+          <li>Hosted Event: 150 万円 / 回</li>
+          <li>Annual Arena: 600 万円 / 年〜</li>
+        </ul>
+        AWS 利用料金 (= お客様アカウントに直接課金) は別途、 お客様負担となります。
+      </td>
+    </tr>
+    <tr>
+      <th>商品代金以外の必要料金</th>
+      <td>
+        振込手数料 (= お客様負担)。 AWS 利用料金 (= お客様の AWS アカウントへ直接課金、 当社を経由しない)。
+      </td>
+    </tr>
+    <tr>
+      <th>支払方法</th>
+      <td>銀行振込 (= 当社指定口座)。 請求書 を発行します。</td>
+    </tr>
+    <tr>
+      <th>支払時期</th>
+      <td>請求書 発行から 30 日以内。</td>
+    </tr>
+    <tr>
+      <th>商品引渡し時期 (= 役務提供時期)</th>
+      <td>個別の見積書 / 契約書に記載されたイベント開催日 / 期間に従い、 当社が運営代行および事後レポート PDF を提供します。</td>
+    </tr>
+    <tr>
+      <th>返品・キャンセル</th>
+      <td>
+        <ul>
+          <li><strong>Starter / Hosted Event</strong>: イベント開催 30 日前までキャンセル無料、 30 日前 〜 7 日前で 50% 支払い、 7 日前以降は 100% 支払い。</li>
+          <li><strong>Annual Arena</strong>: 年間契約の特性上、 中途解約による返金は行わない (= ただし双方協議で例外可)。</li>
+        </ul>
+        詳細は <a href="./terms.html">利用規約</a> 第 9 条をご確認ください。
+      </td>
+    </tr>
+    <tr>
+      <th>動作環境</th>
+      <td>
+        <strong>主催者側</strong>: 自前の AWS アカウント (= リソース deploy 先)、 モダンブラウザ (Chrome / Edge / Safari の最新版)。<br />
+        <strong>参加者側</strong>: モダンブラウザのみ (= AWS アカウント不要、 主催者環境へ federate)。
+      </td>
+    </tr>
+  </table>
+
+  <hr class="divider" />
+  <p class="meta">OSS としての利用 (= 自前 AWS に deploy する自己ホスト、 Apache License 2.0) には、 本表記および 利用規約 は適用されません。</p>
+</main>
+
+<footer class="bottom">
+  © 2026 TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./terms.html">利用規約</a> · <a href="./">ホーム</a>
+</footer>
+</body>
+</html>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>プライバシーポリシー — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/privacy.html" />
+<style>
+:root {
+  --bg: #fafafa;
+  --paper: #fff;
+  --ink: #0b0e14;
+  --ink-2: #2d343d;
+  --ink-3: #5b6470;
+  --line: #d8dde4;
+  --accent: #0066cc;
+}
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+h3 { font-size: 16px; margin: 24px 0 8px; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+ul, ol { padding-left: 22px; }
+li { margin-bottom: 6px; }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <a class="back" href="./">← ホームへ戻る</a>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>プライバシーポリシー</h1>
+  <p class="lede">TenkaCloud (以下「本サービス」) における個人情報の取扱いについて。</p>
+  <p class="meta">最終更新: 2026-05-23 · 運営者: 富田進 (Susumu Tomita)</p>
+
+  <h2>1. 取得する情報</h2>
+  <p>本サービスの提供および商談対応のため、以下の情報を取得することがあります。</p>
+  <ul>
+    <li><strong>お問い合わせ情報</strong>: お名前、 所属組織、 連絡先メールアドレス、 お問い合わせ本文。</li>
+    <li><strong>イベント運営代行に伴う情報</strong>: お客様が運営するイベントの参加者情報 (= チーム名 / 表示名)、 提出ログ、 スコア履歴等。 本サービスの SaaS インフラ (= AWS) 上に保存され、 イベント終了後 7 日経過で自動削除される。</li>
+    <li><strong>アクセスログ</strong>: ランディングページおよびポータルへのアクセスに伴う IP アドレス、 User-Agent、 リファラ等。 GitHub Pages / Amazon CloudFront のアクセスログとして 標準保管される。</li>
+  </ul>
+
+  <h2>2. 利用目的</h2>
+  <ul>
+    <li>お問い合わせへの返信および見積もり提示。</li>
+    <li>本サービスの運営、 障害対応、 セキュリティ監査。</li>
+    <li>本サービスの改善に伴う 統計的分析 (= 個人を特定しない形)。</li>
+    <li>法令に基づく対応 (= 警察 / 裁判所 等からの正当な要請)。</li>
+  </ul>
+
+  <h2>3. 第三者提供</h2>
+  <p>あらかじめお客様の同意を得た場合、 または法令に基づく場合を除き、 個人情報を第三者に提供することはありません。 ただし以下のクラウドサービス提供者にデータが保存されることがあります (= いずれもインフラとしての利用、 内容を読み取られることは想定していない)。</p>
+  <ul>
+    <li>Amazon Web Services, Inc. (= 本サービスの SaaS インフラ提供者)</li>
+    <li>GitHub, Inc. (= ランディングページ配信、 OSS リポジトリ提供者)</li>
+  </ul>
+
+  <h2>4. 保管期間</h2>
+  <ul>
+    <li><strong>お問い合わせ情報</strong>: 商談終了後 2 年間。</li>
+    <li><strong>イベント運営代行の参加者データ</strong>: イベント終了後 7 日間 (= DynamoDB の TTL feature による自動削除、 Issue #1200)。</li>
+    <li><strong>アクセスログ</strong>: AWS / GitHub の標準保管期間に従う。</li>
+  </ul>
+
+  <h2>5. 開示・訂正・削除請求</h2>
+  <p>お客様ご自身の個人情報について、 開示・訂正・削除のご請求は<a href="#contact">お問い合わせ窓口</a>までご連絡ください。 本人確認の上、 法令に基づき速やかに対応します。</p>
+
+  <h2>6. Cookie / トラッキング</h2>
+  <p>本ランディングページ自体は Cookie を設定しません。 ただし参加者ポータル (= portal-demo / 本番ポータル) は、 セッション管理のため localStorage を使用します。 トラッキング目的の Cookie / 解析ツールは使用していません (= 2026-05 時点)。</p>
+
+  <h2>7. 改定</h2>
+  <p>本ポリシーは、 法令の変更や本サービスの内容の変更に応じて改定されることがあります。 重要な改定があった場合は、 本ページに掲載することで お知らせとします。</p>
+
+  <h2 id="contact">8. お問い合わせ窓口</h2>
+  <p>個人情報に関するお問い合わせは、 以下までご連絡ください。</p>
+  <ul>
+    <li>窓口: TenkaCloud 運営 (富田進)</li>
+    <li>連絡方法: <a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> または LP の<a href="./#contact">お問い合わせフォーム</a></li>
+  </ul>
+
+  <hr class="divider" />
+  <p class="meta">準拠法: 日本国法 · 管轄裁判所: 富田進の所在地を管轄する裁判所</p>
+</main>
+
+<footer class="bottom">
+  © 2026 TenkaCloud · <a href="./terms.html">利用規約</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
+</footer>
+</body>
+</html>

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>利用規約 — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/terms.html" />
+<style>
+:root { --bg:#fafafa; --paper:#fff; --ink:#0b0e14; --ink-2:#2d343d; --ink-3:#5b6470; --line:#d8dde4; --accent:#0066cc; }
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+ul, ol { padding-left: 22px; }
+li { margin-bottom: 6px; }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <a class="back" href="./">← ホームへ戻る</a>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>利用規約</h1>
+  <p class="lede">TenkaCloud (以下「本サービス」) の有料プラン (= Starter / Hosted Event / Annual Arena) をご利用いただく際の利用規約。 OSS としての利用 (= 自前 AWS 環境へ deploy する自己ホスト) は Apache License 2.0 が優先します。</p>
+  <p class="meta">最終更新: 2026-05-23 · 運営者: 富田進 (Susumu Tomita)</p>
+
+  <h2>第 1 条 (適用)</h2>
+  <p>本規約は、 お客様 (= 法人または個人) と 本サービス運営者 (以下「当社」) の間の、 有料プランの提供に関するすべての関係に適用されます。 個別の見積書 / 契約書がある場合は、 そちらが優先します。</p>
+
+  <h2>第 2 条 (有料プラン)</h2>
+  <ul>
+    <li><strong>Starter</strong> (50 万円 / 回、 税別): 1 回 / 2 チームまでのお試しイベントを当社が運営代行。</li>
+    <li><strong>Hosted Event</strong> (150 万円 / 回、 税別): 1 回 / 5 チーム (〜 20 人) のイベントを構築から当日進行まで運営代行。</li>
+    <li><strong>Annual Arena</strong> (600 万円 / 年〜、 税別): 年間契約で 年 4 回のイベント開催を代行 + 公開問題カタログから learning path 提案 + 事後レポート PDF。</li>
+  </ul>
+  <p>カスタム問題の追加開発、 業界特化シナリオ、 20 人超の同時開催等は別途お見積もり対応。</p>
+
+  <h2>第 3 条 (申込・契約成立)</h2>
+  <p>お客様が当社のお問い合わせフォームよりプランをお申し込みいただき、 当社が見積書を発行、 双方の合意 (= 書面 / メール) をもって契約成立とします。</p>
+
+  <h2>第 4 条 (支払い)</h2>
+  <ul>
+    <li>支払い方法: 銀行振込 (= 当社指定口座、 振込手数料はお客様負担)。</li>
+    <li>支払時期: 請求書発行から 30 日以内。</li>
+    <li>遅延損害金: 年 14.6% (= 商事法定利率)。</li>
+  </ul>
+
+  <h2>第 5 条 (お客様の責務)</h2>
+  <ul>
+    <li>本サービスが deploy する AWS リソースは <strong>お客様の AWS アカウント</strong>内に作成されます。 AWS アカウントの管理 (= IAM / 課金 / 監査ログ) はお客様の責任。</li>
+    <li>イベント参加者への連絡、 参加者の AWS Console SSO ログイン操作の利用規約遵守 (= 参加者個人の AWS アカウントは不要 / 主催者環境のみに federate) はお客様の責務。</li>
+    <li>本サービスが提供する一時的な AWS 認証情報の取り扱いは、 参加者にも周知する。</li>
+  </ul>
+
+  <h2>第 6 条 (当社の責務)</h2>
+  <ul>
+    <li>有料プランの仕様に沿った 構築・進行・事後レポート PDF (= 1 イベント 1 部) を成果物として提供。</li>
+    <li>イベント期間中の障害対応 (= 当社起因の deploy 失敗、 ポータル不具合等) は best-effort で速やかに対応。</li>
+    <li>SLA は明示的に規定しない (= OSS ベースのため)。 重大障害の場合は協議の上対応する。</li>
+  </ul>
+
+  <h2>第 7 条 (禁止事項)</h2>
+  <p>お客様は以下を行ってはなりません。</p>
+  <ul>
+    <li>本サービスを通じて、 違法な行為 (= 不正アクセス、 著作権侵害 等) を行うこと。</li>
+    <li>当社の知的財産権 (= ロゴ等。 OSS コード自体は Apache 2.0) を無断で使用すること。</li>
+    <li>参加者から取得した個人情報を、 イベント運営目的外で 利用すること。</li>
+  </ul>
+
+  <h2>第 8 条 (免責)</h2>
+  <ul>
+    <li>当社は、 イベント開催により参加者または第三者に発生した損害について、 当社の故意または重大な過失に起因する場合を除き、 責任を負いません。</li>
+    <li>本サービスが deploy する AWS リソースに伴う AWS 利用料金 (= お客様アカウントに直接課金) は、 お客様の負担となります。 当社は AWS 料金については一切責任を負いません。</li>
+    <li>イベント参加者の AWS Console 操作による意図せざる課金 / 設定変更 / リソース削除 についても同様です (= 当社は IAM の最小権限設計を推奨)。</li>
+  </ul>
+
+  <h2>第 9 条 (中途解約)</h2>
+  <ul>
+    <li><strong>Annual Arena</strong> の中途解約は、 残期間相当の費用を返金しない (= 年間契約の特性上)。 ただし双方協議で例外可。</li>
+    <li>Starter / Hosted Event は、 イベント開催 30 日前まで キャンセル無料、 30 日前 〜 7 日前 50% 支払い、 7 日前以降 100% 支払い。</li>
+  </ul>
+
+  <h2>第 10 条 (準拠法・管轄)</h2>
+  <p>本規約は日本国法に準拠し、 本サービスに関する一切の紛争は、 富田進の所在地を管轄する裁判所を 専属的合意管轄裁判所とします。</p>
+
+  <h2>第 11 条 (改定)</h2>
+  <p>当社は、 法令の変更や本サービスの内容の変更に応じて、 本規約を改定することがあります。 重要な改定がある場合は、 30 日前までに本ページまたはメールで お知らせします。</p>
+
+  <hr class="divider" />
+  <p class="meta">OSS 自己ホストの場合 (= Apache License 2.0) は本規約は適用されず、 ライセンス本文 (<a href="https://github.com/susumutomita/TenkaCloud/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">LICENSE</a>) が適用されます。</p>
+</main>
+
+<footer class="bottom">
+  © 2026 TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

商用リリースに向けて 「販売開始しても法的・営業的に大丈夫」 になる最小要件を一括追加:

1. **Legal pages 3 件** (= プライバシーポリシー / 利用規約 / 特定商取引法に基づく表記)
2. **Contact Form section** (= GitHub Discussions 直リンクを正式 form に)
3. **Mobile responsive 強化** (= 640px / 420px breakpoints の補強)

## 1. Legal pages

3 件を独立 HTML として追加 (= GitHub Pages 配信、 SPA 不要、 単独 SEO indexable):

| File | 内容 |
|---|---|
| `landing/privacy.html` | プライバシーポリシー (取得情報 / 利用目的 / 第三者提供 / 保管期間 7 日 (DDB TTL) / 開示請求 / Cookie / 改定 / 連絡先) |
| `landing/terms.html` | 利用規約 11 条 (適用範囲 / プラン (50/150/600) / 申込 / 支払い / 顧客責務 / 当社責務 / 禁止 / 免責 / 中途解約 / 準拠法 / 改定) |
| `landing/legal.html` | 特定商取引法に基づく表記 (事業者 / 所在地 (請求開示) / 価格表 / 支払 / 役務提供時期 / 返品キャンセル / 動作環境) |

OSS 自己ホスト (= Apache 2.0) には適用されない旨を各 page で明記し、 「**OSS は OSS / 有料 SaaS は商法に従う**」 の二層モデルを明確化。 footer に 3 件への link を追加 (ja / en i18n 同期: `footer.privacy / terms / tokushoho`)。

## 2. Contact Form section

**旧**: pricing CTA は `https://github.com/.../discussions` 直リンク (= 商談導線として弱い、 営業担当者がレスポンスを取れない)。

**新**: `#contact` section に inline form を新設:

| フィールド | 必須 |
|---|---|
| お名前 | ✓ |
| 所属組織 | |
| メールアドレス | ✓ |
| 興味のあるプラン (select: Starter / Hosted / Annual / OSS / その他) | |
| 想定規模 / 開催時期 | |
| メッセージ | |

submit handler は GitHub Pages の制約上 backend を持たないため `mailto:` に組み立てて user の mail client を開く + **GitHub Discussions fallback link** を success message に出す (= popup blocker / web mail のみのユーザーに保険)。 将来 backend (= Lambda Function URL) を立てたら `fetch` に差し替え可能な構造。

入力 validation は client-side のみ (= `required` 属性 + JS で名前 / メールの空欄チェック)。 input は 16px font-size で iOS Safari の auto-zoom 防止。

i18n 同期: `contact.field_* / contact.plan_* / contact.fineprint / contact.submit` を ja / en に追加。

## 3. Mobile responsive 強化

旧 `@media (max-width: 640px)` に追記:

- `.contact-row` 2col → 1col stack
- input / select / textarea を 16px に固定 (= iOS Safari の input zoom 防止)
- `.ent-cta` mobile padding 縮小 + h2 を `clamp(22, 6vw, 30)` で fit
- `.hero .cta-row a` を 100% width + 縦並びでタッチターゲット拡大

既存の 980 / 640 / 420 3-breakpoint layered media queries に追記する形なので、 既存 desktop layout には影響なし。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / build 全 pass)
- [ ] 手動: モバイル 390px viewport で全 section が縦 stack、 contact form が読みやすい
- [ ] 手動: 各 legal page (`/privacy.html` / `/terms.html` / `/legal.html`) を開いて link / back navigation 動作確認
- [ ] 手動: contact form 送信で メーラーが開く / fallback Discussions link が success message に出る

## Regression analysis

- 3 file 新規追加 (= 配信のみ)、 既存 page への影響なし
- 既存 `#contact` section の旧 button 2 個 (= Discussions / GitHub) を form 内の primary submit + ghost GitHub link に置換 → CTA 数自体は同じ
- footer .legal の flex-wrap + footer-legal-links を追加 → 既存 layout は崩れない (768px 以上は横並び、 mobile では stack)

## Physical impact

- NO-OP infra (CDK / IAM 変更なし)
- UPDATE `landing/` に 3 file 新規追加 + `index.html` (form / mobile / footer link)
- UPDATE GitHub Pages 配信 (= legal pages 公開、 商用販売の法的要件を満たす)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact form in Enterprise section with name, email, and plan selection
  * Added three new legal documentation pages: Privacy Policy, Terms of Service, and Legal Disclosures
  * Extended multilingual support for contact form and footer links

* **Style**
  * Improved responsive design for mobile devices

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->