### PR TITLE
feat(landing): incorporate BULL LLC as operator + bilingual legal pages + custom-problem option

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1346,6 +1346,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
             <option value="starter">Starter (50万円 / 回)</option>
             <option value="hosted">Hosted Event (150万円 / 回)</option>
             <option value="annual">Annual Arena (600万円 / 年)</option>
+            <option value="custom-problem" data-i18n="contact.plan_custom_problem">独自問題の追加開発</option>
             <option value="oss" data-i18n="contact.plan_oss">OSS 自己ホストの相談</option>
             <option value="other" data-i18n="contact.plan_other">その他 / カスタム</option>
           </select>
@@ -1359,7 +1360,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
         <span class="contact-label" data-i18n="contact.field_message">メッセージ</span>
         <textarea name="message" rows="4" maxlength="2000" data-i18n-attr-placeholder="contact.field_message_placeholder" placeholder="解決したい課題、 参加者の技術レベル、 過去の研修の振り返り 等、 何でもお書きください。"></textarea>
       </label>
-      <p class="contact-fineprint" data-i18n="contact.fineprint">送信先: TenkaCloud 運営 (富田進)。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href="./privacy.html">プライバシーポリシー</a>)。</p>
+      <p class="contact-fineprint" data-i18n="contact.fineprint">送信先: TenkaCloud 運営。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href="./privacy.html">プライバシーポリシー</a>)。</p>
       <div class="btns">
         <button class="btn-primary" type="submit"><span data-i18n="contact.submit">送信する</span> →</button>
         <a class="btn-ghost" href="https://github.com/susumutomita/TenkaCloud" target="_blank" rel="noopener noreferrer"><span data-i18n="ent.cta2">GitHub を見る</span> →</a>
@@ -1404,7 +1405,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
     </div>
     <p class="disclaimer" data-i18n="footer.disclaimer">TenkaCloud は独立した OSS プロジェクトであり、 Amazon Web Services, Inc. またはその関連会社による提供・後援・承認を受けたものではありません。 AWS および関連する名称は Amazon.com, Inc. またはその関連会社の商標です。</p>
     <div class="legal">
-      <span data-i18n="footer.legal">© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0</span>
+      <span data-i18n="footer.legal">© 2026 合同会社BULL · TenkaCloud · Apache License 2.0</span>
       <span class="footer-legal-links">
         <a href="./privacy.html"><span data-i18n="footer.privacy">プライバシーポリシー</span></a> ·
         <a href="./terms.html"><span data-i18n="footer.terms">利用規約</span></a> ·
@@ -1598,12 +1599,13 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
       "contact.field_email": "メールアドレス *",
       "contact.field_plan": "興味のあるプラン",
       "contact.plan_unknown": "未定 / 相談したい",
+      "contact.plan_custom_problem": "独自問題の追加開発",
       "contact.plan_oss": "OSS 自己ホストの相談",
       "contact.plan_other": "その他 / カスタム",
       "contact.field_scale": "想定規模 / 開催時期",
       "contact.field_message": "メッセージ",
       "contact.field_message_placeholder": "解決したい課題、 参加者の技術レベル、 過去の研修の振り返り 等、 何でもお書きください。",
-      "contact.fineprint": "送信先: TenkaCloud 運営 (富田進)。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href=\"./privacy.html\">プライバシーポリシー</a>)。",
+      "contact.fineprint": "送信先: 合同会社BULL (TenkaCloud 運営)。 ご記入いただいた情報は、 お問い合わせ対応と見積もり提示のみに利用します (= <a href=\"./privacy.html\">プライバシーポリシー</a>)。",
       "contact.submit": "送信する",
 
       "footer.tag": "AWS を題材にしたクラウド実戦演習を開催するための OSS ツール。 Apache 2.0。",
@@ -1611,7 +1613,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
       "footer.p0": "概要", "footer.p1": "問題カタログ", "footer.p2": "参加者ポータル", "footer.p3": "運営コンソール",
       "footer.usage": "使い方", "footer.u0": "はじめる", "footer.u1": "ドキュメント", "footer.u2": "運用ガイド",
       "footer.r0": "ドキュメント", "footer.r1": "アーキテクチャ", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0",
+      "footer.legal": "© 2026 合同会社BULL · TenkaCloud · Apache License 2.0",
       "footer.privacy": "プライバシーポリシー",
       "footer.terms": "利用規約",
       "footer.tokushoho": "特定商取引法に基づく表記"
@@ -1799,7 +1801,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
       "contact.field_scale": "Expected scale / timing",
       "contact.field_message": "Message",
       "contact.field_message_placeholder": "Tell us the problem you're trying to solve, your participants' technical level, lessons from past trainings — anything that helps.",
-      "contact.fineprint": "Sent to: TenkaCloud (Susumu Tomita). Your input is used only for replying and quoting (see <a href=\"./privacy.html\">Privacy Policy</a>).",
+      "contact.fineprint": "Sent to: BULL LLC (operator of TenkaCloud). Your input is used only for replying and quoting (see <a href=\"./privacy.en.html\">Privacy Policy</a>).",
       "contact.submit": "Send",
 
       "footer.tag": "An open-source tool for hosting hands-on cloud drills on real AWS. Apache 2.0.",
@@ -1807,7 +1809,7 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
       "footer.p0": "Overview", "footer.p1": "Problems", "footer.p2": "Participant portal", "footer.p3": "Operator console",
       "footer.usage": "Usage", "footer.u0": "Start", "footer.u1": "Docs", "footer.u2": "Operations guide",
       "footer.r0": "Docs", "footer.r1": "Architecture", "footer.r2": "Changelog",
-      "footer.legal": "© 2026 TenkaCloud · Susumu Tomita · Apache License 2.0",
+      "footer.legal": "© 2026 BULL LLC (合同会社BULL) · TenkaCloud · Apache License 2.0",
       "footer.privacy": "Privacy Policy",
       "footer.terms": "Terms of Service",
       "footer.tokushoho": "Business identification (Japan TokushoHo)"
@@ -1899,6 +1901,18 @@ footer .footer-legal-links { display: inline-flex; flex-wrap: wrap; gap: 0 6px; 
     renderProductRows(lang);
     renderTrustBullets(lang);
     renderStats(lang);
+    // Legal page link 群を locale に合わせて swap (= en visitor が ./privacy.html (ja)
+    // に飛ばないように、 en の場合は ./privacy.en.html / terms.en.html / legal.en.html
+    // に href を切り替える)。 ja 戻しは逆方向。
+    var LEGAL_HREF_MAP = {
+      ja: { "./privacy.en.html": "./privacy.html", "./terms.en.html": "./terms.html", "./legal.en.html": "./legal.html" },
+      en: { "./privacy.html": "./privacy.en.html", "./terms.html": "./terms.en.html", "./legal.html": "./legal.en.html" }
+    };
+    var hrefMap = LEGAL_HREF_MAP[lang] || {};
+    document.querySelectorAll('footer a[href$="privacy.html"], footer a[href$="terms.html"], footer a[href$="legal.html"], footer a[href$="privacy.en.html"], footer a[href$="terms.en.html"], footer a[href$="legal.en.html"]').forEach(function (a) {
+      var src = a.getAttribute("href");
+      if (hrefMap[src]) a.setAttribute("href", hrefMap[src]);
+    });
   }
 
   /**

--- a/landing/legal.en.html
+++ b/landing/legal.en.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Business identification — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/legal.en.html" />
+<link rel="alternate" hreflang="ja" href="https://susumutomita.github.io/TenkaCloud/legal.html" />
+<link rel="alternate" hreflang="en" href="https://susumutomita.github.io/TenkaCloud/legal.en.html" />
+<style>
+:root { --bg:#fafafa; --paper:#fff; --ink:#0b0e14; --ink-2:#2d343d; --ink-3:#5b6470; --line:#d8dde4; --accent:#0066cc; }
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.lang { color: var(--accent); text-decoration: none; font-size: 13px; }
+.lang:hover { text-decoration: underline; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+table { width: 100%; border-collapse: collapse; margin: 16px 0 32px; font-size: 14px; }
+th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--ink); font-weight: 600; width: 32%; background: #f3f4f6; }
+td { color: var(--ink-2); }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+  table { font-size: 13px; }
+  th, td { padding: 10px 12px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <span><a class="lang" href="./legal.html">日本語</a> · <a class="back" href="./">← Home</a></span>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>Business identification</h1>
+  <p class="lede">Disclosure required under Article 11 of Japan's Act on Specified Commercial Transactions (特定商取引法). The Japanese version at <a href="./legal.html">/legal.html</a> is the legally binding original; this English version is provided for reference.</p>
+  <p class="meta">Last updated: 2026-05-23</p>
+
+  <table>
+    <tr>
+      <th>Seller</th>
+      <td>BULL LLC (合同会社BULL)</td>
+    </tr>
+    <tr>
+      <th>Representative</th>
+      <td>Susumu Tomita (Representative Member)</td>
+    </tr>
+    <tr>
+      <th>Address</th>
+      <td>Disclosed promptly upon request. Please <a href="./#contact">contact us</a>.</td>
+    </tr>
+    <tr>
+      <th>Contact</th>
+      <td>Via <a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> or the <a href="./#contact">contact form</a>.</td>
+    </tr>
+    <tr>
+      <th>Price</th>
+      <td>
+        Each plan is listed on the <a href="./#pricing">pricing section of the home page</a>. All prices are tax-exclusive.
+        <ul>
+          <li>Starter: ¥500,000 / event</li>
+          <li>Hosted Event: ¥1,500,000 / event</li>
+          <li>Annual Arena: from ¥6,000,000 / year</li>
+        </ul>
+        AWS usage fees (= billed directly to your AWS account) are separate and borne by the Customer.
+      </td>
+    </tr>
+    <tr>
+      <th>Other charges</th>
+      <td>Bank-transfer fees (= borne by the Customer). AWS usage fees (= billed to the Customer's AWS account; not processed by us).</td>
+    </tr>
+    <tr>
+      <th>Payment method</th>
+      <td>Bank transfer (= to our designated account). Invoice will be issued.</td>
+    </tr>
+    <tr>
+      <th>Payment timing</th>
+      <td>Within 30 days of invoice issuance.</td>
+    </tr>
+    <tr>
+      <th>Delivery / service timing</th>
+      <td>According to the event date / period specified in the individual quote or contract, we provide operations and the post-event PDF report.</td>
+    </tr>
+    <tr>
+      <th>Returns / cancellation</th>
+      <td>
+        <ul>
+          <li><strong>Starter / Hosted Event</strong>: Free up to 30 days before the event; 50% charge between 30 and 7 days before; 100% charge within 7 days of the event.</li>
+          <li><strong>Annual Arena</strong>: No refund for mid-term cancellation (= annual contract characteristic). Exceptions by mutual agreement.</li>
+        </ul>
+        See <a href="./terms.en.html">Terms of Service</a> Article 9 for details.
+      </td>
+    </tr>
+    <tr>
+      <th>System requirements</th>
+      <td>
+        <strong>Host side</strong>: Your own AWS account (= where resources are deployed); modern browser (latest Chrome / Edge / Safari).<br />
+        <strong>Participant side</strong>: Modern browser only (= no AWS account required; federate into the host environment).
+      </td>
+    </tr>
+  </table>
+
+  <hr class="divider" />
+  <p class="meta">This page and the Terms of Service do not apply to OSS self-hosting (= deploying into your own AWS account under the Apache License 2.0).</p>
+</main>
+
+<footer class="bottom">
+  © 2026 BULL LLC (合同会社BULL) · TenkaCloud · <a href="./privacy.en.html">Privacy Policy</a> · <a href="./terms.en.html">Terms of Service</a> · <a href="./">Home</a>
+</footer>
+</body>
+</html>

--- a/landing/legal.html
+++ b/landing/legal.html
@@ -58,7 +58,7 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
     </tr>
     <tr>
       <th>代表者</th>
-      <td>代表社員 富田進</td>
+      <td>代表社員 冨田進</td>
     </tr>
     <tr>
       <th>所在地</th>

--- a/landing/legal.html
+++ b/landing/legal.html
@@ -42,7 +42,7 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
 <header class="top">
   <div class="wrap">
     <a class="brand" href="./">TenkaCloud</a>
-    <a class="back" href="./">← ホームへ戻る</a>
+    <span><a class="back" href="./legal.en.html" style="color:var(--accent);text-decoration:none;font-size:13px;margin-right:8px;">English</a> · <a class="back" href="./">← ホームへ戻る</a></span>
   </div>
 </header>
 
@@ -54,11 +54,11 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
   <table>
     <tr>
       <th>販売事業者</th>
-      <td>富田進 (Susumu Tomita)</td>
+      <td>合同会社BULL</td>
     </tr>
     <tr>
-      <th>運営責任者</th>
-      <td>富田進</td>
+      <th>代表者</th>
+      <td>代表社員 富田進</td>
     </tr>
     <tr>
       <th>所在地</th>
@@ -122,7 +122,7 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
 </main>
 
 <footer class="bottom">
-  © 2026 TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./terms.html">利用規約</a> · <a href="./">ホーム</a>
+  © 2026 合同会社BULL · TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./terms.html">利用規約</a> · <a href="./">ホーム</a>
 </footer>
 </body>
 </html>

--- a/landing/privacy.en.html
+++ b/landing/privacy.en.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Privacy Policy — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/privacy.en.html" />
+<link rel="alternate" hreflang="ja" href="https://susumutomita.github.io/TenkaCloud/privacy.html" />
+<link rel="alternate" hreflang="en" href="https://susumutomita.github.io/TenkaCloud/privacy.en.html" />
+<style>
+:root { --bg:#fafafa; --paper:#fff; --ink:#0b0e14; --ink-2:#2d343d; --ink-3:#5b6470; --line:#d8dde4; --accent:#0066cc; }
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.lang { color: var(--accent); text-decoration: none; font-size: 13px; }
+.lang:hover { text-decoration: underline; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+ul, ol { padding-left: 22px; }
+li { margin-bottom: 6px; }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <span><a class="lang" href="./privacy.html">日本語</a> · <a class="back" href="./">← Home</a></span>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>Privacy Policy</h1>
+  <p class="lede">How personal information is handled when you use TenkaCloud (the "Service"). The Japanese version at <a href="./privacy.html">/privacy.html</a> is the legally binding original; this English version is provided for reference.</p>
+  <p class="meta">Last updated: 2026-05-23 · Operator: BULL LLC (合同会社BULL)</p>
+
+  <h2>1. Information we collect</h2>
+  <p>To provide the Service and respond to inquiries, we may collect:</p>
+  <ul>
+    <li><strong>Inquiry information</strong>: name, organization, contact email, and the body of your inquiry.</li>
+    <li><strong>Event operation data</strong>: participant data (= team name / display name), submission logs, and scoring history for events you run on the Service. Stored on the Service's SaaS infrastructure (= AWS) and automatically deleted 7 days after the event ends.</li>
+    <li><strong>Access logs</strong>: IP address, User-Agent, referrer, etc. for visitors to the landing page and the portal. Retained per the standard logging policies of GitHub Pages / Amazon CloudFront.</li>
+  </ul>
+
+  <h2>2. Purpose of use</h2>
+  <ul>
+    <li>Replying to inquiries and providing quotes.</li>
+    <li>Operating the Service, responding to incidents, and security auditing.</li>
+    <li>Statistical analysis to improve the Service (= in a form that does not identify individuals).</li>
+    <li>Compliance with legal requirements (= legitimate requests from police, courts, etc.).</li>
+  </ul>
+
+  <h2>3. Disclosure to third parties</h2>
+  <p>We do not disclose personal information to third parties without your consent, except as required by law. Data may, however, be stored on the following cloud providers (= used as infrastructure; not for content inspection):</p>
+  <ul>
+    <li>Amazon Web Services, Inc. (= SaaS infrastructure provider)</li>
+    <li>GitHub, Inc. (= landing page delivery and OSS repository host)</li>
+  </ul>
+
+  <h2>4. Retention</h2>
+  <ul>
+    <li><strong>Inquiry information</strong>: 2 years after the engagement ends.</li>
+    <li><strong>Event participant data</strong>: 7 days after the event ends (= automatic deletion via DynamoDB TTL feature, Issue #1200).</li>
+    <li><strong>Access logs</strong>: Standard retention of AWS / GitHub.</li>
+  </ul>
+
+  <h2>5. Disclosure, correction, and deletion requests</h2>
+  <p>To request disclosure, correction, or deletion of your personal information, please contact us via the <a href="#contact">contact channel below</a>. After identity verification, we will respond promptly in accordance with applicable laws.</p>
+
+  <h2>6. Cookies / tracking</h2>
+  <p>The landing page itself does not set cookies. The participant portal (= portal-demo / production portal) uses localStorage for session management. We do not use cookies or analytics tools for tracking purposes (= as of 2026-05).</p>
+
+  <h2>7. Revisions</h2>
+  <p>This Policy may be revised in response to changes in law or in the Service. Material revisions will be notified by posting to this page.</p>
+
+  <h2 id="contact">8. Contact</h2>
+  <p>For privacy-related inquiries, please contact us via:</p>
+  <ul>
+    <li>Operator: BULL LLC (合同会社BULL), operator of TenkaCloud</li>
+    <li>Channel: <a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> or the <a href="./#contact">contact form</a> on the landing page</li>
+  </ul>
+
+  <hr class="divider" />
+  <p class="meta">Governing law: Laws of Japan · Jurisdiction: The court having jurisdiction over the registered head office of BULL LLC.</p>
+</main>
+
+<footer class="bottom">
+  © 2026 BULL LLC (合同会社BULL) · TenkaCloud · <a href="./terms.en.html">Terms of Service</a> · <a href="./legal.en.html">Business identification</a> · <a href="./">Home</a>
+</footer>
+</body>
+</html>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -47,14 +47,14 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
 <header class="top">
   <div class="wrap">
     <a class="brand" href="./">TenkaCloud</a>
-    <a class="back" href="./">← ホームへ戻る</a>
+    <span><a class="back" href="./privacy.en.html" style="color:var(--accent);text-decoration:none;font-size:13px;margin-right:8px;">English</a> · <a class="back" href="./">← ホームへ戻る</a></span>
   </div>
 </header>
 
 <main class="wrap">
   <h1>プライバシーポリシー</h1>
   <p class="lede">TenkaCloud (以下「本サービス」) における個人情報の取扱いについて。</p>
-  <p class="meta">最終更新: 2026-05-23 · 運営者: 富田進 (Susumu Tomita)</p>
+  <p class="meta">最終更新: 2026-05-23 · 運営: 合同会社BULL</p>
 
   <h2>1. 取得する情報</h2>
   <p>本サービスの提供および商談対応のため、以下の情報を取得することがあります。</p>
@@ -98,16 +98,16 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
   <h2 id="contact">8. お問い合わせ窓口</h2>
   <p>個人情報に関するお問い合わせは、 以下までご連絡ください。</p>
   <ul>
-    <li>窓口: TenkaCloud 運営 (富田進)</li>
+    <li>窓口: 合同会社BULL (TenkaCloud 運営)</li>
     <li>連絡方法: <a href="https://github.com/susumutomita/TenkaCloud/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> または LP の<a href="./#contact">お問い合わせフォーム</a></li>
   </ul>
 
   <hr class="divider" />
-  <p class="meta">準拠法: 日本国法 · 管轄裁判所: 富田進の所在地を管轄する裁判所</p>
+  <p class="meta">準拠法: 日本国法 · 管轄裁判所: 合同会社BULL の本店所在地を管轄する裁判所</p>
 </main>
 
 <footer class="bottom">
-  © 2026 TenkaCloud · <a href="./terms.html">利用規約</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
+  © 2026 合同会社BULL · TenkaCloud · <a href="./terms.html">利用規約</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
 </footer>
 </body>
 </html>

--- a/landing/terms.en.html
+++ b/landing/terms.en.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Terms of Service — TenkaCloud</title>
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="https://susumutomita.github.io/TenkaCloud/terms.en.html" />
+<link rel="alternate" hreflang="ja" href="https://susumutomita.github.io/TenkaCloud/terms.html" />
+<link rel="alternate" hreflang="en" href="https://susumutomita.github.io/TenkaCloud/terms.en.html" />
+<style>
+:root { --bg:#fafafa; --paper:#fff; --ink:#0b0e14; --ink-2:#2d343d; --ink-3:#5b6470; --line:#d8dde4; --accent:#0066cc; }
+* { box-sizing: border-box; }
+html, body { background: var(--bg); color: var(--ink); margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif; line-height: 1.8; font-size: 15px; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 0 24px 80px; }
+header.top { border-bottom: 1px solid var(--line); margin-bottom: 36px; }
+header.top .wrap { padding-top: 18px; padding-bottom: 18px; display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+.brand { color: var(--ink); text-decoration: none; font-weight: 800; letter-spacing: -0.01em; font-size: 18px; }
+.lang { color: var(--accent); text-decoration: none; font-size: 13px; }
+.lang:hover { text-decoration: underline; }
+.back { color: var(--accent); text-decoration: none; font-size: 14px; }
+.back:hover { text-decoration: underline; }
+h1 { font-size: 32px; line-height: 1.2; margin: 24px 0 8px; letter-spacing: -0.01em; }
+.lede { color: var(--ink-2); margin: 0 0 32px; font-size: 16px; }
+.meta { color: var(--ink-3); font-size: 13px; margin: 0 0 40px; }
+h2 { font-size: 20px; margin: 36px 0 12px; line-height: 1.3; }
+p, ul, ol { margin: 0 0 16px; color: var(--ink-2); }
+ul, ol { padding-left: 22px; }
+li { margin-bottom: 6px; }
+a { color: var(--accent); }
+strong { color: var(--ink); }
+.divider { border: 0; border-top: 1px solid var(--line); margin: 48px 0 32px; }
+footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; padding: 36px 0; border-top: 1px solid var(--line); }
+@media (max-width: 640px) {
+  .wrap { padding: 0 16px 60px; }
+  h1 { font-size: 26px; }
+  h2 { font-size: 18px; }
+}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap">
+    <a class="brand" href="./">TenkaCloud</a>
+    <span><a class="lang" href="./terms.html">日本語</a> · <a class="back" href="./">← Home</a></span>
+  </div>
+</header>
+
+<main class="wrap">
+  <h1>Terms of Service</h1>
+  <p class="lede">These Terms govern the paid plans (= Starter / Hosted Event / Annual Arena) of TenkaCloud (the "Service"). The Japanese version at <a href="./terms.html">/terms.html</a> is the legally binding original; this English version is provided for reference. OSS self-hosting is governed by the Apache License 2.0 instead.</p>
+  <p class="meta">Last updated: 2026-05-23 · Operator: BULL LLC (合同会社BULL)</p>
+
+  <h2>Article 1 (Scope)</h2>
+  <p>These Terms apply to all relationships between the Customer (= a corporation or individual) and BULL LLC (the "Company") regarding the provision of paid plans. Where an individual quote or contract exists, that quote / contract prevails.</p>
+
+  <h2>Article 2 (Paid plans)</h2>
+  <ul>
+    <li><strong>Starter</strong> (¥500,000 / event, tax exclusive): The Company operates a trial event of up to 2 teams.</li>
+    <li><strong>Hosted Event</strong> (¥1,500,000 / event, tax exclusive): The Company operates a single event of up to 5 teams (~20 people), end to end.</li>
+    <li><strong>Annual Arena</strong> (from ¥6,000,000 / year, tax exclusive): Annual contract for up to 4 operated events per year + learning path proposal from the public problem catalog + post-event PDF reports.</li>
+  </ul>
+  <p>Custom problem authoring, industry-specific scenarios, simultaneous events over 20 participants, and similar requirements are quoted separately.</p>
+
+  <h2>Article 3 (Application and formation of contract)</h2>
+  <p>The Customer applies for a plan via the contact form; the Company issues a quote; the contract is formed upon mutual agreement (= written / email).</p>
+
+  <h2>Article 4 (Payment)</h2>
+  <ul>
+    <li>Method: Bank transfer (= to the Company's designated account; transfer fees borne by the Customer).</li>
+    <li>Timing: Within 30 days of invoice issuance.</li>
+    <li>Late charges: 14.6% per annum (= statutory commercial rate).</li>
+  </ul>
+
+  <h2>Article 5 (Customer obligations)</h2>
+  <ul>
+    <li>AWS resources deployed by the Service are created <strong>inside the Customer's own AWS account</strong>. AWS account management (= IAM / billing / audit logs) is the Customer's responsibility.</li>
+    <li>Communicating with event participants and ensuring participants' AWS Console SSO usage complies with applicable terms (= participants do not need personal AWS accounts; they federate only to the host environment) is the Customer's responsibility.</li>
+    <li>The handling of temporary AWS credentials issued by the Service must be communicated to participants.</li>
+  </ul>
+
+  <h2>Article 6 (Company obligations)</h2>
+  <ul>
+    <li>Deliver build, day-of operation, and post-event PDF report (= 1 PDF per event) as specified by the paid plan.</li>
+    <li>Best-effort response to incidents during the event window (= deploy failures caused by the Service, portal issues, etc.).</li>
+    <li>No explicit SLA (= OSS-based). For critical incidents the parties shall consult and respond.</li>
+  </ul>
+
+  <h2>Article 7 (Prohibited acts)</h2>
+  <p>The Customer shall not:</p>
+  <ul>
+    <li>Use the Service to commit illegal acts (= unauthorized access, copyright infringement, etc.).</li>
+    <li>Use the Company's intellectual property (= logo, etc.; OSS code itself is Apache 2.0) without permission.</li>
+    <li>Use participants' personal information for purposes other than event operation.</li>
+  </ul>
+
+  <h2>Article 8 (Limitation of liability)</h2>
+  <ul>
+    <li>The Company is not liable for damages incurred by participants or third parties as a result of an event, except in cases of the Company's intent or gross negligence.</li>
+    <li>AWS usage charges (= billed directly to the Customer's account) are the Customer's responsibility. The Company bears no responsibility for AWS fees.</li>
+    <li>The same applies to unintended billing / configuration changes / resource deletions caused by participants in the AWS Console (= the Company recommends least-privilege IAM design).</li>
+  </ul>
+
+  <h2>Article 9 (Mid-term cancellation)</h2>
+  <ul>
+    <li><strong>Annual Arena</strong>: No refund for the remaining period (= annual contract characteristics). Exceptions may be agreed by the parties.</li>
+    <li>Starter / Hosted Event: Free cancellation up to 30 days before the event; 50% charge between 30 and 7 days before; 100% charge within 7 days of the event.</li>
+  </ul>
+
+  <h2>Article 10 (Governing law and jurisdiction)</h2>
+  <p>These Terms are governed by the laws of Japan. The court having jurisdiction over the registered head office of BULL LLC shall be the exclusive court of agreement for any dispute regarding the Service.</p>
+
+  <h2>Article 11 (Revisions)</h2>
+  <p>The Company may revise these Terms in response to changes in law or in the Service. Material revisions will be notified at least 30 days in advance on this page or by email.</p>
+
+  <hr class="divider" />
+  <p class="meta">For OSS self-hosting (= Apache License 2.0), these Terms do not apply; the LICENSE (<a href="https://github.com/susumutomita/TenkaCloud/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">view</a>) applies.</p>
+</main>
+
+<footer class="bottom">
+  © 2026 BULL LLC (合同会社BULL) · TenkaCloud · <a href="./privacy.en.html">Privacy Policy</a> · <a href="./legal.en.html">Business identification</a> · <a href="./">Home</a>
+</footer>
+</body>
+</html>

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -38,14 +38,14 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
 <header class="top">
   <div class="wrap">
     <a class="brand" href="./">TenkaCloud</a>
-    <a class="back" href="./">← ホームへ戻る</a>
+    <span><a class="back" href="./terms.en.html" style="color:var(--accent);text-decoration:none;font-size:13px;margin-right:8px;">English</a> · <a class="back" href="./">← ホームへ戻る</a></span>
   </div>
 </header>
 
 <main class="wrap">
   <h1>利用規約</h1>
   <p class="lede">TenkaCloud (以下「本サービス」) の有料プラン (= Starter / Hosted Event / Annual Arena) をご利用いただく際の利用規約。 OSS としての利用 (= 自前 AWS 環境へ deploy する自己ホスト) は Apache License 2.0 が優先します。</p>
-  <p class="meta">最終更新: 2026-05-23 · 運営者: 富田進 (Susumu Tomita)</p>
+  <p class="meta">最終更新: 2026-05-23 · 運営: 合同会社BULL</p>
 
   <h2>第 1 条 (適用)</h2>
   <p>本規約は、 お客様 (= 法人または個人) と 本サービス運営者 (以下「当社」) の間の、 有料プランの提供に関するすべての関係に適用されます。 個別の見積書 / 契約書がある場合は、 そちらが優先します。</p>
@@ -104,7 +104,7 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
   </ul>
 
   <h2>第 10 条 (準拠法・管轄)</h2>
-  <p>本規約は日本国法に準拠し、 本サービスに関する一切の紛争は、 富田進の所在地を管轄する裁判所を 専属的合意管轄裁判所とします。</p>
+  <p>本規約は日本国法に準拠し、 本サービスに関する一切の紛争は、 合同会社BULL の本店所在地を管轄する裁判所を 専属的合意管轄裁判所とします。</p>
 
   <h2>第 11 条 (改定)</h2>
   <p>当社は、 法令の変更や本サービスの内容の変更に応じて、 本規約を改定することがあります。 重要な改定がある場合は、 30 日前までに本ページまたはメールで お知らせします。</p>
@@ -114,7 +114,7 @@ footer.bottom { color: var(--ink-3); font-size: 13px; text-align: center; paddin
 </main>
 
 <footer class="bottom">
-  © 2026 TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
+  © 2026 合同会社BULL · TenkaCloud · <a href="./privacy.html">プライバシーポリシー</a> · <a href="./legal.html">特定商取引法に基づく表記</a> · <a href="./">ホーム</a>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

利用者要請の一括対応:

1. **「独自問題の追加開発」** option を contact form select に追加
2. **運営を 「合同会社BULL」 に統一** (= 個人責任 minimize、 法人化)
3. **プライバシー / 利用規約 / 特商法 の en 版** 新規作成 (`.en.html`)
4. LP footer の legal link を locale 連動 (= en visitor は en 版へ遷移)

## 1. 「独自問題の追加開発」 option

旧 select: 未定 / Starter / Hosted / Annual / OSS / その他
新 select: 未定 / Starter / Hosted / Annual / **独自問題の追加開発** / OSS / その他

ja / en 同期 (= `contact.plan_custom_problem` data-i18n key)。

## 2. 運営を 「合同会社BULL」 に統一

旧: 「TenkaCloud 運営 (富田進 / Susumu Tomita)」 が contact fineprint / legal pages / footer copyright に散在 → 個人責任に倒れる構造。

新: 全 operator 表記を **「合同会社BULL」 / 「BULL LLC」** に統一。

| 場所 | 旧 | 新 |
|---|---|---|
| contact.fineprint (ja) | 「TenkaCloud 運営 (富田進)。」 | 「合同会社BULL (TenkaCloud 運営)。」 |
| contact.fineprint (en) | "TenkaCloud (Susumu Tomita)." | "BULL LLC (operator of TenkaCloud)." |
| privacy.html / terms.html `運営者` | 「富田進 (Susumu Tomita)」 | 「合同会社BULL」 |
| 準拠法 / 管轄裁判所 | 「富田進の所在地」 | 「合同会社BULL の本店所在地」 |
| footer copyright (ja) | 「© 2026 TenkaCloud · Susumu Tomita」 | 「© 2026 合同会社BULL · TenkaCloud」 |
| footer copyright (en) | 同上 | 「© 2026 BULL LLC (合同会社BULL) · TenkaCloud」 |

### 法的要件としての代表者表示

**legal.html / legal.en.html の 「代表者」 欄のみ** に 「代表社員 富田進」 / 「Susumu Tomita (Representative Member)」 を残す。 これは **特定商取引法 第 11 条** が法人の場合に 「名称 + 代表者氏名」 の両方を要求するため、 法律要件として削除不可 (= 削除すると法令違反)。 個人名の露出は 特商法 page 1 箇所のみに最小化。

## 3. en 版 legal pages 新規作成

3 file 追加:
- `landing/privacy.en.html`
- `landing/terms.en.html`
- `landing/legal.en.html`

各 page で:
- ja 版を 「legally binding original」 として明示 (= 日本法人なので 日本語版が正本)
- en 版は 「reference」 と位置付け
- `<link rel="alternate" hreflang>` で SEO 連携
- ヘッダーに 「日本語」 ⇄ 「English」 言語切替リンク

合わせて ja page の header にも 「English」 link を追加。

## 4. LP footer の legal link を locale 連動

`applyLang(lang)` 内で footer link href を swap:
- `lang=ja` → `./privacy.html` / `./terms.html` / `./legal.html` (= ja 版)
- `lang=en` → `./privacy.en.html` / `./terms.en.html` / `./legal.en.html` (= en 版)

これで en visitor が footer の "Privacy Policy" link をクリックしたとき、 en 版に直接飛ぶ。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / build 全 pass)
- [ ] 手動 (= Pages merge 後):
  - LP で lang=ja → footer の link が ja 版に
  - LP で lang=en → footer の link が en 版に切替
  - contact form select に 「独自問題の追加開発」 が出る
  - contact form fineprint が 「合同会社BULL (TenkaCloud 運営)」 になる
  - 各 legal page の header から 言語切替が動作

## Regression analysis

- en 版は新規追加のみ、 ja 版の意味変更なし (= 「合同会社BULL」 への operator 置換は事実関係を明示するだけ)
- 特商法 11 条 法的要件 (= 代表者氏名) は legal.html / legal.en.html 1 か所のみに最小化
- LP footer href swap は既存 link object に対する mutation のみ、 構造変更なし

## Physical impact

- NO-OP infra
- UPDATE: `landing/index.html` (contact form / fineprint / footer / applyLang)
- UPDATE: `landing/{privacy,terms,legal}.html` (operator 表記)
- CREATE: `landing/{privacy,terms,legal}.en.html` (3 新規 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom problem plan option to the contact form
  * Launched English versions of legal disclosure, privacy policy, and terms of service pages

* **Documentation**
  * Updated company operator attribution from individual to 合同会社BULL across all pages
  * Implemented language-aware navigation that automatically switches between Japanese and English versions of legal documents

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->