### PR TITLE
feat(harness): enforce no merge conflicts as completion condition

### DIFF
--- a/.claude/harness/src/rules/index.ts
+++ b/.claude/harness/src/rules/index.ts
@@ -4,6 +4,7 @@ import { fileTooLarge } from "./file-too-large.ts";
 import { handlerNoDirectSdkImport } from "./handler-no-direct-sdk-import.ts";
 import { handlerTenantIsolation } from "./handler-tenant-isolation.ts";
 import { iamWildcardNeedsJustify } from "./iam-wildcard-needs-justify.ts";
+import { noConflictMarkers } from "./no-conflict-markers.ts";
 
 export const architectureRules = [
   adrMustBeHtml,
@@ -14,4 +15,6 @@ export const architectureRules = [
   handlerNoDirectSdkImport,
   // Issue #997 / tenant 分離 audit
   handlerTenantIsolation,
+  // feedback_pull_main_before_task: PR の conflict を防ぐ第一線。 commit 内の marker 検知
+  noConflictMarkers,
 ] as const;

--- a/.claude/harness/src/rules/no-conflict-markers.test.ts
+++ b/.claude/harness/src/rules/no-conflict-markers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { noConflictMarkers } from "./no-conflict-markers.ts";
+
+function ctx(files: Record<string, string>) {
+  return {
+    files: Object.keys(files),
+    readFile: (p: string) => files[p] ?? "",
+  };
+}
+
+describe("noConflictMarkers", () => {
+  it("should pass when no conflict markers exist", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        "apps/foo/src/bar.ts": "const x = 1;\nconst y = 2;\n",
+        "docs/architecture/adr-001-foo.html": "<html><body>ok</body></html>",
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("should flag a file with <<<<<<< marker", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        "apps/foo/src/bar.ts":
+          "const x = 1;\n<<<<<<< HEAD\nconst y = 2;\n=======\nconst y = 3;\n>>>>>>> origin/main\n",
+      }),
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.ruleId).toBe("no-conflict-markers");
+    expect(findings[0]?.line).toBe(2);
+    expect(findings[0]?.match).toBe("<<<<<<< HEAD");
+    expect(findings[0]?.severity).toBe("error");
+  });
+
+  it("should flag a file with bare ======= marker", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        "docs/foo.md": "intro\n=======\nrest\n",
+      }),
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.line).toBe(2);
+  });
+
+  it("should not confuse markdown setext h1 ====== (= must equal exactly =======) with conflict", () => {
+    // markdown の setext heading は通常 5 = or more の連続。 git conflict は厳密に 7 =。
+    const findings = noConflictMarkers.check(
+      ctx({
+        "docs/foo.md": "title\n=====\n\nbody\n",
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("should skip binary-like extensions (no scan)", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        "assets/foo.png": "<<<<<<< not actually conflict\n",
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("should skip its own test file (= allows literal markers in fixture)", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        ".claude/harness/src/rules/no-conflict-markers.test.ts": "<<<<<<< literal in test\n",
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("should report only the first marker line per file (= 1 finding / file)", () => {
+    const findings = noConflictMarkers.check(
+      ctx({
+        "apps/x.ts": "<<<<<<< HEAD\na\n=======\nb\n>>>>>>> origin/main\n<<<<<<< HEAD\nc\n",
+      }),
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.line).toBe(1);
+  });
+});

--- a/.claude/harness/src/rules/no-conflict-markers.ts
+++ b/.claude/harness/src/rules/no-conflict-markers.ts
@@ -1,0 +1,84 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+
+/**
+ * Git merge / rebase 中に残った conflict marker (`<<<<<<<` / `=======` / `>>>>>>>`)
+ * が commit に紛れ込むのを防ぐ。 行頭にこれらが出現したらすべて error 扱い。
+ *
+ * 同様の検知は git の merge driver / pre-commit hook でも可能だが、 harness で再確認
+ * することで:
+ *   - rebase 中に conflict 解消し忘れた行を CI でも検知できる
+ *   - reviewer が conflict marker を見落としても block できる
+ *
+ * 副作用: harness 自身のテストファイル等 (= 意図的に conflict marker をリテラルとして
+ * 書きたい test fixture) は除外する必要がある。 ignore 対象は `.test.ts` 末尾を含む
+ * パスのうち、 本 rule 自身のテスト (= `no-conflict-markers.test.ts`) のみ。
+ */
+
+const CONFLICT_MARKER_LINE_RE = /^(<<<<<<< |=======$|>>>>>>> )/m;
+const SCAN_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".json",
+  ".md",
+  ".html",
+  ".css",
+  ".yaml",
+  ".yml",
+  ".sh",
+]);
+
+function shouldScan(path: string): boolean {
+  // 本 rule 自身のテスト fixture は除外。 他に意図的に conflict marker をリテラルで
+  // 書く必要が出てきたら、 ここに足す。
+  if (path.endsWith("no-conflict-markers.test.ts")) return false;
+  // 拡張子なし / バイナリ は scan しない
+  const dotIdx = path.lastIndexOf(".");
+  if (dotIdx < 0) return false;
+  return SCAN_EXTENSIONS.has(path.slice(dotIdx));
+}
+
+function findFirstMarkerLine(content: string): { line: number; match: string } | undefined {
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const l = lines[i] ?? "";
+    if (l.startsWith("<<<<<<< ") || l === "=======" || l.startsWith(">>>>>>> ")) {
+      return { line: i + 1, match: l };
+    }
+  }
+  return undefined;
+}
+
+export const noConflictMarkers: Rule = {
+  id: "no-conflict-markers",
+  severity: "error",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldScan(path)) continue;
+      let content: string;
+      try {
+        content = ctx.readFile(path);
+      } catch {
+        continue;
+      }
+      // 高速 pre-check: marker パターンが含まれているか
+      if (!CONFLICT_MARKER_LINE_RE.test(content)) continue;
+      const hit = findFirstMarkerLine(content);
+      if (!hit) continue;
+      findings.push({
+        ruleId: "no-conflict-markers",
+        severity: "error",
+        filePath: path,
+        line: hit.line,
+        match: hit.match,
+        message:
+          "Git merge / rebase 中に残った conflict marker が含まれています。 commit 前に必ず解消してください。",
+        recommendation:
+          "該当箇所 (= `<<<<<<<` / `=======` / `>>>>>>>` を含む行群) を編集して正しい内容を残し、 marker 自体を削除してから `git add` し直してください。 もし conflict 解消後に再度 PR ブランチを最新 main から rebase したい場合は `git fetch origin main && git rebase origin/main` を実行 (memory: feedback_pull_main_before_task)。",
+      });
+    }
+    return findings;
+  },
+};

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,17 @@ check-template-cfn-refs: ; bun run scripts/check-template-cfn-refs.ts
 # 現状は既存 5 テンプレが未対応なので standalone target のみ。 TenkaCloudChallenge 側で
 # templates を更新してから before-commit / check に組み込む (follow-up PR で wire)。
 check-template-cli-access: ; bun run scripts/check-template-cli-access.ts
+# feedback_pull_main_before_task: 現在のブランチが origin/main と clean に merge 可能かを
+# git merge-tree (= read-only dry-run) で検査。 conflict 発生時は exit 1 で fail。
+# CI / pre-push hook ともに、 「PR を出した瞬間に DIRTY になる」 のを未然に防ぐ。
+check-no-conflicts: ; bun run scripts/check-no-conflicts.ts
 audit-deps:    ; bun run audit:dependencies
 # `check-problems-index` は submodule (= TenkaCloudChallenge) 側 catalog CI に責任を移譲した
 # ため、 本体 before-commit / check からは外す。 platform 側 build:problems-index を走らせると
 # catalog repo の biome JSON formatter (= 別 lock 版) と微妙な drift が出てしまうため、
 # index.json の正本性は catalog 側で担保する設計。
-check:         install lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs audit-deps check-synth
-before-commit: lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs audit-deps check-synth
+check:         install lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-no-conflicts audit-deps check-synth
+before-commit: lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-no-conflicts audit-deps check-synth
 
 # `cdk synth` が通ることを保証 (= ts-node / tsx の module resolution、 stack 構築の type error
 # 等を本番 deploy 前にキャッチ)。 Makefile placeholder env で全 stack を synth するので AWS 認証は不要。

--- a/docs/architecture/harness.html
+++ b/docs/architecture/harness.html
@@ -123,6 +123,11 @@ PR body に <code>## 物理影響</code> セクションを置く。そこで <c
 <li><p><code>adr-self-contained</code>
 <code>docs/architecture/adr-*.html</code> に chat 文脈、段階的反映 metadata、AI agent との役割分担メモが含まれると error。ADR は OSS readers が単独で読める正本として書く。既存違反は <code>.claude/harness/baselines/adr-self-contained.json</code> に baseline 化し、新規 regression だけを捕まえる。</p>
 </li>
+<li><p><code>no-conflict-markers</code>
+Git merge / rebase 中に残った conflict marker (<code>&lt;&lt;&lt;&lt;&lt;&lt;&lt;</code> / <code>=======</code> / <code>&gt;&gt;&gt;&gt;&gt;&gt;&gt;</code> の行頭) を任意の TS / TSX / JS / JSX / JSON / MD / HTML / CSS / YAML / SH に検出すると error。 commit に conflict marker が紛れて push されるのを止める第一線。</p>
+<p>これと対をなす Git 層チェックが <code>make check-no-conflicts</code> (= <code>scripts/check-no-conflicts.ts</code>)。 こちらは <code>git merge-tree HEAD origin/main</code> で「現在のブランチが origin/main に clean に merge できるか」を dry-run 検査する。 PR を出す瞬間に DIRTY (= 上流が進んだ) になるのを未然に防ぐ。 <code>make before-commit</code> に組み込まれており、 fail すると pre-commit で止まる。</p>
+<p>両方とも記憶[[feedback_pull_main_before_task]]に紐づく仕掛け。</p>
+</li>
 </ul>
 <h2>Enforcement</h2>
 <ul>

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -76,6 +76,13 @@ Invariants に加えて、実装レベルの原則を機械検査するルール
 - `adr-self-contained`
   `docs/architecture/adr-*.html` に chat 文脈、段階的反映 metadata、AI agent との役割分担メモが含まれると error。ADR は OSS readers が単独で読める正本として書く。既存違反は `.claude/harness/baselines/adr-self-contained.json` に baseline 化し、新規 regression だけを捕まえる。
 
+- `no-conflict-markers`
+  Git merge / rebase 中に残った conflict marker (`<<<<<<<` / `=======` / `>>>>>>>` の行頭) を任意の TS / TSX / JS / JSX / JSON / MD / HTML / CSS / YAML / SH に検出すると error。 commit に conflict marker が紛れて push されるのを止める第一線。
+
+  これと対をなす Git 層チェックが `make check-no-conflicts` (= `scripts/check-no-conflicts.ts`)。 こちらは `git merge-tree HEAD origin/main` で「現在のブランチが origin/main に clean に merge できるか」を dry-run 検査する。 PR を出す瞬間に DIRTY (= 上流が進んだ) になるのを未然に防ぐ。 `make before-commit` に組み込まれており、 fail すると pre-commit で止まる。
+
+  両方とも記憶[[feedback_pull_main_before_task]]に紐づく仕掛け。
+
 ## Enforcement
 
 - `make harness` (= `bun run .claude/harness/bin/architecture.ts --staged --fail-on=error`)

--- a/scripts/check-no-conflicts.ts
+++ b/scripts/check-no-conflicts.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Verify that the current working tree (HEAD) merges cleanly into the latest
+ * `origin/main`. Fails (exit 1) if any conflict would occur.
+ *
+ * Why: `make before-commit` historically didn't surface "your branch is stale
+ * vs origin/main" issues — they only appeared at PR push time as DIRTY merge
+ * state. Memory feedback_pull_main_before_task records the user's request to
+ * pull latest main before starting work; this script enforces it programmatically.
+ *
+ * Mechanism:
+ *   1. `git fetch origin main` to sync the remote ref.
+ *   2. `git merge-tree --write-tree --no-messages origin/main HEAD` produces a
+ *      synthetic tree object; any conflict makes the command exit non-zero (in
+ *      newer git) or emit conflict markers in stdout. We treat either signal
+ *      as failure.
+ *   3. On main itself, skip (= no point checking).
+ *   4. On detached HEAD / shallow clone / offline (= fetch fails), warn but
+ *      pass (= don't block legitimate flows).
+ */
+import { execSync } from "node:child_process";
+
+interface RunResult {
+  readonly stdout: string;
+  readonly status: number;
+}
+
+function run(cmd: string): RunResult {
+  try {
+    const stdout = execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return { stdout, status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; status?: number };
+    const stdout = typeof e.stdout === "string" ? e.stdout : (e.stdout?.toString() ?? "");
+    return { stdout, status: e.status ?? 1 };
+  }
+}
+
+function currentBranch(): string {
+  return run("git rev-parse --abbrev-ref HEAD").stdout.trim();
+}
+
+function fetchOriginMain(): boolean {
+  const r = run("git fetch --quiet origin main");
+  return r.status === 0;
+}
+
+function mergeTreeAgainstOriginMain(): { ok: boolean; details: string } {
+  // `git merge-tree --write-tree` is the modern (git 2.38+) interface that does
+  // a true three-way merge without touching the working tree. On conflict it
+  // exits non-zero AND prints a structured conflict info block to stdout.
+  const r = run("git merge-tree --write-tree --no-messages HEAD origin/main");
+  if (r.status === 0) return { ok: true, details: "" };
+  // Older git: fall back to plain `merge-tree` which prints markers to stdout.
+  const base = run("git merge-base HEAD origin/main").stdout.trim();
+  if (!base) {
+    return { ok: false, details: "git merge-base HEAD origin/main failed (= no common ancestor)" };
+  }
+  const r2 = run(`git merge-tree ${base} HEAD origin/main`);
+  const hasMarker = /^<<<<<<< |^=======$|^>>>>>>> /m.test(r2.stdout);
+  if (!hasMarker) return { ok: true, details: "" };
+  // Extract conflicting paths from `+<<<<<<< file` etc.
+  const paths = Array.from(r2.stdout.matchAll(/\n@@ \S* (\S+) /g))
+    .map((m) => m[1])
+    .filter((s, i, a): s is string => typeof s === "string" && a.indexOf(s) === i);
+  return {
+    ok: false,
+    details:
+      paths.length > 0 ? `paths likely involved: ${paths.join(", ")}` : "see git merge-tree output",
+  };
+}
+
+function main(): number {
+  const branch = currentBranch();
+  if (branch === "main" || branch === "HEAD") {
+    console.log(`SKIP check-no-conflicts (= branch is "${branch}")`);
+    return 0;
+  }
+  if (!fetchOriginMain()) {
+    console.warn("WARN check-no-conflicts: failed to fetch origin/main (offline?); skipping");
+    return 0;
+  }
+  const result = mergeTreeAgainstOriginMain();
+  if (!result.ok) {
+    console.error("ERROR check-no-conflicts: HEAD does NOT merge cleanly into origin/main.");
+    if (result.details) console.error(`  ${result.details}`);
+    console.error(
+      "  → Run: git fetch origin main && git merge origin/main (resolve conflicts, then commit).",
+    );
+    console.error(
+      "  → Or rebase: git fetch origin main && git rebase origin/main (= linear history).",
+    );
+    return 1;
+  }
+  console.log("OK  HEAD merges cleanly into origin/main");
+  return 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

利用者フィードバック (= [[feedback_pull_main_before_task]]):
> 「PR がコンフリクトしてないこと」 も完了条件にしてハーネスに加えておいて

「stale base から分岐 → PR push 直後に DIRTY」 という事故を **2 段階** で防ぐ:

| 層 | ツール | 何を見るか |
|---|---|---|
| **ファイル内** | `no-conflict-markers` harness rule | 行頭の `<<<<<<<` / `=======` / `>>>>>>>` が commit に残っていないか |
| **git ブランチ** | `make check-no-conflicts` | `git merge-tree HEAD origin/main` で現ブランチが clean に merge できるか |

両方とも `make before-commit` に組み込まれ、 pre-commit hook で止まる。

## 1. `no-conflict-markers` (harness rule)

`.claude/harness/src/rules/no-conflict-markers.ts` を新規追加。

- TS / TSX / JS / JSX / JSON / MD / HTML / CSS / YAML / SH に行頭マーカー検出で **error**
- 本 rule 自身のテスト fixture (= `no-conflict-markers.test.ts`) は除外
- ファイル 1 つあたり 最初の hit 1 件だけ報告 (= overwhelming にしない)
- Markdown setext heading `=====` (5 個以下) は厳密に `=======` (7 個) のみを検知する正規表現で誤検知を回避

Tests: 7 case 全 pass:
- clean (no marker)
- `<<<<<<<` HEAD
- bare `=======`
- markdown setext h1 `=====` (= false positive 回避)
- 非対象拡張子 (e.g. png)
- 自身のテスト fixture (= 除外)
- 1 finding / file (= 重複しない)

## 2. `make check-no-conflicts` (git layer)

`scripts/check-no-conflicts.ts` + Makefile target を新規追加。

```bash
$ make check-no-conflicts
OK  HEAD merges cleanly into origin/main
```

実装:
- `git fetch origin main && git merge-tree HEAD origin/main` で dry-run
- conflict が出れば exit 1、 「`git fetch && git merge` / `git rebase` を実行」 hint を stderr に出す
- main ブランチ / detached HEAD / オフライン時は skip (= 偽陽性回避)
- `make check` および `make before-commit` のチェック群に組み込み

これで pre-commit 時点で 「現ブランチが origin/main と clean に merge できるか」 が必ず検証される。 PR を出す瞬間に DIRTY になるのを未然に防ぐ。

## 3. `docs/architecture/harness.md` 更新

「Enforcement Rules」 セクションに `no-conflict-markers` の説明を追加。 git 層 check との対が記述されており、 紐づく memory (`feedback_pull_main_before_task`) も明示。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make harness-test` (= new rule 7 case 含めて全 pass)
- [x] `make check-no-conflicts` (= clean state で success)
- [x] `make before-commit` (lint / typecheck / build / 全 test 含めて全 pass)
- [ ] 手動: conflict marker を書いた dummy ファイルを 1 つ commit して harness が error を出すこと
- [ ] 手動: stale base から branching して `make check-no-conflicts` が fail すること

## Regression analysis

- 新規 rule は新規 .ts ファイル追加のみ、 既存 rule には影響なし
- Makefile に `check-no-conflicts` target を追加し、 `check` / `before-commit` に sequence で組み込み。 既存 target の動作は変更なし
- script は read-only (= `git merge-tree --write-tree --no-messages` は dry-run、 working tree を一切触らない)
- main / detached HEAD / オフライン時の skip 分岐で通常 dev フローはブロックしない

## Physical impact

- NO-OP infra (= CDK / IAM / DDB 変更なし)
- CREATE: `.claude/harness/src/rules/no-conflict-markers.ts` + test
- CREATE: `scripts/check-no-conflicts.ts`
- UPDATE: `.claude/harness/src/rules/index.ts` (rule register)
- UPDATE: `Makefile` (= 新 target + check / before-commit に組み込み)
- UPDATE: `docs/architecture/harness.md` + html (= rule の説明追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)