### PR TITLE
refactor(portal): remove isMock prop drill + extract dev-mock flag-submit module

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -224,14 +224,11 @@ export function ProblemPanel({
   apiBaseUrl,
   sessionToken,
   onScored,
-  isMock = false,
 }: {
   problem: ParticipantProblemView;
   apiBaseUrl: string;
   sessionToken: string;
   onScored: () => Promise<void>;
-  /** dev-mock mode: backend を呼ばず submit を local で評価する (= LP 「モックで試す」 用)。 */
-  isMock?: boolean;
 }) {
   const t = useT();
   const now = useNowMs(COUNTDOWN_REFRESH_MS);
@@ -318,7 +315,6 @@ export function ProblemPanel({
             points={flagScoring.points ?? 0}
             hints={flagScoring.hints ?? []}
             onScored={onScored}
-            isMock={isMock}
           />
         )}
         {shouldShowAutoRefreshNote(problem.status) && (

--- a/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
+++ b/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
@@ -13,6 +13,8 @@ import {
   type SubmitFlagOutcome,
   submitFlag,
 } from "../api/portal-client";
+import { useIsMock } from "../config-context";
+import { evaluateMockFlag } from "../dev-mock/flag-submit";
 import { useT } from "../i18n";
 import { describeAgo } from "../lib/format";
 import { CelebrationOverlay } from "./CelebrationOverlay";
@@ -29,7 +31,6 @@ export function FlagSubmissionPanel({
   points,
   hints,
   onScored,
-  isMock = false,
 }: {
   apiBaseUrl: string;
   sessionToken: string;
@@ -38,14 +39,12 @@ export function FlagSubmissionPanel({
   points: number;
   hints: readonly ParticipantHintView[];
   onScored: () => Promise<void>;
-  /**
-   * dev-mock mode (= LP の 「モックで試す」 動線)。 true のとき submit を backend に投げず、
-   * local state で 「正解 → celebration」 「不正解 → 減点 + リトライ」 を再現する。
-   * 本物の AWS 環境は無いので flag の中身は問わず、 任意 1 文字以上の入力で OK とする。
-   */
-  isMock?: boolean;
 }) {
   const t = useT();
+  // dev-mock mode (= LP 「モックで試す」 動線) のとき submit を backend に投げず、
+  // dev-mock/flag-submit.evaluateMockFlag で local 評価する。 mode は AppConfig
+  // context から直接読む (= 旧 isMock prop drill を撤去)。
+  const isMock = useIsMock();
   const [flag, setFlag] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
@@ -72,7 +71,7 @@ export function FlagSubmissionPanel({
     setOutcome(null);
     try {
       const result = isMock
-        ? simulateMockFlagSubmit(flag, points)
+        ? evaluateMockFlag(flag, points)
         : await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
       setOutcome(result);
       if (result.kind === "ok") setMockCleared(true);
@@ -161,47 +160,6 @@ export function FlagSubmissionPanel({
       )}
     </SpaceBetween>
   );
-}
-
-/**
- * dev-mock 用 mock flag 検証。 LP visitor が submit 体験を試せるよう、 固定の
- * 「正解」 文字列 `tenkacloudsample` (case-insensitive、 部分一致) のときに celebration を
- * 出し、 それ以外は不正解 (= 減点 + リトライ) にする。 placeholder で答えを示唆する。
- */
-export const MOCK_CORRECT_FLAG = "tenkacloudsample";
-
-/**
- * Easter eggs. ふざけて submit してくれた visitor へのリワード (= 全部 正解扱い)。
- *  - `42`               : The Hitchhiker's Guide to the Galaxy
- *  - `claude`           : 開発で使ってる AI agent への nod
- *  - `kaizen`           : 改善 = 日本語の karma
- *  - `tenkadev`         : 開発者専用 dev wink
- *  - `konnichiwa`       : ja LP visitor 向け hello
- *  - `tenka`            : 部分マッチで通したいゆるさ
- */
-const MOCK_EASTER_EGGS: readonly string[] = [
-  "42",
-  "claude",
-  "kaizen",
-  "tenkadev",
-  "konnichiwa",
-  "tenka",
-];
-
-function simulateMockFlagSubmit(flag: string, points: number): SubmitFlagOutcome {
-  const trimmed = flag.trim().toLowerCase();
-  if (trimmed.length === 0) {
-    return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
-  }
-  // `tenkacloudsample` を含むか、 逆に `tenkacloudsample` が入力を含むときも OK
-  // (= ユーザが `tenkacloud` だけ入れても通る、 typo に少し寛容)。
-  if (trimmed.includes(MOCK_CORRECT_FLAG) || MOCK_CORRECT_FLAG.includes(trimmed)) {
-    return { kind: "ok", scoreDelta: points, totalScore: points };
-  }
-  if (MOCK_EASTER_EGGS.some((egg) => trimmed === egg)) {
-    return { kind: "ok", scoreDelta: points, totalScore: points };
-  }
-  return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
 }
 
 function canSubmitFlag(flag: string, submitting: boolean): boolean {

--- a/apps/participant-portal/src/config-context.tsx
+++ b/apps/participant-portal/src/config-context.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+import type { AppConfig } from "./config";
+
+/**
+ * `AppConfig` は `loadConfig()` で起動時に解決し、 main.tsx で `<AppConfigProvider>` に
+ * 渡す。 page / component は `useAppConfig()` で参照する。
+ *
+ * **Why a context (= prop drill 廃止)**:
+ *   旧: page → ProblemPanel → FlagSubmissionPanel と 3 段で `isMock={config.mode !==
+ *       "backend"}` を渡していた (= Thermo-Nuclear review P1 指摘の thin wrapper)。
+ *   新: 中間 component は config を知らない。 葉 component が必要なら useAppConfig で
+ *       直接読む。 derived `isMock` も `useIsMock()` helper として提供。
+ *
+ * Mock / backend の API 呼び分け (= フル adapter) は別 PR で順次。 まずは prop drill
+ * 撲滅と簡易な mock 判定統合まで。
+ */
+
+const AppConfigContext = createContext<AppConfig | null>(null);
+
+export function AppConfigProvider({
+  config,
+  children,
+}: {
+  readonly config: AppConfig;
+  readonly children: ReactNode;
+}) {
+  // Object identity を react-friendly に固定 (= props.config が同じ参照なら再 render
+  // 連鎖を抑える)。 loadConfig は起動時 1 回しか走らないので useMemo 不要だが、 念のため
+  // wrap して context value の参照同一性を保証する。
+  const value = useMemo(() => config, [config]);
+  return <AppConfigContext.Provider value={value}>{children}</AppConfigContext.Provider>;
+}
+
+export function useAppConfig(): AppConfig {
+  const ctx = useContext(AppConfigContext);
+  if (!ctx) throw new Error("useAppConfig must be used inside <AppConfigProvider>");
+  return ctx;
+}
+
+/**
+ * `mode !== "backend"` を返す derived hook。 dev-mock / future な offline 系を 1 箇所で
+ * 同義語化する (= 「backend 連携している」 の否定 = mock-mode と表現)。
+ */
+export function useIsMock(): boolean {
+  return useAppConfig().mode !== "backend";
+}

--- a/apps/participant-portal/src/dev-mock/flag-submit.ts
+++ b/apps/participant-portal/src/dev-mock/flag-submit.ts
@@ -1,0 +1,57 @@
+import type { SubmitFlagOutcome } from "../api/portal-client";
+
+/**
+ * dev-mock 用の flag 検証ロジック。
+ *
+ * 本物の AWS / scoring backend は存在しないので、 LP 「モックで試す」 動線では portal
+ * の `submitFlag` を呼ぶ代わりに本関数を直接 invoke する。 LP visitor が submit 体験
+ * (= celebration / wrong-answer の両方) を実機と同じ UX で試せるようにする。
+ *
+ * 正解判定:
+ *   1. canonical flag `tenkacloudsample` を `includes` で部分一致 (= 大文字小文字を
+ *      区別しない)。 typo 寛容 (`tenkacloud` 等の prefix 単独でも OK)。
+ *   2. EASTER_EGGS のいずれかと exact match。
+ *
+ * これ以外は wrong (= -10 pt + リトライ可)。
+ *
+ * Easter egg は demo UX を盛り上げる遊び (= `42` / `claude` / `kaizen` / `tenkadev`
+ * / `konnichiwa` / `tenka`)。 production code には影響しないので 「mock-only の
+ * 余り遊び」 として fixture 側 (= 本ファイル) に閉じ込める。
+ */
+
+export const CANONICAL_MOCK_FLAG = "tenkacloudsample";
+
+export const EASTER_EGGS: readonly string[] = [
+  "42",
+  "claude",
+  "kaizen",
+  "tenkadev",
+  "konnichiwa",
+  "tenka",
+];
+
+const WRONG_OUTCOME: SubmitFlagOutcome = {
+  kind: "wrong",
+  scoreDelta: -10,
+  totalScore: -10,
+  wrongCount: 1,
+};
+
+function isCanonicalMatch(trimmed: string): boolean {
+  if (trimmed.length === 0) return false;
+  // `tenkacloudsample` を含むか、 逆に `tenkacloudsample` が入力を含む (= prefix
+  // 単独 `tenkacloud` も OK)
+  return trimmed.includes(CANONICAL_MOCK_FLAG) || CANONICAL_MOCK_FLAG.includes(trimmed);
+}
+
+function isEasterEgg(trimmed: string): boolean {
+  return EASTER_EGGS.includes(trimmed);
+}
+
+export function evaluateMockFlag(rawFlag: string, points: number): SubmitFlagOutcome {
+  const trimmed = rawFlag.trim().toLowerCase();
+  if (isCanonicalMatch(trimmed) || isEasterEgg(trimmed)) {
+    return { kind: "ok", scoreDelta: points, totalScore: points };
+  }
+  return WRONG_OUTCOME;
+}

--- a/apps/participant-portal/src/main.tsx
+++ b/apps/participant-portal/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { App } from "./App";
 import { loadConfig } from "./config";
+import { AppConfigProvider } from "./config-context";
 import { I18nProvider } from "./i18n";
 
 const root = document.getElementById("root");
@@ -18,9 +19,11 @@ loadConfig()
     createRoot(root).render(
       <StrictMode>
         <I18nProvider>
-          <BrowserRouter basename={ROUTER_BASENAME}>
-            <App config={config} />
-          </BrowserRouter>
+          <AppConfigProvider config={config}>
+            <BrowserRouter basename={ROUTER_BASENAME}>
+              <App config={config} />
+            </BrowserRouter>
+          </AppConfigProvider>
         </I18nProvider>
       </StrictMode>,
     );

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -149,7 +149,6 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
           apiBaseUrl={config.apiBaseUrl}
           sessionToken={sessionToken ?? ""}
           onScored={refresh}
-          isMock={config.mode !== "backend"}
         />
       )}
 

--- a/apps/participant-portal/test/dev-mock/flag-submit.test.ts
+++ b/apps/participant-portal/test/dev-mock/flag-submit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { CANONICAL_MOCK_FLAG, EASTER_EGGS, evaluateMockFlag } from "../../src/dev-mock/flag-submit";
+
+describe("evaluateMockFlag", () => {
+  it("should accept the canonical flag exactly", () => {
+    expect(evaluateMockFlag(CANONICAL_MOCK_FLAG, 800)).toEqual({
+      kind: "ok",
+      scoreDelta: 800,
+      totalScore: 800,
+    });
+  });
+
+  it("should accept case-insensitive variants", () => {
+    expect(evaluateMockFlag("TENKACLOUDSAMPLE", 800).kind).toBe("ok");
+    expect(evaluateMockFlag("TenkaCloudSample", 800).kind).toBe("ok");
+  });
+
+  it("should accept a strict prefix of the canonical (= typo 寛容)", () => {
+    expect(evaluateMockFlag("tenkacloud", 800).kind).toBe("ok");
+    expect(evaluateMockFlag("tenka", 800).kind).toBe("ok");
+  });
+
+  it("should accept a string that contains the canonical", () => {
+    expect(evaluateMockFlag("prefix-tenkacloudsample-suffix", 800).kind).toBe("ok");
+  });
+
+  it.each(EASTER_EGGS)("should accept easter egg %s", (egg) => {
+    expect(evaluateMockFlag(egg, 800).kind).toBe("ok");
+  });
+
+  it.each([
+    "wrong",
+    "xxx",
+    "test",
+    "12345",
+    "hello world",
+    "  ",
+  ])("should reject obvious wrong / unrelated input %p", (input) => {
+    const result = evaluateMockFlag(input, 800);
+    expect(result.kind).toBe("wrong");
+    if (result.kind === "wrong") {
+      expect(result.scoreDelta).toBe(-10);
+      expect(result.wrongCount).toBe(1);
+    }
+  });
+
+  it("should reject empty input", () => {
+    expect(evaluateMockFlag("", 800).kind).toBe("wrong");
+  });
+
+  it("should preserve the points value passed in (= ok path uses it)", () => {
+    const r = evaluateMockFlag(CANONICAL_MOCK_FLAG, 1234);
+    expect(r).toEqual({ kind: "ok", scoreDelta: 1234, totalScore: 1234 });
+  });
+});


### PR DESCRIPTION
## Summary

Thermo-Nuclear review **P1** 2 件の対応:

1. **isMock prop drill 撲滅**: ProblemDetail → ProblemPanel → FlagSubmissionPanel と 3 段で `isMock={config.mode !== "backend"}` を渡していた → AppConfigContext + `useIsMock()` で葉 component が直接読む
2. **simulateMockFlagSubmit の分離 + JSDoc 修正**: production component に同居していた mock-only ロジック (= 約 40 行) を `dev-mock/flag-submit.ts` に切り出し、 JSDoc と実装の食い違いを修正、 単体テスト 18 case を追加

## 詳細

### 1. AppConfigContext 新設

`apps/participant-portal/src/config-context.tsx`:

```ts
<AppConfigProvider config={config}>...</AppConfigProvider>
const cfg = useAppConfig();
const isMock = useIsMock(); // = cfg.mode !== "backend"
```

main.tsx で `<App config={...}>` 渡しは backward compat のため残しつつ、 新たに `AppConfigProvider` で wrap。 既存 callers は壊さない。

### 2. isMock prop drill 撤去

| 場所 | 旧 | 新 |
|---|---|---|
| `ProblemDetail.tsx` | `<ProblemPanel ... isMock={config.mode !== "backend"} />` | `<ProblemPanel ... />` |
| `ProblemPanel.tsx` | props に `isMock?: boolean` + 中継 | (削除) |
| `ProblemPanelFlagSubmission.tsx` | props に `isMock?: boolean` | `const isMock = useIsMock()` |

中間 component (ProblemPanel) が config を意識しない構造に。

### 3. dev-mock 用 flag 検証 を専用 module に分離

`apps/participant-portal/src/dev-mock/flag-submit.ts` 新規:
- `CANONICAL_MOCK_FLAG = "tenkacloudsample"` (export)
- `EASTER_EGGS = ["42", "claude", "kaizen", "tenkadev", "konnichiwa", "tenka"]`
- `evaluateMockFlag(rawFlag, points): SubmitFlagOutcome` (= 純関数)

旧 `ProblemPanelFlagSubmission` 内の `simulateMockFlagSubmit` / `MOCK_CORRECT_FLAG` / `MOCK_EASTER_EGGS` (合計 ~40 行) を全て移動し、 component から削除。 JSDoc を実装と整合させた:

| 旧 (誤り) | 新 (正確) |
|---|---|
| 「任意 1 文字以上で OK」 | 「canonical (`tenkacloudsample`) の双方向 `includes` 部分一致 + EASTER_EGGS の exact match」 |

### 4. 単体テスト 18 case 追加

`apps/participant-portal/test/dev-mock/flag-submit.test.ts`:
- canonical exact / case-insensitive (2) / prefix 寛容 (2) / 部分一致 / easter eggs (6) / 否定 (6) / 空 / points パススルー
- 旧 ProblemPanelFlagSubmission には test が無かった → behavior が pin される

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / build 全 pass)
- [x] portal test: **195 → 213 case 全 pass** (= 新 18 case 追加)
- [ ] 手動 (= portal-demo 再ビルド後): `tenkacloudsample` で celebration、 `wrong` で減点 alert、 `claude` / `42` 等の easter egg で celebration

## Regression analysis

- `isMock` prop は optional default false だったので、 削除しても caller 側 default パスと等価
- `useIsMock()` は AppConfigProvider 配下、 main.tsx の wrap で全 page がカバー
- `evaluateMockFlag` は旧 `simulateMockFlagSubmit` と純関数として同型 → 振る舞い変更なし
- 既存 portal test 195 case + 新 18 case = **213 case 全 pass**

## Physical impact

- NO-OP infra
- CREATE: `config-context.tsx` / `dev-mock/flag-submit.ts` / 同 test
- UPDATE: `main.tsx` / `ProblemPanel.tsx` / `ProblemPanelFlagSubmission.tsx` / `ProblemDetail.tsx`

## Follow-up (= 同 review の残)

- **P0**: landing/index.html を CSS / JS / i18n に分解 — #1232 merge 後着手
- **P1 (本 PR で部分対応)**: dev-mock を adapter/provider 1 層に集約 — TeamViewProvider / ScoreEvents / TeamSetup / SsoCredentials / Login も同じ手で `useIsMock()` 化できる。 別 PR で順次
- **P2**: contact form feedback の i18n / legal pages の shared CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1258