### PR TITLE
refactor(portal): migrate remaining pages to useIsMock() (P1 continuation)

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -57,11 +57,8 @@ export function App({ config }: { config: AppConfig }) {
           path="/score-events"
           element={guarded(config, <ScoreEventsPage config={config} />)}
         />
-        <Route
-          path="/notifications"
-          element={guarded(config, <NotificationsPage config={config} />)}
-        />
-        <Route path="/problems" element={guarded(config, <QuestsPage config={config} />)} />
+        <Route path="/notifications" element={guarded(config, <NotificationsPage />)} />
+        <Route path="/problems" element={guarded(config, <QuestsPage />)} />
         <Route
           path="/problems/:jobId"
           element={guarded(config, <ProblemDetailPage config={config} />)}

--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -18,6 +18,7 @@ import {
   PortalAuthError,
 } from "../api/portal-client";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { countUnread, loadLastSeenAt, saveLastSeenAt } from "../lib/notifications-storage";
 import { useAuth } from "./AuthProvider";
 import {
@@ -223,7 +224,7 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
   // codex review: `lastSeenAt` を eventId scope にして「同 browser で別 event ログイン
   // 後、前 event の lastSeen を引きずって新 event の通知を silent 既読化」を防ぐ。
   const eventIdForKey = auth.session?.eventId ?? "";
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
   const [view, setView] = useState<ParticipantTeamView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
@@ -274,7 +275,7 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
 
   /** 5 秒 tick: `/portal/me` + `/portal/leaderboard`。Notifications は別系統。 */
   const refresh = useCallback(async () => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     const [meResult, leaderboardResult] = await Promise.allSettled([
       getPortalMe(config.apiBaseUrl, sessionToken),
       getLeaderboard(config.apiBaseUrl, sessionToken),
@@ -282,11 +283,11 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
 
     if (!applyPortalMeDecision(toPortalMeRefreshDecision(meResult))) return;
     applyLeaderboardDecision(toLeaderboardRefreshDecision(leaderboardResult));
-  }, [isBackend, sessionToken, config.apiBaseUrl, applyPortalMeDecision, applyLeaderboardDecision]);
+  }, [isMock, sessionToken, config.apiBaseUrl, applyPortalMeDecision, applyLeaderboardDecision]);
 
   /** 60 秒 tick: `/portal/me/notifications` 専用。Events table の RCU を守る。 */
   const refreshNotifications = useCallback(async () => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     try {
       const next = await getNotifications(config.apiBaseUrl, sessionToken);
       if (next === undefined) {
@@ -307,22 +308,22 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
       }
       setNotificationsError(err instanceof Error ? err.message : String(err));
     }
-  }, [isBackend, sessionToken, config.apiBaseUrl, auth, eventIdForKey]);
+  }, [isMock, sessionToken, config.apiBaseUrl, auth, eventIdForKey]);
 
   // LP 「モックで試す」 動線: dev-mock mode + session 在りのとき、 backend API が無くても
   // 各画面が空にならないよう固定 fixture を 1 度だけ seed する。 polling は走らない。
-  // production (= backend mode) では `if (!isBackend) return` ガードで素通り。
+  // production (= backend mode) では `if (isMock) return` ガードで素通り。
   useEffect(() => {
-    if (isBackend) return;
+    if (!isMock) return;
     if (!sessionToken) return;
     if (view) return;
     setView(DEV_MOCK_TEAM_VIEW);
     setLeaderboard(DEV_MOCK_LEADERBOARD);
     setNotifications(DEV_MOCK_NOTIFICATIONS);
-  }, [isBackend, sessionToken, view]);
+  }, [isMock, sessionToken, view]);
 
   useEffect(() => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     let cancelled = false;
     stopPollingRef.current = false;
     const tick = async () => {
@@ -335,10 +336,10 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
       cancelled = true;
       clearInterval(interval);
     };
-  }, [isBackend, sessionToken, refresh]);
+  }, [isMock, sessionToken, refresh]);
 
   useEffect(() => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     let cancelled = false;
     const tick = async () => {
       if (cancelled) return;
@@ -350,7 +351,7 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
       cancelled = true;
       clearInterval(interval);
     };
-  }, [isBackend, sessionToken, refreshNotifications]);
+  }, [isMock, sessionToken, refreshNotifications]);
 
   // codex review P3: page を開いた瞬間の既読化を **localStorage と Context state 両方** に
   // 反映して、TopNav 未読 badge が次の 60s tick を待たず即 0 化する。

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -224,14 +224,11 @@ export function ProblemPanel({
   apiBaseUrl,
   sessionToken,
   onScored,
-  isMock = false,
 }: {
   problem: ParticipantProblemView;
   apiBaseUrl: string;
   sessionToken: string;
   onScored: () => Promise<void>;
-  /** dev-mock mode: backend を呼ばず submit を local で評価する (= LP 「モックで試す」 用)。 */
-  isMock?: boolean;
 }) {
   const t = useT();
   const now = useNowMs(COUNTDOWN_REFRESH_MS);
@@ -318,7 +315,6 @@ export function ProblemPanel({
             points={flagScoring.points ?? 0}
             hints={flagScoring.hints ?? []}
             onScored={onScored}
-            isMock={isMock}
           />
         )}
         {shouldShowAutoRefreshNote(problem.status) && (

--- a/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
+++ b/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
@@ -13,6 +13,8 @@ import {
   type SubmitFlagOutcome,
   submitFlag,
 } from "../api/portal-client";
+import { useIsMock } from "../config-context";
+import { evaluateMockFlag } from "../dev-mock/flag-submit";
 import { useT } from "../i18n";
 import { describeAgo } from "../lib/format";
 import { CelebrationOverlay } from "./CelebrationOverlay";
@@ -29,7 +31,6 @@ export function FlagSubmissionPanel({
   points,
   hints,
   onScored,
-  isMock = false,
 }: {
   apiBaseUrl: string;
   sessionToken: string;
@@ -38,14 +39,12 @@ export function FlagSubmissionPanel({
   points: number;
   hints: readonly ParticipantHintView[];
   onScored: () => Promise<void>;
-  /**
-   * dev-mock mode (= LP の 「モックで試す」 動線)。 true のとき submit を backend に投げず、
-   * local state で 「正解 → celebration」 「不正解 → 減点 + リトライ」 を再現する。
-   * 本物の AWS 環境は無いので flag の中身は問わず、 任意 1 文字以上の入力で OK とする。
-   */
-  isMock?: boolean;
 }) {
   const t = useT();
+  // dev-mock mode (= LP 「モックで試す」 動線) のとき submit を backend に投げず、
+  // dev-mock/flag-submit.evaluateMockFlag で local 評価する。 mode は AppConfig
+  // context から直接読む (= 旧 isMock prop drill を撤去)。
+  const isMock = useIsMock();
   const [flag, setFlag] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
@@ -72,7 +71,7 @@ export function FlagSubmissionPanel({
     setOutcome(null);
     try {
       const result = isMock
-        ? simulateMockFlagSubmit(flag, points)
+        ? evaluateMockFlag(flag, points)
         : await submitFlag(apiBaseUrl, sessionToken, problemId, flag);
       setOutcome(result);
       if (result.kind === "ok") setMockCleared(true);
@@ -161,47 +160,6 @@ export function FlagSubmissionPanel({
       )}
     </SpaceBetween>
   );
-}
-
-/**
- * dev-mock 用 mock flag 検証。 LP visitor が submit 体験を試せるよう、 固定の
- * 「正解」 文字列 `tenkacloudsample` (case-insensitive、 部分一致) のときに celebration を
- * 出し、 それ以外は不正解 (= 減点 + リトライ) にする。 placeholder で答えを示唆する。
- */
-export const MOCK_CORRECT_FLAG = "tenkacloudsample";
-
-/**
- * Easter eggs. ふざけて submit してくれた visitor へのリワード (= 全部 正解扱い)。
- *  - `42`               : The Hitchhiker's Guide to the Galaxy
- *  - `claude`           : 開発で使ってる AI agent への nod
- *  - `kaizen`           : 改善 = 日本語の karma
- *  - `tenkadev`         : 開発者専用 dev wink
- *  - `konnichiwa`       : ja LP visitor 向け hello
- *  - `tenka`            : 部分マッチで通したいゆるさ
- */
-const MOCK_EASTER_EGGS: readonly string[] = [
-  "42",
-  "claude",
-  "kaizen",
-  "tenkadev",
-  "konnichiwa",
-  "tenka",
-];
-
-function simulateMockFlagSubmit(flag: string, points: number): SubmitFlagOutcome {
-  const trimmed = flag.trim().toLowerCase();
-  if (trimmed.length === 0) {
-    return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
-  }
-  // `tenkacloudsample` を含むか、 逆に `tenkacloudsample` が入力を含むときも OK
-  // (= ユーザが `tenkacloud` だけ入れても通る、 typo に少し寛容)。
-  if (trimmed.includes(MOCK_CORRECT_FLAG) || MOCK_CORRECT_FLAG.includes(trimmed)) {
-    return { kind: "ok", scoreDelta: points, totalScore: points };
-  }
-  if (MOCK_EASTER_EGGS.some((egg) => trimmed === egg)) {
-    return { kind: "ok", scoreDelta: points, totalScore: points };
-  }
-  return { kind: "wrong", scoreDelta: -10, totalScore: -10, wrongCount: 1 };
 }
 
 function canSubmitFlag(flag: string, submitting: boolean): boolean {

--- a/apps/participant-portal/src/config-context.tsx
+++ b/apps/participant-portal/src/config-context.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+import type { AppConfig } from "./config";
+
+/**
+ * `AppConfig` は `loadConfig()` で起動時に解決し、 main.tsx で `<AppConfigProvider>` に
+ * 渡す。 page / component は `useAppConfig()` で参照する。
+ *
+ * **Why a context (= prop drill 廃止)**:
+ *   旧: page → ProblemPanel → FlagSubmissionPanel と 3 段で `isMock={config.mode !==
+ *       "backend"}` を渡していた (= Thermo-Nuclear review P1 指摘の thin wrapper)。
+ *   新: 中間 component は config を知らない。 葉 component が必要なら useAppConfig で
+ *       直接読む。 derived `isMock` も `useIsMock()` helper として提供。
+ *
+ * Mock / backend の API 呼び分け (= フル adapter) は別 PR で順次。 まずは prop drill
+ * 撲滅と簡易な mock 判定統合まで。
+ */
+
+const AppConfigContext = createContext<AppConfig | null>(null);
+
+export function AppConfigProvider({
+  config,
+  children,
+}: {
+  readonly config: AppConfig;
+  readonly children: ReactNode;
+}) {
+  // Object identity を react-friendly に固定 (= props.config が同じ参照なら再 render
+  // 連鎖を抑える)。 loadConfig は起動時 1 回しか走らないので useMemo 不要だが、 念のため
+  // wrap して context value の参照同一性を保証する。
+  const value = useMemo(() => config, [config]);
+  return <AppConfigContext.Provider value={value}>{children}</AppConfigContext.Provider>;
+}
+
+export function useAppConfig(): AppConfig {
+  const ctx = useContext(AppConfigContext);
+  if (!ctx) throw new Error("useAppConfig must be used inside <AppConfigProvider>");
+  return ctx;
+}
+
+/**
+ * `mode !== "backend"` を返す derived hook。 dev-mock / future な offline 系を 1 箇所で
+ * 同義語化する (= 「backend 連携している」 の否定 = mock-mode と表現)。
+ */
+export function useIsMock(): boolean {
+  return useAppConfig().mode !== "backend";
+}

--- a/apps/participant-portal/src/dev-mock/flag-submit.ts
+++ b/apps/participant-portal/src/dev-mock/flag-submit.ts
@@ -1,0 +1,57 @@
+import type { SubmitFlagOutcome } from "../api/portal-client";
+
+/**
+ * dev-mock 用の flag 検証ロジック。
+ *
+ * 本物の AWS / scoring backend は存在しないので、 LP 「モックで試す」 動線では portal
+ * の `submitFlag` を呼ぶ代わりに本関数を直接 invoke する。 LP visitor が submit 体験
+ * (= celebration / wrong-answer の両方) を実機と同じ UX で試せるようにする。
+ *
+ * 正解判定:
+ *   1. canonical flag `tenkacloudsample` を `includes` で部分一致 (= 大文字小文字を
+ *      区別しない)。 typo 寛容 (`tenkacloud` 等の prefix 単独でも OK)。
+ *   2. EASTER_EGGS のいずれかと exact match。
+ *
+ * これ以外は wrong (= -10 pt + リトライ可)。
+ *
+ * Easter egg は demo UX を盛り上げる遊び (= `42` / `claude` / `kaizen` / `tenkadev`
+ * / `konnichiwa` / `tenka`)。 production code には影響しないので 「mock-only の
+ * 余り遊び」 として fixture 側 (= 本ファイル) に閉じ込める。
+ */
+
+export const CANONICAL_MOCK_FLAG = "tenkacloudsample";
+
+export const EASTER_EGGS: readonly string[] = [
+  "42",
+  "claude",
+  "kaizen",
+  "tenkadev",
+  "konnichiwa",
+  "tenka",
+];
+
+const WRONG_OUTCOME: SubmitFlagOutcome = {
+  kind: "wrong",
+  scoreDelta: -10,
+  totalScore: -10,
+  wrongCount: 1,
+};
+
+function isCanonicalMatch(trimmed: string): boolean {
+  if (trimmed.length === 0) return false;
+  // `tenkacloudsample` を含むか、 逆に `tenkacloudsample` が入力を含む (= prefix
+  // 単独 `tenkacloud` も OK)
+  return trimmed.includes(CANONICAL_MOCK_FLAG) || CANONICAL_MOCK_FLAG.includes(trimmed);
+}
+
+function isEasterEgg(trimmed: string): boolean {
+  return EASTER_EGGS.includes(trimmed);
+}
+
+export function evaluateMockFlag(rawFlag: string, points: number): SubmitFlagOutcome {
+  const trimmed = rawFlag.trim().toLowerCase();
+  if (isCanonicalMatch(trimmed) || isEasterEgg(trimmed)) {
+    return { kind: "ok", scoreDelta: points, totalScore: points };
+  }
+  return WRONG_OUTCOME;
+}

--- a/apps/participant-portal/src/main.tsx
+++ b/apps/participant-portal/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { App } from "./App";
 import { loadConfig } from "./config";
+import { AppConfigProvider } from "./config-context";
 import { I18nProvider } from "./i18n";
 
 const root = document.getElementById("root");
@@ -18,9 +19,11 @@ loadConfig()
     createRoot(root).render(
       <StrictMode>
         <I18nProvider>
-          <BrowserRouter basename={ROUTER_BASENAME}>
-            <App config={config} />
-          </BrowserRouter>
+          <AppConfigProvider config={config}>
+            <BrowserRouter basename={ROUTER_BASENAME}>
+              <App config={config} />
+            </BrowserRouter>
+          </AppConfigProvider>
         </I18nProvider>
       </StrictMode>,
     );

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
 import { ScoreTimelineChart } from "../components/ScoreTimelineChart";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 
 /**
@@ -28,7 +29,7 @@ function truncateTeamName(name: string): string {
 export function HomePage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const sessionToken = auth.session?.sessionToken ?? null;
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
   const t = useT();
   const navigate = useNavigate();
   // Polling は ShellLayout の TeamViewProvider で一括管理される (TopNav も同じデータを共有)。
@@ -51,12 +52,12 @@ export function HomePage({ config }: { config: AppConfig }) {
           {error}
         </Alert>
       )}
-      {isBackend && !view && !error && <Box>{t("app.loading")}</Box>}
+      {!isMock && !view && !error && <Box>{t("app.loading")}</Box>}
 
       {view && <TeamScorePanel view={view} leaderboard={leaderboard} />}
 
       {/* Audit table #12: 競技開始からのスコア推移を 折れ線グラフで可視化 (= dashboard 中段)。 */}
-      {isBackend && sessionToken && view && view.problems.length > 0 && (
+      {!isMock && sessionToken && view && view.problems.length > 0 && (
         <ScoreTimelineChart apiBaseUrl={config.apiBaseUrl} sessionToken={sessionToken} />
       )}
 

--- a/apps/participant-portal/src/pages/Login.tsx
+++ b/apps/participant-portal/src/pages/Login.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 
 /**
@@ -32,7 +33,8 @@ export function LoginPage({ config }: { config: AppConfig }) {
   // LP 「モックで試す」 動線では backend が存在せず login key 文字列 が任意 (= 競技
   // 主催者が発行する短命キーは無い)。 ユーザーに 「何を入れればいいか分からない」 と
   // 思わせないために info banner / placeholder / description を dev-mock 用に出し分ける。
-  const isMock = config.mode !== "backend";
+  // 旧: const isMock = config.mode !== "backend"; → useIsMock() (Thermo-Nuclear review P1)
+  const isMock = useIsMock();
 
   // 既ログイン状態で /login に来た場合は home に redirect (= 別 key 黙々上書き防止)。
   // ready=false の間は loadSession の結果待ちで何も決められないので render を保留。

--- a/apps/participant-portal/src/pages/Notifications.tsx
+++ b/apps/participant-portal/src/pages/Notifications.tsx
@@ -8,7 +8,7 @@ import Spinner from "@cloudscape-design/components/spinner";
 import { useEffect } from "react";
 import type { NotificationView } from "../api/portal-client";
 import { useTeamView } from "../auth/TeamViewProvider";
-import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 import { describeAgo } from "../lib/format";
 
@@ -27,11 +27,11 @@ const SEVERITY_COLOR: Record<NotificationView["severity"], "blue" | "red"> = {
  * Phase 1 以前の旧 deployment (eventId 無し) は backend が 404 を返すので、
  * `notificationsNoEvent` で告知して空白を出す。
  */
-export function NotificationsPage({ config }: { config: AppConfig }) {
+export function NotificationsPage() {
   const { notifications, notificationsError, notificationsNoEvent, markNotificationsSeen } =
     useTeamView();
   const t = useT();
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
   const items = notifications?.items;
 
   // page を開いたら latest occurredAt を context+localStorage に書いて未読 badge を **即時** 0 化。
@@ -61,7 +61,7 @@ export function NotificationsPage({ config }: { config: AppConfig }) {
           {t("notifications.no_event_body")}
         </Alert>
       )}
-      {isBackend && !notifications && !notificationsError && !notificationsNoEvent && (
+      {!isMock && !notifications && !notificationsError && !notificationsNoEvent && (
         <Box textAlign="center" padding="l">
           <Spinner /> {t("notifications.loading")}
         </Box>

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -149,7 +149,6 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
           apiBaseUrl={config.apiBaseUrl}
           sessionToken={sessionToken ?? ""}
           onScored={refresh}
-          isMock={config.mode !== "backend"}
         />
       )}
 

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -16,7 +16,7 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import type { ParticipantProblemView, ParticipantScoringInfo } from "../api/portal-client";
 import { useTeamView } from "../auth/TeamViewProvider";
-import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { findProblemMetadata } from "../data/problems";
 import { useT } from "../i18n";
 import { categoryOf } from "../lib/category";
@@ -101,11 +101,11 @@ function isCleared(problem: ParticipantProblemView): boolean {
  * 「section 分け」 で並列表示する。 未解決 section は常時 expand、 解決済み section は
  * ExpandableSection (= 初期 collapsed)、 ひと目で残タスクと既獲得を区別できる。
  */
-export function QuestsPage({ config }: { config: AppConfig }) {
+export function QuestsPage() {
   const { view, error } = useTeamView();
   const navigate = useNavigate();
   const t = useT();
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
   const [filter, setFilter] = useState<CategoryFilter>("all");
 
   const allProblems = useMemo(() => view?.problems ?? [], [view]);
@@ -200,7 +200,7 @@ export function QuestsPage({ config }: { config: AppConfig }) {
         {unsolved.length > 0 ? (
           <Cards<ParticipantProblemView>
             items={unsolved}
-            loading={isBackend && !view && !error}
+            loading={!isMock && !view && !error}
             loadingText={t("quests.loading_text")}
             cardDefinition={renderCard}
             cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -17,6 +17,7 @@ import {
 import { useAuth } from "../auth/AuthProvider";
 import { DEV_MOCK_SCORE_EVENTS } from "../auth/dev-mock-fixtures";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 import { describeAgo, formatOccurredAtTooltip } from "../lib/format";
 
@@ -61,13 +62,13 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const t = useT();
   const sessionToken = auth.session?.sessionToken ?? null;
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
 
   const [data, setData] = useState<ScoreEventsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const tick = useCallback(async () => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     try {
       const next = await getScoreEvents(config.apiBaseUrl, sessionToken);
       setData(next);
@@ -79,10 +80,10 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
       }
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, [isBackend, sessionToken, config.apiBaseUrl, auth]);
+  }, [isMock, sessionToken, config.apiBaseUrl, auth]);
 
   useEffect(() => {
-    if (!isBackend || !sessionToken) return;
+    if (isMock || !sessionToken) return;
     let cancelled = false;
     const run = async () => {
       if (cancelled) return;
@@ -94,16 +95,16 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [isBackend, sessionToken, tick]);
+  }, [isMock, sessionToken, tick]);
 
   // LP 「モックで試す」 動線: dev-mock mode では backend を叩かないので、 fixture を
   // 1 度だけ seed する (= 競技中のスコア推移 chart + 履歴 table をデモで見せる)。
   useEffect(() => {
-    if (isBackend) return;
+    if (!isMock) return;
     if (!sessionToken) return;
     if (data) return;
     setData(DEV_MOCK_SCORE_EVENTS);
-  }, [isBackend, sessionToken, data]);
+  }, [isMock, sessionToken, data]);
 
   const series = useMemo(() => (data ? buildCumulativeSeries(data.entries) : []), [data]);
 
@@ -121,7 +122,7 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
           {error}
         </Alert>
       )}
-      {isBackend && !data && !error && (
+      {!isMock && !data && !error && (
         <Box textAlign="center" padding="l">
           <Spinner /> {t("app.loading")}
         </Box>

--- a/apps/participant-portal/src/pages/Scoreboard.tsx
+++ b/apps/participant-portal/src/pages/Scoreboard.tsx
@@ -8,6 +8,7 @@ import Table from "@cloudscape-design/components/table";
 import type { LeaderboardEntry } from "../api/portal-client";
 import { useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 
 /**
@@ -20,7 +21,7 @@ import { useT } from "../i18n";
  */
 export function ScoreboardPage({ config }: { config: AppConfig }) {
   const t = useT();
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
   const { leaderboard, leaderboardError, leaderboardNoEvent } = useTeamView();
 
   return (
@@ -42,7 +43,7 @@ export function ScoreboardPage({ config }: { config: AppConfig }) {
           {t("scoreboard.no_event_body")}
         </Alert>
       )}
-      {isBackend && !leaderboard && !leaderboardError && !leaderboardNoEvent && (
+      {!isMock && !leaderboard && !leaderboardError && !leaderboardNoEvent && (
         <Box textAlign="center" padding="l">
           <Spinner /> {t("app.loading")}
         </Box>

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
 import { CliCredentialsPanel } from "../components/CliCredentialsPanel";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
 
 type TranslateFn = (key: string, vars?: Record<string, string>) => string;
@@ -53,7 +54,7 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
   const t = useT();
   const sessionToken = auth.session?.sessionToken ?? null;
   const { view, error } = useTeamView();
-  const isBackend = config.mode === "backend";
+  const isMock = useIsMock();
 
   const [pending, setPending] = useState<string | null>(null);
   const [openError, setOpenError] = useState<string | null>(null);
@@ -63,7 +64,7 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
     // dev-mock mode: backend を呼ぶと localhost への fetch が "Failed to fetch" になるため、
     // 試行せず info メッセージで「モックでは AWS Console を開けません」 を表示する (= LP demo
     // 訪問者が clicked して赤い error alert に驚かないようにする)。
-    if (!isBackend) {
+    if (isMock) {
       setOpenError(t("sso_credentials.mock_open_blocked"));
       return;
     }
@@ -97,11 +98,9 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
       )}
       {openError && (
         <Alert
-          type={isBackend ? "error" : "info"}
+          type={isMock ? "info" : "error"}
           header={
-            isBackend
-              ? t("sso_credentials.open_failed_header")
-              : t("sso_credentials.mock_open_header")
+            isMock ? t("sso_credentials.mock_open_header") : t("sso_credentials.open_failed_header")
           }
           dismissible
           onDismiss={() => setOpenError(null)}
@@ -114,7 +113,7 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
         <Box variant="p">{t("sso_credentials.howto_body")}</Box>
       </Alert>
 
-      {isBackend && !view && !error && <Box>{t("app.loading")}</Box>}
+      {!isMock && !view && !error && <Box>{t("app.loading")}</Box>}
 
       {view && view.problems.length === 0 && (
         <Container>
@@ -168,7 +167,7 @@ export function SsoCredentialsPage({ config }: { config: AppConfig }) {
                   sessionToken={sessionToken}
                   jobId={problem.jobId}
                   onAuthError={auth.logout}
-                  mockBlocked={!isBackend}
+                  mockBlocked={isMock}
                 />
               )}
             </SpaceBetween>

--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from "react-router";
 import { PortalAuthError, PortalValidationError, updateTeamName } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
+import { useIsMock } from "../config-context";
 import { type LocaleCode, SUPPORTED_LOCALES, useI18n, useT } from "../i18n";
 
 const TEAM_NAME_RE = /^[A-Za-z0-9 _\-぀-ヿ一-鿿]{1,40}$/;
@@ -69,6 +70,7 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const t = useT();
   const { locale, setLocale } = useI18n();
+  const isMock = useIsMock();
   // Issue #1191: 既に teamName を設定済の競技者が dropdown 経由でこのページを開く
   // ケースが edit mode。 初期表示の入力欄に現在の名前を埋めておく + Cancel で `/` に戻る。
   const isEditMode = auth.session?.teamNameSetByCompetitor === true;
@@ -91,7 +93,7 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
       // dev-mock mode: backend が無いので 直接 session を更新する (= localStorage に永続化、
       // `auth.updateSession` が saveSession を呼ぶ)。 backend mode と同じ UX (= submit 後
       // home に navigate) を保ち、 「Failed to fetch」 赤エラーを回避する。
-      if (config.mode !== "backend") {
+      if (isMock) {
         auth.updateSession({
           teamName: draft.trimmed,
           teamNameSetByCompetitor: true,

--- a/apps/participant-portal/test/App.test.tsx
+++ b/apps/participant-portal/test/App.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it } from "vitest";
 import { App } from "../src/App";
 import type { AppConfig } from "../src/config";
+import { AppConfigProvider } from "../src/config-context";
 import { I18nProvider } from "../src/i18n";
 
 const config: AppConfig = {
@@ -21,9 +22,11 @@ function renderApp(initialPath: string) {
   localStorage.setItem("tenkacloud.portal.locale", "ja");
   return render(
     <I18nProvider>
-      <MemoryRouter initialEntries={[initialPath]}>
-        <App config={config} />
-      </MemoryRouter>
+      <AppConfigProvider config={config}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App config={config} />
+        </MemoryRouter>
+      </AppConfigProvider>
     </I18nProvider>,
   );
 }

--- a/apps/participant-portal/test/dev-mock/flag-submit.test.ts
+++ b/apps/participant-portal/test/dev-mock/flag-submit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { CANONICAL_MOCK_FLAG, EASTER_EGGS, evaluateMockFlag } from "../../src/dev-mock/flag-submit";
+
+describe("evaluateMockFlag", () => {
+  it("should accept the canonical flag exactly", () => {
+    expect(evaluateMockFlag(CANONICAL_MOCK_FLAG, 800)).toEqual({
+      kind: "ok",
+      scoreDelta: 800,
+      totalScore: 800,
+    });
+  });
+
+  it("should accept case-insensitive variants", () => {
+    expect(evaluateMockFlag("TENKACLOUDSAMPLE", 800).kind).toBe("ok");
+    expect(evaluateMockFlag("TenkaCloudSample", 800).kind).toBe("ok");
+  });
+
+  it("should accept a strict prefix of the canonical (= typo 寛容)", () => {
+    expect(evaluateMockFlag("tenkacloud", 800).kind).toBe("ok");
+    expect(evaluateMockFlag("tenka", 800).kind).toBe("ok");
+  });
+
+  it("should accept a string that contains the canonical", () => {
+    expect(evaluateMockFlag("prefix-tenkacloudsample-suffix", 800).kind).toBe("ok");
+  });
+
+  it.each(EASTER_EGGS)("should accept easter egg %s", (egg) => {
+    expect(evaluateMockFlag(egg, 800).kind).toBe("ok");
+  });
+
+  it.each([
+    "wrong",
+    "xxx",
+    "test",
+    "12345",
+    "hello world",
+    "  ",
+  ])("should reject obvious wrong / unrelated input %p", (input) => {
+    const result = evaluateMockFlag(input, 800);
+    expect(result.kind).toBe("wrong");
+    if (result.kind === "wrong") {
+      expect(result.scoreDelta).toBe(-10);
+      expect(result.wrongCount).toBe(1);
+    }
+  });
+
+  it("should reject empty input", () => {
+    expect(evaluateMockFlag("", 800).kind).toBe("wrong");
+  });
+
+  it("should preserve the points value passed in (= ok path uses it)", () => {
+    const r = evaluateMockFlag(CANONICAL_MOCK_FLAG, 1234);
+    expect(r).toEqual({ kind: "ok", scoreDelta: 1234, totalScore: 1234 });
+  });
+});


### PR DESCRIPTION
## Summary

Thermo-Nuclear review **P1 続き** (= PR #1259 で FlagSubmissionPanel + ProblemPanel を `useIsMock()` 化、 本 PR で残り 7 ファイル):

各 page / provider が `const isBackend = config.mode === "backend"` を inline で書いていたのを、 `const isMock = useIsMock()` の helper hook 1 本に統一。 mode 判定の散在を 「`useIsMock()` 呼び出しという 1 つの単語」 に収斂。

## 変更

| File | 旧 | 新 |
|---|---|---|
| `auth/TeamViewProvider.tsx` | `isBackend` × 8 | `useIsMock()`、 dep array `[isMock, ...]` |
| `pages/Home.tsx` | `isBackend` × 3 | `!isMock` |
| `pages/Scoreboard.tsx` | `isBackend` × 2 | `!isMock` |
| `pages/Quests.tsx` | `isBackend` × 2 | `!isMock` + `config` prop 削除 |
| `pages/Notifications.tsx` | `isBackend` × 2 | `!isMock` + `config` prop 削除 |
| `pages/ScoreEvents.tsx` | `isBackend` × 6 | `isMock` |
| `pages/SsoCredentials.tsx` | `isBackend` × 6 | `isMock` |
| `pages/TeamSetup.tsx` | `config.mode !== "backend"` × 1 | `isMock` |
| `pages/Login.tsx` | `config.mode !== "backend"` × 1 | `useIsMock()` |

`NotificationsPage` / `QuestsPage` は `config` prop が完全に未使用化したため signature から削除、 App.tsx caller も `<NotificationsPage />` / `<QuestsPage />` に。 thin wrapper を更に削減。

## Test

`test/App.test.tsx` の `renderApp()` を `<AppConfigProvider>` で wrap (= useIsMock が context を要求するため)。 既存 5 test 全部復活、 合計 **213 test 全 pass**。

## Base

このブランチは `refactor/portal-dev-mock-adapter` (PR #1259) を base とした stacked PR です。 #1259 merge 後に main へ rebase。

## Regression analysis

- 真偽値が反転する書き換え (`isBackend` ↔ `!isMock`) を 全 callsite grep + 個別確認
- useEffect 依存配列の identity 監視としても等価
- `<NotificationsPage>` / `<QuestsPage>` の prop 削除は typecheck で 100% カバー
- 213 test 全 pass

## Physical impact

- NO-OP infra
- UPDATE: 11 file (= 9 src + 1 App + 1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1234