### PR TITLE
fix: tech-debt quick wins — a11y h3 + portal runtime-config error severity

### DIFF
--- a/apps/participant-portal/src/config.ts
+++ b/apps/participant-portal/src/config.ts
@@ -86,7 +86,17 @@ export async function loadConfig(): Promise<AppConfig> {
       cache: "no-store",
     });
     if (!res.ok) {
-      console.info("[config] no runtime-config.json (dev mode), using fallback");
+      // Issue #1247: 旧来は console.info の silent fallback だった (= production 配信
+      // で runtime-config.json を S3/CloudFront 配備し忘れたとき、 dev-mock に倒れて
+      // 「動くように見える」 misconfig 事故が起きた)。 fetch 自体が失敗 (= 404 / 5xx)
+      // した時点で、 ブラウザの DevTools にも残るよう console.error に格上げ。 fallback
+      // は dev 体験のため依然 DEV_FALLBACK を返すが、 operator が気付けるシグナルは出す。
+      console.error("[config] runtime-config.json not reachable", {
+        url: `${import.meta.env.BASE_URL}runtime-config.json`,
+        status: res.status,
+        statusText: res.statusText,
+        fallback: DEV_FALLBACK.mode,
+      });
       return DEV_FALLBACK;
     }
     const runtime = (await res.json()) as RuntimeConfig;

--- a/landing/app.js
+++ b/landing/app.js
@@ -54,12 +54,10 @@
       "modes.lead":
         "リアルタイムの Battle と、じっくり解く Challenge。1 つのイベントに混ぜて使える。",
       "modes.battle.kicker": "Battle",
-      "modes.battle.h": "Battle.",
       "modes.battle.p":
         "稼働率で競う、リアルタイム対戦。毎分のヘルスチェックを生き残ったチームが、勝つ。",
       "modes.battle.live": "ROUND 03 · LIVE",
       "modes.challenge.kicker": "Challenge",
-      "modes.challenge.h": "Challenge.",
       "modes.challenge.p":
         "問題を解き、フラグを提出する。AWS の一つひとつのサービスを、ひとつずつ理解していく。",
       "modes.challenge.input": "Hello from tc-iam-…",
@@ -298,12 +296,10 @@
       "modes.h2": "Live battles. Solo challenges. Or both.",
       "modes.lead": "Real-time Battles and patient Challenges, in a single event if you want.",
       "modes.battle.kicker": "Battle",
-      "modes.battle.h": "Battle.",
       "modes.battle.p":
         "Uptime, in real time. A health check probes every team every minute — the last one standing wins.",
       "modes.battle.live": "ROUND 03 · LIVE",
       "modes.challenge.kicker": "Challenge",
-      "modes.challenge.h": "Challenge.",
       "modes.challenge.p":
         "Solve the problem, submit the flag, earn the points. Learn one AWS service at a time, in depth.",
       "modes.challenge.input": "Hello from tc-iam-…",

--- a/landing/index.html
+++ b/landing/index.html
@@ -149,8 +149,7 @@
     <p class="lead" data-i18n="modes.lead">リアルタイムの Battle と、じっくり解く Challenge。1 つのイベントに混ぜて使える。</p>
     <div class="twoup">
       <div class="tile">
-        <div class="kicker" data-i18n="modes.battle.kicker">Battle</div>
-        <h3 data-i18n="modes.battle.h">Battle.</h3>
+        <h3 class="kicker" data-i18n="modes.battle.kicker">Battle</h3>
         <p data-i18n="modes.battle.p">稼働率で競う、リアルタイム対戦。毎分のヘルスチェックを生き残ったチームが、勝つ。</p>
         <div class="demo">
           <div class="portal-preview score-events-preview">
@@ -202,8 +201,7 @@
         </div>
       </div>
       <div class="tile">
-        <div class="kicker" data-i18n="modes.challenge.kicker">Challenge</div>
-        <h3 data-i18n="modes.challenge.h">Challenge.</h3>
+        <h3 class="kicker" data-i18n="modes.challenge.kicker">Challenge</h3>
         <p data-i18n="modes.challenge.p">問題を解き、フラグを提出する。AWS の一つひとつのサービスを、ひとつずつ理解していく。</p>
         <div class="demo">
           <div class="portal-preview">

--- a/landing/styles/main.css
+++ b/landing/styles/main.css
@@ -236,9 +236,11 @@ section .lead {
   background: transparent; border-radius: 0; padding: 0;
   min-height: 0; display: flex; flex-direction: column;
 }
-.tile .kicker { font-size: 17px; color: var(--ink); font-weight: 900; margin-bottom: 8px; }
-.tile h3 {
-  display: none;
+/* `.kicker` was a div; now `<h3>` for a11y. Reset h3 default margins to keep visual identical. */
+.tile h3.kicker {
+  margin: 0 0 8px;
+  font-size: 17px; color: var(--ink); font-weight: 900;
+  line-height: 1.3;
 }
 .tile p { font-size: 13px; line-height: 1.55; color: var(--ink-2); max-width: 350px; margin-bottom: 20px; font-weight: 600; }
 .tile .demo { margin-top: 0; }


### PR DESCRIPTION
## Summary

2 件の tech-debt issue を 1 PR で:

- **#1253**: `landing/index.html` hidden h3 → semantic h3
- **#1247**: `participant-portal` runtime-config silent fallback → console.error

## 1. #1253: a11y semantic heading

旧:
```html
<div class="kicker">Battle</div>
<h3 data-i18n="modes.battle.h">Battle.</h3>  <!-- display: none -->
```

→ スクリーンリーダーが hidden h3 を スキップし、 section heading が unreachable。

新:
```html
<h3 class="kicker" data-i18n="modes.battle.kicker">Battle</h3>
```

`<div>` を `<h3>` に昇格 (視覚 byte-equal)。 旧 `<h3>Battle.</h3>` は削除、 i18n key `modes.battle.h` / `modes.challenge.h` も dead として削除。

CSS は `.tile h3.kicker { margin: 0 0 8px; font-size: 17px; font-weight: 900; }` で h3 default margin reset。

## 2. #1247: silent dev-mock fallback の severity 引き上げ

旧 `loadConfig()`:
```ts
if (!res.ok) {
  console.info("[config] no runtime-config.json (dev mode), using fallback");
  return DEV_FALLBACK;
}
```

→ production で runtime-config.json を配備し忘れても dev-mock に倒れ、 「動くように見える」 misconfig 事故が起きていた。

新:
```ts
console.error("[config] runtime-config.json not reachable", {
  url, status, statusText, fallback: DEV_FALLBACK.mode,
});
```

`console.error` に格上げ + 構造化情報。 fallback 動作 自体 は dev 体験のため維持 (= localhost で runtime-config.json なくても portal が動く流儀を壊さない)。

## Base

このブランチは `refactor/lp-p0-file-split` (PR #1262) を base にした stacked PR。 #1262 merge 後 main へ rebase。

## Test plan

- [x] `make harness` (0 findings)
- [x] `make before-commit` (lint / typecheck / build / 全 test pass)
- [x] portal test 195/195 pass
- [ ] 手動: SR で `.tile` section の見出しが読み上げられる
- [ ] 手動: runtime-config.json を 404 にすると console.error が出る

## Physical impact

- NO-OP infra
- UPDATE: `landing/{index.html,styles/main.css,app.js}` + `apps/participant-portal/src/config.ts`

Closes #1253
Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)