### PR TITLE
fix(handlers): throw on score-event write failures instead of silently swallowing

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -169,8 +169,15 @@ async function processDeployment(
 
 /**
  * KindResult を deployment 行に書き戻す。 score 加算 / endpointsHealth 更新 / lastResult 更新 /
- * scoringState 更新 を 1 UpdateItem で atomic に行う。 score event 行 (= ulid SK の sparse row)
- * は別途 best-effort で書く。
+ * scoringState 更新 を 1 UpdateItem で atomic に行う。 続けて score event 行 (= ulid SK の sparse row)
+ * を append する。
+ *
+ * #1244: 旧実装は UpdateItem 失敗を console.warn + return で握り潰し、 さらに writeScoreEvent
+ * 失敗も warn のみで swallow していた。 結果として portal の score / timeline 不整合の温床に
+ * なっていたため、 失敗は log した上で throw する (= 1 deployment の失敗は outer の
+ * `processDeployment` `.catch` で他 deployment と隔離されるが、 CloudWatch には残り
+ * EventBridge 次 tick で retry される)。 AGENTS.md 「モック / スタブで握り潰す fallback 禁止」
+ * に整合。
  */
 async function applyKindResult(
   shared: GenericScoringSharedResources,
@@ -181,24 +188,17 @@ async function applyKindResult(
   if (!item.PK) return;
   const update = buildKindResultUpdate(result, nowIso);
 
-  try {
-    await shared.ddb.send(
-      new UpdateCommand({
-        TableName: shared.deploymentsTableName,
-        Key: { PK: item.PK, SK: "META" },
-        UpdateExpression: update.expression,
-        ExpressionAttributeValues: update.values,
-      }),
-    );
-  } catch (err) {
-    console.warn(`[generic-scoring] UpdateItem failed jobId=${item.jobId}`, {
-      message: err instanceof Error ? err.message : String(err),
-    });
-    return;
-  }
+  await shared.ddb.send(
+    new UpdateCommand({
+      TableName: shared.deploymentsTableName,
+      Key: { PK: item.PK, SK: "META" },
+      UpdateExpression: update.expression,
+      ExpressionAttributeValues: update.values,
+    }),
+  );
 
-  // score event 行 (= 履歴 marker) を best-effort で append。失敗は警告 log のみ
-  // (= 採点 / 健全性 update は既に確定済、整合性より可用性優先)。
+  // score event 行 (= 履歴 marker) を append。失敗は throw して outer
+  // `processDeployment` の .catch (= 1 tick skip + warn log) に委ねる (= 次 tick で retry)。
   await appendKindScoreEvents(shared, item, result);
 }
 
@@ -240,6 +240,9 @@ async function appendKindScoreEvents(
     expiresAt: item.expiresAt ?? 0,
   };
   for (const ev of result.scoreEvents) {
+    // #1244: 失敗は log + throw。 上位 (= processDeployment の .catch) で 1 deployment 単位に
+    // 隔離されるので他 deployment の採点は止まらないが、 score event 抜けは CloudWatch に
+    // 残り、 次 tick で同 source が再評価されたときに再書き込みされる。
     try {
       await writeScoreEvent(
         shared.ddb,
@@ -250,9 +253,12 @@ async function appendKindScoreEvents(
         ev.occurredAt,
       );
     } catch (err) {
-      console.warn(`[generic-scoring] score-event write failed jobId=${item.jobId}`, {
+      console.error(`[generic-scoring] score-event write failed jobId=${item.jobId}`, {
+        source: ev.source,
+        points: ev.points,
         message: err instanceof Error ? err.message : String(err),
       });
+      throw err;
     }
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
@@ -161,6 +161,11 @@ async function writeHintScoreEvent(
   now: string,
 ): Promise<void> {
   if (hint.penalty === 0) return;
+  // #1243: 旧実装は Put 失敗を console.warn で握り潰していたが、 score 減点 (UpdateItem) は
+  // 確定しているのに score event 履歴が空のままになり、 「-10 pt なのに履歴 0 件」 表示の
+  // 不整合を生んでいた (submit-flag #745 と同じ root cause)。 AGENTS.md 「モック / スタブで
+  // 握り潰す fallback 禁止」 違反だったので、 失敗は log した上で throw し、
+  // route-helpers の internal_error 経路で 500 を返す (= CloudWatch + Portal retry に乗せる)。
   try {
     await writeScoreEvent(
       shared.ddb,
@@ -177,10 +182,11 @@ async function writeHintScoreEvent(
       now,
     );
   } catch (err) {
-    console.warn("[reveal-hint] writeScoreEvent failed (best-effort)", {
+    console.error("[reveal-hint] writeScoreEvent failed", {
       jobId: item.jobId,
       hintId,
       message: err instanceof Error ? err.message : String(err),
     });
+    throw err;
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/score-event.ts
@@ -56,11 +56,16 @@ export interface ScoreEventItem {
 
 /**
  * 採点イベントを 1 行 PutItem する。HealthCheck (uptime / attack-detected) と
- * submit-flag (flag) から呼ばれるので shared/ に置く。書き込み失敗は親 score 加算と
- * 整合性が崩れるが、caller が catch して log のみ残す方針 (= MVP は best-effort)。
+ * submit-flag (flag) / reveal-hint (hint) / generic-scoring から呼ばれるので shared/ に置く。
+ *
+ * #745 / #1243 / #1244: 書き込み失敗は throw する。 旧来の caller は console.warn で握り潰して
+ * いたが、 親 score 加算と event 履歴の不整合 (= 「-10 pt なのに履歴 0 件」 / 「+100 pt なのに
+ * timeline 0 件」) の温床になり、 portal の表示矛盾を生んでいた。 silent data loss より
+ * visible failure を優先 (= CloudWatch + retry に乗せる)。
  *
  * `parent` から jobId / teamId / eventId / expiresAt を継承して event row を組む。
- * `result` は source に応じて自動決定 (= attack-detected なら "down"、それ以外は "ok")。
+ * `result` は source に応じて自動決定 (= attack-detected なら "down"、 flag-wrong なら "wrong"、
+ * それ以外は "ok")。
  */
 export async function writeScoreEvent(
   ddb: DynamoDBDocumentClient,

--- a/infrastructure/test/problem-deploy/generic-scoring-dispatcher.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-dispatcher.test.ts
@@ -88,6 +88,62 @@ function handleUptimeDispatcherScan(cmd: { constructor: { name: string } }): obj
   return {};
 }
 
+/**
+ * Failure-injection scenario for #1244 tests: configures uptime scoring + canned mock
+ * sequence (Events/Deployments Scan, scoringLocked BatchGet, optional UpdateItem error,
+ * optional PutItem error). Extracted to keep individual `it` bodies under the biome
+ * complexity threshold.
+ */
+function setupUptimeFailureScenario(failure: {
+  readonly updateThrows?: boolean;
+  readonly putThrows?: boolean;
+}): void {
+  process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
+    "hello-world-battle": {
+      kind: "uptime",
+      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+      pointsPerSuccess: 100,
+    },
+  });
+  process.env.PROBLEM_ENDPOINTS = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_PHASES = JSON.stringify({});
+  ddbSend.mockImplementation(async (cmd: { constructor: { name: string } }) =>
+    handleUptimeFailureCommand(cmd, failure),
+  );
+  fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+}
+
+function handleUptimeFailureCommand(
+  cmd: { constructor: { name: string } },
+  failure: { readonly updateThrows?: boolean; readonly putThrows?: boolean },
+): object {
+  const name = cmd.constructor.name;
+  if (name === "ScanCommand") return handleUptimeDispatcherScan(cmd);
+  if (name === "BatchGetCommand") return { Responses: { TestEvents: [] } };
+  if (name === "UpdateCommand") {
+    if (failure.updateThrows) throw new Error("DDB Update throttle");
+    return {};
+  }
+  if (name === "PutCommand") {
+    if (failure.putThrows) throw new Error("DDB PutItem throttle");
+    return {};
+  }
+  return {};
+}
+
+async function runDispatcherHandlerOnce(): Promise<void> {
+  const { handler } = await import(
+    "../../lib/problem-deploy/handlers/generic-scoring-handler/index"
+  );
+  await handler();
+}
+
+function countCommands(calls: ReadonlyArray<readonly unknown[]>, commandName: string): number {
+  return calls.filter(
+    (c) => (c[0] as { constructor: { name: string } }).constructor.name === commandName,
+  ).length;
+}
+
 describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙動 preservation", () => {
   it("should award +100 and write 1 score-event when scoring=uptime + all endpoints return 200", async () => {
     process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
@@ -211,6 +267,48 @@ describe("generic scoring dispatcher: hello-world-battle (= legacy uptime) 挙�
       restore();
     }
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("should attempt PutItem (score-event) and let it surface when UpdateItem succeeds (#1244)", async () => {
+    // #1244 behavioral pin: writeScoreEvent failures now throw (vs. swallow) so they surface
+    // to CloudWatch via the outer processDeployment .catch (= log + 1 tick skip + retry).
+    // We test the failure-surface contract by failing the PutCommand and asserting:
+    //   - handler() still resolves (= per-deployment isolation preserved, other deployments unaffected)
+    //   - PutCommand WAS attempted (= writeScoreEvent did fire and bubbled up, not silently skipped)
+    setupUptimeFailureScenario({ putThrows: true });
+    const restore = freezeNow();
+    try {
+      // handler stays resolved: per-deployment isolation (outer .catch) preserved.
+      await expect(runDispatcherHandlerOnce()).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+
+    // PutCommand was attempted (= writeScoreEvent fired). Pre-fix would have also attempted
+    // it; the difference is the throw path now reaches outer processDeployment.catch instead
+    // of being swallowed by the inner try/catch inside appendKindScoreEvents.
+    expect(countCommands(ddbSend.mock.calls, "PutCommand")).toBe(1);
+  });
+
+  it("should isolate UpdateItem failures via outer .catch instead of silent inner swallow (#1244)", async () => {
+    // #1244: 旧実装は UpdateItem 失敗時に inner で console.warn + return し、 同 tick で
+    // score-event も skip して silent に 1 tick を消費していた。 新契約: throw して
+    // outer processDeployment.catch に届くので、 handler は他 deployment を続行できる。
+    // 本 test では UpdateItem を throw させて handler が正常終了する (= per-deployment 隔離が
+    // 保たれている) ことと、 同 tick で PutCommand が試行されない (= UpdateItem 失敗時の
+    // 既存 short-circuit が保たれている) ことを pin する。
+    setupUptimeFailureScenario({ updateThrows: true });
+    const restore = freezeNow();
+    try {
+      await expect(runDispatcherHandlerOnce()).resolves.toBeUndefined();
+    } finally {
+      restore();
+    }
+
+    // UpdateItem 失敗で同 tick の PutItem (score-event) を試行しないことを pin
+    // (= short-circuit 維持。 旧実装と挙動同じ、 ただし inner swallow ではなく throw 経由で
+    // outer .catch に届く)。
+    expect(countCommands(ddbSend.mock.calls, "PutCommand")).toBe(0);
   });
 
   it("should skip scoring for events with scoringLocked=true (#558 fail-closed)", async () => {

--- a/infrastructure/test/problem-deploy/reveal-hint.test.ts
+++ b/infrastructure/test/problem-deploy/reveal-hint.test.ts
@@ -189,6 +189,35 @@ describe("revealHint (#742 Phase 3)", () => {
     ).rejects.toThrow(/DDB throttle/);
   });
 
+  it("should throw and surface to CloudWatch when writeScoreEvent fails (Issue #1243)", async () => {
+    // #1243: 旧実装は score-event PutItem 失敗を console.warn で握り潰し、 score 減点は
+    // 確定したのに履歴が空のまま 「-10 pt なのに履歴 0 件」 表示矛盾を生んでいた。
+    // 新契約: 失敗は throw して route-helpers の internal_error 経路で 500 を返し、
+    // CloudWatch + portal retry に乗せる。
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] }); // queryTeamItems
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 90 } }); // UpdateItem (hint reveal)
+    ddbSend.mockRejectedValueOnce(new Error("DDB PutItem throttle")); // writeScoreEvent
+    await expect(
+      revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1"),
+    ).rejects.toThrow(/DDB PutItem throttle/);
+    // score event 試行は 3 回目の DDB call (= query + update + put)
+    expect(ddbSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("should not call writeScoreEvent (no throw on hidden write) when hint penalty is 0", async () => {
+    // penalty=0 は score event を書かない契約。 PutItem を呼ばないので writeScoreEvent 失敗
+    // の throw 経路にも入らない (= 既存の penalty=0 挙動を pin する)。
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] });
+    ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+    const scoring = buildScoringMap([{ id: "hint-1", content: "free", penalty: 0 }]);
+    const out = await revealHint(shared, scoring, TEAM_KEY, "hello-world", "hint-1");
+    expect(out.kind).toBe("ok");
+    // query + update のみ (= 2 call)、 PutCommand は呼ばれない
+    expect(ddbSend).toHaveBeenCalledTimes(2);
+  });
+
   // ---- Issue #1005 / scoring gate (= submit-flag と同じ gate を hint reveal でも通す) ----
   describe("competition scoring gate (Issue #1005)", () => {
     const eventRow = sampleRow({ eventId: "EVT1", score: 0 });


### PR DESCRIPTION
## Summary
- Remove silent `console.warn` + swallow around score-event writes in `reveal-hint` and `generic-scoring` handlers (Issues #1243 / #1244)
- Failures now log via `console.error` and rethrow — reveal-hint surfaces as 500 via `route-helpers` `internal_error`; generic-scoring polling Lambda propagates to outer `processDeployment .catch` so 1 deployment failure stays visible in CloudWatch without blocking the other 49
- Tests assert the new contract: a DDB `PutItem` rejection now propagates instead of being swallowed inside an "ok" outcome

Closes #1243
Closes #1244

## Sites fixed
| File | Before | After |
| --- | --- | --- |
| `participant-handler/reveal-hint.ts` `writeHintScoreEvent` | warn + swallow (`hintsRevealed` + `score -10` committed, history empty) | log + throw → 500 → portal retries |
| `generic-scoring-handler/index.ts` `applyKindResult` (UpdateItem) | warn + early return (also skipped score-event for the tick) | throw → outer `.catch` logs; same short-circuit |
| `generic-scoring-handler/index.ts` `appendKindScoreEvents` | warn + continue (UpdateItem succeeded, event row missing → silent inconsistency) | log + throw → outer `.catch` logs |
| `shared/score-event.ts` | docstring declared best-effort | docstring declares throw contract, references #745 / #1243 / #1244 |

## Regression analysis
- **Behavioral change (`reveal-hint`)**: a hint reveal that successfully deducts score but fails to write the event row used to return 200 with a hidden inconsistency. Now returns 500. The portal client handles 500 via existing retry/backoff in `apps/participant-portal`, and the underlying DDB `UpdateItem` (which holds the penalty + `hintsRevealed`) is idempotent: a second attempt hits `ConditionalCheckFailedException` and returns `already_revealed`, so retries do not double-deduct.
- **Behavioral change (`generic-scoring`)**: the polling Lambda used to silently skip the score-event write when DDB rejected the inner Put. The dispatcher already wraps each deployment in `.catch` for per-deployment isolation, so the new throw is contained — 1 failing deployment no longer affects the other 49. Failures are now visible in CloudWatch and re-evaluated next tick (1-min interval).
- **Inconsistency window (`generic-scoring`)**: UpdateItem (score +N) can succeed and then Put (event row) can fail. Previously this was silently swallowed (data loss). Now the same window remains but is **observable** — operator sees the error and the next tick re-attempts. Net: visibility traded for an unchanged failure rate.
- **No IAM / no table-shape / no event-payload change** — only error-handling discipline.
- Aligns with the project rule "No silent fallbacks via mocks / stubs" (CLAUDE.md / AGENTS.md) and matches the precedent set by submit-flag #745.

## Physical impact
- **NO-OP** for CFn — handler internals only, no construct or IAM changes
- **UPDATE** to Lambda bundles:
  - `ProblemDeployBackendStack/ParticipantHandler` (reveal-hint.ts)
  - `ProblemDeployBackendStack/GenericScoringHandler` (index.ts + score-event.ts shared)
- **TESTS** updated: `reveal-hint.test.ts` (+1 throw assertion), `generic-scoring-dispatcher.test.ts` (+2 failure-surface assertions, plus extracted scenario helpers to stay under biome complexity threshold)

## Test plan
- [x] `bunx vitest run test/problem-deploy/reveal-hint.test.ts test/problem-deploy/generic-scoring-dispatcher.test.ts` — 25 / 25 pass
- [x] `bunx vitest run test/problem-deploy/submit-flag.test.ts` — 20 / 20 (no regression on the sibling handler that already throws)
- [x] `make harness` — no findings
- [x] `make lint` — clean (no biome / markdownlint / textlint errors)
- [x] `make typecheck` — clean across all 6 workspaces
- [ ] `make test` / `make validate-problems` — pre-existing failures unrelated to this PR (worktree missing `TenkaCloudChallenge` submodule contents under `problems/`). Verified the failures are all `ENOENT` on `problems/battles/*/template.yaml` and `problems/SCHEMA.json`, none touch the handlers changed here. CI on a clean checkout will pick up the submodule.