### PR TITLE
feat(problems): provider-specific runtime metadata + ADR-019 (multi-cloud groundwork)

### DIFF
--- a/.claude/templates/problems/attack-detection/metadata.json
+++ b/.claude/templates/problems/attack-detection/metadata.json
@@ -17,6 +17,11 @@
     "false-positive を抑えつつ阻止件数を最大化する trade-off を観察する"
   ],
   "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
   "endpoints": [
     {
       "slot": "main",

--- a/.claude/templates/problems/flag/metadata.json
+++ b/.claude/templates/problems/flag/metadata.json
@@ -19,6 +19,11 @@
     "問題文と CFn Outputs を突き合わせて 「採点対象の値」 を特定する"
   ],
   "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
   "scoring": {
     "kind": "flag",
     "flagOutputKey": "FlagValue",

--- a/.claude/templates/problems/phased-polling/metadata.json
+++ b/.claude/templates/problems/phased-polling/metadata.json
@@ -17,6 +17,11 @@
     "段階的進行で運用優先度 (= まず動かす / 次に最適化) を切り替える判断練習"
   ],
   "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
   "endpoints": [
     {
       "slot": "main",

--- a/.claude/templates/problems/uptime-flat/metadata.json
+++ b/.claude/templates/problems/uptime-flat/metadata.json
@@ -21,6 +21,11 @@
     "CloudWatch Logs で probe 失敗の root cause を読む"
   ],
   "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
   "endpoints": [
     {
       "slot": "main",

--- a/.claude/templates/problems/uptime-multi/metadata.json
+++ b/.claude/templates/problems/uptime-multi/metadata.json
@@ -20,6 +20,11 @@
     "frontend / api / db など層別 service 依存を解消する 「分離設計」 を実装で示す"
   ],
   "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
   "endpoints": [
     {
       "slot": "frontend",

--- a/docs/architecture/adr-023-provider-specific-problem-runtime.html
+++ b/docs/architecture/adr-023-provider-specific-problem-runtime.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ADR-023: Provider-specific problem runtime model for multi-cloud drills</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept  { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject  { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn    { background: #fff8c5; color: var(--c-warn); }
+  .badge.draft   { background: #ddf4ff; color: var(--c-link); }
+  .callout { padding: .8rem 1rem; border-left: 4px solid var(--c-warn); background: #fff8c5; border-radius: 3px; margin: 1rem 0; }
+  .callout.danger { border-color: var(--c-reject); background: #ffe9e9; }
+  .callout.info { border-color: var(--c-link); background: #ddf4ff; }
+  .callout.ok { border-color: var(--c-accept); background: #ddf4e0; }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  .col-accept { color: var(--c-accept); font-weight: 600; }
+  .col-reject { color: var(--c-reject); font-weight: 600; }
+  .col-warn   { color: var(--c-warn);   font-weight: 600; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>ADR-023: Provider-specific problem runtime model for multi-cloud drills</h1>
+  <p><em>Formalize what a TenkaCloud problem runtime is, why CloudFormation-like properties are required, why Terraform is not the default, and how the existing AWS catalog evolves without breakage.</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge accept">Accepted</span> 2026-05-24</div>
+    <div><b>Supersedes:</b> (none)</div>
+    <div><b>Related:</b>
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem plugin architecture),
+      <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> (Trust Bridge: provider/action/engine abstraction)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>TenkaCloud currently treats a problem as a self-contained package deployed into each team's isolated AWS environment using <code>metadata.json</code> + <code>template.yaml</code>. Three earlier ADRs frame how we got here:</p>
+
+<ul>
+  <li><a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> established that the <strong>problem is a plugin</strong> and the <strong>platform is the host</strong>. Problem-specific scoring, endpoint wiring, portal slots, disruptions are declared in metadata; the platform dispatches against a generic contract.</li>
+  <li><a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> introduced a <code>provider</code> / <code>action</code> / <code>engine</code> abstraction for cross-account authority transfer (Trust Bridge), but kept the problem runtime itself implicitly AWS/CloudFormation.</li>
+  <li>The deploy worker today reads <code>metadata.cfnTemplate</code>, AssumeRoles into the competitor account using a tenant <code>ExternalId</code>, and runs CFn <code>CreateStack</code>. The provider/engine is hard-wired AWS/CloudFormation in the codepath.</li>
+</ul>
+
+<p>To evolve toward multi-cloud drills (Azure, GCP, Kubernetes) without sacrificing the property that has made the current model simple and safe — <em>the cloud owns the runtime, owns the state, and owns the teardown</em> — we must define the problem runtime contract explicitly. This ADR exists because, without it, downstream PRs are at risk of three foreseeable bad directions:</p>
+
+<ol>
+  <li><strong>Terraform-by-default multi-cloud.</strong> Easy slogan, but it requires the platform to host an external runner and own state, locking, backend, and partial-failure cleanup. Those are not problem-author concerns today; making them so would shift work back to the platform that ADR-012 deliberately pushed out.</li>
+  <li><strong>Universal cloud-agnostic problem DSL.</strong> Conceptually interesting, but effectively a compiler from an abstract resource model to provider-native services. Many TenkaCloud problems exist <em>because</em> of provider-specific semantics (BigQuery analytics, Entra ID conditional access, Security Hub findings) and cannot be expressed in such a DSL without losing the point of the drill.</li>
+  <li><strong>Ad hoc provider-specific hacks.</strong> Wiring Azure / GCP / Kubernetes directly into the deploy worker without a documented runtime contract repeats the pre-ADR-012 failure mode: every new problem shape forces a platform change.</li>
+</ol>
+
+<p>Issue #1265 captured these concerns. Issue #1266 asked for the ADR to land them. Issue #1267 is the matching schema / CLI seam.</p>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<h3>D1: Multi-cloud means provider-specific problems first</h3>
+
+<p>The first supported multi-cloud expansion is <strong>provider-specific problems</strong>. A problem declares its target provider and engine; the catalog presents them side-by-side; the deploy dispatcher selects the right execution path. The same conceptual problem on two providers stays two separate problems.</p>
+
+<p>Portable same-shape problem families (one conceptual problem, multiple provider implementations bundled together) are a <strong>later</strong>, second-stage model and are sketched here only as a reservation.</p>
+
+<p>Cloud-agnostic single-problem compilation (write once, deploy to AWS / Azure / GCP from a single abstract definition) is <strong>explicitly out of scope</strong> for the near-term roadmap.</p>
+
+<h3>D2: Runtime contract — explicit metadata, AWS/CloudFormation the only executable combination today</h3>
+
+<p>Problem metadata gains an optional <code>runtime</code> object:</p>
+
+<pre>{
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  }
+}</pre>
+
+<p>Backward compatibility:</p>
+
+<ul>
+  <li>If <code>runtime</code> is absent and <code>cfnTemplate</code> exists, the validator normalizes the metadata as if <code>{ provider: "aws", engine: "cloudformation", entry: &lt;cfnTemplate&gt; }</code> were declared. Every existing problem in the catalog keeps validating without modification.</li>
+  <li>If both <code>runtime</code> and <code>cfnTemplate</code> are declared, the two must be consistent — <code>runtime.entry === cfnTemplate</code> — or validation fails with a clear message during the dual-field compatibility window.</li>
+  <li>Long term, <code>runtime.entry</code> is the primary field; <code>cfnTemplate</code> stays as a deprecated alias and is not removed until the entire catalog has migrated.</li>
+</ul>
+
+<p>Schema accepts the <code>runtime</code> field with a permissive shape (any string for <code>provider</code> / <code>engine</code>, regex on <code>entry</code>) so that reserving a future provider value does not require a schema bump. The narrow <strong>executable</strong> set is enforced at the CLI / validator layer, where the error message is descriptive. Today the only executable combination is <code>aws</code> + <code>cloudformation</code>.</p>
+
+<h3>D3: Runtime requirements a first-class engine must satisfy</h3>
+
+<table>
+<thead>
+  <tr><th>Requirement</th><th>Why</th></tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Provider-owned execution environment</td>
+    <td>The platform must not host a generic IaC runner on the default path. Submitting a CFn template to the AWS CFn service is sufficient; the platform does not run <code>terraform apply</code>.</td>
+  </tr>
+  <tr>
+    <td>Provider-managed state</td>
+    <td>The cloud's deployment system owns the resource graph. The platform stores deploy metadata (deployment id, status, outputs) but never the source of truth of cloud state. No state file, no lock backend.</td>
+  </tr>
+  <tr>
+    <td>Single primary deployable artifact</td>
+    <td>Authoring, review, distribution, and standalone validation are simple when <em>one file</em> represents the deploy. Multi-file modules and shared registries push complexity onto the catalog.</td>
+  </tr>
+  <tr>
+    <td>Standalone validation</td>
+    <td>An author must be able to deploy and verify their problem outside TenkaCloud using the provider's native tooling (<code>aws cloudformation deploy</code>, <code>az deployment group create</code>, <code>kubectl apply</code>, etc.). OSS contribution depends on this property.</td>
+  </tr>
+  <tr>
+    <td>Self-contained teardown</td>
+    <td>The provider's deployment lifecycle must expose a clear destroy operation. No hidden state file must be required to clean up.</td>
+  </tr>
+  <tr>
+    <td>Minimal platform coupling</td>
+    <td>Platform passes parameters in, reads outputs back, hands the outputs to the scoring dispatcher. Problem-specific deploy mechanics never require platform code changes.</td>
+  </tr>
+</tbody>
+</table>
+
+<h3>D4: First-class candidate runtimes</h3>
+
+<table>
+<thead>
+  <tr><th>Provider</th><th>Engine</th><th>Status</th><th>Notes</th></tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>aws</code></td>
+    <td><code>cloudformation</code></td>
+    <td><span class="badge accept">Executable</span></td>
+    <td>The current default and the only combination the deploy worker can run today.</td>
+  </tr>
+  <tr>
+    <td><code>azure</code></td>
+    <td><code>bicep</code> / <code>arm</code></td>
+    <td><span class="badge warn">Reserved</span></td>
+    <td>Satisfies D3 (Azure-owned execution / state / teardown via Deployment resource). Acceptable target for a Phase 3 experiment.</td>
+  </tr>
+  <tr>
+    <td><code>kubernetes</code></td>
+    <td><code>helm</code> / <code>manifest</code> / <code>kustomize</code></td>
+    <td><span class="badge warn">Reserved</span></td>
+    <td>Cluster owns state; teardown via release / namespace deletion. The cluster authority transfer model needs a separate ADR (related to ADR-017).</td>
+  </tr>
+  <tr>
+    <td><code>gcp</code></td>
+    <td><code>native-or-investigated-runtime</code></td>
+    <td><span class="badge warn">Needs investigation</span></td>
+    <td>The CloudFormation-equivalent on GCP (Deployment Manager is deprecated, Config Connector / Infra Manager / Terraform via Google) is not obvious. Investigation required before reservation.</td>
+  </tr>
+</tbody>
+</table>
+
+<h3>D5: Terraform is explicitly not the default multi-cloud runtime</h3>
+
+<div class="callout danger">
+<strong>Why Terraform-by-default is rejected:</strong> it fails the runtime requirements in D3.
+<ul>
+  <li><strong>External runner.</strong> The platform must host a Terraform-capable execution environment (worker container, version pinning, provider plugins). That is a new long-lived component to operate and secure.</li>
+  <li><strong>External state.</strong> Terraform requires a state file. The platform becomes responsible for backend choice (S3 + DynamoDB lock today; what about Azure / GCP?), encryption, ACL, and per-team state isolation. None of this exists in the current CloudFormation path.</li>
+  <li><strong>Locking.</strong> Concurrent <code>apply</code> against the same state requires coordination. Cloud-native engines provide this implicitly per Stack / Deployment / Release; Terraform demands explicit lock backend operations.</li>
+  <li><strong>Partial-failure cleanup.</strong> A crashed run can leave state and reality out of sync, with no provider-owned reconciliation. Authors and operators must reason about <code>terraform state rm</code> and similar low-level operations.</li>
+  <li><strong>Standalone validation.</strong> An author wanting to verify a problem outside TenkaCloud must also stand up the state backend, defeating the property that today they can just run <code>aws cloudformation deploy</code>.</li>
+</ul>
+Terraform is not banned as a problem-author tool — an author may use it locally to design a stack — but the <strong>deployed artifact</strong> must be a provider-native template that the cloud itself executes.
+</div>
+
+<h3>D6: Pulumi is unevaluated</h3>
+
+<p>Pulumi is marked <span class="badge warn">Needs investigation</span> and is neither accepted nor rejected by this ADR. Its execution model (program rather than declarative artifact), state model (Pulumi Service / self-managed backend), standalone validation flow, and teardown semantics need to be inspected against D3 before any decision. A separate ADR may follow if there is demand.</p>
+
+<h3>D7: Problem family model (reservation only)</h3>
+
+<p>For the second-stage model, the same conceptual problem with provider-specific implementations could be expressed as:</p>
+
+<pre>{
+  "id": "public-object-storage-remediation",
+  "kind": "problem-family",
+  "learningObjectives": ["..."],
+  "variants": [
+    { "provider": "aws",   "engine": "cloudformation", "entry": "aws/template.yaml" },
+    { "provider": "azure", "engine": "bicep",          "entry": "azure/main.bicep" }
+  ]
+}</pre>
+
+<p>This is documented here as a reservation only. The schema in Phase 1 does not introduce <code>kind: "problem-family"</code>. Adding it requires a follow-up ADR once we have at least one working non-AWS provider.</p>
+
+<h3>D8: Cloud-agnostic single-problem deployment is out of scope</h3>
+
+<p>A shape such as:</p>
+
+<pre>{
+  "id": "cloud-agnostic-object-storage-remediation",
+  "kind": "universal-problem",
+  "abstractResources": [
+    { "type": "object-storage", "publicAccess": true },
+    { "type": "identity", "permissions": "overbroad" }
+  ],
+  "compileTo": ["aws", "azure", "gcp"]
+}</pre>
+
+<p>requires a cloud drill compiler that maps an abstract resource model to provider-native services and failure modes. The model breaks down for provider-native services (BigQuery, Entra ID, IAM, Security Hub) where the point of the drill is the provider-specific semantics. TenkaCloud does not commit to this direction in the near-term roadmap. Such a compiler is closer to a separate research / product invention than a platform extension and is explicitly out of scope of this ADR and the issues it tracks.</p>
+</section>
+
+<section>
+<h2>Options considered</h2>
+
+<h3>Option A: Keep AWS-only until full multi-cloud is implementable <span class="badge reject">Rejected</span></h3>
+
+<table>
+<thead><tr><th>Pros</th><th>Cons</th></tr></thead>
+<tbody>
+<tr>
+  <td>
+    <ul>
+      <li>No schema churn.</li>
+      <li>No partial abstraction in code.</li>
+      <li>Smallest current product surface.</li>
+    </ul>
+  </td>
+  <td>
+    <ul>
+      <li>Misses the chance to define the design boundary while the runtime path is still single-engine.</li>
+      <li>Future contributors are likely to default to "just add Terraform" because no documented contract steers them otherwise.</li>
+      <li>OSS messaging on multi-cloud stays vague, which slows community contribution.</li>
+    </ul>
+  </td>
+</tr>
+</tbody>
+</table>
+
+<h3>Option B: Add runtime metadata now, support AWS only <span class="badge accept">Accepted</span></h3>
+
+<table>
+<thead><tr><th>Pros</th><th>Cons</th></tr></thead>
+<tbody>
+<tr>
+  <td>
+    <ul>
+      <li>Backward compatible — every existing problem normalizes to the same shape.</li>
+      <li>The extension seam is explicit; future provider work is a localized PR rather than a platform refactor.</li>
+      <li>Documentation and authoring guides can speak honestly about future provider-specific support without overpromising.</li>
+      <li>Validator rejects unsupported provider/engine values clearly, so authors do not silently ship a non-executable problem.</li>
+      <li>Avoids premature Azure / GCP / Kubernetes execution work; the engine count stays at one until a real second provider is wired up.</li>
+    </ul>
+  </td>
+  <td>
+    <ul>
+      <li>Adds future-looking metadata before any non-AWS runtime exists.</li>
+      <li>Risk that contributors infer "Azure is supported" from the schema's permissiveness if docs are unclear. Mitigated by: (a) CLI error message naming the only executable combination, (b) AUTHORING.html stating AWS/CloudFormation is the only executable runtime today.</li>
+    </ul>
+  </td>
+</tr>
+</tbody>
+</table>
+
+<h3>Option C: Introduce Terraform as the universal engine <span class="badge reject">Rejected</span></h3>
+
+<table>
+<thead><tr><th>Pros</th><th>Cons</th></tr></thead>
+<tbody>
+<tr>
+  <td>
+    <ul>
+      <li>Superficially broad provider coverage from a single engine.</li>
+      <li>Familiar to many infrastructure engineers.</li>
+    </ul>
+  </td>
+  <td>
+    <ul>
+      <li>Fails every requirement in D3 (external runner, external state, locking, partial-failure cleanup, harder standalone validation).</li>
+      <li>Makes the platform responsible for another execution and security boundary.</li>
+      <li>Pulls authoring complexity back to the platform — the opposite of ADR-012.</li>
+    </ul>
+  </td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Migration plan</h2>
+
+<table>
+<thead>
+  <tr><th>Phase</th><th>Scope</th><th>Status</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td>Phase 0</td>
+  <td>This ADR — direction, requirements, terminology, non-goals.</td>
+  <td><span class="badge accept">Shipped</span> with this PR</td>
+</tr>
+<tr>
+  <td>Phase 1</td>
+  <td>Schema accepts optional <code>runtime</code>; validator normalizes legacy <code>cfnTemplate</code>; CLI <code>create</code> scaffolds the <code>runtime</code> block; CLI <code>validate</code> rejects unsupported provider/engine combinations.</td>
+  <td><span class="badge accept">Shipped</span> with this PR (Issue #1267)</td>
+</tr>
+<tr>
+  <td>Phase 2</td>
+  <td>Deploy worker reads normalized runtime metadata internally. Still only the <code>aws</code> + <code>cloudformation</code> path is wired. Dispatch table exists but has one entry. No behavior change for existing problems.</td>
+  <td><span class="badge draft">Planned</span> (Issue #1268, separate PR)</td>
+</tr>
+<tr>
+  <td>Phase 3</td>
+  <td>One non-AWS provider experiment behind a feature flag. Most likely <code>azure</code> + <code>bicep</code> or <code>kubernetes</code> + <code>helm</code>, chosen for the cleanest cloud-owned execution / state / teardown story. Includes ADR-017-equivalent authority transfer for the second provider.</td>
+  <td><span class="badge draft">Planned</span> (separate ADR + PRs)</td>
+</tr>
+<tr>
+  <td>Phase 4</td>
+  <td>Problem-family model (D7) revisited only after Phase 3 succeeds with at least one second provider.</td>
+  <td><span class="badge draft">Reserved</span></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Consequences</h2>
+
+<h3>Gains</h3>
+
+<ul>
+  <li>The multi-cloud roadmap has a documented boundary: provider-specific first, family later, cloud-agnostic never (as a single-problem compiler).</li>
+  <li>The platform retains its CloudFormation-like simplicity: the cloud owns execution, state, and teardown.</li>
+  <li>Catalog metadata can already distinguish AWS problems from reserved-but-not-yet-executable provider targets, enabling honest authoring documentation.</li>
+  <li>Future PRs that add a second provider have a single seam to extend (runtime dispatch) rather than the whole deploy worker.</li>
+</ul>
+
+<h3>Costs</h3>
+
+<ul>
+  <li>An optional metadata field exists that today only takes one effective value. The cost is borne by the schema and CLI; existing problems are unaffected.</li>
+  <li>Documentation must keep emphasizing that the schema reserves provider values that are not yet executable, to avoid raising expectations.</li>
+  <li>If Phase 3 is delayed indefinitely, the reservation has carrying cost in code review and harness rules. Mitigated by Phase 1 / Phase 2 being thin (validator + dispatch table only).</li>
+</ul>
+</section>
+
+<section>
+<h2>Open questions</h2>
+
+<ul>
+  <li>Which second provider lands first in Phase 3 — Azure / Bicep, Kubernetes / Helm, or another. Decision deferred to a separate ADR once the maintainer team has bandwidth to operate a non-AWS test environment.</li>
+  <li>Authority transfer model for non-AWS providers — ADR-017 covers AWS AssumeRole + ExternalId; Azure Service Principal, Kubernetes ServiceAccount, and GCP Workload Identity Federation each need their own document.</li>
+  <li>Catalog UI presentation of reserved providers — whether to surface them as "coming soon" cards or hide them entirely until executable. UI decision, not schema decision; can be made when Phase 3 is scheduled.</li>
+  <li>Whether <code>cfnTemplate</code> ever gets removed. The current decision is "deprecated alias, not removed until the catalog is migrated"; the trigger for removal is a separate PR after Phase 2.</li>
+</ul>
+</section>
+
+</body>
+</html>

--- a/docs/problems/AUTHORING.html
+++ b/docs/problems/AUTHORING.html
@@ -215,6 +215,7 @@ bun run scripts/tenkacloud-problem.ts list-kinds</pre>
   <tr><td><code>exposedPorts</code></td><td>○</td><td>deploy 後に競技者へ払い出す port</td></tr>
   <tr><td><code>learningGoals</code></td><td>○</td><td>想定学習目的 (非空 array)</td></tr>
   <tr><td><code>cfnTemplate</code></td><td>○</td><td>"template.yaml" など</td></tr>
+  <tr><td><code>runtime</code></td><td>—</td><td>[ADR-023] <code>{provider, engine, entry}</code>。 推奨だが省略可 (= legacy <code>cfnTemplate</code> から自動推論)。 後述</td></tr>
   <tr><td><code>scoring</code></td><td>—</td><td>1 kind 1 設定 (Step 0 参照)。 省略で採点無効</td></tr>
   <tr><td><code>endpoints[]</code></td><td>—</td><td>Battle で endpoint を持つなら宣言 (= 後述)</td></tr>
   <tr><td><code>phases[]</code></td><td>—</td><td>phased-polling 系で時間経過 rule を入れるなら宣言</td></tr>
@@ -260,6 +261,22 @@ bun run scripts/tenkacloud-problem.ts list-kinds</pre>
     "parameters": { "delayMs": 200 }
   }
 ]</pre>
+
+<h3>runtime (= <a href="../architecture/adr-023-provider-specific-problem-runtime.html">ADR-023</a>)</h3>
+
+<p>optional metadata field。 問題が deploy される対象 cloud と engine を明示宣言する。 推奨形式:</p>
+
+<pre>"runtime": {
+  "provider": "aws",
+  "engine": "cloudformation",
+  "entry": "template.yaml"
+}</pre>
+
+<div class="callout warn">
+<strong>現状 executable な組み合わせは <code>provider=aws</code> + <code>engine=cloudformation</code> のみ。</strong> schema は将来の provider 値 (<code>azure</code> / <code>kubernetes</code> / <code>gcp</code>) を reservation として受理するが、 CLI validator (<code>scripts/tenkacloud-problem.ts validate</code>) と deploy worker は今 reject する。 詳細と migration plan は <a href="../architecture/adr-023-provider-specific-problem-runtime.html">ADR-023</a> 参照。
+</div>
+
+<p>後方互換: <code>runtime</code> を省略すると validator が legacy <code>cfnTemplate</code> から <code>{provider:'aws', engine:'cloudformation', entry:cfnTemplate}</code> に正規化する。 既存 catalog 問題はそのまま valid。 両方宣言する場合は <code>runtime.entry === cfnTemplate</code> でなければ validator が reject する (= 互換期間の整合性制約)。</p>
 </section>
 
 <section id="template">

--- a/infrastructure/test/scripts/problem-runtime-metadata.test.ts
+++ b/infrastructure/test/scripts/problem-runtime-metadata.test.ts
@@ -1,0 +1,166 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCreate, runValidate } from "../../../scripts/tenkacloud-problem";
+
+/**
+ * [Issue #1267 / ADR-023] optional `runtime` metadata の Phase 1 schema + CLI 検証。
+ *
+ * 観点:
+ *   1. legacy (= `cfnTemplate` のみ) 問題は引き続き valid (= 後方互換)
+ *   2. 明示宣言 `{aws, cloudformation, template.yaml}` は valid
+ *   3. `runtime.entry` と `cfnTemplate` が食い違うと reject
+ *   4. AWS / CloudFormation 以外の組み合わせは reservation として reject (= 実行不能であることを明示)
+ *   5. `runCreate` (= `/create-problem` scaffold) が runtime block を含む metadata を吐く
+ */
+
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
+const createdPaths: string[] = [];
+
+afterEach(() => {
+  for (const p of createdPaths.splice(0)) {
+    try {
+      rmSync(p, { recursive: true, force: true });
+    } catch {
+      // ignore — partial cleanup でも他 test 影響なし
+    }
+  }
+});
+
+/**
+ * Test helper: 既存 sample scaffold を base に metadata を改造して fixture 問題を 1 つ作る。
+ * runCreate の path を再利用しないのは、 runtime block を後付けで override したいから。
+ */
+function writeFixtureProblem(opts: {
+  uniqueId: string;
+  category: "battles" | "challenges";
+  mutate: (meta: Record<string, unknown>) => void;
+}): string {
+  const { uniqueId, category, mutate } = opts;
+  const dir = join(REPO_ROOT, "problems", category, uniqueId);
+  createdPaths.push(dir);
+  mkdirSync(dir, { recursive: true });
+
+  // Minimal valid metadata + template; we only care about runtime/cfnTemplate consistency here.
+  const meta: Record<string, unknown> = {
+    $schema: "../../SCHEMA.json",
+    id: uniqueId,
+    name: "fixture",
+    category: category === "battles" ? "Battle" : "Challenge",
+    status: "draft",
+    difficulty: 1,
+    estimatedDuration: "10 分",
+    shortDescription: "runtime metadata fixture",
+    description: "runtime metadata fixture",
+    tags: ["fixture"],
+    exposedPorts: [{ port: 1, name: "noop" }],
+    learningGoals: ["fixture"],
+    cfnTemplate: "template.yaml",
+  };
+  mutate(meta);
+  writeFileSync(join(dir, "metadata.json"), `${JSON.stringify(meta, null, 2)}\n`, "utf8");
+  writeFileSync(
+    join(dir, "template.yaml"),
+    "AWSTemplateFormatVersion: '2010-09-09'\nParameters:\n  NamePrefix:\n    Type: String\nResources:\n  Noop:\n    Type: AWS::CloudFormation::WaitConditionHandle\n",
+    "utf8",
+  );
+  return dir;
+}
+
+describe("ADR-023 / Issue #1267: provider-specific runtime metadata", () => {
+  it("should keep legacy problems (cfnTemplate only) valid", () => {
+    const uniqueId = `test-runtime-legacy-${Date.now().toString(36)}`;
+    writeFixtureProblem({
+      uniqueId,
+      category: "challenges",
+      mutate: () => {
+        // no runtime block — strictly legacy shape
+      },
+    });
+    const r = runValidate(uniqueId);
+    if (!r.ok) {
+      throw new Error(`expected legacy fixture to validate, got: ${r.errors.join("; ")}`);
+    }
+    expect(r.ok).toBe(true);
+  });
+
+  it("should accept explicit aws/cloudformation runtime declaration", () => {
+    const uniqueId = `test-runtime-aws-${Date.now().toString(36)}`;
+    writeFixtureProblem({
+      uniqueId,
+      category: "challenges",
+      mutate: (meta) => {
+        meta.runtime = {
+          provider: "aws",
+          engine: "cloudformation",
+          entry: "template.yaml",
+        };
+      },
+    });
+    const r = runValidate(uniqueId);
+    if (!r.ok) {
+      throw new Error(`expected explicit-runtime fixture to validate, got: ${r.errors.join("; ")}`);
+    }
+    expect(r.ok).toBe(true);
+  });
+
+  it("should reject when runtime.entry and cfnTemplate disagree", () => {
+    const uniqueId = `test-runtime-inconsistent-${Date.now().toString(36)}`;
+    writeFixtureProblem({
+      uniqueId,
+      category: "challenges",
+      mutate: (meta) => {
+        meta.cfnTemplate = "template.yaml";
+        meta.runtime = {
+          provider: "aws",
+          engine: "cloudformation",
+          entry: "other-template.yaml",
+        };
+      },
+    });
+    const r = runValidate(uniqueId);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("must match"))).toBe(true);
+  });
+
+  it("should reject unsupported provider/engine with a clear reservation message", () => {
+    const uniqueId = `test-runtime-azure-${Date.now().toString(36)}`;
+    writeFixtureProblem({
+      uniqueId,
+      category: "challenges",
+      mutate: (meta) => {
+        meta.runtime = {
+          provider: "azure",
+          engine: "bicep",
+          entry: "template.yaml",
+        };
+      },
+    });
+    const r = runValidate(uniqueId);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("azure/bicep") && e.includes("not executable"))).toBe(
+      true,
+    );
+  });
+
+  it("should scaffold new problems with an explicit aws/cloudformation runtime block", () => {
+    const uniqueId = `test-runtime-scaffold-${Date.now().toString(36)}`;
+    const created = runCreate({ problemId: uniqueId, kind: "flag" });
+    createdPaths.push(created.outputDir);
+
+    expect(existsSync(join(created.outputDir, "metadata.json"))).toBe(true);
+    const metadata = JSON.parse(readFileSync(join(created.outputDir, "metadata.json"), "utf8"));
+    expect(metadata.runtime).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    });
+
+    // Scaffold should validate end-to-end through the same CLI path.
+    const r = runValidate(uniqueId);
+    if (!r.ok) {
+      throw new Error(`scaffold should validate, got: ${r.errors.join("; ")}`);
+    }
+    expect(r.ok).toBe(true);
+  });
+});

--- a/scripts/problem-cli/problem-loader.ts
+++ b/scripts/problem-cli/problem-loader.ts
@@ -5,6 +5,20 @@ import { PROBLEMS_ROOT } from "./constants";
 
 export type ProblemMetadata = Record<string, unknown>;
 
+/**
+ * [ADR-023] Normalized runtime descriptor. legacy `cfnTemplate` だけ宣言された問題は
+ * `{provider:'aws', engine:'cloudformation', entry:cfnTemplate}` に正規化される (= 後方互換)。
+ * 現在 executable な組み合わせは `aws` + `cloudformation` のみで、 それ以外は CLI validator が reject する。
+ */
+export interface NormalizedRuntime {
+  readonly provider: string;
+  readonly engine: string;
+  readonly entry: string;
+}
+
+export const EXECUTABLE_PROVIDER = "aws";
+export const EXECUTABLE_ENGINE = "cloudformation";
+
 export function findProblemDir(problemId: string): string | undefined {
   for (const category of ["battles", "challenges"]) {
     const candidate = join(PROBLEMS_ROOT, category, problemId);
@@ -18,5 +32,38 @@ export function readProblemMetadata(dir: string): ProblemMetadata {
 }
 
 export function getTemplateName(meta: ProblemMetadata): string {
+  const runtime = meta.runtime as Record<string, unknown> | undefined;
+  if (runtime && typeof runtime.entry === "string") {
+    return runtime.entry;
+  }
   return typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+}
+
+/**
+ * [ADR-023] Normalize a problem's runtime descriptor. Order of precedence:
+ *   1. Explicit `runtime` block (must declare provider/engine/entry per SCHEMA).
+ *   2. Legacy `cfnTemplate` → inferred as `aws` / `cloudformation` / <cfnTemplate>.
+ *   3. Last-resort default `aws` / `cloudformation` / `template.yaml` (= scaffold baseline).
+ *
+ * Returns undefined only when `runtime` is malformed (= missing required keys).
+ * Consistency between `runtime.entry` and `cfnTemplate` is not enforced here; that lives in the validator.
+ */
+export function normalizeRuntime(meta: ProblemMetadata): NormalizedRuntime | undefined {
+  const runtime = meta.runtime as Record<string, unknown> | undefined;
+  if (runtime !== undefined) {
+    if (
+      typeof runtime.provider !== "string" ||
+      typeof runtime.engine !== "string" ||
+      typeof runtime.entry !== "string"
+    ) {
+      return undefined;
+    }
+    return { provider: runtime.provider, engine: runtime.engine, entry: runtime.entry };
+  }
+  const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+  return { provider: EXECUTABLE_PROVIDER, engine: EXECUTABLE_ENGINE, entry: cfnTemplate };
+}
+
+export function isExecutableRuntime(runtime: NormalizedRuntime): boolean {
+  return runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE;
 }

--- a/scripts/problem-cli/validate.ts
+++ b/scripts/problem-cli/validate.ts
@@ -2,7 +2,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { KINDS } from "./constants";
-import { findProblemDir, getTemplateName } from "./problem-loader";
+import {
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  findProblemDir,
+  getTemplateName,
+  normalizeRuntime,
+} from "./problem-loader";
 
 export interface ValidateResult {
   readonly ok: boolean;
@@ -26,6 +32,7 @@ export function runValidate(problemId: string): ValidateResult {
   if (!meta) {
     return { ok: false, errors };
   }
+  validateRuntime(meta, errors);
   const cfnTemplate = getTemplateName(meta);
   const templatePath = join(dir, cfnTemplate);
   const ctx: ValidationContext = { dir, problemId, meta, templatePath };
@@ -34,6 +41,37 @@ export function runValidate(problemId: string): ValidateResult {
   validateEndpointOutputs(ctx, errors);
   validateDashboardSlots(ctx, errors);
   return { ok: errors.length === 0, errors };
+}
+
+/**
+ * [ADR-023] Phase 1: optional `runtime` field の検証。
+ *   - normalize 失敗 (= 不完全な runtime block) は明示エラー
+ *   - `runtime` と `cfnTemplate` 両方宣言時は `runtime.entry === cfnTemplate` を強制 (= 互換期間)
+ *   - 認識できる combination は `aws` + `cloudformation` のみ。 それ以外は reservation として
+ *     reject する (= author が deploy できない問題を ship するのを止める)
+ */
+function validateRuntime(meta: Record<string, unknown>, errors: string[]): void {
+  const runtimeBlock = meta.runtime;
+  if (runtimeBlock !== undefined) {
+    const normalized = normalizeRuntime(meta);
+    if (!normalized) {
+      errors.push(
+        "runtime block must declare provider / engine / entry (all strings). See ADR-023.",
+      );
+      return;
+    }
+    const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : undefined;
+    if (cfnTemplate !== undefined && cfnTemplate !== normalized.entry) {
+      errors.push(
+        `runtime.entry="${normalized.entry}" and cfnTemplate="${cfnTemplate}" must match during the dual-field compatibility window (ADR-023 D2).`,
+      );
+    }
+    if (normalized.provider !== EXECUTABLE_PROVIDER || normalized.engine !== EXECUTABLE_ENGINE) {
+      errors.push(
+        `Runtime ${normalized.provider}/${normalized.engine} is recognized but not executable in this platform version. Only ${EXECUTABLE_PROVIDER}/${EXECUTABLE_ENGINE} is supported today (ADR-023 D4).`,
+      );
+    }
+  }
 }
 
 function loadMetadataForValidation(

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -51,9 +51,30 @@ function findMetadataFiles(dir: string): string[] {
  * 実 deploy で CFn が CREATE_COMPLETE しても、 これらの参照が解決できないと
  * scoring engine / portal が壊れるので、 ここで先に止める。
  */
+function resolveTemplatePath(meta: Metadata): string {
+  // [ADR-023] Prefer `runtime.entry` when declared; fall back to legacy `cfnTemplate`; finally default.
+  const runtime = meta.runtime as Record<string, unknown> | undefined;
+  if (runtime && typeof runtime.entry === "string") return runtime.entry;
+  return typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+}
+
+function checkRuntimeConsistency(meta: Metadata): ValidationError[] {
+  // [ADR-023] If both `runtime` and `cfnTemplate` are declared, they must agree (= compat window).
+  const runtime = meta.runtime as Record<string, unknown> | undefined;
+  if (!runtime) return [];
+  const entry = typeof runtime.entry === "string" ? runtime.entry : undefined;
+  const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : undefined;
+  if (entry && cfnTemplate && entry !== cfnTemplate) {
+    return [
+      `runtime.entry="${entry}" と cfnTemplate="${cfnTemplate}" が一致しません (ADR-023 D2 compat window)`,
+    ];
+  }
+  return [];
+}
+
 function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
   const dir = dirname(metaPath);
-  const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+  const cfnTemplate = resolveTemplatePath(meta);
   const templatePath = join(dir, cfnTemplate);
 
   if (!existsSync(templatePath)) {
@@ -61,6 +82,7 @@ function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
   }
   const yaml = readFileSync(templatePath, "utf8");
   return [
+    ...checkRuntimeConsistency(meta),
     ...checkScoringOutputRefs(meta, yaml, cfnTemplate),
     ...checkEndpointOutputRefs(meta, yaml, cfnTemplate),
     ...checkDashboardSlotFiles(meta, dir),


### PR DESCRIPTION
## Summary
- Add ADR-023 formalizing provider-specific problem runtime model (CloudFormation-like requirements, why not Terraform-by-default, Pulumi unevaluated, cloud-agnostic single-problem compilation explicitly out of scope). Note: ADR-019 was already taken (`adr-019-cross-account-stack-catalog.html`), so this lands as ADR-023.
- Extend `problems/SCHEMA.json` (submodule bump to TenkaCloudChallenge `feat/runtime-metadata-schema`) with optional `runtime: { provider, engine, entry }` — defaults inferred from legacy `cfnTemplate` for backward compat.
- `scripts/tenkacloud-problem.ts create` scaffolds new problems with `runtime` block; `validate` normalizes legacy + new, rejects inconsistent or unsupported combinations.
- Scaffold templates under `.claude/templates/problems/<kind>/` updated for all 5 kinds.
- `docs/problems/AUTHORING.html` cross-links the ADR.

Closes #1266
Closes #1267
Relates #1265

## Regression analysis
- Existing 5 catalog problems do not declare `runtime` → validator infers AWS/CloudFormation from `cfnTemplate` → unchanged behavior. `make validate-problems` passes against all of them post-change.
- Deploy worker / CDK stacks are NOT modified; runtime metadata is read by validator only. Wire-up to deploy dispatch is a follow-up (Issue #1268 candidate) and stays out of scope here.
- Scaffolding CLI now emits an extra `runtime` block — new problems are ~5 lines larger but the validator accepts both shapes.
- Schema change lives in the `problems/` submodule (TenkaCloudChallenge); merging this PR also moves the submodule pointer. The submodule-side PR must merge first (or together) to avoid CI seeing the new field as an unknown property.

## Physical impact
- NO-OP: no CDK / CFn / Lambda runtime artifact changes. `cdk synth` confirmed clean during `make before-commit`.
- DATA: `problems/SCHEMA.json` (in submodule) adds optional property; backward-compatible JSON Schema extension.
- SUBMODULE: `problems` pointer moves from `93a8139` → `7832b6a` (one commit on `feat/runtime-metadata-schema`).
- DOCS: new `docs/architecture/adr-023-provider-specific-problem-runtime.html`, updated `docs/problems/AUTHORING.html`.
- TESTS: new test file `infrastructure/test/scripts/problem-runtime-metadata.test.ts` (5 cases: legacy validates, explicit AWS validates, inconsistent entry rejected, unsupported provider rejected, scaffold includes runtime block).