### PR TITLE
refactor(application-admin-console): split EventCreate.tsx wizard (657->297 lines)

### DIFF
--- a/.claude/harness/baselines/file-too-large.json
+++ b/.claude/harness/baselines/file-too-large.json
@@ -20,12 +20,6 @@
     },
     {
       "ruleId": "file-too-large",
-      "filePath": "apps/application-admin-console/src/pages/EventCreate.tsx",
-      "line": 1,
-      "match": "ge-500-lines"
-    },
-    {
-      "ruleId": "file-too-large",
       "filePath": "apps/application-admin-console/src/pages/EventDetail.tsx",
       "line": 1,
       "match": "ge-800-lines"

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -1,165 +1,48 @@
+import type { MultiselectProps, SelectProps } from "@cloudscape-design/components";
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
-import ColumnLayout from "@cloudscape-design/components/column-layout";
-import Container from "@cloudscape-design/components/container";
 import Form from "@cloudscape-design/components/form";
-import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
-import Input from "@cloudscape-design/components/input";
-import Link from "@cloudscape-design/components/link";
-import Modal from "@cloudscape-design/components/modal";
-import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
-import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import Table from "@cloudscape-design/components/table";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { type ApiClient, useApiClient } from "../api/client";
-import {
-  type CompetitorAccountSummary,
-  listCompetitorAccounts,
-} from "../api/competitor-accounts-client";
+import { useApiClient } from "../api/client";
 import { bulkDeployEvent, createEvent } from "../api/events-client";
 import type { AppConfig } from "../config";
-import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../data/aws-regions";
+import { DEFAULT_AWS_REGION } from "../data/aws-regions";
 import { listProblemSummaries } from "../data/problems";
 import { useT } from "../i18n";
+import { filterVerifiedAccounts } from "../lib/competitor-accounts-filter";
+import { EventCreateAccountsAlerts } from "./event-create/EventCreateAccountsAlerts";
+import { EventCreateBasicInfoSection } from "./event-create/EventCreateBasicInfoSection";
+import { EventCreateDeployPromptModal } from "./event-create/EventCreateDeployPromptModal";
+import { EventCreateProblemsetSection } from "./event-create/EventCreateProblemsetSection";
+import { EventCreateTeamsSection } from "./event-create/EventCreateTeamsSection";
 import {
-  filterVerifiedAccounts,
-  formatCompetitorAccountsLoadError,
-} from "../lib/competitor-accounts-filter";
+  buildVerifiedAccountOption,
+  INITIAL_TEAM_COUNT,
+  NAME_MAX,
+  type ProblemRow,
+  resizeTeamRows,
+  TEAMS_MAX,
+  TEAMS_MIN,
+  type TeamRow,
+  validateTeamRows,
+} from "./event-create/helpers";
+import { useCompetitorAccountsLoader } from "./event-create/useCompetitorAccountsLoader";
 
-const NAME_MAX = 120;
-// MUST match infrastructure/lib/problem-deploy/handlers/event-handler/types.ts (zod schema)。
-// drift すると frontend が通した値を backend が reject する。
-const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
-const ACCOUNT_ID_RE = /^\d{12}$/;
-const TEAMS_MIN = 1;
-const TEAMS_MAX = 99;
-const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
-const INITIAL_TEAM_COUNT = 3;
-
-const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
-  value: r.code,
-  label: r.label,
-}));
-
-export function buildVerifiedAccountOption(a: CompetitorAccountSummary): SelectProps.Option {
-  const descriptionParts = [a.alias, a.region, a.competitorRoleName].filter(
-    (p): p is string => typeof p === "string" && p.length > 0,
-  );
-  return {
-    value: a.awsAccountId,
-    label: a.awsAccountId,
-    labelTag: a.alias,
-    description: descriptionParts.join(" / "),
-    filteringTags: descriptionParts,
-  };
-}
-
-export function formatVerifiedAccountSummary(a: CompetitorAccountSummary): string {
-  return a.alias ? `${a.awsAccountId} (${a.alias})` : a.awsAccountId;
-}
-
-interface ProblemRow {
-  problemId: string;
-  problemName: string;
-  defaultRegion: string;
-  /** Issue #1201 Phase 2: 問題が動作確認済 region 集合。 wizard picker の選択肢を絞る。 */
-  supportedRegions?: readonly string[];
-}
-
-/**
- * Issue #1201 Phase 2: region picker の選択肢を `supportedRegions` で絞る純関数。
- *
- * - `supportedRegions` が undefined / 空 → 全 region (= 後方互換)
- * - 宣言されていれば、 集合と AWS_REGIONS の intersection で picker を構築
- * - 未知 region code (= AWS_REGIONS に無い文字列) は無視 (= UI に壊れた option を出さない)
- */
-export function resolveRegionOptions(
-  supportedRegions: readonly string[] | undefined,
-  baseOptions: readonly SelectProps.Option[],
-): readonly SelectProps.Option[] {
-  if (!supportedRegions || supportedRegions.length === 0) return baseOptions;
-  const allowed = new Set(supportedRegions);
-  const intersection = baseOptions.filter((o) => o.value && allowed.has(o.value));
-  // 宣言が無効 (= AWS_REGIONS と 1 件もマッチしない) のときは base に倒す。
-  // ここで空配列を返すと wizard が壊れるので fail-safe。
-  return intersection.length > 0 ? intersection : baseOptions;
-}
-
-/**
- * #528: 各 team の deploy 先 AWS Account ID は **team 単位** に。region は問題テンプレが
- * 特定 region 依存の場合があるので問題単位を維持。
- */
-interface TeamRow {
-  internalSlug: string;
-  awsAccountId: string;
-}
-
-interface TeamValidation {
-  readonly allSlugsValid: boolean;
-  readonly allAccountsValid: boolean;
-  readonly hasDuplicateSlug: boolean;
-}
-
-/**
- * Issue #1201: 問題行の初期 region を決める純関数。
- *
- * - 問題 metadata に `defaultRegion` が宣言されていればそれを採用
- * - 未宣言なら `globalDefault` (= 通常 `DEFAULT_AWS_REGION.code`) にフォールバック
- *
- * 「全 event が ap-northeast-1 に集中して quota 上限に到達する」 問題を、 問題側
- * (= 動作確認済 region を一番よく知っている人) の宣言で散らすための仕掛け。
- */
-export function resolveInitialRegion(
-  metaDefaultRegion: string | undefined,
-  globalDefault: string,
-): string {
-  return metaDefaultRegion ?? globalDefault;
-}
-
-export function resizeTeamRows(prev: TeamRow[], next: number): TeamRow[] {
-  if (next === prev.length) return prev;
-  if (next < prev.length) return prev.slice(0, Math.max(next, 0));
-  const additions = Array.from({ length: next - prev.length }, (_, i) => ({
-    internalSlug: `team-${prev.length + i + 1}`,
-    awsAccountId: "",
-  }));
-  return [...prev, ...additions];
-}
-
-export function validateTeamRows(teamRows: readonly TeamRow[]): TeamValidation {
-  let allSlugsValid = true;
-  let allAccountsValid = true;
-  const slugs = new Set<string>();
-  let hasDuplicateSlug = false;
-  for (const t of teamRows) {
-    if (!SLUG_RE.test(t.internalSlug)) allSlugsValid = false;
-    if (!ACCOUNT_ID_RE.test(t.awsAccountId)) allAccountsValid = false;
-    if (slugs.has(t.internalSlug)) hasDuplicateSlug = true;
-    else slugs.add(t.internalSlug);
-  }
-  return { allSlugsValid, allAccountsValid, hasDuplicateSlug };
-}
-
-export function parseTeamCountInput(value: string): number | undefined {
-  const next = Number.parseInt(value.replace(/\D/g, "").slice(0, TEAM_COUNT_INPUT_MAX_LEN), 10);
-  return Number.isFinite(next) ? Math.max(0, Math.min(TEAMS_MAX, next)) : undefined;
-}
-
-function getNameErrorText(t: ReturnType<typeof useT>, name: string, nameInvalid: boolean) {
-  return nameInvalid && name.length > 0
-    ? t("event_create.name_invalid", { max: NAME_MAX })
-    : undefined;
-}
-
-function getTeamCountErrorText(t: ReturnType<typeof useT>, teamCountInvalid: boolean) {
-  return teamCountInvalid
-    ? t("event_create.team_count_invalid", { min: TEAMS_MIN, max: TEAMS_MAX })
-    : undefined;
-}
+// 既存テストが `from "./EventCreate"` で import している pure helpers / 型は
+// 後方互換のため re-export する。 Issue #1241 の分割は API breaking でないことが要件。
+export {
+  buildVerifiedAccountOption,
+  formatVerifiedAccountSummary,
+  parseTeamCountInput,
+  resizeTeamRows,
+  resolveInitialRegion,
+  resolveRegionOptions,
+  validateTeamRows,
+} from "./event-create/helpers";
 
 /**
  * Event 作成 form。
@@ -173,6 +56,9 @@ function getTeamCountErrorText(t: ReturnType<typeof useT>, teamCountInvalid: boo
  * 提出後は EventDetail に直接 navigate する (#530)。teamLoginKey は EventDetail の
  * 「チーム」 table で常時表示 + 各行にコピー button があるので、modal で 1 度きり露出
  * する旧 UX は不要。
+ *
+ * Issue #1241: section components (`event-create/*`) に分割。 このファイルは
+ * state / handler / 子 section への配線だけを担う orchestrator。
  */
 export function EventCreatePage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
@@ -186,42 +72,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   );
 
   // Phase 2.2 (Issue #459): verified=true な CompetitorAccounts のみを Select の選択肢にする。
-  // 自由入力の Input は廃止 (= operator が verified 済 account しか選べない fail-closed UX)。
-  const [competitorAccounts, setCompetitorAccounts] = useState<
-    readonly CompetitorAccountSummary[] | null
-  >(null);
-  const [accountsLoadError, setAccountsLoadError] = useState<string | null>(null);
-  const [accountsLoading, setAccountsLoading] = useState(false);
-
-  const fetchAccounts = useCallback(async () => {
-    if (!apiClient) return;
-    setAccountsLoading(true);
-    setAccountsLoadError(null);
-    try {
-      const res = await listCompetitorAccounts(apiClient as ApiClient);
-      setCompetitorAccounts(res.items);
-    } catch (err) {
-      // Issue #815: 401 は friendly な「再ログインしてください」 に flip。 silent 空配列で
-      // operator が次の一手を見失う UX を防ぐ (= 旧 unknown-tenant fallback の置き換え)。
-      setAccountsLoadError(formatCompetitorAccountsLoadError(err));
-    } finally {
-      setAccountsLoading(false);
-    }
-  }, [apiClient]);
-
-  useEffect(() => {
-    void fetchAccounts();
-  }, [fetchAccounts]);
-
-  // #671: window focus 時に再取得する。 別タブで Verify した直後に戻ったとき、
-  // dropdown が古い空配列のまま動かない問題への対処。
-  useEffect(() => {
-    const onFocus = () => {
-      void fetchAccounts();
-    };
-    window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
-  }, [fetchAccounts]);
+  // fetch + window focus 再取得は hook に切り出し済 (Issue #1241)。
+  const { competitorAccounts, accountsLoadError, accountsLoading, fetchAccounts } =
+    useCompetitorAccountsLoader(config);
 
   const verifiedAccounts = useMemo(
     () => filterVerifiedAccounts(competitorAccounts),
@@ -253,41 +106,44 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
 
   /** チーム数の Input 変更で teamRows を伸縮。同数なら same-reference を返して
    *  無駄な再 render を防ぐ。減るとき末尾捨て、増えるとき新 row 追加。 */
-  const handleTeamCountChange = (next: number) => {
+  const handleTeamCountChange = useCallback((next: number) => {
     setTeamRows((prev) => resizeTeamRows(prev, next));
-  };
+  }, []);
 
-  const updateTeamRow = (idx: number, patch: Partial<TeamRow>) => {
+  const updateTeamRow = useCallback((idx: number, patch: Partial<TeamRow>) => {
     setTeamRows((rows) => rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
-  };
+  }, []);
 
   // Multiselect 変更時は problemRows を sync (既存行は値保持、新規分は default region)。
-  const onProblemsChange = (next: readonly MultiselectProps.Option[]) => {
-    setSelectedProblems(next);
-    setProblemRows((prev) => {
-      const byId = new Map(prev.map((r) => [r.problemId, r]));
-      return next
-        .filter((o): o is MultiselectProps.Option & { value: string } => !!o.value)
-        .map((opt) => {
-          const existing = byId.get(opt.value);
-          if (existing) return existing;
-          const meta = allProblems.find((p) => p.id === opt.value);
-          return {
-            problemId: opt.value,
-            problemName: meta?.name ?? opt.value,
-            // Issue #1201: 問題 metadata の defaultRegion を初期値に採用 (= 全 event
-            // が ap-northeast-1 に集中するのを防ぐ)。 未宣言なら従来通り
-            // DEFAULT_AWS_REGION にフォールバック。 operator は wizard で override 可能。
-            defaultRegion: meta?.defaultRegion ?? DEFAULT_AWS_REGION.code,
-            ...(meta?.supportedRegions ? { supportedRegions: meta.supportedRegions } : {}),
-          };
-        });
-    });
-  };
+  const onProblemsChange = useCallback(
+    (next: readonly MultiselectProps.Option[]) => {
+      setSelectedProblems(next);
+      setProblemRows((prev) => {
+        const byId = new Map(prev.map((r) => [r.problemId, r]));
+        return next
+          .filter((o): o is MultiselectProps.Option & { value: string } => !!o.value)
+          .map((opt) => {
+            const existing = byId.get(opt.value);
+            if (existing) return existing;
+            const meta = allProblems.find((p) => p.id === opt.value);
+            return {
+              problemId: opt.value,
+              problemName: meta?.name ?? opt.value,
+              // Issue #1201: 問題 metadata の defaultRegion を初期値に採用 (= 全 event
+              // が ap-northeast-1 に集中するのを防ぐ)。 未宣言なら従来通り
+              // DEFAULT_AWS_REGION にフォールバック。 operator は wizard で override 可能。
+              defaultRegion: meta?.defaultRegion ?? DEFAULT_AWS_REGION.code,
+              ...(meta?.supportedRegions ? { supportedRegions: meta.supportedRegions } : {}),
+            };
+          });
+      });
+    },
+    [allProblems],
+  );
 
-  const updateProblemRow = (problemId: string, patch: Partial<ProblemRow>) => {
+  const updateProblemRow = useCallback((problemId: string, patch: Partial<ProblemRow>) => {
     setProblemRows((rows) => rows.map((r) => (r.problemId === problemId ? { ...r, ...patch } : r)));
-  };
+  }, []);
 
   // teamRows ベースの validation を 1 pass に集約 (= 4 つ .every() / IIFE を回す代わり)。
   // teamRows 変更時のみ再評価され、render path の負担を減らす。
@@ -295,7 +151,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   // Table の items に渡す配列を teamRows ベースで memo 化。Cloudscape Table は items の
   // shallow identity で再 render 判定するので、毎 render 新 array を渡すと無駄に重い
   // (= 99 行 × 2 column の Input が全部 reconcile される)。
-  const teamTableItems = useMemo(() => teamRows.map((t, i) => ({ ...t, idx: i })), [teamRows]);
+  const teamTableItems = useMemo(() => teamRows.map((tr, i) => ({ ...tr, idx: i })), [teamRows]);
   const teamCountInvalid = teamRows.length < TEAMS_MIN || teamRows.length > TEAMS_MAX;
   const nameInvalid = name.length === 0 || name.length > NAME_MAX;
   const canSubmit =
@@ -321,9 +177,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
     try {
       const res = await createEvent(apiClient, {
         name,
-        teams: teamRows.map((t) => ({
-          internalSlug: t.internalSlug,
-          awsAccountId: t.awsAccountId,
+        teams: teamRows.map((tr) => ({
+          internalSlug: tr.internalSlug,
+          awsAccountId: tr.awsAccountId,
         })),
         problems: problemRows.map((r) => ({
           problemId: r.problemId,
@@ -377,233 +233,42 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
             </Alert>
           )}
 
-          <Container header={<Header variant="h2">{t("event_create.basic_info_header")}</Header>}>
-            <ColumnLayout columns={2}>
-              <FormField
-                label={t("event_create.name_label")}
-                description={t("event_create.name_placeholder_example")}
-                errorText={getNameErrorText(t, name, nameInvalid)}
-              >
-                <Input
-                  value={name}
-                  onChange={({ detail }) => setName(detail.value)}
-                  invalid={nameInvalid && name.length > 0}
-                />
-              </FormField>
-              <FormField
-                label={t("event_create.team_count_label")}
-                description={t("event_create.team_count_description", {
-                  min: TEAMS_MIN,
-                  max: TEAMS_MAX,
-                })}
-                errorText={getTeamCountErrorText(t, teamCountInvalid)}
-              >
-                <Input
-                  type="number"
-                  inputMode="numeric"
-                  value={String(teamRows.length)}
-                  onChange={({ detail }) => {
-                    const next = parseTeamCountInput(detail.value);
-                    if (next !== undefined) handleTeamCountChange(next);
-                  }}
-                  invalid={teamCountInvalid}
-                />
-              </FormField>
-            </ColumnLayout>
-          </Container>
+          <EventCreateBasicInfoSection
+            name={name}
+            onNameChange={setName}
+            nameInvalid={nameInvalid}
+            teamCount={teamRows.length}
+            onTeamCountChange={handleTeamCountChange}
+            teamCountInvalid={teamCountInvalid}
+          />
 
-          {/* #528: Teams section — 各 team の internalSlug + AWS Account ID を per-team で入力。
-           *   旧 UX は problem 単位で 1 account 共有だったが、real competition では各 team が
-           *   自社 account を持つため per-team 入力にする。
-           *   Phase 2.2 (Issue #459): account は verified=true な CompetitorAccounts のみ選択
-           *   できる drop-down。0 件のときは Competitor Accounts ページへの導線を出す。 */}
-          {accountsLoadError && (
-            <Alert
-              type="error"
-              header={t("event_create.accounts_load_error_header")}
-              action={
-                <Button
-                  iconName="refresh"
-                  onClick={() => void fetchAccounts()}
-                  loading={accountsLoading}
-                >
-                  {t("event_create.accounts_reload")}
-                </Button>
-              }
-            >
-              {accountsLoadError}
-            </Alert>
-          )}
-          {competitorAccounts === null && accountsLoading && !accountsLoadError && (
-            <Alert type="info" header={t("event_create.accounts_loading_header")}>
-              {t("event_create.accounts_loading_body")}
-            </Alert>
-          )}
-          {showNoVerifiedAccountsHint && (
-            <Alert
-              type="warning"
-              header={t("event_create.no_verified_header")}
-              action={
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    iconName="refresh"
-                    onClick={() => void fetchAccounts()}
-                    loading={accountsLoading}
-                  >
-                    {t("event_create.accounts_reload")}
-                  </Button>
-                  <Link
-                    href="/competitor-accounts"
-                    external={false}
-                    onFollow={(e) => {
-                      e.preventDefault();
-                      navigate("/competitor-accounts");
-                    }}
-                  >
-                    {t("event_create.go_to_competitor_accounts")}
-                  </Link>
-                </SpaceBetween>
-              }
-            >
-              {t("event_create.no_verified_body")}
-            </Alert>
-          )}
-          <Container
-            header={
-              <Header variant="h2" description={t("event_create.teams_description")}>
-                {t("event_create.teams_header", { count: teamRows.length })}
-              </Header>
-            }
-          >
-            {teamRows.length === 0 ? (
-              <Box variant="small" color="text-status-inactive">
-                {t("event_create.teams_empty")}
-              </Box>
-            ) : (
-              <Table
-                variant="embedded"
-                items={teamTableItems}
-                columnDefinitions={[
-                  {
-                    id: "slug",
-                    header: t("event_create.col_internal_slug"),
-                    cell: (tr) => (
-                      <Input
-                        value={tr.internalSlug}
-                        placeholder="team-1"
-                        invalid={!SLUG_RE.test(tr.internalSlug)}
-                        onChange={({ detail }) =>
-                          updateTeamRow(tr.idx, { internalSlug: detail.value })
-                        }
-                      />
-                    ),
-                  },
-                  {
-                    id: "account",
-                    header: t("event_create.col_aws_account"),
-                    cell: (tr) => {
-                      const selected =
-                        accountOptions.find((o) => o.value === tr.awsAccountId) ?? null;
-                      const selectedAccount = accountById.get(tr.awsAccountId);
-                      return (
-                        <SpaceBetween size="xxs">
-                          <Select
-                            selectedOption={selected}
-                            options={accountOptions}
-                            placeholder={
-                              noVerifiedAccounts
-                                ? t("event_create.no_verified_helper")
-                                : t("event_create.select_verified_placeholder")
-                            }
-                            disabled={accountOptions.length === 0}
-                            empty={t("event_create.select_empty_message")}
-                            onChange={({ detail }) =>
-                              updateTeamRow(tr.idx, {
-                                awsAccountId: detail.selectedOption?.value ?? "",
-                              })
-                            }
-                            invalid={
-                              tr.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(tr.awsAccountId)
-                            }
-                            expandToViewport
-                            filteringType="auto"
-                          />
-                          {selectedAccount && (
-                            <Box variant="small" color="text-status-inactive">
-                              <span title={formatVerifiedAccountSummary(selectedAccount)}>
-                                {formatVerifiedAccountSummary(selectedAccount)}
-                              </span>
-                            </Box>
-                          )}
-                          {noVerifiedAccounts && (
-                            <Box variant="small" color="text-status-inactive">
-                              {t("event_create.no_verified_helper")}
-                            </Box>
-                          )}
-                        </SpaceBetween>
-                      );
-                    },
-                  },
-                ]}
-              />
-            )}
-            {teamValidation.hasDuplicateSlug && (
-              <Box variant="small" color="text-status-error" padding={{ top: "xs" }}>
-                {t("event_create.duplicate_slug_error")}
-              </Box>
-            )}
-          </Container>
+          {/* #528 / Phase 2.2 (Issue #459): Teams 入力の上に置く 3 種 Alert。
+           *   load error / loading / 0-verified hint をまとめた小 component。 */}
+          <EventCreateAccountsAlerts
+            accountsLoadError={accountsLoadError}
+            accountsLoading={accountsLoading}
+            showLoadingHint={competitorAccounts === null && accountsLoading && !accountsLoadError}
+            showNoVerifiedAccountsHint={showNoVerifiedAccountsHint}
+            onReload={() => void fetchAccounts()}
+          />
 
-          <Container header={<Header variant="h2">{t("event_create.problemset_header")}</Header>}>
-            <SpaceBetween size="m">
-              <FormField
-                label={t("event_create.use_problems_label")}
-                description={t("event_create.use_problems_description")}
-              >
-                <Multiselect
-                  selectedOptions={selectedProblems}
-                  options={problemOptions}
-                  placeholder={t("event_create.problemset_placeholder")}
-                  onChange={({ detail }) => onProblemsChange(detail.selectedOptions)}
-                />
-              </FormField>
+          <EventCreateTeamsSection
+            teamTableItems={teamTableItems}
+            teamCount={teamRows.length}
+            teamValidation={teamValidation}
+            accountOptions={accountOptions}
+            accountById={accountById}
+            noVerifiedAccounts={noVerifiedAccounts}
+            onUpdateTeamRow={updateTeamRow}
+          />
 
-              {problemRows.length > 0 && (
-                <Table
-                  variant="embedded"
-                  items={problemRows}
-                  columnDefinitions={[
-                    {
-                      id: "name",
-                      header: t("event_create.col_problem"),
-                      cell: (r) => r.problemName,
-                    },
-                    {
-                      id: "region",
-                      header: t("event_create.col_region"),
-                      cell: (r) => {
-                        const options = resolveRegionOptions(r.supportedRegions, REGION_OPTIONS);
-                        return (
-                          <Select
-                            selectedOption={
-                              options.find((o) => o.value === r.defaultRegion) ?? options[0]
-                            }
-                            options={[...options]}
-                            onChange={({ detail }) =>
-                              updateProblemRow(r.problemId, {
-                                defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
-                              })
-                            }
-                            expandToViewport
-                          />
-                        );
-                      },
-                    },
-                  ]}
-                />
-              )}
-            </SpaceBetween>
-          </Container>
+          <EventCreateProblemsetSection
+            problemOptions={problemOptions}
+            selectedProblems={selectedProblems}
+            problemRows={problemRows}
+            onProblemsChange={onProblemsChange}
+            onUpdateProblemRow={updateProblemRow}
+          />
 
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
@@ -621,37 +286,12 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
         </SpaceBetween>
       </Form>
 
-      {/* Issue #1067: Event 作成後の deploy 必要性を operator に明示する modal。
-          旧挙動 (= 即 navigate) では operator が deploy 必要に気付かず participant 側
-          で問題が見えない silent failure が頻発していた。 */}
-      <Modal
+      <EventCreateDeployPromptModal
         visible={deployPromptTarget !== null}
-        onDismiss={() => (deployStarting ? undefined : handleDeployLater())}
-        header={t("event_create.deploy_modal_header")}
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button onClick={handleDeployLater} disabled={deployStarting}>
-                {t("event_create.deploy_modal_later")}
-              </Button>
-              <Button
-                variant="primary"
-                loading={deployStarting}
-                onClick={() => void handleDeployNow()}
-                data-testid="deploy-prompt-now"
-              >
-                {t("event_create.deploy_modal_now")}
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        <SpaceBetween size="m">
-          <Alert type="info" header={t("event_create.deploy_modal_alert_header")}>
-            {t("event_create.deploy_modal_alert_body")}
-          </Alert>
-        </SpaceBetween>
-      </Modal>
+        deployStarting={deployStarting}
+        onDeployNow={() => void handleDeployNow()}
+        onDeployLater={handleDeployLater}
+      />
     </SpaceBetween>
   );
 }

--- a/apps/application-admin-console/src/pages/event-create/EventCreateAccountsAlerts.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateAccountsAlerts.tsx
@@ -1,0 +1,81 @@
+import Alert from "@cloudscape-design/components/alert";
+import Button from "@cloudscape-design/components/button";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useNavigate } from "react-router";
+import { useT } from "../../i18n";
+
+/**
+ * Teams section の上に並ぶ 3 種の Alert: load error / loading / 0-verified hint。
+ *
+ * - load error: red Alert + reload button
+ * - loading: info Alert
+ * - 0-verified: warning Alert + reload button + Competitor Accounts ページへの link
+ *
+ * Parent は state の派生 boolean を渡すだけで済むよう、 表示判定はこの component が握る。
+ */
+export interface EventCreateAccountsAlertsProps {
+  accountsLoadError: string | null;
+  accountsLoading: boolean;
+  showLoadingHint: boolean;
+  showNoVerifiedAccountsHint: boolean;
+  onReload: () => void;
+}
+
+export function EventCreateAccountsAlerts({
+  accountsLoadError,
+  accountsLoading,
+  showLoadingHint,
+  showNoVerifiedAccountsHint,
+  onReload,
+}: EventCreateAccountsAlertsProps) {
+  const t = useT();
+  const navigate = useNavigate();
+  return (
+    <>
+      {accountsLoadError && (
+        <Alert
+          type="error"
+          header={t("event_create.accounts_load_error_header")}
+          action={
+            <Button iconName="refresh" onClick={onReload} loading={accountsLoading}>
+              {t("event_create.accounts_reload")}
+            </Button>
+          }
+        >
+          {accountsLoadError}
+        </Alert>
+      )}
+      {showLoadingHint && (
+        <Alert type="info" header={t("event_create.accounts_loading_header")}>
+          {t("event_create.accounts_loading_body")}
+        </Alert>
+      )}
+      {showNoVerifiedAccountsHint && (
+        <Alert
+          type="warning"
+          header={t("event_create.no_verified_header")}
+          action={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button iconName="refresh" onClick={onReload} loading={accountsLoading}>
+                {t("event_create.accounts_reload")}
+              </Button>
+              <Link
+                href="/competitor-accounts"
+                external={false}
+                onFollow={(e) => {
+                  e.preventDefault();
+                  navigate("/competitor-accounts");
+                }}
+              >
+                {t("event_create.go_to_competitor_accounts")}
+              </Link>
+            </SpaceBetween>
+          }
+        >
+          {t("event_create.no_verified_body")}
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-create/EventCreateBasicInfoSection.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateBasicInfoSection.tsx
@@ -1,0 +1,75 @@
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import { useT } from "../../i18n";
+import {
+  getNameErrorText,
+  getTeamCountErrorText,
+  parseTeamCountInput,
+  TEAMS_MAX,
+  TEAMS_MIN,
+} from "./helpers";
+
+/**
+ * 「基本情報」 section: イベント名 + チーム数。
+ *
+ * チーム数は parent の teamRows 配列長を駆動する numeric input。 parse は
+ * `parseTeamCountInput` (clamp + 桁制限) を通すので、 input.value は文字列のまま渡す。
+ */
+export interface EventCreateBasicInfoSectionProps {
+  name: string;
+  onNameChange: (next: string) => void;
+  nameInvalid: boolean;
+  teamCount: number;
+  onTeamCountChange: (next: number) => void;
+  teamCountInvalid: boolean;
+}
+
+export function EventCreateBasicInfoSection({
+  name,
+  onNameChange,
+  nameInvalid,
+  teamCount,
+  onTeamCountChange,
+  teamCountInvalid,
+}: EventCreateBasicInfoSectionProps) {
+  const t = useT();
+  return (
+    <Container header={<Header variant="h2">{t("event_create.basic_info_header")}</Header>}>
+      <ColumnLayout columns={2}>
+        <FormField
+          label={t("event_create.name_label")}
+          description={t("event_create.name_placeholder_example")}
+          errorText={getNameErrorText(t, name, nameInvalid)}
+        >
+          <Input
+            value={name}
+            onChange={({ detail }) => onNameChange(detail.value)}
+            invalid={nameInvalid && name.length > 0}
+          />
+        </FormField>
+        <FormField
+          label={t("event_create.team_count_label")}
+          description={t("event_create.team_count_description", {
+            min: TEAMS_MIN,
+            max: TEAMS_MAX,
+          })}
+          errorText={getTeamCountErrorText(t, teamCountInvalid)}
+        >
+          <Input
+            type="number"
+            inputMode="numeric"
+            value={String(teamCount)}
+            onChange={({ detail }) => {
+              const next = parseTeamCountInput(detail.value);
+              if (next !== undefined) onTeamCountChange(next);
+            }}
+            invalid={teamCountInvalid}
+          />
+        </FormField>
+      </ColumnLayout>
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-create/EventCreateDeployPromptModal.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateDeployPromptModal.tsx
@@ -1,0 +1,59 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useT } from "../../i18n";
+
+/**
+ * Issue #1067: Event 作成成功後に operator へ deploy の必要性を明示する modal。
+ *
+ * 旧挙動 (= 即 EventDetail に navigate) では「Deploy が必要」 と気付かないまま
+ * participant 側で問題が見えない silent failure が頻発していた。 modal で
+ * 「いま deploy する」 / 「あとで」 の二択を明示する。
+ */
+export interface EventCreateDeployPromptModalProps {
+  visible: boolean;
+  deployStarting: boolean;
+  onDeployNow: () => void;
+  onDeployLater: () => void;
+}
+
+export function EventCreateDeployPromptModal({
+  visible,
+  deployStarting,
+  onDeployNow,
+  onDeployLater,
+}: EventCreateDeployPromptModalProps) {
+  const t = useT();
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={() => (deployStarting ? undefined : onDeployLater())}
+      header={t("event_create.deploy_modal_header")}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={onDeployLater} disabled={deployStarting}>
+              {t("event_create.deploy_modal_later")}
+            </Button>
+            <Button
+              variant="primary"
+              loading={deployStarting}
+              onClick={onDeployNow}
+              data-testid="deploy-prompt-now"
+            >
+              {t("event_create.deploy_modal_now")}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        <Alert type="info" header={t("event_create.deploy_modal_alert_header")}>
+          {t("event_create.deploy_modal_alert_body")}
+        </Alert>
+      </SpaceBetween>
+    </Modal>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-create/EventCreateProblemsetSection.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateProblemsetSection.tsx
@@ -1,0 +1,84 @@
+import Container from "@cloudscape-design/components/container";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import { useT } from "../../i18n";
+import { type ProblemRow, REGION_OPTIONS, resolveRegionOptions } from "./helpers";
+
+/**
+ * 「使う問題」 section: 問題 multiselect + 選択された問題ごとの region picker。
+ *
+ * region 選択肢は問題 metadata の `supportedRegions` 宣言を尊重 (Issue #1201 Phase 2)。
+ */
+export interface EventCreateProblemsetSectionProps {
+  problemOptions: readonly MultiselectProps.Option[];
+  selectedProblems: readonly MultiselectProps.Option[];
+  problemRows: readonly ProblemRow[];
+  onProblemsChange: (next: readonly MultiselectProps.Option[]) => void;
+  onUpdateProblemRow: (problemId: string, patch: Partial<ProblemRow>) => void;
+}
+
+export function EventCreateProblemsetSection({
+  problemOptions,
+  selectedProblems,
+  problemRows,
+  onProblemsChange,
+  onUpdateProblemRow,
+}: EventCreateProblemsetSectionProps) {
+  const t = useT();
+  return (
+    <Container header={<Header variant="h2">{t("event_create.problemset_header")}</Header>}>
+      <SpaceBetween size="m">
+        <FormField
+          label={t("event_create.use_problems_label")}
+          description={t("event_create.use_problems_description")}
+        >
+          <Multiselect
+            selectedOptions={[...selectedProblems]}
+            options={[...problemOptions]}
+            placeholder={t("event_create.problemset_placeholder")}
+            onChange={({ detail }) => onProblemsChange(detail.selectedOptions)}
+          />
+        </FormField>
+
+        {problemRows.length > 0 && (
+          <Table
+            variant="embedded"
+            items={[...problemRows]}
+            columnDefinitions={[
+              {
+                id: "name",
+                header: t("event_create.col_problem"),
+                cell: (r) => r.problemName,
+              },
+              {
+                id: "region",
+                header: t("event_create.col_region"),
+                cell: (r) => {
+                  const options = resolveRegionOptions(r.supportedRegions, REGION_OPTIONS);
+                  return (
+                    <Select
+                      selectedOption={
+                        options.find((o) => o.value === r.defaultRegion) ?? options[0]
+                      }
+                      options={[...options]}
+                      onChange={({ detail }) =>
+                        onUpdateProblemRow(r.problemId, {
+                          defaultRegion: detail.selectedOption?.value ?? r.defaultRegion,
+                        })
+                      }
+                      expandToViewport
+                    />
+                  );
+                },
+              },
+            ]}
+          />
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-create/EventCreateTeamsSection.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateTeamsSection.tsx
@@ -1,0 +1,128 @@
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import type { CompetitorAccountSummary } from "../../api/competitor-accounts-client";
+import { useT } from "../../i18n";
+import {
+  ACCOUNT_ID_RE,
+  formatVerifiedAccountSummary,
+  SLUG_RE,
+  type TeamRow,
+  type TeamTableItem,
+  type TeamValidation,
+} from "./helpers";
+
+/**
+ * Teams section: 各 team の internalSlug + AWS Account ID 入力。
+ *
+ * - account 列は verified=true な CompetitorAccount のみ選択肢に出る drop-down
+ *   (Phase 2.2 Issue #459)
+ * - 0 件のときは disabled + helper text、 重複 slug は table 下に error 表示
+ */
+export interface EventCreateTeamsSectionProps {
+  teamTableItems: readonly TeamTableItem[];
+  teamCount: number;
+  teamValidation: TeamValidation;
+  accountOptions: readonly SelectProps.Option[];
+  accountById: ReadonlyMap<string, CompetitorAccountSummary>;
+  noVerifiedAccounts: boolean;
+  onUpdateTeamRow: (idx: number, patch: Partial<TeamRow>) => void;
+}
+
+export function EventCreateTeamsSection({
+  teamTableItems,
+  teamCount,
+  teamValidation,
+  accountOptions,
+  accountById,
+  noVerifiedAccounts,
+  onUpdateTeamRow,
+}: EventCreateTeamsSectionProps) {
+  const t = useT();
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={t("event_create.teams_description")}>
+          {t("event_create.teams_header", { count: teamCount })}
+        </Header>
+      }
+    >
+      {teamCount === 0 ? (
+        <Box variant="small" color="text-status-inactive">
+          {t("event_create.teams_empty")}
+        </Box>
+      ) : (
+        <Table
+          variant="embedded"
+          items={[...teamTableItems]}
+          columnDefinitions={[
+            {
+              id: "slug",
+              header: t("event_create.col_internal_slug"),
+              cell: (tr) => (
+                <Input
+                  value={tr.internalSlug}
+                  placeholder="team-1"
+                  invalid={!SLUG_RE.test(tr.internalSlug)}
+                  onChange={({ detail }) => onUpdateTeamRow(tr.idx, { internalSlug: detail.value })}
+                />
+              ),
+            },
+            {
+              id: "account",
+              header: t("event_create.col_aws_account"),
+              cell: (tr) => {
+                const selected = accountOptions.find((o) => o.value === tr.awsAccountId) ?? null;
+                const selectedAccount = accountById.get(tr.awsAccountId);
+                return (
+                  <SpaceBetween size="xxs">
+                    <Select
+                      selectedOption={selected}
+                      options={[...accountOptions]}
+                      placeholder={
+                        noVerifiedAccounts
+                          ? t("event_create.no_verified_helper")
+                          : t("event_create.select_verified_placeholder")
+                      }
+                      disabled={accountOptions.length === 0}
+                      empty={t("event_create.select_empty_message")}
+                      onChange={({ detail }) =>
+                        onUpdateTeamRow(tr.idx, {
+                          awsAccountId: detail.selectedOption?.value ?? "",
+                        })
+                      }
+                      invalid={tr.awsAccountId.length > 0 && !ACCOUNT_ID_RE.test(tr.awsAccountId)}
+                      expandToViewport
+                      filteringType="auto"
+                    />
+                    {selectedAccount && (
+                      <Box variant="small" color="text-status-inactive">
+                        <span title={formatVerifiedAccountSummary(selectedAccount)}>
+                          {formatVerifiedAccountSummary(selectedAccount)}
+                        </span>
+                      </Box>
+                    )}
+                    {noVerifiedAccounts && (
+                      <Box variant="small" color="text-status-inactive">
+                        {t("event_create.no_verified_helper")}
+                      </Box>
+                    )}
+                  </SpaceBetween>
+                );
+              },
+            },
+          ]}
+        />
+      )}
+      {teamValidation.hasDuplicateSlug && (
+        <Box variant="small" color="text-status-error" padding={{ top: "xs" }}>
+          {t("event_create.duplicate_slug_error")}
+        </Box>
+      )}
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-create/helpers.ts
+++ b/apps/application-admin-console/src/pages/event-create/helpers.ts
@@ -1,0 +1,159 @@
+/**
+ * EventCreate wizard 用の pure helper / constants 集約。
+ *
+ * Issue #1241: EventCreate.tsx が 657 行に膨らんだので section components に分割した。
+ * このファイルは React 非依存の純粋な constants / type / 関数だけを置き、
+ * - section components (`EventCreate<X>Section.tsx`)
+ * - parent (`EventCreate.tsx`)
+ * - unit tests (`test/pages/EventCreate.team-rows.test.ts`)
+ *
+ * の 3 者から共有される。
+ */
+import type { MultiselectProps, SelectProps } from "@cloudscape-design/components";
+import type { CompetitorAccountSummary } from "../../api/competitor-accounts-client";
+import { AWS_REGIONS } from "../../data/aws-regions";
+import type { useT } from "../../i18n";
+
+export const NAME_MAX = 120;
+// MUST match infrastructure/lib/problem-deploy/handlers/event-handler/types.ts (zod schema)。
+// drift すると frontend が通した値を backend が reject する。
+export const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
+export const ACCOUNT_ID_RE = /^\d{12}$/;
+export const TEAMS_MIN = 1;
+export const TEAMS_MAX = 99;
+export const TEAM_COUNT_INPUT_MAX_LEN = 3; // TEAMS_MAX が 99 = 2 桁、+1 余裕で 3 桁まで入力受理
+export const INITIAL_TEAM_COUNT = 3;
+
+export const REGION_OPTIONS: SelectProps.Option[] = AWS_REGIONS.map((r) => ({
+  value: r.code,
+  label: r.label,
+}));
+
+/**
+ * #528: 各 team の deploy 先 AWS Account ID は **team 単位** に。region は問題テンプレが
+ * 特定 region 依存の場合があるので問題単位を維持。
+ */
+export interface TeamRow {
+  internalSlug: string;
+  awsAccountId: string;
+}
+
+export interface ProblemRow {
+  problemId: string;
+  problemName: string;
+  defaultRegion: string;
+  /** Issue #1201 Phase 2: 問題が動作確認済 region 集合。 wizard picker の選択肢を絞る。 */
+  supportedRegions?: readonly string[];
+}
+
+export interface TeamValidation {
+  readonly allSlugsValid: boolean;
+  readonly allAccountsValid: boolean;
+  readonly hasDuplicateSlug: boolean;
+}
+
+/** Team table の row 描画に使う view-model (idx を抱える)。 */
+export type TeamTableItem = TeamRow & { idx: number };
+
+/** Multiselect option (value 必須) */
+export type ProblemOption = MultiselectProps.Option & { value: string };
+
+export function buildVerifiedAccountOption(a: CompetitorAccountSummary): SelectProps.Option {
+  const descriptionParts = [a.alias, a.region, a.competitorRoleName].filter(
+    (p): p is string => typeof p === "string" && p.length > 0,
+  );
+  return {
+    value: a.awsAccountId,
+    label: a.awsAccountId,
+    labelTag: a.alias,
+    description: descriptionParts.join(" / "),
+    filteringTags: descriptionParts,
+  };
+}
+
+export function formatVerifiedAccountSummary(a: CompetitorAccountSummary): string {
+  return a.alias ? `${a.awsAccountId} (${a.alias})` : a.awsAccountId;
+}
+
+/**
+ * Issue #1201 Phase 2: region picker の選択肢を `supportedRegions` で絞る純関数。
+ *
+ * - `supportedRegions` が undefined / 空 → 全 region (= 後方互換)
+ * - 宣言されていれば、 集合と AWS_REGIONS の intersection で picker を構築
+ * - 未知 region code (= AWS_REGIONS に無い文字列) は無視 (= UI に壊れた option を出さない)
+ */
+export function resolveRegionOptions(
+  supportedRegions: readonly string[] | undefined,
+  baseOptions: readonly SelectProps.Option[],
+): readonly SelectProps.Option[] {
+  if (!supportedRegions || supportedRegions.length === 0) return baseOptions;
+  const allowed = new Set(supportedRegions);
+  const intersection = baseOptions.filter((o) => o.value && allowed.has(o.value));
+  // 宣言が無効 (= AWS_REGIONS と 1 件もマッチしない) のときは base に倒す。
+  // ここで空配列を返すと wizard が壊れるので fail-safe。
+  return intersection.length > 0 ? intersection : baseOptions;
+}
+
+/**
+ * Issue #1201: 問題行の初期 region を決める純関数。
+ *
+ * - 問題 metadata に `defaultRegion` が宣言されていればそれを採用
+ * - 未宣言なら `globalDefault` (= 通常 `DEFAULT_AWS_REGION.code`) にフォールバック
+ *
+ * 「全 event が ap-northeast-1 に集中して quota 上限に到達する」 問題を、 問題側
+ * (= 動作確認済 region を一番よく知っている人) の宣言で散らすための仕掛け。
+ */
+export function resolveInitialRegion(
+  metaDefaultRegion: string | undefined,
+  globalDefault: string,
+): string {
+  return metaDefaultRegion ?? globalDefault;
+}
+
+export function resizeTeamRows(prev: TeamRow[], next: number): TeamRow[] {
+  if (next === prev.length) return prev;
+  if (next < prev.length) return prev.slice(0, Math.max(next, 0));
+  const additions = Array.from({ length: next - prev.length }, (_, i) => ({
+    internalSlug: `team-${prev.length + i + 1}`,
+    awsAccountId: "",
+  }));
+  return [...prev, ...additions];
+}
+
+export function validateTeamRows(teamRows: readonly TeamRow[]): TeamValidation {
+  let allSlugsValid = true;
+  let allAccountsValid = true;
+  const slugs = new Set<string>();
+  let hasDuplicateSlug = false;
+  for (const t of teamRows) {
+    if (!SLUG_RE.test(t.internalSlug)) allSlugsValid = false;
+    if (!ACCOUNT_ID_RE.test(t.awsAccountId)) allAccountsValid = false;
+    if (slugs.has(t.internalSlug)) hasDuplicateSlug = true;
+    else slugs.add(t.internalSlug);
+  }
+  return { allSlugsValid, allAccountsValid, hasDuplicateSlug };
+}
+
+export function parseTeamCountInput(value: string): number | undefined {
+  const next = Number.parseInt(value.replace(/\D/g, "").slice(0, TEAM_COUNT_INPUT_MAX_LEN), 10);
+  return Number.isFinite(next) ? Math.max(0, Math.min(TEAMS_MAX, next)) : undefined;
+}
+
+export function getNameErrorText(
+  t: ReturnType<typeof useT>,
+  name: string,
+  nameInvalid: boolean,
+): string | undefined {
+  return nameInvalid && name.length > 0
+    ? t("event_create.name_invalid", { max: NAME_MAX })
+    : undefined;
+}
+
+export function getTeamCountErrorText(
+  t: ReturnType<typeof useT>,
+  teamCountInvalid: boolean,
+): string | undefined {
+  return teamCountInvalid
+    ? t("event_create.team_count_invalid", { min: TEAMS_MIN, max: TEAMS_MAX })
+    : undefined;
+}

--- a/apps/application-admin-console/src/pages/event-create/useCompetitorAccountsLoader.ts
+++ b/apps/application-admin-console/src/pages/event-create/useCompetitorAccountsLoader.ts
@@ -1,0 +1,65 @@
+/**
+ * Phase 2.2 (Issue #459) / #671: EventCreate ページの Competitor Accounts
+ * fetch + window focus 時の自動再取得を hook に切り出したもの。
+ *
+ * EventCreate.tsx の責務分割 (Issue #1241) の一部。 fetch logic と state を
+ * 1 か所に閉じ込めることで、 parent ページは「いつ Alert を出すか」 だけに集中できる。
+ */
+import { useCallback, useEffect, useState } from "react";
+import { type ApiClient, useApiClient } from "../../api/client";
+import {
+  type CompetitorAccountSummary,
+  listCompetitorAccounts,
+} from "../../api/competitor-accounts-client";
+import type { AppConfig } from "../../config";
+import { formatCompetitorAccountsLoadError } from "../../lib/competitor-accounts-filter";
+
+export interface CompetitorAccountsLoaderState {
+  /** 取得済 (= null → 未取得 / [] → 取得済で 0 件) */
+  competitorAccounts: readonly CompetitorAccountSummary[] | null;
+  accountsLoadError: string | null;
+  accountsLoading: boolean;
+  /** Alert の reload button から手動再取得するための bound fn。 */
+  fetchAccounts: () => Promise<void>;
+}
+
+export function useCompetitorAccountsLoader(config: AppConfig): CompetitorAccountsLoaderState {
+  const apiClient = useApiClient(config);
+  const [competitorAccounts, setCompetitorAccounts] = useState<
+    readonly CompetitorAccountSummary[] | null
+  >(null);
+  const [accountsLoadError, setAccountsLoadError] = useState<string | null>(null);
+  const [accountsLoading, setAccountsLoading] = useState(false);
+
+  const fetchAccounts = useCallback(async () => {
+    if (!apiClient) return;
+    setAccountsLoading(true);
+    setAccountsLoadError(null);
+    try {
+      const res = await listCompetitorAccounts(apiClient as ApiClient);
+      setCompetitorAccounts(res.items);
+    } catch (err) {
+      // Issue #815: 401 は friendly な「再ログインしてください」 に flip。 silent 空配列で
+      // operator が次の一手を見失う UX を防ぐ (= 旧 unknown-tenant fallback の置き換え)。
+      setAccountsLoadError(formatCompetitorAccountsLoadError(err));
+    } finally {
+      setAccountsLoading(false);
+    }
+  }, [apiClient]);
+
+  useEffect(() => {
+    void fetchAccounts();
+  }, [fetchAccounts]);
+
+  // #671: window focus 時に再取得する。 別タブで Verify した直後に戻ったとき、
+  // dropdown が古い空配列のまま動かない問題への対処。
+  useEffect(() => {
+    const onFocus = () => {
+      void fetchAccounts();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [fetchAccounts]);
+
+  return { competitorAccounts, accountsLoadError, accountsLoading, fetchAccounts };
+}


### PR DESCRIPTION
## Summary

Issue #1241: `apps/application-admin-console/src/pages/EventCreate.tsx` had grown to 657 lines (tripping the `ge-500-lines` baseline). Decomposed the page into focused section components under a new `pages/event-create/` directory so the parent reads as a thin orchestrator.

New files:

- `event-create/helpers.ts` (159 LOC) - constants, types, pure validators. Re-exported from `EventCreate.tsx` for back-compat with existing unit tests.
- `event-create/useCompetitorAccountsLoader.ts` (65 LOC) - verified-only account fetch + window-focus refresh hook (Issue #459 / #671).
- `event-create/EventCreateBasicInfoSection.tsx` (75 LOC) - name + team count inputs.
- `event-create/EventCreateAccountsAlerts.tsx` (81 LOC) - load-error / loading / 0-verified hints.
- `event-create/EventCreateTeamsSection.tsx` (128 LOC) - per-team slug + verified-account picker table.
- `event-create/EventCreateProblemsetSection.tsx` (84 LOC) - problem multiselect + per-problem region picker.
- `event-create/EventCreateDeployPromptModal.tsx` (59 LOC) - Issue #1067 deploy-now / deploy-later modal.

`EventCreate.tsx` now: **297 lines** (was 657), kept the same `EventCreatePage` props + every previously-exported pure helper (`buildVerifiedAccountOption`, `formatVerifiedAccountSummary`, `parseTeamCountInput`, `resizeTeamRows`, `resolveInitialRegion`, `resolveRegionOptions`, `validateTeamRows`) is re-exported, so the 3 existing test files import-paths and assertions continue to work unmodified.

Baseline entry for `EventCreate.tsx` removed from `.claude/harness/baselines/file-too-large.json`.

## Test plan

- [x] `bun run --filter @TenkaCloud/application-admin-console test -- --run` -> **262 / 262 passing** (33 files), including all 3 existing `EventCreate.*.test.{ts,tsx}` suites.
- [x] `bun run --filter @TenkaCloud/application-admin-console typecheck` -> clean.
- [x] `bunx --bun biome check apps/application-admin-console` -> clean (auto-formatted on first run).
- [x] `make harness` -> `harness: no findings.`
- [x] `make lint` -> clean (biome + markdownlint + textlint).
- [ ] `make before-commit` blocked: the `infrastructure` test suite + `make validate-problems` both fail in this worktree with ENOENT on `problems/<...>/template.yaml` because the `problems` submodule did not mount (`git submodule update --init` aborts with "destination path already exists"). Verified the identical infra test fails on `origin/main` code in this worktree, so the failure pre-exists this refactor and is purely environmental. CI will pick up the submodule cleanly.

## Regression analysis

Behavior-preserving extraction. The pieces that could regress:

- **Route binding**: `App.tsx` still imports `EventCreatePage` from `./pages/EventCreate`; same name, same single-prop signature (`{ config: AppConfig }`).
- **Existing unit tests** (`test/pages/EventCreate.team-rows.test.ts`, `EventCreate.verified-only.test.tsx`, `EventCreate.no-verified-hint.test.tsx`) keep importing the same names from `./EventCreate` thanks to the re-export block. All 7 pure helpers + `EventCreatePage` are re-exported byte-identically.
- **Cloudscape Table `items` typing**: helpers now expose `readonly`-typed arrays where the parent previously held mutable arrays. Inner components spread (`[...items]`) when handing them to Cloudscape, which only accepts mutable arrays, so Table identity-based render skipping is preserved (memoized at the parent).
- **Modal dismiss path**: `onDismiss={() => (deployStarting ? undefined : onDeployLater())}` is preserved verbatim - dismiss is still disabled while deploy is in flight.
- **Window-focus refresh** (#671) and **load-error friendly text** (#815) both moved into the `useCompetitorAccountsLoader` hook with identical semantics.
- **No new dependencies, no API contract changes, no state-machine changes.**

## Physical impact

- **CFn / IaC**: NO-OP. No infrastructure files changed.
- **SPA bundle (`apps/application-admin-console`)**: UPDATE - source split across 7 new modules + 1 thinned-down parent. ESM modules increase by 7, but each is tiny and gets fully tree-shaken / inlined by Vite + esbuild in production builds (same imports, same JSX shape). Minified gzipped bytes expected within +/- a few hundred bytes (no new runtime code, only file reorganization). Source map readability improves materially.
- **Harness baseline**: DELETE 1 entry from `.claude/harness/baselines/file-too-large.json` (the EventCreate.tsx `ge-500-lines` row).
- **Tests**: NO-OP for test code itself - all 262 application-admin-console tests pass unmodified.

Closes #1241

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>