### PR TITLE
fix(handlers): require ExternalId on every AssumeRole + surface portal plugin load failures

### DIFF
--- a/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
@@ -61,16 +61,16 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
     await waitFor(() => expect(screen.getByTestId("fake-status")).toBeInTheDocument());
   });
 
-  it("should let ErrorBoundary fall back to an Alert when a plugin throws (= the whole portal does not crash)", async () => {
+  it("should let ErrorBoundary fall back to an Alert when a plugin throws (= the whole portal does not crash) and elevate the log to console.error (Issue #1251)", async () => {
     function CrashyPanel(): never {
       throw new Error("plugin runtime crash");
     }
     mockLoadPluginSlot.mockImplementation((_problemId, slotName) =>
       slotName === "StatusPanel" ? CrashyPanel : undefined,
     );
-    // ErrorBoundary class が componentDidCatch で warn log → suppress
+    // warn は出てはいけない (= 旧 band-aid の silent warn を撤去済)
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    // React は ErrorBoundary に到達するまで error を console.error する。 test noise を抑止。
+    // React 自体の "Error in component" + ErrorBoundary の componentDidCatch が両方 console.error する。
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       render(<PortalPluginSlots {...baseProps} />);
@@ -78,10 +78,15 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
         // Alert header text (Cloudscape Alert は header を visible に出す)
         expect(screen.getByText(/Plugin "StatusPanel" failed to render/)).toBeInTheDocument();
       });
-      // ErrorBoundary の componentDidCatch で warn を発火することを確認
-      expect(warnSpy).toHaveBeenCalledWith(
+      // ErrorBoundary の componentDidCatch は console.error で発火する (= operator が見える)
+      expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("[portal-plugin] slot=StatusPanel crashed"),
         expect.anything(),
+      );
+      // 旧 silent fallback (= console.warn) は撤去済 (= warn では出ない)
+      const warnCalls = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnCalls.some((c) => c.includes("[portal-plugin] slot=StatusPanel crashed"))).toBe(
+        false,
       );
     } finally {
       warnSpy.mockRestore();

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
@@ -123,7 +123,11 @@ class PluginErrorBoundary extends Component<
   }
 
   componentDidCatch(err: Error, info: ErrorInfo): void {
-    console.warn(`[portal-plugin] slot=${this.props.slotName} crashed`, {
+    // Issue #1251: 旧 implementation は console.warn で silent に流していたため、 production で
+    // operator が plugin crash を発見できなかった。 user-visible Alert は ErrorBoundary の
+    // render path で出すので「画面が真っ白」にはならない (= decorative ではなく degraded UX) が、
+    // backend 観測のため console.error に昇格させ、 RUM / Sentry error pipeline で pick up する。
+    console.error(`[portal-plugin] slot=${this.props.slotName} crashed`, {
       message: err.message,
       stack: info.componentStack,
     });

--- a/apps/participant-portal/src/plugins/loader.test.ts
+++ b/apps/participant-portal/src/plugins/loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { _clearSlotComponentCache, _listDiscoveredPluginKeys, loadPluginSlot } from "./loader";
 
 afterEach(() => {
@@ -54,5 +54,64 @@ describe("plugin loader (ADR-012 Phase 5)", () => {
     expect(b).toBeDefined();
     // memoize されていなければ React.lazy(loader) で別 instance になる (= Suspense identity 不安定)
     expect(a).toBe(b);
+  });
+});
+
+/**
+ * Issue #1251: metadata で slot が宣言されているのに glob で対応 file が見つからない場合は
+ * silent fallback (= console.warn) を撤去し、 console.error で operator に降ろした上で
+ * Lazy の Promise を reject する。 erroring lazy が ErrorBoundary に catch されることで
+ * UI 側でも user-visible Alert が出る (= fail loudly contract)。
+ */
+describe("plugin loader unresolved-slot reporting (Issue #1251)", () => {
+  it("should call console.error (not warn) and reject the lazy loader when metadata declares a slot but the glob has no matching file", async () => {
+    // 専用に mock し、 metadata は declare しているが glob 上に存在しない file path を返させる
+    vi.resetModules();
+    vi.doMock("../data/problems", () => ({
+      findProblemMetadata: () => ({
+        id: "fixture-missing",
+        dashboardSlots: { StatusPanel: "portal/DoesNotExist.tsx" },
+      }),
+    }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const { loadPluginSlot: load } = await import("./loader");
+      const Comp = load("fixture-missing", "StatusPanel");
+      // metadata 宣言があるので erroring lazy が返ること (undefined では絶対にない)
+      expect(Comp).toBeDefined();
+      // React.lazy は内部 ctor を呼ぶことで lazy の loader を発火させる。 React 18+ の
+      // LazyExoticComponent 構造に直接依存せず、 ctor を 1 回呼んで loader を起動する。
+      const lazyRecord = Comp as unknown as {
+        _init?: (payload: unknown) => unknown;
+        _payload?: unknown;
+      };
+      if (typeof lazyRecord._init === "function" && lazyRecord._payload !== undefined) {
+        try {
+          lazyRecord._init(lazyRecord._payload);
+        } catch {
+          // 初回 call は Promise を throw する (= Suspense 用 thenable)。 catch して握り潰す。
+        }
+      }
+      // microtask queue を drain して lazy 内部 Promise の reject handler を流す
+      await Promise.resolve();
+      await Promise.resolve();
+      const errCalls = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(
+        errCalls.some(
+          (c) =>
+            c.includes("[portal-plugin] unresolved slot") &&
+            c.includes("problemId=fixture-missing"),
+        ),
+      ).toBe(true);
+      // 旧 silent warn は撤去済 (= unresolved slot path で warn は鳴らない)
+      const warnCalls = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnCalls.some((c) => c.includes("[portal-plugin] unresolved slot"))).toBe(false);
+    } finally {
+      errSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.doUnmock("../data/problems");
+      vi.resetModules();
+    }
   });
 });

--- a/apps/participant-portal/src/plugins/loader.ts
+++ b/apps/participant-portal/src/plugins/loader.ts
@@ -103,8 +103,10 @@ export function loadPluginSlot(
         // metadata では宣言されているのに glob で見つからない (= portal/<file>.tsx の typo /
         // deploy 漏れ / file 名 mismatch)。 silent skip だと config bug が誰にも気付かれない
         // ので、 erroring lazy を返して ErrorBoundary 経由で UI に降ろす。
+        // Issue #1251: warn ではなく error level で emit (= backend log ingestion / Sentry / RUM の
+        // error pipeline で pick up される)。 throw も合わせて行うことで「silent fallback」を廃止。
         const msg = `[portal-plugin] unresolved slot: problemId=${problemId}, slot=${slotName}, path=${slotPath}`;
-        console.warn(msg);
+        console.error(msg);
         return Promise.reject(new Error(msg));
       });
   slotComponentCache.set(cacheKey, lazyComp);

--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -2,7 +2,7 @@ import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-clo
 import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import type { Credentials } from "@aws-sdk/client-sts";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
-import { errorDeployTrace, logDeployTrace, warnDeployTrace } from "../shared/trace-log.js";
+import { errorDeployTrace, logDeployTrace } from "../shared/trace-log.js";
 
 export interface DescribeStackStateMachineInput {
   readonly detail?: {
@@ -39,6 +39,24 @@ function assertCompleteCredentials(credentials: Credentials | undefined): Creden
   return credentials;
 }
 
+/**
+ * Issue #1245 + #856: rotation race の AssumeRole 失敗のうち、 ExternalId mismatch に起因する
+ * 4xx だけを 1 generation 前で retry する。 Network / Throttling / 5xx 系は retry せず即 fail。
+ *
+ * `verify.ts` 側の `shouldRetryWithPreviousVersion` と同じ error name 集合を共有し、
+ * blanket-catch (= 全 error で previous version を試す) のような band-aid を避ける。
+ */
+const ASSUME_ROLE_FALLBACK_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "AccessDenied",
+  "AccessDeniedException",
+  "Forbidden",
+]);
+
+function shouldRetryWithPreviousVersion(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : "";
+  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(name);
+}
+
 async function assumeCompetitorRole(
   deps: DescribeStackDeps,
   params: {
@@ -56,49 +74,86 @@ async function assumeCompetitorRole(
   if (!hasRole || !hasExternalId) {
     throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
   }
+  // 上の 2 guard で competitorRoleArn / externalIdParameterName が string であることは確定。
+  const competitorRoleArn = params.competitorRoleArn as string;
+  const externalIdParameterName = params.externalIdParameterName as string;
 
   const externalIdOut = await deps.ssm.send(
     new GetParameterCommand({
-      Name: params.externalIdParameterName,
+      Name: externalIdParameterName,
       WithDecryption: true,
     }),
   );
   const externalId = externalIdOut.Parameter?.Value;
   if (!externalId) {
-    throw new Error(`ExternalId not found in SSM SecureString: ${params.externalIdParameterName}`);
+    throw new Error(`ExternalId not found in SSM SecureString: ${externalIdParameterName}`);
   }
 
   try {
-    return await assumeRoleWithExternalId(deps, params.competitorRoleArn, params.jobId, externalId);
+    return await assumeRoleWithExternalId(deps, competitorRoleArn, params.jobId, externalId);
   } catch (currentErr) {
-    const previousVersion = Number(externalIdOut.Parameter?.Version ?? 0) - 1;
-    if (previousVersion <= 0) throw currentErr;
-    const previousExternalIdOut = await deps.ssm.send(
-      new GetParameterCommand({
-        Name: `${params.externalIdParameterName}:${previousVersion}`,
-        WithDecryption: true,
-      }),
-    );
-    const previousExternalId = previousExternalIdOut.Parameter?.Value;
-    if (!previousExternalId) throw currentErr;
-    const credentials = await assumeRoleWithExternalId(
-      deps,
-      params.competitorRoleArn,
-      params.jobId,
-      previousExternalId,
-    );
-    console.warn("[describe-stack] grace_fallback_used", {
-      jobId: params.jobId,
-      externalIdVersion: previousVersion,
-    });
-    warnDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
-      jobId: params.jobId,
-      correlationId: params.jobId,
+    return await retryWithPreviousExternalId(deps, {
       region: params.region,
-      externalIdVersion: previousVersion,
+      jobId: params.jobId,
+      competitorRoleArn,
+      externalIdParameterName,
+      currentVersion: Number(externalIdOut.Parameter?.Version ?? 0),
+      currentErr,
     });
-    return credentials;
   }
+}
+
+/**
+ * Issue #1245: rotation race の retry path を 1 関数に切り出す。
+ *
+ * 旧 implementation の問題点:
+ *   - 全 error class で blanket fallback (= Throttling / Network 系も前 version で retry していた)
+ *   - 成功時の log が `console.warn` の自由 string であり、 metrics filter が当てづらく silent
+ *
+ * 修正後:
+ *   - `shouldRetryWithPreviousVersion` で AccessDenied 系 (= ExternalId mismatch) に絞る
+ *   - 1 generation 前 SSM version が無ければ original error を rethrow (= silent skip しない)
+ *   - 成功時は `errorDeployTrace` で `deploy.describe-stack.assume-role.grace-fallback` を発火し、
+ *     operator alarm に pick up させる (= grace 多発 = rotation pipeline のバグ可視化)
+ *   - retry でも ExternalId は必ず渡される (= 「ExternalId 無し AssumeRole」は禁止)
+ */
+async function retryWithPreviousExternalId(
+  deps: DescribeStackDeps,
+  args: {
+    readonly region: string;
+    readonly jobId: string;
+    readonly competitorRoleArn: string;
+    readonly externalIdParameterName: string;
+    readonly currentVersion: number;
+    readonly currentErr: unknown;
+  },
+): Promise<Credentials> {
+  const { currentErr } = args;
+  if (!shouldRetryWithPreviousVersion(currentErr)) throw currentErr;
+  const previousVersion = args.currentVersion - 1;
+  if (previousVersion <= 0) throw currentErr;
+  const previousExternalIdOut = await deps.ssm.send(
+    new GetParameterCommand({
+      Name: `${args.externalIdParameterName}:${previousVersion}`,
+      WithDecryption: true,
+    }),
+  );
+  const previousExternalId = previousExternalIdOut.Parameter?.Value;
+  if (!previousExternalId) throw currentErr;
+  const credentials = await assumeRoleWithExternalId(
+    deps,
+    args.competitorRoleArn,
+    args.jobId,
+    previousExternalId,
+  );
+  errorDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
+    jobId: args.jobId,
+    correlationId: args.jobId,
+    region: args.region,
+    externalIdVersion: previousVersion,
+    reason: currentErr instanceof Error ? currentErr.name : "Unknown",
+  });
+  return credentials;
 }
 
 async function assumeRoleWithExternalId(

--- a/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
+++ b/infrastructure/test/problem-deploy/describe-stack-handler.test.ts
@@ -166,12 +166,13 @@ describe("describeStackForDeployment", () => {
     ).rejects.toThrow("competitorRoleArn and externalIdParameterName must be provided together");
   });
 
-  it("should retry with the previous generation when AssumeRole fails on the current ExternalId", async () => {
+  it("should retry with the previous generation when AssumeRole fails with AccessDenied (rotation race window)", async () => {
     const { deps: d, ssmSend, stsSend } = deps();
     ssmSend
       .mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } })
       .mockResolvedValueOnce({ Parameter: { Value: "previous", Version: 2 } });
-    stsSend.mockRejectedValueOnce(new Error("AccessDenied")).mockResolvedValueOnce({
+    const accessDenied = Object.assign(new Error("not authorized"), { name: "AccessDenied" });
+    stsSend.mockRejectedValueOnce(accessDenied).mockResolvedValueOnce({
       Credentials: {
         AccessKeyId: "AKIA2",
         SecretAccessKey: "secret2",
@@ -195,5 +196,75 @@ describe("describeStackForDeployment", () => {
     expect(previousGet.input.Name).toBe("/development/tenants/tenant-acme/external-id:2");
     const retryAssume = stsSend.mock.calls[1]?.[0] as AssumeRoleCommand;
     expect(retryAssume.input.ExternalId).toBe("previous");
+    // ExternalId は常に retry でも渡されること (= 「ExternalId 無し AssumeRole」は禁止)
+    expect(retryAssume.input.ExternalId).toBeDefined();
+  });
+
+  it("should NOT retry with the previous generation when AssumeRole fails with a non-AccessDenied error (= no blanket band-aid)", async () => {
+    const { deps: d, ssmSend, stsSend } = deps();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } });
+    const throttling = Object.assign(new Error("rate exceeded"), { name: "ThrottlingException" });
+    stsSend.mockRejectedValueOnce(throttling);
+
+    await expect(
+      describeStackForDeployment(
+        {
+          detail: {
+            ...input.detail,
+            competitorRoleArn: "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+            externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+          },
+        },
+        d,
+      ),
+    ).rejects.toThrow("rate exceeded");
+    // SSM は current version 1 回しか引かれない (= previous version の SSM lookup 自体起きない)
+    expect(ssmSend).toHaveBeenCalledTimes(1);
+    // STS も 1 回しか発火しない (= retry なし)
+    expect(stsSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("should emit deploy.describe-stack.assume-role.grace-fallback at error level so operators can alarm on rotation-race retries", async () => {
+    const { deps: d, ssmSend, stsSend } = deps();
+    ssmSend
+      .mockResolvedValueOnce({ Parameter: { Value: "current", Version: 5 } })
+      .mockResolvedValueOnce({ Parameter: { Value: "previous", Version: 4 } });
+    const accessDenied = Object.assign(new Error("denied"), { name: "AccessDeniedException" });
+    stsSend.mockRejectedValueOnce(accessDenied).mockResolvedValueOnce({
+      Credentials: {
+        AccessKeyId: "AKIA2",
+        SecretAccessKey: "secret2",
+        SessionToken: "token2",
+      },
+    });
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await describeStackForDeployment(
+        {
+          detail: {
+            ...input.detail,
+            competitorRoleArn: "arn:aws:iam::449699636068:role/TenkaCloud-CompetitorDeploy-Role",
+            externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+          },
+        },
+        d,
+      );
+      const errCalls = errSpy.mock.calls.map((c) => String(c[0]));
+      const graceErr = errCalls.find((c) =>
+        c.includes("deploy.describe-stack.assume-role.grace-fallback"),
+      );
+      expect(graceErr).toBeDefined();
+      expect(graceErr).toContain('"level":"error"');
+      expect(graceErr).toContain('"externalIdVersion":4');
+      expect(graceErr).toContain('"reason":"AccessDeniedException"');
+      // band-aid だった silent console.warn は撤去済 (warn では出ない)
+      const warnCalls = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnCalls.some((c) => c.includes("grace_fallback_used"))).toBe(false);
+    } finally {
+      errSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/infrastructure/test/problem-deploy/trace-log.test.ts
+++ b/infrastructure/test/problem-deploy/trace-log.test.ts
@@ -34,15 +34,15 @@ describe("trace-log helpers", () => {
     expect(payload.correlationId).toBe("01ABC");
   });
 
-  it("warnDeployTrace should emit at level=warn (for grace-fallback notifications etc.)", () => {
-    warnDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
+  it("warnDeployTrace should emit at level=warn (for soft-degraded notifications)", () => {
+    warnDeployTrace("deploy.create.partial-degraded", {
       jobId: "01XYZ",
-      externalIdVersion: 3,
+      reason: "ssm-delete-noop",
     });
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(warnSpy.mock.calls[0]?.[0] as string);
     expect(payload.level).toBe("warn");
-    expect(payload.externalIdVersion).toBe(3);
+    expect(payload.reason).toBe("ssm-delete-noop");
   });
 
   it("errorDeployTrace should emit at level=error", () => {


### PR DESCRIPTION
## Summary

Two small band-aid removals in handler internals.

- **describe-stack handler** (Issue #1245): the rotation-race retry was a *blanket* catch (every error class triggered a fallback to the previous SSM ExternalId version) and emitted only a silent `console.warn`. Tightened both:
  - Retry now only fires for `AccessDenied` / `AccessDeniedException` / `Forbidden` (= legitimate ExternalId-mismatch class). `ThrottlingException` / Network / 5xx now fail-fast.
  - Success log moved from `console.warn` + `warnDeployTrace` to `errorDeployTrace` so operator metric filters / CW Alarms can pick it up (= grace path going hot = rotation pipeline bug, not noise).
  - ExternalId is still *always* required on every `AssumeRole` call (including the retry path) — test pins this.
- **portal plugin** (Issue #1251): `console.warn` paths in `loader.ts` (unresolved-slot lazy) and `PortalPluginSlots.tsx` (`ErrorBoundary.componentDidCatch`) swallowed plugin load/runtime crashes. Promoted to `console.error` so backend log ingestion / RUM error pipelines see them. UX is unchanged (Cloudscape Alert still rendered for the failed slot).

## Issue text vs reality

#1245 framed it as "ExternalId bypass band-aid", but the actual code already always supplies ExternalId on every `AssumeRole`. The real band-aid was (a) the blanket catch and (b) the silent-warn log. Fix narrows the retry surface and elevates log severity.

## Regression analysis

- `describe-stack`: behavior change for non-AccessDenied STS failures — Throttling / Network errors now fail loudly instead of attempting a previous-version retry (which never could have helped them, and was masking the real underlying issue). Tests pin both the AccessDenied-retries-with-ExternalId path and the new ThrottlingException-fails-fast path.
- portal plugin: same crash surface, but logs land at `error` level instead of `warn`. Sentry / RUM error budgets that previously ignored `warn` will now light up — that's the intended outcome (issue summary called this out as "operator が気付きにくい").
- The grace-fallback success now emits via `errorDeployTrace`, which means existing CW Logs metric filters keyed off the old `console.warn "[describe-stack] grace_fallback_used"` line will stop matching. Replace any such filter with `event = "deploy.describe-stack.assume-role.grace-fallback"` (structured JSON; filterable on `level=error`).

## Physical impact

- CFn: **NO-OP** (handler internals only; no Lambda env / IAM / table / event-bus diff).
- Lambda bundle: byte-equivalent in spirit (no new deps; one removed `warnDeployTrace` import in describe-stack, one added retry-helper function).
- Frontend: bundle size unchanged (only string literals + `console.warn` → `console.error` swap).
- `runtime-config.json`: unchanged.

## Test plan

- [x] `make harness` — no findings
- [x] `make before-commit` — full pass (lint:md / lint:text / biome / typecheck / 1358 + 196 vitest / validate-problems / build / cdk synth / audit-deps)
- [x] New tests:
  - `describe-stack-handler.test.ts`: AccessDenied retry path asserts ExternalId is supplied + version `-1` is queried; ThrottlingException path asserts no retry; grace-fallback log is `level=error` JSON line with `reason`
  - `PortalPluginSlots.test.tsx`: ErrorBoundary path asserts `console.error` (not `warn`) is called
  - `loader.test.ts`: unresolved-slot path asserts `console.error` is called and `warn` is not

Closes #1245
Closes #1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)