### PR TITLE
feat(tech-debt): implement real analyzer (assertion-roulette + coupling + magic-number)

### DIFF
--- a/.claude/harness/baselines/tech-debt-assertion-roulette.json
+++ b/.claude/harness/baselines/tech-debt-assertion-roulette.json
@@ -1,0 +1,568 @@
+{
+  "entries": [
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/admin-console/src/auth/cognito.test.ts",
+      "line": 58,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/admin-console/src/auth/cognito.test.ts",
+      "line": 82,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/application-admin-console/src/auth/cognito.test.ts",
+      "line": 53,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/application-admin-console/test/lib/event-wizard.test.ts",
+      "line": 16,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/application-admin-console/test/pages/DeploymentDetail.test.tsx",
+      "line": 93,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx",
+      "line": 105,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/participant-portal/src/data/problems.test.ts",
+      "line": 25,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "apps/participant-portal/test/auth/AuthProvider.test.tsx",
+      "line": 81,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/admin-insight/audit-routes.test.ts",
+      "line": 26,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/admin-insight/pipeline-executions.test.ts",
+      "line": 34,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/application-admin-console-hosting.test.ts",
+      "line": 170,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/identity-provider.test.ts",
+      "line": 174,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/install-script.test.ts",
+      "line": 32,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 174,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 192,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 207,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 224,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 241,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy-backend-stack.test.ts",
+      "line": 298,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/audit-log.test.ts",
+      "line": 48,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/competitor-accounts-store.test.ts",
+      "line": 50,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/competitor-accounts-store.test.ts",
+      "line": 143,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/competitor-accounts-store.test.ts",
+      "line": 197,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/competitor-accounts-store.test.ts",
+      "line": 296,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/competitor-accounts-verify.test.ts",
+      "line": 36,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-delete.test.ts",
+      "line": 70,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-delete.test.ts",
+      "line": 196,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-handler.test.ts",
+      "line": 87,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-handler.test.ts",
+      "line": 116,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-handler.test.ts",
+      "line": 157,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-list.test.ts",
+      "line": 68,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/deploy-retry.test.ts",
+      "line": 98,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/describe-stack-handler.test.ts",
+      "line": 52,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/describe-stack-handler.test.ts",
+      "line": 106,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-archive.test.ts",
+      "line": 35,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-delete.test.ts",
+      "line": 55,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 125,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 450,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 513,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 576,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 692,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 725,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-bulk-deploy.test.ts",
+      "line": 769,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-create-notification.test.ts",
+      "line": 66,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-create.test.ts",
+      "line": 46,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-end.test.ts",
+      "line": 35,
+      "match": "ge-21-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-list.test.ts",
+      "line": 26,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-list.test.ts",
+      "line": 77,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-list.test.ts",
+      "line": 209,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-lock-scoring.test.ts",
+      "line": 32,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-schedule.test.ts",
+      "line": 39,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/event-schedule.test.ts",
+      "line": 168,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/external-id-audit-handler.test.ts",
+      "line": 161,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts",
+      "line": 120,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts",
+      "line": 299,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/generic-scoring-reconciler.test.ts",
+      "line": 361,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/leaderboard-score-events.test.ts",
+      "line": 64,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/leaderboard-score-events.test.ts",
+      "line": 233,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-battle-attacks.test.ts",
+      "line": 83,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-battle-attacks.test.ts",
+      "line": 138,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-cast-event.test.ts",
+      "line": 188,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-cast-event.test.ts",
+      "line": 258,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-deploy-logs.test.ts",
+      "line": 38,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-leaderboard.test.ts",
+      "line": 136,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-lookup.test.ts",
+      "line": 59,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-notifications.test.ts",
+      "line": 64,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-score-events.test.ts",
+      "line": 45,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-sso.test.ts",
+      "line": 155,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-sso.test.ts",
+      "line": 379,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/participant-update.test.ts",
+      "line": 76,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts",
+      "line": 86,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/rate-limiter.test.ts",
+      "line": 37,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/reveal-hint.test.ts",
+      "line": 108,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/stack-progress.test.ts",
+      "line": 141,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/stack-progress.test.ts",
+      "line": 194,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/submit-flag.test.ts",
+      "line": 170,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/system-audit-writer.test.ts",
+      "line": 33,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/system-audit-writer.test.ts",
+      "line": 112,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/trace-log.test.ts",
+      "line": 25,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/problem-deploy/trust-bridge-shadow.test.ts",
+      "line": 56,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/inspect-problem.test.ts",
+      "line": 10,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
+      "line": 85,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
+      "line": 108,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
+      "line": 189,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
+      "line": 293,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-ops.test.ts",
+      "line": 153,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/scripts/tenkacloud-problem-interactive.test.ts",
+      "line": 58,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/security/cloudfront-headers.test.ts",
+      "line": 15,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "infrastructure/test/security/cloudfront-headers.test.ts",
+      "line": 83,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "packages/trust-bridge/test/aws-assume-role.test.ts",
+      "line": 128,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "packages/trust-bridge/test/azure-federated-credential.test.ts",
+      "line": 101,
+      "match": "ge-6-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "packages/trust-bridge/test/gcp-workload-identity.test.ts",
+      "line": 101,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "packages/trust-bridge/test/localstack-cloud-adapter.test.ts",
+      "line": 41,
+      "match": "ge-11-expects"
+    },
+    {
+      "ruleId": "assertion-roulette",
+      "filePath": "packages/trust-bridge/test/mock-cloud-adapter.test.ts",
+      "line": 41,
+      "match": "ge-11-expects"
+    }
+  ]
+}

--- a/.claude/harness/baselines/tech-debt-high-coupling.json
+++ b/.claude/harness/baselines/tech-debt-high-coupling.json
@@ -1,0 +1,94 @@
+{
+  "entries": [
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/admin-console/src/pages/TenantDetail.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/admin-console/src/pages/TenantList.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/App.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/CompetitorAccounts.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/DeploymentDetail.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/EventCreate.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/EventDetail.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/EventList.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/application-admin-console/src/pages/ProblemDetail.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/participant-portal/src/pages/ProblemDetail.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "apps/participant-portal/src/pages/Quests.tsx",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "infrastructure/lib/app-wiring/wire.ts",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/event-handler/index.ts",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts",
+      "line": 1,
+      "match": "ge-16-imports"
+    },
+    {
+      "ruleId": "high-coupling",
+      "filePath": "infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts",
+      "line": 1,
+      "match": "ge-26-imports"
+    }
+  ]
+}

--- a/.claude/harness/baselines/tech-debt-magic-number.json
+++ b/.claude/harness/baselines/tech-debt-magic-number.json
@@ -1,0 +1,106 @@
+{
+  "entries": [
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/admin-console/src/pages/Jobs.tsx",
+      "line": 34,
+      "match": "timeout-ms:60000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/admin-console/src/pages/TenantDetail.tsx",
+      "line": 40,
+      "match": "timeout-ms:60000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/admin-console/src/pages/TenantList.tsx",
+      "line": 131,
+      "match": "timeout-ms:60000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/application-admin-console/src/components/CopyableField.tsx",
+      "line": 22,
+      "match": "timeout-ms:2000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/application-admin-console/src/pages/CompetitorAccounts.tsx",
+      "line": 390,
+      "match": "timeout-ms:2000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/application-admin-console/src/pages/DeploymentDetail.tsx",
+      "line": 48,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/application-admin-console/src/pages/EventList.tsx",
+      "line": 39,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/application-admin-console/src/utils/deployments.ts",
+      "line": 7,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/auth/TeamViewProvider.tsx",
+      "line": 31,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/auth/TeamViewProvider.tsx",
+      "line": 37,
+      "match": "timeout-ms:60000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/components/ProblemPanel.tsx",
+      "line": 52,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/components/ProblemPanel.tsx",
+      "line": 53,
+      "match": "timeout-ms:5000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/components/ScoreTimelineChart.tsx",
+      "line": 23,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "apps/participant-portal/src/pages/ScoreEvents.tsx",
+      "line": 23,
+      "match": "timeout-ms:30000"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts",
+      "line": 93,
+      "match": "http-status:200"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts",
+      "line": 112,
+      "match": "http-status:400"
+    },
+    {
+      "ruleId": "magic-number",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts",
+      "line": 246,
+      "match": "http-status:422"
+    }
+  ]
+}

--- a/.claude/harness/bin/tech-debt.ts
+++ b/.claude/harness/bin/tech-debt.ts
@@ -1,3 +1,35 @@
 #!/usr/bin/env bun
+import {
+  formatFindings,
+  HELP_TEXT,
+  HelpRequested,
+  parseArgs,
+  run,
+  TECH_DEBT_RULES,
+} from "../src/tech-debt/index.ts";
 
-console.log("OK  tech-debt analyzer is not configured for this repository yet");
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const result = run(options);
+  if (options.baseline) {
+    const counts = new Map<string, number>();
+    for (const rule of TECH_DEBT_RULES) counts.set(rule.id, 0);
+    for (const f of result.findings) counts.set(f.ruleId, (counts.get(f.ruleId) ?? 0) + 1);
+    const parts: string[] = [];
+    for (const [ruleId, n] of counts) parts.push(`${ruleId}=${n}`);
+    console.log(`tech-debt: baselines written (${parts.join(", ")}).`);
+    process.exit(0);
+  }
+  const output = formatFindings(result.findings);
+  if (result.exitCode === 0) console.log(output.trimEnd());
+  else console.error(output.trimEnd());
+  process.exit(result.exitCode);
+} catch (err) {
+  if (err instanceof HelpRequested) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`tech-debt analyzer failed: ${message}`);
+  process.exit(1);
+}

--- a/.claude/harness/src/cli.ts
+++ b/.claude/harness/src/cli.ts
@@ -123,6 +123,8 @@ export function loadAllBaselines(dir: string): BaselineFile {
   const entries: BaselineFile["entries"][number][] = [];
   for (const name of names) {
     if (!name.endsWith(".json")) continue;
+    // tech-debt-*.json は tech-debt analyzer 所有。 architecture harness は読まない。
+    if (name.startsWith("tech-debt-")) continue;
     const file = loadBaseline(join(dir, name));
     entries.push(...file.entries);
   }

--- a/.claude/harness/src/tech-debt/assertion-roulette.test.ts
+++ b/.claude/harness/src/tech-debt/assertion-roulette.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { assertionRoulette, countExpectCalls, extractBlocks } from "./assertion-roulette.ts";
+
+const TEST_PATH = "apps/admin-console/src/foo.test.ts";
+
+describe("assertion-roulette", () => {
+  it("should flag an it() block with 6 or more expect() calls as warning", () => {
+    const code = [
+      'import { describe, expect, it } from "vitest";',
+      "",
+      'it("should validate", () => {',
+      "  expect(a).toBe(1);",
+      "  expect(b).toBe(2);",
+      "  expect(c).toBe(3);",
+      "  expect(d).toBe(4);",
+      "  expect(e).toBe(5);",
+      "  expect(f).toBe(6);",
+      "});",
+    ].join("\n");
+    const findings = assertionRoulette.check({
+      files: [TEST_PATH],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("warning");
+    expect(findings[0]?.match).toBe("ge-6-expects");
+  });
+
+  it("should not flag an it() block with 5 expect() calls (= boundary)", () => {
+    const code = [
+      'it("should pass", () => {',
+      "  expect(a).toBe(1);",
+      "  expect(b).toBe(2);",
+      "  expect(c).toBe(3);",
+      "  expect(d).toBe(4);",
+      "  expect(e).toBe(5);",
+      "});",
+    ].join("\n");
+    const findings = assertionRoulette.check({
+      files: [TEST_PATH],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should bucket 11+ expects into ge-11-expects so 1-call drift does not lose baseline", () => {
+    const expects = new Array(12).fill("  expect(x).toBe(1);").join("\n");
+    const code = `it("big", () => {\n${expects}\n});`;
+    const findings = assertionRoulette.check({
+      files: [TEST_PATH],
+      readFile: () => code,
+    });
+    expect(findings[0]?.match).toBe("ge-11-expects");
+  });
+
+  it("should not count expect() inside string literals or comments", () => {
+    const code = [
+      'it("noise", () => {',
+      "  // expect(a).toBe(1);",
+      "  /* expect(b).toBe(2); */",
+      '  const s = "expect(c).toBe(3)";',
+      "  const t = `expect(d).toBe(4)`;",
+      "  expect(real).toBe(1);",
+      "});",
+    ].join("\n");
+    const findings = assertionRoulette.check({
+      files: [TEST_PATH],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should treat nested it() blocks (= inside describe()) independently", () => {
+    const code = [
+      'describe("outer", () => {',
+      '  it("first", () => {',
+      "    expect(a).toBe(1);",
+      "    expect(b).toBe(2);",
+      "  });",
+      '  it("second", () => {',
+      "    expect(c).toBe(1);",
+      "    expect(d).toBe(2);",
+      "    expect(e).toBe(3);",
+      "    expect(f).toBe(4);",
+      "    expect(g).toBe(5);",
+      "    expect(h).toBe(6);",
+      "    expect(i).toBe(7);",
+      "  });",
+      "});",
+    ].join("\n");
+    const findings = assertionRoulette.check({
+      files: [TEST_PATH],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("second");
+  });
+
+  it("should only inspect *.test.ts(x) files", () => {
+    const code = [
+      'it("not actually a test file", () => {',
+      ...new Array(7).fill("  expect(a).toBe(1);"),
+      "});",
+    ].join("\n");
+    const findings = assertionRoulette.check({
+      files: ["apps/admin-console/src/util.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("countExpectCalls() should count expect() outside strings only", () => {
+    expect(countExpectCalls("expect(a); expect(b);")).toBe(2);
+    expect(countExpectCalls("'expect(a)'")).toBe(0);
+    expect(countExpectCalls("`expect(a)`")).toBe(0);
+    expect(countExpectCalls("// expect(a)")).toBe(0);
+    expect(countExpectCalls("foo.expect(a)")).toBe(0); // member call != global expect
+  });
+
+  it("extractBlocks() should return the it() body without the wrapping braces", () => {
+    const src = 'it("x", () => { expect(a); });';
+    const blocks = extractBlocks(src);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.name).toBe("x");
+    expect(blocks[0]?.body.trim()).toBe("expect(a);");
+  });
+});

--- a/.claude/harness/src/tech-debt/assertion-roulette.ts
+++ b/.claude/harness/src/tech-debt/assertion-roulette.ts
@@ -1,0 +1,258 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+import { type ScannerState, step } from "./scanner.ts";
+
+/**
+ * Issue #1227: assertion-roulette detector.
+ *
+ * 1 つの test case (= `it(...)` / `test(...)`) 内で `expect(...)` を 6 個以上呼んでいるテストは
+ * 落ちたときどの assertion で死んだのかが読み取りにくい (= "assertion roulette" smell, xUnit
+ * Test Patterns)。
+ *
+ * 検出条件:
+ *   - test file (`*.test.ts` / `*.test.tsx`)
+ *   - `it(...)` または `test(...)` ブロック内の `expect(...)` を数える
+ *   - **6 個以上** で warning
+ *
+ * 改善方針:
+ *   - 1 it = 1 振る舞いの assertion に絞り、 別 case を `it("should ...")` で増やす
+ *   - 共通 setup は `beforeEach` に移す
+ *   - 複数 assertion を残すなら `expect(actual, "context message").toBe(...)` のように
+ *     第 2 引数で文脈を与える (Vitest はサポート)
+ *
+ * match は bucket (= 6-10 / 11-20 / 20+) にして 1 個増減で baseline が外れないようにする。
+ */
+
+const EXPECT_THRESHOLD = 6;
+
+const TEST_FILE_RE = /\.test\.tsx?$/;
+const EXCLUDE_PATTERNS = [/\/node_modules\//, /\/dist\//, /\/cdk\.out\//, /\/__generated__\//];
+
+const IT_BLOCK_RE = /\b(it|test)\s*\(\s*(?:"([^"]+)"|'([^']+)'|`([^`]+)`)/g;
+
+function shouldInspect(path: string): boolean {
+  if (!TEST_FILE_RE.test(path)) return false;
+  if (EXCLUDE_PATTERNS.some((re) => re.test(path))) return false;
+  return true;
+}
+
+function bucket(count: number): string {
+  if (count >= 21) return "ge-21-expects";
+  if (count >= 11) return "ge-11-expects";
+  return "ge-6-expects";
+}
+
+interface Block {
+  readonly name: string;
+  readonly startLine: number;
+  readonly body: string;
+}
+
+/**
+ * Source から `it(...)` / `test(...)` ブロックを抽出する。 brace 平衡 (= `{` / `}` の depth が
+ * 0 に戻る) を見て本体終端を見つけるシンプルなパーサ。 string literal / template literal / line
+ * comment 内の brace は無視する (scanner.ts に集約)。
+ */
+export function extractBlocks(source: string): Block[] {
+  const blocks: Block[] = [];
+  IT_BLOCK_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: stdlib regex iteration pattern
+  while ((m = IT_BLOCK_RE.exec(source)) !== null) {
+    const name = m[2] ?? m[3] ?? m[4] ?? "";
+    const matchEnd = m.index + m[0].length;
+    const openIdx = findCallbackBodyOpen(source, matchEnd);
+    if (openIdx < 0) continue;
+    const closeIdx = findMatchingBrace(source, openIdx);
+    if (closeIdx < 0) continue;
+    const body = source.slice(openIdx + 1, closeIdx);
+    const startLine = countNewlines(source, 0, m.index) + 1;
+    blocks.push({ name, startLine, body });
+    IT_BLOCK_RE.lastIndex = closeIdx;
+  }
+  return blocks;
+}
+
+interface BodyOpenState {
+  depthParen: number;
+  depthBracket: number;
+  sawFunction: boolean;
+}
+
+function findCallbackBodyOpen(source: string, from: number): number {
+  // After `it("name"`, the rest looks like: `, () => { ... })` or `, function () { ... })`.
+  // We walk forward (depthParen = 1 because we are still inside `it(`) and accept the first
+  // `{` that is preceded by `=>` (arrow body) or comes after a `function` keyword we have
+  // seen since `from` (function-expression body). Object-literal arguments are skipped over
+  // by jumping to the matching `}`.
+  const ctx: BodyOpenState = { depthParen: 1, depthBracket: 0, sawFunction: false };
+  let i = from;
+  let state: ScannerState = "code";
+  while (i < source.length) {
+    const c = source[i] ?? "";
+    const next = source[i + 1] ?? "";
+    if (state === "code") {
+      const res = inspectCodeChar(source, i, c, ctx);
+      if (res.bodyOpenAt !== undefined) return res.bodyOpenAt;
+      if (res.aborted) return -1;
+      if (res.skipTo !== undefined) {
+        i = res.skipTo;
+        continue;
+      }
+    }
+    const s = step(c, next, state);
+    state = s.state;
+    i += s.consumed;
+  }
+  return -1;
+}
+
+interface CodeCharResult {
+  bodyOpenAt?: number;
+  aborted?: boolean;
+  /** When set, caller should resume scanning at this position (= jump past skipped group). */
+  skipTo?: number;
+}
+
+function inspectCodeChar(source: string, i: number, c: string, ctx: BodyOpenState): CodeCharResult {
+  if (c === "(") {
+    ctx.depthParen += 1;
+    return {};
+  }
+  if (c === ")") {
+    ctx.depthParen -= 1;
+    if (ctx.depthParen <= 0) return { aborted: true };
+    return {};
+  }
+  if (c === "[") {
+    ctx.depthBracket += 1;
+    return {};
+  }
+  if (c === "]") {
+    ctx.depthBracket -= 1;
+    return {};
+  }
+  if (c === "{" && ctx.depthBracket === 0) {
+    const back = scanBackToken(source, i - 1);
+    if (back === "=>" || ctx.sawFunction) return { bodyOpenAt: i };
+    const close = findMatchingBrace(source, i);
+    if (close < 0) return { aborted: true };
+    return { skipTo: close + 1 };
+  }
+  if (c === "f" && isFunctionKeyword(source, i)) {
+    ctx.sawFunction = true;
+  }
+  return {};
+}
+
+function isFunctionKeyword(source: string, i: number): boolean {
+  if (source.slice(i, i + 8) !== "function") return false;
+  const prev = source[i - 1] ?? "";
+  const after = source[i + 8] ?? "";
+  return !/[A-Za-z0-9_$]/.test(prev) && !/[A-Za-z0-9_$]/.test(after);
+}
+
+/** Looks at the character at `idx` and reads backward, returning the "=>" token if present. */
+function scanBackToken(source: string, idx: number): string {
+  let i = idx;
+  while (i >= 0 && /\s/.test(source[i] ?? "")) i -= 1;
+  if (i < 1) return "";
+  if (source[i] === ">" && source[i - 1] === "=") return "=>";
+  return source[i] ?? "";
+}
+
+/** Given the position of `{`, returns the position of the matching `}`. Respects strings/comments. */
+function findMatchingBrace(source: string, openIdx: number): number {
+  let depth = 1;
+  let i = openIdx + 1;
+  let state: ScannerState = "code";
+  while (i < source.length) {
+    const c = source[i] ?? "";
+    const next = source[i + 1] ?? "";
+    if (state === "code") {
+      if (c === "{") depth += 1;
+      else if (c === "}") {
+        depth -= 1;
+        if (depth === 0) return i;
+      }
+    }
+    const s = step(c, next, state);
+    state = s.state;
+    i += s.consumed;
+  }
+  return -1;
+}
+
+function countNewlines(s: string, from: number, to: number): number {
+  let n = 0;
+  for (let i = from; i < to; i += 1) {
+    if (s[i] === "\n") n += 1;
+  }
+  return n;
+}
+
+/** Count `expect(` occurrences outside string/comment context. */
+export function countExpectCalls(body: string): number {
+  let count = 0;
+  let i = 0;
+  let state: ScannerState = "code";
+  while (i < body.length) {
+    const c = body[i] ?? "";
+    const next = body[i + 1] ?? "";
+    if (state === "code" && isExpectCallAt(body, i)) {
+      count += 1;
+      i += 7; // length of "expect("
+      continue;
+    }
+    const s = step(c, next, state);
+    state = s.state;
+    i += s.consumed;
+  }
+  return count;
+}
+
+function isExpectCallAt(body: string, i: number): boolean {
+  if (body.slice(i, i + 7) !== "expect(") return false;
+  // `.` excludes member calls (= obj.expect()), which are not the vitest global.
+  const prev = i > 0 ? (body[i - 1] ?? "") : "";
+  return !/[A-Za-z0-9_$.]/.test(prev);
+}
+
+export const assertionRoulette: Rule = {
+  id: "assertion-roulette",
+  severity: "warning",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldInspect(path)) continue;
+      let content: string;
+      try {
+        content = ctx.readFile(path);
+      } catch {
+        continue;
+      }
+      if (!/\b(it|test)\s*\(/.test(content)) continue;
+      const blocks = extractBlocks(content);
+      for (const block of blocks) {
+        const count = countExpectCalls(block.body);
+        if (count < EXPECT_THRESHOLD) continue;
+        findings.push({
+          ruleId: "assertion-roulette",
+          severity: "warning",
+          filePath: path,
+          line: block.startLine,
+          match: bucket(count),
+          message:
+            `Test case "${block.name}" は expect() を ${count} 回呼んでいる (閾値 ${EXPECT_THRESHOLD})。 ` +
+            "失敗時にどの assertion で落ちたか読み取りづらい (= assertion roulette)。",
+          recommendation:
+            '1 it = 1 振る舞いに絞り、 別 case を `it("should ...")` で増やしてください。 共通 setup は ' +
+            '`beforeEach` に集約。 複数 assertion を残す場合は `expect(actual, "context").toBe(...)` の ' +
+            "ように第 2 引数で文脈を与えて失敗 message を読みやすくする。",
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+export const __INTERNAL = { EXPECT_THRESHOLD };

--- a/.claude/harness/src/tech-debt/high-coupling.test.ts
+++ b/.claude/harness/src/tech-debt/high-coupling.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { countTopLevelImports, highCoupling } from "./high-coupling.ts";
+
+function makeImports(n: number): string {
+  return new Array(n)
+    .fill(0)
+    .map((_, i) => `import { x${i} } from "./m${i}.ts";`)
+    .join("\n");
+}
+
+describe("high-coupling", () => {
+  it("should flag a file with 16+ static imports as warning", () => {
+    const code = makeImports(16);
+    const findings = highCoupling.check({
+      files: ["infrastructure/lib/big.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("warning");
+    expect(findings[0]?.match).toBe("ge-16-imports");
+  });
+
+  it("should not flag a file with 15 imports (= boundary)", () => {
+    const code = makeImports(15);
+    const findings = highCoupling.check({
+      files: ["infrastructure/lib/ok.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should escalate to error at 41+ imports", () => {
+    const code = makeImports(41);
+    const findings = highCoupling.check({
+      files: ["apps/admin-console/src/Page.tsx"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("error");
+    expect(findings[0]?.match).toBe("ge-41-imports");
+  });
+
+  it("should bucket 26-40 imports as ge-26-imports", () => {
+    const code = makeImports(30);
+    const findings = highCoupling.check({
+      files: ["infrastructure/lib/medium.ts"],
+      readFile: () => code,
+    });
+    expect(findings[0]?.match).toBe("ge-26-imports");
+  });
+
+  it("should exclude *.test.ts files", () => {
+    const code = makeImports(50);
+    const findings = highCoupling.check({
+      files: ["infrastructure/lib/foo.test.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should only count static imports — dynamic import() is ignored", () => {
+    const code = [
+      `const m1 = await import("./m1.ts");`,
+      `const m2 = await import("./m2.ts");`,
+      `const m3 = await import("./m3.ts");`,
+    ].join("\n");
+    expect(countTopLevelImports(code)).toBe(0);
+  });
+
+  it("should include `import type` because cognitive coupling is symmetric", () => {
+    const code = new Array(16)
+      .fill(0)
+      .map((_, i) => `import type { T${i} } from "./t${i}.ts";`)
+      .join("\n");
+    const findings = highCoupling.check({
+      files: ["apps/participant-portal/src/types.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("should only inspect files under target prefixes", () => {
+    const code = makeImports(50);
+    const findings = highCoupling.check({
+      files: ["references/legacy.ts", "node_modules/lib/index.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/.claude/harness/src/tech-debt/high-coupling.ts
+++ b/.claude/harness/src/tech-debt/high-coupling.ts
@@ -1,0 +1,109 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+
+/**
+ * Issue #1227: high-coupling detector.
+ *
+ * 1 ファイルが 16 個以上の module を `import` していると 「責務を持ちすぎ」 候補。 SRP 違反
+ * の早期警告で、 file 行数の `file-too-large` と相補。
+ *
+ * 検出条件:
+ *   - file top 付近の static `import ... from "..."` 文 (= side-effect import 含む) を数える
+ *   - `import type` も coupling の cognitive load に寄与するので算入
+ *   - 動的 import (`import(...)`) は除外
+ *   - **16 個以上** で warning
+ *
+ * 対象 path: file-too-large 同様 `infrastructure/lib/`、 `apps/<spa>/src/`、 `scripts/`、
+ * `packages/<pkg>/src/`。 test ファイル (`*.test.ts(x)`) は対象外 (= テストは複数 module を
+ * 集約することが正当)。 generated / dist / cdk.out も除外。
+ *
+ * match は bucket (= 16-25 / 26-40 / 40+) にして 1 import 増減で baseline match を外さない。
+ */
+
+const WARNING_THRESHOLD = 16;
+const HIGH_THRESHOLD = 26;
+const VERY_HIGH_THRESHOLD = 41;
+
+const INCLUDE_PATH_PREFIXES = [
+  "infrastructure/lib/",
+  "infrastructure/bin/",
+  "apps/admin-console/src/",
+  "apps/application-admin-console/src/",
+  "apps/participant-portal/src/",
+  "scripts/",
+  "packages/portal-plugin-sdk/src/",
+  "packages/trust-bridge/src/",
+] as const;
+
+const EXCLUDE_PATTERNS = [
+  /\.test\.tsx?$/,
+  /\/node_modules\//,
+  /\/dist\//,
+  /\/cdk\.out\//,
+  /\/__generated__\//,
+  /\/__mocks__\//,
+];
+
+function shouldInspect(path: string): boolean {
+  if (!/\.tsx?$/.test(path)) return false;
+  if (EXCLUDE_PATTERNS.some((re) => re.test(path))) return false;
+  return INCLUDE_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+// 行頭が `import` で始まるスタティック import 文を数える。 文字列内 / コメント内の "import"
+// を誤検出しないため、 行頭 + ホワイトスペース後 + キーワード `import` のみカウントする。
+// `import(...)` (= dynamic) は除外。
+const STATIC_IMPORT_LINE_RE = /^\s*import(?:\s+type)?\s+(?:[^()]*?\bfrom\s+)?["'][^"']+["']/;
+
+export function countTopLevelImports(source: string): number {
+  // Cap to first 400 lines to avoid scanning whole long file; imports always at top.
+  const lines = source.split("\n").slice(0, 400);
+  let count = 0;
+  for (const line of lines) {
+    if (STATIC_IMPORT_LINE_RE.test(line)) count += 1;
+  }
+  return count;
+}
+
+function bucket(count: number): string {
+  if (count >= VERY_HIGH_THRESHOLD) return "ge-41-imports";
+  if (count >= HIGH_THRESHOLD) return "ge-26-imports";
+  return "ge-16-imports";
+}
+
+export const highCoupling: Rule = {
+  id: "high-coupling",
+  severity: "warning",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldInspect(path)) continue;
+      let content: string;
+      try {
+        content = ctx.readFile(path);
+      } catch {
+        continue;
+      }
+      const count = countTopLevelImports(content);
+      if (count < WARNING_THRESHOLD) continue;
+      const severity = count >= VERY_HIGH_THRESHOLD ? "error" : "warning";
+      findings.push({
+        ruleId: "high-coupling",
+        severity,
+        filePath: path,
+        line: 1,
+        match: bucket(count),
+        message:
+          `${path} は ${count} 個の module を import している (閾値 ${WARNING_THRESHOLD})。 ` +
+          "1 ファイルが多くの依存を直接抱えており、 責務超過 / 変更影響範囲が広い (= 高結合)。",
+        recommendation:
+          "関心領域ごとに sub-module を切り、 facade / index に集約する。 例: Lambda handler を " +
+          "routes / service / repository に 3 層分割し、 index は routes と DI 配線のみに絞る。 " +
+          "React page は presentational / container を分け、 各 panel を独立 component に export する。 " +
+          "数値が 26+ の場合は責務分割を優先、 41+ は error (= 必ず分割)。",
+      });
+    }
+    return findings;
+  },
+};
+
+export const __INTERNAL = { WARNING_THRESHOLD, HIGH_THRESHOLD, VERY_HIGH_THRESHOLD };

--- a/.claude/harness/src/tech-debt/index.test.ts
+++ b/.claude/harness/src/tech-debt/index.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { formatFindings, HelpRequested, loadTechDebtBaselines, parseArgs } from "./index.ts";
+
+describe("tech-debt CLI", () => {
+  describe("parseArgs", () => {
+    it("should default to fail-on=warning and staged=false", () => {
+      const opts = parseArgs([]);
+      expect(opts.failOn).toBe("warning");
+      expect(opts.staged).toBe(false);
+      expect(opts.baseline).toBe(false);
+    });
+
+    it("should accept --staged and --fail-on=error", () => {
+      const opts = parseArgs(["--staged", "--fail-on=error"]);
+      expect(opts.staged).toBe(true);
+      expect(opts.failOn).toBe("error");
+    });
+
+    it("should set baseline=true on --baseline", () => {
+      const opts = parseArgs(["--baseline"]);
+      expect(opts.baseline).toBe(true);
+    });
+
+    it("should throw HelpRequested on -h", () => {
+      expect(() => parseArgs(["-h"])).toThrow(HelpRequested);
+    });
+
+    it("should reject unknown --fail-on values", () => {
+      expect(() => parseArgs(["--fail-on=panic"])).toThrow(/--fail-on=/);
+    });
+
+    it("should reject unknown arguments", () => {
+      expect(() => parseArgs(["--lol"])).toThrow(/Unknown argument/);
+    });
+  });
+
+  describe("formatFindings", () => {
+    it("should group output by ruleId and emit a header per rule", () => {
+      const out = formatFindings([
+        {
+          ruleId: "magic-number",
+          severity: "warning",
+          filePath: "a.ts",
+          line: 1,
+          match: "http-status:500",
+          message: "msg",
+          recommendation: "rec",
+        },
+        {
+          ruleId: "assertion-roulette",
+          severity: "warning",
+          filePath: "b.test.ts",
+          line: 2,
+          match: "ge-6-expects",
+          message: "msg2",
+          recommendation: "rec2",
+        },
+      ]);
+      expect(out).toContain("tech-debt: 2 finding(s) across 2 rule(s).");
+      expect(out).toContain("## magic-number (1)");
+      expect(out).toContain("## assertion-roulette (1)");
+    });
+
+    it("should emit no-findings sentinel on empty input", () => {
+      expect(formatFindings([])).toBe("tech-debt: no findings.\n");
+    });
+  });
+
+  describe("loadTechDebtBaselines", () => {
+    it("should return empty when dir is missing (ENOENT tolerant)", () => {
+      const file = loadTechDebtBaselines("/tmp/definitely-does-not-exist-12345");
+      expect(file.entries).toEqual([]);
+    });
+  });
+});

--- a/.claude/harness/src/tech-debt/index.ts
+++ b/.claude/harness/src/tech-debt/index.ts
@@ -1,0 +1,182 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { type BaselineFile, isBaselined, loadBaseline } from "../baseline.ts";
+import type { Finding, Rule, Severity } from "../types.ts";
+import { listAllTrackedFiles, listStagedFiles } from "../utils/staged-files.ts";
+import { assertionRoulette } from "./assertion-roulette.ts";
+import { highCoupling } from "./high-coupling.ts";
+import { magicNumber } from "./magic-number.ts";
+
+export const TECH_DEBT_RULES: readonly Rule[] = [assertionRoulette, highCoupling, magicNumber];
+
+export interface RunOptions {
+  readonly cwd: string;
+  readonly staged: boolean;
+  readonly failOn: Severity;
+  /** When set, write the current findings as the per-rule baselines. */
+  readonly baseline: boolean;
+}
+
+export interface RunResult {
+  readonly findings: readonly Finding[];
+  readonly exitCode: number;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
+export class HelpRequested extends Error {}
+
+export const HELP_TEXT = `tech-debt.ts — TenkaCloud tech-debt analyzer
+
+Usage:
+  bun run .claude/harness/bin/tech-debt.ts [--staged] [--fail-on=error|warning|info] [--baseline]
+
+Options:
+  --staged             Inspect only files in 'git diff --cached' (PR / pre-commit mode).
+                       Without this, every tracked file is inspected.
+  --fail-on=<sev>      Exit non-zero when at least one finding of <sev> or higher is reported.
+                       Defaults to 'warning' (= one knob looser than the architecture harness,
+                       since tech-debt is advisory).
+  --baseline           Write the current findings into
+                       .claude/harness/baselines/tech-debt-<rule>.json and exit 0.
+                       Use this to "freeze the current debt, block new regressions".
+  -h, --help           Show this message.
+
+Rules:
+  assertion-roulette   Test files with > 5 expect() calls per it()/test() block.
+  high-coupling        Production files importing >= 16 modules at top (>= 41 -> error).
+  magic-number         Status codes / timeouts / ports as numeric literals in production code.
+
+Baselines:
+  Per-rule baseline at .claude/harness/baselines/tech-debt-<rule-id>.json.
+  Regenerate via:
+    bun run .claude/harness/bin/tech-debt.ts --baseline
+`;
+
+export function parseArgs(argv: readonly string[]): RunOptions {
+  let staged = false;
+  let failOn: Severity = "warning";
+  let baseline = false;
+  for (const arg of argv) {
+    if (arg === "--staged") staged = true;
+    else if (arg === "--baseline") baseline = true;
+    else if (arg.startsWith("--fail-on=")) {
+      const value = arg.slice("--fail-on=".length);
+      if (value !== "error" && value !== "warning" && value !== "info") {
+        throw new Error(`--fail-on= must be one of error|warning|info (got ${value})`);
+      }
+      failOn = value;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new HelpRequested();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { cwd: process.cwd(), staged, failOn, baseline };
+}
+
+export function run(opts: RunOptions): RunResult {
+  const files = opts.staged
+    ? listStagedFiles({ cwd: opts.cwd })
+    : listAllTrackedFiles({ cwd: opts.cwd });
+  const readFile = (path: string): string => readFileSync(resolve(opts.cwd, path), "utf8");
+  const ctx = { files, readFile };
+  const findings: Finding[] = [];
+  for (const rule of TECH_DEBT_RULES) {
+    findings.push(...rule.check(ctx));
+  }
+  if (opts.baseline) {
+    writeBaselines(opts.cwd, findings);
+    return { findings, exitCode: 0 };
+  }
+  const baseline = loadTechDebtBaselines(resolve(opts.cwd, ".claude/harness/baselines"));
+  const activeFindings = findings.filter((finding) => !isBaselined(finding, baseline));
+  const failThreshold = SEVERITY_RANK[opts.failOn];
+  const triggered = activeFindings.some((f) => SEVERITY_RANK[f.severity] >= failThreshold);
+  return { findings: activeFindings, exitCode: triggered ? 2 : 0 };
+}
+
+/**
+ * tech-debt baselines live alongside the architecture baselines but are prefixed
+ * `tech-debt-` so the architecture harness ignores them and the tech-debt analyzer
+ * picks only its own.
+ */
+export function loadTechDebtBaselines(dir: string): BaselineFile {
+  let names: readonly string[];
+  try {
+    names = readdirSync(dir);
+  } catch (err) {
+    const code = (err as { code?: string })?.code;
+    if (code === "ENOENT") return { entries: [] };
+    throw err;
+  }
+  const entries: BaselineFile["entries"][number][] = [];
+  for (const name of names) {
+    if (!name.startsWith("tech-debt-")) continue;
+    if (!name.endsWith(".json")) continue;
+    const file = loadBaseline(join(dir, name));
+    entries.push(...file.entries);
+  }
+  return { entries };
+}
+
+function writeBaselines(cwd: string, findings: readonly Finding[]): void {
+  const dir = resolve(cwd, ".claude/harness/baselines");
+  const byRule = new Map<string, ReturnType<typeof toBaselineEntry>[]>();
+  for (const rule of TECH_DEBT_RULES) byRule.set(rule.id, []);
+  for (const f of findings) {
+    const arr = byRule.get(f.ruleId);
+    if (!arr) continue;
+    arr.push(toBaselineEntry(f));
+  }
+  for (const [ruleId, entries] of byRule) {
+    const outPath = join(dir, `tech-debt-${ruleId}.json`);
+    writeFileSync(outPath, `${JSON.stringify({ entries }, null, 2)}\n`);
+    // intentionally no console.log here; CLI runner handles user-facing output.
+  }
+}
+
+function toBaselineEntry(f: Finding): {
+  ruleId: string;
+  filePath: string;
+  line: number;
+  match: string;
+} {
+  return {
+    ruleId: f.ruleId,
+    filePath: f.filePath,
+    line: f.line ?? 1,
+    match: f.match ?? "",
+  };
+}
+
+export function formatFindings(findings: readonly Finding[]): string {
+  if (findings.length === 0) return "tech-debt: no findings.\n";
+  const lines: string[] = [];
+  // Group by ruleId to ease scanning, matching the "list per rule" style requested in #1227.
+  const byRule = new Map<string, Finding[]>();
+  for (const f of findings) {
+    let arr = byRule.get(f.ruleId);
+    if (!arr) {
+      arr = [];
+      byRule.set(f.ruleId, arr);
+    }
+    arr.push(f);
+  }
+  lines.push(`tech-debt: ${findings.length} finding(s) across ${byRule.size} rule(s).\n`);
+  for (const [ruleId, rows] of byRule) {
+    lines.push(`## ${ruleId} (${rows.length})\n`);
+    for (const f of rows) {
+      const loc = f.line ? `${f.filePath}:${f.line}` : f.filePath;
+      lines.push(`- [${f.severity}] ${loc}`);
+      lines.push(`  ${f.message}`);
+      lines.push(`  recommendation: ${f.recommendation}`);
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+}

--- a/.claude/harness/src/tech-debt/magic-number.test.ts
+++ b/.claude/harness/src/tech-debt/magic-number.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { extractIntegersFromLine, magicNumber, scanFile } from "./magic-number.ts";
+
+const PROD_PATH = "infrastructure/lib/foo.ts";
+
+describe("magic-number", () => {
+  describe("HTTP status code detection", () => {
+    it("should flag c.json(body, 500) as magic", () => {
+      const code = ["function h(c: any) {", "  return c.json({}, 500);", "}"].join("\n");
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("http-status:500");
+    });
+
+    it("should flag res.status === 401 in production code", () => {
+      const code = ["if (res.status === 401) throw new Error('auth');"].join("\n");
+      const findings = magicNumber.check({
+        files: ["apps/admin-console/src/api.ts"],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("http-status:401");
+    });
+
+    it("should not flag numbers outside http status hint context", () => {
+      const code = "const cohortSize = 200;"; // 200 alone, no HTTP context
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  describe("timeout / ms detection", () => {
+    it("should flag setTimeout(..., 60000) as magic", () => {
+      const code = "setTimeout(() => poll(), 60000);";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("timeout-ms:60000");
+    });
+
+    it("should flag `const POLL = 300_000;` only if context word is nearby", () => {
+      // No timeout/delay/interval hint word, so we should NOT flag
+      const code = "const POLL = 300_000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should flag pollingInterval: 30000 with hint word", () => {
+      const code = "const cfg = { pollingInterval: 30000 };";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("timeout-ms:30000");
+    });
+  });
+
+  describe("port detection", () => {
+    it("should flag listen(3000) with port hint", () => {
+      const code = "const port = 3000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("port:3000");
+    });
+
+    it("should not flag 3000 in isolation without port/listen/url hint", () => {
+      const code = "const cohortSize = 3000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  describe("exclusions", () => {
+    it("should never flag 0, 1, -1, 2", () => {
+      const code = "if (x === 0) return -1; if (y === 1) return 2;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not flag numbers inside string literals", () => {
+      const code = "const url = 'https://example.com:8080/api';";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not flag numbers inside comments", () => {
+      const code = ["// status === 500 is bad", "/* port 3000 */"].join("\n");
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not scan *.test.ts files", () => {
+      const code = "if (res.status === 500) throw new Error();";
+      const findings = magicNumber.check({
+        files: ["apps/admin-console/src/foo.test.ts"],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not scan handlers/shared/http-status.ts (= legacy alias defn)", () => {
+      const code = "export const HTTP_OK = 200;";
+      const findings = magicNumber.check({
+        files: ["infrastructure/lib/problem-deploy/handlers/shared/http-status.ts"],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not scan files outside production prefixes", () => {
+      const code = "c.json({}, 500);";
+      const findings = magicNumber.check({
+        files: ["references/legacy.ts"],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should not scan import lines (= path-internal digits are not magic)", () => {
+      const code = 'import { Foo } from "./bar3000.ts";';
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  describe("dedup", () => {
+    it("should emit 1 finding per (rule, value, kind) per file even if used many times", () => {
+      const code = ["c.json({}, 500);", "c.json({}, 500);", "c.json({}, 500);"].join("\n");
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      // first occurrence's line
+      expect(findings[0]?.line).toBe(1);
+    });
+  });
+
+  describe("helpers", () => {
+    it("extractIntegersFromLine should ignore identifier-suffix digits (= foo3)", () => {
+      const r = extractIntegersFromLine("const foo3 = 42;", "code");
+      expect(r.ints.map((i) => i.value)).toEqual([42]);
+    });
+
+    it("extractIntegersFromLine should handle underscore separators", () => {
+      const r = extractIntegersFromLine("const x = 60_000;", "code");
+      expect(r.ints.map((i) => i.value)).toEqual([60000]);
+    });
+
+    it("scanFile should respect multi-line block comments", () => {
+      const src = ["/*", "  c.json({}, 500);", "*/", "const ok = true;"].join("\n");
+      expect(scanFile(src)).toHaveLength(0);
+    });
+  });
+});

--- a/.claude/harness/src/tech-debt/magic-number.ts
+++ b/.claude/harness/src/tech-debt/magic-number.ts
@@ -1,0 +1,291 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+import { type ScannerState, step } from "./scanner.ts";
+
+/**
+ * Issue #1227: magic-number detector.
+ *
+ * production code (= `infrastructure/lib/`、 `apps/<spa>/src/`、 `packages/<pkg>/src/`) で
+ * 意味の読めない数値リテラルを検出する。 grep / lint で意図 (= 200 vs 202、 60_000 ms vs
+ * 60 個 retry) を区別できなくなる antipattern。
+ *
+ * 検出対象:
+ *   - HTTP status code: 100..599 の整数。 `StatusCodes.*` (= `http-status-codes`) を使うべき
+ *   - timeout / ms: 30_000 等 「ms らしい」 値、 timeout/delay/interval/sleep/ttl/retry hint
+ *   - port: 80 / 443 / 3000 / 5173 / 5174 / 5175 / 8080 / 8443 (port / url / listen hint)
+ *
+ * 除外:
+ *   - `0` / `1` / `2` / `-1` / `10` / `100` / `1000` (= 普通の小数)
+ *   - test file (`*.test.ts(x)`)、 generated / dist / cdk.out
+ *   - 文字列 / コメント / template literal 内の数値
+ *   - `import "..."` 行 (= path-internal の数値)
+ *   - `handlers/shared/http-status.ts` (= legacy alias 定義は対象外)
+ *
+ * dedup: file 単位で同 (kind, value) を 1 件にまとめ、 最初の line を採用する。
+ */
+
+const INCLUDE_PATH_PREFIXES = [
+  "infrastructure/lib/",
+  "infrastructure/bin/",
+  "apps/admin-console/src/",
+  "apps/application-admin-console/src/",
+  "apps/participant-portal/src/",
+  "packages/portal-plugin-sdk/src/",
+  "packages/trust-bridge/src/",
+] as const;
+
+const EXCLUDE_PATTERNS = [
+  /\.test\.tsx?$/,
+  /\/node_modules\//,
+  /\/dist\//,
+  /\/cdk\.out\//,
+  /\/__generated__\//,
+  /\/__mocks__\//,
+  /\/handlers\/shared\/http-status\.ts$/,
+];
+
+const NEVER_FLAG = new Set([0, 1, 2, -1, 10, 100, 1000]);
+const HTTP_STATUS_MIN = 100;
+const HTTP_STATUS_MAX = 599;
+const TIMEOUT_VALUES = new Set([
+  1_000, 2_000, 3_000, 5_000, 10_000, 15_000, 30_000, 60_000, 90_000, 120_000, 180_000, 300_000,
+  600_000, 900_000, 1_800_000, 3_600_000, 86_400_000,
+]);
+const COMMON_PORTS = new Set([80, 443, 3000, 5173, 5174, 5175, 8080, 8443]);
+
+const HTTP_STATUS_CONTEXT_RES = [
+  /\.json\s*\([^)]*,\s*\d{3}\)/,
+  /\bstatus(Code)?\s*[:=]==?\s*\d{3}\b/,
+  /\bstatus(Code)?\s*:\s*\d{3}\b/,
+  /\.status\s*\(\s*\d{3}\s*\)/,
+  /\b(throw|return)\s+\w*\s*\(\s*\d{3}\s*[,)]/,
+];
+const TIMEOUT_CONTEXT_RES = [
+  /(timeout|delay|interval|sleep|wait|ttl|backoff|retry|deadline|expir)/i,
+  /setTimeout|setInterval/,
+];
+const PORT_CONTEXT_RE = /\b(port|PORT|listen|bind|endpoint|url|URL|origin)\b/;
+
+function shouldInspect(path: string): boolean {
+  if (!/\.tsx?$/.test(path)) return false;
+  if (EXCLUDE_PATTERNS.some((re) => re.test(path))) return false;
+  return INCLUDE_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+export type MagicNumberKind = "http-status" | "timeout-ms" | "port";
+
+interface Classification {
+  readonly kind: MagicNumberKind;
+  readonly value: number;
+}
+
+function classify(value: number, lineText: string): Classification | undefined {
+  if (NEVER_FLAG.has(value)) return undefined;
+  if (isHttpStatusCandidate(value) && HTTP_STATUS_CONTEXT_RES.some((re) => re.test(lineText))) {
+    return { kind: "http-status", value };
+  }
+  if (TIMEOUT_VALUES.has(value) && TIMEOUT_CONTEXT_RES.some((re) => re.test(lineText))) {
+    return { kind: "timeout-ms", value };
+  }
+  if (COMMON_PORTS.has(value) && PORT_CONTEXT_RE.test(lineText)) {
+    return { kind: "port", value };
+  }
+  return undefined;
+}
+
+function isHttpStatusCandidate(value: number): boolean {
+  return Number.isInteger(value) && value >= HTTP_STATUS_MIN && value <= HTTP_STATUS_MAX;
+}
+
+interface IntegerHit {
+  readonly value: number;
+  readonly col: number;
+}
+
+export interface LineScanResult {
+  readonly ints: IntegerHit[];
+  readonly nextState: ScannerState;
+}
+
+/** Walk a single line and return integer literals found in `code` positions only. */
+export function extractIntegersFromLine(line: string, initialState: ScannerState): LineScanResult {
+  const ints: IntegerHit[] = [];
+  let i = 0;
+  // line-comment は次の \n で終端する状態だが、 line-by-line scan の本関数は \n を見ない。
+  // 呼び出し元が前行の末尾で state="line-comment" のまま渡してきたら、 本関数開始時点で
+  // code に戻す (= line-comment は line 境界で必ず終わる)。
+  let state: ScannerState = initialState === "line-comment" ? "code" : initialState;
+  while (i < line.length) {
+    const c = line[i] ?? "";
+    const next = line[i + 1] ?? "";
+    if (state === "code" && /[0-9]/.test(c)) {
+      const skip = consumeIdentifierIfDigitFollowsAlpha(line, i);
+      if (skip > i) {
+        i = skip;
+        continue;
+      }
+      const parsed = consumeNumericLiteral(line, i);
+      if (parsed) {
+        ints.push({ value: parsed.value, col: i });
+        i = parsed.end;
+        continue;
+      }
+    }
+    if (state === "line-comment") break; // remainder of line is comment
+    const s = step(c, next, state);
+    state = s.state;
+    i += s.consumed;
+  }
+  // line-comment で行末まで進んだ場合、 次行は新しい code 状態から始める。
+  if (state === "line-comment") state = "code";
+  return { ints, nextState: state };
+}
+
+function consumeIdentifierIfDigitFollowsAlpha(line: string, i: number): number {
+  const prev = i > 0 ? (line[i - 1] ?? "") : "";
+  if (!/[A-Za-z_$]/.test(prev)) return i;
+  let j = i;
+  while (j < line.length && /[A-Za-z0-9_$]/.test(line[j] ?? "")) j += 1;
+  return j;
+}
+
+interface NumericLiteral {
+  readonly value: number;
+  readonly end: number;
+}
+
+function consumeNumericLiteral(line: string, start: number): NumericLiteral | undefined {
+  const acc = { raw: "", j: start, hasDecimal: false };
+  while (acc.j < line.length && advanceNumeric(line, acc)) {
+    /* loop body in advanceNumeric */
+  }
+  const tail = line[acc.j] ?? "";
+  if (tail && /[A-Za-z_$]/.test(tail)) return undefined; // `100n` / `200px`
+  const num = Number(acc.raw);
+  if (!Number.isFinite(num) || !Number.isInteger(num)) return undefined;
+  return { value: num, end: acc.j };
+}
+
+interface NumericAccumulator {
+  raw: string;
+  j: number;
+  hasDecimal: boolean;
+}
+
+/** Consume the next char into `acc` if it's part of the numeric literal. Returns false at end. */
+function advanceNumeric(line: string, acc: NumericAccumulator): boolean {
+  const cj = line[acc.j] ?? "";
+  if (/[0-9]/.test(cj)) {
+    acc.raw += cj;
+    acc.j += 1;
+    return true;
+  }
+  if (cj === "_") {
+    acc.j += 1; // separator allowed between digits
+    return true;
+  }
+  if (cj === "." && !acc.hasDecimal && /[0-9]/.test(line[acc.j + 1] ?? "")) {
+    acc.raw += cj;
+    acc.hasDecimal = true;
+    acc.j += 1;
+    return true;
+  }
+  return false;
+}
+
+export interface MagicNumberHit {
+  readonly line: number;
+  readonly value: number;
+  readonly kind: MagicNumberKind;
+}
+
+export function scanFile(source: string): MagicNumberHit[] {
+  const hits: MagicNumberHit[] = [];
+  const lines = source.split("\n");
+  let state: ScannerState = "code";
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (isImportLine(line)) {
+      if (state === "block-comment" && line.includes("*/")) state = "code";
+      continue;
+    }
+    const { ints, nextState } = extractIntegersFromLine(line, state);
+    state = nextState;
+    for (const { value } of ints) {
+      const c = classify(value, line);
+      if (!c) continue;
+      hits.push({ line: i + 1, value, kind: c.kind });
+    }
+  }
+  return hits;
+}
+
+function isImportLine(line: string): boolean {
+  return /^\s*import\s/.test(line) || /^\s*from\s+["']/.test(line);
+}
+
+export const magicNumber: Rule = {
+  id: "magic-number",
+  severity: "warning",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldInspect(path)) continue;
+      let content: string;
+      try {
+        content = ctx.readFile(path);
+      } catch {
+        continue;
+      }
+      const seen = new Set<string>();
+      for (const hit of scanFile(content)) {
+        const key = `${hit.kind}:${hit.value}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        findings.push({
+          ruleId: "magic-number",
+          severity: "warning",
+          filePath: path,
+          line: hit.line,
+          match: key,
+          message: describe(hit),
+          recommendation: recommend(hit),
+        });
+      }
+    }
+    return findings;
+  },
+};
+
+function describe(hit: MagicNumberHit): string {
+  switch (hit.kind) {
+    case "http-status":
+      return `HTTP status code リテラル ${hit.value} を直接書いている (= magic number)。`;
+    case "timeout-ms":
+      return `タイムアウト / interval 値 ${hit.value} を直接書いている (= magic number)。`;
+    case "port":
+      return `port 番号 ${hit.value} を直接書いている (= magic number)。`;
+  }
+}
+
+function recommend(hit: MagicNumberHit): string {
+  switch (hit.kind) {
+    case "http-status":
+      return (
+        "`StatusCodes.*` (= http-status-codes パッケージ) を使ってください。 例: " +
+        "`c.json(body, StatusCodes.OK)` / `if (res.status === StatusCodes.UNAUTHORIZED) ...`。 " +
+        "規約は AGENTS.md / CLAUDE.md 「HTTP status codes: no magic numbers」 参照。"
+      );
+    case "timeout-ms":
+      return (
+        "名前付き定数に抽出し、 単位 (= `_MS` / `_MINUTES`) を suffix に含めて意図を明示してください。 " +
+        "例: `const POLLING_INTERVAL_MS = 30_000;`。"
+      );
+    case "port":
+      return (
+        "config / 環境変数 / 定数に抽出してください。 frontend 開発 port は `vite.config.ts` の " +
+        "`server.port` で管理し、 アプリ側は import.meta.env 経由で参照。"
+      );
+  }
+}
+
+export const __INTERNAL = { HTTP_STATUS_MIN, HTTP_STATUS_MAX, COMMON_PORTS, TIMEOUT_VALUES };

--- a/.claude/harness/src/tech-debt/scanner.ts
+++ b/.claude/harness/src/tech-debt/scanner.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared TypeScript source scanner state for the tech-debt rule parsers.
+ *
+ * The scanner tracks whether the current position is inside:
+ *   - code             (default)
+ *   - sq / dq / bt     single-quote / double-quote / backtick string literal
+ *   - line-comment     `//` until newline
+ *   - block-comment    `/` `*` ... `*` `/`
+ *
+ * Each step accepts the current `(char, nextChar)` and returns the next state and
+ * how many characters were consumed. Callers iterate manually so they can also
+ * count tokens (= expect / digit / paren) while staying inside `state === "code"`.
+ *
+ * Centralising the state machine here keeps each rule under biome's
+ * `noExcessiveCognitiveComplexity` threshold (= 15) without sacrificing the
+ * literal/comment awareness needed to avoid false positives.
+ */
+
+export type ScannerState = "code" | "sq" | "dq" | "bt" | "line-comment" | "block-comment";
+
+export interface ScanStep {
+  readonly state: ScannerState;
+  readonly consumed: number;
+}
+
+/**
+ * Advance the scanner one step. Returns the next state and how many input chars to
+ * consume. Caller is expected to be in `state === "code"` when interpreting
+ * tokens (= identifiers, parens, numeric literals).
+ */
+export function step(c: string, next: string, state: ScannerState): ScanStep {
+  if (state === "code") return stepCode(c, next);
+  if (state === "line-comment") return c === "\n" ? toCode(1) : same(state, 1);
+  if (state === "block-comment") {
+    if (c === "*" && next === "/") return toCode(2);
+    return same(state, 1);
+  }
+  // string-like states share the escape + close-quote rule
+  return stepString(c, state);
+}
+
+function stepCode(c: string, next: string): ScanStep {
+  if (c === "/" && next === "/") return { state: "line-comment", consumed: 2 };
+  if (c === "/" && next === "*") return { state: "block-comment", consumed: 2 };
+  if (c === '"') return { state: "dq", consumed: 1 };
+  if (c === "'") return { state: "sq", consumed: 1 };
+  if (c === "`") return { state: "bt", consumed: 1 };
+  return same("code", 1);
+}
+
+function stepString(c: string, state: ScannerState): ScanStep {
+  if (c === "\\") return same(state, 2); // skip the escaped char
+  if (state === "dq" && c === '"') return toCode(1);
+  if (state === "sq" && c === "'") return toCode(1);
+  if (state === "bt" && c === "`") return toCode(1);
+  return same(state, 1);
+}
+
+function toCode(consumed: number): ScanStep {
+  return { state: "code", consumed };
+}
+
+function same(state: ScannerState, consumed: number): ScanStep {
+  return { state, consumed };
+}

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -1,54 +1,53 @@
 ---
 name: tech-debt
-description: TenkaCloud tech-debt analyzer を実行し、test smell / 結合漏れ / 握り潰し fallback 等の技術的負債を検出する。コード品質、テスト改善、リファクタの優先順位、技術的負債バックログを訊かれたときに使う。
+description: TenkaCloud tech-debt analyzer を実行し、test smell / 結合漏れ / magic number 等の技術的負債を検出する。コード品質、テスト改善、リファクタの優先順位、技術的負債バックログを訊かれたときに使う。
 allowed-tools: Bash(make tech-debt:*), Bash(bun run .claude/harness/bin/tech-debt.ts:*)
 ---
 
 # TenkaCloud Tech Debt Loop
 
-リポジトリ全体を静的解析し、優先度つきの技術的負債バックログを生成する。実装は [`.claude/harness/src/tech-debt.ts`](../../../.claude/harness/src/tech-debt.ts)。
+リポジトリ全体を静的解析し、ルールごとにグルーピングした finding 一覧を出力する。ルール実装は [`.claude/harness/src/tech-debt/`](../../../.claude/harness/src/tech-debt/) 配下に 1 ルール = 1 ファイルで配置。
 
 ## 実行方法
 
-stdout に markdown レポート (デフォルト):
+全 tracked file を scan (デフォルト):
 
 ```bash
 make tech-debt
 ```
 
-`docs/tech-debt/backlog.md` と `backlog.json` に書き出し:
+Staged ファイルのみ + severity gate (PR 前 / pre-commit 用):
 
 ```bash
-bun run .claude/harness/bin/tech-debt.ts --write
+bun run .claude/harness/bin/tech-debt.ts --staged --fail-on=error
 ```
 
-Staged ファイルのみ + severity gate (PR 前に走らせる用):
+`--fail-on` が無指定の場合は `warning` 以上で exit 2 になる (= advisory ベース)。`error` 指定で error 級だけを blocker 扱いにできる。
+
+現状を baseline として凍結し、 新規違反のみ block する:
 
 ```bash
-bun run .claude/harness/bin/tech-debt.ts --staged --fail-on=high
+bun run .claude/harness/bin/tech-debt.ts --baseline
 ```
 
-`--fail-on=high` 指定時、`high` か `critical` が 1 件でもあれば exit 2 で終了する。
+これで `.claude/harness/baselines/tech-debt-<rule>.json` が更新される。 既存違反は許容、 新規追加のみ次回 run で finding として上がる。
 
 ## 検出するパターン
 
-各 finding に severity (`critical` / `high` / `medium`) と修正方針 (`recommendation`) が付く。
+各 finding には severity (`error` / `warning` / `info`) と修正方針 (`recommendation`) が付く。
 
-- **assertion-roulette** — 単一テストケース内の `expect` が多すぎて失敗原因が読み取れない
-- **auth-skip-leak** — `AUTH_SKIP` 判定が責務境界の外に漏れている
-- **direct-service-env** — フロントエンドから直接 `process.env.*API_URL` を読んでいる (`runtime-config.json` 経由にすべき)
-- **router-without-zod** — API router に入力検証 (Zod) が無い
-- **band-aid-fallback** — `console.warn("fallback to empty…")` のような握り潰しパターン
-- **direct-fetch-in-app** — `apps/*/app/` 配下で直接 `fetch()` を叩いている (api クライアントに閉じ込めるべき)
+- **assertion-roulette** (= test smell) — `it()` / `test()` 1 ブロック内の `expect()` が 6 個以上。 失敗時にどの assertion で死んだか読み取りにくいので、 振る舞い単位で test case を分割する。
+- **high-coupling** (= SRP 違反候補) — `infrastructure/lib/` 等 production code で 1 ファイルが 16 個以上の module を import している。 26 個で重警告、 41 個で error (= 必ず分割)。
+- **magic-number** (= 意図不明な数値リテラル) — HTTP status code (`c.json(body, 500)` / `res.status === 401`) / timeout (`60000` ms 等) / port (`3000` / `8080` 等) を直書きしている。 `StatusCodes.*` (= `http-status-codes`) や名前付き定数に抽出する。
 
 ## 落ちたときの対処
 
-1. `## Hotspots` で finding が集中するファイルを確認
-2. 同じ ruleId が複数出ている場合は、まずそのパターンを 1 箇所だけ模範実装で直して、残りを追従
-3. `--write` で `docs/tech-debt/backlog.md` を更新し、PR で「この PR で解消したもの / 残存」を明示
+1. 同じ `ruleId` が複数出ている場合は、 まずそのパターンを 1 箇所だけ模範実装で直して、 残りを追従
+2. 既存大規模違反 (= legacy debt) は `--baseline` で凍結し、 新規追加だけ block する設計
+3. 1 PR で同 rule の finding を 5+ 件解消したら baseline を再生成して "ratchet" を進める
 
 ## 関連
 
-- `/harness` (= `make harness`) — アーキテクチャ不変条件チェック
-- `docs/tech-debt/backlog.md` — `--write` で更新される永続バックログ
-- [`.claude/harness/src/tech-debt.ts`](../../../.claude/harness/src/tech-debt.ts) — ルール実装
+- `/harness` (= `make harness`) — アーキテクチャ不変条件チェック (= 兄弟 tool)
+- [`.claude/harness/src/tech-debt/`](../../../.claude/harness/src/tech-debt/) — ルール実装 (1 file = 1 rule)
+- [`.claude/harness/baselines/tech-debt-*.json`](../../../.claude/harness/baselines/) — per-rule baseline (= legacy debt 凍結)

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ format_check: lint-format
 HARNESS := bun run .claude/harness/bin
 harness:      ; $(HARNESS)/architecture.ts --staged --fail-on=error
 harness-test: ; cd .claude/harness && bun vitest run
+# Issue #1227: 全 tracked file を scan して assertion-roulette / high-coupling / magic-number
+# を検出。 baseline 越え (= 新規違反) があれば exit 2 で落ちる。 既存違反は
+# .claude/harness/baselines/tech-debt-*.json で凍結。 baseline を更新したいときは
+#   bun run .claude/harness/bin/tech-debt.ts --baseline
 tech-debt:    ; $(HARNESS)/tech-debt.ts
 
 # ===== CDK =====


### PR DESCRIPTION
## Summary
- Replace the no-op stub at `.claude/harness/bin/tech-debt.ts` with a real analyzer modeled on the existing architecture harness.
- Land three rules: `assertion-roulette` (test smell: >=6 expects per `it()`), `high-coupling` (>=16 top-level imports per production file, error at >=41), `magic-number` (HTTP status / timeout-ms / port literals in production code, with hint-word context to suppress false positives).
- Share a `scanner.ts` state machine across rules so each parser stays under biome's cognitive-complexity ceiling without losing string / comment awareness.
- Freeze the current debt (94 / 15 / 17 findings) in `.claude/harness/baselines/tech-debt-<rule>.json`. Future PRs only block on new regressions; `--baseline` re-freezes when debt is paid down.

Closes #1227

## Regression analysis
- `make tech-debt` previously printed one OK line; the new analyzer runs across all tracked files but is fully baselined, so existing CI/`make before-commit` behavior is unchanged (no new failures introduced).
- The architecture harness loads every `*.json` under `.claude/harness/baselines/`; `loadAllBaselines` now skips `tech-debt-*.json` so the two analyzers cannot accidentally consume each other's baselines.
- `loadTechDebtBaselines` is ENOENT-tolerant for first-time bootstrap (covered by `index.test.ts`).
- Biome cognitive-complexity warnings are warn-only; new parser code was decomposed into helpers (`inspectCodeChar`, `advanceNumeric`, etc.) to stay under the 15 threshold.
- No runtime / CDK / deploy / Lambda path touched.

## Physical impact
NO-OP for the runtime / deployed artifact.

- CREATE: `.claude/harness/src/tech-debt/{assertion-roulette,high-coupling,magic-number,index,scanner}.ts` plus 4 unit test files.
- CREATE: 3 baseline JSONs under `.claude/harness/baselines/tech-debt-*.json`.
- UPDATE: `.claude/harness/bin/tech-debt.ts` (stub -> CLI runner), `.claude/harness/src/cli.ts` (2-line skip-tech-debt baselines), `.claude/skills/tech-debt/SKILL.md` (rule list refreshed), `Makefile` (added explanatory comment above the existing `tech-debt:` target).
- NO-OP: `cdk synth` output (no infra files touched).

## Test plan
- [x] `make harness-test` -> 79/79 tests pass (10 files, includes 4 new tech-debt suites + 36 new tech-debt cases)
- [x] `make tech-debt` -> `no findings` after baselining
- [x] `make harness` -> `no findings` (and architecture harness no longer pulls tech-debt baselines)
- [x] `make before-commit` -> green (lint / typecheck / vitest / validate-problems / check-synth / audit-deps)
- [x] `bun run .claude/harness/bin/tech-debt.ts --help` shows the CLI surface
- [x] `bun run .claude/harness/bin/tech-debt.ts --baseline` regenerates frozen state and exits 0

Sample finding counts from a no-baseline run on `main`:
```
tech-debt: 126 finding(s) across 3 rule(s).
## assertion-roulette (94)
## high-coupling (15)
## magic-number (17)
```