### PR TITLE
docs(adr): ADR-024 community voting and on-chain problem registry

### DIFF
--- a/docs/architecture/adr-024-community-voting-and-problem-registry.html
+++ b/docs/architecture/adr-024-community-voting-and-problem-registry.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ADR-024: Community voting and on-chain problem registry</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+    --c-purple: #6639ba;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.show td { background: #ddf4e0; }
+  tr.hide td { background: #ffe9e9; }
+  tr.chosen td { background: #ddf4e0; font-weight: 500; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.accept { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject { background: #ffe9e9; color: var(--c-reject); }
+  .badge.warn   { background: #fff8c5; color: var(--c-warn); }
+  .badge.muted  { background: var(--c-bg-soft); color: var(--c-muted); }
+  .badge.chosen { background: #ddf4e0; color: var(--c-accept); }
+  .badge.draft  { background: #ddf4ff; color: var(--c-link); }
+  .decision-box {
+    border: 2px solid var(--c-accept); border-radius: 6px;
+    background: #f0faf2; padding: 1rem 1.2rem; margin: 1.2rem 0;
+  }
+  .decision-box h3 { margin-top: 0; color: var(--c-accept); }
+  .nongoals-box {
+    border: 2px solid var(--c-reject); border-radius: 6px;
+    background: #fff5f5; padding: 1rem 1.2rem; margin: 1.2rem 0;
+  }
+  .nongoals-box h3 { margin-top: 0; color: var(--c-reject); }
+  .nongoals-box ul { list-style: none; padding-left: 0; }
+  .nongoals-box li::before { content: "\00d7  "; color: var(--c-reject); font-weight: 700; }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  svg { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+  .layer-tag {
+    display: inline-block; padding: 1px 6px; border-radius: 3px;
+    font-size: 0.78rem; font-weight: 600; margin-right: .3rem;
+  }
+  .layer-chain   { background: #ede5fa; color: var(--c-purple); }
+  .layer-off     { background: #ddf4ff; color: var(--c-link); }
+  .layer-catalog { background: #fff5dc; color: var(--c-warn); }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-024: Community voting and on-chain problem registry</h1>
+  <p><em>Hybrid model for community curation of the problem catalog: a minimal on-chain registry of problem cards, paired with an off-chain voting / adoption / sponsorship layer. Web3 is an optional surface, never a requirement.</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge accept">Accepted</span> 2026-05-24</div>
+    <div><b>Tracking:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/1269">#1269</a></div>
+    <div><b>Related:</b>
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin),
+      <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> (Trust Bridge),
+      <a href="./adr-022-inter-team-coordination-plugin.html">ADR-022</a> (inter-team plugin)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>TenkaCloud separates the platform from the problem catalog (<a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>: problem = plugin, platform = host), and the catalog repo is OSS-ready. Multi-cloud problem execution is being unlocked by the Trust Bridge protocol (<a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a>) and the cross-account stack catalog work tracked under the multi-cloud runtime issues. The pieces required to publish, run, and score third-party problems are converging.</p>
+
+<p>Contribution mechanics, however, end at "open a PR to add a problem." There is no community signal layer to answer:</p>
+
+<ul>
+  <li>Which problems are <strong>valuable</strong> enough that operators want to run them in events.</li>
+  <li>Which problems need <strong>improvement</strong>, and in what direction.</li>
+  <li>Which problems deserve <strong>sponsorship</strong> or maintenance funding.</li>
+  <li>Which contributors built durable <strong>learning assets</strong> that the community recognises.</li>
+  <li>Which themes organisations want to see <strong>created</strong> but do not yet exist.</li>
+</ul>
+
+<p>Without that signal layer, the catalog risks becoming a pile of drafts with maintainers as the only filter, contributors getting little recognition, and organisations having no structured way to express demand.</p>
+
+<p>A Web3 mechanism is plausible because voting, ownership, sponsorship, and contributor reputation are the kinds of public, composable records that a chain handles well. A naive Web3 design is also dangerous: a token introduces speculation, mandatory wallets block enterprise adoption, and on-chain governance can lock the project into bad rules before the community is mature enough to know what good rules look like.</p>
+
+<p>This ADR commits to a design that captures the community-curation upside while keeping enterprise usage wallet-free and keeping governance flexible.</p>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<div class="decision-box">
+  <h3>Hybrid: on-chain problem registry + off-chain voting / adoption / sponsorship layer</h3>
+  <ol>
+    <li><strong>Phase 1 (on-chain registry):</strong> Publish a minimal, public registry of <code>ProblemCard</code> records: <code>id</code>, <code>problemId</code>, <code>title</code>, <code>url</code>, <code>contentHash</code>, <code>author</code>, <code>createdAt</code>. Nothing more. The full problem source stays in the catalog repo.</li>
+    <li><strong>Phase 2 (off-chain layer):</strong> Build voting (<code>ProblemVote</code>), event adoption (<code>ProblemAdoption</code>), and sponsorship interest (<code>ProblemSponsorshipInterest</code>) as off-chain records that reference the on-chain <code>chainProblemId</code>.</li>
+    <li><strong>Web3 is optional.</strong> Wallet login is never required for enterprise users. GitHub / Discord identity is a first-class participation path. Wallet identity is an additional path, not a replacement.</li>
+    <li><strong>No token, no vote-to-merge, no replacement of GitHub review.</strong> Quality control stays with maintainers.</li>
+  </ol>
+</div>
+
+<p>The chain stores the smallest public artefact that lets the community build composable surfaces (voting frontends, leaderboards, Discord bots, sponsorship dashboards). Everything that needs flexible rules, moderation, or private enterprise context lives off-chain.</p>
+</section>
+
+<section>
+<h2>Layered model</h2>
+
+<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="13" width="100%" style="max-width: 720px; height: auto;">
+  <rect x="20" y="20" width="200" height="200" rx="6" fill="#ede5fa" stroke="#6639ba" stroke-width="1.5"/>
+  <text x="120" y="42" text-anchor="middle" font-weight="700" fill="#6639ba">On-chain layer</text>
+  <text x="120" y="62" text-anchor="middle" fill="#6639ba" font-size="11">Public, immutable, minimal</text>
+  <rect x="40" y="80" width="160" height="50" rx="4" fill="#fff" stroke="#6639ba"/>
+  <text x="120" y="100" text-anchor="middle" font-weight="600">ProblemCard registry</text>
+  <text x="120" y="118" text-anchor="middle" font-size="11" fill="#59636e">id, title, url, contentHash</text>
+  <rect x="40" y="145" width="160" height="50" rx="4" fill="#fff" stroke="#6639ba" stroke-dasharray="4 3"/>
+  <text x="120" y="166" text-anchor="middle" font-weight="600">Phase 5 attestations</text>
+  <text x="120" y="184" text-anchor="middle" font-size="11" fill="#59636e">(badges, version proofs)</text>
+
+  <rect x="260" y="20" width="200" height="200" rx="6" fill="#ddf4ff" stroke="#0969da" stroke-width="1.5"/>
+  <text x="360" y="42" text-anchor="middle" font-weight="700" fill="#0969da">Off-chain layer</text>
+  <text x="360" y="62" text-anchor="middle" fill="#0969da" font-size="11">Flexible, moderated</text>
+  <rect x="280" y="80" width="160" height="36" rx="4" fill="#fff" stroke="#0969da"/>
+  <text x="360" y="103" text-anchor="middle">ProblemVote</text>
+  <rect x="280" y="124" width="160" height="36" rx="4" fill="#fff" stroke="#0969da"/>
+  <text x="360" y="147" text-anchor="middle">ProblemAdoption</text>
+  <rect x="280" y="168" width="160" height="36" rx="4" fill="#fff" stroke="#0969da"/>
+  <text x="360" y="191" text-anchor="middle">SponsorshipInterest</text>
+
+  <rect x="500" y="20" width="200" height="200" rx="6" fill="#fff5dc" stroke="#9a6700" stroke-width="1.5"/>
+  <text x="600" y="42" text-anchor="middle" font-weight="700" fill="#9a6700">Catalog UI</text>
+  <text x="600" y="62" text-anchor="middle" fill="#9a6700" font-size="11">Per-problem signals</text>
+  <rect x="520" y="80" width="160" height="36" rx="4" fill="#fff" stroke="#9a6700"/>
+  <text x="600" y="103" text-anchor="middle">Registry link</text>
+  <rect x="520" y="124" width="160" height="36" rx="4" fill="#fff" stroke="#9a6700"/>
+  <text x="600" y="147" text-anchor="middle">Vote counts by intent</text>
+  <rect x="520" y="168" width="160" height="36" rx="4" fill="#fff" stroke="#9a6700"/>
+  <text x="600" y="191" text-anchor="middle">Adoption + sponsor CTAs</text>
+
+  <path d="M220 120 L260 120" stroke="#59636e" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <path d="M460 120 L500 120" stroke="#59636e" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#59636e"/>
+    </marker>
+  </defs>
+</svg>
+
+<p>Off-chain records reference the on-chain <code>chainProblemId</code>; catalog UI reads both layers and renders the consolidated signal to operators and authors.</p>
+</section>
+
+<section>
+<h2>Data model</h2>
+
+<h3>On-chain: <code>ProblemCard</code> (Phase 1)</h3>
+
+<p>The on-chain record is intentionally minimal so any community frontend can read it. The illustrative shape (final wire format is a Phase 1 implementation detail):</p>
+
+<pre>struct ProblemCard {
+    uint256 id;
+    string  problemId;     // catalog slug (e.g. "battle/hello-world")
+    string  title;
+    string  url;           // canonical catalog URL
+    string  contentHash;   // catalog commit hash or content hash
+    address author;        // maintainer address (optional in early rollout)
+    uint256 createdAt;
+}</pre>
+
+<table>
+<thead><tr><th>Field</th><th>Purpose</th><th>Mutability</th></tr></thead>
+<tbody>
+<tr><td><code>id</code></td><td>On-chain primary key, surfaced off-chain as <code>chainProblemId</code></td><td>Immutable per registration</td></tr>
+<tr><td><code>problemId</code></td><td>Catalog slug; links to the source-of-truth metadata.json</td><td>Immutable per registration</td></tr>
+<tr><td><code>title</code> / <code>url</code></td><td>Discovery hooks for third-party frontends</td><td>Treated as immutable; material changes register a new card version</td></tr>
+<tr><td><code>contentHash</code></td><td>Catalog commit hash or content hash of the problem at registration time; provenance anchor</td><td>Immutable</td></tr>
+<tr><td><code>author</code></td><td>Maintainer or registrar wallet address; may be a multisig in early rollout</td><td>Immutable</td></tr>
+<tr><td><code>createdAt</code></td><td>Block timestamp at registration</td><td>Immutable</td></tr>
+</tbody>
+</table>
+
+<h3>Off-chain: voting / adoption / sponsorship (Phase 2)</h3>
+
+<pre>type ProblemVoteIntent =
+  | "want-to-play"
+  | "use-for-training"
+  | "important-skill"
+  | "needs-improvement";
+
+interface ProblemVote {
+  problemId: string;
+  chainProblemId?: string;
+  userId: string;
+  walletAddress?: string;
+  intent: ProblemVoteIntent;
+  comment?: string;
+  createdAt: string;
+}
+
+interface ProblemAdoption {
+  problemId: string;
+  chainProblemId?: string;
+  organization?: string;
+  eventName?: string;
+  participantCount?: number;
+  visibility: "public" | "private" | "anonymous";
+  feedbackSummary?: string;
+  createdAt: string;
+}
+
+interface ProblemSponsorshipInterest {
+  theme: string;
+  problemId?: string;
+  chainProblemId?: string;
+  organization?: string;
+  budgetRange?: "unknown" | "small" | "medium" | "large";
+  desiredOutcome: string;
+  visibility: "public" | "private" | "anonymous";
+}</pre>
+
+<h3>Mapping rule</h3>
+
+<ul>
+  <li><strong>Catalog &harr; chain:</strong> <code>problemId</code> (catalog slug) is the join key. Each off-chain record carries both <code>problemId</code> and the optional <code>chainProblemId</code>; the latter is populated once the problem has been registered on-chain.</li>
+  <li><strong>Versioning:</strong> Material changes to a problem register a new <code>ProblemCard</code> rather than mutating the existing one. Off-chain records pinned to a specific <code>chainProblemId</code> stay attached to the version they were cast against.</li>
+  <li><strong>Identity:</strong> Off-chain records require an off-chain identity (GitHub / Discord / SSO). A wallet address is captured only when the participant chose to bind one, and is never required.</li>
+</ul>
+</section>
+
+<section>
+<h2>Options considered</h2>
+
+<table>
+<thead>
+<tr><th>Option</th><th>Pros</th><th>Cons</th><th>Verdict</th><th>Why</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>A. GitHub-native only</strong><br>Discussions / Issues / Reactions / Labels</td>
+  <td>Very low implementation cost; no new auth; OSS-native; zero Web3/compliance risk</td>
+  <td>Weak product UX; reactions are not intent-specific; hard to aggregate by event or organisation; does not feel like a product</td>
+  <td><span class="badge reject">Rejected</span></td>
+  <td>Captures none of the demand-signal, sponsorship, or contributor-reputation outcomes the catalog needs</td>
+</tr>
+<tr>
+  <td><strong>B. Off-chain portal only</strong><br>Catalog voting UI with GitHub / Discord login</td>
+  <td>Strong UX; intent-specific voting; integrates cleanly with catalog metadata; avoids blockchain entirely</td>
+  <td>Loses Web3-native composability; no public provenance for problem versions; future on-chain attestation requires retrofitting identity mapping</td>
+  <td><span class="badge reject">Rejected</span></td>
+  <td>Solves the UX problem but discards the option value of a public, composable registry</td>
+</tr>
+<tr>
+  <td><strong>C. NFT / on-chain governance first</strong><br>Problems, votes, and sponsorships all on-chain; token or DAO</td>
+  <td>Strong community / ownership vibe; durable public artefacts; distinctive Web3-native surface</td>
+  <td>High implementation complexity; compliance sensitivity for enterprises; wallet onboarding friction blocks CCoE buyers; speculative token incentives attract the wrong contributors; on-chain governance locks in immature rules</td>
+  <td><span class="badge reject">Rejected</span></td>
+  <td>Violates the "enterprise-friendly, no token, no wallet requirement" constraint and risks the project's neutrality</td>
+</tr>
+<tr>
+  <td><strong>D. Hybrid progressive</strong><br>Off-chain first, then optional on-chain attestations for selected artefacts</td>
+  <td>Practical MVP; preserves future Web3 path; lets enterprise users ignore Web3</td>
+  <td>More design work than off-chain only; on-chain layer arrives later, so early adopters cannot build composable surfaces on it</td>
+  <td><span class="badge warn">Viable runner-up</span></td>
+  <td>A safe fallback if the on-chain registry is delayed; structurally compatible with the chosen option</td>
+</tr>
+<tr class="chosen">
+  <td><strong>E. On-chain registry + community-built voting UI</strong></td>
+  <td>Minimal on-chain footprint; publicly readable and composable; community frontends can be built without platform changes; provenance for problem versions; Web3-native without token complexity</td>
+  <td>Wallet interaction needed for registration (mitigated by maintainer-gated registration); on-chain metadata updates need a versioning convention; spam registrations need moderation or allowlisting; voting rules still need separate design</td>
+  <td><span class="badge chosen">Chosen</span></td>
+  <td>Captures Web3-native composability while keeping governance flexible off-chain. Enterprise users can ignore the chain entirely. The on-chain layer is small enough to ship without locking the project into a token or DAO model.</td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Phased roadmap</h2>
+
+<table>
+<thead>
+<tr><th>Phase</th><th>Scope</th><th>Platform code change</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>Phase 0</strong><br>GitHub/Discord community process</td>
+  <td>Define and apply labels on the catalog repo: <code>problem-proposal</code>, <code>problem-needs-review</code>, <code>problem-tested</code>, <code>problem-adopted</code>, <code>sponsor-interest</code>. Use GitHub Discussions and the Discord squad for tester / reviewer feedback.</td>
+  <td>None (process change only)</td>
+</tr>
+<tr>
+  <td><strong>Phase 1</strong><br>Lightweight on-chain problem registry</td>
+  <td>Stand up a minimal contract or signed registry artefact that stores <code>ProblemCard</code> records (id, title, canonical URL, content / commit hash, registrar address). No token. Registration is initially gated to maintainers; open registration is an explicit later decision. Provide read examples so the community can build voting pages, leaderboards, Discord bots, sponsorship dashboards, and discovery pages on top.</td>
+  <td>New registry artefact + read SDK; no change to the drill runtime</td>
+</tr>
+<tr>
+  <td><strong>Phase 2</strong><br>Off-chain catalog voting data model</td>
+  <td>Implement <code>ProblemVote</code>, <code>ProblemAdoption</code>, and <code>ProblemSponsorshipInterest</code> records and the API surface that creates them. Identity is GitHub / Discord; wallet addresses are optional attachments.</td>
+  <td>New storage + API; no change to the scoring engine</td>
+</tr>
+<tr>
+  <td><strong>Phase 3</strong><br>Catalog UI signals</td>
+  <td>Render per-problem signals in the catalog UI: on-chain registry link, vote counts by intent, used-in-events count, contributor badges, open sponsor interests, and a "Request this problem for your org" CTA.</td>
+  <td>Catalog UI extension</td>
+</tr>
+<tr>
+  <td><strong>Phase 4</strong><br>Governance rules</td>
+  <td>Define how votes influence catalog status: <code>Draft</code> &rarr; <code>Community requested</code> &rarr; <code>Tested</code> &rarr; <code>Official candidate</code> &rarr; <code>Official</code> &rarr; <code>Deprecated</code>. Promotion always requires technical validation and maintainer review; raw vote counts never auto-promote a problem.</td>
+  <td>Catalog metadata + maintainer tooling</td>
+</tr>
+<tr>
+  <td><strong>Phase 5</strong><br>Optional Web3 attestations</td>
+  <td>Once Phase 1-4 have proven steady, layer attestations for problem version releases, event participation badges, contributor reputation badges, and sponsorship fulfilment records. Prefer non-transferable or reputation-style credentials to avoid speculation.</td>
+  <td>On-chain attestation contracts; opt-in for enterprise users</td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Non-goals</h2>
+
+<div class="nongoals-box">
+  <h3>Out of scope, by design</h3>
+  <ul>
+    <li><strong>No token.</strong> The community-curation layer must not launch or rely on a fungible token.</li>
+    <li><strong>No required wallet for enterprise users.</strong> Wallet login is one identity path among several; enterprise users participate without it.</li>
+    <li><strong>No vote-to-merge.</strong> Votes are signals, not merge authority; they never auto-merge a problem.</li>
+    <li><strong>No replacement of GitHub review.</strong> Maintainer review remains the quality gate.</li>
+    <li><strong>No leakage of private enterprise adoption.</strong> Private adoption signals stay private unless the organisation explicitly opts in.</li>
+    <li><strong>No full problem source on-chain.</strong> Only minimal public metadata (ids, titles, hashes, URLs) is on-chain; problem source stays in the catalog repo.</li>
+  </ul>
+</div>
+</section>
+
+<section>
+<h2>Key design constraints</h2>
+
+<ul>
+  <li><strong>Web3 optional, enterprise neutral.</strong> Web3 must be optional for enterprise usage. Enterprise users must be able to use TenkaCloud without wallets. Wallet-based participation may be interesting for community events, but it must not be a blocker for large enterprise buyers.</li>
+  <li><strong>Maintainer quality control wins.</strong> Voting must not override maintainer quality control. Sponsorship must not imply a problem is official without review.</li>
+  <li><strong>Quality, not spam.</strong> Contributor recognition should encourage quality contributions, not volume farming.</li>
+  <li><strong>Private adoption stays private.</strong> Private enterprise usage must be supported without leaking sensitive training themes.</li>
+  <li><strong>Minimal public metadata.</strong> The on-chain layer stores minimal public metadata only. Full problem source remains in GitHub / the catalog. On-chain records should reference immutable content hashes or commit hashes where possible.</li>
+</ul>
+</section>
+
+<section>
+<h2>Trade-offs</h2>
+
+<table>
+<thead>
+<tr><th>Trade-off</th><th>Position taken</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td>Minimal on-chain registry vs full on-chain voting</td>
+  <td>Start with a registry. Full voting can be added later, but premature on-chain governance risks locking the project into bad rules before the community is mature enough to refine them.</td>
+</tr>
+<tr>
+  <td>Public chain reads vs moderation</td>
+  <td>Embrace public reads for composability. Mitigate spam by allowlisting registration (or requiring a merged catalog entry) rather than by restricting reads.</td>
+</tr>
+<tr>
+  <td>Metadata mutability vs versioning</td>
+  <td>Treat each registered card as immutable. Material changes to a problem register a new version. Off-chain signals pinned to an old version remain valid for that version.</td>
+</tr>
+<tr>
+  <td>Web3 ownership vs enterprise friction</td>
+  <td>Keep wallet participation optional. The chain is composability infrastructure for the community, not a gate for enterprise users.</td>
+</tr>
+<tr>
+  <td>Sponsorship vs neutrality</td>
+  <td>Sponsorship can fund development but must never make the catalog pay-to-win or vendor-biased. Sponsored status is visible and separated from official quality status.</td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section>
+<h2>Open design questions</h2>
+
+<p>Out of scope for this ADR; tracked as follow-up issues so Phase 1-2 implementation can converge.</p>
+
+<ul>
+  <li><strong>Registration authority.</strong> Should on-chain registration be open to anyone, allowlisted to maintainers only, or gated by catalog merge status? Initial Phase 1 stance is maintainer-gated; opening it up is a separate decision.</li>
+  <li><strong>Registry shape.</strong> On-chain registry as a smart contract (which chain, which standard) vs a signed JSON registry artefact published to IPFS or a git repo with cryptographic provenance.</li>
+  <li><strong>Wallet identity model.</strong> Sign-In-With-Ethereum, SIWS (Solana), Discord, or GitHub as the wallet-binding flow; how a single contributor maps across identities.</li>
+  <li><strong>Off-chain storage backend.</strong> Where <code>ProblemVote</code> / <code>ProblemAdoption</code> / <code>ProblemSponsorshipInterest</code> live (catalog-side service vs platform-side service) and the abuse-prevention layer.</li>
+  <li><strong>Visibility defaults.</strong> Default visibility for adoption and sponsorship records; how anonymous records affect aggregate counts.</li>
+  <li><strong>Phase 4 promotion thresholds.</strong> The concrete signal mix that lets a problem progress through <code>Community requested</code> &rarr; <code>Tested</code> &rarr; <code>Official candidate</code>, without making counts authoritative.</li>
+</ul>
+</section>
+
+<section>
+<h2>Impact</h2>
+
+<table>
+<thead>
+<tr><th>Surface</th><th>Impact</th></tr>
+</thead>
+<tbody>
+<tr><td>CDK stacks (Control Plane / App Plane / Problem Deploy)</td><td>No change. The community-signal layer is an additional surface, not a replacement for any plane.</td></tr>
+<tr><td>Drill runtime (per-team deployment, scoring engine, Trust Bridge)</td><td>No change. Voting / adoption / sponsorship records do not enter the scoring or deployment paths.</td></tr>
+<tr><td>Plugin contract (<a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>)</td><td>No change. The 3-asset model (metadata.json + template.yaml + portal/) is unchanged; community signals are catalog-level, not problem-level.</td></tr>
+<tr><td>Catalog repo</td><td>Phase 0 adds labels. Phase 3 reads on-chain and off-chain signals to render catalog UI. Catalog problem schema (<code>problems/SCHEMA.json</code>) is unchanged for Phases 0-2.</td></tr>
+<tr><td>Platform identity / auth (Cognito, GitHub OAuth)</td><td>No change for enterprise users. Wallet identity, if introduced, is an additional optional path bound to an existing account.</td></tr>
+<tr><td>Compliance posture</td><td>Wallet-free participation is preserved end-to-end. No token is launched. Enterprise tenants can disable any Web3 surface in their UI.</td></tr>
+</tbody>
+</table>
+
+<p>No code changes ship with this ADR. Phase 1 onwards each land as separate PRs with their own architecture and security reviews.</p>
+</section>
+
+<section>
+<h2>References</h2>
+
+<ul>
+  <li><a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>: Problem plugin architecture (problem = plugin, platform = host)</li>
+  <li><a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a>: Cloud Action Intent / Trust Bridge (multi-cloud authority transfer)</li>
+  <li><a href="./adr-022-inter-team-coordination-plugin.html">ADR-022</a>: Inter-team coordination plugin contract</li>
+  <li><a href="https://github.com/susumutomita/TenkaCloud/issues/1269">Issue #1269</a>: Design community voting and sponsorship model for problem catalog growth</li>
+</ul>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- ADR-024 documents the chosen design from #1269: a minimal on-chain `ProblemCard` registry (Phase 1) paired with off-chain `ProblemVote` / `ProblemAdoption` / `ProblemSponsorshipInterest` records (Phase 2).
- Hybrid progressive model. Web3 is an optional surface; enterprise users never need wallets.
- No token, no vote-to-merge, no replacement of GitHub maintainer review.

Closes #1269

## Regression analysis

Documentation-only change. No code, schema, runtime, infrastructure, or build configuration is modified.

- No CDK stacks change &rarr; no CloudFormation drift, no resource churn, no deploy-time behaviour change.
- No Lambda handler, scoring engine, plugin contract, or portal API change &rarr; no runtime regression surface.
- No catalog metadata, schema, or validator change &rarr; existing problems remain valid.
- No package dependency change &rarr; no supply chain / install-time surface.
- ADR self-contained harness rule passes (0 findings); `make before-commit` passes end-to-end (lint, typecheck, all 6 workspace test suites, validate-problems, template + CFn-ref + ASCII + security checks, audit-deps, cdk synth).

Decision is forward-looking: Phases 1-5 each land as separate PRs with their own architecture and security reviews. This ADR creates no implementation obligation in any other PR currently in flight.

## Physical impact

| Surface | Change |
| --- | --- |
| CloudFormation templates (all stacks) | NO-OP |
| Lambda handlers / scoring engine | NO-OP |
| Catalog schema (`problems/SCHEMA.json`) | NO-OP |
| Plugin contract (ADR-012 3-asset model) | NO-OP |
| Frontend SPAs (`apps/*`) | NO-OP |
| Identity / auth (Cognito, OAuth) | NO-OP |
| `docs/architecture/adr-024-community-voting-and-problem-registry.html` | CREATE (new file, 447 lines, self-contained HTML ADR) |

No bundled Lambda artefact diff; no `cdk diff` delta on any stack.

## Test plan

- [x] `make harness` &mdash; 0 findings (ADR self-contained rule passes)
- [x] `make before-commit` &mdash; all gates green (lint, format, all workspace tests, validate-problems, template checks, audit-deps, cdk synth)
- [x] ADR renders correctly in browser (HTML + SVG data-flow diagram + colored decision / non-goals callouts + 5-column options table)
- [ ] Reviewer confirms the Decision callout, options table, phased roadmap, and non-goals match the intent of #1269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record detailing a hybrid community curation model for voting and problem registry, including phased implementation approach, data models, and design specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->