### PR TITLE
fix(ci): upload coverage on main push so codecov has a BASE report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,14 @@ permissions:
   actions: read
 
 on:
+  # PR-time: lint / typecheck / test / build を走らせて regression を block
   pull_request:
+  # main への commit / merge 時にも走らせて codecov に BASE coverage を upload する。
+  # これがないと PR diff の coverage delta が "missing BASE report" になり、
+  # 「modified lines are covered」しか出ない (= 数値比較ができない)。
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Previously `.github/workflows/ci.yml` only ran on `pull_request:`, so commits/merges to main never produced a coverage upload. Codecov then reported **"Please upload report for BASE (main@<sha>)"** on every PR — the diff was checked but no delta vs. main was shown.

Add `push: branches: [main]` so the same `make test-coverage` job runs on main commits and uploads `lcov.info` to codecov. PR comments now have a BASE to compare against.

Closes the codecov "missing BASE report" noise that's appeared on every PR since the test-coverage target was introduced (#993).

## Regression analysis

- Pure CI trigger expansion. Same job runs on main push that already runs on PRs — exact same `make` targets, same secret, same artifact list.
- No behavior change for PR runs.
- Compute cost: one additional CI run per main commit (~10 min); the codecov upload is the goal.

## Physical impact

- NO-OP for CFn / Lambda / catalog / app code.
- UPDATE: `.github/workflows/ci.yml` adds `push.branches: [main]` trigger.
- AFTER merge: the first main commit triggers the coverage upload. Subsequent PR runs will show coverage delta vs. that BASE.