### PR TITLE
feat(deploy): runtime-aware adapter (AWS-CFn impl preserves current behavior) — #1268

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -8,10 +8,11 @@ import { parseProblemsCatalog } from "../shared/catalog.js";
 import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
-  type DeployCreateRequestedDetail,
-  EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
-  publishProblemEvent,
-} from "../shared/events.js";
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  type ProblemRuntime,
+  selectAdapter,
+} from "../shared/runtime/index.js";
 import { logDeployTrace } from "../shared/trace-log.js";
 import { emitShadowAudit } from "../shared/trust-bridge-shadow.js";
 import {
@@ -54,6 +55,16 @@ export interface DeployContext {
   readonly problemsVisibility?: Readonly<Record<string, PrivateVisibility>>;
   readonly challengePayloadBucket?: string;
   readonly s3?: S3Client;
+  /**
+   * [ADR-023 / Issue #1268] Optional per-problemId runtime resolver. If
+   * undefined OR if it returns undefined for a given problemId, the deploy
+   * worker assumes `aws/cloudformation` — which preserves pre-#1268 behavior
+   * exactly (every problem in the catalog today is CFn-backed).
+   *
+   * Tests pin this to assert that an `azure/bicep` problem is rejected with
+   * `RuntimeNotSupportedError` BEFORE any DDB Put / EventBridge publish runs.
+   */
+  readonly resolveProblemRuntime?: (problemId: string) => ProblemRuntime | undefined;
 }
 
 export type DeployInvocation = DeployRequest & {
@@ -95,6 +106,21 @@ export async function startDeployment(
 ): Promise<DeployResponse> {
   const problemDir = ctx.problemsCatalog[request.problemId];
   if (!problemDir) throw new UnknownProblemError(request.problemId);
+
+  // [ADR-023 / Issue #1268] Resolve runtime BEFORE any cloud mutation. Default
+  // is aws/cloudformation (= the only registered adapter today), which keeps
+  // legacy problems and explicit `runtime: aws/cloudformation` declarations on
+  // the exact same path. A mismatched runtime (e.g. azure/bicep) raises
+  // `RuntimeNotSupportedError` here — pre-DDB-Put / pre-EventBridge — so the
+  // platform never half-creates an AWS-shaped artifact for a non-AWS problem.
+  const runtime: ProblemRuntime = ctx.resolveProblemRuntime?.(request.problemId) ?? {
+    provider: EXECUTABLE_PROVIDER,
+    engine: EXECUTABLE_ENGINE,
+    entry: "template.yaml",
+  };
+  const adapter = selectAdapter(runtime, {
+    aws: { events: ctx.events, eventBusName: ctx.eventBusName },
+  });
 
   // Phase 2.2 (Issue #459): verified=true な行が無ければ deploy しない (= fail-closed)。
   // 同 account deploy の dev fallback も廃止 — 全 deploy は verified なれた account のみ。
@@ -171,23 +197,6 @@ export async function startDeployment(
     });
   }
 
-  const detail: DeployCreateRequestedDetail = {
-    jobId: item.jobId,
-    correlationId: item.jobId,
-    tenantId: item.tenantId,
-    problemId: item.problemId,
-    problemDir,
-    teamSlug,
-    namePrefix: item.namePrefix,
-    region: item.region,
-    awsAccountId: item.awsAccountId,
-    // Phase 2.2: AssumeRole 用 metadata。`resolveVerifiedCompetitorAccount` の戻り値から
-    // そのまま詰める。CodeBuild script (deploy-battles.sh wrapper) が SSM ExternalId を
-    // fetch して AssumeRole する。
-    competitorRoleArn: verified.competitorRoleArn,
-    externalIdParameterName: verified.externalIdParameterName,
-    ...(challengePayloadUrl ? { challengePayloadUrl } : {}),
-  };
   // Issue #795 ADR-017 Phase 3 (shadow integration): 既存 deploy flow を変更せず、
   // CloudActionIntent を構築 + audit log を CloudWatch に emit する。 失敗系も
   // fail-open (= 既存の publishProblemEvent / DDB Put には影響を与えない)。
@@ -210,12 +219,25 @@ export async function startDeployment(
     ],
   });
   try {
-    await publishProblemEvent({
-      client: ctx.events,
-      busName: ctx.eventBusName,
-      detailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+    // [ADR-023 / Issue #1268] dispatch via runtime adapter. For AWS / CFn (=
+    // the only registered adapter today) this is byte-for-byte the same
+    // `publishProblemEvent` the legacy inline code did — see
+    // `AwsCloudFormationRuntimeAdapter.deploy`. No new IAM, no new SDK calls.
+    await adapter.deploy({
       jobId,
-      detail,
+      correlationId: jobId,
+      tenantId: item.tenantId,
+      problemId: item.problemId,
+      problemDir,
+      teamSlug,
+      namePrefix: item.namePrefix,
+      region: item.region,
+      awsAccountId: item.awsAccountId,
+      ...(verified.competitorRoleArn ? { competitorRoleArn: verified.competitorRoleArn } : {}),
+      ...(verified.externalIdParameterName
+        ? { externalIdParameterName: verified.externalIdParameterName }
+        : {}),
+      ...(challengePayloadUrl ? { challengePayloadUrl } : {}),
     });
   } catch (err) {
     try {

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -4,6 +4,7 @@ import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import { ULID_RE as JOB_ID_RE, PROBLEM_ID_RE } from "../shared/constants.js";
+import { RuntimeNotSupportedError } from "../shared/runtime/index.js";
 import {
   ForbiddenRoleError,
   MissingTenantClaimError,
@@ -172,6 +173,21 @@ app.post("/problems/:problemId/deploy", async (c) => {
           awsAccountId: err.awsAccountId,
           message:
             "AWS Account ID が CompetitorAccounts table で verified=true 状態でないため deploy できません。",
+        },
+        StatusCodes.UNPROCESSABLE_ENTITY,
+      );
+    }
+    // [ADR-023 / Issue #1268] Problem metadata declared a runtime we cannot
+    // execute today (e.g. azure/bicep). 422: request is well-formed, but the
+    // business invariant "platform has an adapter for this provider/engine" is
+    // not satisfied. No cloud mutation happens on this path.
+    if (err instanceof RuntimeNotSupportedError) {
+      return c.json(
+        {
+          error: "runtime_not_supported",
+          provider: err.runtime.provider,
+          engine: err.runtime.engine,
+          message: err.message,
         },
         StatusCodes.UNPROCESSABLE_ENTITY,
       );

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * [ADR-023 / Issue #1268] Problem runtime adapter abstraction.
+ *
+ * Today the deploy worker is hard-wired to AWS / CloudFormation: it publishes a
+ * `DeployCreateRequested` event, the Step Functions state machine fans out to
+ * CodeBuild, and CodeBuild runs `aws cloudformation deploy` in the competitor
+ * account. That path is correct for AWS-only problems.
+ *
+ * Per ADR-023 we will eventually support provider-specific problems (Azure /
+ * GCP / Kubernetes) bound to the same deploy backend. To avoid bolting
+ * provider switches into the deploy handler, the deploy path resolves a
+ * `ProblemRuntimeAdapter` from the problem's normalized runtime descriptor.
+ *
+ * Phase 1 (this issue): the only registered adapter is
+ * `AwsCloudFormationRuntimeAdapter`. It wraps the existing
+ * `publishProblemEvent` flow byte-for-byte. Any other normalized runtime is
+ * rejected via `RuntimeNotSupportedError` BEFORE any cloud mutation, so a
+ * mis-shipped Azure problem cannot create a stack-shaped artifact in AWS.
+ *
+ * Phase 2+ will introduce new adapters without changing this interface.
+ */
+
+/**
+ * Coarse runtime status. Provider-specific statuses (e.g. CFn
+ * `CREATE_IN_PROGRESS` / `UPDATE_ROLLBACK_FAILED`) must be projected onto this
+ * 6-state enum by each adapter so callers outside the runtime layer do not
+ * branch on provider terminology.
+ *
+ * Mapping examples for AWS / CloudFormation:
+ *   - `pending`     — pre-AssumeRole, before CFn knows about the stack
+ *   - `deploying`   — CREATE_IN_PROGRESS / UPDATE_IN_PROGRESS
+ *   - `ready`       — CREATE_COMPLETE / UPDATE_COMPLETE
+ *   - `failed`      — CREATE_FAILED / ROLLBACK_COMPLETE / UPDATE_ROLLBACK_*
+ *   - `destroying`  — DELETE_IN_PROGRESS
+ *   - `destroyed`   — DELETE_COMPLETE / stack not found
+ */
+export type RuntimeStatus =
+  | "pending"
+  | "deploying"
+  | "ready"
+  | "failed"
+  | "destroying"
+  | "destroyed";
+
+/**
+ * Normalized runtime descriptor. Mirrors the metadata-level descriptor in
+ * `scripts/problem-cli/problem-loader.ts` so the same problem produces the
+ * same shape regardless of who reads it. Lambda-local copy because the Lambda
+ * bundle must not depend on `scripts/`.
+ */
+export interface ProblemRuntime {
+  readonly provider: string;
+  readonly engine: string;
+  readonly entry: string;
+}
+
+/**
+ * Inputs for `adapter.deploy(...)`. Kept narrow on purpose; adapter
+ * implementations should not reach back into Lambda env / SDK clients
+ * directly — everything flows through this object so unit tests can pin it.
+ */
+export interface RuntimeDeployInput {
+  readonly jobId: string;
+  readonly correlationId: string;
+  readonly tenantId: string;
+  readonly problemId: string;
+  readonly problemDir: string;
+  readonly teamSlug: string;
+  readonly namePrefix: string;
+  readonly region: string;
+  readonly awsAccountId: string;
+  /** Cross-account AssumeRole target. AWS adapter only. */
+  readonly competitorRoleArn?: string;
+  /** SSM SecureString path. AWS adapter only. */
+  readonly externalIdParameterName?: string;
+  /** ADR-008: optional presigned URL for private problem payloads. */
+  readonly challengePayloadUrl?: string;
+}
+
+/** Adapter-side outcome of `deploy`. */
+export interface RuntimeDeployResult {
+  /** Coarse normalized status reflecting the post-call state. */
+  readonly status: RuntimeStatus;
+}
+
+export interface RuntimeCollectOutputsInput {
+  readonly jobId: string;
+  readonly namePrefix: string;
+  readonly region: string;
+  readonly awsAccountId: string;
+}
+
+/**
+ * Provider-independent map of deploy outputs (e.g. endpoint URLs / flag
+ * values). AWS adapter maps CloudFormation Outputs into this map; future
+ * adapters do the analogous projection.
+ */
+export type RuntimeOutputs = Readonly<Record<string, string>>;
+
+export interface RuntimeStatusInput {
+  readonly jobId: string;
+  readonly namePrefix: string;
+  readonly region: string;
+  readonly awsAccountId: string;
+}
+
+export interface RuntimeDestroyInput {
+  readonly jobId: string;
+  readonly namePrefix: string;
+  readonly region: string;
+  readonly awsAccountId: string;
+  readonly competitorRoleArn?: string;
+  readonly externalIdParameterName?: string;
+}
+
+export interface RuntimeDestroyResult {
+  readonly status: RuntimeStatus;
+}
+
+/**
+ * Problem runtime adapter. Implementations represent one
+ * `<provider>/<engine>` pair. Only AWS / CloudFormation is registered today.
+ *
+ * The interface is intentionally small (deploy / collectOutputs / getStatus /
+ * destroy) so contributors do not infer that the platform is provider-aware
+ * beyond what ADR-023 promises. Anything richer should be added in a separate
+ * PR with the matching ADR amendment.
+ */
+export interface ProblemRuntimeAdapter {
+  readonly provider: string;
+  readonly engine: string;
+
+  deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult>;
+  collectOutputs(input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs>;
+  getStatus(input: RuntimeStatusInput): Promise<RuntimeStatus>;
+  destroy(input: RuntimeDestroyInput): Promise<RuntimeDestroyResult>;
+}
+
+/**
+ * Thrown when a problem's normalized runtime has no registered adapter — i.e.
+ * the metadata declares e.g. `azure/bicep` but the platform only knows
+ * `aws/cloudformation` today.
+ *
+ * This is a LOUD failure on purpose. Per AGENTS.md "no silent fallbacks": we
+ * never substitute a different adapter, we never quietly degrade. The
+ * deploy-handler converts this to an HTTP 4xx so the operator sees the
+ * mismatch before any cloud mutation runs.
+ */
+export class RuntimeNotSupportedError extends Error {
+  constructor(public readonly runtime: ProblemRuntime) {
+    super(
+      `Runtime ${runtime.provider}/${runtime.engine} is recognized by metadata but not executable in this platform version. ` +
+        `Only aws/cloudformation is supported today (ADR-023 D4).`,
+    );
+    this.name = "RuntimeNotSupportedError";
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/aws-cfn-adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/aws-cfn-adapter.ts
@@ -1,0 +1,118 @@
+/**
+ * [ADR-023 / Issue #1268] AWS CloudFormation runtime adapter.
+ *
+ * Wraps the existing AWS-only deploy behavior so callers can resolve a
+ * `ProblemRuntimeAdapter` and call `.deploy(...)` without knowing this is the
+ * CFn path. This is a behavior-preserving abstraction: the adapter calls the
+ * same `publishProblemEvent` with the same shape that pre-#1268 code did, so
+ * the downstream Step Functions / CodeBuild pipeline is untouched.
+ *
+ * Phase 1 scope (this issue):
+ *   - `deploy`: publish `DeployCreateRequested` to EventBridge. Identical to
+ *     the legacy inline call in `deploy.ts`.
+ *   - `collectOutputs` / `getStatus` / `destroy`: not wired in this PR.
+ *     Existing call sites (`describe-stack-handler`, `delete.ts`) keep using
+ *     their direct CFn SDK calls. The methods exist on the interface so
+ *     future adapters can be drop-in; here they throw a clearly named
+ *     `AdapterMethodNotWiredError` if someone tries to use them via the
+ *     adapter before the matching follow-up PR lands.
+ *
+ * Why partial wiring is OK now: the interface is the seam, not the migration
+ * lever. Migrating existing call sites onto the adapter is its own PR with
+ * its own regression analysis; bundling it into the abstraction PR would
+ * violate INVARIANT_PR_SHIPS_WORKING_INCREMENT.
+ */
+
+import type { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import {
+  type DeployCreateRequestedDetail,
+  EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+  publishProblemEvent,
+} from "../events.js";
+import type {
+  ProblemRuntimeAdapter,
+  RuntimeCollectOutputsInput,
+  RuntimeDeployInput,
+  RuntimeDeployResult,
+  RuntimeDestroyInput,
+  RuntimeDestroyResult,
+  RuntimeOutputs,
+  RuntimeStatus,
+  RuntimeStatusInput,
+} from "./adapter.js";
+import { EXECUTABLE_ENGINE, EXECUTABLE_PROVIDER } from "./normalize.js";
+
+/**
+ * Resources injected by the deploy handler when constructing the adapter.
+ * Mirrors the slice of `DeployContext` the existing publish-event path uses.
+ */
+export interface AwsCloudFormationAdapterContext {
+  readonly events: EventBridgeClient;
+  readonly eventBusName: string;
+}
+
+/**
+ * Thrown when an adapter method that exists on the interface but is not
+ * wired into this adapter is called. Today: `collectOutputs` / `getStatus` /
+ * `destroy`. We throw loudly rather than silently no-oping (= AGENTS.md "no
+ * silent fallbacks via mocks / stubs / empty-array returns").
+ */
+export class AdapterMethodNotWiredError extends Error {
+  constructor(method: string) {
+    super(
+      `AwsCloudFormationRuntimeAdapter.${method} is not wired in Phase 1 (Issue #1268). ` +
+        `Existing handlers must keep using their direct CloudFormation SDK calls until the ` +
+        `migration PR lands. See ADR-023 D6.`,
+    );
+    this.name = "AdapterMethodNotWiredError";
+  }
+}
+
+export class AwsCloudFormationRuntimeAdapter implements ProblemRuntimeAdapter {
+  public readonly provider = EXECUTABLE_PROVIDER;
+  public readonly engine = EXECUTABLE_ENGINE;
+
+  constructor(private readonly ctx: AwsCloudFormationAdapterContext) {}
+
+  async deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult> {
+    // Build the legacy detail shape unchanged. Behavior preservation requires
+    // that downstream consumers (`DeployCreateStateMachine`, CodeBuild scripts)
+    // see exactly the same field set as before the adapter existed.
+    const detail: DeployCreateRequestedDetail = {
+      jobId: input.jobId,
+      correlationId: input.correlationId,
+      tenantId: input.tenantId,
+      problemId: input.problemId,
+      problemDir: input.problemDir,
+      teamSlug: input.teamSlug,
+      namePrefix: input.namePrefix,
+      region: input.region,
+      awsAccountId: input.awsAccountId,
+      ...(input.competitorRoleArn ? { competitorRoleArn: input.competitorRoleArn } : {}),
+      ...(input.externalIdParameterName
+        ? { externalIdParameterName: input.externalIdParameterName }
+        : {}),
+      ...(input.challengePayloadUrl ? { challengePayloadUrl: input.challengePayloadUrl } : {}),
+    };
+    await publishProblemEvent({
+      client: this.ctx.events,
+      busName: this.ctx.eventBusName,
+      detailType: EVENT_DETAIL_TYPE_DEPLOY_CREATE_REQUESTED,
+      jobId: input.jobId,
+      detail,
+    });
+    return { status: "pending" };
+  }
+
+  async collectOutputs(_input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs> {
+    throw new AdapterMethodNotWiredError("collectOutputs");
+  }
+
+  async getStatus(_input: RuntimeStatusInput): Promise<RuntimeStatus> {
+    throw new AdapterMethodNotWiredError("getStatus");
+  }
+
+  async destroy(_input: RuntimeDestroyInput): Promise<RuntimeDestroyResult> {
+    throw new AdapterMethodNotWiredError("destroy");
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
@@ -1,0 +1,34 @@
+/**
+ * [ADR-023 / Issue #1268] Runtime adapter package barrel.
+ *
+ * Public entrypoints used by the deploy handler and tests. Keep this re-export
+ * surface minimal so future adapters slot in via `selectAdapter` only and do
+ * not leak provider-specific types into the rest of the handler code.
+ */
+
+export type {
+  ProblemRuntime,
+  ProblemRuntimeAdapter,
+  RuntimeCollectOutputsInput,
+  RuntimeDeployInput,
+  RuntimeDeployResult,
+  RuntimeDestroyInput,
+  RuntimeDestroyResult,
+  RuntimeOutputs,
+  RuntimeStatus,
+  RuntimeStatusInput,
+} from "./adapter.js";
+export { RuntimeNotSupportedError } from "./adapter.js";
+export {
+  AdapterMethodNotWiredError,
+  type AwsCloudFormationAdapterContext,
+  AwsCloudFormationRuntimeAdapter,
+} from "./aws-cfn-adapter.js";
+export {
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  isExecutableRuntime,
+  normalizeRuntime,
+  type RuntimeMetadataInput,
+} from "./normalize.js";
+export { type AdapterDependencies, selectAdapter } from "./registry.js";

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/normalize.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/normalize.ts
@@ -1,0 +1,71 @@
+/**
+ * [ADR-023 / Issue #1268] Runtime normalization for the deploy worker side.
+ *
+ * Mirrors `scripts/problem-cli/problem-loader.ts#normalizeRuntime` but lives
+ * inside the Lambda bundle. The Lambda must not import from `scripts/` (=
+ * separate workspace, separate tsconfig, different bundling target), so the
+ * normalization rules are duplicated by design.
+ *
+ * Rules (kept in lock-step with `validate-problems` / `problem-cli`):
+ *   1. An explicit `runtime` block on `metadata.json` wins. It must declare
+ *      provider / engine / entry all as strings, otherwise the input is
+ *      malformed and we return `undefined` (caller throws).
+ *   2. Legacy problems (only `cfnTemplate` declared) are normalized to
+ *      `aws / cloudformation / <cfnTemplate>` — this is the back-compat path.
+ *   3. The very last fallback is `aws / cloudformation / template.yaml` so
+ *      future scaffolding never blows up before the validator runs.
+ *
+ * Consistency between `runtime.entry` and `cfnTemplate` is NOT checked here —
+ * that lives in `scripts/problem-cli/validate.ts` and runs at PR time. By
+ * deploy time, validate-problems has already passed, so the deploy handler
+ * trusts the descriptor as-is.
+ */
+
+import type { ProblemRuntime } from "./adapter.js";
+
+export const EXECUTABLE_PROVIDER = "aws" as const;
+export const EXECUTABLE_ENGINE = "cloudformation" as const;
+
+/**
+ * Loose metadata shape. We accept `Record<string, unknown>` because the
+ * Lambda parses metadata coming from EventBridge / catalog payloads that have
+ * already been JSON.parsed — we cannot assume a Zod schema upfront here.
+ */
+export type RuntimeMetadataInput = {
+  readonly runtime?: unknown;
+  readonly cfnTemplate?: unknown;
+};
+
+/**
+ * Normalize a problem's runtime descriptor. Returns `undefined` only when an
+ * explicit `runtime` block is present but malformed (= missing provider /
+ * engine / entry, or wrong types). Callers should treat `undefined` as a
+ * loud failure (the input is unparseable, not a missing default).
+ */
+export function normalizeRuntime(meta: RuntimeMetadataInput): ProblemRuntime | undefined {
+  const runtime = meta.runtime as Record<string, unknown> | undefined;
+  if (runtime !== undefined && runtime !== null) {
+    if (
+      typeof runtime.provider !== "string" ||
+      typeof runtime.engine !== "string" ||
+      typeof runtime.entry !== "string"
+    ) {
+      return undefined;
+    }
+    return {
+      provider: runtime.provider,
+      engine: runtime.engine,
+      entry: runtime.entry,
+    };
+  }
+  const cfnTemplate = typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+  return {
+    provider: EXECUTABLE_PROVIDER,
+    engine: EXECUTABLE_ENGINE,
+    entry: cfnTemplate,
+  };
+}
+
+export function isExecutableRuntime(runtime: ProblemRuntime): boolean {
+  return runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE;
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
@@ -1,0 +1,41 @@
+/**
+ * [ADR-023 / Issue #1268] Adapter registry / selector.
+ *
+ * Maps a normalized `ProblemRuntime` to the concrete adapter that knows how
+ * to drive that provider/engine. Phase 1: only `aws/cloudformation` is
+ * registered. Any other combination throws `RuntimeNotSupportedError`.
+ *
+ * The registry is intentionally not a public map (= no module-level
+ * `register(adapter)` API) because:
+ *   - Phase 1 has exactly one adapter; a Map would be over-engineering.
+ *   - Adding a second adapter is its own PR with its own ADR amendment, at
+ *     which point we revisit the data structure.
+ *   - A static switch makes the supported set greppable / auditable.
+ */
+
+import type { ProblemRuntime, ProblemRuntimeAdapter } from "./adapter.js";
+import { RuntimeNotSupportedError } from "./adapter.js";
+import {
+  type AwsCloudFormationAdapterContext,
+  AwsCloudFormationRuntimeAdapter,
+} from "./aws-cfn-adapter.js";
+import { EXECUTABLE_ENGINE, EXECUTABLE_PROVIDER } from "./normalize.js";
+
+/**
+ * Dependencies any adapter might need. Phase 1 only uses the AWS subset; the
+ * shape is open so future adapters (Azure ARM client, kubectl client, etc.)
+ * can be added without changing this signature.
+ */
+export interface AdapterDependencies {
+  readonly aws: AwsCloudFormationAdapterContext;
+}
+
+export function selectAdapter(
+  runtime: ProblemRuntime,
+  deps: AdapterDependencies,
+): ProblemRuntimeAdapter {
+  if (runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE) {
+    return new AwsCloudFormationRuntimeAdapter(deps.aws);
+  }
+  throw new RuntimeNotSupportedError(runtime);
+}

--- a/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
@@ -1,0 +1,157 @@
+/**
+ * [ADR-023 / Issue #1268] Integration tests for runtime-aware deploy
+ * dispatch in `startDeployment`.
+ *
+ * What we assert:
+ *   1. Legacy problems (no resolver injected) deploy on the AWS/CFn path
+ *      exactly as before — same EventBridge detail shape, no extra calls.
+ *   2. Explicit `runtime: aws/cloudformation` problems deploy on the same
+ *      path with identical observable behavior.
+ *   3. Unsupported runtimes (azure/bicep) throw `RuntimeNotSupportedError`
+ *      BEFORE any DDB Put or EventBridge publish — = no cloud mutation.
+ */
+
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DeployContext,
+  type DeployInvocation,
+  startDeployment,
+} from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
+import {
+  type ProblemRuntime,
+  RuntimeNotSupportedError,
+} from "../../lib/problem-deploy/handlers/shared/runtime/index";
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/presigned-url", () => ({
+  generateChallengePayloadUrl: vi.fn(async () => "https://example.invalid/fake.zip"),
+}));
+
+function buildContext(overrides: Partial<DeployContext> = {}): {
+  ctx: DeployContext;
+  putSend: ReturnType<typeof vi.fn>;
+  eventsSend: ReturnType<typeof vi.fn>;
+} {
+  const putSend = vi.fn().mockResolvedValue({});
+  const eventsSend = vi.fn().mockResolvedValue({});
+  const ddbSend = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand && cmd.input.TableName === "TestCompetitorAccounts") {
+      const sk = String(cmd.input.Key?.SK ?? "");
+      const awsAccountId = sk.replace(/^ACCOUNT#/, "");
+      return {
+        Item: {
+          PK: cmd.input.Key?.PK,
+          SK: cmd.input.Key?.SK,
+          awsAccountId,
+          region: "ap-northeast-1",
+          competitorRoleName: "TenkaCloud-CompetitorDeploy-Role",
+          verified: true,
+        },
+      };
+    }
+    return putSend(cmd);
+  });
+  const ctx: DeployContext = {
+    tableName: "TestDeployments",
+    competitorAccountsTableName: "TestCompetitorAccounts",
+    env: "development",
+    eventBusName: "test-bus",
+    ddb: { send: ddbSend } as unknown as DeployContext["ddb"],
+    events: { send: eventsSend } as unknown as DeployContext["events"],
+    now: () => 1_700_000_000_000,
+    ttlMs: 60_000,
+    tenantId: "tenant-acme",
+    problemsCatalog: {
+      "hello-world": "problems/challenges/hello-world",
+      "azure-only-problem": "problems/challenges/azure-only-problem",
+    },
+    ...overrides,
+  };
+  return { ctx, putSend, eventsSend };
+}
+
+const sampleRequest = (overrides: Partial<DeployInvocation> = {}): DeployInvocation => ({
+  problemId: "hello-world",
+  region: "ap-northeast-1",
+  awsAccountId: "123456789012",
+  teamName: "Alpha Team",
+  ...overrides,
+});
+
+describe("startDeployment with runtime-aware dispatch (ADR-023 / Issue #1268)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should deploy legacy problems exactly as before when no resolver is injected", async () => {
+    const { ctx, putSend, eventsSend } = buildContext();
+    const res = await startDeployment(ctx, sampleRequest());
+    expect(res.status).toBe("PENDING");
+    // 1 PutCommand for the deployment row
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(true);
+    // 1 PutEventsCommand for DeployCreateRequested
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const detail = JSON.parse(eventsSend.mock.calls[0]?.[0]?.input?.Entries?.[0]?.Detail ?? "{}");
+    expect(detail.problemId).toBe("hello-world");
+    expect(detail.problemDir).toBe("problems/challenges/hello-world");
+  });
+
+  it("should deploy an explicit aws/cloudformation problem on the same path", async () => {
+    const explicitRuntime: ProblemRuntime = {
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    };
+    const { ctx, putSend, eventsSend } = buildContext({
+      resolveProblemRuntime: (problemId) =>
+        problemId === "hello-world" ? explicitRuntime : undefined,
+    });
+    const res = await startDeployment(ctx, sampleRequest());
+    expect(res.status).toBe("PENDING");
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(true);
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const detail = JSON.parse(eventsSend.mock.calls[0]?.[0]?.input?.Entries?.[0]?.Detail ?? "{}");
+    // Same shape as the legacy path — no provider/engine fields leak into the
+    // detail (= byte-for-byte compat for the State Machine input transformer).
+    expect(detail.problemId).toBe("hello-world");
+    expect(detail.problemDir).toBe("problems/challenges/hello-world");
+    expect(detail).not.toHaveProperty("provider");
+    expect(detail).not.toHaveProperty("engine");
+  });
+
+  it("should throw RuntimeNotSupportedError BEFORE any DDB Put / EventBridge publish for azure/bicep", async () => {
+    const azureRuntime: ProblemRuntime = {
+      provider: "azure",
+      engine: "bicep",
+      entry: "main.bicep",
+    };
+    const { ctx, putSend, eventsSend } = buildContext({
+      resolveProblemRuntime: (problemId) =>
+        problemId === "azure-only-problem" ? azureRuntime : undefined,
+    });
+
+    await expect(
+      startDeployment(ctx, sampleRequest({ problemId: "azure-only-problem" })),
+    ).rejects.toBeInstanceOf(RuntimeNotSupportedError);
+
+    // No DDB Put — the deployment row must not exist.
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(false);
+    // No EventBridge publish — the State Machine never sees this.
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("should not call CompetitorAccounts lookup either when the runtime is unsupported", async () => {
+    // Runtime gate happens FIRST so we save even the read-only DDB Get round-trip.
+    const k8sRuntime: ProblemRuntime = {
+      provider: "kubernetes",
+      engine: "helm",
+      entry: "Chart.yaml",
+    };
+    const { ctx } = buildContext({
+      resolveProblemRuntime: () => k8sRuntime,
+    });
+    const ddbSendSpy = vi.spyOn(ctx.ddb, "send");
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toBeInstanceOf(
+      RuntimeNotSupportedError,
+    );
+    expect(ddbSendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/infrastructure/test/problem-deploy/runtime-adapter.test.ts
+++ b/infrastructure/test/problem-deploy/runtime-adapter.test.ts
@@ -1,0 +1,278 @@
+/**
+ * [ADR-023 / Issue #1268] Unit tests for the runtime adapter abstraction.
+ *
+ * Coverage:
+ *   - `normalizeRuntime`: legacy `cfnTemplate` → aws/cloudformation, explicit
+ *     `runtime` block parses through, malformed `runtime` returns undefined.
+ *   - `selectAdapter`: aws/cloudformation resolves to
+ *     `AwsCloudFormationRuntimeAdapter`; any other combination throws
+ *     `RuntimeNotSupportedError` (= LOUD failure, no fallback).
+ *   - `AwsCloudFormationRuntimeAdapter.deploy`: publishes the same
+ *     `DeployCreateRequested` shape the legacy inline call did (behavior
+ *     preservation).
+ *   - Stub methods (`collectOutputs` / `getStatus` / `destroy`) throw
+ *     `AdapterMethodNotWiredError` until the migration PR.
+ */
+
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AdapterMethodNotWiredError,
+  AwsCloudFormationRuntimeAdapter,
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  isExecutableRuntime,
+  normalizeRuntime,
+  type ProblemRuntime,
+  RuntimeNotSupportedError,
+  selectAdapter,
+} from "../../lib/problem-deploy/handlers/shared/runtime/index";
+
+describe("normalizeRuntime", () => {
+  it("should normalize a legacy cfnTemplate-only problem to aws/cloudformation", () => {
+    const out = normalizeRuntime({ cfnTemplate: "template.yaml" });
+    expect(out).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    });
+  });
+
+  it("should pass through an explicit aws/cloudformation runtime block", () => {
+    const out = normalizeRuntime({
+      runtime: { provider: "aws", engine: "cloudformation", entry: "template.yaml" },
+      cfnTemplate: "template.yaml",
+    });
+    expect(out).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    });
+  });
+
+  it("should return the explicit runtime even when provider/engine is non-AWS", () => {
+    // normalization stays loose; the registry / validator is what rejects
+    // unsupported combinations. Normalization only fails on shape errors.
+    const out = normalizeRuntime({
+      runtime: { provider: "azure", engine: "bicep", entry: "main.bicep" },
+    });
+    expect(out).toEqual({ provider: "azure", engine: "bicep", entry: "main.bicep" });
+  });
+
+  it("should return undefined for a malformed runtime block (missing entry)", () => {
+    const out = normalizeRuntime({ runtime: { provider: "aws", engine: "cloudformation" } });
+    expect(out).toBeUndefined();
+  });
+
+  it("should default to template.yaml when neither runtime nor cfnTemplate is declared", () => {
+    const out = normalizeRuntime({});
+    expect(out).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    });
+  });
+
+  it("should mark aws/cloudformation as the executable combination", () => {
+    expect(
+      isExecutableRuntime({ provider: "aws", engine: "cloudformation", entry: "template.yaml" }),
+    ).toBe(true);
+    expect(isExecutableRuntime({ provider: "azure", engine: "bicep", entry: "main.bicep" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("selectAdapter", () => {
+  const deps = {
+    aws: {
+      events: { send: vi.fn() } as unknown as Parameters<typeof selectAdapter>[1]["aws"]["events"],
+      eventBusName: "test-bus",
+    },
+  };
+
+  it("should return the AWS CloudFormation adapter for aws/cloudformation", () => {
+    const runtime: ProblemRuntime = {
+      provider: "aws",
+      engine: "cloudformation",
+      entry: "template.yaml",
+    };
+    const adapter = selectAdapter(runtime, deps);
+    expect(adapter).toBeInstanceOf(AwsCloudFormationRuntimeAdapter);
+    expect(adapter.provider).toBe("aws");
+    expect(adapter.engine).toBe("cloudformation");
+  });
+
+  it("should throw RuntimeNotSupportedError for azure/bicep", () => {
+    const runtime: ProblemRuntime = {
+      provider: "azure",
+      engine: "bicep",
+      entry: "main.bicep",
+    };
+    expect(() => selectAdapter(runtime, deps)).toThrow(RuntimeNotSupportedError);
+  });
+
+  it("should include the rejected runtime in the error so operators can diagnose", () => {
+    const runtime: ProblemRuntime = {
+      provider: "kubernetes",
+      engine: "helm",
+      entry: "Chart.yaml",
+    };
+    try {
+      selectAdapter(runtime, deps);
+      throw new Error("expected selectAdapter to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RuntimeNotSupportedError);
+      if (err instanceof RuntimeNotSupportedError) {
+        expect(err.runtime).toEqual(runtime);
+        expect(err.message).toContain("kubernetes/helm");
+        expect(err.message).toContain("aws/cloudformation");
+      }
+    }
+  });
+
+  // Reservation guard: even though normalize emits aws/cloudformation as the
+  // baseline, the registry must not accept partial matches like
+  // aws/<something-else>. We assert this explicitly so a future contributor
+  // who reaches for `if (provider === "aws")` short-circuits has to update the
+  // test too.
+  it("should reject aws/<non-cloudformation> engines", () => {
+    const runtime: ProblemRuntime = {
+      provider: "aws",
+      engine: "cdk",
+      entry: "cdk.json",
+    };
+    expect(() => selectAdapter(runtime, deps)).toThrow(RuntimeNotSupportedError);
+  });
+});
+
+describe("AwsCloudFormationRuntimeAdapter", () => {
+  function build(): {
+    adapter: AwsCloudFormationRuntimeAdapter;
+    eventsSend: ReturnType<typeof vi.fn>;
+  } {
+    const eventsSend = vi.fn().mockResolvedValue({});
+    const adapter = new AwsCloudFormationRuntimeAdapter({
+      events: { send: eventsSend } as unknown as Parameters<
+        typeof selectAdapter
+      >[1]["aws"]["events"],
+      eventBusName: "test-bus",
+    });
+    return { adapter, eventsSend };
+  }
+
+  it("should advertise aws/cloudformation as its provider/engine", () => {
+    const { adapter } = build();
+    expect(adapter.provider).toBe(EXECUTABLE_PROVIDER);
+    expect(adapter.engine).toBe(EXECUTABLE_ENGINE);
+  });
+
+  it("should publish DeployCreateRequested with the legacy detail shape", async () => {
+    const { adapter, eventsSend } = build();
+    await adapter.deploy({
+      jobId: "01HJOB",
+      correlationId: "01HJOB",
+      tenantId: "tenant-acme",
+      problemId: "hello-world",
+      problemDir: "problems/challenges/hello-world",
+      teamSlug: "alpha-team",
+      namePrefix: "tc-hello-world-alpha-team",
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+      competitorRoleArn: "arn:aws:iam::123456789012:role/TenkaCloud-CompetitorDeploy-Role",
+      externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+    });
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(cmd).toBeInstanceOf(PutEventsCommand);
+    const entry = cmd.input.Entries?.[0];
+    expect(entry?.EventBusName).toBe("test-bus");
+    expect(entry?.Source).toBe("tenkacloud.deploy");
+    expect(entry?.DetailType).toBe("DeployCreateRequested");
+    const detail = JSON.parse(entry?.Detail ?? "{}");
+    expect(detail).toMatchObject({
+      jobId: "01HJOB",
+      tenantId: "tenant-acme",
+      problemId: "hello-world",
+      problemDir: "problems/challenges/hello-world",
+      teamSlug: "alpha-team",
+      namePrefix: "tc-hello-world-alpha-team",
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+      competitorRoleArn: "arn:aws:iam::123456789012:role/TenkaCloud-CompetitorDeploy-Role",
+      externalIdParameterName: "/development/tenants/tenant-acme/external-id",
+    });
+  });
+
+  it("should omit optional fields from the detail when absent (= legacy compat)", async () => {
+    const { adapter, eventsSend } = build();
+    await adapter.deploy({
+      jobId: "01HJOB",
+      correlationId: "01HJOB",
+      tenantId: "tenant-acme",
+      problemId: "hello-world",
+      problemDir: "problems/challenges/hello-world",
+      teamSlug: "alpha-team",
+      namePrefix: "tc-hello-world-alpha-team",
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+    });
+    const cmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    const detail = JSON.parse(cmd.input.Entries?.[0]?.Detail ?? "{}");
+    expect(detail).not.toHaveProperty("competitorRoleArn");
+    expect(detail).not.toHaveProperty("externalIdParameterName");
+    expect(detail).not.toHaveProperty("challengePayloadUrl");
+  });
+
+  it("should return status=pending after a successful publish", async () => {
+    const { adapter } = build();
+    const result = await adapter.deploy({
+      jobId: "01HJOB",
+      correlationId: "01HJOB",
+      tenantId: "tenant-acme",
+      problemId: "hello-world",
+      problemDir: "problems/challenges/hello-world",
+      teamSlug: "alpha-team",
+      namePrefix: "tc-hello-world-alpha-team",
+      region: "ap-northeast-1",
+      awsAccountId: "123456789012",
+    });
+    expect(result.status).toBe("pending");
+  });
+
+  it("should throw AdapterMethodNotWiredError for collectOutputs (Phase 1 stub)", async () => {
+    const { adapter } = build();
+    await expect(
+      adapter.collectOutputs({
+        jobId: "01HJOB",
+        namePrefix: "tc-hello-world-alpha-team",
+        region: "ap-northeast-1",
+        awsAccountId: "123456789012",
+      }),
+    ).rejects.toBeInstanceOf(AdapterMethodNotWiredError);
+  });
+
+  it("should throw AdapterMethodNotWiredError for getStatus (Phase 1 stub)", async () => {
+    const { adapter } = build();
+    await expect(
+      adapter.getStatus({
+        jobId: "01HJOB",
+        namePrefix: "tc-hello-world-alpha-team",
+        region: "ap-northeast-1",
+        awsAccountId: "123456789012",
+      }),
+    ).rejects.toBeInstanceOf(AdapterMethodNotWiredError);
+  });
+
+  it("should throw AdapterMethodNotWiredError for destroy (Phase 1 stub)", async () => {
+    const { adapter } = build();
+    await expect(
+      adapter.destroy({
+        jobId: "01HJOB",
+        namePrefix: "tc-hello-world-alpha-team",
+        region: "ap-northeast-1",
+        awsAccountId: "123456789012",
+      }),
+    ).rejects.toBeInstanceOf(AdapterMethodNotWiredError);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduce `ProblemRuntimeAdapter` interface + `AwsCloudFormationRuntimeAdapter` as the only registered adapter today. Wraps the existing `publishProblemEvent` call byte-for-byte so the State Machine / CodeBuild path is untouched.
- `startDeployment` resolves a normalized `ProblemRuntime` BEFORE any cloud mutation (DDB Get, DDB Put, EventBridge PutEvents); a non-AWS runtime now fails loud via `RuntimeNotSupportedError` → HTTP 422 `runtime_not_supported`.
- Phase-1 stub: `collectOutputs` / `getStatus` / `destroy` throw `AdapterMethodNotWiredError`. Existing handlers (`describe-stack-handler`, `delete.ts`) keep their direct CFn SDK calls until the migration PR — keeps INVARIANT_PR_SHIPS_WORKING_INCREMENT.

Closes #1268
Related: ADR-023 (`docs/architecture/adr-023-provider-specific-problem-runtime.html`).

## Adapter interface (Lambda-local, `infrastructure/lib/problem-deploy/handlers/shared/runtime/`)

```ts
export interface ProblemRuntimeAdapter {
  readonly provider: string;
  readonly engine: string;
  deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult>;
  collectOutputs(input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs>;
  getStatus(input: RuntimeStatusInput): Promise<RuntimeStatus>;
  destroy(input: RuntimeDestroyInput): Promise<RuntimeDestroyResult>;
}
export type RuntimeStatus =
  | "pending" | "deploying" | "ready" | "failed" | "destroying" | "destroyed";
```

`selectAdapter(runtime, deps)` returns `AwsCloudFormationRuntimeAdapter` for `aws/cloudformation` and throws `RuntimeNotSupportedError` for every other combination (including `aws/<non-cfn>`).

## Regression analysis

Behavior-preserving abstraction:

- **Legacy `cfnTemplate`-only problems**: `resolveProblemRuntime` is undefined → default normalized runtime is `aws/cloudformation/template.yaml` → `AwsCloudFormationRuntimeAdapter.deploy` runs the same `publishProblemEvent` call with the same `DeployCreateRequestedDetail` shape. Existing `deploy-handler.test.ts` (16 tests) still green.
- **Explicit `runtime: aws/cloudformation` problems**: resolved to the same adapter, same detail shape, no extra fields leak into the EventBridge detail (= State Machine input transformer is byte-for-byte compatible).
- **Improvement (was missing before)**: if a problem author somehow gets a non-AWS runtime past `validate-problems`, the deploy worker now refuses the request at the Lambda boundary with 422 instead of silently invoking the AWS path. No half-created stacks.
- **`describe-stack-handler` / `delete.ts` paths**: untouched. Adapter Phase-1 stubs throw `AdapterMethodNotWiredError`, but nothing in this PR routes those call sites through the adapter yet.
- **Compensation path**: the `publishProblemEvent` failure → DDB FAILED rollback in `startDeployment` is preserved; the adapter throws on PutEvents failure exactly like the inline call did.

## Physical impact

- **CFn diff**: NO-OP. No CDK changes. No new env vars, no new IAM, no new resources.
- **Lambda bundle size**: ~3 KB bigger (new `shared/runtime/` directory with 5 small files; minified bundle target).
- **Runtime behavior for legacy / explicit-AWS problems**: NO-OP. Same DDB Put, same EventBridge detail, same downstream State Machine input.
- **Runtime behavior for non-AWS problems**: NEW LOUD FAILURE. `RuntimeNotSupportedError` → 422 `runtime_not_supported` JSON body, no cloud mutation. ADR-023 D4 contract.
- **Public API**: no change to `POST /problems/:problemId/deploy` request schema. New error code `runtime_not_supported` (422) is additive and only fires for problems whose metadata declares an unsupported provider/engine.

## Tests

21 new tests, all green via `bun run test` in `infrastructure/`:

- `infrastructure/test/problem-deploy/runtime-adapter.test.ts` — 16 tests across `normalizeRuntime`, `selectAdapter`, and `AwsCloudFormationRuntimeAdapter` (legacy detail shape, optional field omission, status=pending, Phase-1 stubs).
- `infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts` — 4 tests covering `startDeployment` integration: legacy path unchanged, explicit-AWS path identical, azure/bicep rejected pre-DDB / pre-EventBridge, kubernetes/helm rejected pre-CompetitorAccounts-lookup.

Existing `deploy-handler.test.ts` (16 tests) still passes — same EventBridge detail shape preserved.

## Test plan

- [ ] `make harness` clean (no new findings).
- [ ] `make before-commit` test suite green (single flaky CDK-bundling timeout unrelated to this change; passes in isolation and on rerun).
- [ ] `bun run test test/problem-deploy/` — all 73 deploy tests pass.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-problem runtime configuration support.
  * Deploy system now uses runtime adapters for deployment execution.
  * Added detailed error responses (422 status) for unsupported runtimes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->