### PR TITLE
feat(harness): lambda-env-size rule blocks 4KB env overflow regression

### DIFF
--- a/.claude/harness/baselines/lambda-env-size.json
+++ b/.claude/harness/baselines/lambda-env-size.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "ruleId": "lambda-env-size",
+      "filePath": "infrastructure/cdk.out/tenkacloud-problem-deploy.template.json",
+      "line": 1,
+      "match": "tenkacloud-problem-deploy::EventApiFunction801117B3::ge-hard-limit"
+    }
+  ]
+}

--- a/.claude/harness/bin/regenerate-baselines.ts
+++ b/.claude/harness/bin/regenerate-baselines.ts
@@ -20,6 +20,7 @@ import { adrSelfContained } from "../src/rules/adr-self-contained.ts";
 import { fileTooLarge } from "../src/rules/file-too-large.ts";
 import { handlerNoDirectSdkImport } from "../src/rules/handler-no-direct-sdk-import.ts";
 import { iamWildcardNeedsJustify } from "../src/rules/iam-wildcard-needs-justify.ts";
+import { lambdaEnvSize } from "../src/rules/lambda-env-size.ts";
 import { listAllTrackedFiles } from "../src/utils/staged-files.ts";
 
 const RULES = {
@@ -28,6 +29,7 @@ const RULES = {
   "adr-must-be-html": adrMustBeHtml,
   "adr-self-contained": adrSelfContained,
   "iam-wildcard-needs-justify": iamWildcardNeedsJustify,
+  "lambda-env-size": lambdaEnvSize,
 } as const;
 
 const args = process.argv.slice(2);

--- a/.claude/harness/src/cli.ts
+++ b/.claude/harness/src/cli.ts
@@ -7,6 +7,7 @@ import { fileTooLarge } from "./rules/file-too-large.ts";
 import { handlerNoDirectSdkImport } from "./rules/handler-no-direct-sdk-import.ts";
 import { handlerTenantIsolation } from "./rules/handler-tenant-isolation.ts";
 import { iamWildcardNeedsJustify } from "./rules/iam-wildcard-needs-justify.ts";
+import { lambdaEnvSize } from "./rules/lambda-env-size.ts";
 import type { Finding, Rule, Severity } from "./types.ts";
 import { listAllTrackedFiles, listStagedFiles } from "./utils/staged-files.ts";
 
@@ -30,6 +31,8 @@ const ALL_RULES: readonly Rule[] = [
   handlerNoDirectSdkImport,
   // Issue #997 / tenant 分離 audit
   handlerTenantIsolation,
+  // Issue #1309 / Lambda env 4KB hard limit 再発防止 (= #1308 root cause)
+  lambdaEnvSize,
 ];
 
 const SEVERITY_RANK: Record<Severity, number> = {
@@ -78,6 +81,7 @@ Rules:
   iam-wildcard-needs-justify    Wildcard IAM policies need an inline justification comment.
   file-too-large                Single .ts/.tsx files must not exceed 500 (warn) / 800 (error) lines.
   handler-no-direct-sdk-import  handlers/<x>/index.ts must not import @aws-sdk/client-* directly.
+  lambda-env-size               AWS::Lambda::Function env total must stay under 3KB (4KB hard limit - 1KB margin).
 
 Baselines:
   Each rule may have a baseline file at .claude/harness/baselines/<rule-id>.json.

--- a/.claude/harness/src/rules/index.ts
+++ b/.claude/harness/src/rules/index.ts
@@ -4,6 +4,7 @@ import { fileTooLarge } from "./file-too-large.ts";
 import { handlerNoDirectSdkImport } from "./handler-no-direct-sdk-import.ts";
 import { handlerTenantIsolation } from "./handler-tenant-isolation.ts";
 import { iamWildcardNeedsJustify } from "./iam-wildcard-needs-justify.ts";
+import { lambdaEnvSize } from "./lambda-env-size.ts";
 import { noConflictMarkers } from "./no-conflict-markers.ts";
 
 export const architectureRules = [
@@ -17,4 +18,6 @@ export const architectureRules = [
   handlerTenantIsolation,
   // feedback_pull_main_before_task: PR の conflict を防ぐ第一線。 commit 内の marker 検知
   noConflictMarkers,
+  // Issue #1309 / Lambda env 4KB hard limit 再発防止 (= #1308 root cause)
+  lambdaEnvSize,
 ] as const;

--- a/.claude/harness/src/rules/lambda-env-size.test.ts
+++ b/.claude/harness/src/rules/lambda-env-size.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import { bucketFor, checkTemplates, measureEnvVariables } from "./lambda-env-size.ts";
+
+/**
+ * Issue #1309 lambda-env-size rule unit tests。
+ * 実 cdk.out には依存させず、 CFn template fixture を inline で組んで checkTemplates を
+ * 直接 drive する (= fast / hermetic)。
+ */
+
+function makeTemplate(
+  resources: Record<string, { Type: string; Properties?: Record<string, unknown> }>,
+) {
+  return { Resources: resources };
+}
+
+function makeLambda(envVars: Record<string, unknown>) {
+  return {
+    Type: "AWS::Lambda::Function",
+    Properties: {
+      Environment: {
+        Variables: envVars,
+      },
+    },
+  };
+}
+
+describe("measureEnvVariables", () => {
+  it("should return zero total for empty env", () => {
+    expect(measureEnvVariables({})).toEqual({
+      totalBytes: 0,
+      largestKey: "",
+      largestBytes: 0,
+    });
+  });
+
+  it("should exact-count string values via UTF-8 byte length", () => {
+    // "A=1" = 1 (key) + 1 (value) + 2 (delim overhead) = 4 bytes
+    const r = measureEnvVariables({ A: "1" });
+    expect(r.totalBytes).toBe(4);
+    expect(r.largestKey).toBe("A");
+  });
+
+  it("should sum multi-entry env correctly", () => {
+    const r = measureEnvVariables({ A: "1", BB: "22" });
+    // A: 1 + 1 + 2 = 4; BB: 2 + 2 + 2 = 6; total 10
+    expect(r.totalBytes).toBe(10);
+    expect(r.largestKey).toBe("BB");
+  });
+
+  it("should identify the largest env var", () => {
+    const r = measureEnvVariables({
+      SMALL: "x",
+      BIG: "x".repeat(1000),
+      MEDIUM: "x".repeat(100),
+    });
+    expect(r.largestKey).toBe("BIG");
+  });
+
+  it("should estimate CFn intrinsic (object) values as 200 bytes", () => {
+    const r = measureEnvVariables({ TABLE_NAME: { Ref: "TableX" } });
+    // 10 (key) + 200 (estimate) + 2 (delim) = 212
+    expect(r.totalBytes).toBe(212);
+  });
+
+  it("should handle multibyte UTF-8 string values", () => {
+    // 日本語 1 文字 = 3 bytes (UTF-8)
+    const r = measureEnvVariables({ K: "あ" });
+    expect(r.totalBytes).toBe(1 + 3 + 2);
+  });
+});
+
+describe("bucketFor", () => {
+  it("should return ok for under 2.5KB", () => {
+    expect(bucketFor(2559)).toBe("ok");
+    expect(bucketFor(0)).toBe("ok");
+  });
+
+  it("should return ge-warning for 2.5KB-3KB", () => {
+    expect(bucketFor(2560)).toBe("ge-warning");
+    expect(bucketFor(3071)).toBe("ge-warning");
+  });
+
+  it("should return ge-error for 3KB-4KB", () => {
+    expect(bucketFor(3072)).toBe("ge-error");
+    expect(bucketFor(4095)).toBe("ge-error");
+  });
+
+  it("should return ge-hard-limit for >= 4KB (= AWS reject)", () => {
+    expect(bucketFor(4096)).toBe("ge-hard-limit");
+    expect(bucketFor(5000)).toBe("ge-hard-limit");
+  });
+});
+
+describe("checkTemplates", () => {
+  it("should return no findings when all Lambdas are under 2.5KB", () => {
+    const templates = [
+      {
+        relPath: "infrastructure/cdk.out/small.template.json",
+        stackName: "small",
+        template: makeTemplate({
+          Fn1: makeLambda({ K: "v" }),
+        }),
+      },
+    ];
+    expect(checkTemplates({ templates })).toEqual([]);
+  });
+
+  it("should report warning for Lambda env between 2.5KB and 3KB", () => {
+    // 2600 bytes = 1 (key) + 2597 (value) + 2 (delim) = 2600
+    const big = "x".repeat(2597);
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/warn.template.json",
+          stackName: "warn-stack",
+          template: makeTemplate({ WarnFn: makeLambda({ K: big }) }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("warning");
+    expect(findings[0]?.match).toBe("warn-stack::WarnFn::ge-warning");
+  });
+
+  it("should report error for Lambda env between 3KB and 4KB", () => {
+    const big = "x".repeat(3100);
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/err.template.json",
+          stackName: "err-stack",
+          template: makeTemplate({ ErrFn: makeLambda({ K: big }) }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("error");
+    expect(findings[0]?.match).toBe("err-stack::ErrFn::ge-error");
+  });
+
+  it("should report error and call out the hard limit when env >= 4KB", () => {
+    const big = "x".repeat(4100);
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/overflow.template.json",
+          stackName: "overflow-stack",
+          template: makeTemplate({ OverflowFn: makeLambda({ K: big }) }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("error");
+    expect(findings[0]?.match).toBe("overflow-stack::OverflowFn::ge-hard-limit");
+    expect(findings[0]?.message).toContain("hard limit");
+  });
+
+  it("should identify the largest env var in the finding message", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/multi.template.json",
+          stackName: "multi-stack",
+          template: makeTemplate({
+            BigFn: makeLambda({
+              SMALL_VAR: "x",
+              CATALOG_BLOB: "x".repeat(3100),
+              MEDIUM_VAR: "x".repeat(100),
+            }),
+          }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("CATALOG_BLOB");
+  });
+
+  it("should only report the violating Lambda when multiple exist", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/mixed.template.json",
+          stackName: "mixed-stack",
+          template: makeTemplate({
+            OkFn: makeLambda({ K: "small" }),
+            BadFn: makeLambda({ K: "x".repeat(3100) }),
+          }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.match).toContain("BadFn");
+  });
+
+  it("should walk multiple stack templates", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/a.template.json",
+          stackName: "a",
+          template: makeTemplate({ Fn1: makeLambda({ K: "x".repeat(3100) }) }),
+        },
+        {
+          relPath: "infrastructure/cdk.out/b.template.json",
+          stackName: "b",
+          template: makeTemplate({ Fn2: makeLambda({ K: "x".repeat(2600) }) }),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(2);
+    const matches = findings.map((f) => f.match).sort();
+    expect(matches).toEqual(["a::Fn1::ge-error", "b::Fn2::ge-warning"]);
+  });
+
+  it("should ignore non-Lambda resources", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/dynamo.template.json",
+          stackName: "ddb",
+          template: {
+            Resources: {
+              TableX: {
+                Type: "AWS::DynamoDB::Table",
+                Properties: { TableName: "x".repeat(4000) },
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should handle Lambda with no env block (= undefined Properties.Environment)", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/noenv.template.json",
+          stackName: "noenv",
+          template: {
+            Resources: {
+              Fn1: { Type: "AWS::Lambda::Function", Properties: {} },
+            },
+          },
+        },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("should include remediation pointing to S3 / SSM / bundling.define", () => {
+    const findings = checkTemplates({
+      templates: [
+        {
+          relPath: "infrastructure/cdk.out/rec.template.json",
+          stackName: "rec",
+          template: makeTemplate({ Fn1: makeLambda({ K: "x".repeat(3100) }) }),
+        },
+      ],
+    });
+    expect(findings[0]?.recommendation).toMatch(/bundling\.define/);
+    expect(findings[0]?.recommendation).toMatch(/S3/);
+    expect(findings[0]?.recommendation).toMatch(/SSM/);
+    expect(findings[0]?.recommendation).toMatch(/#1308/);
+  });
+});

--- a/.claude/harness/src/rules/lambda-env-size.ts
+++ b/.claude/harness/src/rules/lambda-env-size.ts
@@ -1,0 +1,253 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { Finding, Rule, RuleContext } from "../types.ts";
+
+/**
+ * Issue #1309 / Lambda env 4KB hard limit overflow 再発防止。
+ *
+ * Background (= 症状 #1308):
+ *   `BATTLE_PROBLEMS_DISRUPTIONS` env が 5 問追加で 3.4KB に膨らみ、 他 env (table 名 / catalog
+ *   JSON 等) と合算で AWS Lambda env 4KB hard limit を超え、 CFn CreateStack が
+ *   `Lambda was unable to configure environment variables: Environment variable maximum size exceeded`
+ *   で fail した。 PR review でも `cdk synth` でも気づけない (= synth は通る / deploy で初めて落ちる)
+ *   ので、 構造的に harness 側で先に検出するしかない。
+ *
+ * Strategy:
+ *   `infrastructure/cdk.out/*.template.json` を walk し、 各 `AWS::Lambda::Function`
+ *   `Properties.Environment.Variables` の合計 byte 数を AWS Lambda の env 計測 spec
+ *   (= name + "=" + value + delimiter ~= 2 bytes overhead per entry, UTF-8) で集計する。
+ *
+ *   - >= 3072 bytes (3KB) → error (= 4KB hard limit に 1KB margin。 PR を block)
+ *   - >= 2560 bytes (2.5KB) → warning (= 早めに掃除しろ)
+ *
+ *   CFn intrinsic (= `{ Ref: ... }` / `{ Fn::Select: [...] }` 等) は deploy 時に
+ *   resolve されると ARN 長 (~200 bytes 平均) になるため、 CFN_INTRINSIC_ESTIMATE_BYTES で
+ *   保守的に見積もる。 純 string env (= catalog JSON / 長い feature flag list) こそが
+ *   feature 追加で線形に膨らむ本丸なので、 文字列値は exact 計測する。
+ *
+ * Baseline:
+ *   `.claude/harness/baselines/lambda-env-size.json` で現状の違反 (= #1308 の本丸である
+ *   EventApiFunction) を凍結。 新規 Lambda が閾値を超える、 もしくは baseline 既存 Lambda が
+ *   さらに膨らんで severity bucket を超えると baseline match を外れて発火する設計。
+ *
+ * cdk.out が存在しない場合 (= fresh clone で synth してない):
+ *   info-level (= 非 blocking) finding を 1 件返して "make synth してから再実行" を促す。
+ *   通常運用では `make before-commit` の `check-synth` で cdk.out が生成されるので、
+ *   CI / PR 経路では確実に動く。
+ *
+ * Detection target (= 特に膨らみやすい):
+ *   - catalog / disruption blob (= 問題追加で線形増加)
+ *   - 長い resource ARN list / API base URLs list / IAM policy JSON
+ */
+
+const CDK_OUT_DIR = "infrastructure/cdk.out";
+const HARD_LIMIT_BYTES = 4096;
+const ERROR_BYTES = 3072; // 4KB - 1KB margin
+const WARNING_BYTES = 2560; // 2.5KB
+const ENV_VAR_DELIMITER_OVERHEAD_BYTES = 2; // "=" + entry delimiter approximation
+const CFN_INTRINSIC_ESTIMATE_BYTES = 200; // average resolved ARN length
+
+interface CfnTemplate {
+  readonly Resources?: Record<string, CfnResource>;
+}
+
+interface CfnResource {
+  readonly Type?: string;
+  readonly Properties?: {
+    readonly Environment?: {
+      readonly Variables?: Record<string, unknown>;
+    };
+    readonly FunctionName?: unknown;
+  };
+}
+
+interface EnvMeasurement {
+  readonly totalBytes: number;
+  readonly largestKey: string;
+  readonly largestBytes: number;
+}
+
+/**
+ * 1 env var の byte 数を AWS Lambda の env 計測に合わせて見積もる。
+ * 文字列値は UTF-8 byte length で exact 計測、 CFn intrinsic (= 中身が object) は
+ * 平均 ARN 長 (= 200 bytes) で見積もり。
+ */
+function measureEnvValueBytes(key: string, value: unknown): number {
+  const keyBytes = Buffer.byteLength(key, "utf8");
+  let valueBytes: number;
+  if (typeof value === "string") {
+    valueBytes = Buffer.byteLength(value, "utf8");
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    valueBytes = Buffer.byteLength(String(value), "utf8");
+  } else {
+    // CFn intrinsic ({Ref}, {Fn::Sub}, {Fn::Select}, etc.) — deploy 時に resolve される ARN。
+    valueBytes = CFN_INTRINSIC_ESTIMATE_BYTES;
+  }
+  return keyBytes + valueBytes + ENV_VAR_DELIMITER_OVERHEAD_BYTES;
+}
+
+export function measureEnvVariables(envVars: Record<string, unknown>): EnvMeasurement {
+  let total = 0;
+  let largestKey = "";
+  let largestBytes = 0;
+  for (const [key, value] of Object.entries(envVars)) {
+    const size = measureEnvValueBytes(key, value);
+    total += size;
+    if (size > largestBytes) {
+      largestBytes = size;
+      largestKey = key;
+    }
+  }
+  return { totalBytes: total, largestKey, largestBytes };
+}
+
+interface CdkTemplateFile {
+  readonly relPath: string; // e.g. "infrastructure/cdk.out/tenkacloud-problem-deploy.template.json"
+  readonly stackName: string; // e.g. "tenkacloud-problem-deploy"
+  readonly template: CfnTemplate;
+}
+
+function listCdkTemplates(cwd: string): readonly CdkTemplateFile[] {
+  const dir = resolve(cwd, CDK_OUT_DIR);
+  if (!existsSync(dir)) return [];
+  let entries: readonly string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const results: CdkTemplateFile[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".template.json")) continue;
+    // CDK が出す asset.* / nested stack の template も .template.json で出るが
+    // top-level stack だけが対象。 asset bundle 用は asset.<hash>.* の prefix。
+    if (name.startsWith("asset.")) continue;
+    const fullPath = join(dir, name);
+    let raw: string;
+    try {
+      raw = readFileSync(fullPath, "utf8");
+    } catch {
+      continue;
+    }
+    let parsed: CfnTemplate;
+    try {
+      parsed = JSON.parse(raw) as CfnTemplate;
+    } catch {
+      continue;
+    }
+    const stackName = name.replace(/\.template\.json$/, "");
+    results.push({
+      relPath: `${CDK_OUT_DIR}/${name}`,
+      stackName,
+      template: parsed,
+    });
+  }
+  return results;
+}
+
+function isCdkOutFresh(cwd: string): boolean {
+  const dir = resolve(cwd, CDK_OUT_DIR);
+  if (!existsSync(dir)) return false;
+  try {
+    const entries = readdirSync(dir).filter((n) => n.endsWith(".template.json"));
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * severity bucket を返す。 baseline match の単位として使う (= byte 数そのものを match
+ * key にすると 1 byte 増えるだけで baseline 外れて再警告するため、 bucket 化する)。
+ */
+export function bucketFor(totalBytes: number): "ok" | "ge-warning" | "ge-error" | "ge-hard-limit" {
+  if (totalBytes >= HARD_LIMIT_BYTES) return "ge-hard-limit";
+  if (totalBytes >= ERROR_BYTES) return "ge-error";
+  if (totalBytes >= WARNING_BYTES) return "ge-warning";
+  return "ok";
+}
+
+export interface CheckTemplatesOptions {
+  readonly templates: readonly CdkTemplateFile[];
+}
+
+export function checkTemplates(opts: CheckTemplatesOptions): Finding[] {
+  const findings: Finding[] = [];
+  for (const { relPath, stackName, template } of opts.templates) {
+    const resources = template.Resources ?? {};
+    for (const [logicalId, resource] of Object.entries(resources)) {
+      if (resource.Type !== "AWS::Lambda::Function") continue;
+      const envVars = resource.Properties?.Environment?.Variables ?? {};
+      const measurement = measureEnvVariables(envVars);
+      const bucket = bucketFor(measurement.totalBytes);
+      if (bucket === "ok") continue;
+      const severity = bucket === "ge-warning" ? "warning" : "error";
+      const overLimitNote =
+        bucket === "ge-hard-limit"
+          ? ` (= AWS Lambda 4KB hard limit ${HARD_LIMIT_BYTES} bytes 超過、 deploy で必ず fail する)`
+          : bucket === "ge-error"
+            ? ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${HARD_LIMIT_BYTES - measurement.totalBytes} bytes)`
+            : ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${HARD_LIMIT_BYTES - measurement.totalBytes} bytes、 早めに掃除推奨)`;
+      findings.push({
+        ruleId: "lambda-env-size",
+        severity,
+        filePath: relPath,
+        line: 1,
+        // bucket 単位で baseline match (= 同 bucket 内なら byte 増減で baseline 外れない)
+        match: `${stackName}::${logicalId}::${bucket}`,
+        message:
+          `Lambda \`${logicalId}\` in stack \`${stackName}\` has total env size ` +
+          `${measurement.totalBytes} bytes${overLimitNote}. ` +
+          `Largest var: \`${measurement.largestKey}\` (${measurement.largestBytes} bytes).`,
+        recommendation:
+          "AWS Lambda 4KB hard limit. Move large env data to one of: " +
+          "(1) bundled module via esbuild `bundling.define` (literal substitution at build time, = #1158 / #1308 catalog pattern); " +
+          "(2) S3 + lazy fetch at cold start; " +
+          "(3) SSM Parameter Store SecureString (cost-zero, AGENTS.md secrets-manager-forbidden rule). " +
+          "See #1308 for the catalog/disruption bundling pattern.",
+      });
+    }
+  }
+  return findings;
+}
+
+export const lambdaEnvSize: Rule = {
+  id: "lambda-env-size",
+  severity: "error",
+  check(ctx: RuleContext): readonly Finding[] {
+    const cwd = process.cwd();
+    if (!isCdkOutFresh(cwd)) {
+      // cdk.out が無い fresh clone / synth 未実行ケース。 false negative より silent skip
+      // を選ぶと #1308 の再発を見逃すため、 info 1 件出して synth を促す。
+      return [
+        {
+          ruleId: "lambda-env-size",
+          severity: "info",
+          filePath: CDK_OUT_DIR,
+          line: 1,
+          match: "cdk-out-missing",
+          message:
+            "lambda-env-size: cdk.out が存在しません (= synth 未実行)。 Lambda env 計測を skip しました。",
+          recommendation:
+            "`make synth` を実行して `infrastructure/cdk.out/*.template.json` を生成してから harness を再実行してください。 " +
+            "`make before-commit` を経由すれば check-synth が自動で走るので追加操作不要です。",
+        },
+      ];
+    }
+    const templates = listCdkTemplates(cwd);
+    if (templates.length === 0) return [];
+    return checkTemplates({ templates });
+  },
+};
+
+// vitest からは内部 helper を直接 import するためここで再 export。
+// 不要 export を一括公開しないよう named only。
+export const __test__ = {
+  listCdkTemplates,
+  isCdkOutFresh,
+  measureEnvValueBytes,
+  CFN_INTRINSIC_ESTIMATE_BYTES,
+  ERROR_BYTES,
+  WARNING_BYTES,
+  HARD_LIMIT_BYTES,
+};


### PR DESCRIPTION
## Summary

- Adds harness rule `lambda-env-size` that walks `infrastructure/cdk.out/*.template.json`, sums each `AWS::Lambda::Function` env total in bytes, and **blocks PRs at >= 3072 bytes** (= 4KB hard limit - 1KB margin). Warns at >= 2560 bytes.
- Prevents recurrence of #1308 (= `BATTLE_PROBLEMS_DISRUPTIONS` blob growth caused CFn `Environment variable maximum size exceeded` at deploy time, undetected by `cdk synth` / PR review).
- 1 existing violator frozen in `lambda-env-size.json` baseline: `EventApiFunction` in `tenkacloud-problem-deploy` (5611 bytes, the very #1308 root cause). New growth past the same severity bucket trips the baseline match.

Closes #1309.

## Regression analysis

Pure additive harness rule. Behavior on the current tree:

- 25 of 26 Lambdas: env total under 1KB (= no warning, no error).
- 1 Lambda (`EventApiFunction`): 5611 bytes, baselined → suppressed.
- Future PRs that add env vars (= new tables, longer feature-flag catalogs, IAM policy strings) get flagged at PR time instead of at deploy time.
- `cdk.out` missing case (= fresh clone, no synth yet): rule emits info-level finding (= non-blocking) telling the dev to run `make synth`. `make before-commit` runs `check-synth` already, so the normal PR flow always has cdk.out fresh.

## Physical impact

NO-OP runtime / CFn. Pure harness addition:

| Asset | Type |
| --- | --- |
| `.claude/harness/src/rules/lambda-env-size.ts` | CREATE (253 lines, 1 Rule + helpers) |
| `.claude/harness/src/rules/lambda-env-size.test.ts` | CREATE (20 vitest cases) |
| `.claude/harness/baselines/lambda-env-size.json` | CREATE (1 entry — #1308 EventApi) |
| `.claude/harness/src/rules/index.ts` | UPDATE (register rule) |
| `.claude/harness/src/cli.ts` | UPDATE (ALL_RULES + help text) |
| `.claude/harness/bin/regenerate-baselines.ts` | UPDATE (RULES map) |

## Test plan

- [x] `make harness-test` — 20 new unit tests pass (measurement / bucketing / multi-stack walk / largest-var identification / non-Lambda ignore / empty env / remediation text)
- [x] `make harness` — clean against baseline (no new findings)
- [x] `make before-commit` — full gate (lint / typecheck / vitest / synth / validate-problems / audit-deps) passes
- [x] Manually verified: synthetic Lambda with 3500-byte env triggers `[error] lambda-env-size` finding; reverting restores clean run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Lambda environment size validation rule that checks AWS Lambda function environment variables don't exceed 3KB (warning threshold) or 4KB (error threshold), helping identify potential deployment issues early.

* **Tests**
  * Comprehensive test suite added for the environment size validation rule, covering edge cases including multibyte characters, CloudFormation intrinsics, and threshold boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->