### PR TITLE
fix(deploy): bundle problem catalog instead of env var (4KB limit fix) — #1308

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -88,7 +88,6 @@ export class DeployApiLambda extends Construct {
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         // #686: legacy "unknown-tenant" fallback は削除 (= JWT claim 欠落時は handler が 401)
         ...(props.defaultTenantId ? { DEFAULT_TENANT_ID: props.defaultTenantId } : {}),
-        BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
         // ADR-008 Phase 3 (Issue #642): visibility + bucket env、 default は dormant
         BATTLE_PROBLEMS_VISIBILITY: JSON.stringify(props.problemsVisibility),
         CHALLENGE_PAYLOAD_BUCKET: props.challengePayloadBucketName ?? "",
@@ -101,6 +100,16 @@ export class DeployApiLambda extends Construct {
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
         sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
+        // Issue #1308: BATTLE_PROBLEMS_CATALOG は問題が増えるたび growing し 4 KB Lambda env
+        // hard limit に張り付いた (= EventApi / DeployApi の deploy が CREATE_FAILED)。 #1158
+        // (GenericScoring / ParticipantPortal) と同じ esbuild define で build 時に literal 置換
+        // し env を 0 化する。 handler は process.env を読む既存 code のまま (= build 後に literal
+        // JSON 文字列が埋まる)。 tests は process.env 経由で fixture を注入するので影響なし。
+        define: {
+          "process.env.BATTLE_PROBLEMS_CATALOG": JSON.stringify(
+            JSON.stringify(props.problemsCatalog),
+          ),
+        },
       },
     });
 

--- a/infrastructure/lib/problem-deploy/event-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/event-api-lambda.ts
@@ -109,10 +109,8 @@ export class EventApiLambda extends Construct {
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         // #686: legacy "unknown-tenant" fallback は削除 (= JWT claim 欠落時は handler が 401)
         ...(props.defaultTenantId ? { DEFAULT_TENANT_ID: props.defaultTenantId } : {}),
-        BATTLE_PROBLEMS_CATALOG: JSON.stringify(props.problemsCatalog),
         // Issue #888: disruption fire / catalog / audit Lambda 経路で参照
         DISRUPTIONS_TABLE_NAME: props.disruptionsTable.tableName,
-        BATTLE_PROBLEMS_DISRUPTIONS: JSON.stringify(props.problemsDisruptions),
         // Issue #910 (#895 Phase 2.C.2.b): bulk batch payload S3 bucket + feature flag。
         // bucket 未配線時は空文字、 flag は default false (= 旧 fan-out 維持)。
         BULK_DEPLOY_PAYLOAD_BUCKET: props.bulkDeployPayloadBucket?.bucketName ?? "",
@@ -126,6 +124,20 @@ export class EventApiLambda extends Construct {
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
         sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
+        // Issue #1308: BATTLE_PROBLEMS_CATALOG + BATTLE_PROBLEMS_DISRUPTIONS は問題が増える
+        // たび growing し、 4 KB Lambda env hard limit に張り付いた (= EventApi の deploy が
+        // CREATE_FAILED)。 #1158 (GenericScoring / ParticipantPortal) と同じ esbuild define で
+        // build 時に literal 置換し env を 0 化する。 handler は process.env を読む既存 code の
+        // まま (= build 後に literal JSON 文字列が埋まる)。 tests は process.env 経由で fixture を
+        // 注入するので影響なし。
+        define: {
+          "process.env.BATTLE_PROBLEMS_CATALOG": JSON.stringify(
+            JSON.stringify(props.problemsCatalog),
+          ),
+          "process.env.BATTLE_PROBLEMS_DISRUPTIONS": JSON.stringify(
+            JSON.stringify(props.problemsDisruptions),
+          ),
+        },
       },
     });
 

--- a/infrastructure/lib/problem-deploy/handlers/shared/catalog.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/catalog.ts
@@ -1,6 +1,11 @@
 /**
  * `BATTLE_PROBLEMS_CATALOG` env (JSON `{problemId: problemDir}`) を decode する。
  *
+ * Issue #1308: 配線は #1158 と同じく esbuild `bundling.define` で build 時 literal 置換
+ * される (= Lambda env からは取り除かれている)。 handler は `process.env.BATTLE_PROBLEMS_CATALOG`
+ * 読み取りのまま動く (= build 後に literal JSON 文字列が固定)。 vitest は `process.env.X = ...`
+ * 注入で fixture を渡すので test 経路でも変わらず動く。
+ *
  * Lambda cold start で 1 回だけ評価される想定 (deploy-handler / event-handler の
  * shared resource 構築時)。不正な JSON / shape は drop し warn log を出す
  * (operator が CloudWatch で気づける)。

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -5,21 +5,68 @@ import { synthDefault } from "./problem-deploy-backend-stack.test-helpers";
 describe("ProblemDeployBackendStack (MVP-1) — Deploy API Lambda (invoked from tenant API)", () => {
   const tpl = synthDefault();
 
-  it("should run on Node.js 22 / arm64 with BATTLE_PROBLEMS_CATALOG env", () => {
-    tpl.hasResourceProperties(
-      "AWS::Lambda::Function",
-      Match.objectLike({
-        Runtime: "nodejs22.x",
-        Architectures: ["arm64"],
-        Environment: Match.objectLike({
-          Variables: Match.objectLike({
-            BATTLE_PROBLEMS_CATALOG: JSON.stringify({
-              "hello-world": "problems/challenges/hello-world",
-            }),
-          }),
-        }),
-      }),
+  it("should run on Node.js 22 / arm64 without the BATTLE_PROBLEMS_CATALOG env (#1308 bundled-define)", () => {
+    // Issue #1308: BATTLE_PROBLEMS_CATALOG は #1158 と同じ esbuild bundling.define で build 時
+    // literal 置換し、 Lambda env から取り除いた (= 4 KB env 上限を回避)。 handler は
+    // `process.env.BATTLE_PROBLEMS_CATALOG` 読み取りのまま動く (= build 後に literal JSON が固定)。
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const deployApi = Object.entries(functions).find(
+      ([name]) => name.includes("DeployApi") && name.includes("Function"),
     );
+    expect(deployApi).toBeDefined();
+    const props = deployApi?.[1] as {
+      Properties?: {
+        Runtime?: string;
+        Architectures?: readonly string[];
+        Environment?: { Variables?: Record<string, unknown> };
+      };
+    };
+    expect(props.Properties?.Runtime).toBe("nodejs22.x");
+    expect(props.Properties?.Architectures).toEqual(["arm64"]);
+    const vars = props.Properties?.Environment?.Variables ?? {};
+    expect(vars.BATTLE_PROBLEMS_CATALOG).toBeUndefined();
+  });
+
+  it("EventApi Lambda env should not include BATTLE_PROBLEMS_CATALOG / BATTLE_PROBLEMS_DISRUPTIONS (#1308)", () => {
+    // Issue #1308 root cause: BATTLE_PROBLEMS_DISRUPTIONS (~2.5KB+) + BATTLE_PROBLEMS_CATALOG +
+    // 8 個の他 env で 4 KB Lambda env hard limit を超過し EventApi が CREATE_FAILED。
+    // bundling.define 経由に切替えて env から落とす。
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const eventApi = Object.entries(functions).find(
+      ([name]) => name.includes("EventApi") && name.includes("Function"),
+    );
+    expect(eventApi).toBeDefined();
+    const vars =
+      (
+        eventApi?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    // pin: env から消えていること
+    expect(vars.BATTLE_PROBLEMS_CATALOG).toBeUndefined();
+    expect(vars.BATTLE_PROBLEMS_DISRUPTIONS).toBeUndefined();
+    // pin: 残しておく env が消えていないこと (= regression 防止)
+    expect(vars.EVENTS_TABLE_NAME).toBeDefined();
+    expect(vars.DISRUPTIONS_TABLE_NAME).toBeDefined();
+  });
+
+  it("EventApi Lambda total env size should stay under 3 KB (1 KB margin under the 4 KB hard limit, #1308)", () => {
+    // 4 KB hard limit に張り付くと問題追加で deploy が壊れるため、 3 KB に閾値を引き下げる
+    // (= 1 KB 余裕を保つ)。 4 KB は Lambda の AWS::Lambda::Function Environment.Variables の
+    // serialized key=value 合計のため、 token 含む CFn intrinsic は概算長で OK (= 値が小さい)。
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const eventApi = Object.entries(functions).find(
+      ([name]) => name.includes("EventApi") && name.includes("Function"),
+    );
+    expect(eventApi).toBeDefined();
+    const vars =
+      (
+        eventApi?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    const serialized = JSON.stringify(vars);
+    expect(serialized.length).toBeLessThan(3 * 1024);
   });
 
   // #534: CFn StackEvents / StackResources を読む IAM Allow を持つべき


### PR DESCRIPTION
## Summary

- `BATTLE_PROBLEMS_DISRUPTIONS` (~2.5KB+) + `BATTLE_PROBLEMS_CATALOG` + 8 other env vars on `EventApi` grew past the 4KB Lambda env hard limit as problems were added (microservice-migration-battle / security-battle-royale / stackstack), and `make deploy` failed with `CREATE_FAILED` on EventApi/Function.
- Fix: switch wiring to the **same esbuild `bundling.define` pattern that #1158 already uses** for `BATTLE_PROBLEMS_SCORING` / `PROBLEM_ENDPOINTS` / `BATTLE_PROBLEMS_PHASES` on `GenericScoring` + `ParticipantPortal`. Catalog + disruptions become literal JSON inlined into the Lambda bundle at build time, and the Lambda env is freed.
- Handler code is unchanged — it still reads `process.env.BATTLE_PROBLEMS_CATALOG` / `process.env.BATTLE_PROBLEMS_DISRUPTIONS`; esbuild literal-replaces those reads. Tests still inject via `process.env.X = ...` because esbuild `define` does not apply to vitest runs.

Closes #1308

## Measured Lambda env size

Synthesized from `infrastructure/cdk.out/tenkacloud-problem-deploy.template.json`:

| Lambda      | Before                         | After      |
| ----------- | ------------------------------ | ---------- |
| `EventApi`  | > 4096 bytes (`CREATE_FAILED`) | 771 bytes  |
| `DeployApi` | (catalog ~500B + others)       | 651 bytes  |

Both Lambdas are now ~1/5 of the 4KB hard limit, with > 3KB of headroom for future env vars / problem additions.

## Regression analysis

- **Handler reads**: identical. `parseProblemsCatalog(process.env.BATTLE_PROBLEMS_CATALOG)` / `parseProblemsDisruptions(process.env.BATTLE_PROBLEMS_DISRUPTIONS)` still run; esbuild emits the same JSON literal that the env path used to deliver. Same shape, same `discoverProblems*` upstream, same handler logic downstream.
- **Tests**: `infrastructure/test/problem-deploy/disruption-fire.test.ts` builds `EventSharedResources` directly (does not touch env). `handler-error-cors.test.ts` / `role-gates.test.ts` / `deploy-handler-routes.test.ts` mock `buildSharedResources` entirely. The one test that asserted env presence (`should run on Node.js 22 / arm64 with BATTLE_PROBLEMS_CATALOG env`) is updated to assert env absence + `nodejs22.x` / `arm64` invariants (so we don't lose the runtime / arch pinning). Two new tests added to pin (a) absence of both `BATTLE_PROBLEMS_*` env vars on EventApi and (b) total EventApi env size < 3 KB (= 1 KB margin under the 4 KB hard limit so future regressions surface in CI, not at deploy time).
- **What could break**: if a future PR forgets to mirror a new `BATTLE_PROBLEMS_X` env into `bundling.define` after removing it from `environment`, the handler would read `undefined` at runtime. Mitigation: `make before-commit` runs the new size assertion; if anyone adds a fat env back without going through `define`, the test fails.

## Physical impact

- **EventApi/Function**: `UPDATE` — `Environment.Variables` shrinks from > 4096 bytes to 771 bytes (drops `BATTLE_PROBLEMS_CATALOG`, `BATTLE_PROBLEMS_DISRUPTIONS`). `Code` hash updates (= esbuild inlines the JSON into the bundle). No IAM / role / table changes.
- **DeployApi/Function**: `UPDATE` — `Environment.Variables` shrinks (drops `BATTLE_PROBLEMS_CATALOG`). `Code` hash updates. No IAM / role / table changes.
- **Other resources**: `NO-OP` — no IAM / DDB / EventBridge / S3 changes. No CloudFormation REPLACE on any resource.
- Net effect: the next `make deploy` (or `cdk deploy ProblemDeployBackendStack`) succeeds where the previous one failed.

## Test plan

- [x] `make harness` — no findings
- [x] `bunx --bun biome check` on touched files — clean
- [x] `vitest test/problem-deploy-backend-stack-lambdas.test.ts` — 10/10 pass (including 2 new pins + 1 updated)
- [x] Full `vitest run` (`make before-commit` test phase) — 1505/1505 pass
- [x] `make before-commit` — exits 0 (env: `SYSTEM_ADMIN_EMAIL=admin@example.com CDK_PARAM_DEPLOY_EXTERNAL_ID=test-external-id`)
- [x] `cdk synth ProblemDeployBackendStack` — no CREATE_FAILED, env size verified 771 / 651 bytes
- [ ] `make deploy` on a dev account — confirms EventApi `CREATE_COMPLETE` (deferred to maintainer per role split: CDK / IAM / deploy is user's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)