### PR TITLE
fix(infra): unique Competitor Role name allowing same competitor account across N Planes — #1314

### DIFF
--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -517,7 +517,7 @@
     "add_modal_region_label": "Region",
     "add_modal_region_description": "Deploy region (default: ap-northeast-1)",
     "add_modal_role_label": "IAM Role name",
-    "add_modal_role_description": "Role name to deploy on the competitor side via bootstrap (default: TenkaCloud-CompetitorDeploy-Role)",
+    "add_modal_role_description": "Role name to deploy on the competitor side via bootstrap. The default `TenkaCloud-{tenantId}-deploy-Role` is unique per Plane, so the same competitor AWS account can join multiple Planes (separate events / TenkaCloud environments) in parallel.",
     "secret_modal_header": "Information to share with the competitor",
     "secret_modal_close": "Close",
     "secret_modal_warning_header": "ExternalId can only be viewed on this screen",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -517,7 +517,7 @@
     "add_modal_region_label": "Region",
     "add_modal_region_description": "deploy 先 region (default: ap-northeast-1)",
     "add_modal_role_label": "IAM Role 名",
-    "add_modal_role_description": "競技者側 bootstrap で deploy する Role 名 (default: TenkaCloud-CompetitorDeploy-Role)",
+    "add_modal_role_description": "競技者側 bootstrap で deploy する Role 名。 default は `TenkaCloud-{tenantId}-deploy-Role` 形式で Plane ごとに unique なので、 同一 AWS アカウントを複数 Plane (= 別 event / 別 TenkaCloud 環境) に並列接続できます。",
     "secret_modal_header": "競技者に共有する情報",
     "secret_modal_close": "閉じる",
     "secret_modal_warning_header": "この画面でのみ ExternalId を確認できます",

--- a/apps/application-admin-console/src/lib/default-competitor-role-name.test.ts
+++ b/apps/application-admin-console/src/lib/default-competitor-role-name.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { defaultCompetitorRoleName } from "./resource-naming";
+
+/**
+ * Issue #1314: SPA 側 generator が `events.ts` (backend) と同じロジックで Plane scope の
+ * unique 名を提案できることを assert する。
+ */
+describe("defaultCompetitorRoleName (SPA)", () => {
+  const IAM_ROLE_NAME_RE = /^[A-Za-z0-9_+=,.@-]{1,64}$/;
+  const TENKACLOUD_ROLE_RE = /^TenkaCloud-[-_A-Za-z0-9]+-Role$/;
+
+  it("should embed tenantId with default namespace", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme" })).toBe("TenkaCloud-acme-deploy-Role");
+  });
+
+  it("should produce different names for different tenantIds", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme" })).not.toBe(
+      defaultCompetitorRoleName({ tenantId: "beta" }),
+    );
+  });
+
+  it("should produce different names for different namespaces", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme", namespace: "deploy" })).not.toBe(
+      defaultCompetitorRoleName({ tenantId: "acme", namespace: "rehearsal" }),
+    );
+  });
+
+  it("should satisfy CFn AllowedPattern + TenkaCloud-{...}-Role shape", () => {
+    const name = defaultCompetitorRoleName({ tenantId: "acme" });
+    expect(name).toMatch(IAM_ROLE_NAME_RE);
+    expect(name).toMatch(TENKACLOUD_ROLE_RE);
+  });
+
+  it("should cap output at 64 chars", () => {
+    const name = defaultCompetitorRoleName({ tenantId: "a".repeat(200) });
+    expect(name.length).toBeLessThanOrEqual(64);
+  });
+});

--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -41,7 +41,7 @@ const KNOWN_ERRORS: Readonly<Record<string, FriendlyError>> = {
     hint: "指定した Role 名が、 競技者の AWS account に存在しません",
     possibleCauses: [
       "competitor-bootstrap.yaml が deploy されていない",
-      "Role 名の入力が間違っている (= default `TenkaCloud-CompetitorDeploy-Role` か確認)",
+      "Role 名の入力が間違っている (= モーダルが提案する `TenkaCloud-{tenantId}-deploy-Role` 形式と一致するか確認)",
       "競技者が手動で Role を削除した",
     ],
   },

--- a/apps/application-admin-console/src/lib/resource-naming.ts
+++ b/apps/application-admin-console/src/lib/resource-naming.ts
@@ -34,3 +34,35 @@ export function buildStackPrefix(problemId: string, teamName: string): string {
   const teamSlug = slugify(teamName);
   return `tc-${probSlug}-${teamSlug}`;
 }
+
+/**
+ * Issue #1314: 競技者 IAM Role 名は **Application Plane (= tenantId) ごとに unique** に
+ * 生成する。 同一 AWS account が 別 Plane / 別 event に並列参加するとき、 固定名
+ * `TenkaCloud-CompetitorDeploy-Role` を再利用すると CFn create-stack が
+ * `AlreadyExistsException` で fail するため、 Plane scope の namespace を含める。
+ *
+ *   TenkaCloud-{tenantId}-{namespace}-Role
+ *
+ * IAM Role 名 charclass (`[A-Za-z0-9_+=,.@-]{1,64}`) は CFn `competitor-bootstrap.yaml` の
+ * `AllowedPattern` と一致。 backend (`infrastructure/lib/problem-deploy/handlers/shared/events.ts`)
+ * の `defaultCompetitorRoleName` と同じロジック (= 1 場所に集約せず重複している理由は、
+ * SPA bundle が Lambda code を import すると node 専用 dep が芋づる的に入るため)。
+ */
+const IAM_ROLE_SANITIZE_RE = /[^A-Za-z0-9_+=,.@-]+/g;
+const IAM_ROLE_MAX_LENGTH = 64;
+
+function sanitizeRoleSegment(segment: string): string {
+  return segment.replace(IAM_ROLE_SANITIZE_RE, "-").replace(/^-+|-+$/g, "");
+}
+
+export function defaultCompetitorRoleName(opts: { tenantId: string; namespace?: string }): string {
+  const tenant = sanitizeRoleSegment(opts.tenantId) || "tenant";
+  const ns = sanitizeRoleSegment(opts.namespace ?? "deploy") || "deploy";
+  const candidate = `TenkaCloud-${tenant}-${ns}-Role`;
+  if (candidate.length <= IAM_ROLE_MAX_LENGTH) return candidate;
+  const suffix = `-${ns}-Role`;
+  const prefix = "TenkaCloud-";
+  const room = IAM_ROLE_MAX_LENGTH - prefix.length - suffix.length;
+  const truncated = tenant.slice(0, Math.max(1, room));
+  return `${prefix}${truncated}${suffix}`;
+}

--- a/apps/application-admin-console/src/pages/competitor-accounts/AddAccountModal.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/AddAccountModal.tsx
@@ -14,6 +14,7 @@ import { FriendlyErrorAlert } from "../../components/FriendlyErrorAlert";
 import type { AppConfig } from "../../config";
 import { useT } from "../../i18n";
 import { type FriendlyError, toFriendlyError } from "../../lib/friendly-error";
+import { defaultCompetitorRoleName } from "../../lib/resource-naming";
 
 const ACCOUNT_ID_RE = /^\d{12}$/;
 const ALIAS_MAX = 120;
@@ -28,10 +29,13 @@ interface AddAccountModalProps {
 export function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAccountModalProps) {
   const apiClient = useApiClient(config);
   const t = useT();
+  // Issue #1314: Plane (= tenantId) scope を含む unique 名を default で提案する。
+  // 同一競技者 AWS account を複数 Plane に並列接続できる (= 名前衝突しない)。
+  const suggestedRoleName = defaultCompetitorRoleName({ tenantId: config.tenantId });
   const [awsAccountId, setAwsAccountId] = useState("");
   const [alias, setAlias] = useState("");
   const [region, setRegion] = useState("ap-northeast-1");
-  const [competitorRoleName, setCompetitorRoleName] = useState("TenkaCloud-CompetitorDeploy-Role");
+  const [competitorRoleName, setCompetitorRoleName] = useState(suggestedRoleName);
   const [inFlight, setInFlight] = useState(false);
   const [error, setError] = useState<FriendlyError | null>(null);
 
@@ -39,7 +43,7 @@ export function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAc
     setAwsAccountId("");
     setAlias("");
     setRegion("ap-northeast-1");
-    setCompetitorRoleName("TenkaCloud-CompetitorDeploy-Role");
+    setCompetitorRoleName(suggestedRoleName);
     setError(null);
   };
 

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/types.ts
@@ -43,13 +43,13 @@ export const CreateCompetitorAccountRequestSchema = z
      */
     region: z.string().regex(AWS_REGION_RE, "AWS region 形式が不正です").default("ap-northeast-1"),
     /**
-     * 競技者側 bootstrap が作る IAM Role 名。`competitor-bootstrap.yaml` の default は
-     * `TenkaCloud-CompetitorDeploy-Role`。tenant ごとに変える運用も許す。
+     * 競技者側 bootstrap が作る IAM Role 名。 Issue #1314 以降、 frontend は
+     * `defaultCompetitorRoleName({ tenantId })` で Plane scope の unique 名 (例
+     * `TenkaCloud-acme-deploy-Role`) を提案する。 operator はそれを編集できるが、
+     * 固定 default を schema 側で持つと **caller の tenantId が抜けたとき暗黙に
+     * 名前衝突する** ため zod default は外す (= 呼び側で必ず明示)。
      */
-    competitorRoleName: z
-      .string()
-      .regex(IAM_ROLE_NAME_RE, "IAM Role 名の形式が不正です")
-      .default("TenkaCloud-CompetitorDeploy-Role"),
+    competitorRoleName: z.string().regex(IAM_ROLE_NAME_RE, "IAM Role 名の形式が不正です"),
     /** operator 表示用ラベル (例: `Team Acme prod`)。任意。 */
     alias: z.string().min(1).max(120).optional(),
   })

--- a/infrastructure/lib/problem-deploy/handlers/shared/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/events.ts
@@ -27,6 +27,53 @@ export const EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED = "DeployDeleteRequested"
  */
 export const EVENT_DETAIL_TYPE_BULK_DEPLOY_CREATE_REQUESTED = "BulkDeployCreateRequested" as const;
 
+/**
+ * Issue #1314: 競技者 IAM Role 名は **Application Plane (= tenantId) ごとに unique** に
+ * 生成する。 同一 AWS account が 別 Plane / 別 event に並列参加するときに固定名
+ * (`TenkaCloud-CompetitorDeploy-Role`) を再利用すると CFn create-stack が
+ * `AlreadyExistsException` で fail するため、 Plane scope の namespace を含める。
+ *
+ * 命名規約:
+ *
+ *   TenkaCloud-{tenantId}-{namespace}-Role
+ *
+ * - `tenantId`: Application Plane の識別子 (Lite mode は `"local"`)。
+ * - `namespace`: event / scenario 単位の suffix (default `"deploy"`)。 同 tenant 内で
+ *   さらに複数 deploy 経路を扱うときに operator が区別できるようにする。
+ *
+ * IAM Role 名の charclass (`[A-Za-z0-9_+=,.@-]{1,64}`) は CFn `competitor-bootstrap.yaml` の
+ * `AllowedPattern` と一致。 invalid char (空白 / `/` 等) を呼び側が混入させると AWS が
+ * reject するため、 generator 側で sanitize する責任を持つ。
+ *
+ * Backward-compat: 既存 DDB レコードの `competitorRoleName` は そのまま読まれる
+ * (= AssumeRole 経路は DDB を source of truth にしている)。 新規追加 (= AddAccountModal)
+ * の提案 default のみ本 helper が source。
+ */
+const IAM_ROLE_SANITIZE_RE = /[^A-Za-z0-9_+=,.@-]+/g;
+const IAM_ROLE_MAX_LENGTH = 64;
+
+function sanitizeRoleSegment(segment: string): string {
+  return segment.replace(IAM_ROLE_SANITIZE_RE, "-").replace(/^-+|-+$/g, "");
+}
+
+export function defaultCompetitorRoleName(opts: { tenantId: string; namespace?: string }): string {
+  const tenant = sanitizeRoleSegment(opts.tenantId) || "tenant";
+  const ns = sanitizeRoleSegment(opts.namespace ?? "deploy") || "deploy";
+  const candidate = `TenkaCloud-${tenant}-${ns}-Role`;
+  if (candidate.length <= IAM_ROLE_MAX_LENGTH) return candidate;
+  // 64 文字超過時は tenant segment を truncate (= 末尾 `-Role` は保持)。
+  const suffix = `-${ns}-Role`;
+  const prefix = "TenkaCloud-";
+  const room = IAM_ROLE_MAX_LENGTH - prefix.length - suffix.length;
+  const truncated = tenant.slice(0, Math.max(1, room));
+  return `${prefix}${truncated}${suffix}`;
+}
+
+/**
+ * @deprecated Issue #1314: 固定 Role 名は 同 AWS account が複数 Plane に並列参加するとき
+ * 衝突する。 新規 caller は `defaultCompetitorRoleName({ tenantId })` を使うこと。
+ * 既存配備 (DDB に固定名で保存済) は そのまま動作 (DDB が source of truth)。
+ */
 export const COMPETITOR_ROLE_NAME_DEFAULT = "TenkaCloud-CompetitorDeploy-Role" as const;
 
 /**

--- a/infrastructure/test/problem-deploy/default-competitor-role-name.test.ts
+++ b/infrastructure/test/problem-deploy/default-competitor-role-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { defaultCompetitorRoleName } from "../../lib/problem-deploy/handlers/shared/events.js";
+
+/**
+ * Issue #1314: 競技者 IAM Role 名は Application Plane (= tenantId) ごとに unique。
+ * 同一 AWS account が 別 Plane / 別 event に並列接続できることが本 helper の責務。
+ */
+describe("defaultCompetitorRoleName", () => {
+  const IAM_ROLE_NAME_RE = /^[A-Za-z0-9_+=,.@-]{1,64}$/;
+  const TENKACLOUD_ROLE_RE = /^TenkaCloud-[-_A-Za-z0-9]+-Role$/;
+
+  it("should embed tenantId and default namespace into the role name", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme" })).toBe("TenkaCloud-acme-deploy-Role");
+  });
+
+  it("should embed a custom namespace when provided", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme", namespace: "q1arena" })).toBe(
+      "TenkaCloud-acme-q1arena-Role",
+    );
+  });
+
+  it("should produce different names for different tenantIds (= no collision when same competitor account joins multiple Planes)", () => {
+    const a = defaultCompetitorRoleName({ tenantId: "acme" });
+    const b = defaultCompetitorRoleName({ tenantId: "beta" });
+    expect(a).not.toBe(b);
+  });
+
+  it("should produce the same name for same (tenantId, namespace)", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme" })).toBe(
+      defaultCompetitorRoleName({ tenantId: "acme" }),
+    );
+  });
+
+  it("should produce different names for different namespaces under the same tenantId", () => {
+    const a = defaultCompetitorRoleName({ tenantId: "acme", namespace: "deploy" });
+    const b = defaultCompetitorRoleName({ tenantId: "acme", namespace: "rehearsal" });
+    expect(a).not.toBe(b);
+  });
+
+  it("should always satisfy CFn competitor-bootstrap.yaml AllowedPattern", () => {
+    const samples = [
+      defaultCompetitorRoleName({ tenantId: "local" }),
+      defaultCompetitorRoleName({ tenantId: "tenant-with-dashes" }),
+      defaultCompetitorRoleName({ tenantId: "01JABC1234567890" }),
+      defaultCompetitorRoleName({ tenantId: "acme", namespace: "q1-arena" }),
+    ];
+    for (const name of samples) {
+      expect(name).toMatch(IAM_ROLE_NAME_RE);
+      expect(name).toMatch(TENKACLOUD_ROLE_RE);
+    }
+  });
+
+  it("should sanitize invalid IAM Role chars (space / slash) into dashes", () => {
+    const name = defaultCompetitorRoleName({ tenantId: "tenant/with space" });
+    expect(name).toMatch(IAM_ROLE_NAME_RE);
+    expect(name).toContain("tenant-with-space");
+  });
+
+  it("should truncate the tenant segment when the result would exceed 64 chars", () => {
+    const longTenant = "a".repeat(200);
+    const name = defaultCompetitorRoleName({ tenantId: longTenant });
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.startsWith("TenkaCloud-")).toBe(true);
+    expect(name.endsWith("-deploy-Role")).toBe(true);
+  });
+
+  it("should fall back to 'tenant' segment when the tenantId is all invalid chars", () => {
+    const name = defaultCompetitorRoleName({ tenantId: "///" });
+    expect(name).toBe("TenkaCloud-tenant-deploy-Role");
+  });
+});


### PR DESCRIPTION
## Summary

- Competitor IAM Role name was hardcoded to `TenkaCloud-CompetitorDeploy-Role`, which caused `AlreadyExistsException` when the same competitor AWS account tried to join a second Application Plane (= different event / TenkaCloud env). This blocked enterprise multi-Plane re-use of a single sandbox account.
- New default is `TenkaCloud-{tenantId}-{namespace}-Role` generated by `defaultCompetitorRoleName({ tenantId, namespace? })` in both `infrastructure/.../shared/events.ts` (backend) and `apps/.../lib/resource-naming.ts` (SPA). `AddAccountModal` proposes the unique name from `config.tenantId`; operators can still edit it.
- Backward-compat: existing CompetitorAccounts DDB rows are untouched. AssumeRole reads `competitorRoleName` from DDB (= source of truth), so the already-deployed `TenkaCloud-CompetitorDeploy-Role` bootstrap stacks keep working. Only newly registered (or re-registered) accounts pick up the per-Plane name.

Closes #1314

## Regression analysis

- **Existing CompetitorAccounts**: DDB-stored names are read as-is. AssumeRole / verify / deploy / describe-stack code paths use `account.competitorRoleName` (DDB), never the hardcoded constant. No data migration needed.
- **Backend zod schema**: `competitorRoleName` lost its `.default("TenkaCloud-CompetitorDeploy-Role")`. Every existing caller (UI + 14 tests) already passes the field explicitly, so removing the default does not silently break anyone. A caller that omits the field now gets a `400 validation_failed` — which is the correct behavior, since the implicit default is exactly what the bug is about.
- **Friendly error / i18n**: surface-only string changes (description + 1 hint). No state machine impact.
- **`COMPETITOR_ROLE_NAME_DEFAULT` constant**: kept as `@deprecated` re-export so any external consumer (or stale branch) keeps compiling. Marked for removal in a follow-up.
- **Bundle size**: helper + tests are < 1 KB. Lambda env / handler size unaffected.

## Physical impact

- **NO-OP** for every existing CFn stack (`tenkacloud-control-plane`, `tenkacloud-problem-deploy`, `tenkacloud-tenant-template-*`, `tenkacloud-admin-console-hosting`). No resource property changes — verified via `cdk synth`.
- **NO-OP** for Lambda runtime: code path that consumes the field reads DDB, not the constant.
- **NEW behavior**: a competitor bootstrap CFn stack created via the modal after this PR uses the per-Plane Role name (e.g. `TenkaCloud-acme-deploy-Role`). This is what unblocks Issue #1314.
- No AWS deploy required for this PR. Operator-facing default name change rolls out the next time the modal is opened.

## Test plan

- [x] `make harness` — no findings
- [x] `make before-commit` (lint / typecheck / test 1485 + 294 + 214 = 1993+ tests / build / validate-problems / synth) green
- [x] New unit tests cover: same tenantId twice → same name; different tenantIds → different names; different namespaces → different names; IAM AllowedPattern conformance; > 64-char truncation; all-invalid-char tenantId falls back to `tenant`
- [x] Backend zod schema regression: existing tests pass without changes (they all pass `competitorRoleName` explicitly)

## Before / After

```text
Before: TenkaCloud-CompetitorDeploy-Role         (collides on shared account)
After:  TenkaCloud-{tenantId}-deploy-Role
        e.g. TenkaCloud-local-deploy-Role        (Lite mode)
             TenkaCloud-acme-deploy-Role         (SaaS BASIC tenant)
             TenkaCloud-acme-q1arena-Role        (custom namespace)
```

Generator guarantees `^TenkaCloud-[-_A-Za-z0-9]+-Role$`, `length ≤ 64`, and sanitizes spaces / slashes to `-` to stay within the CFn `competitor-bootstrap.yaml` AllowedPattern.