### PR TITLE
fix(deploy): hello-world ParticipantViewerRole allows ssm:DescribeParameters

### DIFF
--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -85,6 +85,13 @@ const RESOURCE_STAR_OK_SIDS = new Set([
   // (= 参加者は console / CLI で自分の LB / TG / Listener / TargetHealth を観測する
   // のに必要)。 per-team dedicated AWS account 前提で cross-tenant leak リスクなし。
   "ReadLoadBalancerState",
+  // Issue #1316: hello-world hint で案内している AWS Console の SSM Parameter
+  // detail page は navigation chrome (sidebar list / breadcrumb) で
+  // ssm:DescribeParameters を呼ぶ。 これは AWS IAM 仕様で resource-level perm
+  // を受け付けない metadata-only API。 per-team dedicated AWS account 前提で
+  // cross-tenant leak リスクなし。 ConsoleEc2Metadata / ManageOwnTaskDefinitions
+  // / ReadLoadBalancerState と同じ扱い。
+  "DescribeOwnParameters",
 ]);
 
 describe("problem template ParticipantViewerRole (#744)", () => {


### PR DESCRIPTION
## Summary

- Hint 1 in `problems/challenges/hello-world/metadata.json` directs competitors to the `ParameterConsoleUrl` output; clicking it hit AccessDenied because the AWS Console SSM Parameter detail page calls `ssm:DescribeParameters` for sidebar / breadcrumb rendering.
- That API does not support resource-level permissions or tag-based Condition keys (AWS IAM spec). Under TenkaCloud's per-team dedicated AWS account model (= one account holds exactly one team's stack), granting it with `Resource:"*"` carries no cross-tenant leak risk - same allowlist treatment as `ConsoleEc2Metadata` / `ManageOwnTaskDefinitions` / `ReadLoadBalancerState` on other problems.
- Submodule bump: TenkaCloudChallenge PR-25 (https://github.com/susumutomita/TenkaCloudChallenge/pull/25) adds the new `DescribeOwnParameters` Sid plus an in-template comment that replaces the stale (incorrect) Outputs comment claiming the detail page only needs `ssm:GetParameter`.
- Platform-side allowlist update: `RESOURCE_STAR_OK_SIDS` in `problem-template-participant-viewer-role.test.ts` gains `"DescribeOwnParameters"`.

Closes #1316
Submodule companion PR: susumutomita/TenkaCloudChallenge#25

Other problems were checked - hello-world is the only template that surfaces a Console deep link or grants SSM Parameter access, so no other problems need this patch.

## Regression analysis

- New Sid `DescribeOwnParameters` grants only `ssm:DescribeParameters`. The existing `ReadOwnSsmParameters` Sid (= `GetParameter` family scoped to `arn:aws:ssm:*:*:parameter/${NamePrefix}/*`) is unchanged.
- per-team dedicated AWS account assumption means the assumed Role can only see Parameters that belong to its own deploy - there is no other team's data co-resident in the same account. ADR-021's "JAM/GameDay baseline = metadata-only API allowlist" guidance applies.
- `MaxSessionDuration` / `AssumeRolePolicyDocument` / `RoleName` / `Outputs` / `HelloParameter` are unchanged - no CFn drift on existing deploys; the next CFn UPDATE on existing stacks simply appends the new Sid (no resource replacement).
- Tests: `infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts` continues to enforce `Resource:"*" requires Condition or allowlisted Sid` for every Sid - the new Sid is explicitly allowlisted with a comment pointing back to this issue.

## Physical impact

- UPDATE - `hello-world` stack's `ParticipantViewerRole.Policies.ProblemSpecific` gains one new Statement (`DescribeOwnParameters`). Existing deploys do NOT need redeploy; new deploys (and any future `cfn update-stack` on existing ones) pick it up.
- NO-OP - no other CFn resource shape, IAM principal, or Output changes.
- NO-OP - no new Lambda / DDB / S3 / EventBridge resources on the platform side; only the test allowlist gains an entry.

## Test plan

- [x] `bunx vitest run test/problem-deploy/problem-template-participant-viewer-role.test.ts` -> 4/4 PASS (hello-world allowlist accepts the new Sid; the other three Battle templates remain at the same fail/pass status as origin/main and were not touched).
- [x] `make harness` -> no findings
- [x] `make before-commit` -> green (cdk synth needs `SYSTEM_ADMIN_EMAIL` env var as on all branches)
- [ ] Manual: deploy hello-world into a per-team account and confirm clicking `ParameterConsoleUrl` lands on the 200 detail page

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>