### PR TITLE
fix(portal): sequential hint reveal — Hint N requires Hint N-1 first — #1315

### DIFF
--- a/apps/participant-portal/src/api/portal-client/errors.ts
+++ b/apps/participant-portal/src/api/portal-client/errors.ts
@@ -9,7 +9,15 @@ import type { AssumeRoleStage } from "./types";
  */
 
 export class PortalValidationError extends Error {
-  constructor(public readonly errorCode: string) {
+  /**
+   * Issue #1315: 400 / 409 で backend が `error` 以外の付加 field (例: `missingHintId`) を
+   * 返すケース向けの optional 受け皿。 UI 側で error 種別ごとに必要な field を引き出して
+   * 親切メッセージを組み立てる (= 各 error 種別ごとに sub-class を量産しない軽量解)。
+   */
+  constructor(
+    public readonly errorCode: string,
+    public readonly details?: Readonly<Record<string, unknown>>,
+  ) {
     super("入力値が不正です。");
     this.name = "PortalValidationError";
   }

--- a/apps/participant-portal/src/api/portal-client/fetch.ts
+++ b/apps/participant-portal/src/api/portal-client/fetch.ts
@@ -42,6 +42,8 @@ interface PortalErrorBody {
   /** Issue #1197: assume_role_failed の付加情報。 stage = どちらの段で落ちたか、 reason = STS error name。 */
   readonly stage?: string;
   readonly reason?: string;
+  /** Issue #1315: hint_out_of_order の 「次に開けるべき直前 hint」 id。 */
+  readonly missingHintId?: string;
 }
 
 function isAssumeRoleStage(value: unknown): value is AssumeRoleStage {
@@ -85,6 +87,13 @@ async function throwConflictError(res: Response): Promise<never> {
   // Issue #1006: scoring gate 系の 409 は startsAt / endsAt を持つ専用 error にする。
   if (isScoringGateError(body.error)) {
     throw new PortalScoringGateError(body.error, body.startsAt, body.endsAt);
+  }
+  // Issue #1315: hint_out_of_order は body.missingHintId を details に詰めて UI が
+  // 「Hint N-1 を先に reveal してください」 文言を組み立てられるようにする。
+  if (body.error === "hint_out_of_order") {
+    throw new PortalValidationError("hint_out_of_order", {
+      missingHintId: body.missingHintId,
+    });
   }
   throw new PortalValidationError(body.error ?? "conflict");
 }

--- a/apps/participant-portal/src/components/ProblemPanelFlagSubmission.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanelFlagSubmission.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PortalValidationError } from "../api/portal-client";
+import { AppConfigProvider } from "../config-context";
+import { I18nProvider } from "../i18n";
+import { FlagSubmissionPanel } from "./ProblemPanelFlagSubmission";
+
+/**
+ * Issue #1315: progressive hint reveal の順序制約 (= Hint N は Hint 1..N-1 が
+ * revealed のときのみ enable) と、 backend 409 hint_out_of_order を受け取ったときの
+ * UI message 表示を pin する。
+ */
+
+const apiMocks = vi.hoisted(() => ({
+  revealHint: vi.fn(),
+  submitFlag: vi.fn(),
+}));
+
+vi.mock("../api/portal-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/portal-client")>();
+  return { ...actual, revealHint: apiMocks.revealHint, submitFlag: apiMocks.submitFlag };
+});
+
+function withProviders(node: React.ReactNode) {
+  // mode="backend" (= isMock=false) で revealHint API を実際に叩く (= mock 経由) ルートを通す。
+  return (
+    <AppConfigProvider
+      config={{
+        apiBaseUrl: "https://api.example.com",
+        eventTitle: "Test event",
+        eventRegion: "ap-northeast-1",
+        mode: "backend",
+        cloudMode: "real",
+      }}
+    >
+      <I18nProvider>{node}</I18nProvider>
+    </AppConfigProvider>
+  );
+}
+
+const HINTS_3 = [
+  { id: "hint-1", penalty: 10, revealed: false },
+  { id: "hint-2", penalty: 20, revealed: false },
+  { id: "hint-3", penalty: 30, revealed: false },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("HintsPanel order constraint (Issue #1315)", () => {
+  beforeEach(() => {
+    apiMocks.revealHint.mockReset();
+  });
+
+  function findRevealButtons(): HTMLButtonElement[] {
+    // disabled な reveal button は aria-label に "Reveal Hint N first..." を持つ。
+    // enabled な reveal button は inner text "Reveal hint" を持つ。 両方を拾うため
+    // accessible name regex を union で書く。
+    return screen.getAllByRole("button", {
+      name: /Reveal hint|ヒントを公開する|Reveal Hint \d+ first|ヒント \d+ を先に公開/,
+    }) as HTMLButtonElement[];
+  }
+
+  it("should enable only the first hint button when no hint is revealed", () => {
+    render(
+      withProviders(
+        <FlagSubmissionPanel
+          apiBaseUrl="https://api.example.com"
+          sessionToken="team-key"
+          problemId="hello-world"
+          flagSubmitted={false}
+          points={100}
+          hints={HINTS_3}
+          onScored={async () => undefined}
+        />,
+      ),
+    );
+    const buttons = findRevealButtons();
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toBeEnabled();
+    expect(buttons[1]).toBeDisabled();
+    expect(buttons[2]).toBeDisabled();
+  });
+
+  it("should enable hint 2 and keep hint 3 disabled after hint 1 is revealed", () => {
+    const hints = [
+      { ...HINTS_3[0], revealed: true, content: "h1 content" },
+      HINTS_3[1],
+      HINTS_3[2],
+    ] as typeof HINTS_3;
+    render(
+      withProviders(
+        <FlagSubmissionPanel
+          apiBaseUrl="https://api.example.com"
+          sessionToken="team-key"
+          problemId="hello-world"
+          flagSubmitted={false}
+          points={100}
+          hints={hints}
+          onScored={async () => undefined}
+        />,
+      ),
+    );
+    const buttons = findRevealButtons();
+    // hint-1 は revealed なので reveal button は出ない (= 2 個)
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toBeEnabled(); // hint-2
+    expect(buttons[1]).toBeDisabled(); // hint-3
+  });
+
+  it("should display a friendly error message when backend returns 409 hint_out_of_order", async () => {
+    // ユーザーが hint 1 を即座に reveal しようとした瞬間 (= state はまだ revealed=false で
+    // button enable) に race condition で hint-2 が backend に到達するケースを想定。
+    // backend の 409 hint_out_of_order を受け取って 「ヒント N を先に公開してください」 を出す。
+    apiMocks.revealHint.mockRejectedValueOnce(
+      new PortalValidationError("hint_out_of_order", { missingHintId: "hint-1" }),
+    );
+    const user = userEvent.setup();
+    render(
+      withProviders(
+        <FlagSubmissionPanel
+          apiBaseUrl="https://api.example.com"
+          sessionToken="team-key"
+          problemId="hello-world"
+          flagSubmitted={false}
+          points={100}
+          // hint-1 を artificially enable して click → reject される動線
+          hints={[{ ...HINTS_3[0], revealed: false }]}
+          onScored={async () => undefined}
+        />,
+      ),
+    );
+    const revealButton = screen.getByRole("button", { name: /Reveal hint|ヒントを公開する/ });
+    await user.click(revealButton);
+    // confirm modal の submit を押す
+    const confirmButton = await screen.findByRole("button", { name: /^Reveal$|^公開する$/ });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      // 「ヒント 1 を先に公開してください」 / 「Reveal Hint 1 first before this one.」 を期待
+      const errorEl = screen.queryByText(/Hint 1 first|ヒント 1 を先に公開/);
+      expect(errorEl).not.toBeNull();
+    });
+  });
+});

--- a/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
+++ b/apps/participant-portal/src/components/ProblemPanelFlagSubmission.tsx
@@ -9,6 +9,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
 import {
   type ParticipantHintView,
+  PortalValidationError,
   revealHint,
   type SubmitFlagOutcome,
   submitFlag,
@@ -167,6 +168,26 @@ function canSubmitFlag(flag: string, submitting: boolean): boolean {
 }
 
 /**
+ * Issue #1315: 409 hint_out_of_order は missingHintId を hints から index 引きして
+ * 「ヒント N を先に公開してください」 の親切文言を出す。 他の error は既存の
+ * formatProblemPanelActionError 経路に委譲する。
+ */
+function formatRevealError(
+  t: (key: string, params?: Readonly<Record<string, string | number>>) => string,
+  err: unknown,
+  hints: readonly ParticipantHintView[],
+): string {
+  if (err instanceof PortalValidationError && err.errorCode === "hint_out_of_order") {
+    const missingId =
+      typeof err.details?.missingHintId === "string" ? err.details.missingHintId : undefined;
+    const missingIdx = missingId ? hints.findIndex((h) => h.id === missingId) : -1;
+    const indexLabel = missingIdx >= 0 ? missingIdx + 1 : 1;
+    return t("problem_panel.hint_out_of_order_error", { index: indexLabel });
+  }
+  return formatProblemPanelActionError(t, err, "problem_panel.validation_error");
+}
+
+/**
  * Issue #742 Phase 4: progressive hint UI。
  *
  * - revealed=false (locked): 「ヒント N (-X pt)」 + 「reveal」 button
@@ -203,7 +224,7 @@ function HintsPanel({
       await revealHint(apiBaseUrl, sessionToken, problemId, hintId);
       await onRevealed();
     } catch (err) {
-      setRevealError(formatProblemPanelActionError(t, err, "problem_panel.validation_error"));
+      setRevealError(formatRevealError(t, err, hints));
     } finally {
       setRevealing(null);
       setPendingReveal(null);
@@ -218,42 +239,58 @@ function HintsPanel({
         header={t("problem_panel.hint_header", { revealed: revealedCount, total: hints.length })}
       >
         <SpaceBetween size="xs">
-          {hints.map((h, i) => (
-            <Box key={h.id}>
-              {h.revealed ? (
-                <Box>
-                  <strong>{t("problem_panel.hint_label_colon", { index: i + 1 })}</strong>{" "}
-                  {h.content}
-                  {h.revealedAt && (
-                    <Box variant="small" color="text-status-info" margin={{ top: "xxs" }}>
-                      {t("problem_panel.hint_revealed_ago", {
-                        ago: describeAgo(h.revealedAt, Date.now()),
-                      })}
-                    </Box>
-                  )}
-                </Box>
-              ) : (
-                <Box>
-                  <strong>{t("problem_panel.hint_label", { index: i + 1 })}</strong>{" "}
-                  <span style={{ color: h.penalty > 0 ? "#b54708" : "#475467" }}>
-                    {t("problem_panel.hint_penalty_note", { penalty: h.penalty })}
-                  </span>{" "}
-                  <Button
-                    variant="normal"
-                    iconName="lock-private"
-                    loading={revealing === h.id}
-                    disabled={revealing !== null && revealing !== h.id}
-                    onClick={() => {
-                      setPendingReveal(h);
-                      setPendingIndex(i);
-                    }}
-                  >
-                    {t("problem_panel.hint_reveal_button")}
-                  </Button>
-                </Box>
-              )}
-            </Box>
-          ))}
+          {hints.map((h, i) => {
+            // Issue #1315: progressive hint 順序制約。 Hint N (index i) は Hint 1..i が
+            // すべて revealed=true のときのみ button 有効。 backend (409 hint_out_of_order)
+            // と同じ contract を UI で先回り disable し、 不要な round trip を抑える。
+            const predecessorsRevealed = hints.slice(0, i).every((prev) => prev.revealed);
+            const lockedByOrder = !predecessorsRevealed;
+            const ariaLabel = lockedByOrder
+              ? t("problem_panel.hint_predecessor_required_aria", { index: i })
+              : undefined;
+            return (
+              <Box key={h.id}>
+                {h.revealed ? (
+                  <Box>
+                    <strong>{t("problem_panel.hint_label_colon", { index: i + 1 })}</strong>{" "}
+                    {h.content}
+                    {h.revealedAt && (
+                      <Box variant="small" color="text-status-info" margin={{ top: "xxs" }}>
+                        {t("problem_panel.hint_revealed_ago", {
+                          ago: describeAgo(h.revealedAt, Date.now()),
+                        })}
+                      </Box>
+                    )}
+                  </Box>
+                ) : (
+                  <Box>
+                    <strong>{t("problem_panel.hint_label", { index: i + 1 })}</strong>{" "}
+                    <span style={{ color: h.penalty > 0 ? "#b54708" : "#475467" }}>
+                      {t("problem_panel.hint_penalty_note", { penalty: h.penalty })}
+                    </span>{" "}
+                    <Button
+                      variant="normal"
+                      iconName="lock-private"
+                      loading={revealing === h.id}
+                      disabled={lockedByOrder || (revealing !== null && revealing !== h.id)}
+                      ariaLabel={ariaLabel}
+                      onClick={() => {
+                        setPendingReveal(h);
+                        setPendingIndex(i);
+                      }}
+                    >
+                      {t("problem_panel.hint_reveal_button")}
+                    </Button>
+                    {lockedByOrder && (
+                      <Box variant="small" color="text-status-inactive" margin={{ top: "xxs" }}>
+                        {t("problem_panel.hint_predecessor_required", { index: i })}
+                      </Box>
+                    )}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
           {revealError && (
             <Box color="text-status-error" variant="small">
               {revealError}

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -321,7 +321,10 @@
     "hint_confirm_submit": "Reveal",
     "hint_confirm_penalty": "Revealing will cost {penalty} pt. This cannot be undone.",
     "hint_confirm_no_penalty": "No penalty for this hint. Revealing will display the content.",
-    "hint_confirm_footer": "Hint text appears after reveal."
+    "hint_confirm_footer": "Hint text appears after reveal.",
+    "hint_predecessor_required": "Reveal Hint {index} first.",
+    "hint_predecessor_required_aria": "Reveal Hint {index} first before unlocking this one.",
+    "hint_out_of_order_error": "Reveal Hint {index} first before this one."
   },
   "score_timeline": {
     "header": "Score timeline",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -321,7 +321,10 @@
     "hint_confirm_submit": "公開する",
     "hint_confirm_penalty": "公開すると {penalty} pt 減点されます。 一度公開すると元に戻せません。",
     "hint_confirm_no_penalty": "このヒントには減点はありません。 公開するとヒントが表示されます。",
-    "hint_confirm_footer": "ヒント本文は公開後に表示されます。"
+    "hint_confirm_footer": "ヒント本文は公開後に表示されます。",
+    "hint_predecessor_required": "ヒント {index} を先に公開してください。",
+    "hint_predecessor_required_aria": "ヒント {index} を先に公開すると、このヒントが公開できます。",
+    "hint_out_of_order_error": "ヒント {index} を先に公開してください。"
   },
   "score_timeline": {
     "header": "スコア推移",

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -337,6 +337,11 @@ function respondHintRevealOutcome(
   if (outcome.kind === "scoring_ended") {
     return respondError(c, "scoring_ended", { endsAt: outcome.endsAt });
   }
+  if (outcome.kind === "hint_out_of_order") {
+    // Issue #1315: UI が 「Hint N-1 を先に reveal」 文言を組み立てるため、 missingHintId を
+    // body に含めて返す (= scoring_not_started + startsAt と同じ pattern)。
+    return respondError(c, "hint_out_of_order", { missingHintId: outcome.missingHintId });
+  }
   if (
     outcome.kind === "unauthorized" ||
     outcome.kind === "not_flag_problem" ||

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/reveal-hint.ts
@@ -28,6 +28,13 @@ export type RevealHintOutcome =
   | { kind: "not_flag_problem" }
   | { kind: "unknown_hint" }
   /**
+   * Issue #1315: ヒント順序制約。 Hint N は Hint 1..N-1 がすべて reveal 済のときのみ
+   * 開封できる (progressive hint convention)。 違反時は missingHintId (= 次に開ける
+   * べき直前 hint) を含めて 409 を返し、 UI は 「Hint N-1 を先に reveal してください」
+   * の親切文言を出す。
+   */
+  | { kind: "hint_out_of_order"; missingHintId: string }
+  /**
    * Issue #1005: 競技開始前 / 終了後 / scoringLocked 状態でヒント開封を block する。
    * submit-flag と同じ gate を共有 (event-gate.ts)。 旧来 reveal-hint は gate を見ず、
    * 開始前に開けて -penalty が accrue する公平性破壊バグがあった。
@@ -58,7 +65,10 @@ export async function revealHint(
   // Phase 3 は flag kind 限定で hints をサポート (= Phase 5 で他 4 kind に拡張)。
   if (scoring?.kind !== "flag") return { kind: "not_flag_problem" };
 
-  const hint = scoring.hints?.find((h) => h.id === hintId);
+  const hints = scoring.hints ?? [];
+  const hintIndex = hints.findIndex((h) => h.id === hintId);
+  if (hintIndex < 0) return { kind: "unknown_hint" };
+  const hint = hints[hintIndex];
   if (!hint) return { kind: "unknown_hint" };
 
   // 既に reveal 済か read-through で先に check (= UI の 「locked → unlocked」 UX で同 hint を
@@ -74,7 +84,34 @@ export async function revealHint(
     };
   }
 
+  // Issue #1315: 順序制約。 Hint N (index > 0) は Hint 1..N-1 がすべて reveal 済の
+  // ときのみ開封可。 違反時は missing する 「次に開けるべき直前 hint」 の id を返す
+  // (= UI で 「Hint N-1 を先に reveal」 文言を組み立てるため)。
+  const missingPredecessor = findMissingPredecessor(hints, hintIndex, alreadyRevealed);
+  if (missingPredecessor) {
+    return { kind: "hint_out_of_order", missingHintId: missingPredecessor };
+  }
+
   return updateHintReveal(shared, item, hint, hintId);
+}
+
+/**
+ * 順序制約 enforcer。 Hint index 0 は無条件 OK。 index > 0 のとき、 index 未満の hint が
+ * 1 つでも未 reveal なら最初の未 reveal hint の id を返す (= UI へのヒント)。
+ * 全先行 hint が reveal 済なら undefined。
+ */
+function findMissingPredecessor(
+  hints: readonly ProgressiveHint[],
+  targetIndex: number,
+  alreadyRevealed: readonly { readonly hintId: string }[],
+): string | undefined {
+  if (targetIndex <= 0) return undefined;
+  const revealedIds = new Set(alreadyRevealed.map((r) => r.hintId));
+  for (let i = 0; i < targetIndex; i++) {
+    const predecessor = hints[i];
+    if (predecessor && !revealedIds.has(predecessor.id)) return predecessor.id;
+  }
+  return undefined;
 }
 
 function isRevealHintItem(

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -28,6 +28,9 @@ const ERROR_STATUS = {
   not_flag_problem: StatusCodes.BAD_REQUEST,
   invalid_hint_id: StatusCodes.BAD_REQUEST,
   unknown_hint: StatusCodes.NOT_FOUND,
+  // Issue #1315: progressive hint の順序違反 (= Hint 1 未 reveal で Hint 2 を request)。
+  // 409 (= 状態的に受け付けない、 scoring_locked と同じ conflict 系) + body に missingHintId。
+  hint_out_of_order: StatusCodes.CONFLICT,
   no_outputs: StatusCodes.BAD_REQUEST,
   no_event: StatusCodes.NOT_FOUND,
   not_found: StatusCodes.NOT_FOUND,

--- a/infrastructure/test/problem-deploy/reveal-hint.test.ts
+++ b/infrastructure/test/problem-deploy/reveal-hint.test.ts
@@ -130,6 +130,91 @@ describe("revealHint (#742 Phase 3)", () => {
     expect(input.ExpressionAttributeValues?.[":neg"]).toBe(-10);
   });
 
+  // ---- Issue #1315: progressive hint の順序制約 (= Hint N は Hint 1..N-1 reveal 後のみ) ----
+  describe("hint reveal order constraint (Issue #1315)", () => {
+    it("should accept reveal of hint 1 unconditionally (no predecessor)", async () => {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100 })] });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 90 } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("ok");
+    });
+
+    it("should reject reveal of hint 2 when hint 1 not yet revealed", async () => {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ score: 100, hintsRevealed: [] })] });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-2");
+      expect(out.kind).toBe("hint_out_of_order");
+      if (out.kind !== "hint_out_of_order") return;
+      expect(out.missingHintId).toBe("hint-1");
+      // DDB UpdateItem は走らない (= score / hintsRevealed は変更されない)
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("should accept reveal of hint 2 after hint 1 revealed", async () => {
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({
+        Items: [
+          sampleRow({
+            score: 90,
+            hintsRevealed: [
+              { hintId: "hint-1", revealedAt: "2026-05-15T01:00:00.000Z", penaltyApplied: 10 },
+            ],
+          }),
+        ],
+      });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 70 } });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-2");
+      expect(out.kind).toBe("ok");
+      if (out.kind !== "ok") return;
+      expect(out.penaltyApplied).toBe(20);
+      expect(out.totalScore).toBe(70);
+    });
+
+    it("should preserve already_revealed (= same hint twice) when the hint is already in hintsRevealed", async () => {
+      // Regression pin: 順序制約の追加で 「既出 hint の二度押し」 idempotent 路を壊さないこと。
+      const { shared, ddbSend } = buildShared();
+      ddbSend.mockResolvedValueOnce({
+        Items: [
+          sampleRow({
+            score: 90,
+            hintsRevealed: [
+              { hintId: "hint-1", revealedAt: "2026-05-15T01:00:00.000Z", penaltyApplied: 10 },
+            ],
+          }),
+        ],
+      });
+      const out = await revealHint(shared, buildScoringMap(), TEAM_KEY, "hello-world", "hint-1");
+      expect(out.kind).toBe("already_revealed");
+      // UpdateItem は呼ばれない (= idempotent)
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("should report missing predecessor as the first unrevealed hint when skipping multiple", async () => {
+      // hints = [1,2,3]、 1 だけ reveal 済で 3 を request → missingHintId は 2 を返す。
+      const { shared, ddbSend } = buildShared();
+      const scoring = buildScoringMap([
+        { id: "hint-1", content: "h1", penalty: 5 },
+        { id: "hint-2", content: "h2", penalty: 10 },
+        { id: "hint-3", content: "h3", penalty: 15 },
+      ]);
+      ddbSend.mockResolvedValueOnce({
+        Items: [
+          sampleRow({
+            score: 95,
+            hintsRevealed: [
+              { hintId: "hint-1", revealedAt: "2026-05-15T01:00:00.000Z", penaltyApplied: 5 },
+            ],
+          }),
+        ],
+      });
+      const out = await revealHint(shared, scoring, TEAM_KEY, "hello-world", "hint-3");
+      expect(out.kind).toBe("hint_out_of_order");
+      if (out.kind !== "hint_out_of_order") return;
+      expect(out.missingHintId).toBe("hint-2");
+    });
+  });
+
   it("既に reveal 済の hintId は already_revealed (= content + 既存 score を返す、 idempotent)", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

ヒントの順序制約。 Hint 2 を Hint 1 未 reveal で取れる scoring abuse を防止。

- Backend: `reveal-hint.ts` に `findMissingPredecessor` を追加。 違反時は 409 CONFLICT + body `{ error: \"hint_out_of_order\", missingHintId: \"...\" }` を返す。
- Frontend: `HintsPanel` で先行 hint 未 reveal なら button を `disabled` + aria-label に理由を露出。 409 を受け取った場合は missingHintId から index 引きして親切文言を出す。
- i18n: ja + en の両方に `hint_predecessor_required` / `hint_predecessor_required_aria` / `hint_out_of_order_error` を追加。
- Tests: backend 4 件 + frontend 3 件追加。

Closes #1315

## Regression analysis

- 既存の 「同 hint 二重 reveal 不可」 idempotent (= already_revealed) 路を保持。
- Hint 1 は無条件 reveal 可 (= 後方互換)。
- 既存 `PortalValidationError` (1-arg constructor) caller は `details` 省略で互換。
- 既存 217 participant-portal tests 全 pass。 1510 infrastructure tests 全 pass。

## Physical impact

- CFn / IAM / Lambda runtime architecture: **NO-OP**。
- Lambda bundle (`participant-handler/reveal-hint` + `route-helpers`): **UPDATE**。
- SPA bundle (`participant-portal` component disable logic + i18n keys): **UPDATE**。
- DynamoDB schema: 不変 (= `hintsRevealed` attribute shape 同じ)。
- API contract: 新 error code `hint_out_of_order` (HTTP 409) を追加。 既存 200 / 404 / 既存 409 (scoring gate) は不変。

## Test plan

- [ ] Backend: `cd infrastructure && bunx vitest run test/problem-deploy/reveal-hint.test.ts` → 24 tests pass (4 new for #1315 + 20 regression).
- [ ] Frontend: `cd apps/participant-portal && bunx vitest run src/components/ProblemPanelFlagSubmission.test.tsx` → 3 new tests pass.
- [ ] Smoke: deploy Lite mode, open a Challenge problem with 3 hints, verify Hint 2 / 3 buttons are disabled until Hint 1 reveal completes; verify the friendly error message appears if a 409 is forced (e.g. via DevTools nuking the local state).