### PR TITLE
fix(problems): sync catalog checks with submodule

### DIFF
--- a/.claude/harness/src/rules/lambda-env-size.ts
+++ b/.claude/harness/src/rules/lambda-env-size.ts
@@ -177,44 +177,62 @@ export function checkTemplates(opts: CheckTemplatesOptions): Finding[] {
     const resources = template.Resources ?? {};
     for (const [logicalId, resource] of Object.entries(resources)) {
       if (resource.Type !== "AWS::Lambda::Function") continue;
-      const envVars = resource.Properties?.Environment?.Variables ?? {};
-      const measurement = measureEnvVariables(envVars);
-      const bucket = bucketFor(measurement.totalBytes);
-      if (bucket === "ok") continue;
-      const severity = bucket === "ge-warning" ? "warning" : "error";
-      const overLimitNote =
-        bucket === "ge-hard-limit"
-          ? ` (= AWS Lambda 4KB hard limit ${HARD_LIMIT_BYTES} bytes 超過、 deploy で必ず fail する)`
-          : bucket === "ge-error"
-            ? ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${HARD_LIMIT_BYTES - measurement.totalBytes} bytes)`
-            : ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${HARD_LIMIT_BYTES - measurement.totalBytes} bytes、 早めに掃除推奨)`;
-      findings.push({
-        ruleId: "lambda-env-size",
-        severity,
-        filePath: relPath,
-        line: 1,
-        // bucket 単位で baseline match (= 同 bucket 内なら byte 増減で baseline 外れない)
-        match: `${stackName}::${logicalId}::${bucket}`,
-        message:
-          `Lambda \`${logicalId}\` in stack \`${stackName}\` has total env size ` +
-          `${measurement.totalBytes} bytes${overLimitNote}. ` +
-          `Largest var: \`${measurement.largestKey}\` (${measurement.largestBytes} bytes).`,
-        recommendation:
-          "AWS Lambda 4KB hard limit. Move large env data to one of: " +
-          "(1) bundled module via esbuild `bundling.define` (literal substitution at build time, = #1158 / #1308 catalog pattern); " +
-          "(2) S3 + lazy fetch at cold start; " +
-          "(3) SSM Parameter Store SecureString (cost-zero, AGENTS.md secrets-manager-forbidden rule). " +
-          "See #1308 for the catalog/disruption bundling pattern.",
-      });
+      const finding = findingForLambdaEnv({ relPath, stackName, logicalId, resource });
+      if (finding) findings.push(finding);
     }
   }
   return findings;
 }
 
+interface LambdaEnvFindingInput {
+  readonly relPath: string;
+  readonly stackName: string;
+  readonly logicalId: string;
+  readonly resource: CfnResource;
+}
+
+function findingForLambdaEnv(input: LambdaEnvFindingInput): Finding | undefined {
+  const { relPath, stackName, logicalId, resource } = input;
+  const envVars = resource.Properties?.Environment?.Variables ?? {};
+  const measurement = measureEnvVariables(envVars);
+  const bucket = bucketFor(measurement.totalBytes);
+  if (bucket === "ok") return undefined;
+  const severity = bucket === "ge-warning" ? "warning" : "error";
+  return {
+    ruleId: "lambda-env-size",
+    severity,
+    filePath: relPath,
+    line: 1,
+    // bucket 単位で baseline match (= 同 bucket 内なら byte 増減で baseline 外れない)
+    match: `${stackName}::${logicalId}::${bucket}`,
+    message:
+      `Lambda \`${logicalId}\` in stack \`${stackName}\` has total env size ` +
+      `${measurement.totalBytes} bytes${overLimitNote(bucket, measurement.totalBytes)}. ` +
+      `Largest var: \`${measurement.largestKey}\` (${measurement.largestBytes} bytes).`,
+    recommendation:
+      "AWS Lambda 4KB hard limit. Move large env data to one of: " +
+      "(1) bundled module via esbuild `bundling.define` (literal substitution at build time, = #1158 / #1308 catalog pattern); " +
+      "(2) S3 + lazy fetch at cold start; " +
+      "(3) SSM Parameter Store SecureString (cost-zero, AGENTS.md secrets-manager-forbidden rule). " +
+      "See #1308 for the catalog/disruption bundling pattern.",
+  };
+}
+
+function overLimitNote(bucket: ReturnType<typeof bucketFor>, totalBytes: number): string {
+  if (bucket === "ge-hard-limit") {
+    return ` (= AWS Lambda 4KB hard limit ${HARD_LIMIT_BYTES} bytes 超過、 deploy で必ず fail する)`;
+  }
+  const margin = HARD_LIMIT_BYTES - totalBytes;
+  if (bucket === "ge-error") {
+    return ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${margin} bytes)`;
+  }
+  return ` (= 4KB hard limit ${HARD_LIMIT_BYTES} bytes に対し残 margin ${margin} bytes、 早めに掃除推奨)`;
+}
+
 export const lambdaEnvSize: Rule = {
   id: "lambda-env-size",
   severity: "error",
-  check(ctx: RuleContext): readonly Finding[] {
+  check(_ctx: RuleContext): readonly Finding[] {
     const cwd = process.cwd();
     if (!isCdkOutFresh(cwd)) {
       // cdk.out が無い fresh clone / synth 未実行ケース。 false negative より silent skip

--- a/.claude/harness/src/tech-debt/magic-number.ts
+++ b/.claude/harness/src/tech-debt/magic-number.ts
@@ -110,23 +110,15 @@ export interface LineScanResult {
 export function extractIntegersFromLine(line: string, initialState: ScannerState): LineScanResult {
   const ints: IntegerHit[] = [];
   let i = 0;
-  // line-comment は次の \n で終端する状態だが、 line-by-line scan の本関数は \n を見ない。
-  // 呼び出し元が前行の末尾で state="line-comment" のまま渡してきたら、 本関数開始時点で
-  // code に戻す (= line-comment は line 境界で必ず終わる)。
-  let state: ScannerState = initialState === "line-comment" ? "code" : initialState;
+  let state = resetLineComment(initialState);
   while (i < line.length) {
     const c = line[i] ?? "";
     const next = line[i + 1] ?? "";
     if (state === "code" && /[0-9]/.test(c)) {
-      const skip = consumeIdentifierIfDigitFollowsAlpha(line, i);
-      if (skip > i) {
-        i = skip;
-        continue;
-      }
-      const parsed = consumeNumericLiteral(line, i);
-      if (parsed) {
-        ints.push({ value: parsed.value, col: i });
-        i = parsed.end;
+      const numeric = scanNumericAt(line, i);
+      if (numeric?.value !== undefined) ints.push({ value: numeric.value, col: i });
+      if (numeric?.nextIndex !== undefined) {
+        i = numeric.nextIndex;
         continue;
       }
     }
@@ -138,6 +130,26 @@ export function extractIntegersFromLine(line: string, initialState: ScannerState
   // line-comment で行末まで進んだ場合、 次行は新しい code 状態から始める。
   if (state === "line-comment") state = "code";
   return { ints, nextState: state };
+}
+
+function resetLineComment(initialState: ScannerState): ScannerState {
+  // line-comment は次の \n で終端する状態だが、 line-by-line scan の本関数は \n を見ない。
+  // 呼び出し元が前行の末尾で state="line-comment" のまま渡してきたら、 本関数開始時点で
+  // code に戻す (= line-comment は line 境界で必ず終わる)。
+  return initialState === "line-comment" ? "code" : initialState;
+}
+
+interface NumericScanResult {
+  readonly nextIndex: number;
+  readonly value?: number;
+}
+
+function scanNumericAt(line: string, i: number): NumericScanResult | undefined {
+  const skip = consumeIdentifierIfDigitFollowsAlpha(line, i);
+  if (skip > i) return { nextIndex: skip };
+  const parsed = consumeNumericLiteral(line, i);
+  if (!parsed) return undefined;
+  return { value: parsed.value, nextIndex: parsed.end };
 }
 
 function consumeIdentifierIfDigitFollowsAlpha(line: string, i: number): number {

--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -159,7 +159,10 @@ describe("findProblemMetadata (Portal build-time catalog #550)", () => {
     it("security-battle-royale の locale='en' で英語翻訳を返すべき", () => {
       const m = requireProblemMetadata("security-battle-royale");
       const r = resolveLocalizedNarrative(m, "en");
-      expect(r.shortDescription).toMatch(/Attack\/defend/);
+      expect(r.shortDescription).not.toBe(m.shortDescription);
+      expect(r.shortDescription).not.toMatch(
+        /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u,
+      );
     });
   });
 });

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/audit-log.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/audit-log.ts
@@ -1,4 +1,4 @@
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import { requireRole, resolveTenantId, TENANT_ADMIN_ROLE } from "../../deploy-handler/auth.js";
 import { exportTenantAuditCsv, listTenantAuditEntries } from "../audit-log-read.js";
@@ -17,78 +17,99 @@ import type { EventSharedResources } from "../shared.js";
  * 提供する。
  */
 export function registerAuditLogRoutes(app: Hono, shared: EventSharedResources): void {
-  app.get("/admin/audit-log", async (c) => {
-    requireRole(c, [TENANT_ADMIN_ROLE]);
-    const auditTableName = process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "";
-    if (auditTableName.length === 0) {
-      return c.json({ error: "audit_log_unconfigured" }, StatusCodes.SERVICE_UNAVAILABLE);
-    }
-    const parsedLimit = parseLimit(c.req.query("limit"));
-    if (!parsedLimit) return c.json({ error: "invalid_limit" }, StatusCodes.BAD_REQUEST);
-    const from = c.req.query("from");
-    const to = c.req.query("to");
-    if (from && Number.isNaN(new Date(from).getTime())) {
-      return c.json({ error: "invalid_from" }, StatusCodes.BAD_REQUEST);
-    }
-    if (to && Number.isNaN(new Date(to).getTime())) {
-      return c.json({ error: "invalid_to" }, StatusCodes.BAD_REQUEST);
-    }
-    try {
-      const tenantId = resolveTenantId(c);
-      const result = await listTenantAuditEntries(
-        { ddb: shared.ddb, auditTableName },
-        {
-          tenantId,
-          ...(parsedLimit.limit ? { limit: parsedLimit.limit } : {}),
-          ...(c.req.query("cursor") ? { cursor: c.req.query("cursor") } : {}),
-          ...(from ? { from } : {}),
-          ...(to ? { to } : {}),
-          ...(c.req.query("principal") ? { principal: c.req.query("principal") } : {}),
-          ...(c.req.query("action") ? { action: c.req.query("action") } : {}),
-        },
-      );
-      return c.json(result, StatusCodes.OK);
-    } catch (err) {
-      return handleRouteError(c, "[events] listTenantAuditEntries failed", {}, err);
-    }
-  });
+  app.get("/admin/audit-log", (c) => handleAuditLogList(c, shared));
+  app.get("/admin/audit-log/export", (c) => handleAuditLogExport(c, shared));
+}
 
-  app.get("/admin/audit-log/export", async (c) => {
-    requireRole(c, [TENANT_ADMIN_ROLE]);
-    const auditTableName = process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "";
-    if (auditTableName.length === 0) {
-      return c.json({ error: "audit_log_unconfigured" }, StatusCodes.SERVICE_UNAVAILABLE);
-    }
-    const from = c.req.query("from");
-    const to = c.req.query("to");
-    if (from && Number.isNaN(new Date(from).getTime())) {
-      return c.json({ error: "invalid_from" }, StatusCodes.BAD_REQUEST);
-    }
-    if (to && Number.isNaN(new Date(to).getTime())) {
-      return c.json({ error: "invalid_to" }, StatusCodes.BAD_REQUEST);
-    }
-    try {
-      const tenantId = resolveTenantId(c);
-      const csv = await exportTenantAuditCsv(
-        { ddb: shared.ddb, auditTableName },
-        {
-          tenantId,
-          ...(from ? { from } : {}),
-          ...(to ? { to } : {}),
-          ...(c.req.query("principal") ? { principal: c.req.query("principal") } : {}),
-          ...(c.req.query("action") ? { action: c.req.query("action") } : {}),
-        },
-      );
-      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-      return new Response(csv, {
-        status: StatusCodes.OK,
-        headers: {
-          "content-type": "text/csv; charset=utf-8",
-          "content-disposition": `attachment; filename="audit-tenant-${tenantId}-${stamp}.csv"`,
-        },
-      });
-    } catch (err) {
-      return handleRouteError(c, "[events] exportTenantAuditCsv failed", {}, err);
-    }
+async function handleAuditLogList(c: Context, shared: EventSharedResources): Promise<Response> {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
+  const auditTableName = process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "";
+  if (auditTableName.length === 0) return auditLogUnconfigured(c);
+  const parsedLimit = parseLimit(c.req.query("limit"));
+  if (!parsedLimit) return c.json({ error: "invalid_limit" }, StatusCodes.BAD_REQUEST);
+  const parsedFilters = parseAuditFilters(c);
+  if (!parsedFilters.ok) return parsedFilters.response;
+  try {
+    const tenantId = resolveTenantId(c);
+    const result = await listTenantAuditEntries(
+      { ddb: shared.ddb, auditTableName },
+      {
+        tenantId,
+        ...(parsedLimit.limit ? { limit: parsedLimit.limit } : {}),
+        ...(c.req.query("cursor") ? { cursor: c.req.query("cursor") } : {}),
+        ...parsedFilters.filters,
+      },
+    );
+    return c.json(result, StatusCodes.OK);
+  } catch (err) {
+    return handleRouteError(c, "[events] listTenantAuditEntries failed", {}, err);
+  }
+}
+
+async function handleAuditLogExport(c: Context, shared: EventSharedResources): Promise<Response> {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
+  const auditTableName = process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "";
+  if (auditTableName.length === 0) return auditLogUnconfigured(c);
+  const parsedFilters = parseAuditFilters(c);
+  if (!parsedFilters.ok) return parsedFilters.response;
+  try {
+    const tenantId = resolveTenantId(c);
+    const csv = await exportTenantAuditCsv(
+      { ddb: shared.ddb, auditTableName },
+      { tenantId, ...parsedFilters.filters },
+    );
+    return csvResponse(csv, tenantId);
+  } catch (err) {
+    return handleRouteError(c, "[events] exportTenantAuditCsv failed", {}, err);
+  }
+}
+
+interface AuditFilters {
+  readonly from?: string;
+  readonly to?: string;
+  readonly principal?: string;
+  readonly action?: string;
+}
+
+type ParsedAuditFilters =
+  | { readonly ok: true; readonly filters: AuditFilters }
+  | { readonly ok: false; readonly response: Response };
+
+function parseAuditFilters(c: Context): ParsedAuditFilters {
+  const from = c.req.query("from");
+  const to = c.req.query("to");
+  if (isInvalidDate(from)) {
+    return { ok: false, response: c.json({ error: "invalid_from" }, StatusCodes.BAD_REQUEST) };
+  }
+  if (isInvalidDate(to)) {
+    return { ok: false, response: c.json({ error: "invalid_to" }, StatusCodes.BAD_REQUEST) };
+  }
+  return {
+    ok: true,
+    filters: {
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+      ...(c.req.query("principal") ? { principal: c.req.query("principal") } : {}),
+      ...(c.req.query("action") ? { action: c.req.query("action") } : {}),
+    },
+  };
+}
+
+function isInvalidDate(value: string | undefined): boolean {
+  return value !== undefined && Number.isNaN(new Date(value).getTime());
+}
+
+function auditLogUnconfigured(c: Context): Response {
+  return c.json({ error: "audit_log_unconfigured" }, StatusCodes.SERVICE_UNAVAILABLE);
+}
+
+function csvResponse(csv: string, tenantId: string): Response {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return new Response(csv, {
+    status: StatusCodes.OK,
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition": `attachment; filename="audit-tenant-${tenantId}-${stamp}.csv"`,
+    },
   });
 }

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -20,8 +20,6 @@ const TEMPLATES = [
       "ssm:StartSession",
       "ssm:TerminateSession",
       "cloudformation:DescribeStacks",
-      "logs:FilterLogEvents",
-      "lambda:GetFunction",
     ],
   },
   {
@@ -85,6 +83,16 @@ const RESOURCE_STAR_OK_SIDS = new Set([
   // (= 参加者は console / CLI で自分の LB / TG / Listener / TargetHealth を観測する
   // のに必要)。 per-team dedicated AWS account 前提で cross-tenant leak リスクなし。
   "ReadLoadBalancerState",
+  // TenkaCloudChallenge PR #25: microservice-migration-battle intentionally
+  // allows Console navigation list APIs. These reveal account-local names but
+  // do not grant cross-resource access; mutating/inspect grants remain
+  // ${NamePrefix}*-scoped in the same role.
+  "ConsoleListLambda",
+  "ConsoleListEcs",
+  "ConsoleListAppRunner",
+  "ConsoleListEcr",
+  "ConsoleListLogs",
+  "ConsoleListIamRoles",
   // Issue #1316: hello-world hint で案内している AWS Console の SSM Parameter
   // detail page は navigation chrome (sidebar list / breadcrumb) で
   // ssm:DescribeParameters を呼ぶ。 これは AWS IAM 仕様で resource-level perm

--- a/infrastructure/test/scripts/check-template-security.test.ts
+++ b/infrastructure/test/scripts/check-template-security.test.ts
@@ -54,6 +54,30 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       expect(findings).toEqual([]);
     });
 
+    it('should not return a finding for Resource: "*" when a NamePrefix tag condition scopes the statement', () => {
+      const findings = findIamResourceWildcardFindings(PATH, "loc", ["*"], ["ec2:CreateTags"], {
+        StringEquals: {
+          "aws:RequestTag/TenkaCloud:NamePrefix": "tc-demo-team",
+        },
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it("should not return a finding when an AWS service-specific condition scopes the statement to NamePrefix", () => {
+      const findings = findIamResourceWildcardFindings(
+        PATH,
+        "loc",
+        ["*"],
+        ["application-autoscaling:RegisterScalableTarget"],
+        {
+          StringLike: {
+            "application-autoscaling:resource-id": "service/NamePrefix*",
+          },
+        },
+      );
+      expect(findings).toEqual([]);
+    });
+
     it('should allow the CloudShell participant baseline on Resource: "*"', () => {
       const findings = findIamResourceWildcardFindings(
         PATH,

--- a/scripts/check-template-security.ts
+++ b/scripts/check-template-security.ts
@@ -74,7 +74,50 @@ const RESOURCE_STAR_OK_ACTIONS = new Set([
   "s3:GetBucketLocation",
   // Lambda — list verbs are global-scoped
   "lambda:ListFunctions",
+  "lambda:ListLayers",
+  "lambda:ListFunctionUrlConfigs",
+  "lambda:ListTags",
   "lambda:ListEventSourceMappings",
+  // ECS / App Runner / ECR / Cognito / CloudFront console navigation list verbs.
+  "ecs:ListClusters",
+  "ecs:ListServices",
+  "ecs:ListTasks",
+  "ecs:ListTaskDefinitions",
+  "ecs:ListTaskDefinitionFamilies",
+  "ecs:ListAccountSettings",
+  "apprunner:ListServices",
+  "apprunner:ListOperations",
+  "apprunner:ListTagsForResource",
+  "ecr:DescribeRepositories",
+  "ecr:DescribeImages",
+  "ecr:ListImages",
+  "ecr:ListTagsForResource",
+  "cognito-idp:ListUserPools",
+  "cognito-idp:ListUserPoolClients",
+  "cognito-idp:ListTagsForResource",
+  "cloudfront:ListDistributions",
+  "cloudfront:ListOriginAccessControls",
+  "cloudfront:ListTagsForResource",
+  // ELBv2 / CloudTrail / Athena / Glue read-only inventory APIs do not give
+  // useful resource-level scoping for the console discovery flows these
+  // problems require. Mutating access remains tag/ARN scoped in the templates.
+  "elasticloadbalancing:DescribeLoadBalancers",
+  "elasticloadbalancing:DescribeTargetGroups",
+  "elasticloadbalancing:DescribeListeners",
+  "elasticloadbalancing:DescribeRules",
+  "elasticloadbalancing:DescribeTargetHealth",
+  "elasticloadbalancing:DescribeTags",
+  "elasticloadbalancing:DescribeLoadBalancerAttributes",
+  "elasticloadbalancing:DescribeTargetGroupAttributes",
+  "elasticloadbalancing:DescribeAccountLimits",
+  "cloudtrail:ListTrails",
+  "cloudtrail:LookupEvents",
+  "athena:ListWorkGroups",
+  "athena:ListQueryExecutions",
+  "athena:ListDatabases",
+  "athena:ListTagsForResource",
+  "glue:GetDatabases",
+  "glue:SearchTables",
   // DynamoDB — list / describe per-account
   "dynamodb:ListTables",
   "dynamodb:DescribeTable",
@@ -156,12 +199,13 @@ export function findIamResourceWildcardFindings(
   loc: string,
   resources: readonly unknown[],
   actions: readonly unknown[],
+  condition?: unknown,
 ): Finding[] {
   if (!resources.includes("*")) return [];
   const actionList = actions.map((a) => (typeof a === "string" ? a : "")).filter(Boolean);
   const allRequireStar =
     actionList.length > 0 && actionList.every((a) => RESOURCE_STAR_OK_ACTIONS.has(a));
-  if (allRequireStar) return [];
+  if (allRequireStar || conditionScopesToNamePrefix(condition)) return [];
   return [
     {
       templatePath,
@@ -172,6 +216,28 @@ export function findIamResourceWildcardFindings(
   ];
 }
 
+function conditionScopesToNamePrefix(
+  condition: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): boolean {
+  if (Array.isArray(condition)) {
+    return condition.some((item) => conditionScopesToNamePrefix(item, seen));
+  }
+  if (!isPlainObject(condition)) return false;
+  if (seen.has(condition)) return false;
+  seen.add(condition);
+  for (const [key, value] of Object.entries(condition)) {
+    if (isNamePrefixScope(key, value) || conditionScopesToNamePrefix(value, seen)) return true;
+  }
+  return false;
+}
+
+function isNamePrefixScope(key: string, value: unknown): boolean {
+  if (key.endsWith("TenkaCloud:NamePrefix")) return true;
+  if (key !== "application-autoscaling:resource-id") return false;
+  return typeof value !== "string" || value.includes("NamePrefix");
+}
+
 function checkIamWildcards(template: unknown, results: Finding[], templatePath: string): void {
   visit(template, "", (loc, node) => {
     if (!isPlainObject(node)) return;
@@ -180,7 +246,9 @@ function checkIamWildcards(template: unknown, results: Finding[], templatePath: 
     const actions = toArrayField(node.Action);
     const resources = toArrayField(node.Resource);
     results.push(...findIamActionWildcardFindings(templatePath, loc, actions));
-    results.push(...findIamResourceWildcardFindings(templatePath, loc, resources, actions));
+    results.push(
+      ...findIamResourceWildcardFindings(templatePath, loc, resources, actions, node.Condition),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- Update the `problems` submodule pointer to the latest catalog commit.
- Align parent-repo tests with the current catalog metadata and ParticipantViewerRole IAM shape.
- Refactor leftover Biome complexity warnings in harness/audit-log code.
- Teach `check-template-security` to accept NamePrefix-scoped `Resource: "*"` statements and required console/list APIs used by the updated catalog.

## Test plan

- `make harness`
- `make before-commit`

## Regression analysis

- Root cause: the parent repo had tests and scanner assumptions pinned to an older `problems` submodule shape, while Biome complexity warnings were still present in touched code paths.
- The catalog-dependent assertions now verify the intended contracts instead of stale literal text or removed Lambda grants.
- The IAM scanner still flags unscoped `Resource: "*"` statements, but allows statements scoped by `TenkaCloud:NamePrefix` conditions or AWS APIs that require account-level list/describe access.

## Physical impact

- No deployed infrastructure changes are applied by this PR.
- Runtime behavior is unchanged except for audit-log route refactoring with the same request validation and responses.
- CI/local gates now pass against the updated problem catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization in rules and infrastructure handling.

* **Tests**
  * Enhanced security validation test coverage for template auditing and IAM resource policies.
  * Updated test expectations for security templates.

* **Chores**
  * Updated dependency references.
  * Expanded security scanning allowlists and added condition-scoping validation for resource wildcards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->