### PR TITLE
fix(scripts): make before-commit clean — exclude .cache + rsync prepare-source-bundle

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -5,6 +5,8 @@ dist
 build
 coverage
 .git
+.cache/
+.cache/**
 plans.md
 Plan.md
 docs/plans/

--- a/infrastructure/test/install-script.test.ts
+++ b/infrastructure/test/install-script.test.ts
@@ -44,7 +44,11 @@ describe("scripts/install.sh (Issue #1031: single-phase deploy)", () => {
   });
 
   it("prepare-source-bundle.sh should copy the `packages` directory to the staging root (workspace:* protocol)", () => {
-    expect(prepareBundle).toContain(`cp -R packages "\${STAGING}/packages"`);
+    // Issue: prepare-source-bundle hang on re-run — switched from `cp -R` to `rsync -a` with
+    // source-side excludes (node_modules / cdk.out / dist) to avoid copy-then-delete pattern.
+    expect(prepareBundle).toContain(
+      `rsync -a "\${RSYNC_EXCLUDES[@]}" packages/ "\${STAGING}/packages/"`,
+    );
   });
 
   it("prepare-source-bundle.sh should rewrite staging package.json workspaces from `infrastructure` to `cdk`", () => {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "build:problems-index": "bun run scripts/build-problem-index.ts",
     "check:problems-index": "bun run scripts/build-problem-index.ts --check",
     "audit:dependencies": "bun run scripts/audit-dependencies.ts",
-    "lint:md": "markdownlint-cli2 '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist' '#problems/**'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist' '#problems/**' '#.cache/**'",
     "lint:text": "textlint '**/*.md' '!problems/**'",
     "lint:format": "biome check",
-    "fix:md": "markdownlint-cli2 --fix '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist' '#problems/**'",
+    "fix:md": "markdownlint-cli2 --fix '**/*.md' '#**/node_modules' '#references' '#client' '#src' '#infrastructure/cdk.out' '#**/dist' '#problems/**' '#.cache/**'",
     "fix:text": "textlint --fix '**/*.md'",
     "fix:format": "biome check --write",
     "prepare": "husky"

--- a/scripts/prepare-source-bundle.sh
+++ b/scripts/prepare-source-bundle.sh
@@ -91,11 +91,26 @@ mkdir -p "${STAGING}"
 trap "rm -rf '${STAGING}'" EXIT INT TERM
 echo "[prepare-source-bundle] staging at ${STAGING}..."
 
+# `cp -R` は node_modules / dist / cdk.out をまず全部コピーしてから line 114 の find
+# で削除する pattern だったため、 巨大な node_modules を copy → delete で 30-60 秒
+# ハングしているように見えた (Issue: prepare-source-bundle hang on re-run)。
+# rsync で除外パスを source 側で skip すれば copy 自体が短くなる。
+# macOS / Linux 標準 rsync で動作。
+RSYNC_EXCLUDES=(
+  --exclude=node_modules
+  --exclude=cdk.out
+  --exclude=dist
+  --exclude=.cache
+  --exclude=.env
+  --exclude=.env.local
+  --exclude=.DS_Store
+)
+
 # SBT ref-arch 互換: infrastructure → cdk リネーム
-cp -R infrastructure "${STAGING}/cdk"
-cp -R scripts "${STAGING}/scripts"
-cp -R problems "${STAGING}/problems"
-cp -R packages "${STAGING}/packages"
+rsync -a "${RSYNC_EXCLUDES[@]}" infrastructure/ "${STAGING}/cdk/"
+rsync -a "${RSYNC_EXCLUDES[@]}" scripts/ "${STAGING}/scripts/"
+rsync -a "${RSYNC_EXCLUDES[@]}" problems/ "${STAGING}/problems/"
+rsync -a "${RSYNC_EXCLUDES[@]}" packages/ "${STAGING}/packages/"
 cp .nvmrc "${STAGING}/.nvmrc"
 cp package.json "${STAGING}/package.json"
 
@@ -110,9 +125,8 @@ with open(p, 'w') as f:
     json.dump(pkg, f, indent=2)
 "
 
-# clean up
-find "${STAGING}" -type d \( -name node_modules -o -name cdk.out -o -name dist \) -prune -exec rm -rf {} +
-find "${STAGING}" -type f \( -name ".env" -o -name ".env.local" \) -delete
+# rsync の --exclude が source 側で skip 済なので、 残り find clean up は念のための
+# 二重防御 (= rsync 漏れ + apps/ サブコピー時の .DS_Store 防止)。
 find "${STAGING}" -name ".DS_Store" -delete
 
 # dist は個別 copy (= 上記 find で消されているので)


### PR DESCRIPTION
## Summary

\`make before-commit\` was failing on fresh main checkouts due to two compounding issues:

1. **4 markdownlint + 34 textlint errors** in \`.cache/source-bundle/problems/...\` — the lint globs scanned a build cache directory that's regenerated by \`scripts/prepare-source-bundle.sh\`.
2. **\`prepare-source-bundle.sh\` appeared to hang** on re-run with cache present — \`cp -R infrastructure\` copied node_modules (~1GB) first, then \`find -prune\` deleted it. The cp ran 30-60s silently, looking hung.

## Fixes

- \`package.json\`: \`lint:md\` / \`fix:md\` globs add \`#.cache/**\` exclusion.
- \`.textlintignore\`: add \`.cache/\` + \`.cache/**\`.
- \`scripts/prepare-source-bundle.sh\`: switch from \`cp -R + find -prune\` to \`rsync -a\` with source-side \`--exclude=node_modules / cdk.out / dist / .cache / .env\`. Excluded paths skipped at source — copy phase is ~10x faster.
- \`infrastructure/test/install-script.test.ts\`: assertion updated to the new \`rsync\` line.

## Regression analysis

- \`make before-commit\` now exits 0 on fresh main (verified locally).
- \`rsync -a\` preserves attributes (mode / mtime / symlinks) — equivalent to \`cp -R\` for the staging-then-zip use case.
- \`.cache/\` is gitignored, so the exclude is purely a lint scope fix, not a behavior change.
- Excluded dirs (node_modules etc) were already cleaned by the post-copy find — same end result, faster.

## Physical impact

- NO-OP for CloudFormation / Lambda / runtime.
- UPDATE: \`scripts/prepare-source-bundle.sh\` — copy command swap.
- UPDATE: \`package.json\` lint scripts + \`.textlintignore\` — lint scope tightening.
- UPDATE: 1 test file — string-literal assertion updated.

## Why this kept recurring

Same structural pattern as #1308 (Lambda env 4KB): "tooling exits silently on edge cases, no harness rule catches it pre-merge". The lint globs and the cp -R pattern were both fragile against state that accumulates (\`.cache/\` between runs, dir contents during deploy prep). The fixes move both to a more declarative style (explicit excludes / rsync with --exclude).