### PR TITLE
fix(event-detail): time-aware effective status badge — #1330

### DIFF
--- a/apps/application-admin-console/src/components/event-detail/ScoringLockPanel.tsx
+++ b/apps/application-admin-console/src/components/event-detail/ScoringLockPanel.tsx
@@ -5,7 +5,7 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import type { EventDetail } from "../../api/events-client";
-import { Field, STATUS_COLOR } from "./shared";
+import { eventStatusBadge, Field } from "./shared";
 
 type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
@@ -33,7 +33,7 @@ export function ScoringLockPanel({
         <ColumnLayout columns={4} variant="text-grid">
           <Field label={t("event_detail.field_status")}>
             <SpaceBetween direction="horizontal" size="xxs">
-              <Badge color={STATUS_COLOR[detail.status]}>{detail.status}</Badge>
+              {eventStatusBadge(detail)}
               {detail.scoringLocked === true && (
                 <Badge color="red">{t("event_detail.scoring_locked_badge")}</Badge>
               )}

--- a/apps/application-admin-console/src/components/event-detail/shared.tsx
+++ b/apps/application-admin-console/src/components/event-detail/shared.tsx
@@ -8,6 +8,7 @@ import type {
   EventDetail,
   EventStatus,
 } from "../../api/events-client";
+import { computeEffectiveStatus, type EffectiveStatus } from "../../lib/effective-event-status";
 
 type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
@@ -30,6 +31,39 @@ export const STATUS_COLOR: Record<EventStatus, "blue" | "green" | "grey" | "red"
   TEARDOWN: "red",
   ARCHIVED: "grey",
 };
+
+/**
+ * #1330: effective status (= time-aware) ごとの badge 色。 RUNNING は競技進行中なので
+ * 引き続き green、 READY は「未開始」 を示すため blue に降格 (= 真の RUNNING との差別化)。
+ */
+export const EFFECTIVE_STATUS_COLOR: Record<EffectiveStatus, "blue" | "green" | "grey" | "red"> = {
+  DRAFT: "blue",
+  DEPLOYING: "blue",
+  READY: "blue",
+  RUNNING: "green",
+  ENDED: "grey",
+  TEARDOWN: "red",
+  ARCHIVED: "grey",
+};
+
+/**
+ * #1330: Event detail の status badge。 Phase indicator と同じ time-aware ロジックで
+ * effective status を計算して表示する (= DB の raw status は不変)。
+ */
+export function eventStatusBadge(
+  detail: Pick<EventDetail, "status" | "startsAt" | "endsAt">,
+  now: Date = new Date(),
+) {
+  const effective = computeEffectiveStatus(
+    {
+      status: detail.status,
+      startsAt: detail.startsAt ?? null,
+      endsAt: detail.endsAt ?? null,
+    },
+    now,
+  );
+  return <Badge color={EFFECTIVE_STATUS_COLOR[effective]}>{effective}</Badge>;
+}
 
 /**
  * 1 problem 行の deploy 状況サマリ: `成功 N / 全 M` + 失敗があれば赤 Badge を併記。

--- a/apps/application-admin-console/src/lib/effective-event-status.ts
+++ b/apps/application-admin-console/src/lib/effective-event-status.ts
@@ -1,0 +1,71 @@
+import type { EventStatus } from "../api/events-client";
+
+/**
+ * Issue #1330: 表示用の「effective status」 = raw `event.status` を時刻ベースで補正した値。
+ *
+ * 背景 (Phase indicator との乖離問題):
+ *   - DB 上の `event.status` は手動遷移 (= 運営者が「競技開始」 / 「Event を終了」 button で明示変更)。
+ *   - 一方 Phase indicator (= EventWizardPanel) は startsAt / endsAt / 現在時刻から動的計算するため、
+ *     startsAt を過ぎた瞬間に「競技中」 表示になる。
+ *   - 結果、 startsAt 過ぎ + status=READY のときに badge=「READY」 / Phase=「競技中」 で乖離。
+ *
+ * 解決方針 (Option A):
+ *   表示時にのみ effective status を計算 (DB の status field 自体は不変)。 これで Phase と
+ *   badge が常に同期する。 ENDED / TEARDOWN / ARCHIVED 等の terminal status は時刻無関係。
+ *
+ * 注意:
+ *   - terminal status (ARCHIVED / TEARDOWN / ENDED) は時刻に関係なく raw status を返す
+ *     (= 運営者が明示的に終了させた状態は時刻で巻き戻さない)。
+ *   - DEPLOYING は wizard step に渡るので effective status としてもそのまま透過する。
+ *   - DRAFT は startsAt が未来でも RUNNING にしない (= deploy 前提の workflow)。
+ */
+export type EffectiveStatus =
+  | "DRAFT"
+  | "DEPLOYING"
+  | "READY"
+  | "RUNNING"
+  | "ENDED"
+  | "TEARDOWN"
+  | "ARCHIVED";
+
+export interface EffectiveEventInput {
+  readonly status: EventStatus;
+  readonly startsAt?: string | null;
+  readonly endsAt?: string | null;
+}
+
+/**
+ * raw status + startsAt + endsAt + now から effective status を計算する純粋関数。
+ *
+ * 優先順位:
+ *   1. terminal status (ARCHIVED / TEARDOWN / ENDED) は時刻無視で raw 返却
+ *   2. DRAFT / DEPLOYING も時刻無視で raw 返却 (= deploy 前後では時刻に意味がない)
+ *   3. それ以外 (= READY) で endsAt 過ぎ → ENDED に昇格
+ *   4. startsAt 過ぎ (かつ endsAt 未到達) → RUNNING に昇格
+ *   5. どれにも当てはまらなければ raw status (= READY) を返す
+ */
+export function computeEffectiveStatus(
+  event: EffectiveEventInput,
+  now: Date = new Date(),
+): EffectiveStatus {
+  // 1. terminal status は時刻無関係 (= 運営者が明示的に倒した状態を尊重)
+  if (event.status === "ARCHIVED" || event.status === "TEARDOWN" || event.status === "ENDED") {
+    return event.status;
+  }
+  // 2. deploy 前後の status は時刻に意味がない (= 競技開始時刻を過ぎていても deploy 未完了は RUNNING ではない)
+  if (event.status === "DRAFT" || event.status === "DEPLOYING") {
+    return event.status;
+  }
+
+  const start = event.startsAt ? new Date(event.startsAt) : null;
+  const end = event.endsAt ? new Date(event.endsAt) : null;
+
+  // 3. endsAt 過ぎ → ENDED に昇格 (= 終了時刻予約が満了した READY)
+  if (end && now.getTime() >= end.getTime()) return "ENDED";
+
+  // 4. startsAt 過ぎ → RUNNING (= 競技中)
+  if (start && now.getTime() >= start.getTime()) return "RUNNING";
+
+  // 5. それ以外 (= READY + startsAt 未来 or startsAt なし)
+  return event.status;
+}

--- a/apps/application-admin-console/test/lib/effective-event-status.test.ts
+++ b/apps/application-admin-console/test/lib/effective-event-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { computeEffectiveStatus } from "../../src/lib/effective-event-status";
+
+const PAST = "2026-05-01T00:00:00Z";
+const FUTURE = "2099-01-01T00:00:00Z";
+const NOW = new Date("2026-05-24T12:00:00Z");
+
+describe("computeEffectiveStatus", () => {
+  it("should return DRAFT when status=DRAFT regardless of times", () => {
+    expect(computeEffectiveStatus({ status: "DRAFT" }, NOW)).toBe("DRAFT");
+    expect(computeEffectiveStatus({ status: "DRAFT", startsAt: PAST }, NOW)).toBe("DRAFT");
+    expect(computeEffectiveStatus({ status: "DRAFT", startsAt: PAST, endsAt: PAST }, NOW)).toBe(
+      "DRAFT",
+    );
+  });
+
+  it("should return DEPLOYING when status=DEPLOYING even after startsAt", () => {
+    expect(
+      computeEffectiveStatus({ status: "DEPLOYING", startsAt: PAST, endsAt: FUTURE }, NOW),
+    ).toBe("DEPLOYING");
+  });
+
+  it("should return READY when status=READY without any times", () => {
+    expect(computeEffectiveStatus({ status: "READY" }, NOW)).toBe("READY");
+  });
+
+  it("should return READY when status=READY and startsAt is in the future", () => {
+    expect(computeEffectiveStatus({ status: "READY", startsAt: FUTURE }, NOW)).toBe("READY");
+  });
+
+  it("should return RUNNING when status=READY, startsAt past, endsAt future", () => {
+    expect(computeEffectiveStatus({ status: "READY", startsAt: PAST, endsAt: FUTURE }, NOW)).toBe(
+      "RUNNING",
+    );
+  });
+
+  it("should return RUNNING when status=READY, startsAt past, endsAt null", () => {
+    expect(computeEffectiveStatus({ status: "READY", startsAt: PAST }, NOW)).toBe("RUNNING");
+    expect(computeEffectiveStatus({ status: "READY", startsAt: PAST, endsAt: null }, NOW)).toBe(
+      "RUNNING",
+    );
+  });
+
+  it("should return ENDED when status=READY, startsAt past, endsAt past", () => {
+    expect(computeEffectiveStatus({ status: "READY", startsAt: PAST, endsAt: PAST }, NOW)).toBe(
+      "ENDED",
+    );
+  });
+
+  it("should return ENDED when status=READY, endsAt past (without startsAt)", () => {
+    expect(computeEffectiveStatus({ status: "READY", endsAt: PAST }, NOW)).toBe("ENDED");
+  });
+
+  it("should treat endsAt equal to now as ENDED (boundary)", () => {
+    const exact = NOW.toISOString();
+    expect(computeEffectiveStatus({ status: "READY", endsAt: exact }, NOW)).toBe("ENDED");
+  });
+
+  it("should treat startsAt equal to now as RUNNING (boundary)", () => {
+    const exact = NOW.toISOString();
+    expect(computeEffectiveStatus({ status: "READY", startsAt: exact }, NOW)).toBe("RUNNING");
+  });
+
+  it("should return ENDED when status=ENDED regardless of times", () => {
+    expect(computeEffectiveStatus({ status: "ENDED", startsAt: FUTURE, endsAt: FUTURE }, NOW)).toBe(
+      "ENDED",
+    );
+  });
+
+  it("should return TEARDOWN when status=TEARDOWN regardless of times", () => {
+    expect(
+      computeEffectiveStatus({ status: "TEARDOWN", startsAt: PAST, endsAt: FUTURE }, NOW),
+    ).toBe("TEARDOWN");
+    expect(computeEffectiveStatus({ status: "TEARDOWN" }, NOW)).toBe("TEARDOWN");
+  });
+
+  it("should return ARCHIVED when status=ARCHIVED regardless of times", () => {
+    expect(computeEffectiveStatus({ status: "ARCHIVED", startsAt: PAST, endsAt: PAST }, NOW)).toBe(
+      "ARCHIVED",
+    );
+    expect(computeEffectiveStatus({ status: "ARCHIVED" }, NOW)).toBe("ARCHIVED");
+  });
+
+  it("should sync with Phase indicator: status=READY + startsAt past + endsAt future → RUNNING", () => {
+    // Phase indicator (= computeEventWizardState) では同条件で stepIndex=3 (= 「競技中」) になる。
+    // ここでの effective status も RUNNING を返すことで badge と Phase が同期する (#1330)。
+    const effective = computeEffectiveStatus(
+      { status: "READY", startsAt: PAST, endsAt: FUTURE },
+      NOW,
+    );
+    expect(effective).toBe("RUNNING");
+  });
+
+  it("should default the `now` argument to current time when omitted", () => {
+    // PAST < Date.now() なので RUNNING になるはず。
+    expect(computeEffectiveStatus({ status: "READY", startsAt: PAST })).toBe("RUNNING");
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #1330: Event Detail の status badge と Phase indicator が乖離していた問題 (startsAt 過ぎ + status=READY のとき badge=「READY」 / Phase=「競技中」) を修正。
- `lib/effective-event-status.ts` を追加し、 raw status + startsAt + endsAt + now から effective status (DRAFT / DEPLOYING / READY / RUNNING / ENDED / TEARDOWN / ARCHIVED) を計算する純粋関数を導入。
- `ScoringLockPanel` の badge を新 helper `eventStatusBadge()` に差し替え、 Phase indicator (= `computeEventWizardState`) と同じ time-aware ロジックで同期表示。
- terminal status (ARCHIVED / TEARDOWN / ENDED) と deploy 前後 (DRAFT / DEPLOYING) は時刻無視で raw 返却。 READY のときのみ時刻ベースで RUNNING / ENDED に昇格。
- DB 上の `event.status` field は不変 (= 運営者の手動制御を維持)、 表示のみ補正する Option A 方式。

Closes #1330

## Test plan

- [x] `bunx vitest run test/lib/effective-event-status.test.ts` — 15 ケースの matrix (DRAFT / DEPLOYING / READY × 各時刻フェーズ + boundary + ARCHIVED / TEARDOWN / ENDED の terminal 動作 + default `now` 引数省略) すべて pass
- [x] `bunx vitest run` (application-admin-console 全 341 tests) — 全 pass
- [x] `make harness` — error level violation 0 件
- [x] `make before-commit` — lint + typecheck + test + build + validate-problems + audit-deps + synth すべて green
- [ ] (visual) startsAt 過去 + endsAt 未来 + status=READY の event を Event Detail で開き、 badge が 「RUNNING」 + Phase indicator が 「4. 競技中」 で同期表示されることを確認

## Regression analysis

- DB 上の `event.status` は一切変更しない (= storage / API / event handlers は全 NO-OP)。 表示時にのみ effective status を計算するため、 採点 / scheduling / EventBridge 連携などの状態遷移ロジックには影響しない。
- `STATUS_COLOR` は raw EventStatus 用に残置 (= EventList 等は raw status を引き続き表示)。 新規 `EFFECTIVE_STATUS_COLOR` は effective status 専用。
- `eventStatusBadge` の引数は `Pick<EventDetail, "status" | "startsAt" | "endsAt">` で `startsAt` / `endsAt` が undefined / null のどちらでも安全に動作 (= null 合体演算子で正規化)。
- terminal status (ARCHIVED / TEARDOWN / ENDED) は時刻無関係で raw 返却するため、 「過去 endsAt を持つ ARCHIVED が再び ENDED に降格する」 ような表示ループは発生しない。
- 既存 `scoringBadge()` は #1095 の採点状況バッジ専用で別系統。 今回の effective status とは関心が異なるため影響しない。

## Physical impact

- **NO-OP**: CFn (= infrastructure stacks), Lambda artifacts, DynamoDB schema, EventBridge rules
- **UPDATE (SPA artifact)**: `apps/application-admin-console/dist/` の build hash が変化 (= 新 helper + Badge text の差分)
- **CREATE (source)**:
  - `apps/application-admin-console/src/lib/effective-event-status.ts` (純粋関数 + 型定義)
  - `apps/application-admin-console/test/lib/effective-event-status.test.ts` (15 matrix ケース)
- **UPDATE (source)**:
  - `apps/application-admin-console/src/components/event-detail/shared.tsx` (`EFFECTIVE_STATUS_COLOR` + `eventStatusBadge` 追加、 既存 `STATUS_COLOR` / `scoringBadge` は不変)
  - `apps/application-admin-console/src/components/event-detail/ScoringLockPanel.tsx` (raw status badge → `eventStatusBadge(detail)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event status badges now display time-aware information, automatically updating to reflect whether events are upcoming, currently running, or completed based on their scheduled start and end times.

* **Refactoring**
  * Event status badge rendering logic has been consolidated into a shared component, ensuring consistent display across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->