### PR TITLE
fix(lite): Lite mode user gets TenantAdmin role via Cognito Pre-Token trigger — #1327

### DIFF
--- a/infrastructure/lib/app-plane-core/app-plane-core.ts
+++ b/infrastructure/lib/app-plane-core/app-plane-core.ts
@@ -6,6 +6,7 @@ import { SamlIdpLambda } from "../problem-deploy/saml-idp-lambda.js";
 import { ApiGateway } from "../tenant-template/api-gateway.js";
 import { ApplicationAdminConsoleHosting } from "../tenant-template/application-admin-console-hosting.js";
 import { IdentityProvider } from "../tenant-template/identity-provider.js";
+import { LiteAdminClaimsLambda } from "./lite-admin-claims-lambda.js";
 
 /**
  * Issue #778 ADR-016 Phase 1: TenantTemplateStack から共通 App Plane コア構成を抽出する。
@@ -66,6 +67,16 @@ export interface AppPlaneCoreProps {
    * 配線をスキップする (= 後続 phase で ApiGateway 側にも optional 化を入れる予定)。
    */
   readonly apiKeyConfig: AppPlaneCoreApiKeyConfig;
+  /**
+   * Issue #1327: Lite mode 専用の opt-in flag。 `true` のとき Cognito Pre-Token Generation
+   * Lambda を UserPool に attach し、 JWT 発行直前に `custom:userRole = "TenantAdmin"` +
+   * `custom:tenantId = "local"` を注入する。
+   *
+   * SaaS mode (= SBT pipeline / `provision-tenant.sh` 経路) では `undefined` / `false` を渡し、
+   * Lambda trigger を一切立てない (= role 割り当ては SaaS 側 admin-create-user 経路に任せる)。
+   * 既定 `false` にすることで、 既存 SaaS / Full mode の CFn 物理差分を 0 件に保つ。
+   */
+  readonly liteAdminClaimsInjection?: boolean;
   // Issue #1066: SAML IdP 機能を廃止 (= MFA 必須化 #1035 で代替)。
 }
 
@@ -79,6 +90,11 @@ export interface AppPlaneCoreHandles {
    * 未配線時は undefined。
    */
   readonly samlIdpLambda?: SamlIdpLambda;
+  /**
+   * Issue #1327: `liteAdminClaimsInjection: true` を渡したときに立つ Pre-Token Generation Lambda。
+   * SaaS mode 経路では undefined のまま (= attach なし)。
+   */
+  readonly liteAdminClaimsLambda?: LiteAdminClaimsLambda;
 }
 
 /**
@@ -116,6 +132,15 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
         samlIdpsTable: props.samlIdpsTable,
         userPool: identityProvider.tenantUserPool,
         idpTierGuard: "silo",
+      })
+    : undefined;
+
+  // Issue #1327: Lite mode opt-in で Cognito Pre-Token Generation Lambda を UserPool に attach。
+  // SaaS mode 経路 (= flag 未指定 / false) では Lambda を一切立てず、 既存 stack の CFn 物理差分を
+  // 0 件に保つ。 Lambda は event を mutate して返すだけ (= IAM / external API call 不要)。
+  const liteAdminClaimsLambda = props.liteAdminClaimsInjection
+    ? new LiteAdminClaimsLambda(scope, "LiteAdminClaims", {
+        userPool: identityProvider.tenantUserPool,
       })
     : undefined;
 
@@ -169,5 +194,6 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
     apiGateway,
     applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
     ...(samlIdpLambda ? { samlIdpLambda } : {}),
+    ...(liteAdminClaimsLambda ? { liteAdminClaimsLambda } : {}),
   };
 }

--- a/infrastructure/lib/app-plane-core/handlers/pre-token-generation/index.ts
+++ b/infrastructure/lib/app-plane-core/handlers/pre-token-generation/index.ts
@@ -1,0 +1,52 @@
+import type { PreTokenGenerationTriggerEvent, PreTokenGenerationTriggerHandler } from "aws-lambda";
+
+/**
+ * Issue #1327: Lite mode Cognito UserPool 用 Pre-Token Generation trigger。
+ *
+ * ## なぜ必要か
+ * Lite mode (= `tenantId="local"` 1 tenant 専用) では SBT pipeline / `provision-tenant.sh`
+ * を経由しないため、 sign-up 直後の Cognito user は `custom:userRole` / `custom:tenantId`
+ * 属性が空 (= null) のままになる。 一方 Application Plane handler は SaaS mode と同じ
+ * `requireRole(c, [TENANT_ADMIN_ROLE])` で `custom:userRole == "TenantAdmin"` 必須、
+ * `resolveTenantId(c)` で `custom:tenantId` を読むため、 Lite mode で sign-in した user は
+ * SAML IdP / 監査ログ ページが 403 で開けない (= bug #1327 の症状)。
+ *
+ * ## 解決
+ * Cognito の Pre-Token Generation trigger を Lite mode UserPool に attach し、 id_token /
+ * access_token 発行のタイミングで `custom:userRole = "TenantAdmin"` + `custom:tenantId = "local"`
+ * を必ず claim に上書きする。 Lite mode は 1 tenant 専用 (= ADR-016 Phase 3) なので、
+ * 「全 user は暗黙に TenantAdmin」 という運用前提を JWT claim 層で具現化する。
+ *
+ * ## SaaS mode との分離
+ * SaaS mode の UserPool には本 Lambda を attach しない (= `IdentityProvider` のオプトイン flag
+ * `liteAdminClaimsInjection: true` 経由でのみ追加される)。 SaaS の role 割り当ては
+ * `provision-tenant.sh` の `admin-create-user` + SBT pipeline 経由なので、 本 Lambda が
+ * 暗黙の TenantAdmin 昇格を引き起こすことは無い。
+ *
+ * ## なぜ event を mutate するだけで済むか
+ * Cognito Pre-Token Generation は handler が `event.response.claimsOverrideDetails.claimsToAddOrOverride`
+ * を返すと、 JWT 発行直前にその key / value を claim に注入する (= AWS doc: Customizing user
+ * pool workflows with Lambda triggers / Pre token generation Lambda trigger)。 IAM / 外部
+ * API call は不要。
+ *
+ * ## 注意 (= overwrite ではなく override)
+ * `claimsToAddOrOverride` は既存 claim を **上書き** する仕様 (= 既存 user attribute に
+ * `custom:userRole` が別値で設定されていても本 Lambda の値で上書きされる)。 Lite mode は
+ * 全員 TenantAdmin / tenantId=local 前提なので intentional な挙動。
+ */
+export const LITE_TENANT_ADMIN_ROLE = "TenantAdmin" as const;
+export const LITE_TENANT_ID = "local" as const;
+
+export const handler: PreTokenGenerationTriggerHandler = async (
+  event: PreTokenGenerationTriggerEvent,
+) => {
+  event.response = {
+    claimsOverrideDetails: {
+      claimsToAddOrOverride: {
+        "custom:userRole": LITE_TENANT_ADMIN_ROLE,
+        "custom:tenantId": LITE_TENANT_ID,
+      },
+    },
+  };
+  return event;
+};

--- a/infrastructure/lib/app-plane-core/index.ts
+++ b/infrastructure/lib/app-plane-core/index.ts
@@ -4,3 +4,4 @@ export type {
   AppPlaneCoreProps,
 } from "./app-plane-core.js";
 export { buildAppPlaneCore } from "./app-plane-core.js";
+export { LiteAdminClaimsLambda } from "./lite-admin-claims-lambda.js";

--- a/infrastructure/lib/app-plane-core/lite-admin-claims-lambda.ts
+++ b/infrastructure/lib/app-plane-core/lite-admin-claims-lambda.ts
@@ -1,0 +1,73 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { UserPool } from "aws-cdk-lib/aws-cognito";
+import { UserPoolOperation } from "aws-cdk-lib/aws-cognito";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime.js";
+
+export interface LiteAdminClaimsLambdaProps {
+  /**
+   * Lite mode UserPool。 本 Lambda は Pre-Token Generation trigger として attach され、
+   * JWT 発行直前に `custom:userRole = "TenantAdmin"` + `custom:tenantId = "local"` を注入する。
+   */
+  readonly userPool: UserPool;
+}
+
+/**
+ * Issue #1327: Lite mode 専用の Cognito Pre-Token Generation Lambda construct。
+ *
+ * ## なぜ別 construct か
+ * SaaS mode の UserPool には絶対 attach しない (= SBT 経路の role 割り当てを汚さない)。
+ * オプトイン flag (`liteAdminClaimsInjection`) で TenkaCloudLiteStack だけが本 construct を
+ * 立てるよう scope を絞る。 IdentityProvider 直下に書くと SaaS / Lite の分岐が増えるため、
+ * Lite 専用構築物として独立させる。
+ *
+ * ## IAM / env / network
+ * 本 Lambda は event を mutate して返すだけ (= 外部 service call 不要)。 IAM 追加権限・
+ * env / VPC は不要。 timeout 5s / memory 128MB で十分 (Cognito の sync invoke 上限 5s も満たす)。
+ *
+ * ## addTrigger の挙動
+ * `userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION, fn)` は CFn 上で UserPool の
+ * `LambdaConfig.PreTokenGeneration` を本 Lambda の ARN に設定し、 同時に Cognito service
+ * principal が本 Lambda を invoke するための resource-based policy も自動追加する。
+ */
+export class LiteAdminClaimsLambda extends Construct {
+  public readonly fn: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: LiteAdminClaimsLambdaProps) {
+    super(scope, id);
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(import.meta.dirname, "./handlers/pre-token-generation/index.ts"),
+      handler: "handler",
+      // Cognito Pre-Token Generation trigger は sync invoke で 5s が上限。 Lambda の
+      // timeout を 5s に揃え、 cold start で trigger が timeout して JWT 発行が失敗する
+      // 経路を避ける (= warm 化された後は数 ms で完了)。
+      timeout: Duration.seconds(5),
+      memorySize: 128,
+      environment: {
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: LAMBDA_NODEJS_BUNDLING_TARGET,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
+        externalModules: [],
+      },
+    });
+
+    // UserPool に Pre-Token Generation trigger として bind する。 これにより
+    //   - UserPool.LambdaConfig.PreTokenGeneration が fn ARN を指す
+    //   - fn の resource-based policy に Cognito 経由の invoke 権限が自動追加される
+    // が同時に行われる。
+    props.userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION, this.fn);
+  }
+}

--- a/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
+++ b/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
@@ -90,6 +90,12 @@ export class TenkaCloudLiteStack extends Stack {
       samlIdpsTable: samlIdps.table,
       participantPortalUrl: props.participantPortalUrl,
       competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+      // Issue #1327: Lite mode は 1 tenant 専用 (tenantId="local") なので全 user が
+      // 暗黙に TenantAdmin。 Cognito Pre-Token Generation trigger で JWT 発行時に
+      // `custom:userRole=TenantAdmin` + `custom:tenantId=local` を注入し、
+      // SAML IdP / 監査ログ ページの `requireRole(c, [TENANT_ADMIN_ROLE])` を成立させる。
+      // SaaS mode (= TenantTemplateStack) では本 flag は未指定 (= attach なし)。
+      liteAdminClaimsInjection: true,
       apiKeyConfig: {
         ssmParameterNames: {
           basic: { keyId: `${liteApiKeyPlaceholder}-basic-id`, value: liteApiKeyPlaceholder },

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -83,6 +83,55 @@ describe("buildAppPlaneCore", () => {
     expect(logouts.length).toBeGreaterThan(0);
   });
 
+  // Issue #1327: SaaS mode (= `liteAdminClaimsInjection` 未指定) では Pre-Token Generation Lambda を
+  // 立てない (= SBT pipeline / provision-tenant.sh の role 割り当てを汚さない)。 既存 SaaS / Full mode の
+  // CFn 物理差分が 0 件であることを機械的に保証する。
+
+  it("should NOT attach a Pre-Token Generation Lambda when liteAdminClaimsInjection is not set (SaaS mode regression guard)", () => {
+    const template = synth();
+    const userPools = template.findResources("AWS::Cognito::UserPool");
+    const userPool = Object.values(userPools)[0];
+    const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
+      ?.LambdaConfig;
+    // LambdaConfig 自体が無いか、 PreTokenGeneration key が無い (= SaaS mode regression なし)。
+    expect(lambdaConfig?.PreTokenGeneration).toBeUndefined();
+  });
+
+  it("should attach a Pre-Token Generation Lambda when liteAdminClaimsInjection is true (#1327)", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    buildAppPlaneCore(stack, {
+      tenantId: "tenant-1",
+      tenantName: "Tenant 1",
+      environment: "development",
+      isPooledDeploy: false,
+      deployApiLambda: buildStubLambda(stack, "StubDeploy"),
+      eventApiLambda: buildStubLambda(stack, "StubEvent"),
+      competitorAccountsApiLambda: buildStubLambda(stack, "StubCompetitorAccounts"),
+      liteAdminClaimsInjection: true,
+      apiKeyConfig: {
+        ssmParameterNames: {
+          basic: { keyId: "basic-id", value: "basic-val" },
+          standard: { keyId: "standard-id", value: "standard-val" },
+          premium: { keyId: "premium-id", value: "premium-val" },
+          platinum: { keyId: "platinum-id", value: "platinum-val" },
+        },
+        ssmLookup: (name: string) => `SSM:${name}`,
+      },
+    });
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties(
+      "AWS::Cognito::UserPool",
+      Match.objectLike({
+        LambdaConfig: Match.objectLike({
+          PreTokenGeneration: Match.anyValue(),
+        }),
+      }),
+    );
+  });
+
   it("the returned applicationAdminConsoleUrl should equal hosting.distributionUrl", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack", {

--- a/infrastructure/test/app-plane-core/handlers/pre-token-generation.test.ts
+++ b/infrastructure/test/app-plane-core/handlers/pre-token-generation.test.ts
@@ -1,0 +1,94 @@
+import type { PreTokenGenerationTriggerEvent } from "aws-lambda";
+import { describe, expect, it } from "vitest";
+import {
+  handler,
+  LITE_TENANT_ADMIN_ROLE,
+  LITE_TENANT_ID,
+} from "../../../lib/app-plane-core/handlers/pre-token-generation/index.js";
+
+/**
+ * Issue #1327: Pre-Token Generation handler の契約 pin。
+ *
+ * Cognito の trigger 仕様 (= 同期 / event mutate 経由で JWT claim を上書き) を
+ * input → output で固定する。 SaaS mode handler の `requireRole(c, [TENANT_ADMIN_ROLE])` +
+ * `resolveTenantId(c)` が成立するために必要な 2 claim (`custom:userRole` / `custom:tenantId`)
+ * が必ず注入されることを保証する。
+ */
+
+function buildEvent(
+  overrides?: Partial<PreTokenGenerationTriggerEvent>,
+): PreTokenGenerationTriggerEvent {
+  return {
+    version: "1",
+    triggerSource: "TokenGeneration_HostedAuth",
+    region: "ap-northeast-1",
+    userPoolId: "ap-northeast-1_AAA",
+    userName: "operator@example.com",
+    callerContext: { awsSdkVersion: "aws-sdk-unknown-unknown", clientId: "client-123" },
+    request: {
+      userAttributes: {
+        sub: "00000000-0000-0000-0000-000000000000",
+        email: "operator@example.com",
+        email_verified: "true",
+      },
+      groupConfiguration: {
+        groupsToOverride: [],
+        iamRolesToOverride: [],
+        preferredRole: undefined,
+      },
+    },
+    response: {
+      claimsOverrideDetails: null,
+    },
+    ...overrides,
+  } as PreTokenGenerationTriggerEvent;
+}
+
+describe("Pre-Token Generation handler (#1327)", () => {
+  it("should inject custom:userRole=TenantAdmin and custom:tenantId=local into JWT claims", async () => {
+    const event = buildEvent();
+    const result = await handler(event, {} as never, () => undefined);
+    expect(result).toBeDefined();
+    const claims =
+      (result as PreTokenGenerationTriggerEvent).response.claimsOverrideDetails
+        ?.claimsToAddOrOverride ?? {};
+    expect(claims["custom:userRole"]).toBe("TenantAdmin");
+    expect(claims["custom:tenantId"]).toBe("local");
+  });
+
+  it("should preserve the input event shape (Cognito trigger contract: handler returns the mutated event)", async () => {
+    const event = buildEvent();
+    const result = (await handler(
+      event,
+      {} as never,
+      () => undefined,
+    )) as PreTokenGenerationTriggerEvent;
+    // Cognito requires the handler to return the event (sync invoke). Confirm identity is preserved.
+    expect(result.userPoolId).toBe(event.userPoolId);
+    expect(result.userName).toBe(event.userName);
+    expect(result.triggerSource).toBe(event.triggerSource);
+  });
+
+  it("should override existing custom:userRole / custom:tenantId if the user attribute is already set", async () => {
+    // Lite mode は 1 tenant 前提なので、 仮に user attribute に別 role/tenant が入っていても
+    // JWT 上は強制 TenantAdmin / local に倒す (= 運用契約)。
+    const event = buildEvent();
+    event.request.userAttributes["custom:userRole"] = "ReadOnly";
+    event.request.userAttributes["custom:tenantId"] = "some-other-tenant";
+    const result = (await handler(
+      event,
+      {} as never,
+      () => undefined,
+    )) as PreTokenGenerationTriggerEvent;
+    const claims = result.response.claimsOverrideDetails?.claimsToAddOrOverride ?? {};
+    expect(claims["custom:userRole"]).toBe("TenantAdmin");
+    expect(claims["custom:tenantId"]).toBe("local");
+  });
+
+  it("should export constants matching the Application Plane handler expectations", () => {
+    // SaaS mode handler が require する `TENANT_ADMIN_ROLE` 値と一致していること。
+    expect(LITE_TENANT_ADMIN_ROLE).toBe("TenantAdmin");
+    // Lite mode の固定 tenantId (= TenkaCloudLiteStack の LITE_TENANT_ID と一致)。
+    expect(LITE_TENANT_ID).toBe("local");
+  });
+});

--- a/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
+++ b/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
@@ -195,6 +195,30 @@ describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
     );
   });
 
+  // Issue #1327: Lite mode user に `custom:userRole=TenantAdmin` + `custom:tenantId=local` を
+  // JWT 発行時に注入する Pre-Token Generation Lambda が UserPool に attach されていることを pin。
+
+  it("should attach a Pre-Token Generation Lambda trigger on the Lite UserPool (#1327)", () => {
+    const template = synth();
+    template.hasResourceProperties(
+      "AWS::Cognito::UserPool",
+      Match.objectLike({
+        LambdaConfig: Match.objectLike({
+          PreTokenGeneration: Match.anyValue(),
+        }),
+      }),
+    );
+  });
+
+  it("should bundle a LiteAdminClaims Lambda Function for the Pre-Token Generation trigger (#1327)", () => {
+    const template = synth();
+    const functions = template.findResources("AWS::Lambda::Function");
+    const liteAdminClaims = Object.entries(functions).find(
+      ([name]) => name.includes("LiteAdminClaims") && name.includes("Function"),
+    );
+    expect(liteAdminClaims).toBeDefined();
+  });
+
   it("should expose /tenant/idp and /tenant/idp/{idpId} routes on the tenant REST API (#1312)", () => {
     const template = synth();
     // ApiGateway は /tenant/idp (GET POST) と /tenant/idp/{idpId} (GET PATCH DELETE) を生やすので、


### PR DESCRIPTION
## Summary

- Lite mode (= `tenantId="local"` 1 tenant 専用) で sign-in した user に `custom:userRole=TenantAdmin` + `custom:tenantId=local` が JWT に乗らず、 SAML IdP / 監査ログ ページが 403 になる #1327 を解消する。
- Cognito Pre-Token Generation trigger Lambda を Lite mode UserPool だけに attach し、 JWT 発行直前に 2 claim を強制注入する (Option A、 handler 側 mode 分岐ゼロ)。
- SaaS mode UserPool には新 flag (`liteAdminClaimsInjection`) を渡さないので Lambda は一切立たない (= SBT pipeline / `provision-tenant.sh` の role 割り当てを汚さない)。

Closes #1327

## Changes

- `infrastructure/lib/app-plane-core/handlers/pre-token-generation/index.ts` — Cognito Pre-Token Generation handler。 `event.response.claimsOverrideDetails.claimsToAddOrOverride` で `custom:userRole=TenantAdmin` + `custom:tenantId=local` を上書き。
- `infrastructure/lib/app-plane-core/lite-admin-claims-lambda.ts` — Lambda + `UserPool.addTrigger(PRE_TOKEN_GENERATION, fn)` を組み立てる CDK construct。 timeout 5s / memory 128MB / ARM64、 IAM / env / VPC 不要。
- `infrastructure/lib/app-plane-core/app-plane-core.ts` — `buildAppPlaneCore` に opt-in flag `liteAdminClaimsInjection?: boolean` を追加。 未指定 / `false` のときは Lambda 一切立てず、 既存 SaaS / Full mode の CFn 物理差分を 0 件に保つ。
- `infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts` — Lite stack 側で `liteAdminClaimsInjection: true` を渡す。
- 3 件の test 追加 (= handler unit + CDK stack regression guard 2 件)。

## Test plan

- [x] Handler unit test: `claimsToAddOrOverride` に `custom:userRole=TenantAdmin` + `custom:tenantId=local` が必ず入る (3 ケース: default / mutated event preservation / override existing)。
- [x] CDK stack test (Lite): UserPool に `LambdaConfig.PreTokenGeneration` が立つ + `LiteAdminClaims` Lambda function が bundle される。
- [x] CDK stack test (SaaS regression guard): `liteAdminClaimsInjection` 未指定なら UserPool の `LambdaConfig.PreTokenGeneration` は `undefined` のまま。
- [x] `make harness` (= invariant violation 0 件)。
- [x] `make before-commit` (= 全 156 test files / 1534 tests pass、 cdk synth OK)。
- [ ] (post-merge) `make deploy` した Lite 環境で sign-in → SAML IdP ページ / 監査ログ ページが 200 で開ける。

## Regression analysis

- **SaaS mode (= TenantTemplateStack / pooled / silo) は無影響**。 本 PR の Lambda は `buildAppPlaneCore` の `liteAdminClaimsInjection: true` flag opt-in。 SaaS mode 経路 (= 既存 `TenantTemplateStack` / pooled / silo) では flag を渡さないので Lambda は一切 instantiate されない。 CFn diff 上でも UserPool `LambdaConfig` は出現しない。 これを CDK stack test (`should NOT attach a Pre-Token Generation Lambda when liteAdminClaimsInjection is not set`) で機械的に保証している。
- **既存 Lite UserPool への影響は単方向**。 既に Lite で sign-up 済の user は次回 JWT 発行のタイミングで claim が上書きされる (= 既存 sign-in セッションの id_token は変わらないが、 refresh 後に反映)。 destructive な user attribute mutation は無し (= `claimsToAddOrOverride` は JWT 発行時の override であって user pool の user attribute を書き換えない)。
- **失敗時挙動**。 Lambda timeout / 例外時は Cognito が 5s 後に invocation error を返して JWT 発行を失敗させる (= sign-in が止まる)。 本 handler は event を mutate して return するだけ (= 外部 service call 0 件) なので、 失敗経路は Lambda runtime 自体の障害のみ。 cold start でも数 ms で完了し 5s timeout に余裕がある。
- **Tenant 越境のリスクなし**。 Lite mode は 1 tenant 専用 (= `tenantId="local"`) なので、 全 user を `TenantAdmin` 扱いに昇格させてもクロステナント漏洩は発生しない。 SaaS mode に本挙動が漏れないことが regression guard test の主目的。

## Physical impact

- **CREATE** (Lite UserPool side only):
  - `AWS::Lambda::Function` (`TenkaCloudLiteStack/LiteAdminClaims/Function`) — Node.js 22 / ARM64 / 128MB / 5s。
  - `AWS::IAM::Role` (Lambda execution role、 basic execution policy のみ)。
  - `AWS::Lambda::Permission` (Cognito service principal が Lambda を invoke するため、 CDK `addTrigger` が自動生成)。
- **UPDATE** (Lite UserPool only): `AWS::Cognito::UserPool.LambdaConfig.PreTokenGeneration` に新 Lambda ARN が入る (= 既存 LambdaConfig は無かったので実質追加)。
- **NO-OP** (SaaS / Full mode TenantTemplateStack / Pooled / Silo): UserPool / Lambda / IAM / API Gateway すべて差分なし。 stack test で `LambdaConfig.PreTokenGeneration` が `undefined` のままを pin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)