### PR TITLE
fix(event-detail): 運用 tab が空にならないよう高度操作を常時表示 — #1328

### DIFF
--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -312,7 +312,18 @@
     "tab_teams": "Teams",
     "tab_scoreboard": "Scoreboard",
     "tab_notifications": "Notifications",
-    "tab_operations": "Operations"
+    "tab_operations": "Operations",
+    "operations_header": "Operations — advanced",
+    "operations_intro": "This tab is not for normal workflow. It collects advanced operations like delete, bulk redeploy, and recovery. Use the other tabs for day-to-day work.",
+    "operations_bulk_header": "Bulk operations",
+    "operations_bulk_description": "Run deploy / teardown against every problem in the Event at once (same as the header buttons).",
+    "operations_bulk_deploy": "Redeploy all problems",
+    "operations_bulk_teardown": "Teardown all problems",
+    "operations_deploy_progress_header": "Deploy progress (detail)",
+    "operations_deploy_progress_empty": "No deploy has been kicked off yet. Press \"Redeploy all problems\" above to start.",
+    "operations_delete_header": "Delete Event (danger zone)",
+    "operations_delete_button": "Delete Event",
+    "operations_delete_warning": "Deleting the Event removes all related deployments / score events / notifications. This cannot be undone. To stop deployments while keeping the Event, use \"Teardown all problems\" above."
   },
   "send_notification": {
     "header": "Send notification",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -312,7 +312,18 @@
     "tab_teams": "チーム",
     "tab_scoreboard": "スコアボード",
     "tab_notifications": "通知",
-    "tab_operations": "運用"
+    "tab_operations": "運用",
+    "operations_header": "運用 — 高度操作",
+    "operations_intro": "この tab は通常運用では使いません。 削除・一括再 deploy・トラブル復旧などの高度操作を集約しています。 普段の workflow は他 tab を使ってください。",
+    "operations_bulk_header": "一括操作",
+    "operations_bulk_description": "Event 配下の全 problem に対して一括で deploy / teardown を実行します (header の button と同じ動作)。",
+    "operations_bulk_deploy": "全 problem を再 deploy",
+    "operations_bulk_teardown": "全 problem を teardown",
+    "operations_deploy_progress_header": "Deploy 進捗詳細",
+    "operations_deploy_progress_empty": "まだ deploy が行われていません。 上の 「全 problem を再 deploy」 を押すと開始します。",
+    "operations_delete_header": "Event 削除 (danger zone)",
+    "operations_delete_button": "Event 削除",
+    "operations_delete_warning": "Event を削除すると関連する全 deployment / score event / 通知が消えます。 取り消しできません。 Event を残したまま deployment だけを止めたい場合は、 上の 「全 problem を teardown」 を使ってください。"
   },
   "send_notification": {
     "header": "通知を送る",

--- a/apps/application-admin-console/src/pages/event-detail/tabs.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/tabs.tsx
@@ -12,6 +12,11 @@
  * Tab id は URL fragment (`#tab=schedule` 等) で deep-link 可能。
  */
 
+import Alert from "@cloudscape-design/components/alert";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import type { ApiClient } from "../../api/client";
 import type { EventDetail } from "../../api/events-client";
 import { DeployProgressPanel } from "../../components/event-detail/DeployProgressPanel";
@@ -160,18 +165,118 @@ export function NotificationsTab({ detail, operations, t }: EventTabContentProps
 }
 
 /**
- * Operations tab: 普段使わない高度操作 (rescue 系) を集約。
+ * Operations tab: 普段使わない高度操作を集約する。
  *
- * 現在は TEARDOWN 時の Force ARCHIVED rescue Alert のみ。 将来的に bulk redeploy / 詳細削除 等の
- * 進阶操作を追加する予定 (issue #1318 の Out of scope ではあるが格納先として確保)。
+ * Issue #1318 で 「rescue 系を Operations に集約」 と決めたが、 #1324 で実装したときに
+ * EventRescuePanel (TEARDOWN 時のみ render) のみを置いてしまい、 非 TEARDOWN 状態では
+ * tab が完全に空になっていた (issue #1328)。 本コミットで 4 section を常時表示するようにし、
+ * status を問わず 運用 tab に内容があることを保証する。
+ *
+ * 表示 section:
+ *  1. EventRescuePanel — 既存。 status === TEARDOWN のときだけ render
+ *  2. 一括操作 — Bulk redeploy / Bulk teardown。 header にも同等 button があるが Operations tab
+ *     の主目的 (= 高度操作の集約先) として明示的に重複配置する
+ *  3. Deploy 進捗詳細 — DeployProgressPanel。 deployment が 0 件のときは empty hint
+ *  4. Event 削除 (danger zone) — header の Delete と同じ confirmTeardown modal を開く
  */
-export function OperationsTab({ detail, operations, t }: EventTabContentProps) {
+export function OperationsTab({
+  counts,
+  detail,
+  manualRefresh,
+  manualRefreshInFlight,
+  operations,
+  t,
+}: EventTabContentProps) {
+  const bulkDisabled =
+    detail.status === "ENDED" || detail.status === "TEARDOWN" || detail.status === "ARCHIVED";
   return (
-    <EventRescuePanel
-      detail={detail}
-      forceArchiveInFlight={operations.forceArchiveInFlight}
-      onForceArchive={() => operations.setConfirmForceArchive(true)}
-      t={t}
-    />
+    <SpaceBetween size="l">
+      <Header variant="h2">{t("event_detail.operations_header")}</Header>
+      <Alert type="info" data-testid="operations-tab-intro">
+        {t("event_detail.operations_intro")}
+      </Alert>
+
+      <EventRescuePanel
+        detail={detail}
+        forceArchiveInFlight={operations.forceArchiveInFlight}
+        onForceArchive={() => operations.setConfirmForceArchive(true)}
+        t={t}
+      />
+
+      <Container
+        data-testid="operations-bulk-section"
+        header={
+          <Header variant="h3" description={t("event_detail.operations_bulk_description")}>
+            {t("event_detail.operations_bulk_header")}
+          </Header>
+        }
+      >
+        <SpaceBetween size="xs" direction="horizontal">
+          <Button
+            data-testid="operations-bulk-deploy"
+            loading={operations.bulkInFlight === "deploy"}
+            disabled={
+              detail.problems.length === 0 ||
+              detail.teams.length === 0 ||
+              bulkDisabled ||
+              operations.bulkInFlight !== null
+            }
+            onClick={() => void operations.handleBulkDeploy()}
+          >
+            {t("event_detail.operations_bulk_deploy")}
+          </Button>
+          <Button
+            data-testid="operations-bulk-teardown"
+            loading={operations.bulkInFlight === "teardown"}
+            disabled={operations.bulkInFlight !== null}
+            onClick={() => operations.setConfirmTeardown(true)}
+          >
+            {t("event_detail.operations_bulk_teardown")}
+          </Button>
+        </SpaceBetween>
+      </Container>
+
+      <Container
+        header={<Header variant="h3">{t("event_detail.operations_deploy_progress_header")}</Header>}
+      >
+        {counts.totalDeployCount > 0 ? (
+          <DeployProgressPanel
+            allDoneCount={counts.allDoneCount}
+            completeCount={counts.completeCount}
+            failedCount={counts.failedCount}
+            inFlightCount={counts.inFlightCount}
+            manualRefreshInFlight={manualRefreshInFlight}
+            onManualRefresh={manualRefresh}
+            t={t}
+            totalDeployCount={counts.totalDeployCount}
+          />
+        ) : (
+          <Alert type="info">{t("event_detail.operations_deploy_progress_empty")}</Alert>
+        )}
+      </Container>
+
+      <Container
+        data-testid="operations-delete-section"
+        header={
+          <Header
+            variant="h3"
+            actions={
+              <Button
+                variant="primary"
+                data-testid="operations-delete-button"
+                loading={operations.bulkInFlight === "teardown"}
+                onClick={() => operations.setConfirmTeardown(true)}
+              >
+                {t("event_detail.operations_delete_button")}
+              </Button>
+            }
+          >
+            {t("event_detail.operations_delete_header")}
+          </Header>
+        }
+      >
+        <Alert type="warning">{t("event_detail.operations_delete_warning")}</Alert>
+      </Container>
+    </SpaceBetween>
   );
 }

--- a/apps/application-admin-console/test/pages/EventDetail.operations-tab.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.operations-tab.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1328: Event Detail の 「運用」 tab が status が TEARDOWN 以外のときに完全空だった bug。
+ *
+ * 元仕様 (#1318) は 「普段使わない高度操作」 を 運用 tab に集約するという方針だったが、
+ * PR #1324 ではその中身を Force ARCHIVED rescue Alert (= TEARDOWN 専用 conditional) のみ
+ * 配置してしまい、 非 TEARDOWN 時の 運用 tab が空 panel になっていた。
+ *
+ * 本テストは 「status を問わず内容を持つ運用 tab」 を保証する:
+ *
+ * - DRAFT でも 運用 tab に高度操作 4 section が見える
+ * - EventRescuePanel は引き続き TEARDOWN 時のみ表示 (conditional rescue は維持)
+ * - Bulk 操作 (再 deploy / 全 teardown) / Event 削除 section は status を問わず表示
+ */
+
+const mocks = vi.hoisted(() => ({
+  useApiClient: vi.fn(),
+  getEvent: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return { ...actual, useApiClient: mocks.useApiClient };
+});
+
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return { ...actual, getEvent: mocks.getEvent };
+});
+
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Test Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+
+const baseDetail: EventDetail = {
+  eventId: EVENT_ID,
+  name: "Operations Tab Test Event",
+  status: "DRAFT",
+  teamCount: 1,
+  problemCount: 1,
+  createdAt: "2026-05-11T00:00:00.000Z",
+  updatedAt: "2026-05-11T00:00:00.000Z",
+  expiresAt: 0,
+  teams: [{ teamId: "t1", internalSlug: "team-alpha" }],
+  problems: [{ problemId: "hello-world", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {},
+};
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+const { I18nProvider } = await import("../../src/i18n");
+
+function renderPage() {
+  return render(
+    <I18nProvider>
+      <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+        <Routes>
+          <Route path="/events/:eventId" element={<EventDetailPage config={config} />} />
+        </Routes>
+      </MemoryRouter>
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue({});
+  window.localStorage.setItem("tenkacloud.application-admin.locale", "ja");
+  if (typeof window !== "undefined") {
+    window.history.replaceState(null, "", "/");
+  }
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+async function openOperationsTab() {
+  const opsTab = await screen.findByRole("tab", { name: /Operations|運用/ });
+  await userEvent.click(opsTab);
+}
+
+describe("EventDetailPage #1328 Operations tab", () => {
+  it("should render Operations tab with content even when event is DRAFT", async () => {
+    mocks.getEvent.mockResolvedValueOnce(baseDetail);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Operations Tab Test Event/).length).toBeGreaterThan(0),
+    );
+    await openOperationsTab();
+    // 運用 tab の説明 Alert (= 高度操作 intro) が見える
+    expect(await screen.findByTestId("operations-tab-intro")).toBeInTheDocument();
+    // bulk operations / delete container header が見える
+    expect(screen.getByTestId("operations-bulk-section")).toBeInTheDocument();
+    expect(screen.getByTestId("operations-delete-section")).toBeInTheDocument();
+  });
+
+  it("should show EventRescuePanel only when status is TEARDOWN", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "READY" });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Operations Tab Test Event/).length).toBeGreaterThan(0),
+    );
+    await openOperationsTab();
+    expect(screen.queryByTestId("force-archive-button")).not.toBeInTheDocument();
+    // operations tab は引き続き内容を持つ
+    expect(screen.getByTestId("operations-tab-intro")).toBeInTheDocument();
+  });
+
+  it("should show Bulk operations buttons regardless of status", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "DRAFT" });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Operations Tab Test Event/).length).toBeGreaterThan(0),
+    );
+    await openOperationsTab();
+    // 一括再 deploy / 一括 teardown の 2 button (本 section 内、 header の button と別カウント)
+    expect(screen.getByTestId("operations-bulk-deploy")).toBeInTheDocument();
+    expect(screen.getByTestId("operations-bulk-teardown")).toBeInTheDocument();
+  });
+
+  it("should show Event 削除 section regardless of status", async () => {
+    mocks.getEvent.mockResolvedValueOnce({ ...baseDetail, status: "ENDED" });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getAllByText(/Operations Tab Test Event/).length).toBeGreaterThan(0),
+    );
+    await openOperationsTab();
+    expect(screen.getByTestId("operations-delete-button")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #1318 (PR #1324) で Event Detail を 7-tab 化したとき、 Operations tab の中身を `EventRescuePanel` のみ にしてしまい、 そのパネルが `status === TEARDOWN` 時しか render しない構造のため、 非 TEARDOWN 状態 (DRAFT / READY / RUNNING / ENDED / ARCHIVED) で Operations tab が完全に空 panel になっていた。
- 本 PR では Operations tab を 5 section の常時表示に拡張: (1) header + intro Alert / (2) EventRescuePanel (引き続き TEARDOWN 時のみ) / (3) 一括操作 (Bulk Redeploy / Bulk Teardown) / (4) Deploy 進捗詳細 (DeployProgressPanel の詳細 view、 deployment 0 件時は empty hint) / (5) Event 削除 (danger zone)。
- 既存 header の Delete button / Overview tab の DeployProgressPanel (概要表示) はそのまま残し、 利用者が header / Overview / Operations のいずれからも高度操作にアクセスできる構造にした。

Closes #1328

## Test plan

- [x] `apps/application-admin-console/test/pages/EventDetail.operations-tab.test.tsx` (4 cases) を新規追加し、 DRAFT / READY / ENDED 状態で運用 tab に各 section が見えることを vitest で固定
  - should render Operations tab with content even when event is DRAFT
  - should show EventRescuePanel only when status is TEARDOWN
  - should show Bulk operations buttons regardless of status
  - should show Event 削除 section regardless of status
- [x] 既存 EventDetail tests (27 cases) も引き続き全 pass
- [x] `make harness` 緑
- [x] `make before-commit` 緑 (lint / typecheck / test / validate-problems / check-synth)
- [ ] 手元の Lite mode (`make deploy`) で実機確認: DRAFT event で運用 tab に高度操作が並ぶ / TEARDOWN 時のみ Rescue panel が追加表示 / mobile viewport で button が縦並びになる (Cloudscape `SpaceBetween direction="horizontal"` のデフォルト挙動)

## Regression analysis

- **対象範囲**: 1 file の component (`OperationsTab` in `apps/application-admin-console/src/pages/event-detail/tabs.tsx`) と関連 i18n key 追加。 backend / IaC / scoring / API 経路に影響なし。
- **再利用しているのは既存 hook と既存 handler**: `operations.handleBulkDeploy()` / `operations.setConfirmTeardown(true)` / `operations.setConfirmForceArchive(true)` / `operations.forceArchiveInFlight` / `operations.bulkInFlight` — どれも `EventDangerZone` / `EventHeaderActions` で既に呼ばれているもの。 新規 wiring はゼロ。
- **`EventDangerZone` (header の Delete button) はそのまま残置**: 利用者によっては header から触る慣習があるため重複を許容。 user-visible に Delete を発火する経路が 1 → 2 に増えるだけで、 confirm modal の挙動は同じ (= 同じ `operations.setConfirmTeardown(true)` を叩く)。
- **bulkDisabled 判定** (`status === ENDED || TEARDOWN || ARCHIVED`) は `EventHeaderActions` の disable 条件と同等にしてあり、 終了状態で誤って再 deploy が走る道は塞いである。
- **Empty hint Alert は存在しない i18n key を持たない**: `operations_deploy_progress_empty` を新規追加し ja / en 両方に揃えてある。

## Physical impact

- **NO-OP runtime (= CFn / Lambda artifact に差分なし)**: SPA frontend (`apps/application-admin-console/dist/`) のみ変更され、 CDK stack / Lambda handler / IAM Role / DDB schema には触らない。 cdk synth は通常通り pass (= synth 出力 diff は SPA bundle hash 程度)。
- **CloudFront 配信の上書き**: 次回 `make deploy` 時に `application-admin-console` の S3 オブジェクトが UPDATE される (= bundle hash 変化分のみ)。 invalidation は既存の deploy フローで実行される。
- **DB / event bus / Cognito UserPool / IAM Role には UPDATE / REPLACE / DELETE なし** (= operator 観点でのリスクはほぼゼロ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)