### PR TITLE
fix(login): branded login pages for admin consoles — #1329

### DIFF
--- a/apps/admin-console/src/auth/AuthProvider.tsx
+++ b/apps/admin-console/src/auth/AuthProvider.tsx
@@ -14,7 +14,12 @@ import type { AppConfig } from "../config";
 interface AuthState {
   tokens: TokenSet | null;
   ready: boolean;
-  login: () => void;
+  /**
+   * Cognito Hosted UI へ redirect する。 Issue #1329: LoginPage が signing-in /
+   * error UI 状態を出せるよう Promise を返す (= 旧 fire-and-forget の `void` 戻り値だと
+   * PKCE 派生 / redirect URL 構築の失敗を UI に出せなかった)。
+   */
+  login: () => Promise<void>;
   logout: () => void;
   setTokens: (tokens: TokenSet) => void;
 }
@@ -75,9 +80,7 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     () => ({
       tokens,
       ready,
-      login: () => {
-        void beginLogin(config);
-      },
+      login: () => beginLogin(config),
       logout,
       setTokens: (t) => setTokensState(t),
     }),

--- a/apps/admin-console/src/components/ProductLoginShell.tsx
+++ b/apps/admin-console/src/components/ProductLoginShell.tsx
@@ -1,0 +1,250 @@
+/**
+ * Issue #1329: 商用 grade のログイン画面 shell。
+ *
+ * LP (`landing/`) と同じ branding を SPA のログイン画面にも適用する。 admin-console
+ * (System Admin) / application-admin-console (Tenant Admin) は構造が同一なので、
+ * 各 app に同名の component を置き、 props (= title / subtitle) で差し替える。
+ *
+ * 設計判断:
+ *   - Cloudscape の Container / Header / Button だけで組み立てる (= 新 dep 0)
+ *   - LP の Inter / Noto Sans JP は OS font fallback に任せる (= preconnect しない)
+ *   - Footer の legal リンクは LP の本物 URL (https://tenkacloud.cloud/) を指す
+ *   - i18n switch UI を内蔵 (Cognito redirect 前なので AppLayout の switcher が無い)
+ */
+
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import { type LocaleCode, SUPPORTED_LOCALES, useI18n, useT } from "../i18n";
+
+/**
+ * LP の <nav class="brand">TenkaCloud</nav> と意匠を揃えた wordmark。
+ * 円形マーク + ワードマークの 2 column。 svg viewBox を 40 高に固定。
+ */
+function TenkaCloudWordmark() {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 12,
+        color: "#07111f",
+      }}
+    >
+      <svg viewBox="0 0 40 40" width="40" height="40" aria-hidden="true" focusable="false">
+        <title>TenkaCloud logo</title>
+        <defs>
+          <linearGradient id="tc-mark-grad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#0969da" />
+            <stop offset="100%" stopColor="#08111f" />
+          </linearGradient>
+        </defs>
+        <circle cx="20" cy="20" r="18" fill="url(#tc-mark-grad)" />
+        <path
+          d="M12 18 L20 12 L28 18 L28 28 L22 28 L22 22 L18 22 L18 28 L12 28 Z"
+          fill="#ffffff"
+          opacity="0.95"
+        />
+      </svg>
+      <span
+        style={{
+          fontFamily:
+            "Inter, 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          fontSize: 22,
+          fontWeight: 800,
+          letterSpacing: "-0.02em",
+        }}
+      >
+        TenkaCloud
+      </span>
+    </div>
+  );
+}
+
+const LEGAL_LINKS = {
+  privacy: "https://tenkacloud.cloud/privacy.html",
+  terms: "https://tenkacloud.cloud/terms.html",
+  tokushoho: "https://tenkacloud.cloud/legal.html",
+} as const;
+
+export interface ProductLoginShellProps {
+  /** ページ見出し。 e.g. "TenkaCloud System Admin Console" */
+  readonly title: string;
+  /** 見出し直下の説明。 dev jargon を排除した一文。 */
+  readonly subtitle: string;
+  /** ボタン文言 (= 「サインイン」 / "Sign in")。 */
+  readonly signInLabel: string;
+  /** signing-in state の表示文言。 */
+  readonly signingInLabel: string;
+  /** Cognito Hosted UI へ redirect を開始するハンドラ。 */
+  readonly onSignIn: () => void | Promise<void>;
+  /** 旧 idle state で fire-and-forget submit を防ぐためのフラグ。 */
+  readonly signingIn: boolean;
+  /** beginLogin が throw した場合に表示する一行メッセージ。 */
+  readonly errorMessage?: string;
+}
+
+export function ProductLoginShell(props: ProductLoginShellProps) {
+  const t = useT();
+  const { locale, setLocale } = useI18n();
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "radial-gradient(circle at 20% 10%, #eef5ff 0%, #f6f7fb 45%, #ffffff 100%)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "20px 24px",
+        }}
+      >
+        <TenkaCloudWordmark />
+        <fieldset
+          aria-label={t("login.language_switcher_aria")}
+          style={{
+            display: "flex",
+            gap: 4,
+            border: "none",
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          {SUPPORTED_LOCALES.map((code) => (
+            <button
+              key={code}
+              type="button"
+              onClick={() => setLocale(code as LocaleCode)}
+              aria-pressed={locale === code}
+              style={{
+                background: locale === code ? "#0969da" : "transparent",
+                color: locale === code ? "#ffffff" : "#5d6877",
+                border: locale === code ? "1px solid #0969da" : "1px solid #c8d0db",
+                borderRadius: 999,
+                padding: "6px 14px",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {code === "ja" ? "日本語" : "English"}
+            </button>
+          ))}
+        </fieldset>
+      </header>
+
+      <main
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "24px 16px",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: 480 }}>
+          <Container>
+            <SpaceBetween size="l">
+              <div>
+                <h1
+                  style={{
+                    margin: 0,
+                    fontSize: 24,
+                    fontWeight: 800,
+                    letterSpacing: "-0.02em",
+                    color: "#07111f",
+                  }}
+                >
+                  {props.title}
+                </h1>
+                <Box variant="p" margin={{ top: "s" }} color="text-body-secondary">
+                  {props.subtitle}
+                </Box>
+              </div>
+
+              {props.errorMessage ? (
+                <Alert type="error" header={t("login.error_header")}>
+                  {props.errorMessage}{" "}
+                  <a href="mailto:support@tenkacloud.cloud">support@tenkacloud.cloud</a>
+                </Alert>
+              ) : null}
+
+              {props.signingIn ? (
+                <Box textAlign="center" padding="s">
+                  <SpaceBetween direction="horizontal" size="s" alignItems="center">
+                    <Spinner />
+                    <span>{props.signingInLabel}</span>
+                  </SpaceBetween>
+                </Box>
+              ) : (
+                <Button
+                  variant="primary"
+                  iconAlign="right"
+                  iconName="external"
+                  onClick={() => {
+                    void props.onSignIn();
+                  }}
+                  fullWidth
+                >
+                  {props.signInLabel}
+                </Button>
+              )}
+            </SpaceBetween>
+          </Container>
+        </div>
+      </main>
+
+      <footer
+        style={{
+          padding: "20px 24px",
+          borderTop: "1px solid #e4e7ec",
+          background: "rgba(255, 255, 255, 0.65)",
+          color: "#5d6877",
+          fontSize: 13,
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 16,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span>{t("login.footer_operator")}</span>
+        <span style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+          <a
+            href={LEGAL_LINKS.privacy}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_privacy")}
+          </a>
+          <a
+            href={LEGAL_LINKS.terms}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_terms")}
+          </a>
+          <a
+            href={LEGAL_LINKS.tokushoho}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_tokushoho")}
+          </a>
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -40,7 +40,19 @@
   "login": {
     "header": "TenkaCloud Admin Console",
     "description": "Sign in as a system administrator. You will be redirected to the Cognito Hosted UI.",
-    "submit": "Sign in"
+    "submit": "Sign in",
+    "title": "TenkaCloud System Admin Console",
+    "subtitle": "Sign in with your platform administrator account.",
+    "sign_in_button": "Sign in",
+    "signing_in": "Redirecting to Cognito…",
+    "error_header": "Sign-in failed",
+    "error_body": "We could not start the sign-in flow.",
+    "support_contact": "Please contact support@tenkacloud.cloud.",
+    "footer_operator": "Operator: BULL LLC",
+    "footer_privacy": "Privacy policy",
+    "footer_terms": "Terms of use",
+    "footer_tokushoho": "Specified Commercial Transactions Act disclosure",
+    "language_switcher_aria": "Language switcher"
   },
   "tenant_list": {
     "header": "Tenants",

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -40,7 +40,19 @@
   "login": {
     "header": "TenkaCloud Admin Console",
     "description": "システム管理者としてサインインしてください。Cognito の Hosted UI に遷移します。",
-    "submit": "サインイン"
+    "submit": "サインイン",
+    "title": "TenkaCloud System Admin Console",
+    "subtitle": "プラットフォーム管理者アカウントでサインインしてください。",
+    "sign_in_button": "サインイン",
+    "signing_in": "Cognito にリダイレクト中…",
+    "error_header": "サインインに失敗しました",
+    "error_body": "サインイン中に問題が発生しました。",
+    "support_contact": "support@tenkacloud.cloud にお問い合わせください。",
+    "footer_operator": "運営: 合同会社 BULL",
+    "footer_privacy": "プライバシーポリシー",
+    "footer_terms": "利用規約",
+    "footer_tokushoho": "特定商取引法に基づく表記",
+    "language_switcher_aria": "言語切替 / Language"
   },
   "tenant_list": {
     "header": "テナント一覧",

--- a/apps/admin-console/src/pages/Login.tsx
+++ b/apps/admin-console/src/pages/Login.tsx
@@ -1,25 +1,51 @@
-import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
-import SpaceBetween from "@cloudscape-design/components/space-between";
+/**
+ * Issue #1329: System Admin (admin-console) のログイン画面。 LP と同じ branding を
+ * 適用し、 「dev 感のある heading + 灰色 box」 から商用 SaaS のログイン画面へ refresh。
+ *
+ * 表示状態:
+ *   1) idle     : title + subtitle + 「サインイン」 button
+ *   2) signing  : Cognito へ redirect 中 spinner (= window.location.assign 直前)
+ *   3) error    : beginLogin throw 時の fallback alert + mailto link
+ */
+
+import { useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { ProductLoginShell } from "../components/ProductLoginShell";
 import { useT } from "../i18n";
 
 export function LoginPage() {
   const auth = useAuth();
   const t = useT();
+  const [signingIn, setSigningIn] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const onSignIn = async () => {
+    setSigningIn(true);
+    setErrorMessage(undefined);
+    try {
+      await auth.login();
+      // 成功時は Cognito Hosted UI への redirect が走るため、 ここに到達しない (= browser
+      // が unload される)。 finally の setSigningIn(false) を打つと redirect 直前に
+      // button が一瞬戻ってしまう UX 劣化があるため、 成功 path では state を保持。
+    } catch (err) {
+      setSigningIn(false);
+      setErrorMessage(
+        `${t("login.error_body")} ${err instanceof Error ? err.message : ""} ${t(
+          "login.support_contact",
+        )}`,
+      );
+    }
+  };
 
   return (
-    <Box margin={{ top: "xxxl" }} textAlign="center">
-      <Container header={<Header variant="h1">{t("login.header")}</Header>}>
-        <SpaceBetween size="m">
-          <Box variant="p">{t("login.description")}</Box>
-          <Button variant="primary" onClick={auth.login}>
-            {t("login.submit")}
-          </Button>
-        </SpaceBetween>
-      </Container>
-    </Box>
+    <ProductLoginShell
+      title={t("login.title")}
+      subtitle={t("login.subtitle")}
+      signInLabel={t("login.sign_in_button")}
+      signingInLabel={t("login.signing_in")}
+      signingIn={signingIn}
+      errorMessage={errorMessage}
+      onSignIn={onSignIn}
+    />
   );
 }

--- a/apps/admin-console/test/pages/login.test.tsx
+++ b/apps/admin-console/test/pages/login.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Issue #1329: System Admin Console login redesign regression tests.
+ *
+ * The page must:
+ *   - render TenkaCloud product name + sign-in button (= LP branding, not "Admin Console" alone)
+ *   - call beginLogin on button click (= contract preserved across the redesign)
+ *   - show signing-in state after click (= no fire-and-forget UX)
+ *   - show error fallback when beginLogin throws (= support contact + mailto)
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const beginLoginMock = vi.fn();
+vi.mock("@tenkacloud/auth-client", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    beginLogin: beginLoginMock,
+    beginLogout: vi.fn(),
+  };
+});
+
+const { AuthProvider } = await import("../../src/auth/AuthProvider");
+const { LoginPage } = await import("../../src/pages/Login");
+const { I18nProvider } = await import("../../src/i18n");
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5173/callback",
+  apiBaseUrl: "https://api.example.com",
+  scope: "openid email",
+  pooledApplicationAdminConsoleUrl: "",
+  provisioningCodeBuildProject: "unknown",
+  awsRegion: "",
+  awsAccountId: "",
+  adminInsightApiUrl: "",
+  cloudWatchDashboardName: "",
+};
+
+function renderLogin() {
+  // pin Japanese locale so assertions are stable under jsdom (= navigator.language defaults).
+  localStorage.setItem("tenkacloud.admin.locale", "ja");
+  return render(
+    <I18nProvider>
+      <AuthProvider config={config}>
+        <LoginPage />
+      </AuthProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("admin-console LoginPage (#1329)", () => {
+  beforeEach(() => {
+    beginLoginMock.mockReset();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("should render the TenkaCloud product name and sign-in button", () => {
+    renderLogin();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /TenkaCloud System Admin Console/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "サインイン" })).toBeInTheDocument();
+  });
+
+  it("should call beginLogin when the sign-in button is clicked", async () => {
+    beginLoginMock.mockResolvedValue(undefined);
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    await waitFor(() => {
+      expect(beginLoginMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should show the signing-in state after the sign-in button is clicked", async () => {
+    // hold the promise open so the spinner state is observable.
+    let resolveLogin: (() => void) | undefined;
+    beginLoginMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogin = resolve;
+        }),
+    );
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    expect(await screen.findByText(/Cognito にリダイレクト中/)).toBeInTheDocument();
+    resolveLogin?.();
+  });
+
+  it("should show the error fallback when beginLogin throws", async () => {
+    beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    expect(await screen.findByText(/サインインに失敗しました/)).toBeInTheDocument();
+    // mailto link presence: support@tenkacloud.cloud
+    const mailto = screen.getByRole("link", { name: /support@tenkacloud\.cloud/ });
+    expect(mailto).toHaveAttribute("href", "mailto:support@tenkacloud.cloud");
+  });
+});

--- a/apps/application-admin-console/src/auth/AuthProvider.tsx
+++ b/apps/application-admin-console/src/auth/AuthProvider.tsx
@@ -14,7 +14,12 @@ import type { AppConfig } from "../config";
 interface AuthState {
   tokens: TokenSet | null;
   ready: boolean;
-  login: () => void;
+  /**
+   * Cognito Hosted UI へ redirect する。 Issue #1329: LoginPage が signing-in /
+   * error UI 状態を出せるよう Promise を返す (= 旧 fire-and-forget の `void` 戻り値だと
+   * PKCE 派生 / redirect URL 構築の失敗を UI に出せなかった)。
+   */
+  login: () => Promise<void>;
   logout: () => void;
   setTokens: (tokens: TokenSet) => void;
 }
@@ -71,9 +76,7 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     () => ({
       tokens,
       ready,
-      login: () => {
-        void beginLogin(config);
-      },
+      login: () => beginLogin(config),
       logout,
       setTokens: (t) => setTokensState(t),
     }),

--- a/apps/application-admin-console/src/components/ProductLoginShell.tsx
+++ b/apps/application-admin-console/src/components/ProductLoginShell.tsx
@@ -1,0 +1,250 @@
+/**
+ * Issue #1329: 商用 grade のログイン画面 shell。
+ *
+ * LP (`landing/`) と同じ branding を SPA のログイン画面にも適用する。 admin-console
+ * (System Admin) / application-admin-console (Tenant Admin) は構造が同一なので、
+ * 各 app に同名の component を置き、 props (= title / subtitle) で差し替える。
+ *
+ * 設計判断:
+ *   - Cloudscape の Container / Header / Button だけで組み立てる (= 新 dep 0)
+ *   - LP の Inter / Noto Sans JP は OS font fallback に任せる (= preconnect しない)
+ *   - Footer の legal リンクは LP の本物 URL (https://tenkacloud.cloud/) を指す
+ *   - i18n switch UI を内蔵 (Cognito redirect 前なので AppLayout の switcher が無い)
+ */
+
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import { type LocaleCode, SUPPORTED_LOCALES, useI18n, useT } from "../i18n";
+
+/**
+ * LP の <nav class="brand">TenkaCloud</nav> と意匠を揃えた wordmark。
+ * 円形マーク + ワードマークの 2 column。 svg viewBox を 40 高に固定。
+ */
+function TenkaCloudWordmark() {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 12,
+        color: "#07111f",
+      }}
+    >
+      <svg viewBox="0 0 40 40" width="40" height="40" aria-hidden="true" focusable="false">
+        <title>TenkaCloud logo</title>
+        <defs>
+          <linearGradient id="tc-mark-grad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#0969da" />
+            <stop offset="100%" stopColor="#08111f" />
+          </linearGradient>
+        </defs>
+        <circle cx="20" cy="20" r="18" fill="url(#tc-mark-grad)" />
+        <path
+          d="M12 18 L20 12 L28 18 L28 28 L22 28 L22 22 L18 22 L18 28 L12 28 Z"
+          fill="#ffffff"
+          opacity="0.95"
+        />
+      </svg>
+      <span
+        style={{
+          fontFamily:
+            "Inter, 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          fontSize: 22,
+          fontWeight: 800,
+          letterSpacing: "-0.02em",
+        }}
+      >
+        TenkaCloud
+      </span>
+    </div>
+  );
+}
+
+const LEGAL_LINKS = {
+  privacy: "https://tenkacloud.cloud/privacy.html",
+  terms: "https://tenkacloud.cloud/terms.html",
+  tokushoho: "https://tenkacloud.cloud/legal.html",
+} as const;
+
+export interface ProductLoginShellProps {
+  /** ページ見出し。 e.g. "TenkaCloud System Admin Console" */
+  readonly title: string;
+  /** 見出し直下の説明。 dev jargon を排除した一文。 */
+  readonly subtitle: string;
+  /** ボタン文言 (= 「サインイン」 / "Sign in")。 */
+  readonly signInLabel: string;
+  /** signing-in state の表示文言。 */
+  readonly signingInLabel: string;
+  /** Cognito Hosted UI へ redirect を開始するハンドラ。 */
+  readonly onSignIn: () => void | Promise<void>;
+  /** 旧 idle state で fire-and-forget submit を防ぐためのフラグ。 */
+  readonly signingIn: boolean;
+  /** beginLogin が throw した場合に表示する一行メッセージ。 */
+  readonly errorMessage?: string;
+}
+
+export function ProductLoginShell(props: ProductLoginShellProps) {
+  const t = useT();
+  const { locale, setLocale } = useI18n();
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "radial-gradient(circle at 20% 10%, #eef5ff 0%, #f6f7fb 45%, #ffffff 100%)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "20px 24px",
+        }}
+      >
+        <TenkaCloudWordmark />
+        <fieldset
+          aria-label={t("login.language_switcher_aria")}
+          style={{
+            display: "flex",
+            gap: 4,
+            border: "none",
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          {SUPPORTED_LOCALES.map((code) => (
+            <button
+              key={code}
+              type="button"
+              onClick={() => setLocale(code as LocaleCode)}
+              aria-pressed={locale === code}
+              style={{
+                background: locale === code ? "#0969da" : "transparent",
+                color: locale === code ? "#ffffff" : "#5d6877",
+                border: locale === code ? "1px solid #0969da" : "1px solid #c8d0db",
+                borderRadius: 999,
+                padding: "6px 14px",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {code === "ja" ? "日本語" : "English"}
+            </button>
+          ))}
+        </fieldset>
+      </header>
+
+      <main
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "24px 16px",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: 480 }}>
+          <Container>
+            <SpaceBetween size="l">
+              <div>
+                <h1
+                  style={{
+                    margin: 0,
+                    fontSize: 24,
+                    fontWeight: 800,
+                    letterSpacing: "-0.02em",
+                    color: "#07111f",
+                  }}
+                >
+                  {props.title}
+                </h1>
+                <Box variant="p" margin={{ top: "s" }} color="text-body-secondary">
+                  {props.subtitle}
+                </Box>
+              </div>
+
+              {props.errorMessage ? (
+                <Alert type="error" header={t("login.error_header")}>
+                  {props.errorMessage}{" "}
+                  <a href="mailto:support@tenkacloud.cloud">support@tenkacloud.cloud</a>
+                </Alert>
+              ) : null}
+
+              {props.signingIn ? (
+                <Box textAlign="center" padding="s">
+                  <SpaceBetween direction="horizontal" size="s" alignItems="center">
+                    <Spinner />
+                    <span>{props.signingInLabel}</span>
+                  </SpaceBetween>
+                </Box>
+              ) : (
+                <Button
+                  variant="primary"
+                  iconAlign="right"
+                  iconName="external"
+                  onClick={() => {
+                    void props.onSignIn();
+                  }}
+                  fullWidth
+                >
+                  {props.signInLabel}
+                </Button>
+              )}
+            </SpaceBetween>
+          </Container>
+        </div>
+      </main>
+
+      <footer
+        style={{
+          padding: "20px 24px",
+          borderTop: "1px solid #e4e7ec",
+          background: "rgba(255, 255, 255, 0.65)",
+          color: "#5d6877",
+          fontSize: 13,
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 16,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span>{t("login.footer_operator")}</span>
+        <span style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+          <a
+            href={LEGAL_LINKS.privacy}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_privacy")}
+          </a>
+          <a
+            href={LEGAL_LINKS.terms}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_terms")}
+          </a>
+          <a
+            href={LEGAL_LINKS.tokushoho}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "#0969da", textDecoration: "none" }}
+          >
+            {t("login.footer_tokushoho")}
+          </a>
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -27,7 +27,19 @@
   "login": {
     "header": "Application Admin Console",
     "description": "Sign in as a tenant developer. You will be redirected to the Cognito Hosted UI.",
-    "submit": "Sign in"
+    "submit": "Sign in",
+    "title": "TenkaCloud Application Admin Console",
+    "subtitle": "Sign in with your tenant operator account.",
+    "sign_in_button": "Sign in",
+    "signing_in": "Redirecting to Cognito…",
+    "error_header": "Sign-in failed",
+    "error_body": "We could not start the sign-in flow.",
+    "support_contact": "Please contact support@tenkacloud.cloud.",
+    "footer_operator": "Operator: BULL LLC",
+    "footer_privacy": "Privacy policy",
+    "footer_terms": "Terms of use",
+    "footer_tokushoho": "Specified Commercial Transactions Act disclosure",
+    "language_switcher_aria": "Language switcher"
   },
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — Tenant admin console",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -27,7 +27,19 @@
   "login": {
     "header": "Application Admin Console",
     "description": "テナント開発者としてサインインしてください。Cognito の Hosted UI に遷移します。",
-    "submit": "サインイン"
+    "submit": "サインイン",
+    "title": "TenkaCloud Application Admin Console",
+    "subtitle": "ご契約テナントの運営者アカウントでサインインしてください。",
+    "sign_in_button": "サインイン",
+    "signing_in": "Cognito にリダイレクト中…",
+    "error_header": "サインインに失敗しました",
+    "error_body": "サインイン中に問題が発生しました。",
+    "support_contact": "support@tenkacloud.cloud にお問い合わせください。",
+    "footer_operator": "運営: 合同会社 BULL",
+    "footer_privacy": "プライバシーポリシー",
+    "footer_terms": "利用規約",
+    "footer_tokushoho": "特定商取引法に基づく表記",
+    "language_switcher_aria": "言語切替 / Language"
   },
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — テナント管理コンソール",

--- a/apps/application-admin-console/src/pages/Login.tsx
+++ b/apps/application-admin-console/src/pages/Login.tsx
@@ -1,25 +1,50 @@
-import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
-import SpaceBetween from "@cloudscape-design/components/space-between";
+/**
+ * Issue #1329: Tenant Admin (application-admin-console) のログイン画面。 LP と同じ
+ * branding を適用し、 「Application Admin Console」 + dev jargon の文言を商用 SaaS
+ * のログイン画面へ refresh。
+ *
+ * 表示状態:
+ *   1) idle     : title + subtitle + 「サインイン」 button
+ *   2) signing  : Cognito へ redirect 中 spinner
+ *   3) error    : beginLogin throw 時の fallback alert + mailto link
+ */
+
+import { useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { ProductLoginShell } from "../components/ProductLoginShell";
 import { useT } from "../i18n";
 
 export function LoginPage() {
   const auth = useAuth();
   const t = useT();
+  const [signingIn, setSigningIn] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const onSignIn = async () => {
+    setSigningIn(true);
+    setErrorMessage(undefined);
+    try {
+      await auth.login();
+      // 成功時は Cognito Hosted UI への redirect で browser が unload されるため到達せず。
+    } catch (err) {
+      setSigningIn(false);
+      setErrorMessage(
+        `${t("login.error_body")} ${err instanceof Error ? err.message : ""} ${t(
+          "login.support_contact",
+        )}`,
+      );
+    }
+  };
 
   return (
-    <Box margin={{ top: "xxxl" }} textAlign="center">
-      <Container header={<Header variant="h1">{t("login.header")}</Header>}>
-        <SpaceBetween size="m">
-          <Box variant="p">{t("login.description")}</Box>
-          <Button variant="primary" onClick={auth.login}>
-            {t("login.submit")}
-          </Button>
-        </SpaceBetween>
-      </Container>
-    </Box>
+    <ProductLoginShell
+      title={t("login.title")}
+      subtitle={t("login.subtitle")}
+      signInLabel={t("login.sign_in_button")}
+      signingInLabel={t("login.signing_in")}
+      signingIn={signingIn}
+      errorMessage={errorMessage}
+      onSignIn={onSignIn}
+    />
   );
 }

--- a/apps/application-admin-console/test/pages/login.test.tsx
+++ b/apps/application-admin-console/test/pages/login.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Issue #1329: Tenant Admin Console login redesign regression tests.
+ *
+ * The page must:
+ *   - render TenkaCloud product name + sign-in button
+ *   - call beginLogin on button click
+ *   - show signing-in state after click
+ *   - show error fallback when beginLogin throws
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const beginLoginMock = vi.fn();
+vi.mock("@tenkacloud/auth-client", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    beginLogin: beginLoginMock,
+    beginLogout: vi.fn(),
+  };
+});
+
+const { AuthProvider } = await import("../../src/auth/AuthProvider");
+const { LoginPage } = await import("../../src/pages/Login");
+const { I18nProvider } = await import("../../src/i18n");
+
+import type { AppConfig } from "../../src/config";
+
+const config: AppConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5174/callback",
+  scope: "openid email profile",
+  tenantId: "tenant-test",
+  tenantName: "Shared Pooled Tenant",
+  apiBaseUrl: "https://api.example.com/prod",
+};
+
+function renderLogin() {
+  localStorage.setItem("tenkacloud.application-admin.locale", "ja");
+  return render(
+    <I18nProvider>
+      <AuthProvider config={config}>
+        <LoginPage />
+      </AuthProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("application-admin-console LoginPage (#1329)", () => {
+  beforeEach(() => {
+    beginLoginMock.mockReset();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("should render the TenkaCloud product name and sign-in button", () => {
+    renderLogin();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /TenkaCloud Application Admin Console/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "サインイン" })).toBeInTheDocument();
+  });
+
+  it("should call beginLogin when the sign-in button is clicked", async () => {
+    beginLoginMock.mockResolvedValue(undefined);
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    await waitFor(() => {
+      expect(beginLoginMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should show the signing-in state after the sign-in button is clicked", async () => {
+    let resolveLogin: (() => void) | undefined;
+    beginLoginMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogin = resolve;
+        }),
+    );
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    expect(await screen.findByText(/Cognito にリダイレクト中/)).toBeInTheDocument();
+    resolveLogin?.();
+  });
+
+  it("should show the error fallback when beginLogin throws", async () => {
+    beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
+    expect(await screen.findByText(/サインインに失敗しました/)).toBeInTheDocument();
+    const mailto = screen.getByRole("link", { name: /support@tenkacloud\.cloud/ });
+    expect(mailto).toHaveAttribute("href", "mailto:support@tenkacloud.cloud");
+  });
+});


### PR DESCRIPTION
## Summary

- Replace dev-grade login screens in `admin-console` (System Admin) and `application-admin-console` (Tenant Admin) with a shared `ProductLoginShell` that mirrors LP branding (TenkaCloud wordmark + gradient background + Privacy / Terms / Tokushoho footer).
- Add 3 visual states: idle (heading + sign-in button), signing-in (spinner + "Cognito にリダイレクト中…"), error (alert + `support@tenkacloud.cloud` mailto fallback).
- i18n keys (ja + en) added: `login.title`, `login.subtitle`, `login.sign_in_button`, `login.signing_in`, `login.error_header`, `login.error_body`, `login.support_contact`, `login.footer_operator`, `login.footer_privacy`, `login.footer_terms`, `login.footer_tokushoho`.

Closes #1329

## Test plan

- [x] `apps/admin-console/test/pages/login.test.tsx` — renders product name, calls `beginLogin`, signing-in spinner, error fallback (all 4 pass)
- [x] `apps/application-admin-console/test/pages/login.test.tsx` — same 4 cases (all pass)
- [x] `bun run typecheck` clean in both SPAs
- [x] `bunx --bun biome check apps` clean (a11y fieldset + lint)
- [x] `make harness` reports zero errors

## Regression analysis

- Sign-in contract preserved: button onClick still triggers `beginLogin(config)` via `useAuth().login()`; only the return type widened from `void` to `Promise<void>` to allow awaiting the redirect prep step. Callers of `useAuth().login()` outside the new LoginPage do not exist in the consoles — verified via grep across `apps/admin-console/src` and `apps/application-admin-console/src`.
- AuthProvider behavior unchanged for idle session timeout, logout, token loading.
- The old `login.header` / `login.description` / `login.submit` keys are retained in locale files for any consumers (= existing `App.test.tsx` tests which assert on "サインイン" label still pass; admin-console + application-admin-console suites stay green at 110/110 and 330/330 respectively).
- Visual-only redesign — no API / event / DynamoDB contract touched.

## Physical impact

- **CFn**: NO-OP. No CDK stacks modified.
- **Lambda**: NO-OP. No handler / runtime config changes.
- **SPA bundles**: small increase (~3 KB per SPA for the new ProductLoginShell + i18n keys; new SVG wordmark is inline so no extra request).
- **Runtime config**: NO-OP. No new keys consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)